### PR TITLE
fix(mir,types): reject use-after-move of managed values in HashMap/HashSet, auto-close channel handles

### DIFF
--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -496,7 +496,12 @@ fn main() {
 }
 ```
 
-Inside a single actor and in free functions, pass values freely and keep using them. Do not defensively `.clone()` for ordinary fn calls. The move boundary is only at an actor send.
+Inside a single actor and in free functions, ordinary function calls do not move
+their arguments, so you can keep using those values afterward. Ownership-sink
+operations still move managed values: for example, `HashSet.insert(x)` and
+`HashMap.insert(k, v)` take ownership of managed string keys/elements/values. If
+you need to keep using the original after such an insert, pass `clone x` (or
+`x.clone()`) into the collection.
 
 ### .clone() produces an independent copy
 

--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -1725,11 +1725,12 @@ actor Inbox {
 ```
 
 Use `channel.new(capacity)` to build a bounded MPSC channel. `Sender<T>` is
-cloneable; close senders when production is complete. `await rx.recv()` returns
-`Option<T>`: `Some(value)` for a received item and `None` when the channel is
-closed. `rx.try_recv()` never suspends and returns `None` for both empty and
-closed. In `select`, write the sealed channel arm as `pat from rx.recv()` and
-match the bound `Option<T>`. Full examples:
+cloneable, and both channel handles are closed automatically at scope exit;
+call `.close()` only when you need to end production or reception before then.
+`await rx.recv()` returns `Option<T>`: `Some(value)` for a received item and
+`None` when the channel is closed. `rx.try_recv()` never suspends and returns
+`None` for both empty and closed. In `select`, write the sealed channel arm as
+`pat from rx.recv()` and match the bound `Option<T>`. Full examples:
 [`examples/channel/await_recv_actor.hew`](../examples/channel/await_recv_actor.hew)
 and [`examples/channel/select_recv.hew`](../examples/channel/select_recv.hew).
 

--- a/examples/v05/checked-mir/channel_auto_close_scope.hew
+++ b/examples/v05/checked-mir/channel_auto_close_scope.hew
@@ -1,0 +1,14 @@
+// MIR-corpus fixture: Sender/Receiver scope-exit auto-close.
+//
+// The function intentionally does not call tx.close() or rx.close(); the
+// elaborated MIR must emit scope-exit channel close drops for both handles.
+import std::channel::channel;
+
+fn main() {
+    let (tx, rx): (channel.Sender<string>, channel.Receiver<string>) = channel.new(1);
+    tx.send("ready");
+    match rx.try_recv() {
+        Some(msg) => println(msg),
+        None => println("empty"),
+    }
+}

--- a/examples/v05/checked-mir/golden/channel_auto_close_scope.elab.mir
+++ b/examples/v05/checked-mir/golden/channel_auto_close_scope.elab.mir
@@ -1,0 +1,2709 @@
+ElaboratedMirFunction {
+    name: "main",
+    return_ty: Unit,
+    statements: [
+        Bind {
+            binding: BindingId(
+                1,
+            ),
+            name: "__tuple_0",
+            site: SiteId(
+                0,
+            ),
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                ],
+            ),
+        },
+        Use {
+            binding: BindingId(
+                1,
+            ),
+            name: "__tuple_0",
+            site: SiteId(
+                3,
+            ),
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                ],
+            ),
+            intent: Read,
+        },
+        Bind {
+            binding: BindingId(
+                2,
+            ),
+            name: "tx",
+            site: SiteId(
+                4,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+        },
+        Use {
+            binding: BindingId(
+                1,
+            ),
+            name: "__tuple_0",
+            site: SiteId(
+                5,
+            ),
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                ],
+            ),
+            intent: Read,
+        },
+        Bind {
+            binding: BindingId(
+                3,
+            ),
+            name: "rx",
+            site: SiteId(
+                6,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+        },
+        Use {
+            binding: BindingId(
+                2,
+            ),
+            name: "tx",
+            site: SiteId(
+                8,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Evaluate {
+            site: SiteId(
+                7,
+            ),
+            ty: Unit,
+        },
+        Use {
+            binding: BindingId(
+                3,
+            ),
+            name: "rx",
+            site: SiteId(
+                13,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    11,
+                ),
+            ),
+            ty: Unit,
+        },
+        Bind {
+            binding: BindingId(
+                4,
+            ),
+            name: "msg",
+            site: SiteId(
+                15,
+            ),
+            ty: String,
+        },
+        Use {
+            binding: BindingId(
+                4,
+            ),
+            name: "msg",
+            site: SiteId(
+                16,
+            ),
+            ty: String,
+            intent: Read,
+        },
+        Drop {
+            binding: BindingId(
+                1,
+            ),
+            name: "__tuple_0",
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                ],
+            ),
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                0,
+            ),
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                ],
+            ),
+            value_class: CowValue,
+            intent: Consume,
+            strategy: Move,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                1,
+            ),
+            ty: I64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                4,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                3,
+            ),
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                ],
+            ),
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                6,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                5,
+            ),
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                ],
+            ),
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                7,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                8,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                9,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                11,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                12,
+            ),
+            ty: Named {
+                name: "Option",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Option,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                13,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                15,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                16,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                18,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                19,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 2,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 3,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 4,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 5,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 6,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 7,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 8,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 9,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 10,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 11,
+            kind: Cleanup,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "channel$new",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Call {
+                block: 1,
+                callee: "hew_channel_send_layout",
+                next: 2,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Call {
+                block: 2,
+                callee: "hew_channel_try_recv_layout",
+                next: 3,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Branch {
+                block: 3,
+                then_target: 5,
+                else_target: 8,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 4,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Call {
+                block: 5,
+                callee: "println_str",
+                next: 9,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Call {
+                block: 6,
+                callee: "println_str",
+                next: 10,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Panic {
+                block: 7,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Branch {
+                block: 8,
+                then_target: 6,
+                else_target: 7,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Goto {
+                block: 9,
+                target: 4,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 9,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Goto {
+                block: 10,
+                target: 4,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 10,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "Sender::send",
+    return_ty: Unit,
+    statements: [
+        Use {
+            binding: BindingId(
+                5,
+            ),
+            name: "tx",
+            site: SiteId(
+                23,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Use {
+            binding: BindingId(
+                6,
+            ),
+            name: "data",
+            site: SiteId(
+                24,
+            ),
+            ty: String,
+            intent: Read,
+        },
+        Evaluate {
+            site: SiteId(
+                21,
+            ),
+            ty: Unit,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                21,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                22,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                23,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                24,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "hew_channel_send_layout",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "Sender::clone",
+    return_ty: Named {
+        name: "Sender",
+        args: [],
+        builtin: Some(
+            Sender,
+        ),
+        is_opaque: false,
+    },
+    statements: [
+        Use {
+            binding: BindingId(
+                7,
+            ),
+            name: "tx",
+            site: SiteId(
+                28,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    26,
+                ),
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                26,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                27,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                28,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "hew_channel_sender_clone",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "Sender::close",
+    return_ty: Unit,
+    statements: [
+        Use {
+            binding: BindingId(
+                8,
+            ),
+            name: "tx",
+            site: SiteId(
+                32,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Evaluate {
+            site: SiteId(
+                30,
+            ),
+            ty: Unit,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                30,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                31,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                32,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "hew_channel_sender_close",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "Receiver::recv",
+    return_ty: Named {
+        name: "Option",
+        args: [
+            String,
+        ],
+        builtin: Some(
+            Option,
+        ),
+        is_opaque: false,
+    },
+    statements: [
+        Use {
+            binding: BindingId(
+                9,
+            ),
+            name: "rx",
+            site: SiteId(
+                36,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    34,
+                ),
+            ),
+            ty: Named {
+                name: "Option",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Option,
+                ),
+                is_opaque: false,
+            },
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                34,
+            ),
+            ty: Named {
+                name: "Option",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Option,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                35,
+            ),
+            ty: Named {
+                name: "Option",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Option,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                36,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "hew_channel_recv_layout",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "Receiver::try_recv",
+    return_ty: Named {
+        name: "Option",
+        args: [
+            String,
+        ],
+        builtin: Some(
+            Option,
+        ),
+        is_opaque: false,
+    },
+    statements: [
+        Use {
+            binding: BindingId(
+                10,
+            ),
+            name: "rx",
+            site: SiteId(
+                40,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    38,
+                ),
+            ),
+            ty: Named {
+                name: "Option",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Option,
+                ),
+                is_opaque: false,
+            },
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                38,
+            ),
+            ty: Named {
+                name: "Option",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Option,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                39,
+            ),
+            ty: Named {
+                name: "Option",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Option,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                40,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "hew_channel_try_recv_layout",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "Receiver::close",
+    return_ty: Unit,
+    statements: [
+        Use {
+            binding: BindingId(
+                11,
+            ),
+            name: "rx",
+            site: SiteId(
+                44,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Evaluate {
+            site: SiteId(
+                42,
+            ),
+            ty: Unit,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                42,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                43,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                44,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "hew_channel_receiver_close",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "channel$new",
+    return_ty: Tuple(
+        [
+            Named {
+                name: "Sender",
+                args: [],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            Named {
+                name: "Receiver",
+                args: [],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+        ],
+    ),
+    statements: [
+        Use {
+            binding: BindingId(
+                12,
+            ),
+            name: "capacity",
+            site: SiteId(
+                49,
+            ),
+            ty: I64,
+            intent: Read,
+        },
+        Bind {
+            binding: BindingId(
+                13,
+            ),
+            name: "pair",
+            site: SiteId(
+                47,
+            ),
+            ty: Named {
+                name: "ChannelPair",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+        },
+        Use {
+            binding: BindingId(
+                13,
+            ),
+            name: "pair",
+            site: SiteId(
+                52,
+            ),
+            ty: Named {
+                name: "ChannelPair",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Bind {
+            binding: BindingId(
+                14,
+            ),
+            name: "tx",
+            site: SiteId(
+                51,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+        },
+        Use {
+            binding: BindingId(
+                13,
+            ),
+            name: "pair",
+            site: SiteId(
+                55,
+            ),
+            ty: Named {
+                name: "ChannelPair",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Bind {
+            binding: BindingId(
+                15,
+            ),
+            name: "rx",
+            site: SiteId(
+                54,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+        },
+        Use {
+            binding: BindingId(
+                13,
+            ),
+            name: "pair",
+            site: SiteId(
+                58,
+            ),
+            ty: Named {
+                name: "ChannelPair",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Evaluate {
+            site: SiteId(
+                57,
+            ),
+            ty: Unit,
+        },
+        Use {
+            binding: BindingId(
+                14,
+            ),
+            name: "tx",
+            site: SiteId(
+                61,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Use {
+            binding: BindingId(
+                15,
+            ),
+            name: "rx",
+            site: SiteId(
+                62,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    46,
+                ),
+            ),
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                ],
+            ),
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                46,
+            ),
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                ],
+            ),
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                47,
+            ),
+            ty: Named {
+                name: "ChannelPair",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Consume,
+            strategy: Move,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                48,
+            ),
+            ty: I64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                49,
+            ),
+            ty: I64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                51,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Consume,
+            strategy: Move,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                52,
+            ),
+            ty: Named {
+                name: "ChannelPair",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                54,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Consume,
+            strategy: Move,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                55,
+            ),
+            ty: Named {
+                name: "ChannelPair",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                57,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                58,
+            ),
+            ty: Named {
+                name: "ChannelPair",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                60,
+            ),
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                ],
+            ),
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                61,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                62,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 2,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 3,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 4,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "hew_channel_new",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Call {
+                block: 1,
+                callee: "hew_channel_pair_sender",
+                next: 2,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Call {
+                block: 2,
+                callee: "hew_channel_pair_receiver",
+                next: 3,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Call {
+                block: 3,
+                callee: "hew_channel_pair_free",
+                next: 4,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 4,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "i32::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                19,
+            ),
+            name: "val",
+            site: SiteId(
+                92,
+            ),
+            ty: I32,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    91,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                91,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                92,
+            ),
+            ty: I32,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "to_string_i32",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "i64::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                20,
+            ),
+            name: "val",
+            site: SiteId(
+                95,
+            ),
+            ty: I64,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    94,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                94,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                95,
+            ),
+            ty: I64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "to_string_i64",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "u32::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                21,
+            ),
+            name: "val",
+            site: SiteId(
+                98,
+            ),
+            ty: U32,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    97,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                97,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                98,
+            ),
+            ty: U32,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "to_string_u32",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "u64::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                22,
+            ),
+            name: "val",
+            site: SiteId(
+                101,
+            ),
+            ty: U64,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    100,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                100,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                101,
+            ),
+            ty: U64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "to_string_u64",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "bool::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                23,
+            ),
+            name: "val",
+            site: SiteId(
+                104,
+            ),
+            ty: Bool,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    103,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                103,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                104,
+            ),
+            ty: Bool,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "to_string_bool",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "char::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                24,
+            ),
+            name: "val",
+            site: SiteId(
+                107,
+            ),
+            ty: Char,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    106,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                106,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                107,
+            ),
+            ty: Char,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "to_string_char",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "f64::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                25,
+            ),
+            name: "val",
+            site: SiteId(
+                110,
+            ),
+            ty: F64,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    109,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                109,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                110,
+            ),
+            ty: F64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "to_string_f64",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "string::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                26,
+            ),
+            name: "val",
+            site: SiteId(
+                112,
+            ),
+            ty: String,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    112,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                112,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Return {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}

--- a/examples/v05/checked-mir/golden/channel_auto_close_scope.raw.mir
+++ b/examples/v05/checked-mir/golden/channel_auto_close_scope.raw.mir
@@ -1,0 +1,3882 @@
+RawMirFunction {
+    name: "main",
+    return_ty: Unit,
+    call_conv: Default,
+    params: [],
+    locals: [
+        I64,
+        Tuple(
+            [
+                Named {
+                    name: "Sender",
+                    args: [
+                        String,
+                    ],
+                    builtin: Some(
+                        Sender,
+                    ),
+                    is_opaque: false,
+                },
+                Named {
+                    name: "Receiver",
+                    args: [
+                        String,
+                    ],
+                    builtin: Some(
+                        Receiver,
+                    ),
+                    is_opaque: false,
+                },
+            ],
+        ),
+        Tuple(
+            [
+                Named {
+                    name: "Sender",
+                    args: [
+                        String,
+                    ],
+                    builtin: Some(
+                        Sender,
+                    ),
+                    is_opaque: false,
+                },
+                Named {
+                    name: "Receiver",
+                    args: [
+                        String,
+                    ],
+                    builtin: Some(
+                        Receiver,
+                    ),
+                    is_opaque: false,
+                },
+            ],
+        ),
+        Named {
+            name: "Sender",
+            args: [
+                String,
+            ],
+            builtin: Some(
+                Sender,
+            ),
+            is_opaque: false,
+        },
+        Named {
+            name: "Sender",
+            args: [
+                String,
+            ],
+            builtin: Some(
+                Sender,
+            ),
+            is_opaque: false,
+        },
+        Named {
+            name: "Receiver",
+            args: [
+                String,
+            ],
+            builtin: Some(
+                Receiver,
+            ),
+            is_opaque: false,
+        },
+        Named {
+            name: "Receiver",
+            args: [
+                String,
+            ],
+            builtin: Some(
+                Receiver,
+            ),
+            is_opaque: false,
+        },
+        String,
+        Unit,
+        Named {
+            name: "Option",
+            args: [
+                String,
+            ],
+            builtin: Some(
+                Option,
+            ),
+            is_opaque: false,
+        },
+        I64,
+        I64,
+        Bool,
+        I64,
+        Bool,
+        String,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [],
+            instructions: [
+                ConstI64 {
+                    dest: Local(
+                        0,
+                    ),
+                    value: 1,
+                },
+            ],
+            terminator: Call {
+                callee: "channel$new",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Bind {
+                    binding: BindingId(
+                        1,
+                    ),
+                    name: "__tuple_0",
+                    site: SiteId(
+                        0,
+                    ),
+                    ty: Tuple(
+                        [
+                            Named {
+                                name: "Sender",
+                                args: [
+                                    String,
+                                ],
+                                builtin: Some(
+                                    Sender,
+                                ),
+                                is_opaque: false,
+                            },
+                            Named {
+                                name: "Receiver",
+                                args: [
+                                    String,
+                                ],
+                                builtin: Some(
+                                    Receiver,
+                                ),
+                                is_opaque: false,
+                            },
+                        ],
+                    ),
+                },
+                Use {
+                    binding: BindingId(
+                        1,
+                    ),
+                    name: "__tuple_0",
+                    site: SiteId(
+                        3,
+                    ),
+                    ty: Tuple(
+                        [
+                            Named {
+                                name: "Sender",
+                                args: [
+                                    String,
+                                ],
+                                builtin: Some(
+                                    Sender,
+                                ),
+                                is_opaque: false,
+                            },
+                            Named {
+                                name: "Receiver",
+                                args: [
+                                    String,
+                                ],
+                                builtin: Some(
+                                    Receiver,
+                                ),
+                                is_opaque: false,
+                            },
+                        ],
+                    ),
+                    intent: Read,
+                },
+                Bind {
+                    binding: BindingId(
+                        2,
+                    ),
+                    name: "tx",
+                    site: SiteId(
+                        4,
+                    ),
+                    ty: Named {
+                        name: "Sender",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                },
+                Use {
+                    binding: BindingId(
+                        1,
+                    ),
+                    name: "__tuple_0",
+                    site: SiteId(
+                        5,
+                    ),
+                    ty: Tuple(
+                        [
+                            Named {
+                                name: "Sender",
+                                args: [
+                                    String,
+                                ],
+                                builtin: Some(
+                                    Sender,
+                                ),
+                                is_opaque: false,
+                            },
+                            Named {
+                                name: "Receiver",
+                                args: [
+                                    String,
+                                ],
+                                builtin: Some(
+                                    Receiver,
+                                ),
+                                is_opaque: false,
+                            },
+                        ],
+                    ),
+                    intent: Read,
+                },
+                Bind {
+                    binding: BindingId(
+                        3,
+                    ),
+                    name: "rx",
+                    site: SiteId(
+                        6,
+                    ),
+                    ty: Named {
+                        name: "Receiver",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                },
+                Use {
+                    binding: BindingId(
+                        2,
+                    ),
+                    name: "tx",
+                    site: SiteId(
+                        8,
+                    ),
+                    ty: Named {
+                        name: "Sender",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: Local(
+                        2,
+                    ),
+                    src: Local(
+                        1,
+                    ),
+                },
+                TupleFieldLoad {
+                    tuple: Local(
+                        2,
+                    ),
+                    field_index: 0,
+                    dest: Local(
+                        3,
+                    ),
+                },
+                Move {
+                    dest: Local(
+                        4,
+                    ),
+                    src: Local(
+                        3,
+                    ),
+                },
+                TupleFieldLoad {
+                    tuple: Local(
+                        2,
+                    ),
+                    field_index: 1,
+                    dest: Local(
+                        5,
+                    ),
+                },
+                Move {
+                    dest: Local(
+                        6,
+                    ),
+                    src: Local(
+                        5,
+                    ),
+                },
+                StringLit {
+                    bytes: [
+                        114,
+                        101,
+                        97,
+                        100,
+                        121,
+                    ],
+                    dest: Local(
+                        7,
+                    ),
+                },
+            ],
+            terminator: Call {
+                callee: "hew_channel_send_layout",
+                builtin: Some(
+                    ChannelSendLayout,
+                ),
+                args: [
+                    Local(
+                        4,
+                    ),
+                    Local(
+                        7,
+                    ),
+                ],
+                dest: None,
+                next: 2,
+            },
+        },
+        BasicBlock {
+            id: 2,
+            statements: [
+                Evaluate {
+                    site: SiteId(
+                        7,
+                    ),
+                    ty: Unit,
+                },
+                Use {
+                    binding: BindingId(
+                        3,
+                    ),
+                    name: "rx",
+                    site: SiteId(
+                        13,
+                    ),
+                    ty: Named {
+                        name: "Receiver",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "hew_channel_try_recv_layout",
+                builtin: Some(
+                    ChannelTryRecvLayout,
+                ),
+                args: [
+                    Local(
+                        6,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        9,
+                    ),
+                ),
+                next: 3,
+            },
+        },
+        BasicBlock {
+            id: 3,
+            statements: [],
+            instructions: [
+                Move {
+                    dest: Local(
+                        10,
+                    ),
+                    src: EnumTag(
+                        9,
+                    ),
+                },
+                ConstI64 {
+                    dest: Local(
+                        11,
+                    ),
+                    value: 0,
+                },
+                IntCmp {
+                    dest: Local(
+                        12,
+                    ),
+                    pred: Eq,
+                    lhs: Local(
+                        10,
+                    ),
+                    rhs: Local(
+                        11,
+                    ),
+                },
+            ],
+            terminator: Branch {
+                cond: Local(
+                    12,
+                ),
+                then_target: 5,
+                else_target: 8,
+            },
+        },
+        BasicBlock {
+            id: 4,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            11,
+                        ),
+                    ),
+                    ty: Unit,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        8,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+        BasicBlock {
+            id: 5,
+            statements: [
+                Bind {
+                    binding: BindingId(
+                        4,
+                    ),
+                    name: "msg",
+                    site: SiteId(
+                        15,
+                    ),
+                    ty: String,
+                },
+                Use {
+                    binding: BindingId(
+                        4,
+                    ),
+                    name: "msg",
+                    site: SiteId(
+                        16,
+                    ),
+                    ty: String,
+                    intent: Read,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: Local(
+                        15,
+                    ),
+                    src: MachineVariant {
+                        local: 9,
+                        variant_idx: 0,
+                        field_idx: 0,
+                    },
+                },
+            ],
+            terminator: Call {
+                callee: "println_str",
+                builtin: None,
+                args: [
+                    Local(
+                        15,
+                    ),
+                ],
+                dest: None,
+                next: 9,
+            },
+        },
+        BasicBlock {
+            id: 6,
+            statements: [],
+            instructions: [
+                StringLit {
+                    bytes: [
+                        101,
+                        109,
+                        112,
+                        116,
+                        121,
+                    ],
+                    dest: Local(
+                        16,
+                    ),
+                },
+            ],
+            terminator: Call {
+                callee: "println_str",
+                builtin: None,
+                args: [
+                    Local(
+                        16,
+                    ),
+                ],
+                dest: None,
+                next: 10,
+            },
+        },
+        BasicBlock {
+            id: 7,
+            statements: [],
+            instructions: [],
+            terminator: Trap {
+                kind: ExhaustivenessFallthrough,
+            },
+        },
+        BasicBlock {
+            id: 8,
+            statements: [],
+            instructions: [
+                ConstI64 {
+                    dest: Local(
+                        13,
+                    ),
+                    value: 1,
+                },
+                IntCmp {
+                    dest: Local(
+                        14,
+                    ),
+                    pred: Eq,
+                    lhs: Local(
+                        10,
+                    ),
+                    rhs: Local(
+                        13,
+                    ),
+                },
+            ],
+            terminator: Branch {
+                cond: Local(
+                    14,
+                ),
+                then_target: 6,
+                else_target: 7,
+            },
+        },
+        BasicBlock {
+            id: 9,
+            statements: [],
+            instructions: [
+                Drop {
+                    place: Local(
+                        15,
+                    ),
+                    ty: String,
+                    drop_fn: Some(
+                        Release(
+                            "hew_string_drop",
+                        ),
+                    ),
+                },
+            ],
+            terminator: Goto {
+                target: 4,
+            },
+        },
+        BasicBlock {
+            id: 10,
+            statements: [],
+            instructions: [],
+            terminator: Goto {
+                target: 4,
+            },
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                0,
+            ),
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                ],
+            ),
+            value_class: CowValue,
+            intent: Consume,
+            strategy: Move,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                1,
+            ),
+            ty: I64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                4,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                3,
+            ),
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                ],
+            ),
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                6,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                5,
+            ),
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                ],
+            ),
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                7,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                8,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                9,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                11,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                12,
+            ),
+            ty: Named {
+                name: "Option",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Option,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                13,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                15,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                16,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                18,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                19,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            247,
+            470,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            263,
+            350,
+        ),
+        (
+            0,
+            1,
+        ): (
+            263,
+            350,
+        ),
+        (
+            1,
+            0,
+        ): (
+            263,
+            350,
+        ),
+        (
+            1,
+            1,
+        ): (
+            268,
+            270,
+        ),
+        (
+            1,
+            2,
+        ): (
+            268,
+            270,
+        ),
+        (
+            1,
+            3,
+        ): (
+            272,
+            274,
+        ),
+        (
+            1,
+            4,
+        ): (
+            272,
+            274,
+        ),
+        (
+            1,
+            5,
+        ): (
+            350,
+            366,
+        ),
+        (
+            1,
+            6,
+        ): (
+            350,
+            366,
+        ),
+        (
+            2,
+            0,
+        ): (
+            372,
+            469,
+        ),
+        (
+            3,
+            0,
+        ): (
+            372,
+            469,
+        ),
+        (
+            3,
+            1,
+        ): (
+            372,
+            469,
+        ),
+        (
+            3,
+            2,
+        ): (
+            372,
+            469,
+        ),
+        (
+            3,
+            3,
+        ): (
+            372,
+            469,
+        ),
+        (
+            4,
+            0,
+        ): (
+            372,
+            469,
+        ),
+        (
+            4,
+            1,
+        ): (
+            372,
+            469,
+        ),
+        (
+            5,
+            0,
+        ): (
+            372,
+            469,
+        ),
+        (
+            5,
+            1,
+        ): (
+            372,
+            469,
+        ),
+        (
+            6,
+            0,
+        ): (
+            372,
+            469,
+        ),
+        (
+            6,
+            1,
+        ): (
+            372,
+            469,
+        ),
+        (
+            7,
+            0,
+        ): (
+            372,
+            469,
+        ),
+        (
+            8,
+            0,
+        ): (
+            372,
+            469,
+        ),
+        (
+            8,
+            1,
+        ): (
+            372,
+            469,
+        ),
+        (
+            8,
+            2,
+        ): (
+            372,
+            469,
+        ),
+        (
+            9,
+            0,
+        ): (
+            372,
+            469,
+        ),
+        (
+            9,
+            1,
+        ): (
+            372,
+            469,
+        ),
+        (
+            10,
+            0,
+        ): (
+            372,
+            469,
+        ),
+    },
+}
+RawMirFunction {
+    name: "Sender::send",
+    return_ty: Unit,
+    call_conv: Default,
+    params: [
+        Named {
+            name: "Sender",
+            args: [],
+            builtin: Some(
+                Sender,
+            ),
+            is_opaque: false,
+        },
+        String,
+    ],
+    locals: [
+        Named {
+            name: "Sender",
+            args: [],
+            builtin: Some(
+                Sender,
+            ),
+            is_opaque: false,
+        },
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        5,
+                    ),
+                    name: "tx",
+                    site: SiteId(
+                        23,
+                    ),
+                    ty: Named {
+                        name: "Sender",
+                        args: [],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+                Use {
+                    binding: BindingId(
+                        6,
+                    ),
+                    name: "data",
+                    site: SiteId(
+                        24,
+                    ),
+                    ty: String,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "hew_channel_send_layout",
+                builtin: Some(
+                    ChannelSendLayout,
+                ),
+                args: [
+                    Local(
+                        0,
+                    ),
+                    Local(
+                        1,
+                    ),
+                ],
+                dest: None,
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Evaluate {
+                    site: SiteId(
+                        21,
+                    ),
+                    ty: Unit,
+                },
+            ],
+            instructions: [],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                21,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                22,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                23,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                24,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            2878,
+            3730,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            3168,
+            3232,
+        ),
+        (
+            1,
+            0,
+        ): (
+            3168,
+            3232,
+        ),
+    },
+}
+RawMirFunction {
+    name: "Sender::clone",
+    return_ty: Named {
+        name: "Sender",
+        args: [],
+        builtin: Some(
+            Sender,
+        ),
+        is_opaque: false,
+    },
+    call_conv: Default,
+    params: [
+        Named {
+            name: "Sender",
+            args: [],
+            builtin: Some(
+                Sender,
+            ),
+            is_opaque: false,
+        },
+    ],
+    locals: [
+        Named {
+            name: "Sender",
+            args: [],
+            builtin: Some(
+                Sender,
+            ),
+            is_opaque: false,
+        },
+        Named {
+            name: "Sender",
+            args: [],
+            builtin: None,
+            is_opaque: false,
+        },
+        Named {
+            name: "Sender",
+            args: [],
+            builtin: None,
+            is_opaque: false,
+        },
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        7,
+                    ),
+                    name: "tx",
+                    site: SiteId(
+                        28,
+                    ),
+                    ty: Named {
+                        name: "Sender",
+                        args: [],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "hew_channel_sender_clone",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            26,
+                        ),
+                    ),
+                    ty: Named {
+                        name: "Sender",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: Local(
+                        2,
+                    ),
+                    src: Local(
+                        1,
+                    ),
+                },
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        2,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                26,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                27,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                28,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            2878,
+            3730,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            3335,
+            3399,
+        ),
+        (
+            1,
+            0,
+        ): (
+            3335,
+            3399,
+        ),
+        (
+            1,
+            1,
+        ): (
+            3335,
+            3399,
+        ),
+        (
+            1,
+            2,
+        ): (
+            3335,
+            3399,
+        ),
+    },
+}
+RawMirFunction {
+    name: "Sender::close",
+    return_ty: Unit,
+    call_conv: Default,
+    params: [
+        Named {
+            name: "Sender",
+            args: [],
+            builtin: Some(
+                Sender,
+            ),
+            is_opaque: false,
+        },
+    ],
+    locals: [
+        Named {
+            name: "Sender",
+            args: [],
+            builtin: Some(
+                Sender,
+            ),
+            is_opaque: false,
+        },
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        8,
+                    ),
+                    name: "tx",
+                    site: SiteId(
+                        32,
+                    ),
+                    ty: Named {
+                        name: "Sender",
+                        args: [],
+                        builtin: Some(
+                            Sender,
+                        ),
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "hew_channel_sender_close",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: None,
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Evaluate {
+                    site: SiteId(
+                        30,
+                    ),
+                    ty: Unit,
+                },
+            ],
+            instructions: [],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                30,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                31,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                32,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            2878,
+            3730,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            3485,
+            3544,
+        ),
+        (
+            1,
+            0,
+        ): (
+            3485,
+            3544,
+        ),
+    },
+}
+RawMirFunction {
+    name: "Receiver::recv",
+    return_ty: Named {
+        name: "Option",
+        args: [
+            String,
+        ],
+        builtin: Some(
+            Option,
+        ),
+        is_opaque: false,
+    },
+    call_conv: Default,
+    params: [
+        Named {
+            name: "Receiver",
+            args: [],
+            builtin: Some(
+                Receiver,
+            ),
+            is_opaque: false,
+        },
+    ],
+    locals: [
+        Named {
+            name: "Receiver",
+            args: [],
+            builtin: Some(
+                Receiver,
+            ),
+            is_opaque: false,
+        },
+        Named {
+            name: "Option",
+            args: [
+                String,
+            ],
+            builtin: Some(
+                Option,
+            ),
+            is_opaque: false,
+        },
+        Named {
+            name: "Option",
+            args: [
+                String,
+            ],
+            builtin: Some(
+                Option,
+            ),
+            is_opaque: false,
+        },
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        9,
+                    ),
+                    name: "rx",
+                    site: SiteId(
+                        36,
+                    ),
+                    ty: Named {
+                        name: "Receiver",
+                        args: [],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "hew_channel_recv_layout",
+                builtin: Some(
+                    ChannelRecvLayout,
+                ),
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            34,
+                        ),
+                    ),
+                    ty: Named {
+                        name: "Option",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Option,
+                        ),
+                        is_opaque: false,
+                    },
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: Local(
+                        2,
+                    ),
+                    src: Local(
+                        1,
+                    ),
+                },
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        2,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                34,
+            ),
+            ty: Named {
+                name: "Option",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Option,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                35,
+            ),
+            ty: Named {
+                name: "Option",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Option,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                36,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            4534,
+            5255,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            4690,
+            4753,
+        ),
+        (
+            1,
+            0,
+        ): (
+            4690,
+            4753,
+        ),
+        (
+            1,
+            1,
+        ): (
+            4690,
+            4753,
+        ),
+        (
+            1,
+            2,
+        ): (
+            4690,
+            4753,
+        ),
+    },
+}
+RawMirFunction {
+    name: "Receiver::try_recv",
+    return_ty: Named {
+        name: "Option",
+        args: [
+            String,
+        ],
+        builtin: Some(
+            Option,
+        ),
+        is_opaque: false,
+    },
+    call_conv: Default,
+    params: [
+        Named {
+            name: "Receiver",
+            args: [],
+            builtin: Some(
+                Receiver,
+            ),
+            is_opaque: false,
+        },
+    ],
+    locals: [
+        Named {
+            name: "Receiver",
+            args: [],
+            builtin: Some(
+                Receiver,
+            ),
+            is_opaque: false,
+        },
+        Named {
+            name: "Option",
+            args: [
+                String,
+            ],
+            builtin: Some(
+                Option,
+            ),
+            is_opaque: false,
+        },
+        Named {
+            name: "Option",
+            args: [
+                String,
+            ],
+            builtin: Some(
+                Option,
+            ),
+            is_opaque: false,
+        },
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        10,
+                    ),
+                    name: "rx",
+                    site: SiteId(
+                        40,
+                    ),
+                    ty: Named {
+                        name: "Receiver",
+                        args: [],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "hew_channel_try_recv_layout",
+                builtin: Some(
+                    ChannelTryRecvLayout,
+                ),
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            38,
+                        ),
+                    ),
+                    ty: Named {
+                        name: "Option",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            Option,
+                        ),
+                        is_opaque: false,
+                    },
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: Local(
+                        2,
+                    ),
+                    src: Local(
+                        1,
+                    ),
+                },
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        2,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                38,
+            ),
+            ty: Named {
+                name: "Option",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Option,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                39,
+            ),
+            ty: Named {
+                name: "Option",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    Option,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                40,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            4534,
+            5255,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            4863,
+            4930,
+        ),
+        (
+            1,
+            0,
+        ): (
+            4863,
+            4930,
+        ),
+        (
+            1,
+            1,
+        ): (
+            4863,
+            4930,
+        ),
+        (
+            1,
+            2,
+        ): (
+            4863,
+            4930,
+        ),
+    },
+}
+RawMirFunction {
+    name: "Receiver::close",
+    return_ty: Unit,
+    call_conv: Default,
+    params: [
+        Named {
+            name: "Receiver",
+            args: [],
+            builtin: Some(
+                Receiver,
+            ),
+            is_opaque: false,
+        },
+    ],
+    locals: [
+        Named {
+            name: "Receiver",
+            args: [],
+            builtin: Some(
+                Receiver,
+            ),
+            is_opaque: false,
+        },
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        11,
+                    ),
+                    name: "rx",
+                    site: SiteId(
+                        44,
+                    ),
+                    ty: Named {
+                        name: "Receiver",
+                        args: [],
+                        builtin: Some(
+                            Receiver,
+                        ),
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "hew_channel_receiver_close",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: None,
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Evaluate {
+                    site: SiteId(
+                        42,
+                    ),
+                    ty: Unit,
+                },
+            ],
+            instructions: [],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                42,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                43,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                44,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            4534,
+            5255,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            5020,
+            5081,
+        ),
+        (
+            1,
+            0,
+        ): (
+            5020,
+            5081,
+        ),
+    },
+}
+RawMirFunction {
+    name: "channel$new",
+    return_ty: Tuple(
+        [
+            Named {
+                name: "Sender",
+                args: [],
+                builtin: Some(
+                    Sender,
+                ),
+                is_opaque: false,
+            },
+            Named {
+                name: "Receiver",
+                args: [],
+                builtin: Some(
+                    Receiver,
+                ),
+                is_opaque: false,
+            },
+        ],
+    ),
+    call_conv: Default,
+    params: [
+        I64,
+    ],
+    locals: [
+        I64,
+        I64,
+        Named {
+            name: "ChannelPair",
+            args: [],
+            builtin: None,
+            is_opaque: false,
+        },
+        Named {
+            name: "ChannelPair",
+            args: [],
+            builtin: None,
+            is_opaque: false,
+        },
+        Named {
+            name: "Sender",
+            args: [],
+            builtin: None,
+            is_opaque: false,
+        },
+        Named {
+            name: "Sender",
+            args: [],
+            builtin: None,
+            is_opaque: false,
+        },
+        Named {
+            name: "Receiver",
+            args: [],
+            builtin: None,
+            is_opaque: false,
+        },
+        Named {
+            name: "Receiver",
+            args: [],
+            builtin: None,
+            is_opaque: false,
+        },
+        Tuple(
+            [
+                Named {
+                    name: "Sender",
+                    args: [],
+                    builtin: None,
+                    is_opaque: false,
+                },
+                Named {
+                    name: "Receiver",
+                    args: [],
+                    builtin: None,
+                    is_opaque: false,
+                },
+            ],
+        ),
+        Tuple(
+            [
+                Named {
+                    name: "Sender",
+                    args: [],
+                    builtin: None,
+                    is_opaque: false,
+                },
+                Named {
+                    name: "Receiver",
+                    args: [],
+                    builtin: None,
+                    is_opaque: false,
+                },
+            ],
+        ),
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        12,
+                    ),
+                    name: "capacity",
+                    site: SiteId(
+                        49,
+                    ),
+                    ty: I64,
+                    intent: Read,
+                },
+            ],
+            instructions: [
+                NumericCast {
+                    dest: Local(
+                        1,
+                    ),
+                    src: Local(
+                        0,
+                    ),
+                    from_ty: I64,
+                    to_ty: I64,
+                },
+            ],
+            terminator: Call {
+                callee: "hew_channel_new",
+                builtin: None,
+                args: [
+                    Local(
+                        1,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        2,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Bind {
+                    binding: BindingId(
+                        13,
+                    ),
+                    name: "pair",
+                    site: SiteId(
+                        47,
+                    ),
+                    ty: Named {
+                        name: "ChannelPair",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                },
+                Use {
+                    binding: BindingId(
+                        13,
+                    ),
+                    name: "pair",
+                    site: SiteId(
+                        52,
+                    ),
+                    ty: Named {
+                        name: "ChannelPair",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: Local(
+                        3,
+                    ),
+                    src: Local(
+                        2,
+                    ),
+                },
+            ],
+            terminator: Call {
+                callee: "hew_channel_pair_sender",
+                builtin: None,
+                args: [
+                    Local(
+                        3,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        4,
+                    ),
+                ),
+                next: 2,
+            },
+        },
+        BasicBlock {
+            id: 2,
+            statements: [
+                Bind {
+                    binding: BindingId(
+                        14,
+                    ),
+                    name: "tx",
+                    site: SiteId(
+                        51,
+                    ),
+                    ty: Named {
+                        name: "Sender",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                },
+                Use {
+                    binding: BindingId(
+                        13,
+                    ),
+                    name: "pair",
+                    site: SiteId(
+                        55,
+                    ),
+                    ty: Named {
+                        name: "ChannelPair",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: Local(
+                        5,
+                    ),
+                    src: Local(
+                        4,
+                    ),
+                },
+            ],
+            terminator: Call {
+                callee: "hew_channel_pair_receiver",
+                builtin: None,
+                args: [
+                    Local(
+                        3,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        6,
+                    ),
+                ),
+                next: 3,
+            },
+        },
+        BasicBlock {
+            id: 3,
+            statements: [
+                Bind {
+                    binding: BindingId(
+                        15,
+                    ),
+                    name: "rx",
+                    site: SiteId(
+                        54,
+                    ),
+                    ty: Named {
+                        name: "Receiver",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                },
+                Use {
+                    binding: BindingId(
+                        13,
+                    ),
+                    name: "pair",
+                    site: SiteId(
+                        58,
+                    ),
+                    ty: Named {
+                        name: "ChannelPair",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: Local(
+                        7,
+                    ),
+                    src: Local(
+                        6,
+                    ),
+                },
+            ],
+            terminator: Call {
+                callee: "hew_channel_pair_free",
+                builtin: None,
+                args: [
+                    Local(
+                        3,
+                    ),
+                ],
+                dest: None,
+                next: 4,
+            },
+        },
+        BasicBlock {
+            id: 4,
+            statements: [
+                Evaluate {
+                    site: SiteId(
+                        57,
+                    ),
+                    ty: Unit,
+                },
+                Use {
+                    binding: BindingId(
+                        14,
+                    ),
+                    name: "tx",
+                    site: SiteId(
+                        61,
+                    ),
+                    ty: Named {
+                        name: "Sender",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+                Use {
+                    binding: BindingId(
+                        15,
+                    ),
+                    name: "rx",
+                    site: SiteId(
+                        62,
+                    ),
+                    ty: Named {
+                        name: "Receiver",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+                Return {
+                    site: Some(
+                        SiteId(
+                            46,
+                        ),
+                    ),
+                    ty: Tuple(
+                        [
+                            Named {
+                                name: "Sender",
+                                args: [],
+                                builtin: None,
+                                is_opaque: false,
+                            },
+                            Named {
+                                name: "Receiver",
+                                args: [],
+                                builtin: None,
+                                is_opaque: false,
+                            },
+                        ],
+                    ),
+                },
+            ],
+            instructions: [
+                TupleConstruct {
+                    elements: [
+                        Local(
+                            5,
+                        ),
+                        Local(
+                            7,
+                        ),
+                    ],
+                    dest: Local(
+                        8,
+                    ),
+                },
+                Move {
+                    dest: Local(
+                        9,
+                    ),
+                    src: Local(
+                        8,
+                    ),
+                },
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        9,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                46,
+            ),
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                ],
+            ),
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                47,
+            ),
+            ty: Named {
+                name: "ChannelPair",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Consume,
+            strategy: Move,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                48,
+            ),
+            ty: I64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                49,
+            ),
+            ty: I64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                51,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Consume,
+            strategy: Move,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                52,
+            ),
+            ty: Named {
+                name: "ChannelPair",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                54,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Consume,
+            strategy: Move,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                55,
+            ),
+            ty: Named {
+                name: "ChannelPair",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                57,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                58,
+            ),
+            ty: Named {
+                name: "ChannelPair",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                60,
+            ),
+            ty: Tuple(
+                [
+                    Named {
+                        name: "Sender",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                    Named {
+                        name: "Receiver",
+                        args: [],
+                        builtin: None,
+                        is_opaque: false,
+                    },
+                ],
+            ),
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                61,
+            ),
+            ty: Named {
+                name: "Sender",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                62,
+            ),
+            ty: Named {
+                name: "Receiver",
+                args: [],
+                builtin: None,
+                is_opaque: false,
+            },
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            5646,
+            6154,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            5717,
+            5818,
+        ),
+        (
+            0,
+            1,
+        ): (
+            5717,
+            5818,
+        ),
+        (
+            1,
+            0,
+        ): (
+            5717,
+            5818,
+        ),
+        (
+            1,
+            1,
+        ): (
+            5818,
+            5866,
+        ),
+        (
+            2,
+            0,
+        ): (
+            5818,
+            5866,
+        ),
+        (
+            2,
+            1,
+        ): (
+            5866,
+            5916,
+        ),
+        (
+            3,
+            0,
+        ): (
+            5866,
+            5916,
+        ),
+        (
+            3,
+            1,
+        ): (
+            5916,
+            5943,
+        ),
+        (
+            4,
+            0,
+        ): (
+            5916,
+            5943,
+        ),
+        (
+            4,
+            1,
+        ): (
+            5916,
+            5943,
+        ),
+        (
+            4,
+            2,
+        ): (
+            5916,
+            5943,
+        ),
+        (
+            4,
+            3,
+        ): (
+            5916,
+            5943,
+        ),
+    },
+}
+RawMirFunction {
+    name: "i32::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        I32,
+    ],
+    locals: [
+        I32,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        19,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        92,
+                    ),
+                    ty: I32,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "to_string_i32",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            91,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        1,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                91,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                92,
+            ),
+            ty: I32,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            14556,
+            14644,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            14620,
+            14639,
+        ),
+        (
+            1,
+            0,
+        ): (
+            14620,
+            14639,
+        ),
+        (
+            1,
+            1,
+        ): (
+            14620,
+            14639,
+        ),
+    },
+}
+RawMirFunction {
+    name: "i64::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        I64,
+    ],
+    locals: [
+        I64,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        20,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        95,
+                    ),
+                    ty: I64,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "to_string_i64",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            94,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        1,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                94,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                95,
+            ),
+            ty: I64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            14644,
+            14732,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            14708,
+            14727,
+        ),
+        (
+            1,
+            0,
+        ): (
+            14708,
+            14727,
+        ),
+        (
+            1,
+            1,
+        ): (
+            14708,
+            14727,
+        ),
+    },
+}
+RawMirFunction {
+    name: "u32::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        U32,
+    ],
+    locals: [
+        U32,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        21,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        98,
+                    ),
+                    ty: U32,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "to_string_u32",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            97,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        1,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                97,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                98,
+            ),
+            ty: U32,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            14906,
+            14994,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            14970,
+            14989,
+        ),
+        (
+            1,
+            0,
+        ): (
+            14970,
+            14989,
+        ),
+        (
+            1,
+            1,
+        ): (
+            14970,
+            14989,
+        ),
+    },
+}
+RawMirFunction {
+    name: "u64::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        U64,
+    ],
+    locals: [
+        U64,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        22,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        101,
+                    ),
+                    ty: U64,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "to_string_u64",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            100,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        1,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                100,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                101,
+            ),
+            ty: U64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            14994,
+            15082,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            15058,
+            15077,
+        ),
+        (
+            1,
+            0,
+        ): (
+            15058,
+            15077,
+        ),
+        (
+            1,
+            1,
+        ): (
+            15058,
+            15077,
+        ),
+    },
+}
+RawMirFunction {
+    name: "bool::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        Bool,
+    ],
+    locals: [
+        Bool,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        23,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        104,
+                    ),
+                    ty: Bool,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "to_string_bool",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            103,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        1,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                103,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                104,
+            ),
+            ty: Bool,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            15082,
+            15172,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            15148,
+            15167,
+        ),
+        (
+            1,
+            0,
+        ): (
+            15148,
+            15167,
+        ),
+        (
+            1,
+            1,
+        ): (
+            15148,
+            15167,
+        ),
+    },
+}
+RawMirFunction {
+    name: "char::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        Char,
+    ],
+    locals: [
+        Char,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        24,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        107,
+                    ),
+                    ty: Char,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "to_string_char",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            106,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        1,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                106,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                107,
+            ),
+            ty: Char,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            15172,
+            15262,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            15238,
+            15257,
+        ),
+        (
+            1,
+            0,
+        ): (
+            15238,
+            15257,
+        ),
+        (
+            1,
+            1,
+        ): (
+            15238,
+            15257,
+        ),
+    },
+}
+RawMirFunction {
+    name: "f64::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        F64,
+    ],
+    locals: [
+        F64,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        25,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        110,
+                    ),
+                    ty: F64,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "to_string_f64",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            109,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        1,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                109,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                110,
+            ),
+            ty: F64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            15262,
+            15350,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            15326,
+            15345,
+        ),
+        (
+            1,
+            0,
+        ): (
+            15326,
+            15345,
+        ),
+        (
+            1,
+            1,
+        ): (
+            15326,
+            15345,
+        ),
+    },
+}
+RawMirFunction {
+    name: "string::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        String,
+    ],
+    locals: [
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        26,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        112,
+                    ),
+                    ty: String,
+                    intent: Read,
+                },
+                Return {
+                    site: Some(
+                        SiteId(
+                            112,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        0,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                112,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            15350,
+            15920,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            15420,
+            15428,
+        ),
+        (
+            0,
+            1,
+        ): (
+            15420,
+            15428,
+        ),
+    },
+}

--- a/examples/v05/checked-mir/golden/hashset_insert_managed_string_move.elab.mir
+++ b/examples/v05/checked-mir/golden/hashset_insert_managed_string_move.elab.mir
@@ -1,0 +1,1048 @@
+ElaboratedMirFunction {
+    name: "main",
+    return_ty: Unit,
+    statements: [
+        Bind {
+            binding: BindingId(
+                0,
+            ),
+            name: "words",
+            site: SiteId(
+                0,
+            ),
+            ty: Named {
+                name: "HashSet",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    HashSet,
+                ),
+                is_opaque: false,
+            },
+        },
+        Bind {
+            binding: BindingId(
+                1,
+            ),
+            name: "word",
+            site: SiteId(
+                2,
+            ),
+            ty: String,
+        },
+        Use {
+            binding: BindingId(
+                0,
+            ),
+            name: "words",
+            site: SiteId(
+                4,
+            ),
+            ty: Named {
+                name: "HashSet",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    HashSet,
+                ),
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Use {
+            binding: BindingId(
+                1,
+            ),
+            name: "word",
+            site: SiteId(
+                5,
+            ),
+            ty: String,
+            intent: Read,
+        },
+        Use {
+            binding: BindingId(
+                1,
+            ),
+            name: "word",
+            site: SiteId(
+                5,
+            ),
+            ty: String,
+            intent: Consume,
+        },
+        Evaluate {
+            site: SiteId(
+                3,
+            ),
+            ty: Bool,
+        },
+        Use {
+            binding: BindingId(
+                0,
+            ),
+            name: "words",
+            site: SiteId(
+                8,
+            ),
+            ty: Named {
+                name: "HashSet",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    HashSet,
+                ),
+                is_opaque: false,
+            },
+            intent: Read,
+        },
+        Evaluate {
+            site: SiteId(
+                6,
+            ),
+            ty: Unit,
+        },
+        Drop {
+            binding: BindingId(
+                1,
+            ),
+            name: "word",
+            ty: String,
+        },
+        Drop {
+            binding: BindingId(
+                0,
+            ),
+            name: "words",
+            ty: Named {
+                name: "HashSet",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    HashSet,
+                ),
+                is_opaque: false,
+            },
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                0,
+            ),
+            ty: Named {
+                name: "HashSet",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    HashSet,
+                ),
+                is_opaque: false,
+            },
+            value_class: CowValue,
+            intent: Consume,
+            strategy: Move,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                2,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Consume,
+            strategy: Move,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                3,
+            ),
+            ty: Bool,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                4,
+            ),
+            ty: Named {
+                name: "HashSet",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    HashSet,
+                ),
+                is_opaque: false,
+            },
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                5,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                6,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                7,
+            ),
+            ty: I64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                8,
+            ),
+            ty: Named {
+                name: "HashSet",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    HashSet,
+                ),
+                is_opaque: false,
+            },
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 2,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 3,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 4,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "HashSet::new",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Call {
+                block: 1,
+                callee: "hew_hashset_insert_layout",
+                next: 2,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Call {
+                block: 2,
+                callee: "hew_hashset_len_layout",
+                next: 3,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Call {
+                block: 3,
+                callee: "println_i64",
+                next: 4,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 4,
+            },
+            DropPlan {
+                drops: [
+                    ElabDrop {
+                        place: Local(
+                            1,
+                        ),
+                        ty: Named {
+                            name: "HashSet",
+                            args: [
+                                String,
+                            ],
+                            builtin: Some(
+                                HashSet,
+                            ),
+                            is_opaque: false,
+                        },
+                        drop_fn: None,
+                        kind: CowHeap {
+                            drop_fn: "hew_hashset_free_layout",
+                        },
+                        guard: None,
+                    },
+                ],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "i32::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                5,
+            ),
+            name: "val",
+            site: SiteId(
+                39,
+            ),
+            ty: I32,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    38,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                38,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                39,
+            ),
+            ty: I32,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "to_string_i32",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "i64::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                6,
+            ),
+            name: "val",
+            site: SiteId(
+                42,
+            ),
+            ty: I64,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    41,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                41,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                42,
+            ),
+            ty: I64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "to_string_i64",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "u32::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                7,
+            ),
+            name: "val",
+            site: SiteId(
+                45,
+            ),
+            ty: U32,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    44,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                44,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                45,
+            ),
+            ty: U32,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "to_string_u32",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "u64::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                8,
+            ),
+            name: "val",
+            site: SiteId(
+                48,
+            ),
+            ty: U64,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    47,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                47,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                48,
+            ),
+            ty: U64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "to_string_u64",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "bool::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                9,
+            ),
+            name: "val",
+            site: SiteId(
+                51,
+            ),
+            ty: Bool,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    50,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                50,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                51,
+            ),
+            ty: Bool,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "to_string_bool",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "char::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                10,
+            ),
+            name: "val",
+            site: SiteId(
+                54,
+            ),
+            ty: Char,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    53,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                53,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                54,
+            ),
+            ty: Char,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "to_string_char",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "f64::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                11,
+            ),
+            name: "val",
+            site: SiteId(
+                57,
+            ),
+            ty: F64,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    56,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                56,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                57,
+            ),
+            ty: F64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+        ElabBlock {
+            id: 1,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Call {
+                block: 0,
+                callee: "to_string_f64",
+                next: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Cancel {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+        (
+            Return {
+                block: 1,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}
+ElaboratedMirFunction {
+    name: "string::fmt",
+    return_ty: String,
+    statements: [
+        Use {
+            binding: BindingId(
+                12,
+            ),
+            name: "val",
+            site: SiteId(
+                59,
+            ),
+            ty: String,
+            intent: Read,
+        },
+        Return {
+            site: Some(
+                SiteId(
+                    59,
+                ),
+            ),
+            ty: String,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                59,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    blocks: [
+        ElabBlock {
+            id: 0,
+            kind: Normal,
+            drops: [],
+            successor: None,
+        },
+    ],
+    drop_plans: [
+        (
+            Return {
+                block: 0,
+            },
+            DropPlan {
+                drops: [],
+            },
+        ),
+    ],
+    coroutine: None,
+    lambda_captures: [],
+}

--- a/examples/v05/checked-mir/golden/hashset_insert_managed_string_move.raw.mir
+++ b/examples/v05/checked-mir/golden/hashset_insert_managed_string_move.raw.mir
@@ -1,0 +1,1373 @@
+RawMirFunction {
+    name: "main",
+    return_ty: Unit,
+    call_conv: Default,
+    params: [],
+    locals: [
+        Named {
+            name: "HashSet",
+            args: [
+                String,
+            ],
+            builtin: Some(
+                HashSet,
+            ),
+            is_opaque: false,
+        },
+        Named {
+            name: "HashSet",
+            args: [
+                String,
+            ],
+            builtin: Some(
+                HashSet,
+            ),
+            is_opaque: false,
+        },
+        String,
+        String,
+        Bool,
+        I64,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [],
+            instructions: [],
+            terminator: Call {
+                callee: "HashSet::new",
+                builtin: Some(
+                    HashSetNew,
+                ),
+                args: [],
+                dest: Some(
+                    Local(
+                        0,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Bind {
+                    binding: BindingId(
+                        0,
+                    ),
+                    name: "words",
+                    site: SiteId(
+                        0,
+                    ),
+                    ty: Named {
+                        name: "HashSet",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            HashSet,
+                        ),
+                        is_opaque: false,
+                    },
+                },
+                Bind {
+                    binding: BindingId(
+                        1,
+                    ),
+                    name: "word",
+                    site: SiteId(
+                        2,
+                    ),
+                    ty: String,
+                },
+                Use {
+                    binding: BindingId(
+                        0,
+                    ),
+                    name: "words",
+                    site: SiteId(
+                        4,
+                    ),
+                    ty: Named {
+                        name: "HashSet",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            HashSet,
+                        ),
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+                Use {
+                    binding: BindingId(
+                        1,
+                    ),
+                    name: "word",
+                    site: SiteId(
+                        5,
+                    ),
+                    ty: String,
+                    intent: Read,
+                },
+                Use {
+                    binding: BindingId(
+                        1,
+                    ),
+                    name: "word",
+                    site: SiteId(
+                        5,
+                    ),
+                    ty: String,
+                    intent: Consume,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: Local(
+                        1,
+                    ),
+                    src: Local(
+                        0,
+                    ),
+                },
+                StringLit {
+                    bytes: [
+                        98,
+                        101,
+                        104,
+                        97,
+                        118,
+                        105,
+                        111,
+                        117,
+                        114,
+                    ],
+                    dest: Local(
+                        2,
+                    ),
+                },
+                Move {
+                    dest: Local(
+                        3,
+                    ),
+                    src: Local(
+                        2,
+                    ),
+                },
+            ],
+            terminator: Call {
+                callee: "hew_hashset_insert_layout",
+                builtin: Some(
+                    HashSetInsertLayout,
+                ),
+                args: [
+                    Local(
+                        1,
+                    ),
+                    Local(
+                        3,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        4,
+                    ),
+                ),
+                next: 2,
+            },
+        },
+        BasicBlock {
+            id: 2,
+            statements: [
+                Evaluate {
+                    site: SiteId(
+                        3,
+                    ),
+                    ty: Bool,
+                },
+                Use {
+                    binding: BindingId(
+                        0,
+                    ),
+                    name: "words",
+                    site: SiteId(
+                        8,
+                    ),
+                    ty: Named {
+                        name: "HashSet",
+                        args: [
+                            String,
+                        ],
+                        builtin: Some(
+                            HashSet,
+                        ),
+                        is_opaque: false,
+                    },
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "hew_hashset_len_layout",
+                builtin: Some(
+                    HashSetLenLayout,
+                ),
+                args: [
+                    Local(
+                        1,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        5,
+                    ),
+                ),
+                next: 3,
+            },
+        },
+        BasicBlock {
+            id: 3,
+            statements: [],
+            instructions: [],
+            terminator: Call {
+                callee: "println_i64",
+                builtin: None,
+                args: [
+                    Local(
+                        5,
+                    ),
+                ],
+                dest: None,
+                next: 4,
+            },
+        },
+        BasicBlock {
+            id: 4,
+            statements: [
+                Evaluate {
+                    site: SiteId(
+                        6,
+                    ),
+                    ty: Unit,
+                },
+            ],
+            instructions: [],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                0,
+            ),
+            ty: Named {
+                name: "HashSet",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    HashSet,
+                ),
+                is_opaque: false,
+            },
+            value_class: CowValue,
+            intent: Consume,
+            strategy: Move,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                2,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Consume,
+            strategy: Move,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                3,
+            ),
+            ty: Bool,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                4,
+            ),
+            ty: Named {
+                name: "HashSet",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    HashSet,
+                ),
+                is_opaque: false,
+            },
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                5,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                6,
+            ),
+            ty: Unit,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                7,
+            ),
+            ty: I64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                8,
+            ),
+            ty: Named {
+                name: "HashSet",
+                args: [
+                    String,
+                ],
+                builtin: Some(
+                    HashSet,
+                ),
+                is_opaque: false,
+            },
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            212,
+            352,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            228,
+            277,
+        ),
+        (
+            1,
+            0,
+        ): (
+            228,
+            277,
+        ),
+        (
+            1,
+            1,
+        ): (
+            277,
+            305,
+        ),
+        (
+            1,
+            2,
+        ): (
+            277,
+            305,
+        ),
+        (
+            1,
+            3,
+        ): (
+            305,
+            323,
+        ),
+        (
+            2,
+            0,
+        ): (
+            329,
+            349,
+        ),
+        (
+            3,
+            0,
+        ): (
+            329,
+            349,
+        ),
+        (
+            4,
+            0,
+        ): (
+            329,
+            349,
+        ),
+    },
+}
+RawMirFunction {
+    name: "i32::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        I32,
+    ],
+    locals: [
+        I32,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        5,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        39,
+                    ),
+                    ty: I32,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "to_string_i32",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            38,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        1,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                38,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                39,
+            ),
+            ty: I32,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            14556,
+            14644,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            14620,
+            14639,
+        ),
+        (
+            1,
+            0,
+        ): (
+            14620,
+            14639,
+        ),
+        (
+            1,
+            1,
+        ): (
+            14620,
+            14639,
+        ),
+    },
+}
+RawMirFunction {
+    name: "i64::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        I64,
+    ],
+    locals: [
+        I64,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        6,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        42,
+                    ),
+                    ty: I64,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "to_string_i64",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            41,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        1,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                41,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                42,
+            ),
+            ty: I64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            14644,
+            14732,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            14708,
+            14727,
+        ),
+        (
+            1,
+            0,
+        ): (
+            14708,
+            14727,
+        ),
+        (
+            1,
+            1,
+        ): (
+            14708,
+            14727,
+        ),
+    },
+}
+RawMirFunction {
+    name: "u32::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        U32,
+    ],
+    locals: [
+        U32,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        7,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        45,
+                    ),
+                    ty: U32,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "to_string_u32",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            44,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        1,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                44,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                45,
+            ),
+            ty: U32,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            14906,
+            14994,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            14970,
+            14989,
+        ),
+        (
+            1,
+            0,
+        ): (
+            14970,
+            14989,
+        ),
+        (
+            1,
+            1,
+        ): (
+            14970,
+            14989,
+        ),
+    },
+}
+RawMirFunction {
+    name: "u64::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        U64,
+    ],
+    locals: [
+        U64,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        8,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        48,
+                    ),
+                    ty: U64,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "to_string_u64",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            47,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        1,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                47,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                48,
+            ),
+            ty: U64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            14994,
+            15082,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            15058,
+            15077,
+        ),
+        (
+            1,
+            0,
+        ): (
+            15058,
+            15077,
+        ),
+        (
+            1,
+            1,
+        ): (
+            15058,
+            15077,
+        ),
+    },
+}
+RawMirFunction {
+    name: "bool::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        Bool,
+    ],
+    locals: [
+        Bool,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        9,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        51,
+                    ),
+                    ty: Bool,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "to_string_bool",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            50,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        1,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                50,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                51,
+            ),
+            ty: Bool,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            15082,
+            15172,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            15148,
+            15167,
+        ),
+        (
+            1,
+            0,
+        ): (
+            15148,
+            15167,
+        ),
+        (
+            1,
+            1,
+        ): (
+            15148,
+            15167,
+        ),
+    },
+}
+RawMirFunction {
+    name: "char::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        Char,
+    ],
+    locals: [
+        Char,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        10,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        54,
+                    ),
+                    ty: Char,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "to_string_char",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            53,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        1,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                53,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                54,
+            ),
+            ty: Char,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            15172,
+            15262,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            15238,
+            15257,
+        ),
+        (
+            1,
+            0,
+        ): (
+            15238,
+            15257,
+        ),
+        (
+            1,
+            1,
+        ): (
+            15238,
+            15257,
+        ),
+    },
+}
+RawMirFunction {
+    name: "f64::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        F64,
+    ],
+    locals: [
+        F64,
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        11,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        57,
+                    ),
+                    ty: F64,
+                    intent: Read,
+                },
+            ],
+            instructions: [],
+            terminator: Call {
+                callee: "to_string_f64",
+                builtin: None,
+                args: [
+                    Local(
+                        0,
+                    ),
+                ],
+                dest: Some(
+                    Local(
+                        1,
+                    ),
+                ),
+                next: 1,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: [
+                Return {
+                    site: Some(
+                        SiteId(
+                            56,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        1,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                56,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+        DecisionFact {
+            site: SiteId(
+                57,
+            ),
+            ty: F64,
+            value_class: BitCopy,
+            intent: Read,
+            strategy: BorrowRead,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            15262,
+            15350,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            15326,
+            15345,
+        ),
+        (
+            1,
+            0,
+        ): (
+            15326,
+            15345,
+        ),
+        (
+            1,
+            1,
+        ): (
+            15326,
+            15345,
+        ),
+    },
+}
+RawMirFunction {
+    name: "string::fmt",
+    return_ty: String,
+    call_conv: Default,
+    params: [
+        String,
+    ],
+    locals: [
+        String,
+    ],
+    blocks: [
+        BasicBlock {
+            id: 0,
+            statements: [
+                Use {
+                    binding: BindingId(
+                        12,
+                    ),
+                    name: "val",
+                    site: SiteId(
+                        59,
+                    ),
+                    ty: String,
+                    intent: Read,
+                },
+                Return {
+                    site: Some(
+                        SiteId(
+                            59,
+                        ),
+                    ),
+                    ty: String,
+                },
+            ],
+            instructions: [
+                Move {
+                    dest: ReturnSlot,
+                    src: Local(
+                        0,
+                    ),
+                },
+            ],
+            terminator: Return,
+        },
+    ],
+    decisions: [
+        DecisionFact {
+            site: SiteId(
+                59,
+            ),
+            ty: String,
+            value_class: CowValue,
+            intent: Read,
+            strategy: CowShare,
+            why: "first vertical-slice classifier",
+        },
+    ],
+    intrinsic_id: None,
+    await_deadline_ns: {},
+    lambda_actor_user_param_locals: [],
+    span: Some(
+        (
+            15350,
+            15920,
+        ),
+    ),
+    instr_spans: {
+        (
+            0,
+            0,
+        ): (
+            15420,
+            15428,
+        ),
+        (
+            0,
+            1,
+        ): (
+            15420,
+            15428,
+        ),
+    },
+}

--- a/examples/v05/checked-mir/hashset_insert_managed_string_move.hew
+++ b/examples/v05/checked-mir/hashset_insert_managed_string_move.hew
@@ -1,0 +1,10 @@
+// MIR-corpus fixture: managed string moved into HashSet.insert and not reused.
+//
+// This must compile: the move-checker consumes the source binding at insert,
+// but no later use observes the consumed binding.
+fn main() {
+    let words: HashSet<string> = HashSet::new();
+    let word = "behaviour";
+    words.insert(word);
+    println(words.len());
+}

--- a/examples/v05/checked-mir/reject/README.md
+++ b/examples/v05/checked-mir/reject/README.md
@@ -16,6 +16,7 @@ Each `.hew` source in this directory exercises one `MirCheck` variant.
 | `use_after_consume_in_block.hew`   | `UseAfterConsume`            | shipping |
 | `init_before_use_in_block.hew`     | `InitialisedBeforeUse`       | shipping |
 | `use_after_consume_in_if.hew`      | `UseAfterConsume`            | shipping |
+| `use_after_hashset_insert_managed_string.hew` | `UseAfterConsume` | shipping |
 | `aliasing.hew`                     | `Aliasing`                   | deferred |
 | `generator_borrow.hew`             | `GeneratorBorrowAcrossYield` | deferred |
 | `actor_send_escape.hew`            | `ActorSendEscape`            | deferred |

--- a/examples/v05/checked-mir/reject/use_after_hashset_insert_managed_string.hew
+++ b/examples/v05/checked-mir/reject/use_after_hashset_insert_managed_string.hew
@@ -1,0 +1,11 @@
+// CHECK-MIR-REJECT: UseAfterConsume
+//
+// HashSet.insert takes ownership of a managed string element. Reusing the
+// source binding after insert would leave both the set slot and source binding
+// on drop paths for the same heap owner.
+fn main() -> string {
+    let words: HashSet<string> = HashSet::new();
+    let word = "colour";
+    words.insert(word);
+    word
+}

--- a/hew-cli/tests/nested_vec_push_leak_oracle.rs
+++ b/hew-cli/tests/nested_vec_push_leak_oracle.rs
@@ -115,7 +115,7 @@ fn main() {\n\
 \x20   var i: i64 = 0;\n\
 \x20   while i < 3 {\n\
 \x20       let m: HashMap<string, i64> = HashMap::new();\n\
-\x20       m.insert(key, i * 7);\n\
+\x20       m.insert(clone key, i * 7);\n\
 \x20       rows.push(m);\n\
 \x20       i = i + 1;\n\
 \x20   }\n\

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -827,6 +827,8 @@ fn wasm_excluded_drop_symbol(spec: &hew_mir::DropFnSpec) -> Option<String> {
             D::DuplexClose | D::SendHalfClose | D::RecvHalfClose => Some(d.c_symbol().to_string()),
             D::StreamClose
             | D::SinkClose
+            | D::SenderClose
+            | D::ReceiverClose
             | D::LambdaActorHandleClose
             | D::CancellationTokenRelease => None,
         },

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -22219,6 +22219,31 @@ impl Builder {
         });
     }
 
+    /// Emit a `MirStatement::Use(Consume)` for a managed-type binding that is
+    /// moved into a builtin aggregate method (HashMap/HashSet insert).
+    ///
+    /// WHY: A vacant `HashMap.insert` / `HashSet.insert` call moves the
+    /// caller's key into the slot (`!existed` path in the runtime). Without
+    /// this consume the scope-exit drop would run *after* the runtime has
+    /// already taken ownership — a double-free. The static consume suppresses
+    /// that scope-exit drop, making the vacant-insert path sound.
+    ///
+    /// LIMITATION (known bounded leak — see issue #2033): on an overwrite
+    /// (`existed` path), the runtime reuses the stored key in place and the
+    /// caller's duplicate key is NOT consumed by the runtime. The static
+    /// consume still suppresses the scope-exit drop, so the caller's duplicate
+    /// leaks (one allocation per colliding insert, no UB). This is a strict
+    /// improvement over the prior double-free. The fix is a Stage-C
+    /// conditional-drop materializer: branch on the `existed` return from
+    /// `hew_hashmap_insert_layout` / `hew_hashset_insert_layout`
+    /// (`hew-codegen-rs/src/llvm.rs:21305`) and emit a drop for the caller's
+    /// duplicate on the overwrite path. See the conditional-key-consume
+    /// contract comment in `hew-runtime/src/hashmap.rs:995-1010`.
+    ///
+    /// WHEN obsolete: once the Stage-C materializer is implemented and the
+    /// codegen branches on `existed`, this function's unconditional consume is
+    /// narrowed to the vacant-insert path only; the overwrite path materialises
+    /// its own drop instead.
     fn consume_moved_builtin_method_arg(&mut self, operand: &HirExpr) {
         let HirExprKind::BindingRef {
             name,

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -9499,7 +9499,7 @@ impl Builder {
                 let mut arg_places = vec![receiver_place];
                 for arg in args {
                     arg_places.push(self.lower_value(arg)?);
-                    if builtin_method_arg_is_move_ingress(target_family) {
+                    if builtin_method_arg_is_move_ingress(*target_family) {
                         self.consume_moved_builtin_method_arg(arg);
                     }
                     if is_array_literal_push {
@@ -29878,7 +29878,7 @@ fn ty_is_closure_pair_vec(ty: &ResolvedTy) -> bool {
     )
 }
 
-fn builtin_method_arg_is_move_ingress(family: &hew_types::MethodTargetFamily) -> bool {
+fn builtin_method_arg_is_move_ingress(family: hew_types::MethodTargetFamily) -> bool {
     matches!(
         family,
         hew_types::MethodTargetFamily::HashMap(hew_types::HashMapMethod::Insert)

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -9499,6 +9499,9 @@ impl Builder {
                 let mut arg_places = vec![receiver_place];
                 for arg in args {
                     arg_places.push(self.lower_value(arg)?);
+                    if builtin_method_arg_is_move_ingress(target_family) {
+                        self.consume_moved_builtin_method_arg(arg);
+                    }
                     if is_array_literal_push {
                         self.alias_moved_owned_operand(arg);
                     }
@@ -22216,6 +22219,27 @@ impl Builder {
         });
     }
 
+    fn consume_moved_builtin_method_arg(&mut self, operand: &HirExpr) {
+        let HirExprKind::BindingRef {
+            name,
+            resolved: ResolvedRef::Binding(id),
+        } = &operand.kind
+        else {
+            return;
+        };
+        let ty = self.subst_ty(&operand.ty);
+        if !self.aggregate_ingress_moves_binding_ty(&ty) {
+            return;
+        }
+        self.statements.push(MirStatement::Use {
+            binding: *id,
+            name: name.clone(),
+            site: operand.site,
+            ty,
+            intent: IntentKind::Consume,
+        });
+    }
+
     /// True when a `Let` RHS produces a named-function pair whose `env_ptr`
     /// is null by construction: a direct `Item`-resolved fn reference
     /// (`let f = double;`), a rebind of an already-exempt binding, or either
@@ -29851,6 +29875,14 @@ fn ty_is_closure_pair_vec(ty: &ResolvedTy) -> bool {
             args,
             ..
         } if args.first().is_some_and(ty_is_closure_pair)
+    )
+}
+
+fn builtin_method_arg_is_move_ingress(family: &hew_types::MethodTargetFamily) -> bool {
+    matches!(
+        family,
+        hew_types::MethodTargetFamily::HashMap(hew_types::HashMapMethod::Insert)
+            | hew_types::MethodTargetFamily::HashSet(hew_types::HashSetMethod::Insert)
     )
 }
 

--- a/hew-mir/tests/runtime_call_allowlist.rs
+++ b/hew-mir/tests/runtime_call_allowlist.rs
@@ -97,8 +97,14 @@ fn pre_staged_families_are_disjoint_from_the_emitter_allowlist() {
 /// call-family side.)
 #[test]
 fn drop_descriptor_symbols_in_allowlist_or_pre_staged() {
-    let pre_staged: HashSet<&'static str> =
-        ["hew_stream_close", "hew_sink_close"].into_iter().collect();
+    let pre_staged: HashSet<&'static str> = [
+        "hew_stream_close",
+        "hew_sink_close",
+        "hew_channel_sender_close",
+        "hew_channel_receiver_close",
+    ]
+    .into_iter()
+    .collect();
     for d in all_runtime_drop_descriptors() {
         let sym = d.c_symbol();
         if pre_staged.contains(sym) {

--- a/hew-mir/tests/vertical.rs
+++ b/hew-mir/tests/vertical.rs
@@ -1091,6 +1091,67 @@ fn cowvalue_string_moved_into_tuple_rejects_post_move_use() {
 }
 
 #[test]
+fn managed_string_moved_into_hashset_insert_rejects_post_move_use() {
+    let p = lower_source(
+        r#"fn main() -> string {
+            let words: HashSet<string> = HashSet::new();
+            let word = "colour";
+            words.insert(word);
+            word
+        }"#,
+    );
+    assert!(
+        p.diagnostics.iter().any(
+            |d| matches!(&d.kind, MirDiagnosticKind::UseAfterConsume { name, .. } if name == "word")
+        ),
+        "reusing a managed string after HashSet.insert moves it into the set \
+         must fire UseAfterConsume: {:?}",
+        p.diagnostics
+    );
+}
+
+#[test]
+fn managed_string_moved_into_hashmap_insert_rejects_post_move_use() {
+    let p = lower_source(
+        r#"fn main() -> string {
+            let labels: HashMap<string, string> = HashMap::new();
+            let key = "k";
+            let value = "v";
+            labels.insert(key, value);
+            value
+        }"#,
+    );
+    assert!(
+        p.diagnostics.iter().any(
+            |d| matches!(&d.kind, MirDiagnosticKind::UseAfterConsume { name, .. } if name == "value")
+        ),
+        "reusing a managed string after HashMap.insert moves it into the map \
+         must fire UseAfterConsume: {:?}",
+        p.diagnostics
+    );
+}
+
+#[test]
+fn managed_string_insert_without_reuse_stays_clean() {
+    let p = lower_source(
+        r#"fn main() -> i64 {
+            let words: HashSet<string> = HashSet::new();
+            let word = "behaviour";
+            words.insert(word);
+            words.len()
+        }"#,
+    );
+    assert!(
+        !p.diagnostics
+            .iter()
+            .any(|d| matches!(&d.kind, MirDiagnosticKind::UseAfterConsume { .. })),
+        "moving a managed string into HashSet.insert without reusing it must not \
+         over-reject: {:?}",
+        p.diagnostics
+    );
+}
+
+#[test]
 fn checked_mir_rejects_use_of_uninitialised_binding() {
     // `let x;` declares without initialising; the subsequent `let _y = x;`
     // reads `x` before any `Bind` for it. The check fires on the

--- a/hew-types/src/builtin_type.rs
+++ b/hew-types/src/builtin_type.rs
@@ -423,6 +423,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines, reason = "single builtin fact table")]
     fn handle_and_project_cap_facts_are_registered() {
         let expected = [
             (

--- a/hew-types/src/builtin_type.rs
+++ b/hew-types/src/builtin_type.rs
@@ -190,6 +190,8 @@ impl BuiltinType {
             Self::Duplex
             | Self::Sink
             | Self::Stream
+            | Self::Sender
+            | Self::Receiver
             | Self::LocalPid
             | Self::RemotePid
             | Self::HewActor
@@ -213,6 +215,8 @@ impl BuiltinType {
             Self::Duplex
             | Self::Sink
             | Self::Stream
+            | Self::Sender
+            | Self::Receiver
             | Self::HewActor
             | Self::HewDuplex
             | Self::HewSendHalf
@@ -447,6 +451,22 @@ mod tests {
                 Some(BuiltinHandleFamily::ActorPid),
                 1,
                 &[BuiltinTypeRole::ActorDispatchRemote][..],
+            ),
+            (
+                BuiltinType::Sender,
+                BuiltinTypeMarker::Resource,
+                Some("close"),
+                None,
+                1,
+                &[][..],
+            ),
+            (
+                BuiltinType::Receiver,
+                BuiltinTypeMarker::Resource,
+                Some("close"),
+                None,
+                1,
+                &[][..],
             ),
             (
                 BuiltinType::HewActor,

--- a/hew-types/src/runtime_call.rs
+++ b/hew-types/src/runtime_call.rs
@@ -1306,8 +1306,8 @@ impl std::error::Error for DescriptorError {}
 /// Closed-set descriptor for compiler-known runtime drop entries. Mirrors
 /// the `runtime_drop_symbol` table in `hew-codegen-rs/src/llvm.rs:18352`
 /// (today: `Duplex::close`, `Stream::close`, `Sink::close`,
-/// `LambdaActorHandle::close`, `SendHalf::close | RecvHalf::close`,
-/// `CancellationToken::release`).
+/// `Sender::close`, `Receiver::close`, `LambdaActorHandle::close`,
+/// `SendHalf::close | RecvHalf::close`, `CancellationToken::release`).
 ///
 /// `non_exhaustive` is INTENTIONALLY OMITTED — same exhaustiveness
 /// argument as [`RuntimeCallFamily`]. The codegen-internal "literal
@@ -1325,6 +1325,10 @@ pub enum RuntimeDropDescriptor {
     StreamClose,
     /// `Sink::close` → `hew_sink_close`.
     SinkClose,
+    /// `Sender::close` → `hew_channel_sender_close`.
+    SenderClose,
+    /// `Receiver::close` → `hew_channel_receiver_close`.
+    ReceiverClose,
     /// `LambdaActorHandle::close` → `hew_lambda_actor_release`. NB the
     /// type-class seeding calls the method "close" but the runtime
     /// C-ABI symbol is "release"; an explicit table entry is required.
@@ -1353,6 +1357,8 @@ impl RuntimeDropDescriptor {
             Self::DuplexClose => "hew_duplex_close",
             Self::StreamClose => "hew_stream_close",
             Self::SinkClose => "hew_sink_close",
+            Self::SenderClose => "hew_channel_sender_close",
+            Self::ReceiverClose => "hew_channel_receiver_close",
             Self::LambdaActorHandleClose => "hew_lambda_actor_release",
             Self::SendHalfClose | Self::RecvHalfClose => "hew_duplex_close_half",
             Self::CancellationTokenRelease => "hew_cancel_token_release",
@@ -1370,6 +1376,8 @@ impl RuntimeDropDescriptor {
             Self::DuplexClose => "Duplex::close",
             Self::StreamClose => "Stream::close",
             Self::SinkClose => "Sink::close",
+            Self::SenderClose => "Sender::close",
+            Self::ReceiverClose => "Receiver::close",
             Self::LambdaActorHandleClose => "LambdaActorHandle::close",
             Self::SendHalfClose => "SendHalf::close",
             Self::RecvHalfClose => "RecvHalf::close",
@@ -1390,6 +1398,8 @@ impl RuntimeDropDescriptor {
             "Duplex::close" => Some(Self::DuplexClose),
             "Stream::close" => Some(Self::StreamClose),
             "Sink::close" => Some(Self::SinkClose),
+            "Sender::close" => Some(Self::SenderClose),
+            "Receiver::close" => Some(Self::ReceiverClose),
             "LambdaActorHandle::close" => Some(Self::LambdaActorHandleClose),
             "SendHalf::close" => Some(Self::SendHalfClose),
             "RecvHalf::close" => Some(Self::RecvHalfClose),
@@ -1447,11 +1457,13 @@ pub fn all_runtime_call_families() -> Vec<RuntimeCallFamily> {
 /// See the bijection / parity tests; same coverage discipline as
 /// [`all_runtime_call_families`].
 #[must_use]
-pub fn all_runtime_drop_descriptors() -> [RuntimeDropDescriptor; 7] {
+pub fn all_runtime_drop_descriptors() -> [RuntimeDropDescriptor; 9] {
     [
         RuntimeDropDescriptor::DuplexClose,
         RuntimeDropDescriptor::StreamClose,
         RuntimeDropDescriptor::SinkClose,
+        RuntimeDropDescriptor::SenderClose,
+        RuntimeDropDescriptor::ReceiverClose,
         RuntimeDropDescriptor::LambdaActorHandleClose,
         RuntimeDropDescriptor::SendHalfClose,
         RuntimeDropDescriptor::RecvHalfClose,
@@ -1753,6 +1765,8 @@ mod tests {
             ("Duplex::close", "hew_duplex_close"),
             ("Stream::close", "hew_stream_close"),
             ("Sink::close", "hew_sink_close"),
+            ("Sender::close", "hew_channel_sender_close"),
+            ("Receiver::close", "hew_channel_receiver_close"),
             ("LambdaActorHandle::close", "hew_lambda_actor_release"),
             ("SendHalf::close", "hew_duplex_close_half"),
             ("RecvHalf::close", "hew_duplex_close_half"),


### PR DESCRIPTION
## Summary

Managed-type bindings (`String`, `Bytes`, heap-owning records) are now statically consumed at `HashMap.insert` and `HashSet.insert` call sites. Re-using such a binding after the insert is rejected by the move checker (`E_MIR_CHECK: binding '...' is used after it was consumed`), closing the double-free that arose when the runtime moved the key into the slot and the scope-exit drop also ran. `Copy` types (e.g. `i64`) and non-insert methods (`contains`, `get`, `len`) are unaffected.

`Sender` and `Receiver` channel handles are promoted to `Resource` builtins with a `close` ritual, identical to the existing `Stream`/`Sink`/`Duplex` pattern. Handles that are never explicitly closed now receive an auto-generated scope-exit `hew_channel_sender_close` / `hew_channel_receiver_close` drop, eliminating the leak. Explicit `.close()` continues to work; the existing channel-handle consume gate prevents double-close.

## Verification

- `hew check reject/use_after_hashset_insert_managed_string.hew`: exit 1, binding consumed at insert site, use-site error anchored correctly.
- `hew check hashset_insert_managed_string_move.hew`: exit 0 (no over-rejection).
- `hew check` with `i64` key reused after insert: exit 0 (`Copy` types not moved).
- `hew check` with `.contains` / `.get` after insert: exit 0 (non-insert methods do not consume).
- Elaborated golden `channel_auto_close_scope.elab.mir`: exactly one `hew_channel_sender_close` and one `hew_channel_receiver_close` at scope exit, no double-close.
- `make test-lane CRATE=hew-mir`: 724/724 passed.
- `make test-lane CRATE=hew-types`: 2140/2140 passed, 2 skipped.
- `cargo nextest run -p hew-mir --test vertical`: 73/73 passed (includes `managed_string_moved_into_hashmap_insert_rejects_post_move_use`, `managed_string_moved_into_hashset_insert_rejects_post_move_use`, `managed_string_insert_without_reuse_stays_clean`).
- `cargo clippy --tests -p hew-mir -p hew-types -p hew-codegen-rs`: exit 0, no warnings.
- `cargo fmt --check -p hew-mir -p hew-types -p hew-codegen-rs`: clean.
- Preflight: ready-to-push.

## Out of scope

- **Overwrite-path duplicate-key leak (#2033):** on a colliding insert, the runtime reuses the stored key in place; the caller's duplicate leaks (no UB, bounded to one allocation per collision). The static consume is still correct for the vacant-insert path and is documented at `consume_moved_builtin_method_arg` in `hew-mir/src/lower.rs`. The fix (a Stage-C conditional-drop materializer branching on the `existed` return from `hew_hashmap_insert_layout`) is tracked in #2033.
- Runtime supervisor scheduling and remote-actor tests (`two_process_remote_ask`, `rest_for_one`, `supervisor_escalation`) are pre-existing timing-sensitive failures not in this diff's surface.