### PR TITLE
fix(hir,mir): for-in borrows Vec — collection usable after loop

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -16988,7 +16988,22 @@ impl LowerCtx {
                 Some(pattern.clone()),
             )
         };
-        let lowered_iterable = self.lower_expr(iterable, IntentKind::Consume);
+        // Lower the iterable with Read intent for inspection; the intent on the
+        // BindingRef is patched per arm below:
+        //
+        //  - Vec (borrow arm): intent → Capture.  Vec is a refcounted heap handle;
+        //    CowShare increments the refcount so the source binding stays Live after
+        //    the loop.  IntentKind::Capture is the "share without consuming" signal:
+        //    MIR recognises Capture+CowValue as a CowShare and does NOT emit
+        //    AggregateAlias for the VecIter struct init, leaving the source Live.
+        //
+        //  - Draining iterables (Generator, Receiver, Stream, VecIter, generic
+        //    IntoIterator/Iterator): intent → Consume.  The source is fully drained
+        //    so the binding must be Consumed.
+        //
+        // The intent field of the BindingRef is what the MIR dataflow checker reads
+        // to decide Consumed vs Live for the source collection binding.
+        let mut lowered_iterable = self.lower_expr(iterable, IntentKind::Read);
         let (iter_init, iter_ty, elem_ty, next_call) = match lowered_iterable.ty.clone() {
             ResolvedTy::Named {
                 name,
@@ -16996,6 +17011,11 @@ impl LowerCtx {
                 builtin: Some(BuiltinType::Vec),
                 ..
             } if name == "Vec" && args.len() == 1 => {
+                // Vec is a refcounted heap handle: sharing it (CowShare) leaves the
+                // source binding Live, so the collection is usable after the loop.
+                // Use Capture intent to signal "share, not move" to the MIR; the MIR
+                // alias_moved_owned_operand skips AggregateAlias for Capture+CowValue.
+                lowered_iterable.intent = IntentKind::Capture;
                 let elem_ty = args[0].clone();
                 (
                     self.make_vec_iter_init(lowered_iterable, elem_ty.clone(), iterable.1.clone()),
@@ -17009,12 +17029,17 @@ impl LowerCtx {
                 args,
                 builtin: None,
                 ..
-            } if name == "VecIter" && args.len() == 1 => (
-                lowered_iterable,
-                Self::resolved_vec_iter_ty(args[0].clone()),
-                args[0].clone(),
-                ForIterNextCall::BuiltinVecIter,
-            ),
+            } if name == "VecIter" && args.len() == 1 => {
+                // VecIter is already an iterator object; consuming it drives
+                // the cursor forward and the source binding is fully drained.
+                lowered_iterable.intent = IntentKind::Consume;
+                (
+                    lowered_iterable,
+                    Self::resolved_vec_iter_ty(args[0].clone()),
+                    args[0].clone(),
+                    ForIterNextCall::BuiltinVecIter,
+                )
+            }
             ResolvedTy::Named {
                 args,
                 builtin: Some(BuiltinType::Receiver),
@@ -17035,6 +17060,9 @@ impl LowerCtx {
                         "for await over unsupported Receiver<T> element type".into(),
                     );
                 }
+                // Receiver is an affine resource: `for await rx` drains and
+                // implicitly closes the channel; the source binding is consumed.
+                lowered_iterable.intent = IntentKind::Consume;
                 let iter_ty = lowered_iterable.ty.clone();
                 (
                     lowered_iterable,
@@ -17063,12 +17091,15 @@ impl LowerCtx {
                         "for await over unsupported Stream<T> element type".into(),
                     );
                 }
+                // Stream is an affine resource: `for await stream` drains it;
+                // the source binding is consumed.
                 // The layout-witness recv (`hew_stream_next_layout`) carries
                 // every describable element type; MIR's `lower_direct_call`
                 // suspendable-caller flip turns it into
                 // `Terminator::SuspendingStreamNext` in actor/task execution
                 // contexts, non-context callers keep the blocking call via
                 // the codegen `Terminator::Call` intercept.
+                lowered_iterable.intent = IntentKind::Consume;
                 let iter_ty = lowered_iterable.ty.clone();
                 (
                     lowered_iterable,
@@ -17087,6 +17118,8 @@ impl LowerCtx {
             } if !args.is_empty() => {
                 let elem_ty = args[0].clone();
                 let gen_ty = lowered_iterable.ty.clone();
+                // Generator is a linear resource: iterating consumes it.
+                lowered_iterable.intent = IntentKind::Consume;
                 (
                     lowered_iterable,
                     gen_ty,
@@ -17095,6 +17128,9 @@ impl LowerCtx {
                 )
             }
             other => {
+                // Generic IntoIterator/Iterator: the into_iter() call consumes
+                // the source, or a plain Iterator binding is drained.
+                lowered_iterable.intent = IntentKind::Consume;
                 if let Some(shape) =
                     self.generic_into_iter_init(lowered_iterable.clone(), &iterable.1)
                 {

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -22199,6 +22199,19 @@ impl Builder {
     /// Copy operands carry no single-owner drop obligation and share freely, so
     /// they must NOT be flagged: `BitCopy` ints/durations, non-owning borrows,
     /// and persistent handles are excluded by `aggregate_ingress_moves_binding_ty`.
+    ///
+    /// `CowValue` operands with `IntentKind::Capture` share the refcounted handle
+    /// via `CowShare` rather than moving it; the source binding stays Live.  The
+    /// canonical case is `for x in vec { … }` desugaring, which places the Vec
+    /// handle into `VecIter { vec: _, idx: 0 }` with Capture intent so the source
+    /// collection is usable after the loop.  Emitting `AggregateAlias` for such
+    /// a captured (shared) `CowValue` operand would incorrectly mark the source
+    /// Consumed.
+    ///
+    /// All other intent values (Read, Consume, Modify, Yield, Unknown) trigger
+    /// the alias marker as before — including `CowValue` with Read intent, where
+    /// the HIR signals a structural move into an aggregate (e.g. strings into
+    /// tuples or `HashSet.insert`).
     fn alias_moved_owned_operand(&mut self, operand: &HirExpr) {
         let HirExprKind::BindingRef {
             name,
@@ -22209,6 +22222,14 @@ impl Builder {
         };
         let ty = self.subst_ty(&operand.ty);
         if !self.aggregate_ingress_moves_binding_ty(&ty) {
+            return;
+        }
+        // A CowValue binding with Capture intent is a refcount-share (CowShare),
+        // not a structural move.  The source stays Live; skip the alias marker.
+        // This intent is set exclusively by the for-in Vec borrow desugaring path.
+        if operand.intent == IntentKind::Capture
+            && ValueClass::of_ty(&ty, &self.type_classes) == ValueClass::CowValue
+        {
             return;
         }
         self.statements.push(MirStatement::AggregateAlias {

--- a/tests/hew/for_in_borrow_test.hew
+++ b/tests/hew/for_in_borrow_test.hew
@@ -1,0 +1,132 @@
+//! Proving fixture for DF-16: for-in borrows the collection (does not consume it).
+//!
+//! Each test verifies that `for x in coll { … }` leaves `coll` alive and usable
+//! after the loop — the binding is NOT consumed.  Element values are asserted
+//! exactly so the test fails on uninitialised memory or wrong indices.
+
+import std::testing;
+
+// ── Vec<i64> ──────────────────────────────────────────────────────────────────
+#[test]
+fn test_vec_i64_for_in_borrows_collection() {
+    let v: Vec<i64> = Vec::new();
+    v.push(10);
+    v.push(20);
+    v.push(30);
+    var sum: i64 = 0;
+    for x in v {
+        sum = sum + x;
+    }
+    // Collection must still be alive after the loop.
+    testing.assert_eq(v.len(), 3);
+    testing.assert_eq(v.get(0), 10);
+    testing.assert_eq(v.get(1), 20);
+    testing.assert_eq(v.get(2), 30);
+    // Loop must have seen all elements.
+    testing.assert_eq(sum, 60);
+}
+
+#[test]
+fn test_vec_i64_second_loop_after_first() {
+    let v: Vec<i64> = Vec::new();
+    v.push(1);
+    v.push(2);
+    v.push(3);
+    var first_sum: i64 = 0;
+    for x in v {
+        first_sum = first_sum + x;
+    }
+    // Second loop over the same collection — valid because for-in borrows.
+    var second_sum: i64 = 0;
+    for x in v {
+        second_sum = second_sum + x;
+    }
+    testing.assert_eq(first_sum, 6);
+    testing.assert_eq(second_sum, 6);
+    testing.assert_eq(v.len(), 3);
+}
+
+// ── Vec<string> ───────────────────────────────────────────────────────────────
+#[test]
+fn test_vec_string_for_in_borrows_collection() {
+    let v: Vec<string> = Vec::new();
+    v.push("alpha");
+    v.push("beta");
+    v.push("gamma");
+    var count: i64 = 0;
+    for s in v {
+        count = count + s.len();
+    }
+    // Collection must still be alive after the loop.
+    testing.assert_eq(v.len(), 3);
+    testing.assert_eq_str(v.get(0), "alpha");
+    testing.assert_eq_str(v.get(1), "beta");
+    testing.assert_eq_str(v.get(2), "gamma");
+    // alpha=5, beta=4, gamma=5 = 14
+    testing.assert_eq(count, 14);
+}
+
+// ── Vec<f64> ──────────────────────────────────────────────────────────────────
+#[test]
+fn test_vec_f64_for_in_borrows_collection() {
+    let v: Vec<f64> = Vec::new();
+    v.push(1.5);
+    v.push(2.5);
+    v.push(3.0);
+    var total: f64 = 0.0;
+    for x in v {
+        total = total + x;
+    }
+    // Collection must still be alive after the loop.
+    testing.assert_eq(v.len(), 3);
+    testing.assert_true(v.get(0) == 1.5);
+    testing.assert_true(v.get(1) == 2.5);
+    testing.assert_true(v.get(2) == 3.0);
+    testing.assert_true(total == 7.0);
+}
+
+// ── range 0..n ────────────────────────────────────────────────────────────────
+// Ranges use ForRange (not lower_for_iter_desugar) so were never affected by the
+// borrow bug.  Confirm they still produce correct element values.
+#[test]
+fn test_range_for_in_elements_and_count() {
+    let n: i64 = 5;
+    var sum: i64 = 0;
+    var count: i64 = 0;
+    for i in 0 .. n {
+        sum = sum + i;
+        count = count + 1;
+    }
+    testing.assert_eq(count, 5);
+    // 0+1+2+3+4 = 10
+    testing.assert_eq(sum, 10);
+}
+
+// ── Empty Vec — loop body does not execute ────────────────────────────────────
+#[test]
+fn test_empty_vec_for_in_borrows_collection() {
+    let v: Vec<i64> = Vec::new();
+    var count: i64 = 0;
+    for x in v {
+        count = count + x;
+    }
+    // Loop body never ran; collection still alive.
+    testing.assert_eq(v.len(), 0);
+    testing.assert_eq(count, 0);
+}
+
+// ── for-in then mutate the collection ─────────────────────────────────────────
+// Borrow semantics must allow mutation of the collection after the loop.
+#[test]
+fn test_vec_mutable_after_for_in() {
+    let v: Vec<i64> = Vec::new();
+    v.push(1);
+    v.push(2);
+    for x in v {
+        let _ = x;
+    }
+    // Push a new element after iterating — collection is still alive.
+    v.push(3);
+    testing.assert_eq(v.len(), 3);
+    testing.assert_eq(v.get(2), 3);
+}


### PR DESCRIPTION
## Summary

`for x in v { … }` now borrows the collection rather than consuming it. After the loop body completes the source binding remains live, and a second loop or any method call on the original `Vec` compiles and runs correctly.

The fix is a narrow discriminant in `alias_moved_owned_operand` in MIR lowering: a `CowValue` binding with `IntentKind::Capture` takes the refcount-share (CowShare) path and skips the alias marker that would mark the source binding Consumed. All other intent values — including `Read+CowValue`, which is the path for managed values moving into `HashMap`/`HashSet.insert` — continue to trigger the alias marker and are consumed as before. The two code paths do not overlap.

Draining forms (into_iter, receivers, streams, generators) are unaffected; they use Consume intent and still consume the source.

## Verification

- `hew-hir` unit tests: 482/482 passed
- `hew-mir` unit tests: 724/724 passed
- `vec_string_for_in_*` MIR canary (6 tests): 6/6 passed
- `managed_string_moved_into_hashset_insert_rejects_post_move_use`: passed (DF-A borrow-checker intact)
- `managed_string_moved_into_hashmap_insert_rejects_post_move_use`: passed (DF-A borrow-checker intact)
- iter/vec/sort/hashset regression suite: 98/98 passed
- `make test-vertical-slice`: EXIT=0 (all entries PASS)
- `make test` (full CI profile, 9537 tests): 9537/9537 passed
- `make fuzz-oracle`: passed (151s)
- `cargo fmt --check`: EXIT=0
- `cargo clippy --workspace -- -D warnings`: EXIT=0
- `make verify-ffi`: EXIT=0
- Preflight: ready-to-push

## Out of scope

- Draining iterator forms (`IntoIterator`, generator drain, stream/receiver drain) — these remain Consume by design; the borrow applies only to the `Vec` shared-handle path.
- Non-Vec collection types — this fix is scoped to the Vec desugaring path; other collections use the same intent machinery and will be addressed when those for-in paths are added.
