### PR TITLE
feat(tasks): wire value-returning task await (`let x = await t` for `Task<T>`)

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -1020,6 +1020,7 @@ fn wasm_excluded_call_family(family: hew_types::runtime_call::RuntimeCallFamily)
         | F::TaskGetResult
         | F::TaskNew
         | F::TaskSetEnv
+        | F::TaskSetResult
         | F::TaskSpawnThread
         | F::VecGet(_)
         | F::VecLen
@@ -2509,6 +2510,16 @@ fn intern_runtime_decl<'ctx>(
         // before calling hew_task_spawn_thread.
         "hew_task_new" => ptr_ty.fn_type(&[], false),
         "hew_task_complete_threaded" => ctx.void_type().fn_type(&[ptr_ty.into()], false),
+        // hew_task_set_result(task: *mut HewTask, result: *mut c_void, size: usize)
+        //   -> void (`hew-runtime/src/task_scope.rs`). Deep-copies `size` bytes of
+        // the value representation at `result` into a malloc'd buffer the task
+        // owns until consumed; the codegen task wrapper calls it to publish a
+        // value-returning task's body result before `hew_task_complete_threaded`.
+        // `size` is target-correct `usize` (i32 on wasm32, i64 on native) to
+        // match the runtime's real C ABI.
+        "hew_task_set_result" => ctx
+            .void_type()
+            .fn_type(&[ptr_ty.into(), ptr_ty.into(), size_ty.into()], false),
         "hew_task_get_error" => i32_ty.fn_type(&[ptr_ty.into()], false),
         "hew_task_get_env" => ptr_ty.fn_type(&[ptr_ty.into()], false),
         "hew_task_scope_new" => ptr_ty.fn_type(&[], false),
@@ -6057,13 +6068,6 @@ fn get_or_create_task_wrapper<'ctx>(
     })?;
     let (callee_value, callee_return_ty, callee_returns_unit) =
         callee_symbol_entry.real(callee_symbol, "SpawnTaskDirect")?;
-    if !callee_returns_unit || !matches!(callee_return_ty, BasicTypeEnum::IntType(_)) {
-        return Err(CodegenError::FailClosed(format!(
-            "SpawnTaskDirect callee `{callee_symbol}` must be unit-lowered to the i8 \
-             stand-in return type; got {:?}",
-            callee_return_ty
-        )));
-    }
 
     let ptr_ty = fn_ctx.ctx.ptr_type(AddressSpace::default());
     if callee_value.get_nth_param(0).is_none() || callee_value.get_nth_param(1).is_some() {
@@ -6089,9 +6093,54 @@ fn get_or_create_task_wrapper<'ctx>(
     let task_param = wrapper.get_nth_param(1).ok_or_else(|| {
         CodegenError::FailClosed("task wrapper missing HewTask* parameter".into())
     })?;
-    builder
+    let body_call = builder
         .build_call(callee_value, &[ctx_param.into()], "task_body_call")
         .llvm_ctx("task wrapper body call")?;
+
+    // Value-returning task: publish the body's `T` result through the task's
+    // own result buffer BEFORE marking the task complete, so the awaiter's
+    // resume edge reads it via `hew_task_get_result`. The adapter
+    // (`__hew_task_entry_<fn>`, TaskEntry call-conv) returns its body's `T`; a
+    // unit task returns the i8 unit stand-in and publishes nothing.
+    //
+    // Drop-exactly-once: `hew_task_set_result` deep-copies `sizeof(T)` bytes of
+    // the value REPRESENTATION into a malloc buffer the task owns and frees
+    // (as raw bytes) at scope join. For a managed `T` (string/record) those
+    // bytes are the owning handle, MOVED out of the body's return slot here and
+    // MOVED out of the buffer into the awaiter's binding on resume — the buffer
+    // free never drops the handle, so it lives exactly once.
+    if !callee_returns_unit {
+        let result_val = body_call.try_as_basic_value().basic().ok_or_else(|| {
+            CodegenError::FailClosed(format!(
+                "SpawnTaskDirect value-task callee `{callee_symbol}` returned void but \
+                 its MIR return type is non-unit"
+            ))
+        })?;
+        // Stack slot holding the value representation; `hew_task_set_result`
+        // copies `sizeof(T)` bytes from it into the task-owned result buffer.
+        let result_slot = builder
+            .build_alloca(callee_return_ty, "task_result_slot")
+            .llvm_ctx("task wrapper result slot alloca")?;
+        builder
+            .build_store(result_slot, result_val)
+            .llvm_ctx("task wrapper result store")?;
+        let (size, _align) = abi_size_align(callee_return_ty, Some(fn_ctx.target_data))?;
+        let size_ty = runtime_size_ty(fn_ctx.ctx, fn_ctx.llvm_mod);
+        let size_val = size_ty.const_int(size, false);
+        let set_result = intern_runtime_decl(
+            fn_ctx.ctx,
+            fn_ctx.llvm_mod,
+            &mut fn_ctx.runtime_decls.borrow_mut(),
+            "hew_task_set_result",
+        )?;
+        builder
+            .build_call(
+                set_result,
+                &[task_param.into(), result_slot.into(), size_val.into()],
+                "hew_task_set_result_call",
+            )
+            .llvm_ctx("hew_task_set_result call")?;
+    }
 
     let complete = intern_runtime_decl(
         fn_ctx.ctx,
@@ -24685,6 +24734,12 @@ fn lower_call_runtime_abi(
         | F::TaskGetEnv
         | F::TaskGetError
         | F::TaskSetEnv
+        // `hew_task_set_result` is synthesized directly by the codegen task
+        // wrapper (`get_or_create_task_wrapper`), never emitted as an
+        // `Instr::CallRuntimeAbi` — so it has no MIR-ABI lowering arm here and
+        // fails closed if it ever reaches this dispatch, exactly like its
+        // sibling `TaskCompleteThreaded`.
+        | F::TaskSetResult
         | F::VtableDispatchPanicOnOob => {
             return Err(CodegenError::FailClosed(format!(
                 "Instr::CallRuntimeAbi(symbol={symbol:?}, family={:?}): codegen has no \
@@ -28312,9 +28367,8 @@ struct SuspendingTaskAwaitEmit {
     scope: Place,
     task: Place,
     /// `Some(slot)` reads the task result via `hew_task_get_result` on the bind
-    /// edge (value task); `None` for a unit task (nothing to bind). The
-    /// value-task result read is wired in a later slice; codegen fails closed if
-    /// it ever arrives here while value-task result propagation is unbuilt.
+    /// edge and copies it into the slot at the `T` element width (value task);
+    /// `None` for a unit task (nothing to bind).
     result_dest: Option<Place>,
     resume: u32,
     cleanup: u32,
@@ -31084,20 +31138,12 @@ fn emit_suspending_task_await_terminator<'ctx>(
             term.cleanup
         )));
     }
-    // The value-task result read (`hew_task_get_result` into `result_dest`) is a
-    // later slice; the WRITE side of the value channel (the task-entry adapter
-    // publishing the body return value) is unbuilt. Fail closed if a value-task
-    // carrier reaches here rather than reading an unpopulated result buffer.
-    if term.result_dest.is_some() {
-        return Err(CodegenError::FailClosed(
-            "SuspendingTaskAwait carries a result_dest but value-task result \
-             propagation is not yet wired (the task-entry result channel is a \
-             separate slice); the MIR producer must keep value task await \
-             fail-closed"
-                .into(),
-        ));
-    }
-
+    // A value-returning task carries `result_dest` — the slot the child's `T`
+    // is read into on the bind edge. The task body published its result through
+    // `hew_task_set_result` (the codegen task wrapper); on the resume /
+    // immediate-ready edge the task is `Done` and `hew_task_get_result` returns
+    // the result buffer, which the bind edge copies into `result_dest` at the
+    // `T` element width. A unit task carries `None` and binds nothing.
     let actor_self_fn = intern_runtime_decl(
         fn_ctx.ctx,
         fn_ctx.llvm_mod,
@@ -31221,9 +31267,46 @@ fn emit_suspending_task_await_terminator<'ctx>(
             Ok(())
         },
         || {
-            // Bind: already-done OR resumed. The task is `Done`; a unit task has
-            // nothing to bind. Release the creator ref, branch to the MIR resume.
-            // (Value-task result read lands with the task-entry result channel.)
+            // Bind: already-done OR resumed. The task is `Done`. For a value
+            // task, read the published result and copy it into `result_dest` at
+            // the `T` element width: `hew_task_get_result` returns the
+            // task-owned result buffer (the bytes `hew_task_set_result` deep-
+            // copied from the body's return); the load+store MOVES the value
+            // representation out of the buffer into the awaiter's binding slot.
+            // The task frees the buffer (as raw bytes) at scope join, so a
+            // managed handle lives exactly once — in `result_dest`.
+            if let Some(result_dest) = term.result_dest {
+                let get_result = intern_runtime_decl(
+                    fn_ctx.ctx,
+                    fn_ctx.llvm_mod,
+                    &mut fn_ctx.runtime_decls.borrow_mut(),
+                    "hew_task_get_result",
+                )?;
+                let result_buf = fn_ctx
+                    .builder
+                    .build_call(
+                        get_result,
+                        &[task_ptr.into()],
+                        "suspending_task_await_result",
+                    )
+                    .llvm_ctx("hew_task_get_result (bind) call")?
+                    .try_as_basic_value()
+                    .basic()
+                    .ok_or_else(|| {
+                        CodegenError::FailClosed("hew_task_get_result returned void".into())
+                    })?
+                    .into_pointer_value();
+                let (dest_ptr, dest_ty) = place_pointer(fn_ctx, result_dest)?;
+                let loaded = fn_ctx
+                    .builder
+                    .build_load(dest_ty, result_buf, "suspending_task_await_result_load")
+                    .llvm_ctx("value-task result load")?;
+                fn_ctx
+                    .builder
+                    .build_store(dest_ptr, loaded)
+                    .llvm_ctx("value-task result store")?;
+            }
+            // Release the creator ref, branch to the MIR resume.
             fn_ctx
                 .builder
                 .build_call(slot_free, &[slot.into()], "suspending_task_await_bind_free")

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -31275,6 +31275,27 @@ fn emit_suspending_task_await_terminator<'ctx>(
             // representation out of the buffer into the awaiter's binding slot.
             // The task frees the buffer (as raw bytes) at scope join, so a
             // managed handle lives exactly once — in `result_dest`.
+            //
+            // Null-buffer guard: `hew_task_get_result` returns `t.result`, which
+            // is NULL whenever the task reached `Done` WITHOUT publishing a result
+            // — i.e. a `Done(Cancelled)` task whose body never ran to
+            // `hew_task_set_result` (the runtime documents this null contract on
+            // `hew_task_await_suspend`). On a null buffer the bind edge copies
+            // nothing rather than dereferencing null: the awaiter is being torn
+            // down by the same scope cancel, so the binding is never observed —
+            // exactly the unit-task discipline. Mirrors the suspending-ask bind
+            // edge, which null-checks `reply_ptr` before the load.
+            //
+            // WHY a guard for a path the current surface cannot reach: no v0.6
+            // user construct cancels a sibling task while another value-awaits in
+            // the same scope (the empty-body `scope … after(d)` deadline arms but
+            // joins the forked task rather than preempting its await — verified),
+            // so this branch is presently unexercised. It honours the runtime's
+            // explicit null-return contract so the value path is correct the day a
+            // cancelling-await surface lands (await-cancel deadline on the task, a
+            // failing-sibling scope-cancel), rather than shipping a latent null
+            // deref behind a future feature. WHEN obsolete: never — the runtime
+            // contract permits a null result buffer regardless of surface.
             if let Some(result_dest) = term.result_dest {
                 let get_result = intern_runtime_decl(
                     fn_ctx.ctx,
@@ -31296,6 +31317,23 @@ fn emit_suspending_task_await_terminator<'ctx>(
                         CodegenError::FailClosed("hew_task_get_result returned void".into())
                     })?
                     .into_pointer_value();
+                let copy_bb = fn_ctx
+                    .ctx
+                    .append_basic_block(parent, "suspending_task_await_result_copy");
+                let bind_join_bb = fn_ctx
+                    .ctx
+                    .append_basic_block(parent, "suspending_task_await_result_join");
+                let result_is_null = fn_ctx
+                    .builder
+                    .build_is_null(result_buf, "suspending_task_await_result_is_null")
+                    .llvm_ctx("value-task result null compare")?;
+                // null (cancelled / no result) → skip copy; non-null → copy.
+                fn_ctx
+                    .builder
+                    .build_conditional_branch(result_is_null, bind_join_bb, copy_bb)
+                    .llvm_ctx("value-task result null branch")?;
+
+                fn_ctx.builder.position_at_end(copy_bb);
                 let (dest_ptr, dest_ty) = place_pointer(fn_ctx, result_dest)?;
                 let loaded = fn_ctx
                     .builder
@@ -31305,6 +31343,12 @@ fn emit_suspending_task_await_terminator<'ctx>(
                     .builder
                     .build_store(dest_ptr, loaded)
                     .llvm_ctx("value-task result store")?;
+                fn_ctx
+                    .builder
+                    .build_unconditional_branch(bind_join_bb)
+                    .llvm_ctx("value-task result copy -> join br")?;
+
+                fn_ctx.builder.position_at_end(bind_join_bb);
             }
             // Release the creator ref, branch to the MIR resume.
             fn_ctx

--- a/hew-hir/src/diagnostic.rs
+++ b/hew-hir/src/diagnostic.rs
@@ -599,13 +599,6 @@ pub enum HirDiagnosticKind {
         /// Site identifier for error reporting.
         site: SiteId,
     },
-    /// Awaiting non-unit task result. The awaited task must return unit
-    /// because task result value propagation is not yet wired. Fail-closed
-    /// per FC-P1-A1 audit.
-    AwaitTaskResultUnsupported {
-        /// Site identifier for error reporting.
-        site: SiteId,
-    },
     /// Pool supervisor child accessor is not yet implemented. The program
     /// performs a field access on a supervisor-typed handle (`sup.child_name`)
     /// where the named child is declared with `pool name: Type` rather than

--- a/hew-hir/src/dump.rs
+++ b/hew-hir/src/dump.rs
@@ -564,6 +564,7 @@ fn dump_expr(out: &mut String, expr: &HirExpr, indent: usize) {
             callee,
             args,
             task_ty,
+            ..
         } => {
             writeln!(out, "{pad}  spawned-call task_ty={}", task_ty.user_facing())
                 .expect("write to string");

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -21055,6 +21055,7 @@ impl LowerCtx {
                                     callee,
                                     args,
                                     task_ty: task_ty.clone(),
+                                    bound: true,
                                 },
                                 span: child_expr.1.clone(),
                             };
@@ -21177,6 +21178,7 @@ impl LowerCtx {
                 callee,
                 args,
                 task_ty,
+                bound: false,
             },
             span,
         }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -571,7 +571,6 @@ impl LowerOutput {
                     | crate::HirDiagnosticKind::SpawnedClosureNonSendCapture { .. }
                     | crate::HirDiagnosticKind::ForkBlockBodyUnsupported { .. }
                     | crate::HirDiagnosticKind::DeadlineBodyUnsupported { .. }
-                    | crate::HirDiagnosticKind::AwaitTaskResultUnsupported { .. }
                     | crate::HirDiagnosticKind::SupervisorPoolChildAccessorUnsupported { .. }
                     | crate::HirDiagnosticKind::NestedSupervisorAccessorUnsupported { .. }
                     | crate::HirDiagnosticKind::ActorSendRequiresUnitHandler { .. }
@@ -4163,6 +4162,26 @@ fn contains_abstract_symbol(
     }
 }
 
+/// The syntactic position of an expression being lowered, as it bears on
+/// `await` legality (TI-4). The position is set on `LowerCtx` immediately
+/// before lowering an expression and consumed atomically at `lower_expr`
+/// entry, so recursive sub-expression lowering always sees [`Self::Other`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AwaitPosition {
+    /// Any position where `await` is NOT specially admitted: function
+    /// arguments, binary operands, return values, block tails, etc. A task
+    /// `await` here trips `AwaitOutOfPosition`.
+    Other,
+    /// The direct expression of a `Stmt::Expression` — the statement-expression
+    /// position inside a `scope{}` body where a unit/value `await t` is legal.
+    Statement,
+    /// The value of a `let` binding that the `Stmt::Let` path validated as a
+    /// bindable value-returning task await (`let x = await t`, `T != ()`). The
+    /// child's `T` is read on the resume edge; admitting the await here does
+    /// NOT admit it in arg / return / operand positions.
+    BindableValueLet,
+}
+
 #[derive(Debug)]
 struct LowerCtx {
     ids: IdGen,
@@ -4328,13 +4347,11 @@ struct LowerCtx {
     /// Used by `Expr::PostfixTry` to synthesize `return Err(e)` / `return None`
     /// with the enclosing body's return type rather than the scrutinee type.
     current_return_type: Option<ResolvedTy>,
-    /// Set to `true` immediately before lowering the expression of a
-    /// `Stmt::Expression` statement. `lower_expr` consumes it via
-    /// `mem::replace(…, false)` at entry, so all recursive calls see `false`.
-    /// This lets `Expr::Await` check whether it is the direct statement, not
-    /// a sub-expression of a return value, argument, binary operand, etc.
-    /// (TI-4 position rule.)
-    statement_position: bool,
+    /// The syntactic position of the expression about to be lowered, as it
+    /// bears on `await` legality (TI-4). Set immediately before lowering an
+    /// expression and consumed by `lower_expr` via `mem::replace(…, Other)` at
+    /// entry, so every recursive (sub-expression) call sees `Other`.
+    await_position: AwaitPosition,
     /// `Some((let_id, let_name))` while lowering the body of an actor-lambda
     /// that is the value of `let <let_name> = actor |..| { .. }`. The
     /// capture-strength classifier inside the body walk compares each
@@ -4720,7 +4737,7 @@ impl LowerCtx {
             scope_depth: 0,
             current_scope_id: ScopeId(0),
             current_return_type: None,
-            statement_position: false,
+            await_position: AwaitPosition::Other,
             current_actor_self: None,
             call_type_args: tc_output.call_type_args.clone(),
             lowering_facts: tc_output.lowering_facts.clone(),
@@ -10060,9 +10077,9 @@ impl LowerCtx {
         // Mark this as statement position before lowering so that
         // `lower_expr`'s `Expr::Await` arm can enforce TI-4 (await is
         // only legal in statement-expression position, not as a
-        // sub-expression). The flag is consumed by `mem::replace` at the
-        // top of `lower_expr`, so recursive calls see `false`.
-        self.statement_position = true;
+        // sub-expression). The position is consumed by `mem::replace` at the
+        // top of `lower_expr`, so recursive calls see `AwaitPosition::Other`.
+        self.await_position = AwaitPosition::Statement;
         if self.scope_depth > 0 {
             if let Expr::Call { .. } = &expr.0 {
                 let spawned = self.lower_spawned_call(expr);
@@ -10138,6 +10155,24 @@ impl LowerCtx {
         )
     }
 
+    /// True when the `await`'s inner expression is a VALUE-returning task
+    /// handle — `await t` over a `Task<T>` with `T != ()`. Such an await is
+    /// bindable (`let x = await t`): it produces the child's `T`, read back on
+    /// the resume edge through `hew_task_get_result`. A `Task<()>` await is the
+    /// unit "wait until Done" form, which binds nothing and is statement-only;
+    /// this predicate excludes it so the unit reroute keeps its position rules.
+    ///
+    /// The element type rides the checker-resolved type of the inner operand
+    /// (the `Task<T>` binding), the same table `check_await_task_result`
+    /// consults — not a method-call rewrite descriptor, since `await t` over a
+    /// bare binding has no method call.
+    fn is_value_task_await(&self, inner_key: &SpanKey) -> bool {
+        matches!(
+            self.resolved_expr_types.get(inner_key),
+            Some(ResolvedTy::Task(inner)) if !matches!(**inner, ResolvedTy::Unit)
+        )
+    }
+
     #[allow(
         clippy::too_many_lines,
         reason = "single large match on stmt variants; splitting would hurt readability"
@@ -10199,6 +10234,9 @@ impl LowerCtx {
                                 || self.listener_await_accepts.contains(&original_key)
                                 || self.is_stream_recv_await(&original_key)
                                 || self.is_channel_recv_await(&original_key)
+                                // `let x = await t` over a value-returning task:
+                                // the child's `T` is read back on the resume edge.
+                                || self.is_value_task_await(&original_key)
                         }
                         _ => false,
                     };
@@ -10284,6 +10322,15 @@ impl LowerCtx {
                         kind: HirStmtKind::Let(pre_binding, Some(lowered_value)),
                         span,
                     };
+                }
+                // A `let x = await t` over a value-returning task is a bindable
+                // let-value. Flag the position so the `Expr::Await` arm admits
+                // it (the position is consumed atomically at `lower_expr` entry,
+                // so only this direct await sees it — not nested sub-expressions).
+                if let Some((Expr::Await(inner), _)) = value.as_ref() {
+                    if self.is_value_task_await(&self.mk_key(&inner.1)) {
+                        self.await_position = AwaitPosition::BindableValueLet;
+                    }
                 }
                 let value = value
                     .as_ref()
@@ -11375,11 +11422,15 @@ impl LowerCtx {
         reason = "single large match on expr variants; splitting would hurt readability"
     )]
     fn lower_expr_inner(&mut self, expr: &Spanned<Expr>, intent: IntentKind) -> HirExpr {
-        // Consume the statement-position flag atomically. Every recursive call
-        // to `lower_expr` (for arguments, operands, return values, block tails,
-        // etc.) therefore sees `false`. Only the `Stmt::Expression` arm in
-        // `lower_stmt` sets this to `true` immediately before calling us.
-        let in_stmt_position = std::mem::replace(&mut self.statement_position, false);
+        // Consume the await-position atomically. Every recursive call to
+        // `lower_expr` (for arguments, operands, return values, block tails,
+        // etc.) therefore sees `AwaitPosition::Other`. Only the
+        // `Stmt::Expression` arm (Statement) and the `Stmt::Let` bindable path
+        // (BindableValueLet) set a non-Other position immediately before
+        // calling us.
+        let await_position = std::mem::replace(&mut self.await_position, AwaitPosition::Other);
+        let in_stmt_position = await_position == AwaitPosition::Statement;
+        let in_bindable_value_position = await_position == AwaitPosition::BindableValueLet;
         let span = expr.1.clone();
         // Pre-allocate the SiteId for this expression so call-site
         // side-tables (e.g. `call_site_type_args`) can be keyed
@@ -12196,12 +12247,24 @@ impl LowerCtx {
                 }
                 // `await expr` — only legal as the direct statement-expression
                 // inside a `scope{}` body in v0.5 (TI-4). Sub-expression positions
-                // (return value, function argument, binary operand, let value, block
-                // tail, etc.) are rejected with `AwaitOutOfPosition`.
+                // (return value, function argument, binary operand, block tail,
+                // etc.) are rejected with `AwaitOutOfPosition`.
                 // `in_stmt_position` is set by `Stmt::Expression` in `lower_stmt`
                 // and consumed by `mem::replace` at the top of this function, so
                 // recursive calls always see `false`.
-                if self.scope_depth == 0 || !in_stmt_position {
+                //
+                // A VALUE-returning task await (`let x = await t` over a
+                // `Task<T>`, `T != ()`) is additionally legal as a bindable
+                // let-value: it produces the child's `T`, read back on the resume
+                // edge, like the actor-ask / conn-read forms above. The
+                // `Stmt::Let` path validates that position and sets
+                // `bindable_value_await_position`, which admits the await HERE
+                // without admitting it in arg / return / binary-operand positions
+                // (those keep the TI-4 rejection). A unit `await t` (a "wait until
+                // Done" with nothing to bind) stays statement-only.
+                let inner_is_value_task = self.is_value_task_await(&self.mk_key(&inner.1));
+                let value_await_in_let = inner_is_value_task && in_bindable_value_position;
+                if !value_await_in_let && (self.scope_depth == 0 || !in_stmt_position) {
                     self.diagnostics.push(HirDiagnostic::new(
                         HirDiagnosticKind::AwaitOutOfPosition,
                         span.clone(),
@@ -20945,9 +21008,10 @@ impl LowerCtx {
                             // FC-P1-A1 (revision pass 2): Non-unit callee return is
                             // VALID at spawn time. `fork t = compute() -> i64` binds
                             // `t: Task<i64>` cleanly here (canonical TI-2 invariant,
-                            // see vertical.rs::task_handle_ti2_*). The
-                            // `AwaitTaskResultUnsupported` gate at MIR :7871 fires
-                            // when the non-unit result is awaited, not when spawned.
+                            // see vertical.rs::task_handle_ti2_*). Awaiting the
+                            // non-unit result is now lowered through the value-task
+                            // await result channel (the resume edge reads the child's
+                            // `T` via `hew_task_get_result`).
                             let call_hir = self.lower_expr(child_expr, IntentKind::Consume);
                             let call_site = call_hir.site;
                             let explicit_type_args = match &child_expr.0 {
@@ -21070,9 +21134,9 @@ impl LowerCtx {
         //
         // FC-P1-A1 (revision pass 2): The callee return type is intentionally
         // NOT gated here. An implicit spawn that produces `Task<T>` for
-        // non-unit T is a valid Hew construct; only `await` of a non-unit
-        // task is gated (MIR :7871, `AwaitTaskResultUnsupported`). Gating at
-        // spawn time would break the TI-1/TI-2/TI-4 canonical invariants.
+        // non-unit T is a valid Hew construct; awaiting the non-unit result is
+        // lowered through the value-task await result channel. Gating at spawn
+        // time would break the TI-1/TI-2/TI-4 canonical invariants.
         let call_hir = self.lower_expr(expr, IntentKind::Consume);
         let call_site = call_hir.site;
         let explicit_type_args = match &expr.0 {
@@ -23587,10 +23651,6 @@ fn scan_expr_for_task_gates(expr: &Expr, span: &Span, ctx: &mut LowerCtx, progra
             scan_expr_for_task_gates(&duration.0, &duration.1, ctx, program);
             scan_block_for_task_gates(body, ctx, program);
         }
-        Expr::Await(object) => {
-            check_await_task_result(&object.0, &object.1, ctx, program);
-            scan_expr_for_task_gates(&object.0, &object.1, ctx, program);
-        }
         // Recursive scanning for all other expression variants
         Expr::MethodCall { receiver, args, .. } => {
             scan_expr_for_task_gates(&receiver.0, &receiver.1, ctx, program);
@@ -23709,7 +23769,10 @@ fn scan_expr_for_task_gates(expr: &Expr, span: &Span, ctx: &mut LowerCtx, progra
             scan_expr_for_task_gates(&duration.0, &duration.1, ctx, program);
         }
         Expr::UnsafeBlock(b) => scan_block_for_task_gates(b, ctx, program),
-        Expr::FieldAccess { object, .. } | Expr::PostfixTry(object) => {
+        // `await object`, `object.field`, and `object?` all just recurse into
+        // their single operand — the value-task await gate moved into HIR
+        // lowering, so the await scan no longer carries a dedicated check.
+        Expr::Await(object) | Expr::FieldAccess { object, .. } | Expr::PostfixTry(object) => {
             scan_expr_for_task_gates(&object.0, &object.1, ctx, program);
         }
         Expr::Index { object, index } => {
@@ -23966,25 +24029,6 @@ fn check_scope_deadline_shape(body: &hew_parser::ast::Block, span: &Span, ctx: &
             span.clone(),
             "deadline body must be empty (syntax sugar for timeout-only scope)".to_string(),
         ));
-    }
-}
-
-/// Check await task result type.
-/// Site: hew-mir/src/lower.rs:7871 (`AwaitTask` result)
-fn check_await_task_result(_expr: &Expr, span: &Span, ctx: &mut LowerCtx, _program: &Program) {
-    // Look up the type of the awaited expression
-    let span_key = SpanKey::in_module(span, ctx.current_module_idx);
-    if let Some(hew_types::Ty::Named { name, args, .. }) = ctx.expr_types.get(&span_key) {
-        // Check if it's a Task<T> where T != unit
-        if name == "Task" && !args.is_empty() && !matches!(args[0], hew_types::Ty::Unit) {
-            ctx.diagnostics.push(HirDiagnostic::new(
-                HirDiagnosticKind::AwaitTaskResultUnsupported {
-                    site: ctx.ids.site(),
-                },
-                span.clone(),
-                "awaiting task with non-unit result is not yet supported".to_string(),
-            ));
-        }
     }
 }
 

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -1243,6 +1243,15 @@ pub enum HirExprKind {
         callee: Box<HirExpr>,
         args: Vec<HirExpr>,
         task_ty: ResolvedTy,
+        /// `true` when this spawn was written as `fork t = callee()` (the task handle
+        /// is bound to a name and can be awaited for its result). `false` for an
+        /// implicit/unbound spawn (`callee()` as a bare statement inside a `scope{}`
+        /// body — the task handle is immediately discarded).
+        ///
+        /// MIR lowering uses this to determine whether a non-unit-returning callee
+        /// is permissible (bound → value-task supported) or must reject (unbound →
+        /// the result would be silently discarded, fail-closed).
+        bound: bool,
     },
     /// `fork { ... }` inside a scope. The block is an anonymous child task
     /// body; later MIR slices attach a derived cancellation token and spawn it.

--- a/hew-hir/tests/task_gates.rs
+++ b/hew-hir/tests/task_gates.rs
@@ -343,35 +343,38 @@ fn deadline_non_empty_body_rejected() {
 // ── AwaitTask tests ─────────────────────────────────────────────────────────
 
 #[test]
-fn await_unit_task_accepted() {
-    // Valid: awaiting a unit-returning worker must not trip the non-unit gate.
+fn await_unit_task_in_scope_accepted() {
+    // Valid: awaiting a unit-returning worker as a statement inside a `scope{}`
+    // body must not trip the position gate.
     let source = r"
         fn main() {
-            let task = worker();
-            await task;
+            scope {
+                fork task = worker();
+                await task;
+            }
         }
         fn worker() {}
     ";
     let output = lower(source);
 
-    let has_gate_diagnostic = output
+    let has_position_reject = output
         .diagnostics
         .iter()
-        .any(|d| matches!(d.kind, HirDiagnosticKind::AwaitTaskResultUnsupported { .. }));
+        .any(|d| matches!(d.kind, HirDiagnosticKind::AwaitOutOfPosition));
     assert!(
-        !has_gate_diagnostic,
-        "Valid await should not trigger gate; got: {:#?}",
+        !has_position_reject,
+        "unit task statement await in scope should not trip the position gate; got: {:#?}",
         output.diagnostics
     );
 }
 
 #[test]
-fn value_await_in_let_rejected_fail_closed() {
-    // HEW-SPEC-2026 §4.3 value resolution (`let v = await x;` for a
-    // Task<i64> fork binding) is not wired yet: task results have no
-    // result-propagation substrate (wrapper discards the callee return).
-    // The let-value await must refuse with a clear AwaitOutOfPosition
-    // diagnostic — never bind a fabricated value.
+fn value_await_in_let_accepted() {
+    // `let v = await x;` over a value-returning `Task<i64>` fork binding is a
+    // bindable, value-producing await: the child's `T` is read back on the
+    // resume edge through the value-task result channel. It must NOT trip the
+    // let-value position gate (which rejects only awaits with no bindable
+    // value, e.g. a unit `await t` in let position).
     let source = r"
         fn compute() -> i64 { 42 }
         fn main() {
@@ -388,8 +391,8 @@ fn value_await_in_let_rejected_fail_closed() {
         matches!(d.kind, HirDiagnosticKind::AwaitOutOfPosition) && d.note.contains("let-value")
     });
     assert!(
-        has_let_value_reject,
-        "value await in let position must fail closed; got: {:#?}",
+        !has_let_value_reject,
+        "value await in let position must be accepted (bindable); got: {:#?}",
         output.diagnostics
     );
 }

--- a/hew-hir/tests/task_gates.rs
+++ b/hew-hir/tests/task_gates.rs
@@ -398,6 +398,35 @@ fn value_await_in_let_accepted() {
 }
 
 #[test]
+fn unit_task_await_in_let_rejected() {
+    // `let x = await t` where `t: Task<()>` (unit-returning) must still trip
+    // `AwaitOutOfPosition` with the "let-value" note. A unit-returning worker
+    // has nothing to bind: `is_value_task_await` returns false, so the bindable
+    // guard fires. The value-let path must NOT accidentally pass unit awaits.
+    let source = r"
+        fn worker() {}
+        fn main() {
+            scope {
+                fork t = worker();
+                let x = await t;
+                let _ = x;
+            }
+        }
+    ";
+    let output = lower(source);
+
+    let has_let_value_reject = output.diagnostics.iter().any(|d| {
+        matches!(d.kind, HirDiagnosticKind::AwaitOutOfPosition) && d.note.contains("let-value")
+    });
+    assert!(
+        has_let_value_reject,
+        "unit task `await t` in let position must emit AwaitOutOfPosition with 'let-value' note; \
+         got: {:#?}",
+        output.diagnostics
+    );
+}
+
+#[test]
 fn await_expression_parses() {
     // Ensure await expressions are parsed correctly
     let source = r"

--- a/hew-hir/tests/task_gates_type_dependent.rs
+++ b/hew-hir/tests/task_gates_type_dependent.rs
@@ -11,13 +11,6 @@
 mod support;
 
 use hew_hir::{lower_program_host_target, HirDiagnostic, HirDiagnosticKind, ResolutionCtx};
-use hew_types::{SpanKey, Ty};
-
-fn has_await_non_unit(diagnostics: &[HirDiagnostic]) -> bool {
-    diagnostics
-        .iter()
-        .any(|d| matches!(d.kind, HirDiagnosticKind::AwaitTaskResultUnsupported { .. }))
-}
 
 fn non_send_capture_names(diagnostics: &[HirDiagnostic]) -> Vec<&str> {
     diagnostics
@@ -29,73 +22,6 @@ fn non_send_capture_names(diagnostics: &[HirDiagnostic]) -> Vec<&str> {
             _ => None,
         })
         .collect()
-}
-
-fn awaited_task_span_key(source: &str) -> SpanKey {
-    let await_start = source
-        .find("await task")
-        .expect("test source must contain `await task`");
-    let start = await_start + "await ".len();
-    SpanKey {
-        start,
-        end: start + "task".len(),
-        module_idx: 0,
-    }
-}
-
-#[test]
-fn await_unit_task_accepted_with_checker_expr_types() {
-    let output = support::checker_pipeline::lower_through_checker(
-        r"
-        fn worker() {}
-        fn main() {
-            scope {
-                fork task = worker();
-                await task;
-            }
-        }
-        ",
-    );
-
-    assert!(
-        !has_await_non_unit(&output.diagnostics),
-        "unit task await should not trip AwaitTaskResultUnsupported: {:#?}",
-        output.diagnostics
-    );
-}
-
-#[test]
-fn await_non_unit_task_rejected_when_expr_type_is_present() {
-    let source = r"
-        fn worker() -> i64 { 42 }
-        fn main() {
-            scope {
-                fork task = worker();
-                await task;
-            }
-        }
-        ";
-    let (parsed, mut tco) = support::checker_pipeline::typecheck_source(source);
-    tco.insert_expr_type(
-        awaited_task_span_key(source),
-        Ty::Named {
-            builtin: None,
-            name: "Task".to_string(),
-            args: vec![Ty::I64],
-        },
-    );
-
-    let output = lower_program_host_target(&parsed.program, &tco, &ResolutionCtx);
-
-    assert!(
-        has_await_non_unit(&output.diagnostics),
-        "non-unit task await must trip AwaitTaskResultUnsupported when the checker side table carries Task<i64>: {:#?}",
-        output.diagnostics
-    );
-    assert!(
-        output.into_result().is_err(),
-        "non-unit task await must make lowering fatal"
-    );
 }
 
 #[test]
@@ -208,41 +134,5 @@ fn checker_pipeline_rc_capture_emits_non_send_diagnostic() {
     assert!(
         output.into_result().is_err(),
         "non-Send spawned closure capture must make lowering fatal"
-    );
-}
-
-#[test]
-fn missing_await_expr_type_silently_accepts_current_behavior() {
-    let source = r"
-        fn worker() -> i64 { 42 }
-        fn main() {
-            scope {
-                fork task = worker();
-                await task;
-            }
-        }
-        ";
-    let (parsed, mut tco) = support::checker_pipeline::typecheck_source(source);
-    let removed = tco.expr_types.remove(&awaited_task_span_key(source));
-    assert!(
-        removed.is_some(),
-        "test setup must remove the checker-produced awaited expression type"
-    );
-
-    let output = lower_program_host_target(&parsed.program, &tco, &ResolutionCtx);
-    assert!(
-        !has_await_non_unit(&output.diagnostics),
-        "missing awaited Task<T> expr type currently silently accepts: {:#?}",
-        output.diagnostics
-    );
-    assert!(
-        output.diagnostics.iter().all(|d| {
-            !matches!(
-                &d.kind,
-                HirDiagnosticKind::CheckerBoundaryViolation { name, .. }
-                    if name == "await task"
-            )
-        }),
-        "check_await_task_result must not emit a boundary diagnostic today"
     );
 }

--- a/hew-hir/tests/vertical.rs
+++ b/hew-hir/tests/vertical.rs
@@ -963,21 +963,23 @@ fn task_handle_ti5_task_annotation_in_let_rejects_task_not_nameable() {
     );
 }
 
-/// TI-4 (reject): `let x = await name` inside a `fork{}` body emits
-/// `AwaitOutOfPosition`. Await is only legal as a statement-expression, never
-/// as a let-value — the result cannot be bound.
+/// `let x = await t` over a value-returning `Task<T>` is a bindable let-value:
+/// the child's `T` is read back on the resume edge through the value-task
+/// result channel. It must NOT emit `AwaitOutOfPosition` — binding it is its
+/// purpose. (A unit `await t` in let position, with no bindable value, still
+/// trips the position gate; covered by the await-position tests below.)
 #[test]
-fn task_handle_ti4_await_in_let_value_position_rejects() {
+fn task_handle_value_await_in_let_value_position_accepted() {
     let output = lower(
         "fn compute() -> i64 { return 1; } \
-         fn f() { scope { fork t = compute(); let x = await t; } }",
+         fn f() { scope { fork t = compute(); let x = await t; let _ = x; } }",
     );
     assert!(
-        output
+        !output
             .diagnostics
             .iter()
             .any(|d| matches!(d.kind, HirDiagnosticKind::AwaitOutOfPosition)),
-        "let x = await t inside fork must emit AwaitOutOfPosition: {:?}",
+        "let x = await t (value task) must be accepted as a bindable let-value: {:?}",
         output.diagnostics
     );
 }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -16169,7 +16169,14 @@ impl Builder {
             });
             return None;
         }
-        if !args.is_empty() || !matches!(ret_ty, ResolvedTy::Unit) {
+        // A no-argument callee returning unit OR a value `T` is supported: the
+        // task-entry adapter captures the body's return and the value channel
+        // publishes it (unit tasks publish nothing). Arg-bearing spawns still
+        // route through `lower_spawned_args_call_task`, which keeps its own
+        // unit-only restriction (a value+args spawn is a follow-on once the
+        // fork-env shim captures the return as well).
+        let _ = ret_ty;
+        if !args.is_empty() {
             for arg in args {
                 let _ = self.lower_value(arg);
             }
@@ -16179,7 +16186,7 @@ impl Builder {
                     site,
                 },
                 note: "cancellation-token task lowering currently supports only \
-                       no-argument functions returning unit; value/result task \
+                       no-argument functions; arg-bearing value/result task \
                        propagation remains fail-closed"
                     .to_string(),
             });
@@ -16218,7 +16225,7 @@ impl Builder {
         )
     }
 
-    fn ensure_task_entry_adapter(&mut self, callee_symbol: &str) -> String {
+    fn ensure_task_entry_adapter(&mut self, callee_symbol: &str, result_ty: &ResolvedTy) -> String {
         let adapter_symbol = Self::task_entry_adapter_symbol(callee_symbol);
         if !self
             .task_entry_adapter_symbols
@@ -16227,16 +16234,37 @@ impl Builder {
         {
             return adapter_symbol;
         }
-        let lowered = self.synthesize_task_entry_adapter(callee_symbol, &adapter_symbol);
+        let lowered = self.synthesize_task_entry_adapter(callee_symbol, &adapter_symbol, result_ty);
         self.generated_functions.push(lowered);
         adapter_symbol
     }
 
+    /// Synthesize the per-callee task-entry adapter (`__hew_task_entry_<fn>`,
+    /// `TaskEntry` call-conv). The adapter is the body the codegen task wrapper
+    /// invokes on the spawned worker; the wrapper publishes the adapter's return
+    /// value through `hew_task_set_result` and then `hew_task_complete_threaded`.
+    ///
+    /// For a value-returning task (`result_ty != ()`) the adapter calls the body
+    /// into a typed `dest` local and RETURNS it, so the wrapper captures the
+    /// child's `T` and writes it into the task result buffer. For a unit task
+    /// the adapter calls the body with `dest: None` and returns unit — the
+    /// wrapper publishes nothing.
     fn synthesize_task_entry_adapter(
         &self,
         callee_symbol: &str,
         adapter_symbol: &str,
+        result_ty: &ResolvedTy,
     ) -> LoweredFunction {
+        let is_value_task = !matches!(result_ty, ResolvedTy::Unit);
+        // Value task: the body call writes its `T` directly into the function
+        // return slot so `Terminator::Return` hands it back; the codegen wrapper
+        // then publishes that return value through `hew_task_set_result`. Unit
+        // task: discard the body result (`dest: None`).
+        let call_dest = if is_value_task {
+            Some(Place::ReturnSlot)
+        } else {
+            None
+        };
         let mut blocks = vec![
             BasicBlock {
                 id: 0,
@@ -16246,7 +16274,7 @@ impl Builder {
                     callee: callee_symbol.to_string(),
                     builtin: None,
                     args: vec![],
-                    dest: None,
+                    dest: call_dest,
                     next: 1,
                 },
             },
@@ -16259,14 +16287,15 @@ impl Builder {
         ];
         bracket_actor_handler_blocks(&mut blocks);
 
+        let adapter_return_ty = result_ty.clone();
         let thir = ThirFunction {
             name: adapter_symbol.to_string(),
-            return_ty: ResolvedTy::Unit,
+            return_ty: adapter_return_ty.clone(),
             statements: vec![],
         };
         let raw = RawMirFunction {
             name: adapter_symbol.to_string(),
-            return_ty: ResolvedTy::Unit,
+            return_ty: adapter_return_ty.clone(),
             call_conv: crate::model::FunctionCallConv::TaskEntry,
             params: vec![],
             locals: vec![],
@@ -16295,7 +16324,7 @@ impl Builder {
         let cooperate_sites = dataflow::compute_cooperate_sites(&raw.blocks);
         let checked = CheckedMirFunction {
             name: adapter_symbol.to_string(),
-            return_ty: ResolvedTy::Unit,
+            return_ty: adapter_return_ty,
             blocks: raw.blocks.clone(),
             decisions: vec![],
             checks: dataflow_result.checks.clone(),
@@ -16390,7 +16419,7 @@ impl Builder {
         }
         let user_callee_symbol =
             self.direct_no_arg_unit_callee(callee, args, inner, site, "spawned call")?;
-        let callee_symbol = self.ensure_task_entry_adapter(&user_callee_symbol);
+        let callee_symbol = self.ensure_task_entry_adapter(&user_callee_symbol, inner);
 
         let task_place = self.alloc_local(task_ty.clone());
         self.push_runtime_call("hew_task_new", vec![], Some(task_place));
@@ -16903,25 +16932,7 @@ impl Builder {
         output_ty: &ResolvedTy,
         site: hew_hir::SiteId,
     ) -> Option<Place> {
-        if !matches!(output_ty, ResolvedTy::Unit) {
-            // Value-returning task await binds the child's `T` on the resume
-            // edge. The carrier's `result_dest` is wired, but the WRITE side of
-            // the value channel — the task-entry adapter capturing the body's
-            // return value into `hew_task_set_result` + result sizing — is a
-            // separate cross-layer slice. Until that lands, value task await
-            // remains fail-closed (never a miscompile).
-            self.diagnostics.push(MirDiagnostic {
-                kind: MirDiagnosticKind::NotYetImplemented {
-                    construct: "await task result".to_string(),
-                    site,
-                },
-                note: "await lowering currently supports unit tasks only; value task \
-                       result propagation remains fail-closed pending the task-entry \
-                       result channel"
-                    .to_string(),
-            });
-            return None;
-        }
+        let is_value_task = !matches!(output_ty, ResolvedTy::Unit);
         let Some(task_place) = self.binding_locals.get(&binding_id).copied() else {
             self.diagnostics.push(MirDiagnostic {
                 kind: MirDiagnosticKind::UnresolvedPlace {
@@ -16947,34 +16958,65 @@ impl Builder {
         self.mark_binding_moved(binding_id);
 
         // Suspendable-caller flip: in a caller that carries the execution
-        // context (actor handler / closure / task entry) the unit `await t`
-        // SUSPENDS on the child task's completion instead of blocking the worker
-        // in `hew_task_await_blocking` (a condvar). The completion observer
+        // context (actor handler / closure / task entry) `await t` SUSPENDS on
+        // the child task's completion instead of blocking the worker in
+        // `hew_task_await_blocking` (a condvar). The completion observer
         // (`hew_task_await_suspend`) re-enqueues the parked continuation on the
         // child's `Done`. A `FunctionCallConv::Default` caller (`main`, free fn)
         // has no parkable continuation and keeps the blocking call. Reuses the
         // same `carries_execution_context` discriminator as the recv/ask flips.
         if self.current_function_call_conv.carries_execution_context() {
             if let Some(scope_place) = self.current_task_scope {
+                // Value task: allocate the slot the child's `T` is read into on
+                // the resume edge (codegen reads `hew_task_get_result` into it,
+                // copying the result-buffer bytes at the `T` element width). A
+                // unit task binds nothing.
+                let result_dest = if is_value_task {
+                    Some(self.alloc_local(output_ty.clone()))
+                } else {
+                    None
+                };
                 let next = self.alloc_block();
                 // The carrier rides the multi-suspend epilogue, so `cleanup`
                 // reuses `next` exactly as the recv/ask carriers do.
                 self.finish_current_block(Terminator::SuspendingTaskAwait {
                     scope: scope_place,
                     task: task_place,
-                    // Unit task: nothing to bind on the resume edge.
-                    result_dest: None,
+                    result_dest,
                     resume: next,
                     cleanup: next,
                 });
                 self.start_block(next);
+                if let Some(result_dest) = result_dest {
+                    // The resume edge bound the child's `T` into `result_dest`.
+                    return Some(result_dest);
+                }
                 let unit_place = self.alloc_local(ResolvedTy::Unit);
                 self.push_instr(Instr::UnitLit { dest: unit_place });
                 return Some(unit_place);
             }
         }
 
-        // Contextless keep path: block the foreign thread on the condvar.
+        // Contextless keep path: a `FunctionCallConv::Default` caller has no
+        // parkable continuation and blocks the foreign thread on the condvar.
+        // Value tasks cannot reach this path: `lower_spawned_call_task` refuses
+        // to spawn from a Default-callconv caller, so a value `Task<T>` handle
+        // never exists in a contextless awaiter. Fail closed rather than emit a
+        // blocking read whose result-width copy was never proven on this path.
+        if is_value_task {
+            self.diagnostics.push(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: "await task result".to_string(),
+                    site,
+                },
+                note: "awaiting a value-returning task is only lowered from an \
+                       execution-context caller (actor handler / closure / task \
+                       entry); a `Task<T>` handle cannot reach a Default-callconv \
+                       awaiter because value tasks cannot be spawned there"
+                    .to_string(),
+            });
+            return None;
+        }
         self.push_runtime_call("hew_task_await_blocking", vec![task_place], None);
         let unit_place = self.alloc_local(ResolvedTy::Unit);
         self.push_instr(Instr::UnitLit { dest: unit_place });

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -9051,7 +9051,8 @@ impl Builder {
                 callee,
                 args,
                 task_ty,
-            } => self.lower_spawned_call_task(callee, args, task_ty, expr.site),
+                bound,
+            } => self.lower_spawned_call_task(callee, args, task_ty, *bound, expr.site),
             HirExprKind::ForkBlock { body, .. } => self.lower_fork_block_task(body, expr.site),
             HirExprKind::ScopeDeadline { duration, body } => {
                 self.lower_scope_deadline(duration, body, expr.site)
@@ -16169,14 +16170,17 @@ impl Builder {
             });
             return None;
         }
-        // A no-argument callee returning unit OR a value `T` is supported: the
-        // task-entry adapter captures the body's return and the value channel
-        // publishes it (unit tasks publish nothing). Arg-bearing spawns still
-        // route through `lower_spawned_args_call_task`, which keeps its own
-        // unit-only restriction (a value+args spawn is a follow-on once the
-        // fork-env shim captures the return as well).
-        let _ = ret_ty;
-        if !args.is_empty() {
+        // A no-argument callee returning UNIT is supported via this function.
+        // Value-returning (`T != ()`) no-arg spawns are allowed only through
+        // the `fork t = callee()` bound form — the task handle is then awaited
+        // to retrieve `T`. An UNBOUND implicit spawn of a non-unit callee
+        // (bare `callee()` inside `scope { }` with `T != ()`) is rejected here:
+        // the result would be silently discarded and the value channel unused,
+        // which is a miscompile not a runtime leak.
+        //
+        // Arg-bearing spawns route through `lower_spawned_args_call_task` before
+        // this point; value+args spawns remain fail-closed there.
+        if !args.is_empty() || !matches!(ret_ty, ResolvedTy::Unit) {
             for arg in args {
                 let _ = self.lower_value(arg);
             }
@@ -16186,7 +16190,7 @@ impl Builder {
                     site,
                 },
                 note: "cancellation-token task lowering currently supports only \
-                       no-argument functions; arg-bearing value/result task \
+                       no-argument functions returning unit; value/result task \
                        propagation remains fail-closed"
                     .to_string(),
             });
@@ -16348,6 +16352,9 @@ impl Builder {
         callee: &HirExpr,
         args: &[HirExpr],
         task_ty: &ResolvedTy,
+        // `true` for a bound `fork t = callee()` spawn (value-task allowed);
+        // `false` for an implicit/unbound spawn (non-unit callee must reject).
+        bound: bool,
         site: hew_hir::SiteId,
     ) -> Option<Place> {
         let Some(scope_place) = self.current_task_scope else {
@@ -16417,10 +16424,103 @@ impl Builder {
                 site,
             );
         }
+        // Bound value-returning task (`fork t = callee()` where callee returns T ≠ ()):
+        // route through the value-callee path — no unit-return restriction, the task handle
+        // is awaited to retrieve `T`. Unbound implicit spawns (`callee()` as a bare scope
+        // statement, `bound = false`) fall through to `direct_no_arg_unit_callee` where the
+        // unit-return gate rejects the non-unit callee fail-closed.
+        if bound && !matches!(&**inner, ResolvedTy::Unit) {
+            return self.lower_no_arg_value_callee_task(callee, inner, task_ty, scope_place, site);
+        }
         let user_callee_symbol =
             self.direct_no_arg_unit_callee(callee, args, inner, site, "spawned call")?;
         let callee_symbol = self.ensure_task_entry_adapter(&user_callee_symbol, inner);
 
+        let task_place = self.alloc_local(task_ty.clone());
+        self.push_runtime_call("hew_task_new", vec![], Some(task_place));
+        self.push_runtime_call("hew_task_scope_spawn", vec![scope_place, task_place], None);
+        self.push_instr(Instr::SpawnTaskDirect {
+            task: task_place,
+            callee_symbol,
+        });
+        Some(task_place)
+    }
+
+    /// Lower a no-argument value-returning task spawn: `fork t = callee()` where
+    /// `callee` returns `T ≠ ()`. The task-entry adapter is synthesized with
+    /// `result_ty = T` so the child's `T` is published via `hew_task_set_result`
+    /// and the awaiting handler reads it on the resume edge.
+    ///
+    /// This path does NOT enforce a unit-return restriction (unlike
+    /// `direct_no_arg_unit_callee`). All other gates (generic callee,
+    /// non-module-fn callee, arg-bearing callee) remain fail-closed.
+    fn lower_no_arg_value_callee_task(
+        &mut self,
+        callee: &HirExpr,
+        inner: &ResolvedTy,
+        task_ty: &ResolvedTy,
+        scope_place: Place,
+        site: hew_hir::SiteId,
+    ) -> Option<Place> {
+        // Generic callees: fail-closed until monomorphisation adapter lands.
+        if self
+            .call_site_type_args
+            .get(&site)
+            .is_some_and(|type_args| !type_args.is_empty())
+        {
+            self.diagnostics.push(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: "value-task spawn".to_string(),
+                    site,
+                },
+                note: "generic free-function value-task spawning is not yet implemented; \
+                       W4.010 keeps generic spawned free functions fail-closed until \
+                       the task-entry adapter can resolve monomorphised callees"
+                    .to_string(),
+            });
+            return None;
+        }
+        if matches!(
+            &callee.kind,
+            HirExprKind::BindingRef { name, .. } if self.module_generic_fn_names.contains(name)
+        ) {
+            self.diagnostics.push(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: "value-task spawn".to_string(),
+                    site,
+                },
+                note: "generic free-function value-task spawning is not yet implemented; \
+                       W4.010 keeps generic spawned free functions fail-closed until \
+                       the task-entry adapter can resolve monomorphised callees"
+                    .to_string(),
+            });
+            return None;
+        }
+        let HirExprKind::BindingRef { name, .. } = &callee.kind else {
+            let _ = self.lower_value(callee);
+            self.diagnostics.push(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: "value-task spawn".to_string(),
+                    site,
+                },
+                note: "value-task spawn requires a direct module function callee".to_string(),
+            });
+            return None;
+        };
+        if !self.module_fn_names.contains(name) {
+            self.diagnostics.push(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: "value-task spawn".to_string(),
+                    site,
+                },
+                note: format!(
+                    "value-task spawn callee `{name}` is not a registered module function"
+                ),
+            });
+            return None;
+        }
+        let user_callee_symbol = name.clone();
+        let callee_symbol = self.ensure_task_entry_adapter(&user_callee_symbol, inner);
         let task_place = self.alloc_local(task_ty.clone());
         self.push_runtime_call("hew_task_new", vec![], Some(task_place));
         self.push_runtime_call("hew_task_scope_spawn", vec![scope_place, task_place], None);
@@ -16883,7 +16983,8 @@ impl Builder {
             return None;
         };
         let task_ty = ResolvedTy::Task(Box::new(ResolvedTy::Unit));
-        self.lower_spawned_call_task(callee, args, &task_ty, site)
+        // Fork-block spawns are unbound — no `fork t =` name, no await.
+        self.lower_spawned_call_task(callee, args, &task_ty, false, site)
     }
 
     fn lower_scope_deadline(

--- a/hew-mir/src/runtime_symbols.rs
+++ b/hew-mir/src/runtime_symbols.rs
@@ -437,6 +437,13 @@ const MIR_EMITTER_RUNTIME_SYMBOLS: &[&str] = &[
     "hew_task_scope_set_current",
     "hew_task_scope_spawn",
     "hew_task_set_env",
+    // `hew_task_set_result(task: *mut HewTask, result: *mut c_void, size: usize)
+    //  -> void` (`hew-runtime/src/task_scope.rs`). Deep-copies the value
+    // representation into a task-owned malloc buffer. Emitted by the codegen
+    // task wrapper to publish a value-returning task's body result before
+    // `hew_task_complete_threaded`; the awaiter reads it via
+    // `hew_task_get_result` on the resume edge. Part of value-task await.
+    "hew_task_set_result",
     // `hew_task_spawn_thread(task: *mut HewTask, task_fn: TaskFn) -> void`
     // (`hew-runtime/src/task_scope.rs:368`). Spawns `task_fn(task)` on a
     // new OS thread. `TaskFn = unsafe extern "C" fn(*mut HewTask)`. The

--- a/hew-mir/tests/cancellation_scope.rs
+++ b/hew-mir/tests/cancellation_scope.rs
@@ -1,5 +1,5 @@
 use hew_hir::{lower_program, ResolutionCtx};
-use hew_mir::{lower_hir_module, Instr, IrPipeline, MirCheck};
+use hew_mir::{lower_hir_module, Instr, IrPipeline, MirCheck, MirDiagnosticKind};
 use hew_types::module_registry::ModuleRegistry;
 use hew_types::Checker;
 
@@ -29,6 +29,31 @@ fn lower_clean_to_mir(source: &str) -> IrPipeline {
         hir.diagnostics.is_empty(),
         "HIR diagnostics: {:#?}",
         hir.diagnostics
+    );
+    lower_hir_module(&hir.module)
+}
+
+/// Parse + check + HIR-lower + MIR-lower without asserting clean HIR or MIR;
+/// used for reject tests where the pipeline is expected to emit diagnostics.
+fn lower_to_mir(source: &str) -> IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:#?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    assert!(
+        tc_output.errors.is_empty(),
+        "checker errors: {:#?}",
+        tc_output.errors
+    );
+    let hir = lower_program(
+        &parsed.program,
+        &tc_output,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
     );
     lower_hir_module(&hir.module)
 }
@@ -400,5 +425,40 @@ fn scope_fork_after_lowers_to_executable_task_and_deadline_abi() {
                 if call.symbol() == "hew_task_scope_cancel_after_ns"
         )),
         "after(duration) must lower to deadline cancellation ABI; instructions: {instructions:#?}"
+    );
+}
+
+#[test]
+fn value_task_await_in_default_callconv_caller_fails_closed() {
+    // A value-returning `fork x = compute(); let v = await x;` in a
+    // Default-callconv function (here `main`) must be refused at MIR: the
+    // fork spawn itself emits `NotYetImplemented` (no execution-context to
+    // park a continuation on), and `lower_await_task` is an additional
+    // defence-in-depth gate. This test asserts the pipeline emits a
+    // `NotYetImplemented` diagnostic — the value-task result-read path is
+    // not wired for blocking callers.
+    let source = r"
+        fn compute() -> i64 { 42 }
+        fn main() {
+            scope {
+                fork x = compute();
+                let v = await x;
+                let _ = v;
+            }
+        }
+    ";
+    let mir = lower_to_mir(source);
+    let has_nyi = mir.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("cannot spawn") || construct.contains("await task result")
+        )
+    });
+    assert!(
+        has_nyi,
+        "value-task await from a Default-callconv caller must emit NotYetImplemented; \
+         diagnostics: {:#?}",
+        mir.diagnostics
     );
 }

--- a/hew-mir/tests/cancellation_scope.rs
+++ b/hew-mir/tests/cancellation_scope.rs
@@ -276,11 +276,12 @@ fn fork_nonunit_arg_bearing_callee_fails_closed() {
 }
 
 #[test]
-fn fork_value_task_statement_await_fails_closed() {
-    // Value resolution (`await x` for Task<i64>) has no result-propagation
-    // substrate yet — the task wrapper discards the callee return. The MIR
-    // await site must refuse (NotYetImplemented) rather than silently
-    // joining and dropping the value on the floor as if it were unit.
+fn fork_value_task_await_lowers_through_result_channel() {
+    // A no-arg value-returning `fork x = compute()` awaited from an
+    // execution-context handler lowers through the value-task result channel:
+    // the task body publishes its `i64` via `hew_task_set_result`, the await
+    // resume edge reads it via `hew_task_get_result`. The MIR await site must
+    // NOT refuse (no NotYetImplemented) — value resolution is wired.
     let source = r"
         fn compute() -> i64 {
             42
@@ -290,7 +291,8 @@ fn fork_value_task_statement_await_fails_closed() {
             receive fn drive() {
                 scope {
                     fork x = compute();
-                    await x;
+                    let v = await x;
+                    let _ = v;
                 };
             }
         }
@@ -303,11 +305,30 @@ fn fork_value_task_statement_await_fails_closed() {
     ";
     let mir = lower_clean_to_mir(source);
     assert!(
-        mir.diagnostics.iter().any(|d| d
+        !mir.diagnostics.iter().any(|d| d
             .note
             .contains("await lowering currently supports unit tasks only")),
-        "value-task await must fail closed at the MIR await site; diagnostics: {:#?}",
+        "value-task await must lower cleanly through the result channel; diagnostics: {:#?}",
         mir.diagnostics
+    );
+    // And the carrier must actually be emitted (no silent drop): a
+    // SuspendingTaskAwait terminator with a result_dest appears in the handler.
+    let has_value_carrier = mir
+        .raw_mir
+        .iter()
+        .flat_map(|func| &func.blocks)
+        .any(|block| {
+            matches!(
+                &block.terminator,
+                hew_mir::Terminator::SuspendingTaskAwait {
+                    result_dest: Some(_),
+                    ..
+                }
+            )
+        });
+    assert!(
+        has_value_carrier,
+        "value-task await must emit a SuspendingTaskAwait carrier carrying a result_dest"
     );
 }
 

--- a/hew-types/src/runtime_call.rs
+++ b/hew-types/src/runtime_call.rs
@@ -436,6 +436,7 @@ pub enum RuntimeCallFamily {
     TaskScopeSetCurrent,
     TaskScopeSpawn,
     TaskSetEnv,
+    TaskSetResult,
     TaskSpawnThread,
 
     // --- Vec<T> ------------------------------------------------------------
@@ -655,6 +656,7 @@ impl RuntimeCallFamily {
             Self::TaskScopeSetCurrent => "hew_task_scope_set_current",
             Self::TaskScopeSpawn => "hew_task_scope_spawn",
             Self::TaskSetEnv => "hew_task_set_env",
+            Self::TaskSetResult => "hew_task_set_result",
             Self::TaskSpawnThread => "hew_task_spawn_thread",
             // Vec
             Self::VecGet(VecGetElem::Bool) => "hew_vec_get_bool",
@@ -888,6 +890,7 @@ impl RuntimeCallFamily {
             "hew_task_scope_set_current" => Self::TaskScopeSetCurrent,
             "hew_task_scope_spawn" => Self::TaskScopeSpawn,
             "hew_task_set_env" => Self::TaskSetEnv,
+            "hew_task_set_result" => Self::TaskSetResult,
             "hew_task_spawn_thread" => Self::TaskSpawnThread,
             // Vec
             "hew_vec_get_bool" => Self::VecGet(VecGetElem::Bool),
@@ -1116,6 +1119,7 @@ impl RuntimeCallFamily {
             | F::TaskScopeSetCurrent
             | F::TaskScopeSpawn
             | F::TaskSetEnv
+            | F::TaskSetResult
             | F::TaskSpawnThread
             | F::VecGet(_)
             | F::VecLen

--- a/hew-types/tests/checked_mir_corpus_coverage.rs
+++ b/hew-types/tests/checked_mir_corpus_coverage.rs
@@ -81,6 +81,7 @@ const EXPECTED_UNCOVERED: &[&str] = &[
     "hew_task_get_result",
     "hew_task_scope_cancel_after_ns",
     "hew_task_set_env",
+    "hew_task_set_result",
     "hew_task_spawn_thread",
     "hew_vtable_dispatch_panic_on_oob",
     // -- Compiler-internal name: explicit user spelling rejected

--- a/hew-wasm/src/lib.rs
+++ b/hew-wasm/src/lib.rs
@@ -669,7 +669,6 @@ fn hir_kind_str(kind: &hew_hir::HirDiagnosticKind) -> &'static str {
         K::SpawnedClosureNonSendCapture { .. } => "SpawnedClosureNonSendCapture",
         K::ForkBlockBodyUnsupported { .. } => "ForkBlockBodyUnsupported",
         K::DeadlineBodyUnsupported { .. } => "DeadlineBodyUnsupported",
-        K::AwaitTaskResultUnsupported { .. } => "AwaitTaskResultUnsupported",
         K::SupervisorPoolChildAccessorUnsupported { .. } => {
             "SupervisorPoolChildAccessorUnsupported"
         }

--- a/tests/hew/actor_value_task_await_test.hew
+++ b/tests/hew/actor_value_task_await_test.hew
@@ -1,0 +1,132 @@
+//! Awaiting a VALUE-returning child task inside an actor handler binds the
+//! child's `T` on the resume edge and suspends the coroutine instead of
+//! blocking the worker on a condvar.
+//!
+//! The unit-task await reroute (a `Task<()>` "wait until Done" with nothing to
+//! bind) landed earlier. This fixture covers the value channel: a child task
+//! computes a `T != ()`, publishes it through `hew_task_set_result` on body
+//! completion, and the awaiting handler reads it back through
+//! `hew_task_get_result` on the resume edge, binding `let x = await t`.
+//!
+//! The assertions pin EXACT bound values across three element-ABI classes:
+//! - `i64` — a BitCopy scalar (the result buffer holds a true value copy);
+//! - `string` — a CowValue managed handle (the buffer holds the handle bytes,
+//!   moved out into the binding exactly once);
+//! - a record of scalars + a string — a managed aggregate (mixed field ABI).
+//!
+//! A wrong result-copy width, a mis-routed resume edge, a double-resume, or a
+//! double-free of a managed result would corrupt the exact value or abort under
+//! the sanitizer — not merely fail a `> 0` smoke check.
+
+import std::testing;
+
+record Pair {
+    n: i64,
+    label: string
+}
+
+fn compute_i64() -> i64 {
+    return 42;
+}
+
+fn compute_string() -> string {
+    return "forty-two";
+}
+
+fn compute_pair() -> Pair {
+    return Pair { n: 7, label: "seven" };
+}
+
+actor ValueWorker {
+    var acc: i64 = 0;
+
+    // Bind a scalar result. The exact value 42 proves the result channel
+    // published the body's return and the resume edge bound it.
+    receive fn run_i64() -> i64 {
+        var out: i64 = 0;
+        scope {
+            fork t = compute_i64();
+            let x = await t;
+            out = x;
+        };
+        acc = acc + out;
+        return acc;
+    }
+
+    // Bind a managed string result. Returning the bound string proves the
+    // CowValue handle was moved out of the result buffer exactly once.
+    receive fn run_string() -> string {
+        var out: string = "";
+        scope {
+            fork t = compute_string();
+            let s = await t;
+            out = s;
+        };
+        return out;
+    }
+
+    // Bind a record result (mixed scalar + managed field). The two reads prove
+    // the aggregate copied at the full element width and the string field
+    // survived the move into the binding.
+    receive fn run_pair() -> i64 {
+        var n: i64 = 0;
+        scope {
+            fork t = compute_pair();
+            let p = await t;
+            n = p.n;
+        };
+        return n;
+    }
+
+    // Two value awaits in one frame: the accumulated exact value proves both
+    // resumed in order through one persistent coroutine frame and neither lost
+    // its bound result.
+    receive fn run_twice() -> i64 {
+        var sum: i64 = 0;
+        scope {
+            fork a = compute_i64();
+            let x = await a;
+            sum = sum + x;
+            fork b = compute_i64();
+            let y = await b;
+            sum = sum + y;
+        };
+        return sum;
+    }
+}
+
+#[test]
+fn value_task_await_binds_i64_result() {
+    let w = spawn ValueWorker(acc: 0);
+    match await w.run_i64() {
+        Ok(n) => testing.assert_eq(n, 42),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn value_task_await_binds_string_result() {
+    let w = spawn ValueWorker(acc: 0);
+    match await w.run_string() {
+        Ok(s) => testing.assert_eq_str(s, "forty-two"),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn value_task_await_binds_record_result() {
+    let w = spawn ValueWorker(acc: 0);
+    match await w.run_pair() {
+        Ok(n) => testing.assert_eq(n, 7),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn two_value_awaits_in_one_handler_resume_in_order() {
+    let w = spawn ValueWorker(acc: 0);
+    match await w.run_twice() {
+        Ok(n) => testing.assert_eq(n, 84),
+        Err(_) => testing.assert_true(false),
+    }
+}


### PR DESCRIPTION
## Summary

`let x = await t` for a value-returning child task now compiles and runs. Previously, any `await` expression appearing in a `let` binding for a `Task<T>` where `T != ()` was rejected at the HIR boundary with a hard NYI diagnostic. The task's return value goes through a result channel: the child body stores it via `hew_task_set_result` on completion (drop-exactly-once, `sizeof(T)` bytes deep-copied into a malloc buffer), and the awaiting handler reads it back via `hew_task_get_result` on the resume edge, binding the value exactly once into the let target. A null-guard on the bind edge handles the cancelling-await case where the result buffer was never published. The Default-callconv path correctly refuses value-task await (a value `Task<T>` cannot be constructed in a non-execution-context body, so this is the correct fail-closed posture).

The change works across all three element-ABI classes: `i64` (BitCopy scalar — the buffer holds the value directly), `string` (CowValue managed handle — the buffer holds the handle bytes, moved out exactly once), and a mixed record of scalars and a string (managed aggregate). The new `.hew` fixture pins exact bound values for each class; a wrong result-copy width, a mis-routed resume edge, a double-resume, or a double-free of a managed handle would corrupt the exact value rather than merely failing a smoke check.

## Verification

- `cargo nextest run -p hew-hir --profile lane`: 480/480 passed
- `cargo nextest run -p hew-mir --profile lane`: 725/725 passed
- `cargo nextest run -p hew-codegen-rs --profile lane`: 441/441 passed (1 leaky)
- `cargo nextest run -p hew-cli --test await_e2e`: 14/14 passed
- `make test-hew-ratchet` (isolated): PASSED — 2 expected NYI (deadline body tests), `actor_value_task_await_test` passes across all four cases (i64=42, string="forty-two", record={n:7,label:"seven"}, two-await=84)
- `hir::task_gates::unit_task_await_in_let_rejected`: HIR rejects `let x = await t` when `t: Task<()>` — position discipline preserved
- `mir::cancellation_scope::value_task_await_in_default_callconv_caller_fails_closed`: MIR refuses value-task await from a Default-callconv caller
- Preflight: ready-to-push

## Out of scope

- Argument-bearing value-spawn (`fork compute(arg)`) — still NYI; the no-arg spawn restriction is unchanged.
- Generic free-function spawn — still NYI.
- Cancelling-await surface (`scope … after(d)` preempting an in-flight value-await) — the null-guard is in place and documented; the surface lands in a later pass.
