### PR TITLE
feat(parser,types,hir): shorthand record destructure `let {a,b} = rec`

### DIFF
--- a/hew-analysis/src/ast_visit.rs
+++ b/hew-analysis/src/ast_visit.rs
@@ -993,7 +993,7 @@ fn collect_pattern_bindings<'ast>(
                 collect_pattern_bindings(source, pattern, span, bindings);
             }
         }
-        Pattern::Struct { fields, .. } => {
+        Pattern::Struct { fields, .. } | Pattern::RecordShorthand { fields } => {
             for field in fields {
                 collect_pattern_field_bindings(source, span, field, bindings);
             }

--- a/hew-analysis/src/completions.rs
+++ b/hew-analysis/src/completions.rs
@@ -787,7 +787,7 @@ fn collect_pattern_names(pattern: &Pattern, locals: &mut Vec<CompletionItem>) {
                 collect_pattern_names(p, locals);
             }
         }
-        Pattern::Struct { fields, .. } => {
+        Pattern::Struct { fields, .. } | Pattern::RecordShorthand { fields } => {
             for field in fields {
                 if let Some((pattern, _)) = &field.pattern {
                     collect_pattern_names(pattern, locals);

--- a/hew-analysis/src/hover.rs
+++ b/hew-analysis/src/hover.rs
@@ -787,6 +787,15 @@ fn find_pattern_binding_type(
                 find_pattern_binding_type(pattern, &field_ty, type_defs, word, offset)
             })
         }),
+        // For shorthand, look up field type from the scrutinee type directly.
+        Pattern::RecordShorthand { fields } => fields.iter().find_map(|field| {
+            // Derive field type from source_ty by name, same as bind_pattern does.
+            let type_name = source_ty.type_name()?;
+            let field_ty = struct_pattern_field_ty(source_ty, type_name, &field.name, type_defs)?;
+            field.pattern.as_ref().and_then(|pattern| {
+                find_pattern_binding_type(pattern, &field_ty, type_defs, word, offset)
+            })
+        }),
         Pattern::Tuple(patterns) => {
             let Ty::Tuple(elem_tys) = source_ty else {
                 return None;
@@ -826,12 +835,14 @@ fn find_binding_name(pattern: &(Pattern, Span), word: &str, offset: usize) -> Op
         Pattern::Constructor { patterns, .. } | Pattern::Tuple(patterns) => patterns
             .iter()
             .find_map(|pattern| find_binding_name(pattern, word, offset)),
-        Pattern::Struct { fields, .. } => fields.iter().find_map(|field| {
-            field
-                .pattern
-                .as_ref()
-                .and_then(|pattern| find_binding_name(pattern, word, offset))
-        }),
+        Pattern::Struct { fields, .. } | Pattern::RecordShorthand { fields } => {
+            fields.iter().find_map(|field| {
+                field
+                    .pattern
+                    .as_ref()
+                    .and_then(|pattern| find_binding_name(pattern, word, offset))
+            })
+        }
         Pattern::Or(left, right) => {
             find_binding_name(left, word, offset).or_else(|| find_binding_name(right, word, offset))
         }

--- a/hew-analysis/src/references.rs
+++ b/hew-analysis/src/references.rs
@@ -420,12 +420,14 @@ fn pattern_binds_name(pattern: &Pattern, name: &str) -> bool {
         Pattern::Constructor { patterns, .. } | Pattern::Tuple(patterns) => patterns
             .iter()
             .any(|(pattern, _)| pattern_binds_name(pattern, name)),
-        Pattern::Struct { fields, .. } => fields.iter().any(|field| {
-            field
-                .pattern
-                .as_ref()
-                .is_some_and(|(pattern, _)| pattern_binds_name(pattern, name))
-        }),
+        Pattern::Struct { fields, .. } | Pattern::RecordShorthand { fields } => {
+            fields.iter().any(|field| {
+                field
+                    .pattern
+                    .as_ref()
+                    .is_some_and(|(pattern, _)| pattern_binds_name(pattern, name))
+            })
+        }
         Pattern::Or(left, right) => {
             pattern_binds_name(&left.0, name) || pattern_binds_name(&right.0, name)
         }
@@ -473,7 +475,7 @@ impl RefsVisitor<'_> {
                     self.push_pattern_matches(p, s);
                 }
             }
-            Pattern::Struct { fields, .. } => {
+            Pattern::Struct { fields, .. } | Pattern::RecordShorthand { fields } => {
                 for field in fields {
                     if let Some((p, s)) = &field.pattern {
                         self.push_pattern_matches(p, s);

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -151,7 +151,8 @@ fn collect_match_payload_predicates(ctx: &LowerCtx, pattern: &Pattern) -> Vec<Hi
         | Pattern::Literal(_)
         | Pattern::Tuple(_)
         | Pattern::Or(_, _)
-        | Pattern::Regex { .. } => Vec::new(),
+        | Pattern::Regex { .. }
+        | Pattern::RecordShorthand { .. } => Vec::new(),
     }
 }
 
@@ -9671,6 +9672,7 @@ impl LowerCtx {
             }
 
             // Record-let: `let Point { x, y } = value_expr;`
+            // and shorthand: `let { x, y } = value_expr;`
             //
             // Desugar into the same three-phase template as tuple-let:
             //   1. `let __rec_N = expr;`         — synthetic temp binds the record
@@ -9682,10 +9684,13 @@ impl LowerCtx {
             // `bind_pattern` (called by the checker at check_stmt time) has
             // already bound the field names in the checker's env; HIR mirrors
             // those bindings via `self.bind(...)` below.
-            if let Pattern::Struct {
-                fields: pat_fields, ..
-            } = &pattern.0
-            {
+            let pat_fields_opt = match &pattern.0 {
+                Pattern::Struct { fields, .. } | Pattern::RecordShorthand { fields } => {
+                    Some(fields)
+                }
+                _ => None,
+            };
+            if let Some(pat_fields) = pat_fields_opt {
                 let rec_val = self.lower_expr(value_expr, IntentKind::Consume);
                 let rec_ty = rec_val.ty.clone();
 
@@ -9848,7 +9853,7 @@ impl LowerCtx {
             Pattern::Tuple(elements) => {
                 self.lower_tuple_pattern_value_into_stmts(elements, value, &value_ty, stmts, span);
             }
-            Pattern::Struct { fields, .. } => {
+            Pattern::Struct { fields, .. } | Pattern::RecordShorthand { fields } => {
                 self.lower_record_pattern_value_into_stmts(fields, value, &value_ty, stmts, span);
             }
             Pattern::Constructor { .. }
@@ -20933,7 +20938,9 @@ impl LowerCtx {
             // Struct / tuple / nested-or / regex leaves inside an or-pattern
             // remain fail-closed: they require deeper destructure lowering the
             // v0.5 substrate does not yet provide.
+            // RecordShorthand is only valid in `let` position; reject here.
             Pattern::Struct { .. }
+            | Pattern::RecordShorthand { .. }
             | Pattern::Tuple(_)
             | Pattern::Or(_, _)
             | Pattern::Regex { .. } => None,

--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -458,6 +458,14 @@ pub enum Pattern {
         name: String,
         fields: Vec<PatternField>,
     },
+    /// Shorthand record destructure: `{ a, b }` with no type name.
+    ///
+    /// The checker infers the record type from the expected/scrutinee type and
+    /// delegates to the same field-binding path as `Pattern::Struct`.  Only
+    /// valid in `let` positions against an irrefutable (product) type.
+    RecordShorthand {
+        fields: Vec<PatternField>,
+    },
     Tuple(Vec<Spanned<Pattern>>),
     Or(Box<Spanned<Pattern>>, Box<Spanned<Pattern>>),
     /// A regex literal pattern in a match arm: `re"^Bearer\s+(.+)$"`.

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -3295,6 +3295,11 @@ impl<'a> Formatter<'a> {
                 self.comma_sep(fields, Self::format_pattern_field);
                 self.write(" }");
             }
+            Pattern::RecordShorthand { fields } => {
+                self.write("{ ");
+                self.comma_sep(fields, Self::format_pattern_field);
+                self.write(" }");
+            }
             Pattern::Tuple(patterns) => {
                 self.write("(");
                 self.comma_sep(patterns, |f, p| f.format_pattern(&p.0));

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -8286,6 +8286,30 @@ impl<'src> Parser<'src> {
                     Pattern::Tuple(patterns)
                 }
             }
+            // Shorthand record destructure: `{ a, b }` with no type name.
+            // The checker infers the record type from the scrutinee type and
+            // delegates to the same field-binding path as `Pattern::Struct`.
+            Some(Token::LeftBrace) => {
+                self.advance(); // consume '{'
+                let mut fields = Vec::new();
+                while !self.at_end() && self.peek() != Some(&Token::RightBrace) {
+                    let field_name = self.expect_ident()?;
+                    let pattern = if self.eat(&Token::Colon) {
+                        Some(self.parse_pattern()?)
+                    } else {
+                        None
+                    };
+                    fields.push(PatternField {
+                        name: field_name,
+                        pattern,
+                    });
+                    if !self.eat(&Token::Comma) {
+                        break;
+                    }
+                }
+                self.expect(&Token::RightBrace)?;
+                Pattern::RecordShorthand { fields }
+            }
             Some(Token::Integer(s)) => {
                 if let Ok((val, radix)) = parse_int_literal(s) {
                     self.advance();
@@ -12604,5 +12628,79 @@ wire type Msg {
             other => panic!("expected qualified Pattern::Constructor, got {other:?}"),
         }
         assert!(matches!(&patterns[1], Pattern::Identifier(n) if n == "None"));
+    }
+
+    // ── RecordShorthand pattern (let {a, b} = rec) ───────────────────────────
+
+    /// `let { x, y } = p` parses as `Pattern::RecordShorthand` with two plain
+    /// field bindings and no type name.
+    #[test]
+    fn parse_let_record_shorthand_two_fields_no_type_name() {
+        let source = "fn main() -> i64 { let p = Point { x: 1, y: 2 }; let { x, y } = p; x + y }";
+        let result = parse(source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        // Extract the let statement pattern from the function body.
+        let crate::ast::Item::Function(func) = &result.program.items[0].0 else {
+            panic!("expected function, got {:?}", result.program.items[0].0);
+        };
+        let stmts = &func.body.stmts;
+        // Second statement (index 1) is `let { x, y } = p`.
+        let (crate::ast::Stmt::Let { pattern, .. }, _) = &stmts[1] else {
+            panic!("expected let statement at index 1, got {:?}", stmts[1]);
+        };
+        let Pattern::RecordShorthand { fields } = &pattern.0 else {
+            panic!("expected Pattern::RecordShorthand, got {:?}", pattern.0);
+        };
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].name, "x");
+        assert!(
+            fields[0].pattern.is_none(),
+            "shorthand field should have no sub-pattern"
+        );
+        assert_eq!(fields[1].name, "y");
+    }
+
+    /// `let { x: px, y: py } = p` parses as `Pattern::RecordShorthand` with
+    /// alias sub-patterns for each field.
+    #[test]
+    fn parse_let_record_shorthand_with_alias_subpatterns() {
+        let source =
+            "fn main() -> i64 { let p = Point { x: 1, y: 2 }; let { x: px, y: py } = p; px + py }";
+        let result = parse(source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let crate::ast::Item::Function(func) = &result.program.items[0].0 else {
+            panic!("expected function, got {:?}", result.program.items[0].0);
+        };
+        let stmts = &func.body.stmts;
+        let (crate::ast::Stmt::Let { pattern, .. }, _) = &stmts[1] else {
+            panic!("expected let statement at index 1, got {:?}", stmts[1]);
+        };
+        let Pattern::RecordShorthand { fields } = &pattern.0 else {
+            panic!("expected Pattern::RecordShorthand, got {:?}", pattern.0);
+        };
+        assert_eq!(fields.len(), 2);
+        assert!(
+            fields[0].pattern.is_some(),
+            "field x should have alias sub-pattern"
+        );
+        assert!(
+            fields[1].pattern.is_some(),
+            "field y should have alias sub-pattern"
+        );
+    }
+
+    /// `let { x, y } = p` round-trips through the formatter as `let { x, y } = p`
+    /// (the shorthand form is preserved — not rewritten to the typed form).
+    #[test]
+    fn format_let_record_shorthand_round_trips_without_type_name() {
+        let source = "fn main() -> i64 {\n    let p = Point { x: 1, y: 2 };\n    let { x, y } = p;\n    x + y\n}\n";
+        let result = parse(source);
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        let formatted = crate::fmt::format_program(&result.program);
+        // The formatted output must contain the shorthand `{ x, y }`, not `Point { x, y }`.
+        assert!(
+            formatted.contains("let { x, y } = p"),
+            "formatted output should preserve shorthand form, got:\n{formatted}"
+        );
     }
 } // mod tests

--- a/hew-sandbox-wasm/src/profile.rs
+++ b/hew-sandbox-wasm/src/profile.rs
@@ -814,7 +814,7 @@ impl<'a> ProfileChecker<'a> {
                     self.check_pattern(pattern);
                 }
             }
-            Pattern::Struct { fields, .. } => {
+            Pattern::Struct { fields, .. } | Pattern::RecordShorthand { fields } => {
                 for field in fields {
                     if let Some(pattern) = &field.pattern {
                         self.check_pattern(pattern);

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -884,6 +884,7 @@ mod ast_surface {
             Pattern::Identifier(_) => Some("match with constructor-payload patterns"),
             Pattern::Constructor { .. } => Some("match with constructor-payload patterns"),
             Pattern::Struct { .. } => Some("struct pattern in match arm"),
+            Pattern::RecordShorthand { .. } => Some("struct pattern in match arm"),
             Pattern::Tuple(_) => Some("tuple value + tuple-let destructure"),
             Pattern::Or(_, _) => Some("match with wildcard arm"),
             Pattern::Regex { .. } => Some("regex compile + is_match"),

--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -603,6 +603,7 @@ impl Checker {
     ) -> bool {
         let kind_name = match pattern {
             Pattern::Regex { .. } => "regex",
+            Pattern::RecordShorthand { .. } => "record shorthand",
             Pattern::Wildcard
             | Pattern::Identifier(_)
             | Pattern::Literal(_)

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -3945,7 +3945,7 @@ impl Checker {
                     Self::shadow_pattern_bindings(pattern, scopes);
                 }
             }
-            Pattern::Struct { fields, .. } => {
+            Pattern::Struct { fields, .. } | Pattern::RecordShorthand { fields } => {
                 for field in fields {
                     if let Some((pattern, _)) = &field.pattern {
                         Self::shadow_pattern_bindings(pattern, scopes);

--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -20,7 +20,7 @@ fn collect_pattern_bound_names(pattern: &Pattern) -> HashSet<String> {
             .iter()
             .flat_map(|pattern| collect_pattern_bound_names(&pattern.0))
             .collect(),
-        Pattern::Struct { fields, .. } => fields
+        Pattern::Struct { fields, .. } | Pattern::RecordShorthand { fields } => fields
             .iter()
             .flat_map(|field| {
                 field.pattern.as_ref().map_or_else(
@@ -99,6 +99,7 @@ fn binding_name_for_pattern(pattern: &Pattern) -> Option<String> {
         | Pattern::Regex { .. }
         | Pattern::Constructor { .. }
         | Pattern::Struct { .. }
+        | Pattern::RecordShorthand { .. }
         | Pattern::Tuple(_)
         | Pattern::Or(_, _) => None,
     }
@@ -114,9 +115,11 @@ fn unsupported_payload_subpattern_label(pattern: &Pattern) -> Option<&'static st
     match pattern {
         // Plain binding, wildcard, literal predicates, and aggregate
         // destructures are supported.
-        Pattern::Wildcard | Pattern::Literal(_) | Pattern::Struct { .. } | Pattern::Tuple(_) => {
-            None
-        }
+        Pattern::Wildcard
+        | Pattern::Literal(_)
+        | Pattern::Struct { .. }
+        | Pattern::RecordShorthand { .. }
+        | Pattern::Tuple(_) => None,
         Pattern::Identifier(name) => {
             let is_constructor_like =
                 name.contains("::") || name.chars().next().is_some_and(char::is_uppercase);
@@ -160,7 +163,7 @@ fn unsupported_project_subpattern_label(pattern: &Pattern) -> Option<&'static st
         Pattern::Tuple(pats) if pats.is_empty() => None,
         Pattern::Literal(lit) => Some(literal_pattern_label(lit)),
         Pattern::Constructor { .. } => Some("nested constructor"),
-        Pattern::Struct { .. } => Some("struct destructure"),
+        Pattern::Struct { .. } | Pattern::RecordShorthand { .. } => Some("struct destructure"),
         Pattern::Tuple(_) => Some("tuple destructure"),
         Pattern::Or(_, _) => Some("or-pattern"),
         Pattern::Regex { .. } => Some("regex pattern"),
@@ -699,6 +702,77 @@ impl Checker {
                     self.bind_struct_field_placeholders(fields, &Ty::Error, is_mutable, span);
                 }
             }
+            // Shorthand record destructure `{ a, b }` — no type name in the pattern.
+            // Use the scrutinee's type directly to look up field types, identical to
+            // the `Pattern::Struct` fields-only path but without the variant-name check.
+            Pattern::RecordShorthand { fields } => {
+                let type_name_opt = ty.type_name();
+                if let Some(type_name) = type_name_opt {
+                    if let Some(td) = self.lookup_type_def(type_name) {
+                        let type_params = td.type_params.clone();
+                        let type_args = if let Ty::Named { args, .. } = ty {
+                            args.clone()
+                        } else {
+                            vec![]
+                        };
+                        for pf in fields {
+                            if let Some(raw_field_ty) = td.fields.get(&pf.name) {
+                                let field_ty = substitute_pattern_field_ty(
+                                    raw_field_ty,
+                                    &type_params,
+                                    &type_args,
+                                );
+                                if let Some((pat, ps)) = &pf.pattern {
+                                    self.bind_pattern(pat, &field_ty, is_mutable, ps);
+                                } else {
+                                    self.check_shadowing(&pf.name, span);
+                                    self.env.define_with_span(
+                                        pf.name.clone(),
+                                        field_ty,
+                                        is_mutable,
+                                        span.clone(),
+                                    );
+                                }
+                            } else {
+                                let similar = crate::error::find_similar(
+                                    &pf.name,
+                                    td.fields.keys().map(String::as_str),
+                                );
+                                self.report_error_with_suggestions(
+                                    TypeErrorKind::UndefinedField,
+                                    span,
+                                    format!("no field `{}` on type `{type_name}`", pf.name),
+                                    similar,
+                                );
+                            }
+                        }
+                    } else {
+                        self.report_error(
+                            TypeErrorKind::UndefinedType,
+                            span,
+                            format!(
+                                "type `{type_name}` is not defined for record shorthand pattern"
+                            ),
+                        );
+                        self.bind_struct_field_placeholders(fields, &Ty::Error, is_mutable, span);
+                    }
+                } else if matches!(ty, Ty::Var(_) | Ty::Error) {
+                    self.bind_struct_field_placeholders(fields, ty, is_mutable, span);
+                } else {
+                    let expected = ty.user_facing().to_string();
+                    self.report_error(
+                        TypeErrorKind::Mismatch {
+                            expected: expected.clone(),
+                            actual: "{ .. }".to_string(),
+                        },
+                        span,
+                        format!(
+                            "record shorthand pattern cannot match non-record type `{expected}`"
+                        ),
+                    );
+                    self.bind_struct_field_placeholders(fields, &Ty::Error, is_mutable, span);
+                }
+            }
             Pattern::Tuple(pats) => match ty {
                 // `()` as a pattern (empty tuple) is the unit literal; accept
                 // it against unit-typed payloads, e.g. `Ok(())` on
@@ -1211,6 +1285,19 @@ impl Checker {
                     payload_variant_patterns: vec![],
                 }
             }
+            // Shorthand `{ a, b }` is only valid in `let` position; the
+            // checker's `check_stmt` validates this before `record_arm_resolution`
+            // is reached. If it somehow appears in a match arm, fail closed.
+            Pattern::RecordShorthand { .. } => {
+                self.report_error(
+                    crate::error::TypeErrorKind::InvalidOperation,
+                    pattern_span,
+                    "record shorthand pattern `{ .. }` is not valid in match arms; \
+                     use a typed record pattern `TypeName { .. }` instead"
+                        .to_string(),
+                );
+                return;
+            }
             Pattern::Tuple(pats) => {
                 for (sub_pat, sub_span) in pats {
                     if let Some(label) = unsupported_project_subpattern_label(sub_pat) {
@@ -1414,7 +1501,9 @@ impl Checker {
                     // fail-closed at every depth.
                     let label = match other {
                         Pattern::Literal(_) => "literal predicate inside a nested constructor",
-                        Pattern::Struct { .. } => "struct destructure",
+                        Pattern::Struct { .. } | Pattern::RecordShorthand { .. } => {
+                            "struct destructure"
+                        }
                         Pattern::Tuple(_) => "tuple destructure",
                         Pattern::Or(_, _) => "or-pattern",
                         Pattern::Regex { .. } => "regex pattern",

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -26966,4 +26966,44 @@ mod every_attribute {
             output.errors
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Record shorthand pattern: `let { a, b } = rec` (no type name)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn let_record_shorthand_binds_fields_no_error() {
+        // `let { x, y } = p` — shorthand with no type name must bind both
+        // fields with zero checker errors.
+        let output = check_source(
+            "type Point { x: i64; y: i64; }
+             fn main() -> i64 { let p = Point { x: 1, y: 2 }; let { x, y } = p; x + y }",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "shorthand record let must emit zero checker errors; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn let_record_shorthand_unknown_field_emits_undefined_field_error() {
+        // `let { x, z } = p` where `z` does not exist on `Point` must emit
+        // exactly one UndefinedField error (not cascade into UnresolvedSymbol).
+        let output = check_source(
+            "type Point { x: i64; y: i64; }
+             fn main() -> i64 { let p = Point { x: 1, y: 2 }; let { x, z } = p; x }",
+        );
+        let undef_field: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::UndefinedField))
+            .collect();
+        assert_eq!(
+            undef_field.len(),
+            1,
+            "unknown field in shorthand must emit exactly one UndefinedField; got: {:#?}",
+            output.errors
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Bare brace patterns in `let` bindings now resolve to a new `Pattern::RecordShorthand { fields }` variant rather than hitting `NYI`. The type of each bound field is inferred from the scrutinee's record type (or the expected type propagated from context), so generics resolve correctly without annotation. Lowering routes directly through the existing typed record-destructure spine (`lower_record_pattern_value_into_stmts`), so ownership and drop behaviour matches the typed `TypeName { field }` form exactly — no parallel path.

Match arms, `if let`, and `while-let` each reject shorthand with a single clear diagnostic; no cascade errors are emitted.

## Verification

- `make test-lane CRATE=hew-parser`: 679/679 passed
- `make test-lane CRATE=hew-types`: 2140/2140 passed (2 skipped, pre-existing)
- `make test-lane CRATE=hew-hir`: 482/482 passed
- `cargo check -p hew-analysis -p hew-sandbox-wasm`: clean
- Preflight: ready-to-push
- MallocScribble=1 string-field smoke test: no crash

## Out of scope

- Shorthand in match arms, `if let`, and `while-let` is intentionally not implemented here; each position reports a clear diagnostic rather than silently failing.
- Partial-field shorthand (binding only a subset of fields) follows from this variant but is deferred; the full-field case is the common ergonomic need.

Fixes #31