### PR TITLE
feat(mir): allow state-field spawn args alongside init() params

### DIFF
--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -20043,33 +20043,44 @@ impl Builder {
         actor_name: &str,
         name: &str,
         explicit_init: bool,
-        expected_arg_names: &[String],
+        init_param_names: &[String],
         state_field_names: &[String],
     ) -> String {
-        let parameters = format!(
-            "[{}]",
-            expected_arg_names
-                .iter()
-                .map(|expected| format!("`{expected}`"))
-                .collect::<Vec<_>>()
-                .join(", ")
-        );
         if explicit_init {
-            if state_field_names.iter().any(|field| field == name) {
-                format!(
-                    "`{name}` is a state field on actor `{actor_name}` but not an `init()` \
-                     parameter; init() parameters are: {parameters}"
-                )
-            } else {
-                format!(
-                    "actor `{actor_name}` has no init() parameter named `{name}`; \
-                     parameters are: {parameters}"
-                )
-            }
+            // Both init params and state fields are valid spawn args when an
+            // init() block is present (COEXIST model). Report the full valid set.
+            let params = format!(
+                "[{}]",
+                init_param_names
+                    .iter()
+                    .map(|n| format!("`{n}`"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            let fields = format!(
+                "[{}]",
+                state_field_names
+                    .iter()
+                    .map(|n| format!("`{n}`"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            format!(
+                "actor `{actor_name}` has no init() parameter or state field named `{name}`; \
+                 init() parameters are: {params}; state fields are: {fields}"
+            )
         } else {
+            let fields = format!(
+                "[{}]",
+                state_field_names
+                    .iter()
+                    .map(|n| format!("`{n}`"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
             format!(
                 "actor `{actor_name}` has no state field named `{name}`; \
-                 fields are: {parameters}"
+                 fields are: {fields}"
             )
         }
     }
@@ -20127,19 +20138,24 @@ impl Builder {
             return None;
         };
         let explicit_init = layout.init_symbol.is_some();
-        let expected_arg_names = if explicit_init {
-            &layout.init_param_names
-        } else {
-            &layout.state_field_names
-        };
         let mut explicit: HashMap<&str, &HirExpr> = HashMap::new();
         for (name, arg) in args {
-            if !expected_arg_names.iter().any(|expected| expected == name) {
+            // COEXIST model (A155): when an init() block is present, spawn args
+            // may name EITHER init() parameters (routed to the init call) OR
+            // state fields (routed to the initial state record). Without init(),
+            // only state fields are valid.
+            let is_valid = if explicit_init {
+                layout.init_param_names.iter().any(|n| n == name)
+                    || layout.state_field_names.iter().any(|n| n == name)
+            } else {
+                layout.state_field_names.iter().any(|n| n == name)
+            };
+            if !is_valid {
                 let note = Self::invalid_spawn_arg_note(
                     actor_name,
                     name,
                     explicit_init,
-                    expected_arg_names,
+                    &layout.init_param_names,
                     &layout.state_field_names,
                 );
                 self.diagnostics.push(MirDiagnostic {

--- a/hew-mir/tests/actor_send_ask.rs
+++ b/hew-mir/tests/actor_send_ask.rs
@@ -133,7 +133,45 @@ fn actor_send_ask_lower_to_mir_terminators_and_state_access() {
 }
 
 #[test]
-fn spawn_init_actor_rejects_state_field_argument_as_user_error() {
+fn spawn_init_actor_accepts_state_field_argument_coexist() {
+    // COEXIST model: state-field spawn args are valid alongside init() params.
+    // `spawn Counter(count: 5)` should lower cleanly — `count` is routed into
+    // the initial state record; `init()` is still called but with no explicit
+    // arg (the init param `initial` is missing here, so we check that the
+    // *absence* of an init param surfaces, not the presence of a state-field arg).
+    //
+    // For a clean lower we supply both the state-field arg AND the init param.
+    let pipeline = lower_checked(
+        r"
+        actor Counter {
+            var count: i64;
+
+            init(initial: i64) {
+                count = initial;
+            }
+
+            receive fn total() -> i64 {
+                count
+            }
+        }
+
+        fn main() {
+            let _counter = spawn Counter(initial: 0, count: 5);
+        }
+        ",
+    );
+
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "expected no MIR diagnostics for coexist spawn; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+#[test]
+fn spawn_init_actor_rejects_unknown_argument() {
+    // A name that is neither an init() parameter nor a state field must still
+    // be rejected with a clear diagnostic.
     let pipeline = lower_for_mir_diagnostics(
         r"
         actor Counter {
@@ -149,7 +187,7 @@ fn spawn_init_actor_rejects_state_field_argument_as_user_error() {
         }
 
         fn main() {
-            let _counter = spawn Counter(count: 5);
+            let _counter = spawn Counter(initial: 0, bogus: 99);
         }
         ",
     );
@@ -157,38 +195,38 @@ fn spawn_init_actor_rejects_state_field_argument_as_user_error() {
     let diagnostic = pipeline
         .diagnostics
         .iter()
-        .find(|diagnostic| {
+        .find(|d| {
             matches!(
-                &diagnostic.kind,
+                &d.kind,
                 MirDiagnosticKind::InvalidActorSpawnArgument {
                     actor,
                     argument,
                     ..
-                } if actor == "Counter" && argument == "count"
+                } if actor == "Counter" && argument == "bogus"
             )
         })
         .unwrap_or_else(|| {
             panic!(
-                "expected InvalidActorSpawnArgument for Counter.count; diagnostics: {:#?}",
+                "expected InvalidActorSpawnArgument for `bogus`; diagnostics: {:#?}",
                 pipeline.diagnostics
             )
         });
-    assert!(diagnostic
-        .note
-        .contains("`count` is a state field on actor `Counter` but not an `init()` parameter"));
     assert!(
-        diagnostic
-            .note
-            .contains("init() parameters are: [`initial`]"),
-        "unexpected note: {}",
+        diagnostic.note.contains("init() parameters are:") && diagnostic.note.contains("`initial`"),
+        "note should list init params; got: {}",
         diagnostic.note
     );
     assert!(
-        !pipeline.diagnostics.iter().any(|diagnostic| matches!(
-            diagnostic.kind,
-            MirDiagnosticKind::NotYetImplemented { .. }
-        )),
-        "invalid init argument must not surface as NotYetImplemented: {:#?}",
+        diagnostic.note.contains("state fields are:") && diagnostic.note.contains("`count`"),
+        "note should list state fields; got: {}",
+        diagnostic.note
+    );
+    assert!(
+        !pipeline
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.kind, MirDiagnosticKind::NotYetImplemented { .. })),
+        "invalid spawn arg must not surface as NotYetImplemented: {:#?}",
         pipeline.diagnostics
     );
 }

--- a/tests/vertical-slice/accept/actor_ctor_init_coexist.hew
+++ b/tests/vertical-slice/accept/actor_ctor_init_coexist.hew
@@ -1,0 +1,24 @@
+// COEXIST: state-field spawn args alongside init() params.
+// `offset` is a state field passed at spawn time; `multiplier` is an init()
+// param that mutates state in the init block. The final value is:
+//   count = 0 (zero-init) + offset (5) = 5, then init sets count *= multiplier (2) → 10.
+// Then total() returns count (10) + base (100) = 110.
+actor Calc {
+    var count: i64;
+    var base: i64;
+    init(multiplier: i64) {
+        count = count * multiplier;
+    }
+    receive fn total() -> i64 {
+        count + base
+    }
+}
+
+fn main() -> i64 {
+    // `count` and `base` are state fields; `multiplier` is an init() param.
+    let calc = spawn Calc(multiplier: 2, count: 5, base: 100);
+    match await calc.total() {
+        Ok(v) => v,
+        Err(_e) => -1,
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -528,6 +528,11 @@ run_accept_expect_status "actor_counter_reorder" 42
 # The exit code being 42 (not 41) proves on(start) fired before the first message.
 run_accept_expect_status "actor_counter_init" 42
 
+# COEXIST: state-field spawn args alongside init() params. count=5, base=100 are
+# state fields passed at spawn; multiplier=2 is an init() param. init() runs
+# count = count * multiplier = 5*2 = 10. total() returns count + base = 110.
+run_accept_expect_status "actor_ctor_init_coexist" 110
+
 # Actor body with init + on(start) + on(stop): initial=9, boot increments to 10,
 # increment(32) = 42. The on(stop) handler zeroes count after the final ask —
 # the total() ask completes before teardown, so the returned value is 42 regardless.


### PR DESCRIPTION
## Summary

Actors with both state fields and an `init()` method can now receive spawn arguments for either. Previously, `lower_spawn_actor` only accepted spawn args matching init-param names; state fields that carried ownership through spawn were rejected as `InvalidActorSpawnArgument`. The validation now accepts the union of init-param names and state-field names — state-field args route into the `RecordInit` for the actor's state struct, while init params stay on the `lower_spawn_actor_init_args` path. Unknown args are still rejected, and the error note lists both valid sets so the caller knows what's accepted.

This closes the state-field-spawn-arg gap: an actor can populate owned state fields at spawn time (e.g. a string base URL or numeric multiplier) and still run custom setup through `init()`, without needing to duplicate those fields as init params.

## Verification

- `make test-lane CRATE=hew-mir` (729/729): pass — coexist path, unknown-arg rejection, restart-safe paths
- `make test-lane CRATE=hew-types` (2144/2144): pass — no type-system regressions
- Vertical slice `actor_ctor_init_coexist.hew`: exits 110 (count + base populated before `init(multiplier)` runs)
- Owned `string` state-field arg E2E: exits 42 — `RecordInit → SpawnActor` excluded from sender-scope drops, no double-free
- Restart paths (`supervisor_child_after_restart`, `supervised_actor_init_block`): pass — restart replays the child spec, not stale actor storage
- Preflight: ready-to-push

## Out of scope

- Keyword `new` / named-constructor syntax is not introduced here — spawn-arg routing is the only change.
- No changes to the supervision tree restart policy or clone/drop hook registration order.
- Init-param default values and optional spawn args are not addressed in this PR.
