### PR TITLE
fix(types): gate TypeVar::reset behind cfg(test), remove reset calls from tests

### DIFF
--- a/hew-analysis/src/hover.rs
+++ b/hew-analysis/src/hover.rs
@@ -2142,7 +2142,6 @@ mod tests {
     fn hover_expr_reports_resolved_ty_boundary_failure() {
         use hew_types::ty::TypeVar;
 
-        TypeVar::reset();
         let var = TypeVar::fresh();
         let rendered = render_expr_hover("value", &Ty::Var(var));
         let body = rendered.split("\n\n").next().unwrap();

--- a/hew-types/src/ty.rs
+++ b/hew-types/src/ty.rs
@@ -79,7 +79,13 @@ impl TypeVar {
         Self(NEXT_TYPE_VAR.fetch_add(1, Ordering::Relaxed))
     }
 
-    /// Reset the type variable counter (for testing).
+    /// Reset the type variable counter.
+    ///
+    /// Only available in test builds. Production code must never reset the
+    /// counter; doing so outside a single-threaded test context causes two
+    /// distinct inference variables to share the same ID (a silent
+    /// non-determinism source when nextest runs tests in parallel).
+    #[cfg(test)]
     pub fn reset() {
         NEXT_TYPE_VAR.store(0, Ordering::Relaxed);
     }
@@ -1767,7 +1773,6 @@ mod tests {
 
     #[test]
     fn test_contains_var() {
-        TypeVar::reset();
         let v = TypeVar::fresh();
         let ty = Ty::Tuple(vec![Ty::I32, Ty::Var(v)]);
         assert!(ty.contains_var(v));
@@ -1776,7 +1781,6 @@ mod tests {
 
     #[test]
     fn test_substitute() {
-        TypeVar::reset();
         let v = TypeVar::fresh();
         let ty = Ty::Tuple(vec![Ty::Var(v), Ty::I32]);
         let result = ty.substitute(v, &Ty::Bool);
@@ -1816,7 +1820,6 @@ mod tests {
     fn test_borrow_contains_var_recurses_through_pointee() {
         // Guards the type-inference-boundary invariant: an unresolved `Ty::Var`
         // inside `&T` must be detected by the occurs/contains check, not skipped.
-        TypeVar::reset();
         let v = TypeVar::fresh();
         let borrow = Ty::Borrow {
             pointee: Box::new(Ty::Var(v)),
@@ -1854,7 +1857,6 @@ mod tests {
     fn test_borrow_substitute_recurses_through_nested_pointee() {
         // `map_children` (via `substitute`) must recurse through a borrow into a
         // nested generic pointee: `&Vec<$v>` with `$v := i32` becomes `&Vec<i32>`.
-        TypeVar::reset();
         let v = TypeVar::fresh();
         let borrow = Ty::Borrow {
             pointee: Box::new(Ty::Named {
@@ -1880,7 +1882,6 @@ mod tests {
 
     #[test]
     fn test_has_inference_var() {
-        TypeVar::reset();
         let inferred = Ty::Var(TypeVar::fresh());
         let ty = Ty::Function {
             params: vec![Ty::I32],
@@ -2077,7 +2078,6 @@ mod tests {
 
     #[test]
     fn test_substitute_nested() {
-        TypeVar::reset();
         let v = TypeVar::fresh();
         let ty = Ty::Named {
             builtin: None,
@@ -2097,7 +2097,6 @@ mod tests {
 
     #[test]
     fn test_substitute_no_match() {
-        TypeVar::reset();
         let v1 = TypeVar::fresh();
         let v2 = TypeVar::fresh();
         let ty = Ty::Tuple(vec![Ty::Var(v1), Ty::I32]);
@@ -2108,7 +2107,6 @@ mod tests {
 
     #[test]
     fn test_contains_var_in_function() {
-        TypeVar::reset();
         let v = TypeVar::fresh();
         let ty = Ty::Function {
             params: vec![Ty::I32],
@@ -2119,7 +2117,6 @@ mod tests {
 
     #[test]
     fn test_contains_var_in_option() {
-        TypeVar::reset();
         let v = TypeVar::fresh();
         let ty = Ty::option(Ty::Var(v));
         assert!(ty.contains_var(v));
@@ -2133,7 +2130,6 @@ mod tests {
 
     #[test]
     fn test_substitution_insert_rejects_direct_cycle() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v = TypeVar::fresh();
 
@@ -2147,7 +2143,6 @@ mod tests {
 
     #[test]
     fn test_substitution_resolve_returns_error_on_cycle() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v1 = TypeVar::fresh();
         let v2 = TypeVar::fresh();
@@ -2160,7 +2155,6 @@ mod tests {
 
     #[test]
     fn test_apply_subst_returns_error_on_cycle() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v1 = TypeVar::fresh();
         let v2 = TypeVar::fresh();

--- a/hew-types/src/unify.rs
+++ b/hew-types/src/unify.rs
@@ -410,7 +410,6 @@ mod tests {
 
     #[test]
     fn test_unify_type_var_left() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v = TypeVar::fresh();
         assert!(unify(&mut subst, &Ty::Var(v), &Ty::I32).is_ok());
@@ -419,7 +418,6 @@ mod tests {
 
     #[test]
     fn test_unify_type_var_right() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v = TypeVar::fresh();
         assert!(unify(&mut subst, &Ty::Bool, &Ty::Var(v)).is_ok());
@@ -436,7 +434,6 @@ mod tests {
 
     #[test]
     fn test_unify_tuples_with_var() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v = TypeVar::fresh();
         let a = Ty::Tuple(vec![Ty::Var(v), Ty::Bool]);
@@ -470,7 +467,6 @@ mod tests {
 
     #[test]
     fn test_occurs_check() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v = TypeVar::fresh();
         let ty = Ty::Tuple(vec![Ty::Var(v), Ty::I32]);
@@ -480,7 +476,6 @@ mod tests {
 
     #[test]
     fn test_unify_functions() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v = TypeVar::fresh();
         let a = Ty::Function {
@@ -497,7 +492,6 @@ mod tests {
 
     #[test]
     fn test_unify_named_types() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v = TypeVar::fresh();
         let a = Ty::Named {
@@ -544,7 +538,6 @@ mod tests {
 
     #[test]
     fn test_unify_promotes_var_bound_to_int_literal() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v = TypeVar::fresh();
         subst.insert(v, &Ty::IntLiteral).unwrap();
@@ -554,7 +547,6 @@ mod tests {
 
     #[test]
     fn test_unify_promotes_var_bound_to_float_literal() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v = TypeVar::fresh();
         subst.insert(v, &Ty::FloatLiteral).unwrap();
@@ -600,7 +592,6 @@ mod tests {
 
     #[test]
     fn test_unify_closure_with_closure() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v = TypeVar::fresh();
         let a = Ty::Closure {
@@ -685,7 +676,6 @@ mod tests {
 
     #[test]
     fn test_unify_chained_vars() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v1 = TypeVar::fresh();
         let v2 = TypeVar::fresh();
@@ -696,7 +686,6 @@ mod tests {
 
     #[test]
     fn test_literal_promotion_preserves_alias_equivalence() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v1 = TypeVar::fresh();
         let v2 = TypeVar::fresh();
@@ -748,7 +737,6 @@ mod tests {
 
     #[test]
     fn test_resolve_deeply_nested() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v = TypeVar::fresh();
         let ty = Ty::Named {
@@ -781,7 +769,6 @@ mod tests {
 
     #[test]
     fn task_unifies_inner_var() {
-        TypeVar::reset();
         let mut subst = Substitution::new();
         let v = TypeVar::fresh();
         let a = Ty::Task(Box::new(Ty::Var(v)));


### PR DESCRIPTION
Gate `TypeVar::reset()` behind `#[cfg(test)]` and remove the vestigial `reset()` calls from the affected tests.

`reset()` was `pub` and ungated, and several `#[test]` sites called it to zero the global `NEXT_TYPE_VAR` counter. Under nextest's default parallelism, a `reset()` on one thread racing a `fresh()` on another collapses TypeVar IDs — two distinct inference variables sharing one ID. The tests never depended on absolute IDs (they assert on captured `fresh()` results), so the resets were vestigial; removing them is behaviour-preserving and eliminates the race. `reset()` is now `#[cfg(test)]`-gated so it cannot exist in non-test builds.

Verification: `cargo test -p hew-types` plus a 3× determinism run.