### PR TITLE
refactor(types): remove legacy builtin channel() constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,14 +190,15 @@ the structured changelog.
   only inside a `gen` block.
 - **Unified concurrency substrate — `Duplex<S,R>`, `Sink<T>`, `Stream<T>`:**
   Three typed channel primitives replace the legacy send-operator surface.
-  `Duplex<S,R>` is a full-duplex channel; `Sink<T>` and `Stream<T>` are the
-  directional halves, constructed via `duplex_pair<S,R>(capacity)` and
-  `channel<T>(capacity)`. In 0.5.0 the lowered surface is tell-shaped
-  `.send(msg)` on these primitives plus the full `std::channel`
-  `Sender`/`Receiver` pair (`channel.new(capacity)`, `await rx.recv()`,
-  deadline-aware recv); the remaining Duplex/Sink methods (`.try_send`,
-  `.try_recv`, `.close`, ask-shaped send) type-check but refuse with named
-  diagnostics until their lowering lands.
+  `Duplex<S,R>` is a full-duplex channel constructed via
+  `duplex_pair<S,R>(capacity)`; `Sink<T>` and `Stream<T>` are the directional
+  halves exposed by std / runtime streaming surfaces (file, network, HTTP,
+  `std::stream`). Generic in-memory message channels use the `std::channel`
+  `Sender<T>`/`Receiver<T>` pair (`channel.new(capacity)`, `await rx.recv()`,
+  deadline-aware recv). In 0.5.0 the lowered surface is tell-shaped `.send(msg)`
+  on `Duplex`; the remaining Duplex/Sink methods (`.try_send`, `.try_recv`,
+  `.close`, ask-shaped send) type-check but refuse with named diagnostics until
+  their lowering lands.
 - **Lambda-actor form — `actor |params| { body }`:** A lambda-actor literal
   evaluates to a `Duplex<Msg, Reply>` handle running in a supervised child
   context. Both bare-call syntax `handle(msg)` and `.send(msg)` are accepted.

--- a/hew-hir/src/builtin_type_classes.rs
+++ b/hew-hir/src/builtin_type_classes.rs
@@ -166,7 +166,7 @@ pub fn crash_info_type_registration() -> &'static BuiltinTypeRegistration {
 /// lowering can query the registry instead of matching user-visible names.
 ///
 /// WHY: `Duplex<S,R>`, `Sink<T>`, `Stream<T>`, etc. are constructed via
-/// builtin functions (`duplex_pair`, `channel`) registered in
+/// builtin functions (`duplex_pair`, `duplex`) registered in
 /// `hew-types/src/check/registration.rs`.  Those builtins return `Ty::Duplex { .. }`
 /// which crosses the checker boundary as `ResolvedTy::Named { name: "Duplex", .. }`.
 /// Without this seeding, `ValueClass::of_ty` returns `Unknown` for every

--- a/hew-hir/src/builtin_type_classes.rs
+++ b/hew-hir/src/builtin_type_classes.rs
@@ -165,12 +165,17 @@ pub fn crash_info_type_registration() -> &'static BuiltinTypeRegistration {
 /// compiler-known records carry their marker and shape here so downstream
 /// lowering can query the registry instead of matching user-visible names.
 ///
-/// WHY: `Duplex<S,R>`, `Sink<T>`, `Stream<T>`, etc. are constructed via
-/// builtin functions (`duplex_pair`, `duplex`) registered in
-/// `hew-types/src/check/registration.rs`.  Those builtins return `Ty::Duplex { .. }`
-/// which crosses the checker boundary as `ResolvedTy::Named { name: "Duplex", .. }`.
+/// WHY: `Duplex<S,R>` is constructed via the `duplex_pair` / `duplex` builtin
+/// functions registered in `hew-types/src/check/registration.rs`.  Those
+/// builtins return `Ty::Duplex { .. }` which crosses the checker boundary as
+/// `ResolvedTy::Named { name: "Duplex", .. }`.  `Sink<T>` and `Stream<T>` have
+/// no builtin constructors (the `channel()` builtin was retired in favour of
+/// `std::channel::channel.new`, which yields `(Sender<T>, Receiver<T>)`) but are
+/// still registered here so that `ValueClass::of_ty` resolves them correctly for
+/// drop elaboration when they appear as values from std / runtime surfaces.
 /// Without this seeding, `ValueClass::of_ty` returns `Unknown` for every
-/// `Named { "Duplex", .. }` binding, and drop elaboration never fires.
+/// `Named { "Duplex", .. }` / `Named { "Sink", .. }` etc. binding, and drop
+/// elaboration never fires.
 ///
 /// WHEN-OBSOLETE: when user-level `@resource` type declarations become the
 /// canonical authority for all substrate types (i.e. when `std/duplex.hew`

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -873,13 +873,12 @@ impl Checker {
             Ty::I64,
         );
 
-        // Duplex / channel constructors — compiler builtins.
+        // Duplex constructors — compiler builtins.
         //
-        // WHY: slice 5 codegen and the HIR-level accept fixtures below need these
-        //   names resolvable without importing a stdlib module.
-        // WHEN-OBSOLETE: once `std::channel` (stdlib slice 6) ships, the stdlib
-        //   module replaces these registrations and these calls are removed.
-        // WHAT-REAL-SOLUTION: `std/channel.hew` module with proper source definitions.
+        // WHY: `duplex_pair` and `duplex` are constructor-only surfaces with no
+        //   stdlib module equivalent yet; they must remain resolvable without an
+        //   explicit import. `channel(capacity)` was removed: its canonical
+        //   replacement is `std::channel::channel.new(capacity)`.
         //
         // `duplex_pair<S: Send, R: Send>(capacity: int) -> (Duplex<S, R>, Duplex<R, S>)`
         // Returns a cross-wired pair of Duplex handles backed by a shared buffer.
@@ -945,27 +944,6 @@ impl Checker {
                     args: vec![],
                 },
             ),
-        );
-
-        // `channel<T: Send>(capacity: int) -> (Sink<T>, Stream<T>)`
-        // Constructs a unidirectional channel pair: the Sink writes, the Stream reads.
-        self.register_builtin_fn_with_bounds(
-            "channel",
-            vec!["T".to_string()],
-            HashMap::from([("T".to_string(), vec!["Send".to_string()])]),
-            vec![Ty::I64],
-            Ty::Tuple(vec![
-                Ty::sink(Ty::Named {
-                    builtin: None,
-                    name: "T".to_string(),
-                    args: vec![],
-                }),
-                Ty::stream(Ty::Named {
-                    builtin: None,
-                    name: "T".to_string(),
-                    args: vec![],
-                }),
-            ]),
         );
 
         // Register the compiled-in primitive/builtin receiver impls that must

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -877,8 +877,8 @@ impl Checker {
         //
         // WHY: `duplex_pair` and `duplex` are constructor-only surfaces with no
         //   stdlib module equivalent yet; they must remain resolvable without an
-        //   explicit import. `channel(capacity)` was removed: its canonical
-        //   replacement is `std::channel::channel.new(capacity)`.
+        //   explicit import. The former `channel` builtin constructor was removed;
+        //   callers use `std::channel::channel.new` instead.
         //
         // `duplex_pair<S: Send, R: Send>(capacity: int) -> (Duplex<S, R>, Duplex<R, S>)`
         // Returns a cross-wired pair of Duplex handles backed by a shared buffer.

--- a/hew-types/tests/builtins_duplex_resolution.rs
+++ b/hew-types/tests/builtins_duplex_resolution.rs
@@ -61,24 +61,6 @@ fn duplex_detached_resolves() {
     );
 }
 
-/// `channel<i64>(16)` returns `(Sink<i64>, Stream<i64>)`.
-#[test]
-fn channel_resolves_to_sink_stream_pair() {
-    let source = r"
-        fn main() {
-            let (sink, stream) = channel<i64>(16);
-            let _: Sink<i64> = sink;
-            let _: Stream<i64> = stream;
-        }
-    ";
-    let output = typecheck(source);
-    assert!(
-        output.errors.is_empty(),
-        "channel<i64>(16) should give (Sink<i64>, Stream<i64>); got: {:#?}",
-        output.errors
-    );
-}
-
 // ---------------------------------------------------------------------------
 // Reject fixtures
 // ---------------------------------------------------------------------------
@@ -123,26 +105,6 @@ fn duplex_pair_non_send_r_rejected() {
     assert!(
         has_bounds_err,
         "duplex_pair<i64, Rc<i64>> should fail with BoundsNotSatisfied; got: {:#?}",
-        output.errors
-    );
-}
-
-/// `channel<Rc<i64>>(16)` — `Rc<T>` is not Send; must fail.
-#[test]
-fn channel_non_send_rejected() {
-    let source = r"
-        fn main() {
-            let (s, r) = channel<Rc<i64>>(16);
-        }
-    ";
-    let output = typecheck(source);
-    let has_bounds_err = output
-        .errors
-        .iter()
-        .any(|e| matches!(e.kind, TypeErrorKind::BoundsNotSatisfied));
-    assert!(
-        has_bounds_err,
-        "channel<Rc<i64>> should fail with BoundsNotSatisfied; got: {:#?}",
         output.errors
     );
 }
@@ -222,9 +184,10 @@ fn duplex_missing_generic_args_rejected() {
     );
 }
 
-/// Calling `channel(16)` with no generic args must fail similarly.
+/// `channel(16)` is no longer a builtin; the name is unresolved and must fail.
+/// The canonical constructor is `std::channel::channel.new(capacity)`.
 #[test]
-fn channel_missing_generic_args_rejected() {
+fn channel_builtin_is_removed_unresolved() {
     let source = r"
         fn main() {
             let (s, r) = channel(16);
@@ -233,7 +196,7 @@ fn channel_missing_generic_args_rejected() {
     let output = typecheck(source);
     assert!(
         !output.errors.is_empty(),
-        "channel(16) without generic args must produce an error; got: {:#?}",
+        "channel(16) must fail after builtin removal; got: {:#?}",
         output.errors
     );
 }


### PR DESCRIPTION
## Summary

The builtin `channel(cap)` constructor — previously registered as a special-cased function in the type-checker — is removed. All call sites now use `std::channel::channel.new`, which has been the idiomatic form since the std channel module landed. The old path existed as a compatibility shim; removing it eliminates a parallel resolution branch in the checker and keeps the builtins surface honest.

`Sink<T>` and `Stream<T>` type-class entries in `builtin_type_classes.rs` are retained — they seed drop elaboration for values sourced from std/runtime, not constructors.

## Verification

- `grep -r "channel(cap"` across the tree: 0 matches
- `cargo test -p hew-types -p hew-hir`: pass
- `cargo test -p hew-cli --test eval_e2e channel -- --nocapture`: pass
- `cargo test -p hew-cli --test channel_recv_e2e`: pass
- Preflight (fmt check): ready-to-push

## Out of scope

No changes to the `std::channel` implementation, `Sender<T>` / `Receiver<T>` types, or runtime channel primitives. Those are unaffected by the registration-side removal.