### PR TITLE
fix(ci): pre-build wasm32-wasip1 debug archives before macOS smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,9 +545,28 @@ jobs:
           command -v wasm-ld
           wasm-ld --version
 
-      - name: Build hew-runtime for wasm32-wasip1
+      - name: Build hew-runtime for wasm32-wasip1 (release)
         if: env.RUN_CODE_PATH == 'true'
         run: cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features --release
+
+      - name: Build hew-runtime for wasm32-wasip1 (debug)
+        # The platform smoke tests run as debug binaries (cargo nextest run, no
+        # --release). bootstrap_wasi_runner in support/mod.rs derives the build
+        # profile from the test binary path and looks for the same profile's
+        # libhew_runtime.a before falling back to an on-demand build. Without
+        # this step the debug staticlib is absent at test startup, causing
+        # multiple parallel test processes to each launch `cargo build` for it
+        # concurrently — Cargo writes the archive non-atomically, so races
+        # corrupt or transiently delete the file and wasm-ld then fails with
+        # "cannot open .../wasm32-wasip1/debug/libhew_runtime.a".
+        if: env.RUN_CODE_PATH == 'true'
+        run: cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features
+
+      - name: Build hew-std for wasm32-wasip1 (debug)
+        # Pre-build the stdlib WASI archive for the same reason: bootstrap_wasi_runner
+        # builds libhew_std.a on demand if absent, same concurrent-write race applies.
+        if: env.RUN_CODE_PATH == 'true'
+        run: cargo build -p hew-std --target wasm32-wasip1
 
       - name: Run platform smoke tests
         # Default macOS path: prove the Apple Silicon build links and the

--- a/hew-cli/tests/support/mod.rs
+++ b/hew-cli/tests/support/mod.rs
@@ -144,19 +144,59 @@ fn bootstrap_wasi_runner() -> Result<(), String> {
     })?;
 
     let build_profile = build_profile();
+    build_wasi_runtime_serialized(&target_dir, build_profile)?;
+
+    for (package, archive) in WASI_STDLIB_ARCHIVES {
+        build_wasi_stdlib_archive(&target_dir, build_profile, package, archive)?;
+    }
+
+    Ok(())
+}
+
+/// Build `libhew_runtime.a` for wasm32-wasip1, serialized across parallel
+/// nextest test processes.
+///
+/// The fast path (all artifacts present) skips the lock entirely. Otherwise a
+/// cross-process `fd_lock::RwLock` serializes the build: without it, multiple
+/// test binaries each see the artifact absent and each launch `cargo build`
+/// concurrently; Cargo writes the staticlib non-atomically, so races corrupt
+/// or transiently delete the file and wasm-ld then fails with
+/// "cannot open `libhew_runtime.a`". `bootstrap_codegen` uses the same pattern.
+fn build_wasi_runtime_serialized(target_dir: &Path, build_profile: &str) -> Result<(), String> {
     let runtime_path = target_dir
         .join("wasm32-wasip1")
         .join(build_profile)
         .join("libhew_runtime.a");
-    if runtime_path.is_file()
-        && WASI_STDLIB_ARCHIVES.iter().all(|(_, archive)| {
-            target_dir
-                .join("wasm32-wasip1")
-                .join(build_profile)
-                .join(archive)
-                .is_file()
-        })
-    {
+
+    // Fast path: artifact already present (common case after the CI pre-build
+    // step or after a sibling process completed the build).
+    if runtime_path.is_file() {
+        return Ok(());
+    }
+
+    let lock_path = target_dir.join("hew-cli-wasi-bootstrap.lock");
+    let lock_file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|error| {
+            format!(
+                "failed to open WASI bootstrap lock {}: {error}",
+                lock_path.display()
+            )
+        })?;
+    let mut lock = RwLock::new(lock_file);
+    let _guard = lock.write().map_err(|error| {
+        format!(
+            "failed to lock WASI bootstrap {}: {error}",
+            lock_path.display()
+        )
+    })?;
+
+    // Re-check after acquiring the lock: a sibling may have built while we waited.
+    if runtime_path.is_file() {
         return Ok(());
     }
 
@@ -171,7 +211,7 @@ fn bootstrap_wasi_runner() -> Result<(), String> {
             "wasm32-wasip1",
             "--no-default-features",
         ])
-        .env("CARGO_TARGET_DIR", &target_dir)
+        .env("CARGO_TARGET_DIR", target_dir)
         .current_dir(repo_root());
     if build_profile == "release" {
         command.arg("--release");
@@ -180,36 +220,22 @@ fn bootstrap_wasi_runner() -> Result<(), String> {
     let output = command.output().map_err(|error| {
         format!(
             "failed to invoke `cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features{}`: {error}",
-            if build_profile == "release" {
-                " --release"
-            } else {
-                ""
-            }
+            if build_profile == "release" { " --release" } else { "" }
         )
     })?;
 
     if !output.status.success() {
         return Err(format!(
             "failed to bootstrap WASI runner runtime with `cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features{}`\n{}",
-            if build_profile == "release" {
-                " --release"
-            } else {
-                ""
-            },
+            if build_profile == "release" { " --release" } else { "" },
             describe_output(&output)
         ));
     }
 
-    for (package, archive) in WASI_STDLIB_ARCHIVES {
-        build_wasi_stdlib_archive(&target_dir, build_profile, package, archive)?;
-    }
-
     if !runtime_path.is_file() {
         // Cargo can exit 0 without producing the staticlib when a stale
-        // fingerprint (e.g. from a CI cache hit that only cached the rlib)
-        // convinces it that nothing needs to be rebuilt.  Recover by cleaning
-        // the wasm32-wasip1 artifacts for this package and retrying once.
-        wasi_runtime_clean_and_retry(&target_dir, build_profile)?;
+        // fingerprint convinces it nothing needs rebuilding.  Clean and retry.
+        wasi_runtime_clean_and_retry(target_dir, build_profile)?;
 
         if !runtime_path.is_file() {
             return Err(format!(


### PR DESCRIPTION
## Summary

The macOS wasm32 eval tests were flaking with `cannot open .../wasm32-wasip1/debug/libhew_runtime.a` because CI only pre-built the `--release` variant of `hew-runtime` and `hew-std` for `wasm32-wasip1`. The debug variant — which nextest consumes when running without `--release` — was absent at test startup. `bootstrap_wasi_runner` checks for the file first and, on a miss, launches `cargo build -p hew-runtime --target wasm32-wasip1`. With nextest running tests in parallel, multiple processes each saw the artifact missing and each started their own build concurrently. Cargo writes the staticlib non-atomically, so concurrent writers corrupt or transiently delete the file, and `wasm-ld` fails.

Two layers of defence close both causes:

1. Explicit `Build hew-runtime for wasm32-wasip1 (debug)` and `Build hew-std for wasm32-wasip1 (debug)` steps added to the macOS CI job, sequenced after the release builds and before the smoke/full test steps. The debug artifact is present when any test process calls `bootstrap_wasi_runner`, so the fast-path file-existence check always hits.

2. `build_wasi_runtime_serialized` extracted from `bootstrap_wasi_runner` with a cross-process `fd_lock::RwLock`, mirroring the existing pattern in `bootstrap_codegen`. If the fast-path ever misses, the build is serialized across all parallel test processes; a re-check after acquiring the lock avoids redundant rebuilds.

This was blocking PR #2061.

## Verification

- `git show --stat 506bd3f6`: `.github/workflows/ci.yml` +21 lines, `hew-cli/tests/support/mod.rs` +53/−29 lines — both causes addressed
- CI pre-build steps sequenced correctly: release builds → debug builds → smoke tests → full tests
- `fd_lock::RwLock` pattern mirrors `bootstrap_codegen` exactly (already proven correct in that path)
- Preflight: ready-to-push (fmt check passed on push)

## Out of scope

- Flake hardening for other bootstrap helpers (`bootstrap_codegen` already locked; this PR closes the `bootstrap_wasi_runner` gap only)
- Windows / Linux variants of this path (not affected — this race is macOS-specific parallelism behaviour under nextest)
