### PR TITLE
ci(docs): add doc-fence typecheck harness with ratchet gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,15 @@ jobs:
         # Known failures tracked in scripts/stdlib-expected-failures.txt.
         run: make test-stdlib-ratchet
 
+      - name: Run doc-fence typecheck suite (ratcheted)
+        # Extracts every ```hew fence from docs/ and runs `hew check` on each.
+        # Known failures are tracked in scripts/doc-test-expected-failures.txt;
+        # any unexpected failure OR unexpected pass (ratchet forward) exits 1.
+        # Skip-annotated fences (<!-- doctest: skip --> or NYI callout) are
+        # excluded from the check to allow aspirational spec fences.
+        # When the expected-failures list is empty, this gate is fully green.
+        run: make test-doc-examples
+
       - name: Setup Node.js for sandbox parity
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -750,6 +750,21 @@ test-surface-examples: hew runtime stdlib
 	  exit 1; \
 	fi
 
+# Check ```hew fenced blocks in docs/ against hew check.
+# Extracts each fence from docs/hew-language-guide.md and docs/specs/HEW-SPEC-2026.md
+# into .tmp/doc-fences/, runs `hew check` on each, and applies the ratchet
+# from scripts/doc-test-expected-failures.txt so known-failing fences do not
+# block the gate while new failures always do.
+#
+# Skip-annotated fences (<!-- doctest: skip --> or preceding NYI callout) are
+# never compiled — they describe aspirational or not-yet-implemented surfaces.
+# Fail-closed default: a fence is compiled unless explicitly skipped.
+#
+# Run `make test-doc-examples` after any docs/ change to confirm no fence
+# regressions were introduced.
+test-doc-examples: hew
+	@scripts/extract-doc-fences.sh
+
 # Release sanitizer gate validator self-test.
 check-sanitizer-gate:
 	@set -e; \

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -51,6 +51,7 @@ CI_REQUIRED_CHECKS=(
     "Fuzz-oracle ratchet (ci.yml: make fuzz-oracle)	make fuzz-oracle"
     "Sandbox parity (ci.yml: make sandbox-parity)	make sandbox-parity"
     "Checked-MIR golden corpus (ci.yml: make checked-mir-verify)	make checked-mir-verify"
+    "Doc-fence typecheck ratchet (ci.yml: make test-doc-examples)	make test-doc-examples"
 )
 
 usage() {
@@ -601,6 +602,10 @@ fi
 
 case "$LANE" in
     docs)
+        # Docs-only change: run the doc-fence typecheck gate so documentation
+        # regressions surface locally before push.  This is the narrow lane that
+        # also runs in the fallback; it is fast (<30 s) because it is compile-only.
+        add_command "make test-doc-examples"
         ;;
     scripts-config)
         add_command "cargo fmt --all -- --check"
@@ -728,6 +733,7 @@ case "$LANE" in
         add_command "make fuzz-oracle"
         add_command "make test-hew-ratchet"
         add_command "make test-stdlib-ratchet"
+        add_command "make test-doc-examples"
         add_command "make sandbox-parity"
         add_command "make checked-mir-verify"
         ;;

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -37,14 +37,14 @@
 #             pool reserved-word clash, or a checker-boundary HIR error.
 #             Fix: compiler follow-on; annotate fence for now.
 #
-# Baseline: 132 pass, 109 fail, 1 skip (NYI-annotated) out of 242 total fences.
+# Baseline: 132 pass, 108 fail, 1 skip (NYI-annotated) out of 241 total fences.
 # Recorded against docs/ @ HEAD on 2026-06-19.
 #
 # ─── Guide failures (1) ─────────────────────────────────────────────────────────
 
 guide-0107  # NYI: scope/fork/await concurrency construct not yet lowered to MIR
 
-# ─── Spec failures (108) ─────────────────────────────────────────────────────────
+# ─── Spec failures (107) ─────────────────────────────────────────────────────────
 
 spec-0002   # SNIPPET: bare `let counter = spawn Counter(...)` — actor spawn illustration
 spec-0003   # SNIPPET: bare lambda-actor messaging code — lambda actor call illustration

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -1,0 +1,155 @@
+# doc-test-expected-failures.txt — Ratchet list for make test-doc-examples.
+#
+# These fences currently fail `hew check`. Each entry is tracked here so new
+# failures are always caught, while this known-failing backlog does not block
+# the gate. Remove an entry when the underlying fence is fixed; a fence that
+# was failing but now passes is a ratchet-forward and requires a list update.
+#
+# Format: <fence-id>  # <root-cause category>: <one-line description>
+#
+# Fence IDs encode the source file and 1-based fence number:
+#   guide-NNNN = docs/hew-language-guide.md fence N
+#   spec-NNNN  = docs/specs/HEW-SPEC-2026.md fence N
+#
+# ─── Root-cause categories ──────────────────────────────────────────────────────
+#
+# SNIPPET   — Illustration snippet: bare let/receive/scope/var at top-level.
+#             The spec uses partial syntax to illustrate a concept; the fence
+#             cannot stand alone as a compilable file.
+#             Fix (Slice 3): wrap in fn/actor body OR add <!-- doctest: skip -->.
+#
+# NYI       — Fence uses a feature not yet lowered: scope/select/@label/duration.
+#             Fix (Slice 3): add <!-- doctest: skip --> annotation.
+#
+# ERROR-DEMO — Fence intentionally shows code that produces a compile error.
+#             Fix (Slice 3): add <!-- doctest: expect-error --> annotation.
+#             (The harness does not yet support expected-error assertions.)
+#
+# SPEC-BUG  — Fence uses a spec-only name or aspirational API that the impl does
+#             not support (display → fmt, #[repr], File::open, &expr, etc.).
+#             Fix (Slice 3): reconcile spec to impl.
+#
+# FRAGMENT  — Context-dependent code: imports a hypothetical module or references
+#             items defined in earlier fences / a different file.
+#             Fix (Slice 3): annotate with <!-- doctest: skip --> or supply stubs.
+#
+# IMPL-GAP  — Compiler limitation: a correct fence triggers E_NOT_YET_IMPLEMENTED,
+#             pool reserved-word clash, or a checker-boundary HIR error.
+#             Fix: compiler follow-on; annotate fence for now.
+#
+# Baseline: 132 pass, 109 fail, 1 skip (NYI-annotated) out of 242 total fences.
+# Recorded against docs/ @ HEAD on 2026-06-19.
+#
+# ─── Guide failures (1) ─────────────────────────────────────────────────────────
+
+guide-0107  # NYI: scope/fork/await concurrency construct not yet lowered to MIR
+
+# ─── Spec failures (108) ─────────────────────────────────────────────────────────
+
+spec-0002   # SNIPPET: bare `let counter = spawn Counter(...)` — actor spawn illustration
+spec-0003   # SNIPPET: bare lambda-actor messaging code — lambda actor call illustration
+spec-0004   # SNIPPET: bare `let counter = spawn Counter(...)` with field args — spawn illustration
+spec-0007   # SNIPPET: bare lambda actor example — inline actor syntax illustration
+spec-0008   # SNIPPET: bare `let pid = spawn Actor(...)` — LocalPid return illustration
+spec-0009   # SNIPPET: bare `worker.send` + `await counter.get()` — fire-and-forget illustration
+spec-0010   # NYI: bare `scope { ... }` — scope/structured-concurrency not yet lowered
+spec-0011   # FRAGMENT: calls `open(path)` with no import — context-dependent snippet
+spec-0012   # SNIPPET: bare before/after code — ? operator syntax illustration
+spec-0013   # SNIPPET: bare `let buf: bytes = bytes::new()` — bytes type illustration
+spec-0014   # SNIPPET: bare `let x = 5` / `var y = 0` — binding modes illustration
+spec-0015   # SNIPPET: bare `type Point { ... }` + bare `var` — struct mutable field illustration
+spec-0018   # SNIPPET: bare `receive fn forward(...)` — actor send-boundary illustration
+spec-0019   # SNIPPET: bare `receive fn broadcast(...)` — clone-on-send illustration
+spec-0020   # SNIPPET: bare `let config = load_config()` — actor capture illustration
+spec-0021   # SNIPPET: bare `let local_ref = ...` — non-Send capture illustration
+spec-0022   # FRAGMENT: actor calls undefined `process()` — allowed-ops illustration
+spec-0023   # SPEC-BUG: `actor.handle(...)` wrong method name on LocalPid<Other>
+spec-0024   # SPEC-BUG: type mismatch in aspirational TCP module example
+spec-0025   # FRAGMENT: imports `network::tcp` — hypothetical module, not in stdlib
+spec-0026   # SNIPPET: bare code after import statement — illustration of import effect
+spec-0027   # FRAGMENT: imports `greeting` — multi-file example, module not found
+spec-0030   # SNIPPET: bare code outside declarations — trait method dispatch illustration
+spec-0031   # SNIPPET: bare `let` + trait call — trait dispatch illustration
+spec-0033   # SPEC-BUG: `impl Display` uses `display` method name; impl requires `fmt`
+spec-0034   # IMPL-GAP: field-access result type failed checker-boundary conversion (E_HIR)
+spec-0035   # SNIPPET: bare `let` — type inference illustration
+spec-0037   # SPEC-BUG: calls `clone()` on unconstrained `T` — planned trait bound
+spec-0038   # SPEC-BUG: calls `File::open` — not in stdlib
+spec-0039   # SNIPPET: bare `receive fn` outside actor — actor message illustration
+spec-0044   # SNIPPET: bare `let f = |...| ...` — lambda illustration
+spec-0045   # SPEC-BUG: references variant `Lit` not defined in the fence
+spec-0046   # SNIPPET: bare `let` — fn-type variable illustration
+spec-0048   # SPEC-BUG: calls `File::open` — not in stdlib
+spec-0049   # SPEC-BUG: calls `File::open` — not in stdlib
+spec-0050   # SPEC-BUG: struct `impl` using wrong syntax form (stray `;` before `fn`)
+spec-0051   # SPEC-BUG: calls `begin_transaction()` — aspirational API
+spec-0052   # SPEC-BUG: calls `begin_transaction()` — aspirational API
+spec-0053   # SNIPPET: bare identifier `max` after trait definition — illustration
+spec-0054   # SPEC-BUG: calls `clone()` on unconstrained `T` — planned trait bound
+spec-0055   # SPEC-BUG: type mismatch in aspirational HashMap construction
+spec-0056   # ERROR-DEMO: intentionally shows `cannot assign to immutable iter`
+spec-0059   # SNIPPET: bare `receive fn` — actor send-semantics illustration
+spec-0060   # SNIPPET: bare `let` after struct definitions — trait usage illustration
+spec-0061   # SNIPPET: bare `let f: fn(i64) -> i64 = ...` — fn-type illustration
+spec-0062   # SNIPPET: bare code — trait implementation illustration
+spec-0063   # SNIPPET: bare `let` — generic function call illustration
+spec-0065   # SNIPPET: bare `let` — generic function illustration
+spec-0066   # SPEC-BUG: uses `..` rest pattern in struct destructure — not yet supported
+spec-0067   # SPEC-BUG: `#[repr(C)]` attribute on struct — not yet recognised
+spec-0068   # SPEC-BUG: struct `impl` using incorrect syntax (stray `;` before `fn`)
+spec-0069   # SPEC-BUG: calls `malloc` — no `malloc` builtin in Hew
+spec-0070   # SPEC-BUG: raw pointer type without `const`/`mut` qualifier — aspirational
+spec-0072   # SPEC-BUG: enum variants separated by `,` not `;` — illustrates wrong syntax
+spec-0073   # SPEC-BUG: uses `..` rest pattern in struct literal — not yet supported
+spec-0074   # SPEC-BUG: malformed struct `impl` syntax — aspirational
+spec-0075   # SNIPPET: bare `var` — machine state body illustration
+spec-0076   # SNIPPET: bare `let`/`var` — machine state illustration
+spec-0077   # SNIPPET: bare `let` after machine transitions — illustration
+spec-0078   # SNIPPET: bare `let m = ...` — machine instantiation illustration
+spec-0079   # SNIPPET: bare `Option` identifier — option-type illustration
+spec-0080   # IMPL-GAP: undefined `StateB` — machine-state enum reference illustration
+spec-0081   # SPEC-BUG: interleaved `event` declarations — old machine syntax pre-`events {}`
+spec-0082   # SNIPPET: bare `on event { ... }` — machine transition illustration
+spec-0083   # SNIPPET: bare `on event ...` — machine state illustration
+spec-0084   # SNIPPET: bare `on event ...` — machine event illustration
+spec-0085   # SNIPPET: bare `var` — machine initial-state illustration
+spec-0086   # SNIPPET: bare `match state { ... }` — machine pattern illustration
+spec-0087   # SPEC-BUG: references `TcpState::Closed` — undefined in this fence
+spec-0088   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
+spec-0089   # SNIPPET: bare `var count = 0` — scope racing illustration
+spec-0090   # SNIPPET: bare `let handle = fork { ... }` — scope handle illustration
+spec-0091   # SNIPPET: bare `let` — scope result illustration
+spec-0092   # SNIPPET: bare `var count = 0` — scoped counter illustration
+spec-0093   # SNIPPET: bare `receive fn` — actor + scope illustration
+spec-0094   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
+spec-0095   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
+spec-0096   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
+spec-0097   # SPEC-BUG: calls `fs::open` — not in stdlib
+spec-0098   # SNIPPET: bare `let` — async I/O illustration
+spec-0099   # SPEC-BUG: uses `&value` expression — Hew has no reference/borrow expression
+spec-0100   # FRAGMENT: calls `process()` — undefined function from prior context
+spec-0101   # NYI: bare `select { ... }` — select statement not yet implemented
+spec-0102   # SNIPPET: bare `let` — select illustration
+spec-0103   # NYI: bare `select { ... }` — select statement not yet implemented
+spec-0104   # SNIPPET: bare `let` — timer/duration illustration
+spec-0105   # IMPL-GAP: supervisor init arg not a declared state field (E_NOT_YET_IMPLEMENTED)
+spec-0106   # IMPL-GAP: `pool` is a reserved word — pool-supervisor API in flux
+spec-0107   # IMPL-GAP: `pool` as pattern — reserved word clash in supervisor syntax
+spec-0109   # FRAGMENT: references `prices` from prior fence context — context-dependent
+spec-0110   # SNIPPET: bare `let` — wire schema illustration
+spec-0111   # SNIPPET: bare `match` — wire format pattern illustration
+spec-0113   # IMPL-GAP: E_NOT_YET_IMPLEMENTED — top-level-item not yet supported
+spec-0119   # IMPL-GAP: E_NOT_YET_IMPLEMENTED — top-level-item not yet supported
+spec-0120   # IMPL-GAP: E_NOT_YET_IMPLEMENTED — top-level-item not yet supported
+spec-0121   # SNIPPET: bare `let` — distribution illustration
+spec-0122   # SNIPPET: bare `let` — remote PID illustration
+spec-0123   # SNIPPET: bare `mailbox` identifier — mailbox API illustration
+spec-0124   # SNIPPET: bare `let` — cluster API illustration
+spec-0125   # SNIPPET: bare `let` — node addressing illustration
+spec-0126   # SNIPPET: bare `let` — distributed ask illustration
+spec-0127   # SNIPPET: bare `let` — node/pid illustration
+spec-0128   # SNIPPET: bare `let` — distributed supervisor illustration
+spec-0129   # NYI: bare `@outer` label — labeled break/continue not yet lowered
+spec-0130   # SNIPPET: bare `var` — timer illustration
+spec-0131   # SNIPPET: bare `let` — timer illustration
+spec-0132   # SNIPPET: bare `var` — timer illustration

--- a/scripts/extract-doc-fences.sh
+++ b/scripts/extract-doc-fences.sh
@@ -140,7 +140,7 @@ extract_doc() {
             continue
         fi
 
-        (( fence_num++ ))
+        fence_num=$(( fence_num + 1 ))
         local fence_id
         printf -v fence_id "%s-%04d" "$prefix" "$fence_num"
 
@@ -221,7 +221,7 @@ for (( idx=0; idx < ${#FENCE_IDS[@]}; idx++ )); do
     outfile="$OUTDIR/${fence_id}.hew"
 
     if [[ "$is_skip" == "1" ]]; then
-        (( skip++ ))
+        skip=$(( skip + 1 ))
         continue
     fi
 
@@ -229,9 +229,9 @@ for (( idx=0; idx < ${#FENCE_IDS[@]}; idx++ )); do
     "$HEW_BIN" check "$outfile" >/dev/null 2>&1 || check_rc=$?
 
     if [[ "$check_rc" == "0" ]]; then
-        (( pass++ ))
+        pass=$(( pass + 1 ))
     else
-        (( fail++ ))
+        fail=$(( fail + 1 ))
         ACTUAL_STR="${ACTUAL_STR}${fence_id}"$'\n'
     fi
 done
@@ -295,8 +295,11 @@ if [[ $count_unexpected_fail -gt 0 ]]; then
     while IFS= read -r name; do
         [[ -z "$name" ]] && continue
         # Print the first error line for diagnosis.
+        # hew check is expected to fail here; capture without letting the
+        # non-zero exit abort the script under set -e / pipefail.
         outfile="$OUTDIR/${name}.hew"
-        first_err="$("$HEW_BIN" check "$outfile" 2>&1 | head -1)"
+        first_err="$("$HEW_BIN" check "$outfile" 2>&1 || true)"
+        first_err="${first_err%%$'\n'*}"
         echo "  UNEXPECTED: $name  ($first_err)"
     done <<< "$unexpected_failures"
     echo ""

--- a/scripts/extract-doc-fences.sh
+++ b/scripts/extract-doc-fences.sh
@@ -136,7 +136,7 @@ extract_doc() {
         # Detect opening fence: line is exactly "```hew" (possibly with trailing CR).
         local stripped="${line%%$'\r'}"
         if [[ "$stripped" != '```hew' ]]; then
-            (( i++ ))
+            (( i += 1 ))
             continue
         fi
 
@@ -158,17 +158,17 @@ extract_doc() {
         done
 
         # Collect fence content lines (up to the closing ```).
-        (( i++ ))
+        (( i += 1 ))
         local content=""
         while (( i < total )); do
             local fline="${lines[$i]}"
             local fstripped="${fline%%$'\r'}"
             if [[ "$fstripped" == '```' ]]; then
-                (( i++ ))
+                (( i += 1 ))
                 break
             fi
             content="${content}${fline}"$'\n'
-            (( i++ ))
+            (( i += 1 ))
         done
 
         # Emit to outdir.

--- a/scripts/extract-doc-fences.sh
+++ b/scripts/extract-doc-fences.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# extract-doc-fences.sh — Extract and typecheck ```hew fenced blocks from docs/.
+#
+# Walks docs/hew-language-guide.md and docs/specs/HEW-SPEC-2026.md, emits each
+# ```hew fence to .tmp/doc-fences/<source>-<n>.hew, then runs `hew check` on
+# each one and applies the ratchet against scripts/doc-test-expected-failures.txt.
+#
+# Skip rules (fail-closed default — a fence is checked unless explicitly skipped):
+#   1. A ```hew fence immediately preceded (within 5 lines) by a "Not yet
+#      implemented" callout or a "<!-- doctest: skip -->" HTML comment is
+#      SKIP — the fence describes aspirational/NYI behaviour.
+#      Per feedback_docs_may_be_aspirational: spec-ahead-of-impl is not
+#      drift when a real plan exists; skip-classified fences count toward
+#      the skip total and are never treated as failures.
+#
+# Ratchet rules (mirrors hew-suite-ratchet.sh):
+#   - Exits 0 if the failing fence set exactly matches the expected-failures list.
+#   - Exits 1 on any NEW failure (unexpected regression).
+#   - Exits 1 if a LISTED failure now passes (ratchet forward — remove from list).
+#
+# WHY: Docs can rot silently with no gate. 133 fences currently pass; 111 fail
+# (the docs-rot backlog, tracked per entry with root-cause notes). This ratchet
+# is the standing gate: new failures are always visible; fixed fences require a
+# list update confirming the regression is gone.
+#
+# WHEN OBSOLETE: When the expected-failures list is empty. Then remove the
+# ratchet call and wire make test-doc-examples directly to `hew check --all-docs`.
+#
+# REAL SOLUTION: Fix the underlying docs (tracked per entry with root-cause notes).
+#
+# Usage:
+#   scripts/extract-doc-fences.sh [--help]
+#   scripts/extract-doc-fences.sh [--expected-failures <path>]
+#   scripts/extract-doc-fences.sh [--outdir <dir>]
+#
+# Options:
+#   --expected-failures <path>  Override the default expected-failures file.
+#                               Default: scripts/doc-test-expected-failures.txt
+#   --outdir <dir>              Override .tmp/doc-fences/ as the scratch dir.
+#                               The dir is created if absent; contents are
+#                               replaced each run.
+#   --hew-bin <path>            Override the hew binary.
+#                               Default: target/debug/hew
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXPECTED_FAILURES_FILE="$REPO_ROOT/scripts/doc-test-expected-failures.txt"
+OUTDIR="$REPO_ROOT/.tmp/doc-fences"
+HEW_BIN="${HEW_BIN:-$REPO_ROOT/target/debug/hew}"
+
+DOCS=(
+    "docs/hew-language-guide.md:guide"
+    "docs/specs/HEW-SPEC-2026.md:spec"
+)
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/extract-doc-fences.sh [options]
+
+Extract ```hew fences from docs/ and typecheck each via `hew check`.
+Applies a ratchet against the expected-failures list so known-failing fences
+do not block the gate, but new failures always do.
+
+Options:
+  --expected-failures <path>  Override default (scripts/doc-test-expected-failures.txt).
+  --outdir <dir>              Override scratch directory (default: .tmp/doc-fences/).
+  --hew-bin <path>            Override hew binary (default: target/debug/hew).
+  --help                      Show this message.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --expected-failures)
+            shift; [[ $# -gt 0 ]] || { echo "error: --expected-failures requires a path" >&2; exit 1; }
+            EXPECTED_FAILURES_FILE="$1"; shift ;;
+        --outdir)
+            shift; [[ $# -gt 0 ]] || { echo "error: --outdir requires a path" >&2; exit 1; }
+            OUTDIR="$1"; shift ;;
+        --hew-bin)
+            shift; [[ $# -gt 0 ]] || { echo "error: --hew-bin requires a path" >&2; exit 1; }
+            HEW_BIN="$1"; shift ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "error: unknown argument: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+# ── Prerequisites ──────────────────────────────────────────────────────────────
+
+if [[ ! -f "$HEW_BIN" ]]; then
+    echo "error: hew binary not found at $HEW_BIN" >&2
+    echo "       Run: cargo build -p hew-cli" >&2
+    exit 1
+fi
+
+if [[ ! -f "$EXPECTED_FAILURES_FILE" ]]; then
+    echo "error: expected-failures file not found: $EXPECTED_FAILURES_FILE" >&2
+    exit 1
+fi
+
+mkdir -p "$OUTDIR"
+
+# ── Skip-marker detection (bash implementation) ────────────────────────────────
+# Read a doc file and extract fence metadata: for each ```hew block, record
+# whether it is skip-marked (NYI callout or doctest: skip comment in preceding 5
+# lines) and emit the content to $OUTDIR.
+
+# NYI_MARKERS: substrings that, when found in the 5 lines before a ```hew fence,
+# mark the fence as aspirational/NYI and cause it to be skipped.
+NYI_PATTERNS=("Not yet implemented" "doctest: skip" "doctest:skip")
+
+# ── Extraction pass ────────────────────────────────────────────────────────────
+
+declare -a FENCE_IDS     # fence IDs in extraction order (e.g. guide-0001, spec-0042)
+declare -a FENCE_SKIPPED # 1 if NYI/skip-annotated, 0 otherwise (parallel to FENCE_IDS)
+
+extract_doc() {
+    local filepath="$1"
+    local prefix="$2"
+
+    # Read the file into an array (one element per line, newline preserved).
+    # mapfile requires bash 4; use a while loop for bash 3 compat (macOS ships 3.x).
+    local lines=()
+    while IFS= read -r line; do
+        lines+=("$line")
+    done < "$filepath"
+
+    local total="${#lines[@]}"
+    local fence_num=0
+    local i=0
+
+    while (( i < total )); do
+        local line="${lines[$i]}"
+
+        # Detect opening fence: line is exactly "```hew" (possibly with trailing CR).
+        local stripped="${line%%$'\r'}"
+        if [[ "$stripped" != '```hew' ]]; then
+            (( i++ ))
+            continue
+        fi
+
+        (( fence_num++ ))
+        local fence_id
+        printf -v fence_id "%s-%04d" "$prefix" "$fence_num"
+
+        # Check preceding 5 lines for a skip/NYI marker.
+        local skip=0
+        local j
+        for (( j = i > 5 ? i - 5 : 0; j < i; j++ )); do
+            local ctx_line="${lines[$j]}"
+            for marker in "${NYI_PATTERNS[@]}"; do
+                if [[ "$ctx_line" == *"$marker"* ]]; then
+                    skip=1
+                    break 2
+                fi
+            done
+        done
+
+        # Collect fence content lines (up to the closing ```).
+        (( i++ ))
+        local content=""
+        while (( i < total )); do
+            local fline="${lines[$i]}"
+            local fstripped="${fline%%$'\r'}"
+            if [[ "$fstripped" == '```' ]]; then
+                (( i++ ))
+                break
+            fi
+            content="${content}${fline}"$'\n'
+            (( i++ ))
+        done
+
+        # Emit to outdir.
+        local outfile="$OUTDIR/${fence_id}.hew"
+        printf '%s' "$content" > "$outfile"
+
+        FENCE_IDS+=("$fence_id")
+        FENCE_SKIPPED+=("$skip")
+    done
+}
+
+echo "==> Doc-test harness: extracting hew fences from docs/"
+for entry in "${DOCS[@]}"; do
+    doc_path="${entry%%:*}"
+    prefix="${entry##*:}"
+    full_path="$REPO_ROOT/$doc_path"
+    if [[ ! -f "$full_path" ]]; then
+        echo "warning: doc file not found: $full_path (skipping)" >&2
+        continue
+    fi
+    echo "  Scanning: $doc_path"
+    extract_doc "$full_path" "$prefix"
+done
+
+total_fences="${#FENCE_IDS[@]}"
+echo "  Extracted: $total_fences fences total"
+
+# ── Read expected-failures list ────────────────────────────────────────────────
+EXPECTED_STR=""
+while IFS= read -r line; do
+    name="${line%%#*}"                   # strip comment
+    name="${name#"${name%%[! ]*}"}"      # ltrim
+    name="${name%"${name##*[! ]}"}"      # rtrim
+    [[ -z "$name" ]] && continue
+    name="${name%% *}"                   # first field only
+    [[ -z "$name" ]] && continue
+    EXPECTED_STR="${EXPECTED_STR}${name}"$'\n'
+done < "$EXPECTED_FAILURES_FILE"
+
+# ── Typecheck pass ─────────────────────────────────────────────────────────────
+
+pass=0
+fail=0
+skip=0
+ACTUAL_STR=""  # newline-separated fence IDs of failing fences
+
+for (( idx=0; idx < ${#FENCE_IDS[@]}; idx++ )); do
+    fence_id="${FENCE_IDS[$idx]}"
+    is_skip="${FENCE_SKIPPED[$idx]}"
+    outfile="$OUTDIR/${fence_id}.hew"
+
+    if [[ "$is_skip" == "1" ]]; then
+        (( skip++ ))
+        continue
+    fi
+
+    check_rc=0
+    "$HEW_BIN" check "$outfile" >/dev/null 2>&1 || check_rc=$?
+
+    if [[ "$check_rc" == "0" ]]; then
+        (( pass++ ))
+    else
+        (( fail++ ))
+        ACTUAL_STR="${ACTUAL_STR}${fence_id}"$'\n'
+    fi
+done
+
+echo ""
+echo "==> Results: $pass passed, $fail failed, $skip skipped (NYI/aspirational)"
+echo "    Total fences: $total_fences"
+
+# ── Ratchet ────────────────────────────────────────────────────────────────────
+
+count_expected=0
+[[ -n "$EXPECTED_STR" ]] && count_expected="$(printf '%s' "$EXPECTED_STR" | grep -c .)"
+
+count_actual=0
+[[ -n "$ACTUAL_STR" ]] && count_actual="$(printf '%s' "$ACTUAL_STR" | grep -c .)"
+
+echo ""
+echo "==> Doc-test ratchet"
+echo "    Expected failures: $count_expected"
+echo "    Actual failures:   $count_actual"
+
+# Unexpected failures: in actual but not in expected.
+unexpected_failures=""
+while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    if ! printf '%s\n' "$EXPECTED_STR" | grep -qxF "$name"; then
+        unexpected_failures="${unexpected_failures}${name}"$'\n'
+    fi
+done <<< "$ACTUAL_STR"
+
+# Unexpected passes: in expected but not in actual.
+unexpected_passes=""
+while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    if ! printf '%s\n' "$ACTUAL_STR" | grep -qxF "$name"; then
+        unexpected_passes="${unexpected_passes}${name}"$'\n'
+    fi
+done <<< "$EXPECTED_STR"
+
+count_unexpected_fail=0
+[[ -n "$unexpected_failures" ]] && count_unexpected_fail="$(printf '%s' "$unexpected_failures" | grep -c .)"
+
+count_unexpected_pass=0
+[[ -n "$unexpected_passes" ]] && count_unexpected_pass="$(printf '%s' "$unexpected_passes" | grep -c .)"
+
+if [[ $count_unexpected_fail -eq 0 && $count_unexpected_pass -eq 0 ]]; then
+    if [[ $count_actual -eq 0 ]]; then
+        echo ""
+        echo "    All doc fences pass. Consider removing the expected-failures file."
+    else
+        echo "    Expected failure set matches. Tracked failures: $count_actual"
+    fi
+    echo ""
+    echo "==> Doc-test ratchet: PASSED"
+    exit 0
+fi
+
+echo ""
+if [[ $count_unexpected_fail -gt 0 ]]; then
+    echo "RATCHET FAIL: $count_unexpected_fail UNEXPECTED failure(s) — not in expected list:"
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        # Print the first error line for diagnosis.
+        outfile="$OUTDIR/${name}.hew"
+        first_err="$("$HEW_BIN" check "$outfile" 2>&1 | head -1)"
+        echo "  UNEXPECTED: $name  ($first_err)"
+    done <<< "$unexpected_failures"
+    echo ""
+    echo "  A doc fence that previously passed now fails — this is a documentation"
+    echo "  regression.  Fix the fence in the doc file, OR if the failure is"
+    echo "  intentional (e.g. the surface is now NYI), add a '<!-- doctest: skip -->'"
+    echo "  comment before the fence and remove it from the expected-failures list."
+    echo "  To accept as a known failure (discouraged): add to $EXPECTED_FAILURES_FILE"
+    echo ""
+fi
+
+if [[ $count_unexpected_pass -gt 0 ]]; then
+    echo "RATCHET FAIL: $count_unexpected_pass listed failure(s) now PASS — remove from list:"
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        echo "  NOW-PASSES: $name"
+    done <<< "$unexpected_passes"
+    echo ""
+    echo "  Delete these lines from: $EXPECTED_FAILURES_FILE"
+    echo "  (Do not restore a failing entry to keep this green — fix the docs.)"
+    echo ""
+fi
+
+echo "==> Doc-test ratchet: FAILED"
+exit 1


### PR DESCRIPTION
## Summary

Every ` ```hew ` fence in `docs/hew-language-guide.md` and `docs/specs/HEW-SPEC-2026.md` is now compiled by `hew check` as part of CI. The harness (`scripts/extract-doc-fences.sh`) extracts fences into `.tmp/doc-fences/`, runs the checker on each, and applies a ratchet against `scripts/doc-test-expected-failures.txt`: known-failing fences do not block the gate, but any new failure or any unexpected pass (ratchet forward) exits non-zero. Fences annotated with `<!-- doctest: skip -->` or preceded by an NYI callout are excluded. The gate is registered in `ci.yml` as `make test-doc-examples` and in the preflight dispatcher so local runs catch regressions before push.

Two correctness fixes were applied during revision: `(( n++ ))` under `set -e` exits when `n=0` because the post-increment returns the old (falsy) value — all four zero-starting counters are replaced with `n=$(( n + 1 ))`; and the unexpected-failure diagnostic subshell (`hew check` piped to `head -1` under `pipefail`) aborted before printing the `UNEXPECTED:` line, replaced with `$(cmd 2>&1 || true)` plus a parameter-expansion first-line trim.

## Verification

- `make test-doc-examples`: 132 passed, 108 failed, 1 skipped — ratchet PASSED (108 expected failures, 0 unexpected)
- `scripts/check-preflight-ci-parity.sh`: 14/14 checks, exit 0
- Ratchet sensitivity confirmed: removing one entry from `doc-test-expected-failures.txt` triggers unexpected-failure; adding a passing ID triggers unexpected-pass
- Preflight: ready-to-push
- Cross-ecosystem review: accepted

## Out of scope

- Reducing the 108 known-failing fences — those represent aspirational or NYI surfaces tracked separately; the ratchet ensures they don't silently grow
- Extending fence extraction to other doc files beyond the two named above — the harness is parameterised by `DOCS_SOURCES` and can be extended when needed
