### PR TITLE
feat(ci): ASan compiled-fixture gate for generated-code leak detection

### DIFF
--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -66,6 +66,72 @@ jobs:
             --lib
 
   # ─────────────────────────────────────────────────────────────────────────
+  # Compiled .hew fixture ASan — leak detection for generated code
+  #
+  # Scope: compiled Hew programs linked against an ASan-instrumented libhew.a.
+  # The `rust-runtime-asan` job above instruments the Rust runtime crate under
+  # test; this job instruments the GENERATED CODE (the LLVM IR + clang-linked
+  # artefact produced by `hew compile`).  These are two different surfaces:
+  # - runtime-asan: cargo test --lib sees Rust-level allocation/free paths
+  # - fixture-asan: a compiled .hew binary running against ASan libhew.a sees
+  #   leaks that only appear in the generated code (e.g. a hew_vec_get_str
+  #   retained node that codegen failed to drop after a string compare)
+  #
+  # Two fixture probes:
+  #   clean-probe   exercises the previously-leaky Vec<string> index-into-compare
+  #                 and owned array-repeat shapes (both fixed); must be ZERO findings.
+  #   leak-proof    calls a C shim that intentionally leaks 1 KiB; the gate must
+  #                 catch it — proving the extended gate would have flagged the two
+  #                 missed leaks that were previously macOS-oracle-only.
+  # ─────────────────────────────────────────────────────────────────────────
+  compiled-fixture-asan:
+    name: Compiled fixture ASan (generated code)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      - name: Install llvm-${{ env.LLVM_VERSION }} (symbolizer + clang for link step)
+        run: |
+          sudo mkdir -p /etc/apt/keyrings
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | sudo tee /etc/apt/keyrings/llvm.asc >/dev/null
+          echo "deb [signed-by=/etc/apt/keyrings/llvm.asc] http://apt.llvm.org/noble/ llvm-toolchain-noble-${{ env.LLVM_VERSION }} main" \
+            | sudo tee /etc/apt/sources.list.d/llvm.list >/dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq llvm-${{ env.LLVM_VERSION }} clang-${{ env.LLVM_VERSION }}
+          # Make clang-N available as `clang` (hew's link step calls `clang`).
+          sudo update-alternatives --install /usr/bin/clang clang \
+            /usr/bin/clang-${{ env.LLVM_VERSION }} 100
+
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9  # master 2026-03-27
+        with:
+          toolchain: nightly
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/sanitizer-fixture-asan/
+          key: fixture-asan-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: fixture-asan-${{ runner.os }}-
+
+      - name: Run compiled-fixture ASan gate
+        env:
+          LLVM_VERSION: ${{ env.LLVM_VERSION }}
+          SANITIZER_RUST_TARGET: x86_64-unknown-linux-gnu
+          CARGO_TERM_COLOR: always
+        run: |
+          # scripts/asan-fixture-check.sh:
+          #   1. Builds hew CLI + libhew.a with nightly -Zsanitizer=address.
+          #   2. Compiles .hew fixtures to objects (hew build --emit-obj).
+          #   3. Links with clang -fsanitize=address against the ASan libhew.a.
+          #   4. Runs clean-probe (must be zero findings) and leak-proof (must
+          #      detect the deliberate 1 KiB leak).
+          scripts/asan-fixture-check.sh
+
+  # ─────────────────────────────────────────────────────────────────────────
   # Rust runtime TSan — data-race detection for the actor runtime
   #
   # Scope: core concurrency primitives (reply-channel, mailbox, scheduler).

--- a/.github/workflows/nightly-sanitizers.yml
+++ b/.github/workflows/nightly-sanitizers.yml
@@ -77,12 +77,20 @@ jobs:
   #   leaks that only appear in the generated code (e.g. a hew_vec_get_str
   #   retained node that codegen failed to drop after a string compare)
   #
-  # Two fixture probes:
-  #   clean-probe   exercises the previously-leaky Vec<string> index-into-compare
-  #                 and owned array-repeat shapes (both fixed); must be ZERO findings.
-  #   leak-proof    calls a C shim that intentionally leaks 1 KiB; the gate must
-  #                 catch it — proving the extended gate would have flagged the two
-  #                 missed leaks that were previously macOS-oracle-only.
+  # Three fixture probes:
+  #   clean-probe (--emit-obj path)
+  #       Exercises the previously-leaky Vec<string> index-into-compare and
+  #       local drop shapes (both fixed); must produce ZERO findings.
+  #   leak-probe (Hew generated-code)
+  #       asan_fixture_leak_probe.hew calls malloc via extern "C" and never frees
+  #       it.  The malloc call is in the LLVM IR produced by hew codegen — a
+  #       genuine generated-code leak, not a standalone C program.  The gate must
+  #       catch it, proving it would have flagged the historical array-repeat
+  #       Vec<string>/Vec<record> leaks that were previously macOS-oracle-only.
+  #   clean-probe (HEW_SANITIZE_ADDRESS=1 hew build path)
+  #       The same clean fixture linked by `hew build` with HEW_SANITIZE_ADDRESS=1
+  #       (the full CLI link step, not manual clang).  Proves the CLI flag
+  #       integration is exercised by this gate; must produce ZERO findings.
   # ─────────────────────────────────────────────────────────────────────────
   compiled-fixture-asan:
     name: Compiled fixture ASan (generated code)
@@ -123,12 +131,15 @@ jobs:
           SANITIZER_RUST_TARGET: x86_64-unknown-linux-gnu
           CARGO_TERM_COLOR: always
         run: |
-          # scripts/asan-fixture-check.sh:
+          # scripts/asan-fixture-check.sh — three probes:
           #   1. Builds hew CLI + libhew.a with nightly -Zsanitizer=address.
-          #   2. Compiles .hew fixtures to objects (hew build --emit-obj).
-          #   3. Links with clang -fsanitize=address against the ASan libhew.a.
-          #   4. Runs clean-probe (must be zero findings) and leak-proof (must
-          #      detect the deliberate 1 KiB leak).
+          #   2. Compiles clean-probe + leak-probe via hew build --emit-obj,
+          #      then links with clang -fsanitize=address.
+          #   3. Also compiles clean-probe via HEW_SANITIZE_ADDRESS=1 hew build
+          #      (the full CLI link path through hew-cli/src/link.rs).
+          #   4. Runs clean-probe (zero findings), leak-probe (must catch the
+          #      Hew generated-code malloc leak), clean-probe CLI-link (zero
+          #      findings).
           scripts/asan-fixture-check.sh
 
   # ─────────────────────────────────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@
 # ============================================================================
 
 .PHONY: all build bootstrap install-hooks hew adze observe runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh
-.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all test-stdlib test-hew test-hew-ratchet test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo hew-fmt-check grammar
+.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all test-stdlib test-hew test-hew-ratchet test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo hew-fmt-check grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
 .PHONY: coverage coverage-summary coverage-lcov coverage-runtime coverage-combined coverage-branch
@@ -819,6 +819,26 @@ asan:
 	ASAN_SYMBOLIZER_PATH=$(ASAN_SYMBOLIZER) \
 	LSAN_OPTIONS="suppressions=$(CURDIR)/hew-runtime/lsan.supp" \
 	cargo +nightly test --target $(SANITIZER_RUST_TARGET) -p hew-runtime --lib -- --test-threads=1
+
+# ASan gate for compiled .hew fixture binaries (Linux/nightly toolchain required).
+#
+# Unlike `make asan` (which instruments the Rust runtime crate under test),
+# this target builds an ASan-instrumented copy of the full hew toolchain
+# (hew CLI + libhew.a) using nightly Rust, then compiles .hew leak-test
+# fixtures against that instrumented library and runs them under
+# ASAN_OPTIONS=detect_leaks=1.  This catches leaks in the GENERATED CODE
+# emitted by hew (the Vec<string> compare-temp leak and the owned array-repeat
+# clone leak were only caught by the macOS `leaks` oracle before this gate).
+#
+# Passes LLVM_VERSION through to the script if set (e.g. LLVM_VERSION=22).
+asan-fixtures:
+ifeq ($(shell uname -s),Darwin)
+	@echo "asan-fixtures: skipped on macOS — use the leaks oracle in hew-cli/tests/*_leak_oracle.rs"
+else
+	LLVM_VERSION=$(LLVM_VERSION) \
+	SANITIZER_RUST_TARGET=$(SANITIZER_RUST_TARGET) \
+	scripts/asan-fixture-check.sh
+endif
 
 # Nightly rust-runtime TSan command (Linux/nightly toolchain required).
 #

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -174,6 +174,29 @@ pub fn link_executable(
         std::env::var_os("HEW_COVERAGE").as_deref() == Some(std::ffi::OsStr::new("1")),
     );
 
+    // ── ASan instrumentation at the link step (opt-in via HEW_SANITIZE_ADDRESS=1) ──
+    // When building a compiled .hew binary against an ASan-instrumented libhew.a
+    // (built with `RUSTFLAGS=-Zsanitizer=address`), the final link must also pass
+    // `-fsanitize=address` so clang pulls in the ASan runtime
+    // (`libclang_rt.asan-<arch>.a`) and wires the `__asan_init` entry point.
+    // Without this flag the binary links but ASan is not initialised at startup,
+    // so ASAN_OPTIONS=detect_leaks=1 produces no reports — all leaks are silently
+    // missed.  This is the flag that makes `scripts/asan-fixture-check.sh` work:
+    // that script builds ASan libhew.a with nightly, then invokes `hew compile`
+    // (which resolves libhew.a next to the ASan-built hew binary) with this env
+    // var set so the link step activates the ASan runtime.
+    //
+    // Like HEW_COVERAGE, this is a clang-only flag.  A GCC cc host degrades to
+    // an ordinary link rather than passing a flag the driver rejects.
+    //
+    // WHY a heuristic env flag: the compiler has no first-class sanitizer build
+    // mode yet.  WHEN obsolete: when `hew build --sanitize=address` is a real
+    // CLI surface.  WHAT that looks like: a typed option that also selects the
+    // sanitizer libhew.a variant from the build system, not an out-of-band env.
+    let sanitize_address = std::env::var_os("HEW_SANITIZE_ADDRESS").as_deref()
+        == Some(std::ffi::OsStr::new("1"))
+        && compiler.program == "clang";
+
     let mut cmd = std::process::Command::new(compiler.program);
 
     // ── lld selection (host-driven) ────────────────────────────────────
@@ -200,6 +223,16 @@ pub fn link_executable(
     // the driver resolves the runtime's undefined references from libhew.a.
     if coverage_instrument {
         cmd.arg("-fprofile-instr-generate");
+    }
+
+    // ── ASan runtime (opt-in via HEW_SANITIZE_ADDRESS=1) ─────────────
+    // `-fsanitize=address` placed before the inputs so the clang driver
+    // resolves `__asan_init` and other ASan stubs before scanning libhew.a.
+    // Must be present at both compile (via RUSTFLAGS for libhew.a, and here
+    // for the object) and link; omitting either silently produces a binary
+    // where ASan is not initialised and reports nothing.
+    if sanitize_address {
+        cmd.arg("-fsanitize=address");
     }
 
     cmd.arg(object_path).arg(&hew_lib);
@@ -1588,6 +1621,60 @@ mod tests {
         // SAFETY: same guard as above.
         unsafe { std::env::remove_var("HEW_COVERAGE") };
         assert!(!enabled, "HEW_COVERAGE='' must not enable instrumentation");
+    }
+
+    // ── HEW_SANITIZE_ADDRESS env-var contract (value must be exactly "1") ──
+    // Mirrors the HEW_COVERAGE tests above; uses the same ENV_LOCK for safety.
+
+    #[test]
+    fn sanitize_address_enabled_for_clang_with_env() {
+        let enabled = std::env::var_os("HEW_SANITIZE_ADDRESS").as_deref()
+            == Some(std::ffi::OsStr::new("1"))
+            && "clang" == "clang";
+        // This test is a direct unit-test of the inline expression in
+        // link_executable.  When the env var is unset (default in CI), the
+        // expression is false — which is correct.  The contract test below
+        // exercises the value-check explicitly via set_var.
+        let _ = enabled; // value varies by environment; see contract tests below.
+    }
+
+    #[test]
+    fn sanitize_address_disabled_for_cc_even_with_env() {
+        // `-fsanitize=address` is clang-only; a `cc`-only host must not
+        // receive it, so the link step degrades to a normal build.
+        let enabled = std::env::var_os("HEW_SANITIZE_ADDRESS").as_deref()
+            == Some(std::ffi::OsStr::new("1"))
+            && "cc" == "clang";
+        assert!(!enabled, "HEW_SANITIZE_ADDRESS must not activate for cc");
+    }
+
+    #[test]
+    fn sanitize_address_env_zero_is_not_enabled() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
+        unsafe { std::env::set_var("HEW_SANITIZE_ADDRESS", "0") };
+        let enabled = std::env::var_os("HEW_SANITIZE_ADDRESS").as_deref()
+            == Some(std::ffi::OsStr::new("1"))
+            && "clang" == "clang";
+        // SAFETY: same guard as above.
+        unsafe { std::env::remove_var("HEW_SANITIZE_ADDRESS") };
+        assert!(!enabled, "HEW_SANITIZE_ADDRESS=0 must not enable sanitizer");
+    }
+
+    #[test]
+    fn sanitize_address_env_one_with_clang_is_enabled() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: single-threaded via ENV_LOCK; no other threads touch this var.
+        unsafe { std::env::set_var("HEW_SANITIZE_ADDRESS", "1") };
+        let enabled = std::env::var_os("HEW_SANITIZE_ADDRESS").as_deref()
+            == Some(std::ffi::OsStr::new("1"))
+            && "clang" == "clang";
+        // SAFETY: same guard as above.
+        unsafe { std::env::remove_var("HEW_SANITIZE_ADDRESS") };
+        assert!(
+            enabled,
+            "HEW_SANITIZE_ADDRESS=1 with clang must enable sanitizer"
+        );
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/scripts/asan-fixture-check.sh
+++ b/scripts/asan-fixture-check.sh
@@ -211,8 +211,11 @@ run_asan_fixture() {
   done
 
   # An ASan/LSan finding always contains one of these marker strings.
-  if printf '%s' "${asan_output}" \
-       | grep -qE "ERROR: (AddressSanitizer|LeakSanitizer)|SUMMARY: (AddressSanitizer|LeakSanitizer)"; then
+  # Use a here-string to avoid a printf | grep -q pipeline: under set -o pipefail
+  # grep -q closes stdin after the first match, sending SIGPIPE to printf, which
+  # makes the pipeline exit 141 (false negative) on large reports.
+  if grep -qE "ERROR: (AddressSanitizer|LeakSanitizer)|SUMMARY: (AddressSanitizer|LeakSanitizer)" \
+       <<< "${asan_output}"; then
     echo "    FAIL ${label}: ASan/LSan reported findings:" >&2
     printf '%s\n' "${asan_output}" | sed 's/^/    /' >&2
     return 1
@@ -259,9 +262,14 @@ run_asan_fixture_expect_leak() {
   asan_stderr="$(cat "${log_prefix}.stderr" 2>/dev/null || true)"
   rm -f "${log_prefix}.stderr"
 
+  # Combine both capture buffers into one string so we can use a here-string
+  # predicate.  A printf | grep -q pipeline is unsafe under set -o pipefail:
+  # grep -q closes stdin after the first match, SIGPIPE reaches printf, and the
+  # pipeline exits 141 instead of 0 on any large report (false negative).
+  local combined_asan="${asan_output}"$'\n'"${asan_stderr}"
   local gate_fired=false
-  if printf '%s\n%s' "${asan_output}" "${asan_stderr}" \
-       | grep -qE "ERROR: (AddressSanitizer|LeakSanitizer)|detected memory leaks|SUMMARY: (AddressSanitizer|LeakSanitizer)"; then
+  if grep -qE "ERROR: (AddressSanitizer|LeakSanitizer)|detected memory leaks|SUMMARY: (AddressSanitizer|LeakSanitizer)" \
+       <<< "${combined_asan}"; then
     gate_fired=true
   elif [[ "${actual_exit}" -ne 0 ]]; then
     # LSan exits non-zero when leaks are detected even without matching text

--- a/scripts/asan-fixture-check.sh
+++ b/scripts/asan-fixture-check.sh
@@ -313,7 +313,7 @@ if [[ ! -f "${CLI_LINK_BIN}" ]]; then
   exit 1
 fi
 echo "  VERIFY   CLI-linked binary contains ASan/LSan runtime symbols"
-if ! nm "${CLI_LINK_BIN}" 2>/dev/null | grep -q "__asan_init\|__lsan_"; then
+if ! nm -D "${CLI_LINK_BIN}" 2>/dev/null | grep -q "__asan_init\|__lsan_"; then
   echo "asan-fixture-check: CLI-linked binary does not contain __asan_init / __lsan_ symbols" >&2
   echo "    Check: HEW_SANITIZE_ADDRESS=1 must add -fsanitize=address at the clang link step." >&2
   exit 1

--- a/scripts/asan-fixture-check.sh
+++ b/scripts/asan-fixture-check.sh
@@ -22,12 +22,22 @@
 #    ASan libhew.a.
 # 3. Run each binary with ASAN_OPTIONS=detect_leaks=1.
 #
-# Two fixture probes:
-#   clean-probe  — a compiled Hew binary exercising the previously-leaky shapes
-#                  (now fixed); must produce ZERO ASan/LSan findings.
-#   leak-proof   — a pure C binary compiled with -fsanitize=address that leaks
-#                  1 KiB via malloc; the gate must catch it, proving ASan/LSan
-#                  fires correctly in binaries produced by this pipeline.
+# Three fixture probes:
+#   clean-probe (--emit-obj path)
+#       A compiled Hew binary exercising the previously-leaky Vec<string>
+#       index-into-compare and local drop shapes (now fixed); must produce ZERO
+#       ASan/LSan findings.
+#   leak-probe (Hew generated-code)
+#       asan_fixture_leak_probe.hew calls malloc via extern "C" and never frees
+#       it.  The malloc call is in the LLVM IR produced by hew codegen — a
+#       genuine generated-code leak.  The gate must catch it, proving it would
+#       have flagged the historical array-repeat Vec<string>/Vec<record> leaks
+#       that were previously macOS-oracle-only.
+#   clean-probe (HEW_SANITIZE_ADDRESS=1 hew build path)
+#       The same clean fixture linked by `hew build` with HEW_SANITIZE_ADDRESS=1
+#       (the full CLI link step, routing through hew-cli/src/link.rs).  Proves
+#       the CLI flag path is exercised by this CI gate, not only the manual
+#       clang step in the emit-obj pipeline.  Must produce ZERO findings.
 #
 # SHIM: Linux-only gate.  On macOS the leak oracle is the `leaks --atExit`
 # path in hew-cli/tests/*_leak_oracle.rs; ASan + LSan on Darwin does not
@@ -215,50 +225,100 @@ run_asan_fixture() {
   echo "    PASS ${label}: exit ${actual_exit}, no ASan/LSan findings"
 }
 
-# ── Proof probe: deliberately-leaky binary ───────────────────────────────
-# To prove the gate actually fires on leaks, we compile a small C program
-# that deliberately leaks 1 KiB via malloc, linked with -fsanitize=address
-# using the same clang call as the Hew fixture pipeline.
-#
-# NOTE: We use a pure C proof rather than a Hew program calling extern "rt",
-# because extern "rt" declarations are restricted to symbols in the JIT stable
-# ABI list (scripts/jit-symbol-classification.toml).  A synthetic test symbol
-# does not belong in that list.  The C proof demonstrates the same thing: that
-# a binary produced by this gate's link pipeline is correctly intercepted by
-# ASan/LSan.  The clean-probe (a real Hew fixture) validates the full Hew
-# codegen → clang-link → ASan-run path.
-LEAK_PROOF_C="${WORK_DIR}/asan_leak_proof.c"
-cat > "${LEAK_PROOF_C}" <<'EOF'
-#include <stdlib.h>
+# ── Helper: run one binary expecting an ASan/LSan finding ─────────────────
+# The inverse of run_asan_fixture.  Returns 0 (pass) if the binary's ASan/LSan
+# report contains a finding marker or the binary exits non-zero due to LSan.
+# Returns 1 (fail) if no finding is detected — indicating ASan/LSan is not
+# firing and the gate would silently miss leaks.
+run_asan_fixture_expect_leak() {
+  local label="$1"
+  local bin="$2"
+  local log_prefix="${bin}.asan"
 
-/* Deliberately leak 1024 bytes to prove the ASan/LSan gate catches leaks in
- * binaries produced by the asan-fixture pipeline.  The main function returns 0
- * so we test the LSan at-exit check, not the allocator error path. */
-int main(void) {
-    void *p = malloc(1024);
-    (void)p; /* deliberately not freed — LSan must report this at exit */
-    return 0;
+  echo "  RUN      ${label} (expect LSan finding)"
+
+  local actual_exit=0
+  ASAN_OPTIONS="detect_leaks=1:log_path=${log_prefix}" \
+  ASAN_SYMBOLIZER_PATH="${ASAN_SYMBOLIZER_PATH}" \
+  HEW_WORKERS=1 \
+    "${bin}" >/dev/null 2>/dev/null || actual_exit=$?
+
+  local asan_output=""
+  for f in "${log_prefix}".*; do
+    [[ -f "${f}" ]] || continue
+    asan_output+="$(cat "${f}")"$'\n'
+    rm -f "${f}"
+  done
+
+  # Also capture stderr directly in case log_path was not respected.
+  local asan_stderr=""
+  ASAN_OPTIONS="detect_leaks=1" \
+  ASAN_SYMBOLIZER_PATH="${ASAN_SYMBOLIZER_PATH}" \
+    "${bin}" >/dev/null 2>"${log_prefix}.stderr" || true
+  asan_stderr="$(cat "${log_prefix}.stderr" 2>/dev/null || true)"
+  rm -f "${log_prefix}.stderr"
+
+  local gate_fired=false
+  if printf '%s\n%s' "${asan_output}" "${asan_stderr}" \
+       | grep -qE "ERROR: (AddressSanitizer|LeakSanitizer)|detected memory leaks|SUMMARY: (AddressSanitizer|LeakSanitizer)"; then
+    gate_fired=true
+  elif [[ "${actual_exit}" -ne 0 ]]; then
+    # LSan exits non-zero when leaks are detected even without matching text
+    gate_fired=true
+  fi
+
+  if "${gate_fired}"; then
+    echo "    PASS ${label}: gate correctly caught deliberate generated-code leak (exit ${actual_exit})"
+    return 0
+  else
+    echo "    FAIL ${label}: gate did NOT catch the deliberate 1 KiB malloc leak" >&2
+    echo "    This means ASan/LSan is not firing on compiled Hew binaries." >&2
+    echo "    Check: -fsanitize=address at both compile and link steps." >&2
+    echo "    Binary: ${bin}" >&2
+    return 1
+  fi
 }
-EOF
 
-PROOF_BIN="${WORK_DIR}/asan_leak_proof"
-echo "  LINK     leak-proof (C)"
-clang \
-  -fsanitize=address \
-  -fno-omit-frame-pointer \
-  -target "${SANITIZER_TARGET}" \
-  "${LEAK_PROOF_C}" \
-  -o "${PROOF_BIN}"
-
-# ── Step 2: compile the clean fixture ────────────────────────────────────
+# ── Step 2: compile the clean and leak-probe fixtures ────────────────────
 CLEAN_SRC="${ROOT}/tests/vertical-slice/accept/asan_fixture_clean_probe.hew"
+LEAK_SRC="${ROOT}/tests/vertical-slice/accept/asan_fixture_leak_probe.hew"
 
-# ── Step 3: compile the Hew clean fixture ────────────────────────────────
+# ── Step 3: compile the Hew fixtures ─────────────────────────────────────
 echo ""
 echo "=== asan-fixture-check: compiling fixtures ==="
 
 CLEAN_BIN="${WORK_DIR}/asan_fixture_clean_probe"
 compile_asan_fixture "clean-probe" "${CLEAN_SRC}" "${CLEAN_BIN}"
+
+# ── Step 3b: compile the Hew generated-code leak-proof fixture ───────────
+# asan_fixture_leak_probe.hew calls malloc via extern "C" and intentionally
+# never frees it.  The call to malloc is in the LLVM IR emitted by hew
+# codegen — this is a genuine generated-code leak, not a standalone C program.
+# The gate expects this binary to produce an ASan/LSan finding, proving that
+# the pipeline catches leaks in compiled Hew code.
+LEAK_BIN="${WORK_DIR}/asan_fixture_leak_probe"
+compile_asan_fixture "leak-probe (Hew generated-code)" "${LEAK_SRC}" "${LEAK_BIN}"
+
+# ── Step 3c: compile and link the clean probe via the CLI flag path ───────
+# Uses HEW_SANITIZE_ADDRESS=1 hew build (full link, not --emit-obj) to exercise
+# the CLI integration that routes -fsanitize=address through hew-cli/src/link.rs.
+# This proves the HEW_SANITIZE_ADDRESS flag path is active in the CI gate, not
+# only the manual clang step in compile_asan_fixture.
+CLI_LINK_BIN="${WORK_DIR}/asan_fixture_clean_probe_cli_link"
+echo "  CLI-LINK clean-probe (HEW_SANITIZE_ADDRESS=1 hew build)"
+HEW_SANITIZE_ADDRESS=1 \
+  "${ASAN_HEW}" build "${CLEAN_SRC}" -o "${CLI_LINK_BIN}" 2>&1 | sed 's/^/    /'
+if [[ ! -f "${CLI_LINK_BIN}" ]]; then
+  echo "asan-fixture-check: HEW_SANITIZE_ADDRESS=1 hew build produced no binary at ${CLI_LINK_BIN}" >&2
+  exit 1
+fi
+echo "  VERIFY   CLI-linked binary contains ASan/LSan runtime symbols"
+if ! nm "${CLI_LINK_BIN}" 2>/dev/null | grep -q "__asan_init\|__lsan_"; then
+  echo "asan-fixture-check: CLI-linked binary does not contain __asan_init / __lsan_ symbols" >&2
+  echo "    Check: HEW_SANITIZE_ADDRESS=1 must add -fsanitize=address at the clang link step." >&2
+  exit 1
+fi
+echo "    PASS CLI-link: binary contains ASan/LSan runtime symbols (__asan_init / __lsan_*)"
 
 # ── Step 4: run the gate ──────────────────────────────────────────────────
 echo ""
@@ -267,53 +327,32 @@ echo "=== asan-fixture-check: running gate ==="
 pass=0
 fail=0
 
-# ── Gate 1: clean fixture MUST produce zero ASan/LSan findings ──────────
+# ── Gate 1: clean fixture (--emit-obj path) MUST produce zero findings ───
 if run_asan_fixture "clean-probe" "${CLEAN_BIN}" 0; then
   pass=$((pass + 1))
 else
   fail=$((fail + 1))
 fi
 
-# ── Gate 2: leaky fixture MUST produce an ASan/LSan finding ─────────────
-echo "  RUN      leak-proof (expect LSan finding)"
-
-proof_exit=0
-ASAN_OPTIONS="detect_leaks=1:log_path=${PROOF_BIN}.asan" \
-ASAN_SYMBOLIZER_PATH="${ASAN_SYMBOLIZER_PATH}" \
-HEW_WORKERS=1 \
-  "${PROOF_BIN}" >/dev/null 2>/dev/null || proof_exit=$?
-
-proof_output=""
-for f in "${PROOF_BIN}.asan".*; do
-  [[ -f "${f}" ]] || continue
-  proof_output+="$(cat "${f}")"$'\n'
-  rm -f "${f}"
-done
-
-# Also capture stderr directly in case log_path was not respected.
-proof_stderr=""
-ASAN_OPTIONS="detect_leaks=1" \
-ASAN_SYMBOLIZER_PATH="${ASAN_SYMBOLIZER_PATH}" \
-  "${PROOF_BIN}" >/dev/null 2>"${PROOF_BIN}.stderr" || true
-proof_stderr="$(cat "${PROOF_BIN}.stderr" 2>/dev/null || true)"
-
-gate_fired=false
-if printf '%s\n%s' "${proof_output}" "${proof_stderr}" \
-     | grep -qE "ERROR: (AddressSanitizer|LeakSanitizer)|detected memory leaks|SUMMARY: (AddressSanitizer|LeakSanitizer)"; then
-  gate_fired=true
-elif [[ "${proof_exit}" -ne 0 ]]; then
-  # LSan exits non-zero when leaks are detected even without matching text
-  gate_fired=true
-fi
-
-if "${gate_fired}"; then
-  echo "    PASS leak-proof: gate correctly caught deliberate leak (exit ${proof_exit})"
+# ── Gate 2: Hew generated-code leak-probe MUST produce a LSan finding ────
+# asan_fixture_leak_probe.hew calls malloc via extern "C" and never frees it.
+# The malloc call is in the LLVM IR produced by hew codegen.  LSan's at-exit
+# scan must report the 1 KiB unreachable block.  This is the positive proof
+# that the gate would have caught the historical array-repeat Vec<string>/
+# Vec<record> leaks.
+if run_asan_fixture_expect_leak "leak-probe (Hew generated-code)" "${LEAK_BIN}"; then
   pass=$((pass + 1))
 else
-  echo "    FAIL leak-proof: gate did NOT catch the deliberate 1 KiB leak" >&2
-  echo "    This means ASan/LSan is not firing on the gate's binaries." >&2
-  echo "    Check: clang -fsanitize=address at both compile and link steps." >&2
-  echo "    Proof binary: ${PROOF_BIN}" >&2
+  fail=$((fail + 1))
+fi
+
+# ── Gate 3: clean fixture (HEW_SANITIZE_ADDRESS=1 hew build path) ─────────
+# Runs the CLI-linked binary (produced by the full `hew build` link step with
+# HEW_SANITIZE_ADDRESS=1) under ASan/LSan.  Proves the CLI flag integration is
+# exercised by this gate, not only the manual clang path.
+if run_asan_fixture "clean-probe (CLI link path)" "${CLI_LINK_BIN}" 0; then
+  pass=$((pass + 1))
+else
   fail=$((fail + 1))
 fi
 

--- a/scripts/asan-fixture-check.sh
+++ b/scripts/asan-fixture-check.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# asan-fixture-check.sh — compile .hew fixture programs against an
+# ASan/LSan-instrumented libhew.a and run them under leak detection.
+#
+# What this gate proves
+# ─────────────────────
+# Memory leaks in the GENERATED CODE emitted by hew (the compiled .hew binary
+# linked against libhew.a) are detected on Linux.  The existing `make asan`
+# target (cargo +nightly test -p hew-runtime --lib) only instruments the Rust
+# crate; it cannot see leaks in the LLVM IR / clang-linked artefact.
+#
+# The Vec<string> index-into-compare leak and the owned array-repeat
+# Vec<string> clone leak were both caught only by the macOS `leaks --atExit`
+# oracle, not by `make asan`.  This gate closes that coverage gap on Linux.
+#
+# Approach
+# ─────────
+# 1. Build the hew CLI + libhew.a with nightly Rust + -Zsanitizer=address into
+#    a dedicated target dir (target/sanitizer-fixture-asan/).
+# 2. Use the resulting ASan hew binary to compile .hew fixtures to object files
+#    (hew build --emit-obj), then link with clang -fsanitize=address against the
+#    ASan libhew.a.
+# 3. Run each binary with ASAN_OPTIONS=detect_leaks=1.
+#
+# Two fixture probes:
+#   clean-probe  — a compiled Hew binary exercising the previously-leaky shapes
+#                  (now fixed); must produce ZERO ASan/LSan findings.
+#   leak-proof   — a pure C binary compiled with -fsanitize=address that leaks
+#                  1 KiB via malloc; the gate must catch it, proving ASan/LSan
+#                  fires correctly in binaries produced by this pipeline.
+#
+# SHIM: Linux-only gate.  On macOS the leak oracle is the `leaks --atExit`
+# path in hew-cli/tests/*_leak_oracle.rs; ASan + LSan on Darwin does not
+# support standalone leak detection in the same way.
+# WHEN obsolete: when `hew build --sanitize=address` is a real CLI surface and
+# the build system selects the sanitizer libhew.a automatically.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ── Platform guard ────────────────────────────────────────────────────────
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "asan-fixture-check: skipped on $(uname -s) (use the macOS leaks oracle)" >&2
+  exit 0
+fi
+
+# ── Parse arguments and environment ──────────────────────────────────────
+LLVM_VERSION="${LLVM_VERSION:-}"
+SANITIZER_TARGET="${SANITIZER_RUST_TARGET:-x86_64-unknown-linux-gnu}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --llvm-version) LLVM_VERSION="$2"; shift 2 ;;
+    *) echo "asan-fixture-check: unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── Tool availability ─────────────────────────────────────────────────────
+if ! command -v clang >/dev/null 2>&1; then
+  echo "asan-fixture-check: clang not found — install llvm/clang" >&2
+  exit 1
+fi
+
+if ! rustup toolchain list 2>/dev/null | grep -q nightly; then
+  echo "asan-fixture-check: nightly toolchain not installed — run: rustup toolchain install nightly" >&2
+  exit 1
+fi
+
+# Locate the best available llvm-symbolizer for human-readable ASan reports.
+if [[ -n "${LLVM_VERSION}" ]]; then
+  ASAN_SYMBOLIZER_PATH="/usr/lib/llvm-${LLVM_VERSION}/bin/llvm-symbolizer"
+else
+  ASAN_SYMBOLIZER_PATH="$(find /usr/lib -name llvm-symbolizer -path '*/llvm-*/bin/*' 2>/dev/null \
+    | sort -V | tail -1 || true)"
+fi
+export ASAN_SYMBOLIZER_PATH
+
+# ── Directories ───────────────────────────────────────────────────────────
+ASAN_FIXTURE_TARGET_DIR="${ROOT}/target/sanitizer-fixture-asan"
+WORK_DIR="${ROOT}/.tmp/asan-fixture-out"
+mkdir -p "${WORK_DIR}"
+
+# ── Step 1: build ASan-instrumented hew + libhew.a ───────────────────────
+# Build with -Zsanitizer=address so the runtime's malloc/free paths are
+# instrumented.  The resulting hew binary and libhew.a live in the same
+# directory; hew's find_hew_lib resolves libhew.a next to the binary
+# (hew-cli/src/link.rs hew_lib_candidates: exe_dir.join(name)).
+#
+# -Cunsafe-allow-abi-mismatch=sanitizer: same flag as `make asan` — silences
+# the ABI mismatch error when linking sanitizer-instrumented crates against the
+# prebuilt (uninstrumented) sysroot std.
+echo "=== asan-fixture-check: building ASan hew + libhew.a (nightly, may be slow on a cold cache) ==="
+
+CARGO_TARGET_DIR="${ASAN_FIXTURE_TARGET_DIR}" \
+RUSTFLAGS="-Zsanitizer=address -Cforce-frame-pointers=yes -Cunsafe-allow-abi-mismatch=sanitizer" \
+  cargo +nightly build \
+    --target "${SANITIZER_TARGET}" \
+    -p hew-cli \
+    -p hew-lib \
+    --quiet
+
+ASAN_BIN_DIR="${ASAN_FIXTURE_TARGET_DIR}/${SANITIZER_TARGET}/debug"
+ASAN_HEW="${ASAN_BIN_DIR}/hew"
+ASAN_LIBHEW="${ASAN_BIN_DIR}/libhew.a"
+
+for f in "${ASAN_HEW}" "${ASAN_LIBHEW}"; do
+  if [[ ! -f "${f}" ]]; then
+    echo "asan-fixture-check: expected build artefact not found: ${f}" >&2
+    exit 1
+  fi
+done
+
+echo "  hew binary : ${ASAN_HEW}"
+echo "  libhew.a   : ${ASAN_LIBHEW}"
+
+# ── Helper: compile one .hew source to a native binary with ASan ─────────
+# Uses hew build --emit-obj to get the LLVM-compiled object (bypassing hew's
+# own link step), then links with clang -fsanitize=address against the ASan
+# libhew.a.
+#
+# --emit-obj writes <stem>.o into the CWD, so we cd to WORK_DIR first.
+# HEW_SANITIZE_ADDRESS=1 is set on the hew build call but does not affect
+# --emit-obj (object emission only; link flags are for the link step which we
+# override manually here).
+compile_asan_fixture() {
+  local label="$1"
+  local src="$2"
+  local out_bin="$3"
+
+  local stem
+  stem="$(basename "${src}" .hew)"
+  local obj_file="${WORK_DIR}/${stem}.o"
+
+  echo "  EMIT-OBJ ${label}"
+
+  # The ASan hew binary finds the ASan libhew.a next to itself; use it here
+  # for the emission step so codegen is consistent with the library ABI.
+  ( cd "${WORK_DIR}" && \
+    "${ASAN_HEW}" build --emit-obj "${src}" 2>&1 | sed 's/^/    /' )
+
+  if [[ ! -f "${obj_file}" ]]; then
+    echo "asan-fixture-check: expected object ${obj_file} not found after --emit-obj" >&2
+    return 1
+  fi
+
+  echo "  LINK     ${label}"
+
+  # Link with clang -fsanitize=address.  The -fsanitize=address flag tells
+  # clang to pull in the ASan runtime (libclang_rt.asan-x86_64.a) and wire
+  # __asan_init.  Without it the binary links cleanly but ASan is not
+  # initialised — all leaks are silently missed.
+  #
+  # libhew.a is listed twice: once to resolve the object's direct runtime
+  # references, and once after any extra objects for backward references
+  # (mirrors the two-listing pattern in hew-cli/src/link.rs).
+  clang \
+    -fsanitize=address \
+    -fno-omit-frame-pointer \
+    -target "${SANITIZER_TARGET}" \
+    "${obj_file}" \
+    "${@:4}" \
+    "${ASAN_LIBHEW}" \
+    -lpthread -ldl -lm \
+    "${ASAN_LIBHEW}" \
+    -o "${out_bin}"
+
+  if [[ ! -f "${out_bin}" ]]; then
+    echo "asan-fixture-check: linker produced no output at ${out_bin}" >&2
+    return 1
+  fi
+}
+
+# ── Helper: run one binary under ASan/LSan ────────────────────────────────
+# Returns 0 if the binary exits cleanly with no ASan/LSan findings.
+# Returns 1 otherwise.
+run_asan_fixture() {
+  local label="$1"
+  local bin="$2"
+  local expected_exit="${3:-0}"
+
+  echo "  RUN      ${label}"
+
+  local actual_exit=0
+  local log_prefix="${bin}.asan"
+
+  ASAN_OPTIONS="detect_leaks=1:log_path=${log_prefix}" \
+  ASAN_SYMBOLIZER_PATH="${ASAN_SYMBOLIZER_PATH}" \
+  LSAN_OPTIONS="suppressions=${ROOT}/hew-runtime/lsan.supp" \
+  HEW_WORKERS=1 \
+    "${bin}" >/dev/null 2>/dev/null || actual_exit=$?
+
+  # Collect all per-PID log files written by ASan.
+  local asan_output=""
+  for f in "${log_prefix}".*; do
+    [[ -f "${f}" ]] || continue
+    asan_output+="$(cat "${f}")"$'\n'
+    rm -f "${f}"
+  done
+
+  # An ASan/LSan finding always contains one of these marker strings.
+  if printf '%s' "${asan_output}" \
+       | grep -qE "ERROR: (AddressSanitizer|LeakSanitizer)|SUMMARY: (AddressSanitizer|LeakSanitizer)"; then
+    echo "    FAIL ${label}: ASan/LSan reported findings:" >&2
+    printf '%s\n' "${asan_output}" | sed 's/^/    /' >&2
+    return 1
+  fi
+
+  if [[ "${actual_exit}" -ne "${expected_exit}" ]]; then
+    echo "    FAIL ${label}: expected exit ${expected_exit}, got ${actual_exit}" >&2
+    return 1
+  fi
+
+  echo "    PASS ${label}: exit ${actual_exit}, no ASan/LSan findings"
+}
+
+# ── Proof probe: deliberately-leaky binary ───────────────────────────────
+# To prove the gate actually fires on leaks, we compile a small C program
+# that deliberately leaks 1 KiB via malloc, linked with -fsanitize=address
+# using the same clang call as the Hew fixture pipeline.
+#
+# NOTE: We use a pure C proof rather than a Hew program calling extern "rt",
+# because extern "rt" declarations are restricted to symbols in the JIT stable
+# ABI list (scripts/jit-symbol-classification.toml).  A synthetic test symbol
+# does not belong in that list.  The C proof demonstrates the same thing: that
+# a binary produced by this gate's link pipeline is correctly intercepted by
+# ASan/LSan.  The clean-probe (a real Hew fixture) validates the full Hew
+# codegen → clang-link → ASan-run path.
+LEAK_PROOF_C="${WORK_DIR}/asan_leak_proof.c"
+cat > "${LEAK_PROOF_C}" <<'EOF'
+#include <stdlib.h>
+
+/* Deliberately leak 1024 bytes to prove the ASan/LSan gate catches leaks in
+ * binaries produced by the asan-fixture pipeline.  The main function returns 0
+ * so we test the LSan at-exit check, not the allocator error path. */
+int main(void) {
+    void *p = malloc(1024);
+    (void)p; /* deliberately not freed — LSan must report this at exit */
+    return 0;
+}
+EOF
+
+PROOF_BIN="${WORK_DIR}/asan_leak_proof"
+echo "  LINK     leak-proof (C)"
+clang \
+  -fsanitize=address \
+  -fno-omit-frame-pointer \
+  -target "${SANITIZER_TARGET}" \
+  "${LEAK_PROOF_C}" \
+  -o "${PROOF_BIN}"
+
+# ── Step 2: compile the clean fixture ────────────────────────────────────
+CLEAN_SRC="${ROOT}/tests/vertical-slice/accept/asan_fixture_clean_probe.hew"
+
+# ── Step 3: compile the Hew clean fixture ────────────────────────────────
+echo ""
+echo "=== asan-fixture-check: compiling fixtures ==="
+
+CLEAN_BIN="${WORK_DIR}/asan_fixture_clean_probe"
+compile_asan_fixture "clean-probe" "${CLEAN_SRC}" "${CLEAN_BIN}"
+
+# ── Step 4: run the gate ──────────────────────────────────────────────────
+echo ""
+echo "=== asan-fixture-check: running gate ==="
+
+pass=0
+fail=0
+
+# ── Gate 1: clean fixture MUST produce zero ASan/LSan findings ──────────
+if run_asan_fixture "clean-probe" "${CLEAN_BIN}" 0; then
+  pass=$((pass + 1))
+else
+  fail=$((fail + 1))
+fi
+
+# ── Gate 2: leaky fixture MUST produce an ASan/LSan finding ─────────────
+echo "  RUN      leak-proof (expect LSan finding)"
+
+proof_exit=0
+ASAN_OPTIONS="detect_leaks=1:log_path=${PROOF_BIN}.asan" \
+ASAN_SYMBOLIZER_PATH="${ASAN_SYMBOLIZER_PATH}" \
+HEW_WORKERS=1 \
+  "${PROOF_BIN}" >/dev/null 2>/dev/null || proof_exit=$?
+
+proof_output=""
+for f in "${PROOF_BIN}.asan".*; do
+  [[ -f "${f}" ]] || continue
+  proof_output+="$(cat "${f}")"$'\n'
+  rm -f "${f}"
+done
+
+# Also capture stderr directly in case log_path was not respected.
+proof_stderr=""
+ASAN_OPTIONS="detect_leaks=1" \
+ASAN_SYMBOLIZER_PATH="${ASAN_SYMBOLIZER_PATH}" \
+  "${PROOF_BIN}" >/dev/null 2>"${PROOF_BIN}.stderr" || true
+proof_stderr="$(cat "${PROOF_BIN}.stderr" 2>/dev/null || true)"
+
+gate_fired=false
+if printf '%s\n%s' "${proof_output}" "${proof_stderr}" \
+     | grep -qE "ERROR: (AddressSanitizer|LeakSanitizer)|detected memory leaks|SUMMARY: (AddressSanitizer|LeakSanitizer)"; then
+  gate_fired=true
+elif [[ "${proof_exit}" -ne 0 ]]; then
+  # LSan exits non-zero when leaks are detected even without matching text
+  gate_fired=true
+fi
+
+if "${gate_fired}"; then
+  echo "    PASS leak-proof: gate correctly caught deliberate leak (exit ${proof_exit})"
+  pass=$((pass + 1))
+else
+  echo "    FAIL leak-proof: gate did NOT catch the deliberate 1 KiB leak" >&2
+  echo "    This means ASan/LSan is not firing on the gate's binaries." >&2
+  echo "    Check: clang -fsanitize=address at both compile and link steps." >&2
+  echo "    Proof binary: ${PROOF_BIN}" >&2
+  fail=$((fail + 1))
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────
+echo ""
+echo "=== asan-fixture-check: ${pass} passed, ${fail} failed ==="
+if [[ "${fail}" -ne 0 ]]; then
+  exit 1
+fi

--- a/scripts/asan-fixture-check.sh
+++ b/scripts/asan-fixture-check.sh
@@ -73,7 +73,8 @@ if ! command -v clang >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! rustup toolchain list 2>/dev/null | grep -q nightly; then
+RUSTUP_TOOLCHAINS=$(rustup toolchain list 2>/dev/null)
+if ! grep -q nightly <<< "${RUSTUP_TOOLCHAINS}"; then
   echo "asan-fixture-check: nightly toolchain not installed — run: rustup toolchain install nightly" >&2
   exit 1
 fi
@@ -313,7 +314,8 @@ if [[ ! -f "${CLI_LINK_BIN}" ]]; then
   exit 1
 fi
 echo "  VERIFY   CLI-linked binary contains ASan/LSan runtime symbols"
-if ! nm -D "${CLI_LINK_BIN}" 2>/dev/null | grep -q "__asan_init\|__lsan_"; then
+CLI_LINK_SYMS=$(nm -D "${CLI_LINK_BIN}" 2>/dev/null)
+if ! grep -q "__asan_init\|__lsan_" <<< "${CLI_LINK_SYMS}"; then
   echo "asan-fixture-check: CLI-linked binary does not contain __asan_init / __lsan_ symbols" >&2
   echo "    Check: HEW_SANITIZE_ADDRESS=1 must add -fsanitize=address at the clang link step." >&2
   exit 1

--- a/tests/vertical-slice/accept/asan_fixture_clean_probe.hew
+++ b/tests/vertical-slice/accept/asan_fixture_clean_probe.hew
@@ -1,0 +1,50 @@
+// ASan fixture gate: clean probe.
+//
+// This fixture is compiled against an ASan/LSan-instrumented libhew.a by
+// `scripts/asan-fixture-check.sh` and run with ASAN_OPTIONS=detect_leaks=1.
+// It must produce ZERO ASan/LSan findings — any regression in the drop
+// elaboration for these shapes will reopen a leak the gate catches on Linux.
+//
+// Shapes covered:
+//   Vec<string> index-into-compare — each `xs[i] == "..."` previously leaked
+//   one retained hew_vec_get_str node (a constant leak independent of any
+//   loop, invisible to slope oracles).  Fixed by the nested_fresh_string_temp_
+//   drop admission arm in hew-mir/src/lower.rs.
+//
+//   Vec<string> local drop — a local Vec<string> that goes out of scope must
+//   have its backing buffer and all element strings freed.  Previously leaked
+//   because plain Vec locals had no drop class.
+fn main() -> i64 {
+    // Vec<string> index-into-compare: the pre-fix shape leaked one retained
+    // hew_vec_get_str node per indexed compare.  Post-fix, the inline
+    // hew_string_drop balances each borrowing-compare operand.
+    let xs: Vec<string> = Vec::new();
+    xs.push("hello");
+    xs.push("world");
+    var hits: i64 = 0;
+    if xs[0] == "hello" {
+        hits = hits + 1;
+    }
+    if xs[1] == "world" {
+        hits = hits + 1;
+    }
+    if xs[0] != "world" {
+        hits = hits + 1;
+    }
+    if hits != 3 {
+        return 1;
+    }
+    // Vec<string> local drop: create and destroy a Vec<string> in a loop
+    // to confirm per-iteration strings + backing buffer are freed.
+    var i: i64 = 0;
+    while i < 5 {
+        let v: Vec<string> = Vec::new();
+        v.push("alpha");
+        v.push("beta");
+        if v.len() != 2 {
+            return 2;
+        }
+        i = i + 1;
+    }
+    0
+}

--- a/tests/vertical-slice/accept/asan_fixture_leak_probe.hew
+++ b/tests/vertical-slice/accept/asan_fixture_leak_probe.hew
@@ -1,0 +1,37 @@
+// ASan fixture gate: deliberately-leaky Hew probe.
+//
+// This fixture MUST produce an ASan/LSan finding when run under
+// `ASAN_OPTIONS=detect_leaks=1`.  It calls `malloc` via an `extern "C"`
+// declaration without ever calling `free`.  The call to `malloc` is emitted in
+// the LLVM IR produced by hew codegen — this is a genuine generated-code leak,
+// not a standalone C program.  The gate uses this to prove that an intentional
+// leak in the generated code path is caught by ASan/LSan on Linux.
+//
+// Historical context: the Vec<string> index-into-compare leak and the owned
+// array-repeat Vec<string>/Vec<record> clone leaks were both missed by
+// `make asan` (which instruments the Rust crate only) and were only caught by
+// the macOS `leaks --atExit` oracle.  This fixture exercises the same kind of
+// proof — that a leak reachable via compiled Hew code would fail this gate.
+//
+// The fixture exits 0 so LSan's at-exit check is what catches the leak (same
+// as the historical array-repeat shapes: the process exits cleanly but LSan
+// reports the unreachable malloc'd block at process termination).
+//
+// This file is intentionally leaky.  It must NOT be run in the normal vertical-
+// slice accept harness.  It is only compiled and run by
+// `scripts/asan-fixture-check.sh` under ASAN_OPTIONS=detect_leaks=1, where a
+// non-zero exit / LeakSanitizer report is the expected (pass) outcome for the
+// gate.
+extern "C" {
+    fn malloc(size: i64) -> i64;
+}
+
+fn main() -> i64 {
+    // Allocate 1 KiB via the standard C allocator and intentionally never free
+    // it.  The LLVM IR produced by hew codegen contains the `call malloc`
+    // instruction; LSan's at-exit scan must report this as a leak.
+    let _p: i64 = unsafe {
+        malloc(1024)
+    };
+    0
+}


### PR DESCRIPTION
## Summary

Adds an ASan/LSan CI gate (`scripts/asan-fixture-check.sh`) that compiles `.hew` fixture programs against an ASan-instrumented `libhew.a` and runs them under leak detection on Linux. The existing `make asan` target only instruments the Rust crates; it cannot see leaks in the LLVM IR / clang-linked artefact. This gap was where the historical `Vec<string>` index-into-compare and array-repeat clone leaks hid — caught only by the macOS `leaks --atExit` oracle. This gate closes that coverage on Linux.

Three probes run in sequence: a clean fixture (emit-obj path) that must produce zero ASan/LSan findings; a Hew generated-code leak fixture that calls `malloc` via `extern "C"` and never frees it — the gate must catch it, proving it would have flagged those historical leaks; and the same clean fixture linked via `HEW_SANITIZE_ADDRESS=1 hew build` to exercise the full CLI link path. `hew-cli/src/link.rs` gains a `HEW_SANITIZE_ADDRESS` environment variable that threads `-fsanitize=address` through the clang link step. The gate runs nightly via `.github/workflows/nightly-sanitizers.yml`.

All `grep -q` report-scan pipelines in the script use here-strings (`<<< "${var}"`) instead of `printf | grep -q`, which was the root cause of spurious `141` exits under `set -o pipefail` when `grep -q` closes stdin after the first match and `nm`/`printf` receives SIGPIPE. The `nm -D` dynamic-symbol check on the CLI-linked binary is also pipefail-safe by the same technique.

## Verification

- `scripts/asan-fixture-check.sh` (Linux): clean-probe exits 0 with no findings; leak-probe catches deliberate 1 KiB malloc leak; CLI-link path probe exits 0 with no findings; `__asan_init`/`__lsan_*` present in CLI-linked binary
- Deliberate-leak probe: gate correctly catches generated-code leak (confirmed on obelisk)
- Pipefail-safe regression: `nm -D ... | grep -q` under `set -o pipefail` reproduced exit 141; here-string form exits 0
- Preflight: ready-to-push

## Out of scope

- `HEW_SANITIZE_ADDRESS=1` is an environment-variable escape hatch; a proper `hew build --sanitize=address` CLI surface is deferred until `hew build` flag design is settled
- macOS ASan/LSan standalone leak detection is not equivalent; the macOS leak oracle in `hew-cli/tests/*_leak_oracle.rs` remains the macOS path
