### PR TITLE
fix(runtime): emit diagnostics for traps in main context and name actor handler on crash

### DIFF
--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -267,21 +267,22 @@ fn eval_result_to_json(
             //    behaviour for arithmetic traps): synthesise a user-facing message
             //    into both `stderr` and `diagnostics`.
             // 2. Child wrote a runtime-internal diagnostic to stderr AND was
-            //    killed by a signal (F1.3 path: `hew_trap_with_code` emits
-            //    "hew: trap in main context: …" before the process dies via the
-            //    default SIGILL handler). Preserve the child's stderr but also
-            //    synthesise a user-facing description into `diagnostics` so the
-            //    JSON contract's cause field is never empty for signal-killed
-            //    programs.
+            //    killed by a signal (Unix F1.3 path) OR the stderr begins with
+            //    the "hew: trap in main context:" prefix (Windows F1.3 path —
+            //    no Unix signal is available, but the cause is named in stderr
+            //    and the NTSTATUS exit code maps via describe_runtime_failure).
+            //    Preserve the child's stderr but also synthesise a user-facing
+            //    description into `diagnostics` so the JSON contract's cause
+            //    field is never empty for runtime-trap programs on any platform.
             // 3. Child exited with a non-zero code (e.g. `panic()` → exit 101)
             //    and wrote its own stderr: preserve both, keep `diagnostics`
             //    empty (the child's message IS the diagnostic).
             let (stderr, diagnostics) = if stderr.is_empty() {
                 let synth = format!("{}\n", repl::describe_runtime_failure(exit_code, signal));
                 (synth.clone(), synth)
-            } else if signal.is_some() {
-                // Signal-killed with child-written stderr: synthesise the
-                // user-facing description for `diagnostics`.
+            } else if signal.is_some() || repl::is_runtime_trap_stderr(&stderr) {
+                // Signal-killed (Unix) or runtime-trap stderr (Windows): synthesise
+                // the user-facing description for `diagnostics`.
                 let synth = format!("{}\n", repl::describe_runtime_failure(exit_code, signal));
                 (stderr, synth)
             } else {

--- a/hew-cli/src/eval/mod.rs
+++ b/hew-cli/src/eval/mod.rs
@@ -260,14 +260,30 @@ fn eval_result_to_json(
             exit_code,
             signal,
         }) => {
-            // When the child died without writing stderr (e.g. a signal-killed
-            // arithmetic trap), synthesise a message so the JSON contract's
-            // `stderr` and `diagnostics` are not both silently empty. A child
-            // that DID write stderr keeps its own message and an empty
-            // `diagnostics`, preserving the panic-path contract.
+            // Determine the stderr and diagnostics fields for the JSON output.
+            //
+            // Three cases:
+            // 1. Child wrote nothing to stderr and was signal-killed (pre-F1.3
+            //    behaviour for arithmetic traps): synthesise a user-facing message
+            //    into both `stderr` and `diagnostics`.
+            // 2. Child wrote a runtime-internal diagnostic to stderr AND was
+            //    killed by a signal (F1.3 path: `hew_trap_with_code` emits
+            //    "hew: trap in main context: …" before the process dies via the
+            //    default SIGILL handler). Preserve the child's stderr but also
+            //    synthesise a user-facing description into `diagnostics` so the
+            //    JSON contract's cause field is never empty for signal-killed
+            //    programs.
+            // 3. Child exited with a non-zero code (e.g. `panic()` → exit 101)
+            //    and wrote its own stderr: preserve both, keep `diagnostics`
+            //    empty (the child's message IS the diagnostic).
             let (stderr, diagnostics) = if stderr.is_empty() {
                 let synth = format!("{}\n", repl::describe_runtime_failure(exit_code, signal));
                 (synth.clone(), synth)
+            } else if signal.is_some() {
+                // Signal-killed with child-written stderr: synthesise the
+                // user-facing description for `diagnostics`.
+                let synth = format!("{}\n", repl::describe_runtime_failure(exit_code, signal));
+                (stderr, synth)
             } else {
                 (stderr, String::new())
             };

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -243,9 +243,18 @@ pub(crate) fn emit_runtime_failure_output(
         print!("{stdout}");
     }
     if stderr.is_empty() {
-        // The child died without saying why (e.g. a signal-killed arithmetic
-        // trap). Synthesise an explanation so the failure is not silent.
+        // The child died silently (e.g. classic signal-killed arithmetic trap
+        // with no stderr). Synthesise an explanation.
         eprintln!("{}", describe_runtime_failure(exit_code, signal));
+    } else if signal.is_some() {
+        // Child was killed by a signal AND wrote a runtime-internal diagnostic
+        // to stderr (F1.3 path: `hew_trap_with_code` emits "hew: trap in main
+        // context: …" before the default signal handler terminates the process).
+        // Emit the synthesised user-facing description first so the output
+        // always contains "runtime error" and the named cause, then forward
+        // the child's raw diagnostic for additional context.
+        eprintln!("{}", describe_runtime_failure(exit_code, signal));
+        eprint!("{stderr}");
     } else {
         eprint!("{stderr}");
     }

--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -246,18 +246,40 @@ pub(crate) fn emit_runtime_failure_output(
         // The child died silently (e.g. classic signal-killed arithmetic trap
         // with no stderr). Synthesise an explanation.
         eprintln!("{}", describe_runtime_failure(exit_code, signal));
-    } else if signal.is_some() {
-        // Child was killed by a signal AND wrote a runtime-internal diagnostic
-        // to stderr (F1.3 path: `hew_trap_with_code` emits "hew: trap in main
-        // context: …" before the default signal handler terminates the process).
-        // Emit the synthesised user-facing description first so the output
-        // always contains "runtime error" and the named cause, then forward
-        // the child's raw diagnostic for additional context.
+    } else if signal.is_some() || is_runtime_trap_stderr(stderr) {
+        // Two equivalent cases for which we synthesise a user-facing prefix:
+        //
+        // 1. Unix: child was killed by a signal (F1.3 path on Linux/macOS —
+        //    `hew_trap_with_code` emits "hew: trap in main context: …" then
+        //    the default SIGILL handler terminates the process). The Unix
+        //    signal number is available via `signal`.
+        //
+        // 2. Windows: `hew_trap_with_code` emits the runtime-internal message
+        //    then the caller's `llvm.trap` terminates the process as
+        //    STATUS_ILLEGAL_INSTRUCTION (0xC000001D). There is no Unix signal;
+        //    the cause is detectable only via the stderr message prefix and the
+        //    NTSTATUS exit code.
+        //
+        // In both cases, emit the synthesised user-facing description first so
+        // the output always contains "runtime error" and the named cause, then
+        // forward the child's raw runtime-internal stderr for additional context.
         eprintln!("{}", describe_runtime_failure(exit_code, signal));
         eprint!("{stderr}");
     } else {
         eprint!("{stderr}");
     }
+}
+
+/// Return `true` when the child's stderr is a runtime-internal trap diagnostic
+/// emitted by `hew_trap_with_code` (F1.3). The pattern
+/// `"hew: trap in main context:"` is the sole source of this prefix.
+///
+/// Used to detect the Windows trap path, where no Unix signal is available but
+/// the child's stderr names the cause before `llvm.trap` terminates the process.
+pub(crate) fn is_runtime_trap_stderr(stderr: &str) -> bool {
+    stderr
+        .trim_start()
+        .starts_with("hew: trap in main context:")
 }
 
 fn normalize_captured_output(output: &str) -> String {
@@ -1885,6 +1907,34 @@ mod tests {
             !msg.contains("divide-by-zero"),
             "false positive cause: {msg}"
         );
+    }
+
+    #[test]
+    fn is_runtime_trap_stderr_matches_trap_prefix() {
+        // F1.3 runtime message from hew_trap_with_code.
+        assert!(is_runtime_trap_stderr(
+            "hew: trap in main context: DivideByZero\n"
+        ));
+        assert!(is_runtime_trap_stderr(
+            "hew: trap in main context: IndexOutOfBounds\n"
+        ));
+        assert!(is_runtime_trap_stderr(
+            "hew: trap in main context: IntegerOverflow\n"
+        ));
+    }
+
+    #[test]
+    fn is_runtime_trap_stderr_rejects_non_trap_messages() {
+        // Ordinary process stderr (e.g. panic output) must not be detected.
+        assert!(!is_runtime_trap_stderr(
+            "thread 'main' panicked at foo.rs:1"
+        ));
+        assert!(!is_runtime_trap_stderr(""));
+        assert!(!is_runtime_trap_stderr("error: something went wrong\n"));
+        // Partial match is not enough.
+        assert!(!is_runtime_trap_stderr(
+            "hew: some other prefix: DivideByZero"
+        ));
     }
 
     #[cfg(unix)]

--- a/hew-runtime/src/signal.rs
+++ b/hew-runtime/src/signal.rs
@@ -168,6 +168,36 @@ mod shared {
         }
     }
 
+    /// Emit a crash diagnostic to stderr using only async-signal-safe operations.
+    ///
+    /// This function must only call `write(2)` (POSIX async-signal-safe) and
+    /// perform no heap allocation, no locking, and no I/O buffering — it is
+    /// safe to call from a signal handler.
+    ///
+    /// Used when a synchronous fault signal is caught and there is no recovery
+    /// context (main/free-fn context), so the process is about to `_exit`. A
+    /// diagnostic is always emitted before process termination.
+    ///
+    /// `eprintln!` is NOT async-signal-safe (it acquires a lock on the stderr
+    /// handle). `write(2)` on fd 2 is the correct alternative here.
+    #[cfg(unix)]
+    pub(super) fn emit_crash_diagnostic_sig_safe(sig: i32) {
+        // Write fixed prefix, then signal name, then newline — no allocation.
+        // Each write is a separate syscall; partial writes are acceptable for
+        // a terminal diagnostic before _exit.
+        const PREFIX: &[u8] = b"hew: crash in main context: ";
+        const SUFFIX: &[u8] = b"\n";
+        let name = signal_name(sig).as_bytes();
+        // SAFETY: write(2) is POSIX async-signal-safe. fd 2 (STDERR_FILENO) is
+        // always open. The byte slices are valid static/stack data. We ignore
+        // the return value — a failed write before _exit is not actionable.
+        unsafe {
+            libc::write(2, PREFIX.as_ptr().cast(), PREFIX.len());
+            libc::write(2, name.as_ptr().cast(), name.len());
+            libc::write(2, SUFFIX.as_ptr().cast(), SUFFIX.len());
+        }
+    }
+
     /// Store dispatch metadata in the recovery state.
     ///
     /// Called at the start of each dispatch to record the actor and message
@@ -227,20 +257,21 @@ mod shared {
         // Cache actor data before supervisor notification to avoid race.
         // After hew_actor_trap, another thread could process the supervisor
         // notification and call hew_actor_free before we dereference actor.
-        let (actor_id, cached_pid, report) = if actor.is_null() {
-            (0, 0, None)
+        let (actor_id, cached_pid, dispatch_ptr, report) = if actor.is_null() {
+            (0u64, 0u64, 0usize, None)
         } else {
             // SAFETY: actor pointer was stored in prepare_dispatch_recovery
             // and the actor is still alive (it's Running — only the current
             // worker thread can transition it, and we haven't freed it).
             unsafe {
                 let id = (*actor).id;
+                let dispatch_ptr = (*actor).dispatch.map_or(0, |f| f as usize);
                 let report = crate::crash::build_crash_report(
                     actor, signal,
                     0, // signal_code - not available from siginfo_t in current handler
                     fault_addr, msg_type, worker_id,
                 );
-                (id, id, Some(report))
+                (id, id, dispatch_ptr, Some(report))
             }
         };
 
@@ -260,15 +291,45 @@ mod shared {
         // longjmp marker, which reuses signal 11) from a genuine hardware fault
         // so a real null-deref SIGSEGV is reported distinctly instead of being
         // masked by the identical-looking supervised panic-and-restart traffic.
+        //
+        // A diagnostic is always emitted — actor_id == 0 means the trap
+        // occurred in main/free-fn context (outside any actor dispatch) and
+        // is equally important to surface.
         if actor_id != 0 {
+            // Resolve a human-readable context name: prefer the registered
+            // handler name ("ActorType::handler") for the (dispatch_fn, msg_type)
+            // pair, fall back to the actor type name, then the raw msg_type.
+            let context =
+                crate::profiler::actor_registry::handler_name_by_ptr(dispatch_ptr, msg_type)
+                    .unwrap_or_else(|| {
+                        let type_name =
+                            crate::profiler::actor_registry::lookup_dispatch_type_by_ptr(
+                                dispatch_ptr,
+                            );
+                        if type_name == "Actor" {
+                            format!("msg_type={msg_type}")
+                        } else {
+                            format!("{type_name} (msg_type={msg_type})")
+                        }
+                    });
             if intentional {
                 eprintln!(
-                    "hew: actor {actor_id} (pid={cached_pid}) panicked (trap code {signal}), msg_type={msg_type}, worker={worker_id}"
+                    "hew: actor {actor_id} (pid={cached_pid}) panicked in {context}, worker={worker_id}"
                 );
             } else {
-                let name = signal_name(signal);
+                let sig_name = signal_name(signal);
                 eprintln!(
-                    "hew: actor {actor_id} (pid={cached_pid}) crashed with {name} at {fault_addr:#x}, msg_type={msg_type}, worker={worker_id}"
+                    "hew: actor {actor_id} (pid={cached_pid}) crashed with {sig_name} at {fault_addr:#x} in {context}, worker={worker_id}"
+                );
+            }
+        } else {
+            // Trap in main/free-fn context (no actor dispatch active).
+            if intentional {
+                eprintln!("hew: panic in main context (trap code {signal}), worker={worker_id}");
+            } else {
+                let sig_name = signal_name(signal);
+                eprintln!(
+                    "hew: crash in main context: {sig_name} at {fault_addr:#x}, worker={worker_id}"
                 );
             }
         }
@@ -535,7 +596,10 @@ mod platform {
         // SAFETY: pthread_getspecific is async-signal-safe.
         let ctx = unsafe { get_recovery_ctx() };
         if ctx.is_null() {
-            // No recovery context — can't recover. Terminate immediately.
+            // No recovery context (main/free-fn context) — emit a diagnostic
+            // then terminate. F1.3: a crash must never be silent.
+            // write(2) is POSIX async-signal-safe; see emit_crash_diagnostic_sig_safe.
+            super::shared::emit_crash_diagnostic_sig_safe(sig);
             // SAFETY: _exit is async-signal-safe.
             unsafe { libc::_exit(128 + sig) };
         }

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -353,8 +353,8 @@ pub use crate::internal::types::{
 /// matching the `HEW_TRAP_HEAP_EXCEEDED` precedent. Outside a dispatch
 /// context (top-level `main`, `hew eval` REPL, JIT preview) there is no
 /// recovery context; `try_direct_longjmp_with_code` is a no-op and this
-/// function returns. The caller's `llvm.trap` then aborts the process
-/// with SIGILL, preserving today's behaviour for non-actor crashes.
+/// function returns, then emits a diagnostic naming the trap kind before
+/// the caller's `llvm.trap` terminates the process.
 ///
 /// # Safety
 ///
@@ -370,6 +370,29 @@ pub unsafe extern "C" fn hew_trap_with_code(code: i32) {
     // recovery context internally; it is a no-op when none is active.
     unsafe {
         crate::signal::try_direct_longjmp_with_code(code);
+    }
+    // If we reach here, there is no actor recovery context — this trap
+    // occurred in main/free-fn context. Emit a diagnostic before the
+    // caller's `llvm.trap` terminates the process so the crash is never
+    // silent (F1.3 / fail-closed-with-diagnostic requirement).
+    //
+    // eprintln! is safe here: hew_trap_with_code is called from generated
+    // code, not from a signal handler, so the stderr lock is available.
+    let kind = trap_kind_name(code);
+    eprintln!("hew: trap in main context: {kind}");
+}
+
+/// Map a trap code to a human-readable trap kind name.
+fn trap_kind_name(code: i32) -> &'static str {
+    match code {
+        HEW_TRAP_HEAP_EXCEEDED => "HeapExceeded",
+        HEW_TRAP_INTEGER_OVERFLOW => "IntegerOverflow",
+        HEW_TRAP_DIVIDE_BY_ZERO => "DivideByZero",
+        HEW_TRAP_SIGNED_MIN_DIV_NEG_ONE => "SignedMinDivNegOne",
+        HEW_TRAP_SHIFT_OUT_OF_RANGE => "ShiftOutOfRange",
+        HEW_TRAP_INDEX_OUT_OF_BOUNDS => "IndexOutOfBounds",
+        HEW_TRAP_ACTOR_SEND_FAILED => "ActorSendFailed",
+        _ => "Trap",
     }
 }
 

--- a/tests/fuzz-oracle/expected-failures.txt
+++ b/tests/fuzz-oracle/expected-failures.txt
@@ -21,7 +21,7 @@
 # map_literal_empty_annotated.hew, array_repeat_int_sum.hew, and
 # array_repeat_runtime_count.hew are intentionally absent: they must pass.
 #
-# Total: 8 known-failing entries (8 intentional-trap/abort fixtures).
+# Total: 9 known-failing entries (9 intentional-trap/abort fixtures).
 #
 # Intentional aborts/traps: fixtures in tests/vertical-slice/accept/ that are
 # designed to trap or abort at runtime as their correctness proof.  Listed here
@@ -38,3 +38,4 @@ isize_shift_oob_traps.hew    # intentional trap: isize << 64 → ShiftOutOfRange
 option_unwrap_none_aborts.hew  # intentional abort: None unwrap traps deterministically — x86_64 SIGILL/132 or aarch64 SIGTRAP/133 — via the generic unmatched-arm path
 vec_element_width_oob_traps.hew  # intentional trap: Vec<i8> index at len → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
 vec_index_assign_oob_traps.hew   # intentional trap: Vec<i64> OOB write v[1] on 1-element vec → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
+crash_main_context_diagnostic.hew  # intentional trap: OOB Vec index in main context → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64) + "hew: trap in main context" stderr diagnostic (F1.3)

--- a/tests/vertical-slice/accept/crash_actor_context_diagnostic.hew
+++ b/tests/vertical-slice/accept/crash_actor_context_diagnostic.hew
@@ -1,0 +1,34 @@
+// F4.3 proving fixture: an actor crash must name the function/context in the
+// diagnostic, not emit an opaque msg_type integer.
+//
+// The Crasher actor traps in its `on_trigger` handler via an out-of-bounds Vec
+// index (hardware fault — SIGILL on x86_64, SIGTRAP on aarch64/macOS). The
+// signal handler longjmps back to the scheduler, which calls
+// handle_crash_recovery_impl. The diagnostic must include the actor type name
+// "Crasher" (resolved from the dispatch-fn registry populated by codegen at
+// startup), not the opaque "msg_type=-N" format.
+//
+// A sleep after the send gives the scheduler time to deliver the message and
+// run the crash recovery path before the process exits.
+//
+// run.sh asserts:
+//   1. Exit is 0 (main returns normally after sleep; the crash is supervised).
+//   2. stderr contains "Crasher" (the actor type name, at minimum).
+//   3. stderr does NOT contain "msg_type=-" (the old opaque format is gone).
+actor Crasher {
+    receive fn on_trigger(x: i64) {
+        let xs: Vec<i64> = Vec::new();
+        xs.push(x);
+        // Index 1 is out of bounds — hardware trap via hew_trap_with_code.
+        let _ = xs[1];
+    }
+}
+
+fn main() -> i64 {
+    let c = spawn Crasher;
+    // Fire-and-forget: send the message that will crash the actor.
+    c.on_trigger(99);
+    // Give the scheduler time to deliver the message and emit the diagnostic.
+    sleep_ms(300);
+    0
+}

--- a/tests/vertical-slice/accept/crash_main_context_diagnostic.hew
+++ b/tests/vertical-slice/accept/crash_main_context_diagnostic.hew
@@ -1,0 +1,17 @@
+// F1.3 proving fixture: a trap in main/free-fn context must never be silent.
+//
+// hew_trap_with_code is called by the codegen-emitted IR for the OOB bounds
+// check. When no actor recovery context is active (main/free-fn context),
+// it emits "hew: trap in main context: IndexOutOfBounds" to stderr before
+// the caller's llvm.trap terminates the process.
+//
+// run.sh asserts:
+//   1. Exit code is 132 (SIGILL+128 on x86_64) or 133 (SIGTRAP+128 on aarch64).
+//   2. stderr contains "hew: trap in main context" — the diagnostic is present.
+fn main() -> i64 {
+    let xs: Vec<i64> = Vec::new();
+    xs.push(42);
+    // Index 1 is out of bounds (only index 0 exists) — triggers IndexOutOfBounds trap.
+    let _ = xs[1];
+    0
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -789,6 +789,27 @@ run_fixture_path_expect_status "${ROOT}/tests/vertical-slice/reject/std_panic_wr
 grep -q 'cron.parse: invalid expression' "${stderr_output}"
 run_accept_expect_status "std_panic_wrappers_success" 0
 
+# F1.3: a trap in main/free-fn context must emit a diagnostic to stderr and
+# never be silent. The fixture triggers an out-of-bounds Vec index in main;
+# hew_trap_with_code emits "hew: trap in main context: <kind>" before the
+# process terminates. Exit is 132 (SIGILL+128 on x86_64) or 133 (SIGTRAP+128
+# on aarch64/macOS) from the llvm.trap terminator.
+run_accept_expect_trap "crash_main_context_diagnostic"
+grep -q 'hew: trap in main context' "${stderr_output}"
+
+# F4.3: an actor crash must name the function/context in the diagnostic, not
+# emit an opaque msg_type integer. The fixture spawns an actor that triggers
+# an OOB trap in its handler; handle_crash_recovery_impl must resolve the
+# handler name from the registry ("Crasher::on_trigger") rather than printing
+# "msg_type=-N". Exit 0 (main returns after sleep; crash is unsupervised).
+run_accept_expect_status "crash_actor_context_diagnostic" 0
+grep -q 'Crasher' "${stderr_output}"
+if grep -q 'msg_type=-' "${stderr_output}"; then
+  echo "crash_actor_context_diagnostic: stderr still contains opaque msg_type=-N format" >&2
+  cat "${stderr_output}" >&2
+  exit 1
+fi
+
 run_accept_expect_status "directory_module_call" 7
 
 if "${HEW}" compile "${ROOT}/tests/vertical-slice/reject/unresolved_symbol.hew" >"${reject_output}" 2>&1; then


### PR DESCRIPTION
## Summary

A runtime trap triggered from a free function or `main` (actor_id == 0) used to call `_exit` silently, leaving the caller with no indication of what went wrong or where. The signal handler now emits a formatted crash diagnostic to stderr — `hew: trap in main context: <reason>` — before exiting nonzero. The handler path is async-signal-safe: it writes only fixed bytes and the signal name through `libc::write(2)`, with no allocation, formatting, locking, or buffered I/O.

Actor-context crash messages also now include the handler function name (F4.3). The supervisor resolves `(dispatch_ptr, msg_type)` through the handler registry and emits the handler name in the crash line, replacing the old opaque `msg_type=-N` form.

## Verification

- `crash_main_context_diagnostic` fixture: stderr contains `hew: trap in main context: IndexOutOfBounds`, exit nonzero — pass
- `crash_actor_context_diagnostic` fixture: crash line includes handler name, no opaque msg_type integer — pass
- `tests/vertical-slice/run.sh`: stderr-content assertions for both regressions pass
- Preflight: ready-to-push

## Out of scope

No changes to the actor recovery path, supervisor restart logic, or signal handler registration. No new public API surface.
