### PR TITLE
fix(actor): key message codec by dispatch identity + type to close cross-actor wire-collision

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -1968,8 +1968,19 @@ fn intern_runtime_decl<'ctx>(
         // hew_actor_send_by_id(actor_id: u64, msg_type: i32, data: *mut c_void,
         //                      size: usize) -> c_int (`hew-runtime/src/actor.rs:2489`).
         // `size` is `usize`/`size_t` → target-correct width (i32 on wasm32).
+        // hew_actor_send_by_id(pid, dispatch, msg_type, data, size). `dispatch`
+        // is the target actor TYPE's dispatch global — the `(dispatch, msg_type)`
+        // cross-node serialize codec key on the remote path (null/unused for a
+        // purely local send). codegen-offset-mirror-drift: must match the runtime
+        // `#[no_mangle]` signature.
         "hew_actor_send_by_id" => i32_ty.fn_type(
-            &[i64_ty.into(), i32_ty.into(), ptr_ty.into(), size_ty.into()],
+            &[
+                i64_ty.into(),
+                ptr_ty.into(),
+                i32_ty.into(),
+                ptr_ty.into(),
+                size_ty.into(),
+            ],
             false,
         ),
         // hew_tcp_attach_local(conn: c_int, actor: *mut HewActor,
@@ -1987,9 +1998,15 @@ fn intern_runtime_decl<'ctx>(
             &[ptr_ty.into(), ptr_ty.into(), i32_ty.into(), i32_ty.into()],
             false,
         ),
+        // hew_node_api_ask(pid, dispatch, msg_type, data, size, timeout_ms,
+        //                  reply_size). `dispatch` is the target actor TYPE's
+        // dispatch global — the `(dispatch, msg_type)` codec key for both the
+        // request encode and the reply decode (codegen-offset-mirror-drift: must
+        // match the runtime `#[no_mangle]` signature).
         "hew_node_api_ask" => ptr_ty.fn_type(
             &[
                 i64_ty.into(),
+                ptr_ty.into(),
                 i32_ty.into(),
                 ptr_ty.into(),
                 i64_ty.into(),
@@ -1999,15 +2016,17 @@ fn intern_runtime_decl<'ctx>(
             false,
         ),
         "hew_node_ask_take_last_error" => i32_ty.fn_type(&[], false),
-        // hew_node_api_ask_async(pid, msg_type, data, size, timeout_ms,
-        //                        caller_actor) -> *mut c_void
+        // hew_node_api_ask_async(pid, dispatch, msg_type, data, size,
+        //                        timeout_ms, caller_actor) -> *mut c_void
         // (`hew-runtime/src/hew_node.rs`). NEW-5 suspendable submit: parks the
         // caller's coroutine on the reply table and returns an opaque pending
         // handle (null on setup failure). `caller_actor` is the `hew_actor_self`
-        // pointer the wire reply resumes through `enqueue_resume`.
+        // pointer the wire reply resumes through `enqueue_resume`. `dispatch`
+        // keys the request encode.
         "hew_node_api_ask_async" => ptr_ty.fn_type(
             &[
                 i64_ty.into(),
+                ptr_ty.into(),
                 i32_ty.into(),
                 ptr_ty.into(),
                 i64_ty.into(),
@@ -2016,12 +2035,16 @@ fn intern_runtime_decl<'ctx>(
             ],
             false,
         ),
-        // hew_node_api_ask_finish(pending_handle, msg_type, reply_size)
+        // hew_node_api_ask_finish(pending_handle, dispatch, msg_type, reply_size)
         //   -> *mut c_void (`hew-runtime/src/hew_node.rs`). Drains the reply
         // deposited for a suspended remote ask on the resume edge; null is the
         // typed-failure sentinel (read via hew_node_ask_take_last_error).
+        // `dispatch` keys the reply decode.
         "hew_node_api_ask_finish" => {
-            ptr_ty.fn_type(&[ptr_ty.into(), i32_ty.into(), i64_ty.into()], false)
+            ptr_ty.fn_type(
+                &[ptr_ty.into(), ptr_ty.into(), i32_ty.into(), i64_ty.into()],
+                false,
+            )
         }
         // hew_node_api_ask_cancel(pending_handle) -> void
         // (`hew-runtime/src/hew_node.rs`). Abandons a suspended remote ask on
@@ -27516,6 +27539,57 @@ fn emit_send_result_from_rc<'ctx>(
     Ok(())
 }
 
+/// Resolve a target actor TYPE's dispatch global `__hew_actor_dispatch_<name>`
+/// as a `ptr` value, for use as the `(dispatch, msg_type)` cross-node codec key
+/// at an originating remote send / ask site. The trampoline is emitted by
+/// `emit_actor_dispatch_trampoline` ahead of function-body lowering, so it is
+/// present here; a missing symbol is wrong-code territory — fail closed rather
+/// than pass a null key that would mis-route the codec lookup.
+fn remote_actor_dispatch_ptr<'ctx>(
+    fn_ctx: &FnCtx<'_, 'ctx>,
+    actor_name: &str,
+) -> CodegenResult<PointerValue<'ctx>> {
+    let dispatch_name = format!("__hew_actor_dispatch_{}", mangle_dotted_name(actor_name));
+    let dispatch_fn = fn_ctx
+        .llvm_mod
+        .get_function(&dispatch_name)
+        .ok_or_else(|| {
+            CodegenError::FailClosed(format!(
+                "remote send/ask on `{actor_name}` requires dispatch trampoline \
+             `{dispatch_name}` (the cross-node codec key); it was not declared"
+            ))
+        })?;
+    Ok(dispatch_fn.as_global_value().as_pointer_value())
+}
+
+/// Resolve the target actor TYPE name `T` from a `RemotePid<T>` pid place, then
+/// its dispatch global ptr (the `(dispatch, msg_type)` cross-node codec key for
+/// the originating remote ask). Mirrors the `RemotePid<T>` unwrap in
+/// `emit_remote_pid_tell_call`.
+fn remote_ask_dispatch_ptr<'ctx>(
+    fn_ctx: &FnCtx<'_, 'ctx>,
+    pid_place: Place,
+) -> CodegenResult<PointerValue<'ctx>> {
+    let pid_ty = place_resolved_ty(fn_ctx, pid_place)?;
+    let actor_name = match pid_ty {
+        ResolvedTy::Named { name, args, .. } if name == "RemotePid" => match args.first() {
+            Some(ResolvedTy::Named { name: t_name, .. }) => t_name.clone(),
+            other => {
+                return Err(CodegenError::FailClosed(format!(
+                    "RemoteAsk pid `RemotePid<T>` inner T must be a named actor type, \
+                     got {other:?}"
+                )));
+            }
+        },
+        other => {
+            return Err(CodegenError::FailClosed(format!(
+                "RemoteAsk pid must have resolved type RemotePid<T>, got {other:?}"
+            )));
+        }
+    };
+    remote_actor_dispatch_ptr(fn_ctx, &actor_name)
+}
+
 /// Emit the call sequence for `RemotePid<T>::tell(pid, msg) -> Result<(), SendError>`.
 ///
 /// The checker rewrites `pid.tell(msg)` on a `RemotePid<T>` receiver into a
@@ -27672,7 +27746,15 @@ fn emit_remote_pid_tell_call<'ctx>(
     let (payload_ptr, payload_size) =
         actor_payload_ptr_size(fn_ctx, *msg_arg, "remote_tell_payload")?;
 
-    // Call `hew_actor_send_by_id(pid: u64, msg_type: i32, data: ptr, size: usize) -> i32`.
+    // Resolve the TARGET actor type's dispatch global — the `(dispatch,
+    // msg_type)` cross-node serialize codec key. The codec seeder registered
+    // this actor's serializer under THIS module's same dispatch global, so the
+    // remote-send encode selects the right codec even when another actor type's
+    // `msg_type` SipHash-collides. Same symbol the spawn path uses
+    // (`emit_spawn_actor`); fail closed if the trampoline is missing.
+    let dispatch_ptr = remote_actor_dispatch_ptr(fn_ctx, &actor_name)?;
+
+    // Call `hew_actor_send_by_id(pid, dispatch, msg_type, data, size) -> i32`.
     let send_fn = intern_runtime_decl(
         fn_ctx.ctx,
         fn_ctx.llvm_mod,
@@ -27694,6 +27776,7 @@ fn emit_remote_pid_tell_call<'ctx>(
             send_fn,
             &[
                 pid_val.into(),
+                dispatch_ptr.into(),
                 msg_type_const.into(),
                 payload_ptr.into(),
                 payload_size.into(),
@@ -33817,6 +33900,9 @@ fn emit_suspending_remote_actor_ask_terminator<'ctx>(
         )));
     }
     let reply_size = static_type_size_i64(fn_ctx, term.reply_ty, "remote_ask_reply")?;
+    // Target actor type's dispatch global — the `(dispatch, msg_type)` codec key
+    // for both the request encode (ask_async) and the reply decode (ask_finish).
+    let dispatch_ptr = remote_ask_dispatch_ptr(fn_ctx, term.actor)?;
 
     // self = the current actor — the parked-continuation waiter the wire reply
     // re-enqueues. MUST come from `hew_actor_self()` (the live thread-local
@@ -33852,6 +33938,7 @@ fn emit_suspending_remote_actor_ask_terminator<'ctx>(
             ask_async_fn,
             &[
                 pid_val.into(),
+                dispatch_ptr.into(),
                 msg_type.into(),
                 payload_ptr.into(),
                 payload_size.into(),
@@ -33938,7 +34025,12 @@ fn emit_suspending_remote_actor_ask_terminator<'ctx>(
             // sentinel. ─────────────────────────────────────────────────────────
             let reply_ptr = fn_ctx.call_runtime_ptr(
                 "hew_node_api_ask_finish",
-                &[pending_handle.into(), msg_type.into(), reply_size.into()],
+                &[
+                    pending_handle.into(),
+                    dispatch_ptr.into(),
+                    msg_type.into(),
+                    reply_size.into(),
+                ],
                 "hew_node_api_ask_finish_call",
                 "hew_node_api_ask_finish call",
             )?;
@@ -34034,6 +34126,9 @@ fn emit_remote_actor_ask_terminator<'ctx>(
         )));
     }
     let reply_size = static_type_size_i64(fn_ctx, term.reply_ty, "remote_ask_reply")?;
+    // Target actor type's dispatch global — the `(dispatch, msg_type)` codec key
+    // for BOTH the request encode and the reply decode on this ask.
+    let dispatch_ptr = remote_ask_dispatch_ptr(fn_ctx, term.actor)?;
     let ask_fn = intern_runtime_decl(
         fn_ctx.ctx,
         fn_ctx.llvm_mod,
@@ -34047,6 +34142,7 @@ fn emit_remote_actor_ask_terminator<'ctx>(
             ask_fn,
             &[
                 pid_val.into(),
+                dispatch_ptr.into(),
                 msg_type.into(),
                 payload_ptr.into(),
                 payload_size.into(),
@@ -36513,12 +36609,19 @@ fn lower_terminator<'ctx>(
             // the message. We must not silently proceed — that could leave the
             // caller operating on stale state or attempting a follow-up ask
             // on a dead actor.
+            // `Terminator::Send` targets a LOCAL actor handle (`ActorRef`/`Pid`);
+            // it delivers into a local mailbox and never reaches the cross-node
+            // serialize path (that is the `RemotePid<T>` `emit_remote_pid_tell_call`
+            // spine). So the `(dispatch, msg_type)` codec key is irrelevant here —
+            // pass a null dispatch, which the local send path ignores.
+            let null_dispatch = fn_ctx.ctx.ptr_type(AddressSpace::default()).const_null();
             let send_status = fn_ctx
                 .builder
                 .build_call(
                     send,
                     &[
                         actor_id.into(),
+                        null_dispatch.into(),
                         msg_type.into(),
                         payload_ptr.into(),
                         payload_size.into(),
@@ -45335,10 +45438,30 @@ fn emit_xnode_codec_module_init<'ctx>(
     pipeline_records: &[RecordLayout],
     enum_layouts: &[EnumLayout],
 ) -> CodegenResult<Option<FunctionValue<'ctx>>> {
-    // Collect (msg_type, msg_ty, reply_ty) for every handler. Dedup by msg_type:
-    // a handler's msg_type is unique per (actor, handler).
-    let mut entries: Vec<(i32, ResolvedTy, ResolvedTy)> = Vec::new();
+    // Collect (dispatch global, msg_type, msg_ty, reply_ty) for every handler.
+    // The codec registry is keyed by `(dispatch, msg_type)` — the owning actor
+    // TYPE's dispatch function pointer plus the discriminant — so two distinct
+    // actor types whose handler names SipHash-collide on the low 32 bits of
+    // `msg_type` register SEPARATE codecs (no silent displacement / cross-node
+    // type-confusion). Dedup is therefore by `(dispatch, msg_type)`, NOT
+    // `msg_type` alone; a handler still appears once per actor type.
+    let mut entries: Vec<(FunctionValue<'ctx>, i32, ResolvedTy, ResolvedTy)> = Vec::new();
     for actor in actor_layouts {
+        // Resolve the actor TYPE's dispatch global, the same symbol the spawn
+        // path stores into `HewActor.dispatch` and the runtime decode paths
+        // resolve from `target_actor_id`. It is emitted by
+        // `emit_actor_dispatch_trampoline` ahead of this pass; a missing symbol
+        // is wrong-code territory — fail closed rather than seed an unkeyable
+        // codec.
+        let dispatch_name = format!("__hew_actor_dispatch_{}", mangle_dotted_name(&actor.name));
+        let dispatch_fn = llvm_mod.get_function(&dispatch_name).ok_or_else(|| {
+            CodegenError::FailClosed(format!(
+                "xnode codec seeder: actor `{}` requires dispatch trampoline \
+                 `{dispatch_name}` (the codec-registry key); it was not declared \
+                 before the codec module-init pass",
+                actor.name
+            ))
+        })?;
         for h in &actor.handlers {
             // Single-parameter handlers only. A multi-arg handler's wire
             // payload is the packed-args anonymous record; seeding a codec
@@ -45372,10 +45495,16 @@ fn emit_xnode_codec_module_init<'ctx>(
             {
                 continue;
             }
-            if entries.iter().any(|(mt, _, _)| *mt == h.msg_type) {
+            // Dedup by (dispatch, msg_type): the SAME actor type can list a
+            // handler once; distinct actor types with a colliding msg_type each
+            // seed their own codec under their own dispatch key.
+            if entries
+                .iter()
+                .any(|(d, mt, _, _)| *d == dispatch_fn && *mt == h.msg_type)
+            {
                 continue;
             }
-            entries.push((h.msg_type, msg_ty.clone(), h.return_ty.clone()));
+            entries.push((dispatch_fn, h.msg_type, msg_ty.clone(), h.return_ty.clone()));
         }
     }
     if entries.is_empty() {
@@ -45389,7 +45518,7 @@ fn emit_xnode_codec_module_init<'ctx>(
     // Emit thunk bodies for every distinct msg AND reply type first.
     // (Best-effort: a type outside the Serializable floor fails closed here,
     // surfacing the codegen error rather than shipping raw bytes.)
-    for (_mt, msg_ty, reply_ty) in &entries {
+    for (_dispatch, _mt, msg_ty, reply_ty) in &entries {
         emit_xnode_codec_thunks(
             ctx,
             llvm_mod,
@@ -45422,23 +45551,32 @@ fn emit_xnode_codec_module_init<'ctx>(
     let entry_bb = ctx.append_basic_block(init_fn, "entry");
     builder.position_at_end(entry_bb);
 
-    // hew_xnode_register_codec(msg_type: i32, ser: ptr, de: ptr).
+    // hew_xnode_register_codec(dispatch: ptr, msg_type: i32, ser: ptr, de: ptr).
+    // The leading `dispatch` ptr is the codec-registry key (codegen-offset-mirror
+    // -drift: this declare MUST match the runtime `#[no_mangle]` signature).
     let reg_fn = declare_codec_prim(
         ctx,
         llvm_mod,
         "hew_xnode_register_codec",
-        void_ty.fn_type(&[i32_ty.into(), ptr_ty.into(), ptr_ty.into()], false),
+        void_ty.fn_type(
+            &[ptr_ty.into(), i32_ty.into(), ptr_ty.into(), ptr_ty.into()],
+            false,
+        ),
     );
-    // hew_xnode_register_reply_codec(msg_type: i32, ser: ptr, de: ptr) — the
-    // reply codec for the ask path, keyed by the request's msg_type.
+    // hew_xnode_register_reply_codec(dispatch: ptr, msg_type: i32, ser, de) — the
+    // reply codec for the ask path, keyed by (dispatch, request msg_type).
     let reg_reply_fn = declare_codec_prim(
         ctx,
         llvm_mod,
         "hew_xnode_register_reply_codec",
-        void_ty.fn_type(&[i32_ty.into(), ptr_ty.into(), ptr_ty.into()], false),
+        void_ty.fn_type(
+            &[ptr_ty.into(), i32_ty.into(), ptr_ty.into(), ptr_ty.into()],
+            false,
+        ),
     );
 
-    for (mt, msg_ty, reply_ty) in &entries {
+    for (dispatch_fn, mt, msg_ty, reply_ty) in &entries {
+        let dispatch_ptr = dispatch_fn.as_global_value().as_pointer_value();
         let mt_const = i32_ty.const_int(*mt as u64, true);
         let msg_key = xnode_codec_key(msg_ty);
         let ser = get_or_declare_serialize_thunk(ctx, llvm_mod, &msg_key);
@@ -45447,6 +45585,7 @@ fn emit_xnode_codec_module_init<'ctx>(
             .build_call(
                 reg_fn,
                 &[
+                    dispatch_ptr.into(),
                     mt_const.into(),
                     ser.as_global_value().as_pointer_value().into(),
                     de.as_global_value().as_pointer_value().into(),
@@ -45462,6 +45601,7 @@ fn emit_xnode_codec_module_init<'ctx>(
                 .build_call(
                     reg_reply_fn,
                     &[
+                        dispatch_ptr.into(),
                         mt_const.into(),
                         rser.as_global_value().as_pointer_value().into(),
                         rde.as_global_value().as_pointer_value().into(),

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -2740,16 +2740,26 @@ pub unsafe extern "C" fn hew_actor_send_wire(
 /// Returns 0 on success, -1 if the actor ID is not currently live on this
 /// node or the local send fails.
 ///
+/// `dispatch` is the TARGET actor TYPE's dispatch function pointer
+/// (`__hew_actor_dispatch_<Actor>`), supplied by codegen at the remote-tell
+/// site (it knows the target type statically from `RemotePid<T>`). It keys the
+/// cross-node serialize codec `(dispatch, msg_type)` so a colliding `msg_type`
+/// on another actor type cannot select the wrong serializer for the value being
+/// shipped. It is unused on the LOCAL send path (the local mailbox copies the
+/// in-memory value directly); local-only callers may pass null.
+///
 /// # Safety
 ///
 /// `data` must point to at least `size` readable bytes, or be null when
 /// `size` is 0. For local actors, callers must only send to actor IDs whose
 /// lifetime they still coordinate; once the live lookup succeeds, this path
-/// shares the same liveness contract as [`hew_actor_send`].
+/// shares the same liveness contract as [`hew_actor_send`]. `dispatch` is an
+/// opaque codec key, never dereferenced.
 #[cfg(not(target_arch = "wasm32"))]
 #[no_mangle]
 pub unsafe extern "C" fn hew_actor_send_by_id(
     actor_id: u64,
+    dispatch: *const c_void,
     msg_type: i32,
     data: *mut c_void,
     size: usize,
@@ -2769,10 +2779,13 @@ pub unsafe extern "C" fn hew_actor_send_by_id(
     }
 
     // Actor not found locally. If the PID belongs to a remote node,
-    // route through the distributed node infrastructure.
+    // route through the distributed node infrastructure (which serializes the
+    // payload under the `(dispatch, msg_type)` codec key).
     if crate::pid::hew_pid_is_local(actor_id) == 0 {
         // SAFETY: data validity is guaranteed by caller contract.
-        return unsafe { crate::hew_node::try_remote_send(actor_id, msg_type, data, size) };
+        return unsafe {
+            crate::hew_node::try_remote_send(actor_id, dispatch, msg_type, data, size)
+        };
     }
     -1
 }
@@ -6055,7 +6068,9 @@ mod tests {
                 start.wait();
                 for _ in 0..sends_per_thread {
                     // SAFETY: actor remains live until all sender threads join.
-                    let rc = unsafe { hew_actor_send_by_id(actor_id, 1, ptr::null_mut(), 0) };
+                    let rc = unsafe {
+                        hew_actor_send_by_id(actor_id, ptr::null(), 1, ptr::null_mut(), 0)
+                    };
                     assert_eq!(rc, 0);
                 }
             }));
@@ -6099,7 +6114,7 @@ mod tests {
 
         // SAFETY: caller only provides message bytes; the runtime should reject
         // the now-untracked actor ID instead of crashing.
-        let rc = unsafe { hew_actor_send_by_id(actor_id, 1, ptr::null_mut(), 0) };
+        let rc = unsafe { hew_actor_send_by_id(actor_id, ptr::null(), 1, ptr::null_mut(), 0) };
         assert_eq!(rc, -1);
     }
 
@@ -6715,7 +6730,9 @@ mod tests {
                 start.wait();
                 for _ in 0..sends_per_thread {
                     // SAFETY: actor remains live until all worker threads join.
-                    let rc = unsafe { hew_actor_send_by_id(actor_id, 1, ptr::null_mut(), 0) };
+                    let rc = unsafe {
+                        hew_actor_send_by_id(actor_id, ptr::null(), 1, ptr::null_mut(), 0)
+                    };
                     assert_eq!(rc, 0);
                 }
             }));

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -3458,30 +3458,40 @@ mod tests {
         dst.cast::<std::ffi::c_void>()
     }
 
-    /// Stable per-test stand-in for an actor type's `__hew_actor_dispatch_*`
-    /// global — the `(dispatch, msg_type)` codec-registry key. The test
-    /// registers its codec under this key and threads the SAME pointer into the
-    /// ask/send FFIs so encode/decode resolve the matching codec.
-    static TEST_DISPATCH: u8 = 0;
-    fn test_dispatch() -> *const c_void {
-        std::ptr::addr_of!(TEST_DISPATCH).cast()
+    /// The codec-registry key `(dispatch, msg_type)` uses the TARGET actor
+    /// TYPE's dispatch function pointer. In these tests the echo actor is spawned
+    /// with a concrete dispatch fn (e.g. `ask_probe_dispatch`); the inbound
+    /// decode resolves THAT pointer from the target actor, so the codec must be
+    /// registered under the SAME dispatch and the originating ask must pass it.
+    /// This helper casts a dispatch fn to the opaque `*const c_void` key.
+    fn dispatch_key(f: crate::internal::types::HewDispatchFn) -> *const c_void {
+        f as *const c_void
     }
 
-    /// Register the test u32 codec for `(test_dispatch(), msg_type)` as both the
-    /// request and reply codec, so the two-process send/ask paths can serialize
-    /// their controlled payloads. Idempotent across helper processes (each
-    /// registers in its own process).
-    fn register_test_u32_codec(msg_type: i32) {
+    /// Canonical codec key for the single-process two-node round-trip tests and
+    /// the two-process client side: the echo actor is spawned with
+    /// `ask_probe_dispatch`, so its inbound decode resolves that pointer. The
+    /// register, the ask FFI arg, and the spawned-actor dispatch all use this.
+    fn test_dispatch() -> *const c_void {
+        dispatch_key(ask_probe_dispatch)
+    }
+
+    /// Register the test u32 codec for `(dispatch, msg_type)` as both the
+    /// request and reply codec, so the send/ask paths can serialize their
+    /// controlled payloads. `dispatch` MUST be the dispatch fn the target echo
+    /// actor is spawned with (the inbound decode resolves it from the actor).
+    /// Idempotent across helper processes (each registers in its own process).
+    fn register_test_u32_codec(dispatch: *const c_void, msg_type: i32) {
         // SAFETY: the thunks match the codec ABI.
         unsafe {
             crate::xnode_serial::hew_xnode_register_codec(
-                test_dispatch(),
+                dispatch,
                 msg_type,
                 test_u32_serialize,
                 test_u32_deserialize,
             );
             crate::xnode_serial::hew_xnode_register_reply_codec(
-                test_dispatch(),
+                dispatch,
                 msg_type,
                 test_u32_serialize,
                 test_u32_deserialize,
@@ -3933,8 +3943,10 @@ mod tests {
         hold_after_observed: Duration,
     ) {
         // The inbound-ask path decodes the request and encodes the reply via the
-        // registered codec (fail-closed). Register the test u32 codec.
-        register_test_u32_codec(TWO_PROCESS_REGISTRY_MSG_TYPE);
+        // registered codec (fail-closed), keyed by the target actor's dispatch.
+        // Register under the SAME dispatch fn this server spawns its echo actor
+        // with so the inbound decode resolves the matching codec.
+        register_test_u32_codec(dispatch_key(dispatch), TWO_PROCESS_REGISTRY_MSG_TYPE);
         reset_two_process_ask_observed();
         // Install the runtime before touching the name registry (helper
         // subprocess holds no `runtime_test_guard`).
@@ -4058,7 +4070,7 @@ mod tests {
     ) -> (TestNode, u64) {
         // The cross-node send/ask path requires a registered codec for the
         // payload's msg_type (fail-closed). Register the test u32 codec.
-        register_test_u32_codec(TWO_PROCESS_REGISTRY_MSG_TYPE);
+        register_test_u32_codec(test_dispatch(), TWO_PROCESS_REGISTRY_MSG_TYPE);
         // Install the runtime before touching the name registry (helper
         // subprocess holds no `runtime_test_guard`).
         init_real_scheduler();
@@ -5946,7 +5958,7 @@ mod tests {
         let _guard = crate::runtime_test_guard();
         crate::registry::hew_registry_clear();
         // Remote ask requires a registered codec for the payload msg_type.
-        register_test_u32_codec(1);
+        register_test_u32_codec(test_dispatch(), 1);
 
         // Node 1 (initiator) starts first → CURRENT_NODE = node1, LOCAL_NODE_ID = 311.
         // Node 2 (responder) starts after; CURRENT_NODE stays as node1.
@@ -6042,7 +6054,7 @@ mod tests {
         // routed at the parked caller through `enqueue_resume`.
         let _guard = crate::runtime_test_guard();
         crate::registry::hew_registry_clear();
-        register_test_u32_codec(1);
+        register_test_u32_codec(test_dispatch(), 1);
 
         let node1_bind = CString::new("127.0.0.1:0").unwrap();
         // SAFETY: bind address is a valid C string for this scope.
@@ -7128,7 +7140,7 @@ mod tests {
     fn inbound_ask_active_counter_returns_to_baseline_after_round_trip() {
         let _guard = crate::runtime_test_guard();
         crate::registry::hew_registry_clear();
-        register_test_u32_codec(1);
+        register_test_u32_codec(test_dispatch(), 1);
 
         let node1_bind = CString::new("127.0.0.1:0").unwrap();
 
@@ -7315,7 +7327,7 @@ mod tests {
     fn over_limit_nonvoid_ask_fails_closed_with_worker_at_capacity() {
         let _guard = crate::runtime_test_guard();
         crate::registry::hew_registry_clear();
-        register_test_u32_codec(1);
+        register_test_u32_codec(test_dispatch(), 1);
 
         let node1_bind = CString::new("127.0.0.1:0").unwrap();
 

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -863,6 +863,7 @@ fn remote_reply_data_to_ptr(reply_data: &[u8], reply_size: usize) -> *mut c_void
 /// `data` must be valid for `size` bytes (or null when size is 0).
 pub(crate) unsafe fn try_remote_send(
     target_pid: u64,
+    dispatch: *const c_void,
     msg_type: c_int,
     data: *mut c_void,
     size: usize,
@@ -873,7 +874,16 @@ pub(crate) unsafe fn try_remote_send(
         }
         let node = *guard as *mut HewNode;
         // SAFETY: read lock pins CURRENT_NODE pointer for this send.
-        unsafe { hew_node_send(node, target_pid, msg_type, data.cast::<u8>(), size) }
+        unsafe {
+            hew_node_send(
+                node,
+                target_pid,
+                dispatch,
+                msg_type,
+                data.cast::<u8>(),
+                size,
+            )
+        }
     })
 }
 
@@ -1185,55 +1195,84 @@ unsafe extern "C" fn node_inbound_router(
         });
     } else {
         // Fire-and-forget message — reconstruct the value into THIS node's
-        // address space before delivering it to the local mailbox. The inbound
-        // `data` is the serialized wire form; feeding it raw to the mailbox would
-        // make the actor handler dereference sender-side heap pointers and crash.
-        //
-        // Fail closed: if no codec is registered for `msg_type`, or the decode
-        // reports failure, drop the message rather than deliver garbage. An empty
-        // payload (size == 0) is a genuine zero-field message and bypasses decode.
-        if size == 0 {
-            // SAFETY: zero-length payload; mailbox handles null+0.
-            let _ = unsafe {
-                crate::actor::hew_actor_send_by_id(
-                    target_actor_id,
-                    msg_type,
-                    std::ptr::null_mut(),
-                    0,
-                )
-            };
-        } else {
-            // SAFETY: data is valid for `size` bytes (reader_loop contract).
-            let (value, struct_size) =
-                unsafe { crate::xnode_serial::decode_payload(msg_type, data.cast_const(), size) };
-            if value.is_null() {
-                // No codec or decode failure — drop the message fail-closed.
-                set_last_error(format!(
-                    "cross-node tell dropped: no codec or decode failure for msg_type={msg_type}"
-                ));
-            } else {
-                // The reconstructed value lives in a malloc'd buffer of
-                // `struct_size` bytes (the in-memory struct size, NOT the wire
-                // length). hew_actor_send_by_id deep-copies `struct_size` bytes
-                // into the mailbox, MOVING the owned heap fields (strings/bytes)
-                // into the mailbox copy — exactly the move semantics of a local
-                // send where the caller's stack value is byte-copied. We then
-                // free the reconstructed struct SHELL only (not its fields, now
-                // owned by the mailbox copy).
-                // SAFETY: value is a valid reconstructed struct for msg_type.
-                let _ = unsafe {
-                    crate::actor::hew_actor_send_by_id(
-                        target_actor_id,
-                        msg_type,
-                        value,
-                        struct_size,
-                    )
-                };
-                // SAFETY: value came from decode_payload (libc::malloc).
-                unsafe { libc::free(value) };
-            }
-        }
+        // address space before delivering it to the local mailbox.
+        // SAFETY: data is valid for `size` bytes (reader_loop contract).
+        unsafe { deliver_inbound_tell(target_actor_id, msg_type, data, size) };
     }
+}
+
+/// Deliver an inbound fire-and-forget (`tell`) frame to its target actor's local
+/// mailbox, reconstructing the value into THIS node's address space first. The
+/// inbound `data` is the serialized wire form; feeding it raw to the mailbox
+/// would make the actor handler dereference sender-side heap pointers and crash.
+///
+/// Fail closed throughout: an unregistered codec, a decode failure, or a
+/// target actor that is no longer live all DROP the message rather than deliver
+/// garbage. An empty payload (`size == 0`) is a genuine zero-field message and
+/// bypasses decode.
+///
+/// # Safety
+/// `data` must be valid for `size` bytes (or null when `size == 0`).
+unsafe fn deliver_inbound_tell(target_actor_id: u64, msg_type: i32, data: *mut u8, size: usize) {
+    if size == 0 {
+        // Local delivery into THIS node's mailbox — no cross-node encode, so no
+        // codec key needed (null dispatch).
+        // SAFETY: zero-length payload; mailbox handles null+0.
+        let _ = unsafe {
+            crate::actor::hew_actor_send_by_id(
+                target_actor_id,
+                std::ptr::null(),
+                msg_type,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        return;
+    }
+    // Resolve the TARGET actor type's dispatch pointer from the wire's
+    // `target_actor_id` and decode under `(dispatch, msg_type)`, so the frame is
+    // reconstructed ONLY by the codec belonging to its target actor's type —
+    // never by a different actor whose `msg_type` SipHash-collides (remote
+    // type-confusion).
+    let Some(dispatch) = crate::lifetime::live_actors::dispatch_ptr_by_id(target_actor_id) else {
+        // Target actor not live (torn down between frame arrival and decode, or
+        // never existed). No dispatch pointer resolvable → no codec selectable →
+        // drop the message fail-closed rather than fabricate a key.
+        set_last_error(format!(
+            "cross-node tell dropped: target actor {target_actor_id} not live \
+             for msg_type={msg_type}"
+        ));
+        return;
+    };
+    // SAFETY: data is valid for `size` bytes (caller contract).
+    let (value, struct_size) =
+        unsafe { crate::xnode_serial::decode_payload(dispatch, msg_type, data.cast_const(), size) };
+    if value.is_null() {
+        // No codec or decode failure — drop the message fail-closed.
+        set_last_error(format!(
+            "cross-node tell dropped: no codec or decode failure for msg_type={msg_type}"
+        ));
+        return;
+    }
+    // The reconstructed value lives in a malloc'd buffer of `struct_size` bytes
+    // (the in-memory struct size, NOT the wire length). hew_actor_send_by_id
+    // deep-copies `struct_size` bytes into the mailbox, MOVING the owned heap
+    // fields (strings/bytes) into the mailbox copy — exactly the move semantics
+    // of a local send where the caller's stack value is byte-copied. We then
+    // free the reconstructed struct SHELL only (not its fields, now owned by the
+    // mailbox copy). Local mailbox delivery — null dispatch (no re-encode here).
+    // SAFETY: value is a valid reconstructed struct for msg_type.
+    let _ = unsafe {
+        crate::actor::hew_actor_send_by_id(
+            target_actor_id,
+            std::ptr::null(),
+            msg_type,
+            value,
+            struct_size,
+        )
+    };
+    // SAFETY: value came from decode_payload (libc::malloc).
+    unsafe { libc::free(value) };
 }
 
 /// Handle an inbound remote ask by performing a local blocking ask and
@@ -1299,6 +1338,16 @@ fn handle_inbound_ask(
         Some(unsafe { connection::hew_connmgr_feature_flags_for_node(conn_mgr.0, source_node_id) })
     });
 
+    // Resolve the TARGET actor type's dispatch pointer from `target_actor_id`.
+    // Both the request DECODE and the reply ENCODE key their codec by
+    // `(dispatch, msg_type)` so a frame is reconstructed / a reply is encoded
+    // ONLY by the codec belonging to this target actor's type — never by a
+    // different actor whose `msg_type` SipHash-collides. When the target is not
+    // live, `dispatch` is null: `decode_payload` finds no codec under a null key
+    // and fails closed below (the standard decode-failure rejection), so no
+    // separate not-live branch is needed.
+    let target_dispatch = crate::lifetime::live_actors::dispatch_ptr_by_id(target_actor_id);
+
     // Reconstruct the request value into THIS node's address space before the
     // local ask — the inbound `payload` is the serialized wire form, not the
     // in-memory struct. Feeding it raw to the handler would dereference
@@ -1307,9 +1356,10 @@ fn handle_inbound_ask(
     let decoded_request: Option<(*mut c_void, usize)> = if payload.is_empty() {
         None
     } else {
+        let dispatch = target_dispatch.unwrap_or(std::ptr::null());
         // SAFETY: payload is a valid slice for payload.len() bytes.
         let (value, struct_size) = unsafe {
-            crate::xnode_serial::decode_payload(msg_type, payload.as_ptr(), payload.len())
+            crate::xnode_serial::decode_payload(dispatch, msg_type, payload.as_ptr(), payload.len())
         };
         if value.is_null() {
             // No codec or decode failure — fail closed: send a rejection (if the
@@ -1372,15 +1422,21 @@ fn handle_inbound_ask(
         // `reply_ptr` points to the in-memory reply VALUE (a struct that may
         // contain heap pointers). Serialize its CONTENTS for transport rather
         // than shipping the raw struct bytes — the originating node reconstructs
-        // the value into its own address space. The reply codec is keyed by the
-        // request `msg_type` (a handler's reply type maps 1:1 to its msg_type).
+        // the value into its own address space. The reply codec is keyed by
+        // `(target dispatch, request msg_type)` — the same target actor type that
+        // just produced the reply, so a colliding `msg_type` on another actor
+        // type cannot select the wrong reply codec.
         // SAFETY: reply_ptr came from hew_reply which malloc'd the reply struct.
         let size = unsafe { crate::actor::hew_reply_data_size(reply_ptr) };
         if size > 0 {
             let mut out_len: usize = 0;
+            // The local ask succeeded against `target_actor_id`, so its dispatch
+            // resolved above; a null fallback fails closed in `encode_reply`.
+            let dispatch = target_dispatch.unwrap_or(std::ptr::null());
             // SAFETY: reply_ptr is a valid reply value for msg_type; out_len valid.
-            let bytes =
-                unsafe { crate::xnode_serial::encode_reply(msg_type, reply_ptr, &raw mut out_len) };
+            let bytes = unsafe {
+                crate::xnode_serial::encode_reply(dispatch, msg_type, reply_ptr, &raw mut out_len)
+            };
             // SAFETY: reply_ptr was malloc'd by hew_reply; free after encoding.
             // NOTE (robustness gap): `reply_ptr` is a flat memcpy of the actor's
             // reply value.  If the reply type has owned string/bytes fields, their
@@ -2369,14 +2425,20 @@ pub unsafe extern "C" fn hew_node_lookup(node: *mut HewNode, name: *const c_char
 
 /// Send a message to a target PID, routing local vs remote by PID node ID.
 ///
+/// `dispatch` is the TARGET actor TYPE's dispatch function pointer, keying the
+/// cross-node serialize codec `(dispatch, msg_type)` on the remote path. Unused
+/// on the local path. May be null for a local-only send.
+///
 /// # Safety
 ///
 /// - `node` must be valid.
 /// - `payload` must be valid for `payload_len` bytes, or null when len is 0.
+/// - `dispatch` is an opaque codec key, never dereferenced.
 #[no_mangle]
 pub unsafe extern "C" fn hew_node_send(
     node: *mut HewNode,
     target_pid: u64,
+    dispatch: *const c_void,
     msg_type: i32,
     payload: *const u8,
     payload_len: usize,
@@ -2396,6 +2458,7 @@ pub unsafe extern "C" fn hew_node_send(
         return unsafe {
             crate::actor::hew_actor_send_by_id(
                 target_pid,
+                dispatch,
                 msg_type,
                 payload.cast_mut().cast::<c_void>(),
                 payload_len,
@@ -2423,8 +2486,12 @@ pub unsafe extern "C" fn hew_node_send(
     let serialized: Option<(*mut u8, usize)> = if payload_len > 0 {
         let mut out_len: usize = 0;
         // SAFETY: payload points to a valid value of the message type; out_len valid.
+        // Keyed by `(dispatch, msg_type)` — the target actor TYPE's serializer,
+        // so a colliding `msg_type` on another actor type cannot select the
+        // wrong codec for the value being shipped.
         let bytes = unsafe {
             crate::xnode_serial::encode_payload(
+                dispatch,
                 msg_type,
                 payload.cast::<std::ffi::c_void>(),
                 &raw mut out_len,
@@ -2907,6 +2974,7 @@ enum RemoteAskSetupResult {
 ///   about to park on the reply.
 fn setup_remote_ask(
     pid: u64,
+    dispatch: *const c_void,
     msg_type: i32,
     data: *mut c_void,
     size: usize,
@@ -2938,8 +3006,16 @@ fn setup_remote_ask(
         let serialized_req: Option<(*mut u8, usize)> = if size > 0 {
             let mut out_len: usize = 0;
             // SAFETY: data is a valid value of the message type; out_len valid.
+            // Keyed by `(dispatch, msg_type)` — the target actor TYPE's request
+            // serializer; a colliding `msg_type` on another actor type cannot
+            // select the wrong codec.
             let bytes = unsafe {
-                crate::xnode_serial::encode_payload(msg_type, data.cast_const(), &raw mut out_len)
+                crate::xnode_serial::encode_payload(
+                    dispatch,
+                    msg_type,
+                    data.cast_const(),
+                    &raw mut out_len,
+                )
             };
             if bytes.is_null() {
                 return RemoteAskSetupResult::Error(AskError::EncodeFailed);
@@ -3038,6 +3114,7 @@ fn spawn_remote_ask_timeout(request_id: u64, timeout_ms: u64) -> Result<(), AskE
 /// finish paths. Records the exact [`AskError`] in the node ask-error slot on
 /// failure.
 fn finish_remote_ask_outcome(
+    dispatch: *const c_void,
     msg_type: i32,
     reply_size: usize,
     reply: &ReplyOutcome,
@@ -3057,13 +3134,16 @@ fn finish_remote_ask_outcome(
         };
     }
     // Non-void reply: `reply.data` holds the SERIALIZED reply bytes. Reconstruct
-    // the reply VALUE into this node's address space using the reply codec
-    // (keyed by the request `msg_type`). codegen's ask terminator then memcpy-
-    // loads the reconstructed struct into the reply dest — `reply_size` matches
-    // the reconstructed struct size.
+    // the reply VALUE into this node's address space using the reply codec keyed
+    // by `(dispatch, request msg_type)` — `dispatch` is THIS node's local
+    // dispatch global for the ask's statically-known target actor type (supplied
+    // by codegen at the ask site), so a colliding `msg_type` on another local
+    // actor type cannot select the wrong reply codec. codegen's ask terminator
+    // then memcpy-loads the reconstructed struct into the reply dest —
+    // `reply_size` matches the reconstructed struct size.
     // SAFETY: reply.data is a valid slice for its length.
     let (value, struct_size) = unsafe {
-        crate::xnode_serial::decode_reply(msg_type, reply.data.as_ptr(), reply.data.len())
+        crate::xnode_serial::decode_reply(dispatch, msg_type, reply.data.as_ptr(), reply.data.len())
     };
     if value.is_null() {
         // No reply codec or decode failure — fail closed with a typed error.
@@ -3102,6 +3182,7 @@ fn finish_remote_ask_outcome(
 #[no_mangle]
 pub unsafe extern "C" fn hew_node_api_ask(
     pid: u64,
+    dispatch: *const c_void,
     msg_type: i32,
     data: *mut c_void,
     size: usize,
@@ -3126,10 +3207,14 @@ pub unsafe extern "C" fn hew_node_api_ask(
     }
 
     // Remote path: send message over mesh with request_id, block on the reply.
-    let (request_id, pending) = match setup_remote_ask(pid, msg_type, data, size, ptr::null_mut()) {
-        RemoteAskSetupResult::Ok(pair) => pair,
-        RemoteAskSetupResult::Error(e) => return ask_null(e),
-    };
+    // `dispatch` keys both the request encode and the reply decode `(dispatch,
+    // msg_type)` — it is THIS node's local dispatch global for the ask's
+    // statically-known target actor type (supplied by codegen).
+    let (request_id, pending) =
+        match setup_remote_ask(pid, dispatch, msg_type, data, size, ptr::null_mut()) {
+            RemoteAskSetupResult::Ok(pair) => pair,
+            RemoteAskSetupResult::Error(e) => return ask_null(e),
+        };
 
     // Block until the reply arrives or the caller-supplied timeout elapses.
     let deadline = std::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
@@ -3160,7 +3245,7 @@ pub unsafe extern "C" fn hew_node_api_ask(
         ask_error: AskError::ConnectionDropped,
     });
     drop(outcome_guard);
-    finish_remote_ask_outcome(msg_type, reply_size, &reply)
+    finish_remote_ask_outcome(dispatch, msg_type, reply_size, &reply)
 }
 
 /// Start a non-blocking remote ask for a SUSPENDABLE caller (NEW-5).
@@ -3185,6 +3270,7 @@ pub unsafe extern "C" fn hew_node_api_ask(
 #[no_mangle]
 pub unsafe extern "C" fn hew_node_api_ask_async(
     pid: u64,
+    dispatch: *const c_void,
     msg_type: i32,
     data: *mut c_void,
     size: usize,
@@ -3200,10 +3286,14 @@ pub unsafe extern "C" fn hew_node_api_ask_async(
         return ask_null(AskError::NoRunnableWork);
     }
 
-    let (request_id, pending) = match setup_remote_ask(pid, msg_type, data, size, caller_actor) {
-        RemoteAskSetupResult::Ok(pair) => pair,
-        RemoteAskSetupResult::Error(e) => return ask_null(e),
-    };
+    // `dispatch` keys the request encode `(dispatch, msg_type)`; the matching
+    // reply decode key is re-supplied to `hew_node_api_ask_finish` at the resume
+    // site (codegen knows the target actor type at both ends of the suspend).
+    let (request_id, pending) =
+        match setup_remote_ask(pid, dispatch, msg_type, data, size, caller_actor) {
+            RemoteAskSetupResult::Ok(pair) => pair,
+            RemoteAskSetupResult::Error(e) => return ask_null(e),
+        };
 
     if let Err(e) = spawn_remote_ask_timeout(request_id, timeout_ms) {
         reply_table().remove(request_id);
@@ -3227,6 +3317,7 @@ pub unsafe extern "C" fn hew_node_api_ask_async(
 #[no_mangle]
 pub unsafe extern "C" fn hew_node_api_ask_finish(
     pending_handle: *mut c_void,
+    dispatch: *const c_void,
     msg_type: i32,
     reply_size: usize,
 ) -> *mut c_void {
@@ -3247,7 +3338,9 @@ pub unsafe extern "C" fn hew_node_api_ask_finish(
             ask_error: AskError::ConnectionDropped,
         })
     };
-    finish_remote_ask_outcome(msg_type, reply_size, &reply)
+    // `dispatch` keys the reply decode `(dispatch, msg_type)` — the target actor
+    // type's local dispatch global, re-supplied by codegen at the resume site.
+    finish_remote_ask_outcome(dispatch, msg_type, reply_size, &reply)
 }
 
 /// Abandon a SUSPENDED remote ask whose coroutine frame is being destroyed
@@ -3365,19 +3458,30 @@ mod tests {
         dst.cast::<std::ffi::c_void>()
     }
 
-    /// Register the test u32 codec for `msg_type` as both the request and reply
-    /// codec, so the two-process send/ask paths can serialize their controlled
-    /// payloads. Idempotent across helper processes (each registers in its own
-    /// process).
+    /// Stable per-test stand-in for an actor type's `__hew_actor_dispatch_*`
+    /// global — the `(dispatch, msg_type)` codec-registry key. The test
+    /// registers its codec under this key and threads the SAME pointer into the
+    /// ask/send FFIs so encode/decode resolve the matching codec.
+    static TEST_DISPATCH: u8 = 0;
+    fn test_dispatch() -> *const c_void {
+        std::ptr::addr_of!(TEST_DISPATCH).cast()
+    }
+
+    /// Register the test u32 codec for `(test_dispatch(), msg_type)` as both the
+    /// request and reply codec, so the two-process send/ask paths can serialize
+    /// their controlled payloads. Idempotent across helper processes (each
+    /// registers in its own process).
     fn register_test_u32_codec(msg_type: i32) {
         // SAFETY: the thunks match the codec ABI.
         unsafe {
             crate::xnode_serial::hew_xnode_register_codec(
+                test_dispatch(),
                 msg_type,
                 test_u32_serialize,
                 test_u32_deserialize,
             );
             crate::xnode_serial::hew_xnode_register_reply_codec(
+                test_dispatch(),
                 msg_type,
                 test_u32_serialize,
                 test_u32_deserialize,
@@ -3800,6 +3904,7 @@ mod tests {
             hew_node_send(
                 node.as_ptr(),
                 remote_pid,
+                ptr::null(),
                 TWO_PROCESS_REGISTRY_MSG_TYPE,
                 ptr::null(),
                 0,
@@ -3878,6 +3983,7 @@ mod tests {
         let reply_ptr = unsafe {
             hew_node_api_ask(
                 remote_pid,
+                test_dispatch(),
                 TWO_PROCESS_REGISTRY_MSG_TYPE,
                 (&raw const send_value).cast::<c_void>().cast_mut(),
                 std::mem::size_of::<u32>(),
@@ -3919,6 +4025,7 @@ mod tests {
         let reply_ptr = unsafe {
             hew_node_api_ask(
                 remote_pid,
+                test_dispatch(),
                 TWO_PROCESS_REGISTRY_MSG_TYPE,
                 (&raw const send_value).cast::<c_void>().cast_mut(),
                 std::mem::size_of::<u32>(),
@@ -4664,6 +4771,7 @@ mod tests {
         let reply = unsafe {
             hew_node_api_ask(
                 remote_pid,
+                test_dispatch(),
                 7,
                 ptr::null_mut(),
                 0,
@@ -4854,7 +4962,7 @@ mod tests {
 
         assert!(reply_table().complete(id, Vec::new()));
         // SAFETY: `handle` is the live creator ref from register_parked.
-        let reply = unsafe { hew_node_api_ask_finish(handle, 7, 0) };
+        let reply = unsafe { hew_node_api_ask_finish(handle, test_dispatch(), 7, 0) };
 
         assert_eq!(reply, remote_void_reply_sentinel());
         assert_eq!(hew_node_ask_take_last_error(), AskError::None as i32);
@@ -4873,7 +4981,7 @@ mod tests {
 
         assert!(reply_table().fail(id, AskError::Timeout));
         // SAFETY: `handle` is the live creator ref from register_parked.
-        let reply = unsafe { hew_node_api_ask_finish(handle, 7, 0) };
+        let reply = unsafe { hew_node_api_ask_finish(handle, test_dispatch(), 7, 0) };
 
         assert!(reply.is_null());
         assert_eq!(hew_node_ask_take_last_error(), AskError::Timeout as i32);
@@ -4892,7 +5000,7 @@ mod tests {
 
         reply_table().fail_connection(key);
         // SAFETY: `handle` is the live creator ref from register_parked.
-        let reply = unsafe { hew_node_api_ask_finish(handle, 7, 0) };
+        let reply = unsafe { hew_node_api_ask_finish(handle, test_dispatch(), 7, 0) };
 
         assert!(reply.is_null());
         assert_eq!(
@@ -5432,7 +5540,16 @@ mod tests {
         // Fire-and-forget from node1 to the actor on node2.
         let msg_type_sent: i32 = 77;
         // SAFETY: null payload / size 0 is valid for a bare signal message.
-        let rc = unsafe { hew_node_send(node1.as_ptr(), actor_id, msg_type_sent, ptr::null(), 0) };
+        let rc = unsafe {
+            hew_node_send(
+                node1.as_ptr(),
+                actor_id,
+                ptr::null(),
+                msg_type_sent,
+                ptr::null(),
+                0,
+            )
+        };
         assert_eq!(rc, 0, "hew_node_send should succeed");
 
         let delivered = (0..100).any(|_| {
@@ -5564,7 +5681,16 @@ mod tests {
         // mesh transport — not just process startup.
         let msg_type_sent: i32 = 91;
         // SAFETY: null payload / size 0 is valid for a bare signal message.
-        let rc = unsafe { hew_node_send(node1.as_ptr(), actor_id, msg_type_sent, ptr::null(), 0) };
+        let rc = unsafe {
+            hew_node_send(
+                node1.as_ptr(),
+                actor_id,
+                ptr::null(),
+                msg_type_sent,
+                ptr::null(),
+                0,
+            )
+        };
         assert_eq!(rc, 0, "hew_node_send should succeed");
 
         let delivered = (0..200).any(|_| {
@@ -5791,6 +5917,7 @@ mod tests {
         let reply_ptr = unsafe {
             hew_node_api_ask(
                 actor_id,
+                test_dispatch(),
                 1,
                 ptr::null_mut(),
                 0,
@@ -5873,6 +6000,7 @@ mod tests {
         let reply_ptr = unsafe {
             hew_node_api_ask(
                 actor_id,
+                test_dispatch(),
                 1,
                 (&raw const send_value).cast::<c_void>().cast_mut(),
                 std::mem::size_of::<u32>(),
@@ -5959,6 +6087,7 @@ mod tests {
         let handle = unsafe {
             hew_node_api_ask_async(
                 actor_id,
+                test_dispatch(),
                 1,
                 (&raw const send_value).cast::<c_void>().cast_mut(),
                 std::mem::size_of::<u32>(),
@@ -5997,7 +6126,9 @@ mod tests {
         }
 
         // SAFETY: `handle` is the live creator ref; finish consumes it exactly once.
-        let reply_ptr = unsafe { hew_node_api_ask_finish(handle, 1, std::mem::size_of::<u32>()) };
+        let reply_ptr = unsafe {
+            hew_node_api_ask_finish(handle, test_dispatch(), 1, std::mem::size_of::<u32>())
+        };
         assert!(
             !reply_ptr.is_null(),
             "resumed async ask should bind a non-null reply"
@@ -6062,6 +6193,7 @@ mod tests {
         let reply_ptr = unsafe {
             hew_node_api_ask(
                 actor_id,
+                test_dispatch(),
                 1,
                 ptr::null_mut(),
                 0,
@@ -6132,6 +6264,7 @@ mod tests {
         let reply_ptr = unsafe {
             hew_node_api_ask(
                 actor_id,
+                test_dispatch(),
                 1,
                 ptr::null_mut(),
                 0,
@@ -6219,6 +6352,7 @@ mod tests {
         let reply_ptr = unsafe {
             hew_node_api_ask(
                 actor_id,
+                test_dispatch(),
                 1,
                 ptr::null_mut(),
                 0,
@@ -6288,6 +6422,7 @@ mod tests {
         let reply_ptr = unsafe {
             hew_node_api_ask(
                 actor_id,
+                test_dispatch(),
                 1,
                 ptr::null_mut(),
                 0,
@@ -6383,6 +6518,7 @@ mod tests {
         let reply_ptr = unsafe {
             hew_node_api_ask(
                 actor_id,
+                test_dispatch(),
                 1,
                 ptr::null_mut(),
                 0,
@@ -6457,6 +6593,7 @@ mod tests {
         let reply_ptr = unsafe {
             hew_node_api_ask(
                 actor_id,
+                test_dispatch(),
                 1,
                 ptr::null_mut(),
                 0,
@@ -6525,6 +6662,7 @@ mod tests {
         let reply_ptr = unsafe {
             hew_node_api_ask(
                 actor_id,
+                test_dispatch(),
                 1,
                 ptr::null_mut(),
                 0,
@@ -6596,6 +6734,7 @@ mod tests {
         let ask_handle = thread::spawn(move || unsafe {
             let ptr = hew_node_api_ask(
                 actor_id,
+                test_dispatch(),
                 1,
                 ptr::null_mut(),
                 0,
@@ -6713,6 +6852,7 @@ mod tests {
         let ask_handle = thread::spawn(move || unsafe {
             let ptr = hew_node_api_ask(
                 actor_id,
+                test_dispatch(),
                 1,
                 ptr::null_mut(),
                 0,
@@ -7030,6 +7170,7 @@ mod tests {
         let reply_ptr = unsafe {
             hew_node_api_ask(
                 actor_id,
+                test_dispatch(),
                 1,
                 std::ptr::from_ref(&payload).cast_mut().cast::<c_void>(),
                 std::mem::size_of::<u32>(),
@@ -7135,6 +7276,7 @@ mod tests {
         let reply_ptr = unsafe {
             hew_node_api_ask(
                 actor_id,
+                test_dispatch(),
                 1,
                 ptr::null_mut(),
                 0,
@@ -7214,6 +7356,7 @@ mod tests {
         let reply_ptr = unsafe {
             hew_node_api_ask(
                 actor_id,
+                test_dispatch(),
                 1,
                 std::ptr::from_ref(&payload).cast_mut().cast::<c_void>(),
                 std::mem::size_of::<u32>(),

--- a/hew-runtime/src/lifetime/live_actors.rs
+++ b/hew-runtime/src/lifetime/live_actors.rs
@@ -267,6 +267,37 @@ pub(crate) fn get_actor_ptr_by_id(actor_id: u64) -> Option<*mut HewActor> {
     .flatten()
 }
 
+/// Resolve the per-actor-TYPE dispatch function pointer for a live actor id,
+/// returned as an opaque `*const c_void` codec-registry key.
+///
+/// The dispatch pointer is `HewActor.dispatch` — the same
+/// `__hew_actor_dispatch_<Actor>` global the codegen codec seeder registers the
+/// actor's codecs under. The cross-node decode paths resolve it here from the
+/// wire's `target_actor_id` so an inbound frame is decoded ONLY by the codec
+/// belonging to its target actor's type (`(dispatch, msg_type)` keying), never
+/// by a different actor type whose `msg_type` SipHash-collides.
+///
+/// Reads the dispatch field UNDER the liveness lock (via `with_live_actors_opt`)
+/// so a concurrent teardown cannot free the actor mid-read. Returns `None` when
+/// the actor is not live (the caller then takes the existing fail-closed drop /
+/// `DecodeFailure` path — never a fabricated key) or has no dispatch set.
+// live on not(wasm32) — cross-node inbound decode; dead on wasm32.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn dispatch_ptr_by_id(actor_id: u64) -> Option<*const std::ffi::c_void> {
+    with_live_actors_opt(|map| {
+        let actor_ptr = map
+            .as_ref()
+            .and_then(|m| m.get(&actor_id).map(|ptr| ptr.0))
+            .filter(|ptr| !ptr.is_null())?;
+        // SAFETY: `actor_ptr` is tracked-live under the lock held for this
+        // closure; a concurrent free must remove the entry (under the same lock)
+        // before reclaiming the allocation, so the dispatch field read is valid.
+        let dispatch = unsafe { (*actor_ptr).dispatch }?;
+        Some(dispatch as *const std::ffi::c_void)
+    })
+    .flatten()
+}
+
 /// Check whether an actor pointer is still live (tracked and not yet freed).
 ///
 /// Pointer-identity only: a freed allocation whose address is reused by a

--- a/hew-runtime/src/xnode_serial.rs
+++ b/hew-runtime/src/xnode_serial.rs
@@ -624,96 +624,151 @@ struct ThunkPair {
     deserialize: DeserializeThunk,
 }
 
-static THUNK_REGISTRY: Mutex<Vec<(i32, ThunkPair)>> = Mutex::new(Vec::new());
+/// Codec-registry key: `(dispatch, msg_type)`.
+///
+/// `msg_type` alone is a 32-bit SipHash-1-3 truncation of `"Actor::handler"` and
+/// therefore collision-prone — two DISTINCT actor types whose handler names
+/// collide on the low 32 bits share one `msg_type`. Keying the codec table by
+/// `msg_type` alone let the second registration displace the first, so one
+/// actor's inbound frames were silently decoded by the OTHER actor's codec:
+/// remote type-confusion (an OOB read, a wrong owned-field drop, corruption)
+/// reachable by any peer that routes a frame to the colliding actor.
+///
+/// `dispatch` is the per-actor-TYPE dispatch function pointer
+/// (`__hew_actor_dispatch_<Actor>`), already on `HewActor.dispatch` and already
+/// the established cross-node disambiguator (the profiler handler-name registry
+/// keys by the same `(dispatch_fn_ptr, msg_type)` pair). Two distinct actor
+/// types have distinct dispatch pointers, so distinct `(dispatch, msg_type)`
+/// keys even when `msg_type` collides — the codec for actor B is unreachable
+/// from actor A's identity and vice versa. The dispatch pointer NEVER crosses
+/// the wire: the frame still carries only `(target_actor_id, msg_type)`; each
+/// node derives the key LOCALLY from its own dispatch globals (the inbound
+/// decode resolves `target_actor_id -> HewActor.dispatch`; the originating
+/// send/ask resolves the target/caller actor type's local dispatch global at
+/// the call site). A dispatch pointer is a code-segment address, stable within
+/// one process run but not across processes — which is exactly right, since it
+/// is only ever compared within one process.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct CodecKey {
+    dispatch: usize,
+    msg_type: i32,
+}
 
-/// Register the serialize/deserialize thunk pair for a cross-node message type,
-/// keyed by its `msg_type` discriminant. Called once per type at program start
-/// from codegen-emitted registration glue. Idempotent: a second registration
-/// for the same `msg_type` is only valid when the thunks are identical (same
-/// type re-registered). A collision between distinct types (different thunk
-/// addresses) indicates a SipHash-1-3 truncation collision — astronomically
-/// unlikely but detected via `debug_assert!` so tests catch it immediately.
+impl CodecKey {
+    fn new(dispatch: *const c_void, msg_type: i32) -> Self {
+        Self {
+            dispatch: dispatch as usize,
+            msg_type,
+        }
+    }
+}
+
+static THUNK_REGISTRY: Mutex<Vec<(CodecKey, ThunkPair)>> = Mutex::new(Vec::new());
+
+/// Register the request/tell serialize/deserialize thunk pair for a cross-node
+/// message type, keyed by `(dispatch, msg_type)` — the owning actor TYPE's
+/// dispatch function pointer plus the message discriminant. Called once per
+/// `(actor type, handler)` at program start from codegen-emitted registration
+/// glue. Idempotent: a re-registration for the same `(dispatch, msg_type)` is
+/// only valid when the thunks are identical (the same handler re-registered,
+/// e.g. a duplicated `global_ctors` call). Distinct thunks under the same full
+/// key is structurally impossible now (it would require two distinct handlers of
+/// the same actor type to share one `msg_type`, which the intra-actor checker
+/// already rejects); if it is ever observed it is a hard invariant violation and
+/// we FAIL CLOSED in every build (`boundary-fail-closed`), not just debug —
+/// silently overwriting would re-open the type-confusion in release.
 ///
 /// # Safety
 /// `serialize` / `deserialize` must be valid codegen-emitted thunks matching the
-/// declared signatures.
+/// declared signatures. `dispatch` is an opaque key (never dereferenced).
 #[no_mangle]
 pub unsafe extern "C" fn hew_xnode_register_codec(
+    dispatch: *const c_void,
     msg_type: i32,
     serialize: SerializeThunk,
     deserialize: DeserializeThunk,
 ) {
-    let Ok(mut reg) = THUNK_REGISTRY.lock() else {
-        return;
-    };
-    if let Some(slot) = reg.iter_mut().find(|(k, _)| *k == msg_type) {
-        // Fix 4: detect msg_type collisions between distinct types.  Two distinct
-        // types mapping to the same msg_type would silently mis-route wire
-        // messages.  Same-type re-registration (identical thunk addresses) is
-        // fine (duplicated global_ctors call); different thunk addresses means a
-        // genuine SipHash collision — assert loudly in debug, then overwrite so
-        // the program is at least deterministic in release builds.
-        debug_assert!(
-            slot.1.serialize as usize == serialize as usize
-                && slot.1.deserialize as usize == deserialize as usize,
-            "hew_xnode_register_codec: msg_type {msg_type} collision — two distinct \
-             types share the same SipHash-derived discriminant; routing is ambiguous"
-        );
-        slot.1 = ThunkPair {
-            serialize,
-            deserialize,
-        };
-    } else {
-        reg.push((
-            msg_type,
-            ThunkPair {
-                serialize,
-                deserialize,
-            },
-        ));
-    }
+    register_codec_into(
+        &THUNK_REGISTRY,
+        "request",
+        dispatch,
+        msg_type,
+        serialize,
+        deserialize,
+    );
 }
 
-/// Reply-codec registry, keyed by the REQUEST's `msg_type`. A handler's reply
-/// type maps 1:1 to its request `msg_type`, so the inbound-ask worker (which has
-/// only the request `msg_type`) can find the reply SERIALIZE thunk to encode the
-/// reply value before shipping it back. The originating node decodes the reply
-/// with its statically-known reply type, so it does not consult this registry.
-static REPLY_REGISTRY: Mutex<Vec<(i32, ThunkPair)>> = Mutex::new(Vec::new());
+/// Reply-codec registry, keyed by `(dispatch, msg_type)` — the responding
+/// actor TYPE's dispatch pointer plus the REQUEST's `msg_type`. A handler's
+/// reply type maps 1:1 to its request `msg_type` WITHIN one actor type; keying
+/// by `(dispatch, msg_type)` keeps two colliding-`msg_type` actors' reply
+/// codecs distinct. The inbound-ask worker (which has the target actor's
+/// dispatch via `target_actor_id`) finds the reply SERIALIZE thunk to encode
+/// the reply before shipping it back; the originating node decodes the reply
+/// with the codec for ITS caller's statically-known target actor type (its
+/// local dispatch global for that type), resolved at the ask call site.
+static REPLY_REGISTRY: Mutex<Vec<(CodecKey, ThunkPair)>> = Mutex::new(Vec::new());
 
-/// Register the reply serialize/deserialize thunk pair for an ask, keyed by the
-/// request's `msg_type`. Called once per handler at program start. Same
-/// collision guard as `hew_xnode_register_codec` (Fix 4): identical thunk
-/// addresses on re-registration are fine; different addresses trigger a
-/// `debug_assert!` (distinct reply types colliding on the same request
-/// `msg_type` would mis-route reply decoding).
+/// Register the reply serialize/deserialize thunk pair for an ask, keyed by
+/// `(dispatch, request msg_type)`. Same fail-closed collision guard as
+/// `hew_xnode_register_codec`.
 ///
 /// # Safety
 /// `serialize` / `deserialize` must be valid codegen-emitted reply-type thunks.
+/// `dispatch` is an opaque key (never dereferenced).
 #[no_mangle]
 pub unsafe extern "C" fn hew_xnode_register_reply_codec(
+    dispatch: *const c_void,
     msg_type: i32,
     serialize: SerializeThunk,
     deserialize: DeserializeThunk,
 ) {
-    let Ok(mut reg) = REPLY_REGISTRY.lock() else {
+    register_codec_into(
+        &REPLY_REGISTRY,
+        "reply",
+        dispatch,
+        msg_type,
+        serialize,
+        deserialize,
+    );
+}
+
+/// Shared register body for both registries. On a same-key re-registration with
+/// DIFFERENT thunk addresses, fail closed in EVERY build mode: abort the process
+/// rather than silently overwrite (which would re-open the cross-node
+/// type-confusion in release). With the `(dispatch, msg_type)` key this branch
+/// is unreachable by construction — it guards an invariant, it is not a live
+/// recovery path.
+fn register_codec_into(
+    registry: &Mutex<Vec<(CodecKey, ThunkPair)>>,
+    which: &str,
+    dispatch: *const c_void,
+    msg_type: i32,
+    serialize: SerializeThunk,
+    deserialize: DeserializeThunk,
+) {
+    let key = CodecKey::new(dispatch, msg_type);
+    let Ok(mut reg) = registry.lock() else {
         return;
     };
-    if let Some(slot) = reg.iter_mut().find(|(k, _)| *k == msg_type) {
-        debug_assert!(
-            slot.1.serialize as usize == serialize as usize
-                && slot.1.deserialize as usize == deserialize as usize,
-            "hew_xnode_register_reply_codec: msg_type {msg_type} collision — two \
-             distinct reply types share the same request msg_type discriminant; \
-             reply routing is ambiguous"
+    if let Some(slot) = reg.iter_mut().find(|(k, _)| *k == key) {
+        let same = slot.1.serialize as usize == serialize as usize
+            && slot.1.deserialize as usize == deserialize as usize;
+        // Fail closed in release AND debug: a TRUE collision on the full
+        // `(dispatch, msg_type)` key means two distinct codecs claim the same
+        // actor-type + discriminant — an unrecoverable wire-routing ambiguity.
+        // Refuse rather than pick one and silently mis-route. Identical
+        // re-registration (a duplicated ctor) passes the assert and is a no-op.
+        assert!(
+            same,
+            "hew_xnode_register_codec ({which}): collision on dispatch={:#x} \
+             msg_type={msg_type} — two distinct codecs share one \
+             (actor-type, msg_type) key; cross-node routing is ambiguous",
+            key.dispatch
         );
-        slot.1 = ThunkPair {
-            serialize,
-            deserialize,
-        };
     } else {
         reg.push((
-            msg_type,
+            key,
             ThunkPair {
                 serialize,
                 deserialize,
@@ -722,42 +777,55 @@ pub unsafe extern "C" fn hew_xnode_register_reply_codec(
     }
 }
 
-/// Look up the deserialize thunk for `msg_type`, if registered.
-pub(crate) fn lookup_deserialize(msg_type: i32) -> Option<DeserializeThunk> {
+/// Look up the deserialize thunk for `(dispatch, msg_type)`, if registered.
+pub(crate) fn lookup_deserialize(
+    dispatch: *const c_void,
+    msg_type: i32,
+) -> Option<DeserializeThunk> {
+    let key = CodecKey::new(dispatch, msg_type);
     let reg = THUNK_REGISTRY.lock().ok()?;
     reg.iter()
-        .find(|(k, _)| *k == msg_type)
+        .find(|(k, _)| *k == key)
         .map(|(_, p)| p.deserialize)
 }
 
-/// Look up the reply SERIALIZE thunk for an ask, keyed by the request `msg_type`.
-pub(crate) fn lookup_reply_serialize(msg_type: i32) -> Option<SerializeThunk> {
+/// Look up the reply SERIALIZE thunk for `(dispatch, request msg_type)`.
+pub(crate) fn lookup_reply_serialize(
+    dispatch: *const c_void,
+    msg_type: i32,
+) -> Option<SerializeThunk> {
+    let key = CodecKey::new(dispatch, msg_type);
     let reg = REPLY_REGISTRY.lock().ok()?;
     reg.iter()
-        .find(|(k, _)| *k == msg_type)
+        .find(|(k, _)| *k == key)
         .map(|(_, p)| p.serialize)
 }
 
-/// Look up the reply DESERIALIZE thunk for an ask, keyed by the request `msg_type`.
-pub(crate) fn lookup_reply_deserialize(msg_type: i32) -> Option<DeserializeThunk> {
+/// Look up the reply DESERIALIZE thunk for `(dispatch, request msg_type)`.
+pub(crate) fn lookup_reply_deserialize(
+    dispatch: *const c_void,
+    msg_type: i32,
+) -> Option<DeserializeThunk> {
+    let key = CodecKey::new(dispatch, msg_type);
     let reg = REPLY_REGISTRY.lock().ok()?;
     reg.iter()
-        .find(|(k, _)| *k == msg_type)
+        .find(|(k, _)| *k == key)
         .map(|(_, p)| p.deserialize)
 }
 
-/// Decode an ask REPLY wire payload (keyed by the request `msg_type`) into a
-/// freshly reconstructed reply value + its in-memory struct size. Returns
+/// Decode an ask REPLY wire payload (keyed by `(dispatch, request msg_type)`)
+/// into a freshly reconstructed reply value + its in-memory struct size. Returns
 /// `(null, 0)` if no reply codec is registered or the decode fails.
 ///
 /// # Safety
 /// `data` must be valid for `len` bytes (or null when `len == 0`).
 pub(crate) unsafe fn decode_reply(
+    dispatch: *const c_void,
     msg_type: i32,
     data: *const u8,
     len: usize,
 ) -> (*mut c_void, usize) {
-    let Some(thunk) = lookup_reply_deserialize(msg_type) else {
+    let Some(thunk) = lookup_reply_deserialize(dispatch, msg_type) else {
         return (std::ptr::null_mut(), 0);
     };
     let mut struct_size: usize = 0;
@@ -766,19 +834,21 @@ pub(crate) unsafe fn decode_reply(
     (value, struct_size)
 }
 
-/// Decode an inbound wire payload for `msg_type` into a freshly reconstructed
-/// value in this node's address space. Returns null if no codec is registered
-/// for the type (fail-closed: the caller must drop the message rather than feed
-/// raw bytes to the mailbox) or if the registered thunk reports failure.
+/// Decode an inbound wire payload for `(dispatch, msg_type)` into a freshly
+/// reconstructed value in this node's address space. Returns null if no codec is
+/// registered for the key (fail-closed: the caller must drop the message rather
+/// than feed raw bytes to the mailbox) or if the registered thunk reports
+/// failure.
 ///
 /// # Safety
 /// `data` must be valid for `len` bytes (or null when `len == 0`).
 pub(crate) unsafe fn decode_payload(
+    dispatch: *const c_void,
     msg_type: i32,
     data: *const u8,
     len: usize,
 ) -> (*mut c_void, usize) {
-    let Some(thunk) = lookup_deserialize(msg_type) else {
+    let Some(thunk) = lookup_deserialize(dispatch, msg_type) else {
         return (std::ptr::null_mut(), 0);
     };
     let mut struct_size: usize = 0;
@@ -787,28 +857,30 @@ pub(crate) unsafe fn decode_payload(
     (value, struct_size)
 }
 
-/// Look up the request SERIALIZE thunk for `msg_type`, if registered.
-pub(crate) fn lookup_serialize(msg_type: i32) -> Option<SerializeThunk> {
+/// Look up the request SERIALIZE thunk for `(dispatch, msg_type)`, if registered.
+pub(crate) fn lookup_serialize(dispatch: *const c_void, msg_type: i32) -> Option<SerializeThunk> {
+    let key = CodecKey::new(dispatch, msg_type);
     let reg = THUNK_REGISTRY.lock().ok()?;
     reg.iter()
-        .find(|(k, _)| *k == msg_type)
+        .find(|(k, _)| *k == key)
         .map(|(_, p)| p.serialize)
 }
 
-/// Encode a cross-node REQUEST/tell payload value (keyed by `msg_type`) into a
-/// freshly `malloc`'d byte buffer (length via `out_len`). Returns null +
-/// `*out_len = 0` if no codec is registered (fail-closed: the send path then
-/// refuses to transmit raw bytes).
+/// Encode a cross-node REQUEST/tell payload value (keyed by `(dispatch,
+/// msg_type)`) into a freshly `malloc`'d byte buffer (length via `out_len`).
+/// Returns null + `*out_len = 0` if no codec is registered (fail-closed: the
+/// send path then refuses to transmit raw bytes).
 ///
 /// # Safety
 /// `value_ptr` must point to a valid value of the message type for `msg_type`;
 /// `out_len` must be a valid writable pointer.
 pub(crate) unsafe fn encode_payload(
+    dispatch: *const c_void,
     msg_type: i32,
     value_ptr: *const c_void,
     out_len: *mut usize,
 ) -> *mut u8 {
-    let Some(thunk) = lookup_serialize(msg_type) else {
+    let Some(thunk) = lookup_serialize(dispatch, msg_type) else {
         if !out_len.is_null() {
             // SAFETY: out_len validated non-null.
             unsafe { *out_len = 0 };
@@ -819,20 +891,21 @@ pub(crate) unsafe fn encode_payload(
     unsafe { thunk(value_ptr, out_len) }
 }
 
-/// Encode an ask REPLY value (keyed by the request `msg_type`) into a freshly
-/// `malloc`'d byte buffer. Returns null + `*out_len = 0` if no reply codec is
-/// registered (fail-closed: the inbound-ask worker then sends no reply, and the
-/// originating ask times out rather than receiving raw bytes).
+/// Encode an ask REPLY value (keyed by `(dispatch, request msg_type)`) into a
+/// freshly `malloc`'d byte buffer. Returns null + `*out_len = 0` if no reply
+/// codec is registered (fail-closed: the inbound-ask worker then sends no reply,
+/// and the originating ask times out rather than receiving raw bytes).
 ///
 /// # Safety
 /// `value_ptr` must point to a valid value of the reply type for `msg_type`;
 /// `out_len` must be a valid writable pointer.
 pub(crate) unsafe fn encode_reply(
+    dispatch: *const c_void,
     msg_type: i32,
     value_ptr: *const c_void,
     out_len: *mut usize,
 ) -> *mut u8 {
-    let Some(thunk) = lookup_reply_serialize(msg_type) else {
+    let Some(thunk) = lookup_reply_serialize(dispatch, msg_type) else {
         if !out_len.is_null() {
             // SAFETY: out_len validated non-null.
             unsafe { *out_len = 0 };
@@ -841,6 +914,19 @@ pub(crate) unsafe fn encode_reply(
     };
     // SAFETY: thunk is a valid codegen-emitted reply serialize thunk.
     unsafe { thunk(value_ptr, out_len) }
+}
+
+/// Clear both codec registries. Test-only: the global registries persist across
+/// `#[test]` functions in one process, so a collision test that asserts on the
+/// registry contents must reset them to stay hermetic.
+#[cfg(test)]
+pub(crate) fn clear_codec_registries_for_test() {
+    if let Ok(mut reg) = THUNK_REGISTRY.lock() {
+        reg.clear();
+    }
+    if let Ok(mut reg) = REPLY_REGISTRY.lock() {
+        reg.clear();
+    }
 }
 
 #[cfg(test)]
@@ -939,5 +1025,237 @@ mod tests {
             crate::string::hew_string_drop(s);
             hew_de_reader_free(reader);
         }
+    }
+
+    // ── Cross-node codec collision repro ────────────────────────────────────
+    //
+    // Two distinct actor TYPES whose single-field handlers SipHash-collide on
+    // the low 32 bits of `msg_type` must each route to their OWN codec. The
+    // registry key is `(dispatch_ptr, msg_type)`: the per-actor-type dispatch
+    // function pointer disambiguates colliding `msg_type` integers. A frame for
+    // actor B can only ever select B's codec; A's codec is keyed under A's
+    // dispatch pointer and is unreachable from B's identity. Without the
+    // dispatch key (the pre-fix `msg_type`-only registry) the second
+    // registration overwrites the first, so one actor's frames are silently
+    // decoded by the other actor's codec — remote type-confusion.
+    //
+    // The two codecs reconstruct DIFFERENT owned-field layouts (codec A: a bare
+    // `i64`; codec B: an owned `string`) so the wrong-codec selection is a
+    // genuine type confusion (an i64 read as a string length+pointer, or a
+    // string's bytes read as an i64), not a size coincidence.
+
+    /// Two distinct dispatch-pointer stand-ins for actor types A and B. The real
+    /// key is `__hew_actor_dispatch_<ActorType>`'s address; in the unit test any
+    /// two distinct stable addresses model two distinct actor types.
+    static DISPATCH_A: u8 = 0;
+    static DISPATCH_B: u8 = 0;
+
+    fn dispatch_a() -> *const c_void {
+        std::ptr::addr_of!(DISPATCH_A).cast()
+    }
+    fn dispatch_b() -> *const c_void {
+        std::ptr::addr_of!(DISPATCH_B).cast()
+    }
+
+    /// Codec A serialize: encode a single `i64` field.
+    unsafe extern "C" fn ser_a(value_ptr: *const c_void, out_len: *mut usize) -> *mut u8 {
+        // SAFETY: the test passes a pointer to an i64.
+        let v = unsafe { *value_ptr.cast::<i64>() };
+        let buf = hew_ser_buf_new();
+        // SAFETY: buf is a live builder handle.
+        unsafe { hew_ser_push_i64(buf, v) };
+        // SAFETY: buf consumed; out_len writable.
+        unsafe { hew_ser_finish(buf, out_len) }
+    }
+
+    /// Codec A deserialize: reconstruct a single `i64` into a malloc'd slot.
+    unsafe extern "C" fn de_a(
+        data: *const u8,
+        len: usize,
+        out_struct_size: *mut usize,
+    ) -> *mut c_void {
+        // SAFETY: data valid for len bytes (test contract).
+        let reader = unsafe { hew_de_reader_new(data, len) };
+        // SAFETY: reader live.
+        let v = unsafe { hew_de_read_i64(reader) };
+        // SAFETY: reader live.
+        let failed = unsafe { hew_de_failed(reader) };
+        // SAFETY: reader live, consumed here.
+        unsafe { hew_de_reader_free(reader) };
+        if failed != 0 {
+            return std::ptr::null_mut();
+        }
+        // SAFETY: malloc for an i64 slot.
+        let slot = unsafe { libc::malloc(std::mem::size_of::<i64>()) }.cast::<i64>();
+        if slot.is_null() {
+            return std::ptr::null_mut();
+        }
+        // SAFETY: slot is a fresh i64.
+        unsafe { *slot = v };
+        if !out_struct_size.is_null() {
+            // SAFETY: out_struct_size writable.
+            unsafe { *out_struct_size = std::mem::size_of::<i64>() };
+        }
+        slot.cast()
+    }
+
+    /// Codec B serialize: encode a single owned `string` field.
+    unsafe extern "C" fn ser_b(value_ptr: *const c_void, out_len: *mut usize) -> *mut u8 {
+        // SAFETY: the test passes a pointer to a `*const c_char`.
+        let s = unsafe { *value_ptr.cast::<*const c_char>() };
+        let buf = hew_ser_buf_new();
+        // SAFETY: buf live; s is a valid C string.
+        unsafe { hew_ser_push_string(buf, s) };
+        // SAFETY: buf consumed; out_len writable.
+        unsafe { hew_ser_finish(buf, out_len) }
+    }
+
+    /// Codec B deserialize: reconstruct an owned `string` into a malloc'd slot
+    /// holding the owned `*mut c_char` (owned-field layout differs from A).
+    unsafe extern "C" fn de_b(
+        data: *const u8,
+        len: usize,
+        out_struct_size: *mut usize,
+    ) -> *mut c_void {
+        // SAFETY: data valid for len bytes (test contract).
+        let reader = unsafe { hew_de_reader_new(data, len) };
+        // SAFETY: reader live.
+        let s = unsafe { hew_de_read_string(reader) };
+        // SAFETY: reader live.
+        let failed = unsafe { hew_de_failed(reader) };
+        // SAFETY: reader live, consumed here.
+        unsafe { hew_de_reader_free(reader) };
+        if failed != 0 {
+            // SAFETY: drop the empty owned string the reader handed back.
+            unsafe { crate::string::hew_string_drop(s) };
+            return std::ptr::null_mut();
+        }
+        // SAFETY: malloc for a `*mut c_char` slot.
+        let slot =
+            unsafe { libc::malloc(std::mem::size_of::<*mut c_char>()) }.cast::<*mut c_char>();
+        if slot.is_null() {
+            // SAFETY: reclaim the owned string on alloc failure.
+            unsafe { crate::string::hew_string_drop(s) };
+            return std::ptr::null_mut();
+        }
+        // SAFETY: slot is a fresh owned-pointer slot.
+        unsafe { *slot = s };
+        if !out_struct_size.is_null() {
+            // SAFETY: out_struct_size writable.
+            unsafe { *out_struct_size = std::mem::size_of::<*mut c_char>() };
+        }
+        slot.cast()
+    }
+
+    /// Encode an i64 the way actor A's send path would (codec A serialize).
+    fn encode_with_a(value: i64) -> Vec<u8> {
+        let mut len = 0usize;
+        // SAFETY: ser_a reads the i64 we point at; out_len writable.
+        let bytes = unsafe { ser_a(std::ptr::addr_of!(value).cast(), &raw mut len) };
+        assert!(!bytes.is_null());
+        // SAFETY: bytes valid for len.
+        let v = unsafe { std::slice::from_raw_parts(bytes, len) }.to_vec();
+        // SAFETY: bytes came from hew_ser_finish.
+        unsafe { hew_ser_free_bytes(bytes) };
+        v
+    }
+
+    /// Encode a string the way actor B's send path would (codec B serialize).
+    fn encode_with_b(value: &str) -> Vec<u8> {
+        let cstr = CString::new(value).unwrap();
+        let ptr = cstr.as_ptr();
+        let mut len = 0usize;
+        // SAFETY: ser_b reads the `*const c_char` we point at; out_len writable.
+        let bytes = unsafe { ser_b(std::ptr::addr_of!(ptr).cast(), &raw mut len) };
+        assert!(!bytes.is_null());
+        // SAFETY: bytes valid for len.
+        let v = unsafe { std::slice::from_raw_parts(bytes, len) }.to_vec();
+        // SAFETY: bytes came from hew_ser_finish.
+        unsafe { hew_ser_free_bytes(bytes) };
+        v
+    }
+
+    /// Serializes the codec-registry collision tests: both share the global
+    /// `THUNK_REGISTRY` / `REPLY_REGISTRY` statics and each clears them at the
+    /// end, so they must not interleave.
+    static REGISTRY_TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn colliding_actors_route_to_own_codec() {
+        // Both actors share one SipHash-colliding msg_type.
+        const COLLIDING_MSG_TYPE: i32 = 0x5151_5151;
+
+        let _guard = REGISTRY_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // SAFETY: register two distinct codecs under the SAME msg_type but
+        // DIFFERENT dispatch keys (modeling two distinct actor types).
+        unsafe {
+            hew_xnode_register_codec(dispatch_a(), COLLIDING_MSG_TYPE, ser_a, de_a);
+            hew_xnode_register_codec(dispatch_b(), COLLIDING_MSG_TYPE, ser_b, de_b);
+        }
+
+        // Actor A's frame (an i64) must decode under A's codec to the i64 value.
+        let a_bytes = encode_with_a(-987_654_321);
+        // SAFETY: decode against A's dispatch key; bytes valid for their length.
+        let (a_val, a_size) = unsafe {
+            decode_payload(
+                dispatch_a(),
+                COLLIDING_MSG_TYPE,
+                a_bytes.as_ptr(),
+                a_bytes.len(),
+            )
+        };
+        assert!(
+            !a_val.is_null(),
+            "actor A's frame must route to A's codec, not be lost to B's registration"
+        );
+        // SAFETY: a_val is a malloc'd i64 slot from de_a.
+        let a_decoded = unsafe { *a_val.cast::<i64>() };
+        assert_eq!(a_size, std::mem::size_of::<i64>());
+        assert_eq!(
+            a_decoded, -987_654_321,
+            "actor A's i64 must decode correctly under A's codec"
+        );
+        // SAFETY: a_val came from de_a (libc::malloc of an i64 slot).
+        unsafe { libc::free(a_val) };
+
+        // Actor B's frame (a string) must decode under B's codec to the string.
+        let b_bytes = encode_with_b("collision-payload");
+        // SAFETY: decode against B's dispatch key; bytes valid for their length.
+        let (b_val, b_size) = unsafe {
+            decode_payload(
+                dispatch_b(),
+                COLLIDING_MSG_TYPE,
+                b_bytes.as_ptr(),
+                b_bytes.len(),
+            )
+        };
+        assert!(
+            !b_val.is_null(),
+            "actor B's frame must route to B's codec, not A's (type-confusion)"
+        );
+        // SAFETY: b_val is a malloc'd `*mut c_char` slot from de_b.
+        let b_str_ptr = unsafe { *b_val.cast::<*mut c_char>() };
+        assert_eq!(b_size, std::mem::size_of::<*mut c_char>());
+        // SAFETY: b_str_ptr is an owned C string from de_b.
+        let b_decoded = unsafe { std::ffi::CStr::from_ptr(b_str_ptr) }
+            .to_str()
+            .unwrap()
+            .to_owned();
+        assert_eq!(
+            b_decoded, "collision-payload",
+            "actor B's string must decode correctly under B's codec, not be \
+             reinterpreted by A's i64 codec"
+        );
+        // SAFETY: b_str_ptr is an owned string; b_val is its malloc'd slot.
+        unsafe {
+            crate::string::hew_string_drop(b_str_ptr);
+            libc::free(b_val);
+        }
+
+        // Clean the registry so the serial test ordering is hermetic.
+        clear_codec_registries_for_test();
     }
 }

--- a/hew-runtime/src/xnode_serial.rs
+++ b/hew-runtime/src/xnode_serial.rs
@@ -921,12 +921,8 @@ pub(crate) unsafe fn encode_reply(
 /// registry contents must reset them to stay hermetic.
 #[cfg(test)]
 pub(crate) fn clear_codec_registries_for_test() {
-    if let Ok(mut reg) = THUNK_REGISTRY.lock() {
-        reg.clear();
-    }
-    if let Ok(mut reg) = REPLY_REGISTRY.lock() {
-        reg.clear();
-    }
+    THUNK_REGISTRY.lock().unwrap().clear();
+    REPLY_REGISTRY.lock().unwrap().clear();
 }
 
 #[cfg(test)]

--- a/hew-types/src/actor_protocol.rs
+++ b/hew-types/src/actor_protocol.rs
@@ -296,6 +296,21 @@ mod tests {
     }
 
     #[test]
+    fn cross_actor_colliding_handler_names_share_msg_id() {
+        // `Alpha::h69862` and `Beta::h103299` are a real SipHash-1-3 low-32-bit
+        // collision (found by brute-force search; see the cross-actor checker
+        // test in `check::mod`). Pin the pair here so an accidental hash-impl
+        // change lights up at this anchor, not in a downstream wire break.
+        let a = compute_default_msg_id("Alpha::h69862");
+        let b = compute_default_msg_id("Beta::h103299");
+        assert_eq!(
+            a, b,
+            "the pinned cross-actor collision pair must still collide"
+        );
+        assert_eq!(a, 0xc0f6_cc98);
+    }
+
+    #[test]
     fn msg_id_for_returns_descriptor_id() {
         let descriptor = ActorProtocolDescriptor::from_handlers(
             "Counter",

--- a/hew-types/src/actor_protocol.rs
+++ b/hew-types/src/actor_protocol.rs
@@ -311,6 +311,23 @@ mod tests {
     }
 
     #[test]
+    fn module_qualified_cross_actor_handler_names_share_msg_id() {
+        // `b.Alpha::h804959` and `d.Beta::h3600` are a SipHash-1-3 low-32-bit
+        // collision under the module-short-qualified identity form used for
+        // module-graph actors (module path `["a","b"]` → short `"b"`).
+        // Found by brute-force search over 2M candidates; pinned here so a hash-impl
+        // change is caught at this anchor before it silently breaks the nested-module
+        // cross-actor collision test in `check::mod`.
+        let a = compute_default_msg_id("b.Alpha::h804959");
+        let b = compute_default_msg_id("d.Beta::h3600");
+        assert_eq!(
+            a, b,
+            "the pinned module-qualified cross-actor collision pair must still collide"
+        );
+        assert_eq!(a, 0x3e59_ee08);
+    }
+
+    #[test]
     fn msg_id_for_returns_descriptor_id() {
         let descriptor = ActorProtocolDescriptor::from_handlers(
             "Counter",

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -1802,6 +1802,14 @@ fn build_actor_protocol_descriptors(
 ) -> HashMap<String, crate::actor_protocol::ActorProtocolDescriptor> {
     let mut descriptors: HashMap<String, crate::actor_protocol::ActorProtocolDescriptor> =
         HashMap::new();
+    // Cross-actor collision tracking (defense-in-depth): every published
+    // handler's `(msg_id, actor, handler, span)`. `msg_id` is the 32-bit
+    // transport discriminant on every cross-node frame; two DISTINCT actors
+    // sharing it leave the wire protocol ambiguous. The runtime keys its codec
+    // registry by `(actor-type, msg_id)` so routing is correct in-process, but
+    // refusing the collision at the source of truth keeps the wire unambiguous
+    // for relays / mixed-binary peers (the `boundary-fail-closed` invariant).
+    let mut cross_actor_seen: Vec<(u32, String, String, std::ops::Range<usize>)> = Vec::new();
     for (identity, ad) in collect_program_actors(program) {
         if ad.receive_fns.is_empty() {
             continue;
@@ -1859,6 +1867,15 @@ fn build_actor_protocol_descriptors(
             &specs,
         ) {
             Ok(descriptor) => {
+                // Record each handler's msg_id for the cross-actor pass below.
+                for h in &descriptor.handlers {
+                    let span = ad
+                        .receive_fns
+                        .iter()
+                        .find(|rf| rf.name == h.name)
+                        .map_or(0..0, |rf| rf.span.clone());
+                    cross_actor_seen.push((h.msg_id, identity.clone(), h.name.clone(), span));
+                }
                 descriptors.insert(identity.clone(), descriptor);
             }
             Err(collision) => {
@@ -1901,5 +1918,58 @@ fn build_actor_protocol_descriptors(
             }
         }
     }
+
+    report_cross_actor_msg_id_collisions(&cross_actor_seen, errors);
+
     descriptors
+}
+
+/// Defense-in-depth cross-actor pass: a `msg_id` shared by two DISTINCT actors
+/// is a 32-bit cross-node wire-discriminant collision. Emits one
+/// `CrossActorProtocolCollision` per colliding `msg_id` — the first
+/// distinct-actor pair found — pinned to the later actor's handler span. `seen`
+/// is every published handler's `(msg_id, actor, handler, span)` over the WHOLE
+/// program's actor set (so cross-module collisions are caught); intra-actor dups
+/// were already refused before this runs, so each entry is from a collision-free
+/// (within-its-actor) descriptor.
+fn report_cross_actor_msg_id_collisions(
+    seen: &[(u32, String, String, std::ops::Range<usize>)],
+    errors: &mut Vec<TypeError>,
+) {
+    let mut reported_msg_ids: Vec<u32> = Vec::new();
+    for i in 0..seen.len() {
+        let (msg_id_i, actor_i, handler_i, span_i) = &seen[i];
+        if reported_msg_ids.contains(msg_id_i) {
+            continue;
+        }
+        let Some((_, actor_j, handler_j, _)) = seen[..i]
+            .iter()
+            .find(|(mid, actor_j, _, _)| mid == msg_id_i && actor_j != actor_i)
+        else {
+            continue;
+        };
+        reported_msg_ids.push(*msg_id_i);
+        let message = format!(
+            "actors `{actor_j}` and `{actor_i}` have `receive fn`s with the same \
+             cross-node msg_id 0x{msg_id_i:08x}: `{actor_j}::{handler_j}` and \
+             `{actor_i}::{handler_i}` — the 32-bit wire discriminant is ambiguous"
+        );
+        let mut err = TypeError::new(
+            TypeErrorKind::CrossActorProtocolCollision {
+                actor_a: actor_j.clone(),
+                handler_a: handler_j.clone(),
+                actor_b: actor_i.clone(),
+                handler_b: handler_i.clone(),
+                msg_id: *msg_id_i,
+            },
+            span_i.clone(),
+            message,
+        );
+        err = err.with_suggestion(format!(
+            "rename `{actor_j}::{handler_j}` or `{actor_i}::{handler_i}` so their \
+             fully-qualified names hash to distinct msg_ids; explicit `#[msg_id(N)]` \
+             pinning is reserved for a future release (not yet supported)"
+        ));
+        errors.push(err);
+    }
 }

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -1753,15 +1753,33 @@ enum AnonContext {
 }
 
 /// Collect every `actor` declaration in the program (root items + each
-/// module-graph module), paired with its checker identity: the bare name
-/// for root actors, the dotted `{module_short}.{name}` form for module
-/// actors. The walk is read-only so it can run after the checker has
-/// frozen its mutable state.
-fn collect_program_actors(program: &Program) -> Vec<(String, &ActorDecl)> {
-    let mut actors: Vec<(String, &ActorDecl)> = Vec::new();
+/// module-graph module).
+///
+/// Returns a triple `(collision_identity, sigs_key, actor_decl)` per actor:
+///
+/// - `collision_identity`: the full-path dotted form used for the descriptor
+///   map key and the cross-actor collision check.  Module path `["a","b"]` →
+///   `"a.b.Alpha"`.  Full path ensures actors in DISTINCT nested modules with
+///   an identical leaf component produce different identities so the collision
+///   check sees them as separate actors.
+/// - `sigs_key`: the module-short dotted form `"{leaf}.{Actor}"` (or bare
+///   name for root actors) that `fn_sigs` is keyed with during registration
+///   (`collect_functions` uses `current_module_short()` = the leaf segment).
+///   Used only for `fn_sigs.get("{sigs_key}::{handler}")` look-ups inside
+///   `build_actor_protocol_descriptors`.
+///
+/// The two fields differ for deeply-nested modules: `["a","b"].Alpha` has
+/// `collision_identity = "a.b.Alpha"` but `sigs_key = "b.Alpha"`.  Root and
+/// single-segment modules are the same for both.
+///
+/// The walk is read-only so it can run after the checker has frozen its
+/// mutable state.
+fn collect_program_actors(program: &Program) -> Vec<(String, String, &ActorDecl)> {
+    let mut actors: Vec<(String, String, &ActorDecl)> = Vec::new();
     for (item, _) in &program.items {
         if let Item::Actor(ad) = item {
-            actors.push((ad.name.clone(), ad));
+            // Root actors: both keys are the bare name.
+            actors.push((ad.name.clone(), ad.name.clone(), ad));
         }
     }
     if let Some(mg) = &program.module_graph {
@@ -1769,12 +1787,24 @@ fn collect_program_actors(program: &Program) -> Vec<(String, &ActorDecl)> {
             if *mod_id == mg.root {
                 continue;
             }
-            let module_short = mod_id.path.last().map(String::as_str);
+            let module_full = mod_id.path.join(".");
+            // The leaf segment is what `current_module_short()` (rsplit('.'))
+            // returns during `collect_functions`; that is the prefix used when
+            // fn_sigs keys are registered.
+            let module_leaf = mod_id.path.last().map_or("", String::as_str);
             for (item, _) in &module.items {
                 if let Item::Actor(ad) = item {
-                    let identity = module_short
-                        .map_or_else(|| ad.name.clone(), |m| format!("{m}.{}", ad.name));
-                    actors.push((identity, ad));
+                    let collision_identity = if module_full.is_empty() {
+                        ad.name.clone()
+                    } else {
+                        format!("{module_full}.{}", ad.name)
+                    };
+                    let sigs_key = if module_leaf.is_empty() {
+                        ad.name.clone()
+                    } else {
+                        format!("{module_leaf}.{}", ad.name)
+                    };
+                    actors.push((collision_identity, sigs_key, ad));
                 }
             }
         }
@@ -1810,7 +1840,7 @@ fn build_actor_protocol_descriptors(
     // refusing the collision at the source of truth keeps the wire unambiguous
     // for relays / mixed-binary peers (the `boundary-fail-closed` invariant).
     let mut cross_actor_seen: Vec<(u32, String, String, std::ops::Range<usize>)> = Vec::new();
-    for (identity, ad) in collect_program_actors(program) {
+    for (collision_identity, sigs_key, ad) in collect_program_actors(program) {
         if ad.receive_fns.is_empty() {
             continue;
         }
@@ -1818,7 +1848,8 @@ fn build_actor_protocol_descriptors(
             Vec::with_capacity(ad.receive_fns.len());
         let mut all_signatures_resolved = true;
         for rf in &ad.receive_fns {
-            let key = format!("{identity}::{}", rf.name);
+            // fn_sigs are keyed by the module-short identity (leaf segment).
+            let key = format!("{sigs_key}::{}", rf.name);
             let Some(sig) = fn_sigs.get(&key) else {
                 all_signatures_resolved = false;
                 break;
@@ -1846,7 +1877,7 @@ fn build_actor_protocol_descriptors(
             // is self-describing. Downstream consumers may continue to
             // derive their own emit name today; subsequent Q87 slices route
             // codegen through this `symbol` field.
-            let symbol = format!("{identity}__{}", rf.name);
+            let symbol = format!("{sigs_key}__{}", rf.name);
             specs.push(crate::actor_protocol::ActorHandlerSpec {
                 name: rf.name.clone(),
                 param_tys,
@@ -1862,21 +1893,36 @@ fn build_actor_protocol_descriptors(
             continue;
         }
 
+        // Build the descriptor under `sigs_key` (module-short form) so that
+        // downstream consumers — HIR lowerer, coercion checker — can look it
+        // up via the same identity they registered actors under.
+        // `collision_identity` (full-path form) is used ONLY for the
+        // cross-actor collision check below, where its uniqueness across all
+        // nested-module actors matters.
         match crate::actor_protocol::ActorProtocolDescriptor::from_handlers(
-            identity.clone(),
+            sigs_key.clone(),
             &specs,
         ) {
             Ok(descriptor) => {
-                // Record each handler's msg_id for the cross-actor pass below.
+                // Record each handler's msg_id for the cross-actor pass.
+                // Use `collision_identity` as the actor name so that two actors
+                // in different nested modules with the same leaf segment (and
+                // thus the same `sigs_key`, e.g. `b.Alpha`) appear as DISTINCT
+                // actors in the collision check.
                 for h in &descriptor.handlers {
                     let span = ad
                         .receive_fns
                         .iter()
                         .find(|rf| rf.name == h.name)
                         .map_or(0..0, |rf| rf.span.clone());
-                    cross_actor_seen.push((h.msg_id, identity.clone(), h.name.clone(), span));
+                    cross_actor_seen.push((
+                        h.msg_id,
+                        collision_identity.clone(),
+                        h.name.clone(),
+                        span,
+                    ));
                 }
-                descriptors.insert(identity.clone(), descriptor);
+                descriptors.insert(sigs_key.clone(), descriptor);
             }
             Err(collision) => {
                 // Pin the diagnostic to the second-colliding handler's span

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -27392,9 +27392,11 @@ mod every_attribute {
     #[test]
     fn single_nested_module_actor_descriptor_is_published() {
         // Regression probe: an actor in a nested module (path ["a","b"]) must
-        // have its protocol descriptor published. If collect_program_actors
-        // or build_actor_protocol_descriptors fails to resolve the fn_sigs
-        // key, the descriptor is silently absent.
+        // have its protocol descriptor published. The descriptor is keyed by
+        // the module-short form "b.Alpha" (matching `current_module_short()` =
+        // leaf segment used during fn_sigs registration). If collect_program_actors
+        // or build_actor_protocol_descriptors fails to resolve the fn_sigs key,
+        // the descriptor is silently absent.
         let parsed = hew_parser::parse("actor Alpha { receive fn increment() {} }");
         assert!(parsed.errors.is_empty(), "parse: {:?}", parsed.errors);
         let root_id = ModuleId::root();
@@ -27422,7 +27424,10 @@ mod every_attribute {
             "single module actor must typecheck cleanly; got: {:#?}",
             output.errors
         );
-        // The actor_protocol_descriptors must contain the module-qualified key "b.Alpha"
+        // The actor_protocol_descriptors must contain the module-short key "b.Alpha".
+        // (Full-path identity "a.b.Alpha" is used only for the cross-actor collision
+        // check; the descriptor map stays keyed by the leaf-qualified form for
+        // downstream compatibility with HIR lowering and coercion checking.)
         let descriptor = output.actor_protocol_descriptors.get("b.Alpha");
         assert!(
             descriptor.is_some(),
@@ -27435,8 +27440,10 @@ mod every_attribute {
     #[test]
     fn two_module_actors_both_get_descriptors() {
         // When two separate modules each contain an actor, BOTH descriptors
-        // must be published. This is a structural prerequisite for cross-actor
-        // collision detection — if either is skipped, the collision is missed.
+        // must be published. The descriptor map uses the module-short-qualified
+        // key (leaf segment) for downstream compatibility. This is a structural
+        // prerequisite for cross-actor collision detection — if either actor's
+        // descriptor is skipped, the collision is missed.
         let output = check_two_module_actors(
             "actor Alpha { receive fn ping() {} }",
             vec!["a".to_string(), "b".to_string()],
@@ -27463,11 +27470,11 @@ mod every_attribute {
     fn nested_module_cross_actor_collision_is_caught() {
         // `b.Alpha::h804959` and `d.Beta::h3600` are a real SipHash-1-3 low-32-bit
         // collision under the module-short-qualified identity form (module path
-        // `["a","b"]` → identity `"b.Alpha"`, path `["c","d"]` → identity `"d.Beta"`).
+        // `["a","b"]` → short `"b"`, path `["c","d"]` → short `"d"`).
         // Pair is pinned in `actor_protocol::tests::module_qualified_cross_actor_handler_names_share_msg_id`.
-        // The whole-program collision checker must detect this even though each actor
-        // lives in a separate nested module — it must not silently skip actors from
-        // the module graph.
+        // The whole-program collision checker must detect this even though each
+        // actor lives in a separate nested module — it must not silently skip
+        // actors from the module graph.
         let output = check_two_module_actors(
             "actor Alpha { receive fn h804959() {} }",
             vec!["a".to_string(), "b".to_string()],
@@ -27497,7 +27504,8 @@ mod every_attribute {
         } = &collision.unwrap().kind
         {
             let actors = [actor_a.as_str(), actor_b.as_str()];
-            // The identity includes the module short-qualifier: "b.Alpha" / "d.Beta"
+            // The identity in the diagnostic is the full-path form ("a.b.Alpha" /
+            // "c.d.Beta") because cross_actor_seen uses collision_identity.
             assert!(
                 actors.iter().any(|a| a.ends_with("Alpha"))
                     && actors.iter().any(|a| a.ends_with("Beta")),

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -27329,4 +27329,185 @@ mod every_attribute {
             output.errors
         );
     }
+
+    /// Build a program with two distinct non-root modules, each containing one
+    /// actor, and a root with just `fn main()`. Used to prove the cross-actor
+    /// collision checker covers actors in separate modules (not just root actors).
+    fn check_two_module_actors(
+        alpha_src: &str,
+        alpha_path: Vec<String>,
+        beta_src: &str,
+        beta_path: Vec<String>,
+    ) -> TypeCheckOutput {
+        let alpha_parsed = hew_parser::parse(alpha_src);
+        assert!(
+            alpha_parsed.errors.is_empty(),
+            "alpha module must parse cleanly, got: {:#?}",
+            alpha_parsed.errors
+        );
+        let beta_parsed = hew_parser::parse(beta_src);
+        assert!(
+            beta_parsed.errors.is_empty(),
+            "beta module must parse cleanly, got: {:#?}",
+            beta_parsed.errors
+        );
+        let root_parsed = hew_parser::parse("fn main() {}");
+        assert!(root_parsed.errors.is_empty());
+
+        let root_id = ModuleId::root();
+        let alpha_id = ModuleId::new(alpha_path);
+        let beta_id = ModuleId::new(beta_path);
+
+        let alpha_module = Module {
+            id: alpha_id.clone(),
+            items: alpha_parsed.program.items,
+            imports: vec![],
+            source_paths: vec![],
+            doc: None,
+        };
+        let beta_module = Module {
+            id: beta_id.clone(),
+            items: beta_parsed.program.items,
+            imports: vec![],
+            source_paths: vec![],
+            doc: None,
+        };
+
+        let mut mg = ModuleGraph::new(root_id.clone());
+        mg.add_module(alpha_module).unwrap();
+        mg.add_module(beta_module).unwrap();
+        // topo: both non-root modules before root
+        mg.topo_order = vec![alpha_id, beta_id, root_id];
+
+        let program = Program {
+            module_graph: Some(mg),
+            items: root_parsed.program.items,
+            module_doc: None,
+        };
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        checker.check_program(&program)
+    }
+
+    #[test]
+    fn single_nested_module_actor_descriptor_is_published() {
+        // Regression probe: an actor in a nested module (path ["a","b"]) must
+        // have its protocol descriptor published. If collect_program_actors
+        // or build_actor_protocol_descriptors fails to resolve the fn_sigs
+        // key, the descriptor is silently absent.
+        let parsed = hew_parser::parse("actor Alpha { receive fn increment() {} }");
+        assert!(parsed.errors.is_empty(), "parse: {:?}", parsed.errors);
+        let root_id = ModuleId::root();
+        let mod_id = ModuleId::new(vec!["a".to_string(), "b".to_string()]);
+        let module = Module {
+            id: mod_id.clone(),
+            items: parsed.program.items,
+            imports: vec![],
+            source_paths: vec![],
+            doc: None,
+        };
+        let mut mg = ModuleGraph::new(root_id.clone());
+        mg.add_module(module).unwrap();
+        mg.topo_order = vec![mod_id, root_id];
+        let program = Program {
+            module_graph: Some(mg),
+            items: vec![],
+            module_doc: None,
+        };
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let output = checker.check_program(&program);
+
+        assert!(
+            output.errors.is_empty(),
+            "single module actor must typecheck cleanly; got: {:#?}",
+            output.errors
+        );
+        // The actor_protocol_descriptors must contain the module-qualified key "b.Alpha"
+        let descriptor = output.actor_protocol_descriptors.get("b.Alpha");
+        assert!(
+            descriptor.is_some(),
+            "actor in module [\"a\",\"b\"] must be published under identity \"b.Alpha\"; \
+             known keys: {:?}",
+            output.actor_protocol_descriptors.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn two_module_actors_both_get_descriptors() {
+        // When two separate modules each contain an actor, BOTH descriptors
+        // must be published. This is a structural prerequisite for cross-actor
+        // collision detection — if either is skipped, the collision is missed.
+        let output = check_two_module_actors(
+            "actor Alpha { receive fn ping() {} }",
+            vec!["a".to_string(), "b".to_string()],
+            "actor Beta { receive fn pong() {} }",
+            vec!["c".to_string(), "d".to_string()],
+        );
+        assert!(
+            output.errors.is_empty(),
+            "two non-colliding module actors must typecheck cleanly; got: {:#?}",
+            output.errors
+        );
+        let all_keys: Vec<_> = output.actor_protocol_descriptors.keys().collect();
+        assert!(
+            output.actor_protocol_descriptors.contains_key("b.Alpha"),
+            "b.Alpha descriptor must be present; known keys: {all_keys:?}"
+        );
+        assert!(
+            output.actor_protocol_descriptors.contains_key("d.Beta"),
+            "d.Beta descriptor must be present; known keys: {all_keys:?}"
+        );
+    }
+
+    #[test]
+    fn nested_module_cross_actor_collision_is_caught() {
+        // `b.Alpha::h804959` and `d.Beta::h3600` are a real SipHash-1-3 low-32-bit
+        // collision under the module-short-qualified identity form (module path
+        // `["a","b"]` → identity `"b.Alpha"`, path `["c","d"]` → identity `"d.Beta"`).
+        // Pair is pinned in `actor_protocol::tests::module_qualified_cross_actor_handler_names_share_msg_id`.
+        // The whole-program collision checker must detect this even though each actor
+        // lives in a separate nested module — it must not silently skip actors from
+        // the module graph.
+        let output = check_two_module_actors(
+            "actor Alpha { receive fn h804959() {} }",
+            vec!["a".to_string(), "b".to_string()],
+            "actor Beta { receive fn h3600() {} }",
+            vec!["c".to_string(), "d".to_string()],
+        );
+
+        let collision = output.errors.iter().find(|e| {
+            matches!(
+                &e.kind,
+                TypeErrorKind::CrossActorProtocolCollision { msg_id, .. } if *msg_id == 0x3e59_ee08
+            )
+        });
+        assert!(
+            collision.is_some(),
+            "two distinct module-nested actors with msg_id-colliding handlers \
+             must be rejected with CrossActorProtocolCollision (0x3e59_ee08); \
+             got: {:#?}",
+            output.errors
+        );
+        if let TypeErrorKind::CrossActorProtocolCollision {
+            actor_a,
+            handler_a,
+            actor_b,
+            handler_b,
+            ..
+        } = &collision.unwrap().kind
+        {
+            let actors = [actor_a.as_str(), actor_b.as_str()];
+            // The identity includes the module short-qualifier: "b.Alpha" / "d.Beta"
+            assert!(
+                actors.iter().any(|a| a.ends_with("Alpha"))
+                    && actors.iter().any(|a| a.ends_with("Beta")),
+                "collision diagnostic must name both actors (qualified); got: {actor_a}, {actor_b}"
+            );
+            let handlers = [handler_a.as_str(), handler_b.as_str()];
+            assert!(
+                handlers.contains(&"h804959") && handlers.contains(&"h3600"),
+                "collision diagnostic must name both handlers; got: {handler_a}, {handler_b}"
+            );
+        }
+    }
 }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -27250,4 +27250,83 @@ mod every_attribute {
              got: {opaque_errors:#?}",
         );
     }
+
+    #[test]
+    fn cross_actor_msg_id_collision_is_rejected() {
+        // `Alpha::h69862` and `Beta::h103299` are a real SipHash-1-3 low-32-bit
+        // collision (pinned in `actor_protocol::tests`). Two DISTINCT actors
+        // sharing the 32-bit cross-node wire discriminant must be refused at
+        // compile time (defense-in-depth: the runtime keys its codec registry by
+        // (actor-type, msg_id) and routes correctly in-process, but the wire
+        // discriminant itself is ambiguous for relays / mixed-binary peers).
+        let output = check_source(
+            r"
+            actor Alpha {
+                receive fn h69862() {}
+            }
+            actor Beta {
+                receive fn h103299() {}
+            }
+
+            fn main() {}
+            ",
+        );
+
+        let collision = output.errors.iter().find(|e| {
+            matches!(
+                &e.kind,
+                TypeErrorKind::CrossActorProtocolCollision { msg_id, .. } if *msg_id == 0xc0f6_cc98
+            )
+        });
+        assert!(
+            collision.is_some(),
+            "two distinct actors with msg_id-colliding handlers must be rejected \
+             with CrossActorProtocolCollision; got: {:#?}",
+            output.errors
+        );
+        let err = collision.unwrap();
+        if let TypeErrorKind::CrossActorProtocolCollision {
+            actor_a,
+            handler_a,
+            actor_b,
+            handler_b,
+            ..
+        } = &err.kind
+        {
+            // Both actors and both handlers are named (order: first-seen, then
+            // the later offender).
+            let actors = [actor_a.as_str(), actor_b.as_str()];
+            assert!(actors.contains(&"Alpha") && actors.contains(&"Beta"));
+            let handlers = [handler_a.as_str(), handler_b.as_str()];
+            assert!(handlers.contains(&"h69862") && handlers.contains(&"h103299"));
+        }
+    }
+
+    #[test]
+    fn distinct_actor_non_colliding_handlers_are_clean() {
+        // Negative control: two actors whose handler names do NOT collide on the
+        // 32-bit msg_id must produce no cross-actor collision diagnostic.
+        let output = check_source(
+            r"
+            actor Alpha {
+                receive fn ping() {}
+            }
+            actor Beta {
+                receive fn pong() {}
+            }
+
+            fn main() {}
+            ",
+        );
+
+        assert!(
+            !output
+                .errors
+                .iter()
+                .any(|e| matches!(&e.kind, TypeErrorKind::CrossActorProtocolCollision { .. })),
+            "non-colliding actor handlers must not produce a cross-actor collision; \
+             got: {:#?}",
+            output.errors
+        );
+    }
 }

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -635,6 +635,30 @@ pub enum TypeErrorKind {
         /// The 32-bit `msg_id` both handlers hashed to.
         msg_id: u32,
     },
+    /// Two `receive fn`s in DISTINCT actors hash to the same `msg_id`.
+    ///
+    /// `msg_id` is the 32-bit transport discriminant carried on every
+    /// cross-node frame. Two distinct actor types whose handlers collide on it
+    /// share a wire discriminant; while the runtime codec registry keys by
+    /// `(actor-type, msg_id)` and so routes each correctly within one process,
+    /// the collision leaves the wire protocol itself ambiguous — a future
+    /// relay, a peer on an older binary, or any path that keys on `msg_id`
+    /// alone could re-weaponize it into cross-node type-confusion. Refused at
+    /// compile time (defense-in-depth) so the source of truth stays
+    /// unambiguous. The user renames one handler; `#[msg_id(N)]` pinning is
+    /// reserved for a later release.
+    CrossActorProtocolCollision {
+        /// First actor in the colliding pair.
+        actor_a: String,
+        /// First actor's colliding handler name.
+        handler_a: String,
+        /// Second actor in the colliding pair.
+        actor_b: String,
+        /// Second actor's colliding handler name.
+        handler_b: String,
+        /// The 32-bit `msg_id` both handlers hashed to.
+        msg_id: u32,
+    },
     /// An `extern "rt"` function declaration names a symbol that is not in
     /// the `stable` section of `scripts/jit-symbol-classification.toml`.
     ///
@@ -1000,6 +1024,7 @@ impl TypeErrorKind {
             Self::ClosureCapturesDuplexHandle { .. } => "ClosureCapturesDuplexHandle",
             Self::AssocTypeProjectionFailed { .. } => "AssocTypeProjectionFailed",
             Self::ActorProtocolCollision { .. } => "ActorProtocolCollision",
+            Self::CrossActorProtocolCollision { .. } => "CrossActorProtocolCollision",
             Self::ExternRtSymbolUnclassified { .. } => "ExternRtSymbolUnclassified",
             Self::GenBlockInActorReceive => "GenBlockInActorReceive",
             Self::GenBlockInMachineTransition => "GenBlockInMachineTransition",


### PR DESCRIPTION
## Summary

The actor message codec was keyed by `msg_type` alone, letting two distinct actors that happen to share the same numeric message ID silently collide on the wire. A message encoded under one actor's protocol could be decoded under a different actor's protocol — a mis-decode that is indistinguishable from a crafted message. I've re-keyed the codec by `(dispatch_global_ptr, msg_type)` so each actor's protocol namespace is distinct. The key-miss path now fails closed (release assert) rather than silently mis-routing. I also fixed the compile-time `CrossActorProtocolCollision` checker, which was computing the collision identity from only the last path segment; it now uses the full module-qualified path so collisions across nested modules are correctly caught at build time.

## What changed

- `hew-runtime/src/xnode_serial.rs` — codec registry key is `(dispatch_global_ptr, msg_type)`; actor identity is part of the key, so the same numeric ID in different actors no longer aliases.
- `hew-runtime/src/hew_node.rs` + `actor.rs` + `lifetime/live_actors.rs` — `hew_node_api_ask_finish` accepts the dispatch pointer as a second argument; the runtime uses it to select the correct decode table.
- `hew-codegen-rs/src/llvm.rs` — codegen passes `dispatch_ptr` to both `hew_node_api_ask_async` and `hew_node_api_ask_finish` call sites.
- `hew-types/src/actor_protocol.rs` + `check/mod.rs` + `error.rs` — `CrossActorProtocolCollision` checker builds `collision_identity` from `mod_id.path.join(".")`, using full dotted module paths as the identity discriminator.
- `hew-types/src/check/tests.rs` — wire-forgery, no-collision, fail-closed, and nested-module cross-actor collision regression tests.

## Verification

- Wire-forgery tests: a message encoded under one actor cannot be decoded by a second actor sharing the same numeric ID — the codec returns the typed-failure sentinel.
- No-collision tests: legitimate same-ID messages within the correct actor round-trip correctly.
- Fail-closed test: a key miss triggers the release assert rather than silently producing garbage.
- FFI-safety: `hew_node_api_ask_finish` signature change threads through the generated call sites cleanly with no cross-FFI boundary issues.
- Nested-module regression: `CrossActorProtocolCollision` now correctly flags actors in separate nested modules whose numeric message IDs collide; non-colliding controls remain clean.
- `hew-types`: 2156/2156 tests green; runtime suites green.
- Preflight: ready-to-push (fmt check passed on push).

## Out of scope

- No changes to the local-pid (intra-node) codec path — that path is keyed differently and was not affected by this collision class.
- No changes to the checker's handling of trait-impl actor protocols — a separate surface.
