### PR TITLE
fix(types): fail-closed the `#[on(crash)]` crash-action hook at check time

### DIFF
--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -2485,6 +2485,7 @@ machine Traffic {
             TypeErrorKind::OrphanImpl,
             TypeErrorKind::PlatformLimitation,
             TypeErrorKind::OnUpgradeNotYetWired,
+            TypeErrorKind::CrashActionReturnNotYetWired,
             TypeErrorKind::MachineExhaustivenessError,
             TypeErrorKind::BlockingCallInReceiveFn,
         ];

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -5353,6 +5353,12 @@ impl Checker {
         let prev_capture_facts = std::mem::take(&mut self.lambda_capture_facts);
         let prev_actor_handler_context = self.in_actor_handler_context;
         self.in_actor_handler_context = false;
+        // A closure is NOT the crash hook itself, even if it is syntactically
+        // nested inside one.  Clear in_crash_hook so a `return CrashAction::X;`
+        // inside the nested closure does not inherit the hook's flag and fire a
+        // false-positive CrashActionReturnNotYetWired diagnostic.
+        let prev_in_crash_hook = self.in_crash_hook;
+        self.in_crash_hook = false;
         // A lambda body does not inherit the lexical task scope it is written
         // inside: the closure may run after the scope has joined, so `fork`
         // statements inside it have no spawn context.
@@ -5479,6 +5485,7 @@ impl Checker {
 
         self.current_return_type = prev_return_type;
         self.in_actor_handler_context = prev_actor_handler_context;
+        self.in_crash_hook = prev_in_crash_hook;
         self.task_scope_depth = prev_task_scope_depth;
         self.in_lambda_actor_body = prev_in_lambda_actor_body;
         self.in_generator = prev_in_generator;

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -1399,7 +1399,10 @@ impl Checker {
         }
 
         self.current_return_type = Some(return_ty);
+        let prev_in_crash_hook = self.in_crash_hook;
+        self.in_crash_hook = true;
         let body_ty = self.check_block(&hook.body, None);
+        self.in_crash_hook = prev_in_crash_hook;
         self.current_return_type = None;
         self.in_actor_handler_context = prev_actor_handler_context;
 

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -1399,9 +1399,40 @@ impl Checker {
         }
 
         self.current_return_type = Some(return_ty);
-        self.check_block(&hook.body, None);
+        let body_ty = self.check_block(&hook.body, None);
         self.current_return_type = None;
         self.in_actor_handler_context = prev_actor_handler_context;
+
+        // Fail-closed: `CrashAction` enum-variant return is not yet wired
+        // through HIR→MIR→codegen (the MIR lowering coerces the handler return
+        // to `i32` and the body's `CrashAction` struct causes a Move type
+        // mismatch at codegen time).  Gate it here so the user sees a clear
+        // compile error instead of an internal `E_NOT_YET_IMPLEMENTED` panic.
+        //
+        // Match by name rather than by `builtin: Some(CrashAction)` because
+        // `fn_sigs`-sourced variant constructors carry `builtin: None` (set at
+        // `registration.rs:1584`) — the authoritative discriminant is the name.
+        //
+        // WHEN obsolete: when v0.6 removes the I32 return coercion in
+        // `hew-mir/src/lower.rs` (`lower_actor_lifecycle_hooks`) and wires the
+        // full enum-variant return path, remove this guard and the corresponding
+        // `TypeErrorKind::CrashActionReturnNotYetWired` variant.
+        let body_is_crash_action = matches!(
+            &body_ty,
+            Ty::Named { name, .. } if name == "CrashAction"
+        );
+        if body_is_crash_action {
+            self.errors.push(TypeError::new(
+                TypeErrorKind::CrashActionReturnNotYetWired,
+                hook.fn_span.clone(),
+                format!(
+                    "`#[on(crash)]` hook `{actor_name}::{}` body returns `CrashAction` directly; \
+                     `CrashAction` enum-variant construction is not yet wired through the compiler — \
+                     use `panic(...)` (a diverging expression) as the hook body for now",
+                    hook.name
+                ),
+            ));
+        }
 
         self.current_function = prev_function;
         self.env.pop_scope();

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -237,6 +237,10 @@ impl Checker {
 
     /// Check a statement that may serve as a block's trailing expression.
     /// Returns the "expression type" of the statement.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "statement-as-expr covers many Stmt variants including the crash-hook return gate"
+    )]
     pub(super) fn check_stmt_as_expr(
         &mut self,
         stmt: &Stmt,
@@ -332,6 +336,37 @@ impl Checker {
                             }
                             _ => {}
                         }
+                    }
+                    // Fail-closed: a `return <CrashAction>;` inside a
+                    // `#[on(crash)]` hook is equivalent to the tail-expression
+                    // form and hits the same unimplemented lowering path.
+                    // Reject it here with the same diagnostic so the user
+                    // never reaches codegen.
+                    //
+                    // WHEN obsolete: when v0.6 wires CrashAction return-shape
+                    // through HIR lowering, remove this guard together with the
+                    // `in_crash_hook` field and the tail-expression gate in
+                    // `check_crash_hook` in `items.rs`.
+                    if self.in_crash_hook
+                        && matches!(
+                            self.subst.resolve(&effective_expected),
+                            Ty::Named { name, .. } if name == "CrashAction"
+                        )
+                    {
+                        let fn_name = self
+                            .current_function
+                            .clone()
+                            .unwrap_or_else(|| "<unknown>".to_string());
+                        self.errors.push(TypeError::new(
+                            TypeErrorKind::CrashActionReturnNotYetWired,
+                            span.clone(),
+                            format!(
+                                "`#[on(crash)]` hook `{fn_name}` uses `return CrashAction::…`; \
+                                 `CrashAction` enum-variant construction is not yet wired through \
+                                 the compiler — use `panic(...)` (a diverging expression) as the \
+                                 hook body for now",
+                            ),
+                        ));
                     }
                 }
                 Ty::Never

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -235,6 +235,27 @@ impl Checker {
         ty
     }
 
+    /// Emit `CrashActionReturnNotYetWired` for a `return CrashAction::…;` inside
+    /// an `#[on(crash)]` hook body.  Called from both `Stmt::Return` arms
+    /// (`check_stmt` and `check_stmt_as_expr`) after the type of the returned
+    /// expression is confirmed to be `CrashAction`.
+    ///
+    /// WHEN obsolete: when v0.6 wires the full `CrashAction` return path through
+    /// HIR lowering, remove this helper together with the `in_crash_hook` field
+    /// and the `body_is_crash_action` check in `check_crash_hook` in `items.rs`.
+    fn emit_crash_action_return_error(&mut self, span: &Span, fn_name: &str) {
+        self.errors.push(TypeError::new(
+            TypeErrorKind::CrashActionReturnNotYetWired,
+            span.clone(),
+            format!(
+                "`#[on(crash)]` hook `{fn_name}` uses `return CrashAction::…`; \
+                 `CrashAction` enum-variant construction is not yet wired through \
+                 the compiler — use `panic(...)` (a diverging expression) as the \
+                 hook body for now",
+            ),
+        ));
+    }
+
     /// Check a statement that may serve as a block's trailing expression.
     /// Returns the "expression type" of the statement.
     #[expect(
@@ -340,13 +361,7 @@ impl Checker {
                     // Fail-closed: a `return <CrashAction>;` inside a
                     // `#[on(crash)]` hook is equivalent to the tail-expression
                     // form and hits the same unimplemented lowering path.
-                    // Reject it here with the same diagnostic so the user
-                    // never reaches codegen.
-                    //
-                    // WHEN obsolete: when v0.6 wires CrashAction return-shape
-                    // through HIR lowering, remove this guard together with the
-                    // `in_crash_hook` field and the tail-expression gate in
-                    // `check_crash_hook` in `items.rs`.
+                    // Reject it here so the user never reaches codegen.
                     if self.in_crash_hook
                         && matches!(
                             self.subst.resolve(&effective_expected),
@@ -357,16 +372,7 @@ impl Checker {
                             .current_function
                             .clone()
                             .unwrap_or_else(|| "<unknown>".to_string());
-                        self.errors.push(TypeError::new(
-                            TypeErrorKind::CrashActionReturnNotYetWired,
-                            span.clone(),
-                            format!(
-                                "`#[on(crash)]` hook `{fn_name}` uses `return CrashAction::…`; \
-                                 `CrashAction` enum-variant construction is not yet wired through \
-                                 the compiler — use `panic(...)` (a diverging expression) as the \
-                                 hook body for now",
-                            ),
-                        ));
+                        self.emit_crash_action_return_error(span, &fn_name);
                     }
                 }
                 Ty::Never
@@ -948,18 +954,7 @@ impl Checker {
                     }
                     // Fail-closed: a non-final `return <CrashAction>;` inside an
                     // `#[on(crash)]` hook (e.g. inside an `if` branch, followed by
-                    // more code) hits the same unimplemented lowering path as a
-                    // tail-expression or final-return form.  Gate it here so no
-                    // `return CrashAction::X;` anywhere in the hook body escapes to
-                    // codegen regardless of its position.
-                    //
-                    // This mirrors the identical gate in `check_stmt_as_expr`'s
-                    // `Stmt::Return` arm (which covers final/tail-position returns).
-                    // Together they close every path a `CrashAction` value can travel
-                    // through a `return` statement inside `#[on(crash)]`.  The third
-                    // path — a CrashAction tail-expression without a `return` keyword —
-                    // is caught by the `body_is_crash_action` check in `check_crash_hook`
-                    // in `items.rs` after `check_block` returns.
+                    // more code) hits the same unimplemented lowering path.
                     //
                     // Exit inventory (all gated):
                     //   (1) non-final `return CrashAction`  → THIS guard
@@ -967,11 +962,6 @@ impl Checker {
                     //   (3) tail-expr CrashAction (no return keyword) → items.rs body_is_crash_action
                     //   (4) if/match expr whose arms all yield CrashAction → flows into (3)
                     //   (5) let-bound CrashAction, then returned → flows into (1) or (2)
-                    //
-                    // WHEN obsolete: when v0.6 wires CrashAction return-shape
-                    // through HIR lowering, remove this guard together with the
-                    // `in_crash_hook` field, the `check_stmt_as_expr` gate, and the
-                    // `body_is_crash_action` check in `check_crash_hook` in `items.rs`.
                     if self.in_crash_hook
                         && matches!(
                             self.subst.resolve(&effective_expected),
@@ -982,16 +972,7 @@ impl Checker {
                             .current_function
                             .clone()
                             .unwrap_or_else(|| "<unknown>".to_string());
-                        self.errors.push(TypeError::new(
-                            TypeErrorKind::CrashActionReturnNotYetWired,
-                            span.clone(),
-                            format!(
-                                "`#[on(crash)]` hook `{fn_name}` uses `return CrashAction::…`; \
-                                 `CrashAction` enum-variant construction is not yet wired through \
-                                 the compiler — use `panic(...)` (a diverging expression) as the \
-                                 hook body for now",
-                            ),
-                        ));
+                        self.emit_crash_action_return_error(span, &fn_name);
                     }
                 }
             }

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -946,6 +946,53 @@ impl Checker {
                             _ => {}
                         }
                     }
+                    // Fail-closed: a non-final `return <CrashAction>;` inside an
+                    // `#[on(crash)]` hook (e.g. inside an `if` branch, followed by
+                    // more code) hits the same unimplemented lowering path as a
+                    // tail-expression or final-return form.  Gate it here so no
+                    // `return CrashAction::X;` anywhere in the hook body escapes to
+                    // codegen regardless of its position.
+                    //
+                    // This mirrors the identical gate in `check_stmt_as_expr`'s
+                    // `Stmt::Return` arm (which covers final/tail-position returns).
+                    // Together they close every path a `CrashAction` value can travel
+                    // through a `return` statement inside `#[on(crash)]`.  The third
+                    // path — a CrashAction tail-expression without a `return` keyword —
+                    // is caught by the `body_is_crash_action` check in `check_crash_hook`
+                    // in `items.rs` after `check_block` returns.
+                    //
+                    // Exit inventory (all gated):
+                    //   (1) non-final `return CrashAction`  → THIS guard
+                    //   (2) final/tail `return CrashAction` → check_stmt_as_expr gate
+                    //   (3) tail-expr CrashAction (no return keyword) → items.rs body_is_crash_action
+                    //   (4) if/match expr whose arms all yield CrashAction → flows into (3)
+                    //   (5) let-bound CrashAction, then returned → flows into (1) or (2)
+                    //
+                    // WHEN obsolete: when v0.6 wires CrashAction return-shape
+                    // through HIR lowering, remove this guard together with the
+                    // `in_crash_hook` field, the `check_stmt_as_expr` gate, and the
+                    // `body_is_crash_action` check in `check_crash_hook` in `items.rs`.
+                    if self.in_crash_hook
+                        && matches!(
+                            self.subst.resolve(&effective_expected),
+                            Ty::Named { name, .. } if name == "CrashAction"
+                        )
+                    {
+                        let fn_name = self
+                            .current_function
+                            .clone()
+                            .unwrap_or_else(|| "<unknown>".to_string());
+                        self.errors.push(TypeError::new(
+                            TypeErrorKind::CrashActionReturnNotYetWired,
+                            span.clone(),
+                            format!(
+                                "`#[on(crash)]` hook `{fn_name}` uses `return CrashAction::…`; \
+                                 `CrashAction` enum-variant construction is not yet wired through \
+                                 the compiler — use `panic(...)` (a diverging expression) as the \
+                                 hook body for now",
+                            ),
+                        ));
+                    }
                 }
             }
             Stmt::Loop { label, body } => {

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -2553,6 +2553,13 @@ pub struct Checker {
     /// (a Duplex capture called from within its own actor body) while rejecting
     /// fn-closure captures of Duplex handles.
     pub(super) in_lambda_actor_body: bool,
+    /// Whether we are currently inside a `#[on(crash)]` hook body.
+    ///
+    /// Set to `true` for the duration of `check_crash_hook`'s body check so
+    /// that `Stmt::Return` can reject `return <CrashAction>;` with the same
+    /// `CrashActionReturnNotYetWired` diagnostic that the tail-expression gate
+    /// fires — both forms are fail-closed until v0.6 wires the full return path.
+    pub(super) in_crash_hook: bool,
     /// Whether we are currently inside an unsafe block.
     pub(super) in_unsafe: bool,
     /// Nesting depth of `scope { }` structured-concurrency blocks in the
@@ -2912,6 +2919,7 @@ impl Checker {
             in_receive_fn: false,
             in_actor_handler_context: false,
             in_lambda_actor_body: false,
+            in_crash_hook: false,
             in_unsafe: false,
             task_scope_depth: 0,
             current_module: None,

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -469,6 +469,21 @@ pub enum TypeErrorKind {
     PlatformLimitation,
     /// `#[on(upgrade)]` is parsed but rejected: it is reserved and not supported.
     OnUpgradeNotYetWired,
+    /// `#[on(crash)]` body returns a `CrashAction` value rather than diverging.
+    ///
+    /// The v0.5 MIR crash-hook lowering coerces the handler return type to
+    /// `i32` because the `CrashAction` enum-variant return path is not yet
+    /// wired through HIR→MIR→codegen.  A non-diverging crash hook body (one
+    /// that constructs `CrashAction::Restart`, `::Escalate`, or `::Kill`)
+    /// produces a type mismatch at codegen time.  Fail-closed: surface this as
+    /// a compile-time diagnostic so the user sees a clear message rather than an
+    /// internal `E_NOT_YET_IMPLEMENTED` codegen panic.
+    ///
+    /// WHEN obsolete: when v0.6 wires `CrashAction` enum-variant return-shape
+    /// through HIR lowering and removes the `I32` coercion in
+    /// `hew-mir/src/lower.rs` (`lower_actor_lifecycle_hooks`), remove this
+    /// variant and the gate in `check_crash_hook`.
+    CrashActionReturnNotYetWired,
     /// Machine state × event exhaustiveness violation
     MachineExhaustivenessError,
     /// Import cannot be resolved: module not found or failed to parse
@@ -1004,6 +1019,7 @@ impl TypeErrorKind {
             Self::OrphanImpl => "OrphanImpl",
             Self::PlatformLimitation => "PlatformLimitation",
             Self::OnUpgradeNotYetWired => "OnUpgradeNotYetWired",
+            Self::CrashActionReturnNotYetWired => "CrashActionReturnNotYetWired",
             Self::MachineExhaustivenessError => "MachineExhaustivenessError",
             Self::UnresolvedImport => "UnresolvedImport",
             Self::BlockingCallInReceiveFn => "BlockingCallInReceiveFn",

--- a/hew-types/tests/actor_lifecycle_hooks.rs
+++ b/hew-types/tests/actor_lifecycle_hooks.rs
@@ -198,23 +198,27 @@ fn reject_unknown_hook_kind() {
 
 #[test]
 fn on_crash_still_works() {
+    // `#[on(crash)]` with a diverging body (`panic(...)`) must type-check
+    // cleanly.  The hook itself is live — only the non-diverging
+    // `CrashAction`-return path is fail-closed (see
+    // `reject_crash_action_return_not_yet_wired`).
     let output = typecheck(
-        r"
+        r#"
         actor Worker {
             let count: i32;
 
             #[on(crash)]
             fn on_crash(info: CrashInfo) -> CrashAction {
-                CrashAction::Restart
+                panic("handled")
             }
         }
 
         fn main() {}
-        ",
+        "#,
     );
     assert!(
         output.errors.is_empty(),
-        "well-formed `#[on(crash)]` should type-check cleanly: {:?}",
+        "well-formed `#[on(crash)]` with diverging body should type-check cleanly: {:?}",
         output.errors
     );
 }
@@ -304,6 +308,43 @@ fn reject_on_upgrade_with_extra_args() {
     );
 }
 
+// ── E1b: `#[on(crash)]` fail-closed for non-diverging body ───────────
+//
+// `CrashAction` enum-variant return is not yet wired through the compiler
+// (the MIR lowering coerces the handler return type to `i32` and a
+// `CrashAction` value causes a codegen Move type mismatch).  Surfaced here
+// at check-time so the user sees a clear compile error.
+//
+// WHEN obsolete: when v0.6 wires the full CrashAction return path.
+
+#[test]
+fn reject_crash_action_return_not_yet_wired() {
+    // Reject twin: `CrashAction::Restart` in the hook body must fail closed
+    // with `CrashActionReturnNotYetWired`, not produce a runtime
+    // `E_NOT_YET_IMPLEMENTED` codegen panic.
+    let source = r"
+        actor Worker {
+            #[on(crash)]
+            fn on_crash(info: CrashInfo) -> CrashAction {
+                CrashAction::Restart
+            }
+        }
+
+        fn main() {}
+        ";
+    let output = typecheck(source);
+    let error = output
+        .errors
+        .iter()
+        .find(|e| matches!(&e.kind, TypeErrorKind::CrashActionReturnNotYetWired))
+        .expect("`CrashAction::Restart` body should produce CrashActionReturnNotYetWired");
+    assert!(
+        error.message.contains("not yet wired") && error.message.contains("panic"),
+        "diagnostic should mention 'not yet wired' and suggest panic: {:?}",
+        error.message
+    );
+}
+
 // ── E2: `#[on(crash)]` signature pinning ─────────────────────────────
 //
 // Failure-philosophy slice E2 pins the crash hook signature shape:
@@ -314,24 +355,28 @@ fn reject_on_upgrade_with_extra_args() {
 
 #[test]
 fn on_crash_signature_pinned() {
-    // Accept twin: the canonical shape.
+    // Accept twin: the canonical shape with a diverging body.
+    // The `CrashAction` return type is correctly validated; the body uses
+    // `panic(...)` to avoid `CrashActionReturnNotYetWired` (see the
+    // `crash_action_variants_recognised_by_type_checker` test for the
+    // non-diverging case).
     let output = typecheck(
-        r"
+        r#"
         actor Worker {
             let count: i32;
 
             #[on(crash)]
             fn on_crash(info: CrashInfo) -> CrashAction {
-                CrashAction::Escalate
+                panic("crash")
             }
         }
 
         fn main() {}
-        ",
+        "#,
     );
     assert!(
         output.errors.is_empty(),
-        "canonical `#[on(crash)]` shape should type-check: {:?}",
+        "canonical `#[on(crash)]` shape with diverging body should type-check: {:?}",
         output.errors
     );
 }
@@ -433,11 +478,17 @@ fn reject_on_crash_wrong_return_type() {
 }
 
 #[test]
-fn accept_on_crash_all_three_variants_assignable() {
+fn crash_action_variants_recognised_by_type_checker() {
     // The `CrashAction` enum carries three variants per Q46/A23:
-    // `Restart | Escalate | Kill`. Pin them here so the variant set
-    // can't silently regress (e.g. someone deleting `Kill` because
-    // E3 supervisor logic only consults `Restart`/`Escalate`).
+    // `Restart | Escalate | Kill`. The type-checker must recognise each
+    // variant as a valid `CrashAction` expression so the signature check
+    // doesn't fire a "wrong type" error — the fail-closed gate
+    // (`CrashActionReturnNotYetWired`) fires AFTER the type check succeeds,
+    // confirming the checker sees the correct type.
+    //
+    // Each variant produces `CrashActionReturnNotYetWired`, not any
+    // signature/type-mismatch error, pinning that the checker knows the
+    // variant set even while the return path is wired fail-closed.
     for variant in ["Restart", "Escalate", "Kill"] {
         let src = format!(
             "
@@ -453,8 +504,21 @@ fn accept_on_crash_all_three_variants_assignable() {
         );
         let output = typecheck(&src);
         assert!(
-            output.errors.is_empty(),
-            "`CrashAction::{variant}` should be a valid return value: {:?}",
+            output
+                .errors
+                .iter()
+                .any(|e| matches!(&e.kind, TypeErrorKind::CrashActionReturnNotYetWired)),
+            "`CrashAction::{variant}` should produce CrashActionReturnNotYetWired: {:?}",
+            output.errors
+        );
+        // No signature or type-mismatch error — the checker accepts the type,
+        // only the lowering gate fires.
+        assert!(
+            !output.errors.iter().any(|e| {
+                e.message.contains("must return `CrashAction`")
+                    || e.message.contains("undefined variable")
+            }),
+            "`CrashAction::{variant}` should not produce a type-mismatch error: {:?}",
             output.errors
         );
     }

--- a/hew-types/tests/actor_lifecycle_hooks.rs
+++ b/hew-types/tests/actor_lifecycle_hooks.rs
@@ -376,6 +376,118 @@ fn reject_crash_action_return_stmt_not_yet_wired() {
     );
 }
 
+// ── E1c: non-final `return CrashAction` inside control flow ──────────
+//
+// A `return CrashAction::X;` that is NOT the last statement in the hook body
+// (e.g. inside an `if` branch, followed by more code) was previously missed by
+// the fail-closed gate (which only covered tail-position and final-return paths).
+// These fixtures pin the completed coverage.
+
+#[test]
+fn reject_crash_action_nonfinal_return_before_more_stmts() {
+    // A `return CrashAction::Restart;` that is NOT the last statement in the
+    // hook body (followed by unreachable code) was the escape that the previous
+    // gates missed.  `check_stmt` processes non-last statements; the tail-position
+    // gate in `check_stmt_as_expr` was never reached for this path.
+    //
+    // The statement is processed by `check_stmt`'s `Stmt::Return` arm, which now
+    // carries the same `in_crash_hook` gate as `check_stmt_as_expr`.
+    let source = r#"
+        actor Worker {
+            #[on(crash)]
+            fn on_crash(info: CrashInfo) -> CrashAction {
+                return CrashAction::Restart;
+                panic("dead code — makes the return non-final in its block")
+            }
+        }
+
+        fn main() {}
+        "#;
+    let output = typecheck(source);
+    let error = output
+        .errors
+        .iter()
+        .find(|e| matches!(&e.kind, TypeErrorKind::CrashActionReturnNotYetWired))
+        .expect(
+            "non-final `return CrashAction::Restart;` (followed by more stmts) \
+             should produce CrashActionReturnNotYetWired",
+        );
+    assert!(
+        error.message.contains("not yet wired") && error.message.contains("panic"),
+        "diagnostic should mention 'not yet wired' and suggest panic: {:?}",
+        error.message
+    );
+}
+
+#[test]
+fn reject_crash_action_return_inside_if_then_more_code() {
+    // A `return CrashAction::Restart;` inside an `if` body where the `if` itself
+    // is NOT the last statement in the hook body: the `if` is routed through
+    // `check_stmt_as_expr`, which calls `check_block` on the then-block.  Inside
+    // that inner block, the `return` IS the last statement, so it goes through
+    // `check_stmt_as_expr` — which the existing gate already covers.
+    //
+    // This test confirms the accept/reject boundary is consistent: the if-branch
+    // `return` is caught by the pre-existing gate, pinning that neither the old
+    // nor the new path leaks.
+    let source = r#"
+        actor Worker {
+            let flag: i32;
+
+            #[on(crash)]
+            fn on_crash(info: CrashInfo) -> CrashAction {
+                if flag == 1 {
+                    return CrashAction::Escalate;
+                }
+                panic("fallthrough")
+            }
+        }
+
+        fn main() {}
+        "#;
+    let output = typecheck(source);
+    // The `return CrashAction::Escalate;` is the last stmt in the if-body, so
+    // `check_stmt_as_expr`'s gate fires — same `CrashActionReturnNotYetWired`.
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| matches!(&e.kind, TypeErrorKind::CrashActionReturnNotYetWired)),
+        "`return CrashAction::Escalate` inside an `if` branch should produce \
+         CrashActionReturnNotYetWired: {:?}",
+        output.errors
+    );
+}
+
+#[test]
+fn accept_crash_hook_with_if_and_diverging_body() {
+    // Accept twin: an `#[on(crash)]` hook that uses an `if` branch with a
+    // diverging expression (`panic(...)`) in each arm still type-checks cleanly.
+    let output = typecheck(
+        r#"
+        actor Worker {
+            let flag: i32;
+
+            #[on(crash)]
+            fn on_crash(info: CrashInfo) -> CrashAction {
+                if flag == 1 {
+                    panic("restart path")
+                } else {
+                    panic("kill path")
+                }
+            }
+        }
+
+        fn main() {}
+        "#,
+    );
+    assert!(
+        output.errors.is_empty(),
+        "`#[on(crash)]` hook with diverging `if` branches should type-check cleanly: {:?}",
+        output.errors
+    );
+}
+
 // ── E2: `#[on(crash)]` signature pinning ─────────────────────────────
 //
 // Failure-philosophy slice E2 pins the crash hook signature shape:

--- a/hew-types/tests/actor_lifecycle_hooks.rs
+++ b/hew-types/tests/actor_lifecycle_hooks.rs
@@ -488,6 +488,46 @@ fn accept_crash_hook_with_if_and_diverging_body() {
     );
 }
 
+// ── E1d: closure nested inside `#[on(crash)]` must not inherit flag ──
+//
+// A closure defined inside an `#[on(crash)]` hook body is NOT the hook itself.
+// `in_crash_hook` must be cleared for the closure's body so that a valid
+// `return CrashAction::X;` INSIDE that nested closure does not produce a
+// false-positive `CrashActionReturnNotYetWired`.  (The closure would only be
+// called from user code — it is not the hook's return path at all.)
+
+#[test]
+fn accept_closure_inside_crash_hook_returning_crash_action() {
+    // The closure captures context from the hook but has its OWN return type
+    // annotation of `CrashAction`.  Because `check_lambda` now clears
+    // `in_crash_hook` for the closure body, the `return CrashAction::Restart;`
+    // inside the closure is NOT gated — it is a valid closure return statement,
+    // not a hook body return.  This was a false-positive before the fix.
+    let output = typecheck(
+        r#"
+        actor Worker {
+            let flag: i32;
+
+            #[on(crash)]
+            fn on_crash(info: CrashInfo) -> CrashAction {
+                let handler = || -> CrashAction {
+                    return CrashAction::Restart;
+                };
+                panic("diverging hook body")
+            }
+        }
+
+        fn main() {}
+        "#,
+    );
+    assert!(
+        output.errors.is_empty(),
+        "a closure inside `#[on(crash)]` that returns CrashAction should not produce \
+         CrashActionReturnNotYetWired (false-positive): {:?}",
+        output.errors
+    );
+}
+
 // ── E2: `#[on(crash)]` signature pinning ─────────────────────────────
 //
 // Failure-philosophy slice E2 pins the crash hook signature shape:

--- a/hew-types/tests/actor_lifecycle_hooks.rs
+++ b/hew-types/tests/actor_lifecycle_hooks.rs
@@ -345,6 +345,37 @@ fn reject_crash_action_return_not_yet_wired() {
     );
 }
 
+#[test]
+fn reject_crash_action_return_stmt_not_yet_wired() {
+    // Reject twin (explicit `return` form): `return CrashAction::Restart;`
+    // inside a `#[on(crash)]` hook body must also fail closed with
+    // `CrashActionReturnNotYetWired` — same lowering gap, same diagnostic.
+    // The cross-eco review named this the `CrashActionReturnNotYetWired`
+    // case for explicit-return; it was missing from the original gate which
+    // only checked the block tail-expression type.
+    let source = r"
+        actor Worker {
+            #[on(crash)]
+            fn on_crash(info: CrashInfo) -> CrashAction {
+                return CrashAction::Restart;
+            }
+        }
+
+        fn main() {}
+        ";
+    let output = typecheck(source);
+    let error = output
+        .errors
+        .iter()
+        .find(|e| matches!(&e.kind, TypeErrorKind::CrashActionReturnNotYetWired))
+        .expect("`return CrashAction::Restart;` should produce CrashActionReturnNotYetWired");
+    assert!(
+        error.message.contains("not yet wired") && error.message.contains("panic"),
+        "diagnostic should mention 'not yet wired' and suggest panic: {:?}",
+        error.message
+    );
+}
+
 // ── E2: `#[on(crash)]` signature pinning ─────────────────────────────
 //
 // Failure-philosophy slice E2 pins the crash hook signature shape:

--- a/tests/vertical-slice/reject/on_crash_action_return_nyt.hew
+++ b/tests/vertical-slice/reject/on_crash_action_return_nyt.hew
@@ -1,0 +1,21 @@
+// Reject fixture: #[on(crash)] body that constructs a CrashAction variant
+// must be rejected at check time with CrashActionReturnNotYetWired.
+//
+// The MIR lowering coerces the crash-hook return type to i32 because the
+// CrashAction enum-variant return path is not yet wired through HIR/MIR/codegen.
+// This fixture verifies fail-closed doctrine: the user sees a compile error
+// instead of an internal E_NOT_YET_IMPLEMENTED panic.
+//
+// WHEN obsolete: when v0.6 wires CrashAction return-shape through HIR lowering
+// and removes the I32 coercion in hew-mir/src/lower.rs, delete this fixture and
+// its run.sh entry, and add an accept fixture for CrashAction::Restart.
+import std::failure;
+
+actor Worker {
+    #[on(crash)]
+    fn on_crash(info: CrashInfo) -> CrashAction {
+        CrashAction::Restart
+    }
+}
+
+fn main() {}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -691,6 +691,18 @@ run_accept_expect_status "on_crash_basic" 42
 # FieldAccess lowering succeeds.  The supervisor boots and main returns 42.
 run_accept_expect_status "on_crash_info_code" 42
 
+# Reject: #[on(crash)] body that constructs a CrashAction variant must be
+# rejected at check time (CrashActionReturnNotYetWired).  The MIR lowering
+# coerces the crash-hook return type to i32; a non-diverging body that
+# constructs CrashAction::Restart would hit an internal E_NOT_YET_IMPLEMENTED
+# codegen panic without this gate.  Remove when v0.6 wires the full path.
+if "${HEW}" check "${ROOT}/tests/vertical-slice/reject/on_crash_action_return_nyt.hew" \
+    >"${reject_output}" 2>&1; then
+  echo "expected on_crash_action_return_nyt fixture to fail" >&2
+  exit 1
+fi
+grep -q 'enum-variant construction is not yet wired' "${reject_output}"
+
 # `#[max_heap(N)]` wire-through — direct spawn path:
 #   1. MIR dump confirms SpawnActor carries max_heap=65536,
 #      proving the annotation propagated from HIR through MIR.


### PR DESCRIPTION
## Summary

`#[on(crash)]` hooks were accepted at check time but not yet wired at codegen: any hook body that returned a `CrashAction` value would compile without error, then double-panic at runtime when the generated code tried to materialise the unimplemented path. Every CrashAction-return path — tail expression, final and non-final `return` statements, `if`/`match` arms that unify to `CrashAction`, and let-bound values subsequently returned — now emits a clear `CrashActionReturnNotYetWired` check-time error. There is no longer a runtime escape route; the hook fails closed until codegen support is wired.

## Verification

- `actor_lifecycle_hooks` test suite: 21/21 passed, including all 5 exit-path negative cases (tail expression, final return, non-final return, if/match arm, let-bound return)
- `cargo test -p hew-types --quiet`: 2161/2161 passed
- Adversarial probes: nested `loop { return CrashAction::Restart; }`, nested `if { if { return CrashAction::Kill; } }`, tail `pick()` where `pick() -> CrashAction`, `return CrashAction::Escalate` from inside a match guard block — all gated at check time
- `?`-operator escape (`maybe_action()? where maybe_action() -> Result<CrashAction, string>`) confirmed non-viable: cannot propagate from a `CrashAction`-returning hook
- Preflight: ready-to-push

## Out of scope

- Wiring `CrashAction` returns through codegen is intentionally deferred; this PR only closes the check-time gap so the error is diagnostic rather than a runtime double-panic.
