### PR TITLE
feat(net): introduce net.NetError, migrate std/net APIs off fs.IoError

### DIFF
--- a/examples/quic_service/client.hew
+++ b/examples/quic_service/client.hew
@@ -12,16 +12,16 @@
 //
 // Optional:
 //   HEW_QUIC_SERVICE_PORT=4545 hew run examples/quic_service/client.hew
-import std::net::quic;
+import std::net;
 
-import std::fs;
+import std::net::quic;
 
 import std::os;
 
-fn assert_ok(result: Result<(), fs.IoError>) {
+fn assert_ok(result: Result<(), net.NetError>) {
     match result {
         Ok(_) => assert(true),
-        Err(e) => panic("quic operation failed: " + fs.io_error_message(e)),
+        Err(e) => panic("quic operation failed: " + net.net_error_message(e)),
     }
 }
 

--- a/examples/quic_service/server.hew
+++ b/examples/quic_service/server.hew
@@ -15,16 +15,16 @@
 //
 // Optional:
 //   HEW_QUIC_SERVICE_PORT=4545 hew run examples/quic_service/server.hew
-import std::net::quic;
+import std::net;
 
-import std::fs;
+import std::net::quic;
 
 import std::os;
 
-fn assert_ok(result: Result<(), fs.IoError>) {
+fn assert_ok(result: Result<(), net.NetError>) {
     match result {
         Ok(_) => assert(true),
-        Err(e) => panic("quic operation failed: " + fs.io_error_message(e)),
+        Err(e) => panic("quic operation failed: " + net.net_error_message(e)),
     }
 }
 

--- a/examples/v05/checked-mir/golden/actor_ask_race.raw.mir
+++ b/examples/v05/checked-mir/golden/actor_ask_race.raw.mir
@@ -16,7 +16,7 @@ fn SlowWorker__recv__compute(i64) -> i64 [conv=actor_handler]
   bb0:
     enter_context
     _1 = const.i64 50
-    suspend [sleep] is_final=false -> resume=bb1 cleanup=bb1
+    suspend.sleep _1 -> resume=bb1 cleanup=bb1
   bb1:
     stmt: eval site=SiteId(1) ty=()
     stmt: use BindingId(1) query site=SiteId(4) ty=i64 intent=Read

--- a/examples/v05/checked-mir/golden/actor_ask_race.raw.mir
+++ b/examples/v05/checked-mir/golden/actor_ask_race.raw.mir
@@ -16,7 +16,7 @@ fn SlowWorker__recv__compute(i64) -> i64 [conv=actor_handler]
   bb0:
     enter_context
     _1 = const.i64 50
-    suspend.sleep _1 -> resume=bb1 cleanup=bb1
+    suspend [sleep] is_final=false -> resume=bb1 cleanup=bb1
   bb1:
     stmt: eval site=SiteId(1) ty=()
     stmt: use BindingId(1) query site=SiteId(4) ty=i64 intent=Read

--- a/examples/v05/checked-mir/golden/await_ask_deadline.raw.mir
+++ b/examples/v05/checked-mir/golden/await_ask_deadline.raw.mir
@@ -30,7 +30,7 @@ fn Caller__recv__go() -> i64 [conv=actor_handler]
     stmt: use BindingId(0) f site=SiteId(6) ty=LocalPid<Fast> intent=Read
     enter_context
     actor0 = spawn_actor Fast cycle_capable=false
-    suspend [ask] is_final=false -> resume=bb1 cleanup=bb1
+    _3 = suspend.ask actor0[msg=1098906379] _2 reply=_4 err=_5 -> resume=bb1 cleanup=bb1
   bb1:
     _6 = move etag3
     _7 = const.i64 0

--- a/examples/v05/checked-mir/golden/await_ask_deadline.raw.mir
+++ b/examples/v05/checked-mir/golden/await_ask_deadline.raw.mir
@@ -30,7 +30,7 @@ fn Caller__recv__go() -> i64 [conv=actor_handler]
     stmt: use BindingId(0) f site=SiteId(6) ty=LocalPid<Fast> intent=Read
     enter_context
     actor0 = spawn_actor Fast cycle_capable=false
-    _3 = suspend.ask actor0[msg=1098906379] _2 reply=_4 err=_5 -> resume=bb1 cleanup=bb1
+    suspend [ask] is_final=false -> resume=bb1 cleanup=bb1
   bb1:
     _6 = move etag3
     _7 = const.i64 0

--- a/examples/v05/checked-mir/golden/channel_recv_select.raw.mir
+++ b/examples/v05/checked-mir/golden/channel_recv_select.raw.mir
@@ -65,7 +65,7 @@ fn Inbox__recv__run(i64) -> () [conv=actor_handler]
   bb3:
     stmt: eval site=SiteId(11) ty=()
     stmt: use BindingId(4) rx site=SiteId(16) ty=Receiver<string> intent=Read
-    suspend [channel_recv] elem_ty=string is_final=false -> resume=bb4 cleanup=bb4
+    _10 = suspend.channel_recv _7 elem_ty=string -> resume=bb4 cleanup=bb4
   bb4:
     _11 = move etag10
     _12 = const.i64 0

--- a/examples/v05/checked-mir/golden/channel_recv_select.raw.mir
+++ b/examples/v05/checked-mir/golden/channel_recv_select.raw.mir
@@ -65,7 +65,7 @@ fn Inbox__recv__run(i64) -> () [conv=actor_handler]
   bb3:
     stmt: eval site=SiteId(11) ty=()
     stmt: use BindingId(4) rx site=SiteId(16) ty=Receiver<string> intent=Read
-    _10 = suspend.channel_recv _7 elem_ty=string -> resume=bb4 cleanup=bb4
+    suspend [channel_recv] elem_ty=string is_final=false -> resume=bb4 cleanup=bb4
   bb4:
     _11 = move etag10
     _12 = const.i64 0

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.elab.mir
@@ -89,16 +89,7 @@ fn fs$io_error_from_errno -> IoError
     use BindingId(6) errno site=SiteId(72) ty=i64 intent=Read
     use BindingId(6) errno site=SiteId(75) ty=i64 intent=Read
     use BindingId(6) errno site=SiteId(79) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(83) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(86) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(90) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(94) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(97) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(101) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(105) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(108) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(112) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(115) ty=i64 intent=Read
+    use BindingId(6) errno site=SiteId(82) ty=i64 intent=Read
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -144,113 +135,75 @@ fn fs$io_error_from_errno -> IoError
       (none)
     goto[bb17->bb19] ->
       (none)
-    branch[bb18: bb21/bb20] ->
+    goto[bb18->bb19] ->
       (none)
     goto[bb19->bb14] ->
       (none)
     cancel[bb19] ->
       (none)
-    goto[bb20->bb21] ->
-      (none)
-    branch[bb21: bb22/bb23] ->
-      (none)
-    goto[bb22->bb24] ->
-      (none)
-    branch[bb23: bb26/bb25] ->
-      (none)
-    goto[bb24->bb19] ->
-      (none)
-    cancel[bb24] ->
-      (none)
-    goto[bb25->bb26] ->
-      (none)
-    branch[bb26: bb27/bb28] ->
-      (none)
-    goto[bb27->bb29] ->
-      (none)
-    branch[bb28: bb31/bb30] ->
-      (none)
-    goto[bb29->bb24] ->
-      (none)
-    cancel[bb29] ->
-      (none)
-    goto[bb30->bb31] ->
-      (none)
-    branch[bb31: bb32/bb33] ->
-      (none)
-    goto[bb32->bb34] ->
-      (none)
-    goto[bb33->bb34] ->
-      (none)
-    goto[bb34->bb29] ->
-      (none)
-    cancel[bb34] ->
-      (none)
 
 fn fs$io_error_message -> string
   statements:
-    use BindingId(7) e site=SiteId(117) ty=IoError intent=Read
-    return site=Some(SiteId(116)) ty=string
-    bind BindingId(8) code site=SiteId(118) ty=i64
-    use BindingId(8) code site=SiteId(120) ty=i64 intent=Read
-    bind BindingId(9) code site=SiteId(128) ty=i64
-    use BindingId(9) code site=SiteId(130) ty=i64 intent=Read
-    bind BindingId(10) code site=SiteId(138) ty=i64
-    use BindingId(10) code site=SiteId(140) ty=i64 intent=Read
-    bind BindingId(11) code site=SiteId(148) ty=i64
-    use BindingId(11) code site=SiteId(150) ty=i64 intent=Read
-    bind BindingId(12) code site=SiteId(158) ty=i64
-    use BindingId(12) code site=SiteId(160) ty=i64 intent=Read
-    bind BindingId(13) code site=SiteId(168) ty=i64
-    use BindingId(13) code site=SiteId(170) ty=i64 intent=Read
-    bind BindingId(14) code site=SiteId(178) ty=i64
-    use BindingId(14) code site=SiteId(180) ty=i64 intent=Read
-    bind BindingId(15) code site=SiteId(188) ty=i64
-    use BindingId(15) code site=SiteId(190) ty=i64 intent=Read
-    bind BindingId(16) code site=SiteId(198) ty=i64
-    use BindingId(16) code site=SiteId(200) ty=i64 intent=Read
+    use BindingId(7) e site=SiteId(84) ty=IoError intent=Read
+    return site=Some(SiteId(83)) ty=string
+    bind BindingId(8) code site=SiteId(85) ty=i64
+    use BindingId(8) code site=SiteId(87) ty=i64 intent=Read
+    bind BindingId(9) code site=SiteId(95) ty=i64
+    use BindingId(9) code site=SiteId(97) ty=i64 intent=Read
+    bind BindingId(10) code site=SiteId(105) ty=i64
+    use BindingId(10) code site=SiteId(107) ty=i64 intent=Read
+    bind BindingId(11) code site=SiteId(115) ty=i64
+    use BindingId(11) code site=SiteId(117) ty=i64 intent=Read
+    bind BindingId(12) code site=SiteId(125) ty=i64
+    use BindingId(12) code site=SiteId(127) ty=i64 intent=Read
+    bind BindingId(13) code site=SiteId(135) ty=i64
+    use BindingId(13) code site=SiteId(137) ty=i64 intent=Read
   drop_plans:
-    branch[bb0: bb2/bb12] ->
+    branch[bb0: bb2/bb9] ->
       (none)
     cancel[bb0] ->
       (none)
     return[bb1] ->
       (none)
-    call[bb2 to_string_i64 -> bb20] ->
+    call[bb2 to_string_i64 -> bb14] ->
       (none)
-    call[bb3 to_string_i64 -> bb23] ->
+    call[bb3 to_string_i64 -> bb17] ->
       (none)
-    call[bb4 to_string_i64 -> bb26] ->
+    call[bb4 to_string_i64 -> bb20] ->
       (none)
-    call[bb5 to_string_i64 -> bb29] ->
+    call[bb5 to_string_i64 -> bb23] ->
       (none)
-    call[bb6 to_string_i64 -> bb32] ->
+    call[bb6 to_string_i64 -> bb26] ->
       (none)
-    call[bb7 to_string_i64 -> bb35] ->
+    call[bb7 to_string_i64 -> bb29] ->
       (none)
-    call[bb8 to_string_i64 -> bb38] ->
+    panic[bb8] ->
       (none)
-    call[bb9 to_string_i64 -> bb41] ->
+    branch[bb9: bb3/bb10] ->
       (none)
-    call[bb10 to_string_i64 -> bb44] ->
+    branch[bb10: bb4/bb11] ->
       (none)
-    panic[bb11] ->
+    branch[bb11: bb5/bb12] ->
       (none)
-    branch[bb12: bb3/bb13] ->
+    branch[bb12: bb6/bb13] ->
       (none)
-    branch[bb13: bb4/bb14] ->
+    branch[bb13: bb7/bb8] ->
       (none)
-    branch[bb14: bb5/bb15] ->
+    call[bb14 string_concat -> bb15] ->
       (none)
-    branch[bb15: bb6/bb16] ->
+    call[bb15 string_concat -> bb16] ->
       (none)
-    branch[bb16: bb7/bb17] ->
+    goto[bb16->bb1] ->
       (none)
-    branch[bb17: bb8/bb18] ->
+    cancel[bb16] ->
       (none)
-    branch[bb18: bb9/bb19] ->
+    call[bb17 string_concat -> bb18] ->
       (none)
-    branch[bb19: bb10/bb11] ->
+    call[bb18 string_concat -> bb19] ->
+      (none)
+    goto[bb19->bb1] ->
+      (none)
+    cancel[bb19] ->
       (none)
     call[bb20 string_concat -> bb21] ->
       (none)
@@ -284,69 +237,29 @@ fn fs$io_error_message -> string
       (none)
     cancel[bb31] ->
       (none)
-    call[bb32 string_concat -> bb33] ->
-      (none)
-    call[bb33 string_concat -> bb34] ->
-      (none)
-    goto[bb34->bb1] ->
-      (none)
-    cancel[bb34] ->
-      (none)
-    call[bb35 string_concat -> bb36] ->
-      (none)
-    call[bb36 string_concat -> bb37] ->
-      (none)
-    goto[bb37->bb1] ->
-      (none)
-    cancel[bb37] ->
-      (none)
-    call[bb38 string_concat -> bb39] ->
-      (none)
-    call[bb39 string_concat -> bb40] ->
-      (none)
-    goto[bb40->bb1] ->
-      (none)
-    cancel[bb40] ->
-      (none)
-    call[bb41 string_concat -> bb42] ->
-      (none)
-    call[bb42 string_concat -> bb43] ->
-      (none)
-    goto[bb43->bb1] ->
-      (none)
-    cancel[bb43] ->
-      (none)
-    call[bb44 string_concat -> bb45] ->
-      (none)
-    call[bb45 string_concat -> bb46] ->
-      (none)
-    goto[bb46->bb1] ->
-      (none)
-    cancel[bb46] ->
-      (none)
 
 fn fs$io_error_timed_out -> IoError
   statements:
-    return site=Some(SiteId(208)) ty=IoError
+    return site=Some(SiteId(145)) ty=IoError
   drop_plans:
     return[bb0] ->
       (none)
 
 fn fs$io_error_cancelled -> IoError
   statements:
-    return site=Some(SiteId(210)) ty=IoError
+    return site=Some(SiteId(147)) ty=IoError
   drop_plans:
     return[bb0] ->
       (none)
 
 fn fs$missing_parent -> bool
   statements:
-    use BindingId(17) target site=SiteId(213) ty=string intent=Read
-    bind BindingId(18) parent site=SiteId(212) ty=string
-    use BindingId(18) parent site=SiteId(217) ty=string intent=Read
-    use BindingId(18) parent site=SiteId(221) ty=string intent=Read
-    return site=Some(SiteId(215)) ty=bool
-    drop BindingId(18) parent ty=string
+    use BindingId(14) target site=SiteId(150) ty=string intent=Read
+    bind BindingId(15) parent site=SiteId(149) ty=string
+    use BindingId(15) parent site=SiteId(154) ty=string intent=Read
+    use BindingId(15) parent site=SiteId(158) ty=string intent=Read
+    return site=Some(SiteId(152)) ty=bool
+    drop BindingId(15) parent ty=string
   drop_plans:
     call[bb0 fs$dirname -> bb1] ->
       (none)
@@ -365,20 +278,20 @@ fn fs$missing_parent -> bool
 
 fn fs$dirname -> string
   statements:
-    use BindingId(19) p site=SiteId(224) ty=string intent=Read
-    bind BindingId(20) s site=SiteId(223) ty=string
-    use BindingId(20) s site=SiteId(227) ty=string intent=Read
-    bind BindingId(21) pos site=SiteId(226) ty=i64
-    use BindingId(21) pos site=SiteId(230) ty=i64 intent=Read
-    return site=Some(SiteId(232)) ty=string
-    eval site=SiteId(234) ty=()
-    use BindingId(21) pos site=SiteId(236) ty=i64 intent=Read
-    return site=Some(SiteId(238)) ty=string
-    eval site=SiteId(240) ty=()
-    use BindingId(20) s site=SiteId(242) ty=string intent=Read
-    use BindingId(21) pos site=SiteId(244) ty=i64 intent=Read
-    return site=Some(SiteId(241)) ty=string
-    drop BindingId(20) s ty=string
+    use BindingId(16) p site=SiteId(161) ty=string intent=Read
+    bind BindingId(17) s site=SiteId(160) ty=string
+    use BindingId(17) s site=SiteId(164) ty=string intent=Read
+    bind BindingId(18) pos site=SiteId(163) ty=i64
+    use BindingId(18) pos site=SiteId(167) ty=i64 intent=Read
+    return site=Some(SiteId(169)) ty=string
+    eval site=SiteId(171) ty=()
+    use BindingId(18) pos site=SiteId(173) ty=i64 intent=Read
+    return site=Some(SiteId(175)) ty=string
+    eval site=SiteId(177) ty=()
+    use BindingId(17) s site=SiteId(179) ty=string intent=Read
+    use BindingId(18) pos site=SiteId(181) ty=i64 intent=Read
+    return site=Some(SiteId(178)) ty=string
+    drop BindingId(17) s ty=string
   drop_plans:
     call[bb0 fs$strip_trailing_slash -> bb1] ->
       (none)
@@ -413,18 +326,18 @@ fn fs$dirname -> string
 
 fn fs$strip_trailing_slash -> string
   statements:
-    use BindingId(22) p site=SiteId(247) ty=string intent=Read
-    use BindingId(22) p site=SiteId(251) ty=string intent=Read
-    return site=Some(SiteId(249)) ty=string
-    eval site=SiteId(253) ty=()
-    use BindingId(22) p site=SiteId(257) ty=string intent=Read
-    use BindingId(22) p site=SiteId(261) ty=string intent=Read
-    use BindingId(22) p site=SiteId(265) ty=string intent=Read
-    use BindingId(22) p site=SiteId(269) ty=string intent=Read
-    eval site=SiteId(274) ty=()
-    use BindingId(22) p site=SiteId(277) ty=string intent=Read
-    return site=Some(SiteId(275)) ty=string
-    return site=Some(SiteId(264)) ty=string
+    use BindingId(19) p site=SiteId(184) ty=string intent=Read
+    use BindingId(19) p site=SiteId(188) ty=string intent=Read
+    return site=Some(SiteId(186)) ty=string
+    eval site=SiteId(190) ty=()
+    use BindingId(19) p site=SiteId(194) ty=string intent=Read
+    use BindingId(19) p site=SiteId(198) ty=string intent=Read
+    use BindingId(19) p site=SiteId(202) ty=string intent=Read
+    use BindingId(19) p site=SiteId(206) ty=string intent=Read
+    eval site=SiteId(211) ty=()
+    use BindingId(19) p site=SiteId(214) ty=string intent=Read
+    return site=Some(SiteId(212)) ty=string
+    return site=Some(SiteId(201)) ty=string
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -471,36 +384,36 @@ fn fs$strip_trailing_slash -> string
 
 fn fs$last_slash_pos -> i64
   statements:
-    use BindingId(23) s site=SiteId(279) ty=string intent=Read
-    bind BindingId(24) first site=SiteId(278) ty=i64
-    use BindingId(24) first site=SiteId(283) ty=i64 intent=Read
-    eval site=SiteId(288) ty=()
-    use BindingId(24) first site=SiteId(289) ty=i64 intent=Consume
-    bind BindingId(25) last site=SiteId(289) ty=i64
-    use BindingId(24) first site=SiteId(291) ty=i64 intent=Read
-    return site=Some(SiteId(285)) ty=i64
-    bind BindingId(26) search_from site=SiteId(290) ty=i64
-    use BindingId(26) search_from site=SiteId(294) ty=i64 intent=Read
-    use BindingId(23) s site=SiteId(296) ty=string intent=Read
-    use BindingId(23) s site=SiteId(299) ty=string intent=Read
-    use BindingId(26) search_from site=SiteId(300) ty=i64 intent=Read
-    use BindingId(23) s site=SiteId(302) ty=string intent=Read
-    eval site=SiteId(323) ty=()
-    use BindingId(25) last site=SiteId(324) ty=i64 intent=Read
-    return site=Some(SiteId(324)) ty=i64
-    bind BindingId(27) rest site=SiteId(298) ty=string
-    use BindingId(27) rest site=SiteId(306) ty=string intent=Read
-    bind BindingId(28) next site=SiteId(305) ty=i64
-    use BindingId(28) next site=SiteId(310) ty=i64 intent=Read
-    use BindingId(25) last site=SiteId(312) ty=i64 intent=Consume
-    return site=Some(SiteId(312)) ty=i64
-    eval site=SiteId(314) ty=()
-    use BindingId(26) search_from site=SiteId(317) ty=i64 intent=Read
-    use BindingId(28) next site=SiteId(318) ty=i64 intent=Read
-    eval site=SiteId(316) ty=()
-    use BindingId(25) last site=SiteId(321) ty=i64 intent=Read
-    eval site=SiteId(320) ty=()
-    drop BindingId(27) rest ty=string
+    use BindingId(20) s site=SiteId(216) ty=string intent=Read
+    bind BindingId(21) first site=SiteId(215) ty=i64
+    use BindingId(21) first site=SiteId(220) ty=i64 intent=Read
+    eval site=SiteId(225) ty=()
+    use BindingId(21) first site=SiteId(226) ty=i64 intent=Consume
+    bind BindingId(22) last site=SiteId(226) ty=i64
+    use BindingId(21) first site=SiteId(228) ty=i64 intent=Read
+    return site=Some(SiteId(222)) ty=i64
+    bind BindingId(23) search_from site=SiteId(227) ty=i64
+    use BindingId(23) search_from site=SiteId(231) ty=i64 intent=Read
+    use BindingId(20) s site=SiteId(233) ty=string intent=Read
+    use BindingId(20) s site=SiteId(236) ty=string intent=Read
+    use BindingId(23) search_from site=SiteId(237) ty=i64 intent=Read
+    use BindingId(20) s site=SiteId(239) ty=string intent=Read
+    eval site=SiteId(260) ty=()
+    use BindingId(22) last site=SiteId(261) ty=i64 intent=Read
+    return site=Some(SiteId(261)) ty=i64
+    bind BindingId(24) rest site=SiteId(235) ty=string
+    use BindingId(24) rest site=SiteId(243) ty=string intent=Read
+    bind BindingId(25) next site=SiteId(242) ty=i64
+    use BindingId(25) next site=SiteId(247) ty=i64 intent=Read
+    use BindingId(22) last site=SiteId(249) ty=i64 intent=Consume
+    return site=Some(SiteId(249)) ty=i64
+    eval site=SiteId(251) ty=()
+    use BindingId(23) search_from site=SiteId(254) ty=i64 intent=Read
+    use BindingId(25) next site=SiteId(255) ty=i64 intent=Read
+    eval site=SiteId(253) ty=()
+    use BindingId(22) last site=SiteId(258) ty=i64 intent=Read
+    eval site=SiteId(257) ty=()
+    drop BindingId(24) rest ty=string
   drop_plans:
     call[bb0 hew_string_find -> bb1] ->
       (none)
@@ -563,8 +476,8 @@ fn fs$last_slash_pos -> i64
 
 fn fs$write_error -> IoError
   statements:
-    use BindingId(29) target site=SiteId(327) ty=string intent=Read
-    return site=Some(SiteId(325)) ty=IoError
+    use BindingId(26) target site=SiteId(264) ty=string intent=Read
+    return site=Some(SiteId(262)) ty=IoError
   drop_plans:
     call[bb0 fs$missing_parent -> bb1] ->
       (none)
@@ -581,8 +494,8 @@ fn fs$write_error -> IoError
 
 fn fs$missing_path_error -> IoError
   statements:
-    use BindingId(30) target site=SiteId(337) ty=string intent=Read
-    return site=Some(SiteId(335)) ty=IoError
+    use BindingId(27) target site=SiteId(274) ty=string intent=Read
+    return site=Some(SiteId(272)) ty=IoError
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -599,9 +512,9 @@ fn fs$missing_path_error -> IoError
 
 fn fs$mkdir_error -> IoError
   statements:
-    use BindingId(31) target site=SiteId(347) ty=string intent=Read
-    use BindingId(31) target site=SiteId(354) ty=string intent=Read
-    return site=Some(SiteId(345)) ty=IoError
+    use BindingId(28) target site=SiteId(284) ty=string intent=Read
+    use BindingId(28) target site=SiteId(291) ty=string intent=Read
+    return site=Some(SiteId(282)) ty=IoError
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -628,9 +541,9 @@ fn fs$mkdir_error -> IoError
 
 fn fs$move_copy_error -> IoError
   statements:
-    use BindingId(32) source site=SiteId(365) ty=string intent=Read
-    use BindingId(33) target site=SiteId(372) ty=string intent=Read
-    return site=Some(SiteId(362)) ty=IoError
+    use BindingId(29) source site=SiteId(302) ty=string intent=Read
+    use BindingId(30) target site=SiteId(309) ty=string intent=Read
+    return site=Some(SiteId(299)) ty=IoError
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -657,23 +570,23 @@ fn fs$move_copy_error -> IoError
 
 fn fs$read -> string
   statements:
-    use BindingId(34) path site=SiteId(382) ty=string intent=Read
-    bind BindingId(35) contents site=SiteId(381) ty=string
-    bind BindingId(36) errno site=SiteId(384) ty=i32
-    use BindingId(36) errno site=SiteId(387) ty=i32 intent=Read
-    eval site=SiteId(439) ty=()
-    use BindingId(35) contents site=SiteId(440) ty=string intent=Read
-    return site=Some(SiteId(380)) ty=string
-    bind BindingId(37) detail site=SiteId(389) ty=string
-    use BindingId(37) detail site=SiteId(394) ty=string intent=Read
-    use BindingId(34) path site=SiteId(401) ty=string intent=Read
-    use BindingId(34) path site=SiteId(424) ty=string intent=Read
-    use BindingId(36) errno site=SiteId(408) ty=i32 intent=Read
-    eval site=SiteId(398) ty=!
-    use BindingId(37) detail site=SiteId(428) ty=string intent=Read
-    eval site=SiteId(421) ty=!
-    drop BindingId(37) detail ty=string
-    drop BindingId(35) contents ty=string
+    use BindingId(31) path site=SiteId(319) ty=string intent=Read
+    bind BindingId(32) contents site=SiteId(318) ty=string
+    bind BindingId(33) errno site=SiteId(321) ty=i32
+    use BindingId(33) errno site=SiteId(324) ty=i32 intent=Read
+    eval site=SiteId(376) ty=()
+    use BindingId(32) contents site=SiteId(377) ty=string intent=Read
+    return site=Some(SiteId(317)) ty=string
+    bind BindingId(34) detail site=SiteId(326) ty=string
+    use BindingId(34) detail site=SiteId(331) ty=string intent=Read
+    use BindingId(31) path site=SiteId(338) ty=string intent=Read
+    use BindingId(31) path site=SiteId(361) ty=string intent=Read
+    use BindingId(33) errno site=SiteId(345) ty=i32 intent=Read
+    eval site=SiteId(335) ty=!
+    use BindingId(34) detail site=SiteId(365) ty=string intent=Read
+    eval site=SiteId(358) ty=!
+    drop BindingId(34) detail ty=string
+    drop BindingId(32) contents ty=string
   drop_plans:
     call[bb0 hew_file_read -> bb1] ->
       (none)
@@ -736,14 +649,14 @@ fn fs$read -> string
 
 fn fs$try_read -> Result<string, IoError>
   statements:
-    use BindingId(38) file_path site=SiteId(443) ty=string intent=Read
-    bind BindingId(39) file site=SiteId(442) ty=FileReadStream
-    use BindingId(39) file site=SiteId(447) ty=FileReadStream intent=Read
-    use BindingId(39) file site=SiteId(452) ty=FileReadStream intent=Read
-    return site=Some(SiteId(441)) ty=Result<string, IoError>
-    bind BindingId(40) errno site=SiteId(455) ty=i32
-    eval site=SiteId(457) ty=string
-    use BindingId(40) errno site=SiteId(462) ty=i32 intent=Read
+    use BindingId(35) file_path site=SiteId(380) ty=string intent=Read
+    bind BindingId(36) file site=SiteId(379) ty=FileReadStream
+    use BindingId(36) file site=SiteId(384) ty=FileReadStream intent=Read
+    use BindingId(36) file site=SiteId(389) ty=FileReadStream intent=Read
+    return site=Some(SiteId(378)) ty=Result<string, IoError>
+    bind BindingId(37) errno site=SiteId(392) ty=i32
+    eval site=SiteId(394) ty=string
+    use BindingId(37) errno site=SiteId(399) ty=i32 intent=Read
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -774,9 +687,9 @@ fn fs$try_read -> Result<string, IoError>
 
 fn fs$write -> i64
   statements:
-    use BindingId(41) path site=SiteId(467) ty=string intent=Read
-    use BindingId(42) content site=SiteId(468) ty=string intent=Read
-    return site=Some(SiteId(464)) ty=i64
+    use BindingId(38) path site=SiteId(404) ty=string intent=Read
+    use BindingId(39) content site=SiteId(405) ty=string intent=Read
+    return site=Some(SiteId(401)) ty=i64
   drop_plans:
     call[bb0 hew_file_write -> bb1] ->
       (none)
@@ -787,10 +700,10 @@ fn fs$write -> i64
 
 fn fs$try_write -> Result<i64, IoError>
   statements:
-    use BindingId(43) file_path site=SiteId(473) ty=string intent=Read
-    use BindingId(44) content site=SiteId(474) ty=string intent=Read
-    return site=Some(SiteId(470)) ty=Result<i64, IoError>
-    use BindingId(43) file_path site=SiteId(480) ty=string intent=Read
+    use BindingId(40) file_path site=SiteId(410) ty=string intent=Read
+    use BindingId(41) content site=SiteId(411) ty=string intent=Read
+    return site=Some(SiteId(407)) ty=Result<i64, IoError>
+    use BindingId(40) file_path site=SiteId(417) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_write -> bb1] ->
       (none)
@@ -817,9 +730,9 @@ fn fs$try_write -> Result<i64, IoError>
 
 fn fs$append -> i64
   statements:
-    use BindingId(45) path site=SiteId(485) ty=string intent=Read
-    use BindingId(46) content site=SiteId(486) ty=string intent=Read
-    return site=Some(SiteId(482)) ty=i64
+    use BindingId(42) path site=SiteId(422) ty=string intent=Read
+    use BindingId(43) content site=SiteId(423) ty=string intent=Read
+    return site=Some(SiteId(419)) ty=i64
   drop_plans:
     call[bb0 hew_file_append -> bb1] ->
       (none)
@@ -830,10 +743,10 @@ fn fs$append -> i64
 
 fn fs$try_append -> Result<i64, IoError>
   statements:
-    use BindingId(47) file_path site=SiteId(491) ty=string intent=Read
-    use BindingId(48) content site=SiteId(492) ty=string intent=Read
-    return site=Some(SiteId(488)) ty=Result<i64, IoError>
-    use BindingId(47) file_path site=SiteId(498) ty=string intent=Read
+    use BindingId(44) file_path site=SiteId(428) ty=string intent=Read
+    use BindingId(45) content site=SiteId(429) ty=string intent=Read
+    return site=Some(SiteId(425)) ty=Result<i64, IoError>
+    use BindingId(44) file_path site=SiteId(435) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_append -> bb1] ->
       (none)
@@ -860,8 +773,8 @@ fn fs$try_append -> Result<i64, IoError>
 
 fn fs$exists -> bool
   statements:
-    use BindingId(49) path site=SiteId(502) ty=string intent=Read
-    return site=Some(SiteId(500)) ty=bool
+    use BindingId(46) path site=SiteId(439) ty=string intent=Read
+    return site=Some(SiteId(437)) ty=bool
   drop_plans:
     call[bb0 hew_file_exists -> bb1] ->
       (none)
@@ -872,8 +785,8 @@ fn fs$exists -> bool
 
 fn fs$delete -> i64
   statements:
-    use BindingId(50) path site=SiteId(507) ty=string intent=Read
-    return site=Some(SiteId(504)) ty=i64
+    use BindingId(47) path site=SiteId(444) ty=string intent=Read
+    return site=Some(SiteId(441)) ty=i64
   drop_plans:
     call[bb0 hew_file_delete -> bb1] ->
       (none)
@@ -884,9 +797,9 @@ fn fs$delete -> i64
 
 fn fs$try_delete -> Result<i64, IoError>
   statements:
-    use BindingId(51) file_path site=SiteId(512) ty=string intent=Read
-    return site=Some(SiteId(509)) ty=Result<i64, IoError>
-    use BindingId(51) file_path site=SiteId(518) ty=string intent=Read
+    use BindingId(48) file_path site=SiteId(449) ty=string intent=Read
+    return site=Some(SiteId(446)) ty=Result<i64, IoError>
+    use BindingId(48) file_path site=SiteId(455) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_delete -> bb1] ->
       (none)
@@ -913,8 +826,8 @@ fn fs$try_delete -> Result<i64, IoError>
 
 fn fs$size -> i64
   statements:
-    use BindingId(52) path site=SiteId(522) ty=string intent=Read
-    return site=Some(SiteId(520)) ty=i64
+    use BindingId(49) path site=SiteId(459) ty=string intent=Read
+    return site=Some(SiteId(457)) ty=i64
   drop_plans:
     call[bb0 hew_file_size -> bb1] ->
       (none)
@@ -925,8 +838,8 @@ fn fs$size -> i64
 
 fn fs$read_bytes -> bytes
   statements:
-    use BindingId(53) path site=SiteId(526) ty=string intent=Read
-    return site=Some(SiteId(524)) ty=bytes
+    use BindingId(50) path site=SiteId(463) ty=string intent=Read
+    return site=Some(SiteId(461)) ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
       (none)
@@ -937,15 +850,15 @@ fn fs$read_bytes -> bytes
 
 fn fs$try_read_bytes -> Result<bytes, IoError>
   statements:
-    use BindingId(54) file_path site=SiteId(530) ty=string intent=Read
-    bind BindingId(55) data site=SiteId(529) ty=bytes
-    bind BindingId(56) errno site=SiteId(532) ty=i32
-    use BindingId(56) errno site=SiteId(536) ty=i32 intent=Read
-    use BindingId(56) errno site=SiteId(542) ty=i32 intent=Read
-    use BindingId(55) data site=SiteId(546) ty=bytes intent=Read
-    agg_alias BindingId(55) data site=SiteId(546) ty=bytes
-    return site=Some(SiteId(528)) ty=Result<bytes, IoError>
-    drop BindingId(55) data ty=bytes
+    use BindingId(51) file_path site=SiteId(467) ty=string intent=Read
+    bind BindingId(52) data site=SiteId(466) ty=bytes
+    bind BindingId(53) errno site=SiteId(469) ty=i32
+    use BindingId(53) errno site=SiteId(473) ty=i32 intent=Read
+    use BindingId(53) errno site=SiteId(479) ty=i32 intent=Read
+    use BindingId(52) data site=SiteId(483) ty=bytes intent=Read
+    agg_alias BindingId(52) data site=SiteId(483) ty=bytes
+    return site=Some(SiteId(465)) ty=Result<bytes, IoError>
+    drop BindingId(52) data ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
       (none)
@@ -968,9 +881,9 @@ fn fs$try_read_bytes -> Result<bytes, IoError>
 
 fn fs$write_bytes -> i64
   statements:
-    use BindingId(57) path site=SiteId(550) ty=string intent=Read
-    use BindingId(58) data site=SiteId(551) ty=bytes intent=Read
-    return site=Some(SiteId(547)) ty=i64
+    use BindingId(54) path site=SiteId(487) ty=string intent=Read
+    use BindingId(55) data site=SiteId(488) ty=bytes intent=Read
+    return site=Some(SiteId(484)) ty=i64
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -981,10 +894,10 @@ fn fs$write_bytes -> i64
 
 fn fs$try_write_bytes -> Result<i64, IoError>
   statements:
-    use BindingId(59) file_path site=SiteId(556) ty=string intent=Read
-    use BindingId(60) data site=SiteId(557) ty=bytes intent=Read
-    return site=Some(SiteId(553)) ty=Result<i64, IoError>
-    use BindingId(59) file_path site=SiteId(563) ty=string intent=Read
+    use BindingId(56) file_path site=SiteId(493) ty=string intent=Read
+    use BindingId(57) data site=SiteId(494) ty=bytes intent=Read
+    return site=Some(SiteId(490)) ty=Result<i64, IoError>
+    use BindingId(56) file_path site=SiteId(500) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -1011,8 +924,8 @@ fn fs$try_write_bytes -> Result<i64, IoError>
 
 fn fs$mkdir -> i64
   statements:
-    use BindingId(61) path site=SiteId(568) ty=string intent=Read
-    return site=Some(SiteId(565)) ty=i64
+    use BindingId(58) path site=SiteId(505) ty=string intent=Read
+    return site=Some(SiteId(502)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -1023,9 +936,9 @@ fn fs$mkdir -> i64
 
 fn fs$try_mkdir -> Result<i64, IoError>
   statements:
-    use BindingId(62) dir_path site=SiteId(573) ty=string intent=Read
-    return site=Some(SiteId(570)) ty=Result<i64, IoError>
-    use BindingId(62) dir_path site=SiteId(579) ty=string intent=Read
+    use BindingId(59) dir_path site=SiteId(510) ty=string intent=Read
+    return site=Some(SiteId(507)) ty=Result<i64, IoError>
+    use BindingId(59) dir_path site=SiteId(516) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -1052,8 +965,8 @@ fn fs$try_mkdir -> Result<i64, IoError>
 
 fn fs$mkdir_all -> i64
   statements:
-    use BindingId(63) path site=SiteId(584) ty=string intent=Read
-    return site=Some(SiteId(581)) ty=i64
+    use BindingId(60) path site=SiteId(521) ty=string intent=Read
+    return site=Some(SiteId(518)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -1064,9 +977,9 @@ fn fs$mkdir_all -> i64
 
 fn fs$try_mkdir_all -> Result<i64, IoError>
   statements:
-    use BindingId(64) dir_path site=SiteId(589) ty=string intent=Read
-    return site=Some(SiteId(586)) ty=Result<i64, IoError>
-    use BindingId(64) dir_path site=SiteId(596) ty=string intent=Read
+    use BindingId(61) dir_path site=SiteId(526) ty=string intent=Read
+    return site=Some(SiteId(523)) ty=Result<i64, IoError>
+    use BindingId(61) dir_path site=SiteId(533) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -1099,8 +1012,8 @@ fn fs$try_mkdir_all -> Result<i64, IoError>
 
 fn fs$list_dir -> Vec<string>
   statements:
-    use BindingId(65) path site=SiteId(608) ty=string intent=Read
-    return site=Some(SiteId(606)) ty=Vec<string>
+    use BindingId(62) path site=SiteId(545) ty=string intent=Read
+    return site=Some(SiteId(543)) ty=Vec<string>
   drop_plans:
     call[bb0 hew_fs_list_dir -> bb1] ->
       (none)
@@ -1111,14 +1024,14 @@ fn fs$list_dir -> Vec<string>
 
 fn fs$try_list_dir -> Result<Vec<string>, IoError>
   statements:
-    use BindingId(66) dir_path site=SiteId(612) ty=string intent=Read
-    return site=Some(SiteId(614)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(618) ty=()
-    use BindingId(66) dir_path site=SiteId(621) ty=string intent=Read
-    return site=Some(SiteId(623)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(627) ty=()
-    use BindingId(66) dir_path site=SiteId(631) ty=string intent=Read
-    return site=Some(SiteId(628)) ty=Result<Vec<string>, IoError>
+    use BindingId(63) dir_path site=SiteId(549) ty=string intent=Read
+    return site=Some(SiteId(551)) ty=Result<Vec<string>, IoError>
+    eval site=SiteId(555) ty=()
+    use BindingId(63) dir_path site=SiteId(558) ty=string intent=Read
+    return site=Some(SiteId(560)) ty=Result<Vec<string>, IoError>
+    eval site=SiteId(564) ty=()
+    use BindingId(63) dir_path site=SiteId(568) ty=string intent=Read
+    return site=Some(SiteId(565)) ty=Result<Vec<string>, IoError>
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -1153,9 +1066,9 @@ fn fs$try_list_dir -> Result<Vec<string>, IoError>
 
 fn fs$rename -> i64
   statements:
-    use BindingId(67) from site=SiteId(636) ty=string intent=Read
-    use BindingId(68) to site=SiteId(637) ty=string intent=Read
-    return site=Some(SiteId(633)) ty=i64
+    use BindingId(64) from site=SiteId(573) ty=string intent=Read
+    use BindingId(65) to site=SiteId(574) ty=string intent=Read
+    return site=Some(SiteId(570)) ty=i64
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1166,11 +1079,11 @@ fn fs$rename -> i64
 
 fn fs$try_rename -> Result<i64, IoError>
   statements:
-    use BindingId(69) from site=SiteId(642) ty=string intent=Read
-    use BindingId(70) to site=SiteId(643) ty=string intent=Read
-    return site=Some(SiteId(639)) ty=Result<i64, IoError>
-    use BindingId(69) from site=SiteId(649) ty=string intent=Read
-    use BindingId(70) to site=SiteId(650) ty=string intent=Read
+    use BindingId(66) from site=SiteId(579) ty=string intent=Read
+    use BindingId(67) to site=SiteId(580) ty=string intent=Read
+    return site=Some(SiteId(576)) ty=Result<i64, IoError>
+    use BindingId(66) from site=SiteId(586) ty=string intent=Read
+    use BindingId(67) to site=SiteId(587) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1197,9 +1110,9 @@ fn fs$try_rename -> Result<i64, IoError>
 
 fn fs$copy -> i64
   statements:
-    use BindingId(71) from site=SiteId(655) ty=string intent=Read
-    use BindingId(72) to site=SiteId(656) ty=string intent=Read
-    return site=Some(SiteId(652)) ty=i64
+    use BindingId(68) from site=SiteId(592) ty=string intent=Read
+    use BindingId(69) to site=SiteId(593) ty=string intent=Read
+    return site=Some(SiteId(589)) ty=i64
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1210,11 +1123,11 @@ fn fs$copy -> i64
 
 fn fs$try_copy -> Result<i64, IoError>
   statements:
-    use BindingId(73) from site=SiteId(661) ty=string intent=Read
-    use BindingId(74) to site=SiteId(662) ty=string intent=Read
-    return site=Some(SiteId(658)) ty=Result<i64, IoError>
-    use BindingId(73) from site=SiteId(668) ty=string intent=Read
-    use BindingId(74) to site=SiteId(669) ty=string intent=Read
+    use BindingId(70) from site=SiteId(598) ty=string intent=Read
+    use BindingId(71) to site=SiteId(599) ty=string intent=Read
+    return site=Some(SiteId(595)) ty=Result<i64, IoError>
+    use BindingId(70) from site=SiteId(605) ty=string intent=Read
+    use BindingId(71) to site=SiteId(606) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1241,8 +1154,8 @@ fn fs$try_copy -> Result<i64, IoError>
 
 fn fs$is_dir -> bool
   statements:
-    use BindingId(75) path site=SiteId(673) ty=string intent=Read
-    return site=Some(SiteId(671)) ty=bool
+    use BindingId(72) path site=SiteId(610) ty=string intent=Read
+    return site=Some(SiteId(608)) ty=bool
   drop_plans:
     call[bb0 hew_fs_is_dir -> bb1] ->
       (none)
@@ -1253,21 +1166,21 @@ fn fs$is_dir -> bool
 
 fn stream$pipe -> (Sink<string>, Stream<string>)
   statements:
-    use BindingId(76) capacity site=SiteId(678) ty=i64 intent=Read
-    bind BindingId(77) pair site=SiteId(676) ty=StreamPair
-    use BindingId(77) pair site=SiteId(681) ty=StreamPair intent=Read
-    bind BindingId(78) sink site=SiteId(680) ty=Sink<string>
-    use BindingId(77) pair site=SiteId(684) ty=StreamPair intent=Read
-    bind BindingId(79) input site=SiteId(683) ty=Stream<string>
-    use BindingId(77) pair site=SiteId(687) ty=StreamPair intent=Read
-    eval site=SiteId(686) ty=()
-    use BindingId(78) sink site=SiteId(690) ty=Sink<string> intent=Read
-    use BindingId(79) input site=SiteId(691) ty=Stream<string> intent=Read
-    agg_alias BindingId(78) sink site=SiteId(690) ty=Sink<string>
-    agg_alias BindingId(79) input site=SiteId(691) ty=Stream<string>
-    return site=Some(SiteId(675)) ty=(Sink<string>, Stream<string>)
-    drop BindingId(79) input ty=Stream<string>
-    drop BindingId(78) sink ty=Sink<string>
+    use BindingId(73) capacity site=SiteId(615) ty=i64 intent=Read
+    bind BindingId(74) pair site=SiteId(613) ty=StreamPair
+    use BindingId(74) pair site=SiteId(618) ty=StreamPair intent=Read
+    bind BindingId(75) sink site=SiteId(617) ty=Sink<string>
+    use BindingId(74) pair site=SiteId(621) ty=StreamPair intent=Read
+    bind BindingId(76) input site=SiteId(620) ty=Stream<string>
+    use BindingId(74) pair site=SiteId(624) ty=StreamPair intent=Read
+    eval site=SiteId(623) ty=()
+    use BindingId(75) sink site=SiteId(627) ty=Sink<string> intent=Read
+    use BindingId(76) input site=SiteId(628) ty=Stream<string> intent=Read
+    agg_alias BindingId(75) sink site=SiteId(627) ty=Sink<string>
+    agg_alias BindingId(76) input site=SiteId(628) ty=Stream<string>
+    return site=Some(SiteId(612)) ty=(Sink<string>, Stream<string>)
+    drop BindingId(76) input ty=Stream<string>
+    drop BindingId(75) sink ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_channel -> bb1] ->
       (none)
@@ -1284,21 +1197,21 @@ fn stream$pipe -> (Sink<string>, Stream<string>)
 
 fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
   statements:
-    use BindingId(80) capacity site=SiteId(695) ty=i64 intent=Read
-    bind BindingId(81) pair site=SiteId(693) ty=StreamPair
-    use BindingId(81) pair site=SiteId(698) ty=StreamPair intent=Read
-    bind BindingId(82) sink site=SiteId(697) ty=Sink<bytes>
-    use BindingId(81) pair site=SiteId(701) ty=StreamPair intent=Read
-    bind BindingId(83) input site=SiteId(700) ty=Stream<bytes>
-    use BindingId(81) pair site=SiteId(704) ty=StreamPair intent=Read
-    eval site=SiteId(703) ty=()
-    use BindingId(82) sink site=SiteId(707) ty=Sink<bytes> intent=Read
-    use BindingId(83) input site=SiteId(708) ty=Stream<bytes> intent=Read
-    agg_alias BindingId(82) sink site=SiteId(707) ty=Sink<bytes>
-    agg_alias BindingId(83) input site=SiteId(708) ty=Stream<bytes>
-    return site=Some(SiteId(692)) ty=(Sink<bytes>, Stream<bytes>)
-    drop BindingId(83) input ty=Stream<bytes>
-    drop BindingId(82) sink ty=Sink<bytes>
+    use BindingId(77) capacity site=SiteId(632) ty=i64 intent=Read
+    bind BindingId(78) pair site=SiteId(630) ty=StreamPair
+    use BindingId(78) pair site=SiteId(635) ty=StreamPair intent=Read
+    bind BindingId(79) sink site=SiteId(634) ty=Sink<bytes>
+    use BindingId(78) pair site=SiteId(638) ty=StreamPair intent=Read
+    bind BindingId(80) input site=SiteId(637) ty=Stream<bytes>
+    use BindingId(78) pair site=SiteId(641) ty=StreamPair intent=Read
+    eval site=SiteId(640) ty=()
+    use BindingId(79) sink site=SiteId(644) ty=Sink<bytes> intent=Read
+    use BindingId(80) input site=SiteId(645) ty=Stream<bytes> intent=Read
+    agg_alias BindingId(79) sink site=SiteId(644) ty=Sink<bytes>
+    agg_alias BindingId(80) input site=SiteId(645) ty=Stream<bytes>
+    return site=Some(SiteId(629)) ty=(Sink<bytes>, Stream<bytes>)
+    drop BindingId(80) input ty=Stream<bytes>
+    drop BindingId(79) sink ty=Sink<bytes>
   drop_plans:
     call[bb0 hew_stream_channel -> bb1] ->
       (none)
@@ -1315,13 +1228,13 @@ fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
 
 fn stream$from_file -> Result<Stream<string>, string>
   statements:
-    use BindingId(84) path site=SiteId(711) ty=string intent=Read
-    bind BindingId(85) s site=SiteId(710) ty=Stream<string>
-    use BindingId(85) s site=SiteId(715) ty=Stream<string> intent=Read
-    use BindingId(85) s site=SiteId(719) ty=Stream<string> intent=Read
-    agg_alias BindingId(85) s site=SiteId(719) ty=Stream<string>
-    return site=Some(SiteId(709)) ty=Result<Stream<string>, string>
-    drop BindingId(85) s ty=Stream<string>
+    use BindingId(81) path site=SiteId(648) ty=string intent=Read
+    bind BindingId(82) s site=SiteId(647) ty=Stream<string>
+    use BindingId(82) s site=SiteId(652) ty=Stream<string> intent=Read
+    use BindingId(82) s site=SiteId(656) ty=Stream<string> intent=Read
+    agg_alias BindingId(82) s site=SiteId(656) ty=Stream<string>
+    return site=Some(SiteId(646)) ty=Result<Stream<string>, string>
+    drop BindingId(82) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1344,16 +1257,16 @@ fn stream$from_file -> Result<Stream<string>, string>
 
 fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
   statements:
-    use BindingId(86) path site=SiteId(726) ty=string intent=Read
-    bind BindingId(87) s site=SiteId(725) ty=Stream<string>
-    use BindingId(87) s site=SiteId(730) ty=Stream<string> intent=Read
-    use BindingId(87) s site=SiteId(734) ty=Stream<string> intent=Read
-    agg_alias BindingId(87) s site=SiteId(734) ty=Stream<string>
-    return site=Some(SiteId(724)) ty=Result<Stream<string>, fs.IoError>
-    bind BindingId(88) errno site=SiteId(736) ty=i32
-    eval site=SiteId(738) ty=string
-    use BindingId(88) errno site=SiteId(743) ty=i32 intent=Read
-    drop BindingId(87) s ty=Stream<string>
+    use BindingId(83) path site=SiteId(663) ty=string intent=Read
+    bind BindingId(84) s site=SiteId(662) ty=Stream<string>
+    use BindingId(84) s site=SiteId(667) ty=Stream<string> intent=Read
+    use BindingId(84) s site=SiteId(671) ty=Stream<string> intent=Read
+    agg_alias BindingId(84) s site=SiteId(671) ty=Stream<string>
+    return site=Some(SiteId(661)) ty=Result<Stream<string>, fs.IoError>
+    bind BindingId(85) errno site=SiteId(673) ty=i32
+    eval site=SiteId(675) ty=string
+    use BindingId(85) errno site=SiteId(680) ty=i32 intent=Read
+    drop BindingId(84) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1380,13 +1293,13 @@ fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
 
 fn stream$to_file -> Result<Sink<string>, string>
   statements:
-    use BindingId(89) path site=SiteId(747) ty=string intent=Read
-    bind BindingId(90) s site=SiteId(746) ty=Sink<string>
-    use BindingId(90) s site=SiteId(751) ty=Sink<string> intent=Read
-    use BindingId(90) s site=SiteId(755) ty=Sink<string> intent=Read
-    agg_alias BindingId(90) s site=SiteId(755) ty=Sink<string>
-    return site=Some(SiteId(745)) ty=Result<Sink<string>, string>
-    drop BindingId(90) s ty=Sink<string>
+    use BindingId(86) path site=SiteId(684) ty=string intent=Read
+    bind BindingId(87) s site=SiteId(683) ty=Sink<string>
+    use BindingId(87) s site=SiteId(688) ty=Sink<string> intent=Read
+    use BindingId(87) s site=SiteId(692) ty=Sink<string> intent=Read
+    agg_alias BindingId(87) s site=SiteId(692) ty=Sink<string>
+    return site=Some(SiteId(682)) ty=Result<Sink<string>, string>
+    drop BindingId(87) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1409,16 +1322,16 @@ fn stream$to_file -> Result<Sink<string>, string>
 
 fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
   statements:
-    use BindingId(91) path site=SiteId(762) ty=string intent=Read
-    bind BindingId(92) s site=SiteId(761) ty=Sink<string>
-    use BindingId(92) s site=SiteId(766) ty=Sink<string> intent=Read
-    use BindingId(92) s site=SiteId(770) ty=Sink<string> intent=Read
-    agg_alias BindingId(92) s site=SiteId(770) ty=Sink<string>
-    return site=Some(SiteId(760)) ty=Result<Sink<string>, fs.IoError>
-    bind BindingId(93) errno site=SiteId(772) ty=i32
-    eval site=SiteId(774) ty=string
-    use BindingId(93) errno site=SiteId(779) ty=i32 intent=Read
-    drop BindingId(92) s ty=Sink<string>
+    use BindingId(88) path site=SiteId(699) ty=string intent=Read
+    bind BindingId(89) s site=SiteId(698) ty=Sink<string>
+    use BindingId(89) s site=SiteId(703) ty=Sink<string> intent=Read
+    use BindingId(89) s site=SiteId(707) ty=Sink<string> intent=Read
+    agg_alias BindingId(89) s site=SiteId(707) ty=Sink<string>
+    return site=Some(SiteId(697)) ty=Result<Sink<string>, fs.IoError>
+    bind BindingId(90) errno site=SiteId(709) ty=i32
+    eval site=SiteId(711) ty=string
+    use BindingId(90) errno site=SiteId(716) ty=i32 intent=Read
+    drop BindingId(89) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1445,9 +1358,9 @@ fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
 
 fn stream$forward -> ()
   statements:
-    use BindingId(94) source site=SiteId(783) ty=Stream<string> intent=Read
-    use BindingId(95) dest site=SiteId(784) ty=Sink<string> intent=Read
-    eval site=SiteId(781) ty=()
+    use BindingId(91) source site=SiteId(720) ty=Stream<string> intent=Read
+    use BindingId(92) dest site=SiteId(721) ty=Sink<string> intent=Read
+    eval site=SiteId(718) ty=()
   drop_plans:
     call[bb0 hew_stream_pipe -> bb1] ->
       (none)
@@ -1458,8 +1371,8 @@ fn stream$forward -> ()
 
 fn i32::fmt -> string
   statements:
-    use BindingId(99) val site=SiteId(815) ty=i32 intent=Read
-    return site=Some(SiteId(814)) ty=string
+    use BindingId(96) val site=SiteId(752) ty=i32 intent=Read
+    return site=Some(SiteId(751)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1470,8 +1383,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(100) val site=SiteId(818) ty=i64 intent=Read
-    return site=Some(SiteId(817)) ty=string
+    use BindingId(97) val site=SiteId(755) ty=i64 intent=Read
+    return site=Some(SiteId(754)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1482,8 +1395,8 @@ fn i64::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(101) val site=SiteId(821) ty=u32 intent=Read
-    return site=Some(SiteId(820)) ty=string
+    use BindingId(98) val site=SiteId(758) ty=u32 intent=Read
+    return site=Some(SiteId(757)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -1494,8 +1407,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(102) val site=SiteId(824) ty=u64 intent=Read
-    return site=Some(SiteId(823)) ty=string
+    use BindingId(99) val site=SiteId(761) ty=u64 intent=Read
+    return site=Some(SiteId(760)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1506,8 +1419,8 @@ fn u64::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(103) val site=SiteId(827) ty=bool intent=Read
-    return site=Some(SiteId(826)) ty=string
+    use BindingId(100) val site=SiteId(764) ty=bool intent=Read
+    return site=Some(SiteId(763)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -1518,8 +1431,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(104) val site=SiteId(830) ty=char intent=Read
-    return site=Some(SiteId(829)) ty=string
+    use BindingId(101) val site=SiteId(767) ty=char intent=Read
+    return site=Some(SiteId(766)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -1530,8 +1443,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(105) val site=SiteId(833) ty=f64 intent=Read
-    return site=Some(SiteId(832)) ty=string
+    use BindingId(102) val site=SiteId(770) ty=f64 intent=Read
+    return site=Some(SiteId(769)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1542,8 +1455,8 @@ fn f64::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(106) val site=SiteId(835) ty=string intent=Read
-    return site=Some(SiteId(835)) ty=string
+    use BindingId(103) val site=SiteId(772) ty=string intent=Read
+    return site=Some(SiteId(772)) ty=string
   drop_plans:
     return[bb0] ->
       (none)

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
@@ -151,35 +151,8 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     _35: i64
     _36: IoError
     _37: IoError
-    _38: bool
-    _39: i64
-    _40: bool
-    _41: i64
-    _42: bool
-    _43: IoError
-    _44: i64
-    _45: IoError
-    _46: IoError
-    _47: bool
-    _48: i64
-    _49: bool
-    _50: i64
-    _51: bool
-    _52: IoError
-    _53: i64
-    _54: IoError
-    _55: IoError
-    _56: bool
-    _57: i64
-    _58: bool
-    _59: i64
-    _60: bool
-    _61: IoError
-    _62: i64
-    _63: IoError
-    _64: IoError
-    _65: i64
-    _66: IoError
+    _38: i64
+    _39: IoError
   bb0:
     stmt: use BindingId(6) errno site=SiteId(39) ty=i64 intent=Read
     _2 = const.i64 2
@@ -229,7 +202,7 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
   bb8:
     stmt: use BindingId(6) errno site=SiteId(61) ty=i64 intent=Read
     _20 = const.i64 1
-    _21 = const.i64 111
+    _21 = const.i64 110
     _22 = icmp.eq _0 _21
     branch _22 ? bb11 : bb10
   bb9:
@@ -237,7 +210,7 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     goto bb6
   bb10:
     stmt: use BindingId(6) errno site=SiteId(64) ty=i64 intent=Read
-    _23 = const.i64 61
+    _23 = const.i64 60
     _24 = icmp.eq _0 _23
     _20 = move _24
     goto bb11
@@ -254,7 +227,7 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
   bb13:
     stmt: use BindingId(6) errno site=SiteId(72) ty=i64 intent=Read
     _29 = const.i64 1
-    _30 = const.i64 98
+    _30 = const.i64 125
     _31 = icmp.eq _0 _30
     branch _31 ? bb16 : bb15
   bb14:
@@ -262,7 +235,7 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     goto bb9
   bb15:
     stmt: use BindingId(6) errno site=SiteId(75) ty=i64 intent=Read
-    _32 = const.i64 48
+    _32 = const.i64 89
     _33 = icmp.eq _0 _32
     _29 = move _33
     goto bb16
@@ -277,91 +250,16 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     _28 = move _36
     goto bb19
   bb18:
-    stmt: use BindingId(6) errno site=SiteId(83) ty=i64 intent=Read
-    _38 = const.i64 1
-    _39 = const.i64 110
-    _40 = icmp.eq _0 _39
-    branch _40 ? bb21 : bb20
+    stmt: use BindingId(6) errno site=SiteId(82) ty=i64 intent=Read
+    _38 = const.i64 5
+    mtag37 = move _38
+    mvar37.5.0 = move _0
+    _39 = move _37
+    _28 = move _39
+    goto bb19
   bb19:
     _19 = move _28
     goto bb14
-  bb20:
-    stmt: use BindingId(6) errno site=SiteId(86) ty=i64 intent=Read
-    _41 = const.i64 60
-    _42 = icmp.eq _0 _41
-    _38 = move _42
-    goto bb21
-  bb21:
-    branch _38 ? bb22 : bb23
-  bb22:
-    stmt: use BindingId(6) errno site=SiteId(90) ty=i64 intent=Read
-    _44 = const.i64 5
-    mtag43 = move _44
-    mvar43.5.0 = move _0
-    _45 = move _43
-    _37 = move _45
-    goto bb24
-  bb23:
-    stmt: use BindingId(6) errno site=SiteId(94) ty=i64 intent=Read
-    _47 = const.i64 1
-    _48 = const.i64 125
-    _49 = icmp.eq _0 _48
-    branch _49 ? bb26 : bb25
-  bb24:
-    _28 = move _37
-    goto bb19
-  bb25:
-    stmt: use BindingId(6) errno site=SiteId(97) ty=i64 intent=Read
-    _50 = const.i64 89
-    _51 = icmp.eq _0 _50
-    _47 = move _51
-    goto bb26
-  bb26:
-    branch _47 ? bb27 : bb28
-  bb27:
-    stmt: use BindingId(6) errno site=SiteId(101) ty=i64 intent=Read
-    _53 = const.i64 6
-    mtag52 = move _53
-    mvar52.6.0 = move _0
-    _54 = move _52
-    _46 = move _54
-    goto bb29
-  bb28:
-    stmt: use BindingId(6) errno site=SiteId(105) ty=i64 intent=Read
-    _56 = const.i64 1
-    _57 = const.i64 99
-    _58 = icmp.eq _0 _57
-    branch _58 ? bb31 : bb30
-  bb29:
-    _37 = move _46
-    goto bb24
-  bb30:
-    stmt: use BindingId(6) errno site=SiteId(108) ty=i64 intent=Read
-    _59 = const.i64 49
-    _60 = icmp.eq _0 _59
-    _56 = move _60
-    goto bb31
-  bb31:
-    branch _56 ? bb32 : bb33
-  bb32:
-    stmt: use BindingId(6) errno site=SiteId(112) ty=i64 intent=Read
-    _62 = const.i64 7
-    mtag61 = move _62
-    mvar61.7.0 = move _0
-    _63 = move _61
-    _55 = move _63
-    goto bb34
-  bb33:
-    stmt: use BindingId(6) errno site=SiteId(115) ty=i64 intent=Read
-    _65 = const.i64 8
-    mtag64 = move _65
-    mvar64.8.0 = move _0
-    _66 = move _64
-    _55 = move _66
-    goto bb34
-  bb34:
-    _46 = move _55
-    goto bb29
 
 fn fs$io_error_message(IoError) -> string [conv=default]
   locals:
@@ -381,11 +279,11 @@ fn fs$io_error_message(IoError) -> string [conv=default]
     _13: i64
     _14: bool
     _15: i64
-    _16: bool
-    _17: i64
-    _18: bool
-    _19: i64
-    _20: bool
+    _16: string
+    _17: string
+    _18: string
+    _19: string
+    _20: string
     _21: i64
     _22: string
     _23: string
@@ -416,199 +314,121 @@ fn fs$io_error_message(IoError) -> string [conv=default]
     _48: string
     _49: string
     _50: string
-    _51: i64
-    _52: string
-    _53: string
-    _54: string
-    _55: string
-    _56: string
-    _57: i64
-    _58: string
-    _59: string
-    _60: string
-    _61: string
-    _62: string
-    _63: i64
-    _64: string
-    _65: string
-    _66: string
-    _67: string
-    _68: string
-    _69: i64
-    _70: string
-    _71: string
-    _72: string
-    _73: string
-    _74: string
   bb0:
-    stmt: use BindingId(7) e site=SiteId(117) ty=IoError intent=Read
+    stmt: use BindingId(7) e site=SiteId(84) ty=IoError intent=Read
     _2 = move etag0
     _3 = const.i64 0
     _4 = icmp.eq _2 _3
-    branch _4 ? bb2 : bb12
+    branch _4 ? bb2 : bb9
   bb1:
-    stmt: return site=Some(SiteId(116)) ty=string
+    stmt: return site=Some(SiteId(83)) ty=string
     ret = move _1
     return
   bb2:
-    stmt: bind BindingId(8) code site=SiteId(118) ty=i64
-    stmt: use BindingId(8) code site=SiteId(120) ty=i64 intent=Read
-    _21 = move mvar0.0.0
-    _22 = string_lit "NotFound("
-    _23 = call to_string_i64(_21) -> bb20
+    stmt: bind BindingId(8) code site=SiteId(85) ty=i64
+    stmt: use BindingId(8) code site=SiteId(87) ty=i64 intent=Read
+    _15 = move mvar0.0.0
+    _16 = string_lit "NotFound("
+    _17 = call to_string_i64(_15) -> bb14
   bb3:
-    stmt: bind BindingId(9) code site=SiteId(128) ty=i64
-    stmt: use BindingId(9) code site=SiteId(130) ty=i64 intent=Read
-    _27 = move mvar0.1.0
-    _28 = string_lit "PermissionDenied("
-    _29 = call to_string_i64(_27) -> bb23
+    stmt: bind BindingId(9) code site=SiteId(95) ty=i64
+    stmt: use BindingId(9) code site=SiteId(97) ty=i64 intent=Read
+    _21 = move mvar0.1.0
+    _22 = string_lit "PermissionDenied("
+    _23 = call to_string_i64(_21) -> bb17
   bb4:
-    stmt: bind BindingId(10) code site=SiteId(138) ty=i64
-    stmt: use BindingId(10) code site=SiteId(140) ty=i64 intent=Read
-    _33 = move mvar0.2.0
-    _34 = string_lit "AlreadyExists("
-    _35 = call to_string_i64(_33) -> bb26
+    stmt: bind BindingId(10) code site=SiteId(105) ty=i64
+    stmt: use BindingId(10) code site=SiteId(107) ty=i64 intent=Read
+    _27 = move mvar0.2.0
+    _28 = string_lit "AlreadyExists("
+    _29 = call to_string_i64(_27) -> bb20
   bb5:
-    stmt: bind BindingId(11) code site=SiteId(148) ty=i64
-    stmt: use BindingId(11) code site=SiteId(150) ty=i64 intent=Read
-    _39 = move mvar0.3.0
-    _40 = string_lit "ConnectionRefused("
-    _41 = call to_string_i64(_39) -> bb29
+    stmt: bind BindingId(11) code site=SiteId(115) ty=i64
+    stmt: use BindingId(11) code site=SiteId(117) ty=i64 intent=Read
+    _33 = move mvar0.3.0
+    _34 = string_lit "TimedOut("
+    _35 = call to_string_i64(_33) -> bb23
   bb6:
-    stmt: bind BindingId(12) code site=SiteId(158) ty=i64
-    stmt: use BindingId(12) code site=SiteId(160) ty=i64 intent=Read
-    _45 = move mvar0.4.0
-    _46 = string_lit "AddressInUse("
-    _47 = call to_string_i64(_45) -> bb32
+    stmt: bind BindingId(12) code site=SiteId(125) ty=i64
+    stmt: use BindingId(12) code site=SiteId(127) ty=i64 intent=Read
+    _39 = move mvar0.4.0
+    _40 = string_lit "Cancelled("
+    _41 = call to_string_i64(_39) -> bb26
   bb7:
-    stmt: bind BindingId(13) code site=SiteId(168) ty=i64
-    stmt: use BindingId(13) code site=SiteId(170) ty=i64 intent=Read
-    _51 = move mvar0.5.0
-    _52 = string_lit "TimedOut("
-    _53 = call to_string_i64(_51) -> bb35
+    stmt: bind BindingId(13) code site=SiteId(135) ty=i64
+    stmt: use BindingId(13) code site=SiteId(137) ty=i64 intent=Read
+    _45 = move mvar0.5.0
+    _46 = string_lit "Other("
+    _47 = call to_string_i64(_45) -> bb29
   bb8:
-    stmt: bind BindingId(14) code site=SiteId(178) ty=i64
-    stmt: use BindingId(14) code site=SiteId(180) ty=i64 intent=Read
-    _57 = move mvar0.6.0
-    _58 = string_lit "Cancelled("
-    _59 = call to_string_i64(_57) -> bb38
-  bb9:
-    stmt: bind BindingId(15) code site=SiteId(188) ty=i64
-    stmt: use BindingId(15) code site=SiteId(190) ty=i64 intent=Read
-    _63 = move mvar0.7.0
-    _64 = string_lit "AddressNotAvailable("
-    _65 = call to_string_i64(_63) -> bb41
-  bb10:
-    stmt: bind BindingId(16) code site=SiteId(198) ty=i64
-    stmt: use BindingId(16) code site=SiteId(200) ty=i64 intent=Read
-    _69 = move mvar0.8.0
-    _70 = string_lit "Other("
-    _71 = call to_string_i64(_69) -> bb44
-  bb11:
     trap(ExhaustivenessFallthrough)
-  bb12:
+  bb9:
     _5 = const.i64 1
     _6 = icmp.eq _2 _5
-    branch _6 ? bb3 : bb13
-  bb13:
+    branch _6 ? bb3 : bb10
+  bb10:
     _7 = const.i64 2
     _8 = icmp.eq _2 _7
-    branch _8 ? bb4 : bb14
-  bb14:
+    branch _8 ? bb4 : bb11
+  bb11:
     _9 = const.i64 3
     _10 = icmp.eq _2 _9
-    branch _10 ? bb5 : bb15
-  bb15:
+    branch _10 ? bb5 : bb12
+  bb12:
     _11 = const.i64 4
     _12 = icmp.eq _2 _11
-    branch _12 ? bb6 : bb16
-  bb16:
+    branch _12 ? bb6 : bb13
+  bb13:
     _13 = const.i64 5
     _14 = icmp.eq _2 _13
-    branch _14 ? bb7 : bb17
+    branch _14 ? bb7 : bb8
+  bb14:
+    _18 = call string_concat(_16, _17) -> bb15
+  bb15:
+    _19 = string_lit ")"
+    _20 = call string_concat(_18, _19) -> bb16
+  bb16:
+    _1 = move _20
+    goto bb1
   bb17:
-    _15 = const.i64 6
-    _16 = icmp.eq _2 _15
-    branch _16 ? bb8 : bb18
+    _24 = call string_concat(_22, _23) -> bb18
   bb18:
-    _17 = const.i64 7
-    _18 = icmp.eq _2 _17
-    branch _18 ? bb9 : bb19
-  bb19:
-    _19 = const.i64 8
-    _20 = icmp.eq _2 _19
-    branch _20 ? bb10 : bb11
-  bb20:
-    _24 = call string_concat(_22, _23) -> bb21
-  bb21:
     _25 = string_lit ")"
-    _26 = call string_concat(_24, _25) -> bb22
-  bb22:
+    _26 = call string_concat(_24, _25) -> bb19
+  bb19:
     _1 = move _26
     goto bb1
-  bb23:
-    _30 = call string_concat(_28, _29) -> bb24
-  bb24:
+  bb20:
+    _30 = call string_concat(_28, _29) -> bb21
+  bb21:
     _31 = string_lit ")"
-    _32 = call string_concat(_30, _31) -> bb25
-  bb25:
+    _32 = call string_concat(_30, _31) -> bb22
+  bb22:
     _1 = move _32
     goto bb1
-  bb26:
-    _36 = call string_concat(_34, _35) -> bb27
-  bb27:
+  bb23:
+    _36 = call string_concat(_34, _35) -> bb24
+  bb24:
     _37 = string_lit ")"
-    _38 = call string_concat(_36, _37) -> bb28
-  bb28:
+    _38 = call string_concat(_36, _37) -> bb25
+  bb25:
     _1 = move _38
     goto bb1
-  bb29:
-    _42 = call string_concat(_40, _41) -> bb30
-  bb30:
+  bb26:
+    _42 = call string_concat(_40, _41) -> bb27
+  bb27:
     _43 = string_lit ")"
-    _44 = call string_concat(_42, _43) -> bb31
-  bb31:
+    _44 = call string_concat(_42, _43) -> bb28
+  bb28:
     _1 = move _44
     goto bb1
-  bb32:
-    _48 = call string_concat(_46, _47) -> bb33
-  bb33:
+  bb29:
+    _48 = call string_concat(_46, _47) -> bb30
+  bb30:
     _49 = string_lit ")"
-    _50 = call string_concat(_48, _49) -> bb34
-  bb34:
+    _50 = call string_concat(_48, _49) -> bb31
+  bb31:
     _1 = move _50
-    goto bb1
-  bb35:
-    _54 = call string_concat(_52, _53) -> bb36
-  bb36:
-    _55 = string_lit ")"
-    _56 = call string_concat(_54, _55) -> bb37
-  bb37:
-    _1 = move _56
-    goto bb1
-  bb38:
-    _60 = call string_concat(_58, _59) -> bb39
-  bb39:
-    _61 = string_lit ")"
-    _62 = call string_concat(_60, _61) -> bb40
-  bb40:
-    _1 = move _62
-    goto bb1
-  bb41:
-    _66 = call string_concat(_64, _65) -> bb42
-  bb42:
-    _67 = string_lit ")"
-    _68 = call string_concat(_66, _67) -> bb43
-  bb43:
-    _1 = move _68
-    goto bb1
-  bb44:
-    _72 = call string_concat(_70, _71) -> bb45
-  bb45:
-    _73 = string_lit ")"
-    _74 = call string_concat(_72, _73) -> bb46
-  bb46:
-    _1 = move _74
     goto bb1
 
 fn fs$io_error_timed_out() -> IoError [conv=default]
@@ -617,11 +437,11 @@ fn fs$io_error_timed_out() -> IoError [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: return site=Some(SiteId(208)) ty=IoError
-    _1 = const.i64 5
+    stmt: return site=Some(SiteId(145)) ty=IoError
+    _1 = const.i64 3
     mtag0 = move _1
     _2 = const.i64 0
-    mvar0.5.0 = move _2
+    mvar0.3.0 = move _2
     ret = move _0
     return
 
@@ -631,11 +451,11 @@ fn fs$io_error_cancelled() -> IoError [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: return site=Some(SiteId(210)) ty=IoError
-    _1 = const.i64 6
+    stmt: return site=Some(SiteId(147)) ty=IoError
+    _1 = const.i64 4
     mtag0 = move _1
     _2 = const.i64 0
-    mvar0.6.0 = move _2
+    mvar0.4.0 = move _2
     ret = move _0
     return
 
@@ -650,21 +470,21 @@ fn fs$missing_parent(string) -> bool [conv=default]
     _6: bool
     _7: bool
   bb0:
-    stmt: use BindingId(17) target site=SiteId(213) ty=string intent=Read
+    stmt: use BindingId(14) target site=SiteId(150) ty=string intent=Read
     _1 = call fs$dirname(_0) -> bb1
   bb1:
-    stmt: bind BindingId(18) parent site=SiteId(212) ty=string
-    stmt: use BindingId(18) parent site=SiteId(217) ty=string intent=Read
+    stmt: bind BindingId(15) parent site=SiteId(149) ty=string
+    stmt: use BindingId(15) parent site=SiteId(154) ty=string intent=Read
     _2 = move _1
     _3 = const.i64 0
     _4 = string_lit ""
     _5 = icmp.ne _2 _4
     branch _5 ? bb2 : bb3
   bb2:
-    stmt: use BindingId(18) parent site=SiteId(221) ty=string intent=Read
+    stmt: use BindingId(15) parent site=SiteId(158) ty=string intent=Read
     _6 = call fs$exists(_2) -> bb4
   bb3:
-    stmt: return site=Some(SiteId(215)) ty=bool
+    stmt: return site=Some(SiteId(152)) ty=bool
     ret = move _3
     return
   bb4:
@@ -690,52 +510,52 @@ fn fs$dirname(string) -> string [conv=default]
     _13: i64
     _14: string
   bb0:
-    stmt: use BindingId(19) p site=SiteId(224) ty=string intent=Read
+    stmt: use BindingId(16) p site=SiteId(161) ty=string intent=Read
     _1 = call fs$strip_trailing_slash(_0) -> bb1
   bb1:
-    stmt: bind BindingId(20) s site=SiteId(223) ty=string
-    stmt: use BindingId(20) s site=SiteId(227) ty=string intent=Read
+    stmt: bind BindingId(17) s site=SiteId(160) ty=string
+    stmt: use BindingId(17) s site=SiteId(164) ty=string intent=Read
     _2 = move _1
     _3 = call fs$last_slash_pos(_2) -> bb2
   bb2:
-    stmt: bind BindingId(21) pos site=SiteId(226) ty=i64
-    stmt: use BindingId(21) pos site=SiteId(230) ty=i64 intent=Read
+    stmt: bind BindingId(18) pos site=SiteId(163) ty=i64
+    stmt: use BindingId(18) pos site=SiteId(167) ty=i64 intent=Read
     _4 = move _3
     _6 = const.i64 0
     _7 = icmp.slt _4 _6
     branch _7 ? bb3 : bb4
   bb3:
-    stmt: return site=Some(SiteId(232)) ty=string
+    stmt: return site=Some(SiteId(169)) ty=string
     _8 = string_lit ""
     ret = move _8
     return
   bb4:
     goto bb5
   bb5:
-    stmt: eval site=SiteId(234) ty=()
-    stmt: use BindingId(21) pos site=SiteId(236) ty=i64 intent=Read
+    stmt: eval site=SiteId(171) ty=()
+    stmt: use BindingId(18) pos site=SiteId(173) ty=i64 intent=Read
     _10 = const.i64 0
     _11 = icmp.eq _4 _10
     branch _11 ? bb7 : bb8
   bb6:
     goto bb5
   bb7:
-    stmt: return site=Some(SiteId(238)) ty=string
+    stmt: return site=Some(SiteId(175)) ty=string
     _12 = string_lit "/"
     ret = move _12
     return
   bb8:
     goto bb9
   bb9:
-    stmt: eval site=SiteId(240) ty=()
-    stmt: use BindingId(20) s site=SiteId(242) ty=string intent=Read
-    stmt: use BindingId(21) pos site=SiteId(244) ty=i64 intent=Read
+    stmt: eval site=SiteId(177) ty=()
+    stmt: use BindingId(17) s site=SiteId(179) ty=string intent=Read
+    stmt: use BindingId(18) pos site=SiteId(181) ty=i64 intent=Read
     _13 = const.i64 0
     _14 = call hew_string_slice(_2, _13, _4) -> bb11
   bb10:
     goto bb9
   bb11:
-    stmt: return site=Some(SiteId(241)) ty=string
+    stmt: return site=Some(SiteId(178)) ty=string
     ret = move _14
     return
 
@@ -763,13 +583,13 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
     _19: string
     _20: string
   bb0:
-    stmt: use BindingId(22) p site=SiteId(247) ty=string intent=Read
+    stmt: use BindingId(19) p site=SiteId(184) ty=string intent=Read
     _2 = string_lit "/"
     _3 = icmp.eq _0 _2
     branch _3 ? bb1 : bb2
   bb1:
-    stmt: use BindingId(22) p site=SiteId(251) ty=string intent=Read
-    stmt: return site=Some(SiteId(249)) ty=string
+    stmt: use BindingId(19) p site=SiteId(188) ty=string intent=Read
+    stmt: return site=Some(SiteId(186)) ty=string
     _4 = string_lit ""
     _5 = call_rt hew_string_concat(_4, _0)
     ret = move _5
@@ -777,8 +597,8 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
   bb2:
     goto bb3
   bb3:
-    stmt: eval site=SiteId(253) ty=()
-    stmt: use BindingId(22) p site=SiteId(257) ty=string intent=Read
+    stmt: eval site=SiteId(190) ty=()
+    stmt: use BindingId(19) p site=SiteId(194) ty=string intent=Read
     _7 = const.i64 0
     _8 = call hew_string_length(_0) -> bb5
   bb4:
@@ -788,7 +608,7 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
     _10 = icmp.sgt _8 _9
     branch _10 ? bb6 : bb7
   bb6:
-    stmt: use BindingId(22) p site=SiteId(261) ty=string intent=Read
+    stmt: use BindingId(19) p site=SiteId(198) ty=string intent=Read
     _11 = string_lit "/"
     _12 = call hew_string_ends_with(_0, _11) -> bb8
   bb7:
@@ -797,16 +617,16 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
     _7 = move _12
     goto bb7
   bb9:
-    stmt: use BindingId(22) p site=SiteId(265) ty=string intent=Read
-    stmt: use BindingId(22) p site=SiteId(269) ty=string intent=Read
+    stmt: use BindingId(19) p site=SiteId(202) ty=string intent=Read
+    stmt: use BindingId(19) p site=SiteId(206) ty=string intent=Read
     _13 = const.i64 0
     _14 = call hew_string_length(_0) -> bb12
   bb10:
     goto bb11
   bb11:
-    stmt: eval site=SiteId(274) ty=()
-    stmt: use BindingId(22) p site=SiteId(277) ty=string intent=Read
-    stmt: return site=Some(SiteId(275)) ty=string
+    stmt: eval site=SiteId(211) ty=()
+    stmt: use BindingId(19) p site=SiteId(214) ty=string intent=Read
+    stmt: return site=Some(SiteId(212)) ty=string
     _19 = string_lit ""
     _20 = call_rt hew_string_concat(_19, _0)
     ret = move _20
@@ -820,7 +640,7 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
   bb14:
     _18 = call hew_string_slice(_0, _13, _16) -> bb15
   bb15:
-    stmt: return site=Some(SiteId(264)) ty=string
+    stmt: return site=Some(SiteId(201)) ty=string
     ret = move _18
     return
   bb16:
@@ -860,12 +680,12 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
     _29: i64
     _30: bool
   bb0:
-    stmt: use BindingId(23) s site=SiteId(279) ty=string intent=Read
+    stmt: use BindingId(20) s site=SiteId(216) ty=string intent=Read
     _1 = string_lit "/"
     _2 = call hew_string_find(_0, _1) -> bb1
   bb1:
-    stmt: bind BindingId(24) first site=SiteId(278) ty=i64
-    stmt: use BindingId(24) first site=SiteId(283) ty=i64 intent=Read
+    stmt: bind BindingId(21) first site=SiteId(215) ty=i64
+    stmt: use BindingId(21) first site=SiteId(220) ty=i64 intent=Read
     _3 = move _2
     _5 = const.i64 0
     _6 = icmp.slt _3 _5
@@ -877,10 +697,10 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb3:
     goto bb4
   bb4:
-    stmt: eval site=SiteId(288) ty=()
-    stmt: use BindingId(24) first site=SiteId(289) ty=i64 intent=Consume
-    stmt: bind BindingId(25) last site=SiteId(289) ty=i64
-    stmt: use BindingId(24) first site=SiteId(291) ty=i64 intent=Read
+    stmt: eval site=SiteId(225) ty=()
+    stmt: use BindingId(21) first site=SiteId(226) ty=i64 intent=Consume
+    stmt: bind BindingId(22) last site=SiteId(226) ty=i64
+    stmt: use BindingId(21) first site=SiteId(228) ty=i64 intent=Read
     _10 = move _3
     _11 = const.i64 1
     _12 ovf=_13 = add.checked.s _3 _11
@@ -888,7 +708,7 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb5:
     trap(IntegerOverflow)
   bb6:
-    stmt: return site=Some(SiteId(285)) ty=i64
+    stmt: return site=Some(SiteId(222)) ty=i64
     ret = move _8
     return
   bb7:
@@ -896,22 +716,22 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb8:
     trap(IntegerOverflow)
   bb9:
-    stmt: bind BindingId(26) search_from site=SiteId(290) ty=i64
+    stmt: bind BindingId(23) search_from site=SiteId(227) ty=i64
     _14 = move _12
     goto bb10
   bb10:
-    stmt: use BindingId(26) search_from site=SiteId(294) ty=i64 intent=Read
-    stmt: use BindingId(23) s site=SiteId(296) ty=string intent=Read
+    stmt: use BindingId(23) search_from site=SiteId(231) ty=i64 intent=Read
+    stmt: use BindingId(20) s site=SiteId(233) ty=string intent=Read
     _15 = call hew_string_length(_0) -> bb13
   bb11:
-    stmt: use BindingId(23) s site=SiteId(299) ty=string intent=Read
-    stmt: use BindingId(26) search_from site=SiteId(300) ty=i64 intent=Read
-    stmt: use BindingId(23) s site=SiteId(302) ty=string intent=Read
+    stmt: use BindingId(20) s site=SiteId(236) ty=string intent=Read
+    stmt: use BindingId(23) search_from site=SiteId(237) ty=i64 intent=Read
+    stmt: use BindingId(20) s site=SiteId(239) ty=string intent=Read
     _17 = call hew_string_length(_0) -> bb14
   bb12:
-    stmt: eval site=SiteId(323) ty=()
-    stmt: use BindingId(25) last site=SiteId(324) ty=i64 intent=Read
-    stmt: return site=Some(SiteId(324)) ty=i64
+    stmt: eval site=SiteId(260) ty=()
+    stmt: use BindingId(22) last site=SiteId(261) ty=i64 intent=Read
+    stmt: return site=Some(SiteId(261)) ty=i64
     ret = move _10
     return
   bb13:
@@ -920,29 +740,29 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb14:
     _18 = call hew_string_slice(_0, _14, _17) -> bb15
   bb15:
-    stmt: bind BindingId(27) rest site=SiteId(298) ty=string
-    stmt: use BindingId(27) rest site=SiteId(306) ty=string intent=Read
+    stmt: bind BindingId(24) rest site=SiteId(235) ty=string
+    stmt: use BindingId(24) rest site=SiteId(243) ty=string intent=Read
     _19 = move _18
     _20 = string_lit "/"
     _21 = call hew_string_find(_19, _20) -> bb16
   bb16:
-    stmt: bind BindingId(28) next site=SiteId(305) ty=i64
-    stmt: use BindingId(28) next site=SiteId(310) ty=i64 intent=Read
+    stmt: bind BindingId(25) next site=SiteId(242) ty=i64
+    stmt: use BindingId(25) next site=SiteId(247) ty=i64 intent=Read
     _22 = move _21
     _24 = const.i64 0
     _25 = icmp.slt _22 _24
     branch _25 ? bb17 : bb18
   bb17:
-    stmt: use BindingId(25) last site=SiteId(312) ty=i64 intent=Consume
-    stmt: return site=Some(SiteId(312)) ty=i64
+    stmt: use BindingId(22) last site=SiteId(249) ty=i64 intent=Consume
+    stmt: return site=Some(SiteId(249)) ty=i64
     ret = move _10
     return
   bb18:
     goto bb19
   bb19:
-    stmt: eval site=SiteId(314) ty=()
-    stmt: use BindingId(26) search_from site=SiteId(317) ty=i64 intent=Read
-    stmt: use BindingId(28) next site=SiteId(318) ty=i64 intent=Read
+    stmt: eval site=SiteId(251) ty=()
+    stmt: use BindingId(23) search_from site=SiteId(254) ty=i64 intent=Read
+    stmt: use BindingId(25) next site=SiteId(255) ty=i64 intent=Read
     _26 ovf=_27 = add.checked.s _14 _22
     branch _27 ? bb21 : bb22
   bb20:
@@ -950,8 +770,8 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb21:
     trap(IntegerOverflow)
   bb22:
-    stmt: eval site=SiteId(316) ty=()
-    stmt: use BindingId(25) last site=SiteId(321) ty=i64 intent=Read
+    stmt: eval site=SiteId(253) ty=()
+    stmt: use BindingId(22) last site=SiteId(258) ty=i64 intent=Read
     _10 = move _26
     _28 = const.i64 1
     _29 ovf=_30 = add.checked.s _10 _28
@@ -959,7 +779,7 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb23:
     trap(IntegerOverflow)
   bb24:
-    stmt: eval site=SiteId(320) ty=()
+    stmt: eval site=SiteId(257) ty=()
     _14 = move _29
     goto bb10
 
@@ -977,7 +797,7 @@ fn fs$write_error(string) -> IoError [conv=default]
     _9: i64
     _10: IoError
   bb0:
-    stmt: use BindingId(29) target site=SiteId(327) ty=string intent=Read
+    stmt: use BindingId(26) target site=SiteId(264) ty=string intent=Read
     _2 = call fs$missing_parent(_0) -> bb1
   bb1:
     branch _2 ? bb2 : bb3
@@ -990,15 +810,15 @@ fn fs$write_error(string) -> IoError [conv=default]
     _1 = move _6
     goto bb4
   bb3:
-    _8 = const.i64 8
+    _8 = const.i64 5
     mtag7 = move _8
     _9 = const.i64 0
-    mvar7.8.0 = move _9
+    mvar7.5.0 = move _9
     _10 = move _7
     _1 = move _10
     goto bb4
   bb4:
-    stmt: return site=Some(SiteId(325)) ty=IoError
+    stmt: return site=Some(SiteId(262)) ty=IoError
     ret = move _1
     return
 
@@ -1016,15 +836,15 @@ fn fs$missing_path_error(string) -> IoError [conv=default]
     _9: i64
     _10: IoError
   bb0:
-    stmt: use BindingId(30) target site=SiteId(337) ty=string intent=Read
+    stmt: use BindingId(27) target site=SiteId(274) ty=string intent=Read
     _2 = call fs$exists(_0) -> bb1
   bb1:
     branch _2 ? bb2 : bb3
   bb2:
-    _4 = const.i64 8
+    _4 = const.i64 5
     mtag3 = move _4
     _5 = const.i64 0
-    mvar3.8.0 = move _5
+    mvar3.5.0 = move _5
     _6 = move _3
     _1 = move _6
     goto bb4
@@ -1037,7 +857,7 @@ fn fs$missing_path_error(string) -> IoError [conv=default]
     _1 = move _10
     goto bb4
   bb4:
-    stmt: return site=Some(SiteId(335)) ty=IoError
+    stmt: return site=Some(SiteId(272)) ty=IoError
     ret = move _1
     return
 
@@ -1061,7 +881,7 @@ fn fs$mkdir_error(string) -> IoError [conv=default]
     _15: i64
     _16: IoError
   bb0:
-    stmt: use BindingId(31) target site=SiteId(347) ty=string intent=Read
+    stmt: use BindingId(28) target site=SiteId(284) ty=string intent=Read
     _2 = call fs$exists(_0) -> bb1
   bb1:
     branch _2 ? bb2 : bb3
@@ -1074,10 +894,10 @@ fn fs$mkdir_error(string) -> IoError [conv=default]
     _1 = move _6
     goto bb4
   bb3:
-    stmt: use BindingId(31) target site=SiteId(354) ty=string intent=Read
+    stmt: use BindingId(28) target site=SiteId(291) ty=string intent=Read
     _8 = call fs$missing_parent(_0) -> bb5
   bb4:
-    stmt: return site=Some(SiteId(345)) ty=IoError
+    stmt: return site=Some(SiteId(282)) ty=IoError
     ret = move _1
     return
   bb5:
@@ -1091,10 +911,10 @@ fn fs$mkdir_error(string) -> IoError [conv=default]
     _7 = move _12
     goto bb8
   bb7:
-    _14 = const.i64 8
+    _14 = const.i64 5
     mtag13 = move _14
     _15 = const.i64 0
-    mvar13.8.0 = move _15
+    mvar13.5.0 = move _15
     _16 = move _13
     _7 = move _16
     goto bb8
@@ -1124,7 +944,7 @@ fn fs$move_copy_error(string, string) -> IoError [conv=default]
     _17: i64
     _18: IoError
   bb0:
-    stmt: use BindingId(32) source site=SiteId(365) ty=string intent=Read
+    stmt: use BindingId(29) source site=SiteId(302) ty=string intent=Read
     _3 = call fs$exists(_0) -> bb1
   bb1:
     _4 = not _3
@@ -1138,10 +958,10 @@ fn fs$move_copy_error(string, string) -> IoError [conv=default]
     _2 = move _8
     goto bb4
   bb3:
-    stmt: use BindingId(33) target site=SiteId(372) ty=string intent=Read
+    stmt: use BindingId(30) target site=SiteId(309) ty=string intent=Read
     _10 = call fs$missing_parent(_1) -> bb5
   bb4:
-    stmt: return site=Some(SiteId(362)) ty=IoError
+    stmt: return site=Some(SiteId(299)) ty=IoError
     ret = move _2
     return
   bb5:
@@ -1155,10 +975,10 @@ fn fs$move_copy_error(string, string) -> IoError [conv=default]
     _9 = move _14
     goto bb8
   bb7:
-    _16 = const.i64 8
+    _16 = const.i64 5
     mtag15 = move _16
     _17 = const.i64 0
-    mvar15.8.0 = move _17
+    mvar15.5.0 = move _17
     _18 = move _15
     _9 = move _18
     goto bb8
@@ -1202,15 +1022,15 @@ fn fs$read(string) -> string [conv=default]
     _31: ()
     _32: string
   bb0:
-    stmt: use BindingId(34) path site=SiteId(382) ty=string intent=Read
+    stmt: use BindingId(31) path site=SiteId(319) ty=string intent=Read
     _1 = call hew_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(35) contents site=SiteId(381) ty=string
+    stmt: bind BindingId(32) contents site=SiteId(318) ty=string
     _2 = move _1
     _3 = call hew_stream_last_errno() -> bb2
   bb2:
-    stmt: bind BindingId(36) errno site=SiteId(384) ty=i32
-    stmt: use BindingId(36) errno site=SiteId(387) ty=i32 intent=Read
+    stmt: bind BindingId(33) errno site=SiteId(321) ty=i32
+    stmt: use BindingId(33) errno site=SiteId(324) ty=i32 intent=Read
     _4 = move _3
     _6 = const.i64 0
     _7 = icmp.ne _4 _6
@@ -1220,15 +1040,15 @@ fn fs$read(string) -> string [conv=default]
   bb4:
     goto bb5
   bb5:
-    stmt: eval site=SiteId(439) ty=()
-    stmt: use BindingId(35) contents site=SiteId(440) ty=string intent=Read
-    stmt: return site=Some(SiteId(380)) ty=string
+    stmt: eval site=SiteId(376) ty=()
+    stmt: use BindingId(32) contents site=SiteId(377) ty=string intent=Read
+    stmt: return site=Some(SiteId(317)) ty=string
     _32 = move _2
     ret = move _32
     return
   bb6:
-    stmt: bind BindingId(37) detail site=SiteId(389) ty=string
-    stmt: use BindingId(37) detail site=SiteId(394) ty=string intent=Read
+    stmt: bind BindingId(34) detail site=SiteId(326) ty=string
+    stmt: use BindingId(34) detail site=SiteId(331) ty=string intent=Read
     _9 = move _8
     _11 = call hew_string_length(_9) -> bb7
   bb7:
@@ -1236,11 +1056,11 @@ fn fs$read(string) -> string [conv=default]
     _13 = icmp.eq _11 _12
     branch _13 ? bb8 : bb9
   bb8:
-    stmt: use BindingId(34) path site=SiteId(401) ty=string intent=Read
+    stmt: use BindingId(31) path site=SiteId(338) ty=string intent=Read
     _14 = string_lit "fs.read failed for `"
     _15 = call string::fmt(_0) -> bb11
   bb9:
-    stmt: use BindingId(34) path site=SiteId(424) ty=string intent=Read
+    stmt: use BindingId(31) path site=SiteId(361) ty=string intent=Read
     _24 = string_lit "fs.read failed for `"
     _25 = call string::fmt(_0) -> bb19
   bb10:
@@ -1253,7 +1073,7 @@ fn fs$read(string) -> string [conv=default]
     _17 = string_lit "`: "
     _18 = call string_concat(_16, _17) -> bb13
   bb13:
-    stmt: use BindingId(36) errno site=SiteId(408) ty=i32 intent=Read
+    stmt: use BindingId(33) errno site=SiteId(345) ty=i32 intent=Read
     _19 = cast _4 i32 -> i64
     _20 = call fs$io_error_from_errno(_19) -> bb14
   bb14:
@@ -1265,7 +1085,7 @@ fn fs$read(string) -> string [conv=default]
   bb17:
     call panic(_23) -> bb18
   bb18:
-    stmt: eval site=SiteId(398) ty=!
+    stmt: eval site=SiteId(335) ty=!
     goto bb10
   bb19:
     _26 = call string_concat(_24, _25) -> bb20
@@ -1273,14 +1093,14 @@ fn fs$read(string) -> string [conv=default]
     _27 = string_lit "`: "
     _28 = call string_concat(_26, _27) -> bb21
   bb21:
-    stmt: use BindingId(37) detail site=SiteId(428) ty=string intent=Read
+    stmt: use BindingId(34) detail site=SiteId(365) ty=string intent=Read
     _29 = call string::fmt(_9) -> bb22
   bb22:
     _30 = call string_concat(_28, _29) -> bb23
   bb23:
     call panic(_30) -> bb24
   bb24:
-    stmt: eval site=SiteId(421) ty=!
+    stmt: eval site=SiteId(358) ty=!
     goto bb10
 
 fn fs$try_read(string) -> Result<string, IoError> [conv=default]
@@ -1304,24 +1124,24 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
     _16: Result<string, IoError>
     _17: Result<string, IoError>
   bb0:
-    stmt: use BindingId(38) file_path site=SiteId(443) ty=string intent=Read
+    stmt: use BindingId(35) file_path site=SiteId(380) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(39) file site=SiteId(442) ty=FileReadStream
-    stmt: use BindingId(39) file site=SiteId(447) ty=FileReadStream intent=Read
+    stmt: bind BindingId(36) file site=SiteId(379) ty=FileReadStream
+    stmt: use BindingId(36) file site=SiteId(384) ty=FileReadStream intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(39) file site=SiteId(452) ty=FileReadStream intent=Read
+    stmt: use BindingId(36) file site=SiteId(389) ty=FileReadStream intent=Read
     _6 = const.i64 0
     mtag5 = move _6
     _7 = call hew_stream_collect_string(_2) -> bb6
   bb4:
     _9 = call hew_stream_last_errno() -> bb7
   bb5:
-    stmt: return site=Some(SiteId(441)) ty=Result<string, IoError>
+    stmt: return site=Some(SiteId(378)) ty=Result<string, IoError>
     _17 = move _3
     ret = move _17
     return
@@ -1331,12 +1151,12 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
     _3 = move _8
     goto bb5
   bb7:
-    stmt: bind BindingId(40) errno site=SiteId(455) ty=i32
+    stmt: bind BindingId(37) errno site=SiteId(392) ty=i32
     _10 = move _9
     _11 = call hew_stream_last_error() -> bb8
   bb8:
-    stmt: eval site=SiteId(457) ty=string
-    stmt: use BindingId(40) errno site=SiteId(462) ty=i32 intent=Read
+    stmt: eval site=SiteId(394) ty=string
+    stmt: use BindingId(37) errno site=SiteId(399) ty=i32 intent=Read
     _13 = const.i64 1
     mtag12 = move _13
     _14 = cast _10 i32 -> i64
@@ -1355,11 +1175,11 @@ fn fs$write(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(41) path site=SiteId(467) ty=string intent=Read
-    stmt: use BindingId(42) content site=SiteId(468) ty=string intent=Read
+    stmt: use BindingId(38) path site=SiteId(404) ty=string intent=Read
+    stmt: use BindingId(39) content site=SiteId(405) ty=string intent=Read
     _2 = call hew_file_write(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(464)) ty=i64
+    stmt: return site=Some(SiteId(401)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1381,14 +1201,14 @@ fn fs$try_write(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(43) file_path site=SiteId(473) ty=string intent=Read
-    stmt: use BindingId(44) content site=SiteId(474) ty=string intent=Read
+    stmt: use BindingId(40) file_path site=SiteId(410) ty=string intent=Read
+    stmt: use BindingId(41) content site=SiteId(411) ty=string intent=Read
     _3 = call hew_file_write(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(470)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(407)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1396,7 +1216,7 @@ fn fs$try_write(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(43) file_path site=SiteId(480) ty=string intent=Read
+    stmt: use BindingId(40) file_path site=SiteId(417) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$write_error(_0) -> bb7
@@ -1422,11 +1242,11 @@ fn fs$append(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(45) path site=SiteId(485) ty=string intent=Read
-    stmt: use BindingId(46) content site=SiteId(486) ty=string intent=Read
+    stmt: use BindingId(42) path site=SiteId(422) ty=string intent=Read
+    stmt: use BindingId(43) content site=SiteId(423) ty=string intent=Read
     _2 = call hew_file_append(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(482)) ty=i64
+    stmt: return site=Some(SiteId(419)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1448,14 +1268,14 @@ fn fs$try_append(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(47) file_path site=SiteId(491) ty=string intent=Read
-    stmt: use BindingId(48) content site=SiteId(492) ty=string intent=Read
+    stmt: use BindingId(44) file_path site=SiteId(428) ty=string intent=Read
+    stmt: use BindingId(45) content site=SiteId(429) ty=string intent=Read
     _3 = call hew_file_append(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(488)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(425)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1463,7 +1283,7 @@ fn fs$try_append(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(47) file_path site=SiteId(498) ty=string intent=Read
+    stmt: use BindingId(44) file_path site=SiteId(435) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$write_error(_0) -> bb7
@@ -1487,10 +1307,10 @@ fn fs$exists(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(49) path site=SiteId(502) ty=string intent=Read
+    stmt: use BindingId(46) path site=SiteId(439) ty=string intent=Read
     _1 = call hew_file_exists(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(500)) ty=bool
+    stmt: return site=Some(SiteId(437)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -1502,10 +1322,10 @@ fn fs$delete(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(50) path site=SiteId(507) ty=string intent=Read
+    stmt: use BindingId(47) path site=SiteId(444) ty=string intent=Read
     _1 = call hew_file_delete(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(504)) ty=i64
+    stmt: return site=Some(SiteId(441)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1526,13 +1346,13 @@ fn fs$try_delete(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(51) file_path site=SiteId(512) ty=string intent=Read
+    stmt: use BindingId(48) file_path site=SiteId(449) ty=string intent=Read
     _2 = call hew_file_delete(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(509)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(446)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1540,7 +1360,7 @@ fn fs$try_delete(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(51) file_path site=SiteId(518) ty=string intent=Read
+    stmt: use BindingId(48) file_path site=SiteId(455) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
     _11 = call fs$missing_path_error(_0) -> bb7
@@ -1564,10 +1384,10 @@ fn fs$size(string) -> i64 [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: use BindingId(52) path site=SiteId(522) ty=string intent=Read
+    stmt: use BindingId(49) path site=SiteId(459) ty=string intent=Read
     _1 = call hew_file_size(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(520)) ty=i64
+    stmt: return site=Some(SiteId(457)) ty=i64
     _2 = move _1
     ret = move _2
     return
@@ -1578,10 +1398,10 @@ fn fs$read_bytes(string) -> bytes [conv=default]
     _1: bytes
     _2: bytes
   bb0:
-    stmt: use BindingId(53) path site=SiteId(526) ty=string intent=Read
+    stmt: use BindingId(50) path site=SiteId(463) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(524)) ty=bytes
+    stmt: return site=Some(SiteId(461)) ty=bytes
     _2 = move _1
     ret = move _2
     return
@@ -1606,28 +1426,28 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _15: Result<bytes, IoError>
     _16: Result<bytes, IoError>
   bb0:
-    stmt: use BindingId(54) file_path site=SiteId(530) ty=string intent=Read
+    stmt: use BindingId(51) file_path site=SiteId(467) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
   bb1:
-    stmt: bind BindingId(55) data site=SiteId(529) ty=bytes
+    stmt: bind BindingId(52) data site=SiteId(466) ty=bytes
     _2 = move _1
     _3 = call hew_stream_last_errno() -> bb2
   bb2:
-    stmt: bind BindingId(56) errno site=SiteId(532) ty=i32
-    stmt: use BindingId(56) errno site=SiteId(536) ty=i32 intent=Read
+    stmt: bind BindingId(53) errno site=SiteId(469) ty=i32
+    stmt: use BindingId(53) errno site=SiteId(473) ty=i32 intent=Read
     _4 = move _3
     _6 = const.i64 0
     _7 = icmp.ne _4 _6
     branch _7 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(56) errno site=SiteId(542) ty=i32 intent=Read
+    stmt: use BindingId(53) errno site=SiteId(479) ty=i32 intent=Read
     _9 = const.i64 1
     mtag8 = move _9
     _10 = cast _4 i32 -> i64
     _11 = call fs$io_error_from_errno(_10) -> bb6
   bb4:
-    stmt: use BindingId(55) data site=SiteId(546) ty=bytes intent=Read
-    stmt: agg_alias BindingId(55) data site=SiteId(546) ty=bytes
+    stmt: use BindingId(52) data site=SiteId(483) ty=bytes intent=Read
+    stmt: agg_alias BindingId(52) data site=SiteId(483) ty=bytes
     _14 = const.i64 0
     mtag13 = move _14
     mvar13.0.0 = move _2
@@ -1635,7 +1455,7 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _5 = move _15
     goto bb5
   bb5:
-    stmt: return site=Some(SiteId(528)) ty=Result<bytes, IoError>
+    stmt: return site=Some(SiteId(465)) ty=Result<bytes, IoError>
     _16 = move _5
     ret = move _16
     return
@@ -1653,11 +1473,11 @@ fn fs$write_bytes(string, bytes) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(57) path site=SiteId(550) ty=string intent=Read
-    stmt: use BindingId(58) data site=SiteId(551) ty=bytes intent=Read
+    stmt: use BindingId(54) path site=SiteId(487) ty=string intent=Read
+    stmt: use BindingId(55) data site=SiteId(488) ty=bytes intent=Read
     _2 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(547)) ty=i64
+    stmt: return site=Some(SiteId(484)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1679,14 +1499,14 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(59) file_path site=SiteId(556) ty=string intent=Read
-    stmt: use BindingId(60) data site=SiteId(557) ty=bytes intent=Read
+    stmt: use BindingId(56) file_path site=SiteId(493) ty=string intent=Read
+    stmt: use BindingId(57) data site=SiteId(494) ty=bytes intent=Read
     _3 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(553)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(490)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1694,7 +1514,7 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(59) file_path site=SiteId(563) ty=string intent=Read
+    stmt: use BindingId(56) file_path site=SiteId(500) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$write_error(_0) -> bb7
@@ -1719,10 +1539,10 @@ fn fs$mkdir(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(61) path site=SiteId(568) ty=string intent=Read
+    stmt: use BindingId(58) path site=SiteId(505) ty=string intent=Read
     _1 = call hew_fs_mkdir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(565)) ty=i64
+    stmt: return site=Some(SiteId(502)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1743,13 +1563,13 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(62) dir_path site=SiteId(573) ty=string intent=Read
+    stmt: use BindingId(59) dir_path site=SiteId(510) ty=string intent=Read
     _2 = call hew_fs_mkdir(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(570)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(507)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1757,7 +1577,7 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(62) dir_path site=SiteId(579) ty=string intent=Read
+    stmt: use BindingId(59) dir_path site=SiteId(516) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
     _11 = call fs$mkdir_error(_0) -> bb7
@@ -1782,10 +1602,10 @@ fn fs$mkdir_all(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(63) path site=SiteId(584) ty=string intent=Read
+    stmt: use BindingId(60) path site=SiteId(521) ty=string intent=Read
     _1 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(581)) ty=i64
+    stmt: return site=Some(SiteId(518)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1818,13 +1638,13 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _22: Result<i64, IoError>
     _23: Result<i64, IoError>
   bb0:
-    stmt: use BindingId(64) dir_path site=SiteId(589) ty=string intent=Read
+    stmt: use BindingId(61) dir_path site=SiteId(526) ty=string intent=Read
     _2 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(586)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(523)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1832,7 +1652,7 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(64) dir_path site=SiteId(596) ty=string intent=Read
+    stmt: use BindingId(61) dir_path site=SiteId(533) ty=string intent=Read
     _10 = call fs$exists(_0) -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
@@ -1859,10 +1679,10 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
   bb9:
     _18 = const.i64 1
     mtag17 = move _18
-    _20 = const.i64 8
+    _20 = const.i64 5
     mtag19 = move _20
     _21 = const.i64 0
-    mvar19.8.0 = move _21
+    mvar19.5.0 = move _21
     mvar17.1.0 = move _19
     _22 = move _17
     _9 = move _22
@@ -1878,10 +1698,10 @@ fn fs$list_dir(string) -> Vec<string> [conv=default]
     _1: Vec<string>
     _2: Vec<string>
   bb0:
-    stmt: use BindingId(65) path site=SiteId(608) ty=string intent=Read
+    stmt: use BindingId(62) path site=SiteId(545) ty=string intent=Read
     _1 = call hew_fs_list_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(606)) ty=Vec<string>
+    stmt: return site=Some(SiteId(543)) ty=Vec<string>
     _2 = move _1
     ret = move _2
     return
@@ -1910,13 +1730,13 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
     _19: Vec<string>
     _20: Vec<string>
   bb0:
-    stmt: use BindingId(66) dir_path site=SiteId(612) ty=string intent=Read
+    stmt: use BindingId(63) dir_path site=SiteId(549) ty=string intent=Read
     _2 = call fs$exists(_0) -> bb1
   bb1:
     _3 = not _2
     branch _3 ? bb2 : bb3
   bb2:
-    stmt: return site=Some(SiteId(614)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(551)) ty=Result<Vec<string>, IoError>
     _5 = const.i64 1
     mtag4 = move _5
     _7 = const.i64 0
@@ -1929,8 +1749,8 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   bb3:
     goto bb4
   bb4:
-    stmt: eval site=SiteId(618) ty=()
-    stmt: use BindingId(66) dir_path site=SiteId(621) ty=string intent=Read
+    stmt: eval site=SiteId(555) ty=()
+    stmt: use BindingId(63) dir_path site=SiteId(558) ty=string intent=Read
     _10 = call fs$is_dir(_0) -> bb6
   bb5:
     goto bb4
@@ -1938,28 +1758,28 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
     _11 = not _10
     branch _11 ? bb7 : bb8
   bb7:
-    stmt: return site=Some(SiteId(623)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(560)) ty=Result<Vec<string>, IoError>
     _13 = const.i64 1
     mtag12 = move _13
-    _15 = const.i64 8
+    _15 = const.i64 5
     mtag14 = move _15
     _16 = const.i64 0
-    mvar14.8.0 = move _16
+    mvar14.5.0 = move _16
     mvar12.1.0 = move _14
     ret = move _12
     return
   bb8:
     goto bb9
   bb9:
-    stmt: eval site=SiteId(627) ty=()
-    stmt: use BindingId(66) dir_path site=SiteId(631) ty=string intent=Read
+    stmt: eval site=SiteId(564) ty=()
+    stmt: use BindingId(63) dir_path site=SiteId(568) ty=string intent=Read
     _18 = const.i64 0
     mtag17 = move _18
     _19 = call hew_fs_list_dir(_0) -> bb11
   bb10:
     goto bb9
   bb11:
-    stmt: return site=Some(SiteId(628)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(565)) ty=Result<Vec<string>, IoError>
     _20 = move _19
     mvar17.0.0 = move _20
     ret = move _17
@@ -1973,11 +1793,11 @@ fn fs$rename(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(67) from site=SiteId(636) ty=string intent=Read
-    stmt: use BindingId(68) to site=SiteId(637) ty=string intent=Read
+    stmt: use BindingId(64) from site=SiteId(573) ty=string intent=Read
+    stmt: use BindingId(65) to site=SiteId(574) ty=string intent=Read
     _2 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(633)) ty=i64
+    stmt: return site=Some(SiteId(570)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1999,14 +1819,14 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(69) from site=SiteId(642) ty=string intent=Read
-    stmt: use BindingId(70) to site=SiteId(643) ty=string intent=Read
+    stmt: use BindingId(66) from site=SiteId(579) ty=string intent=Read
+    stmt: use BindingId(67) to site=SiteId(580) ty=string intent=Read
     _3 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(639)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(576)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -2014,8 +1834,8 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(69) from site=SiteId(649) ty=string intent=Read
-    stmt: use BindingId(70) to site=SiteId(650) ty=string intent=Read
+    stmt: use BindingId(66) from site=SiteId(586) ty=string intent=Read
+    stmt: use BindingId(67) to site=SiteId(587) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$move_copy_error(_0, _1) -> bb7
@@ -2041,11 +1861,11 @@ fn fs$copy(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(71) from site=SiteId(655) ty=string intent=Read
-    stmt: use BindingId(72) to site=SiteId(656) ty=string intent=Read
+    stmt: use BindingId(68) from site=SiteId(592) ty=string intent=Read
+    stmt: use BindingId(69) to site=SiteId(593) ty=string intent=Read
     _2 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(652)) ty=i64
+    stmt: return site=Some(SiteId(589)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -2067,14 +1887,14 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(73) from site=SiteId(661) ty=string intent=Read
-    stmt: use BindingId(74) to site=SiteId(662) ty=string intent=Read
+    stmt: use BindingId(70) from site=SiteId(598) ty=string intent=Read
+    stmt: use BindingId(71) to site=SiteId(599) ty=string intent=Read
     _3 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(658)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(595)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -2082,8 +1902,8 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(73) from site=SiteId(668) ty=string intent=Read
-    stmt: use BindingId(74) to site=SiteId(669) ty=string intent=Read
+    stmt: use BindingId(70) from site=SiteId(605) ty=string intent=Read
+    stmt: use BindingId(71) to site=SiteId(606) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$move_copy_error(_0, _1) -> bb7
@@ -2107,10 +1927,10 @@ fn fs$is_dir(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(75) path site=SiteId(673) ty=string intent=Read
+    stmt: use BindingId(72) path site=SiteId(610) ty=string intent=Read
     _1 = call hew_fs_is_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(671)) ty=bool
+    stmt: return site=Some(SiteId(608)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -2128,31 +1948,31 @@ fn stream$pipe(i64) -> (Sink<string>, Stream<string>) [conv=default]
     _8: (Sink<string>, Stream<string>)
     _9: (Sink<string>, Stream<string>)
   bb0:
-    stmt: use BindingId(76) capacity site=SiteId(678) ty=i64 intent=Read
+    stmt: use BindingId(73) capacity site=SiteId(615) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(77) pair site=SiteId(676) ty=StreamPair
-    stmt: use BindingId(77) pair site=SiteId(681) ty=StreamPair intent=Read
+    stmt: bind BindingId(74) pair site=SiteId(613) ty=StreamPair
+    stmt: use BindingId(74) pair site=SiteId(618) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink(_3) -> bb2
   bb2:
-    stmt: bind BindingId(78) sink site=SiteId(680) ty=Sink<string>
-    stmt: use BindingId(77) pair site=SiteId(684) ty=StreamPair intent=Read
+    stmt: bind BindingId(75) sink site=SiteId(617) ty=Sink<string>
+    stmt: use BindingId(74) pair site=SiteId(621) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream(_3) -> bb3
   bb3:
-    stmt: bind BindingId(79) input site=SiteId(683) ty=Stream<string>
-    stmt: use BindingId(77) pair site=SiteId(687) ty=StreamPair intent=Read
+    stmt: bind BindingId(76) input site=SiteId(620) ty=Stream<string>
+    stmt: use BindingId(74) pair site=SiteId(624) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(686) ty=()
-    stmt: use BindingId(78) sink site=SiteId(690) ty=Sink<string> intent=Read
-    stmt: use BindingId(79) input site=SiteId(691) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(78) sink site=SiteId(690) ty=Sink<string>
-    stmt: agg_alias BindingId(79) input site=SiteId(691) ty=Stream<string>
-    stmt: return site=Some(SiteId(675)) ty=(Sink<string>, Stream<string>)
+    stmt: eval site=SiteId(623) ty=()
+    stmt: use BindingId(75) sink site=SiteId(627) ty=Sink<string> intent=Read
+    stmt: use BindingId(76) input site=SiteId(628) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(75) sink site=SiteId(627) ty=Sink<string>
+    stmt: agg_alias BindingId(76) input site=SiteId(628) ty=Stream<string>
+    stmt: return site=Some(SiteId(612)) ty=(Sink<string>, Stream<string>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2171,31 +1991,31 @@ fn stream$bytes_pipe(i64) -> (Sink<bytes>, Stream<bytes>) [conv=default]
     _8: (Sink<bytes>, Stream<bytes>)
     _9: (Sink<bytes>, Stream<bytes>)
   bb0:
-    stmt: use BindingId(80) capacity site=SiteId(695) ty=i64 intent=Read
+    stmt: use BindingId(77) capacity site=SiteId(632) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(81) pair site=SiteId(693) ty=StreamPair
-    stmt: use BindingId(81) pair site=SiteId(698) ty=StreamPair intent=Read
+    stmt: bind BindingId(78) pair site=SiteId(630) ty=StreamPair
+    stmt: use BindingId(78) pair site=SiteId(635) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink_bytes(_3) -> bb2
   bb2:
-    stmt: bind BindingId(82) sink site=SiteId(697) ty=Sink<bytes>
-    stmt: use BindingId(81) pair site=SiteId(701) ty=StreamPair intent=Read
+    stmt: bind BindingId(79) sink site=SiteId(634) ty=Sink<bytes>
+    stmt: use BindingId(78) pair site=SiteId(638) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream_bytes(_3) -> bb3
   bb3:
-    stmt: bind BindingId(83) input site=SiteId(700) ty=Stream<bytes>
-    stmt: use BindingId(81) pair site=SiteId(704) ty=StreamPair intent=Read
+    stmt: bind BindingId(80) input site=SiteId(637) ty=Stream<bytes>
+    stmt: use BindingId(78) pair site=SiteId(641) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(703) ty=()
-    stmt: use BindingId(82) sink site=SiteId(707) ty=Sink<bytes> intent=Read
-    stmt: use BindingId(83) input site=SiteId(708) ty=Stream<bytes> intent=Read
-    stmt: agg_alias BindingId(82) sink site=SiteId(707) ty=Sink<bytes>
-    stmt: agg_alias BindingId(83) input site=SiteId(708) ty=Stream<bytes>
-    stmt: return site=Some(SiteId(692)) ty=(Sink<bytes>, Stream<bytes>)
+    stmt: eval site=SiteId(640) ty=()
+    stmt: use BindingId(79) sink site=SiteId(644) ty=Sink<bytes> intent=Read
+    stmt: use BindingId(80) input site=SiteId(645) ty=Stream<bytes> intent=Read
+    stmt: agg_alias BindingId(79) sink site=SiteId(644) ty=Sink<bytes>
+    stmt: agg_alias BindingId(80) input site=SiteId(645) ty=Stream<bytes>
+    stmt: return site=Some(SiteId(629)) ty=(Sink<bytes>, Stream<bytes>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2217,18 +2037,18 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     _11: Result<Stream<string>, string>
     _12: Result<Stream<string>, string>
   bb0:
-    stmt: use BindingId(84) path site=SiteId(711) ty=string intent=Read
+    stmt: use BindingId(81) path site=SiteId(648) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(85) s site=SiteId(710) ty=Stream<string>
-    stmt: use BindingId(85) s site=SiteId(715) ty=Stream<string> intent=Read
+    stmt: bind BindingId(82) s site=SiteId(647) ty=Stream<string>
+    stmt: use BindingId(82) s site=SiteId(652) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(85) s site=SiteId(719) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(85) s site=SiteId(719) ty=Stream<string>
+    stmt: use BindingId(82) s site=SiteId(656) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(82) s site=SiteId(656) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2240,7 +2060,7 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(709)) ty=Result<Stream<string>, string>
+    stmt: return site=Some(SiteId(646)) ty=Result<Stream<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2270,18 +2090,18 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _15: Result<Stream<string>, fs.IoError>
     _16: Result<Stream<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(86) path site=SiteId(726) ty=string intent=Read
+    stmt: use BindingId(83) path site=SiteId(663) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(87) s site=SiteId(725) ty=Stream<string>
-    stmt: use BindingId(87) s site=SiteId(730) ty=Stream<string> intent=Read
+    stmt: bind BindingId(84) s site=SiteId(662) ty=Stream<string>
+    stmt: use BindingId(84) s site=SiteId(667) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(87) s site=SiteId(734) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(87) s site=SiteId(734) ty=Stream<string>
+    stmt: use BindingId(84) s site=SiteId(671) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(84) s site=SiteId(671) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2291,17 +2111,17 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
   bb4:
     _8 = call hew_stream_last_errno() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(724)) ty=Result<Stream<string>, fs.IoError>
+    stmt: return site=Some(SiteId(661)) ty=Result<Stream<string>, fs.IoError>
     _16 = move _3
     ret = move _16
     return
   bb6:
-    stmt: bind BindingId(88) errno site=SiteId(736) ty=i32
+    stmt: bind BindingId(85) errno site=SiteId(673) ty=i32
     _9 = move _8
     _10 = call hew_stream_last_error() -> bb7
   bb7:
-    stmt: eval site=SiteId(738) ty=string
-    stmt: use BindingId(88) errno site=SiteId(743) ty=i32 intent=Read
+    stmt: eval site=SiteId(675) ty=string
+    stmt: use BindingId(85) errno site=SiteId(680) ty=i32 intent=Read
     _12 = const.i64 1
     mtag11 = move _12
     _13 = cast _9 i32 -> i64
@@ -2328,18 +2148,18 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     _11: Result<Sink<string>, string>
     _12: Result<Sink<string>, string>
   bb0:
-    stmt: use BindingId(89) path site=SiteId(747) ty=string intent=Read
+    stmt: use BindingId(86) path site=SiteId(684) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(90) s site=SiteId(746) ty=Sink<string>
-    stmt: use BindingId(90) s site=SiteId(751) ty=Sink<string> intent=Read
+    stmt: bind BindingId(87) s site=SiteId(683) ty=Sink<string>
+    stmt: use BindingId(87) s site=SiteId(688) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(90) s site=SiteId(755) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(90) s site=SiteId(755) ty=Sink<string>
+    stmt: use BindingId(87) s site=SiteId(692) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(87) s site=SiteId(692) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2351,7 +2171,7 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(745)) ty=Result<Sink<string>, string>
+    stmt: return site=Some(SiteId(682)) ty=Result<Sink<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2381,18 +2201,18 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _15: Result<Sink<string>, fs.IoError>
     _16: Result<Sink<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(91) path site=SiteId(762) ty=string intent=Read
+    stmt: use BindingId(88) path site=SiteId(699) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(92) s site=SiteId(761) ty=Sink<string>
-    stmt: use BindingId(92) s site=SiteId(766) ty=Sink<string> intent=Read
+    stmt: bind BindingId(89) s site=SiteId(698) ty=Sink<string>
+    stmt: use BindingId(89) s site=SiteId(703) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(92) s site=SiteId(770) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(92) s site=SiteId(770) ty=Sink<string>
+    stmt: use BindingId(89) s site=SiteId(707) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(89) s site=SiteId(707) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2402,17 +2222,17 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
   bb4:
     _8 = call hew_stream_last_errno() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(760)) ty=Result<Sink<string>, fs.IoError>
+    stmt: return site=Some(SiteId(697)) ty=Result<Sink<string>, fs.IoError>
     _16 = move _3
     ret = move _16
     return
   bb6:
-    stmt: bind BindingId(93) errno site=SiteId(772) ty=i32
+    stmt: bind BindingId(90) errno site=SiteId(709) ty=i32
     _9 = move _8
     _10 = call hew_stream_last_error() -> bb7
   bb7:
-    stmt: eval site=SiteId(774) ty=string
-    stmt: use BindingId(93) errno site=SiteId(779) ty=i32 intent=Read
+    stmt: eval site=SiteId(711) ty=string
+    stmt: use BindingId(90) errno site=SiteId(716) ty=i32 intent=Read
     _12 = const.i64 1
     mtag11 = move _12
     _13 = cast _9 i32 -> i64
@@ -2428,11 +2248,11 @@ fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
     _0: Stream<string>
     _1: Sink<string>
   bb0:
-    stmt: use BindingId(94) source site=SiteId(783) ty=Stream<string> intent=Read
-    stmt: use BindingId(95) dest site=SiteId(784) ty=Sink<string> intent=Read
+    stmt: use BindingId(91) source site=SiteId(720) ty=Stream<string> intent=Read
+    stmt: use BindingId(92) dest site=SiteId(721) ty=Sink<string> intent=Read
     call hew_stream_pipe(_0, _1) -> bb1
   bb1:
-    stmt: eval site=SiteId(781) ty=()
+    stmt: eval site=SiteId(718) ty=()
     return
 
 fn i32::fmt(i32) -> string [conv=default]
@@ -2440,10 +2260,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(99) val site=SiteId(815) ty=i32 intent=Read
+    stmt: use BindingId(96) val site=SiteId(752) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(814)) ty=string
+    stmt: return site=Some(SiteId(751)) ty=string
     ret = move _1
     return
 
@@ -2452,10 +2272,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(100) val site=SiteId(818) ty=i64 intent=Read
+    stmt: use BindingId(97) val site=SiteId(755) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(817)) ty=string
+    stmt: return site=Some(SiteId(754)) ty=string
     ret = move _1
     return
 
@@ -2464,10 +2284,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(101) val site=SiteId(821) ty=u32 intent=Read
+    stmt: use BindingId(98) val site=SiteId(758) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(820)) ty=string
+    stmt: return site=Some(SiteId(757)) ty=string
     ret = move _1
     return
 
@@ -2476,10 +2296,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(102) val site=SiteId(824) ty=u64 intent=Read
+    stmt: use BindingId(99) val site=SiteId(761) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(823)) ty=string
+    stmt: return site=Some(SiteId(760)) ty=string
     ret = move _1
     return
 
@@ -2488,10 +2308,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(103) val site=SiteId(827) ty=bool intent=Read
+    stmt: use BindingId(100) val site=SiteId(764) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(826)) ty=string
+    stmt: return site=Some(SiteId(763)) ty=string
     ret = move _1
     return
 
@@ -2500,10 +2320,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(104) val site=SiteId(830) ty=char intent=Read
+    stmt: use BindingId(101) val site=SiteId(767) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(829)) ty=string
+    stmt: return site=Some(SiteId(766)) ty=string
     ret = move _1
     return
 
@@ -2512,10 +2332,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(105) val site=SiteId(833) ty=f64 intent=Read
+    stmt: use BindingId(102) val site=SiteId(770) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(832)) ty=string
+    stmt: return site=Some(SiteId(769)) ty=string
     ret = move _1
     return
 
@@ -2523,8 +2343,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(106) val site=SiteId(835) ty=string intent=Read
-    stmt: return site=Some(SiteId(835)) ty=string
+    stmt: use BindingId(103) val site=SiteId(772) ty=string intent=Read
+    stmt: return site=Some(SiteId(772)) ty=string
     ret = move _0
     return
 

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.elab.mir
@@ -120,16 +120,7 @@ fn fs$io_error_from_errno -> IoError
     use BindingId(11) errno site=SiteId(91) ty=i64 intent=Read
     use BindingId(11) errno site=SiteId(94) ty=i64 intent=Read
     use BindingId(11) errno site=SiteId(98) ty=i64 intent=Read
-    use BindingId(11) errno site=SiteId(102) ty=i64 intent=Read
-    use BindingId(11) errno site=SiteId(105) ty=i64 intent=Read
-    use BindingId(11) errno site=SiteId(109) ty=i64 intent=Read
-    use BindingId(11) errno site=SiteId(113) ty=i64 intent=Read
-    use BindingId(11) errno site=SiteId(116) ty=i64 intent=Read
-    use BindingId(11) errno site=SiteId(120) ty=i64 intent=Read
-    use BindingId(11) errno site=SiteId(124) ty=i64 intent=Read
-    use BindingId(11) errno site=SiteId(127) ty=i64 intent=Read
-    use BindingId(11) errno site=SiteId(131) ty=i64 intent=Read
-    use BindingId(11) errno site=SiteId(134) ty=i64 intent=Read
+    use BindingId(11) errno site=SiteId(101) ty=i64 intent=Read
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -175,113 +166,75 @@ fn fs$io_error_from_errno -> IoError
       (none)
     goto[bb17->bb19] ->
       (none)
-    branch[bb18: bb21/bb20] ->
+    goto[bb18->bb19] ->
       (none)
     goto[bb19->bb14] ->
       (none)
     cancel[bb19] ->
       (none)
-    goto[bb20->bb21] ->
-      (none)
-    branch[bb21: bb22/bb23] ->
-      (none)
-    goto[bb22->bb24] ->
-      (none)
-    branch[bb23: bb26/bb25] ->
-      (none)
-    goto[bb24->bb19] ->
-      (none)
-    cancel[bb24] ->
-      (none)
-    goto[bb25->bb26] ->
-      (none)
-    branch[bb26: bb27/bb28] ->
-      (none)
-    goto[bb27->bb29] ->
-      (none)
-    branch[bb28: bb31/bb30] ->
-      (none)
-    goto[bb29->bb24] ->
-      (none)
-    cancel[bb29] ->
-      (none)
-    goto[bb30->bb31] ->
-      (none)
-    branch[bb31: bb32/bb33] ->
-      (none)
-    goto[bb32->bb34] ->
-      (none)
-    goto[bb33->bb34] ->
-      (none)
-    goto[bb34->bb29] ->
-      (none)
-    cancel[bb34] ->
-      (none)
 
 fn fs$io_error_message -> string
   statements:
-    use BindingId(12) e site=SiteId(136) ty=IoError intent=Read
-    return site=Some(SiteId(135)) ty=string
-    bind BindingId(13) code site=SiteId(137) ty=i64
-    use BindingId(13) code site=SiteId(139) ty=i64 intent=Read
-    bind BindingId(14) code site=SiteId(147) ty=i64
-    use BindingId(14) code site=SiteId(149) ty=i64 intent=Read
-    bind BindingId(15) code site=SiteId(157) ty=i64
-    use BindingId(15) code site=SiteId(159) ty=i64 intent=Read
-    bind BindingId(16) code site=SiteId(167) ty=i64
-    use BindingId(16) code site=SiteId(169) ty=i64 intent=Read
-    bind BindingId(17) code site=SiteId(177) ty=i64
-    use BindingId(17) code site=SiteId(179) ty=i64 intent=Read
-    bind BindingId(18) code site=SiteId(187) ty=i64
-    use BindingId(18) code site=SiteId(189) ty=i64 intent=Read
-    bind BindingId(19) code site=SiteId(197) ty=i64
-    use BindingId(19) code site=SiteId(199) ty=i64 intent=Read
-    bind BindingId(20) code site=SiteId(207) ty=i64
-    use BindingId(20) code site=SiteId(209) ty=i64 intent=Read
-    bind BindingId(21) code site=SiteId(217) ty=i64
-    use BindingId(21) code site=SiteId(219) ty=i64 intent=Read
+    use BindingId(12) e site=SiteId(103) ty=IoError intent=Read
+    return site=Some(SiteId(102)) ty=string
+    bind BindingId(13) code site=SiteId(104) ty=i64
+    use BindingId(13) code site=SiteId(106) ty=i64 intent=Read
+    bind BindingId(14) code site=SiteId(114) ty=i64
+    use BindingId(14) code site=SiteId(116) ty=i64 intent=Read
+    bind BindingId(15) code site=SiteId(124) ty=i64
+    use BindingId(15) code site=SiteId(126) ty=i64 intent=Read
+    bind BindingId(16) code site=SiteId(134) ty=i64
+    use BindingId(16) code site=SiteId(136) ty=i64 intent=Read
+    bind BindingId(17) code site=SiteId(144) ty=i64
+    use BindingId(17) code site=SiteId(146) ty=i64 intent=Read
+    bind BindingId(18) code site=SiteId(154) ty=i64
+    use BindingId(18) code site=SiteId(156) ty=i64 intent=Read
   drop_plans:
-    branch[bb0: bb2/bb12] ->
+    branch[bb0: bb2/bb9] ->
       (none)
     cancel[bb0] ->
       (none)
     return[bb1] ->
       (none)
-    call[bb2 to_string_i64 -> bb20] ->
+    call[bb2 to_string_i64 -> bb14] ->
       (none)
-    call[bb3 to_string_i64 -> bb23] ->
+    call[bb3 to_string_i64 -> bb17] ->
       (none)
-    call[bb4 to_string_i64 -> bb26] ->
+    call[bb4 to_string_i64 -> bb20] ->
       (none)
-    call[bb5 to_string_i64 -> bb29] ->
+    call[bb5 to_string_i64 -> bb23] ->
       (none)
-    call[bb6 to_string_i64 -> bb32] ->
+    call[bb6 to_string_i64 -> bb26] ->
       (none)
-    call[bb7 to_string_i64 -> bb35] ->
+    call[bb7 to_string_i64 -> bb29] ->
       (none)
-    call[bb8 to_string_i64 -> bb38] ->
+    panic[bb8] ->
       (none)
-    call[bb9 to_string_i64 -> bb41] ->
+    branch[bb9: bb3/bb10] ->
       (none)
-    call[bb10 to_string_i64 -> bb44] ->
+    branch[bb10: bb4/bb11] ->
       (none)
-    panic[bb11] ->
+    branch[bb11: bb5/bb12] ->
       (none)
-    branch[bb12: bb3/bb13] ->
+    branch[bb12: bb6/bb13] ->
       (none)
-    branch[bb13: bb4/bb14] ->
+    branch[bb13: bb7/bb8] ->
       (none)
-    branch[bb14: bb5/bb15] ->
+    call[bb14 string_concat -> bb15] ->
       (none)
-    branch[bb15: bb6/bb16] ->
+    call[bb15 string_concat -> bb16] ->
       (none)
-    branch[bb16: bb7/bb17] ->
+    goto[bb16->bb1] ->
       (none)
-    branch[bb17: bb8/bb18] ->
+    cancel[bb16] ->
       (none)
-    branch[bb18: bb9/bb19] ->
+    call[bb17 string_concat -> bb18] ->
       (none)
-    branch[bb19: bb10/bb11] ->
+    call[bb18 string_concat -> bb19] ->
+      (none)
+    goto[bb19->bb1] ->
+      (none)
+    cancel[bb19] ->
       (none)
     call[bb20 string_concat -> bb21] ->
       (none)
@@ -315,69 +268,29 @@ fn fs$io_error_message -> string
       (none)
     cancel[bb31] ->
       (none)
-    call[bb32 string_concat -> bb33] ->
-      (none)
-    call[bb33 string_concat -> bb34] ->
-      (none)
-    goto[bb34->bb1] ->
-      (none)
-    cancel[bb34] ->
-      (none)
-    call[bb35 string_concat -> bb36] ->
-      (none)
-    call[bb36 string_concat -> bb37] ->
-      (none)
-    goto[bb37->bb1] ->
-      (none)
-    cancel[bb37] ->
-      (none)
-    call[bb38 string_concat -> bb39] ->
-      (none)
-    call[bb39 string_concat -> bb40] ->
-      (none)
-    goto[bb40->bb1] ->
-      (none)
-    cancel[bb40] ->
-      (none)
-    call[bb41 string_concat -> bb42] ->
-      (none)
-    call[bb42 string_concat -> bb43] ->
-      (none)
-    goto[bb43->bb1] ->
-      (none)
-    cancel[bb43] ->
-      (none)
-    call[bb44 string_concat -> bb45] ->
-      (none)
-    call[bb45 string_concat -> bb46] ->
-      (none)
-    goto[bb46->bb1] ->
-      (none)
-    cancel[bb46] ->
-      (none)
 
 fn fs$io_error_timed_out -> IoError
   statements:
-    return site=Some(SiteId(227)) ty=IoError
+    return site=Some(SiteId(164)) ty=IoError
   drop_plans:
     return[bb0] ->
       (none)
 
 fn fs$io_error_cancelled -> IoError
   statements:
-    return site=Some(SiteId(229)) ty=IoError
+    return site=Some(SiteId(166)) ty=IoError
   drop_plans:
     return[bb0] ->
       (none)
 
 fn fs$missing_parent -> bool
   statements:
-    use BindingId(22) target site=SiteId(232) ty=string intent=Read
-    bind BindingId(23) parent site=SiteId(231) ty=string
-    use BindingId(23) parent site=SiteId(236) ty=string intent=Read
-    use BindingId(23) parent site=SiteId(240) ty=string intent=Read
-    return site=Some(SiteId(234)) ty=bool
-    drop BindingId(23) parent ty=string
+    use BindingId(19) target site=SiteId(169) ty=string intent=Read
+    bind BindingId(20) parent site=SiteId(168) ty=string
+    use BindingId(20) parent site=SiteId(173) ty=string intent=Read
+    use BindingId(20) parent site=SiteId(177) ty=string intent=Read
+    return site=Some(SiteId(171)) ty=bool
+    drop BindingId(20) parent ty=string
   drop_plans:
     call[bb0 fs$dirname -> bb1] ->
       (none)
@@ -396,20 +309,20 @@ fn fs$missing_parent -> bool
 
 fn fs$dirname -> string
   statements:
-    use BindingId(24) p site=SiteId(243) ty=string intent=Read
-    bind BindingId(25) s site=SiteId(242) ty=string
-    use BindingId(25) s site=SiteId(246) ty=string intent=Read
-    bind BindingId(26) pos site=SiteId(245) ty=i64
-    use BindingId(26) pos site=SiteId(249) ty=i64 intent=Read
-    return site=Some(SiteId(251)) ty=string
-    eval site=SiteId(253) ty=()
-    use BindingId(26) pos site=SiteId(255) ty=i64 intent=Read
-    return site=Some(SiteId(257)) ty=string
-    eval site=SiteId(259) ty=()
-    use BindingId(25) s site=SiteId(261) ty=string intent=Read
-    use BindingId(26) pos site=SiteId(263) ty=i64 intent=Read
-    return site=Some(SiteId(260)) ty=string
-    drop BindingId(25) s ty=string
+    use BindingId(21) p site=SiteId(180) ty=string intent=Read
+    bind BindingId(22) s site=SiteId(179) ty=string
+    use BindingId(22) s site=SiteId(183) ty=string intent=Read
+    bind BindingId(23) pos site=SiteId(182) ty=i64
+    use BindingId(23) pos site=SiteId(186) ty=i64 intent=Read
+    return site=Some(SiteId(188)) ty=string
+    eval site=SiteId(190) ty=()
+    use BindingId(23) pos site=SiteId(192) ty=i64 intent=Read
+    return site=Some(SiteId(194)) ty=string
+    eval site=SiteId(196) ty=()
+    use BindingId(22) s site=SiteId(198) ty=string intent=Read
+    use BindingId(23) pos site=SiteId(200) ty=i64 intent=Read
+    return site=Some(SiteId(197)) ty=string
+    drop BindingId(22) s ty=string
   drop_plans:
     call[bb0 fs$strip_trailing_slash -> bb1] ->
       (none)
@@ -444,18 +357,18 @@ fn fs$dirname -> string
 
 fn fs$strip_trailing_slash -> string
   statements:
-    use BindingId(27) p site=SiteId(266) ty=string intent=Read
-    use BindingId(27) p site=SiteId(270) ty=string intent=Read
-    return site=Some(SiteId(268)) ty=string
-    eval site=SiteId(272) ty=()
-    use BindingId(27) p site=SiteId(276) ty=string intent=Read
-    use BindingId(27) p site=SiteId(280) ty=string intent=Read
-    use BindingId(27) p site=SiteId(284) ty=string intent=Read
-    use BindingId(27) p site=SiteId(288) ty=string intent=Read
-    eval site=SiteId(293) ty=()
-    use BindingId(27) p site=SiteId(296) ty=string intent=Read
-    return site=Some(SiteId(294)) ty=string
-    return site=Some(SiteId(283)) ty=string
+    use BindingId(24) p site=SiteId(203) ty=string intent=Read
+    use BindingId(24) p site=SiteId(207) ty=string intent=Read
+    return site=Some(SiteId(205)) ty=string
+    eval site=SiteId(209) ty=()
+    use BindingId(24) p site=SiteId(213) ty=string intent=Read
+    use BindingId(24) p site=SiteId(217) ty=string intent=Read
+    use BindingId(24) p site=SiteId(221) ty=string intent=Read
+    use BindingId(24) p site=SiteId(225) ty=string intent=Read
+    eval site=SiteId(230) ty=()
+    use BindingId(24) p site=SiteId(233) ty=string intent=Read
+    return site=Some(SiteId(231)) ty=string
+    return site=Some(SiteId(220)) ty=string
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -502,36 +415,36 @@ fn fs$strip_trailing_slash -> string
 
 fn fs$last_slash_pos -> i64
   statements:
-    use BindingId(28) s site=SiteId(298) ty=string intent=Read
-    bind BindingId(29) first site=SiteId(297) ty=i64
-    use BindingId(29) first site=SiteId(302) ty=i64 intent=Read
-    eval site=SiteId(307) ty=()
-    use BindingId(29) first site=SiteId(308) ty=i64 intent=Consume
-    bind BindingId(30) last site=SiteId(308) ty=i64
-    use BindingId(29) first site=SiteId(310) ty=i64 intent=Read
-    return site=Some(SiteId(304)) ty=i64
-    bind BindingId(31) search_from site=SiteId(309) ty=i64
-    use BindingId(31) search_from site=SiteId(313) ty=i64 intent=Read
-    use BindingId(28) s site=SiteId(315) ty=string intent=Read
-    use BindingId(28) s site=SiteId(318) ty=string intent=Read
-    use BindingId(31) search_from site=SiteId(319) ty=i64 intent=Read
-    use BindingId(28) s site=SiteId(321) ty=string intent=Read
-    eval site=SiteId(342) ty=()
-    use BindingId(30) last site=SiteId(343) ty=i64 intent=Read
-    return site=Some(SiteId(343)) ty=i64
-    bind BindingId(32) rest site=SiteId(317) ty=string
-    use BindingId(32) rest site=SiteId(325) ty=string intent=Read
-    bind BindingId(33) next site=SiteId(324) ty=i64
-    use BindingId(33) next site=SiteId(329) ty=i64 intent=Read
-    use BindingId(30) last site=SiteId(331) ty=i64 intent=Consume
-    return site=Some(SiteId(331)) ty=i64
-    eval site=SiteId(333) ty=()
-    use BindingId(31) search_from site=SiteId(336) ty=i64 intent=Read
-    use BindingId(33) next site=SiteId(337) ty=i64 intent=Read
-    eval site=SiteId(335) ty=()
-    use BindingId(30) last site=SiteId(340) ty=i64 intent=Read
-    eval site=SiteId(339) ty=()
-    drop BindingId(32) rest ty=string
+    use BindingId(25) s site=SiteId(235) ty=string intent=Read
+    bind BindingId(26) first site=SiteId(234) ty=i64
+    use BindingId(26) first site=SiteId(239) ty=i64 intent=Read
+    eval site=SiteId(244) ty=()
+    use BindingId(26) first site=SiteId(245) ty=i64 intent=Consume
+    bind BindingId(27) last site=SiteId(245) ty=i64
+    use BindingId(26) first site=SiteId(247) ty=i64 intent=Read
+    return site=Some(SiteId(241)) ty=i64
+    bind BindingId(28) search_from site=SiteId(246) ty=i64
+    use BindingId(28) search_from site=SiteId(250) ty=i64 intent=Read
+    use BindingId(25) s site=SiteId(252) ty=string intent=Read
+    use BindingId(25) s site=SiteId(255) ty=string intent=Read
+    use BindingId(28) search_from site=SiteId(256) ty=i64 intent=Read
+    use BindingId(25) s site=SiteId(258) ty=string intent=Read
+    eval site=SiteId(279) ty=()
+    use BindingId(27) last site=SiteId(280) ty=i64 intent=Read
+    return site=Some(SiteId(280)) ty=i64
+    bind BindingId(29) rest site=SiteId(254) ty=string
+    use BindingId(29) rest site=SiteId(262) ty=string intent=Read
+    bind BindingId(30) next site=SiteId(261) ty=i64
+    use BindingId(30) next site=SiteId(266) ty=i64 intent=Read
+    use BindingId(27) last site=SiteId(268) ty=i64 intent=Consume
+    return site=Some(SiteId(268)) ty=i64
+    eval site=SiteId(270) ty=()
+    use BindingId(28) search_from site=SiteId(273) ty=i64 intent=Read
+    use BindingId(30) next site=SiteId(274) ty=i64 intent=Read
+    eval site=SiteId(272) ty=()
+    use BindingId(27) last site=SiteId(277) ty=i64 intent=Read
+    eval site=SiteId(276) ty=()
+    drop BindingId(29) rest ty=string
   drop_plans:
     call[bb0 hew_string_find -> bb1] ->
       (none)
@@ -594,8 +507,8 @@ fn fs$last_slash_pos -> i64
 
 fn fs$write_error -> IoError
   statements:
-    use BindingId(34) target site=SiteId(346) ty=string intent=Read
-    return site=Some(SiteId(344)) ty=IoError
+    use BindingId(31) target site=SiteId(283) ty=string intent=Read
+    return site=Some(SiteId(281)) ty=IoError
   drop_plans:
     call[bb0 fs$missing_parent -> bb1] ->
       (none)
@@ -612,8 +525,8 @@ fn fs$write_error -> IoError
 
 fn fs$missing_path_error -> IoError
   statements:
-    use BindingId(35) target site=SiteId(356) ty=string intent=Read
-    return site=Some(SiteId(354)) ty=IoError
+    use BindingId(32) target site=SiteId(293) ty=string intent=Read
+    return site=Some(SiteId(291)) ty=IoError
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -630,9 +543,9 @@ fn fs$missing_path_error -> IoError
 
 fn fs$mkdir_error -> IoError
   statements:
-    use BindingId(36) target site=SiteId(366) ty=string intent=Read
-    use BindingId(36) target site=SiteId(373) ty=string intent=Read
-    return site=Some(SiteId(364)) ty=IoError
+    use BindingId(33) target site=SiteId(303) ty=string intent=Read
+    use BindingId(33) target site=SiteId(310) ty=string intent=Read
+    return site=Some(SiteId(301)) ty=IoError
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -659,9 +572,9 @@ fn fs$mkdir_error -> IoError
 
 fn fs$move_copy_error -> IoError
   statements:
-    use BindingId(37) source site=SiteId(384) ty=string intent=Read
-    use BindingId(38) target site=SiteId(391) ty=string intent=Read
-    return site=Some(SiteId(381)) ty=IoError
+    use BindingId(34) source site=SiteId(321) ty=string intent=Read
+    use BindingId(35) target site=SiteId(328) ty=string intent=Read
+    return site=Some(SiteId(318)) ty=IoError
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -688,23 +601,23 @@ fn fs$move_copy_error -> IoError
 
 fn fs$read -> string
   statements:
-    use BindingId(39) path site=SiteId(401) ty=string intent=Read
-    bind BindingId(40) contents site=SiteId(400) ty=string
-    bind BindingId(41) errno site=SiteId(403) ty=i32
-    use BindingId(41) errno site=SiteId(406) ty=i32 intent=Read
-    eval site=SiteId(458) ty=()
-    use BindingId(40) contents site=SiteId(459) ty=string intent=Read
-    return site=Some(SiteId(399)) ty=string
-    bind BindingId(42) detail site=SiteId(408) ty=string
-    use BindingId(42) detail site=SiteId(413) ty=string intent=Read
-    use BindingId(39) path site=SiteId(420) ty=string intent=Read
-    use BindingId(39) path site=SiteId(443) ty=string intent=Read
-    use BindingId(41) errno site=SiteId(427) ty=i32 intent=Read
-    eval site=SiteId(417) ty=!
-    use BindingId(42) detail site=SiteId(447) ty=string intent=Read
-    eval site=SiteId(440) ty=!
-    drop BindingId(42) detail ty=string
-    drop BindingId(40) contents ty=string
+    use BindingId(36) path site=SiteId(338) ty=string intent=Read
+    bind BindingId(37) contents site=SiteId(337) ty=string
+    bind BindingId(38) errno site=SiteId(340) ty=i32
+    use BindingId(38) errno site=SiteId(343) ty=i32 intent=Read
+    eval site=SiteId(395) ty=()
+    use BindingId(37) contents site=SiteId(396) ty=string intent=Read
+    return site=Some(SiteId(336)) ty=string
+    bind BindingId(39) detail site=SiteId(345) ty=string
+    use BindingId(39) detail site=SiteId(350) ty=string intent=Read
+    use BindingId(36) path site=SiteId(357) ty=string intent=Read
+    use BindingId(36) path site=SiteId(380) ty=string intent=Read
+    use BindingId(38) errno site=SiteId(364) ty=i32 intent=Read
+    eval site=SiteId(354) ty=!
+    use BindingId(39) detail site=SiteId(384) ty=string intent=Read
+    eval site=SiteId(377) ty=!
+    drop BindingId(39) detail ty=string
+    drop BindingId(37) contents ty=string
   drop_plans:
     call[bb0 hew_file_read -> bb1] ->
       (none)
@@ -767,14 +680,14 @@ fn fs$read -> string
 
 fn fs$try_read -> Result<string, IoError>
   statements:
-    use BindingId(43) file_path site=SiteId(462) ty=string intent=Read
-    bind BindingId(44) file site=SiteId(461) ty=FileReadStream
-    use BindingId(44) file site=SiteId(466) ty=FileReadStream intent=Read
-    use BindingId(44) file site=SiteId(471) ty=FileReadStream intent=Read
-    return site=Some(SiteId(460)) ty=Result<string, IoError>
-    bind BindingId(45) errno site=SiteId(474) ty=i32
-    eval site=SiteId(476) ty=string
-    use BindingId(45) errno site=SiteId(481) ty=i32 intent=Read
+    use BindingId(40) file_path site=SiteId(399) ty=string intent=Read
+    bind BindingId(41) file site=SiteId(398) ty=FileReadStream
+    use BindingId(41) file site=SiteId(403) ty=FileReadStream intent=Read
+    use BindingId(41) file site=SiteId(408) ty=FileReadStream intent=Read
+    return site=Some(SiteId(397)) ty=Result<string, IoError>
+    bind BindingId(42) errno site=SiteId(411) ty=i32
+    eval site=SiteId(413) ty=string
+    use BindingId(42) errno site=SiteId(418) ty=i32 intent=Read
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -805,9 +718,9 @@ fn fs$try_read -> Result<string, IoError>
 
 fn fs$write -> i64
   statements:
-    use BindingId(46) path site=SiteId(486) ty=string intent=Read
-    use BindingId(47) content site=SiteId(487) ty=string intent=Read
-    return site=Some(SiteId(483)) ty=i64
+    use BindingId(43) path site=SiteId(423) ty=string intent=Read
+    use BindingId(44) content site=SiteId(424) ty=string intent=Read
+    return site=Some(SiteId(420)) ty=i64
   drop_plans:
     call[bb0 hew_file_write -> bb1] ->
       (none)
@@ -818,10 +731,10 @@ fn fs$write -> i64
 
 fn fs$try_write -> Result<i64, IoError>
   statements:
-    use BindingId(48) file_path site=SiteId(492) ty=string intent=Read
-    use BindingId(49) content site=SiteId(493) ty=string intent=Read
-    return site=Some(SiteId(489)) ty=Result<i64, IoError>
-    use BindingId(48) file_path site=SiteId(499) ty=string intent=Read
+    use BindingId(45) file_path site=SiteId(429) ty=string intent=Read
+    use BindingId(46) content site=SiteId(430) ty=string intent=Read
+    return site=Some(SiteId(426)) ty=Result<i64, IoError>
+    use BindingId(45) file_path site=SiteId(436) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_write -> bb1] ->
       (none)
@@ -848,9 +761,9 @@ fn fs$try_write -> Result<i64, IoError>
 
 fn fs$append -> i64
   statements:
-    use BindingId(50) path site=SiteId(504) ty=string intent=Read
-    use BindingId(51) content site=SiteId(505) ty=string intent=Read
-    return site=Some(SiteId(501)) ty=i64
+    use BindingId(47) path site=SiteId(441) ty=string intent=Read
+    use BindingId(48) content site=SiteId(442) ty=string intent=Read
+    return site=Some(SiteId(438)) ty=i64
   drop_plans:
     call[bb0 hew_file_append -> bb1] ->
       (none)
@@ -861,10 +774,10 @@ fn fs$append -> i64
 
 fn fs$try_append -> Result<i64, IoError>
   statements:
-    use BindingId(52) file_path site=SiteId(510) ty=string intent=Read
-    use BindingId(53) content site=SiteId(511) ty=string intent=Read
-    return site=Some(SiteId(507)) ty=Result<i64, IoError>
-    use BindingId(52) file_path site=SiteId(517) ty=string intent=Read
+    use BindingId(49) file_path site=SiteId(447) ty=string intent=Read
+    use BindingId(50) content site=SiteId(448) ty=string intent=Read
+    return site=Some(SiteId(444)) ty=Result<i64, IoError>
+    use BindingId(49) file_path site=SiteId(454) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_append -> bb1] ->
       (none)
@@ -891,8 +804,8 @@ fn fs$try_append -> Result<i64, IoError>
 
 fn fs$exists -> bool
   statements:
-    use BindingId(54) path site=SiteId(521) ty=string intent=Read
-    return site=Some(SiteId(519)) ty=bool
+    use BindingId(51) path site=SiteId(458) ty=string intent=Read
+    return site=Some(SiteId(456)) ty=bool
   drop_plans:
     call[bb0 hew_file_exists -> bb1] ->
       (none)
@@ -903,8 +816,8 @@ fn fs$exists -> bool
 
 fn fs$delete -> i64
   statements:
-    use BindingId(55) path site=SiteId(526) ty=string intent=Read
-    return site=Some(SiteId(523)) ty=i64
+    use BindingId(52) path site=SiteId(463) ty=string intent=Read
+    return site=Some(SiteId(460)) ty=i64
   drop_plans:
     call[bb0 hew_file_delete -> bb1] ->
       (none)
@@ -915,9 +828,9 @@ fn fs$delete -> i64
 
 fn fs$try_delete -> Result<i64, IoError>
   statements:
-    use BindingId(56) file_path site=SiteId(531) ty=string intent=Read
-    return site=Some(SiteId(528)) ty=Result<i64, IoError>
-    use BindingId(56) file_path site=SiteId(537) ty=string intent=Read
+    use BindingId(53) file_path site=SiteId(468) ty=string intent=Read
+    return site=Some(SiteId(465)) ty=Result<i64, IoError>
+    use BindingId(53) file_path site=SiteId(474) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_delete -> bb1] ->
       (none)
@@ -944,8 +857,8 @@ fn fs$try_delete -> Result<i64, IoError>
 
 fn fs$size -> i64
   statements:
-    use BindingId(57) path site=SiteId(541) ty=string intent=Read
-    return site=Some(SiteId(539)) ty=i64
+    use BindingId(54) path site=SiteId(478) ty=string intent=Read
+    return site=Some(SiteId(476)) ty=i64
   drop_plans:
     call[bb0 hew_file_size -> bb1] ->
       (none)
@@ -956,8 +869,8 @@ fn fs$size -> i64
 
 fn fs$read_bytes -> bytes
   statements:
-    use BindingId(58) path site=SiteId(545) ty=string intent=Read
-    return site=Some(SiteId(543)) ty=bytes
+    use BindingId(55) path site=SiteId(482) ty=string intent=Read
+    return site=Some(SiteId(480)) ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
       (none)
@@ -968,15 +881,15 @@ fn fs$read_bytes -> bytes
 
 fn fs$try_read_bytes -> Result<bytes, IoError>
   statements:
-    use BindingId(59) file_path site=SiteId(549) ty=string intent=Read
-    bind BindingId(60) data site=SiteId(548) ty=bytes
-    bind BindingId(61) errno site=SiteId(551) ty=i32
-    use BindingId(61) errno site=SiteId(555) ty=i32 intent=Read
-    use BindingId(61) errno site=SiteId(561) ty=i32 intent=Read
-    use BindingId(60) data site=SiteId(565) ty=bytes intent=Read
-    agg_alias BindingId(60) data site=SiteId(565) ty=bytes
-    return site=Some(SiteId(547)) ty=Result<bytes, IoError>
-    drop BindingId(60) data ty=bytes
+    use BindingId(56) file_path site=SiteId(486) ty=string intent=Read
+    bind BindingId(57) data site=SiteId(485) ty=bytes
+    bind BindingId(58) errno site=SiteId(488) ty=i32
+    use BindingId(58) errno site=SiteId(492) ty=i32 intent=Read
+    use BindingId(58) errno site=SiteId(498) ty=i32 intent=Read
+    use BindingId(57) data site=SiteId(502) ty=bytes intent=Read
+    agg_alias BindingId(57) data site=SiteId(502) ty=bytes
+    return site=Some(SiteId(484)) ty=Result<bytes, IoError>
+    drop BindingId(57) data ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
       (none)
@@ -999,9 +912,9 @@ fn fs$try_read_bytes -> Result<bytes, IoError>
 
 fn fs$write_bytes -> i64
   statements:
-    use BindingId(62) path site=SiteId(569) ty=string intent=Read
-    use BindingId(63) data site=SiteId(570) ty=bytes intent=Read
-    return site=Some(SiteId(566)) ty=i64
+    use BindingId(59) path site=SiteId(506) ty=string intent=Read
+    use BindingId(60) data site=SiteId(507) ty=bytes intent=Read
+    return site=Some(SiteId(503)) ty=i64
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -1012,10 +925,10 @@ fn fs$write_bytes -> i64
 
 fn fs$try_write_bytes -> Result<i64, IoError>
   statements:
-    use BindingId(64) file_path site=SiteId(575) ty=string intent=Read
-    use BindingId(65) data site=SiteId(576) ty=bytes intent=Read
-    return site=Some(SiteId(572)) ty=Result<i64, IoError>
-    use BindingId(64) file_path site=SiteId(582) ty=string intent=Read
+    use BindingId(61) file_path site=SiteId(512) ty=string intent=Read
+    use BindingId(62) data site=SiteId(513) ty=bytes intent=Read
+    return site=Some(SiteId(509)) ty=Result<i64, IoError>
+    use BindingId(61) file_path site=SiteId(519) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -1042,8 +955,8 @@ fn fs$try_write_bytes -> Result<i64, IoError>
 
 fn fs$mkdir -> i64
   statements:
-    use BindingId(66) path site=SiteId(587) ty=string intent=Read
-    return site=Some(SiteId(584)) ty=i64
+    use BindingId(63) path site=SiteId(524) ty=string intent=Read
+    return site=Some(SiteId(521)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -1054,9 +967,9 @@ fn fs$mkdir -> i64
 
 fn fs$try_mkdir -> Result<i64, IoError>
   statements:
-    use BindingId(67) dir_path site=SiteId(592) ty=string intent=Read
-    return site=Some(SiteId(589)) ty=Result<i64, IoError>
-    use BindingId(67) dir_path site=SiteId(598) ty=string intent=Read
+    use BindingId(64) dir_path site=SiteId(529) ty=string intent=Read
+    return site=Some(SiteId(526)) ty=Result<i64, IoError>
+    use BindingId(64) dir_path site=SiteId(535) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -1083,8 +996,8 @@ fn fs$try_mkdir -> Result<i64, IoError>
 
 fn fs$mkdir_all -> i64
   statements:
-    use BindingId(68) path site=SiteId(603) ty=string intent=Read
-    return site=Some(SiteId(600)) ty=i64
+    use BindingId(65) path site=SiteId(540) ty=string intent=Read
+    return site=Some(SiteId(537)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -1095,9 +1008,9 @@ fn fs$mkdir_all -> i64
 
 fn fs$try_mkdir_all -> Result<i64, IoError>
   statements:
-    use BindingId(69) dir_path site=SiteId(608) ty=string intent=Read
-    return site=Some(SiteId(605)) ty=Result<i64, IoError>
-    use BindingId(69) dir_path site=SiteId(615) ty=string intent=Read
+    use BindingId(66) dir_path site=SiteId(545) ty=string intent=Read
+    return site=Some(SiteId(542)) ty=Result<i64, IoError>
+    use BindingId(66) dir_path site=SiteId(552) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -1130,8 +1043,8 @@ fn fs$try_mkdir_all -> Result<i64, IoError>
 
 fn fs$list_dir -> Vec<string>
   statements:
-    use BindingId(70) path site=SiteId(627) ty=string intent=Read
-    return site=Some(SiteId(625)) ty=Vec<string>
+    use BindingId(67) path site=SiteId(564) ty=string intent=Read
+    return site=Some(SiteId(562)) ty=Vec<string>
   drop_plans:
     call[bb0 hew_fs_list_dir -> bb1] ->
       (none)
@@ -1142,14 +1055,14 @@ fn fs$list_dir -> Vec<string>
 
 fn fs$try_list_dir -> Result<Vec<string>, IoError>
   statements:
-    use BindingId(71) dir_path site=SiteId(631) ty=string intent=Read
-    return site=Some(SiteId(633)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(637) ty=()
-    use BindingId(71) dir_path site=SiteId(640) ty=string intent=Read
-    return site=Some(SiteId(642)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(646) ty=()
-    use BindingId(71) dir_path site=SiteId(650) ty=string intent=Read
-    return site=Some(SiteId(647)) ty=Result<Vec<string>, IoError>
+    use BindingId(68) dir_path site=SiteId(568) ty=string intent=Read
+    return site=Some(SiteId(570)) ty=Result<Vec<string>, IoError>
+    eval site=SiteId(574) ty=()
+    use BindingId(68) dir_path site=SiteId(577) ty=string intent=Read
+    return site=Some(SiteId(579)) ty=Result<Vec<string>, IoError>
+    eval site=SiteId(583) ty=()
+    use BindingId(68) dir_path site=SiteId(587) ty=string intent=Read
+    return site=Some(SiteId(584)) ty=Result<Vec<string>, IoError>
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -1184,9 +1097,9 @@ fn fs$try_list_dir -> Result<Vec<string>, IoError>
 
 fn fs$rename -> i64
   statements:
-    use BindingId(72) from site=SiteId(655) ty=string intent=Read
-    use BindingId(73) to site=SiteId(656) ty=string intent=Read
-    return site=Some(SiteId(652)) ty=i64
+    use BindingId(69) from site=SiteId(592) ty=string intent=Read
+    use BindingId(70) to site=SiteId(593) ty=string intent=Read
+    return site=Some(SiteId(589)) ty=i64
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1197,11 +1110,11 @@ fn fs$rename -> i64
 
 fn fs$try_rename -> Result<i64, IoError>
   statements:
-    use BindingId(74) from site=SiteId(661) ty=string intent=Read
-    use BindingId(75) to site=SiteId(662) ty=string intent=Read
-    return site=Some(SiteId(658)) ty=Result<i64, IoError>
-    use BindingId(74) from site=SiteId(668) ty=string intent=Read
-    use BindingId(75) to site=SiteId(669) ty=string intent=Read
+    use BindingId(71) from site=SiteId(598) ty=string intent=Read
+    use BindingId(72) to site=SiteId(599) ty=string intent=Read
+    return site=Some(SiteId(595)) ty=Result<i64, IoError>
+    use BindingId(71) from site=SiteId(605) ty=string intent=Read
+    use BindingId(72) to site=SiteId(606) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1228,9 +1141,9 @@ fn fs$try_rename -> Result<i64, IoError>
 
 fn fs$copy -> i64
   statements:
-    use BindingId(76) from site=SiteId(674) ty=string intent=Read
-    use BindingId(77) to site=SiteId(675) ty=string intent=Read
-    return site=Some(SiteId(671)) ty=i64
+    use BindingId(73) from site=SiteId(611) ty=string intent=Read
+    use BindingId(74) to site=SiteId(612) ty=string intent=Read
+    return site=Some(SiteId(608)) ty=i64
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1241,11 +1154,11 @@ fn fs$copy -> i64
 
 fn fs$try_copy -> Result<i64, IoError>
   statements:
-    use BindingId(78) from site=SiteId(680) ty=string intent=Read
-    use BindingId(79) to site=SiteId(681) ty=string intent=Read
-    return site=Some(SiteId(677)) ty=Result<i64, IoError>
-    use BindingId(78) from site=SiteId(687) ty=string intent=Read
-    use BindingId(79) to site=SiteId(688) ty=string intent=Read
+    use BindingId(75) from site=SiteId(617) ty=string intent=Read
+    use BindingId(76) to site=SiteId(618) ty=string intent=Read
+    return site=Some(SiteId(614)) ty=Result<i64, IoError>
+    use BindingId(75) from site=SiteId(624) ty=string intent=Read
+    use BindingId(76) to site=SiteId(625) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1272,8 +1185,8 @@ fn fs$try_copy -> Result<i64, IoError>
 
 fn fs$is_dir -> bool
   statements:
-    use BindingId(80) path site=SiteId(692) ty=string intent=Read
-    return site=Some(SiteId(690)) ty=bool
+    use BindingId(77) path site=SiteId(629) ty=string intent=Read
+    return site=Some(SiteId(627)) ty=bool
   drop_plans:
     call[bb0 hew_fs_is_dir -> bb1] ->
       (none)
@@ -1284,21 +1197,21 @@ fn fs$is_dir -> bool
 
 fn stream$pipe -> (Sink<string>, Stream<string>)
   statements:
-    use BindingId(81) capacity site=SiteId(697) ty=i64 intent=Read
-    bind BindingId(82) pair site=SiteId(695) ty=StreamPair
-    use BindingId(82) pair site=SiteId(700) ty=StreamPair intent=Read
-    bind BindingId(83) sink site=SiteId(699) ty=Sink<string>
-    use BindingId(82) pair site=SiteId(703) ty=StreamPair intent=Read
-    bind BindingId(84) input site=SiteId(702) ty=Stream<string>
-    use BindingId(82) pair site=SiteId(706) ty=StreamPair intent=Read
-    eval site=SiteId(705) ty=()
-    use BindingId(83) sink site=SiteId(709) ty=Sink<string> intent=Read
-    use BindingId(84) input site=SiteId(710) ty=Stream<string> intent=Read
-    agg_alias BindingId(83) sink site=SiteId(709) ty=Sink<string>
-    agg_alias BindingId(84) input site=SiteId(710) ty=Stream<string>
-    return site=Some(SiteId(694)) ty=(Sink<string>, Stream<string>)
-    drop BindingId(84) input ty=Stream<string>
-    drop BindingId(83) sink ty=Sink<string>
+    use BindingId(78) capacity site=SiteId(634) ty=i64 intent=Read
+    bind BindingId(79) pair site=SiteId(632) ty=StreamPair
+    use BindingId(79) pair site=SiteId(637) ty=StreamPair intent=Read
+    bind BindingId(80) sink site=SiteId(636) ty=Sink<string>
+    use BindingId(79) pair site=SiteId(640) ty=StreamPair intent=Read
+    bind BindingId(81) input site=SiteId(639) ty=Stream<string>
+    use BindingId(79) pair site=SiteId(643) ty=StreamPair intent=Read
+    eval site=SiteId(642) ty=()
+    use BindingId(80) sink site=SiteId(646) ty=Sink<string> intent=Read
+    use BindingId(81) input site=SiteId(647) ty=Stream<string> intent=Read
+    agg_alias BindingId(80) sink site=SiteId(646) ty=Sink<string>
+    agg_alias BindingId(81) input site=SiteId(647) ty=Stream<string>
+    return site=Some(SiteId(631)) ty=(Sink<string>, Stream<string>)
+    drop BindingId(81) input ty=Stream<string>
+    drop BindingId(80) sink ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_channel -> bb1] ->
       (none)
@@ -1315,21 +1228,21 @@ fn stream$pipe -> (Sink<string>, Stream<string>)
 
 fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
   statements:
-    use BindingId(85) capacity site=SiteId(714) ty=i64 intent=Read
-    bind BindingId(86) pair site=SiteId(712) ty=StreamPair
-    use BindingId(86) pair site=SiteId(717) ty=StreamPair intent=Read
-    bind BindingId(87) sink site=SiteId(716) ty=Sink<bytes>
-    use BindingId(86) pair site=SiteId(720) ty=StreamPair intent=Read
-    bind BindingId(88) input site=SiteId(719) ty=Stream<bytes>
-    use BindingId(86) pair site=SiteId(723) ty=StreamPair intent=Read
-    eval site=SiteId(722) ty=()
-    use BindingId(87) sink site=SiteId(726) ty=Sink<bytes> intent=Read
-    use BindingId(88) input site=SiteId(727) ty=Stream<bytes> intent=Read
-    agg_alias BindingId(87) sink site=SiteId(726) ty=Sink<bytes>
-    agg_alias BindingId(88) input site=SiteId(727) ty=Stream<bytes>
-    return site=Some(SiteId(711)) ty=(Sink<bytes>, Stream<bytes>)
-    drop BindingId(88) input ty=Stream<bytes>
-    drop BindingId(87) sink ty=Sink<bytes>
+    use BindingId(82) capacity site=SiteId(651) ty=i64 intent=Read
+    bind BindingId(83) pair site=SiteId(649) ty=StreamPair
+    use BindingId(83) pair site=SiteId(654) ty=StreamPair intent=Read
+    bind BindingId(84) sink site=SiteId(653) ty=Sink<bytes>
+    use BindingId(83) pair site=SiteId(657) ty=StreamPair intent=Read
+    bind BindingId(85) input site=SiteId(656) ty=Stream<bytes>
+    use BindingId(83) pair site=SiteId(660) ty=StreamPair intent=Read
+    eval site=SiteId(659) ty=()
+    use BindingId(84) sink site=SiteId(663) ty=Sink<bytes> intent=Read
+    use BindingId(85) input site=SiteId(664) ty=Stream<bytes> intent=Read
+    agg_alias BindingId(84) sink site=SiteId(663) ty=Sink<bytes>
+    agg_alias BindingId(85) input site=SiteId(664) ty=Stream<bytes>
+    return site=Some(SiteId(648)) ty=(Sink<bytes>, Stream<bytes>)
+    drop BindingId(85) input ty=Stream<bytes>
+    drop BindingId(84) sink ty=Sink<bytes>
   drop_plans:
     call[bb0 hew_stream_channel -> bb1] ->
       (none)
@@ -1346,13 +1259,13 @@ fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
 
 fn stream$from_file -> Result<Stream<string>, string>
   statements:
-    use BindingId(89) path site=SiteId(730) ty=string intent=Read
-    bind BindingId(90) s site=SiteId(729) ty=Stream<string>
-    use BindingId(90) s site=SiteId(734) ty=Stream<string> intent=Read
-    use BindingId(90) s site=SiteId(738) ty=Stream<string> intent=Read
-    agg_alias BindingId(90) s site=SiteId(738) ty=Stream<string>
-    return site=Some(SiteId(728)) ty=Result<Stream<string>, string>
-    drop BindingId(90) s ty=Stream<string>
+    use BindingId(86) path site=SiteId(667) ty=string intent=Read
+    bind BindingId(87) s site=SiteId(666) ty=Stream<string>
+    use BindingId(87) s site=SiteId(671) ty=Stream<string> intent=Read
+    use BindingId(87) s site=SiteId(675) ty=Stream<string> intent=Read
+    agg_alias BindingId(87) s site=SiteId(675) ty=Stream<string>
+    return site=Some(SiteId(665)) ty=Result<Stream<string>, string>
+    drop BindingId(87) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1375,16 +1288,16 @@ fn stream$from_file -> Result<Stream<string>, string>
 
 fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
   statements:
-    use BindingId(91) path site=SiteId(745) ty=string intent=Read
-    bind BindingId(92) s site=SiteId(744) ty=Stream<string>
-    use BindingId(92) s site=SiteId(749) ty=Stream<string> intent=Read
-    use BindingId(92) s site=SiteId(753) ty=Stream<string> intent=Read
-    agg_alias BindingId(92) s site=SiteId(753) ty=Stream<string>
-    return site=Some(SiteId(743)) ty=Result<Stream<string>, fs.IoError>
-    bind BindingId(93) errno site=SiteId(755) ty=i32
-    eval site=SiteId(757) ty=string
-    use BindingId(93) errno site=SiteId(762) ty=i32 intent=Read
-    drop BindingId(92) s ty=Stream<string>
+    use BindingId(88) path site=SiteId(682) ty=string intent=Read
+    bind BindingId(89) s site=SiteId(681) ty=Stream<string>
+    use BindingId(89) s site=SiteId(686) ty=Stream<string> intent=Read
+    use BindingId(89) s site=SiteId(690) ty=Stream<string> intent=Read
+    agg_alias BindingId(89) s site=SiteId(690) ty=Stream<string>
+    return site=Some(SiteId(680)) ty=Result<Stream<string>, fs.IoError>
+    bind BindingId(90) errno site=SiteId(692) ty=i32
+    eval site=SiteId(694) ty=string
+    use BindingId(90) errno site=SiteId(699) ty=i32 intent=Read
+    drop BindingId(89) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1411,13 +1324,13 @@ fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
 
 fn stream$to_file -> Result<Sink<string>, string>
   statements:
-    use BindingId(94) path site=SiteId(766) ty=string intent=Read
-    bind BindingId(95) s site=SiteId(765) ty=Sink<string>
-    use BindingId(95) s site=SiteId(770) ty=Sink<string> intent=Read
-    use BindingId(95) s site=SiteId(774) ty=Sink<string> intent=Read
-    agg_alias BindingId(95) s site=SiteId(774) ty=Sink<string>
-    return site=Some(SiteId(764)) ty=Result<Sink<string>, string>
-    drop BindingId(95) s ty=Sink<string>
+    use BindingId(91) path site=SiteId(703) ty=string intent=Read
+    bind BindingId(92) s site=SiteId(702) ty=Sink<string>
+    use BindingId(92) s site=SiteId(707) ty=Sink<string> intent=Read
+    use BindingId(92) s site=SiteId(711) ty=Sink<string> intent=Read
+    agg_alias BindingId(92) s site=SiteId(711) ty=Sink<string>
+    return site=Some(SiteId(701)) ty=Result<Sink<string>, string>
+    drop BindingId(92) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1440,16 +1353,16 @@ fn stream$to_file -> Result<Sink<string>, string>
 
 fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
   statements:
-    use BindingId(96) path site=SiteId(781) ty=string intent=Read
-    bind BindingId(97) s site=SiteId(780) ty=Sink<string>
-    use BindingId(97) s site=SiteId(785) ty=Sink<string> intent=Read
-    use BindingId(97) s site=SiteId(789) ty=Sink<string> intent=Read
-    agg_alias BindingId(97) s site=SiteId(789) ty=Sink<string>
-    return site=Some(SiteId(779)) ty=Result<Sink<string>, fs.IoError>
-    bind BindingId(98) errno site=SiteId(791) ty=i32
-    eval site=SiteId(793) ty=string
-    use BindingId(98) errno site=SiteId(798) ty=i32 intent=Read
-    drop BindingId(97) s ty=Sink<string>
+    use BindingId(93) path site=SiteId(718) ty=string intent=Read
+    bind BindingId(94) s site=SiteId(717) ty=Sink<string>
+    use BindingId(94) s site=SiteId(722) ty=Sink<string> intent=Read
+    use BindingId(94) s site=SiteId(726) ty=Sink<string> intent=Read
+    agg_alias BindingId(94) s site=SiteId(726) ty=Sink<string>
+    return site=Some(SiteId(716)) ty=Result<Sink<string>, fs.IoError>
+    bind BindingId(95) errno site=SiteId(728) ty=i32
+    eval site=SiteId(730) ty=string
+    use BindingId(95) errno site=SiteId(735) ty=i32 intent=Read
+    drop BindingId(94) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1476,9 +1389,9 @@ fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
 
 fn stream$forward -> ()
   statements:
-    use BindingId(99) source site=SiteId(802) ty=Stream<string> intent=Read
-    use BindingId(100) dest site=SiteId(803) ty=Sink<string> intent=Read
-    eval site=SiteId(800) ty=()
+    use BindingId(96) source site=SiteId(739) ty=Stream<string> intent=Read
+    use BindingId(97) dest site=SiteId(740) ty=Sink<string> intent=Read
+    eval site=SiteId(737) ty=()
   drop_plans:
     call[bb0 hew_stream_pipe -> bb1] ->
       (none)
@@ -1489,8 +1402,8 @@ fn stream$forward -> ()
 
 fn i32::fmt -> string
   statements:
-    use BindingId(104) val site=SiteId(834) ty=i32 intent=Read
-    return site=Some(SiteId(833)) ty=string
+    use BindingId(101) val site=SiteId(771) ty=i32 intent=Read
+    return site=Some(SiteId(770)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1501,8 +1414,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(105) val site=SiteId(837) ty=i64 intent=Read
-    return site=Some(SiteId(836)) ty=string
+    use BindingId(102) val site=SiteId(774) ty=i64 intent=Read
+    return site=Some(SiteId(773)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1513,8 +1426,8 @@ fn i64::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(106) val site=SiteId(840) ty=u32 intent=Read
-    return site=Some(SiteId(839)) ty=string
+    use BindingId(103) val site=SiteId(777) ty=u32 intent=Read
+    return site=Some(SiteId(776)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -1525,8 +1438,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(107) val site=SiteId(843) ty=u64 intent=Read
-    return site=Some(SiteId(842)) ty=string
+    use BindingId(104) val site=SiteId(780) ty=u64 intent=Read
+    return site=Some(SiteId(779)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1537,8 +1450,8 @@ fn u64::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(108) val site=SiteId(846) ty=bool intent=Read
-    return site=Some(SiteId(845)) ty=string
+    use BindingId(105) val site=SiteId(783) ty=bool intent=Read
+    return site=Some(SiteId(782)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -1549,8 +1462,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(109) val site=SiteId(849) ty=char intent=Read
-    return site=Some(SiteId(848)) ty=string
+    use BindingId(106) val site=SiteId(786) ty=char intent=Read
+    return site=Some(SiteId(785)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -1561,8 +1474,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(110) val site=SiteId(852) ty=f64 intent=Read
-    return site=Some(SiteId(851)) ty=string
+    use BindingId(107) val site=SiteId(789) ty=f64 intent=Read
+    return site=Some(SiteId(788)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1573,8 +1486,8 @@ fn f64::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(111) val site=SiteId(854) ty=string intent=Read
-    return site=Some(SiteId(854)) ty=string
+    use BindingId(108) val site=SiteId(791) ty=string intent=Read
+    return site=Some(SiteId(791)) ty=string
   drop_plans:
     return[bb0] ->
       (none)

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -86,7 +86,7 @@ fn Echo__recv__run(i64) -> () [conv=actor_handler]
   bb9:
     _20 = call hew_string_to_bytes(_19) -> bb10
   bb10:
-    suspend [stream_send] is_final=false -> resume=bb11 cleanup=bb11
+    suspend.stream_send _5 _20 -> resume=bb11 cleanup=bb11
   bb11:
     stmt: eval site=SiteId(11) ty=()
     goto bb6
@@ -105,7 +105,7 @@ fn Echo__recv__run(i64) -> () [conv=actor_handler]
     branch _24 ? bb15 : bb16
   bb15:
     stmt: use BindingId(5) input site=SiteId(32) ty=Stream<bytes> intent=Read
-    suspend [stream_next] elem_ty=bytes is_final=false -> resume=bb17 cleanup=bb17
+    _25 = suspend.stream_next _7 elem_ty=bytes -> resume=bb17 cleanup=bb17
   bb16:
     stmt: eval site=SiteId(44) ty=()
     stmt: use BindingId(5) input site=SiteId(46) ty=Stream<bytes> intent=Consume

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -86,7 +86,7 @@ fn Echo__recv__run(i64) -> () [conv=actor_handler]
   bb9:
     _20 = call hew_string_to_bytes(_19) -> bb10
   bb10:
-    suspend.stream_send _5 _20 -> resume=bb11 cleanup=bb11
+    suspend [stream_send] is_final=false -> resume=bb11 cleanup=bb11
   bb11:
     stmt: eval site=SiteId(11) ty=()
     goto bb6
@@ -105,7 +105,7 @@ fn Echo__recv__run(i64) -> () [conv=actor_handler]
     branch _24 ? bb15 : bb16
   bb15:
     stmt: use BindingId(5) input site=SiteId(32) ty=Stream<bytes> intent=Read
-    _25 = suspend.stream_next _7 elem_ty=bytes -> resume=bb17 cleanup=bb17
+    suspend [stream_next] elem_ty=bytes is_final=false -> resume=bb17 cleanup=bb17
   bb16:
     stmt: eval site=SiteId(44) ty=()
     stmt: use BindingId(5) input site=SiteId(46) ty=Stream<bytes> intent=Consume

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -209,35 +209,8 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     _35: i64
     _36: IoError
     _37: IoError
-    _38: bool
-    _39: i64
-    _40: bool
-    _41: i64
-    _42: bool
-    _43: IoError
-    _44: i64
-    _45: IoError
-    _46: IoError
-    _47: bool
-    _48: i64
-    _49: bool
-    _50: i64
-    _51: bool
-    _52: IoError
-    _53: i64
-    _54: IoError
-    _55: IoError
-    _56: bool
-    _57: i64
-    _58: bool
-    _59: i64
-    _60: bool
-    _61: IoError
-    _62: i64
-    _63: IoError
-    _64: IoError
-    _65: i64
-    _66: IoError
+    _38: i64
+    _39: IoError
   bb0:
     stmt: use BindingId(11) errno site=SiteId(58) ty=i64 intent=Read
     _2 = const.i64 2
@@ -287,7 +260,7 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
   bb8:
     stmt: use BindingId(11) errno site=SiteId(80) ty=i64 intent=Read
     _20 = const.i64 1
-    _21 = const.i64 111
+    _21 = const.i64 110
     _22 = icmp.eq _0 _21
     branch _22 ? bb11 : bb10
   bb9:
@@ -295,7 +268,7 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     goto bb6
   bb10:
     stmt: use BindingId(11) errno site=SiteId(83) ty=i64 intent=Read
-    _23 = const.i64 61
+    _23 = const.i64 60
     _24 = icmp.eq _0 _23
     _20 = move _24
     goto bb11
@@ -312,7 +285,7 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
   bb13:
     stmt: use BindingId(11) errno site=SiteId(91) ty=i64 intent=Read
     _29 = const.i64 1
-    _30 = const.i64 98
+    _30 = const.i64 125
     _31 = icmp.eq _0 _30
     branch _31 ? bb16 : bb15
   bb14:
@@ -320,7 +293,7 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     goto bb9
   bb15:
     stmt: use BindingId(11) errno site=SiteId(94) ty=i64 intent=Read
-    _32 = const.i64 48
+    _32 = const.i64 89
     _33 = icmp.eq _0 _32
     _29 = move _33
     goto bb16
@@ -335,91 +308,16 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     _28 = move _36
     goto bb19
   bb18:
-    stmt: use BindingId(11) errno site=SiteId(102) ty=i64 intent=Read
-    _38 = const.i64 1
-    _39 = const.i64 110
-    _40 = icmp.eq _0 _39
-    branch _40 ? bb21 : bb20
+    stmt: use BindingId(11) errno site=SiteId(101) ty=i64 intent=Read
+    _38 = const.i64 5
+    mtag37 = move _38
+    mvar37.5.0 = move _0
+    _39 = move _37
+    _28 = move _39
+    goto bb19
   bb19:
     _19 = move _28
     goto bb14
-  bb20:
-    stmt: use BindingId(11) errno site=SiteId(105) ty=i64 intent=Read
-    _41 = const.i64 60
-    _42 = icmp.eq _0 _41
-    _38 = move _42
-    goto bb21
-  bb21:
-    branch _38 ? bb22 : bb23
-  bb22:
-    stmt: use BindingId(11) errno site=SiteId(109) ty=i64 intent=Read
-    _44 = const.i64 5
-    mtag43 = move _44
-    mvar43.5.0 = move _0
-    _45 = move _43
-    _37 = move _45
-    goto bb24
-  bb23:
-    stmt: use BindingId(11) errno site=SiteId(113) ty=i64 intent=Read
-    _47 = const.i64 1
-    _48 = const.i64 125
-    _49 = icmp.eq _0 _48
-    branch _49 ? bb26 : bb25
-  bb24:
-    _28 = move _37
-    goto bb19
-  bb25:
-    stmt: use BindingId(11) errno site=SiteId(116) ty=i64 intent=Read
-    _50 = const.i64 89
-    _51 = icmp.eq _0 _50
-    _47 = move _51
-    goto bb26
-  bb26:
-    branch _47 ? bb27 : bb28
-  bb27:
-    stmt: use BindingId(11) errno site=SiteId(120) ty=i64 intent=Read
-    _53 = const.i64 6
-    mtag52 = move _53
-    mvar52.6.0 = move _0
-    _54 = move _52
-    _46 = move _54
-    goto bb29
-  bb28:
-    stmt: use BindingId(11) errno site=SiteId(124) ty=i64 intent=Read
-    _56 = const.i64 1
-    _57 = const.i64 99
-    _58 = icmp.eq _0 _57
-    branch _58 ? bb31 : bb30
-  bb29:
-    _37 = move _46
-    goto bb24
-  bb30:
-    stmt: use BindingId(11) errno site=SiteId(127) ty=i64 intent=Read
-    _59 = const.i64 49
-    _60 = icmp.eq _0 _59
-    _56 = move _60
-    goto bb31
-  bb31:
-    branch _56 ? bb32 : bb33
-  bb32:
-    stmt: use BindingId(11) errno site=SiteId(131) ty=i64 intent=Read
-    _62 = const.i64 7
-    mtag61 = move _62
-    mvar61.7.0 = move _0
-    _63 = move _61
-    _55 = move _63
-    goto bb34
-  bb33:
-    stmt: use BindingId(11) errno site=SiteId(134) ty=i64 intent=Read
-    _65 = const.i64 8
-    mtag64 = move _65
-    mvar64.8.0 = move _0
-    _66 = move _64
-    _55 = move _66
-    goto bb34
-  bb34:
-    _46 = move _55
-    goto bb29
 
 fn fs$io_error_message(IoError) -> string [conv=default]
   locals:
@@ -439,11 +337,11 @@ fn fs$io_error_message(IoError) -> string [conv=default]
     _13: i64
     _14: bool
     _15: i64
-    _16: bool
-    _17: i64
-    _18: bool
-    _19: i64
-    _20: bool
+    _16: string
+    _17: string
+    _18: string
+    _19: string
+    _20: string
     _21: i64
     _22: string
     _23: string
@@ -474,199 +372,121 @@ fn fs$io_error_message(IoError) -> string [conv=default]
     _48: string
     _49: string
     _50: string
-    _51: i64
-    _52: string
-    _53: string
-    _54: string
-    _55: string
-    _56: string
-    _57: i64
-    _58: string
-    _59: string
-    _60: string
-    _61: string
-    _62: string
-    _63: i64
-    _64: string
-    _65: string
-    _66: string
-    _67: string
-    _68: string
-    _69: i64
-    _70: string
-    _71: string
-    _72: string
-    _73: string
-    _74: string
   bb0:
-    stmt: use BindingId(12) e site=SiteId(136) ty=IoError intent=Read
+    stmt: use BindingId(12) e site=SiteId(103) ty=IoError intent=Read
     _2 = move etag0
     _3 = const.i64 0
     _4 = icmp.eq _2 _3
-    branch _4 ? bb2 : bb12
+    branch _4 ? bb2 : bb9
   bb1:
-    stmt: return site=Some(SiteId(135)) ty=string
+    stmt: return site=Some(SiteId(102)) ty=string
     ret = move _1
     return
   bb2:
-    stmt: bind BindingId(13) code site=SiteId(137) ty=i64
-    stmt: use BindingId(13) code site=SiteId(139) ty=i64 intent=Read
-    _21 = move mvar0.0.0
-    _22 = string_lit "NotFound("
-    _23 = call to_string_i64(_21) -> bb20
+    stmt: bind BindingId(13) code site=SiteId(104) ty=i64
+    stmt: use BindingId(13) code site=SiteId(106) ty=i64 intent=Read
+    _15 = move mvar0.0.0
+    _16 = string_lit "NotFound("
+    _17 = call to_string_i64(_15) -> bb14
   bb3:
-    stmt: bind BindingId(14) code site=SiteId(147) ty=i64
-    stmt: use BindingId(14) code site=SiteId(149) ty=i64 intent=Read
-    _27 = move mvar0.1.0
-    _28 = string_lit "PermissionDenied("
-    _29 = call to_string_i64(_27) -> bb23
+    stmt: bind BindingId(14) code site=SiteId(114) ty=i64
+    stmt: use BindingId(14) code site=SiteId(116) ty=i64 intent=Read
+    _21 = move mvar0.1.0
+    _22 = string_lit "PermissionDenied("
+    _23 = call to_string_i64(_21) -> bb17
   bb4:
-    stmt: bind BindingId(15) code site=SiteId(157) ty=i64
-    stmt: use BindingId(15) code site=SiteId(159) ty=i64 intent=Read
-    _33 = move mvar0.2.0
-    _34 = string_lit "AlreadyExists("
-    _35 = call to_string_i64(_33) -> bb26
+    stmt: bind BindingId(15) code site=SiteId(124) ty=i64
+    stmt: use BindingId(15) code site=SiteId(126) ty=i64 intent=Read
+    _27 = move mvar0.2.0
+    _28 = string_lit "AlreadyExists("
+    _29 = call to_string_i64(_27) -> bb20
   bb5:
-    stmt: bind BindingId(16) code site=SiteId(167) ty=i64
-    stmt: use BindingId(16) code site=SiteId(169) ty=i64 intent=Read
-    _39 = move mvar0.3.0
-    _40 = string_lit "ConnectionRefused("
-    _41 = call to_string_i64(_39) -> bb29
+    stmt: bind BindingId(16) code site=SiteId(134) ty=i64
+    stmt: use BindingId(16) code site=SiteId(136) ty=i64 intent=Read
+    _33 = move mvar0.3.0
+    _34 = string_lit "TimedOut("
+    _35 = call to_string_i64(_33) -> bb23
   bb6:
-    stmt: bind BindingId(17) code site=SiteId(177) ty=i64
-    stmt: use BindingId(17) code site=SiteId(179) ty=i64 intent=Read
-    _45 = move mvar0.4.0
-    _46 = string_lit "AddressInUse("
-    _47 = call to_string_i64(_45) -> bb32
+    stmt: bind BindingId(17) code site=SiteId(144) ty=i64
+    stmt: use BindingId(17) code site=SiteId(146) ty=i64 intent=Read
+    _39 = move mvar0.4.0
+    _40 = string_lit "Cancelled("
+    _41 = call to_string_i64(_39) -> bb26
   bb7:
-    stmt: bind BindingId(18) code site=SiteId(187) ty=i64
-    stmt: use BindingId(18) code site=SiteId(189) ty=i64 intent=Read
-    _51 = move mvar0.5.0
-    _52 = string_lit "TimedOut("
-    _53 = call to_string_i64(_51) -> bb35
+    stmt: bind BindingId(18) code site=SiteId(154) ty=i64
+    stmt: use BindingId(18) code site=SiteId(156) ty=i64 intent=Read
+    _45 = move mvar0.5.0
+    _46 = string_lit "Other("
+    _47 = call to_string_i64(_45) -> bb29
   bb8:
-    stmt: bind BindingId(19) code site=SiteId(197) ty=i64
-    stmt: use BindingId(19) code site=SiteId(199) ty=i64 intent=Read
-    _57 = move mvar0.6.0
-    _58 = string_lit "Cancelled("
-    _59 = call to_string_i64(_57) -> bb38
-  bb9:
-    stmt: bind BindingId(20) code site=SiteId(207) ty=i64
-    stmt: use BindingId(20) code site=SiteId(209) ty=i64 intent=Read
-    _63 = move mvar0.7.0
-    _64 = string_lit "AddressNotAvailable("
-    _65 = call to_string_i64(_63) -> bb41
-  bb10:
-    stmt: bind BindingId(21) code site=SiteId(217) ty=i64
-    stmt: use BindingId(21) code site=SiteId(219) ty=i64 intent=Read
-    _69 = move mvar0.8.0
-    _70 = string_lit "Other("
-    _71 = call to_string_i64(_69) -> bb44
-  bb11:
     trap(ExhaustivenessFallthrough)
-  bb12:
+  bb9:
     _5 = const.i64 1
     _6 = icmp.eq _2 _5
-    branch _6 ? bb3 : bb13
-  bb13:
+    branch _6 ? bb3 : bb10
+  bb10:
     _7 = const.i64 2
     _8 = icmp.eq _2 _7
-    branch _8 ? bb4 : bb14
-  bb14:
+    branch _8 ? bb4 : bb11
+  bb11:
     _9 = const.i64 3
     _10 = icmp.eq _2 _9
-    branch _10 ? bb5 : bb15
-  bb15:
+    branch _10 ? bb5 : bb12
+  bb12:
     _11 = const.i64 4
     _12 = icmp.eq _2 _11
-    branch _12 ? bb6 : bb16
-  bb16:
+    branch _12 ? bb6 : bb13
+  bb13:
     _13 = const.i64 5
     _14 = icmp.eq _2 _13
-    branch _14 ? bb7 : bb17
+    branch _14 ? bb7 : bb8
+  bb14:
+    _18 = call string_concat(_16, _17) -> bb15
+  bb15:
+    _19 = string_lit ")"
+    _20 = call string_concat(_18, _19) -> bb16
+  bb16:
+    _1 = move _20
+    goto bb1
   bb17:
-    _15 = const.i64 6
-    _16 = icmp.eq _2 _15
-    branch _16 ? bb8 : bb18
+    _24 = call string_concat(_22, _23) -> bb18
   bb18:
-    _17 = const.i64 7
-    _18 = icmp.eq _2 _17
-    branch _18 ? bb9 : bb19
-  bb19:
-    _19 = const.i64 8
-    _20 = icmp.eq _2 _19
-    branch _20 ? bb10 : bb11
-  bb20:
-    _24 = call string_concat(_22, _23) -> bb21
-  bb21:
     _25 = string_lit ")"
-    _26 = call string_concat(_24, _25) -> bb22
-  bb22:
+    _26 = call string_concat(_24, _25) -> bb19
+  bb19:
     _1 = move _26
     goto bb1
-  bb23:
-    _30 = call string_concat(_28, _29) -> bb24
-  bb24:
+  bb20:
+    _30 = call string_concat(_28, _29) -> bb21
+  bb21:
     _31 = string_lit ")"
-    _32 = call string_concat(_30, _31) -> bb25
-  bb25:
+    _32 = call string_concat(_30, _31) -> bb22
+  bb22:
     _1 = move _32
     goto bb1
-  bb26:
-    _36 = call string_concat(_34, _35) -> bb27
-  bb27:
+  bb23:
+    _36 = call string_concat(_34, _35) -> bb24
+  bb24:
     _37 = string_lit ")"
-    _38 = call string_concat(_36, _37) -> bb28
-  bb28:
+    _38 = call string_concat(_36, _37) -> bb25
+  bb25:
     _1 = move _38
     goto bb1
-  bb29:
-    _42 = call string_concat(_40, _41) -> bb30
-  bb30:
+  bb26:
+    _42 = call string_concat(_40, _41) -> bb27
+  bb27:
     _43 = string_lit ")"
-    _44 = call string_concat(_42, _43) -> bb31
-  bb31:
+    _44 = call string_concat(_42, _43) -> bb28
+  bb28:
     _1 = move _44
     goto bb1
-  bb32:
-    _48 = call string_concat(_46, _47) -> bb33
-  bb33:
+  bb29:
+    _48 = call string_concat(_46, _47) -> bb30
+  bb30:
     _49 = string_lit ")"
-    _50 = call string_concat(_48, _49) -> bb34
-  bb34:
+    _50 = call string_concat(_48, _49) -> bb31
+  bb31:
     _1 = move _50
-    goto bb1
-  bb35:
-    _54 = call string_concat(_52, _53) -> bb36
-  bb36:
-    _55 = string_lit ")"
-    _56 = call string_concat(_54, _55) -> bb37
-  bb37:
-    _1 = move _56
-    goto bb1
-  bb38:
-    _60 = call string_concat(_58, _59) -> bb39
-  bb39:
-    _61 = string_lit ")"
-    _62 = call string_concat(_60, _61) -> bb40
-  bb40:
-    _1 = move _62
-    goto bb1
-  bb41:
-    _66 = call string_concat(_64, _65) -> bb42
-  bb42:
-    _67 = string_lit ")"
-    _68 = call string_concat(_66, _67) -> bb43
-  bb43:
-    _1 = move _68
-    goto bb1
-  bb44:
-    _72 = call string_concat(_70, _71) -> bb45
-  bb45:
-    _73 = string_lit ")"
-    _74 = call string_concat(_72, _73) -> bb46
-  bb46:
-    _1 = move _74
     goto bb1
 
 fn fs$io_error_timed_out() -> IoError [conv=default]
@@ -675,11 +495,11 @@ fn fs$io_error_timed_out() -> IoError [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: return site=Some(SiteId(227)) ty=IoError
-    _1 = const.i64 5
+    stmt: return site=Some(SiteId(164)) ty=IoError
+    _1 = const.i64 3
     mtag0 = move _1
     _2 = const.i64 0
-    mvar0.5.0 = move _2
+    mvar0.3.0 = move _2
     ret = move _0
     return
 
@@ -689,11 +509,11 @@ fn fs$io_error_cancelled() -> IoError [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: return site=Some(SiteId(229)) ty=IoError
-    _1 = const.i64 6
+    stmt: return site=Some(SiteId(166)) ty=IoError
+    _1 = const.i64 4
     mtag0 = move _1
     _2 = const.i64 0
-    mvar0.6.0 = move _2
+    mvar0.4.0 = move _2
     ret = move _0
     return
 
@@ -708,21 +528,21 @@ fn fs$missing_parent(string) -> bool [conv=default]
     _6: bool
     _7: bool
   bb0:
-    stmt: use BindingId(22) target site=SiteId(232) ty=string intent=Read
+    stmt: use BindingId(19) target site=SiteId(169) ty=string intent=Read
     _1 = call fs$dirname(_0) -> bb1
   bb1:
-    stmt: bind BindingId(23) parent site=SiteId(231) ty=string
-    stmt: use BindingId(23) parent site=SiteId(236) ty=string intent=Read
+    stmt: bind BindingId(20) parent site=SiteId(168) ty=string
+    stmt: use BindingId(20) parent site=SiteId(173) ty=string intent=Read
     _2 = move _1
     _3 = const.i64 0
     _4 = string_lit ""
     _5 = icmp.ne _2 _4
     branch _5 ? bb2 : bb3
   bb2:
-    stmt: use BindingId(23) parent site=SiteId(240) ty=string intent=Read
+    stmt: use BindingId(20) parent site=SiteId(177) ty=string intent=Read
     _6 = call fs$exists(_2) -> bb4
   bb3:
-    stmt: return site=Some(SiteId(234)) ty=bool
+    stmt: return site=Some(SiteId(171)) ty=bool
     ret = move _3
     return
   bb4:
@@ -748,52 +568,52 @@ fn fs$dirname(string) -> string [conv=default]
     _13: i64
     _14: string
   bb0:
-    stmt: use BindingId(24) p site=SiteId(243) ty=string intent=Read
+    stmt: use BindingId(21) p site=SiteId(180) ty=string intent=Read
     _1 = call fs$strip_trailing_slash(_0) -> bb1
   bb1:
-    stmt: bind BindingId(25) s site=SiteId(242) ty=string
-    stmt: use BindingId(25) s site=SiteId(246) ty=string intent=Read
+    stmt: bind BindingId(22) s site=SiteId(179) ty=string
+    stmt: use BindingId(22) s site=SiteId(183) ty=string intent=Read
     _2 = move _1
     _3 = call fs$last_slash_pos(_2) -> bb2
   bb2:
-    stmt: bind BindingId(26) pos site=SiteId(245) ty=i64
-    stmt: use BindingId(26) pos site=SiteId(249) ty=i64 intent=Read
+    stmt: bind BindingId(23) pos site=SiteId(182) ty=i64
+    stmt: use BindingId(23) pos site=SiteId(186) ty=i64 intent=Read
     _4 = move _3
     _6 = const.i64 0
     _7 = icmp.slt _4 _6
     branch _7 ? bb3 : bb4
   bb3:
-    stmt: return site=Some(SiteId(251)) ty=string
+    stmt: return site=Some(SiteId(188)) ty=string
     _8 = string_lit ""
     ret = move _8
     return
   bb4:
     goto bb5
   bb5:
-    stmt: eval site=SiteId(253) ty=()
-    stmt: use BindingId(26) pos site=SiteId(255) ty=i64 intent=Read
+    stmt: eval site=SiteId(190) ty=()
+    stmt: use BindingId(23) pos site=SiteId(192) ty=i64 intent=Read
     _10 = const.i64 0
     _11 = icmp.eq _4 _10
     branch _11 ? bb7 : bb8
   bb6:
     goto bb5
   bb7:
-    stmt: return site=Some(SiteId(257)) ty=string
+    stmt: return site=Some(SiteId(194)) ty=string
     _12 = string_lit "/"
     ret = move _12
     return
   bb8:
     goto bb9
   bb9:
-    stmt: eval site=SiteId(259) ty=()
-    stmt: use BindingId(25) s site=SiteId(261) ty=string intent=Read
-    stmt: use BindingId(26) pos site=SiteId(263) ty=i64 intent=Read
+    stmt: eval site=SiteId(196) ty=()
+    stmt: use BindingId(22) s site=SiteId(198) ty=string intent=Read
+    stmt: use BindingId(23) pos site=SiteId(200) ty=i64 intent=Read
     _13 = const.i64 0
     _14 = call hew_string_slice(_2, _13, _4) -> bb11
   bb10:
     goto bb9
   bb11:
-    stmt: return site=Some(SiteId(260)) ty=string
+    stmt: return site=Some(SiteId(197)) ty=string
     ret = move _14
     return
 
@@ -821,13 +641,13 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
     _19: string
     _20: string
   bb0:
-    stmt: use BindingId(27) p site=SiteId(266) ty=string intent=Read
+    stmt: use BindingId(24) p site=SiteId(203) ty=string intent=Read
     _2 = string_lit "/"
     _3 = icmp.eq _0 _2
     branch _3 ? bb1 : bb2
   bb1:
-    stmt: use BindingId(27) p site=SiteId(270) ty=string intent=Read
-    stmt: return site=Some(SiteId(268)) ty=string
+    stmt: use BindingId(24) p site=SiteId(207) ty=string intent=Read
+    stmt: return site=Some(SiteId(205)) ty=string
     _4 = string_lit ""
     _5 = call_rt hew_string_concat(_4, _0)
     ret = move _5
@@ -835,8 +655,8 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
   bb2:
     goto bb3
   bb3:
-    stmt: eval site=SiteId(272) ty=()
-    stmt: use BindingId(27) p site=SiteId(276) ty=string intent=Read
+    stmt: eval site=SiteId(209) ty=()
+    stmt: use BindingId(24) p site=SiteId(213) ty=string intent=Read
     _7 = const.i64 0
     _8 = call hew_string_length(_0) -> bb5
   bb4:
@@ -846,7 +666,7 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
     _10 = icmp.sgt _8 _9
     branch _10 ? bb6 : bb7
   bb6:
-    stmt: use BindingId(27) p site=SiteId(280) ty=string intent=Read
+    stmt: use BindingId(24) p site=SiteId(217) ty=string intent=Read
     _11 = string_lit "/"
     _12 = call hew_string_ends_with(_0, _11) -> bb8
   bb7:
@@ -855,16 +675,16 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
     _7 = move _12
     goto bb7
   bb9:
-    stmt: use BindingId(27) p site=SiteId(284) ty=string intent=Read
-    stmt: use BindingId(27) p site=SiteId(288) ty=string intent=Read
+    stmt: use BindingId(24) p site=SiteId(221) ty=string intent=Read
+    stmt: use BindingId(24) p site=SiteId(225) ty=string intent=Read
     _13 = const.i64 0
     _14 = call hew_string_length(_0) -> bb12
   bb10:
     goto bb11
   bb11:
-    stmt: eval site=SiteId(293) ty=()
-    stmt: use BindingId(27) p site=SiteId(296) ty=string intent=Read
-    stmt: return site=Some(SiteId(294)) ty=string
+    stmt: eval site=SiteId(230) ty=()
+    stmt: use BindingId(24) p site=SiteId(233) ty=string intent=Read
+    stmt: return site=Some(SiteId(231)) ty=string
     _19 = string_lit ""
     _20 = call_rt hew_string_concat(_19, _0)
     ret = move _20
@@ -878,7 +698,7 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
   bb14:
     _18 = call hew_string_slice(_0, _13, _16) -> bb15
   bb15:
-    stmt: return site=Some(SiteId(283)) ty=string
+    stmt: return site=Some(SiteId(220)) ty=string
     ret = move _18
     return
   bb16:
@@ -918,12 +738,12 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
     _29: i64
     _30: bool
   bb0:
-    stmt: use BindingId(28) s site=SiteId(298) ty=string intent=Read
+    stmt: use BindingId(25) s site=SiteId(235) ty=string intent=Read
     _1 = string_lit "/"
     _2 = call hew_string_find(_0, _1) -> bb1
   bb1:
-    stmt: bind BindingId(29) first site=SiteId(297) ty=i64
-    stmt: use BindingId(29) first site=SiteId(302) ty=i64 intent=Read
+    stmt: bind BindingId(26) first site=SiteId(234) ty=i64
+    stmt: use BindingId(26) first site=SiteId(239) ty=i64 intent=Read
     _3 = move _2
     _5 = const.i64 0
     _6 = icmp.slt _3 _5
@@ -935,10 +755,10 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb3:
     goto bb4
   bb4:
-    stmt: eval site=SiteId(307) ty=()
-    stmt: use BindingId(29) first site=SiteId(308) ty=i64 intent=Consume
-    stmt: bind BindingId(30) last site=SiteId(308) ty=i64
-    stmt: use BindingId(29) first site=SiteId(310) ty=i64 intent=Read
+    stmt: eval site=SiteId(244) ty=()
+    stmt: use BindingId(26) first site=SiteId(245) ty=i64 intent=Consume
+    stmt: bind BindingId(27) last site=SiteId(245) ty=i64
+    stmt: use BindingId(26) first site=SiteId(247) ty=i64 intent=Read
     _10 = move _3
     _11 = const.i64 1
     _12 ovf=_13 = add.checked.s _3 _11
@@ -946,7 +766,7 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb5:
     trap(IntegerOverflow)
   bb6:
-    stmt: return site=Some(SiteId(304)) ty=i64
+    stmt: return site=Some(SiteId(241)) ty=i64
     ret = move _8
     return
   bb7:
@@ -954,22 +774,22 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb8:
     trap(IntegerOverflow)
   bb9:
-    stmt: bind BindingId(31) search_from site=SiteId(309) ty=i64
+    stmt: bind BindingId(28) search_from site=SiteId(246) ty=i64
     _14 = move _12
     goto bb10
   bb10:
-    stmt: use BindingId(31) search_from site=SiteId(313) ty=i64 intent=Read
-    stmt: use BindingId(28) s site=SiteId(315) ty=string intent=Read
+    stmt: use BindingId(28) search_from site=SiteId(250) ty=i64 intent=Read
+    stmt: use BindingId(25) s site=SiteId(252) ty=string intent=Read
     _15 = call hew_string_length(_0) -> bb13
   bb11:
-    stmt: use BindingId(28) s site=SiteId(318) ty=string intent=Read
-    stmt: use BindingId(31) search_from site=SiteId(319) ty=i64 intent=Read
-    stmt: use BindingId(28) s site=SiteId(321) ty=string intent=Read
+    stmt: use BindingId(25) s site=SiteId(255) ty=string intent=Read
+    stmt: use BindingId(28) search_from site=SiteId(256) ty=i64 intent=Read
+    stmt: use BindingId(25) s site=SiteId(258) ty=string intent=Read
     _17 = call hew_string_length(_0) -> bb14
   bb12:
-    stmt: eval site=SiteId(342) ty=()
-    stmt: use BindingId(30) last site=SiteId(343) ty=i64 intent=Read
-    stmt: return site=Some(SiteId(343)) ty=i64
+    stmt: eval site=SiteId(279) ty=()
+    stmt: use BindingId(27) last site=SiteId(280) ty=i64 intent=Read
+    stmt: return site=Some(SiteId(280)) ty=i64
     ret = move _10
     return
   bb13:
@@ -978,29 +798,29 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb14:
     _18 = call hew_string_slice(_0, _14, _17) -> bb15
   bb15:
-    stmt: bind BindingId(32) rest site=SiteId(317) ty=string
-    stmt: use BindingId(32) rest site=SiteId(325) ty=string intent=Read
+    stmt: bind BindingId(29) rest site=SiteId(254) ty=string
+    stmt: use BindingId(29) rest site=SiteId(262) ty=string intent=Read
     _19 = move _18
     _20 = string_lit "/"
     _21 = call hew_string_find(_19, _20) -> bb16
   bb16:
-    stmt: bind BindingId(33) next site=SiteId(324) ty=i64
-    stmt: use BindingId(33) next site=SiteId(329) ty=i64 intent=Read
+    stmt: bind BindingId(30) next site=SiteId(261) ty=i64
+    stmt: use BindingId(30) next site=SiteId(266) ty=i64 intent=Read
     _22 = move _21
     _24 = const.i64 0
     _25 = icmp.slt _22 _24
     branch _25 ? bb17 : bb18
   bb17:
-    stmt: use BindingId(30) last site=SiteId(331) ty=i64 intent=Consume
-    stmt: return site=Some(SiteId(331)) ty=i64
+    stmt: use BindingId(27) last site=SiteId(268) ty=i64 intent=Consume
+    stmt: return site=Some(SiteId(268)) ty=i64
     ret = move _10
     return
   bb18:
     goto bb19
   bb19:
-    stmt: eval site=SiteId(333) ty=()
-    stmt: use BindingId(31) search_from site=SiteId(336) ty=i64 intent=Read
-    stmt: use BindingId(33) next site=SiteId(337) ty=i64 intent=Read
+    stmt: eval site=SiteId(270) ty=()
+    stmt: use BindingId(28) search_from site=SiteId(273) ty=i64 intent=Read
+    stmt: use BindingId(30) next site=SiteId(274) ty=i64 intent=Read
     _26 ovf=_27 = add.checked.s _14 _22
     branch _27 ? bb21 : bb22
   bb20:
@@ -1008,8 +828,8 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb21:
     trap(IntegerOverflow)
   bb22:
-    stmt: eval site=SiteId(335) ty=()
-    stmt: use BindingId(30) last site=SiteId(340) ty=i64 intent=Read
+    stmt: eval site=SiteId(272) ty=()
+    stmt: use BindingId(27) last site=SiteId(277) ty=i64 intent=Read
     _10 = move _26
     _28 = const.i64 1
     _29 ovf=_30 = add.checked.s _10 _28
@@ -1017,7 +837,7 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb23:
     trap(IntegerOverflow)
   bb24:
-    stmt: eval site=SiteId(339) ty=()
+    stmt: eval site=SiteId(276) ty=()
     _14 = move _29
     goto bb10
 
@@ -1035,7 +855,7 @@ fn fs$write_error(string) -> IoError [conv=default]
     _9: i64
     _10: IoError
   bb0:
-    stmt: use BindingId(34) target site=SiteId(346) ty=string intent=Read
+    stmt: use BindingId(31) target site=SiteId(283) ty=string intent=Read
     _2 = call fs$missing_parent(_0) -> bb1
   bb1:
     branch _2 ? bb2 : bb3
@@ -1048,15 +868,15 @@ fn fs$write_error(string) -> IoError [conv=default]
     _1 = move _6
     goto bb4
   bb3:
-    _8 = const.i64 8
+    _8 = const.i64 5
     mtag7 = move _8
     _9 = const.i64 0
-    mvar7.8.0 = move _9
+    mvar7.5.0 = move _9
     _10 = move _7
     _1 = move _10
     goto bb4
   bb4:
-    stmt: return site=Some(SiteId(344)) ty=IoError
+    stmt: return site=Some(SiteId(281)) ty=IoError
     ret = move _1
     return
 
@@ -1074,15 +894,15 @@ fn fs$missing_path_error(string) -> IoError [conv=default]
     _9: i64
     _10: IoError
   bb0:
-    stmt: use BindingId(35) target site=SiteId(356) ty=string intent=Read
+    stmt: use BindingId(32) target site=SiteId(293) ty=string intent=Read
     _2 = call fs$exists(_0) -> bb1
   bb1:
     branch _2 ? bb2 : bb3
   bb2:
-    _4 = const.i64 8
+    _4 = const.i64 5
     mtag3 = move _4
     _5 = const.i64 0
-    mvar3.8.0 = move _5
+    mvar3.5.0 = move _5
     _6 = move _3
     _1 = move _6
     goto bb4
@@ -1095,7 +915,7 @@ fn fs$missing_path_error(string) -> IoError [conv=default]
     _1 = move _10
     goto bb4
   bb4:
-    stmt: return site=Some(SiteId(354)) ty=IoError
+    stmt: return site=Some(SiteId(291)) ty=IoError
     ret = move _1
     return
 
@@ -1119,7 +939,7 @@ fn fs$mkdir_error(string) -> IoError [conv=default]
     _15: i64
     _16: IoError
   bb0:
-    stmt: use BindingId(36) target site=SiteId(366) ty=string intent=Read
+    stmt: use BindingId(33) target site=SiteId(303) ty=string intent=Read
     _2 = call fs$exists(_0) -> bb1
   bb1:
     branch _2 ? bb2 : bb3
@@ -1132,10 +952,10 @@ fn fs$mkdir_error(string) -> IoError [conv=default]
     _1 = move _6
     goto bb4
   bb3:
-    stmt: use BindingId(36) target site=SiteId(373) ty=string intent=Read
+    stmt: use BindingId(33) target site=SiteId(310) ty=string intent=Read
     _8 = call fs$missing_parent(_0) -> bb5
   bb4:
-    stmt: return site=Some(SiteId(364)) ty=IoError
+    stmt: return site=Some(SiteId(301)) ty=IoError
     ret = move _1
     return
   bb5:
@@ -1149,10 +969,10 @@ fn fs$mkdir_error(string) -> IoError [conv=default]
     _7 = move _12
     goto bb8
   bb7:
-    _14 = const.i64 8
+    _14 = const.i64 5
     mtag13 = move _14
     _15 = const.i64 0
-    mvar13.8.0 = move _15
+    mvar13.5.0 = move _15
     _16 = move _13
     _7 = move _16
     goto bb8
@@ -1182,7 +1002,7 @@ fn fs$move_copy_error(string, string) -> IoError [conv=default]
     _17: i64
     _18: IoError
   bb0:
-    stmt: use BindingId(37) source site=SiteId(384) ty=string intent=Read
+    stmt: use BindingId(34) source site=SiteId(321) ty=string intent=Read
     _3 = call fs$exists(_0) -> bb1
   bb1:
     _4 = not _3
@@ -1196,10 +1016,10 @@ fn fs$move_copy_error(string, string) -> IoError [conv=default]
     _2 = move _8
     goto bb4
   bb3:
-    stmt: use BindingId(38) target site=SiteId(391) ty=string intent=Read
+    stmt: use BindingId(35) target site=SiteId(328) ty=string intent=Read
     _10 = call fs$missing_parent(_1) -> bb5
   bb4:
-    stmt: return site=Some(SiteId(381)) ty=IoError
+    stmt: return site=Some(SiteId(318)) ty=IoError
     ret = move _2
     return
   bb5:
@@ -1213,10 +1033,10 @@ fn fs$move_copy_error(string, string) -> IoError [conv=default]
     _9 = move _14
     goto bb8
   bb7:
-    _16 = const.i64 8
+    _16 = const.i64 5
     mtag15 = move _16
     _17 = const.i64 0
-    mvar15.8.0 = move _17
+    mvar15.5.0 = move _17
     _18 = move _15
     _9 = move _18
     goto bb8
@@ -1260,15 +1080,15 @@ fn fs$read(string) -> string [conv=default]
     _31: ()
     _32: string
   bb0:
-    stmt: use BindingId(39) path site=SiteId(401) ty=string intent=Read
+    stmt: use BindingId(36) path site=SiteId(338) ty=string intent=Read
     _1 = call hew_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(40) contents site=SiteId(400) ty=string
+    stmt: bind BindingId(37) contents site=SiteId(337) ty=string
     _2 = move _1
     _3 = call hew_stream_last_errno() -> bb2
   bb2:
-    stmt: bind BindingId(41) errno site=SiteId(403) ty=i32
-    stmt: use BindingId(41) errno site=SiteId(406) ty=i32 intent=Read
+    stmt: bind BindingId(38) errno site=SiteId(340) ty=i32
+    stmt: use BindingId(38) errno site=SiteId(343) ty=i32 intent=Read
     _4 = move _3
     _6 = const.i64 0
     _7 = icmp.ne _4 _6
@@ -1278,15 +1098,15 @@ fn fs$read(string) -> string [conv=default]
   bb4:
     goto bb5
   bb5:
-    stmt: eval site=SiteId(458) ty=()
-    stmt: use BindingId(40) contents site=SiteId(459) ty=string intent=Read
-    stmt: return site=Some(SiteId(399)) ty=string
+    stmt: eval site=SiteId(395) ty=()
+    stmt: use BindingId(37) contents site=SiteId(396) ty=string intent=Read
+    stmt: return site=Some(SiteId(336)) ty=string
     _32 = move _2
     ret = move _32
     return
   bb6:
-    stmt: bind BindingId(42) detail site=SiteId(408) ty=string
-    stmt: use BindingId(42) detail site=SiteId(413) ty=string intent=Read
+    stmt: bind BindingId(39) detail site=SiteId(345) ty=string
+    stmt: use BindingId(39) detail site=SiteId(350) ty=string intent=Read
     _9 = move _8
     _11 = call hew_string_length(_9) -> bb7
   bb7:
@@ -1294,11 +1114,11 @@ fn fs$read(string) -> string [conv=default]
     _13 = icmp.eq _11 _12
     branch _13 ? bb8 : bb9
   bb8:
-    stmt: use BindingId(39) path site=SiteId(420) ty=string intent=Read
+    stmt: use BindingId(36) path site=SiteId(357) ty=string intent=Read
     _14 = string_lit "fs.read failed for `"
     _15 = call string::fmt(_0) -> bb11
   bb9:
-    stmt: use BindingId(39) path site=SiteId(443) ty=string intent=Read
+    stmt: use BindingId(36) path site=SiteId(380) ty=string intent=Read
     _24 = string_lit "fs.read failed for `"
     _25 = call string::fmt(_0) -> bb19
   bb10:
@@ -1311,7 +1131,7 @@ fn fs$read(string) -> string [conv=default]
     _17 = string_lit "`: "
     _18 = call string_concat(_16, _17) -> bb13
   bb13:
-    stmt: use BindingId(41) errno site=SiteId(427) ty=i32 intent=Read
+    stmt: use BindingId(38) errno site=SiteId(364) ty=i32 intent=Read
     _19 = cast _4 i32 -> i64
     _20 = call fs$io_error_from_errno(_19) -> bb14
   bb14:
@@ -1323,7 +1143,7 @@ fn fs$read(string) -> string [conv=default]
   bb17:
     call panic(_23) -> bb18
   bb18:
-    stmt: eval site=SiteId(417) ty=!
+    stmt: eval site=SiteId(354) ty=!
     goto bb10
   bb19:
     _26 = call string_concat(_24, _25) -> bb20
@@ -1331,14 +1151,14 @@ fn fs$read(string) -> string [conv=default]
     _27 = string_lit "`: "
     _28 = call string_concat(_26, _27) -> bb21
   bb21:
-    stmt: use BindingId(42) detail site=SiteId(447) ty=string intent=Read
+    stmt: use BindingId(39) detail site=SiteId(384) ty=string intent=Read
     _29 = call string::fmt(_9) -> bb22
   bb22:
     _30 = call string_concat(_28, _29) -> bb23
   bb23:
     call panic(_30) -> bb24
   bb24:
-    stmt: eval site=SiteId(440) ty=!
+    stmt: eval site=SiteId(377) ty=!
     goto bb10
 
 fn fs$try_read(string) -> Result<string, IoError> [conv=default]
@@ -1362,24 +1182,24 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
     _16: Result<string, IoError>
     _17: Result<string, IoError>
   bb0:
-    stmt: use BindingId(43) file_path site=SiteId(462) ty=string intent=Read
+    stmt: use BindingId(40) file_path site=SiteId(399) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(44) file site=SiteId(461) ty=FileReadStream
-    stmt: use BindingId(44) file site=SiteId(466) ty=FileReadStream intent=Read
+    stmt: bind BindingId(41) file site=SiteId(398) ty=FileReadStream
+    stmt: use BindingId(41) file site=SiteId(403) ty=FileReadStream intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(44) file site=SiteId(471) ty=FileReadStream intent=Read
+    stmt: use BindingId(41) file site=SiteId(408) ty=FileReadStream intent=Read
     _6 = const.i64 0
     mtag5 = move _6
     _7 = call hew_stream_collect_string(_2) -> bb6
   bb4:
     _9 = call hew_stream_last_errno() -> bb7
   bb5:
-    stmt: return site=Some(SiteId(460)) ty=Result<string, IoError>
+    stmt: return site=Some(SiteId(397)) ty=Result<string, IoError>
     _17 = move _3
     ret = move _17
     return
@@ -1389,12 +1209,12 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
     _3 = move _8
     goto bb5
   bb7:
-    stmt: bind BindingId(45) errno site=SiteId(474) ty=i32
+    stmt: bind BindingId(42) errno site=SiteId(411) ty=i32
     _10 = move _9
     _11 = call hew_stream_last_error() -> bb8
   bb8:
-    stmt: eval site=SiteId(476) ty=string
-    stmt: use BindingId(45) errno site=SiteId(481) ty=i32 intent=Read
+    stmt: eval site=SiteId(413) ty=string
+    stmt: use BindingId(42) errno site=SiteId(418) ty=i32 intent=Read
     _13 = const.i64 1
     mtag12 = move _13
     _14 = cast _10 i32 -> i64
@@ -1413,11 +1233,11 @@ fn fs$write(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(46) path site=SiteId(486) ty=string intent=Read
-    stmt: use BindingId(47) content site=SiteId(487) ty=string intent=Read
+    stmt: use BindingId(43) path site=SiteId(423) ty=string intent=Read
+    stmt: use BindingId(44) content site=SiteId(424) ty=string intent=Read
     _2 = call hew_file_write(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(483)) ty=i64
+    stmt: return site=Some(SiteId(420)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1439,14 +1259,14 @@ fn fs$try_write(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(48) file_path site=SiteId(492) ty=string intent=Read
-    stmt: use BindingId(49) content site=SiteId(493) ty=string intent=Read
+    stmt: use BindingId(45) file_path site=SiteId(429) ty=string intent=Read
+    stmt: use BindingId(46) content site=SiteId(430) ty=string intent=Read
     _3 = call hew_file_write(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(489)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(426)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1454,7 +1274,7 @@ fn fs$try_write(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(48) file_path site=SiteId(499) ty=string intent=Read
+    stmt: use BindingId(45) file_path site=SiteId(436) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$write_error(_0) -> bb7
@@ -1480,11 +1300,11 @@ fn fs$append(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(50) path site=SiteId(504) ty=string intent=Read
-    stmt: use BindingId(51) content site=SiteId(505) ty=string intent=Read
+    stmt: use BindingId(47) path site=SiteId(441) ty=string intent=Read
+    stmt: use BindingId(48) content site=SiteId(442) ty=string intent=Read
     _2 = call hew_file_append(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(501)) ty=i64
+    stmt: return site=Some(SiteId(438)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1506,14 +1326,14 @@ fn fs$try_append(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(52) file_path site=SiteId(510) ty=string intent=Read
-    stmt: use BindingId(53) content site=SiteId(511) ty=string intent=Read
+    stmt: use BindingId(49) file_path site=SiteId(447) ty=string intent=Read
+    stmt: use BindingId(50) content site=SiteId(448) ty=string intent=Read
     _3 = call hew_file_append(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(507)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(444)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1521,7 +1341,7 @@ fn fs$try_append(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(52) file_path site=SiteId(517) ty=string intent=Read
+    stmt: use BindingId(49) file_path site=SiteId(454) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$write_error(_0) -> bb7
@@ -1545,10 +1365,10 @@ fn fs$exists(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(54) path site=SiteId(521) ty=string intent=Read
+    stmt: use BindingId(51) path site=SiteId(458) ty=string intent=Read
     _1 = call hew_file_exists(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(519)) ty=bool
+    stmt: return site=Some(SiteId(456)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -1560,10 +1380,10 @@ fn fs$delete(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(55) path site=SiteId(526) ty=string intent=Read
+    stmt: use BindingId(52) path site=SiteId(463) ty=string intent=Read
     _1 = call hew_file_delete(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(523)) ty=i64
+    stmt: return site=Some(SiteId(460)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1584,13 +1404,13 @@ fn fs$try_delete(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(56) file_path site=SiteId(531) ty=string intent=Read
+    stmt: use BindingId(53) file_path site=SiteId(468) ty=string intent=Read
     _2 = call hew_file_delete(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(528)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(465)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1598,7 +1418,7 @@ fn fs$try_delete(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(56) file_path site=SiteId(537) ty=string intent=Read
+    stmt: use BindingId(53) file_path site=SiteId(474) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
     _11 = call fs$missing_path_error(_0) -> bb7
@@ -1622,10 +1442,10 @@ fn fs$size(string) -> i64 [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: use BindingId(57) path site=SiteId(541) ty=string intent=Read
+    stmt: use BindingId(54) path site=SiteId(478) ty=string intent=Read
     _1 = call hew_file_size(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(539)) ty=i64
+    stmt: return site=Some(SiteId(476)) ty=i64
     _2 = move _1
     ret = move _2
     return
@@ -1636,10 +1456,10 @@ fn fs$read_bytes(string) -> bytes [conv=default]
     _1: bytes
     _2: bytes
   bb0:
-    stmt: use BindingId(58) path site=SiteId(545) ty=string intent=Read
+    stmt: use BindingId(55) path site=SiteId(482) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(543)) ty=bytes
+    stmt: return site=Some(SiteId(480)) ty=bytes
     _2 = move _1
     ret = move _2
     return
@@ -1664,28 +1484,28 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _15: Result<bytes, IoError>
     _16: Result<bytes, IoError>
   bb0:
-    stmt: use BindingId(59) file_path site=SiteId(549) ty=string intent=Read
+    stmt: use BindingId(56) file_path site=SiteId(486) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
   bb1:
-    stmt: bind BindingId(60) data site=SiteId(548) ty=bytes
+    stmt: bind BindingId(57) data site=SiteId(485) ty=bytes
     _2 = move _1
     _3 = call hew_stream_last_errno() -> bb2
   bb2:
-    stmt: bind BindingId(61) errno site=SiteId(551) ty=i32
-    stmt: use BindingId(61) errno site=SiteId(555) ty=i32 intent=Read
+    stmt: bind BindingId(58) errno site=SiteId(488) ty=i32
+    stmt: use BindingId(58) errno site=SiteId(492) ty=i32 intent=Read
     _4 = move _3
     _6 = const.i64 0
     _7 = icmp.ne _4 _6
     branch _7 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(61) errno site=SiteId(561) ty=i32 intent=Read
+    stmt: use BindingId(58) errno site=SiteId(498) ty=i32 intent=Read
     _9 = const.i64 1
     mtag8 = move _9
     _10 = cast _4 i32 -> i64
     _11 = call fs$io_error_from_errno(_10) -> bb6
   bb4:
-    stmt: use BindingId(60) data site=SiteId(565) ty=bytes intent=Read
-    stmt: agg_alias BindingId(60) data site=SiteId(565) ty=bytes
+    stmt: use BindingId(57) data site=SiteId(502) ty=bytes intent=Read
+    stmt: agg_alias BindingId(57) data site=SiteId(502) ty=bytes
     _14 = const.i64 0
     mtag13 = move _14
     mvar13.0.0 = move _2
@@ -1693,7 +1513,7 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _5 = move _15
     goto bb5
   bb5:
-    stmt: return site=Some(SiteId(547)) ty=Result<bytes, IoError>
+    stmt: return site=Some(SiteId(484)) ty=Result<bytes, IoError>
     _16 = move _5
     ret = move _16
     return
@@ -1711,11 +1531,11 @@ fn fs$write_bytes(string, bytes) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(62) path site=SiteId(569) ty=string intent=Read
-    stmt: use BindingId(63) data site=SiteId(570) ty=bytes intent=Read
+    stmt: use BindingId(59) path site=SiteId(506) ty=string intent=Read
+    stmt: use BindingId(60) data site=SiteId(507) ty=bytes intent=Read
     _2 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(566)) ty=i64
+    stmt: return site=Some(SiteId(503)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1737,14 +1557,14 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(64) file_path site=SiteId(575) ty=string intent=Read
-    stmt: use BindingId(65) data site=SiteId(576) ty=bytes intent=Read
+    stmt: use BindingId(61) file_path site=SiteId(512) ty=string intent=Read
+    stmt: use BindingId(62) data site=SiteId(513) ty=bytes intent=Read
     _3 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(572)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(509)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1752,7 +1572,7 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(64) file_path site=SiteId(582) ty=string intent=Read
+    stmt: use BindingId(61) file_path site=SiteId(519) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$write_error(_0) -> bb7
@@ -1777,10 +1597,10 @@ fn fs$mkdir(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(66) path site=SiteId(587) ty=string intent=Read
+    stmt: use BindingId(63) path site=SiteId(524) ty=string intent=Read
     _1 = call hew_fs_mkdir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(584)) ty=i64
+    stmt: return site=Some(SiteId(521)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1801,13 +1621,13 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(67) dir_path site=SiteId(592) ty=string intent=Read
+    stmt: use BindingId(64) dir_path site=SiteId(529) ty=string intent=Read
     _2 = call hew_fs_mkdir(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(589)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(526)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1815,7 +1635,7 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(67) dir_path site=SiteId(598) ty=string intent=Read
+    stmt: use BindingId(64) dir_path site=SiteId(535) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
     _11 = call fs$mkdir_error(_0) -> bb7
@@ -1840,10 +1660,10 @@ fn fs$mkdir_all(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(68) path site=SiteId(603) ty=string intent=Read
+    stmt: use BindingId(65) path site=SiteId(540) ty=string intent=Read
     _1 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(600)) ty=i64
+    stmt: return site=Some(SiteId(537)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1876,13 +1696,13 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _22: Result<i64, IoError>
     _23: Result<i64, IoError>
   bb0:
-    stmt: use BindingId(69) dir_path site=SiteId(608) ty=string intent=Read
+    stmt: use BindingId(66) dir_path site=SiteId(545) ty=string intent=Read
     _2 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(605)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(542)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1890,7 +1710,7 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(69) dir_path site=SiteId(615) ty=string intent=Read
+    stmt: use BindingId(66) dir_path site=SiteId(552) ty=string intent=Read
     _10 = call fs$exists(_0) -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
@@ -1917,10 +1737,10 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
   bb9:
     _18 = const.i64 1
     mtag17 = move _18
-    _20 = const.i64 8
+    _20 = const.i64 5
     mtag19 = move _20
     _21 = const.i64 0
-    mvar19.8.0 = move _21
+    mvar19.5.0 = move _21
     mvar17.1.0 = move _19
     _22 = move _17
     _9 = move _22
@@ -1936,10 +1756,10 @@ fn fs$list_dir(string) -> Vec<string> [conv=default]
     _1: Vec<string>
     _2: Vec<string>
   bb0:
-    stmt: use BindingId(70) path site=SiteId(627) ty=string intent=Read
+    stmt: use BindingId(67) path site=SiteId(564) ty=string intent=Read
     _1 = call hew_fs_list_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(625)) ty=Vec<string>
+    stmt: return site=Some(SiteId(562)) ty=Vec<string>
     _2 = move _1
     ret = move _2
     return
@@ -1968,13 +1788,13 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
     _19: Vec<string>
     _20: Vec<string>
   bb0:
-    stmt: use BindingId(71) dir_path site=SiteId(631) ty=string intent=Read
+    stmt: use BindingId(68) dir_path site=SiteId(568) ty=string intent=Read
     _2 = call fs$exists(_0) -> bb1
   bb1:
     _3 = not _2
     branch _3 ? bb2 : bb3
   bb2:
-    stmt: return site=Some(SiteId(633)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(570)) ty=Result<Vec<string>, IoError>
     _5 = const.i64 1
     mtag4 = move _5
     _7 = const.i64 0
@@ -1987,8 +1807,8 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   bb3:
     goto bb4
   bb4:
-    stmt: eval site=SiteId(637) ty=()
-    stmt: use BindingId(71) dir_path site=SiteId(640) ty=string intent=Read
+    stmt: eval site=SiteId(574) ty=()
+    stmt: use BindingId(68) dir_path site=SiteId(577) ty=string intent=Read
     _10 = call fs$is_dir(_0) -> bb6
   bb5:
     goto bb4
@@ -1996,28 +1816,28 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
     _11 = not _10
     branch _11 ? bb7 : bb8
   bb7:
-    stmt: return site=Some(SiteId(642)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(579)) ty=Result<Vec<string>, IoError>
     _13 = const.i64 1
     mtag12 = move _13
-    _15 = const.i64 8
+    _15 = const.i64 5
     mtag14 = move _15
     _16 = const.i64 0
-    mvar14.8.0 = move _16
+    mvar14.5.0 = move _16
     mvar12.1.0 = move _14
     ret = move _12
     return
   bb8:
     goto bb9
   bb9:
-    stmt: eval site=SiteId(646) ty=()
-    stmt: use BindingId(71) dir_path site=SiteId(650) ty=string intent=Read
+    stmt: eval site=SiteId(583) ty=()
+    stmt: use BindingId(68) dir_path site=SiteId(587) ty=string intent=Read
     _18 = const.i64 0
     mtag17 = move _18
     _19 = call hew_fs_list_dir(_0) -> bb11
   bb10:
     goto bb9
   bb11:
-    stmt: return site=Some(SiteId(647)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(584)) ty=Result<Vec<string>, IoError>
     _20 = move _19
     mvar17.0.0 = move _20
     ret = move _17
@@ -2031,11 +1851,11 @@ fn fs$rename(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(72) from site=SiteId(655) ty=string intent=Read
-    stmt: use BindingId(73) to site=SiteId(656) ty=string intent=Read
+    stmt: use BindingId(69) from site=SiteId(592) ty=string intent=Read
+    stmt: use BindingId(70) to site=SiteId(593) ty=string intent=Read
     _2 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(652)) ty=i64
+    stmt: return site=Some(SiteId(589)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -2057,14 +1877,14 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(74) from site=SiteId(661) ty=string intent=Read
-    stmt: use BindingId(75) to site=SiteId(662) ty=string intent=Read
+    stmt: use BindingId(71) from site=SiteId(598) ty=string intent=Read
+    stmt: use BindingId(72) to site=SiteId(599) ty=string intent=Read
     _3 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(658)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(595)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -2072,8 +1892,8 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(74) from site=SiteId(668) ty=string intent=Read
-    stmt: use BindingId(75) to site=SiteId(669) ty=string intent=Read
+    stmt: use BindingId(71) from site=SiteId(605) ty=string intent=Read
+    stmt: use BindingId(72) to site=SiteId(606) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$move_copy_error(_0, _1) -> bb7
@@ -2099,11 +1919,11 @@ fn fs$copy(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(76) from site=SiteId(674) ty=string intent=Read
-    stmt: use BindingId(77) to site=SiteId(675) ty=string intent=Read
+    stmt: use BindingId(73) from site=SiteId(611) ty=string intent=Read
+    stmt: use BindingId(74) to site=SiteId(612) ty=string intent=Read
     _2 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(671)) ty=i64
+    stmt: return site=Some(SiteId(608)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -2125,14 +1945,14 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(78) from site=SiteId(680) ty=string intent=Read
-    stmt: use BindingId(79) to site=SiteId(681) ty=string intent=Read
+    stmt: use BindingId(75) from site=SiteId(617) ty=string intent=Read
+    stmt: use BindingId(76) to site=SiteId(618) ty=string intent=Read
     _3 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(677)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(614)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -2140,8 +1960,8 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(78) from site=SiteId(687) ty=string intent=Read
-    stmt: use BindingId(79) to site=SiteId(688) ty=string intent=Read
+    stmt: use BindingId(75) from site=SiteId(624) ty=string intent=Read
+    stmt: use BindingId(76) to site=SiteId(625) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$move_copy_error(_0, _1) -> bb7
@@ -2165,10 +1985,10 @@ fn fs$is_dir(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(80) path site=SiteId(692) ty=string intent=Read
+    stmt: use BindingId(77) path site=SiteId(629) ty=string intent=Read
     _1 = call hew_fs_is_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(690)) ty=bool
+    stmt: return site=Some(SiteId(627)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -2186,31 +2006,31 @@ fn stream$pipe(i64) -> (Sink<string>, Stream<string>) [conv=default]
     _8: (Sink<string>, Stream<string>)
     _9: (Sink<string>, Stream<string>)
   bb0:
-    stmt: use BindingId(81) capacity site=SiteId(697) ty=i64 intent=Read
+    stmt: use BindingId(78) capacity site=SiteId(634) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(82) pair site=SiteId(695) ty=StreamPair
-    stmt: use BindingId(82) pair site=SiteId(700) ty=StreamPair intent=Read
+    stmt: bind BindingId(79) pair site=SiteId(632) ty=StreamPair
+    stmt: use BindingId(79) pair site=SiteId(637) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink(_3) -> bb2
   bb2:
-    stmt: bind BindingId(83) sink site=SiteId(699) ty=Sink<string>
-    stmt: use BindingId(82) pair site=SiteId(703) ty=StreamPair intent=Read
+    stmt: bind BindingId(80) sink site=SiteId(636) ty=Sink<string>
+    stmt: use BindingId(79) pair site=SiteId(640) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream(_3) -> bb3
   bb3:
-    stmt: bind BindingId(84) input site=SiteId(702) ty=Stream<string>
-    stmt: use BindingId(82) pair site=SiteId(706) ty=StreamPair intent=Read
+    stmt: bind BindingId(81) input site=SiteId(639) ty=Stream<string>
+    stmt: use BindingId(79) pair site=SiteId(643) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(705) ty=()
-    stmt: use BindingId(83) sink site=SiteId(709) ty=Sink<string> intent=Read
-    stmt: use BindingId(84) input site=SiteId(710) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(83) sink site=SiteId(709) ty=Sink<string>
-    stmt: agg_alias BindingId(84) input site=SiteId(710) ty=Stream<string>
-    stmt: return site=Some(SiteId(694)) ty=(Sink<string>, Stream<string>)
+    stmt: eval site=SiteId(642) ty=()
+    stmt: use BindingId(80) sink site=SiteId(646) ty=Sink<string> intent=Read
+    stmt: use BindingId(81) input site=SiteId(647) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(80) sink site=SiteId(646) ty=Sink<string>
+    stmt: agg_alias BindingId(81) input site=SiteId(647) ty=Stream<string>
+    stmt: return site=Some(SiteId(631)) ty=(Sink<string>, Stream<string>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2229,31 +2049,31 @@ fn stream$bytes_pipe(i64) -> (Sink<bytes>, Stream<bytes>) [conv=default]
     _8: (Sink<bytes>, Stream<bytes>)
     _9: (Sink<bytes>, Stream<bytes>)
   bb0:
-    stmt: use BindingId(85) capacity site=SiteId(714) ty=i64 intent=Read
+    stmt: use BindingId(82) capacity site=SiteId(651) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(86) pair site=SiteId(712) ty=StreamPair
-    stmt: use BindingId(86) pair site=SiteId(717) ty=StreamPair intent=Read
+    stmt: bind BindingId(83) pair site=SiteId(649) ty=StreamPair
+    stmt: use BindingId(83) pair site=SiteId(654) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink_bytes(_3) -> bb2
   bb2:
-    stmt: bind BindingId(87) sink site=SiteId(716) ty=Sink<bytes>
-    stmt: use BindingId(86) pair site=SiteId(720) ty=StreamPair intent=Read
+    stmt: bind BindingId(84) sink site=SiteId(653) ty=Sink<bytes>
+    stmt: use BindingId(83) pair site=SiteId(657) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream_bytes(_3) -> bb3
   bb3:
-    stmt: bind BindingId(88) input site=SiteId(719) ty=Stream<bytes>
-    stmt: use BindingId(86) pair site=SiteId(723) ty=StreamPair intent=Read
+    stmt: bind BindingId(85) input site=SiteId(656) ty=Stream<bytes>
+    stmt: use BindingId(83) pair site=SiteId(660) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(722) ty=()
-    stmt: use BindingId(87) sink site=SiteId(726) ty=Sink<bytes> intent=Read
-    stmt: use BindingId(88) input site=SiteId(727) ty=Stream<bytes> intent=Read
-    stmt: agg_alias BindingId(87) sink site=SiteId(726) ty=Sink<bytes>
-    stmt: agg_alias BindingId(88) input site=SiteId(727) ty=Stream<bytes>
-    stmt: return site=Some(SiteId(711)) ty=(Sink<bytes>, Stream<bytes>)
+    stmt: eval site=SiteId(659) ty=()
+    stmt: use BindingId(84) sink site=SiteId(663) ty=Sink<bytes> intent=Read
+    stmt: use BindingId(85) input site=SiteId(664) ty=Stream<bytes> intent=Read
+    stmt: agg_alias BindingId(84) sink site=SiteId(663) ty=Sink<bytes>
+    stmt: agg_alias BindingId(85) input site=SiteId(664) ty=Stream<bytes>
+    stmt: return site=Some(SiteId(648)) ty=(Sink<bytes>, Stream<bytes>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2275,18 +2095,18 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     _11: Result<Stream<string>, string>
     _12: Result<Stream<string>, string>
   bb0:
-    stmt: use BindingId(89) path site=SiteId(730) ty=string intent=Read
+    stmt: use BindingId(86) path site=SiteId(667) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(90) s site=SiteId(729) ty=Stream<string>
-    stmt: use BindingId(90) s site=SiteId(734) ty=Stream<string> intent=Read
+    stmt: bind BindingId(87) s site=SiteId(666) ty=Stream<string>
+    stmt: use BindingId(87) s site=SiteId(671) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(90) s site=SiteId(738) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(90) s site=SiteId(738) ty=Stream<string>
+    stmt: use BindingId(87) s site=SiteId(675) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(87) s site=SiteId(675) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2298,7 +2118,7 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(728)) ty=Result<Stream<string>, string>
+    stmt: return site=Some(SiteId(665)) ty=Result<Stream<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2328,18 +2148,18 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _15: Result<Stream<string>, fs.IoError>
     _16: Result<Stream<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(91) path site=SiteId(745) ty=string intent=Read
+    stmt: use BindingId(88) path site=SiteId(682) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(92) s site=SiteId(744) ty=Stream<string>
-    stmt: use BindingId(92) s site=SiteId(749) ty=Stream<string> intent=Read
+    stmt: bind BindingId(89) s site=SiteId(681) ty=Stream<string>
+    stmt: use BindingId(89) s site=SiteId(686) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(92) s site=SiteId(753) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(92) s site=SiteId(753) ty=Stream<string>
+    stmt: use BindingId(89) s site=SiteId(690) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(89) s site=SiteId(690) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2349,17 +2169,17 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
   bb4:
     _8 = call hew_stream_last_errno() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(743)) ty=Result<Stream<string>, fs.IoError>
+    stmt: return site=Some(SiteId(680)) ty=Result<Stream<string>, fs.IoError>
     _16 = move _3
     ret = move _16
     return
   bb6:
-    stmt: bind BindingId(93) errno site=SiteId(755) ty=i32
+    stmt: bind BindingId(90) errno site=SiteId(692) ty=i32
     _9 = move _8
     _10 = call hew_stream_last_error() -> bb7
   bb7:
-    stmt: eval site=SiteId(757) ty=string
-    stmt: use BindingId(93) errno site=SiteId(762) ty=i32 intent=Read
+    stmt: eval site=SiteId(694) ty=string
+    stmt: use BindingId(90) errno site=SiteId(699) ty=i32 intent=Read
     _12 = const.i64 1
     mtag11 = move _12
     _13 = cast _9 i32 -> i64
@@ -2386,18 +2206,18 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     _11: Result<Sink<string>, string>
     _12: Result<Sink<string>, string>
   bb0:
-    stmt: use BindingId(94) path site=SiteId(766) ty=string intent=Read
+    stmt: use BindingId(91) path site=SiteId(703) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(95) s site=SiteId(765) ty=Sink<string>
-    stmt: use BindingId(95) s site=SiteId(770) ty=Sink<string> intent=Read
+    stmt: bind BindingId(92) s site=SiteId(702) ty=Sink<string>
+    stmt: use BindingId(92) s site=SiteId(707) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(95) s site=SiteId(774) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(95) s site=SiteId(774) ty=Sink<string>
+    stmt: use BindingId(92) s site=SiteId(711) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(92) s site=SiteId(711) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2409,7 +2229,7 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(764)) ty=Result<Sink<string>, string>
+    stmt: return site=Some(SiteId(701)) ty=Result<Sink<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2439,18 +2259,18 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _15: Result<Sink<string>, fs.IoError>
     _16: Result<Sink<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(96) path site=SiteId(781) ty=string intent=Read
+    stmt: use BindingId(93) path site=SiteId(718) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(97) s site=SiteId(780) ty=Sink<string>
-    stmt: use BindingId(97) s site=SiteId(785) ty=Sink<string> intent=Read
+    stmt: bind BindingId(94) s site=SiteId(717) ty=Sink<string>
+    stmt: use BindingId(94) s site=SiteId(722) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(97) s site=SiteId(789) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(97) s site=SiteId(789) ty=Sink<string>
+    stmt: use BindingId(94) s site=SiteId(726) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(94) s site=SiteId(726) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2460,17 +2280,17 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
   bb4:
     _8 = call hew_stream_last_errno() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(779)) ty=Result<Sink<string>, fs.IoError>
+    stmt: return site=Some(SiteId(716)) ty=Result<Sink<string>, fs.IoError>
     _16 = move _3
     ret = move _16
     return
   bb6:
-    stmt: bind BindingId(98) errno site=SiteId(791) ty=i32
+    stmt: bind BindingId(95) errno site=SiteId(728) ty=i32
     _9 = move _8
     _10 = call hew_stream_last_error() -> bb7
   bb7:
-    stmt: eval site=SiteId(793) ty=string
-    stmt: use BindingId(98) errno site=SiteId(798) ty=i32 intent=Read
+    stmt: eval site=SiteId(730) ty=string
+    stmt: use BindingId(95) errno site=SiteId(735) ty=i32 intent=Read
     _12 = const.i64 1
     mtag11 = move _12
     _13 = cast _9 i32 -> i64
@@ -2486,11 +2306,11 @@ fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
     _0: Stream<string>
     _1: Sink<string>
   bb0:
-    stmt: use BindingId(99) source site=SiteId(802) ty=Stream<string> intent=Read
-    stmt: use BindingId(100) dest site=SiteId(803) ty=Sink<string> intent=Read
+    stmt: use BindingId(96) source site=SiteId(739) ty=Stream<string> intent=Read
+    stmt: use BindingId(97) dest site=SiteId(740) ty=Sink<string> intent=Read
     call hew_stream_pipe(_0, _1) -> bb1
   bb1:
-    stmt: eval site=SiteId(800) ty=()
+    stmt: eval site=SiteId(737) ty=()
     return
 
 fn i32::fmt(i32) -> string [conv=default]
@@ -2498,10 +2318,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(104) val site=SiteId(834) ty=i32 intent=Read
+    stmt: use BindingId(101) val site=SiteId(771) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(833)) ty=string
+    stmt: return site=Some(SiteId(770)) ty=string
     ret = move _1
     return
 
@@ -2510,10 +2330,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(105) val site=SiteId(837) ty=i64 intent=Read
+    stmt: use BindingId(102) val site=SiteId(774) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(836)) ty=string
+    stmt: return site=Some(SiteId(773)) ty=string
     ret = move _1
     return
 
@@ -2522,10 +2342,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(106) val site=SiteId(840) ty=u32 intent=Read
+    stmt: use BindingId(103) val site=SiteId(777) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(839)) ty=string
+    stmt: return site=Some(SiteId(776)) ty=string
     ret = move _1
     return
 
@@ -2534,10 +2354,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(107) val site=SiteId(843) ty=u64 intent=Read
+    stmt: use BindingId(104) val site=SiteId(780) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(842)) ty=string
+    stmt: return site=Some(SiteId(779)) ty=string
     ret = move _1
     return
 
@@ -2546,10 +2366,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(108) val site=SiteId(846) ty=bool intent=Read
+    stmt: use BindingId(105) val site=SiteId(783) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(845)) ty=string
+    stmt: return site=Some(SiteId(782)) ty=string
     ret = move _1
     return
 
@@ -2558,10 +2378,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(109) val site=SiteId(849) ty=char intent=Read
+    stmt: use BindingId(106) val site=SiteId(786) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(848)) ty=string
+    stmt: return site=Some(SiteId(785)) ty=string
     ret = move _1
     return
 
@@ -2570,10 +2390,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(110) val site=SiteId(852) ty=f64 intent=Read
+    stmt: use BindingId(107) val site=SiteId(789) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(851)) ty=string
+    stmt: return site=Some(SiteId(788)) ty=string
     ret = move _1
     return
 
@@ -2581,8 +2401,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(111) val site=SiteId(854) ty=string intent=Read
-    stmt: return site=Some(SiteId(854)) ty=string
+    stmt: use BindingId(108) val site=SiteId(791) ty=string intent=Read
+    stmt: return site=Some(SiteId(791)) ty=string
     ret = move _0
     return
 

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.elab.mir
@@ -56,16 +56,7 @@ fn fs$io_error_from_errno -> IoError
     use BindingId(6) errno site=SiteId(59) ty=i64 intent=Read
     use BindingId(6) errno site=SiteId(62) ty=i64 intent=Read
     use BindingId(6) errno site=SiteId(66) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(70) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(73) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(77) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(81) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(84) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(88) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(92) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(95) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(99) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(102) ty=i64 intent=Read
+    use BindingId(6) errno site=SiteId(69) ty=i64 intent=Read
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -111,113 +102,75 @@ fn fs$io_error_from_errno -> IoError
       (none)
     goto[bb17->bb19] ->
       (none)
-    branch[bb18: bb21/bb20] ->
+    goto[bb18->bb19] ->
       (none)
     goto[bb19->bb14] ->
       (none)
     cancel[bb19] ->
       (none)
-    goto[bb20->bb21] ->
-      (none)
-    branch[bb21: bb22/bb23] ->
-      (none)
-    goto[bb22->bb24] ->
-      (none)
-    branch[bb23: bb26/bb25] ->
-      (none)
-    goto[bb24->bb19] ->
-      (none)
-    cancel[bb24] ->
-      (none)
-    goto[bb25->bb26] ->
-      (none)
-    branch[bb26: bb27/bb28] ->
-      (none)
-    goto[bb27->bb29] ->
-      (none)
-    branch[bb28: bb31/bb30] ->
-      (none)
-    goto[bb29->bb24] ->
-      (none)
-    cancel[bb29] ->
-      (none)
-    goto[bb30->bb31] ->
-      (none)
-    branch[bb31: bb32/bb33] ->
-      (none)
-    goto[bb32->bb34] ->
-      (none)
-    goto[bb33->bb34] ->
-      (none)
-    goto[bb34->bb29] ->
-      (none)
-    cancel[bb34] ->
-      (none)
 
 fn fs$io_error_message -> string
   statements:
-    use BindingId(7) e site=SiteId(104) ty=IoError intent=Read
-    return site=Some(SiteId(103)) ty=string
-    bind BindingId(8) code site=SiteId(105) ty=i64
-    use BindingId(8) code site=SiteId(107) ty=i64 intent=Read
-    bind BindingId(9) code site=SiteId(115) ty=i64
-    use BindingId(9) code site=SiteId(117) ty=i64 intent=Read
-    bind BindingId(10) code site=SiteId(125) ty=i64
-    use BindingId(10) code site=SiteId(127) ty=i64 intent=Read
-    bind BindingId(11) code site=SiteId(135) ty=i64
-    use BindingId(11) code site=SiteId(137) ty=i64 intent=Read
-    bind BindingId(12) code site=SiteId(145) ty=i64
-    use BindingId(12) code site=SiteId(147) ty=i64 intent=Read
-    bind BindingId(13) code site=SiteId(155) ty=i64
-    use BindingId(13) code site=SiteId(157) ty=i64 intent=Read
-    bind BindingId(14) code site=SiteId(165) ty=i64
-    use BindingId(14) code site=SiteId(167) ty=i64 intent=Read
-    bind BindingId(15) code site=SiteId(175) ty=i64
-    use BindingId(15) code site=SiteId(177) ty=i64 intent=Read
-    bind BindingId(16) code site=SiteId(185) ty=i64
-    use BindingId(16) code site=SiteId(187) ty=i64 intent=Read
+    use BindingId(7) e site=SiteId(71) ty=IoError intent=Read
+    return site=Some(SiteId(70)) ty=string
+    bind BindingId(8) code site=SiteId(72) ty=i64
+    use BindingId(8) code site=SiteId(74) ty=i64 intent=Read
+    bind BindingId(9) code site=SiteId(82) ty=i64
+    use BindingId(9) code site=SiteId(84) ty=i64 intent=Read
+    bind BindingId(10) code site=SiteId(92) ty=i64
+    use BindingId(10) code site=SiteId(94) ty=i64 intent=Read
+    bind BindingId(11) code site=SiteId(102) ty=i64
+    use BindingId(11) code site=SiteId(104) ty=i64 intent=Read
+    bind BindingId(12) code site=SiteId(112) ty=i64
+    use BindingId(12) code site=SiteId(114) ty=i64 intent=Read
+    bind BindingId(13) code site=SiteId(122) ty=i64
+    use BindingId(13) code site=SiteId(124) ty=i64 intent=Read
   drop_plans:
-    branch[bb0: bb2/bb12] ->
+    branch[bb0: bb2/bb9] ->
       (none)
     cancel[bb0] ->
       (none)
     return[bb1] ->
       (none)
-    call[bb2 to_string_i64 -> bb20] ->
+    call[bb2 to_string_i64 -> bb14] ->
       (none)
-    call[bb3 to_string_i64 -> bb23] ->
+    call[bb3 to_string_i64 -> bb17] ->
       (none)
-    call[bb4 to_string_i64 -> bb26] ->
+    call[bb4 to_string_i64 -> bb20] ->
       (none)
-    call[bb5 to_string_i64 -> bb29] ->
+    call[bb5 to_string_i64 -> bb23] ->
       (none)
-    call[bb6 to_string_i64 -> bb32] ->
+    call[bb6 to_string_i64 -> bb26] ->
       (none)
-    call[bb7 to_string_i64 -> bb35] ->
+    call[bb7 to_string_i64 -> bb29] ->
       (none)
-    call[bb8 to_string_i64 -> bb38] ->
+    panic[bb8] ->
       (none)
-    call[bb9 to_string_i64 -> bb41] ->
+    branch[bb9: bb3/bb10] ->
       (none)
-    call[bb10 to_string_i64 -> bb44] ->
+    branch[bb10: bb4/bb11] ->
       (none)
-    panic[bb11] ->
+    branch[bb11: bb5/bb12] ->
       (none)
-    branch[bb12: bb3/bb13] ->
+    branch[bb12: bb6/bb13] ->
       (none)
-    branch[bb13: bb4/bb14] ->
+    branch[bb13: bb7/bb8] ->
       (none)
-    branch[bb14: bb5/bb15] ->
+    call[bb14 string_concat -> bb15] ->
       (none)
-    branch[bb15: bb6/bb16] ->
+    call[bb15 string_concat -> bb16] ->
       (none)
-    branch[bb16: bb7/bb17] ->
+    goto[bb16->bb1] ->
       (none)
-    branch[bb17: bb8/bb18] ->
+    cancel[bb16] ->
       (none)
-    branch[bb18: bb9/bb19] ->
+    call[bb17 string_concat -> bb18] ->
       (none)
-    branch[bb19: bb10/bb11] ->
+    call[bb18 string_concat -> bb19] ->
+      (none)
+    goto[bb19->bb1] ->
+      (none)
+    cancel[bb19] ->
       (none)
     call[bb20 string_concat -> bb21] ->
       (none)
@@ -251,69 +204,29 @@ fn fs$io_error_message -> string
       (none)
     cancel[bb31] ->
       (none)
-    call[bb32 string_concat -> bb33] ->
-      (none)
-    call[bb33 string_concat -> bb34] ->
-      (none)
-    goto[bb34->bb1] ->
-      (none)
-    cancel[bb34] ->
-      (none)
-    call[bb35 string_concat -> bb36] ->
-      (none)
-    call[bb36 string_concat -> bb37] ->
-      (none)
-    goto[bb37->bb1] ->
-      (none)
-    cancel[bb37] ->
-      (none)
-    call[bb38 string_concat -> bb39] ->
-      (none)
-    call[bb39 string_concat -> bb40] ->
-      (none)
-    goto[bb40->bb1] ->
-      (none)
-    cancel[bb40] ->
-      (none)
-    call[bb41 string_concat -> bb42] ->
-      (none)
-    call[bb42 string_concat -> bb43] ->
-      (none)
-    goto[bb43->bb1] ->
-      (none)
-    cancel[bb43] ->
-      (none)
-    call[bb44 string_concat -> bb45] ->
-      (none)
-    call[bb45 string_concat -> bb46] ->
-      (none)
-    goto[bb46->bb1] ->
-      (none)
-    cancel[bb46] ->
-      (none)
 
 fn fs$io_error_timed_out -> IoError
   statements:
-    return site=Some(SiteId(195)) ty=IoError
+    return site=Some(SiteId(132)) ty=IoError
   drop_plans:
     return[bb0] ->
       (none)
 
 fn fs$io_error_cancelled -> IoError
   statements:
-    return site=Some(SiteId(197)) ty=IoError
+    return site=Some(SiteId(134)) ty=IoError
   drop_plans:
     return[bb0] ->
       (none)
 
 fn fs$missing_parent -> bool
   statements:
-    use BindingId(17) target site=SiteId(200) ty=string intent=Read
-    bind BindingId(18) parent site=SiteId(199) ty=string
-    use BindingId(18) parent site=SiteId(204) ty=string intent=Read
-    use BindingId(18) parent site=SiteId(208) ty=string intent=Read
-    return site=Some(SiteId(202)) ty=bool
-    drop BindingId(18) parent ty=string
+    use BindingId(14) target site=SiteId(137) ty=string intent=Read
+    bind BindingId(15) parent site=SiteId(136) ty=string
+    use BindingId(15) parent site=SiteId(141) ty=string intent=Read
+    use BindingId(15) parent site=SiteId(145) ty=string intent=Read
+    return site=Some(SiteId(139)) ty=bool
+    drop BindingId(15) parent ty=string
   drop_plans:
     call[bb0 fs$dirname -> bb1] ->
       (none)
@@ -332,20 +245,20 @@ fn fs$missing_parent -> bool
 
 fn fs$dirname -> string
   statements:
-    use BindingId(19) p site=SiteId(211) ty=string intent=Read
-    bind BindingId(20) s site=SiteId(210) ty=string
-    use BindingId(20) s site=SiteId(214) ty=string intent=Read
-    bind BindingId(21) pos site=SiteId(213) ty=i64
-    use BindingId(21) pos site=SiteId(217) ty=i64 intent=Read
-    return site=Some(SiteId(219)) ty=string
-    eval site=SiteId(221) ty=()
-    use BindingId(21) pos site=SiteId(223) ty=i64 intent=Read
-    return site=Some(SiteId(225)) ty=string
-    eval site=SiteId(227) ty=()
-    use BindingId(20) s site=SiteId(229) ty=string intent=Read
-    use BindingId(21) pos site=SiteId(231) ty=i64 intent=Read
-    return site=Some(SiteId(228)) ty=string
-    drop BindingId(20) s ty=string
+    use BindingId(16) p site=SiteId(148) ty=string intent=Read
+    bind BindingId(17) s site=SiteId(147) ty=string
+    use BindingId(17) s site=SiteId(151) ty=string intent=Read
+    bind BindingId(18) pos site=SiteId(150) ty=i64
+    use BindingId(18) pos site=SiteId(154) ty=i64 intent=Read
+    return site=Some(SiteId(156)) ty=string
+    eval site=SiteId(158) ty=()
+    use BindingId(18) pos site=SiteId(160) ty=i64 intent=Read
+    return site=Some(SiteId(162)) ty=string
+    eval site=SiteId(164) ty=()
+    use BindingId(17) s site=SiteId(166) ty=string intent=Read
+    use BindingId(18) pos site=SiteId(168) ty=i64 intent=Read
+    return site=Some(SiteId(165)) ty=string
+    drop BindingId(17) s ty=string
   drop_plans:
     call[bb0 fs$strip_trailing_slash -> bb1] ->
       (none)
@@ -380,18 +293,18 @@ fn fs$dirname -> string
 
 fn fs$strip_trailing_slash -> string
   statements:
-    use BindingId(22) p site=SiteId(234) ty=string intent=Read
-    use BindingId(22) p site=SiteId(238) ty=string intent=Read
-    return site=Some(SiteId(236)) ty=string
-    eval site=SiteId(240) ty=()
-    use BindingId(22) p site=SiteId(244) ty=string intent=Read
-    use BindingId(22) p site=SiteId(248) ty=string intent=Read
-    use BindingId(22) p site=SiteId(252) ty=string intent=Read
-    use BindingId(22) p site=SiteId(256) ty=string intent=Read
-    eval site=SiteId(261) ty=()
-    use BindingId(22) p site=SiteId(264) ty=string intent=Read
-    return site=Some(SiteId(262)) ty=string
-    return site=Some(SiteId(251)) ty=string
+    use BindingId(19) p site=SiteId(171) ty=string intent=Read
+    use BindingId(19) p site=SiteId(175) ty=string intent=Read
+    return site=Some(SiteId(173)) ty=string
+    eval site=SiteId(177) ty=()
+    use BindingId(19) p site=SiteId(181) ty=string intent=Read
+    use BindingId(19) p site=SiteId(185) ty=string intent=Read
+    use BindingId(19) p site=SiteId(189) ty=string intent=Read
+    use BindingId(19) p site=SiteId(193) ty=string intent=Read
+    eval site=SiteId(198) ty=()
+    use BindingId(19) p site=SiteId(201) ty=string intent=Read
+    return site=Some(SiteId(199)) ty=string
+    return site=Some(SiteId(188)) ty=string
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -438,36 +351,36 @@ fn fs$strip_trailing_slash -> string
 
 fn fs$last_slash_pos -> i64
   statements:
-    use BindingId(23) s site=SiteId(266) ty=string intent=Read
-    bind BindingId(24) first site=SiteId(265) ty=i64
-    use BindingId(24) first site=SiteId(270) ty=i64 intent=Read
-    eval site=SiteId(275) ty=()
-    use BindingId(24) first site=SiteId(276) ty=i64 intent=Consume
-    bind BindingId(25) last site=SiteId(276) ty=i64
-    use BindingId(24) first site=SiteId(278) ty=i64 intent=Read
-    return site=Some(SiteId(272)) ty=i64
-    bind BindingId(26) search_from site=SiteId(277) ty=i64
-    use BindingId(26) search_from site=SiteId(281) ty=i64 intent=Read
-    use BindingId(23) s site=SiteId(283) ty=string intent=Read
-    use BindingId(23) s site=SiteId(286) ty=string intent=Read
-    use BindingId(26) search_from site=SiteId(287) ty=i64 intent=Read
-    use BindingId(23) s site=SiteId(289) ty=string intent=Read
-    eval site=SiteId(310) ty=()
-    use BindingId(25) last site=SiteId(311) ty=i64 intent=Read
-    return site=Some(SiteId(311)) ty=i64
-    bind BindingId(27) rest site=SiteId(285) ty=string
-    use BindingId(27) rest site=SiteId(293) ty=string intent=Read
-    bind BindingId(28) next site=SiteId(292) ty=i64
-    use BindingId(28) next site=SiteId(297) ty=i64 intent=Read
-    use BindingId(25) last site=SiteId(299) ty=i64 intent=Consume
-    return site=Some(SiteId(299)) ty=i64
-    eval site=SiteId(301) ty=()
-    use BindingId(26) search_from site=SiteId(304) ty=i64 intent=Read
-    use BindingId(28) next site=SiteId(305) ty=i64 intent=Read
-    eval site=SiteId(303) ty=()
-    use BindingId(25) last site=SiteId(308) ty=i64 intent=Read
-    eval site=SiteId(307) ty=()
-    drop BindingId(27) rest ty=string
+    use BindingId(20) s site=SiteId(203) ty=string intent=Read
+    bind BindingId(21) first site=SiteId(202) ty=i64
+    use BindingId(21) first site=SiteId(207) ty=i64 intent=Read
+    eval site=SiteId(212) ty=()
+    use BindingId(21) first site=SiteId(213) ty=i64 intent=Consume
+    bind BindingId(22) last site=SiteId(213) ty=i64
+    use BindingId(21) first site=SiteId(215) ty=i64 intent=Read
+    return site=Some(SiteId(209)) ty=i64
+    bind BindingId(23) search_from site=SiteId(214) ty=i64
+    use BindingId(23) search_from site=SiteId(218) ty=i64 intent=Read
+    use BindingId(20) s site=SiteId(220) ty=string intent=Read
+    use BindingId(20) s site=SiteId(223) ty=string intent=Read
+    use BindingId(23) search_from site=SiteId(224) ty=i64 intent=Read
+    use BindingId(20) s site=SiteId(226) ty=string intent=Read
+    eval site=SiteId(247) ty=()
+    use BindingId(22) last site=SiteId(248) ty=i64 intent=Read
+    return site=Some(SiteId(248)) ty=i64
+    bind BindingId(24) rest site=SiteId(222) ty=string
+    use BindingId(24) rest site=SiteId(230) ty=string intent=Read
+    bind BindingId(25) next site=SiteId(229) ty=i64
+    use BindingId(25) next site=SiteId(234) ty=i64 intent=Read
+    use BindingId(22) last site=SiteId(236) ty=i64 intent=Consume
+    return site=Some(SiteId(236)) ty=i64
+    eval site=SiteId(238) ty=()
+    use BindingId(23) search_from site=SiteId(241) ty=i64 intent=Read
+    use BindingId(25) next site=SiteId(242) ty=i64 intent=Read
+    eval site=SiteId(240) ty=()
+    use BindingId(22) last site=SiteId(245) ty=i64 intent=Read
+    eval site=SiteId(244) ty=()
+    drop BindingId(24) rest ty=string
   drop_plans:
     call[bb0 hew_string_find -> bb1] ->
       (none)
@@ -530,8 +443,8 @@ fn fs$last_slash_pos -> i64
 
 fn fs$write_error -> IoError
   statements:
-    use BindingId(29) target site=SiteId(314) ty=string intent=Read
-    return site=Some(SiteId(312)) ty=IoError
+    use BindingId(26) target site=SiteId(251) ty=string intent=Read
+    return site=Some(SiteId(249)) ty=IoError
   drop_plans:
     call[bb0 fs$missing_parent -> bb1] ->
       (none)
@@ -548,8 +461,8 @@ fn fs$write_error -> IoError
 
 fn fs$missing_path_error -> IoError
   statements:
-    use BindingId(30) target site=SiteId(324) ty=string intent=Read
-    return site=Some(SiteId(322)) ty=IoError
+    use BindingId(27) target site=SiteId(261) ty=string intent=Read
+    return site=Some(SiteId(259)) ty=IoError
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -566,9 +479,9 @@ fn fs$missing_path_error -> IoError
 
 fn fs$mkdir_error -> IoError
   statements:
-    use BindingId(31) target site=SiteId(334) ty=string intent=Read
-    use BindingId(31) target site=SiteId(341) ty=string intent=Read
-    return site=Some(SiteId(332)) ty=IoError
+    use BindingId(28) target site=SiteId(271) ty=string intent=Read
+    use BindingId(28) target site=SiteId(278) ty=string intent=Read
+    return site=Some(SiteId(269)) ty=IoError
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -595,9 +508,9 @@ fn fs$mkdir_error -> IoError
 
 fn fs$move_copy_error -> IoError
   statements:
-    use BindingId(32) source site=SiteId(352) ty=string intent=Read
-    use BindingId(33) target site=SiteId(359) ty=string intent=Read
-    return site=Some(SiteId(349)) ty=IoError
+    use BindingId(29) source site=SiteId(289) ty=string intent=Read
+    use BindingId(30) target site=SiteId(296) ty=string intent=Read
+    return site=Some(SiteId(286)) ty=IoError
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -624,23 +537,23 @@ fn fs$move_copy_error -> IoError
 
 fn fs$read -> string
   statements:
-    use BindingId(34) path site=SiteId(369) ty=string intent=Read
-    bind BindingId(35) contents site=SiteId(368) ty=string
-    bind BindingId(36) errno site=SiteId(371) ty=i32
-    use BindingId(36) errno site=SiteId(374) ty=i32 intent=Read
-    eval site=SiteId(426) ty=()
-    use BindingId(35) contents site=SiteId(427) ty=string intent=Read
-    return site=Some(SiteId(367)) ty=string
-    bind BindingId(37) detail site=SiteId(376) ty=string
-    use BindingId(37) detail site=SiteId(381) ty=string intent=Read
-    use BindingId(34) path site=SiteId(388) ty=string intent=Read
-    use BindingId(34) path site=SiteId(411) ty=string intent=Read
-    use BindingId(36) errno site=SiteId(395) ty=i32 intent=Read
-    eval site=SiteId(385) ty=!
-    use BindingId(37) detail site=SiteId(415) ty=string intent=Read
-    eval site=SiteId(408) ty=!
-    drop BindingId(37) detail ty=string
-    drop BindingId(35) contents ty=string
+    use BindingId(31) path site=SiteId(306) ty=string intent=Read
+    bind BindingId(32) contents site=SiteId(305) ty=string
+    bind BindingId(33) errno site=SiteId(308) ty=i32
+    use BindingId(33) errno site=SiteId(311) ty=i32 intent=Read
+    eval site=SiteId(363) ty=()
+    use BindingId(32) contents site=SiteId(364) ty=string intent=Read
+    return site=Some(SiteId(304)) ty=string
+    bind BindingId(34) detail site=SiteId(313) ty=string
+    use BindingId(34) detail site=SiteId(318) ty=string intent=Read
+    use BindingId(31) path site=SiteId(325) ty=string intent=Read
+    use BindingId(31) path site=SiteId(348) ty=string intent=Read
+    use BindingId(33) errno site=SiteId(332) ty=i32 intent=Read
+    eval site=SiteId(322) ty=!
+    use BindingId(34) detail site=SiteId(352) ty=string intent=Read
+    eval site=SiteId(345) ty=!
+    drop BindingId(34) detail ty=string
+    drop BindingId(32) contents ty=string
   drop_plans:
     call[bb0 hew_file_read -> bb1] ->
       (none)
@@ -703,14 +616,14 @@ fn fs$read -> string
 
 fn fs$try_read -> Result<string, IoError>
   statements:
-    use BindingId(38) file_path site=SiteId(430) ty=string intent=Read
-    bind BindingId(39) file site=SiteId(429) ty=FileReadStream
-    use BindingId(39) file site=SiteId(434) ty=FileReadStream intent=Read
-    use BindingId(39) file site=SiteId(439) ty=FileReadStream intent=Read
-    return site=Some(SiteId(428)) ty=Result<string, IoError>
-    bind BindingId(40) errno site=SiteId(442) ty=i32
-    eval site=SiteId(444) ty=string
-    use BindingId(40) errno site=SiteId(449) ty=i32 intent=Read
+    use BindingId(35) file_path site=SiteId(367) ty=string intent=Read
+    bind BindingId(36) file site=SiteId(366) ty=FileReadStream
+    use BindingId(36) file site=SiteId(371) ty=FileReadStream intent=Read
+    use BindingId(36) file site=SiteId(376) ty=FileReadStream intent=Read
+    return site=Some(SiteId(365)) ty=Result<string, IoError>
+    bind BindingId(37) errno site=SiteId(379) ty=i32
+    eval site=SiteId(381) ty=string
+    use BindingId(37) errno site=SiteId(386) ty=i32 intent=Read
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -741,9 +654,9 @@ fn fs$try_read -> Result<string, IoError>
 
 fn fs$write -> i64
   statements:
-    use BindingId(41) path site=SiteId(454) ty=string intent=Read
-    use BindingId(42) content site=SiteId(455) ty=string intent=Read
-    return site=Some(SiteId(451)) ty=i64
+    use BindingId(38) path site=SiteId(391) ty=string intent=Read
+    use BindingId(39) content site=SiteId(392) ty=string intent=Read
+    return site=Some(SiteId(388)) ty=i64
   drop_plans:
     call[bb0 hew_file_write -> bb1] ->
       (none)
@@ -754,10 +667,10 @@ fn fs$write -> i64
 
 fn fs$try_write -> Result<i64, IoError>
   statements:
-    use BindingId(43) file_path site=SiteId(460) ty=string intent=Read
-    use BindingId(44) content site=SiteId(461) ty=string intent=Read
-    return site=Some(SiteId(457)) ty=Result<i64, IoError>
-    use BindingId(43) file_path site=SiteId(467) ty=string intent=Read
+    use BindingId(40) file_path site=SiteId(397) ty=string intent=Read
+    use BindingId(41) content site=SiteId(398) ty=string intent=Read
+    return site=Some(SiteId(394)) ty=Result<i64, IoError>
+    use BindingId(40) file_path site=SiteId(404) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_write -> bb1] ->
       (none)
@@ -784,9 +697,9 @@ fn fs$try_write -> Result<i64, IoError>
 
 fn fs$append -> i64
   statements:
-    use BindingId(45) path site=SiteId(472) ty=string intent=Read
-    use BindingId(46) content site=SiteId(473) ty=string intent=Read
-    return site=Some(SiteId(469)) ty=i64
+    use BindingId(42) path site=SiteId(409) ty=string intent=Read
+    use BindingId(43) content site=SiteId(410) ty=string intent=Read
+    return site=Some(SiteId(406)) ty=i64
   drop_plans:
     call[bb0 hew_file_append -> bb1] ->
       (none)
@@ -797,10 +710,10 @@ fn fs$append -> i64
 
 fn fs$try_append -> Result<i64, IoError>
   statements:
-    use BindingId(47) file_path site=SiteId(478) ty=string intent=Read
-    use BindingId(48) content site=SiteId(479) ty=string intent=Read
-    return site=Some(SiteId(475)) ty=Result<i64, IoError>
-    use BindingId(47) file_path site=SiteId(485) ty=string intent=Read
+    use BindingId(44) file_path site=SiteId(415) ty=string intent=Read
+    use BindingId(45) content site=SiteId(416) ty=string intent=Read
+    return site=Some(SiteId(412)) ty=Result<i64, IoError>
+    use BindingId(44) file_path site=SiteId(422) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_append -> bb1] ->
       (none)
@@ -827,8 +740,8 @@ fn fs$try_append -> Result<i64, IoError>
 
 fn fs$exists -> bool
   statements:
-    use BindingId(49) path site=SiteId(489) ty=string intent=Read
-    return site=Some(SiteId(487)) ty=bool
+    use BindingId(46) path site=SiteId(426) ty=string intent=Read
+    return site=Some(SiteId(424)) ty=bool
   drop_plans:
     call[bb0 hew_file_exists -> bb1] ->
       (none)
@@ -839,8 +752,8 @@ fn fs$exists -> bool
 
 fn fs$delete -> i64
   statements:
-    use BindingId(50) path site=SiteId(494) ty=string intent=Read
-    return site=Some(SiteId(491)) ty=i64
+    use BindingId(47) path site=SiteId(431) ty=string intent=Read
+    return site=Some(SiteId(428)) ty=i64
   drop_plans:
     call[bb0 hew_file_delete -> bb1] ->
       (none)
@@ -851,9 +764,9 @@ fn fs$delete -> i64
 
 fn fs$try_delete -> Result<i64, IoError>
   statements:
-    use BindingId(51) file_path site=SiteId(499) ty=string intent=Read
-    return site=Some(SiteId(496)) ty=Result<i64, IoError>
-    use BindingId(51) file_path site=SiteId(505) ty=string intent=Read
+    use BindingId(48) file_path site=SiteId(436) ty=string intent=Read
+    return site=Some(SiteId(433)) ty=Result<i64, IoError>
+    use BindingId(48) file_path site=SiteId(442) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_delete -> bb1] ->
       (none)
@@ -880,8 +793,8 @@ fn fs$try_delete -> Result<i64, IoError>
 
 fn fs$size -> i64
   statements:
-    use BindingId(52) path site=SiteId(509) ty=string intent=Read
-    return site=Some(SiteId(507)) ty=i64
+    use BindingId(49) path site=SiteId(446) ty=string intent=Read
+    return site=Some(SiteId(444)) ty=i64
   drop_plans:
     call[bb0 hew_file_size -> bb1] ->
       (none)
@@ -892,8 +805,8 @@ fn fs$size -> i64
 
 fn fs$read_bytes -> bytes
   statements:
-    use BindingId(53) path site=SiteId(513) ty=string intent=Read
-    return site=Some(SiteId(511)) ty=bytes
+    use BindingId(50) path site=SiteId(450) ty=string intent=Read
+    return site=Some(SiteId(448)) ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
       (none)
@@ -904,15 +817,15 @@ fn fs$read_bytes -> bytes
 
 fn fs$try_read_bytes -> Result<bytes, IoError>
   statements:
-    use BindingId(54) file_path site=SiteId(517) ty=string intent=Read
-    bind BindingId(55) data site=SiteId(516) ty=bytes
-    bind BindingId(56) errno site=SiteId(519) ty=i32
-    use BindingId(56) errno site=SiteId(523) ty=i32 intent=Read
-    use BindingId(56) errno site=SiteId(529) ty=i32 intent=Read
-    use BindingId(55) data site=SiteId(533) ty=bytes intent=Read
-    agg_alias BindingId(55) data site=SiteId(533) ty=bytes
-    return site=Some(SiteId(515)) ty=Result<bytes, IoError>
-    drop BindingId(55) data ty=bytes
+    use BindingId(51) file_path site=SiteId(454) ty=string intent=Read
+    bind BindingId(52) data site=SiteId(453) ty=bytes
+    bind BindingId(53) errno site=SiteId(456) ty=i32
+    use BindingId(53) errno site=SiteId(460) ty=i32 intent=Read
+    use BindingId(53) errno site=SiteId(466) ty=i32 intent=Read
+    use BindingId(52) data site=SiteId(470) ty=bytes intent=Read
+    agg_alias BindingId(52) data site=SiteId(470) ty=bytes
+    return site=Some(SiteId(452)) ty=Result<bytes, IoError>
+    drop BindingId(52) data ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
       (none)
@@ -935,9 +848,9 @@ fn fs$try_read_bytes -> Result<bytes, IoError>
 
 fn fs$write_bytes -> i64
   statements:
-    use BindingId(57) path site=SiteId(537) ty=string intent=Read
-    use BindingId(58) data site=SiteId(538) ty=bytes intent=Read
-    return site=Some(SiteId(534)) ty=i64
+    use BindingId(54) path site=SiteId(474) ty=string intent=Read
+    use BindingId(55) data site=SiteId(475) ty=bytes intent=Read
+    return site=Some(SiteId(471)) ty=i64
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -948,10 +861,10 @@ fn fs$write_bytes -> i64
 
 fn fs$try_write_bytes -> Result<i64, IoError>
   statements:
-    use BindingId(59) file_path site=SiteId(543) ty=string intent=Read
-    use BindingId(60) data site=SiteId(544) ty=bytes intent=Read
-    return site=Some(SiteId(540)) ty=Result<i64, IoError>
-    use BindingId(59) file_path site=SiteId(550) ty=string intent=Read
+    use BindingId(56) file_path site=SiteId(480) ty=string intent=Read
+    use BindingId(57) data site=SiteId(481) ty=bytes intent=Read
+    return site=Some(SiteId(477)) ty=Result<i64, IoError>
+    use BindingId(56) file_path site=SiteId(487) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -978,8 +891,8 @@ fn fs$try_write_bytes -> Result<i64, IoError>
 
 fn fs$mkdir -> i64
   statements:
-    use BindingId(61) path site=SiteId(555) ty=string intent=Read
-    return site=Some(SiteId(552)) ty=i64
+    use BindingId(58) path site=SiteId(492) ty=string intent=Read
+    return site=Some(SiteId(489)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -990,9 +903,9 @@ fn fs$mkdir -> i64
 
 fn fs$try_mkdir -> Result<i64, IoError>
   statements:
-    use BindingId(62) dir_path site=SiteId(560) ty=string intent=Read
-    return site=Some(SiteId(557)) ty=Result<i64, IoError>
-    use BindingId(62) dir_path site=SiteId(566) ty=string intent=Read
+    use BindingId(59) dir_path site=SiteId(497) ty=string intent=Read
+    return site=Some(SiteId(494)) ty=Result<i64, IoError>
+    use BindingId(59) dir_path site=SiteId(503) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -1019,8 +932,8 @@ fn fs$try_mkdir -> Result<i64, IoError>
 
 fn fs$mkdir_all -> i64
   statements:
-    use BindingId(63) path site=SiteId(571) ty=string intent=Read
-    return site=Some(SiteId(568)) ty=i64
+    use BindingId(60) path site=SiteId(508) ty=string intent=Read
+    return site=Some(SiteId(505)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -1031,9 +944,9 @@ fn fs$mkdir_all -> i64
 
 fn fs$try_mkdir_all -> Result<i64, IoError>
   statements:
-    use BindingId(64) dir_path site=SiteId(576) ty=string intent=Read
-    return site=Some(SiteId(573)) ty=Result<i64, IoError>
-    use BindingId(64) dir_path site=SiteId(583) ty=string intent=Read
+    use BindingId(61) dir_path site=SiteId(513) ty=string intent=Read
+    return site=Some(SiteId(510)) ty=Result<i64, IoError>
+    use BindingId(61) dir_path site=SiteId(520) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -1066,8 +979,8 @@ fn fs$try_mkdir_all -> Result<i64, IoError>
 
 fn fs$list_dir -> Vec<string>
   statements:
-    use BindingId(65) path site=SiteId(595) ty=string intent=Read
-    return site=Some(SiteId(593)) ty=Vec<string>
+    use BindingId(62) path site=SiteId(532) ty=string intent=Read
+    return site=Some(SiteId(530)) ty=Vec<string>
   drop_plans:
     call[bb0 hew_fs_list_dir -> bb1] ->
       (none)
@@ -1078,14 +991,14 @@ fn fs$list_dir -> Vec<string>
 
 fn fs$try_list_dir -> Result<Vec<string>, IoError>
   statements:
-    use BindingId(66) dir_path site=SiteId(599) ty=string intent=Read
-    return site=Some(SiteId(601)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(605) ty=()
-    use BindingId(66) dir_path site=SiteId(608) ty=string intent=Read
-    return site=Some(SiteId(610)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(614) ty=()
-    use BindingId(66) dir_path site=SiteId(618) ty=string intent=Read
-    return site=Some(SiteId(615)) ty=Result<Vec<string>, IoError>
+    use BindingId(63) dir_path site=SiteId(536) ty=string intent=Read
+    return site=Some(SiteId(538)) ty=Result<Vec<string>, IoError>
+    eval site=SiteId(542) ty=()
+    use BindingId(63) dir_path site=SiteId(545) ty=string intent=Read
+    return site=Some(SiteId(547)) ty=Result<Vec<string>, IoError>
+    eval site=SiteId(551) ty=()
+    use BindingId(63) dir_path site=SiteId(555) ty=string intent=Read
+    return site=Some(SiteId(552)) ty=Result<Vec<string>, IoError>
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -1120,9 +1033,9 @@ fn fs$try_list_dir -> Result<Vec<string>, IoError>
 
 fn fs$rename -> i64
   statements:
-    use BindingId(67) from site=SiteId(623) ty=string intent=Read
-    use BindingId(68) to site=SiteId(624) ty=string intent=Read
-    return site=Some(SiteId(620)) ty=i64
+    use BindingId(64) from site=SiteId(560) ty=string intent=Read
+    use BindingId(65) to site=SiteId(561) ty=string intent=Read
+    return site=Some(SiteId(557)) ty=i64
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1133,11 +1046,11 @@ fn fs$rename -> i64
 
 fn fs$try_rename -> Result<i64, IoError>
   statements:
-    use BindingId(69) from site=SiteId(629) ty=string intent=Read
-    use BindingId(70) to site=SiteId(630) ty=string intent=Read
-    return site=Some(SiteId(626)) ty=Result<i64, IoError>
-    use BindingId(69) from site=SiteId(636) ty=string intent=Read
-    use BindingId(70) to site=SiteId(637) ty=string intent=Read
+    use BindingId(66) from site=SiteId(566) ty=string intent=Read
+    use BindingId(67) to site=SiteId(567) ty=string intent=Read
+    return site=Some(SiteId(563)) ty=Result<i64, IoError>
+    use BindingId(66) from site=SiteId(573) ty=string intent=Read
+    use BindingId(67) to site=SiteId(574) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1164,9 +1077,9 @@ fn fs$try_rename -> Result<i64, IoError>
 
 fn fs$copy -> i64
   statements:
-    use BindingId(71) from site=SiteId(642) ty=string intent=Read
-    use BindingId(72) to site=SiteId(643) ty=string intent=Read
-    return site=Some(SiteId(639)) ty=i64
+    use BindingId(68) from site=SiteId(579) ty=string intent=Read
+    use BindingId(69) to site=SiteId(580) ty=string intent=Read
+    return site=Some(SiteId(576)) ty=i64
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1177,11 +1090,11 @@ fn fs$copy -> i64
 
 fn fs$try_copy -> Result<i64, IoError>
   statements:
-    use BindingId(73) from site=SiteId(648) ty=string intent=Read
-    use BindingId(74) to site=SiteId(649) ty=string intent=Read
-    return site=Some(SiteId(645)) ty=Result<i64, IoError>
-    use BindingId(73) from site=SiteId(655) ty=string intent=Read
-    use BindingId(74) to site=SiteId(656) ty=string intent=Read
+    use BindingId(70) from site=SiteId(585) ty=string intent=Read
+    use BindingId(71) to site=SiteId(586) ty=string intent=Read
+    return site=Some(SiteId(582)) ty=Result<i64, IoError>
+    use BindingId(70) from site=SiteId(592) ty=string intent=Read
+    use BindingId(71) to site=SiteId(593) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1208,8 +1121,8 @@ fn fs$try_copy -> Result<i64, IoError>
 
 fn fs$is_dir -> bool
   statements:
-    use BindingId(75) path site=SiteId(660) ty=string intent=Read
-    return site=Some(SiteId(658)) ty=bool
+    use BindingId(72) path site=SiteId(597) ty=string intent=Read
+    return site=Some(SiteId(595)) ty=bool
   drop_plans:
     call[bb0 hew_fs_is_dir -> bb1] ->
       (none)
@@ -1220,21 +1133,21 @@ fn fs$is_dir -> bool
 
 fn stream$pipe -> (Sink<string>, Stream<string>)
   statements:
-    use BindingId(76) capacity site=SiteId(665) ty=i64 intent=Read
-    bind BindingId(77) pair site=SiteId(663) ty=StreamPair
-    use BindingId(77) pair site=SiteId(668) ty=StreamPair intent=Read
-    bind BindingId(78) sink site=SiteId(667) ty=Sink<string>
-    use BindingId(77) pair site=SiteId(671) ty=StreamPair intent=Read
-    bind BindingId(79) input site=SiteId(670) ty=Stream<string>
-    use BindingId(77) pair site=SiteId(674) ty=StreamPair intent=Read
-    eval site=SiteId(673) ty=()
-    use BindingId(78) sink site=SiteId(677) ty=Sink<string> intent=Read
-    use BindingId(79) input site=SiteId(678) ty=Stream<string> intent=Read
-    agg_alias BindingId(78) sink site=SiteId(677) ty=Sink<string>
-    agg_alias BindingId(79) input site=SiteId(678) ty=Stream<string>
-    return site=Some(SiteId(662)) ty=(Sink<string>, Stream<string>)
-    drop BindingId(79) input ty=Stream<string>
-    drop BindingId(78) sink ty=Sink<string>
+    use BindingId(73) capacity site=SiteId(602) ty=i64 intent=Read
+    bind BindingId(74) pair site=SiteId(600) ty=StreamPair
+    use BindingId(74) pair site=SiteId(605) ty=StreamPair intent=Read
+    bind BindingId(75) sink site=SiteId(604) ty=Sink<string>
+    use BindingId(74) pair site=SiteId(608) ty=StreamPair intent=Read
+    bind BindingId(76) input site=SiteId(607) ty=Stream<string>
+    use BindingId(74) pair site=SiteId(611) ty=StreamPair intent=Read
+    eval site=SiteId(610) ty=()
+    use BindingId(75) sink site=SiteId(614) ty=Sink<string> intent=Read
+    use BindingId(76) input site=SiteId(615) ty=Stream<string> intent=Read
+    agg_alias BindingId(75) sink site=SiteId(614) ty=Sink<string>
+    agg_alias BindingId(76) input site=SiteId(615) ty=Stream<string>
+    return site=Some(SiteId(599)) ty=(Sink<string>, Stream<string>)
+    drop BindingId(76) input ty=Stream<string>
+    drop BindingId(75) sink ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_channel -> bb1] ->
       (none)
@@ -1251,21 +1164,21 @@ fn stream$pipe -> (Sink<string>, Stream<string>)
 
 fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
   statements:
-    use BindingId(80) capacity site=SiteId(682) ty=i64 intent=Read
-    bind BindingId(81) pair site=SiteId(680) ty=StreamPair
-    use BindingId(81) pair site=SiteId(685) ty=StreamPair intent=Read
-    bind BindingId(82) sink site=SiteId(684) ty=Sink<bytes>
-    use BindingId(81) pair site=SiteId(688) ty=StreamPair intent=Read
-    bind BindingId(83) input site=SiteId(687) ty=Stream<bytes>
-    use BindingId(81) pair site=SiteId(691) ty=StreamPair intent=Read
-    eval site=SiteId(690) ty=()
-    use BindingId(82) sink site=SiteId(694) ty=Sink<bytes> intent=Read
-    use BindingId(83) input site=SiteId(695) ty=Stream<bytes> intent=Read
-    agg_alias BindingId(82) sink site=SiteId(694) ty=Sink<bytes>
-    agg_alias BindingId(83) input site=SiteId(695) ty=Stream<bytes>
-    return site=Some(SiteId(679)) ty=(Sink<bytes>, Stream<bytes>)
-    drop BindingId(83) input ty=Stream<bytes>
-    drop BindingId(82) sink ty=Sink<bytes>
+    use BindingId(77) capacity site=SiteId(619) ty=i64 intent=Read
+    bind BindingId(78) pair site=SiteId(617) ty=StreamPair
+    use BindingId(78) pair site=SiteId(622) ty=StreamPair intent=Read
+    bind BindingId(79) sink site=SiteId(621) ty=Sink<bytes>
+    use BindingId(78) pair site=SiteId(625) ty=StreamPair intent=Read
+    bind BindingId(80) input site=SiteId(624) ty=Stream<bytes>
+    use BindingId(78) pair site=SiteId(628) ty=StreamPair intent=Read
+    eval site=SiteId(627) ty=()
+    use BindingId(79) sink site=SiteId(631) ty=Sink<bytes> intent=Read
+    use BindingId(80) input site=SiteId(632) ty=Stream<bytes> intent=Read
+    agg_alias BindingId(79) sink site=SiteId(631) ty=Sink<bytes>
+    agg_alias BindingId(80) input site=SiteId(632) ty=Stream<bytes>
+    return site=Some(SiteId(616)) ty=(Sink<bytes>, Stream<bytes>)
+    drop BindingId(80) input ty=Stream<bytes>
+    drop BindingId(79) sink ty=Sink<bytes>
   drop_plans:
     call[bb0 hew_stream_channel -> bb1] ->
       (none)
@@ -1282,13 +1195,13 @@ fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
 
 fn stream$from_file -> Result<Stream<string>, string>
   statements:
-    use BindingId(84) path site=SiteId(698) ty=string intent=Read
-    bind BindingId(85) s site=SiteId(697) ty=Stream<string>
-    use BindingId(85) s site=SiteId(702) ty=Stream<string> intent=Read
-    use BindingId(85) s site=SiteId(706) ty=Stream<string> intent=Read
-    agg_alias BindingId(85) s site=SiteId(706) ty=Stream<string>
-    return site=Some(SiteId(696)) ty=Result<Stream<string>, string>
-    drop BindingId(85) s ty=Stream<string>
+    use BindingId(81) path site=SiteId(635) ty=string intent=Read
+    bind BindingId(82) s site=SiteId(634) ty=Stream<string>
+    use BindingId(82) s site=SiteId(639) ty=Stream<string> intent=Read
+    use BindingId(82) s site=SiteId(643) ty=Stream<string> intent=Read
+    agg_alias BindingId(82) s site=SiteId(643) ty=Stream<string>
+    return site=Some(SiteId(633)) ty=Result<Stream<string>, string>
+    drop BindingId(82) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1311,16 +1224,16 @@ fn stream$from_file -> Result<Stream<string>, string>
 
 fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
   statements:
-    use BindingId(86) path site=SiteId(713) ty=string intent=Read
-    bind BindingId(87) s site=SiteId(712) ty=Stream<string>
-    use BindingId(87) s site=SiteId(717) ty=Stream<string> intent=Read
-    use BindingId(87) s site=SiteId(721) ty=Stream<string> intent=Read
-    agg_alias BindingId(87) s site=SiteId(721) ty=Stream<string>
-    return site=Some(SiteId(711)) ty=Result<Stream<string>, fs.IoError>
-    bind BindingId(88) errno site=SiteId(723) ty=i32
-    eval site=SiteId(725) ty=string
-    use BindingId(88) errno site=SiteId(730) ty=i32 intent=Read
-    drop BindingId(87) s ty=Stream<string>
+    use BindingId(83) path site=SiteId(650) ty=string intent=Read
+    bind BindingId(84) s site=SiteId(649) ty=Stream<string>
+    use BindingId(84) s site=SiteId(654) ty=Stream<string> intent=Read
+    use BindingId(84) s site=SiteId(658) ty=Stream<string> intent=Read
+    agg_alias BindingId(84) s site=SiteId(658) ty=Stream<string>
+    return site=Some(SiteId(648)) ty=Result<Stream<string>, fs.IoError>
+    bind BindingId(85) errno site=SiteId(660) ty=i32
+    eval site=SiteId(662) ty=string
+    use BindingId(85) errno site=SiteId(667) ty=i32 intent=Read
+    drop BindingId(84) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1347,13 +1260,13 @@ fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
 
 fn stream$to_file -> Result<Sink<string>, string>
   statements:
-    use BindingId(89) path site=SiteId(734) ty=string intent=Read
-    bind BindingId(90) s site=SiteId(733) ty=Sink<string>
-    use BindingId(90) s site=SiteId(738) ty=Sink<string> intent=Read
-    use BindingId(90) s site=SiteId(742) ty=Sink<string> intent=Read
-    agg_alias BindingId(90) s site=SiteId(742) ty=Sink<string>
-    return site=Some(SiteId(732)) ty=Result<Sink<string>, string>
-    drop BindingId(90) s ty=Sink<string>
+    use BindingId(86) path site=SiteId(671) ty=string intent=Read
+    bind BindingId(87) s site=SiteId(670) ty=Sink<string>
+    use BindingId(87) s site=SiteId(675) ty=Sink<string> intent=Read
+    use BindingId(87) s site=SiteId(679) ty=Sink<string> intent=Read
+    agg_alias BindingId(87) s site=SiteId(679) ty=Sink<string>
+    return site=Some(SiteId(669)) ty=Result<Sink<string>, string>
+    drop BindingId(87) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1376,16 +1289,16 @@ fn stream$to_file -> Result<Sink<string>, string>
 
 fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
   statements:
-    use BindingId(91) path site=SiteId(749) ty=string intent=Read
-    bind BindingId(92) s site=SiteId(748) ty=Sink<string>
-    use BindingId(92) s site=SiteId(753) ty=Sink<string> intent=Read
-    use BindingId(92) s site=SiteId(757) ty=Sink<string> intent=Read
-    agg_alias BindingId(92) s site=SiteId(757) ty=Sink<string>
-    return site=Some(SiteId(747)) ty=Result<Sink<string>, fs.IoError>
-    bind BindingId(93) errno site=SiteId(759) ty=i32
-    eval site=SiteId(761) ty=string
-    use BindingId(93) errno site=SiteId(766) ty=i32 intent=Read
-    drop BindingId(92) s ty=Sink<string>
+    use BindingId(88) path site=SiteId(686) ty=string intent=Read
+    bind BindingId(89) s site=SiteId(685) ty=Sink<string>
+    use BindingId(89) s site=SiteId(690) ty=Sink<string> intent=Read
+    use BindingId(89) s site=SiteId(694) ty=Sink<string> intent=Read
+    agg_alias BindingId(89) s site=SiteId(694) ty=Sink<string>
+    return site=Some(SiteId(684)) ty=Result<Sink<string>, fs.IoError>
+    bind BindingId(90) errno site=SiteId(696) ty=i32
+    eval site=SiteId(698) ty=string
+    use BindingId(90) errno site=SiteId(703) ty=i32 intent=Read
+    drop BindingId(89) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1412,9 +1325,9 @@ fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
 
 fn stream$forward -> ()
   statements:
-    use BindingId(94) source site=SiteId(770) ty=Stream<string> intent=Read
-    use BindingId(95) dest site=SiteId(771) ty=Sink<string> intent=Read
-    eval site=SiteId(768) ty=()
+    use BindingId(91) source site=SiteId(707) ty=Stream<string> intent=Read
+    use BindingId(92) dest site=SiteId(708) ty=Sink<string> intent=Read
+    eval site=SiteId(705) ty=()
   drop_plans:
     call[bb0 hew_stream_pipe -> bb1] ->
       (none)
@@ -1425,8 +1338,8 @@ fn stream$forward -> ()
 
 fn i32::fmt -> string
   statements:
-    use BindingId(99) val site=SiteId(802) ty=i32 intent=Read
-    return site=Some(SiteId(801)) ty=string
+    use BindingId(96) val site=SiteId(739) ty=i32 intent=Read
+    return site=Some(SiteId(738)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1437,8 +1350,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(100) val site=SiteId(805) ty=i64 intent=Read
-    return site=Some(SiteId(804)) ty=string
+    use BindingId(97) val site=SiteId(742) ty=i64 intent=Read
+    return site=Some(SiteId(741)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1449,8 +1362,8 @@ fn i64::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(101) val site=SiteId(808) ty=u32 intent=Read
-    return site=Some(SiteId(807)) ty=string
+    use BindingId(98) val site=SiteId(745) ty=u32 intent=Read
+    return site=Some(SiteId(744)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -1461,8 +1374,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(102) val site=SiteId(811) ty=u64 intent=Read
-    return site=Some(SiteId(810)) ty=string
+    use BindingId(99) val site=SiteId(748) ty=u64 intent=Read
+    return site=Some(SiteId(747)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1473,8 +1386,8 @@ fn u64::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(103) val site=SiteId(814) ty=bool intent=Read
-    return site=Some(SiteId(813)) ty=string
+    use BindingId(100) val site=SiteId(751) ty=bool intent=Read
+    return site=Some(SiteId(750)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -1485,8 +1398,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(104) val site=SiteId(817) ty=char intent=Read
-    return site=Some(SiteId(816)) ty=string
+    use BindingId(101) val site=SiteId(754) ty=char intent=Read
+    return site=Some(SiteId(753)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -1497,8 +1410,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(105) val site=SiteId(820) ty=f64 intent=Read
-    return site=Some(SiteId(819)) ty=string
+    use BindingId(102) val site=SiteId(757) ty=f64 intent=Read
+    return site=Some(SiteId(756)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1509,8 +1422,8 @@ fn f64::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(106) val site=SiteId(822) ty=string intent=Read
-    return site=Some(SiteId(822)) ty=string
+    use BindingId(103) val site=SiteId(759) ty=string intent=Read
+    return site=Some(SiteId(759)) ty=string
   drop_plans:
     return[bb0] ->
       (none)

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
@@ -99,35 +99,8 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     _35: i64
     _36: IoError
     _37: IoError
-    _38: bool
-    _39: i64
-    _40: bool
-    _41: i64
-    _42: bool
-    _43: IoError
-    _44: i64
-    _45: IoError
-    _46: IoError
-    _47: bool
-    _48: i64
-    _49: bool
-    _50: i64
-    _51: bool
-    _52: IoError
-    _53: i64
-    _54: IoError
-    _55: IoError
-    _56: bool
-    _57: i64
-    _58: bool
-    _59: i64
-    _60: bool
-    _61: IoError
-    _62: i64
-    _63: IoError
-    _64: IoError
-    _65: i64
-    _66: IoError
+    _38: i64
+    _39: IoError
   bb0:
     stmt: use BindingId(6) errno site=SiteId(26) ty=i64 intent=Read
     _2 = const.i64 2
@@ -177,7 +150,7 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
   bb8:
     stmt: use BindingId(6) errno site=SiteId(48) ty=i64 intent=Read
     _20 = const.i64 1
-    _21 = const.i64 111
+    _21 = const.i64 110
     _22 = icmp.eq _0 _21
     branch _22 ? bb11 : bb10
   bb9:
@@ -185,7 +158,7 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     goto bb6
   bb10:
     stmt: use BindingId(6) errno site=SiteId(51) ty=i64 intent=Read
-    _23 = const.i64 61
+    _23 = const.i64 60
     _24 = icmp.eq _0 _23
     _20 = move _24
     goto bb11
@@ -202,7 +175,7 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
   bb13:
     stmt: use BindingId(6) errno site=SiteId(59) ty=i64 intent=Read
     _29 = const.i64 1
-    _30 = const.i64 98
+    _30 = const.i64 125
     _31 = icmp.eq _0 _30
     branch _31 ? bb16 : bb15
   bb14:
@@ -210,7 +183,7 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     goto bb9
   bb15:
     stmt: use BindingId(6) errno site=SiteId(62) ty=i64 intent=Read
-    _32 = const.i64 48
+    _32 = const.i64 89
     _33 = icmp.eq _0 _32
     _29 = move _33
     goto bb16
@@ -225,91 +198,16 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     _28 = move _36
     goto bb19
   bb18:
-    stmt: use BindingId(6) errno site=SiteId(70) ty=i64 intent=Read
-    _38 = const.i64 1
-    _39 = const.i64 110
-    _40 = icmp.eq _0 _39
-    branch _40 ? bb21 : bb20
+    stmt: use BindingId(6) errno site=SiteId(69) ty=i64 intent=Read
+    _38 = const.i64 5
+    mtag37 = move _38
+    mvar37.5.0 = move _0
+    _39 = move _37
+    _28 = move _39
+    goto bb19
   bb19:
     _19 = move _28
     goto bb14
-  bb20:
-    stmt: use BindingId(6) errno site=SiteId(73) ty=i64 intent=Read
-    _41 = const.i64 60
-    _42 = icmp.eq _0 _41
-    _38 = move _42
-    goto bb21
-  bb21:
-    branch _38 ? bb22 : bb23
-  bb22:
-    stmt: use BindingId(6) errno site=SiteId(77) ty=i64 intent=Read
-    _44 = const.i64 5
-    mtag43 = move _44
-    mvar43.5.0 = move _0
-    _45 = move _43
-    _37 = move _45
-    goto bb24
-  bb23:
-    stmt: use BindingId(6) errno site=SiteId(81) ty=i64 intent=Read
-    _47 = const.i64 1
-    _48 = const.i64 125
-    _49 = icmp.eq _0 _48
-    branch _49 ? bb26 : bb25
-  bb24:
-    _28 = move _37
-    goto bb19
-  bb25:
-    stmt: use BindingId(6) errno site=SiteId(84) ty=i64 intent=Read
-    _50 = const.i64 89
-    _51 = icmp.eq _0 _50
-    _47 = move _51
-    goto bb26
-  bb26:
-    branch _47 ? bb27 : bb28
-  bb27:
-    stmt: use BindingId(6) errno site=SiteId(88) ty=i64 intent=Read
-    _53 = const.i64 6
-    mtag52 = move _53
-    mvar52.6.0 = move _0
-    _54 = move _52
-    _46 = move _54
-    goto bb29
-  bb28:
-    stmt: use BindingId(6) errno site=SiteId(92) ty=i64 intent=Read
-    _56 = const.i64 1
-    _57 = const.i64 99
-    _58 = icmp.eq _0 _57
-    branch _58 ? bb31 : bb30
-  bb29:
-    _37 = move _46
-    goto bb24
-  bb30:
-    stmt: use BindingId(6) errno site=SiteId(95) ty=i64 intent=Read
-    _59 = const.i64 49
-    _60 = icmp.eq _0 _59
-    _56 = move _60
-    goto bb31
-  bb31:
-    branch _56 ? bb32 : bb33
-  bb32:
-    stmt: use BindingId(6) errno site=SiteId(99) ty=i64 intent=Read
-    _62 = const.i64 7
-    mtag61 = move _62
-    mvar61.7.0 = move _0
-    _63 = move _61
-    _55 = move _63
-    goto bb34
-  bb33:
-    stmt: use BindingId(6) errno site=SiteId(102) ty=i64 intent=Read
-    _65 = const.i64 8
-    mtag64 = move _65
-    mvar64.8.0 = move _0
-    _66 = move _64
-    _55 = move _66
-    goto bb34
-  bb34:
-    _46 = move _55
-    goto bb29
 
 fn fs$io_error_message(IoError) -> string [conv=default]
   locals:
@@ -329,11 +227,11 @@ fn fs$io_error_message(IoError) -> string [conv=default]
     _13: i64
     _14: bool
     _15: i64
-    _16: bool
-    _17: i64
-    _18: bool
-    _19: i64
-    _20: bool
+    _16: string
+    _17: string
+    _18: string
+    _19: string
+    _20: string
     _21: i64
     _22: string
     _23: string
@@ -364,199 +262,121 @@ fn fs$io_error_message(IoError) -> string [conv=default]
     _48: string
     _49: string
     _50: string
-    _51: i64
-    _52: string
-    _53: string
-    _54: string
-    _55: string
-    _56: string
-    _57: i64
-    _58: string
-    _59: string
-    _60: string
-    _61: string
-    _62: string
-    _63: i64
-    _64: string
-    _65: string
-    _66: string
-    _67: string
-    _68: string
-    _69: i64
-    _70: string
-    _71: string
-    _72: string
-    _73: string
-    _74: string
   bb0:
-    stmt: use BindingId(7) e site=SiteId(104) ty=IoError intent=Read
+    stmt: use BindingId(7) e site=SiteId(71) ty=IoError intent=Read
     _2 = move etag0
     _3 = const.i64 0
     _4 = icmp.eq _2 _3
-    branch _4 ? bb2 : bb12
+    branch _4 ? bb2 : bb9
   bb1:
-    stmt: return site=Some(SiteId(103)) ty=string
+    stmt: return site=Some(SiteId(70)) ty=string
     ret = move _1
     return
   bb2:
-    stmt: bind BindingId(8) code site=SiteId(105) ty=i64
-    stmt: use BindingId(8) code site=SiteId(107) ty=i64 intent=Read
-    _21 = move mvar0.0.0
-    _22 = string_lit "NotFound("
-    _23 = call to_string_i64(_21) -> bb20
+    stmt: bind BindingId(8) code site=SiteId(72) ty=i64
+    stmt: use BindingId(8) code site=SiteId(74) ty=i64 intent=Read
+    _15 = move mvar0.0.0
+    _16 = string_lit "NotFound("
+    _17 = call to_string_i64(_15) -> bb14
   bb3:
-    stmt: bind BindingId(9) code site=SiteId(115) ty=i64
-    stmt: use BindingId(9) code site=SiteId(117) ty=i64 intent=Read
-    _27 = move mvar0.1.0
-    _28 = string_lit "PermissionDenied("
-    _29 = call to_string_i64(_27) -> bb23
+    stmt: bind BindingId(9) code site=SiteId(82) ty=i64
+    stmt: use BindingId(9) code site=SiteId(84) ty=i64 intent=Read
+    _21 = move mvar0.1.0
+    _22 = string_lit "PermissionDenied("
+    _23 = call to_string_i64(_21) -> bb17
   bb4:
-    stmt: bind BindingId(10) code site=SiteId(125) ty=i64
-    stmt: use BindingId(10) code site=SiteId(127) ty=i64 intent=Read
-    _33 = move mvar0.2.0
-    _34 = string_lit "AlreadyExists("
-    _35 = call to_string_i64(_33) -> bb26
+    stmt: bind BindingId(10) code site=SiteId(92) ty=i64
+    stmt: use BindingId(10) code site=SiteId(94) ty=i64 intent=Read
+    _27 = move mvar0.2.0
+    _28 = string_lit "AlreadyExists("
+    _29 = call to_string_i64(_27) -> bb20
   bb5:
-    stmt: bind BindingId(11) code site=SiteId(135) ty=i64
-    stmt: use BindingId(11) code site=SiteId(137) ty=i64 intent=Read
-    _39 = move mvar0.3.0
-    _40 = string_lit "ConnectionRefused("
-    _41 = call to_string_i64(_39) -> bb29
+    stmt: bind BindingId(11) code site=SiteId(102) ty=i64
+    stmt: use BindingId(11) code site=SiteId(104) ty=i64 intent=Read
+    _33 = move mvar0.3.0
+    _34 = string_lit "TimedOut("
+    _35 = call to_string_i64(_33) -> bb23
   bb6:
-    stmt: bind BindingId(12) code site=SiteId(145) ty=i64
-    stmt: use BindingId(12) code site=SiteId(147) ty=i64 intent=Read
-    _45 = move mvar0.4.0
-    _46 = string_lit "AddressInUse("
-    _47 = call to_string_i64(_45) -> bb32
+    stmt: bind BindingId(12) code site=SiteId(112) ty=i64
+    stmt: use BindingId(12) code site=SiteId(114) ty=i64 intent=Read
+    _39 = move mvar0.4.0
+    _40 = string_lit "Cancelled("
+    _41 = call to_string_i64(_39) -> bb26
   bb7:
-    stmt: bind BindingId(13) code site=SiteId(155) ty=i64
-    stmt: use BindingId(13) code site=SiteId(157) ty=i64 intent=Read
-    _51 = move mvar0.5.0
-    _52 = string_lit "TimedOut("
-    _53 = call to_string_i64(_51) -> bb35
+    stmt: bind BindingId(13) code site=SiteId(122) ty=i64
+    stmt: use BindingId(13) code site=SiteId(124) ty=i64 intent=Read
+    _45 = move mvar0.5.0
+    _46 = string_lit "Other("
+    _47 = call to_string_i64(_45) -> bb29
   bb8:
-    stmt: bind BindingId(14) code site=SiteId(165) ty=i64
-    stmt: use BindingId(14) code site=SiteId(167) ty=i64 intent=Read
-    _57 = move mvar0.6.0
-    _58 = string_lit "Cancelled("
-    _59 = call to_string_i64(_57) -> bb38
-  bb9:
-    stmt: bind BindingId(15) code site=SiteId(175) ty=i64
-    stmt: use BindingId(15) code site=SiteId(177) ty=i64 intent=Read
-    _63 = move mvar0.7.0
-    _64 = string_lit "AddressNotAvailable("
-    _65 = call to_string_i64(_63) -> bb41
-  bb10:
-    stmt: bind BindingId(16) code site=SiteId(185) ty=i64
-    stmt: use BindingId(16) code site=SiteId(187) ty=i64 intent=Read
-    _69 = move mvar0.8.0
-    _70 = string_lit "Other("
-    _71 = call to_string_i64(_69) -> bb44
-  bb11:
     trap(ExhaustivenessFallthrough)
-  bb12:
+  bb9:
     _5 = const.i64 1
     _6 = icmp.eq _2 _5
-    branch _6 ? bb3 : bb13
-  bb13:
+    branch _6 ? bb3 : bb10
+  bb10:
     _7 = const.i64 2
     _8 = icmp.eq _2 _7
-    branch _8 ? bb4 : bb14
-  bb14:
+    branch _8 ? bb4 : bb11
+  bb11:
     _9 = const.i64 3
     _10 = icmp.eq _2 _9
-    branch _10 ? bb5 : bb15
-  bb15:
+    branch _10 ? bb5 : bb12
+  bb12:
     _11 = const.i64 4
     _12 = icmp.eq _2 _11
-    branch _12 ? bb6 : bb16
-  bb16:
+    branch _12 ? bb6 : bb13
+  bb13:
     _13 = const.i64 5
     _14 = icmp.eq _2 _13
-    branch _14 ? bb7 : bb17
+    branch _14 ? bb7 : bb8
+  bb14:
+    _18 = call string_concat(_16, _17) -> bb15
+  bb15:
+    _19 = string_lit ")"
+    _20 = call string_concat(_18, _19) -> bb16
+  bb16:
+    _1 = move _20
+    goto bb1
   bb17:
-    _15 = const.i64 6
-    _16 = icmp.eq _2 _15
-    branch _16 ? bb8 : bb18
+    _24 = call string_concat(_22, _23) -> bb18
   bb18:
-    _17 = const.i64 7
-    _18 = icmp.eq _2 _17
-    branch _18 ? bb9 : bb19
-  bb19:
-    _19 = const.i64 8
-    _20 = icmp.eq _2 _19
-    branch _20 ? bb10 : bb11
-  bb20:
-    _24 = call string_concat(_22, _23) -> bb21
-  bb21:
     _25 = string_lit ")"
-    _26 = call string_concat(_24, _25) -> bb22
-  bb22:
+    _26 = call string_concat(_24, _25) -> bb19
+  bb19:
     _1 = move _26
     goto bb1
-  bb23:
-    _30 = call string_concat(_28, _29) -> bb24
-  bb24:
+  bb20:
+    _30 = call string_concat(_28, _29) -> bb21
+  bb21:
     _31 = string_lit ")"
-    _32 = call string_concat(_30, _31) -> bb25
-  bb25:
+    _32 = call string_concat(_30, _31) -> bb22
+  bb22:
     _1 = move _32
     goto bb1
-  bb26:
-    _36 = call string_concat(_34, _35) -> bb27
-  bb27:
+  bb23:
+    _36 = call string_concat(_34, _35) -> bb24
+  bb24:
     _37 = string_lit ")"
-    _38 = call string_concat(_36, _37) -> bb28
-  bb28:
+    _38 = call string_concat(_36, _37) -> bb25
+  bb25:
     _1 = move _38
     goto bb1
-  bb29:
-    _42 = call string_concat(_40, _41) -> bb30
-  bb30:
+  bb26:
+    _42 = call string_concat(_40, _41) -> bb27
+  bb27:
     _43 = string_lit ")"
-    _44 = call string_concat(_42, _43) -> bb31
-  bb31:
+    _44 = call string_concat(_42, _43) -> bb28
+  bb28:
     _1 = move _44
     goto bb1
-  bb32:
-    _48 = call string_concat(_46, _47) -> bb33
-  bb33:
+  bb29:
+    _48 = call string_concat(_46, _47) -> bb30
+  bb30:
     _49 = string_lit ")"
-    _50 = call string_concat(_48, _49) -> bb34
-  bb34:
+    _50 = call string_concat(_48, _49) -> bb31
+  bb31:
     _1 = move _50
-    goto bb1
-  bb35:
-    _54 = call string_concat(_52, _53) -> bb36
-  bb36:
-    _55 = string_lit ")"
-    _56 = call string_concat(_54, _55) -> bb37
-  bb37:
-    _1 = move _56
-    goto bb1
-  bb38:
-    _60 = call string_concat(_58, _59) -> bb39
-  bb39:
-    _61 = string_lit ")"
-    _62 = call string_concat(_60, _61) -> bb40
-  bb40:
-    _1 = move _62
-    goto bb1
-  bb41:
-    _66 = call string_concat(_64, _65) -> bb42
-  bb42:
-    _67 = string_lit ")"
-    _68 = call string_concat(_66, _67) -> bb43
-  bb43:
-    _1 = move _68
-    goto bb1
-  bb44:
-    _72 = call string_concat(_70, _71) -> bb45
-  bb45:
-    _73 = string_lit ")"
-    _74 = call string_concat(_72, _73) -> bb46
-  bb46:
-    _1 = move _74
     goto bb1
 
 fn fs$io_error_timed_out() -> IoError [conv=default]
@@ -565,11 +385,11 @@ fn fs$io_error_timed_out() -> IoError [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: return site=Some(SiteId(195)) ty=IoError
-    _1 = const.i64 5
+    stmt: return site=Some(SiteId(132)) ty=IoError
+    _1 = const.i64 3
     mtag0 = move _1
     _2 = const.i64 0
-    mvar0.5.0 = move _2
+    mvar0.3.0 = move _2
     ret = move _0
     return
 
@@ -579,11 +399,11 @@ fn fs$io_error_cancelled() -> IoError [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: return site=Some(SiteId(197)) ty=IoError
-    _1 = const.i64 6
+    stmt: return site=Some(SiteId(134)) ty=IoError
+    _1 = const.i64 4
     mtag0 = move _1
     _2 = const.i64 0
-    mvar0.6.0 = move _2
+    mvar0.4.0 = move _2
     ret = move _0
     return
 
@@ -598,21 +418,21 @@ fn fs$missing_parent(string) -> bool [conv=default]
     _6: bool
     _7: bool
   bb0:
-    stmt: use BindingId(17) target site=SiteId(200) ty=string intent=Read
+    stmt: use BindingId(14) target site=SiteId(137) ty=string intent=Read
     _1 = call fs$dirname(_0) -> bb1
   bb1:
-    stmt: bind BindingId(18) parent site=SiteId(199) ty=string
-    stmt: use BindingId(18) parent site=SiteId(204) ty=string intent=Read
+    stmt: bind BindingId(15) parent site=SiteId(136) ty=string
+    stmt: use BindingId(15) parent site=SiteId(141) ty=string intent=Read
     _2 = move _1
     _3 = const.i64 0
     _4 = string_lit ""
     _5 = icmp.ne _2 _4
     branch _5 ? bb2 : bb3
   bb2:
-    stmt: use BindingId(18) parent site=SiteId(208) ty=string intent=Read
+    stmt: use BindingId(15) parent site=SiteId(145) ty=string intent=Read
     _6 = call fs$exists(_2) -> bb4
   bb3:
-    stmt: return site=Some(SiteId(202)) ty=bool
+    stmt: return site=Some(SiteId(139)) ty=bool
     ret = move _3
     return
   bb4:
@@ -638,52 +458,52 @@ fn fs$dirname(string) -> string [conv=default]
     _13: i64
     _14: string
   bb0:
-    stmt: use BindingId(19) p site=SiteId(211) ty=string intent=Read
+    stmt: use BindingId(16) p site=SiteId(148) ty=string intent=Read
     _1 = call fs$strip_trailing_slash(_0) -> bb1
   bb1:
-    stmt: bind BindingId(20) s site=SiteId(210) ty=string
-    stmt: use BindingId(20) s site=SiteId(214) ty=string intent=Read
+    stmt: bind BindingId(17) s site=SiteId(147) ty=string
+    stmt: use BindingId(17) s site=SiteId(151) ty=string intent=Read
     _2 = move _1
     _3 = call fs$last_slash_pos(_2) -> bb2
   bb2:
-    stmt: bind BindingId(21) pos site=SiteId(213) ty=i64
-    stmt: use BindingId(21) pos site=SiteId(217) ty=i64 intent=Read
+    stmt: bind BindingId(18) pos site=SiteId(150) ty=i64
+    stmt: use BindingId(18) pos site=SiteId(154) ty=i64 intent=Read
     _4 = move _3
     _6 = const.i64 0
     _7 = icmp.slt _4 _6
     branch _7 ? bb3 : bb4
   bb3:
-    stmt: return site=Some(SiteId(219)) ty=string
+    stmt: return site=Some(SiteId(156)) ty=string
     _8 = string_lit ""
     ret = move _8
     return
   bb4:
     goto bb5
   bb5:
-    stmt: eval site=SiteId(221) ty=()
-    stmt: use BindingId(21) pos site=SiteId(223) ty=i64 intent=Read
+    stmt: eval site=SiteId(158) ty=()
+    stmt: use BindingId(18) pos site=SiteId(160) ty=i64 intent=Read
     _10 = const.i64 0
     _11 = icmp.eq _4 _10
     branch _11 ? bb7 : bb8
   bb6:
     goto bb5
   bb7:
-    stmt: return site=Some(SiteId(225)) ty=string
+    stmt: return site=Some(SiteId(162)) ty=string
     _12 = string_lit "/"
     ret = move _12
     return
   bb8:
     goto bb9
   bb9:
-    stmt: eval site=SiteId(227) ty=()
-    stmt: use BindingId(20) s site=SiteId(229) ty=string intent=Read
-    stmt: use BindingId(21) pos site=SiteId(231) ty=i64 intent=Read
+    stmt: eval site=SiteId(164) ty=()
+    stmt: use BindingId(17) s site=SiteId(166) ty=string intent=Read
+    stmt: use BindingId(18) pos site=SiteId(168) ty=i64 intent=Read
     _13 = const.i64 0
     _14 = call hew_string_slice(_2, _13, _4) -> bb11
   bb10:
     goto bb9
   bb11:
-    stmt: return site=Some(SiteId(228)) ty=string
+    stmt: return site=Some(SiteId(165)) ty=string
     ret = move _14
     return
 
@@ -711,13 +531,13 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
     _19: string
     _20: string
   bb0:
-    stmt: use BindingId(22) p site=SiteId(234) ty=string intent=Read
+    stmt: use BindingId(19) p site=SiteId(171) ty=string intent=Read
     _2 = string_lit "/"
     _3 = icmp.eq _0 _2
     branch _3 ? bb1 : bb2
   bb1:
-    stmt: use BindingId(22) p site=SiteId(238) ty=string intent=Read
-    stmt: return site=Some(SiteId(236)) ty=string
+    stmt: use BindingId(19) p site=SiteId(175) ty=string intent=Read
+    stmt: return site=Some(SiteId(173)) ty=string
     _4 = string_lit ""
     _5 = call_rt hew_string_concat(_4, _0)
     ret = move _5
@@ -725,8 +545,8 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
   bb2:
     goto bb3
   bb3:
-    stmt: eval site=SiteId(240) ty=()
-    stmt: use BindingId(22) p site=SiteId(244) ty=string intent=Read
+    stmt: eval site=SiteId(177) ty=()
+    stmt: use BindingId(19) p site=SiteId(181) ty=string intent=Read
     _7 = const.i64 0
     _8 = call hew_string_length(_0) -> bb5
   bb4:
@@ -736,7 +556,7 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
     _10 = icmp.sgt _8 _9
     branch _10 ? bb6 : bb7
   bb6:
-    stmt: use BindingId(22) p site=SiteId(248) ty=string intent=Read
+    stmt: use BindingId(19) p site=SiteId(185) ty=string intent=Read
     _11 = string_lit "/"
     _12 = call hew_string_ends_with(_0, _11) -> bb8
   bb7:
@@ -745,16 +565,16 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
     _7 = move _12
     goto bb7
   bb9:
-    stmt: use BindingId(22) p site=SiteId(252) ty=string intent=Read
-    stmt: use BindingId(22) p site=SiteId(256) ty=string intent=Read
+    stmt: use BindingId(19) p site=SiteId(189) ty=string intent=Read
+    stmt: use BindingId(19) p site=SiteId(193) ty=string intent=Read
     _13 = const.i64 0
     _14 = call hew_string_length(_0) -> bb12
   bb10:
     goto bb11
   bb11:
-    stmt: eval site=SiteId(261) ty=()
-    stmt: use BindingId(22) p site=SiteId(264) ty=string intent=Read
-    stmt: return site=Some(SiteId(262)) ty=string
+    stmt: eval site=SiteId(198) ty=()
+    stmt: use BindingId(19) p site=SiteId(201) ty=string intent=Read
+    stmt: return site=Some(SiteId(199)) ty=string
     _19 = string_lit ""
     _20 = call_rt hew_string_concat(_19, _0)
     ret = move _20
@@ -768,7 +588,7 @@ fn fs$strip_trailing_slash(string) -> string [conv=default]
   bb14:
     _18 = call hew_string_slice(_0, _13, _16) -> bb15
   bb15:
-    stmt: return site=Some(SiteId(251)) ty=string
+    stmt: return site=Some(SiteId(188)) ty=string
     ret = move _18
     return
   bb16:
@@ -808,12 +628,12 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
     _29: i64
     _30: bool
   bb0:
-    stmt: use BindingId(23) s site=SiteId(266) ty=string intent=Read
+    stmt: use BindingId(20) s site=SiteId(203) ty=string intent=Read
     _1 = string_lit "/"
     _2 = call hew_string_find(_0, _1) -> bb1
   bb1:
-    stmt: bind BindingId(24) first site=SiteId(265) ty=i64
-    stmt: use BindingId(24) first site=SiteId(270) ty=i64 intent=Read
+    stmt: bind BindingId(21) first site=SiteId(202) ty=i64
+    stmt: use BindingId(21) first site=SiteId(207) ty=i64 intent=Read
     _3 = move _2
     _5 = const.i64 0
     _6 = icmp.slt _3 _5
@@ -825,10 +645,10 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb3:
     goto bb4
   bb4:
-    stmt: eval site=SiteId(275) ty=()
-    stmt: use BindingId(24) first site=SiteId(276) ty=i64 intent=Consume
-    stmt: bind BindingId(25) last site=SiteId(276) ty=i64
-    stmt: use BindingId(24) first site=SiteId(278) ty=i64 intent=Read
+    stmt: eval site=SiteId(212) ty=()
+    stmt: use BindingId(21) first site=SiteId(213) ty=i64 intent=Consume
+    stmt: bind BindingId(22) last site=SiteId(213) ty=i64
+    stmt: use BindingId(21) first site=SiteId(215) ty=i64 intent=Read
     _10 = move _3
     _11 = const.i64 1
     _12 ovf=_13 = add.checked.s _3 _11
@@ -836,7 +656,7 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb5:
     trap(IntegerOverflow)
   bb6:
-    stmt: return site=Some(SiteId(272)) ty=i64
+    stmt: return site=Some(SiteId(209)) ty=i64
     ret = move _8
     return
   bb7:
@@ -844,22 +664,22 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb8:
     trap(IntegerOverflow)
   bb9:
-    stmt: bind BindingId(26) search_from site=SiteId(277) ty=i64
+    stmt: bind BindingId(23) search_from site=SiteId(214) ty=i64
     _14 = move _12
     goto bb10
   bb10:
-    stmt: use BindingId(26) search_from site=SiteId(281) ty=i64 intent=Read
-    stmt: use BindingId(23) s site=SiteId(283) ty=string intent=Read
+    stmt: use BindingId(23) search_from site=SiteId(218) ty=i64 intent=Read
+    stmt: use BindingId(20) s site=SiteId(220) ty=string intent=Read
     _15 = call hew_string_length(_0) -> bb13
   bb11:
-    stmt: use BindingId(23) s site=SiteId(286) ty=string intent=Read
-    stmt: use BindingId(26) search_from site=SiteId(287) ty=i64 intent=Read
-    stmt: use BindingId(23) s site=SiteId(289) ty=string intent=Read
+    stmt: use BindingId(20) s site=SiteId(223) ty=string intent=Read
+    stmt: use BindingId(23) search_from site=SiteId(224) ty=i64 intent=Read
+    stmt: use BindingId(20) s site=SiteId(226) ty=string intent=Read
     _17 = call hew_string_length(_0) -> bb14
   bb12:
-    stmt: eval site=SiteId(310) ty=()
-    stmt: use BindingId(25) last site=SiteId(311) ty=i64 intent=Read
-    stmt: return site=Some(SiteId(311)) ty=i64
+    stmt: eval site=SiteId(247) ty=()
+    stmt: use BindingId(22) last site=SiteId(248) ty=i64 intent=Read
+    stmt: return site=Some(SiteId(248)) ty=i64
     ret = move _10
     return
   bb13:
@@ -868,29 +688,29 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb14:
     _18 = call hew_string_slice(_0, _14, _17) -> bb15
   bb15:
-    stmt: bind BindingId(27) rest site=SiteId(285) ty=string
-    stmt: use BindingId(27) rest site=SiteId(293) ty=string intent=Read
+    stmt: bind BindingId(24) rest site=SiteId(222) ty=string
+    stmt: use BindingId(24) rest site=SiteId(230) ty=string intent=Read
     _19 = move _18
     _20 = string_lit "/"
     _21 = call hew_string_find(_19, _20) -> bb16
   bb16:
-    stmt: bind BindingId(28) next site=SiteId(292) ty=i64
-    stmt: use BindingId(28) next site=SiteId(297) ty=i64 intent=Read
+    stmt: bind BindingId(25) next site=SiteId(229) ty=i64
+    stmt: use BindingId(25) next site=SiteId(234) ty=i64 intent=Read
     _22 = move _21
     _24 = const.i64 0
     _25 = icmp.slt _22 _24
     branch _25 ? bb17 : bb18
   bb17:
-    stmt: use BindingId(25) last site=SiteId(299) ty=i64 intent=Consume
-    stmt: return site=Some(SiteId(299)) ty=i64
+    stmt: use BindingId(22) last site=SiteId(236) ty=i64 intent=Consume
+    stmt: return site=Some(SiteId(236)) ty=i64
     ret = move _10
     return
   bb18:
     goto bb19
   bb19:
-    stmt: eval site=SiteId(301) ty=()
-    stmt: use BindingId(26) search_from site=SiteId(304) ty=i64 intent=Read
-    stmt: use BindingId(28) next site=SiteId(305) ty=i64 intent=Read
+    stmt: eval site=SiteId(238) ty=()
+    stmt: use BindingId(23) search_from site=SiteId(241) ty=i64 intent=Read
+    stmt: use BindingId(25) next site=SiteId(242) ty=i64 intent=Read
     _26 ovf=_27 = add.checked.s _14 _22
     branch _27 ? bb21 : bb22
   bb20:
@@ -898,8 +718,8 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb21:
     trap(IntegerOverflow)
   bb22:
-    stmt: eval site=SiteId(303) ty=()
-    stmt: use BindingId(25) last site=SiteId(308) ty=i64 intent=Read
+    stmt: eval site=SiteId(240) ty=()
+    stmt: use BindingId(22) last site=SiteId(245) ty=i64 intent=Read
     _10 = move _26
     _28 = const.i64 1
     _29 ovf=_30 = add.checked.s _10 _28
@@ -907,7 +727,7 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb23:
     trap(IntegerOverflow)
   bb24:
-    stmt: eval site=SiteId(307) ty=()
+    stmt: eval site=SiteId(244) ty=()
     _14 = move _29
     goto bb10
 
@@ -925,7 +745,7 @@ fn fs$write_error(string) -> IoError [conv=default]
     _9: i64
     _10: IoError
   bb0:
-    stmt: use BindingId(29) target site=SiteId(314) ty=string intent=Read
+    stmt: use BindingId(26) target site=SiteId(251) ty=string intent=Read
     _2 = call fs$missing_parent(_0) -> bb1
   bb1:
     branch _2 ? bb2 : bb3
@@ -938,15 +758,15 @@ fn fs$write_error(string) -> IoError [conv=default]
     _1 = move _6
     goto bb4
   bb3:
-    _8 = const.i64 8
+    _8 = const.i64 5
     mtag7 = move _8
     _9 = const.i64 0
-    mvar7.8.0 = move _9
+    mvar7.5.0 = move _9
     _10 = move _7
     _1 = move _10
     goto bb4
   bb4:
-    stmt: return site=Some(SiteId(312)) ty=IoError
+    stmt: return site=Some(SiteId(249)) ty=IoError
     ret = move _1
     return
 
@@ -964,15 +784,15 @@ fn fs$missing_path_error(string) -> IoError [conv=default]
     _9: i64
     _10: IoError
   bb0:
-    stmt: use BindingId(30) target site=SiteId(324) ty=string intent=Read
+    stmt: use BindingId(27) target site=SiteId(261) ty=string intent=Read
     _2 = call fs$exists(_0) -> bb1
   bb1:
     branch _2 ? bb2 : bb3
   bb2:
-    _4 = const.i64 8
+    _4 = const.i64 5
     mtag3 = move _4
     _5 = const.i64 0
-    mvar3.8.0 = move _5
+    mvar3.5.0 = move _5
     _6 = move _3
     _1 = move _6
     goto bb4
@@ -985,7 +805,7 @@ fn fs$missing_path_error(string) -> IoError [conv=default]
     _1 = move _10
     goto bb4
   bb4:
-    stmt: return site=Some(SiteId(322)) ty=IoError
+    stmt: return site=Some(SiteId(259)) ty=IoError
     ret = move _1
     return
 
@@ -1009,7 +829,7 @@ fn fs$mkdir_error(string) -> IoError [conv=default]
     _15: i64
     _16: IoError
   bb0:
-    stmt: use BindingId(31) target site=SiteId(334) ty=string intent=Read
+    stmt: use BindingId(28) target site=SiteId(271) ty=string intent=Read
     _2 = call fs$exists(_0) -> bb1
   bb1:
     branch _2 ? bb2 : bb3
@@ -1022,10 +842,10 @@ fn fs$mkdir_error(string) -> IoError [conv=default]
     _1 = move _6
     goto bb4
   bb3:
-    stmt: use BindingId(31) target site=SiteId(341) ty=string intent=Read
+    stmt: use BindingId(28) target site=SiteId(278) ty=string intent=Read
     _8 = call fs$missing_parent(_0) -> bb5
   bb4:
-    stmt: return site=Some(SiteId(332)) ty=IoError
+    stmt: return site=Some(SiteId(269)) ty=IoError
     ret = move _1
     return
   bb5:
@@ -1039,10 +859,10 @@ fn fs$mkdir_error(string) -> IoError [conv=default]
     _7 = move _12
     goto bb8
   bb7:
-    _14 = const.i64 8
+    _14 = const.i64 5
     mtag13 = move _14
     _15 = const.i64 0
-    mvar13.8.0 = move _15
+    mvar13.5.0 = move _15
     _16 = move _13
     _7 = move _16
     goto bb8
@@ -1072,7 +892,7 @@ fn fs$move_copy_error(string, string) -> IoError [conv=default]
     _17: i64
     _18: IoError
   bb0:
-    stmt: use BindingId(32) source site=SiteId(352) ty=string intent=Read
+    stmt: use BindingId(29) source site=SiteId(289) ty=string intent=Read
     _3 = call fs$exists(_0) -> bb1
   bb1:
     _4 = not _3
@@ -1086,10 +906,10 @@ fn fs$move_copy_error(string, string) -> IoError [conv=default]
     _2 = move _8
     goto bb4
   bb3:
-    stmt: use BindingId(33) target site=SiteId(359) ty=string intent=Read
+    stmt: use BindingId(30) target site=SiteId(296) ty=string intent=Read
     _10 = call fs$missing_parent(_1) -> bb5
   bb4:
-    stmt: return site=Some(SiteId(349)) ty=IoError
+    stmt: return site=Some(SiteId(286)) ty=IoError
     ret = move _2
     return
   bb5:
@@ -1103,10 +923,10 @@ fn fs$move_copy_error(string, string) -> IoError [conv=default]
     _9 = move _14
     goto bb8
   bb7:
-    _16 = const.i64 8
+    _16 = const.i64 5
     mtag15 = move _16
     _17 = const.i64 0
-    mvar15.8.0 = move _17
+    mvar15.5.0 = move _17
     _18 = move _15
     _9 = move _18
     goto bb8
@@ -1150,15 +970,15 @@ fn fs$read(string) -> string [conv=default]
     _31: ()
     _32: string
   bb0:
-    stmt: use BindingId(34) path site=SiteId(369) ty=string intent=Read
+    stmt: use BindingId(31) path site=SiteId(306) ty=string intent=Read
     _1 = call hew_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(35) contents site=SiteId(368) ty=string
+    stmt: bind BindingId(32) contents site=SiteId(305) ty=string
     _2 = move _1
     _3 = call hew_stream_last_errno() -> bb2
   bb2:
-    stmt: bind BindingId(36) errno site=SiteId(371) ty=i32
-    stmt: use BindingId(36) errno site=SiteId(374) ty=i32 intent=Read
+    stmt: bind BindingId(33) errno site=SiteId(308) ty=i32
+    stmt: use BindingId(33) errno site=SiteId(311) ty=i32 intent=Read
     _4 = move _3
     _6 = const.i64 0
     _7 = icmp.ne _4 _6
@@ -1168,15 +988,15 @@ fn fs$read(string) -> string [conv=default]
   bb4:
     goto bb5
   bb5:
-    stmt: eval site=SiteId(426) ty=()
-    stmt: use BindingId(35) contents site=SiteId(427) ty=string intent=Read
-    stmt: return site=Some(SiteId(367)) ty=string
+    stmt: eval site=SiteId(363) ty=()
+    stmt: use BindingId(32) contents site=SiteId(364) ty=string intent=Read
+    stmt: return site=Some(SiteId(304)) ty=string
     _32 = move _2
     ret = move _32
     return
   bb6:
-    stmt: bind BindingId(37) detail site=SiteId(376) ty=string
-    stmt: use BindingId(37) detail site=SiteId(381) ty=string intent=Read
+    stmt: bind BindingId(34) detail site=SiteId(313) ty=string
+    stmt: use BindingId(34) detail site=SiteId(318) ty=string intent=Read
     _9 = move _8
     _11 = call hew_string_length(_9) -> bb7
   bb7:
@@ -1184,11 +1004,11 @@ fn fs$read(string) -> string [conv=default]
     _13 = icmp.eq _11 _12
     branch _13 ? bb8 : bb9
   bb8:
-    stmt: use BindingId(34) path site=SiteId(388) ty=string intent=Read
+    stmt: use BindingId(31) path site=SiteId(325) ty=string intent=Read
     _14 = string_lit "fs.read failed for `"
     _15 = call string::fmt(_0) -> bb11
   bb9:
-    stmt: use BindingId(34) path site=SiteId(411) ty=string intent=Read
+    stmt: use BindingId(31) path site=SiteId(348) ty=string intent=Read
     _24 = string_lit "fs.read failed for `"
     _25 = call string::fmt(_0) -> bb19
   bb10:
@@ -1201,7 +1021,7 @@ fn fs$read(string) -> string [conv=default]
     _17 = string_lit "`: "
     _18 = call string_concat(_16, _17) -> bb13
   bb13:
-    stmt: use BindingId(36) errno site=SiteId(395) ty=i32 intent=Read
+    stmt: use BindingId(33) errno site=SiteId(332) ty=i32 intent=Read
     _19 = cast _4 i32 -> i64
     _20 = call fs$io_error_from_errno(_19) -> bb14
   bb14:
@@ -1213,7 +1033,7 @@ fn fs$read(string) -> string [conv=default]
   bb17:
     call panic(_23) -> bb18
   bb18:
-    stmt: eval site=SiteId(385) ty=!
+    stmt: eval site=SiteId(322) ty=!
     goto bb10
   bb19:
     _26 = call string_concat(_24, _25) -> bb20
@@ -1221,14 +1041,14 @@ fn fs$read(string) -> string [conv=default]
     _27 = string_lit "`: "
     _28 = call string_concat(_26, _27) -> bb21
   bb21:
-    stmt: use BindingId(37) detail site=SiteId(415) ty=string intent=Read
+    stmt: use BindingId(34) detail site=SiteId(352) ty=string intent=Read
     _29 = call string::fmt(_9) -> bb22
   bb22:
     _30 = call string_concat(_28, _29) -> bb23
   bb23:
     call panic(_30) -> bb24
   bb24:
-    stmt: eval site=SiteId(408) ty=!
+    stmt: eval site=SiteId(345) ty=!
     goto bb10
 
 fn fs$try_read(string) -> Result<string, IoError> [conv=default]
@@ -1252,24 +1072,24 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
     _16: Result<string, IoError>
     _17: Result<string, IoError>
   bb0:
-    stmt: use BindingId(38) file_path site=SiteId(430) ty=string intent=Read
+    stmt: use BindingId(35) file_path site=SiteId(367) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(39) file site=SiteId(429) ty=FileReadStream
-    stmt: use BindingId(39) file site=SiteId(434) ty=FileReadStream intent=Read
+    stmt: bind BindingId(36) file site=SiteId(366) ty=FileReadStream
+    stmt: use BindingId(36) file site=SiteId(371) ty=FileReadStream intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(39) file site=SiteId(439) ty=FileReadStream intent=Read
+    stmt: use BindingId(36) file site=SiteId(376) ty=FileReadStream intent=Read
     _6 = const.i64 0
     mtag5 = move _6
     _7 = call hew_stream_collect_string(_2) -> bb6
   bb4:
     _9 = call hew_stream_last_errno() -> bb7
   bb5:
-    stmt: return site=Some(SiteId(428)) ty=Result<string, IoError>
+    stmt: return site=Some(SiteId(365)) ty=Result<string, IoError>
     _17 = move _3
     ret = move _17
     return
@@ -1279,12 +1099,12 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
     _3 = move _8
     goto bb5
   bb7:
-    stmt: bind BindingId(40) errno site=SiteId(442) ty=i32
+    stmt: bind BindingId(37) errno site=SiteId(379) ty=i32
     _10 = move _9
     _11 = call hew_stream_last_error() -> bb8
   bb8:
-    stmt: eval site=SiteId(444) ty=string
-    stmt: use BindingId(40) errno site=SiteId(449) ty=i32 intent=Read
+    stmt: eval site=SiteId(381) ty=string
+    stmt: use BindingId(37) errno site=SiteId(386) ty=i32 intent=Read
     _13 = const.i64 1
     mtag12 = move _13
     _14 = cast _10 i32 -> i64
@@ -1303,11 +1123,11 @@ fn fs$write(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(41) path site=SiteId(454) ty=string intent=Read
-    stmt: use BindingId(42) content site=SiteId(455) ty=string intent=Read
+    stmt: use BindingId(38) path site=SiteId(391) ty=string intent=Read
+    stmt: use BindingId(39) content site=SiteId(392) ty=string intent=Read
     _2 = call hew_file_write(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(451)) ty=i64
+    stmt: return site=Some(SiteId(388)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1329,14 +1149,14 @@ fn fs$try_write(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(43) file_path site=SiteId(460) ty=string intent=Read
-    stmt: use BindingId(44) content site=SiteId(461) ty=string intent=Read
+    stmt: use BindingId(40) file_path site=SiteId(397) ty=string intent=Read
+    stmt: use BindingId(41) content site=SiteId(398) ty=string intent=Read
     _3 = call hew_file_write(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(457)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(394)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1344,7 +1164,7 @@ fn fs$try_write(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(43) file_path site=SiteId(467) ty=string intent=Read
+    stmt: use BindingId(40) file_path site=SiteId(404) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$write_error(_0) -> bb7
@@ -1370,11 +1190,11 @@ fn fs$append(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(45) path site=SiteId(472) ty=string intent=Read
-    stmt: use BindingId(46) content site=SiteId(473) ty=string intent=Read
+    stmt: use BindingId(42) path site=SiteId(409) ty=string intent=Read
+    stmt: use BindingId(43) content site=SiteId(410) ty=string intent=Read
     _2 = call hew_file_append(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(469)) ty=i64
+    stmt: return site=Some(SiteId(406)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1396,14 +1216,14 @@ fn fs$try_append(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(47) file_path site=SiteId(478) ty=string intent=Read
-    stmt: use BindingId(48) content site=SiteId(479) ty=string intent=Read
+    stmt: use BindingId(44) file_path site=SiteId(415) ty=string intent=Read
+    stmt: use BindingId(45) content site=SiteId(416) ty=string intent=Read
     _3 = call hew_file_append(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(475)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(412)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1411,7 +1231,7 @@ fn fs$try_append(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(47) file_path site=SiteId(485) ty=string intent=Read
+    stmt: use BindingId(44) file_path site=SiteId(422) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$write_error(_0) -> bb7
@@ -1435,10 +1255,10 @@ fn fs$exists(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(49) path site=SiteId(489) ty=string intent=Read
+    stmt: use BindingId(46) path site=SiteId(426) ty=string intent=Read
     _1 = call hew_file_exists(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(487)) ty=bool
+    stmt: return site=Some(SiteId(424)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -1450,10 +1270,10 @@ fn fs$delete(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(50) path site=SiteId(494) ty=string intent=Read
+    stmt: use BindingId(47) path site=SiteId(431) ty=string intent=Read
     _1 = call hew_file_delete(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(491)) ty=i64
+    stmt: return site=Some(SiteId(428)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1474,13 +1294,13 @@ fn fs$try_delete(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(51) file_path site=SiteId(499) ty=string intent=Read
+    stmt: use BindingId(48) file_path site=SiteId(436) ty=string intent=Read
     _2 = call hew_file_delete(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(496)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(433)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1488,7 +1308,7 @@ fn fs$try_delete(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(51) file_path site=SiteId(505) ty=string intent=Read
+    stmt: use BindingId(48) file_path site=SiteId(442) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
     _11 = call fs$missing_path_error(_0) -> bb7
@@ -1512,10 +1332,10 @@ fn fs$size(string) -> i64 [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: use BindingId(52) path site=SiteId(509) ty=string intent=Read
+    stmt: use BindingId(49) path site=SiteId(446) ty=string intent=Read
     _1 = call hew_file_size(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(507)) ty=i64
+    stmt: return site=Some(SiteId(444)) ty=i64
     _2 = move _1
     ret = move _2
     return
@@ -1526,10 +1346,10 @@ fn fs$read_bytes(string) -> bytes [conv=default]
     _1: bytes
     _2: bytes
   bb0:
-    stmt: use BindingId(53) path site=SiteId(513) ty=string intent=Read
+    stmt: use BindingId(50) path site=SiteId(450) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(511)) ty=bytes
+    stmt: return site=Some(SiteId(448)) ty=bytes
     _2 = move _1
     ret = move _2
     return
@@ -1554,28 +1374,28 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _15: Result<bytes, IoError>
     _16: Result<bytes, IoError>
   bb0:
-    stmt: use BindingId(54) file_path site=SiteId(517) ty=string intent=Read
+    stmt: use BindingId(51) file_path site=SiteId(454) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
   bb1:
-    stmt: bind BindingId(55) data site=SiteId(516) ty=bytes
+    stmt: bind BindingId(52) data site=SiteId(453) ty=bytes
     _2 = move _1
     _3 = call hew_stream_last_errno() -> bb2
   bb2:
-    stmt: bind BindingId(56) errno site=SiteId(519) ty=i32
-    stmt: use BindingId(56) errno site=SiteId(523) ty=i32 intent=Read
+    stmt: bind BindingId(53) errno site=SiteId(456) ty=i32
+    stmt: use BindingId(53) errno site=SiteId(460) ty=i32 intent=Read
     _4 = move _3
     _6 = const.i64 0
     _7 = icmp.ne _4 _6
     branch _7 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(56) errno site=SiteId(529) ty=i32 intent=Read
+    stmt: use BindingId(53) errno site=SiteId(466) ty=i32 intent=Read
     _9 = const.i64 1
     mtag8 = move _9
     _10 = cast _4 i32 -> i64
     _11 = call fs$io_error_from_errno(_10) -> bb6
   bb4:
-    stmt: use BindingId(55) data site=SiteId(533) ty=bytes intent=Read
-    stmt: agg_alias BindingId(55) data site=SiteId(533) ty=bytes
+    stmt: use BindingId(52) data site=SiteId(470) ty=bytes intent=Read
+    stmt: agg_alias BindingId(52) data site=SiteId(470) ty=bytes
     _14 = const.i64 0
     mtag13 = move _14
     mvar13.0.0 = move _2
@@ -1583,7 +1403,7 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _5 = move _15
     goto bb5
   bb5:
-    stmt: return site=Some(SiteId(515)) ty=Result<bytes, IoError>
+    stmt: return site=Some(SiteId(452)) ty=Result<bytes, IoError>
     _16 = move _5
     ret = move _16
     return
@@ -1601,11 +1421,11 @@ fn fs$write_bytes(string, bytes) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(57) path site=SiteId(537) ty=string intent=Read
-    stmt: use BindingId(58) data site=SiteId(538) ty=bytes intent=Read
+    stmt: use BindingId(54) path site=SiteId(474) ty=string intent=Read
+    stmt: use BindingId(55) data site=SiteId(475) ty=bytes intent=Read
     _2 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(534)) ty=i64
+    stmt: return site=Some(SiteId(471)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1627,14 +1447,14 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(59) file_path site=SiteId(543) ty=string intent=Read
-    stmt: use BindingId(60) data site=SiteId(544) ty=bytes intent=Read
+    stmt: use BindingId(56) file_path site=SiteId(480) ty=string intent=Read
+    stmt: use BindingId(57) data site=SiteId(481) ty=bytes intent=Read
     _3 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(540)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(477)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1642,7 +1462,7 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(59) file_path site=SiteId(550) ty=string intent=Read
+    stmt: use BindingId(56) file_path site=SiteId(487) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$write_error(_0) -> bb7
@@ -1667,10 +1487,10 @@ fn fs$mkdir(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(61) path site=SiteId(555) ty=string intent=Read
+    stmt: use BindingId(58) path site=SiteId(492) ty=string intent=Read
     _1 = call hew_fs_mkdir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(552)) ty=i64
+    stmt: return site=Some(SiteId(489)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1691,13 +1511,13 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(62) dir_path site=SiteId(560) ty=string intent=Read
+    stmt: use BindingId(59) dir_path site=SiteId(497) ty=string intent=Read
     _2 = call hew_fs_mkdir(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(557)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(494)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1705,7 +1525,7 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(62) dir_path site=SiteId(566) ty=string intent=Read
+    stmt: use BindingId(59) dir_path site=SiteId(503) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
     _11 = call fs$mkdir_error(_0) -> bb7
@@ -1730,10 +1550,10 @@ fn fs$mkdir_all(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(63) path site=SiteId(571) ty=string intent=Read
+    stmt: use BindingId(60) path site=SiteId(508) ty=string intent=Read
     _1 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(568)) ty=i64
+    stmt: return site=Some(SiteId(505)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1766,13 +1586,13 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _22: Result<i64, IoError>
     _23: Result<i64, IoError>
   bb0:
-    stmt: use BindingId(64) dir_path site=SiteId(576) ty=string intent=Read
+    stmt: use BindingId(61) dir_path site=SiteId(513) ty=string intent=Read
     _2 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(573)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(510)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1780,7 +1600,7 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(64) dir_path site=SiteId(583) ty=string intent=Read
+    stmt: use BindingId(61) dir_path site=SiteId(520) ty=string intent=Read
     _10 = call fs$exists(_0) -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
@@ -1807,10 +1627,10 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
   bb9:
     _18 = const.i64 1
     mtag17 = move _18
-    _20 = const.i64 8
+    _20 = const.i64 5
     mtag19 = move _20
     _21 = const.i64 0
-    mvar19.8.0 = move _21
+    mvar19.5.0 = move _21
     mvar17.1.0 = move _19
     _22 = move _17
     _9 = move _22
@@ -1826,10 +1646,10 @@ fn fs$list_dir(string) -> Vec<string> [conv=default]
     _1: Vec<string>
     _2: Vec<string>
   bb0:
-    stmt: use BindingId(65) path site=SiteId(595) ty=string intent=Read
+    stmt: use BindingId(62) path site=SiteId(532) ty=string intent=Read
     _1 = call hew_fs_list_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(593)) ty=Vec<string>
+    stmt: return site=Some(SiteId(530)) ty=Vec<string>
     _2 = move _1
     ret = move _2
     return
@@ -1858,13 +1678,13 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
     _19: Vec<string>
     _20: Vec<string>
   bb0:
-    stmt: use BindingId(66) dir_path site=SiteId(599) ty=string intent=Read
+    stmt: use BindingId(63) dir_path site=SiteId(536) ty=string intent=Read
     _2 = call fs$exists(_0) -> bb1
   bb1:
     _3 = not _2
     branch _3 ? bb2 : bb3
   bb2:
-    stmt: return site=Some(SiteId(601)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(538)) ty=Result<Vec<string>, IoError>
     _5 = const.i64 1
     mtag4 = move _5
     _7 = const.i64 0
@@ -1877,8 +1697,8 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   bb3:
     goto bb4
   bb4:
-    stmt: eval site=SiteId(605) ty=()
-    stmt: use BindingId(66) dir_path site=SiteId(608) ty=string intent=Read
+    stmt: eval site=SiteId(542) ty=()
+    stmt: use BindingId(63) dir_path site=SiteId(545) ty=string intent=Read
     _10 = call fs$is_dir(_0) -> bb6
   bb5:
     goto bb4
@@ -1886,28 +1706,28 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
     _11 = not _10
     branch _11 ? bb7 : bb8
   bb7:
-    stmt: return site=Some(SiteId(610)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(547)) ty=Result<Vec<string>, IoError>
     _13 = const.i64 1
     mtag12 = move _13
-    _15 = const.i64 8
+    _15 = const.i64 5
     mtag14 = move _15
     _16 = const.i64 0
-    mvar14.8.0 = move _16
+    mvar14.5.0 = move _16
     mvar12.1.0 = move _14
     ret = move _12
     return
   bb8:
     goto bb9
   bb9:
-    stmt: eval site=SiteId(614) ty=()
-    stmt: use BindingId(66) dir_path site=SiteId(618) ty=string intent=Read
+    stmt: eval site=SiteId(551) ty=()
+    stmt: use BindingId(63) dir_path site=SiteId(555) ty=string intent=Read
     _18 = const.i64 0
     mtag17 = move _18
     _19 = call hew_fs_list_dir(_0) -> bb11
   bb10:
     goto bb9
   bb11:
-    stmt: return site=Some(SiteId(615)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(552)) ty=Result<Vec<string>, IoError>
     _20 = move _19
     mvar17.0.0 = move _20
     ret = move _17
@@ -1921,11 +1741,11 @@ fn fs$rename(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(67) from site=SiteId(623) ty=string intent=Read
-    stmt: use BindingId(68) to site=SiteId(624) ty=string intent=Read
+    stmt: use BindingId(64) from site=SiteId(560) ty=string intent=Read
+    stmt: use BindingId(65) to site=SiteId(561) ty=string intent=Read
     _2 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(620)) ty=i64
+    stmt: return site=Some(SiteId(557)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1947,14 +1767,14 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(69) from site=SiteId(629) ty=string intent=Read
-    stmt: use BindingId(70) to site=SiteId(630) ty=string intent=Read
+    stmt: use BindingId(66) from site=SiteId(566) ty=string intent=Read
+    stmt: use BindingId(67) to site=SiteId(567) ty=string intent=Read
     _3 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(626)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(563)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1962,8 +1782,8 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(69) from site=SiteId(636) ty=string intent=Read
-    stmt: use BindingId(70) to site=SiteId(637) ty=string intent=Read
+    stmt: use BindingId(66) from site=SiteId(573) ty=string intent=Read
+    stmt: use BindingId(67) to site=SiteId(574) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$move_copy_error(_0, _1) -> bb7
@@ -1989,11 +1809,11 @@ fn fs$copy(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(71) from site=SiteId(642) ty=string intent=Read
-    stmt: use BindingId(72) to site=SiteId(643) ty=string intent=Read
+    stmt: use BindingId(68) from site=SiteId(579) ty=string intent=Read
+    stmt: use BindingId(69) to site=SiteId(580) ty=string intent=Read
     _2 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(639)) ty=i64
+    stmt: return site=Some(SiteId(576)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -2015,14 +1835,14 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(73) from site=SiteId(648) ty=string intent=Read
-    stmt: use BindingId(74) to site=SiteId(649) ty=string intent=Read
+    stmt: use BindingId(70) from site=SiteId(585) ty=string intent=Read
+    stmt: use BindingId(71) to site=SiteId(586) ty=string intent=Read
     _3 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(645)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(582)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -2030,8 +1850,8 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(73) from site=SiteId(655) ty=string intent=Read
-    stmt: use BindingId(74) to site=SiteId(656) ty=string intent=Read
+    stmt: use BindingId(70) from site=SiteId(592) ty=string intent=Read
+    stmt: use BindingId(71) to site=SiteId(593) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$move_copy_error(_0, _1) -> bb7
@@ -2055,10 +1875,10 @@ fn fs$is_dir(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(75) path site=SiteId(660) ty=string intent=Read
+    stmt: use BindingId(72) path site=SiteId(597) ty=string intent=Read
     _1 = call hew_fs_is_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(658)) ty=bool
+    stmt: return site=Some(SiteId(595)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -2076,31 +1896,31 @@ fn stream$pipe(i64) -> (Sink<string>, Stream<string>) [conv=default]
     _8: (Sink<string>, Stream<string>)
     _9: (Sink<string>, Stream<string>)
   bb0:
-    stmt: use BindingId(76) capacity site=SiteId(665) ty=i64 intent=Read
+    stmt: use BindingId(73) capacity site=SiteId(602) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(77) pair site=SiteId(663) ty=StreamPair
-    stmt: use BindingId(77) pair site=SiteId(668) ty=StreamPair intent=Read
+    stmt: bind BindingId(74) pair site=SiteId(600) ty=StreamPair
+    stmt: use BindingId(74) pair site=SiteId(605) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink(_3) -> bb2
   bb2:
-    stmt: bind BindingId(78) sink site=SiteId(667) ty=Sink<string>
-    stmt: use BindingId(77) pair site=SiteId(671) ty=StreamPair intent=Read
+    stmt: bind BindingId(75) sink site=SiteId(604) ty=Sink<string>
+    stmt: use BindingId(74) pair site=SiteId(608) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream(_3) -> bb3
   bb3:
-    stmt: bind BindingId(79) input site=SiteId(670) ty=Stream<string>
-    stmt: use BindingId(77) pair site=SiteId(674) ty=StreamPair intent=Read
+    stmt: bind BindingId(76) input site=SiteId(607) ty=Stream<string>
+    stmt: use BindingId(74) pair site=SiteId(611) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(673) ty=()
-    stmt: use BindingId(78) sink site=SiteId(677) ty=Sink<string> intent=Read
-    stmt: use BindingId(79) input site=SiteId(678) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(78) sink site=SiteId(677) ty=Sink<string>
-    stmt: agg_alias BindingId(79) input site=SiteId(678) ty=Stream<string>
-    stmt: return site=Some(SiteId(662)) ty=(Sink<string>, Stream<string>)
+    stmt: eval site=SiteId(610) ty=()
+    stmt: use BindingId(75) sink site=SiteId(614) ty=Sink<string> intent=Read
+    stmt: use BindingId(76) input site=SiteId(615) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(75) sink site=SiteId(614) ty=Sink<string>
+    stmt: agg_alias BindingId(76) input site=SiteId(615) ty=Stream<string>
+    stmt: return site=Some(SiteId(599)) ty=(Sink<string>, Stream<string>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2119,31 +1939,31 @@ fn stream$bytes_pipe(i64) -> (Sink<bytes>, Stream<bytes>) [conv=default]
     _8: (Sink<bytes>, Stream<bytes>)
     _9: (Sink<bytes>, Stream<bytes>)
   bb0:
-    stmt: use BindingId(80) capacity site=SiteId(682) ty=i64 intent=Read
+    stmt: use BindingId(77) capacity site=SiteId(619) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(81) pair site=SiteId(680) ty=StreamPair
-    stmt: use BindingId(81) pair site=SiteId(685) ty=StreamPair intent=Read
+    stmt: bind BindingId(78) pair site=SiteId(617) ty=StreamPair
+    stmt: use BindingId(78) pair site=SiteId(622) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink_bytes(_3) -> bb2
   bb2:
-    stmt: bind BindingId(82) sink site=SiteId(684) ty=Sink<bytes>
-    stmt: use BindingId(81) pair site=SiteId(688) ty=StreamPair intent=Read
+    stmt: bind BindingId(79) sink site=SiteId(621) ty=Sink<bytes>
+    stmt: use BindingId(78) pair site=SiteId(625) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream_bytes(_3) -> bb3
   bb3:
-    stmt: bind BindingId(83) input site=SiteId(687) ty=Stream<bytes>
-    stmt: use BindingId(81) pair site=SiteId(691) ty=StreamPair intent=Read
+    stmt: bind BindingId(80) input site=SiteId(624) ty=Stream<bytes>
+    stmt: use BindingId(78) pair site=SiteId(628) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(690) ty=()
-    stmt: use BindingId(82) sink site=SiteId(694) ty=Sink<bytes> intent=Read
-    stmt: use BindingId(83) input site=SiteId(695) ty=Stream<bytes> intent=Read
-    stmt: agg_alias BindingId(82) sink site=SiteId(694) ty=Sink<bytes>
-    stmt: agg_alias BindingId(83) input site=SiteId(695) ty=Stream<bytes>
-    stmt: return site=Some(SiteId(679)) ty=(Sink<bytes>, Stream<bytes>)
+    stmt: eval site=SiteId(627) ty=()
+    stmt: use BindingId(79) sink site=SiteId(631) ty=Sink<bytes> intent=Read
+    stmt: use BindingId(80) input site=SiteId(632) ty=Stream<bytes> intent=Read
+    stmt: agg_alias BindingId(79) sink site=SiteId(631) ty=Sink<bytes>
+    stmt: agg_alias BindingId(80) input site=SiteId(632) ty=Stream<bytes>
+    stmt: return site=Some(SiteId(616)) ty=(Sink<bytes>, Stream<bytes>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2165,18 +1985,18 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     _11: Result<Stream<string>, string>
     _12: Result<Stream<string>, string>
   bb0:
-    stmt: use BindingId(84) path site=SiteId(698) ty=string intent=Read
+    stmt: use BindingId(81) path site=SiteId(635) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(85) s site=SiteId(697) ty=Stream<string>
-    stmt: use BindingId(85) s site=SiteId(702) ty=Stream<string> intent=Read
+    stmt: bind BindingId(82) s site=SiteId(634) ty=Stream<string>
+    stmt: use BindingId(82) s site=SiteId(639) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(85) s site=SiteId(706) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(85) s site=SiteId(706) ty=Stream<string>
+    stmt: use BindingId(82) s site=SiteId(643) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(82) s site=SiteId(643) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2188,7 +2008,7 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(696)) ty=Result<Stream<string>, string>
+    stmt: return site=Some(SiteId(633)) ty=Result<Stream<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2218,18 +2038,18 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _15: Result<Stream<string>, fs.IoError>
     _16: Result<Stream<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(86) path site=SiteId(713) ty=string intent=Read
+    stmt: use BindingId(83) path site=SiteId(650) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(87) s site=SiteId(712) ty=Stream<string>
-    stmt: use BindingId(87) s site=SiteId(717) ty=Stream<string> intent=Read
+    stmt: bind BindingId(84) s site=SiteId(649) ty=Stream<string>
+    stmt: use BindingId(84) s site=SiteId(654) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(87) s site=SiteId(721) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(87) s site=SiteId(721) ty=Stream<string>
+    stmt: use BindingId(84) s site=SiteId(658) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(84) s site=SiteId(658) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2239,17 +2059,17 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
   bb4:
     _8 = call hew_stream_last_errno() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(711)) ty=Result<Stream<string>, fs.IoError>
+    stmt: return site=Some(SiteId(648)) ty=Result<Stream<string>, fs.IoError>
     _16 = move _3
     ret = move _16
     return
   bb6:
-    stmt: bind BindingId(88) errno site=SiteId(723) ty=i32
+    stmt: bind BindingId(85) errno site=SiteId(660) ty=i32
     _9 = move _8
     _10 = call hew_stream_last_error() -> bb7
   bb7:
-    stmt: eval site=SiteId(725) ty=string
-    stmt: use BindingId(88) errno site=SiteId(730) ty=i32 intent=Read
+    stmt: eval site=SiteId(662) ty=string
+    stmt: use BindingId(85) errno site=SiteId(667) ty=i32 intent=Read
     _12 = const.i64 1
     mtag11 = move _12
     _13 = cast _9 i32 -> i64
@@ -2276,18 +2096,18 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     _11: Result<Sink<string>, string>
     _12: Result<Sink<string>, string>
   bb0:
-    stmt: use BindingId(89) path site=SiteId(734) ty=string intent=Read
+    stmt: use BindingId(86) path site=SiteId(671) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(90) s site=SiteId(733) ty=Sink<string>
-    stmt: use BindingId(90) s site=SiteId(738) ty=Sink<string> intent=Read
+    stmt: bind BindingId(87) s site=SiteId(670) ty=Sink<string>
+    stmt: use BindingId(87) s site=SiteId(675) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(90) s site=SiteId(742) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(90) s site=SiteId(742) ty=Sink<string>
+    stmt: use BindingId(87) s site=SiteId(679) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(87) s site=SiteId(679) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2299,7 +2119,7 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(732)) ty=Result<Sink<string>, string>
+    stmt: return site=Some(SiteId(669)) ty=Result<Sink<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2329,18 +2149,18 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _15: Result<Sink<string>, fs.IoError>
     _16: Result<Sink<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(91) path site=SiteId(749) ty=string intent=Read
+    stmt: use BindingId(88) path site=SiteId(686) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(92) s site=SiteId(748) ty=Sink<string>
-    stmt: use BindingId(92) s site=SiteId(753) ty=Sink<string> intent=Read
+    stmt: bind BindingId(89) s site=SiteId(685) ty=Sink<string>
+    stmt: use BindingId(89) s site=SiteId(690) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(92) s site=SiteId(757) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(92) s site=SiteId(757) ty=Sink<string>
+    stmt: use BindingId(89) s site=SiteId(694) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(89) s site=SiteId(694) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2350,17 +2170,17 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
   bb4:
     _8 = call hew_stream_last_errno() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(747)) ty=Result<Sink<string>, fs.IoError>
+    stmt: return site=Some(SiteId(684)) ty=Result<Sink<string>, fs.IoError>
     _16 = move _3
     ret = move _16
     return
   bb6:
-    stmt: bind BindingId(93) errno site=SiteId(759) ty=i32
+    stmt: bind BindingId(90) errno site=SiteId(696) ty=i32
     _9 = move _8
     _10 = call hew_stream_last_error() -> bb7
   bb7:
-    stmt: eval site=SiteId(761) ty=string
-    stmt: use BindingId(93) errno site=SiteId(766) ty=i32 intent=Read
+    stmt: eval site=SiteId(698) ty=string
+    stmt: use BindingId(90) errno site=SiteId(703) ty=i32 intent=Read
     _12 = const.i64 1
     mtag11 = move _12
     _13 = cast _9 i32 -> i64
@@ -2376,11 +2196,11 @@ fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
     _0: Stream<string>
     _1: Sink<string>
   bb0:
-    stmt: use BindingId(94) source site=SiteId(770) ty=Stream<string> intent=Read
-    stmt: use BindingId(95) dest site=SiteId(771) ty=Sink<string> intent=Read
+    stmt: use BindingId(91) source site=SiteId(707) ty=Stream<string> intent=Read
+    stmt: use BindingId(92) dest site=SiteId(708) ty=Sink<string> intent=Read
     call hew_stream_pipe(_0, _1) -> bb1
   bb1:
-    stmt: eval site=SiteId(768) ty=()
+    stmt: eval site=SiteId(705) ty=()
     return
 
 fn i32::fmt(i32) -> string [conv=default]
@@ -2388,10 +2208,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(99) val site=SiteId(802) ty=i32 intent=Read
+    stmt: use BindingId(96) val site=SiteId(739) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(801)) ty=string
+    stmt: return site=Some(SiteId(738)) ty=string
     ret = move _1
     return
 
@@ -2400,10 +2220,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(100) val site=SiteId(805) ty=i64 intent=Read
+    stmt: use BindingId(97) val site=SiteId(742) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(804)) ty=string
+    stmt: return site=Some(SiteId(741)) ty=string
     ret = move _1
     return
 
@@ -2412,10 +2232,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(101) val site=SiteId(808) ty=u32 intent=Read
+    stmt: use BindingId(98) val site=SiteId(745) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(807)) ty=string
+    stmt: return site=Some(SiteId(744)) ty=string
     ret = move _1
     return
 
@@ -2424,10 +2244,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(102) val site=SiteId(811) ty=u64 intent=Read
+    stmt: use BindingId(99) val site=SiteId(748) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(810)) ty=string
+    stmt: return site=Some(SiteId(747)) ty=string
     ret = move _1
     return
 
@@ -2436,10 +2256,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(103) val site=SiteId(814) ty=bool intent=Read
+    stmt: use BindingId(100) val site=SiteId(751) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(813)) ty=string
+    stmt: return site=Some(SiteId(750)) ty=string
     ret = move _1
     return
 
@@ -2448,10 +2268,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(104) val site=SiteId(817) ty=char intent=Read
+    stmt: use BindingId(101) val site=SiteId(754) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(816)) ty=string
+    stmt: return site=Some(SiteId(753)) ty=string
     ret = move _1
     return
 
@@ -2460,10 +2280,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(105) val site=SiteId(820) ty=f64 intent=Read
+    stmt: use BindingId(102) val site=SiteId(757) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(819)) ty=string
+    stmt: return site=Some(SiteId(756)) ty=string
     ret = move _1
     return
 
@@ -2471,8 +2291,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(106) val site=SiteId(822) ty=string intent=Read
-    stmt: return site=Some(SiteId(822)) ty=string
+    stmt: use BindingId(103) val site=SiteId(759) ty=string intent=Read
+    stmt: return site=Some(SiteId(759)) ty=string
     ret = move _0
     return
 

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -22732,14 +22732,15 @@ pub(crate) fn emit_read_deadline_timeout_err(
     result_dest: Place,
     error_dest: Place,
 ) -> CodegenResult<()> {
-    let error_local = composite_dest_local(error_dest, "SuspendingRead IoError")?;
-    // `IoError::TimedOut` is variant index 5 in `std/fs.hew`.
-    store_composite_tag(fn_ctx, error_local, 5, "SuspendingRead IoError::TimedOut")?;
+    let error_local = composite_dest_local(error_dest, "SuspendingRead NetError")?;
+    // `NetError::TimedOut` is variant index 3 in `std/net/net.hew`
+    // (ConnectionRefused=0, AddressInUse=1, AddressNotAvailable=2, TimedOut=3).
+    store_composite_tag(fn_ctx, error_local, 3, "SuspendingRead NetError::TimedOut")?;
     let (payload_ptr, payload_ty) = place_pointer(
         fn_ctx,
         Place::MachineVariant {
             local: error_local,
-            variant_idx: 5,
+            variant_idx: 3,
             field_idx: 0,
         },
     )?;
@@ -22747,14 +22748,14 @@ pub(crate) fn emit_read_deadline_timeout_err(
         BasicTypeEnum::IntType(t) => t,
         other => {
             return Err(CodegenError::FailClosed(format!(
-                "SuspendingRead IoError::TimedOut payload must be integer, got {other:?}"
+                "SuspendingRead NetError::TimedOut payload must be integer, got {other:?}"
             )));
         }
     };
     fn_ctx
         .builder
         .build_store(payload_ptr, payload_int_ty.const_zero())
-        .llvm_ctx("store SuspendingRead IoError::TimedOut payload")?;
+        .llvm_ctx("store SuspendingRead NetError::TimedOut payload")?;
     emit_result_err(fn_ctx, result_dest, error_dest)
 }
 

--- a/hew-codegen-rs/src/suspend.rs
+++ b/hew-codegen-rs/src/suspend.rs
@@ -81,7 +81,7 @@ pub(crate) struct SuspendingReadEmit {
     pub(crate) cleanup: u32,
     /// NEW-6c `await conn.read() | after d` deadline (nanoseconds). `Some(ns)`
     /// schedules the common await-cancel arbiter against the read slot; timeout
-    /// binds `Err(IoError::TimedOut(0))`. `None` is a plain suspending read.
+    /// binds `Err(NetError::TimedOut(0))`. `None` is a plain suspending read.
     pub(crate) deadline_ns: Option<i64>,
 }
 
@@ -92,15 +92,15 @@ pub(crate) struct SuspendingAcceptEmit {
     pub(crate) result_dest: Place,
     /// When present, this accept is the source of `await ln.accept() | after d`.
     /// `result_dest` remains the raw `Connection` slot; codegen binds
-    /// `Ok(result_dest)` or `Err(IoError::TimedOut)` into this outer Result slot
+    /// `Ok(result_dest)` or `Err(NetError::TimedOut)` into this outer Result slot
     /// after resolving the await-cancel arbiter.
     pub(crate) deadline_result_dest: Option<Place>,
-    /// `IoError` payload slot for the deadline Err arm. Present exactly when
+    /// `NetError` payload slot for the deadline Err arm. Present exactly when
     /// `deadline_result_dest` is present.
     pub(crate) error_dest: Option<Place>,
     /// NEW-6d `await ln.accept() | after d` deadline (nanoseconds). `Some(ns)`
     /// schedules the common await-cancel arbiter against the read slot; timeout
-    /// binds `Err(IoError::TimedOut(0))`. `None` is a plain suspending accept.
+    /// binds `Err(NetError::TimedOut(0))`. `None` is a plain suspending accept.
     pub(crate) deadline_ns: Option<i64>,
     pub(crate) resume: u32,
     pub(crate) cleanup: u32,
@@ -320,7 +320,7 @@ pub(crate) fn emit_suspending_read_terminator<'ctx>(
         && (term.deadline_result_dest.is_none() || term.error_dest.is_none())
     {
         return Err(CodegenError::FailClosed(
-            "SuspendingRead deadline reached codegen without Result/IoError destinations".into(),
+            "SuspendingRead deadline reached codegen without Result/NetError destinations".into(),
         ));
     }
 
@@ -621,7 +621,7 @@ pub(crate) fn emit_suspending_read_terminator<'ctx>(
             CodegenError::FailClosed("SuspendingRead fail-closed missing Result dest".into())
         })?;
         let error_dest = term.error_dest.ok_or_else(|| {
-            CodegenError::FailClosed("SuspendingRead fail-closed missing IoError dest".into())
+            CodegenError::FailClosed("SuspendingRead fail-closed missing NetError dest".into())
         })?;
         emit_read_deadline_timeout_err(fn_ctx, result_dest, error_dest)?;
         fn_ctx
@@ -707,7 +707,7 @@ pub(crate) fn emit_suspending_read_terminator<'ctx>(
 /// resumed us (enqueue_resume). The bytes are already deposited in `slot`;
 /// `hew_read_slot_take_raw` writes them into `result_dest` on the fast path.
 /// On a deadline carrier the deadline-vs-read arbiter runs first (timeout binds
-/// `Err(IoError::TimedOut)`). Release the creator ref and branch to the MIR
+/// `Err(NetError::TimedOut)`). Release the creator ref and branch to the MIR
 /// resume block. Split out so the suspend-point seam owns the suspend + abandon
 /// scaffolding while this owns the value routing.
 #[allow(
@@ -792,7 +792,7 @@ fn emit_suspending_read_bind<'ctx>(
             CodegenError::FailClosed("SuspendingRead timeout missing Result dest".into())
         })?;
         let error_dest = term.error_dest.ok_or_else(|| {
-            CodegenError::FailClosed("SuspendingRead timeout missing IoError dest".into())
+            CodegenError::FailClosed("SuspendingRead timeout missing NetError dest".into())
         })?;
         emit_read_deadline_timeout_err(fn_ctx, result_dest, error_dest)?;
         fn_ctx
@@ -850,7 +850,7 @@ fn emit_suspending_read_bind<'ctx>(
                 .ok_or_else(|| {
                     CodegenError::FailClosed("hew_bytes_to_string returned void".into())
                 })?;
-            // result_dest is Result<string, IoError>; tag=0, Ok variant field 0 = ptr.
+            // result_dest is Result<string, NetError>; tag=0, Ok variant field 0 = ptr.
             // Write the string pointer directly into the Ok variant field — no
             // intermediate alloca needed since `string_val` is already a ptr value.
             let dest_local = composite_dest_local(result_dest, "SuspendingRead read_string ok")?;
@@ -967,7 +967,7 @@ pub(crate) fn emit_suspending_accept_terminator<'ctx>(
         && (term.deadline_result_dest.is_none() || term.error_dest.is_none())
     {
         return Err(CodegenError::FailClosed(
-            "SuspendingAccept deadline reached codegen without Result/IoError destinations".into(),
+            "SuspendingAccept deadline reached codegen without Result/NetError destinations".into(),
         ));
     }
 
@@ -1105,7 +1105,7 @@ pub(crate) fn emit_suspending_accept_terminator<'ctx>(
     )?;
 
     // ── register_err: the registration failed; no accept will ever arrive.
-    // Cancel + free the slot. On a deadline path, emit IoError::TimedOut into the
+    // Cancel + free the slot. On a deadline path, emit NetError::TimedOut into the
     // Result destination. On the plain path, bind an INVALID `Connection`. ──────
     fn_ctx.builder.position_at_end(register_err_bb);
     fn_ctx
@@ -1292,7 +1292,7 @@ pub(crate) fn emit_suspending_accept_terminator<'ctx>(
             CodegenError::FailClosed("SuspendingAccept fail-closed missing Result dest".into())
         })?;
         let error_dest = term.error_dest.ok_or_else(|| {
-            CodegenError::FailClosed("SuspendingAccept fail-closed missing IoError dest".into())
+            CodegenError::FailClosed("SuspendingAccept fail-closed missing NetError dest".into())
         })?;
         emit_read_deadline_timeout_err(fn_ctx, result_dest, error_dest)?;
         fn_ctx
@@ -1474,7 +1474,7 @@ fn emit_suspending_accept_bind<'ctx>(
             CodegenError::FailClosed("SuspendingAccept timeout missing Result dest".into())
         })?;
         let error_dest = term.error_dest.ok_or_else(|| {
-            CodegenError::FailClosed("SuspendingAccept timeout missing IoError dest".into())
+            CodegenError::FailClosed("SuspendingAccept timeout missing NetError dest".into())
         })?;
         emit_read_deadline_timeout_err(fn_ctx, result_dest, error_dest)?;
         fn_ctx
@@ -1502,7 +1502,7 @@ fn emit_suspending_accept_bind<'ctx>(
         .llvm_ctx("suspending accept connection store")?;
     if let Some(result_dest) = term.deadline_result_dest {
         // `await ln.accept() | after d` success path: wrap the accepted Connection
-        // in `Ok(_)` into the Result<Connection, IoError> destination.
+        // in `Ok(_)` into the Result<Connection, NetError> destination.
         emit_result_ok(fn_ctx, result_dest, Some(term.result_dest))?;
     }
     fn_ctx

--- a/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
+++ b/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
@@ -210,13 +210,13 @@ fn construct_and_match_imported_ioerror_variant_round_trips() {
         r#"
         import std::fs;
         fn make_err() -> Result<i64, fs.IoError> {
-            Err(IoError::ConnectionRefused(111))
+            Err(IoError::NotFound(111))
         }
         fn main() {
             match make_err() {
                 Ok(v) => println(f"ok: {v}"),
                 Err(e) => match e {
-                    IoError::ConnectionRefused(code) => println(f"refused {code}"),
+                    IoError::NotFound(code) => println(f"not_found {code}"),
                     _ => println("other"),
                 },
             }
@@ -228,7 +228,7 @@ fn construct_and_match_imported_ioerror_variant_round_trips() {
         "constructing+matching imported `fs.IoError` must compile and run;\nstderr:\n{stderr}"
     );
     assert!(
-        stdout.contains("refused 111"),
+        stdout.contains("not_found 111"),
         "matched arm must bind the payload and run; stdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert!(
@@ -238,7 +238,7 @@ fn construct_and_match_imported_ioerror_variant_round_trips() {
 }
 
 /// The same round-trip across the `std::net` surface that motivated the fix:
-/// `net.try_connect` returns `Result<_, fs.IoError>`; connecting to a closed
+/// `net.try_connect` returns `Result<_, net.NetError>`; connecting to a closed
 /// port on localhost yields `ConnectionRefused`, matched at the importer.
 #[test]
 fn net_try_connect_error_match_round_trips() {
@@ -252,7 +252,7 @@ fn net_try_connect_error_match_round_trips() {
             match net.try_connect("127.0.0.1:1") {
                 Ok(_) => println("connected"),
                 Err(e) => match e {
-                    IoError::ConnectionRefused(_) => println("refused"),
+                    NetError::ConnectionRefused(_) => println("refused"),
                     _ => println("other"),
                 },
             }
@@ -261,7 +261,7 @@ fn net_try_connect_error_match_round_trips() {
     );
     assert!(
         ok,
-        "`net.try_connect` + match on IoError must compile and run;\nstderr:\n{stderr}"
+        "`net.try_connect` + match on NetError must compile and run;\nstderr:\n{stderr}"
     );
     assert!(
         stdout.contains("refused") || stdout.contains("other"),

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -20218,8 +20218,9 @@ impl LowerCtx {
             return self.unsupported_expr(span.clone(), "non-await deadline combinator");
         };
         // The suspendable awaits whose timeout `Result` is concretely specced are
-        // local actor asks (`Result<R, AskError>`, `AskError::Timeout`) and raw
-        // connection reads (`Result<bytes, IoError>`, `IoError::TimedOut`).
+        // local actor asks (`Result<R, AskError>`, `AskError::Timeout`), raw
+        // connection reads (`Result<bytes, NetError>`, `NetError::TimedOut`), and
+        // listener accepts (`Result<Connection, NetError>`, `NetError::TimedOut`).
         let inner_key = self.mk_key(&await_inner.1);
         let is_local_ask = matches!(
             self.actor_method_dispatch.get(&inner_key),
@@ -20255,13 +20256,13 @@ impl LowerCtx {
                 let is_to_string = *to_string;
                 *slot = Some(deadline_ns);
                 let io_error_ty = ResolvedTy::Named {
-                    name: "IoError".to_string(),
+                    name: "NetError".to_string(),
                     args: Vec::new(),
                     builtin: None,
                     is_opaque: false,
                 };
-                // `read_string | after d` yields `Result<string, IoError>`;
-                // raw `read | after d` yields `Result<bytes, IoError>`.
+                // `read_string | after d` yields `Result<string, NetError>`;
+                // raw `read | after d` yields `Result<bytes, NetError>`.
                 let ok_ty = if is_to_string {
                     ResolvedTy::String
                 } else {
@@ -20293,12 +20294,12 @@ impl LowerCtx {
             {
                 *slot = Some(deadline_ns);
                 let io_error_ty = ResolvedTy::Named {
-                    name: "IoError".to_string(),
+                    name: "NetError".to_string(),
                     args: Vec::new(),
                     builtin: None,
                     is_opaque: false,
                 };
-                // `await ln.accept() | after d` yields `Result<Connection, IoError>`;
+                // `await ln.accept() | after d` yields `Result<Connection, NetError>`;
                 // the Ok arm carries the accepted connection type from the plain accept.
                 let ok_ty = accept_expr.ty.clone();
                 accept_expr.ty = ResolvedTy::Named {

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -1300,7 +1300,7 @@ pub enum HirExprKind {
     /// `read_string` is `await conn.read()` + `hew_bytes_to_string`, so the HIR
     /// node carries only the bytes read; the string conversion wraps it. A raw
     /// `read()` may carry a literal deadline and then resolves to
-    /// `Result<bytes, IoError>` with MIR/codegen binding `Err(TimedOut)` if the
+    /// `Result<bytes, NetError>` with MIR/codegen binding `Err(TimedOut)` if the
     /// timer wins.
     ConnAwaitRead {
         /// The connection receiver expression (`conn`).
@@ -1324,8 +1324,8 @@ pub enum HirExprKind {
         listener: Box<HirExpr>,
         /// NEW-6d `await ln.accept() | after d` deadline, in nanoseconds. `None`
         /// preserves the plain-accept `Connection` result and unconditional read-slot
-        /// wake. `Some(ns)` produces `Result<Connection, IoError>` with
-        /// `IoError::TimedOut` on the deadline arm — parallel to `ConnAwaitRead`.
+        /// wake. `Some(ns)` produces `Result<Connection, NetError>` with
+        /// `NetError::TimedOut` on the deadline arm — parallel to `ConnAwaitRead`.
         deadline_ns: Option<i64>,
     },
     /// `await rx.recv() | after d` — a suspending channel recv with a deadline

--- a/hew-lsp/src/server/analysis.rs
+++ b/hew-lsp/src/server/analysis.rs
@@ -1911,20 +1911,20 @@ mod tests {
         assert_eq!(hard_type_diagnostic(&doc), None);
         let hover = surface_hover(&doc, source, "tls.read");
         assert!(
-            hover.contains("Result<bytes,") && hover.contains("IoError"),
-            "hover over tls.read should report Result<bytes, fs.IoError>, got: {hover}",
+            hover.contains("Result<bytes,") && hover.contains("NetError"),
+            "hover over tls.read should report Result<bytes, net.NetError>, got: {hover}",
         );
         let sig = surface_sighelp(&doc, source, "tls.read");
         assert!(
             sig.iter()
                 .any(|s| s.contains("read(") && s.contains("Result<bytes,")),
-            "signature help should label tls.read -> Result<bytes, fs.IoError>, got: {sig:?}",
+            "signature help should label tls.read -> Result<bytes, net.NetError>, got: {sig:?}",
         );
         assert!(
             surface_inlays(&doc)
                 .iter()
-                .any(|l| l.contains("Result<bytes,") && l.contains("IoError")),
-            "inlay hint for `chunk` should show the Result<bytes, fs.IoError> type",
+                .any(|l| l.contains("Result<bytes,") && l.contains("NetError")),
+            "inlay hint for `chunk` should show the Result<bytes, net.NetError> type",
         );
     }
 

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -19816,7 +19816,7 @@ impl Builder {
                 deadline_ns.map(|_| self.alloc_local(self.subst_ty(&expr.ty)));
             let error_dest = deadline_ns.map(|_| {
                 self.alloc_local(ResolvedTy::Named {
-                    name: "IoError".to_string(),
+                    name: "NetError".to_string(),
                     args: Vec::new(),
                     builtin: None,
                     is_opaque: false,
@@ -20126,12 +20126,12 @@ impl Builder {
     ) -> Option<Place> {
         let listener_place = self.lower_value(listener)?;
 
-        // When a deadline is active, `expr.ty` is `Result<Connection, IoError>` (set
+        // When a deadline is active, `expr.ty` is `Result<Connection, NetError>` (set
         // by HIR). The raw `Connection` slot is the `result_dest`; codegen wraps it
-        // into `Ok(_)` or binds `Err(IoError::TimedOut)` into `deadline_result_dest`.
+        // into `Ok(_)` or binds `Err(NetError::TimedOut)` into `deadline_result_dest`.
         // Without a deadline, `expr.ty` is `Connection` directly.
         let conn_ty = if deadline_ns.is_some() {
-            // Extract the Ok arm type (Connection) from Result<Connection, IoError>.
+            // Extract the Ok arm type (Connection) from Result<Connection, NetError>.
             match &expr.ty {
                 hew_types::ResolvedTy::Named { args, .. } if !args.is_empty() => {
                     self.subst_ty(&args[0])
@@ -20151,7 +20151,7 @@ impl Builder {
                 deadline_ns.map(|_| self.alloc_local(self.subst_ty(&expr.ty)));
             let error_dest = deadline_ns.map(|_| {
                 self.alloc_local(hew_types::ResolvedTy::Named {
-                    name: "IoError".to_string(),
+                    name: "NetError".to_string(),
                     args: Vec::new(),
                     builtin: None,
                     is_opaque: false,

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -1932,24 +1932,24 @@ impl Checker {
                     {
                         Ty::result(reply_ty, Ty::ask_error())
                     } else if let Some(&to_string) = self.conn_await_reads.get(&inner_key) {
-                        // `await conn.read() | after d` → `Result<bytes, IoError>`
-                        // `await conn.read_string() | after d` → `Result<string, IoError>`
+                        // `await conn.read() | after d` → `Result<bytes, NetError>`
+                        // `await conn.read_string() | after d` → `Result<string, NetError>`
                         let ok_ty = if to_string { Ty::String } else { Ty::Bytes };
                         Ty::result(
                             ok_ty,
                             Ty::Named {
-                                name: "IoError".to_string(),
+                                name: "NetError".to_string(),
                                 args: Vec::new(),
                                 builtin: None,
                             },
                         )
                     } else if self.listener_await_accepts.contains(&inner_key) {
-                        // `await ln.accept() | after d` → `Result<Connection, IoError>`
+                        // `await ln.accept() | after d` → `Result<Connection, NetError>`
                         // The Ok type mirrors the plain await's inner type (Connection).
                         Ty::result(
                             inner_ty,
                             Ty::Named {
-                                name: "IoError".to_string(),
+                                name: "NetError".to_string(),
                                 args: Vec::new(),
                                 builtin: None,
                             },

--- a/hew-types/tests/fixtures/net_parameter_surfaces_typecheck.hew
+++ b/hew-types/tests/fixtures/net_parameter_surfaces_typecheck.hew
@@ -1,51 +1,31 @@
 import std::net;
+
 import std::net::quic;
+
 import std::net::smtp;
+
 import std::net::tls;
+
 import std::net::websocket;
-import std::fs;
 
 fn main() {
     let tls_port: i64 = 443;
     let tls_size: i64 = 4096;
     let tls_stream: tls.TlsStream = tls.connect("example.com", tls_port);
-    let _tls_chunk: Result<bytes, fs.IoError> = tls.read(tls_stream, tls_size);
-
+    let _tls_chunk: Result<bytes, net.NetError> = tls.read(tls_stream, tls_size);
     let smtp_port: i64 = 587;
     let _smtp_conn: smtp.Conn = smtp.connect("smtp.example.com", smtp_port, "user", "pass");
     let _smtp_tls_conn: smtp.Conn = smtp.connect_tls("smtp.example.com", 465, "user", "pass");
-    let _smtp_send_status: i64 = smtp.send(
-        "smtp.example.com",
-        smtp_port,
-        "user",
-        "pass",
-        "from@example.com",
-        "to@example.com",
-        "subject",
-        "body",
-    );
-    let _smtp_send_html_status: i64 = smtp.send_html(
-        "smtp.example.com",
-        smtp_port,
-        "user",
-        "pass",
-        "from@example.com",
-        "to@example.com",
-        "subject",
-        "<p>body</p>",
-    );
-
+    let _smtp_send_status: i64 = smtp.send("smtp.example.com", smtp_port, "user", "pass", "from@example.com", "to@example.com", "subject", "body");
+    let _smtp_send_html_status: i64 = smtp.send_html("smtp.example.com", smtp_port, "user", "pass", "from@example.com", "to@example.com", "subject", "<p>body</p>");
     let ws_server: websocket.Server = websocket.listen("127.0.0.1:0");
     let ws_port: i64 = ws_server.port();
-
     let timeout_ms: i64 = 1500;
     let conn: net.Connection = net.connect_timeout("127.0.0.1:8080", 1, 500000);
-    let _read_timeout_status: Result<(), fs.IoError> = conn.set_read_timeout(timeout_ms);
-    let _write_timeout_status: Result<(), fs.IoError> = conn.set_write_timeout(timeout_ms);
-
+    let _read_timeout_status: Result<(), net.NetError> = conn.set_read_timeout(timeout_ms);
+    let _write_timeout_status: Result<(), net.NetError> = conn.set_write_timeout(timeout_ms);
     let quic_conn: quic.QUICConnection = quic.new_client().connect("127.0.0.1:4433", "localhost");
     let quic_obs: quic.QUICConnectionObservation = quic_conn.observe();
     let quic_rtt: i64 = quic_obs.rtt_ms;
-
     println(ws_port + quic_rtt);
 }

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -32,14 +32,13 @@
 //! ```
 
 // ── Error type ───────────────────────────────────────────────────────
-/// Structured error type for file-system and network operations.
+/// Structured error type for file-system operations.
 ///
 /// Define `Result<T, IoError>` return types in your own functions for
 /// structured error handling with the `?` operator.
 ///
-/// Variants below cover both file-system and TCP/network failure codes so
-/// callers can handle connection errors uniformly across `fs`, `net`, `quic`,
-/// `http`, `tls`, `dns`, and `websocket` modules.
+/// For network errors (`ConnectionRefused`, `AddressInUse`, etc.) see
+/// `net.NetError` in `std::net`.
 pub enum IoError {
     /// The target path does not exist.
     NotFound(i64);
@@ -47,20 +46,13 @@ pub enum IoError {
     PermissionDenied(i64);
     /// A file or directory already exists at the target path.
     AlreadyExists(i64);
-    /// The remote host actively refused the connection (ECONNREFUSED).
-    ConnectionRefused(i64);
-    /// The local address is already in use (EADDRINUSE).
-    AddressInUse(i64);
-    /// The connection attempt or I/O operation timed out (ETIMEDOUT).
+    /// The operation timed out (e.g. the blocking pool exceeded its deadline).
     TimedOut(i64);
-    /// Operation was cancelled (e.g., a deadline expired before the I/O could complete).
+    /// Operation was cancelled (e.g., the blocking pool was shut down mid-call).
     ///
     /// Distinct from `TimedOut`: `TimedOut` means the deadline expired; `Cancelled`
-    /// means the operation was abandoned for another reason (e.g. the blocking
-    /// pool was shut down mid-call).
+    /// means the operation was abandoned for another reason.
     Cancelled(i64);
-    /// The address or hostname could not be resolved (EADDRNOTAVAIL).
-    AddressNotAvailable(i64);
     /// Any other OS-level I/O failure.
     Other(i64);
 }
@@ -71,9 +63,8 @@ pub enum IoError {
 /// The i64 payload carried in each variant is the raw OS errno so callers
 /// can inspect the platform value. errno=0 (no OS error) maps to `Other(0)`.
 ///
-/// Covers both file-system and network errno values so this function can be
-/// shared across `fs`, `net`, `stream`, `http`, `tls`, `quic`, `dns`, and
-/// `websocket` modules.
+/// Covers file-system errno values. For network errno values use
+/// `net.net_error_from_errno` in `std::net`.
 pub fn io_error_from_errno(errno: i64) -> IoError {
     // ENOENT: Linux=2, macOS=2
     if errno == 2 {
@@ -84,21 +75,12 @@ pub fn io_error_from_errno(errno: i64) -> IoError {
     // EEXIST: Linux=17, macOS=17
     } else if errno == 17 {
         IoError::AlreadyExists(errno)
-    // ECONNREFUSED: Linux=111, macOS=61
-    } else if errno == 111 || errno == 61 {
-        IoError::ConnectionRefused(errno)
-    // EADDRINUSE: Linux=98, macOS=48
-    } else if errno == 98 || errno == 48 {
-        IoError::AddressInUse(errno)
     // ETIMEDOUT: Linux=110, macOS=60
     } else if errno == 110 || errno == 60 {
         IoError::TimedOut(errno)
     // ECANCELED: Linux=125, macOS=89
     } else if errno == 125 || errno == 89 {
         IoError::Cancelled(errno)
-    // EADDRNOTAVAIL: Linux=99, macOS=49
-    } else if errno == 99 || errno == 49 {
-        IoError::AddressNotAvailable(errno)
     } else {
         IoError::Other(errno)
     }
@@ -107,7 +89,8 @@ pub fn io_error_from_errno(errno: i64) -> IoError {
 /// Return a human-readable description of an `IoError`.
 ///
 /// The returned string includes the variant name and the raw OS errno so
-/// callers can log or surface structured errors without matching on every arm:
+/// callers can log or surface structured errors without matching on every arm.
+/// For network errors use `net.net_error_message` in `std::net`.
 ///
 /// ```
 /// match result {
@@ -120,11 +103,8 @@ pub fn io_error_message(e: IoError) -> string {
         IoError::NotFound(code) => f"NotFound({code})",
         IoError::PermissionDenied(code) => f"PermissionDenied({code})",
         IoError::AlreadyExists(code) => f"AlreadyExists({code})",
-        IoError::ConnectionRefused(code) => f"ConnectionRefused({code})",
-        IoError::AddressInUse(code) => f"AddressInUse({code})",
         IoError::TimedOut(code) => f"TimedOut({code})",
         IoError::Cancelled(code) => f"Cancelled({code})",
-        IoError::AddressNotAvailable(code) => f"AddressNotAvailable({code})",
         IoError::Other(code) => f"Other({code})",
     }
 }

--- a/std/net/dns/dns.hew
+++ b/std/net/dns/dns.hew
@@ -18,7 +18,7 @@
 //! }
 //! ```
 
-import std::fs;
+import std::net;
 
 /// Resolve a hostname to all associated IP addresses.
 ///
@@ -38,16 +38,16 @@ pub fn resolve(hostname: string) -> Vec<string> {
 
 /// Resolve a hostname to all associated IP addresses.
 ///
-/// Returns `Err(fs.io_error_from_errno(0))` when the hostname cannot be resolved.
+/// Returns `Err(NetError::Other(0))` when the hostname cannot be resolved.
 /// Use this when structured error handling with `?` is preferred over an
 /// empty-vector sentinel.
 ///
 /// Note: DNS has no OS errno channel; the errno payload is always 0.
 /// A follow-up issue will wire errno once hew_dns_resolve exposes it.
-pub fn try_resolve(hostname: string) -> Result<Vec<string>, fs.IoError> {
+pub fn try_resolve(hostname: string) -> Result<Vec<string>, net.NetError> {
     let addrs = resolve(hostname);
     if addrs.len() == 0 {
-        Err(fs.io_error_from_errno(0))
+        Err(net.net_error_from_errno(0))
     } else {
         Ok(addrs)
     }
@@ -71,16 +71,16 @@ pub fn lookup_host(hostname: string) -> string {
 
 /// Resolve a hostname to its first IP address.
 ///
-/// Returns `Err(fs.io_error_from_errno(0))` when the hostname cannot be resolved.
+/// Returns `Err(NetError::Other(0))` when the hostname cannot be resolved.
 /// Use this when structured error handling with `?` is preferred over an
 /// empty-string sentinel.
 ///
 /// Note: DNS has no OS errno channel; the errno payload is always 0.
 /// A follow-up issue will wire errno once hew_dns_lookup_host exposes it.
-pub fn try_lookup_host(hostname: string) -> Result<string, fs.IoError> {
+pub fn try_lookup_host(hostname: string) -> Result<string, net.NetError> {
     let ip = lookup_host(hostname);
     if ip == "" {
-        Err(fs.io_error_from_errno(0))
+        Err(net.net_error_from_errno(0))
     } else {
         Ok(ip)
     }

--- a/std/net/http/http.hew
+++ b/std/net/http/http.hew
@@ -19,7 +19,7 @@
 //! }
 //! ```
 
-import std::fs;
+import std::net;
 
 /// An HTTP server bound to a TCP address.
 ///
@@ -137,17 +137,17 @@ trait RequestMethods {
     /// ```
     fn respond_stream(self, status: i64, content_type: string) -> Sink<string>;
 
-    /// Send a full HTTP response, returning `Err(fs.IoError)` on failure.
-    fn try_respond(self, status: i64, content_type: string, body: string) -> Result<i64, fs.IoError>;
+    /// Send a full HTTP response, returning `Err(net.NetError)` on failure.
+    fn try_respond(self, status: i64, content_type: string, body: string) -> Result<i64, net.NetError>;
 
-    /// Send a plain-text HTTP response, returning `Err(fs.IoError)` on failure.
-    fn try_respond_text(self, status: i64, body: string) -> Result<i64, fs.IoError>;
+    /// Send a plain-text HTTP response, returning `Err(net.NetError)` on failure.
+    fn try_respond_text(self, status: i64, body: string) -> Result<i64, net.NetError>;
 
-    /// Send a JSON HTTP response, returning `Err(fs.IoError)` on failure.
-    fn try_respond_json(self, status: i64, json: string) -> Result<i64, fs.IoError>;
+    /// Send a JSON HTTP response, returning `Err(net.NetError)` on failure.
+    fn try_respond_json(self, status: i64, json: string) -> Result<i64, net.NetError>;
 
-    /// Begin a streaming response, returning `Err(fs.IoError)` on failure.
-    fn try_respond_stream(self, status: i64, content_type: string) -> Result<Sink<string>, fs.IoError>;
+    /// Begin a streaming response, returning `Err(net.NetError)` on failure.
+    fn try_respond_stream(self, status: i64, content_type: string) -> Result<Sink<string>, net.NetError>;
 
     /// Release the request resources.
     ///
@@ -220,8 +220,8 @@ impl RequestMethods for Request {
             hew_http_request_free(req)
         };
     }
-    /// Send a full HTTP response; returns Err(IoError::Other(0)) on failure.
-    fn try_respond(req: Request, status: i64, content_type: string, body: string) -> Result<i64, fs.IoError> {
+    /// Send a full HTTP response; returns Err(NetError::Other(0)) on failure.
+    fn try_respond(req: Request, status: i64, content_type: string, body: string) -> Result<i64, net.NetError> {
         // SHIM: WHY — codegen drops the `as i32` cast when inlining through respond(); call FFI
         //   directly to preserve the i32 truncation the FFI signature requires.
         // WHEN — remove when codegen correctly propagates explicit casts through method-call inlining.
@@ -230,13 +230,13 @@ impl RequestMethods for Request {
             hew_http_respond_bridge(req, status as i32, content_type, body)
         } as i64;
         if n < 0 {
-            Err(fs.io_error_from_errno(0))
+            Err(net.net_error_from_errno(0))
         } else {
             Ok(n)
         } // HTTP has no OS errno channel
     }
-    /// Send a plain-text HTTP response; returns Err(IoError::Other(0)) on failure.
-    fn try_respond_text(req: Request, status: i64, body: string) -> Result<i64, fs.IoError> {
+    /// Send a plain-text HTTP response; returns Err(NetError::Other(0)) on failure.
+    fn try_respond_text(req: Request, status: i64, body: string) -> Result<i64, net.NetError> {
         // SHIM: WHY — codegen drops the `as i32` cast when inlining through respond_text(); call FFI
         //   directly to preserve the i32 truncation the FFI signature requires.
         // WHEN — remove when codegen correctly propagates explicit casts through method-call inlining.
@@ -245,13 +245,13 @@ impl RequestMethods for Request {
             hew_http_respond_text(req, status as i32, body)
         } as i64;
         if n < 0 {
-            Err(fs.io_error_from_errno(0))
+            Err(net.net_error_from_errno(0))
         } else {
             Ok(n)
         } // HTTP has no OS errno channel
     }
-    /// Send a JSON HTTP response; returns Err(IoError::Other(0)) on failure.
-    fn try_respond_json(req: Request, status: i64, json: string) -> Result<i64, fs.IoError> {
+    /// Send a JSON HTTP response; returns Err(NetError::Other(0)) on failure.
+    fn try_respond_json(req: Request, status: i64, json: string) -> Result<i64, net.NetError> {
         // SHIM: WHY — codegen drops the `as i32` cast when inlining through respond_json(); call FFI
         //   directly to preserve the i32 truncation the FFI signature requires.
         // WHEN — remove when codegen correctly propagates explicit casts through method-call inlining.
@@ -260,13 +260,13 @@ impl RequestMethods for Request {
             hew_http_respond_json(req, status as i32, json)
         } as i64;
         if n < 0 {
-            Err(fs.io_error_from_errno(0))
+            Err(net.net_error_from_errno(0))
         } else {
             Ok(n)
         } // HTTP has no OS errno channel
     }
-    /// Begin a streaming response; returns Err(IoError::Other(0)) on failure.
-    fn try_respond_stream(req: Request, status: i64, content_type: string) -> Result<Sink<string>, fs.IoError> {
+    /// Begin a streaming response; returns Err(NetError::Other(0)) on failure.
+    fn try_respond_stream(req: Request, status: i64, content_type: string) -> Result<Sink<string>, net.NetError> {
         let sink = unsafe {
             hew_http_respond_stream(req, status as i32, content_type)
         };
@@ -281,7 +281,7 @@ impl RequestMethods for Request {
             let _ = unsafe {
                 hew_stream_last_error()
             }; // consume the error message
-            Err(fs.io_error_from_errno(0))
+            Err(net.net_error_from_errno(0))
         }
     }
 }
@@ -306,23 +306,23 @@ pub fn listen(addr: string) -> Server {
     }
 }
 
-/// Send a full HTTP response, returning `Err(fs.IoError)` on failure.
-pub fn try_respond(req: Request, status: i64, content_type: string, body: string) -> Result<i64, fs.IoError> {
+/// Send a full HTTP response, returning `Err(net.NetError)` on failure.
+pub fn try_respond(req: Request, status: i64, content_type: string, body: string) -> Result<i64, net.NetError> {
     req.try_respond(status, content_type, body)
 }
 
-/// Send a plain-text HTTP response, returning `Err(fs.IoError)` on failure.
-pub fn try_respond_text(req: Request, status: i64, body: string) -> Result<i64, fs.IoError> {
+/// Send a plain-text HTTP response, returning `Err(net.NetError)` on failure.
+pub fn try_respond_text(req: Request, status: i64, body: string) -> Result<i64, net.NetError> {
     req.try_respond_text(status, body)
 }
 
-/// Send a JSON HTTP response, returning `Err(fs.IoError)` on failure.
-pub fn try_respond_json(req: Request, status: i64, json: string) -> Result<i64, fs.IoError> {
+/// Send a JSON HTTP response, returning `Err(net.NetError)` on failure.
+pub fn try_respond_json(req: Request, status: i64, json: string) -> Result<i64, net.NetError> {
     req.try_respond_json(status, json)
 }
 
-/// Begin a streaming HTTP response, returning `Err(fs.IoError)` on failure.
-pub fn try_respond_stream(req: Request, status: i64, content_type: string) -> Result<Sink<string>, fs.IoError> {
+/// Begin a streaming HTTP response, returning `Err(net.NetError)` on failure.
+pub fn try_respond_stream(req: Request, status: i64, content_type: string) -> Result<Sink<string>, net.NetError> {
     req.try_respond_stream(status, content_type)
 }
 

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -6,15 +6,15 @@
 //!
 //! # Error Handling
 //!
-//! `fs.IoError` is the stable user-facing error enum for all I/O failures,
-//! including TCP network errors.  Use the `try_*` wrappers with
-//! `Result<T, fs.IoError>` and the `?` operator for structured error
-//! propagation:
+//! `net.NetError` is the stable user-facing error enum for all network
+//! failures — TCP, TLS, QUIC, HTTP, WebSocket, and DNS.  Use the `try_*`
+//! wrappers with `Result<T, net.NetError>` and the `?` operator for
+//! structured error propagation:
 //!
 //! ```
-//! import std::fs;
+//! import std::net;
 //!
-//! fn dial(addr: string) -> Result<Connection, fs.IoError> {
+//! fn dial(addr: string) -> Result<Connection, net.NetError> {
 //!     net.try_connect(addr)
 //! }
 //!
@@ -23,9 +23,9 @@
 //!         Ok(conn) => println("connected"),
 //!         Err(e) => {
 //!             match e {
-//!                 IoError::ConnectionRefused(_) => println("nobody home"),
-//!                 IoError::TimedOut(_)          => println("timed out"),
-//!                 _                             => println("network error"),
+//!                 NetError::ConnectionRefused(_) => println("nobody home"),
+//!                 NetError::TimedOut(_)          => println("timed out"),
+//!                 _                              => println("network error"),
 //!             }
 //!         },
 //!     }
@@ -46,11 +46,92 @@
 //! }
 //! ```
 
-import std::fs;
-
 import std::string;
 
-fn net_result_from_status(status: i32) -> Result<(), fs.IoError> { // INTERNAL-ABI: status from C ABI is i32; internal helper only
+// ── Network error type ────────────────────────────────────────────────
+/// Structured error type for network operations.
+///
+/// Returned by all `try_*` functions in `net`, `net::tls`, `net::quic`,
+/// `net::http`, `net::websocket`, and `net::dns`.  Use
+/// `Result<T, NetError>` return types with the `?` operator for
+/// structured error propagation.
+///
+/// For file-system errors see `fs.IoError`.
+pub enum NetError {
+    /// The remote host actively refused the connection (ECONNREFUSED).
+    ConnectionRefused(i64);
+    /// The local address is already in use (EADDRINUSE).
+    AddressInUse(i64);
+    /// The address or hostname could not be resolved (EADDRNOTAVAIL).
+    AddressNotAvailable(i64);
+    /// The connection attempt or I/O operation timed out (ETIMEDOUT).
+    TimedOut(i64);
+    /// Operation was cancelled (e.g., a deadline expired before the I/O
+    /// could complete).
+    ///
+    /// Distinct from `TimedOut`: `TimedOut` means the OS deadline expired;
+    /// `Cancelled` means the operation was abandoned for another reason
+    /// (e.g. the blocking pool was shut down mid-call).
+    Cancelled(i64);
+    /// Any other network-level failure.
+    Other(i64);
+}
+
+// WASM-TODO(#1451): WASI uses wasi_errno codes; needs a WASI branch or separate mapping
+/// Map an OS errno integer to a structured `NetError` variant.
+///
+/// The i64 payload carried in each variant is the raw OS errno so callers
+/// can inspect the platform value. errno=0 (no OS error) maps to `Other(0)`.
+///
+/// Covers TCP, QUIC, TLS, HTTP, WebSocket, and DNS failure codes.
+pub fn net_error_from_errno(errno: i64) -> NetError {
+    // ECONNREFUSED: Linux=111, macOS=61
+    if errno == 111 || errno == 61 {
+        NetError::ConnectionRefused(errno)
+    // EADDRINUSE: Linux=98, macOS=48
+    } else if errno == 98 || errno == 48 {
+        NetError::AddressInUse(errno)
+    // ETIMEDOUT: Linux=110, macOS=60
+    } else if errno == 110 || errno == 60 {
+        NetError::TimedOut(errno)
+    // ECANCELED: Linux=125, macOS=89
+    } else if errno == 125 || errno == 89 {
+        NetError::Cancelled(errno)
+    // EADDRNOTAVAIL: Linux=99, macOS=49
+    } else if errno == 99 || errno == 49 {
+        NetError::AddressNotAvailable(errno)
+    } else {
+        NetError::Other(errno)
+    }
+}
+
+/// Return a human-readable description of a `NetError`.
+pub fn net_error_message(e: NetError) -> string {
+    match e {
+        NetError::ConnectionRefused(code) => f"ConnectionRefused({code})",
+        NetError::AddressInUse(code) => f"AddressInUse({code})",
+        NetError::AddressNotAvailable(code) => f"AddressNotAvailable({code})",
+        NetError::TimedOut(code) => f"TimedOut({code})",
+        NetError::Cancelled(code) => f"Cancelled({code})",
+        NetError::Other(code) => f"Other({code})",
+    }
+}
+
+/// Construct a `NetError::TimedOut(0)` value without a platform-specific
+/// errno. Useful for in-process deadline expiry where there is no OS error
+/// to map.
+pub fn net_error_timed_out() -> NetError {
+    NetError::TimedOut(0)
+}
+
+/// Construct a `NetError::Cancelled(0)` value without a platform-specific
+/// errno. Useful for in-process cancellation where there is no OS error
+/// to map.
+pub fn net_error_cancelled() -> NetError {
+    NetError::Cancelled(0)
+}
+
+fn net_result_from_status(status: i32) -> Result<(), NetError> { // INTERNAL-ABI: status from C ABI is i32; internal helper only
     if status < 0 {
         // Read errno before the message: hew_stream_last_error clears errno as a
         // side-effect (they share a paired thread-local), so errno must be
@@ -61,7 +142,7 @@ fn net_result_from_status(status: i32) -> Result<(), fs.IoError> { // INTERNAL-A
         let _ = unsafe {
             hew_stream_last_error()
         };
-        Err(fs.io_error_from_errno(errno as i64))
+        Err(net_error_from_errno(errno as i64))
     } else {
         Ok(())
     }
@@ -135,12 +216,12 @@ trait ConnectionMethods {
     /// Set the read timeout in milliseconds.
     ///
     /// Pass a negative value to clear the timeout.
-    fn set_read_timeout(self, ms: i64) -> Result<(), fs.IoError>;
+    fn set_read_timeout(self, ms: i64) -> Result<(), NetError>;
 
     /// Set the write timeout in milliseconds.
     ///
     /// Pass a negative value to clear the timeout.
-    fn set_write_timeout(self, ms: i64) -> Result<(), fs.IoError>;
+    fn set_write_timeout(self, ms: i64) -> Result<(), NetError>;
 
     /// Send raw bytes to the connection (active-mode-paired name for `write`).
     ///
@@ -275,13 +356,13 @@ impl ConnectionMethods for Connection {
         };
     }
     /// Set the read timeout in milliseconds.
-    fn set_read_timeout(conn: Connection, ms: i64) -> Result<(), fs.IoError> {
+    fn set_read_timeout(conn: Connection, ms: i64) -> Result<(), NetError> {
         net_result_from_status(unsafe {
             hew_tcp_set_read_timeout(conn, ms as i32)
         })
     }
     /// Set the write timeout in milliseconds.
-    fn set_write_timeout(conn: Connection, ms: i64) -> Result<(), fs.IoError> {
+    fn set_write_timeout(conn: Connection, ms: i64) -> Result<(), NetError> {
         net_result_from_status(unsafe {
             hew_tcp_set_write_timeout(conn, ms as i32)
         })
@@ -340,20 +421,20 @@ pub fn listen(addr: string) -> Listener {
 
 /// Create a TCP listener bound to the given address.
 ///
-/// Returns `Err(fs.IoError)` instead of panicking on bind failure.
+/// Returns `Err(NetError)` instead of panicking on bind failure.
 ///
 /// # Examples
 ///
 /// ```
-/// import std::fs;
+/// import std::net;
 ///
 /// match net.try_listen(":9000") {
 ///     Ok(ln) => { /* accept connections */ },
-///     Err(IoError::AddressInUse(_)) => println("port already taken"),
+///     Err(NetError::AddressInUse(_)) => println("port already taken"),
 ///     Err(e) => println("bind failed"),
 /// }
 /// ```
-pub fn try_listen(addr: string) -> Result<Listener, fs.IoError> {
+pub fn try_listen(addr: string) -> Result<Listener, NetError> {
     unsafe {
         let ln = hew_tcp_listen(addr);
         if hew_listener_is_valid(ln) {
@@ -361,7 +442,7 @@ pub fn try_listen(addr: string) -> Result<Listener, fs.IoError> {
         } else {
             let errno = hew_stream_last_errno();
             let _ = hew_stream_last_error();
-            Err(fs.io_error_from_errno(errno as i64))
+            Err(net_error_from_errno(errno as i64))
         }
     }
 }
@@ -383,20 +464,20 @@ pub fn connect(addr: string) -> Connection {
 
 /// Connect to a TCP server at the given address.
 ///
-/// Returns `Err(fs.IoError)` instead of panicking on failure.
+/// Returns `Err(NetError)` instead of panicking on failure.
 ///
 /// # Examples
 ///
 /// ```
-/// import std::fs;
+/// import std::net;
 ///
 /// match net.try_connect("localhost:9000") {
 ///     Ok(conn) => { /* use conn */ },
-///     Err(IoError::ConnectionRefused(_)) => println("nothing listening"),
+///     Err(NetError::ConnectionRefused(_)) => println("nothing listening"),
 ///     Err(e) => println("connect failed"),
 /// }
 /// ```
-pub fn try_connect(addr: string) -> Result<Connection, fs.IoError> {
+pub fn try_connect(addr: string) -> Result<Connection, NetError> {
     unsafe {
         let conn = hew_tcp_connect(addr);
         if hew_connection_is_valid(conn) {
@@ -404,7 +485,7 @@ pub fn try_connect(addr: string) -> Result<Connection, fs.IoError> {
         } else {
             let errno = hew_stream_last_errno();
             let _ = hew_stream_last_error();
-            Err(fs.io_error_from_errno(errno as i64))
+            Err(net_error_from_errno(errno as i64))
         }
     }
 }
@@ -449,7 +530,7 @@ pub fn broadcast_except(sender: Connection, message: bytes) -> i64 {
 /// Broadcast a message to all connections except the sender.
 ///
 /// Used in chat-server patterns to fan out messages.
-pub fn try_broadcast_except(sender: Connection, message: bytes) -> Result<i64, fs.IoError> {
+pub fn try_broadcast_except(sender: Connection, message: bytes) -> Result<i64, NetError> {
     let n: i32 = unsafe {
         hew_tcp_broadcast_except(sender, message)
     };
@@ -460,7 +541,7 @@ pub fn try_broadcast_except(sender: Connection, message: bytes) -> Result<i64, f
         unsafe {
             let _ = hew_stream_last_error();
         };
-        Err(fs.io_error_from_errno(errno as i64))
+        Err(net_error_from_errno(errno as i64))
     } else {
         Ok(n as i64)
     }

--- a/std/net/quic/quic.hew
+++ b/std/net/quic/quic.hew
@@ -89,7 +89,7 @@
 //! }
 //! ```
 
-import std::fs;
+import std::net;
 
 /// A QUIC endpoint bound to a local UDP address.
 ///
@@ -230,8 +230,8 @@ trait QUICConnectionMethods {
 
     /// Gracefully close this connection and release its resources.
     ///
-    /// Returns `Ok(())` on success or `Err(fs.IoError)` on failure.
-    fn disconnect(self) -> Result<(), fs.IoError>;
+    /// Returns `Ok(())` on success or `Err(net.NetError)` on failure.
+    fn disconnect(self) -> Result<(), net.NetError>;
 
     /// Block until the next queued QUIC event on this connection.
     ///
@@ -254,7 +254,7 @@ impl QUICConnectionMethods for QUICConnection {
             hew_quic_conn_accept_stream(conn)
         }
     }
-    fn disconnect(conn: QUICConnection) -> Result<(), fs.IoError> {
+    fn disconnect(conn: QUICConnection) -> Result<(), net.NetError> {
         connection_disconnect(conn)
     }
     fn on_event(conn: QUICConnection) -> QUICEvent {
@@ -272,8 +272,8 @@ impl QUICConnectionMethods for QUICConnection {
 trait QUICStreamMethods {
     /// Send raw bytes on this stream.
     ///
-    /// Returns `Ok(())` on success or `Err(fs.IoError)` on failure.
-    fn send(self, data: bytes) -> Result<(), fs.IoError>;
+    /// Returns `Ok(())` on success or `Err(net.NetError)` on failure.
+    fn send(self, data: bytes) -> Result<(), net.NetError>;
 
     /// Block until data arrives and return the received bytes.
     ///
@@ -283,29 +283,29 @@ trait QUICStreamMethods {
     /// Receive bytes with a per-call deadline.
     ///
     /// `deadline_ms <= 0` disables the deadline. On deadline expiry returns
-    /// `Err(IoError::TimedOut(0))`. On stream EOF returns `Ok(empty)`.
-    fn recv_timeout(self, deadline_ms: i64) -> Result<bytes, fs.IoError>;
+    /// `Err(NetError::TimedOut(0))`. On stream EOF returns `Ok(empty)`.
+    fn recv_timeout(self, deadline_ms: i64) -> Result<bytes, net.NetError>;
 
     /// Send bytes with a per-call deadline.
     ///
     /// `deadline_ms <= 0` disables the deadline. On deadline expiry returns
-    /// `Err(IoError::TimedOut(0))`.
-    fn send_timeout(self, data: bytes, deadline_ms: i64) -> Result<(), fs.IoError>;
+    /// `Err(NetError::TimedOut(0))`.
+    fn send_timeout(self, data: bytes, deadline_ms: i64) -> Result<(), net.NetError>;
 
     /// Signal that no more data will be sent on this stream.
     ///
     /// The receive side of the remote peer will see EOF after all buffered
     /// data has been delivered. This does not release the local stream handle;
     /// call `close()` when you are finished with the stream. Returns `Ok(())`
-    /// on success or `Err(fs.IoError)` on failure.
-    fn finish(self) -> Result<(), fs.IoError>;
+    /// on success or `Err(net.NetError)` on failure.
+    fn finish(self) -> Result<(), net.NetError>;
 
     /// Abruptly stop this stream with an application-defined error code.
     ///
     /// Unlike `finish`, pending data is discarded. Call `close()` afterwards to
     /// release the local stream handle. Returns `Ok(())` on success or
-    /// `Err(fs.IoError)` on failure.
-    fn stop(self, error_code: i64) -> Result<(), fs.IoError>;
+    /// `Err(net.NetError)` on failure.
+    fn stop(self, error_code: i64) -> Result<(), net.NetError>;
 
     /// Release the local stream handle.
     ///
@@ -315,8 +315,8 @@ trait QUICStreamMethods {
     /// Send a UTF-8 string on this stream.
     ///
     /// Convenience wrapper around `send` that converts `msg` to bytes first.
-    /// Returns `Ok(())` on success or `Err(fs.IoError)` on failure.
-    fn send_string(self, msg: string) -> Result<(), fs.IoError>;
+    /// Returns `Ok(())` on success or `Err(net.NetError)` on failure.
+    fn send_string(self, msg: string) -> Result<(), net.NetError>;
 
     /// Block until data arrives and return it as a UTF-8 string.
     ///
@@ -329,7 +329,7 @@ trait QUICStreamMethods {
 }
 
 impl QUICStreamMethods for QUICStream {
-    fn send(strm: QUICStream, data: bytes) -> Result<(), fs.IoError> {
+    fn send(strm: QUICStream, data: bytes) -> Result<(), net.NetError> {
         stream_send(strm, data)
     }
     fn recv(strm: QUICStream) -> bytes {
@@ -337,16 +337,16 @@ impl QUICStreamMethods for QUICStream {
             hew_quic_stream_recv(strm)
         }
     }
-    fn recv_timeout(strm: QUICStream, deadline_ms: i64) -> Result<bytes, fs.IoError> {
+    fn recv_timeout(strm: QUICStream, deadline_ms: i64) -> Result<bytes, net.NetError> {
         stream_recv_timeout(strm, deadline_ms)
     }
-    fn send_timeout(strm: QUICStream, data: bytes, deadline_ms: i64) -> Result<(), fs.IoError> {
+    fn send_timeout(strm: QUICStream, data: bytes, deadline_ms: i64) -> Result<(), net.NetError> {
         stream_send_timeout(strm, data, deadline_ms)
     }
-    fn finish(strm: QUICStream) -> Result<(), fs.IoError> {
+    fn finish(strm: QUICStream) -> Result<(), net.NetError> {
         stream_finish(strm)
     }
-    fn stop(strm: QUICStream, error_code: i64) -> Result<(), fs.IoError> {
+    fn stop(strm: QUICStream, error_code: i64) -> Result<(), net.NetError> {
         stream_stop(strm, error_code)
     }
     fn close(strm: QUICStream) {
@@ -354,7 +354,7 @@ impl QUICStreamMethods for QUICStream {
             hew_quic_stream_close(strm)
         };
     }
-    fn send_string(strm: QUICStream, msg: string) -> Result<(), fs.IoError> {
+    fn send_string(strm: QUICStream, msg: string) -> Result<(), net.NetError> {
         stream_send_string(strm, msg)
     }
     fn recv_string(strm: QUICStream) -> string {
@@ -508,16 +508,16 @@ pub fn connection_observe(conn: QUICConnection) -> QUICConnectionObservation {
 ///
 /// Sends a `CONNECTION_CLOSE` frame to the peer and releases the
 /// connection handle. Returns `Ok(())` on success. On failure, returns
-/// `Err(IoError::Other(0))`; inspect `conn.observe().last_error` for the
+/// `Err(NetError::Other(0))`; inspect `conn.observe().last_error` for the
 /// QUIC-level error string because QUIC errors carry no OS errno.
 /// After calling `connection_disconnect`, the connection handle must
 /// not be used again.
-pub fn connection_disconnect(conn: QUICConnection) -> Result<(), fs.IoError> {
+pub fn connection_disconnect(conn: QUICConnection) -> Result<(), net.NetError> {
     // QUIC errors carry no OS errno; error string available via conn.observe().last_error
     unsafe {
         let status = hew_quic_conn_disconnect(conn);
         if status < 0 {
-            Err(fs.io_error_from_errno(0))
+            Err(net.net_error_from_errno(0))
         } else {
             Ok(())
         }
@@ -550,15 +550,15 @@ pub fn stream_observe(stream: QUICStream) -> QUICStreamObservation {
 /// Sends `data` as a single STREAM frame sequence. Blocks until the
 /// data is accepted by the QUIC stack (not until it is acknowledged
 /// by the peer). Returns `Ok(())` on success. On failure, returns
-/// `Err(IoError::Other(0))`; inspect `strm.observe().last_error` for
+/// `Err(NetError::Other(0))`; inspect `strm.observe().last_error` for
 /// the QUIC-level error string. Does not close the send side — call
 /// `stream_finish` when all data has been written.
-pub fn stream_send(strm: QUICStream, data: bytes) -> Result<(), fs.IoError> {
+pub fn stream_send(strm: QUICStream, data: bytes) -> Result<(), net.NetError> {
     // QUIC errors carry no OS errno; error string available via stream.observe().last_error
     unsafe {
         let status = hew_quic_stream_send(strm, data);
         if status < 0 {
-            Err(fs.io_error_from_errno(0))
+            Err(net.net_error_from_errno(0))
         } else {
             Ok(())
         }
@@ -567,16 +567,16 @@ pub fn stream_send(strm: QUICStream, data: bytes) -> Result<(), fs.IoError> {
 
 /// Send bytes on a QUIC stream with a per-call deadline.
 ///
-/// `deadline_ms <= 0` disables the deadline. Returns `Err(IoError::TimedOut(0))`
-/// on deadline expiry, `Err(IoError::Other(0))` on transport error.
-pub fn stream_send_timeout(strm: QUICStream, data: bytes, deadline_ms: i64) -> Result<(), fs.IoError> {
+/// `deadline_ms <= 0` disables the deadline. Returns `Err(NetError::TimedOut(0))`
+/// on deadline expiry, `Err(NetError::Other(0))` on transport error.
+pub fn stream_send_timeout(strm: QUICStream, data: bytes, deadline_ms: i64) -> Result<(), net.NetError> {
     let status: i32 = unsafe { // INTERNAL-ABI: 0=ok, -1=error, -2=timeout
         hew_quic_stream_send_timeout_hew(strm, data, deadline_ms as i32)
     };
     if status == -2 {
-        Err(fs.io_error_timed_out())
+        Err(net.net_error_timed_out())
     } else if status < 0 {
-        Err(fs.io_error_from_errno(0))
+        Err(net.net_error_from_errno(0))
     } else {
         Ok(())
     }
@@ -584,9 +584,9 @@ pub fn stream_send_timeout(strm: QUICStream, data: bytes, deadline_ms: i64) -> R
 
 /// Receive bytes from a QUIC stream with a per-call deadline.
 ///
-/// `deadline_ms <= 0` disables the deadline. Returns `Err(IoError::TimedOut(0))`
+/// `deadline_ms <= 0` disables the deadline. Returns `Err(NetError::TimedOut(0))`
 /// on deadline expiry. On success returns the bytes (may be empty for EOF).
-pub fn stream_recv_timeout(strm: QUICStream, deadline_ms: i64) -> Result<bytes, fs.IoError> {
+pub fn stream_recv_timeout(strm: QUICStream, deadline_ms: i64) -> Result<bytes, net.NetError> {
     let payload: bytes = unsafe {
         hew_quic_stream_recv_timeout_hew(strm, deadline_ms as i32)
     };
@@ -594,7 +594,7 @@ pub fn stream_recv_timeout(strm: QUICStream, deadline_ms: i64) -> Result<bytes, 
         hew_quic_stream_last_recv_timed_out()
     };
     if timed_out == 1 {
-        Err(fs.io_error_timed_out())
+        Err(net.net_error_timed_out())
     } else {
         Ok(payload)
     }
@@ -605,14 +605,14 @@ pub fn stream_recv_timeout(strm: QUICStream, deadline_ms: i64) -> Result<bytes, 
 /// Sends a FIN to the peer, indicating no more data will be written.
 /// The stream remains open for receiving until the peer also closes
 /// their send side (or until `stream_stop` is called). Returns
-/// `Ok(())` on success. On failure, returns `Err(IoError::Other(0))`;
+/// `Ok(())` on success. On failure, returns `Err(NetError::Other(0))`;
 /// inspect `strm.observe().last_error` for the QUIC-level error string.
-pub fn stream_finish(strm: QUICStream) -> Result<(), fs.IoError> {
+pub fn stream_finish(strm: QUICStream) -> Result<(), net.NetError> {
     // QUIC errors carry no OS errno; error string available via stream.observe().last_error
     unsafe {
         let status = hew_quic_stream_finish(strm);
         if status < 0 {
-            Err(fs.io_error_from_errno(0))
+            Err(net.net_error_from_errno(0))
         } else {
             Ok(())
         }
@@ -626,14 +626,14 @@ pub fn stream_finish(strm: QUICStream) -> Result<(), fs.IoError> {
 /// the QUIC protocol mandates 62-bit codes and `i64` is a 64-bit i64
 /// so no narrowing occurs). Use this when the stream must be abandoned
 /// rather than gracefully finished. Returns `Ok(())` on success. On
-/// failure, returns `Err(IoError::Other(0))`; inspect
+/// failure, returns `Err(NetError::Other(0))`; inspect
 /// `strm.observe().last_error` for the QUIC-level error string.
-pub fn stream_stop(strm: QUICStream, error_code: i64) -> Result<(), fs.IoError> { // INTERNAL-ABI: QUIC protocol mandates 62-bit error codes; i64 is 64-bit i64 so no narrowing needed
+pub fn stream_stop(strm: QUICStream, error_code: i64) -> Result<(), net.NetError> { // INTERNAL-ABI: QUIC protocol mandates 62-bit error codes; i64 is 64-bit i64 so no narrowing needed
     // QUIC errors carry no OS errno; error string available via stream.observe().last_error
     unsafe {
         let status = hew_quic_stream_stop(strm, error_code);
         if status < 0 {
-            Err(fs.io_error_from_errno(0))
+            Err(net.net_error_from_errno(0))
         } else {
             Ok(())
         }
@@ -644,7 +644,7 @@ pub fn stream_stop(strm: QUICStream, error_code: i64) -> Result<(), fs.IoError> 
 ///
 /// Converts `msg` to bytes using the runtime string helper, then delegates
 /// to the underlying `hew_quic_stream_send` FFI.
-pub fn stream_send_string(strm: QUICStream, msg: string) -> Result<(), fs.IoError> {
+pub fn stream_send_string(strm: QUICStream, msg: string) -> Result<(), net.NetError> {
     unsafe {
         let payload = hew_string_to_bytes(msg);
         stream_send(strm, payload)

--- a/std/net/tls/tls.hew
+++ b/std/net/tls/tls.hew
@@ -7,6 +7,7 @@
 //! # Examples
 //!
 //! ```
+//! import std::net;
 //! import std::net::tls;
 //!
 //! fn main() {
@@ -14,17 +15,17 @@
 //!     let request = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n";
 //!     match tls.try_write(stream, hew_string_to_bytes(request)) {
 //!         Ok(_) => {},
-//!         Err(err) => panic(fs.io_error_message(err)),
+//!         Err(err) => panic(net.net_error_message(err)),
 //!     }
 //!     let response = match tls.read(stream, 4096) {
 //!         Ok(data) => data,
-//!         Err(err) => panic(fs.io_error_message(err)),
+//!         Err(err) => panic(net.net_error_message(err)),
 //!     };
 //!     tls.close(stream);
 //! }
 //! ```
 
-import std::fs;
+import std::net;
 
 /// An established TLS connection to a remote host.
 ///
@@ -51,15 +52,15 @@ const TLS_STATUS_TLS_ERROR: i32 = 2;
 
 const TLS_STATUS_IO_ERROR: i32 = 3;
 
-fn tls_error_from_status(status: i32, _message: string) -> fs.IoError { // INTERNAL-ABI: TLS FFI bridge reports a small status enum plus thread-local last_error
+fn tls_error_from_status(status: i32, _message: string) -> net.NetError { // INTERNAL-ABI: TLS FFI bridge reports a small status enum plus thread-local last_error
     if status == TLS_STATUS_RETRYABLE {
-        IoError::TimedOut(0)
+        NetError::TimedOut(0)
     } else {
-        IoError::Other(0)
+        NetError::Other(0)
     }
 }
 
-fn tls_write_result(raw: TlsWriteFfiResult) -> Result<i64, fs.IoError> { // INTERNAL-ABI: bridge helper lifts raw FFI status into Result while leaving detail in last_error()
+fn tls_write_result(raw: TlsWriteFfiResult) -> Result<i64, net.NetError> { // INTERNAL-ABI: bridge helper lifts raw FFI status into Result while leaving detail in last_error()
     if raw.status == TLS_STATUS_SUCCESS {
         Ok(raw.written as i64)
     } else {
@@ -67,7 +68,7 @@ fn tls_write_result(raw: TlsWriteFfiResult) -> Result<i64, fs.IoError> { // INTE
     }
 }
 
-fn tls_read_result(raw: TlsReadFfiResult) -> Result<bytes, fs.IoError> { // INTERNAL-ABI: bridge helper lifts raw FFI status into Result while leaving detail in last_error()
+fn tls_read_result(raw: TlsReadFfiResult) -> Result<bytes, net.NetError> { // INTERNAL-ABI: bridge helper lifts raw FFI status into Result while leaving detail in last_error()
     if raw.status == TLS_STATUS_SUCCESS {
         Ok(raw.data)
     } else {
@@ -85,14 +86,14 @@ trait TlsStreamMethods {
 
     /// Write raw bytes to the TLS stream.
     ///
-    /// Returns the number of bytes written, or `Err(fs.IoError)` on failure.
-    fn try_write(self, data: bytes) -> Result<i64, fs.IoError>;
+    /// Returns the number of bytes written, or `Err(net.NetError)` on failure.
+    fn try_write(self, data: bytes) -> Result<i64, net.NetError>;
 
     /// Read up to `size` bytes from the TLS stream.
     ///
-    /// Returns `Ok(bytes)` on success or orderly EOF, or `Err(fs.IoError)` on
+    /// Returns `Ok(bytes)` on success or orderly EOF, or `Err(net.NetError)` on
     /// retryable/TLS/I-O failures. Use `last_error()` for the precise class.
-    fn read(self, size: i64) -> Result<bytes, fs.IoError>;
+    fn read(self, size: i64) -> Result<bytes, net.NetError>;
 
     /// Close the TLS connection and release resources.
     fn close(self);
@@ -109,12 +110,12 @@ impl TlsStreamMethods for TlsStream {
             -1
         }
     }
-    fn try_write(stream: TlsStream, data: bytes) -> Result<i64, fs.IoError> {
+    fn try_write(stream: TlsStream, data: bytes) -> Result<i64, net.NetError> {
         tls_write_result(unsafe {
             hew_tls_write_result(stream, data)
         })
     }
-    fn read(stream: TlsStream, size: i64) -> Result<bytes, fs.IoError> {
+    fn read(stream: TlsStream, size: i64) -> Result<bytes, net.NetError> {
         tls_read_result(unsafe {
             hew_tls_read_result(stream, size as i32)
         })
@@ -161,16 +162,16 @@ pub fn write(stream: TlsStream, data: bytes) -> i64 {
 
 /// Write raw bytes to a TLS stream.
 ///
-/// Returns the number of bytes written, or `Err(fs.IoError)` on failure.
-pub fn try_write(stream: TlsStream, data: bytes) -> Result<i64, fs.IoError> {
+/// Returns the number of bytes written, or `Err(net.NetError)` on failure.
+pub fn try_write(stream: TlsStream, data: bytes) -> Result<i64, net.NetError> {
     stream.try_write(data)
 }
 
 /// Read up to `size` bytes from a TLS stream.
 ///
-/// Returns `Ok(bytes)` on success or orderly EOF, or `Err(fs.IoError)` on
+/// Returns `Ok(bytes)` on success or orderly EOF, or `Err(net.NetError)` on
 /// retryable/TLS/I-O failures. Call `last_error()` for the precise detail.
-pub fn read(stream: TlsStream, size: i64) -> Result<bytes, fs.IoError> {
+pub fn read(stream: TlsStream, size: i64) -> Result<bytes, net.NetError> {
     stream.read(size)
 }
 

--- a/std/net/websocket/websocket.hew
+++ b/std/net/websocket/websocket.hew
@@ -33,7 +33,7 @@
 //! }
 //! ```
 
-import std::fs;
+import std::net;
 
 /// An open WebSocket connection handle.
 ///
@@ -58,7 +58,7 @@ trait ConnMethods {
     fn send_text(self, msg: string) -> i64;
 
     /// Send a text message over the connection.
-    fn try_send_text(self, msg: string) -> Result<(), fs.IoError>;
+    fn try_send_text(self, msg: string) -> Result<(), net.NetError>;
 
     /// Block until a message is received and return it.
     fn recv(self) -> Message;
@@ -66,10 +66,10 @@ trait ConnMethods {
     /// Receive a message with a per-call deadline.
     ///
     /// `deadline_ms <= 0` disables the deadline and behaves like `recv`.
-    /// Returns `Err(IoError::TimedOut(0))` on deadline expiry. On other
-    /// failures returns `Err(IoError::Other(0))` (WebSocket errors carry
+    /// Returns `Err(NetError::TimedOut(0))` on deadline expiry. On other
+    /// failures returns `Err(NetError::Other(0))` (WebSocket errors carry
     /// no OS errno channel).
-    fn recv_timeout(self, deadline_ms: i64) -> Result<Message, fs.IoError>;
+    fn recv_timeout(self, deadline_ms: i64) -> Result<Message, net.NetError>;
 
     /// Close the WebSocket connection.
     fn close(self);
@@ -92,12 +92,12 @@ impl ConnMethods for Conn {
             hew_ws_send_text(conn, msg) as i64
         }
     }
-    fn try_send_text(conn: Conn, msg: string) -> Result<(), fs.IoError> {
+    fn try_send_text(conn: Conn, msg: string) -> Result<(), net.NetError> {
         let n: i64 = unsafe {
             hew_ws_send_text(conn, msg) as i64
         };
         if n < 0 {
-            Err(fs.io_error_from_errno(0))
+            Err(net.net_error_from_errno(0))
         } else {
             Ok(())
         } // WebSocket errors carry no OS errno
@@ -107,7 +107,7 @@ impl ConnMethods for Conn {
             hew_ws_recv(conn)
         }
     }
-    fn recv_timeout(conn: Conn, deadline_ms: i64) -> Result<Message, fs.IoError> {
+    fn recv_timeout(conn: Conn, deadline_ms: i64) -> Result<Message, net.NetError> {
         let msg: Message = unsafe { // INTERNAL-ABI: deadline_ms cast to i32 for FFI
             hew_ws_recv_timeout(conn, deadline_ms as i32)
         };
@@ -120,9 +120,9 @@ impl ConnMethods for Conn {
         if valid {
             Ok(msg)
         } else if timed_out == 1 {
-            Err(fs.io_error_timed_out())
+            Err(net.net_error_timed_out())
         } else {
-            Err(fs.io_error_from_errno(0))
+            Err(net.net_error_from_errno(0))
         }
     }
     fn close(conn: Conn) {

--- a/tests/hew/fs_stream_test.hew
+++ b/tests/hew/fs_stream_test.hew
@@ -2,6 +2,8 @@
 
 import std::fs;
 
+import std::net;
+
 import std::stream;
 
 import std::testing;
@@ -233,52 +235,52 @@ fn test_stream_try_to_file_send_close_and_try_from_file() {
         Err(_) => panic("expected try_to_file to succeed"),
     }
     match stream.try_from_file(file_path) {
-        Ok(_) => {},  // stream handle dropped; Ok(file) binding deferred to v0.5.1
+        Ok(_) => {}, // stream handle dropped; Ok(file) binding deferred to v0.5.1
         Err(_) => panic("expected try_from_file to succeed on the written file"),
     }
     cleanup_file(file_path);
 }
 
-// ── IoError network variants ──────────────────────────────────────────
+// ── NetError variants ─────────────────────────────────────────────────
 #[test]
-fn test_io_error_from_errno_network_variants() {
+fn test_net_error_from_errno_network_variants() {
     // Let-bind each call before matching: direct `match f(x) { ... }` on
     // multiple enum-returning calls in one function body triggers a codegen
     // hang at 2e6fac15 (tracked v0.5.1 under TWO-FROM-FILE-GAP / enum drop).
     //
     // ECONNREFUSED: Linux=111, macOS=61
-    let err111 = fs.io_error_from_errno(111);
+    let err111 = net.net_error_from_errno(111);
     match err111 {
-        IoError::ConnectionRefused(code) => testing.assert_eq(code, 111),
-        _ => panic("expected IoError::ConnectionRefused for errno 111"),
+        NetError::ConnectionRefused(code) => testing.assert_eq(code, 111),
+        _ => panic("expected NetError::ConnectionRefused for errno 111"),
     }
-    let err61 = fs.io_error_from_errno(61);
+    let err61 = net.net_error_from_errno(61);
     match err61 {
-        IoError::ConnectionRefused(code) => testing.assert_eq(code, 61),
-        _ => panic("expected IoError::ConnectionRefused for errno 61"),
+        NetError::ConnectionRefused(code) => testing.assert_eq(code, 61),
+        _ => panic("expected NetError::ConnectionRefused for errno 61"),
     }
     // EADDRINUSE: Linux=98, macOS=48
-    let err98 = fs.io_error_from_errno(98);
+    let err98 = net.net_error_from_errno(98);
     match err98 {
-        IoError::AddressInUse(code) => testing.assert_eq(code, 98),
-        _ => panic("expected IoError::AddressInUse for errno 98"),
+        NetError::AddressInUse(code) => testing.assert_eq(code, 98),
+        _ => panic("expected NetError::AddressInUse for errno 98"),
     }
     // ETIMEDOUT: Linux=110, macOS=60
-    let err110 = fs.io_error_from_errno(110);
+    let err110 = net.net_error_from_errno(110);
     match err110 {
-        IoError::TimedOut(code) => testing.assert_eq(code, 110),
-        _ => panic("expected IoError::TimedOut for errno 110"),
+        NetError::TimedOut(code) => testing.assert_eq(code, 110),
+        _ => panic("expected NetError::TimedOut for errno 110"),
     }
     // EADDRNOTAVAIL: Linux=99, macOS=49
-    let err99 = fs.io_error_from_errno(99);
+    let err99 = net.net_error_from_errno(99);
     match err99 {
-        IoError::AddressNotAvailable(code) => testing.assert_eq(code, 99),
-        _ => panic("expected IoError::AddressNotAvailable for errno 99"),
+        NetError::AddressNotAvailable(code) => testing.assert_eq(code, 99),
+        _ => panic("expected NetError::AddressNotAvailable for errno 99"),
     }
 }
 
 #[test]
-fn test_io_error_message_formats_all_variants() {
+fn test_io_error_message_formats_fs_variants() {
     // Let-bind each call: direct `f(Enum::Variant(...))` on multiple string-
     // returning calls in one function body triggers a codegen hang at 2e6fac15
     // (tracked v0.5.1 under enum drop multi-call pattern).
@@ -288,14 +290,25 @@ fn test_io_error_message_formats_all_variants() {
     testing.assert_eq_str(m2, "PermissionDenied(13)");
     let m3 = fs.io_error_message(IoError::AlreadyExists(17));
     testing.assert_eq_str(m3, "AlreadyExists(17)");
-    let m4 = fs.io_error_message(IoError::ConnectionRefused(111));
-    testing.assert_eq_str(m4, "ConnectionRefused(111)");
-    let m5 = fs.io_error_message(IoError::AddressInUse(98));
-    testing.assert_eq_str(m5, "AddressInUse(98)");
-    let m6 = fs.io_error_message(IoError::TimedOut(110));
-    testing.assert_eq_str(m6, "TimedOut(110)");
-    let m7 = fs.io_error_message(IoError::AddressNotAvailable(99));
-    testing.assert_eq_str(m7, "AddressNotAvailable(99)");
-    let m8 = fs.io_error_message(IoError::Other(0));
-    testing.assert_eq_str(m8, "Other(0)");
+    let m4 = fs.io_error_message(IoError::TimedOut(110));
+    testing.assert_eq_str(m4, "TimedOut(110)");
+    let m5 = fs.io_error_message(IoError::Other(0));
+    testing.assert_eq_str(m5, "Other(0)");
+}
+
+#[test]
+fn test_net_error_message_formats_net_variants() {
+    // Let-bind each call: direct `f(Enum::Variant(...))` on multiple string-
+    // returning calls in one function body triggers a codegen hang at 2e6fac15
+    // (tracked v0.5.1 under enum drop multi-call pattern).
+    let m1 = net.net_error_message(NetError::ConnectionRefused(111));
+    testing.assert_eq_str(m1, "ConnectionRefused(111)");
+    let m2 = net.net_error_message(NetError::AddressInUse(98));
+    testing.assert_eq_str(m2, "AddressInUse(98)");
+    let m3 = net.net_error_message(NetError::TimedOut(110));
+    testing.assert_eq_str(m3, "TimedOut(110)");
+    let m4 = net.net_error_message(NetError::AddressNotAvailable(99));
+    testing.assert_eq_str(m4, "AddressNotAvailable(99)");
+    let m5 = net.net_error_message(NetError::Other(0));
+    testing.assert_eq_str(m5, "Other(0)");
 }

--- a/tests/hew/net_try_api_test.hew
+++ b/tests/hew/net_try_api_test.hew
@@ -1,22 +1,21 @@
-//! Tests for the `IoError` + `try_connect` / `try_listen` surface.
+//! Tests for the `NetError` + `try_connect` / `try_listen` surface.
 //!
-//! TCP operations return `fs.IoError` so callers handle network failures
-//! uniformly alongside file-system errors.
+//! TCP operations return `net.NetError` so callers handle network failures
+//! independently from file-system errors.
 
 import std::net;
-import std::fs;
+
 import std::testing;
 
 // ── try_connect ───────────────────────────────────────────────────────
-
 #[test]
 fn test_try_connect_refused_returns_connection_refused() {
     // Port 1 is never open in test environments (privileged, nothing binds it).
     match net.try_connect("127.0.0.1:1") {
         Ok(_) => panic("expected connection to fail"),
         Err(err) => match err {
-            IoError::ConnectionRefused(_) => {},
-            _ => panic("expected IoError::ConnectionRefused"),
+            NetError::ConnectionRefused(_) => {},
+            _ => panic("expected NetError::ConnectionRefused"),
         },
     }
 }
@@ -30,7 +29,6 @@ fn test_try_connect_bad_address_returns_err() {
 }
 
 // ── try_listen ────────────────────────────────────────────────────────
-
 #[test]
 fn test_try_listen_returns_ok_on_available_port() {
     // Use an ephemeral port unlikely to be in use.
@@ -48,8 +46,8 @@ fn test_try_listen_address_in_use_returns_address_in_use() {
             match net.try_listen(":19731") {
                 Ok(_) => panic("expected second bind to fail"),
                 Err(err) => match err {
-                    IoError::AddressInUse(_) => {},
-                    _ => panic("expected IoError::AddressInUse"),
+                    NetError::AddressInUse(_) => {},
+                    _ => panic("expected NetError::AddressInUse"),
                 },
             }
         },
@@ -65,29 +63,27 @@ fn test_listener_close_surface_returns_unit() {
     listener.close();
 }
 
-// ── IoError variant coverage for TCP ────────────────────────────────
-
+// ── NetError variant coverage for TCP ────────────────────────────────
 #[test]
-fn test_io_error_tcp_variants_are_distinct() {
-    let refused: fs.IoError = IoError::ConnectionRefused(111);
-    let in_use: fs.IoError = IoError::AddressInUse(98);
-    let timed_out: fs.IoError = IoError::TimedOut(110);
-    let other: fs.IoError = IoError::Other(1);
-
+fn test_net_error_tcp_variants_are_distinct() {
+    let refused: net.NetError = NetError::ConnectionRefused(111);
+    let in_use: net.NetError = NetError::AddressInUse(98);
+    let timed_out: net.NetError = NetError::TimedOut(110);
+    let other: net.NetError = NetError::Other(1);
     match refused {
-        IoError::ConnectionRefused(_) => {},
+        NetError::ConnectionRefused(_) => {},
         _ => panic("unexpected variant"),
     }
     match in_use {
-        IoError::AddressInUse(_) => {},
+        NetError::AddressInUse(_) => {},
         _ => panic("unexpected variant"),
     }
     match timed_out {
-        IoError::TimedOut(_) => {},
+        NetError::TimedOut(_) => {},
         _ => panic("unexpected variant"),
     }
     match other {
-        IoError::Other(_) => {},
+        NetError::Other(_) => {},
         _ => panic("unexpected variant"),
     }
 }

--- a/tests/vertical-slice/accept/await_accept_deadline_deferred.hew
+++ b/tests/vertical-slice/accept/await_accept_deadline_deferred.hew
@@ -1,6 +1,6 @@
 // Accept fixture (NEW-6d): `await ln.accept() | after d` — the simplest
 // deadline-accept form. An actor creates a listener, parks on accept with a
-// short deadline, and receives Err(IoError::TimedOut) because no client
+// short deadline, and receives Err(NetError::TimedOut) because no client
 // connects. This was the original reject-deferred placeholder; it now
 // compiles and runs cleanly under v0.5.
 //

--- a/tests/vertical-slice/accept/await_accept_deadline_timeout.hew
+++ b/tests/vertical-slice/accept/await_accept_deadline_timeout.hew
@@ -1,14 +1,14 @@
 // Accept fixture (NEW-6d): `await ln.accept() | after d` — deadline elapses
 // before any client connects, so the suspending accept resolves to
-// `Err(IoError::TimedOut(_))`.
+// `Err(NetError::TimedOut(_))`.
 //
 // Run under HEW_WORKERS=1: Server creates a fresh listener on port 0 and
 // parks worker-free on the accept slot. No client connects. The deadline
-// timer fires and resumes the actor with Err(IoError::TimedOut) -> exit 7.
+// timer fires and resumes the actor with Err(NetError::TimedOut) -> exit 7.
 // A blocking accept would strand the lone worker and hang.
 //
 // Exit-code contract: timeout Err(TimedOut) -> 7; unexpected Ok -> 42;
-// wrong IoError variant -> 8; no actor exit -> main fallback 99.
+// wrong NetError variant -> 8; no actor exit -> main fallback 99.
 import std::net;
 
 actor Server {
@@ -18,7 +18,7 @@ actor Server {
             Ok(_conn) => 42,
             Err(e) => {
                 match e {
-                    IoError::TimedOut(_code) => 7,
+                    NetError::TimedOut(_code) => 7,
                     _ => 8,
                 }
             },

--- a/tests/vertical-slice/accept/await_read_deadline_deferred.hew
+++ b/tests/vertical-slice/accept/await_read_deadline_deferred.hew
@@ -8,8 +8,6 @@
 //
 // Exit-code contract: timeout Err(TimedOut) -> 7; unexpected Ok -> 42; wrong
 // NetError variant -> 8; no actor exit -> main fallback 99.
-import std::net;
-
 import std::net::{Listener};
 
 extern "C" {

--- a/tests/vertical-slice/accept/await_read_deadline_deferred.hew
+++ b/tests/vertical-slice/accept/await_read_deadline_deferred.hew
@@ -1,14 +1,15 @@
 // Accept fixture (NEW-6c): `await conn.read() | after d` — deadline elapses
 // before the peer writes, so the suspending read resolves to
-// `Err(IoError::TimedOut(_))`.
+// `Err(NetError::TimedOut(_))`.
 //
 // Run under `HEW_WORKERS=1`: the reader parks worker-free on the read slot, the
 // main thread keeps the accepted peer silent, and the deadline timer resumes the
 // parked actor. A blocking read would strand the lone worker and hang.
 //
 // Exit-code contract: timeout Err(TimedOut) -> 7; unexpected Ok -> 42; wrong
-// IoError variant -> 8; no actor exit -> main fallback 99.
-import std::fs;
+// NetError variant -> 8; no actor exit -> main fallback 99.
+import std::net;
+
 import std::net::{Listener};
 
 extern "C" {
@@ -17,7 +18,6 @@ extern "C" {
 
 actor Reader {
     let port: i32;
-
     receive fn go() {
         sleep_ms(100);
         let conn = net.connect(f"127.0.0.1:{port}");
@@ -25,7 +25,7 @@ actor Reader {
             Ok(_body) => 42,
             Err(e) => {
                 match e {
-                    IoError::TimedOut(_code) => 7,
+                    NetError::TimedOut(_code) => 7,
                     _ => 8,
                 }
             },

--- a/tests/vertical-slice/accept/await_read_string_deadline_timeout.hew
+++ b/tests/vertical-slice/accept/await_read_string_deadline_timeout.hew
@@ -1,6 +1,6 @@
 // Accept fixture (NEW-6c): `await conn.read_string() | after d` — deadline
 // elapses before the peer writes, so the suspending read resolves to
-// `Err(IoError::TimedOut(_))`.
+// `Err(NetError::TimedOut(_))`.
 //
 // Run under `HEW_WORKERS=1`: the reader parks worker-free on the read slot,
 // the main thread keeps the accepted peer silent, and the deadline timer
@@ -8,7 +8,9 @@
 // and hang.
 //
 // Exit-code contract: timeout Err(TimedOut) -> 7; unexpected Ok -> 42;
-// wrong IoError variant -> 8; no actor exit -> main fallback 99.
+// wrong NetError variant -> 8; no actor exit -> main fallback 99.
+import std::net;
+
 import std::net::{Listener};
 
 extern "C" {
@@ -24,7 +26,7 @@ actor Reader {
             Ok(_body) => 42,
             Err(e) => {
                 match e {
-                    IoError::TimedOut(_code) => 7,
+                    NetError::TimedOut(_code) => 7,
                     _ => 8,
                 }
             },

--- a/tests/vertical-slice/accept/await_read_string_deadline_timeout.hew
+++ b/tests/vertical-slice/accept/await_read_string_deadline_timeout.hew
@@ -9,8 +9,6 @@
 //
 // Exit-code contract: timeout Err(TimedOut) -> 7; unexpected Ok -> 42;
 // wrong NetError variant -> 8; no actor exit -> main fallback 99.
-import std::net;
-
 import std::net::{Listener};
 
 extern "C" {

--- a/tests/vertical-slice/reject/await_read_deadline_default_context.hew
+++ b/tests/vertical-slice/reject/await_read_deadline_default_context.hew
@@ -4,9 +4,11 @@
 //
 // Harness verb: hew compile (must fail)
 // Expected diagnostic substring: "non-suspendable context"
+import std::net;
+
 import std::net::{Connection};
 
-fn helper(conn: Connection) -> Result<bytes, fs.IoError> {
+fn helper(conn: Connection) -> Result<bytes, net.NetError> {
     await conn.read() | after 50ms
 }
 

--- a/tests/vertical-slice/reject/await_read_deadline_default_context.hew
+++ b/tests/vertical-slice/reject/await_read_deadline_default_context.hew
@@ -4,8 +4,6 @@
 //
 // Harness verb: hew compile (must fail)
 // Expected diagnostic substring: "non-suspendable context"
-import std::net;
-
 import std::net::{Connection};
 
 fn helper(conn: Connection) -> Result<bytes, net.NetError> {

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -2321,7 +2321,7 @@ fi
 
 # Accept (worker-free read-deadline oracle): `await conn.read() | after 60ms`
 # where the peer stays silent. Under HEW_WORKERS=1 the read parks worker-free and
-# the deadline timer resumes the actor with Err(IoError::TimedOut) -> exit 7.
+# the deadline timer resumes the actor with Err(NetError::TimedOut) -> exit 7.
 compile_accept "await_read_deadline_deferred"
 read_timeout_bin="${ROOT}/.tmp/compile-out/await_read_deadline_deferred"
 read_deadline_status=0
@@ -2356,7 +2356,7 @@ fi
 
 # Accept (read_string worker-free timeout oracle): `await conn.read_string() | after 60ms`
 # where the peer stays silent. Under HEW_WORKERS=1 the read parks worker-free and
-# the deadline timer resumes the actor with Err(IoError::TimedOut) -> exit 7.
+# the deadline timer resumes the actor with Err(NetError::TimedOut) -> exit 7.
 # Proves the to_string deadline path does NOT apply bytes-to-string on the timeout edge.
 compile_accept "await_read_string_deadline_timeout"
 read_str_timeout_bin="${ROOT}/.tmp/compile-out/await_read_string_deadline_timeout"
@@ -2490,7 +2490,7 @@ fi
 
 # Accept (accept-deadline worker-free timeout oracle): `await ln.accept() | after 60ms`
 # where no client connects. Under HEW_WORKERS=1 the accept parks worker-free and
-# the deadline timer resumes the actor with Err(IoError::TimedOut) -> exit 7.
+# the deadline timer resumes the actor with Err(NetError::TimedOut) -> exit 7.
 compile_accept "await_accept_deadline_timeout"
 accept_timeout_bin="${ROOT}/.tmp/compile-out/await_accept_deadline_timeout"
 accept_timeout_status=0


### PR DESCRIPTION
## Summary

`net::NetError` is a new purpose-built error type for network failures, carrying variants `ConnectionRefused`, `AddressInUse`, `AddressNotAvailable`, `TimedOut`, `Cancelled`, and `Other`. All std/net APIs — `net`, `dns`, `http`, `quic`, `tls`, and `websocket` — now return `NetError` instead of the filesystem `fs::IoError`. `fs::IoError` is unchanged and continues to cover file-system error paths exclusively. The split makes the type contract of network vs. file-system operations unambiguous at the call site.

## Verification

- `make test-hew`: 888 passed, 0 failed, 0 ignored
- `make test-stdlib-ratchet`: 72/72 pass (Actual failures: 0)
- Net e2e vertical-slice fixtures: pass (TCP accept/read deadline accept + timeout paths)
- `cargo fmt --check`: pass (pre-push hook)
- Preflight: ready-to-push

## Out of scope

- No changes to the `fs::IoError` variant set or any file-system API signatures — filesystem error handling is intentionally untouched.
- No runtime ABI changes; `NetError` is emitted as a standard Hew enum and requires no codec update.
- Migration of any user-facing `.hew` code outside std/ and examples/ is left to adopters — the stdlib surface is the normative reference.
