### PR TITLE
fix(hir): skip diverging arms when inferring match result type

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -21027,7 +21027,13 @@ impl LowerCtx {
                 self.pop_scope();
             }
 
-            if result_ty.is_none() {
+            // Skip diverging arms (Unit = no trailing expr / return-only block;
+            // Never = explicit bottom type) when inferring the match result type,
+            // mirroring `check_match_expr`'s `Ty::Never | Ty::Error` skip.  A
+            // diverging arm body typed as `Unit` by `lower_block` (because it has
+            // no tail expression, e.g. `{ return X; }`) must not constrain the
+            // match result type — only non-diverging arms should set it.
+            if result_ty.is_none() && !matches!(body_hir.ty, ResolvedTy::Unit | ResolvedTy::Never) {
                 result_ty = Some(body_hir.ty.clone());
             }
 

--- a/tests/vertical-slice/accept/match_diverging_arm_result_type.expected
+++ b/tests/vertical-slice/accept/match_diverging_arm_result_type.expected
@@ -1,0 +1,2 @@
+hello
+ok

--- a/tests/vertical-slice/accept/match_diverging_arm_result_type.hew
+++ b/tests/vertical-slice/accept/match_diverging_arm_result_type.hew
@@ -1,0 +1,42 @@
+//! Match expression where the first arm diverges via early return and the
+//! second arm produces the match result type.
+//!
+//! Root cause that was fixed: `lower_match_expr` took the first arm's body
+//! type as the match result type regardless of divergence.  A return-only arm
+//! (`{ return X; }`) is typed `Unit` by `lower_block` (no trailing expression),
+//! so the match node received `ty = Unit`, the `let` binding got an `i8` slot,
+//! but MIR's mixed-divergence recovery correctly made the result_place `ptr`.
+//! That mismatch emitted a codegen ICE: "fail-closed: Move type mismatch:
+//! src=ptr dest=i8".
+//!
+//! The fix mirrors `check_match_expr`: skip `Unit | Never` arms when inferring
+//! the match result type in `lower_match_expr`.
+//!
+//! Observable contract: the program prints two lines and exits 0.
+
+enum Status {
+    Good(string);
+    Bad;
+}
+
+fn parse(input: string, fail: bool) -> Status {
+    // First arm diverges; second arm produces `Status` — the match result type.
+    let result = match fail {
+        true => {
+            return Status::Bad;
+        },
+        false => Status::Good(input),
+    };
+    result
+}
+
+fn main() {
+    match parse("hello", false) {
+        Status::Good(s) => println(s),
+        Status::Bad => println("bad"),
+    }
+    match parse("ignored", true) {
+        Status::Good(_) => println("unexpected"),
+        Status::Bad => println("ok"),
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -757,6 +757,9 @@ run_accept_expect_stdout "owned_nested_tuple_clone"
 run_accept_expect_stdout "owned_nested_tuple_bytes"
 run_accept_expect_stdout "owned_nested_tuple_record"
 run_accept_expect_stdout "match_float_literal_arm"
+# match result type is inferred from the non-diverging arm; a return-only arm
+# (typed Unit by lower_block) must not set the match result type.
+run_accept_expect_stdout "match_diverging_arm_result_type"
 run_check_run_expect_stdout "const_ref_init"
 
 # W4.039 — bytes-to-string triple-ABI canonicalisation. Behavioural proof


### PR DESCRIPTION
## Summary

`lower_match_expr` in the HIR lowering pass was allowing a diverging arm (a return-only block, lowered to `Unit`) to set the match result type, even when a later arm produces a real value. This diverged from the type checker's logic in `check_match_expr`, which skips `Never`/`Error` arms when seeding the result type. The mismatch caused a codegen ICE: a function containing an early `return EnumVariant(payload)` arm followed by a json API call in the value arm produced a `Move type mismatch: src=ptr dest=i8` with no source span.

`lower_match_expr` now skips arms whose body type is `ResolvedTy::Unit | ResolvedTy::Never` when inferring the match result type, matching the checker's contract. All-diverging and all-value matches are unaffected; only mixed-divergence/value matches where a diverging arm was incorrectly anchoring the result type are fixed.

## Verification

- `make test-lane CRATE=hew-hir`: green
- `make test-lane CRATE=hew-mir`: green
- `tests/vertical-slice/run.sh` (full suite including new fixture): green
- New vertical-slice fixture `tests/vertical-slice/accept/match_diverging_arm_result_type.hew`: compiles and produces expected output
- Incident shape repro (early `return EnumVariant` + json API call): compiles and runs without the `Move type mismatch` ICE
- Preflight: ready-to-push

## Out of scope

No changes to the type checker, parser, or MIR lowering — this is a one-line HIR inference fix. No other divergence-handling sites in the lowering pass were altered.
