### PR TITLE
test(await): widen scope_deadline_suspend nap_long margin from 100ms to 500ms

### DIFF
--- a/examples/actor/scope_deadline_suspend.hew
+++ b/examples/actor/scope_deadline_suspend.hew
@@ -16,7 +16,7 @@
 actor Worker {
     var fired: i64 = 0;
 
-    // The scoped child sleeps 100ms; the deadline is 20ms, so the deadline wins
+    // The scoped child sleeps 500ms; the deadline is 20ms, so the deadline wins
     // and the recovery body runs (fired = 7).
     receive fn timeout_wins() -> i64 {
         scope {
@@ -46,7 +46,7 @@ actor Worker {
 }
 
 fn nap_long() {
-    sleep_ms(100);
+    sleep_ms(500);
 }
 
 fn nap_short() {
@@ -55,7 +55,7 @@ fn nap_short() {
 
 fn main() {
     let w = spawn Worker(fired: 0);
-    // Deadline (20ms) beats the 100ms child: the recovery body runs.
+    // Deadline (20ms) beats the 500ms child: the recovery body runs.
     let t = await w.timeout_wins();
     match t {
         Ok(v) => println(f"timeout={v}"),


### PR DESCRIPTION
## Summary

The `scope_deadline_runs_or_skips_the_timeout_body_under_both_pools` test had a pre-existing timing flake under CI load. The 20ms deadline could fire after the 100ms child task completed, leaving the timeout-recovery body unexecuted (`timeout=0` vs expected `7`). Widening `nap_long` to 500ms gives the deadline a 25x margin over worst-case delayed delivery, so the deadline reliably wins regardless of scheduler jitter. No engine change — pure test-fixture timing adjustment.

## Verification

- `make test-lane CRATE=hew-cli`: green
- `scope_deadline_runs_or_skips_the_timeout_body_under_both_pools`: 5/5 flake-gate passes; expected output unchanged (timeout=7/work=0)
- Codegen output: byte-identical to main
- Preflight: ready-to-push

## Out of scope

- No engine, runtime, or stdlib changes. The 20ms deadline value itself is untouched; only the child task sleep duration changes so the fixture reliably exercises the timeout path.
