### PR TITLE
refactor(types): make the trait registry the single authority for #[resource] declarations

### DIFF
--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -1129,13 +1129,11 @@ impl Checker {
         if method != "close" || sig.requires_mutable_receiver {
             return false;
         }
-        // `resource_types` is keyed by the declared (bare) type name. The
-        // receiver type name may arrive module-qualified (`mod.Conn`) for an
-        // imported handle type; match on the unqualified suffix too.
-        let unqualified = type_name
-            .rsplit_once('.')
-            .map_or(type_name, |(_, suffix)| suffix);
-        self.resource_types.contains(type_name) || self.resource_types.contains(unqualified)
+        // The trait registry is the single authority for the `#[resource]`
+        // fact. `is_resource` matches the declared bare name and the
+        // module-qualified receiver's unqualified suffix (`mod.Conn` → `Conn`)
+        // for imported handle types.
+        self.registry.is_resource(type_name)
     }
 
     /// Apply the consume-receiver marker for a trait-dispatched method call:

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -1533,7 +1533,7 @@ impl Checker {
         // modules too, so an imported handle type's inherent `close(self)`
         // consumes its receiver at the call site (mirrors `register_type_decl`).
         if td.resource_marker == hew_parser::ast::ResourceMarker::Resource {
-            self.resource_types.insert(td.name.clone());
+            self.registry.register_resource_type(td.name.clone());
         }
         let kind = match td.kind {
             TypeDeclKind::Struct => TypeDefKind::Struct,
@@ -1776,7 +1776,7 @@ impl Checker {
         // duplicate scope-exit implicit drop). HIR owns the close-discipline
         // diagnostics (W3.030); the checker only needs the marker fact here.
         if td.resource_marker == hew_parser::ast::ResourceMarker::Resource {
-            self.resource_types.insert(td.name.clone());
+            self.registry.register_resource_type(td.name.clone());
         }
         // Track user-declared `#[opaque]` types so `record_clone_admissibility`
         // can detect opaque fields transitively. The module_registry only

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -2177,13 +2177,6 @@ pub struct Checker {
     /// this set when `trait Closable` is registered. Tests may insert names
     /// directly to exercise the consume-marker path before PR 2 lands.
     pub(super) consume_receiver_methods: HashSet<String>,
-    /// Names of types declared with the `#[resource]` marker. A `#[resource]`
-    /// type's inherent `close(self)` is BOTH the implicit-drop dispatch target
-    /// (W3.030) AND a terminal consuming method: calling it moves the receiver,
-    /// so a subsequent use is `UseAfterMove` and the scope-exit implicit drop is
-    /// suppressed on the consumed path (#1295). Populated at type-decl
-    /// registration; consulted when an inherent `close` call site is dispatched.
-    pub(super) resource_types: HashSet<String>,
     pub(super) pending_lowering_facts: HashMap<SpanKey, PendingLoweringFact>,
     /// `HashMap` key/value admission checks deferred until after inference
     /// completes.  Keyed by span to suppress duplicates from repeated
@@ -2845,7 +2838,6 @@ impl Checker {
             actor_handler_state_guards: HashMap::new(),
             actor_max_heap: HashMap::new(),
             consume_receiver_methods: HashSet::new(),
-            resource_types: HashSet::new(),
             pending_lowering_facts: HashMap::new(),
             deferred_hashmap_admission: HashMap::new(),
             deferred_hashset_admission: HashMap::new(),

--- a/hew-types/src/traits.rs
+++ b/hew-types/src/traits.rs
@@ -181,6 +181,20 @@ pub struct TraitRegistry {
     /// be serializable. Registration deliberately includes records, enums, and
     /// wire-marked types, but not ordinary plain structs.
     serializable_members: HashMap<String, Vec<Ty>>,
+    /// Names of types declared with the `#[resource]` marker.
+    ///
+    /// A `#[resource]` type's inherent `close(self)` is BOTH the implicit-drop
+    /// dispatch target (W3.030) AND a terminal consuming method: calling it
+    /// moves the receiver, so a subsequent use is `UseAfterMove` and the
+    /// scope-exit implicit drop is suppressed on the consumed path (#1295).
+    ///
+    /// This is the single source of truth for the user-declared `#[resource]`
+    /// fact. The structural `MarkerTrait::Resource` derivation in
+    /// `implements_marker` covers the built-in resource handles (`Duplex`,
+    /// `CancellationToken`) on their type shape; this set covers the
+    /// user/stdlib `#[resource]` declarations keyed by name. Both are owned by
+    /// the registry so the checker no longer keeps a parallel allowlist.
+    resource_types: HashSet<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -533,6 +547,30 @@ impl TraitRegistry {
                 .drop_types
                 .iter()
                 .any(|dt| dt.rsplit('.').next() == Some(name))
+    }
+
+    /// Register a `#[resource]` type by its declared (bare) name.
+    ///
+    /// Called at type-decl registration for every user/stdlib `#[resource]`
+    /// declaration. The registry is the single authority for this fact;
+    /// `is_resource` is the only query path.
+    pub fn register_resource_type(&mut self, name: String) {
+        self.resource_types.insert(name);
+    }
+
+    /// Report whether `name` is a `#[resource]` type.
+    ///
+    /// `resource_types` is keyed by the declared (bare) type name. A receiver
+    /// type name may arrive module-qualified (`mod.Conn`) for an imported
+    /// handle type, so the unqualified suffix is matched too — mirroring the
+    /// bare/unqualified lookup the `Drop`/handle type sets use.
+    #[must_use]
+    pub fn is_resource(&self, name: &str) -> bool {
+        if self.resource_types.contains(name) {
+            return true;
+        }
+        let unqualified = name.rsplit_once('.').map_or(name, |(_, suffix)| suffix);
+        self.resource_types.contains(unqualified)
     }
 
     /// Register a negative impl (type does NOT implement trait).
@@ -1551,6 +1589,26 @@ mod tests {
             "HashMap<String, i64> must NOT be Serializable at the RemotePid boundary \
              (codec walk does not support collection types)"
         );
+    }
+
+    /// RI-01: the `TraitRegistry` is the single source of truth for the
+    /// user-declared `#[resource]` fact. After the unify the checker keeps no
+    /// parallel allowlist — a resource type is recognised ONLY because it was
+    /// registered here, via the registry's own `is_resource` query.
+    #[test]
+    fn registry_is_sole_authority_for_resource_types() {
+        let mut registry = TraitRegistry::new();
+        // Unregistered type is not a resource.
+        assert!(!registry.is_resource("Child"));
+
+        registry.register_resource_type("Child".to_string());
+        // Registered bare name resolves through the registry alone.
+        assert!(registry.is_resource("Child"));
+        // Module-qualified receiver name resolves via the unqualified suffix,
+        // matching the imported-handle dispatch path.
+        assert!(registry.is_resource("process.Child"));
+        // A different qualified type is not admitted by the suffix fallback.
+        assert!(!registry.is_resource("process.Parent"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`TraitRegistry` is now the sole source of truth for the user `#[resource]` fact. `TraitRegistry::register_resource_type` records every `#[resource]`-annotated declaration, and `TraitRegistry::is_resource` answers the lookup — handling both bare names and module-qualified receivers (`mod.Conn` → `Conn`) to preserve imported-handle coverage. The parallel `Checker::resource_types` allowlist is deleted; both registration write paths and the inherent-close consume query now go through the registry.

The structural `Resource` marker derivation for built-in types (`CancellationToken`, `Duplex`) is unchanged — `implements_marker` continues to handle that path and the two mechanisms stay distinct.

## Verification

- `registry_is_sole_authority_for_resource_types`: pass — proves default negative, explicit registration, module-qualified suffix match, and distinct-name negative
- `resource_inherent_close_records_per_call_site_flag`: pass
- `non_resource_inherent_close_not_in_resource_consume_set`: pass
- `named_type_inherent_close_consumes_receiver`: pass
- `cargo nextest run -p hew-types`: 2186/2186 passed
- Preflight: ready-to-push

## Out of scope

- Routing `type_implements_trait` through `TraitRegistry::trait_impls` (that is a separate refactor targeting the silent impl-shadowing hazard and is tracked independently)
- Any changes to codegen or the LLVM emission layer