### PR TITLE
fix(cli): allow hyphen-prefixed values for --link-lib

### DIFF
--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -203,7 +203,8 @@ pub struct RunArgs {
     #[arg(long)]
     pub profile: bool,
     /// Pass an extra library or linker argument to the native link step.
-    #[arg(long = "link-lib", value_name = "PATH")]
+    /// Values may begin with a dash (e.g. `-lMagickWand-7.Q16`).
+    #[arg(long = "link-lib", value_name = "PATH", allow_hyphen_values = true)]
     pub link_libs: Vec<String>,
     /// Target triple.
     #[arg(long, value_name = "TRIPLE")]
@@ -251,7 +252,8 @@ pub struct DebugArgs {
     #[arg(long, short = 'g', hide = true)]
     pub debug: bool,
     /// Pass an extra library or linker argument to the native link step.
-    #[arg(long = "link-lib", value_name = "PATH")]
+    /// Values may begin with a dash (e.g. `-lMagickWand-7.Q16`).
+    #[arg(long = "link-lib", value_name = "PATH", allow_hyphen_values = true)]
     pub link_libs: Vec<String>,
     /// Target triple.
     #[arg(long, value_name = "TRIPLE")]
@@ -339,7 +341,8 @@ pub struct BuildArgs {
     #[arg(long, short = 'g')]
     pub debug: bool,
     /// Pass an extra library or linker argument to the native link step.
-    #[arg(long = "link-lib", value_name = "PATH")]
+    /// Values may begin with a dash (e.g. `-lMagickWand-7.Q16`).
+    #[arg(long = "link-lib", value_name = "PATH", allow_hyphen_values = true)]
     pub link_libs: Vec<String>,
     #[command(flatten)]
     pub common: CommonBuildArgs,

--- a/hew-cli/tests/build_args_e2e.rs
+++ b/hew-cli/tests/build_args_e2e.rs
@@ -4,6 +4,37 @@ use std::process::Command;
 
 use support::{describe_output, hew_binary, repo_root};
 
+/// `--link-lib` must accept values that begin with a dash, such as `-lMagickWand-7.Q16`.
+///
+/// Before the fix, clap interpreted the leading `-` as an unknown flag and
+/// rejected the argument before the file was even opened. The test uses a
+/// non-existent input path so it never reaches the linker, but the error must
+/// be about the missing file, not about an unexpected argument or unknown flag.
+#[test]
+fn link_lib_hyphen_value_is_not_rejected_as_unknown_flag() {
+    for command in ["run", "debug", "build"] {
+        let output = Command::new(hew_binary())
+            .args([
+                command,
+                "--link-lib",
+                "-lMagickWand-7.Q16",
+                "placeholder.hew",
+            ])
+            .current_dir(repo_root())
+            .output()
+            .unwrap();
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("unexpected argument")
+                && !stderr.contains("unknown flag")
+                && !stderr.contains("invalid value")
+                && !stderr.contains("unrecognized"),
+            "`hew {command} --link-lib -lMagickWand-7.Q16` was rejected by clap as a flag: {stderr}",
+        );
+    }
+}
+
 #[test]
 fn werror_flag_is_accepted_by_build_style_commands() {
     // --Werror must stay accepted by the build-style commands even when the


### PR DESCRIPTION
## Summary

clap was rejecting hyphen-prefixed values for `--link-lib` — arguments like `-lMagickWand-7.Q16` were parsed as unknown flags rather than library names. `allow_hyphen_values = true` is now set on `--link-lib` for the `run`, `debug`, and `build` subcommands, matching what native-FFI callers need when passing platform library names that include version suffixes or other hyphens (as in the `image_batch` example's link flags).

## Verification

- `link_lib_hyphen_value_is_not_rejected_as_unknown_flag` test (run/debug/build subcommands): PASS
- `build_args_e2e`: 3/3 PASS
- Preflight: ready-to-push (fmt ✓, clippy ✓)

## Out of scope

No changes to link-flag propagation through the build pipeline or to how `--link-lib` values are consumed downstream — those paths are unchanged. No other CLI flags were touched.
