### PR TITLE
feat(codegen): add --opt-level flag and the -O2 middle-end pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@
 # ============================================================================
 
 .PHONY: all build bootstrap install-hooks hew adze observe runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh
-.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all test-stdlib test-hew test-hew-ratchet test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo hew-fmt-check grammar
+.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all test-stdlib test-hew test-hew-ratchet test-o2-differential test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo hew-fmt-check grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
 .PHONY: coverage coverage-summary coverage-lcov coverage-runtime coverage-combined coverage-branch
@@ -682,6 +682,13 @@ test-hew: hew runtime stdlib
 test-hew-ratchet: hew runtime stdlib
 	@echo "==> Running Hew test suite (ratcheted)"
 	scripts/hew-suite-ratchet.sh
+
+# The -O0-vs-O2 differential-exec parity gate: every compiled `.hew` program
+# must behave identically at -O0 and -O2. The no-miscompile oracle for the LLVM
+# middle-end pipeline (RC9). A divergence is a miscompile and a full stop.
+test-o2-differential: hew runtime stdlib
+	@echo "==> Running -O0-vs-O2 differential-exec parity gate"
+	scripts/o2-differential.sh
 
 test-stdlib-ratchet: hew
 	@echo "==> Type-checking stdlib (ratcheted)"

--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -118,6 +118,10 @@ pub struct CompileArgs {
     /// Compilation target. Omit for native; pass `wasm32-unknown-unknown` for WASM.
     #[arg(long, value_name = "TRIPLE")]
     pub target: Option<String>,
+    /// LLVM middle-end optimization level: `0` (default, no optimization) or
+    /// `2` (the `default<O2>` release pipeline — inlining, SROA, GVN, loop opts).
+    #[arg(long = "opt-level", value_parser = ["0", "2"], default_value = "0", value_name = "LEVEL")]
+    pub opt_level: String,
     /// Diagnostic output format: `text` (default) or `json`.
     #[arg(long, value_enum, default_value_t = DiagnosticFormat::Text, value_name = "FORMAT")]
     pub format: DiagnosticFormat,
@@ -340,6 +344,12 @@ pub struct BuildArgs {
     /// Build with debug info (no optimization, no stripping).
     #[arg(long, short = 'g')]
     pub debug: bool,
+    /// LLVM middle-end optimization level: `0` (default, no optimization) or
+    /// `2` (the `default<O2>` release pipeline). Independent of `-g`: `-g`
+    /// remains O0 unless `--opt-level 2` is also passed (which produces
+    /// lower-fidelity DWARF — inlined frames, optimized-out locals).
+    #[arg(long = "opt-level", value_parser = ["0", "2"], default_value = "0", value_name = "LEVEL")]
+    pub opt_level: String,
     /// Pass an extra library or linker argument to the native link step.
     /// Values may begin with a dash (e.g. `-lMagickWand-7.Q16`).
     #[arg(long = "link-lib", value_name = "PATH", allow_hyphen_values = true)]

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -389,6 +389,7 @@ fn emit_module(
     emit_dir: &Path,
     emit_target: CompileEmitTarget,
     link_freestanding_wasm: bool,
+    opt_level: hew_codegen_rs::OptLevel,
 ) -> Result<hew_codegen_rs::EmitArtefacts, ()> {
     emit_module_with_triple(
         pipeline,
@@ -398,6 +399,7 @@ fn emit_module(
         None,
         link_freestanding_wasm,
         false,
+        opt_level,
         None,
     )
 }
@@ -420,6 +422,7 @@ fn emit_module_with_triple(
     target_triple: Option<&str>,
     link_freestanding_wasm: bool,
     debug: bool,
+    opt_level: hew_codegen_rs::OptLevel,
     source_path: Option<&Path>,
 ) -> Result<hew_codegen_rs::EmitArtefacts, ()> {
     let options = hew_codegen_rs::EmitOptions {
@@ -429,6 +432,7 @@ fn emit_module_with_triple(
         wasm: emit_target == CompileEmitTarget::Wasm,
         target_triple,
         debug,
+        opt_level,
         source_path,
     };
     let result = if emit_target == CompileEmitTarget::Wasm && !link_freestanding_wasm {
@@ -470,6 +474,7 @@ fn emit_module_for_target(
     target: &target::TargetSpec,
     link_freestanding_wasm: bool,
     debug: bool,
+    opt_level: hew_codegen_rs::OptLevel,
     source_path: Option<&Path>,
 ) -> Result<hew_codegen_rs::EmitArtefacts, ()> {
     let codegen_triple = match emit_target {
@@ -484,6 +489,7 @@ fn emit_module_for_target(
         codegen_triple.as_deref(),
         link_freestanding_wasm,
         debug,
+        opt_level,
         source_path,
     )
 }
@@ -516,6 +522,7 @@ pub(crate) fn compile_native_binary(input: &Path, bin_path: &Path) -> Result<(),
         emit_dir,
         CompileEmitTarget::Native,
         true,
+        hew_codegen_rs::OptLevel::O0,
     )?;
     let obj = artefacts.native_obj_path.as_deref().ok_or_else(|| {
         eprintln!("E_NOT_YET_IMPLEMENTED: native codegen did not produce an object");
@@ -523,6 +530,11 @@ pub(crate) fn compile_native_binary(input: &Path, bin_path: &Path) -> Result<(),
     link_native_object(obj, bin_path)
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "cohesive frontend->MIR->emit->link pipeline already at the line boundary; \
+              threading opt_level tipped it over — splitting it would obscure the linear flow"
+)]
 pub(crate) fn compile_native_from_program(
     program: hew_parser::ast::Program,
     source: &str,
@@ -605,14 +617,20 @@ pub(crate) fn compile_native_from_program(
         .unwrap_or("module");
     let emit_target = if target.is_wasm() {
         CompileEmitTarget::Wasm
-    } else {
-        if !target.can_link_with_host_tools() {
-            eprintln!("{}", target.unsupported_native_link_error());
-            return Err(());
-        }
+    } else if target.can_link_with_host_tools() {
         CompileEmitTarget::Native
+    } else {
+        eprintln!("{}", target.unsupported_native_link_error());
+        return Err(());
     };
-    let artefacts = emit_module(&pipeline, module_name, emit_dir, emit_target, false)?;
+    let artefacts = emit_module(
+        &pipeline,
+        module_name,
+        emit_dir,
+        emit_target,
+        false,
+        hew_codegen_rs::OptLevel::O0,
+    )?;
 
     match emit_target {
         CompileEmitTarget::Native => {
@@ -686,11 +704,16 @@ fn link_native_object_for_target(
 
 /// Build a native (or wasm) binary for an explicit target, writing it to
 /// `output_path`. Reuses the front-end → MIR → emit → link chain.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the build path threads each emit/link knob explicitly; grouping obscures the flow"
+)]
 fn compile_build_binary(
     input: &Path,
     output_path: &Path,
     target: &target::TargetSpec,
     debug: bool,
+    opt_level: hew_codegen_rs::OptLevel,
     extra_libs: &[String],
     options: &compile::CompileOptions,
 ) -> Result<(), ()> {
@@ -715,6 +738,7 @@ fn compile_build_binary(
         // yields a runnable `.wasm`; the native branch links separately below.
         emit_target == CompileEmitTarget::Wasm,
         debug,
+        opt_level,
         Some(input),
     )?;
 
@@ -759,6 +783,7 @@ fn compile_build_binary(
 fn emit_obj_only(
     input: &Path,
     target: &target::TargetSpec,
+    opt_level: hew_codegen_rs::OptLevel,
     options: &compile::CompileOptions,
 ) -> Result<(), ()> {
     let (pipeline, _native_pkg_dirs) = lower_file_to_mir_for_target(input, target, options)?;
@@ -781,6 +806,7 @@ fn emit_obj_only(
         target,
         false,
         false,
+        opt_level,
         None,
     )?;
     let produced = match emit_target {
@@ -813,8 +839,19 @@ fn cmd_build(a: &args::BuildArgs) {
     });
     let options = a.to_compile_options();
 
+    // The clap `value_parser` already constrains `--opt-level` to {"0","2"}, so
+    // `from_cli_str` cannot return `None` here; fail closed regardless rather than
+    // silently defaulting if the parser contract ever drifts.
+    let opt_level = hew_codegen_rs::OptLevel::from_cli_str(&a.opt_level).unwrap_or_else(|| {
+        eprintln!(
+            "Error: invalid --opt-level `{}` (expected 0 or 2)",
+            a.opt_level
+        );
+        std::process::exit(2);
+    });
+
     if a.emit_obj {
-        emit_obj_only(&a.input, &target, &options).unwrap_or_else(|()| {
+        emit_obj_only(&a.input, &target, opt_level, &options).unwrap_or_else(|()| {
             if json {
                 diagnostic_json::flush_json_diagnostics();
             }
@@ -842,6 +879,7 @@ fn cmd_build(a: &args::BuildArgs) {
         &output_path,
         &target,
         a.debug,
+        opt_level,
         &a.link_libs,
         &options,
     )
@@ -893,14 +931,31 @@ fn cmd_compile(a: &args::CompileArgs) {
         .and_then(|s| s.to_str())
         .unwrap_or("module");
 
+    // The clap `value_parser` constrains `--opt-level` to {"0","2"}; fail closed
+    // if that contract ever drifts rather than silently defaulting.
+    let opt_level = hew_codegen_rs::OptLevel::from_cli_str(&a.opt_level).unwrap_or_else(|| {
+        eprintln!(
+            "Error: invalid --opt-level `{}` (expected 0 or 2)",
+            a.opt_level
+        );
+        std::process::exit(2);
+    });
+
     let emit_target = resolve_compile_emit_target(a.target.as_deref());
-    let artefacts = emit_module(&pipeline, module_name, emit_dir, emit_target, true)
-        .unwrap_or_else(|()| {
-            if json {
-                diagnostic_json::flush_json_diagnostics();
-            }
-            std::process::exit(1);
-        });
+    let artefacts = emit_module(
+        &pipeline,
+        module_name,
+        emit_dir,
+        emit_target,
+        true,
+        opt_level,
+    )
+    .unwrap_or_else(|()| {
+        if json {
+            diagnostic_json::flush_json_diagnostics();
+        }
+        std::process::exit(1);
+    });
 
     // Link the native object into an executable using the shared
     // `link::link_executable` path. This resolves `libhew.a` (the
@@ -1017,6 +1072,9 @@ fn compile_temp_wasi_module(
             &target_spec,
             false,
             false,
+            // The WASI `run`/`eval` path is debug-default O0; the `HEW_OPT_LEVEL`
+            // env floor lifts the whole corpus to O2 for the differential gate.
+            hew_codegen_rs::OptLevel::O0,
             None,
         )?;
         let obj = artefacts.wasm_obj_path.as_deref().ok_or_else(|| {
@@ -1069,6 +1127,9 @@ fn compile_temp_artifact(
         artifact.path(),
         &target,
         false,
+        // `hew run` is debug-default O0; the `HEW_OPT_LEVEL` env floor lifts the
+        // whole corpus to O2 for the differential-exec parity gate.
+        hew_codegen_rs::OptLevel::O0,
         &[],
         options,
     )

--- a/hew-cli/src/router.rs
+++ b/hew-cli/src/router.rs
@@ -259,6 +259,7 @@ mod tests {
             emit_dir: None,
             dump_mir: None,
             target: None,
+            opt_level: "0".to_string(),
             format: crate::args::DiagnosticFormat::Text,
         });
         let mut dispatcher = RecordingDispatcher::default();
@@ -276,6 +277,7 @@ mod tests {
             target: None,
             emit_obj: false,
             debug: false,
+            opt_level: "0".to_string(),
             link_libs: Vec::new(),
             common: crate::args::CommonBuildArgs::default(),
             format: crate::args::DiagnosticFormat::Text,

--- a/hew-codegen-rs/src/lib.rs
+++ b/hew-codegen-rs/src/lib.rs
@@ -40,5 +40,5 @@ pub(crate) mod thunks;
 
 pub use llvm::{
     emit_module, emit_module_objects, validate_codegen_front, verify_pipeline, CodegenError,
-    EmitArtefacts, EmitOptions,
+    EmitArtefacts, EmitOptions, OptLevel,
 };

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -43246,15 +43246,15 @@ fn main() {
             .unwrap_or_else(|e| panic!("post-O2 module failed verify: {e}"));
     }
 
-    /// RC9: a trivial (non-coroutine) module run through `run_module_pipeline` at
+    /// A trivial (non-coroutine) module run through `run_module_pipeline` at
     /// `O2` takes the plain `default<O2>` branch and stays verifier-clean. The
     /// post-pass `verify()` inside `run_module_pipeline` is the fail-closed guard;
     /// this pins that the production seam (not just an ad-hoc `run_passes` call)
     /// accepts a real module at O2.
     #[test]
-    fn rc9_run_module_pipeline_o2_noncoro_verifies() {
+    fn o2_pipeline_noncoro_module_verifies() {
         let ctx = Context::create();
-        let module = ctx.create_module("rc9_o2_noncoro");
+        let module = ctx.create_module("o2_noncoro");
         let machine = target_machine_for_triple(&native_emission_triple()).expect("host machine");
         let builder = ctx.create_builder();
 
@@ -43275,14 +43275,14 @@ fn main() {
         module.verify().expect("post-O2 verify");
     }
 
-    /// RC9: `module_has_coroutines` reports `false` for a non-coroutine module, so
+    /// `module_has_coroutines` reports `false` for a non-coroutine module, so
     /// `run_module_pipeline` at O2 selects the plain `default<O2>` branch (not the
     /// folded coro string). Pins the fold-guard predicate the production seam keys
     /// on — a regression that always reported `true` would double-run coro-split.
     #[test]
-    fn rc9_noncoro_module_takes_plain_o2_branch() {
+    fn o2_pipeline_noncoro_takes_default_branch() {
         let ctx = Context::create();
-        let module = ctx.create_module("rc9_fold_guard");
+        let module = ctx.create_module("fold_guard");
         let i64_ty = ctx.i64_type();
         let fn_ty = i64_ty.fn_type(&[], false);
         let f = module.add_function("k", fn_ty, None);
@@ -43298,7 +43298,7 @@ fn main() {
         );
     }
 
-    /// RC9: the `HEW_OPT_LEVEL` env var is a FLOOR — it raises O0 → O2 but never
+    /// The `HEW_OPT_LEVEL` env var is a FLOOR — it raises O0 → O2 but never
     /// lowers O2, and ignores any value other than exactly `"2"`. This is the
     /// test-harness lever the differential-exec gate uses; a regression that let
     /// it demote an explicit O2 build would silently weaken release codegen.
@@ -43307,7 +43307,7 @@ fn main() {
     /// codegen test suite runs in-process, so two env-mutating tests must not
     /// interleave.
     #[test]
-    fn rc9_env_floor_raises_but_never_lowers() {
+    fn opt_level_env_floor_raises_but_never_lowers() {
         use std::sync::Mutex;
         static ENV_LOCK: Mutex<()> = Mutex::new(());
         let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
@@ -43344,10 +43344,10 @@ fn main() {
         restore();
     }
 
-    /// RC9: `OptLevel::from_cli_str` accepts exactly `{"0","2"}` and rejects
-    /// everything else (the fail-closed CLI parse).
+    /// `OptLevel::from_cli_str` accepts exactly `{"0","2"}` and rejects
+    /// everything else — the fail-closed CLI parse.
     #[test]
-    fn rc9_opt_level_from_cli_str_is_closed() {
+    fn opt_level_from_cli_str_is_fail_closed() {
         assert_eq!(OptLevel::from_cli_str("0"), Some(OptLevel::O0));
         assert_eq!(OptLevel::from_cli_str("2"), Some(OptLevel::O2));
         assert_eq!(OptLevel::from_cli_str("1"), None);

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -331,11 +331,69 @@ pub struct EmitOptions<'a> {
     /// Whether to emit DWARF debug info (`hew build -g`). When `false` the
     /// emitted module carries zero debug metadata (the legacy behaviour).
     pub debug: bool,
+    /// LLVM middle-end optimization level to run over each emitted module
+    /// before object emission. [`OptLevel::O0`] (the default) runs NO module
+    /// optimization pipeline — only the conditional coroutine lowering — exactly
+    /// matching the legacy behaviour. [`OptLevel::O2`] runs LLVM's `default<O2>`
+    /// pipeline (inlining, SROA, GVN, instcombine, mem2reg, loop opts, DCE) at
+    /// the single object-emission chokepoint. The pipeline is fail-closed: a
+    /// `run_passes` error aborts emission rather than writing an unoptimized or
+    /// half-optimized module. Threaded exactly parallel to the `debug` field
+    /// above; defaults to `O0` so existing callers are behaviour-preserving.
+    pub opt_level: OptLevel,
     /// Path to the originating Hew source file, used as the DWARF
     /// `DICompileUnit`/`DIFile` and to build the byte-offset → line index for
     /// function-entry locations. `None` (or `debug == false`) emits no debug
     /// info. Only consulted when `debug` is `true`.
     pub source_path: Option<&'a Path>,
+}
+
+/// The LLVM middle-end optimization level applied to each emitted module.
+///
+/// `O0` is the default and the historical behaviour: `write_to_file` runs only
+/// the backend (instruction selection / regalloc) passes plus the conditional
+/// coroutine lowering — no IR-level middle-end. `O2` runs LLVM's battle-tested
+/// `default<O2>` module pipeline before object emission. Only the two levels
+/// `{0, 2}` are exposed; intermediate/aggressive levels (O1/O3/Os/Oz) are a
+/// trivial future extension of this enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OptLevel {
+    /// No middle-end optimization (fast compile, debuggable). The default.
+    #[default]
+    O0,
+    /// LLVM `default<O2>` — the SOTA release pipeline.
+    O2,
+}
+
+impl OptLevel {
+    /// Parse a CLI `--opt-level` value (`"0"` or `"2"`) into the enum.
+    /// Returns `None` for any other value so the caller fails closed.
+    pub fn from_cli_str(s: &str) -> Option<Self> {
+        match s {
+            "0" => Some(OptLevel::O0),
+            "2" => Some(OptLevel::O2),
+            _ => None,
+        }
+    }
+}
+
+/// Raise `requested` to `O2` when `HEW_OPT_LEVEL=2` is set in the environment.
+///
+/// This is the test-harness FLOOR (see the call site for the full rationale):
+/// the differential-exec parity gate forces the whole compiled corpus through
+/// O2 by exporting `HEW_OPT_LEVEL=2`, without a per-subcommand flag. The env var
+/// can only RAISE the level (an explicit `--opt-level 2` is never demoted); any
+/// value other than exactly `"2"` is ignored and the requested level stands.
+fn resolve_opt_level_with_env_floor(requested: OptLevel) -> OptLevel {
+    let env_o2 = std::env::var_os("HEW_OPT_LEVEL")
+        .as_deref()
+        .map(|v| v == std::ffi::OsStr::new("2"))
+        .unwrap_or(false);
+    if env_o2 {
+        OptLevel::O2
+    } else {
+        requested
+    }
 }
 
 /// Result of an emit: the paths of every produced artefact, for the CLI to
@@ -501,6 +559,20 @@ fn emit_module_with_options(
         _ => None,
     };
 
+    // Resolve the effective optimization level. The production source of truth is
+    // `options.opt_level` (set from the `--opt-level` CLI flag). The
+    // `HEW_OPT_LEVEL` env var is a TEST-HARNESS FLOOR: it lets the differential-exec
+    // parity gate and the `hew test`/`hew run` ratchet drive the WHOLE corpus
+    // through O2 without threading a flag through every subcommand. It can only
+    // RAISE the level (O0 → O2), never lower it, so it can never weaken a build
+    // that explicitly requested O2.
+    // WHY a floor and not an override: a release build that already asked for O2
+    // must not be silently demoted by a stray `HEW_OPT_LEVEL=0`; an O0 build is the
+    // only one the harness needs to lift. WHEN OBSOLETE: when every subcommand
+    // (`run`/`test`/`eval`) carries its own `--opt-level` flag and the harness sets
+    // it directly. REAL SOLUTION: per-subcommand flag plumbing (a follow-up).
+    let effective_opt_level = resolve_opt_level_with_env_floor(options.opt_level);
+
     // Build the textual IR once as the forensic `.ll` artefact — `opt
     // -passes=verify` runs against it directly. It is classified against the
     // requested target (the explicit `--target` triple, the wasm32 triple, or
@@ -536,6 +608,7 @@ fn emit_module_with_options(
             &triple_str,
             &obj_path,
             debug_input,
+            effective_opt_level,
         )?;
         artefacts.native_obj_path = Some(obj_path);
     }
@@ -551,6 +624,7 @@ fn emit_module_with_options(
             "wasm32-unknown-unknown",
             &wasm_obj_path,
             debug_input,
+            effective_opt_level,
         )?;
         if link_freestanding_wasm {
             let wasm_path = options
@@ -1045,6 +1119,7 @@ fn emit_object_in_process(
     triple: &str,
     out_path: &Path,
     debug: Option<DebugInput<'_>>,
+    opt_level: OptLevel,
 ) -> CodegenResult<()> {
     let _guard = llvm_codegen_lock()
         .lock()
@@ -1052,14 +1127,21 @@ fn emit_object_in_process(
     let machine = target_machine_for_triple(triple)?;
     let ctx = Context::create();
     let llvm_mod = build_module_for_target(&ctx, pipeline, module_name, Some(&machine), debug)?;
-    // Run LLVM's coroutine lowering (CoroSplit et al.) before instruction
-    // selection. `write_to_file` does NOT run the module optimization pipeline,
-    // so a `presplitcoroutine` function would otherwise reach the backend
-    // un-split and fail to lower its `llvm.coro.*` intrinsics. Gated on a
-    // coroutine actually being present, so non-suspending programs pay nothing.
-    if crate::coro::module_has_coroutines(&llvm_mod) {
-        crate::coro::run_coro_passes(&llvm_mod, &machine)?;
-    }
+    // Run the requested optimization pipeline + coroutine lowering before
+    // instruction selection.
+    //
+    // `write_to_file` runs the BACKEND passes (instruction selection, register
+    // allocation) configured on the `TargetMachine`, but NOT the middle-end IR
+    // pipeline (inlining, SROA, GVN, instcombine, loop opts, DCE). At `O0` we run
+    // only the conditional coroutine lowering (CoroSplit et al.) — otherwise a
+    // `presplitcoroutine` function reaches the backend un-split and fails to lower
+    // its `llvm.coro.*` intrinsics. At `O2` we run LLVM's `default<O2>` middle-end
+    // pipeline, which itself includes the coro passes; to keep `coro-split`
+    // running EXACTLY ONCE (and before the O2 inliner sees the split outlines) we
+    // FOLD the coro passes into a single combined pipeline string when a coroutine
+    // is present, and SKIP the standalone `run_coro_passes` call. Without the fold,
+    // `default<O2>` would double-run `coro-split`.
+    run_module_pipeline(&llvm_mod, &machine, opt_level)?;
     machine
         .write_to_file(&llvm_mod, FileType::Object, out_path)
         .llvm_ctx_with(|| {
@@ -1069,6 +1151,60 @@ fn emit_object_in_process(
             )
         })?;
     Ok(())
+}
+
+/// Run the requested middle-end + coroutine pipeline over `llvm_mod` in place,
+/// fail-closed.
+///
+/// - **`O0`**: the legacy behaviour — run the conditional coroutine lowering
+///   ONLY when a coroutine is present; non-suspending programs pay nothing and
+///   no middle-end optimization runs.
+/// - **`O2`**: run LLVM's `default<O2>` module pipeline. When a coroutine is
+///   present, the coro passes are FOLDED into the front of one combined pipeline
+///   string (`globaldce,coro-early,cgscc(coro-split),coro-cleanup,default<O2>`)
+///   so `coro-split` runs exactly once, before the O2 inliner — and the
+///   standalone `run_coro_passes` is skipped to avoid a double-run. When no
+///   coroutine is present, plain `default<O2>` runs.
+///
+/// Any `run_passes` failure maps to [`CodegenError::Llvm`] and aborts emission
+/// (the caller never reaches `write_to_file` with an unverified module). After a
+/// successful pass run the module is re-verified — `default<O2>` reshapes IR
+/// heavily, so a post-pass verify catches an optimizer-exposed invariant
+/// violation at the source rather than as a downstream backend crash.
+fn run_module_pipeline(
+    llvm_mod: &LlvmModule<'_>,
+    machine: &TargetMachine,
+    opt_level: OptLevel,
+) -> CodegenResult<()> {
+    let has_coro = crate::coro::module_has_coroutines(llvm_mod);
+    match opt_level {
+        OptLevel::O0 => {
+            if has_coro {
+                crate::coro::run_coro_passes(llvm_mod, machine)?;
+            }
+            Ok(())
+        }
+        OptLevel::O2 => {
+            // FOLD: coro lowering precedes the O2 inliner in one pipeline string
+            // when coroutines are present; otherwise plain `default<O2>`.
+            let pipeline = if has_coro {
+                "globaldce,coro-early,cgscc(coro-split),coro-cleanup,default<O2>"
+            } else {
+                "default<O2>"
+            };
+            let options = inkwell::passes::PassBuilderOptions::create();
+            llvm_mod
+                .run_passes(pipeline, machine, options)
+                .map_err(|e| {
+                    CodegenError::Llvm(format!("O2 pass pipeline `{pipeline}` failed: {e}"))
+                })?;
+            // Fail closed on any optimizer-exposed IR invariant violation.
+            llvm_mod.verify().map_err(|e| {
+                CodegenError::LlvmVerify(format!("module rejected after O2 pipeline: {e}"))
+            })?;
+            Ok(())
+        }
+    }
 }
 
 fn llvm_codegen_lock() -> &'static Mutex<()> {
@@ -33872,6 +34008,7 @@ mod tests {
             wasm: false,
             target_triple: None,
             debug: false,
+            opt_level: OptLevel::O0,
             source_path: None,
         };
         let host_artefacts = emit_module(&pipeline, &host_opts).expect("host emit");
@@ -33912,6 +34049,7 @@ mod tests {
             wasm: false,
             target_triple: Some(cross_triple),
             debug: false,
+            opt_level: OptLevel::O0,
             source_path: None,
         };
         let cross_artefacts = emit_module(&pipeline, &cross_opts).expect("cross emit");
@@ -39600,6 +39738,7 @@ mod tests {
             wasm: false,
             target_triple: None,
             debug: false,
+            opt_level: OptLevel::O0,
             source_path: None,
         };
         let artefacts = emit_module(&pipeline, &options)
@@ -39745,6 +39884,7 @@ mod tests {
             wasm: false,
             target_triple: None,
             debug: false,
+            opt_level: OptLevel::O0,
             source_path: None,
         };
         let err = emit_module(&pipeline, &options).expect_err(
@@ -40128,6 +40268,7 @@ mod tests {
             wasm: false,
             target_triple: None,
             debug: false,
+            opt_level: OptLevel::O0,
             source_path: None,
         };
         let err = emit_module(&pipeline, &options)
@@ -43103,6 +43244,116 @@ fn main() {
         module
             .verify()
             .unwrap_or_else(|e| panic!("post-O2 module failed verify: {e}"));
+    }
+
+    /// RC9: a trivial (non-coroutine) module run through `run_module_pipeline` at
+    /// `O2` takes the plain `default<O2>` branch and stays verifier-clean. The
+    /// post-pass `verify()` inside `run_module_pipeline` is the fail-closed guard;
+    /// this pins that the production seam (not just an ad-hoc `run_passes` call)
+    /// accepts a real module at O2.
+    #[test]
+    fn rc9_run_module_pipeline_o2_noncoro_verifies() {
+        let ctx = Context::create();
+        let module = ctx.create_module("rc9_o2_noncoro");
+        let machine = target_machine_for_triple(&native_emission_triple()).expect("host machine");
+        let builder = ctx.create_builder();
+
+        // A non-trivial body so the optimizer has work: add two args, return.
+        let i64_ty = ctx.i64_type();
+        let fn_ty = i64_ty.fn_type(&[i64_ty.into(), i64_ty.into()], false);
+        let f = module.add_function("add2", fn_ty, Some(Linkage::External));
+        let entry = ctx.append_basic_block(f, "entry");
+        builder.position_at_end(entry);
+        let a = f.get_nth_param(0).expect("a").into_int_value();
+        let b = f.get_nth_param(1).expect("b").into_int_value();
+        let sum = builder.build_int_add(a, b, "sum").expect("add");
+        builder.build_return(Some(&sum)).expect("ret");
+        module.verify().expect("pre-O2 verify");
+
+        run_module_pipeline(&module, &machine, OptLevel::O0).expect("O0 pipeline");
+        run_module_pipeline(&module, &machine, OptLevel::O2).expect("O2 pipeline");
+        module.verify().expect("post-O2 verify");
+    }
+
+    /// RC9: `module_has_coroutines` reports `false` for a non-coroutine module, so
+    /// `run_module_pipeline` at O2 selects the plain `default<O2>` branch (not the
+    /// folded coro string). Pins the fold-guard predicate the production seam keys
+    /// on — a regression that always reported `true` would double-run coro-split.
+    #[test]
+    fn rc9_noncoro_module_takes_plain_o2_branch() {
+        let ctx = Context::create();
+        let module = ctx.create_module("rc9_fold_guard");
+        let i64_ty = ctx.i64_type();
+        let fn_ty = i64_ty.fn_type(&[], false);
+        let f = module.add_function("k", fn_ty, None);
+        let entry = ctx.append_basic_block(f, "entry");
+        let builder = ctx.create_builder();
+        builder.position_at_end(entry);
+        builder
+            .build_return(Some(&i64_ty.const_int(1, false)))
+            .expect("ret");
+        assert!(
+            !crate::coro::module_has_coroutines(&module),
+            "a plain module must not be treated as a coroutine (would double-run coro-split)"
+        );
+    }
+
+    /// RC9: the `HEW_OPT_LEVEL` env var is a FLOOR — it raises O0 → O2 but never
+    /// lowers O2, and ignores any value other than exactly `"2"`. This is the
+    /// test-harness lever the differential-exec gate uses; a regression that let
+    /// it demote an explicit O2 build would silently weaken release codegen.
+    ///
+    /// Serialised via a process-global lock: env vars are process-wide, and the
+    /// codegen test suite runs in-process, so two env-mutating tests must not
+    /// interleave.
+    #[test]
+    fn rc9_env_floor_raises_but_never_lowers() {
+        use std::sync::Mutex;
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _g = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        // Save + restore the ambient value so the test is hermetic.
+        let saved = std::env::var_os("HEW_OPT_LEVEL");
+        let restore = || match &saved {
+            Some(v) => unsafe { std::env::set_var("HEW_OPT_LEVEL", v) },
+            None => unsafe { std::env::remove_var("HEW_OPT_LEVEL") },
+        };
+
+        unsafe { std::env::remove_var("HEW_OPT_LEVEL") };
+        assert_eq!(resolve_opt_level_with_env_floor(OptLevel::O0), OptLevel::O0);
+        assert_eq!(resolve_opt_level_with_env_floor(OptLevel::O2), OptLevel::O2);
+
+        unsafe { std::env::set_var("HEW_OPT_LEVEL", "2") };
+        assert_eq!(
+            resolve_opt_level_with_env_floor(OptLevel::O0),
+            OptLevel::O2,
+            "HEW_OPT_LEVEL=2 must raise O0 to O2"
+        );
+        assert_eq!(resolve_opt_level_with_env_floor(OptLevel::O2), OptLevel::O2);
+
+        // A non-"2" value is ignored (the floor only acts on exactly "2").
+        unsafe { std::env::set_var("HEW_OPT_LEVEL", "0") };
+        assert_eq!(
+            resolve_opt_level_with_env_floor(OptLevel::O2),
+            OptLevel::O2,
+            "HEW_OPT_LEVEL=0 must never demote an explicit O2 build"
+        );
+        unsafe { std::env::set_var("HEW_OPT_LEVEL", "1") };
+        assert_eq!(resolve_opt_level_with_env_floor(OptLevel::O0), OptLevel::O0);
+
+        restore();
+    }
+
+    /// RC9: `OptLevel::from_cli_str` accepts exactly `{"0","2"}` and rejects
+    /// everything else (the fail-closed CLI parse).
+    #[test]
+    fn rc9_opt_level_from_cli_str_is_closed() {
+        assert_eq!(OptLevel::from_cli_str("0"), Some(OptLevel::O0));
+        assert_eq!(OptLevel::from_cli_str("2"), Some(OptLevel::O2));
+        assert_eq!(OptLevel::from_cli_str("1"), None);
+        assert_eq!(OptLevel::from_cli_str("3"), None);
+        assert_eq!(OptLevel::from_cli_str(""), None);
+        assert_eq!(OptLevel::from_cli_str("O2"), None);
     }
 }
 

--- a/hew-codegen-rs/tests/actor_dispatch_borrow_abi.rs
+++ b/hew-codegen-rs/tests/actor_dispatch_borrow_abi.rs
@@ -59,6 +59,7 @@ fn emit_ll_text(pipeline: &hew_mir::IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("emit_module must succeed");

--- a/hew-codegen-rs/tests/actor_send_status_check.rs
+++ b/hew-codegen-rs/tests/actor_send_status_check.rs
@@ -144,6 +144,7 @@ fn send_terminator_checks_return_status_and_traps_on_failure() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =

--- a/hew-codegen-rs/tests/bytes_extern_fail_closed.rs
+++ b/hew-codegen-rs/tests/bytes_extern_fail_closed.rs
@@ -162,6 +162,7 @@ fn emit_options(label: &str) -> EmitOptions<'static> {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     }
 }

--- a/hew-codegen-rs/tests/char_emission.rs
+++ b/hew-codegen-rs/tests/char_emission.rs
@@ -48,6 +48,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("char pipeline must emit successfully");

--- a/hew-codegen-rs/tests/composite_return.rs
+++ b/hew-codegen-rs/tests/composite_return.rs
@@ -26,6 +26,7 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(pipeline, &options)
@@ -252,6 +253,7 @@ fn option_i64_return_module_verifies() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(&pipeline, &options)

--- a/hew-codegen-rs/tests/cooperate_emission.rs
+++ b/hew-codegen-rs/tests/cooperate_emission.rs
@@ -17,6 +17,7 @@ fn emit_ll_result(pipeline: &IrPipeline, module_name: &str) -> Result<String, Co
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(pipeline, &options)?;

--- a/hew-codegen-rs/tests/cycle_capable_spawn_abi.rs
+++ b/hew-codegen-rs/tests/cycle_capable_spawn_abi.rs
@@ -116,6 +116,7 @@ fn emit_ll(pipeline: &IrPipeline, slug: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("cycle spawn pipeline must emit");

--- a/hew-codegen-rs/tests/div_shift_trap_emission.rs
+++ b/hew-codegen-rs/tests/div_shift_trap_emission.rs
@@ -50,6 +50,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =

--- a/hew-codegen-rs/tests/duration_emission.rs
+++ b/hew-codegen-rs/tests/duration_emission.rs
@@ -52,6 +52,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =

--- a/hew-codegen-rs/tests/dyn_trait_drop_in_place_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_drop_in_place_emission.rs
@@ -139,6 +139,7 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("emit_module must succeed");

--- a/hew-codegen-rs/tests/dyn_trait_method_dispatch.rs
+++ b/hew-codegen-rs/tests/dyn_trait_method_dispatch.rs
@@ -103,6 +103,7 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("emit_module must succeed");

--- a/hew-codegen-rs/tests/dyn_trait_thunk_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_thunk_emission.rs
@@ -161,6 +161,7 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("emit_module must succeed");

--- a/hew-codegen-rs/tests/dyn_trait_vtable_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_vtable_emission.rs
@@ -177,6 +177,7 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("emit_module must succeed");

--- a/hew-codegen-rs/tests/elab_drop_plans.rs
+++ b/hew-codegen-rs/tests/elab_drop_plans.rs
@@ -146,6 +146,7 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =
@@ -200,6 +201,7 @@ fn elab_drop_plan_duplex_close_blocks_wasm_emission() {
         wasm: true,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let result = emit_module(&pipeline, &options);
@@ -310,6 +312,7 @@ fn elab_drop_plan_unknown_drop_fn_fails_closed() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let result = emit_module(&pipeline, &options);

--- a/hew-codegen-rs/tests/emit_duplex_pair.rs
+++ b/hew-codegen-rs/tests/emit_duplex_pair.rs
@@ -175,6 +175,7 @@ fn emit_textual_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =
@@ -280,6 +281,7 @@ fn duplex_exemplar_module_verifies() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(&pipeline, &options).expect("the duplex exemplar must pass `Module::verify()`");

--- a/hew-codegen-rs/tests/float_emission.rs
+++ b/hew-codegen-rs/tests/float_emission.rs
@@ -55,6 +55,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =

--- a/hew-codegen-rs/tests/hashmap_hashset_local_drop_emission.rs
+++ b/hew-codegen-rs/tests/hashmap_hashset_local_drop_emission.rs
@@ -58,6 +58,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("module must emit successfully");

--- a/hew-codegen-rs/tests/hashmap_layout_emission.rs
+++ b/hew-codegen-rs/tests/hashmap_layout_emission.rs
@@ -135,6 +135,7 @@ fn emit_ll(pipeline: IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options)
@@ -795,6 +796,7 @@ fn hashmap_layout_emit_for_wasm_target_emits_descriptor_object() {
         wasm: true,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module_objects(&pipeline, &options)
@@ -852,6 +854,7 @@ fn hashset_layout_emit_for_wasm_target_emits_descriptor_object() {
         wasm: true,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module_objects(&pipeline, &options)
@@ -925,6 +928,7 @@ fn lower_hashmap_layout_probe_with_wrong_arity_fails_closed() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     match emit_module(&pipeline, &options) {
@@ -961,6 +965,7 @@ fn lower_hashset_layout_probe_with_wrong_arity_fails_closed() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     match emit_module(&pipeline, &options) {
@@ -994,6 +999,7 @@ fn lower_hashmap_layout_probe_with_dest_fails_closed() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     match emit_module(&pipeline, &options) {

--- a/hew-codegen-rs/tests/hashmap_layout_ops.rs
+++ b/hew-codegen-rs/tests/hashmap_layout_ops.rs
@@ -149,6 +149,7 @@ fn consistency_check_rejects_pending_fact_at_pipeline_finalize() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     match emit_module(&pipeline, &options) {
@@ -184,6 +185,7 @@ fn consistency_check_rejects_pending_hashset_fact_at_pipeline_finalize() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     match emit_module(&pipeline, &options) {
@@ -326,6 +328,7 @@ fn emit_ll(pipeline: IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options)
@@ -570,6 +573,7 @@ fn pending_fact_without_matching_call_still_fails_closed() {
             wasm: false,
             target_triple: None,
             debug: false,
+            opt_level: hew_codegen_rs::OptLevel::O0,
             source_path: None,
         },
     ) {

--- a/hew-codegen-rs/tests/identity_emission.rs
+++ b/hew-codegen-rs/tests/identity_emission.rs
@@ -58,6 +58,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options)

--- a/hew-codegen-rs/tests/jit_trap_bridge.rs
+++ b/hew-codegen-rs/tests/jit_trap_bridge.rs
@@ -207,6 +207,7 @@ fn compile_to_ll(source: &str, module_name: &str) -> std::path::PathBuf {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options)

--- a/hew-codegen-rs/tests/llvm_native_lowering.rs
+++ b/hew-codegen-rs/tests/llvm_native_lowering.rs
@@ -76,6 +76,7 @@ fn emit_ll_from_tc(source: &str, module_name: &str, tc_output: &TypeCheckOutput)
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("emit_module must succeed");

--- a/hew-codegen-rs/tests/machine_dispatch_codegen.rs
+++ b/hew-codegen-rs/tests/machine_dispatch_codegen.rs
@@ -62,6 +62,7 @@ fn emit_ll_text(pipeline: &hew_mir::IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("emit_module must succeed");

--- a/hew-codegen-rs/tests/machine_emit_exec.rs
+++ b/hew-codegen-rs/tests/machine_emit_exec.rs
@@ -223,6 +223,7 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("emit_module must succeed");
@@ -324,6 +325,7 @@ fn machine_emit_push_populates_thread_queue_in_fifo_order() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("emit_module must succeed");

--- a/hew-codegen-rs/tests/machine_layout.rs
+++ b/hew-codegen-rs/tests/machine_layout.rs
@@ -41,6 +41,7 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> Result<String, CodegenEr
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(pipeline, &options)?;

--- a/hew-codegen-rs/tests/mem_floor_intrinsic_emission.rs
+++ b/hew-codegen-rs/tests/mem_floor_intrinsic_emission.rs
@@ -119,6 +119,7 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =
@@ -244,6 +245,7 @@ fn unknown_floor_intrinsic_id_fails_closed() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     match emit_module(&pipeline, &options) {

--- a/hew-codegen-rs/tests/mem_floor_intrinsic_exec.rs
+++ b/hew-codegen-rs/tests/mem_floor_intrinsic_exec.rs
@@ -437,6 +437,7 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> std::path::PathBuf {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =
@@ -640,6 +641,7 @@ fn mem_floor_is_not_a_wasm_excluded_substrate() {
         wasm: true,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     if let Err(CodegenError::WasmUnsupportedSubstrate { symbol }) = emit_module(&pipeline, &options)
@@ -674,6 +676,7 @@ fn mem_floor_emits_linkable_wasm_module() {
         wasm: true,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options)

--- a/hew-codegen-rs/tests/monomorph_emit_test.rs
+++ b/hew-codegen-rs/tests/monomorph_emit_test.rs
@@ -84,6 +84,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =

--- a/hew-codegen-rs/tests/numeric_methods_exec.rs
+++ b/hew-codegen-rs/tests/numeric_methods_exec.rs
@@ -57,6 +57,7 @@ fn compile_to_ll(source: &str, module_name: &str) -> std::path::PathBuf {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).unwrap_or_else(|e| panic!("emit_module: {e}"));

--- a/hew-codegen-rs/tests/overflow_trap_emission.rs
+++ b/hew-codegen-rs/tests/overflow_trap_emission.rs
@@ -52,6 +52,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =

--- a/hew-codegen-rs/tests/periodic_spawn_arming.rs
+++ b/hew-codegen-rs/tests/periodic_spawn_arming.rs
@@ -154,6 +154,7 @@ fn emit_ll(pipeline: &IrPipeline, slug: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("periodic spawn pipeline must emit");

--- a/hew-codegen-rs/tests/pipeline_smoke.rs
+++ b/hew-codegen-rs/tests/pipeline_smoke.rs
@@ -45,6 +45,7 @@ fn emit_ll_for_source(src: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("emit_module must succeed");

--- a/hew-codegen-rs/tests/record_emission.rs
+++ b/hew-codegen-rs/tests/record_emission.rs
@@ -65,6 +65,7 @@ fn emit_ll_with_checker(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =
@@ -103,6 +104,7 @@ fn try_emit_ll(source: &str, module_name: &str) -> Result<String, String> {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).map_err(|e| format!("{e:?}"))?;

--- a/hew-codegen-rs/tests/recursion_exec.rs
+++ b/hew-codegen-rs/tests/recursion_exec.rs
@@ -65,6 +65,7 @@ fn compile_to_ll(source: &str, module_name: &str) -> std::path::PathBuf {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).unwrap_or_else(|e| panic!("emit_module: {e}"));

--- a/hew-codegen-rs/tests/runtime_abi_fail_closed.rs
+++ b/hew-codegen-rs/tests/runtime_abi_fail_closed.rs
@@ -143,6 +143,7 @@ fn call_runtime_abi_fails_closed_with_symbol_in_message() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let result = emit_module(&pipeline, &options);
@@ -205,6 +206,7 @@ fn call_runtime_abi_succeeds_for_lambda_actor_release() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let result = emit_module(&pipeline, &options);
@@ -232,6 +234,7 @@ fn actor_link_and_monitor_runtime_calls_are_codegen_reachable_without_dest() {
             wasm: false,
             target_triple: None,
             debug: false,
+            opt_level: hew_codegen_rs::OptLevel::O0,
             source_path: None,
         };
         let result = emit_module(&pipeline, &options);
@@ -258,6 +261,7 @@ fn actor_monitor_runtime_call_with_dest_still_fails_closed() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let result = emit_module(&pipeline, &options);

--- a/hew-codegen-rs/tests/scalar_discard_guard.rs
+++ b/hew-codegen-rs/tests/scalar_discard_guard.rs
@@ -146,6 +146,7 @@ fn emit_options(module_name: &str) -> (EmitOptions<'static>, std::path::PathBuf)
             wasm: false,
             target_triple: None,
             debug: false,
+            opt_level: hew_codegen_rs::OptLevel::O0,
             source_path: None,
         },
         tmp,

--- a/hew-codegen-rs/tests/select_stream_e2e.rs
+++ b/hew-codegen-rs/tests/select_stream_e2e.rs
@@ -129,6 +129,7 @@ fn compile_to_ll(pipeline: &IrPipeline, module_name: &str) -> PathBuf {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(pipeline, &options)

--- a/hew-codegen-rs/tests/state_clone_generic_enum_pipeline.rs
+++ b/hew-codegen-rs/tests/state_clone_generic_enum_pipeline.rs
@@ -92,6 +92,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("pipeline must emit successfully");

--- a/hew-codegen-rs/tests/state_clone_synthesis.rs
+++ b/hew-codegen-rs/tests/state_clone_synthesis.rs
@@ -137,6 +137,7 @@ fn try_emit_to_string(pipeline: &IrPipeline, slug: &str) -> Result<String, Codeg
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(pipeline, &options)?;

--- a/hew-codegen-rs/tests/stdlib_builtins_emission.rs
+++ b/hew-codegen-rs/tests/stdlib_builtins_emission.rs
@@ -44,6 +44,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =

--- a/hew-codegen-rs/tests/stdlib_print_emission.rs
+++ b/hew-codegen-rs/tests/stdlib_print_emission.rs
@@ -39,6 +39,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =

--- a/hew-codegen-rs/tests/supervisor_child_get_emission.rs
+++ b/hew-codegen-rs/tests/supervisor_child_get_emission.rs
@@ -118,6 +118,7 @@ fn emit_child_access_ir_for(slug: &str, target_triple: Option<&str>) -> String {
         wasm: false,
         target_triple,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("emit_module must succeed");
@@ -247,6 +248,7 @@ fn supervisor_child_get_classified_as_wasm_excluded() {
         wasm: true,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let err = emit_module(&pipeline, &options)

--- a/hew-codegen-rs/tests/supervisor_emission.rs
+++ b/hew-codegen-rs/tests/supervisor_emission.rs
@@ -197,6 +197,7 @@ fn emit_to_string(pipeline: &IrPipeline, slug: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(pipeline, &options).expect("supervisor emission should succeed");
@@ -506,6 +507,7 @@ fn supervisor_bootstrap_fails_closed_on_missing_on_crash_symbol() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let err = emit_module(&pipeline, &options)
@@ -532,6 +534,7 @@ fn supervisor_bootstrap_accepts_duration_window() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(&pipeline, &options)
@@ -552,6 +555,7 @@ fn supervisor_bootstrap_rejects_invalid_window() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let err = emit_module(&pipeline, &options)

--- a/hew-codegen-rs/tests/task_abi_emission.rs
+++ b/hew-codegen-rs/tests/task_abi_emission.rs
@@ -450,6 +450,7 @@ fn task_abi_emission_task_new_declare() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(&pipeline, &options).expect("hew_task_new emission should succeed");
@@ -480,6 +481,7 @@ fn task_abi_emission_task_await_blocking_declare() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(&pipeline, &options).expect("hew_task_await_blocking emission should succeed");
@@ -508,6 +510,7 @@ fn task_abi_emission_task_get_result_declare() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(&pipeline, &options).expect("hew_task_get_result emission should succeed");
@@ -532,6 +535,7 @@ fn task_abi_emission_task_free_declare() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(&pipeline, &options).expect("hew_task_free emission should succeed");
@@ -648,6 +652,7 @@ fn task_abi_emission_task_scope_spawn_paired_with_task_new() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(&pipeline, &options)
@@ -700,6 +705,7 @@ fn task_abi_emission_spawn_task_direct_synthesizes_wrapper() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(&pipeline, &options).expect("SpawnTaskDirect emission should succeed");
@@ -731,6 +737,7 @@ fn task_abi_emission_spawn_task_direct_rejects_contextless_target() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     match emit_module(&pipeline, &options) {
@@ -758,6 +765,7 @@ fn task_abi_emission_spawn_task_closure_threads_execution_context() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(&pipeline, &options).expect("SpawnTaskClosure emission should succeed");
@@ -792,6 +800,7 @@ fn task_abi_emission_task_spawn_thread_fail_closed() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     match emit_module(&pipeline, &options) {

--- a/hew-codegen-rs/tests/trap_kind_emission.rs
+++ b/hew-codegen-rs/tests/trap_kind_emission.rs
@@ -62,6 +62,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =
@@ -148,6 +149,7 @@ fn emit_trap_kind_ll(kind: TrapKind, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("trap-kind MIR fixture must emit");

--- a/hew-codegen-rs/tests/tuple_construct_emission.rs
+++ b/hew-codegen-rs/tests/tuple_construct_emission.rs
@@ -41,6 +41,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("tuple pipeline must emit");

--- a/hew-codegen-rs/tests/unary_emission.rs
+++ b/hew-codegen-rs/tests/unary_emission.rs
@@ -41,6 +41,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options).expect("unary pipeline must emit");

--- a/hew-codegen-rs/tests/user_enum_exec.rs
+++ b/hew-codegen-rs/tests/user_enum_exec.rs
@@ -25,6 +25,7 @@ fn emit_ll(pipeline: &IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =
@@ -179,6 +180,7 @@ fn enum_unit_ctor_module_verifies() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(&pipeline, &options)

--- a/hew-codegen-rs/tests/user_fn_emission.rs
+++ b/hew-codegen-rs/tests/user_fn_emission.rs
@@ -50,6 +50,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =

--- a/hew-codegen-rs/tests/vec_index_emission.rs
+++ b/hew-codegen-rs/tests/vec_index_emission.rs
@@ -522,6 +522,7 @@ fn emit_ll(module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =
@@ -543,6 +544,7 @@ fn emit_bool_ll(module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options)
@@ -564,6 +566,7 @@ fn emit_char_ll(module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(&pipeline, &options)

--- a/hew-codegen-rs/tests/vec_layout_emission.rs
+++ b/hew-codegen-rs/tests/vec_layout_emission.rs
@@ -122,6 +122,7 @@ fn emit_ll(pipeline: IrPipeline, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =
@@ -846,6 +847,7 @@ fn vec_layout_contains_thunk_emits_for_wasm_target() {
         wasm: true,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let result = emit_module(&pipeline, &options);

--- a/hew-codegen-rs/tests/vec_slice_emission.rs
+++ b/hew-codegen-rs/tests/vec_slice_emission.rs
@@ -257,6 +257,7 @@ fn emit_ll(module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =

--- a/hew-codegen-rs/tests/wasm_actor_metadata_emission.rs
+++ b/hew-codegen-rs/tests/wasm_actor_metadata_emission.rs
@@ -153,6 +153,7 @@ fn emit_ll(pipeline: &IrPipeline, slug: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts = emit_module(pipeline, &options).expect("metadata pipeline must emit");

--- a/hew-codegen-rs/tests/wasm_duplex_classification.rs
+++ b/hew-codegen-rs/tests/wasm_duplex_classification.rs
@@ -324,6 +324,7 @@ fn duplex_pair_call_blocks_wasm_emission() {
         wasm: true,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let result = emit_module(&pipeline, &options);
@@ -355,6 +356,7 @@ fn duplex_close_drop_blocks_wasm_emission() {
         wasm: true,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let result = emit_module(&pipeline, &options);
@@ -387,6 +389,7 @@ fn duplex_pair_native_only_succeeds_without_wasm_emit() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =
@@ -422,6 +425,7 @@ fn non_duplex_pipeline_does_not_trigger_wasm_substrate_error() {
         wasm: false, // avoid invoking wasm-ld in unit tests
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let result = emit_module(&pipeline, &options);

--- a/hew-codegen-rs/tests/wasm_task_scope_classification.rs
+++ b/hew-codegen-rs/tests/wasm_task_scope_classification.rs
@@ -214,6 +214,7 @@ fn task_scope_new_call_blocks_wasm_emission() {
         wasm: true,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let result = emit_module(&pipeline, &options);
@@ -247,6 +248,7 @@ fn task_scope_spawn_call_blocks_wasm_emission() {
         wasm: true,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let result = emit_module(&pipeline, &options);
@@ -282,6 +284,7 @@ fn task_scope_wasm_diagnostic_message_names_scope_construct() {
         wasm: true,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let err =
@@ -316,6 +319,7 @@ fn task_scope_native_emission_unaffected() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     emit_module(&pipeline, &options)

--- a/hew-codegen-rs/tests/wrapping_emission.rs
+++ b/hew-codegen-rs/tests/wrapping_emission.rs
@@ -48,6 +48,7 @@ fn emit_ll(source: &str, module_name: &str) -> String {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
     let artefacts =

--- a/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
+++ b/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
@@ -407,6 +407,7 @@ fn unknown_named_type_still_fails_closed_with_d10() {
         wasm: false,
         target_triple: None,
         debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: None,
     };
 

--- a/scripts/o2-differential.sh
+++ b/scripts/o2-differential.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# o2-differential.sh — the -O0-vs-O2 differential-exec parity gate (RC9).
+#
+# The no-miscompile oracle for the LLVM middle-end pipeline: every compiled
+# `.hew` program must behave IDENTICALLY at -O0 and -O2. The optimizer may
+# reshape IR arbitrarily; it must never change what a program DOES.
+#
+# WHAT it proves: RUNTIME identity (test pass/fail set + per-test outcome),
+# NOT IR/ll identity — `default<O2>` reshapes IR by design, so byte identity is
+# meaningless here. A divergence between the O0 and O2 run IS a miscompile and a
+# FULL STOP: root-cause it to the upstream UB (a missed lifetime marker, a wrong
+# ABI attribute, an aliasing violation), NEVER weaken the pipeline.
+#
+# HOW: runs `hew test tests/hew/` twice over the same binary — once at the O0
+# default, once with `HEW_OPT_LEVEL=2` forcing the whole corpus through the O2
+# pipeline (the env FLOOR that raises O0->O2 without a per-subcommand flag). The
+# two failing-test sets must be identical.
+#
+# This gate is re-run by every future optimization lane (PGO, LTO, target-cpu)
+# as the permanent guard that the optimization did not change behaviour.
+#
+# Usage:
+#   scripts/o2-differential.sh            # uses target/debug/hew (or HEW_BIN)
+#   HEW_BIN=/path/to/hew scripts/o2-differential.sh
+#   scripts/o2-differential.sh --tests-dir <dir>
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HEW_BIN="${HEW_BIN:-$REPO_ROOT/target/debug/hew}"
+TESTS_DIR="$REPO_ROOT/tests/hew"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tests-dir) shift; TESTS_DIR="$1"; shift ;;
+        --help|-h)
+            grep '^#' "$0" | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        *) echo "error: unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ ! -x "$HEW_BIN" ]]; then
+    echo "error: hew binary not found/executable at $HEW_BIN" >&2
+    echo "       Build it first (make hew), or set HEW_BIN." >&2
+    exit 1
+fi
+if [[ ! -d "$TESTS_DIR" ]]; then
+    echo "error: tests dir not found: $TESTS_DIR" >&2
+    exit 1
+fi
+
+# Extract the sorted "test <name> ... PASSED|FAILED" outcome lines from a
+# `hew test` run, stripping ANSI. The full per-test outcome set (not just the
+# count) is the comparison key — a miscompile that flips one test from PASS to
+# FAIL (or vice versa, or changes which tests fail) is caught.
+run_outcomes() {
+    local opt_env="$1"
+    local raw
+    raw="$(env HEW_OPT_LEVEL="$opt_env" "$HEW_BIN" test "$TESTS_DIR" 2>&1)" || true
+    # Fail closed if there is no summary — a runner crash must not read as match.
+    local clean
+    clean="$(printf '%s\n' "$raw" | sed $'s/\x1b\\[[0-9;]*m//g')"
+    if ! printf '%s\n' "$clean" | grep -q "^test result:"; then
+        echo "__NO_SUMMARY__"
+        printf '%s\n' "$raw" >&2
+        return
+    fi
+    printf '%s\n' "$clean" \
+        | grep -E "^test .* \.\.\. (ok|PASSED|FAILED|ignored)" \
+        | sort
+}
+
+echo "==> O2 differential-exec parity gate"
+echo "    binary:  $HEW_BIN"
+echo "    corpus:  $TESTS_DIR"
+echo ""
+
+echo "--> baseline run (O0, default)"
+O0_OUTCOMES="$(run_outcomes 0)"
+echo "--> optimized run (O2, HEW_OPT_LEVEL=2)"
+O2_OUTCOMES="$(run_outcomes 2)"
+
+if [[ "$O0_OUTCOMES" == "__NO_SUMMARY__" || "$O2_OUTCOMES" == "__NO_SUMMARY__" ]]; then
+    echo ""
+    echo "==> Differential gate: FAILED (no test-result summary; runner crash)"
+    exit 1
+fi
+
+if [[ "$O0_OUTCOMES" == "$O2_OUTCOMES" ]]; then
+    n="$(printf '%s\n' "$O0_OUTCOMES" | grep -c . || true)"
+    echo ""
+    echo "==> Differential gate: PASSED — O0 and O2 outcome sets identical ($n tests)"
+    exit 0
+fi
+
+echo ""
+echo "==> Differential gate: FAILED — O0 vs O2 outcome DIVERGENCE (a miscompile):"
+echo ""
+diff <(printf '%s\n' "$O0_OUTCOMES") <(printf '%s\n' "$O2_OUTCOMES")
+echo ""
+echo "  A divergence IS a miscompile. Root-cause to the upstream UB"
+echo "  (missed lifetime marker / wrong ABI attribute / aliasing violation)."
+echo "  NEVER weaken the pipeline to make this pass."
+exit 1


### PR DESCRIPTION
## Summary

The `-O2` middle-end optimization pipeline is now wired and opt-in. Passing `--opt-level 2` (or setting `HEW_OPT_LEVEL=2`) runs LLVM's `default<O2>` pipeline; the release default stays `O0`, so existing behaviour is unchanged. For coroutine modules the coro passes are folded into one pipeline string (`globaldce,coro-early,cgscc(coro-split),coro-cleanup,default<O2>`) so `coro-split` runs exactly once before the O2 inliner — no double-run, same split semantics as the O0 path. The pipeline is fail-closed: a `run_passes` error or a failed post-pass `module.verify()` aborts emission before writing any object; there is no fallback to unoptimized output.

## Verification

- `cargo test -p hew-codegen-rs`: 472 tests passed
- `make test-o2-differential` (`scripts/o2-differential.sh`): 0 divergences over the `.hew` test corpus — O0 and O2 outcome sets identical
- Suspend/async corpus at O2 — generators (6/6), `actor_multi_return_suspend` (2/2), `actor_value_task_await` (4/4), `actor_select_suspend` (3/3)
- Overflow trap at O2: `i64::MAX + 1` traps `IntegerOverflow` exit 133 at both `--opt-level 0` and `--opt-level 2` — trap is not elided
- 48 leak-oracle tests green at O2
- `cargo clippy -p hew-codegen-rs -p hew-cli --tests -- -D warnings`: exit 0, zero warnings
- Preflight: ready-to-push

## Out of scope

- **O0 → O2 release default flip** — deferred. The cross-platform matrix (wasm32, Linux x86_64, Windows-MSVC) and the O2 suspend/async ASan corpus are the stated gates before any default change; those are tracked follow-ons.
- **Cross-platform O2 parity** (wasm32 / Linux x86_64 / Windows-MSVC) — host-only parity does not prove the other targets; tracked as a follow-on.
- **O2 suspend corpus under ASan / MallocScribble** — the differential exec gate covers outcome parity; a dedicated O2-compiled coro-frame UAF harness is a defence-in-depth strengthening, tracked as a follow-on.
- **O0-vs-O2 perf benchmark** — the optimizer pipeline is wired and proven non-regressing; a recorded perf gain measurement is tracked as a follow-on.
- **O2 overflow-trap exec fixture** — the trap survives O2 (proven by direct execution above), but there is no dedicated fixture that forces the overflow path and asserts the trap fires at O2 specifically; tracked as a follow-on.
- **`o2-differential.sh` extended to vertical-slice/examples corpora** — current gate covers `tests/hew/`; broadening to vertical-slice and examples is tracked as a follow-on.
