### PR TITLE
feat(types,hir): fork-block diagnostics, body type-checking, and arg-bearing form

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -24308,7 +24308,20 @@ fn check_fork_child_shape(
 }
 
 /// Check fork block body shape.
-/// Sites: hew-mir/src/lower.rs:7774, 7787, 7799, 7811 (`ForkBlock` body)
+///
+/// The checker's `synthesize_concurrency` `Expr::ForkBlock` arm now fully
+/// type-checks the body (statements, callee arguments, tail expression), so the
+/// shape restrictions here are NOT type-coverage proxies — they mirror exactly
+/// the body shapes the MIR `lower_fork_block_task` lowering can currently spawn:
+/// a single direct module-function call (any arity). Everything else fails
+/// closed here with an actionable compile-time diagnostic, the earliest clean
+/// point, rather than reaching MIR as a less-legible `NotYetImplemented`.
+///
+/// Unlocking multi-statement / non-call fork bodies is downstream MIR work
+/// (wrap the body in a synthesized anonymous task entry point, mirroring the
+/// lambda-actor path); until then they reject here.
+///
+/// Sites: hew-mir/src/lower.rs `lower_fork_block_task` (`ForkBlock` body).
 fn check_fork_block_shape(
     body: &hew_parser::ast::Block,
     span: &Span,
@@ -24326,7 +24339,9 @@ fn check_fork_block_shape(
                 reason: "empty body".to_string(),
             },
             span.clone(),
-            "fork block body must contain exactly one direct function call".to_string(),
+            "empty `fork { }` spawns nothing; put a function call in the body, \
+             e.g. `fork { work() }`"
+                .to_string(),
         ));
         return;
     }
@@ -24338,7 +24353,9 @@ fn check_fork_block_shape(
                 reason: "multi-statement".to_string(),
             },
             span.clone(),
-            "fork block body must contain exactly one statement or expression".to_string(),
+            "multi-statement `fork { }` bodies are not yet supported; move the work \
+             into a function and spawn it as `fork { the_fn() }`"
+                .to_string(),
         ));
         return;
     }
@@ -24353,7 +24370,7 @@ fn check_fork_block_shape(
         body.trailing_expr.as_ref().map(|e| &e.0)
     };
 
-    if let Some(Expr::Call { function, args, .. }) = call_expr {
+    if let Some(Expr::Call { function, .. }) = call_expr {
         // Must be a direct function identifier
         if let Expr::Identifier(name) = &function.0 {
             // FC-P1-A1 (revision pass 2, Finding 2): strip `mod::` prefix
@@ -24372,25 +24389,12 @@ fn check_fork_block_shape(
             // FC-P1-A1 (revision pass 2, Finding 1): Non-unit return is
             // VALID at spawn time — see `lower_spawned_call` comment.
             //
-            // The block form (`fork { f(…); }`) stays nullary: the checker
-            // never visits block bodies, so arg types are unchecked there.
-            // Argument-bearing spawns must use the named form
-            // (`fork t = f(args)`), where the checker fully type-checks the
-            // call. Any args here would silently bypass type-checking.
-            //
-            // WHY: block bodies are not visited by synthesize_concurrency;
-            // WHEN: remove this gate when ForkBlock bodies are checker-visited;
-            // WHAT: add an Expr::ForkBlock arm to synthesize_concurrency.
-            if !args.is_empty() {
-                ctx.diagnostics.push(HirDiagnostic::new(
-                    HirDiagnosticKind::ForkBlockBodyUnsupported {
-                        site: ctx.ids.site(),
-                        reason: "function has arguments".to_string(),
-                    },
-                    span.clone(),
-                    "fork block callee must have zero arguments; use `fork name = f(args)` for argument-bearing spawns".to_string(),
-                ));
-            }
+            // RETIRED (RI-08 fold): the zero-argument restriction is gone.
+            // The checker's `Expr::ForkBlock` arm now type-checks callee
+            // arguments, and MIR's `lower_spawned_args_call_task` lowers
+            // arg-bearing single-call fork bodies, so `fork { f(args) }` is
+            // a first-class form. The old gate proxied for "the checker does
+            // not visit block bodies"; that premise no longer holds.
         } else {
             ctx.diagnostics.push(HirDiagnostic::new(
                 HirDiagnosticKind::ForkBlockBodyUnsupported {
@@ -24398,7 +24402,8 @@ fn check_fork_block_shape(
                     reason: "callee is not a direct function identifier".to_string(),
                 },
                 span.clone(),
-                "fork block body must be a direct function call".to_string(),
+                "fork block body must be a direct function call, e.g. `fork { work() }`"
+                    .to_string(),
             ));
         }
     } else {
@@ -24408,7 +24413,9 @@ fn check_fork_block_shape(
                 reason: "not a call expression".to_string(),
             },
             span.clone(),
-            "fork block body must be a direct function call".to_string(),
+            "`fork { }` bodies must be a direct function call, e.g. `fork { work() }`; \
+             other expression forms are not yet supported"
+                .to_string(),
         ));
     }
 }

--- a/hew-hir/tests/task_gates.rs
+++ b/hew-hir/tests/task_gates.rs
@@ -192,6 +192,33 @@ fn fork_block_single_call_accepted() {
 }
 
 #[test]
+fn fork_block_with_args_accepted() {
+    // RI-08 fold: an argument-bearing single-call fork body is now a
+    // first-class form. The checker type-checks the callee arguments and MIR
+    // lowers the arg-bearing spawn, so the old zero-argument gate is retired —
+    // no ForkBlockBodyUnsupported diagnostic must fire.
+    let source = r"
+        fn work(n: i64) {}
+        fn main() {
+            scope {
+                fork { work(5) }
+            }
+        }
+    ";
+    let output = lower(source);
+
+    let has_gate_diagnostic = output
+        .diagnostics
+        .iter()
+        .any(|d| matches!(d.kind, HirDiagnosticKind::ForkBlockBodyUnsupported { .. }));
+    assert!(
+        !has_gate_diagnostic,
+        "Arg-bearing single-call fork block must not trigger the shape gate; got: {:#?}",
+        output.diagnostics
+    );
+}
+
+#[test]
 fn fork_block_empty_rejected() {
     // Invalid: fork block has empty body
     let source = r"
@@ -222,7 +249,10 @@ fn fork_block_empty_rejected() {
 
 #[test]
 fn fork_block_multi_statement_rejected() {
-    // Invalid: fork block has multiple statements
+    // Fail-closed: a multi-statement fork body is type-checked by the checker
+    // (post RI-08 fold), but MIR cannot yet spawn it. It rejects here at the
+    // earliest clean point with an actionable diagnostic rather than reaching
+    // MIR as a less-legible NotYetImplemented.
     let source = r"
         fn a() {}
         fn b() {}
@@ -256,7 +286,9 @@ fn fork_block_multi_statement_rejected() {
 
 #[test]
 fn fork_block_not_call_rejected() {
-    // Invalid: fork block body is not a call expression
+    // Fail-closed: a non-call fork body (here a bare literal) is type-checked by
+    // the checker, but MIR can only spawn a direct function call. It rejects
+    // here with an actionable diagnostic rather than reaching MIR.
     let source = r"
         fn main() {
             scope {

--- a/hew-hir/tests/task_gates.rs
+++ b/hew-hir/tests/task_gates.rs
@@ -267,14 +267,25 @@ fn fork_block_multi_statement_rejected() {
     ";
     let output = lower(source);
 
-    let has_fork_block_unsupported = output
-        .diagnostics
-        .iter()
-        .any(|d| matches!(d.kind, HirDiagnosticKind::ForkBlockBodyUnsupported { .. }));
+    // Pin the fail-closed diagnostic: it must be the typed shape gate AND carry
+    // an actionable message that names the workaround, so a future refactor
+    // cannot silently degrade it to an opaque NotYetImplemented.
+    let multi_stmt_gate = output.diagnostics.iter().find(|d| {
+        matches!(d.kind, HirDiagnosticKind::ForkBlockBodyUnsupported { .. })
+            && d.note.contains("multi-statement")
+    });
+    let multi_stmt_gate = multi_stmt_gate.unwrap_or_else(|| {
+        panic!(
+            "Multi-statement fork block must emit an actionable ForkBlockBodyUnsupported; \
+             got: {:#?}",
+            output.diagnostics
+        )
+    });
     assert!(
-        has_fork_block_unsupported,
-        "Multi-statement fork block must emit ForkBlockBodyUnsupported; got: {:#?}",
-        output.diagnostics
+        multi_stmt_gate.note.contains("not yet supported")
+            && multi_stmt_gate.note.contains("fork { the_fn() }"),
+        "multi-statement reject must name the workaround; got note: {:?}",
+        multi_stmt_gate.note
     );
 
     let result = output.into_result();

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -1749,6 +1749,51 @@ impl Checker {
                 self.current_return_type = Some(Ty::Unit);
                 self.check_block(body, Some(&Ty::Unit));
                 self.current_return_type = prev_return_type;
+                // Mirror the `ForkChild` ownership gate: mark non-Copy call
+                // arguments as moved into this child task so that parent use
+                // after the fork reports `UseAfterMove`.
+                //
+                // `fork { f(a) }` transfers ownership of non-Copy args to the
+                // child task, exactly as `fork name = f(a)` does. The general
+                // `Expr::Call` arm does NOT mark args moved, so without this
+                // pass a heap `string` arg remains live in the parent scope
+                // and a subsequent use goes unreported — contradicting the
+                // lowering's "parent emits NO drop for moved-in args" contract.
+                //
+                // The accepted single-call form appears in two shapes:
+                //   a) `fork { f(args) }`  — tail expression (no semicolon)
+                //   b) `fork { f(args); }` — single stmt with semicolon
+                // For multi-statement bodies the HIR lowering rejects the fork,
+                // so we only encounter those shapes during type-checking; we
+                // still mark them (each call transfers its non-Copy args) to
+                // keep the ownership contract uniform even when HIR will err.
+                //
+                // WHEN-OBSOLETE: if the general call-arg path gains move-
+                // tracking, this pass (and the ForkChild one) become redundant.
+                macro_rules! mark_call_args_moved {
+                    ($args:expr) => {
+                        for arg in $args {
+                            let (arg_expr, arg_span) = arg.expr();
+                            if let Expr::Identifier(arg_name) = arg_expr {
+                                if let Some(binding_ty) =
+                                    self.env.lookup_ref(arg_name).map(|b| b.ty.clone())
+                                {
+                                    let resolved = self.subst.resolve(&binding_ty);
+                                    self.mark_expr_moved_if_non_copy(arg_expr, arg_span, &resolved);
+                                }
+                            }
+                        }
+                    };
+                }
+                if let Some(tail) = &body.trailing_expr {
+                    if let (Expr::Call { args, .. }, _) = tail.as_ref() {
+                        mark_call_args_moved!(args);
+                    }
+                } else if body.stmts.len() == 1 {
+                    if let (Stmt::Expression((Expr::Call { args, .. }, _)), _) = &body.stmts[0] {
+                        mark_call_args_moved!(args);
+                    }
+                }
                 // The fork statement itself produces no value.
                 Ty::Unit
             }

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -1692,6 +1692,39 @@ impl Checker {
                 // The fork statement itself produces no value.
                 Ty::Unit
             }
+            Expr::ForkBlock { body } => {
+                // `fork { ... }` is a fire-and-forget anonymous child task,
+                // `≈ fork _ = (|| { body })()`. Its body is checked here as a
+                // zero-parameter, unit-returning closure context so that body
+                // statements, callee arguments, and the tail expression are all
+                // type-checked — the same coverage the named `fork name = call()`
+                // form already enjoys.
+                //
+                // Position gate: like `fork name = call(...)`, `fork { ... }` is
+                // only meaningful inside a `scope { }` body. HIR lowering enforces
+                // the same rule; rejecting here too gives a check-time diagnostic.
+                if self.task_scope_depth == 0 {
+                    self.report_error(
+                        TypeErrorKind::InvalidOperation,
+                        span,
+                        "`fork { ... }` is only valid inside a `scope { }` body".to_string(),
+                    );
+                    return Ty::Unit;
+                }
+                // Check the body as an anonymous, unit-returning task context.
+                // `task_scope_depth` stays elevated (the body runs inside the
+                // enclosing scope, it does not open a fresh scope boundary), so a
+                // nested `fork name = call()` inside the body still passes its
+                // position gate. Save/restore `current_return_type` exactly as the
+                // `Expr::GenBlock` arm does so the enclosing function's return
+                // type is not polluted.
+                let prev_return_type = self.current_return_type.take();
+                self.current_return_type = Some(Ty::Unit);
+                self.check_block(body, Some(&Ty::Unit));
+                self.current_return_type = prev_return_type;
+                // The fork statement itself produces no value.
+                Ty::Unit
+            }
             Expr::SpawnLambdaActor {
                 is_move,
                 params,

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -1700,9 +1700,11 @@ impl Checker {
                 // type-checked — the same coverage the named `fork name = call()`
                 // form already enjoys.
                 //
-                // Position gate: like `fork name = call(...)`, `fork { ... }` is
-                // only meaningful inside a `scope { }` body. HIR lowering enforces
-                // the same rule; rejecting here too gives a check-time diagnostic.
+                // Position gate (defence-in-depth): like `fork name = call(...)`,
+                // `fork { ... }` is only meaningful inside a `scope { }` body. The
+                // parser already rejects `fork { }` outside a scope, so this gate is
+                // unreachable via a clean parse; it mirrors the `ForkChild` arm so
+                // the checker never silently accepts an out-of-position fork.
                 if self.task_scope_depth == 0 {
                     self.report_error(
                         TypeErrorKind::InvalidOperation,

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -1713,6 +1713,31 @@ impl Checker {
                     );
                     return Ty::Unit;
                 }
+                // Shape gate: a fork body that is a single bare non-call tail
+                // expression (no stmts, trailing_expr present but not a Call)
+                // must be caught here with the actionable fork-shape message.
+                // Without this gate the body reaches `check_block` against
+                // `Some(&Ty::Unit)`, which emits a generic "type mismatch:
+                // expected `()`, found `<T>`" — unhelpful for the user.
+                //
+                // `fork { 42; }` (with semicolon) becomes a single stmt and
+                // reaches the HIR gate's own ForkBlockBodyUnsupported path,
+                // so we only need to handle the no-semicolon tail case here.
+                if body.stmts.is_empty() {
+                    if let Some(tail) = &body.trailing_expr {
+                        if !matches!(&tail.0, Expr::Call { .. }) {
+                            self.report_error(
+                                TypeErrorKind::InvalidOperation,
+                                span,
+                                "`fork { }` bodies must be a direct function call, \
+                                 e.g. `fork { work() }`; other expression forms are \
+                                 not yet supported"
+                                    .to_string(),
+                            );
+                            return Ty::Unit;
+                        }
+                    }
+                }
                 // Check the body as an anonymous, unit-returning task context.
                 // `task_scope_depth` stays elevated (the body runs inside the
                 // enclosing scope, it does not open a fresh scope boundary), so a

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -20719,6 +20719,95 @@ mod for_loop_iterable_fail_closed {
         );
     }
 
+    // ── fork-block body type-checking (synthesize_concurrency arm) ───────
+
+    #[test]
+    fn fork_block_body_clean_single_call_has_no_type_errors() {
+        // A clean `fork { f() }` body type-checks with no diagnostics: the
+        // checker visits the body but a well-typed unit call is valid.
+        let output = check_source(
+            r"
+            fn worker() {}
+            fn main() {
+                scope {
+                    fork {
+                        worker();
+                    };
+                };
+            }
+            ",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "clean single-call fork body should produce no type errors; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn fork_block_arg_bearing_body_is_type_checked() {
+        // Pre-fold the block body was never visited, so a wrong-typed call
+        // argument inside `fork { ... }` was silently accepted. The fold routes
+        // the body through `check_block`, so the mismatch must now surface as a
+        // type error instead of being bypassed.
+        let output = check_source(
+            r#"
+            fn work(n: i64) { let _ = n; }
+            fn main() {
+                scope {
+                    fork {
+                        work("not an int");
+                    };
+                };
+            }
+            "#,
+        );
+        assert!(
+            output.errors.iter().any(|e| {
+                matches!(
+                    &e.kind,
+                    TypeErrorKind::Mismatch { expected, actual }
+                        if expected == "i64" && actual == "string"
+                )
+            }),
+            "arg-bearing fork body must surface the arg type mismatch; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn fork_block_multi_statement_body_is_type_checked() {
+        // A multi-statement fork body is visited statement-by-statement: a bad
+        // call in the second statement is reported even though the first is
+        // well-typed. (HIR lowering separately fails the multi-statement shape
+        // closed; this test pins only the checker's body coverage.)
+        let output = check_source(
+            r#"
+            fn ok() {}
+            fn work(n: i64) { let _ = n; }
+            fn main() {
+                scope {
+                    fork {
+                        ok();
+                        work("nope");
+                    };
+                };
+            }
+            "#,
+        );
+        assert!(
+            output.errors.iter().any(|e| {
+                matches!(
+                    &e.kind,
+                    TypeErrorKind::Mismatch { expected, actual }
+                        if expected == "i64" && actual == "string"
+                )
+            }),
+            "multi-statement fork body must type-check each statement; got: {:#?}",
+            output.errors
+        );
+    }
+
     #[test]
     fn closure_escape_channel_send_is_escapes() {
         // Case: closure stored-in / sent through a channel.

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -20719,129 +20719,6 @@ mod for_loop_iterable_fail_closed {
         );
     }
 
-    // ── fork-block body type-checking (synthesize_concurrency arm) ───────
-
-    #[test]
-    fn fork_block_body_clean_single_call_has_no_type_errors() {
-        // A clean `fork { f() }` body type-checks with no diagnostics: the
-        // checker visits the body but a well-typed unit call is valid.
-        let output = check_source(
-            r"
-            fn worker() {}
-            fn main() {
-                scope {
-                    fork {
-                        worker();
-                    };
-                };
-            }
-            ",
-        );
-        assert!(
-            output.errors.is_empty(),
-            "clean single-call fork body should produce no type errors; got: {:#?}",
-            output.errors
-        );
-    }
-
-    #[test]
-    fn fork_block_arg_bearing_body_is_type_checked() {
-        // Pre-fold the block body was never visited, so a wrong-typed call
-        // argument inside `fork { ... }` was silently accepted. The fold routes
-        // the body through `check_block`, so the mismatch must now surface as a
-        // type error instead of being bypassed.
-        let output = check_source(
-            r#"
-            fn work(n: i64) { let _ = n; }
-            fn main() {
-                scope {
-                    fork {
-                        work("not an int");
-                    };
-                };
-            }
-            "#,
-        );
-        assert!(
-            output.errors.iter().any(|e| {
-                matches!(
-                    &e.kind,
-                    TypeErrorKind::Mismatch { expected, actual }
-                        if expected == "i64" && actual == "string"
-                )
-            }),
-            "arg-bearing fork body must surface the arg type mismatch; got: {:#?}",
-            output.errors
-        );
-    }
-
-    #[test]
-    fn fork_block_multi_statement_body_is_type_checked() {
-        // A multi-statement fork body is visited statement-by-statement: a bad
-        // call in the second statement is reported even though the first is
-        // well-typed. (HIR lowering separately fails the multi-statement shape
-        // closed; this test pins only the checker's body coverage.)
-        let output = check_source(
-            r#"
-            fn ok() {}
-            fn work(n: i64) { let _ = n; }
-            fn main() {
-                scope {
-                    fork {
-                        ok();
-                        work("nope");
-                    };
-                };
-            }
-            "#,
-        );
-        assert!(
-            output.errors.iter().any(|e| {
-                matches!(
-                    &e.kind,
-                    TypeErrorKind::Mismatch { expected, actual }
-                        if expected == "i64" && actual == "string"
-                )
-            }),
-            "multi-statement fork body must type-check each statement; got: {:#?}",
-            output.errors
-        );
-    }
-
-    #[test]
-    fn fork_block_tail_expr_non_call_emits_actionable_diagnostic() {
-        // `fork { 42 }` — a bare tail-expression with no semicolon — must
-        // emit the actionable fork-shape message ("fork{} bodies must be a
-        // direct function call") rather than a generic type mismatch.
-        // Regression pin: previously the checker deferred to check_block
-        // which emitted "type mismatch: expected `()`, found `i64`".
-        let output = check_source(
-            r"
-            fn main() {
-                scope {
-                    fork { 42 };
-                };
-            }
-            ",
-        );
-        let has_actionable = output.errors.iter().any(|e| {
-            matches!(&e.kind, TypeErrorKind::InvalidOperation)
-                && e.message.contains("fork")
-                && e.message.contains("direct function call")
-        });
-        assert!(
-            has_actionable,
-            "fork {{ 42 }} (tail expr, no semicolon) must emit the actionable fork-shape \
-             diagnostic, not a generic type mismatch; got: {:#?}",
-            output.errors
-        );
-        // Must still be fail-closed (at least one error).
-        assert!(
-            !output.errors.is_empty(),
-            "fork {{ 42 }} must produce at least one error"
-        );
-    }
-
     #[test]
     fn closure_escape_channel_send_is_escapes() {
         // Case: closure stored-in / sent through a channel.
@@ -21117,6 +20994,133 @@ mod for_loop_iterable_fail_closed {
                 .iter()
                 .any(|e| e.kind == TypeErrorKind::InvalidOperation),
             "Ty::Never iterable must not emit InvalidOperation; got: {errors:?}",
+        );
+    }
+}
+
+// ── fork-block body type-checking ─────────────────────────────────────────
+
+mod fork_block_body_checks {
+    use super::*;
+
+    #[test]
+    fn fork_block_body_clean_single_call_has_no_type_errors() {
+        // A clean `fork { f() }` body type-checks with no diagnostics: the
+        // checker visits the body but a well-typed unit call is valid.
+        let output = check_source(
+            r"
+            fn worker() {}
+            fn main() {
+                scope {
+                    fork {
+                        worker();
+                    };
+                };
+            }
+            ",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "clean single-call fork body should produce no type errors; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn fork_block_arg_bearing_body_is_type_checked() {
+        // Pre-fold the block body was never visited, so a wrong-typed call
+        // argument inside `fork { ... }` was silently accepted. The fold routes
+        // the body through `check_block`, so the mismatch must now surface as a
+        // type error instead of being bypassed.
+        let output = check_source(
+            r#"
+            fn work(n: i64) { let _ = n; }
+            fn main() {
+                scope {
+                    fork {
+                        work("not an int");
+                    };
+                };
+            }
+            "#,
+        );
+        assert!(
+            output.errors.iter().any(|e| {
+                matches!(
+                    &e.kind,
+                    TypeErrorKind::Mismatch { expected, actual }
+                        if expected == "i64" && actual == "string"
+                )
+            }),
+            "arg-bearing fork body must surface the arg type mismatch; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn fork_block_multi_statement_body_is_type_checked() {
+        // A multi-statement fork body is visited statement-by-statement: a bad
+        // call in the second statement is reported even though the first is
+        // well-typed. (HIR lowering separately fails the multi-statement shape
+        // closed; this test pins only the checker's body coverage.)
+        let output = check_source(
+            r#"
+            fn ok() {}
+            fn work(n: i64) { let _ = n; }
+            fn main() {
+                scope {
+                    fork {
+                        ok();
+                        work("nope");
+                    };
+                };
+            }
+            "#,
+        );
+        assert!(
+            output.errors.iter().any(|e| {
+                matches!(
+                    &e.kind,
+                    TypeErrorKind::Mismatch { expected, actual }
+                        if expected == "i64" && actual == "string"
+                )
+            }),
+            "multi-statement fork body must type-check each statement; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn fork_block_tail_expr_non_call_emits_actionable_diagnostic() {
+        // `fork { 42 }` — a bare tail-expression with no semicolon — must
+        // emit the actionable fork-shape message ("fork{} bodies must be a
+        // direct function call") rather than a generic type mismatch.
+        // Regression pin: previously the checker deferred to check_block
+        // which emitted "type mismatch: expected `()`, found `i64`".
+        let output = check_source(
+            r"
+            fn main() {
+                scope {
+                    fork { 42 };
+                };
+            }
+            ",
+        );
+        let has_actionable = output.errors.iter().any(|e| {
+            matches!(&e.kind, TypeErrorKind::InvalidOperation)
+                && e.message.contains("fork")
+                && e.message.contains("direct function call")
+        });
+        assert!(
+            has_actionable,
+            "fork {{ 42 }} (tail expr, no semicolon) must emit the actionable fork-shape \
+             diagnostic, not a generic type mismatch; got: {:#?}",
+            output.errors
+        );
+        // Must still be fail-closed (at least one error).
+        assert!(
+            !output.errors.is_empty(),
+            "fork {{ 42 }} must produce at least one error"
         );
     }
 }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -21091,6 +21091,71 @@ mod fork_block_body_checks {
     }
 
     #[test]
+    fn fork_block_string_arg_parent_use_after_fork_block_rejected() {
+        // Ownership hole regression: `fork { shout(greeting) }` must mark
+        // `greeting` (a non-Copy `string`) moved into the child task, so that
+        // parent use after the fork reports `UseAfterMove`.
+        //
+        // The block form `fork { f(args) }` and the named form
+        // `fork ts = f(args)` must be symmetric — the named form already
+        // rejects parent-use-after-move; this test pins the block form.
+        let output = check_source(
+            r#"
+            fn shout(msg: string) {}
+
+            fn main() {
+                let greeting: string = "hello" + " world";
+                scope {
+                    fork {
+                        shout(greeting);
+                    };
+                };
+                // greeting was moved into the fork block — UseAfterMove here.
+                let _x = greeting;
+            }
+            "#,
+        );
+        assert!(
+            output
+                .errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::UseAfterMove),
+            "parent use of a string arg after fork-block must be UseAfterMove \
+             (parity with named fork); got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn fork_block_bitcopy_arg_parent_use_after_fork_block_accepted() {
+        // BitCopy scalars (i64) passed to a fork-block must remain live in
+        // the parent scope — no UseAfterMove for Copy types.
+        let output = check_source(
+            r"
+            fn add_print(a: i64, b: i64) {}
+
+            fn main() {
+                let x: i64 = 20;
+                let y: i64 = 22;
+                scope {
+                    fork {
+                        add_print(x, y);
+                    };
+                };
+                // BitCopy scalars remain live in the parent.
+                let _sum = x + y;
+            }
+            ",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "parent use of i64 args after fork-block must check clean \
+             (BitCopy exemption); got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
     fn fork_block_tail_expr_non_call_emits_actionable_diagnostic() {
         // `fork { 42 }` — a bare tail-expression with no semicolon — must
         // emit the actionable fork-shape message ("fork{} bodies must be a

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -20809,6 +20809,40 @@ mod for_loop_iterable_fail_closed {
     }
 
     #[test]
+    fn fork_block_tail_expr_non_call_emits_actionable_diagnostic() {
+        // `fork { 42 }` — a bare tail-expression with no semicolon — must
+        // emit the actionable fork-shape message ("fork{} bodies must be a
+        // direct function call") rather than a generic type mismatch.
+        // Regression pin: previously the checker deferred to check_block
+        // which emitted "type mismatch: expected `()`, found `i64`".
+        let output = check_source(
+            r"
+            fn main() {
+                scope {
+                    fork { 42 };
+                };
+            }
+            ",
+        );
+        let has_actionable = output.errors.iter().any(|e| {
+            matches!(&e.kind, TypeErrorKind::InvalidOperation)
+                && e.message.contains("fork")
+                && e.message.contains("direct function call")
+        });
+        assert!(
+            has_actionable,
+            "fork {{ 42 }} (tail expr, no semicolon) must emit the actionable fork-shape \
+             diagnostic, not a generic type mismatch; got: {:#?}",
+            output.errors
+        );
+        // Must still be fail-closed (at least one error).
+        assert!(
+            !output.errors.is_empty(),
+            "fork {{ 42 }} must produce at least one error"
+        );
+    }
+
+    #[test]
     fn closure_escape_channel_send_is_escapes() {
         // Case: closure stored-in / sent through a channel.
         let output = check_source(

--- a/tests/vertical-slice/accept/fork_args_spawn.hew
+++ b/tests/vertical-slice/accept/fork_args_spawn.hew
@@ -9,9 +9,9 @@
 // would corrupt the output; the companion run_e2e test re-runs this fixture
 // under MallocScribble for freed-read determinism.
 //
-// Argument-bearing spawns use the named form exclusively: the block form
-// (`fork { f(…); }`) is nullary because the checker does not visit block
-// bodies, so args there would bypass type-checking.
+// This fixture pins the named arg-bearing form. The block form
+// (`fork { f(args) }`) also accepts arguments now that the checker visits
+// the body; a single direct call of any arity is a first-class fork block.
 //
 // Harness verb: compile + run (exit 0)
 // Expected stdout: see fork_args_spawn.expected
@@ -28,12 +28,12 @@ actor Driver {
         scope {
             fork t = add_print(20, 22);
             await t;
-        }
+        };
         let greeting = "hello" + " world";
         scope {
             fork ts = shout(greeting);
             await ts;
-        }
+        };
         7
     }
 }

--- a/tests/vertical-slice/accept/fork_block_args_spawn.expected
+++ b/tests/vertical-slice/accept/fork_block_args_spawn.expected
@@ -1,0 +1,2 @@
+42
+hello world!

--- a/tests/vertical-slice/accept/fork_block_args_spawn.hew
+++ b/tests/vertical-slice/accept/fork_block_args_spawn.hew
@@ -1,0 +1,51 @@
+// Accept fixture: arg-bearing fork-BLOCK form compiles and runs correctly.
+// Covers the `fork { f(args) }` surface for both scalar and heap-string args:
+//   1. Block form with BitCopy scalar args: `fork { add_print(20, 22) }`
+//      — expects "42" on stdout.
+//   2. Block form with a moved-in heap `string` arg: `fork { shout(greeting) }`
+//      — expects "hello world!" on stdout.
+//
+// This is the block-form counterpart to fork_args_spawn.hew (which covers the
+// named `fork t = f(args)` form). The block form collapses to a nameless scope
+// spawn; the checker visits the body so arg-type mismatches surface at
+// type-check time (pinned by fork_block_body_checks tests).
+//
+// The ask-shaped go() reply synchronizes main with the handler, ordering all
+// output before process exit.
+//
+// Harness verb: compile + run (exit 0)
+// Expected stdout: see fork_block_args_spawn.expected
+fn add_print(a: i64, b: i64) {
+    println(f"{a + b}");
+}
+
+fn shout(msg: string) {
+    println(f"{msg}!");
+}
+
+actor Driver {
+    receive fn go() -> i64 {
+        scope {
+            fork {
+                add_print(20, 22);
+            };
+        };
+        let greeting = "hello" + " world";
+        scope {
+            fork {
+                shout(greeting);
+            };
+        };
+        7
+    }
+}
+
+fn main() -> i64 {
+    let d = spawn Driver;
+    match await d.go() {
+        // The handler replies 7 after both scopes join; exit 0 on the
+        // expected reply, non-zero otherwise.
+        Ok(v) => v - 7,
+        Err(_e) => 1,
+    }
+}

--- a/tests/vertical-slice/reject/fork_block_arg_type_mismatch.hew
+++ b/tests/vertical-slice/reject/fork_block_arg_type_mismatch.hew
@@ -1,28 +1,19 @@
 // Reject fixture: fork-block body with a type-mismatched argument.
 //
-// R1 pin: the `fork { … }` block form is nullary — the checker never visits
-// block bodies, so argument types there would be unchecked. HIR lowering
-// rejects arg-bearing block callees with a `ForkBlockBodyUnsupported`
-// diagnostic (source span present) BEFORE MIR or codegen see the call.
+// Arg-bearing single-call fork blocks are a first-class form: the checker now
+// visits the body and type-checks the callee arguments. `fork { flag(42); }`
+// (flag: bool, given i64 literal 42) is rejected by the checker with a
+// source-spanned `type mismatch` diagnostic BEFORE MIR or codegen see the
+// call — so it can never escape to a span-less `E_CODEGEN_FRONT … Call
+// parameter type does not match function signature!`.
 //
-// Without this gate, `fork { flag(42); }` (flag: bool → accepts bool, given
-// i64 literal 42) silently miscompiles; `fork { sink("s"); }` (sink: i64)
-// escapes to `E_CODEGEN_FRONT … Call parameter type does not match function
-// signature!` (no source span). Both are blocked here.
-//
-// Argument-bearing spawns must use the named form:
-//   `fork t = flag(true); await t;`
-//
-// This fixture pins the fail-closed boundary at:
-//   hew-hir/src/lower.rs  check_fork_block_shape (args.is_empty gate)
-//
-// When fork-block bodies gain checker coverage, this gate may be relaxed
-// and this fixture moved to accept/.
+// This fixture pins the checker's fork-block body coverage: a bad argument is
+// a real type error, not a blunt shape reject.
 //
 // Harness verb: hew compile
 // Expected diagnostics:
-//   - E_HIR
-//   - "fork block callee must have zero arguments"
+//   - "type mismatch: expected `bool`, found `i64`"
+//   - NOT E_CODEGEN_FRONT
 fn flag(b: bool) {
     println(f"{b}");
 }
@@ -30,7 +21,9 @@ fn flag(b: bool) {
 actor _Worker {
     receive fn run() {
         scope {
-            fork { flag(42); }
+            fork {
+                flag(42);
+            };
         };
     }
 }

--- a/tests/vertical-slice/reject/fork_block_parent_use_after_move.hew
+++ b/tests/vertical-slice/reject/fork_block_parent_use_after_move.hew
@@ -1,0 +1,27 @@
+// Reject fixture: fork_block_parent_use_after_move — ownership hole regression.
+//
+// A non-Copy `string` arg passed to `fork { shout(greeting); }` is moved
+// into the child task. Parent use of `greeting` after the fork must report
+// `UseAfterMove`, exactly as the named form `fork t = shout(greeting)` does.
+//
+// This fixture pins the parity between the block and named fork forms. Without
+// the move-marking pass in the ForkBlock checker arm, the block form would
+// silently leave `greeting` live in the parent scope and the second use below
+// would go unreported — contradicting the lowering's ownership contract.
+//
+// Expected diagnostics:
+//   - UseAfterMove: "use of moved value `greeting`"
+fn shout(msg: string) {
+    println(f"{msg}!");
+}
+
+fn main() {
+    let greeting: string = "hello" + " world";
+    scope {
+        fork {
+            shout(greeting);
+        };
+    };
+    // greeting was moved into the fork block — UseAfterMove here.
+    let _x = greeting;
+}

--- a/tests/vertical-slice/reject/fork_multi_stmt.hew
+++ b/tests/vertical-slice/reject/fork_multi_stmt.hew
@@ -1,9 +1,10 @@
 // Reject fixture: fork_multi_stmt — `fork { ... }` block body with multiple statements.
 //
-// The `fork { ... }` block form currently supports exactly one statement (a
-// single no-argument unit function call).  Two or more statements in the block
-// body fail closed in HIR lowering before MIR/codegen see the unsupported task
-// shape.
+// The `fork { ... }` block form supports exactly one statement: a single
+// direct function call (any arity). The checker type-checks the body, but MIR
+// cannot yet spawn a multi-statement body, so two or more statements fail
+// closed in HIR lowering before MIR/codegen see the unsupported task shape,
+// with an actionable diagnostic.
 //
 // This fixture pins the fail-closed boundary at:
 //   hew-hir/src/lower.rs fork block body guard
@@ -11,14 +12,17 @@
 // Harness verb: hew compile
 // Expected diagnostics:
 //   - E_HIR
-//   - "fork block body must contain exactly one statement or expression"
-
+//   - "multi-statement `fork { }` bodies are not yet supported"
 fn _foo() {}
+
 fn _bar() {}
 
 fn main() -> i64 {
     scope {
-        fork { _foo(); _bar(); }
+        fork {
+            _foo();
+            _bar();
+        };
     };
     0
 }

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1329,15 +1329,22 @@ fi
 grep -q 'E_HIR' "${reject_output}"
 grep -qF 'spawned call must have zero arguments' "${reject_output}"
 
-# Reject: fork-block body with a type-mismatched argument (R1 pin).
-# Pins the HIR fail-closed wall: fork { f(wrongtype); } must produce a
-# source-spanned E_HIR diagnostic, never E_CODEGEN_FRONT.
+# Reject: fork-block body with a type-mismatched argument.
+# Arg-bearing single-call fork blocks are now a first-class form, so the
+# checker visits the body and catches the real type error: `fork { flag(42) }`
+# where `flag: bool` produces a source-spanned `type mismatch` diagnostic at
+# the checker, never E_CODEGEN_FRONT downstream.
 if "${HEW}" compile "${ROOT}/tests/vertical-slice/reject/fork_block_arg_type_mismatch.hew" >"${reject_output}" 2>&1; then
   echo "expected fork-block-arg-type-mismatch fixture to fail" >&2
   exit 1
 fi
-grep -q 'E_HIR' "${reject_output}"
-grep -qF 'fork block callee must have zero arguments' "${reject_output}"
+# shellcheck disable=SC2016  # backticks in the pattern are literal — they match
+# the diagnostic text, not a command substitution.
+grep -qF 'type mismatch: expected `bool`, found `i64`' "${reject_output}"
+if grep -q 'E_CODEGEN_FRONT' "${reject_output}"; then
+  echo "fork-block arg type mismatch must fail at the checker, not codegen" >&2
+  exit 1
+fi
 
 # Reject: `fork { ... }` block with multiple statements.
 # Pins the HIR fail-closed fork-block body boundary.
@@ -1346,7 +1353,9 @@ if "${HEW}" compile "${ROOT}/tests/vertical-slice/reject/fork_multi_stmt.hew" >"
   exit 1
 fi
 grep -q 'E_HIR' "${reject_output}"
-grep -qF 'fork block body must contain exactly one statement or expression' "${reject_output}"
+# shellcheck disable=SC2016  # backticks in the pattern are literal — they match
+# the diagnostic text, not a command substitution.
+grep -qF 'multi-statement `fork { }` bodies are not yet supported' "${reject_output}"
 
 # Reject: `after(duration) { ... }` with a non-empty timeout body in a
 # CONTEXTLESS caller. The HIR shape gate now admits non-empty bodies (MIR

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1297,6 +1297,11 @@ run_accept_expect_stdout "fork_named_await_unit"
 # string on a fork block both transfer through the fork-entry shim env.
 run_accept_expect_stdout "fork_args_spawn"
 
+# Accept (arg-bearing fork-BLOCK form): `fork { f(args) }` with a scalar arg
+# and a heap-string arg. The block form collapses to a nameless scope spawn;
+# the fork-entry shim transfers args the same way as the named form.
+run_accept_expect_stdout "fork_block_args_spawn"
+
 # Reject: removed `scope |s| { s.launch / s.spawn / s.cancel }` surface.
 # Pins LESSONS row reject-scope-fork-collapse: the handle-based scope API was
 # removed; the parser emits a targeted diagnostic directing users to the new

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1302,6 +1302,15 @@ run_accept_expect_stdout "fork_args_spawn"
 # the fork-entry shim transfers args the same way as the named form.
 run_accept_expect_stdout "fork_block_args_spawn"
 
+# Reject: parent use of a non-Copy string arg after `fork { f(arg); }` must
+# report UseAfterMove — parity with the named `fork t = f(arg)` form. Without
+# the move-marking pass the block form would silently leave `greeting` live and
+# this use would go unreported, violating the lowering's ownership contract.
+expect_check_fail_contains \
+  "${ROOT}/tests/vertical-slice/reject/fork_block_parent_use_after_move.hew" \
+  "use of moved value \`greeting\`" \
+  "fork_block_parent_use_after_move"
+
 # Reject: removed `scope |s| { s.launch / s.spawn / s.cancel }` surface.
 # Pins LESSONS row reject-scope-fork-collapse: the handle-based scope API was
 # removed; the parser emits a targeted diagnostic directing users to the new


### PR DESCRIPTION
## Summary

`fork { expr }` bodies are now fully type-checked. A fork block whose tail
expression is not a direct function call — `fork { 42 }`, `fork { obj.method() }` —
produces an actionable diagnostic ("fork {} bodies must be a direct function call;
try `fork { the_fn() }`") instead of the previous generic type mismatch emitted at
the HIR layer. The checker visits the block body, saves and restores
`current_return_type`, and keeps `task_scope_depth` elevated so nested `fork name =
call()` statements inside the block pass their own gate correctly.

Argument-bearing single-call fork blocks (`fork { f(a, b) }`) are a first-class form
end-to-end. The arg-bearing block applies the same non-Copy move-marking as the named
`fork t = f(a, b)` form: a value moved into a fork child is rejected if the parent
attempts to reuse it after the fork, closing the ownership hole that existed in the
unnamed block path.

## Verification

- `cargo test -p hew-types -- check::tests::fork_block_body_checks`: 4/4 pass — pins
  actionable diagnostic text, UseAfterMove rejection, bitcopy exemption, and valid-args
  accept
- `hew-hir task_gates` proving gate: 19/19 pass (`fork_block_with_args_accepted`,
  `fork_block_multi_statement_rejected` with exact actionable note)
- `closure_escape_anonymous_fork` proving gate: exit 0 (no escape-classification
  regression)
- Vertical-slice `accept/fork_block_args_spawn.hew`: exits 0, output matches `.expected`
- Vertical-slice `reject/fork_block_parent_use_after_move.hew`: exits 1 with
  `UseAfterMove` diagnostic at the correct span
- Vertical-slice `reject/fork_block_arg_type_mismatch.hew`: exits 1 with
  `type mismatch: expected \`bool\`, found \`i64\`` at precise span, no `E_CODEGEN_FRONT`
- hew-types: 2196/2196 pass
- Preflight: ready-to-push

## Out of scope

- Method-call fork blocks (`fork { obj.method() }`) are explicitly rejected with an
  actionable diagnostic; MIR cannot spawn them today. Enabling that form is a separate
  MIR lowering change.
- Multi-statement fork bodies (`fork { a(); b() }`) continue to reject at the HIR gate
  with an improved message; the single-call restriction is current MIR capability, not
  a design choice.
- No changes to the named `fork t = call()` form or its codegen path.