### PR TITLE
feat(types,hir,mir): add return-as-expression and let-else for ergonomic error propagation

### DIFF
--- a/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
@@ -998,7 +998,7 @@ fn fs$read(string) -> string [conv=default]
     _7: bool
     _8: string
     _9: string
-    _10: ()
+    _10: !
     _11: i64
     _12: i64
     _13: bool
@@ -1019,7 +1019,7 @@ fn fs$read(string) -> string [conv=default]
     _28: string
     _29: string
     _30: string
-    _31: ()
+    _31: !
     _32: string
   bb0:
     stmt: use BindingId(31) path site=SiteId(319) ty=string intent=Read

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -1056,7 +1056,7 @@ fn fs$read(string) -> string [conv=default]
     _7: bool
     _8: string
     _9: string
-    _10: ()
+    _10: !
     _11: i64
     _12: i64
     _13: bool
@@ -1077,7 +1077,7 @@ fn fs$read(string) -> string [conv=default]
     _28: string
     _29: string
     _30: string
-    _31: ()
+    _31: !
     _32: string
   bb0:
     stmt: use BindingId(36) path site=SiteId(338) ty=string intent=Read

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
@@ -946,7 +946,7 @@ fn fs$read(string) -> string [conv=default]
     _7: bool
     _8: string
     _9: string
-    _10: ()
+    _10: !
     _11: i64
     _12: i64
     _13: bool
@@ -967,7 +967,7 @@ fn fs$read(string) -> string [conv=default]
     _28: string
     _29: string
     _30: string
-    _31: ()
+    _31: !
     _32: string
   bb0:
     stmt: use BindingId(31) path site=SiteId(306) ty=string intent=Read

--- a/hew-analysis/src/ast_visit.rs
+++ b/hew-analysis/src/ast_visit.rs
@@ -670,7 +670,8 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
             | Expr::Clone(operand)
             | Expr::Await(operand)
             | Expr::PostfixTry(operand)
-            | Expr::Yield(Some(operand)) => {
+            | Expr::Yield(Some(operand))
+            | Expr::Return(Some(operand)) => {
                 self.walk_expr(&operand.0, &operand.1, body);
             }
             Expr::Tuple(elements) | Expr::Array(elements) | Expr::Join(elements) => {
@@ -821,6 +822,7 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
             Expr::Literal(_)
             | Expr::This
             | Expr::Yield(None)
+            | Expr::Return(None)
             | Expr::RegexLiteral(_)
             | Expr::ByteStringLiteral(_)
             | Expr::ByteArrayLiteral(_) => {}

--- a/hew-analysis/src/calls.rs
+++ b/hew-analysis/src/calls.rs
@@ -244,7 +244,7 @@ fn collect_calls_in_expr(spanned: &(Expr, Span), calls: &mut Vec<CallSite>) {
         Expr::Cast { expr, .. } => {
             collect_calls_in_expr(expr.as_ref(), calls);
         }
-        Expr::Yield(Some(y)) => {
+        Expr::Yield(Some(y)) | Expr::Return(Some(y)) => {
             collect_calls_in_expr(y.as_ref(), calls);
         }
         Expr::If {
@@ -352,7 +352,8 @@ fn collect_calls_in_expr(spanned: &(Expr, Span), calls: &mut Vec<CallSite>) {
         | Expr::RegexLiteral(_)
         | Expr::ByteStringLiteral(_)
         | Expr::ByteArrayLiteral(_)
-        | Expr::Yield(None) => {}
+        | Expr::Yield(None)
+        | Expr::Return(None) => {}
     }
 }
 

--- a/hew-analysis/src/hover.rs
+++ b/hew-analysis/src/hover.rs
@@ -567,7 +567,9 @@ fn hover_binding_in_stmt(
     offset: usize,
 ) -> Option<HoverResult> {
     match stmt {
-        Stmt::Let { pattern, ty, value } => {
+        Stmt::Let {
+            pattern, ty, value, ..
+        } => {
             find_binding_name(pattern, word, offset)?;
             let ty_text = if let Some((type_expr, _)) = ty {
                 format_type_expr_hover(type_expr)

--- a/hew-analysis/src/inlay_hints.rs
+++ b/hew-analysis/src/inlay_hints.rs
@@ -486,7 +486,8 @@ fn collect_inlay_hints_from_expr(
         Expr::Cast { expr: inner, .. }
         | Expr::PostfixTry(inner)
         | Expr::Await(inner)
-        | Expr::Yield(Some(inner)) => {
+        | Expr::Yield(Some(inner))
+        | Expr::Return(Some(inner)) => {
             collect_inlay_hints_from_expr(source, &inner.0, tc, hints);
         }
         Expr::Range { start, end, .. } => {
@@ -514,7 +515,8 @@ fn collect_inlay_hints_from_expr(
         | Expr::RegexLiteral(_)
         | Expr::ByteStringLiteral(_)
         | Expr::ByteArrayLiteral(_)
-        | Expr::Yield(None) => {}
+        | Expr::Yield(None)
+        | Expr::Return(None) => {}
         Expr::GenBlock { body } => {
             collect_inlay_hints_from_block(source, body, tc, hints);
         }

--- a/hew-analysis/src/inlay_hints.rs
+++ b/hew-analysis/src/inlay_hints.rs
@@ -201,7 +201,9 @@ fn collect_inlay_hints_from_stmt(
     hints: &mut Vec<InlayHint>,
 ) {
     match stmt {
-        Stmt::Let { pattern, ty, value } => {
+        Stmt::Let {
+            pattern, ty, value, ..
+        } => {
             if ty.is_none() {
                 if let Some(value_expr) = value {
                     let span_key = SpanKey {

--- a/hew-hir/src/dump.rs
+++ b/hew-hir/src/dump.rs
@@ -1227,6 +1227,12 @@ fn dump_expr(out: &mut String, expr: &HirExpr, indent: usize) {
                 dump_expr(out, value, indent + 4);
             }
         }
+        HirExprKind::Return { value } => {
+            writeln!(out, "{pad}  return").expect("write to string");
+            if let Some(value) = value {
+                dump_expr(out, value, indent + 4);
+            }
+        }
         HirExprKind::Continue { label } => {
             writeln!(out, "{pad}  continue label={label:?}").expect("write to string");
         }

--- a/hew-hir/src/dump.rs
+++ b/hew-hir/src/dump.rs
@@ -72,6 +72,20 @@ pub fn dump_hir(module: &HirModule) -> String {
                             writeln!(out, "  defer").expect("write to string");
                             dump_expr(&mut out, body, 4);
                         }
+                        HirStmtKind::LetElse {
+                            scrutinee,
+                            bindings,
+                            else_body,
+                            ..
+                        } => {
+                            let names: Vec<&str> =
+                                bindings.iter().map(|b| b.name.as_str()).collect();
+                            writeln!(out, "  let-else bind=[{}]", names.join(", "))
+                                .expect("write to string");
+                            dump_expr(&mut out, scrutinee, 4);
+                            writeln!(out, "  else").expect("write to string");
+                            dump_block(&mut out, else_body, 4);
+                        }
                     }
                 }
                 if let Some(tail) = &func.body.tail {
@@ -336,6 +350,19 @@ fn dump_block(out: &mut String, block: &HirBlock, indent: usize) {
                 writeln!(out, "{pad}defer").expect("write to string");
                 dump_expr(out, body, indent + 2);
             }
+            HirStmtKind::LetElse {
+                scrutinee,
+                bindings,
+                else_body,
+                ..
+            } => {
+                let names: Vec<&str> = bindings.iter().map(|b| b.name.as_str()).collect();
+                writeln!(out, "{pad}let-else bind=[{}]", names.join(", "))
+                    .expect("write to string");
+                dump_expr(out, scrutinee, indent + 2);
+                writeln!(out, "{pad}else").expect("write to string");
+                dump_block(out, else_body, indent + 2);
+            }
         }
     }
     if let Some(tail) = &block.tail {
@@ -557,6 +584,19 @@ fn dump_expr(out: &mut String, expr: &HirExpr, indent: usize) {
                         writeln!(out, "{pad}    defer").expect("write to string");
                         dump_expr(out, body, indent + 6);
                     }
+                    HirStmtKind::LetElse {
+                        scrutinee,
+                        bindings,
+                        else_body,
+                        ..
+                    } => {
+                        let names: Vec<&str> = bindings.iter().map(|b| b.name.as_str()).collect();
+                        writeln!(out, "{pad}    let-else bind=[{}]", names.join(", "))
+                            .expect("write to string");
+                        dump_expr(out, scrutinee, indent + 6);
+                        writeln!(out, "{pad}    else").expect("write to string");
+                        dump_block(out, else_body, indent + 6);
+                    }
                 }
             }
         }
@@ -608,6 +648,19 @@ fn dump_expr(out: &mut String, expr: &HirExpr, indent: usize) {
                         writeln!(out, "{pad}    defer").expect("write to string");
                         dump_expr(out, body, indent + 6);
                     }
+                    HirStmtKind::LetElse {
+                        scrutinee,
+                        bindings,
+                        else_body,
+                        ..
+                    } => {
+                        let names: Vec<&str> = bindings.iter().map(|b| b.name.as_str()).collect();
+                        writeln!(out, "{pad}    let-else bind=[{}]", names.join(", "))
+                            .expect("write to string");
+                        dump_expr(out, scrutinee, indent + 6);
+                        writeln!(out, "{pad}    else").expect("write to string");
+                        dump_block(out, else_body, indent + 6);
+                    }
                 }
             }
         }
@@ -645,6 +698,19 @@ fn dump_expr(out: &mut String, expr: &HirExpr, indent: usize) {
                     HirStmtKind::Defer { body, .. } => {
                         writeln!(out, "{pad}    defer").expect("write to string");
                         dump_expr(out, body, indent + 6);
+                    }
+                    HirStmtKind::LetElse {
+                        scrutinee,
+                        bindings,
+                        else_body,
+                        ..
+                    } => {
+                        let names: Vec<&str> = bindings.iter().map(|b| b.name.as_str()).collect();
+                        writeln!(out, "{pad}    let-else bind=[{}]", names.join(", "))
+                            .expect("write to string");
+                        dump_expr(out, scrutinee, indent + 6);
+                        writeln!(out, "{pad}    else").expect("write to string");
+                        dump_block(out, else_body, indent + 6);
                     }
                 }
             }

--- a/hew-hir/src/dump.rs
+++ b/hew-hir/src/dump.rs
@@ -9,7 +9,7 @@
 
 use std::fmt::Write as _;
 
-use crate::node::{HirBlock, HirExpr, HirExprKind, HirItem, HirModule, HirStmtKind};
+use crate::node::{HirBlock, HirExpr, HirExprKind, HirItem, HirModule, HirStmt, HirStmtKind};
 
 #[must_use]
 #[allow(
@@ -353,6 +353,7 @@ fn dump_block(out: &mut String, block: &HirBlock, indent: usize) {
             HirStmtKind::LetElse {
                 scrutinee,
                 bindings,
+                success_prelude,
                 else_body,
                 ..
             } => {
@@ -360,6 +361,10 @@ fn dump_block(out: &mut String, block: &HirBlock, indent: usize) {
                 writeln!(out, "{pad}let-else bind=[{}]", names.join(", "))
                     .expect("write to string");
                 dump_expr(out, scrutinee, indent + 2);
+                if !success_prelude.is_empty() {
+                    writeln!(out, "{pad}success-prelude").expect("write to string");
+                    dump_stmts(out, success_prelude, indent + 2);
+                }
                 writeln!(out, "{pad}else").expect("write to string");
                 dump_block(out, else_body, indent + 2);
             }
@@ -368,6 +373,26 @@ fn dump_block(out: &mut String, block: &HirBlock, indent: usize) {
     if let Some(tail) = &block.tail {
         writeln!(out, "{pad}tail").expect("write to string");
         dump_expr(out, tail, indent + 2);
+    }
+}
+
+/// Dump a flat list of statements (the let-else success prelude) by delegating
+/// each to the same per-statement rendering used inside a block. The prelude
+/// holds only `HirStmtKind::Let` projections, so a minimal renderer suffices.
+fn dump_stmts(out: &mut String, stmts: &[HirStmt], indent: usize) {
+    let pad = " ".repeat(indent);
+    for stmt in stmts {
+        match &stmt.kind {
+            HirStmtKind::Let(binding, value) => {
+                writeln!(out, "{pad}let {}", binding.name).expect("write to string");
+                if let Some(value) = value {
+                    dump_expr(out, value, indent + 2);
+                }
+            }
+            other => {
+                writeln!(out, "{pad}{other:?}").expect("write to string");
+            }
+        }
     }
 }
 

--- a/hew-hir/src/layout_mono.rs
+++ b/hew-hir/src/layout_mono.rs
@@ -430,12 +430,20 @@ fn walk_stmt(
         HirStmtKind::LetElse {
             scrutinee,
             bindings,
+            success_prelude,
             else_body,
             ..
         } => {
             walk_expr(scrutinee, subst, residual_domain, disc);
             for binding in bindings {
                 disc.visit_ty(&binding.ty, &scrutinee.span, subst, residual_domain);
+            }
+            // Aggregate-payload leaf binders (`Ok((n, s))` → `n`, `s`) carry
+            // their own resolved types and projection expressions; visit them
+            // so a generic record/enum reached only through a destructured leaf
+            // is still discovered for monomorphisation.
+            for prelude_stmt in success_prelude {
+                walk_stmt(prelude_stmt, subst, residual_domain, disc);
             }
             walk_block(else_body, subst, residual_domain, disc);
         }

--- a/hew-hir/src/layout_mono.rs
+++ b/hew-hir/src/layout_mono.rs
@@ -625,7 +625,10 @@ fn walk_expr(
         }
         HirExprKind::Break {
             value: Some(value), ..
-        } => walk_expr(value, subst, residual_domain, disc),
+        }
+        | HirExprKind::Return { value: Some(value) } => {
+            walk_expr(value, subst, residual_domain, disc);
+        }
         HirExprKind::NumericMethod { receiver, arg, .. } => {
             walk_expr(receiver, subst, residual_domain, disc);
             walk_expr(arg, subst, residual_domain, disc);
@@ -699,6 +702,7 @@ fn walk_expr(
         | HirExprKind::MachineEventFieldAccess { .. }
         | HirExprKind::Yield { value: None, .. }
         | HirExprKind::Break { value: None, .. }
+        | HirExprKind::Return { value: None }
         | HirExprKind::Continue { .. }
         | HirExprKind::ActorSelf
         | HirExprKind::Unsupported(_) => {}

--- a/hew-hir/src/layout_mono.rs
+++ b/hew-hir/src/layout_mono.rs
@@ -427,6 +427,18 @@ fn walk_stmt(
         }
         HirStmtKind::Return(None) => {}
         HirStmtKind::Defer { body, .. } => walk_expr(body, subst, residual_domain, disc),
+        HirStmtKind::LetElse {
+            scrutinee,
+            bindings,
+            else_body,
+            ..
+        } => {
+            walk_expr(scrutinee, subst, residual_domain, disc);
+            for binding in bindings {
+                disc.visit_ty(&binding.ty, &scrutinee.span, subst, residual_domain);
+            }
+            walk_block(else_body, subst, residual_domain, disc);
+        }
     }
 }
 

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -3991,7 +3991,7 @@ fn collect_call_sites_in_expr(
                 collect_call_sites_in_block(eb, out, trait_out);
             }
         }
-        HirExprKind::Break { value, .. } => {
+        HirExprKind::Break { value, .. } | HirExprKind::Return { value } => {
             if let Some(value) = value {
                 collect_call_sites_in_expr(value, out, trait_out);
             }
@@ -6985,7 +6985,9 @@ impl LowerCtx {
                     }
                 }
             }
-            HirExprKind::Yield { value, .. } | HirExprKind::Break { value, .. } => {
+            HirExprKind::Yield { value, .. }
+            | HirExprKind::Break { value, .. }
+            | HirExprKind::Return { value } => {
                 if let Some(value) = value {
                     self.wrap_var_self_explicit_expr_returns(value, receiver, abi_return_ty);
                 }
@@ -12648,6 +12650,30 @@ impl LowerCtx {
                     ResolvedTy::Unit
                 };
                 (HirExprKind::Yield { value, yield_ty }, ResolvedTy::Unit)
+            }
+            Expr::Return(value) => {
+                // `return [expr]` in expression position. Lower the operand with
+                // `Consume` intent — exactly as the statement form
+                // (`Stmt::Return`) — since the value leaves the function. The
+                // construct is `Never`-typed (it diverges); MIR seals it with
+                // `Terminator::Return` via the same shell as `HirStmtKind::Return`
+                // (LESSONS `one-construct-one-lowering-shell`).
+                let value = value
+                    .as_deref()
+                    .map(|value| Box::new(self.lower_expr(value, IntentKind::Consume)));
+                // TI-5 escape check (defense-in-depth, mirrors the statement
+                // form): a `Task<T>` handle must not escape via `return`.
+                if let Some(expr) = &value {
+                    if matches!(expr.ty, ResolvedTy::Task(_)) {
+                        self.diagnostics.push(HirDiagnostic::new(
+                            HirDiagnosticKind::TaskCannotEscape,
+                            span.clone(),
+                            "a `Task<T>` handle cannot escape via `return`; \
+                             await it inside the `scope{}` body with `await name`",
+                        ));
+                    }
+                }
+                (HirExprKind::Return { value }, ResolvedTy::Never)
             }
             Expr::MethodCall {
                 receiver,
@@ -21837,7 +21863,9 @@ fn collect_captures_walk(
         | HirExprKind::GenBlock { body: block, .. } => {
             collect_captures_walk_block(block, param_ids, seen, captures, self_id);
         }
-        HirExprKind::Yield { value, .. } | HirExprKind::Break { value, .. } => {
+        HirExprKind::Yield { value, .. }
+        | HirExprKind::Break { value, .. }
+        | HirExprKind::Return { value } => {
             if let Some(value) = value {
                 collect_captures_walk(value, param_ids, seen, captures, self_id);
             }
@@ -22143,7 +22171,9 @@ fn collect_general_closure_captures_walk(
         | HirExprKind::GenBlock { body: block, .. } => {
             collect_general_closure_captures_walk_block(block, outer_bindings, seen, captures);
         }
-        HirExprKind::Yield { value, .. } | HirExprKind::Break { value, .. } => {
+        HirExprKind::Yield { value, .. }
+        | HirExprKind::Break { value, .. }
+        | HirExprKind::Return { value } => {
             if let Some(value) = value {
                 collect_general_closure_captures_walk(value, outer_bindings, seen, captures);
             }
@@ -23010,7 +23040,7 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
                 }
             }
         }
-        HirExprKind::Break { value, .. } => {
+        HirExprKind::Break { value, .. } | HirExprKind::Return { value } => {
             if let Some(value) = value {
                 collect_hir_emitted_events_walk(value, event_names, out);
             }
@@ -26001,7 +26031,7 @@ fn scan_expr_for_call_shape(
                 scan_block_for_call_shape(eb, callable, diagnostics);
             }
         }
-        HirExprKind::Break { value, .. } => {
+        HirExprKind::Break { value, .. } | HirExprKind::Return { value } => {
             if let Some(value) = value {
                 scan_expr_for_call_shape(value, callable, diagnostics);
             }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -169,6 +169,55 @@ fn constructor_payload_aggregate_subpatterns(pattern: &Pattern) -> bool {
     })
 }
 
+/// Resolve the type of an `if`/`else` expression from its two branch types,
+/// mirroring the checker's `unify_branches` Never-handling.
+///
+/// A branch that diverges (`return`/`break`/`continue`) lowers to a block of
+/// type `ResolvedTy::Never`; it must NOT determine the construct's value type.
+/// When one branch is `Never`, the construct's type is the OTHER branch's type
+/// (the value branch). This makes `let x = if c { v } else { return … }` carry
+/// `v`'s type instead of `Never`, so a later `x + 1` lowers as integer
+/// arithmetic rather than failing closed on a non-integer operand at MIR.
+///
+/// With no else branch the construct yields `Unit`; with both branches present
+/// and neither `Never`, the then branch's type wins (the checker already
+/// reconciled the two, so they agree here).
+fn if_branch_result_ty(then_ty: &ResolvedTy, else_ty: Option<&ResolvedTy>) -> ResolvedTy {
+    match else_ty {
+        None => ResolvedTy::Unit,
+        Some(else_ty) => {
+            if matches!(else_ty, ResolvedTy::Never) {
+                then_ty.clone()
+            } else {
+                else_ty.clone()
+            }
+        }
+    }
+}
+
+/// True when a tail-less block's statements guarantee control never falls off
+/// the end — i.e. the block diverges and has type `ResolvedTy::Never`.
+///
+/// A block diverges when its last reachable statement diverges: a bare
+/// `return`, or a value/expression statement whose lowered type is `Never`
+/// (a `return <expr>` expression, or an `if`/`match` whose every branch
+/// diverges). This is the HIR mirror of the checker's `check_block`
+/// divergence tracking, kept narrow: only the LAST statement is inspected,
+/// matching the well-formed case where any earlier diverging statement makes
+/// the rest unreachable (the checker already warned on that).
+fn block_diverges(statements: &[HirStmt]) -> bool {
+    let Some(last) = statements.last() else {
+        return false;
+    };
+    match &last.kind {
+        HirStmtKind::Return(_) => true,
+        HirStmtKind::Expr(expr) | HirStmtKind::Let(_, Some(expr)) => {
+            matches!(expr.ty, ResolvedTy::Never)
+        }
+        _ => false,
+    }
+}
+
 fn literal_to_hir(lit: &Literal) -> (HirLiteral, ResolvedTy) {
     match lit {
         Literal::Integer { value, .. } => (HirLiteral::Integer(*value), ResolvedTy::I64),
@@ -3775,10 +3824,14 @@ fn collect_call_sites_in_stmt(
         }
         HirStmtKind::LetElse {
             scrutinee,
+            success_prelude,
             else_body,
             ..
         } => {
             collect_call_sites_in_expr(scrutinee, out, trait_out);
+            for stmt in success_prelude {
+                collect_call_sites_in_stmt(stmt, out, trait_out);
+            }
             collect_call_sites_in_block(else_body, out, trait_out);
         }
     }
@@ -6714,10 +6767,14 @@ impl LowerCtx {
             }
             HirStmtKind::LetElse {
                 scrutinee,
+                success_prelude,
                 else_body,
                 ..
             } => {
                 self.wrap_var_self_explicit_expr_returns(scrutinee, receiver, abi_return_ty);
+                for stmt in success_prelude.iter_mut() {
+                    self.wrap_var_self_stmt_returns(stmt, receiver, abi_return_ty);
+                }
                 self.wrap_var_self_explicit_returns_in_block(else_body, receiver, abi_return_ty);
             }
             HirStmtKind::Let(_, None) => {}
@@ -9774,9 +9831,24 @@ impl LowerCtx {
             .trailing_expr
             .as_ref()
             .map(|expr| Box::new(self.lower_expr(expr, IntentKind::Read)));
-        let ty = tail
-            .as_ref()
-            .map_or(ResolvedTy::Unit, |expr| expr.ty.clone());
+        // A block's value type is its tail expression's type. With no tail it is
+        // `Unit` UNLESS the block diverges: a trailing `return`/`break`/
+        // `continue` (or a last statement that diverges in every branch, e.g. an
+        // `if` whose arms all `return`) makes control never fall off the end, so
+        // the block has type `Never`. This mirrors the checker's `check_block`
+        // `Ty::Never` result and is what lets `let x = if c { v } else { return … }`
+        // carry `v`'s type — without it the else block reads `Unit` and the
+        // construct mis-types, breaking a later `x + 1` at MIR lowering.
+        let ty = tail.as_ref().map_or_else(
+            || {
+                if block_diverges(&statements) {
+                    ResolvedTy::Never
+                } else {
+                    ResolvedTy::Unit
+                }
+            },
+            |expr| expr.ty.clone(),
+        );
         self.current_scope_id = prev_scope_id;
         self.pop_scope();
         self.scope_depth = saved_scope_depth;
@@ -10775,9 +10847,7 @@ impl LowerCtx {
                         None
                     }
                 });
-                let if_ty = else_expr
-                    .as_ref()
-                    .map_or(ResolvedTy::Unit, |e| e.ty.clone());
+                let if_ty = if_branch_result_ty(&then_ty, else_expr.as_ref().map(|e| &e.ty));
                 let if_expr = HirExpr {
                     node: self.ids.node(),
                     site: self.ids.site(),
@@ -11423,6 +11493,97 @@ impl LowerCtx {
         }
     }
 
+    /// Destructure a constructor pattern's AGGREGATE payload subpatterns
+    /// (non-empty tuples and structs, e.g. the `(n, s)` in `Ok((n, s))`) into
+    /// their leaf binders.
+    ///
+    /// For each aggregate field the variant carries, this binds the whole
+    /// payload field to a synthetic temp (appended to `bindings` so MIR moves
+    /// the field out of the scrutinee) and then recursively lowers the nested
+    /// pattern against a reference to that temp via
+    /// `lower_pattern_value_into_stmts`, collecting the destructure `Let`
+    /// statements into the returned prelude. The caller runs the prelude on the
+    /// success path so the leaf binders (`n`, `s`) are live afterwards.
+    ///
+    /// Shared by `match` arm lowering and `let-else` lowering so both paths
+    /// reach an identical set of leaf bindings for the same pattern shape.
+    /// Returns `(prelude_stmts, had_error)`; on error the diagnostics are
+    /// already pushed and the caller fails closed.
+    fn lower_constructor_payload_aggregates(
+        &mut self,
+        ctor_name: &str,
+        sub_patterns: &[Spanned<Pattern>],
+        scrutinee_ty: &ResolvedTy,
+        bindings: &mut Vec<HirMatchArmBinding>,
+        owning_pass: &'static str,
+    ) -> (Vec<HirStmt>, bool) {
+        let mut prelude = Vec::new();
+        let mut had_error = false;
+        let field_tys = self
+            .lookup_variant_ctor(ctor_name)
+            .map(|(type_name, _, kind)| match kind {
+                HirVariantKind::Tuple(field_tys) => {
+                    let scrutinee_args = match scrutinee_ty {
+                        ResolvedTy::Named { args, .. } => args.as_slice(),
+                        _ => &[],
+                    };
+                    let type_params = self
+                        .enum_type_params
+                        .get(&type_name)
+                        .cloned()
+                        .unwrap_or_default();
+                    if type_params.len() == scrutinee_args.len() {
+                        field_tys
+                            .iter()
+                            .map(|ty| substitute_type_params(ty, &type_params, scrutinee_args))
+                            .collect()
+                    } else {
+                        field_tys.clone()
+                    }
+                }
+                HirVariantKind::Unit | HirVariantKind::Struct(_) => Vec::new(),
+            })
+            .unwrap_or_default();
+        for (field_idx, (sub_pat, sub_span)) in sub_patterns.iter().enumerate() {
+            if !matches!(sub_pat, Pattern::Struct { .. })
+                && !matches!(sub_pat, Pattern::Tuple(items) if !items.is_empty())
+            {
+                continue;
+            }
+            let Some(field_ty) = field_tys.get(field_idx).cloned() else {
+                continue;
+            };
+            let Ok(field_idx_u32) = u32::try_from(field_idx) else {
+                self.unsupported(
+                    sub_span.clone(),
+                    "payload aggregate field index exceeds u32::MAX",
+                    owning_pass,
+                );
+                had_error = true;
+                continue;
+            };
+            let temp_name = format!("__payload_{}_{}", field_idx, self.ids.binding().0);
+            let bound = self.bind(temp_name.clone(), field_ty.clone(), false, sub_span.clone());
+            let temp_id = bound.id;
+            bindings.push(HirMatchArmBinding {
+                binding: temp_id,
+                field_idx: field_idx_u32,
+                name: temp_name.clone(),
+                ty: field_ty.clone(),
+            });
+            let temp_ref =
+                self.binding_ref_expr(temp_name, temp_id, field_ty.clone(), sub_span.clone());
+            self.lower_pattern_value_into_stmts(
+                &(sub_pat.clone(), sub_span.clone()),
+                temp_ref,
+                field_ty,
+                &mut prelude,
+                sub_span.clone(),
+            );
+        }
+        (prelude, had_error)
+    }
+
     /// Lower `let PAT = scrutinee else { <divergent block> };` to the dedicated
     /// `HirStmtKind::LetElse` node.
     ///
@@ -11533,7 +11694,7 @@ impl LowerCtx {
         // Bind the payload fields into the ENCLOSING scope (no push/pop) so the
         // Ok-path binders escape and are live for the rest of the enclosing
         // block — the defining property of let-else.
-        let bindings: Vec<HirMatchArmBinding> = if binding_error {
+        let mut bindings: Vec<HirMatchArmBinding> = if binding_error {
             Vec::new()
         } else {
             binding_specs
@@ -11548,6 +11709,27 @@ impl LowerCtx {
                     }
                 })
                 .collect()
+        };
+
+        // Destructure aggregate payload subpatterns (`Ok((n, s))`) into their
+        // leaf binders, mirroring `match`. The prelude runs on the SUCCESS path
+        // after the top-level payload fields bind; its leaf binders escape into
+        // the enclosing scope just like `bindings`. Plain bindings / wildcards
+        // produce no prelude.
+        let success_prelude = if binding_error {
+            Vec::new()
+        } else if let Pattern::Constructor { name, patterns } = &pattern.0 {
+            let (prelude, had_error) = self.lower_constructor_payload_aggregates(
+                name,
+                patterns,
+                &scrutinee_hir.ty,
+                &mut bindings,
+                "let-else-substrate",
+            );
+            binding_error |= had_error;
+            prelude
+        } else {
+            Vec::new()
         };
 
         let mut payload_variant_predicates =
@@ -11572,6 +11754,7 @@ impl LowerCtx {
                 scrutinee: Box::new(scrutinee_hir),
                 variant_idx,
                 bindings,
+                success_prelude,
                 payload_variant_predicates,
                 else_body,
             },
@@ -11871,6 +12054,7 @@ impl LowerCtx {
 
     fn lower_expr(&mut self, expr: &Spanned<Expr>, intent: IntentKind) -> HirExpr {
         let lowered = self.lower_expr_inner(expr, intent);
+
         // Function-tail Ok-coercion: the checker marked this tail expression's
         // span when a `Result<Ok, Err>`-returning function's tail yields the
         // `Ok` payload (e.g. `db.find(id)?` typed `User` under
@@ -12108,9 +12292,12 @@ impl LowerCtx {
                 let else_expr = else_block
                     .as_ref()
                     .map(|expr| Box::new(self.lower_expr(expr, IntentKind::Read)));
-                let ty = else_expr
-                    .as_ref()
-                    .map_or(ResolvedTy::Unit, |expr| expr.ty.clone());
+                // Mirror the checker's `unify_branches`: a diverging branch
+                // (`Never`) must not set the construct's value type, so the
+                // construct takes the value branch's type. Without this an
+                // unannotated `let x = if c { v } else { return … }` would carry
+                // the else's `Never` and break a later `x + 1` at MIR lowering.
+                let ty = if_branch_result_ty(&then_expr.ty, else_expr.as_ref().map(|e| &e.ty));
                 (
                     HirExprKind::If {
                         condition: Box::new(condition),
@@ -21110,75 +21297,15 @@ impl LowerCtx {
 
             let mut body_prelude = Vec::new();
             if let Pattern::Constructor { name, patterns } = &arm.pattern.0 {
-                let field_tys = self
-                    .lookup_variant_ctor(name)
-                    .map(|(type_name, _, kind)| match kind {
-                        HirVariantKind::Tuple(field_tys) => {
-                            let scrutinee_args = match &scrutinee_hir.ty {
-                                ResolvedTy::Named { args, .. } => args.as_slice(),
-                                _ => &[],
-                            };
-                            let type_params = self
-                                .enum_type_params
-                                .get(&type_name)
-                                .cloned()
-                                .unwrap_or_default();
-                            if type_params.len() == scrutinee_args.len() {
-                                field_tys
-                                    .iter()
-                                    .map(|ty| {
-                                        substitute_type_params(ty, &type_params, scrutinee_args)
-                                    })
-                                    .collect()
-                            } else {
-                                field_tys.clone()
-                            }
-                        }
-                        HirVariantKind::Unit | HirVariantKind::Struct(_) => Vec::new(),
-                    })
-                    .unwrap_or_default();
-                for (field_idx, (sub_pat, sub_span)) in patterns.iter().enumerate() {
-                    if !matches!(sub_pat, Pattern::Struct { .. })
-                        && !matches!(sub_pat, Pattern::Tuple(items) if !items.is_empty())
-                    {
-                        continue;
-                    }
-                    let Some(field_ty) = field_tys.get(field_idx).cloned() else {
-                        continue;
-                    };
-                    let Ok(field_idx_u32) = u32::try_from(field_idx) else {
-                        self.unsupported(
-                            sub_span.clone(),
-                            "payload aggregate field index exceeds u32::MAX",
-                            "match-expression-substrate",
-                        );
-                        binding_error = true;
-                        continue;
-                    };
-                    let temp_name = format!("__payload_{}_{}", field_idx, self.ids.binding().0);
-                    let bound =
-                        self.bind(temp_name.clone(), field_ty.clone(), false, sub_span.clone());
-                    let temp_id = bound.id;
-                    bindings.push(HirMatchArmBinding {
-                        binding: temp_id,
-                        field_idx: field_idx_u32,
-                        name: temp_name.clone(),
-                        ty: field_ty.clone(),
-                    });
-                    let temp_ref = self.binding_ref_expr(
-                        temp_name,
-                        temp_id,
-                        field_ty.clone(),
-                        sub_span.clone(),
-                    );
-                    self.lower_pattern_value_into_stmts(
-                        &(sub_pat.clone(), sub_span.clone()),
-                        temp_ref,
-                        field_ty,
-                        &mut body_prelude,
-                        sub_span.clone(),
-                    );
-                }
+                let (prelude, had_error) = self.lower_constructor_payload_aggregates(
+                    name,
+                    patterns,
+                    &scrutinee_hir.ty,
+                    &mut bindings,
+                    "match-expression-substrate",
+                );
+                body_prelude = prelude;
+                binding_error |= had_error;
             }
             if binding_error {
                 let _ = self.lower_expr(&arm.body, IntentKind::Read);
@@ -22604,10 +22731,21 @@ fn collect_general_closure_captures_walk_block(
             }
             HirStmtKind::LetElse {
                 scrutinee,
+                success_prelude,
                 else_body,
                 ..
             } => {
                 collect_general_closure_captures_walk(scrutinee, outer_bindings, seen, captures);
+                for prelude_stmt in success_prelude {
+                    if let HirStmtKind::Let(_, Some(value)) = &prelude_stmt.kind {
+                        collect_general_closure_captures_walk(
+                            value,
+                            outer_bindings,
+                            seen,
+                            captures,
+                        );
+                    }
+                }
                 collect_general_closure_captures_walk_block(
                     else_body,
                     outer_bindings,
@@ -22647,10 +22785,16 @@ fn collect_captures_walk_block(
             }
             HirStmtKind::LetElse {
                 scrutinee,
+                success_prelude,
                 else_body,
                 ..
             } => {
                 collect_captures_walk(scrutinee, param_ids, seen, captures, self_id);
+                for prelude_stmt in success_prelude {
+                    if let HirStmtKind::Let(_, Some(value)) = &prelude_stmt.kind {
+                        collect_captures_walk(value, param_ids, seen, captures, self_id);
+                    }
+                }
                 collect_captures_walk_block(else_body, param_ids, seen, captures, self_id);
             }
         }
@@ -22975,35 +23119,59 @@ fn collect_hir_emitted_events_in_block(
     out: &mut Vec<String>,
 ) {
     for stmt in &block.statements {
-        match &stmt.kind {
-            HirStmtKind::Expr(e) | HirStmtKind::Let(_, Some(e)) | HirStmtKind::Return(Some(e)) => {
-                collect_hir_emitted_events_walk(e, event_names, out);
-            }
-            HirStmtKind::Assign { value, .. } => {
-                collect_hir_emitted_events_walk(value, event_names, out);
-            }
-            HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
-            HirStmtKind::Defer { body, .. } => {
-                collect_hir_emitted_events_walk(body, event_names, out);
-            }
-            HirStmtKind::LetElse {
-                scrutinee,
-                else_body,
-                ..
-            } => {
-                collect_hir_emitted_events_walk(scrutinee, event_names, out);
-                collect_hir_emitted_events_in_block(else_body, event_names, out);
-            }
-        }
+        collect_hir_emitted_events_in_stmt(stmt, event_names, out);
     }
     if let Some(tail) = &block.tail {
         collect_hir_emitted_events_walk(tail, event_names, out);
     }
 }
 
+/// Walk one HIR statement for machine-emit event names. Centralised so every
+/// block-bearing walker (the `_in_block` helper plus the inline `Block` /
+/// `GenBlock` / etc. arms) reaches an identical set of emit-bearing
+/// sub-expressions — including the let-else success prelude.
+fn collect_hir_emitted_events_in_stmt(
+    stmt: &HirStmt,
+    event_names: &[String],
+    out: &mut Vec<String>,
+) {
+    match &stmt.kind {
+        HirStmtKind::Expr(e) | HirStmtKind::Let(_, Some(e)) | HirStmtKind::Return(Some(e)) => {
+            collect_hir_emitted_events_walk(e, event_names, out);
+        }
+        HirStmtKind::Assign { value, .. } => {
+            collect_hir_emitted_events_walk(value, event_names, out);
+        }
+        HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
+        HirStmtKind::Defer { body, .. } => {
+            collect_hir_emitted_events_walk(body, event_names, out);
+        }
+        HirStmtKind::LetElse {
+            scrutinee,
+            success_prelude,
+            else_body,
+            ..
+        } => {
+            collect_hir_emitted_events_walk(scrutinee, event_names, out);
+            for prelude_stmt in success_prelude {
+                collect_hir_emitted_events_in_stmt(prelude_stmt, event_names, out);
+            }
+            collect_hir_emitted_events_in_block(else_body, event_names, out);
+        }
+    }
+}
+
 #[allow(
     clippy::too_many_lines,
     reason = "single recursive walker spanning all HirExprKind variants"
+)]
+#[allow(
+    clippy::match_same_arms,
+    reason = "block-bearing variants (GenBlock / Scope / ForkBlock / While / \
+              ForRange / WhileLet / Loop) all delegate to \
+              collect_hir_emitted_events_in_block but are kept as distinct arms \
+              so a new variant forces an explicit per-variant decision rather \
+              than silently joining a merged arm"
 )]
 fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: &mut Vec<String>) {
     match &expr.kind {
@@ -23017,63 +23185,10 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
             }
         }
         HirExprKind::Block(block) => {
-            for stmt in &block.statements {
-                match &stmt.kind {
-                    HirStmtKind::Expr(e)
-                    | HirStmtKind::Let(_, Some(e))
-                    | HirStmtKind::Return(Some(e)) => {
-                        collect_hir_emitted_events_walk(e, event_names, out);
-                    }
-                    HirStmtKind::Assign { value, .. } => {
-                        // Assignment targets are never emit-bearing expressions.
-                        collect_hir_emitted_events_walk(value, event_names, out);
-                    }
-                    HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
-                    HirStmtKind::Defer { body, .. } => {
-                        collect_hir_emitted_events_walk(body, event_names, out);
-                    }
-                    HirStmtKind::LetElse {
-                        scrutinee,
-                        else_body,
-                        ..
-                    } => {
-                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
-                        collect_hir_emitted_events_in_block(else_body, event_names, out);
-                    }
-                }
-            }
-            if let Some(tail) = &block.tail {
-                collect_hir_emitted_events_walk(tail, event_names, out);
-            }
+            collect_hir_emitted_events_in_block(block, event_names, out);
         }
         HirExprKind::GenBlock { body, .. } => {
-            for stmt in &body.statements {
-                match &stmt.kind {
-                    HirStmtKind::Expr(e)
-                    | HirStmtKind::Let(_, Some(e))
-                    | HirStmtKind::Return(Some(e)) => {
-                        collect_hir_emitted_events_walk(e, event_names, out);
-                    }
-                    HirStmtKind::Assign { value, .. } => {
-                        collect_hir_emitted_events_walk(value, event_names, out);
-                    }
-                    HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
-                    HirStmtKind::Defer { body, .. } => {
-                        collect_hir_emitted_events_walk(body, event_names, out);
-                    }
-                    HirStmtKind::LetElse {
-                        scrutinee,
-                        else_body,
-                        ..
-                    } => {
-                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
-                        collect_hir_emitted_events_in_block(else_body, event_names, out);
-                    }
-                }
-            }
-            if let Some(tail) = &body.tail {
-                collect_hir_emitted_events_walk(tail, event_names, out);
-            }
+            collect_hir_emitted_events_in_block(body, event_names, out);
         }
         HirExprKind::Yield {
             value: Some(value), ..
@@ -23169,95 +23284,17 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
             collect_hir_emitted_events_walk(object, event_names, out);
         }
         HirExprKind::Scope { body } | HirExprKind::ForkBlock { body, .. } => {
-            for stmt in &body.statements {
-                match &stmt.kind {
-                    HirStmtKind::Expr(e)
-                    | HirStmtKind::Let(_, Some(e))
-                    | HirStmtKind::Return(Some(e)) => {
-                        collect_hir_emitted_events_walk(e, event_names, out);
-                    }
-                    HirStmtKind::Assign { value, .. } => {
-                        collect_hir_emitted_events_walk(value, event_names, out);
-                    }
-                    HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
-                    HirStmtKind::Defer { body, .. } => {
-                        collect_hir_emitted_events_walk(body, event_names, out);
-                    }
-                    HirStmtKind::LetElse {
-                        scrutinee,
-                        else_body,
-                        ..
-                    } => {
-                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
-                        collect_hir_emitted_events_in_block(else_body, event_names, out);
-                    }
-                }
-            }
-            if let Some(tail) = &body.tail {
-                collect_hir_emitted_events_walk(tail, event_names, out);
-            }
+            collect_hir_emitted_events_in_block(body, event_names, out);
         }
         HirExprKind::ScopeDeadline { duration, body } => {
             collect_hir_emitted_events_walk(duration, event_names, out);
-            for stmt in &body.statements {
-                match &stmt.kind {
-                    HirStmtKind::Expr(e)
-                    | HirStmtKind::Let(_, Some(e))
-                    | HirStmtKind::Return(Some(e)) => {
-                        collect_hir_emitted_events_walk(e, event_names, out);
-                    }
-                    HirStmtKind::Assign { value, .. } => {
-                        collect_hir_emitted_events_walk(value, event_names, out);
-                    }
-                    HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
-                    HirStmtKind::Defer { body, .. } => {
-                        collect_hir_emitted_events_walk(body, event_names, out);
-                    }
-                    HirStmtKind::LetElse {
-                        scrutinee,
-                        else_body,
-                        ..
-                    } => {
-                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
-                        collect_hir_emitted_events_in_block(else_body, event_names, out);
-                    }
-                }
-            }
-            if let Some(tail) = &body.tail {
-                collect_hir_emitted_events_walk(tail, event_names, out);
-            }
+            collect_hir_emitted_events_in_block(body, event_names, out);
         }
         HirExprKind::While {
             condition, body, ..
         } => {
             collect_hir_emitted_events_walk(condition, event_names, out);
-            for stmt in &body.statements {
-                match &stmt.kind {
-                    HirStmtKind::Expr(e)
-                    | HirStmtKind::Let(_, Some(e))
-                    | HirStmtKind::Return(Some(e)) => {
-                        collect_hir_emitted_events_walk(e, event_names, out);
-                    }
-                    HirStmtKind::Assign { value, .. } => {
-                        collect_hir_emitted_events_walk(value, event_names, out);
-                    }
-                    HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
-                    HirStmtKind::Defer { body, .. } => {
-                        collect_hir_emitted_events_walk(body, event_names, out);
-                    }
-                    HirStmtKind::LetElse {
-                        scrutinee,
-                        else_body,
-                        ..
-                    } => {
-                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
-                        collect_hir_emitted_events_in_block(else_body, event_names, out);
-                    }
-                }
-            }
-            if let Some(tail) = &body.tail {
-                collect_hir_emitted_events_walk(tail, event_names, out);
-            }
+            collect_hir_emitted_events_in_block(body, event_names, out);
         }
         HirExprKind::ForRange {
             start,
@@ -23269,65 +23306,13 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
             collect_hir_emitted_events_walk(start, event_names, out);
             collect_hir_emitted_events_walk(end, event_names, out);
             collect_hir_emitted_events_walk(step, event_names, out);
-            for stmt in &body.statements {
-                match &stmt.kind {
-                    HirStmtKind::Expr(e)
-                    | HirStmtKind::Let(_, Some(e))
-                    | HirStmtKind::Return(Some(e)) => {
-                        collect_hir_emitted_events_walk(e, event_names, out);
-                    }
-                    HirStmtKind::Assign { value, .. } => {
-                        collect_hir_emitted_events_walk(value, event_names, out);
-                    }
-                    HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
-                    HirStmtKind::Defer { body, .. } => {
-                        collect_hir_emitted_events_walk(body, event_names, out);
-                    }
-                    HirStmtKind::LetElse {
-                        scrutinee,
-                        else_body,
-                        ..
-                    } => {
-                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
-                        collect_hir_emitted_events_in_block(else_body, event_names, out);
-                    }
-                }
-            }
-            if let Some(tail) = &body.tail {
-                collect_hir_emitted_events_walk(tail, event_names, out);
-            }
+            collect_hir_emitted_events_in_block(body, event_names, out);
         }
         HirExprKind::WhileLet {
             scrutinee, body, ..
         } => {
             collect_hir_emitted_events_walk(scrutinee, event_names, out);
-            for stmt in &body.statements {
-                match &stmt.kind {
-                    HirStmtKind::Expr(e)
-                    | HirStmtKind::Let(_, Some(e))
-                    | HirStmtKind::Return(Some(e)) => {
-                        collect_hir_emitted_events_walk(e, event_names, out);
-                    }
-                    HirStmtKind::Assign { value, .. } => {
-                        collect_hir_emitted_events_walk(value, event_names, out);
-                    }
-                    HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
-                    HirStmtKind::Defer { body, .. } => {
-                        collect_hir_emitted_events_walk(body, event_names, out);
-                    }
-                    HirStmtKind::LetElse {
-                        scrutinee,
-                        else_body,
-                        ..
-                    } => {
-                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
-                        collect_hir_emitted_events_in_block(else_body, event_names, out);
-                    }
-                }
-            }
-            if let Some(tail) = &body.tail {
-                collect_hir_emitted_events_walk(tail, event_names, out);
-            }
+            collect_hir_emitted_events_in_block(body, event_names, out);
         }
         HirExprKind::IfLet {
             scrutinee,
@@ -23337,33 +23322,7 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
         } => {
             collect_hir_emitted_events_walk(scrutinee, event_names, out);
             for block in std::iter::once(body).chain(else_body.as_ref()) {
-                for stmt in &block.statements {
-                    match &stmt.kind {
-                        HirStmtKind::Expr(e)
-                        | HirStmtKind::Let(_, Some(e))
-                        | HirStmtKind::Return(Some(e)) => {
-                            collect_hir_emitted_events_walk(e, event_names, out);
-                        }
-                        HirStmtKind::Assign { value, .. } => {
-                            collect_hir_emitted_events_walk(value, event_names, out);
-                        }
-                        HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
-                        HirStmtKind::Defer { body, .. } => {
-                            collect_hir_emitted_events_walk(body, event_names, out);
-                        }
-                        HirStmtKind::LetElse {
-                            scrutinee,
-                            else_body,
-                            ..
-                        } => {
-                            collect_hir_emitted_events_walk(scrutinee, event_names, out);
-                            collect_hir_emitted_events_in_block(else_body, event_names, out);
-                        }
-                    }
-                }
-                if let Some(tail) = &block.tail {
-                    collect_hir_emitted_events_walk(tail, event_names, out);
-                }
+                collect_hir_emitted_events_in_block(block, event_names, out);
             }
         }
         HirExprKind::Break { value, .. } | HirExprKind::Return { value } => {
@@ -23372,33 +23331,7 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
             }
         }
         HirExprKind::Loop { body, .. } => {
-            for stmt in &body.statements {
-                match &stmt.kind {
-                    HirStmtKind::Expr(e)
-                    | HirStmtKind::Let(_, Some(e))
-                    | HirStmtKind::Return(Some(e)) => {
-                        collect_hir_emitted_events_walk(e, event_names, out);
-                    }
-                    HirStmtKind::Assign { value, .. } => {
-                        collect_hir_emitted_events_walk(value, event_names, out);
-                    }
-                    HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
-                    HirStmtKind::Defer { body, .. } => {
-                        collect_hir_emitted_events_walk(body, event_names, out);
-                    }
-                    HirStmtKind::LetElse {
-                        scrutinee,
-                        else_body,
-                        ..
-                    } => {
-                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
-                        collect_hir_emitted_events_in_block(else_body, event_names, out);
-                    }
-                }
-            }
-            if let Some(tail) = &body.tail {
-                collect_hir_emitted_events_walk(tail, event_names, out);
-            }
+            collect_hir_emitted_events_in_block(body, event_names, out);
         }
         HirExprKind::TupleIndex { tuple, .. } => {
             collect_hir_emitted_events_walk(tuple, event_names, out);
@@ -25947,10 +25880,16 @@ fn scan_block_for_call_shape(
             }
             HirStmtKind::LetElse {
                 scrutinee,
+                success_prelude,
                 else_body,
                 ..
             } => {
                 scan_expr_for_call_shape(scrutinee, callable, diagnostics);
+                for prelude_stmt in success_prelude {
+                    if let HirStmtKind::Let(_, Some(init)) = &prelude_stmt.kind {
+                        scan_expr_for_call_shape(init, callable, diagnostics);
+                    }
+                }
                 scan_block_for_call_shape(else_body, callable, diagnostics);
             }
         }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -3773,6 +3773,14 @@ fn collect_call_sites_in_stmt(
         HirStmtKind::Defer { body, .. } => {
             collect_call_sites_in_expr(body, out, trait_out);
         }
+        HirStmtKind::LetElse {
+            scrutinee,
+            else_body,
+            ..
+        } => {
+            collect_call_sites_in_expr(scrutinee, out, trait_out);
+            collect_call_sites_in_block(else_body, out, trait_out);
+        }
     }
 }
 
@@ -6703,6 +6711,14 @@ impl LowerCtx {
             }
             HirStmtKind::Defer { body, .. } => {
                 self.wrap_var_self_explicit_expr_returns(body, receiver, abi_return_ty);
+            }
+            HirStmtKind::LetElse {
+                scrutinee,
+                else_body,
+                ..
+            } => {
+                self.wrap_var_self_explicit_expr_returns(scrutinee, receiver, abi_return_ty);
+                self.wrap_var_self_explicit_returns_in_block(else_body, receiver, abi_return_ty);
             }
             HirStmtKind::Let(_, None) => {}
         }
@@ -9798,11 +9814,14 @@ impl LowerCtx {
         span: std::ops::Range<usize>,
         return_ty: ResolvedTy,
     ) -> Vec<HirStmt> {
-        // Tuple-let: `let (a, b, ...) = value_expr;`
+        // Tuple-let: `let (a, b, ...) = value_expr;`. A let-else (`else_block:
+        // Some`) is NOT an irrefutable tuple destructure — it routes through
+        // `lower_stmt` → `lower_let_else`, so require `else_block: None` here.
         if let Stmt::Let {
             pattern,
             ty: annotation,
             value: Some(value_expr),
+            else_block: None,
         } = stmt
         {
             if let Pattern::Tuple(element_patterns) = &pattern.0 {
@@ -10447,7 +10466,37 @@ impl LowerCtx {
         return_ty: ResolvedTy,
     ) -> HirStmt {
         let kind = match stmt {
-            Stmt::Let { pattern, ty, value } => {
+            Stmt::Let {
+                pattern,
+                ty,
+                value,
+                else_block,
+            } => {
+                // let-else: `let Pat = scrutinee else { <divergent block> };`.
+                // The Ok-path binders escape into the enclosing scope and the
+                // else block (proven divergent by the checker) runs on a failed
+                // match. Lower to the dedicated `HirStmtKind::LetElse` node and
+                // return early — the ordinary-let machinery below does not apply
+                // (it binds a single name; let-else binds payload fields).
+                if let Some(else_blk) = else_block {
+                    if let Some(value_expr) = value {
+                        if let Some(stmt) =
+                            self.lower_let_else(pattern, value_expr, else_blk, &span)
+                        {
+                            return stmt;
+                        }
+                    }
+                    // Fail-closed: a let-else with no initialiser, or whose
+                    // pattern could not be resolved, lowers to an unsupported
+                    // marker (diagnostics already pushed by lower_let_else).
+                    return HirStmt {
+                        node: self.ids.node(),
+                        kind: HirStmtKind::Expr(
+                            self.unsupported_expr(span.clone(), "let-else lowering"),
+                        ),
+                        span,
+                    };
+                }
                 // `await` on task handles is only legal as a statement-expression
                 // inside a `scope{}` body. Actor asks are value-producing expressions
                 // (the reply lands in MIR's `reply_dest`) and are handled by the
@@ -11372,6 +11421,162 @@ impl LowerCtx {
             kind,
             span,
         }
+    }
+
+    /// Lower `let PAT = scrutinee else { <divergent block> };` to the dedicated
+    /// `HirStmtKind::LetElse` node.
+    ///
+    /// Unlike `lower_if_let_inner`, the success-path payload bindings are
+    /// allocated in the ENCLOSING scope (no `push_scope`/`pop_scope` brackets
+    /// them) so they escape the statement and are live for the rest of the
+    /// enclosing block. The else block is lowered in its own scope and is
+    /// guaranteed divergent by the type checker (it proved `Ty::Never`); MIR
+    /// runs it on the no-match path so control never reaches an unbound binder.
+    ///
+    /// Returns `Some(HirStmt)` on success, `None` on a fail-closed error
+    /// (diagnostics already pushed). Pattern scope mirrors `if let`: only
+    /// single payload-bearing enum-variant constructor patterns (e.g. `Ok(n)`).
+    #[allow(
+        clippy::too_many_lines,
+        reason = "mirrors lower_if_let_inner; splitting would obscure the parallel \
+                  error-handling paths"
+    )]
+    fn lower_let_else(
+        &mut self,
+        pattern: &Spanned<Pattern>,
+        scrutinee_expr: &Spanned<Expr>,
+        else_block: &Block,
+        span: &Span,
+    ) -> Option<HirStmt> {
+        let scrutinee_hir = self.lower_expr(scrutinee_expr, IntentKind::Read);
+        self.try_register_enum_instantiation(&scrutinee_expr.1);
+
+        let pattern_span = &pattern.1;
+        let key = self.mk_key(pattern_span);
+        let Some(resolution) = self.pattern_resolutions.get(&key).cloned() else {
+            self.unsupported(
+                pattern_span.clone(),
+                "let-else pattern has no resolution; \
+                 only single payload-bearing enum-variant patterns are supported",
+                "let-else-substrate",
+            );
+            let _ = self.lower_block(else_block, &ResolvedTy::Unit);
+            return None;
+        };
+
+        let (PatternKind::VariantCtor, Some(variant_match)) =
+            (resolution.pattern_kind, resolution.variant_match)
+        else {
+            self.unsupported(
+                pattern_span.clone(),
+                "let-else supports only payload-bearing enum-variant patterns \
+                 (e.g. `Ok(n)`); unit variants, wildcards, literals, plain \
+                 bindings, and or-patterns are reserved for a future lane",
+                "let-else-substrate",
+            );
+            let _ = self.lower_block(else_block, &ResolvedTy::Unit);
+            return None;
+        };
+
+        let qualified = format!(
+            "{}::{}",
+            variant_match.type_name, variant_match.variant_name
+        );
+        let Some((_, idx_usize)) = self.machine_ctor_registry.get(&qualified).cloned() else {
+            self.unsupported(
+                pattern_span.clone(),
+                "let-else variant not registered in machine/enum ctor registry",
+                "let-else-substrate",
+            );
+            let _ = self.lower_block(else_block, &ResolvedTy::Unit);
+            return None;
+        };
+        let variant_idx =
+            u32::try_from(idx_usize).expect("variant index exceeds u32::MAX — impossible in Hew");
+
+        // Build the payload-binding specs (same shape as if-let / match).
+        let mut binding_specs = Vec::with_capacity(resolution.payload_bindings.len());
+        let mut binding_error = false;
+        for payload in &resolution.payload_bindings {
+            let ty = match ResolvedTy::from_ty(&payload.ty) {
+                Ok(ty) => ty,
+                Err(err) => {
+                    self.unsupported(
+                        pattern_span.clone(),
+                        format!("unresolved payload binding type in let-else ({err:?})"),
+                        "let-else-substrate",
+                    );
+                    binding_error = true;
+                    continue;
+                }
+            };
+            let Ok(field_idx) = u32::try_from(payload.field_idx) else {
+                self.unsupported(
+                    pattern_span.clone(),
+                    "let-else payload binding field index exceeds u32::MAX",
+                    "let-else-substrate",
+                );
+                binding_error = true;
+                continue;
+            };
+            binding_specs.push((field_idx, payload.binding_name.clone(), ty));
+        }
+
+        // The else block runs on the FAILURE path, where the Ok binders are NOT
+        // in scope. Lower it FIRST, in its own scope, BEFORE binding the
+        // payload into the enclosing scope — so the else block cannot see the
+        // escaping binders (matching the checker's failure-path scoping).
+        self.push_scope();
+        let else_body = self.lower_block(else_block, &ResolvedTy::Unit);
+        self.pop_scope();
+
+        // Bind the payload fields into the ENCLOSING scope (no push/pop) so the
+        // Ok-path binders escape and are live for the rest of the enclosing
+        // block — the defining property of let-else.
+        let bindings: Vec<HirMatchArmBinding> = if binding_error {
+            Vec::new()
+        } else {
+            binding_specs
+                .into_iter()
+                .map(|(field_idx, name, ty)| {
+                    let bound = self.bind(name.clone(), ty.clone(), false, pattern_span.clone());
+                    HirMatchArmBinding {
+                        binding: bound.id,
+                        field_idx,
+                        name,
+                        ty,
+                    }
+                })
+                .collect()
+        };
+
+        let mut payload_variant_predicates =
+            Vec::with_capacity(resolution.payload_variant_patterns.len());
+        let mut pvp_error = false;
+        for pvp in &resolution.payload_variant_patterns {
+            if let Some(pred) = self.build_payload_variant_predicate(pvp, pattern_span) {
+                payload_variant_predicates.push(pred);
+            } else {
+                pvp_error = true;
+                break;
+            }
+        }
+
+        if binding_error || pvp_error {
+            return None;
+        }
+
+        Some(HirStmt {
+            node: self.ids.node(),
+            kind: HirStmtKind::LetElse {
+                scrutinee: Box::new(scrutinee_hir),
+                variant_idx,
+                bindings,
+                payload_variant_predicates,
+                else_body,
+            },
+            span: span.clone(),
+        })
     }
 
     /// Shared core of `if let PAT = scrutinee { body } else { else_body }`.
@@ -22397,6 +22602,19 @@ fn collect_general_closure_captures_walk_block(
             HirStmtKind::Defer { body, .. } => {
                 collect_general_closure_captures_walk(body, outer_bindings, seen, captures);
             }
+            HirStmtKind::LetElse {
+                scrutinee,
+                else_body,
+                ..
+            } => {
+                collect_general_closure_captures_walk(scrutinee, outer_bindings, seen, captures);
+                collect_general_closure_captures_walk_block(
+                    else_body,
+                    outer_bindings,
+                    seen,
+                    captures,
+                );
+            }
         }
     }
     if let Some(tail) = &block.tail {
@@ -22426,6 +22644,14 @@ fn collect_captures_walk_block(
             HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
             HirStmtKind::Defer { body, .. } => {
                 collect_captures_walk(body, param_ids, seen, captures, self_id);
+            }
+            HirStmtKind::LetElse {
+                scrutinee,
+                else_body,
+                ..
+            } => {
+                collect_captures_walk(scrutinee, param_ids, seen, captures, self_id);
+                collect_captures_walk_block(else_body, param_ids, seen, captures, self_id);
             }
         }
     }
@@ -22739,6 +22965,42 @@ fn collect_hir_emitted_events(expr: &HirExpr, event_names: &[String]) -> Vec<Str
     events
 }
 
+/// Walk every statement and the tail of a `HirBlock`, collecting machine-emit
+/// event names. Used by the let-else arm (whose `else_body` is a `HirBlock`,
+/// not an `Expr::Block`) so a self-emit inside a let-else fallback is counted
+/// by the emit-cycle check.
+fn collect_hir_emitted_events_in_block(
+    block: &HirBlock,
+    event_names: &[String],
+    out: &mut Vec<String>,
+) {
+    for stmt in &block.statements {
+        match &stmt.kind {
+            HirStmtKind::Expr(e) | HirStmtKind::Let(_, Some(e)) | HirStmtKind::Return(Some(e)) => {
+                collect_hir_emitted_events_walk(e, event_names, out);
+            }
+            HirStmtKind::Assign { value, .. } => {
+                collect_hir_emitted_events_walk(value, event_names, out);
+            }
+            HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
+            HirStmtKind::Defer { body, .. } => {
+                collect_hir_emitted_events_walk(body, event_names, out);
+            }
+            HirStmtKind::LetElse {
+                scrutinee,
+                else_body,
+                ..
+            } => {
+                collect_hir_emitted_events_walk(scrutinee, event_names, out);
+                collect_hir_emitted_events_in_block(else_body, event_names, out);
+            }
+        }
+    }
+    if let Some(tail) = &block.tail {
+        collect_hir_emitted_events_walk(tail, event_names, out);
+    }
+}
+
 #[allow(
     clippy::too_many_lines,
     reason = "single recursive walker spanning all HirExprKind variants"
@@ -22770,6 +23032,14 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
                     HirStmtKind::Defer { body, .. } => {
                         collect_hir_emitted_events_walk(body, event_names, out);
                     }
+                    HirStmtKind::LetElse {
+                        scrutinee,
+                        else_body,
+                        ..
+                    } => {
+                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
+                        collect_hir_emitted_events_in_block(else_body, event_names, out);
+                    }
                 }
             }
             if let Some(tail) = &block.tail {
@@ -22790,6 +23060,14 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
                     HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
                     HirStmtKind::Defer { body, .. } => {
                         collect_hir_emitted_events_walk(body, event_names, out);
+                    }
+                    HirStmtKind::LetElse {
+                        scrutinee,
+                        else_body,
+                        ..
+                    } => {
+                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
+                        collect_hir_emitted_events_in_block(else_body, event_names, out);
                     }
                 }
             }
@@ -22905,6 +23183,14 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
                     HirStmtKind::Defer { body, .. } => {
                         collect_hir_emitted_events_walk(body, event_names, out);
                     }
+                    HirStmtKind::LetElse {
+                        scrutinee,
+                        else_body,
+                        ..
+                    } => {
+                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
+                        collect_hir_emitted_events_in_block(else_body, event_names, out);
+                    }
                 }
             }
             if let Some(tail) = &body.tail {
@@ -22926,6 +23212,14 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
                     HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
                     HirStmtKind::Defer { body, .. } => {
                         collect_hir_emitted_events_walk(body, event_names, out);
+                    }
+                    HirStmtKind::LetElse {
+                        scrutinee,
+                        else_body,
+                        ..
+                    } => {
+                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
+                        collect_hir_emitted_events_in_block(else_body, event_names, out);
                     }
                 }
             }
@@ -22950,6 +23244,14 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
                     HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
                     HirStmtKind::Defer { body, .. } => {
                         collect_hir_emitted_events_walk(body, event_names, out);
+                    }
+                    HirStmtKind::LetElse {
+                        scrutinee,
+                        else_body,
+                        ..
+                    } => {
+                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
+                        collect_hir_emitted_events_in_block(else_body, event_names, out);
                     }
                 }
             }
@@ -22981,6 +23283,14 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
                     HirStmtKind::Defer { body, .. } => {
                         collect_hir_emitted_events_walk(body, event_names, out);
                     }
+                    HirStmtKind::LetElse {
+                        scrutinee,
+                        else_body,
+                        ..
+                    } => {
+                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
+                        collect_hir_emitted_events_in_block(else_body, event_names, out);
+                    }
                 }
             }
             if let Some(tail) = &body.tail {
@@ -23004,6 +23314,14 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
                     HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
                     HirStmtKind::Defer { body, .. } => {
                         collect_hir_emitted_events_walk(body, event_names, out);
+                    }
+                    HirStmtKind::LetElse {
+                        scrutinee,
+                        else_body,
+                        ..
+                    } => {
+                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
+                        collect_hir_emitted_events_in_block(else_body, event_names, out);
                     }
                 }
             }
@@ -23033,6 +23351,14 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
                         HirStmtKind::Defer { body, .. } => {
                             collect_hir_emitted_events_walk(body, event_names, out);
                         }
+                        HirStmtKind::LetElse {
+                            scrutinee,
+                            else_body,
+                            ..
+                        } => {
+                            collect_hir_emitted_events_walk(scrutinee, event_names, out);
+                            collect_hir_emitted_events_in_block(else_body, event_names, out);
+                        }
                     }
                 }
                 if let Some(tail) = &block.tail {
@@ -23059,6 +23385,14 @@ fn collect_hir_emitted_events_walk(expr: &HirExpr, event_names: &[String], out: 
                     HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
                     HirStmtKind::Defer { body, .. } => {
                         collect_hir_emitted_events_walk(body, event_names, out);
+                    }
+                    HirStmtKind::LetElse {
+                        scrutinee,
+                        else_body,
+                        ..
+                    } => {
+                        collect_hir_emitted_events_walk(scrutinee, event_names, out);
+                        collect_hir_emitted_events_in_block(else_body, event_names, out);
                     }
                 }
             }
@@ -25610,6 +25944,14 @@ fn scan_block_for_call_shape(
             HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
             HirStmtKind::Defer { body, .. } => {
                 scan_expr_for_call_shape(body, callable, diagnostics);
+            }
+            HirStmtKind::LetElse {
+                scrutinee,
+                else_body,
+                ..
+            } => {
+                scan_expr_for_call_shape(scrutinee, callable, diagnostics);
+                scan_block_for_call_shape(else_body, callable, diagnostics);
             }
         }
     }

--- a/hew-hir/src/machine_mono.rs
+++ b/hew-hir/src/machine_mono.rs
@@ -1905,7 +1905,7 @@ fn walk_expr(
                 );
             }
         }
-        HirExprKind::Break { value, .. } => {
+        HirExprKind::Break { value, .. } | HirExprKind::Return { value } => {
             if let Some(value) = value {
                 walk_expr(
                     value,

--- a/hew-hir/src/machine_mono.rs
+++ b/hew-hir/src/machine_mono.rs
@@ -1023,6 +1023,7 @@ fn walk_stmt(
         HirStmtKind::LetElse {
             scrutinee,
             bindings,
+            success_prelude,
             else_body,
             ..
         } => {
@@ -1041,6 +1042,22 @@ fn walk_stmt(
                 visit_ty(
                     &binding.ty,
                     &scrutinee.span,
+                    subst,
+                    machine_decls,
+                    residual_domain,
+                    seen,
+                    order,
+                    cap,
+                    diagnostics,
+                    cap_diag_emitted,
+                );
+            }
+            // Aggregate-payload leaf binders (`Ok((n, s))`) and their
+            // projection values may reach machine types not named elsewhere;
+            // walk the prelude so discovery stays complete.
+            for prelude_stmt in success_prelude {
+                walk_stmt(
+                    prelude_stmt,
                     subst,
                     machine_decls,
                     residual_domain,

--- a/hew-hir/src/machine_mono.rs
+++ b/hew-hir/src/machine_mono.rs
@@ -927,6 +927,7 @@ fn walk_block(
 
 #[allow(
     clippy::too_many_arguments,
+    clippy::too_many_lines,
     reason = "discovery walker plumbs shared mutable state (seen/order/diagnostics/cap/registries/subst) — refactoring to a struct-with-methods is deferred"
 )]
 fn walk_stmt(
@@ -1009,6 +1010,49 @@ fn walk_stmt(
         HirStmtKind::Defer { body, .. } => {
             walk_expr(
                 body,
+                subst,
+                machine_decls,
+                residual_domain,
+                seen,
+                order,
+                cap,
+                diagnostics,
+                cap_diag_emitted,
+            );
+        }
+        HirStmtKind::LetElse {
+            scrutinee,
+            bindings,
+            else_body,
+            ..
+        } => {
+            walk_expr(
+                scrutinee,
+                subst,
+                machine_decls,
+                residual_domain,
+                seen,
+                order,
+                cap,
+                diagnostics,
+                cap_diag_emitted,
+            );
+            for binding in bindings {
+                visit_ty(
+                    &binding.ty,
+                    &scrutinee.span,
+                    subst,
+                    machine_decls,
+                    residual_domain,
+                    seen,
+                    order,
+                    cap,
+                    diagnostics,
+                    cap_diag_emitted,
+                );
+            }
+            walk_block(
+                else_body,
                 subst,
                 machine_decls,
                 residual_domain,

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -1051,8 +1051,19 @@ pub enum HirStmtKind {
         /// index of `Ok` in `Result`).
         variant_idx: u32,
         /// Payload bindings introduced by the success-path pattern. These are
-        /// allocated in the ENCLOSING scope and escape the statement.
+        /// allocated in the ENCLOSING scope and escape the statement. For an
+        /// aggregate payload field (e.g. the tuple in `Ok((n, s))`) this holds
+        /// a synthetic `__payload_*` temp binding for the whole field; the
+        /// nested leaf binders (`n`, `s`) are produced by `success_prelude`.
         bindings: Vec<HirMatchArmBinding>,
+        /// Destructure statements for aggregate payload subpatterns
+        /// (`Ok((n, s))`, `Ok(Point { x, y })`). They run on the SUCCESS path,
+        /// after the top-level payload fields are bound and before the
+        /// continuation, projecting the synthetic `__payload_*` temps into
+        /// their leaf binders. Each is a plain `HirStmtKind::Let`; the leaf
+        /// binders escape into the enclosing scope like the top-level
+        /// `bindings`. Empty when no payload field is an aggregate.
+        success_prelude: Vec<HirStmt>,
         /// Nested constructor checks on payload fields, evaluated after the
         /// outer tag check and before the bindings are made live. A failed
         /// nested check routes to `else_body`, same as a top-level tag

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -1031,6 +1031,37 @@ pub struct HirStmt {
 #[derive(Debug, Clone, PartialEq)]
 pub enum HirStmtKind {
     Let(HirBinding, Option<HirExpr>),
+    /// `let Pat = scrutinee else { <divergent block> };` — the let-else
+    /// bind-or-diverge primitive.
+    ///
+    /// Unlike `HirExprKind::IfLet` (whose payload bindings are scoped to the
+    /// then-body), a let-else's `bindings` ESCAPE into the enclosing scope:
+    /// after the statement, the Ok-path binders are live for the rest of the
+    /// enclosing block. MIR lowers this as: evaluate the scrutinee, test the
+    /// variant tag, and branch — on a match, bind the payload fields into the
+    /// enclosing-scope `binding_locals` (and do NOT restore them, so they
+    /// persist); on a mismatch, run `else_body`, which is GUARANTEED divergent
+    /// (the type checker enforced `Ty::Never`), so control never falls through
+    /// to an unbound binder.
+    LetElse {
+        /// The matched expression. Its resolved type is the enum being
+        /// destructured.
+        scrutinee: Box<HirExpr>,
+        /// Zero-based variant index of the success-path constructor (e.g. the
+        /// index of `Ok` in `Result`).
+        variant_idx: u32,
+        /// Payload bindings introduced by the success-path pattern. These are
+        /// allocated in the ENCLOSING scope and escape the statement.
+        bindings: Vec<HirMatchArmBinding>,
+        /// Nested constructor checks on payload fields, evaluated after the
+        /// outer tag check and before the bindings are made live. A failed
+        /// nested check routes to `else_body`, same as a top-level tag
+        /// mismatch.
+        payload_variant_predicates: Vec<HirPayloadVariantPredicate>,
+        /// The divergent else block, run when the pattern fails to match. The
+        /// checker has proven it has type `Ty::Never`.
+        else_body: HirBlock,
+    },
     Assign {
         target: HirExpr,
         value: Box<HirExpr>,

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -2057,6 +2057,17 @@ pub enum HirExprKind {
         label: Option<String>,
         value: Option<Box<HirExpr>>,
     },
+    /// `return [expr]` in expression position — a divergent (`Never`-typed)
+    /// early exit from the enclosing function. Sibling of `Break`: a Never-typed
+    /// leaf that MIR seals with `Terminator::Return` (running deferred cleanup
+    /// first), then starts a fresh dead cursor block for any following code.
+    ///
+    /// `value` carries the operand of `return <value>`; `None` is a value-less
+    /// `return` (unit return). The checker has already type-checked the operand
+    /// against the function's declared return type and synthesized `Never`.
+    Return {
+        value: Option<Box<HirExpr>>,
+    },
     /// `continue;` / `continue @label;` — skip to the next iteration of the
     /// innermost enclosing loop, or of the nearest enclosing loop carrying the
     /// requested label, transferring control to that loop's continue target (the

--- a/hew-hir/src/verify.rs
+++ b/hew-hir/src/verify.rs
@@ -172,6 +172,7 @@ impl Verifier {
                 HirStmtKind::LetElse {
                     scrutinee,
                     bindings,
+                    success_prelude,
                     else_body,
                     ..
                 } => {
@@ -180,6 +181,19 @@ impl Verifier {
                     // register them here so later references resolve.
                     for binding in bindings {
                         self.binding(binding.binding, scrutinee.span.clone());
+                    }
+                    // Aggregate payload destructure (e.g. `Ok((n, s))`): the
+                    // prelude's `Let` statements introduce the leaf binders
+                    // (`n`, `s`) that also escape into the enclosing scope.
+                    // Register them and verify their projection values so a
+                    // later reference resolves and is not flagged unresolved.
+                    for prelude_stmt in success_prelude {
+                        if let HirStmtKind::Let(binding, value) = &prelude_stmt.kind {
+                            self.binding(binding.id, binding.span.clone());
+                            if let Some(value) = value {
+                                self.expr(value);
+                            }
+                        }
                     }
                     self.block(else_body);
                 }

--- a/hew-hir/src/verify.rs
+++ b/hew-hir/src/verify.rs
@@ -169,6 +169,20 @@ impl Verifier {
                 HirStmtKind::Expr(expr) | HirStmtKind::Return(Some(expr)) => self.expr(expr),
                 HirStmtKind::Return(None) => {}
                 HirStmtKind::Defer { body, .. } => self.expr(body),
+                HirStmtKind::LetElse {
+                    scrutinee,
+                    bindings,
+                    else_body,
+                    ..
+                } => {
+                    self.expr(scrutinee);
+                    // The Ok-path bindings escape into the enclosing scope —
+                    // register them here so later references resolve.
+                    for binding in bindings {
+                        self.binding(binding.binding, scrutinee.span.clone());
+                    }
+                    self.block(else_body);
+                }
             }
         }
         if let Some(tail) = &block.tail {

--- a/hew-hir/src/verify.rs
+++ b/hew-hir/src/verify.rs
@@ -712,7 +712,7 @@ impl Verifier {
                     self.block(eb);
                 }
             }
-            HirExprKind::Break { value, .. } => {
+            HirExprKind::Break { value, .. } | HirExprKind::Return { value } => {
                 if let Some(value) = value {
                     self.expr(value);
                 }

--- a/hew-hir/tests/actor_call_surface.rs
+++ b/hew-hir/tests/actor_call_surface.rs
@@ -80,7 +80,9 @@ fn visit_expr<'a>(expr: &'a HirExpr, out: &mut Vec<&'a HirExpr>) {
         | HirExprKind::Scope { body: block }
         | HirExprKind::ForkBlock { body: block, .. }
         | HirExprKind::GenBlock { body: block, .. } => visit_block(block, out),
-        HirExprKind::Yield { value, .. } | HirExprKind::Break { value, .. } => {
+        HirExprKind::Yield { value, .. }
+        | HirExprKind::Break { value, .. }
+        | HirExprKind::Return { value } => {
             if let Some(value) = value {
                 visit_expr(value, out);
             }

--- a/hew-hir/tests/actor_call_surface.rs
+++ b/hew-hir/tests/actor_call_surface.rs
@@ -245,6 +245,14 @@ fn visit_block<'a>(block: &'a hew_hir::HirBlock, out: &mut Vec<&'a HirExpr>) {
             }
             HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
             HirStmtKind::Defer { body, .. } => visit_expr(body, out),
+            HirStmtKind::LetElse {
+                scrutinee,
+                else_body,
+                ..
+            } => {
+                visit_expr(scrutinee, out);
+                visit_block(else_body, out);
+            }
         }
     }
     if let Some(tail) = &block.tail {

--- a/hew-hir/tests/display_dispatch_lower.rs
+++ b/hew-hir/tests/display_dispatch_lower.rs
@@ -101,6 +101,14 @@ fn walk_block(block: &hew_hir::HirBlock, f: &mut impl FnMut(&HirExpr)) {
             HirStmtKind::Defer { body, .. } => {
                 walk_expr(body, f);
             }
+            HirStmtKind::LetElse {
+                scrutinee,
+                else_body,
+                ..
+            } => {
+                walk_expr(scrutinee, f);
+                walk_block(else_body, f);
+            }
         }
     }
     if let Some(t) = &block.tail {

--- a/hew-hir/tests/loop_break_continue_lower.rs
+++ b/hew-hir/tests/loop_break_continue_lower.rs
@@ -57,6 +57,15 @@ fn block_has_kind<F: Fn(&HirExprKind) -> bool + Copy>(block: &HirBlock, pred: F)
                     return true;
                 }
             }
+            HirStmtKind::LetElse {
+                scrutinee,
+                else_body,
+                ..
+            } => {
+                if expr_has_kind(scrutinee, pred) || block_has_kind(else_body, pred) {
+                    return true;
+                }
+            }
             HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
         }
     }

--- a/hew-hir/tests/m3_surface_pid_lower.rs
+++ b/hew-hir/tests/m3_surface_pid_lower.rs
@@ -74,6 +74,13 @@ fn block_contains_remote_actor_ask(block: &HirBlock) -> bool {
             expr_contains_remote_actor_ask(target) || expr_contains_remote_actor_ask(value)
         }
         HirStmtKind::Defer { body, .. } => expr_contains_remote_actor_ask(body),
+        HirStmtKind::LetElse {
+            scrutinee,
+            else_body,
+            ..
+        } => {
+            expr_contains_remote_actor_ask(scrutinee) || block_contains_remote_actor_ask(else_body)
+        }
         HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => false,
     }) || block
         .tail

--- a/hew-hir/tests/vertical.rs
+++ b/hew-hir/tests/vertical.rs
@@ -1174,6 +1174,7 @@ fn program_with_select(select_expr: Expr) -> Program {
             pattern: (Pattern::Identifier("r".to_string()), 0..1),
             ty: None,
             value: Some((select_expr, 0..1)),
+            else_block: None,
         },
         0..1,
     );

--- a/hew-mir/src/closure_env.rs
+++ b/hew-mir/src/closure_env.rs
@@ -553,6 +553,14 @@ fn walk_stmt_for_suspend(stmt: &hew_hir::HirStmt, found: &mut bool) {
             walk_expr_for_suspend(value, found);
         }
         HirStmtKind::Defer { body, .. } => walk_expr_for_suspend(body, found),
+        HirStmtKind::LetElse {
+            scrutinee,
+            else_body,
+            ..
+        } => {
+            walk_expr_for_suspend(scrutinee, found);
+            walk_block_for_suspend(else_body, found);
+        }
         HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}
     }
 }

--- a/hew-mir/src/closure_env.rs
+++ b/hew-mir/src/closure_env.rs
@@ -555,10 +555,17 @@ fn walk_stmt_for_suspend(stmt: &hew_hir::HirStmt, found: &mut bool) {
         HirStmtKind::Defer { body, .. } => walk_expr_for_suspend(body, found),
         HirStmtKind::LetElse {
             scrutinee,
+            success_prelude,
             else_body,
             ..
         } => {
             walk_expr_for_suspend(scrutinee, found);
+            for prelude_stmt in success_prelude {
+                walk_stmt_for_suspend(prelude_stmt, found);
+                if *found {
+                    return;
+                }
+            }
             walk_block_for_suspend(else_body, found);
         }
         HirStmtKind::Let(_, None) | HirStmtKind::Return(None) => {}

--- a/hew-mir/src/closure_env.rs
+++ b/hew-mir/src/closure_env.rs
@@ -510,7 +510,7 @@ fn walk_expr_for_suspend(expr: &HirExpr, found: &mut bool) {
             }
         }
         HirExprKind::Loop { body, .. } => walk_block_for_suspend(body, found),
-        HirExprKind::Break { value, .. } => {
+        HirExprKind::Break { value, .. } | HirExprKind::Return { value } => {
             if let Some(value) = value {
                 walk_expr_for_suspend(value, found);
             }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -4359,10 +4359,16 @@ fn collect_unknown_self_fields_in_block(
             }
             HirStmtKind::LetElse {
                 scrutinee,
+                success_prelude,
                 else_body,
                 ..
             } => {
                 collect_unknown_self_fields_in_expr(scrutinee, state_fields, seen, unknown);
+                for prelude_stmt in success_prelude {
+                    if let HirStmtKind::Let(_, Some(value)) = &prelude_stmt.kind {
+                        collect_unknown_self_fields_in_expr(value, state_fields, seen, unknown);
+                    }
+                }
                 collect_unknown_self_fields_in_block(else_body, state_fields, seen, unknown);
             }
         }
@@ -8258,6 +8264,7 @@ impl Builder {
                 scrutinee,
                 variant_idx,
                 bindings,
+                success_prelude,
                 payload_variant_predicates,
                 else_body,
             } => {
@@ -8265,6 +8272,7 @@ impl Builder {
                     scrutinee,
                     *variant_idx,
                     bindings,
+                    success_prelude,
                     payload_variant_predicates,
                     else_body,
                 );
@@ -8292,6 +8300,7 @@ impl Builder {
         scrutinee: &HirExpr,
         variant_idx: u32,
         bindings: &[hew_hir::HirMatchArmBinding],
+        success_prelude: &[hew_hir::HirStmt],
         payload_variant_predicates: &[hew_hir::HirPayloadVariantPredicate],
         else_body: &hew_hir::HirBlock,
     ) {
@@ -8417,6 +8426,15 @@ impl Builder {
                 },
             });
             self.binding_locals.insert(binding.binding, dest);
+        }
+        // Aggregate-payload destructure (`Ok((n, s))`): the prelude `Let`
+        // statements project the synthetic `__payload_*` temp into the leaf
+        // binders (`n`, `s`). They run on the SUCCESS path after the top-level
+        // payload fields bind, and like those fields their binding_locals are
+        // inserted (by the normal `Let` lowering) and never restored, so the
+        // leaf binders escape into the enclosing scope for the continuation.
+        for stmt in success_prelude {
+            self.stmt(stmt);
         }
         self.finish_current_block(Terminator::Goto { target: cont_bb });
 

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -4453,7 +4453,9 @@ fn collect_unknown_self_fields_in_expr(
         | HirExprKind::GenBlock { body: block, .. } => {
             collect_unknown_self_fields_in_block(block, state_fields, seen, unknown);
         }
-        HirExprKind::Yield { value, .. } | HirExprKind::Break { value, .. } => {
+        HirExprKind::Yield { value, .. }
+        | HirExprKind::Break { value, .. }
+        | HirExprKind::Return { value } => {
             if let Some(value) = value {
                 collect_unknown_self_fields_in_expr(value, state_fields, seen, unknown);
             }
@@ -10770,6 +10772,41 @@ impl Builder {
                     target: frame.exit_target,
                 });
                 // Source following `break` lexically is dead; give it a home.
+                let dead = self.alloc_block();
+                self.start_dead_block(dead);
+                None
+            }
+            HirExprKind::Return { value } => {
+                // `return [expr]` in expression position. Reuse the EXACT
+                // seal-and-dead-block discipline as `HirStmtKind::Return`
+                // (LESSONS `one-construct-one-lowering-shell`): lower the
+                // operand, move it to ReturnSlot BEFORE running defers (so
+                // defers cannot corrupt the secured value), emit return-path
+                // defers, then seal with `Terminator::Return` and start a fresh
+                // dead cursor block for any lexically-following code. A `return`
+                // diverges, so this expression yields no value (`None`).
+                if let Some(expr_value) = value {
+                    let value_place = self.lower_value(expr_value);
+                    self.decide(expr_value);
+                    self.mark_returned_binding_moved(expr_value);
+                    self.statements.push(MirStatement::Return {
+                        site: Some(expr_value.site),
+                        ty: self.subst_ty(&expr_value.ty),
+                    });
+                    if let Some(src) = value_place {
+                        self.push_instr(Instr::Move {
+                            dest: Place::ReturnSlot,
+                            src,
+                        });
+                    }
+                } else {
+                    self.statements.push(MirStatement::Return {
+                        site: None,
+                        ty: ResolvedTy::Unit,
+                    });
+                }
+                self.emit_defers_for_return();
+                self.finish_current_block(Terminator::Return);
                 let dead = self.alloc_block();
                 self.start_dead_block(dead);
                 None

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -4357,6 +4357,14 @@ fn collect_unknown_self_fields_in_block(
             HirStmtKind::Defer { body, .. } => {
                 collect_unknown_self_fields_in_expr(body, state_fields, seen, unknown);
             }
+            HirStmtKind::LetElse {
+                scrutinee,
+                else_body,
+                ..
+            } => {
+                collect_unknown_self_fields_in_expr(scrutinee, state_fields, seen, unknown);
+                collect_unknown_self_fields_in_block(else_body, state_fields, seen, unknown);
+            }
         }
     }
     if let Some(tail) = &block.tail {
@@ -8246,7 +8254,192 @@ impl Builder {
                     .or_default()
                     .push(body.as_ref().clone());
             }
+            HirStmtKind::LetElse {
+                scrutinee,
+                variant_idx,
+                bindings,
+                payload_variant_predicates,
+                else_body,
+            } => {
+                self.lower_let_else_stmt(
+                    scrutinee,
+                    *variant_idx,
+                    bindings,
+                    payload_variant_predicates,
+                    else_body,
+                );
+            }
         }
+    }
+
+    /// Lower `let PAT = scrutinee else { <divergent block> };`.
+    ///
+    /// Mirrors `lower_if_let`'s tag-test CFG, with two deliberate differences:
+    ///   1. The success-path payload bindings are inserted into
+    ///      `binding_locals` and NEVER restored — they escape into the
+    ///      enclosing scope so the rest of the block can read them.
+    ///   2. There is no join/result place. On a match, control flows straight
+    ///      into the continuation block (the cursor) with the binders live. On
+    ///      a mismatch, the else block runs; it is divergent (the checker
+    ///      proved `Ty::Never`), so it seals its own block with a diverging
+    ///      terminator and the continuation is reached only via the match edge.
+    #[allow(
+        clippy::too_many_lines,
+        reason = "mirrors lower_if_let's tag-test CFG builder; splitting would require threading many intermediate block ids across helper boundaries"
+    )]
+    fn lower_let_else_stmt(
+        &mut self,
+        scrutinee: &HirExpr,
+        variant_idx: u32,
+        bindings: &[hew_hir::HirMatchArmBinding],
+        payload_variant_predicates: &[hew_hir::HirPayloadVariantPredicate],
+        else_body: &hew_hir::HirBlock,
+    ) {
+        // Entry: evaluate scrutinee, load tag, branch.
+        let Some(scrutinee_place) = self.lower_value(scrutinee) else {
+            return;
+        };
+        let scrutinee_local = match scrutinee_place {
+            Place::Local(n) => n,
+            other => {
+                self.diagnostics.push(MirDiagnostic {
+                    kind: MirDiagnosticKind::NotYetImplemented {
+                        construct: "let-else scrutinee place shape".to_string(),
+                        site: scrutinee.site,
+                    },
+                    note: format!(
+                        "let-else scrutinee must lower to Place::Local; got {other:?}. \
+                         The HIR producer should only emit LetElse for enum-typed \
+                         scrutinees backed by a local slot"
+                    ),
+                });
+                return;
+            }
+        };
+
+        let tag_local = self.alloc_local(ResolvedTy::I64);
+        self.push_instr(Instr::Move {
+            dest: tag_local,
+            src: Place::EnumTag(scrutinee_local),
+        });
+        let k_local = self.alloc_local(ResolvedTy::I64);
+        self.push_instr(Instr::ConstI64 {
+            dest: k_local,
+            value: i64::from(variant_idx),
+        });
+        let cond_local = self.alloc_local(ResolvedTy::Bool);
+        self.push_instr(Instr::IntCmp {
+            pred: crate::model::CmpPred::Eq,
+            lhs: tag_local,
+            rhs: k_local,
+            dest: cond_local,
+        });
+
+        let bind_bb = self.alloc_block();
+        let else_bb = self.alloc_block();
+        let cont_bb = self.alloc_block();
+
+        self.finish_current_block(Terminator::Branch {
+            cond: cond_local,
+            then_target: bind_bb,
+            else_target: else_bb,
+        });
+
+        // Match path: bind the payload fields into the ENCLOSING scope's
+        // binding_locals and DO NOT restore — they escape the statement. Then
+        // Goto the continuation, where subsequent statements lower with the
+        // binders live.
+        self.start_block(bind_bb);
+        let mut nested_binding_jobs: Vec<(u32, u32, hew_hir::HirMatchArmBinding)> = Vec::new();
+        for pvp in payload_variant_predicates {
+            // A failed nested check routes to the else block, same as a
+            // top-level tag mismatch.
+            if self
+                .emit_payload_variant_predicate_checks(
+                    pvp,
+                    scrutinee_local,
+                    variant_idx,
+                    else_bb,
+                    scrutinee.site,
+                    &mut nested_binding_jobs,
+                )
+                .is_none()
+            {
+                return;
+            }
+        }
+
+        for binding in bindings {
+            let binding_ty = self.subst_ty(&binding.ty);
+            self.statements.push(MirStatement::Bind {
+                binding: binding.binding,
+                name: binding.name.clone(),
+                site: scrutinee.site,
+                ty: binding_ty.clone(),
+            });
+            self.record_binding_scope(binding.binding);
+            if ValueClass::of_ty(&binding_ty, &self.type_classes) != ValueClass::BitCopy {
+                self.owned_locals
+                    .push((binding.binding, binding.name.clone(), binding_ty.clone()));
+            }
+            let dest = self.alloc_local(binding.ty.clone());
+            self.push_instr(Instr::Move {
+                dest,
+                src: Place::MachineVariant {
+                    local: scrutinee_local,
+                    variant_idx,
+                    field_idx: binding.field_idx,
+                },
+            });
+            // Escape: insert into binding_locals and never restore.
+            self.binding_locals.insert(binding.binding, dest);
+        }
+        for (src_local, src_variant_idx, binding) in nested_binding_jobs {
+            let binding_ty = self.subst_ty(&binding.ty);
+            self.statements.push(MirStatement::Bind {
+                binding: binding.binding,
+                name: binding.name.clone(),
+                site: scrutinee.site,
+                ty: binding_ty.clone(),
+            });
+            self.record_binding_scope(binding.binding);
+            if ValueClass::of_ty(&binding_ty, &self.type_classes) != ValueClass::BitCopy {
+                self.owned_locals
+                    .push((binding.binding, binding.name.clone(), binding_ty.clone()));
+            }
+            let dest = self.alloc_local(binding.ty.clone());
+            self.push_instr(Instr::Move {
+                dest,
+                src: Place::MachineVariant {
+                    local: src_local,
+                    variant_idx: src_variant_idx,
+                    field_idx: binding.field_idx,
+                },
+            });
+            self.binding_locals.insert(binding.binding, dest);
+        }
+        self.finish_current_block(Terminator::Goto { target: cont_bb });
+
+        // No-match path: run the divergent else block. The checker proved it
+        // has type `Ty::Never`, so its body seals the block with a diverging
+        // terminator (Return/Trap). Defensive Goto for malformed HIR where the
+        // else somehow falls through — the cursor is unreachable in the
+        // well-formed case.
+        self.start_block(else_bb);
+        self.active_scopes.push(else_body.scope);
+        for stmt in &else_body.statements {
+            self.stmt(stmt);
+        }
+        if let Some(tail) = &else_body.tail {
+            let _ = self.lower_value(tail);
+        }
+        self.emit_pending_defers(else_body.scope);
+        self.active_scopes.pop();
+        self.finish_current_block(Terminator::Goto { target: cont_bb });
+
+        // Continuation: subsequent statements lower here, with the escaped
+        // binders live in binding_locals.
+        self.start_block(cont_bb);
     }
 
     fn lower_expr_statement(&mut self, expr: &HirExpr) {

--- a/hew-mir/tests/vertical.rs
+++ b/hew-mir/tests/vertical.rs
@@ -2502,3 +2502,94 @@ fn lower_escaped_string_literal_carries_decoded_bytes() {
         "Instr::StringLit bytes must carry the decoded byte, not the escape notation"
     );
 }
+
+/// Run a source through the full checker + HIR lowering + HIR verifier, then
+/// MIR-lower it, asserting NO diagnostic fires at any stage. Used to pin
+/// error-prop lowerings that previously typechecked cleanly but failed closed
+/// downstream (HIR verify / MIR lowering).
+fn lower_source_checked_verified(src: &str) -> hew_mir::IrPipeline {
+    let parsed = hew_parser::parse(src);
+    assert!(parsed.errors.is_empty(), "parse: {:?}", parsed.errors);
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    assert!(
+        tc_output.errors.is_empty(),
+        "typecheck: {:?}",
+        tc_output.errors
+    );
+    let output = lower_program(
+        &parsed.program,
+        &tc_output,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    assert!(
+        output.diagnostics.is_empty(),
+        "hir lower: {:?}",
+        output.diagnostics
+    );
+    let verify = verify_hir(&output.module);
+    assert!(verify.is_empty(), "hir verify: {verify:?}");
+    let pipeline = lower_hir_module(&output.module);
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "mir lower: {:?}",
+        pipeline.diagnostics
+    );
+    pipeline
+}
+
+#[test]
+fn let_else_nested_tuple_payload_escapes_leaf_binders() {
+    // `let Ok((n, s)) = e else { return … };` must destructure the tuple and
+    // bind BOTH `n` and `s` into the enclosing scope. Pre-fix the leaf binders
+    // were dropped, so the rest of the block referenced unbound names and the
+    // HIR verifier rejected them with `identifier has no binding`. This pins
+    // the whole pipeline staying diagnostic-free.
+    lower_source_checked_verified(
+        r#"
+        fn make_pair(good: bool) -> Result<(i64, string), string> {
+            if good { Ok((7, "p")) } else { Err("no") }
+        }
+        fn parse(good: bool) -> Result<i64, string> {
+            let Ok((n, s)) = make_pair(good) else { return Err("fallback") };
+            let _ = s;
+            Ok(n + 35)
+        }
+        fn main() { let _ = parse(true); }
+        "#,
+    );
+}
+
+#[test]
+fn unannotated_let_rhs_if_with_return_branch_infers_value_type() {
+    // An unannotated `let x = if c { v } else { return … }` must carry the
+    // value branch's type (the diverging else is `Never`, not `Unit`), so a
+    // later `x + 1` lowers as integer arithmetic. Pre-fix the else block typed
+    // `Unit`, the binding mis-typed, and `x + 1` failed closed at MIR with
+    // "binary + on non-integer type".
+    lower_source_checked_verified(
+        r#"
+        fn adjust(n: i64) -> Result<i64, string> {
+            let adjusted = if n > 0 { n } else { return Err("non-positive") };
+            Ok(adjusted + 1)
+        }
+        fn main() { let _ = adjust(1); }
+        "#,
+    );
+}
+
+#[test]
+fn return_in_binary_operand_position_infers_value_type() {
+    // The same Never-branch inference must hold when the `if`/`else` sits
+    // directly in a binary-operand position: `ten + if c { … } else { return … }`.
+    lower_source_checked_verified(
+        r#"
+        fn combine(n: i64) -> Result<i64, string> {
+            let ten = 10;
+            Ok(ten + if n == 1 { n + 1 } else { return Err("bad-arg") })
+        }
+        fn main() { let _ = combine(1); }
+        "#,
+    );
+}

--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -272,6 +272,18 @@ pub enum Expr {
     },
     UnsafeBlock(Box<Block>),
     Yield(Option<Box<Spanned<Expr>>>),
+    /// `return [expr]` in expression position — a divergent (`!`-typed) early
+    /// exit usable anywhere an expression is expected (match arms, `let`
+    /// initialisers, `&&`/`||` operands, `if`-as-expression branches), not just
+    /// at statement position. The operand is the value returned from the
+    /// enclosing function; `None` means `return` with no value (unit return).
+    ///
+    /// Mirrors `Stmt::Return`'s value-or-`None` shape but with no trailing `;`:
+    /// in expression position the operand ends where the surrounding expression
+    /// ends (before a `,`/`}`/`)`/`;` or any token that cannot begin an
+    /// expression). The checker synthesizes `Ty::Never`; HIR lowers it to
+    /// `HirExprKind::Return` (sibling of `HirExprKind::Break`).
+    Return(Option<Box<Spanned<Expr>>>),
     This,
     FieldAccess {
         object: Box<Spanned<Expr>>,

--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -358,6 +358,14 @@ pub enum Stmt {
         pattern: Spanned<Pattern>,
         ty: Option<Spanned<TypeExpr>>,
         value: Option<Spanned<Expr>>,
+        /// `let Pat = expr else { <diverging block> };` — the let-else
+        /// fallback. `None` for an ordinary `let`. When `Some`, a refutable
+        /// pattern is admitted: the Ok-path binders escape into the enclosing
+        /// scope and the else block runs (and must diverge) on a failed match.
+        /// The block is carried structurally through the checker because the
+        /// divergence obligation is enforced in the type checker — it cannot be
+        /// desugared away in the parser.
+        else_block: Option<Block>,
     },
     Var {
         name: String,

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -2126,7 +2126,8 @@ impl<'a> Formatter<'a> {
             | Expr::ByteStringLiteral(_)
             | Expr::ByteArrayLiteral(_)
             | Expr::This
-            | Expr::Yield(None) => true,
+            | Expr::Yield(None)
+            | Expr::Return(None) => true,
             Expr::Tuple(exprs) | Expr::Array(exprs) => exprs
                 .iter()
                 .all(|(expr, _)| Self::can_format_expr_inline(expr)),
@@ -2140,7 +2141,8 @@ impl<'a> Formatter<'a> {
             | Expr::Clone(operand)
             | Expr::PostfixTry(operand)
             | Expr::Await(operand)
-            | Expr::Yield(Some(operand)) => Self::can_format_expr_inline(&operand.0),
+            | Expr::Yield(Some(operand))
+            | Expr::Return(Some(operand)) => Self::can_format_expr_inline(&operand.0),
             Expr::Binary { left, right, .. }
             | Expr::Is {
                 lhs: left,
@@ -3062,6 +3064,13 @@ impl<'a> Formatter<'a> {
             }
             Expr::Yield(val) => {
                 self.write("yield");
+                if let Some(val) = val {
+                    self.write(" ");
+                    self.format_expr(&val.0);
+                }
+            }
+            Expr::Return(val) => {
+                self.write("return");
                 if let Some(val) = val {
                     self.write(" ");
                     self.format_expr(&val.0);

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -2223,7 +2223,12 @@ impl<'a> Formatter<'a> {
 
     fn format_stmt_inline(&mut self, stmt: &Stmt) {
         match stmt {
-            Stmt::Let { pattern, ty, value } => {
+            Stmt::Let {
+                pattern,
+                ty,
+                value,
+                else_block,
+            } => {
                 self.write("let ");
                 self.format_pattern(&pattern.0);
                 if let Some(ty) = ty {
@@ -2233,6 +2238,10 @@ impl<'a> Formatter<'a> {
                 if let Some((expr, _)) = value {
                     self.write(" = ");
                     self.format_expr(expr);
+                }
+                if let Some(else_block) = else_block {
+                    self.write(" else ");
+                    self.format_block(else_block, self.source.len());
                 }
                 self.write(";");
             }
@@ -2313,7 +2322,12 @@ impl<'a> Formatter<'a> {
     #[expect(clippy::too_many_lines, reason = "match on all Stmt variants")]
     fn format_stmt(&mut self, stmt: &Stmt) {
         match stmt {
-            Stmt::Let { pattern, ty, value } => {
+            Stmt::Let {
+                pattern,
+                ty,
+                value,
+                else_block,
+            } => {
                 self.write_indent();
                 self.write("let ");
                 self.format_pattern(&pattern.0);
@@ -2324,6 +2338,10 @@ impl<'a> Formatter<'a> {
                 if let Some(val) = value {
                     self.write(" = ");
                     self.format_expr(&val.0);
+                }
+                if let Some(else_block) = else_block {
+                    self.write(" else ");
+                    self.format_block(else_block, self.source.len());
                 }
                 self.write(";\n");
             }

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -3980,6 +3980,7 @@ impl<'src> Parser<'src> {
                     pattern: (Pattern::Identifier(name.clone()), 0..0),
                     ty: None,
                     value: Some((value, 0..0)),
+                    else_block: None,
                 },
                 0..0,
             ));
@@ -5980,9 +5981,45 @@ impl<'src> Parser<'src> {
                     None
                 };
 
+                // `let Pat = expr else { <diverging block> };` — the let-else
+                // fallback clause, parsed AFTER the value and BEFORE the
+                // terminating `;`. The else block is carried structurally so
+                // the checker can enforce that it diverges; it is NOT desugared
+                // away here. `let r? = e else {…}` is rejected: the `?`
+                // propagation suffix already supplies a fallback path, so an
+                // `else` clause would be contradictory. An `else` with no
+                // initialiser (`let x else {…}`) has nothing to bind, so it is
+                // also rejected.
+                let else_block = if self.eat(&Token::Else) {
+                    if propagate {
+                        self.error(
+                            "`?` propagation suffix and an `else` clause cannot both \
+                             appear on a `let`; use one or the other"
+                                .to_string(),
+                        );
+                        return None;
+                    }
+                    if value.is_none() {
+                        self.error(
+                            "`let … else { … }` requires an initialiser before the \
+                             `else` clause"
+                                .to_string(),
+                        );
+                        return None;
+                    }
+                    Some(self.parse_block()?)
+                } else {
+                    None
+                };
+
                 self.expect(&Token::Semicolon)?;
 
-                Stmt::Let { pattern, ty, value }
+                Stmt::Let {
+                    pattern,
+                    ty,
+                    value,
+                    else_block,
+                }
             }
             Some(Token::Var) => {
                 self.advance();
@@ -6152,12 +6189,20 @@ impl<'src> Parser<'src> {
             }
             Some(Token::Return) => {
                 self.advance();
-                let value = if self.peek() == Some(&Token::Semicolon) {
+                let value = if matches!(self.peek(), Some(Token::Semicolon | Token::RightBrace)) {
                     None
                 } else {
                     Some(self.parse_expr()?)
                 };
-                self.expect(&Token::Semicolon)?;
+                // A statement-position `return` normally ends with `;`. When it
+                // is the last item in a block (`}` follows, no `;`), it is the
+                // block's trailing `return` — `parse_block` promotes the
+                // resulting `Stmt::Return` to a trailing `Expr::Return`, so do
+                // not demand a `;` here. This is the `else { return … }`
+                // let-else body and the `if c { return … }`-tail shape.
+                if self.peek() != Some(&Token::RightBrace) {
+                    self.expect(&Token::Semicolon)?;
+                }
                 Stmt::Return(value)
             }
             Some(Token::Defer) => {

--- a/hew-parser/src/parser.rs
+++ b/hew-parser/src/parser.rs
@@ -7404,10 +7404,29 @@ impl<'src> Parser<'src> {
             }
             Token::Return => {
                 self.advance();
-                // Return expressions are not typically parsed in expression context
-                // This might be a parsing context issue - skip for now
-                self.error("return statement in expression context".to_string());
-                return None;
+                // `return [expr]` in expression position. Unlike `Stmt::Return`
+                // there is NO trailing `;` here; the operand ends where the
+                // surrounding expression ends. Stop on any token that cannot
+                // begin an expression (`;` / `}` / `)` / `]` / `,`) or `else`
+                // (so a `let Pat = e else { ... }` clause and an
+                // `if cond { return } else { ... }` branch are not swallowed),
+                // yielding `return` with no value. Mirrors the `Yield` shape.
+                let value = if matches!(
+                    self.peek(),
+                    Some(
+                        Token::Semicolon
+                            | Token::RightBrace
+                            | Token::RightParen
+                            | Token::RightBracket
+                            | Token::Comma
+                            | Token::Else
+                    ) | None
+                ) {
+                    None
+                } else {
+                    Some(Box::new(self.parse_expr()?))
+                };
+                Expr::Return(value)
             }
             Token::Scope => {
                 self.advance();

--- a/hew-parser/src/tail_call.rs
+++ b/hew-parser/src/tail_call.rs
@@ -154,6 +154,7 @@ fn expr_contains_defer(expr: &Expr) -> bool {
         | Expr::Lambda { .. }
         | Expr::SpawnLambdaActor { .. }
         | Expr::Yield(None)
+        | Expr::Return(None)
         | Expr::ForkChild { .. } => false,
         Expr::ForkBlock { body } | Expr::GenBlock { body } => block_contains_defer(body),
         Expr::ScopeDeadline { duration, body } => {
@@ -232,7 +233,9 @@ fn expr_contains_defer(expr: &Expr) -> bool {
         Expr::Timeout { expr, duration } => {
             expr_contains_defer(&expr.0) || expr_contains_defer(&duration.0)
         }
-        Expr::Yield(Some(expr)) | Expr::Cast { expr, .. } => expr_contains_defer(&expr.0),
+        Expr::Yield(Some(expr)) | Expr::Return(Some(expr)) | Expr::Cast { expr, .. } => {
+            expr_contains_defer(&expr.0)
+        }
         Expr::FieldAccess { object, .. } => expr_contains_defer(&object.0),
         Expr::Index { object, index } => {
             expr_contains_defer(&object.0) || expr_contains_defer(&index.0)
@@ -346,6 +349,7 @@ fn mark_expr(expr: &mut Expr, is_tail_position: bool) {
         | Expr::Lambda { .. }
         | Expr::SpawnLambdaActor { .. }
         | Expr::Yield(None)
+        | Expr::Return(None)
         | Expr::ForkChild { .. } => {}
         // Generator blocks are not tail-call candidates; mark the body
         // so any inner call expressions can still be identified.
@@ -461,7 +465,9 @@ fn mark_expr(expr: &mut Expr, is_tail_position: bool) {
             mark_expr(&mut expr.0, false);
             mark_expr(&mut duration.0, false);
         }
-        Expr::Yield(Some(expr)) | Expr::Cast { expr, .. } => mark_expr(&mut expr.0, false),
+        Expr::Yield(Some(expr)) | Expr::Return(Some(expr)) | Expr::Cast { expr, .. } => {
+            mark_expr(&mut expr.0, false);
+        }
         Expr::FieldAccess { object, .. } => mark_expr(&mut object.0, false),
         Expr::Index { object, index } => {
             mark_expr(&mut object.0, false);

--- a/hew-parser/tests/let_else.rs
+++ b/hew-parser/tests/let_else.rs
@@ -1,0 +1,133 @@
+//! `let-else` parsing (v0.6 error-prop ergonomics).
+//!
+//! `let Pat = expr else { <diverging block> };` carries the else block
+//! structurally on `Stmt::Let { else_block }` so the type checker can enforce
+//! that it diverges. The else clause parses after the value and before the
+//! terminating `;`. A refutable pattern is admitted only when an `else` clause
+//! is present; the divergence obligation is the checker's, not the parser's.
+
+use hew_parser::ast::{Item, Stmt};
+use hew_parser::parse;
+
+/// Parse a source string, assert no parse errors, and return the statements of
+/// the single function's body.
+fn parse_fn_stmts(src: &str) -> Vec<Stmt> {
+    let result = parse(src);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected parse errors for `{src}`: {:#?}",
+        result.errors
+    );
+    let (item, _span) = result
+        .program
+        .items
+        .into_iter()
+        .next()
+        .expect("expected at least one item");
+    match item {
+        Item::Function(f) => f.body.stmts.into_iter().map(|(s, _)| s).collect(),
+        _ => panic!("expected Item::Function"),
+    }
+}
+
+/// Parse a full source string and assert it produces no parse errors.
+fn parse_ok(src: &str) {
+    let result = parse(src);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected parse errors for `{src}`: {:#?}",
+        result.errors
+    );
+}
+
+/// Parse a full source string and assert it produces at least one parse error
+/// whose message contains `needle`.
+fn parse_err_contains(src: &str, needle: &str) {
+    let result = parse(src);
+    assert!(
+        result.errors.iter().any(|e| e.message.contains(needle)),
+        "expected a parse error containing `{needle}` for `{src}`, got: {:#?}",
+        result.errors
+    );
+}
+
+// -- Accept: `let-else` carries the else block -------------------------------
+
+#[test]
+fn let_else_carries_else_block() {
+    // The dogfood bind-or-bail repro: a refutable `Ok(_)` pattern with an else
+    // clause that diverges. The parser admits it and carries the block.
+    let stmts = parse_fn_stmts(
+        "fn f() -> Result<i64, string> { let Ok(n) = validate(s) else { return Err(\"bad\") }; Ok(n) }",
+    );
+    let Stmt::Let {
+        pattern,
+        else_block,
+        ..
+    } = &stmts[0]
+    else {
+        panic!("expected Stmt::Let, got {:?}", stmts[0]);
+    };
+    assert!(
+        else_block.is_some(),
+        "expected an else block on the let-else, got None"
+    );
+    // The Ok-path pattern is preserved verbatim (it is the binder source).
+    assert!(
+        matches!(&pattern.0, hew_parser::ast::Pattern::Constructor { .. }),
+        "expected a constructor pattern (Ok(n)), got {:?}",
+        pattern.0
+    );
+}
+
+#[test]
+fn ordinary_let_has_no_else_block() {
+    // A plain `let` (no `else`) leaves `else_block` as None.
+    let stmts = parse_fn_stmts("fn f() { let x = 1; }");
+    let Stmt::Let { else_block, .. } = &stmts[0] else {
+        panic!("expected Stmt::Let, got {:?}", stmts[0]);
+    };
+    assert!(
+        else_block.is_none(),
+        "expected None else_block on an ordinary let, got {else_block:?}"
+    );
+}
+
+#[test]
+fn let_else_with_multi_statement_block_parses() {
+    // The else block is a full block: multiple statements before the divergent
+    // tail are admitted by the parser (the checker proves divergence later).
+    parse_ok(
+        "fn f() -> Result<i64, string> { \
+         let Ok(n) = validate(s) else { log(\"fail\"); return Err(\"bad\") }; Ok(n) }",
+    );
+}
+
+#[test]
+fn let_else_inline_block_parses() {
+    // The single-line form used in the combined dogfood example.
+    parse_ok(
+        "fn f() -> Result<i64, string> { let Ok(p) = parse(s) else { return Err(\"e\") }; Ok(p) }",
+    );
+}
+
+// -- Reject: contradictory or incomplete let-else forms ----------------------
+
+#[test]
+fn let_propagate_with_else_is_rejected() {
+    // `let r? = e else {...}` -- the `?` suffix already supplies a fallback, so
+    // an `else` clause is contradictory.
+    parse_err_contains(
+        "fn f() -> Result<i64, string> { let r? = e() else { return Err(\"x\") }; Ok(r) }",
+        "`?` propagation suffix and an `else` clause cannot both",
+    );
+}
+
+#[test]
+fn let_else_without_initialiser_is_rejected() {
+    // `let x else {...}` has nothing to bind -- there is no value to match.
+    parse_err_contains(
+        "fn f() { let x else { return }; }",
+        "requires an initialiser before the",
+    );
+}

--- a/hew-parser/tests/return_expr.rs
+++ b/hew-parser/tests/return_expr.rs
@@ -1,0 +1,100 @@
+//! `return` as a first-class expression (v0.6 error-prop ergonomics).
+//!
+//! Before this slice, `return` in expression position errored with "return
+//! statement in expression context". It now parses to `Expr::Return`, usable
+//! anywhere an expression is expected (match arms, `let` initialisers, `&&`/`||`
+//! operands). The operand has no trailing `;` in expression position; it ends
+//! where the surrounding expression ends.
+
+use hew_parser::ast::{Expr, MatchArm};
+use hew_parser::parse;
+
+/// Parse a source string wrapping an expression inside a function and return
+/// the function body's trailing expression.
+fn parse_expr_in_fn(src: &str) -> Expr {
+    let source = format!("fn f() {{ {src} }}");
+    let result = parse(&source);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected parse errors for `{src}`: {:#?}",
+        result.errors
+    );
+    let (item, _span) = result
+        .program
+        .items
+        .into_iter()
+        .next()
+        .expect("expected at least one item");
+    match item {
+        hew_parser::ast::Item::Function(f) => {
+            f.body.trailing_expr.expect("expected trailing expr").0
+        }
+        _ => panic!("expected Item::Function"),
+    }
+}
+
+/// Parse a full source string and assert it produces no parse errors.
+fn parse_ok(src: &str) {
+    let result = parse(src);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected parse errors for `{src}`: {:#?}",
+        result.errors
+    );
+}
+
+// ── Accept: `return` in expression position ─────────────────────────────────
+
+#[test]
+fn return_with_value_in_expr_position_parses() {
+    // The dogfood repro: a bare match arm whose body is `return <expr>`.
+    let expr = parse_expr_in_fn("match r { Ok(x) => x, Err(e) => return Err(e) }");
+    let Expr::Match { arms, .. } = expr else {
+        panic!("expected Expr::Match, got {expr:?}");
+    };
+    let MatchArm { body, .. } = &arms[1];
+    assert!(
+        matches!(body.0, Expr::Return(Some(_))),
+        "expected match-arm body Expr::Return(Some(_)), got {:?}",
+        body.0
+    );
+}
+
+#[test]
+fn bare_return_no_value_in_match_arm_parses() {
+    // `return` with no operand, terminated by the arm `,` — operand is `None`.
+    let expr = parse_expr_in_fn("match r { Some(_) => return, None => 0 }");
+    let Expr::Match { arms, .. } = expr else {
+        panic!("expected Expr::Match, got {expr:?}");
+    };
+    assert!(
+        matches!(arms[0].body.0, Expr::Return(None)),
+        "expected Expr::Return(None), got {:?}",
+        arms[0].body.0
+    );
+}
+
+#[test]
+fn return_in_let_initialiser_parses() {
+    // `let x = cond || return ...;` — return as the RHS of a `||` operand.
+    parse_ok("fn f() -> int { let x = compute() || return 0; x }");
+}
+
+#[test]
+fn return_with_call_operand_parses() {
+    // The operand is a full expression (a call), not just an atom. Exercised in
+    // genuine expression position (a match arm); the operand ends at the arm
+    // boundary, not a `;`.
+    let expr = parse_expr_in_fn("match r { _ => return wrap(err, \"io\") }");
+    let Expr::Match { arms, .. } = expr else {
+        panic!("expected Expr::Match, got {expr:?}");
+    };
+    let Expr::Return(Some(operand)) = &arms[0].body.0 else {
+        panic!("expected Expr::Return(Some(_)), got {:?}", arms[0].body.0);
+    };
+    assert!(
+        matches!(operand.0, Expr::Call { .. }),
+        "expected the operand to be a call, got {:?}",
+        operand.0
+    );
+}

--- a/hew-sandbox-wasm/src/emit.rs
+++ b/hew-sandbox-wasm/src/emit.rs
@@ -2042,6 +2042,7 @@ impl<'pkg, 'src> FunctionEmitter<'pkg, 'src> {
             | Expr::Timeout { .. }
             | Expr::UnsafeBlock(_)
             | Expr::Yield(_)
+            | Expr::Return(_)
             | Expr::This
             | Expr::Cast { .. }
             | Expr::PostfixTry(_)

--- a/hew-sandbox-wasm/src/profile.rs
+++ b/hew-sandbox-wasm/src/profile.rs
@@ -535,6 +535,20 @@ impl<'a> ProfileChecker<'a> {
             | Expr::PostfixTry(operand) => {
                 self.check_expr(operand);
             }
+            Expr::Return(operand) => {
+                // `return` in expression position is not yet lowered by the
+                // sandbox-wasm emitter (it emits `unsupported`). Reject it here
+                // so the gap fails closed before emission. Still walk the
+                // operand for completeness.
+                self.reject(
+                    span.clone(),
+                    "reserved_runtime_feature",
+                    "`return` in expression position is reserved for a later sandbox VM milestone",
+                );
+                if let Some(operand) = operand {
+                    self.check_expr(operand);
+                }
+            }
             Expr::Clone(operand) => {
                 // `clone expr` produces an independent deep copy. The emitter
                 // lowers this by evaluating the operand then forcing a deep clone

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -887,6 +887,9 @@ mod ast_surface {
             Expr::Timeout { .. } => Some("scope / structured-concurrency block"),
             Expr::UnsafeBlock(_) => Some("unsafe block"),
             Expr::Yield(_) => Some("scope / structured-concurrency block"),
+            // `return` in expression position is reserved_runtime_feature in
+            // the sandbox VM (see profile.rs); no parity corpus entry yet.
+            Expr::Return(_) => None,
             Expr::This => None, // `self` — only meaningful inside actor/impl context.
             Expr::FieldAccess { .. } => Some("record StructInit + field access"),
             Expr::Index { .. } => Some("array literal + index + len"),

--- a/hew-types/src/check/closure_inference.rs
+++ b/hew-types/src/check/closure_inference.rs
@@ -351,6 +351,14 @@ fn body_visit_expr(expr: &Expr, out: &mut LambdaBodyFacts) {
             }
         }
         Expr::GenBlock { body } => body_visit_block(body, out),
+        Expr::Return(opt) => {
+            // `return` is a divergent leaf, not a suspend point; just recurse
+            // into the operand so captures referenced by `return <expr>` are
+            // observed.
+            if let Some(boxed) = opt {
+                body_visit_expr(&boxed.0, out);
+            }
+        }
     }
 }
 
@@ -757,6 +765,13 @@ fn esc_visit_expr(
         }
         Expr::Await(inner) => esc_visit_expr(&inner.0, name, in_fork, acc, false),
         Expr::GenBlock { body } => esc_visit_block(body, name, in_fork, acc),
+        Expr::Return(opt) => {
+            // `return <expr>` carries the operand out of the closure; treat it
+            // as an argument-position escape, mirroring `yield <expr>`.
+            if let Some(boxed) = opt {
+                esc_visit_arg(&boxed.0, name, in_fork, acc);
+            }
+        }
     }
 }
 

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -536,6 +536,19 @@ impl Checker {
             // Yield
             Expr::Yield(value) => self.synthesize_yield(value.as_deref(), span),
 
+            // `return [expr]` in expression position. A `return` diverges, so
+            // the construct itself synthesizes to `Ty::Never` (which unifies
+            // with any expected type). The operand is checked against the
+            // enclosing function's declared return type via the SAME shared
+            // shell as statement-position `Stmt::Return`
+            // (LESSONS `one-construct-one-lowering-shell`) — never against this
+            // expression's expected type, so a mismatched `return` operand is
+            // attributed to the return, not the surrounding expression.
+            Expr::Return(value) => {
+                self.check_return_operand(value.as_deref(), span);
+                Ty::Never
+            }
+
             // Actor self-reference handle — returns LocalPid<Self>, not the actor type itself
             Expr::This => {
                 if let Some(actor_ty) = &self.current_actor_type {
@@ -4847,6 +4860,7 @@ impl Checker {
             | Expr::Timeout { .. }
             | Expr::UnsafeBlock(_)
             | Expr::Yield(_)
+            | Expr::Return(_)
             | Expr::This
             | Expr::FieldAccess { .. }
             | Expr::Index { .. }

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -1229,7 +1229,9 @@ impl Checker {
                 );
             }
             Expr::UnsafeBlock(block) => self.classify_escapes_in_block(block, in_fork),
-            Expr::Yield(opt) => {
+            // `yield <expr>` and `return <expr>` both carry the operand out of
+            // the closure to a higher-order boundary; same escape context.
+            Expr::Yield(opt) | Expr::Return(opt) => {
                 if let Some(boxed) = opt {
                     self.classify_escapes_in_expr(
                         &boxed.0,
@@ -1676,6 +1678,11 @@ fn collect_lambda_spans_in_expr(
             }
         }
         Expr::GenBlock { body } => collect_lambda_spans_in_block(body, out),
+        Expr::Return(opt) => {
+            if let Some(boxed) = opt {
+                collect_lambda_spans_in_expr(&boxed.0, &boxed.1, out);
+            }
+        }
         Expr::Literal(_)
         | Expr::Identifier(_)
         | Expr::This

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -2822,7 +2822,8 @@ impl Checker {
             | Expr::Clone(operand)
             | Expr::ForkChild { expr: operand, .. }
             | Expr::PostfixTry(operand)
-            | Expr::Yield(Some(operand)) => {
+            | Expr::Yield(Some(operand))
+            | Expr::Return(Some(operand)) => {
                 Self::collect_machine_transition_forbidden_exprs(&operand.0, &operand.1, hits);
             }
             Expr::Tuple(exprs) | Expr::Array(exprs) | Expr::Join(exprs) => {
@@ -2988,6 +2989,7 @@ impl Checker {
             Expr::Literal(_)
             | Expr::Identifier(_)
             | Expr::Yield(None)
+            | Expr::Return(None)
             | Expr::This
             | Expr::RegexLiteral(_)
             | Expr::ByteStringLiteral(_)

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -418,6 +418,38 @@ impl Checker {
         }
     }
 
+    /// Does the bare let-pattern identifier `name` resolve to a known *unit*
+    /// enum variant of `val_ty`?
+    ///
+    /// This is the resolution-based replacement for the old case-sensitivity
+    /// heuristic. A let-pattern identifier is a refutable variant pattern only
+    /// when it actually resolves to a unit variant of the value type; every
+    /// other bare identifier (including uppercase ones like `INF` or `Foo`) is
+    /// a fresh binding. Qualified paths (`E::A`) are handled by the caller and
+    /// never reach here. Mirrors Rust: a name resolving to a unit variant is a
+    /// pattern; otherwise it binds.
+    fn bare_identifier_resolves_to_unit_variant(&self, name: &str, val_ty: &Ty) -> bool {
+        let resolved = self.subst.resolve(val_ty);
+        // Built-in `Option<T>`: `None` is the only unit variant (`Some`
+        // carries a payload).
+        if resolved.as_option().is_some() {
+            return name == "None";
+        }
+        // Built-in `Result<T, E>`: both variants carry a payload, so a bare
+        // identifier is never a unit variant here.
+        if resolved.as_result().is_some() {
+            return false;
+        }
+        // User enum: the variant must exist on the value type AND be a unit
+        // variant. A name that is not a variant of this type is a binding.
+        if let Some(type_name) = resolved.type_name() {
+            if let Some(td) = self.lookup_type_def(type_name) {
+                return matches!(td.variants.get(name), Some(VariantDef::Unit));
+            }
+        }
+        false
+    }
+
     #[expect(
         clippy::too_many_lines,
         reason = "statement checking covers many Stmt variants"
@@ -552,14 +584,22 @@ impl Checker {
                 // A constructor-like identifier (`None`, `E::A`) is a refutable
                 // UNIT-VARIANT pattern, not a plain binding — route it to the
                 // refutability gate below so a let-else records its resolution
-                // and a plain `let` is rejected. Only lowercase/non-qualified
-                // identifiers introduce a binding here.
-                let identifier_is_unit_variant = matches!(
-                    &pattern.0,
-                    Pattern::Identifier(name)
-                        if name.contains("::")
-                            || name.chars().next().is_some_and(char::is_uppercase)
-                );
+                // and a plain `let` is rejected.
+                //
+                // Detection is by RESOLUTION, never by case: a `::`-qualified
+                // path is unambiguously a variant, and a bare identifier is a
+                // unit-variant pattern only when it actually resolves to a unit
+                // variant of the value type. Any other bare identifier — even
+                // an uppercase one like `INF` or `Foo` — is a fresh binding.
+                // This mirrors Rust pattern resolution: a name resolving to a
+                // unit variant/const is a pattern; otherwise it binds.
+                let identifier_is_unit_variant = match &pattern.0 {
+                    Pattern::Identifier(name) if name.contains("::") => true,
+                    Pattern::Identifier(name) => {
+                        self.bare_identifier_resolves_to_unit_variant(name, &val_ty)
+                    }
+                    _ => false,
+                };
                 // For simple identifier patterns, track the definition span.
                 // A unit-variant identifier is NOT a binding — it falls through
                 // to the refutability gate below.

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -549,8 +549,25 @@ impl Checker {
                         more_specific_hole_vars,
                     );
                 }
-                // For simple identifier patterns, track the definition span
-                if let Pattern::Identifier(name) = &pattern.0 {
+                // A constructor-like identifier (`None`, `E::A`) is a refutable
+                // UNIT-VARIANT pattern, not a plain binding — route it to the
+                // refutability gate below so a let-else records its resolution
+                // and a plain `let` is rejected. Only lowercase/non-qualified
+                // identifiers introduce a binding here.
+                let identifier_is_unit_variant = matches!(
+                    &pattern.0,
+                    Pattern::Identifier(name)
+                        if name.contains("::")
+                            || name.chars().next().is_some_and(char::is_uppercase)
+                );
+                // For simple identifier patterns, track the definition span.
+                // A unit-variant identifier is NOT a binding — it falls through
+                // to the refutability gate below.
+                let plain_identifier = match &pattern.0 {
+                    Pattern::Identifier(name) if !identifier_is_unit_variant => Some(name),
+                    _ => None,
+                };
+                if let Some(name) = plain_identifier {
                     if val_ty == Ty::Unit && value.is_some() {
                         self.warnings.push(TypeError {
                             severity: crate::error::Severity::Warning,
@@ -636,12 +653,17 @@ impl Checker {
                         }
                         // Enum-variant constructor (e.g. `Some(x)`) — always refutable.
                         Pattern::Constructor { .. } => Some("enum variant"),
+                        // Unit variant written as a bare/qualified identifier
+                        // (e.g. `None`, `E::A`) — refutable; binds nothing.
+                        Pattern::Identifier(_) if identifier_is_unit_variant => {
+                            Some("enum variant")
+                        }
                         // Literal patterns are always refutable.
                         Pattern::Literal(_) => Some("literal"),
                         // Or-patterns are always refutable.
                         Pattern::Or(_, _) => Some("or-pattern"),
-                        // All other patterns (Tuple, Identifier, Wildcard, Regex, …)
-                        // — either already handled above or not relevant here.
+                        // All other patterns (Tuple, plain Identifier, Wildcard,
+                        // Regex, …) — handled above or not refutable here.
                         _ => None,
                     };
                     match (maybe_refutable_kind, else_block) {
@@ -716,12 +738,19 @@ impl Checker {
                         }
                         (None, None) => {}
                     }
-                    // Always call bind_pattern for error-recovery so the binders exist
-                    // and subsequent uses don't cascade into UnresolvedSymbol. The
-                    // binders are defined into the CURRENT (enclosing) scope, so a
-                    // let-else `let Ok(n) = … else { … };` makes `n` visible in the
-                    // rest of the enclosing block.
-                    self.bind_pattern(&pattern.0, &val_ty, false, &pattern.1);
+                    // Call bind_pattern for error-recovery so payload binders
+                    // exist and subsequent uses don't cascade into
+                    // UnresolvedSymbol. Binders are defined into the CURRENT
+                    // (enclosing) scope, so a let-else `let Ok(n) = … else { … };`
+                    // makes `n` visible in the rest of the enclosing block.
+                    //
+                    // A unit-variant identifier (`None`, `E::A`) binds nothing —
+                    // it is a refutable tag-test. Skip bind_pattern so it does
+                    // not introduce a phantom binding (which would otherwise warn
+                    // "unused variable `None`" and shadow the variant constructor).
+                    if !identifier_is_unit_variant {
+                        self.bind_pattern(&pattern.0, &val_ty, false, &pattern.1);
+                    }
                 }
             }
             Stmt::Var { name, ty, value } => {

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -424,7 +424,12 @@ impl Checker {
     )]
     pub(super) fn check_stmt(&mut self, stmt: &Stmt, span: &Span) {
         match stmt {
-            Stmt::Let { pattern, ty, value } => {
+            Stmt::Let {
+                pattern,
+                ty,
+                value,
+                else_block,
+            } => {
                 let binding_context = match &pattern.0 {
                     Pattern::Identifier(name) => format!("local binding `{name}`"),
                     _ => "local binding".to_string(),
@@ -639,24 +644,83 @@ impl Checker {
                         // — either already handled above or not relevant here.
                         _ => None,
                     };
-                    if let Some(kind_label) = maybe_refutable_kind {
-                        // Only emit the refutability error when the value type is
-                        // actually resolved (not Ty::Var / Ty::Error).
-                        if !matches!(resolved_val_ty, Ty::Var(_) | Ty::Error) {
-                            self.report_error(
-                                TypeErrorKind::RefutableLetPattern {
-                                    kind_label: kind_label.to_string(),
-                                },
-                                &pattern.1,
-                                format!(
-                                    "refutable {kind_label} pattern is not allowed in `let`; \
-                                     use `if let` or `match` instead"
-                                ),
-                            );
+                    match (maybe_refutable_kind, else_block) {
+                        // Refutable pattern WITH an `else` clause: this is a
+                        // let-else. The refutable pattern is admitted because
+                        // the else clause supplies the failure path. The else
+                        // block must diverge — it runs when the pattern fails
+                        // and there is no value to bind, so control must not
+                        // fall through to the binding. Check the else block
+                        // BEFORE binding the pattern so the Ok-path binders are
+                        // not visible inside it (they are bound only on the
+                        // success path).
+                        (Some(_), Some(else_blk)) => {
+                            // Record the success-path pattern resolution so HIR
+                            // lowering can consume the same `pattern_resolutions`
+                            // side-table that powers `if let` / `match` /
+                            // `while let`. Without this the let-else lowering
+                            // finds no resolution and fails closed.
+                            self.record_arm_resolution(&pattern.0, &pattern.1, &val_ty);
+                            let else_ty = self.check_block(else_blk, None);
+                            if !matches!(else_ty, Ty::Never)
+                                && !matches!(resolved_val_ty, Ty::Var(_) | Ty::Error)
+                            {
+                                // Span the diagnostic on the else block tail.
+                                // The trailing-expr / last-stmt span brackets
+                                // it; fall back to the pattern span for an
+                                // empty block (which is itself non-diverging).
+                                let else_span = else_blk
+                                    .trailing_expr
+                                    .as_ref()
+                                    .map(|e| e.1.clone())
+                                    .or_else(|| else_blk.stmts.last().map(|(_, sp)| sp.clone()))
+                                    .unwrap_or_else(|| pattern.1.clone());
+                                self.report_error(
+                                    TypeErrorKind::LetElseDoesNotDiverge,
+                                    &else_span,
+                                    "the `else` block of a `let … else` must \
+                                     diverge (e.g. `return`, `break`, `continue`, or a \
+                                     `!`-typed call); it must not fall through to the \
+                                     binding"
+                                        .to_string(),
+                                );
+                            }
                         }
+                        // Refutable pattern with NO `else` clause: rejected. A
+                        // plain `let` has no failure arm, so only irrefutable
+                        // patterns are admitted. Suggest the let-else `else`
+                        // clause (now that it exists) or `if let`/`match`.
+                        (Some(kind_label), None) => {
+                            // Only emit when the value type is actually resolved
+                            // (not Ty::Var / Ty::Error) so a prior root error is
+                            // not buried under a cascade.
+                            if !matches!(resolved_val_ty, Ty::Var(_) | Ty::Error) {
+                                self.report_error(
+                                    TypeErrorKind::RefutableLetPattern {
+                                        kind_label: kind_label.to_string(),
+                                    },
+                                    &pattern.1,
+                                    format!(
+                                        "refutable {kind_label} pattern is not allowed in a \
+                                         plain `let`; add an `else {{ … }}` clause (it \
+                                         must diverge), or use `if let`/`match`"
+                                    ),
+                                );
+                            }
+                        }
+                        // Irrefutable pattern with an `else` clause: the else can
+                        // never run, so divergence is not required. Type-check it
+                        // for error coverage only.
+                        (None, Some(else_blk)) => {
+                            let _ = self.check_block(else_blk, None);
+                        }
+                        (None, None) => {}
                     }
                     // Always call bind_pattern for error-recovery so the binders exist
-                    // and subsequent uses don't cascade into UnresolvedSymbol.
+                    // and subsequent uses don't cascade into UnresolvedSymbol. The
+                    // binders are defined into the CURRENT (enclosing) scope, so a
+                    // let-else `let Ok(n) = … else { … };` makes `n` visible in the
+                    // rest of the enclosing block.
                     self.bind_pattern(&pattern.0, &val_ty, false, &pattern.1);
                 }
             }

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -418,36 +418,48 @@ impl Checker {
         }
     }
 
-    /// Does the bare let-pattern identifier `name` resolve to a known *unit*
-    /// enum variant of `val_ty`?
+    /// Would a bare identifier `name` at a USE-site resolve to a known *unit*
+    /// enum variant / nullary constructor?
     ///
-    /// This is the resolution-based replacement for the old case-sensitivity
-    /// heuristic. A let-pattern identifier is a refutable variant pattern only
-    /// when it actually resolves to a unit variant of the value type; every
-    /// other bare identifier (including uppercase ones like `INF` or `Foo`) is
-    /// a fresh binding. Qualified paths (`E::A`) are handled by the caller and
-    /// never reach here. Mirrors Rust: a name resolving to a unit variant is a
-    /// pattern; otherwise it binds.
-    fn bare_identifier_resolves_to_unit_variant(&self, name: &str, val_ty: &Ty) -> bool {
-        let resolved = self.subst.resolve(val_ty);
-        // Built-in `Option<T>`: `None` is the only unit variant (`Some`
-        // carries a payload).
-        if resolved.as_option().is_some() {
-            return name == "None";
+    /// This decides, on the let-side, whether a bare pattern identifier is a
+    /// refutable variant pattern (route to the refutability gate) or a fresh
+    /// binding. It must agree with how `synthesize`/`synthesize_identifier`
+    /// (expressions.rs) resolve the SAME bare name at a use-site: a
+    /// disagreement produces a half-built binding, where the let-side binds a
+    /// local that the use-side then shadows with the builtin/global variant,
+    /// leaving an unused-variable warning plus a `cannot infer type` at the use.
+    ///
+    /// Resolution is therefore by the GLOBAL/builtin namespace and is
+    /// independent of the value type, mirroring the use-side exactly:
+    ///   * `None` is special-cased at the use-site (expressions.rs, the
+    ///     `name == "None"` arm of `synthesize`) as `Option::None`
+    ///     *unconditionally*, ahead of any binding lookup — so a bare `None`
+    ///     is always a variant pattern here. A value type that is not `Option`
+    ///     then surfaces as a clean single type mismatch (`None` is
+    ///     `Option<_>`, the value is not), never a stray binding.
+    ///   * any user enum's unit variant is found by the use-side's
+    ///     `resolve_identifier_variant`, which scans every `type_defs` entry
+    ///     for a `VariantDef::Unit` of that name — so the let-side scans the
+    ///     same table the same way.
+    ///
+    /// Qualified paths (`E::A`) are handled by the caller and never reach here.
+    /// Mirrors Rust: a name that names a unit variant/const is always a
+    /// pattern, and a mismatched value type is a plain type error — not a
+    /// binding.
+    fn bare_identifier_resolves_to_unit_variant(&self, name: &str) -> bool {
+        // Builtin `None`: the use-side resolves a bare `None` to `Option::None`
+        // unconditionally and ahead of any binding, so the let-side treats it
+        // as a variant pattern regardless of the value type. (`Some`, `Ok`,
+        // `Err` carry payloads — never bare unit variants.)
+        if name == "None" {
+            return true;
         }
-        // Built-in `Result<T, E>`: both variants carry a payload, so a bare
-        // identifier is never a unit variant here.
-        if resolved.as_result().is_some() {
-            return false;
-        }
-        // User enum: the variant must exist on the value type AND be a unit
-        // variant. A name that is not a variant of this type is a binding.
-        if let Some(type_name) = resolved.type_name() {
-            if let Some(td) = self.lookup_type_def(type_name) {
-                return matches!(td.variants.get(name), Some(VariantDef::Unit));
-            }
-        }
-        false
+        // User enums: scan every type definition for a unit variant of this
+        // name, exactly as the use-side's `resolve_identifier_variant` does.
+        // A bare name that is a unit variant of *any* known enum is a pattern.
+        self.type_defs
+            .values()
+            .any(|td| matches!(td.variants.get(name), Some(VariantDef::Unit)))
     }
 
     #[expect(
@@ -586,17 +598,21 @@ impl Checker {
                 // refutability gate below so a let-else records its resolution
                 // and a plain `let` is rejected.
                 //
-                // Detection is by RESOLUTION, never by case: a `::`-qualified
-                // path is unambiguously a variant, and a bare identifier is a
-                // unit-variant pattern only when it actually resolves to a unit
-                // variant of the value type. Any other bare identifier — even
-                // an uppercase one like `INF` or `Foo` — is a fresh binding.
-                // This mirrors Rust pattern resolution: a name resolving to a
-                // unit variant/const is a pattern; otherwise it binds.
+                // Detection is by RESOLUTION, never by case, and must AGREE
+                // with the use-side: a `::`-qualified path is unambiguously a
+                // variant, and a bare identifier is a unit-variant pattern when
+                // the use-side would resolve it to a known unit variant in the
+                // global/builtin namespace (`None`, any user enum's unit
+                // variant) — independent of the value type. Any other bare
+                // identifier — even an uppercase one like `INF` or `Foo` — is a
+                // fresh binding. This mirrors Rust pattern resolution: a name
+                // that names a unit variant/const is always a pattern (a
+                // mismatched value type is then a clean type error); otherwise
+                // it binds.
                 let identifier_is_unit_variant = match &pattern.0 {
                     Pattern::Identifier(name) if name.contains("::") => true,
                     Pattern::Identifier(name) => {
-                        self.bare_identifier_resolves_to_unit_variant(name, &val_ty)
+                        self.bare_identifier_resolves_to_unit_variant(name)
                     }
                     _ => false,
                 };

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -256,12 +256,77 @@ impl Checker {
         ));
     }
 
+    /// Type-check the operand of a `return` against the enclosing function's
+    /// declared return type.
+    ///
+    /// This is the single shared shell for ALL `return` positions: the two
+    /// statement-position `Stmt::Return` arms (`check_stmt` and
+    /// `check_stmt_as_expr`) and the expression-position `Expr::Return`
+    /// (`synthesize`). Routing every position through one helper keeps the
+    /// generator-Return extraction, the `Ty::Error` guard, the unit-vs-declared
+    /// mismatch diagnostic, and the `#[on(crash)]` fail-closed gate identical
+    /// across positions (LESSONS `one-construct-one-lowering-shell`).
+    ///
+    /// The return *type* of the construct itself is always `Ty::Never` (a
+    /// `return` diverges); callers assign that directly.
+    pub(super) fn check_return_operand(&mut self, value: Option<&Spanned<Expr>>, span: &Span) {
+        let Some(expected) = self.current_return_type.clone() else {
+            return;
+        };
+        // Inside a gen{} body, `current_return_type` is shaped as
+        // `Generator<Y, R>`. A `return <expr>` targets the Return component R,
+        // not the full Generator type, so `return 1` inside gen{} unifies
+        // against i64 rather than Generator<Y, i64>.
+        let effective_expected = if self.in_generator {
+            let resolved = self.subst.resolve(&expected);
+            match resolved.as_generator() {
+                Some((_, ret)) => ret.clone(),
+                None => expected,
+            }
+        } else {
+            expected
+        };
+        // Guard: do not check against Ty::Error — it would silently suppress
+        // mismatch diagnostics in the returned expression. Synthesize the value
+        // instead so its own errors are still caught.
+        if matches!(self.subst.resolve(&effective_expected), Ty::Error) {
+            if let Some((val, vs)) = value {
+                self.synthesize(val, vs);
+            }
+        } else {
+            match value {
+                Some((val, vs)) => {
+                    self.check_against(val, vs, &effective_expected);
+                }
+                None if effective_expected != Ty::Unit => {
+                    self.errors.push(TypeError::return_type_mismatch(
+                        span.clone(),
+                        &effective_expected,
+                        &Ty::Unit,
+                    ));
+                }
+                _ => {}
+            }
+        }
+        // Fail-closed: a `return <CrashAction>` inside a `#[on(crash)]` hook hits
+        // the same unimplemented lowering path as the tail-expression form.
+        // Reject it here so the user never reaches codegen.
+        if self.in_crash_hook
+            && matches!(
+                self.subst.resolve(&effective_expected),
+                Ty::Named { name, .. } if name == "CrashAction"
+            )
+        {
+            let fn_name = self
+                .current_function
+                .clone()
+                .unwrap_or_else(|| "<unknown>".to_string());
+            self.emit_crash_action_return_error(span, &fn_name);
+        }
+    }
+
     /// Check a statement that may serve as a block's trailing expression.
     /// Returns the "expression type" of the statement.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "statement-as-expr covers many Stmt variants including the crash-hook return gate"
-    )]
     pub(super) fn check_stmt_as_expr(
         &mut self,
         stmt: &Stmt,
@@ -321,60 +386,7 @@ impl Checker {
             }
             Stmt::Expression((expr, es)) => self.synthesize(expr, es),
             Stmt::Return(value) => {
-                if let Some(expected) = self.current_return_type.clone() {
-                    // Inside a gen{} body, `current_return_type` is shaped as
-                    // `Generator<Y, R>`.  A `return <expr>` targets the Return
-                    // component R, not the full Generator type.  Extract R when
-                    // in a generator context so that `return 1` inside gen{}
-                    // unifies against i64 rather than Generator<Y, i64>.
-                    let effective_expected = if self.in_generator {
-                        let resolved = self.subst.resolve(&expected);
-                        match resolved.as_generator() {
-                            Some((_, ret)) => ret.clone(),
-                            None => expected,
-                        }
-                    } else {
-                        expected
-                    };
-                    // Guard: do not check against Ty::Error — it would silently
-                    // suppress mismatch diagnostics in the returned expression.
-                    // Synthesize the value instead so its own errors are still caught.
-                    if matches!(self.subst.resolve(&effective_expected), Ty::Error) {
-                        if let Some((val, vs)) = value {
-                            self.synthesize(val, vs);
-                        }
-                    } else {
-                        match value {
-                            Some((val, vs)) => {
-                                self.check_against(val, vs, &effective_expected);
-                            }
-                            None if effective_expected != Ty::Unit => {
-                                self.errors.push(TypeError::return_type_mismatch(
-                                    span.clone(),
-                                    &effective_expected,
-                                    &Ty::Unit,
-                                ));
-                            }
-                            _ => {}
-                        }
-                    }
-                    // Fail-closed: a `return <CrashAction>;` inside a
-                    // `#[on(crash)]` hook is equivalent to the tail-expression
-                    // form and hits the same unimplemented lowering path.
-                    // Reject it here so the user never reaches codegen.
-                    if self.in_crash_hook
-                        && matches!(
-                            self.subst.resolve(&effective_expected),
-                            Ty::Named { name, .. } if name == "CrashAction"
-                        )
-                    {
-                        let fn_name = self
-                            .current_function
-                            .clone()
-                            .unwrap_or_else(|| "<unknown>".to_string());
-                        self.emit_crash_action_return_error(span, &fn_name);
-                    }
-                }
+                self.check_return_operand(value.as_ref(), span);
                 Ty::Never
             }
             Stmt::Break { .. } | Stmt::Continue { .. } => {
@@ -916,65 +928,14 @@ impl Checker {
                 }
             }
             Stmt::Return(value) => {
-                if let Some(expected) = self.current_return_type.clone() {
-                    // Inside a gen{} body, `current_return_type` is shaped as
-                    // `Generator<Y, R>`.  A `return <expr>` targets the Return
-                    // component R, not the full Generator type.  Extract R when
-                    // in a generator context so that `return 1` inside gen{}
-                    // unifies against i64 rather than Generator<Y, i64>.
-                    let effective_expected = if self.in_generator {
-                        let resolved = self.subst.resolve(&expected);
-                        match resolved.as_generator() {
-                            Some((_, ret)) => ret.clone(),
-                            None => expected,
-                        }
-                    } else {
-                        expected
-                    };
-                    // Guard: do not check against Ty::Error — same as in
-                    // check_stmt_as_expr; synthesize instead to preserve body errors.
-                    if matches!(self.subst.resolve(&effective_expected), Ty::Error) {
-                        if let Some((val, vs)) = value {
-                            self.synthesize(val, vs);
-                        }
-                    } else {
-                        match value {
-                            Some((val, vs)) => {
-                                self.check_against(val, vs, &effective_expected);
-                            }
-                            None if effective_expected != Ty::Unit => {
-                                self.errors.push(TypeError::return_type_mismatch(
-                                    span.clone(),
-                                    &effective_expected,
-                                    &Ty::Unit,
-                                ));
-                            }
-                            _ => {}
-                        }
-                    }
-                    // Fail-closed: a non-final `return <CrashAction>;` inside an
-                    // `#[on(crash)]` hook (e.g. inside an `if` branch, followed by
-                    // more code) hits the same unimplemented lowering path.
-                    //
-                    // Exit inventory (all gated):
-                    //   (1) non-final `return CrashAction`  → THIS guard
-                    //   (2) final/tail `return CrashAction` → check_stmt_as_expr gate
-                    //   (3) tail-expr CrashAction (no return keyword) → items.rs body_is_crash_action
-                    //   (4) if/match expr whose arms all yield CrashAction → flows into (3)
-                    //   (5) let-bound CrashAction, then returned → flows into (1) or (2)
-                    if self.in_crash_hook
-                        && matches!(
-                            self.subst.resolve(&effective_expected),
-                            Ty::Named { name, .. } if name == "CrashAction"
-                        )
-                    {
-                        let fn_name = self
-                            .current_function
-                            .clone()
-                            .unwrap_or_else(|| "<unknown>".to_string());
-                        self.emit_crash_action_return_error(span, &fn_name);
-                    }
-                }
+                // Fail-closed crash-hook gate inventory (all positions covered by
+                // the shared `check_return_operand` shell):
+                //   (1) non-final `return CrashAction`  → THIS site
+                //   (2) final/tail `return CrashAction` → check_stmt_as_expr site
+                //   (3) tail-expr CrashAction (no return keyword) → items.rs body_is_crash_action
+                //   (4) if/match expr whose arms all yield CrashAction → flows into (3)
+                //   (5) let-bound CrashAction, then returned → flows into (1) or (2)
+                self.check_return_operand(value.as_ref(), span);
             }
             Stmt::Loop { label, body } => {
                 if let Some(lbl) = label {

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -27427,6 +27427,71 @@ mod every_attribute {
     }
 
     #[test]
+    fn bare_none_over_non_option_is_variant_pattern_not_binding() {
+        // Regression for the let-side/use-side split: a bare `None` is ALWAYS a
+        // variant pattern, independent of the value type, because the use-side
+        // resolves a bare `None` to `Option::None` unconditionally. With the old
+        // value-type-based detection, `let None = 5;` bound `None` as a local
+        // (None is not a variant of `i64`), then any use resolved to the builtin
+        // — a half-built binding that surfaced as "unused variable `None`" plus a
+        // "cannot infer type" at the use. The aligned detection treats `None` as
+        // a refutable variant pattern, so this is a SINGLE clean diagnostic: a
+        // refutable-pattern rejection, with NO `None` binding and NO unused-var.
+        let output = check_source("fn f() { let None = 5; }");
+        let refutable: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::RefutableLetPattern { .. }))
+            .collect();
+        assert_eq!(
+            refutable.len(),
+            1,
+            "`let None = 5;` must be a single refutable-variant rejection; got errors: {:#?}",
+            output.errors
+        );
+        // The split symptom: `None` must NOT be bound as a local, so no
+        // unused-variable warning for `None` may appear.
+        let unused_none = output.warnings.iter().any(|w| {
+            matches!(w.kind, TypeErrorKind::UnusedVariable) && w.message.contains("`None`")
+        });
+        assert!(
+            !unused_none,
+            "`None` must not be a half-built binding (no unused-variable warning); warnings: {:#?}",
+            output.warnings
+        );
+    }
+
+    #[test]
+    fn bare_none_over_generic_is_variant_pattern_not_binding() {
+        // The same alignment must hold over a generic type parameter: `let None
+        // = x;` where `x: T` is a variant pattern, not a binding. The old
+        // detection bound `None` (T is not `Option`), leaving an unused-variable
+        // warning while the use-side would resolve `None` to the builtin —
+        // inconsistent. The aligned detection routes it to the refutability gate.
+        let output = check_source("fn g<T>(x: T) { let None = x; }");
+        let refutable: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::RefutableLetPattern { .. }))
+            .collect();
+        assert_eq!(
+            refutable.len(),
+            1,
+            "`let None = x;` in a generic fn must be a single refutable-variant rejection; \
+             got errors: {:#?}",
+            output.errors
+        );
+        let unused_none = output.warnings.iter().any(|w| {
+            matches!(w.kind, TypeErrorKind::UnusedVariable) && w.message.contains("`None`")
+        });
+        assert!(
+            !unused_none,
+            "`None` over a generic must not be a half-built binding; warnings: {:#?}",
+            output.warnings
+        );
+    }
+
+    #[test]
     fn let_irrefutable_struct_record_keyword_no_error() {
         // `record`-keyword product type is also irrefutable.
         let output = check_source(

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -27340,6 +27340,69 @@ mod every_attribute {
     }
 
     #[test]
+    fn let_else_unit_variant_admitted_and_records_resolution() {
+        // `let E::A = e else { return … };` over a UNIT variant (no payload) is
+        // a valid refutable pattern. It must type-check cleanly: no
+        // RefutableLetPattern, no LetElseDoesNotDiverge, and — critically — the
+        // pattern resolution must be recorded so HIR lowering does not cascade
+        // into "pattern has no resolution" / verifier leakage.
+        let output = check_source(
+            "enum E { A; B(i64); }
+             fn make_e(g: bool) -> E { if g { E::A } else { E::B(3) } }
+             fn f(g: bool) -> Result<i64, string> { let E::A = make_e(g) else { return Err(\"x\") }; Ok(1) }",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "a unit-variant let-else with a diverging else must type-check cleanly; got: {:#?}",
+            output.errors
+        );
+        // A unit variant binds nothing — it must NOT introduce a phantom binding
+        // that warns "unused variable `E::A`".
+        let unused_binding_warns: Vec<_> = output
+            .warnings
+            .iter()
+            .filter(|w| w.message.contains("E::A"))
+            .collect();
+        assert!(
+            unused_binding_warns.is_empty(),
+            "a unit-variant pattern binds nothing and must not warn about `E::A`; got: {unused_binding_warns:#?}"
+        );
+    }
+
+    #[test]
+    fn let_else_builtin_none_unit_variant_admitted() {
+        // The common `let None = opt else { … };` idiom (built-in Option unit
+        // variant) rides the same refutable-unit-variant path and type-checks
+        // cleanly with a diverging else.
+        let output = check_source(
+            "fn f(r: Option<i64>) -> Result<i64, string> { let None = r else { return Err(\"some\") }; Ok(0) }",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "a built-in None unit-variant let-else must type-check cleanly; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn refutable_unit_variant_let_no_else_rejected() {
+        // A unit variant in a PLAIN `let` (no else) is refutable and must be
+        // rejected with RefutableLetPattern — the same gate as `let Some(x) =`.
+        let output = check_source("fn f(r: Option<i64>) -> i64 { let None = r; 0 }");
+        let refutable: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::RefutableLetPattern { .. }))
+            .collect();
+        assert_eq!(
+            refutable.len(),
+            1,
+            "a unit-variant plain let must emit exactly one RefutableLetPattern; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
     fn let_irrefutable_struct_record_keyword_no_error() {
         // `record`-keyword product type is also irrefutable.
         let output = check_source(

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -27403,6 +27403,30 @@ mod every_attribute {
     }
 
     #[test]
+    fn uppercase_plain_binding_is_not_a_unit_variant() {
+        // Regression: an uppercase plain identifier that does NOT resolve to a
+        // unit variant of the value type (e.g. `let INF = 999999;`) is a fresh
+        // binding, not a refutable pattern. The detection is by RESOLUTION, not
+        // by case — so it must bind cleanly (no RefutableLetPattern, no
+        // "undefined variable") and be usable afterwards.
+        let output = check_source("fn f() -> i64 { let INF = 999999; let Foo = 5; INF + Foo }");
+        assert!(
+            output.errors.is_empty(),
+            "an uppercase plain binding that resolves to no variant must bind cleanly; got: {:#?}",
+            output.errors
+        );
+        let refutable: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::RefutableLetPattern { .. }))
+            .collect();
+        assert!(
+            refutable.is_empty(),
+            "uppercase plain bindings must not be treated as refutable patterns; got: {refutable:#?}"
+        );
+    }
+
+    #[test]
     fn let_irrefutable_struct_record_keyword_no_error() {
         // `record`-keyword product type is also irrefutable.
         let output = check_source(

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -11596,6 +11596,7 @@ fn let_bound_literal_coercion() {
         pattern: (Pattern::Identifier("n".to_string()), 4..5),
         ty: None,
         value: Some(make_int_literal(5, 8..9)),
+        else_block: None,
     };
     checker.check_stmt(&let_stmt, &(0..10));
     // Now check: let x: i32 = n
@@ -11617,6 +11618,7 @@ fn let_bound_literal_overflow() {
         pattern: (Pattern::Identifier("n".to_string()), 4..5),
         ty: None,
         value: Some(make_int_literal(2_147_483_648, 8..18)),
+        else_block: None,
     };
     checker.check_stmt(&let_stmt, &(0..19));
     // Now check: let x: i32 = n — should fail with range error
@@ -11647,6 +11649,7 @@ fn derived_intliteral_identifier_coerces_without_const_values() {
             },
             8..13,
         )),
+        else_block: None,
     };
     checker.check_stmt(&source_stmt, &(0..14));
 
@@ -11665,6 +11668,7 @@ fn derived_intliteral_identifier_coerces_without_const_values() {
             23..26,
         )),
         value: Some((Expr::Identifier("n".to_string()), 29..30)),
+        else_block: None,
     };
     checker.check_stmt(&target_stmt, &(20..30));
 
@@ -11688,6 +11692,7 @@ fn negated_literal_let_binding_coerces_signed() {
             },
             8..10,
         )),
+        else_block: None,
     };
     checker.check_stmt(&let_stmt, &(0..11));
 
@@ -11791,6 +11796,7 @@ fn const_explicit_width_assigned_to_wider_type_is_rejected() {
             14..17,
         )),
         value: Some((Expr::Identifier("N".to_string()), 20..21)),
+        else_block: None,
     };
     checker.check_stmt(&target_stmt, &(10..21));
 
@@ -15491,6 +15497,7 @@ mod non_root_module_inference_scope {
             pattern: (Pattern::Identifier("y".to_string()), 14..15),
             ty: None,
             value: Some((cast_expr, 18..26)),
+            else_block: None,
         };
         let fn_decl = FnDecl {
             attributes: vec![],
@@ -15567,6 +15574,7 @@ mod non_root_module_inference_scope {
             pattern: (Pattern::Identifier("y".to_string()), 14..15),
             ty: Some((TypeExpr::Infer, 17..18)),
             value: Some(make_int_literal(42, 21..23)),
+            else_block: None,
         };
         let fn_decl = FnDecl {
             attributes: vec![],
@@ -16019,6 +16027,7 @@ mod non_root_module_inference_scope {
             pattern: (Pattern::Identifier("f".to_string()), 10..11),
             ty: None,
             value: Some((lambda_expr, 14..21)),
+            else_block: None,
         };
         let fn_decl = FnDecl {
             attributes: vec![],
@@ -16371,6 +16380,7 @@ fn module_graph_body_private_local_type_is_available() {
                         },
                         0..10,
                     )),
+                    else_block: None,
                 },
                 0..10,
             )],
@@ -16920,6 +16930,7 @@ mod module_body_diagnostic_envelope {
             pattern: (Pattern::Identifier("y".to_string()), 14..15),
             ty: None,
             value: Some((cast_expr, 18..27)),
+            else_block: None,
         };
         let fn_decl = FnDecl {
             attributes: vec![],
@@ -18224,6 +18235,7 @@ fn bad(r: Result<i64, string>) -> Result<i64, i64> {
                     }),
                     14..16,
                 )),
+                else_block: None,
             },
             10..16,
         )];
@@ -27204,6 +27216,126 @@ mod every_attribute {
             output.errors.is_empty(),
             "irrefutable record let must emit zero checker errors; got: {:#?}",
             output.errors
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // let-else: refutable pattern admitted with a divergent `else` clause
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn let_else_with_diverging_else_no_refutable_error() {
+        // `let Ok(n) = r else { return … };` — a refutable Ok-pattern is
+        // admitted when an else clause is present and the else diverges.
+        let output = check_source(
+            "fn f(r: Result<i64, string>) -> Result<i64, string> {              let Ok(n) = r else { return Err(\"bad\") }; Ok(n) }",
+        );
+        let refutable: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::RefutableLetPattern { .. }))
+            .collect();
+        assert!(
+            refutable.is_empty(),
+            "let-else must NOT emit RefutableLetPattern; got: {:#?}",
+            output.errors
+        );
+        let diverge: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::LetElseDoesNotDiverge))
+            .collect();
+        assert!(
+            diverge.is_empty(),
+            "a diverging else must not trip LetElseDoesNotDiverge; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn let_else_ok_binding_escapes_to_enclosing_scope() {
+        // The Ok-path binder `n` must be visible in the rest of the enclosing
+        // block AFTER the let-else statement. If it did not escape, the use of
+        // `n` would cascade into UndefinedVariable.
+        let output = check_source(
+            "fn f(r: Result<i64, string>) -> Result<i64, string> {              let Ok(n) = r else { return Err(\"bad\") }; Ok(n + 1) }",
+        );
+        let unresolved: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::UndefinedVariable))
+            .collect();
+        assert!(
+            unresolved.is_empty(),
+            "let-else Ok binder must escape to the enclosing scope (no UndefinedVariable); \
+             got: {unresolved:#?}"
+        );
+        assert!(
+            output.errors.is_empty(),
+            "a well-formed let-else must type-check cleanly; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn let_else_non_diverging_else_emits_error() {
+        // `let Ok(n) = r else { 0 };` — the else block produces a value instead
+        // of diverging. It must emit exactly one LetElseDoesNotDiverge error.
+        let output =
+            check_source("fn f(r: Result<i64, string>) -> i64 { let Ok(n) = r else { 0 }; n }");
+        let diverge: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::LetElseDoesNotDiverge))
+            .collect();
+        assert_eq!(
+            diverge.len(),
+            1,
+            "a non-diverging let-else else must emit exactly one LetElseDoesNotDiverge; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn let_else_else_does_not_see_ok_binder() {
+        // The else block runs on the FAILURE path, where the Ok binder is not
+        // bound. Referencing `n` inside the else must be an UndefinedVariable.
+        let output = check_source(
+            "fn f(r: Result<i64, string>) -> i64 { let Ok(n) = r else { return n }; n }",
+        );
+        let unresolved: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::UndefinedVariable))
+            .collect();
+        assert!(
+            !unresolved.is_empty(),
+            "the else block must not see the Ok binder `n`; expected UndefinedVariable, \
+             got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn refutable_let_no_else_message_suggests_else_clause() {
+        // The reworded no-else diagnostic must point users at the `else` clause
+        // (now that let-else exists), while still mentioning if-let / match.
+        let output = check_source("fn main() -> i64 { let opt = Some(5); let Some(x) = opt; x }");
+        let refutable: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(e.kind, TypeErrorKind::RefutableLetPattern { .. }))
+            .collect();
+        assert_eq!(
+            refutable.len(),
+            1,
+            "expected one RefutableLetPattern; got: {:#?}",
+            output.errors
+        );
+        let msg = &refutable[0].message;
+        assert!(
+            msg.contains("else"),
+            "the reworded refutable-let message must suggest an `else` clause; got: {msg}"
         );
     }
 

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -1042,6 +1042,17 @@ pub enum TypeErrorKind {
         /// e.g. `"enum variant"`, `"literal"`, or `"or-pattern"`.
         kind_label: String,
     },
+    /// A `let … else { … }` clause whose else block does not diverge.
+    ///
+    /// The else block of a let-else runs when the refutable pattern fails to
+    /// match. Because control must not fall through to the binding (there is
+    /// no value bound on the failure path), the else block MUST diverge —
+    /// `return`, `break`, `continue`, a `!`-typed call, or any block whose
+    /// type is `Ty::Never`. A non-diverging else block would let execution
+    /// reach code that reads an unbound binder, so it is rejected.
+    ///
+    /// Envelope code: `E_LET_ELSE_DOES_NOT_DIVERGE`.
+    LetElseDoesNotDiverge,
     /// A function carrying `#[intrinsic("…")]` was declared outside the
     /// designated stdlib-floor modules.
     ///
@@ -1217,6 +1228,7 @@ impl TypeErrorKind {
             Self::IntrinsicOutsideFloor { .. } => "IntrinsicOutsideFloor",
             Self::IntrinsicOnMethod { .. } => "IntrinsicOnMethod",
             Self::RefutableLetPattern { .. } => "RefutableLetPattern",
+            Self::LetElseDoesNotDiverge => "LetElseDoesNotDiverge",
             Self::OpaqueDirectConstruct { .. } => "OpaqueDirectConstruct",
             Self::VisibilityViolationPrivate { .. } => "VisibilityViolationPrivate",
             Self::VisibilityViolationPackage { .. } => "VisibilityViolationPackage",

--- a/tests/vertical-slice/accept/error_prop_combined.expected
+++ b/tests/vertical-slice/accept/error_prop_combined.expected
@@ -1,0 +1,3 @@
+config: localhost:8080
+parse-failed: port
+missing-field: host

--- a/tests/vertical-slice/accept/error_prop_combined.hew
+++ b/tests/vertical-slice/accept/error_prop_combined.hew
@@ -1,0 +1,55 @@
+//! Combined error-prop idiom (v0.6): let-else + return-as-expression.
+//!
+//! The full q175 errors-as-values program: a typed `ConfigError` enum, a
+//! `parse_port` that binds-or-bails with let-else, and a `load_config` that
+//! mixes a let-else, an early `return` guard, and a final `Ok`. `?` cannot be
+//! used because the error types differ (`string` vs `ConfigError`).
+//!
+//! Observable contract: prints the formatted config on success and the typed
+//! error label on each failure path, then exits 0.
+
+enum ConfigError {
+    ParseFailed(string);
+    MissingField(string);
+}
+
+fn validate(s: string) -> Result<i64, string> {
+    if s == "8080" {
+        Ok(8080)
+    } else {
+        Err("not a port")
+    }
+}
+
+fn parse_port(s: string) -> Result<i64, ConfigError> {
+    // let-else: bind the port or bail with a wrapped error (return-as-expr in
+    // the else block).
+    let Ok(n) = validate(s) else {
+        return Err(ConfigError::ParseFailed("invalid"))
+    };
+    Ok(n)
+}
+
+fn load_config(port_str: string, host: string) -> Result<string, ConfigError> {
+    let Ok(port) = parse_port(port_str) else {
+        return Err(ConfigError::ParseFailed("port"))
+    };
+    if host.len() == 0 {
+        return Err(ConfigError::MissingField("host"))
+    }
+    Ok(f"config: {host}:{port}")
+}
+
+fn run(port_str: string, host: string) -> string {
+    match load_config(port_str, host) {
+        Ok(cfg) => cfg,
+        Err(ConfigError::ParseFailed(w)) => f"parse-failed: {w}",
+        Err(ConfigError::MissingField(w)) => f"missing-field: {w}",
+    }
+}
+
+fn main() {
+    println(run("8080", "localhost"));
+    println(run("nope", "localhost"));
+    println(run("8080", ""));
+}

--- a/tests/vertical-slice/accept/let_else_bind_or_bail.expected
+++ b/tests/vertical-slice/accept/let_else_bind_or_bail.expected
@@ -1,0 +1,2 @@
+ok: 42
+err: invalid

--- a/tests/vertical-slice/accept/let_else_bind_or_bail.hew
+++ b/tests/vertical-slice/accept/let_else_bind_or_bail.hew
@@ -1,0 +1,37 @@
+//! `let-else` bind-or-bail (v0.6 error-prop ergonomics).
+//!
+//! `let Ok(n) = validate(s) else { return Err(...) };` binds the Ok payload
+//! into the ENCLOSING scope or diverges through the else block. The binder `n`
+//! is used AFTER the let-else statement, proving it escaped the statement into
+//! the surrounding block — the defining property of let-else.
+//!
+//! Observable contract: prints the bound value on the Ok path and the
+//! propagated error on the Err path, then exits 0.
+
+fn validate(s: string) -> Result<i64, string> {
+    if s == "good" {
+        Ok(41)
+    } else {
+        Err("bad input")
+    }
+}
+
+fn parse_one(s: string) -> Result<i64, string> {
+    // The else block diverges; on a successful match `n` escapes to here.
+    let Ok(n) = validate(s) else {
+        return Err("invalid")
+    };
+    Ok(n + 1)
+}
+
+fn run(s: string) -> string {
+    match parse_one(s) {
+        Ok(v) => f"ok: {v}",
+        Err(e) => f"err: {e}",
+    }
+}
+
+fn main() {
+    println(run("good"));
+    println(run("nope"));
+}

--- a/tests/vertical-slice/accept/let_else_tuple_payload.expected
+++ b/tests/vertical-slice/accept/let_else_tuple_payload.expected
@@ -1,0 +1,2 @@
+ok=payload:42
+err=fallback

--- a/tests/vertical-slice/accept/let_else_tuple_payload.hew
+++ b/tests/vertical-slice/accept/let_else_tuple_payload.hew
@@ -1,0 +1,31 @@
+// let-else over a nested-tuple payload (v0.6 error-prop): `let Ok((n, s)) = e
+// else { return … };` destructures the tuple and binds BOTH leaf binders into
+// the enclosing scope, so `n` and `s` are live for the rest of the block. The
+// success-path prelude mirrors `match`'s aggregate-payload destructure.
+fn make_pair(good: bool) -> Result<(i64, string), string> {
+    if good {
+        Ok((7, "payload"))
+    } else {
+        Err("no-pair")
+    }
+}
+
+fn parse(good: bool) -> Result<string, string> {
+    let Ok((n, s)) = make_pair(good) else {
+        return Err("fallback")
+    };
+    let later = n + 35;
+    Ok(f"{s}:{later}")
+}
+
+fn run(good: bool) -> string {
+    match parse(good) {
+        Ok(v) => f"ok={v}",
+        Err(e) => f"err={e}",
+    }
+}
+
+fn main() {
+    println(run(true));
+    println(run(false));
+}

--- a/tests/vertical-slice/accept/let_else_unit_variant.expected
+++ b/tests/vertical-slice/accept/let_else_unit_variant.expected
@@ -1,0 +1,4 @@
+ok: unit
+err: not-A
+ok: none
+err: had-some

--- a/tests/vertical-slice/accept/let_else_unit_variant.hew
+++ b/tests/vertical-slice/accept/let_else_unit_variant.hew
@@ -1,0 +1,63 @@
+//! `let-else` over a UNIT variant (v0.6 error-prop ergonomics).
+//!
+//! `let E::A = make_e() else { return Err(...) };` checks the variant TAG and
+//! binds nothing — a unit variant carries no payload. On a match, control falls
+//! through to the rest of the enclosing block; on a mismatch the else block
+//! diverges. This is the no-payload sibling of `let Ok(n) = … else { … };`:
+//! the success prelude is empty, the MIR is a tag-test plus a diverge.
+//!
+//! The common `let None = opt else { … };` idiom rides the same path (built-in
+//! Option unit variant), exercised here alongside a user-enum unit variant.
+//!
+//! Observable contract: prints the fall-through value on the match path and the
+//! propagated error on the mismatch path, then exits 0.
+
+enum E {
+    A;
+    B(i64);
+}
+
+fn make_e(good: bool) -> E {
+    if good {
+        E::A
+    } else {
+        E::B(3)
+    }
+}
+
+fn parse(good: bool) -> Result<string, string> {
+    // User-enum unit variant: matches E::A (binds nothing) or diverges.
+    let E::A = make_e(good) else {
+        return Err("not-A")
+    };
+    Ok("unit")
+}
+
+fn require_none(r: Option<i64>) -> Result<string, string> {
+    // Built-in Option unit variant: matches None or diverges.
+    let None = r else {
+        return Err("had-some")
+    };
+    Ok("none")
+}
+
+fn show_parse(good: bool) -> string {
+    match parse(good) {
+        Ok(v) => f"ok: {v}",
+        Err(e) => f"err: {e}",
+    }
+}
+
+fn show_none(r: Option<i64>) -> string {
+    match require_none(r) {
+        Ok(v) => f"ok: {v}",
+        Err(e) => f"err: {e}",
+    }
+}
+
+fn main() {
+    println(show_parse(true));
+    println(show_parse(false));
+    println(show_none(None));
+    println(show_none(Some(9)));
+}

--- a/tests/vertical-slice/accept/return_expr_unannotated_branch.expected
+++ b/tests/vertical-slice/accept/return_expr_unannotated_branch.expected
@@ -1,0 +1,4 @@
+ok=2
+err=non-positive
+ok=12
+err=bad-arg

--- a/tests/vertical-slice/accept/return_expr_unannotated_branch.hew
+++ b/tests/vertical-slice/accept/return_expr_unannotated_branch.hew
@@ -1,0 +1,33 @@
+// return-as-expression in a diverging branch (v0.6 error-prop): an `if`/`else`
+// whose else branch `return`s leaves the construct's value type as the THEN
+// branch's type. An UNANNOTATED `let adjusted = if … else { return … }` must
+// infer `i64` (not `Never`/`Unit`) so a later `adjusted + 1` lowers as integer
+// arithmetic. Covers the let-RHS and binary-operand positions that previously
+// failed closed at MIR while the annotated and fn-arg positions worked.
+fn adjust(n: i64) -> Result<i64, string> {
+    let adjusted = if n > 0 {
+        n
+    } else {
+        return Err("non-positive")
+    };
+    Ok(adjusted + 1)
+}
+
+fn combine(n: i64) -> Result<i64, string> {
+    let ten = 10;
+    Ok(ten + if n == 1 { n + 1 } else { return Err("bad-arg") })
+}
+
+fn show(r: Result<i64, string>) -> string {
+    match r {
+        Ok(v) => f"ok={v}",
+        Err(e) => f"err={e}",
+    }
+}
+
+fn main() {
+    println(show(adjust(1)));
+    println(show(adjust(0)));
+    println(show(combine(1)));
+    println(show(combine(2)));
+}

--- a/tests/vertical-slice/accept/return_in_match_arm.expected
+++ b/tests/vertical-slice/accept/return_in_match_arm.expected
@@ -1,0 +1,2 @@
+ok: 5
+err: divide by zero

--- a/tests/vertical-slice/accept/return_in_match_arm.hew
+++ b/tests/vertical-slice/accept/return_in_match_arm.hew
@@ -6,7 +6,7 @@
 //! usable directly as a match-arm body. The diverging arm contributes `Never`,
 //! so the match's result type comes from the value-producing arm.
 //!
-//! Observable contract: pri64s the propagated error message then exits 0.
+//! Observable contract: prints the propagated error message then exits 0.
 
 fn checked_div(n: i64, d: i64) -> Result<i64, string> {
     // The error arm is a bare expression-position `return` — no block, no `;`.

--- a/tests/vertical-slice/accept/return_in_match_arm.hew
+++ b/tests/vertical-slice/accept/return_in_match_arm.hew
@@ -1,0 +1,30 @@
+//! `return` as a bare match-arm expression (v0.6 error-prop ergonomics).
+//!
+//! Before this slice, `return` was only valid in statement position; a bare
+//! `Err(e) => return Err(...)` arm errored with "return statement in expression
+//! context". `return` is now a first-class divergent (`Never`-typed) expression
+//! usable directly as a match-arm body. The diverging arm contributes `Never`,
+//! so the match's result type comes from the value-producing arm.
+//!
+//! Observable contract: pri64s the propagated error message then exits 0.
+
+fn checked_div(n: i64, d: i64) -> Result<i64, string> {
+    // The error arm is a bare expression-position `return` — no block, no `;`.
+    let safe = match d {
+        0 => return Err("divide by zero"),
+        _ => d,
+    };
+    Ok(n / safe)
+}
+
+fn run(n: i64, d: i64) -> string {
+    match checked_div(n, d) {
+        Ok(v) => f"ok: {v}",
+        Err(e) => f"err: {e}",
+    }
+}
+
+fn main() {
+    println(run(10, 2));
+    println(run(10, 0));
+}

--- a/tests/vertical-slice/reject/let_else_non_diverging.hew
+++ b/tests/vertical-slice/reject/let_else_non_diverging.hew
@@ -1,0 +1,20 @@
+//! Reject: a `let … else` whose else block does NOT diverge.
+//!
+//! The else block of a let-else runs on the failure path, where the Ok binder
+//! is not bound. It must diverge (return/break/continue/`!`-typed). An else
+//! that produces a value (here `0`) would fall through to an unbound binder, so
+//! the checker rejects it with E_LET_ELSE_DOES_NOT_DIVERGE.
+
+fn validate(s: string) -> Result<i64, string> {
+    if s == "good" { Ok(1) } else { Err("bad") }
+}
+
+fn parse_one(s: string) -> i64 {
+    let Ok(n) = validate(s) else { 0 };
+    n
+}
+
+fn main() {
+    let v = parse_one("good");
+    println(f"{v}");
+}

--- a/tests/vertical-slice/reject/refutable_let_no_else.hew
+++ b/tests/vertical-slice/reject/refutable_let_no_else.hew
@@ -1,0 +1,19 @@
+//! Reject: a refutable pattern in a plain `let` with no `else` clause.
+//!
+//! A plain `let` has no failure arm, so a refutable enum-variant pattern is
+//! rejected. With let-else now available, the reworded diagnostic suggests
+//! adding an `else { … }` clause (it must diverge) or using `if let`/`match`.
+
+fn validate(s: string) -> Result<i64, string> {
+    if s == "good" { Ok(1) } else { Err("bad") }
+}
+
+fn parse_one(s: string) -> i64 {
+    let Ok(n) = validate(s);
+    n
+}
+
+fn main() {
+    let v = parse_one("good");
+    println(f"{v}");
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -760,6 +760,9 @@ run_accept_expect_stdout "match_float_literal_arm"
 # match result type is inferred from the non-diverging arm; a return-only arm
 # (typed Unit by lower_block) must not set the match result type.
 run_accept_expect_stdout "match_diverging_arm_result_type"
+# `return` as a bare expression-position match-arm body (v0.6 error-prop):
+# `0 => return Err(...)` propagates the error; the value arm sets the result.
+run_accept_expect_stdout "return_in_match_arm"
 run_check_run_expect_stdout "const_ref_init"
 
 # W4.039 — bytes-to-string triple-ABI canonicalisation. Behavioural proof

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -767,6 +767,15 @@ run_accept_expect_stdout "return_in_match_arm"
 # binds the Ok payload into the enclosing scope (used after the statement) or
 # diverges through the else block.
 run_accept_expect_stdout "let_else_bind_or_bail"
+# let-else over a nested-tuple payload: `let Ok((n, s)) = e else { return … };`
+# destructures the tuple and escapes BOTH leaf binders into the enclosing scope
+# (the success-path prelude mirrors `match`'s aggregate-payload destructure).
+run_accept_expect_stdout "let_else_tuple_payload"
+# return-as-expression in a diverging branch: an unannotated
+# `let x = if … else { return … }` infers the value branch's type (not Never),
+# so a later `x + 1` lowers as integer arithmetic in let-RHS and binary-operand
+# positions.
+run_accept_expect_stdout "return_expr_unannotated_branch"
 # Combined error-prop idiom: let-else + return-as-expression closing the full
 # errors-as-values program (typed ConfigError, parse_port, load_config).
 run_accept_expect_stdout "error_prop_combined"

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -767,6 +767,10 @@ run_accept_expect_stdout "return_in_match_arm"
 # binds the Ok payload into the enclosing scope (used after the statement) or
 # diverges through the else block.
 run_accept_expect_stdout "let_else_bind_or_bail"
+# let-else over a UNIT variant: `let E::A = e else { return … };` and the
+# built-in `let None = opt else { … };` idiom check the variant tag and bind
+# nothing (empty success prelude), matching or diverging through the else.
+run_accept_expect_stdout "let_else_unit_variant"
 # let-else over a nested-tuple payload: `let Ok((n, s)) = e else { return … };`
 # destructures the tuple and escapes BOTH leaf binders into the enclosing scope
 # (the success-path prelude mirrors `match`'s aggregate-payload destructure).

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -763,6 +763,13 @@ run_accept_expect_stdout "match_diverging_arm_result_type"
 # `return` as a bare expression-position match-arm body (v0.6 error-prop):
 # `0 => return Err(...)` propagates the error; the value arm sets the result.
 run_accept_expect_stdout "return_in_match_arm"
+# let-else bind-or-bail (v0.6 error-prop): `let Ok(n) = e else { return … };`
+# binds the Ok payload into the enclosing scope (used after the statement) or
+# diverges through the else block.
+run_accept_expect_stdout "let_else_bind_or_bail"
+# Combined error-prop idiom: let-else + return-as-expression closing the full
+# errors-as-values program (typed ConfigError, parse_port, load_config).
+run_accept_expect_stdout "error_prop_combined"
 run_check_run_expect_stdout "const_ref_init"
 
 # W4.039 — bytes-to-string triple-ABI canonicalisation. Behavioural proof
@@ -2845,6 +2852,28 @@ if grep -q 'has no binding' "${reject_output}"; then
   cat "${reject_output}" >&2
   exit 1
 fi
+
+# Reject: a `let … else` whose else block does not diverge. The non-diverging
+# else (`{ 0 }`) trips the new E_LET_ELSE_DOES_NOT_DIVERGE diagnostic.
+expect_check_fail_error_count \
+    "${ROOT}/tests/vertical-slice/reject/let_else_non_diverging.hew" \
+    1 \
+    "let_else_non_diverging"
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/let_else_non_diverging.hew" \
+    "must diverge" \
+    "let_else_non_diverging_message"
+
+# Reject: a refutable pattern in a plain `let` with no `else`. The reworded
+# diagnostic must suggest adding an `else` clause now that let-else exists.
+expect_check_fail_error_count \
+    "${ROOT}/tests/vertical-slice/reject/refutable_let_no_else.hew" \
+    1 \
+    "refutable_let_no_else"
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/refutable_let_no_else.hew" \
+    "else" \
+    "refutable_let_no_else_message"
 
 # .wrapping_as_<W> and .saturating_as_<W> width-conversion methods.
 # Tests exact values: wrapping narrowing/widening/sign-change and


### PR DESCRIPTION
## Summary

`return` is now valid in expression position, typed `Never`, and lowers to a sealing terminator in MIR. This means `Err(e) => return Err(e)` works directly as a match arm body without wrapping in a block, and `let v = if c { n } else { return err }` correctly infers `v`'s type from the non-diverging branch.

`let Pat = expr else { <diverging block> };` is now fully supported. The success pattern binds into the enclosing scope; the else branch must diverge. Payload-bearing enum variants, nested-tuple payloads (`let Ok((n, s)) = …`), and unit variants are all supported. A known unit-variant name resolves as a pattern regardless of its identifier casing, so `let INF = 999` still binds a plain variable as expected — only names that resolve to a unit variant are treated as patterns. A diverging tail-less block (one ending in `return` or a `Never`-typed expression) is now typed `Never`, which lets `if`/`match` take the value-branch type when the other branch diverges.

## Verification

- `make test-vertical-slice`: EXIT 0 — 238 fixtures pass including 6 new error-prop accept cases and 2 reject cases
- `cargo test -p hew-types`: EXIT 0 — 3184 tests pass including 284 new checker tests for return-as-expression and let-else
- `cargo test -p hew-hir -p hew-mir -p hew-compile`: EXIT 0
- `cargo clippy -p hew-hir -p hew-mir -p hew-types -p hew-analysis --all-targets`: EXIT 0
- `cargo fmt --check`: EXIT 0
- Live repro matrix verified: `return` in a match arm, `let Ok((n,s))` nested-tuple escape, `let None`/`let Idle` unit-variant else, `let INF = 999` plain binding, non-diverging else rejected with `E_LET_ELSE_DOES_NOT_DIVERGE`, binders correctly invisible in the else block
- Fail-closed cases confirmed: unit-variant let-else with unresolved payload produces `E_NOT_YET_IMPLEMENTED` (non-zero exit, no miscompile); `let x` without `else` on a refutable pattern produces a diagnostic suggesting `else { … }`

## Out of scope

- `loop {}` (and other never-terminating loops) as an `if`/`match` branch typing `Never` — pre-existing gap, neither touched nor regressed here; tracked in #2112
- The `match`/`if let`/`while let` arm uppercase-identifier heuristic mis-classifying plain uppercase bindings (e.g. `match x { INF => … }` for `x: i64`) — pre-existing, not touched by this lane; tracked in #2113
