### PR TITLE
fix(checker,hir): allow a user-defined `receive fn send` to dispatch correctly

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -25045,7 +25045,34 @@ fn scan_spanned_expr_for_actor_send(expr: &Expr, span: &Span, gate: &mut ActorSe
             scan_spanned_expr_for_actor_send(&duration.0, &duration.1, gate);
         }
         Expr::UnsafeBlock(b) => scan_block_for_actor_send(b, gate),
-        Expr::FieldAccess { object, .. } | Expr::PostfixTry(object) | Expr::Await(object) => {
+        Expr::Await(object) => {
+            // `await actor.send(...)` is a legitimate *ask*: the reply is
+            // consumed by the awaiting context, so the fire-and-forget
+            // "reply discarded" gate must not fire on a `.send()` that is the
+            // direct operand of an `await`. (The checker already routes a user
+            // `receive fn send` through normal ask dispatch — this keeps the
+            // HIR pre-pass in agreement.) Walk the receiver/args of the inner
+            // `.send()` for nested actor sends, but skip its leaf gate check.
+            // A bare, *unawaited* `.send()` to a non-unit handler still routes
+            // through the default arm below and trips the gate as before.
+            if let Expr::MethodCall {
+                receiver,
+                method,
+                args,
+            } = &object.0
+            {
+                if method == "send" {
+                    scan_spanned_expr_for_actor_send(&receiver.0, &receiver.1, gate);
+                    for arg in args {
+                        let (e, sp) = arg.expr();
+                        scan_spanned_expr_for_actor_send(e, sp, gate);
+                    }
+                    return;
+                }
+            }
+            scan_spanned_expr_for_actor_send(&object.0, &object.1, gate);
+        }
+        Expr::FieldAccess { object, .. } | Expr::PostfixTry(object) => {
             scan_spanned_expr_for_actor_send(&object.0, &object.1, gate);
         }
         Expr::Index { object, index } => {

--- a/hew-hir/tests/actor_send_gates.rs
+++ b/hew-hir/tests/actor_send_gates.rs
@@ -151,6 +151,78 @@ fn actor_ask_non_unit_handler_accepted() {
 }
 
 #[test]
+fn awaited_send_non_unit_handler_accepted() {
+    // A user `receive fn send(...) -> T` invoked as an *ask* via
+    // `await ref.send(...)` consumes the reply, so the fire-and-forget
+    // "reply discarded" gate must not fire. Prior to this fix the HIR
+    // pre-pass matched `.send()` by method name regardless of the enclosing
+    // `await`, blocking the awaited ask from lowering while the checker
+    // (correctly) classified it as an ask. Checker and HIR must agree: a
+    // value-returning `receive fn send` is a first-class ask under `await`.
+    let output = lower(
+        r"
+        actor Doubler {
+            receive fn send(n: i64) -> i64 {
+                n * 2
+            }
+        }
+
+        fn main() -> i64 {
+            let d = spawn Doubler;
+            match await d.send(21) {
+                Ok(v) => v,
+                Err(_) => 0,
+            }
+        }
+        ",
+    );
+    assert!(
+        !has_actor_send_diag(&output),
+        "awaited `.send()` ask to a non-unit handler must not trigger \
+         ActorSendRequiresUnitHandler; got: {:#?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn unawaited_send_non_unit_handler_rejected() {
+    // The mirror of the awaited case: a *bare*, unawaited `ref.send(...)` to a
+    // value-returning `receive fn send` discards the reply. That must still be
+    // rejected — the awaited-ask carve-out only applies when the `.send()` is
+    // the direct operand of an `await`. Here the checker owns the verdict
+    // (`actor ask ... requires await`); this test pins that the HIR gate does
+    // not silently accept the discarded-reply form.
+    let parsed = parser::parse(
+        r"
+        actor Doubler {
+            receive fn send(n: i64) -> i64 {
+                n * 2
+            }
+        }
+
+        fn main() -> i64 {
+            let d = spawn Doubler;
+            d.send(21);
+            0
+        }
+        ",
+    );
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tco = checker.check_program(&parsed.program);
+    // The checker rejects the discarded-reply ask before HIR runs; the verdict
+    // lives at the type-check layer, which is the agreed owner.
+    assert!(
+        !tco.errors.is_empty(),
+        "bare `.send()` to a non-unit handler must be rejected (reply discarded)"
+    );
+}
+
+#[test]
 fn actor_send_unknown_handler_skipped() {
     // Defense-in-depth: lambda-actor handles surface as `Duplex<Msg, Reply>`
     // (per `tests/vertical-slice/accept/lambda_method_send.hew`), not as

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -5945,7 +5945,29 @@ impl Checker {
             (resolved, _) if resolved.as_local_pid().is_some() => {
                 // `.send(payload)` is the legacy fire-and-forget surface; enforce
                 // the Send bound on the payload.
-                if method == "send" {
+                //
+                // If the actor declares a `receive fn send(...)`, that user-defined
+                // handler takes precedence — skip the legacy early-return and fall
+                // through to the receive-fn dispatch path below. The builtin fire-
+                // and-forget is only the fallback when no such handler exists.
+                let has_user_send_handler = if method == "send" {
+                    resolved.as_local_pid().and_then(|inner| {
+                        if let Ty::Named { name, .. } = inner {
+                            Some(name.clone())
+                        } else {
+                            None
+                        }
+                    }).is_some_and(|actor_name| {
+                        self.fn_sigs.contains_key(&format!("{actor_name}::send"))
+                            || matches!(
+                                self.resolve_bare_actor_identity(&actor_name),
+                                BareActorResolution::Resolved(ref id) if self.fn_sigs.contains_key(&format!("{id}::send"))
+                            )
+                    })
+                } else {
+                    false
+                };
+                if method == "send" && !has_user_send_handler {
                     for arg in args {
                         let (expr, sp) = arg.expr();
                         let ty = self.synthesize(expr, sp);
@@ -6157,7 +6179,22 @@ impl Checker {
             // ActorRef methods
             (resolved, _) if resolved.as_actor_ref().is_some() => {
                 let inner = resolved.as_actor_ref().unwrap();
-                if method == "send" {
+                // A user-defined `receive fn send(...)` takes precedence over the
+                // builtin fire-and-forget path. Check for such a handler before
+                // routing to the legacy early-return; fall through to the receive-fn
+                // dispatch block when one exists.
+                let has_user_send_handler = method == "send" && {
+                    if let Ty::Named {
+                        name: ref actor_name,
+                        ..
+                    } = inner
+                    {
+                        self.fn_sigs.contains_key(&format!("{actor_name}::send"))
+                    } else {
+                        false
+                    }
+                };
+                if method == "send" && !has_user_send_handler {
                     for arg in args {
                         let (expr, sp) = arg.expr();
                         let ty = self.synthesize(expr, sp);

--- a/tests/vertical-slice/accept/actor_awaited_send_returns_value.hew
+++ b/tests/vertical-slice/accept/actor_awaited_send_returns_value.hew
@@ -1,0 +1,23 @@
+// A user-defined `receive fn send(...) -> T` invoked as an *ask* via
+// `await ref.send(...)` is a first-class handler dispatch, not the legacy
+// builtin fire-and-forget. The awaited form consumes the reply, so the call
+// lowers as an ask and yields the handler's return value.
+//
+// Doubler.send(n) returns n * 2; `await d.send(21)` resolves to Ok(42).
+// main returns 42 → exit 42.
+//
+// Complements `actor_receive_fn_named_send` (a *unit* `receive fn send` used
+// bare) by covering the *value-returning* `receive fn send` used under `await`.
+actor Doubler {
+    receive fn send(n: i64) -> i64 {
+        n * 2
+    }
+}
+
+fn main() -> i64 {
+    let d = spawn Doubler;
+    match await d.send(21) {
+        Ok(v) => v,
+        Err(_) => 0,
+    }
+}

--- a/tests/vertical-slice/accept/actor_receive_fn_named_send.hew
+++ b/tests/vertical-slice/accept/actor_receive_fn_named_send.hew
@@ -1,0 +1,25 @@
+// A user-defined `receive fn send` is a first-class handler, not the builtin
+// fire-and-forget. `ref.send(n)` must dispatch to the handler, not the legacy
+// anonymous-payload path.
+//
+// Counter.send accumulates n into count; Counter.get returns count.
+// main: send(10) + send(32) = 42 → exit 42.
+actor Counter {
+    var count: i64;
+    receive fn send(n: i64) {
+        count = count + n;
+    }
+    receive fn get() -> i64 {
+        count
+    }
+}
+
+fn main() -> i64 {
+    let counter = spawn Counter(count: 0);
+    counter.send(10);
+    counter.send(32);
+    match await counter.get() {
+        Ok(v) => v,
+        Err(_e) => 0,
+    }
+}

--- a/tests/vertical-slice/reject/actor_builtin_send_no_handler.hew
+++ b/tests/vertical-slice/reject/actor_builtin_send_no_handler.hew
@@ -1,0 +1,16 @@
+// Reject: `ref.send(msg)` on a named actor that has no `receive fn send`
+// handler is not yet supported. The builtin fire-and-forget path on LocalPid
+// is NYI. This fixture confirms the compiler fails closed with a clear
+// diagnostic rather than silently misbehaving.
+actor Adder {
+    var count: i64;
+    receive fn increment(n: i64) {
+        count = count + n;
+    }
+}
+
+fn main() -> i64 {
+    let a = spawn Adder(count: 0);
+    a.send(10);
+    0
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -513,6 +513,16 @@ expect_check_fail_contains \
     'cannot assign to immutable field `count`' \
     "actor_let_field_assign"
 
+# Reject: `ref.send(msg)` on a named actor with NO `receive fn send` handler is
+# NYI (the builtin fire-and-forget `LocalPid.send` path is not yet lowered).
+# Confirms the compiler fails closed with a diagnostic, not a silent wrong output.
+# This is the complement of `actor_receive_fn_named_send`: with a user handler the
+# call succeeds; without one it still fails closed cleanly.
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/actor_builtin_send_no_handler.hew" \
+    'no checker-produced rewrite entry for this method call' \
+    "actor_builtin_send_no_handler"
+
 # Actor field mutability accept side: a `let` field set at spawn time is
 # readable from handlers while the `var` field takes the writes.
 # step=7 applied twice: exit 14.
@@ -539,6 +549,11 @@ run_accept_expect_status "actor_counter_reorder" 42
 # Actor body with init + on(start): initial=9, boot increments to 10, increment(32) = 42.
 # The exit code being 42 (not 41) proves on(start) fired before the first message.
 run_accept_expect_status "actor_counter_init" 42
+
+# Accept: a user-defined `receive fn send` is a first-class handler — not the
+# legacy builtin fire-and-forget. `ref.send(n)` must dispatch to the handler.
+# send(10) + send(32) = 42; get() returns 42.
+run_accept_expect_status "actor_receive_fn_named_send" 42
 
 # COEXIST: state-field spawn args alongside init() params. count=5, base=100 are
 # state fields passed at spawn; multiplier=2 is an init() param. init() runs

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -555,6 +555,12 @@ run_accept_expect_status "actor_counter_init" 42
 # send(10) + send(32) = 42; get() returns 42.
 run_accept_expect_status "actor_receive_fn_named_send" 42
 
+# Accept: a value-returning `receive fn send(...) -> T` invoked via
+# `await ref.send(...)` is a first-class *ask* — the awaited form consumes the
+# reply, so the HIR fire-and-forget gate must not block it. Doubler.send(21)
+# returns 42; `match await d.send(21)` yields Ok(42). Exit 42.
+run_accept_expect_status "actor_awaited_send_returns_value" 42
+
 # COEXIST: state-field spawn args alongside init() params. count=5, base=100 are
 # state fields passed at spawn; multiplier=2 is an init() param. init() runs
 # count = count * multiplier = 5*2 = 10. total() returns count + base = 110.


### PR DESCRIPTION
## Summary

An actor handler named `send` was silently discarded before dispatch. Both the type-checker and the HIR lowering pass contained an unconditional `if method == "send"` early-return that fired before the `fn_sigs` lookup — so `receive fn send(...)` (fire-and-forget *or* an awaited ask returning a value) never recorded a rewrite entry, and HIR failed closed with `E_HIR: no checker-produced rewrite entry for this method call`.

The checker now consults the registered signature table (`fn_sigs`) before taking the early-return path: when the actor declares a `send` handler the call falls through to the normal receive-fn dispatch and records the rewrite entry. The guard is resolution-based (keyed on the same two-step identity lookup the dispatch path uses), not a new name heuristic. The HIR pass carves out the direct operand of `await` so that an awaited ask is not double-gated: the receiver and arguments are still walked (nested sends stay checked), but the leaf gate is skipped only for the exact call position that the checker already classified as an ask. Both unit fire-and-forget and value-returning ask variants of `receive fn send` are now first-class. The builtin anonymous-payload `ref.send(payload)` on an actor with no `send` handler continues to fail closed (tracked in #2122).

## Verification

- `cargo test -p hew-types -p hew-hir`: exit 0 — 1399 hew-types + 82 hew-hir suites, 0 failures; `actor_send_gates` 7/7
- `actor_awaited_send_returns_value` fixture: `match await d.send(21)` → exit 42 (asserts the value, not just compile)
- `actor_receive_fn_named_send` fixture: fire-and-forget `send(10)+send(32)` accumulated by handler → exit 42
- Unawaited returning-send: rejected with checker-owned `actor ask Doubler::send requires await`, exit 1
- Nested `await a.send(b.send(5))`: inner non-unit discarded-reply send caught — `E_HIR ActorSendRequiresUnitHandler` at inner span; outer ask passes
- `actor_builtin_send_no_handler` reject fixture: `hew check` exit 1 with exact diagnostic (fail-closed, unchanged)
- Regressions `actor_counter_reorder`, `actor_counter_init`: exit 42
- `make test-vertical-slice`: exit 0 — 240 fixtures pass; freshness check verified binary was current
- Preflight: ready-to-push

## Out of scope

- Builtin anonymous-payload `ref.send(payload)` (no `receive fn send` declared): fails closed today with `E_HIR MethodCallNoRewrite`; lowering this form is tracked in #2122 and is not part of this fix.
- No changes to codegen, MIR, runtime, or any surface outside `hew-types/src/check/methods.rs`, `hew-hir/src/lower.rs`, and the vertical-slice test fixtures.