### PR TITLE
ci(cache): wire sccache into Rust CI build jobs

### DIFF
--- a/.github/actions/setup-rust-build/action.yml
+++ b/.github/actions/setup-rust-build/action.yml
@@ -1,9 +1,11 @@
 name: Setup Rust build environment
 description: >
   Install the stable Rust toolchain, optional cargo tools (via
-  taiki-e/install-action), and Swatinem/rust-cache.  Extracts the
-  repeated three-step sequence that every Rust job in ci.yml and
-  release-gate.yml otherwise duplicates.
+  taiki-e/install-action), Swatinem/rust-cache for the registry/deps
+  layer, and mozilla-actions/sccache-action for the workspace-crate
+  compilation cache (GitHub Actions cache backend, content-addressed,
+  disk-safe).  Extracts the repeated setup sequence that every Rust job
+  in ci.yml and release-gate.yml otherwise duplicates.
 
 inputs:
   components:
@@ -52,6 +54,28 @@ runs:
       if: inputs.tools != ''
       with:
         tool: ${{ inputs.tools }}
+
+    # ── sccache: workspace-crate compilation cache ─────────────────────────
+    # Promotes the .cargo/config.toml opt-in annotation to CI reality.
+    # Uses the GitHub Actions cache backend (content-addressed, no blob
+    # expansion — the ENOSPC cause that led to dropping target/ caching in
+    # e9f65f19 was blob size, not sccache).  Swatinem/rust-cache below
+    # continues to handle the registry/deps layer; sccache handles workspace
+    # crate compilation.  The two compose: sccache caches compiler
+    # invocations; Swatinem caches the registry.  SCCACHE_CACHE_SIZE bounds
+    # the on-disk buffer; the GHA cache has its own 10 GB/repo ceiling.
+    - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+      with:
+        # Always pull the latest released sccache binary unless we need to
+        # pin for a specific fix.  The action itself is SHA-pinned above.
+        version: "v0.10.0"
+
+    - name: Export sccache environment variables
+      shell: bash
+      run: |
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+        echo "SCCACHE_CACHE_SIZE=2G" >> "$GITHUB_ENV"
 
     - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,12 +252,13 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Free runner disk
-        # This job runs a release build (hew-runtime + hew-lsp), a wasm32 build,
-        # and the full debug workspace nextest run on one ubuntu-24.04 runner.
-        # That combination is the same shape release-gate documents as
-        # disk-marginal; the runner process itself died of ENOSPC twice (after
-        # all tests passed, and again mid-test-step — see PR #1994). Mirror the
-        # same preinstalled-toolchain purge release-gate already carries.
+        # This job installs LLVM 22.1.5 (~1.5 GB), builds the release hew-runtime
+        # + hew-lsp binaries, the wasm32-wasip1 runtime, and runs the full debug
+        # workspace nextest suite — all on one ubuntu-24.04 runner (~14 GB free).
+        # The runner died of ENOSPC twice before this step was added (PR #1994).
+        # Code coverage moved to the nightly workflow (c24721fa) so target/llvm-cov-target/
+        # no longer accumulates here; the preinstalled-toolchain purge below still
+        # recovers the headroom the LLVM download + workspace nextest target/ needs.
         run: |
           sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/.ghcup \
             /opt/hostedtoolcache/CodeQL /usr/local/share/boost /usr/share/swift || true


### PR DESCRIPTION
## Summary

`mozilla-actions/sccache-action` (SHA-pinned to `9e7fa8a1`, `v0.0.10`) is wired into the shared `setup-rust-build` composite action with `RUSTC_WRAPPER=sccache` and the GitHub Actions Cache backend (`SCCACHE_GHA_ENABLED=true`). Every Rust job that calls the composite action now content-addresses workspace-crate compilation through sccache; registry deps already hit `Swatinem/rust-cache`, which is unchanged. The Linux gate is currently ~30 min, dominated by a cold nextest compile (~700s) and a cold `.hew` ratchet compile (~400s); `Swatinem/rust-cache` caches registry deps but not the ~90 workspace crates, and `target/` blob-caching was dropped for macOS after ENOSPC failures (#1994). With a warm sccache store those compile-heavy steps are expected to drop ~350–500s on subsequent runs. The first CI run against this PR is a cold miss — expected; the saving shows on the second run onward.

The disk-comment in the `Free runner disk` step is updated to reflect current reality: coverage moved to nightly (`c24721fa`) so `target/llvm-cov-target/` no longer accumulates here, and the real consumers are now LLVM (~1.5 GB), the release build, wasm32, and nextest `target/`. The `sudo rm -rf` purge commands are byte-for-byte unchanged.

A follow-on will split the Linux job into parallel nextest + ratchet children, which will add another ~6–7 min off the end-to-end gate time on top of the warm cache.

## Verification

- `scripts/check-preflight-ci-parity.sh --verbose`: 14/14 preflight↔CI checks present, 9/9 CI build-and-test steps mapped, 5/5 GAP-2 assertions pass — exit 0. No proving gate removed or weakened.
- `actionlint .github/workflows/ci.yml`: exit 0.
- SHA pin verified: `mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696` matches upstream `v0.0.10` tag dereference. The `# v0.0.10` comment is accurate.
- sccache content-addressed: object key = compiler binary + full argument list + preprocessed source + relevant env. Changed source produces a different hash; there is no non-hermetic key that could serve a stale object for changed source — no false-green path.
- Diff stat: exactly two files changed (`.github/actions/setup-rust-build/action.yml` +27/-3, `.github/workflows/ci.yml` comment-only +7/-6). No stray edits.
- Preflight: ready-to-push.

## Out of scope

- Parallel nextest + ratchet job split: higher impact but a separate change; deferred to the follow-on CI speed lane.
- Raising `SCCACHE_CACHE_SIZE` above 2G: the current bound is intentionally conservative given the ENOSPC history. After the warm run, `sccache --show-stats` from the Post Run step will show the hit rate; if local eviction is frequent, bumping to 4–5G is the lever.
- macOS `target/` blob-caching: dropped in #1994 due to ENOSPC; sccache is the replacement strategy for macOS workspace-crate compilation.