### PR TITLE
fix(codegen): emit fcmp une for float != so NaN != NaN is true

### DIFF
--- a/examples/playground/basics/float_nonfinite_compare.expected
+++ b/examples/playground/basics/float_nonfinite_compare.expected
@@ -3,6 +3,6 @@ nan==inf false
 inf==inf true
 neg_inf==inf false
 neg_zero==zero true
-nan!=nan false
-nan!=inf false
+nan!=nan true
+nan!=inf true
 inf!=neg_inf true

--- a/examples/playground/basics/float_nonfinite_compare.hew
+++ b/examples/playground/basics/float_nonfinite_compare.hew
@@ -18,7 +18,7 @@ fn main() {
     // -0.0 and 0.0 are equal under IEEE-754.
     println(f"neg_zero==zero {neg_zero == zero}");
 
-    // Ordered not-equal: false whenever a NaN is involved.
+    // Unordered not-equal: true whenever a NaN is involved (IEEE-754 UNE).
     println(f"nan!=nan {nan != nan}");
     println(f"nan!=inf {nan != inf}");
     println(f"inf!=neg_inf {inf != neg_inf}");

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -13027,7 +13027,10 @@ fn lower_instruction(
                 .into_float_value();
             let llvm_pred = match pred {
                 CmpPred::Eq => FloatPredicate::OEQ,
-                CmpPred::NotEq => FloatPredicate::ONE,
+                // UNE (unordered-not-equal): returns true when either operand is NaN,
+                // matching IEEE-754 — `NaN != NaN` must be true.  ONE (ordered-not-equal)
+                // was wrong here because it returns false whenever either operand is NaN.
+                CmpPred::NotEq => FloatPredicate::UNE,
                 CmpPred::SignedLess => FloatPredicate::OLT,
                 CmpPred::SignedLessEq => FloatPredicate::OLE,
                 CmpPred::SignedGreater => FloatPredicate::OGT,

--- a/hew-codegen-rs/tests/float_emission.rs
+++ b/hew-codegen-rs/tests/float_emission.rs
@@ -174,8 +174,16 @@ fn float_emission_rem_emits_frem() {
     );
 }
 
+// IEEE-754 comparison predicate coverage.
+//
+// `==`         → OEQ (ordered-equal):         NaN == NaN is false.
+// `!=`         → UNE (unordered-not-equal):   NaN != NaN is true.
+// `< <= > >=`  → ordered predicates:          any NaN operand yields false.
+//
+// Prior to this fix `!=` incorrectly emitted ONE (ordered-not-equal), making
+// NaN != NaN return false — violating IEEE-754.
 #[test]
-fn float_emission_cmp_emits_ordered_fcmp_for_f64_and_f32() {
+fn float_emission_cmp_emits_correct_fcmp_predicates() {
     let ll = emit_ll(
         "fn main() -> i64 {
             let a: f64 = 1.0;
@@ -190,9 +198,21 @@ fn float_emission_cmp_emits_ordered_fcmp_for_f64_and_f32() {
         }",
         "float_cmp",
     );
+    // == must be ordered-equal so that NaN == NaN is false.
+    assert!(
+        ll.contains("fcmp oeq double"),
+        "float `==` must emit `fcmp oeq double`; got:\n{ll}"
+    );
+    // != must be unordered-not-equal so that NaN != NaN is true (IEEE-754).
+    assert!(
+        ll.contains("fcmp une double"),
+        "float `!=` must emit `fcmp une double`; got:\n{ll}"
+    );
+    assert!(
+        !ll.contains("fcmp one double"),
+        "float `!=` must NOT emit `fcmp one double` (ONE makes NaN != NaN false); got:\n{ll}"
+    );
     for expected in [
-        "fcmp oeq double",
-        "fcmp one double",
         "fcmp olt double",
         "fcmp ole double",
         "fcmp ogt double",
@@ -200,7 +220,7 @@ fn float_emission_cmp_emits_ordered_fcmp_for_f64_and_f32() {
     ] {
         assert!(
             ll.contains(expected),
-            "FloatCmp must emit ordered `{expected}`; got:\n{ll}"
+            "float ordered comparison must emit `{expected}`; got:\n{ll}"
         );
     }
 }

--- a/hew-sandbox-vm/bytecode/opcodes-v0.md
+++ b/hew-sandbox-vm/bytecode/opcodes-v0.md
@@ -93,7 +93,10 @@ f64, and string operands. The interpreter dispatches on the runtime value kind
 | `cmp.ge` | bool | lhs, rhs |
 
 Comparison semantics must match canonical Hew for admitted operand types. For
-unsupported types, profile admission or runtime execution must fail closed.
+f64 operands, `cmp.eq` is ordered equal (`NaN == NaN` is false) and `cmp.ne` is
+unordered not-equal (`NaN != NaN` and `NaN != inf` are true), matching native
+LLVM `fcmp oeq`/`fcmp une`. For unsupported types, profile admission or runtime
+execution must fail closed.
 
 ## Calls
 

--- a/hew-sandbox-vm/src/interpreter/interpreter.ts
+++ b/hew-sandbox-vm/src/interpreter/interpreter.ts
@@ -1195,16 +1195,11 @@ class Interpreter {
         }
         return canonicalComparable(left) === canonicalComparable(right);
       case "cmp.ne":
-        // f64 inequality mirrors native `fcmp ONE` (ordered not-equal): true only
-        // when both operands are non-NaN AND differ. If either is NaN the result
-        // is false — so `nan != nan`, `nan != inf` are both false, unlike JS `!==`
-        // (which is true when a NaN is present). Model ONE explicitly.
+        // f64 inequality mirrors native `fcmp UNE` (unordered not-equal): true
+        // when the operands differ or either operand is NaN. JS `!==` matches
+        // UNE exactly (`NaN!==NaN` and `NaN!==Infinity` are true).
         if (left.kind === "f64" && right.kind === "f64") {
-          return (
-            !Number.isNaN(left.value) &&
-            !Number.isNaN(right.value) &&
-            left.value !== right.value
-          );
+          return left.value !== right.value;
         }
         return canonicalComparable(left) !== canonicalComparable(right);
       case "cmp.lt":

--- a/hew-sandbox-wasm/tests/parity.rs
+++ b/hew-sandbox-wasm/tests/parity.rs
@@ -34,8 +34,8 @@ const PARITY_CASES: &[ParityCase] = &[
     },
     ParityCase {
         // Non-finite f64 equality: NaN never equal, ±Infinity compare by sign,
-        // -0.0 == 0.0. `==` mirrors native `fcmp OEQ` and `!=` mirrors `fcmp ONE`
-        // (false whenever a NaN operand is present), proving the sandbox no longer
+        // -0.0 == 0.0. `==` mirrors native `fcmp OEQ` and `!=` mirrors `fcmp UNE`
+        // (true whenever a NaN operand is present), proving the sandbox no longer
         // collapses NaN/±Infinity through the canonical-JSON path.
         test_name: "float_nonfinite_compare",
         source_rel: "examples/playground/basics/float_nonfinite_compare.hew",

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -301,8 +301,9 @@ const CONSTRUCTS: &[Construct] = &[
     },
     Construct {
         id: "non-finite f64 comparison (`==`/`!=`)",
-        // f64 `==`/`!=` now mirror native `fcmp OEQ`/`ONE`: NaN never equal,
-        // ±Infinity compare by sign, -0.0 == 0.0. Pinned to float_nonfinite_compare.
+        // f64 `==`/`!=` now mirror native `fcmp OEQ`/`UNE`: NaN never equal,
+        // NaN is always unequal, ±Infinity compare by sign, -0.0 == 0.0. Pinned
+        // to float_nonfinite_compare.
         probe: "fn main() {\n    let nan: f64 = 0.0 / 0.0;\n    println(nan == nan);\n}\n",
         coverage: Coverage::Parity("float_nonfinite_compare"),
     },

--- a/scripts/gen-playground-manifest.py
+++ b/scripts/gen-playground-manifest.py
@@ -107,7 +107,7 @@ SANDBOX_CAPABILITY: dict[str, str] = {
     "basics/float_arithmetic": "runnable",
     "basics/float_division": "runnable",
     # Non-finite f64 equality (NaN/±Infinity) executes at native parity now that
-    # the sandbox VM compares f64 operands with IEEE OEQ/ONE semantics.
+    # the sandbox VM compares f64 operands with IEEE OEQ/UNE semantics.
     "basics/float_nonfinite_compare": "runnable",
     "basics/mixed_numeric": "runnable",
     # Statement-position if/match/if-let lower to branch terminators in sandbox

--- a/tests/vertical-slice/accept/float_nan_semantics.hew
+++ b/tests/vertical-slice/accept/float_nan_semantics.hew
@@ -1,0 +1,39 @@
+// IEEE-754 NaN comparison semantics.
+//
+// NaN != NaN  must be true  (UNE — unordered-not-equal).
+// NaN == NaN  must be false (OEQ — ordered-equal).
+// Ordered comparisons (< <= > >=) with NaN must be false.
+fn main() -> i64 {
+    let nan: f64 = 0.0 / 0.0;
+    let one: f64 = 1.0;
+    let two: f64 = 2.0;
+    // NaN != NaN → true
+    if nan != nan {} else {
+        return 1;
+    }
+    // NaN == NaN → false
+    if nan == nan {
+        return 2;
+    }
+    // 1.0 != 2.0 → true
+    if one != two {} else {
+        return 3;
+    }
+    // 1.0 != 1.0 → false
+    if one != one {
+        return 4;
+    }
+    // 1.0 == 1.0 → true
+    if one == one {} else {
+        return 5;
+    }
+    // NaN < 1.0 → false (ordered)
+    if nan < one {
+        return 6;
+    }
+    // NaN > 1.0 → false (ordered)
+    if nan > one {
+        return 7;
+    }
+    return 0;
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -343,6 +343,7 @@ expect_check_fail_contains \
 run_accept_expect_status "map_literal_string_keys" 0
 run_accept_expect_status "map_literal_empty_annotated" 0
 run_accept_expect_stdout "array_literal_float_sum"
+run_accept_expect_status "float_nan_semantics" 0
 run_accept_expect_stdout "array_literal_string_for_each"
 run_accept_expect_status "iter_manual_next_42" 42
 run_accept_expect_status "gen_next_stack_bounded" 0


### PR DESCRIPTION
## Summary

Float `!=` was lowered to `fcmp one` (ordered-not-equal), which returns false whenever either operand is NaN. This meant `NaN != NaN` evaluated to false — contradicting IEEE-754, which requires any comparison involving NaN (other than `!=`) to return false, and `!=` specifically to return true. The `hash_eligibility` logic in the compiler also relies on `NaN != NaN == true` to exclude `f32`/`f64` from HashMap key types; the wrong predicate made floats appear hash-eligible by accident.

I've switched `CmpPred::NotEq` to `fcmp une` (unordered-not-equal), which correctly returns true when either operand is NaN. The ordered predicates (`<`, `<=`, `>`, `>=`) and `==` (`fcmp oeq`) are unchanged — those already have the right behaviour for NaN (all ordered comparisons correctly return false for NaN).

## Verification

- `cargo test -p hew-codegen-rs`: DEFERRED to CI — local target is cold and disk is constrained; the codegen unit tests including `float_emission` cover the predicate selection directly
- `tests/vertical-slice/accept/float_nan_semantics.hew`: new fixture asserts `NaN != NaN == true`, `NaN == NaN == false`, and that all ordered comparisons with NaN return false
- `playground/basics/float_nonfinite_compare.{hew,.expected}`: migrated forward to match corrected NaN behaviour
- Preflight: pre-push hook (fmt check) passed on push

## Out of scope

- Unordered vs ordered semantics for `==` — `fcmp oeq` is intentional; `NaN == NaN` should be false per IEEE-754 and is already correct
- Signalling NaN handling — Hew does not expose sNaN and this fix does not change that
- Float hash eligibility enforcement in the type checker — the existing `hash_eligibility` guard already excludes `f32`/`f64`; this fix just ensures the runtime predicate matches the static assumption