### PR TITLE
fix(cli): fail closed on invalid machine input

### DIFF
--- a/hew-cli/src/machine.rs
+++ b/hew-cli/src/machine.rs
@@ -112,11 +112,15 @@ fn check_machines_or_ast_fallback(
     path: &str,
     source: &str,
     ast_machines: &[MachineDecl],
+    supports_no_check: bool,
 ) -> MachineCheckResult {
     if ast_machines.iter().any(|m| !m.type_params.is_empty()) {
-        eprintln!(
-            "{path}: advisory: generic machine(s) skipping HIR checks — use --no-check to suppress"
-        );
+        let suppression_hint = if supports_no_check {
+            " — use --no-check to suppress"
+        } else {
+            ""
+        };
+        eprintln!("{path}: warning: generic machine(s) skipping HIR checks{suppression_hint}");
         return MachineCheckResult::AstFallback;
     }
 
@@ -133,7 +137,9 @@ fn cmd_list(path: &str) {
     let source = read_source(path);
     let machines = parse_machines(path, &source);
 
-    let _ = check_machines_or_ast_fallback(path, &source, &machines);
+    // `list` renders from the AST below, but keeps fail-closed HIR validation
+    // for non-generic machines.
+    check_machines_or_ast_fallback(path, &source, &machines, false);
 
     for md in &machines {
         println!("machine {} {{", md.name);
@@ -183,7 +189,7 @@ fn cmd_diagram(path: &str, args: &MachineDiagramArgs) {
     let ast_machines = parse_machines(path, &source);
 
     if args.check {
-        match check_machines_or_ast_fallback(path, &source, &ast_machines) {
+        match check_machines_or_ast_fallback(path, &source, &ast_machines, true) {
             MachineCheckResult::AstFallback => {
                 // Fall through to AST rendering below.
             }

--- a/hew-cli/src/machine.rs
+++ b/hew-cli/src/machine.rs
@@ -10,7 +10,7 @@
 //!   hew machine diagram <file.hew> --no-check           Skip HIR static checks
 //!   hew machine list <file.hew>                         List all machines with states/events
 
-use hew_hir::{lower_program, HirDiagnosticKind, HirItem, HirMachineDecl, ResolutionCtx};
+use hew_hir::{lower_program, HirItem, HirMachineDecl, ResolutionCtx};
 use hew_parser::ast::{Item, MachineDecl};
 use hew_types::TypeCheckOutput;
 
@@ -46,6 +46,7 @@ fn parse_machines(path: &str, source: &str) -> Vec<MachineDecl> {
         for err in &result.errors {
             eprintln!("{path}: parse error: {err:?}");
         }
+        std::process::exit(1);
     }
 
     result
@@ -81,23 +82,8 @@ fn check_and_lower(path: &str, source: &str) -> Vec<HirMachineDecl> {
         hew_hir::TargetArch::host(),
     );
 
-    // Filter out NotYetImplemented diagnostics from non-machine items —
-    // Lane A only lowers machines; functions are also lowered if present.
-    let machine_errors: Vec<_> = lowered
-        .diagnostics
-        .iter()
-        .filter(|d| {
-            !matches!(
-                &d.kind,
-                HirDiagnosticKind::NotYetImplemented { .. }
-                    | HirDiagnosticKind::UnresolvedSymbol { .. }
-                    | HirDiagnosticKind::ImportMissing { .. }
-            )
-        })
-        .collect();
-
-    if !machine_errors.is_empty() {
-        for diag in &machine_errors {
+    if !lowered.diagnostics.is_empty() {
+        for diag in &lowered.diagnostics {
             eprintln!("{path}: error: {}", diag.note);
         }
         std::process::exit(1);
@@ -119,11 +105,12 @@ fn check_and_lower(path: &str, source: &str) -> Vec<HirMachineDecl> {
 
 fn cmd_list(path: &str) {
     let source = read_source(path);
+    let hir_machines = check_and_lower(path, &source);
     let machines = parse_machines(path, &source);
 
-    if machines.is_empty() {
-        println!("No machines found in {path}");
-        return;
+    if hir_machines.is_empty() {
+        eprintln!("No machines found in {path}");
+        std::process::exit(1);
     }
 
     for md in &machines {

--- a/hew-cli/src/machine.rs
+++ b/hew-cli/src/machine.rs
@@ -103,15 +103,37 @@ fn check_and_lower(path: &str, source: &str) -> Vec<HirMachineDecl> {
         .collect()
 }
 
-fn cmd_list(path: &str) {
-    let source = read_source(path);
-    let hir_machines = check_and_lower(path, &source);
-    let machines = parse_machines(path, &source);
+enum MachineCheckResult {
+    Checked(Vec<HirMachineDecl>),
+    AstFallback,
+}
 
+fn check_machines_or_ast_fallback(
+    path: &str,
+    source: &str,
+    ast_machines: &[MachineDecl],
+) -> MachineCheckResult {
+    if ast_machines.iter().any(|m| !m.type_params.is_empty()) {
+        eprintln!(
+            "{path}: advisory: generic machine(s) skipping HIR checks — use --no-check to suppress"
+        );
+        return MachineCheckResult::AstFallback;
+    }
+
+    let hir_machines = check_and_lower(path, source);
     if hir_machines.is_empty() {
         eprintln!("No machines found in {path}");
         std::process::exit(1);
     }
+
+    MachineCheckResult::Checked(hir_machines)
+}
+
+fn cmd_list(path: &str) {
+    let source = read_source(path);
+    let machines = parse_machines(path, &source);
+
+    let _ = check_machines_or_ast_fallback(path, &source, &machines);
 
     for md in &machines {
         println!("machine {} {{", md.name);
@@ -158,77 +180,62 @@ fn cmd_diagram(path: &str, args: &MachineDiagramArgs) {
         args.format.clone().unwrap_or(MachineFormat::Mermaid)
     };
 
-    // Parse AST first. Any machine with non-empty type_params cannot be
-    // monomorphised by the HIR pipeline — fall back to AST renderers for
-    // those machines with an advisory on stderr (fix 4: generic crash guard).
     let ast_machines = parse_machines(path, &source);
 
     if args.check {
-        // fix 4: if any machine in the file is generic, lower_program would crash
-        // in the machine-mono pass. Detect before invoking it and fall through
-        // to AST rendering with a stderr advisory.
-        let any_generic = ast_machines.iter().any(|m| !m.type_params.is_empty());
-        if any_generic {
-            eprintln!(
-                "{path}: advisory: generic machine(s) skipping HIR checks — use --no-check to suppress"
-            );
-            // Fall through to AST rendering below.
-        } else {
-            // Run HIR checks first; exit non-zero on any machine error.
-            let hir_machines = check_and_lower(path, &source);
-
-            if hir_machines.is_empty() {
-                eprintln!("No machines found in {path}");
-                std::process::exit(1);
+        match check_machines_or_ast_fallback(path, &source, &ast_machines) {
+            MachineCheckResult::AstFallback => {
+                // Fall through to AST rendering below.
             }
+            MachineCheckResult::Checked(hir_machines) => {
+                // HIR is flat by invariant — composite grouping and the emits
+                // manifest live only on the AST. Build both side-tables keyed by
+                // machine name, threaded alongside the HIR (same pattern as
+                // groups_by_name that already existed for composites).
+                let groups_by_name: std::collections::HashMap<
+                    &str,
+                    &[hew_parser::ast::CompositeGroup],
+                > = ast_machines
+                    .iter()
+                    .map(|m| (m.name.as_str(), m.composite_groups.as_slice()))
+                    .collect();
+                // fix 3: emits manifest side-table for the HIR path.
+                let emits_by_name: std::collections::HashMap<&str, &[String]> = ast_machines
+                    .iter()
+                    .map(|m| (m.name.as_str(), m.emits.as_slice()))
+                    .collect();
 
-            // HIR is flat by invariant — composite grouping and the emits
-            // manifest live only on the AST. Build both side-tables keyed by
-            // machine name, threaded alongside the HIR (same pattern as
-            // groups_by_name that already existed for composites).
-            let groups_by_name: std::collections::HashMap<
-                &str,
-                &[hew_parser::ast::CompositeGroup],
-            > = ast_machines
-                .iter()
-                .map(|m| (m.name.as_str(), m.composite_groups.as_slice()))
-                .collect();
-            // fix 3: emits manifest side-table for the HIR path.
-            let emits_by_name: std::collections::HashMap<&str, &[String]> = ast_machines
-                .iter()
-                .map(|m| (m.name.as_str(), m.emits.as_slice()))
-                .collect();
-
-            // Filter by --machine if specified.
-            let filtered: Vec<&HirMachineDecl> = if let Some(name) = &args.machine_name {
-                let matched: Vec<_> = hir_machines.iter().filter(|m| &m.name == name).collect();
-                if matched.is_empty() {
-                    eprintln!("No machine named `{name}` found in {path}");
-                    std::process::exit(1);
-                }
-                matched
-            } else {
-                hir_machines.iter().collect()
-            };
-
-            for machine in filtered {
-                let groups = groups_by_name
-                    .get(machine.name.as_str())
-                    .copied()
-                    .unwrap_or(&[]);
-                let emits = emits_by_name
-                    .get(machine.name.as_str())
-                    .copied()
-                    .unwrap_or(&[]);
-                match format {
-                    MachineFormat::Mermaid => print_mermaid_hir(machine, groups, emits),
-                    MachineFormat::Graphviz | MachineFormat::Dot => {
-                        print_dot_hir(machine, groups, emits);
+                // Filter by --machine if specified.
+                let filtered: Vec<&HirMachineDecl> = if let Some(name) = &args.machine_name {
+                    let matched: Vec<_> = hir_machines.iter().filter(|m| &m.name == name).collect();
+                    if matched.is_empty() {
+                        eprintln!("No machine named `{name}` found in {path}");
+                        std::process::exit(1);
                     }
-                    MachineFormat::Json => print_json_hir(machine, groups, emits),
+                    matched
+                } else {
+                    hir_machines.iter().collect()
+                };
+
+                for machine in filtered {
+                    let groups = groups_by_name
+                        .get(machine.name.as_str())
+                        .copied()
+                        .unwrap_or(&[]);
+                    let emits = emits_by_name
+                        .get(machine.name.as_str())
+                        .copied()
+                        .unwrap_or(&[]);
+                    match format {
+                        MachineFormat::Mermaid => print_mermaid_hir(machine, groups, emits),
+                        MachineFormat::Graphviz | MachineFormat::Dot => {
+                            print_dot_hir(machine, groups, emits);
+                        }
+                        MachineFormat::Json => print_json_hir(machine, groups, emits),
+                    }
                 }
+                return;
             }
-            return;
         }
     }
 

--- a/hew-cli/tests/machine_e2e.rs
+++ b/hew-cli/tests/machine_e2e.rs
@@ -8,6 +8,21 @@ fn machine_fixture() -> &'static str {
     "machine Light {\n    events {\n        Toggle;\n    }\n    state Off;\n    state On;\n    on Toggle: Off => On { On }\n    on Toggle: On => Off { Off }\n}\n"
 }
 
+fn missing_import_fixture() -> &'static str {
+    "machine TrafficLight {\n\
+     \x20   events { Tick; }\n\
+     \x20   state Red;\n\
+     \x20   state Green;\n\
+     \x20   state Yellow;\n\
+     \x20   on Tick: Red => Green { Green }\n\
+     \x20   on Tick: Green => Yellow { Yellow }\n\
+     \x20   on Tick: Yellow => Red { Red }\n\
+     }\n\
+     fn main() {\n\
+     \x20   let _ = fs.read(\"test.txt\");\n\
+     }\n"
+}
+
 #[test]
 fn machine_diagram_emits_mermaid_on_stdout() {
     let dir = support::tempdir();
@@ -211,6 +226,113 @@ fn machine_diagram_no_machines_exits_non_zero() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.contains("No machines found in"), "stderr: {stderr}");
     assert!(stderr.contains("no_machine.hew"), "stderr: {stderr}");
+}
+
+#[test]
+fn machine_diagram_fails_closed_on_missing_import() {
+    let dir = support::tempdir();
+    let input = dir.path().join("missing_import.hew");
+    std::fs::write(&input, missing_import_fixture()).unwrap();
+
+    let output = Command::new(hew_binary())
+        .arg("machine")
+        .arg("diagram")
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("stateDiagram-v2"),
+        "must not emit a fabricated diagram; stdout: {stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("add 'import std::fs;'"),
+        "stderr must surface the missing-import diagnostic; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn machine_list_fails_closed_on_missing_import() {
+    let dir = support::tempdir();
+    let input = dir.path().join("missing_import.hew");
+    std::fs::write(&input, missing_import_fixture()).unwrap();
+
+    let output = Command::new(hew_binary())
+        .arg("machine")
+        .arg("list")
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("machine TrafficLight"),
+        "must not emit a fabricated inventory; stdout: {stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("add 'import std::fs;'"),
+        "stderr must surface the missing-import diagnostic; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn machine_list_fails_closed_on_parse_error() {
+    let dir = support::tempdir();
+    let input = dir.path().join("parse_err.hew");
+    std::fs::write(&input, "machine Broken {\n  state A\n  on A + => \n").unwrap();
+
+    let output = Command::new(hew_binary())
+        .arg("machine")
+        .arg("list")
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("parse error"), "stderr: {stderr}");
+}
+
+#[test]
+fn machine_diagram_no_check_still_renders() {
+    let dir = support::tempdir();
+    let input = dir.path().join("missing_import.hew");
+    std::fs::write(&input, missing_import_fixture()).unwrap();
+
+    let output = Command::new(hew_binary())
+        .arg("machine")
+        .arg("diagram")
+        .arg(&input)
+        .arg("--no-check")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("stateDiagram-v2"), "stdout: {stdout}");
+}
+
+#[test]
+fn machine_list_fails_closed_on_zero_machines() {
+    let dir = support::tempdir();
+    let input = dir.path().join("no_machine.hew");
+    std::fs::write(&input, "fn main() -> i64 {\n    0\n}\n").unwrap();
+
+    let output = Command::new(hew_binary())
+        .arg("machine")
+        .arg("list")
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("No machines found in"), "stderr: {stderr}");
 }
 
 // ── Fixtures for new gap-filling tests ───────────────────────────────────────

--- a/hew-cli/tests/machine_e2e.rs
+++ b/hew-cli/tests/machine_e2e.rs
@@ -680,6 +680,39 @@ fn machine_diagram_generic_fallback_exits_zero_with_advisory() {
 }
 
 #[test]
+fn machine_list_generic_lists_with_advisory() {
+    let dir = support::tempdir();
+    let input = dir.path().join("box.hew");
+    std::fs::write(&input, generic_fixture()).unwrap();
+
+    let output = Command::new(hew_binary())
+        .args(["machine", "list"])
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "generic machine list must not fail; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("machine Box {"), "stdout:\n{stdout}");
+    assert!(stdout.contains("  States:"), "stdout:\n{stdout}");
+    assert!(stdout.contains("    Empty"), "stdout:\n{stdout}");
+    assert!(stdout.contains("    Full { value }"), "stdout:\n{stdout}");
+    assert!(stdout.contains("  Events:"), "stdout:\n{stdout}");
+    assert!(stdout.contains("    Put { value }"), "stdout:\n{stdout}");
+    assert!(stdout.contains("  Transitions: 2"), "stdout:\n{stdout}");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("advisory: generic machine(s) skipping HIR checks"),
+        "stderr:\n{stderr}"
+    );
+}
+
+#[test]
 fn machine_diagram_generic_json_carries_type_params() {
     let dir = support::tempdir();
     let input = dir.path().join("box.hew");

--- a/hew-cli/tests/machine_e2e.rs
+++ b/hew-cli/tests/machine_e2e.rs
@@ -386,7 +386,7 @@ fn emits_fixture() -> &'static str {
      }\n"
 }
 
-/// Generic machine — HIR path must not crash; falls back to AST with advisory.
+/// Generic machine — HIR path must not crash; falls back to AST with a warning.
 fn generic_fixture() -> &'static str {
     "machine Box<T> {\n\
      \x20   events {\n\
@@ -650,12 +650,12 @@ fn machine_list_shows_emits_section() {
 // ── fix 4: generic machines fall back to AST (no crash) ──────────────────────
 
 #[test]
-fn machine_diagram_generic_fallback_exits_zero_with_advisory() {
+fn machine_diagram_generic_fallback_exits_zero_with_warning() {
     let dir = support::tempdir();
     let input = dir.path().join("box.hew");
     std::fs::write(&input, generic_fixture()).unwrap();
 
-    // Default (check) path — must not crash; must emit advisory on stderr.
+    // Default (check) path — must not crash; must emit warning on stderr.
     let output = Command::new(hew_binary())
         .args(["machine", "diagram"])
         .arg(&input)
@@ -669,8 +669,10 @@ fn machine_diagram_generic_fallback_exits_zero_with_advisory() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("advisory"),
-        "must emit advisory for generic machine; stderr:\n{stderr}"
+        stderr.contains(
+            "warning: generic machine(s) skipping HIR checks — use --no-check to suppress"
+        ),
+        "must emit warning with suppression hint for generic machine; stderr:\n{stderr}"
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -680,7 +682,7 @@ fn machine_diagram_generic_fallback_exits_zero_with_advisory() {
 }
 
 #[test]
-fn machine_list_generic_lists_with_advisory() {
+fn machine_list_generic_lists_with_warning() {
     let dir = support::tempdir();
     let input = dir.path().join("box.hew");
     std::fs::write(&input, generic_fixture()).unwrap();
@@ -707,8 +709,12 @@ fn machine_list_generic_lists_with_advisory() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("advisory: generic machine(s) skipping HIR checks"),
+        stderr.contains("warning: generic machine(s) skipping HIR checks"),
         "stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("--no-check"),
+        "list warning must not mention unsupported --no-check flag; stderr:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary

`hew machine diagram` and `hew machine list` were swallowing import errors, resolution failures, `NotYetImplemented` diagnostics, and parse errors — emitting fabricated output with exit 0 on a broken machine file. Parse errors and every HIR diagnostic are now fatal in the checked path (exit 1, no output). Both commands share a single generic-aware entry point (`check_machines_or_ast_fallback`): generic machines render from the AST with an advisory on stderr (exit 0); non-generic machines run the full HIR check and fail closed (exit 1 on any diagnostic or empty HIR result).

## Verification

- `cargo test -p hew-cli --test machine_e2e` (×3, `--test-threads=1`): 28 passed, 0 failed each run
- `cargo clippy --workspace --tests -- -D warnings`: exit 0, zero warnings
- `cargo fmt --all -- --check`: exit 0, clean
- Preflight: ready-to-push
- Manual checks: missing-import `list`/`diagram` → exit 1, no fabricated output; parse-error → exit 1; zero-machine file → exit 1 "No machines found"; valid `Box<T>` generic → exit 0 + advisory on stderr

## Out of scope

- `cmd_list` currently parses the source twice — `parse_machines` for the inventory render, then `check_machines_or_ast_fallback` runs `check_and_lower` as a pure fail-closed gate (result discarded). The double-parse is a small waste, not a defect; the intent is correct. Optional future cleanup.
