### PR TITLE
fix(types): reject crypto.random_bytes on wasm32 instead of warning

### DIFF
--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -101,7 +101,7 @@ The **Checker disposition** column documents what the type checker emits when
 | **`std::net::quic.*`, `quic.QUICEndpoint.*`, `quic.QUICConnection.*`, `quic.QUICStream.*`, `quic.QUICEvent.*`** | 🚫 Error (`Quic`) | `quic_transport` is feature-gated and not compiled for wasm32 | WASM-TODO |
 | **`std::net::dns.resolve`, `dns.lookup_host`** | 🚫 Error (`Dns`) | Native OS resolver; not compiled for wasm32 | WASM-TODO |
 | **`std::os.*`** | 🚫 Error (`OsEnv`) | Hew OS/env helpers are native-only today even where WASI may offer host data | WASM-TODO |
-| **`std::crypto::crypto.random_bytes`** | ⚠️ Warn (`CryptoRandom`) | wasm32 falls back to a seeded PRNG without host entropy; not cryptographically secure | WASM-TODO |
+| **`std::crypto::crypto.random_bytes`** | 🚫 Error (`CryptoRandom`) | Secure entropy source is native-only; fail-closed rejection until wasm32 cryptographic entropy exists | WASM-TODO |
 | Generators on WASM | ✅ Pass (basic syntax) | Cooperative scheduler | Note below |
 
 ---
@@ -200,6 +200,13 @@ would otherwise end in a trap or linker failure:
   feature-specific diagnostic rather than a native-symbol failure downstream.
   - WASM-TODO: define a host capability model for subprocess execution.
 
+- **`std::crypto::crypto.random_bytes`**: Secure randomness is backed by
+  `ring::SystemRandom`, which is native-only and absent from the wasm32 link set.
+  The checker rejects `crypto.random_bytes` on wasm32 so key material generation
+  fails closed instead of compiling to a non-cryptographic fallback or host
+  import. WASM-TODO: plumb a secure host entropy capability such as WASI
+  `random_get`.
+
 ### ⚠️ WASM-TODO (documented gap / not yet checker-gated)
 
 Rows whose **Checker disposition** is **WASM-TODO** are intentionally *not*
@@ -247,9 +254,9 @@ reject_wasm_feature   → Severity::Error    → self.errors
 
 **Reject group** is wired in:
 - `hew-types/src/check/expressions.rs :: reject_if_wasm_incompatible_expr` (scope/tasks)
-- `hew-types/src/check/calls.rs :: reject_if_wasm_incompatible_call` (link/monitor/supervisor)
+- `hew-types/src/check/calls.rs :: reject_if_wasm_incompatible_call` (link/monitor/supervisor/`random_bytes`)
 - `hew-types/src/check/registration.rs` (supervisor actor declarations)
-- `hew-types/src/check/methods.rs :: check_method_call` (stream.* / `http_client.*` / `smtp.*` / http.* / net.* / process.* / tls.* / quic.* / dns.* / os.* module calls)
+- `hew-types/src/check/methods.rs :: check_method_call` (stream.* / `http_client.*` / `smtp.*` / http.* / net.* / process.* / tls.* / quic.* / dns.* / os.* / `crypto.random_bytes` module calls)
 - `hew-types/src/check/methods.rs` Receiver match arm (`recv` → `BlockingChannelRecv`)
 - `hew-types/src/check/methods.rs` semaphore handle gate (`acquire` / `acquire_timeout` → `BlockingSemaphoreAcquire`)
 - `hew-types/src/check/methods.rs` Stream / http.Server / http.Request / net.Listener / net.Connection / process.Child / tls.TlsStream / quic.QUIC* handle match arms

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -565,11 +565,12 @@ impl Checker {
             "sleep_ms" | "sleep" => {
                 self.warn_wasm_limitation(span, WasmUnsupportedFeature::Timers);
             }
-            // crypto.random_bytes falls back to a seeded non-cryptographic PRNG
-            // on wasm32; warn rather than reject so programs can still use it
-            // for test data with the degraded-semantics caveat.
+            // crypto.random_bytes depends on a secure native-only entropy source
+            // that is absent from the wasm32 link set. Reject at check time so
+            // secure randomness fails closed instead of compiling to a non-secure
+            // host import or fallback.
             "random_bytes" => {
-                self.warn_wasm_limitation(span, WasmUnsupportedFeature::CryptoRandom);
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::CryptoRandom);
             }
             _ => {}
         }

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -5279,10 +5279,11 @@ impl Checker {
                         }
                         _ => {}
                     }
-                    // Warn-level module-qualified calls with degraded wasm32
-                    // semantics (non-cryptographic PRNG fallback).
+                    // crypto.random_bytes depends on a native-only secure entropy
+                    // source absent from the wasm32 link set; reject so secure
+                    // randomness fails closed on wasm32.
                     if name == "crypto" && method == "random_bytes" {
-                        self.warn_wasm_limitation(span, WasmUnsupportedFeature::CryptoRandom);
+                        self.reject_wasm_feature(span, WasmUnsupportedFeature::CryptoRandom);
                     }
                 }
                 if let Some(sig) = self.fn_sigs.get(&key).cloned() {

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -18818,7 +18818,7 @@ mod wasm_rejects {
         );
     }
 
-    // ── TLS / QUIC / DNS / OS reject + CryptoRandom warn ───────────────────
+    // ── TLS / QUIC / DNS / OS / CryptoRandom reject ────────────────────────
 
     fn check_wasm_with_registry(source: &str) -> TypeCheckOutput {
         let result = hew_parser::parse(source);
@@ -18906,28 +18906,28 @@ mod wasm_rejects {
     }
 
     #[test]
-    fn wasm_warns_crypto_random_bytes() {
-        // crypto.random_bytes is a WARNING, not an error, because the wasm32
-        // implementation falls back to a seeded non-cryptographic PRNG.
+    fn wasm_rejects_crypto_random_bytes() {
+        // crypto.random_bytes requires secure entropy. On wasm32, no secure
+        // implementation is linked, so the checker must fail closed.
         let source = concat!(
             "import std::crypto::crypto;\n",
             "fn main() { crypto.random_bytes(16); }\n",
         );
         let output = check_wasm_with_registry(source);
         assert!(
-            has_platform_limitation_warning(&output),
-            "crypto.random_bytes should emit a PlatformLimitation warning on WASM; got warnings: {:?}",
-            output.warnings
-        );
-        assert!(
-            platform_warning_contains(&output, "random_bytes"),
-            "warning message should mention crypto.random_bytes; got: {:?}",
-            output.warnings
-        );
-        assert!(
-            !has_platform_limitation_error(&output),
-            "crypto.random_bytes should NOT be a compile-time error on WASM; got errors: {:?}",
+            has_platform_limitation_error(&output),
+            "crypto.random_bytes should be a compile-time error on WASM; got errors: {:?}",
             output.errors
+        );
+        assert!(
+            platform_error_contains(&output, "random_bytes"),
+            "error message should mention crypto.random_bytes; got: {:?}",
+            output.errors
+        );
+        assert!(
+            !has_platform_limitation_warning(&output),
+            "crypto.random_bytes should not emit a PlatformLimitation warning on WASM; got warnings: {:?}",
+            output.warnings
         );
     }
 

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -1781,10 +1781,10 @@ pub(super) enum WasmUnsupportedFeature {
     /// POSIX APIs and is not compiled for wasm32. WASM-TODO(#1451): route through a
     /// capability-scoped WASI surface.
     OsEnv,
-    // ── Warning group additions ─────────────────────────────────────────────
-    /// `crypto.random_bytes`: on wasm32 the implementation falls back to a
-    /// seeded PRNG without host-provided entropy, so the resulting stream is
-    /// not cryptographically secure. Warn so callers can gate their use.
+    // ── Crypto reject additions ─────────────────────────────────────────────
+    /// `crypto.random_bytes`: the secure entropy source (`ring::SystemRandom`)
+    /// is native-only and absent from the wasm32 link set. Reject so callers
+    /// cannot accidentally generate key material without cryptographic entropy.
     /// WASM-TODO(#1451): plumb host entropy through WASI `random_get`.
     CryptoRandom,
     /// `encrypt.*` (`std::crypto::encrypt`): AES-256-GCM seal/open helpers are
@@ -1893,9 +1893,10 @@ impl WasmUnsupportedFeature {
                  the os runtime layer is not compiled for wasm32"
             }
             Self::CryptoRandom => {
-                "on wasm32 crypto.random_bytes falls back to a seeded PRNG without host \
-                 entropy and is not cryptographically secure; \
-                 the result is suitable for test data but not for key material"
+                "the std::crypto.random_bytes secure entropy source (ring::SystemRandom) is \
+                 native-only and absent from the wasm32 link set; no cryptographically secure \
+                 wasm32 implementation exists yet; generating key material on wasm32 would \
+                 not be secure"
             }
             Self::CryptoEncrypt => {
                 "the std::crypto::encrypt module is backed by a native-only staticlib \

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -5185,7 +5185,7 @@ fn await_stream_recv_int_element_admitted() {
     );
 }
 
-// ── WASM gate: std::crypto::encrypt and std::crypto::sign (native-only) ──────
+// ── WASM gate: std::crypto native-only surfaces ─────────────────────────────
 
 /// `std::crypto::encrypt` module calls are rejected on wasm32 with a structured
 /// `PlatformLimitation` diagnostic.  The encrypt and sign modules are backed by
@@ -5228,6 +5228,25 @@ fn wasm_rejects_crypto_sign_module_calls() {
                 && e.message.contains("std::crypto::sign")
         }),
         "expected PlatformLimitation for sign module call on wasm32, got: {:#?}",
+        output.errors
+    );
+}
+
+/// `std::crypto::crypto.random_bytes` is rejected on wasm32 with a structured
+/// `PlatformLimitation` diagnostic. The secure entropy source is native-only
+/// and absent from the wasm32 link set.
+#[test]
+fn wasm_rejects_crypto_random_bytes_module_call() {
+    let output = typecheck_inline_wasm(
+        "import std::crypto::crypto;\n\
+         fn main() { let _ = crypto.random_bytes(32); }",
+    );
+    assert!(
+        output.errors.iter().any(|e| {
+            e.kind == hew_types::error::TypeErrorKind::PlatformLimitation
+                && e.message.contains("random_bytes")
+        }),
+        "expected PlatformLimitation for crypto.random_bytes on wasm32, got: {:#?}",
         output.errors
     );
 }


### PR DESCRIPTION
I now reject std::crypto::crypto.random_bytes on wasm32 because the secure entropy source (ring::SystemRandom) is native-only and absent from the wasm32 link set. Previously the checker warned for random_bytes while rejecting encrypt/sign for the same native-only link-set reason, so a wasm32 program depending on secure randomness could pass check.\n\nrandom_bytes now fails closed on wasm32, symmetric with encrypt/sign, instead of compiling to a non-secure host import or fallback. I also updated the capability matrix to mark CryptoRandom as an Error disposition.\n\nGates run:\n- cargo test -p hew-types\n- cargo clippy --workspace --tests -- -D warnings\n- cargo fmt --all -- --check