### PR TITLE
fix(codegen,runtime): clone owned HashMap values on get

### DIFF
--- a/hew-cabi/src/map.rs
+++ b/hew-cabi/src/map.rs
@@ -21,6 +21,7 @@
 //! | `hew_hashmap_insert_layout` (vacant slot) | **owned** (transferred) | **owned** (transferred) | Raw-copy K and V bytes into the slot; possession transfers to the map. No clone, no drop.                                                          |
 //! | `hew_hashmap_insert_layout` (occupied)    | **owned** (eq to stored K — caller drops/recycles the duplicate `K_in`) | **owned** (transferred) | Drop the **old V** via `val_layout.drop_fn`; raw-copy new V into the slot. The slot K stays in place; the kernel **never** drops the stored K here. |
 //! | `hew_hashmap_get_layout`                  | **borrowed**            | n/a                     | Returns `*const c_void` pointing into the slot; lifetime valid until the next mutation. Caller must not free.                                       |
+//! | `hew_hashmap_get_clone_layout`            | **borrowed**            | n/a                     | Clones the stored V into caller-provided out storage via `val_layout.clone_fn` when V is non-Plain; caller owns the out value.                       |
 //! | `hew_hashmap_remove_layout`               | **borrowed**            | n/a                     | Invoke `key_layout.drop_fn` on the slot K and `val_layout.drop_fn` on the slot V before tombstoning. Caller's lookup K is untouched.                |
 //! | `hew_hashmap_free_layout`                 | n/a                     | n/a                     | Iterate occupied slots, invoke key + value `drop_fn` on each, then deallocate the entries buffer. Tombstoned slots already had their blobs dropped at remove-time. |
 //!
@@ -28,7 +29,8 @@
 //!
 //! 1. Insert transfers ownership of K and V into the map (vacant) or of V
 //!    only (occupied — the slot K is reused).
-//! 2. Get borrows; no `clone_fn` is invoked on the standard `_get_layout`.
+//! 2. Standard `_get_layout` borrows; `_get_clone_layout` produces an owned V
+//!    by invoking the descriptor's semantic clone authority.
 //! 3. Remove drops stored K + V via the descriptor thunks; the lookup K
 //!    is borrowed and never dropped by the kernel.
 //! 4. Free drops every occupied K + V exactly once; tombstoned slots are
@@ -103,12 +105,14 @@ pub type HewMapValueDropThunk = extern "C" fn(blob: *mut c_void);
 
 /// Thunk that clones an owned value blob from `src` to `dst`.
 ///
-/// Optional — never invoked by the standard `hew_hashmap_get_layout` path
-/// (which borrows). Consulted only by an opt-in cloning-get variant when the
-/// HIR consumer requires owned-V return.
+/// Invoked by the cloning-get path and layout-map clone when the value
+/// descriptor declares non-Plain ownership. The runtime has already raw-copied
+/// `dst <- src` before invoking this thunk so `BitCopy` fields, enum tags, and
+/// inactive bytes are in place; the thunk deep-clones owned leaves in place.
+/// Returns 0 on success, non-zero after rolling back any partial clone.
 ///
-/// `extern "C" fn(*const u8, *mut u8)` (Q281=A discipline).
-pub type HewMapValueCloneThunk = extern "C" fn(src: *const c_void, dst: *mut c_void);
+/// `extern "C" fn(*const u8, *mut u8) -> i32` (Q281=A discipline).
+pub type HewMapValueCloneThunk = unsafe extern "C" fn(src: *const c_void, dst: *mut c_void) -> i32;
 
 // ---------------------------------------------------------------------------
 // Niche-optimization compile-time assertions
@@ -201,7 +205,7 @@ pub struct HewMapKeyLayout {
 ///     HewTypeOwnershipKind   ownership_kind;
 ///     /* padding to pointer alignment */
 ///     HewMapValueDropThunk   drop_fn;   /* may be NULL when ownership_kind == Plain */
-///     HewMapValueCloneThunk  clone_fn;  /* may be NULL — never required by _get_layout */
+///     HewMapValueCloneThunk  clone_fn;  /* may be NULL only for Plain values */
 /// } HewMapValueLayout;
 /// ```
 #[repr(C)]
@@ -222,8 +226,9 @@ pub struct HewMapValueLayout {
     /// `LayoutManaged` require `Some(_)` (fail-closed constructor check).
     /// W4.001 Stage C0a.
     pub drop_fn: Option<HewMapValueDropThunk>,
-    /// Optional clone thunk consulted only by the opt-in cloning-get
-    /// variant; the standard `hew_hashmap_get_layout` ignores it.
+    /// Optional clone thunk consulted by the cloning-get and map-clone paths.
+    /// `None` is valid only for Plain values; owned `Option<V>` producers must
+    /// fail closed before constructing a non-Plain value layout without it.
     /// W4.001 Stage C0a.
     pub clone_fn: Option<HewMapValueCloneThunk>,
 }

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -35688,20 +35688,21 @@ mod tests {
             "wasm32 key descriptor must use 4-byte usize fields:\n{wasm_key}\n\nfull IR:\n{wasm}"
         );
 
-        let native_value = descriptor_line(&native, "@__hew_map_value_layout_8_8_plain");
+        let native_value =
+            descriptor_line(&native, "@__hew_map_value_layout_rec_PtrPayload_8_8_owned");
         assert!(
             native_value.contains("{ i64, i64, i8, ptr, ptr }")
-                && native_value.contains("{ i64 8, i64 8, i8 0,"),
-            "native pointer-field value descriptor must use host pointer ABI and 8-byte usize fields:\n{native_value}\n\nfull IR:\n{native}"
+                && native_value.contains("{ i64 8, i64 8, i8 2,"),
+            "native owned pointer-field value descriptor must use host pointer ABI and 8-byte usize fields:\n{native_value}\n\nfull IR:\n{native}"
         );
-        let wasm_value = descriptor_line(&wasm, "@__hew_map_value_layout_4_4_plain");
+        let wasm_value = descriptor_line(&wasm, "@__hew_map_value_layout_rec_PtrPayload_4_4_owned");
         assert!(
             wasm_value.contains("{ i32, i32, i8, ptr, ptr }")
-                && wasm_value.contains("{ i32 4, i32 4, i8 0,"),
-            "wasm32 pointer-field value descriptor must use wasm pointer ABI and 4-byte usize fields:\n{wasm_value}\n\nfull IR:\n{wasm}"
+                && wasm_value.contains("{ i32 4, i32 4, i8 2,"),
+            "wasm32 owned pointer-field value descriptor must use wasm pointer ABI and 4-byte usize fields:\n{wasm_value}\n\nfull IR:\n{wasm}"
         );
         assert!(
-            !wasm.contains("@__hew_map_value_layout_8_8_plain"),
+            !wasm.contains("@__hew_map_value_layout_rec_PtrPayload_8_8_owned"),
             "wasm32 descriptor synthesis must not reuse the native 8-byte pointer layout:\n{wasm}"
         );
     }
@@ -39899,7 +39900,7 @@ mod tests {
     }
 
     #[test]
-    fn hashmap_layout_ops_get_emits_option_branches_and_size_copy() {
+    fn hashmap_layout_ops_get_emits_clone_call_and_option_branches() {
         let ctx = Context::create();
         let m = ctx.create_module("hashmap_get_option_test");
         let harness = build_harness(
@@ -39960,18 +39961,18 @@ mod tests {
         );
         let ir = m.print_to_string().to_string();
         assert!(
-            ir.contains("hew_hashmap_get_layout_call")
+            ir.contains("hew_hashmap_get_clone_layout_call")
                 && ir.contains("hashmap_get_none")
                 && ir.contains("hashmap_get_some"),
-            "expected get call and two branches; got IR:\n{ir}"
+            "expected clone-on-get call and two branches; got IR:\n{ir}"
         );
         assert!(
             ir.contains("store i8 0") && ir.contains("store i8 1"),
             "expected Option::Some/None tags via emit_enum_variant_literal; got IR:\n{ir}"
         );
         assert!(
-            ir.contains("llvm.memcpy") && ir.contains("i64 8"),
-            "expected value-layout-sized copy of i64 payload, not a fixed ad-hoc load; got IR:\n{ir}"
+            !ir.contains("llvm.memcpy"),
+            "HashMap::get must not memcpy a borrowed slot into owned Option<V>; got IR:\n{ir}"
         );
     }
 

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -9186,16 +9186,18 @@ fn collect_wire_codec_value_types(pipeline: &IrPipeline) -> Vec<ResolvedTy> {
 }
 
 /// Walk every raw-MIR function's local/param/return types and collect the
-/// record / enum layout keys of every owned-element `Vec<T>` (W5.016).
+/// record / enum layout keys of every owned-element `Vec<T>` (W5.016) and every
+/// heap-owning `HashMap<K, V>` value descriptor (G1 clone-on-get).
 ///
-/// An owned-Vec element type's `__hew_record/enum_{clone,drop}_inplace_<key>`
-/// helper body is NOT reachable from any actor/record state field nor from a
-/// `DropKind::EnumInPlace` seed — it is referenced only by the owned Vec
-/// descriptor (`owned_elem_layout_descriptor_ptr`). Without seeding the body,
-/// the descriptor's thunk pointers would dangle at link time (fail-closed at
-/// link, but blocks the feature). Returns `(record_seeds, enum_seeds)` keyed
-/// the same way `collect_reachable_clone_targets` / `collect_enum_inplace_
-/// drop_seeds` expect.
+/// An owned-Vec element or owned HashMap value type's
+/// `__hew_record/enum_{clone,drop}_inplace_<key>` helper body is NOT reachable
+/// from any actor/record state field nor from a `DropKind::EnumInPlace` seed —
+/// it is referenced only by the descriptor
+/// (`owned_elem_layout_descriptor_ptr` / `hashmap_owned_value_layout_descriptor_ptr`).
+/// Without seeding the body, the descriptor's thunk pointers would dangle at
+/// link time (fail-closed at link, but blocks the feature). Returns
+/// `(record_seeds, enum_seeds)` keyed the same way `collect_reachable_clone_targets`
+/// / `collect_enum_inplace_drop_seeds` expect.
 ///
 /// Element-shape resolution mirrors `owned_elem_thunk_key`: a `Named` element
 /// resolving to a registered enum seeds the enum list; one resolving to a
@@ -9256,8 +9258,9 @@ fn collect_vec_owned_element_seeds(
             }
         };
 
-    // Recursively scan a type for `Vec<elem>` occurrences (so a
-    // `Vec<Vec<owned>>` or an owned-Vec nested in a tuple/option arg is seeded).
+    // Recursively scan a type for `Vec<elem>` and `HashMap<K, V>` occurrences
+    // (so a `Vec<Vec<owned>>`, an owned-Vec nested in a tuple/option arg, or a
+    // map whose heap-owning V is not otherwise dropped is seeded).
     fn scan_ty(
         ty: &ResolvedTy,
         visited: &mut std::collections::HashSet<String>,
@@ -9279,6 +9282,10 @@ fn collect_vec_owned_element_seeds(
                 if name == "Vec" || matches!(short_name(name), "Sender" | "Receiver" | "Stream") {
                     if let Some(elem) = args.first() {
                         on_vec_elem(elem);
+                    }
+                } else if name == "HashMap" || short_name(name) == "HashMap" {
+                    if let Some(value) = args.get(1) {
+                        on_vec_elem(value);
                     }
                 }
                 // Guard against unbounded recursion through self-referential
@@ -16712,7 +16719,10 @@ fn lower_owned_vec_direct_call(
 //     `HewMapKeyLayout`-shaped private constant whose field layout matches
 //     `hew_cabi::map::HewMapKeyLayout` byte-for-byte.
 //   - `@__hew_map_value_layout_<size>_<align>_plain` — a `HewMapValueLayout`
-//     private constant.
+//     private constant for POD values.
+//   - `@__hew_map_value_layout_<kind>_<key>_<size>_<align>_owned` — a
+//     `HewMapValueLayout` private constant for heap-owning values, carrying the
+//     same per-type clone/drop in-place thunks used by the owned Vec substrate.
 //
 // **Equality thunk reuse.**  The hash thunk does NOT carry an equality
 // twin.  The `eq_fn` field of the key-layout global re-uses the existing
@@ -16899,7 +16909,8 @@ fn hashmap_key_layout_descriptor_ptr<'ctx>(
 /// clone_fn: *const fn }`. For Plain ownership both function-pointer fields
 /// are null (Option::None). Dedup by `(size, align)` alone — two Plain scalar
 /// values with identical ABI shape may share a global since their thunk
-/// fields are both null.
+/// fields are both null. Heap-owning values use the owned descriptor variant
+/// below, keyed by the same per-type thunk authority as owned Vec elements.
 ///
 /// HashSet zero-size value layout is **not emitted** by this helper: per
 /// C-1c, the runtime's `hew_hashset_new_with_layout` injects a hard-coded
@@ -16919,6 +16930,9 @@ fn hashmap_value_layout_descriptor_ptr<'ctx>(
     if let Some(rty) = resolved_ty {
         if let Some(name) = primitive_value_layout_extern_name(rty) {
             return Ok(declare_extern_layout_global(fn_ctx, name));
+        }
+        if resolved_ty_contains_heap_leaf(fn_ctx, rty, &mut HashSet::new()) {
+            return hashmap_owned_value_layout_descriptor_ptr(fn_ctx, rty, val_ty);
         }
     }
     let (size, align) = abi_size_align(val_ty, Some(fn_ctx.target_data))?;
@@ -16949,6 +16963,101 @@ fn hashmap_value_layout_descriptor_ptr<'ctx>(
         i8_ty.const_zero().into(),
         ptr_ty.const_null().into(),
         ptr_ty.const_null().into(),
+    ]);
+    let g = fn_ctx.llvm_mod.add_global(layout_ty, None, &global_name);
+    g.set_constant(true);
+    g.set_linkage(Linkage::Private);
+    g.set_initializer(&init);
+    Ok(g.as_pointer_value())
+}
+
+fn hashmap_owned_value_layout_descriptor_ptr<'ctx>(
+    fn_ctx: &FnCtx<'_, 'ctx>,
+    val_resolved_ty: &ResolvedTy,
+    val_llvm_ty: BasicTypeEnum<'ctx>,
+) -> CodegenResult<PointerValue<'ctx>> {
+    let Some((kind, key)) = crate::thunks::owned_elem_thunk_key(fn_ctx, val_resolved_ty) else {
+        return Err(CodegenError::FailClosed(format!(
+            "owned HashMap value `{val_resolved_ty:?}` has no resolvable clone/drop \
+             thunk path; checker admission must reject non-POD values without a \
+             map value clone_fn"
+        )));
+    };
+    let (size, align) = abi_size_align(val_llvm_ty, Some(fn_ctx.target_data))?;
+    let kind_tag = match kind {
+        OwnedElemThunkKind::Record => "rec",
+        OwnedElemThunkKind::Enum => "enum",
+        OwnedElemThunkKind::Tuple => "tup",
+        OwnedElemThunkKind::Collection => "coll",
+    };
+    let global_name = format!("__hew_map_value_layout_{kind_tag}_{key}_{size}_{align}_owned");
+    if let Some(g) = fn_ctx.llvm_mod.get_global(&global_name) {
+        return Ok(g.as_pointer_value());
+    }
+
+    let (clone_fn, drop_fn) = match kind {
+        OwnedElemThunkKind::Record => (
+            get_or_declare_record_clone_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
+            get_or_declare_record_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
+        ),
+        OwnedElemThunkKind::Enum => (
+            get_or_declare_enum_clone_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
+            get_or_declare_enum_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
+        ),
+        OwnedElemThunkKind::Tuple => {
+            let elems = match val_resolved_ty {
+                ResolvedTy::Tuple(elems) => elems,
+                _ => {
+                    return Err(CodegenError::FailClosed(format!(
+                        "owned HashMap tuple value `{val_resolved_ty:?}` resolved to Tuple \
+                         thunk kind but is not a tuple"
+                    )));
+                }
+            };
+            crate::thunks::emit_tuple_inplace_thunk_bodies(fn_ctx, &key, elems, val_llvm_ty)?;
+            (
+                get_or_declare_tuple_clone_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
+                get_or_declare_tuple_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
+            )
+        }
+        OwnedElemThunkKind::Collection => {
+            let (clone_sym, drop_sym) = collection_elem_clone_drop_syms(fn_ctx, val_resolved_ty)
+                .ok_or_else(|| {
+                    CodegenError::FailClosed(format!(
+                        "owned HashMap collection value `{val_resolved_ty:?}` has no canonical \
+                         clone/free primitive"
+                    ))
+                })?;
+            crate::thunks::emit_collection_handle_thunk_bodies(fn_ctx, &key, clone_sym, drop_sym)?;
+            (
+                get_or_declare_collection_clone_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
+                get_or_declare_collection_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &key),
+            )
+        }
+    };
+
+    let ctx = fn_ctx.ctx;
+    let usize_ty = ctx.ptr_sized_int_type(fn_ctx.target_data, None);
+    let i8_ty = ctx.i8_type();
+    let ptr_ty = ctx.ptr_type(AddressSpace::default());
+    let layout_ty = ctx.struct_type(
+        &[
+            usize_ty.into(),
+            usize_ty.into(),
+            i8_ty.into(),
+            ptr_ty.into(),
+            ptr_ty.into(),
+        ],
+        false,
+    );
+    // HewMapValueLayout field order is { size, align, ownership_kind, drop_fn,
+    // clone_fn }. Do not reuse HewVecElemLayout's clone/drop order.
+    let init = layout_ty.const_named_struct(&[
+        usize_ty.const_int(size, false).into(),
+        usize_ty.const_int(u64::from(align), false).into(),
+        i8_ty.const_int(2, false).into(),
+        drop_fn.as_global_value().as_pointer_value().into(),
+        clone_fn.as_global_value().as_pointer_value().into(),
     ]);
     let g = fn_ctx.llvm_mod.add_global(layout_ty, None, &global_name);
     g.set_constant(true);
@@ -17425,6 +17534,10 @@ fn layout_hashmap_fn_type<'ctx>(
         }
         // `*const c_void hew_hashmap_get_layout(map, key_ptr)`
         "hew_hashmap_get_layout" => Ok(ptr_ty.fn_type(&[ptr_ty.into(), ptr_ty.into()], false)),
+        // `bool hew_hashmap_get_clone_layout(map, key_ptr, out_ptr)`
+        "hew_hashmap_get_clone_layout" => {
+            Ok(i1_ty.fn_type(&[ptr_ty.into(), ptr_ty.into(), ptr_ty.into()], false))
+        }
         // `bool hew_hashmap_remove_layout(map, key_ptr)`
         "hew_hashmap_remove_layout" => Ok(i1_ty.fn_type(&[ptr_ty.into(), ptr_ty.into()], false)),
         // `i64 hew_hashmap_len_layout(map)`
@@ -18968,26 +19081,8 @@ fn lower_hashmap_get_layout_call(
     }
 
     let val_llvm_ty = resolve_ty(fn_ctx.ctx, &val_resolved, fn_ctx.record_layouts)?;
-    let (val_size, val_align) = abi_size_align(val_llvm_ty, None)?;
     let map_ptr = load_duplex_handle(fn_ctx, args[0], "hew_hashmap_get_layout arg0")?;
     let (key_ptr, _key_ty) = place_pointer(fn_ctx, args[1])?;
-    let fv = get_or_declare_layout_hashmap_runtime(
-        fn_ctx.ctx,
-        fn_ctx.llvm_mod,
-        "hew_hashmap_get_layout",
-    )?;
-    let raw_ptr = fn_ctx
-        .builder
-        .build_call(
-            fv,
-            &[map_ptr.into(), key_ptr.into()],
-            "hew_hashmap_get_layout_call",
-        )
-        .llvm_ctx("hew_hashmap_get_layout call")?
-        .try_as_basic_value()
-        .basic()
-        .ok_or_else(|| CodegenError::FailClosed("hew_hashmap_get_layout returned void".into()))?
-        .into_pointer_value();
 
     let parent = fn_ctx
         .builder
@@ -19002,32 +19097,10 @@ fn lower_hashmap_get_layout_call(
         .blocks
         .get(&next)
         .ok_or_else(|| CodegenError::FailClosed(format!("Call next bb{next} missing")))?;
-    let is_some = fn_ctx
-        .builder
-        .build_int_compare(
-            IntPredicate::NE,
-            raw_ptr,
-            fn_ctx.ctx.ptr_type(AddressSpace::default()).const_null(),
-            "hashmap_get_is_some",
-        )
-        .llvm_ctx("hew_hashmap_get_layout null compare")?;
-    fn_ctx
-        .builder
-        .build_conditional_branch(is_some, some_bb, none_bb)
-        .llvm_ctx("hew_hashmap_get_layout condbr")?;
-
-    // None = variant 1 for Hew's builtin `Option<T>` layout.
-    fn_ctx.builder.position_at_end(none_bb);
-    emit_enum_variant_literal(fn_ctx, *dest_place, 1, &[])?;
-    fn_ctx
-        .builder
-        .build_unconditional_branch(next_bb)
-        .llvm_ctx("hew_hashmap_get_layout none br")?;
-
-    // Some = variant 0.  Tag via the enum-literal primitive, then copy exactly
-    // the registered value-layout byte size into the Some payload field.
-    fn_ctx.builder.position_at_end(some_bb);
-    emit_enum_variant_literal(fn_ctx, *dest_place, 0, &[])?;
+    // `HashMap::get` returns an owned `Option<V>`. Compute the Some payload
+    // address up front, then let the runtime clone the stored slot value into
+    // it through the descriptor's semantic clone_fn. This replaces the old
+    // borrowed-slot memcpy, which aliased owned V into the Option payload.
     let dest_local = composite_dest_local(*dest_place, "hew_hashmap_get_layout")?;
     let (payload_ptr, payload_ty) = place_pointer(
         fn_ctx,
@@ -19043,16 +19116,41 @@ fn lower_hashmap_get_layout_call(
              does not match HashMap value type {val_llvm_ty:?}"
         )));
     }
+    let fv = get_or_declare_layout_hashmap_runtime(
+        fn_ctx.ctx,
+        fn_ctx.llvm_mod,
+        "hew_hashmap_get_clone_layout",
+    )?;
+    let is_some = fn_ctx
+        .builder
+        .build_call(
+            fv,
+            &[map_ptr.into(), key_ptr.into(), payload_ptr.into()],
+            "hew_hashmap_get_clone_layout_call",
+        )
+        .llvm_ctx("hew_hashmap_get_clone_layout call")?
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| {
+            CodegenError::FailClosed("hew_hashmap_get_clone_layout returned void".into())
+        })?
+        .into_int_value();
     fn_ctx
         .builder
-        .build_memcpy(
-            payload_ptr,
-            val_align,
-            raw_ptr,
-            val_align,
-            fn_ctx.ctx.i64_type().const_int(val_size, false),
-        )
-        .llvm_ctx("hew_hashmap_get_layout value copy")?;
+        .build_conditional_branch(is_some, some_bb, none_bb)
+        .llvm_ctx("hew_hashmap_get_clone_layout condbr")?;
+
+    // None = variant 1 for Hew's builtin `Option<T>` layout.
+    fn_ctx.builder.position_at_end(none_bb);
+    emit_enum_variant_literal(fn_ctx, *dest_place, 1, &[])?;
+    fn_ctx
+        .builder
+        .build_unconditional_branch(next_bb)
+        .llvm_ctx("hew_hashmap_get_layout none br")?;
+
+    // Some = variant 0. The runtime already cloned into the payload slot.
+    fn_ctx.builder.position_at_end(some_bb);
+    emit_enum_variant_literal(fn_ctx, *dest_place, 0, &[])?;
     fn_ctx
         .builder
         .build_unconditional_branch(next_bb)

--- a/hew-codegen-rs/tests/llvm_native_lowering.rs
+++ b/hew-codegen-rs/tests/llvm_native_lowering.rs
@@ -87,6 +87,32 @@ fn emit_ll_from_tc(source: &str, module_name: &str, tc_output: &TypeCheckOutput)
     std::fs::read_to_string(ll_path).expect("read emitted .ll")
 }
 
+#[test]
+fn hashmap_get_layout_call_uses_clone_runtime_abi() {
+    let ll = emit_ll_checked(
+        r#"fn main() -> i64 {
+            let m: HashMap<string, string> = HashMap::new();
+            m.insert("k", "owned-value");
+            let got: Option<string> = m.get("k");
+            match got {
+                Some(s) => {
+                    if s == "owned-value" { 0 } else { 1 }
+                },
+                None => 2,
+            }
+        }"#,
+        "hashmap_get_clone_abi",
+    );
+    assert!(
+        ll.contains("@hew_hashmap_get_clone_layout"),
+        "HashMap::get must lower to the clone-on-get runtime ABI; got:\n{ll}"
+    );
+    assert!(
+        !ll.contains("call ptr @hew_hashmap_get_layout"),
+        "HashMap::get must not borrow a map slot and memcpy it into Option<V>; got:\n{ll}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Change 1a: IntArithSaturating Add/Sub → .sat intrinsics
 // ---------------------------------------------------------------------------

--- a/hew-runtime/src/hashmap.rs
+++ b/hew-runtime/src/hashmap.rs
@@ -820,7 +820,12 @@ unsafe fn clone_layout_key_blob(
     }
 }
 
-unsafe fn clone_layout_value_blob(layout: HewMapValueLayout, src: *const u8, dst: *mut u8) {
+unsafe fn clone_layout_value_blob(
+    layout: HewMapValueLayout,
+    src: *const u8,
+    dst: *mut u8,
+    label: &str,
+) {
     match layout.ownership_kind {
         HewTypeOwnershipKind::Plain => {
             if layout.size > 0 {
@@ -829,21 +834,29 @@ unsafe fn clone_layout_value_blob(layout: HewMapValueLayout, src: *const u8, dst
                 unsafe { ptr::copy_nonoverlapping(src, dst, layout.size) };
             }
         }
-        HewTypeOwnershipKind::String => {
-            // SAFETY: forwarded blob contract.
-            unsafe { clone_layout_string_blob(src, dst, "hew_hashmap_clone_layout value") };
-        }
-        HewTypeOwnershipKind::LayoutManaged => {
+        HewTypeOwnershipKind::String | HewTypeOwnershipKind::LayoutManaged => {
             let Some(clone_fn) = layout.clone_fn else {
-                abort_layout_clone(
-                    "hew_hashmap_clone_layout: value layout-managed clone thunk is unavailable",
-                );
+                abort_layout_clone(format!("{label}: value clone thunk is unavailable"));
             };
-            clone_fn(src.cast::<c_void>(), dst.cast::<c_void>());
+            if layout.size > 0 {
+                // The map-value clone thunk ABI matches the existing aggregate
+                // clone helpers: caller first seeds dst with an exact byte copy
+                // so tags/BitCopy fields are present, then the thunk overwrites
+                // owned leaves with semantic clones.
+                // SAFETY: caller guarantees both blobs are valid for
+                // `layout.size` bytes and non-overlapping.
+                unsafe { ptr::copy_nonoverlapping(src, dst, layout.size) };
+            }
+            // SAFETY: descriptor validator/checker ensures `clone_fn` matches
+            // the value blob ABI; dst was seeded per thunk contract above.
+            let rc = unsafe { clone_fn(src.cast::<c_void>(), dst.cast::<c_void>()) };
+            if rc != 0 {
+                abort_layout_clone(format!("{label}: value clone thunk returned {rc}"));
+            }
         }
-        HewTypeOwnershipKind::Bytes => abort_layout_clone(
-            "hew_hashmap_clone_layout: value ownership_kind=Bytes is not valid for maps",
-        ),
+        HewTypeOwnershipKind::Bytes => abort_layout_clone(format!(
+            "{label}: value ownership_kind=Bytes is not valid for maps"
+        )),
     }
 }
 
@@ -879,12 +892,10 @@ pub unsafe extern "C" fn hew_hashmap_clone_layout(
     }
     if matches!(
         src.val_layout.ownership_kind,
-        HewTypeOwnershipKind::LayoutManaged
+        HewTypeOwnershipKind::String | HewTypeOwnershipKind::LayoutManaged
     ) && src.val_layout.clone_fn.is_none()
     {
-        abort_layout_clone(
-            "hew_hashmap_clone_layout: value layout-managed clone thunk is unavailable",
-        );
+        abort_layout_clone("hew_hashmap_clone_layout: value clone thunk is unavailable");
     }
 
     // SAFETY: source map was validated at construction time.
@@ -944,7 +955,14 @@ pub unsafe extern "C" fn hew_hashmap_clone_layout(
             // SAFETY: destination slot is in-bounds in the cloned allocation.
             let dst_val = unsafe { slot_val(cloned_entries, idx, src.stride, src.val_offset) };
             // SAFETY: forwarded blob contracts.
-            unsafe { clone_layout_value_blob(src.val_layout, src_val, dst_val) };
+            unsafe {
+                clone_layout_value_blob(
+                    src.val_layout,
+                    src_val,
+                    dst_val,
+                    "hew_hashmap_clone_layout value",
+                );
+            }
         }
     }
 
@@ -1204,6 +1222,74 @@ pub unsafe extern "C" fn hew_hashmap_get_layout(
     // SAFETY: idx < cap; val_offset valid.
     let val_ptr = unsafe { slot_val(map.entries, idx, map.stride, map.val_offset) };
     val_ptr.cast::<c_void>().cast_const()
+}
+
+/// Look up a key and semantic-clone the stored value into caller-provided
+/// storage. Returns `true` when the key was found, `false` when absent.
+///
+/// This is the owned-return counterpart to [`hew_hashmap_get_layout`]. The
+/// borrowed getter remains available for predicates and internal probes; Hew
+/// `HashMap::get()` uses this entry so `Option<V>` owns an independent `V`.
+///
+/// # Safety
+///
+/// `m` must be a valid `HewLayoutHashMap`. `key` must point to a valid key
+/// blob. When the map's value size is non-zero, `out` must point to writable
+/// storage for exactly `val_layout.size` bytes at `val_layout.align`.
+#[no_mangle]
+pub unsafe extern "C" fn hew_hashmap_get_clone_layout(
+    m: *const HewLayoutHashMap,
+    key: *const c_void,
+    out: *mut c_void,
+) -> bool {
+    // SAFETY: shared fail-closed gate; no value pointer participates in lookup.
+    unsafe { validate_op_inputs(m, key, None) };
+    // SAFETY: m non-null per gate.
+    let map = unsafe { &*m };
+    if map.val_layout.size > 0 && out.is_null() {
+        crate::set_last_error("hew_hashmap_get_clone_layout: out is null for non-zero value");
+        std::process::abort();
+    }
+    if map.cap == 0 || map.len == 0 {
+        return false;
+    }
+    let kl = &map.key_layout;
+    let (Some(hash_fn), Some(eq_fn)) = (kl.hash_fn, kl.eq_fn) else {
+        crate::set_last_error(
+            "hew_hashmap_get_clone_layout: hash_fn/eq_fn None (constructor guard violated)",
+        );
+        std::process::abort();
+    };
+    // SAFETY: layout fields valid.
+    let (idx, found) = unsafe {
+        layout_probe(
+            map.entries,
+            map.cap,
+            map.stride,
+            map.key_offset,
+            key,
+            hash_fn,
+            eq_fn,
+        )
+    };
+    if !found {
+        return false;
+    }
+    if map.val_layout.size > 0 {
+        // SAFETY: idx < cap; val_offset valid.
+        let val_ptr = unsafe { slot_val(map.entries, idx, map.stride, map.val_offset) };
+        // SAFETY: val_ptr points at the occupied slot value and `out` was
+        // validated for this value layout above.
+        unsafe {
+            clone_layout_value_blob(
+                map.val_layout,
+                val_ptr,
+                out.cast::<u8>(),
+                "hew_hashmap_get_clone_layout value",
+            );
+        }
+    }
+    true
 }
 
 /// Predicate form of `hew_hashmap_get_layout`.

--- a/hew-runtime/src/layout_intrinsics.rs
+++ b/hew-runtime/src/layout_intrinsics.rs
@@ -20,8 +20,8 @@
 //! Two families, one per (K | V) role per type:
 //!
 //! - `hew_layout_key_<type>` — `HewMapKeyLayout` (carries hash + eq + drop).
-//! - `hew_layout_val_<type>` — `HewMapValueLayout` (carries drop + optional
-//!   clone; never hashes, per the kernel's get-borrows contract).
+//! - `hew_layout_val_<type>` — `HewMapValueLayout` (carries drop + clone for
+//!   non-Plain values; never hashes, per the kernel's get-borrows contract).
 //!
 //! Scope per plan §4 Stage C0b:
 //!
@@ -270,6 +270,34 @@ extern "C" fn hew_layout_string_drop(blob: *mut c_void) {
     }
 }
 
+unsafe extern "C" fn hew_layout_string_clone(src: *const c_void, dst: *mut c_void) -> i32 {
+    // SAFETY: src/dst point at pointer-sized string slots. The runtime already
+    // copied dst <- src; overwrite dst with an independent header-aware clone.
+    let src_ptr: *const c_char = unsafe { core::ptr::read(src.cast::<*const c_char>()) };
+    // SAFETY: `src_ptr` is null or a valid Hew string per the descriptor's
+    // String ownership contract.
+    let cloned = unsafe { crate::string::hew_string_clone(src_ptr) };
+    if !src_ptr.is_null() && cloned.is_null() {
+        return 1;
+    }
+    // SAFETY: `dst` is writable pointer-sized string storage.
+    unsafe { core::ptr::write(dst.cast::<*mut c_char>(), cloned) };
+    0
+}
+
+unsafe extern "C" fn hew_layout_bytes_clone(src: *const c_void, dst: *mut c_void) -> i32 {
+    // SAFETY: src/dst point at BytesTriple slots. Refcount the backing buffer,
+    // then copy the by-value view into dst.
+    let triple: BytesTripleRepr = unsafe { core::ptr::read(src.cast::<BytesTripleRepr>()) };
+    if !triple.ptr.is_null() {
+        // SAFETY: non-null buffer pointer comes from a valid BytesTriple.
+        unsafe { crate::bytes::hew_bytes_clone_ref(triple.ptr) };
+    }
+    // SAFETY: `dst` is writable BytesTriple storage.
+    unsafe { core::ptr::write(dst.cast::<BytesTripleRepr>(), triple) };
+    0
+}
+
 extern "C" fn hew_layout_bytes_drop(blob: *mut c_void) {
     // SAFETY: blob is non-null and points to a `BytesTriple` slot owned by
     // the kernel. Reload + drop the inner buffer via the bytes runtime.
@@ -405,9 +433,9 @@ pub static hew_layout_key_bytes: HewMapKeyLayout = HewMapKeyLayout {
 //
 // Value descriptors carry no hash / eq (the kernel never hashes V — see
 // the get-borrows contract in hew-cabi/src/map.rs). They carry drop (always)
-// and an optional clone (consulted only by the opt-in cloning-get variant,
-// per C0a). C0b ships clone_fn = None for every value descriptor; Stage C
-// or later may wire concrete clone thunks when an owned-V return path lands.
+// and a clone thunk for non-Plain values. Plain descriptors keep clone_fn =
+// None; string/bytes descriptors publish semantic clone thunks so
+// HashMap::get can return an owned Option<V> without aliasing the slot.
 
 macro_rules! val_layout_plain {
     ($name:ident, $ty:ty) => {
@@ -453,7 +481,7 @@ pub static hew_layout_val_string: HewMapValueLayout = HewMapValueLayout {
     align: core::mem::align_of::<*const c_char>(),
     ownership_kind: HewTypeOwnershipKind::String,
     drop_fn: Some(hew_layout_string_drop),
-    clone_fn: None,
+    clone_fn: Some(hew_layout_string_clone),
 };
 
 #[no_mangle]
@@ -462,7 +490,7 @@ pub static hew_layout_val_bytes: HewMapValueLayout = HewMapValueLayout {
     align: core::mem::align_of::<BytesTripleRepr>(),
     ownership_kind: HewTypeOwnershipKind::LayoutManaged,
     drop_fn: Some(hew_layout_bytes_drop),
-    clone_fn: None,
+    clone_fn: Some(hew_layout_bytes_clone),
 };
 
 // unit V (ZST): the HashSet-as-HashMap<T,()> pattern. The kernel admits

--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -844,9 +844,171 @@ impl Checker {
             && self.registry.implements_marker(ty, MarkerTrait::Eq)
     }
 
-    fn is_supported_hashmap_value_type(_ty: &Ty) -> bool {
-        // W4.001 Stage C3: resolver imposes no V bound on
-        // `impl<K, V> Map for HashMap<K, V> where K: Hash + Eq`.
+    fn hashmap_nested_key_clone_blocker(
+        &self,
+        ty: &Ty,
+        _visiting: &mut HashSet<String>,
+    ) -> Option<String> {
+        let resolved = self.subst.resolve(ty).materialize_literal_defaults();
+        if primitive_copy_layout(&resolved, &self.type_defs).is_some() {
+            return None;
+        }
+        match &resolved {
+            Ty::String => None,
+            // `hew_hashmap_clone_layout` can deep-clone Plain and string keys.
+            // Bytes/layout-managed keys have no key-side clone thunk field in
+            // `HewMapKeyLayout`, so a HashMap with such a key is not cloneable
+            // when nested inside another owned value.
+            Ty::Bytes => Some("bytes key".to_string()),
+            Ty::Function { .. }
+            | Ty::Closure { .. }
+            | Ty::TraitObject { .. }
+            | Ty::CancellationToken
+            | Ty::Task(_) => Some(resolved.user_facing().to_string()),
+            Ty::Named { name, .. }
+                if self.canonical_owned_handle_type_name(name).is_some()
+                    || self.user_opaque_type_names.contains(name.as_str()) =>
+            {
+                Some(name.clone())
+            }
+            other => Some(format!("non-cloneable map key `{}`", other.user_facing())),
+        }
+    }
+
+    fn hashmap_type_def_clone_blocker(
+        &self,
+        type_def: &TypeDef,
+        args: &[Ty],
+        visiting: &mut HashSet<String>,
+    ) -> Option<String> {
+        let field_blocker = type_def.fields.values().find_map(|field_ty| {
+            let field_ty = Self::instantiate_type_def_member(field_ty, &type_def.type_params, args);
+            self.hashmap_value_clone_blocker(&field_ty, visiting)
+        });
+        if field_blocker.is_some() {
+            return field_blocker;
+        }
+
+        type_def
+            .variants
+            .values()
+            .find_map(|variant| match variant {
+                VariantDef::Unit => None,
+                VariantDef::Tuple(tys) => tys.iter().find_map(|field_ty| {
+                    let field_ty =
+                        Self::instantiate_type_def_member(field_ty, &type_def.type_params, args);
+                    self.hashmap_value_clone_blocker(&field_ty, visiting)
+                }),
+                VariantDef::Struct(fields) => fields.iter().find_map(|(_, field_ty)| {
+                    let field_ty =
+                        Self::instantiate_type_def_member(field_ty, &type_def.type_params, args);
+                    self.hashmap_value_clone_blocker(&field_ty, visiting)
+                }),
+            })
+    }
+
+    fn hashmap_named_value_clone_blocker(
+        &self,
+        name: &str,
+        args: &[Ty],
+        builtin: Option<BuiltinType>,
+        resolved: &Ty,
+        visiting: &mut HashSet<String>,
+    ) -> Option<String> {
+        if self.canonical_owned_handle_type_name(name).is_some()
+            || self.user_opaque_type_names.contains(name)
+        {
+            return Some(name.to_string());
+        }
+
+        match builtin {
+            Some(BuiltinType::Vec) => {
+                return args
+                    .first()
+                    .and_then(|elem| self.hashmap_value_clone_blocker(elem, visiting));
+            }
+            Some(BuiltinType::HashMap) if args.len() == 2 => {
+                return self
+                    .hashmap_nested_key_clone_blocker(&args[0], visiting)
+                    .or_else(|| self.hashmap_value_clone_blocker(&args[1], visiting));
+            }
+            Some(BuiltinType::HashSet) => {
+                return args
+                    .first()
+                    .and_then(|elem| self.hashmap_nested_key_clone_blocker(elem, visiting));
+            }
+            Some(BuiltinType::Option | BuiltinType::Result | BuiltinType::Range) => {
+                if let Some(blocker) = args
+                    .iter()
+                    .find_map(|arg| self.hashmap_value_clone_blocker(arg, visiting))
+                {
+                    return Some(blocker);
+                }
+            }
+            _ => {}
+        }
+
+        if let Some(blocker) = args
+            .iter()
+            .find_map(|arg| self.hashmap_value_clone_blocker(arg, visiting))
+        {
+            return Some(blocker);
+        }
+
+        let type_def = self.lookup_type_def(name)?;
+        let visit_key = resolved.user_facing().to_string();
+        if !visiting.insert(visit_key.clone()) {
+            return None;
+        }
+        let blocker = self.hashmap_type_def_clone_blocker(&type_def, args, visiting);
+        visiting.remove(&visit_key);
+        blocker
+    }
+
+    fn hashmap_value_clone_blocker(
+        &self,
+        ty: &Ty,
+        visiting: &mut HashSet<String>,
+    ) -> Option<String> {
+        let resolved = self.subst.resolve(ty).materialize_literal_defaults();
+        match &resolved {
+            Ty::Function { .. }
+            | Ty::Closure { .. }
+            | Ty::TraitObject { .. }
+            | Ty::CancellationToken
+            | Ty::Task(_) => Some(resolved.user_facing().to_string()),
+            Ty::Tuple(items) => items
+                .iter()
+                .find_map(|item| self.hashmap_value_clone_blocker(item, visiting)),
+            Ty::Array(elem, _) | Ty::Slice(elem) => {
+                self.hashmap_value_clone_blocker(elem, visiting)
+            }
+            Ty::Named {
+                name,
+                args,
+                builtin,
+            } => self.hashmap_named_value_clone_blocker(name, args, *builtin, &resolved, visiting),
+            _ => None,
+        }
+    }
+
+    fn validate_hashmap_value_clone_type(&mut self, ty: &Ty, span: &Span) -> bool {
+        let mut visiting = HashSet::new();
+        if let Some(blocker) = self.hashmap_value_clone_blocker(ty, &mut visiting) {
+            let resolved = self.subst.resolve(ty).materialize_literal_defaults();
+            self.report_error(
+                TypeErrorKind::InvalidOperation,
+                span,
+                format!(
+                    "`HashMap<_, {}>` is not supported: `HashMap::get()` returns an owned \
+                     `Option<V>`, but value type `{}` contains `{blocker}` which has no \
+                     map value clone_fn; use a cloneable value type",
+                    resolved.user_facing(),
+                    resolved.user_facing(),
+                ),
+            );
+            return false;
+        }
         true
     }
 
@@ -910,6 +1072,10 @@ impl Checker {
             return true; // optimistically admit; finalization will fail closed
         }
 
+        if !self.validate_hashmap_value_clone_type(&resolved_val, span) {
+            return false;
+        }
+
         // Named record key: defer to finalize_hashmap_admission for full hash-eligibility
         // check and HashMapLoweringFact production (C-2c).  Optimistically admit here;
         // finalize will fail closed with a diagnostic if the key is ineligible.
@@ -925,9 +1091,7 @@ impl Checker {
             return true;
         }
 
-        if self.is_supported_hashmap_key_type(&resolved_key)
-            && Self::is_supported_hashmap_value_type(&resolved_val)
-        {
+        if self.is_supported_hashmap_key_type(&resolved_key) {
             return true;
         }
 

--- a/repros/03_hashmap_string_vec_value.hew
+++ b/repros/03_hashmap_string_vec_value.hew
@@ -1,0 +1,17 @@
+fn main() {
+    let m: HashMap<string, Vec<i64>> = HashMap::new();
+    let xs: Vec<i64> = Vec::new();
+    xs.push(1);
+    xs.push(2);
+    m.insert("a", clone xs);
+    xs.push(99);
+
+    match m.get("a") {
+        Some(v) => println(f"got={v.len()}:{v.get(0)}:{v.get(1)}"),
+        None => println("got=missing"),
+    }
+    let has = m.contains_key("a");
+    let removed = m.remove("a");
+    let len = m.len();
+    println(f"has={has} removed={removed} len={len} src={xs.len()}");
+}

--- a/repros/p0a_hashmap_owned_record_value.hew
+++ b/repros/p0a_hashmap_owned_record_value.hew
@@ -1,0 +1,20 @@
+type Payload {
+    label: string;
+    count: i64;
+}
+
+fn main() {
+    let m: HashMap<string, Payload> = HashMap::new();
+    let n: i64 = 77;
+    let payload = Payload {
+        label: f"record-value-{n}-heap-owned",
+        count: n,
+    };
+    m.insert("record", payload);
+    let got: Option<Payload> = m.get("record");
+    m.remove("record");
+    match got {
+        Some(p) => println(f"{p.label}:{p.count}"),
+        None => println("missing"),
+    }
+}

--- a/repros/p0a_hashmap_string_vec_value.hew
+++ b/repros/p0a_hashmap_string_vec_value.hew
@@ -1,0 +1,15 @@
+fn main() {
+    let m: HashMap<string, Vec<i64>> = HashMap::new();
+    let xs: Vec<i64> = Vec::new();
+    xs.push(1);
+    xs.push(2);
+    xs.push(3);
+    m.insert("vec", clone xs);
+    xs.push(99);
+    let got: Option<Vec<i64>> = m.get("vec");
+    m.remove("vec");
+    match got {
+        Some(v) => println(f"got={v.len()}:{v.get(0)}:{v.get(1)}:{v.get(2)} src={xs.len()}"),
+        None => println("missing"),
+    }
+}

--- a/repros/p0a_heap_remove_uaf.hew
+++ b/repros/p0a_heap_remove_uaf.hew
@@ -1,0 +1,12 @@
+fn main() {
+    let m: HashMap<string, string> = HashMap::new();
+    let n: i64 = 123456;
+    let heap: string = f"prefix-{n}-suffix-padding-to-force-heap-alloc-zzzzzzzzzzzz";
+    m.insert("k", heap);
+    let got: Option<string> = m.get("k");
+    m.remove("k");
+    match got {
+        Some(s) => println(s),
+        None => println("none"),
+    }
+}

--- a/scripts/hew-suite-expected-failures.txt
+++ b/scripts/hew-suite-expected-failures.txt
@@ -11,4 +11,5 @@
 #
 # Format: <test_function_name>  # <root_cause>; converging lane: <lane>
 #
-# Total: 0 unique failing test function names.
+# Total: 1 unique failing test function name.
+test_hashmap_get_string_value_survives_remove  # HashMap::get aliases owned V; converging lane: G1

--- a/scripts/hew-suite-expected-failures.txt
+++ b/scripts/hew-suite-expected-failures.txt
@@ -11,5 +11,4 @@
 #
 # Format: <test_function_name>  # <root_cause>; converging lane: <lane>
 #
-# Total: 1 unique failing test function name.
-test_hashmap_get_string_value_survives_remove  # HashMap::get aliases owned V; converging lane: G1
+# Total: 0 unique failing test function names.

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -242,6 +242,7 @@ stable = [
   "hew_hashmap_clone_layout",
   "hew_hashmap_contains_key_layout",
   "hew_hashmap_free_layout",
+  "hew_hashmap_get_clone_layout",
   "hew_hashmap_get_layout",
   "hew_hashmap_insert_layout",
   "hew_hashmap_keys_layout",

--- a/tests/hew/hashmap_get_clone_test.hew
+++ b/tests/hew/hashmap_get_clone_test.hew
@@ -1,0 +1,75 @@
+//! Regression tests for HashMap::get ownership.
+//!
+//! `HashMap<K, V>.get()` returns `Option<V>`, so `Some(v)` must own an
+//! independent semantic clone of the stored value. Removing the key after get
+//! must not invalidate the returned value.
+
+import std::testing;
+
+type Payload {
+    label: string;
+    count: i64;
+}
+
+#[test]
+fn test_hashmap_get_string_value_survives_remove() {
+    let m: HashMap<string, string> = HashMap::new();
+    let n: i64 = 123456;
+    let heap: string = f"prefix-{n}-suffix-padding-to-force-heap-alloc-zzzzzzzzzzzz";
+    m.insert("k", heap);
+
+    let got: Option<string> = m.get("k");
+    m.remove("k");
+
+    match got {
+        Some(s) => testing.assert_eq_str(s, "prefix-123456-suffix-padding-to-force-heap-alloc-zzzzzzzzzzzz"),
+        None => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn test_hashmap_get_owned_record_value_survives_remove() {
+    let m: HashMap<string, Payload> = HashMap::new();
+    let n: i64 = 77;
+    let payload = Payload {
+        label: f"record-value-{n}-heap-owned",
+        count: n,
+    };
+    m.insert("record", payload);
+
+    let got: Option<Payload> = m.get("record");
+    m.remove("record");
+
+    match got {
+        Some(p) => {
+            testing.assert_eq_str(p.label, "record-value-77-heap-owned");
+            testing.assert_eq(p.count, 77);
+        },
+        None => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn test_hashmap_get_nested_vec_value_survives_remove() {
+    let m: HashMap<string, Vec<i64>> = HashMap::new();
+    let xs: Vec<i64> = Vec::new();
+    xs.push(1);
+    xs.push(2);
+    xs.push(3);
+    m.insert("vec", clone xs);
+    xs.push(99);
+
+    let got: Option<Vec<i64>> = m.get("vec");
+    m.remove("vec");
+
+    match got {
+        Some(v) => {
+            testing.assert_eq(v.len(), 3);
+            testing.assert_eq(v.get(0), 1);
+            testing.assert_eq(v.get(1), 2);
+            testing.assert_eq(v.get(2), 3);
+        },
+        None => testing.assert_true(false),
+    }
+    testing.assert_eq(xs.len(), 4);
+}

--- a/tests/vertical-slice/accept/hashmap_get_clone_string_value.hew
+++ b/tests/vertical-slice/accept/hashmap_get_clone_string_value.hew
@@ -1,0 +1,23 @@
+// Accept fixture: HashMap::get clones a heap-owned string value into Option<V>.
+//
+// Harness verb: hew compile + run
+// Expected: clean compile + exit 0 after using the returned value post-remove.
+
+fn main() -> i64 {
+    let m: HashMap<string, string> = HashMap::new();
+    let n: i64 = 123456;
+    let heap: string = f"prefix-{n}-suffix-padding-to-force-heap-alloc-zzzzzzzzzzzz";
+    m.insert("k", heap);
+    let got: Option<string> = m.get("k");
+    m.remove("k");
+    match got {
+        Some(s) => {
+            if s == "prefix-123456-suffix-padding-to-force-heap-alloc-zzzzzzzzzzzz" {
+                0
+            } else {
+                1
+            }
+        },
+        None => 2,
+    }
+}

--- a/tests/vertical-slice/reject/hashmap_get_unclonable_opaque_value.hew
+++ b/tests/vertical-slice/reject/hashmap_get_unclonable_opaque_value.hew
@@ -1,0 +1,24 @@
+// Reject fixture: HashMap::get must fail closed when V contains no clone_fn.
+//
+// `HashMap::get()` returns an owned `Option<V>`. A value containing an
+// `#[opaque]` runtime handle cannot be semantically cloned, so admitting this
+// map would require a shallow pointer copy into Some(V).
+
+#[opaque]
+type Handle {}
+
+record WrappedHandle {
+    h: Handle,
+}
+
+extern "C" {
+    fn hew_handle_create() -> Handle;
+}
+
+fn main() -> i64 {
+    let m: HashMap<string, WrappedHandle> = HashMap::new();
+    let h = unsafe { hew_handle_create() };
+    m.insert("h", WrappedHandle { h: h });
+    let _ = m.get("h");
+    0
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -2373,6 +2373,14 @@ if "${HEW}" check "${ROOT}/tests/vertical-slice/reject/opaque_handle_non_empty_b
 fi
 grep -q 'E_OPAQUE_TYPE_SHAPE' "${reject_output}"
 
+# G1: HashMap::get returns an owned Option<V>, so heap values must clone out of
+# the slot and V with no clone_fn must fail closed at check time.
+run_accept_expect_status "hashmap_get_clone_string_value" 0
+expect_check_fail_contains \
+  "${ROOT}/tests/vertical-slice/reject/hashmap_get_unclonable_opaque_value.hew" \
+  "no map value clone_fn" \
+  "hashmap_get_unclonable_opaque_value"
+
 # ---------------------------------------------------------------------------
 # NEW-6b — `await … | after d` deadlines on suspendable actor asks
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`HashMap<K,V>.get()` previously memcpied a borrowed slot into the returned `Option<V>`, leaving the map slot holding a copy of the same owned allocation — a double-free or use-after-free when the caller used the returned value after removing or overwriting the key. The value is now deep-cloned through the existing per-type `clone_fn` substrate (`hew_hashmap_get_clone_layout`), so the map retains its own copy and the caller receives an independent owned value.

The admissibility checker now fails closed at compile time on any `HashMap<K,V>` whose `V` has no clone path transitively — catching opaque handles, closures, and task-typed values before codegen, through a single recursive authority.

## Verification

- get-after-remove repro (`repros/p0a_heap_remove_uaf.hew`): sentinel-abort EXIT=1 pre-fix → clean exit post-fix under Guard Malloc + MallocScribble + `leaks`
- all three drop paths verified clean: sync return, async cancel (mailbox interleave), actor shutdown
- overwrite-key forced-ordering probe: returns correct independent clone (not the mutated slot value)
- checker rejects 7 unclonable value shapes (bare opaque, opaque-in-Vec, opaque-in-Option, opaque-in-tuple, opaque-in-enum-payload, opaque-in-nested-map, function-typed); admits 5 clonable shapes that compile, run, and sanitize clean
- `make test-hew-ratchet`: Expected failures 0 / Actual failures 0, ratchet PASSED
- `make test-vertical-slice`: exit 0 with new `hashmap_get_clone_string_value` accept fixture
- codegen unit (`llvm_native_lowering` map-clone test): pass
- runtime layout tests (53): pass
- `make ci-preflight`: all 12 targets green (1192s total)
- Linux x86_64 ASan: pending

## Out of scope

- Leak-slope / drop-count oracle for owned-record and nested-container value shapes (current repros assert output, which is invisible to the pre-fix leak-only bug; a drop-count oracle would catch future descriptor regressions). Filed as a follow-up.
- Direct Rust unit test for `hew_hashmap_get_clone_layout` and the `hew_layout_string_clone` / `hew_layout_bytes_clone` thunks. Filed as a follow-up.