### PR TITLE
fix(types): admit generic HashMap key and value parameters

### DIFF
--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -1068,11 +1068,23 @@ impl Checker {
                     key_ty: key_ty.clone(),
                     val_ty: val_ty.clone(),
                     source_module: self.current_module.clone(),
+                    is_abstract_key_param: false,
                 });
             return true; // optimistically admit; finalization will fail closed
         }
 
-        if !self.validate_hashmap_value_clone_type(&resolved_val, span) {
+        let is_abstract_key_param = matches!(
+            &resolved_key,
+            Ty::Named { name, args, builtin: None }
+                if args.is_empty() && self.is_type_param_in_scope(name)
+        );
+        let is_abstract_val_param = matches!(
+            &resolved_val,
+            Ty::Named { name, args, builtin: None }
+                if args.is_empty() && self.is_type_param_in_scope(name)
+        );
+
+        if !is_abstract_val_param && !self.validate_hashmap_value_clone_type(&resolved_val, span) {
             return false;
         }
 
@@ -1082,11 +1094,15 @@ impl Checker {
         if matches!(&resolved_key, Ty::Named { .. }) {
             self.deferred_hashmap_admission
                 .entry(SpanKey::in_module(span, self.current_module_idx))
+                .and_modify(|existing| {
+                    existing.is_abstract_key_param |= is_abstract_key_param;
+                })
                 .or_insert_with(|| DeferredHashMapAdmission {
                     span: span.clone(),
                     key_ty: resolved_key.clone(),
                     val_ty: resolved_val.clone(),
                     source_module: self.current_module.clone(),
+                    is_abstract_key_param,
                 });
             return true;
         }
@@ -3273,6 +3289,7 @@ mod tests {
                 key_ty: Ty::normalize_named("Point".to_string(), vec![]),
                 val_ty: Ty::I64,
                 source_module: None,
+                is_abstract_key_param: false,
             },
         );
         checker.finalize_hashmap_admission();
@@ -3355,6 +3372,7 @@ mod tests {
                 key_ty: Ty::normalize_named("Bad".to_string(), vec![]),
                 val_ty: Ty::I64,
                 source_module: None,
+                is_abstract_key_param: false,
             },
         );
         checker.finalize_hashmap_admission();
@@ -3463,6 +3481,7 @@ mod tests {
                 key_ty: Ty::normalize_named("K".to_string(), vec![]),
                 val_ty: Ty::I64,
                 source_module: None,
+                is_abstract_key_param: false,
             },
         );
         checker.finalize_hashmap_admission();
@@ -3498,6 +3517,7 @@ mod tests {
                 key_ty: Ty::normalize_named("Handle".to_string(), vec![]),
                 val_ty: Ty::I64,
                 source_module: None,
+                is_abstract_key_param: false,
             },
         );
         checker.finalize_hashmap_admission();
@@ -3537,6 +3557,7 @@ mod tests {
                 key_ty: Ty::normalize_named("Color".to_string(), vec![]),
                 val_ty: Ty::I64,
                 source_module: None,
+                is_abstract_key_param: false,
             },
         );
         checker.finalize_hashmap_admission();
@@ -3574,6 +3595,7 @@ mod tests {
                 key_ty: Ty::normalize_named("Point".to_string(), vec![]),
                 val_ty: Ty::normalize_named("Pos".to_string(), vec![]),
                 source_module: None,
+                is_abstract_key_param: false,
             },
         );
         checker.finalize_hashmap_admission();

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -530,6 +530,14 @@ impl Checker {
                 continue;
             }
 
+            // Bare type-parameter keys are checked against their declared
+            // `K: Hash + Eq` bounds at the call site.  They have no concrete
+            // layout fact before monomorphization; the HashMap handle bakes the
+            // substituted K/V layouts at `HashMap::new()` for each instantiation.
+            if check.is_abstract_key_param {
+                continue;
+            }
+
             // Still unresolved at the checker boundary → fail closed, but
             // deduplicate across multiple call sites that share the same
             // unresolved root vars.
@@ -3499,7 +3507,95 @@ impl Checker {
                 self.ty_to_dispatch_pattern(val_ty),
             ],
         };
-        self.record_resolved_collection_call("Map", method, &receiver, span);
+        if !self.is_hashmap_abstract_key_param(key_ty) {
+            self.record_resolved_collection_call("Map", method, &receiver, span);
+            return;
+        }
+        let key_param_name = self
+            .hashmap_abstract_key_param_name(key_ty)
+            .expect("abstract HashMap key param was checked above");
+
+        let key_pattern = self.ty_to_dispatch_pattern(key_ty);
+        let registry = collection_dispatch_registry_impl();
+        let resolved = resolve_method_call(&registry, "Map", method, &receiver, &|marker, ty| {
+            if *ty == key_pattern {
+                return self.type_param_has_marker_bound(&key_param_name, marker);
+            }
+            let ty = Self::dispatch_pattern_to_ty(ty);
+            self.registry.implements_marker(&ty, marker)
+        });
+        match resolved {
+            Ok(call) => {
+                self.resolved_calls
+                    .insert(SpanKey::in_module(span, self.current_module_idx), call);
+            }
+            Err(LookupError::BoundsNotSatisfied {
+                unsatisfied,
+                witness,
+                ..
+            }) => {
+                let witness_ty = Self::dispatch_pattern_to_ty(&witness);
+                let bound_summary = unsatisfied
+                    .iter()
+                    .map(|b| format!("{}: {}", b.var, b.trait_name))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                self.report_error(
+                    TypeErrorKind::BoundsNotSatisfied,
+                    span,
+                    format!(
+                        "`{}` does not satisfy the required bounds for \
+                         `Map::{method}` ({bound_summary})",
+                        witness_ty.user_facing()
+                    ),
+                );
+            }
+            Err(LookupError::NoImpl { .. } | LookupError::UnknownMethod { .. }) => {
+                self.report_error(
+                    TypeErrorKind::InvalidOperation,
+                    span,
+                    format!(
+                        "internal compiler error: collection resolver could \
+                         not locate `Map::{method}` for receiver `{receiver:?}`"
+                    ),
+                );
+            }
+        }
+    }
+
+    fn hashmap_abstract_key_param_name(&self, key_ty: &Ty) -> Option<String> {
+        match self.subst.resolve(key_ty).materialize_literal_defaults() {
+            Ty::Named {
+                name,
+                args,
+                builtin: None,
+            } if args.is_empty() && self.is_type_param_in_scope(&name) => Some(name),
+            _ => None,
+        }
+    }
+
+    fn type_param_has_marker_bound(&self, param_name: &str, marker: MarkerTrait) -> bool {
+        let marker_name = marker.to_string();
+        for frame in self.current_type_param_bounds.iter().rev() {
+            if let Some(bounds) = frame.bounds.get(param_name) {
+                return bounds.iter().any(|bound| bound == &marker_name);
+            }
+        }
+        if let Some(fn_name) = self.current_function.as_ref() {
+            if let Some(sig) = self.fn_sigs.get(fn_name) {
+                if sig.type_params.iter().any(|param| param == param_name) {
+                    return sig
+                        .type_param_bounds
+                        .get(param_name)
+                        .is_some_and(|bounds| bounds.iter().any(|bound| bound == &marker_name));
+                }
+            }
+        }
+        false
+    }
+
+    fn is_hashmap_abstract_key_param(&self, key_ty: &Ty) -> bool {
+        self.hashmap_abstract_key_param_name(key_ty).is_some()
     }
 
     fn record_resolved_hashset_call(&mut self, method: &str, elem_ty: &Ty, span: &Span) {
@@ -7994,6 +8090,7 @@ mod tests {
                 key_ty: Ty::Error,
                 val_ty: Ty::I64,
                 source_module: None,
+                is_abstract_key_param: false,
             },
         );
 
@@ -8020,6 +8117,7 @@ mod tests {
                 key_ty: Ty::String,
                 val_ty: Ty::Var(TypeVar::fresh()),
                 source_module: None,
+                is_abstract_key_param: false,
             },
         );
 
@@ -8034,6 +8132,69 @@ mod tests {
              Ty::Var; got: {:?}",
             checker.errors
         );
+    }
+
+    /// An abstract key parameter already admitted under its generic bounds has
+    /// no concrete layout fact until monomorphization substitutes K/V.
+    #[test]
+    fn finalize_hashmap_admission_skips_abstract_key_param() {
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let span = 60..70;
+        checker.deferred_hashmap_admission.insert(
+            SpanKey::in_module(&span, 0),
+            DeferredHashMapAdmission {
+                span: span.clone(),
+                key_ty: Ty::normalize_named("K".to_string(), vec![]),
+                val_ty: Ty::normalize_named("V".to_string(), vec![]),
+                source_module: None,
+                is_abstract_key_param: true,
+            },
+        );
+
+        checker.finalize_hashmap_admission();
+
+        assert!(
+            checker.errors.is_empty(),
+            "abstract HashMap key params are checked via declared bounds, not layout eligibility; got: {:?}",
+            checker.errors
+        );
+        assert!(
+            checker.hashmap_layout_facts.is_empty(),
+            "abstract HashMap key params must not produce concrete layout facts"
+        );
+    }
+
+    #[test]
+    fn record_resolved_hashmap_call_abstract_key_emits_resolved_call() {
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        checker
+            .current_type_param_bounds
+            .push(crate::check::types::TypeParamScope::new(
+                std::collections::HashMap::from([
+                    ("K".to_string(), vec!["Hash".to_string(), "Eq".to_string()]),
+                    ("V".to_string(), vec![]),
+                ]),
+                std::collections::HashMap::new(),
+            ));
+        let span = 80..90;
+
+        checker.record_resolved_hashmap_call(
+            "insert",
+            &Ty::normalize_named("K".to_string(), vec![]),
+            &Ty::normalize_named("V".to_string(), vec![]),
+            &span,
+        );
+
+        assert!(
+            checker.errors.is_empty(),
+            "declared K: Hash + Eq bounds must satisfy HashMap method dispatch; got: {:?}",
+            checker.errors
+        );
+        let call = checker
+            .resolved_calls
+            .get(&SpanKey::in_module(&span, 0))
+            .expect("generic HashMap method dispatch must record a resolved call");
+        assert_eq!(call.target.symbol_name, "hew_hashmap_insert_layout");
     }
 
     /// Two deferred `HashMap` admissions sharing the same unresolved
@@ -8053,6 +8214,7 @@ mod tests {
                 key_ty: Ty::Var(key_var),
                 val_ty: Ty::Var(val_var),
                 source_module: None,
+                is_abstract_key_param: false,
             },
         );
         checker.deferred_hashmap_admission.insert(
@@ -8062,6 +8224,7 @@ mod tests {
                 key_ty: Ty::Var(key_var),
                 val_ty: Ty::Var(val_var),
                 source_module: None,
+                is_abstract_key_param: false,
             },
         );
 

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -1643,6 +1643,7 @@ pub(super) struct DeferredHashMapAdmission {
     pub(super) key_ty: Ty,
     pub(super) val_ty: Ty,
     pub(super) source_module: Option<String>,
+    pub(super) is_abstract_key_param: bool,
 }
 
 /// A `HashSet` element admission check deferred until after all inference has

--- a/tests/hew/hashmap_generic_mono_test.hew
+++ b/tests/hew/hashmap_generic_mono_test.hew
@@ -1,0 +1,38 @@
+//! Generic HashMap operations must honor declared key bounds.
+
+import std::testing;
+
+fn fill<K: Hash + Eq, V>(m: HashMap<K, V>, k: K, v: V) {
+    m.insert(k, v);
+}
+
+fn has_key<K: Hash + Eq, V>(m: HashMap<K, V>, k: K) -> bool {
+    m.contains_key(k)
+}
+
+fn drop_key<K: Hash + Eq, V>(m: HashMap<K, V>, k: K) -> bool {
+    m.remove(k)
+}
+
+fn read_or<K: Hash + Eq, V>(m: HashMap<K, V>, k: K, fallback: V) -> V {
+    match m.get(k) {
+        Some(v) => v,
+        None => fallback,
+    }
+}
+
+fn count<K: Hash + Eq, V>(m: HashMap<K, V>) -> i64 {
+    m.len()
+}
+
+#[test]
+fn test_generic_hashmap_methods_honor_key_bounds() {
+    let m: HashMap<string, i64> = HashMap::new();
+
+    fill(m, "hello", 42);
+    testing.assert_true(has_key(m, "hello"));
+    testing.assert_eq(read_or(m, "hello", 0), 42);
+    testing.assert_eq(count(m), 1);
+    testing.assert_true(drop_key(m, "hello"));
+    testing.assert_eq(count(m), 0);
+}

--- a/tests/vertical-slice/accept/hashmap_generic_ops.hew
+++ b/tests/vertical-slice/accept/hashmap_generic_ops.hew
@@ -1,0 +1,51 @@
+// Accept fixture: HashMap<K, V> methods inside a generic function honor K bounds.
+
+fn put<K: Hash + Eq, V>(m: HashMap<K, V>, k: K, v: V) {
+    m.insert(k, v);
+}
+
+fn get_or<K: Hash + Eq, V>(m: HashMap<K, V>, k: K, fallback: V) -> V {
+    match m.get(k) {
+        Some(v) => v,
+        None => fallback,
+    }
+}
+
+fn has_key<K: Hash + Eq, V>(m: HashMap<K, V>, k: K) -> bool {
+    m.contains_key(k)
+}
+
+fn drop_key<K: Hash + Eq, V>(m: HashMap<K, V>, k: K) -> bool {
+    m.remove(k)
+}
+
+fn count<K: Hash + Eq, V>(m: HashMap<K, V>) -> i64 {
+    m.len()
+}
+
+fn check_i64_value() -> i64 {
+    let m: HashMap<string, i64> = HashMap::new();
+    put(m, "hello", 42);
+    if !has_key(m, "hello") { return 1; }
+    if get_or(m, "hello", 0) != 42 { return 2; }
+    if count(m) != 1 { return 3; }
+    if !drop_key(m, "hello") { return 4; }
+    if has_key(m, "hello") { return 5; }
+    if count(m) != 0 { return 6; }
+    0
+}
+
+fn check_string_value() -> i64 {
+    let m: HashMap<i64, string> = HashMap::new();
+    put(m, 7, "seven");
+    let got = get_or(m, 7, "missing");
+    if got != "seven" { return 11; }
+    if !drop_key(m, 7) { return 12; }
+    0
+}
+
+fn main() -> i64 {
+    let a = check_i64_value();
+    if a != 0 { return a; }
+    check_string_value()
+}

--- a/tests/vertical-slice/reject/hashmap_generic_key_missing_bounds.hew
+++ b/tests/vertical-slice/reject/hashmap_generic_key_missing_bounds.hew
@@ -1,0 +1,10 @@
+// Reject fixture: abstract HashMap keys still require declared Hash + Eq bounds.
+
+fn has_key<K, V>(m: HashMap<K, V>, k: K) -> bool {
+    m.contains_key(k)
+}
+
+fn main() {
+    let m: HashMap<string, i64> = HashMap::new();
+    let _ = has_key(m, "hello");
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1769,6 +1769,7 @@ run_accept_expect_status "vec_range_slice_inclusive" 3
 # and run with exact values; managed aggregate projections fail closed at check.
 run_accept_expect_stdout "hashmap_values_scalar"
 run_accept_expect_stdout "hashmap_values_string"
+run_accept_expect_status "hashmap_generic_ops" 0
 run_accept_expect_stdout "vec_scalar_range_slice"
 run_accept_expect_stdout "vec_string_range_slice"
 run_accept_expect_stdout "vec_element_widths"
@@ -1806,6 +1807,12 @@ expect_check_fail_error_count \
   "${ROOT}/tests/vertical-slice/reject/hashmap_keys_bytes.hew" \
   1 \
   "hashmap_keys_bytes"
+
+# shellcheck disable=SC2016  # backtick-containing diagnostic string; not shell expansion.
+expect_check_fail_contains \
+  "${ROOT}/tests/vertical-slice/reject/hashmap_generic_key_missing_bounds.hew" \
+  'does not satisfy the required bounds for `Map::contains_key`' \
+  "hashmap_generic_key_missing_bounds"
 
 expect_check_fail_contains \
   "${ROOT}/tests/vertical-slice/reject/vec_record_range_slice.hew" \


### PR DESCRIPTION
## Summary

A generic `HashMap<K,V>` — e.g. `fn put<K: Hash + Eq, V>(m: HashMap<K,V>, k: K, v: V)` — previously failed at the type checker because a bare type parameter `K` never matched the structural Hash/Eq marker lookup and an abstract `K` had no concrete layout to verify against. The checker now honors declared `K: Hash + Eq` where-bounds when a type parameter occupies key position, and defers concrete K/V layout resolution to monomorphization; HashMap already bakes K/V layout into the handle at construction, so K and V are concrete by the time codegen runs. A `K` without `Hash + Eq` bounds still fails closed. An abstract `V` monomorphized at a concretely unclonable type is caught by the codegen-front transitive-opaque authority at `hew check` time — exit 1, no UAF window.

## Verification

- `tests/vertical-slice/accept/hashmap_generic_ops.hew` (`HashMap<string,i64>` and `HashMap<i64,string>`, insert/get/remove/contains/len through the generic; string value exercises clone-on-get): `hew run` exit 0
- `tests/hew/hashmap_generic_mono_test.hew`: `test_generic_hashmap_methods_honor_key_bounds` — 1 passed
- Reject fixture (`K` with no bounds, `K: Hash`-only, managed-field record key): `hew check` exit 1 on each variant
- Abstract `V` at unclonable concrete type: `hew check` exit 1 (`E_CODEGEN_FRONT`), no binary produced; `hew run` exit 1 — fail-closed proven, no runtime UAF window
- `cargo nextest run -p hew-types`: 2426 passed, 2 skipped, exit 0
- `bash scripts/checked-mir-corpus.sh verify`: 29 fixtures × 2 stages byte-identical, exit 0
- `cargo clippy -p hew-types --all-targets`: exit 0, no warnings
- Preflight: ready-to-push

## Out of scope

- Clearer `hew check`-time diagnostic when an abstract-routed `V` is monomorphized at an unclonable concrete type — the concrete path emits the actionable `no map value clone_fn` message; the abstract path reaches the same codegen-front gate with a message framed around actor-supervisor state. Fail-closed; tracked as a follow-up.
- Generic record-key support (`K` as a fixed-width record type with derived `Hash + Eq`) — the concrete record-key path works but the generic where-bound lookup does not yet cover derived-Hash record types. Fail-closed capability gap; tracked as a follow-up.