### PR TITLE
fix(runtime): trap instead of silently dropping a full wasm channel send

### DIFF
--- a/hew-cli/tests/wasi_run_e2e.rs
+++ b/hew-cli/tests/wasi_run_e2e.rs
@@ -180,6 +180,54 @@ fn toml_encoding_round_trips_under_wasi() {
     assert_eq!(stdout.as_ref(), "hew\n", "stderr:\n{stderr}");
 }
 
+// WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
+#[cfg_attr(windows, ignore)]
+#[test]
+fn wasm_channel_send_full_traps_instead_of_dropping() {
+    require_wasi_runner();
+
+    let dir = support::tempdir();
+    let source = dir.path().join("channel_send_full_traps_wasi.hew");
+    fs::write(
+        &source,
+        r#"import std::channel::channel;
+
+fn main() {
+    let (tx, rx): (channel.Sender<string>, channel.Receiver<string>) = channel.new(2);
+
+    tx.send("msg-1");
+    tx.send("msg-2");
+    tx.send("msg-3");
+    tx.close();
+
+    match rx.try_recv() { Some(s) => println(s), None => println("empty-1") }
+    match rx.try_recv() { Some(s) => println(s), None => println("empty-2") }
+    match rx.try_recv() { Some(s) => println(s), None => println("empty-3-DROPPED") }
+    match rx.try_recv() { Some(s) => println(s), None => println("drained") }
+    rx.close();
+}
+"#,
+    )
+    .expect("write channel full-send WASI source");
+
+    let output = run_wasi_example(&source);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "full wasm channel send must trap rather than exiting successfully\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("channel is full"),
+        "trap diagnostic should name the full channel\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(
+        !stdout.contains("empty-3-DROPPED"),
+        "full send must not silently drop and continue\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+}
+
 // The layout-keyed `HashMap<Record, V>` / `HashSet<string>` runtime ABI
 // (`hew_hashmap_*_layout` / `hew_hashset_*_layout`) is target-agnostic: the
 // modules are not `cfg`-gated against wasm32 and codegen lowers their callees

--- a/hew-runtime/src/channel_wasm.rs
+++ b/hew-runtime/src/channel_wasm.rs
@@ -266,9 +266,10 @@ fn send_bytes(sender: &HewWasmChannelSender, bytes: Vec<u8>, api_name: &str) {
     match sender.inner.try_send(bytes) {
         Ok(()) | Err(TrySendError::Closed) => {}
         Err(TrySendError::Full) => {
-            crate::set_last_error(format!(
-                "{api_name}: channel is full; message dropped (blocking send not yet implemented for wasm32)"
-            ));
+            panic!(
+                "{api_name}: channel is full; blocking send is not available on wasm32 \
+                 (cooperative scheduler does not yet support yield/resume for send parks)"
+            );
         }
     }
 }
@@ -276,8 +277,8 @@ fn send_bytes(sender: &HewWasmChannelSender, bytes: Vec<u8>, api_name: &str) {
 /// Send one element of any witness-describable type through the channel
 /// (the wasm32 counterpart of the native `hew_channel_send_layout`). The
 /// element is deep-copied into the envelope; the caller keeps its value.
-/// Non-blocking: a full queue drops the message and records a diagnostic
-/// (blocking send needs cooperative yield/resume parity).
+/// Non-blocking: a full queue traps because blocking send needs cooperative
+/// yield/resume parity.
 ///
 /// # Safety
 ///
@@ -765,64 +766,18 @@ mod tests {
         }
     }
 
-    // When a WASM channel is full, hew_channel_send_layout must set the last
-    // error and silently drop the message rather than trapping with a panic.
     #[test]
-    fn abi_send_layout_full_sets_last_error() {
+    #[should_panic(expected = "channel is full; blocking send is not available on wasm32")]
+    fn send_bytes_full_traps() {
         crate::hew_clear_error();
         let _guard = crate::runtime_test_guard();
-        let pair = hew_channel_new(1);
-        // SAFETY: extracted handles are used only within this test and are
-        // closed exactly once before returning.
-        unsafe {
-            let tx = hew_channel_pair_sender(pair);
-            let rx = hew_channel_pair_receiver(pair);
-            hew_channel_pair_free(pair);
+        let (tx, _rx) = channel(1);
+        let tx = HewWasmChannelSender::new(tx);
 
-            let plain_witness = plain_layout(8, 8);
+        // Fill the channel to capacity.
+        send_bytes(&tx, vec![1], "hew_channel_send_layout");
 
-            // Fill the channel to capacity.
-            let one: i64 = 1;
-            hew_channel_send_layout(tx, std::ptr::addr_of!(one).cast(), &raw const plain_witness);
-
-            // Send to a full channel — must NOT panic; must set last error.
-            let two: i64 = 2;
-            hew_channel_send_layout(tx, std::ptr::addr_of!(two).cast(), &raw const plain_witness);
-
-            let err_ptr = crate::hew_last_error();
-            assert!(
-                !err_ptr.is_null(),
-                "hew_last_error should be set after send on full channel"
-            );
-            let err = CStr::from_ptr(err_ptr).to_str().unwrap();
-            assert!(
-                err.contains("full") || err.contains("Full"),
-                "error message should mention full channel, got: {err:?}"
-            );
-
-            // Only the first message should be in the queue.
-            let mut value: i64 = -1;
-            let rc = hew_channel_try_recv_layout(
-                rx,
-                std::ptr::addr_of_mut!(value).cast(),
-                &raw const plain_witness,
-            );
-            assert_eq!(rc, 1);
-            assert_eq!(value, 1, "first element must be dequeued");
-
-            // The second message must have been dropped (not enqueued).
-            let rc = hew_channel_try_recv_layout(
-                rx,
-                std::ptr::addr_of_mut!(value).cast(),
-                &raw const plain_witness,
-            );
-            assert_eq!(
-                rc, 0,
-                "full-channel send must not enqueue the dropped message"
-            );
-
-            hew_channel_sender_close(tx);
-            hew_channel_receiver_close(rx);
-        }
+        // Send to a full channel — must trap rather than silently dropping.
+        send_bytes(&tx, vec![2], "hew_channel_send_layout");
     }
 }

--- a/std/channel/channel.hew
+++ b/std/channel/channel.hew
@@ -71,7 +71,8 @@ pub type Receiver {
 trait SenderMethods {
     /// Send a message through the channel.
     ///
-    /// Blocks if the channel is full (backpressure).
+    /// Blocks if the channel is full (backpressure). On wasm32, a full send
+    /// traps because blocking is pending cooperative scheduler yield/resume.
     fn send(self, data: string);
 
     /// Clone this sender for multi-producer use.


### PR DESCRIPTION
## Summary

On wasm32, a `send` to a full bounded channel set an internal error flag and returned, allowing the caller to continue while the message was silently discarded — a fail-open data loss. Native `send` blocks on a condvar guaranteeing delivery; wasm's cooperative scheduler cannot block, so the fail-closed substitute is to trap (a wasm `unreachable` instruction), which is exactly what the capability matrix already documents for this surface. The `panic=abort` profile converts the `panic!` to an `unreachable` trap and surfaces a `"channel is full"` diagnostic to stderr before stopping. The native code path is unchanged; the intentional native-blocks / wasm-traps asymmetry is now documented in `std/channel/channel.hew`. Silent data loss is removed.

## Verification

- `cargo test -p hew-cli --test wasi_run_e2e wasm_channel_send_full_traps_instead_of_dropping` (Linux wasm32-wasip1 / wasmtime): pass — cap-2 channel, 3 sends; 3rd send traps (exit 134, `wasm 'unreachable'`, `"channel is full"` diagnostic), message not present in output.
- Probe: cap-3 channel filled exactly to capacity (3 sends): exit 0, no false-trap — boundary `len() >= capacity` is correct.
- Probe: send after consumer drains space (cap-2, fill, recv one, send again): exit 0, succeeds.
- `cargo test -p hew-runtime --lib channel_wasm::tests` (Linux x86_64): 44 passed — `send_bytes_full_traps` (`#[should_panic]`) and reply-channel lifecycle tests included.
- Native channel path: zero diff; native condvar-blocking tests unchanged and green.
- Preflight: ready-to-push — `cargo fmt --all -- --check`, `cargo clippy -p hew-runtime --lib --tests -D warnings`, `cargo clippy -p hew-cli --tests -D warnings` all exit 0 on Linux x86_64 + wasm32-wasip1.

## Out of scope

- Pre-existing `i as u8` cast (`cast_possible_truncation`) in `hew-runtime/benches/observe_overhead.rs:8` — not in this diff; does not affect the project's clippy gate (`--tests`). Filed for separate triage.
- Pre-existing `wasm32-unknown-unknown` build gap in `hew-cabi` (`libc::abort`/`libc::free` absent on bare wasm target) — not in this diff; the project ships and tests `wasm32-wasip1`, which builds and runs cleanly.
