### PR TITLE
Refresh editor syntax grammars to the current keyword surface

### DIFF
--- a/docs/syntax-data.json
+++ b/docs/syntax-data.json
@@ -194,6 +194,7 @@
     "events": "Machine input-event vocabulary block header (contextual inside machine body)",
     "emits": "Machine Mealy-output manifest block header (contextual inside machine body)",
     "reenter": "Machine transition self-re-entry modifier (contextual after target state name)",
+    "initial": "Machine composite-state initial-substate marker (contextual before nested state decl)",
     "mailbox": "Actor mailbox configuration block",
     "overflow": "Mailbox overflow policy",
     "intensity": "Supervisor restart-budget field (intensity: N within <duration>)",

--- a/editors/nano/hew.nanorc
+++ b/editors/nano/hew.nanorc
@@ -35,35 +35,34 @@ color brightmagenta "\<[0-9][0-9_]*\>"
 # Boolean & None
 color brightmagenta "\<(true|false|None)\>"
 
-# Control flow keywords (v0.5 additions: is)
+# Control flow keywords
 color brightwhite "\<(if|else|match|loop|for|while|break|continue|return|in)\>"
-color brightwhite "\<(yield|defer|select|join|cooperate|after|from|await|scope|is)\>"
+color brightwhite "\<(yield|defer|select|join|cooperate|after|from|await|scope)\>"
 
 # Declaration keywords
-color green "\<(let|var|const|fn|gen|async|pub|import|package|super)\>"
-color green "\<(extern|where|type|indirect|enum|trait|impl|as|struct|record)\>"
+color green "\<(let|var|const|mut|fn|gen|async|pub|import|package)\>"
+color green "\<(super|extern|where|record|type|indirect|enum|trait|impl|as)\>"
+color green "\<(struct)\>"
 
-# Actor & concurrency (v0.5 additions: link, monitor)
-color brightgreen "\<(actor|fork|init|link|monitor|move|receive|spawn|this)\>"
+# Actor & concurrency
+color brightgreen "\<(actor|supervisor|spawn|receive|init|scope|fork|move|select|join)\>"
+color brightgreen "\<(after|from|await|this)\>"
 
-# Supervisor
-color brightgreen "\<(supervisor|child|restart|budget|strategy)\>"
+# Supervisor configuration
+color brightgreen "\<(child|restart|budget|strategy|permanent|transient|temporary|brutal_kill|one_for_one|one_for_all)\>"
+color brightgreen "\<(rest_for_one|simple_one_for_one|pool)\>"
 
 # Wire protocol
 color green "\<(wire|reserved|optional|deprecated|default)\>"
 
-# Machine keywords (v0.5 additions: drives, emit, entry, exit, transitions)
-color green "\<(drives|emit|entry|event|exit|machine|on|state|transitions|when)\>"
+# Machine keywords
+color green "\<(machine|state|event|on|when|entry|exit|emit)\>"
 
 # Other keywords
-color green "\<(dyn|unsafe)\>"
-
-# Strategy & policy constants
-color brightmagenta "\<(one_for_one|one_for_all|rest_for_one)\>"
-color brightmagenta "\<(permanent|transient|temporary)\>"
+color green "\<(dyn|unsafe|is)\>"
 
 # Reserved keywords
-color green "\<(try|catch|race|foreign)\>"
+color green "\<(try|catch|race|foreign|cooperate)\>"
 
 # Types — primitives
 color brightblue "\<(i8|i16|i32|i64|u8|u16|u32|u64|isize|usize|f32|f64)\>"
@@ -96,8 +95,7 @@ color white "::"
 # Attributes
 color magenta "#\[[^\]]*\]"
 
-# Labels and decorators
-color red "@reenter"
+# Labels
 color red "@[a-zA-Z_][a-zA-Z0-9_]*"
 
 # TODO/FIXME in comments

--- a/editors/sublime/Hew.tmLanguage.json
+++ b/editors/sublime/Hew.tmLanguage.json
@@ -28,9 +28,6 @@
       "include": "#actors"
     },
     {
-      "include": "#type-forms"
-    },
-    {
       "include": "#keywords"
     },
     {
@@ -38,6 +35,15 @@
     },
     {
       "include": "#types"
+    },
+    {
+      "include": "#turbofish"
+    },
+    {
+      "include": "#closures"
+    },
+    {
+      "include": "#glob-import"
     },
     {
       "include": "#operators"
@@ -83,7 +89,12 @@
     "strings": {
       "patterns": [
         {
-          "comment": "Byte string literal: b\"bytes\"",
+          "comment": "Char literal: 'a', '\\n'",
+          "name": "string.quoted.single.char.hew",
+          "match": "'([^'\\\\]|\\\\.)'"
+        },
+        {
+          "comment": "Byte string literal: b\"data\"",
           "name": "string.quoted.byte.hew",
           "begin": "b\"",
           "end": "\"",
@@ -92,11 +103,6 @@
               "include": "#string-escape"
             }
           ]
-        },
-        {
-          "comment": "Char literal: 'a', '\\n'",
-          "name": "string.quoted.single.char.hew",
-          "match": "'([^'\\\\]|\\\\(n|r|t|\\\\|'|0|x[0-9a-fA-F]{2}))'"
         },
         {
           "comment": "Interpolated string: f\"hello {name}\"",
@@ -194,7 +200,7 @@
       ]
     },
     "attributes": {
-      "comment": "Attribute syntax with optional payload: #[test], #[max_heap(...)], #[on(crash)]",
+      "comment": "Attribute syntax: #[test], #[inline]",
       "name": "meta.attribute.hew",
       "begin": "#\\[",
       "end": "\\]",
@@ -215,32 +221,12 @@
         },
         {
           "include": "#strings"
-        },
-        {
-          "include": "#numbers"
-        },
-        {
-          "include": "#types"
-        },
-        {
-          "include": "#operators"
-        },
-        {
-          "include": "#punctuation"
-        },
-        {
-          "include": "#variables"
         }
       ]
     },
     "wire-annotations": {
       "comment": "Wire field tags (@1, @2) and loop labels (@outer, @inner)",
       "patterns": [
-        {
-          "comment": "Machine self-transition marker",
-          "name": "keyword.control.machine.reenter.hew",
-          "match": "@reenter\\b"
-        },
         {
           "comment": "Wire field tag: @1, @2",
           "name": "constant.numeric.wire-tag.hew",
@@ -256,19 +242,19 @@
     "keywords": {
       "patterns": [
         {
-          "comment": "Control flow (v0.5 additions: is)",
+          "comment": "Control flow",
           "name": "keyword.control.hew",
-          "match": "\\b(after|await|break|continue|cooperate|defer|else|for|from|if|in|is|join|loop|match|return|scope|select|while|yield)\\b"
+          "match": "\\b(after|await|break|continue|cooperate|defer|else|for|from|if|in|join|loop|match|return|scope|select|while|yield)\\b"
         },
         {
           "comment": "Declarations",
           "name": "keyword.declaration.hew",
-          "match": "\\b(as|async|const|enum|extern|fn|gen|impl|import|indirect|let|package|pub|struct|super|trait|type|var|where)\\b"
+          "match": "\\b(as|async|const|enum|extern|fn|gen|impl|import|indirect|let|mut|package|pub|record|struct|super|trait|type|var|where)\\b"
         },
         {
           "comment": "Actor and concurrency",
           "name": "keyword.actor.hew",
-          "match": "\\b(actor|fork|init|link|monitor|move|receive|spawn|this)\\b"
+          "match": "\\b(actor|fork|init|move|receive|spawn|this)\\b"
         },
         {
           "comment": "Supervisor",
@@ -278,7 +264,7 @@
         {
           "comment": "Supervisor strategy and overflow policy values",
           "name": "constant.language.strategy.hew",
-          "match": "\\b(brutal_kill|one_for_all|one_for_one|permanent|rest_for_one|simple_one_for_one|temporary|transient)\\b"
+          "match": "\\b(brutal_kill|one_for_all|one_for_one|permanent|pool|rest_for_one|simple_one_for_one|temporary|transient)\\b"
         },
         {
           "comment": "Wire protocol keywords",
@@ -288,12 +274,12 @@
         {
           "comment": "State machine keywords",
           "name": "keyword.control.machine.hew",
-          "match": "\\b(drives|emit|entry|event|exit|machine|on|state|transitions|when)\\b"
+          "match": "\\b(emit|entry|event|exit|machine|on|state|when)\\b"
         },
         {
           "comment": "Other keywords",
           "name": "keyword.other.hew",
-          "match": "\\b(dyn|unsafe)\\b"
+          "match": "\\b(dyn|is|unsafe)\\b"
         },
         {
           "comment": "Boolean literals",
@@ -306,14 +292,32 @@
           "match": "\\bNone\\b"
         },
         {
+          "comment": "Removed/rejected keywords — parser explicitly rejects these with migration diagnostics. Highlight as invalid so users know these are not valid v0.5 syntax.",
+          "name": "invalid.removed.hew",
+          "match": "\\b(catch|foreign|race|try)\\b"
+        },
+        {
           "comment": "Reserved keywords (not yet used in the language)",
           "name": "keyword.reserved.hew",
-          "match": "\\b(catch|foreign|race|try)\\b"
+          "match": "\\b(catch|cooperate|foreign|race|try)\\b"
         }
       ]
     },
     "types": {
       "patterns": [
+        {
+          "comment": "Raw pointer type prefix *const/*mut — valid only in extern/FFI/unsafe context. *var T is LEGACY and rejected by the parser.",
+          "name": "meta.type.pointer.raw.hew",
+          "match": "(\\*)\\s*(const|mut)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.operator.pointer.hew"
+            },
+            "2": {
+              "name": "storage.modifier.pointer-mutability.hew"
+            }
+          }
+        },
         {
           "comment": "Numeric types",
           "name": "storage.type.numeric.hew",
@@ -327,12 +331,12 @@
         {
           "comment": "Generic / collection types",
           "name": "storage.type.generic.hew",
-          "match": "\\b(Arc|Err|HashMap|HashSet|Map|Ok|Option|Range|Rc|Result|Some|Vec|Weak)\\b"
+          "match": "\\b(Arc|Err|HashMap|HashSet|Ok|Option|Range|Rc|Result|Some|Vec|Weak)\\b"
         },
         {
           "comment": "Concurrency types",
           "name": "storage.type.concurrency.hew",
-          "match": "\\b(ActorRef|AsyncGenerator|Channel|Duplex|Generator|LocalPid|Pid|Scope|Sink|Stream|Task)\\b"
+          "match": "\\b(ActorRef|AsyncGenerator|Generator|Scope|Sink|Stream|Task)\\b"
         },
         {
           "comment": "Built-in trait names",
@@ -348,201 +352,6 @@
           "comment": "PascalCase type name",
           "name": "entity.name.type.hew",
           "match": "\\b[A-Z][a-zA-Z0-9_]*\\b"
-        }
-      ]
-    },
-    "type-forms": {
-      "patterns": [
-        {
-          "comment": "Collection / sum generic type forms: Vec<T>, Map<K, V>, Result<T, E>, Option<T>",
-          "name": "meta.type.generic.collection.hew",
-          "begin": "\\b(Arc|HashMap|HashSet|Map|Option|Range|Rc|Result|Vec|Weak)\\s*(<)",
-          "beginCaptures": {
-            "1": {
-              "name": "storage.type.generic.hew"
-            },
-            "2": {
-              "name": "punctuation.definition.generic.begin.hew"
-            }
-          },
-          "end": ">",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.generic.end.hew"
-            }
-          },
-          "patterns": [
-            {
-              "include": "#type-forms"
-            },
-            {
-              "include": "#types"
-            },
-            {
-              "include": "#operators"
-            },
-            {
-              "include": "#punctuation"
-            },
-            {
-              "include": "#variables"
-            }
-          ]
-        },
-        {
-          "comment": "Concurrency generic type forms: Stream<T>, Sink<T>, Duplex<S, R>, Channel<T>, Pid<T>, Task<T>",
-          "name": "meta.type.generic.concurrency.hew",
-          "begin": "\\b(ActorRef|Channel|Duplex|LocalPid|Pid|Sink|Stream|Task)\\s*(<)",
-          "beginCaptures": {
-            "1": {
-              "name": "storage.type.concurrency.hew"
-            },
-            "2": {
-              "name": "punctuation.definition.generic.begin.hew"
-            }
-          },
-          "end": ">",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.generic.end.hew"
-            }
-          },
-          "patterns": [
-            {
-              "include": "#type-forms"
-            },
-            {
-              "include": "#types"
-            },
-            {
-              "include": "#operators"
-            },
-            {
-              "include": "#punctuation"
-            },
-            {
-              "include": "#variables"
-            }
-          ]
-        },
-        {
-          "comment": "Associated type projection: Self::Item",
-          "name": "meta.type.associated.hew",
-          "match": "\\b(Self)(::)([A-Z][a-zA-Z0-9_]*)\\b",
-          "captures": {
-            "1": {
-              "name": "storage.type.self.hew"
-            },
-            "2": {
-              "name": "keyword.operator.namespace.hew"
-            },
-            "3": {
-              "name": "entity.name.type.associated.hew"
-            }
-          }
-        },
-        {
-          "comment": "Raw pointer type prefix: *const T, *mut T",
-          "name": "meta.type.pointer.raw.hew",
-          "match": "(\\*)(\\s*)(const|mut)\\b",
-          "captures": {
-            "1": {
-              "name": "keyword.operator.pointer.hew"
-            },
-            "3": {
-              "name": "storage.modifier.pointer.hew"
-            }
-          }
-        },
-        {
-          "comment": "Named record literal: TypeName { field: value }",
-          "name": "meta.record.literal.hew",
-          "begin": "\\b([A-Z][a-zA-Z0-9_]*)\\s*(\\{)",
-          "beginCaptures": {
-            "1": {
-              "name": "entity.name.type.record.hew"
-            },
-            "2": {
-              "name": "punctuation.brackets.curly.hew"
-            }
-          },
-          "end": "\\}",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.brackets.curly.hew"
-            }
-          },
-          "patterns": [
-            {
-              "include": "#comments"
-            },
-            {
-              "include": "#strings"
-            },
-            {
-              "include": "#numbers"
-            },
-            {
-              "include": "#attributes"
-            },
-            {
-              "include": "#type-forms"
-            },
-            {
-              "include": "#keywords"
-            },
-            {
-              "include": "#function-calls"
-            },
-            {
-              "include": "#types"
-            },
-            {
-              "include": "#operators"
-            },
-            {
-              "include": "#punctuation"
-            },
-            {
-              "include": "#variables"
-            }
-          ]
-        },
-        {
-          "comment": "Tuple type annotation: name: (A, B, C)",
-          "name": "meta.type.tuple.hew",
-          "begin": "(:)\\s*(\\()(?=[^\\n)]*,)",
-          "beginCaptures": {
-            "1": {
-              "name": "punctuation.separator.colon.hew"
-            },
-            "2": {
-              "name": "punctuation.brackets.round.hew"
-            }
-          },
-          "end": "\\)",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.brackets.round.hew"
-            }
-          },
-          "patterns": [
-            {
-              "include": "#type-forms"
-            },
-            {
-              "include": "#types"
-            },
-            {
-              "include": "#operators"
-            },
-            {
-              "include": "#punctuation"
-            },
-            {
-              "include": "#variables"
-            }
-          ]
         }
       ]
     },
@@ -692,18 +501,6 @@
           }
         },
         {
-          "comment": "Type declaration",
-          "match": "\\b(type)\\s+([A-Z][a-zA-Z0-9_]*)",
-          "captures": {
-            "1": {
-              "name": "keyword.declaration.hew"
-            },
-            "2": {
-              "name": "entity.name.type.hew"
-            }
-          }
-        },
-        {
           "comment": "Impl Trait for Type",
           "match": "\\b(impl)\\s+([A-Z][a-zA-Z0-9_]*)\\s+(for)\\s+([A-Z][a-zA-Z0-9_]*)",
           "captures": {
@@ -717,18 +514,6 @@
               "name": "keyword.declaration.hew"
             },
             "4": {
-              "name": "entity.name.type.hew"
-            }
-          }
-        },
-        {
-          "comment": "Inherent impl block: impl Type { — must precede #type-forms so 'Type {' is not mis-scoped as a record literal",
-          "match": "\\b(impl)\\s+([A-Z][a-zA-Z0-9_]*)",
-          "captures": {
-            "1": {
-              "name": "keyword.declaration.hew"
-            },
-            "2": {
               "name": "entity.name.type.hew"
             }
           }
@@ -777,6 +562,89 @@
         }
       ]
     },
+    "turbofish": {
+      "patterns": [
+        {
+          "comment": "Turbofish type arguments in expression position: Ident::<T>(...), Vec::<i64>::new() (grammar.ebnf:249). Scoped before #operators so the angle brackets are not mistaken for comparison operators.",
+          "begin": "(::)(<)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.operator.namespace.hew"
+            },
+            "2": {
+              "name": "punctuation.definition.typeparameters.begin.hew"
+            }
+          },
+          "end": "(>)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.typeparameters.end.hew"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#types"
+            },
+            {
+              "name": "punctuation.separator.comma.hew",
+              "match": ","
+            }
+          ]
+        }
+      ]
+    },
+    "closures": {
+      "patterns": [
+        {
+          "comment": "Closure parameters: |x|, |x, y|, |x: T|, move |x|, actor |x| (grammar.ebnf:289-295). Anchored to closure-introducing contexts (after = ( , [ => move actor) so bitwise-or `a | b | c`, or-patterns `A | B`, and logical-or `a || b` keep their operator scopes. Empty `||` closures intentionally stay logical-or to avoid mis-scoping `a || b`.",
+          "begin": "(?<=[=(,\\[]\\s*|=>\\s*|\\bmove\\s+|\\bactor\\s+)(\\|)(?!\\|)(?=[^|]*\\|)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.parameters.begin.hew"
+            }
+          },
+          "end": "(\\|)",
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.parameters.end.hew"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#types"
+            },
+            {
+              "name": "variable.parameter.hew",
+              "match": "\\b[a-z_][a-zA-Z0-9_]*\\b"
+            },
+            {
+              "name": "punctuation.separator.colon.hew",
+              "match": ":"
+            },
+            {
+              "name": "punctuation.separator.comma.hew",
+              "match": ","
+            }
+          ]
+        }
+      ]
+    },
+    "glob-import": {
+      "patterns": [
+        {
+          "comment": "Glob import wildcard: import a::b::* (grammar.ebnf:66). Matched before #operators so the trailing * is a wildcard, not arithmetic multiply. The `::*` sequence only occurs in glob imports — Hew dereference is prefix *expr, never path::*.",
+          "match": "(::)(\\*)",
+          "captures": {
+            "1": {
+              "name": "keyword.operator.namespace.hew"
+            },
+            "2": {
+              "name": "keyword.operator.wildcard.hew"
+            }
+          }
+        }
+      ]
+    },
     "operators": {
       "patterns": [
         {
@@ -785,14 +653,14 @@
           "match": "->|=>"
         },
         {
-          "comment": "Send operator",
-          "name": "keyword.operator.send.hew",
-          "match": "<-"
-        },
-        {
           "comment": "Range operators",
           "name": "keyword.operator.range.hew",
           "match": "\\.\\.=|\\.\\.(?!\\.)"
+        },
+        {
+          "comment": "Regex match operators",
+          "name": "keyword.operator.regex.hew",
+          "match": "=~|!~"
         },
         {
           "comment": "Logical operators",
@@ -803,11 +671,6 @@
           "comment": "Comparison operators",
           "name": "keyword.operator.comparison.hew",
           "match": "==|!=|<=|>=|<|>"
-        },
-        {
-          "comment": "Pattern / type test operator",
-          "name": "keyword.operator.is.hew",
-          "match": "\\bis\\b"
         },
         {
           "comment": "Bitwise shift compound assignment",
@@ -921,12 +784,7 @@
         {
           "comment": "Contextual identifiers (special meaning in specific contexts)",
           "name": "variable.language.contextual.hew",
-          "match": "\\b(block|coalesce|drop_new|drop_old|export|fail|fallback|infinity|intensity|json|mailbox|mut|overflow|repeated|shutdown|wired_to|within|yaml)\\b"
-        },
-        {
-          "comment": "Field label in records, type fields, and named arguments",
-          "name": "variable.other.field.hew",
-          "match": "\\b[a-z_][a-zA-Z0-9_]*\\b(?=\\s*:)"
+          "match": "\\b(block|coalesce|drop_new|drop_old|emits|events|export|fail|fallback|infinity|initial|intensity|json|mailbox|overflow|reenter|repeated|shutdown|wired_to|within|yaml)\\b"
         },
         {
           "comment": "Identifier (catch-all for variables, parameters, fields)",

--- a/tools/downstream/generate-nano.mjs
+++ b/tools/downstream/generate-nano.mjs
@@ -150,14 +150,18 @@ blank();
 
 // Actor & concurrency
 emit('# Actor & concurrency');
-const actorWords = ['actor', 'fork', 'init', 'move', 'receive', 'spawn', 'terminate', 'this'];
-emit(`color brightgreen ${nanoKeywordRegex(actorWords)}`);
+const actorChunks = chunkArray([...kw.actors], 10);
+for (const chunk of actorChunks) {
+  emit(`color brightgreen ${nanoKeywordRegex(chunk)}`);
+}
 blank();
 
-// Supervisor
-emit('# Supervisor');
-const supervisorWords = ['supervisor', 'child', 'restart', 'budget', 'strategy'];
-emit(`color brightgreen ${nanoKeywordRegex(supervisorWords)}`);
+// Supervisor configuration (config words + restart strategy / overflow constants)
+emit('# Supervisor configuration');
+const supervisorChunks = chunkArray([...kw.supervisor_config], 10);
+for (const chunk of supervisorChunks) {
+  emit(`color brightgreen ${nanoKeywordRegex(chunk)}`);
+}
 blank();
 
 // Wire protocol
@@ -173,14 +177,6 @@ blank();
 // Other keywords
 emit('# Other keywords');
 emit(`color green ${nanoKeywordRegex(kw.other)}`);
-blank();
-
-// Strategy & policy constants
-emit('# Strategy & policy constants');
-const strategies = ['one_for_one', 'one_for_all', 'rest_for_one'];
-const permanence = ['permanent', 'transient', 'temporary'];
-emit(`color brightmagenta ${nanoKeywordRegex(strategies)}`);
-emit(`color brightmagenta ${nanoKeywordRegex(permanence)}`);
 blank();
 
 // Reserved keywords
@@ -259,6 +255,21 @@ blank();
 // TODO/FIXME in comments
 emit('# TODO/FIXME in comments');
 emit('color brightyellow,cyan "\\<(TODO|FIXME|XXX|NOTE|HACK)\\>"');
+
+// -- Verify keyword coverage -----------------------------------------------
+// Guard against drift: every keyword the lexer recognises (all_keywords, kept
+// in sync with the lexer by a hew-lexer unit test) must fall into a highlighted
+// group. A miss means a new keyword needs a home in one of the groups above.
+
+const coveredKeywords = new Set([
+  ...kw.control_flow, ...kw.declarations, ...kw.actors, ...kw.supervisor_config,
+  ...kw.wire, ...kw.machine, ...kw.other, ...kw.reserved_unused, ...kw.logical,
+]);
+const missingKeywords = syntaxData.all_keywords.filter(k => !coveredKeywords.has(k));
+if (missingKeywords.length > 0) {
+  console.log('\u26a0 Keywords in all_keywords not highlighted in the nano grammar:');
+  console.log(`   ${missingKeywords.join(', ')}\n`);
+}
 
 // -- Write output ----------------------------------------------------------
 

--- a/tools/downstream/generate-tmgrammar.mjs
+++ b/tools/downstream/generate-tmgrammar.mjs
@@ -69,7 +69,7 @@ const keywordGroups = {
   ],
 
   'keyword.actor.hew': [
-    'actor', 'fork', 'init', 'move', 'receive', 'spawn', 'terminate', 'this',
+    'actor', 'fork', 'init', 'move', 'receive', 'spawn', 'this',
   ],
 
   'keyword.supervisor.hew': [
@@ -78,7 +78,8 @@ const keywordGroups = {
 
   'constant.language.strategy.hew': [
     'permanent', 'transient', 'temporary',
-    'one_for_one', 'one_for_all', 'rest_for_one',
+    'one_for_one', 'one_for_all', 'rest_for_one', 'simple_one_for_one',
+    'pool', 'brutal_kill',
   ],
 
   'keyword.wire.hew': [...kw.wire],

--- a/tools/downstream/patch-vim-syntax.mjs
+++ b/tools/downstream/patch-vim-syntax.mjs
@@ -12,7 +12,7 @@
  *
  * Supported categories:
  *   control_flow, declarations, actors, supervisor, wire, machine, other,
- *   logical, supervisor_config, reserved_unused, types
+ *   logical, supervisor_config, reserved_unused, contextual, types
  *
  * Usage: node tools/downstream/patch-vim-syntax.mjs [HEW_VIM_PATH]
  *
@@ -59,6 +59,33 @@ const originalSource = readFileSync(syntaxFilePath, 'utf8');
 
 const kw = syntaxData.keywords;
 const types = syntaxData.types;
+const contextual = syntaxData.contextual_identifiers;
+
+// -- Hub-derived supervisor + contextual keyword sets ----------------------
+// supervisor_config entries that name structural fields are highlighted as
+// keywords (hewSupervisor); the rest are restart-strategy / permanence /
+// child-kind value constants (hewStrategy). The `supervisor` keyword itself
+// is sourced from kw.actors (emitted by the actors category), so it is not
+// repeated here.
+const supervisorFieldKeywords = ['child', 'restart', 'budget', 'strategy'];
+const supervisorConfigFields = kw.supervisor_config.filter(
+  w => supervisorFieldKeywords.includes(w));
+const supervisorConstants = kw.supervisor_config.filter(
+  w => !supervisorFieldKeywords.includes(w));
+
+// Mailbox overflow policy values live in contextual_identifiers, flagged by an
+// "overflow" mention in their description. The `overflow` block-header key
+// names the field rather than a value, so it is excluded.
+const overflowKinds = Object.entries(contextual)
+  .filter(([name, desc]) =>
+    name !== 'overflow' && typeof desc === 'string' && /overflow/i.test(desc))
+  .map(([name]) => name);
+
+// Remaining contextual identifiers: soft keywords that are not reserved and
+// not overflow values (within, intensity, initial, repeated, infinity, ...).
+const contextualKeywords = Object.keys(contextual)
+  .filter(name => name !== 'description' && name !== 'self'
+    && !overflowKinds.includes(name));
 
 // -- Category → { group, keywords[] } mapping -----------------------------
 // Each category produces one or more `syn keyword <group> <words...>` lines.
@@ -86,7 +113,7 @@ const categoryMap = {
 
   supervisor: {
     group: 'hewSupervisor',
-    keywords: ['supervisor', 'child', 'restart', 'budget', 'strategy'],
+    keywords: [...supervisorConfigFields],
   },
 
   wire: {
@@ -117,21 +144,22 @@ const categoryMap = {
 
   supervisor_config: {
     group: 'hewStrategy',
-    keywords: () => {
-      const strategies = ['one_for_one', 'one_for_all', 'rest_for_one'];
-      const permanence = ['permanent', 'transient', 'temporary'];
-      const overflow = ['block', 'drop_new', 'drop_old', 'fail', 'coalesce', 'fallback'];
-      return [
-        { words: strategies },
-        { words: permanence },
-        { words: overflow },
-      ];
-    },
+    keywords: () => [
+      { words: supervisorConstants },
+      { words: overflowKinds },
+    ],
   },
 
   reserved_unused: {
     group: 'hewReserved',
     keywords: [...kw.reserved_unused],
+  },
+
+  // Contextual identifiers — special meaning in specific parser contexts but
+  // NOT reserved keywords (usable as ordinary identifiers elsewhere).
+  contextual: {
+    group: 'hewContextual',
+    keywords: [...contextualKeywords],
   },
 
   types: {
@@ -261,6 +289,43 @@ function formatKeywordLine(prefix, words, maxWidth) {
     lines.push(current);
   }
   return lines.join('\n');
+}
+
+// -- Verify keyword coverage -----------------------------------------------
+// Guard against drift: every keyword the lexer recognises (all_keywords, kept
+// in sync with the lexer by a hew-lexer unit test) must be emitted by some
+// category. Contextual identifiers, overflow kinds, and types are
+// intentionally NOT in all_keywords, so they are excluded from this check.
+
+const coveredKeywords = new Set([
+  ...categoryMap.control_flow.keywords,
+  ...categoryMap.declarations.keywords,
+  ...categoryMap.actors.keywords,
+  ...categoryMap.supervisor.keywords,
+  ...categoryMap.wire.keywords,
+  ...categoryMap.machine.keywords,
+  ...categoryMap.other.keywords,
+  ...categoryMap.logical.keywords,
+  ...categoryMap.reserved_unused.keywords,
+  ...supervisorConstants,
+]);
+
+const missingKeywords = syntaxData.all_keywords.filter(k => !coveredKeywords.has(k));
+if (missingKeywords.length > 0) {
+  console.warn('\u26a0 Keywords in all_keywords not emitted by any category:');
+  console.warn(`   ${missingKeywords.join(', ')}`);
+}
+
+const extraKeywords = [...coveredKeywords].filter(
+  k => !syntaxData.all_keywords.includes(k));
+if (extraKeywords.length > 0) {
+  console.warn('\u26a0 Keywords emitted but not in all_keywords:');
+  console.warn(`   ${extraKeywords.join(', ')}`);
+}
+
+if (missingKeywords.length === 0 && extraKeywords.length === 0) {
+  console.log(
+    `Keyword coverage: all ${syntaxData.all_keywords.length} all_keywords emitted.`);
 }
 
 // -- Write output ----------------------------------------------------------


### PR DESCRIPTION
## Summary
Keeps the generated editor grammars aligned with the lexer's keyword set, which `docs/syntax-data.json` mirrors (enforced by a `hew-lexer` unit test).

- `tools/downstream/generate-nano.mjs`: derive the actor and supervisor keyword groups from the shared keyword data rather than hardcoded arrays, and assert that every keyword in `all_keywords` is highlighted. This removes the stale `terminate` and adds the supervisor strategy / overflow constants (`simple_one_for_one`, `pool`, `brutal_kill`).
- `editors/nano/hew.nanorc`, `editors/sublime/Hew.tmLanguage.json`: regenerated from the current data and template.
- `docs/syntax-data.json`: record `initial` as a contextual machine keyword.

## Verification
- `node tools/downstream/generate-nano.mjs` and `generate-tmgrammar.mjs` run clean; the nano coverage check reports every lexer keyword highlighted.
- Regenerated `editors/` artifacts match the generator output.

## Out of scope
The tree-sitter grammar and the VS Code TextMate template are updated in their own repositories; the ast-grep custom-language wiring is a separate change.
