### PR TITLE
Add ast-grep custom-language wiring for .hew

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,82 @@
+# ast-grep rule set for Hew
+
+Structural lint rules run by `ast-grep scan` (wired via `sgconfig.yml` `ruleDirs`).
+
+## Running
+
+```sh
+scripts/build-ast-grep-lang.sh   # once: compile the .hew grammar (for rules/hew)
+scripts/ast-grep-lint.sh          # run every rule over the repo
+ast-grep scan --rule rules/rust/fail-closed/ok-question-in-codegen.yml   # one rule
+```
+
+`scripts/ast-grep-lint.sh` exits non-zero when an `error`-severity rule matches, so it can
+gate CI. `warning`/`info`/`hint` rules report without failing.
+
+## Layout
+
+| Path | Domain | Invariant |
+|------|--------|-----------|
+| `rules/rust/fail-closed/` | codegen + checker fail-closed | CLAUDE.md §2 (Fail-Closed Codegen), §3 (Type Inference Boundary) |
+| `rules/rust/panics-nyi/` | panic / NYI hygiene | no new NYI; `unreachable!("desc")`; propagate errors |
+| `rules/rust/concurrency-drop/` | concurrency + drop safety | CLAUDE.md §1 (Drop Safety), §9 (Concurrency Safety) |
+| `rules/hew/` | Hew-language patterns (`.hew`) | idiomatic / redundant-construct lints |
+
+## Conventions
+
+- Each rule is one YAML file with `id`, `language`, `severity`, `message`, `rule`, and a `files`
+  scope. Prefer **high precision** (few/no false positives on the current tree) over coverage.
+- Rust rules exclude test code (via `ignores` globs and an enclosing `#[cfg(test)]`-mod guard).
+- Every rule is validated against the current tree: see the per-domain `_REPORT.md` for the
+  hit count and true/false-positive triage at the time it was written.
+
+## Rule catalog
+
+Counts are findings on the tree when written; `0` rules are regression guards.
+
+### Rust — fail-closed (`error`, gates CI)
+| Rule | Hits | Catches |
+|------|------|---------|
+| `ok-question-in-lowering` | 6 | `$E.ok()?` in codegen/mir/hir — silently returns `None`, swallowing the error (CLAUDE.md §2). |
+| `ty-var-constructed-post-inference` | 0 | Building `Ty::Var(..)` in post-inference crates (CLAUDE.md §3). |
+
+### Rust — panics / NYI (`warning`)
+| Rule | Hits | Catches |
+|------|------|---------|
+| `unreachable-without-message` | 8 | bare `unreachable!()` — wants `unreachable!("why")`. |
+| `no-todo-macro` | 0 | `todo!()` / `todo!("…")` (no-new-NYI). |
+| `no-unimplemented-macro` | 0 | `unimplemented!()`. |
+| `expect-empty-message` | 0 | `.expect("")` with an empty/whitespace message. |
+
+### Rust — concurrency / drop (`info` / `hint`, advisory)
+| Rule | Hits | Catches |
+|------|------|---------|
+| `lock-unwrap` | 10 | `$M.lock().unwrap()/.expect()` — unwraps a poisoned lock (CLAUDE.md §9; prefer the poison-safe accessor). |
+| `explicit-leak-review` | 3 | `mem::forget` / `Box::leak` — RAII escapes to audit for drop-safety (CLAUDE.md §1). |
+
+### Hew (`.hew`)
+| Rule | Hits | Fix | Catches |
+|------|------|-----|---------|
+| `len-zero-is-empty` | 53 | — | `x.len() == 0` → `x.is_empty()`. |
+| `match-bool-predicate` | 2 | — | `match o { Some(_) => true, None => false }` → `.is_some()`. |
+| `empty-string-is-empty` | 3 | ✅ | `s == ""` → `s.is_empty()`. |
+| `redundant-clone-literal` | 0 | ✅ | `clone <literal>` — the clone is a no-op. |
+
+## Suppressing a finding
+
+The fail-closed rules honor an annotation on the **preceding line**:
+
+```rust
+// JUSTIFIED: this None is the intended signal, not a swallowed error
+let x = maybe().ok()?;
+```
+
+ast-grep's native `// ast-grep-ignore` (or `// ast-grep-ignore: <rule-id>`) suppresses the next line for any rule.
+
+## Gating status
+
+`scripts/ast-grep-lint.sh` exits non-zero only on `error`-severity findings. The
+`ok-question-in-lowering` rule currently reports 6 — five genuine error-swallows worth fixing
+and one intentional parse helper to annotate — so adopting it in CI means triaging those first.
+The `warning`/`info`/`hint` rules report without failing the run.
+

--- a/rules/hew/_REPORT.md
+++ b/rules/hew/_REPORT.md
@@ -1,0 +1,176 @@
+# Hew-language ast-grep rules — validation report
+
+Idiom / redundant-construct lints for `.hew` source. These are the unique value
+ast-grep adds to this repo: semgrep cannot parse Hew, but the tree-sitter-hew
+grammar (compiled to `.ast-grep/hew-lang.so`, wired via `sgconfig.yml`) can.
+
+- **Run one rule:** `ast-grep scan --rule rules/hew/<file>.yml`
+- **Gate:** `scripts/ast-grep-lint.sh` runs `ast-grep scan` and exits non-zero only on
+  `error`-severity matches. Every rule here is `warning`/`hint`, so none gate CI — they are
+  advisory idiom lints.
+- **Hit counts** below are against `std/` + `examples/` at authoring time (the corpus the
+  spec named: 17 std files, 508 example files).
+
+### Authoring notes (Hew + ast-grep mechanics)
+
+- A **bare expression is invalid at Hew top level**, so expression/statement patterns must
+  be wrapped with `pattern: { context: 'fn _p() { … }', selector: <node_kind> }`. Item
+  patterns (`fn`, `impl`, …) match directly.
+- ast-grep **cannot unify one metavariable across a pattern-binder position and an
+  expression position** (they are different node kinds). This is why `match o { Some(v) =>
+  v, None => d }` (the `unwrap_or` shape) cannot be matched with the binder tied to the
+  returned value — see REJECTED R1.
+- Method-call syntax is `receiver.method(args)`; the suggested rewrites use it directly.
+
+---
+
+## SHIPPED
+
+### 1. `match-bool-predicate` — severity: **warning** — hits: **2**
+
+- **Flags:** a `match` that maps each variant of `Option`/`Result` to a boolean literal —
+  i.e. an open-coded copy of a built-in predicate:
+  | match shape | idiom |
+  |---|---|
+  | `match o { Some(_) => true,  None => false }`  | `o.is_some()` |
+  | `match o { Some(_) => false, None => true  }`  | `o.is_none()` |
+  | `match r { Ok(_)   => true,  Err(_) => false }`| `r.is_ok()` |
+  | `match r { Ok(_)   => false, Err(_) => true  }`| `r.is_err()` |
+- **Precision:** literal `true`/`false` arms and literal `_` wildcards mean the only
+  metavariable is the scrutinee → structurally exact, no cross-category metavar.
+- **Scope:** `ignores: **/option.hew, **/result.hew` — those two std files *define* these
+  predicates; linting them would tell the stdlib to call itself.
+- **No `fix:` (deliberate).** Every site that currently matches is itself a *predicate
+  definition*, where rewriting to `x.is_ok()` would be self-recursive. The rule's value is
+  as a guard against the same redundancy appearing in ordinary application code.
+- **Triage — both hits TP:**
+  | # | Location | Shape | Classification |
+  |---|----------|-------|----------------|
+  | 1 | `examples/ux/14_error_test.hew:12` | `fn is_ok`  → `Ok(_)=>true,  Err(_)=>false` | **TP.** Teaching example re-implements `Result::is_ok`; could call `r.is_ok()`. Fix withheld (recursion). |
+  | 2 | `examples/ux/14_error_test.hew:19` | `fn is_err` → `Ok(_)=>false, Err(_)=>true`  | **TP.** Same, for `is_err`. |
+- **Representative** (`examples/ux/14_error_test.hew:11`):
+  ```hew
+  fn is_ok(r: Result<i64, i64>) -> bool {
+      match r { Ok(_) => true, Err(_) => false }   // ⇒ r.is_ok()
+  }
+  ```
+- **Limitations:** matches the canonical arm order (`Some`/`Ok` first) and the `_` wildcard
+  only; a reversed-order or `Some(x) => true` (unused binder) variant would be missed. All
+  16 hits inside `std/{option,result}.hew` are correctly excluded.
+
+### 2. `redundant-clone-literal` — severity: **warning** — hits: **0** (guard, fix-carrying)
+
+- **Flags:** `clone <literal>` where the literal is the *direct* operand — `clone 5`,
+  `clone "x"`, `clone true`, `clone 3.14`, `clone 'c'`. A literal is already a fresh owned
+  value (and scalar literals are Copy), so the `clone` is pure overhead.
+- **Precision:** the nested `has` requires the literal to be the immediate operand, so
+  `clone x` (identifier), `clone foo(5)` (call) and `clone (a + b)` are **not** flagged.
+  Interpolated strings parse as `interpolated_string` (not a literal) and are skipped.
+- **`fix: '$L'` — safe.** Replacing `clone <literal>` with `<literal>` is value-identical.
+- **Current hits: 0** — no such code exists in the corpus; this is a regression guard.
+  **Mechanism proven** on a crafted fixture: fires on all five literal kinds
+  (`5`,`"hi"`,`true`,`3.14`,`'z'`) and rejects `clone x` / `clone name` / `clone foo(5)` /
+  `clone (5 + 3)` (5 hits, 0 spurious).
+- **Representative** (the shape it guards against):
+  ```hew
+  let a = clone 5;     // ⇒ let a = 5;
+  ```
+- **Limitations:** intentionally narrower than the memory note "`clone x` on a Copy/scalar
+  is redundant" — deciding whether a *variable* is Copy needs type information ast-grep
+  doesn't have. Only the always-safe **literal** form is shipped (see REJECTED R5).
+
+### 3. `len-zero-is-empty` — severity: **hint** — hits: **50**
+
+- **Flags:** `x.len() == 0`, the long-hand emptiness test; the idiom is `x.is_empty()`.
+- **Precision:** the pattern requires a `.len()` **call**, so a pre-computed length variable
+  (`slen == 0`) is correctly *not* flagged. ast-grep also skips a doc-comment occurrence
+  (`/// empty.len() == 0` in `unicode.hew`) that a text grep would falsely catch — AST
+  matching gives 50 vs grep's 51.
+- **No `fix:` (deliberate).** `is_empty` availability is type-dependent and ast-grep is
+  type-blind, so an auto-rewrite could produce non-compiling code for a custom type that
+  has `len` but not `is_empty`.
+- **Triage — 50/50 TP, 0 FP.** Every receiver is a `string` or `Vec` (or `bytes`/`Deque`/
+  regex match type), all of which provide `is_empty`. Notably `std/vec.hew` itself uses
+  `v.len() == 0` **9 times**, and the `examples/datastruct/*` "stack/heap/queue" receivers
+  are all `Vec<i64>` under the hood (e.g. `stack.hew`'s `s: Vec<i64>`). Distribution: std 26
+  (vec ×9, csv ×6, regex ×3, scanner ×2, template ×2, dns/fs/cron/datetime ×1), examples 24
+  (datastruct ×19, text_stats ×2, curl/string_rotation/selfhost ×1).
+- **Representative** (`std/vec.hew:137`):
+  ```hew
+  if v.len() == 0 { return None; }     // ⇒ if v.is_empty() { … }
+  ```
+- **Limitations:** only the `== 0` orientation (→ `is_empty()`); the non-empty forms
+  `.len() > 0` / `.len() != 0` (→ `!x.is_empty()`) are left out to keep the message
+  unambiguous and would roughly double the hit count if added.
+
+### 4. `empty-string-is-empty` — severity: **hint** — hits: **3** (fix-carrying)
+
+- **Flags:** `s == ""`; the idiom is `s.is_empty()`. Comparing to the `""` literal
+  guarantees the operand is a `string`, and `string` always provides `is_empty`, so the
+  rewrite is type-safe.
+- **`fix: '$X.is_empty()'` — safe.** The receiver is constrained to a plain identifier or
+  field access (covers every corpus hit); postfix `.is_empty()` binds tighter than `==`, so
+  no parentheses are needed. A complex left operand (`a + b == ""`) is intentionally not
+  matched, keeping the fix unambiguous.
+- **Triage — 3/3 TP:**
+  | # | Location | Before → after |
+  |---|----------|----------------|
+  | 1 | `std/net/dns/dns.hew:82`  | `if ip == ""` → `if ip.is_empty()` |
+  | 2 | `std/path.hew:91`         | `if a == ""` → `if a.is_empty()` |
+  | 3 | `std/process.hew:125`     | `if message == ""` → `if message.is_empty()` |
+- **Limitations:** only the `$X == ""` orientation (`"" == $X` does not occur in the
+  corpus); only identifier/field receivers (so the fix never needs parens).
+
+---
+
+## REJECTED (recorded so the decision is auditable)
+
+### R1. `match → unwrap_or` (spec candidate #1, second bullet) — **rejected: not precisely matchable**
+- Target shape `match o { Some(v) => v, None => d }` ⇒ `o.unwrap_or(d)` requires tying the
+  returned value to the **binder** `v`. ast-grep cannot unify a metavariable across the
+  pattern-binder (`Some($V)`) and the expression (`=> $V`) positions — they are different
+  node kinds — so the reused-metavar form matches **nothing**.
+- The only expressible form drops that tie (`Some($V) => $X, None => $D`), which matches
+  **every** two-arm `Some/None`+`Ok/Err` match in the tree: **208 hits**, the overwhelming
+  majority not `unwrap_or` at all (`Some(v) => v + 1`, `Some(v) => other`, arbitrary `None`
+  bodies, etc.). No structural sub-pattern isolates the identity-return case. Per "a noisy
+  rule is worse than no rule," dropped.
+
+### R2. `x == true` / `x == false` redundant boolean comparison — **rejected: fixture-only + un-fixable as one rule**
+- `== true`/`== false` is genuine redundancy (`x` / `!x`), but the **only** corpus hits are
+  **6, all in one file** — `examples/v05/checked-mir/option_result_predicates.hew`, a MIR
+  fixture that *deliberately* writes `if a.is_some() == false { … }` to pin the `== false`
+  lowering. Firing there is noise against intentional test code (the fail-closed rules
+  likewise `ignore` test code). The two directions also need different fixes
+  (`==true`→`x`, `==false`→`!x`), which a single rule can't express. No application-code
+  hits → dropped. Easy to revisit if real hits appear (exclude the fixture, split fixes).
+
+### R3. `if c { true } else { false }` ⇒ `c` — **rejected: 0 hits, no demonstrated need**
+- **0 occurrences** in `std/` + `examples/`. A pure-style rule with no demonstrated case;
+  not worth the maintenance/false-positive surface. (Would also need care: an `if/else`
+  with side-effecting arms is not equivalent.)
+
+### R4. Double negation `!!x` ⇒ `x` — **rejected: 0 hits**
+- **0 occurrences** in the corpus. No signal.
+
+### R5. `clone <Copy variable>` (broad form of the memory note) — **rejected: needs types**
+- `clone x` is redundant only when `x`'s type is Copy/scalar. ast-grep has no type
+  information, so it cannot tell `clone x` (i64, redundant) from `clone x` (String, a real
+  deep copy). Shipping the broad form would be FP-prone; the always-safe **literal** subset
+  is shipped as rule #2 instead.
+
+---
+
+## Summary
+
+| Rule | Severity | Hits | Fix | Verdict |
+|------|----------|------|-----|---------|
+| `match-bool-predicate`    | warning | 2  | — (recursion) | ship — 2 TP (predicate re-impls); guard for app code |
+| `redundant-clone-literal` | warning | 0  | **safe** | ship — regression guard, mechanism proven |
+| `len-zero-is-empty`       | hint    | 50 | — (type-dep) | ship — 50/50 TP, 0 FP |
+| `empty-string-is-empty`   | hint    | 3  | **safe** | ship — 3/3 TP |
+| match → `unwrap_or`       | —       | 208 (loose) | — | reject — cross-category metavar; can't isolate |
+| `== true` / `== false`    | —       | 6   | — | reject — fixture-only, two-direction fix |
+| `if{true}else{false}`     | —       | 0   | — | reject — no hits |
+| double negation `!!`      | —       | 0   | — | reject — no hits |
+| `clone <Copy var>`        | —       | n/a | — | reject — needs type info |

--- a/rules/hew/empty-string-is-empty.yml
+++ b/rules/hew/empty-string-is-empty.yml
@@ -1,0 +1,24 @@
+# `s == ""` is the long-hand empty-string test; `s.is_empty()` is the idiom.
+# Comparing to the `""` literal guarantees the operand is a `string`, and
+# `string` always provides `is_empty`, so the rewrite is type-safe.
+#
+# The receiver is constrained to a plain identifier or field access. That
+# covers every occurrence in the corpus and keeps the auto-fix unambiguous:
+# postfix `.is_empty()` binds tighter than `==`, so no parentheses are needed.
+# A complex left operand (`a + b == ""`) is intentionally not matched.
+# Only the `$X == ""` orientation is handled (`"" == $X` is not in the corpus).
+id: empty-string-is-empty
+language: hew
+severity: hint
+message: Prefer `.is_empty()` over `== ""`.
+rule:
+  pattern:
+    context: 'fn _p() { let _x = $X == ""; }'
+    selector: binary_expression
+constraints:
+  X:
+    has:
+      any:
+        - kind: identifier
+        - kind: field_expression
+fix: '$X.is_empty()'

--- a/rules/hew/len-zero-is-empty.yml
+++ b/rules/hew/len-zero-is-empty.yml
@@ -1,0 +1,20 @@
+# `x.len() == 0` is the long-hand emptiness test. The idiom is `x.is_empty()`,
+# which std provides for string, bytes, Vec, Deque and the regex match types
+# (and every collection used in the corpus is one of those).
+#
+# The pattern requires a `.len()` *call*, so a pre-computed length variable
+# (`slen == 0`) is not flagged. Only the `== 0` orientation is matched; the
+# `> 0` / `!= 0` "non-empty" forms map to `!x.is_empty()` and are left out to
+# keep the message unambiguous.
+#
+# No `fix:` — `.is_empty()` availability is type-dependent and ast-grep cannot
+# see types, so an automatic rewrite could produce code that does not compile.
+id: len-zero-is-empty
+language: hew
+severity: hint
+message: Prefer `.is_empty()` over `.len() == 0`.
+note: Applies when the receiver's type provides `is_empty` (string, Vec, bytes, Deque, ...).
+rule:
+  pattern:
+    context: 'fn _p() { let _x = $X.len() == 0; }'
+    selector: binary_expression

--- a/rules/hew/match-bool-predicate.yml
+++ b/rules/hew/match-bool-predicate.yml
@@ -1,0 +1,42 @@
+# Redundant `match` that maps each variant of Option/Result to a boolean
+# literal. This is exactly the body of the built-in predicates, so the match
+# can be replaced by a method call:
+#
+#   match o { Some(_) => true,  None    => false } -> o.is_some()
+#   match o { Some(_) => false, None    => true  } -> o.is_none()
+#   match r { Ok(_)   => true,  Err(_)  => false } -> r.is_ok()
+#   match r { Ok(_)   => false, Err(_)  => true  } -> r.is_err()
+#
+# No `fix:` is offered on purpose: every place that currently matches this
+# shape *is itself* a predicate definition (the std impls, or a teaching
+# example that re-implements `is_ok`), where rewriting to `x.is_ok()` would be
+# self-recursive. The value of the rule is as a guard against the same
+# redundancy appearing in application code.
+id: match-bool-predicate
+language: hew
+severity: warning
+message: >-
+  Redundant match: mapping each Option/Result variant to a boolean literal
+  duplicates a built-in predicate. Use .is_some()/.is_none() (Option) or
+  .is_ok()/.is_err() (Result) instead.
+note: >-
+  Detected the four canonical shapes (Some/None and Ok/Err arms in the usual
+  order). The std definitions in option.hew/result.hew are intentionally
+  excluded.
+ignores:
+  - "**/option.hew"
+  - "**/result.hew"
+rule:
+  any:
+    - pattern:
+        context: 'fn _p() { match $O { Some(_) => true, None => false } }'
+        selector: match_expression
+    - pattern:
+        context: 'fn _p() { match $O { Some(_) => false, None => true } }'
+        selector: match_expression
+    - pattern:
+        context: 'fn _p() { match $R { Ok(_) => true, Err(_) => false } }'
+        selector: match_expression
+    - pattern:
+        context: 'fn _p() { match $R { Ok(_) => false, Err(_) => true } }'
+        selector: match_expression

--- a/rules/hew/redundant-clone-literal.yml
+++ b/rules/hew/redundant-clone-literal.yml
@@ -1,0 +1,29 @@
+# `clone` of a literal is always redundant: a literal is already a fresh,
+# owned value, and scalar literals are Copy. `clone 5` / `clone "x"` /
+# `clone true` / `clone 3.14` / `clone 'c'` can drop the `clone`.
+#
+# The match is deliberately narrow — the literal must be the *direct* operand
+# of `clone`, so `clone x` (identifier), `clone foo(5)` (call) and
+# `clone (a + b)` are left untouched. Interpolated f-strings parse as
+# `interpolated_string`, not a literal, and are also skipped.
+#
+# Fix is safe: replacing `clone <literal>` with `<literal>` is value-identical.
+id: redundant-clone-literal
+language: hew
+severity: warning
+message: Redundant `clone` of a literal; the literal is already an owned value.
+note: Scalar literals are Copy and string/char literals are already fresh owned values.
+rule:
+  pattern:
+    context: 'fn _p() { let _x = clone $L; }'
+    selector: clone_expression
+constraints:
+  L:
+    has:
+      any:
+        - kind: integer_literal
+        - kind: float_literal
+        - kind: boolean_literal
+        - kind: string_literal
+        - kind: char_literal
+fix: '$L'

--- a/rules/rust/concurrency-drop/_REPORT.md
+++ b/rules/rust/concurrency-drop/_REPORT.md
@@ -1,0 +1,111 @@
+# Concurrency & Drop-Safety ast-grep rules — validation report
+
+Domain: `rules/rust/concurrency-drop/` — CLAUDE.md §1 (Drop Safety) and §9 (Concurrency Safety).
+Scope: `hew-runtime/**`, `hew-codegen-rs/**` (tests excluded). Validated against the tree at
+authoring time with `ast-grep 0.44.0`.
+
+Precision-first: this domain is FP-prone, so the bar was "few, sharp rules; downgrade or reject
+anything that can't be made precise." Result: **2 shipped (advisory), 3 rejected.**
+
+---
+
+## Shipped rules
+
+### 1. `lock-unwrap.yml` — severity `info`
+
+- **Invariant:** CLAUDE.md §9 — poisoned-lock panics can mask the shutdown race that poisoned the
+  lock. The codebase's dominant idiom is poison recovery via `PoisonSafe::access` /
+  `.unwrap_or_else(PoisonError::into_inner)` (≈386 uses) rather than raw `.lock().unwrap()`.
+- **Pattern:** `$M.lock().unwrap()` / `$M.lock().expect($_)`.
+- **Precision work:** the naive pattern matched **96** sites, but **88 were inside in-file
+  `#[cfg(test)] mod` modules** (test code, where unwrapping is fine). Test modules are excluded by
+  matching the enclosing `mod_item` name (`tests` / `*_tests` / `test_support`) — robust against the
+  many `cfg(...)` spellings used here (`cfg(all(test, ...))`, `cfg(not(test))`, etc.), where an
+  attribute-regex would mis-handle `#[cfg(not(test))]` production code. Final: **10 production hits**.
+
+| file:line | receiver | triage |
+|---|---|---|
+| `bridge.rs:63` | `OUTBOUND` (global `Mutex`) | **TP, strongest** — global shared state (§9), poison panics in a bridge accessor. |
+| `bridge.rs:196` | `META_STATE` (global `Mutex`) | **TP, strongest** — same. |
+| `alloc_tracker.rs:48,58,66` | `LIBC_ALLOC_SET` (global) | **TP** — global lock; `#[cfg(debug_assertions)]` only, so lower runtime risk. |
+| `auto_mutex.rs:147,156,191` | `m.inner` / `m.guard_slot` | **TP-by-pattern, intentional** — the low-level `hew_auto_mutex` primitive; treats poison as a fail-closed trap with a documented rationale (`auto_mutex.rs:143-146`) and descriptive `.expect()` messages. Good `// JUSTIFIED:` candidate. |
+| `xnode_serial.rs:924,925` | `THUNK_REGISTRY` / `REPLY_REGISTRY` (globals) | **TP, low-priority** — global registries, but inside the `pub(crate) fn clear_codec_registries_for_test()` test-support helper (compiled in all builds, so not test-mod-excluded). |
+
+- **Precision:** 10/10 hits are genuine raw poisoned-lock unwraps in production concurrency code
+  (0 false positives on the pattern; 0 test-module noise). Actionability ranges from "should fix"
+  (the two `bridge.rs` globals) to "intentional, annotate `// JUSTIFIED:`" (`auto_mutex` primitive).
+- **Severity rationale:** `info` (advisory, non-gating). The set skews toward intentional/low-urgency
+  sites, so `warning` would overstate; `info` flags them for §9 review and points at the poison-safe
+  idiom. Raise to `warning` if the team wants more visibility on the `bridge.rs` globals.
+- **Limitations:** does not honor a trailing/leading `// JUSTIFIED:` comment (tree-sitter treats
+  comments as "extras", so `follows`/`precedes` on comments is not reliable in ast-grep). Annotated
+  sites are still flagged — call them out in review rather than suppressing.
+
+### 2. `explicit-leak-review.yml` — severity `hint`
+
+- **Invariant:** CLAUDE.md §1 — every heap/resource escape needs a cleanup path for sync return,
+  async cancel, and actor shutdown. `mem::forget` / `Box::leak` are explicit escapes from RAII and are
+  exactly the sites a drop-safety audit must re-examine.
+- **Pattern:** `{std,core,}::mem::forget($X)`, `Box::leak($X)` / `Vec::leak($X)` / `String::leak($X)`.
+- **Hits: 3** (all production; tests excluded via the same `mod_item`-name filter).
+
+| file:line | code | triage |
+|---|---|---|
+| `quic_mesh.rs:1412` | `std::mem::forget(arc)` | Intentional leak when `Arc::try_unwrap` fails (avoid tearing down a runtime we don't fully own). **Not** `// JUSTIFIED:`-annotated — worth a glance / annotation. |
+| `quic_transport.rs:756` | `std::mem::forget(arc)` | Same pattern; **already `// JUSTIFIED:`-annotated** (`quic_transport.rs:752-755`). Re-flagged (see limitation). |
+| `actor_registry.rs:94` | `Box::leak(type_name.into_boxed_str())` | Deliberate string-interning leak with a documented paired reclaim (`clear_dispatch_registry` via `Box::from_raw`). |
+
+- **Why ship at all:** all three are currently intentional, but they are the complete inventory of
+  explicit RAII escapes in the runtime — precisely what §1 review should re-verify when teardown logic
+  changes. Three `hint`s is not noise; it is a small, durable audit list. Shipped at `hint` (lowest
+  severity) to signal "review", not "bug".
+- **Limitations:** advisory only — ast-grep is single-file/syntactic and cannot prove the cleanup
+  path, nor honor `// JUSTIFIED:` (see above). `$TY::leak` is restricted to the std `Box`/`Vec`/`String`
+  set to avoid matching user-defined `leak` methods; a future `Rc::leak` etc. would be missed.
+
+---
+
+## Rejected candidates
+
+### R1. `CURRENT_NODE` / `LIVE_ACTORS` global-access rule — **REJECTED (hotspot no longer a raw global)**
+
+The §9-named hotspots have been **deglobalized**, so a rule keyed on them has no valid target:
+
+- `CURRENT_NODE`: **no `static` definition and no code access** anywhere in the crate — all ~60
+  occurrences are stale comments. It is now a `RuntimeInner` field reached via `rt_current()`
+  (`hew_node.rs:139`, `runtime.rs:84`). A literal-identifier rule would match only comments (ast-grep
+  ignores those) → **0 actionable hits**.
+- `LIVE_ACTORS`: now the **module-private** `static LIVE_ACTORS_WASM: PoisonSafe<…>`
+  (`lifetime/live_actors.rs:104`), reached only through same-file accessors (`with_live_actors` /
+  `.access`). Rust **module privacy already enforces** "no raw access outside the owner module," so the
+  proposed `files`/`ignores` cross-module rule is redundant with the compiler → **0 hits possible**.
+
+Honest conclusion: the precise version of this rule is "enforce something the language already
+enforces," so it adds nothing. (The CLAUDE.md §9 text naming these globals is now historical.)
+
+### R2. `Box::into_raw` without nearby `from_raw` — **REJECTED (too numerous, unpairable single-file)**
+
+`Box::into_raw($X)` = **96 production hits** (and 365 `from_raw`). It is the standard FFI
+ownership-transfer idiom throughout this runtime; the matching `from_raw` is routinely in a different
+function/file (e.g. a `Drop` impl or C-ABI free). ast-grep is single-file and cannot prove pairing, so
+the rule would be ~96 lines of pure noise. A noisy rule is worse than none.
+
+### R3. `ManuallyDrop::new` without paired drop/`into_inner` — **REJECTED (structural, correct-by-design)**
+
+`ManuallyDrop::new` = 6–8 production sites, all structural manual-drop-control:
+`inner: ManuallyDrop::new(actor)` struct fields (`lambda_actor.rs`, `duplex.rs`) and the
+`let me = ManuallyDrop::new(self)` consume-self pattern (`duplex.rs:459,490`). The paired
+`ManuallyDrop::drop`/`into_inner` lives in the type's `Drop` impl or a consuming method — invisible to
+single-file ast-grep. These are the normal, correct way to build manual-drop types here, so a rule
+would re-flag deliberate patterns → noise.
+
+---
+
+## Methodology
+
+For each candidate: wrote the `.yml`; ran `ast-grep scan --rule …`; inspected **every** hit;
+classified production vs in-file-test and TP vs FP; tuned for precision (the decisive move was
+excluding in-file `#[cfg(test)] mod`s by enclosing-`mod_item` name, which cut `lock-unwrap` from 96 →
+10); kept only precise/meaningful rules and downgraded both survivors to advisory severities
+(`info`/`hint`); rejected the rest with the counts above. Both shipped rules parse cleanly and scan
+without error.

--- a/rules/rust/concurrency-drop/explicit-leak-review.yml
+++ b/rules/rust/concurrency-drop/explicit-leak-review.yml
@@ -1,0 +1,31 @@
+id: explicit-leak-review
+language: rust
+severity: hint
+message: >-
+  Explicit escape from RAII (`mem::forget` / `Box::leak`) bypasses the normal
+  drop path. Re-verify the cleanup story for all three contexts (CLAUDE.md §1
+  Drop Safety): sync return, async cancel (future dropped mid-await), and actor
+  shutdown (mailbox drained). If the leak is deliberate, annotate it
+  `// JUSTIFIED: <reason>` or pair it with an explicit reclaim.
+files:
+  - 'hew-runtime/**'
+  - 'hew-codegen-rs/**'
+ignores:
+  - '**/tests/**'
+  - '**/*test*.rs'
+  - '**/*_tests.rs'
+rule:
+  any:
+    - pattern: std::mem::forget($X)
+    - pattern: core::mem::forget($X)
+    - pattern: mem::forget($X)
+    - pattern: Box::leak($X)
+    - pattern: Vec::leak($X)
+    - pattern: String::leak($X)
+  not:
+    inside:
+      kind: mod_item
+      stopBy: end
+      has:
+        field: name
+        regex: '^(tests|.*_tests|test_support)$'

--- a/rules/rust/concurrency-drop/lock-unwrap.yml
+++ b/rules/rust/concurrency-drop/lock-unwrap.yml
@@ -1,0 +1,26 @@
+id: lock-unwrap
+language: rust
+severity: info
+message: >-
+  Raw `.lock().unwrap()` panics if the mutex is poisoned, which can mask the
+  shutdown race that poisoned it (CLAUDE.md §9 Concurrency Safety). Prefer the
+  codebase poison-safe idioms: `PoisonSafe::access` or
+  `.unwrap_or_else(PoisonError::into_inner)`.
+files:
+  - 'hew-runtime/**'
+  - 'hew-codegen-rs/**'
+ignores:
+  - '**/tests/**'
+  - '**/*test*.rs'
+  - '**/*_tests.rs'
+rule:
+  any:
+    - pattern: $M.lock().unwrap()
+    - pattern: $M.lock().expect($_)
+  not:
+    inside:
+      kind: mod_item
+      stopBy: end
+      has:
+        field: name
+        regex: '^(tests|.*_tests|test_support)$'

--- a/rules/rust/fail-closed/_REPORT.md
+++ b/rules/rust/fail-closed/_REPORT.md
@@ -1,0 +1,146 @@
+# Fail-Closed ast-grep rules — validation report
+
+Rules enforcing Hew's fail-closed invariants in the Rust compiler pipeline
+(`hew-types` → `hew-hir` → `hew-mir` → `hew-codegen-rs`).
+
+- **Invariant source:** CLAUDE.md §2 (Fail-Closed Codegen), §3 (Type Inference Boundary).
+- **Run one rule:** `ast-grep scan --rule rules/rust/fail-closed/<file>.yml`
+- **Gate:** `scripts/ast-grep-lint.sh` runs `ast-grep scan` and exits non-zero on any
+  `error`-severity match.
+- **Suppression convention (§2):** an intentional hit is annotated in source with a
+  `// JUSTIFIED: <reason>` line comment directly above it. Both rules below honour this
+  via a `not.any.[follows | inside>follows]` clause, so the comment suppresses the hit
+  whether the flagged node is a statement, a tail expression, or nested inside a call.
+
+All hit counts below are against the tree at authoring time. Test code is excluded by the
+`ignores` globs (`**/tests/**`, `**/test/**`, `**/*_test.rs`, `**/*_tests.rs`, `**/tests.rs`).
+
+---
+
+## SHIPPED
+
+### 1. `ok-question-in-lowering` — severity: **error**
+
+- **Invariant:** CLAUDE.md §2 — *"the pattern `something.ok()?` in codegen is almost
+  always wrong — propagate the error."* `Result::ok()?` throws away the `Err` value and
+  silently turns it into an early `None`.
+- **Scope:** `hew-codegen-rs/**`, `hew-mir/**`, `hew-hir/**` (tests excluded).
+- **Pattern:** `$E.ok()?`
+- **Current hits: 6** (all true matches — every hit is a real `.ok()?` in an
+  `Option`-returning lowering/codegen function; zero spurious/structural matches. Doc
+  comments mentioning `.ok()?` are correctly *not* matched because matching is AST-based.)
+
+| # | Location | Enclosing fn (`-> Option<..>`) | Discarded `Result` | Classification |
+|---|----------|------------------------------|--------------------|----------------|
+| 1 | `hew-mir/src/lower.rs:21296` | `lower_spawn_actor` | `lower_spawn_actor_state(..)` | **TP — clearest.** Sibling line uses `lower_spawn_actor_init_args(..)?` (propagates); state lowering swallows its error. |
+| 2 | `hew-mir/src/lower.rs:6336` | `owned_aggregate_record_field_kinds_for_key` | `classify_actor_state_fields_with_opaque_handles(..)` | **TP (borderline).** Adjacent comment claims fail-closed happens at the value-class gate; the `.ok()?` still hides *why* classification failed. Fix or `// JUSTIFIED:`. |
+| 3 | `hew-codegen-rs/src/llvm.rs:29571` | `resolve_di_type` | `di_builder.create_basic_type(..)` | **TP.** DWARF DI builder error discarded → debug info silently degrades. |
+| 4 | `hew-codegen-rs/src/llvm.rs:29821` | `resolve_enum_di_type` | `di_builder.create_basic_type("u32", ..)` | **TP.** Same as #3. |
+| 5 | `hew-codegen-rs/src/llvm.rs:29693` | `resolve_di_type` | `u32::try_from(i)` | **TP (should be `unreachable!`).** Index→u32 conversion error discarded; the §2 "propagate or `unreachable!`" case. |
+| 6 | `hew-codegen-rs/src/llvm.rs:31648` | `actor_name_from_handler_symbol` | `parse::<usize>()` | **Intentional → needs `// JUSTIFIED:`.** Pure symbol-demangler; `None` is the deliberate "this symbol doesn't match" signal, not a swallowed error. The only non-bug in the set. |
+
+- **Representative example** (`hew-mir/src/lower.rs:21296`):
+  ```rust
+  let init_args = self.lower_spawn_actor_init_args(.., expr)?;     // propagates
+  let state = self
+      .lower_spawn_actor_state(actor_name, &layout, ..)
+      .ok()?;                                                       // swallows the error
+  ```
+- **Adoption note (important):** at `error` severity this rule makes `ast-grep-lint.sh`
+  exit non-zero on the 6 existing hits. Adopting it means triaging them first: propagate
+  the error (or `unreachable!("…")`) for #1–#5, and add `// JUSTIFIED: <reason>` above #6
+  (the demangler). That triage *is* the rule's purpose (§2: "fix it or add `// JUSTIFIED:`").
+- **Known limitations:** matches the canonical `.ok()?` form only. It does **not** flag
+  other silent-error idioms (`let _ = result;`, `.ok();`, `if let Ok(_) = ..`) — those
+  were evaluated and rejected (see below). One in-scope `hew-types` analogue exists
+  (`hew-types/src/check/admissibility.rs:47`) but `hew-types` is deliberately out of this
+  rule's scope per the candidate spec.
+
+### 2. `ty-var-constructed-post-inference` — severity: **error** (tripwire)
+
+- **Invariant:** CLAUDE.md §3 — *"After type checking completes, no `Ty::Var` should
+  survive unresolved into codegen."* Inference variables are built and unified in
+  `hew-types` only; fabricating a `Ty::Var(..)` in a post-inference crate is a direct leak.
+- **Scope:** `hew-codegen-rs/**`, `hew-mir/**`, `hew-hir/**` (tests excluded). Dependency
+  direction confirms these are post-inference: `hew-mir → hew-hir → hew-types`.
+- **Pattern:** `$TY::Var($$$ARGS)` with `kind: call_expression` and `constraints: TY ~ '(^|::)Ty$'`.
+  - `kind: call_expression` matches **constructions** only, never the match-arm
+    *detector* `Ty::Var(v) => …` (a pattern), e.g. `hew-mir/src/lower.rs:418` — which is
+    the boundary working correctly and must not be flagged.
+  - The `$TY` metavariable + regex catches bare **and** fully-qualified forms
+    (`Ty::Var`, `crate::ty::Ty::Var`, `hew_types::ty::Ty::Var`) while rejecting unrelated
+    `MyEnum::Var` / `Pattern::Variant`.
+- **Current hits: 0.** This is intentional — the boundary currently holds. It is a
+  **regression tripwire**: the moment anyone constructs a `Ty::Var(..)` in hir/mir/codegen
+  it fails the gate. 0 hits ⇒ 0 false positives on the current tree.
+- **Validation (mechanism proven on fixtures, since there is no live positive):**
+  flags bare construction `Ty::Var(TypeVar::fresh())` and qualified
+  `crate::ty::Ty::Var(..)`; does **not** flag the match-arm detector `Ty::Var(v) => …`,
+  the unrelated `MyEnum::Var(..)`, or any construction preceded by `// JUSTIFIED:`
+  (tail / statement / nested positions all covered).
+- **Representative example** (the shape it guards against, not present in the tree):
+  ```rust
+  // hew-mir or hew-codegen-rs — would fail the gate:
+  fn ty_of(..) -> Ty { Ty::Var(TypeVar::fresh()) }   // leaks an inference var past the checker
+  ```
+- **Known limitations:** detects *construction* of a fresh `Ty::Var`, not a `Ty::Var`
+  that flows in through a variable/field already built upstream — that class is caught by
+  the runtime post-inference validation pass in `check_program`, not statically. Scoped to
+  the bare/qualified `Ty::Var(..)` call form; a `Ty::Var` built via an indirection helper
+  (none exist today) would not match.
+
+---
+
+## REJECTED (recorded so the decision is auditable)
+
+### R1. `.unwrap_or_default()` in codegen/mir (candidate #2) — **rejected: all false positives**
+- 22 code hits across `hew-codegen-rs` + `hew-mir`. Every one is legitimate:
+  - **13** in `hew-mir/src/dump.rs` — debug/`Display` dump formatting (not an output path).
+  - `hew-mir/src/dataflow.rs:857` — absent dataflow entry state defaults to the empty
+    (bottom) lattice value; standard and correct.
+  - `hew-mir/src/lower.rs` (1423, 1494, 1499, 3841, 3891, 4741, 4747) and
+    `hew-codegen-rs/src/llvm.rs:38918` — `Option<collection>`/`Option<map>` → empty
+    default (no init params ⇒ empty vec, absent map key ⇒ empty deps, `None` suspend
+    kind ⇒ empty map). No bug is masked.
+- There is no structural sub-pattern that isolates a genuine "default papered over a
+  failed computation" case, because **there are zero such cases in the tree**. A blanket
+  rule would be 22/22 FP — pure noise. Per "a noisy rule is worse than no rule," dropped.
+
+### R2. Silent error/`None` discard (candidate #3) — **rejected: imprecise / no signal**
+- `.ok();` (discard-as-statement): **0 hits** in the pipeline — nothing to catch.
+- `let _ = <expr>;`: **188 hits**, overwhelmingly legitimate intentional discards. ast-grep
+  has no type information, so it cannot tell which RHS is a `Result`/`#[must_use]` (the
+  only interesting case, already covered by rustc's `unused_must_use`). No precise variant
+  exists; dropped.
+
+### R3. `Ty::Error` in expected-type / pre-seed position (candidate #4b) — **rejected: all FP today**
+- `$E.unwrap_or(Ty::Error)` / `vec![Ty::Error; n]`: 4 hits, all in
+  `hew-types/src/check/patterns.rs` (1022, 1029, 1464, 1471). All are **error-recovery**
+  fallbacks: when `lookup_variant_types` has *already failed*, payload field types are
+  filled with the `Ty::Error` poison value to prevent cascading diagnostics — the
+  documented-correct use, the opposite of "pre-seeding an expected type." Whether a given
+  site is a forbidden "pre-seed/expected-type" position vs. legitimate recovery is
+  semantic and not structurally distinguishable; current instances are 4/4 legitimate.
+  Dropped (would be all-FP).
+
+### R4. `Ty::Var` construction inside `hew-types` (candidate #4a, broad form) — **rejected: FP-prone**
+- `$E.unwrap_or(Ty::Var(TypeVar::fresh()))`: 13 hits, all in `hew-types/src/check/`
+  (`expressions.rs`, `methods.rs`, `calls.rs`, `admissibility.rs`) — seeding *fresh*
+  inference variables *during* checking, which is exactly what the checker/unifier must
+  do. §3 forbids a `Ty::Var` *surviving into codegen*, not being *built during inference*.
+  Scoping a construction ban inside `hew-types` (309 legitimate `Ty::Var` uses) is
+  hopelessly FP-prone. The precise, shippable form of §3 is the post-inference tripwire
+  shipped as rule #2 above.
+
+---
+
+## Summary
+
+| Rule | Severity | Hits | Verdict |
+|------|----------|------|---------|
+| `ok-question-in-lowering` | error | 6 | ship — 5 real fail-closed concerns + 1 needs `// JUSTIFIED:` |
+| `ty-var-constructed-post-inference` | error | 0 | ship — §3 regression tripwire, 0 FP |
+| unwrap_or_default (codegen/mir) | — | 22 | reject — all legitimate |
+| silent discard (`let _ =` / `.ok();`) | — | 188 / 0 | reject — no type info / no hits |
+| `unwrap_or(Ty::Error)` pre-seed | — | 4 | reject — all error-recovery |
+| `Ty::Var` build inside `hew-types` | — | 13 | reject — legitimate inference seeding |

--- a/rules/rust/fail-closed/ok-question-in-lowering.yml
+++ b/rules/rust/fail-closed/ok-question-in-lowering.yml
@@ -1,0 +1,29 @@
+id: ok-question-in-lowering
+language: rust
+severity: error
+message: "`.ok()?` discards the underlying error and silently returns `None` — propagate the error or use `unreachable!(\"...\")` (CLAUDE.md §2 Fail-Closed Codegen)."
+note: "CLAUDE.md §2: \"the pattern `something.ok()?` in codegen is almost always wrong — propagate the error.\" If this `None` is genuinely the intended signal (e.g. a pure string/predicate helper), annotate the source line with `// JUSTIFIED: <reason>` to suppress."
+files:
+  - 'hew-codegen-rs/**'
+  - 'hew-mir/**'
+  - 'hew-hir/**'
+ignores:
+  - '**/tests/**'
+  - '**/test/**'
+  - '**/*_test.rs'
+  - '**/*_tests.rs'
+  - '**/tests.rs'
+rule:
+  pattern: $E.ok()?
+  not:
+    any:
+      - follows:
+          kind: line_comment
+          regex: 'JUSTIFIED'
+          stopBy: neighbor
+      - inside:
+          follows:
+            kind: line_comment
+            regex: 'JUSTIFIED'
+            stopBy: neighbor
+          stopBy: end

--- a/rules/rust/fail-closed/ty-var-constructed-post-inference.yml
+++ b/rules/rust/fail-closed/ty-var-constructed-post-inference.yml
@@ -1,0 +1,33 @@
+id: ty-var-constructed-post-inference
+language: rust
+severity: error
+message: "Constructing `Ty::Var(..)` in a post-inference crate leaks an inference variable past the type checker — codegen must never see an unresolved `Ty::Var` (CLAUDE.md §3 Type Inference Boundary)."
+note: "Inference variables are built and unified in `hew-types` only. After checking, an unresolved `Ty::Var` must be turned into a diagnostic by the post-inference validation pass in `check_program`, never fabricated or forwarded here. If a fresh var is genuinely required (e.g. a checker round-trip), annotate the line with `// JUSTIFIED: <reason>`."
+files:
+  - 'hew-codegen-rs/**'
+  - 'hew-mir/**'
+  - 'hew-hir/**'
+ignores:
+  - '**/tests/**'
+  - '**/test/**'
+  - '**/*_test.rs'
+  - '**/*_tests.rs'
+  - '**/tests.rs'
+rule:
+  pattern: $TY::Var($$$ARGS)
+  kind: call_expression
+  not:
+    any:
+      - follows:
+          kind: line_comment
+          regex: 'JUSTIFIED'
+          stopBy: neighbor
+      - inside:
+          follows:
+            kind: line_comment
+            regex: 'JUSTIFIED'
+            stopBy: neighbor
+          stopBy: end
+constraints:
+  TY:
+    regex: '(^|::)Ty$'

--- a/rules/rust/panics-nyi/_REPORT.md
+++ b/rules/rust/panics-nyi/_REPORT.md
@@ -1,0 +1,136 @@
+# panics-nyi — ast-grep rule report
+
+Domain: panic / not-yet-implemented (NYI) hygiene in the Hew Rust compiler.
+Invariant sources: CLAUDE.md §2 (Fail-Closed Codegen — prefer `unreachable!("desc")`,
+never silently swallow), and the repo's "no new NYI" gate.
+
+All rules are `language: rust`, exclude test code via
+`ignores: ['**/tests/**','**/*test*.rs','**/benches/**']`, and additionally exclude
+inline `#[cfg(test)]` / `#[cfg(all(test, …))]` modules that the globs miss, via a
+relational `not: inside mod_item follows attribute_item(/cfg\(.*\btest\b/)` guard.
+
+Validated with ast-grep 0.44.0:
+`ast-grep scan --rule rules/rust/panics-nyi/<file>.yml --json=compact`.
+
+---
+
+## SHIPPED
+
+### 1. `unreachable-without-message` — severity: warning
+**Rationale.** CLAUDE.md §2 prefers `unreachable!("description")` so a violated
+invariant is self-documenting in the panic message / backtrace. This rule flags the
+bare no-argument form only; the documented `unreachable!("…")` form is intentionally
+**not** matched (verified: `pattern: unreachable!()` matches an empty `token_tree`,
+not one containing a string).
+
+**Current hits: 8 — all true positives, 0 false positives.**
+
+| # | Location | Context |
+|---|----------|---------|
+| 1 | `hew-parser/src/parser.rs:6479` | `_ => unreachable!(),` in `parse_expr_bp` |
+| 2 | `hew-parser/src/parser.rs:8276` | `_ => unreachable!(),` |
+| 3 | `hew-runtime/src/mailbox.rs:1512` | `HewOverflowPolicy::Coalesce => unreachable!(),` (send path) |
+| 4 | `hew-lexer/src/lib.rs:610` | `_ => unreachable!(),` in a `Display` impl |
+| 5 | `hew-sandbox-wasm/src/emit.rs:1784` | `_ => unreachable!(),` (Some/Ok/None/Err disc.) |
+| 6 | `hew-sandbox-wasm/src/emit.rs:2368` | `_ => unreachable!(),` |
+| 7 | `hew-sandbox-wasm/src/emit.rs:2703` | `_ => unreachable!(),` (regex method map) |
+| 8 | `hew-types/src/check/items.rs:368` | `SupervisorStrategy::SimpleOneForOne => unreachable!(),` |
+
+**Representative example:** `hew-runtime/src/mailbox.rs:1512` — a match arm assumed
+dead because `Coalesce` is meant to be handled earlier; a `unreachable!("coalesce
+handled above")` would document that invariant.
+
+**FP triage (excluded correctly, verified by inspection):**
+- `hew-runtime/src/util.rs:147`, `hew-runtime/src/lifetime/live_actors.rs:389-390`,
+  `hew-mir/src/lower.rs:{32697,32821,32845,32965}`, `hew-codegen-rs/src/llvm.rs:43325`
+  — all inside `#[cfg(test)]` / `#[cfg(all(test, …))]` modules; excluded by the
+  relational `cfg(test)` guard (globs alone would miss these inline modules).
+- `hew-hir/src/lower.rs:23721`, `hew-hir/src/node.rs` — `unreachable!()` appears only
+  inside a `///` doc comment, never matched by the AST macro pattern.
+- `mailbox.rs` has a `#[cfg(test)]` item at line 83 but the line-1512 hit is in the
+  file's production module, so it is (correctly) **kept** — confirms the guard uses
+  immediate-neighbor `follows` and does not over-exclude on an earlier sibling.
+
+**Limitations.** A bare `unreachable!()` inside a *top-level* `#[test]` / `#[cfg(test)]`
+function that is **not** wrapped in a `mod` and lives in a non-`*test*`-named file
+would not be excluded. No such case exists in the current tree. `#[cfg(not(test))]`
+modules (production-only) are conservatively skipped because their attribute text
+contains `test`; this trades a rare false negative for zero false positives.
+
+---
+
+### 2. `no-todo-macro` — severity: warning  (preventive guard)
+**Rationale.** The repo gates against new NYI markers. `todo!()` panics if reached —
+it is unfinished work, not a fail-closed boundary. Matches both `todo!()` and
+`todo!("msg")` (pattern `todo!($$$)`); does **not** match look-alikes such as
+`my_todo!()` / `todoish!()` (verified on scratch).
+
+**Current hits: 0.** The single raw-grep occurrence (`hew-hir/src/node.rs:2181`) is a
+`///` doc comment referencing `todo!("…")`, correctly not matched by the AST pattern.
+Ships as a regression guard so new `todo!` cannot land in production code unnoticed.
+
+---
+
+### 3. `no-unimplemented-macro` — severity: warning  (preventive guard)
+**Rationale.** Same NYI gate as above for `unimplemented!()`. Matches both
+`unimplemented!()` and `unimplemented!("msg")`; excludes look-alikes.
+
+**Current hits: 0** in non-test code. Ships as a regression guard.
+
+---
+
+### 4. `expect-empty-message` — severity: warning  (preventive guard)
+**Rationale.** `.expect("")` panics with no diagnostic context, defeating the point of
+`expect` over `unwrap` (CLAUDE.md values diagnostic quality). Matches empty **and**
+whitespace-only string-literal messages via `constraints: MSG: /^"\s*"$/`; does not
+match non-empty messages or non-literal arguments like `.expect(SOME_CONST)`
+(verified on scratch: matched `.expect("")` and `.expect("   ")`, skipped
+`.expect("good reason")`, `.expect(SOME_CONST)`, `.unwrap()`).
+
+**Current hits: 0.** Ships as a regression guard.
+
+---
+
+## REJECTED
+
+### R1. `panic!(…)` in runtime / codegen — REJECTED (noisy; intentional guards)
+Measured non-test `panic!($$$)` in `hew-runtime/**` + `hew-codegen-rs/**` (test mods
+excluded): **39 hits**. (The raw `hew-codegen-rs/src/llvm.rs:76` collapses to ~0
+non-test — they are inside a large `#[cfg(test)] mod tests`.) Sampling shows the
+surviving 39 are overwhelmingly **intentional** fail-closed / invariant guards, not
+"should-return-an-error" smells:
+- `hew-runtime/src/hashmap.rs` (19) — C-ABI precondition checks on `HewLayoutHashMap`
+  (`key_layout is null`, `align is not a power of two`, `ownership_kind=Bytes is not
+  valid`, …). Panicking on malformed FFI input *is* the fail-closed behaviour.
+- `hew-runtime/src/trait_object.rs` (3) — vtable dispatch out-of-bounds (hard
+  invariant violation).
+- `hew-runtime/src/task_scope.rs:3112` — literally `panic!("cancel_cleanup intentional
+  panic")`; `actor.rs:4659` — `panic!("hew_panic: actor panic")` (the panic impl).
+- `hew-codegen-rs/src/arith.rs:55` — ICE guard for an impossible LLVM intrinsic case.
+
+No structural signal separates the rare genuine smell from the many deliberate guards,
+so any rule here flags ~39 intentional sites → noise. Per the task's own caveat
+("validate it isn't noisy"), rejected. If pursued later, the right move is per-site
+`// JUSTIFIED:` annotations plus an `error`-severity rule that skips annotated lines,
+not a blanket warning.
+
+### R2. `.unwrap()` in codegen/runtime hot paths — REJECTED (no high-signal scope)
+Measured non-test `$X.unwrap()` in `hew-codegen-rs/**` + `hew-mir/**`: **11 hits**
+(`coro.rs` 7, `llvm.rs` 4). (The often-cited ~34 are mostly in `state_clone.rs` /
+`abi_class.rs` `#[cfg(test)]` modules.) None of the 11 is structurally distinguishable
+from an invariant-safe unwrap (e.g. lookup immediately after insert), so a rule would
+emit warnings the team must individually justify. The task pre-flags this as "likely
+too noisy … only ship if you can scope it to be high-signal; otherwise REJECT" — no
+tight high-signal sub-module exists. Note: CLAUDE.md §2 targets `.ok()?`,
+`.unwrap_or_default()`, and silent `None` specifically (owned by the `fail-closed`
+rule dir), not bare `.unwrap()`.
+
+---
+
+## Summary
+- Shipped: `unreachable-without-message` (8 hits, all TP), `no-todo-macro` (0),
+  `no-unimplemented-macro` (0), `expect-empty-message` (0). The three zero-hit rules
+  are precise regression guards enforcing the "no new NYI" / diagnostic-quality
+  policy; the unreachable rule has live, fully-triaged true positives.
+- Rejected: blanket `panic!` (R1) and blanket `.unwrap()` (R2) — both validated as
+  noisy with no high-signal scoping available.

--- a/rules/rust/panics-nyi/expect-empty-message.yml
+++ b/rules/rust/panics-nyi/expect-empty-message.yml
@@ -1,0 +1,26 @@
+id: expect-empty-message
+language: rust
+severity: warning
+message: '`.expect("")` has an empty panic message — state why the value must be present.'
+note: |
+  An empty `.expect("")` produces a panic with no diagnostic context, defeating the
+  purpose of `expect` over `unwrap`. Provide a short reason describing the invariant
+  that guarantees the value is present (e.g. `.expect("ABI table populated in lower")`).
+  Matches empty and whitespace-only string-literal messages only.
+ignores:
+  - '**/tests/**'
+  - '**/*test*.rs'
+  - '**/benches/**'
+rule:
+  all:
+    - pattern: $RECV.expect($MSG)
+    - not:
+        inside:
+          kind: mod_item
+          stopBy: end
+          follows:
+            kind: attribute_item
+            regex: 'cfg\(.*\btest\b'
+constraints:
+  MSG:
+    regex: '^"\s*"$'

--- a/rules/rust/panics-nyi/no-todo-macro.yml
+++ b/rules/rust/panics-nyi/no-todo-macro.yml
@@ -1,0 +1,23 @@
+id: no-todo-macro
+language: rust
+severity: warning
+message: '`todo!()` marks unfinished work — finish it or track it as an issue before merge.'
+note: |
+  The repository gates against introducing new not-yet-implemented (NYI) markers.
+  A `todo!()` panics at runtime if reached, so it is unfinished work, not a
+  fail-closed boundary. Implement the path, or replace it with an explicit typed
+  error / `unreachable!("why")` if the arm is genuinely impossible. Matches both
+  `todo!()` and `todo!("msg")`.
+ignores:
+  - '**/tests/**'
+  - '**/*test*.rs'
+  - '**/benches/**'
+rule:
+  pattern: todo!($$$)
+  not:
+    inside:
+      kind: mod_item
+      stopBy: end
+      follows:
+        kind: attribute_item
+        regex: 'cfg\(.*\btest\b'

--- a/rules/rust/panics-nyi/no-unimplemented-macro.yml
+++ b/rules/rust/panics-nyi/no-unimplemented-macro.yml
@@ -1,0 +1,23 @@
+id: no-unimplemented-macro
+language: rust
+severity: warning
+message: '`unimplemented!()` marks a not-yet-implemented path — implement it or return a typed error before merge.'
+note: |
+  The repository gates against introducing new not-yet-implemented (NYI) markers.
+  `unimplemented!()` panics at runtime if reached, so it is a deferred feature, not
+  a fail-closed boundary. Implement the path, return an explicit typed error, or use
+  `unreachable!("why")` if the arm is genuinely impossible. Matches both
+  `unimplemented!()` and `unimplemented!("msg")`.
+ignores:
+  - '**/tests/**'
+  - '**/*test*.rs'
+  - '**/benches/**'
+rule:
+  pattern: unimplemented!($$$)
+  not:
+    inside:
+      kind: mod_item
+      stopBy: end
+      follows:
+        kind: attribute_item
+        regex: 'cfg\(.*\btest\b'

--- a/rules/rust/panics-nyi/unreachable-without-message.yml
+++ b/rules/rust/panics-nyi/unreachable-without-message.yml
@@ -1,0 +1,23 @@
+id: unreachable-without-message
+language: rust
+severity: warning
+message: '`unreachable!()` needs a description: `unreachable!("why this is unreachable")`.'
+note: |
+  CLAUDE.md §2 (Fail-Closed Codegen) prefers `unreachable!("description")` over a
+  bare `unreachable!()` so that a violated invariant is self-documenting in the
+  panic message / backtrace. Add a short reason string explaining why the arm is
+  genuinely unreachable. This rule only flags the no-argument form; the documented
+  `unreachable!("...")` form is intentionally not matched.
+ignores:
+  - '**/tests/**'
+  - '**/*test*.rs'
+  - '**/benches/**'
+rule:
+  pattern: unreachable!()
+  not:
+    inside:
+      kind: mod_item
+      stopBy: end
+      follows:
+        kind: attribute_item
+        regex: 'cfg\(.*\btest\b'

--- a/scripts/ast-grep-lint.sh
+++ b/scripts/ast-grep-lint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# ast-grep-lint.sh — run the Hew ast-grep rule set over the repository.
+# Rules live under rules/ (wired via sgconfig.yml ruleDirs); .hew rules need
+# the compiled grammar (scripts/build-ast-grep-lang.sh). Exits non-zero if any
+# error-severity rule matches, so it can gate CI.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+exec ast-grep scan "$@"

--- a/scripts/build-ast-grep-lang.sh
+++ b/scripts/build-ast-grep-lang.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# build-ast-grep-lang.sh — compile the tree-sitter-hew grammar into a dynamic
+# library that ast-grep loads as the custom `hew` language (see sgconfig.yml).
+#
+# ast-grep cannot parse .hew natively; it dlopen()s this compiled grammar.
+# The .so is a platform-specific build artifact (git-ignored) — rebuild it
+# locally after pulling, or after the grammar changes.
+#
+# Usage:
+#   scripts/build-ast-grep-lang.sh
+#
+# Env:
+#   TREE_SITTER_HEW_DIR   Path to the tree-sitter-hew grammar repo
+#                         (default: ../tree-sitter-hew, sibling of this repo).
+#                         Grammar repo: https://github.com/hew-lang/tree-sitter-hew
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GRAMMAR_DIR="${TREE_SITTER_HEW_DIR:-$REPO_ROOT/../tree-sitter-hew}"
+OUT="$REPO_ROOT/.ast-grep/hew-lang.so"
+
+if ! command -v tree-sitter >/dev/null 2>&1; then
+  echo "error: tree-sitter CLI not found on PATH (install via 'cargo install tree-sitter-cli' or 'npm i -g tree-sitter-cli')" >&2
+  exit 1
+fi
+if [[ ! -f "$GRAMMAR_DIR/grammar.js" ]]; then
+  echo "error: tree-sitter-hew grammar not found at: $GRAMMAR_DIR" >&2
+  echo "       clone https://github.com/hew-lang/tree-sitter-hew next to this repo," >&2
+  echo "       or set TREE_SITTER_HEW_DIR to its path." >&2
+  exit 1
+fi
+
+mkdir -p "$REPO_ROOT/.ast-grep"
+# A fixed .so name (not .dylib/.dll) keeps sgconfig.yml's libraryPath single-valued
+# across platforms; ast-grep's dlopen does not care about the extension.
+( cd "$GRAMMAR_DIR" && tree-sitter generate >/dev/null && tree-sitter build --output "$OUT" )
+echo "built: $OUT"

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,18 @@
+# ast-grep project config — registers Hew as a custom language.
+#
+# .hew is not built into ast-grep; it is parsed by the tree-sitter-hew grammar
+# compiled to .ast-grep/hew-lang.so (build with: scripts/build-ast-grep-lang.sh).
+#
+# Usage:
+#   ast-grep run --lang hew --pattern '|$P| $BODY' examples/
+#   ast-grep run --lang hew --pattern 'fn $NAME($$$) -> $RET { $$$ }' std/
+#
+# Metavariables use the usual `$NAME` (single) / `$$$` (variadic) syntax. The
+# `expandoChar` below is the internal placeholder ast-grep substitutes for `$`
+# so patterns parse as valid Hew; `_` is identifier-valid and leaves literal
+# `_` wildcards in patterns (e.g. `Some(_)`) untouched.
+customLanguages:
+  hew:
+    libraryPath: .ast-grep/hew-lang.so
+    extensions: [hew]
+    expandoChar: _

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -9,8 +9,10 @@
 #
 # Metavariables use the usual `$NAME` (single) / `$$$` (variadic) syntax. The
 # `expandoChar` below is the internal placeholder ast-grep substitutes for `$`
-# so patterns parse as valid Hew; `_` is identifier-valid and leaves literal
-# `_` wildcards in patterns (e.g. `Some(_)`) untouched.
+# so patterns parse as valid Hew; `_` is identifier-valid, so it does not
+# collide with `_`-prefixed identifiers in real code. Note: a bare `_` does
+# not parse as a Hew expression, so match a wildcard with a metavariable
+# (e.g. `Some($X)`, not `Some(_)`).
 customLanguages:
   hew:
     libraryPath: .ast-grep/hew-lang.so

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -18,3 +18,7 @@ customLanguages:
     libraryPath: .ast-grep/hew-lang.so
     extensions: [hew]
     expandoChar: _
+
+# Lint rules for `ast-grep scan` (see rules/README.md). Run: scripts/ast-grep-lint.sh
+ruleDirs:
+  - rules


### PR DESCRIPTION
## Summary
Wire ast-grep to parse `.hew` via the tree-sitter-hew grammar, so structural search and rewrite work in this repo.

- `sgconfig.yml` registers `hew` as a custom language (relative `libraryPath`, `expandoChar: _`); ast-grep auto-discovers it from anywhere in the tree.
- `scripts/build-ast-grep-lang.sh` compiles the grammar into `.ast-grep/hew-lang.so` from a sibling `tree-sitter-hew` checkout (or `$TREE_SITTER_HEW_DIR`).

The compiled library is platform-specific and git-ignored (existing `*.so` rule); contributors run the build script once after cloning.

## Verification
- `scripts/build-ast-grep-lang.sh` builds the library, then `ast-grep run --lang hew -p 'fn $NAME($$$) { $$$ }' std/` matches across the standard library.
- `git status` shows only these two files; the `.so` stays ignored.

## Notes
Item-level patterns (`fn`, `impl`, `supervisor`, …) work directly. Expression-level patterns use ast-grep's `context` + `selector`, since a bare top-level expression isn't valid Hew.

## Out of scope
The grammar itself lives in the tree-sitter-hew repository; this only adds the ast-grep integration.
