### PR TITLE
fix(build): make Windows source builds link-ready

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,10 @@
+# Windows uses the LLVM linker from the same provisioned LLVM 22 toolchain that
+# supplies clang.exe for `hew build` and llvm-config for llvm-sys.  Keep this
+# pinned to lld-link rather than relying on a Developer Command Prompt: the
+# provisioned LLVM 22.1.6 release includes lld-link.exe, lld-link auto-detects
+# the MSVC/Windows SDK libraries, and building under vcvars64.bat has broken
+# llvm-sys detection on the Windows validation host.  A clean Windows checkout
+# should have the LLVM bin directory on PATH instead of requiring vcvars.
 [target.x86_64-pc-windows-msvc]
 linker = "lld-link"
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@
 #   make pre-release  — release + validate on all platforms before tagging
 #   make publish-docs — build stdlib docs + print wrangler deploy command (operator runs wrangler)
 #   make hew          — just the compiler driver
+#   make hew-native   — compiler driver + native libhew archive for `hew build`
 #   make adze         — just the package manager
 #   make observe      — just the TUI observer (hew-observe)
 #   make runtime      — just libhew_runtime.a
@@ -62,7 +63,7 @@
 #   make clean        — remove build/, target/
 # ============================================================================
 
-.PHONY: all build bootstrap install-hooks hew adze observe runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh
+.PHONY: all build bootstrap install-hooks hew hew-native adze observe runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh
 .PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all test-stdlib test-hew test-hew-ratchet test-o2-differential test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo hew-fmt-check grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
@@ -123,6 +124,15 @@ build: all
 # Build the hew compiler driver (debug).
 hew:
 	cargo build -p hew-cli
+
+# Build the native artifacts required for `hew build` from a source checkout.
+# `cargo build -p hew-cli` only produces the driver; the link step also needs
+# hew-lib's staticlib next to the driver (`target/debug/libhew.a` on Unix,
+# `target/debug/hew.lib` on Windows).  Keep this target cross-platform so fresh
+# Windows hosts use the same build graph as Linux/macOS rather than a bespoke
+# manual `cargo build -p hew-lib` follow-up.
+hew-native:
+	cargo build -p hew-cli -p hew-lib
 
 # Build the adze package manager (debug)
 adze:

--- a/docs/cross-platform-build-guide.md
+++ b/docs/cross-platform-build-guide.md
@@ -18,9 +18,12 @@ Both Rust binaries build with `cargo build --release` once LLVM 22
 libraries and headers are available; set `LLVM_PREFIX` (or
 `LLVM_SYS_221_PREFIX`) to point at the install.
 
-Use `make` / `make release` from the repository root rather than invoking
-`cargo` directly — the Makefile wires up symlinks and per-target lib
-layouts correctly.
+Use the Makefile from the repository root rather than invoking `cargo build
+-p hew-cli` directly.  The compiler driver is not enough for `hew build`: the
+native `hew-lib` staticlib must be built in the same Cargo profile so the link
+step can find `target/debug/libhew.a` (Unix) or `target/debug/hew.lib`
+(Windows).  For a narrow local build, use `make hew-native`; for the full
+artifact set, use `make` / `make release`.
 
 ## Linux x86_64
 
@@ -163,19 +166,42 @@ LLVM_SYS_221_PREFIX=/usr/local/llvm22 make release
 ## Windows
 
 **Status:** Supported for release builds when LLVM 22 is installed locally
-and `LLVM_PREFIX` is set. The runtime's low-level memory paths have Windows
-implementations (`VirtualAlloc` / `VirtualFree`). Windows is fail-soft /
-Tier 2 in `release.yml` today: the tag-release Windows job remains
-`continue-on-error: true` until this validation path has proven itself
+and discoverable by both `llvm-sys` and PATH. The runtime's low-level memory
+paths have Windows implementations (`VirtualAlloc` / `VirtualFree`). Windows
+is fail-soft / Tier 2 in `release.yml` today: the tag-release Windows job
+remains `continue-on-error: true` until this validation path has proven itself
 through a full release cycle.
 
 ### Prerequisites
 
-The release workflow provisions LLVM 22 into `C:\llvm-22` and builds with
-MSVC's `cl`. The local Windows validator in `scripts/pre-release-validate.sh`
-expects the same layout by default.
+Install the prebuilt LLVM 22.1.6 Windows MSVC toolchain and put its `bin`
+directory on `PATH`. Hew uses:
 
-One-time bootstrap on the Windows host:
+- `llvm-config.exe` / LLVM libraries for `llvm-sys`
+- `clang.exe` as the `hew build` link driver
+- `lld-link.exe` as the Cargo linker for `x86_64-pc-windows-msvc`
+
+The provisioned validation host uses the upstream release archive:
+
+```powershell
+https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.6/clang+llvm-22.1.6-x86_64-pc-windows-msvc.tar.xz
+```
+
+Set `LLVM_PREFIX` or `LLVM_SYS_221_PREFIX` to the extracted LLVM root and make
+sure `where clang` and `where lld-link` both resolve before building. NASM is
+also required by `hew-lib` through `aws-lc-sys`:
+
+```powershell
+winget install --id NASM.NASM
+```
+
+Do not run Hew Cargo builds from a `vcvars64.bat` / Developer Command Prompt
+environment unless you are debugging that path specifically. The provisioned
+LLVM `lld-link.exe` auto-detects the MSVC and Windows SDK libraries without
+vcvars, while vcvars has interfered with `llvm-sys` version detection on the
+Windows validation host.
+
+If you need to build LLVM locally instead of using the release archive:
 
 ```powershell
 choco install ninja cmake -y
@@ -222,19 +248,25 @@ If the host cannot use MSVC, override the validator/compiler environment with
 
 ### Build
 
-Use a Developer PowerShell (or equivalent environment where your chosen
-compiler is on `PATH`):
+Use a normal PowerShell or cmd.exe session with LLVM and NASM on `PATH`:
 
 ```powershell
-$env:LLVM_PREFIX = 'C:\llvm-22'
-$env:Path = 'C:\llvm-22\bin;' + $env:Path
+$env:LLVM_SYS_221_PREFIX = 'P:\llvm22'
+$env:Path = 'P:\llvm22\bin;' + $env:Path
 
-cargo build -p hew-cli -p adze-cli -p hew-lsp --release
-cargo build -p hew-lib --release
+make hew-native    # debug: target\debug\hew.exe + target\debug\hew.lib
+make release       # release: target\release\hew.exe + target\release\hew.lib
 ```
 
-`LLVM_PREFIX` (or `LLVM_SYS_221_PREFIX`) must point at an LLVM 22 install
-so `llvm-sys` can locate `llvm-config` and the static libraries.
+`cargo build -p hew-cli` by itself is intentionally not the build recipe for a
+working source checkout: it does not build `hew-lib`, and `hew build` needs the
+fresh `hew.lib` next to `hew.exe`. If `make` is unavailable, use the equivalent
+single Cargo invocation:
+
+```powershell
+cargo build -p hew-cli -p hew-lib
+cargo build --release -p hew-cli -p hew-lib
+```
 
 ### Smoke test
 

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -438,6 +438,23 @@ fn select_native_compiler(target: &TargetSpec) -> Result<NativeCompiler, String>
     select_native_compiler_with(target, has_tool)
 }
 
+#[cfg_attr(
+    not(target_os = "windows"),
+    allow(
+        dead_code,
+        reason = "the Windows linker diagnostic is unit-tested cross-platform but only used on Windows builds"
+    )
+)]
+fn windows_missing_clang_error() -> String {
+    "Error: clang.exe not found on PATH. Install the LLVM 22.1.6 Windows MSVC \
+     toolchain from https://github.com/llvm/llvm-project/releases/download/llvmorg-22.1.6/clang+llvm-22.1.6-x86_64-pc-windows-msvc.tar.xz, \
+     add its bin directory to PATH, and ensure lld-link.exe is available from \
+     the same LLVM bin directory. Do not rely on vcvars64.bat for Hew builds; \
+     lld-link auto-detects the MSVC/Windows SDK libraries and vcvars64.bat can \
+     interfere with llvm-sys detection."
+        .to_string()
+}
+
 /// Decide whether to link the LLVM profiler runtime into the final binary for
 /// coverage capture. Gated on BOTH `HEW_COVERAGE` being set to the exact value
 /// `"1"` AND the selected driver being clang — `-fprofile-instr-generate` is a
@@ -469,7 +486,7 @@ where
     #[cfg(target_os = "windows")]
     {
         let _ = target;
-        return Err("Error: clang not found. Install LLVM to link Hew programs.".into());
+        return Err(windows_missing_clang_error());
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -1706,6 +1723,18 @@ mod tests {
                 accepts_target_flag: true
             }
         );
+    }
+
+    #[test]
+    fn windows_missing_clang_message_names_required_tools_and_provisioning() {
+        let error = windows_missing_clang_error();
+
+        assert!(error.contains("clang.exe"));
+        assert!(error.contains("lld-link.exe"));
+        assert!(error.contains("LLVM 22.1.6"));
+        assert!(error.contains("llvm-project/releases/download/llvmorg-22.1.6"));
+        assert!(error.contains("PATH"));
+        assert!(error.contains("vcvars64.bat"));
     }
 
     #[cfg(all(


### PR DESCRIPTION
## Summary

On a clean Windows checkout `cargo build -p hew-cli` alone didn't produce a working `hew build`: the `hew.lib` runtime staticlib the linker step requires was never built. `make hew-native` is now a single cross-platform target that builds `hew-cli` + `hew-lib` together (→ `hew.exe`+`hew.lib` on Windows, `hew`+`libhew.a` on Unix).

`lld-link` is kept as the Windows MSVC linker with a documented rationale in `.cargo/config.toml`: it ships in the same LLVM 22.1.6 archive as `clang.exe` (co-presence is guaranteed by the mandatory prerequisite) and avoids the vcvars environment, which breaks `llvm-sys`'s version probe. The terse missing-`clang` link error is replaced by an actionable diagnostic that names the required tools, the LLVM release, PATH setup, and the vcvars footgun. The cross-platform build guide is updated to match.

## Verification

- `make hew-native`: pass — produces `target/debug/hew` + `target/debug/libhew.a` on macOS; exit 0.
- `cargo build -p hew-cli`: pass — exit 0 (also confirms this alone does NOT refresh `libhew.a`, empirically demonstrating the gap this closes).
- `cargo test -p hew-cli link`: pass — 90 unit tests + all `link` integration suites (`ffi_link_e2e` 5/5 incl. fail-closed cases, `cross_target_e2e` 3/3, `compile_links_runtime`, `build_host_e2e`) green; new `windows_missing_clang_message_names_required_tools_and_provisioning` test passes cross-platform on macOS. exit 0.
- `cargo fmt -p hew-cli -- --check`: pass — exit 0.
- `cargo clippy -p hew-cli --all-targets`: pass — zero warnings; exit 0.
- Windows-specific code is `cfg`-guarded; macOS build above is green with the lld-link pin present (inert on non-Windows).
- Preflight: ready-to-push.

## Out of scope

- CodeView/PDB `-g` debuggability improvements (#2117, tracked separately).
- No changes to `llvm.rs`, `lower.rs`, or any codegen path.