### PR TITLE
fix(codegen): fail closed on discarded lowering errors

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -29740,7 +29740,7 @@ fn resolve_di_type<'ctx>(
         let basic = dctx
             .di_builder
             .create_basic_type(name, size_bits, encoding, DIFlags::PUBLIC)
-            .ok()?
+            .expect("DWARF base type for a scalar is infallible")
             .as_type();
         dctx.di_type_cache.borrow_mut().insert(key, basic);
         return Some(basic);
@@ -29859,7 +29859,10 @@ fn resolve_di_type<'ctx>(
                         return None;
                     };
                     let offset_bits = target_data
-                        .offset_of_element(&llvm_struct, u32::try_from(i).ok()?)
+                        .offset_of_element(
+                            &llvm_struct,
+                            u32::try_from(i).expect("struct field count fits in u32"),
+                        )
                         .map(|b| b * 8)
                         .unwrap_or(0);
                     let member_size = member_di_size_bits(member_di, target_data, fty);
@@ -29990,7 +29993,7 @@ fn resolve_enum_di_type<'ctx>(
     let tag_underlying = dctx
         .di_builder
         .create_basic_type("u32", tag_bits.max(8), DW_ATE_UNSIGNED, DIFlags::PUBLIC)
-        .ok()?
+        .expect("DWARF base type for the enum tag is infallible")
         .as_type();
     let tag_di = dctx
         .di_builder
@@ -31814,6 +31817,7 @@ fn actor_name_from_handler_symbol(symbol: &str) -> Option<&str> {
         .or_else(|| {
             let after_on_stop = symbol.split_once("__on_stop__")?;
             // Verify the suffix is a decimal index (no empty or non-numeric).
+            // JUSTIFIED: malformed indexed stop-hook suffixes are not handler symbols.
             after_on_stop.1.parse::<usize>().ok()?;
             Some(after_on_stop.0)
         })

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -6326,10 +6326,15 @@ impl Builder {
     fn owned_aggregate_record_field_kinds_for_key(
         &self,
         key: &str,
-    ) -> Option<Vec<crate::state_clone::StateFieldCloneKind>> {
-        let fields = self.lookup_record_field_order(key)?;
+    ) -> Result<
+        Option<Vec<crate::state_clone::StateFieldCloneKind>>,
+        crate::state_clone::ClassificationError,
+    > {
+        let Some(fields) = self.lookup_record_field_order(key) else {
+            return Ok(None);
+        };
         if fields.is_empty() {
-            return None;
+            return Ok(None);
         }
         let field_tys: Vec<ResolvedTy> = fields.iter().map(|(_, ty)| ty.clone()).collect();
         let record_layouts = self.record_layouts_for_classification();
@@ -6338,8 +6343,7 @@ impl Builder {
             &record_layouts,
             &self.enum_layouts,
             &self.opaque_handle_names,
-        )
-        .ok()?;
+        )?;
         // Fail closed at the value-class gate, not late at codegen. An admitted
         // owned-aggregate record is seeded for `DropKind::RecordInPlace`, which
         // drives codegen to synthesise BOTH the clone and the drop body. A field
@@ -6356,12 +6360,12 @@ impl Builder {
             .iter()
             .all(crate::state_clone::StateFieldCloneKind::supports_value_class_drop_spine)
         {
-            return None;
+            return Ok(None);
         }
         let has_owned_field = kinds
             .iter()
             .any(|k| !matches!(k, crate::state_clone::StateFieldCloneKind::BitCopy { .. }));
-        has_owned_field.then_some(kinds)
+        Ok(has_owned_field.then_some(kinds))
     }
 
     /// True when `ty` is a user record admitted by the unified
@@ -6392,7 +6396,7 @@ impl Builder {
     fn is_owned_aggregate_record_ty(&self, ty: &ResolvedTy) -> bool {
         user_record_layout_key(ty).is_some_and(|key| {
             self.owned_aggregate_record_field_kinds_for_key(&key)
-                .is_some()
+                .is_ok_and(|kinds| kinds.is_some())
         })
     }
 
@@ -21332,9 +21336,15 @@ impl Builder {
         }
         let init_args =
             self.lower_spawn_actor_init_args(actor_name, &layout, explicit_init, &explicit, expr)?;
-        let state = self
-            .lower_spawn_actor_state(actor_name, &layout, explicit_init, &explicit, expr)
-            .ok()?;
+        let Ok(state) = self.lower_spawn_actor_state_or_diag(
+            actor_name,
+            &layout,
+            explicit_init,
+            &explicit,
+            expr,
+        ) else {
+            return None;
+        };
         let slot = self.alloc_local(expr.ty.clone());
         let Place::Local(local_id) = slot else {
             unreachable!("alloc_local returns Place::Local");
@@ -21349,6 +21359,33 @@ impl Builder {
             cycle_capable: layout.cycle_capable,
         });
         Some(dest)
+    }
+
+    fn lower_spawn_actor_state_or_diag(
+        &mut self,
+        actor_name: &str,
+        layout: &ActorLayout,
+        explicit_init: bool,
+        explicit: &HashMap<&str, &HirExpr>,
+        expr: &HirExpr,
+    ) -> Result<Option<Place>, ()> {
+        let diagnostics_before_state = self.diagnostics.len();
+        let Ok(state) =
+            self.lower_spawn_actor_state(actor_name, layout, explicit_init, explicit, expr)
+        else {
+            if self.diagnostics.len() == diagnostics_before_state {
+                self.diagnostics.push(MirDiagnostic {
+                    kind: MirDiagnosticKind::NotYetImplemented {
+                        construct: format!("spawn `{actor_name}` state lowering failed"),
+                        site: expr.site,
+                    },
+                    note: "actor spawn state lowering failed before a field/value diagnostic was recorded"
+                        .to_string(),
+                });
+            }
+            return Err(());
+        };
+        Ok(state)
     }
 
     fn lower_spawn_actor_init_args(
@@ -23448,22 +23485,27 @@ impl Builder {
             return;
         }
 
-        let reason = fields
-            .iter()
-            .find_map(|(field_name, field_ty)| {
-                let field_class = ValueClass::of_ty(field_ty, &self.type_classes);
-                (field_class != ValueClass::BitCopy).then(|| {
-                    format!(
-                        "field `{field_name}` has value class {field_class:?}; \
-                         user record/type aggregates are BitCopy only when every \
-                         substituted field is BitCopy"
-                    )
+        let reason = match self.owned_aggregate_record_field_kinds_for_key(&key) {
+            Err(err) => {
+                format!("owned-aggregate field classifier failed for `{key}`: {err}")
+            }
+            Ok(_) => fields
+                .iter()
+                .find_map(|(field_name, field_ty)| {
+                    let field_class = ValueClass::of_ty(field_ty, &self.type_classes);
+                    (field_class != ValueClass::BitCopy).then(|| {
+                        format!(
+                            "field `{field_name}` has value class {field_class:?}; \
+                             user record/type aggregates are BitCopy only when every \
+                             substituted field is BitCopy"
+                        )
+                    })
                 })
-            })
-            .unwrap_or_else(|| {
-                "record layout is present but no BitCopy value-class registration was produced"
-                    .to_string()
-            });
+                .unwrap_or_else(|| {
+                    "record layout is present but no BitCopy value-class registration was produced"
+                        .to_string()
+                }),
+        };
 
         self.diagnostics.push(MirDiagnostic {
             kind: MirDiagnosticKind::UnsupportedUserRecordValueClass {
@@ -35442,7 +35484,7 @@ mod generic_record_owned_aggregate_admission {
         assert!(
             builder
                 .owned_aggregate_record_field_kinds_for_key(&key)
-                .is_none(),
+                .is_ok_and(|kinds| kinds.is_none()),
             "the opaque-bearing layout resolves but the clone-support gate must \
              reject it (None), not a key miss"
         );


### PR DESCRIPTION
## Summary

Silent `.ok()?` swallows in the lowering/codegen pipeline are removed. A classification error in the owned-aggregate value-class path now propagates: the type is excluded from the drop allow-set and a diagnostic is emitted, rather than silently resolving to "not an owned aggregate" and skipping drop synthesis. A spawn-state lowering error now guarantees a diagnostic instead of returning a bare `None`. The DWARF base-type and field-index sites—infallible by construction—use `.expect()` with an invariant note. One symbol-classifier site retains `.ok()?` with a `// JUSTIFIED:` comment: a malformed suffix is a benign non-match, not a swallowed error.

## Verification

- `make test-hew-ratchet`: pass — 0 expected failures / 0 actual failures; ratchet PASSED (load-bearing check for the drop/value-class surface)
- `make build`: pass — all crates compiled
- `cargo fmt -p hew-mir -p hew-codegen-rs -- --check`: pass
- `cargo clippy -p hew-mir -p hew-codegen-rs --all-targets`: pass — zero warnings
- `ast-grep scan --rule rules/rust/fail-closed/ok-question-in-lowering.yml`: 0 unannotated hits
- Full ast-grep lint gate (`scripts/ast-grep-lint.sh`): pass — 0 error-severity matches
- Preflight: ready-to-push

## Out of scope

- The two new defense-in-depth diagnostic branches (classification-error reason in the owned-aggregate value-class path; spawn-state `NotYetImplemented` fallback) do not yet have dedicated reject fixtures. These branches guard internal-invariant conditions that are not currently reachable from a known `.hew` construct; fixtures will be added when such a construct is identified.
