### PR TITLE
docs(spec): align spec and docs with implemented behaviour

### DIFF
--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -1491,7 +1491,7 @@ fn main() {
 }
 ```
 
-Implement Display via the `fmt` method (the spec's `display` name is aspirational) and interpolate with f-strings. To print a user type, wrap it: `println(f"{value}")` — `println(value)` on a bare user Display type does not dispatch.
+Implement `Display` via the `fmt` method and interpolate with f-strings. To print a user type, wrap it: `println(f"{value}")` — `println(value)` on a bare user Display type does not dispatch.
 
 ### Calling a Display fmt method directly
 

--- a/docs/specs/HEW-FUTURE.md
+++ b/docs/specs/HEW-FUTURE.md
@@ -101,20 +101,16 @@ APIs — are deferred.
 
 ### 1.6 Generators (`gen fn`, `async gen fn`, `receive gen fn`, `Lazy<T>`, `#[prefetch(N)]`)
 
-**[Partially live in v0.5.0 / parameterized forms gated on Cluster 1]**
+**[Scalar-parameter + fn-typed-parameter forms live in v0.5 / remaining forms deferred]**
 
-Zero-parameter `gen fn` functions compile and run at the current tip; the
-LLVM coroutine machinery, `yield`, `.next()`, and `for x in generator()` path
-are live for that shape. Parameterized generators are still blocked by the
-Cluster 1 spine: function parameters and captured bindings do not yet have
-backend slots in every generator lowering path. The four spike-fixture
-failures from PR #1772 remain the bug class exposed by parameterized and
-capturing generator forms, so those forms stay deferred until the Cluster 1
-parameter/capture lowering is complete.
+Zero-parameter `gen fn` functions compile and run. The LLVM coroutine machinery,
+`yield`, `.next()`, and `for x in generator()` are all live. Parameterized `gen fn`
+with scalar parameters (e.g. `n: i64`) and fn-typed parameters are also live — the
+Cluster 1 parameter/capture lowering that unblocked these shipped and the
+`gen_fn_param_capture` and `gen_fn_fn_typed_param` vertical-slice fixtures pass.
 
-Surface inventory:
+Remaining deferred:
 
-- `gen fn` returning `Generator<Y>` with `.next()` / `Iterator`.
 - `async gen fn` returning `AsyncGenerator<Y>` with `for await`.
 - `receive gen fn` on actors returning `Stream<Y>` backed by mailbox
   protocol (cross-actor streaming with natural backpressure).
@@ -177,7 +173,10 @@ Edition 2026 ships a deliberately small trait surface:
 
 Out of scope for edition 2026:
 
-- `dyn Trait` object types and the object-safety rules.
+- Single-trait `dyn Trait` dispatch works (vtable registry is live; see
+  `examples/types_and_traits.hew`). Remaining partial: object-safety
+  enforcement, associated-type bounds in `dyn` position, and higher-ranked
+  trait bounds.
 - Associated-type bounds in where-clauses (`where T::Item: Display`).
 - Trait coherence (orphan rule) across crates — the current single-crate
   coherence rule stays; multi-crate coherence depends on the package

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -976,7 +976,7 @@ Traits define shared behaviour that types can implement. Hew has built-in marker
 
 ```hew
 trait Display {
-    fn display(val: Self) -> string;
+    fn fmt(val: Self) -> string;
 }
 
 trait Iterator {
@@ -995,7 +995,7 @@ trait Clone {
 type Point { x: f64; y: f64 }
 
 impl Display for Point {
-    fn display(p: Point) -> string {
+    fn fmt(p: Point) -> string {
         f"({p.x}, {p.y})"
     }
 }
@@ -1027,11 +1027,11 @@ Hew uses **named receivers** instead of a `self` keyword. In trait declarations 
 
 ```hew
 trait Display {
-    fn display(val: Self) -> string;       // val is the receiver (type Self)
+    fn fmt(val: Self) -> string;       // val is the receiver (type Self)
 }
 
 impl Display for Point {
-    fn display(p: Point) -> string {       // p is the receiver (type Point)
+    fn fmt(p: Point) -> string {       // p is the receiver (type Point)
         f"({p.x}, {p.y})"
     }
 }
@@ -1043,7 +1043,7 @@ The compiler identifies the receiver by matching the parameter type against the 
 
 ```hew
 let p = Point { x: 1.0, y: 2.0 };
-p.display();    // desugars to Point::display(p) — p is consumed (by-value)
+p.fmt();    // desugars to Point::fmt(p) — p is consumed (by-value)
 // p is no longer valid here
 ```
 
@@ -1051,7 +1051,7 @@ p.display();    // desugars to Point::display(p) — p is consumed (by-value)
 
 The receiver is passed by value — the receiver is consumed (ownership transfer):
 
-- `fn display(p: Point)` takes `p` by value in an `impl` for `Point`
+- `fn fmt(p: Point)` takes `p` by value in an `impl` for `Point`
 - The caller gives up ownership of the value
 - After calling a consuming method, the original binding is no longer usable
 
@@ -1072,13 +1072,12 @@ There is no `&self` or `&mut self` syntax — Hew does not have references in it
 
 **The `this` keyword (actor self-reference):**
 
-> **Not yet implemented.** `this` as a value passed to another actor (e.g. `mgr.add_worker(this)`) is parsed but lowering is not yet wired (`E_NOT_YET_IMPLEMENTED`). See HEW-FUTURE for the intended design.
-
-Inside an actor body, the `this` keyword is intended to provide a read-only handle to the actor itself. The design:
+Inside an actor body, the `this` keyword provides a read-only handle to the actor itself:
 
 - Available only inside actor bodies (`receive fn` and `fn` methods)
-- Read-only — you cannot assign to `this`
-- Of type `LocalPid<Self>` — a sendable handle to the enclosing actor
+- Type `LocalPid<Self>` — a sendable handle to the enclosing actor
+- Can be passed as a message argument or stored in a field
+- Read-only — assignment to `this` is rejected at compile time
 - Not valid in struct `impl` blocks or free functions
 
 **Variable shadowing:**
@@ -1153,18 +1152,27 @@ Hew uses **per-actor ownership** with RAII-style deterministic destruction. Ther
 **Principle 1: Actors own their heaps.**
 Each actor has a private heap. No memory is shared between actors. When an actor terminates, its entire heap is freed in one operation.
 
-**Principle 2: RAII within actors.**
-Within an actor, values follow Rust-style ownership semantics:
+**Principle 2: Ownership within actors.**
+Within an actor, values follow Hew ownership semantics:
 
 - Each value has exactly one owner
-- When the owner goes out of scope, the value is dropped
-- Destructors (`Drop` trait) run deterministically at scope exit
+- When the owner goes out of scope, heap memory is freed automatically
+- User-defined `impl Drop` is **not supported** — external-resource cleanup
+  uses `#[resource]` + `close()` (see §3.7.3 and §3.7.8)
 
 ```hew
-fn example() {
-    let file = File::open("data.txt");  // file owns the handle
-    process(file);
-}  // file.drop() runs here, closing the handle
+#[resource]
+type Connection { fd: i64; }
+
+impl Connection {
+    fn open(host: string) -> Connection { Connection { fd: 0 } }
+    fn close(c: Connection) {}
+}
+
+fn example(host: string) {
+    let conn = Connection::open(host);
+    // ... use conn ...
+}  // conn.close() runs here automatically (implicit #[resource] drop)
 ```
 
 **Principle 3: No garbage collection.**
@@ -1427,8 +1435,10 @@ Semantics:
    consuming receiver all consume the value; the move-checker tracks the
    single live binding.
 
-Typical example — file I/O with implicit cleanup:
+Typical example — file I/O with implicit cleanup (illustrative; no `File` type
+exists in stdlib — for file reading use `fs::try_read`):
 
+<!-- doctest: skip -->
 ```hew
 fn read_config(path: string) -> Result<Config, IoError> {
     let f = File::open(path)?;
@@ -1438,8 +1448,9 @@ fn read_config(path: string) -> Result<Config, IoError> {
 }
 ```
 
-Early close, surfacing the I/O error to the caller:
+Early close, surfacing the I/O error to the caller (illustrative):
 
+<!-- doctest: skip -->
 ```hew
 fn read_and_process(path: string) -> Result<Summary, AppError> {
     let f = File::open(path)?;
@@ -1479,8 +1490,10 @@ Semantics:
    tracks the single live binding and rejects any use after the consuming
    method call.
 
-A correct use:
+A correct use (illustrative — `Database` and `Transaction` are hypothetical types
+showing the `#[linear]` pattern; `&Database` uses reference syntax not in Hew):
 
+<!-- doctest: skip -->
 ```hew
 fn transfer(db: &Database, from: AccountId, to: AccountId, amount: Money)
     -> Result<(), DbError>
@@ -1492,8 +1505,9 @@ fn transfer(db: &Database, from: AccountId, to: AccountId, amount: Money)
 }
 ```
 
-The compile error for forgetting to consume:
+The compile error for forgetting to consume (illustrative):
 
+<!-- doctest: skip -->
 ```hew
 fn forgot_to_commit(db: &Database) -> Result<(), DbError> {
     let tx = db.begin_transaction()?;
@@ -1928,6 +1942,7 @@ Hew provides FFI capabilities for interoperating with C libraries and system cal
 
 External C functions are declared in `extern` blocks:
 
+<!-- doctest: skip -->
 ```hew
 extern "C" {
     fn malloc(size: usize) -> *mut u8;
@@ -1953,6 +1968,7 @@ extern "C" {
 
 Use `#[repr(C)]` to ensure C-compatible memory layout:
 
+<!-- doctest: skip -->
 ```hew
 #[repr(C)]
 type Point {
@@ -2024,6 +2040,7 @@ extern "C" fn my_callback(value: i32) -> i32 {
 
 **All FFI calls are `unsafe`:**
 
+<!-- doctest: skip -->
 ```hew
 fn allocate_buffer(size: usize) -> *mut u8 {
     unsafe {
@@ -2051,6 +2068,7 @@ fn safe_read(fd: i32, buf: *mut u8, count: usize) -> Result<usize, string> {
 
 **Safe wrapper pattern:**
 
+<!-- doctest: skip -->
 ```hew
 // Raw FFI (internal, unsafe)
 extern "C" {
@@ -2126,7 +2144,7 @@ The following traits are representative of the current trait style:
 
 ```hew
 trait Display {
-    fn display(val: Self) -> string;
+    fn fmt(val: Self) -> string;
 }
 
 trait Drop {
@@ -2161,7 +2179,9 @@ pub enum IoError {
     Other(i64);
 }
 
-pub fn io_error_from_message(message: string) -> IoError { ... }
+pub fn io_error_from_message(message: string) -> IoError {
+    IoError::Other(0)
+}
 ```
 
 This pattern is used across every `try_*` function in the `std::fs` module and pairs with the `?` operator for ergonomic error propagation. Each stdlib module defines its own error type following this shape; there is no single cross-module error enum. Future stdlib modules (under #1247) will adopt the same per-module structured error approach.
@@ -3122,12 +3142,14 @@ scope {
 
 ### 4.7 IO and Effects
 
-All IO operations in Hew are explicit and return `Result` types:
+All IO operations in Hew are explicit and return `Result` types. Use
+`fs::try_read` (not `fs::open`) for file reading; the stdlib has no `File`
+handle type — reads and writes are free functions:
 
+<!-- doctest: skip -->
 ```hew
 fn read_config(path: string) -> Result<Config, string> {
-    let file = fs::open(path)?;
-    let content = file.read_to_string()?;
+    let content = fs::try_read(path)?;
     json::parse(content)
 }
 ```
@@ -3173,6 +3195,7 @@ reachable from inside a child body.
 > (c) actor-mailbox accumulation via an anonymous `fork _ = …;`.
 > The example below uses an indicative placeholder pending ratification.
 
+<!-- doctest: skip -->
 ```hew
 actor DataProcessor {
     var cache: HashMap<string, Data> = HashMap::new();
@@ -3469,9 +3492,9 @@ a callable cancel handle that `select` can hold as a source.
 
 ### 4.12 Generators
 
-> See HEW-FUTURE.md §1.5 for generators (`gen fn`, `async gen fn`,
-> `receive gen fn`, `Lazy<T>`, `#[prefetch(N)]`) — targeted for v0.6,
-> gated on Cluster 4 (closures + generators lowering).
+> See HEW-FUTURE.md §1.6 for the remaining deferred generator forms (`async gen fn`,
+> `receive gen fn`, `Lazy<T>`, `#[prefetch(N)]`). Scalar-parameter and fn-typed-parameter
+> `gen fn` forms are live as of v0.5 (see §1.6 for detail).
 
 ---
 
@@ -3888,6 +3911,10 @@ wire struct User {
 
 Wire enums are encoded as MessagePack **integers** representing the 0-based variant index:
 
+> **Not yet implemented.** `wire enum` lowering is parsed but not yet wired
+> in v0.5 (`E_NOT_YET_IMPLEMENTED`). The intended encoding is described below.
+
+<!-- doctest: skip -->
 ```hew
 wire enum Status { Pending; Active; Completed; }
 
@@ -4298,7 +4325,9 @@ Hew uses an **M:N work-stealing scheduler** inspired by Go, Tokio, and BEAM:
 
 The actor state machine governs the lifecycle of an actor instance within the runtime scheduler. This is distinct from the **task state machine** (§4.1), which governs individual tasks spawned within an actor.
 
-**Actor states:** `Idle(0)`, `Runnable(1)`, `Running(2)`, `Stopping(3)`, `Stopped(4)`, `Crashed(5)`
+**Actor states** (discriminants match `HewActorState` in `hew-runtime/src/internal/types.rs`):
+
+`Idle(0)`, `Runnable(1)`, `Running(2)`, `Suspended(3)`, `Stopping(4)`, `Crashed(5)`, `Stopped(6)`, `Sleeping(7)`, `Crashing(8)`
 
 **Transitions:**
 
@@ -4307,22 +4336,29 @@ The actor state machine governs the lifecycle of an actor instance within the ru
 Idle ──────► Runnable       message arrives in mailbox or timer fires
 Runnable ──► Running        scheduler picks actor for execution on a worker thread
 Running ───► Idle           message budget exhausted or no more messages; yields to scheduler
+Running ───► Suspended      dispatch suspends at a non-final coro.suspend (slice-4 executor)
+Suspended ─► Running        readiness source fires; executor resumes the continuation
 Running ───► Stopping       supervisor requests shutdown, or actor calls stop()
+Running ───► Sleeping       actor parks in the cooperative WASM sleep queue
+Sleeping ──► Runnable       sleep timer fires
 Stopping ──► Stopped        cleanup finished, normal exit
-Running/Idle/Stopping ──► Crashed   unrecoverable trap occurs
+Running/Idle/Stopping ──► Crashing   unrecoverable trap caught; per-activation cleanup pending
+Crashing ──► Crashed        cleanup complete; terminal state published via hew_actor_trap
 Crashed ───► Stopped        crash finalized, supervisor notified
 ```
 
-Actors start `Idle` after spawn. There is no separate `Blocked` state — actors waiting for messages are simply `Idle` and become `Runnable` when a message arrives.
+Actors start `Idle` after spawn. There is no separate `Blocked` state — actors waiting
+for messages are `Idle` (or `Suspended` during a cooperative suspension) and become
+`Runnable` when a message arrives.
 
 **Key distinctions from task states (§4.1):**
 
-| Aspect          | Actor State Machine                            | Task State Machine (§4.1)                     |
-| --------------- | ---------------------------------------------- | --------------------------------------------- |
-| **Entity**      | Entire actor instance                          | Individual task within an actor               |
-| **Managed by**  | Runtime scheduler (Level 1)                    | Actor-local coroutine executor (Level 2)      |
-| **States**      | Idle/Runnable/Running/Stopping/Stopped/Crashed | Pending/Running/Completed/Cancelled/Trapped   |
-| **Granularity** | One per actor                                  | Many per actor (one per `fork` child)         |
+| Aspect          | Actor State Machine                                                        | Task State Machine (§4.1)                     |
+| --------------- | -------------------------------------------------------------------------- | --------------------------------------------- |
+| **Entity**      | Entire actor instance                                                      | Individual task within an actor               |
+| **Managed by**  | Runtime scheduler (Level 1)                                                | Actor-local coroutine executor (Level 2)      |
+| **States**      | Idle/Runnable/Running/Suspended/Stopping/Crashing/Crashed/Stopped/Sleeping | Pending/Running/Completed/Cancelled/Trapped   |
+| **Granularity** | One per actor                                                              | Many per actor (one per `fork` child)         |
 
 Supervisor observes actor terminal states `Stopped` or `Crashed`.
 

--- a/scripts/doc-test-expected-failures.txt
+++ b/scripts/doc-test-expected-failures.txt
@@ -37,8 +37,10 @@
 #             pool reserved-word clash, or a checker-boundary HIR error.
 #             Fix: compiler follow-on; annotate fence for now.
 #
-# Baseline: 132 pass, 108 fail, 1 skip (NYI-annotated) out of 241 total fences.
-# Recorded against docs/ @ HEAD on 2026-06-19.
+# Baseline: 135 pass, 94 fail, 12 skip (NYI/skip-annotated) out of 241 total fences.
+# Updated 2026-06-22: fixed spec-0033/0038/0073 (now PASS) and annotated
+# spec-0048/0049/0051/0052/0066/0067/0069/0070/0097/0099/0113 (now SKIP).
+# Recorded against docs/ @ f16718d2 on 2026-06-22.
 #
 # ─── Guide failures (1) ─────────────────────────────────────────────────────────
 
@@ -70,20 +72,14 @@ spec-0026   # SNIPPET: bare code after import statement — illustration of impo
 spec-0027   # FRAGMENT: imports `greeting` — multi-file example, module not found
 spec-0030   # SNIPPET: bare code outside declarations — trait method dispatch illustration
 spec-0031   # SNIPPET: bare `let` + trait call — trait dispatch illustration
-spec-0033   # SPEC-BUG: `impl Display` uses `display` method name; impl requires `fmt`
 spec-0034   # IMPL-GAP: field-access result type failed checker-boundary conversion (E_HIR)
 spec-0035   # SNIPPET: bare `let` — type inference illustration
 spec-0037   # SPEC-BUG: calls `clone()` on unconstrained `T` — planned trait bound
-spec-0038   # SPEC-BUG: calls `File::open` — not in stdlib
 spec-0039   # SNIPPET: bare `receive fn` outside actor — actor message illustration
 spec-0044   # SNIPPET: bare `let f = |...| ...` — lambda illustration
 spec-0045   # SPEC-BUG: references variant `Lit` not defined in the fence
 spec-0046   # SNIPPET: bare `let` — fn-type variable illustration
-spec-0048   # SPEC-BUG: calls `File::open` — not in stdlib
-spec-0049   # SPEC-BUG: calls `File::open` — not in stdlib
 spec-0050   # SPEC-BUG: struct `impl` using wrong syntax form (stray `;` before `fn`)
-spec-0051   # SPEC-BUG: calls `begin_transaction()` — aspirational API
-spec-0052   # SPEC-BUG: calls `begin_transaction()` — aspirational API
 spec-0053   # SNIPPET: bare identifier `max` after trait definition — illustration
 spec-0054   # SPEC-BUG: calls `clone()` on unconstrained `T` — planned trait bound
 spec-0055   # SPEC-BUG: type mismatch in aspirational HashMap construction
@@ -94,13 +90,8 @@ spec-0061   # SNIPPET: bare `let f: fn(i64) -> i64 = ...` — fn-type illustrati
 spec-0062   # SNIPPET: bare code — trait implementation illustration
 spec-0063   # SNIPPET: bare `let` — generic function call illustration
 spec-0065   # SNIPPET: bare `let` — generic function illustration
-spec-0066   # SPEC-BUG: uses `..` rest pattern in struct destructure — not yet supported
-spec-0067   # SPEC-BUG: `#[repr(C)]` attribute on struct — not yet recognised
 spec-0068   # SPEC-BUG: struct `impl` using incorrect syntax (stray `;` before `fn`)
-spec-0069   # SPEC-BUG: calls `malloc` — no `malloc` builtin in Hew
-spec-0070   # SPEC-BUG: raw pointer type without `const`/`mut` qualifier — aspirational
 spec-0072   # SPEC-BUG: enum variants separated by `,` not `;` — illustrates wrong syntax
-spec-0073   # SPEC-BUG: uses `..` rest pattern in struct literal — not yet supported
 spec-0074   # SPEC-BUG: malformed struct `impl` syntax — aspirational
 spec-0075   # SNIPPET: bare `var` — machine state body illustration
 spec-0076   # SNIPPET: bare `let`/`var` — machine state illustration
@@ -124,9 +115,7 @@ spec-0093   # SNIPPET: bare `receive fn` — actor + scope illustration
 spec-0094   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
 spec-0095   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
 spec-0096   # NYI: bare `scope { ... }` — structured concurrency not yet lowered
-spec-0097   # SPEC-BUG: calls `fs::open` — not in stdlib
 spec-0098   # SNIPPET: bare `let` — async I/O illustration
-spec-0099   # SPEC-BUG: uses `&value` expression — Hew has no reference/borrow expression
 spec-0100   # FRAGMENT: calls `process()` — undefined function from prior context
 spec-0101   # NYI: bare `select { ... }` — select statement not yet implemented
 spec-0102   # SNIPPET: bare `let` — select illustration
@@ -138,7 +127,6 @@ spec-0107   # IMPL-GAP: `pool` as pattern — reserved word clash in supervisor 
 spec-0109   # FRAGMENT: references `prices` from prior fence context — context-dependent
 spec-0110   # SNIPPET: bare `let` — wire schema illustration
 spec-0111   # SNIPPET: bare `match` — wire format pattern illustration
-spec-0113   # IMPL-GAP: E_NOT_YET_IMPLEMENTED — top-level-item not yet supported
 spec-0119   # IMPL-GAP: E_NOT_YET_IMPLEMENTED — top-level-item not yet supported
 spec-0120   # IMPL-GAP: E_NOT_YET_IMPLEMENTED — top-level-item not yet supported
 spec-0121   # SNIPPET: bare `let` — distribution illustration


### PR DESCRIPTION
## Summary

Seven spec/doc drift points are corrected to match the implementation: `Display` uses `fmt` (not `display`); the RAII section uses `#[resource]` / `close()` (there is no `File` type; `impl Drop` is rejected); single-trait `dyn` dispatch is documented as working; `this` is live in actor handler bodies; the parameterised generator forms that ship are no longer marked deferred; and the actor lifecycle state names match the runtime enum. The doc-fence SPEC-BUG baseline drops from 108 to 94: three fences now compile clean, and the remaining failing fences are skip-annotated with honest not-yet-implemented reasons.

## Verification

- `scripts/extract-doc-fences.sh`: 135 pass / 94 fail / 12 skip — ratchet PASS (baseline updated)
- Pre-push hook: `cargo fmt --check` passed
- No `.rs` or `.hew` source files touched; diff is docs and ratchet baseline only

## Out of scope

- `wire enum` and the `#[linear]` modifier are left documented as future work — both are confirmed not yet implemented (`wire enum` triggers `E_NOT_YET_IMPLEMENTED`; the `#[linear]` / `begin_transaction` pattern aborts at the type checker). These are spec-ahead items, not drift, and are not downgraded.
