### PR TITLE
feat(generics): monomorphization-keyed clone/drop synthesis for generic records

### DIFF
--- a/hew-cli/tests/record_clone_generic_leak_oracle.rs
+++ b/hew-cli/tests/record_clone_generic_leak_oracle.rs
@@ -1,0 +1,552 @@
+//! Drop-safety oracle for GENERIC record clone (`clone Pair<i64, i64>` and
+//! owned-field instantiations). Pins R1 of the G6 lane: a per-mono clone thunk
+//! synthesised WITHOUT its matching per-mono drop thunk is a leak (and, with a
+//! shallow byte-copy, a double-free). The codegen synthesis loop emits the
+//! clone AND drop body together per monomorphised key
+//! (`emit_state_clone_drop_synthesis`), and the clone site is seeded from the
+//! raw-MIR `RecordCloneInplace` walk (`collect_record_clone_inplace_seeds`);
+//! this oracle proves that pair is balanced at runtime.
+//!
+//! ## Methodology: differential against a NO-CLONE construction control
+//!
+//! macOS `leaks --atExit` treats a pointer still sitting in a function-scope
+//! `alloca` at process exit as REACHABLE and does not flag it. Each fixture
+//! therefore allocates in a HELPER fn that returns an `i64`, run in a loop: the
+//! stack slot is reused every iteration, so a leaked clone buffer becomes
+//! genuinely unreachable and `leaks` counts it (the shape Valgrind flags).
+//!
+//! The clone fixture is measured against a control that performs the IDENTICAL
+//! record CONSTRUCTION but performs NO clone. Constructing an owned record from
+//! a fresh string producer (`seed + "-a"` into a field) has a pre-existing,
+//! clone-independent leak (it reproduces with zero `clone` in the program — see
+//! the `construct-only` shape in the lane notes), so the control absorbs that
+//! floor. The DIFFERENCE between fixture and control is exactly the clone's
+//! deep-copied buffers and their matching drop. A balanced clone/drop pair
+//! leaves the fixture at the control's floor; a missing per-mono drop (the R1
+//! asymmetry) puts the fixture `ITERATIONS * fields-per-clone` nodes above it.
+//! This is the floor-equality assertion the `assert-distinguishes-garbage`
+//! rule calls for, not a happy-path `> 0`.
+//!
+//! ## Skip behaviour
+//!
+//! `leaks(1)` is Darwin's allocator inspector; on non-macOS hosts the leak
+//! probes log `skip:` and return. The `MallocScribble` no-double-free pin runs
+//! on any unix host.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+/// Loop iterations each fixture's helper-fn is called. Each iteration's clone
+/// buffers become unreachable when the helper returns (stack-slot reuse), the
+/// shape `leaks` detects. Picked well above the jitter tolerance so a regression
+/// of even a few un-dropped clone buffers is unambiguous.
+const ITERATIONS: usize = 64;
+
+/// Permitted leak-node delta between a clone fixture and its no-clone control.
+/// A missing per-mono drop puts the fixture `>= ITERATIONS` nodes above the
+/// control; the tolerance of 2 absorbs the +/-1 runtime one-off jitter the
+/// sibling oracles document while staying far below `ITERATIONS`.
+const FLOOR_TOLERANCE: usize = 2;
+
+// -- fixtures ----------------------------------------------------------------
+
+/// Control: construct an owned `Pair<string, string>` in a helper, NO clone.
+/// Establishes the construction floor (the clone-independent fresh-producer
+/// leak the fixture also incurs).
+fn control_flat_source() -> String {
+    format!(
+        "\
+type Pair<A, B> {{ a: A; b: B; }}
+
+fn build(seed: string) -> i64 {{
+    let p = Pair {{ a: seed + \"-a\", b: seed + \"-b\" }};
+    p.a.len() + p.b.len()
+}}
+
+fn main() -> i64 {{
+    var total: i64 = 0;
+    for i in 0..{ITERATIONS} {{
+        total = total + build(\"seed\");
+    }}
+    if total != {expected} {{ return 70; }}
+    0
+}}
+",
+        expected = ITERATIONS * 12
+    )
+}
+
+/// Fixture: construct + `clone` an owned `Pair<string, string>`, using BOTH the
+/// original and the clone (so neither is elided) and dropping both at helper
+/// exit. The clone deep-copies two heap strings; its matching per-mono drop must
+/// free them. Against `control_flat_source` the clone must add no leak.
+fn fixture_flat_source() -> String {
+    format!(
+        "\
+type Pair<A, B> {{ a: A; b: B; }}
+
+fn build(seed: string) -> i64 {{
+    let p = Pair {{ a: seed + \"-a\", b: seed + \"-b\" }};
+    let q = clone p;
+    q.a.len() + q.b.len() + p.a.len() + p.b.len()
+}}
+
+fn main() -> i64 {{
+    var total: i64 = 0;
+    for i in 0..{ITERATIONS} {{
+        total = total + build(\"seed\");
+    }}
+    if total != {expected} {{ return 71; }}
+    0
+}}
+",
+        expected = ITERATIONS * 24
+    )
+}
+
+/// Control: construct a NESTED owned `Pair<Pair<string, string>, string>`, no clone.
+fn control_nested_source() -> String {
+    format!(
+        "\
+type Pair<A, B> {{ a: A; b: B; }}
+
+fn build(seed: string) -> i64 {{
+    let inner = Pair {{ a: seed + \"-a\", b: seed + \"-b\" }};
+    let p = Pair {{ a: inner, b: seed + \"-c\" }};
+    p.a.a.len() + p.a.b.len() + p.b.len()
+}}
+
+fn main() -> i64 {{
+    var total: i64 = 0;
+    for i in 0..{ITERATIONS} {{
+        total = total + build(\"seed\");
+    }}
+    if total != {expected} {{ return 72; }}
+    0
+}}
+",
+        expected = ITERATIONS * 18
+    )
+}
+
+/// Fixture: construct + `clone` the nested record. The clone must deep-copy the
+/// inner record AND all three heap strings, and the per-mono drop of the nested
+/// instantiation must free every cloned buffer transitively.
+fn fixture_nested_source() -> String {
+    format!(
+        "\
+type Pair<A, B> {{ a: A; b: B; }}
+
+fn build(seed: string) -> i64 {{
+    let inner = Pair {{ a: seed + \"-a\", b: seed + \"-b\" }};
+    let p = Pair {{ a: inner, b: seed + \"-c\" }};
+    let q = clone p;
+    q.a.a.len() + q.a.b.len() + q.b.len() + p.a.a.len() + p.a.b.len() + p.b.len()
+}}
+
+fn main() -> i64 {{
+    var total: i64 = 0;
+    for i in 0..{ITERATIONS} {{
+        total = total + build(\"seed\");
+    }}
+    if total != {expected} {{ return 73; }}
+    0
+}}
+",
+        expected = ITERATIONS * 36
+    )
+}
+
+/// Control: construct BOTH a `Pair<i64, i64>` and a `Pair<string, string>` in
+/// one helper, no clone. Pins that the per-mono keying does not cross-wire two
+/// instantiations of the same generic record.
+fn control_multi_source() -> String {
+    format!(
+        "\
+type Pair<A, B> {{ a: A; b: B; }}
+
+fn build(seed: string) -> i64 {{
+    let nums = Pair {{ a: 1, b: 2 }};
+    let strs = Pair {{ a: seed + \"-a\", b: seed + \"-b\" }};
+    nums.a + nums.b + strs.a.len() + strs.b.len()
+}}
+
+fn main() -> i64 {{
+    var total: i64 = 0;
+    for i in 0..{ITERATIONS} {{
+        total = total + build(\"seed\");
+    }}
+    if total != {expected} {{ return 74; }}
+    0
+}}
+",
+        expected = ITERATIONS * 15
+    )
+}
+
+/// Fixture: clone BOTH instantiations. The scalar `Pair$$i64$i64` clone is a
+/// trivial (no-heap) copy; the `Pair$$string$string` clone deep-copies two heap
+/// strings. Each instantiation must resolve its OWN per-mono clone/drop pair.
+fn fixture_multi_source() -> String {
+    format!(
+        "\
+type Pair<A, B> {{ a: A; b: B; }}
+
+fn build(seed: string) -> i64 {{
+    let nums = Pair {{ a: 1, b: 2 }};
+    let strs = Pair {{ a: seed + \"-a\", b: seed + \"-b\" }};
+    let nums2 = clone nums;
+    let strs2 = clone strs;
+    nums2.a + nums2.b + strs2.a.len() + strs2.b.len()
+        + nums.a + nums.b + strs.a.len() + strs.b.len()
+}}
+
+fn main() -> i64 {{
+    var total: i64 = 0;
+    for i in 0..{ITERATIONS} {{
+        total = total + build(\"seed\");
+    }}
+    if total != {expected} {{ return 75; }}
+    0
+}}
+",
+        expected = ITERATIONS * 30
+    )
+}
+
+/// Control: an actor holds a generic `Pair<i64, string>` in a state field by
+/// MOVE (`held = p`), no clone. Each loop iteration spawns the actor, stores,
+/// and lets it go out of scope so the runtime shuts it down and drops the state
+/// field. Establishes the actor-shutdown floor: the runtime-concat string
+/// (`tag + "-held"`) carries the same clone-independent fresh-producer leak the
+/// flat fixtures document, present here with ZERO clone.
+fn control_actor_source() -> String {
+    format!(
+        "\
+type Pair<A, B> {{ a: A; b: B; }}
+
+actor Keeper {{
+    var held: Pair<i64, string> = Pair {{ a: 0, b: \"none\" }};
+    receive fn store(n: i64, tag: string) -> i64 {{
+        let s2 = tag + \"-held\";
+        let p = Pair {{ a: n, b: s2 }};
+        held = p;
+        return held.a;
+    }}
+}}
+
+fn main() -> i64 {{
+    var total: i64 = 0;
+    for i in 0..{ITERATIONS} {{
+        let k = spawn Keeper();
+        let base = \"row\";
+        let tag = base + \"-x\";
+        match await k.store(i, tag) {{
+            Ok(n) => {{ total = total + n; }}
+            Err(_) => {{ return 80; }}
+        }}
+    }}
+    if total != {expected} {{ return 81; }}
+    0
+}}
+",
+        expected = ITERATIONS * (ITERATIONS - 1) / 2
+    )
+}
+
+/// Fixture: the actor stores its state field by `clone` (`held = clone p`). The
+/// per-mono clone of `Pair$$i64$string` deep-copies the heap string; its matching
+/// per-mono DROP must fire when the actor shuts down and the state field is
+/// released. This is R1's actor-shutdown path (the lifecycle tests forget): a
+/// clone synthesised without its paired drop puts the fixture `>= ITERATIONS`
+/// nodes above the move control. Against `control_actor_source` the clone must
+/// add no leak beyond the construction floor.
+fn fixture_actor_source() -> String {
+    format!(
+        "\
+type Pair<A, B> {{ a: A; b: B; }}
+
+actor Keeper {{
+    var held: Pair<i64, string> = Pair {{ a: 0, b: \"none\" }};
+    receive fn store(n: i64, tag: string) -> i64 {{
+        let s2 = tag + \"-held\";
+        let p = Pair {{ a: n, b: s2 }};
+        held = clone p;
+        return held.a;
+    }}
+}}
+
+fn main() -> i64 {{
+    var total: i64 = 0;
+    for i in 0..{ITERATIONS} {{
+        let k = spawn Keeper();
+        let base = \"row\";
+        let tag = base + \"-x\";
+        match await k.store(i, tag) {{
+            Ok(n) => {{ total = total + n; }}
+            Err(_) => {{ return 80; }}
+        }}
+    }}
+    if total != {expected} {{ return 81; }}
+    0
+}}
+",
+        expected = ITERATIONS * (ITERATIONS - 1) / 2
+    )
+}
+
+/// No-double-free pin: clone an owned `Pair<string, string>`, read fields from
+/// BOTH the original and the clone, and let both drop in one frame. If the clone
+/// shallow-copied (aliased) the string buffers instead of deep-copying, dropping
+/// both originals and clone would double-free the shared buffers and crash under
+/// the poisoned-allocator triple before the sentinel prints. Runs on any unix.
+const NO_DOUBLE_FREE_SOURCE: &str = "\
+type Pair<A, B> { a: A; b: B; }
+
+fn main() {
+    let p = Pair { a: \"alpha\", b: \"beta\" };
+    let q = clone p;
+    let sum = p.a.len() + p.b.len() + q.a.len() + q.b.len();
+    print(sum);
+    print(\"OK\");
+}
+";
+
+// -- leak measurement plumbing (shape shared with the sibling oracles) -------
+
+fn compile_to_native(source: &str, dir: &std::path::Path, name: &str) -> PathBuf {
+    let hew_src = dir.join(format!("{name}.hew"));
+    std::fs::write(&hew_src, source).expect("write hew source");
+
+    let output = Command::new(hew_binary())
+        .args([
+            "compile",
+            "--emit-dir",
+            dir.to_str().expect("emit-dir utf-8"),
+            hew_src.to_str().expect("hew src utf-8"),
+        ])
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew compile");
+
+    assert!(
+        output.status.success(),
+        "hew compile failed for {name}:\n{}",
+        describe_output(&output)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let bin = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("native: "))
+        .unwrap_or_else(|| panic!("no `native:` line for {name}:\n{stdout}"))
+        .to_string();
+    PathBuf::from(bin)
+}
+
+/// Run `bin` under the poisoned-allocator triple + `leaks --atExit` and return
+/// `Some(leak_count)` when `leaks` produced a usable report.
+fn measure_leaks(bin: &std::path::Path) -> Option<usize> {
+    let output = Command::new("leaks")
+        .arg("--atExit")
+        .arg("--")
+        .arg(bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .ok()?;
+    if !output.status.success() && output.stdout.is_empty() {
+        eprintln!(
+            "skip: leaks declined to attach to {}: {}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+    let report = String::from_utf8_lossy(&output.stdout);
+    let mut parsed: Option<usize> = None;
+    for line in report.lines() {
+        if !line.contains(" leaks for ") && !line.contains(" leak for ") {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("Process ") {
+            if !rest.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+                continue;
+            }
+            if let Some(after_colon) = rest.split_once(": ").map(|(_, s)| s) {
+                if let Some(n) = after_colon.split_whitespace().next() {
+                    if let Ok(n) = n.parse::<usize>() {
+                        eprintln!("  parsed leak count from line: {line}");
+                        parsed = Some(n);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    if parsed.is_none() {
+        eprintln!(
+            "skip: leaks did not emit a `Process <pid>: N leak(s) for B total leaked bytes.` \
+             summary for {}: stderr=\n{}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    parsed
+}
+
+/// macOS + `leaks(1)` availability guard shared by every leak probe.
+fn leaks_available(shape_name: &str) -> bool {
+    if !cfg!(target_os = "macos") {
+        eprintln!("skip: {shape_name}: leaks(1) is macOS-only");
+        return false;
+    }
+    let avail = Command::new("which")
+        .arg("leaks")
+        .output()
+        .is_ok_and(|o| o.status.success());
+    if !avail {
+        eprintln!("skip: {shape_name}: `leaks` binary not on PATH");
+    }
+    avail
+}
+
+/// Compile + measure `fixture` (construct + clone) against `control` (the same
+/// construction with no clone) and assert the clone added no leak beyond the
+/// construction floor (within `FLOOR_TOLERANCE`). A missing per-mono drop puts
+/// the fixture `>= ITERATIONS` nodes above the control.
+fn assert_clone_adds_no_leak(shape_name: &str, control_source: &str, fixture_source: &str) {
+    if !leaks_available(shape_name) {
+        return;
+    }
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("record-clone-leak-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+
+    let control_bin = compile_to_native(control_source, dir.path(), "control");
+    let fixture_bin = compile_to_native(fixture_source, dir.path(), shape_name);
+
+    let Some(control_leaks) = measure_leaks(&control_bin) else {
+        return;
+    };
+    let Some(fixture_leaks) = measure_leaks(&fixture_bin) else {
+        return;
+    };
+
+    eprintln!(
+        "{shape_name}: control_leaks={control_leaks} fixture_leaks={fixture_leaks} \
+         tolerance={FLOOR_TOLERANCE} iterations={ITERATIONS}"
+    );
+    assert!(
+        fixture_leaks <= control_leaks + FLOOR_TOLERANCE,
+        "{shape_name}: generic record clone DROP LEAK -- the clone fixture leaked \
+         {fixture_leaks} nodes against the no-clone construction control's floor of \
+         {control_leaks} (tolerance {FLOOR_TOLERANCE}). An excess of {} nodes means a per-mono \
+         clone thunk was synthesised WITHOUT its matching per-mono drop (R1 asymmetry): the \
+         clone's deep-copied buffers are never freed. The fix is the clone/drop thunk PAIR \
+         emitted together per key in `emit_state_clone_drop_synthesis`, seeded by \
+         `collect_record_clone_inplace_seeds` (hew-codegen-rs/src/llvm.rs). Re-run with \
+         `MallocStackLogging=1 leaks --atExit -- {}` to see the leaked stack.",
+        fixture_leaks.saturating_sub(control_leaks + FLOOR_TOLERANCE),
+        fixture_bin.display()
+    );
+}
+
+// -- oracles -----------------------------------------------------------------
+
+/// Flat `clone Pair<string, string>`: the per-mono clone deep-copies two heap
+/// strings and the matching drop frees them. Reverting the clone-seed collector
+/// makes this fail to COMPILE; dropping the per-mono drop (R1) fails it by
+/// `>= ITERATIONS` leaked nodes.
+#[test]
+fn generic_record_clone_flat_no_drop_leak() {
+    assert_clone_adds_no_leak("clone_flat", &control_flat_source(), &fixture_flat_source());
+}
+
+/// Nested `clone Pair<Pair<string, string>, string>`: the clone must recurse
+/// into the inner record and free every transitively cloned buffer.
+#[test]
+fn generic_record_clone_nested_no_drop_leak() {
+    assert_clone_adds_no_leak(
+        "clone_nested",
+        &control_nested_source(),
+        &fixture_nested_source(),
+    );
+}
+
+/// Two instantiations of the same generic record cloned in one frame. Pins that
+/// per-mono keying gives each its own balanced clone/drop pair (the scalar
+/// `Pair$$i64$i64` and the owned `Pair$$string$string`).
+#[test]
+fn generic_record_clone_multi_instantiation_no_drop_leak() {
+    assert_clone_adds_no_leak(
+        "clone_multi",
+        &control_multi_source(),
+        &fixture_multi_source(),
+    );
+}
+
+/// Actor-shutdown path (R1's headline hazard): a generic aggregate cloned into
+/// an actor STATE field must have its per-mono drop fire when the actor shuts
+/// down. Each iteration spawns + drives + drops a `Keeper` holding a cloned
+/// `Pair$$i64$string`; against the MOVE control (same construction, no clone)
+/// the clone must add no leak. A per-mono clone synthesised without its paired
+/// drop on the shutdown path leaks `>= ITERATIONS` heap strings here — the
+/// silent unwind UAF/leak the sync oracles cannot reach.
+#[test]
+fn generic_record_clone_actor_shutdown_no_drop_leak() {
+    assert_clone_adds_no_leak(
+        "clone_actor",
+        &control_actor_source(),
+        &fixture_actor_source(),
+    );
+}
+
+/// No-double-free pin: the clone must DEEP-COPY, not alias, the string buffers,
+/// and the clone + original must each drop exactly once. A shallow-copy alias
+/// would double-free under the poisoned-allocator triple before the sentinel
+/// prints. Runs on any unix.
+#[test]
+fn generic_record_clone_release_is_exactly_once_under_malloc_scribble() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("record-clone-no-double-free-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(NO_DOUBLE_FREE_SOURCE, dir.path(), "no_double_free");
+
+    let output = Command::new(&bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .expect("run no-double-free binary");
+
+    assert!(
+        output.status.success(),
+        "generic record clone release must run exactly once -- a crash here indicates the clone \
+         aliased the string buffers (shallow copy) and dropping both the original and the clone \
+         double-freed them;\n{}",
+        describe_output(&output)
+    );
+    // p.a("alpha"=5) + p.b("beta"=4) + q.a(5) + q.b(4) = 18, then the `OK` sentinel.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        "18OK",
+        "output must be untouched -- a scribbled value indicates an over-drop corrupted a live \
+         string;\n{}",
+        describe_output(&output)
+    );
+}

--- a/hew-cli/tests/record_clone_generic_leak_oracle.rs
+++ b/hew-cli/tests/record_clone_generic_leak_oracle.rs
@@ -1,5 +1,5 @@
 //! Drop-safety oracle for GENERIC record clone (`clone Pair<i64, i64>` and
-//! owned-field instantiations). Pins R1 of the G6 lane: a per-mono clone thunk
+//! owned-field instantiations). A per-mono clone thunk
 //! synthesised WITHOUT its matching per-mono drop thunk is a leak (and, with a
 //! shallow byte-copy, a double-free). The codegen synthesis loop emits the
 //! clone AND drop body together per monomorphised key
@@ -18,12 +18,12 @@
 //! The clone fixture is measured against a control that performs the IDENTICAL
 //! record CONSTRUCTION but performs NO clone. Constructing an owned record from
 //! a fresh string producer (`seed + "-a"` into a field) has a pre-existing,
-//! clone-independent leak (it reproduces with zero `clone` in the program — see
-//! the `construct-only` shape in the lane notes), so the control absorbs that
+//! clone-independent leak (it reproduces with zero `clone` in the program —
+//! the `construct-only` control fixtures in this file confirm), so the control absorbs that
 //! floor. The DIFFERENCE between fixture and control is exactly the clone's
 //! deep-copied buffers and their matching drop. A balanced clone/drop pair
-//! leaves the fixture at the control's floor; a missing per-mono drop (the R1
-//! asymmetry) puts the fixture `ITERATIONS * fields-per-clone` nodes above it.
+//! leaves the fixture at the control's floor; a missing per-mono drop puts the
+//! fixture `ITERATIONS * fields-per-clone` nodes above it.
 //! This is the floor-equality assertion the `assert-distinguishes-garbage`
 //! rule calls for, not a happy-path `> 0`.
 //!
@@ -263,10 +263,9 @@ fn main() -> i64 {{
 /// Fixture: the actor stores its state field by `clone` (`held = clone p`). The
 /// per-mono clone of `Pair$$i64$string` deep-copies the heap string; its matching
 /// per-mono DROP must fire when the actor shuts down and the state field is
-/// released. This is R1's actor-shutdown path (the lifecycle tests forget): a
-/// clone synthesised without its paired drop puts the fixture `>= ITERATIONS`
-/// nodes above the move control. Against `control_actor_source` the clone must
-/// add no leak beyond the construction floor.
+/// released. A clone synthesised without its paired drop puts the fixture
+/// `>= ITERATIONS` nodes above the move control. Against `control_actor_source`
+/// the clone must add no leak beyond the construction floor.
 fn fixture_actor_source() -> String {
     format!(
         "\
@@ -466,7 +465,7 @@ fn assert_clone_adds_no_leak(shape_name: &str, control_source: &str, fixture_sou
 
 /// Flat `clone Pair<string, string>`: the per-mono clone deep-copies two heap
 /// strings and the matching drop frees them. Reverting the clone-seed collector
-/// makes this fail to COMPILE; dropping the per-mono drop (R1) fails it by
+/// makes this fail to COMPILE; omitting the per-mono drop fails it by
 /// `>= ITERATIONS` leaked nodes.
 #[test]
 fn generic_record_clone_flat_no_drop_leak() {
@@ -496,7 +495,7 @@ fn generic_record_clone_multi_instantiation_no_drop_leak() {
     );
 }
 
-/// Actor-shutdown path (R1's headline hazard): a generic aggregate cloned into
+/// Actor-shutdown path for clone/drop symmetry: a generic aggregate cloned into
 /// an actor STATE field must have its per-mono drop fire when the actor shuts
 /// down. Each iteration spawns + drives + drops a `Keeper` holding a cloned
 /// `Pair$$i64$string`; against the MOVE control (same construction, no clone)

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -32298,7 +32298,7 @@ fn build_module_for_target<'ctx>(
     // which the bare-name `user_clone_record_seeds` above does not cover and
     // which the `RecordInPlace` drop twin only covers when the record has a
     // non-trivial drop. Seed the clone site directly so the per-mono clone/drop
-    // thunk pair is synthesised together (R1: no clone without its drop).
+    // thunk pair is synthesised together (clone/drop always emitted as a unit per key).
     for seed in collect_record_clone_inplace_seeds(&pipeline.raw_mir, &pipeline.record_layouts) {
         if !vec_owned_record_seeds.contains(&seed) {
             vec_owned_record_seeds.push(seed);

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -8997,6 +8997,57 @@ fn collect_record_inplace_drop_seeds(
     seeds
 }
 
+/// Collect the monomorphised record layout key of every `RecordCloneInplace`
+/// instruction in raw MIR so its `__hew_record_clone_inplace_<key>` /
+/// `__hew_record_drop_inplace_<key>` thunk PAIR is synthesised by
+/// `emit_state_clone_drop_synthesis`.
+///
+/// `clone <record>` lowers to `RecordCloneInplace { record_name, .. }`, where
+/// `record_name` is the monomorphised layout key (the bare name for a
+/// monomorphic record, the mangled `Pair$$i64$i64` for a generic instantiation —
+/// see `user_record_layout_key` in hew-mir). A generic instantiation reaches
+/// the synthesis pass through NO other seed:
+///
+///  * `user_clone_record_seeds` (the checker-side clone seed) carries the bare
+///    declared name (`Pair`), which never matches the mangled layout key; and
+///  * the drop twin (`collect_record_inplace_drop_seeds`) only fires for a
+///    record with a non-trivial drop, so a generic record whose fields are all
+///    Copy (`Pair<i64, i64>`) is cloned but never drop-seeded.
+///
+/// Without this seed the generic clone thunk is declared-but-undefined and LLVM
+/// verify rejects the module. Seeding the clone site directly closes the gap;
+/// because the synthesis loop emits the clone AND drop body together per key,
+/// the thunk pair stays symmetric — there is no clone without its matching drop
+/// (the leak / double-free hazard on unwind).
+///
+/// A seed is registered only when `record_name` names a registered layout, so
+/// the key the synthesis pass emits a body under is exactly the key the clone
+/// call resolves; a `record_name` with no registered layout is left unseeded
+/// and fails closed loudly at LLVM verify rather than silently aliasing.
+fn collect_record_clone_inplace_seeds(
+    raw_mir: &[RawMirFunction],
+    record_layouts: &[RecordLayout],
+) -> Vec<String> {
+    let mut seeds: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for func in raw_mir {
+        for block in &func.blocks {
+            for instr in &block.instructions {
+                let Instr::RecordCloneInplace { record_name, .. } = instr else {
+                    continue;
+                };
+                if !record_layouts.iter().any(|rl| rl.name == *record_name) {
+                    continue;
+                }
+                if seen.insert(record_name.clone()) {
+                    seeds.push(record_name.clone());
+                }
+            }
+        }
+    }
+    seeds
+}
+
 /// D2 / W3.031 — collect the record/enum layout keys of every type that
 /// appears as a `dyn Trait` CONCRETE so its
 /// `__hew_{record,enum}_drop_inplace_<key>` body is synthesised before
@@ -32240,6 +32291,17 @@ fn build_module_for_target<'ctx>(
     for seed in &pipeline.user_clone_record_seeds {
         if !vec_owned_record_seeds.contains(seed) {
             vec_owned_record_seeds.push(seed.clone());
+        }
+    }
+    // Generic record-clone instantiations: `clone Pair<i64, i64>` lowers to a
+    // `RecordCloneInplace` keyed by the monomorphised layout (`Pair$$i64$i64`),
+    // which the bare-name `user_clone_record_seeds` above does not cover and
+    // which the `RecordInPlace` drop twin only covers when the record has a
+    // non-trivial drop. Seed the clone site directly so the per-mono clone/drop
+    // thunk pair is synthesised together (R1: no clone without its drop).
+    for seed in collect_record_clone_inplace_seeds(&pipeline.raw_mir, &pipeline.record_layouts) {
+        if !vec_owned_record_seeds.contains(&seed) {
+            vec_owned_record_seeds.push(seed);
         }
     }
     emit_state_clone_drop_synthesis(

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -11169,11 +11169,28 @@ impl Builder {
             } => {
                 let src_place = self.lower_value(src)?;
                 let record_ty = self.subst_ty(&expr.ty);
+                // Key the clone thunk by the MONOMORPHISED record layout: a
+                // generic instantiation (`clone Pair<i64, i64>`) must resolve
+                // `__hew_record_clone_inplace_Pair$$i64$i64`, not the bare
+                // `Pair` — the bare name names no monomorphic layout, so the
+                // call resolves a declared-but-undefined thunk that fails LLVM
+                // verify (the G6 / E2 bug). A monomorphic record keeps its bare
+                // declared name BYTE-IDENTICALLY via the `record_name.clone()`
+                // arm, so monomorphic goldens and behaviour are unchanged. The
+                // drop side already keys via the same `user_record_layout_key`
+                // helper (`record_inplace_drop_name`), so the clone/drop thunk
+                // PAIR stays symmetric per instantiation (R1).
+                let layout_name = match monomorphic_user_record_key(&record_ty) {
+                    Some(_) => record_name.clone(),
+                    None => {
+                        user_record_layout_key(&record_ty).unwrap_or_else(|| record_name.clone())
+                    }
+                };
                 let dest = self.alloc_local(record_ty);
                 self.instructions.push(Instr::RecordCloneInplace {
                     dest,
                     src: src_place,
-                    record_name: record_name.clone(),
+                    record_name: layout_name,
                 });
                 Some(dest)
             }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -11174,12 +11174,12 @@ impl Builder {
                 // `__hew_record_clone_inplace_Pair$$i64$i64`, not the bare
                 // `Pair` — the bare name names no monomorphic layout, so the
                 // call resolves a declared-but-undefined thunk that fails LLVM
-                // verify (the G6 / E2 bug). A monomorphic record keeps its bare
-                // declared name BYTE-IDENTICALLY via the `record_name.clone()`
-                // arm, so monomorphic goldens and behaviour are unchanged. The
-                // drop side already keys via the same `user_record_layout_key`
+                // verify. A monomorphic record keeps its bare declared name
+                // BYTE-IDENTICALLY via the `record_name.clone()` arm, so
+                // monomorphic goldens and behaviour are unchanged. The drop
+                // side already keys via the same `user_record_layout_key`
                 // helper (`record_inplace_drop_name`), so the clone/drop thunk
-                // PAIR stays symmetric per instantiation (R1).
+                // PAIR stays symmetric per instantiation.
                 let layout_name = match monomorphic_user_record_key(&record_ty) {
                     Some(_) => record_name.clone(),
                     None => {

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -2574,35 +2574,49 @@ impl Checker {
         // avoid importing hew-mir (wrong dependency direction). The authoritative
         // MIR-side `ty_contains_unclonable_opaque` is mirrored here at the checker
         // boundary; the two must agree but are structurally independent.
-        if let Some(opaque_name) =
-            self.record_field_contains_opaque(name, &mut std::collections::HashSet::new())
-        {
+        if let Some(opaque_name) = self.record_field_contains_opaque(
+            name,
+            type_args,
+            &mut std::collections::HashSet::new(),
+        ) {
             return RecordCloneAdmissibility::OpaqueField { opaque_name };
         }
         RecordCloneAdmissibility::Admissible
     }
 
-    /// Transitive walk of a record's fields looking for an opaque handle type.
-    /// Returns the first opaque field-type name found, or `None` if clean.
-    /// Uses `canonical_owned_handle_type_name` as the single opaque-detection
-    /// authority (mirrors `ty_contains_owned_handle` in `registration.rs`).
+    /// Transitive, substitution-aware walk of a (possibly generic) record's
+    /// fields looking for an opaque handle leaf. `type_args` are the concrete
+    /// arguments at the clone site; each field is instantiated with them before
+    /// recursing, so a concrete instantiation like `Box<Handle>` resolves its
+    /// `item: T` field to `item: Handle` and the opaque leaf is detected. A
+    /// monomorphic record passes `type_args = []`, so the substitution is a
+    /// no-op and behaviour is unchanged. Returns the first opaque field-type
+    /// name found, or `None` if clean. Uses `canonical_owned_handle_type_name`
+    /// as the single opaque-detection authority (mirrors `ty_contains_owned_handle`
+    /// in `registration.rs`); the substitution mirrors
+    /// `vec_element_contains_structural_array` (admissibility.rs).
     fn record_field_contains_opaque(
         &self,
         name: &str,
+        type_args: &[Ty],
         visiting: &mut std::collections::HashSet<String>,
     ) -> Option<String> {
         if !visiting.insert(name.to_string()) {
             return None; // cycle protection
         }
-        let type_def = self.type_defs.get(name)?;
-        for field_ty in type_def.fields.values() {
-            if let Some(opaque) = self.ty_field_contains_opaque(field_ty, visiting) {
-                visiting.remove(name);
-                return Some(opaque);
+        let mut found = None;
+        if let Some(type_def) = self.type_defs.get(name) {
+            for field_ty in type_def.fields.values() {
+                let field_ty =
+                    Self::instantiate_type_def_member(field_ty, &type_def.type_params, type_args);
+                if let Some(opaque) = self.ty_field_contains_opaque(&field_ty, visiting) {
+                    found = Some(opaque);
+                    break;
+                }
             }
         }
         visiting.remove(name);
-        None
+        found
     }
 
     fn ty_field_contains_opaque(
@@ -2610,7 +2624,11 @@ impl Checker {
         ty: &Ty,
         visiting: &mut std::collections::HashSet<String>,
     ) -> Option<String> {
-        match ty {
+        // Resolve inference vars so a field whose type is still a `Ty::Var`
+        // bound in the substitution environment is walked at its concrete type
+        // (mirrors `vec_element_contains_structural_array`).
+        let resolved = self.subst.resolve(ty);
+        match &resolved {
             Ty::Named { name, args, .. } => {
                 // Direct opaque handle (imported via module registry OR user-declared #[opaque])?
                 if self.canonical_owned_handle_type_name(name).is_some()
@@ -2618,14 +2636,15 @@ impl Checker {
                 {
                     return Some(name.clone());
                 }
-                // Recurse into type args.
+                // Recurse into type args (e.g. `Vec<Handle>`, `Option<Handle>`).
                 for arg in args {
                     if let Some(n) = self.ty_field_contains_opaque(arg, visiting) {
                         return Some(n);
                     }
                 }
-                // Recurse into the type def's fields.
-                if let Some(n) = self.record_field_contains_opaque(name, visiting) {
+                // Recurse into the type def's fields, substituting the def's
+                // params with the concrete `args` at this use site.
+                if let Some(n) = self.record_field_contains_opaque(name, args, visiting) {
                     return Some(n);
                 }
                 None

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -2397,7 +2397,15 @@ impl Checker {
                             },
                         );
                         // Seed for codegen's `emit_state_clone_drop_synthesis`.
-                        if !self.user_clone_record_seeds.contains(name) {
+                        // Bare-seed MONOMORPHIC records only: a generic
+                        // instantiation (`type_args` present) is keyed by its
+                        // monomorphised layout (`Pair$$i64$i64`) in MIR and
+                        // seeded from the `RecordCloneInplace` walk in codegen
+                        // (`collect_record_clone_inplace_seeds`). The bare name
+                        // names no monomorphic layout, so seeding it here would
+                        // register a dead key. This mirrors the MIR keying
+                        // (`monomorphic_user_record_key`, `args.is_empty()`).
+                        if type_args.is_empty() && !self.user_clone_record_seeds.contains(name) {
                             self.user_clone_record_seeds.push(name.clone());
                         }
                         return record_ty;
@@ -7508,7 +7516,13 @@ impl Checker {
                                         record_name: name.clone(),
                                     },
                                 );
-                                if !self.user_clone_record_seeds.contains(name) {
+                                // Bare-seed monomorphic records only; a generic
+                                // instantiation is MIR-keyed by its mono layout
+                                // and seeded from the `RecordCloneInplace` walk
+                                // in codegen (see the sibling clone intercept).
+                                if type_args.is_empty()
+                                    && !self.user_clone_record_seeds.contains(name)
+                                {
                                     self.user_clone_record_seeds.push(name.clone());
                                 }
                                 return resolved;

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -617,7 +617,7 @@ fn vec_contains_eq_eligibility_classifies_layout_elements() {
 
 #[test]
 fn generic_record_clone_concrete_instantiation_is_admissible() {
-    // V1 (unit): a generic record whose type params resolve to concrete,
+    // A generic record whose type params resolve to concrete,
     // clonable types is admissible — the per-mono clone thunk is synthesised
     // per instantiation.
     let mut checker = Checker::new(ModuleRegistry::new(vec![]));
@@ -662,10 +662,10 @@ fn generic_record_clone_concrete_instantiation_is_admissible() {
 
 #[test]
 fn generic_record_clone_opaque_instantiation_fails_closed() {
-    // V7 (unit): the opaque-leaf walk is substitution-aware. `Box<Handle>`
-    // instantiates the declared field `item: T` to `item: Handle` before
-    // checking, so the transitive opaque leaf is detected even though the
-    // declared field type is the abstract param `T`.
+    // The opaque-leaf walk is substitution-aware: `Box<Handle>` instantiates
+    // the declared field `item: T` to `item: Handle` before checking, so the
+    // transitive opaque leaf is detected even though the declared field type
+    // is the abstract param `T`.
     let mut checker = Checker::new(ModuleRegistry::new(vec![]));
     checker.user_opaque_type_names.insert("Handle".to_string());
     checker.type_defs.insert(
@@ -719,7 +719,7 @@ fn generic_record_clone_opaque_instantiation_fails_closed() {
 
 #[test]
 fn generic_record_clone_unresolved_var_is_nyi() {
-    // V9: an unresolved receiver (a generic record whose type args are still
+    // An unresolved receiver (a generic record whose type args are still
     // inference vars) keeps the `GenericRecord` NYI diagnostic; the
     // substitution-aware opaque walk must not regress this clean reject.
     let mut checker = Checker::new(ModuleRegistry::new(vec![]));

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -1,4 +1,5 @@
 use super::coerce::common_integer_type;
+use super::methods::RecordCloneAdmissibility;
 #[allow(
     clippy::wildcard_imports,
     reason = "submodules mirror the legacy check namespace during the split"
@@ -612,6 +613,154 @@ fn vec_contains_eq_eligibility_classifies_layout_elements() {
         ty_is_eq_eligible(&unknown, &checker.type_defs),
         EqEligibility::IneligibleUnknown
     );
+}
+
+#[test]
+fn generic_record_clone_concrete_instantiation_is_admissible() {
+    // V1 (unit): a generic record whose type params resolve to concrete,
+    // clonable types is admissible — the per-mono clone thunk is synthesised
+    // per instantiation.
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    checker.type_defs.insert(
+        "Pair".to_string(),
+        TypeDef {
+            kind: TypeDefKind::Record,
+            name: "Pair".to_string(),
+            type_params: vec!["A".to_string(), "B".to_string()],
+            bounds: HashMap::new(),
+            fields: HashMap::from([
+                (
+                    "a".to_string(),
+                    Ty::Named {
+                        name: "A".to_string(),
+                        args: vec![],
+                        builtin: None,
+                    },
+                ),
+                (
+                    "b".to_string(),
+                    Ty::Named {
+                        name: "B".to_string(),
+                        args: vec![],
+                        builtin: None,
+                    },
+                ),
+            ]),
+            variants: HashMap::new(),
+            methods: HashMap::new(),
+            doc_comment: None,
+            field_order: vec!["a".to_string(), "b".to_string()],
+            is_indirect: false,
+        },
+    );
+    let span = Span::from(0..0);
+    assert!(matches!(
+        checker.record_clone_admissibility("Pair", &[Ty::I64, Ty::I64], &span),
+        RecordCloneAdmissibility::Admissible
+    ));
+}
+
+#[test]
+fn generic_record_clone_opaque_instantiation_fails_closed() {
+    // V7 (unit): the opaque-leaf walk is substitution-aware. `Box<Handle>`
+    // instantiates the declared field `item: T` to `item: Handle` before
+    // checking, so the transitive opaque leaf is detected even though the
+    // declared field type is the abstract param `T`.
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    checker.user_opaque_type_names.insert("Handle".to_string());
+    checker.type_defs.insert(
+        "Handle".to_string(),
+        TypeDef {
+            kind: TypeDefKind::Struct,
+            name: "Handle".to_string(),
+            type_params: vec![],
+            bounds: HashMap::new(),
+            fields: HashMap::new(),
+            variants: HashMap::new(),
+            methods: HashMap::new(),
+            doc_comment: None,
+            field_order: vec![],
+            is_indirect: true,
+        },
+    );
+    checker.type_defs.insert(
+        "Box".to_string(),
+        TypeDef {
+            kind: TypeDefKind::Record,
+            name: "Box".to_string(),
+            type_params: vec!["T".to_string()],
+            bounds: HashMap::new(),
+            fields: HashMap::from([(
+                "item".to_string(),
+                Ty::Named {
+                    name: "T".to_string(),
+                    args: vec![],
+                    builtin: None,
+                },
+            )]),
+            variants: HashMap::new(),
+            methods: HashMap::new(),
+            doc_comment: None,
+            field_order: vec!["item".to_string()],
+            is_indirect: false,
+        },
+    );
+    let span = Span::from(0..0);
+    let handle = Ty::Named {
+        name: "Handle".to_string(),
+        args: vec![],
+        builtin: None,
+    };
+    assert!(matches!(
+        checker.record_clone_admissibility("Box", std::slice::from_ref(&handle), &span),
+        RecordCloneAdmissibility::OpaqueField { .. }
+    ));
+}
+
+#[test]
+fn generic_record_clone_unresolved_var_is_nyi() {
+    // V9: an unresolved receiver (a generic record whose type args are still
+    // inference vars) keeps the `GenericRecord` NYI diagnostic; the
+    // substitution-aware opaque walk must not regress this clean reject.
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    checker.type_defs.insert(
+        "Pair".to_string(),
+        TypeDef {
+            kind: TypeDefKind::Record,
+            name: "Pair".to_string(),
+            type_params: vec!["A".to_string(), "B".to_string()],
+            bounds: HashMap::new(),
+            fields: HashMap::from([
+                (
+                    "a".to_string(),
+                    Ty::Named {
+                        name: "A".to_string(),
+                        args: vec![],
+                        builtin: None,
+                    },
+                ),
+                (
+                    "b".to_string(),
+                    Ty::Named {
+                        name: "B".to_string(),
+                        args: vec![],
+                        builtin: None,
+                    },
+                ),
+            ]),
+            variants: HashMap::new(),
+            methods: HashMap::new(),
+            doc_comment: None,
+            field_order: vec!["a".to_string(), "b".to_string()],
+            is_indirect: false,
+        },
+    );
+    let span = Span::from(0..0);
+    let args = [Ty::Var(crate::ty::TypeVar(0)), Ty::I64];
+    assert!(matches!(
+        checker.record_clone_admissibility("Pair", &args, &span),
+        RecordCloneAdmissibility::GenericRecord
+    ));
 }
 
 #[test]

--- a/scripts/hew-suite-expected-failures.txt
+++ b/scripts/hew-suite-expected-failures.txt
@@ -11,15 +11,5 @@
 #
 # Format: <test_function_name>  # <root_cause>; converging lane: <lane>
 #
-# Total: 5 unique failing test function names.
+# Total: 1 unique failing test function name.
 test_generic_vec_iter_i64  # G5 split follow-on: Hew-level Vec<T>::iter substrate
-# G6 generic record clone (RED until the per-mono clone/drop synthesis lands in
-# the codegen slice of feat/v06-generic-record-clone). The clone of a generic
-# record instantiation resolves a declared-but-undefined
-# `__hew_record_clone_inplace_<R>` thunk and the module fails LLVM verify until
-# the thunk is synthesised per concrete instantiation. Delete these four lines
-# in the codegen slice when they flip green.
-test_generic_record_clone_scalar_independence  # G6: per-mono record clone synthesis; converging lane: G6
-test_generic_record_clone_string_field  # G6: per-mono record clone synthesis; converging lane: G6
-test_generic_record_clone_nested  # G6: per-mono record clone synthesis; converging lane: G6
-test_generic_record_clone_multi_instantiation  # G6: per-mono record clone synthesis; converging lane: G6

--- a/scripts/hew-suite-expected-failures.txt
+++ b/scripts/hew-suite-expected-failures.txt
@@ -11,5 +11,7 @@
 #
 # Format: <test_function_name>  # <root_cause>; converging lane: <lane>
 #
-# Total: 1 unique failing test function name.
+# Total: 3 unique failing test function names.
 test_generic_vec_iter_i64  # G5 split follow-on: Hew-level Vec<T>::iter substrate
+test_generic_record_of_vec_clone  # G6 scope-out: generic record with a Vec<T> field hits an orthogonal MIR-boundary gap (E_MIR: unknown type T; no ValueClass for T); converging lane: generic-record-Vec-field follow-on
+test_generic_enum_clone  # G6 scope-out: generic enum clone (clone Maybe<T>) is a separate synthesis path — clone is not yet a method on enums (no method clone on Maybe<i64>); converging lane: generic-enum-clone follow-on

--- a/scripts/hew-suite-expected-failures.txt
+++ b/scripts/hew-suite-expected-failures.txt
@@ -11,5 +11,15 @@
 #
 # Format: <test_function_name>  # <root_cause>; converging lane: <lane>
 #
-# Total: 1 unique failing test function name.
+# Total: 5 unique failing test function names.
 test_generic_vec_iter_i64  # G5 split follow-on: Hew-level Vec<T>::iter substrate
+# G6 generic record clone (RED until the per-mono clone/drop synthesis lands in
+# the codegen slice of feat/v06-generic-record-clone). The clone of a generic
+# record instantiation resolves a declared-but-undefined
+# `__hew_record_clone_inplace_<R>` thunk and the module fails LLVM verify until
+# the thunk is synthesised per concrete instantiation. Delete these four lines
+# in the codegen slice when they flip green.
+test_generic_record_clone_scalar_independence  # G6: per-mono record clone synthesis; converging lane: G6
+test_generic_record_clone_string_field  # G6: per-mono record clone synthesis; converging lane: G6
+test_generic_record_clone_nested  # G6: per-mono record clone synthesis; converging lane: G6
+test_generic_record_clone_multi_instantiation  # G6: per-mono record clone synthesis; converging lane: G6

--- a/tests/hew/clone_copy_scalar_value_test.hew
+++ b/tests/hew/clone_copy_scalar_value_test.hew
@@ -3,13 +3,13 @@
 //! `clone` on a value whose type is `Copy` (e.g. `i64`) is redundant: the
 //! checker emits a redundancy warning and lowers the `clone` as a plain read
 //! (`CopyCloneNoop`) — the build SUCCEEDS and the value is produced unchanged.
-//! G6 preserves this diagnostic; this fixture pins that a scalar `clone` still
+//! This fixture pins that a scalar `clone` still
 //! yields the correct value (the warning itself is pinned in
 //! `hew-hir/tests/clone_not_yet_supported.rs`).
 
 import std::testing;
 
-// V6 — `clone` on a scalar is a redundant no-op that still produces the value.
+// Clone on a scalar is a redundant no-op that still produces the value.
 #[test]
 fn test_clone_copy_scalar_produces_value() {
     let n: i64 = 41;

--- a/tests/hew/clone_copy_scalar_value_test.hew
+++ b/tests/hew/clone_copy_scalar_value_test.hew
@@ -1,0 +1,18 @@
+//! Regression pin for `clone` on a Copy (scalar) receiver.
+//!
+//! `clone` on a value whose type is `Copy` (e.g. `i64`) is redundant: the
+//! checker emits a redundancy warning and lowers the `clone` as a plain read
+//! (`CopyCloneNoop`) — the build SUCCEEDS and the value is produced unchanged.
+//! G6 preserves this diagnostic; this fixture pins that a scalar `clone` still
+//! yields the correct value (the warning itself is pinned in
+//! `hew-hir/tests/clone_not_yet_supported.rs`).
+
+import std::testing;
+
+// V6 — `clone` on a scalar is a redundant no-op that still produces the value.
+#[test]
+fn test_clone_copy_scalar_produces_value() {
+    let n: i64 = 41;
+    let m = clone n;
+    testing.assert_eq(m, 41);
+}

--- a/tests/hew/generic_enum_clone_test.hew
+++ b/tests/hew/generic_enum_clone_test.hew
@@ -1,0 +1,22 @@
+//! FAILABLE (tracked NYI): cloning a generic enum (`clone Maybe<T>`) is a
+//! SEPARATE synthesis path from record/aggregate clone — `clone` is not even a
+//! method on enums today (`no method clone on Maybe<i64>`). Explicitly OUT of
+//! scope for G6 (generic record/aggregate clone); registered here so the gap
+//! stays visible. Registered in scripts/hew-suite-expected-failures.txt; the
+//! ratchet flips to an unexpected-pass the instant generic enum clone lands,
+//! forcing this test's promotion to a positive regression guard.
+
+import std::testing;
+
+enum Maybe<T> { Some(T); None }
+
+#[test]
+fn test_generic_enum_clone() {
+    let m = Maybe::Some(42);
+    let n = clone m;
+    let v = match n {
+        Maybe::Some(x) => x,
+        Maybe::None => 0,
+    };
+    testing.assert_eq(v, 42);
+}

--- a/tests/hew/generic_enum_clone_test.hew
+++ b/tests/hew/generic_enum_clone_test.hew
@@ -1,7 +1,7 @@
 //! FAILABLE (tracked NYI): cloning a generic enum (`clone Maybe<T>`) is a
 //! SEPARATE synthesis path from record/aggregate clone — `clone` is not even a
 //! method on enums today (`no method clone on Maybe<i64>`). Explicitly OUT of
-//! scope for G6 (generic record/aggregate clone); registered here so the gap
+//! scope for generic record/aggregate clone; registered here so the gap
 //! stays visible. Registered in scripts/hew-suite-expected-failures.txt; the
 //! ratchet flips to an unexpected-pass the instant generic enum clone lands,
 //! forcing this test's promotion to a positive regression guard.

--- a/tests/hew/generic_record_clone_actor_state_test.hew
+++ b/tests/hew/generic_record_clone_actor_state_test.hew
@@ -1,11 +1,11 @@
-//! V8 — drop-safety on actor shutdown / state reassignment.
+//! Drop-safety on actor shutdown / state reassignment.
 //!
 //! An actor holds a CLONED generic aggregate (`Pair<i64, string>`) in a state
 //! field. The clone-into-state path drives the per-mono clone thunk for the
 //! `Pair$$i64$string` instantiation; the actor's shutdown (and each overwrite
 //! of the field) releases the prior value through the MATCHING per-mono drop
-//! thunk. R1 (a clone synthesised without its paired drop) would leak / double
-//! free on this path — the lifecycle path the sync fixtures cannot reach.
+//! thunk. A clone synthesised without its paired drop would leak / double-free
+//! on this path — the lifecycle path the sync fixtures cannot reach.
 //!
 //! A generic record is not yet `Send`, so the `Pair` never crosses the actor
 //! boundary; the actor builds it from scalar/`string` message args (both Send)
@@ -32,7 +32,7 @@ actor Keeper {
     }
 }
 
-// V8 — the actor holds a cloned generic aggregate; assert the scalar and the
+// The actor holds a cloned generic aggregate; assert the scalar and the
 // owned `string` leaf are both the values stored (the clone deep-copied them).
 #[test]
 fn actor_holds_cloned_generic_pair_values() {
@@ -47,7 +47,7 @@ fn actor_holds_cloned_generic_pair_values() {
     }
 }
 
-// V8 (drop-on-reassign) — a second store overwrites `held`: the prior clone
+// Drop-on-reassign: a second store overwrites `held`; the prior clone
 // must drop through the per-mono drop thunk and the new clone replace it. The
 // observable label reflects ONLY the latest store, proving the field is a real
 // owned copy reclaimed each cycle (no stale alias, no corruption from an

--- a/tests/hew/generic_record_clone_actor_state_test.hew
+++ b/tests/hew/generic_record_clone_actor_state_test.hew
@@ -1,0 +1,67 @@
+//! V8 — drop-safety on actor shutdown / state reassignment.
+//!
+//! An actor holds a CLONED generic aggregate (`Pair<i64, string>`) in a state
+//! field. The clone-into-state path drives the per-mono clone thunk for the
+//! `Pair$$i64$string` instantiation; the actor's shutdown (and each overwrite
+//! of the field) releases the prior value through the MATCHING per-mono drop
+//! thunk. R1 (a clone synthesised without its paired drop) would leak / double
+//! free on this path — the lifecycle path the sync fixtures cannot reach.
+//!
+//! A generic record is not yet `Send`, so the `Pair` never crosses the actor
+//! boundary; the actor builds it from scalar/`string` message args (both Send)
+//! and clones it internally. These tests assert the held VALUES are correct
+//! across stores; the leak / double-free freedom on the shutdown path is pinned
+//! by the differential `generic_record_clone_actor_shutdown_no_drop_leak`
+//! oracle (`hew-cli/tests/record_clone_generic_leak_oracle.rs`) under libgmalloc.
+
+import std::testing;
+
+type Pair<A, B> { first: A; second: B; }
+
+actor Keeper {
+    var held: Pair<i64, string> = Pair { first: 0, second: "none" };
+
+    receive fn store(n: i64, tag: string) -> i64 {
+        let p = Pair { first: n, second: tag };
+        held = clone p;
+        return held.first;
+    }
+
+    receive fn label() -> string {
+        return clone held.second;
+    }
+}
+
+// V8 — the actor holds a cloned generic aggregate; assert the scalar and the
+// owned `string` leaf are both the values stored (the clone deep-copied them).
+#[test]
+fn actor_holds_cloned_generic_pair_values() {
+    let k = spawn Keeper();
+    match await k.store(7, "alpha") {
+        Ok(n) => testing.assert_eq(n, 7),
+        Err(_) => testing.assert_true(false),
+    }
+    match await k.label() {
+        Ok(s) => testing.assert_eq_str(s, "alpha"),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+// V8 (drop-on-reassign) — a second store overwrites `held`: the prior clone
+// must drop through the per-mono drop thunk and the new clone replace it. The
+// observable label reflects ONLY the latest store, proving the field is a real
+// owned copy reclaimed each cycle (no stale alias, no corruption from an
+// over-drop of the previous value).
+#[test]
+fn actor_reclones_state_field_each_store() {
+    let k = spawn Keeper();
+    let _ = await k.store(7, "alpha");
+    match await k.store(9, "beta") {
+        Ok(n) => testing.assert_eq(n, 9),
+        Err(_) => testing.assert_true(false),
+    }
+    match await k.label() {
+        Ok(s) => testing.assert_eq_str(s, "beta"),
+        Err(_) => testing.assert_true(false),
+    }
+}

--- a/tests/hew/generic_record_clone_test.hew
+++ b/tests/hew/generic_record_clone_test.hew
@@ -1,0 +1,70 @@
+//! Behavioural tests for generic record (`type R<T> { … }`) `clone`.
+//!
+//! `clone` on a *monomorphic* record already synthesises a structural
+//! `__hew_record_clone_inplace_<R>` thunk and deep-copies every owned field.
+//! For a *generic* record the clone thunk must be synthesised **per concrete
+//! instantiation** (`Pair$$i64$i64`, `Pair$$string$string`, …), mirroring the
+//! `make$$i64` monomorphisation key — otherwise the clone call resolves a
+//! declared-but-undefined external thunk and the module fails LLVM verify.
+//!
+//! Each test asserts EXACT cloned values (a behavioural-green `exit 0` is
+//! non-evidence — `admission-gate-is-not-runnability`). The scalar test also
+//! mutates the original after cloning and asserts the clone is unaffected,
+//! proving value-semantics (the clone is a copy, not an alias).
+
+import std::testing;
+
+type Pair<A, B> { a: A; b: B; }
+
+// V1 — generic record clone over scalar leaves; mutate the original and assert
+// the clone is independent (deep copy, not alias).
+#[test]
+fn test_generic_record_clone_scalar_independence() {
+    var p = Pair { a: 10, b: 20 };
+    let q = clone p;
+    // Mutate the original after cloning.
+    p.a = 99;
+    p.b = 88;
+    // The clone keeps its own values.
+    testing.assert_eq(q.a, 10);
+    testing.assert_eq(q.b, 20);
+    // The original reflects the mutation.
+    testing.assert_eq(p.a, 99);
+    testing.assert_eq(p.b, 88);
+}
+
+// V2a — generic record clone with an owned `string` leaf; the clone must
+// deep-copy the managed string handle, not alias it.
+#[test]
+fn test_generic_record_clone_string_field() {
+    let p = Pair { a: 7, b: "hello" };
+    let q = clone p;
+    testing.assert_eq(q.a, 7);
+    testing.assert_eq_str(q.b, "hello");
+}
+
+// V2b — nested generic record clone (`Pair<Pair<i64, i64>, string>`); assert
+// the inner record fields and the string leaf are all deep-copied.
+#[test]
+fn test_generic_record_clone_nested() {
+    let inner = Pair { a: 1, b: 2 };
+    let outer = Pair { a: inner, b: "tag" };
+    let c = clone outer;
+    testing.assert_eq(c.a.a, 1);
+    testing.assert_eq(c.a.b, 2);
+    testing.assert_eq_str(c.b, "tag");
+}
+
+// V5 — two distinct instantiations of the same generic record in one program
+// (`Pair<i64, i64>` and `Pair<string, string>`) must synthesise distinct mono
+// thunks with no symbol collision, both producing correct clones.
+#[test]
+fn test_generic_record_clone_multi_instantiation() {
+    let pi = Pair { a: 1, b: 2 };
+    let ps = Pair { a: "x", b: "y" };
+    let ci = clone pi;
+    let cs = clone ps;
+    testing.assert_eq(ci.a + ci.b, 3);
+    testing.assert_eq_str(cs.a, "x");
+    testing.assert_eq_str(cs.b, "y");
+}

--- a/tests/hew/generic_record_clone_test.hew
+++ b/tests/hew/generic_record_clone_test.hew
@@ -16,7 +16,7 @@ import std::testing;
 
 type Pair<A, B> { a: A; b: B; }
 
-// V1 — generic record clone over scalar leaves; mutate the original and assert
+// Generic record clone over scalar leaves; mutate the original and assert
 // the clone is independent (deep copy, not alias).
 #[test]
 fn test_generic_record_clone_scalar_independence() {
@@ -33,7 +33,7 @@ fn test_generic_record_clone_scalar_independence() {
     testing.assert_eq(p.b, 88);
 }
 
-// V2a — generic record clone with an owned `string` leaf; the clone must
+// Generic record clone with an owned `string` leaf; the clone must
 // deep-copy the managed string handle, not alias it.
 #[test]
 fn test_generic_record_clone_string_field() {
@@ -43,7 +43,7 @@ fn test_generic_record_clone_string_field() {
     testing.assert_eq_str(q.b, "hello");
 }
 
-// V2b — nested generic record clone (`Pair<Pair<i64, i64>, string>`); assert
+// Nested generic record clone (`Pair<Pair<i64, i64>, string>`); assert
 // the inner record fields and the string leaf are all deep-copied.
 #[test]
 fn test_generic_record_clone_nested() {
@@ -55,7 +55,7 @@ fn test_generic_record_clone_nested() {
     testing.assert_eq_str(c.b, "tag");
 }
 
-// V5 — two distinct instantiations of the same generic record in one program
+// Two distinct instantiations of the same generic record in one program
 // (`Pair<i64, i64>` and `Pair<string, string>`) must synthesise distinct mono
 // thunks with no symbol collision, both producing correct clones.
 #[test]

--- a/tests/hew/generic_record_of_vec_clone_test.hew
+++ b/tests/hew/generic_record_of_vec_clone_test.hew
@@ -1,0 +1,20 @@
+//! FAILABLE (tracked NYI): cloning a generic record whose field is `Vec<T>` is
+//! blocked by an ORTHOGONAL, pre-existing gap — the element type `T` has no
+//! known ValueClass at the MIR boundary (`E_MIR: unknown type T`). This is
+//! independent of the per-mono clone/drop synthesis G6 delivers (a generic
+//! record with scalar / string / nested-record fields clones correctly); it is
+//! the generic-record `Vec<T>`-field surface, tracked as a follow-on. Registered
+//! in scripts/hew-suite-expected-failures.txt; the ratchet flips to an
+//! unexpected-pass the instant the MIR-boundary gap is closed.
+
+import std::testing;
+
+type Bag<T> { items: Vec<T>; }
+
+#[test]
+fn test_generic_record_of_vec_clone() {
+    let b = Bag { items: Vec::new() };
+    b.items.push(7);
+    let c = clone b;
+    testing.assert_eq(c.items.len(), 1);
+}

--- a/tests/hew/generic_record_of_vec_clone_test.hew
+++ b/tests/hew/generic_record_of_vec_clone_test.hew
@@ -1,7 +1,7 @@
 //! FAILABLE (tracked NYI): cloning a generic record whose field is `Vec<T>` is
 //! blocked by an ORTHOGONAL, pre-existing gap — the element type `T` has no
 //! known ValueClass at the MIR boundary (`E_MIR: unknown type T`). This is
-//! independent of the per-mono clone/drop synthesis G6 delivers (a generic
+//! independent of the per-mono clone/drop synthesis for generic records (a generic
 //! record with scalar / string / nested-record fields clones correctly); it is
 //! the generic-record `Vec<T>`-field surface, tracked as a follow-on. Registered
 //! in scripts/hew-suite-expected-failures.txt; the ratchet flips to an

--- a/tests/hew/generic_vec_owned_record_clone_test.hew
+++ b/tests/hew/generic_vec_owned_record_clone_test.hew
@@ -1,18 +1,18 @@
 //! Value-asserting fixture for `clone` on a `Vec<R>` whose element `R` is an
-//! owned (managed) record — the deep-clone path G5 wired through
-//! `hew_vec_clone_owned`, which clones every element via the element's
+//! owned (managed) record — the deep-clone path through `hew_vec_clone_owned`,
+//! which clones every element via the element's
 //! `__hew_record_clone_inplace_<R>` thunk.
 //!
-//! G6 adds NO Vec-routing code; this fixture is the value-assertion of the G5
-//! mechanism (G5 shipped the routing with no behavioural clone test — this
-//! pins it). The clone must deep-copy each element's owned `string` field so
-//! the clone survives independently of the original.
+//! No Vec-routing code was added here; this fixture provides the
+//! value-assertion for that mechanism (the routing had no behavioural clone
+//! test — this pins it). The clone must deep-copy each element's owned `string`
+//! field so the clone survives independently of the original.
 
 import std::testing;
 
 type Item { name: string; n: i64; }
 
-// V4 — clone a Vec of owned records; assert each cloned element holds the
+// Clone a Vec of owned records; assert each cloned element holds the
 // correct field values (the owned `string` leaf was deep-copied, not aliased).
 #[test]
 fn test_clone_vec_of_owned_records_copies_fields() {
@@ -30,7 +30,7 @@ fn test_clone_vec_of_owned_records_copies_fields() {
     testing.assert_eq(b.n, 20);
 }
 
-// V4 (independence) — growing the clone leaves the source untouched, proving
+// Growing the clone leaves the source untouched, proving
 // the clone owns a distinct backing allocation.
 #[test]
 fn test_clone_vec_of_owned_records_is_independent() {

--- a/tests/hew/generic_vec_owned_record_clone_test.hew
+++ b/tests/hew/generic_vec_owned_record_clone_test.hew
@@ -1,0 +1,47 @@
+//! Value-asserting fixture for `clone` on a `Vec<R>` whose element `R` is an
+//! owned (managed) record — the deep-clone path G5 wired through
+//! `hew_vec_clone_owned`, which clones every element via the element's
+//! `__hew_record_clone_inplace_<R>` thunk.
+//!
+//! G6 adds NO Vec-routing code; this fixture is the value-assertion of the G5
+//! mechanism (G5 shipped the routing with no behavioural clone test — this
+//! pins it). The clone must deep-copy each element's owned `string` field so
+//! the clone survives independently of the original.
+
+import std::testing;
+
+type Item { name: string; n: i64; }
+
+// V4 — clone a Vec of owned records; assert each cloned element holds the
+// correct field values (the owned `string` leaf was deep-copied, not aliased).
+#[test]
+fn test_clone_vec_of_owned_records_copies_fields() {
+    let xs: Vec<Item> = Vec::new();
+    xs.push(Item { name: "alpha", n: 10 });
+    xs.push(Item { name: "beta", n: 20 });
+    let ys = xs.clone();
+
+    testing.assert_eq(ys.len(), 2);
+    let a = ys.get(0);
+    let b = ys.get(1);
+    testing.assert_eq_str(a.name, "alpha");
+    testing.assert_eq(a.n, 10);
+    testing.assert_eq_str(b.name, "beta");
+    testing.assert_eq(b.n, 20);
+}
+
+// V4 (independence) — growing the clone leaves the source untouched, proving
+// the clone owns a distinct backing allocation.
+#[test]
+fn test_clone_vec_of_owned_records_is_independent() {
+    let xs: Vec<Item> = Vec::new();
+    xs.push(Item { name: "only", n: 1 });
+    let ys = xs.clone();
+    ys.push(Item { name: "extra", n: 2 });
+
+    testing.assert_eq(xs.len(), 1);
+    testing.assert_eq(ys.len(), 2);
+    let extra = ys.get(1);
+    testing.assert_eq_str(extra.name, "extra");
+    testing.assert_eq(extra.n, 2);
+}

--- a/tests/vertical-slice/reject/generic_record_clone_opaque_leaf.hew
+++ b/tests/vertical-slice/reject/generic_record_clone_opaque_leaf.hew
@@ -1,0 +1,34 @@
+// Reject fixture: generic_record_clone_opaque_leaf — a GENERIC record whose
+// type parameter is instantiated with an `#[opaque]` runtime handle must fail
+// closed when cloned, exactly like the monomorphic case
+// (`record_clone_unclonable_field.hew`).
+//
+// The clone-admissibility opaque walk is substitution-aware: for `Box<Handle>`
+// it instantiates the declared field `item: T` to `item: Handle` before
+// checking, so the transitive opaque leaf is detected at the concrete
+// instantiation. Without substitution the walk sees only the abstract `T` and
+// would admit the clone, then emit a thunk that byte-copies (aliases) the
+// opaque handle — a double-free when both the original and the clone are freed.
+//
+// Harness verb: hew check
+// Expected: rejected with an `UndefinedMethod` error mentioning the opaque
+// field name ("contains an opaque field").
+
+#[opaque]
+type Handle {}
+
+extern "C" {
+    fn hew_handle_create() -> Handle;
+    fn hew_handle_free(h: Handle);
+}
+
+type Box<T> {
+    item: T,
+}
+
+fn main() -> i64 {
+    let b = Box { item: unsafe { hew_handle_create() } };
+    let _c = clone b;
+    unsafe { hew_handle_free(b.item) };
+    0
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -2873,6 +2873,18 @@ if "${HEW}" check \
 fi
 grep -q 'contains an opaque field' "${reject_output}"
 
+# User-defined GENERIC record `clone` on an instantiation whose type parameter
+# resolves to an opaque handle (`Box<Handle>`) must be rejected too — the
+# admissibility opaque walk is substitution-aware (instantiates `item: T` to
+# `item: Handle` before checking).
+if "${HEW}" check \
+    "${ROOT}/tests/vertical-slice/reject/generic_record_clone_opaque_leaf.hew" \
+    >"${reject_output}" 2>&1; then
+  echo "expected generic_record_clone_opaque_leaf fixture to fail" >&2
+  exit 1
+fi
+grep -q 'contains an opaque field' "${reject_output}"
+
 # ---------------------------------------------------------------------------
 # let-destructure: record/struct product-type irrefutable patterns
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The existing structural record clone/drop synthesis is now monomorphization-keyed, mirroring the `make$$i64` mono-key pattern used elsewhere. Previously a generic record clone over-admitted (abstract type parameters are not caught by the concrete-leaf walk) and emitted an unbodied clone thunk, producing an LLVM verify failure at any generic instantiation. A substitution-aware opaque-leaf walk now catches non-duplicable leaves at the concrete instantiation site. The clone thunk is keyed by monomorphized layout — bare name for monomorphic records (byte-identical to prior behaviour), mangled key for generic instantiations. The per-mono clone body and its paired drop body are synthesised together per key, so a clone can never exist without its drop.

## Verification

- Differential leak oracle — 5 programs, clone-count == no-clone control (delta-0), including actor-shutdown 64/64 case — under MallocScribble + GuardEdges + libgmalloc: all pass
- `make ci-preflight`: 13/13 green
- `make checked-mir-verify`: byte-identical output (30×2 MIR checks)
- Fail-closed: opaque-leaf clone rejects at the type checker and at codegen with no broken thunk emitted
- Value-asserting fixtures: scalar-independence, string deep-copy, nested records, multi-instantiation, actor-state
- Preflight: ready-to-push

## Out of scope

- Generic enum clone and generic record-of-`Vec<T>` are follow-ons; both are registered as failable tests so they auto-flag when addressed
- Generic-record `Send` is a separate follow-on
- A pre-existing mangler non-injectivity for coinciding flat-underscore type names vs nested generics (e.g. a type named `Foo_Bar` colliding with `Foo<Bar>`) is tracked as a separate hardening lane and predates this change
- A pre-existing record-construction leak orthogonal to clone/drop is tracked separately
