### PR TITLE
feat(types): support calling a function-typed record field

### DIFF
--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -2920,7 +2920,13 @@ impl<'a> Formatter<'a> {
                 args,
                 ..
             } => {
-                let needs_callee_parens = matches!(function.0, Expr::Lambda { .. });
+                // Add parens around a FieldAccess callee so that `(rec.f)(args)` — a
+                // function call through a fn-typed field — formats as `(rec.f)(args)` and
+                // re-parses as `Call { FieldAccess }`, not as a `MethodCall`. The two forms
+                // are syntactically distinct (different AST nodes, different checker paths);
+                // normalising them would break the round-trip property.
+                let needs_callee_parens =
+                    matches!(function.0, Expr::Lambda { .. } | Expr::FieldAccess { .. });
                 if needs_callee_parens {
                     self.write("(");
                 }

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -641,9 +641,25 @@ impl Checker {
         // Get function name from expression
         let func_name = match &func.0 {
             Expr::Identifier(name) => name.clone(),
-            // Handle path-style calls like Vec::new(), HashMap::new()
             Expr::FieldAccess { object, field } => {
                 if let Expr::Identifier(obj_name) = &object.0 {
+                    // When the object identifier names a live value binding,
+                    // the callee is a field access on a value — not a
+                    // module-qualified or type-namespaced name. Synthesise the
+                    // field type and delegate to the indirect-call path so that
+                    // `(rec.f)(args)` where `f: fn(A)->B` reaches
+                    // `check_call_with_type` instead of failing with
+                    // "undefined function `rec::f`".
+                    //
+                    // The `env.lookup_ref` guard keeps type and module
+                    // identifiers on the existing name-building path
+                    // (`(Vec.new)(args)` → `"Vec::new"`) because type/module
+                    // names are not registered as value bindings.
+                    if self.env.lookup_ref(obj_name).is_some() {
+                        let field_ty = self.synthesize(&func.0, &func.1);
+                        let resolved = self.subst.resolve(&field_ty);
+                        return self.check_call_with_type(&resolved, args, span);
+                    }
                     format!("{obj_name}::{field}")
                 } else {
                     let func_ty = self.synthesize(&func.0, &func.1);

--- a/tests/vertical-slice/accept/fn_field_self_call.hew
+++ b/tests/vertical-slice/accept/fn_field_self_call.hew
@@ -1,0 +1,23 @@
+// `(self.f)(x)` inside a record method where `f` is a fn-typed field.
+//
+// This is the pattern the lazy `Map` adapter body needs: a record stores a
+// user-provided transformer function and the `next` body calls it via
+// `(self.f)(elem)`. Before the fix this was rejected as
+// "undefined function `self::f`"; after the fix the field access is
+// synthesised to `fn(i64)->i64` and routed through the indirect-call path.
+
+type Map {
+    f: fn(i64) -> i64;
+}
+
+impl Map {
+    fn apply(self, x: i64) -> i64 {
+        (self.f)(x)
+    }
+}
+
+fn main() -> i64 {
+    let m = Map { f: |x: i64| x * 3 };
+    // m.apply(7) = 7 * 3 = 21
+    m.apply(7)
+}

--- a/tests/vertical-slice/accept/fn_field_self_call.hew
+++ b/tests/vertical-slice/accept/fn_field_self_call.hew
@@ -5,7 +5,6 @@
 // `(self.f)(elem)`. Before the fix this was rejected as
 // "undefined function `self::f`"; after the fix the field access is
 // synthesised to `fn(i64)->i64` and routed through the indirect-call path.
-
 type Map {
     f: fn(i64) -> i64;
 }

--- a/tests/vertical-slice/accept/fn_typed_field_call.hew
+++ b/tests/vertical-slice/accept/fn_typed_field_call.hew
@@ -1,0 +1,20 @@
+// A fn-typed record field called via parenthesized access `(rec.f)(x)`.
+//
+// This form was previously rejected with "undefined function `rec::f`"
+// because the checker's FieldAccess branch in `check_call` built the
+// name `rec::f` instead of routing to the indirect-call path.
+//
+// After the fix: when the object identifier names a live value binding,
+// `check_call` synthesises the field type and delegates to
+// `check_call_with_type`, reaching the `Ty::Function`/`Ty::Closure` arm
+// and verifying argument types against the function signature.
+
+type Holder {
+    f: fn(i64) -> i64;
+}
+
+fn main() -> i64 {
+    let h = Holder { f: |x: i64| x * 10 };
+    // `(h.f)(5)` — field access + indirect call; must equal 50.
+    (h.f)(5)
+}

--- a/tests/vertical-slice/accept/fn_typed_field_call.hew
+++ b/tests/vertical-slice/accept/fn_typed_field_call.hew
@@ -8,7 +8,6 @@
 // `check_call` synthesises the field type and delegates to
 // `check_call_with_type`, reaching the `Ty::Function`/`Ty::Closure` arm
 // and verifying argument types against the function signature.
-
 type Holder {
     f: fn(i64) -> i64;
 }

--- a/tests/vertical-slice/reject/fn_field_call_non_fn.hew
+++ b/tests/vertical-slice/reject/fn_field_call_non_fn.hew
@@ -3,7 +3,6 @@
 // is not callable; `check_call_with_type` emits "cannot call value of type `i64`"
 // (not "undefined function") — the guard fires correctly for values that
 // are not function-typed.
-
 type Counter {
     count: i64;
 }

--- a/tests/vertical-slice/reject/fn_field_call_non_fn.hew
+++ b/tests/vertical-slice/reject/fn_field_call_non_fn.hew
@@ -1,0 +1,14 @@
+// Negative control: calling a non-fn-typed field with `(rec.count)(x)`
+// syntax must still be rejected. The field `count` has type `i64`, which
+// is not callable; `check_call_with_type` emits "cannot call value of type `i64`"
+// (not "undefined function") — the guard fires correctly for values that
+// are not function-typed.
+
+type Counter {
+    count: i64;
+}
+
+fn main() -> i64 {
+    let c = Counter { count: 5 };
+    (c.count)(1)
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1256,6 +1256,26 @@ run_accept_expect_status "closure_param_field_store" 42
 # by the dataflow checker with UseAfterConsume, never a silent double-free.
 reject_check_use_after_consume "closure_param_use_after_store"
 
+# Accept + run: `(rec.f)(x)` where `f` is a fn-typed record field — the
+# parenthesized field-access-callee form. Previously rejected as "undefined
+# function `rec::f`" because the checker built an obj::field name; now
+# synthesises the field type and routes to the indirect-call path.
+# Exit 50 = |x| x*10 applied to 5.
+run_accept_expect_status "fn_typed_field_call" 50
+
+# Accept + run: `(self.f)(x)` inside a record method, motivating the Map
+# adapter body pattern (`(self.f)(elem)` in Iterator::next). Exit 21 = 7*3.
+run_accept_expect_status "fn_field_self_call" 21
+
+# Reject: calling a non-fn-typed field with `(rec.count)(x)` is still
+# rejected. The guard fires correctly: `check_call_with_type` sees `i64`
+# and emits "cannot call value of type `i64`", not the old confusing
+# "undefined function `rec::count`".
+expect_check_fail_contains \
+  "${ROOT}/tests/vertical-slice/reject/fn_field_call_non_fn.hew" \
+  "cannot call value of type" \
+  "fn_field_call_non_fn"
+
 # Accept + run: lambda actor capturing a declared-actor pid and forwarding.
 # The pid rides the heap-boxed env as a no-drop field; the state dropper
 # frees env bytes only. Exit 42 = 10 + 32 forwarded.


### PR DESCRIPTION
## Summary

A function-typed record field called as `(rec.f)(x)` or `(self.f)(x)` now type-checks and compiles through the indirect-call path. Previously these expressions were rejected with `error: undefined function 'self::f'` because the checker interpreted the callee as a type- or module-qualified name. The checker now detects when a `FieldAccess` callee's object is a live value binding, synthesises the field's type, and delegates to the existing closure/function-pointer call path. Type- and module-qualified calls are unchanged. The formatter now wraps `FieldAccess` callees in parentheses so `(rec.f)(args)` round-trips as an indirect call rather than collapsing to `rec.f(args)` (a distinct method-call form). This enables calling function-valued fields generally — the pattern is needed by iterator adapter bodies.

## Verification

- Compiled fixture `(h.f)(5)` → binary exits 50
- Compiled fixture `(self.f)(x)` inside `impl Map { fn apply(self, x) }` → binary exits 21
- Negative control `(c.count)(1)` (`count: i64`) → rejected: `cannot call value of type `i64``
- Formatter roundtrip corpus (1 372 files walked) → 0 failures
- Full vertical-slice suite → 254 tests pass
- Preflight: ready-to-push
- Cross-ecosystem review: no findings

## Out of scope

- Method-call syntax `rec.f(args)` is unchanged; this change covers only the parenthesised field-call form.
- No HIR, MIR, or codegen changes; the fix is in the type-checker and formatter only.