### PR TITLE
docs(dist-spec): supervision and capability tokens are not yet runtime-enforced for rc1

### DIFF
--- a/docs/specs/HEW-DIST-SPEC.md
+++ b/docs/specs/HEW-DIST-SPEC.md
@@ -209,12 +209,13 @@ The checker is the authority for ownership classification of supervision tokens,
 per [`handle-safety-and-resource-lifetime.md`](./handle-safety-and-resource-lifetime.md)
 §5 (single ownership oracle).
 
-**Implementation gap:** Single-holder restart-authority enforcement at the type
-level is not yet implemented. This clause is normative spec intent; runtime
-enforcement is tracked under issue #1228 (RuntimeContext handle-shaped API) and
-issue #1399 (move-checker substrate). No existing supervision scaffolding claims
-to enforce single-holder tokens; the gap is absence of enforcement, not wrong
-enforcement.
+**Implementation gap:** Single-holder restart-authority enforcement is
+spec-defined but **NOT** yet runtime-enforced (tracked: #1228 and #1399). The
+type system captures the supervision-token ownership shape described above, but
+the runtime does not yet enforce single-holder transfer exclusivity. No existing
+supervision scaffolding claims to enforce single-holder tokens; the gap is
+absence of enforcement, not wrong enforcement. For rc1, supervision tokens are
+not a runtime security boundary.
 
 **WASM policy:** Supervision token obligations are native-only; see §15 for WASM
 policy.
@@ -307,10 +308,11 @@ per [`handle-safety-and-resource-lifetime.md`](./handle-safety-and-resource-life
 to the transport/security mode is carried in the handshake contract; §12.1 does
 not restate those mechanics, only the ownership shape of tokens once transferred.
 
-**Implementation gap:** Capability transfer and grantor-side revocation are not
-yet runtime-enforced. This clause is normative spec intent; runtime enforcement
-is tracked under issue #1706 (capability transfer ownership and revocation per
-HEW-DIST-SPEC §12).
+**Implementation gap:** Capability transfer and grantor-side revocation are
+spec-defined but **NOT** yet runtime-enforced (tracked: #1706). The type system
+captures the ownership shape described above, but the runtime does not yet
+enforce transfer exclusivity or grantor-side revocation. For rc1, capability
+tokens are not a runtime security boundary.
 
 **WASM policy:** Capability token obligations are native-only; see §15 for WASM
 policy.

--- a/docs/specs/HEW-DIST-SPEC.md
+++ b/docs/specs/HEW-DIST-SPEC.md
@@ -210,12 +210,14 @@ per [`handle-safety-and-resource-lifetime.md`](./handle-safety-and-resource-life
 §5 (single ownership oracle).
 
 **Implementation gap:** Single-holder restart-authority enforcement is
-spec-defined but **NOT** yet runtime-enforced (tracked: #1228 and #1399). The
-type system captures the supervision-token ownership shape described above, but
-the runtime does not yet enforce single-holder transfer exclusivity. No existing
-supervision scaffolding claims to enforce single-holder tokens; the gap is
-absence of enforcement, not wrong enforcement. For rc1, supervision tokens are
-not a runtime security boundary.
+spec-defined but **NOT** yet runtime-enforced (tracked: #2162). The spec is the
+authority for the ownership/transfer shape described above. The current type
+system does not yet model supervision tokens as a distinct type-level boundary;
+they are treated as ordinary Copy values, and `hew-types` has no
+`MarkerTrait::Capability` or equivalent. The runtime does not yet enforce
+single-holder transfer exclusivity. No existing supervision scaffolding claims
+to enforce single-holder tokens; the gap is absence of enforcement, not wrong
+enforcement. For rc1, supervision tokens are not a runtime security boundary.
 
 **WASM policy:** Supervision token obligations are native-only; see §15 for WASM
 policy.
@@ -309,10 +311,13 @@ to the transport/security mode is carried in the handshake contract; §12.1 does
 not restate those mechanics, only the ownership shape of tokens once transferred.
 
 **Implementation gap:** Capability transfer and grantor-side revocation are
-spec-defined but **NOT** yet runtime-enforced (tracked: #1706). The type system
-captures the ownership shape described above, but the runtime does not yet
-enforce transfer exclusivity or grantor-side revocation. For rc1, capability
-tokens are not a runtime security boundary.
+spec-defined but **NOT** yet runtime-enforced (tracked: #1706). The spec is the
+authority for the ownership/transfer shape described above. The current type
+system does not yet model capability tokens as a distinct type-level boundary;
+they are treated as ordinary Copy values, and `hew-types` has no
+`MarkerTrait::Capability` or equivalent. The runtime does not yet enforce
+transfer exclusivity or grantor-side revocation. For rc1, capability tokens are
+not a runtime security boundary.
 
 **WASM policy:** Capability token obligations are native-only; see §15 for WASM
 policy.


### PR DESCRIPTION
## Summary

The distributed-actor spec overstated implementation status for supervision tokens (§8.1) and capability transfer (§12.1) — the notes implied the type system models these as ownership boundaries. They now state accurately that both are spec-defined but **not yet runtime-enforced** and are **not** modeled as a distinct type-level boundary (today they are ordinary `Copy` values; `hew-types` has no capability marker trait). For rc1, supervision and capability tokens are explicitly **not a runtime security boundary**.

## Verification

- `scripts/extract-doc-fences.sh`: prose-only file, 0 code fences, expected-failure count unchanged
- No `.rs` changes
- Preflight: ready-to-push

## Out of scope

- Runtime enforcement of supervision-token single-holder restart authority (tracked #2162)
- Capability transfer ownership and revocation enforcement (tracked #1706)