### PR TITLE
chore: off-hotspot vestigial cleanup batch

### DIFF
--- a/hew-analysis/src/ast_visit.rs
+++ b/hew-analysis/src/ast_visit.rs
@@ -389,7 +389,7 @@ impl<'src, 'ast, V: AstVisitor<'ast>> AstWalker<'src, 'ast, V> {
                 self.visitor
                     .leave_body(body_info, Self::context(Some(body_info)));
             }
-            Item::Record(_) // TODO(A-3): no walkable bodies until checker support lands
+            Item::Record(_) // records carry no callable bodies by design (fields only)
             | Item::Import(_)
             | Item::ExternBlock(_)
             | Item::TypeAlias(_) => {}

--- a/hew-cli/src/doc/extract.rs
+++ b/hew-cli/src/doc/extract.rs
@@ -520,7 +520,7 @@ pub fn extract_docs(program: &Program, module_name: &str) -> DocModule {
             | Item::ExternBlock(_)
             | Item::Supervisor(_)
             | Item::Machine(_)
-            | Item::Record(_) => {} // TODO(A-3): emit doc for record once checker support lands
+            | Item::Record(_) => {} // doc renderer has no record section type yet
         }
     }
 

--- a/hew-cli/src/machine.rs
+++ b/hew-cli/src/machine.rs
@@ -12,6 +12,7 @@
 
 use hew_hir::{lower_program, HirItem, HirMachineDecl, ResolutionCtx};
 use hew_parser::ast::{Item, MachineDecl};
+use hew_parser::ParseResult;
 use hew_types::TypeCheckOutput;
 
 use crate::args::{MachineDiagramArgs, MachineFormat};
@@ -39,7 +40,10 @@ fn read_source(path: &str) -> String {
     }
 }
 
-fn parse_machines(path: &str, source: &str) -> Vec<MachineDecl> {
+/// Parse `source`, extracting machine declarations.  Returns both the flat
+/// machine list and the original `ParseResult` so callers can forward it to
+/// `check_and_lower` without a second parse.
+fn parse_machines(path: &str, source: &str) -> (Vec<MachineDecl>, ParseResult) {
     let result = hew_parser::parse(source);
 
     if !result.errors.is_empty() {
@@ -49,34 +53,26 @@ fn parse_machines(path: &str, source: &str) -> Vec<MachineDecl> {
         std::process::exit(1);
     }
 
-    result
+    let machines = result
         .program
         .items
-        .into_iter()
+        .iter()
         .filter_map(|(item, _)| {
             if let Item::Machine(md) = item {
-                Some(md)
+                Some(md.clone())
             } else {
                 None
             }
         })
-        .collect()
+        .collect();
+    (machines, result)
 }
 
-/// Run HIR lowering + static checks. Returns the checked HIR machines on success,
-/// or exits the process on failure.
-fn check_and_lower(path: &str, source: &str) -> Vec<HirMachineDecl> {
-    let result = hew_parser::parse(source);
-
-    if !result.errors.is_empty() {
-        for err in &result.errors {
-            eprintln!("{path}: parse error: {err:?}");
-        }
-        std::process::exit(1);
-    }
-
+/// Run HIR lowering + static checks on an already-parsed program.  Returns the
+/// checked HIR machines on success, or exits the process on failure.
+fn check_and_lower(path: &str, parsed: &ParseResult) -> Vec<HirMachineDecl> {
     let lowered = lower_program(
-        &result.program,
+        &parsed.program,
         &TypeCheckOutput::default(),
         &ResolutionCtx,
         hew_hir::TargetArch::host(),
@@ -110,7 +106,7 @@ enum MachineCheckResult {
 
 fn check_machines_or_ast_fallback(
     path: &str,
-    source: &str,
+    parsed: &ParseResult,
     ast_machines: &[MachineDecl],
     supports_no_check: bool,
 ) -> MachineCheckResult {
@@ -124,7 +120,7 @@ fn check_machines_or_ast_fallback(
         return MachineCheckResult::AstFallback;
     }
 
-    let hir_machines = check_and_lower(path, source);
+    let hir_machines = check_and_lower(path, parsed);
     if hir_machines.is_empty() {
         eprintln!("No machines found in {path}");
         std::process::exit(1);
@@ -135,11 +131,11 @@ fn check_machines_or_ast_fallback(
 
 fn cmd_list(path: &str) {
     let source = read_source(path);
-    let machines = parse_machines(path, &source);
+    let (machines, parsed) = parse_machines(path, &source);
 
     // `list` renders from the AST below, but keeps fail-closed HIR validation
     // for non-generic machines.
-    check_machines_or_ast_fallback(path, &source, &machines, false);
+    check_machines_or_ast_fallback(path, &parsed, &machines, false);
 
     for md in &machines {
         println!("machine {} {{", md.name);
@@ -186,10 +182,10 @@ fn cmd_diagram(path: &str, args: &MachineDiagramArgs) {
         args.format.clone().unwrap_or(MachineFormat::Mermaid)
     };
 
-    let ast_machines = parse_machines(path, &source);
+    let (ast_machines, parsed) = parse_machines(path, &source);
 
     if args.check {
-        match check_machines_or_ast_fallback(path, &source, &ast_machines, true) {
+        match check_machines_or_ast_fallback(path, &parsed, &ast_machines, true) {
             MachineCheckResult::AstFallback => {
                 // Fall through to AST rendering below.
             }

--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -971,9 +971,6 @@ pub struct TypeAliasDecl {
 /// Records are pure data carriers: they hold named, typed fields and support
 /// generic type parameters and where-clauses.  Methods, variants, and tuple
 /// forms are not permitted (those belong to `TypeDecl`).
-///
-/// Checker support (resolving `RecordDecl` into `Ty::Record`) is deferred to
-/// slice A-3; until then the checker emits an "unsupported" diagnostic.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RecordDecl {
     #[serde(default)]

--- a/std/option.hew
+++ b/std/option.hew
@@ -117,8 +117,6 @@ pub fn unwrap_or_str(opt: Option<string>, fallback: string) -> string {
 }
 
 /// Apply `f` to the contained `string` value, or return `None` if empty.
-/// NOTE: This function is currently blocked by the heap-owning composite return
-/// boundary. It will become usable once tag-aware drop is implemented.
 pub fn map_str(opt: Option<string>, f: fn(string) -> string) -> Option<string> {
     match opt {
         Some(v) => Some(f(v)),

--- a/std/vec.hew
+++ b/std/vec.hew
@@ -3,68 +3,6 @@
 //! Pure Hew implementations for common vector operations.
 //! These replace the equivalent Rust FFI functions for simple linear scans.
 
-/// Check if a `Vec<i32>` contains `val`. Returns `true` if found.
-pub fn contains_i32(v: Vec<i32>, val: i32) -> bool { // INTERNAL-ABI: typed for 32-bit integer vector storage
-    let n = v.len();
-    for i in 0 .. n {
-        if v.get(i) == val {
-            return true;
-        }
-    }
-    false
-}
-
-/// Check if a `Vec<i64>` contains `val`.
-pub fn contains_i64(v: Vec<i64>, val: i64) -> bool { // INTERNAL-ABI: legacy typed alias; Vec<i64> == Vec<i64> in Hew
-    let n = v.len();
-    for i in 0 .. n {
-        if v.get(i) == val {
-            return true;
-        }
-    }
-    false
-}
-
-/// Check if a `Vec<f64>` contains `val`. Uses exact equality.
-///
-/// # Examples
-///
-/// ```
-/// let v: Vec<f64> = Vec::new();
-/// v.push(3.14);
-/// println(vec.contains_f64(v, 3.14));  // true
-/// println(vec.contains_f64(v, 0.0));   // false
-/// ```
-pub fn contains_f64(v: Vec<f64>, val: f64) -> bool {
-    let n = v.len();
-    for i in 0 .. n {
-        if v.get(i) == val {
-            return true;
-        }
-    }
-    false
-}
-
-/// Check if a `Vec<string>` contains `val`. Uses string equality.
-///
-/// # Examples
-///
-/// ```
-/// let v: Vec<string> = Vec::new();
-/// v.push("hello");
-/// println(vec.contains_str(v, "hello"));  // true
-/// println(vec.contains_str(v, "world"));  // false
-/// ```
-pub fn contains_str(v: Vec<string>, val: string) -> bool {
-    let n = v.len();
-    for i in 0 .. n {
-        if v.get(i) == val {
-            return true;
-        }
-    }
-    false
-}
-
 // ── index_of ──────────────────────────────────────────────────────────────
 /// Return the index of `val` in a `Vec<i32>`, or `-1` if not found.
 pub fn index_of_i32(v: Vec<i32>, val: i32) -> i64 { // INTERNAL-ABI: typed for 32-bit integer vector storage


### PR DESCRIPTION
## Summary

Removes four dead `std/vec.hew` helpers (`contains_i32`, `contains_i64`, `contains_f64`, `contains_str`) that were superseded when the runtime `Vec.contains` method was introduced; all call sites already use method syntax routed through the C-ABI runtime. Refreshes three stale "A-3" comments in `hew-parser/src/ast.rs` and `hew-analysis/src/ast_visit.rs` that claimed record type-checking was deferred — records are fully type-checked now — and rewrites an outdated `Option.map_str` comment that cited a heap-boundary limitation no longer present. Removes a redundant second parse of the machine source in `hew-cli/src/machine.rs`; the source is now parsed once in `parse_machines`, the result threaded into `check_and_lower`, so the compiler does no duplicate work and the parse-error check is not repeated.

## Verification

- `cargo nextest -p hew-parser -p hew-analysis -p hew-types`: 3411 tests pass
- `cargo nextest -p hew-cli`: 874 tests pass (machine list/diagram/error-path + doc e2e)
- `hew test` on the vec and option surface suites: pass
- clippy and fmt: clean
- `machine` fail-closed behaviour (exit 1 on invalid input) confirmed end-to-end by `machine_list_fails_closed_on_parse_error`
- Preflight: ready-to-push

## Out of scope

- Implementing record doc extraction (the doc renderer has no `DocRecord` section type yet — the comment was reworded to reflect this accurately, not implemented)
- Cosmetic `std/vec.hew` module-doc line noting that the file previously included the removed helpers