### PR TITLE
fix(types): derive marker traits structurally for Option and Result

### DIFF
--- a/hew-types/src/traits.rs
+++ b/hew-types/src/traits.rs
@@ -906,6 +906,27 @@ impl TraitRegistry {
                             .all(|a| self.implements_marker_guarded(a, marker, visiting)),
                     };
                 }
+                // Option<T> and Result<T,E>: pure value-type generic builtins.
+                // All markers derive structurally from type arguments — same rule as
+                // `implements_serializable_inner` at line ~473 which already had this arm.
+                // Resource uses ANY (not all): if any type argument is a built-in resource
+                // handle (Duplex, LambdaPid, CancellationToken), the wrapper MAY hold one and
+                // must be treated as a resource too. Note: user `#[resource]` types (e.g.
+                // `#[resource] type Conn { fd: i64 }`) return Resource=false from their own
+                // structural field derivation (fields like i64 are not Resource), so
+                // Option<user_resource> is correctly Resource=false here. Variant-aware close
+                // for user-resource payloads inside Option/Result requires separate work in
+                // MIR/codegen and is tracked as a follow-on lane.
+                if matches!(builtin, Some(BuiltinType::Option | BuiltinType::Result)) {
+                    return match marker {
+                        MarkerTrait::Resource => args
+                            .iter()
+                            .any(|a| self.implements_marker_guarded(a, marker, visiting)),
+                        _ => args
+                            .iter()
+                            .all(|a| self.implements_marker_guarded(a, marker, visiting)),
+                    };
+                }
                 // Rc<T>: reference-counted, single-threaded — explicitly NOT Send or Sync.
                 // Supports Clone (inc ref-count) and Drop (dec ref-count); NOT Copy or Frozen.
                 if *builtin == Some(BuiltinType::Rc) {
@@ -1126,8 +1147,12 @@ mod tests {
 
     #[test]
     fn test_option_derives_from_inner() {
-        let mut registry = TraitRegistry::new();
-        registry.register_type("Option".to_string(), vec![Ty::I32]);
+        // Previously this test registered "Option" manually, which masked the bug:
+        // `type_fields.get("Option")` would return Some and happen to pass.
+        // The production path NEVER registers Option via register_type — builtins are
+        // handled by the `matches!(builtin, Some(BuiltinType::Option | ...))` arm.
+        // Use a plain TraitRegistry::new() so the test exercises the real production path.
+        let registry = TraitRegistry::new();
         let option_i32 = Ty::option(Ty::I32);
         assert!(registry.is_send(&option_i32));
         assert!(registry.implements_marker(&option_i32, MarkerTrait::Copy));

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -1348,6 +1348,34 @@ fn actor_ref_send_method_requires_send_payload() {
     );
 }
 
+/// Regression test for F-02: `receive fn -> Option<i64>` must typecheck without
+/// `E_DUPLEX_NON_SEND`. Before the fix, `Option` fell through the marker-derivation
+/// arms to `type_fields.get("Option") → None → false`, so every ask-shaped receive fn
+/// returning `Option<T>` was incorrectly rejected.
+#[test]
+fn actor_receive_fn_option_reply_accepted() {
+    let output = typecheck_inline(
+        r"
+        actor Queue {
+            let items: Vec<i64>;
+            receive fn dequeue() -> Option<i64> {
+                None
+            }
+        }
+
+        fn main() {
+            let q = spawn Queue(items: Vec::new());
+            let _item = await q.dequeue();
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "actor receive fn returning Option<i64> must typecheck cleanly (F-02 regression), got: {:#?}",
+        output.errors
+    );
+}
+
 /// The `<-` send operator was removed in v0.5.  Both the lexer token and the
 /// parser infix rule are gone; any source using `<-` now fails to parse.
 /// This is the `E_OPERATOR_REMOVED` reject path (§3.3 of the migration guide).

--- a/hew-types/tests/trait_coverage.rs
+++ b/hew-types/tests/trait_coverage.rs
@@ -786,3 +786,143 @@ fn primitives_are_not_resource() {
         );
     }
 }
+
+// ===========================================================================
+// Option<T> and Result<T,E> — structural marker derivation (F-02 fix)
+// ===========================================================================
+
+/// `Option<i64>` derives Send, Copy, and Frozen from `i64` (all three hold).
+/// Tests the production path via `Ty::option(Ty::I64)` — no `register_type` scaffolding.
+#[test]
+fn option_i64_is_send_copy_frozen() {
+    let reg = TraitRegistry::new();
+    let opt = Ty::option(Ty::I64);
+    assert!(
+        reg.implements_marker(&opt, MarkerTrait::Send),
+        "Option<i64> must be Send (i64 is Send)"
+    );
+    assert!(
+        reg.implements_marker(&opt, MarkerTrait::Copy),
+        "Option<i64> must be Copy (i64 is Copy)"
+    );
+    assert!(
+        reg.implements_marker(&opt, MarkerTrait::Frozen),
+        "Option<i64> must be Frozen (i64 is Frozen)"
+    );
+}
+
+/// `Option<string>` is Send (string is Send) but NOT Copy or Frozen (string is heap).
+#[test]
+fn option_string_is_send_not_copy() {
+    let reg = TraitRegistry::new();
+    let opt = Ty::option(Ty::String);
+    assert!(
+        reg.implements_marker(&opt, MarkerTrait::Send),
+        "Option<string> must be Send"
+    );
+    assert!(
+        !reg.implements_marker(&opt, MarkerTrait::Copy),
+        "Option<string> must NOT be Copy (string is not Copy)"
+    );
+    assert!(
+        !reg.implements_marker(&opt, MarkerTrait::Frozen),
+        "Option<string> must NOT be Frozen (string is not Frozen)"
+    );
+}
+
+/// `Option<Rc<i64>>` is NOT Send — proves the fix does not over-grant.
+/// The structural arm propagates the Send check into Rc<i64>, which is correctly not-Send.
+#[test]
+fn option_rc_is_not_send() {
+    let reg = TraitRegistry::new();
+    let opt = Ty::option(Ty::rc(Ty::I64));
+    assert!(
+        !reg.implements_marker(&opt, MarkerTrait::Send),
+        "Option<Rc<i64>> must NOT be Send (Rc is not Send)"
+    );
+}
+
+/// `Result<i64, string>` is Send — both type args are Send.
+#[test]
+fn result_i64_string_is_send() {
+    let reg = TraitRegistry::new();
+    let res = Ty::result(Ty::I64, Ty::String);
+    assert!(
+        reg.implements_marker(&res, MarkerTrait::Send),
+        "Result<i64, string> must be Send"
+    );
+}
+
+/// `Result<i64, Rc<i64>>` is NOT Send — the error arm contains a non-Send Rc.
+/// Proves the fix does not over-grant when only one arg fails.
+#[test]
+fn result_rc_err_is_not_send() {
+    let reg = TraitRegistry::new();
+    let res = Ty::result(Ty::I64, Ty::rc(Ty::I64));
+    assert!(
+        !reg.implements_marker(&res, MarkerTrait::Send),
+        "Result<i64, Rc<i64>> must NOT be Send (Rc in error position is not Send)"
+    );
+}
+
+/// `Option<T>` is not a Resource when `T` is a non-resource primitive.
+/// The structural `any()` arm correctly propagates: non-resource args → not Resource.
+#[test]
+fn option_is_not_resource() {
+    let reg = TraitRegistry::new();
+    assert!(
+        !reg.implements_marker(&Ty::option(Ty::I64), MarkerTrait::Resource),
+        "Option<i64> must not be Resource"
+    );
+    assert!(
+        !reg.implements_marker(&Ty::option(Ty::String), MarkerTrait::Resource),
+        "Option<string> must not be Resource"
+    );
+}
+
+/// `Result<T,E>` is not a Resource when neither `T` nor `E` is a resource.
+#[test]
+fn result_is_not_resource() {
+    let reg = TraitRegistry::new();
+    assert!(
+        !reg.implements_marker(&Ty::result(Ty::I64, Ty::String), MarkerTrait::Resource),
+        "Result<i64, string> must not be Resource"
+    );
+}
+
+/// `Option<Duplex<i64,i64>>` IS a Resource — the inner Duplex is a built-in
+/// resource handle (`Resource => true`). The structural `any()` arm propagates
+/// this: a wrapper holding a resource handle is itself conditionally a resource.
+#[test]
+fn option_duplex_is_resource() {
+    let reg = TraitRegistry::new();
+    let opt = Ty::option(Ty::duplex(Ty::I64, Ty::I64));
+    assert!(
+        reg.implements_marker(&opt, MarkerTrait::Resource),
+        "Option<Duplex<i64,i64>> must be Resource (inner Duplex is a resource handle)"
+    );
+}
+
+/// `Result<Duplex<i64,i64>, i64>` IS a Resource — the Ok arm is a Duplex.
+/// Uses `any()`: one resource arg makes the wrapper a resource.
+#[test]
+fn result_duplex_ok_is_resource() {
+    let reg = TraitRegistry::new();
+    let res = Ty::result(Ty::duplex(Ty::I64, Ty::I64), Ty::I64);
+    assert!(
+        reg.implements_marker(&res, MarkerTrait::Resource),
+        "Result<Duplex<i64,i64>, i64> must be Resource (Ok arm is a resource handle)"
+    );
+}
+
+/// `Result<i64, Duplex<i64,i64>>` IS a Resource — the Err arm is a Duplex.
+/// Proves `any()` covers the error arm too.
+#[test]
+fn result_duplex_err_is_resource() {
+    let reg = TraitRegistry::new();
+    let res = Ty::result(Ty::I64, Ty::duplex(Ty::I64, Ty::I64));
+    assert!(
+        reg.implements_marker(&res, MarkerTrait::Resource),
+        "Result<i64, Duplex<i64,i64>> must be Resource (Err arm is a resource handle)"
+    );
+}


### PR DESCRIPTION
## Summary

`Option<T>` and `Result<T,E>` were treated as not-Send (and not-Copy/Frozen/etc.) regardless of their type arguments, so an actor `receive fn` returning `Option<T>`/`Result<T,E>` failed with `E_DUPLEX_NON_SEND` — blocking natural queue/registry/lookup APIs. They now derive marker traits structurally from their type arguments: `Option<i64>` is Send/Copy, `Option<string>` is Send (not Copy), `Option<Rc<_>>` and `Result<_, Rc<_>>` stay not-Send (no over-grant). The `Resource` marker derives structurally too — a built-in handle in either position makes the wrapper a resource.

## Verification

- `cargo test -p hew-types`: 1413 passed, 0 failed (10 new derivation tests, including the Rc no-over-grant cases)
- `make test-compiler-pipeline`: 6177 passed, 30 skipped, zero fixtures flipped
- An actor `receive fn dequeue() -> Option<i64>` now type-checks (previously rejected with `E_DUPLEX_NON_SEND`)
- Preflight: ready-to-push

## Out of scope

- Variant-aware close for a user `#[resource]` payload wrapped in `Option`/`Result` (`Option<Conn>` etc.) — a pre-existing resource-hygiene gap in the separate drop/close mechanism, not this marker derivation change; this change does not introduce or worsen it. Tracked as a follow-up.