### PR TITLE
fix(mir): cancel scope-exit drop of owned Vec moved into spawned actor state

### DIFF
--- a/hew-cli/tests/vec_owned_clone_leak_oracle.rs
+++ b/hew-cli/tests/vec_owned_clone_leak_oracle.rs
@@ -1,0 +1,338 @@
+//! Owned-element `Vec<T>::clone()` receiver-borrow leak oracle.
+//!
+//! ## The leak this pins
+//!
+//! `v.clone()` on an owned-element `Vec<T>` (an element that owns heap — here
+//! `Vec<Vec<string>>`) lowers to `hew_vec_clone_owned`, which deep-clones each
+//! element through the descriptor `clone_fn` into a FRESH, independently owned
+//! Vec. The original receiver `v` is only BORROWED: it keeps its own buffer and
+//! must keep its scope-exit `hew_vec_free_owned`.
+//!
+//! The MIR drop elaborator decides which owned Vecs earn that release with the
+//! fail-closed escape-scan `derive_local_collection_drop_allowed`
+//! (`hew-mir/src/lower.rs`), which excludes any candidate read by an
+//! unclassified runtime call as an owning escape. `hew_vec_clone_owned` was
+//! ABSENT from the receiver-borrow allow-list (`is_vec_receiver_borrow_symbol`)
+//! even though its siblings `hew_vec_clone` / `hew_vec_clone_layout` were
+//! present, so a local owned-element Vec used as the receiver of `.clone()` was
+//! treated as escaped, dropped from `owned_vec_drop_allowed`, and never freed.
+//! The clone RESULT was released, but the ORIGINAL handle (its buffer, every
+//! inner collection handle/buffer, and every element string) leaked on each
+//! scope exit. The fix adds `hew_vec_clone_owned` to the receiver-borrow
+//! classifier (it is a borrow, not an ownership hand-off).
+//!
+//! ## Slope methodology
+//!
+//! Mirrors `nested_vec_push_leak_oracle.rs` / `vec_local_drop_leak_oracle.rs`:
+//! compile the same clone-in-a-loop shape at a LOW and a HIGH frame count,
+//! measure leak NODE counts under `leaks --atExit` with the poisoned-allocator
+//! triple, and assert the delta stays within a small constant independent of
+//! frames. The pre-fix bug class is PER-FRAME GROWTH — the original receiver's
+//! whole tree leaks every iteration — which over the `50 - 3 = 47`-frame delta
+//! lands an order of magnitude above the +5 tolerance. Absolute counts are
+//! deliberately not asserted; runtime/scheduler one-off allocations jitter by
+//! a node or two.
+//!
+//! ## Deep-clone independence + no-double-free pin
+//!
+//! A second fixture mutates the clone (`w.push(..)`) after `let w = v.clone()`
+//! and asserts the original `v` is unchanged (length + inner row intact) and
+//! the program exits cleanly with the exact reconstruction under
+//! `MallocScribble`/`MallocPreScribble`/`MallocGuardEdges`. If the clone
+//! aliased the receiver's buffer instead of deep-copying, the independent
+//! release of two handles over one allocation would double-free (crash under
+//! the poisoned allocator) or the mutation would corrupt `v`.
+//!
+//! ## Skip behaviour
+//!
+//! The slope oracle is macOS-only (`leaks(1)` is Darwin's allocator inspector);
+//! on other platforms it logs `skip:` and returns. The scribble pin runs on any
+//! unix host.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+/// Low frame count: exercises the loop back-edge at least twice while staying
+/// near the constant-overhead floor.
+const LOW_FRAMES: usize = 3;
+
+/// High frame count for the slope check. A per-frame leak of the original
+/// receiver tree (outer handle + buffer + inner handle + buffer + element
+/// strings) lands well above the tolerance over the 47-frame delta.
+const HIGH_FRAMES: usize = 50;
+
+/// Maximum permitted leak-node delta between the HIGH and LOW probes. Same
+/// headroom rationale as the sibling oracles: absorbs one-off
+/// scheduler/runtime allocations that appear only in the HIGH run while still
+/// catching a slope of ~0.1 leaks/frame.
+const SLOPE_TOLERANCE: usize = 5;
+
+// ── fixtures ──────────────────────────────────────────────────────────────
+
+/// Per-frame clone-and-drop shape for the leak slope: each iteration builds a
+/// fresh owned-element `Vec<Vec<string>>`, clones it into `w`, reads BOTH, and
+/// lets both go out of scope on the back-edge. Post-fix the original receiver
+/// `v` keeps its scope-exit `hew_vec_free_owned` (it is only borrowed by
+/// `clone`), so both trees are released each frame and the leak count is flat.
+/// Pre-fix `v` was excluded from the drop allow-set and its whole tree leaked
+/// every iteration.
+fn owned_vec_clone_drop_loop_source(frames: usize) -> String {
+    format!(
+        "fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let v: Vec<Vec<string>> = [];\n\
+         \x20       let row: Vec<string> = [];\n\
+         \x20       row.push(\"owned-clone-leak-oracle-cell-one\");\n\
+         \x20       row.push(\"owned-clone-leak-oracle-cell-two\");\n\
+         \x20       v.push(row);\n\
+         \x20       let w = v.clone();\n\
+         \x20       total = total + v.len() + w.len() + v.get(0).len();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Deep-clone independence + no-double-free pin: `w = v.clone()` then mutate `w`
+/// only. `v` must stay one row of two cells; `w` must have the extra row. Exact
+/// reconstruction proves the clone deep-copied (no alias of `v`'s buffer) and
+/// both handles release independently under the poisoned allocator.
+const OWNED_VEC_CLONE_INDEPENDENT_SOURCE: &str = "\
+fn main() {\n\
+\x20   let v: Vec<Vec<string>> = [];\n\
+\x20   let row: Vec<string> = [];\n\
+\x20   row.push(\"orig-aaa\");\n\
+\x20   row.push(\"orig-bbb\");\n\
+\x20   v.push(row);\n\
+\x20   let w = v.clone();\n\
+\x20   let extra: Vec<string> = [];\n\
+\x20   extra.push(\"clone-ccc\");\n\
+\x20   w.push(extra);\n\
+\x20   print(f\"v{v.len()}r{v.get(0).len()}c;w{w.len()}r;\");\n\
+\x20   print(\"OK\");\n\
+}\n";
+
+/// Expected exact output: `v` is untouched by `w`'s push (deep clone), so one
+/// row of two cells; `w` gained a second row.
+const OWNED_VEC_CLONE_INDEPENDENT_EXPECTED: &str = "v1r2c;w2r;OK";
+
+// ── leak measurement plumbing (same shape as nested_vec_push_leak_oracle) ───
+
+/// Compile `source` to a native binary via `hew compile --emit-dir` and return
+/// the binary path.
+fn compile_to_native(source: &str, dir: &std::path::Path, name: &str) -> PathBuf {
+    let hew_src = dir.join(format!("{name}.hew"));
+    std::fs::write(&hew_src, source).expect("write hew source");
+
+    let output = Command::new(hew_binary())
+        .args([
+            "compile",
+            "--emit-dir",
+            dir.to_str().expect("emit-dir utf-8"),
+            hew_src.to_str().expect("hew src utf-8"),
+        ])
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew compile");
+
+    assert!(
+        output.status.success(),
+        "hew compile failed for {name}:\n{}",
+        describe_output(&output)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let bin = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("native: "))
+        .unwrap_or_else(|| panic!("no `native:` line for {name}:\n{stdout}"))
+        .to_string();
+    PathBuf::from(bin)
+}
+
+/// Run `bin` under the poisoned-allocator triple + `leaks --atExit` and return
+/// `Some(leak_count)` when `leaks` produced a usable report.
+fn measure_leaks(bin: &std::path::Path) -> Option<usize> {
+    let output = Command::new("leaks")
+        .arg("--atExit")
+        .arg("--")
+        .arg(bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .ok()?;
+    if !output.status.success() && output.stdout.is_empty() {
+        eprintln!(
+            "skip: leaks declined to attach to {}: {}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+    let report = String::from_utf8_lossy(&output.stdout);
+    let mut parsed: Option<usize> = None;
+    for line in report.lines() {
+        if !line.contains(" leaks for ") && !line.contains(" leak for ") {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("Process ") {
+            if !rest.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+                continue;
+            }
+            if let Some(after_colon) = rest.split_once(": ").map(|(_, s)| s) {
+                if let Some(n) = after_colon.split_whitespace().next() {
+                    if let Ok(n) = n.parse::<usize>() {
+                        eprintln!("  parsed leak count from line: {line}");
+                        parsed = Some(n);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    if parsed.is_none() {
+        eprintln!(
+            "skip: leaks did not emit a `Process <pid>: N leak(s) for B total leaked bytes.` \
+             summary for {}: stderr=\n{}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    parsed
+}
+
+/// Build `shape_name` at `low_frames` and `high_frames`, measure leak NODE
+/// counts, and assert the delta stays within `SLOPE_TOLERANCE`.
+fn assert_frame_slope_below_tolerance(
+    shape_name: &str,
+    source_fn: fn(usize) -> String,
+    low_frames: usize,
+    high_frames: usize,
+) {
+    if !cfg!(target_os = "macos") {
+        eprintln!("skip: {shape_name}: leaks(1) is macOS-only");
+        return;
+    }
+    let leaks_avail = Command::new("which")
+        .arg("leaks")
+        .output()
+        .is_ok_and(|o| o.status.success());
+    if !leaks_avail {
+        eprintln!("skip: {shape_name}: `leaks` binary not on PATH");
+        return;
+    }
+
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("vec-owned-clone-leak-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+
+    let bin_low = compile_to_native(
+        &source_fn(low_frames),
+        dir.path(),
+        &format!("{shape_name}_low"),
+    );
+    let bin_high = compile_to_native(
+        &source_fn(high_frames),
+        dir.path(),
+        &format!("{shape_name}_high"),
+    );
+
+    let Some(low_leaks) = measure_leaks(&bin_low) else {
+        return;
+    };
+    let Some(high_leaks) = measure_leaks(&bin_high) else {
+        return;
+    };
+
+    eprintln!(
+        "{shape_name}: low_frames={low_frames} low_leaks={low_leaks} \
+         high_frames={high_frames} high_leaks={high_leaks} \
+         tolerance={SLOPE_TOLERANCE}"
+    );
+    assert!(
+        high_leaks <= low_leaks + SLOPE_TOLERANCE,
+        "{shape_name}: per-frame leak SLOPE — low_frames={low_frames} low_leaks={low_leaks}, \
+         high_frames={high_frames} high_leaks={high_leaks}. Excess of {} NODES over the \
+         tolerance of {SLOPE_TOLERANCE} indicates the original owned Vec receiver of `.clone()` \
+         is not being released — `hew_vec_clone_owned` must be classified as a receiver borrow so \
+         the receiver keeps its scope-exit `hew_vec_free_owned`. Re-run with \
+         `MallocStackLogging=1 leaks --atExit -- {}` to see the leaked stack.",
+        high_leaks.saturating_sub(low_leaks + SLOPE_TOLERANCE),
+        bin_high.display()
+    );
+}
+
+/// Compile `source`, run it under the poisoned-allocator triple, and assert it
+/// exits cleanly with `expected` on stdout.
+fn assert_exact_under_malloc_scribble(name: &str, source: &str, expected: &str) {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("vec-owned-clone-{name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), name);
+
+    let output = Command::new(&bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .unwrap_or_else(|error| panic!("run {name} binary: {error}"));
+
+    assert!(
+        output.status.success(),
+        "{name} must run clean under the poisoned allocator — a crash here indicates the clone \
+         aliased the receiver's buffer and the two independent releases double-freed it;\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        expected,
+        "{name} must reconstruct the original verbatim — a differing/empty cell or wrong length \
+         indicates `w = v.clone()` aliased `v` instead of deep-copying;\n{}",
+        describe_output(&output)
+    );
+}
+
+// ── oracles ─────────────────────────────────────────────────────────────────
+
+/// THE clone-leak regression: the original receiver of `.clone()` on an
+/// owned-element `Vec<Vec<string>>` must keep its scope-exit release, so the
+/// per-frame leak slope is flat. Reverting the `hew_vec_clone_owned` classifier
+/// entry re-excludes the receiver and grows the leak ~6 nodes/frame, ~282 NODES
+/// over the 47-frame delta — far above the +5 tolerance.
+#[test]
+fn owned_vec_clone_receiver_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "owned_vec_clone_drop_loop",
+        owned_vec_clone_drop_loop_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// Deep-clone independence + no-double-free: mutating the clone leaves the
+/// original intact and both handles release once under the poisoned allocator.
+#[test]
+fn owned_vec_clone_independent_under_malloc_scribble() {
+    assert_exact_under_malloc_scribble(
+        "owned_vec_clone_independent",
+        OWNED_VEC_CLONE_INDEPENDENT_SOURCE,
+        OWNED_VEC_CLONE_INDEPENDENT_EXPECTED,
+    );
+}

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -24375,19 +24375,37 @@ fn elaborate(
     );
 
     // W5.016 — owned-element `Vec<T>` scope-exit drop allow-set. An owned Vec
-    // is admitted for the `hew_vec_free_owned` release UNLESS it is consumed or
-    // maybe-consumed at any exit (for-in `into_iter` moves it, a return moves it
-    // to the ReturnSlot, a rebind moves it). The per-exit `Live` filter in
-    // `enumerate_exits` is the final authority on which exits actually fire the
-    // drop; this allow-set is the conservative gate that removes any binding the
-    // dataflow proves leaves this scope's ownership, so the drop never
-    // double-frees a moved-out Vec (`raii-null-after-move`, `cleanup-all-exits`).
-    let mut owned_vec_drop_allowed: HashSet<BindingId> = builder
-        .owned_locals
-        .iter()
-        .filter(|(_, _, ty)| builder.binding_ty_is_owned_element_vec(ty))
-        .map(|(binding, _, _)| *binding)
-        .collect();
+    // earns its `hew_vec_free_owned` release UNLESS the fail-closed escape-scan
+    // proves it leaves this scope's sole ownership — most importantly a handle
+    // moved into an actor's initial state (`spawn A(tasks: t)`, which lowers to
+    // `RecordInit` → `SpawnActor`). That ingress sets the source's dataflow
+    // state to `AliasedIntoAggregate`, NOT `Consumed`, so the `Consumed` /
+    // `MaybeConsumed` filter alone left it Live at the exit and fired a second
+    // `hew_vec_free_owned` against the handle the actor's `state_drop_fn` now
+    // owns — the F-01 use-after-free → SIGSEGV. The escape-scan — the SAME
+    // `derive_local_collection_drop_allowed` authority the HashMap/HashSet,
+    // closure-pair Vec, and bytes arms use — is the primary gate: it removes the
+    // spawn-moved / returned / aggregate-stored handle from the LIFO before the
+    // per-exit `Live` filter in `enumerate_exits` ever sees it, while its
+    // receiver-borrow classifier (`is_vec_receiver_borrow_symbol` /
+    // `is_vec_copy_in_element_store_symbol`) keeps a normal owned Vec whose only
+    // reads are `push` / `get` / `len` admitted (those borrow arg[0] / deep-clone
+    // the element, they do not escape the handle). The dataflow `Consumed` /
+    // `MaybeConsumed` removal below is the same belt-and-suspenders net the
+    // sibling arms keep for a handle moved out by a by-value consume; the
+    // interior-alias retain and `dedup_whole_value_handoff` further down close
+    // the `vec.get(i)` ingress-borrow and array-literal-desugar handoff cases.
+    // Every direction only ever over-EXCLUDES (leak), never re-admits — a handle
+    // the prover did not clear is never double-freed
+    // (`drop-allowset-from-value-flow`, `boundary-fail-closed`,
+    // `raii-null-after-move`, `cleanup-all-exits`).
+    let mut owned_vec_drop_allowed = derive_local_collection_drop_allowed(
+        &checked.blocks,
+        &builder.suspend_kinds,
+        &builder.owned_locals,
+        &builder.binding_locals,
+        |ty| builder.binding_ty_is_owned_element_vec(ty),
+    );
     for states in dataflow_result.exit_states.values() {
         for (binding, state) in states {
             if matches!(

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -31857,7 +31857,12 @@ fn ty_is_local_collection_handle(ty: &ResolvedTy) -> bool {
 ///   - `append` / `append_layout` — extends arg[0] with copies of arg[1]'s
 ///     elements; borrows BOTH vecs (arg[1] is scanned by the arg-tail rule
 ///     and over-excludes — a leak, never a double free).
-///   - `clone` / `clone_layout` — deep copy; the result is a fresh handle.
+///   - `clone` / `clone_layout` / `clone_owned` — deep copy; the receiver is
+///     read element-by-element and the result is a fresh, independently owned
+///     handle (`clone_owned` deep-clones each owned element via the descriptor
+///     `clone_fn`). The receiver keeps its own buffer and MUST retain its
+///     scope-exit drop — omitting `clone_owned` here over-excludes the original
+///     owned-element Vec and leaks it (`drop-allowset-from-value-flow`).
 ///
 /// The typed scalar variants (`*_bool` / `*_i32` / `*_i64` / `*_f64`) are the
 /// MIR-level symbols the checker / HIR array-literal desugar resolve for
@@ -31943,6 +31948,7 @@ fn is_vec_receiver_borrow_symbol(callee: &str) -> bool {
             | "hew_vec_append_layout"
             | "hew_vec_clone"
             | "hew_vec_clone_layout"
+            | "hew_vec_clone_owned"
             | "hew_vec_join_str"
     )
 }

--- a/tests/vertical-slice/accept/f01_actor_spawn_owned_vec_drop_segv.hew
+++ b/tests/vertical-slice/accept/f01_actor_spawn_owned_vec_drop_segv.hew
@@ -1,0 +1,57 @@
+// F-01 regression: owned-element Vec moved into a spawned actor's initial state
+// must NOT also get a scope-exit `hew_vec_free_owned` in the spawning function.
+//
+// The bug (100% deterministic UAF -> SIGSEGV, exit 139):
+//   `let t = Vec::new(); let q = spawn TaskQueue(tasks: t);` lowers to
+//   `RecordInit -> SpawnActor`, which marks `t` as `AliasedIntoAggregate` (NOT
+//   `Consumed`). The owned-Vec drop allow-set was derived dataflow-only, so the
+//   `Consumed`/`MaybeConsumed` filter left `t` admitted and emitted a scope-exit
+//   `hew_vec_free_owned(P)`. The actor's handler reassigns `self.tasks`, freeing
+//   the same handle P first; the spawning function's scope-exit drop then
+//   double-frees the already-freed handle -> use-after-free -> SIGSEGV.
+//
+// The fix derives `owned_vec_drop_allowed` from the shared escape-scan
+// (`derive_local_collection_drop_allowed`) the sibling HashMap/HashSet/plain-Vec
+// allow-sets use: it removes the spawn-moved handle from the LIFO before the
+// per-exit Live filter runs, so the actor's `state_drop_fn` is the sole owner.
+//
+// Exit 0 proves the program runs through scope exit (the `println("done")` past
+// the drop site) without the double-free. Requires all three triggers: named
+// binding, owned-element Vec (heap field), and a handler that reassigns the
+// field.
+
+type WorkItem {
+    name: string;
+    priority: i64;
+}
+
+actor TaskQueue {
+    var tasks: Vec<WorkItem>;
+
+    receive fn enqueue(item: WorkItem) {
+        tasks.push(item);
+    }
+
+    receive fn remove_front() -> i64 {
+        let new_tasks: Vec<WorkItem> = Vec::new();
+        var i = 1;
+        while i < tasks.len() {
+            new_tasks.push(tasks.get(i));
+            i = i + 1;
+        }
+        tasks = new_tasks;
+        1
+    }
+}
+
+fn main() {
+    let t: Vec<WorkItem> = Vec::new();
+    let q = spawn TaskQueue(tasks: t);
+    q.enqueue(WorkItem { name: "only", priority: 1 });
+    let r = await q.remove_front();
+    match r {
+        Ok(n) => println(f"r={n}"),
+        Err(_) => println("err"),
+    }
+    println("done");
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -598,6 +598,20 @@ run_accept_expect_status "actor_multi_on_stop" 0
 # value is returned and the loser channel is cancelled without leaking.
 run_accept_expect_status "actor_ask_race" 42
 
+# F-01 regression (P0 UAF): an owned-element `Vec<WorkItem>` moved into a spawned
+# actor's initial state (`let t = Vec::new(); spawn TaskQueue(tasks: t)`) lowers
+# the source `t` to `AliasedIntoAggregate` (NOT `Consumed`). Pre-fix the owned-Vec
+# drop allow-set was dataflow-only, so the `Consumed`/`MaybeConsumed` filter left
+# `t` admitted and emitted a scope-exit `hew_vec_free_owned` against the handle the
+# actor's `state_drop_fn` already owns — a double-free (SIGSEGV(139) on older
+# trunks; `abort_owned_descriptor_missing` on the runtime's fail-closed guard
+# now). The fix derives the allow-set from the shared escape-scan
+# (`derive_local_collection_drop_allowed`) that removes the spawn-moved handle.
+# Exit 0 proves the program runs past the scope-exit drop site (`println("done")`)
+# with no double-free. Requires all three triggers: named binding, owned-element
+# Vec, handler reassigns the field.
+run_accept_expect_status "f01_actor_spawn_owned_vec_drop_segv" 0
+
 # select{} with OWNED-string ask arms (#1739/#1735): FastWorker returns an owned
 # `string` and wins; SlowWorker sleeps 50 ms and loses, its owned reply released
 # on the loser teardown leg by the channel's registered destructor (no leak, no


### PR DESCRIPTION
## Summary

A `Vec<T>` bound to a local, moved into a spawned actor's initial state, and later reassigned by the actor handler triggered a deterministic SIGSEGV: the local's scope-exit `hew_vec_free_owned` double-freed the handle the actor now exclusively owns. The owned-element-Vec drop allow-set now derives from the value-flow escape scan — the same authority the HashMap, plain-Vec, closure-pair, and bytes allow-sets already use — instead of a dataflow-only filter. A handle that escapes into spawn state is excluded from scope-exit drops; the actor's `state_drop_fn` is the sole owner.

A companion fix closes a related over-exclusion introduced by the same change: `Vec<T>::clone()` lowers to `hew_vec_clone_owned`, which was absent from the receiver-borrow classifier. The escape scan read the clone receiver as an owning-sink escape and suppressed its scope-exit free, leaking the receiver's buffer and all owned elements. Adding `hew_vec_clone_owned` to the receiver-borrow set restores the receiver's drop.

## Verification

- `f01_actor_spawn_owned_vec_drop_segv` (new vertical slice): exits 0; reverts to exit 134 / SIGSEGV without the fix (non-deterministic, confirmed by forced-ordering repro).
- `vec_owned_clone_leak_oracle` (new; `leaks --atExit` + `MallocScribble`): flat per-frame slope (0 leaks at 3 frames, 0 leaks at 50 frames); receiver freed exactly once, no double-free; bites on revert at ~6 leaked nodes/frame.
- All 8 owned-Vec/collection leak oracles (27 cases total): drop-leak == 0 — no over-exclusion of normal owned Vecs.
- `make test-hew-ratchet`: green — 3 tracked expected failures match; no new failures, no unexpected passes.
- `make ci-preflight`: RC 0.
- Pre-push preflight: pass.

## Out of scope

- Unit-level negative-control test typed on an owned-element `Vec<record>` asserting the spawn-escape path is excluded and a push-only Vec is admitted (covered today at the oracle and E2E levels; backlog item for the next time this arm is touched).
- Dedicated spawn-then-cancel-mid-await vertical slice fixture (the async-cancel path is sound by construction — the single LIFO allow-set gate applies uniformly across all exit legs; tracked as belt-and-suspenders hardening).
