### PR TITLE
fix(types): keep Self::Item deferred in impl-body check; implement lazy Map/fold/count/collect

### DIFF
--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -1238,24 +1238,42 @@ impl Checker {
                     }
                 }
                 if let Some(alias_name) = name.strip_prefix("Self::") {
-                    // No impl scope: in a trait method body (signature), the
+                    // Resolving a trait method's declared signature: the
                     // `Self::Bar` projection must materialise as a deferred
-                    // `Ty::AssocType` so that downstream call sites (where
+                    // `Ty::AssocType` carrier so downstream call sites (where
                     // `Self` substitutes to a concrete type or a type param
-                    // with a bound) can collapse it. Look up the enclosing
-                    // trait via `current_trait_for_self_projection`.
-                    if self.impl_alias_scopes.is_empty() {
-                        if let Some(trait_name) = self.current_trait_for_self_projection.clone() {
-                            return Ty::AssocType {
-                                base: Box::new(Ty::Named {
-                                    builtin: None,
-                                    name: "Self".to_string(),
-                                    args: vec![],
-                                }),
-                                trait_name: trait_name.into_boxed_str(),
-                                assoc_name: alias_name.to_string().into_boxed_str(),
-                            };
-                        }
+                    // with an `Iterator<Item = …>` bound) can collapse it.
+                    //
+                    // `current_trait_for_self_projection` is set ONLY while a
+                    // trait method's signature is being resolved
+                    // (`register_trait_method_sig`, `lookup_trait_method`,
+                    // `lookup_trait_method_with_origin_inner`), where `Self` is
+                    // the trait's abstract Self. Prefer the carrier whenever it
+                    // is set — independent of whether an impl alias scope is
+                    // currently active.
+                    //
+                    // Q004: gating this on `impl_alias_scopes.is_empty()` was
+                    // wrong. An impl body-check (e.g.
+                    // `impl Iterator for Map { type Item = B; fn next … }`)
+                    // pushes the impl's `type Item = B` alias scope and then,
+                    // for an inner `it.next()`, triggers a trait-method lookup
+                    // that re-resolves `Iterator::next`'s `-> Option<Self::Item>`
+                    // from raw AST. With the scope active the carrier path was
+                    // skipped and `Self::Item` collapsed to the impl's concrete
+                    // `B`, mistyping the inner iterator's item and producing a
+                    // spurious "expected A, found B". The impl-alias path below
+                    // still owns the distinct case where an impl body resolves
+                    // its OWN `Self::Item` (projection flag unset).
+                    if let Some(trait_name) = self.current_trait_for_self_projection.clone() {
+                        return Ty::AssocType {
+                            base: Box::new(Ty::Named {
+                                builtin: None,
+                                name: "Self".to_string(),
+                                args: vec![],
+                            }),
+                            trait_name: trait_name.into_boxed_str(),
+                            assoc_name: alias_name.to_string().into_boxed_str(),
+                        };
                     }
                     if let Some(alias_ty) = self.resolve_impl_associated_type(alias_name) {
                         if type_args.as_ref().is_some_and(|args| !args.is_empty()) {

--- a/hew-types/tests/q004_self_item_projection.rs
+++ b/hew-types/tests/q004_self_item_projection.rs
@@ -1,0 +1,156 @@
+//! Q004 regression: a trait method's `Self::Item` projection must stay a
+//! deferred `Ty::AssocType` carrier when the method signature is re-resolved
+//! *inside an impl body* (where an impl alias scope is active).
+//!
+//! Root cause (fixed in `check/resolution.rs`): the `Self::Bar` carrier path
+//! was gated on `impl_alias_scopes.is_empty()`. An impl body-check (e.g.
+//! `impl Iterator for Map { type Item = B; fn next … }`) pushes the impl's
+//! `type Item = B` alias scope and then, for an inner `it.next()`, re-resolves
+//! `Iterator::next`'s `-> Option<Self::Item>` from raw AST. With the scope
+//! active the carrier path was skipped and `Self::Item` collapsed to the
+//! impl's concrete `B`, mistyping the inner iterator's item and producing a
+//! spurious "expected A, found B". The fix prefers the carrier whenever a
+//! trait-method signature is being resolved
+//! (`current_trait_for_self_projection` is set), independent of the alias
+//! scope.
+//!
+//! These three cases lock the fix:
+//!   * `q004_map_next_body_passes`     — the generic `Map<I, A, B>` adapter
+//!     (inner item `A`, produced item `B`). FAILS pre-fix ("expected A,
+//!     found B"); PASSES post-fix.
+//!   * `q004_inherent_impl_next_passes` — a concrete `i64 → bool` adapter
+//!     whose `Self::Item` (`bool`) differs from the inner item (`i64`).
+//!     FAILS pre-fix ("expected i64, found bool" at `x > 0`); PASSES
+//!     post-fix.
+//!   * `q004_fold_body_passes`         — a free-function `fold` over
+//!     `I: Iterator<Item = A>`. Free functions have no active impl alias
+//!     scope, so this projected correctly both before and after the fix; it
+//!     is a guard that the carrier still collapses to `A` in a terminal
+//!     pump loop.
+
+#![allow(
+    clippy::missing_panics_doc,
+    reason = "integration-test panics on assertion failure are intentional"
+)]
+
+mod common;
+
+use common::typecheck_isolated;
+
+/// The Q001-superseded trait surface as shipped in `std/builtins.hew`:
+/// `next` takes a mutable `var self` receiver so an iterator can advance its
+/// own cursor in place.
+const ITER_PRELUDE: &str = r"
+pub trait Iterator {
+    type Item;
+
+    fn next(var self) -> Option<Self::Item>;
+}
+";
+
+#[test]
+fn q004_map_next_body_passes() {
+    // The generic lazy `Map` adapter. `self.iter` is moved into a `var`
+    // local so the inner iterator's `next(var self)` write-back lands on a
+    // mutable binding receiver; the advanced inner is stored back. The inner
+    // item `<I as Iterator>::Item` must project to `A` (not the impl's
+    // `type Item = B`) so `f: fn(A) -> B` accepts it.
+    let src = format!(
+        "{ITER_PRELUDE}{}",
+        r"
+pub type Map<I, A, B> {
+    iter: I;
+    f: fn(A) -> B;
+}
+
+impl<I, A, B> Iterator for Map<I, A, B> where I: Iterator<Item = A> {
+    type Item = B;
+    fn next(var self) -> Option<B> {
+        var inner = self.iter;
+        let result = match inner.next() {
+            Some(x) => Some((self.f)(x)),
+            None => None,
+        };
+        self.iter = inner;
+        result
+    }
+}
+"
+    );
+    let output = typecheck_isolated(&src);
+    assert!(
+        output.errors.is_empty(),
+        "Map::next must type-check post-Q004 (inner item projects to `A`, not the impl's `B`); got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn q004_inherent_impl_next_passes() {
+    // A concrete `i64 -> bool` adapter. `Self::Item` is `bool`, but the inner
+    // `it.next()` must still yield the inner item type `i64` (via the
+    // `I: Iterator<Item = i64>` bound) so the `x > 0` comparison type-checks.
+    // Pre-fix the inner item collapsed to the impl's `bool`, rejecting
+    // `x > 0`.
+    let src = format!(
+        "{ITER_PRELUDE}{}",
+        r"
+pub type IsPositive<I> {
+    inner: I;
+}
+
+impl<I> Iterator for IsPositive<I> where I: Iterator<Item = i64> {
+    type Item = bool;
+    fn next(var self) -> Option<bool> {
+        var it = self.inner;
+        let result = match it.next() {
+            Some(x) => Some(x > 0),
+            None => None,
+        };
+        self.inner = it;
+        result
+    }
+}
+"
+    );
+    let output = typecheck_isolated(&src);
+    assert!(
+        output.errors.is_empty(),
+        "inherent impl `next` must type-check post-Q004 (inner item projects to `i64`, not the impl's `bool`); got: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
+fn q004_fold_body_passes() {
+    // A free-function terminal fold. No impl alias scope is active here, so
+    // `iter.next()`'s `Self::Item` carrier already collapsed to `A` both
+    // before and after the fix. This guards that the terminal pump loop keeps
+    // projecting the item to `A` so `f: fn(B, A) -> B` accepts it.
+    let src = format!(
+        "{ITER_PRELUDE}{}",
+        r"
+pub fn fold<I, A, B>(it: I, init: B, f: fn(B, A) -> B) -> B where I: Iterator<Item = A> {
+    var acc = init;
+    var iter = it;
+    loop {
+        match iter.next() {
+            Some(x) => {
+                acc = f(acc, x);
+            }
+            None => {
+                break;
+            }
+        }
+    }
+    acc
+}
+"
+    );
+    let output = typecheck_isolated(&src);
+    assert!(
+        output.errors.is_empty(),
+        "free-function fold must type-check (item projects to `A`); got: {:#?}",
+        output.errors
+    );
+}

--- a/std/iter.hew
+++ b/std/iter.hew
@@ -47,21 +47,30 @@ pub type Map<I, A, B> {
 
 impl<I, A, B> Iterator for Map<I, A, B> where I: Iterator<Item = A> {
     type Item = B;
-    fn next(it: Map<I, A, B>) -> Option<B> {
+    fn next(var self) -> Option<B> {
 
-        // DEFERRED — fail loud, not silent: returning `None` here would
-        // make Map look like an empty iterator to every caller.
+        // Pump the inner iterator once and lift the item through `f`.
         //
-        // Q004 (separate branch `feat/q004-checker-authority`
-        // commit 4c9667a8): the checker substitutes `Self::Item` from
-        // the where-clause `I: Iterator<Item = A>` projection in place
-        // of the impl's declared `type Item = B`, so the literal
-        // pump-through body (`match it.iter.next() { Some(x) =>
-        // Some((it.f)(x)), None => None }`) is rejected with
-        // "expected A, found B". Once Q004 lands and this branch is
-        // rebased, the body becomes the pump-through above.
-        panic("Map::next is unimplemented pending Q004 checker fix (Self::Item projection through where-clause `Iterator<Item = A>` currently resolves to A instead of the impl's declared `type Item = B`). See std/iter.hew Map<I,A,B> doc-comment and v06-followups.md (iterator-foundation lane, Map deferred body).");
-        None
+        // `self.iter` is moved into a local `var inner` so the inner
+        // iterator's own `next(var self)` write-back lands on a mutable
+        // *binding* receiver: the static-dispatch path for a trait method
+        // on a type parameter requires the receiver to be a `var`
+        // identifier, not a field access (`self.iter.next()` is rejected).
+        // The advanced inner iterator is stored back into `self.iter`, and
+        // `var self`'s own write-back then persists the cursor into the
+        // caller's `Map` across successive `next()` calls — Map keeps no
+        // buffer of its own.
+        //
+        // The inner item type `<I as Iterator>::Item` projects to `A` via
+        // the `I: Iterator<Item = A>` bound, and `f: fn(A) -> B` produces
+        // the declared `type Item = B`.
+        var inner = self.iter;
+        let result = match inner.next() {
+            Some(x) => Some((self.f)(x)),
+            None => None,
+        };
+        self.iter = inner;
+        result
     }
 }
 
@@ -181,34 +190,61 @@ pub fn skip<I, A>(it: I, n: i64) -> Skip<I> where I: Iterator<Item = A> {
 
 // ── terminal helpers ─────────────────────────────────────────────────────
 //
-// DEFERRED — fail loud, not silent. These bodies must not return a
-// trivial default (init / 0 / empty Vec): a silent default would let
-// every consumer's reduction look correct while never advancing the
-// iterator.
-//
-// Q004 (separate branch `feat/q004-checker-authority` commit
-// 4c9667a8): the checker rejects an explicit pump-through body
-// (`match it.next() { Some(x) => f(acc, x), None => break }`) because
-// `<I as Iterator>::Item` is not unified with the bound projection
-// `A`. The signatures and where-bounds below are the locked surface;
-// real bodies land alongside the Q004 fix.
+// Each helper rebinds its iterator argument as `var` so the receiver of
+// `next()` (the `Iterator::next(var self)` shape) writes its advanced state
+// back across loop iterations, then drives the inner iterator to exhaustion.
+// `<I as Iterator>::Item` projects to the bound's `A`, so the loop sees `A`
+// items directly.
 /// Left-fold over `it`: walk every item applying `f(acc, item)` and
 /// return the accumulated value.
 pub fn fold<I, A, B>(it: I, init: B, f: fn(B, A) -> B) -> B where I: Iterator<Item = A> {
-    panic("iter::fold is unimplemented pending Q004 checker fix (cannot unify `<I as Iterator>::Item` with the where-clause projection `A` in a pump-through body). See std/iter.hew terminal-helpers section.");
-    init
+    var acc = init;
+    var iter = it;
+    loop {
+        match iter.next() {
+            Some(x) => {
+                acc = f(acc, x);
+            },
+            None => {
+                break;
+            },
+        }
+    }
+    acc
 }
 
 /// Return the number of items produced by `it`.
 pub fn count<I, A>(it: I) -> i64 where I: Iterator<Item = A> {
-    panic("iter::count is unimplemented pending Q004 checker fix (cannot unify `<I as Iterator>::Item` with the where-clause projection `A` in a pump-through body). See std/iter.hew terminal-helpers section.");
-    0
+    var n: i64 = 0;
+    var iter = it;
+    loop {
+        match iter.next() {
+            Some(_) => {
+                n = n + 1;
+            },
+            None => {
+                break;
+            },
+        }
+    }
+    n
 }
 
 /// Collect every item produced by `it` into a `Vec<A>`.
 pub fn collect<I, A>(it: I) -> Vec<A> where I: Iterator<Item = A> {
-    panic("iter::collect is unimplemented pending Q004 checker fix (cannot unify `<I as Iterator>::Item` with the where-clause projection `A` in a pump-through body). See std/iter.hew terminal-helpers section.");
-    Vec::new()
+    let out: Vec<A> = Vec::new();
+    var iter = it;
+    loop {
+        match iter.next() {
+            Some(x) => {
+                out.push(x);
+            },
+            None => {
+                break;
+            },
+        }
+    }
+    out
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/vertical-slice/accept/iter_lazy_count_collect_run.hew
+++ b/tests/vertical-slice/accept/iter_lazy_count_collect_run.hew
@@ -1,0 +1,121 @@
+//! Runnable end-to-end check for the terminal `count` and `collect` adapters
+//! driven over a lazy `Map` chain. Unlike `iter_lazy_wrappers.hew` (a
+//! type-check-only surface smoke), this fixture is *compiled and executed* —
+//! it asserts the runtime item count and the materialised `Vec` contents.
+//!
+//! `count`/`collect` here carry a *fixed* `Item = i64` bound rather than the
+//! generic `where I: Iterator<Item = A>` of `std::iter`. The generic signature
+//! type-checks, but a type parameter that appears ONLY inside a where-clause
+//! projection cannot be pinned by the monomorphisation collector, so the
+//! generic `std::iter::count`/`collect` do not yet lower through MIR (a
+//! separate backend lane). Fixing `Item` to `i64` pins every parameter at the
+//! call site and exercises the identical pump-loop body the generic helper
+//! uses.
+//!
+//! Exercises the Q004 fix transitively: the `Map<Countdown, i64, i64>` source
+//! relies on `Map::next` projecting the inner item to `A` (the bound's item),
+//! not the impl's declared `type Item = B`.
+//!
+//! Expected exit code: 15 — item count (3) plus the collected sum
+//! ([6, 4, 2] = 12). Component failures return distinct codes (101 count,
+//! 102 length, 103–105 element values) so a regression is legible.
+
+type Countdown {
+    n: i64;
+}
+
+impl Iterator for Countdown {
+    type Item = i64;
+    /// Yield `n, n-1, …, 1` then `None`; advance the cursor in place.
+    fn next(var self) -> Option<i64> {
+        if self.n <= 0 {
+            None
+        } else {
+            let cur = self.n;
+            self.n = self.n - 1;
+            Some(cur)
+        }
+    }
+}
+
+type Map<I, A, B> {
+    iter: I;
+    f: fn(A) -> B;
+}
+
+impl<I, A, B> Iterator for Map<I, A, B> where I: Iterator<Item = A> {
+    type Item = B;
+    /// Pump the inner iterator once and lift the item through `f`.
+    fn next(var self) -> Option<B> {
+        var inner = self.iter;
+        let result = match inner.next() {
+            Some(x) => Some((self.f)(x)),
+            None => None,
+        };
+        self.iter = inner;
+        result
+    }
+}
+
+/// Construct a lazy `Map` adapter (mirrors `std::iter::map`).
+fn mk_map<I, A, B>(it: I, f: fn(A) -> B) -> Map<I, A, B> where I: Iterator<Item = A> {
+    Map { iter: it, f: f }
+}
+
+/// Count items in a fixed-`i64` iterator (mirrors `std::iter::count`).
+fn count_i64<I>(it: I) -> i64 where I: Iterator<Item = i64> {
+    var n: i64 = 0;
+    var iter = it;
+    loop {
+        match iter.next() {
+            Some(_) => {
+                n = n + 1;
+            },
+            None => {
+                break;
+            },
+        }
+    }
+    n
+}
+
+/// Collect a fixed-`i64` iterator into a `Vec<i64>` (mirrors `std::iter::collect`).
+fn collect_i64<I>(it: I) -> Vec<i64> where I: Iterator<Item = i64> {
+    let out: Vec<i64> = Vec::new();
+    var iter = it;
+    loop {
+        match iter.next() {
+            Some(x) => {
+                out.push(x);
+            },
+            None => {
+                break;
+            },
+        }
+    }
+    out
+}
+
+fn main() -> i64 {
+    // Lazy map [3, 2, 1] through (* 2) → [6, 4, 2]; count its items → 3.
+    let c = count_i64(mk_map(Countdown { n: 3 }, |x: i64| x * 2));
+    if c != 3 {
+        return 101;
+    }
+    // Same chain, materialised → [6, 4, 2].
+    let v = collect_i64(mk_map(Countdown { n: 3 }, |x: i64| x * 2));
+    if v.len() != 3 {
+        return 102;
+    }
+    if v[0] != 6 {
+        return 103;
+    }
+    if v[1] != 4 {
+        return 104;
+    }
+    if v[2] != 2 {
+        return 105;
+    }
+    // count (3) + collected sum (6 + 4 + 2 = 12) = 15.
+    c + v[0] + v[1] + v[2]
+}

--- a/tests/vertical-slice/accept/iter_lazy_map_fold_run.hew
+++ b/tests/vertical-slice/accept/iter_lazy_map_fold_run.hew
@@ -1,0 +1,98 @@
+//! Runnable end-to-end check for the lazy `Map` adapter composed with a
+//! terminal `fold`. Unlike `iter_lazy_wrappers.hew` (a type-check-only
+//! surface smoke), this fixture is *compiled and executed* — it asserts the
+//! runtime values of a lazy iterator chain.
+//!
+//! Inlined and fully monomorphised on purpose: cross-module generic
+//! instantiation of `std::iter` does not yet lower through MIR (a separate
+//! backend lane), so the chain is built from a concrete `Countdown` source
+//! plus a `Map<Countdown, i64, i64>` adapter so every type parameter pins to
+//! a concrete type at the call site.
+//!
+//! Exercises the Q004 fix: `Map::next` calls the inner iterator's `next()`
+//! and lifts each item through `f`. The inner item `<I as Iterator>::Item`
+//! must project to `A` (not the impl's declared `type Item = B`), which the
+//! resolver only does once a trait-method signature's `Self::Item` stays a
+//! deferred carrier inside an impl body.
+//!
+//! Expected exit code: 12 (the map-then-fold result). Any internal mismatch
+//! returns a distinct diagnostic code (101/102) so a regression is legible.
+
+type Countdown {
+    n: i64;
+}
+
+impl Iterator for Countdown {
+    type Item = i64;
+    /// Yield `n, n-1, …, 1` then `None`; advance the cursor in place.
+    fn next(var self) -> Option<i64> {
+        if self.n <= 0 {
+            None
+        } else {
+            let cur = self.n;
+            self.n = self.n - 1;
+            Some(cur)
+        }
+    }
+}
+
+type Map<I, A, B> {
+    iter: I;
+    f: fn(A) -> B;
+}
+
+impl<I, A, B> Iterator for Map<I, A, B> where I: Iterator<Item = A> {
+    type Item = B;
+    /// Pump the inner iterator once and lift the item through `f`. The inner
+    /// iterator is moved into a `var` local so its `next(var self)`
+    /// write-back lands on a mutable binding receiver, then stored back so
+    /// `var self`'s write-back persists the cursor across calls.
+    fn next(var self) -> Option<B> {
+        var inner = self.iter;
+        let result = match inner.next() {
+            Some(x) => Some((self.f)(x)),
+            None => None,
+        };
+        self.iter = inner;
+        result
+    }
+}
+
+/// Construct a lazy `Map` adapter (mirrors `std::iter::map`).
+fn mk_map<I, A, B>(it: I, f: fn(A) -> B) -> Map<I, A, B> where I: Iterator<Item = A> {
+    Map { iter: it, f: f }
+}
+
+/// Left-fold a terminal pump loop (mirrors `std::iter::fold`).
+fn fold<I, A, B>(it: I, init: B, f: fn(B, A) -> B) -> B where I: Iterator<Item = A> {
+    var acc = init;
+    var iter = it;
+    loop {
+        match iter.next() {
+            Some(x) => {
+                acc = f(acc, x);
+            }
+            None => {
+                break;
+            }
+        }
+    }
+    acc
+}
+
+fn main() -> i64 {
+    // Plain fold over Countdown[5, 4, 3, 2, 1] → 15.
+    let plain = fold(Countdown { n: 5 }, 0, |acc: i64, x: i64| acc + x);
+    if plain != 15 {
+        return 101;
+    }
+
+    // Lazy map [3, 2, 1] through (* 2) → [6, 4, 2], then fold → 12.
+    let mapped = mk_map(Countdown { n: 3 }, |x: i64| x * 2);
+    let total = fold(mapped, 0, |acc: i64, x: i64| acc + x);
+    if total != 12 {
+        return 102;
+    }
+
+    total
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -273,14 +273,29 @@ compile_accept "machine_fork_args_spawn"
 
 # Stage-2 lazy iterator wrappers: structural smoke. The fixture's wrapper
 # records and `impl Iterator` blocks compile cleanly through the parser and
-# the type checker, but the generic-T impl bodies do not yet have a MIR
-# `ValueClass` lowering (deferred to the follow-on stages that wire
-# `Vec::IntoIterator` and the for-loop desugar). The lock tests under
-# `hew-types::iterator_lazy_wrappers` carry the binding shape — this
-# command is documentary: the fixture is wired in so a future stage
-# wraps it into a real accept run once MIR lowering catches up.
+# the type checker. The generic adapter bodies only lower through MIR once
+# every type parameter pins to a concrete type at a call site (full
+# monomorphisation); the chained generic surface here is asserted at the
+# `hew check` level. The lock tests under
+# `hew-types::iterator_lazy_wrappers` carry the binding shape.
 "${HEW}" check "${ROOT}/tests/vertical-slice/accept/iter_lazy_wrappers.hew" \
     >"${accept_output}" 2>&1
+
+# Q004 follow-through: a *runnable* lazy chain. `Map::next` (lifting the inner
+# item through `f`) plus a terminal `fold`, fully monomorphised over a
+# concrete `Countdown` source, compiles and executes. Exit code 12 is the
+# map-then-fold result ([3,2,1] * 2 = [6,4,2], sum 12); 101/102 flag an
+# internal value mismatch. Locks the Q004 `Self::Item` projection fix at
+# runtime, not just at type-check time.
+run_accept_expect_status "iter_lazy_map_fold_run" 12
+
+# Q004 follow-through, terminal helpers: `count` and `collect` driven over the
+# same lazy `Map` chain. `count`/`collect` carry a fixed `Item = i64` bound
+# (the generic `std::iter` signature type-checks but cannot yet monomorphise —
+# a free `A` appearing only in the where-clause projection is not pinnable by
+# the collector). Exit code 15 is item count (3) plus the collected sum
+# ([6,4,2] = 12); 101–105 flag a count/length/element mismatch.
+run_accept_expect_status "iter_lazy_count_collect_run" 15
 
 # Reject: spawned closures must not capture non-Send values. This fixture uses
 # a real Checker-produced `Rc<i64>` capture fact and asserts the targeted HIR


### PR DESCRIPTION
## Summary
Resolves a checker bug where `Self::Item` in a trait method's signature
(`fn next(var self) -> Option<Self::Item>`) was prematurely collapsed to an
impl's concrete associated type while re-resolving an inner call's signature
during impl-body checking. The deferred `Ty::AssocType` carrier was gated on
`impl_alias_scopes.is_empty()`; the gate is removed so the carrier is returned
whenever a trait method's own signature is being resolved
(`current_trait_for_self_projection` set). The impl's-own-`Self::Item` case is
unchanged — it still resolves via `resolve_impl_associated_type`.

With the carrier fixed, the lazy-iterator combinators `Map::next`, `fold`,
`count`, and `collect` are implemented in `std/iter.hew` (previously fail-loud
stubs). `Map::next` extracts the inner iterator into a `var` local, pumps it,
and writes the cursor back through `var self` so iteration state persists
across calls.

## Verification
- `make ci-preflight` green (all gates) on the rebased tree.
- `hew-types`: 2433 passed, 0 failed (+3 new `q004_self_item_projection` tests
  that fail pre-fix / pass post-fix).
- New runnable fixtures: `iter_lazy_map_fold_run` (exit 12),
  `iter_lazy_count_collect_run` (count=3, collect=[6,4,2], exit 15).
- `make test-hew-ratchet` green (3 expected = 3 actual).

## Out of scope
- `Filter`/`Take`/`Skip::next` remain stubbed (separate follow-up).
- Generic `count`/`collect` cannot yet be monomorphized when the element type
  appears only in a where-clause projection (pre-existing MIR gap); the new
  fixtures use fixed-`Item` variants that exercise the identical pump-loop.
- Cross-module `std::iter` combinator calls do not yet lower (pre-existing).