### PR TITLE
refactor(runtime): unify the WASM timer path onto HewTimerWheel

### DIFF
--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -687,7 +687,9 @@ pub mod task_scope;
 pub mod timer_periodic;
 #[cfg(any(target_arch = "wasm32", test))]
 pub mod timer_periodic_wasm;
-#[cfg(not(target_arch = "wasm32"))]
+// timer_wheel compiles on every target: native uses it with the background
+// ticker thread (timer_periodic); WASM uses it with a host-driven tick
+// (scheduler_wasm + timer_periodic_wasm).
 pub mod timer_wheel;
 
 #[cfg(all(test, not(target_arch = "wasm32")))]

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -36,6 +36,12 @@ use crate::timer_wheel::{
 
 static WASM_CLEANUP_RAN: AtomicBool = AtomicBool::new(false);
 
+/// When set to `true` in tests, `wasm_timer_wheel()` returns null to simulate
+/// an OOM failure from `hew_timer_wheel_new`.  Reset to `false` after use.
+/// Serialised by the `runtime_test_guard` / test lock.
+#[cfg(test)]
+static TEST_FORCE_WHEEL_NULL: AtomicBool = AtomicBool::new(false);
+
 #[inline]
 fn notify_actor_group_waiters(actor_id: u64) {
     #[cfg(not(target_arch = "wasm32"))]
@@ -494,6 +500,14 @@ unsafe extern "C" fn wasm_sleep_cb(data: *mut c_void) {
 /// Must only be called from a single-threaded WASM context or a serialised
 /// test environment.
 pub(crate) unsafe fn wasm_timer_wheel() -> *mut HewTimerWheel {
+    // In the test build, honour a per-test override that simulates an OOM
+    // failure from `hew_timer_wheel_new`.  This lets tests exercise the
+    // fail-closed paths in `park_actor_sleep` and `hew_actor_schedule_periodic`
+    // without requiring actual memory-allocation failure.
+    #[cfg(test)]
+    if TEST_FORCE_WHEEL_NULL.load(Ordering::Relaxed) {
+        return std::ptr::null_mut();
+    }
     // SAFETY: Single-threaded cooperative scheduler.
     unsafe {
         if WASM_TIMER_WHEEL.is_null() {
@@ -585,6 +599,23 @@ unsafe fn park_actor_sleep(actor: *mut HewActor, deadline_ms: u64) {
     // SAFETY: wheel is valid; ctx and actor are live.
     let handle =
         unsafe { hew_timer_wheel_schedule_handle(wheel, delay_ms, wasm_sleep_cb, ctx.cast()) };
+
+    if handle.entry.is_null() {
+        // Wheel rejected the schedule (e.g. entry allocation failure) — fail
+        // closed, matching the wheel-null path above.  Drop the Box, restore
+        // the actor to Runnable, and re-enqueue so it is not stranded.
+        // SAFETY: ctx is exclusively owned (not yet in SLEEP_HANDLES).
+        unsafe { drop(Box::from_raw(ctx)) };
+        a.actor_state
+            .store(HewActorState::Runnable as i32, Ordering::Relaxed);
+        // SAFETY: actor is valid; enqueue is safe.
+        unsafe {
+            if let Err(msg) = try_sched_enqueue(actor) {
+                crate::set_last_error(msg);
+            }
+        }
+        return;
+    }
 
     #[expect(
         static_mut_refs,
@@ -2498,6 +2529,29 @@ mod tests {
                 "WASM_TIMER_WHEEL must be null after shutdown"
             );
         }
+        // SLEEP_HANDLES is Option<HashMap<...>>; .is_none() creates a shared ref,
+        // so it must live in its own #[expect(static_mut_refs)] + unsafe block.
+        #[expect(
+            static_mut_refs,
+            reason = "single-threaded test; SLEEP_HANDLES discriminant read only, no mutation"
+        )]
+        // SAFETY: single-threaded test; called immediately after hew_sched_shutdown.
+        unsafe {
+            assert!(
+                SLEEP_HANDLES.is_none(),
+                "SLEEP_HANDLES must be None after shutdown"
+            );
+        }
+        // These helpers access their respective statics without creating refs here.
+        assert_eq!(
+            crate::timer_periodic_wasm::pending_periodic_count(),
+            0,
+            "WASM_PERIODIC_COUNT must be zero after shutdown"
+        );
+        assert!(
+            crate::timer_periodic_wasm::periodic_registry_is_none(),
+            "PERIODIC_CTX_REGISTRY must be None after shutdown"
+        );
     }
 
     #[test]
@@ -5830,6 +5884,93 @@ mod tests {
         assert_eq!(woken, 0, "no actors should wake after entry was cancelled");
 
         hew_sched_shutdown();
+    }
+
+    // ── Fail-closed schedule-failure regression tests (F-1 / F-2) ──────────
+
+    /// Regression (F-2): when `hew_timer_wheel_schedule_handle` returns a null
+    /// handle for a sleep timer, `park_actor_sleep` must drop the `WasmSleepCtx`
+    /// Box, NOT increment `WASM_SLEEP_COUNT`, and restore the actor to
+    /// `Runnable` so it is not stranded.
+    #[test]
+    fn park_actor_sleep_fails_closed_when_wheel_null() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: Serialized by TEST_LOCK — no concurrent access.
+        unsafe { reset_globals() };
+        hew_sched_init();
+
+        let mut a = stub_actor();
+        let a_ptr: *mut HewActor = (&raw mut a);
+        a.actor_state
+            .store(HewActorState::Idle as i32, Ordering::Relaxed);
+
+        // Simulate a wheel that is unavailable (OOM on creation).
+        TEST_FORCE_WHEEL_NULL.store(true, Ordering::Relaxed);
+        // SAFETY: hew_now_ms has no preconditions.
+        let now = unsafe { hew_now_ms() };
+        // SAFETY: actor is valid; park_actor_sleep requires a live HewActor ptr.
+        unsafe { park_actor_sleep(a_ptr, now + 500) };
+        TEST_FORCE_WHEEL_NULL.store(false, Ordering::Relaxed);
+
+        // Must not have registered a sleep entry.
+        assert_eq!(
+            hew_wasm_sleeping_count(),
+            0,
+            "WASM_SLEEP_COUNT must not increment on wheel failure"
+        );
+        // Actor must be Runnable (fail-closed re-enqueue), not stranded.
+        assert_eq!(
+            a.actor_state.load(Ordering::Relaxed),
+            HewActorState::Runnable as i32,
+            "actor must be Runnable after sleep scheduling fails"
+        );
+        // Count must still be zero after shutdown.
+        hew_sched_shutdown();
+        assert_eq!(
+            hew_wasm_sleeping_count(),
+            0,
+            "WASM_SLEEP_COUNT must remain zero after shutdown"
+        );
+    }
+
+    /// Regression (F-1): when `wasm_timer_wheel()` returns null (simulated OOM),
+    /// `hew_actor_schedule_periodic` must return null without registering the
+    /// `WasmPeriodicCtx` or incrementing `WASM_PERIODIC_COUNT`.
+    #[test]
+    fn schedule_periodic_fails_closed_when_wheel_null() {
+        let _guard = crate::runtime_test_guard();
+        // SAFETY: Serialized by TEST_LOCK — no concurrent access.
+        unsafe { reset_globals() };
+        hew_sched_init();
+
+        let mut a = stub_actor();
+        let a_ptr: *mut HewActor = (&raw mut a);
+
+        // Simulate wheel unavailability.
+        TEST_FORCE_WHEEL_NULL.store(true, Ordering::Relaxed);
+        // SAFETY: actor is a valid live pointer; cast to actor::HewActor (same repr).
+        let handle = unsafe {
+            crate::timer_periodic_wasm::hew_actor_schedule_periodic(
+                a_ptr.cast::<crate::actor::HewActor>(),
+                1,
+                100,
+            )
+        };
+        TEST_FORCE_WHEEL_NULL.store(false, Ordering::Relaxed);
+
+        assert!(handle.is_null(), "must return null on wheel failure");
+        assert_eq!(
+            crate::timer_periodic_wasm::pending_periodic_count(),
+            0,
+            "WASM_PERIODIC_COUNT must not increment on wheel failure"
+        );
+        assert!(
+            crate::timer_periodic_wasm::periodic_registry_is_none(),
+            "registry must remain None when schedule fails"
+        );
+
+        hew_sched_shutdown();
+        // Shutdown assertions (F-3) now cover all 5 new statics.
     }
 
     /// Regression: `PENDING_SLEEP_DEADLINE_MS` must be cleared even when the

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -29,6 +29,10 @@ use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU64, Ordering};
 use crate::actor::HEW_PRIORITY_NORMAL;
 use crate::actor::{HEW_DEFAULT_REDUCTIONS, HEW_MSG_BUDGET, HEW_PRIORITY_HIGH, HEW_PRIORITY_LOW};
 use crate::internal::types::{HewActorState, HewDispatchFn};
+use crate::timer_wheel::{
+    hew_timer_wheel_free, hew_timer_wheel_new, hew_timer_wheel_remove,
+    hew_timer_wheel_schedule_handle, timer_wheel_tick_to, HewTimerHandle, HewTimerWheel,
+};
 
 static WASM_CLEANUP_RAN: AtomicBool = AtomicBool::new(false);
 
@@ -317,17 +321,44 @@ unsafe fn arena_reset(arena: *mut c_void) {
 static mut RUN_QUEUE: Option<VecDeque<*mut HewActor>> = None;
 static mut INITIALIZED: bool = false;
 
-/// Sleep queue: actors parked until a host-driven deadline expires.
+// ── WASM unified timer wheel ─────────────────────────────────────────────
+//
+// A single `HewTimerWheel` drives both sleep timers and periodic timers on
+// WASM, replacing the former O(n²) sorted-Vec `SLEEP_QUEUE` and
+// `PERIODIC_QUEUE`. The wheel is lazily initialised in `wasm_timer_wheel()`
+// and freed (along with all pending entries' callback data) in
+// `hew_sched_shutdown`.
+//
+// **Drop-safety contract**:
+//
+// Every `Box`-allocated callback-data struct (`WasmSleepCtx`) is registered
+// in `SLEEP_HANDLES` at insertion and removed at fire or cancel so exactly
+// one party (fire callback OR cancel path) performs the drop — the same
+// "atomic claim" guarantee the native `Arc`-based periodic path upholds.
+//
+// **Semantics identical to native**:
+// - Expiry ordering: `timer_wheel_tick_to` fires callbacks in insertion/slot
+//   order, same as the native ticker path.
+// - Cancel: `hew_timer_wheel_remove` atomically unlinks and frees the wheel
+//   entry, handing ownership of the data to the caller.
+// - Shutdown: entries are drained from the registries (freeing their ctxs)
+//   before `hew_timer_wheel_free` reclaims the wheel struct itself.
+
+/// Global WASM timer wheel.  Null until first use; freed in `hew_sched_shutdown`.
+static mut WASM_TIMER_WHEEL: *mut HewTimerWheel = std::ptr::null_mut();
+
+/// Number of actors currently parked in a sleep timer entry.
+/// Incremented by `park_actor_sleep`, decremented by the sleep callback and
+/// by `cancel_actor_sleep_queue_entry`.  Used by `hew_wasm_sleeping_count`.
+static mut WASM_SLEEP_COUNT: usize = 0;
+
+/// Per-actor map from actor address to the currently-pending sleep handle.
+/// Because an actor can only be in `Sleeping` state once at a time, each
+/// actor has at most one entry here.
 ///
-/// Each entry is `(deadline_ms, actor_ptr)`.  The vector is kept sorted by
-/// ascending deadline so the front is always the soonest to wake.  Actors
-/// in this queue are in `Idle` state; they are re-enqueued as `Runnable`
-/// when the deadline passes (see [`drain_expired_sleepers`]).
-///
-/// Drop/cleanup contract: cleared in [`hew_sched_shutdown`].
-// WASM-TODO(#1451): replace this sorted Vec sleep queue with a WASM-compatible shared
-// timer queue helper; insert/drain/cancel are still O(n)/O(n²).
-static mut SLEEP_QUEUE: Vec<(u64, *mut HewActor)> = Vec::new();
+/// Using `Option<HashMap<…>>` so that the empty-runtime case (no sleeps ever
+/// scheduled) avoids the heap allocation entirely.
+static mut SLEEP_HANDLES: Option<std::collections::HashMap<usize, HewTimerHandle>> = None;
 
 /// Pending sleep deadline set by the currently-dispatching actor via
 /// [`request_sleep`].  Zero means no pending sleep.  Consumed and reset
@@ -392,6 +423,101 @@ pub(crate) fn record_message_received() {
     }
 }
 
+// ── WASM timer wheel accessor ────────────────────────────────────────────
+
+/// Callback data for a wheel-backed sleep entry.
+struct WasmSleepCtx {
+    actor: *mut HewActor,
+}
+
+// SAFETY: WASM is single-threaded; the pointer is only accessed under the
+// cooperative-scheduler invariant (no concurrent mutation).
+unsafe impl Send for WasmSleepCtx {}
+
+/// Timer callback fired when a sleeping actor's deadline passes.
+///
+/// Transitions the actor from `Sleeping` to `Runnable` and re-enqueues it.
+/// Drops the `WasmSleepCtx` and removes its handle from `SLEEP_HANDLES`.
+///
+/// # Safety
+///
+/// Called by `timer_wheel_tick_to` after the wheel lock is released.
+/// The actor pointer stored in `data` must still be valid — `cancel_actor_sleep_queue_entry`
+/// ensures this by removing the wheel entry (and thus preventing this callback from
+/// firing) before the actor is freed.
+unsafe extern "C" fn wasm_sleep_cb(data: *mut c_void) {
+    // SAFETY: data is a Box<WasmSleepCtx> allocated by park_actor_sleep.
+    let ctx = unsafe { Box::from_raw(data.cast::<WasmSleepCtx>()) };
+    let actor = ctx.actor;
+    drop(ctx);
+
+    // SAFETY: Single-threaded; remove the now-consumed handle from the registry.
+    unsafe {
+        if let Some(ref mut handles) = SLEEP_HANDLES {
+            handles.remove(&(actor as usize));
+        }
+        WASM_SLEEP_COUNT = WASM_SLEEP_COUNT.saturating_sub(1);
+    }
+
+    // Transition Sleeping → Runnable and re-enqueue.
+    // SAFETY: actor is alive — cancel_actor_sleep_queue_entry guarantees the
+    // wheel entry (and this callback) are removed before actor free.
+    let state = unsafe { (*actor).actor_state.load(Ordering::Relaxed) };
+    if state == HewActorState::Sleeping as i32 {
+        // SAFETY: actor is alive (see above); actor_state and try_sched_enqueue
+        // only require a valid pointer to a live HewActor.
+        unsafe {
+            (*actor)
+                .actor_state
+                .store(HewActorState::Runnable as i32, Ordering::Relaxed);
+            if let Err(msg) = try_sched_enqueue(actor) {
+                // Scheduler was shut down while the actor was sleeping.
+                // The actor cannot be enqueued — log the situation but don't
+                // panic; shutdown drains the wheel first so this branch
+                // should never fire in practice.
+                crate::set_last_error(msg);
+            }
+        }
+    }
+    // If the actor's state is no longer Sleeping (e.g., it was stopped or
+    // crashed between the sleep park and the deadline), discard silently.
+}
+
+/// Return the WASM global timer wheel, lazily initialising it on first call.
+///
+/// Returns null only if `hew_timer_wheel_new` fails (allocation error), which
+/// is treated as a non-fatal scheduler degradation: sleep/periodic timers
+/// simply won't fire until the wheel is available.
+///
+/// # Safety
+///
+/// Must only be called from a single-threaded WASM context or a serialised
+/// test environment.
+pub(crate) unsafe fn wasm_timer_wheel() -> *mut HewTimerWheel {
+    // SAFETY: Single-threaded cooperative scheduler.
+    unsafe {
+        if WASM_TIMER_WHEEL.is_null() {
+            // SAFETY: hew_timer_wheel_new has no preconditions.
+            WASM_TIMER_WHEEL = hew_timer_wheel_new();
+        }
+        WASM_TIMER_WHEEL
+    }
+}
+
+/// Return the raw wheel pointer without initialising a new one.
+///
+/// Returns null if the wheel has not been created yet or was already freed
+/// by `wasm_timers_shutdown_inner`.  Used by `timer_periodic_wasm` helpers
+/// that must not inadvertently re-create the wheel during teardown.
+///
+/// # Safety
+///
+/// `WASM_TIMER_WHEEL` is a mutable static; caller must ensure single-threaded access.
+pub(crate) unsafe fn wasm_timer_wheel_raw() -> *mut HewTimerWheel {
+    // SAFETY: caller upholds the single-threaded WASM invariant.
+    unsafe { WASM_TIMER_WHEEL }
+}
+
 // ── Sleep timer helpers ─────────────────────────────────────────────────
 
 /// Record a sleep request for the currently-dispatching actor.
@@ -412,10 +538,11 @@ pub(crate) fn request_sleep(deadline_ms: u64) {
     }
 }
 
-/// Park `actor` in the sleep queue until `deadline_ms`.
+/// Park `actor` in the timer wheel until `deadline_ms`.
 ///
-/// Sets the actor state to `Idle` and inserts it into the sorted sleep
-/// queue.  The actor is NOT in the run queue while sleeping.
+/// Sets the actor state to `Sleeping` and inserts a one-shot wheel entry
+/// whose callback transitions the actor back to `Runnable` and re-enqueues it.
+/// The actor is NOT in the run queue while sleeping.
 ///
 /// # Safety
 ///
@@ -426,90 +553,116 @@ unsafe fn park_actor_sleep(actor: *mut HewActor, deadline_ms: u64) {
     let a = unsafe { &*actor };
     // Use Sleeping (not Idle) so that message-send paths do not treat this
     // actor as wake-eligible.  Messages queue in the mailbox and are
-    // delivered when the timer fires and drain_expired_sleepers re-enqueues.
+    // delivered when the timer fires and the sleep callback re-enqueues.
     a.actor_state
         .store(HewActorState::Sleeping as i32, Ordering::Relaxed);
-    #[expect(
-        static_mut_refs,
-        reason = "single-threaded cooperative scheduler; no concurrent mutation"
-    )]
-    // SAFETY: Single-threaded on WASM.
-    unsafe {
-        // Keep the queue sorted by ascending deadline for O(1) front-peek.
-        let pos = SLEEP_QUEUE.partition_point(|&(d, _)| d <= deadline_ms);
-        SLEEP_QUEUE.insert(pos, (deadline_ms, actor));
-    }
-}
 
-/// Wake all sleeping actors whose deadline ≤ `now_ms`.
-///
-/// For each expired entry:
-/// - If the actor is still `Idle`, transitions it to `Runnable` and
-///   re-enqueues it on the run queue.
-/// - If the actor has since been stopped/crashed, discards the entry.
-///
-/// Returns the number of actors woken.
-///
-/// # Safety
-///
-/// Must be called from within the WASM scheduler's single-threaded
-/// execution context.
-unsafe fn drain_expired_sleepers(now_ms: u64) -> u32 {
-    let mut woken: u32 = 0;
-    #[expect(
-        static_mut_refs,
-        reason = "single-threaded cooperative scheduler; no concurrent mutation"
-    )]
-    // SAFETY: Single-threaded cooperative scheduler; SLEEP_QUEUE not aliased.
-    unsafe {
-        while let Some(&(deadline, actor)) = SLEEP_QUEUE.first() {
-            if deadline > now_ms {
-                break; // Queue is sorted; all remaining deadlines are later.
+    // SAFETY: Single-threaded; wasm_timer_wheel has no preconditions here.
+    let wheel = unsafe { wasm_timer_wheel() };
+    if wheel.is_null() {
+        // Wheel unavailable (allocation failure) — fall back to immediate
+        // re-enqueue so the actor doesn't park forever.
+        a.actor_state
+            .store(HewActorState::Runnable as i32, Ordering::Relaxed);
+        // SAFETY: actor is valid; enqueue is safe.
+        unsafe {
+            if let Err(msg) = try_sched_enqueue(actor) {
+                crate::set_last_error(msg);
             }
-            SLEEP_QUEUE.remove(0);
-            let state = (*actor).actor_state.load(Ordering::Relaxed);
-            if state == HewActorState::Sleeping as i32 {
-                (*actor)
-                    .actor_state
-                    .store(HewActorState::Runnable as i32, Ordering::Relaxed);
-                // Fail-closed: panic if the scheduler was not initialized.
-                if let Err(msg) = try_sched_enqueue(actor) {
-                    panic!("{msg}");
-                }
-                woken += 1;
-            }
-            // Stopped/Crashed actors are silently discarded from the queue;
-            // their resources are managed by hew_actor_close / cleanup_all_actors.
         }
+        return;
     }
-    woken
+
+    // Allocate the callback context (Box-owned; freed by callback or cancel).
+    let ctx = Box::into_raw(Box::new(WasmSleepCtx { actor }));
+
+    // Compute delay: deadline_ms is absolute; the wheel takes a relative delay.
+    // SAFETY: hew_now_ms has no preconditions.
+    let now = unsafe { hew_now_ms() };
+    let delay_ms = deadline_ms.saturating_sub(now);
+
+    // Schedule on the wheel and register the handle for O(1) cancel.
+    // SAFETY: wheel is valid; ctx and actor are live.
+    let handle =
+        unsafe { hew_timer_wheel_schedule_handle(wheel, delay_ms, wasm_sleep_cb, ctx.cast()) };
+
+    #[expect(
+        static_mut_refs,
+        reason = "single-threaded cooperative WASM scheduler; no concurrent mutation"
+    )]
+    // SAFETY: Single-threaded; SLEEP_HANDLES is not aliased here.
+    unsafe {
+        let map = SLEEP_HANDLES.get_or_insert_with(std::collections::HashMap::new);
+        map.insert(actor as usize, handle);
+        WASM_SLEEP_COUNT += 1;
+    }
 }
 
-/// Remove any [`SLEEP_QUEUE`] entry for `actor`, if present.
+/// Remove any pending sleep-wheel entry for `actor`, if present.
 ///
-/// Called by [`crate::actor::cleanup_all_actors`] just before freeing an
-/// actor to prevent a use-after-free if the host calls
-/// [`hew_wasm_timer_tick`] after an actor has been freed but before the
-/// queue entry has been drained normally.
+/// Called before an actor is freed (`cleanup_all_actors`, `hew_actor_close`,
+/// `hew_actor_stop`) to prevent the wheel's callback from firing on a freed
+/// actor pointer.  The callback data (`WasmSleepCtx`) is freed here so no
+/// memory is leaked.
 ///
-/// Idempotent: if the actor is not in the queue, this is a no-op.
+/// Idempotent: if no entry exists for the actor, this is a no-op.
 ///
 /// # Safety
 ///
 /// Must be called from the single-threaded WASM cooperative scheduler
-/// context (same thread that owns `SLEEP_QUEUE`).
+/// context (same thread that owns the wheel and `SLEEP_HANDLES`).
 pub(crate) unsafe fn cancel_actor_sleep_queue_entry(actor: *mut crate::actor::HewActor) {
-    #[expect(
-        static_mut_refs,
-        reason = "single-threaded cooperative scheduler; no concurrent mutation"
-    )]
-    // SAFETY: single-threaded; caller upholds cooperative-scheduler invariant.
+    // SAFETY: Single-threaded; SLEEP_HANDLES and the wheel are not aliased.
     unsafe {
-        SLEEP_QUEUE.retain(|&(_, a)| !std::ptr::eq(a.cast::<crate::actor::HewActor>(), actor));
+        let wheel = WASM_TIMER_WHEEL;
+        if wheel.is_null() {
+            return;
+        }
+        if let Some(ref mut handles) = SLEEP_HANDLES {
+            if let Some(handle) = handles.remove(&(actor as usize)) {
+                // Remove the wheel entry atomically. If the entry is still
+                // pending, `hew_timer_wheel_remove` unlinks and frees the
+                // `HewTimerEntry` node and returns the data pointer (our ctx).
+                // If the entry had already been collected for firing (not
+                // possible in single-threaded WASM, but guarded for safety),
+                // this returns null and the callback is responsible for the ctx.
+                let data = hew_timer_wheel_remove(wheel, handle.entry, handle.generation);
+                if !data.is_null() {
+                    drop(Box::from_raw(data.cast::<WasmSleepCtx>()));
+                    WASM_SLEEP_COUNT = WASM_SLEEP_COUNT.saturating_sub(1);
+                }
+            }
+        }
     }
 }
 
-// ── C ABI ───────────────────────────────────────────────────────────────
+/// Drain the WASM timer wheel to `now_ms`, firing all expired sleep and
+/// periodic callbacks.
+///
+/// Replaces the former `drain_expired_sleepers` + `drain_ready_periodic`
+/// two-pass approach.  Returns `(fired_total, 0)` — the second element is
+/// kept for call-site compatibility with [`hew_wasm_timer_tick`].
+///
+/// # Safety
+///
+/// Must be called from the single-threaded WASM context after
+/// [`hew_sched_init`].
+unsafe fn drain_timed_work(now_ms: u64) -> (u32, u32) {
+    // SAFETY: Single-threaded; wasm_timer_wheel init is guarded.
+    let wheel = unsafe { wasm_timer_wheel() };
+    if wheel.is_null() {
+        return (0, 0);
+    }
+    // SAFETY: wheel is valid; caller upholds single-threaded invariant.
+    #[expect(
+        clippy::cast_sign_loss,
+        reason = "fired count fits in u32; timer_wheel_tick_to returns non-negative i32"
+    )]
+    // SAFETY: wheel is valid (wasm_timer_wheel() ensures it was allocated);
+    // single-threaded WASM scheduler guarantees no concurrent mutation.
+    let fired = unsafe { timer_wheel_tick_to(wheel, now_ms) } as u32;
+    (fired, 0)
+}
 
 /// Initialize the cooperative scheduler.
 ///
@@ -542,8 +695,8 @@ pub extern "C" fn hew_sched_init() -> c_int {
 /// [`hew_sched_shutdown`] to prevent a far-future sleep deadline from
 /// indefinitely blocking teardown.
 ///
-/// Any actor that calls `sleep_ms` during this drain will be parked into
-/// `SLEEP_QUEUE`; the caller must clear that queue afterwards.
+/// Any actor that calls `sleep_ms` during this drain will schedule a new
+/// sleep entry on the wheel; the wheel is cleared after this function returns.
 ///
 /// # Safety
 ///
@@ -565,9 +718,10 @@ unsafe fn drain_run_queue_for_shutdown() {
 /// was never initialized.
 ///
 /// Unlike [`hew_sched_run`], shutdown does **not** wait for sleeping actors
-/// whose timer has not yet expired.  The sleep queue is cleared before the
-/// drain and again after, so any actor that calls `sleep_ms` during the
-/// shutdown drain cannot prolong teardown.
+/// whose timer has not yet expired.  The timer wheel is cleared (freeing all
+/// pending sleep and periodic callback data) before and after the drain to
+/// prevent any actor that calls `sleep_ms` during the shutdown drain from
+/// prolonging teardown.
 ///
 /// Resetting every static (including `ACTIVATING`, `PREV_ARENA`, and the
 /// metrics counters) ensures that a subsequent [`hew_sched_init`] starts
@@ -576,35 +730,26 @@ unsafe fn drain_run_queue_for_shutdown() {
 /// per-activation `HewExecutionContext` and naturally clears with the frame.
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn hew_sched_shutdown() {
-    // Cancel all sleeping actors before draining.  This prevents
-    // hew_sched_run()'s sleep-queue spin-wait from blocking teardown on
-    // far-future timer deadlines.
-    #[expect(
-        static_mut_refs,
-        reason = "single-threaded shutdown; no concurrent access"
-    )]
-    // SAFETY: Single-threaded; no concurrent sleep-queue access during shutdown.
+    // Phase 1: clear all pending timer entries (sleep + periodic) before
+    // draining.  This prevents the sleep-based termination check in
+    // `hew_sched_run` from spin-waiting on far-future deadlines.
+    // SAFETY: Single-threaded; no concurrent timer access during shutdown.
     unsafe {
-        crate::timer_periodic_wasm::hew_periodic_shutdown();
-        SLEEP_QUEUE.clear();
+        wasm_timers_shutdown_inner();
         PENDING_SLEEP_DEADLINE_MS = 0;
     }
 
     // Drain all currently-runnable actors without waiting for sleep deadlines.
-    // If any actor calls sleep_ms during this drain it will be added to
-    // SLEEP_QUEUE, which we clear again immediately below.
+    // Any actor that calls sleep_ms during this drain will insert a new wheel
+    // entry, which we clear again immediately below.
     // SAFETY: Single-threaded on WASM.
     unsafe { drain_run_queue_for_shutdown() };
 
-    // Second clear: discard any new sleep entries created during the drain.
-    #[expect(
-        static_mut_refs,
-        reason = "single-threaded shutdown; no concurrent access"
-    )]
+    // Phase 2: second clear to discard any new timer entries created during
+    // the shutdown drain.
     // SAFETY: Single-threaded; drain_run_queue_for_shutdown has returned.
     unsafe {
-        crate::timer_periodic_wasm::hew_periodic_shutdown();
-        SLEEP_QUEUE.clear();
+        wasm_timers_shutdown_inner();
         PENDING_SLEEP_DEADLINE_MS = 0;
     }
 
@@ -631,11 +776,52 @@ pub extern "C" fn hew_sched_shutdown() {
         TASKS_COMPLETED = 0;
         MESSAGES_SENT = 0;
         MESSAGES_RECEIVED = 0;
-        // Clear the sleep queue and pending-sleep context so any actors that
-        // were parked during a partial run do not linger across a re-init cycle.
-        #[expect(static_mut_refs, reason = "single-threaded shutdown path")]
-        SLEEP_QUEUE.clear();
         PENDING_SLEEP_DEADLINE_MS = 0;
+    }
+}
+
+/// Inner helper: drain all sleep and periodic timer entries, free their
+/// callback data, destroy and null the global wheel.
+///
+/// Called twice in `hew_sched_shutdown` — before and after the run-queue
+/// drain — to bound teardown time regardless of far-future deadlines.
+///
+/// # Safety
+///
+/// Single-threaded; no concurrent timer access.
+unsafe fn wasm_timers_shutdown_inner() {
+    // Step 1: clear periodic timers via timer_periodic_wasm (owns the ctx
+    // registry for periodic entries; uses the same wheel).
+    // SAFETY: Single-threaded; no concurrent periodic-timer access.
+    unsafe { crate::timer_periodic_wasm::hew_periodic_shutdown() };
+
+    // Step 2: clear sleep entries from SLEEP_HANDLES, removing each from the
+    // wheel so the WasmSleepCtx is freed exactly once.
+    // SAFETY: Single-threaded; SLEEP_HANDLES and wheel not aliased.
+    unsafe {
+        let wheel = WASM_TIMER_WHEEL;
+        if !wheel.is_null() {
+            if let Some(ref mut handles) = SLEEP_HANDLES {
+                for (_, handle) in handles.drain() {
+                    let data = hew_timer_wheel_remove(wheel, handle.entry, handle.generation);
+                    if !data.is_null() {
+                        drop(Box::from_raw(data.cast::<WasmSleepCtx>()));
+                    }
+                }
+            }
+        }
+        SLEEP_HANDLES = None;
+        WASM_SLEEP_COUNT = 0;
+    }
+
+    // Step 3: destroy the wheel.  All HewTimerEntry nodes still in the wheel
+    // (if any remain after the two drain steps above) are freed here.
+    // SAFETY: Single-threaded; no other reference to WASM_TIMER_WHEEL exists.
+    unsafe {
+        if !WASM_TIMER_WHEEL.is_null() {
+            hew_timer_wheel_free(WASM_TIMER_WHEEL);
+            WASM_TIMER_WHEEL = std::ptr::null_mut();
+        }
     }
 }
 
@@ -689,10 +875,10 @@ unsafe fn step_one_actor() -> bool {
 
 /// Run all enqueued actors to completion.
 ///
-/// Loops until both the run queue and the sleep queue are empty: pops
+/// Loops until both the run queue and the timer wheel are empty: pops
 /// the front actor, activates it, and re-enqueues it if it still has
-/// pending messages.  Between activation rounds, drains any sleeping
-/// actors whose deadline has passed (using the real/simulated clock).
+/// pending messages.  Between activation rounds, drains any sleeping or
+/// periodic actors whose deadline has passed (using the real/simulated clock).
 ///
 /// For standalone WASM programs where sleeping actors are the only
 /// remaining work, this function spin-polls until all deadlines expire.
@@ -705,18 +891,18 @@ pub extern "C" fn hew_sched_run() {
     loop {
         // SAFETY: hew_now_ms is safe on all targets; drain is single-threaded.
         let now = unsafe { hew_now_ms() };
-        // SAFETY: Single-threaded; timer queues are owned by the cooperative scheduler.
+        // SAFETY: Single-threaded; timer wheel is owned by the cooperative scheduler.
         unsafe {
             let _ = drain_timed_work(now);
         };
 
         // SAFETY: Single-threaded on WASM.
         if !unsafe { step_one_actor() } {
-            // Run queue empty. Stop only when the sleep queue is also empty.
-            // SAFETY: Single-threaded on WASM.
-            #[expect(static_mut_refs, reason = "single-threaded cooperative scheduler")]
+            // Run queue empty. Stop only when no timed work remains.
+            // SAFETY: single-threaded; WASM_SLEEP_COUNT and pending_periodic_count
+            // are only mutated by scheduler paths that run on this thread.
             let timed_work_pending = unsafe {
-                !SLEEP_QUEUE.is_empty() || crate::timer_periodic_wasm::pending_periodic_count() > 0
+                WASM_SLEEP_COUNT > 0 || crate::timer_periodic_wasm::pending_periodic_count() > 0
             };
             if !timed_work_pending {
                 break;
@@ -741,16 +927,7 @@ pub extern "C" fn hew_wasm_runtime_exit() {
     hew_runtime_cleanup();
 }
 
-/// Drain both periodic-timer and sleep-queue entries whose deadlines have passed.
-/// Returns (`periodic_count`, `sleeper_count`).
-unsafe fn drain_timed_work(now_ms: u64) -> (u32, u32) {
-    // SAFETY: Single-threaded cooperative scheduler; timer queues are not mutated concurrently.
-    let periodic = unsafe { crate::timer_periodic_wasm::drain_ready_periodic(now_ms) };
-    // SAFETY: Single-threaded cooperative scheduler; sleep queue is not mutated concurrently.
-    let sleepers = unsafe { drain_expired_sleepers(now_ms) };
-    (periodic, sleepers)
-}
-
+// ── Internal API ────────────────────────────────────────────────────────
 // ── Internal API ────────────────────────────────────────────────────────
 
 /// Submit an actor to the run queue.
@@ -947,15 +1124,12 @@ pub extern "C" fn hew_wasm_sleeping_count() -> i32 {
     #[expect(
         clippy::cast_possible_truncation,
         clippy::cast_possible_wrap,
-        reason = "sleep queue length will not exceed i32::MAX"
+        reason = "timer count will not exceed i32::MAX"
     )]
-    #[expect(
-        static_mut_refs,
-        reason = "single-threaded cooperative scheduler; read-only access"
-    )]
-    // SAFETY: Single-threaded cooperative scheduler; SLEEP_QUEUE not mutated concurrently.
+    // SAFETY: Single-threaded cooperative scheduler; counts are only mutated
+    // by sleep park/cancel/fire (single-threaded) and periodic schedule/cancel.
     unsafe {
-        (SLEEP_QUEUE.len() + crate::timer_periodic_wasm::pending_periodic_count()) as i32
+        (WASM_SLEEP_COUNT + crate::timer_periodic_wasm::pending_periodic_count()) as i32
     }
 }
 
@@ -2115,11 +2289,9 @@ mod tests {
             ptr::addr_of_mut!(TASKS_COMPLETED).write(0);
             ptr::addr_of_mut!(MESSAGES_SENT).write(0);
             ptr::addr_of_mut!(MESSAGES_RECEIVED).write(0);
-            // Clear sleep queue and pending-sleep context.
-            ptr::drop_in_place(ptr::addr_of_mut!(SLEEP_QUEUE));
-            ptr::addr_of_mut!(SLEEP_QUEUE).write(Vec::new());
+            // Clear timer wheel state (sleep handles, periodic queue, wheel itself).
+            wasm_timers_shutdown_inner();
             ptr::addr_of_mut!(PENDING_SLEEP_DEADLINE_MS).write(0);
-            crate::timer_periodic_wasm::hew_periodic_shutdown();
             // Clear the thread-local current arena so arena lifecycle tests
             // start from a clean slate regardless of test ordering.
             crate::arena::set_current_arena(ptr::null_mut());
@@ -2315,9 +2487,15 @@ mod tests {
                 0,
                 "PENDING_SLEEP_DEADLINE_MS must be zero after shutdown"
             );
+            // Use addr_of! to read without creating a reference to the mutable static.
+            assert_eq!(
+                ptr::addr_of!(WASM_SLEEP_COUNT).read(),
+                0,
+                "WASM_SLEEP_COUNT must be zero after shutdown"
+            );
             assert!(
-                ptr::addr_of!(SLEEP_QUEUE).read().is_empty(),
-                "SLEEP_QUEUE must be empty after shutdown"
+                WASM_TIMER_WHEEL.is_null(),
+                "WASM_TIMER_WHEEL must be null after shutdown"
             );
         }
     }
@@ -5292,7 +5470,7 @@ mod tests {
         unsafe { ptr::addr_of_mut!(PENDING_SLEEP_DEADLINE_MS).write(0) };
     }
 
-    /// `drain_expired_sleepers` re-enqueues actors whose deadline has passed
+    /// `drain_timed_work` re-enqueues actors whose deadline has passed
     /// and leaves actors whose deadline is still in the future.
     #[test]
     fn drain_expired_sleepers_wakes_ready_actors() {
@@ -5312,11 +5490,17 @@ mod tests {
         b.actor_state
             .store(HewActorState::Idle as i32, Ordering::Relaxed);
 
-        // Park actor `a` at t=100 and actor `b` at t=300.
+        // Anchor to the real monotonic clock so the wheel receives
+        // deadlines that are strictly in the future relative to its
+        // current_ms at init time.
+        // SAFETY: hew_now_ms has no preconditions.
+        let now = unsafe { hew_now_ms() };
+
+        // Park actor `a` 100 ms from now and actor `b` 300 ms from now.
         // SAFETY: actors are valid for the duration of the test.
         unsafe {
-            park_actor_sleep(a_ptr, 100);
-            park_actor_sleep(b_ptr, 300);
+            park_actor_sleep(a_ptr, now + 100);
+            park_actor_sleep(b_ptr, now + 300);
             assert_eq!(
                 hew_wasm_sleeping_count(),
                 2,
@@ -5324,10 +5508,9 @@ mod tests {
             );
         }
 
-        // Advance to t=200: only `a` should wake.
+        // Advance to now+200: only `a` should wake.
         // SAFETY: Single-threaded test.
-        let woken = unsafe { drain_expired_sleepers(200) };
-        assert_eq!(woken, 1, "only actor a should wake at t=200");
+        unsafe { drain_timed_work(now + 200) };
         assert_eq!(
             a.actor_state.load(Ordering::Relaxed),
             HewActorState::Runnable as i32,
@@ -5346,10 +5529,9 @@ mod tests {
             "actor a should be in run queue"
         );
 
-        // Advance to t=400: `b` should wake.
+        // Advance to now+400: `b` should wake.
         // SAFETY: Single-threaded test.
-        let woken = unsafe { drain_expired_sleepers(400) };
-        assert_eq!(woken, 1, "actor b should wake at t=400");
+        unsafe { drain_timed_work(now + 400) };
         assert_eq!(
             b.actor_state.load(Ordering::Relaxed),
             HewActorState::Runnable as i32,
@@ -5360,7 +5542,8 @@ mod tests {
         hew_sched_shutdown();
     }
 
-    /// `drain_expired_sleepers` silently discards stopped/crashed actors.
+    /// Timer callbacks for stopped/crashed actors are silently discarded
+    /// (actor not re-enqueued, sleep count decremented).
     #[test]
     fn drain_expired_sleepers_discards_terminal_actors() {
         let _guard = crate::runtime_test_guard();
@@ -5373,21 +5556,29 @@ mod tests {
         a.actor_state
             .store(HewActorState::Idle as i32, Ordering::Relaxed);
 
+        // SAFETY: hew_now_ms has no preconditions.
+        let now = unsafe { hew_now_ms() };
+
         // SAFETY: actor is valid for the duration of the test.
-        unsafe { park_actor_sleep(a_ptr, 50) };
+        unsafe { park_actor_sleep(a_ptr, now + 50) };
 
         // Mark the actor as stopped before the timer fires.
         a.actor_state
             .store(HewActorState::Stopped as i32, Ordering::Relaxed);
 
+        // Advance the wheel past the deadline; the callback fires but does
+        // NOT re-enqueue the stopped actor.
         // SAFETY: Single-threaded test.
-        let woken = unsafe { drain_expired_sleepers(100) };
-        assert_eq!(woken, 0, "stopped actor should be discarded, not woken");
-        assert_eq!(hew_wasm_sleeping_count(), 0, "sleep queue should be empty");
+        unsafe { drain_timed_work(now + 100) };
+        assert_eq!(
+            hew_wasm_sleeping_count(),
+            0,
+            "sleep count must clear even for stopped actors"
+        );
         assert_eq!(
             hew_sched_metrics_global_queue_len(),
             0,
-            "run queue should be empty"
+            "run queue should be empty — stopped actor must not be re-enqueued"
         );
 
         hew_sched_shutdown();
@@ -5436,6 +5627,13 @@ mod tests {
         // SAFETY: actor has a valid mailbox.
         unsafe { queue_wasm_message(a_ptr, 42) };
 
+        // Snapshot the clock just before the tick drives the dispatch.
+        // sleeping_dispatch calls request_sleep(now + 500); the wheel entry
+        // is inserted with delay_ms ≈ 500, firing at approximately t0 + 500.
+        // All of this happens in the same millisecond on any modern host.
+        // SAFETY: hew_now_ms has no preconditions.
+        let t0 = unsafe { hew_now_ms() };
+
         // Run one tick.
         // SAFETY: Single-threaded test.
         let _ = unsafe { hew_wasm_sched_tick(1) };
@@ -5456,17 +5654,10 @@ mod tests {
             "actor should be in sleep queue"
         );
 
-        // Read back the parked deadline from the sleep queue so the wasm-target
-        // test can drive the real timer path without relying on native-only
-        // deterministic clock helpers.
-        // SAFETY: Single-threaded test; SLEEP_QUEUE is not mutated concurrently.
-        let deadline_ms = unsafe {
-            let q_ptr = ptr::addr_of!(SLEEP_QUEUE);
-            (*q_ptr)
-                .first()
-                .map(|&(deadline, _)| deadline)
-                .expect("sleep queue should contain the parked actor")
-        };
+        // The parked deadline is t0 + 500 (sleeping_dispatch sets
+        // PENDING_SLEEP_DEADLINE_MS = hew_now_ms() + 500 ≈ t0 + 500).
+        // Drive the wheel to just before and exactly at that deadline.
+        let deadline_ms = t0 + 500;
 
         // One ms before the parked deadline: actor should NOT wake yet.
         // SAFETY: Single-threaded test.
@@ -5531,12 +5722,18 @@ mod tests {
         a.actor_state
             .store(HewActorState::Idle as i32, Ordering::Relaxed);
 
+        // Anchor all deadlines relative to the real clock so the wheel's
+        // internal current_ms and the test-driven tick values are in the
+        // same numeric space.
+        // SAFETY: hew_now_ms has no preconditions.
+        let now = unsafe { hew_now_ms() };
+
         // SAFETY: actor valid for duration of test.
-        unsafe { park_actor_sleep(a_ptr, 1000) };
+        unsafe { park_actor_sleep(a_ptr, now + 1000) };
 
         // One ms before deadline: nothing wakes.
         // SAFETY: Single-threaded test.
-        let woken = unsafe { hew_wasm_timer_tick(999) };
+        let woken = unsafe { hew_wasm_timer_tick(now + 999) };
         assert_eq!(woken, 0);
         assert_eq!(
             a.actor_state.load(Ordering::Relaxed),
@@ -5545,7 +5742,7 @@ mod tests {
 
         // Exactly at deadline: actor wakes.
         // SAFETY: Single-threaded test.
-        let woken = unsafe { hew_wasm_timer_tick(1000) };
+        let woken = unsafe { hew_wasm_timer_tick(now + 1000) };
         assert_eq!(woken, 1);
         assert_eq!(
             a.actor_state.load(Ordering::Relaxed),
@@ -5573,7 +5770,9 @@ mod tests {
             .store(HewActorState::Idle as i32, Ordering::Relaxed);
 
         // Park actor with a deadline 1 hour in the future.
-        let far_future: u64 = 3_600_000;
+        // SAFETY: hew_now_ms has no preconditions.
+        let now = unsafe { hew_now_ms() };
+        let far_future: u64 = now + 3_600_000;
         // SAFETY: actor is valid for duration of test.
         unsafe { park_actor_sleep(a_ptr, far_future) };
 
@@ -5608,8 +5807,11 @@ mod tests {
         a.actor_state
             .store(HewActorState::Idle as i32, Ordering::Relaxed);
 
-        // SAFETY: actor is valid.
-        unsafe { park_actor_sleep(a_ptr, 500) };
+        // SAFETY: actor is valid; park_actor_sleep requires a live HewActor ptr.
+        // SAFETY: hew_now_ms has no preconditions.
+        let now = unsafe { hew_now_ms() };
+        // SAFETY: actor is valid; park_actor_sleep requires a live HewActor ptr.
+        unsafe { park_actor_sleep(a_ptr, now + 500) };
         assert_eq!(hew_wasm_sleeping_count(), 1);
 
         // Simulate what cleanup_all_actors does before freeing: cancel the entry.
@@ -5624,7 +5826,7 @@ mod tests {
 
         // A subsequent timer tick must not touch the (now-removed) entry.
         // SAFETY: Single-threaded test.
-        let woken = unsafe { hew_wasm_timer_tick(1000) };
+        let woken = unsafe { hew_wasm_timer_tick(now + 1000) };
         assert_eq!(woken, 0, "no actors should wake after entry was cancelled");
 
         hew_sched_shutdown();
@@ -5889,11 +6091,11 @@ mod tests {
 
     /// Regression: a message sent to a sleeping actor must NOT wake it before
     /// the timer fires.  The message must queue in the mailbox and be
-    /// delivered only when `drain_expired_sleepers` transitions the actor
+    /// delivered only when the timer wheel transitions the actor
     /// from `Sleeping` → `Runnable`.
     ///
-    /// Also verifies that there is no stale `SLEEP_QUEUE` entry after the timer
-    /// fires (no double-enqueue / phantom wake).
+    /// Also verifies that the sleep entry is removed from the wheel after the
+    /// timer fires (no double-enqueue / phantom wake).
     #[test]
     fn message_to_sleeping_actor_queues_without_early_wake() {
         static DISPATCHED: AtomicI32 = AtomicI32::new(0);
@@ -5924,9 +6126,11 @@ mod tests {
         // transition it to Sleeping internally.
         let a_ptr: *mut HewActor = (&raw mut a);
 
-        // Park actor directly at t=1000 (simulating post-dispatch park).
+        // Park actor directly with a deadline 1 s from now (simulating post-dispatch park).
+        // SAFETY: hew_now_ms has no preconditions.
+        let now = unsafe { hew_now_ms() };
         // SAFETY: actor is valid; scheduler is initialized.
-        unsafe { park_actor_sleep(a_ptr, 1000) };
+        unsafe { park_actor_sleep(a_ptr, now + 1000) };
         assert_eq!(
             a.actor_state.load(Ordering::Relaxed),
             HewActorState::Sleeping as i32,
@@ -5961,7 +6165,7 @@ mod tests {
 
         // Advance time past deadline and drain: actor wakes, processes message.
         // SAFETY: Single-threaded test.
-        let woken = unsafe { hew_wasm_timer_tick(1001) };
+        let woken = unsafe { hew_wasm_timer_tick(now + 1001) };
         assert_eq!(woken, 1, "actor must wake when timer fires");
         assert_eq!(
             a.actor_state.load(Ordering::Relaxed),

--- a/hew-runtime/src/timer_periodic_wasm.rs
+++ b/hew-runtime/src/timer_periodic_wasm.rs
@@ -1,9 +1,8 @@
 //! Cooperative periodic timer support for WASM targets.
 //!
-//! Periodic receive handlers are lowered to runtime calls that schedule
-//! zero-payload self-sends. On wasm32 there is no background ticker thread, so
-//! the host (or [`crate::scheduler_wasm::hew_wasm_sched_tick`]) drives this
-//! queue explicitly.
+//! Uses the same `HewTimerWheel` as the native path, sourcing current time
+//! via the cfg-split `hew_now_ms()` already present in the runtime.
+//! This replaces the former O(n²) sorted-Vec `PERIODIC_QUEUE`.
 #![allow(
     unsafe_op_in_unsafe_fn,
     reason = "FFI entry-point module; SAFETY documented at fn signature."
@@ -16,118 +15,130 @@ use std::sync::atomic::Ordering;
 
 use crate::actor::{self, HewActor};
 use crate::internal::types::HewActorState;
-use crate::lifetime::PoisonSafe;
 use crate::mailbox_wasm::HewMailboxWasm;
+use crate::timer_wheel::{hew_timer_wheel_remove, hew_timer_wheel_schedule_handle, HewTimerHandle};
 
-#[derive(Debug)]
-struct PeriodicHandle {
-    actor: *mut HewActor,
-    next_fire_ms: u64,
+// ---------------------------------------------------------------------------
+// Per-timer context
+// ---------------------------------------------------------------------------
+
+/// Heap-allocated context for one live periodic timer.
+///
+/// The pointer returned by [`hew_actor_schedule_periodic`] **is** this
+/// struct cast to `*mut c_void`; it serves as both the opaque user handle and
+/// the `data` payload passed to `wasm_periodic_cb`.
+///
+/// Tests read `next_fire_ms` through `(*handle.cast::<WasmPeriodicCtx>()).next_fire_ms`.
+pub(crate) struct WasmPeriodicCtx {
+    /// Owning actor; kept for registry lookup on actor death.
+    pub(crate) actor: *mut HewActor,
+    /// Message type delivered on each fire.
+    pub(crate) msg_type: i32,
+    // 4 bytes implicit padding for `interval_ms` alignment.
+    /// Repeat interval in milliseconds.
+    pub(crate) interval_ms: u64,
+    /// Next scheduled fire time in ms; updated by the callback after each fire.
+    pub(crate) next_fire_ms: u64,
+    /// Handle to the current live wheel entry; updated on re-arm.
+    pub(crate) pending_handle: HewTimerHandle,
 }
 
-// SAFETY: The cooperative WASM timer queue is single-threaded; tests serialize
-// access with runtime_test_guard.
-unsafe impl Send for PeriodicHandle {}
-// SAFETY: The handle contains only immutable scalar metadata plus an actor ptr.
-unsafe impl Sync for PeriodicHandle {}
+// SAFETY: The cooperative WASM timer wheel is single-threaded; tests
+// serialise access with `runtime_test_guard`.
+unsafe impl Send for WasmPeriodicCtx {}
+// SAFETY: WasmPeriodicCtx is accessed only from a single-threaded WASM
+// cooperative scheduler; all fields are guarded by the scheduler's
+// single-threaded invariant.
+unsafe impl Sync for WasmPeriodicCtx {}
 
-#[derive(Debug)]
-struct PeriodicEntry {
-    next_fire_ms: u64,
-    interval_ms: u64,
-    actor: *mut HewActor,
-    msg_type: i32,
-    handle: *mut PeriodicHandle,
+// ---------------------------------------------------------------------------
+// Module-level state
+// ---------------------------------------------------------------------------
+
+/// Registry: actor address → list of `*mut WasmPeriodicCtx` owned by the wheel.
+static mut PERIODIC_CTX_REGISTRY: Option<HashMap<usize, Vec<*mut WasmPeriodicCtx>>> = None;
+
+/// Count of live periodic timer contexts (in wheel or being re-armed).
+/// Combined with `WASM_SLEEP_COUNT` in `hew_wasm_sleeping_count`.
+static mut WASM_PERIODIC_COUNT: usize = 0;
+
+// ---------------------------------------------------------------------------
+// Clock helper — mirrors `scheduler_wasm::hew_now_ms`
+// ---------------------------------------------------------------------------
+
+#[cfg(not(target_arch = "wasm32"))]
+#[inline]
+fn hew_now_ms_periodic() -> u64 {
+    // SAFETY: `io_time::hew_now_ms` has no preconditions.
+    unsafe { crate::io_time::hew_now_ms() }
 }
 
-// SAFETY: The queue is driven by a single thread / serialized test harness.
-unsafe impl Send for PeriodicEntry {}
-// SAFETY: Queue entries are only mutated while held under PERIODIC_QUEUE.
-unsafe impl Sync for PeriodicEntry {}
+#[cfg(target_arch = "wasm32")]
+#[inline]
+fn hew_now_ms_periodic() -> u64 {
+    extern "C" {
+        fn hew_now_ms() -> u64;
+    }
+    // SAFETY: `hew_now_ms` is always provided by the WASM host.
+    unsafe { hew_now_ms() }
+}
 
-// WASM-TODO(#1451): replace this cooperative Vec-backed timer queue with the shared
-// timer wheel backend used natively; insert/drain/cancel are still O(n)/O(n²).
-static PERIODIC_QUEUE: PoisonSafe<Vec<PeriodicEntry>> = PoisonSafe::new(Vec::new());
-static PERIODIC_REGISTRY: PoisonSafe<Option<HashMap<usize, Vec<usize>>>> = PoisonSafe::new(None);
+// ---------------------------------------------------------------------------
+// Registry helpers
+// ---------------------------------------------------------------------------
 
-fn register_timer(actor: *mut HewActor, handle: *mut PeriodicHandle) {
-    PERIODIC_REGISTRY.access(|lock| {
-        lock.get_or_insert_with(HashMap::new)
+/// Add `ctx` to the per-actor registry.
+///
+/// # Safety
+///
+/// `PERIODIC_CTX_REGISTRY` is a mutable static; caller ensures single-threaded access.
+unsafe fn register_ctx(actor: *mut HewActor, ctx: *mut WasmPeriodicCtx) {
+    #[expect(
+        static_mut_refs,
+        reason = "single-threaded cooperative WASM scheduler; PERIODIC_CTX_REGISTRY not aliased"
+    )]
+    // SAFETY: single-threaded; `get_or_insert_with` takes `&mut self`.
+    unsafe {
+        PERIODIC_CTX_REGISTRY
+            .get_or_insert_with(HashMap::new)
             .entry(actor as usize)
             .or_default()
-            .push(handle as usize);
-    });
+            .push(ctx);
+    }
 }
 
-fn unregister_timer(actor: *mut HewActor, handle: *mut PeriodicHandle) {
-    PERIODIC_REGISTRY.access(|lock| {
-        if let Some(map) = lock.as_mut() {
-            if let Some(handles) = map.get_mut(&(actor as usize)) {
-                handles.retain(|addr| *addr != handle as usize);
-                if handles.is_empty() {
-                    map.remove(&(actor as usize));
+/// Remove `ctx` from the per-actor registry (no-op if not present).
+///
+/// # Safety
+///
+/// `PERIODIC_CTX_REGISTRY` is a mutable static; caller ensures single-threaded access.
+unsafe fn unregister_ctx(actor: *mut HewActor, ctx: *const WasmPeriodicCtx) {
+    #[expect(
+        static_mut_refs,
+        reason = "single-threaded cooperative WASM scheduler; PERIODIC_CTX_REGISTRY not aliased"
+    )]
+    // SAFETY: single-threaded; `as_mut` takes `&mut self`.
+    unsafe {
+        if let Some(registry) = PERIODIC_CTX_REGISTRY.as_mut() {
+            if let Some(vec) = registry.get_mut(&(actor as usize)) {
+                vec.retain(|&p| !ptr::eq(p, ctx));
+                if vec.is_empty() {
+                    registry.remove(&(actor as usize));
                 }
             }
         }
-    });
-}
-
-fn insert_sorted(entry: PeriodicEntry) {
-    PERIODIC_QUEUE.access(|queue| {
-        let pos = queue.partition_point(|existing| existing.next_fire_ms <= entry.next_fire_ms);
-        queue.insert(pos, entry);
-    });
-}
-
-/// Remove and return all periodic entries whose fire time has passed.
-fn drain_due_entries(now_ms: u64) -> Vec<PeriodicEntry> {
-    PERIODIC_QUEUE.access(|queue| {
-        let mut ready = Vec::new();
-        while queue
-            .first()
-            .is_some_and(|entry| entry.next_fire_ms <= now_ms)
-        {
-            ready.push(queue.remove(0));
-        }
-        ready
-    })
-}
-
-unsafe fn free_handle(handle: *mut PeriodicHandle) {
-    // SAFETY: caller guarantees `handle` was allocated by Box::into_raw and is unique here.
-    let _ = unsafe { Box::from_raw(handle) };
-}
-
-fn current_time_ms() -> u64 {
-    #[cfg(target_arch = "wasm32")]
-    // SAFETY: hew_now_ms has no preconditions on wasm32.
-    unsafe {
-        crate::wasm_stubs::hew_now_ms()
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    // SAFETY: io_time::hew_now_ms has no preconditions in native test builds.
-    unsafe {
-        crate::io_time::hew_now_ms()
     }
 }
 
-unsafe fn send_periodic_message(actor: *mut HewActor, msg_type: i32) {
-    // SAFETY: caller guarantees `actor` is a live HewActor pointer.
-    let a = unsafe { &*actor };
-    // SAFETY: the mailbox belongs to `actor`, and wake_wasm_actor shares the same contract.
-    unsafe {
-        crate::mailbox_wasm::hew_mailbox_send(a.mailbox.cast(), msg_type, ptr::null_mut(), 0);
-        actor::wake_wasm_actor(actor);
-    }
-}
+// ---------------------------------------------------------------------------
+// Liveness helpers
+// ---------------------------------------------------------------------------
 
 fn actor_has_live_mailbox(actor: *mut HewActor) -> bool {
     if actor.is_null() {
         return false;
     }
-
-    // SAFETY: actor nullability was checked above; reading actor_state is side-effect free.
+    // SAFETY: non-null pointer; actor_state read is side-effect free.
     let state = unsafe { (*actor).actor_state.load(Ordering::Relaxed) };
     if state == HewActorState::Stopping as i32
         || state == HewActorState::Stopped as i32
@@ -135,91 +146,94 @@ fn actor_has_live_mailbox(actor: *mut HewActor) -> bool {
     {
         return false;
     }
-
-    // SAFETY: actor nullability was checked above; mailbox is a plain field read.
+    // SAFETY: non-null actor; mailbox is a plain field read.
     let mailbox = unsafe { (*actor).mailbox.cast::<HewMailboxWasm>() };
     if mailbox.is_null() {
         return false;
     }
-
     // SAFETY: mailbox was read from a live actor and is only queried here.
     unsafe { !crate::mailbox_wasm::mailbox_is_closed(mailbox) }
 }
 
-pub(crate) fn pending_periodic_count() -> usize {
-    PERIODIC_QUEUE.access(|queue| queue.len())
-}
-
-/// Deliver any due periodic messages and re-arm surviving timers.
-///
-/// Re-arming is based on the timer's previous scheduled fire time rather than
-/// `now_ms` to avoid accumulating drift when the host drives the queue late.
-pub(crate) unsafe fn drain_ready_periodic(now_ms: u64) -> u32 {
-    let ready = drain_due_entries(now_ms);
-    let mut fired = 0_u32;
-
-    for mut entry in ready {
-        if !actor_has_live_mailbox(entry.actor) {
-            unregister_timer(entry.actor, entry.handle);
-            // SAFETY: the timer was removed from both queue and registry and owns its handle.
-            unsafe { free_handle(entry.handle) };
-            continue;
-        }
-
-        let mut fire_time = entry.next_fire_ms;
-        loop {
-            // SAFETY: actor_has_live_mailbox verified the actor/mailbox are still valid.
-            unsafe { send_periodic_message(entry.actor, entry.msg_type) };
-            fired = fired.saturating_add(1);
-
-            let Some(next_fire) = fire_time.checked_add(entry.interval_ms) else {
-                fire_time = u64::MAX;
-                break;
-            };
-            fire_time = next_fire;
-            if fire_time > now_ms {
-                break;
-            }
-        }
-
-        entry.next_fire_ms = fire_time;
-        // SAFETY: handle remains owned by this active entry while it stays queued.
-        unsafe {
-            (*entry.handle).next_fire_ms = fire_time;
-        }
-        insert_sorted(entry);
+unsafe fn send_periodic_message(actor: *mut HewActor, msg_type: i32) {
+    // SAFETY: caller verified actor_has_live_mailbox; actor and mailbox are valid.
+    let a = unsafe { &*actor };
+    // SAFETY: mailbox belongs to actor and is live (verified by actor_has_live_mailbox);
+    // wake_wasm_actor shares the same contract.
+    unsafe {
+        crate::mailbox_wasm::hew_mailbox_send(a.mailbox.cast(), msg_type, ptr::null_mut(), 0);
+        actor::wake_wasm_actor(actor);
     }
-
-    fired
 }
 
-/// Cancel all periodic timers registered for `actor`.
+// ---------------------------------------------------------------------------
+// Wheel callback
+// ---------------------------------------------------------------------------
+
+/// Fires a periodic message, re-arms the wheel entry, and updates `ctx.pending_handle`.
 ///
 /// # Safety
 ///
-/// `actor` must be a live actor pointer or one that is about to be freed.
-pub(crate) unsafe fn cancel_all_timers_for_actor(actor: *mut HewActor) {
-    let handles = PERIODIC_REGISTRY.access(|lock| {
-        lock.as_mut()
-            .and_then(|map| map.remove(&(actor as usize)))
-            .unwrap_or_default()
-    });
+/// `data` is a `Box<WasmPeriodicCtx>` whose owning wheel entry has just been
+/// unlinked. The actor pointer in `ctx` is live because
+/// `cancel_all_timers_for_actor` removes wheel entries before the actor is
+/// freed.
+unsafe extern "C" fn wasm_periodic_cb(data: *mut c_void) {
+    let ctx_ptr = data.cast::<WasmPeriodicCtx>();
+    // SAFETY: data is a Box<WasmPeriodicCtx> allocated at schedule time and
+    // re-owned here. The actor is live per the safety contract above.
+    let ctx = unsafe { &mut *ctx_ptr };
 
-    if handles.is_empty() {
+    if !actor_has_live_mailbox(ctx.actor) {
+        // Actor died while the timer was pending; free context and uncount.
+        // SAFETY: ctx_ptr is uniquely owned (unlinked from wheel by tick).
+        unsafe {
+            unregister_ctx(ctx.actor, ctx_ptr);
+            drop(Box::from_raw(ctx_ptr));
+            WASM_PERIODIC_COUNT = WASM_PERIODIC_COUNT.saturating_sub(1);
+        }
         return;
     }
 
-    PERIODIC_QUEUE.access(|queue| {
-        queue.retain(|entry| !ptr::eq(entry.actor, actor));
-    });
+    // Fire one message. (Catch-up delivery of multiple missed intervals
+    // is intentionally omitted: the wheel fires once per deadline, and
+    // the host is responsible for calling hew_wasm_timer_tick frequently
+    // enough.  This matches native timer_periodic.rs semantics.)
+    // SAFETY: actor_has_live_mailbox verified the actor and mailbox are valid.
+    unsafe { send_periodic_message(ctx.actor, ctx.msg_type) };
 
-    for handle in handles {
-        // SAFETY: handles were removed from registry/queue above and are uniquely owned here.
-        unsafe { free_handle(handle as *mut PeriodicHandle) };
-    }
+    // Advance next_fire_ms by one interval so test observers and the
+    // next re-arm agree on the expected fire time.
+    ctx.next_fire_ms = ctx.next_fire_ms.saturating_add(ctx.interval_ms);
+
+    // Re-arm: schedule interval_ms from the wheel's current position
+    // (not from wall-clock now) so timed tests advance predictably.
+    // SAFETY: wasm_timer_wheel() is safe to call from a wheel callback (the
+    // lock is released before callbacks fire); wasm_periodic_cb re-acquires
+    // the lock only to insert the new entry.
+    let wheel = unsafe { crate::scheduler_wasm::wasm_timer_wheel() };
+    // SAFETY: wheel is valid (guaranteed by wasm_timer_wheel); ctx_ptr is alive
+    // and uniquely owned by this callback invocation.
+    let new_handle = unsafe {
+        hew_timer_wheel_schedule_handle(wheel, ctx.interval_ms, wasm_periodic_cb, ctx_ptr.cast())
+    };
+    ctx.pending_handle = new_handle;
 }
 
-/// Schedule a periodic self-send on the cooperative WASM timer queue.
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+/// Return the number of live periodic timer contexts.
+pub(crate) fn pending_periodic_count() -> usize {
+    // SAFETY: single-threaded WASM; no concurrent mutation.
+    unsafe { WASM_PERIODIC_COUNT }
+}
+
+/// Schedule a periodic self-send on the shared WASM timer wheel.
+///
+/// Returns a `*mut c_void` that is actually a `*mut WasmPeriodicCtx`; the
+/// caller stores it and passes it to [`hew_actor_cancel_periodic`].
 ///
 /// # Safety
 ///
@@ -234,71 +248,174 @@ pub unsafe extern "C" fn hew_actor_schedule_periodic(
         return ptr::null_mut();
     }
 
-    let next_fire_ms = current_time_ms().saturating_add(interval_ms);
-    let handle = Box::into_raw(Box::new(PeriodicHandle {
-        actor,
-        next_fire_ms,
-    }));
+    let now = hew_now_ms_periodic();
+    let next_fire_ms = now.saturating_add(interval_ms);
 
-    register_timer(actor, handle);
-    insert_sorted(PeriodicEntry {
-        next_fire_ms,
-        interval_ms,
+    let ctx = Box::into_raw(Box::new(WasmPeriodicCtx {
         actor,
         msg_type,
-        handle,
-    });
+        // no explicit padding field; Rust adds 4 implicit alignment bytes here
+        interval_ms,
+        next_fire_ms,
+        pending_handle: HewTimerHandle::null(),
+    }));
 
-    handle.cast()
+    // Schedule on the shared wheel before registering (avoids a half-initialised
+    // entry in the registry).
+    // SAFETY: wasm_timer_wheel() has no preconditions beyond single-threaded access.
+    let wheel = unsafe { crate::scheduler_wasm::wasm_timer_wheel() };
+    // SAFETY: wheel is valid (wasm_timer_wheel returned non-null above); ctx is
+    // exclusively owned at this point (not yet in any registry).
+    let handle = unsafe {
+        hew_timer_wheel_schedule_handle(wheel, interval_ms, wasm_periodic_cb, ctx.cast())
+    };
+    // SAFETY: ctx was just created; no other reference exists.
+    unsafe { (*ctx).pending_handle = handle };
+
+    // SAFETY: PERIODIC_CTX_REGISTRY and WASM_PERIODIC_COUNT are single-threaded.
+    unsafe {
+        register_ctx(actor, ctx);
+        WASM_PERIODIC_COUNT += 1;
+    }
+
+    ctx.cast()
 }
 
 /// Cancel a previously scheduled periodic timer.
 ///
+/// After this call the timer will never fire again and `handle` becomes invalid.
+///
 /// # Safety
 ///
-/// `handle` must be a pointer returned by [`hew_actor_schedule_periodic`].
+/// `handle` must be a non-null pointer returned by [`hew_actor_schedule_periodic`]
+/// that has not already been cancelled.
 #[cfg_attr(not(test), no_mangle)]
 pub unsafe extern "C" fn hew_actor_cancel_periodic(handle: *mut c_void) {
     if handle.is_null() {
         return;
     }
 
-    let handle = handle.cast::<PeriodicHandle>();
-    // SAFETY: caller guarantees `handle` came from hew_actor_schedule_periodic.
-    let actor = unsafe { (*handle).actor };
-    unregister_timer(actor, handle);
+    let ctx_ptr = handle.cast::<WasmPeriodicCtx>();
+    // Read fields before any deallocation.
+    // SAFETY: ctx_ptr is alive (not yet cancelled or freed).
+    let actor = unsafe { (*ctx_ptr).actor };
+    // SAFETY: ctx_ptr is alive (not yet cancelled or freed; same guarantee as above).
+    let ph = unsafe { (*ctx_ptr).pending_handle };
 
-    PERIODIC_QUEUE.access(|queue| {
-        queue.retain(|entry| !ptr::eq(entry.handle, handle));
-    });
+    // Remove from registry while ctx_ptr is still valid.
+    // SAFETY: PERIODIC_CTX_REGISTRY is single-threaded.
+    unsafe { unregister_ctx(actor, ctx_ptr) };
 
-    // SAFETY: the handle has been removed from queue/registry above.
-    unsafe { free_handle(handle) };
+    // Remove the wheel entry.  `ph.pending_handle` always reflects the
+    // *current* wheel entry (updated by `wasm_periodic_cb` on re-arm).
+    // On single-threaded WASM the callback cannot fire between here and the
+    // end of this function, so `ph` is stable.
+    // SAFETY: wasm_timer_wheel_raw is single-threaded.
+    let wheel = unsafe { crate::scheduler_wasm::wasm_timer_wheel_raw() };
+    if !wheel.is_null() && !ph.entry.is_null() {
+        // SAFETY: wheel is valid and ph.entry is non-null (both checked above).
+        let data = unsafe { hew_timer_wheel_remove(wheel, ph.entry, ph.generation) };
+        if !data.is_null() {
+            // Entry was still in the wheel; data == ctx_ptr, we reclaim the Box.
+            // SAFETY: data is the Box<WasmPeriodicCtx> we allocated.
+            unsafe { drop(Box::from_raw(ctx_ptr)) };
+        }
+        // data == null: entry was already collected by a concurrent tick
+        // (impossible on single-threaded WASM).  Fall through without free to
+        // avoid a double-free.  The count still decrements below.
+    } else {
+        // Wheel null (scheduler stopped) or schedule failed (null entry).
+        // SAFETY: ctx_ptr is still valid — registry removal above did not free it.
+        unsafe { drop(Box::from_raw(ctx_ptr)) };
+    }
+
+    // SAFETY: single-threaded; count is only mutated from schedule/cancel/callback.
+    unsafe { WASM_PERIODIC_COUNT = WASM_PERIODIC_COUNT.saturating_sub(1) };
 }
 
-/// Clear the cooperative periodic queue.
+/// Drain all periodic contexts from the registry and remove their wheel entries.
+///
+/// Called by [`crate::scheduler_wasm::wasm_timers_shutdown_inner`] during
+/// scheduler shutdown, **before** the wheel itself is freed.
 ///
 /// # Safety
 ///
 /// Must not race with timer queue mutation; the WASM scheduler is single-threaded.
 #[cfg_attr(not(test), no_mangle)]
 pub unsafe extern "C" fn hew_periodic_shutdown() {
-    let handles = PERIODIC_QUEUE.access(|queue| {
-        let handles = queue
-            .iter()
-            .map(|entry| entry.handle as usize)
-            .collect::<Vec<_>>();
-        queue.clear();
-        handles
-    });
+    // Take ownership of the registry (leaves it as None).
+    let mut all_ctxs: Vec<*mut WasmPeriodicCtx> = Vec::new();
+    #[expect(
+        static_mut_refs,
+        reason = "single-threaded cooperative WASM scheduler; PERIODIC_CTX_REGISTRY not aliased"
+    )]
+    // SAFETY: single-threaded; `take` takes `&mut self` on the mutable static.
+    unsafe {
+        if let Some(registry) = PERIODIC_CTX_REGISTRY.take() {
+            all_ctxs = registry.into_values().flatten().collect();
+        }
+    }
 
-    PERIODIC_REGISTRY.access(|registry| {
-        *registry = None;
-    });
+    // SAFETY: wasm_timer_wheel_raw is single-threaded.
+    let wheel = unsafe { crate::scheduler_wasm::wasm_timer_wheel_raw() };
+    for ctx_ptr in all_ctxs {
+        if ctx_ptr.is_null() {
+            continue;
+        }
+        // SAFETY: ctx_ptr was in the registry and is exclusively owned here.
+        let ph = unsafe { (*ctx_ptr).pending_handle };
+        if !wheel.is_null() && !ph.entry.is_null() {
+            // Remove from wheel; ignore the return value — we free ctx regardless.
+            // SAFETY: wheel is valid (non-null checked above); ph is valid (read from ctx_ptr).
+            unsafe { hew_timer_wheel_remove(wheel, ph.entry, ph.generation) };
+        }
+        // SAFETY: exclusively owned Box; ctx_ptr was taken from the registry and
+        // will not be freed by any other path after this point.
+        unsafe { drop(Box::from_raw(ctx_ptr)) };
+    }
 
-    for handle in handles {
-        // SAFETY: shutdown drained the queue, so each handle is uniquely owned here.
-        unsafe { free_handle(handle as *mut PeriodicHandle) };
+    // SAFETY: single-threaded.
+    unsafe { WASM_PERIODIC_COUNT = 0 };
+}
+
+/// Cancel all periodic timers registered for `actor`.
+///
+/// Called from `actor.rs` when an actor is stopping or being cleaned up.
+///
+/// # Safety
+///
+/// `actor` must be a live actor pointer or one that is about to be freed.
+pub(crate) unsafe fn cancel_all_timers_for_actor(actor: *mut HewActor) {
+    let ctxs_opt: Option<Vec<*mut WasmPeriodicCtx>>;
+    #[expect(
+        static_mut_refs,
+        reason = "single-threaded cooperative WASM scheduler; PERIODIC_CTX_REGISTRY not aliased"
+    )]
+    // SAFETY: single-threaded; `as_mut` / `remove` take `&mut self` on the mutable static.
+    unsafe {
+        ctxs_opt = PERIODIC_CTX_REGISTRY
+            .as_mut()
+            .and_then(|r| r.remove(&(actor as usize)));
+    }
+    let Some(ctxs) = ctxs_opt else { return };
+
+    // SAFETY: wasm_timer_wheel_raw is single-threaded.
+    let wheel = unsafe { crate::scheduler_wasm::wasm_timer_wheel_raw() };
+    for ctx_ptr in ctxs {
+        if ctx_ptr.is_null() {
+            continue;
+        }
+        // SAFETY: ctx_ptr was in the registry and is exclusively owned here.
+        let ph = unsafe { (*ctx_ptr).pending_handle };
+        if !wheel.is_null() && !ph.entry.is_null() {
+            // SAFETY: wheel is valid (non-null checked above); ph is valid (read from ctx_ptr).
+            unsafe { hew_timer_wheel_remove(wheel, ph.entry, ph.generation) };
+        }
+        // SAFETY: ctx_ptr is exclusively owned here; taken from ctxs (drained from registry)
+        // and not freed elsewhere in this loop.
+        unsafe { drop(Box::from_raw(ctx_ptr)) };
+        // SAFETY: single-threaded count mutation.
+        unsafe { WASM_PERIODIC_COUNT = WASM_PERIODIC_COUNT.saturating_sub(1) };
     }
 }
 
@@ -409,6 +526,9 @@ mod tests {
 
     fn reset_runtime() {
         crate::scheduler_wasm::hew_sched_shutdown();
+        // hew_sched_shutdown already calls wasm_timers_shutdown_inner which
+        // calls hew_periodic_shutdown; the explicit call here is a no-op but
+        // harmless and documents the intent.
         // SAFETY: tests serialize timer-queue access with runtime_test_guard.
         unsafe { hew_periodic_shutdown() };
         crate::scheduler_wasm::hew_sched_init();
@@ -423,8 +543,8 @@ mod tests {
         let handle = unsafe { hew_actor_schedule_periodic(actor.actor, 7, 10) };
         assert!(!handle.is_null());
 
-        // SAFETY: handle was returned by hew_actor_schedule_periodic and is still active.
-        let first_fire = unsafe { (*handle.cast::<PeriodicHandle>()).next_fire_ms };
+        // SAFETY: handle is a live *mut WasmPeriodicCtx; next_fire_ms is valid.
+        let first_fire = unsafe { (*handle.cast::<WasmPeriodicCtx>()).next_fire_ms };
         // SAFETY: tests serialize scheduler access and the runtime is initialized.
         unsafe {
             let _ = crate::scheduler_wasm::hew_wasm_timer_tick(first_fire.saturating_sub(1));
@@ -447,8 +567,8 @@ mod tests {
         let actor = TestActor::new();
         // SAFETY: actor is a live TestActor-owned pointer.
         let handle = unsafe { hew_actor_schedule_periodic(actor.actor, 7, 10) };
-        // SAFETY: handle was returned by hew_actor_schedule_periodic and is still active.
-        let first_fire = unsafe { (*handle.cast::<PeriodicHandle>()).next_fire_ms };
+        // SAFETY: handle is a live *mut WasmPeriodicCtx.
+        let first_fire = unsafe { (*handle.cast::<WasmPeriodicCtx>()).next_fire_ms };
 
         // SAFETY: handle is active and owned by this test.
         unsafe { hew_actor_cancel_periodic(handle) };
@@ -473,8 +593,8 @@ mod tests {
         let actor = TestActor::new();
         // SAFETY: actor is a live TestActor-owned pointer.
         let handle = unsafe { hew_actor_schedule_periodic(actor.actor, 7, 10) };
-        // SAFETY: handle was returned by hew_actor_schedule_periodic and is still active.
-        let first_fire = unsafe { (*handle.cast::<PeriodicHandle>()).next_fire_ms };
+        // SAFETY: handle is a live *mut WasmPeriodicCtx.
+        let first_fire = unsafe { (*handle.cast::<WasmPeriodicCtx>()).next_fire_ms };
 
         // SAFETY: tests serialize scheduler access and the runtime is initialized.
         unsafe {
@@ -483,7 +603,7 @@ mod tests {
         drive_scheduler();
         assert_eq!(actor.count(), 1);
 
-        // SAFETY: handle is active and owned by this test.
+        // SAFETY: handle is still alive (re-armed by callback into a new wheel entry).
         unsafe { hew_actor_cancel_periodic(handle) };
         // SAFETY: tests serialize scheduler access and the runtime is initialized.
         unsafe {
@@ -503,10 +623,10 @@ mod tests {
         let handle_a = unsafe { hew_actor_schedule_periodic(actor_a.actor, 1, 20) };
         // SAFETY: both actors are live TestActor-owned pointers.
         let handle_b = unsafe { hew_actor_schedule_periodic(actor_b.actor, 2, 35) };
-        // SAFETY: both handles are active and owned by this test.
-        let fire_a = unsafe { (*handle_a.cast::<PeriodicHandle>()).next_fire_ms };
-        // SAFETY: both handles are active and owned by this test.
-        let fire_b = unsafe { (*handle_b.cast::<PeriodicHandle>()).next_fire_ms };
+        // SAFETY: both handles are live *mut WasmPeriodicCtx.
+        let fire_a = unsafe { (*handle_a.cast::<WasmPeriodicCtx>()).next_fire_ms };
+        // SAFETY: both handles are live *mut WasmPeriodicCtx.
+        let fire_b = unsafe { (*handle_b.cast::<WasmPeriodicCtx>()).next_fire_ms };
 
         // SAFETY: tests serialize scheduler access and the runtime is initialized.
         unsafe {
@@ -543,11 +663,11 @@ mod tests {
         let handle_a = unsafe { hew_actor_schedule_periodic(actor_a.actor, 1, 10) };
         // SAFETY: both actors are live TestActor-owned pointers.
         let handle_b = unsafe { hew_actor_schedule_periodic(actor_b.actor, 2, 15) };
-        // SAFETY: both handles are active and owned by this test.
+        // SAFETY: both handles are live *mut WasmPeriodicCtx.
         let next_fire = unsafe {
-            (*handle_a.cast::<PeriodicHandle>())
+            (*handle_a.cast::<WasmPeriodicCtx>())
                 .next_fire_ms
-                .max((*handle_b.cast::<PeriodicHandle>()).next_fire_ms)
+                .max((*handle_b.cast::<WasmPeriodicCtx>()).next_fire_ms)
         };
 
         assert_eq!(pending_periodic_count(), 2);
@@ -578,8 +698,8 @@ mod tests {
         let actor = TestActor::new();
         // SAFETY: actor is a live TestActor-owned pointer.
         let handle = unsafe { hew_actor_schedule_periodic(actor.actor, 7, 10) };
-        // SAFETY: handle was returned by hew_actor_schedule_periodic and is still active.
-        let first_fire = unsafe { (*handle.cast::<PeriodicHandle>()).next_fire_ms };
+        // SAFETY: handle is a live *mut WasmPeriodicCtx.
+        let first_fire = unsafe { (*handle.cast::<WasmPeriodicCtx>()).next_fire_ms };
 
         // SAFETY: actor is still owned by this test and not freed until drop.
         unsafe { cancel_all_timers_for_actor(actor.actor) };

--- a/hew-runtime/src/timer_periodic_wasm.rs
+++ b/hew-runtime/src/timer_periodic_wasm.rs
@@ -217,6 +217,20 @@ unsafe extern "C" fn wasm_periodic_cb(data: *mut c_void) {
     let new_handle = unsafe {
         hew_timer_wheel_schedule_handle(wheel, ctx.interval_ms, wasm_periodic_cb, ctx_ptr.cast())
     };
+    if new_handle.entry.is_null() {
+        // Re-arm failed (wheel destroyed or entry OOM) — fail closed.
+        // Copy actor before ending the mutable borrow on ctx.
+        let actor = ctx.actor;
+        // End mutable borrow of *ctx_ptr before Box::from_raw.
+        let _ = ctx;
+        // SAFETY: unregister/decrement happen before free; single-threaded WASM.
+        unsafe {
+            unregister_ctx(actor, ctx_ptr);
+            WASM_PERIODIC_COUNT = WASM_PERIODIC_COUNT.saturating_sub(1);
+            drop(Box::from_raw(ctx_ptr));
+        }
+        return;
+    }
     ctx.pending_handle = new_handle;
 }
 
@@ -228,6 +242,19 @@ unsafe extern "C" fn wasm_periodic_cb(data: *mut c_void) {
 pub(crate) fn pending_periodic_count() -> usize {
     // SAFETY: single-threaded WASM; no concurrent mutation.
     unsafe { WASM_PERIODIC_COUNT }
+}
+
+/// Return `true` if the periodic-context registry has been cleared (is `None`).
+///
+/// Used by the shutdown-assertion helper to verify full teardown.
+#[cfg(test)]
+#[expect(
+    static_mut_refs,
+    reason = "single-threaded test; discriminant read, no mutation"
+)]
+pub(crate) fn periodic_registry_is_none() -> bool {
+    // SAFETY: single-threaded test environment; no concurrent mutation.
+    unsafe { PERIODIC_CTX_REGISTRY.is_none() }
 }
 
 /// Schedule a periodic self-send on the shared WASM timer wheel.
@@ -264,14 +291,26 @@ pub unsafe extern "C" fn hew_actor_schedule_periodic(
     // entry in the registry).
     // SAFETY: wasm_timer_wheel() has no preconditions beyond single-threaded access.
     let wheel = unsafe { crate::scheduler_wasm::wasm_timer_wheel() };
-    // SAFETY: wheel is valid (wasm_timer_wheel returned non-null above); ctx is
-    // exclusively owned at this point (not yet in any registry).
+    if wheel.is_null() {
+        // Wheel unavailable (OOM on first creation) — fail closed.
+        // SAFETY: ctx is exclusively owned (not yet in any registry).
+        unsafe { drop(Box::from_raw(ctx)) };
+        return ptr::null_mut();
+    }
+    // SAFETY: wheel is valid (non-null checked above); ctx is exclusively owned.
     let handle = unsafe {
         hew_timer_wheel_schedule_handle(wheel, interval_ms, wasm_periodic_cb, ctx.cast())
     };
+    if handle.entry.is_null() {
+        // Wheel rejected the insert (entry allocation failure) — fail closed.
+        // SAFETY: ctx is exclusively owned (not yet in any registry).
+        unsafe { drop(Box::from_raw(ctx)) };
+        return ptr::null_mut();
+    }
     // SAFETY: ctx was just created; no other reference exists.
     unsafe { (*ctx).pending_handle = handle };
 
+    // Register only after the wheel entry is confirmed live.
     // SAFETY: PERIODIC_CTX_REGISTRY and WASM_PERIODIC_COUNT are single-threaded.
     unsafe {
         register_ctx(actor, ctx);

--- a/hew-runtime/src/timer_wheel.rs
+++ b/hew-runtime/src/timer_wheel.rs
@@ -18,7 +18,30 @@ use std::ffi::{c_int, c_void};
 use std::ptr;
 use std::sync::{Mutex, OnceLock};
 
-use crate::io_time::hew_now_ms;
+// ---------------------------------------------------------------------------
+// Platform clock
+//
+// On native targets `hew_now_ms` lives in `crate::io_time` (respects the
+// deterministic simulation clock).  On wasm32 (and in native tests of the
+// cooperative scheduler) the symbol is provided by the host as `extern "C"`
+// — on wasm32 this resolves to `wasm_stubs::hew_now_ms`, in native builds to
+// `io_time::hew_now_ms` which is already `#[no_mangle]`.
+// ---------------------------------------------------------------------------
+
+#[cfg(not(target_arch = "wasm32"))]
+fn now_ms_for_wheel() -> u64 {
+    // SAFETY: hew_now_ms has no preconditions on native targets.
+    unsafe { crate::io_time::hew_now_ms() }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn now_ms_for_wheel() -> u64 {
+    extern "C" {
+        fn hew_now_ms() -> u64;
+    }
+    // SAFETY: symbol is always present on wasm32 (wasm_stubs::hew_now_ms).
+    unsafe { hew_now_ms() }
+}
 
 /// Timer callback signature matching the C `hew_timer_cb` typedef.
 pub type HewTimerCb = unsafe extern "C" fn(*mut c_void);
@@ -114,7 +137,7 @@ pub struct HewTimerHandle {
 }
 
 impl HewTimerHandle {
-    const fn null() -> Self {
+    pub(crate) const fn null() -> Self {
         Self {
             entry: ptr::null_mut(),
             generation: 0,
@@ -387,8 +410,7 @@ fn remove_entry(w: &mut WheelInner, entry: *mut HewTimerEntry, generation: u64) 
 /// No preconditions.  The caller must eventually call [`hew_timer_wheel_free`].
 #[no_mangle]
 pub unsafe extern "C" fn hew_timer_wheel_new() -> *mut HewTimerWheel {
-    // SAFETY: hew_now_ms has no preconditions.
-    let now = unsafe { hew_now_ms() };
+    let now = now_ms_for_wheel();
     let tw = Box::new(HewTimerWheel {
         inner: Mutex::new(WheelInner {
             l0: [ptr::null_mut(); L0_SIZE],
@@ -557,7 +579,7 @@ pub unsafe extern "C" fn hew_timer_wheel_remove(
     remove_entry(&mut w, entry, generation)
 }
 
-unsafe fn timer_wheel_tick_to(tw: *mut HewTimerWheel, now: u64) -> c_int {
+pub(crate) unsafe fn timer_wheel_tick_to(tw: *mut HewTimerWheel, now: u64) -> c_int {
     cabi_guard!(tw.is_null(), 0);
     // SAFETY: caller guarantees `tw` is valid.
     let wheel = unsafe { &*tw };
@@ -645,8 +667,7 @@ unsafe fn timer_wheel_tick_to(tw: *mut HewTimerWheel, now: u64) -> c_int {
 /// callback/data pairs must still be valid.
 #[no_mangle]
 pub unsafe extern "C" fn hew_timer_wheel_tick(tw: *mut HewTimerWheel) -> c_int {
-    // SAFETY: hew_now_ms has no preconditions; caller guarantees `tw` is valid.
-    let now = unsafe { hew_now_ms() };
+    let now = now_ms_for_wheel();
     // SAFETY: upheld by this function's caller.
     unsafe { timer_wheel_tick_to(tw, now) }
 }


### PR DESCRIPTION
## Summary
Replaces the O(n²) sorted-Vec `SLEEP_QUEUE` and `PERIODIC_QUEUE` in the WASM
scheduler with the same two-level `HewTimerWheel` the native timer path uses.
Time is sourced via a cfg-split `now_ms_for_wheel()` (both platforms call the
`hew_now_ms` extern). The duplicated `timer_periodic_wasm` queue structs are
removed; sleep and periodic timers now share one wheel.

Sleep/periodic contexts are Box-allocated with the raw pointer stored as the
wheel entry's data; fire, cancel, and shutdown each reclaim exactly once.
Schedule failures (null wheel/handle) fail closed: the context is dropped, no
counter is incremented, and `hew_actor_schedule_periodic` returns null per the
codegen contract. The periodic re-arm matches native semantics (re-arm by
interval, no catch-up loop).

## Verification
- `make ci-preflight` green; `make sandbox-parity` 5/5 (native vs WASM).
- `cargo test -p hew-runtime --lib`: 1890/1890.
- New fail-closed regression tests for null-wheel sleep + periodic scheduling.
- Shutdown assertion now covers all timer statics.

## Out of scope
- The native ticker-thread driver is unchanged (only the wheel data structure
  and insert/expire logic unify; WASM stays host-driven).