### PR TITLE
chore(comments): remove stale NYI/fail-closed and SLEEP_QUEUE annotations

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -4511,13 +4511,14 @@ struct LowerCtx {
     /// Checker-resolved assignment target classification keyed by the target
     /// expression span.
     ///
-    /// Passive pass-through: HIR does not yet lower `Stmt::Assign` (it falls
-    /// through to `unsupported`).  Future consumer: MIR/codegen compound-
-    /// assignment lowering and Machine Lane B actor-field writes.
+    /// Passive pass-through: `Stmt::Assign` is fully lowered in HIR and MIR,
+    /// but neither simple-assign nor compound-assign lowering consults this map
+    /// yet.  Future consumer: compound-assignment signedness dispatch in codegen
+    /// and Machine Lane B actor-field write classification.
     /// (LESSONS: checker-authority P0, end-to-end-before-layer-thickening P1)
     #[expect(
         dead_code,
-        reason = "passive pass-through; future consumer is Stmt::Assign lowering in MIR/codegen"
+        reason = "passive pass-through; future consumer is compound-assignment signedness in codegen"
     )]
     assign_target_kinds: HashMap<SpanKey, AssignTargetKind>,
     /// Checker-resolved assignment target type-shape metadata (signedness flag)

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1390,10 +1390,10 @@ pub(crate) unsafe fn cleanup_all_actors() {
         // possible.
         unsafe { prepare_quiescent_actor_for_cleanup(actor) };
 
-        // Remove any SLEEP_QUEUE entry for this actor before freeing it.
-        // This prevents a use-after-free if hew_wasm_timer_tick is called
-        // after cleanup but before the queue entry is drained naturally.
-        // SAFETY: scheduler is shut down; no concurrent SLEEP_QUEUE access.
+        // Remove any pending WASM sleep timer entry for this actor before
+        // freeing it. This prevents a use-after-free if hew_wasm_timer_tick
+        // is called after cleanup but before the timer fires naturally.
+        // SAFETY: scheduler is shut down; no concurrent timer-wheel access.
         #[cfg(target_arch = "wasm32")]
         unsafe {
             crate::scheduler_wasm::cancel_actor_sleep_queue_entry(actor);

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -959,7 +959,6 @@ pub extern "C" fn hew_wasm_runtime_exit() {
 }
 
 // ── Internal API ────────────────────────────────────────────────────────
-// ── Internal API ────────────────────────────────────────────────────────
 
 /// Submit an actor to the run queue.
 ///

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -2097,14 +2097,6 @@ impl Checker {
                 }
             }
             Expr::GenBlock { body } => {
-                // WHY: `gen { }` expression-position generator blocks are part
-                //      of the v0.5 surface (parser support present).
-                //      HIR/MIR coroutine lowering is not yet wired; fail closed here.
-                // WHEN OBSOLETE: when generator lowering wires
-                //      HirExprKind::GenBlock and the coroutine scheduler.
-                // REAL SOLUTION: synthesize the yield type from the block,
-                //      return Ty::Named { name: "Iterator", args: [yield_ty] }.
-                //
                 // A98 / Q98: generator blocks inside actor receive handlers are
                 // permanently forbidden.  The scheduler holds the actor-state lock
                 // for the entire handler invocation; there is no safe point to
@@ -2138,8 +2130,6 @@ impl Checker {
                 // useful return type).  `gen { return 1; }` and `gen { 1 }` are
                 // both valid generators with inferred Return=i64.
                 //
-                // The HIR lowerer is still fail-closed on GenBlock; this gates
-                // only the type checker so that type errors surface early.
                 let yield_var = TypeVar::fresh();
                 let return_var = TypeVar::fresh();
                 let gen_ty = Ty::generator(Ty::Var(yield_var), Ty::Var(return_var));


### PR DESCRIPTION
Four off-hotspot stale-comment cleanups; no behavioural change.

- `hew-types/src/check/expressions.rs`: remove the block claiming HIR/MIR coroutine lowering is not wired — `lower_gen_block` is fully implemented in both layers.
- `hew-hir/src/lower.rs`: correct the `assign_target_kinds` doc-comment ("HIR does not yet lower Stmt::Assign") — `Stmt::Assign` is fully lowered; the map is a dead pass-through (the `#[expect(dead_code)]` stays, with an accurate reason).
- `hew-runtime/src/scheduler_wasm.rs`: remove a duplicated section banner.
- `hew-runtime/src/actor.rs`: update `SLEEP_QUEUE` references in the cleanup comment block to the `HewTimerWheel` reality.

## Verification
- `cargo fmt --check` / `clippy -D warnings` clean; `cargo test -p hew-types -p hew-hir -p hew-runtime --lib` green; full workspace build OK.
