### PR TITLE
feat(lints): add checker idiom lints and a MIR dead-store lint

### DIFF
--- a/docs/design/lint-pass.md
+++ b/docs/design/lint-pass.md
@@ -12,9 +12,10 @@ ad-hoc warnings (`clone_on_copy`, `dead_code`) migrated onto the registry so
 they are now re-levelable and suppressible. M3 has landed too: a backward
 liveness dataflow pass in `hew-mir`, the `dead_store` MIR lint built on it, and
 the CLI plumbing that surfaces MIR-stage lints as level-controlled, suppressible
-warnings (see §10). `clean_counter` is registered but intentionally **not yet
-emitted** — the deferral and its reasoning are in §10. Editor/web surfacing of
-MIR lints is deferred to issue #2176.
+warnings (see §10). `clean_counter` is deferred and intentionally **not
+registered** — so `-D clean_counter` fails closed as an unknown lint rather than
+silently no-opping; the reasoning is in §10 (tracked in issue #2178). Editor/web
+surfacing of MIR lints is deferred to issue #2176.
 
 ## 1. Goal
 
@@ -252,23 +253,27 @@ the precise subset that is actually convertible.
     scope.* A normal `for i in 0..n` loop does **not** fire — the back-edge keeps the counter
     live-into the header, so the increment store is live and the guards exclude the synthetic counter
     regardless.
-  - **`clean_counter` — deferred (registered, not emitted).** Registered in the `LintId` registry at
-    `default_level() = Warn` but intentionally not yet emitted, for three compounding reasons.
-    (1) *Shape recovery:* a manual `c = c + 1` does not lower to a single self-update instruction — it
-    lowers through a temporary and a checked `IntArithChecked` followed by `Move c = temp`, so the
-    "increment" is not directly recognizable from one instruction. (2) *Liveness cannot separate the
-    two populations:* a dead accumulator `c` and a legitimate for-range counter `i` are *both*
-    "live throughout the loop, dead at the exit"; distinguishing "the counting itself is dead work"
-    from "a value genuinely consumed each iteration" needs faint-variable / strong-liveness analysis
-    (a second dataflow pass asking whether a variable's *value*, not merely its liveness, can ever
-    influence an observable) — out of scope for this milestone. (3) *Checked arithmetic defeats the
-    premise:* the increment's overflow flag feeds a trap branch, so `c` is *strongly* live — its value
-    decides whether the program traps — and removing `c = c + 1` would be semantics-changing exactly
-    where the lint looks most applicable, i.e. the naive lint would be unsound. Per the precision-first
-    bar that governs M1/M2 (one excellent lint beats two noisy overlapping ones), `dead_store` ships
-    alone; `clean_counter` is revisited once a faint-variable pass exists. It would also overlap
+  - **`clean_counter` — deferred and NOT registered.** Considered, but intentionally left out of the
+    `LintId` registry entirely, for three compounding reasons. (1) *Shape recovery:* a manual
+    `c = c + 1` does not lower to a single self-update instruction — it lowers through a temporary and
+    a checked `IntArithChecked` followed by `Move c = temp`, so the "increment" is not directly
+    recognizable from one instruction. (2) *Liveness cannot separate the two populations:* a dead
+    accumulator `c` and a legitimate for-range counter `i` are *both* "live throughout the loop, dead
+    at the exit"; distinguishing "the counting itself is dead work" from "a value genuinely consumed
+    each iteration" needs faint-variable / strong-liveness analysis (a second dataflow pass asking
+    whether a variable's *value*, not merely its liveness, can ever influence an observable) — out of
+    scope for this milestone. (3) *Checked arithmetic defeats the premise:* the increment's overflow
+    flag feeds a trap branch, so `c` is *strongly* live — its value decides whether the program traps
+    — and removing `c = c + 1` would be semantics-changing exactly where the lint looks most
+    applicable, i.e. the naive lint would be unsound. Per the precision-first bar that governs M1/M2
+    (one excellent lint beats two noisy overlapping ones), `dead_store` ships alone; `clean_counter`
+    is revisited once a faint-variable pass exists (tracked in issue #2178). It would also overlap
     `dead_store` on the straight-line `c = c + 1` case, so shipping both today would risk
-    double-firing.
+    double-firing. **It is deliberately not registered** rather than registered-but-unemitted: an
+    un-emitted registered lint would make `-D/-W/-A clean_counter` and `// hew:allow(clean_counter)`
+    silently no-op, a fail-open that defeats `LintId::from_name`'s fail-closed contract (an unknown
+    lint name must surface as a CLI error). With it unregistered, `hew check -D clean_counter` exits
+    non-zero with an "unknown lint" diagnostic — locked by a test in `lint_pass_e2e.rs`.
   - **Severity + surfacing.** MIR lints are level-agnostic in `hew-mir`: each finding is a
     `MirLint { lint, span, message }` pushed onto `IrPipeline.lint_warnings`, a channel kept separate
     from the hard-error `diagnostics` vector so the existing move/init checks stay errors. The CLI

--- a/docs/design/lint-pass.md
+++ b/docs/design/lint-pass.md
@@ -1,13 +1,16 @@
 # Design: a compiler lint pass for Hew (semantic / dataflow idiom lints)
 
-Status: M1 implemented (this change) · M2–M3 planned · Audience: Hew compiler
+Status: M1–M2 implemented · M3 planned · Audience: Hew compiler
 maintainers · Companion to the ast-grep rule set
 
-M1 has landed: the lint infrastructure (`LintId` / `LintLevel` / `LintLevels`),
-the checker `run_lints` sweep, the first lint (`needless_range_loop`), the CLI
-`--allow` / `--warn` / `--deny` flags, and in-source `// hew:allow(...)`
-suppression. M2 (more checker lints) and M3 (MIR liveness + dataflow lints)
-remain future work; see §10.
+M1 + M2 have landed: the lint infrastructure (`LintId` / `LintLevel` /
+`LintLevels`), the checker `run_lints` sweep, the CLI `--allow` / `--warn` /
+`--deny` flags, and in-source `// hew:allow(...)` suppression — plus six
+checker lints (`needless_range_loop`, `redundant_else_after_return`,
+`needless_match_to_if_let`, `len_zero_comparison`, `needless_bool`) and the two
+ad-hoc warnings (`clone_on_copy`, `dead_code`) migrated onto the registry so
+they are now re-levelable and suppressible. M3 (MIR liveness + dataflow lints)
+remains future work; see §10.
 
 ## 1. Goal
 
@@ -76,15 +79,22 @@ AST/HIR — another reason `needless_range_loop` belongs in the checker, not MIR
 ## 6. Architecture
 
 ### 6.1 Lint infrastructure (`hew-types/src/check/lints/`)
-- `LintId` enum (M1: `NeedlessRangeLoop`; future: `RedundantElseAfterReturn`, `LenGtZero`, …).
-  Each lint has a stable `as_str()` name, a `from_name()` parser, and a `default_level()`
-  (`Warn`).
+- `LintId` enum (`NeedlessRangeLoop`, `RedundantElseAfterReturn`,
+  `NeedlessMatchToIfLet`, `LenZeroComparison`, `NeedlessBool`, plus the migrated
+  `CloneOnCopy` and `DeadCode`). Each lint has a stable `as_str()` name, a
+  `from_name()` parser, and a `default_level()` (`Warn`).
 - `LintLevel { Allow, Warn, Deny }` + a `LintLevels` map, built from (a) defaults, (b) the CLI flag
   (§7), (c) in-source suppression (§7). Resolve level at emit time; `Allow` drops the diagnostic,
   `Deny` routes to `output.errors`, `Warn` to `output.warnings`.
 - The lint id is carried on the diagnostic: `TypeErrorKind::Lint(LintId)` so suppression,
-  `--Werror`, and docs can key off it. This also lets the existing ad-hoc warnings (clone-on-Copy,
-  dead-code) migrate onto the registry over time.
+  `--Werror`, and docs can key off it. The two ad-hoc warnings (clone-on-Copy,
+  dead-code) now route through `Checker::emit_main_pass_lint`, which applies the
+  same level/`// hew:allow` resolution to warnings emitted inline during body
+  checking (outside the post-inference sweep).
+- Checker lints that share a body walk implement the read-only `NodeVisitor`
+  trait (`visit_block` / `visit_stmt` / `visit_expr`) driven by the exhaustive
+  `walk_body` helper, so a new AST node forces every visitor to make a decision
+  rather than silently dropping out.
 
 ### 6.2 Checker lint sweep (M1)
 - A `check::lints` module with `Checker::run_lints(&self, program, levels, out)`, invoked in
@@ -93,6 +103,11 @@ AST/HIR — another reason `needless_range_loop` belongs in the checker, not MIR
   builds a `LintCtx` carrying the checker's resolved type facts, and runs each enabled lint. Lints
   are pure read-only visitors over the typed AST (so `.len()`/`.get()` receivers are known to be
   collections).
+- The sweep runs only over **user-authored** bodies. Builtin/standard-library modules (`std::`,
+  `hew::`, `ecosystem::` — the `is_builtin_module` set) ship with the compiler, so a finding inside
+  them is noise the user cannot act on; `run_lints` advances its module index over those modules (to
+  keep span tagging aligned with the checker's module walk) but skips emitting on their items. The
+  inline main-pass lints follow the same rule (e.g. `dead_code` already skips `std.`-prefixed names).
 
 ### 6.3 MIR liveness + MIR lints (M3)
 - Add a generic-enough **liveness** (backward) and/or **reaching-defs** (forward) analysis in
@@ -162,9 +177,39 @@ the precise subset that is actually convertible.
 - **M1 — infra + first lint. (Implemented in this change.)** `LintId`/`LintLevels`, the
   `--warn/--allow/--deny` flags, in-source `// hew:allow(...)`, the checker `run_lints` sweep, and
   `needless_range_loop`. Self-contained, high value, free surfacing. (No MIR work.)
-- **M2 — more checker lints.** `redundant-else-after-return` (reuse the checker's existing
-  `UnreachableCode` reachability to know the `then` diverges), `match-empty → if let`, `len()>0 →
-  !is_empty()`, `if c {true} else {false} → c`. Migrate the existing ad-hoc warnings onto the registry.
+- **M2 — more checker lints. (Implemented in this change.)** Four new checker-stage lints plus the
+  migration of two ad-hoc warnings onto the registry. Each lint stays silent unless its rewrite is
+  provably meaning-preserving (precision over recall):
+  - **`redundant_else_after_return`** — an `if` whose then-branch diverges on *every* path (ends in
+    `return` / `break` / `continue`, or a `!`-typed call such as `panic`) yet still carries an
+    `else`; the `else` body can be de-indented. *Reuses* the checker's recorded `Ty::Never` for the
+    divergence decision (terminator statements are matched structurally). *Guards:* fires only in
+    statement / block-tail position (never a value-position `if` feeding a `let`/arg); skips
+    `if let` / `while let` and `else if` chains (not a clean de-indent).
+  - **`needless_match_to_if_let`** — a two-arm `match` on an `Option` where one arm is
+    `Some(binding)` and the other is a trivial `None => {}` / `None => ()`. Suggests
+    `if let Some(binding) = … { … }`. *Guards:* `Option` only (scrutinee type confirmed via
+    `resolved_type_at`; `Result` is out of scope); no guards; the `None` body must be empty/unit;
+    the `Some` sub-pattern must be a plain identifier or `_`; statement / block-tail position only
+    (a value-position match is never rewritten). Note a bare `None` parses as an *identifier*
+    pattern, so both spellings are accepted.
+  - **`len_zero_comparison`** — a comparison of `<recv>.len()` against `0` / `1` that is really an
+    emptiness test: `len() == 0` / `len() <= 0` / `len() < 1` → `is_empty()`; `len() != 0` /
+    `len() > 0` / `len() >= 1` → `!is_empty()` (either operand order). *Guards:* one side must be
+    literally a no-arg `.len()` method call (a `len` *field* never qualifies) and the other the
+    integer literal; the receiver's resolved type must expose `is_empty()` (`Vec`, `HashMap`,
+    `HashSet`, `string`). The precise, type-checked, suppressible companion to the syntactic
+    `rules/hew/len-zero-is-empty.yml` ast-grep rule.
+  - **`needless_bool`** — `if c { true } else { false }` → `c`; `if c { false } else { true }` →
+    `!c`. *Guards:* each branch must be exactly one boolean literal (no other statements); the two
+    branches must be opposite polarities (a matching pair is a constant, not this lint); `else if`
+    chains never collapse the outer `if`. Position-agnostic (the rewrite is valid anywhere).
+  - **Migrations.** `clone_on_copy` (clone on a Copy/BitCopy type; `hew-types/src/check/methods.rs`)
+    and `dead_code` (unreachable functions; `hew-types/src/check/diagnostics.rs`) now emit through
+    `Checker::emit_main_pass_lint`, giving them a `LintId` with `default_level() = Warn`. Default
+    behaviour is unchanged (they still warn), but they are now re-levelable (`-A/-W/-D`) and
+    suppressible (`// hew:allow`). The LSP keeps tagging migrated `dead_code` as
+    `DiagnosticTag::UNNECESSARY`. Unused-import / unreachable-code were left un-migrated this pass.
 - **M3 — MIR liveness + dataflow lints.** Add liveness/reaching-defs to `hew-mir`; implement
   `dead-store` and `clean-counter` (counter not read after the loop); wire MIR lints into LSP/wasm.
 

--- a/docs/design/lint-pass.md
+++ b/docs/design/lint-pass.md
@@ -1,6 +1,6 @@
 # Design: a compiler lint pass for Hew (semantic / dataflow idiom lints)
 
-Status: M1–M2 implemented · M3 planned · Audience: Hew compiler
+Status: M1–M3 implemented · Audience: Hew compiler
 maintainers · Companion to the ast-grep rule set
 
 M1 + M2 have landed: the lint infrastructure (`LintId` / `LintLevel` /
@@ -9,8 +9,12 @@ M1 + M2 have landed: the lint infrastructure (`LintId` / `LintLevel` /
 checker lints (`needless_range_loop`, `redundant_else_after_return`,
 `needless_match_to_if_let`, `len_zero_comparison`, `needless_bool`) and the two
 ad-hoc warnings (`clone_on_copy`, `dead_code`) migrated onto the registry so
-they are now re-levelable and suppressible. M3 (MIR liveness + dataflow lints)
-remains future work; see §10.
+they are now re-levelable and suppressible. M3 has landed too: a backward
+liveness dataflow pass in `hew-mir`, the `dead_store` MIR lint built on it, and
+the CLI plumbing that surfaces MIR-stage lints as level-controlled, suppressible
+warnings (see §10). `clean_counter` is registered but intentionally **not yet
+emitted** — the deferral and its reasoning are in §10. Editor/web surfacing of
+MIR lints is deferred to issue #2176.
 
 ## 1. Goal
 
@@ -135,11 +139,17 @@ AST/HIR — another reason `needless_range_loop` belongs in the checker, not MIR
   (`hew-types/src/check/types.rs`); the lint resolves the directive against the source line(s)
   preceding the diagnostic's span. A local `allow` wins even over a command-line `--deny`, mirroring
   the rustc/Clippy rule.
-- **Surfacing:** M1 (checker) lints are free on all three surfaces (§3). M3 (MIR) lints:
-  confirm the LSP/wasm analysis runs the MIR gates or extend `convert_diagnostics`
-  (`hew-wasm/src/lib.rs`) and the LSP analysis (`analysis.rs`) to include MIR-stage
-  diagnostics as **warnings** (note: HIR diagnostics are currently mapped as LSP *errors* — keep lints
-  out of that path).
+- **Surfacing:** M1/M2 (checker) lints are free on all three surfaces (§3). M3 (MIR) lints are
+  surfaced **through the CLI only**. They ride a dedicated `IrPipeline.lint_warnings` channel
+  (separate from the hard-error `diagnostics` vector) and are rendered by
+  `render_pipeline_mir_lints` (`hew-cli/src/main.rs`), which threads the resolved `LintLevels` into
+  every MIR-lowering seam (`hew check`, `build`/`run`, eval, `hew compile`), applies
+  `// hew:allow(...)` via `hew_types::directive_suppresses`, renders `Warn` as a warning and `Deny`
+  as a build error, drops `Allow`, and structures `--format json` output via `from_mir_lint`. The
+  LSP and wasm front ends deliberately stop at HIR and never lower to MIR, so they never reach this
+  channel; extending them to run the MIR gates and map MIR-stage diagnostics as LSP/web *warnings*
+  (note: HIR diagnostics are currently mapped as LSP *errors* — keep lints out of that path) is
+  **deferred to issue #2176**.
 
 ## 8. First lint, end-to-end: `needless_range_loop` (84 candidates)
 
@@ -210,8 +220,66 @@ the precise subset that is actually convertible.
     behaviour is unchanged (they still warn), but they are now re-levelable (`-A/-W/-D`) and
     suppressible (`// hew:allow`). The LSP keeps tagging migrated `dead_code` as
     `DiagnosticTag::UNNECESSARY`. Unused-import / unreachable-code were left un-migrated this pass.
-- **M3 — MIR liveness + dataflow lints.** Add liveness/reaching-defs to `hew-mir`; implement
-  `dead-store` and `clean-counter` (counter not read after the loop); wire MIR lints into LSP/wasm.
+- **M3 — MIR liveness + dataflow lints. (Implemented in this change.)** A backward liveness
+  dataflow pass in `hew-mir` plus the `dead_store` lint built on it, surfaced through the CLI.
+  - **Liveness pass (`hew-mir/src/liveness.rs`).** A backward "may-be-live" analysis over
+    `Place::Local(u32)`. It *reuses* the existing forward dataflow scaffolding rather than
+    reinventing CFG plumbing: `build_preds` / `successors` / `compute_rpo` and the worklist-fixpoint
+    shape from `dataflow.rs`, `instr_reads_writes` as the per-instruction gen/kill source, and
+    `terminator_source_places` for terminator reads. Direction: `live_out(b) = ⋃ live_in(s)` over
+    successors `s`; the per-block transfer applies the terminator first (its reads become live; its
+    writes are deliberately *not* killed — a conservative under-kill) and then the instructions in
+    reverse, each as `live = (live − full_defs) ∪ reads`. **Soundness is by over-approximation:** the
+    gen set is a superset of the true reads (every referenced place, via `place_local`) and the kill
+    set is a subset of the true kills (only a `Place::Local` *full* def via `full_def_local`; anything
+    we cannot prove is a total overwrite stays live). So whenever the pass reports a local as **not**
+    live-after a point, it is genuinely dead — there are no false "dead" verdicts. When liveness is
+    uncertain, the local is treated as **live**. Query API: `analyze_liveness(func) -> Liveness` with
+    `Liveness::{is_live_in, is_live_out, live_after}`.
+  - **`dead_store`.** Flags `Instr::Move { dest: Place::Local(N), .. }` whose written value is never
+    read on any path before being overwritten or going out of scope — i.e. `N` is not live-after the
+    move. *Guards (skip → no fire), tuned for precision over recall:* (1) skip parameters
+    (`N ≥ params.len()`); (2) user-named locals only (`local_names[N]` present and non-empty —
+    compiler-synthetic temporaries and the for-range counter machinery, which carries the sentinel
+    `SiteId(0)`, are excluded); (3) no-drop scalar locals only (integers / floats / `bool` / `char`
+    via `is_no_drop_scalar`) — this sidesteps drop semantics entirely: no `Drop` ever observes such a
+    value, so removing the store is always sound and the lint never fights the drop-safety invariant
+    (CLAUDE.md §1); (4) only the pure `Move` form is trapped, never checked arithmetic or any
+    instruction whose uses `instr_reads_writes` does not fully model (those are treated as a use). The
+    span is recovered from `instr_spans`, falling back to `local_decl_bytes`; findings are de-duped by
+    `(lint, span)` to collapse monomorphization duplicates, and synthetic / unreachable functions are
+    skipped. Message: *the value assigned to `x` is never read before it is overwritten or goes out of
+    scope.* A normal `for i in 0..n` loop does **not** fire — the back-edge keeps the counter
+    live-into the header, so the increment store is live and the guards exclude the synthetic counter
+    regardless.
+  - **`clean_counter` — deferred (registered, not emitted).** Registered in the `LintId` registry at
+    `default_level() = Warn` but intentionally not yet emitted, for three compounding reasons.
+    (1) *Shape recovery:* a manual `c = c + 1` does not lower to a single self-update instruction — it
+    lowers through a temporary and a checked `IntArithChecked` followed by `Move c = temp`, so the
+    "increment" is not directly recognizable from one instruction. (2) *Liveness cannot separate the
+    two populations:* a dead accumulator `c` and a legitimate for-range counter `i` are *both*
+    "live throughout the loop, dead at the exit"; distinguishing "the counting itself is dead work"
+    from "a value genuinely consumed each iteration" needs faint-variable / strong-liveness analysis
+    (a second dataflow pass asking whether a variable's *value*, not merely its liveness, can ever
+    influence an observable) — out of scope for this milestone. (3) *Checked arithmetic defeats the
+    premise:* the increment's overflow flag feeds a trap branch, so `c` is *strongly* live — its value
+    decides whether the program traps — and removing `c = c + 1` would be semantics-changing exactly
+    where the lint looks most applicable, i.e. the naive lint would be unsound. Per the precision-first
+    bar that governs M1/M2 (one excellent lint beats two noisy overlapping ones), `dead_store` ships
+    alone; `clean_counter` is revisited once a faint-variable pass exists. It would also overlap
+    `dead_store` on the straight-line `c = c + 1` case, so shipping both today would risk
+    double-firing.
+  - **Severity + surfacing.** MIR lints are level-agnostic in `hew-mir`: each finding is a
+    `MirLint { lint, span, message }` pushed onto `IrPipeline.lint_warnings`, a channel kept separate
+    from the hard-error `diagnostics` vector so the existing move/init checks stay errors. The CLI
+    owns policy (§7): `render_pipeline_mir_lints` applies the resolved `LintLevels` and
+    `// hew:allow(...)`, renders `Warn` as a warning / `Deny` as a build error / drops `Allow`, and is
+    threaded into all four MIR-lowering seams. `hew compile` exposes no lint flags, so it surfaces at
+    default levels. Surfacing is **CLI-only**; editor/web is issue #2176.
+  - **Tests.** Liveness unit + integration fixtures (`hew-mir/tests/liveness.rs`) pin the query API
+    and the over-approximation contract; `dead_store` positives and precision-guard negatives live
+    alongside them and in the CLI e2e suite (`hew-cli/tests/lint_pass_e2e.rs`), including the
+    `for i in 0..n` regression that must stay silent even under `-D dead_store`.
 
 ## 11. Division of labour with ast-grep
 

--- a/hew-cli/src/diagnostic_json.rs
+++ b/hew-cli/src/diagnostic_json.rs
@@ -393,6 +393,37 @@ pub(crate) fn from_mir_diagnostic(
     }
 }
 
+/// Build a [`JsonDiagnostic`] for a MIR-stage lint warning.
+///
+/// Unlike [`from_mir_diagnostic`] — which is always the hard `error` family —
+/// a lint carries its configured severity: `warning` by default, `error` when
+/// promoted by `--deny`. The `code` is the lint's stable name (`dead_store`),
+/// matching the `-A/-W/-D` selector and the HIR-stage lint codes.
+pub(crate) fn from_mir_lint(
+    source: &str,
+    filename: &str,
+    span: &Range<usize>,
+    code: &str,
+    message: &str,
+    is_error: bool,
+) -> JsonDiagnostic {
+    JsonDiagnostic {
+        code: code.to_string(),
+        severity: if is_error {
+            SEVERITY_ERROR
+        } else {
+            SEVERITY_WARNING
+        }
+        .to_string(),
+        source: "hew-mir".to_string(),
+        file: filename.to_string(),
+        span: JsonSpan::from_range(source, span),
+        message: message.to_string(),
+        notes: Vec::new(),
+        fixes: Vec::new(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -121,6 +121,93 @@ fn render_pipeline_mir_diagnostics(
     true
 }
 
+/// Surface the MIR-stage lint warnings recorded on `pipeline`, applying the
+/// user's lint levels and in-source `// hew:allow(...)` directives. Returns
+/// `true` if any lint was promoted to an error (`--deny`), which the caller must
+/// turn into a build failure.
+///
+/// MIR lints are level-configurable warnings, so they render through the
+/// warning / error diagnostic path — never the hard `E_MIR_CHECK` family that
+/// [`render_pipeline_mir_diagnostics`] uses for move/init check failures.
+///
+/// Surfaced through the CLI front end only: the LSP and wasm front ends stop at
+/// HIR and never lower to MIR, so they never reach this path. Editor / web
+/// surfacing of MIR lints is tracked in issue #2176.
+fn render_pipeline_mir_lints(
+    source: &str,
+    label: &str,
+    pipeline: &hew_mir::IrPipeline,
+    levels: &hew_types::LintLevels,
+) -> bool {
+    let mut had_error = false;
+    for warning in &pipeline.lint_warnings {
+        let span_start = warning.span.0 as usize;
+        let span_end = warning.span.1 as usize;
+        // The MIR lint span is a raw byte offset carrying no module identity
+        // (post-flatten HIR spans are module-anonymous). For the single-root
+        // case it indexes the root source directly; a span past the end is from
+        // an imported module we cannot faithfully render here, so skip it rather
+        // than point at the wrong line. Precise multi-module MIR-lint surfacing
+        // rides the same editor/web track as the front ends (issue #2176).
+        if span_end > source.len() {
+            continue;
+        }
+        // An in-source `// hew:allow(lint)` wins over any flag level — the same
+        // precedence the HIR-stage lints honour.
+        if hew_types::directive_suppresses(source, span_start, warning.lint) {
+            continue;
+        }
+        let range = span_start..span_end;
+        match levels.level(warning.lint) {
+            hew_types::LintLevel::Allow => {}
+            hew_types::LintLevel::Warn => {
+                if diagnostic_json::json_output_active() {
+                    diagnostic_json::push_json_diagnostic(diagnostic_json::from_mir_lint(
+                        source,
+                        label,
+                        &range,
+                        warning.lint.as_str(),
+                        &warning.message,
+                        false,
+                    ));
+                } else {
+                    diagnostic::render_warning_with_raw_notes(
+                        source,
+                        label,
+                        &range,
+                        &warning.message,
+                        &[],
+                        &[],
+                    );
+                }
+            }
+            hew_types::LintLevel::Deny => {
+                if diagnostic_json::json_output_active() {
+                    diagnostic_json::push_json_diagnostic(diagnostic_json::from_mir_lint(
+                        source,
+                        label,
+                        &range,
+                        warning.lint.as_str(),
+                        &warning.message,
+                        true,
+                    ));
+                } else {
+                    diagnostic::render_diagnostic_with_raw_notes(
+                        source,
+                        label,
+                        &range,
+                        &warning.message,
+                        &[],
+                        &[],
+                    );
+                }
+                had_error = true;
+            }
+        }
+    }
+    had_error
+}
+
 fn lower_file_to_mir(
     input_path: &Path,
     requested_target: Option<&str>,
@@ -191,6 +278,17 @@ fn lower_file_to_mir(
         &input,
         &lower_output.module,
         &pipeline.diagnostics,
+    ) {
+        return Err(());
+    }
+
+    // `hew compile` exposes no `-A/-W/-D` flags, so MIR lints surface at their
+    // default levels (`// hew:allow(...)` still suppresses).
+    if render_pipeline_mir_lints(
+        &state.source,
+        &input,
+        &pipeline,
+        &hew_types::LintLevels::default(),
     ) {
         return Err(());
     }
@@ -270,6 +368,10 @@ fn lower_file_to_mir_for_target(
         return Err(());
     }
 
+    if render_pipeline_mir_lints(&state.source, &input, &pipeline, &options.lint_levels) {
+        return Err(());
+    }
+
     let native_pkg_dirs = native_link::collect_import_pkg_dirs(&state.program);
     Ok((pipeline, native_pkg_dirs))
 }
@@ -314,6 +416,7 @@ fn run_check_deep_gates(
     input: &str,
     target: &target::TargetSpec,
     state: &hew_compile::FileFrontendState,
+    levels: &hew_types::LintLevels,
 ) -> Result<(), ()> {
     // `std/builtins.hew` is the compiler's embedded builtin-surface substrate:
     // it is consumed by the checker's builtins pre-registration (`include_str!`)
@@ -375,8 +478,17 @@ fn run_check_deep_gates(
         return Err(());
     }
 
+    // Surface MIR lint warnings before the codegen-front gate so they read in
+    // source order ahead of any hard error. A `--deny` lint fails the build, but
+    // only after the codegen-front gate has had its say.
+    let lint_denied = render_pipeline_mir_lints(&state.source, input, &pipeline, levels);
+
     if let Err(error) = hew_codegen_rs::validate_codegen_front(&pipeline) {
         diagnostic::render_codegen_front_diagnostic(&error);
+        return Err(());
+    }
+
+    if lint_denied {
         return Err(());
     }
 
@@ -607,6 +719,10 @@ pub(crate) fn compile_native_from_program(
         &lower_output.module,
         &pipeline.diagnostics,
     ) {
+        return Err(());
+    }
+
+    if render_pipeline_mir_lints(&state.source, source_label, &pipeline, &options.lint_levels) {
         return Err(());
     }
 
@@ -1383,7 +1499,7 @@ fn cmd_check(a: &args::CheckArgs) {
         }
     }
 
-    if run_check_deep_gates(&input, &target, &state).is_err() {
+    if run_check_deep_gates(&input, &target, &state, &options.lint_levels).is_err() {
         if json {
             diagnostic_json::flush_json_diagnostics();
         }

--- a/hew-cli/tests/lint_pass_e2e.rs
+++ b/hew-cli/tests/lint_pass_e2e.rs
@@ -281,3 +281,132 @@ fn stdlib_lints_do_not_leak_through_implicit_import() {
         "a len_zero_comparison finding must not leak from stdlib bodies:\n{stderr}"
     );
 }
+
+// ── MIR-stage lint: dead_store ───────────────────────────────────────
+//
+// `dead_store` is the first lint that rides the MIR liveness pass rather than
+// the HIR checker sweep, so it exercises the separate CLI surfacing seam
+// (`render_pipeline_mir_lints`). It must honour the exact same registry
+// controls — default warning, `-A/-W/-D`, and `// hew:allow(...)` — as every
+// checker-stage lint above.
+
+/// `x` is assigned `5`, then unconditionally overwritten by `6` before the
+/// first value is ever read: the `var x = 5` store is dead.
+const DEAD_STORE: &str = "fn f() -> i64 {\n\
+     var x = 5;\n\
+     x = 6;\n\
+     x\n\
+     }\n\
+     fn main() {\n\
+     let _ = f();\n\
+     }\n";
+
+/// The same program with an in-source allow directive on the line above the
+/// dead store.
+const DEAD_STORE_SUPPRESSED: &str = "fn f() -> i64 {\n\
+     // hew:allow(dead_store)\n\
+     var x = 5;\n\
+     x = 6;\n\
+     x\n\
+     }\n\
+     fn main() {\n\
+     let _ = f();\n\
+     }\n";
+
+/// A textbook `for i in 0..n` accumulator loop: `i` and `total` are both read
+/// normally, so the precision guards must keep `dead_store` silent. This is the
+/// regression that proves the loop-counter / accumulator machinery does not
+/// misfire.
+const FOR_RANGE_CLEAN: &str = "fn sum(n: i64) -> i64 {\n\
+     var total = 0;\n\
+     for i in 0..n {\n\
+     total = total + i;\n\
+     }\n\
+     total\n\
+     }\n\
+     fn main() {\n\
+     let _ = sum(5);\n\
+     }\n";
+
+const DEAD_STORE_MESSAGE: &str = "is never read before it is overwritten";
+
+#[test]
+fn dead_store_warns_by_default() {
+    let output = run_check(DEAD_STORE, &[]);
+    let stderr = stderr_of(&output);
+    assert!(
+        output.status.success(),
+        "a dead_store warning must not fail the build:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("warning:") && stderr.contains(DEAD_STORE_MESSAGE),
+        "expected the dead_store warning to render by default:\n{stderr}"
+    );
+}
+
+#[test]
+fn dead_store_deny_promotes_to_error() {
+    let output = run_check(DEAD_STORE, &["-D", "dead_store"]);
+    let stderr = stderr_of(&output);
+    assert!(
+        !output.status.success(),
+        "-D dead_store must fail the build:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("error:") && stderr.contains(DEAD_STORE_MESSAGE),
+        "-D must render the dead_store lint as an error:\n{stderr}"
+    );
+}
+
+#[test]
+fn dead_store_allow_suppresses() {
+    let output = run_check(DEAD_STORE, &["--allow", "dead_store"]);
+    let stderr = stderr_of(&output);
+    assert!(output.status.success(), "check should pass:\n{stderr}");
+    assert!(
+        !stderr.contains(DEAD_STORE_MESSAGE),
+        "--allow dead_store must suppress the lint:\n{stderr}"
+    );
+}
+
+#[test]
+fn dead_store_inline_directive_suppresses() {
+    let output = run_check(DEAD_STORE_SUPPRESSED, &[]);
+    let stderr = stderr_of(&output);
+    assert!(output.status.success(), "check should pass:\n{stderr}");
+    assert!(
+        !stderr.contains(DEAD_STORE_MESSAGE),
+        "an in-source `// hew:allow(dead_store)` directive must suppress the MIR lint:\n{stderr}"
+    );
+}
+
+#[test]
+fn dead_store_inline_directive_overrides_deny() {
+    // The in-source allow wins even over `-D`: parity with the checker lints.
+    let output = run_check(DEAD_STORE_SUPPRESSED, &["-D", "dead_store"]);
+    let stderr = stderr_of(&output);
+    assert!(
+        output.status.success(),
+        "an in-source allow must override -D for a MIR lint:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains(DEAD_STORE_MESSAGE),
+        "the suppressed MIR lint must not surface under -D:\n{stderr}"
+    );
+}
+
+#[test]
+fn for_range_loop_does_not_trip_dead_store() {
+    // The canonical precision guard: a normal counting loop with a read counter
+    // and a read accumulator must produce no dead_store finding, even under -D.
+    let output = run_check(FOR_RANGE_CLEAN, &["-D", "dead_store"]);
+    let stderr = stderr_of(&output);
+    assert!(
+        output.status.success(),
+        "`for i in 0..n` with used variables must not trip dead_store:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains(DEAD_STORE_MESSAGE),
+        "dead_store must not misfire on a normal counting loop:\n{stderr}"
+    );
+}

--- a/hew-cli/tests/lint_pass_e2e.rs
+++ b/hew-cli/tests/lint_pass_e2e.rs
@@ -410,3 +410,21 @@ fn for_range_loop_does_not_trip_dead_store() {
         "dead_store must not misfire on a normal counting loop:\n{stderr}"
     );
 }
+
+#[test]
+fn clean_counter_is_unregistered_and_fails_closed() {
+    // `clean_counter` was deliberately NOT registered (it has no emission code
+    // yet). Selecting it must fail closed at the CLI boundary as an unknown
+    // lint — never silently no-op — so the registry's fail-closed contract
+    // holds. Mirrors `unknown_lint_name_is_rejected`.
+    let output = run_check(DEAD_STORE, &["-D", "clean_counter"]);
+    let stderr = stderr_of(&output);
+    assert!(
+        !output.status.success(),
+        "-D clean_counter must fail closed (unregistered lint):\n{stderr}"
+    );
+    assert!(
+        stderr.contains("unknown lint `clean_counter`"),
+        "expected a clear unknown-lint error naming clean_counter:\n{stderr}"
+    );
+}

--- a/hew-cli/tests/lint_pass_e2e.rs
+++ b/hew-cli/tests/lint_pass_e2e.rs
@@ -1,8 +1,9 @@
-//! End-to-end coverage for the M1 compiler lint pass surfaced through
-//! `hew check`: the `needless_range_loop` lint renders as a warning by default,
-//! the `--allow` / `--warn` / `--deny` flags re-level it, an in-source
-//! `// hew:allow(...)` directive suppresses it, and an unknown lint name fails
-//! closed at the CLI boundary.
+//! End-to-end coverage for the compiler lint pass surfaced through `hew check`:
+//! lints render as warnings by default, the `--allow` / `--warn` / `--deny`
+//! flags re-level them, an in-source `// hew:allow(...)` directive suppresses
+//! them, and an unknown lint name fails closed at the CLI boundary. Covers the
+//! `needless_range_loop` and `len_zero_comparison` checker lints plus the
+//! `dead_code` warning now routed through the same registry.
 
 mod support;
 
@@ -154,5 +155,129 @@ fn unknown_lint_name_is_rejected() {
     assert!(
         stderr.contains("unknown lint `no_such_lint`"),
         "expected a clear unknown-lint error:\n{stderr}"
+    );
+}
+
+// ── checker-stage lint: len_zero_comparison ──────────────────────────
+
+/// A program whose only diagnostic is `len_zero_comparison`: `xs.len() == 0`
+/// is exactly `xs.is_empty()`.
+const LEN_ZERO: &str = "fn main() {\n\
+     let xs: Vec<i64> = Vec::new();\n\
+     let _ = xs.len() == 0;\n\
+     }\n";
+
+/// The same program with an in-source allow directive on the line above.
+const LEN_ZERO_SUPPRESSED: &str = "fn main() {\n\
+     let xs: Vec<i64> = Vec::new();\n\
+     // hew:allow(len_zero_comparison)\n\
+     let _ = xs.len() == 0;\n\
+     }\n";
+
+const LEN_ZERO_MESSAGE: &str = "is exactly `is_empty()`";
+
+#[test]
+fn len_zero_comparison_renders_by_default() {
+    let output = run_check(LEN_ZERO, &[]);
+    let stderr = stderr_of(&output);
+    assert!(
+        output.status.success(),
+        "a lint warning must not fail the build:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("warning:") && stderr.contains(LEN_ZERO_MESSAGE),
+        "expected the len_zero_comparison warning to render:\n{stderr}"
+    );
+}
+
+#[test]
+fn len_zero_comparison_deny_promotes_to_error() {
+    let output = run_check(LEN_ZERO, &["-D", "len_zero_comparison"]);
+    let stderr = stderr_of(&output);
+    assert!(
+        !output.status.success(),
+        "-D must fail the build:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("error:") && stderr.contains(LEN_ZERO_MESSAGE),
+        "-D must render the lint as an error:\n{stderr}"
+    );
+}
+
+#[test]
+fn len_zero_comparison_inline_directive_suppresses() {
+    let output = run_check(LEN_ZERO_SUPPRESSED, &[]);
+    let stderr = stderr_of(&output);
+    assert!(output.status.success(), "check should pass:\n{stderr}");
+    assert!(
+        !stderr.contains(LEN_ZERO_MESSAGE),
+        "an in-source `// hew:allow(...)` directive must suppress the lint:\n{stderr}"
+    );
+}
+
+// ── migrated warning: dead_code is now registry-controlled ───────────
+
+/// `helper` is never called, so the migrated `dead_code` lint flags it.
+const DEAD_CODE: &str = "fn helper() {}\nfn main() {}\n";
+
+const DEAD_CODE_MESSAGE: &str = "function `helper` is never called";
+
+#[test]
+fn dead_code_warns_by_default_but_is_allowable() {
+    // The migration preserves the default warning while making it suppressible
+    // through the same `--allow` path as every other registry lint.
+    let default = run_check(DEAD_CODE, &[]);
+    let default_stderr = stderr_of(&default);
+    assert!(
+        default_stderr.contains("warning:") && default_stderr.contains(DEAD_CODE_MESSAGE),
+        "dead_code must still warn by default:\n{default_stderr}"
+    );
+
+    let allowed = run_check(DEAD_CODE, &["--allow", "dead_code"]);
+    let allowed_stderr = stderr_of(&allowed);
+    assert!(
+        !allowed_stderr.contains(DEAD_CODE_MESSAGE),
+        "--allow dead_code must suppress the migrated warning:\n{allowed_stderr}"
+    );
+}
+
+#[test]
+fn dead_code_deny_promotes_to_error() {
+    let output = run_check(DEAD_CODE, &["-D", "dead_code"]);
+    let stderr = stderr_of(&output);
+    assert!(
+        !output.status.success(),
+        "-D dead_code must fail the build:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("error:") && stderr.contains(DEAD_CODE_MESSAGE),
+        "-D must render the migrated lint as an error:\n{stderr}"
+    );
+}
+
+/// A `re"..."` literal triggers implicit injection of `import std::text::regex`,
+/// whose body compares `values.len() == 0` internally. The lint sweep runs over
+/// user-authored bodies only, so that standard-library comparison must NOT
+/// surface as a `len_zero_comparison` warning against the user's program. (The
+/// regex literal itself is not yet lowered past the frontend, so `hew check`
+/// still exits non-zero on the `E_NOT_YET_IMPLEMENTED` MIR gate — that error is
+/// the proof the module was pulled in; the lint leak is what we guard against.)
+const REGEX_LITERAL: &str = "fn main() -> i64 {\n    let _r = re\"hello\";\n    return 0;\n}\n";
+
+#[test]
+fn stdlib_lints_do_not_leak_through_implicit_import() {
+    let output = run_check(REGEX_LITERAL, &[]);
+    let stderr = stderr_of(&output);
+    // Sanity: the implicit `std::text::regex` import was actually resolved and
+    // compiled (otherwise this test would pass vacuously). The regex literal is
+    // not yet lowered, so its MIR gate error is the witness.
+    assert!(
+        stderr.contains("RegexLiteralRef") || stderr.contains("regex"),
+        "expected the implicit std::text::regex import to be exercised:\n{stderr}"
+    );
+    // The actual guard: no lint finding from the library's own source.
+    assert!(
+        !stderr.contains(LEN_ZERO_MESSAGE),
+        "a len_zero_comparison finding must not leak from stdlib bodies:\n{stderr}"
     );
 }

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -36564,6 +36564,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         }
     }
 
@@ -37011,6 +37012,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
 
         let ctx = Context::create();
@@ -37102,6 +37104,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         }
     }
 
@@ -37231,6 +37234,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         }
     }
 
@@ -37344,6 +37348,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         }
     }
 
@@ -37477,6 +37482,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         }
     }
 
@@ -37610,6 +37616,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
         let ctx = Context::create();
         let m = build_module(&ctx, &pipeline, "handler_ctx_test")
@@ -37695,6 +37702,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
         let ctx = Context::create();
         let m = build_module(&ctx, &pipeline, "ctx_field_test")
@@ -37774,6 +37782,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
         let ctx = Context::create();
         let m =
@@ -38056,6 +38065,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         }
     }
 
@@ -38270,6 +38280,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         }
     }
 
@@ -39059,6 +39070,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
 
         let ctx = Context::create();
@@ -39153,6 +39165,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
         let ctx = Context::create();
         let m = build_module(&ctx, &pipeline, "gen_yield_codegen_test")
@@ -39313,6 +39326,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
         let ctx = Context::create();
         let m = build_module(&ctx, &pipeline, "make_generator_codegen_test")
@@ -39400,6 +39414,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
         let ctx = Context::create();
         let m = build_module(&ctx, &pipeline, "cancel_token_is_cancelled_codegen_test")
@@ -39673,6 +39688,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
         let syms = empty_fn_symbols();
         let err = verify_drop_dispatch_resolves(&pipeline, &syms)
@@ -39743,6 +39759,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
         let syms = empty_fn_symbols();
         verify_drop_dispatch_resolves(&pipeline, &syms)
@@ -39799,6 +39816,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
         let found = uses_wasm_excluded_symbol(&pipeline)
             .expect("Duplex::close ElabDrop must be flagged as WASM-excluded");
@@ -39833,6 +39851,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         }
     }
 
@@ -40448,6 +40467,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
         assert!(
             uses_wasm_excluded_symbol(&pipeline).is_none(),
@@ -42558,6 +42578,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
         let tmp = tempfile::Builder::new()
             .prefix("hew-dyn-coerce-ok-")
@@ -42708,6 +42729,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
         let tmp = tempfile::Builder::new()
             .prefix("hew-dyn-coerce-miss-")
@@ -43096,6 +43118,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
         let tmp = tempfile::Builder::new()
             .prefix("hew-frame-owned-drop-fail-")
@@ -43380,6 +43403,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         }
     }
 
@@ -43608,6 +43632,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         }
     }
 
@@ -43803,6 +43828,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         }
     }
 
@@ -43995,6 +44021,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         };
 
         let ctx = Context::create();
@@ -44202,6 +44229,7 @@ mod tests {
             actor_send_aliasing: std::collections::HashMap::new(),
             polymorphic_mir: Vec::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
         }
     }
 

--- a/hew-codegen-rs/tests/actor_dispatch_borrow_abi.rs
+++ b/hew-codegen-rs/tests/actor_dispatch_borrow_abi.rs
@@ -711,6 +711,7 @@ fn boxed_enum_recv_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -836,6 +837,7 @@ fn relay_resend_recv_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/actor_send_status_check.rs
+++ b/hew-codegen-rs/tests/actor_send_status_check.rs
@@ -130,6 +130,7 @@ fn send_status_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/bytes_extern_fail_closed.rs
+++ b/hew-codegen-rs/tests/bytes_extern_fail_closed.rs
@@ -151,6 +151,7 @@ fn pipeline_with_extern(
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: vec![],
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/composite_return.rs
+++ b/hew-codegen-rs/tests/composite_return.rs
@@ -139,6 +139,7 @@ fn option_some_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -239,6 +240,7 @@ fn option_string_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -375,6 +377,7 @@ fn envelope_i64_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -456,6 +459,7 @@ fn bytes_return_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -530,6 +534,7 @@ fn tuple_of_bytes_return_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -618,6 +623,7 @@ fn generic_record_of_string_return_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/cooperate_emission.rs
+++ b/hew-codegen-rs/tests/cooperate_emission.rs
@@ -105,6 +105,7 @@ fn loop_pipeline_with_sites(cooperate_sites: Vec<CooperateSite>) -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/cycle_capable_spawn_abi.rs
+++ b/hew-codegen-rs/tests/cycle_capable_spawn_abi.rs
@@ -107,6 +107,7 @@ fn spawn_pipeline(
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/dyn_trait_drop_in_place_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_drop_in_place_emission.rs
@@ -126,6 +126,7 @@ fn pipeline_with(
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/dyn_trait_method_dispatch.rs
+++ b/hew-codegen-rs/tests/dyn_trait_method_dispatch.rs
@@ -82,6 +82,7 @@ fn empty_pipeline(raw_mir: Vec<RawMirFunction>) -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/dyn_trait_thunk_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_thunk_emission.rs
@@ -148,6 +148,7 @@ fn pipeline_with(raw_mir: Vec<RawMirFunction>, registry: Vec<DynVtableInstance>)
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/dyn_trait_vtable_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_vtable_emission.rs
@@ -164,6 +164,7 @@ fn pipeline_with(raw_mir: Vec<RawMirFunction>, registry: Vec<DynVtableInstance>)
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/elab_drop_plans.rs
+++ b/hew-codegen-rs/tests/elab_drop_plans.rs
@@ -132,6 +132,7 @@ fn pipeline_with_elab_drop_plan() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -311,6 +312,7 @@ fn elab_drop_plan_unknown_drop_fn_fails_closed() {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     };
     let dir = out_dir("elab-drop-unknown-fail-closed");
     let options = EmitOptions {

--- a/hew-codegen-rs/tests/emit_duplex_pair.rs
+++ b/hew-codegen-rs/tests/emit_duplex_pair.rs
@@ -166,6 +166,7 @@ fn duplex_exemplar_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/hashmap_layout_emission.rs
+++ b/hew-codegen-rs/tests/hashmap_layout_emission.rs
@@ -126,6 +126,7 @@ fn base_pipeline(
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -595,6 +596,7 @@ fn hash_thunk_dedup_one_per_record_per_module() {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     };
     let ll = emit_ll(pipeline, "hash_dedup");
 
@@ -743,6 +745,7 @@ fn hash_thunk_dedup_no_double_emit_with_vec_contains_eq_thunk() {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     };
     let ll = emit_ll(pipeline, "shared_eq_dedup");
     let eq_defs = ll
@@ -1161,6 +1164,7 @@ fn hash_thunk_dedup_isolates_distinct_records_with_same_size_align() {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     };
     let ll = emit_ll(pipeline, "cross_shape_dedup");
     let hash_defs = ll

--- a/hew-codegen-rs/tests/hashmap_layout_ops.rs
+++ b/hew-codegen-rs/tests/hashmap_layout_ops.rs
@@ -121,6 +121,7 @@ fn pipeline_with_entry_terminator(
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/machine_emit_exec.rs
+++ b/hew-codegen-rs/tests/machine_emit_exec.rs
@@ -219,6 +219,7 @@ fn tcp_handshake_emit_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/machine_layout.rs
+++ b/hew-codegen-rs/tests/machine_layout.rs
@@ -28,6 +28,7 @@ fn empty_pipeline(machine_layouts: Vec<MachineLayout>) -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/mem_floor_intrinsic_emission.rs
+++ b/hew-codegen-rs/tests/mem_floor_intrinsic_emission.rs
@@ -110,6 +110,7 @@ fn floor_pipeline(
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/mem_floor_intrinsic_exec.rs
+++ b/hew-codegen-rs/tests/mem_floor_intrinsic_exec.rs
@@ -436,6 +436,7 @@ fn floor_pipeline_with_driver(driver: RawMirFunction) -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/periodic_spawn_arming.rs
+++ b/hew-codegen-rs/tests/periodic_spawn_arming.rs
@@ -149,6 +149,7 @@ fn spawn_pipeline(every_ms: Option<u64>) -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/runtime_abi_fail_closed.rs
+++ b/hew-codegen-rs/tests/runtime_abi_fail_closed.rs
@@ -114,6 +114,7 @@ fn pipeline_with_call_runtime_abi_parts(
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/scalar_discard_guard.rs
+++ b/hew-codegen-rs/tests/scalar_discard_guard.rs
@@ -133,6 +133,7 @@ fn pipeline_discard_extern(
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: vec![],
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/select_stream_e2e.rs
+++ b/hew-codegen-rs/tests/select_stream_e2e.rs
@@ -120,6 +120,7 @@ fn select_stream_i64_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/state_clone_synthesis.rs
+++ b/hew-codegen-rs/tests/state_clone_synthesis.rs
@@ -127,6 +127,7 @@ fn pipeline_with(actors: Vec<ActorLayout>, records: Vec<RecordLayout>) -> IrPipe
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/supervisor_emission.rs
+++ b/hew-codegen-rs/tests/supervisor_emission.rs
@@ -193,6 +193,7 @@ fn supervisor_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -444,6 +445,7 @@ fn on_crash_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/task_abi_emission.rs
+++ b/hew-codegen-rs/tests/task_abi_emission.rs
@@ -113,6 +113,7 @@ fn pipeline_with_task_abi_call(
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -227,6 +228,7 @@ fn pipeline_with_spawn_task_direct() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -332,6 +334,7 @@ fn pipeline_with_spawn_task_direct_target_without_context() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -461,6 +464,7 @@ fn pipeline_with_spawn_task_closure() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -675,6 +679,7 @@ fn task_abi_emission_task_scope_spawn_paired_with_task_new() {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     };
 
     let tmp = std::env::temp_dir().join("hew-task-abi-task-scope-spawn-paired");

--- a/hew-codegen-rs/tests/trap_kind_emission.rs
+++ b/hew-codegen-rs/tests/trap_kind_emission.rs
@@ -143,6 +143,7 @@ fn emit_trap_kind_ll(kind: TrapKind, module_name: &str) -> String {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     };
     let tmp = std::env::temp_dir().join(format!("hew-trap-kind-{module_name}"));
     std::fs::create_dir_all(&tmp).expect("create out_dir");

--- a/hew-codegen-rs/tests/user_enum_exec.rs
+++ b/hew-codegen-rs/tests/user_enum_exec.rs
@@ -136,6 +136,7 @@ fn colour_red_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/vec_index_emission.rs
+++ b/hew-codegen-rs/tests/vec_index_emission.rs
@@ -202,6 +202,7 @@ fn vec_index_i64_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -361,6 +362,7 @@ fn vec_index_bool_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -520,6 +522,7 @@ fn vec_index_char_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/vec_layout_emission.rs
+++ b/hew-codegen-rs/tests/vec_layout_emission.rs
@@ -114,6 +114,7 @@ fn base_pipeline(
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -714,6 +715,7 @@ fn vec_layout_contains_thunk_dedups_by_structured_type() {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     };
     let ll = emit_ll(pipeline, "contains_thunk_dedup");
 

--- a/hew-codegen-rs/tests/vec_slice_emission.rs
+++ b/hew-codegen-rs/tests/vec_slice_emission.rs
@@ -247,6 +247,7 @@ fn vec_slice_i64_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/verify_pipeline.rs
+++ b/hew-codegen-rs/tests/verify_pipeline.rs
@@ -78,6 +78,7 @@ fn pipeline_const_42() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -133,6 +134,7 @@ fn pipeline_unsupported_array_return() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/wasm_actor_metadata_emission.rs
+++ b/hew-codegen-rs/tests/wasm_actor_metadata_emission.rs
@@ -148,6 +148,7 @@ fn spawn_pipeline() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/wasm_duplex_classification.rs
+++ b/hew-codegen-rs/tests/wasm_duplex_classification.rs
@@ -130,6 +130,7 @@ fn pipeline_with_duplex_pair_call() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -216,6 +217,7 @@ fn pipeline_with_duplex_close_drop() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -304,6 +306,7 @@ fn pipeline_no_duplex() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/wasm_task_scope_classification.rs
+++ b/hew-codegen-rs/tests/wasm_task_scope_classification.rs
@@ -110,6 +110,7 @@ fn pipeline_with_task_scope_new_call() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 
@@ -200,6 +201,7 @@ fn pipeline_with_task_scope_spawn_call() -> IrPipeline {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     }
 }
 

--- a/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
+++ b/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
@@ -400,6 +400,7 @@ fn unknown_named_type_still_fails_closed_with_d10() {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: vec![],
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     };
 
     let tmp = std::env::temp_dir().join(format!("hew-d10-failclosed-{}", std::process::id()));

--- a/hew-lsp/src/server/analysis.rs
+++ b/hew-lsp/src/server/analysis.rs
@@ -9,7 +9,7 @@ use hew_parser::ast::{ImportDecl, Item};
 use hew_parser::{ParseDiagnosticKind, ParseResult};
 use hew_types::error::{Severity, TypeErrorKind};
 use hew_types::module_registry::{build_module_search_paths, build_module_search_paths_for};
-use hew_types::{Checker, TypeCheckOutput};
+use hew_types::{Checker, LintId, TypeCheckOutput};
 use tower_lsp::lsp_types::{
     Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag, Location,
     NumberOrString, Url,
@@ -1370,7 +1370,8 @@ fn unnecessary_diagnostic_tags(kind: &TypeErrorKind) -> Option<Vec<DiagnosticTag
         | TypeErrorKind::UnusedMut
         | TypeErrorKind::UnusedImport
         | TypeErrorKind::DeadCode
-        | TypeErrorKind::UnreachableCode => Some(vec![DiagnosticTag::UNNECESSARY]),
+        | TypeErrorKind::UnreachableCode
+        | TypeErrorKind::Lint(LintId::DeadCode) => Some(vec![DiagnosticTag::UNNECESSARY]),
         _ => None,
     }
 }

--- a/hew-lsp/src/server/analysis.rs
+++ b/hew-lsp/src/server/analysis.rs
@@ -1369,7 +1369,6 @@ fn unnecessary_diagnostic_tags(kind: &TypeErrorKind) -> Option<Vec<DiagnosticTag
         TypeErrorKind::UnusedVariable
         | TypeErrorKind::UnusedMut
         | TypeErrorKind::UnusedImport
-        | TypeErrorKind::DeadCode
         | TypeErrorKind::UnreachableCode
         | TypeErrorKind::Lint(LintId::DeadCode) => Some(vec![DiagnosticTag::UNNECESSARY]),
         _ => None,

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -2539,7 +2539,6 @@ machine Traffic {
             TypeErrorKind::UnusedImport,
             TypeErrorKind::UnreachableCode,
             TypeErrorKind::Shadowing,
-            TypeErrorKind::DeadCode,
             TypeErrorKind::OrphanImpl,
             TypeErrorKind::PlatformLimitation,
             TypeErrorKind::OnUpgradeNotYetWired,

--- a/hew-mir/src/dataflow.rs
+++ b/hew-mir/src/dataflow.rs
@@ -389,7 +389,7 @@ fn meet_predecessors(
     entry
 }
 
-fn build_preds(blocks: &[BasicBlock]) -> HashMap<u32, Vec<u32>> {
+pub(crate) fn build_preds(blocks: &[BasicBlock]) -> HashMap<u32, Vec<u32>> {
     let mut preds: HashMap<u32, Vec<u32>> = HashMap::new();
     for block in blocks {
         let mut emit_edge = |target: u32| preds.entry(target).or_default().push(block.id);
@@ -471,7 +471,7 @@ fn build_preds(blocks: &[BasicBlock]) -> HashMap<u32, Vec<u32>> {
     preds
 }
 
-fn successors(block: &BasicBlock) -> Vec<u32> {
+pub(crate) fn successors(block: &BasicBlock) -> Vec<u32> {
     match &block.terminator {
         Terminator::Return | Terminator::Trap { .. } => Vec::new(),
         Terminator::Goto { target } => vec![*target],
@@ -543,7 +543,7 @@ fn successors(block: &BasicBlock) -> Vec<u32> {
 /// Block IDs reachable from the entry block (id 0) along terminator edges.
 /// Used to exclude unreachable (dangling) predecessors from the dataflow meet —
 /// they never execute and must not contribute state.
-fn reachable_from_entry(blocks: &[BasicBlock]) -> HashSet<u32> {
+pub(crate) fn reachable_from_entry(blocks: &[BasicBlock]) -> HashSet<u32> {
     let by_id: HashMap<u32, &BasicBlock> = blocks.iter().map(|b| (b.id, b)).collect();
     let mut visited: HashSet<u32> = HashSet::new();
     let mut stack: Vec<u32> = Vec::new();
@@ -563,7 +563,7 @@ fn reachable_from_entry(blocks: &[BasicBlock]) -> HashSet<u32> {
     visited
 }
 
-fn compute_rpo(blocks: &[BasicBlock]) -> Vec<u32> {
+pub(crate) fn compute_rpo(blocks: &[BasicBlock]) -> Vec<u32> {
     let by_id: HashMap<u32, &BasicBlock> = blocks.iter().map(|b| (b.id, b)).collect();
     let mut visited: HashSet<u32> = HashSet::new();
     let mut post_order: Vec<u32> = Vec::with_capacity(blocks.len());

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -1728,6 +1728,7 @@ mod tests {
             hashset_lowering_facts: vec![],
             actor_send_aliasing: std::collections::HashMap::new(),
             user_clone_record_seeds: vec![],
+            lint_warnings: vec![],
             wire_layouts: std::sync::Arc::new(std::collections::HashMap::new()),
         }
     }

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -9,6 +9,7 @@ pub mod closure_env;
 pub mod dataflow;
 pub mod dump;
 pub mod dyn_vtable_registry;
+pub mod liveness;
 pub mod lower;
 pub mod model;
 pub mod runtime_call;
@@ -55,10 +56,10 @@ pub use model::{
     ElaboratedMirFunction, EnumLayout, ExitPath, ExternDecl, FieldOffset, FloatWidth,
     FunctionCallConv, Instr, IntArithOp, IntSignedness, IrPipeline, JoinBranch, LambdaActorShape,
     LambdaCapture, LambdaEnvFieldDrop, MachineLayout, MachineVariantLayout, MirCheck, MirConst,
-    MirConstValue, MirDiagnostic, MirDiagnosticKind, MirScope, MirStatement, Place, PointerWidth,
-    PolymorphicMirFunction, RawMirFunction, RecordLayout, RegexLiteral, RuntimeCall, SelectArm,
-    SelectArmKind, SendAliasMode, Strategy, SupervisorChildLayout, SupervisorLayout, SuspendKind,
-    Terminator, ThirFunction, TraitObjectStorage, TrapKind, WitnessOperand,
+    MirConstValue, MirDiagnostic, MirDiagnosticKind, MirLint, MirScope, MirStatement, Place,
+    PointerWidth, PolymorphicMirFunction, RawMirFunction, RecordLayout, RegexLiteral, RuntimeCall,
+    SelectArm, SelectArmKind, SendAliasMode, Strategy, SupervisorChildLayout, SupervisorLayout,
+    SuspendKind, Terminator, ThirFunction, TraitObjectStorage, TrapKind, WitnessOperand,
 };
 pub use runtime_symbols::UnknownRuntimeSymbol;
 pub use state_clone::{

--- a/hew-mir/src/liveness.rs
+++ b/hew-mir/src/liveness.rs
@@ -1,0 +1,475 @@
+//! Backward liveness dataflow over MIR locals, and the MIR-stage lints built on
+//! it (`dead_store` today; `clean_counter` is registered in the lint registry
+//! but intentionally not yet emitted — see the decision recorded in
+//! `docs/design/lint-pass.md`).
+//!
+//! ## Why backward, and why over the `Instr` stream
+//!
+//! Liveness is a backward "may" analysis: a local is *live* at a program point
+//! when some path from that point reads it before overwriting it. We compute it
+//! by reusing the forward move-checker's CFG plumbing — [`build_preds`],
+//! [`successors`], [`compute_rpo`] — with a backward worklist and a
+//! meet-over-successors confluence (`live_out(b) = ⋃ live_in(succ)`).
+//!
+//! The gen/kill sets come from the backend-authority `Instr` stream
+//! ([`instr_reads_writes`]) plus each terminator's source operands
+//! ([`terminator_source_places`]). That stream is *complete*: every
+//! machine-level read of a local is an `Instr` operand or a terminator source,
+//! so liveness computed over it never misses a read. We deliberately do NOT
+//! consult the checker-authority `statements` stream — it is `BindingId`-space
+//! and lowers *into* the `Instr` stream, so it can only carry reads the `Instr`
+//! stream already has.
+//!
+//! ## Soundness contract (precision-first)
+//!
+//! `dead_store` may only fire when a written value is *provably* never read.
+//! That requires the computed live set to be an **over-approximation** of true
+//! liveness — it may claim more locals live than truly are, never fewer:
+//!
+//!   * gen (reads) is a **superset** of the true reads: every operand `Place`
+//!     maps through [`place_local`] and is added, including partial (field /
+//!     tag / handle) reads. Over-approximating reads is safe.
+//!   * kill (writes) is a **subset** of the true kills: only a full
+//!     `Place::Local` def kills its local ([`full_def_local`]). Partial writes
+//!     (machine/enum fields, tags, handle sub-views) do not kill the backing
+//!     local. Under-approximating kills is safe.
+//!   * a terminator's *write* slots are not killed at all (only its reads gen) —
+//!     a further conservative under-kill.
+//!
+//! Under this contract `dest ∉ live_after(store)` implies the stored value is
+//! truly dead, so a fired `dead_store` is never a false positive — at the cost
+//! of occasionally missing one (acceptable recall for a precision-first lint).
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use hew_types::{LintId, ResolvedTy};
+
+use crate::dataflow::{
+    build_preds, compute_rpo, instr_reads_writes, reachable_from_entry, successors,
+};
+use crate::lower::terminator_source_places;
+use crate::model::{BasicBlock, Instr, MirLint, Place, RawMirFunction, SuspendKind};
+
+/// The backing MIR local a `Place` addresses, or `None` for the return slot
+/// (which is not a local register). Exhaustive by construction: a new `Place`
+/// variant forces a compile error here rather than silently escaping the
+/// liveness model (fail-closed — an unmodelled access must not vanish).
+fn place_local(place: Place) -> Option<u32> {
+    match place {
+        Place::Local(n)
+        | Place::DuplexHandle(n)
+        | Place::LambdaActorHandle(n)
+        | Place::ActorHandle(n)
+        | Place::SendHalf(n)
+        | Place::RecvHalf(n)
+        | Place::MachineTag(n)
+        | Place::EnumTag(n) => Some(n),
+        Place::MachineVariant { local, .. } | Place::EnumVariant { local, .. } => Some(local),
+        Place::ReturnSlot => None,
+    }
+}
+
+/// The local a write `Place` *fully* overwrites, or `None` when the write is
+/// partial (a field / tag / handle sub-view) and must NOT kill the backing
+/// local. Keeping the kill set a subset of the true kills preserves the
+/// over-approximation the `dead_store` soundness contract depends on. The
+/// wildcard is the fail-safe direction: an unmodelled write place falls through
+/// to "no kill", leaving the local live (conservative), never marking it dead.
+fn full_def_local(place: Place) -> Option<u32> {
+    match place {
+        Place::Local(n) => Some(n),
+        _ => None,
+    }
+}
+
+/// The pure value-class scalars: copyable, own no heap resource, and never
+/// participate in `Drop`. `dead_store` only targets these, which sidesteps
+/// drop-safety entirely — overwriting such a value can never strand a resource
+/// a later drop would observe.
+fn is_no_drop_scalar(ty: &ResolvedTy) -> bool {
+    matches!(
+        ty,
+        ResolvedTy::I8
+            | ResolvedTy::I16
+            | ResolvedTy::I32
+            | ResolvedTy::I64
+            | ResolvedTy::U8
+            | ResolvedTy::U16
+            | ResolvedTy::U32
+            | ResolvedTy::U64
+            | ResolvedTy::Isize
+            | ResolvedTy::Usize
+            | ResolvedTy::F32
+            | ResolvedTy::F64
+            | ResolvedTy::Bool
+            | ResolvedTy::Char
+    )
+}
+
+/// Apply the backward transfer of a terminator to `live`: gen its source
+/// operands. The terminator's write slots (e.g. a `Call`/`Ask` reply dest) are
+/// intentionally not killed — leaving them live is a conservative under-kill
+/// that only costs recall.
+fn apply_terminator_backward(
+    block: &BasicBlock,
+    suspend: Option<&SuspendKind>,
+    live: &mut HashSet<u32>,
+) {
+    for place in terminator_source_places(&block.terminator, suspend) {
+        if let Some(n) = place_local(place) {
+            live.insert(n);
+        }
+    }
+}
+
+/// Apply the backward transfer of a single instruction to `live`:
+/// `live = (live − full_defs) ∪ reads`. Kills are applied before gens so an
+/// instruction that both reads and writes the same local (`x = x + 1`) leaves
+/// that local live.
+fn apply_instr_backward(instr: &Instr, live: &mut HashSet<u32>) {
+    let (reads, writes) = instr_reads_writes(instr);
+    for place in writes {
+        if let Some(n) = full_def_local(place) {
+            live.remove(&n);
+        }
+    }
+    for place in reads {
+        if let Some(n) = place_local(place) {
+            live.insert(n);
+        }
+    }
+}
+
+/// `live_out(block) = ⋃ live_in(successor)` under the current `live_in` map.
+fn block_live_out(block: &BasicBlock, live_in: &HashMap<u32, HashSet<u32>>) -> HashSet<u32> {
+    let mut live = HashSet::new();
+    for succ in successors(block) {
+        if let Some(succ_in) = live_in.get(&succ) {
+            live.extend(succ_in.iter().copied());
+        }
+    }
+    live
+}
+
+/// For each instruction index in `block`, the set of locals live immediately
+/// *after* that instruction executes. `result[i]` is `live_after(i)` — exactly
+/// the query `dead_store` asks of a `Move`'s destination. `live_out` is the
+/// block's live-out set.
+fn live_after_points(
+    block: &BasicBlock,
+    suspend: Option<&SuspendKind>,
+    live_out: &HashSet<u32>,
+) -> Vec<HashSet<u32>> {
+    let n = block.instructions.len();
+    let mut points: Vec<HashSet<u32>> = vec![HashSet::new(); n];
+    let mut live = live_out.clone();
+    // Roll the terminator back first: `live` becomes live_after(n-1).
+    apply_terminator_backward(block, suspend, &mut live);
+    for idx in (0..n).rev() {
+        points[idx].clone_from(&live);
+        apply_instr_backward(&block.instructions[idx], &mut live);
+    }
+    points
+}
+
+/// Backward liveness fixpoint over one function's CFG. Returns the set of live
+/// locals on entry to each block, keyed by block id.
+fn compute_live_in(func: &RawMirFunction) -> HashMap<u32, HashSet<u32>> {
+    let blocks = &func.blocks;
+    let preds = build_preds(blocks);
+    let order = compute_rpo(blocks);
+    let index: HashMap<u32, usize> = blocks.iter().enumerate().map(|(i, b)| (b.id, i)).collect();
+
+    let mut live_in: HashMap<u32, HashSet<u32>> =
+        blocks.iter().map(|b| (b.id, HashSet::new())).collect();
+
+    // Backward worklist: seed in reverse RPO so successors settle before
+    // predecessors on the first sweep; re-enqueue a block's predecessors
+    // whenever its live-in grows. Monotone growth over a finite local set
+    // guarantees termination.
+    let mut worklist: VecDeque<u32> = order.iter().rev().copied().collect();
+    let mut queued: HashSet<u32> = worklist.iter().copied().collect();
+
+    while let Some(bid) = worklist.pop_front() {
+        queued.remove(&bid);
+        let Some(&idx) = index.get(&bid) else {
+            continue;
+        };
+        let block = &blocks[idx];
+
+        let mut live = block_live_out(block, &live_in);
+        apply_terminator_backward(block, func.suspend_kinds.get(&bid), &mut live);
+        for instr in block.instructions.iter().rev() {
+            apply_instr_backward(instr, &mut live);
+        }
+
+        if live_in.get(&bid) != Some(&live) {
+            live_in.insert(bid, live);
+            if let Some(preds) = preds.get(&bid) {
+                for &pred in preds {
+                    if queued.insert(pred) {
+                        worklist.push_back(pred);
+                    }
+                }
+            }
+        }
+    }
+
+    live_in
+}
+
+/// Backward-liveness result for a single function, queryable per block and per
+/// program point.
+#[derive(Debug, Clone)]
+pub struct Liveness {
+    live_in: HashMap<u32, HashSet<u32>>,
+    live_out: HashMap<u32, HashSet<u32>>,
+}
+
+impl Liveness {
+    /// Whether `local` is live on entry to `block_id`.
+    #[must_use]
+    pub fn is_live_in(&self, block_id: u32, local: u32) -> bool {
+        self.live_in
+            .get(&block_id)
+            .is_some_and(|s| s.contains(&local))
+    }
+
+    /// Whether `local` is live on exit from `block_id` (i.e. live on entry to
+    /// some successor).
+    #[must_use]
+    pub fn is_live_out(&self, block_id: u32, local: u32) -> bool {
+        self.live_out
+            .get(&block_id)
+            .is_some_and(|s| s.contains(&local))
+    }
+
+    /// Whether `local` is live immediately after instruction `instr_idx` of
+    /// `block_id` — the value present after that instruction is read on some
+    /// later path. This is the exact query `dead_store` runs on a `Move` dest.
+    /// Returns `false` for an unknown block / out-of-range index.
+    #[must_use]
+    pub fn live_after(
+        &self,
+        func: &RawMirFunction,
+        block_id: u32,
+        instr_idx: usize,
+        local: u32,
+    ) -> bool {
+        let Some(block) = func.blocks.iter().find(|b| b.id == block_id) else {
+            return false;
+        };
+        let empty = HashSet::new();
+        let live_out = self.live_out.get(&block_id).unwrap_or(&empty);
+        let points = live_after_points(block, func.suspend_kinds.get(&block_id), live_out);
+        points.get(instr_idx).is_some_and(|s| s.contains(&local))
+    }
+}
+
+/// Compute backward liveness for `func`.
+#[must_use]
+pub fn analyze_liveness(func: &RawMirFunction) -> Liveness {
+    let live_in = compute_live_in(func);
+    let live_out = func
+        .blocks
+        .iter()
+        .map(|b| (b.id, block_live_out(b, &live_in)))
+        .collect();
+    Liveness { live_in, live_out }
+}
+
+/// If `Local(n)` is a legitimate `dead_store` target — a user-named,
+/// non-parameter local of a no-drop scalar type — return its source name;
+/// otherwise `None` (skip). Returning `None` is the conservative "not a
+/// candidate" path, not error-swallowing: every guard that fails means the
+/// store is out of scope for this lint.
+fn dead_store_target_name(func: &RawMirFunction, n: u32, param_count: usize) -> Option<&str> {
+    let idx = n as usize;
+    // Skip parameter slots (`locals[0..param_count]`); reassigning a parameter
+    // is deliberately out of scope for this lint.
+    if idx < param_count {
+        return None;
+    }
+    // Must be user-named — skips compiler temporaries and synthesised slots
+    // (including for-range counter machinery, though liveness already keeps a
+    // live counter out of the dead set via the loop back-edge).
+    let name = func.local_names.get(idx)?.as_deref()?;
+    if name.is_empty() {
+        return None;
+    }
+    // Must be a no-drop scalar; anything heap-owning / aggregate / handle is
+    // excluded so we never reason about a value a `Drop` could observe.
+    match func.locals.get(idx) {
+        Some(ty) if is_no_drop_scalar(ty) => Some(name),
+        _ => None,
+    }
+}
+
+/// The span to anchor the diagnostic on: the offending store instruction's own
+/// span when present, else the local's declaration byte (a zero-width span).
+/// `None` when neither is available — a span-less lint is dropped rather than
+/// rendered at a fabricated location (fail-closed). Synthesised functions carry
+/// no `instr_spans` / `local_decl_bytes`, so this naturally suppresses findings
+/// in compiler-generated code.
+fn dead_store_span(
+    func: &RawMirFunction,
+    block_id: u32,
+    instr_idx: usize,
+    n: u32,
+) -> Option<(u32, u32)> {
+    if let Ok(idx) = u32::try_from(instr_idx) {
+        if let Some(&span) = func.instr_spans.get(&(block_id, idx)) {
+            return Some(span);
+        }
+    }
+    if let Some(&Some(byte)) = func.local_decl_bytes.get(n as usize) {
+        return Some((byte, byte));
+    }
+    None
+}
+
+/// Detect `dead_store` findings in one function from its liveness result.
+fn detect_dead_stores(func: &RawMirFunction, liveness: &Liveness, out: &mut Vec<MirLint>) {
+    let reachable = reachable_from_entry(&func.blocks);
+    let param_count = func.params.len();
+    let empty = HashSet::new();
+
+    for block in &func.blocks {
+        // Dead stores inside unreachable code are noise — the unreachable block
+        // is itself the defect; skip it.
+        if !reachable.contains(&block.id) {
+            continue;
+        }
+        let live_out = liveness.live_out.get(&block.id).unwrap_or(&empty);
+        let points = live_after_points(block, func.suspend_kinds.get(&block.id), live_out);
+
+        for (idx, instr) in block.instructions.iter().enumerate() {
+            // Only straight-line `Move` stores. Restricting to `Move` (not, say,
+            // checked arithmetic, which can trap) keeps the candidate pure: the
+            // store has no side effect whose removal would change behaviour.
+            let Instr::Move {
+                dest: Place::Local(n),
+                ..
+            } = instr
+            else {
+                continue;
+            };
+            let n = *n;
+            let Some(name) = dead_store_target_name(func, n, param_count) else {
+                continue;
+            };
+            // The store is dead iff its destination is not live afterwards.
+            if points[idx].contains(&n) {
+                continue;
+            }
+            let Some(span) = dead_store_span(func, block.id, idx, n) else {
+                continue;
+            };
+            out.push(MirLint {
+                lint: LintId::DeadStore,
+                span,
+                message: format!(
+                    "the value assigned to `{name}` is never read before it is overwritten \
+                     or goes out of scope"
+                ),
+            });
+        }
+    }
+}
+
+/// Drop duplicate findings sharing a `(lint, span)`. Generic functions are
+/// lowered once per monomorphisation, all sharing one source span; this reports
+/// a dead store in a generic body once rather than once per instantiation.
+fn dedup_by_lint_span(findings: &mut Vec<MirLint>) {
+    let mut seen: HashSet<(LintId, (u32, u32))> = HashSet::new();
+    findings.retain(|f| seen.insert((f.lint, f.span)));
+}
+
+/// Run the MIR-stage lint pass over every lowered function, returning the raw
+/// (level-agnostic) findings. The MIR stage decides only *what* is a finding;
+/// the CLI applies the user's `LintLevels` and `// hew:allow(...)` policy at
+/// render time.
+///
+/// Surfaced through the CLI front end only — the LSP / wasm front ends stop at
+/// HIR and never lower to MIR, so they never call this. Editor / web surfacing
+/// is tracked in issue #2176.
+#[must_use]
+pub fn run_mir_lints(functions: &[RawMirFunction]) -> Vec<MirLint> {
+    let mut out = Vec::new();
+    for func in functions {
+        // Only real source functions carry the names / spans the lints need;
+        // synthesised shims (drop glue, vtable thunks, dispatch) have
+        // `span == None`. Skipping them is both an optimisation and a guard.
+        if func.span.is_none() {
+            continue;
+        }
+        let liveness = analyze_liveness(func);
+        detect_dead_stores(func, &liveness, &mut out);
+    }
+    dedup_by_lint_span(&mut out);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn place_local_extracts_backing_local_for_every_variant() {
+        assert_eq!(place_local(Place::Local(3)), Some(3));
+        assert_eq!(place_local(Place::DuplexHandle(4)), Some(4));
+        assert_eq!(place_local(Place::LambdaActorHandle(5)), Some(5));
+        assert_eq!(place_local(Place::ActorHandle(6)), Some(6));
+        assert_eq!(place_local(Place::SendHalf(7)), Some(7));
+        assert_eq!(place_local(Place::RecvHalf(8)), Some(8));
+        assert_eq!(place_local(Place::MachineTag(9)), Some(9));
+        assert_eq!(place_local(Place::EnumTag(10)), Some(10));
+        assert_eq!(
+            place_local(Place::MachineVariant {
+                local: 11,
+                variant_idx: 0,
+                field_idx: 0,
+            }),
+            Some(11)
+        );
+        assert_eq!(
+            place_local(Place::EnumVariant {
+                local: 12,
+                variant_idx: 0,
+                field_idx: 0,
+            }),
+            Some(12)
+        );
+        assert_eq!(place_local(Place::ReturnSlot), None);
+    }
+
+    #[test]
+    fn full_def_local_only_kills_whole_local_writes() {
+        assert_eq!(full_def_local(Place::Local(1)), Some(1));
+        // Partial writes must not kill the backing local.
+        assert_eq!(full_def_local(Place::MachineTag(1)), None);
+        assert_eq!(
+            full_def_local(Place::MachineVariant {
+                local: 1,
+                variant_idx: 0,
+                field_idx: 0,
+            }),
+            None
+        );
+        assert_eq!(full_def_local(Place::ReturnSlot), None);
+    }
+
+    #[test]
+    fn no_drop_scalar_classifies_pure_values_only() {
+        assert!(is_no_drop_scalar(&ResolvedTy::I64));
+        assert!(is_no_drop_scalar(&ResolvedTy::U8));
+        assert!(is_no_drop_scalar(&ResolvedTy::F64));
+        assert!(is_no_drop_scalar(&ResolvedTy::Bool));
+        assert!(is_no_drop_scalar(&ResolvedTy::Char));
+        assert!(is_no_drop_scalar(&ResolvedTy::Usize));
+        // Heap-owning / aggregate / unit types are excluded.
+        assert!(!is_no_drop_scalar(&ResolvedTy::String));
+        assert!(!is_no_drop_scalar(&ResolvedTy::Bytes));
+        assert!(!is_no_drop_scalar(&ResolvedTy::Unit));
+    }
+}

--- a/hew-mir/src/liveness.rs
+++ b/hew-mir/src/liveness.rs
@@ -1,7 +1,7 @@
 //! Backward liveness dataflow over MIR locals, and the MIR-stage lints built on
-//! it (`dead_store` today; `clean_counter` is registered in the lint registry
-//! but intentionally not yet emitted — see the decision recorded in
-//! `docs/design/lint-pass.md`).
+//! it (`dead_store`). A `clean_counter` lint was considered but is deferred and
+//! deliberately NOT registered — see the decision recorded in
+//! `docs/design/lint-pass.md` (tracked in issue #2178).
 //!
 //! ## Why backward, and why over the `Instr` stream
 //!
@@ -86,6 +86,13 @@ fn full_def_local(place: Place) -> Option<u32> {
 /// participate in `Drop`. `dead_store` only targets these, which sidesteps
 /// drop-safety entirely — overwriting such a value can never strand a resource
 /// a later drop would observe.
+///
+/// LOAD-BEARING: this scalar restriction is what makes it sound to run the lint
+/// on `raw_mir`, i.e. *before* drop elaboration (see `run_mir_lints`'s call site
+/// in `lower.rs`). A `Drop` is itself a read of the dropped local for liveness,
+/// but raw MIR has not yet materialised drop points — so widening this guard
+/// past no-drop scalars would require re-running the lint on elaborated MIR,
+/// else a value a `Drop` observes could be wrongly flagged dead.
 fn is_no_drop_scalar(ty: &ResolvedTy) -> bool {
     matches!(
         ty,
@@ -247,7 +254,17 @@ impl Liveness {
     /// Whether `local` is live immediately after instruction `instr_idx` of
     /// `block_id` — the value present after that instruction is read on some
     /// later path. This is the exact query `dead_store` runs on a `Move` dest.
-    /// Returns `false` for an unknown block / out-of-range index.
+    ///
+    /// A not-found block or out-of-range index resolves to **`true`**
+    /// (conservatively live): a point we cannot locate must never be reported
+    /// dead, which is the unsound direction for a removal lint.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `func` is not the function this `Liveness` was computed from:
+    /// `analyze_liveness` populates `live_out` for every block of its input, so
+    /// a block found in `func.blocks` but absent from `live_out` can only mean a
+    /// mismatched `func` was passed.
     #[must_use]
     pub fn live_after(
         &self,
@@ -257,12 +274,22 @@ impl Liveness {
         local: u32,
     ) -> bool {
         let Some(block) = func.blocks.iter().find(|b| b.id == block_id) else {
-            return false;
+            // Unknown block ⇒ conservatively live.
+            return true;
         };
-        let empty = HashSet::new();
-        let live_out = self.live_out.get(&block_id).unwrap_or(&empty);
+        // `block_id` was just found in `func.blocks`, and `analyze_liveness`
+        // populates `live_out` for every block of the analysed function, so a
+        // miss here is a real invariant violation, not an empty-set default.
+        let live_out = self
+            .live_out
+            .get(&block_id)
+            .expect("live_out populated for every block (analyze_liveness invariant)");
         let points = live_after_points(block, func.suspend_kinds.get(&block_id), live_out);
-        points.get(instr_idx).is_some_and(|s| s.contains(&local))
+        match points.get(instr_idx) {
+            Some(live) => live.contains(&local),
+            // Out-of-range point ⇒ conservatively live.
+            None => true,
+        }
     }
 }
 
@@ -332,7 +359,6 @@ fn dead_store_span(
 fn detect_dead_stores(func: &RawMirFunction, liveness: &Liveness, out: &mut Vec<MirLint>) {
     let reachable = reachable_from_entry(&func.blocks);
     let param_count = func.params.len();
-    let empty = HashSet::new();
 
     for block in &func.blocks {
         // Dead stores inside unreachable code are noise — the unreachable block
@@ -340,7 +366,13 @@ fn detect_dead_stores(func: &RawMirFunction, liveness: &Liveness, out: &mut Vec<
         if !reachable.contains(&block.id) {
             continue;
         }
-        let live_out = liveness.live_out.get(&block.id).unwrap_or(&empty);
+        // `block` is iterated straight out of `func.blocks`, and `liveness` was
+        // produced by `analyze_liveness(func)`, which populates `live_out` for
+        // every block — so a miss is an invariant violation, not a default.
+        let live_out = liveness
+            .live_out
+            .get(&block.id)
+            .expect("live_out populated for every block (analyze_liveness invariant)");
         let points = live_after_points(block, func.suspend_kinds.get(&block.id), live_out);
 
         for (idx, instr) in block.instructions.iter().enumerate() {

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -2322,6 +2322,12 @@ pub fn lower_hir_module_with_facts(
     // `dyn Trait` usage.
     let dyn_vtable_registry = crate::dyn_vtable_registry::build_dyn_vtable_registry(&raw_mir);
 
+    // MIR-stage lint pass (liveness-driven `dead_store`). Records raw,
+    // level-agnostic findings; the CLI applies the user's `LintLevels` and
+    // `// hew:allow(...)` policy at render time. CLI front end only — the LSP /
+    // wasm front ends stop at HIR and never reach MIR (issue #2176).
+    let lint_warnings = crate::liveness::run_mir_lints(&raw_mir);
+
     IrPipeline {
         thir,
         raw_mir,
@@ -2374,6 +2380,7 @@ pub fn lower_hir_module_with_facts(
         // Populated by `attach_lowering_facts` from `TypeCheckOutput`; empty
         // here so the lowerer does not depend on `TypeCheckOutput` directly.
         user_clone_record_seeds: Vec::new(),
+        lint_warnings,
     }
 }
 

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -2326,6 +2326,11 @@ pub fn lower_hir_module_with_facts(
     // level-agnostic findings; the CLI applies the user's `LintLevels` and
     // `// hew:allow(...)` policy at render time. CLI front end only — the LSP /
     // wasm front ends stop at HIR and never reach MIR (issue #2176).
+    //
+    // Runs on `raw_mir` (pre drop-elaboration) deliberately: this is sound ONLY
+    // because `dead_store` is restricted to no-drop scalars (see
+    // `liveness::is_no_drop_scalar`). Widening the lint past scalars would have
+    // to run after drop elaboration so a `Drop`'s read of the local is modelled.
     let lint_warnings = crate::liveness::run_mir_lints(&raw_mir);
 
     IrPipeline {

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -304,6 +304,36 @@ pub struct IrPipeline {
     /// `TypeCheckOutput` directly. WHEN-OBSOLETE: if user-facing `Clone`
     /// becomes a first-class trait with a dedicated codegen path.
     pub user_clone_record_seeds: Vec<String>,
+    /// Warning-severity findings from the MIR-stage lint pass (`liveness.rs`):
+    /// `dead_store` today. Kept on a channel separate from [`Self::diagnostics`]
+    /// because every `MirDiagnostic` renders as a hard `E_MIR_*` error, whereas
+    /// these are level-configurable lints (`--allow`/`--warn`/`--deny`). The MIR
+    /// stage records the raw findings here; the CLI applies the user's
+    /// [`hew_types::LintLevels`] and `// hew:allow(...)` policy at render time.
+    ///
+    /// Surfaced through the CLI front end only; the LSP / wasm front ends stop
+    /// at HIR and never lower to MIR, so they never populate or read this.
+    /// Editor/web surfacing is tracked in issue #2176.
+    pub lint_warnings: Vec<MirLint>,
+}
+
+/// A single warning-severity finding from the MIR-stage lint pass.
+///
+/// Level-agnostic: `hew-mir` records the finding (which lint fired, where, and
+/// the human message); the CLI maps it through [`hew_types::LintLevels`] to a
+/// rendered warning, a build-failing error (`--deny`), or nothing (`--allow` /
+/// `// hew:allow(...)`). The `span` is a `(start, end)` byte range into the
+/// originating module source so the CLI can point at the offending line and run
+/// the same suppression-directive check used for HIR-stage lints.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MirLint {
+    /// Which registry lint produced this finding.
+    pub lint: hew_types::LintId,
+    /// `(start, end)` byte offsets of the offending construct in module source.
+    pub span: (u32, u32),
+    /// The rendered human-readable message (no severity prefix; the CLI adds
+    /// `warning:` / `error:`).
+    pub message: String,
 }
 
 impl IrPipeline {

--- a/hew-mir/tests/liveness.rs
+++ b/hew-mir/tests/liveness.rs
@@ -1,0 +1,218 @@
+//! Backward liveness + `dead_store` MIR-lint coverage.
+//!
+//! Exercises the liveness query API directly (a dead store's destination is not
+//! live afterwards, a surviving store's is) and the `dead_store` lint surfaced
+//! on `IrPipeline::lint_warnings`: positive cases plus the precision guards that
+//! must stay silent — a `for i in 0..n` counter, a loop-carried accumulator, a
+//! heap-typed (drop-bearing) store, and a value read immediately after the
+//! store.
+
+use hew_hir::{lower_program, verify_hir, ResolutionCtx};
+use hew_mir::liveness::analyze_liveness;
+use hew_mir::{lower_hir_module, Instr, IrPipeline, MirLint, Place, RawMirFunction};
+use hew_types::{module_registry::ModuleRegistry, Checker, LintId};
+
+/// Full type-checked lowering — `dead_store` is type-sensitive (it only targets
+/// no-drop scalars), so the locals must carry resolved types.
+fn checked_pipeline(source: &str) -> IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(parsed.errors.is_empty(), "parse: {:?}", parsed.errors);
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    assert!(tc_output.errors.is_empty(), "check: {:?}", tc_output.errors);
+    let output = lower_program(
+        &parsed.program,
+        &tc_output,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    assert!(
+        output.diagnostics.is_empty(),
+        "hir: {:?}",
+        output.diagnostics
+    );
+    let verify = verify_hir(&output.module);
+    assert!(verify.is_empty(), "verify: {verify:?}");
+    lower_hir_module(&output.module)
+}
+
+fn dead_stores(p: &IrPipeline) -> Vec<&MirLint> {
+    p.lint_warnings
+        .iter()
+        .filter(|l| l.lint == LintId::DeadStore)
+        .collect()
+}
+
+fn func<'a>(p: &'a IrPipeline, name: &str) -> &'a RawMirFunction {
+    p.raw_mir
+        .iter()
+        .find(|f| f.name == name)
+        .unwrap_or_else(|| panic!("function `{name}` present in raw MIR"))
+}
+
+fn local_id(f: &RawMirFunction, name: &str) -> u32 {
+    u32::try_from(
+        f.local_names
+            .iter()
+            .position(|n| n.as_deref() == Some(name))
+            .unwrap_or_else(|| panic!("local `{name}` present")),
+    )
+    .expect("local index fits u32")
+}
+
+// ── liveness query API ───────────────────────────────────────────────
+
+/// In `var x = 5; x = 6; x`, the first store (`x = 5`) is dead — `x` is not live
+/// immediately after it — while the second (`x = 6`) is live (its value is
+/// returned). The per-point query must distinguish the two stores into the same
+/// local.
+#[test]
+fn liveness_distinguishes_dead_and_live_store_into_same_local() {
+    let p = checked_pipeline(
+        "fn f() -> i64 {\n  var x = 5;\n  x = 6;\n  x\n}\nfn main() {\n  let _ = f();\n}\n",
+    );
+    let f = func(&p, "f");
+    let liveness = analyze_liveness(f);
+    let x = local_id(f, "x");
+
+    let mut dead = 0u32;
+    let mut live = 0u32;
+    for block in &f.blocks {
+        for (idx, instr) in block.instructions.iter().enumerate() {
+            if let Instr::Move {
+                dest: Place::Local(n),
+                ..
+            } = instr
+            {
+                if *n == x {
+                    if liveness.live_after(f, block.id, idx, x) {
+                        live += 1;
+                    } else {
+                        dead += 1;
+                    }
+                }
+            }
+        }
+    }
+    assert_eq!(dead, 1, "exactly the `x = 5` store is dead");
+    assert!(live >= 1, "the surviving `x = 6` store is live");
+}
+
+/// A returned local is live immediately after its defining store (the return
+/// reads it). Block-boundary liveness would miss this when define + return live
+/// in one block, so we assert at the program point.
+#[test]
+fn liveness_marks_returned_local_live_after_definition() {
+    let p =
+        checked_pipeline("fn f() -> i64 {\n  let x = 7;\n  x\n}\nfn main() {\n  let _ = f();\n}\n");
+    let f = func(&p, "f");
+    let liveness = analyze_liveness(f);
+    let x = local_id(f, "x");
+    let mut found = false;
+    for block in &f.blocks {
+        for (idx, instr) in block.instructions.iter().enumerate() {
+            if let Instr::Move {
+                dest: Place::Local(n),
+                ..
+            } = instr
+            {
+                if *n == x {
+                    assert!(
+                        liveness.live_after(f, block.id, idx, x),
+                        "`x` must be live after its definition (it is returned)"
+                    );
+                    found = true;
+                }
+            }
+        }
+    }
+    assert!(found, "the defining store of `x` is a Move");
+}
+
+// ── dead_store: positive ─────────────────────────────────────────────
+
+/// A scalar overwritten before it is read fires exactly once, on the dead store.
+#[test]
+fn dead_store_fires_on_overwritten_scalar() {
+    let p = checked_pipeline(
+        "fn f() -> i64 {\n  var x = 5;\n  x = 6;\n  x\n}\nfn main() {\n  let _ = f();\n}\n",
+    );
+    let findings = dead_stores(&p);
+    assert_eq!(findings.len(), 1, "one dead store: {findings:?}");
+    assert!(
+        findings[0].message.contains("`x`") && findings[0].message.contains("is never read"),
+        "message names the local and states the rule: {:?}",
+        findings[0].message
+    );
+}
+
+/// A scalar binding whose value is never read at all fires once.
+#[test]
+fn dead_store_fires_on_unused_scalar() {
+    let p = checked_pipeline(
+        "fn f() -> i64 {\n  var x = 5;\n  let y = 10;\n  y\n}\nfn main() {\n  let _ = f();\n}\n",
+    );
+    let findings = dead_stores(&p);
+    assert_eq!(
+        findings.len(),
+        1,
+        "one dead store on the unused `x`: {findings:?}"
+    );
+    assert!(
+        findings[0].message.contains("`x`"),
+        "{:?}",
+        findings[0].message
+    );
+}
+
+// ── dead_store: precision guards (must stay silent) ──────────────────
+
+/// `for i in 0..n` with the counter used normally and a loop-carried
+/// accumulator read after the loop must NOT fire: the back-edge keeps both `i`
+/// and `sum` live across the increment, so neither store is dead. This is the
+/// load-bearing precision guard.
+#[test]
+fn for_range_counter_and_accumulator_do_not_fire() {
+    let p = checked_pipeline("fn f(n: i64) -> i64 {\n  var sum = 0;\n  for i in 0..n {\n    sum = sum + i;\n  }\n  sum\n}\nfn main() {\n  let _ = f(3);\n}\n");
+    assert!(
+        dead_stores(&p).is_empty(),
+        "for-range counter / accumulator must not be flagged: {:?}",
+        dead_stores(&p)
+    );
+}
+
+/// A heap-typed (`string`) store is excluded — `dead_store` only targets no-drop
+/// scalars, so drop-safety is never in question.
+#[test]
+fn heap_typed_store_does_not_fire() {
+    let p = checked_pipeline("fn f() -> string {\n  var s = \"a\";\n  s = \"b\";\n  s\n}\nfn main() {\n  let _ = f();\n}\n");
+    assert!(
+        dead_stores(&p).is_empty(),
+        "string store must not be flagged: {:?}",
+        dead_stores(&p)
+    );
+}
+
+/// A value read immediately after assignment is live — no finding.
+#[test]
+fn live_store_does_not_fire() {
+    let p =
+        checked_pipeline("fn f() -> i64 {\n  let x = 5;\n  x\n}\nfn main() {\n  let _ = f();\n}\n");
+    assert!(
+        dead_stores(&p).is_empty(),
+        "a read value must not be flagged: {:?}",
+        dead_stores(&p)
+    );
+}
+
+/// A clean program (only the stdlib prelude beyond `main`) produces no MIR lint
+/// warnings — the pass must not spuriously fire inside the prelude.
+#[test]
+fn clean_program_has_no_findings() {
+    let p = checked_pipeline("fn main() {\n  let _ = 1 + 2;\n}\n");
+    assert!(
+        p.lint_warnings.is_empty(),
+        "clean program must have no MIR lint warnings: {:?}",
+        p.lint_warnings
+    );
+}

--- a/hew-mir/tests/vec_index_oob.rs
+++ b/hew-mir/tests/vec_index_oob.rs
@@ -376,6 +376,7 @@ fn vec_index_mir_wraps_in_pipeline_without_errors() {
         actor_send_aliasing: std::collections::HashMap::new(),
         polymorphic_mir: Vec::new(),
         user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
     };
     // No diagnostics from the hand-built MIR (it is already valid).
     assert!(

--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -42,6 +42,7 @@ impl Checker {
             }
         }
 
+        let mut findings: Vec<(Span, String, Option<String>)> = Vec::new();
         for (fn_name, (def_span, stored_module)) in &self.fn_def_spans {
             if fn_name == "main" || fn_name.starts_with('_') || fn_name.contains("::") {
                 continue;
@@ -52,17 +53,21 @@ impl Checker {
             if reachable.contains(fn_name) {
                 continue;
             }
-            self.warnings.push(TypeError {
-                severity: crate::error::Severity::Warning,
-                kind: TypeErrorKind::DeadCode,
-                span: def_span.clone(),
-                message: format!("function `{fn_name}` is never called"),
-                notes: vec![],
-                suggestions: vec![format!(
-                    "if this is intentional, prefix with underscore: `_{fn_name}`"
-                )],
-                source_module: stored_module.clone(),
-            });
+            findings.push((def_span.clone(), fn_name.clone(), stored_module.clone()));
+        }
+        // Route through the lint registry so `dead_code` is configurable
+        // (`-A/-W/-D`) and suppressible (`// hew:allow(dead_code)`). The
+        // collect-then-emit split releases the `&self.fn_def_spans` borrow
+        // before the `&mut self` emit calls. Default level is `Warn`, so the
+        // warning still appears exactly as before unless reconfigured.
+        for (def_span, fn_name, stored_module) in findings {
+            self.emit_main_pass_lint(
+                LintId::DeadCode,
+                &def_span,
+                stored_module.as_deref(),
+                format!("function `{fn_name}` is never called"),
+                format!("if this is intentional, prefix with underscore: `_{fn_name}`"),
+            );
         }
     }
 

--- a/hew-types/src/check/lints/len_zero_comparison.rs
+++ b/hew-types/src/check/lints/len_zero_comparison.rs
@@ -1,0 +1,200 @@
+//! The `len_zero_comparison` lint.
+//!
+//! Flags a comparison of `something.len()` against the integer literal `0` or
+//! `1` whose intent is an emptiness test, and suggests `is_empty()` /
+//! `!is_empty()`:
+//!
+//! | comparison (either operand order)        | meaning      | suggestion     |
+//! | ---------------------------------------- | ------------ | -------------- |
+//! | `len() == 0`                             | empty        | `is_empty()`   |
+//! | `len() != 0`, `len() > 0`, `len() >= 1`  | not empty    | `!is_empty()`  |
+//! | `len() <= 0`, `len() < 1`                | empty        | `is_empty()`   |
+//!
+//! This is the precise, type-checked, suppressible companion to the syntactic
+//! `rules/hew/len-zero-is-empty.yml` ast-grep rule; the two intentionally
+//! coexist (the ast-grep rule is fast and editor-local, this one is type-aware
+//! and honours `// hew:allow`).
+//!
+//! ## Precision over recall
+//!
+//! - One operand must be literally `<recv>.len()` (a no-argument method call);
+//!   a `len` *field* access never qualifies.
+//! - The other operand must be the integer literal `0` or `1` (with the
+//!   operator paired so the predicate is a genuine emptiness test — see the
+//!   table; `len() > 1`, `len() == 1`, … are not flagged).
+//! - The receiver's resolved type must expose `is_empty()` — `Vec`, `HashMap`,
+//!   `HashSet`, and `string` — verified through [`LintCtx::resolved_type_at`].
+
+use hew_parser::ast::{BinaryOp, Block, Expr, Literal, Span, Spanned};
+
+use crate::builtin_type::BuiltinType;
+use crate::error::TypeError;
+use crate::ty::Ty;
+
+use super::{LintCtx, LintId, LintLevels, NodeVisitor};
+
+/// Entry point: walk `body` and flag every `len()`-versus-`0`/`1` comparison.
+pub(super) fn check(ctx: &LintCtx, levels: &LintLevels, body: &Block, out: &mut Vec<TypeError>) {
+    let mut visitor = LenZero {
+        ctx,
+        hits: Vec::new(),
+    };
+    super::walk_body(body, &mut visitor);
+    for hit in visitor.hits {
+        let (message, suggestion) = hit.render();
+        ctx.emit(
+            levels,
+            LintId::LenZeroComparison,
+            &hit.span,
+            message,
+            suggestion,
+            out,
+        );
+    }
+}
+
+struct Hit {
+    span: Span,
+    /// `true` ⇒ the comparison means "empty" (`is_empty()`); `false` ⇒ "not
+    /// empty" (`!is_empty()`).
+    means_empty: bool,
+    /// Best-effort rendering of the receiver, when it is a simple
+    /// identifier / field path; `None` falls back to a generic suggestion.
+    receiver: Option<String>,
+}
+
+impl Hit {
+    fn render(&self) -> (String, String) {
+        if self.means_empty {
+            let suggestion = match &self.receiver {
+                Some(recv) => format!("replace with `{recv}.is_empty()`"),
+                None => "use `is_empty()` instead of comparing `len()` to zero".to_string(),
+            };
+            (
+                "this `len()` comparison is exactly `is_empty()`".to_string(),
+                suggestion,
+            )
+        } else {
+            let suggestion = match &self.receiver {
+                Some(recv) => format!("replace with `!{recv}.is_empty()`"),
+                None => "use `!...is_empty()` instead of comparing `len()`".to_string(),
+            };
+            (
+                "this `len()` comparison is exactly `!is_empty()`".to_string(),
+                suggestion,
+            )
+        }
+    }
+}
+
+struct LenZero<'a> {
+    ctx: &'a LintCtx<'a>,
+    hits: Vec<Hit>,
+}
+
+impl NodeVisitor for LenZero<'_> {
+    fn visit_expr(&mut self, expr: &Expr, span: &Span) {
+        let Expr::Binary { left, op, right } = expr else {
+            return;
+        };
+        // Identify which side is `<recv>.len()` and which is the literal.
+        let (receiver, value, len_on_left) =
+            if let (Some(recv), Some(v)) = (len_receiver(&left.0), int_literal(&right.0)) {
+                (recv, v, true)
+            } else if let (Some(recv), Some(v)) = (len_receiver(&right.0), int_literal(&left.0)) {
+                (recv, v, false)
+            } else {
+                return;
+            };
+        let Some(means_empty) = comparison_meaning(*op, value, len_on_left) else {
+            return;
+        };
+        if !self
+            .ctx
+            .resolved_type_at(&receiver.1)
+            .is_some_and(|ty| type_has_is_empty(&ty))
+        {
+            return;
+        }
+        self.hits.push(Hit {
+            span: span.clone(),
+            means_empty,
+            receiver: render_receiver(&receiver.0),
+        });
+    }
+}
+
+/// The receiver of a no-argument `.len()` call, or `None`.
+fn len_receiver(expr: &Expr) -> Option<&Spanned<Expr>> {
+    match expr {
+        Expr::MethodCall {
+            receiver,
+            method,
+            args,
+        } if method == "len" && args.is_empty() => Some(receiver),
+        _ => None,
+    }
+}
+
+/// The value of a bare non-negative integer literal, or `None`.
+fn int_literal(expr: &Expr) -> Option<i64> {
+    match expr {
+        Expr::Literal(Literal::Integer { value, .. }) => Some(*value),
+        _ => None,
+    }
+}
+
+/// Interpret a `len`-versus-literal comparison.
+///
+/// Canonicalises to `len <op> value` (flipping the operator when `len` is the
+/// right operand) and returns `Some(true)` when the predicate is an emptiness
+/// test (`is_empty()`), `Some(false)` when it is a non-emptiness test
+/// (`!is_empty()`), and `None` for any operator/literal pairing that is not a
+/// clean emptiness test.
+fn comparison_meaning(op: BinaryOp, value: i64, len_on_left: bool) -> Option<bool> {
+    let canonical = if len_on_left { op } else { flip(op)? };
+    match (canonical, value) {
+        (BinaryOp::Equal | BinaryOp::LessEqual, 0) | (BinaryOp::Less, 1) => Some(true),
+        (BinaryOp::NotEqual | BinaryOp::Greater, 0) | (BinaryOp::GreaterEqual, 1) => Some(false),
+        _ => None,
+    }
+}
+
+/// The operator equivalent after swapping operands (`a < b` ≡ `b > a`); `None`
+/// for non-comparison operators.
+fn flip(op: BinaryOp) -> Option<BinaryOp> {
+    Some(match op {
+        BinaryOp::Equal => BinaryOp::Equal,
+        BinaryOp::NotEqual => BinaryOp::NotEqual,
+        BinaryOp::Less => BinaryOp::Greater,
+        BinaryOp::LessEqual => BinaryOp::GreaterEqual,
+        BinaryOp::Greater => BinaryOp::Less,
+        BinaryOp::GreaterEqual => BinaryOp::LessEqual,
+        _ => return None,
+    })
+}
+
+/// Builtin types that expose `len()` and `is_empty()` with `len() == 0`
+/// equivalent to `is_empty()`.
+fn type_has_is_empty(ty: &Ty) -> bool {
+    matches!(ty, Ty::String)
+        || matches!(
+            ty,
+            Ty::Named {
+                builtin: Some(BuiltinType::Vec | BuiltinType::HashMap | BuiltinType::HashSet),
+                ..
+            }
+        )
+}
+
+/// Best-effort source rendering of a receiver expression for the suggestion,
+/// restricted to identifier / field-path shapes that round-trip cleanly.
+fn render_receiver(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Identifier(name) => Some(name.clone()),
+        Expr::FieldAccess { object, field } => {
+            Some(format!("{}.{field}", render_receiver(&object.0)?))
+        }
+        _ => None,
+    }
+}

--- a/hew-types/src/check/lints/mod.rs
+++ b/hew-types/src/check/lints/mod.rs
@@ -82,16 +82,13 @@ pub enum LintId {
     /// is overwritten or goes out of scope — the store is dead. Emitted by the
     /// MIR-stage liveness pass (`hew-mir`), not the HIR checker sweep.
     DeadStore,
-    /// A loop-carried counter / accumulator that is incremented inside a loop
-    /// but whose value is never read after the loop — pure dead counting.
-    ///
-    /// Registered but NOT yet emitted: separating a dead accumulator from a
-    /// legitimate `for i in 0..n` counter needs faint-variable (strong-liveness)
-    /// analysis, and Hew's increments lower through *checked* arithmetic that can
-    /// trap, so the increment is not provably side-effect-free. Detecting this
-    /// precisely is tracked for a later milestone; the name is reserved here so
-    /// the CLI `--allow`/`--deny` surface and docs stay stable in the meantime.
-    CleanCounter,
+    // NOTE: a `clean_counter` lint (a loop-carried accumulator that is
+    // incremented but never read after the loop) is deliberately NOT registered
+    // here. It has no emission code yet, and registering an un-emitted lint
+    // would make `-D/-W/-A clean_counter` and `// hew:allow(clean_counter)`
+    // silently no-op — a fail-open that defeats `from_name`'s fail-closed
+    // contract (an unknown lint must surface as a CLI error). Detecting it
+    // precisely needs faint-variable analysis; tracked in issue #2178.
 }
 
 impl LintId {
@@ -108,7 +105,6 @@ impl LintId {
         LintId::CloneOnCopy,
         LintId::DeadCode,
         LintId::DeadStore,
-        LintId::CleanCounter,
     ];
 
     /// The stable, lowercase string name for this lint.
@@ -127,7 +123,6 @@ impl LintId {
             LintId::CloneOnCopy => "clone_on_copy",
             LintId::DeadCode => "dead_code",
             LintId::DeadStore => "dead_store",
-            LintId::CleanCounter => "clean_counter",
         }
     }
 
@@ -152,8 +147,7 @@ impl LintId {
             | LintId::NeedlessBool
             | LintId::CloneOnCopy
             | LintId::DeadCode
-            | LintId::DeadStore
-            | LintId::CleanCounter => LintLevel::Warn,
+            | LintId::DeadStore => LintLevel::Warn,
         }
     }
 }

--- a/hew-types/src/check/lints/mod.rs
+++ b/hew-types/src/check/lints/mod.rs
@@ -78,6 +78,20 @@ pub enum LintId {
     /// A function that is defined but never reached from any entry point.
     /// (Migrated from an ad-hoc whole-program dead-code warning.)
     DeadCode,
+    /// A value assigned to a local is never read on any path before the local
+    /// is overwritten or goes out of scope — the store is dead. Emitted by the
+    /// MIR-stage liveness pass (`hew-mir`), not the HIR checker sweep.
+    DeadStore,
+    /// A loop-carried counter / accumulator that is incremented inside a loop
+    /// but whose value is never read after the loop — pure dead counting.
+    ///
+    /// Registered but NOT yet emitted: separating a dead accumulator from a
+    /// legitimate `for i in 0..n` counter needs faint-variable (strong-liveness)
+    /// analysis, and Hew's increments lower through *checked* arithmetic that can
+    /// trap, so the increment is not provably side-effect-free. Detecting this
+    /// precisely is tracked for a later milestone; the name is reserved here so
+    /// the CLI `--allow`/`--deny` surface and docs stay stable in the meantime.
+    CleanCounter,
 }
 
 impl LintId {
@@ -93,6 +107,8 @@ impl LintId {
         LintId::NeedlessBool,
         LintId::CloneOnCopy,
         LintId::DeadCode,
+        LintId::DeadStore,
+        LintId::CleanCounter,
     ];
 
     /// The stable, lowercase string name for this lint.
@@ -110,6 +126,8 @@ impl LintId {
             LintId::NeedlessBool => "needless_bool",
             LintId::CloneOnCopy => "clone_on_copy",
             LintId::DeadCode => "dead_code",
+            LintId::DeadStore => "dead_store",
+            LintId::CleanCounter => "clean_counter",
         }
     }
 
@@ -133,7 +151,9 @@ impl LintId {
             | LintId::LenZeroComparison
             | LintId::NeedlessBool
             | LintId::CloneOnCopy
-            | LintId::DeadCode => LintLevel::Warn,
+            | LintId::DeadCode
+            | LintId::DeadStore
+            | LintId::CleanCounter => LintLevel::Warn,
         }
     }
 }
@@ -320,10 +340,11 @@ impl LintCtx<'_> {
 /// and, for item-bodied constructs reached through only comments, the
 /// item-level form. `all` matches every lint.
 ///
-/// Exposed to the wider checker (`pub(super)`) so main-pass lints migrated onto
-/// the registry — `clone_on_copy`, `dead_code` — resolve directives through the
-/// same path as the sweep instead of re-implementing it.
-pub(super) fn directive_suppresses(source: &str, span_start: usize, id: LintId) -> bool {
+/// Exposed beyond the checker so MIR-stage lints surfaced through the CLI
+/// (`dead_store`) resolve `// hew:allow(...)` directives through the same path
+/// as the HIR sweep instead of re-implementing it.
+#[must_use]
+pub fn directive_suppresses(source: &str, span_start: usize, id: LintId) -> bool {
     let lines: Vec<&str> = source.lines().collect();
     if lines.is_empty() {
         return false;

--- a/hew-types/src/check/lints/mod.rs
+++ b/hew-types/src/check/lints/mod.rs
@@ -34,14 +34,20 @@
 
 use std::collections::HashMap;
 
-use hew_parser::ast::{Block, Span};
+use hew_parser::ast::{
+    Block, CallArg, ElseBlock, Expr, MatchArm, SelectArm, Span, Stmt, StringPart,
+};
 
 use crate::error::{Severity, TypeError, TypeErrorKind};
 use crate::ty::{Substitution, Ty};
 
 use super::types::SpanKey;
 
+mod len_zero_comparison;
+mod needless_bool;
+mod needless_match_to_if_let;
 mod needless_range_loop;
+mod redundant_else_after_return;
 
 /// Stable identifier for a single compiler lint.
 ///
@@ -53,6 +59,25 @@ pub enum LintId {
     /// `for i in 0 .. xs.len()` where `i` is only ever used to index `xs` —
     /// the loop should iterate the collection directly.
     NeedlessRangeLoop,
+    /// An `if` whose then-branch unconditionally diverges (`return` / `break`
+    /// / `continue` / a `!`-typed call such as `panic`) yet still carries an
+    /// `else`; the `else` can be dropped and its body de-indented.
+    RedundantElseAfterReturn,
+    /// A two-arm `match` on an `Option` where one arm binds `Some(x)` and the
+    /// other is an empty `None => {}` — exactly an `if let Some(x) = …`.
+    NeedlessMatchToIfLet,
+    /// A `.len()` call compared against the integer literal `0` / `1` where the
+    /// receiver type has `is_empty()` — use `is_empty()` / `!is_empty()`.
+    LenZeroComparison,
+    /// `if c { true } else { false }` (or the inverted polarity) — the whole
+    /// `if` is just `c` (or `!c`).
+    NeedlessBool,
+    /// `.clone()` on a `Copy` type — the value is already duplicated, so the
+    /// `clone` is redundant. (Migrated from an ad-hoc style warning.)
+    CloneOnCopy,
+    /// A function that is defined but never reached from any entry point.
+    /// (Migrated from an ad-hoc whole-program dead-code warning.)
+    DeadCode,
 }
 
 impl LintId {
@@ -60,7 +85,15 @@ impl LintId {
     ///
     /// Used to seed [`LintLevels::from_defaults`] and to back
     /// [`LintId::from_name`] so the CLI flag parser stays in sync.
-    pub const ALL: &'static [LintId] = &[LintId::NeedlessRangeLoop];
+    pub const ALL: &'static [LintId] = &[
+        LintId::NeedlessRangeLoop,
+        LintId::RedundantElseAfterReturn,
+        LintId::NeedlessMatchToIfLet,
+        LintId::LenZeroComparison,
+        LintId::NeedlessBool,
+        LintId::CloneOnCopy,
+        LintId::DeadCode,
+    ];
 
     /// The stable, lowercase string name for this lint.
     ///
@@ -71,6 +104,12 @@ impl LintId {
     pub fn as_str(self) -> &'static str {
         match self {
             LintId::NeedlessRangeLoop => "needless_range_loop",
+            LintId::RedundantElseAfterReturn => "redundant_else_after_return",
+            LintId::NeedlessMatchToIfLet => "needless_match_to_if_let",
+            LintId::LenZeroComparison => "len_zero_comparison",
+            LintId::NeedlessBool => "needless_bool",
+            LintId::CloneOnCopy => "clone_on_copy",
+            LintId::DeadCode => "dead_code",
         }
     }
 
@@ -88,7 +127,13 @@ impl LintId {
     #[must_use]
     pub fn default_level(self) -> LintLevel {
         match self {
-            LintId::NeedlessRangeLoop => LintLevel::Warn,
+            LintId::NeedlessRangeLoop
+            | LintId::RedundantElseAfterReturn
+            | LintId::NeedlessMatchToIfLet
+            | LintId::LenZeroComparison
+            | LintId::NeedlessBool
+            | LintId::CloneOnCopy
+            | LintId::DeadCode => LintLevel::Warn,
         }
     }
 }
@@ -274,7 +319,11 @@ impl LintCtx<'_> {
 /// covers `// hew:allow(needless_range_loop)` placed on the line above the loop
 /// and, for item-bodied constructs reached through only comments, the
 /// item-level form. `all` matches every lint.
-fn directive_suppresses(source: &str, span_start: usize, id: LintId) -> bool {
+///
+/// Exposed to the wider checker (`pub(super)`) so main-pass lints migrated onto
+/// the registry — `clone_on_copy`, `dead_code` — resolve directives through the
+/// same path as the sweep instead of re-implementing it.
+pub(super) fn directive_suppresses(source: &str, span_start: usize, id: LintId) -> bool {
     let lines: Vec<&str> = source.lines().collect();
     if lines.is_empty() {
         return false;
@@ -345,4 +394,312 @@ pub(super) fn lint_block(
     out: &mut Vec<TypeError>,
 ) {
     needless_range_loop::check(ctx, levels, body, out);
+    redundant_else_after_return::check(ctx, levels, body, out);
+    needless_match_to_if_let::check(ctx, levels, body, out);
+    len_zero_comparison::check(ctx, levels, body, out);
+    needless_bool::check(ctx, levels, body, out);
+}
+
+// ── shared read-only body walker ─────────────────────────────────────
+
+/// Read-only pre-order visitor over a typed body.
+///
+/// A lint implements only the callbacks it needs; [`walk_body`] then drives the
+/// exhaustive descent so every lint shares one traversal instead of
+/// re-deriving its own block walker (the `needless_range_loop` module predates
+/// this helper and keeps its bespoke use-tracking walk).
+///
+/// - [`NodeVisitor::visit_block`] sees a [`Block`] with full positional
+///   context: its `stmts` are in statement position (value discarded) and its
+///   `trailing_expr` is in tail position (the block's value). The
+///   position-sensitive lints (`redundant_else_after_return`,
+///   `needless_match_to_if_let`) key off this so they only rewrite where the
+///   transform is sound.
+/// - [`NodeVisitor::visit_stmt`] / [`NodeVisitor::visit_expr`] fire for every
+///   node regardless of position, which the position-agnostic lints
+///   (`len_zero_comparison`, `needless_bool`) use.
+pub(super) trait NodeVisitor {
+    /// A block, visited before its contents are descended.
+    fn visit_block(&mut self, _block: &Block) {}
+    /// A statement, visited before its sub-nodes are descended.
+    fn visit_stmt(&mut self, _stmt: &Stmt, _span: &Span) {}
+    /// An expression, visited before its sub-expressions are descended.
+    fn visit_expr(&mut self, _expr: &Expr, _span: &Span) {}
+}
+
+/// Drive `visitor` over `body` and every node nested inside it.
+pub(super) fn walk_body<V: NodeVisitor>(body: &Block, visitor: &mut V) {
+    walk_block(body, visitor);
+}
+
+fn walk_block<V: NodeVisitor>(block: &Block, visitor: &mut V) {
+    visitor.visit_block(block);
+    for (stmt, span) in &block.stmts {
+        walk_stmt(stmt, span, visitor);
+    }
+    if let Some(trailing) = &block.trailing_expr {
+        walk_expr(&trailing.0, &trailing.1, visitor);
+    }
+}
+
+#[allow(
+    clippy::too_many_lines,
+    clippy::match_same_arms,
+    reason = "exhaustive statement visitor enumerates every Stmt shape so a new node forces a decision; per-variant arms are kept even when two walks coincide"
+)]
+fn walk_stmt<V: NodeVisitor>(stmt: &Stmt, span: &Span, visitor: &mut V) {
+    visitor.visit_stmt(stmt, span);
+    match stmt {
+        Stmt::Let {
+            value, else_block, ..
+        } => {
+            if let Some(v) = value {
+                walk_expr(&v.0, &v.1, visitor);
+            }
+            if let Some(eb) = else_block {
+                walk_block(eb, visitor);
+            }
+        }
+        Stmt::Var { value, .. } => {
+            if let Some(v) = value {
+                walk_expr(&v.0, &v.1, visitor);
+            }
+        }
+        Stmt::Assign { target, value, .. } => {
+            walk_expr(&target.0, &target.1, visitor);
+            walk_expr(&value.0, &value.1, visitor);
+        }
+        Stmt::If {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            walk_expr(&condition.0, &condition.1, visitor);
+            walk_block(then_block, visitor);
+            if let Some(eb) = else_block {
+                walk_else_block(eb, visitor);
+            }
+        }
+        Stmt::IfLet {
+            expr,
+            body,
+            else_body,
+            ..
+        } => {
+            walk_expr(&expr.0, &expr.1, visitor);
+            walk_block(body, visitor);
+            if let Some(eb) = else_body {
+                walk_block(eb, visitor);
+            }
+        }
+        Stmt::Match { scrutinee, arms } => {
+            walk_expr(&scrutinee.0, &scrutinee.1, visitor);
+            for arm in arms {
+                walk_arm(arm, visitor);
+            }
+        }
+        Stmt::Loop { body, .. } => walk_block(body, visitor),
+        Stmt::For { iterable, body, .. } => {
+            walk_expr(&iterable.0, &iterable.1, visitor);
+            walk_block(body, visitor);
+        }
+        Stmt::While {
+            condition, body, ..
+        } => {
+            walk_expr(&condition.0, &condition.1, visitor);
+            walk_block(body, visitor);
+        }
+        Stmt::WhileLet { expr, body, .. } => {
+            walk_expr(&expr.0, &expr.1, visitor);
+            walk_block(body, visitor);
+        }
+        Stmt::Break { value, .. } | Stmt::Return(value) => {
+            if let Some(v) = value {
+                walk_expr(&v.0, &v.1, visitor);
+            }
+        }
+        Stmt::Continue { .. } => {}
+        Stmt::Defer(expr) => walk_expr(&expr.0, &expr.1, visitor),
+        Stmt::Expression(expr) => walk_expr(&expr.0, &expr.1, visitor),
+    }
+}
+
+fn walk_else_block<V: NodeVisitor>(else_block: &ElseBlock, visitor: &mut V) {
+    if let Some(if_stmt) = &else_block.if_stmt {
+        walk_stmt(&if_stmt.0, &if_stmt.1, visitor);
+    }
+    if let Some(block) = &else_block.block {
+        walk_block(block, visitor);
+    }
+}
+
+fn walk_arm<V: NodeVisitor>(arm: &MatchArm, visitor: &mut V) {
+    if let Some(guard) = &arm.guard {
+        walk_expr(&guard.0, &guard.1, visitor);
+    }
+    walk_expr(&arm.body.0, &arm.body.1, visitor);
+}
+
+fn walk_select_arm<V: NodeVisitor>(arm: &SelectArm, visitor: &mut V) {
+    walk_expr(&arm.source.0, &arm.source.1, visitor);
+    walk_expr(&arm.body.0, &arm.body.1, visitor);
+}
+
+fn walk_call_args<V: NodeVisitor>(args: &[CallArg], visitor: &mut V) {
+    for arg in args {
+        let (expr, span) = arg.expr();
+        walk_expr(expr, span, visitor);
+    }
+}
+
+#[allow(
+    clippy::too_many_lines,
+    clippy::match_same_arms,
+    reason = "exhaustive expression visitor enumerates every Expr shape so a new node forces a decision; per-variant arms are kept even when two walks coincide"
+)]
+fn walk_expr<V: NodeVisitor>(expr: &Expr, span: &Span, visitor: &mut V) {
+    visitor.visit_expr(expr, span);
+    match expr {
+        Expr::Literal(_)
+        | Expr::Identifier(_)
+        | Expr::This
+        | Expr::RegexLiteral(_)
+        | Expr::ByteStringLiteral(_)
+        | Expr::ByteArrayLiteral(_) => {}
+        Expr::Binary { left, right, .. } => {
+            walk_expr(&left.0, &left.1, visitor);
+            walk_expr(&right.0, &right.1, visitor);
+        }
+        Expr::Unary { operand, .. } => walk_expr(&operand.0, &operand.1, visitor),
+        Expr::Clone(inner)
+        | Expr::Await(inner)
+        | Expr::PostfixTry(inner)
+        | Expr::Cast { expr: inner, .. }
+        | Expr::FieldAccess { object: inner, .. } => walk_expr(&inner.0, &inner.1, visitor),
+        Expr::Tuple(items) | Expr::Array(items) | Expr::Join(items) => {
+            for item in items {
+                walk_expr(&item.0, &item.1, visitor);
+            }
+        }
+        Expr::ArrayRepeat { value, count } => {
+            walk_expr(&value.0, &value.1, visitor);
+            walk_expr(&count.0, &count.1, visitor);
+        }
+        Expr::MapLiteral { entries } => {
+            for (k, v) in entries {
+                walk_expr(&k.0, &k.1, visitor);
+                walk_expr(&v.0, &v.1, visitor);
+            }
+        }
+        Expr::Block(block)
+        | Expr::Scope { body: block }
+        | Expr::ForkBlock { body: block }
+        | Expr::GenBlock { body: block } => walk_block(block, visitor),
+        Expr::UnsafeBlock(block) => walk_block(block, visitor),
+        Expr::If {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            walk_expr(&condition.0, &condition.1, visitor);
+            walk_expr(&then_block.0, &then_block.1, visitor);
+            if let Some(eb) = else_block {
+                walk_expr(&eb.0, &eb.1, visitor);
+            }
+        }
+        Expr::IfLet {
+            expr,
+            body,
+            else_body,
+            ..
+        } => {
+            walk_expr(&expr.0, &expr.1, visitor);
+            walk_block(body, visitor);
+            if let Some(eb) = else_body {
+                walk_block(eb, visitor);
+            }
+        }
+        Expr::Match { scrutinee, arms } => {
+            walk_expr(&scrutinee.0, &scrutinee.1, visitor);
+            for arm in arms {
+                walk_arm(arm, visitor);
+            }
+        }
+        Expr::Lambda { body, .. } | Expr::SpawnLambdaActor { body, .. } => {
+            walk_expr(&body.0, &body.1, visitor);
+        }
+        Expr::Spawn { target, args, .. } => {
+            walk_expr(&target.0, &target.1, visitor);
+            for (_, value) in args {
+                walk_expr(&value.0, &value.1, visitor);
+            }
+        }
+        Expr::ForkChild { expr, .. } => walk_expr(&expr.0, &expr.1, visitor),
+        Expr::ScopeDeadline { duration, body } => {
+            walk_expr(&duration.0, &duration.1, visitor);
+            walk_block(body, visitor);
+        }
+        Expr::InterpolatedString(parts) => {
+            for part in parts {
+                if let StringPart::Expr(inner) = part {
+                    walk_expr(&inner.0, &inner.1, visitor);
+                }
+            }
+        }
+        Expr::Call { function, args, .. } => {
+            walk_expr(&function.0, &function.1, visitor);
+            walk_call_args(args, visitor);
+        }
+        Expr::MethodCall { receiver, args, .. } => {
+            walk_expr(&receiver.0, &receiver.1, visitor);
+            walk_call_args(args, visitor);
+        }
+        Expr::StructInit { fields, base, .. } => {
+            for (_, value) in fields {
+                walk_expr(&value.0, &value.1, visitor);
+            }
+            if let Some(base) = base {
+                walk_expr(&base.0, &base.1, visitor);
+            }
+        }
+        Expr::Select { arms, timeout } => {
+            for arm in arms {
+                walk_select_arm(arm, visitor);
+            }
+            if let Some(timeout) = timeout {
+                walk_expr(&timeout.duration.0, &timeout.duration.1, visitor);
+                walk_expr(&timeout.body.0, &timeout.body.1, visitor);
+            }
+        }
+        Expr::Timeout { expr, duration } => {
+            walk_expr(&expr.0, &expr.1, visitor);
+            walk_expr(&duration.0, &duration.1, visitor);
+        }
+        Expr::Yield(value) | Expr::Return(value) => {
+            if let Some(v) = value {
+                walk_expr(&v.0, &v.1, visitor);
+            }
+        }
+        Expr::Index { object, index } => {
+            walk_expr(&object.0, &object.1, visitor);
+            walk_expr(&index.0, &index.1, visitor);
+        }
+        Expr::Range { start, end, .. } => {
+            if let Some(start) = start {
+                walk_expr(&start.0, &start.1, visitor);
+            }
+            if let Some(end) = end {
+                walk_expr(&end.0, &end.1, visitor);
+            }
+        }
+        Expr::Is { lhs, rhs } => {
+            walk_expr(&lhs.0, &lhs.1, visitor);
+            walk_expr(&rhs.0, &rhs.1, visitor);
+        }
+        Expr::MachineEmit { fields, .. } => {
+            for (_, value) in fields {
+                walk_expr(&value.0, &value.1, visitor);
+            }
+        }
+    }
 }

--- a/hew-types/src/check/lints/needless_bool.rs
+++ b/hew-types/src/check/lints/needless_bool.rs
@@ -1,0 +1,127 @@
+//! The `needless_bool` lint.
+//!
+//! Flags an `if`/`else` whose only purpose is to produce a boolean literal in
+//! each branch:
+//!
+//! - `if c { true } else { false }` → `c`
+//! - `if c { false } else { true }` → `!c`
+//!
+//! ## Precision over recall
+//!
+//! - Both branches are required; each must be exactly a single boolean literal
+//!   (an empty-statement block whose only content is `true` / `false`). Any
+//!   extra statement in a branch disqualifies the `if`.
+//! - The two branches must be *opposite* literals — `if c { true } else { true }`
+//!   is a different smell (a constant) and is left alone.
+//! - An `else if` chain never qualifies (its else branch is not a bare boolean
+//!   literal).
+//!
+//! The rewrite yields the same boolean value in any context, so unlike the
+//! position-sensitive lints this one fires wherever the shape appears
+//! (statement, block tail, `let` initialiser, argument, …).
+
+use hew_parser::ast::{Block, Expr, Literal, Span, Stmt};
+
+use crate::error::TypeError;
+
+use super::{LintCtx, LintId, LintLevels, NodeVisitor};
+
+/// Entry point: walk `body` and flag every literal-returning `if`/`else`.
+pub(super) fn check(ctx: &LintCtx, levels: &LintLevels, body: &Block, out: &mut Vec<TypeError>) {
+    let mut visitor = NeedlessBool { hits: Vec::new() };
+    super::walk_body(body, &mut visitor);
+    for (span, positive) in visitor.hits {
+        let (message, suggestion) = if positive {
+            (
+                "this `if`/`else` just yields its condition".to_string(),
+                "replace the whole `if` with the condition".to_string(),
+            )
+        } else {
+            (
+                "this `if`/`else` just yields the negation of its condition".to_string(),
+                "replace the whole `if` with the negated condition (`!…`)".to_string(),
+            )
+        };
+        ctx.emit(
+            levels,
+            LintId::NeedlessBool,
+            &span,
+            message,
+            suggestion,
+            out,
+        );
+    }
+}
+
+struct NeedlessBool {
+    /// `(span, positive)` where `positive` is `true` when the then-branch is
+    /// `true` (rewrite → `cond`) and `false` when it is `false` (→ `!cond`).
+    hits: Vec<(Span, bool)>,
+}
+
+impl NeedlessBool {
+    fn record(&mut self, span: &Span, then_value: bool, else_value: bool) {
+        // Opposite polarities only: equal branches are a constant, not this lint.
+        if then_value != else_value {
+            self.hits.push((span.clone(), then_value));
+        }
+    }
+}
+
+impl NodeVisitor for NeedlessBool {
+    fn visit_stmt(&mut self, stmt: &Stmt, span: &Span) {
+        if let Stmt::If {
+            then_block,
+            else_block: Some(else_block),
+            ..
+        } = stmt
+        {
+            // Plain `else { … }` only — an `else if` carries an `if_stmt`.
+            if else_block.if_stmt.is_some() {
+                return;
+            }
+            let Some(else_block) = &else_block.block else {
+                return;
+            };
+            if let (Some(then_value), Some(else_value)) =
+                (block_bool(then_block), block_bool(else_block))
+            {
+                self.record(span, then_value, else_value);
+            }
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &Expr, span: &Span) {
+        if let Expr::If {
+            then_block,
+            else_block: Some(else_expr),
+            ..
+        } = expr
+        {
+            if let (Some(then_value), Some(else_value)) =
+                (branch_bool(&then_block.0), branch_bool(&else_expr.0))
+            {
+                self.record(span, then_value, else_value);
+            }
+        }
+    }
+}
+
+/// The boolean value of a branch expression that is exactly a boolean literal
+/// (directly, or as the sole trailing expression of an otherwise-empty block).
+fn branch_bool(expr: &Expr) -> Option<bool> {
+    match expr {
+        Expr::Literal(Literal::Bool(value)) => Some(*value),
+        Expr::Block(block) => block_bool(block),
+        _ => None,
+    }
+}
+
+/// The boolean value of a block that contains nothing but a boolean-literal
+/// trailing expression (no statements).
+fn block_bool(block: &Block) -> Option<bool> {
+    if !block.stmts.is_empty() {
+        return None;
+    }
+    branch_bool(&block.trailing_expr.as_ref()?.0)
+}

--- a/hew-types/src/check/lints/needless_match_to_if_let.rs
+++ b/hew-types/src/check/lints/needless_match_to_if_let.rs
@@ -1,0 +1,170 @@
+//! The `needless_match_to_if_let` lint.
+//!
+//! Flags a two-arm `match` on an `Option` that is really an `if let`: one arm
+//! binds `Some(x)` and does the work, the other is an empty `None => {}` (or
+//! `None => ()`). Such a `match` reads as `if let Some(x) = scrutinee { … }`.
+//!
+//! ## Precision over recall
+//!
+//! - Exactly two arms, neither carrying a guard.
+//! - The scrutinee's resolved type must be `Option<_>` (checked through
+//!   [`LintCtx::resolved_type_at`]); `Result` is intentionally out of scope.
+//! - One arm is `Some(<binding>)` where `<binding>` is a plain identifier or
+//!   `_` (a nested destructure is left alone — the rewrite is less obviously an
+//!   improvement and rendering it is error-prone).
+//! - The other arm is `None` with a trivial body: an empty block `{}` or unit
+//!   `()` (recursing through a single trivial trailing expression). A `None`
+//!   arm that does any work disqualifies the match — both arms doing work is
+//!   not an `if let`.
+//! - Only fires where the `match` value is discarded: statement position
+//!   (`Stmt::Match` / a bare `match` expression statement) or block-tail
+//!   position. A `match` feeding a `let` / argument (value position) is left
+//!   alone, matching the rule that the binding arm's value must not be consumed
+//!   as the match's result.
+
+use hew_parser::ast::{Block, Expr, MatchArm, Pattern, Span, Stmt};
+
+use crate::error::TypeError;
+use crate::ty::Ty;
+
+use super::{LintCtx, LintId, LintLevels, NodeVisitor};
+use crate::builtin_type::BuiltinType;
+
+/// Entry point: walk `body` and flag every two-arm Option match that is an
+/// `if let` in disguise.
+pub(super) fn check(ctx: &LintCtx, levels: &LintLevels, body: &Block, out: &mut Vec<TypeError>) {
+    let mut visitor = NeedlessMatch {
+        ctx,
+        hits: Vec::new(),
+    };
+    super::walk_body(body, &mut visitor);
+    for (span, binding) in visitor.hits {
+        ctx.emit(
+            levels,
+            LintId::NeedlessMatchToIfLet,
+            &span,
+            "this two-arm `match` on `Option` is an `if let`".to_string(),
+            format!("rewrite as `if let Some({binding}) = … {{ … }}`"),
+            out,
+        );
+    }
+}
+
+struct NeedlessMatch<'a> {
+    ctx: &'a LintCtx<'a>,
+    hits: Vec<(Span, String)>,
+}
+
+impl NeedlessMatch<'_> {
+    fn consider(&mut self, scrutinee_span: &Span, arms: &[MatchArm], report_span: &Span) {
+        if let Some(binding) = needless_binding(self.ctx, scrutinee_span, arms) {
+            self.hits.push((report_span.clone(), binding));
+        }
+    }
+}
+
+impl NodeVisitor for NeedlessMatch<'_> {
+    fn visit_block(&mut self, block: &Block) {
+        for (stmt, span) in &block.stmts {
+            match stmt {
+                Stmt::Match { scrutinee, arms } => self.consider(&scrutinee.1, arms, span),
+                Stmt::Expression((Expr::Match { scrutinee, arms }, expr_span)) => {
+                    self.consider(&scrutinee.1, arms, expr_span);
+                }
+                _ => {}
+            }
+        }
+        if let Some(trailing) = &block.trailing_expr {
+            if let Expr::Match { scrutinee, arms } = &trailing.0 {
+                self.consider(&scrutinee.1, arms, &trailing.1);
+            }
+        }
+    }
+}
+
+/// When `arms` (the arms of a `match` on the expression at `scrutinee_span`)
+/// form the `Some(binding) => …` / `None => {}` shape on an `Option`, return
+/// the binding's spelling for the suggestion. Returns `None` otherwise.
+fn needless_binding(ctx: &LintCtx, scrutinee_span: &Span, arms: &[MatchArm]) -> Option<String> {
+    if arms.len() != 2 || arms.iter().any(|arm| arm.guard.is_some()) {
+        return None;
+    }
+    if !ctx
+        .resolved_type_at(scrutinee_span)
+        .is_some_and(|ty| is_option(&ty))
+    {
+        return None;
+    }
+
+    let mut some_binding: Option<String> = None;
+    let mut none_trivial = false;
+    for arm in arms {
+        match &arm.pattern.0 {
+            Pattern::Constructor { name, patterns } if name == "Some" && patterns.len() == 1 => {
+                some_binding = Some(binding_name(&patterns[0].0)?);
+            }
+            pattern if is_none_pattern(pattern) => {
+                if !is_trivial_body(&arm.body.0) {
+                    return None;
+                }
+                none_trivial = true;
+            }
+            _ => return None,
+        }
+    }
+    if none_trivial {
+        some_binding
+    } else {
+        None
+    }
+}
+
+fn is_option(ty: &Ty) -> bool {
+    matches!(
+        ty,
+        Ty::Named {
+            builtin: Some(BuiltinType::Option),
+            ..
+        }
+    )
+}
+
+/// Whether `pattern` denotes the `Option::None` variant. A bare `None` (no
+/// parens) parses as an *identifier* pattern, not a constructor; accept that
+/// form (in this Option-typed context an identifier spelled exactly `None` is
+/// the variant, never a fresh binding) as well as the rare zero-arg
+/// constructor spelling.
+fn is_none_pattern(pattern: &Pattern) -> bool {
+    match pattern {
+        Pattern::Identifier(name) => name == "None",
+        Pattern::Constructor { name, patterns } => name == "None" && patterns.is_empty(),
+        _ => false,
+    }
+}
+
+/// The spelling to show for a `Some(_)` sub-pattern, restricted to the shapes
+/// that render cleanly: a plain identifier or `_`.
+fn binding_name(pattern: &Pattern) -> Option<String> {
+    match pattern {
+        Pattern::Identifier(name) => Some(name.clone()),
+        Pattern::Wildcard => Some("_".to_string()),
+        _ => None,
+    }
+}
+
+/// Whether `expr` is a side-effect-free unit body: an empty block `{}`, a unit
+/// literal `()`, or a block whose only content is one trivial trailing
+/// expression (e.g. `{ () }`).
+fn is_trivial_body(expr: &Expr) -> bool {
+    match expr {
+        Expr::Tuple(items) => items.is_empty(),
+        Expr::Block(block) => {
+            block.stmts.is_empty()
+                && block
+                    .trailing_expr
+                    .as_ref()
+                    .is_none_or(|trailing| is_trivial_body(&trailing.0))
+        }
+        _ => false,
+    }
+}

--- a/hew-types/src/check/lints/redundant_else_after_return.rs
+++ b/hew-types/src/check/lints/redundant_else_after_return.rs
@@ -1,0 +1,170 @@
+//! The `redundant_else_after_return` lint.
+//!
+//! Flags an `if` whose then-branch unconditionally diverges (every control-flow
+//! path ends in `return` / `break` / `continue`, or a `!`-typed call such as
+//! `panic` / `exit`) yet still carries an `else`. When the then-branch can never
+//! fall through, the `else` adds nothing: its body can be dropped one level of
+//! indentation and run unconditionally after the `if`.
+//!
+//! ## Reusing the checker's divergence facts
+//!
+//! Rather than re-deriving which calls diverge, the lint reuses the type the
+//! checker already recorded for each expression: a diverging expression
+//! (expression-position `return`, a `panic` / `exit` call, a block/`if`/`match`
+//! all of whose arms diverge) is typed [`Ty::Never`]. Terminator *statements*
+//! (`return` / `break` / `continue`) are not expressions and carry no recorded
+//! type, so those are matched structurally. A block diverges exactly when its
+//! tail position — the trailing expression, else the final statement —
+//! diverges, with nested `if` / `match` requiring *every* branch to diverge.
+//!
+//! ## Precision over recall
+//!
+//! - Only fires when the then-branch diverges on *all* paths (a bare
+//!   `if c { return }` with no else, or a nested `if` without a sibling
+//!   diverging branch, never qualifies).
+//! - Skips `if let` / `while let` (the binding scope complicates the rewrite).
+//! - Skips an `else if` chain: flattening `} else if … {` into a bare statement
+//!   is not the clean de-indent this lint promises.
+//! - Considers the `if` only in statement position (`Stmt::If`) or block-tail
+//!   position (a trailing `Expr::If`), where dropping the `else` preserves
+//!   meaning. A value-position `if` feeding a `let` / argument is left alone.
+
+use hew_parser::ast::{Block, Expr, Span, Stmt};
+
+use crate::error::TypeError;
+use crate::ty::Ty;
+
+use super::{LintCtx, LintId, LintLevels, NodeVisitor};
+
+/// Entry point: walk `body` and flag every redundant-else `if`.
+pub(super) fn check(ctx: &LintCtx, levels: &LintLevels, body: &Block, out: &mut Vec<TypeError>) {
+    let mut visitor = RedundantElse {
+        ctx,
+        hits: Vec::new(),
+    };
+    super::walk_body(body, &mut visitor);
+    for span in visitor.hits {
+        ctx.emit(
+            levels,
+            LintId::RedundantElseAfterReturn,
+            &span,
+            "this `else` is redundant — the `if` branch always diverges".to_string(),
+            "drop the `else` and de-indent its body to run after the `if`".to_string(),
+            out,
+        );
+    }
+}
+
+struct RedundantElse<'a> {
+    ctx: &'a LintCtx<'a>,
+    hits: Vec<Span>,
+}
+
+impl NodeVisitor for RedundantElse<'_> {
+    fn visit_block(&mut self, block: &Block) {
+        // Statement-position ifs: the value is discarded, so dropping the else
+        // and running its body unconditionally is sound when the then branch
+        // diverges.
+        for (stmt, span) in &block.stmts {
+            if let Stmt::If {
+                then_block,
+                else_block: Some(else_block),
+                ..
+            } = stmt
+            {
+                // `else if` is not a clean de-indent; require a plain `else`.
+                if else_block.if_stmt.is_some() || else_block.block.is_none() {
+                    continue;
+                }
+                if block_always_diverges(self.ctx, then_block) {
+                    self.hits.push(span.clone());
+                }
+            }
+        }
+
+        // Block-tail if: the block's value is this if's value, but because the
+        // then branch diverges that value only ever comes from the else, so the
+        // de-indent (`else` body becomes the new block tail) preserves meaning.
+        if let Some(trailing) = &block.trailing_expr {
+            if let Expr::If {
+                then_block,
+                else_block: Some(else_expr),
+                ..
+            } = &trailing.0
+            {
+                // An `else if` chain surfaces as the else expression being
+                // itself an `if` / `if let`; skip it.
+                if matches!(else_expr.0, Expr::If { .. } | Expr::IfLet { .. }) {
+                    return;
+                }
+                if expr_always_diverges(self.ctx, &then_block.0, &then_block.1) {
+                    self.hits.push(trailing.1.clone());
+                }
+            }
+        }
+    }
+}
+
+/// Does executing `block` always leave via divergence (never fall off the end)?
+///
+/// Only the tail position decides this: a block falls through exactly when its
+/// trailing expression (or, lacking one, its final statement) falls through.
+fn block_always_diverges(ctx: &LintCtx, block: &Block) -> bool {
+    if let Some(trailing) = &block.trailing_expr {
+        return expr_always_diverges(ctx, &trailing.0, &trailing.1);
+    }
+    match block.stmts.last() {
+        Some((stmt, span)) => stmt_always_diverges(ctx, stmt, span),
+        None => false,
+    }
+}
+
+fn stmt_always_diverges(ctx: &LintCtx, stmt: &Stmt, _span: &Span) -> bool {
+    match stmt {
+        Stmt::Return(_) | Stmt::Break { .. } | Stmt::Continue { .. } => true,
+        Stmt::Expression((expr, span)) => expr_always_diverges(ctx, expr, span),
+        Stmt::If {
+            then_block,
+            else_block: Some(else_block),
+            ..
+        } => {
+            let else_div = if let Some(if_stmt) = &else_block.if_stmt {
+                stmt_always_diverges(ctx, &if_stmt.0, &if_stmt.1)
+            } else if let Some(block) = &else_block.block {
+                block_always_diverges(ctx, block)
+            } else {
+                false
+            };
+            block_always_diverges(ctx, then_block) && else_div
+        }
+        Stmt::IfLet {
+            body,
+            else_body: Some(else_body),
+            ..
+        } => block_always_diverges(ctx, body) && block_always_diverges(ctx, else_body),
+        Stmt::Match { arms, .. } => {
+            !arms.is_empty()
+                && arms
+                    .iter()
+                    .all(|arm| expr_always_diverges(ctx, &arm.body.0, &arm.body.1))
+        }
+        _ => false,
+    }
+}
+
+/// Whether the expression at `span` diverges on every path.
+///
+/// Reuses the checker's recorded [`Ty::Never`] (the result of its
+/// reachability/never-type analysis) for the call cases, descends structurally
+/// into a block / expression-position `return` so a then-branch that ends in a
+/// terminator *statement* (which carries no `Never` type of its own) is still
+/// recognised.
+fn expr_always_diverges(ctx: &LintCtx, expr: &Expr, span: &Span) -> bool {
+    match expr {
+        Expr::Return(_) => true,
+        Expr::Block(block) => block_always_diverges(ctx, block),
+        _ => ctx
+            .resolved_type_at(span)
+            .is_some_and(|ty| matches!(ty, Ty::Never)),
+    }
+}

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -7760,22 +7760,19 @@ impl Checker {
                             | Ty::Char
                     );
                     if is_copy_ty {
-                        self.warnings.push(crate::error::TypeError {
-                            severity: crate::error::Severity::Warning,
-                            kind: TypeErrorKind::StyleSuggestion,
-                            span: span.clone(),
-                            message: format!(
+                        let module = self.current_module.clone();
+                        self.emit_main_pass_lint(
+                            LintId::CloneOnCopy,
+                            span,
+                            module.as_deref(),
+                            format!(
                                 "cloning a Copy type `{}` is redundant; \
                                  this is equivalent to a plain copy",
                                 resolved.user_facing()
                             ),
-                            notes: vec![],
-                            suggestions: vec![
-                                "remove the `clone` — Copy types are duplicated automatically"
-                                    .to_string(),
-                            ],
-                            source_module: self.current_module.clone(),
-                        });
+                            "remove the `clone` — Copy types are duplicated automatically"
+                                .to_string(),
+                        );
                         self.record_method_call_rewrite(span, MethodCallRewrite::CopyCloneNoop);
                         return resolved;
                     }

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -877,6 +877,51 @@ impl Checker {
         }
     }
 
+    /// Emit a finding from a *main-pass* lint — one that runs inline during body
+    /// checking rather than in the post-inference [`run_lints`] sweep — through
+    /// the same level/suppression machinery the sweep uses.
+    ///
+    /// `module` is the module owning `span`; it locates the source text for
+    /// `// hew:allow(...)` resolution and tags the diagnostic. An in-source
+    /// directive is honoured first (it wins even over `Deny`), then the finding
+    /// is routed by the configured [`LintLevel`]: `Allow` drops it, `Warn`
+    /// pushes a warning, `Deny` pushes an error. This keeps migrated warnings
+    /// (`clone_on_copy`, `dead_code`) configurable and suppressible without
+    /// changing their default-`Warn` behaviour.
+    fn emit_main_pass_lint(
+        &mut self,
+        id: LintId,
+        span: &Span,
+        module: Option<&str>,
+        message: String,
+        suggestion: String,
+    ) {
+        if let Some(source) = self.lint_sources.source_for(module) {
+            if lints::directive_suppresses(source, span.start, id) {
+                return;
+            }
+        }
+        let severity = match self.lint_levels.level(id) {
+            LintLevel::Allow => return,
+            LintLevel::Warn => crate::error::Severity::Warning,
+            LintLevel::Deny => crate::error::Severity::Error,
+        };
+        let diag = TypeError {
+            severity,
+            kind: TypeErrorKind::Lint(id),
+            span: span.clone(),
+            message,
+            notes: Vec::new(),
+            suggestions: vec![suggestion],
+            source_module: module.map(str::to_string),
+        };
+        if severity == crate::error::Severity::Error {
+            self.errors.push(diag);
+        } else {
+            self.warnings.push(diag);
+        }
+    }
+
     fn classify_escapes_in_item(&mut self, item: &Item) {
         match item {
             Item::Function(fn_decl) => {

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -811,6 +811,19 @@ impl Checker {
                 .and_then(|mg| mg.modules.get(mod_id))
             {
                 module_idx += 1;
+                // Builtin/standard-library modules (`std::`, `hew::`,
+                // `ecosystem::`) ship with the compiler rather than the user's
+                // project, so lint findings inside them are noise the user
+                // cannot act on. Skip them — but only AFTER advancing
+                // `module_idx`, so span tagging for later user modules stays
+                // aligned with the checker's module indexing. Mirrors
+                // `is_builtin_module` in `hew-compile`.
+                if matches!(
+                    mod_id.path.first().map(String::as_str),
+                    Some("std" | "hew" | "ecosystem")
+                ) {
+                    continue;
+                }
                 let module_name = mod_id.path.join(".");
                 for (item, _) in &module.items {
                     self.lint_item(item, module_idx, Some(&module_name), levels, out);

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -33,7 +33,7 @@ mod expressions;
 mod generics;
 mod items;
 mod lints;
-pub use self::lints::{LintId, LintLevel, LintLevels, LintSources};
+pub use self::lints::{directive_suppresses, LintId, LintLevel, LintLevels, LintSources};
 mod methods;
 pub use self::methods::collection_dispatch_registry_for_tests;
 mod patterns;

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -5570,7 +5570,7 @@ fn main() {
     assert!(
         has(
             &default_out.warnings,
-            &TypeErrorKind::DeadCode,
+            &TypeErrorKind::Lint(LintId::DeadCode),
             "dead_helper"
         ),
         "default should warn dead code, got: {:?}",
@@ -5602,7 +5602,7 @@ fn main() {
     let repl_out = repl_checker.check_program(&parsed.program);
     let suppressed = [
         TypeErrorKind::UnusedImport,
-        TypeErrorKind::DeadCode,
+        TypeErrorKind::Lint(LintId::DeadCode),
         TypeErrorKind::UnusedVariable,
         TypeErrorKind::UnusedMut,
     ];
@@ -6810,6 +6810,599 @@ fn needless_range_loop_not_flagged_for_non_vec_collection() {
     );
 }
 
+// ---- M2 checker-stage lints ----
+
+/// Parse `source`, install it as the root lint source (so `// hew:allow(...)`
+/// resolves) and as the level for `id`, then type-check. A single helper serves
+/// every M2 lint because they all route through the shared registry.
+fn check_with_lint_level(source: &str, id: LintId, level: LintLevel) -> TypeCheckOutput {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "fixture should parse cleanly: {:?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let mut levels = LintLevels::from_defaults();
+    levels.set(id, level);
+    checker.set_lint_levels(levels);
+    let mut sources = LintSources::new();
+    sources.set_root(source.to_string());
+    checker.set_lint_sources(sources);
+    checker.check_program(&parsed.program)
+}
+
+// ---- redundant_else_after_return ----
+
+fn count_redundant_else(diags: &[TypeError]) -> usize {
+    diags
+        .iter()
+        .filter(|d| d.kind == TypeErrorKind::Lint(LintId::RedundantElseAfterReturn))
+        .count()
+}
+
+#[test]
+fn redundant_else_flags_return_then_else() {
+    let (errors, warnings) =
+        parse_and_check("fn f(c: bool) { if c { return; } else { let _ = 1; } }");
+    assert!(
+        errors.is_empty(),
+        "fixture should type-check, got: {errors:?}"
+    );
+    let hit = warnings
+        .iter()
+        .find(|w| w.kind == TypeErrorKind::Lint(LintId::RedundantElseAfterReturn))
+        .expect("expected a redundant_else_after_return warning");
+    assert_eq!(hit.kind.as_kind_str(), "redundant_else_after_return");
+    assert_eq!(hit.severity, crate::error::Severity::Warning);
+    assert!(
+        hit.suggestions.iter().any(|s| s.contains("de-indent")),
+        "suggestions: {:?}",
+        hit.suggestions
+    );
+}
+
+#[test]
+fn redundant_else_flags_break_in_loop() {
+    let (_, warnings) =
+        parse_and_check("fn f(c: bool) { loop { if c { break; } else { let _ = 1; } } }");
+    assert_eq!(
+        count_redundant_else(&warnings),
+        1,
+        "a diverging `break` then-branch with an else must fire, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn redundant_else_not_flagged_without_else() {
+    let (_, warnings) = parse_and_check("fn f(c: bool) { if c { return; } let _ = 1; }");
+    assert_eq!(
+        count_redundant_else(&warnings),
+        0,
+        "no else means nothing to de-indent, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn redundant_else_not_flagged_when_then_falls_through() {
+    let (_, warnings) =
+        parse_and_check("fn f(c: bool) { if c { let _ = 1; } else { let _ = 2; } }");
+    assert_eq!(
+        count_redundant_else(&warnings),
+        0,
+        "a then-branch that falls through keeps the else meaningful, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn redundant_else_not_flagged_for_else_if_chain() {
+    let (_, warnings) = parse_and_check(
+        "fn f(c: bool, d: bool) { if c { return; } else if d { let _ = 1; } else { let _ = 2; } }",
+    );
+    assert_eq!(
+        count_redundant_else(&warnings),
+        0,
+        "an else-if chain is not a clean de-indent, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn redundant_else_deny_routes_to_errors() {
+    let out = check_with_lint_level(
+        "fn f(c: bool) { if c { return; } else { let _ = 1; } }",
+        LintId::RedundantElseAfterReturn,
+        LintLevel::Deny,
+    );
+    assert_eq!(
+        count_redundant_else(&out.errors),
+        1,
+        "errors: {:?}",
+        out.errors
+    );
+    assert_eq!(count_redundant_else(&out.warnings), 0);
+}
+
+#[test]
+fn redundant_else_suppressed_by_directive() {
+    const SOURCE: &str = "fn f(c: bool) {\n    // hew:allow(redundant_else_after_return)\n    if c { return; } else { let _ = 1; }\n}";
+    let out = check_with_lint_level(SOURCE, LintId::RedundantElseAfterReturn, LintLevel::Warn);
+    assert_eq!(
+        count_redundant_else(&out.warnings),
+        0,
+        "a directive above the `if` must suppress, warnings: {:?}",
+        out.warnings
+    );
+}
+
+// ---- needless_match_to_if_let ----
+
+fn count_needless_match(diags: &[TypeError]) -> usize {
+    diags
+        .iter()
+        .filter(|d| d.kind == TypeErrorKind::Lint(LintId::NeedlessMatchToIfLet))
+        .count()
+}
+
+#[test]
+fn needless_match_flags_some_none_empty() {
+    let (errors, warnings) = parse_and_check(
+        "fn f(o: Option<i64>) { match o { Some(x) => { let _ = x; } None => {} } }",
+    );
+    assert!(
+        errors.is_empty(),
+        "fixture should type-check, got: {errors:?}"
+    );
+    let hit = warnings
+        .iter()
+        .find(|w| w.kind == TypeErrorKind::Lint(LintId::NeedlessMatchToIfLet))
+        .expect("expected a needless_match_to_if_let warning");
+    assert_eq!(hit.kind.as_kind_str(), "needless_match_to_if_let");
+    assert!(
+        hit.suggestions.iter().any(|s| s.contains("if let Some(x)")),
+        "suggestions: {:?}",
+        hit.suggestions
+    );
+}
+
+#[test]
+fn needless_match_flags_none_first() {
+    let (_, warnings) = parse_and_check(
+        "fn f(o: Option<i64>) { match o { None => {} Some(x) => { let _ = x; } } }",
+    );
+    assert_eq!(
+        count_needless_match(&warnings),
+        1,
+        "arm order must not matter, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn needless_match_not_flagged_when_none_does_work() {
+    let (_, warnings) = parse_and_check(
+        "fn f(o: Option<i64>) { match o { Some(x) => { let _ = x; } None => { let _ = 0; } } }",
+    );
+    assert_eq!(
+        count_needless_match(&warnings),
+        0,
+        "a None arm that does work is not an `if let`, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn needless_match_not_flagged_with_guard() {
+    let (_, warnings) = parse_and_check(
+        "fn f(o: Option<i64>) { match o { Some(x) if x > 0 => { let _ = x; } None => {} _ => {} } }",
+    );
+    assert_eq!(
+        count_needless_match(&warnings),
+        0,
+        "a guarded arm disqualifies the rewrite, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn needless_match_not_flagged_in_value_position() {
+    let (_, warnings) = parse_and_check(
+        "fn f(o: Option<i64>) -> i64 { let y = match o { Some(x) => x, None => 0 }; y }",
+    );
+    assert_eq!(
+        count_needless_match(&warnings),
+        0,
+        "a match feeding a `let` is in value position, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn needless_match_deny_routes_to_errors() {
+    let out = check_with_lint_level(
+        "fn f(o: Option<i64>) { match o { Some(x) => { let _ = x; } None => {} } }",
+        LintId::NeedlessMatchToIfLet,
+        LintLevel::Deny,
+    );
+    assert_eq!(
+        count_needless_match(&out.errors),
+        1,
+        "errors: {:?}",
+        out.errors
+    );
+    assert_eq!(count_needless_match(&out.warnings), 0);
+}
+
+#[test]
+fn needless_match_suppressed_by_directive() {
+    const SOURCE: &str = "fn f(o: Option<i64>) {\n    // hew:allow(needless_match_to_if_let)\n    match o { Some(x) => { let _ = x; } None => {} }\n}";
+    let out = check_with_lint_level(SOURCE, LintId::NeedlessMatchToIfLet, LintLevel::Warn);
+    assert_eq!(
+        count_needless_match(&out.warnings),
+        0,
+        "a directive above the match must suppress, warnings: {:?}",
+        out.warnings
+    );
+}
+
+// ---- len_zero_comparison ----
+
+fn count_len_zero(diags: &[TypeError]) -> usize {
+    diags
+        .iter()
+        .filter(|d| d.kind == TypeErrorKind::Lint(LintId::LenZeroComparison))
+        .count()
+}
+
+#[test]
+fn len_zero_flags_eq_zero_as_is_empty() {
+    let (errors, warnings) = parse_and_check("fn f(xs: Vec<i64>) -> bool { xs.len() == 0 }");
+    assert!(
+        errors.is_empty(),
+        "fixture should type-check, got: {errors:?}"
+    );
+    let hit = warnings
+        .iter()
+        .find(|w| w.kind == TypeErrorKind::Lint(LintId::LenZeroComparison))
+        .expect("expected a len_zero_comparison warning");
+    assert_eq!(hit.kind.as_kind_str(), "len_zero_comparison");
+    assert!(
+        hit.suggestions.iter().any(|s| s.contains("xs.is_empty()")),
+        "suggestions: {:?}",
+        hit.suggestions
+    );
+}
+
+#[test]
+fn len_zero_flags_gt_zero_as_not_empty() {
+    let (_, warnings) = parse_and_check("fn f(xs: Vec<i64>) -> bool { xs.len() > 0 }");
+    let hit = warnings
+        .iter()
+        .find(|w| w.kind == TypeErrorKind::Lint(LintId::LenZeroComparison))
+        .expect("len() > 0 should fire");
+    assert!(
+        hit.suggestions.iter().any(|s| s.contains("!xs.is_empty()")),
+        "suggestions: {:?}",
+        hit.suggestions
+    );
+}
+
+#[test]
+fn len_zero_flags_literal_on_left() {
+    let (_, warnings) = parse_and_check("fn f(xs: Vec<i64>) -> bool { 0 == xs.len() }");
+    assert_eq!(
+        count_len_zero(&warnings),
+        1,
+        "operand order must not matter, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn len_zero_flags_ge_one_as_not_empty() {
+    let (_, warnings) = parse_and_check("fn f(xs: Vec<i64>) -> bool { xs.len() >= 1 }");
+    assert_eq!(
+        count_len_zero(&warnings),
+        1,
+        "len() >= 1 is a non-emptiness test, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn len_zero_not_flagged_for_eq_one() {
+    let (_, warnings) = parse_and_check("fn f(xs: Vec<i64>) -> bool { xs.len() == 1 }");
+    assert_eq!(
+        count_len_zero(&warnings),
+        0,
+        "len() == 1 is not an emptiness test, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn len_zero_not_flagged_for_gt_one() {
+    let (_, warnings) = parse_and_check("fn f(xs: Vec<i64>) -> bool { xs.len() > 1 }");
+    assert_eq!(
+        count_len_zero(&warnings),
+        0,
+        "len() > 1 is not an emptiness test, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn len_zero_not_flagged_for_len_field() {
+    // `len` is a record field here, not the collection method — the rewrite to
+    // `is_empty()` does not apply.
+    let (errors, warnings) =
+        parse_and_check("type Buf { len: i64 }\nfn f(b: Buf) -> bool { b.len == 0 }");
+    assert!(
+        errors.is_empty(),
+        "fixture should type-check, got: {errors:?}"
+    );
+    assert_eq!(
+        count_len_zero(&warnings),
+        0,
+        "a `len` field access must not fire, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn len_zero_flags_string_with_stdlib() {
+    let (errors, warnings) =
+        parse_and_check_with_stdlib("fn f(s: string) -> bool { s.len() == 0 }");
+    assert!(
+        errors.is_empty(),
+        "fixture should type-check, got: {errors:?}"
+    );
+    assert_eq!(
+        count_len_zero(&warnings),
+        1,
+        "string exposes is_empty, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn len_zero_deny_routes_to_errors() {
+    let out = check_with_lint_level(
+        "fn f(xs: Vec<i64>) -> bool { xs.len() == 0 }",
+        LintId::LenZeroComparison,
+        LintLevel::Deny,
+    );
+    assert_eq!(count_len_zero(&out.errors), 1, "errors: {:?}", out.errors);
+    assert_eq!(count_len_zero(&out.warnings), 0);
+}
+
+#[test]
+fn len_zero_suppressed_by_directive() {
+    const SOURCE: &str =
+        "fn f(xs: Vec<i64>) -> bool {\n    // hew:allow(len_zero_comparison)\n    xs.len() == 0\n}";
+    let out = check_with_lint_level(SOURCE, LintId::LenZeroComparison, LintLevel::Warn);
+    assert_eq!(
+        count_len_zero(&out.warnings),
+        0,
+        "a directive above the comparison must suppress, warnings: {:?}",
+        out.warnings
+    );
+}
+
+// ---- needless_bool ----
+
+fn count_needless_bool(diags: &[TypeError]) -> usize {
+    diags
+        .iter()
+        .filter(|d| d.kind == TypeErrorKind::Lint(LintId::NeedlessBool))
+        .count()
+}
+
+#[test]
+fn needless_bool_flags_true_false() {
+    let (errors, warnings) =
+        parse_and_check("fn f(c: bool) -> bool { if c { true } else { false } }");
+    assert!(
+        errors.is_empty(),
+        "fixture should type-check, got: {errors:?}"
+    );
+    let hit = warnings
+        .iter()
+        .find(|w| w.kind == TypeErrorKind::Lint(LintId::NeedlessBool))
+        .expect("expected a needless_bool warning");
+    assert_eq!(hit.kind.as_kind_str(), "needless_bool");
+    assert!(
+        hit.suggestions.iter().any(|s| s.contains("condition")),
+        "suggestions: {:?}",
+        hit.suggestions
+    );
+}
+
+#[test]
+fn needless_bool_flags_false_true() {
+    let (_, warnings) = parse_and_check("fn f(c: bool) -> bool { if c { false } else { true } }");
+    let hit = warnings
+        .iter()
+        .find(|w| w.kind == TypeErrorKind::Lint(LintId::NeedlessBool))
+        .expect("inverted polarity should fire");
+    assert!(
+        hit.suggestions.iter().any(|s| s.contains("negated")),
+        "suggestions: {:?}",
+        hit.suggestions
+    );
+}
+
+#[test]
+fn needless_bool_not_flagged_for_same_polarity() {
+    let (_, warnings) = parse_and_check("fn f(c: bool) -> bool { if c { true } else { true } }");
+    assert_eq!(
+        count_needless_bool(&warnings),
+        0,
+        "matching branches are a constant, not needless_bool, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn needless_bool_not_flagged_with_extra_statement() {
+    let (_, warnings) =
+        parse_and_check("fn f(c: bool) -> bool { if c { let _ = 1; true } else { false } }");
+    assert_eq!(
+        count_needless_bool(&warnings),
+        0,
+        "an extra statement in a branch disqualifies it, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn needless_bool_not_flagged_for_non_bool_branches() {
+    let (_, warnings) = parse_and_check("fn f(c: bool) -> i64 { if c { 1 } else { 0 } }");
+    assert_eq!(
+        count_needless_bool(&warnings),
+        0,
+        "integer branches are not boolean literals, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn needless_bool_not_flagged_for_else_if() {
+    // The outer `if`'s else is an `else if`, so the outer is never collapsed;
+    // the inner `if d { false } else { false }` is the same polarity, so it is
+    // not collapsed either. Net: an else-if chain produces no suggestion.
+    let (_, warnings) = parse_and_check(
+        "fn f(c: bool, d: bool) -> bool { if c { true } else if d { false } else { false } }",
+    );
+    assert_eq!(
+        count_needless_bool(&warnings),
+        0,
+        "an else-if chain is not the two-branch shape, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn needless_bool_deny_routes_to_errors() {
+    let out = check_with_lint_level(
+        "fn f(c: bool) -> bool { if c { true } else { false } }",
+        LintId::NeedlessBool,
+        LintLevel::Deny,
+    );
+    assert_eq!(
+        count_needless_bool(&out.errors),
+        1,
+        "errors: {:?}",
+        out.errors
+    );
+    assert_eq!(count_needless_bool(&out.warnings), 0);
+}
+
+#[test]
+fn needless_bool_suppressed_by_directive() {
+    const SOURCE: &str =
+        "fn f(c: bool) -> bool {\n    // hew:allow(needless_bool)\n    if c { true } else { false }\n}";
+    let out = check_with_lint_level(SOURCE, LintId::NeedlessBool, LintLevel::Warn);
+    assert_eq!(
+        count_needless_bool(&out.warnings),
+        0,
+        "a directive above the `if` must suppress, warnings: {:?}",
+        out.warnings
+    );
+}
+
+// ---- migrated warnings: clone_on_copy ----
+
+fn count_clone_on_copy(diags: &[TypeError]) -> usize {
+    diags
+        .iter()
+        .filter(|d| d.kind == TypeErrorKind::Lint(LintId::CloneOnCopy))
+        .count()
+}
+
+#[test]
+fn clone_on_copy_warns_by_default() {
+    let (errors, warnings) = parse_and_check("fn f(x: i64) { let _ = x.clone(); }");
+    assert!(
+        errors.is_empty(),
+        "fixture should type-check, got: {errors:?}"
+    );
+    let hit = warnings
+        .iter()
+        .find(|w| w.kind == TypeErrorKind::Lint(LintId::CloneOnCopy))
+        .expect("clone on a Copy type should warn by default");
+    assert_eq!(hit.kind.as_kind_str(), "clone_on_copy");
+    assert_eq!(hit.severity, crate::error::Severity::Warning);
+}
+
+#[test]
+fn clone_on_copy_suppressed_by_allow() {
+    let out = check_with_lint_level(
+        "fn f(x: i64) { let _ = x.clone(); }",
+        LintId::CloneOnCopy,
+        LintLevel::Allow,
+    );
+    assert_eq!(count_clone_on_copy(&out.warnings), 0);
+    assert_eq!(count_clone_on_copy(&out.errors), 0);
+}
+
+#[test]
+fn clone_on_copy_deny_routes_to_errors() {
+    let out = check_with_lint_level(
+        "fn f(x: i64) { let _ = x.clone(); }",
+        LintId::CloneOnCopy,
+        LintLevel::Deny,
+    );
+    assert_eq!(
+        count_clone_on_copy(&out.errors),
+        1,
+        "errors: {:?}",
+        out.errors
+    );
+    assert_eq!(count_clone_on_copy(&out.warnings), 0);
+}
+
+#[test]
+fn clone_on_copy_suppressed_by_directive() {
+    const SOURCE: &str =
+        "fn f(x: i64) {\n    // hew:allow(clone_on_copy)\n    let _ = x.clone();\n}";
+    let out = check_with_lint_level(SOURCE, LintId::CloneOnCopy, LintLevel::Warn);
+    assert_eq!(
+        count_clone_on_copy(&out.warnings),
+        0,
+        "a directive above the clone must suppress, warnings: {:?}",
+        out.warnings
+    );
+}
+
+// ---- migrated warnings: dead_code ----
+
+fn count_dead_code(diags: &[TypeError]) -> usize {
+    diags
+        .iter()
+        .filter(|d| d.kind == TypeErrorKind::Lint(LintId::DeadCode))
+        .count()
+}
+
+#[test]
+fn dead_code_deny_routes_to_errors() {
+    let out = check_with_lint_level(
+        "fn helper() {}\nfn main() {}",
+        LintId::DeadCode,
+        LintLevel::Deny,
+    );
+    assert_eq!(count_dead_code(&out.errors), 1, "errors: {:?}", out.errors);
+    assert_eq!(count_dead_code(&out.warnings), 0);
+}
+
+#[test]
+fn dead_code_suppressed_by_allow() {
+    let out = check_with_lint_level(
+        "fn helper() {}\nfn main() {}",
+        LintId::DeadCode,
+        LintLevel::Allow,
+    );
+    assert_eq!(count_dead_code(&out.warnings), 0);
+    assert_eq!(count_dead_code(&out.errors), 0);
+}
+
+#[test]
+fn dead_code_suppressed_by_directive() {
+    const SOURCE: &str = "// hew:allow(dead_code)\nfn helper() {}\nfn main() {}";
+    let out = check_with_lint_level(SOURCE, LintId::DeadCode, LintLevel::Warn);
+    assert_eq!(
+        count_dead_code(&out.warnings),
+        0,
+        "a directive above the dead function must suppress, warnings: {:?}",
+        out.warnings
+    );
+}
+
 #[test]
 fn unused_variable_has_correct_kind() {
     let (_, warnings) = parse_and_check("fn main() { let unused = 42; }");
@@ -7102,7 +7695,8 @@ fn warn_dead_code_unused_function() {
         output
             .warnings
             .iter()
-            .any(|w| w.kind == TypeErrorKind::DeadCode && w.message.contains("unused_helper")),
+            .any(|w| w.kind == TypeErrorKind::Lint(LintId::DeadCode)
+                && w.message.contains("unused_helper")),
         "expected dead code warning for unused_helper, got: {:?}",
         output.warnings
     );
@@ -7118,7 +7712,7 @@ fn no_warn_dead_code_main() {
         !output
             .warnings
             .iter()
-            .any(|w| w.kind == TypeErrorKind::DeadCode),
+            .any(|w| w.kind == TypeErrorKind::Lint(LintId::DeadCode)),
         "should not warn about main: {:?}",
         output.warnings
     );
@@ -7131,10 +7725,9 @@ fn no_warn_dead_code_called_function() {
     let mut checker = Checker::new(ModuleRegistry::new(vec![]));
     let output = checker.check_program(&result.program);
     assert!(
-        !output
-            .warnings
-            .iter()
-            .any(|w| w.kind == TypeErrorKind::DeadCode && w.message.contains("helper")),
+        !output.warnings.iter().any(
+            |w| w.kind == TypeErrorKind::Lint(LintId::DeadCode) && w.message.contains("helper")
+        ),
         "should not warn about called function: {:?}",
         output.warnings
     );
@@ -7150,7 +7743,7 @@ fn no_warn_dead_code_underscore_prefix() {
         !output
             .warnings
             .iter()
-            .any(|w| w.kind == TypeErrorKind::DeadCode),
+            .any(|w| w.kind == TypeErrorKind::Lint(LintId::DeadCode)),
         "should not warn for _ prefixed functions: {:?}",
         output.warnings
     );
@@ -7180,7 +7773,7 @@ w.compute(10);
         !output
             .warnings
             .iter()
-            .any(|w| w.kind == TypeErrorKind::DeadCode && w.message.contains("fib")),
+            .any(|w| w.kind == TypeErrorKind::Lint(LintId::DeadCode) && w.message.contains("fib")),
         "should not warn about function called from actor receive fn: {:?}",
         output.warnings
     );
@@ -8382,9 +8975,9 @@ fn no_warn_dead_code_function_referenced_as_value() {
     let (_, warnings) =
         parse_and_check("fn helper() -> i32 { 42 } fn main() { let f = helper; println(f); }");
     assert!(
-        !warnings
-            .iter()
-            .any(|w| w.kind == TypeErrorKind::DeadCode && w.message.contains("helper")),
+        !warnings.iter().any(
+            |w| w.kind == TypeErrorKind::Lint(LintId::DeadCode) && w.message.contains("helper")
+        ),
         "function referenced as value should not get dead code warning, got: {warnings:?}"
     );
 }
@@ -8396,7 +8989,7 @@ fn warn_dead_code_self_recursive_function() {
     assert!(
         warnings
             .iter()
-            .any(|w| w.kind == TypeErrorKind::DeadCode && w.message.contains("rec")),
+            .any(|w| w.kind == TypeErrorKind::Lint(LintId::DeadCode) && w.message.contains("rec")),
         "self-recursive unreachable function should get dead code warning, got: {warnings:?}"
     );
 }

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -585,8 +585,6 @@ pub enum TypeErrorKind {
     UnreachableCode,
     /// A variable binding shadows a binding from an outer scope
     Shadowing,
-    /// A function is defined but never called
-    DeadCode,
     /// Impl block violates the orphan rule: neither the type nor the trait is local
     OrphanImpl,
     /// Feature is not available on the selected compilation target
@@ -1190,7 +1188,6 @@ impl TypeErrorKind {
             Self::RedundantIs => "RedundantIs",
             Self::UnreachableCode => "UnreachableCode",
             Self::Shadowing => "Shadowing",
-            Self::DeadCode => "DeadCode",
             Self::OrphanImpl => "OrphanImpl",
             Self::PlatformLimitation => "PlatformLimitation",
             Self::OnUpgradeNotYetWired => "OnUpgradeNotYetWired",

--- a/hew-types/src/lib.rs
+++ b/hew-types/src/lib.rs
@@ -37,18 +37,19 @@ pub use actor_protocol::{
 };
 pub use builtin_type::{builtin_types, lookup_builtin_type, BuiltinType, BuiltinTypeInfo};
 pub use check::{
-    builtin_function_names, ActorMethodKind, ActorSendAliasing, ActorSendCopyReason,
-    ActorStateGuard, ArmResolution, AssignTargetKind, AssignTargetShape, Bound, CallAbiHint,
-    CaptureModeOrigin, Checker, ChildKind, ChildSlot, ClosureCaptureFact, ClosureCaptureMode,
-    ClosureEscapeFact, ClosureEscapeKind, ClosureEscapeRule, DynAssocBinding, DynCoercion,
-    DynMethodCall, DynVtableEntry, DynVtableKey, ExecutionContextReader, FnSig, HashMapMethod,
-    HashSetMethod, ImplDef, ImplId, ImplRegistry, LintId, LintLevel, LintLevels, LintSources,
-    LookupError, MachineMethodKind, MathGenericOp, MethodCallReceiverKind, MethodCallRewrite,
-    MethodTarget, MethodTargetFamily, NumericMethodFamily, NumericMethodLowering, NumericMethodOp,
-    NumericSignedness, NumericWidth, OptionResultMethod, PatternKind, PayloadBinding,
-    PayloadVariantPattern, ResolvedCall, RuntimeAbi, SpanKey, TyPattern, TypeCheckOutput,
-    VariantDef, VariantMatch, VecHigherOrderOp, VecMethod, WidthCastKind, WidthCastLowering,
-    WireCodecDirection, WireFieldLayout, WireLayoutEntry, WireLayoutTable,
+    builtin_function_names, directive_suppresses, ActorMethodKind, ActorSendAliasing,
+    ActorSendCopyReason, ActorStateGuard, ArmResolution, AssignTargetKind, AssignTargetShape,
+    Bound, CallAbiHint, CaptureModeOrigin, Checker, ChildKind, ChildSlot, ClosureCaptureFact,
+    ClosureCaptureMode, ClosureEscapeFact, ClosureEscapeKind, ClosureEscapeRule, DynAssocBinding,
+    DynCoercion, DynMethodCall, DynVtableEntry, DynVtableKey, ExecutionContextReader, FnSig,
+    HashMapMethod, HashSetMethod, ImplDef, ImplId, ImplRegistry, LintId, LintLevel, LintLevels,
+    LintSources, LookupError, MachineMethodKind, MathGenericOp, MethodCallReceiverKind,
+    MethodCallRewrite, MethodTarget, MethodTargetFamily, NumericMethodFamily,
+    NumericMethodLowering, NumericMethodOp, NumericSignedness, NumericWidth, OptionResultMethod,
+    PatternKind, PayloadBinding, PayloadVariantPattern, ResolvedCall, RuntimeAbi, SpanKey,
+    TyPattern, TypeCheckOutput, VariantDef, VariantMatch, VecHigherOrderOp, VecMethod,
+    WidthCastKind, WidthCastLowering, WireCodecDirection, WireFieldLayout, WireLayoutEntry,
+    WireLayoutTable,
 };
 pub use error::TypeError;
 pub use extern_symbol::{


### PR DESCRIPTION
## Summary

Expands the semantic lint pass (introduced in #2174 with `needless_range_loop`) with a batch of idiom lints in the type checker and a new MIR-level dataflow lint. The lints reuse the existing infrastructure: each is configurable via the `-A`/`-W`/`-D` flags and suppressible with an in-source `// hew:allow(<lint>)` directive.

**Checker lints (`hew-types`)** — type-aware idiom checks on the typed AST, built on a shared exhaustive `NodeVisitor`:

- **`redundant_else_after_return`** — an `if` whose then-branch diverges on all paths (`return`/`break`/`continue` or a `!`-typed call) and still has an `else`; the `else` can be de-indented. Skips value position, `if let`, and non-flattenable `else if` chains.
- **`needless_match_to_if_let`** — a two-arm `Option` match where one arm binds `Some(x)` and the other is a trivial `None => {}`; suggests `if let Some(x) = …`. Skips guards, value position, and non-trivial arms.
- **`len_zero_comparison`** — `xs.len() == 0` → `xs.is_empty()` and `xs.len() != 0` / `> 0` / `>= 1` → `!xs.is_empty()`, where the receiver type actually has `is_empty()`. The precise, type-checked companion to the syntactic ast-grep rule.
- **`needless_bool`** — `if c { true } else { false }` → `c` (and the negated form).

It also **migrates the existing clone-on-Copy and dead-code warnings onto the `LintId` registry**, so they are now configurable and suppressible like every other lint (default level unchanged — they still warn by default). The now-unproduced `TypeErrorKind::DeadCode` variant is retired.

**MIR dataflow lint (`hew-mir`)**:

- A backward **liveness** analysis (reusing the move-checker's CFG and exhaustive read/write authorities) powers **`dead_store`** — flags an assignment to a user-named, no-drop **scalar** local whose value is never read before being overwritten or going out of scope. The no-drop-scalar restriction keeps the lint sound on pre-drop-elaboration MIR without any drop reasoning. It is surfaced through the CLI (`hew check`/`build`/`run`/`compile`) via a parallel `lint_warnings` channel that leaves the hard-error MIR diagnostic path untouched; warnings honor the lint levels and `// hew:allow`, and `-D` fails the build.

## Verification

- `cargo test -p hew-types` — 2500 passed
- `cargo test -p hew-mir` — 776 passed (incl. the new `liveness` suite)
- `cargo test -p hew-cli --test lint_pass_e2e` — 21 passed (CLI surfacing, level routing, suppression, fail-closed on unknown lints)
- `cargo test -p hew-lsp` — 274 passed (dead-code `UNNECESSARY` tag preserved through the migration)
- `cargo clippy --workspace --tests -- -D warnings` and `cargo fmt --all -- --check` — clean

Precision is covered by paired positive/negative fixtures for every lint (e.g. `for i in 0..n` does not trip `dead_store`; the lints do not fire inside standard-library source reached by an implicit import).

## Out of scope / deferred

- **`clean_counter`** (dead loop-counter detection) needs faint-variable / strong-liveness analysis to distinguish a dead accumulator from a legitimate loop counter (and to handle checked-arithmetic overflow branches) — tracked in #2178. It is intentionally **not** registered, so `-D clean_counter` fails closed as an unknown lint rather than silently no-opping.
- **Editor/web surfacing of MIR lints** — the LSP and wasm front ends stop at HIR and do not lower to MIR, so `dead_store` surfaces only through the CLI for now. Adding a MIR stage to those surfaces is tracked in #2176.
