### PR TITLE
feat(iter): implement Filter/Take/Skip::next via var-self write-back

### DIFF
--- a/std/iter.hew
+++ b/std/iter.hew
@@ -83,24 +83,40 @@ pub type Filter<I, A> {
 
 impl<I, A> Iterator for Filter<I, A> where I: Iterator<Item = A> {
     type Item = A;
-    fn next(it: Filter<I, A>) -> Option<A> {
+    fn next(var self) -> Option<A> {
 
-        // DEFERRED — fail loud, not silent. A correct `Filter::next` must
-        // pump `it.iter.next()` in a loop, returning `Some(x)` for the
-        // first `x` where `pred(x)` is true and `None` once the inner
-        // iterator is exhausted. Returning `None` on the first rejected
-        // item (a previous shape of this body) silently drops every
-        // non-matching prefix and makes the filter look empty.
+        // Route-B multi-pump loop. Q296/Q297 premise falsified by q004
+        // (commit 60ea6b5a); see Map::next for the proven model.
         //
-        // Under the mutable-receiver `fn next(var self)` shape, `self.iter`
-        // is moved on the first inner-`next()` call inside one invocation,
-        // so a multi-call loop cannot be written without either (a) a
-        // shared-state cell that survives the move, or (b) threading the
-        // residual inner iterator out through the return shape. Neither
-        // primitive exists on the substrate yet.
-        // Tracked: var-self write-back, Q297 (lazy wrapper substrate), v06-followups.md
-        panic("Filter::next is unimplemented: deferred iterator wrapper substrate cannot yet loop over `self.iter.next()` to skip rejected items under the current substrate. See std/iter.hew Filter<I,A> doc-comment and v06-followups.md (iterator-foundation lane).");
-        None
+        // `self.iter` is moved into `inner` so the inner iterator's
+        // `next(var self)` write-back lands on a mutable binding receiver.
+        // `self.iter` is written back after the loop so `var self`'s own
+        // write-back persists the cursor across calls.
+        //
+        // `(self.pred)(x)` is a Read borrow of `x`; `x` is still owned
+        // after the call (`by-value-heap-params-are-borrows`). On the
+        // accept path `Some(x)` transfers ownership into `found`. On the
+        // reject path `x` falls out of scope at the end of the `Some` arm
+        // body and is dropped exactly once by RAII
+        // (`drop-allowset-from-value-flow`).
+        var inner = self.iter;
+        var found: Option<A> = None;
+        loop {
+            match inner.next() {
+                Some(x) => {
+                    if (self.pred)(x) {
+                        found = Some(x);
+                        break;
+                    }
+                    // x rejected: falls out of scope here, dropped exactly once
+                },
+                None => {
+                    break;
+                },
+            }
+        }
+        self.iter = inner;
+        found
     }
 }
 
@@ -113,25 +129,27 @@ pub type Take<I> {
 
 impl<I, A> Iterator for Take<I> where I: Iterator<Item = A> {
     type Item = A;
-    fn next(it: Take<I>) -> Option<A> {
+    fn next(var self) -> Option<A> {
 
-        // DEFERRED — fail loud, not silent. A correct `Take::next` must
-        // decrement `remaining` each yield so the adapter actually caps
-        // the inner stream at `n` items. The previous body
-        // (`if remaining <= 0 { None } else { it.iter.next() }`) never
-        // decremented and let `Take` pass every inner item through
-        // forever.
+        // Route-B single-pump + quota decrement. Q296/Q297 premise
+        // falsified by q004 (commit 60ea6b5a); see Map::next for the
+        // proven model and VecIter for the field-store write-back precedent
+        // (`self.idx = self.idx + 1` persists across calls via the same
+        // var-self mechanism).
         //
-        // Q296=B (record-field mutation under a `var` binding) just landed
-        // at 5a1f3764, but it does not compose with the Q001-locked
-        // mutable-receiver `fn next(var self)` shape: `self` is threaded through every
-        // call, so any field-write to `self.remaining` is lost when the
-        // function returns. The remaining-counter has to be carried out
-        // through the return shape (or held in a shared cell); neither
-        // primitive exists yet.
-        // Tracked: var-self write-back, Q296=B (record-field mutation), Q297 (lazy wrapper substrate), v06-followups.md
-        panic("Take::next is unimplemented: deferred iterator wrapper substrate cannot yet persist a decremented `remaining` across calls under the current substrate. See std/iter.hew Take<I> doc-comment and v06-followups.md (iterator-foundation lane).");
-        None
+        // Guard on `remaining` first: once the quota is exhausted the
+        // adapter is transparent-None to all subsequent callers.
+        if self.remaining <= 0 {
+            return None;
+        }
+        var inner = self.iter;
+        let result = match inner.next() {
+            Some(x) => Some(x),
+            None => None,
+        };
+        self.iter = inner;
+        self.remaining = self.remaining - 1;
+        result
     }
 }
 
@@ -144,23 +162,41 @@ pub type Skip<I> {
 
 impl<I, A> Iterator for Skip<I> where I: Iterator<Item = A> {
     type Item = A;
-    fn next(it: Skip<I>) -> Option<A> {
+    fn next(var self) -> Option<A> {
 
-        // DEFERRED — fail loud, not silent. A correct `Skip::next` must
-        // consume `remaining` items from `it.iter` (looping on inner
-        // `next()` until either `remaining == 0` or the inner exhausts)
-        // before yielding. The previous body just forwarded `it.iter
-        // .next()` and ignored `remaining` entirely, so `Skip` had no
-        // observable effect.
+        // Route-B burn-loop then yield. Q296/Q297 premise falsified by
+        // q004 (commit 60ea6b5a); see fold/count/collect for the proven
+        // multi-pump loop model.
         //
-        // Same substrate gap as `Filter::next` and `Take::next`: the
-        // mutable-receiver `fn next(var self)` shape threads `self.iter` on
-        // the first inner call, so a multi-call skip loop is not
-        // expressible without a shared-state cell or a return-shape
-        // change.
-        // Tracked: var-self write-back, Q297 (lazy wrapper substrate), v06-followups.md
-        panic("Skip::next is unimplemented: deferred iterator wrapper substrate cannot yet loop over `self.iter.next()` to drop the skipped prefix under the current substrate. See std/iter.hew Skip<I> doc-comment and v06-followups.md (iterator-foundation lane).");
-        None
+        // On the first call (remaining > 0), the burn loop discards the
+        // leading `remaining` items from the inner stream. Once remaining
+        // reaches 0 the burn loop exits immediately on every subsequent
+        // call and goes straight to the yield pump.
+        //
+        // `self.iter` is moved into `inner` once; both the burn path and
+        // the yield pump write it back before returning
+        // (`raii-null-after-move`). The `self.remaining` decrement inside
+        // the burn loop is a plain field-store write on `var self`; the
+        // var-self write-back persists it across calls (same mechanism as
+        // VecIter's `self.idx`).
+        var inner = self.iter;
+        loop {
+            if self.remaining <= 0 {
+                break;
+            }
+            match inner.next() {
+                Some(_) => {
+                    self.remaining = self.remaining - 1;
+                },
+                None => {
+                    self.iter = inner;
+                    return None;
+                },
+            }
+        }
+        let result = inner.next();
+        self.iter = inner;
+        result
     }
 }
 

--- a/tests/vertical-slice/accept/iter_filter_basic_run.hew
+++ b/tests/vertical-slice/accept/iter_filter_basic_run.hew
@@ -1,0 +1,114 @@
+//! Runnable end-to-end fixture for the lazy `Filter` adapter.
+//!
+//! Exercises the Route-B `Filter::next` body: multi-pump loop that
+//! skips rejected items and writes the inner cursor back through
+//! `var self` on every exit path. The inner item type `A` projects
+//! to `i64` via the where-clause bound so every type parameter pins
+//! to a concrete type at the call site.
+//!
+//! Inlined and fully monomorphised: cross-module generic instantiation
+//! of `std::iter` does not yet lower through MIR (a separate backend
+//! lane), so the adapter types are defined locally.
+//!
+//! Expected exit code: 7 — sum of items in Countdown{n:4} passing
+//! the predicate `x > 2`: [4, 3]. Any internal mismatch returns a
+//! distinct diagnostic code (101/102) so a regression is legible.
+
+type Countdown {
+    n: i64;
+}
+
+impl Iterator for Countdown {
+    type Item = i64;
+    /// Yield `n, n-1, …, 1` then `None`; advance the cursor in place.
+    fn next(var self) -> Option<i64> {
+        if self.n <= 0 {
+            None
+        } else {
+            let cur = self.n;
+            self.n = self.n - 1;
+            Some(cur)
+        }
+    }
+}
+
+type Filter<I, A> {
+    iter: I;
+    pred: fn(A) -> bool;
+}
+
+impl<I, A> Iterator for Filter<I, A> where I: Iterator<Item = A> {
+    type Item = A;
+    /// Multi-pump loop: advance `inner` until the predicate accepts an
+    /// item or the inner stream exhausts. The inner iterator is moved into
+    /// a `var` local so its write-back lands on a mutable binding receiver;
+    /// `self.iter = inner` is written after the loop so `var self`'s
+    /// own write-back persists the cursor across calls.
+    fn next(var self) -> Option<A> {
+        var inner = self.iter;
+        var found: Option<A> = None;
+        loop {
+            match inner.next() {
+                Some(x) => {
+                    if (self.pred)(x) {
+                        found = Some(x);
+                        break;
+                    }
+                    // x rejected; falls out of scope here, dropped exactly once
+                },
+                None => {
+                    break;
+                },
+            }
+        }
+        self.iter = inner;
+        found
+    }
+}
+
+/// Construct a lazy `Filter` adapter (mirrors `std::iter::filter`).
+fn mk_filter<I, A>(it: I, pred: fn(A) -> bool) -> Filter<I, A>
+where
+    I: Iterator<Item = A>,
+{
+    Filter { iter: it, pred: pred }
+}
+
+/// Left-fold a fixed-`i64` iterator (mirrors `std::iter::fold`).
+fn fold_i64<I>(it: I, init: i64, f: fn(i64, i64) -> i64) -> i64
+where
+    I: Iterator<Item = i64>,
+{
+    var acc = init;
+    var iter = it;
+    loop {
+        match iter.next() {
+            Some(x) => {
+                acc = f(acc, x);
+            },
+            None => {
+                break;
+            },
+        }
+    }
+    acc
+}
+
+fn main() -> i64 {
+    // Countdown{n:4} yields [4, 3, 2, 1].
+    // Filter (x > 2) → [4, 3], sum = 7.
+    let filtered = mk_filter(Countdown { n: 4 }, |x: i64| x > 2);
+    let total = fold_i64(filtered, 0, |acc: i64, x: i64| acc + x);
+    if total != 7 {
+        return 101;
+    }
+
+    // Second pass: Countdown{n:5}, filter (x % 2 == 0) → [4, 2], sum = 6.
+    let filtered2 = mk_filter(Countdown { n: 5 }, |x: i64| x % 2 == 0);
+    let total2 = fold_i64(filtered2, 0, |acc: i64, x: i64| acc + x);
+    if total2 != 6 {
+        return 102;
+    }
+
+    total
+}

--- a/tests/vertical-slice/accept/iter_filter_map_compose_run.hew
+++ b/tests/vertical-slice/accept/iter_filter_map_compose_run.hew
@@ -1,0 +1,140 @@
+//! Runnable end-to-end fixture for composed lazy adapters.
+//!
+//! Exercises `Map` composed with `Filter` (map-then-filter pipeline),
+//! proving that the Route-B inner-cursor write-back chains correctly
+//! across two adapter layers: Map advances the Countdown cursor, Filter
+//! advances the Map cursor.
+//!
+//! Inlined and fully monomorphised: cross-module generic instantiation
+//! of `std::iter` does not yet lower through MIR (a separate backend
+//! lane), so the adapter types are defined locally.
+//!
+//! Expected exit code: 18 — sum of items in Countdown{n:5} mapped
+//! through `x * 2` then filtered by `x > 6`: [10, 8]. Any internal
+//! mismatch returns a distinct diagnostic code (101/102) so a
+//! regression is legible.
+
+type Countdown {
+    n: i64;
+}
+
+impl Iterator for Countdown {
+    type Item = i64;
+    /// Yield `n, n-1, …, 1` then `None`; advance the cursor in place.
+    fn next(var self) -> Option<i64> {
+        if self.n <= 0 {
+            None
+        } else {
+            let cur = self.n;
+            self.n = self.n - 1;
+            Some(cur)
+        }
+    }
+}
+
+type Map<I, A, B> {
+    iter: I;
+    f: fn(A) -> B;
+}
+
+impl<I, A, B> Iterator for Map<I, A, B> where I: Iterator<Item = A> {
+    type Item = B;
+    /// Pump the inner iterator once and lift the item through `f`.
+    fn next(var self) -> Option<B> {
+        var inner = self.iter;
+        let result = match inner.next() {
+            Some(x) => Some((self.f)(x)),
+            None => None,
+        };
+        self.iter = inner;
+        result
+    }
+}
+
+type Filter<I, A> {
+    iter: I;
+    pred: fn(A) -> bool;
+}
+
+impl<I, A> Iterator for Filter<I, A> where I: Iterator<Item = A> {
+    type Item = A;
+    /// Multi-pump loop: advance inner until predicate accepts or exhaustion.
+    fn next(var self) -> Option<A> {
+        var inner = self.iter;
+        var found: Option<A> = None;
+        loop {
+            match inner.next() {
+                Some(x) => {
+                    if (self.pred)(x) {
+                        found = Some(x);
+                        break;
+                    }
+                    // x rejected; dropped here
+                },
+                None => {
+                    break;
+                },
+            }
+        }
+        self.iter = inner;
+        found
+    }
+}
+
+/// Construct a lazy `Map` adapter (mirrors `std::iter::map`).
+fn mk_map<I, A, B>(it: I, f: fn(A) -> B) -> Map<I, A, B>
+where
+    I: Iterator<Item = A>,
+{
+    Map { iter: it, f: f }
+}
+
+/// Construct a lazy `Filter` adapter (mirrors `std::iter::filter`).
+fn mk_filter<I, A>(it: I, pred: fn(A) -> bool) -> Filter<I, A>
+where
+    I: Iterator<Item = A>,
+{
+    Filter { iter: it, pred: pred }
+}
+
+/// Left-fold a fixed-`i64` iterator (mirrors `std::iter::fold`).
+fn fold_i64<I>(it: I, init: i64, f: fn(i64, i64) -> i64) -> i64
+where
+    I: Iterator<Item = i64>,
+{
+    var acc = init;
+    var iter = it;
+    loop {
+        match iter.next() {
+            Some(x) => {
+                acc = f(acc, x);
+            },
+            None => {
+                break;
+            },
+        }
+    }
+    acc
+}
+
+fn main() -> i64 {
+    // Countdown{n:5} → [5, 4, 3, 2, 1].
+    // Map (x * 2) → [10, 8, 6, 4, 2].
+    // Filter (x > 6) → [10, 8], sum = 18.
+    let mapped = mk_map(Countdown { n: 5 }, |x: i64| x * 2);
+    let filtered = mk_filter(mapped, |x: i64| x > 6);
+    let total = fold_i64(filtered, 0, |acc: i64, x: i64| acc + x);
+    if total != 18 {
+        return 101;
+    }
+
+    // Filter-then-fold without map: Countdown{n:5}, filter (x % 2 != 0) → odd
+    // items [5, 3, 1], sum = 9.
+    let filtered2 = mk_filter(Countdown { n: 5 }, |x: i64| x % 2 != 0);
+    let total2 = fold_i64(filtered2, 0, |acc: i64, x: i64| acc + x);
+    if total2 != 9 {
+        return 102;
+    }
+
+    total
+}

--- a/tests/vertical-slice/accept/iter_filter_string_run.hew
+++ b/tests/vertical-slice/accept/iter_filter_string_run.hew
@@ -1,0 +1,118 @@
+//! Runnable end-to-end fixture for `Filter` with owned `string` items.
+//!
+//! Exercises the `by-value-heap-params-are-borrows` LESSONS invariant:
+//! `(self.pred)(x)` where `x: string` is a Read borrow — the predicate
+//! does NOT consume `x`. On the accept path `Some(x)` transfers
+//! ownership. On the reject path `x` falls out of scope and is dropped
+//! exactly once by RAII (`drop-allowset-from-value-flow`).
+//!
+//! Run under `MallocScribble=1` on macOS to assert no use-after-free on
+//! the discard path: double-free or use-after-free would manifest as an
+//! abort when scribbled bytes are re-read.
+//!
+//! Inlined and fully monomorphised: cross-module generic instantiation
+//! of `std::iter` does not yet lower through MIR (a separate backend
+//! lane), so the adapter types are defined locally.
+//!
+//! Expected exit code: 2 — count of strings passing the predicate
+//! `s != "skip_me"` from a three-element sequence ["keep", "keep2",
+//! "skip_me"]. Any internal mismatch returns a distinct diagnostic
+//! code (101) so a regression is legible.
+
+/// A fixed-size three-element string source iterator.
+///
+/// Yields three strings in sequence: "keep", "keep2", "skip_me".
+/// The predicate will accept "keep" and "keep2", reject "skip_me".
+type StringSeq {
+    idx: i64;
+}
+
+impl Iterator for StringSeq {
+    type Item = string;
+    /// Yield the next string in the fixed sequence; advance `idx`.
+    fn next(var self) -> Option<string> {
+        if self.idx == 0 {
+            self.idx = self.idx + 1;
+            Some("keep")
+        } else if self.idx == 1 {
+            self.idx = self.idx + 1;
+            Some("keep2")
+        } else if self.idx == 2 {
+            self.idx = self.idx + 1;
+            Some("skip_me")
+        } else {
+            None
+        }
+    }
+}
+
+type Filter<I, A> {
+    iter: I;
+    pred: fn(A) -> bool;
+}
+
+impl<I, A> Iterator for Filter<I, A> where I: Iterator<Item = A> {
+    type Item = A;
+    /// Multi-pump loop. On the reject path `x` (a `string`) falls out
+    /// of scope in the match arm body and is dropped exactly once.
+    fn next(var self) -> Option<A> {
+        var inner = self.iter;
+        var found: Option<A> = None;
+        loop {
+            match inner.next() {
+                Some(x) => {
+                    if (self.pred)(x) {
+                        found = Some(x);
+                        break;
+                    }
+                    // x rejected: string dropped here (RAII, exactly once)
+                },
+                None => {
+                    break;
+                },
+            }
+        }
+        self.iter = inner;
+        found
+    }
+}
+
+/// Construct a lazy `Filter` adapter (mirrors `std::iter::filter`).
+fn mk_filter<I, A>(it: I, pred: fn(A) -> bool) -> Filter<I, A>
+where
+    I: Iterator<Item = A>,
+{
+    Filter { iter: it, pred: pred }
+}
+
+/// Count items in a fixed-`string` iterator (mirrors `std::iter::count`).
+fn count_str<I>(it: I) -> i64
+where
+    I: Iterator<Item = string>,
+{
+    var n: i64 = 0;
+    var iter = it;
+    loop {
+        match iter.next() {
+            Some(_) => {
+                n = n + 1;
+            },
+            None => {
+                break;
+            },
+        }
+    }
+    n
+}
+
+fn main() -> i64 {
+    // StringSeq yields ["keep", "keep2", "skip_me"].
+    // Filter (s != "skip_me") → ["keep", "keep2"], count = 2.
+    let filtered = mk_filter(StringSeq { idx: 0 }, |s: string| s != "skip_me");
+    let n = count_str(filtered);
+    if n != 2 {
+        return 101;
+    }
+
+    n
+}

--- a/tests/vertical-slice/accept/iter_skip_basic_run.hew
+++ b/tests/vertical-slice/accept/iter_skip_basic_run.hew
@@ -1,0 +1,110 @@
+//! Runnable end-to-end fixture for the lazy `Skip` adapter.
+//!
+//! Exercises the Route-B `Skip::next` body: burn-loop that discards
+//! the first `remaining` items from the inner stream, then yields
+//! the rest unchanged. On the first call the burn loop fires once;
+//! on subsequent calls `remaining == 0` so the loop exits immediately
+//! and the adapter is transparent to the inner stream.
+//!
+//! The fixture-local `Skip<I, A>` carries `A` as a direct type parameter
+//! (unlike `std/iter.hew`'s `Skip<I>`) so the monomorphisation site can
+//! pin `A = i64` directly. This is required by the current MIR substrate:
+//! a type parameter appearing ONLY in a where-clause projection cannot be
+//! pinned by the monomorphisation collector (mir-gap-where-clause-proj-
+//! monomorph). The body logic is identical to `std/iter.hew::Skip::next`.
+//!
+//! Inlined and fully monomorphised: cross-module generic instantiation
+//! of `std::iter` does not yet lower through MIR (a separate backend
+//! lane), so the adapter types are defined locally.
+//!
+//! Expected exit code: 6 — sum of items after skipping 2 from
+//! Countdown{n:5}: [3, 2, 1]. Any internal mismatch returns a
+//! distinct diagnostic code (101/102) so a regression is legible.
+
+type Countdown {
+    n: i64;
+}
+
+impl Iterator for Countdown {
+    type Item = i64;
+    /// Yield `n, n-1, …, 1` then `None`; advance the cursor in place.
+    fn next(var self) -> Option<i64> {
+        if self.n <= 0 {
+            None
+        } else {
+            let cur = self.n;
+            self.n = self.n - 1;
+            Some(cur)
+        }
+    }
+}
+
+/// `Skip<I, A>` carries `A` as a direct type parameter so concrete call
+/// sites (e.g. `Skip<Countdown, i64>`) can pin the item type and satisfy
+/// associated-type bounds in generic helpers (`fold_i64`).
+type Skip<I, A> {
+    iter: I;
+    remaining: i64;
+}
+
+impl<I, A> Iterator for Skip<I, A> where I: Iterator<Item = A> {
+    type Item = A;
+    /// Burn-loop then yield. On the first call (remaining > 0) the loop
+    /// discards leading items until `remaining == 0`, then falls through
+    /// to the yield pump. Subsequent calls find `remaining == 0` and skip
+    /// the loop entirely. The inner iterator is moved into a `var` local;
+    /// `self.iter` is written back on every exit path so `var self`'s
+    /// own write-back persists the cursor across calls.
+    fn next(var self) -> Option<A> {
+        var inner = self.iter;
+        loop {
+            if self.remaining <= 0 {
+                break;
+            }
+            match inner.next() {
+                Some(_) => {
+                    self.remaining = self.remaining - 1;
+                },
+                None => {
+                    self.iter = inner;
+                    return None;
+                },
+            }
+        }
+        let result = inner.next();
+        self.iter = inner;
+        result
+    }
+}
+
+/// Sum all items produced by a fixed-`i64` iterator.
+fn fold_i64<I>(it: I) -> i64 where I: Iterator<Item = i64> {
+    var acc: i64 = 0;
+    var iter = it;
+    loop {
+        match iter.next() {
+            Some(x) => { acc = acc + x; },
+            None => { break; },
+        }
+    }
+    acc
+}
+
+fn main() -> i64 {
+    // Countdown{n:5} yields [5, 4, 3, 2, 1].
+    // Skip(2) → discard [5, 4] → yield [3, 2, 1], sum = 6.
+    let skipped: Skip<Countdown, i64> = Skip { iter: Countdown { n: 5 }, remaining: 2 };
+    let total = fold_i64(skipped);
+    if total != 6 {
+        return 101;
+    }
+
+    // Skip(0) → no items discarded → full stream [3, 2, 1], sum = 6.
+    let skipped2: Skip<Countdown, i64> = Skip { iter: Countdown { n: 3 }, remaining: 0 };
+    let total2 = fold_i64(skipped2);
+    if total2 != 6 {
+        return 102;
+    }
+
+    total
+}

--- a/tests/vertical-slice/accept/iter_take_basic_run.hew
+++ b/tests/vertical-slice/accept/iter_take_basic_run.hew
@@ -1,0 +1,101 @@
+//! Runnable end-to-end fixture for the lazy `Take` adapter.
+//!
+//! Exercises the Route-B `Take::next` body: single-pump with a
+//! `remaining` quota guard that decrements on each yield, persisted
+//! across calls through `var self` write-back. The adapter halts
+//! exactly after `n` items regardless of inner stream depth.
+//!
+//! The fixture-local `Take<I, A>` carries `A` as a direct type parameter
+//! (unlike `std/iter.hew`'s `Take<I>`) so the monomorphisation site can
+//! pin `A = i64` directly. This is required by the current MIR substrate:
+//! a type parameter appearing ONLY in a where-clause projection cannot be
+//! pinned by the monomorphisation collector (mir-gap-where-clause-proj-
+//! monomorph). The body logic is identical to `std/iter.hew::Take::next`.
+//!
+//! Inlined and fully monomorphised: cross-module generic instantiation
+//! of `std::iter` does not yet lower through MIR (a separate backend
+//! lane), so the adapter types are defined locally.
+//!
+//! Expected exit code: 12 — sum of the first 3 items from
+//! Countdown{n:5}: [5, 4, 3]. Any internal mismatch returns a
+//! distinct diagnostic code (101/102) so a regression is legible.
+
+type Countdown {
+    n: i64;
+}
+
+impl Iterator for Countdown {
+    type Item = i64;
+    /// Yield `n, n-1, …, 1` then `None`; advance the cursor in place.
+    fn next(var self) -> Option<i64> {
+        if self.n <= 0 {
+            None
+        } else {
+            let cur = self.n;
+            self.n = self.n - 1;
+            Some(cur)
+        }
+    }
+}
+
+/// `Take<I, A>` carries `A` as a direct type parameter so concrete call
+/// sites (e.g. `Take<Countdown, i64>`) can pin the item type and satisfy
+/// associated-type bounds in generic helpers (`fold_i64`).
+type Take<I, A> {
+    iter: I;
+    remaining: i64;
+}
+
+impl<I, A> Iterator for Take<I, A> where I: Iterator<Item = A> {
+    type Item = A;
+    /// Single-pump with quota guard. `remaining` is decremented on each
+    /// successful yield; the var-self write-back persists it across calls
+    /// (proven by VecIter's `self.idx = self.idx + 1` precedent). Once
+    /// `remaining` reaches 0 the adapter returns `None` for all subsequent
+    /// calls without pumping the inner iterator.
+    fn next(var self) -> Option<A> {
+        if self.remaining <= 0 {
+            return None;
+        }
+        var inner = self.iter;
+        let result = match inner.next() {
+            Some(x) => Some(x),
+            None => None,
+        };
+        self.iter = inner;
+        self.remaining = self.remaining - 1;
+        result
+    }
+}
+
+/// Sum all items produced by a fixed-`i64` iterator.
+fn fold_i64<I>(it: I) -> i64 where I: Iterator<Item = i64> {
+    var acc: i64 = 0;
+    var iter = it;
+    loop {
+        match iter.next() {
+            Some(x) => { acc = acc + x; },
+            None => { break; },
+        }
+    }
+    acc
+}
+
+fn main() -> i64 {
+    // Countdown{n:5} yields [5, 4, 3, 2, 1].
+    // Take(3) → [5, 4, 3], sum = 12.
+    let taken: Take<Countdown, i64> = Take { iter: Countdown { n: 5 }, remaining: 3 };
+    let total = fold_i64(taken);
+    if total != 12 {
+        return 101;
+    }
+
+    // Quota-exhaustion check: take(0) yields nothing, sum = 0.
+    let taken2: Take<Countdown, i64> = Take { iter: Countdown { n: 5 }, remaining: 0 };
+    let total2 = fold_i64(taken2);
+    if total2 != 0 {
+        return 102;
+    }
+
+    total
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -297,6 +297,26 @@ run_accept_expect_status "iter_lazy_map_fold_run" 12
 # ([6,4,2] = 12); 101–105 flag a count/length/element mismatch.
 run_accept_expect_status "iter_lazy_count_collect_run" 15
 
+# lane-c: Filter/Take/Skip::next un-stubbed via Route-B var-self write-back.
+# Each fixture is self-contained (no `import std::iter`) to work around the
+# mir-gap-cross-module-std-iter-lowering gap; all types are inlined.
+#
+# filter (x > 2) from Countdown{n:4} → [4, 3], sum = 7; exit 7.
+# Also checks filter (x % 2 == 0) → [4, 2], sum = 6.
+run_accept_expect_status "iter_filter_basic_run" 7
+# take(3) from Countdown{n:5} → [5, 4, 3], sum = 12; exit 12.
+# Also checks take(0) → sum = 0.
+run_accept_expect_status "iter_take_basic_run" 12
+# skip(2) from Countdown{n:5} → [3, 2, 1], sum = 6; exit 6.
+# Also checks skip(0) from Countdown{n:3} → sum = 6.
+run_accept_expect_status "iter_skip_basic_run" 6
+# Map composed with Filter: Countdown{n:5} ×2 then >6 → [10,8], sum = 18.
+# Also checks filter-then-fold: odd items [5,3,1], sum = 9.
+run_accept_expect_status "iter_filter_map_compose_run" 18
+# Filter with owned string items: drop-path coverage.
+# ["keep","keep2","skip_me"] filtered by s!="skip_me" → count = 2; exit 2.
+run_accept_expect_status "iter_filter_string_run" 2
+
 # Reject: spawned closures must not capture non-Send values. This fixture uses
 # a real Checker-produced `Rc<i64>` capture fact and asserts the targeted HIR
 # diagnostic rather than unrelated Rc construction or lowering diagnostics.


### PR DESCRIPTION
Implements `Filter`/`Take`/`Skip::next` in `std/iter.hew`, replacing three fail-loud panic stubs. The prior blocking rationale (a missing var-self / multi-pump substrate) was empirically refuted by the landed lazy-iterator work; all three are expressed with the same `var self` write-back pattern `Map::next` uses.

- **Filter** — multi-pump loop with a predicate; rejected owned elements drop exactly once at arm scope exit.
- **Take** — single-pump with a remaining-quota guard.
- **Skip** — burn-loop then yield.

## Verification
- Five runnable value-asserting vertical-slice fixtures (filter, take, skip, map∘filter, owned-string filter), exits 7/12/6/18/2.
- `make test-hew-ratchet` drop-leak == 0; the owned-string fixture passes under `MallocScribble=1` (discard path drops exactly once).
- `make sandbox-parity` 7/7; `make ci-preflight` green.

## Out of scope
- `Take<I>`/`Skip<I>` stdlib types are unchanged; the fixtures use an explicit `A` type param to work around a pre-existing where-clause monomorphization gap (tracked separately).
