### PR TITLE
chore(sandbox-wasm): add tracking-issue refs to deferred WASM-TODOs

### DIFF
--- a/hew-sandbox-wasm/src/emit.rs
+++ b/hew-sandbox-wasm/src/emit.rs
@@ -2011,8 +2011,8 @@ impl<'pkg, 'src> FunctionEmitter<'pkg, 'src> {
                     );
                     return Ok(dst);
                 }
-                // WASM-TODO: inclusive range slice `v[start..=end]` — deferred
-                // until `vector.range_slice_inclusive` is added to the VM.
+                // WASM-TODO(#2183): inclusive range slice `v[start..=end]` —
+                // deferred until `vector.range_slice_inclusive` is added to the VM.
                 if matches!(
                     &index.0,
                     Expr::Range {
@@ -2475,7 +2475,7 @@ impl<'pkg, 'src> FunctionEmitter<'pkg, 'src> {
                         return Ok(self.lower_vector_new(span));
                     }
                 }
-                // WASM-TODO: fn-field call `(rec.f)(args)` — the type-checker
+                // WASM-TODO(#2183): fn-field call `(rec.f)(args)` — the type-checker
                 // (ac0bc0ed) now admits calling a function-typed record field when
                 // the callee object is a value binding. The sandbox VM has
                 // `call.indirect` in its schema but marks it M4_DEFERRED; emit


### PR DESCRIPTION
## Summary

Two `WASM-TODO` comments in `hew-sandbox-wasm/src/emit.rs` — for the inclusive range-slice `v[start..=end]` and the function-typed record-field call `(rec.f)(args)`, both deferred sandbox-VM features that correctly emit `unsupported` so the playground fails closed — lacked the issue reference that `scripts/lint-wasm-todo-issue-ref.sh` requires (`WASM-TODO(#NNN):`). That fails the local `make lint` gate (and so `make ci-preflight`). Both now point at the tracking issue #2183.

No behavior change — comments only.

## Verification

- `bash scripts/lint-wasm-todo-issue-ref.sh` → `lint-wasm-todo: ok`
- `cargo fmt --all -- --check` → clean

## Out of scope

Implementing the two sandbox-VM features themselves (`vector.range_slice_inclusive` and un-deferring `call.indirect`) is tracked in #2183.
