### PR TITLE
fix(types): project generic trait-method returns on builtin receivers

### DIFF
--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -247,6 +247,22 @@ impl CollectionTyCx {
             resolved,
         }
     }
+
+    /// Reconstruct the concrete receiver `Ty` (carrying type arguments) for the
+    /// given collection kind, so user-trait dispatch on a builtin receiver can
+    /// bind the impl's type parameters from the element/key/value types.
+    /// `HashMap<K, V>` → `[K, V]`, `HashSet<E>` / `Vec<E>` → `[E]`.
+    fn receiver_with_args(&self, kind: CollectionKind) -> Ty {
+        let args = match kind {
+            CollectionKind::HashMap => vec![self.key.clone(), self.val.clone()],
+            CollectionKind::HashSet | CollectionKind::Vec => vec![self.elem.clone()],
+        };
+        Ty::Named {
+            builtin: Some(kind.builtin()),
+            name: kind.name().to_string(),
+            args,
+        }
+    }
 }
 
 impl Checker {
@@ -4028,15 +4044,16 @@ impl Checker {
     fn collection_method_fallback(
         &mut self,
         kind: CollectionKind,
+        cx: &CollectionTyCx,
         method: &str,
         args: &[CallArg],
         span: &Span,
     ) -> Ty {
-        let receiver = Ty::Named {
-            builtin: Some(kind.builtin()),
-            name: kind.name().to_string(),
-            args: vec![],
-        };
+        // Reconstruct the receiver carrying its concrete type arguments so a
+        // user `impl<T> Trait for HashMap<K, V>` / `Vec<E>` dispatched here can
+        // bind the impl's type parameters from the element/key/value types and
+        // project its `Output`/return — the builtin-vs-user asymmetry fix.
+        let receiver = cx.receiver_with_args(kind);
         if let Some(ret_ty) =
             self.try_dispatch_primitive_trait_method(&receiver, method, args, span)
         {
@@ -4073,7 +4090,7 @@ impl Checker {
         span: &Span,
     ) -> Ty {
         let Some(desc) = collection_method_desc(kind, method) else {
-            return self.collection_method_fallback(kind, method, args, span);
+            return self.collection_method_fallback(kind, cx, method, args, span);
         };
         if let Some(arity) = desc.arity {
             self.check_arity(args, arity, &format!("`{}::{method}`", kind.name()), span);
@@ -5066,7 +5083,7 @@ impl Checker {
                 let receiver = Ty::Named {
                     builtin: Some(BuiltinType::Vec),
                     name: "Vec".to_string(),
-                    args: vec![],
+                    args: vec![self.subst.resolve(&elem_ty)],
                 };
                 if let Some(ret_ty) =
                     self.try_dispatch_primitive_trait_method(&receiver, method, args, span)
@@ -5136,6 +5153,19 @@ impl Checker {
         let defaulted_receiver = resolved_receiver.materialize_literal_defaults();
         let canonical = Checker::canonical_primitive_or_builtin_key(&defaulted_receiver)?;
         let (trait_name, sig) = self.lookup_primitive_trait_method(&defaulted_receiver, method)?;
+        // Bind the impl's type parameters from the concrete receiver's type
+        // arguments BEFORE applying the signature. Without this a generic
+        // builtin impl (`impl<E> Index for Vec<E>`) dispatched on `Vec<i64>`
+        // leaves `E` (hence an `Option<E>` / `Self::Output` return) as an
+        // unresolved inference var that escapes past the checker output
+        // boundary — the builtin-vs-user asymmetry this fix closes. User
+        // `Ty::Named` receivers already do this via `lookup_named_method_sig`.
+        let sig = self.instantiate_primitive_trait_method_sig(
+            sig,
+            &canonical,
+            &trait_name,
+            &defaulted_receiver,
+        );
         let applied_sig = self.apply_instantiated_call_signature(
             &sig,
             None,
@@ -5170,7 +5200,101 @@ impl Checker {
                 },
             );
         }
-        Some(applied_sig.return_type)
+        // Project any `Self::Output`-style associated-type carrier in the
+        // return now that the impl's type params are bound to the concrete
+        // receiver — `project_assoc_types` keys the concrete builtin base
+        // (`<Vec<i64> as Index>::Output`) through `impl_assoc_type_bindings`.
+        Some(self.project_assoc_types(&applied_sig.return_type))
+    }
+
+    /// Instantiate a primitive/builtin-generic trait-impl method signature
+    /// against a concrete receiver.
+    ///
+    /// Binds the impl's type parameters by structurally unifying the impl's
+    /// recorded `Self` type arguments
+    /// ([`Checker::primitive_trait_impl_self_args`]) against the receiver's
+    /// concrete type arguments, then substitutes both `Self` (→ the receiver)
+    /// and the bound parameters through the signature's params and return type.
+    /// Substituted parameters are dropped from `type_params` so
+    /// `apply_instantiated_call_signature` does not re-instantiate them as
+    /// fresh inference vars. Mirrors `instantiate_named_method_sig` (the user
+    /// `Ty::Named` path) for builtin receivers, which have no `type_defs` entry.
+    ///
+    /// Non-generic primitive impls (`impl Display for i64`) have empty stored
+    /// `Self` args and only the `Self` → receiver substitution applies, leaving
+    /// existing dispatch behaviour unchanged.
+    fn instantiate_primitive_trait_method_sig(
+        &self,
+        mut sig: FnSig,
+        canonical: &str,
+        trait_name: &str,
+        receiver_ty: &Ty,
+    ) -> FnSig {
+        let mut subst: HashMap<String, Ty> = HashMap::new();
+        if let Some(self_args) = self
+            .primitive_trait_impl_self_args
+            .get(&(canonical.to_string(), trait_name.to_string()))
+        {
+            let receiver_args = match receiver_ty {
+                Ty::Named { args, .. } => args.as_slice(),
+                _ => &[],
+            };
+            let impl_params: HashSet<&str> = sig.type_params.iter().map(String::as_str).collect();
+            for (self_arg, receiver_arg) in self_args.iter().zip(receiver_args.iter()) {
+                Self::bind_self_arg_param(self_arg, receiver_arg, &impl_params, &mut subst);
+            }
+        }
+        for param_ty in &mut sig.params {
+            *param_ty = param_ty
+                .substitute_named_param("Self", receiver_ty)
+                .substitute_named_params_parallel(&subst);
+        }
+        sig.return_type = sig
+            .return_type
+            .substitute_named_param("Self", receiver_ty)
+            .substitute_named_params_parallel(&subst);
+        sig.type_params.retain(|tp| !subst.contains_key(tp));
+        sig.type_param_bounds
+            .retain(|tp, _| !subst.contains_key(tp));
+        sig
+    }
+
+    /// Structurally bind a single impl `Self`-position type argument against the
+    /// receiver's corresponding concrete argument, recording any impl
+    /// type-parameter bindings into `subst`.
+    ///
+    /// A bare `Ty::Named { name, args: [] }` whose `name` is one of the impl's
+    /// type parameters (`impl<E> … for Vec<E>` → `E`) binds directly to the
+    /// receiver argument. A constructed type (`Box<E>`) recurses positionally so
+    /// nested parameters still bind. Concrete `Self`-position types (`Vec<i64>`)
+    /// contribute nothing, leaving no spurious bindings.
+    fn bind_self_arg_param(
+        self_arg: &Ty,
+        receiver_arg: &Ty,
+        impl_params: &HashSet<&str>,
+        subst: &mut HashMap<String, Ty>,
+    ) {
+        match self_arg {
+            Ty::Named { name, args, .. } if args.is_empty() => {
+                if impl_params.contains(name.as_str()) {
+                    subst.insert(name.clone(), receiver_arg.clone());
+                }
+            }
+            Ty::Named {
+                args: self_args, ..
+            } => {
+                if let Ty::Named {
+                    args: receiver_args,
+                    ..
+                } = receiver_arg
+                {
+                    for (s, r) in self_args.iter().zip(receiver_args.iter()) {
+                        Self::bind_self_arg_param(s, r, impl_params, subst);
+                    }
+                }
+            }
+            _ => {}
+        }
     }
 
     /// Stage A3: UFCS form of [`Self::try_dispatch_primitive_trait_method`].
@@ -5238,6 +5362,16 @@ impl Checker {
             .get(&(canonical.clone(), trait_name.to_string()))
             .and_then(|methods| methods.get(method_name))
             .cloned()?;
+        // Bind the impl's type params from the concrete receiver before
+        // applying the signature, mirroring the method-form path so a UFCS
+        // call (`Index::get(v, i)`) on a generic builtin receiver projects its
+        // `Output`/return instead of leaking an unresolved inference var.
+        let sig = self.instantiate_primitive_trait_method_sig(
+            sig,
+            &canonical,
+            trait_name,
+            &resolved_receiver,
+        );
         // Do not add an outer check_arity here.  apply_instantiated_call_signature
         // already calls check_arity on trailing_args via PositionalOnly, matching
         // the receiver-form path at try_dispatch_primitive_trait_method.  An
@@ -5264,7 +5398,7 @@ impl Checker {
                 canonical_receiver: canonical,
             },
         );
-        Some(applied.return_type)
+        Some(self.project_assoc_types(&applied.return_type))
     }
 
     #[expect(

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -5154,18 +5154,24 @@ impl Checker {
         let canonical = Checker::canonical_primitive_or_builtin_key(&defaulted_receiver)?;
         let (trait_name, sig) = self.lookup_primitive_trait_method(&defaulted_receiver, method)?;
         // Bind the impl's type parameters from the concrete receiver's type
-        // arguments BEFORE applying the signature. Without this a generic
+        // arguments BEFORE applying the signature, and PROVE the impl's `Self`
+        // structurally matches the receiver. Without the binding a generic
         // builtin impl (`impl<E> Index for Vec<E>`) dispatched on `Vec<i64>`
         // leaves `E` (hence an `Option<E>` / `Self::Output` return) as an
         // unresolved inference var that escapes past the checker output
-        // boundary — the builtin-vs-user asymmetry this fix closes. User
-        // `Ty::Named` receivers already do this via `lookup_named_method_sig`.
+        // boundary — the builtin-vs-user asymmetry this fix closes. Without the
+        // shape proof a constrained/concrete impl (`impl Acc for Vec<i64>`)
+        // would be over-applied to a non-matching receiver (`Vec<string>`) and
+        // project an authoritative-but-wrong return type (a fail-open). On a
+        // non-match `instantiate_*` returns `None` and we fall through to the
+        // "no method" path below, failing closed. User `Ty::Named` receivers
+        // already do both via `lookup_named_method_sig`.
         let sig = self.instantiate_primitive_trait_method_sig(
             sig,
             &canonical,
             &trait_name,
             &defaulted_receiver,
-        );
+        )?;
         let applied_sig = self.apply_instantiated_call_signature(
             &sig,
             None,
@@ -5208,40 +5214,68 @@ impl Checker {
     }
 
     /// Instantiate a primitive/builtin-generic trait-impl method signature
-    /// against a concrete receiver.
+    /// against a concrete receiver — **fallibly**.
     ///
-    /// Binds the impl's type parameters by structurally unifying the impl's
-    /// recorded `Self` type arguments
+    /// Dispatch reaches here keyed only on the canonical builtin kind
+    /// (`Vec`/`HashMap`/…), so the registered impl's `Self` type must still be
+    /// *proven* to structurally match the concrete receiver before its return
+    /// type is treated as authoritative. Returns `None` when the impl does not
+    /// apply (constrained/concrete/nested `Self` that the receiver does not
+    /// satisfy), so the caller falls through to the normal "no matching
+    /// method/impl" path and fails **closed** — never projecting an authoritative
+    /// return type for a receiver that does not implement the impl.
+    ///
+    /// On a match, binds the impl's type parameters by structurally unifying the
+    /// impl's recorded `Self` type arguments
     /// ([`Checker::primitive_trait_impl_self_args`]) against the receiver's
     /// concrete type arguments, then substitutes both `Self` (→ the receiver)
     /// and the bound parameters through the signature's params and return type.
     /// Substituted parameters are dropped from `type_params` so
-    /// `apply_instantiated_call_signature` does not re-instantiate them as
-    /// fresh inference vars. Mirrors `instantiate_named_method_sig` (the user
+    /// `apply_instantiated_call_signature` does not re-instantiate them as fresh
+    /// inference vars. Mirrors `instantiate_named_method_sig` (the user
     /// `Ty::Named` path) for builtin receivers, which have no `type_defs` entry.
     ///
+    /// Hew rejects overlapping impls (the associated-type binding table is keyed
+    /// by type *name*, so a second impl for the same `(kind, trait)` collides and
+    /// is diagnosed at registration for builtins and user records alike). There
+    /// is therefore at most one usable impl per `(canonical, trait)`, and the
+    /// stored `Self` args identify exactly that impl — no per-impl table needed.
+    ///
     /// Non-generic primitive impls (`impl Display for i64`) have empty stored
-    /// `Self` args and only the `Self` → receiver substitution applies, leaving
-    /// existing dispatch behaviour unchanged.
+    /// `Self` args and an argument-less receiver, so the arity check passes
+    /// trivially, no parameters bind, and only the `Self` → receiver substitution
+    /// applies — leaving existing dispatch behaviour unchanged.
     fn instantiate_primitive_trait_method_sig(
-        &self,
+        &mut self,
         mut sig: FnSig,
         canonical: &str,
         trait_name: &str,
         receiver_ty: &Ty,
-    ) -> FnSig {
+    ) -> Option<FnSig> {
         let mut subst: HashMap<String, Ty> = HashMap::new();
+        // Clone out of the side table so the structural match can take `&mut
+        // self` (it unifies unbound receiver vars against concrete `Self` args).
         if let Some(self_args) = self
             .primitive_trait_impl_self_args
             .get(&(canonical.to_string(), trait_name.to_string()))
+            .cloned()
         {
-            let receiver_args = match receiver_ty {
-                Ty::Named { args, .. } => args.as_slice(),
-                _ => &[],
+            let receiver_args: Vec<Ty> = match receiver_ty {
+                Ty::Named { args, .. } => args.clone(),
+                _ => Vec::new(),
             };
-            let impl_params: HashSet<&str> = sig.type_params.iter().map(String::as_str).collect();
+            // Arity is part of the shape: an impl whose `Self` constructor takes
+            // a different number of arguments than the receiver cannot apply.
+            if self_args.len() != receiver_args.len() {
+                return None;
+            }
+            let impl_params: HashSet<String> = sig.type_params.iter().cloned().collect();
             for (self_arg, receiver_arg) in self_args.iter().zip(receiver_args.iter()) {
-                Self::bind_self_arg_param(self_arg, receiver_arg, &impl_params, &mut subst);
+                if !self.match_self_arg_param(self_arg, receiver_arg, &impl_params, &mut subst) {
+                    // `Self` does not structurally match the receiver — this impl
+                    // does not apply. Fail closed.
+                    return None;
+                }
             }
         }
         for param_ty in &mut sig.params {
@@ -5256,44 +5290,99 @@ impl Checker {
         sig.type_params.retain(|tp| !subst.contains_key(tp));
         sig.type_param_bounds
             .retain(|tp, _| !subst.contains_key(tp));
-        sig
+        Some(sig)
     }
 
-    /// Structurally bind a single impl `Self`-position type argument against the
-    /// receiver's corresponding concrete argument, recording any impl
-    /// type-parameter bindings into `subst`.
+    /// Fallibly match a single impl `Self`-position type argument against the
+    /// receiver's corresponding concrete argument, recording impl
+    /// type-parameter bindings into `subst`. Returns `false` on any structural
+    /// mismatch so the impl is rejected (fail closed) rather than over-applied.
     ///
-    /// A bare `Ty::Named { name, args: [] }` whose `name` is one of the impl's
-    /// type parameters (`impl<E> … for Vec<E>` → `E`) binds directly to the
-    /// receiver argument. A constructed type (`Box<E>`) recurses positionally so
-    /// nested parameters still bind. Concrete `Self`-position types (`Vec<i64>`)
-    /// contribute nothing, leaving no spurious bindings.
-    fn bind_self_arg_param(
+    /// - A bare `Ty::Named { name, args: [] }` whose `name` is an impl type
+    ///   parameter (`impl<E> … for Vec<E>` → `E`) binds to the resolved receiver
+    ///   argument; a parameter appearing more than once (`HashMap<K, K>`) must
+    ///   bind consistently.
+    /// - A constructed nominal `Self` type (`Vec<T>` in `impl<T> Acc for
+    ///   Vec<Vec<T>>`, or a concrete `Vec<i64>` / user `Point`) requires the
+    ///   receiver to be the **same constructor** — identical `name`, `builtin`,
+    ///   and arity — before recursing element-wise. This rejects
+    ///   `Vec<Vec<T>>` ⊄ `Vec<Option<i64>>` (Vec ≠ Option) and `Vec<i64>` ⊄
+    ///   `Vec<string>`.
+    /// - A concrete non-`Named` leaf (`i64`, `string`, …) requires equality with
+    ///   the resolved receiver argument.
+    /// - In either concrete case, an unbound receiver `Ty::Var` is unified with
+    ///   the fully-concrete `Self` argument, so inference can resolve the element
+    ///   type when exactly one impl could apply.
+    fn match_self_arg_param(
+        &mut self,
         self_arg: &Ty,
         receiver_arg: &Ty,
-        impl_params: &HashSet<&str>,
+        impl_params: &HashSet<String>,
         subst: &mut HashMap<String, Ty>,
-    ) {
+    ) -> bool {
+        let receiver_resolved = self.subst.resolve(receiver_arg);
         match self_arg {
-            Ty::Named { name, args, .. } if args.is_empty() => {
-                if impl_params.contains(name.as_str()) {
-                    subst.insert(name.clone(), receiver_arg.clone());
+            // Bare impl type parameter: bind to the receiver arg (consistently).
+            Ty::Named { name, args, .. } if args.is_empty() && impl_params.contains(name) => {
+                if let Some(existing) = subst.get(name) {
+                    return *existing == receiver_resolved;
                 }
+                subst.insert(name.clone(), receiver_resolved);
+                true
             }
+            // Constructed / concrete-nominal `Self` type: same constructor, then
+            // recurse. An unbound receiver var unifies with a fully-concrete one.
             Ty::Named {
-                args: self_args, ..
+                name: s_name,
+                builtin: s_builtin,
+                args: s_args,
             } => {
-                if let Ty::Named {
-                    args: receiver_args,
-                    ..
-                } = receiver_arg
-                {
-                    for (s, r) in self_args.iter().zip(receiver_args.iter()) {
-                        Self::bind_self_arg_param(s, r, impl_params, subst);
-                    }
+                if matches!(receiver_resolved, Ty::Var(_)) {
+                    return !Self::ty_contains_impl_param(self_arg, impl_params)
+                        && crate::unify::unify(&mut self.subst, &receiver_resolved, self_arg)
+                            .is_ok();
                 }
+                let Ty::Named {
+                    name: r_name,
+                    builtin: r_builtin,
+                    args: r_args,
+                } = &receiver_resolved
+                else {
+                    return false;
+                };
+                if s_name != r_name || s_builtin != r_builtin || s_args.len() != r_args.len() {
+                    return false;
+                }
+                s_args
+                    .iter()
+                    .zip(r_args.iter())
+                    .all(|(s, r)| self.match_self_arg_param(s, r, impl_params, subst))
             }
-            _ => {}
+            // Concrete non-`Named` leaf (`i64`, `string`, `bool`, …): require
+            // equality, or unify an unbound receiver var with the concrete leaf.
+            concrete => {
+                if matches!(receiver_resolved, Ty::Var(_)) {
+                    return crate::unify::unify(&mut self.subst, &receiver_resolved, concrete)
+                        .is_ok();
+                }
+                receiver_resolved == *concrete
+            }
+        }
+    }
+
+    /// Whether `ty` mentions any of the impl's type parameters anywhere in its
+    /// structure. Used to gate unifying an unbound receiver var against a `Self`
+    /// argument: only fully-concrete `Self` args (no impl params) may drive
+    /// inference of the receiver's element type.
+    fn ty_contains_impl_param(ty: &Ty, impl_params: &HashSet<String>) -> bool {
+        match ty {
+            Ty::Named { name, args, .. } => {
+                impl_params.contains(name)
+                    || args
+                        .iter()
+                        .any(|a| Self::ty_contains_impl_param(a, impl_params))
+            }
+            _ => false,
         }
     }
 
@@ -5363,15 +5452,18 @@ impl Checker {
             .and_then(|methods| methods.get(method_name))
             .cloned()?;
         // Bind the impl's type params from the concrete receiver before
-        // applying the signature, mirroring the method-form path so a UFCS
-        // call (`Index::get(v, i)`) on a generic builtin receiver projects its
-        // `Output`/return instead of leaking an unresolved inference var.
+        // applying the signature, and prove `Self` matches (mirroring the
+        // method-form path) so a UFCS call (`Index::get(v, i)`) on a generic
+        // builtin receiver projects its `Output`/return instead of leaking an
+        // unresolved inference var — and a constrained/concrete impl is not
+        // over-applied. On a non-match, fall through to the trait-qualified
+        // path, which fails closed.
         let sig = self.instantiate_primitive_trait_method_sig(
             sig,
             &canonical,
             trait_name,
             &resolved_receiver,
-        );
+        )?;
         // Do not add an outer check_arity here.  apply_instantiated_call_signature
         // already calls check_arity on trailing_args via PositionalOnly, matching
         // the receiver-form path at try_dispatch_primitive_trait_method.  An

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -4257,6 +4257,7 @@ impl Checker {
                                 canonical.clone(),
                                 tb.name.clone(),
                                 self_type_args.clone(),
+                                &id.target_type.1,
                             );
                             self.record_primitive_trait_impl_method(
                                 canonical,
@@ -6352,29 +6353,111 @@ impl Checker {
         method_name: String,
         sig: FnSig,
     ) {
+        // First-wins, matching `record_primitive_trait_impl_self_args` and the
+        // assoc-type binding table. Under Hew's coherence rule there is at most
+        // one impl of a trait per constructor, so a second registration is
+        // either the same impl reprocessed across phases or a rejected
+        // conflicting impl (diagnosed at `record_trait_impl`); in neither case
+        // may it overwrite the surviving impl's signature. Keeping every side
+        // table first-wins guarantees the dispatched method signature and the
+        // applicability proof (self-args) always come from the *same* impl, so
+        // they cannot drift.
         self.primitive_trait_impls
             .entry((canonical_key, trait_name))
             .or_default()
-            .insert(method_name, sig);
+            .entry(method_name)
+            .or_insert(sig);
     }
 
     /// Record the impl's `Self` type arguments for an `impl <Trait> for
     /// <PrimitiveOrBuiltinGeneric>` so a later dispatch on a concrete receiver
     /// can bind the impl's type parameters (see
-    /// [`Checker::primitive_trait_impl_self_args`]). Idempotent: the first
-    /// recorded entry per `(canonical, trait)` wins (all methods of one impl
-    /// share the same `Self` args). `canonical_key` must come from
-    /// [`Self::canonical_primitive_or_builtin_key_from_name`] so registration
-    /// and dispatch agree.
+    /// [`Checker::primitive_trait_impl_self_args`]). Idempotent within one impl:
+    /// every method of that impl records the SAME `Self` args, so the first
+    /// recorded entry per `(canonical, trait)` wins.
+    ///
+    /// Coherence enforcement (single-impl-per-constructor): if a *different*
+    /// `Self` shape is already recorded for this `(canonical, trait)`, two
+    /// distinct impls target the same builtin constructor with the same trait —
+    /// e.g. a blanket `impl<T> Acc for Vec<T>` (`self_args = [T]`) and a concrete
+    /// `impl Acc for Vec<i64>` (`self_args = [i64]`). Hew has no specialization
+    /// or overlapping impls (single-crate coherence, mission Q66.b), so the
+    /// second impl is rejected at its declaration site with a clean diagnostic
+    /// and does NOT overwrite the first (first-wins keeps the surviving impl's
+    /// method signatures and this `Self`-arg applicability proof from the SAME
+    /// impl, so they cannot drift).
+    ///
+    /// Comparing the `Self` shape (rather than a source span) makes this robust
+    /// to the registration architecture re-processing the same impl across
+    /// module/import phases: a reprocessed impl re-presents an *identical*
+    /// `Self` shape and is correctly treated as the same impl, while a genuine
+    /// overlap presents a *different* shape. It also naturally scopes the check
+    /// to builtin/primitive receivers — user-record impls never reach this side
+    /// table — which is exactly where the drift fail-open lived.
+    ///
+    /// KNOWN GAP (tracked): two *genuinely-distinct* impls that share an
+    /// *identical* `Self` shape — e.g. two literal `impl<T> Acc for Vec<T>`
+    /// blocks — are NOT rejected here (they compare shape-equal and are treated
+    /// as a re-presentation). Closing this needs the impl's DEFINING identity,
+    /// but the only readily-available per-impl span (`impl.target_type` span)
+    /// cannot be used as the coherence key because the documented user-redeclare
+    /// path lets a user `pub trait Display` shadow the prelude `Display`: the
+    /// prelude `impl Display for i64` and the user `impl Display for i64` are
+    /// distinct traits that collapse to the same `(canonical, "Display")` key,
+    /// so a defining-span key would falsely reject that legal shadow. A correct
+    /// fix must additionally key on the trait's DEFINING identity (not its
+    /// name), which is a larger cross-cutting change tracked as a separate
+    /// follow-up ("trait-impl coherence: reject duplicate same-(type,trait)
+    /// impls via defining-identity"). The projection fix this method supports is
+    /// unaffected: first-wins keeps the dispatched method signature and the
+    /// applicability proof from the SAME (first) impl, so even an accepted
+    /// duplicate cannot cause the mis-projection fail-open this lane closes.
     pub(super) fn record_primitive_trait_impl_self_args(
         &mut self,
         canonical_key: String,
         trait_name: String,
         self_args: Vec<Ty>,
+        impl_span: &Span,
     ) {
-        self.primitive_trait_impl_self_args
-            .entry((canonical_key, trait_name))
-            .or_insert(self_args);
+        match self
+            .primitive_trait_impl_self_args
+            .get(&(canonical_key.clone(), trait_name.clone()))
+        {
+            None => {
+                self.primitive_trait_impl_self_args
+                    .insert((canonical_key, trait_name), self_args);
+            }
+            Some(existing) if existing == &self_args => {
+                // Same impl (same Self shape), re-presented across a later
+                // registration phase — not a conflict. (See KNOWN GAP above:
+                // this also admits a genuine same-shape duplicate, tracked.)
+            }
+            Some(_) => {
+                // A second, structurally-different impl of the same trait on the
+                // same builtin constructor: an overlapping impl, which Hew does
+                // not permit. Reject it; keep the first-registered impl.
+                let dedup = (
+                    canonical_key.clone(),
+                    trait_name.clone(),
+                    impl_span.start,
+                    impl_span.end,
+                );
+                if self.conflicting_trait_impl_reported.insert(dedup) {
+                    self.report_error(
+                        TypeErrorKind::ConflictingTraitImpl {
+                            trait_name: trait_name.clone(),
+                            type_name: canonical_key.clone(),
+                        },
+                        impl_span,
+                        format!(
+                            "conflicting implementation of trait `{trait_name}` for `{canonical_key}`: \
+                             a trait may be implemented at most once per type constructor \
+                             (Hew has no specialization or overlapping impls)"
+                        ),
+                    );
+                }
+            }
+        }
     }
 
     /// Look up a method on the primitive/builtin-generic impl table.
@@ -7278,6 +7361,7 @@ impl Checker {
                                 canonical.clone(),
                                 tb.name.clone(),
                                 self_type_args.clone(),
+                                &id.target_type.1,
                             );
                             self.record_primitive_trait_impl_method(
                                 canonical,
@@ -7501,6 +7585,7 @@ impl Checker {
                                     canonical.clone(),
                                     tb.name.clone(),
                                     self_type_args.clone(),
+                                    &id.target_type.1,
                                 );
                                 self.record_primitive_trait_impl_method(
                                     canonical,
@@ -8022,6 +8107,7 @@ impl Checker {
                                     canonical.clone(),
                                     tb.name.clone(),
                                     self_type_args.clone(),
+                                    &id.target_type.1,
                                 );
                                 self.record_primitive_trait_impl_method(
                                     canonical,

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -4253,6 +4253,11 @@ impl Checker {
                         if let (Some(canonical), Some(tb)) =
                             (primitive_key.clone(), id.trait_bound.as_ref())
                         {
+                            self.record_primitive_trait_impl_self_args(
+                                canonical.clone(),
+                                tb.name.clone(),
+                                self_type_args.clone(),
+                            );
                             self.record_primitive_trait_impl_method(
                                 canonical,
                                 tb.name.clone(),
@@ -6353,6 +6358,25 @@ impl Checker {
             .insert(method_name, sig);
     }
 
+    /// Record the impl's `Self` type arguments for an `impl <Trait> for
+    /// <PrimitiveOrBuiltinGeneric>` so a later dispatch on a concrete receiver
+    /// can bind the impl's type parameters (see
+    /// [`Checker::primitive_trait_impl_self_args`]). Idempotent: the first
+    /// recorded entry per `(canonical, trait)` wins (all methods of one impl
+    /// share the same `Self` args). `canonical_key` must come from
+    /// [`Self::canonical_primitive_or_builtin_key_from_name`] so registration
+    /// and dispatch agree.
+    pub(super) fn record_primitive_trait_impl_self_args(
+        &mut self,
+        canonical_key: String,
+        trait_name: String,
+        self_args: Vec<Ty>,
+    ) {
+        self.primitive_trait_impl_self_args
+            .entry((canonical_key, trait_name))
+            .or_insert(self_args);
+    }
+
     /// Look up a method on the primitive/builtin-generic impl table.
     ///
     /// Walks every trait registered for the receiver's canonical kind and
@@ -7205,7 +7229,7 @@ impl Checker {
                 {
                     // Set current_self_type for resolving `Self` in method parameters
                     let prev_self_type = self.current_self_type.take();
-                    let self_type_args = type_args
+                    let self_type_args: Vec<Ty> = type_args
                         .as_ref()
                         .map(|args| {
                             args.iter()
@@ -7213,7 +7237,7 @@ impl Checker {
                                 .collect()
                         })
                         .unwrap_or_default();
-                    self.current_self_type = Some((type_name.clone(), self_type_args));
+                    self.current_self_type = Some((type_name.clone(), self_type_args.clone()));
                     let scope_pushed =
                         self.enter_impl_scope(id, span, Some(type_name.as_str()), false);
 
@@ -7250,6 +7274,11 @@ impl Checker {
                         if let (Some(canonical), Some(tb)) =
                             (primitive_key.clone(), id.trait_bound.as_ref())
                         {
+                            self.record_primitive_trait_impl_self_args(
+                                canonical.clone(),
+                                tb.name.clone(),
+                                self_type_args.clone(),
+                            );
                             self.record_primitive_trait_impl_method(
                                 canonical,
                                 tb.name.clone(),
@@ -7421,7 +7450,9 @@ impl Checker {
                 }
                 Item::Impl(id) => {
                     if let TypeExpr::Named {
-                        name: type_name, ..
+                        name: type_name,
+                        type_args: target_type_args,
+                        ..
                     } = &id.target_type.0
                     {
                         if skipped_type_names.contains(type_name) {
@@ -7434,6 +7465,22 @@ impl Checker {
                             id.where_clause.as_ref(),
                             span,
                         );
+                        // The impl's `Self` type arguments (e.g. `[E]` for
+                        // `impl<E> Index for Vec<E>`), resolved so a later
+                        // dispatch on a concrete receiver can bind the impl's
+                        // type parameters. This path bypasses `enter_impl_scope`
+                        // so `E` resolves to a bare `Ty::Named { name: "E" }`,
+                        // which is exactly the placeholder the dispatch-time
+                        // binding zips against the receiver's concrete args.
+                        let self_type_args: Vec<Ty> = target_type_args
+                            .as_ref()
+                            .map(|type_args| {
+                                type_args
+                                    .iter()
+                                    .map(|type_arg| self.resolve_type_expr(type_arg))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
                         let primitive_key = id.trait_bound.as_ref().and_then(|_| {
                             Self::canonical_primitive_or_builtin_key_from_name(type_name)
                         });
@@ -7450,6 +7497,11 @@ impl Checker {
                             if let (Some(canonical), Some(tb)) =
                                 (primitive_key.clone(), id.trait_bound.as_ref())
                             {
+                                self.record_primitive_trait_impl_self_args(
+                                    canonical.clone(),
+                                    tb.name.clone(),
+                                    self_type_args.clone(),
+                                );
                                 self.record_primitive_trait_impl_method(
                                     canonical,
                                     tb.name.clone(),
@@ -7938,7 +7990,7 @@ impl Checker {
                     {
                         // Set current_self_type for resolving `Self` in method parameters
                         let prev_self_type = self.current_self_type.take();
-                        let self_type_args = type_args
+                        let self_type_args: Vec<Ty> = type_args
                             .as_ref()
                             .map(|args| {
                                 args.iter()
@@ -7946,7 +7998,7 @@ impl Checker {
                                     .collect()
                             })
                             .unwrap_or_default();
-                        self.current_self_type = Some((type_name.clone(), self_type_args));
+                        self.current_self_type = Some((type_name.clone(), self_type_args.clone()));
                         let scope_pushed =
                             self.enter_impl_scope(id, span, Some(type_name.as_str()), false);
 
@@ -7966,6 +8018,11 @@ impl Checker {
                             if let (Some(canonical), Some(tb)) =
                                 (primitive_key.clone(), id.trait_bound.as_ref())
                             {
+                                self.record_primitive_trait_impl_self_args(
+                                    canonical.clone(),
+                                    tb.name.clone(),
+                                    self_type_args.clone(),
+                                );
                                 self.record_primitive_trait_impl_method(
                                     canonical,
                                     tb.name.clone(),

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -2429,6 +2429,11 @@ pub struct Checker {
     pub(super) trait_import_bindings: HashMap<(String, String), String>,
     /// Set of (`type_name`, `trait_name`) pairs for concrete impl registrations
     pub(super) trait_impls_set: HashSet<(String, String)>,
+    /// Dedup guard so a rejected overlapping primitive/builtin trait impl emits
+    /// only one `ConflictingTraitImpl` diagnostic even though
+    /// `record_primitive_trait_impl_self_args` runs once per impl method. Keyed
+    /// by (`canonical_constructor`, `trait_name`, `span.start`, `span.end`).
+    pub(super) conflicting_trait_impl_reported: HashSet<(String, String, usize, usize)>,
     /// Method names provided by each concrete trait impl block, keyed by
     /// (`type_name`, `trait_name`) as written on the impl. This preserves
     /// provenance that is lost when impl methods are flattened onto the type's
@@ -2950,6 +2955,7 @@ impl Checker {
             trait_super: HashMap::new(),
             trait_import_bindings: HashMap::new(),
             trait_impls_set: HashSet::new(),
+            conflicting_trait_impl_reported: HashSet::new(),
             trait_impl_method_names: HashMap::new(),
             primitive_trait_impls: HashMap::new(),
             primitive_trait_impl_self_args: HashMap::new(),

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -2443,6 +2443,22 @@ pub struct Checker {
     /// Outer key: (`canonical_primitive_or_builtin_name`, `trait_name`).
     /// Inner: method name → resolved `FnSig` (receiver already filtered).
     pub(super) primitive_trait_impls: HashMap<(String, String), HashMap<String, FnSig>>,
+    /// The impl's `Self` type arguments for each `impl <Trait> for
+    /// <PrimitiveOrBuiltinGeneric>`, captured at registration so dispatch can
+    /// bind the impl's type parameters from a concrete receiver's type
+    /// arguments before applying the signature.
+    ///
+    /// For `impl<E> Index for Vec<E>` the entry is `[Ty::Named { name: "E" }]`;
+    /// at a `v: Vec<i64>` call site, structurally unifying these stored args
+    /// against the receiver's `[i64]` yields the substitution `E → i64`, so the
+    /// method's `Option<E>` / `Self::Output` return projects to a concrete type
+    /// instead of leaking an unresolved inference var past the checker output
+    /// boundary. Non-generic primitive impls (`impl Display for i64`) store an
+    /// empty vec and are a no-op on dispatch.
+    ///
+    /// Key: (`canonical_primitive_or_builtin_name`, `trait_name`) — same as
+    /// [`Self::primitive_trait_impls`].
+    pub(super) primitive_trait_impl_self_args: HashMap<(String, String), Vec<Ty>>,
     /// Maps supervisor name to its partitioned child lists.
     ///
     /// Static children (declared with `child name: Type`) are in `statics`,
@@ -2936,6 +2952,7 @@ impl Checker {
             trait_impls_set: HashSet::new(),
             trait_impl_method_names: HashMap::new(),
             primitive_trait_impls: HashMap::new(),
+            primitive_trait_impl_self_args: HashMap::new(),
             supervisor_children: HashMap::new(),
             supervisor_child_slots: HashMap::new(),
             dyn_trait_coercions: HashMap::new(),

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -1028,6 +1028,26 @@ pub enum TypeErrorKind {
         /// Sorted names of the impl methods that are not on the trait.
         methods: Vec<String>,
     },
+    /// Two or more `impl <Trait> for <Type>` blocks target the same trait and
+    /// type constructor. Hew's single-crate coherence rule permits at most one
+    /// impl of a given trait per type constructor; specialization / overlapping
+    /// impls are a permanent non-goal (mission Q66.b, HEW-FUTURE §2.2). This
+    /// covers both overlapping (`impl<T> Acc for Vec<T>` + `impl Acc for
+    /// Vec<i64>`) and disjoint-concrete (`impl Acc for Vec<i64>` + `impl Acc for
+    /// Vec<string>`) duplicates, neither of which the associated-type binding
+    /// table (keyed by constructor name) can represent. Fail-closed: the second
+    /// impl is rejected at its declaration site rather than silently shadowed,
+    /// which would otherwise let its method signature and applicability proof
+    /// drift apart across the dispatch side tables.
+    ///
+    /// Envelope code: `E_CONFLICTING_TRAIT_IMPL`.
+    ConflictingTraitImpl {
+        /// Trait being implemented more than once for the same constructor.
+        trait_name: String,
+        /// The type constructor (e.g. `Vec`, `HashMap`, or a user record name)
+        /// that already has an impl of this trait.
+        type_name: String,
+    },
     /// A refutable pattern was used in a `let` binding.
     ///
     /// `let` bindings have no failure arm, so only irrefutable patterns
@@ -1231,6 +1251,7 @@ impl TypeErrorKind {
             Self::TraitImplSignatureMismatch { .. } => "TraitImplSignatureMismatch",
             Self::TraitImplMissingMethods { .. } => "TraitImplMissingMethods",
             Self::TraitImplExtraMethods { .. } => "TraitImplExtraMethods",
+            Self::ConflictingTraitImpl { .. } => "ConflictingTraitImpl",
             Self::IntrinsicOutsideFloor { .. } => "IntrinsicOutsideFloor",
             Self::IntrinsicOnMethod { .. } => "IntrinsicOnMethod",
             Self::RefutableLetPattern { .. } => "RefutableLetPattern",

--- a/hew-types/tests/builtin_trait_method_projection.rs
+++ b/hew-types/tests/builtin_trait_method_projection.rs
@@ -325,3 +325,128 @@ fn concrete_self_impl_projects_for_matching_receiver() {
         "concrete impl Acc for Vec<i64> projects Option<i64> on Vec<i64>",
     );
 }
+
+/// Coherence (builtin): two impls of the same trait for the same builtin
+/// constructor — a blanket `impl<T> Acc for Vec<T>` AND a concrete
+/// `impl Acc for Vec<i64>` — must be rejected. Hew has no specialization or
+/// overlapping impls (mission Q66.b; HEW-FUTURE §single-crate coherence), so a
+/// trait may be implemented at most once per type constructor. Without this
+/// rejection the dispatch side tables (self-args proof vs method signature)
+/// could be populated from different impls and drift, re-opening the
+/// over-application fail-open this lane closes.
+#[test]
+fn overlapping_builtin_impls_rejected() {
+    let output = typecheck(
+        r"
+        trait Acc {
+            type Output;
+            fn fetch(self, key: i64) -> Option<Self::Output>;
+        }
+        impl<T> Acc for Vec<T> {
+            type Output = T;
+            fn fetch(self, key: i64) -> Option<T> { None }
+        }
+        impl Acc for Vec<i64> {
+            type Output = i64;
+            fn fetch(self, key: i64) -> Option<i64> { None }
+        }
+        fn main() {}
+        ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|err| matches!(err.kind, TypeErrorKind::ConflictingTraitImpl { .. })),
+        "expected a ConflictingTraitImpl coherence diagnostic for the overlapping \
+         Vec impls, got: {:#?}",
+        output.errors
+    );
+}
+
+/// Coherence (builtin, same shape) — TRACKED KNOWN GAP.
+///
+/// Two genuinely-distinct `impl` blocks with the SAME `Self` shape — two
+/// `impl<T> Acc for Vec<T>` — are a duplicate that SHOULD be rejected with
+/// `ConflictingTraitImpl`, but currently are not: the coherence check compares
+/// `Self` shape (shape-equal duplicates read as a re-presentation of one impl).
+///
+/// Closing this needs the impl's DEFINING identity as the coherence key, but the
+/// only readily-available per-impl span cannot be used directly: the documented
+/// user-redeclare path (a user `pub trait Display` shadowing the prelude
+/// `Display`) makes the prelude `impl Display for i64` and the user
+/// `impl Display for i64` — two DISTINCT traits — collapse to the same
+/// `(canonical, "Display")` coherence key, so a defining-span key would falsely
+/// reject that legal shadow. A correct fix must additionally key on the trait's
+/// DEFINING identity (not its name), a larger cross-cutting change tracked as a
+/// separate follow-up: "trait-impl coherence: reject duplicate same-(type,trait)
+/// impls via defining-identity".
+///
+/// The projection fix this lane delivers is unaffected by the gap: first-wins
+/// keeps the dispatched method signature and the applicability proof from the
+/// SAME (first) impl, so an accepted duplicate cannot cause the mis-projection
+/// fail-open this lane closes. `#[ignore]` keeps the regression CI-visible
+/// (`cargo test -- --ignored`) without failing the gate; remove `#[ignore]` when
+/// the follow-up lands.
+#[test]
+#[ignore = "tracked: duplicate same-(type,trait) impl coherence needs defining-identity key (separate follow-up)"]
+fn duplicate_same_shape_builtin_impls_rejected() {
+    let output = typecheck(
+        r"
+        trait Acc {
+            type Output;
+            fn fetch(self, key: i64) -> Option<Self::Output>;
+        }
+        impl<T> Acc for Vec<T> {
+            type Output = T;
+            fn fetch(self, key: i64) -> Option<T> { None }
+        }
+        impl<T> Acc for Vec<T> {
+            type Output = T;
+            fn fetch(self, key: i64) -> Option<T> { None }
+        }
+        fn main() {}
+        ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|err| matches!(err.kind, TypeErrorKind::ConflictingTraitImpl { .. })),
+        "expected a ConflictingTraitImpl coherence diagnostic for the duplicate \
+         same-shape Vec impls, got: {:#?}",
+        output.errors
+    );
+}
+/// user-defined record constructors — `impl<T> Acc for Box2<T>` AND
+/// `impl Acc for Box2<i64>` must be rejected (fail-closed), never silently
+/// accepted. User-record impls do NOT flow through the primitive/builtin side
+/// table (where this lane's drift fail-open lived), so they are rejected by the
+/// pre-existing impl-coherence path rather than the new `ConflictingTraitImpl`
+/// primitive diagnostic. Either way the overlap must not type-check cleanly.
+#[test]
+fn overlapping_user_record_impls_rejected() {
+    let output = typecheck(
+        r"
+        trait Acc {
+            type Output;
+            fn fetch(self, key: i64) -> Option<Self::Output>;
+        }
+        type Box2<T> { inner: T; }
+        impl<T> Acc for Box2<T> {
+            type Output = T;
+            fn fetch(self, key: i64) -> Option<T> { Some(self.inner) }
+        }
+        impl Acc for Box2<i64> {
+            type Output = i64;
+            fn fetch(self, key: i64) -> Option<i64> { Some(self.inner) }
+        }
+        fn main() {}
+        ",
+    );
+    assert!(
+        !output.errors.is_empty(),
+        "expected the overlapping Box2 impls to be rejected (fail-closed), \
+         but type-check was clean",
+    );
+}

--- a/hew-types/tests/builtin_trait_method_projection.rs
+++ b/hew-types/tests/builtin_trait_method_projection.rs
@@ -1,0 +1,202 @@
+//! Generic trait methods on builtin/primitive receivers must bind the impl's
+//! type parameters from the concrete receiver's type arguments and project the
+//! associated/return types eagerly — exactly as the user-record concrete
+//! receiver path already does.
+//!
+//! Before the fix, `try_dispatch_primitive_trait_method` keyed on the
+//! type-erased canonical key (`"Vec"`, element discarded) and returned the raw
+//! signature's return type, leaving `Self::Output` / `Option<T>` returns as an
+//! unresolved inference var that escaped to the checker output boundary
+//! (`InferenceFailed`). The user-record (`Ty::Named`) path bound and projected
+//! correctly, so the asymmetry only bit builtin receivers (Vec/HashMap/...).
+//!
+//! Each positive test co-asserts projection by feeding the projected element
+//! into a type-constrained position (a `fn` that requires the concrete type) —
+//! if projection failed, the value would be an unresolved var and the program
+//! would not type-check. No external result-pinning (annotation / `unwrap_or`)
+//! is used.
+
+mod common;
+
+use common::typecheck;
+use hew_types::error::TypeErrorKind;
+
+fn assert_clean(source: &str, label: &str) {
+    let output = typecheck(source);
+    assert!(
+        output.errors.is_empty(),
+        "{label}: expected clean type-check, got errors: {:#?}",
+        output.errors
+    );
+}
+
+/// The exact reproducer: a generic trait impl on `Vec<T>` returning
+/// `Option<Self::Output>`, dispatched on a concrete `Vec<i64>`, must project
+/// `Option<i64>` with no external pinning. `takes_int(x)` pins the Some-arm
+/// binder to `i64`, so a failed projection (unresolved var) would not check.
+#[test]
+fn vec_generic_trait_method_projects_output() {
+    assert_clean(
+        r"
+        trait Acc {
+            type Output;
+            fn fetch(self, key: i64) -> Option<Self::Output>;
+        }
+        impl<T> Acc for Vec<T> {
+            type Output = T;
+            fn fetch(self, key: i64) -> Option<T> { None }
+        }
+        fn takes_int(x: i64) {}
+        fn main() {
+            let v: Vec<i64> = [10, 20, 30];
+            match v.fetch(1) {
+                Some(x) => takes_int(x),
+                None => {}
+            }
+        }
+        ",
+        "vec<i64>.fetch projects Option<i64>",
+    );
+}
+
+/// User-record control (`Box2<T>`) — the path that already worked — must keep
+/// projecting, co-asserted in the same harness so a regression here is caught.
+#[test]
+fn user_record_control_still_projects() {
+    assert_clean(
+        r"
+        trait Acc {
+            type Output;
+            fn fetch(self, key: i64) -> Option<Self::Output>;
+        }
+        type Box2<T> { inner: T; }
+        impl<T> Acc for Box2<T> {
+            type Output = T;
+            fn fetch(self, key: i64) -> Option<T> { Some(self.inner) }
+        }
+        fn takes_int(x: i64) {}
+        fn main() {
+            let b = Box2 { inner: 42 };
+            match b.fetch(0) {
+                Some(x) => takes_int(x),
+                None => {}
+            }
+        }
+        ",
+        "Box2<i64>.fetch projects Option<i64>",
+    );
+}
+
+/// Broaden over builtin kind: a generic trait impl on `HashMap<K, V>` must bind
+/// `V` from the concrete value type and project `Option<V>`.
+#[test]
+fn hashmap_generic_trait_method_projects_value() {
+    assert_clean(
+        r#"
+        trait Lookup {
+            type Output;
+            fn grab(self, key: string) -> Option<Self::Output>;
+        }
+        impl<K, V> Lookup for HashMap<K, V> {
+            type Output = V;
+            fn grab(self, key: string) -> Option<V> { None }
+        }
+        fn takes_int(x: i64) {}
+        fn main() {
+            let m: HashMap<string, i64> = HashMap::new();
+            match m.grab("a") {
+                Some(x) => takes_int(x),
+                None => {}
+            }
+        }
+        "#,
+        "HashMap<string,i64>.grab projects Option<i64>",
+    );
+}
+
+/// Broaden over element class: string element. `Vec<string>.fetch` must project
+/// `Option<string>`.
+#[test]
+fn vec_string_element_projects() {
+    assert_clean(
+        r#"
+        trait Acc {
+            type Output;
+            fn fetch(self, key: i64) -> Option<Self::Output>;
+        }
+        impl<T> Acc for Vec<T> {
+            type Output = T;
+            fn fetch(self, key: i64) -> Option<T> { None }
+        }
+        fn takes_str(s: string) {}
+        fn main() {
+            let v: Vec<string> = ["a", "b"];
+            match v.fetch(0) {
+                Some(s) => takes_str(s),
+                None => {}
+            }
+        }
+        "#,
+        "Vec<string>.fetch projects Option<string>",
+    );
+}
+
+/// Broaden over element class: owned-record element. `Vec<Point>.fetch` must
+/// project `Option<Point>` and the Some-arm binder must support field access.
+#[test]
+fn vec_owned_record_element_projects() {
+    assert_clean(
+        r"
+        trait Acc {
+            type Output;
+            fn fetch(self, key: i64) -> Option<Self::Output>;
+        }
+        impl<T> Acc for Vec<T> {
+            type Output = T;
+            fn fetch(self, key: i64) -> Option<T> { None }
+        }
+        type Point { x: i64; y: i64; }
+        fn takes_int(x: i64) {}
+        fn main() {
+            let pts: Vec<Point> = [Point { x: 1, y: 2 }];
+            match pts.fetch(0) {
+                Some(p) => takes_int(p.x),
+                None => {}
+            }
+        }
+        ",
+        "Vec<Point>.fetch projects Option<Point>",
+    );
+}
+
+/// Fail-closed: a genuinely-unresolvable element type (empty literal, no
+/// annotation) must still emit a clean `InferenceFailed` diagnostic — the
+/// projection must NOT fail open (accept a wrong/var shape) and must NOT leak a
+/// `Ty::Var` past the checker boundary or panic.
+#[test]
+fn unresolvable_element_fails_closed() {
+    let output = typecheck(
+        r"
+        trait Acc {
+            type Output;
+            fn fetch(self, key: i64) -> Option<Self::Output>;
+        }
+        impl<T> Acc for Vec<T> {
+            type Output = T;
+            fn fetch(self, key: i64) -> Option<T> { None }
+        }
+        fn main() {
+            let v = [];
+            let r = v.fetch(0);
+        }
+        ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|err| err.kind == TypeErrorKind::InferenceFailed),
+        "expected a clean InferenceFailed diagnostic, got: {:#?}",
+        output.errors
+    );
+}

--- a/hew-types/tests/builtin_trait_method_projection.rs
+++ b/hew-types/tests/builtin_trait_method_projection.rs
@@ -200,3 +200,128 @@ fn unresolvable_element_fails_closed() {
         output.errors
     );
 }
+
+/// Fail-closed (over-application): a concrete-`Self` builtin impl
+/// (`impl Acc for Vec<i64>`) must NOT be selected for a non-matching receiver
+/// (`Vec<string>`). Dispatch keys only on the canonical builtin (`Vec`), so the
+/// instantiation must prove the impl's concrete `Self` arg (`i64`) matches the
+/// receiver's element (`string`) — it does not, so this must fail closed with a
+/// clean "no method" diagnostic, never project an authoritative `Option<i64>`.
+#[test]
+fn concrete_self_impl_not_overapplied_to_mismatched_element() {
+    let output = typecheck(
+        r#"
+        trait Acc {
+            type Output;
+            fn fetch(self, key: i64) -> Option<Self::Output>;
+        }
+        impl Acc for Vec<i64> {
+            type Output = i64;
+            fn fetch(self, key: i64) -> Option<i64> { None }
+        }
+        fn main() {
+            let v: Vec<string> = ["a"];
+            let r = v.fetch(0);
+        }
+        "#,
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|err| err.kind == TypeErrorKind::UndefinedMethod),
+        "expected a no-method diagnostic (concrete impl must not over-apply), got: {:#?}",
+        output.errors
+    );
+}
+
+/// Fail-closed (constrained `Self`): `impl<V> Lookup for HashMap<string, V>`
+/// must NOT be selected for `HashMap<i64, bool>` — the constrained key position
+/// (`string`) does not match the receiver key (`i64`).
+#[test]
+fn constrained_key_impl_not_overapplied_to_mismatched_key() {
+    let output = typecheck(
+        r"
+        trait Lookup {
+            type Output;
+            fn grab(self, key: i64) -> Option<Self::Output>;
+        }
+        impl<V> Lookup for HashMap<string, V> {
+            type Output = V;
+            fn grab(self, key: i64) -> Option<V> { None }
+        }
+        fn main() {
+            let m: HashMap<i64, bool> = HashMap::new();
+            let r = m.grab(0);
+        }
+        ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|err| err.kind == TypeErrorKind::UndefinedMethod),
+        "expected a no-method diagnostic (constrained key must not over-apply), got: {:#?}",
+        output.errors
+    );
+}
+
+/// Fail-closed (nested constructor mismatch): `impl<T> Acc for Vec<Vec<T>>` must
+/// NOT bind `T` from `Vec<Option<i64>>` — the nested `Self` constructor (`Vec`)
+/// differs from the receiver element constructor (`Option`), so the recursive
+/// match must reject it rather than spuriously bind `T = i64`.
+#[test]
+fn nested_self_constructor_mismatch_does_not_bind() {
+    let output = typecheck(
+        r"
+        trait Acc {
+            type Output;
+            fn fetch(self, key: i64) -> Option<Self::Output>;
+        }
+        impl<T> Acc for Vec<Vec<T>> {
+            type Output = T;
+            fn fetch(self, key: i64) -> Option<T> { None }
+        }
+        fn main() {
+            let v: Vec<Option<i64>> = [Some(1)];
+            let r = v.fetch(0);
+        }
+        ",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|err| err.kind == TypeErrorKind::UndefinedMethod),
+        "expected a no-method diagnostic (nested ctor mismatch must not bind), got: {:#?}",
+        output.errors
+    );
+}
+
+/// Positive control for the shape-check: a concrete-`Self` builtin impl DOES
+/// apply to its exact receiver (`impl Acc for Vec<i64>` on `Vec<i64>`), proving
+/// the shape-check admits the matching case while rejecting the mismatched one.
+#[test]
+fn concrete_self_impl_projects_for_matching_receiver() {
+    assert_clean(
+        r"
+        trait Acc {
+            type Output;
+            fn fetch(self, key: i64) -> Option<Self::Output>;
+        }
+        impl Acc for Vec<i64> {
+            type Output = i64;
+            fn fetch(self, key: i64) -> Option<i64> { None }
+        }
+        fn takes_int(x: i64) {}
+        fn main() {
+            let v: Vec<i64> = [1, 2];
+            match v.fetch(0) {
+                Some(x) => takes_int(x),
+                None => {}
+            }
+        }
+        ",
+        "concrete impl Acc for Vec<i64> projects Option<i64> on Vec<i64>",
+    );
+}


### PR DESCRIPTION
## Summary
Generic trait methods on builtin receivers (e.g. `v.fetch(1)` where
`impl<T> Acc for Vec<T> { type Output = T; fn fetch(self, k: i64) -> Option<T> }`
and `v: Vec<i64>`) failed to project their return type — `Option<Self::Output>`
leaked an unresolved inference variable at the checker output boundary, because
builtin/primitive receivers dispatched through a type-erased path that never
bound the impl's type-params from the concrete receiver or projected the
associated type. User-record receivers already worked; this makes builtins
symmetric.

The dispatch now (1) records each `impl ... for <builtin>`'s `Self` type-args,
(2) proves the impl applies by structurally matching its `Self` against the
concrete receiver (arity + same-constructor + concrete-leaf equality) before
projecting — a non-matching impl fails closed to the normal "no method" path
rather than projecting an authoritative wrong type, and (3) enforces single-impl
coherence per (builtin constructor, trait), rejecting a structurally-different
second impl with a `ConflictingTraitImpl` diagnostic.

## Verification
- `make ci-preflight` green; `hew-types` full suite passes.
- Tests: projection fail→pass for the reproducer; over-application negatives
  (`Vec<i64>` impl rejected for `Vec<string>`; `HashMap<string,V>` for
  `HashMap<i64,bool>`; `Vec<Vec<T>>` for `Vec<Option<i64>>`); different-shape
  overlap rejection; positive projection controls across scalar/string/record
  and Vec/HashMap.

## Out of scope
- Same-name-trait shadow + same-shape duplicate-impl coherence (a duplicate
  `impl<T> Acc for Vec<T>` is currently accepted) needs trait-defining-identity
  threading; tracked as an ignored regression test that flips when that lands.
  The projection is unaffected (single-impl first-wins keeps sig and proof
  consistent).