### PR TITLE
fix(lints): stop two idiom-lint false positives (HashMap is_empty, else-scope)

### DIFF
--- a/hew-types/src/check/lints/len_zero_comparison.rs
+++ b/hew-types/src/check/lints/len_zero_comparison.rs
@@ -22,8 +22,12 @@
 //! - The other operand must be the integer literal `0` or `1` (with the
 //!   operator paired so the predicate is a genuine emptiness test — see the
 //!   table; `len() > 1`, `len() == 1`, … are not flagged).
-//! - The receiver's resolved type must expose `is_empty()` — `Vec`, `HashMap`,
-//!   `HashSet`, and `string` — verified through [`LintCtx::resolved_type_at`].
+//! - The receiver's resolved type must expose `is_empty()` — `Vec`, `HashSet`,
+//!   and `string` — verified through [`LintCtx::resolved_type_at`].
+//!   **`HashMap` is intentionally excluded**: it has a `len()` method but no
+//!   `is_empty()` in the dispatch registry or the `HashMapMethod` enum, so
+//!   suggesting `m.is_empty()` on a `HashMap` would produce a program that fails
+//!   at MIR lowering.
 
 use hew_parser::ast::{BinaryOp, Block, Expr, Literal, Span, Spanned};
 
@@ -174,14 +178,25 @@ fn flip(op: BinaryOp) -> Option<BinaryOp> {
     })
 }
 
-/// Builtin types that expose `len()` and `is_empty()` with `len() == 0`
-/// equivalent to `is_empty()`.
+/// Builtin types that expose both `len()` and a callable `is_empty()` with
+/// `len() == 0` equivalent to `is_empty()`.
+///
+/// Audit (origin/main ca310f0a):
+/// - `string`  — `is_empty` registered in the string method table ✓
+/// - `Vec<T>`  — `VecMethod::IsEmpty` in dispatch + registry ✓
+/// - `HashSet<T>` — `HashSetMethod::IsEmpty` in dispatch + registry ✓
+/// - `HashMap<K,V>` — **NOT included**: `HashMapMethod` has no `IsEmpty`
+///   variant and the `HashMap` method registry has no `is_empty` entry.  The
+///   descriptor table accepts the call for type-checking purposes, but
+///   `HashMap::is_empty` fails at MIR lowering because no runtime shim exists.
+///   Tracked as a stdlib gap (rc1 candidate); lint suppressed until the method
+///   is fully registered.
 fn type_has_is_empty(ty: &Ty) -> bool {
     matches!(ty, Ty::String)
         || matches!(
             ty,
             Ty::Named {
-                builtin: Some(BuiltinType::Vec | BuiltinType::HashMap | BuiltinType::HashSet),
+                builtin: Some(BuiltinType::Vec | BuiltinType::HashSet),
                 ..
             }
         )

--- a/hew-types/src/check/lints/redundant_else_after_return.rs
+++ b/hew-types/src/check/lints/redundant_else_after_return.rs
@@ -28,8 +28,13 @@
 //! - Considers the `if` only in statement position (`Stmt::If`) or block-tail
 //!   position (a trailing `Expr::If`), where dropping the `else` preserves
 //!   meaning. A value-position `if` feeding a `let` / argument is left alone.
+//! - Skips when the `else` body introduces a named `let` or `var` binding:
+//!   de-indenting would move it to the enclosing scope, where a later
+//!   same-name `let` becomes a hard same-scope rebinding error.  Wildcard
+//!   patterns (`let _ = …`) are not considered named bindings and do not
+//!   suppress the lint.
 
-use hew_parser::ast::{Block, Expr, Span, Stmt};
+use hew_parser::ast::{Block, Expr, Pattern, PatternField, Span, Stmt};
 
 use crate::error::TypeError;
 use crate::ty::Ty;
@@ -76,6 +81,17 @@ impl NodeVisitor for RedundantElse<'_> {
                 if else_block.if_stmt.is_some() || else_block.block.is_none() {
                     continue;
                 }
+                // Suppress when the else body introduces a named binding.
+                // De-indenting would move that binding to the enclosing scope;
+                // any later same-name `let` there becomes a same-scope
+                // rebinding error.  Wildcard `_` is exempt.
+                if else_block
+                    .block
+                    .as_ref()
+                    .is_some_and(block_has_any_named_binding)
+                {
+                    continue;
+                }
                 if block_always_diverges(self.ctx, then_block) {
                     self.hits.push(span.clone());
                 }
@@ -95,6 +111,11 @@ impl NodeVisitor for RedundantElse<'_> {
                 // An `else if` chain surfaces as the else expression being
                 // itself an `if` / `if let`; skip it.
                 if matches!(else_expr.0, Expr::If { .. } | Expr::IfLet { .. }) {
+                    return;
+                }
+                // Suppress when the else body (an Expr::Block) introduces a
+                // named binding for the same scope-safety reason as above.
+                if expr_block_has_any_named_binding(&else_expr.0) {
                     return;
                 }
                 if expr_always_diverges(self.ctx, &then_block.0, &then_block.1) {
@@ -166,5 +187,63 @@ fn expr_always_diverges(ctx: &LintCtx, expr: &Expr, span: &Span) -> bool {
         _ => ctx
             .resolved_type_at(span)
             .is_some_and(|ty| matches!(ty, Ty::Never)),
+    }
+}
+
+// ── Binding-scope guards ──────────────────────────────────────────────────────
+
+/// `true` when `block` contains a top-level `let` with a named pattern or a
+/// `var` declaration.
+///
+/// De-indenting a block with such statements moves the binding(s) into the
+/// enclosing scope, where a later same-name `let` becomes a hard same-scope
+/// rebinding error.  `let _ = …` (wildcard pattern) is exempted: `_` never
+/// introduces a named binding and cannot conflict.
+fn block_has_any_named_binding(block: &Block) -> bool {
+    block.stmts.iter().any(|(stmt, _)| match stmt {
+        Stmt::Let { pattern, .. } => pattern_introduces_binding(&pattern.0),
+        Stmt::Var { .. } => true,
+        _ => false,
+    })
+}
+
+/// `true` when `expr` is an [`Expr::Block`] that contains a named binding.
+fn expr_block_has_any_named_binding(expr: &Expr) -> bool {
+    if let Expr::Block(block) = expr {
+        block_has_any_named_binding(block)
+    } else {
+        false
+    }
+}
+
+/// `true` when `pat` introduces at least one named (non-wildcard) variable
+/// binding that would occupy a slot in the enclosing scope after de-indent.
+fn pattern_introduces_binding(pat: &Pattern) -> bool {
+    match pat {
+        // Non-binding leaf patterns.
+        Pattern::Wildcard | Pattern::Literal(_) => false,
+        // A single named binding.
+        Pattern::Identifier(_) => true,
+        // Composite patterns: any sub-pattern may bind.
+        Pattern::Constructor { patterns, .. } | Pattern::Tuple(patterns) => {
+            patterns.iter().any(|(p, _)| pattern_introduces_binding(p))
+        }
+        Pattern::Struct { fields, .. } | Pattern::RecordShorthand { fields, .. } => {
+            fields.iter().any(struct_field_introduces_binding)
+        }
+        Pattern::Or(a, b) => pattern_introduces_binding(&a.0) || pattern_introduces_binding(&b.0),
+        // Regex captures are named bindings.
+        Pattern::Regex { captures, .. } => !captures.is_empty(),
+    }
+}
+
+/// `true` when a struct/record pattern field introduces a named binding.
+///
+/// A shorthand field (`{ x }` with no explicit sub-pattern) always binds the
+/// field name; an explicit sub-pattern (`{ x: pat }`) delegates recursively.
+fn struct_field_introduces_binding(field: &PatternField) -> bool {
+    match &field.pattern {
+        None => true, // shorthand: `{ name }` binds `name`
+        Some((sub, _)) => pattern_introduces_binding(sub),
     }
 }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -6907,6 +6907,26 @@ fn redundant_else_not_flagged_for_else_if_chain() {
 }
 
 #[test]
+fn redundant_else_not_flagged_when_else_introduces_binding() {
+    // FP regression: the `else` block introduces `let y`, so de-indenting it
+    // would move `y` into the enclosing scope.  Any same-name `let y` that
+    // follows (as shown here) would then become a same-scope rebinding error.
+    // The lint must stay silent even though the then-branch always diverges.
+    let (errors, warnings) = parse_and_check(
+        "fn f(c: bool) -> i64 { if c { return 0; } else { let _y = 1; } let _y = 2; _y }",
+    );
+    assert!(
+        errors.is_empty(),
+        "fixture should type-check cleanly, got: {errors:?}"
+    );
+    assert_eq!(
+        count_redundant_else(&warnings),
+        0,
+        "else body introduces `let _y` — de-indent would change scope, must not lint, warnings: {warnings:?}"
+    );
+}
+
+#[test]
 fn redundant_else_deny_routes_to_errors() {
     let out = check_with_lint_level(
         "fn f(c: bool) { if c { return; } else { let _ = 1; } }",
@@ -7175,6 +7195,25 @@ fn len_zero_suppressed_by_directive() {
         0,
         "a directive above the comparison must suppress, warnings: {:?}",
         out.warnings
+    );
+}
+
+#[test]
+fn len_zero_hashmap_len_not_flagged() {
+    // FP regression: HashMap has no `is_empty()` method in the dispatch
+    // registry (HashMapMethod has no IsEmpty variant), so the suggested
+    // `m.is_empty()` rewrite would fail at MIR lowering.  The lint must
+    // not fire on HashMap receivers.
+    let (errors, warnings) =
+        parse_and_check("fn f(m: HashMap<string, i64>) -> bool { m.len() == 0 }");
+    assert!(
+        errors.is_empty(),
+        "fixture should type-check cleanly, got: {errors:?}"
+    );
+    assert_eq!(
+        count_len_zero(&warnings),
+        0,
+        "HashMap has no is_empty() — lint must not fire, warnings: {warnings:?}"
     );
 }
 


### PR DESCRIPTION
Fixes two false positives in the checker idiom lints (follow-on to the lint pass): both fired on valid code and suggested rewrites that break it.

- **`len_zero_comparison`**: stop suggesting `HashMap.is_empty()` — HashMap has no `is_empty` in the dispatch registry, so the rewrite fails MIR lowering. Audited the allow-list; string/Vec/HashSet keep `is_empty`, HashMap is removed.
- **`redundant_else_after_return`**: suppress when the `else` body introduces a named `let`/`var` binding — de-indenting it changes the binding's scope and can create a same-scope rebinding error. Wildcard `_` is exempt (genuinely redundant).

## Verification
- Two non-firing regression tests (HashMap `len() == 0`; `else { let _y = 1 }` before a same-name binding).
- Existing positive lint tests unaffected; `make ci-preflight` green.

## Out of scope
- HashMap genuinely lacks `is_empty` end-to-end (a real stdlib/dispatch gap) — tracked separately.
