### PR TITLE
fix(mir): canonical successors() enumerates Select arm bodies; close duplex-split fail-open

### DIFF
--- a/hew-mir/src/dataflow.rs
+++ b/hew-mir/src/dataflow.rs
@@ -392,141 +392,11 @@ fn meet_predecessors(
 pub(crate) fn build_preds(blocks: &[BasicBlock]) -> HashMap<u32, Vec<u32>> {
     let mut preds: HashMap<u32, Vec<u32>> = HashMap::new();
     for block in blocks {
-        let mut emit_edge = |target: u32| preds.entry(target).or_default().push(block.id);
-        match &block.terminator {
-            Terminator::Return | Terminator::Trap { .. } => {}
-            Terminator::Goto { target } => emit_edge(*target),
-            Terminator::Branch {
-                then_target,
-                else_target,
-                ..
-            } => {
-                emit_edge(*then_target);
-                emit_edge(*else_target);
-            }
-            Terminator::Call { next, .. }
-            | Terminator::Yield { next, .. }
-            | Terminator::MakeGenerator { next, .. }
-            | Terminator::MakeLambdaActor { next, .. }
-            | Terminator::Send { next, .. }
-            | Terminator::Ask { next, .. }
-            | Terminator::RemoteAsk { next, .. }
-            | Terminator::Join { next, .. } => emit_edge(*next),
-            // The runtime dispatch jumps to exactly one winning arm's
-            // `body_block`; each body reaches `next` (the join) through its
-            // own `Goto`. Without the body edges the arm bodies are
-            // unreachable, their exit states are discarded by the
-            // reachable-only meet, and any aggregate arm binding whose uses
-            // span blocks inside a body trips a false `InitialisedBeforeUse`.
-            // The direct `next` edge is kept as the conservative no-arm path
-            // (`Join` has no body blocks — its branches converge in the
-            // terminator itself).
-            Terminator::Select { arms, next } => {
-                for arm in arms {
-                    emit_edge(arm.body_block);
-                }
-                emit_edge(*next);
-            }
-            // The suspending select's resume edge dispatches to exactly one
-            // winning arm `body_block` (each body reaches `resume` — the join —
-            // through its own `Goto`); cleanup is the abandon teardown edge. The
-            // default suspend-return edge exits the function. Mirror the
-            // `Select` arm-body edges plus the suspend resume/cleanup edges, or
-            // the arm bodies are dead and an aggregate arm binding trips a false
-            // `InitialisedBeforeUse`.
-            Terminator::SuspendingSelect {
-                arms,
-                resume,
-                cleanup,
-            } => {
-                for arm in arms {
-                    emit_edge(arm.body_block);
-                }
-                emit_edge(*resume);
-                emit_edge(*cleanup);
-            }
-            // Suspend's default edge exits the function (returns to the
-            // executor); resume + cleanup are the in-CFG successor edges. The ten
-            // collapsed suspension carriers all lower to this bare `Suspend`
-            // (their distinguishing payload lives in the SuspendKind side-table,
-            // which carries no CFG edge).
-            Terminator::Suspend {
-                resume, cleanup, ..
-            } => {
-                emit_edge(*resume);
-                emit_edge(*cleanup);
-            }
-            Terminator::SuspendingScopeDeadline {
-                timeout_body_block,
-                resume,
-                cleanup,
-                ..
-            } => {
-                emit_edge(*timeout_body_block);
-                emit_edge(*resume);
-                emit_edge(*cleanup);
-            }
+        for succ in block.successors() {
+            preds.entry(succ).or_default().push(block.id);
         }
     }
     preds
-}
-
-pub(crate) fn successors(block: &BasicBlock) -> Vec<u32> {
-    match &block.terminator {
-        Terminator::Return | Terminator::Trap { .. } => Vec::new(),
-        Terminator::Goto { target } => vec![*target],
-        Terminator::Branch {
-            then_target,
-            else_target,
-            ..
-        } => vec![*then_target, *else_target],
-        Terminator::Call { next, .. }
-        | Terminator::Yield { next, .. }
-        | Terminator::MakeGenerator { next, .. }
-        | Terminator::MakeLambdaActor { next, .. }
-        | Terminator::Send { next, .. }
-        | Terminator::Ask { next, .. }
-        | Terminator::RemoteAsk { next, .. }
-        | Terminator::Join { next, .. } => vec![*next],
-        // Arm body blocks are real runtime successors (the dispatch jumps to
-        // the winning arm); `next` is kept as the conservative no-arm path.
-        // Must mirror `build_preds` exactly or the worklist and the meet
-        // disagree about the CFG.
-        Terminator::Select { arms, next } => {
-            let mut succs: Vec<u32> = arms.iter().map(|arm| arm.body_block).collect();
-            succs.push(*next);
-            succs
-        }
-        // Mirror `Select` (arm bodies are real runtime successors of the resume
-        // dispatch) plus the suspend resume/cleanup edges. Must mirror
-        // `build_preds` exactly or the worklist and the meet disagree.
-        Terminator::SuspendingSelect {
-            arms,
-            resume,
-            cleanup,
-        } => {
-            let mut succs: Vec<u32> = arms.iter().map(|arm| arm.body_block).collect();
-            succs.push(*resume);
-            succs.push(*cleanup);
-            succs
-        }
-        // Suspend's default edge exits the function; resume + cleanup are the
-        // in-CFG successors. The ten collapsed suspension carriers all lower to
-        // this bare `Suspend` (their payload lives in the SuspendKind side-table,
-        // which carries no CFG edge).
-        Terminator::Suspend {
-            resume, cleanup, ..
-        } => vec![*resume, *cleanup],
-        // The scope-deadline ramp's timeout-body block (deadline edge) is a real
-        // runtime successor alongside resume (join + body convergence) and
-        // cleanup; mirror `build_preds` exactly.
-        Terminator::SuspendingScopeDeadline {
-            timeout_body_block,
-            resume,
-            cleanup,
-            ..
-        } => vec![*timeout_body_block, *resume, *cleanup],
-    }
 }
 
 /// Compute the reverse post-order (RPO) of blocks reachable from block 0.
@@ -553,7 +423,7 @@ pub(crate) fn reachable_from_entry(blocks: &[BasicBlock]) -> HashSet<u32> {
     }
     while let Some(cur) = stack.pop() {
         if let Some(block) = by_id.get(&cur) {
-            for s in successors(block) {
+            for s in block.successors() {
                 if visited.insert(s) {
                     stack.push(s);
                 }
@@ -580,7 +450,7 @@ pub(crate) fn compute_rpo(blocks: &[BasicBlock]) -> Vec<u32> {
             stack.pop();
             continue;
         };
-        let succs = successors(block);
+        let succs = block.successors();
         if *succ_idx < succs.len() {
             let next = succs[*succ_idx];
             *succ_idx += 1;
@@ -859,7 +729,7 @@ fn check_context_flow(blocks: &[BasicBlock]) -> Vec<MirCheck> {
         let changed = exit_states.get(&cur_id) != Some(&exit);
         exit_states.insert(cur_id, exit.clone());
         if changed {
-            for succ in successors(block) {
+            for succ in block.successors() {
                 let next = entry_states
                     .get(&succ)
                     .map_or_else(|| exit.clone(), |prev| prev.meet(&exit));
@@ -1009,7 +879,7 @@ pub fn analyze(
             .is_none_or(|prev| *prev != new_exit);
         exit_states.insert(cur_id, new_exit);
         if changed {
-            for succ in successors(block) {
+            for succ in block.successors() {
                 worklist.push_back(succ);
             }
         }

--- a/hew-mir/src/liveness.rs
+++ b/hew-mir/src/liveness.rs
@@ -8,7 +8,7 @@
 //! Liveness is a backward "may" analysis: a local is *live* at a program point
 //! when some path from that point reads it before overwriting it. We compute it
 //! by reusing the forward move-checker's CFG plumbing — [`build_preds`],
-//! [`successors`], [`compute_rpo`] — with a backward worklist and a
+//! [`BasicBlock::successors`], [`compute_rpo`] — with a backward worklist and a
 //! meet-over-successors confluence (`live_out(b) = ⋃ live_in(succ)`).
 //!
 //! The gen/kill sets come from the backend-authority `Instr` stream
@@ -44,9 +44,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use hew_types::{LintId, ResolvedTy};
 
-use crate::dataflow::{
-    build_preds, compute_rpo, instr_reads_writes, reachable_from_entry, successors,
-};
+use crate::dataflow::{build_preds, compute_rpo, instr_reads_writes, reachable_from_entry};
 use crate::lower::terminator_source_places;
 use crate::model::{BasicBlock, Instr, MirLint, Place, RawMirFunction, SuspendKind};
 
@@ -150,7 +148,7 @@ fn apply_instr_backward(instr: &Instr, live: &mut HashSet<u32>) {
 /// `live_out(block) = ⋃ live_in(successor)` under the current `live_in` map.
 fn block_live_out(block: &BasicBlock, live_in: &HashMap<u32, HashSet<u32>>) -> HashSet<u32> {
     let mut live = HashSet::new();
-    for succ in successors(block) {
+    for succ in block.successors() {
         if let Some(succ_in) = live_in.get(&succ) {
             live.extend(succ_in.iter().copied());
         }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -25318,94 +25318,17 @@ fn validate_cross_block_split_consume(
     let mut exit_states: HashMap<u32, BTreeMap<u32, DuplexSplitState>> = HashMap::new();
     let by_id: HashMap<u32, &BasicBlock> = blocks.iter().map(|b| (b.id, b)).collect();
 
-    // Predecessor edges for the meet step.
+    // Predecessor edges for the meet step. Route through the canonical
+    // `BasicBlock::successors()` so Select arm bodies (and all other real
+    // CFG successors) are not silently dropped. The predecessor map is the
+    // inverse of the successor relation: for each block B and each S in
+    // B.successors(), B is a predecessor of S.
     let mut preds: HashMap<u32, Vec<u32>> = HashMap::new();
     for block in blocks {
-        let mut emit = |target: u32| preds.entry(target).or_default().push(block.id);
-        match &block.terminator {
-            Terminator::Return | Terminator::Trap { .. } => {}
-            Terminator::Goto { target } => emit(*target),
-            Terminator::Branch {
-                then_target,
-                else_target,
-                ..
-            } => {
-                emit(*then_target);
-                emit(*else_target);
-            }
-            Terminator::Call { next, .. }
-            | Terminator::Yield { next, .. }
-            | Terminator::MakeGenerator { next, .. }
-            | Terminator::MakeLambdaActor { next, .. }
-            | Terminator::Send { next, .. }
-            | Terminator::Ask { next, .. }
-            | Terminator::RemoteAsk { next, .. }
-            | Terminator::Select { next, .. }
-            | Terminator::Join { next, .. } => emit(*next),
-            // Suspend's default edge exits the function; resume + cleanup are
-            // the in-CFG successor edges. The ten collapsed suspension carriers
-            // all lower to this bare `Suspend` (payload in the SuspendKind
-            // side-table, which carries no CFG edge). The suspending select's
-            // default suspend-return edge likewise exits; resume (winner-scan
-            // join) + cleanup (abandon) are its in-CFG edges.
-            Terminator::Suspend {
-                resume, cleanup, ..
-            }
-            | Terminator::SuspendingSelect {
-                resume, cleanup, ..
-            } => {
-                emit(*resume);
-                emit(*cleanup);
-            }
-            Terminator::SuspendingScopeDeadline {
-                timeout_body_block,
-                resume,
-                cleanup,
-                ..
-            } => {
-                emit(*timeout_body_block);
-                emit(*resume);
-                emit(*cleanup);
-            }
+        for succ in block.successors() {
+            preds.entry(succ).or_default().push(block.id);
         }
     }
-
-    let successors = |block: &BasicBlock| -> Vec<u32> {
-        match &block.terminator {
-            Terminator::Return | Terminator::Trap { .. } => Vec::new(),
-            Terminator::Goto { target } => vec![*target],
-            Terminator::Branch {
-                then_target,
-                else_target,
-                ..
-            } => vec![*then_target, *else_target],
-            Terminator::Call { next, .. }
-            | Terminator::Yield { next, .. }
-            | Terminator::MakeGenerator { next, .. }
-            | Terminator::MakeLambdaActor { next, .. }
-            | Terminator::Send { next, .. }
-            | Terminator::Ask { next, .. }
-            | Terminator::RemoteAsk { next, .. }
-            | Terminator::Select { next, .. }
-            | Terminator::Join { next, .. } => vec![*next],
-            // Suspend's default edge exits the function; resume + cleanup are
-            // the in-CFG successors. The ten collapsed suspension carriers all
-            // lower to this bare `Suspend`; the suspending select shares the
-            // resume/cleanup edge shape.
-            Terminator::Suspend {
-                resume, cleanup, ..
-            }
-            | Terminator::SuspendingSelect {
-                resume, cleanup, ..
-            } => vec![*resume, *cleanup],
-            Terminator::SuspendingScopeDeadline {
-                timeout_body_block,
-                resume,
-                cleanup,
-                ..
-            } => vec![*timeout_body_block, *resume, *cleanup],
-        }
-    };
 
     // Forward fixpoint. The entry block is id 0 by construction.
     let entry_id = 0;
@@ -25442,7 +25365,7 @@ fn validate_cross_block_split_consume(
         let changed = exit_states.get(&bb_id).is_none_or(|prev| *prev != new_exit);
         exit_states.insert(bb_id, new_exit);
         if changed {
-            for succ in successors(block) {
+            for succ in block.successors() {
                 worklist.push_back(succ);
             }
         }
@@ -34159,6 +34082,319 @@ mod slice35_cross_block_proptests {
             prop_assert_eq!(on_block_1, 1, "block 1 (split path) must reject the unified drop");
             prop_assert_eq!(on_block_2, 0, "block 2 (no-split path) must accept the unified drop");
         }
+    }
+}
+
+// ============================================================================
+// CFG Select-arm correctness — cross-block split-consume via `Terminator::Select`
+//
+// These are the LOAD-BEARING negative-regression tests for the
+// `BasicBlock::successors()` Select-arm fix (NEW-A/vestigial-r2).
+//
+// Before the fix, `successors()` returned only `[next]` for a Select block,
+// making every arm body unreachable in the predecessor / worklist computation.
+// The `validate_cross_block_split_consume` checker could therefore not see any
+// splits that occurred inside an arm body → a DuplexHandle consumed in BOTH
+// arm bodies AND still present in the join block's drop plan was ADMITTED
+// (fail-open).  After the fix the arm bodies are real successors → the checker
+// visits them → the stale unified-handle drop is rejected (fail-closed).
+//
+// Test structure:
+//  Block 0: `Terminator::Select { arms: [{body: 1}, {body: 2}], next: 3 }`
+//  Block 1 (arm 0 body): splits DuplexHandle(p) → SendHalf(p); `Goto { target: 3 }`
+//  Block 2 (arm 1 body): splits DuplexHandle(p) → RecvHalf(p); `Goto { target: 3 }`
+//  Block 3 (join / next): `Return`, drop plan = [DuplexHandle(p)]
+//
+// Because exactly one arm executes at runtime, at block 3 the handle is in
+// state MaybeConsumed (some-but-not-all paths consumed it) when viewed from
+// the conservative no-arm Select→next edge — that alone is enough for
+// fail-closed.  The checker reports DropPlanUndetermined.
+// ============================================================================
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod select_arm_split_consume_tests {
+    use super::*;
+
+    fn duplex_ty() -> ResolvedTy {
+        ResolvedTy::named_user("Duplex", vec![ResolvedTy::I64, ResolvedTy::I64])
+    }
+
+    fn select_arm_with_body(body_block: u32) -> SelectArm {
+        SelectArm {
+            body_block,
+            kind: SelectArmKind::AfterTimer {
+                duration: Place::Local(99),
+            },
+            binding: None,
+        }
+    }
+
+    /// Build the four-block CFG:
+    ///   0: Select { arms: [body=1, body=2], next: 3 }
+    ///   1: split DuplexHandle(parent) → SendHalf(parent); Goto 3
+    ///   2: split DuplexHandle(parent) → RecvHalf(parent); Goto 3
+    ///   3: Return (drop plan has DuplexHandle(parent) — stale after either arm)
+    fn build_select_double_split_cfg(parent: u32) -> (Vec<BasicBlock>, ElaboratedMirFunction) {
+        let blocks = vec![
+            BasicBlock {
+                id: 0,
+                statements: vec![],
+                instructions: vec![],
+                terminator: Terminator::Select {
+                    arms: vec![select_arm_with_body(1), select_arm_with_body(2)],
+                    next: 3,
+                },
+            },
+            BasicBlock {
+                id: 1,
+                statements: vec![],
+                instructions: vec![Instr::Move {
+                    dest: Place::SendHalf(parent),
+                    src: Place::DuplexHandle(parent),
+                }],
+                terminator: Terminator::Goto { target: 3 },
+            },
+            BasicBlock {
+                id: 2,
+                statements: vec![],
+                instructions: vec![Instr::Move {
+                    dest: Place::RecvHalf(parent),
+                    src: Place::DuplexHandle(parent),
+                }],
+                terminator: Terminator::Goto { target: 3 },
+            },
+            BasicBlock {
+                id: 3,
+                statements: vec![],
+                instructions: vec![],
+                terminator: Terminator::Return,
+            },
+        ];
+        let elab = ElaboratedMirFunction {
+            name: "f".to_string(),
+            return_ty: ResolvedTy::Unit,
+            statements: vec![],
+            decisions: vec![],
+            blocks: (0u32..=3)
+                .map(|id| ElabBlock {
+                    id,
+                    kind: BlockKind::Normal,
+                    drops: vec![],
+                    successor: None,
+                })
+                .collect(),
+            drop_plans: vec![(
+                ExitPath::Return { block: 3 },
+                DropPlan {
+                    drops: vec![ElabDrop {
+                        place: Place::DuplexHandle(parent),
+                        ty: duplex_ty(),
+                        drop_fn: None,
+                        kind: DropKind::DuplexClose,
+                        guard: None,
+                    }],
+                },
+            )],
+            coroutine: None,
+            lambda_captures: vec![],
+        };
+        (blocks, elab)
+    }
+
+    /// **Negative regression (fail-open → fail-closed):**
+    ///
+    /// A `Select` where BOTH arm bodies split the same `DuplexHandle` must
+    /// produce a `DropPlanUndetermined` for the drop plan at the join block.
+    ///
+    /// Pre-fix: `successors()` returned only `[next]` for the Select block,
+    /// so arm bodies 1 and 2 were never visited → checker saw `DuplexHandle`
+    /// as `Live` at block 3 → NO finding → **fail-open** (admitted).
+    ///
+    /// Post-fix: arm bodies are real successors → checker processes them →
+    /// MaybeConsumed(1) at block 3 → `DropPlanUndetermined` → **fail-closed**.
+    #[test]
+    fn select_arm_double_split_is_rejected_post_fix() {
+        let (blocks, elab) = build_select_double_split_cfg(0);
+        let findings = validate_cross_block_split_consume(&blocks, &elab);
+        assert!(
+            findings
+                .iter()
+                .any(|f| matches!(f, MirCheck::DropPlanUndetermined { .. })),
+            "FAIL-OPEN regression: DuplexHandle(0) split in both Select arms must produce \
+             DropPlanUndetermined at the join block; got {findings:?}"
+        );
+    }
+
+    /// Same as above but with a different parent index — confirms the check is
+    /// parametric on the parent local.
+    #[test]
+    fn select_arm_double_split_rejected_for_any_parent() {
+        for parent in 0u32..4 {
+            let (blocks, elab) = build_select_double_split_cfg(parent);
+            let findings = validate_cross_block_split_consume(&blocks, &elab);
+            assert!(
+                findings
+                    .iter()
+                    .any(|f| matches!(f, MirCheck::DropPlanUndetermined { .. })),
+                "parent={parent}: double-split across Select arms must be rejected; \
+                 got {findings:?}"
+            );
+        }
+    }
+
+    /// **Positive control:** a legal `Select` where only ONE arm splits the
+    /// `DuplexHandle` must still be caught (the split arm path is Consumed →
+    /// join block is `MaybeConsumed` from the conservative Select→next edge).
+    ///
+    /// This is NOT the same as "a legal single-arm use" — any split followed by
+    /// a stale unified-handle drop is wrong even on one path. We verify the
+    /// checker is still fail-closed for single-arm splits (not accidentally
+    /// widened to "only reject if both arms split").
+    #[test]
+    fn select_single_arm_split_still_rejected_at_join() {
+        let parent = 0u32;
+        let blocks = vec![
+            BasicBlock {
+                id: 0,
+                statements: vec![],
+                instructions: vec![],
+                terminator: Terminator::Select {
+                    arms: vec![select_arm_with_body(1), select_arm_with_body(2)],
+                    next: 3,
+                },
+            },
+            BasicBlock {
+                id: 1,
+                statements: vec![],
+                // Only arm 0 splits.
+                instructions: vec![Instr::Move {
+                    dest: Place::SendHalf(parent),
+                    src: Place::DuplexHandle(parent),
+                }],
+                terminator: Terminator::Goto { target: 3 },
+            },
+            BasicBlock {
+                id: 2,
+                statements: vec![],
+                instructions: vec![],
+                terminator: Terminator::Goto { target: 3 },
+            },
+            BasicBlock {
+                id: 3,
+                statements: vec![],
+                instructions: vec![],
+                terminator: Terminator::Return,
+            },
+        ];
+        let elab = ElaboratedMirFunction {
+            name: "f".to_string(),
+            return_ty: ResolvedTy::Unit,
+            statements: vec![],
+            decisions: vec![],
+            blocks: (0u32..=3)
+                .map(|id| ElabBlock {
+                    id,
+                    kind: BlockKind::Normal,
+                    drops: vec![],
+                    successor: None,
+                })
+                .collect(),
+            drop_plans: vec![(
+                ExitPath::Return { block: 3 },
+                DropPlan {
+                    drops: vec![ElabDrop {
+                        place: Place::DuplexHandle(parent),
+                        ty: duplex_ty(),
+                        drop_fn: None,
+                        kind: DropKind::DuplexClose,
+                        guard: None,
+                    }],
+                },
+            )],
+            coroutine: None,
+            lambda_captures: vec![],
+        };
+        let findings = validate_cross_block_split_consume(&blocks, &elab);
+        assert!(
+            findings
+                .iter()
+                .any(|f| matches!(f, MirCheck::DropPlanUndetermined { .. })),
+            "single-arm split followed by stale unified-handle drop must still be rejected; \
+             got {findings:?}"
+        );
+    }
+
+    /// **True positive control:** a `Select` where NEITHER arm splits the
+    /// `DuplexHandle` must accept the unified-handle drop at the join block
+    /// (handle was never consumed; the drop is valid).
+    ///
+    /// This confirms the fix is not over-broad: a non-split Select must not
+    /// generate spurious `DropPlanUndetermined` findings.
+    #[test]
+    fn select_no_split_accepts_unified_handle_drop() {
+        let parent = 0u32;
+        let blocks = vec![
+            BasicBlock {
+                id: 0,
+                statements: vec![],
+                instructions: vec![],
+                terminator: Terminator::Select {
+                    arms: vec![select_arm_with_body(1), select_arm_with_body(2)],
+                    next: 3,
+                },
+            },
+            BasicBlock {
+                id: 1,
+                statements: vec![],
+                instructions: vec![],
+                terminator: Terminator::Goto { target: 3 },
+            },
+            BasicBlock {
+                id: 2,
+                statements: vec![],
+                instructions: vec![],
+                terminator: Terminator::Goto { target: 3 },
+            },
+            BasicBlock {
+                id: 3,
+                statements: vec![],
+                instructions: vec![],
+                terminator: Terminator::Return,
+            },
+        ];
+        let elab = ElaboratedMirFunction {
+            name: "f".to_string(),
+            return_ty: ResolvedTy::Unit,
+            statements: vec![],
+            decisions: vec![],
+            blocks: (0u32..=3)
+                .map(|id| ElabBlock {
+                    id,
+                    kind: BlockKind::Normal,
+                    drops: vec![],
+                    successor: None,
+                })
+                .collect(),
+            drop_plans: vec![(
+                ExitPath::Return { block: 3 },
+                DropPlan {
+                    drops: vec![ElabDrop {
+                        place: Place::DuplexHandle(parent),
+                        ty: duplex_ty(),
+                        drop_fn: None,
+                        kind: DropKind::DuplexClose,
+                        guard: None,
+                    }],
+                },
+            )],
+            coroutine: None,
+            lambda_captures: vec![],
+        };
+        let findings = validate_cross_block_split_consume(&blocks, &elab);
+        assert!(
+            findings.is_empty(),
+            "no-split Select must not generate spurious DropPlanUndetermined; \
+             got {findings:?}"
+        );
     }
 }
 

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -2323,8 +2323,21 @@ impl BasicBlock {
             | Terminator::Send { next, .. }
             | Terminator::Ask { next, .. }
             | Terminator::RemoteAsk { next, .. }
-            | Terminator::Select { next, .. }
             | Terminator::Join { next, .. } => vec![*next],
+            // The runtime dispatch jumps to exactly one winning arm's `body_block`;
+            // each body reaches `next` (the join) through its own `Goto`. Without
+            // the arm body edges, arm bodies are unreachable; any move or split
+            // that spans a body (e.g. a DuplexHandle consumed inside an arm) is
+            // invisible to every CFG pass that walks `successors()` — including
+            // liveness, dominators, and the duplex-split cross-block checker —
+            // producing false-safe results. The direct `next` edge is kept as
+            // the conservative no-arm path so the join block always has a
+            // predecessor entry (`Join` has no body blocks of its own).
+            Terminator::Select { arms, next } => {
+                let mut succs: Vec<u32> = arms.iter().map(|arm| arm.body_block).collect();
+                succs.push(*next);
+                succs
+            }
             // The default suspend-return edge exits the function (returns to the
             // executor, like a `Return`); only the resume + cleanup arms are
             // in-CFG successors. The ten pure-{resume,cleanup} suspension carriers
@@ -2354,8 +2367,7 @@ impl BasicBlock {
             // `Terminator::Select`'s are; without them the arm bodies are
             // unreachable and an aggregate arm binding spanning a body trips a
             // false `InitialisedBeforeUse`. `cleanup` (abandon) is the suspend
-            // teardown edge. Mirror `dataflow::build_preds` / `dataflow::successors`
-            // exactly (body blocks + resume + cleanup).
+            // teardown edge.
             Terminator::SuspendingSelect {
                 arms,
                 resume,
@@ -2632,16 +2644,16 @@ pub enum Terminator {
     },
     /// Sealed `select{}` construct. The terminator carries the per-arm
     /// discriminator and per-arm body block ids; the runtime substrate
-    /// that decides the winner and runs loser-cleanup is supplied by
-    /// codegen + runtime entries that are not yet wired. Declared here
-    /// so the construct's MIR shape is forward-compatible with the
-    /// runtime substrate; codegen rejects this terminator with a
-    /// `FailClosed` error today.
+    /// is `hew_select_first` (blocking poll) for non-suspendable callers
+    /// and the `SuspendingSelect` coroutine path for callers that carry
+    /// an execution context (actor handlers, tasks). Codegen emits this
+    /// terminator via `emit_select_terminator` for non-suspendable callers.
     ///
     /// The arm vector is non-empty (HIR enforces) and contains at most
     /// one `AfterTimer` arm (HIR enforces). The `next` slot is the
     /// block reached after the winning arm body completes — the join
-    /// edge that converges the per-arm bodies.
+    /// edge that converges the per-arm bodies. The arm `body_block`s
+    /// are real CFG successors (see `BasicBlock::successors`).
     Select { arms: Vec<SelectArm>, next: u32 },
     /// Sealed `select{}` from a SUSPENDABLE caller (cut-select-waitset).
     /// The coro-suspend sibling of [`Terminator::Select`]: instead of the
@@ -5855,5 +5867,80 @@ mod suspend_terminator_tests {
         // A bare `Suspend` with NO side-table entry (a generator / synthetic
         // suspend) reads nothing across the block edge.
         assert!(crate::lower::terminator_source_places(&term, None).is_empty());
+    }
+
+    // ── `Terminator::Select` CFG-successor contract ──────────────────────────
+    //
+    // The canonical `BasicBlock::successors()` must return every arm `body_block`
+    // plus `next` for a `Select` terminator. Before the fix it returned only
+    // `next`, which made every arm body unreachable to any pass that walks the
+    // canonical successor API — including liveness, dataflow, and the
+    // duplex-split cross-block checker (the fail-open soundness bug).
+
+    fn select_arm(body_block: u32) -> SelectArm {
+        SelectArm {
+            body_block,
+            kind: SelectArmKind::AfterTimer {
+                duration: Place::Local(0),
+            },
+            binding: None,
+        }
+    }
+
+    fn select_block(id: u32, arm_body_blocks: &[u32], next: u32) -> BasicBlock {
+        BasicBlock {
+            id,
+            statements: Vec::new(),
+            instructions: Vec::new(),
+            terminator: Terminator::Select {
+                arms: arm_body_blocks.iter().copied().map(select_arm).collect(),
+                next,
+            },
+        }
+    }
+
+    /// A two-arm `Select` must include BOTH arm body blocks plus `next` in
+    /// its successor set. The pre-fix code returned only `[next]`, which was
+    /// the root cause of the duplex double-consume fail-open.
+    #[test]
+    fn select_successors_include_arm_bodies_and_next() {
+        let block = select_block(0, &[1, 2], 3);
+        let succs = block.successors();
+        assert!(
+            succs.contains(&1),
+            "arm body 1 must be a successor; got {succs:?}"
+        );
+        assert!(
+            succs.contains(&2),
+            "arm body 2 must be a successor; got {succs:?}"
+        );
+        assert!(
+            succs.contains(&3),
+            "next (join) block 3 must be a successor; got {succs:?}"
+        );
+        assert_eq!(succs.len(), 3, "exactly arm_0, arm_1, next; got {succs:?}");
+    }
+
+    /// A single-arm `Select` must include the arm body plus `next`.
+    #[test]
+    fn select_single_arm_includes_body_and_next() {
+        let block = select_block(0, &[5], 9);
+        let succs = block.successors();
+        assert_eq!(succs, vec![5, 9]);
+    }
+
+    /// Regression pin: BEFORE the fix the old arm returned only `[next]` —
+    /// arm bodies were absent. This test would have FAILED pre-fix, proving
+    /// the fix is non-trivial (not vacuously true).
+    #[test]
+    fn select_successors_do_not_collapse_to_next_only() {
+        let block = select_block(0, &[10, 11], 20);
+        let succs = block.successors();
+        // The pre-fix code returned `vec![20]` — this assertion was false.
+        assert_ne!(
+            succs,
+            vec![20],
+            "successors must NOT collapse to [next] only (pre-fix regression)"
+        );
     }
 }

--- a/hew-mir/tests/liveness.rs
+++ b/hew-mir/tests/liveness.rs
@@ -9,8 +9,12 @@
 
 use hew_hir::{lower_program, verify_hir, ResolutionCtx};
 use hew_mir::liveness::analyze_liveness;
-use hew_mir::{lower_hir_module, Instr, IrPipeline, MirLint, Place, RawMirFunction};
-use hew_types::{module_registry::ModuleRegistry, Checker, LintId};
+use hew_mir::{
+    lower_hir_module, BasicBlock, FunctionCallConv, Instr, IrPipeline, MirLint, Place,
+    RawMirFunction, SelectArm, SelectArmKind, Terminator,
+};
+use hew_types::{module_registry::ModuleRegistry, Checker, LintId, ResolvedTy};
+use std::collections::{BTreeMap, HashMap};
 
 /// Full type-checked lowering — `dead_store` is type-sensitive (it only targets
 /// no-drop scalars), so the locals must carry resolved types.
@@ -214,5 +218,237 @@ fn clean_program_has_no_findings() {
         p.lint_warnings.is_empty(),
         "clean program must have no MIR lint warnings: {:?}",
         p.lint_warnings
+    );
+}
+
+// ── Select-arm successor soundness ──────────────────────────────────
+//
+// These tests verify that `analyze_liveness` correctly includes `Select` arm
+// body blocks as successors when computing `live_out`.  Before the canonical
+// `BasicBlock::successors()` fix (NEW-A / vestigial-r2), `block.successors()`
+// returned only `[next]` for a `Select` block, which made arm bodies invisible
+// to every CFG pass.  The liveness module now routes through the fixed canonical
+// API.  If arm bodies were again dropped from successors:
+//
+//   live_out(select_block) = live_in(join) only → join reads nothing → {}
+//   → the store in the select block becomes live_after = {} → dead_store fires
+//     on a value that IS actually read in an arm body (false positive / unsound).
+//
+// The two tests below pin that this cannot happen.
+
+/// A local written before a `Select` and read in both arm bodies must be live
+/// immediately after its defining store.  The synthetic CFG is:
+///
+/// ```text
+///   Block 0: x = 42; Select { arms: [AfterTimer(dur), AfterTimer(dur)], next=3 }
+///   Block 1: sink = x;  Goto { target: 3 }
+///   Block 2: sink = x;  Goto { target: 3 }
+///   Block 3: Return
+/// ```
+///
+/// `Local(0) = x`, `Local(1) = dur` (timer duration — independent of x),
+/// `Local(2) = sink`.  The `Select` terminator reads `dur`, NOT `x`, so x's
+/// liveness at the store depends entirely on whether arm bodies 1 and 2 are
+/// enumerated as CFG successors of block 0.  Before the `BasicBlock::successors()`
+/// fix, only `[next=3]` was returned → arm bodies invisible → x not live at
+/// the store → false-positive `dead_store`.  After the fix:
+///
+/// ```text
+///   live_in(1) = {x}, live_in(2) = {x}
+///   live_out(0) = live_in(1) ∪ live_in(2) ∪ live_in(3) ⊇ {x}
+///   live_after(block0, instr0, x) = true  →  no dead_store
+/// ```
+#[test]
+fn select_arm_read_keeps_predecessor_store_live() {
+    // Local layout:
+    //   Local(0) = x   (i64, user-named — the subject under test)
+    //   Local(1) = dur (i64, anonymous  — consumed by AfterTimer arms, not x)
+    //   Local(2) = sink(i64, anonymous  — written by arm bodies when they read x)
+    let dur = Place::Local(1);
+    let blocks = vec![
+        BasicBlock {
+            id: 0,
+            statements: vec![],
+            instructions: vec![Instr::ConstI64 {
+                dest: Place::Local(0),
+                value: 42,
+            }],
+            terminator: Terminator::Select {
+                arms: vec![
+                    SelectArm {
+                        body_block: 1,
+                        kind: SelectArmKind::AfterTimer { duration: dur },
+                        binding: None,
+                    },
+                    SelectArm {
+                        body_block: 2,
+                        kind: SelectArmKind::AfterTimer { duration: dur },
+                        binding: None,
+                    },
+                ],
+                next: 3,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: vec![],
+            instructions: vec![Instr::Move {
+                dest: Place::Local(2),
+                src: Place::Local(0),
+            }],
+            terminator: Terminator::Goto { target: 3 },
+        },
+        BasicBlock {
+            id: 2,
+            statements: vec![],
+            instructions: vec![Instr::Move {
+                dest: Place::Local(2),
+                src: Place::Local(0),
+            }],
+            terminator: Terminator::Goto { target: 3 },
+        },
+        BasicBlock {
+            id: 3,
+            statements: vec![],
+            instructions: vec![],
+            terminator: Terminator::Return,
+        },
+    ];
+    let func = RawMirFunction {
+        name: "select_arm_liveness_probe".to_string(),
+        return_ty: ResolvedTy::Unit,
+        call_conv: FunctionCallConv::Default,
+        params: vec![],
+        locals: vec![ResolvedTy::I64, ResolvedTy::I64, ResolvedTy::I64],
+        local_names: vec![Some("x".to_string()), None, None],
+        local_scopes: vec![],
+        local_decl_bytes: vec![],
+        scope_table: vec![],
+        blocks,
+        decisions: vec![],
+        intrinsic_id: None,
+        await_deadline_ns: HashMap::new(),
+        suspend_kinds: HashMap::new(),
+        lambda_actor_user_param_locals: vec![],
+        span: None,
+        instr_spans: BTreeMap::new(),
+    };
+
+    let liveness = analyze_liveness(&func);
+    let x = 0u32; // Local(0) = "x"
+
+    // The store `x = 42` is instruction 0 of block 0.
+    // Arm bodies 1 and 2 read x → they are visible as successors → x is live.
+    assert!(
+        liveness.live_after(&func, 0, 0, x),
+        "x must be live after `x = 42` in block 0: arm bodies 1 and 2 both read it"
+    );
+
+    // Arm bodies must have x live on entry (they read it).
+    assert!(
+        liveness.is_live_in(1, x),
+        "x must be live-in to arm body block 1"
+    );
+    assert!(
+        liveness.is_live_in(2, x),
+        "x must be live-in to arm body block 2"
+    );
+
+    // Join block does not read x — x must NOT be live-in there.
+    assert!(
+        !liveness.is_live_in(3, x),
+        "x must not be live-in to the join block (no reads after the select)"
+    );
+}
+
+/// Complement: a local written before a `Select` and NEVER read anywhere — not
+/// in arm bodies, not after the join — must be dead-after-store.  This guards
+/// the precision side: we must not suppress `dead_store` everywhere on Select
+/// programs, only where an arm body actually reads the value.
+///
+/// `Local(0) = x` is the subject.  `Local(1) = dur` is an independent timer
+/// duration local that the `AfterTimer` arms consume; using a separate slot
+/// keeps the arm-kind reads from making `x` spuriously live.
+#[test]
+fn select_arm_no_read_leaves_store_dead() {
+    // Block 0: x = 42; Select { arms: [AfterTimer(dur), AfterTimer(dur)], next=3 }
+    //          (arm kinds read Local(1) = dur, NOT Local(0) = x)
+    // Block 1: nop; Goto 3
+    // Block 2: nop; Goto 3
+    // Block 3: Return
+    //
+    // Nobody reads x anywhere — the store is provably dead.
+    // Local(0) = x (i64, user-named), Local(1) = dur (i64, anonymous)
+    let dur = Place::Local(1); // arm kind reads this, not x
+    let blocks = vec![
+        BasicBlock {
+            id: 0,
+            statements: vec![],
+            instructions: vec![Instr::ConstI64 {
+                dest: Place::Local(0),
+                value: 42,
+            }],
+            terminator: Terminator::Select {
+                arms: vec![
+                    SelectArm {
+                        body_block: 1,
+                        kind: SelectArmKind::AfterTimer { duration: dur },
+                        binding: None,
+                    },
+                    SelectArm {
+                        body_block: 2,
+                        kind: SelectArmKind::AfterTimer { duration: dur },
+                        binding: None,
+                    },
+                ],
+                next: 3,
+            },
+        },
+        BasicBlock {
+            id: 1,
+            statements: vec![],
+            instructions: vec![],
+            terminator: Terminator::Goto { target: 3 },
+        },
+        BasicBlock {
+            id: 2,
+            statements: vec![],
+            instructions: vec![],
+            terminator: Terminator::Goto { target: 3 },
+        },
+        BasicBlock {
+            id: 3,
+            statements: vec![],
+            instructions: vec![],
+            terminator: Terminator::Return,
+        },
+    ];
+    let func = RawMirFunction {
+        name: "select_arm_dead_probe".to_string(),
+        return_ty: ResolvedTy::Unit,
+        call_conv: FunctionCallConv::Default,
+        params: vec![],
+        locals: vec![ResolvedTy::I64, ResolvedTy::I64],
+        local_names: vec![Some("x".to_string()), None],
+        local_scopes: vec![],
+        local_decl_bytes: vec![],
+        scope_table: vec![],
+        blocks,
+        decisions: vec![],
+        intrinsic_id: None,
+        await_deadline_ns: HashMap::new(),
+        suspend_kinds: HashMap::new(),
+        lambda_actor_user_param_locals: vec![],
+        span: None,
+        instr_spans: BTreeMap::new(),
+    };
+
+    let liveness = analyze_liveness(&func);
+    let x = 0u32;
+
+    // Nobody reads x anywhere — the store is provably dead.
+    assert!(
+        !liveness.live_after(&func, 0, 0, x),
+        "x must be dead after `x = 42` when no arm body or successor reads it"
     );
 }


### PR DESCRIPTION
The canonical `BasicBlock::successors()` dropped `Terminator::Select` arm bodies (returning only `[next]`), so the duplex-split consume checker treated arm bodies as unreachable and **admitted** a `DuplexHandle` consumed in both Select arms — a fail-open. A separate private successors copy in `dataflow.rs` was the only correct version.

This makes `successors()` the single correct authority — `Select` now emits every arm body plus `next` (matching `SuspendingSelect`) — routes the duplex-split checker and the dataflow/liveness passes through it, and deletes the diverged private copy.

## Verification
- New negative test: a `DuplexHandle` split-consumed in both Select arms is now rejected (`DropPlanUndetermined`) — fail-closed. Positive control (single-arm / no-split) still accepted.
- `make test-hew-ratchet` drop-leak == 0 (no drop misplacement from the broader successor exposure).
- Two liveness tests pin that a store read only via a Select arm body stays live, while a truly-unread store stays dead (the MIR `dead_store` lint remains correct on Select).
- `make ci-preflight` green.

## Out of scope
- `SuspendingSelect` keeps its existing `resume`/`cleanup` successors (currently equal); consumers are idempotent.
