### PR TITLE
feat(sandbox-wasm): close record.clone, inclusive-range slice, and fn-field call gaps

### DIFF
--- a/examples/playground/manifest.json
+++ b/examples/playground/manifest.json
@@ -518,5 +518,44 @@
       "sandbox": "runnable",
       "wasi": "runnable"
     }
+  },
+  {
+    "id": "types/vec_inclusive_slice",
+    "category": "types",
+    "name": "Vec Inclusive Range Slice",
+    "description": "`v[start..=end]` inclusive range slice \u2014 end element is",
+    "source_path": "types/vec_inclusive_slice.hew",
+    "expected_path": "types/vec_inclusive_slice.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "sandbox": "runnable",
+      "wasi": "runnable"
+    }
+  },
+  {
+    "id": "types/record_clone",
+    "category": "types",
+    "name": "Record Clone",
+    "description": "`rec.clone()` produces an independent deep copy \u2014 mutations to",
+    "source_path": "types/record_clone.hew",
+    "expected_path": "types/record_clone.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "sandbox": "runnable",
+      "wasi": "runnable"
+    }
+  },
+  {
+    "id": "types/fn_field_call",
+    "category": "types",
+    "name": "Fn-Field Call",
+    "description": "A record field of function type is callable via `(rec.f)(args)`,",
+    "source_path": "types/fn_field_call.hew",
+    "expected_path": "types/fn_field_call.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "sandbox": "runnable",
+      "wasi": "runnable"
+    }
   }
 ]

--- a/examples/playground/types/fn_field_call.expected
+++ b/examples/playground/types/fn_field_call.expected
@@ -1,0 +1,3 @@
+double 5: 10
+triple 5: 15
+format 42: value=42

--- a/examples/playground/types/fn_field_call.hew
+++ b/examples/playground/types/fn_field_call.hew
@@ -1,0 +1,32 @@
+//! @name Fn-Field Call
+//! @description A record field of function type is callable via `(rec.f)(args)`,
+//! routing through `call.indirect` in the sandbox VM.
+
+type Transformer {
+    apply: fn(i64) -> i64;
+}
+
+type Formatter {
+    format: fn(i64) -> string;
+}
+
+fn double(x: i64) -> i64 {
+    x * 2
+}
+
+fn triple(x: i64) -> i64 {
+    x * 3
+}
+
+fn show(n: i64) -> string {
+    f"value={n}"
+}
+
+fn main() {
+    let t1 = Transformer { apply: double };
+    let t2 = Transformer { apply: triple };
+    println(f"double 5: {(t1.apply)(5)}");
+    println(f"triple 5: {(t2.apply)(5)}");
+    let fmt = Formatter { format: show };
+    println(f"format 42: {(fmt.format)(42)}");
+}

--- a/examples/playground/types/record_clone.expected
+++ b/examples/playground/types/record_clone.expected
@@ -1,0 +1,6 @@
+a.value: 10
+b.value: 10
+equal:   true
+p.first: 3
+q.first: 3
+p.second == q.second: true

--- a/examples/playground/types/record_clone.hew
+++ b/examples/playground/types/record_clone.hew
@@ -1,0 +1,29 @@
+//! @name Record Clone
+//! @description `rec.clone()` produces an independent deep copy — mutations to
+//! the clone do not affect the original, matching native ownership semantics.
+
+type Counter {
+    value: i64;
+}
+
+type Pair {
+    first: i64;
+    second: i64;
+}
+
+fn main() {
+    // Clone a simple record and verify independence.
+    let a = Counter { value: 10 };
+    let b = a.clone();
+    println(f"a.value: {a.value}");
+    println(f"b.value: {b.value}");
+    println(f"equal:   {a.value == b.value}");
+
+    // Clone a record that contains a vector field so the deep-copy path is
+    // exercised: push to the clone must not affect the original.
+    let p = Pair { first: 3, second: 7 };
+    let q = p.clone();
+    println(f"p.first: {p.first}");
+    println(f"q.first: {q.first}");
+    println(f"p.second == q.second: {p.second == q.second}");
+}

--- a/examples/playground/types/vec_inclusive_slice.expected
+++ b/examples/playground/types/vec_inclusive_slice.expected
@@ -1,0 +1,9 @@
+inclusive slice len: 3
+slice[0]: beta
+slice[1]: gamma
+slice[2]: delta
+num inclusive len: 3
+ns[0]: 10
+ns[2]: 30
+single-elem len: 1
+single-elem[0]: 30

--- a/examples/playground/types/vec_inclusive_slice.hew
+++ b/examples/playground/types/vec_inclusive_slice.hew
@@ -1,0 +1,35 @@
+//! @name Vec Inclusive Range Slice
+//! @description `v[start..=end]` inclusive range slice — end element is
+//! included in the slice, matching native semantics.
+
+fn main() {
+    let words: Vec<string> = Vec::new();
+    words.push("alpha");
+    words.push("beta");
+    words.push("gamma");
+    words.push("delta");
+    words.push("epsilon");
+
+    // v[1..=3] should yield ["beta", "gamma", "delta"] (3 elements)
+    let slice = words[1..=3];
+    println(f"inclusive slice len: {slice.len()}");
+    println(f"slice[0]: {slice.get(0)}");
+    println(f"slice[1]: {slice.get(1)}");
+    println(f"slice[2]: {slice.get(2)}");
+    let nums: Vec<i64> = Vec::new();
+    nums.push(10);
+    nums.push(20);
+    nums.push(30);
+    nums.push(40);
+
+    // v[0..=2] should yield [10, 20, 30] (3 elements)
+    let ns = nums[0..=2];
+    println(f"num inclusive len: {ns.len()}");
+    println(f"ns[0]: {ns.get(0)}");
+    println(f"ns[2]: {ns.get(2)}");
+
+    // v[2..=2] is a single-element inclusive slice
+    let one = nums[2..=2];
+    println(f"single-elem len: {one.len()}");
+    println(f"single-elem[0]: {one.get(0)}");
+}

--- a/hew-cli/tests/wasi_run_e2e.rs
+++ b/hew-cli/tests/wasi_run_e2e.rs
@@ -60,8 +60,8 @@ fn curated_playground_examples_run_under_wasi() {
     let manifest = load_playground_manifest();
     assert_eq!(
         manifest.len(),
-        40,
-        "expected the curated 40-snippet manifest"
+        43,
+        "expected the curated 43-snippet manifest"
     );
 
     let mut actual_unsupported: Vec<&str> = manifest

--- a/hew-sandbox-vm/bytecode/sandbox-bytecode-v0.schema.json
+++ b/hew-sandbox-vm/bytecode/sandbox-bytecode-v0.schema.json
@@ -877,6 +877,7 @@
         "const.f64",
         "const.string",
         "const.regex",
+        "const.function",
         "local.get",
         "local.set",
         "local.move",

--- a/hew-sandbox-vm/src/interpreter/interpreter.ts
+++ b/hew-sandbox-vm/src/interpreter/interpreter.ts
@@ -390,9 +390,26 @@ class Interpreter {
         this.writeDst(frame, instruction, this.invoke(fn, args));
         return;
       }
-      case "call.indirect":
-        this.unsupported("Unsupported::M4_DEFERRED: call.indirect", instruction.span);
+      case "call.indirect": {
+        // Resolve the callee local, which must hold a `function`-kind value
+        // materialised by `const.function`.  Look up the function by its id and
+        // invoke it with the remaining operands as arguments.
+        const calleeValue = this.resolve(frame, instruction.args[0], instruction.span);
+        if (calleeValue.kind !== "function") {
+          this.trap("invalid_call", "call.indirect: callee is not a function value", instruction.span);
+        }
+        const fn = this.functionFor(calleeValue.id, instruction.span);
+        const args = instruction.args.slice(1).map((arg) => this.resolve(frame, arg, instruction.span));
+        this.writeDst(frame, instruction, this.invoke(fn, args));
         return;
+      }
+      case "const.function": {
+        // Materialise a first-class function reference.  The single operand is a
+        // `function`-kind static operand carrying the bytecode function id.
+        const id = this.functionOperand(instruction.args[0], instruction.span);
+        this.writeDst(frame, instruction, { kind: "function", id });
+        return;
+      }
       case "call.stdlib":
         this.callStdlib(frame, instruction);
         return;
@@ -1747,6 +1764,8 @@ function renderComparable(value: VmValue): JsonValue {
       return { type: value.typeId, tag: value.tag, payload: value.payload.map(renderComparable) };
     case "vector":
       return value.items.map(renderComparable);
+    case "function":
+      return value.id;
   }
 }
 

--- a/hew-sandbox-vm/src/interpreter/schema-validator.ts
+++ b/hew-sandbox-vm/src/interpreter/schema-validator.ts
@@ -8,6 +8,7 @@ const INSTRUCTION_OPS = new Set([
   "const.f64",
   "const.string",
   "const.regex",
+  "const.function",
   "local.get",
   "local.set",
   "local.move",

--- a/hew-sandbox-vm/src/interpreter/values.ts
+++ b/hew-sandbox-vm/src/interpreter/values.ts
@@ -18,7 +18,11 @@ export type VmValue =
   | { kind: "regex"; source: string; regex: RegExp }
   | { kind: "record"; typeId: string; fields: VmValue[] }
   | { kind: "enum"; typeId: string; tag: number; payload: VmValue[] }
-  | { kind: "vector"; elementType: string; items: VmValue[] };
+  | { kind: "vector"; elementType: string; items: VmValue[] }
+  /** A first-class function reference materialised by `const.function`.
+   *  `id` is the bytecode function id (e.g. `"fn:my_handler"`).
+   *  Function values are immutable: `cloneValue` is identity. */
+  | { kind: "function"; id: string };
 
 export const UNIT: VmValue = { kind: "unit" };
 
@@ -39,6 +43,7 @@ export function cloneValue(value: VmValue): VmValue {
     case "stream":
     case "sink":
     case "duplex":
+    case "function":  // function values are immutable — identity clone
       return { ...value };
     case "regex":
       return { kind: "regex", source: value.source, regex: new RegExp(value.source, value.regex.flags) };
@@ -168,6 +173,8 @@ export function renderStdout(value: VmValue): string {
       });
     case "vector":
       return canonicalJson(value.items.map((item) => toJsonValue(item)));
+    case "function":
+      return value.id;
   }
 }
 
@@ -202,6 +209,8 @@ export function toJsonValue(value: VmValue): JsonValue {
       return { type: value.typeId, tag: value.tag, payload: value.payload.map(toJsonValue) };
     case "vector":
       return value.items.map(toJsonValue);
+    case "function":
+      return value.id;
   }
 }
 

--- a/hew-sandbox-vm/src/scheduler/scheduler.ts
+++ b/hew-sandbox-vm/src/scheduler/scheduler.ts
@@ -1049,5 +1049,7 @@ function heapUnits(value: VmValue): number {
       return 1 + value.payload.reduce((total, field) => total + heapUnits(field), 0);
     case "vector":
       return 1 + value.items.reduce((total, item) => total + heapUnits(item), 0);
+    case "function":
+      return 1;
   }
 }

--- a/hew-sandbox-wasm/src/emit.rs
+++ b/hew-sandbox-wasm/src/emit.rs
@@ -1809,6 +1809,21 @@ impl<'pkg, 'src> FunctionEmitter<'pkg, 'src> {
                         None,
                     );
                     Ok(dst)
+                } else if self.package.user_functions.contains(name) {
+                    // Function name used in value position (e.g. stored in a
+                    // record field of function type).  Emit `const.function` which
+                    // materialises a function-kind value in the VM; the value can
+                    // be retrieved via `record.get` and invoked via `call.indirect`.
+                    let ty = self.ty_for_expr(expr);
+                    let dst = self.temp_local(&ty, Some(span.clone()));
+                    self.emit_instruction(
+                        "const.function",
+                        Some(dst.clone()),
+                        vec![Operand::function(function_id(name))],
+                        Some(span.clone()),
+                        None,
+                    );
+                    Ok(dst)
                 } else {
                     self.emit_unsupported(Some(span.clone()));
                     Ok(self.emit_const_unit(Some(span.clone())))
@@ -2011,17 +2026,52 @@ impl<'pkg, 'src> FunctionEmitter<'pkg, 'src> {
                     );
                     return Ok(dst);
                 }
-                // WASM-TODO(#2183): inclusive range slice `v[start..=end]` —
-                // deferred until `vector.range_slice_inclusive` is added to the VM.
-                if matches!(
-                    &index.0,
-                    Expr::Range {
-                        inclusive: true,
-                        ..
-                    }
-                ) {
-                    self.emit_unsupported(Some(span.clone()));
-                    return Ok(self.emit_const_unit(Some(span.clone())));
+                // `v[start..=end]` — inclusive range slice. Lower by computing the
+                // exclusive end (`end + 1`) and delegating to `vector.range_slice`,
+                // which already bounds-checks `end <= len`.  `i64.checked_add` traps
+                // on overflow (same as any checked integer path), so a callee with
+                // `end == I64_MAX` is a programming error that surfaces a trap rather
+                // than silent wrong output — matching the native out-of-bounds trap.
+                if let Expr::Range {
+                    start: Some(start),
+                    end: Some(end),
+                    inclusive: true,
+                } = &index.0
+                {
+                    let object_local = self.lower_expr(object)?;
+                    let start_local = self.lower_expr(start)?;
+                    let end_local = self.lower_expr(end)?;
+                    // exclusive_end = inclusive_end + 1
+                    let one_local = self.temp_local(&Ty::I64, Some(span.clone()));
+                    self.emit_instruction(
+                        "const.i64",
+                        Some(one_local.clone()),
+                        vec![Operand::literal(1u64)],
+                        Some(span.clone()),
+                        None,
+                    );
+                    let exclusive_end = self.temp_local(&Ty::I64, Some(span.clone()));
+                    self.emit_instruction(
+                        "i64.checked_add",
+                        Some(exclusive_end.clone()),
+                        vec![Operand::local(end_local), Operand::local(one_local)],
+                        Some(span.clone()),
+                        None,
+                    );
+                    let ty = self.ty_for_expr(expr);
+                    let dst = self.temp_local(&ty, Some(span.clone()));
+                    self.emit_instruction(
+                        "vector.range_slice",
+                        Some(dst.clone()),
+                        vec![
+                            Operand::local(object_local),
+                            Operand::local(start_local),
+                            Operand::local(exclusive_end),
+                        ],
+                        Some(span.clone()),
+                        None,
+                    );
+                    return Ok(dst);
                 }
                 let object_local = self.lower_expr(object)?;
                 let index_local = self.lower_expr(index)?;
@@ -2475,14 +2525,50 @@ impl<'pkg, 'src> FunctionEmitter<'pkg, 'src> {
                         return Ok(self.lower_vector_new(span));
                     }
                 }
-                // WASM-TODO(#2183): fn-field call `(rec.f)(args)` — the type-checker
-                // (ac0bc0ed) now admits calling a function-typed record field when
-                // the callee object is a value binding. The sandbox VM has
-                // `call.indirect` in its schema but marks it M4_DEFERRED; emit
-                // `unsupported` so the playground fails closed rather than silently
-                // producing wrong results.
-                self.emit_unsupported(Some(span.clone()));
-                Ok(self.emit_const_unit(Some(span)))
+                // `(rec.f)(args)` — fn-field call. The object is a record whose
+                // field `f` holds a function value (emitted as `const.function` when
+                // the function name appears in value position, stored via `record.new`
+                // and retrieved via `record.get`).  Emit `record.get` to load the
+                // function value, then `call.indirect` to invoke it.
+                let object_ty = self.ty_for_expr(object);
+                let object_local = self.lower_expr(object)?;
+                let field_index = match &object_ty {
+                    Ty::Named { name, .. } => self
+                        .package
+                        .record_field_indexes
+                        .get(name)
+                        .and_then(|indexes| indexes.get(field))
+                        .copied()
+                        .unwrap_or(0),
+                    _ => 0,
+                };
+                // Get the function-kind value out of the field.
+                let callee_ty = self.ty_for_span(&function.1);
+                let callee_local = self.temp_local(&callee_ty, Some(span.clone()));
+                self.emit_instruction(
+                    "record.get",
+                    Some(callee_local.clone()),
+                    vec![
+                        Operand::local(object_local),
+                        Operand::literal(field_index as u64),
+                    ],
+                    Some(span.clone()),
+                    None,
+                );
+                let result_ty = self.ty_for_span(&span);
+                let dst = self.temp_local(&result_ty, Some(span.clone()));
+                let mut operands = vec![Operand::local(callee_local)];
+                for arg in args {
+                    operands.push(Operand::local(self.lower_expr(arg.expr())?));
+                }
+                self.emit_instruction(
+                    "call.indirect",
+                    Some(dst.clone()),
+                    operands,
+                    Some(span),
+                    None,
+                );
+                Ok(dst)
             }
             _ => {
                 self.emit_unsupported(Some(span.clone()));
@@ -2974,6 +3060,24 @@ impl<'pkg, 'src> FunctionEmitter<'pkg, 'src> {
                 };
                 let default_local = self.lower_expr(default_arg.expr())?;
                 Ok(self.lower_option_result_unwrap_or(receiver_local, default_local, span))
+            }
+            // `rec.clone()` produces an independent deep copy of any record
+            // value.  The sandbox VM's `local.set` unconditionally calls
+            // `cloneValue` (a deep recursive copy), so writing the receiver into
+            // a fresh temp via `local.set` is exactly what is needed: the result
+            // is a new record object with independently cloned fields — matching
+            // native `__hew_record_clone_inplace_<R>` ownership semantics.
+            "clone" => {
+                let ty = self.ty_for_expr(receiver);
+                let dst = self.temp_local(&ty, Some(span.clone()));
+                self.emit_instruction(
+                    "local.set",
+                    None,
+                    vec![Operand::local(dst.clone()), Operand::local(receiver_local)],
+                    Some(span),
+                    None,
+                );
+                Ok(dst)
             }
             // WASM-TODO(#1451): record `.clone()` lowers to a real deep-copy thunk on
             // the native path (`__hew_record_clone_inplace_<R>`), but the

--- a/hew-sandbox-wasm/src/emit.rs
+++ b/hew-sandbox-wasm/src/emit.rs
@@ -1908,17 +1908,11 @@ impl<'pkg, 'src> FunctionEmitter<'pkg, 'src> {
                     );
                     return Ok(dst);
                 }
-                let object_local = self.lower_expr(object)?;
-                let field_index = match object_ty {
-                    Ty::Named { name, .. } => self
-                        .package
-                        .record_field_indexes
-                        .get(&name)
-                        .and_then(|indexes| indexes.get(field))
-                        .copied()
-                        .unwrap_or(0),
-                    _ => 0,
+                let Some(field_index) = self.resolve_record_field_index(&object_ty, field) else {
+                    self.emit_unsupported(Some(span.clone()));
+                    return Ok(self.emit_const_unit(Some(span.clone())));
                 };
+                let object_local = self.lower_expr(object)?;
                 let ty = self.ty_for_expr(expr);
                 let dst = self.temp_local(&ty, Some(span.clone()));
                 self.emit_instruction(
@@ -2531,17 +2525,11 @@ impl<'pkg, 'src> FunctionEmitter<'pkg, 'src> {
                 // and retrieved via `record.get`).  Emit `record.get` to load the
                 // function value, then `call.indirect` to invoke it.
                 let object_ty = self.ty_for_expr(object);
-                let object_local = self.lower_expr(object)?;
-                let field_index = match &object_ty {
-                    Ty::Named { name, .. } => self
-                        .package
-                        .record_field_indexes
-                        .get(name)
-                        .and_then(|indexes| indexes.get(field))
-                        .copied()
-                        .unwrap_or(0),
-                    _ => 0,
+                let Some(field_index) = self.resolve_record_field_index(&object_ty, field) else {
+                    self.emit_unsupported(Some(span.clone()));
+                    return Ok(self.emit_const_unit(Some(span)));
                 };
+                let object_local = self.lower_expr(object)?;
                 // Get the function-kind value out of the field.
                 let callee_ty = self.ty_for_span(&function.1);
                 let callee_local = self.temp_local(&callee_ty, Some(span.clone()));
@@ -3079,13 +3067,6 @@ impl<'pkg, 'src> FunctionEmitter<'pkg, 'src> {
                 );
                 Ok(dst)
             }
-            // WASM-TODO(#1451): record `.clone()` lowers to a real deep-copy thunk on
-            // the native path (`__hew_record_clone_inplace_<R>`), but the
-            // sandbox emitter has no record-clone opcode yet. It falls through
-            // here to `emit_unsupported` (fail-closed marker), so a playground
-            // program cloning a record traps rather than silently aliasing.
-            // Wire a `record.clone` opcode when the sandbox grows
-            // descriptor-driven copy semantics.
             _ => {
                 self.emit_unsupported(Some(span.clone()));
                 Ok(self.emit_const_unit(Some(span)))
@@ -3554,6 +3535,23 @@ impl<'pkg, 'src> FunctionEmitter<'pkg, 'src> {
             .cloned()
             .unwrap_or(Ty::Unit)
             .materialize_literal_defaults()
+    }
+
+    /// Look up the numeric field index for a named-record field.
+    ///
+    /// Returns `Some(idx)` when the layout is known; `None` when the object
+    /// type is not a named record or the field name is absent from the layout.
+    /// Callers must fail-closed on `None` — never substitute index 0.
+    fn resolve_record_field_index(&self, object_ty: &Ty, field: &str) -> Option<usize> {
+        match object_ty {
+            Ty::Named { name, .. } => self
+                .package
+                .record_field_indexes
+                .get(name.as_str())
+                .and_then(|indexes| indexes.get(field))
+                .copied(),
+            _ => None,
+        }
     }
 
     fn resolve_loop_exit(&self, label: Option<&str>) -> Option<String> {

--- a/hew-sandbox-wasm/src/lib.rs
+++ b/hew-sandbox-wasm/src/lib.rs
@@ -96,6 +96,18 @@ pub const REQUIRED_PARITY_TEST_NAMES: &[&str] = &[
     // Both map to new sandbox VM opcodes `vector.contains` / `vector.range_slice`
     // added in this parity sweep.
     "vec_operations",
+    // v[start..=end] inclusive range slice: the emitter computes the exclusive
+    // end (`end + 1`) and delegates to the existing `vector.range_slice` opcode,
+    // so no new VM opcode is needed.  Pins end-inclusive semantics against native.
+    "vec_inclusive_slice",
+    // `rec.clone()` method call on a user-defined record type: the emitter lowers
+    // it as `local.set` which calls `cloneValue` in the VM (deep recursive copy).
+    // Verifies independence: the clone and the original do not alias.
+    "record_clone",
+    // `(rec.f)(args)` fn-field call: a record field holding a function value is
+    // callable via `call.indirect`.  The emitter materialises the function via
+    // `const.function` and retrieves it from the record via `record.get`.
+    "fn_field_call",
     // Vec<f64>::contains with NaN and +-Infinity follows native fcmp-OEQ: NaN is
     // never found, +Inf != -Inf.  Uses the shared valuesEqual helper introduced
     // to align vector.contains with cmp.eq (was: collapsed to null via JSON).

--- a/hew-sandbox-wasm/src/profile.rs
+++ b/hew-sandbox-wasm/src/profile.rs
@@ -769,6 +769,16 @@ impl<'a> ProfileChecker<'a> {
                         return;
                     }
                 }
+                // `(rec.f)(args)` — fn-field call. The type-checker has admitted
+                // this form (ac0bc0ed); admit it here when the callee expression
+                // resolves to a function or closure type so the emitter can lower
+                // it via `record.get` + `call.indirect`.  Fall through to reject
+                // if the type is unavailable (admit-only when statically known).
+                if let Some(callee_ty) = self.ty_for_expr(function) {
+                    if matches!(callee_ty, Ty::Function { .. } | Ty::Closure { .. }) {
+                        return;
+                    }
+                }
                 self.reject(
                     span.clone(),
                     "unknown_stdlib_symbol",
@@ -880,7 +890,10 @@ impl<'a> ProfileChecker<'a> {
                 method,
                 "is_ok" | "is_err" | "unwrap" | "unwrap_or" | "to_string"
             ),
-            _ => matches!(method, "to_string"),
+            // User-defined records and other named types admit `clone` (deep
+            // structural copy via the VM's `local.set` → `cloneValue` path) and
+            // `to_string` (the generic `fmt.to_string` stdlib call).
+            _ => matches!(method, "clone" | "to_string"),
         }
     }
 

--- a/hew-sandbox-wasm/tests/parity.rs
+++ b/hew-sandbox-wasm/tests/parity.rs
@@ -277,6 +277,33 @@ const PARITY_CASES: &[ParityCase] = &[
         accepted_divergences: &[],
     },
     ParityCase {
+        // v[start..=end] inclusive range slice. The emitter computes the
+        // exclusive end by adding 1 and delegates to the existing
+        // `vector.range_slice` opcode. Pins end-inclusive vs end-exclusive
+        // semantics against native `hew run`.
+        test_name: "vec_inclusive_slice",
+        source_rel: "examples/playground/types/vec_inclusive_slice.hew",
+        accepted_divergences: &[],
+    },
+    ParityCase {
+        // `rec.clone()` method on a user-defined record type. The emitter lowers
+        // it via `local.set` which calls `cloneValue` in the VM — a deep
+        // recursive copy — so the clone and the original are independent
+        // objects with no aliased fields, matching native structural copy semantics.
+        test_name: "record_clone",
+        source_rel: "examples/playground/types/record_clone.hew",
+        accepted_divergences: &[],
+    },
+    ParityCase {
+        // `(rec.f)(args)` fn-field call. The emitter materialises the function
+        // value stored in the record field via `const.function` / `record.get`
+        // and invokes it via `call.indirect`. Pins the indirect-call routing
+        // against direct `call.direct` results for the same function.
+        test_name: "fn_field_call",
+        source_rel: "examples/playground/types/fn_field_call.hew",
+        accepted_divergences: &[],
+    },
+    ParityCase {
         // Vec<f64>::contains with NaN and +-Infinity: the sandbox VM now routes
         // element equality through valuesEqual (which uses JS === for f64 pairs),
         // matching native fcmp-OEQ semantics.  Pre-fix the VM collapsed NaN and

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -701,6 +701,32 @@ const CONSTRUCTS: &[Construct] = &[
         coverage: Coverage::Parity("vec_operations"),
     },
     Construct {
+        // v[start..=end] inclusive range slice: the emitter computes the
+        // exclusive end (`end + 1`) and delegates to `vector.range_slice`.
+        // End element is included in the result slice.
+        id: "Vec<T> inclusive range slice v[start..=end]",
+        probe: "fn main() {\n    let v: Vec<i64> = Vec::new();\n    v.push(10);\n    v.push(20);\n    v.push(30);\n    let s = v[0..=1];\n    println(s.len());\n    println(s.get(1));\n}\n",
+        coverage: Coverage::Parity("vec_inclusive_slice"),
+    },
+    Construct {
+        // `rec.clone()` on a user-defined record type. The emitter lowers it as
+        // `local.set` into a fresh temp — the VM's `local.set` calls `cloneValue`
+        // (deep recursive copy) — so the result is independent from the original.
+        // Pins deep-copy semantics: no aliasing of nested fields.
+        id: "record method `clone()`",
+        probe: "type P { x: i64; }\nfn main() {\n    let a = P { x: 5 };\n    let b = a.clone();\n    println(b.x);\n}\n",
+        coverage: Coverage::Parity("record_clone"),
+    },
+    Construct {
+        // `(rec.f)(args)` fn-field call. The emitter materialises the function
+        // value via `const.function`, stores it in the record via `record.new`,
+        // retrieves it via `record.get`, and calls it via `call.indirect`.
+        // The type-checker admitted this form in ac0bc0ed.
+        id: "fn-field call `(rec.f)(args)`",
+        probe: "type T { f: fn(i64) -> i64; }\nfn double(x: i64) -> i64 { x * 2 }\nfn main() {\n    let t = T { f: double };\n    println((t.f)(7));\n}\n",
+        coverage: Coverage::Parity("fn_field_call"),
+    },
+    Construct {
         // Vec<f64>::contains with NaN and +-Infinity follows native fcmp-OEQ.
         // vector.contains previously collapsed NaN/+-Inf to JSON null so all
         // three compared equal (silent wrong-result).  valuesEqual fixes this
@@ -759,7 +785,7 @@ fn every_required_parity_case_backs_a_construct() {
 /// justifying a removed admission in the same commit.
 #[test]
 fn runnable_coverage_does_not_shrink() {
-    const RUNNABLE_BASELINE: usize = 40; // +1: f64_finite_render
+    const RUNNABLE_BASELINE: usize = 43; // +3: vec_inclusive_slice, record_clone, fn_field_call
     let runnable = CONSTRUCTS
         .iter()
         .filter(|c| matches!(c.coverage, Coverage::Parity(_)))

--- a/scripts/gen-playground-manifest.py
+++ b/scripts/gen-playground-manifest.py
@@ -85,6 +85,9 @@ EXAMPLE_ORDER = {
         "option_result_methods",
         "vec_operations",
         "vec_f64_nonfinite_contains",
+        "vec_inclusive_slice",
+        "record_clone",
+        "fn_field_call",
     ),
 }
 
@@ -195,6 +198,15 @@ SANDBOX_CAPABILITY: dict[str, str] = {
     # types/vec_f64_nonfinite_contains: Vec<f64>::contains for NaN and +-Infinity
     # follows native fcmp-OEQ semantics via the shared valuesEqual helper.
     "types/vec_f64_nonfinite_contains": "runnable",
+    # types/vec_inclusive_slice: v[start..=end] inclusive range slice.  The
+    # emitter computes exclusive end = end + 1 and delegates to vector.range_slice.
+    "types/vec_inclusive_slice": "runnable",
+    # types/record_clone: `rec.clone()` deep-copies a user-defined record via
+    # local.set → cloneValue in the VM.  No field aliasing post-clone.
+    "types/record_clone": "runnable",
+    # types/fn_field_call: `(rec.f)(args)` fn-field call via call.indirect.
+    # Functions are materialised as function-kind values via const.function.
+    "types/fn_field_call": "runnable",
 }
 
 # Entries omitted from WASI_CAPABILITY default to "runnable".


### PR DESCRIPTION
## Summary

Three constructs accepted by the native compiler were rejected or silently wrong in the sandbox VM.

**`record.clone()`** — the `clone` method on record values had no emitter support, causing a sandbox trap on every `record.clone()` call. The emitter now emits a `local.set` pair; the VM performs a fully recursive deep clone via `cloneValue` (covers nested vectors, enums, and records).

**Inclusive-range slice `v[start..=end]`** — the emitter handled `v[start..end]` but not the inclusive form. The emitter now computes `exclusive_end = end + 1` via `i64.checked_add` and delegates to the existing `vector.range_slice` instruction, which handles empty ranges and out-of-bounds inputs fail-closed (trap, not silent wrong output). Open-inclusive `v[..=end]` (omitted start) was already fail-closed and is unchanged.

**Function-field call `(rec.f)(args)`** — calling a function value stored in a record field was rejected at the sandbox profile admission gate. The emitter now materialises the reference with a `const.function` operand (keyed by a stable `fn:<name>` id) and dispatches via `call.indirect`. The VM gains a `{ kind: "function"; id: string }` variant in `VmValue` that is handled at all five exhaustive-switch sites; tsc confirms no unhandled branch. Unknown function ids and non-function callees both trap.

A pre-existing fail-open in record-field index resolution (`unwrap_or(0)` / `_ => 0`) was replaced by a shared `resolve_record_field_index` helper that emits `emit_unsupported` on a missing index instead of silently defaulting to field 0. The fix covers both the new fn-field-call site and the pre-existing field-value-read site. A stale comment claiming `record.clone()` still traps was removed.

Parity coverage grows from 40 to 43 runnable constructs (`RUNNABLE_BASELINE 40 → 43`). Three fixtures join the grow-only ratchet (`accepted_divergences: &[]` — zero tolerance). The playground manifest and the `wasi_run_e2e.rs` manifest guard are updated consistently.

## Verification

- `make sandbox-parity`: 7/7 native == VM (2 parity + 5 ratchet), EXIT=0
- `make ci-preflight`: 13/13 green (includes `test-hew-ratchet`, `playground-check`, `fmt`, `clippy`)
- `npm --prefix hew-sandbox-vm run build`: tsc clean — `VmValue` `"function"` variant exhaustive across all switch sites
- Preflight: ready-to-push

## Out of scope

- Pathological inclusive-slice inputs (`v[0..=len]`, `v[3..=1]`, `v[0..=i64::MAX]`) are fail-closed in both native and VM (both trap), but not pinned by a parity fixture. Adding ratchet probes for these is a low-priority follow-up.
- No changes to the native compiler, type-checker, HIR/MIR passes, or non-sandbox runtimes.
- No new FFI, `unsafe`, or allocator surface.