### PR TITLE
feat: migrate HashMap indexing to a trapping Index accessor (m[k]) with drop-safe m.get

### DIFF
--- a/hew-cli/tests/hashmap_index_owned_leak_oracle.rs
+++ b/hew-cli/tests/hashmap_index_owned_leak_oracle.rs
@@ -1,0 +1,332 @@
+//! `HashMap` `m[k]` owned-value leak oracle (indexed-accessor convergence).
+//!
+//! `m[k]` over a `HashMap<K, V>` is the trapping `Index::at` accessor: on a hit
+//! the runtime semantic-clones the stored value into the caller's slot through
+//! `hew_hashmap_get_clone_layout`, producing a FRESH, independently-droppable
+//! owner — never a borrow into the live table. The table keeps its own copy and
+//! frees it on `remove`/overwrite/drop. If the read aliased the table's slot
+//! instead of cloning, removing the key would free the buffer the caller still
+//! holds, producing a use-after-free read (scribbled bytes) or a double-free
+//! (the caller's drop and `hew_hashmap_remove_layout` both releasing it).
+//!
+//! This is the headline GAP-2 drop-safety invariant for the `HashMap` indexed accessor
+//! (`by-value-heap-params-are-borrows` P0), proven on the new trapping `m[k]`
+//! path. `m.get(k) -> Option<V>` routes through the same clone choke, so this
+//! oracle pins the choke for both siblings.
+//!
+//! ## What each oracle pins
+//!
+//! - **Exact contents under the poisoned-allocator triple** (any unix): insert
+//!   an owned `Name { label: "owned-ok" }`, read it back through `m["k"]`,
+//!   remove the key (freeing the table's copy), then read the cloned record's
+//!   field. Under `MallocScribble`/`MallocPreScribble`/`MallocGuardEdges` a
+//!   double-free aborts the process and a use-after-free read returns scribbled
+//!   memory, changing the output. The string equality plus the clean exit pin
+//!   both regression directions.
+//!
+//! - **Exact zero-leak assertion** (macOS-only via `leaks(1)`): run a SINGLE
+//!   insert/index/remove cycle under the leak detector and assert exactly
+//!   `0 leaks for 0 total leaked bytes`. The cycle is wrapped in a helper
+//!   function so the stack slot holding the cloned record is gone at process
+//!   exit, making any leaked heap genuinely unreachable. A regression that
+//!   double-frees fails the scribble pin; one that leaks the clone (the read
+//!   path retains but no drop runs) fails here on any non-zero byte.
+//!
+//! ## Skip behaviour
+//!
+//! The zero-leak oracle is macOS-only (`leaks(1)` is Darwin's allocator
+//! inspector); elsewhere it logs `skip:` and returns. The scribble correctness
+//! pin runs on any unix host.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+// ── fixtures ──────────────────────────────────────────────────────────────
+
+/// Single round-trip under the poisoned allocator: insert one `Name { label:
+/// "owned-ok" }`, read it back through the trapping `m["k"]` accessor, remove
+/// the key (freeing the table's copy), and read `got.label`. Under
+/// `MallocScribble` a double-free aborts; a UAF read on `got.label` returns
+/// scribbled memory (not `"owned-ok"`). The exact-string equality plus clean
+/// exit pin both directions simultaneously.
+const INDEX_GET_SINGLE_ROUNDTRIP_SOURCE: &str = "\
+type Name { label: string; }\n\
+\n\
+fn main() {\n\
+\x20   let m: HashMap<string, Name> = HashMap::new();\n\
+\x20   m.insert(\"k\", Name { label: \"owned-ok\" });\n\
+\x20   let got: Name = m[\"k\"];\n\
+\x20   let _ = m.remove(\"k\");\n\
+\x20   print(got.label);\n\
+}\n";
+
+/// Expected exact output for `INDEX_GET_SINGLE_ROUNDTRIP_SOURCE`. Any aliasing
+/// or UAF changes the `got.label` read.
+const INDEX_GET_SINGLE_ROUNDTRIP_EXPECTED: &str = "owned-ok";
+
+/// Zero-leak fixture: the insert/index/remove cycle lives inside a helper
+/// function (`run_one_cycle`) so the stack slot holding the cloned record is
+/// gone by the time `leaks --atExit` inspects the heap. Any allocation that the
+/// cycle fails to release (the cloned `label` buffer whose drop never runs)
+/// becomes genuinely unreachable and is counted by `leaks(1)`.
+///
+/// Post-fix: `m["k"]` clones `label` into `got`; `m.remove("k")` frees the
+/// table's `label`; `got` drops at the end of `run_one_cycle`, freeing the
+/// clone. Zero live heap at process exit: `0 leaks for 0 total leaked bytes`.
+const INDEX_GET_ZERO_LEAK_SOURCE: &str = "\
+type Name { label: string; }\n\
+\n\
+fn run_one_cycle() {\n\
+\x20   let m: HashMap<string, Name> = HashMap::new();\n\
+\x20   m.insert(\"k\", Name { label: \"owned-ok\" });\n\
+\x20   let got: Name = m[\"k\"];\n\
+\x20   let _ = m.remove(\"k\");\n\
+\x20   print(got.label);\n\
+}\n\
+\n\
+fn main() {\n\
+\x20   run_one_cycle();\n\
+}\n";
+
+// ── leak measurement plumbing ─────────────────────────────────────────────────
+
+/// Compile `source` to a native binary via `hew compile --emit-dir` and return
+/// the binary path.
+fn compile_to_native(source: &str, dir: &std::path::Path, name: &str) -> PathBuf {
+    let hew_src = dir.join(format!("{name}.hew"));
+    std::fs::write(&hew_src, source).expect("write hew source");
+
+    let output = Command::new(hew_binary())
+        .args([
+            "compile",
+            "--emit-dir",
+            dir.to_str().expect("emit-dir utf-8"),
+            hew_src.to_str().expect("hew src utf-8"),
+        ])
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew compile");
+
+    assert!(
+        output.status.success(),
+        "hew compile failed for {name}:\n{}",
+        describe_output(&output)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let bin = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("native: "))
+        .unwrap_or_else(|| panic!("no `native:` line for {name}:\n{stdout}"))
+        .to_string();
+    PathBuf::from(bin)
+}
+
+/// Run `bin` under the poisoned-allocator triple + `leaks --atExit` and return
+/// `Some((leak_count, leaked_bytes))` when `leaks` produced a usable summary.
+///
+/// The parsed summary line has the form:
+/// ```text
+/// Process <pid>: N leaks for B total leaked bytes.
+/// ```
+/// where `N` is the leak count and `B` is the total leaked bytes. Both are
+/// extracted so the caller can assert exactly `(0, 0)`.
+///
+/// Returns `None` (with a `skip:` notice on stderr) when `leaks(1)` declines to
+/// attach or does not emit the expected summary line.
+fn measure_leaks_exact(bin: &std::path::Path) -> Option<(usize, usize)> {
+    let output = Command::new("leaks")
+        .arg("--atExit")
+        .arg("--")
+        .arg(bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .ok()?;
+    if !output.status.success() && output.stdout.is_empty() {
+        eprintln!(
+            "skip: leaks declined to attach to {}: {}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+    let report = String::from_utf8_lossy(&output.stdout);
+    for line in report.lines() {
+        // Match: "Process <pid>: N leak(s) for B total leaked bytes."
+        if !line.contains(" leaks for ") && !line.contains(" leak for ") {
+            continue;
+        }
+        let Some(rest) = line.strip_prefix("Process ") else {
+            continue;
+        };
+        if !rest.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+            continue;
+        }
+        // rest = "<pid>: N leaks for B total leaked bytes."
+        let Some(after_colon) = rest.split_once(": ").map(|(_, s)| s) else {
+            continue;
+        };
+        // after_colon = "N leaks for B total leaked bytes."
+        let mut words = after_colon.split_whitespace();
+        let Some(count_str) = words.next() else {
+            continue;
+        };
+        let Ok(count) = count_str.parse::<usize>() else {
+            continue;
+        };
+        // skip "leaks" / "leak", "for"
+        let _ = words.next(); // "leaks" or "leak"
+        let _ = words.next(); // "for"
+        let Some(bytes_str) = words.next() else {
+            // No bytes field — can't form an exact assertion; skip gracefully.
+            eprintln!(
+                "skip: leaks summary for {} has count ({count}) but no bytes field: {line}",
+                bin.display()
+            );
+            return None;
+        };
+        let Ok(bytes) = bytes_str.parse::<usize>() else {
+            eprintln!(
+                "skip: leaks summary for {} bytes field not a number ({bytes_str}): {line}",
+                bin.display()
+            );
+            return None;
+        };
+        eprintln!("  leaks(1) summary: count={count} bytes={bytes} (from: {line})");
+        return Some((count, bytes));
+    }
+    eprintln!(
+        "skip: leaks did not emit a `Process <pid>: N leak(s) for B total leaked bytes.` \
+         summary for {}: stderr=\n{}",
+        bin.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    None
+}
+
+/// Compile `source`, run it under the poisoned-allocator triple, and assert it
+/// exits cleanly with `expected` on stdout.
+fn assert_exact_under_malloc_scribble(name: &str, source: &str, expected: &str) {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("hashmap-index-owned-{name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), name);
+
+    let output = Command::new(&bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .unwrap_or_else(|error| panic!("run {name} binary: {error}"));
+
+    assert!(
+        output.status.success(),
+        "{name} must run clean under the poisoned allocator — a crash here indicates a \
+         double-free of the owned `Name.label` string (the `m[k]` read aliased the table's \
+         slot while `hew_hashmap_remove_layout` also released it);\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        expected,
+        "{name} must read back the label verbatim — scribbled/empty output indicates a \
+         use-after-free read on `got.label` (the table slot was freed by `remove` before the \
+         caller read the clone);\n{}",
+        describe_output(&output)
+    );
+}
+
+/// Compile `source`, run it under `leaks --atExit`, and assert exactly
+/// `0 leaks for 0 total leaked bytes`. Any non-zero count or non-zero byte total
+/// fails immediately — no tolerance, no slope.
+///
+/// The fixture must wrap the cycle in a helper function so the stack slot
+/// holding the cloned record is gone at process exit, making any un-dropped heap
+/// genuinely unreachable and visible to `leaks(1)`.
+fn assert_zero_leaks_exact(name: &str, source: &str) {
+    if !cfg!(target_os = "macos") {
+        eprintln!("skip: {name}: leaks(1) is macOS-only");
+        return;
+    }
+    let leaks_avail = Command::new("which")
+        .arg("leaks")
+        .output()
+        .is_ok_and(|o| o.status.success());
+    if !leaks_avail {
+        eprintln!("skip: {name}: `leaks` binary not on PATH");
+        return;
+    }
+
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("hashmap-index-owned-zero-leak-{name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), name);
+
+    let Some((leak_count, leaked_bytes)) = measure_leaks_exact(&bin) else {
+        return;
+    };
+
+    assert_eq!(
+        leak_count,
+        0,
+        "{name}: leaks(1) reported {leak_count} leak(s) — expected exactly 0. A non-zero count \
+         means the cloned `label` buffer was never freed (the `m[k]` retain has no matching \
+         drop). Re-run with `MallocStackLogging=1 leaks --atExit -- {}` to see the leaked \
+         allocation stack.",
+        bin.display()
+    );
+    assert_eq!(
+        leaked_bytes,
+        0,
+        "{name}: leaks(1) reported 0 leak nodes but {leaked_bytes} total leaked bytes — expected \
+         exactly 0 bytes. The cloned record's `label` heap buffer must be freed when `got` drops. \
+         Re-run with `MallocStackLogging=1 leaks --atExit -- {}` to see the leaked stack.",
+        bin.display()
+    );
+
+    eprintln!(
+        "{name}: leaks(1) confirmed 0 leaks for 0 total leaked bytes — exact zero-leak oracle PASS"
+    );
+}
+
+// ── oracles ─────────────────────────────────────────────────────────────────
+
+/// Exact-contents pin: a single insert/index/remove/read round-trip must print
+/// `"owned-ok"` and exit clean under the poisoned allocator. Reverting the
+/// trapping read to alias the table's slot (so `m[k]` borrows while
+/// `hew_hashmap_remove_layout` also releases it) fails this with either an abort
+/// (double-free) or garbled output (UAF read).
+#[test]
+fn hashmap_index_owned_value_exact_contents_under_malloc_scribble() {
+    assert_exact_under_malloc_scribble(
+        "hashmap_index_single_roundtrip",
+        INDEX_GET_SINGLE_ROUNDTRIP_SOURCE,
+        INDEX_GET_SINGLE_ROUNDTRIP_EXPECTED,
+    );
+}
+
+/// Exact zero-leak oracle: an insert/index/remove cycle (wrapped in
+/// `run_one_cycle()` so the stack slot is gone at process exit) must report
+/// exactly `0 leaks for 0 total leaked bytes` under `leaks --atExit`. The
+/// `m[k]` clone retains the `label` buffer; `got` dropping at scope exit frees
+/// it; `m.remove` frees the table's copy. A regression that leaks the clone
+/// fails the `== 0` assertion on any leaked byte.
+#[test]
+fn hashmap_index_owned_value_zero_leaks_exact() {
+    assert_zero_leaks_exact("hashmap_index_zero_leak", INDEX_GET_ZERO_LEAK_SOURCE);
+}

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -19448,6 +19448,137 @@ fn lower_hashmap_get_layout_call(
     Ok(())
 }
 
+/// Lower the trapping `m[k]` (`HashMap` `Index::at`) read. The map twin of
+/// `lower_vec_get_clone_call`, and structurally `lower_hashmap_get_layout_call`
+/// with the `None` branch replaced by an `IndexOutOfBounds` trap and the dest
+/// narrowed from `Option<V>` to a BARE `V`.
+///
+/// Calls the fresh-owner clone choke `hew_hashmap_get_clone_layout(map, key,
+/// out) -> bool`: on a hit the runtime semantic-clones the stored value into
+/// `out` (the dest slot) through the value descriptor's `clone_fn` — a
+/// retained/independent owner, never a borrow into the live table
+/// (`by-value-heap-params-are-borrows` P0 drop-safety; the headline GAP-2
+/// invariant of this lane). The map keeps its own copy. On a miss the runtime
+/// returns `false` WITHOUT writing `out`, and we trap (`IndexOutOfBounds`)
+/// instead of materialising a value, so the dest is never observed and never
+/// dropped on the miss path (MIR schedules the dest's scope-exit drop only on
+/// the through path, which the trap pre-empts). `m.get(k) -> Option<V>` is the
+/// non-aborting sibling, lowered by `lower_hashmap_get_layout_call`.
+fn lower_hashmap_index_trap_call(
+    fn_ctx: &FnCtx<'_, '_>,
+    args: &[Place],
+    dest: Option<&Place>,
+    next: u32,
+) -> CodegenResult<()> {
+    if args.len() != 2 {
+        return Err(CodegenError::FailClosed(format!(
+            "hew_hashmap_get_clone_layout (m[k] trap) expects 2 source-level \
+             args (handle, key), got {}",
+            args.len()
+        )));
+    }
+    let dest_place = dest.ok_or_else(|| {
+        CodegenError::FailClosed(
+            "m[k] (HashMap Index::at) yields a bare V; call must supply a dest".into(),
+        )
+    })?;
+
+    let map_ty = place_resolved_ty(fn_ctx, args[0])?.clone();
+    let val_resolved = match map_ty {
+        ResolvedTy::Named {
+            name,
+            args: ty_args,
+            ..
+        } if name == "HashMap" && ty_args.len() == 2 => ty_args[1].clone(),
+        other => {
+            return Err(CodegenError::FailClosed(format!(
+                "hew_hashmap_get_clone_layout (m[k] trap) arg0 must be HashMap<K,V>, got {other:?}"
+            )));
+        }
+    };
+    // The dest is the BARE value `V` (not `Option<V>`): the trapping accessor
+    // never materialises an `Option`.
+    let dest_ty = place_resolved_ty(fn_ctx, *dest_place)?.clone();
+    if dest_ty != val_resolved {
+        return Err(CodegenError::FailClosed(format!(
+            "m[k] (HashMap Index::at) dest must be the bare value type \
+             {val_resolved:?}, got {dest_ty:?}"
+        )));
+    }
+
+    let val_llvm_ty = resolve_ty(fn_ctx.ctx, &val_resolved, fn_ctx.record_layouts)?;
+    let map_ptr = load_duplex_handle(
+        fn_ctx,
+        args[0],
+        "hew_hashmap_get_clone_layout (m[k] trap) arg0",
+    )?;
+    let (key_ptr, _key_ty) = place_pointer(fn_ctx, args[1])?;
+
+    // The matched value is cloned directly into the dest slot (the bare `V`), so
+    // the runtime out-pointer is the dest place's own address — not a
+    // `Some`-payload subplace (the `Option`-building sibling's distinction).
+    let (out_ptr, out_ty) = place_pointer(fn_ctx, *dest_place)?;
+    if out_ty != val_llvm_ty {
+        return Err(CodegenError::FailClosed(format!(
+            "m[k] (HashMap Index::at) dest slot type {out_ty:?} does not match \
+             HashMap value type {val_llvm_ty:?}"
+        )));
+    }
+
+    let parent = fn_ctx
+        .builder
+        .get_insert_block()
+        .and_then(|bb| bb.get_parent())
+        .ok_or_else(|| {
+            CodegenError::FailClosed(
+                "hew_hashmap_get_clone_layout (m[k] trap) has no parent fn".into(),
+            )
+        })?;
+    let trap_bb = fn_ctx
+        .ctx
+        .append_basic_block(parent, "hashmap_index_absent_trap");
+    let next_bb = *fn_ctx
+        .blocks
+        .get(&next)
+        .ok_or_else(|| CodegenError::FailClosed(format!("Call next bb{next} missing")))?;
+
+    let fv = get_or_declare_layout_hashmap_runtime(
+        fn_ctx.ctx,
+        fn_ctx.llvm_mod,
+        "hew_hashmap_get_clone_layout",
+    )?;
+    let found = fn_ctx
+        .builder
+        .build_call(
+            fv,
+            &[map_ptr.into(), key_ptr.into(), out_ptr.into()],
+            "hashmap_index_trap_clone_call",
+        )
+        .llvm_ctx("hew_hashmap_get_clone_layout (m[k] trap) call")?
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| {
+            CodegenError::FailClosed(
+                "hew_hashmap_get_clone_layout (m[k] trap) returned void".into(),
+            )
+        })?
+        .into_int_value();
+    // Hit → fall through to `next` with the cloned `V` already in the dest slot.
+    // Miss → trap (`IndexOutOfBounds`), mirroring `v[i]` OOB.
+    fn_ctx
+        .builder
+        .build_conditional_branch(found, next_bb, trap_bb)
+        .llvm_ctx("hew_hashmap_get_clone_layout (m[k] trap) condbr")?;
+
+    fn_ctx.builder.position_at_end(trap_bb);
+    emit_trap_with_code(
+        fn_ctx,
+        HEW_TRAP_INDEX_OUT_OF_BOUNDS as u64,
+        "hashmap_index_trap",
+    )?;
+    Ok(())
+}
+
 /// Lower the trait-routed `Vec::get` → `Option<T>` call (the Vec twin of
 /// `lower_hashmap_get_layout_call`). Calls the fresh-owner runtime choke point
 /// `hew_vec_get_clone(vec, index, out) -> bool`: the runtime bounds-checks and,
@@ -25107,6 +25238,10 @@ fn lower_terminator<'ctx>(
             }
             if callee == "hew_vec_get_clone" {
                 lower_vec_get_clone_call(fn_ctx, args, dest.as_ref(), *next)?;
+                return Ok(());
+            }
+            if callee == "hew_hashmap_get_clone_layout" {
+                lower_hashmap_index_trap_call(fn_ctx, args, dest.as_ref(), *next)?;
                 return Ok(());
             }
             if is_hashmap_constructor_symbol(callee) {

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -19458,7 +19458,7 @@ fn lower_hashmap_get_layout_call(
 /// `out` (the dest slot) through the value descriptor's `clone_fn` — a
 /// retained/independent owner, never a borrow into the live table
 /// (`by-value-heap-params-are-borrows` P0 drop-safety; the headline GAP-2
-/// invariant of this lane). The map keeps its own copy. On a miss the runtime
+/// invariant). The map keeps its own copy. On a miss the runtime
 /// returns `false` WITHOUT writing `out`, and we trap (`IndexOutOfBounds`)
 /// instead of materialising a value, so the dest is never observed and never
 /// dropped on the miss path (MIR schedules the dest's scope-exit drop only on

--- a/hew-codegen-rs/tests/hashmap_index_exec.rs
+++ b/hew-codegen-rs/tests/hashmap_index_exec.rs
@@ -5,8 +5,8 @@
 //! position `m[k]` is the trapping `Index::at` accessor (`-> V`): an absent key
 //! aborts with `IndexOutOfBounds` (the map analogue of `v[i]` OOB), NOT an
 //! `Option` round-trip. The non-aborting `Option<V>` outcome lives on
-//! `m.get(k)`, which is re-routed through the `Index` trait this lane
-//! (runtime-identical). The write `m[k] = v` lowers to
+//! `m.get(k)`, which is re-routed through the `Index` trait (runtime-identical).
+//! The write `m[k] = v` lowers to
 //! `hew_hashmap_insert_layout`.
 //!
 //! Pipeline under test: checker key-bound and value-type wiring; HIR routing
@@ -263,7 +263,7 @@ fn index_read_agrees_with_method_insert() {
 }
 
 /// `m.get(k)` keeps the non-aborting `Option<V>` contract (re-routed through the
-/// `Index` trait this lane, runtime-identical to before): present → `Some`,
+/// `Index` trait, runtime-identical to before): present → `Some`,
 /// absent → `None`. Oracle: `Some(40)` hit + `None` miss-marker 2 = 42. This is
 /// the sibling of the trapping `m[k]` read above.
 #[test]

--- a/hew-codegen-rs/tests/hashmap_index_exec.rs
+++ b/hew-codegen-rs/tests/hashmap_index_exec.rs
@@ -1,10 +1,19 @@
-//! End-to-end execution tests for `HashMap` key indexing: `m[k]` read and
-//! `m[k] = v` write.
+//! End-to-end execution tests for `HashMap` key indexing: the trapping `m[k]`
+//! read, the `m[k] = v` write, and the `m.get(k) -> Option<V>` sibling.
 //!
-//! Verifies the full pipeline: checker key-bound + Option/value-type wiring →
-//! HIR routing (read → get ResolvedImplCall, write → insert) → MIR insert
-//! lowering → codegen → runtime execution. Exit codes (mod-256) encode the
-//! grounding oracle.
+//! Verifies the full pipeline for the indexed-accessor INVERSION. In read
+//! position `m[k]` is the trapping `Index::at` accessor (`-> V`): an absent key
+//! aborts with `IndexOutOfBounds` (the map analogue of `v[i]` OOB), NOT an
+//! `Option` round-trip. The non-aborting `Option<V>` outcome lives on
+//! `m.get(k)`, which is re-routed through the `Index` trait this lane
+//! (runtime-identical). The write `m[k] = v` lowers to
+//! `hew_hashmap_insert_layout`.
+//!
+//! Pipeline under test: checker key-bound and value-type wiring; HIR routing
+//! (read to a plain `Index` node, `get` to a `ResolvedImplCall`, write to
+//! insert); MIR `lower_hashmap_index_trap` or insert; codegen; runtime
+//! execution. Exit codes (mod-256) encode the grounding oracle; the trap test
+//! asserts the `IndexOutOfBounds` abort.
 #![cfg(not(target_arch = "wasm32"))]
 #![cfg(unix)]
 
@@ -107,9 +116,42 @@ fn run_hew_source_exit_code(repo: &Path, stem: &str, source: &str) -> i32 {
     })
 }
 
-/// Write via `m[k] = v`, then read back via `m[k]`. Oracle: the written value
-/// flows back out unchanged. `Some(42)` → exit 42; the `None` arm would exit 0,
-/// so a non-zero exit also proves the key was present.
+/// Compile and run a Hew snippet expected to TRAP at runtime; return
+/// `(exit_code, stderr)`. `hew run` catches the abort, prints
+/// `hew: trap in main context: <kind>` to stderr, and exits non-zero (1) — a
+/// clean exit code, not a propagated signal — so the oracle asserts on both the
+/// non-zero code and the trap kind in stderr.
+fn run_hew_source_trap(repo: &Path, stem: &str, source: &str) -> (i32, String) {
+    ensure_hew_runtime_lib(repo);
+    let dir =
+        std::env::temp_dir().join(format!("hew-hashmap-index-{}-{}", std::process::id(), stem));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create temp source dir");
+    let path = dir.join(format!("{stem}.hew"));
+    std::fs::write(&path, source).expect("write temp Hew source");
+
+    let mut cmd = hew_command(repo);
+    cmd.arg("run").arg(&path);
+    let output = hew_testutil::run_command_bounded(
+        &mut cmd,
+        format!("hew run {}", path.display()),
+        Duration::from_secs(20),
+    )
+    .unwrap_or_else(|e| panic!("{e}"));
+
+    let code = output.status.code().unwrap_or_else(|| {
+        panic!(
+            "hew run was killed by signal (expected a clean trap exit); stderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    (code, stderr)
+}
+
+/// Write via `m[k] = v`, then read back via the trapping `m[k]` accessor. Oracle:
+/// the written value flows back out unchanged as a BARE `V` (no `Option`). Exit
+/// 42 proves the present key read the written value directly.
 #[test]
 fn string_key_write_then_read_returns_written_value() {
     let repo = repo_root();
@@ -119,10 +161,7 @@ fn string_key_write_then_read_returns_written_value() {
         r#"fn main() -> i64 {
     var m: HashMap<string, i64> = HashMap::new();
     m["answer"] = 42;
-    match m["answer"] {
-        Some(v) => v,
-        None => 0,
-    }
+    m["answer"]
 }
 "#,
     );
@@ -143,42 +182,44 @@ fn string_key_write_overwrites_existing_value() {
     var m: HashMap<string, i64> = HashMap::new();
     m["k"] = 10;
     m["k"] = 99;
-    match m["k"] {
-        Some(v) => v,
-        None => 0,
-    }
+    m["k"]
 }
 "#,
     );
     assert_eq!(code, 99, "overwrite oracle: expected exit 99, got {code}");
 }
 
-/// Reading an absent key yields `None`; the `None` arm encodes 7 so a stray
-/// `Some` (or a present key) would not produce this exit code.
+/// Reading an ABSENT key now TRAPS (`IndexOutOfBounds`) — the inverted accessor:
+/// `m[k]` is the trapping `Index::at` (`-> V`), the map analogue of a `v[i]` OOB
+/// abort. The present key read above proves the happy path, so a trap here proves
+/// the miss path aborts rather than returning a sentinel. The non-aborting
+/// `Option<V>` outcome is `m.get(k)` (see `method_get_returns_option_some_and_none`).
 #[test]
-fn read_absent_key_yields_none() {
+fn read_absent_key_traps() {
     let repo = repo_root();
-    let code = run_hew_source_exit_code(
+    let (code, stderr) = run_hew_source_trap(
         &repo,
-        "absent_none",
+        "absent_trap",
         r#"fn main() -> i64 {
     var m: HashMap<string, i64> = HashMap::new();
     m["present"] = 1;
-    match m["missing"] {
-        Some(_) => 0,
-        None => 7,
-    }
+    let r: i64 = m["missing"];
+    r
 }
 "#,
     );
-    assert_eq!(
-        code, 7,
-        "absent-key None oracle: expected exit 7, got {code}"
+    assert_ne!(
+        code, 0,
+        "absent-key read must trap (non-zero exit), got {code}; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("IndexOutOfBounds"),
+        "absent-key read must trap with IndexOutOfBounds; exit={code}, stderr:\n{stderr}"
     );
 }
 
 /// The key bound generalises beyond `string`: an `i64` key (Hash + Eq) indexes
-/// just as well. Oracle sums two written values, 11 + 22 = 33.
+/// just as well. Oracle sums two written values read back as bare `V`, 11 + 22 = 33.
 #[test]
 fn i64_key_write_then_read() {
     let repo = repo_root();
@@ -189,15 +230,7 @@ fn i64_key_write_then_read() {
     var m: HashMap<i64, i64> = HashMap::new();
     m[1] = 11;
     m[2] = 22;
-    let a = match m[1] {
-        Some(v) => v,
-        None => 0,
-    };
-    let b = match m[2] {
-        Some(v) => v,
-        None => 0,
-    };
-    a + b
+    m[1] + m[2]
 }
 ",
     );
@@ -207,8 +240,9 @@ fn i64_key_write_then_read() {
     );
 }
 
-/// `m[k]` read agrees with `m.get(k)`: both yield `Option<V>` from the same
-/// runtime path, so indexing a key written via `.insert` reads back the value.
+/// The trapping `m[k]` read agrees with `m.insert(k, v)`: indexing a key written
+/// via `.insert` reads back the value as a bare `V` (same runtime table, same
+/// clone choke).
 #[test]
 fn index_read_agrees_with_method_insert() {
     let repo = repo_root();
@@ -218,15 +252,43 @@ fn index_read_agrees_with_method_insert() {
         r#"fn main() -> i64 {
     var m: HashMap<string, i64> = HashMap::new();
     m.insert("v", 55);
-    match m["v"] {
-        Some(v) => v,
-        None => 0,
-    }
+    m["v"]
 }
 "#,
     );
     assert_eq!(
         code, 55,
         "index/insert parity oracle: expected exit 55, got {code}"
+    );
+}
+
+/// `m.get(k)` keeps the non-aborting `Option<V>` contract (re-routed through the
+/// `Index` trait this lane, runtime-identical to before): present → `Some`,
+/// absent → `None`. Oracle: `Some(40)` hit + `None` miss-marker 2 = 42. This is
+/// the sibling of the trapping `m[k]` read above.
+#[test]
+fn method_get_returns_option_some_and_none() {
+    let repo = repo_root();
+    let code = run_hew_source_exit_code(
+        &repo,
+        "method_get_option",
+        r#"fn main() -> i64 {
+    var m: HashMap<string, i64> = HashMap::new();
+    m.insert("k", 40);
+    let hit = match m.get("k") {
+        Some(v) => v,
+        None => 0,
+    };
+    let miss = match m.get("absent") {
+        Some(_) => 0,
+        None => 2,
+    };
+    hit + miss
+}
+"#,
+    );
+    assert_eq!(
+        code, 42,
+        "m.get Some/None oracle: expected 42 (40+2), got {code}"
     );
 }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -13203,51 +13203,27 @@ impl LowerCtx {
                         }
                     }
 
-                    // `m[k]` over a `HashMap<K, V>` reuses the `.get(k)` runtime
-                    // ABI in READ position. The checker recorded a `ResolvedCall`
-                    // to `hew_hashmap_get_layout` at this span (result type
-                    // `Option<V>`); emit the same `ResolvedImplCall` that
-                    // `m.get(k)` produces so MIR/codegen consume the existing
-                    // Option-projecting get path verbatim.
+                    // `m[k]` over a `HashMap<K, V>` in READ position is the
+                    // trapping `Index::at` accessor (`-> V`): a missing key
+                    // aborts with IndexOutOfBounds (the map analogue of `v[i]`
+                    // OOB), mirroring `Vec`. It falls through to the plain
+                    // `HirExprKind::Index` node below, which the MIR rvalue
+                    // `Index` match lowers to `lower_hashmap_index_trap`
+                    // (`hew_hashmap_get_clone_layout` + trap-on-miss). The
+                    // non-aborting `Option<V>` outcome is `m.get(k)`, which
+                    // takes the `ResolvedImplCall` get path above.
                     //
                     // An assignment target (`m[k] = v`, `IntentKind::Modify`)
-                    // must NOT take the read path — it falls through to the plain
-                    // `HirExprKind::Index` node below, which the MIR `assign`
-                    // arm recognises and lowers to `hew_hashmap_insert_layout`.
-                    if intent != IntentKind::Modify
-                        && matches!(&container.ty, ResolvedTy::Named { name, .. } if name == "HashMap")
-                    {
-                        if let Some(resolved) =
-                            self.resolved_calls.get(&self.mk_key(&span)).cloned()
-                        {
-                            // Register the `Option<V>` instantiation so the
-                            // module enum-layout table carries the matching key
-                            // (mirrors the `HashMap::get` method-call path).
-                            self.try_register_enum_instantiation(&span);
-                            return HirExpr {
-                                node: self.ids.node(),
-                                site,
-                                value_class: ValueClass::of_ty(&result_ty, &self.type_classes),
-                                ty: result_ty.clone(),
-                                intent,
-                                kind: HirExprKind::ResolvedImplCall {
-                                    receiver: Box::new(container),
-                                    impl_id: resolved.impl_id,
-                                    method_name: resolved.method_name,
-                                    target_symbol: resolved.target.symbol_name,
-                                    target_family: resolved.target.family,
-                                    type_args: resolved.type_args,
-                                    args: vec![index_expr],
-                                    ret_ty: result_ty.clone(),
-                                },
-                                span: span.clone(),
-                            };
-                        }
-                    }
+                    // also falls through to the plain `Index` node, which the
+                    // MIR `assign` arm recognises and lowers to
+                    // `hew_hashmap_insert_layout`.
 
                     if let ResolvedTy::Named { name, .. } = &container.ty {
                         let callee_name = format!("{name}::at");
-                        if name != "Vec" && self.fn_registry.contains_key(&callee_name) {
+                        if name != "Vec"
+                            && name != "HashMap"
+                            && self.fn_registry.contains_key(&callee_name)
+                        {
                             let callee_ty = ResolvedTy::Function {
                                 params: vec![container.ty.clone(), index_expr.ty.clone()],
                                 ret: Box::new(result_ty.clone()),

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -10051,6 +10051,15 @@ impl Builder {
                     ResolvedTy::Bytes => {
                         self.lower_bytes_index(container, index, &elem_ty, expr.site)
                     }
+                    // `m[k]` over `HashMap<K, V>` in READ position is the
+                    // trapping `Index::at` accessor: it clones the matched value
+                    // out through the `hew_hashmap_get_clone_layout` choke and
+                    // aborts with IndexOutOfBounds on a miss (the map analogue of
+                    // `v[i]` OOB). `m.get(k) -> Option<V>` is the non-aborting
+                    // form and takes the `ResolvedImplCall` get path.
+                    ResolvedTy::Named { name, .. } if name == "HashMap" => {
+                        self.lower_hashmap_index_trap(container, index, &elem_ty, expr.site)
+                    }
                     _ => self.lower_vec_index(container, index, &elem_ty, expr.site),
                 }
             }
@@ -16583,6 +16592,51 @@ impl Builder {
             .expect("hew_vec_get_T is an allowlisted runtime symbol"),
         ));
 
+        Some(result_place)
+    }
+
+    /// Lower `m[k]` over a `HashMap<K, V>` in READ position — the trapping
+    /// `Index::at` accessor, the map twin of `lower_vec_index`.
+    ///
+    /// Emits a single `Terminator::Call` to the `hew_hashmap_get_clone_layout`
+    /// choke with the BARE `V` dest (no `Option` round-trip). Codegen
+    /// (`lower_hashmap_index_trap_call`) synthesises the runtime out-pointer
+    /// from that dest, branches on the runtime's found-bit, and aborts with
+    /// `IndexOutOfBounds` on a miss (the map analogue of `lower_vec_index`'s OOB
+    /// trap). On a hit, the matched value is cloned into the dest through the
+    /// value descriptor's semantic clone (`clone_layout_value_blob`), so the
+    /// result is a FRESH, independently-droppable owner — never a borrow into
+    /// the live table (GAP-2 drop-safety; `by-value-heap-params-are-borrows`
+    /// P0). On a miss the dest is never written and codegen traps before the
+    /// `next` block, so the dest's scope-exit drop (scheduled on the through
+    /// path) never fires on the miss path.
+    ///
+    /// `m.get(k) -> Option<V>` is the non-aborting sibling; it routes through
+    /// the `ResolvedImplCall` get path to the same runtime choke.
+    fn lower_hashmap_index_trap(
+        &mut self,
+        container: &HirExpr,
+        index: &HirExpr,
+        elem_ty: &ResolvedTy,
+        _site: hew_hir::SiteId,
+    ) -> Option<Place> {
+        let map_place = self.lower_value(container)?;
+        let key_place = self.lower_value(index)?;
+        let result_place = self.alloc_local(elem_ty.clone());
+        let next = self.alloc_block();
+        // The callee is the fresh-owner clone choke shared with `m.get` (codegen
+        // declares the `(ptr, ptr, ptr) -> i1` runtime). It is not in the typed
+        // `RuntimeCallFamily` catalog, so it carries `builtin: None` like
+        // `hew_vec_get_clone`; codegen dispatches on the symbol string and owns
+        // the trap-on-miss CFG.
+        self.finish_current_block(Terminator::Call {
+            callee: "hew_hashmap_get_clone_layout".to_string(),
+            builtin: None,
+            args: vec![map_place, key_place],
+            dest: Some(result_place),
+            next,
+        });
+        self.start_block(next);
         Some(result_place)
     }
 
@@ -31918,6 +31972,12 @@ fn is_collection_receiver_borrow_callee(callee: &str) -> bool {
         callee,
         "hew_hashmap_insert_layout"
             | "hew_hashmap_get_layout"
+            // The trapping `m[k]` read (`Index::at`) choke: reads the table and
+            // clones the matched value into the caller's out-slot, never freeing
+            // the map (`m: *const HewLayoutHashMap`). Same receiver-borrow
+            // contract as `hew_hashmap_get_layout`; classified here so `m[k]`
+            // does not exclude the handle from its scope-exit release.
+            | "hew_hashmap_get_clone_layout"
             | "hew_hashmap_remove_layout"
             | "hew_hashmap_contains_key_layout"
             | "hew_hashmap_len_layout"

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -1458,22 +1458,24 @@ impl Checker {
                 }
                 args[0].clone()
             }
-            // `m[k]` over `HashMap<K, V>` reuses the existing `.get(k)` /
-            // `.insert(k, v)` runtime ABI rather than the `Index` trait.
+            // `m[k]` over `HashMap<K, V>` is the trait-routed `Index<K>`
+            // accessor (`<HashMap<K, V> as Index>::Output = V`), mirroring
+            // `v[i]` over `Vec<T>`.
             //
-            // Read context (`let x = m[k]`): result type is `Option<V>` — a
-            // missing key is a normal, non-aborting outcome for a map, so the
-            // surface is fail-closed by construction (the caller must match the
-            // `None`). The checker records a `ResolvedCall` to
-            // `hew_hashmap_get_layout` at this span; HIR routes the index node
-            // to the same `ResolvedImplCall` that `m.get(k)` produces.
+            // Read context (`let x = m[k]`): the TRAPPING accessor
+            // (`Index::at`) — result type is the BARE value `V`. A missing key
+            // aborts with `IndexOutOfBounds` (the map analogue of a `v[i]`
+            // out-of-bounds trap), so there is no `Option` round-trip. No
+            // resolved `.get` call is recorded here: the MIR `Index` node lowers
+            // directly to the `hew_hashmap_get_clone_layout` trap choke
+            // (`lower_hashmap_index_trap`). Callers who want the non-aborting
+            // outcome use `m.get(k) -> Option<V>` instead.
             //
             // Write context (`m[k] = v`): the assignment-target type is the
-            // bare value `V` (so the RHS checks against `V`, not `Option<V>`),
-            // and the checker records a `ResolvedCall` to
-            // `hew_hashmap_insert_layout` at this span. The key bound is the
-            // existing `K: Hash + Eq` admission contract — the same one every
-            // HashMap method call enforces.
+            // bare value `V` (so the RHS checks against `V`), and the checker
+            // records a `ResolvedCall` to `hew_hashmap_insert_layout` at this
+            // span. The key bound is the existing `K: Hash + Eq` admission
+            // contract — the same one every HashMap method call enforces.
             Ty::Named {
                 builtin: Some(BuiltinType::HashMap),
                 args,
@@ -1482,20 +1484,23 @@ impl Checker {
                 let key_ty = args[0].clone();
                 let val_ty = args[1].clone();
                 self.check_against(&index.0, &index.1, &key_ty);
-                let method = match ctx {
-                    IndexContext::Read => "get",
-                    IndexContext::AssignTarget => "insert",
-                };
-                // Enforce `K: Hash + Eq` and record the resolved runtime call
-                // (`hew_hashmap_get_layout` / `hew_hashmap_insert_layout`) at
-                // the index span, exactly as the method-call path does.
+                // Enforce `K: Hash + Eq` and reject unsafe key/value element
+                // types, exactly as the method-call path does — for both the
+                // read (trap) and the write (insert) surfaces.
                 if !self.validate_hashmap_owned_element_types(&key_ty, &val_ty, span) {
                     return Ty::Error;
                 }
-                self.record_resolved_hashmap_call(method, &key_ty, &val_ty, span);
                 match ctx {
-                    IndexContext::Read => Ty::option(val_ty),
-                    IndexContext::AssignTarget => val_ty,
+                    // Trapping bare-`V` read: no `.get` resolved call; MIR's
+                    // `Index` node owns the `hew_hashmap_get_clone_layout` trap
+                    // lowering.
+                    IndexContext::Read => val_ty,
+                    // Write target: record the `hew_hashmap_insert_layout` call
+                    // at the index span (the same one `m.insert(k, v)` emits).
+                    IndexContext::AssignTarget => {
+                        self.record_resolved_hashmap_call("insert", &key_ty, &val_ty, span);
+                        val_ty
+                    }
                 }
             }
             // W3 collections-sugar S2: `s[i]` over `string` returns a `char`

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -110,8 +110,6 @@ pub(super) enum RetTemplate {
     Unit,
     Bool,
     I64,
-    /// `Option<V>` (`HashMap` `get`).
-    OptionVal,
     /// The element type `elem` (Vec `pop`/`get`).
     Elem,
     /// `Vec<K>` (`HashMap` `keys`).
@@ -159,13 +157,16 @@ const fn desc(
 )]
 fn collection_method_desc(kind: CollectionKind, method: &str) -> Option<CollectionMethodDesc> {
     use ArgTemplate::{Elem, Key, Receiver, Value, I64};
-    use RetTemplate::{
-        Bool, Elem as RetElem, OptionVal, SelfTy, Unit, VecOfKey, VecOfVal, I64 as RetI64,
-    };
+    use RetTemplate::{Bool, Elem as RetElem, SelfTy, Unit, VecOfKey, VecOfVal, I64 as RetI64};
     Some(match kind {
         CollectionKind::HashMap => match method {
             "insert" => desc(Some(2), &[Key, Value], Unit),
-            "get" => desc(Some(1), &[Key], OptionVal),
+            // `get` is intentionally ABSENT: it is routed through the
+            // `Index<K>` trait (`<HashMap<K, V> as Index>::get -> Option<V>`)
+            // so the accessor model is uniform with `Vec`. `check_hashmap_method`
+            // has an explicit `get` arm that records the `Index` primitive-trait
+            // dispatch and the `hew_hashmap_get_layout` resolved call; the bare
+            // `m[k]` read is the trapping `Index::at` (`-> V`).
             "remove" => desc(Some(1), &[Key], Bool),
             "contains_key" => desc(Some(1), &[Key], Bool),
             "keys" => desc(Some(0), &[], VecOfKey),
@@ -3946,7 +3947,6 @@ impl Checker {
             RetTemplate::Unit => Ty::Unit,
             RetTemplate::Bool => Ty::Bool,
             RetTemplate::I64 => Ty::I64,
-            RetTemplate::OptionVal => Ty::option(cx.val.clone()),
             RetTemplate::Elem => cx.elem.clone(),
             RetTemplate::VecOfKey => self.make_vec_type(cx.key.clone(), span),
             RetTemplate::VecOfVal => self.make_vec_type(cx.val.clone(), span),
@@ -4135,6 +4135,40 @@ impl Checker {
             .get(1)
             .cloned()
             .unwrap_or(Ty::Var(TypeVar::fresh()));
+        // Trait-routed `Index<K>` accessor: `<HashMap<K, V> as Index>::get
+        // -> Option<V>` — the map twin of `Vec::get`. Dispatch is marked as
+        // the `Index` primitive-trait impl and records the
+        // `hew_hashmap_get_layout` resolved call, which codegen rewrites to
+        // the SINGLE fresh-owner clone choke (`hew_hashmap_get_clone_layout`)
+        // that writes a retained/cloned owner into the `Option` payload
+        // (drop-safe; `by-value-heap-params-are-borrows` P0). `get` is
+        // intentionally NOT in `collection_method_desc`: this explicit arm
+        // keeps the accessor model uniform with `Vec`, while the trapping
+        // `m[k]` read is the sibling `Index::at` (`-> V`).
+        if method == "get" {
+            self.check_arity(args, 1, "`HashMap::get`", span);
+            if let Some(arg) = args.first() {
+                let (expr, sp) = arg.expr();
+                self.check_against(expr, sp, &key_ty);
+            }
+            // Enforce `K: Hash + Eq` and reject unsafe key/value element
+            // types — the same admission the table-driven path ran for
+            // `get` (fire-and-return on rejection).
+            if !self.validate_hashmap_owned_element_types(&key_ty, &val_ty, span) {
+                return Ty::Error;
+            }
+            self.record_method_call_receiver_kind(
+                span,
+                MethodCallReceiverKind::PrimitiveTraitImpl {
+                    trait_name: "Index".to_string(),
+                    canonical_receiver: "HashMap".to_string(),
+                },
+            );
+            // Records the `Map::get` resolved call. `<HashMap<K, V> as
+            // Index>::Output` is `V`, so the projected return is `Option<V>`.
+            self.record_resolved_hashmap_call("get", &key_ty, &val_ty, span);
+            return Ty::option(val_ty);
+        }
         let cx = CollectionTyCx::hashmap(key_ty, val_ty);
         self.check_collection_method(CollectionKind::HashMap, &cx, method, args, span)
     }
@@ -8800,7 +8834,10 @@ mod tests {
     #[test]
     fn descriptor_table_checked_arities() {
         assert_eq!(arity_of(CollectionKind::HashMap, "insert"), Some(2));
-        assert_eq!(arity_of(CollectionKind::HashMap, "get"), Some(1));
+        // HashMap `get` is no longer in the descriptor table: it is trait-routed
+        // (`<HashMap<K, V> as Index>::get -> Option<V>`) through the explicit
+        // `check_hashmap_method` arm, not the collection driver (mirrors Vec).
+        assert!(collection_method_desc(CollectionKind::HashMap, "get").is_none());
         assert_eq!(arity_of(CollectionKind::HashMap, "keys"), Some(0));
         assert_eq!(arity_of(CollectionKind::HashSet, "insert"), Some(1));
         assert_eq!(arity_of(CollectionKind::HashSet, "contains"), Some(1));
@@ -8823,9 +8860,10 @@ mod tests {
         );
         assert_eq!(hm_insert.ret, RetTemplate::Unit);
 
-        let hm_get = collection_method_desc(CollectionKind::HashMap, "get").unwrap();
-        assert_eq!(hm_get.arg_templates, &[ArgTemplate::Key]);
-        assert_eq!(hm_get.ret, RetTemplate::OptionVal);
+        // HashMap `get` is intentionally absent from the descriptor table: the
+        // accessor is trait-routed through `Index<K>` (see
+        // `descriptor_table_checked_arities`).
+        assert!(collection_method_desc(CollectionKind::HashMap, "get").is_none());
 
         let hm_keys = collection_method_desc(CollectionKind::HashMap, "keys").unwrap();
         assert_eq!(hm_keys.ret, RetTemplate::VecOfKey);

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -15705,27 +15705,30 @@ fn index_dispatch_via_trait_for_vec() {
 }
 
 #[test]
-fn index_read_for_hashmap_string_key_yields_option() {
-    // `m["k"]` now reads through the HashMap get ABI and yields `Option<V>`
-    // (not the i32-keyed `Index` trait). A function returning `Option<i32>`
-    // accepts the index result directly.
-    let output = check_source(r#"fn f(m: HashMap<string, i32>) -> Option<i32> { m["k"] }"#);
+fn index_read_for_hashmap_string_key_yields_bare_value() {
+    // `m["k"]` is the trapping `Index::at` accessor and yields the BARE value
+    // `V` (a missing key aborts with IndexOutOfBounds — the map analogue of a
+    // `v[i]` out-of-bounds trap). A function returning the bare value type
+    // `i32` accepts the index result directly. The non-aborting outcome lives
+    // on `m.get("k") -> Option<V>`.
+    let output = check_source(r#"fn f(m: HashMap<string, i32>) -> i32 { m["k"] }"#);
     assert!(
         output.errors.is_empty(),
-        "HashMap<string, _> read indexing should type-check as Option<V>: {:?}",
+        "HashMap<string, _> read indexing should type-check as bare V: {:?}",
         output.errors
     );
 }
 
 #[test]
-fn index_read_for_hashmap_string_key_is_not_bare_value() {
-    // The read result is `Option<V>`, so a function annotated to return the
-    // bare value `i32` must be rejected — proving the surface is fail-closed
-    // (callers must handle the `None` case) rather than aborting on a miss.
-    let output = check_source(r#"fn f(m: HashMap<string, i32>) -> i32 { m["k"] }"#);
+fn index_read_for_hashmap_string_key_is_not_option() {
+    // The read result is the bare value `V` (trapping), so a function annotated
+    // to return `Option<V>` must be rejected — proving the surface inverted from
+    // the old `Option`-returning read. The non-aborting outcome is `m.get(k) ->
+    // Option<V>`, not the `m[k]` trapping accessor.
+    let output = check_source(r#"fn f(m: HashMap<string, i32>) -> Option<i32> { m["k"] }"#);
     assert!(
         !output.errors.is_empty(),
-        "HashMap read index returns Option<V>, so a bare-i32 return must mismatch: {:?}",
+        "HashMap read index returns bare V, so an Option<i32> return must mismatch: {:?}",
         output.errors
     );
 }

--- a/tests/fuzz-oracle/expected-failures.txt
+++ b/tests/fuzz-oracle/expected-failures.txt
@@ -21,7 +21,7 @@
 # map_literal_empty_annotated.hew, array_repeat_int_sum.hew, and
 # array_repeat_runtime_count.hew are intentionally absent: they must pass.
 #
-# Total: 13 known-failing entries (13 intentional-trap/abort fixtures).
+# Total: 17 known-failing entries (17 intentional-trap/abort fixtures).
 #
 # Intentional aborts/traps: fixtures in tests/vertical-slice/accept/ that are
 # designed to trap or abort at runtime as their correctness proof.  Listed here
@@ -40,6 +40,8 @@ vec_element_width_oob_traps.hew  # intentional trap: Vec<i8> index at len → In
 vec_index_assign_oob_traps.hew   # intentional trap: Vec<i64> OOB write v[1] on 1-element vec → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
 vec_index_oob_traps.hew          # intentional trap: Vec<i64> read v[10] on 3-element vec → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
 vec_enum_index_oob_traps.hew     # intentional trap: Vec<enum> read v[i] past end → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
+hashmap_index_absent_traps.hew       # intentional trap: HashMap<string,i64> read m["absent"] on missing key → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
+hashmap_enum_index_absent_traps.hew  # intentional trap: HashMap<string,enum> read m["absent"] on missing key → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64)
 crash_main_context_diagnostic.hew  # intentional trap: OOB Vec index in main context → IndexOutOfBounds signal (SIGILL x86_64 / SIGTRAP aarch64) + "hew: trap in main context" stderr diagnostic (F1.3)
 wire_cbor_decode_malformed_traps.hew  # intentional trap: decoding malformed CBOR (0xFF filler bytes) through the wire body codec fails closed → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)
 wire_cbor_enum_oob_tag_traps.hew  # intentional trap: decoding an out-of-range enum variant tag (well-formed CBOR, unknown tag) through the wire body codec fails closed → DecodeFailure trap (SIGILL x86_64 / SIGTRAP aarch64)

--- a/tests/hew/hashmap_index_get_proving_test.hew
+++ b/tests/hew/hashmap_index_get_proving_test.hew
@@ -1,0 +1,205 @@
+//! Proving fixtures for HashMap key indexing under the `Index<Idx>` trait-convergence.
+//!
+//! Two sibling accessors, one runtime choke (`hew_hashmap_get_clone_layout`):
+//!
+//!   * `m[k]` is the TRAPPING `Index::at` accessor — it yields a BARE `V` and
+//!     aborts with `IndexOutOfBounds` on a missing key (the map analogue of a
+//!     `v[i]` out-of-bounds trap). The miss/abort path is covered by the
+//!     vertical-slice fixtures (`hashmap_index_absent_traps`); here `m[k]` is
+//!     exercised only on the hit path, where the result is an independent,
+//!     drop-safe clone of the stored value (never a borrow into the live table).
+//!   * `m.get(k)` is the non-aborting sibling — it yields `Option<V>` with the
+//!     `Some` payload owning the same independent clone. A missing key is `None`.
+//!
+//! Mutating, overwriting, or removing the source key after the read must not
+//! invalidate the returned value — the headline GAP-2 drop-safety invariant of
+//! this lane (`by-value-heap-params-are-borrows` P0).
+//!
+//! Value classes exercised: scalar (i64), string, owned record, enum. Key
+//! classes: string and i64.
+
+import std::testing;
+
+type Rec {
+    label: string;
+    count: i64;
+}
+
+enum Shade {
+    Light;
+    Medium;
+    Dark;
+}
+
+// ── scalar value ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_hashmap_get_scalar_some_and_absent_none() {
+    let m: HashMap<string, i64> = HashMap::new();
+    m.insert("a", 10);
+    m.insert("b", 20);
+
+    match m.get("a") {
+        Some(x) => testing.assert_eq(x, 10),
+        None => testing.assert_true(false),
+    }
+    match m.get("b") {
+        Some(x) => testing.assert_eq(x, 20),
+        None => testing.assert_true(false),
+    }
+    match m.get("absent") {
+        Some(_) => testing.assert_true(false),
+        None => testing.assert_true(true),
+    }
+}
+
+#[test]
+fn test_hashmap_index_scalar_present_is_bare_value() {
+    let m: HashMap<string, i64> = HashMap::new();
+    m.insert("a", 42);
+    // The trapping accessor yields the bare value directly (no Option to match).
+    let x: i64 = m["a"];
+    testing.assert_eq(x, 42);
+}
+
+// ── string value (drop-safe retain) ──────────────────────────────────────────
+
+#[test]
+fn test_hashmap_get_string_some_survives_overwrite() {
+    let m: HashMap<string, string> = HashMap::new();
+    let n: i64 = 424242;
+    m.insert("k", f"heap-string-{n}-padding-zzzzzzzzzzzzzzzzzzzz");
+
+    let got: Option<string> = m.get("k");
+    // Overwrite the key: the old value is freed in the table. A borrowed payload
+    // would dangle here.
+    m.insert("k", "overwritten");
+
+    match got {
+        Some(s) => testing.assert_eq_str(s, "heap-string-424242-padding-zzzzzzzzzzzzzzzzzzzz"),
+        None => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn test_hashmap_index_string_present_survives_remove() {
+    let m: HashMap<string, string> = HashMap::new();
+    m.insert("k", "heap-string-survives-removal-zzzzzzzzzzzz");
+
+    let got: string = m["k"];
+    // Drop the table's copy entirely.
+    let _ = m.remove("k");
+
+    testing.assert_eq_str(got, "heap-string-survives-removal-zzzzzzzzzzzz");
+}
+
+#[test]
+fn test_hashmap_get_string_absent_none() {
+    let m: HashMap<string, string> = HashMap::new();
+    m.insert("only", "value");
+    match m.get("missing") {
+        Some(_) => testing.assert_true(false),
+        None => testing.assert_true(true),
+    }
+}
+
+// ── owned record value (drop-safe deep copy) ─────────────────────────────────
+
+#[test]
+fn test_hashmap_get_owned_record_some_is_independent_clone() {
+    let m: HashMap<string, Rec> = HashMap::new();
+    m.insert("a", Rec { label: "alpha-heap-owned-label", count: 1 });
+
+    let got: Option<Rec> = m.get("a");
+    // Overwrite the key in the source; the returned clone must be unaffected.
+    m.insert("a", Rec { label: "mutated-after-get", count: 999 });
+
+    match got {
+        Some(r) => {
+            testing.assert_eq_str(r.label, "alpha-heap-owned-label");
+            testing.assert_eq(r.count, 1);
+        },
+        None => testing.assert_true(false),
+    }
+    // And the source mutation actually landed (sanity).
+    match m.get("a") {
+        Some(r) => testing.assert_eq_str(r.label, "mutated-after-get"),
+        None => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn test_hashmap_index_owned_record_present_survives_overwrite() {
+    let m: HashMap<string, Rec> = HashMap::new();
+    m.insert("a", Rec { label: "survives-the-overwrite-heap-zzzz", count: 77 });
+
+    let got: Rec = m["a"];
+    // Free the source element by overwriting the key.
+    m.insert("a", Rec { label: "mutated", count: 0 });
+
+    testing.assert_eq_str(got.label, "survives-the-overwrite-heap-zzzz");
+    testing.assert_eq(got.count, 77);
+}
+
+#[test]
+fn test_hashmap_get_owned_record_absent_none() {
+    let m: HashMap<string, Rec> = HashMap::new();
+    m.insert("a", Rec { label: "x", count: 0 });
+    match m.get("absent") {
+        Some(_) => testing.assert_true(false),
+        None => testing.assert_true(true),
+    }
+}
+
+// ── enum value ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_hashmap_get_enum_some_and_absent_none() {
+    let m: HashMap<string, Shade> = HashMap::new();
+    m.insert("light", Shade::Light);
+    m.insert("dark", Shade::Dark);
+
+    match m.get("dark") {
+        Some(s) => match s {
+            Shade::Dark => testing.assert_true(true),
+            _ => testing.assert_true(false),
+        },
+        None => testing.assert_true(false),
+    }
+    match m.get("absent") {
+        Some(_) => testing.assert_true(false),
+        None => testing.assert_true(true),
+    }
+}
+
+#[test]
+fn test_hashmap_index_enum_present_is_bare_value() {
+    let m: HashMap<string, Shade> = HashMap::new();
+    m.insert("dark", Shade::Dark);
+    let s: Shade = m["dark"];
+    match s {
+        Shade::Dark => testing.assert_true(true),
+        _ => testing.assert_true(false),
+    }
+}
+
+// ── i64 key class ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_hashmap_index_i64_key_present_and_get_absent_none() {
+    let m: HashMap<i64, string> = HashMap::new();
+    m.insert(7, "seven");
+    m.insert(11, "eleven");
+
+    let got: string = m[7];
+    testing.assert_eq_str(got, "seven");
+
+    match m.get(11) {
+        Some(s) => testing.assert_eq_str(s, "eleven"),
+        None => testing.assert_true(false),
+    }
+    match m.get(99) {
+        Some(_) => testing.assert_true(false),
+        None => testing.assert_true(true),
+    }
+}

--- a/tests/hew/hashmap_index_get_proving_test.hew
+++ b/tests/hew/hashmap_index_get_proving_test.hew
@@ -12,8 +12,8 @@
 //!     `Some` payload owning the same independent clone. A missing key is `None`.
 //!
 //! Mutating, overwriting, or removing the source key after the read must not
-//! invalidate the returned value — the headline GAP-2 drop-safety invariant of
-//! this lane (`by-value-heap-params-are-borrows` P0).
+//! invalidate the returned value — the headline GAP-2 drop-safety invariant
+//! (`by-value-heap-params-are-borrows` P0).
 //!
 //! Value classes exercised: scalar (i64), string, owned record, enum. Key
 //! classes: string and i64.

--- a/tests/vertical-slice/accept/hashmap_enum_index_absent_traps.hew
+++ b/tests/vertical-slice/accept/hashmap_enum_index_absent_traps.hew
@@ -1,0 +1,21 @@
+// Indexed-accessor trap negative for an enum value class: `m[k]` on an absent
+// key over a `HashMap<K, enum>` must trap (IndexOutOfBounds) exactly like the
+// scalar case — proving the trapping `at` path is value-class-uniform and does
+// not silently synthesise a default variant. Terminates via `llvm.trap`: exit
+// 132 (SIGILL, x86_64 Linux) or 133 (SIGTRAP, aarch64/macOS).
+enum Shade {
+    Light;
+    Medium;
+    Dark;
+}
+
+fn main() -> i64 {
+    let m: HashMap<string, Shade> = HashMap::new();
+    m.insert("present", Shade::Dark);
+    // "absent" was never inserted: the read must trap before yielding a variant.
+    let s = m["absent"];
+    match s {
+        Shade::Dark => 1,
+        _ => 0,
+    }
+}

--- a/tests/vertical-slice/accept/hashmap_index_absent_traps.hew
+++ b/tests/vertical-slice/accept/hashmap_index_absent_traps.hew
@@ -1,0 +1,15 @@
+// Indexed-accessor trap negative: `m[k]` on an absent key must trap
+// (IndexOutOfBounds) rather than read garbage or fall back to a default. This is
+// the trapping `at` half of the `Index<Idx>` model for HashMap, and the m[k]
+// INVERSION: `m[k]` is the BARE-`V` aborting accessor, while `m.get(k)` returns
+// `Option<V>` for the non-aborting outcome. The binary terminates via
+// `llvm.trap`: exit 132 (SIGILL, x86_64 Linux) or 133 (SIGTRAP, aarch64/macOS)
+// — run_accept_expect_trap accepts either.
+fn main() -> i64 {
+    let m: HashMap<string, i64> = HashMap::new();
+    m.insert("present", 42);
+    // "absent" was never inserted: the read must trap before yielding a value.
+    let x = m["absent"];
+    // Unreachable: the index trap fires above.
+    x
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -425,6 +425,13 @@ run_accept_expect_trap "isize_shift_oob_traps"
 run_accept_expect_trap "vec_index_oob_traps"
 run_accept_expect_trap "vec_enum_index_oob_traps"
 
+# Indexed-accessor trap negatives for HashMap: `m[k]` on an absent key traps
+# (IndexOutOfBounds) for every value class — the trapping `at` half of the
+# `Index<Idx>` model and the m[k] INVERSION (the non-aborting outcome is now
+# `m.get(k) -> Option<V>`). Same arch-dependent trap signal (132/133).
+run_accept_expect_trap "hashmap_index_absent_traps"
+run_accept_expect_trap "hashmap_enum_index_absent_traps"
+
 # defer: basic (no effect on return), executes (exit override), LIFO, block scope
 run_accept_expect_status "defer_basic" 7
 run_accept_expect_status "defer_executes" 42


### PR DESCRIPTION
## Summary

`m[k]` now performs a trapping indexed read returning a bare `V` (mirroring `v[i]` from the Vec migration), and `m.get(k)` returns a drop-safe `Option<V>` via the `Index<Idx>` trait. This **inverts** the previous `m[k] → Option<V>` behaviour.

Owned values are cloned to fresh, independently-droppable owners through the `hew_hashmap_get_clone_layout` runtime choke — the map is borrowed, never consumed, and the miss path traps without any drop. The existing choke is reused unchanged; `hew-runtime` and `hew-cabi` are not touched. bytes/string indexing migrate in follow-on PRs.

## Verification

- `make ci-preflight`: green
- `test-hew-ratchet` drop-leak: 0 leaks / 0 bytes
- GAP-2 leak oracle under MallocScribble/MallocPreScribble/MallocGuardEdges: 0 leaks / 0 bytes; owned value survives same-key overwrite + remove
- `m[absent]`: traps `IndexOutOfBounds` (verified by vertical-slice exit 133 + diagnostic string)
- `m.get` Option path: present → `Some(V)`, absent → `None` — not hijacked by the trap dispatch
- `make sandbox-parity`: 7/7 native == wasm32
- `cargo fmt --check`: exit 0
- Preflight: ready-to-push

## Out of scope

- bytes and string indexed-accessor migration (follow-on PRs in this series)

**Breaking change:** `m[k]` now returns bare `V` and traps on a missing key (was `Option<V>`). Use `m.get(k)` for the fallible read.