### PR TITLE
fix(types,hir): local declarations shadow built-in enum variant names

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -43117,6 +43117,7 @@ mod tests {
                 doc_comment: None,
                 extern_symbol: None,
                 requires_mutable_receiver: false,
+                is_builtin_variant: false,
             },
         }];
         // Declare the drop-in-place fn so we make it past arm (a).

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -1817,18 +1817,31 @@ pub fn lower_program_with_mono_cap(
         // redeclares `Some` or `Ok` will correctly mark the bare name as
         // ambiguous (qualified forms still resolve via `Option::Some`,
         // `Result::Ok`).
+        //
+        // Local-shadows-global: builtins are NOT pre-seeded any longer.
+        // Instead, after counting all user variants, builtin names are
+        // inserted with count 1 ONLY WHERE user count is 0 (via `or_insert`).
+        // A companion `user_declared_variant_names` set tracks which bare
+        // names the root program declared, so the builtin spec registration
+        // pass can skip the bare-form insertion for those names (preventing
+        // the last-write-wins overwrite of the user's registration).
         let mut bare_counts: HashMap<String, usize> = HashMap::new();
-        for name in BUILTIN_ENUM_VARIANT_BARE_NAMES {
-            *bare_counts.entry((*name).to_string()).or_insert(0) += 1;
-        }
+        // Accumulate user-declared variant names from root `program.items` so
+        // the builtin registration pass can honour local-shadows-global.
+        let mut user_declared_variant_names: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
         for (item, _) in &program.items {
             match item {
                 Item::Machine(md) => {
                     for state in &md.states {
                         *bare_counts.entry(state.name.clone()).or_insert(0) += 1;
+                        // Machine states shadow same-named builtins (local-shadows-global).
+                        user_declared_variant_names.insert(state.name.clone());
                     }
                     for event in &md.events {
                         *bare_counts.entry(event.name.clone()).or_insert(0) += 1;
+                        // Machine events shadow same-named builtins (local-shadows-global).
+                        user_declared_variant_names.insert(event.name.clone());
                     }
                 }
                 Item::TypeDecl(td) if td.kind == TypeDeclKind::Enum => {
@@ -1839,6 +1852,9 @@ pub fn lower_program_with_mono_cap(
                     for body_item in &td.body {
                         if let TypeBodyItem::Variant(v) = body_item {
                             *bare_counts.entry(v.name.clone()).or_insert(0) += 1;
+                            // Track root-program user variants for the
+                            // local-shadows-global builtin registration guard.
+                            user_declared_variant_names.insert(v.name.clone());
                         }
                     }
                 }
@@ -1914,6 +1930,16 @@ pub fn lower_program_with_mono_cap(
                     }
                 }
             }
+        }
+        // Post-user-scan: seed builtin enum variant names with count 1 where
+        // the user has not declared any variant with that name.  This preserves
+        // bare-form accessibility for pure-builtin names (e.g. `Ok`, `None`,
+        // `Full`) while preventing builtins from contributing a spurious "1"
+        // to names the user already declared.  Combined with the guard in the
+        // builtin spec registration pass below, this implements the
+        // local-shadows-global rule at the HIR bare-name layer.
+        for name in BUILTIN_ENUM_VARIANT_BARE_NAMES {
+            bare_counts.entry((*name).to_string()).or_insert(1);
         }
         for (item, _) in &program.items {
             match item {
@@ -2084,12 +2110,21 @@ pub fn lower_program_with_mono_cap(
         // user enums. Without these entries, `Ok(42)` would lower as an
         // unresolved identifier and `match r { Ok(n) => ... }` would emit
         // `match arm variant not registered in machine/enum ctor registry`.
+        //
+        // Local-shadows-global: skip the bare-form insertion for any builtin
+        // variant name that the root program has already declared.  The
+        // qualified form (`LookupError::NotFound`) is always registered so
+        // existing code that uses the fully-qualified path keeps working.
         for spec in builtin_enum_specs() {
             for (variant_idx, variant_name) in spec.variant_names.iter().enumerate() {
                 let qualified = format!("{}::{}", spec.type_name, variant_name);
                 ctx.machine_ctor_registry
                     .insert(qualified, (spec.type_name.to_string(), variant_idx));
-                if bare_counts.get(*variant_name).copied().unwrap_or(0) == 1 {
+                // Register the bare form only when count == 1 (unique) AND
+                // the user has not declared their own variant with this name.
+                if bare_counts.get(*variant_name).copied().unwrap_or(0) == 1
+                    && !user_declared_variant_names.contains(*variant_name)
+                {
                     ctx.machine_ctor_registry.insert(
                         (*variant_name).to_string(),
                         (spec.type_name.to_string(), variant_idx),

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -1897,9 +1897,14 @@ pub fn lower_program_with_mono_cap(
                             Item::Machine(md) if md.visibility.is_pub() => {
                                 for state in &md.states {
                                     *bare_counts.entry(state.name.clone()).or_insert(0) += 1;
+                                    // Pub machine states shadow same-named builtins
+                                    // across the flat global registry.
+                                    user_declared_variant_names.insert(state.name.clone());
                                 }
                                 for event in &md.events {
                                     *bare_counts.entry(event.name.clone()).or_insert(0) += 1;
+                                    // Pub machine events shadow same-named builtins.
+                                    user_declared_variant_names.insert(event.name.clone());
                                 }
                             }
                             Item::TypeDecl(td)
@@ -1908,6 +1913,8 @@ pub fn lower_program_with_mono_cap(
                                 for body_item in &td.body {
                                     if let TypeBodyItem::Variant(v) = body_item {
                                         *bare_counts.entry(v.name.clone()).or_insert(0) += 1;
+                                        // Pub enum variants shadow same-named builtins.
+                                        user_declared_variant_names.insert(v.name.clone());
                                     }
                                 }
                             }
@@ -28806,6 +28813,71 @@ mod tests {
                 .iter()
                 .map(|layout| &layout.key)
                 .collect::<Vec<_>>()
+        );
+    }
+
+    /// A pub enum declared in a non-root (imported) module whose variant name
+    /// matches a builtin variant name must not be overwritten by the builtin
+    /// in `machine_ctor_registry`.  Without the local-shadows-global fix that
+    /// extends `user_declared_variant_names` to non-root pub items, the
+    /// `builtin_enum_specs` registration pass sees `!user_declared_variant_names
+    /// .contains("NotFound")` as true and overwrites the user's
+    /// `AppErr::NotFound` (Tuple kind) entry with `LookupError::NotFound`
+    /// (Unit kind).  The Tuple-variant call `NotFound(msg)` inside the module
+    /// body then hits `report_variant_ctor_call_shape_mismatch` and emits a
+    /// "unit variant called as a function" diagnostic.
+    #[test]
+    fn nonroot_pub_enum_variant_shadows_same_named_builtin_in_hir() {
+        use hew_parser::module::{Module, ModuleGraph, ModuleId};
+
+        let mod_src = hew_parser::parse(
+            r"
+            pub enum AppErr { NotFound(string) }
+
+            pub fn make_error(msg: string) -> AppErr {
+                NotFound(msg)
+            }
+            ",
+        );
+        assert!(
+            mod_src.errors.is_empty(),
+            "module parse errors: {:?}",
+            mod_src.errors
+        );
+
+        let root_id = ModuleId::root();
+        let mod_id = ModuleId::new(vec!["errmod".to_string()]);
+        let module = Module {
+            id: mod_id.clone(),
+            items: mod_src.program.items,
+            imports: vec![],
+            source_paths: vec![],
+            doc: None,
+        };
+        let mut mg = ModuleGraph::new(root_id.clone());
+        mg.add_module(module).unwrap();
+        mg.topo_order = vec![mod_id, root_id];
+        let program = Program {
+            module_graph: Some(mg),
+            items: vec![],
+            module_doc: None,
+        };
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let tco = checker.check_program(&program);
+        assert!(
+            tco.errors.is_empty(),
+            "type errors (should be none): {:?}",
+            tco.errors
+        );
+
+        let lowered = lower_program(&program, &tco, &ResolutionCtx, TargetArch::host());
+        assert!(
+            lowered.diagnostics.is_empty(),
+            "HIR diagnostics must be empty — a 'unit variant NotFound called as a \
+             function' diagnostic means the builtin LookupError::NotFound overwrote \
+             AppErr::NotFound in machine_ctor_registry: {:#?}",
+            lowered.diagnostics
         );
     }
 }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -1894,33 +1894,36 @@ pub fn lower_program_with_mono_cap(
                 if let Some(module) = mg.modules.get(mod_id) {
                     for (item, _) in &module.items {
                         match item {
-                            Item::Machine(md) if md.visibility.is_pub() => {
+                            Item::Machine(md) => {
                                 for state in &md.states {
                                     *bare_counts.entry(state.name.clone()).or_insert(0) += 1;
-                                    // Pub machine states shadow same-named builtins
-                                    // across the flat global registry.
+                                    // Machine states (pub or private) shadow same-named
+                                    // builtins across the flat global registry, matching
+                                    // the checker's global register_machine_decl walk.
                                     user_declared_variant_names.insert(state.name.clone());
                                 }
                                 for event in &md.events {
                                     *bare_counts.entry(event.name.clone()).or_insert(0) += 1;
-                                    // Pub machine events shadow same-named builtins.
+                                    // Machine events shadow same-named builtins.
                                     user_declared_variant_names.insert(event.name.clone());
                                 }
                             }
-                            Item::TypeDecl(td)
-                                if td.visibility.is_pub() && td.kind == TypeDeclKind::Enum =>
-                            {
+                            Item::TypeDecl(td) if td.kind == TypeDeclKind::Enum => {
+                                // All enum variants (pub or private) shadow same-named
+                                // builtins, matching the checker's global
+                                // pre_register_type_decl walk (registration.rs:1359)
+                                // which inserts bare variant fn_sigs regardless of
+                                // visibility.
                                 for body_item in &td.body {
                                     if let TypeBodyItem::Variant(v) = body_item {
                                         *bare_counts.entry(v.name.clone()).or_insert(0) += 1;
-                                        // Pub enum variants shadow same-named builtins.
                                         user_declared_variant_names.insert(v.name.clone());
                                     }
                                 }
                             }
-                            // No pub variant bare-names in imported modules for
-                            // these items. Compiler enforces exhaustivity if a
-                            // new Item variant is added.
+                            // No variant bare-names to count for these items.
+                            // Compiler enforces exhaustivity if a new Item variant
+                            // is added. Item::Machine is handled by the arm above.
                             Item::Import(_)
                             | Item::Const(_)
                             | Item::TypeDecl(_)
@@ -1929,7 +1932,6 @@ pub fn lower_program_with_mono_cap(
                             | Item::Impl(_)
                             | Item::Function(_)
                             | Item::ExternBlock(_)
-                            | Item::Machine(_)
                             | Item::Actor(_)
                             | Item::Supervisor(_)
                             | Item::Record(_) => {}
@@ -2015,15 +2017,13 @@ pub fn lower_program_with_mono_cap(
         // Mirror the machine_ctor_registry fill over `program.module_graph`
         // non-root modules. The checker's `register_machine_decl` walk in
         // `hew-types/src/check/registration.rs` already populates `type_defs`
-        // for imported pub machines and enums; this loop is the HIR-side
-        // symmetric producer so `resolve_identifier_variant` hits in
-        // `lower_identifier` (machine_ctor_registry lookup) for cross-module
-        // ctors. Without this, a root `fn main() { var t: Toggle = Toggle::Off; }`
-        // that imports `std::machines::toggle` would emit `UnresolvedSymbol`
-        // at HIR even though the checker accepted the reference.
-        //
-        // Same Pub gating as the bare-count walk above so private machines /
-        // enums in imported modules are invisible to consumers.
+        // for imported machines and enums regardless of visibility; this loop
+        // is the HIR-side symmetric producer.  Visibility is NOT used as a
+        // filter here: private machines and enums in imported modules are
+        // registered globally so that their own pub function bodies (which are
+        // lowered in §4b / fourth-pass) resolve bare variant constructors
+        // correctly.  This matches the checker's global pre_register_type_decl
+        // behaviour (registration.rs:1359, no pub guard).
         if let Some(ref mg) = program.module_graph {
             for mod_id in &mg.topo_order {
                 if *mod_id == mg.root {
@@ -2033,7 +2033,7 @@ pub fn lower_program_with_mono_cap(
                 if let Some(module) = mg.modules.get(mod_id) {
                     for (item, _) in &module.items {
                         match item {
-                            Item::Machine(md) if md.visibility.is_pub() => {
+                            Item::Machine(md) => {
                                 let event_type_name = format!("{}Event", md.name);
                                 for (idx, state) in md.states.iter().enumerate() {
                                     let qualified = format!("{}::{}", md.name, state.name);
@@ -2064,9 +2064,7 @@ pub fn lower_program_with_mono_cap(
                                     }
                                 }
                             }
-                            Item::TypeDecl(td)
-                                if td.visibility.is_pub() && td.kind == TypeDeclKind::Enum =>
-                            {
+                            Item::TypeDecl(td) if td.kind == TypeDeclKind::Enum => {
                                 let mut variant_idx: usize = 0;
                                 for body_item in &td.body {
                                     if let TypeBodyItem::Variant(v) = body_item {
@@ -2089,9 +2087,10 @@ pub fn lower_program_with_mono_cap(
                                     }
                                 }
                             }
-                            // No pub ctor entries to register from imported
-                            // modules for these items. Compiler enforces
-                            // exhaustivity if a new Item variant is added.
+                            // No ctor entries to register for these items.
+                            // Compiler enforces exhaustivity if a new Item variant
+                            // is added. Item::Machine and TypeDecl::Enum are
+                            // handled by the arms above.
                             Item::Import(_)
                             | Item::Const(_)
                             | Item::TypeDecl(_)
@@ -2100,7 +2099,6 @@ pub fn lower_program_with_mono_cap(
                             | Item::Impl(_)
                             | Item::Function(_)
                             | Item::ExternBlock(_)
-                            | Item::Machine(_)
                             | Item::Actor(_)
                             | Item::Supervisor(_)
                             | Item::Record(_) => {}
@@ -2422,6 +2420,7 @@ pub fn lower_program_with_mono_cap(
                     match item {
                         Item::TypeDecl(decl)
                             if decl.visibility.is_pub()
+                                || decl.kind == TypeDeclKind::Enum
                                 || (decl.kind == TypeDeclKind::Struct
                                     && decl.type_params.is_none()) =>
                         {
@@ -2503,11 +2502,15 @@ pub fn lower_program_with_mono_cap(
                             }
                             type_decl_cache.insert(decl as *const _, hir_decl);
                         }
-                        Item::Machine(md) if md.visibility.is_pub() => {
+                        Item::Machine(md) => {
                             // Synthesise state variants. Unit when stateless,
                             // Struct otherwise — mirrors how `lookup_variant_ctor`
                             // dispatches on `HirVariantKind` at struct-init /
-                            // identifier resolution sites.
+                            // identifier resolution sites.  Matches pub and
+                            // private machines: the checker's register_machine_decl
+                            // (registration.rs:1371) uses an idempotency guard, not
+                            // a pub guard, so private machines are registered globally
+                            // by the checker too.
                             let state_variants: Vec<HirVariant> = md
                                 .states
                                 .iter()
@@ -2567,7 +2570,8 @@ pub fn lower_program_with_mono_cap(
                         // No enum-variant/machine descriptors to cache for
                         // these items in imported modules (§4b pre-pass). If
                         // a new Item variant is added, the compiler will force
-                        // a conscious decision here.
+                        // a conscious decision here. Item::Machine is handled
+                        // by the arm above.
                         Item::Import(_)
                         | Item::Const(_)
                         | Item::TypeDecl(_)
@@ -2576,7 +2580,6 @@ pub fn lower_program_with_mono_cap(
                         | Item::Impl(_)
                         | Item::Function(_)
                         | Item::ExternBlock(_)
-                        | Item::Machine(_)
                         | Item::Actor(_)
                         | Item::Supervisor(_)
                         | Item::Record(_) => {}
@@ -28877,6 +28880,69 @@ mod tests {
             "HIR diagnostics must be empty — a 'unit variant NotFound called as a \
              function' diagnostic means the builtin LookupError::NotFound overwrote \
              AppErr::NotFound in machine_ctor_registry: {:#?}",
+            lowered.diagnostics
+        );
+    }
+
+    /// Same as `nonroot_pub_enum_variant_shadows_same_named_builtin_in_hir`
+    /// but with a PRIVATE enum.  The checker's `pre_register_type_decl`
+    /// (registration.rs:1359) inserts bare variant `fn_sigs` for ALL non-root
+    /// `TypeDecl`s regardless of visibility, so a program where a private enum
+    /// uses a builtin-named variant is accepted by the checker.  HIR must
+    /// match: the bare form of the variant constructor in the module body
+    /// must resolve to the user's private enum, not to the builtin unit
+    /// variant.
+    #[test]
+    fn nonroot_private_enum_variant_shadows_same_named_builtin_in_hir() {
+        use hew_parser::module::{Module, ModuleGraph, ModuleId};
+
+        let mod_src = hew_parser::parse(
+            r"
+            enum AppErr { NotFound(string) }
+
+            pub fn make_error(msg: string) -> AppErr {
+                NotFound(msg)
+            }
+            ",
+        );
+        assert!(
+            mod_src.errors.is_empty(),
+            "module parse errors: {:?}",
+            mod_src.errors
+        );
+
+        let root_id = ModuleId::root();
+        let mod_id = ModuleId::new(vec!["errmod".to_string()]);
+        let module = Module {
+            id: mod_id.clone(),
+            items: mod_src.program.items,
+            imports: vec![],
+            source_paths: vec![],
+            doc: None,
+        };
+        let mut mg = ModuleGraph::new(root_id.clone());
+        mg.add_module(module).unwrap();
+        mg.topo_order = vec![mod_id, root_id];
+        let program = Program {
+            module_graph: Some(mg),
+            items: vec![],
+            module_doc: None,
+        };
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let tco = checker.check_program(&program);
+        assert!(
+            tco.errors.is_empty(),
+            "type errors (should be none): {:?}",
+            tco.errors
+        );
+
+        let lowered = lower_program(&program, &tco, &ResolutionCtx, TargetArch::host());
+        assert!(
+            lowered.diagnostics.is_empty(),
+            "HIR diagnostics must be empty — a 'unit variant NotFound called as a \
+             function' diagnostic means the builtin LookupError::NotFound overwrote \
+             the private AppErr::NotFound in machine_ctor_registry: {:#?}",
             lowered.diagnostics
         );
     }

--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -2268,6 +2268,7 @@ mod tests {
                 doc_comment: None,
                 extern_symbol: None,
                 requires_mutable_receiver: false,
+                is_builtin_variant: false,
             },
         )]);
         let mut type_defs = HashMap::new(); // "T" is not a user-defined type

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -42,19 +42,38 @@ impl Checker {
                 })
             })
         } else {
-            self.type_defs
-                .iter()
-                .filter(|(_, td)| td.kind == TypeDefKind::Enum || td.kind == TypeDefKind::Struct)
-                .find_map(|(type_name, td)| {
-                    td.variants.get(func_name).and_then(|variant| {
-                        let params = match variant {
-                            VariantDef::Unit => Vec::new(),
-                            VariantDef::Tuple(p) => p.clone(),
-                            VariantDef::Struct(_) => return None,
-                        };
-                        Some((type_name.clone(), params, td.type_params.clone()))
+            // Two-pass scan: local/source types win over builtin/imported types
+            // (local-shadows-global rule).  Pass 1 scans only locally-declared
+            // types; pass 2 scans the remainder.  This prevents a builtin unit
+            // variant (e.g. `LookupError::NotFound`) from shadowing a user-
+            // declared tuple variant with the same bare name
+            // (e.g. `AppError::NotFound(string)`).
+            let find_in = |name: &str, check_local: bool| {
+                self.type_defs
+                    .iter()
+                    .filter(|(type_name, td)| {
+                        let is_local = self.local_type_defs.contains(type_name.as_str())
+                            || self.source_type_defs.contains(type_name.as_str());
+                        let kind_ok =
+                            td.kind == TypeDefKind::Enum || td.kind == TypeDefKind::Struct;
+                        kind_ok && (is_local == check_local)
                     })
-                })
+                    .find_map(|(type_name, td)| {
+                        td.variants.get(name).and_then(|variant| {
+                            let params = match variant {
+                                VariantDef::Unit => Vec::new(),
+                                VariantDef::Tuple(p) => p.clone(),
+                                VariantDef::Struct(_) => return None,
+                            };
+                            Some((type_name.clone(), params, td.type_params.clone()))
+                        })
+                    })
+            };
+            // Pass 1: user-declared types.
+            find_in(func_name, true).or_else(|| {
+                // Pass 2: builtin/imported types.
+                find_in(func_name, false)
+            })
         }
     }
 

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -1203,6 +1203,15 @@ impl Checker {
                     .insert(name.to_string());
             }
             let sig = self.fn_sigs[name].clone();
+            // local-shadows-global: when the fn_sig slot was won by a builtin enum
+            // variant, prefer any user-declared enum that has a variant with the
+            // same name (e.g. user `enum AppError { NotFound(string); }` shadows
+            // the builtin `LookupError::NotFound` unit variant).
+            if sig.is_builtin_variant {
+                if let Some(user_ty) = self.find_user_variant_shadow_ty(name) {
+                    return user_ty;
+                }
+            }
             if sig.params.is_empty() {
                 sig.return_type
             } else {
@@ -1216,19 +1225,111 @@ impl Checker {
         }
     }
 
+    /// Look up whether any user-declared enum type (in `local_type_defs` or
+    /// `source_type_defs`) has a variant named `variant_name`.  Returns the
+    /// resolved `Ty` for that variant if found (unit variant → the enum type;
+    /// tuple variant → a `Ty::Function` constructing that enum), or `None` if
+    /// no user type shadows the given bare name.
+    ///
+    /// Used by `check_identifier` to implement the local-shadows-global rule:
+    /// when `fn_sigs[variant_name].is_builtin_variant` is `true`, the builtin
+    /// won the bare-name slot but a user-declared variant with the same name
+    /// should take priority within this compilation unit.
+    fn find_user_variant_shadow_ty(&self, variant_name: &str) -> Option<Ty> {
+        // Iterate over local types (user-declared in root or imported source modules).
+        // Two-set iteration: local first, then source.  In practice most programs
+        // won't have shadowing at all, so this is a short-circuit path.
+        for type_name in self
+            .local_type_defs
+            .iter()
+            .chain(self.source_type_defs.iter())
+        {
+            let Some(td) = self.type_defs.get(type_name.as_str()) else {
+                continue;
+            };
+            if td.kind != TypeDefKind::Enum {
+                continue;
+            }
+            let Some(variant) = td.variants.get(variant_name) else {
+                continue;
+            };
+            // Build fresh inference variables for any type parameters on the
+            // user enum (e.g. `enum Outcome<T> { Found(T); NotFound; }`).
+            let type_args: Vec<Ty> = td
+                .type_params
+                .iter()
+                .map(|_| Ty::Var(TypeVar::fresh()))
+                .collect();
+            let return_type = Ty::normalize_named(type_name.clone(), type_args.clone());
+            return Some(match variant {
+                VariantDef::Tuple(payload_tys) => {
+                    // Substitute generic type params with their corresponding
+                    // fresh inference variables in each payload type.
+                    let params: Vec<Ty> = payload_tys
+                        .iter()
+                        .map(|ty| {
+                            td.type_params.iter().zip(&type_args).fold(
+                                ty.clone(),
+                                |acc, (tp_name, fresh_var)| {
+                                    acc.substitute_named_param(tp_name, fresh_var)
+                                },
+                            )
+                        })
+                        .collect();
+                    Ty::Function {
+                        params,
+                        ret: Box::new(return_type),
+                    }
+                }
+                // Unit variants are values (no call needed); struct variants
+                // are constructed via `Expr::StructInit`, not
+                // `Expr::Identifier` — this path is not reached for them.
+                VariantDef::Unit | VariantDef::Struct(_) => return_type,
+            });
+        }
+        None
+    }
+
     /// Look up an identifier as a unit enum variant or qualified variant name.
     #[allow(
         clippy::too_many_lines,
         reason = "multi-branch variant resolution: unqualified, qualified-in-type_defs, and qualified-in-fn_sigs each need distinct handling"
     )]
     pub(super) fn resolve_identifier_variant(&mut self, name: &str, span: &Span) -> Ty {
+        // Two-pass scan: user-declared (local/source) types win over builtin/
+        // imported types when both declare a unit variant with the same bare name
+        // (local-shadows-global rule).  Pass 1 considers only types recorded in
+        // `local_type_defs` or `source_type_defs`; pass 2 considers the rest.
         let mut found = None;
+        // Pass 1: user-declared types.
         for (type_name, td) in &self.type_defs {
+            if !self.local_type_defs.contains(type_name.as_str())
+                && !self.source_type_defs.contains(type_name.as_str())
+            {
+                continue;
+            }
             if let Some(variant) = td.variants.get(name) {
                 if matches!(variant, VariantDef::Unit) {
                     let ty = Ty::normalize_named(type_name.clone(), vec![]);
                     found = Some(ty);
                     break;
+                }
+            }
+        }
+        // Pass 2: builtin/imported types (only when no user type matched).
+        if found.is_none() {
+            for (type_name, td) in &self.type_defs {
+                if self.local_type_defs.contains(type_name.as_str())
+                    || self.source_type_defs.contains(type_name.as_str())
+                {
+                    continue; // already scanned in pass 1
+                }
+                if let Some(variant) = td.variants.get(name) {
+                    if matches!(variant, VariantDef::Unit) {
+                        let ty = Ty::normalize_named(type_name.clone(), vec![]);
+                        found = Some(ty);
+                        break;
+                    }
                 }
             }
         }

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -1591,6 +1591,7 @@ impl Checker {
                                     type_params: type_param_names.clone(),
                                     type_param_bounds: type_param_bounds.clone(),
                                     return_type,
+                                    is_builtin_variant: self.in_stdlib_registration,
                                     ..FnSig::default()
                                 },
                             );
@@ -1613,6 +1614,7 @@ impl Checker {
                                     type_param_bounds: type_param_bounds.clone(),
                                     params: variant_tys,
                                     return_type,
+                                    is_builtin_variant: self.in_stdlib_registration,
                                     ..FnSig::default()
                                 },
                             );
@@ -7123,7 +7125,9 @@ impl Checker {
                     if !self.register_type_namespace_name(Some(module_short), &td.name, span) {
                         continue;
                     }
+                    self.in_stdlib_registration = true;
                     self.register_type_decl(td);
+                    self.in_stdlib_registration = false;
                     self.known_types.insert(td.name.clone());
                     // Qualified authority is always published, mirroring the
                     // user-module path: the qualified alias and the module-export

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -1349,7 +1349,14 @@ impl Checker {
                 // Any occurrence of the name "Task" in a user-source type
                 // annotation is an error. Emit `E_TASK_NOT_NAMEABLE` and
                 // return `Ty::Error` so downstream checks don't cascade.
-                if name == "Task" {
+                //
+                // Guard: if the user declared their own `Task` type in scope,
+                // the reservation does not fire — the user's declaration shadows
+                // the compiler-internal name (local-shadows-global rule).
+                if name == "Task"
+                    && !self.local_type_defs.contains("Task")
+                    && !self.source_type_defs.contains("Task")
+                {
                     self.report_error(
                         TypeErrorKind::TaskNotNameable,
                         &te.1,

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -29317,3 +29317,198 @@ mod every_attribute {
         }
     }
 }
+
+/// Tests for the local-shadows-global reserved-name fix (rc1-reserved-names lane).
+///
+/// Four invariants:
+///   1. A user payload variant shadows a builtin unit variant of the same name.
+///   2. A user unit variant deterministically shadows a builtin unit variant.
+///   3. Qualified builtin variant still resolves after the fix (no regression).
+///   4. Two user enums with the same variant name remain ambiguous (user-vs-user
+///      behaviour is unchanged by this fix).
+#[cfg(test)]
+mod reserved_names {
+    use super::*;
+
+    /// User `enum AppError { NotFound(string); }` — bare `NotFound("msg")`
+    /// must resolve to `AppError::NotFound`, NOT to the builtin
+    /// `LookupError::NotFound` unit variant.
+    ///
+    /// In the no-search-paths test context, `register_builtins` runs before
+    /// `collect_types`, so the user's registration overwrites the builtin's
+    /// `fn_sigs` slot (user already wins).  This test pins the expected
+    /// behaviour as a regression guard, and also validates the
+    /// `resolve_identifier_variant` two-pass fix does not break this.
+    #[test]
+    fn user_payload_variant_shadows_builtin_unit() {
+        let output = check_source(
+            r#"
+            enum AppError {
+                NotFound(string);
+                Timeout;
+                Forbidden;
+            }
+
+            fn get_error() -> AppError {
+                NotFound("resource missing")
+            }
+
+            fn main() {
+                let _e = get_error();
+            }
+            "#,
+        );
+        assert!(
+            output.errors.is_empty(),
+            "user payload variant NotFound should shadow builtin LookupError::NotFound; \
+             got errors: {:#?}",
+            output.errors
+        );
+    }
+
+    /// User `enum Status { Timeout; }` — bare `Timeout` must deterministically
+    /// resolve to `Status::Timeout`, not `LookupError::Timeout` (builtin unit).
+    ///
+    /// The two-pass scan in `resolve_identifier_variant` ensures user-declared
+    /// types always win regardless of `HashMap` iteration order.
+    #[test]
+    fn user_unit_variant_shadows_builtin_unit() {
+        let output = check_source(
+            r"
+            enum Status {
+                Timeout;
+                Ready;
+            }
+
+            fn check_timeout(s: Status) -> bool {
+                s == Timeout
+            }
+
+            fn main() {
+                let s: Status = Timeout;
+                let _b = check_timeout(s);
+            }
+            ",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "user unit variant Timeout should shadow builtin; got errors: {:#?}",
+            output.errors
+        );
+    }
+
+    /// Qualified form `LookupError::NotFound` must still resolve correctly
+    /// even when a user enum declares `NotFound`.  Qualified resolution
+    /// bypasses the bare-name collision entirely.
+    #[test]
+    fn qualified_builtin_variant_still_resolves() {
+        let output = check_source(
+            r"
+            fn main() {
+                let _e: LookupError = LookupError::NotFound;
+            }
+            ",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "qualified LookupError::NotFound must still resolve; got errors: {:#?}",
+            output.errors
+        );
+    }
+
+    /// Two user enums that both declare the same bare variant name: the TYPE
+    /// CHECKER resolves it to whichever registration ran last (last-write-wins
+    /// `fn_sigs` slot for user enums) — no type error at the checker layer.
+    ///
+    /// User-vs-user ambiguity is enforced at the HIR lowering layer via
+    /// `bare_counts` (not the type checker), which is unchanged by the
+    /// local-shadows-global fix.  This test pins the checker-layer behaviour:
+    /// bare `Conflict` is NOT a type error even with two same-named variants,
+    /// and this is unchanged by the shadowing fix (which only demotes BUILTIN
+    /// variants relative to user-declared ones).
+    #[test]
+    fn user_vs_user_same_variant_checker_resolves_last_writer() {
+        // At the checker layer, fn_sigs["Conflict"] is last-write-wins: A
+        // registers first, B overwrites.  The expression `Conflict` resolves
+        // to whichever won the slot — no type error.
+        let output = check_source(
+            r"
+            enum A { Conflict; }
+            enum B { Conflict; }
+
+            fn main() {
+                let _x = Conflict;
+            }
+            ",
+        );
+        // Type checker does not enforce uniqueness for bare variants when there
+        // are multiple user-declared types with the same variant name — that
+        // guard lives in HIR lowering (bare_counts).  No type errors expected.
+        assert!(
+            output.errors.is_empty(),
+            "bare Conflict with two user enums should not produce type errors \
+             (HIR lowering enforces uniqueness, not the checker); got: {:#?}",
+            output.errors
+        );
+    }
+
+    /// A user-declared `Task` enum must not trigger `TaskNotNameable`.
+    ///
+    /// `Task<T>` is normally a compiler-internal name.  When the user declares
+    /// their own `Task` enum, the local-shadows-global rule must bypass the
+    /// reservation guard so `Task` in type-annotation positions resolves to the
+    /// user's enum, not the compiler-internal type.
+    #[test]
+    fn user_task_enum_shadows_reserved_name() {
+        let output = check_source(
+            r#"
+            enum Task {
+                Pending;
+                Done;
+            }
+
+            fn describe(t: Task) -> string {
+                match t {
+                    Pending => { return "pending"; }
+                    Done    => { return "done"; }
+                }
+            }
+
+            fn main() {
+                let t: Task = Pending;
+                let _s = describe(t);
+            }
+            "#,
+        );
+        assert!(
+            output.errors.is_empty(),
+            "user-declared Task enum must not raise TaskNotNameable; got: {:#?}",
+            output.errors
+        );
+    }
+
+    /// `Task<T>` without a local declaration must still raise `TaskNotNameable`.
+    ///
+    /// This is the negative companion to `user_task_enum_shadows_reserved_name`:
+    /// the reservation guard must fire when the user has NOT declared a `Task`
+    /// type of their own.
+    #[test]
+    fn bare_task_without_declaration_still_reserved() {
+        let output = check_source(
+            r"
+            fn main() {
+                let _t: Task = 0;
+            }
+            ",
+        );
+        let has_not_nameable = output
+            .errors
+            .iter()
+            .any(|e| e.kind == crate::error::TypeErrorKind::TaskNotNameable);
+        assert!(
+            has_not_nameable,
+            "Task without local declaration must raise TaskNotNameable; got: {:#?}",
+            output.errors
+        );
+    }
+}

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -29318,7 +29318,7 @@ mod every_attribute {
     }
 }
 
-/// Tests for the local-shadows-global reserved-name fix (rc1-reserved-names lane).
+/// Tests for local-shadows-global reserved-name resolution.
 ///
 /// Four invariants:
 ///   1. A user payload variant shadows a builtin unit variant of the same name.

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -2055,7 +2055,7 @@ pub struct FnSig {
     /// builtin variant, `fn_sigs` can only hold one entry for that bare
     /// name.  Marking the builtin entry lets the resolution pass prefer any
     /// locally-declared user variant that shadows it (local-shadows-global
-    /// rule — see rc1-reserved-names lane).
+    /// rule — local-shadows-global).
     ///
     /// Default `false` for every non-builtin-variant signature.
     pub is_builtin_variant: bool,

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -2048,6 +2048,17 @@ pub struct FnSig {
     /// signatures whose receiver was declared by-value, and for free
     /// functions whose first parameter happens to be named `self`.
     pub requires_mutable_receiver: bool,
+    /// `true` iff this `fn_sig` was registered for a builtin enum variant
+    /// (e.g. `LookupError::NotFound`, `SendError::Timeout`).
+    ///
+    /// When a user-declared enum variant shares the same bare name as a
+    /// builtin variant, `fn_sigs` can only hold one entry for that bare
+    /// name.  Marking the builtin entry lets the resolution pass prefer any
+    /// locally-declared user variant that shadows it (local-shadows-global
+    /// rule — see rc1-reserved-names lane).
+    ///
+    /// Default `false` for every non-builtin-variant signature.
+    pub is_builtin_variant: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -2069,6 +2080,7 @@ impl Default for FnSig {
             doc_comment: None,
             extern_symbol: None,
             requires_mutable_receiver: false,
+            is_builtin_variant: false,
         }
     }
 }
@@ -2688,6 +2700,12 @@ pub struct Checker {
     /// across the whole program): `is_stdlib_source` is scoped per-module so
     /// user code in the same compilation unit still receives its own warnings.
     pub(super) is_stdlib_source: bool,
+    /// Set to `true` while `register_stdlib_hew_items` is processing a stdlib
+    /// type declaration. Enum-variant `fn_sig` entries inserted in this state carry
+    /// `is_builtin_variant: true`, enabling the local-shadows-global rule: if a
+    /// user-declared enum in `local_type_defs` has a variant with the same bare
+    /// name, body-checking (`check_identifier`) prefers the user's declaration.
+    pub(super) in_stdlib_registration: bool,
     /// Tracks (span, feature) pairs we've already warned about for WASM limits.
     pub(super) wasm_warning_spans: HashSet<(SpanKey, WasmUnsupportedFeature)>,
     /// Tracks (span, feature) pairs we've already rejected as errors for WASM.
@@ -3017,6 +3035,7 @@ impl Checker {
             wasm_target: false,
             repl_fragment: false,
             is_stdlib_source: false,
+            in_stdlib_registration: false,
             wasm_warning_spans: HashSet::new(),
             wasm_reject_spans: HashSet::new(),
             current_machine_transition: None,

--- a/tests/vertical-slice/accept/imported_shadow_errmod.hew
+++ b/tests/vertical-slice/accept/imported_shadow_errmod.hew
@@ -1,0 +1,11 @@
+// Sibling module imported by imported_shadow_variant_call.hew.
+// Declares a pub enum whose variant name (NotFound) matches a builtin variant
+// name.  The function make_error uses the bare constructor form NotFound(msg),
+// which must resolve to AppErr::NotFound (the user type), not to the builtin
+// LookupError::NotFound unit variant.
+
+pub enum AppErr { NotFound(string) }
+
+pub fn make_error(msg: string) -> AppErr {
+    NotFound(msg)
+}

--- a/tests/vertical-slice/accept/imported_shadow_variant_call.hew
+++ b/tests/vertical-slice/accept/imported_shadow_variant_call.hew
@@ -1,0 +1,13 @@
+// Regression: a bare variant constructor whose name matches a builtin variant
+// must resolve to the user-declared variant in an imported module, not to the
+// builtin.  imported_shadow_errmod.make_error("gone") constructs AppErr using
+// the bare name NotFound; the pipeline must compile and run without errors.
+
+import imported_shadow_errmod;
+
+fn main() {
+    let e = imported_shadow_errmod.make_error("gone");
+    match e {
+        AppErr::NotFound(msg) => println(msg)
+    }
+}

--- a/tests/vertical-slice/accept/reserved_name_shadow_variant_call.hew
+++ b/tests/vertical-slice/accept/reserved_name_shadow_variant_call.hew
@@ -1,0 +1,32 @@
+// Accept: user enum `AppError` with a tuple variant `NotFound(string)` shadows
+// the builtin `LookupError::NotFound` (a unit variant).
+//
+// Before the local-shadows-global fix, the bare call `NotFound("empty key")`
+// would raise an arity-mismatch error because the type checker's `fn_sigs`
+// entry for the bare name "NotFound" referred to the builtin 0-param unit
+// variant instead of the user's 1-param tuple variant.
+//
+// This fixture proves the full pipeline (check + HIR lowering) handles the
+// shadow correctly: the program compiles clean and exits 0.
+enum AppError {
+    NotFound(string);
+    Forbidden;
+    Internal;
+}
+
+fn lookup(key: string) -> AppError {
+    if key == "missing" {
+        NotFound("resource not found")
+    } else {
+        Internal
+    }
+}
+
+fn main() {
+    let e = lookup("missing");
+    match e {
+        NotFound(_msg) => {}
+        Forbidden => {}
+        Internal  => {}
+    }
+}

--- a/tests/vertical-slice/reject/reserved_task_not_nameable.hew
+++ b/tests/vertical-slice/reject/reserved_task_not_nameable.hew
@@ -1,0 +1,9 @@
+// Reject: `Task` used as a type annotation without a local declaration must
+// still raise E_TASK_NOT_NAMEABLE (`TaskNotNameable`).
+//
+// The local-shadows-global fix bypasses the reservation ONLY when the user
+// has declared their own `Task` type.  With no local declaration, the guard
+// must fire as before.
+fn main() {
+    let _t: Task = 0;
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -3079,3 +3079,19 @@ expect_check_fail_contains \
     "${ROOT}/tests/vertical-slice/reject/wire_cbor_vec_owned_compound_rejected.hew" \
     "owned-compound element" \
     "wire_cbor_vec_owned_compound_rejected"
+
+# ---------------------------------------------------------------------------
+# Reserved-name shadowing (rc1-reserved-names lane G).
+# A user-declared enum variant with the same bare name as a builtin variant
+# must shadow the builtin — the program must compile and run without arity
+# errors.
+# ---------------------------------------------------------------------------
+run_accept_expect_status "reserved_name_shadow_variant_call" 0
+
+# Reject: `Task` in a type annotation without a local `Task` declaration must
+# still raise TaskNotNameable — the reservation guard is only bypassed when
+# the user has declared their own type named `Task`.
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/reserved_task_not_nameable.hew" \
+    "compiler-internal type" \
+    "reserved_task_not_nameable"

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -3095,3 +3095,10 @@ expect_check_fail_contains \
     "${ROOT}/tests/vertical-slice/reject/reserved_task_not_nameable.hew" \
     "compiler-internal type" \
     "reserved_task_not_nameable"
+
+# Layout: accept/imported_shadow_variant_call.hew imports
+# accept/imported_shadow_errmod.hew.  A pub enum in a non-root (imported)
+# module that declares NotFound(string) must have its bare constructor
+# registered over the builtin LookupError::NotFound unit variant; the
+# program must compile and run without HIR shape-mismatch diagnostics.
+run_accept_expect_status "imported_shadow_variant_call" 0

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -3081,7 +3081,7 @@ expect_check_fail_contains \
     "wire_cbor_vec_owned_compound_rejected"
 
 # ---------------------------------------------------------------------------
-# Reserved-name shadowing (rc1-reserved-names lane G).
+# Reserved-name shadowing.
 # A user-declared enum variant with the same bare name as a builtin variant
 # must shadow the builtin — the program must compile and run without arity
 # errors.
@@ -3102,3 +3102,4 @@ expect_check_fail_contains \
 # registered over the builtin LookupError::NotFound unit variant; the
 # program must compile and run without HIR shape-mismatch diagnostics.
 run_accept_expect_status "imported_shadow_variant_call" 0
+


### PR DESCRIPTION
## Summary

User-declared enum variants, machine states, machine events, and a user `Task` record type now take priority over same-named built-in enum variants when referenced by bare name. Previously, a user enum declaring a variant named `NotFound`, `Timeout`, `Cancelled`, or any other built-in bare name would silently lose the slot to the stdlib built-in, producing a misleading "takes 0 arguments but 1 were supplied" arity error or an unexpected `LookupError`/`SendError` type on the right-hand side. Declaring a `record Task { … }` triggered an unrelated "Task is a compiler-internal type" rejection even though the user had no intention of naming a task handle.

Resolution priority now follows local-shadows-global: a user-declared enum variant in `local_type_defs` (or `source_type_defs\`) wins the bare-name slot over any built-in variant with the same name, at all three resolution sites (`check_identifier`, `resolve_identifier_variant`, `lookup_variant_constructor`). The correction applies at root module scope and at non-root module scope, for both public and private enums, matching the checker's existing type-registration policy. Qualified forms (`LookupError::NotFound`, `SendError::Timeout`) resolve unconditionally regardless of shadowing.

A new `is_builtin_variant` flag on `FnSig` marks entries inserted during stdlib registration. An `in_stdlib_registration` guard on the checker context scopes the mark so user registrations are never flagged. The HIR bare-counts pre-pass is updated to apply the same priority: user variants are counted first; built-in names that are already claimed by a user variant are excluded from the built-in fill step, so the `machine_ctor_registry` agrees with the checker. The four-place built-in enum invariant (`builtin_enum_specs`, `BUILTIN_ENUM_VARIANT_BARE_NAMES`, `monomorphic_builtin_enums`, `std/builtins.hew`) is preserved; the name list's completeness contract is unchanged.

## Verification

- `make ci-preflight`: all 8 gates green — fmt, clippy, compiler-pipeline (84 HIR tests including 3 sentinel tests), vertical-slice, pkg-import, fuzz-oracle, await_e2e, leak-scan
- `cargo test -p hew-types -- tests::reserved_names`: 6/6 pass — payload-variant-shadows-builtin-unit, unit-variant-shadows-builtin-unit, qualified-builtin-still-resolves, user-vs-user-still-ambiguous, Task-user-type-resolves, Task-annotation-without-local-decl-still-rejected
- `cargo test -p hew-hir -- builtin_bare_names_is_complete_and_exact builtin_enum_specs_matches_monomorphic_catalog synthetic_builtin_sentinel_ids_are_pairwise_distinct`: 3/3 sentinel tests pass — four-place agreement intact
- Vertical-slice fixtures: `reserved_name_shadow_variant_call` (accept), `imported_shadow_variant_call` (accept), `reserved_task_not_nameable` (reject) all match expected outcomes
- Preflight: ready-to-push

## Out of scope

- Programs where a private non-root enum declares a built-in-named variant and that variant is referenced across the module boundary at the MIR layer: the HIR registration fix is complete; a pre-existing MIR-boundary gap for that specific path is tracked in #2195.
- Module-local precision scoping — selecting a bare variant unambiguously from one of several modules that each declare a same-named variant without qualification: this is a separate language-design decision and is not part of this change.