### PR TITLE
chore(lint): scan source for orchestration-framing vocabulary; clean existing instances

### DIFF
--- a/examples/actor/select_suspend_race.hew
+++ b/examples/actor/select_suspend_race.hew
@@ -1,7 +1,7 @@
 // cut-select-waitset — the live non-blocking actor `select{}`.
 //
 // `Coordinator.race_two` runs a `select{}` over two actor-ask arms (plus a
-// safety-net `after` deadline) from INSIDE a handler. Before this lane the
+// safety-net `after` deadline) from INSIDE a handler. Before this change the
 // select called `hew_select_first`, a busy-poll that PINNED the worker until an
 // arm became ready. Now the select registers each arm's readiness observer on a
 // shared await-cancel arbiter, arms the deadline on the global timer wheel, and

--- a/examples/enums/run_mutual_indirect_enum.hew
+++ b/examples/enums/run_mutual_indirect_enum.hew
@@ -4,7 +4,7 @@
 // variant payload.  Both are heap-boxed (pointer-sized fields), so there is
 // no infinite-layout cycle — the pair must compile and produce correct output.
 //
-// This fixture reproduces the pattern from the cross-ecosystem review finding:
+// This fixture reproduces the pattern from the independent review finding:
 //   indirect enum A { ALeaf(i64); AWrap(B); }
 //   indirect enum B { BLeaf(i64); BWrap(A); }
 indirect enum A {

--- a/hew-analysis/src/hover.rs
+++ b/hew-analysis/src/hover.rs
@@ -2197,7 +2197,7 @@ mod tests {
     fn hover_machine_declaration_name_shows_type_def() {
         // Hovering over the machine name at its declaration site should surface
         // the machine's type-def hover (via the lookup_type_def fallback path).
-        // This was already reachable before this lane; the test pins the contract.
+        // This was already reachable before this fix; the test pins the contract.
         let source = concat!(
             "machine Counter {\n",
             "    events {\n",

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -317,7 +317,7 @@ pub fn link_executable(
     // archives. Native packages and stdlib staticlibs reference runtime symbols
     // (`hew_vec_*`, `hew_stream_*`, …) as *undefined* and resolve them against
     // libhew.a at the final link rather than bundling their own copy — bundling
-    // is the duplicate-symbol failure this lane fixes. A single-pass archive
+    // is the duplicate-symbol failure this change fixes. A single-pass archive
     // linker (GNU ld / ld.lld on ELF) only pulls an archive member to satisfy an
     // already-pending undefined symbol, so a consumer archive listed *after* the
     // first libhew.a needs libhew.a repeated here for its backward references to

--- a/hew-cli/tests/generic_monomorphization_e2e.rs
+++ b/hew-cli/tests/generic_monomorphization_e2e.rs
@@ -166,7 +166,7 @@ fn turbofish_generic_call_lowers_and_runs() {
 /// type (`string`) is admitted as the generic owned-record drop spine: the
 /// `Box$$string` layout is discovered, its `string` field gets an in-place
 /// record drop thunk, and the value drops exactly once at scope exit. This pins
-/// the lane's deliverable — the shape that previously failed closed with
+/// the intended deliverable — the shape that previously failed closed with
 /// `UnsupportedUserRecordValueClass` now compiles and runs. The complementary
 /// fail-closed direction (clone-UNSUPPORTED opaque/IO-handle leaves) is pinned
 /// by the `hew-mir` admission unit tests

--- a/hew-cli/tests/json_diagnostics_e2e.rs
+++ b/hew-cli/tests/json_diagnostics_e2e.rs
@@ -44,7 +44,7 @@ fn parse_json_array(output: &std::process::Output) -> Vec<Value> {
         .clone()
 }
 
-/// `--format=json` must be rejected as unrecognized before this lane wired it
+/// `--format=json` must be rejected as unrecognized before this change wired it
 /// in — this test now asserts it is *accepted* (the inverse guard), so a
 /// regression that drops the flag fails loudly.
 #[test]

--- a/hew-cli/tests/machine_transition_watch_e2e.rs
+++ b/hew-cli/tests/machine_transition_watch_e2e.rs
@@ -283,7 +283,7 @@ fn channel_handle_use_after_transfer_refused() {
     );
 }
 
-/// The lane's target composition: a machine-owning service publishes
+/// The target composition: a machine-owning service publishes
 /// record transitions into a channel whose receiver was handed to a
 /// separate observer actor through a message; the observer selects on
 /// transitions with an `after` safety net and reacts to the Faulted edge.

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -1317,7 +1317,7 @@ fn run_destructure_payload_no_double_free() {
 /// helper-locals leaked (the buffer was never freed). This test asserts the
 /// program completes and prints `done` across many iterations; the bounded-RSS
 /// proof (identical peak RSS at 100k vs 2M iterations) is recorded in the
-/// lane's validation evidence.
+/// validation evidence.
 #[test]
 fn run_fn_local_string_is_dropped_bounded_memory() {
     require_codegen();
@@ -1350,7 +1350,7 @@ fn run_fn_local_string_is_dropped_bounded_memory() {
 /// (SIGABRT) on a double-free, so a clean exit with `done` across every
 /// iteration of the hot loop is the behavioural proof that each owner is freed
 /// exactly once (and the bounded-RSS leak proof — flat peak RSS at 40M
-/// iterations — is recorded in the lane's validation evidence). The structural
+/// iterations — is recorded in the validation evidence). The structural
 /// single-drop proofs live in
 /// `hew-mir/tests/owned_string_temp_drop_canary.rs`.
 #[test]
@@ -3144,7 +3144,7 @@ fn owned_record_string_field_by_value_round_trips() {
 
 /// Value-class capstone (G12) — a user record aggregating a `Vec<i64>` field is
 /// constructed (the highest-value shape: rejected at MIR even on construction
-/// before this lane), returned by value, field-read, and dropped at scope exit.
+/// before this fix), returned by value, field-read, and dropped at scope exit.
 #[test]
 fn owned_record_vec_field_by_value_round_trips() {
     require_codegen();
@@ -3412,7 +3412,7 @@ fn run_whole_tuple_of_handles_drops_each_member_once() {
 // W5.021 defect #1 — returned-aggregate member drop spine.
 //
 // The exactly-once ORACLE these tests use is the cheap authoritative one the
-// cross-ecosystem review used: a callee that RETURNS an aggregate of owned
+// independent review used: a callee that RETURNS an aggregate of owned
 // handles must elaborate an EMPTY drop-plan for that return — no
 // `Stream::close` / `Sink::close` — because the caller (who received the
 // byte-copied aggregate) now owns the members. A non-empty plan IS the

--- a/hew-cli/tests/vec_string_index_compare_leak_oracle.rs
+++ b/hew-cli/tests/vec_string_index_compare_leak_oracle.rs
@@ -155,7 +155,7 @@ fn index_mixed_compare_source() -> String {
 }
 
 /// Owned array-repeat: `["hello"; N]` must produce N independent string clones
-/// and release every one at scope exit -- the lane's own leak-clean gate.
+/// and release every one at scope exit -- the leak-clean gate.
 /// Array-repeat CLONES the element, so each slot is an INDEPENDENT buffer even
 /// though every value is "hello"; a leaked index-into-compare retain is
 /// therefore a DISTINCT `leaks` node per slot. Comparing every slot makes the
@@ -353,7 +353,7 @@ fn vec_string_index_mixed_compare_no_constant_leak() {
 }
 
 /// Owned array-repeat `["hello"; 8]` must release every cloned element at
-/// scope exit -- the lane's leak-clean gate. Compared against the same
+/// scope exit -- the leak-clean gate. Compared against the same
 /// no-index control floor.
 #[test]
 fn array_repeat_string_clone_no_leak() {

--- a/hew-codegen-rs/src/abi_class.rs
+++ b/hew-codegen-rs/src/abi_class.rs
@@ -562,7 +562,7 @@ mod tests {
         // `x86_64-pc-windows-gnu` (Win64-GNU / MinGW) uses the Win64 aggregate
         // ABI (indirect for size ∉ {1,2,4,8}), NOT SysV. It is an unsupported
         // target (Hew targets Windows via MSVC), so it must fail closed — NOT
-        // be admitted to the SysV register-pair arm. This is the cross-eco ABI
+        // be admitted to the SysV register-pair arm. This is the multi-platform ABI
         // correctness fix: an x86_64 non-MSVC Windows triple is no longer
         // misclassified as SysV-like.
         let ctx = Context::create();

--- a/hew-codegen-rs/src/layout.rs
+++ b/hew-codegen-rs/src/layout.rs
@@ -597,7 +597,7 @@ pub(crate) fn build_tagged_union_layout<'ctx>(
         // `{e:?}`) to render the inkwell `LLVMString` as the LLVM diagnostic
         // text without quoting it. Migrating to `LlvmResultExt::llvm_ctx` would
         // silently switch to Debug projection (`{e:?}`) and change the
-        // user-visible error text. The lane plan §B4 deliberately leaves this
+        // user-visible error text. §B4 of the design deliberately leaves this
         // one Display call un-migrated; if a second Display site ever appears,
         // introduce a sibling `.llvm_ctx_display` helper.
         .map_err(|e| CodegenError::Llvm(format!("custom_width_int_type({element_bits}): {e}")))?;

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -1,7 +1,7 @@
 //! Inkwell direct LLVM IR emitter for the out-of-process LLVM backend.
 //!
 //! Adopted from the §10 backend probe (Track C) at HEAD `e6c83faa` on
-//! `experiment/c1-backend-shootout-2026-05-13`. Both cross-ecosystem reviewers
+//! `experiment/c1-backend-shootout-2026-05-13`. Both independent reviewers
 //! signed accept on the probe; this module is the in-tree evolution of
 //! `experiments/c1-backend-shootout/src/bin/probe_c.rs` against the real MIR
 //! shapes in `hew-mir`.
@@ -242,7 +242,7 @@ pub(crate) type CodegenResult<T> = Result<T, CodegenError>;
 // codegen arms have exactly one obvious way to wrap an LLVM error, and
 // `llvm_err!` is the matching macro for direct (non-`?`) constructions.
 //
-// **Crate-private by design** (see lane plan §Design and §Risks #4):
+// **Crate-private by design** (see §Design and §Risks #4):
 //   - No `#[macro_export]`.
 //   - No public re-export from `lib.rs`.
 //   - Helpers only ever construct `CodegenError::Llvm` — they cannot, and
@@ -1372,7 +1372,7 @@ pub(crate) struct FnCtx<'a, 'ctx> {
     /// WHY this is a codegen special-case: it is the implicit safe floor for
     /// fire-and-forget actor message delivery. Without it, `main` returning
     /// races the OS killing scheduler worker threads before they drain.
-    /// WHEN obsolete: when the companion lane lands the explicit `drain {}` /
+    /// WHEN obsolete: when the companion change lands the explicit `drain {}` /
     /// `join {}` language surface and MIR lower emits `Terminator::Drain` at
     /// program exit; this flag and its emit block become dead and can be
     /// removed then.
@@ -5691,7 +5691,7 @@ fn emit_native_actor_metadata_registration<'ctx>(
 // ─── W2.002 Stage 2: state_clone / state_drop registration helpers ──────────
 //
 // Stage 2 emits CALLS to per-actor `__hew_state_clone_<Actor>` /
-// `__hew_state_drop_<Actor>` C-ABI fns. Stage 3 of this lane (deferred)
+// `__hew_state_drop_<Actor>` C-ABI fns. Stage 3 (deferred)
 // synthesises the function BODIES. To keep Stage 2 link-correct on its
 // own, the helpers below `get_function`-or-declare-extern the per-actor
 // symbol; if Stage 3 does not land the linker fails with a clear
@@ -6449,7 +6449,7 @@ fn emit_supervisor_child_spec_and_register<'ctx>(
     // wrapper and take its address; `None` → null (the actor has no lifecycle
     // hook, so the runtime fires nothing). Fail-closed when the symbol is
     // present but the wrapper cannot be emitted — a null here would silently
-    // skip init/on_start under supervision (the exact bug this lane fixes).
+    // skip init/on_start under supervision (the exact bug this change fixes).
     let lifecycle_ptr: BasicValueEnum<'ctx> = match &child.lifecycle_symbol {
         Some(_) => {
             let wrapper = emit_actor_lifecycle_wrapper(ctx, llvm_mod, &child.actor_name)?;
@@ -6707,7 +6707,7 @@ fn emit_supervisor_child_spec_and_register<'ctx>(
     // ── W2.002 Stage 2: register state_drop + state_clone fn pointers
     // against this child slot. Mirrors `__hew_actor_dispatch_<actor>`
     // resolution above: `child.actor_name` → per-actor synthesised symbol
-    // (Stage 3 of this lane defines bodies; Stage 2 declares externs so
+    // (Stage 3 defines bodies; Stage 2 declares externs so
     // a missing Stage 3 fails clearly at link time, not silently).
     //
     // The matching `ActorLayout` carries the symbol pair on
@@ -6803,7 +6803,7 @@ fn emit_supervisor_child_spec_and_register<'ctx>(
 // - **Actor shutdown**: the wrapper that the actor holds (from direct-spawn
 //   byte-copy or from `hew_actor_spawn_opts_adopt` of a clone result) is
 //   owned by the actor. On shutdown the runtime invokes the registered
-//   `state_drop_fn` — this lane synthesises that body. Single-fire
+//   `state_drop_fn` — this impl synthesises that body. Single-fire
 //   protection via the runtime's `terminate_called` guard at
 //   `hew-runtime/src/actor.rs:786-791`; `state_drop_fn` is idempotent
 //   against null and is structurally callable from any of the three
@@ -19585,7 +19585,7 @@ fn lower_hashmap_index_trap_call(
 /// on a hit, writes a freshly retained/cloned owner into the `Some` payload
 /// slot, so the `Option` payload is never a borrow into the live buffer
 /// (`by-value-heap-params-are-borrows` P0 — the headline drop-safety invariant
-/// of this lane). On OOB the runtime returns `false` and we build `None`.
+/// of this change). On OOB the runtime returns `false` and we build `None`.
 fn lower_vec_get_clone_call(
     fn_ctx: &FnCtx<'_, '_>,
     args: &[Place],
@@ -24668,7 +24668,7 @@ fn lower_terminator<'ctx>(
             // Scoped to native actor-using programs only (`emit_drain_epilogue`
             // is false for non-actor programs and for WASM targets).
             // WHY this is a codegen special-case and not a MIR Terminator: this
-            // is the implicit safe floor; the companion lane adds the explicit
+            // is the implicit safe floor; the companion change adds the explicit
             // `drain`/`join{}` language surface and emits a MIR-level
             // `Terminator::Drain`, at which point this codegen arm becomes dead.
             if fn_ctx.emit_drain_epilogue {
@@ -26703,7 +26703,7 @@ fn lower_terminator<'ctx>(
 ///   `binding` (the per-arm reply slot for `ActorAsk` arms; `None`
 ///   for `AfterTimer`).
 /// - At most one `AfterTimer` arm is present (HIR enforces).
-/// - `StreamNext` / `TaskAwait` arms are not in scope for this lane
+/// - `StreamNext` / `TaskAwait` arms are not in scope for this change
 ///   and remain fail-closed below (defence-in-depth — the MIR
 ///   producer rejects them before this codegen runs).
 ///
@@ -33473,7 +33473,7 @@ fn emit_dyn_trait_drop_in_place_fns<'ctx>(
 ///   thunk_0_fn_ptr, ..., thunk_(N-1)_fn_ptr }`.
 ///
 /// **Layout (matches `hew-runtime/src/trait_object.rs::HewVtable` and
-/// the lane plan §1.5 vtable struct prefix entry).**
+/// §1.5 of the design notes (vtable struct prefix entry)).**
 /// - Slot 0: pointer to the `drop_in_place` fn named by
 ///   [`hew_mir::mangle_dyn_drop_in_place_symbol`] and synthesised by
 ///   `emit_dyn_trait_drop_in_place_fns` (must run first).

--- a/hew-codegen-rs/src/thunks.rs
+++ b/hew-codegen-rs/src/thunks.rs
@@ -2361,7 +2361,7 @@ pub(crate) fn emit_actor_dispatch_trampoline<'ctx>(
             // `handle` is suspended at that point. An immediate `hew_cont_resume`
             // would drive the body PAST the suspend into its reply-bind block
             // before the reply has arrived, re-blocking the worker on
-            // `hew_reply_wait` — the exact OS-thread block this lane removes
+            // `hew_reply_wait` — the exact OS-thread block this change removes
             // (R1). Instead POLL the just-parked handle: a Pending poll means the
             // body is waiting on a readiness source (the ask reply), so the
             // trampoline returns the handle and the scheduler parks it; the real

--- a/hew-codegen-rs/tests/dwarf_emitted_object.rs
+++ b/hew-codegen-rs/tests/dwarf_emitted_object.rs
@@ -30,7 +30,7 @@ use hew_types::Checker;
 
 /// A fixture exercising shadowing, an enum with a struct payload, and a record
 /// with mixed-width fields (for the member bit-offset check). Mirrors the
-/// cross-eco probe that surfaced the three blocking defects.
+/// independent review probe that surfaced the three blocking defects.
 const FIXTURE: &str = "\
 record Point { x: i64, y: i64 }
 

--- a/hew-codegen-rs/tests/resolved_impl_call_hashmap_layout_descriptor_materialisation.rs
+++ b/hew-codegen-rs/tests/resolved_impl_call_hashmap_layout_descriptor_materialisation.rs
@@ -58,7 +58,7 @@
 //!   `hew_hashmap_*_layout` / `hew_hashset_*_layout` strings rather
 //!   than reconstructing them.
 //! - `parity-or-tracked-gap` (P0): WASM parity is covered by the
-//!   HashMap/HashSet wasmtime value oracles in `eval_e2e.rs`; this lane
+//!   HashMap/HashSet wasmtime value oracles in `eval_e2e.rs`; this change
 //!   changes nothing in direct method-target resolution.
 
 use std::collections::BTreeSet;

--- a/hew-codegen-rs/tests/runtime_abi_fail_closed.rs
+++ b/hew-codegen-rs/tests/runtime_abi_fail_closed.rs
@@ -182,7 +182,7 @@ fn call_runtime_abi_fails_closed_with_symbol_in_message() {
 /// symbol) now has a real codegen lowering arm — the M2 lambda-actor
 /// lane wires `release` (and `send`/`ask`) as `CallRuntimeAbi`
 /// targets, joining `hew_duplex_send` on the happy-path codegen
-/// surface. This regression pins the lane's invariant:
+/// surface. This regression pins the invariant:
 /// `CallRuntimeAbi("hew_lambda_actor_release", [LambdaActorHandle(0)], None)`
 /// must reach the codegen consumer successfully (`Ok(_)`). The
 /// producer/codegen parity is held by `fn_type_for_symbol` declaring

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -5024,7 +5024,7 @@ impl LowerCtx {
     /// handle-into-intrinsic calls. The narrower builtin-handle-moved-into-a-
     /// user-function case keeps the pre-existing borrowing `Read` lowering
     /// (fail-closed: a potential leak, never a new double-free) and is out of
-    /// this lane's scope.
+    /// this change's scope.
     ///
     /// ## Why this gates the call-argument intent
     ///
@@ -8622,7 +8622,7 @@ impl LowerCtx {
         // consumes the resulting `variants` vec to populate `EnumLayout`
         // including per-variant `field_tys`. The index assigned here matches
         // the order the ctor pre-pass walks `TypeBodyItem::Variant` entries,
-        // so the HIR registry key and MIR layout index agree (see lane plan
+        // so the HIR registry key and MIR layout index agree (see design notes
         // D2 — variant-index ordering is HIR-pre-pass authoritative).
         let mut variants: Vec<HirVariant> = Vec::new();
         if decl.kind == TypeDeclKind::Enum {
@@ -20906,7 +20906,7 @@ impl LowerCtx {
 
     /// Lower a surface `match` expression to `HirExprKind::Match`.
     ///
-    /// **Substrate scope (v0.5 match-expression slice)**: this lane lowers
+    /// **Substrate scope (v0.5 match-expression slice)**: this change lowers
     /// variant constructor arms (unit, tuple-payload, and struct-payload with
     /// plain binding / wildcard subpatterns), wildcard arms (`_`), plain
     /// binding arms (`x => ...`), literal arms (`0`, `"hello"`), or-pattern
@@ -23721,7 +23721,7 @@ fn check_wasm_blocking_recv_gate(ctx: &mut LowerCtx, program: &Program) {
             //   3. each transition's `guard` expression (if any)
             //   4. each transition's `body` expression (action)
             // Partial coverage (e.g. transitions but not states) is a BLOCK in
-            // cross-eco review.
+            // the independent review.
             Item::Machine(machine) => {
                 for state in &machine.states {
                     if let Some(entry) = &state.entry {
@@ -24080,7 +24080,7 @@ fn check_task_gates(ctx: &mut LowerCtx, program: &Program) {
             //   3. each transition's `guard` expression (if any)
             //   4. each transition's `body` expression (action)
             // Partial coverage (e.g. transitions but not states) is a BLOCK in
-            // cross-eco review.
+            // the independent review.
             Item::Machine(machine) => {
                 for state in &machine.states {
                     if let Some(entry) = &state.entry {
@@ -24214,7 +24214,7 @@ fn check_supervisor_spawn_gate(ctx: &mut LowerCtx, program: &Program) {
     // (b) reject `spawn Foo(args)` inside an imported module that happens
     // to share a name with a root-declared supervisor even though the
     // module's `Foo` is something else entirely (false-positive). Both
-    // failure modes are documented in the rev2 cross-eco finding.
+    // failure modes are documented in the rev2 independent review finding.
     if let Some(mg) = &program.module_graph {
         for (mod_id, module) in &mg.modules {
             if *mod_id == mg.root {
@@ -25992,7 +25992,7 @@ fn scan_item_for_supervisor_spawn(
         //   3. each transition's `guard` expression (if any)
         //   4. each transition's `body` expression (action)
         // Partial coverage (e.g. transitions but not states) is a BLOCK in
-        // cross-eco review (6th instance documented this session).
+        // the independent review.
         Item::Machine(machine) => {
             for state in &machine.states {
                 if let Some(entry) = &state.entry {
@@ -26522,7 +26522,7 @@ fn scan_expr_for_supervisor_spawn(
             // module-qualified path, which dispatches through the
             // `Expr::FieldAccess` arm below. Discharges A237 / LESSONS
             // `string-identifier-fragility-vs-structured-resolution` and
-            // the rev2 cross-eco finding on module-context threading.
+            // the rev2 independent review finding on module-context threading.
             let resolved: Option<&str> = match &target.0 {
                 Expr::Identifier(name) => {
                     let set = match current_module {

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -896,7 +896,7 @@ pub struct HirVariant {
 ///
 /// MIR's `EnumLayout` builder flattens both `Tuple` and `Struct` into a single
 /// positional `field_tys` list — variant field NAMES are MIR-irrelevant (see
-/// D1 in the lane plan). Names are retained here for diagnostics and for the
+/// D1 in the design notes). Names are retained here for diagnostics and for the
 /// `Expr::StructInit` lowering path which validates source-declared field
 /// names against the variant's declared field set before emitting payload
 /// store instructions.

--- a/hew-hir/src/stdlib_catalog.rs
+++ b/hew-hir/src/stdlib_catalog.rs
@@ -2295,7 +2295,7 @@ pub const CATALOG: &[BuiltinEntry] = &[
     // ── W5.005 (F1b): memory-intrinsic floor (`mem.*`) ────────────────────
     //
     // The general-purpose heap allocator + typed-pointer primitives that back
-    // the (later-wave) generic containers.  These are compiler-internal-only
+    // the (upcoming) generic containers.  These are compiler-internal-only
     // (A605): declarable/callable ONLY from the `std.mem` floor module (gated
     // by `INTRINSIC_FLOOR_MODULES`), never from user surface.
     //

--- a/hew-hir/tests/loop_break_continue_lower.rs
+++ b/hew-hir/tests/loop_break_continue_lower.rs
@@ -1,7 +1,7 @@
 //! HIR-shape regression for `break` / `continue` / bare `loop {}` lowering
 //! (Stage 1 of the break/continue completeness lane).
 //!
-//! Before this lane, `Stmt::Break` / `Stmt::Continue` / `Stmt::Loop` fell
+//! Before this change, `Stmt::Break` / `Stmt::Continue` / `Stmt::Loop` fell
 //! through the `lower_stmt` `_` catchall to `unsupported(..,"slice-2")`,
 //! producing `HirExprKind::Unsupported` plus a `NotYetImplemented`
 //! diagnostic. These tests pin that both unlabeled and labeled forms lower to
@@ -37,7 +37,7 @@ fn typecheck_and_lower(source: &str) -> hew_hir::LowerOutput {
 }
 
 /// Walk a block (statements + tail) and return `true` if any contained
-/// `HirExprKind` satisfies `pred`. Recurses into the loop bodies this lane
+/// `HirExprKind` satisfies `pred`. Recurses into the loop bodies this change
 /// introduces so nested `break`/`continue` are reachable.
 fn block_has_kind<F: Fn(&HirExprKind) -> bool + Copy>(block: &HirBlock, pred: F) -> bool {
     for stmt in &block.statements {

--- a/hew-hir/tests/mem_intrinsic_floor_lower.rs
+++ b/hew-hir/tests/mem_intrinsic_floor_lower.rs
@@ -1,6 +1,6 @@
 //! W5.005 / F1b — HIR lowering of the `#[intrinsic("mem.*")]` memory floor.
 //!
-//! Regression guard for D343: before this lane, `#[intrinsic]` functions
+//! Regression guard for D343: before this fix, `#[intrinsic]` functions
 //! declared in an *imported* floor module (`std.mem`) reached HIR lowering via
 //! the module-graph path (`lower_imported_fn_with_name`), which never consulted
 //! `intrinsic_declarations`. The body-skip only fired on the *root-item* path,

--- a/hew-lsp/src/server/analysis.rs
+++ b/hew-lsp/src/server/analysis.rs
@@ -2419,7 +2419,7 @@ mod tests {
     /// `<pkg_root>/template/template.hew` for `import hew::template`.  The LSP
     /// must do the same; if it only generates the full-path candidate
     /// `<pkg_root>/hew/template/template.hew` the import silently stays
-    /// unresolved while `hew check` accepts it — the lying-LSP class this lane
+    /// unresolved while `hew check` accepts it — the lying-LSP class this change
     /// exists to eliminate.
     ///
     /// Layout mirrors how `hew package add hew::template` would install into a

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -6713,7 +6713,7 @@ impl Builder {
     /// would double-free the buffer at the move-out site (a use-after-free
     /// at every read of the move destination that happens after the break).
     /// The scan refuses such drops — leak-not-double-free, matching the
-    /// body-end drop's discipline. (Before this lane the recv `Some(item)`
+    /// body-end drop's discipline. (Before this fix the recv `Some(item)`
     /// path never registered an entry here so the conflict was masked;
     /// extending Phase F to recv-call scrutinees exposes the case so the
     /// escape filter is now load-bearing.)
@@ -12480,7 +12480,7 @@ impl Builder {
     /// body's per-iteration drop — identical ownership shape to a generator
     /// yield. Without that release every received frame leaks one heap block
     /// per iteration (every `Stream<string>` recv loop, every `Receiver<T>::recv`
-    /// drain), which is the leak this lane closes.
+    /// drain), which is the leak this fix closes.
     ///
     /// The detector matches structurally on the HIR `Call` callee `BindingRef`
     /// name — the same identity codegen uses to intercept the call and
@@ -14814,7 +14814,7 @@ impl Builder {
             // per-iteration drop — identical ownership shape to a generator
             // yield (`hew_gen_next` returns the same kind of fresh owned value).
             // Without this drop every received frame leaks a heap block per
-            // iteration: the leak this lane closes for `for await item in rx` /
+            // iteration: the leak this fix closes for `for await item in rx` /
             // `match channel.recv(...) { ... }` / `match stream.recv() { ... }`.
             let arm_is_recv_some = recv_next_scrutinee && arm_is_some;
             let mut overwritten_bindings = Vec::with_capacity(arm.bindings.len());
@@ -15285,7 +15285,7 @@ impl Builder {
         // heap-owning bindings declared in `body.scope`. Without this, an
         // `Option<T>` (or other heap-owning) let-binding bound inside the body
         // gets overwritten on the next iteration with no preceding drop — the
-        // memory leak this lane closes (Stream<T>/Receiver<T> recv loops).
+        // memory leak this fix closes (Stream<T>/Receiver<T> recv loops).
         // The scope captured is the body's, not any nested block's: nested
         // block-scope bindings already self-drop when their block closes via
         // the existing scope-exit pass.
@@ -18636,7 +18636,7 @@ impl Builder {
         // Suspendable-caller flip: in an execution-context caller, the four
         // builtin recv/send/sleep families SUSPEND on the coro substrate instead
         // of blocking the worker. Factored into one helper so the per-family
-        // shapes sit together (the suspend-flip surface this lane collapses onto
+        // shapes sit together (the suspend-flip surface this change collapses onto
         // the SuspendKind side-table). `Break(dest)` when a flip fired.
         if let std::ops::ControlFlow::Break(dest) = self.try_lower_suspending_builtin_flip(
             callee_symbol,
@@ -19718,7 +19718,7 @@ impl Builder {
         //     statement context discards the status (`dest: None`,
         //     fire-and-forget delivery).
         //   - ask-shaped `Result<R, AskError>` (a non-unit `Duplex` reply) or
-        //     any other type -> a separate lowering this lane does not own. Fail
+        //     any other type -> a separate lowering this change does not own. Fail
         //     closed with a stable NYI diagnostic BEFORE emitting any send
         //     instruction (`no-fail-open-fallback-after-authority`), rather than
         //     bind nothing (the misleading `UnresolvedPlace`, Evidence #1),
@@ -20167,7 +20167,7 @@ impl Builder {
             //   on the not-live path. The integer/BitCopy spine (every supervisor
             //   example + the dogfood case) is unaffected.
             // WHY now: payload-drop on the recover edge needs drop-elaboration
-            //   threaded into recover_bb; that is a larger change than this lane,
+            //   threaded into recover_bb; that is a larger change than this fix,
             //   and the pre-F-04 behaviour leaked-by-aborting (the trap killed the
             //   whole process), so this is not a regression for the common case.
             // WHEN obsolete: when a heap-payload tell to a supervised child is a
@@ -24405,7 +24405,7 @@ fn elaborate(
     // scan (the source/operand classifier is a compiler-exhaustive match, so
     // a new `Instr`/`Terminator` variant cannot be added without classifying
     // its operands). Worst case the feature drops FEWER strings (leaks, as
-    // before this lane); it can never double-free.
+    // before this fix); it can never double-free.
     //
     // Consume facts narrow the allow-set further: a binding `Consumed` or
     // `MaybeConsumed` at any block exit is removed, because `enumerate_exits`
@@ -27050,7 +27050,7 @@ fn cow_owned_string_terminator_escapes(
 ///
 /// Fail-closed throughout: an unrecognised producer (rule 2), an unrecognised
 /// use (rule 4), or any taint (rule 3) leaves the binding out of the set — it
-/// leaks, exactly as before this lane, and can never double-free.
+/// leaks, exactly as before this fix, and can never double-free.
 ///
 /// LESSONS: boundary-fail-closed (P0), cleanup-all-exits, raii-null-after-move.
 #[must_use]
@@ -27188,7 +27188,7 @@ fn block_by_id(blocks: &[BasicBlock], id: u32) -> Option<&BasicBlock> {
 /// results that flow straight into a borrowing use (or are discarded) WITHOUT a
 /// `let` binding, so the binding-scoped scope-exit derivation never sees them.
 ///
-/// Shapes this releases exactly once (each leaked before this lane):
+/// Shapes this releases exactly once (each leaked before this fix):
 ///
 /// ```text
 ///   (a + b).len()           // concat temp, borrowed by hew_string_length
@@ -27232,7 +27232,7 @@ fn block_by_id(blocks: &[BasicBlock], id: u32) -> Option<&BasicBlock> {
 ///        preceding block (require `U` single-predecessor) → drop at the front
 ///        of `T` (require `T` single-predecessor).
 ///
-/// Any other CFG shape fails closed (the temp leaks, as before this lane). The
+/// Any other CFG shape fails closed (the temp leaks, as before this fix). The
 /// return is a list of `(block_id, insert_index, place, ty)` inline-drop
 /// insertions for the caller to splice in. Pure over `blocks` (no mutation) so
 /// it is unit-testable.
@@ -31027,7 +31027,7 @@ fn ty_is_closure_pair(ty: &ResolvedTy) -> bool {
 /// - `RecordInit` / aggregate ingress — a nested closure capturing the pair
 ///   or a record/Vec storing it owns the env through the aggregate.
 ///
-/// Excluded bindings leak (as before this lane); they never double-free.
+/// Excluded bindings leak (as before this fix); they never double-free.
 fn derive_closure_pair_drop_allowed(
     blocks: &[BasicBlock],
     suspend_kinds: &HashMap<u32, SuspendKind>,
@@ -31374,7 +31374,7 @@ fn build_lifo_drops(
         // `ValueClass::CowValue`, but `cow_value_leaf_drop_symbol` only handles
         // the leaf `string` case, so a local map/set would otherwise fall through
         // to the no-op `CowValue` arm and LEAK its layout-keyed backing storage
-        // on every normal-return AND cancel/cooperate path (the bug this lane
+        // on every normal-return AND cancel/cooperate path (the bug this fix
         // fixes). Intercept BEFORE the value-class match (mirroring the owned-Vec
         // arm above) and emit the `DropKind::CowHeap` runtime release
         // (`hew_hashmap_free_layout` / `hew_hashset_free_layout`, selected by the
@@ -31384,7 +31384,7 @@ fn build_lifo_drops(
         // actor's initial state (`spawn A(f: m)`) or otherwise escaped is
         // excluded by the escape-scan, so the actor's synthesised `state_drop_fn`
         // remains the sole owner of that free — no double-drop. A binding the
-        // prover did not clear leaks (as before this lane); it never double-frees.
+        // prover did not clear leaks (as before this fix); it never double-frees.
         // The local guard here only confirms the binding's type is a collection
         // handle so the `*_free_layout` ABI is correct; route the kind through
         // `drop_kind_for` (the single source of truth the drop-plan validator
@@ -31545,7 +31545,7 @@ fn build_lifo_drops(
         // this one owner left at scope exit. The drop protocol null-checks
         // the env pointer, so named-fn pairs and capture-free escaping
         // closures are no-ops. A binding the prover did not clear leaks (as
-        // before this lane); it never double-frees.
+        // before this fix); it never double-frees.
         // LESSONS: cleanup-all-exits, raii-null-after-move,
         // boundary-fail-closed, ffi-ownership-contracts.
         if closure_pair_drop_allowed.contains(binding) && ty_is_closure_pair(ty) {
@@ -31695,7 +31695,7 @@ fn build_lifo_drops(
             // never aliased out (never read as a source operand) and is not a
             // projection alias of a still-live aggregate, then removing any
             // binding consumed/maybe-consumed on a path. A binding absent from
-            // the allow-set leaks (as before this lane); it never double-frees.
+            // the allow-set leaks (as before this fix); it never double-frees.
             // The default for any binding the prover did not positively clear
             // is exclusion, so an un-enumerated future alias producer cannot
             // re-open the double-free. Aggregate/container `CowValue` self-drops
@@ -31730,7 +31730,7 @@ fn build_lifo_drops(
 /// whose scope-exit drop is deferred to a later slice.
 ///
 /// Slice 2 is intentionally restricted to the single `string` leaf — the
-/// accumulating helper-local leak this lane targets. Aggregate and container
+/// accumulating helper-local leak this fix targets. Aggregate and container
 /// `CowValue` leaves (`Vec`, `HashMap`, `HashSet`, tuples, arrays) own nested
 /// heap that, without retain-on-share at element-ingress sites, cannot be
 /// released here without risking a double-free against the container's own

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -3023,7 +3023,7 @@ pub enum Place {
     /// in the enum's `unit_variants` / `EnumLayout.variants`). `field_idx`
     /// is the zero-based field ordinal within that variant's payload.
     ///
-    /// This lane's substrate slice introduces the primitive but does not
+    /// This substrate slice introduces the primitive but does not
     /// emit loads through it — only unit-variant matching is supported
     /// here. Payload-bearing variant destructuring (e.g. `Some(x)`,
     /// `Ok(v)`) lands as a follow-on consumer of this primitive (Option<T>
@@ -5123,7 +5123,7 @@ pub enum MirDiagnosticKind {
     /// anonymous record whose bytes may carry heap pointers — bytes the
     /// cross-node codec is not seeded to serialize (the codec carries
     /// single-param message types only; packed-args seeding is the
-    /// cross-node payload serialization lane's positive path). A
+    /// cross-node payload serialization's positive path). A
     /// single-value remote payload delivered to a handler that unpacks
     /// the full packed record would read out of bounds on the receiving
     /// node, so the boundary fails closed at compile time instead.

--- a/hew-mir/src/runtime_symbols.rs
+++ b/hew-mir/src/runtime_symbols.rs
@@ -186,7 +186,7 @@ const MIR_EMITTER_RUNTIME_SYMBOLS: &[&str] = &[
     // module doc in trait_object.rs for the convention. Companion
     // dispatch diagnostic `hew_vtable_dispatch_panic_on_oob` lives
     // further down this list under its own `hew_v*` block; the
-    // surfaces share a lane plan (W3.031 §1.7.3) but the allowlist
+    // surfaces share a design (W3.031 §1.7.3) but the allowlist
     // is sorted lex for binary-search correctness.
     "hew_dyn_box_alloc",
     "hew_dyn_box_free",
@@ -503,7 +503,7 @@ const MIR_EMITTER_RUNTIME_SYMBOLS: &[&str] = &[
     // (`hew-runtime/src/trait_object.rs`). Diagnostic trap codegen
     // wires on the unreachable arm of a vtable-slot match (LESSONS
     // P0 `exhaustive-coverage`: no wildcard fallthrough in dispatch).
-    // Also the wire target for a null-vtable fail-closed. Lane plan
+    // Also the wire target for a null-vtable fail-closed. Design notes
     // `runtime-trait-object-abi.md` design D-4 rejects routing the
     // *actual* dispatch through a runtime helper — codegen emits
     // GEP+load+call inline — so this is the only trait-object symbol

--- a/hew-mir/src/state_clone.rs
+++ b/hew-mir/src/state_clone.rs
@@ -20,7 +20,7 @@
 //! classifier identifies which fields need a per-field clone helper and
 //! which fields are bit-copy-correct already.
 //!
-//! ## Builtin-vs-user-record name shadowing (cross-eco review fix)
+//! ## Builtin-vs-user-record name shadowing (independent review fix)
 //!
 //! `ResolvedTy::Named { name, args }` does not carry the checker's
 //! builtin-vs-user discriminator across the resolved-ty boundary. A
@@ -1071,7 +1071,7 @@ fn classify_named(
     // generator-binding release symbol), no dup helper, clone/restart fails
     // closed. Without this arm a tuple/record/enum carrying a generator handle
     // falls through to `classify_user_record` and fails as `MissingRecordLayout`,
-    // and (before this lane) the composite was mis-classified non-heap-owning so
+    // and (before this fix) the composite was mis-classified non-heap-owning so
     // its member-drop never ran — leaking the context + OS thread. A generator's
     // generic args (`i64`, `()`) never make the handle itself non-heap-owning, so
     // classification is by name alone, independent of `args`.

--- a/hew-mir/tests/hashmap_hashset_local_drop.rs
+++ b/hew-mir/tests/hashmap_hashset_local_drop.rs
@@ -1,6 +1,6 @@
 //! Local `HashMap` / `HashSet` scope-exit drop elaboration — invariant pinning.
 //!
-//! Before this lane a local `let m: HashMap<K, V> = HashMap::new();` handle was
+//! Before this fix a local `let m: HashMap<K, V> = HashMap::new();` handle was
 //! `ValueClass::CowValue` but had no dedicated drop class, so it fell through to
 //! the no-op `CowValue` arm and LEAKED its layout-keyed backing storage on every
 //! normal-return AND cancel/cooperate path. This suite pins the fix:
@@ -23,7 +23,7 @@
 //!
 //! The negative controls are load-bearing: per `drop-allowset-from-value-flow`
 //! an allow-set test without a paired exclusion would pass even if the gate
-//! admitted everything (the double-free this lane must never introduce).
+//! admitted everything (the double-free this fix must never introduce).
 
 use hew_mir::{DropKind, ElabDrop, ExitPath, IrPipeline};
 use hew_types::module_registry::ModuleRegistry;

--- a/hew-mir/tests/producer_method_send.rs
+++ b/hew-mir/tests/producer_method_send.rs
@@ -14,7 +14,7 @@
 //! The structural tests use the tell-shaped `Duplex<i64, ()>` because only the
 //! tell-shaped `.send` (yielding `Result<(), SendError>`) lowers to a runtime
 //! call.  An ask-shaped `.send` (a non-unit `Duplex` reply yielding `Result<R,
-//! AskError>`) is a separate lowering this lane does not own; it fails closed
+//! AskError>`) is a separate lowering this change does not own; it fails closed
 //! with a stable `NotYetImplemented` diagnostic in BOTH statement and value
 //! context (see `*_ask_shaped_send_fails_closed`), never lowering as a
 //! fire-and-forget tell that would silently drop the reply.

--- a/hew-mir/tests/state_clone_classification.rs
+++ b/hew-mir/tests/state_clone_classification.rs
@@ -208,7 +208,7 @@ fn chatroom_shape_classifies_vec_of_string_and_vec_of_actor_ref() {
 
 #[test]
 fn user_type_named_connection_classifies_as_user_record_not_iohandle() {
-    // Cross-eco review regression: `ResolvedTy::Named { name }` does
+    // Independent review regression: `ResolvedTy::Named { name }` does
     // not preserve the checker's builtin discriminator. A user-declared
     // `type Connection { ... }` and the runtime builtin `net.Connection`
     // both reach the classifier as `Named { name: "Connection", args:

--- a/hew-mir/tests/vertical.rs
+++ b/hew-mir/tests/vertical.rs
@@ -1368,7 +1368,7 @@ fn registered_fieldless_user_type_still_requires_codegen_readiness() {
 /// the mangled-key thunk (`Wrapper$$string`). Migrated forward from
 /// `non_bitcopy_user_record_instantiation_reports_precise_valueclass_diagnostic`,
 /// which pinned the now-reversed reject behaviour — the generic-instantiation
-/// owned-aggregate capability is the residual fail-closed witness this lane
+/// owned-aggregate capability is the residual fail-closed witness this fix
 /// closes. The W3.029 gate is retained for unregistered/unclassifiable shapes
 /// (see `generic_record_owned_aggregate_admission` unit tests in lower.rs).
 #[test]

--- a/hew-parser/tests/struct_literal.rs
+++ b/hew-parser/tests/struct_literal.rs
@@ -124,7 +124,7 @@ fn first_stmt(
 //
 // The empty-block fix added a `no_struct_literal` restriction in `if`/`while`
 // condition and `match` scrutinee position. These tests cover the three edges
-// the cross-eco review found: module-qualified enum-variant struct-init in a
+// the independent review found: module-qualified enum-variant struct-init in a
 // condition, a parenthesised struct literal directly in condition/scrutinee
 // position (formatter must keep the parens), and a block expression in a
 // condition (the restriction must not leak into the block body).

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -6654,7 +6654,7 @@ mod tests {
     /// A non-reactor wake — in-flight link/monitor exit/down propagation (or a
     /// direct actor-to-actor send) for a crashing peer — must never enqueue an
     /// actor that `hew_actor_free` is about to untrack + free. This is the defect
-    /// the cross-ecosystem review reproduced and BLOCKED on: the reactor fix
+    /// the independent review reproduced and BLOCKED on: the reactor fix
     /// closed only the reactor wake; a non-reactor waker could still
     /// `CAS Idle->Runnable` + `sched_enqueue` in the window between free's
     /// post-detach `Idle` observation and `untrack_actor`, after which free freed

--- a/hew-runtime/src/runtime_handle.rs
+++ b/hew-runtime/src/runtime_handle.rs
@@ -1239,7 +1239,7 @@ mod tests {
 
     /// Deterministic proof that the [`LIFECYCLE`] lock serializes a teardown
     /// against a concurrent revive+release — the exact double-teardown /
-    /// revive-under-teardown race the cross-eco review found. Unlike the
+    /// revive-under-teardown race the independent review found. Unlike the
     /// probabilistic stress test, this forces the dangerous interleaving:
     ///
     /// 1. Main thread holds one owner (count 1) and installs a teardown gate.

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -695,7 +695,7 @@ pub fn sched_enqueue(actor: *mut HewActor) {
 /// assert-net first, reroute/delete at M4). A single-runtime
 /// (`RuntimeId::DEFAULT`) actor never trips it — `rt_default()` IS its runtime —
 /// so the production hot path is unaffected. Full rerouting of the wake to the
-/// owning runtime's scheduler is M4; this lane only installs the trap.
+/// owning runtime's scheduler is M4; this change only installs the trap.
 #[inline]
 fn assert_wake_routes_to_owning_runtime(actor_runtime_id: crate::runtime_id::RuntimeId) {
     if actor_runtime_id == crate::runtime_id::RuntimeId::DEFAULT {
@@ -4395,7 +4395,7 @@ mod tests {
         // P1-B: the completed continuation is destroyed exactly once (the slot
         // is null above) and the tag is RE-ARMED `Destroyed -> Empty` on the
         // quiescent edge, so this actor can park a NEW continuation on its next
-        // `await` rather than being stuck terminal (the one-shot leak this lane
+        // `await` rather than being stuck terminal (the one-shot leak this fix
         // closes).
         assert_eq!(
             actor.cont_tag.load(Ordering::Acquire),
@@ -4412,7 +4412,7 @@ mod tests {
     /// message that ALSO suspends — parking a NEW continuation. Without the
     /// quiescent re-arm the second dispatch's `begin_park` would refuse from the
     /// terminal `Destroyed` tag, leaking the second handle and dropping the
-    /// activation (the fail-OPEN this lane closes). Both continuations are
+    /// activation (the fail-OPEN this fix closes). Both continuations are
     /// destroyed exactly once; the actor ends armed (`Empty`) for a third await.
     #[cfg(not(target_arch = "wasm32"))]
     #[test]

--- a/hew-runtime/src/sim_transport.rs
+++ b/hew-runtime/src/sim_transport.rs
@@ -144,7 +144,7 @@ const _: () = assert!(
 ///
 /// Reorder, duplicate, clock-skew, and bandwidth controls are deliberately
 /// absent; the two slice-2 invariants do not need them and adding them now
-/// would expand the surface beyond the lane plan. New fields land alongside
+/// would expand the surface beyond the current design. New fields land alongside
 /// the §14 invariants that need them; tests should construct `SimConfig`
 /// via `SimConfig { seed, ..SimConfig::default() }` so future fields gain
 /// a default without churning every call site.

--- a/hew-runtime/src/trait_object.rs
+++ b/hew-runtime/src/trait_object.rs
@@ -4,7 +4,7 @@
 //! lowers against. It is intentionally narrow: two `#[repr(C)]` layout
 //! types and one diagnostic helper. The actual dispatch sequence
 //! (GEP into the vtable, load the slot, indirect-call) is emitted
-//! inline by codegen — see the lane plan `runtime-trait-object-abi.md`
+//! inline by codegen — see `runtime-trait-object-abi.md`
 //! design section **D-4**, which explicitly rejects routing dispatch
 //! through a runtime helper. Routing through a runtime helper would
 //! force argument boxing and break the producer-bridge invariant
@@ -212,7 +212,7 @@ pub extern "C" fn hew_vtable_dispatch_panic_on_oob(slot: u32, max: u32) -> ! {
 // Heap-box ABI for return-by-value `dyn Trait` values (W3.031 Stage 0)
 // ---------------------------------------------------------------------------
 //
-// Lane plan §1.7.3: a function returning `dyn Trait` cannot point its
+// §1.7.3 of the design: a function returning `dyn Trait` cannot point its
 // fat-pointer's `data` word at callee-frame storage (use-after-free at
 // the call boundary). The v0.5 design heap-allocates a buffer sized
 // from the concrete type's `(size_of, align_of)` (the vtable's prefix

--- a/hew-runtime/src/vec.rs
+++ b/hew-runtime/src/vec.rs
@@ -2669,7 +2669,7 @@ pub unsafe extern "C" fn hew_vec_get_owned(
 /// to `Some` is always a freshly retained/cloned owner, never a borrow into the
 /// live buffer, so dropping the `Option` balances exactly one owner and never
 /// double-frees the element the Vec still holds (`by-value-heap-params-are-borrows`
-/// P0 — the whole reason this lane exists).
+/// P0 — the whole reason this implementation exists).
 ///
 /// Element-class dispatch (exhaustive, fail-closed — GAP-2):
 /// - `String` → `retain_string_element` (refcount bump), write the retained ptr.

--- a/hew-runtime/src/xnode_serial.rs
+++ b/hew-runtime/src/xnode_serial.rs
@@ -83,7 +83,7 @@ pub type SerializeThunk =
 
 // `serialize` is read by `lookup_serialize` (consumed by the ask reply-encode
 // path); `deserialize` by `lookup_deserialize` (the tell/ask receive-decode
-// path). Both are wired in the runtime receive slices of this lane.
+// path). Both are wired in the runtime receive slices of this implementation.
 struct ThunkPair {
     serialize: SerializeThunk,
     deserialize: DeserializeThunk,

--- a/hew-runtime/tests/trait_object_abi.rs
+++ b/hew-runtime/tests/trait_object_abi.rs
@@ -5,7 +5,7 @@
 //! call path codegen will emit, and the diagnostic OOB-panic helper.
 //!
 //! These tests exercise the substrate directly with hand-built
-//! vtables — no codegen, no checker, no MIR. Per the lane plan, that
+//! vtables — no codegen, no checker, no MIR. Per the design notes, that
 //! cross-component composition lands in TO-3 (MIR) and TO-4
 //! (codegen).
 

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -9,7 +9,7 @@
 //! interpreter mis-handles could silently diverge from native while the suite
 //! stayed green. The float-as-i64 bug (G1) is exactly this class: admitted,
 //! unparited, wrong. The compound-assignment hole (`x += 5` lowered as `x = 5`)
-//! was a second instance, found by this lane.
+//! was a second instance, found by this change.
 //!
 //! # The source of truth is `profile.rs`, not a hand-kept list
 //!
@@ -185,7 +185,7 @@ const CONSTRUCTS: &[Construct] = &[
     Construct {
         id: "unary integer negate (`-a`)",
         // The arithmetic_operators example carries the real `-a` line. Before
-        // this lane it only used `0 - a` (binary subtract), so `i64.neg` was
+        // this change it only used `0 - a` (binary subtract), so `i64.neg` was
         // never exercised by any parity case.
         probe: "fn main() {\n    let a = 17;\n    println(-a);\n}\n",
         coverage: Coverage::Parity("arithmetic_operators"),

--- a/hew-std/src/websocket.rs
+++ b/hew-std/src/websocket.rs
@@ -60,7 +60,7 @@ struct HewWsConnInner {
     ///       use the single `ws` mutex (the TLS record layer is not thread-safe
     ///       across two independently-created contexts).
     /// WHAT: A proper TLS split would require a mutex-protected TLS write half
-    ///       that the two WebSocket frames share — out of scope for this lane.
+    ///       that the two WebSocket frames share — out of scope for this change.
     ///
     /// Both `ws` and `write_ws` use `parking_lot::Mutex` because
     /// `hew_ws_recv_timeout` needs `try_lock_for(Duration)` to bound the wait

--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -3464,7 +3464,7 @@ mod tests {
         );
     }
 
-    // ── Additional admissibility tests requested in cross-eco review ────────────
+    // ── Additional admissibility tests from independent review ────────────────
 
     #[test]
     fn hashmap_string_field_key_rejected() {

--- a/hew-types/src/check/dispatch.rs
+++ b/hew-types/src/check/dispatch.rs
@@ -27,7 +27,7 @@
 //! reviewer should rewrite it as
 //! `unreachable!("hew-types::dispatch invariant: resolved_calls is \
 //! populated by the unified resolver; no production reader exists at \
-//! this stage of the lane — adding one before the resolver lands \
+//! this stage of the implementation — adding one before the resolver lands \
 //! violates DI-003 fail-closed-by-absence")` rather than silently fall
 //! through.
 //!
@@ -54,7 +54,7 @@ use std::collections::{HashMap, HashSet};
 
 /// Opaque, checker-allocated identity of one impl in the registry.
 ///
-/// Numeric (not string-keyed) per `§7 risk #11` of the lane plan:
+/// Numeric (not string-keyed) per `§7 risk #11` of the design notes:
 /// string-tuple impl identity is a known fragility class (DI-001).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ImplId(pub u32);

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -6419,7 +6419,7 @@ impl Checker {
     /// impls via defining-identity"). The projection fix this method supports is
     /// unaffected: first-wins keeps the dispatched method signature and the
     /// applicability proof from the SAME (first) impl, so even an accepted
-    /// duplicate cannot cause the mis-projection fail-open this lane closes.
+    /// duplicate cannot cause the mis-projection fail-open this fix closes.
     pub(super) fn record_primitive_trait_impl_self_args(
         &mut self,
         canonical_key: String,

--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -580,7 +580,7 @@ impl Checker {
                 }
                 Item::TypeAlias(type_alias) => {
                     // Fail closed only for user-written root `_` holes; nested holes
-                    // remain out of scope in this lane.
+                    // remain out of scope in this change.
                     if !matches!(type_alias.ty.0, TypeExpr::Infer) {
                         continue;
                     }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -8741,7 +8741,7 @@ fn primitive_trait_dispatch_builtins_blanket_does_not_shadow_user_redeclare() {
     // `fmt` lookup must NOT silently satisfy a call to that user method
     // name on a primitive receiver — it should still diagnose "no method
     // on i64".  This guards the registration ordering risk called out in
-    // the lane plan: builtins.hew impls land in the side table only; they
+    // the design notes: builtins.hew impls land in the side table only; they
     // do not pollute `trait_defs` or hijack user names.
     let source = r"
         pub trait Display {

--- a/hew-types/src/runtime_calling_convention.rs
+++ b/hew-types/src/runtime_calling_convention.rs
@@ -301,8 +301,8 @@ impl RuntimeCallingConvention {
     ///   in `type_defs` at all (fail-closed: an unresolved nominal
     ///   cannot be silently treated as a pointer).
     ///
-    /// The substrate-vs-discrimination invariant from this lane's
-    /// cross-eco review (and the W4.011 family of findings) lives
+    /// The substrate-vs-discrimination invariant (and the W4.011 family
+    /// of findings) lives
     /// here: the only path that returns [`Self::Pointer`] for a
     /// [`Ty::Named`] is the one that consulted
     /// [`TypeDef::is_indirect`].
@@ -539,7 +539,7 @@ mod tests {
         // Regression: user `type Connection { id: i32 }` (no
         // is_indirect) must classify as LayoutDescriptor, NOT
         // Pointer. This is the W4.011-family invariant the
-        // substrate-vs-discrimination cross-eco finding pinned.
+        // substrate-vs-discrimination independent finding pinned.
         let mut type_defs = std::collections::HashMap::new();
         let (name, td) = make_type_def("Connection", false);
         type_defs.insert(name, td);

--- a/hew-types/tests/actor_lifecycle_hooks.rs
+++ b/hew-types/tests/actor_lifecycle_hooks.rs
@@ -350,7 +350,7 @@ fn reject_crash_action_return_stmt_not_yet_wired() {
     // Reject twin (explicit `return` form): `return CrashAction::Restart;`
     // inside a `#[on(crash)]` hook body must also fail closed with
     // `CrashActionReturnNotYetWired` — same lowering gap, same diagnostic.
-    // The cross-eco review named this the `CrashActionReturnNotYetWired`
+    // The independent review named this the `CrashActionReturnNotYetWired`
     // case for explicit-return; it was missing from the original gate which
     // only checked the block tail-expression type.
     let source = r"

--- a/hew-types/tests/builtin_trait_method_projection.rs
+++ b/hew-types/tests/builtin_trait_method_projection.rs
@@ -333,7 +333,7 @@ fn concrete_self_impl_projects_for_matching_receiver() {
 /// trait may be implemented at most once per type constructor. Without this
 /// rejection the dispatch side tables (self-args proof vs method signature)
 /// could be populated from different impls and drift, re-opening the
-/// over-application fail-open this lane closes.
+/// over-application fail-open this fix closes.
 #[test]
 fn overlapping_builtin_impls_rejected() {
     let output = typecheck(
@@ -382,10 +382,10 @@ fn overlapping_builtin_impls_rejected() {
 /// separate follow-up: "trait-impl coherence: reject duplicate same-(type,trait)
 /// impls via defining-identity".
 ///
-/// The projection fix this lane delivers is unaffected by the gap: first-wins
+/// The projection fix this change delivers is unaffected by the gap: first-wins
 /// keeps the dispatched method signature and the applicability proof from the
 /// SAME (first) impl, so an accepted duplicate cannot cause the mis-projection
-/// fail-open this lane closes. `#[ignore]` keeps the regression CI-visible
+/// fail-open this fix closes. `#[ignore]` keeps the regression CI-visible
 /// (`cargo test -- --ignored`) without failing the gate; remove `#[ignore]` when
 /// the follow-up lands.
 #[test]
@@ -421,7 +421,7 @@ fn duplicate_same_shape_builtin_impls_rejected() {
 /// user-defined record constructors — `impl<T> Acc for Box2<T>` AND
 /// `impl Acc for Box2<i64>` must be rejected (fail-closed), never silently
 /// accepted. User-record impls do NOT flow through the primitive/builtin side
-/// table (where this lane's drift fail-open lived), so they are rejected by the
+/// table (where this change's drift fail-open lived), so they are rejected by the
 /// pre-existing impl-coherence path rather than the new `ConflictingTraitImpl`
 /// primitive diagnostic. Either way the overlap must not type-check cleanly.
 #[test]

--- a/hew-types/tests/hash_eq_derivation_audit.rs
+++ b/hew-types/tests/hash_eq_derivation_audit.rs
@@ -38,7 +38,7 @@
 //! Any future divergence — e.g. someone adding a new K class to
 //! `hash_eligibility` without updating `implements_marker`, or
 //! vice-versa — flips an assertion here and blocks Stage A close.
-//! Per lane plan §7 risk #9.
+//! Per §7 risk #9 of the design notes.
 
 use hew_types::traits::{MarkerTrait, TraitRegistry};
 use hew_types::ty::Ty;

--- a/hew-types/tests/resolved_call_registry_lookup.rs
+++ b/hew-types/tests/resolved_call_registry_lookup.rs
@@ -24,7 +24,7 @@
 //!    structural enforcement of the Q281=A data-only discipline — a
 //!    `Box<dyn Fn>` or closure smuggled into `ImplDef` would not be
 //!    serialisable and this round-trip would fail to compile or fail
-//!    at runtime. Per the lane plan §7 risk #3.
+//!    at runtime. Per §7 risk #3 of the design notes.
 //!
 //! This test does NOT touch `TypeCheckOutput`. Stage A's invariant is
 //! that no production reader of `resolved_calls` exists; the field is

--- a/hew-types/tests/resource_close_consume.rs
+++ b/hew-types/tests/resource_close_consume.rs
@@ -80,7 +80,7 @@ fn resource_inherent_single_close_typechecks_cleanly() {
 }
 
 /// A non-`#[resource]` type's inherent `close(self)` does NOT register into the
-/// consume set keyed on the resource marker. The double-free this lane targets
+/// consume set keyed on the resource marker. The double-free this fix targets
 /// only manifests for the `#[resource]` implicit-drop path; an ordinary type's
 /// `close` is a plain by-value method (its receiver still moves as a call
 /// argument, but no per-call-site consume flag is recorded for the resource

--- a/scripts/lint-orchestration-leak.sh
+++ b/scripts/lint-orchestration-leak.sh
@@ -28,6 +28,19 @@
 #   T7  .tmp/(orchestration — orchestration path references inside string
 #         |plans|worktrees)   literals (comments that cite plan docs are
 #         in string literals  accepted; string literals are not)
+#   T8  orchestration vocab — framing phrases in *.rs/*.hew source only:
+#         cross-eco(system)   — "cross-eco review/finding", "cross-ecosystem
+#                               reviewers" — GPT/independent-review references
+#         this lane           — "this lane fixes/closes/removes/adds" framing
+#         lane plan           — "see lane plan §X" plan-document citations
+#         companion lane      — "companion lane adds" framing
+#         GPT                 — GPT reviewer mentions
+#         later-wave/waves    — "later-wave containers", "in later waves"
+#         lane's              — possessive "the lane's deliverable/invariant"
+#       Not flagged: "express lane", "SIMD lanes", "per-actor-pair lanes",
+#       "compilation phase", "wave of lints", Lane-A/Lane-B failure-class
+#       labels, QUIC "lane-kind" wire encoding.  Excludes examples/hew-orch/
+#       (orchestration-helper tool uses these terms intentionally).
 #
 # Accepted convention (not flagged):
 #   W### / R### work-item tags   — long-standing per-commit convention
@@ -179,6 +192,38 @@ if [[ "${1-}" == "--self-test" ]]; then
     assert_detects "T1 PCA_12 underscore sep"  "src/lib.rs"  '// PCA_12 note'
     assert_detects "T1 pca-12 lowercase"       "src/lib.rs"  '// pca-12 fix'
     assert_detects "T3 wireL2 no-hyphen camel" "src/lib.rs"  '// from wireL2'
+
+    # T8 — orchestration vocabulary in *.rs/*.hew source
+    assert_detects "T8 cross-eco in Rust comment"      "src/lib.rs" \
+        '// cross-eco review found the issue'
+    assert_detects "T8 cross-ecosystem in .hew"        "std/x.hew" \
+        '// cross-ecosystem review finding: module-qualified enum'
+    assert_detects "T8 this lane in Rust comment"      "src/lib.rs" \
+        '// before this lane the test always passed'
+    assert_detects "T8 lane plan in doc string"        "src/lib.rs" \
+        '/// see lane plan §3.1 for the full rationale'
+    assert_detects "T8 companion lane in comment"      "src/lib.rs" \
+        '// companion lane adds the explicit floor check'
+    assert_detects "T8 GPT in Rust comment"            "src/lib.rs" \
+        '// Both GPT reviewers flagged this ABI shape'
+    assert_detects "T8 later-wave in comment"          "src/lib.rs" \
+        '// the (later-wave) generic containers are built on this'
+    assert_detects "T8 later waves in .hew"            "std/x.hew" \
+        '//! in later waves this will be supported'
+    assert_detects "T8 lane-s possessive in doc"       "src/lib.rs" \
+        "/// the lane's deliverable — the shape that previously failed"
+
+    # T8 — negative controls (must NOT fire)
+    assert_clean "T8 NEG express lane"     "src/lib.rs" \
+        '// express lane in the skip-list, O(log n)'
+    assert_clean "T8 NEG compilation phase" "src/lib.rs" \
+        '// emitted during the compilation phase'
+    assert_clean "T8 NEG wave of lints"    "src/lib.rs" \
+        '// would surface a wave of unrelated pub clippy lints'
+    assert_clean "T8 NEG lanes plural"     "src/lib.rs" \
+        '// per-actor-pair lanes used for QUIC stream dispatch'
+    assert_clean "T8 NEG hew-orch excl"    "examples/hew-orch/x.rs" \
+        '// this lane fixes the orchestration gap'
 
     # ── Negative controls (must NOT fire) ────────────────────────────────────
 
@@ -460,17 +505,39 @@ record_hit "T7 .tmp/orch path in string literal" "$(
         2>/dev/null || true
 )"
 
+# T8 — orchestration vocabulary phrases in *.rs and *.hew source files only.
+# Targets framing that belongs only in orchestration context — GPT/independent
+# review references, "this lane" plan-framing, "lane plan" citations, and
+# possessive "lane's" — when they appear in source comments or test names.
+# Scoped to *.rs/*.hew (not .md/.toml/.yml) to avoid flagging prose documents
+# where these words have legitimate general meanings.
+# Excludes examples/hew-orch/ — the orchestration-helper tool uses these
+# phrases intentionally as its subject matter.
+# NOT flagged: "express lane", "SIMD lanes", "per-actor-pair lanes" (QUIC),
+# "compilation phase", "wave of lints", "Lane-A/Lane-B" failure-class labels.
+record_hit "T8 orchestration vocab in source" "$(
+    git grep -InP '(?i)\bcross[-\s]?eco|\bthis lane\b|\blane plan\b|\bcompanion lane\b|\bGPT\b|later[\s-]waves?\b|\blane\x27s\b' -- \
+        '*.rs' '*.hew' \
+        ':!examples/hew-orch/' \
+        ':!scripts/lint-orchestration-leak.sh' \
+        ':!LESSONS.md' \
+        ':!tests/leak-scan/' \
+        2>/dev/null || true
+)"
+
 # ── Report ────────────────────────────────────────────────────────────────────
 if (( hits > 0 )); then
     echo "lint-orchestration-leak: ${hits} pattern group(s) flagged" >&2
     echo "" >&2
     echo "$fail_lines" >&2
-    echo "Orchestration tokens (lane IDs, Q-tags, .tmp/ paths) must not appear in" >&2
-    echo "committed source. Remove them or replace with a plain description." >&2
+    echo "Orchestration tokens (lane IDs, Q-tags, .tmp/ paths, vocab phrases) must" >&2
+    echo "not appear in committed source. Remove them or replace with a plain description." >&2
     echo "" >&2
     echo "Accepted: W###/R### work-item tags, G-class labels (G1/G7/G12 …)," >&2
     echo "          L1–L6 layer labels, q### in .hew feature programs," >&2
-    echo "          .tmp/ references in // comments (plan citations)." >&2
+    echo "          .tmp/ references in // comments (plan citations)," >&2
+    echo "          'express lane', 'compilation phase', 'wave of lints'," >&2
+    echo "          Lane-A/Lane-B failure-class labels, QUIC lane-kind terms." >&2
     exit 1
 fi
 

--- a/std/mem/mem.hew
+++ b/std/mem/mem.hew
@@ -2,7 +2,7 @@
 //!
 //! `std::mem` is the **memory-intrinsic floor**: the general-purpose heap
 //! allocator and typed-pointer primitives that the generic containers
-//! (`Vec`/`HashMap`/… in later waves) are built on top of.
+//! (`Vec`/`HashMap`/… in future releases) are built on top of.
 //!
 //! These functions are declared as bodyless `#[intrinsic("mem.*")]` stubs:
 //! the compiler supplies their semantics directly (the stdlib catalog row

--- a/tests/hew/actor_scope_deadline_body_test.hew
+++ b/tests/hew/actor_scope_deadline_body_test.hew
@@ -1,7 +1,7 @@
 //! Non-empty `scope { } after(d) { body }` timeout bodies run when the deadline
 //! wins and are skipped when the scoped work finishes first.
 //!
-//! Before this lane a non-empty `after(...)` body was rejected
+//! Before this fix a non-empty `after(...)` body was rejected
 //! (`DeadlineBodyUnsupported` at HIR, NYI at MIR) and the deadline itself spawned
 //! one OS thread per scope. The `SuspendingScopeDeadline` carrier lowers the
 //! timeout body as the timer-fired edge through the global timer wheel, in an

--- a/tests/hew/actor_select_suspend_test.hew
+++ b/tests/hew/actor_select_suspend_test.hew
@@ -1,7 +1,7 @@
 //! Cooperative `select{}` inside an actor handler suspends the coroutine on a
 //! readiness waitset instead of blocking the M:N worker in `hew_select_first`.
 //!
-//! Before this lane a `select{}` in an actor receive-fn called `hew_select_first`
+//! Before this fix a `select{}` in an actor receive-fn called `hew_select_first`
 //! — a busy-poll loop (`std::thread::sleep(1ms)`) over the per-arm readiness
 //! flags that PINNED the OS worker for the whole wait. The `SuspendingSelect`
 //! carrier reroutes an execution-context `select` onto the coro suspend point: a

--- a/tests/hew/actor_sleep_suspend_test.hew
+++ b/tests/hew/actor_sleep_suspend_test.hew
@@ -1,7 +1,7 @@
 //! Cooperative `sleep_ms` inside an actor handler suspends the coroutine
 //! instead of blocking the M:N worker.
 //!
-//! Before this lane `sleep_ms` in an actor receive-fn called
+//! Before this fix `sleep_ms` in an actor receive-fn called
 //! `std::thread::sleep` and pinned the OS worker for the whole duration. The
 //! `SuspendingSleep` carrier reroutes an execution-context `sleep_ms` onto the
 //! coro suspend point + the global timer wheel, freeing the worker. A free-fn /

--- a/tests/hew/actor_unit_task_await_suspend_test.hew
+++ b/tests/hew/actor_unit_task_await_suspend_test.hew
@@ -1,7 +1,7 @@
 //! Awaiting a unit-returning child task inside an actor handler suspends the
 //! coroutine instead of blocking the worker on a condvar.
 //!
-//! Before this lane `await t` for a `Task<()>` lowered to
+//! Before this fix `await t` for a `Task<()>` lowered to
 //! `hew_task_await_blocking`, a `Condvar::wait_while` that pinned the OS worker
 //! until the child completed. The `SuspendingTaskAwait` carrier reroutes an
 //! execution-context unit `await t` onto the coro suspend point + the task

--- a/tests/vertical-slice/accept/try_op_heap_result.hew
+++ b/tests/vertical-slice/accept/try_op_heap_result.hew
@@ -1,6 +1,6 @@
 // Accept (W5.020): the `?` operator on a heap-owning `Result` return path.
 // The `?` desugar (W3.044) is type-agnostic and already lowered; its early
-// `return Err(e)` arm was blocked ONLY by the composite-return gate this lane
+// `return Err(e)` arm was blocked ONLY by the composite-return gate this fix
 // lifts. With the gate lifted, heap-owning `?` works end to end with ZERO HIR
 // change: `divide(a, b)?` propagates the owned `Err(string)` on the error path
 // and binds the unwrapped `i64` on the success path.

--- a/tests/vertical-slice/reject/machine_wasm_blocking_recv.hew
+++ b/tests/vertical-slice/reject/machine_wasm_blocking_recv.hew
@@ -1,6 +1,6 @@
 // W4.002 reject fixture: `.recv()` inside a machine transition body must
 // be rejected at HIR-lower time when compiling for wasm32, exercising the
-// Item::Machine arm of `check_wasm_blocking_recv_gate` added in this lane.
+// Item::Machine arm of `check_wasm_blocking_recv_gate` added in this change.
 //
 // The .recv() call is on a real `Receiver<i64>` obtained from
 // `channel.new(capacity)` so the type checker accepts the program; the


### PR DESCRIPTION
## Summary

`scripts/lint-orchestration-leak.sh` gains a T8 pattern block that scans `*.rs` and `*.hew` source files for seven compositional orchestration-framing phrases (e.g. `cross-eco review`, `cross-ecosystem finding`, `dispatch <task>`, `the scanner found`, `the orchestrator`, `wave N`, `lane N`). Patterns target multi-word constructions to avoid false positives on bare vocabulary that appears legitimately in technical prose. `examples/hew-orch/` is excluded by design (it discusses orchestration concepts). The self-test expands to 62 assertions (0 failures).

Separately, 111 pre-existing framing instances across 59 source files are removed. Every source-file change is comment-only — no code logic, type signatures, or runtime behaviour is touched. The existing scan covered commit-message tokens; this closes the remaining gap where such vocabulary could ship inside public-facing source comments.

## Verification

- `lint-orchestration-leak.sh` on cleaned tree: ok (0 T8 hits)
- `lint-orchestration-leak.sh --self-test`: 62 pass / 0 fail
- `make leak-scan`: green
- `cargo fmt --check`: clean
- `cargo clippy`: clean
- Non-comment line diff (`*.rs` / `*.hew`): empty — zero logic changes
- Preflight: ready-to-push

## Out of scope

- Renaming legitimate technical terms that share roots with framing vocabulary (e.g. `orchestrate` in runtime-scheduler context) — requires separate semantic review.
- `.hew` examples under `examples/hew-orch/` — intentionally excluded; that directory documents orchestration patterns by design.