### PR TITLE
Complete the indexed-accessor convergence for bytes and string

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -989,6 +989,7 @@ fn wasm_excluded_call_family(family: hew_types::runtime_call::RuntimeCallFamily)
         | F::AutoMutexFree
         | F::AutoMutexLock
         | F::AutoMutexUnlock
+        | F::BytesGet
         | F::BytesIndex
         | F::BytesLen
         | F::BytesPush
@@ -19701,6 +19702,182 @@ fn lower_vec_get_clone_call(
     Ok(())
 }
 
+/// Lower the `bytes.get(index) -> Option<u8>` choke (`Index::get`), de-aliased
+/// from the trapping `b[i]` (`hew_bytes_index`). Mirrors `lower_vec_get_clone_call`
+/// but owns the bounds check inline (bytes carries no `*_get_clone` runtime
+/// export — plan §4.2: "do the check in MIR/codegen + an in-bounds typed load"):
+///
+/// ```text
+///   entry:  unpack BytesTriple {ptr, offset, len}; index_in_bounds := index <u len
+///           condbr index_in_bounds -> some_bb, none_bb
+///   some_bb: byte := hew_bytes_index(ptr, offset, len, index)   -- in-bounds, no trap
+///            store byte into Option::Some payload; tag := 0; br next
+///   none_bb: tag := 1 (None); br next
+/// ```
+///
+/// The receiver is borrowed (`is_collection_receiver_borrow_callee`), so `buf`
+/// keeps its scope-exit drop. `u8` is a scalar (Copy): the `Some` payload is a
+/// by-value load — no owned clone, no drop obligation on the payload.
+fn lower_bytes_get_option_call(
+    fn_ctx: &FnCtx<'_, '_>,
+    args: &[Place],
+    dest: Option<&Place>,
+    next: u32,
+) -> CodegenResult<()> {
+    if args.len() != 2 {
+        return Err(CodegenError::FailClosed(format!(
+            "hew_bytes_get expects 2 source-level args (bytes, index), got {}",
+            args.len()
+        )));
+    }
+    let dest_place = dest.ok_or_else(|| {
+        CodegenError::FailClosed("hew_bytes_get returns Option<u8>; call must supply a dest".into())
+    })?;
+    if !matches!(place_resolved_ty(fn_ctx, args[0])?, ResolvedTy::Bytes) {
+        return Err(CodegenError::FailClosed(format!(
+            "hew_bytes_get arg0 must be a `bytes` receiver; got {:?}",
+            place_resolved_ty(fn_ctx, args[0])?
+        )));
+    }
+    let dest_ty = place_resolved_ty(fn_ctx, *dest_place)?.clone();
+    match &dest_ty {
+        ResolvedTy::Named {
+            name,
+            args: ty_args,
+            ..
+        } if name == "Option" && ty_args.len() == 1 && ty_args[0] == ResolvedTy::U8 => {}
+        other => {
+            return Err(CodegenError::FailClosed(format!(
+                "hew_bytes_get dest must be Option<u8>, got {other:?}"
+            )));
+        }
+    }
+
+    let ptr_ty = fn_ctx.ctx.ptr_type(AddressSpace::default());
+    let i32_ty = fn_ctx.ctx.i32_type();
+    let i64_ty = fn_ctx.ctx.i64_type();
+
+    // Unpack the stack-resident BytesTriple {ptr, i32 offset, i32 len} by value,
+    // field-by-field — identical to the `hew_bytes_index` ABI marshalling. A
+    // `bytes` value is NOT a `*mut HewVec`, so it must not route through the Vec
+    // handle load.
+    let (triple_ptr, triple_ty) = place_pointer(fn_ctx, args[0])?;
+    let BasicTypeEnum::StructType(triple_struct_ty) = triple_ty else {
+        return Err(CodegenError::FailClosed(format!(
+            "hew_bytes_get: bytes receiver alloca has non-struct type {triple_ty:?}; \
+             expected the `{{ptr, i32, i32}}` BytesTriple layout"
+        )));
+    };
+    let data_ptr_gep = fn_ctx
+        .builder
+        .build_struct_gep(triple_struct_ty, triple_ptr, 0, "bytes_get_ptr_gep")
+        .llvm_ctx("hew_bytes_get ptr GEP")?;
+    let data_ptr = fn_ctx
+        .builder
+        .build_load(ptr_ty, data_ptr_gep, "bytes_get_ptr")
+        .llvm_ctx("hew_bytes_get ptr load")?
+        .into_pointer_value();
+    let offset_gep = fn_ctx
+        .builder
+        .build_struct_gep(triple_struct_ty, triple_ptr, 1, "bytes_get_offset_gep")
+        .llvm_ctx("hew_bytes_get offset GEP")?;
+    let offset_val = fn_ctx
+        .builder
+        .build_load(i32_ty, offset_gep, "bytes_get_offset")
+        .llvm_ctx("hew_bytes_get offset load")?
+        .into_int_value();
+    let len_gep = fn_ctx
+        .builder
+        .build_struct_gep(triple_struct_ty, triple_ptr, 2, "bytes_get_len_gep")
+        .llvm_ctx("hew_bytes_get len GEP")?;
+    let len_val = fn_ctx
+        .builder
+        .build_load(i32_ty, len_gep, "bytes_get_len")
+        .llvm_ctx("hew_bytes_get len load")?
+        .into_int_value();
+    let index = load_int_arg(fn_ctx, args[1], i64_ty, "hew_bytes_get index")?;
+
+    // index_in_bounds := (index <u zext(len)). The unsigned compare folds the
+    // negative-index case into "out of bounds" (a negative i64 reinterpreted as
+    // u64 exceeds any real length) so `.get(-1)` yields `None`, never a trap.
+    let len_i64 = fn_ctx
+        .builder
+        .build_int_z_extend_or_bit_cast(len_val, i64_ty, "bytes_get_len_i64")
+        .llvm_ctx("hew_bytes_get len zext")?;
+    let in_bounds = fn_ctx
+        .builder
+        .build_int_compare(IntPredicate::ULT, index, len_i64, "bytes_get_in_bounds")
+        .llvm_ctx("hew_bytes_get bounds cmp")?;
+
+    let parent = fn_ctx
+        .builder
+        .get_insert_block()
+        .and_then(|bb| bb.get_parent())
+        .ok_or_else(|| CodegenError::FailClosed("hew_bytes_get has no parent fn".into()))?;
+    let some_bb = fn_ctx.ctx.append_basic_block(parent, "bytes_get_some");
+    let none_bb = fn_ctx.ctx.append_basic_block(parent, "bytes_get_none");
+    let next_bb = *fn_ctx
+        .blocks
+        .get(&next)
+        .ok_or_else(|| CodegenError::FailClosed(format!("Call next bb{next} missing")))?;
+    fn_ctx
+        .builder
+        .build_conditional_branch(in_bounds, some_bb, none_bb)
+        .llvm_ctx("hew_bytes_get condbr")?;
+
+    // Some = variant 0. The in-bounds typed load reuses the canonical
+    // `hew_bytes_index` getter (single source of truth for byte addressing); it
+    // is reached only on the in-bounds edge, so its OOB trap is unreachable.
+    fn_ctx.builder.position_at_end(some_bb);
+    let byte_val = fn_ctx.call_runtime_int(
+        "hew_bytes_index",
+        &[
+            data_ptr.into(),
+            offset_val.into(),
+            len_val.into(),
+            index.into(),
+        ],
+        "bytes_get_byte",
+        "hew_bytes_get element load",
+    )?;
+    let dest_local = composite_dest_local(*dest_place, "hew_bytes_get")?;
+    let (payload_ptr, payload_ty) = place_pointer(
+        fn_ctx,
+        Place::MachineVariant {
+            local: dest_local,
+            variant_idx: 0,
+            field_idx: 0,
+        },
+    )?;
+    let BasicTypeEnum::IntType(payload_int_ty) = payload_ty else {
+        return Err(CodegenError::FailClosed(format!(
+            "hew_bytes_get Option::Some payload must be integer-shaped (u8); got {payload_ty:?}"
+        )));
+    };
+    let store_val = fn_ctx
+        .builder
+        .build_int_z_extend_or_bit_cast(byte_val, payload_int_ty, "bytes_get_byte_cast")
+        .llvm_ctx("hew_bytes_get payload cast")?;
+    fn_ctx
+        .builder
+        .build_store(payload_ptr, store_val)
+        .llvm_ctx("hew_bytes_get payload store")?;
+    emit_enum_variant_literal(fn_ctx, *dest_place, 0, &[])?;
+    fn_ctx
+        .builder
+        .build_unconditional_branch(next_bb)
+        .llvm_ctx("hew_bytes_get some br")?;
+
+    // None = variant 1 for Hew's builtin `Option<T>` layout.
+    fn_ctx.builder.position_at_end(none_bb);
+    emit_enum_variant_literal(fn_ctx, *dest_place, 1, &[])?;
+    fn_ctx
+        .builder
+        .build_unconditional_branch(next_bb)
+        .llvm_ctx("hew_bytes_get none br")?;
+    Ok(())
+}
+
 /// Declare (or fetch) the `hew_vec_get_clone(vec, index, out) -> bool` runtime
 /// choke point: `(ptr, i64, ptr) -> i1`.
 fn get_or_declare_vec_get_clone_runtime<'ctx>(
@@ -25238,6 +25415,10 @@ fn lower_terminator<'ctx>(
             }
             if callee == "hew_vec_get_clone" {
                 lower_vec_get_clone_call(fn_ctx, args, dest.as_ref(), *next)?;
+                return Ok(());
+            }
+            if callee == "hew_bytes_get" {
+                lower_bytes_get_option_call(fn_ctx, args, dest.as_ref(), *next)?;
                 return Ok(());
             }
             if callee == "hew_hashmap_get_clone_layout" {

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -1090,6 +1090,7 @@ fn wasm_excluded_call_family(family: hew_types::runtime_call::RuntimeCallFamily)
         | F::StreamTryNextLayout
         | F::StringCharCount
         | F::StringConcat
+        | F::StringGet
         | F::StringIndex
         | F::StringSliceCodepoints
         | F::TcpAttachLocal
@@ -19878,6 +19879,154 @@ fn lower_bytes_get_option_call(
     Ok(())
 }
 
+/// Lower the codegen-intercepted `hew_string_get(s, index) -> Option<char>`
+/// accessor: the non-trapping, drop-safe counterpart to the trapping `s[i]`
+/// (`hew_string_index`). Builds the bounds-check CFG and the `Some`/`None`
+/// materialisation inline, mirroring `lower_bytes_get_option_call`:
+///
+/// ```text
+///   entry:  s_ptr := load string handle; count := hew_string_char_count(s_ptr)
+///           index_in_bounds := index <u zext(count)
+///           condbr index_in_bounds -> some_bb, none_bb
+///   some_bb: cp := hew_string_index(s_ptr, index)   -- in-bounds, no trap
+///            store cp into Option::Some payload; tag := 0; br next
+///   none_bb: tag := 1 (None); br next
+/// ```
+///
+/// The receiver is borrowed (`is_collection_receiver_borrow_callee`), so `s`
+/// keeps its scope-exit drop. `char` is a scalar (Copy): the `Some` payload is
+/// a by-value codepoint load — no owned clone, no drop obligation on the
+/// payload. Unlike `bytes` (a stack `BytesTriple`), a `string` value is a
+/// single heap `*const c_char` handle, so the receiver marshals through
+/// `load_duplex_handle` exactly like the trapping `hew_string_index` arm.
+fn lower_string_get_option_call(
+    fn_ctx: &FnCtx<'_, '_>,
+    args: &[Place],
+    dest: Option<&Place>,
+    next: u32,
+) -> CodegenResult<()> {
+    if args.len() != 2 {
+        return Err(CodegenError::FailClosed(format!(
+            "hew_string_get expects 2 source-level args (string, index), got {}",
+            args.len()
+        )));
+    }
+    let dest_place = dest.ok_or_else(|| {
+        CodegenError::FailClosed(
+            "hew_string_get returns Option<char>; call must supply a dest".into(),
+        )
+    })?;
+    if !matches!(place_resolved_ty(fn_ctx, args[0])?, ResolvedTy::String) {
+        return Err(CodegenError::FailClosed(format!(
+            "hew_string_get arg0 must be a `string` receiver; got {:?}",
+            place_resolved_ty(fn_ctx, args[0])?
+        )));
+    }
+    let dest_ty = place_resolved_ty(fn_ctx, *dest_place)?.clone();
+    match &dest_ty {
+        ResolvedTy::Named {
+            name,
+            args: ty_args,
+            ..
+        } if name == "Option" && ty_args.len() == 1 && ty_args[0] == ResolvedTy::Char => {}
+        other => {
+            return Err(CodegenError::FailClosed(format!(
+                "hew_string_get dest must be Option<char>, got {other:?}"
+            )));
+        }
+    }
+
+    let i64_ty = fn_ctx.ctx.i64_type();
+
+    // A `string` value is a single heap `*const c_char` handle — marshal it
+    // exactly like the trapping `hew_string_index` ABI arm.
+    let s_ptr = load_duplex_handle(fn_ctx, args[0], "hew_string_get arg0")?;
+    let index = load_int_arg(fn_ctx, args[1], i64_ty, "hew_string_get index")?;
+
+    // count := hew_string_char_count(s_ptr) -> i32 (codepoint count, NOT byte
+    // length). index_in_bounds := (index <u zext(count)). The unsigned compare
+    // folds the negative-index case into "out of bounds" so `.get(-1)` yields
+    // `None`, never a trap.
+    let count = fn_ctx.call_runtime_int(
+        "hew_string_char_count",
+        &[s_ptr.into()],
+        "string_get_count",
+        "hew_string_get char count",
+    )?;
+    let count_i64 = fn_ctx
+        .builder
+        .build_int_z_extend_or_bit_cast(count, i64_ty, "string_get_count_i64")
+        .llvm_ctx("hew_string_get count zext")?;
+    let in_bounds = fn_ctx
+        .builder
+        .build_int_compare(IntPredicate::ULT, index, count_i64, "string_get_in_bounds")
+        .llvm_ctx("hew_string_get bounds cmp")?;
+
+    let parent = fn_ctx
+        .builder
+        .get_insert_block()
+        .and_then(|bb| bb.get_parent())
+        .ok_or_else(|| CodegenError::FailClosed("hew_string_get has no parent fn".into()))?;
+    let some_bb = fn_ctx.ctx.append_basic_block(parent, "string_get_some");
+    let none_bb = fn_ctx.ctx.append_basic_block(parent, "string_get_none");
+    let next_bb = *fn_ctx
+        .blocks
+        .get(&next)
+        .ok_or_else(|| CodegenError::FailClosed(format!("Call next bb{next} missing")))?;
+    fn_ctx
+        .builder
+        .build_conditional_branch(in_bounds, some_bb, none_bb)
+        .llvm_ctx("hew_string_get condbr")?;
+
+    // Some = variant 0. The in-bounds codepoint load reuses the canonical
+    // `hew_string_index` getter (single source of truth for codepoint
+    // addressing); it is reached only on the in-bounds edge, so its OOB trap is
+    // unreachable.
+    fn_ctx.builder.position_at_end(some_bb);
+    let codepoint = fn_ctx.call_runtime_int(
+        "hew_string_index",
+        &[s_ptr.into(), index.into()],
+        "string_get_codepoint",
+        "hew_string_get codepoint load",
+    )?;
+    let dest_local = composite_dest_local(*dest_place, "hew_string_get")?;
+    let (payload_ptr, payload_ty) = place_pointer(
+        fn_ctx,
+        Place::MachineVariant {
+            local: dest_local,
+            variant_idx: 0,
+            field_idx: 0,
+        },
+    )?;
+    let BasicTypeEnum::IntType(payload_int_ty) = payload_ty else {
+        return Err(CodegenError::FailClosed(format!(
+            "hew_string_get Option::Some payload must be integer-shaped (char); got {payload_ty:?}"
+        )));
+    };
+    let store_val = fn_ctx
+        .builder
+        .build_int_z_extend_or_bit_cast(codepoint, payload_int_ty, "string_get_codepoint_cast")
+        .llvm_ctx("hew_string_get payload cast")?;
+    fn_ctx
+        .builder
+        .build_store(payload_ptr, store_val)
+        .llvm_ctx("hew_string_get payload store")?;
+    emit_enum_variant_literal(fn_ctx, *dest_place, 0, &[])?;
+    fn_ctx
+        .builder
+        .build_unconditional_branch(next_bb)
+        .llvm_ctx("hew_string_get some br")?;
+
+    // None = variant 1 for Hew's builtin `Option<T>` layout.
+    fn_ctx.builder.position_at_end(none_bb);
+    emit_enum_variant_literal(fn_ctx, *dest_place, 1, &[])?;
+    fn_ctx
+        .builder
+        .build_unconditional_branch(next_bb)
+        .llvm_ctx("hew_string_get none br")?;
+    Ok(())
+}
+
 /// Declare (or fetch) the `hew_vec_get_clone(vec, index, out) -> bool` runtime
 /// choke point: `(ptr, i64, ptr) -> i1`.
 fn get_or_declare_vec_get_clone_runtime<'ctx>(
@@ -25419,6 +25568,10 @@ fn lower_terminator<'ctx>(
             }
             if callee == "hew_bytes_get" {
                 lower_bytes_get_option_call(fn_ctx, args, dest.as_ref(), *next)?;
+                return Ok(());
+            }
+            if callee == "hew_string_get" {
+                lower_string_get_option_call(fn_ctx, args, dest.as_ref(), *next)?;
                 return Ok(());
             }
             if callee == "hew_hashmap_get_clone_layout" {

--- a/hew-codegen-rs/src/runtime_abi.rs
+++ b/hew-codegen-rs/src/runtime_abi.rs
@@ -2797,6 +2797,11 @@ pub(crate) fn lower_call_runtime_abi(
         | F::StreamNextLayout
         | F::StreamSendLayout
         | F::StreamTryNextLayout
+        // `hew_string_get` rides a `Terminator::Call` whose callee codegen
+        // intercepts to build `Option<char>` inline; it is never emitted as an
+        // `Instr::CallRuntimeAbi`, so it has no MIR-ABI lowering arm here and
+        // fails closed if it ever reaches this dispatch, like `BytesGet`.
+        | F::StringGet
         | F::SupervisorNestedGet
         | F::TcpAttachLocal
         | F::TaskCompleteThreaded

--- a/hew-codegen-rs/src/runtime_abi.rs
+++ b/hew-codegen-rs/src/runtime_abi.rs
@@ -2719,6 +2719,11 @@ pub(crate) fn lower_call_runtime_abi(
         | F::AutoMutexFree
         | F::AutoMutexLock
         | F::AutoMutexUnlock
+        // `hew_bytes_get` rides a `Terminator::Call` whose callee codegen
+        // intercepts to build `Option<u8>` inline; it is never emitted as an
+        // `Instr::CallRuntimeAbi`, so it has no MIR-ABI lowering arm here and
+        // fails closed if it ever reaches this dispatch, like `TaskSetResult`.
+        | F::BytesGet
         | F::CancelTokenIsRequested
         | F::CancelTokenRelease
         | F::CancelTokenRetain

--- a/hew-codegen-rs/tests/bytes_index_exec.rs
+++ b/hew-codegen-rs/tests/bytes_index_exec.rs
@@ -1,13 +1,14 @@
 //! Execution tests for `bytes` element loads through `hew_bytes_index`.
 //!
 //! A `bytes` value is a stack-resident `BytesTriple { ptr, offset, len }`, NOT
-//! a `*mut HewVec`, so both the `b[i]` indexing sugar and the `bytes.get(i)`
-//! method route to the dedicated `hew_bytes_index(ptr, offset, len, index) -> u8`
-//! runtime getter (not the heap-Vec element getter `hew_vec_get_i32`, whose arg0
-//! ABI is a Vec `ptr`). This was previously a fail-closed codegen-front error
-//! (`hew_vec_get_i32 arg0 resolves to non-pointer type {ptr,i32,i32}`); the
-//! `hew_bytes_index` codegen arm unpacks the triple into the runtime's
-//! (ptr, offset, len) args.
+//! a `*mut HewVec`, so the `b[i]` indexing sugar routes to the dedicated
+//! `hew_bytes_index(ptr, offset, len, index) -> u8` runtime getter (not the
+//! heap-Vec element getter `hew_vec_get_i32`, whose arg0 ABI is a Vec `ptr`),
+//! and `bytes.get(i)` lowers through the `hew_bytes_get` codegen arm to an
+//! in-bounds `Some(u8)` / out-of-bounds `None`. This was previously a
+//! fail-closed codegen-front error (`hew_vec_get_i32 arg0 resolves to
+//! non-pointer type {ptr,i32,i32}`); the `hew_bytes_index` codegen arm unpacks
+//! the triple into the runtime's (ptr, offset, len) args.
 
 #![cfg(not(target_arch = "wasm32"))]
 #![cfg(unix)]
@@ -139,35 +140,53 @@ fn bytes_index_sugar_reads_pushed_bytes() {
     assert_eq!(stdout, "PASS");
 }
 
-/// `bytes.get(i)` method routes to the same `hew_bytes_index` getter and returns
-/// the byte widened to the method's declared `i32` return.
+/// `bytes.get(i)` returns `Option<u8>`: `Some(byte)` in bounds, `None` out of
+/// bounds (de-aliased from the trapping `b[i]`). The high byte 200 (>127) must
+/// round-trip through the `Some` payload as 200, not a sign-extended negative.
 #[test]
-fn bytes_get_method_reads_pushed_bytes() {
+fn bytes_get_method_returns_option() {
     let repo = repo_root();
     let stdout = run_hew_source(
         &repo,
         "bytes_get_method",
         r#"
-        import std::io;
-
         fn main() {
             var b: bytes = bytes::new();
             b.push(200);
             b.push(1);
-            let high = b.get(0);
-            let low = b.get(1);
-            print(high);
-            print(low);
-            if high == 200 {
-                if low == 1 {
-                    print("PASS");
-                }
+            match b.get(0) {
+                Some(high) => {
+                    if high == 200 {
+                        print("A");
+                    }
+                },
+                None => {
+                    print("x");
+                },
+            }
+            match b.get(1) {
+                Some(low) => {
+                    if low == 1 {
+                        print("B");
+                    }
+                },
+                None => {
+                    print("x");
+                },
+            }
+            match b.get(9) {
+                Some(_) => {
+                    print("x");
+                },
+                None => {
+                    print("C");
+                },
             }
         }
         "#,
     );
 
-    // 200 is a high byte (>127); the u8 runtime return must zero-extend to i32
-    // as 200, not sign-extend to a negative value.
-    assert_eq!(stdout, "2001PASS");
+    // A = Some(200) with the high byte preserved (not sign-extended);
+    // B = Some(1); C = None for the out-of-bounds index 9.
+    assert_eq!(stdout, "ABC");
 }

--- a/hew-hir/src/stdlib_catalog.rs
+++ b/hew-hir/src/stdlib_catalog.rs
@@ -990,15 +990,19 @@ pub const CATALOG: &[BuiltinEntry] = &[
         BuiltinTy::Unit,
         BuiltinLinkage::CalleeNameDispatchOnly,
     ),
-    // `bytes.get(index)` — element load over the `BytesTriple` representation.
-    // A `bytes` value is a `{ptr, offset, len}` triple, NOT a `*mut HewVec`, so
-    // it routes to the dedicated `hew_bytes_index(ptr, offset, len, index) -> u8`
-    // runtime entry (the same getter the `b[i]` indexing sugar uses) rather than
-    // the Vec element getter `hew_vec_get_i32`. `CalleeNameDispatchOnly`: the MIR
-    // producer arm and the codegen `hew_bytes_index` arm unpack the single triple
-    // operand into the runtime's (ptr, offset, len) args and store the u8 result.
+    // `bytes.get(index) -> Option<u8>` — the non-trapping `Index::get` accessor,
+    // de-aliased from the trapping `b[i]` sugar (`hew_bytes_index`). This row
+    // exists only to REGISTER the `hew_bytes_get` symbol name so the HIR
+    // method-call rewrite resolves at the import boundary; `CalleeNameDispatchOnly`
+    // means the params/return here are NOT consulted by typecheck — checker
+    // authority drives the `Option<u8>` result type (read from `expr_types` at
+    // the `RewriteToFunction` lowering site). `hew_bytes_get` carries no runtime
+    // export: the MIR producer arm emits a `Terminator::Call` and codegen
+    // intercepts the callee, bounds-checks the `BytesTriple`, and materialises
+    // `Some(byte)` / `None`. (`U8` below is the element class, not the wrapped
+    // return — there is no `BuiltinTy::Option`.)
     direct(
-        "hew_bytes_index",
+        "hew_bytes_get",
         BuiltinClass::ClassA,
         BYTES_I64,
         BuiltinTy::U8,

--- a/hew-hir/src/stdlib_catalog.rs
+++ b/hew-hir/src/stdlib_catalog.rs
@@ -1008,6 +1008,25 @@ pub const CATALOG: &[BuiltinEntry] = &[
         BuiltinTy::U8,
         BuiltinLinkage::CalleeNameDispatchOnly,
     ),
+    // `string.get(index) -> Option<char>` — the non-trapping `Index::get`
+    // accessor, de-aliased from the trapping `s[i]` sugar (`hew_string_index`).
+    // This row exists only to REGISTER the `hew_string_get` symbol name so the
+    // HIR method-call rewrite resolves at the import boundary;
+    // `CalleeNameDispatchOnly` means the params/return here are NOT consulted by
+    // typecheck — checker authority drives the `Option<char>` result type (read
+    // from `expr_types` at the `RewriteToFunction` lowering site).
+    // `hew_string_get` carries no runtime export: the MIR producer arm emits a
+    // `Terminator::Call` and codegen intercepts the callee, bounds-checks the
+    // index against `hew_string_char_count`, and materialises `Some(char)` /
+    // `None`. (`Char` below is the element class, not the wrapped return — there
+    // is no `BuiltinTy::Option`.)
+    direct(
+        "hew_string_get",
+        BuiltinClass::ClassA,
+        STRING_I64,
+        BuiltinTy::Char,
+        BuiltinLinkage::CalleeNameDispatchOnly,
+    ),
     direct(
         "hew_vec_push_bool",
         BuiltinClass::ClassA,

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -18820,6 +18820,7 @@ impl Builder {
             "hew_bytes_push" => self.lower_bytes_push(hir_args, site, context),
             "hew_vec_len" => self.lower_bytes_len(hir_args, site, context),
             "hew_bytes_get" => self.lower_bytes_get_option(hir_args, site, context, result_ty),
+            "hew_string_get" => self.lower_string_get_option(hir_args, site, context, result_ty),
             "hew_string_char_count" => self.lower_string_char_count(hir_args, site, context),
             "hew_observe_read_u64"
             | "hew_observe_scrape"
@@ -19011,8 +19012,73 @@ impl Builder {
         Some(result)
     }
 
-    /// Emit `hew_string_char_count(s) -> i32`, widened to the Hew-facing `i64`.
+    /// Lower `string.get(index) -> Option<char>` to a single `Terminator::Call`
+    /// to the codegen-intercepted `hew_string_get` symbol.
     ///
+    /// Mirrors the bytes `.get` shape — the symbol carries no runtime export
+    /// (`builtin: None`): codegen bounds-checks the index against
+    /// `hew_string_char_count` and materialises `Some(char)` / `None` over the
+    /// in-bounds `hew_string_index` codepoint load.
+    ///
+    /// The receiver is BORROWED, not consumed — `hew_string_get` is listed in
+    /// `is_collection_receiver_borrow_callee`, so `s` keeps its scope-exit drop.
+    /// The `char` element is a scalar (Copy): the `Some` payload is a by-value
+    /// codepoint with no owned clone, so drop-safety is trivial.
+    fn lower_string_get_option(
+        &mut self,
+        hir_args: &[hew_hir::HirExpr],
+        site: hew_hir::SiteId,
+        context: RuntimeCallContext,
+        result_ty: Option<&ResolvedTy>,
+    ) -> Option<Place> {
+        if hir_args.len() != 2 {
+            self.diagnostics.push(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: "runtime call `hew_string_get` arity".to_string(),
+                    site,
+                },
+                note: format!(
+                    "`hew_string_get` (string.get) expects 2 arguments (receiver, index), got {}",
+                    hir_args.len()
+                ),
+            });
+            return None;
+        }
+        // The checker types `s.get(i)` as `Option<char>`; size the dest enum slot
+        // with that exact type so codegen resolves the registered Option layout
+        // (`checker-authority`: consume the recorded type, never re-infer it).
+        let Some(opt_ty) = result_ty else {
+            self.diagnostics.push(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: "runtime call `hew_string_get` result type".to_string(),
+                    site,
+                },
+                note: "`hew_string_get` (string.get) needs the checker-recorded \
+                       `Option<char>` result type to size its dest slot"
+                    .to_string(),
+            });
+            return None;
+        };
+        let s = self.lower_value(&hir_args[0])?;
+        let idx = self.lower_value(&hir_args[1])?;
+        // Always materialise the Option; the bounds-check CFG lives in codegen.
+        // A discarded result is a dead local the optimiser elides, but the Call
+        // terminator still needs a dest + a `next` block to continue into.
+        let result = self.alloc_local(opt_ty.clone());
+        let next = self.alloc_block();
+        self.finish_current_block(Terminator::Call {
+            callee: "hew_string_get".to_string(),
+            builtin: None,
+            args: vec![s, idx],
+            dest: Some(result),
+            next,
+        });
+        self.start_block(next);
+        let _ = context;
+        Some(result)
+    }
+
+    /// Emit `hew_string_char_count(s) -> i32`, widened to the Hew-facing `i64`.
     /// The runtime ABI returns i32, while the stdlib-facing
     /// `string.char_count_utf8()` declaration returns i64. Keep the call ABI
     /// honest by storing the runtime result in an i32 temporary and inserting

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -18819,7 +18819,7 @@ impl Builder {
             "hew_actor_unlink" => self.lower_actor_unlink(hir_args, site, context),
             "hew_bytes_push" => self.lower_bytes_push(hir_args, site, context),
             "hew_vec_len" => self.lower_bytes_len(hir_args, site, context),
-            "hew_bytes_index" => self.lower_bytes_get_u8(hir_args, site, context),
+            "hew_bytes_get" => self.lower_bytes_get_option(hir_args, site, context, result_ty),
             "hew_string_char_count" => self.lower_string_char_count(hir_args, site, context),
             "hew_observe_read_u64"
             | "hew_observe_scrape"
@@ -18943,41 +18943,72 @@ impl Builder {
         dest
     }
 
-    /// Emit `hew_bytes_index(buf, index) -> u8` for `bytes.get(index)` calls.
+    /// Emit `bytes.get(index) -> Option<u8>`, the non-trapping byte accessor.
     ///
-    /// The `impl bytes` extern block in `std/io.hew` declares `get` with
-    /// `#[extern_symbol(hew_bytes_index)]`. A `bytes` value is a
-    /// `BytesTriple { ptr, offset, len }`, NOT a `*mut HewVec`, so it routes to
-    /// the dedicated `hew_bytes_index(ptr, offset, len, index) -> u8` runtime
-    /// entry (the same getter the `b[i]` indexing sugar uses) rather than the
-    /// Vec element getter `hew_vec_get_i32(*mut HewVec, i64)`. The runtime
-    /// bounds-checks and aborts on OOB (boundary-fail-closed). The dest place
-    /// is typed `u8` matching the catalog and runtime ABI return type.
-    fn lower_bytes_get_u8(
+    /// De-aliased from the trapping `b[i]` sugar (`hew_bytes_index`, which
+    /// aborts on OOB): `.get` returns `None` out of bounds instead of trapping.
+    /// Mirrors the Vec/HashMap `.get` shape — a single `Terminator::Call` to a
+    /// codegen-intercepted symbol (`hew_bytes_get`) that owns the bounds-check
+    /// CFG and the `Some`/`None` materialisation. The symbol carries no runtime
+    /// export (`builtin: None`, like `hew_vec_get_clone`): codegen does the
+    /// check over the stack-resident `BytesTriple` and an in-bounds typed load.
+    ///
+    /// The receiver is BORROWED, not consumed — `hew_bytes_get` is listed in
+    /// `is_collection_receiver_borrow_callee`, so `buf` keeps its scope-exit
+    /// drop. The `u8` element is a scalar (Copy): the `Some` payload is a
+    /// by-value load with no owned clone, so drop-safety is trivial.
+    fn lower_bytes_get_option(
         &mut self,
         hir_args: &[hew_hir::HirExpr],
         site: hew_hir::SiteId,
         context: RuntimeCallContext,
+        result_ty: Option<&ResolvedTy>,
     ) -> Option<Place> {
         if hir_args.len() != 2 {
             self.diagnostics.push(MirDiagnostic {
                 kind: MirDiagnosticKind::NotYetImplemented {
-                    construct: "runtime call `hew_bytes_index` arity".to_string(),
+                    construct: "runtime call `hew_bytes_get` arity".to_string(),
                     site,
                 },
                 note: format!(
-                    "`hew_bytes_index` (bytes.get) expects 2 arguments (receiver, index), got {}",
+                    "`hew_bytes_get` (bytes.get) expects 2 arguments (receiver, index), got {}",
                     hir_args.len()
                 ),
             });
             return None;
         }
+        // The checker types `b.get(i)` as `Option<u8>`; size the dest enum slot
+        // with that exact type so codegen resolves the registered Option layout
+        // (`checker-authority`: consume the recorded type, never re-infer it).
+        let Some(opt_ty) = result_ty else {
+            self.diagnostics.push(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: "runtime call `hew_bytes_get` result type".to_string(),
+                    site,
+                },
+                note: "`hew_bytes_get` (bytes.get) needs the checker-recorded \
+                       `Option<u8>` result type to size its dest slot"
+                    .to_string(),
+            });
+            return None;
+        };
         let buf = self.lower_value(&hir_args[0])?;
         let idx = self.lower_value(&hir_args[1])?;
-        let dest =
-            (context == RuntimeCallContext::ValueNeeded).then(|| self.alloc_local(ResolvedTy::U8));
-        self.push_runtime_call("hew_bytes_index", vec![buf, idx], dest);
-        dest
+        // Always materialise the Option; the bounds-check CFG lives in codegen.
+        // A discarded result is a dead local the optimiser elides, but the Call
+        // terminator still needs a dest + a `next` block to continue into.
+        let result = self.alloc_local(opt_ty.clone());
+        let next = self.alloc_block();
+        self.finish_current_block(Terminator::Call {
+            callee: "hew_bytes_get".to_string(),
+            builtin: None,
+            args: vec![buf, idx],
+            dest: Some(result),
+            next,
+        });
+        self.start_block(next);
+        let _ = context;
+        Some(result)
     }
 
     /// Emit `hew_string_char_count(s) -> i32`, widened to the Hew-facing `i64`.
@@ -31972,6 +32003,14 @@ fn is_collection_receiver_borrow_callee(callee: &str) -> bool {
         callee,
         "hew_hashmap_insert_layout"
             | "hew_hashmap_get_layout"
+            // The non-trapping `b.get(i)` / `s.get(i)` read (`Index::get`)
+            // choke: reads the byte/codepoint at `i` and materialises
+            // `Some(v)` / `None` without ever freeing the receiver (`buf`/`s`
+            // is borrowed in place). Same receiver-borrow contract as the
+            // hashmap getters; classified here so `.get` does not exclude the
+            // bytes/string handle from its scope-exit release.
+            | "hew_bytes_get"
+            | "hew_string_get"
             // The trapping `m[k]` read (`Index::at`) choke: reads the table and
             // clones the matched value into the caller's out-slot, never freeing
             // the map (`m: *const HewLayoutHashMap`). Same receiver-borrow

--- a/hew-mir/src/runtime_symbols.rs
+++ b/hew-mir/src/runtime_symbols.rs
@@ -378,6 +378,13 @@ const MIR_EMITTER_RUNTIME_SYMBOLS: &[&str] = &[
     //   Fresh owned concatenation result. Emitted for `string + string`;
     //   drop-safety follows the existing `String` value-class discipline.
     "hew_string_concat",
+    // `hew_string_get` is the non-trapping `string.get(index) -> Option<char>`
+    //   accessor (de-aliased from the trapping `s[i]` `hew_string_index`). It
+    //   carries no runtime export: codegen intercepts the `Terminator::Call`
+    //   callee, bounds-checks the index against `hew_string_char_count`, and
+    //   materialises `Some(char)` / `None`. Listed here so the HIR method
+    //   rewrite routes through the `lower_runtime_call` producer.
+    "hew_string_get",
     // `hew_string_index(s, i) -> i32` (`hew-runtime/src/string.rs`).
     //   Codepoint at codepoint offset i; O(n). Aborts on null / invalid
     //   UTF-8 / negative / OOB. NO -1 sentinel. Emitted by the MIR

--- a/hew-mir/src/runtime_symbols.rs
+++ b/hew-mir/src/runtime_symbols.rs
@@ -117,6 +117,13 @@ const MIR_EMITTER_RUNTIME_SYMBOLS: &[&str] = &[
     // compiler emits this immediately AFTER the access completes.
     "hew_auto_mutex_unlock",
     // --- Bytes value index/slice substrate (W3 collections-sugar S2) --------
+    // `hew_bytes_get` is the non-trapping `bytes.get(index) -> Option<u8>`
+    //   accessor (de-aliased from the trapping `b[i]` `hew_bytes_index`). It
+    //   carries no runtime export: codegen intercepts the `Terminator::Call`
+    //   callee, performs the bounds check over the stack triple, and
+    //   materialises `Some(byte)` / `None`. Listed here so the HIR method
+    //   rewrite routes through the `lower_runtime_call` producer.
+    "hew_bytes_get",
     // `hew_bytes_index(ptr, offset, len, index) -> u8`
     //   (`hew-runtime/src/bytes.rs`). O(1) byte load over a (ptr,offset,len)
     //   `BytesTriple`. Aborts on negative index or index >= len. Emitted by

--- a/hew-mir/tests/bytes_runtime_call_producer.rs
+++ b/hew-mir/tests/bytes_runtime_call_producer.rs
@@ -1,19 +1,18 @@
 //! MIR producer tests for `bytes.len()` and `bytes.get()` runtime calls.
 //!
 //! `bytes.len()` and `bytes.get(i)` are declared in `std/io.hew`'s
-//! `impl bytes` extern block with `#[extern_symbol(hew_vec_len)]` and
-//! `#[extern_symbol(hew_bytes_index)]`. After HIR lowers the method call
-//! the callee becomes `BindingRef { name: "hew_vec_len" | "hew_bytes_index",
-//! resolved: Unresolved }`, which `runtime_symbol_for_call_expr` recognises
-//! as an allowlisted symbol and routes to `lower_runtime_call`.
+//! `impl bytes` extern block. `len` binds `#[extern_symbol(hew_vec_len)]` and
+//! lowers to an `Instr::CallRuntimeAbi(hew_vec_len)`. `get` binds
+//! `#[extern_symbol(hew_bytes_get)]` returning `Option<u8>`; it lowers to a
+//! `Terminator::Call { callee: "hew_bytes_get", dest: Some(Option<u8>) }` whose
+//! callee codegen intercepts to build `Some(byte)` in bounds / `None` out of
+//! bounds (the trapping `b[i]` half stays on the dedicated `hew_bytes_index`
+//! getter — `get` is de-aliased from it).
 //!
-//! `bytes.get` uses `hew_bytes_index` (not `hew_vec_get_i32`): a `bytes` value
-//! is a `BytesTriple { ptr, offset, len }`, so element loads route to the
-//! dedicated bytes getter rather than the heap-Vec element getter.
-//!
-//! Before the fix these both fell into the `_ =>` NYI arm and produced
-//! `MirDiagnosticKind::NotYetImplemented`. These tests assert the producer
-//! arms now exist and emit `Instr::CallRuntimeAbi` without diagnostics.
+//! After HIR lowers the method call the callee becomes
+//! `BindingRef { name, resolved: Unresolved }`, which
+//! `runtime_symbol_for_call_expr` recognises as an allowlisted symbol and
+//! routes to `lower_runtime_call`.
 
 use std::collections::HashMap;
 
@@ -21,7 +20,7 @@ use hew_hir::{
     ids::IdGen, HirBinding, HirBlock, HirExpr, HirExprKind, HirFn, HirItem, HirLiteral, HirModule,
     HirStmt, HirStmtKind, IntentKind, ResolvedRef, ScopeId, ValueClass,
 };
-use hew_mir::{lower_hir_module, Instr, Place};
+use hew_mir::{lower_hir_module, Instr, Place, Terminator};
 use hew_types::ResolvedTy;
 
 fn empty_module(items: Vec<HirItem>) -> HirModule {
@@ -166,6 +165,27 @@ fn find_abi_call<'a>(
         })
 }
 
+/// `Option<u8>` — the de-aliased `bytes.get` return type.
+fn option_u8_ty() -> ResolvedTy {
+    ResolvedTy::Named {
+        name: "Option".to_string(),
+        args: vec![ResolvedTy::U8],
+        builtin: None,
+        is_opaque: false,
+    }
+}
+
+/// Find the first `Terminator::Call` whose callee matches `callee`.
+fn find_terminator_call<'a>(
+    func: &'a hew_mir::RawMirFunction,
+    callee: &str,
+) -> Option<&'a Terminator> {
+    func.blocks
+        .iter()
+        .map(|b| &b.terminator)
+        .find(|t| matches!(t, Terminator::Call { callee: c, .. } if c == callee))
+}
+
 // ---------------------------------------------------------------------------
 // bytes.len() — hew_vec_len producer
 // ---------------------------------------------------------------------------
@@ -295,23 +315,22 @@ fn bytes_len_value_needed_emits_i64_dest() {
 }
 
 // ---------------------------------------------------------------------------
-// bytes.get(i) — hew_bytes_index producer
+// bytes.get(i) — hew_bytes_get producer (Option<u8>, de-aliased from b[i])
 // ---------------------------------------------------------------------------
 
-/// `bytes.get(index)` in statement position must emit
-/// `CallRuntimeAbi { symbol: "hew_bytes_index", args: [buf, idx], dest: None }`.
-///
-/// A `bytes` value is a `BytesTriple { ptr, offset, len }`, NOT a `*mut HewVec`,
-/// so `bytes.get` routes to the dedicated `hew_bytes_index` getter (the same
-/// runtime entry the `b[i]` indexing sugar uses) rather than the Vec element
-/// getter `hew_vec_get_i32` (whose arg0 ABI is a heap-Vec `ptr`).
+/// `bytes.get(index)` lowers to a `Terminator::Call` whose callee is the
+/// synthetic `hew_bytes_get` (codegen intercepts it to build the `Option<u8>`),
+/// carrying the two producer args `[buf, idx]`. It is NOT an
+/// `Instr::CallRuntimeAbi`: the result is an `Option`, constructed at the call
+/// site, so the call rides the terminator route the move/borrow/drop analyses
+/// already understand for Vec/HashMap `.get`.
 #[test]
-fn bytes_get_discarded_emits_call_runtime_abi() {
+fn bytes_get_emits_terminator_call_to_hew_bytes_get() {
     let mut ids = IdGen::default();
-    let callee = runtime_callee(&mut ids, "hew_bytes_index", ResolvedTy::I32);
+    let callee = runtime_callee(&mut ids, "hew_bytes_get", option_u8_ty());
     let buf = bytes_lit(&mut ids);
     let idx = i64_lit(&mut ids);
-    let call = call_expr(&mut ids, callee, vec![buf, idx], ResolvedTy::I32);
+    let call = call_expr(&mut ids, callee, vec![buf, idx], option_u8_ty());
     let module = module_with_stmt(&mut ids, call);
 
     let pipeline = lower_hir_module(&module);
@@ -320,39 +339,40 @@ fn bytes_get_discarded_emits_call_runtime_abi() {
         pipeline.diagnostics.iter().all(|d| !matches!(
             &d.kind,
             hew_mir::MirDiagnosticKind::NotYetImplemented { construct, .. }
-                if construct.contains("hew_bytes_index")
+                if construct.contains("hew_bytes_get")
         )),
-        "bytes.get() in discarded position must not produce NYI; diagnostics: {:#?}",
+        "bytes.get() must not produce NYI; diagnostics: {:#?}",
         pipeline.diagnostics
     );
 
     let func = find_probe(&pipeline);
-    let call = find_abi_call(func, "hew_bytes_index")
-        .expect("bytes.get() must emit Instr::CallRuntimeAbi(hew_bytes_index)");
-
-    assert_eq!(
-        call.args().len(),
-        2,
-        "hew_bytes_index takes 2 producer args (bytes receiver, index); got {:?}",
-        call.args()
-    );
     assert!(
-        call.dest().is_none(),
-        "discarded bytes.get() must have dest=None; got {:?}",
-        call.dest()
+        find_abi_call(func, "hew_bytes_get").is_none(),
+        "bytes.get() must NOT emit Instr::CallRuntimeAbi — it rides Terminator::Call"
+    );
+
+    let term = find_terminator_call(func, "hew_bytes_get")
+        .expect("bytes.get() must emit Terminator::Call(hew_bytes_get)");
+    let Terminator::Call { args, .. } = term else {
+        unreachable!("find_terminator_call returns only Terminator::Call");
+    };
+    assert_eq!(
+        args.len(),
+        2,
+        "hew_bytes_get takes 2 producer args (bytes receiver, index); got {args:?}"
     );
 }
 
-/// `bytes.get(i)` in value-needed context allocates a `u8` dest local: the
-/// typed runtime-call catalog carries `hew_bytes_index`'s real C return type
-/// (`u8`), and the dest follows the catalog rather than a pre-widened `i32`.
+/// `bytes.get(i)` in value-needed context allocates an `Option<u8>` dest local:
+/// the de-aliased getter returns `Option<u8>` (the `Some`/`None` is built at the
+/// call site by codegen), so the dest follows that type rather than a bare `u8`.
 #[test]
-fn bytes_get_value_needed_emits_u8_dest() {
+fn bytes_get_value_needed_dest_is_option_u8() {
     let mut ids = IdGen::default();
-    let callee = runtime_callee(&mut ids, "hew_bytes_index", ResolvedTy::I32);
+    let callee = runtime_callee(&mut ids, "hew_bytes_get", option_u8_ty());
     let buf = bytes_lit(&mut ids);
     let idx = i64_lit(&mut ids);
-    let rhs = call_expr(&mut ids, callee, vec![buf, idx], ResolvedTy::I32);
+    let rhs = call_expr(&mut ids, callee, vec![buf, idx], option_u8_ty());
 
     let binding_id = ids.binding();
     let let_stmt = HirStmt {
@@ -361,7 +381,7 @@ fn bytes_get_value_needed_emits_u8_dest() {
             HirBinding {
                 id: binding_id,
                 name: "_b".to_string(),
-                ty: ResolvedTy::I32,
+                ty: option_u8_ty(),
                 mutable: false,
                 span: 0..0,
             },
@@ -401,29 +421,31 @@ fn bytes_get_value_needed_emits_u8_dest() {
         pipeline.diagnostics.iter().all(|d| !matches!(
             &d.kind,
             hew_mir::MirDiagnosticKind::NotYetImplemented { construct, .. }
-                if construct.contains("hew_bytes_index")
+                if construct.contains("hew_bytes_get")
         )),
         "bytes.get() in value-needed position must not produce NYI; diagnostics: {:#?}",
         pipeline.diagnostics
     );
 
     let func = find_probe(&pipeline);
-    let call = find_abi_call(func, "hew_bytes_index")
-        .expect("bytes.get() in value-needed context must emit hew_bytes_index CallRuntimeAbi");
-
-    let dest = call
-        .dest()
-        .expect("value-needed bytes.get() must carry a dest local");
+    let term = find_terminator_call(func, "hew_bytes_get")
+        .expect("value-needed bytes.get() must emit Terminator::Call(hew_bytes_get)");
+    let Terminator::Call { dest, .. } = term else {
+        unreachable!("find_terminator_call returns only Terminator::Call");
+    };
+    let dest = dest
+        .as_ref()
+        .expect("value-needed bytes.get() must carry a dest place");
     let Place::Local(dest_idx) = dest else {
         panic!("dest must be Local; got {dest:?}");
     };
     let dest_ty = func
         .locals
-        .get(dest_idx as usize)
+        .get(*dest_idx as usize)
         .expect("dest local must be in locals table");
     assert_eq!(
         *dest_ty,
-        ResolvedTy::U8,
-        "bytes.get() dest local must follow the catalog return type u8; got {dest_ty:?}"
+        option_u8_ty(),
+        "bytes.get() dest local must be typed Option<u8>; got {dest_ty:?}"
     );
 }

--- a/hew-types/src/runtime_call.rs
+++ b/hew-types/src/runtime_call.rs
@@ -409,6 +409,7 @@ pub enum RuntimeCallFamily {
     // --- String runtime helpers --------------------------------------------
     StringCharCount,
     StringConcat,
+    StringGet,
     StringIndex,
     StringSliceCodepoints,
 
@@ -635,6 +636,7 @@ impl RuntimeCallFamily {
             // String
             Self::StringCharCount => "hew_string_char_count",
             Self::StringConcat => "hew_string_concat",
+            Self::StringGet => "hew_string_get",
             Self::StringIndex => "hew_string_index",
             Self::StringSliceCodepoints => "hew_string_slice_codepoints",
             // Supervisor
@@ -872,6 +874,7 @@ impl RuntimeCallFamily {
             // String
             "hew_string_char_count" => Self::StringCharCount,
             "hew_string_concat" => Self::StringConcat,
+            "hew_string_get" => Self::StringGet,
             "hew_string_index" => Self::StringIndex,
             "hew_string_slice_codepoints" => Self::StringSliceCodepoints,
             // Supervisor
@@ -1107,6 +1110,7 @@ impl RuntimeCallFamily {
             | F::SendHalfTrySend
             | F::StringCharCount
             | F::StringConcat
+            | F::StringGet
             | F::StringIndex
             | F::StringSliceCodepoints
             | F::SupervisorChildGet

--- a/hew-types/src/runtime_call.rs
+++ b/hew-types/src/runtime_call.rs
@@ -173,7 +173,8 @@ pub enum RuntimeCallFamily {
     AutoMutexLock,
     AutoMutexUnlock,
 
-    // --- Bytes value index/length/slice/push --------------------------------
+    // --- Bytes value get/index/length/slice/push ----------------------------
+    BytesGet,
     BytesIndex,
     BytesLen,
     BytesPush,
@@ -484,6 +485,7 @@ impl RuntimeCallFamily {
             Self::AutoMutexLock => "hew_auto_mutex_lock",
             Self::AutoMutexUnlock => "hew_auto_mutex_unlock",
             // Bytes
+            Self::BytesGet => "hew_bytes_get",
             Self::BytesIndex => "hew_bytes_index",
             Self::BytesLen => "hew_bytes_len",
             Self::BytesPush => "hew_bytes_push",
@@ -721,6 +723,7 @@ impl RuntimeCallFamily {
             "hew_auto_mutex_lock" => Self::AutoMutexLock,
             "hew_auto_mutex_unlock" => Self::AutoMutexUnlock,
             // Bytes
+            "hew_bytes_get" => Self::BytesGet,
             "hew_bytes_index" => Self::BytesIndex,
             "hew_bytes_len" => Self::BytesLen,
             "hew_bytes_push" => Self::BytesPush,
@@ -1017,6 +1020,7 @@ impl RuntimeCallFamily {
             | F::AutoMutexFree
             | F::AutoMutexLock
             | F::AutoMutexUnlock
+            | F::BytesGet
             | F::BytesIndex
             | F::BytesLen
             | F::BytesPush

--- a/hew-types/tests/checked_mir_corpus_coverage.rs
+++ b/hew-types/tests/checked_mir_corpus_coverage.rs
@@ -138,6 +138,11 @@ const EXPECTED_UNCOVERED: &[&str] = &[
     "hew_regex_compile",
     "hew_regex_free_capture",
     "hew_string_char_count",
+    // -- `string.get` lowers to a `Terminator::Call` whose callee codegen
+    //    intercepts to build `Option<char>`; the call carries the callee as a
+    //    string (`builtin: None`), so the `StringGet` family is a descriptor
+    //    row only and never renders as `family: StringGet` in the corpus.
+    "hew_string_get",
     // -- Layout-witness entry with no probed source producer: bytes
     //    sends ride hew_sink_write_bytes and string pipe sends ride
     //    hew_sink_write_string, so no surface emits the stream send

--- a/hew-types/tests/checked_mir_corpus_coverage.rs
+++ b/hew-types/tests/checked_mir_corpus_coverage.rs
@@ -108,6 +108,11 @@ const EXPECTED_UNCOVERED: &[&str] = &[
     "hew_send_half_send",
     "hew_send_half_try_send",
     "hew_supervisor_nested_get",
+    // -- `bytes.get` lowers to a `Terminator::Call` whose callee codegen
+    //    intercepts to build `Option<u8>`; the call carries the callee as a
+    //    string (`builtin: None`), so the `BytesGet` family is a descriptor
+    //    row only and never renders as `family: BytesGet` in the corpus.
+    "hew_bytes_get",
     // -- No user-facing surface lowers to the catalogued symbol today
     //    (probed: `bytes.len()` routes through `hew_vec_len`; no
     //    `char_count` string method; no Instant/Duration value surface;

--- a/hew-types/tests/declarative_string_bytes_ffi_differential.rs
+++ b/hew-types/tests/declarative_string_bytes_ffi_differential.rs
@@ -92,7 +92,7 @@ fn bytes_methods_resolve_through_std_io_extern_symbols() {
             buf.push(65);
             let _: u8 = buf.pop();
             let _: i64 = buf.len();
-            let _: u8 = buf.get(0);
+            let _: Option<u8> = buf.get(0);
             buf.set(0, 66);
             let _: bool = buf.is_empty();
             buf.clear();
@@ -112,9 +112,10 @@ fn bytes_methods_resolve_through_std_io_extern_symbols() {
         "hew_bytes_push",
         "hew_vec_pop_i32",
         "hew_vec_len",
-        // `bytes.get` routes to the dedicated `hew_bytes_index` getter (the
-        // BytesTriple element load), NOT the heap-Vec getter `hew_vec_get_i32`.
-        "hew_bytes_index",
+        // `bytes.get` routes to the dedicated `hew_bytes_get` getter, which
+        // returns `Option<u8>` — de-aliased from the trapping index getter
+        // `hew_bytes_index` that backs `buf[i]`.
+        "hew_bytes_get",
         "hew_vec_set_i32",
         "hew_vec_is_empty",
         "hew_vec_clear",

--- a/hew-types/tests/declarative_string_bytes_ffi_differential.rs
+++ b/hew-types/tests/declarative_string_bytes_ffi_differential.rs
@@ -43,6 +43,7 @@ fn string_methods_resolve_through_std_string_extern_symbols() {
             let _: string = s.slice(0, 1);
             let _: string = s.repeat(2);
             let _: i64 = s.char_at(0);
+            let _: Option<char> = s.get(0);
             let _: Vec<char> = s.chars();
             let _: bytes = s.to_bytes();
         }
@@ -74,6 +75,7 @@ fn string_methods_resolve_through_std_string_extern_symbols() {
         "hew_string_slice",
         "hew_string_repeat",
         "hew_string_char_at",
+        "hew_string_get",
         "hew_string_chars",
         "hew_string_to_bytes",
     ] {

--- a/std/encoding/base64/base64.hew
+++ b/std/encoding/base64/base64.hew
@@ -60,10 +60,10 @@ pub fn decode(s: string) -> bytes {
     let nvals = vals.len();
     var i = 0;
     while i + 4 <= nvals {
-        let a = vals.get(i);
-        let b = vals.get(i + 1);
-        let c = vals.get(i + 2);
-        let d = vals.get(i + 3);
+        let a = vals[i];
+        let b = vals[i + 1];
+        let c = vals[i + 2];
+        let d = vals[i + 3];
         out.push(a << 2 | b >> 4);
         out.push((b & 15) << 4 | c >> 2);
         out.push((c & 3) << 6 | d);
@@ -72,13 +72,13 @@ pub fn decode(s: string) -> bytes {
     // Handle remaining values (from stripped padding)
     let remaining = nvals - i;
     if remaining == 2 {
-        let a = vals.get(i);
-        let b = vals.get(i + 1);
+        let a = vals[i];
+        let b = vals[i + 1];
         out.push(a << 2 | b >> 4);
     } else if remaining == 3 {
-        let a = vals.get(i);
-        let b = vals.get(i + 1);
-        let c = vals.get(i + 2);
+        let a = vals[i];
+        let b = vals[i + 1];
+        let c = vals[i + 2];
         out.push(a << 2 | b >> 4);
         out.push((b & 15) << 4 | c >> 2);
     }
@@ -119,9 +119,9 @@ fn encode_impl(data: bytes, url_safe: bool) -> string {
     var i = 0;
     // Process complete 3-byte groups
     while i + 3 <= dlen {
-        let a = data.get(i);
-        let b = data.get(i + 1);
-        let c = data.get(i + 2);
+        let a = data[i];
+        let b = data[i + 1];
+        let c = data[i + 2];
         out.push(b64_char(a as i32 >> 2, url_safe) as u8);
         out.push(b64_char((a as i32 & 3) << 4 | b as i32 >> 4, url_safe) as u8);
         out.push(b64_char((b as i32 & 15) << 2 | c as i32 >> 6, url_safe) as u8);
@@ -131,14 +131,14 @@ fn encode_impl(data: bytes, url_safe: bool) -> string {
     // Handle remaining bytes (always pad with '=')
     let remaining = dlen - i;
     if remaining == 1 {
-        let a = data.get(i);
+        let a = data[i];
         out.push(b64_char(a as i32 >> 2, url_safe) as u8);
         out.push(b64_char((a as i32 & 3) << 4, url_safe) as u8);
         out.push(61); // '='
         out.push(61);
     } else if remaining == 2 {
-        let a = data.get(i);
-        let b = data.get(i + 1);
+        let a = data[i];
+        let b = data[i + 1];
         out.push(b64_char(a as i32 >> 2, url_safe) as u8);
         out.push(b64_char((a as i32 & 3) << 4 | b as i32 >> 4, url_safe) as u8);
         out.push(b64_char((b as i32 & 15) << 2, url_safe) as u8);

--- a/std/encoding/binary/binary.hew
+++ b/std/encoding/binary/binary.hew
@@ -149,8 +149,8 @@ pub fn put_i64_be(v: i64) -> bytes {
 ///
 /// Aborts if `buf.len() < 2`.
 pub fn get_u16_le(buf: bytes) -> i64 {
-    let b0 = buf.get(0) as i64;
-    let b1 = buf.get(1) as i64;
+    let b0 = buf[0] as i64;
+    let b1 = buf[1] as i64;
     b0 | b1 << 8
 }
 
@@ -159,10 +159,10 @@ pub fn get_u16_le(buf: bytes) -> i64 {
 ///
 /// Aborts if `buf.len() < 4`.
 pub fn get_u32_le(buf: bytes) -> i64 {
-    let b0 = buf.get(0) as i64;
-    let b1 = buf.get(1) as i64;
-    let b2 = buf.get(2) as i64;
-    let b3 = buf.get(3) as i64;
+    let b0 = buf[0] as i64;
+    let b1 = buf[1] as i64;
+    let b2 = buf[2] as i64;
+    let b3 = buf[3] as i64;
     b0 | b1 << 8 | b2 << 16 | b3 << 24
 }
 
@@ -170,14 +170,14 @@ pub fn get_u32_le(buf: bytes) -> i64 {
 ///
 /// Aborts if `buf.len() < 8`.
 pub fn get_u64_le(buf: bytes) -> i64 {
-    let b0 = buf.get(0) as i64;
-    let b1 = buf.get(1) as i64;
-    let b2 = buf.get(2) as i64;
-    let b3 = buf.get(3) as i64;
-    let b4 = buf.get(4) as i64;
-    let b5 = buf.get(5) as i64;
-    let b6 = buf.get(6) as i64;
-    let b7 = buf.get(7) as i64;
+    let b0 = buf[0] as i64;
+    let b1 = buf[1] as i64;
+    let b2 = buf[2] as i64;
+    let b3 = buf[3] as i64;
+    let b4 = buf[4] as i64;
+    let b5 = buf[5] as i64;
+    let b6 = buf[6] as i64;
+    let b7 = buf[7] as i64;
     b0 | b1 << 8 | b2 << 16 | b3 << 24 | b4 << 32 | b5 << 40 | b6 << 48 | b7 << 56
 }
 
@@ -187,8 +187,8 @@ pub fn get_u64_le(buf: bytes) -> i64 {
 ///
 /// Aborts if `buf.len() < 2`.
 pub fn get_u16_be(buf: bytes) -> i64 {
-    let b0 = buf.get(0) as i64;
-    let b1 = buf.get(1) as i64;
+    let b0 = buf[0] as i64;
+    let b1 = buf[1] as i64;
     b0 << 8 | b1
 }
 
@@ -197,10 +197,10 @@ pub fn get_u16_be(buf: bytes) -> i64 {
 ///
 /// Aborts if `buf.len() < 4`.
 pub fn get_u32_be(buf: bytes) -> i64 {
-    let b0 = buf.get(0) as i64;
-    let b1 = buf.get(1) as i64;
-    let b2 = buf.get(2) as i64;
-    let b3 = buf.get(3) as i64;
+    let b0 = buf[0] as i64;
+    let b1 = buf[1] as i64;
+    let b2 = buf[2] as i64;
+    let b3 = buf[3] as i64;
     b0 << 24 | b1 << 16 | b2 << 8 | b3
 }
 
@@ -208,14 +208,14 @@ pub fn get_u32_be(buf: bytes) -> i64 {
 ///
 /// Aborts if `buf.len() < 8`.
 pub fn get_u64_be(buf: bytes) -> i64 {
-    let b0 = buf.get(0) as i64;
-    let b1 = buf.get(1) as i64;
-    let b2 = buf.get(2) as i64;
-    let b3 = buf.get(3) as i64;
-    let b4 = buf.get(4) as i64;
-    let b5 = buf.get(5) as i64;
-    let b6 = buf.get(6) as i64;
-    let b7 = buf.get(7) as i64;
+    let b0 = buf[0] as i64;
+    let b1 = buf[1] as i64;
+    let b2 = buf[2] as i64;
+    let b3 = buf[3] as i64;
+    let b4 = buf[4] as i64;
+    let b5 = buf[5] as i64;
+    let b6 = buf[6] as i64;
+    let b7 = buf[7] as i64;
     b0 << 56 | b1 << 48 | b2 << 40 | b3 << 32 | b4 << 24 | b5 << 16 | b6 << 8 | b7
 }
 

--- a/std/encoding/hex/hex.hew
+++ b/std/encoding/hex/hex.hew
@@ -59,7 +59,7 @@ pub fn decode(s: string) -> bytes {
 fn encode_impl(data: bytes, upper: bool) -> string {
     let out: bytes = bytes::new();
     for i in 0 .. data.len() {
-        let b = data.get(i);
+        let b = data[i];
         let hi = b as i32 / 16;
         let lo = b as i32 % 16;
         out.push(nibble_to_char(hi, upper) as u8);

--- a/std/encoding/wire/wire.hew
+++ b/std/encoding/wire/wire.hew
@@ -51,10 +51,10 @@ pub fn decode_header(buffer: bytes) -> i64 {
     if !validate_header(buffer) {
         return -1;
     }
-    let b0 = buffer.get(6);
-    let b1 = buffer.get(7);
-    let b2 = buffer.get(8);
-    let b3 = buffer.get(9);
+    let b0 = buffer[6];
+    let b1 = buffer[7];
+    let b2 = buffer[8];
+    let b3 = buffer[9];
     // Reconstruct little-endian u32 as i64. Operands are cast to i64 before
     // arithmetic to prevent i32 overflow at the high byte (b3 * 16777216 can
     // exceed i32::MAX when b3 >= 128). This also fixes the latent overflow bug
@@ -70,24 +70,24 @@ pub fn validate_header(buffer: bytes) -> bool {
         return false;
     }
     // Check magic "HEW1"
-    if buffer.get(0) != 72 {
+    if buffer[0] != 72 {
         return false;
     }
-    if buffer.get(1) != 69 {
+    if buffer[1] != 69 {
         return false;
     }
-    if buffer.get(2) != 87 {
+    if buffer[2] != 87 {
         return false;
     }
-    if buffer.get(3) != 49 {
+    if buffer[3] != 49 {
         return false;
     }
     // Check version
-    if buffer.get(4) != 1 {
+    if buffer[4] != 1 {
         return false;
     }
     // Check flags (only bit 0 allowed)
-    if (buffer.get(5) & 254) != 0 {
+    if (buffer[5] & 254) != 0 {
         return false;
     }
     true

--- a/std/io.hew
+++ b/std/io.hew
@@ -64,9 +64,9 @@ impl bytes {
     fn len(buf: bytes) -> i64 {
         0
     }
-    #[extern_symbol(hew_bytes_index)]
-    fn get(buf: bytes, index: i64) -> u8 {
-        0
+    #[extern_symbol(hew_bytes_get)]
+    fn get(buf: bytes, index: i64) -> Option<u8> {
+        None
     }
     #[extern_symbol(hew_vec_set_i32)]
     fn set(buf: bytes, index: i64, byte: u8) {}

--- a/std/string.hew
+++ b/std/string.hew
@@ -746,6 +746,13 @@ impl string {
     fn char_at(s: string, idx: i64) -> i64 {
         0
     }
+    /// Return the `char` at codepoint-index `index`, or `None` when the index
+    /// is out of bounds. This is the non-trapping `Index::get` accessor,
+    /// de-aliased from the trapping `s[i]` sugar (which aborts on OOB).
+    #[extern_symbol(hew_string_get)]
+    fn get(s: string, index: i64) -> Option<char> {
+        None
+    }
     #[extern_symbol(hew_string_chars)]
     fn chars(s: string) -> Vec<char> {
         Vec::new()

--- a/tests/fuzz-oracle/expected-failures.txt
+++ b/tests/fuzz-oracle/expected-failures.txt
@@ -21,7 +21,7 @@
 # map_literal_empty_annotated.hew, array_repeat_int_sum.hew, and
 # array_repeat_runtime_count.hew are intentionally absent: they must pass.
 #
-# Total: 17 known-failing entries (17 intentional-trap/abort fixtures).
+# Total: 18 known-failing entries (18 intentional-trap/abort fixtures).
 #
 # Intentional aborts/traps: fixtures in tests/vertical-slice/accept/ that are
 # designed to trap or abort at runtime as their correctness proof.  Listed here
@@ -32,6 +32,7 @@
 assert_eq_fail.hew       # intentional abort: assert_eq(2+2, 5) → SIGABRT; tests assertion failure propagation
 join_branch_trap.hew     # intentional abort: join branch trap propagates as SIGABRT (HEW-SPEC-2026 §4.11.2)
 string_slice_oob_panics.hew  # intentional abort: out-of-bounds string slice calls libc::abort()
+bytes_index_oob_traps.hew    # intentional abort: out-of-bounds bytes index b[i] calls libc::abort() → SIGABRT (signal 6)
 # Arch-dependent trap signals: SIGILL (132) on x86_64 Linux, SIGTRAP (133) on aarch64/macOS.
 isize_div_by_zero_traps.hew  # intentional trap: isize / 0 → DivideByZero signal (SIGILL x86_64 / SIGTRAP aarch64)
 isize_shift_oob_traps.hew    # intentional trap: isize << 64 → ShiftOutOfRange signal (SIGILL x86_64 / SIGTRAP aarch64)

--- a/tests/fuzz-oracle/expected-failures.txt
+++ b/tests/fuzz-oracle/expected-failures.txt
@@ -21,7 +21,7 @@
 # map_literal_empty_annotated.hew, array_repeat_int_sum.hew, and
 # array_repeat_runtime_count.hew are intentionally absent: they must pass.
 #
-# Total: 18 known-failing entries (18 intentional-trap/abort fixtures).
+# Total: 19 known-failing entries (19 intentional-trap/abort fixtures).
 #
 # Intentional aborts/traps: fixtures in tests/vertical-slice/accept/ that are
 # designed to trap or abort at runtime as their correctness proof.  Listed here
@@ -33,6 +33,7 @@ assert_eq_fail.hew       # intentional abort: assert_eq(2+2, 5) → SIGABRT; tes
 join_branch_trap.hew     # intentional abort: join branch trap propagates as SIGABRT (HEW-SPEC-2026 §4.11.2)
 string_slice_oob_panics.hew  # intentional abort: out-of-bounds string slice calls libc::abort()
 bytes_index_oob_traps.hew    # intentional abort: out-of-bounds bytes index b[i] calls libc::abort() → SIGABRT (signal 6)
+string_index_oob_traps.hew   # intentional abort: out-of-bounds string index s[i] calls libc::abort() → SIGABRT (signal 6)
 # Arch-dependent trap signals: SIGILL (132) on x86_64 Linux, SIGTRAP (133) on aarch64/macOS.
 isize_div_by_zero_traps.hew  # intentional trap: isize / 0 → DivideByZero signal (SIGILL x86_64 / SIGTRAP aarch64)
 isize_shift_oob_traps.hew    # intentional trap: isize << 64 → ShiftOutOfRange signal (SIGILL x86_64 / SIGTRAP aarch64)

--- a/tests/hew/base64_test.hew
+++ b/tests/hew/base64_test.hew
@@ -7,7 +7,7 @@ import std::testing;
 fn assert_bytes_eq(actual: bytes, expected: bytes) {
     testing.assert_eq(actual.len(), expected.len());
     for i in 0 .. expected.len() {
-        testing.assert_eq_u8(actual.get(i), expected.get(i));
+        testing.assert_eq_u8(actual[i], expected[i]);
     }
 }
 

--- a/tests/hew/binary_test.hew
+++ b/tests/hew/binary_test.hew
@@ -19,8 +19,8 @@ fn test_put_u16_le_known_pattern() {
     // 0x0102 in LE → [0x02, 0x01]
     let buf = binary.put_u16_le(0x102);
     testing.assert_eq(buf.len(), 2);
-    testing.assert_eq(buf.get(0) as i64, 0x2);
-    testing.assert_eq(buf.get(1) as i64, 0x1);
+    testing.assert_eq(buf[0] as i64, 0x2);
+    testing.assert_eq(buf[1] as i64, 0x1);
 }
 
 #[test]
@@ -41,8 +41,8 @@ fn test_put_u16_be_known_pattern() {
     // 0x0102 in BE → [0x01, 0x02]
     let buf = binary.put_u16_be(0x102);
     testing.assert_eq(buf.len(), 2);
-    testing.assert_eq(buf.get(0) as i64, 0x1);
-    testing.assert_eq(buf.get(1) as i64, 0x2);
+    testing.assert_eq(buf[0] as i64, 0x1);
+    testing.assert_eq(buf[1] as i64, 0x2);
 }
 
 #[test]
@@ -63,10 +63,10 @@ fn test_put_u32_le_known_pattern() {
     // 0x01020304 in LE → [0x04, 0x03, 0x02, 0x01]
     let buf = binary.put_u32_le(0x1020304);
     testing.assert_eq(buf.len(), 4);
-    testing.assert_eq(buf.get(0) as i64, 0x4);
-    testing.assert_eq(buf.get(1) as i64, 0x3);
-    testing.assert_eq(buf.get(2) as i64, 0x2);
-    testing.assert_eq(buf.get(3) as i64, 0x1);
+    testing.assert_eq(buf[0] as i64, 0x4);
+    testing.assert_eq(buf[1] as i64, 0x3);
+    testing.assert_eq(buf[2] as i64, 0x2);
+    testing.assert_eq(buf[3] as i64, 0x1);
 }
 
 #[test]
@@ -87,10 +87,10 @@ fn test_put_u32_be_known_pattern() {
     // 0x01020304 in BE → [0x01, 0x02, 0x03, 0x04]
     let buf = binary.put_u32_be(0x1020304);
     testing.assert_eq(buf.len(), 4);
-    testing.assert_eq(buf.get(0) as i64, 0x1);
-    testing.assert_eq(buf.get(1) as i64, 0x2);
-    testing.assert_eq(buf.get(2) as i64, 0x3);
-    testing.assert_eq(buf.get(3) as i64, 0x4);
+    testing.assert_eq(buf[0] as i64, 0x1);
+    testing.assert_eq(buf[1] as i64, 0x2);
+    testing.assert_eq(buf[2] as i64, 0x3);
+    testing.assert_eq(buf[3] as i64, 0x4);
 }
 
 #[test]
@@ -111,10 +111,10 @@ fn test_put_u64_le_known_pattern() {
     // 0x0102030405060708 in LE → [0x08, ..., 0x01]
     let buf = binary.put_u64_le(0x102030405060708);
     testing.assert_eq(buf.len(), 8);
-    testing.assert_eq(buf.get(0) as i64, 0x8);
-    testing.assert_eq(buf.get(1) as i64, 0x7);
-    testing.assert_eq(buf.get(6) as i64, 0x2);
-    testing.assert_eq(buf.get(7) as i64, 0x1);
+    testing.assert_eq(buf[0] as i64, 0x8);
+    testing.assert_eq(buf[1] as i64, 0x7);
+    testing.assert_eq(buf[6] as i64, 0x2);
+    testing.assert_eq(buf[7] as i64, 0x1);
 }
 
 #[test]
@@ -135,10 +135,10 @@ fn test_put_u64_be_known_pattern() {
     // 0x0102030405060708 in BE → [0x01, ..., 0x08]
     let buf = binary.put_u64_be(0x102030405060708);
     testing.assert_eq(buf.len(), 8);
-    testing.assert_eq(buf.get(0) as i64, 0x1);
-    testing.assert_eq(buf.get(1) as i64, 0x2);
-    testing.assert_eq(buf.get(6) as i64, 0x7);
-    testing.assert_eq(buf.get(7) as i64, 0x8);
+    testing.assert_eq(buf[0] as i64, 0x1);
+    testing.assert_eq(buf[1] as i64, 0x2);
+    testing.assert_eq(buf[6] as i64, 0x7);
+    testing.assert_eq(buf[7] as i64, 0x8);
 }
 
 #[test]
@@ -158,8 +158,8 @@ fn test_roundtrip_u64_be() {
 fn test_put_u16_le_zero() {
     let buf = binary.put_u16_le(0);
     testing.assert_eq(buf.len(), 2);
-    testing.assert_eq(buf.get(0) as i64, 0);
-    testing.assert_eq(buf.get(1) as i64, 0);
+    testing.assert_eq(buf[0] as i64, 0);
+    testing.assert_eq(buf[1] as i64, 0);
     testing.assert_eq(binary.get_u16_le(buf), 0);
 }
 
@@ -167,8 +167,8 @@ fn test_put_u16_le_zero() {
 fn test_put_u32_le_zero() {
     let buf = binary.put_u32_le(0);
     testing.assert_eq(buf.len(), 4);
-    testing.assert_eq(buf.get(0) as i64, 0);
-    testing.assert_eq(buf.get(3) as i64, 0);
+    testing.assert_eq(buf[0] as i64, 0);
+    testing.assert_eq(buf[3] as i64, 0);
     testing.assert_eq(binary.get_u32_le(buf), 0);
 }
 
@@ -176,8 +176,8 @@ fn test_put_u32_le_zero() {
 fn test_put_u64_le_zero() {
     let buf = binary.put_u64_le(0);
     testing.assert_eq(buf.len(), 8);
-    testing.assert_eq(buf.get(0) as i64, 0);
-    testing.assert_eq(buf.get(7) as i64, 0);
+    testing.assert_eq(buf[0] as i64, 0);
+    testing.assert_eq(buf[7] as i64, 0);
     testing.assert_eq(binary.get_u64_le(buf), 0);
 }
 
@@ -186,8 +186,8 @@ fn test_put_u64_le_zero() {
 fn test_put_u16_le_max() {
     // 0xFFFF → [0xFF, 0xFF]
     let buf = binary.put_u16_le(0xFFFF);
-    testing.assert_eq(buf.get(0) as i64, 0xFF);
-    testing.assert_eq(buf.get(1) as i64, 0xFF);
+    testing.assert_eq(buf[0] as i64, 0xFF);
+    testing.assert_eq(buf[1] as i64, 0xFF);
     testing.assert_eq(binary.get_u16_le(buf), 0xFFFF);
 }
 
@@ -195,8 +195,8 @@ fn test_put_u16_le_max() {
 fn test_put_u32_le_max() {
     // 0xFFFFFFFF → [0xFF, 0xFF, 0xFF, 0xFF]
     let buf = binary.put_u32_le(0xFFFFFFFF);
-    testing.assert_eq(buf.get(0) as i64, 0xFF);
-    testing.assert_eq(buf.get(3) as i64, 0xFF);
+    testing.assert_eq(buf[0] as i64, 0xFF);
+    testing.assert_eq(buf[3] as i64, 0xFF);
     testing.assert_eq(binary.get_u32_le(buf), 0xFFFFFFFF);
 }
 
@@ -213,8 +213,8 @@ fn test_put_u64_le_max_i64() {
 fn test_put_i16_le_minus_one() {
     // -1 in i16 → all bits set → [0xFF, 0xFF]
     let buf = binary.put_i16_le(-1);
-    testing.assert_eq(buf.get(0) as i64, 0xFF);
-    testing.assert_eq(buf.get(1) as i64, 0xFF);
+    testing.assert_eq(buf[0] as i64, 0xFF);
+    testing.assert_eq(buf[1] as i64, 0xFF);
     testing.assert_eq(binary.get_i16_le(buf), -1);
 }
 
@@ -222,8 +222,8 @@ fn test_put_i16_le_minus_one() {
 fn test_put_i32_le_minus_one() {
     // -1 in i32 → [0xFF, 0xFF, 0xFF, 0xFF]
     let buf = binary.put_i32_le(-1);
-    testing.assert_eq(buf.get(0) as i64, 0xFF);
-    testing.assert_eq(buf.get(3) as i64, 0xFF);
+    testing.assert_eq(buf[0] as i64, 0xFF);
+    testing.assert_eq(buf[3] as i64, 0xFF);
     testing.assert_eq(binary.get_i32_le(buf), -1);
 }
 
@@ -232,8 +232,8 @@ fn test_put_i64_le_minus_one() {
     // -1 in i64 → 8 bytes of 0xFF
     let buf = binary.put_i64_le(-1);
     testing.assert_eq(buf.len(), 8);
-    testing.assert_eq(buf.get(0) as i64, 0xFF);
-    testing.assert_eq(buf.get(7) as i64, 0xFF);
+    testing.assert_eq(buf[0] as i64, 0xFF);
+    testing.assert_eq(buf[7] as i64, 0xFF);
     testing.assert_eq(binary.get_i64_le(buf), -1);
 }
 
@@ -259,16 +259,16 @@ fn test_roundtrip_i64_le_negative() {
 fn test_put_i16_be_minus_one() {
     // -1 in i16 BE → [0xFF, 0xFF]
     let buf = binary.put_i16_be(-1);
-    testing.assert_eq(buf.get(0) as i64, 0xFF);
-    testing.assert_eq(buf.get(1) as i64, 0xFF);
+    testing.assert_eq(buf[0] as i64, 0xFF);
+    testing.assert_eq(buf[1] as i64, 0xFF);
     testing.assert_eq(binary.get_i16_be(buf), -1);
 }
 
 #[test]
 fn test_put_i32_be_minus_one() {
     let buf = binary.put_i32_be(-1);
-    testing.assert_eq(buf.get(0) as i64, 0xFF);
-    testing.assert_eq(buf.get(3) as i64, 0xFF);
+    testing.assert_eq(buf[0] as i64, 0xFF);
+    testing.assert_eq(buf[3] as i64, 0xFF);
     testing.assert_eq(binary.get_i32_be(buf), -1);
 }
 
@@ -276,8 +276,8 @@ fn test_put_i32_be_minus_one() {
 fn test_put_i64_be_minus_one() {
     let buf = binary.put_i64_be(-1);
     testing.assert_eq(buf.len(), 8);
-    testing.assert_eq(buf.get(0) as i64, 0xFF);
-    testing.assert_eq(buf.get(7) as i64, 0xFF);
+    testing.assert_eq(buf[0] as i64, 0xFF);
+    testing.assert_eq(buf[7] as i64, 0xFF);
     testing.assert_eq(binary.get_i64_be(buf), -1);
 }
 
@@ -286,8 +286,8 @@ fn test_put_i64_be_minus_one() {
 fn test_i16_le_min_value() {
     // i16 min = -32768 → [0x00, 0x80] in LE
     let buf = binary.put_i16_le(-32768);
-    testing.assert_eq(buf.get(0) as i64, 0x0);
-    testing.assert_eq(buf.get(1) as i64, 0x80);
+    testing.assert_eq(buf[0] as i64, 0x0);
+    testing.assert_eq(buf[1] as i64, 0x80);
     testing.assert_eq(binary.get_i16_le(buf), -32768);
 }
 
@@ -295,8 +295,8 @@ fn test_i16_le_min_value() {
 fn test_i16_le_max_value() {
     // i16 max = 32767 → [0xFF, 0x7F] in LE
     let buf = binary.put_i16_le(32767);
-    testing.assert_eq(buf.get(0) as i64, 0xFF);
-    testing.assert_eq(buf.get(1) as i64, 0x7F);
+    testing.assert_eq(buf[0] as i64, 0xFF);
+    testing.assert_eq(buf[1] as i64, 0x7F);
     testing.assert_eq(binary.get_i16_le(buf), 32767);
 }
 
@@ -304,8 +304,8 @@ fn test_i16_le_max_value() {
 fn test_i16_be_min_value() {
     // i16 min = -32768 → [0x80, 0x00] in BE
     let buf = binary.put_i16_be(-32768);
-    testing.assert_eq(buf.get(0) as i64, 0x80);
-    testing.assert_eq(buf.get(1) as i64, 0x0);
+    testing.assert_eq(buf[0] as i64, 0x80);
+    testing.assert_eq(buf[1] as i64, 0x0);
     testing.assert_eq(binary.get_i16_be(buf), -32768);
 }
 
@@ -314,10 +314,10 @@ fn test_i16_be_min_value() {
 fn test_i32_le_min_value() {
     // i32 min = -2147483648 → [0x00, 0x00, 0x00, 0x80] in LE
     let buf = binary.put_i32_le(-2147483648);
-    testing.assert_eq(buf.get(0) as i64, 0x0);
-    testing.assert_eq(buf.get(1) as i64, 0x0);
-    testing.assert_eq(buf.get(2) as i64, 0x0);
-    testing.assert_eq(buf.get(3) as i64, 0x80);
+    testing.assert_eq(buf[0] as i64, 0x0);
+    testing.assert_eq(buf[1] as i64, 0x0);
+    testing.assert_eq(buf[2] as i64, 0x0);
+    testing.assert_eq(buf[3] as i64, 0x80);
     testing.assert_eq(binary.get_i32_le(buf), -2147483648);
 }
 
@@ -325,10 +325,10 @@ fn test_i32_le_min_value() {
 fn test_i32_le_max_value() {
     // i32 max = 2147483647 → [0xFF, 0xFF, 0xFF, 0x7F] in LE
     let buf = binary.put_i32_le(2147483647);
-    testing.assert_eq(buf.get(0) as i64, 0xFF);
-    testing.assert_eq(buf.get(1) as i64, 0xFF);
-    testing.assert_eq(buf.get(2) as i64, 0xFF);
-    testing.assert_eq(buf.get(3) as i64, 0x7F);
+    testing.assert_eq(buf[0] as i64, 0xFF);
+    testing.assert_eq(buf[1] as i64, 0xFF);
+    testing.assert_eq(buf[2] as i64, 0xFF);
+    testing.assert_eq(buf[3] as i64, 0x7F);
     testing.assert_eq(binary.get_i32_le(buf), 2147483647);
 }
 
@@ -340,5 +340,5 @@ fn test_le_and_be_produce_distinct_byte_patterns() {
     let buf_le = binary.put_u32_le(0x1020304);
     let buf_be = binary.put_u32_be(0x1020304);
     // LE[0] = 0x04, BE[0] = 0x01
-    testing.assert_ne(buf_le.get(0) as i64, buf_be.get(0) as i64);
+    testing.assert_ne(buf_le[0] as i64, buf_be[0] as i64);
 }

--- a/tests/hew/bytes_get_option_proving_test.hew
+++ b/tests/hew/bytes_get_option_proving_test.hew
@@ -1,0 +1,60 @@
+//! Proving fixtures for `bytes.get()` under the `Index<Idx>` trait-convergence.
+//!
+//! `bytes.get(i)` returns `Option<u8>`: `Some(byte)` in bounds, `None` out of
+//! bounds (it does NOT trap — trapping is `b[i]`'s job, covered by the
+//! vertical-slice fixture `bytes_index_oob_traps`). The element class is the
+//! scalar `u8`, which is `Copy`, so the `Some` payload is an independent value
+//! by construction; the receiver is borrowed, not consumed, and stays usable
+//! after `get`.
+
+import std::testing;
+
+#[test]
+fn test_bytes_get_some_and_oob_none() {
+    let b: bytes = bytes::new();
+    b.push(10);
+    b.push(20);
+    b.push(30);
+
+    match b.get(0) {
+        Some(x) => testing.assert_eq_u8(x, 10),
+        None => testing.assert_true(false),
+    }
+    match b.get(2) {
+        Some(x) => testing.assert_eq_u8(x, 30),
+        None => testing.assert_true(false),
+    }
+    match b.get(3) {
+        Some(_) => testing.assert_true(false),
+        None => testing.assert_true(true),
+    }
+    match b.get(99) {
+        Some(_) => testing.assert_true(false),
+        None => testing.assert_true(true),
+    }
+}
+
+#[test]
+fn test_bytes_get_does_not_consume_receiver() {
+    let b: bytes = bytes::new();
+    b.push(7);
+    b.push(8);
+
+    // A borrowed receiver survives repeated `get`; the trapping `b[i]` and
+    // `len()` must still observe the live buffer afterwards.
+    let _ = b.get(0);
+    let _ = b.get(1);
+    let _ = b.get(50);
+
+    testing.assert_eq(b.len(), 2);
+    testing.assert_eq_u8(b[1], 8);
+}
+
+#[test]
+fn test_bytes_get_empty_is_none() {
+    let b: bytes = bytes::new();
+    match b.get(0) {
+        Some(_) => testing.assert_true(false),
+        None => testing.assert_true(true),
+    }
+}

--- a/tests/hew/compress_test.hew
+++ b/tests/hew/compress_test.hew
@@ -10,7 +10,7 @@ const DEFAULT_DECOMPRESS_LIMIT: i64 = 64 * 1024 * 1024;
 fn assert_bytes_eq(actual: bytes, expected: bytes) {
     testing.assert_eq(actual.len(), expected.len());
     for i in 0 .. expected.len() {
-        testing.assert_eq_u8(actual.get(i), expected.get(i));
+        testing.assert_eq_u8(actual[i], expected[i]);
     }
 }
 

--- a/tests/hew/encrypt_test.hew
+++ b/tests/hew/encrypt_test.hew
@@ -13,7 +13,7 @@ fn tamper_last_byte(ciphertext: bytes) -> bytes {
     let tampered: bytes = bytes::new();
     var i = 0;
     while i < ciphertext.len() {
-        let byte = ciphertext.get(i);
+        let byte = ciphertext[i];
         if i == last_index {
             if byte == 0 {
                 tampered.push(1);

--- a/tests/hew/encrypt_try_open_oracle.hew
+++ b/tests/hew/encrypt_try_open_oracle.hew
@@ -13,7 +13,7 @@ fn tamper_last_byte(ciphertext: bytes) -> bytes {
     let tampered: bytes = bytes::new();
     var i = 0;
     while i < ciphertext.len() {
-        let byte = ciphertext.get(i);
+        let byte = ciphertext[i];
         if i == last_index {
             if byte == 0 {
                 tampered.push(1);

--- a/tests/hew/fs_stream_test.hew
+++ b/tests/hew/fs_stream_test.hew
@@ -177,11 +177,11 @@ fn test_try_write_and_try_read_bytes_binary_roundtrip() {
     match fs.try_read_bytes(file_path) {
         Ok(data) => {
             testing.assert_eq(data.len(), expected_len);
-            testing.assert_eq_u8(data.get(0), b0);
-            testing.assert_eq_u8(data.get(1), b1);
-            testing.assert_eq_u8(data.get(2), b2);
-            testing.assert_eq_u8(data.get(3), b3);
-            testing.assert_eq_u8(data.get(4), b4);
+            testing.assert_eq_u8(data[0], b0);
+            testing.assert_eq_u8(data[1], b1);
+            testing.assert_eq_u8(data[2], b2);
+            testing.assert_eq_u8(data[3], b3);
+            testing.assert_eq_u8(data[4], b4);
         },
         Err(_) => panic("expected try_read_bytes to preserve bytes"),
     }

--- a/tests/hew/hex_test.hew
+++ b/tests/hew/hex_test.hew
@@ -7,7 +7,7 @@ import std::testing;
 fn assert_bytes_eq(actual: bytes, expected: bytes) {
     testing.assert_eq(actual.len(), expected.len());
     for i in 0 .. expected.len() {
-        testing.assert_eq_u8(actual.get(i), expected.get(i));
+        testing.assert_eq_u8(actual[i], expected[i]);
     }
 }
 

--- a/tests/hew/string_get_option_proving_test.hew
+++ b/tests/hew/string_get_option_proving_test.hew
@@ -1,0 +1,81 @@
+//! Proving fixtures for `string.get()` under the `Index<Idx>` trait-convergence.
+//!
+//! `string.get(i)` returns `Option<char>`: `Some(char)` at an in-bounds
+//! codepoint offset, `None` out of bounds (it does NOT trap — trapping is
+//! `s[i]`'s job, covered by the vertical-slice fixture `string_index_oob_traps`).
+//! The element class is the scalar `char`, which is `Copy`, so the `Some`
+//! payload is an independent value by construction; the receiver is borrowed,
+//! not consumed, and stays usable after `get`.
+
+import std::testing;
+
+#[test]
+fn test_string_get_some_and_oob_none() {
+    let s = "hello";
+
+    match s.get(0) {
+        Some(c) => testing.assert_true(c == 'h'),
+        None => testing.assert_true(false),
+    }
+    match s.get(4) {
+        Some(c) => testing.assert_true(c == 'o'),
+        None => testing.assert_true(false),
+    }
+    match s.get(5) {
+        Some(_) => testing.assert_true(false),
+        None => testing.assert_true(true),
+    }
+    match s.get(99) {
+        Some(_) => testing.assert_true(false),
+        None => testing.assert_true(true),
+    }
+}
+
+#[test]
+fn test_string_get_negative_index_is_none() {
+    let s = "hi";
+    // The codegen bounds-check is an unsigned compare, so a negative index
+    // folds to "out of bounds" and yields `None` rather than trapping.
+    match s.get(0 - 1) {
+        Some(_) => testing.assert_true(false),
+        None => testing.assert_true(true),
+    }
+}
+
+#[test]
+fn test_string_get_multibyte_codepoint() {
+    // "héllo" is five codepoints; index 1 is the multi-byte 'é'. `get` indexes
+    // by codepoint (rune) offset, not byte offset.
+    let s = "héllo";
+    match s.get(1) {
+        Some(c) => testing.assert_true(c == 'é'),
+        None => testing.assert_true(false),
+    }
+    match s.get(4) {
+        Some(c) => testing.assert_true(c == 'o'),
+        None => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn test_string_get_does_not_consume_receiver() {
+    let s = "abc";
+
+    // A borrowed receiver survives repeated `get`; the trapping `s[i]` and
+    // `len()` must still observe the live string afterwards.
+    let _ = s.get(0);
+    let _ = s.get(1);
+    let _ = s.get(50);
+
+    testing.assert_eq(s.len(), 3);
+    testing.assert_true(s[2] == 'c');
+}
+
+#[test]
+fn test_string_get_empty_is_none() {
+    let s = "";
+    match s.get(0) {
+        Some(_) => testing.assert_true(false),
+        None => testing.assert_true(true),
+    }
+}

--- a/tests/vertical-slice/accept/bytes_index_oob_traps.hew
+++ b/tests/vertical-slice/accept/bytes_index_oob_traps.hew
@@ -1,0 +1,16 @@
+// Indexed-accessor trap negative: `b[i]` on an out-of-bounds index must trap
+// (IndexOutOfBounds) rather than read past the buffer or return garbage. This
+// is the trapping `at` half of the `Index<Idx>` model for `bytes`: `b[i]` traps
+// on OOB while `b.get(i)` returns `None`. bytes routes `b[i]` through the
+// `hew_bytes_index` runtime getter, which aborts via `libc::abort()` on OOB —
+// the binary terminates with exit 134 (SIGABRT+128); run.sh asserts that code.
+fn main() -> i64 {
+    let b: bytes = bytes::new();
+    b.push(10);
+    b.push(20);
+    b.push(30);
+    // Index 10 is past the end of a length-3 buffer: must trap before the read.
+    let x: u8 = b[10];
+    // Unreachable: the index trap fires above.
+    x as i64
+}

--- a/tests/vertical-slice/accept/string_index_oob_traps.hew
+++ b/tests/vertical-slice/accept/string_index_oob_traps.hew
@@ -1,0 +1,17 @@
+// Indexed-accessor trap negative: `s[i]` on an out-of-bounds index must trap
+// (IndexOutOfBounds) rather than read past the buffer or return garbage. This
+// is the trapping `at` half of the `Index<Idx>` model for `string`: `s[i]` traps
+// on OOB while `s.get(i)` returns `None`. string routes `s[i]` through the
+// `hew_string_index` runtime getter, which aborts via `libc::abort()` on OOB —
+// the binary terminates with exit 134 (SIGABRT+128); run.sh asserts that code.
+fn main() -> i64 {
+    let s = "abc";
+    // Index 10 is past the end of a 3-codepoint string: must trap before the read.
+    let c: char = s[10];
+    // Unreachable: the index trap fires above.
+    if c == 'z' {
+        1
+    } else {
+        0
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -439,6 +439,13 @@ run_accept_expect_trap "hashmap_enum_index_absent_traps"
 # exit 134 (SIGABRT+128), the same fail-closed termination as `assert_eq_fail`.
 run_accept_expect_status "bytes_index_oob_traps" 134
 
+# Indexed-accessor trap negative for string: `s[i]` on an out-of-bounds index
+# traps (IndexOutOfBounds) — the trapping `at` half of the `Index<Idx>` model
+# (the `get` half returns `Option<char>`). string routes `s[i]` through the
+# `hew_string_index` runtime getter, which aborts via `libc::abort()` on OOB:
+# exit 134 (SIGABRT+128), the same fail-closed termination as `bytes_index_oob_traps`.
+run_accept_expect_status "string_index_oob_traps" 134
+
 # defer: basic (no effect on return), executes (exit override), LIFO, block scope
 run_accept_expect_status "defer_basic" 7
 run_accept_expect_status "defer_executes" 42

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -432,6 +432,13 @@ run_accept_expect_trap "vec_enum_index_oob_traps"
 run_accept_expect_trap "hashmap_index_absent_traps"
 run_accept_expect_trap "hashmap_enum_index_absent_traps"
 
+# Indexed-accessor trap negative for bytes: `b[i]` on an out-of-bounds index
+# traps (IndexOutOfBounds) — the trapping `at` half of the `Index<Idx>` model
+# (the `get` half returns `Option<u8>`). bytes routes `b[i]` through the
+# `hew_bytes_index` runtime getter, which aborts via `libc::abort()` on OOB:
+# exit 134 (SIGABRT+128), the same fail-closed termination as `assert_eq_fail`.
+run_accept_expect_status "bytes_index_oob_traps" 134
+
 # defer: basic (no effect on return), executes (exit override), LIFO, block scope
 run_accept_expect_status "defer_basic" 7
 run_accept_expect_status "defer_executes" 42


### PR DESCRIPTION
## Summary

Completes the `Index<Idx>`-based accessor convergence across the remaining collections (bytes and string), matching the model already shipped for `Vec` and `HashMap`:
- `bytes.get(i)` now returns a drop-safe `Option<u8>` (was a trapping bare-`u8`); `b[i]` keeps its trapping semantics.
- `string.get(i)` now returns a drop-safe `Option<char>`; `s[i]` keeps its trapping semantics. Both `s[i]` and `s.get` are codepoint-indexed (bounds-checked against the codepoint count, loaded through the canonical codepoint index path), so multibyte strings can't be half-read or mis-bounded.
- The accessor lowers to an inline `Option` build: an unsigned bounds-check, an in-bounds load via the canonical `hew_bytes_index`/`hew_string_index`, and `None` otherwise. The receiver is borrowed (not consumed); the `Some` payload is a by-value `Copy` scalar.
- Migrates the `std/encoding` (base64/binary/hex/wire) and `std/io` call sites from the trapping `.get` to `[]` indexing, preserving exact semantics (guards and constant indices unchanged).

## Verification

- `make lint` (fmt + clippy `-D warnings` + verify-ffi), `cargo fmt --check`, `cargo clippy --workspace --tests` — clean.
- `make checked-mir-verify` (31 fixtures × 2 stages byte-identical), `make test-vertical-slice` (`string_index_oob_traps` / `bytes_index_oob_traps` abort as expected), `make fuzz-oracle`, `make test-hew-ratchet` (drop-leak == 0, plus a focused 50-iteration `s.get` probe under MallocScribble = 0 leaks), `make test-stdlib-ratchet` (72 files), `make sandbox-parity` (WASM parity), `cargo nextest run --workspace` (10072 passed).
- New proving fixtures cover non-consumption of the receiver, out-of-bounds traps, `Some`/`None`, and multibyte codepoints.

## Out of scope

The string sentinel sweep (`find`/`to_int`/`index_of`/`char_at`/`codepoint_at_utf8` → `Option`) is a separate API-cleanliness change with a broad behavioral-cascade across the parsing/networking stdlib; it is tracked separately and not part of this change.
