### PR TITLE
Close actor use-after-free and deadlock windows in the runtime free/send paths

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ffi::{c_int, c_void};
 use std::ptr;
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU32, AtomicU64, Ordering};
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::{Condvar, Mutex, OnceLock, PoisonError};
 #[cfg(not(target_arch = "wasm32"))]
@@ -1080,6 +1080,27 @@ pub struct HewActor {
     /// WASM has no native `RuntimeInner`; keep the layout mirror opaque.
     #[cfg(target_arch = "wasm32")]
     pub(crate) runtime: *const c_void,
+
+    /// Count of in-flight by-ID send/ask/stop operations currently pinning
+    /// this actor allocation.
+    ///
+    /// `with_actor_send_by_id` increments this field (atomically, under
+    /// `LIVE_ACTORS`) before releasing the registry lock, then decrements it
+    /// via a RAII guard when the operation completes.  The free path in
+    /// `hew_actor_free_inner` treats `send_pin_count > 0` as non-quiescent:
+    /// it will not call `untrack_actor` or free the box until every in-flight
+    /// pin has been released, guaranteeing the allocation remains valid for
+    /// the duration of any by-ID mailbox send or actor stop.
+    ///
+    /// **Why not `dispatch_active`**: `dispatch_active` serialises the
+    /// scheduler worker's activation ownership; reusing it for external sends
+    /// would conflate two orthogonal notions of "in use".
+    ///
+    /// **ABI note**: appended at the end of `HewActor` after all previously
+    /// appended fields (`prof_*`, `arena`, suspend/resume, `runtime_id`,
+    /// `runtime`), so the only codegen-mirrored offsets — `id` at 8 and
+    /// `state` at 16 — are unaffected (verified by `abi_offset_parity`).
+    pub send_pin_count: AtomicU32,
 }
 
 // SAFETY: `HewActor` is designed for concurrent access across worker threads.
@@ -2110,6 +2131,7 @@ fn build_spawned_actor(
         runtime: rt as *const crate::runtime::RuntimeInner,
         #[cfg(target_arch = "wasm32")]
         runtime: ptr::null(),
+        send_pin_count: AtomicU32::new(0),
     })
 }
 
@@ -3228,7 +3250,17 @@ unsafe fn hew_actor_free_inner(actor: *mut HewActor, suppress_state_drop: bool) 
             // quiescence decision so we wait the worker out. The `Acquire` load
             // pairs with the guard's `Release` clear so we also observe every
             // write the activation made before we proceed to free.
-            if actor_free_state_is_quiescent(state) && !a.dispatch_active.load(Ordering::Acquire) {
+            //
+            // `send_pin_count > 0` means a `with_actor_send_by_id` operation is
+            // currently using the actor pointer after releasing `LIVE_ACTORS`.
+            // We must not free until the pin drops (the send/stop finishes),
+            // otherwise we get a use-after-free in the send path.  The pin is
+            // decremented with `Release` ordering, so this `Acquire` load
+            // observes the end of the by-ID operation before we proceed.
+            if actor_free_state_is_quiescent(state)
+                && !a.dispatch_active.load(Ordering::Acquire)
+                && a.send_pin_count.load(Ordering::Acquire) == 0
+            {
                 break;
             }
             if std::time::Instant::now() >= deadline {
@@ -5907,6 +5939,7 @@ mod tests {
                 suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
                 runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
                 runtime: ptr::null(),
+                send_pin_count: AtomicU32::new(0),
             }));
             (actor, mailbox)
         }
@@ -5950,6 +5983,7 @@ mod tests {
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
             runtime: ptr::null(),
+            send_pin_count: AtomicU32::new(0),
         }));
         // SAFETY: actor is fully initialised above with a valid id field.
         unsafe { live_actors::track_actor(actor) };
@@ -9343,6 +9377,7 @@ mod tests {
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
             runtime: ptr::null(),
+            send_pin_count: AtomicU32::new(0),
         }));
         // SAFETY: actor is fully initialised above with a valid id field.
         unsafe { live_actors::track_actor(actor) };

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -2825,21 +2825,21 @@ pub unsafe extern "C" fn hew_actor_send_by_id(
     data: *mut c_void,
     size: usize,
 ) -> c_int {
-    let local_actor = live_actors::get_actor_ptr_by_id(actor_id);
-
-    if let Some(actor) = local_actor {
-        // SAFETY: `LIVE_ACTORS` only proves that the pointer was live at
-        // lookup time. After we drop the mutex, this path intentionally
-        // matches `hew_actor_send`: callers that route by actor ID must
-        // uphold the same liveness invariant as direct-pointer sends and
-        // only race with frees they coordinate. If a free wins before the
-        // lookup, the ID is absent and we fall through below.
-        if unsafe { actor_send_internal(actor, msg_type, data, size) } {
-            return 0;
-        }
+    // Hold LIVE_ACTORS across the lookup and dispatch to close the TOCTOU
+    // window between pointer retrieval and dereference.  A concurrent
+    // hew_actor_free_inner cannot free the actor while the closure runs
+    // (untrack_actor runs under the same lock, before hew_actor_free_box).
+    let sent = live_actors::with_actor_send_by_id(actor_id, |actor| {
+        // SAFETY: `actor` is tracked in LIVE_ACTORS and the registry lock is
+        // held for this closure; the allocation is valid for the send.  Same
+        // data/size preconditions as hew_actor_send.
+        unsafe { actor_send_internal(actor, msg_type, data, size) }
+    });
+    if sent == Some(true) {
+        return 0;
     }
 
-    // Actor not found locally. If the PID belongs to a remote node,
+    // Actor not found locally (or send failed). If the PID belongs to a remote node,
     // route through the distributed node infrastructure (which serializes the
     // payload under the `(dispatch, msg_type)` codec key).
     if crate::pid::hew_pid_is_local(actor_id) == 0 {
@@ -4498,22 +4498,20 @@ pub(crate) unsafe fn hew_actor_ask_by_id(
     // closure preserves the same actor-ID/data preconditions.
     let send_result_code = unsafe {
         submit_ask_with_reply_channel(ch, AskReplyChannelFailureCleanup::FreeCreatorRef, |ch| {
-            // Look up actor and send with reply channel in the msg node
-            // field. Capture the send error code (not just bool) for
-            // accurate error discrimination.
-            live_actors::get_actor_ptr_by_id(actor_id).map_or(
-                HewError::ErrActorStopped as i32,
-                |actor| {
-                    // SAFETY: `LIVE_ACTORS` only proves that the pointer was
-                    // live at lookup time. After we drop the mutex, this path
-                    // intentionally matches `hew_actor_send_by_id`: callers that
-                    // route by actor ID must uphold the same liveness invariant
-                    // as direct-pointer asks and only race with frees they
-                    // coordinate. If a free wins before the lookup, the ID is
-                    // absent and we report ActorStopped above.
-                    actor_send_result_internal_reply(actor, msg_type, data, size, ch.cast())
-                },
-            )
+            // Hold LIVE_ACTORS across the lookup and dispatch to close the
+            // TOCTOU window between pointer retrieval and dereference.  A
+            // concurrent hew_actor_free_inner cannot free the actor while the
+            // closure runs (untrack_actor runs under the same lock, before
+            // hew_actor_free_box).
+            live_actors::with_actor_send_by_id(actor_id, |actor| {
+                // SAFETY: `actor` is tracked in LIVE_ACTORS and the registry
+                // lock is held for this closure; the allocation is valid.  `ch`
+                // is a live reply channel retained above.  Same data/size
+                // preconditions as hew_actor_ask.  Outer `unsafe` block covers
+                // this call.
+                actor_send_result_internal_reply(actor, msg_type, data, size, ch.cast())
+            })
+            .unwrap_or(HewError::ErrActorStopped as i32)
         })
     };
 

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -146,6 +146,38 @@ fn run_free_post_latch_hook(actor: *mut HewActor) {
     }
 }
 
+// ── cleanup_all_actors post-prepare rendezvous hook (test-only) ───────────
+//
+// Fires inside `cleanup_all_actors` for each actor, AFTER
+// `prepare_quiescent_actor_for_cleanup` runs and BEFORE the Idle→Stopped
+// wake-proofing latch. A test uses this point to simulate a concurrent
+// by-ID send that CAS-es `Idle→Runnable` in the latch window, proving that
+// the latch-fail path (actor skipped / leaked) fires instead of a UAF
+// finalize-under-queued-actor.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+static CLEANUP_POST_PREPARE_HOOK: Mutex<Option<fn(*mut HewActor)>> = Mutex::new(None);
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+fn set_cleanup_post_prepare_hook_for_test(hook: Option<fn(*mut HewActor)>) {
+    let mut guard = CLEANUP_POST_PREPARE_HOOK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    *guard = hook;
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+fn run_cleanup_post_prepare_hook(actor: *mut HewActor) {
+    let hook = {
+        let guard = CLEANUP_POST_PREPARE_HOOK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *guard
+    };
+    if let Some(hook) = hook {
+        hook(actor);
+    }
+}
+
 // ── Thread-local local ask error ────────────────────────────────────────
 
 thread_local! {
@@ -1406,7 +1438,11 @@ pub(crate) unsafe fn cleanup_all_actors() {
             continue;
         }
         // SAFETY: actor is valid (from LIVE_ACTORS); scheduler is shut down.
-        let state = unsafe { (*actor).actor_state.load(Ordering::Acquire) };
+        let a = unsafe { &*actor };
+        // Load state BEFORE prepare so we pass the original value to finalize
+        // (the terminate-vs-skip decision must see Idle, not the latch-imposed
+        // Stopped).
+        let state = a.actor_state.load(Ordering::Acquire);
 
         // Cancel periodic timers, drop link/monitor entries, and unregister
         // named-node bindings BEFORE running terminate or freeing the
@@ -1428,20 +1464,63 @@ pub(crate) unsafe fn cleanup_all_actors() {
             crate::scheduler_wasm::cancel_actor_sleep_queue_entry(actor);
         }
 
-        // Drain send pins.  All worker threads are joined before this runs,
-        // so send_pin_count should be 0.  The spin is a safety net for
-        // unusual paths (e.g. a non-runtime thread that holds a pin during
-        // shutdown); on timeout we log and skip finalize for this actor
-        // (fail-closed: leak) to avoid freeing under an active pin.
+        // Test-only rendezvous: fires after prepare, before the latch. A test
+        // uses this to simulate a concurrent by-ID send CAS-ing Idle→Runnable
+        // in the wake-proofing window, verifying the latch-fail skip fires.
+        #[cfg(all(test, not(target_arch = "wasm32")))]
+        run_cleanup_post_prepare_hook(actor);
+
+        // Wake-proof still-Idle actors before draining send pins.
+        //
+        // A pinned by-ID sender (that incremented `send_pin_count` before
+        // `drain_all_for_cleanup` removed the map entry) can still be running
+        // its send closure, which may CAS `Idle→Runnable` to re-enqueue the
+        // actor.  Without this latch, the send drops its pin and the freer
+        // proceeds to finalize a still-queued actor → UAF (dangling scheduler
+        // pointer). `hew_actor_free_inner` applies the same Idle→Stopped latch
+        // for the same reason; this path mirrors it.
+        //
+        // Actors already in a terminal state (Stopped/Crashed) are already
+        // wake-proof: CAS `Idle→Runnable` cannot succeed on a non-Idle state.
+        // Skip the latch for those.
+        //
+        // Pass the ORIGINAL pre-latch `state` to finalize so the
+        // terminate-vs-skip decision sees Idle (= run terminate), not the
+        // latch-imposed Stopped.
+        if state == HewActorState::Idle as i32
+            && a.actor_state
+                .compare_exchange(
+                    HewActorState::Idle as i32,
+                    HewActorState::Stopped as i32,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_err()
+        {
+            // A concurrent operation (e.g. a pinned send) won the CAS
+            // `Idle→Runnable` before we could latch `Idle→Stopped`.  The
+            // actor may now be queued in the scheduler; freeing it would
+            // be a UAF.  Leak it (fail-closed) and log.
+            eprintln!(
+                "hew: runtime error: actor {:#x} was re-enqueued during \
+                 shutdown cleanup (concurrent send beat the wake-proof latch); \
+                 actor leaked to avoid UAF",
+                a.id
+            );
+            continue;
+        }
+
+        // Drain send pins.  After drain_all_for_cleanup no new pins can be
+        // taken; after the Idle→Stopped latch above, any in-flight pin
+        // holder whose CAS Idle→Runnable is rejected (state=Stopped) cannot
+        // re-enqueue.  We still wait for existing pin holders to finish their
+        // send closures and drop the pin before finalizing.
         // SAFETY: LIVE_ACTORS is not held here; no deadlock risk.
         {
-            // SAFETY: actor came from LIVE_ACTORS (non-null check above);
-            // the scheduler is shut down, so no concurrent dispatch is possible.
-            let a = unsafe { &*actor };
             debug_assert_eq!(
                 a.send_pin_count.load(Ordering::Acquire),
                 0,
-                "send_pin_count must be 0 in cleanup_all_actors (single-threaded)"
+                "send_pin_count should be 0 in cleanup_all_actors (all workers joined)"
             );
             let pin_deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
             let mut pinned = false;
@@ -1452,7 +1531,7 @@ pub(crate) unsafe fn cleanup_all_actors() {
                 if std::time::Instant::now() >= pin_deadline {
                     eprintln!(
                         "hew: runtime error: actor {:#x} send pins did not drain \
-                     during shutdown cleanup; actor leaked to avoid UAF",
+                         during shutdown cleanup; actor leaked to avoid UAF",
                         a.id
                     );
                     pinned = true;
@@ -1472,8 +1551,9 @@ pub(crate) unsafe fn cleanup_all_actors() {
         // (still IDLE at process exit). Skip crashed actors — their state
         // may be corrupted. `finalize_quiescent_actor_cleanup` performs the
         // terminate-or-skip dance plus the resource free.
-        // SAFETY: actor is quiescent, no longer tracked, and all send pins
-        // have drained (verified above).
+        // Pass the original `state` (Idle) so finalize runs terminate.
+        // SAFETY: actor is quiescent, no longer tracked, wake-proofed, and
+        // all send pins have drained.
         unsafe { finalize_quiescent_actor_cleanup(actor, state) };
     }
 }
@@ -3407,11 +3487,15 @@ unsafe fn hew_actor_free_inner(actor: *mut HewActor, suppress_state_drop: bool) 
     // LIVE_ACTORS is NOT held here, so pinned senders can freely re-acquire
     // it (e.g. via `enqueue_resume` → `with_live_actor`) without deadlock.
     // The `Release` in `SendPinGuard::drop` pairs with this `Acquire` load.
+    //
+    // Fresh deadline: the quiescence wait above may have consumed most of
+    // `deadline`; give the pin drain its own full budget.
+    let drain_deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
     loop {
         if a.send_pin_count.load(Ordering::Acquire) == 0 {
             break;
         }
-        if std::time::Instant::now() >= deadline {
+        if std::time::Instant::now() >= drain_deadline {
             crate::set_last_error("hew_actor_free: send pins did not drain after timeout");
             return -2;
         }
@@ -3459,6 +3543,18 @@ fn drain_backoff_duration(delay: std::time::Duration) -> std::time::Duration {
 /// — into one call site so both the inner loop and the post-deadline pass use
 /// the same ordering. Both call sites in `drain_actors` were already identical;
 /// this is a behaviour-equivalent extraction with no normalisation.
+///
+/// ## Wake-proof contract
+///
+/// Unlike `cleanup_all_actors`, this function does NOT need a separate
+/// `Idle→Stopped` latch before draining pins.  `drain_actors` calls
+/// `hew_actor_stop` on every actor BEFORE waiting for quiescence; `hew_actor_stop`
+/// closes the mailbox and performs `CAS Idle→Stopped` for any actor that is
+/// still `Idle` at stop time.  By the time `drain_quiesced_actor` is called the
+/// actor is already in a terminal state (Stopped or Crashed), so any concurrent
+/// `CAS Idle→Runnable` will fail (state is not `Idle`).  **Callers must uphold
+/// this stop-first contract; removing the stop call before drain would introduce
+/// the same re-enqueue UAF that the latch in `cleanup_all_actors` prevents.**
 ///
 /// # Safety
 ///
@@ -7011,6 +7107,106 @@ mod tests {
             "freed actor must no longer be tracked in LIVE_ACTORS"
         );
         drop(sched);
+    }
+
+    /// Forced-ordering regression for the `cleanup_all_actors` re-enqueue UAF
+    /// (cap-xeco3 / fourth review round).
+    ///
+    /// A pinned by-ID sender that incremented `send_pin_count` before
+    /// `drain_all_for_cleanup` removed the map entry can still be running its
+    /// send closure, which may CAS `Idle→Runnable` to re-enqueue the actor into
+    /// the scheduler.  Without the `Idle→Stopped` latch, `cleanup_all_actors`
+    /// would call `finalize` on a still-queued actor — a UAF.
+    ///
+    /// This test simulates that race with `CLEANUP_POST_PREPARE_HOOK`: the hook
+    /// fires after `prepare_quiescent_actor_for_cleanup` and before the latch,
+    /// performs `CAS Idle→Runnable` (as a concurrent sender would), and then
+    /// asserts that the latch-fail path skips finalize (the actor is leaked) and
+    /// does NOT free the allocation.
+    ///
+    /// **Before the fix**: `cleanup_all_actors` proceeded to finalize regardless
+    /// of state → the hook would observe state=Runnable post-finalize (freed
+    /// memory read → UB), and in practice the scheduler would later dereference
+    /// the queued dangling pointer.
+    ///
+    /// **After the fix**: `CAS Idle→Stopped` fails (state is already Runnable)
+    /// → the actor is logged + leaked.  Allocation still valid post-call.
+    static CLEANUP_REENQUEUE_CAS_SUCCEEDED: AtomicBool = AtomicBool::new(false);
+
+    fn reenqueue_for_cleanup_hook(actor: *mut HewActor) {
+        // SAFETY: actor is valid (from cleanup_all_actors iteration).
+        let a = unsafe { &*actor };
+        let ok = a
+            .actor_state
+            .compare_exchange(
+                HewActorState::Idle as i32,
+                HewActorState::Runnable as i32,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok();
+        CLEANUP_REENQUEUE_CAS_SUCCEEDED.store(ok, Ordering::Release);
+    }
+
+    #[test]
+    fn cleanup_skips_actor_reenqueued_during_latch_window() {
+        let _guard = crate::runtime_test_guard();
+        let _scheduler = scheduler::NoWorkerSchedulerForTest::install();
+        let _tracing = crate::tracing::tracing_test_guard();
+
+        // SAFETY: null state + valid dispatch are valid spawn args.
+        let actor = unsafe { hew_actor_spawn(ptr::null_mut(), 0, Some(noop_dispatch)) };
+        assert!(!actor.is_null());
+
+        // Freshly spawned actors are Idle — the hook will win the
+        // CAS Idle→Runnable race before the latch can run.
+        // SAFETY: actor is valid (just spawned).
+        let spawned_state = unsafe { (*actor).actor_state.load(Ordering::Acquire) };
+        assert_eq!(spawned_state, HewActorState::Idle as i32);
+
+        CLEANUP_REENQUEUE_CAS_SUCCEEDED.store(false, Ordering::Release);
+
+        set_cleanup_post_prepare_hook_for_test(Some(reenqueue_for_cleanup_hook));
+
+        // SAFETY: scheduler is stopped (NoWorkerSchedulerForTest installed);
+        // no dispatch is in progress.
+        unsafe { cleanup_all_actors() };
+
+        set_cleanup_post_prepare_hook_for_test(None);
+
+        // 1. Hook must have fired and the CAS must have succeeded (state was Idle
+        //    when the hook ran, before the latch attempt).
+        assert!(
+            CLEANUP_REENQUEUE_CAS_SUCCEEDED.load(Ordering::Acquire),
+            "hook must fire and CAS Idle→Runnable must succeed in the latch window"
+        );
+
+        // 2. The latch-fail path must have SKIPPED finalize: the allocation is
+        //    still valid and the state is Runnable (not freed/corrupted).
+        // SAFETY: actor was not freed (latch-fail → continue; allocation is valid).
+        let post_state = unsafe { (*actor).actor_state.load(Ordering::Acquire) };
+        assert_eq!(
+            post_state,
+            HewActorState::Runnable as i32,
+            "actor must be Runnable (leaked, not freed) after cleanup latch-fail"
+        );
+
+        // 3. The actor must be untracked — drain_all_for_cleanup removed it.
+        assert!(
+            !live_actors::is_actor_live(actor),
+            "actor must be untracked even when cleanup skips finalize"
+        );
+
+        // Manual cleanup: cleanup_all_actors deliberately leaked this actor to
+        // avoid UAF.  Finalize it here to avoid a test memory leak.  The actor
+        // has no terminate_fn (noop_dispatch), so call_terminate_fn is a no-op.
+        // SAFETY: actor is valid, untracked, and no concurrent access is possible.
+        unsafe {
+            (*actor)
+                .actor_state
+                .store(HewActorState::Stopped as i32, Ordering::Release);
+            finalize_quiescent_actor_cleanup(actor, HewActorState::Stopped as i32);
+        }
     }
 
     #[test]

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1375,6 +1375,82 @@ unsafe fn prepare_quiescent_actor_for_cleanup(actor: *mut HewActor) {
     }
 }
 
+/// Outcome of [`decide_finalize_by_latch`] — the canonical "is it safe to
+/// finalize this quiescent-but-possibly-re-enqueued actor?" decision.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+enum FinalizeDecision {
+    /// Safe to finalize. Carries the state to hand to
+    /// [`finalize_quiescent_actor_cleanup`]; that value drives only the
+    /// terminate-vs-skip choice (`Crashed` ⇒ skip terminate, every other value
+    /// ⇒ run terminate). It is NOT a stale liveness gate.
+    Finalize(i32),
+    /// The actor is neither `Idle` nor a quiescent terminal state. It is
+    /// `Runnable`/`Running` (re-enqueued or actively dispatching), `Suspended`
+    /// (a live continuation frame is parked against it), or another non-quiescent
+    /// state. A scheduler queue may hold its raw pointer, or a parked frame may
+    /// still own it, so freeing it would be a use-after-free or a frame leak. The
+    /// caller MUST skip/leak fail-closed.
+    Skip,
+}
+
+/// Decide whether a quiescent-but-possibly-re-enqueued actor is safe to
+/// finalize, using the CAS RESULT (the actual state at decision time) rather
+/// than any pre-loaded snapshot.
+///
+/// This is the single robust primitive shared by every bulk/terminal free path
+/// (`cleanup_all_actors`, `drain_quiesced_actor`, `actor_free_wasm_impl`).
+/// `hew_actor_free_inner` implements the same CAS-result discipline inline, but
+/// with retry-instead-of-skip semantics (a single explicit free can afford to
+/// wait the queued activation out and try again, whereas a bulk sweep leaks the
+/// straggler fail-closed).
+///
+/// Why a snapshot is unsafe: between loading `actor_state` and acting on it, a
+/// pinned by-ID sender can win `CAS Idle→Runnable` (+ `sched_enqueue`) and
+/// re-enqueue the actor. A decision that branches on the stale snapshot can then
+/// (a) believe the actor is still `Idle` and free it after a lost latch, or
+/// (b) observe the snapshot already `Runnable`,
+/// short-circuit the latch entirely, and finalize the queued actor. Both are
+/// use-after-frees. Latching and branching on the CAS result closes both:
+///
+/// - `Ok(_)`                       ⇒ we latched it out of `Idle` into the
+///   terminal `Stopped` state; every waker's `CAS Idle→Runnable` now fails, so
+///   nothing can enqueue it. Finalize and run terminate (`Finalize(Idle)` — the
+///   pre-latch identity, so finalize treats it as a clean stop, not a crash).
+/// - `Err(s)` with `actor_free_state_is_quiescent(s)` ⇒ already terminal and
+///   wake-proof (necessarily `Stopped`/`Crashed`, since the CAS proved `s` was
+///   not `Idle`). Finalize under the observed terminal state (preserves the
+///   `Crashed ⇒ skip-terminate` path). No CAS needed.
+/// - `Err(s)` otherwise (`Runnable`/`Running`/`Suspended`/…) ⇒ re-enqueued,
+///   actively dispatching, or holding a parked continuation frame; a scheduler
+///   queue may hold its raw pointer, or a parked frame still owns it. `Skip` —
+///   leak fail-closed; never free a queued/active/parked actor. Gating on the
+///   shared `actor_free_state_is_quiescent` predicate (rather than an ad-hoc
+///   `Stopped || Crashed` test) keeps this decision consistent with the sibling
+///   free paths and routes `Suspended` to the same fail-closed leak — closing a
+///   latent finalize-over-a-parked-frame on the cleanup path.
+fn decide_finalize_by_latch(a: &HewActor) -> FinalizeDecision {
+    match a.actor_state.compare_exchange(
+        HewActorState::Idle as i32,
+        HewActorState::Stopped as i32,
+        Ordering::AcqRel,
+        Ordering::Acquire,
+    ) {
+        Ok(_) => FinalizeDecision::Finalize(HewActorState::Idle as i32),
+        // CAS failed: the actor was not `Idle`. Decide from the ACTUAL observed
+        // state `s` using the SAME `actor_free_state_is_quiescent` predicate the
+        // sibling free paths gate on (`hew_actor_free_inner`'s quiescence wait,
+        // `drain_actors`). A quiescent `s` (here necessarily `Stopped`/`Crashed`,
+        // since the CAS proved it was not `Idle`) is already terminal and
+        // wake-proof ⇒ finalize under it. Any non-quiescent `s` — `Runnable`/
+        // `Running` (re-enqueued or actively dispatching), or `Suspended` (a live
+        // continuation frame is parked) — must NOT be finalized: a scheduler
+        // queue may hold its raw pointer, or a parked frame still owns it. Leak
+        // fail-closed.
+        Err(s) if actor_free_state_is_quiescent(s) => FinalizeDecision::Finalize(s),
+        Err(_) => FinalizeDecision::Skip,
+    }
+}
+
 /// Finish the `hew_actor_free` cleanup path after the actor has been untracked.
 ///
 /// # Safety
@@ -1439,10 +1515,6 @@ pub(crate) unsafe fn cleanup_all_actors() {
         }
         // SAFETY: actor is valid (from LIVE_ACTORS); scheduler is shut down.
         let a = unsafe { &*actor };
-        // Load state BEFORE prepare so we pass the original value to finalize
-        // (the terminate-vs-skip decision must see Idle, not the latch-imposed
-        // Stopped).
-        let state = a.actor_state.load(Ordering::Acquire);
 
         // Cancel periodic timers, drop link/monitor entries, and unregister
         // named-node bindings BEFORE running terminate or freeing the
@@ -1464,57 +1536,56 @@ pub(crate) unsafe fn cleanup_all_actors() {
             crate::scheduler_wasm::cancel_actor_sleep_queue_entry(actor);
         }
 
-        // Test-only rendezvous: fires after prepare, before the latch. A test
-        // uses this to simulate a concurrent by-ID send CAS-ing Idle→Runnable
-        // in the wake-proofing window, verifying the latch-fail skip fires.
+        // Test-only rendezvous: fires after prepare, before the finalize
+        // decision. A test uses this to simulate a concurrent by-ID send
+        // CAS-ing Idle→Runnable in the wake-proofing window, verifying the
+        // skip fires.
         #[cfg(all(test, not(target_arch = "wasm32")))]
         run_cleanup_post_prepare_hook(actor);
 
-        // Wake-proof still-Idle actors before draining send pins.
+        // Wake-proof + finalize decision, by the CAS RESULT — never a stale
+        // snapshot (see `decide_finalize_by_latch`).
         //
         // A pinned by-ID sender (that incremented `send_pin_count` before
         // `drain_all_for_cleanup` removed the map entry) can still be running
-        // its send closure, which may CAS `Idle→Runnable` to re-enqueue the
-        // actor.  Without this latch, the send drops its pin and the freer
-        // proceeds to finalize a still-queued actor → UAF (dangling scheduler
-        // pointer). `hew_actor_free_inner` applies the same Idle→Stopped latch
-        // for the same reason; this path mirrors it.
+        // its send closure, which may CAS `Idle→Runnable` (+ `sched_enqueue`)
+        // to re-enqueue the actor. The latch `Idle→Stopped` wake-proofs a
+        // still-Idle actor (every waker's CAS then fails). If a waker already
+        // won — whether the wake landed BEFORE this sweep reached the actor
+        // (the snapshot-already-Runnable window) or AFTER, in the latch
+        // window — the CAS returns
+        // `Err(Runnable/Running/…)` and we leak fail-closed rather than
+        // finalize a queued actor (a dangling scheduler pointer → UAF). The
+        // decision uses the actual state at CAS time, so neither window can
+        // finalize a re-enqueued actor.
         //
-        // Actors already in a terminal state (Stopped/Crashed) are already
-        // wake-proof: CAS `Idle→Runnable` cannot succeed on a non-Idle state.
-        // Skip the latch for those.
-        //
-        // Pass the ORIGINAL pre-latch `state` to finalize so the
-        // terminate-vs-skip decision sees Idle (= run terminate), not the
-        // latch-imposed Stopped.
-        if state == HewActorState::Idle as i32
-            && a.actor_state
-                .compare_exchange(
-                    HewActorState::Idle as i32,
-                    HewActorState::Stopped as i32,
-                    Ordering::AcqRel,
-                    Ordering::Acquire,
-                )
-                .is_err()
-        {
-            // A concurrent operation (e.g. a pinned send) won the CAS
-            // `Idle→Runnable` before we could latch `Idle→Stopped`.  The
-            // actor may now be queued in the scheduler; freeing it would
-            // be a UAF.  Leak it (fail-closed) and log.
-            eprintln!(
-                "hew: runtime error: actor {:#x} was re-enqueued during \
-                 shutdown cleanup (concurrent send beat the wake-proof latch); \
-                 actor leaked to avoid UAF",
-                a.id
-            );
-            continue;
-        }
+        // The same quiescence gate routes a still-`Suspended` actor (one parked
+        // at a non-final `coro.suspend` with a live continuation frame) to the
+        // fail-closed leak: `actor_free_state_is_quiescent` excludes `Suspended`,
+        // so cleanup never finalizes a parked actor (which would free its box
+        // and leak the frame). Unlike `hew_actor_free_inner`, the shutdown sweep
+        // cannot block to destroy the parked frame (workers are joined), so it
+        // leaks-not-frees — the correct fail-closed shutdown behaviour.
+        let finalize_state = match decide_finalize_by_latch(a) {
+            FinalizeDecision::Finalize(state) => state,
+            FinalizeDecision::Skip => {
+                eprintln!(
+                    "hew: runtime error: actor {:#x} was non-quiescent at \
+                     shutdown cleanup (re-enqueued/active after a concurrent \
+                     send beat the wake-proof latch, or parked at a suspend \
+                     point); actor leaked to avoid UAF",
+                    a.id
+                );
+                continue;
+            }
+        };
 
         // Drain send pins.  After drain_all_for_cleanup no new pins can be
-        // taken; after the Idle→Stopped latch above, any in-flight pin
-        // holder whose CAS Idle→Runnable is rejected (state=Stopped) cannot
-        // re-enqueue.  We still wait for existing pin holders to finish their
-        // send closures and drop the pin before finalizing.
+        // taken; after the Idle→Stopped latch (a `Finalize` decision means the
+        // actor is now terminal), any in-flight pin holder whose CAS
+        // Idle→Runnable is rejected cannot re-enqueue.  We still wait for
+        // existing pin holders to finish their send closures and drop the pin
+        // before finalizing.
         // SAFETY: LIVE_ACTORS is not held here; no deadlock risk.
         {
             debug_assert_eq!(
@@ -1547,14 +1618,13 @@ pub(crate) unsafe fn cleanup_all_actors() {
             }
         }
 
-        // Run terminate for actors that never reached a terminal state
-        // (still IDLE at process exit). Skip crashed actors — their state
-        // may be corrupted. `finalize_quiescent_actor_cleanup` performs the
-        // terminate-or-skip dance plus the resource free.
-        // Pass the original `state` (Idle) so finalize runs terminate.
-        // SAFETY: actor is quiescent, no longer tracked, wake-proofed, and
-        // all send pins have drained.
-        unsafe { finalize_quiescent_actor_cleanup(actor, state) };
+        // Run terminate for actors that never reached a terminal state (still
+        // IDLE at process exit; `Finalize(Idle)`). Skip crashed actors — their
+        // state may be corrupted. `finalize_quiescent_actor_cleanup` performs
+        // the terminate-or-skip dance plus the resource free.
+        // SAFETY: actor is quiescent, no longer tracked, wake-proofed (latched
+        // out of Idle, or already terminal), and all send pins have drained.
+        unsafe { finalize_quiescent_actor_cleanup(actor, finalize_state) };
     }
 }
 
@@ -3419,6 +3489,16 @@ unsafe fn hew_actor_free_inner(actor: *mut HewActor, suppress_state_drop: bool) 
         unsafe { prepare_quiescent_actor_for_cleanup(actor) };
 
         // Step 3: re-load after cleanup, then latch the actor out of `Idle`.
+        //
+        // This is the inline, *retry*-on-loss variant of the shared
+        // `decide_finalize_by_latch` primitive (used by `cleanup_all_actors`,
+        // `drain_quiesced_actor`, and `actor_free_wasm_impl`): all four branch on
+        // the CAS RESULT, never on a pre-loaded snapshot. The bulk/terminal paths
+        // *skip* (leak fail-closed) when the latch loses to a waker; this explicit
+        // single-actor free instead *loops back* to wait the queued activation out
+        // and free cleanly, returning `-2` only at the deadline. Same decision
+        // table (`Ok⇒Stopped`, `Err(Stopped|Crashed)⇒that state`, else not-safe);
+        // different not-safe handling.
         let state = a.actor_state.load(Ordering::Acquire);
         if state == HewActorState::Idle as i32 {
             // Latch Idle->Stopped. This is the wake-proofing step: after it
@@ -3538,34 +3618,35 @@ fn drain_backoff_duration(delay: std::time::Duration) -> std::time::Duration {
 /// Quiesce and free an actor that has already reached a terminal state inside
 /// `drain_actors`.
 ///
-/// This consolidates the three-step sequence — cancel timers/links/monitors,
-/// take ownership from `LIVE_ACTORS`, and run `finalize_quiescent_actor_cleanup`
-/// — into one call site so both the inner loop and the post-deadline pass use
-/// the same ordering. Both call sites in `drain_actors` were already identical;
-/// this is a behaviour-equivalent extraction with no normalisation.
+/// This consolidates the sequence — cancel timers/links/monitors, wake-proof,
+/// take ownership from `LIVE_ACTORS`, drain pins, and run
+/// `finalize_quiescent_actor_cleanup` — into one call site so both the inner
+/// loop and the post-deadline pass use the same ordering.
 ///
-/// ## Wake-proof contract
+/// ## Finalize decision (CAS-result, never a snapshot)
 ///
-/// Unlike `cleanup_all_actors`, this function does NOT need a separate
-/// `Idle→Stopped` latch before draining pins.  `drain_actors` calls
-/// `hew_actor_stop` on every actor BEFORE waiting for quiescence; `hew_actor_stop`
-/// closes the mailbox and performs `CAS Idle→Stopped` for any actor that is
-/// still `Idle` at stop time.  By the time `drain_quiesced_actor` is called the
-/// actor is already in a terminal state (Stopped or Crashed), so any concurrent
-/// `CAS Idle→Runnable` will fail (state is not `Idle`).  **Callers must uphold
-/// this stop-first contract; removing the stop call before drain would introduce
-/// the same re-enqueue UAF that the latch in `cleanup_all_actors` prevents.**
+/// The finalize decision comes from [`decide_finalize_by_latch`] — the same
+/// CAS-result primitive `cleanup_all_actors` uses — applied BEFORE untracking,
+/// not from a state value the caller snapshotted earlier. `drain_actors` calls
+/// `hew_actor_stop` on every actor BEFORE waiting for quiescence, so by the time
+/// this runs the actor is already terminal (`Stopped`): the latch CAS returns
+/// `Err(Stopped)` ⇒ `Finalize(Stopped)`, the same finalize the previous
+/// snapshot-based code performed. The latch additionally HARDENS the path
+/// against stop-first contract drift: were a future caller to skip the stop, a
+/// re-enqueued (`Runnable`) actor now fails closed (`Skip` ⇒ leak) instead of
+/// being finalized while a scheduler queue still holds its pointer.
+///
+/// **Callers should still uphold the stop-first contract** so the common path
+/// finalizes cleanly rather than relying on the defensive `Skip` leak.
 ///
 /// # Safety
 ///
 /// `expected` must be a valid, quiescent actor pointer that is still tracked
-/// in `LIVE_ACTORS`. `state` must be the value loaded from `actor_state`
-/// immediately before this call.
+/// in `LIVE_ACTORS`.
 #[cfg(not(target_arch = "wasm32"))]
 unsafe fn drain_quiesced_actor(
     actor_id: ActorId,
     expected: *mut HewActor,
-    state: i32,
     deadline: std::time::Instant,
 ) {
     // SAFETY: caller guarantees `expected` is quiescent and still tracked in
@@ -3573,6 +3654,26 @@ unsafe fn drain_quiesced_actor(
     // untracking so that any in-flight timer callback or signal propagation
     // still observes the actor as live and bails out cooperatively.
     unsafe { prepare_quiescent_actor_for_cleanup(expected) };
+
+    // Wake-proof + finalize decision by the CAS RESULT, BEFORE untracking
+    // (mirrors `hew_actor_free_inner` / `cleanup_all_actors`). Under the
+    // stop-first contract this is `Err(Stopped) ⇒ Finalize(Stopped)`; a
+    // re-enqueued actor (contract drift) takes the fail-closed `Skip` leak.
+    // SAFETY: caller guarantees `expected` is valid.
+    let a = unsafe { &*expected };
+    let finalize_state = match decide_finalize_by_latch(a) {
+        FinalizeDecision::Finalize(state) => state,
+        FinalizeDecision::Skip => {
+            // Re-enqueued/active despite stop-first: leave it tracked so the
+            // shutdown sweep (`cleanup_all_actors`) reclaims it once it drains,
+            // and leak fail-closed here rather than free a queued actor.
+            crate::set_last_error(
+                "drain_quiesced_actor: actor re-enqueued during drain; leaked fail-closed",
+            );
+            return;
+        }
+    };
+
     if let Some(actor) = live_actors::take_actor_by_id(actor_id, expected) {
         // After take_actor_by_id the map entry is removed: no new send pins
         // can be taken.  Drain any in-flight pins before finalizing.
@@ -3592,9 +3693,9 @@ unsafe fn drain_quiesced_actor(
             }
             std::thread::yield_now();
         }
-        // SAFETY: the actor is quiescent, prepared for cleanup, no longer tracked,
-        // and all send pins have drained.
-        unsafe { finalize_quiescent_actor_cleanup(actor, state) };
+        // SAFETY: the actor is quiescent, prepared for cleanup, wake-proofed,
+        // no longer tracked, and all send pins have drained.
+        unsafe { finalize_quiescent_actor_cleanup(actor, finalize_state) };
     }
 }
 
@@ -3638,7 +3739,7 @@ pub fn drain_actors(ids: &[ActorId], deadline: std::time::Instant) -> DrainOutco
                 }
                 Some(state) if actor_free_state_is_quiescent(state) => {
                     // SAFETY: `expected` is quiescent and still tracked in LIVE_ACTORS.
-                    unsafe { drain_quiesced_actor(actor_id, expected, state, deadline) };
+                    unsafe { drain_quiesced_actor(actor_id, expected, deadline) };
                     pending.swap_remove(index);
                 }
                 Some(_) => {
@@ -3673,7 +3774,7 @@ pub fn drain_actors(ids: &[ActorId], deadline: std::time::Instant) -> DrainOutco
             Some(state) if state == HewActorState::Crashed as i32 => crashed.push(actor_id),
             Some(state) if actor_free_state_is_quiescent(state) => {
                 // SAFETY: `expected` is quiescent and still tracked in LIVE_ACTORS.
-                unsafe { drain_quiesced_actor(actor_id, expected, state, deadline) };
+                unsafe { drain_quiesced_actor(actor_id, expected, deadline) };
             }
             Some(_) => still_live.push(actor_id),
         }
@@ -5756,6 +5857,22 @@ pub(crate) unsafe fn actor_free_wasm_impl(actor: *mut HewActor) -> c_int {
     // SAFETY: the wait loop above ensures the actor is quiescent and not dispatching.
     unsafe { prepare_quiescent_actor_for_cleanup(actor) };
 
+    // Wake-proof + finalize decision by the CAS RESULT — parity with the native
+    // bulk/terminal free paths (`cleanup_all_actors`, `drain_quiesced_actor`)
+    // and the same primitive `hew_actor_free_inner` applies inline. WASM is
+    // single-threaded, so the latch always observes the quiescent state the
+    // gate above checked: `Ok ⇒ Finalize(Idle)` or `Err(Stopped|Crashed) ⇒
+    // Finalize(s)`. The `Skip` arm is unreachable here (no concurrent waker) but
+    // fails closed — leaving the actor tracked and unfreed — if it ever fires.
+    // SAFETY: actor is valid and quiescent.
+    let finalize_state = match decide_finalize_by_latch(a) {
+        FinalizeDecision::Finalize(state) => state,
+        FinalizeDecision::Skip => {
+            crate::set_last_error("hew_actor_free: actor re-enqueued; leaked fail-closed");
+            return -2;
+        }
+    };
+
     if !live_actors::untrack_actor(actor) {
         crate::set_last_error("hew_actor_free: actor already freed or not tracked");
         return -1;
@@ -5769,8 +5886,9 @@ pub(crate) unsafe fn actor_free_wasm_impl(actor: *mut HewActor) -> c_int {
         "send_pin_count must be 0 before finalize in actor_free_wasm_impl"
     );
 
-    // SAFETY: actor is quiescent, no longer tracked, and not being dispatched.
-    unsafe { finalize_quiescent_actor_cleanup(actor, state) };
+    // SAFETY: actor is quiescent, wake-proofed, no longer tracked, and not
+    // being dispatched.
+    unsafe { finalize_quiescent_actor_cleanup(actor, finalize_state) };
     0
 }
 
@@ -6980,9 +7098,9 @@ mod tests {
     /// `post_latch_inject_send_pin` BEFORE it decrements `send_pin_count`.
     /// On the fixed code the freer spins until the pin drops, so the bg
     /// thread runs while the freer is blocked and `SEND_PIN_DRAIN_WAITED` is
-    /// `true` when the freer proceeds to finalize.  On 520ad161d (no drain
-    /// loop) the freer proceeds to finalize immediately (no spin); the bg
-    /// thread is still sleeping so `SEND_PIN_DRAIN_WAITED` is `false` when
+    /// `true` when the freer proceeds to finalize.  Without the post-untrack
+    /// pin-drain loop the freer proceeds to finalize immediately (no spin); the
+    /// bg thread is still sleeping so `SEND_PIN_DRAIN_WAITED` is `false` when
     /// `hew_actor_free` returns → assertion fails → test fails.
     static SEND_PIN_DRAIN_WAITED: AtomicBool = AtomicBool::new(false);
 
@@ -7015,8 +7133,8 @@ mod tests {
             std::thread::sleep(std::time::Duration::from_millis(60));
 
             // Check the cancel flag set by the test thread after free returns.
-            // On 520ad161d (no pin drain spin) free returns immediately and
-            // CANCEL is set before we wake — we must NOT do the fetch_sub on
+            // Without the post-untrack pin-drain spin, free returns immediately
+            // and CANCEL is set before we wake — we must NOT do the fetch_sub on
             // the now-freed box.
             if SEND_PIN_TEST_CANCEL.load(Ordering::Acquire) {
                 return;
@@ -7038,17 +7156,17 @@ mod tests {
     /// Verify that `hew_actor_free` drains all send pins **before** finalizing
     /// (calling terminate + freeing the box), not before the quiescence check.
     ///
-    /// **Why this test catches the TOCTOU bug in 520ad161d:**
+    /// **Why this test catches the post-untrack pin-drain TOCTOU bug:**
     ///
-    /// 520ad161d checked `send_pin_count == 0` inside the quiescence *wait
-    /// loop* (before the latch), not after `untrack_actor`.  The post-latch
-    /// hook fires AFTER the latch succeeds but BEFORE `untrack_actor`.  In
-    /// that window, `with_actor_send_by_id` can still find the actor in the
+    /// The pre-drain form checked `send_pin_count == 0` inside the quiescence
+    /// *wait loop* (before the latch), not after `untrack_actor`.  The
+    /// post-latch hook fires AFTER the latch succeeds but BEFORE `untrack_actor`.
+    /// In that window, `with_actor_send_by_id` can still find the actor in the
     /// map and increment the pin — the quiescence check that passed was
-    /// already stale.  520ad161d then proceeded to `untrack_actor` +
+    /// already stale.  That form then proceeded to `untrack_actor` +
     /// `finalize` without waiting → use-after-free.
     ///
-    /// **On 520ad161d (FAIL):** the hook increments `send_pin_count`; free
+    /// **Pre-drain form (FAIL):** the hook increments `send_pin_count`; free
     /// has no pin-drain loop after `untrack_actor` → proceeds to finalize
     /// immediately → returns in < 5 ms.  The bg thread wakes at 60 ms, finds
     /// `CANCEL == true` (set just after free returned), skips the `fetch_sub`
@@ -7085,7 +7203,7 @@ mod tests {
 
         set_free_post_latch_hook_for_test(None);
         // Signal the bg thread: if free returned before the bg thread ran
-        // (the 520ad161d regression path), the bg thread must not touch the
+        // (the pre-drain regression path), the bg thread must not touch the
         // freed box.
         SEND_PIN_TEST_CANCEL.store(true, Ordering::Release);
 
@@ -7094,7 +7212,7 @@ mod tests {
         // proceeded to finalize it observed WAITED = true, meaning all pins
         // were drained before finalize ran.
         //
-        // 520ad161d: free returned before the bg thread ran → WAITED = false.
+        // Pre-drain form: free returned before the bg thread ran → WAITED = false.
         assert!(
             SEND_PIN_DRAIN_WAITED.load(Ordering::Acquire),
             "hew_actor_free must drain all send pins before finalizing the actor \
@@ -7110,7 +7228,7 @@ mod tests {
     }
 
     /// Forced-ordering regression for the `cleanup_all_actors` re-enqueue UAF
-    /// (cap-xeco3 / fourth review round).
+    /// in the post-prepare latch window.
     ///
     /// A pinned by-ID sender that incremented `send_pin_count` before
     /// `drain_all_for_cleanup` removed the map entry can still be running its
@@ -7207,6 +7325,267 @@ mod tests {
                 .store(HewActorState::Stopped as i32, Ordering::Release);
             finalize_quiescent_actor_cleanup(actor, HewActorState::Stopped as i32);
         }
+    }
+
+    /// Deterministic free-vs-leak probe for the `cleanup_all_actors`
+    /// *snapshot-already-non-Idle* re-enqueue UAF.
+    ///
+    /// Set by [`cleanup_runnable_leak_state_drop_callback`] when (and only when)
+    /// `free_actor_resources` runs the codegen state-drop — i.e. when the actor
+    /// was *finalized* (freed).  A leaked (skipped) actor never reaches finalize,
+    /// so the counter stays 0.  Reading this global (not the actor box) keeps the
+    /// assertion well-defined on BOTH the buggy path (box freed) and the fixed
+    /// path (box leaked): no use-after-free read is needed to tell them apart.
+    static CLEANUP_RUNNABLE_LEAK_STATE_DROP_COUNT: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+
+    unsafe extern "C" fn cleanup_runnable_leak_state_drop_callback(_state: *mut c_void) {
+        CLEANUP_RUNNABLE_LEAK_STATE_DROP_COUNT.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Forced-ordering regression for the `cleanup_all_actors`
+    /// *snapshot-already-non-Idle* re-enqueue UAF.
+    ///
+    /// Companion to `cleanup_skips_actor_reenqueued_during_latch_window`, which
+    /// covers the window where the wake CAS lands AFTER cleanup loads the state.
+    /// This test covers the window a stale-snapshot decision MISSES: a pinned
+    /// by-ID sender wins `CAS Idle→Runnable` BEFORE cleanup reaches the actor, so
+    /// the actor is already `Runnable` (re-enqueued) when the finalize decision
+    /// runs.
+    ///
+    /// We reproduce that window deterministically and end-to-end: store
+    /// `Runnable` AND `sched_enqueue` the actor into the scheduler's global
+    /// queue BEFORE `cleanup_all_actors` runs — exactly the end-state of a
+    /// pinned by-ID sender that won `CAS Idle→Runnable` + `sched_enqueue` before
+    /// the sweep reached the actor. `drain_all_for_cleanup` untracks it, and the
+    /// per-actor finalize decision then observes `Runnable`. After cleanup we
+    /// DRAIN the queue (`pop_global`) and deref the popped pointer — the
+    /// "anything ever drains `global_queue` post-cleanup" scenario, where a
+    /// later consumer pops the queue — proving the leaked pointer still resolves
+    /// to a live actor (no UAF). On the buggy path that deref would hit freed
+    /// memory, but the counter assertion fails first, so the deref only runs once
+    /// the fix has proven the box was leaked, not freed.
+    ///
+    /// **Under a snapshot-gated decision (FAIL):** cleanup loads `state =
+    /// Runnable`, the `if state == Idle` short-circuits (no latch CAS, no
+    /// fail-closed `continue`), and `finalize_quiescent_actor_cleanup(actor,
+    /// Runnable)` frees the re-enqueued actor — state-drop runs → counter == 1 →
+    /// assertion fails. (A scheduler queue holding the now-dangling pointer is
+    /// the UAF.)
+    ///
+    /// **Under the CAS-result decision (PASS):** the finalize decision attempts
+    /// `CAS Idle→Stopped`, observes `Err(Runnable)`, and SKIPs (leaks
+    /// fail-closed) — finalize never runs → counter == 0 → assertion passes.
+    /// The leaked actor is reclaimed manually at the end so the test does not
+    /// leak.
+    #[test]
+    fn cleanup_skips_actor_already_runnable_before_finalize_decision() {
+        let _guard = crate::runtime_test_guard();
+        let scheduler = scheduler::NoWorkerSchedulerForTest::install();
+        let _tracing = crate::tracing::tracing_test_guard();
+
+        CLEANUP_RUNNABLE_LEAK_STATE_DROP_COUNT.store(0, Ordering::SeqCst);
+
+        // Spawn with a malloc'd source so `state` is non-null: the state-drop
+        // callback only fires when finalize runs over a non-null, non-crashed
+        // state — that is the "was freed" signal.
+        // SAFETY: malloc returns a valid 8-byte allocation or null.
+        let src = unsafe { libc::malloc(8) };
+        assert!(!src.is_null());
+        // SAFETY: spawn deep-copies the bytes; src is released immediately after.
+        let actor = unsafe { hew_actor_spawn(src, 8, Some(noop_dispatch)) };
+        assert!(!actor.is_null());
+        // SAFETY: spawn copied the bytes; release the source allocation.
+        unsafe { libc::free(src) };
+
+        // SAFETY: actor is valid and not being dispatched.
+        unsafe {
+            hew_actor_set_state_drop(actor, cleanup_runnable_leak_state_drop_callback);
+            assert!(
+                !(*actor).state.is_null(),
+                "spawn must produce a non-null state for the state-drop signal"
+            );
+            // Simulate the end-state of a pinned by-ID sender that already won
+            // `CAS Idle→Runnable` (+ `sched_enqueue`) BEFORE the sweep loop
+            // observes this actor — the exact snapshot-already-non-Idle window.
+            (*actor)
+                .actor_state
+                .store(HewActorState::Runnable as i32, Ordering::Release);
+        }
+
+        // Genuinely enqueue the actor, so this is "Runnable AND queued" — the
+        // real shape of a won wake CAS, not just a state store. `sched_enqueue`
+        // pushes the raw pointer into the global queue and notifies a parker
+        // (no worker exists to deref it under NoWorkerSchedulerForTest).
+        scheduler::sched_enqueue(actor);
+
+        // SAFETY: scheduler is stopped (NoWorkerSchedulerForTest installed); no
+        // dispatch is in progress.
+        unsafe { cleanup_all_actors() };
+
+        // Load-bearing assertion: a `Runnable` (re-enqueued) actor must be
+        // SKIPPED, not finalized.  state-drop running means finalize ran means
+        // the queued actor was freed — the use-after-free.  Reads only the
+        // global counter, never the (possibly-freed) actor box.
+        assert_eq!(
+            CLEANUP_RUNNABLE_LEAK_STATE_DROP_COUNT.load(Ordering::SeqCst),
+            0,
+            "cleanup_all_actors must SKIP (leak) an actor that is Runnable at the \
+             finalize decision; a non-zero count means it ran finalize over a \
+             re-enqueued actor (the snapshot-already-Runnable use-after-free)"
+        );
+
+        // Drain the scheduler queue exactly as a post-cleanup consumer would.
+        // The pointer cleanup left enqueued must still be VALID. On the buggy
+        // (snapshot-gated) path cleanup freed this box, so this pop would return
+        // a dangling pointer and the deref below would read freed memory — but
+        // the counter assertion above already failed before we reach here, so
+        // the deref only ever runs on the fixed (leaked-not-freed) path. This is
+        // the "anything ever drains global_queue post-cleanup" scenario, made
+        // observable.
+        let popped = scheduler.pop_global();
+        assert_eq!(
+            popped,
+            Some(actor),
+            "the enqueued actor must still be in the scheduler queue (cleanup \
+             leaked it rather than freeing a queued pointer)"
+        );
+        // SAFETY: reached only because the counter assertion passed, i.e. cleanup
+        // leaked (did not free) the actor — the queued pointer is still valid.
+        let queued_state = unsafe { (*actor).actor_state.load(Ordering::Acquire) };
+        assert_eq!(
+            queued_state,
+            HewActorState::Runnable as i32,
+            "the queued pointer must still resolve to the live Runnable actor (no UAF)"
+        );
+
+        // The actor must be untracked (drain_all_for_cleanup removed it) even
+        // though cleanup skipped finalize.  Pointer-identity probe; no deref.
+        assert!(
+            !live_actors::is_actor_live(actor),
+            "actor must be untracked even when cleanup skips finalize"
+        );
+
+        // Manual reclaim: cleanup deliberately leaked this actor to avoid the
+        // UAF.  Finalize it here so the test itself does not leak.
+        // SAFETY: actor is valid, untracked, pin-free, no concurrent access.
+        unsafe {
+            (*actor)
+                .actor_state
+                .store(HewActorState::Stopped as i32, Ordering::Release);
+            finalize_quiescent_actor_cleanup(actor, HewActorState::Stopped as i32);
+        }
+        assert_eq!(
+            CLEANUP_RUNNABLE_LEAK_STATE_DROP_COUNT.load(Ordering::SeqCst),
+            1,
+            "manual reclaim must run state-drop exactly once (no leak)"
+        );
+    }
+
+    /// Deterministic free-vs-leak probe for the bonus `cleanup_all_actors`
+    /// *Suspended*-finalize fix.  Set by
+    /// [`cleanup_suspended_leak_state_drop_callback`] only when finalize runs
+    /// over the actor (i.e. it was freed); a leaked (skipped) actor never reaches
+    /// finalize, so the counter stays 0.
+    static CLEANUP_SUSPENDED_LEAK_STATE_DROP_COUNT: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+
+    unsafe extern "C" fn cleanup_suspended_leak_state_drop_callback(_state: *mut c_void) {
+        CLEANUP_SUSPENDED_LEAK_STATE_DROP_COUNT.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Forced-ordering regression for the bonus `cleanup_all_actors`
+    /// *Suspended*-finalize leak that the quiescence gate also closes.
+    ///
+    /// A `Suspended` actor is parked at a non-final `coro.suspend` with a live
+    /// continuation frame (`suspended_cont`).  `actor_free_state_is_quiescent`
+    /// excludes `Suspended`, so it is never safe to finalize on the shutdown
+    /// sweep: `hew_actor_free_inner` destroys the parked frame first, but
+    /// `cleanup_all_actors` (workers joined) cannot block to do so — it must
+    /// leak-not-free.
+    ///
+    /// **Under a snapshot-gated decision (FAIL):** cleanup loads `state =
+    /// Suspended`, the `if state == Idle` short-circuits (no latch, no
+    /// fail-closed `continue`), and `finalize_quiescent_actor_cleanup(actor,
+    /// Suspended)` frees the parked actor — running its state-drop and leaking
+    /// the continuation frame → counter == 1 → assertion fails.
+    ///
+    /// **Under the quiescence gate (PASS):** the finalize decision attempts `CAS
+    /// Idle→Stopped`, observes `Err(Suspended)`, and — because `Suspended` is
+    /// not `actor_free_state_is_quiescent` — SKIPs (leaks fail-closed) → finalize
+    /// never runs → counter == 0 → assertion passes.
+    ///
+    /// The finalize decision reads only `actor_state`, so storing `Suspended` is
+    /// the faithful observable; no real parked frame is needed to exercise the
+    /// gate.
+    #[test]
+    fn cleanup_skips_suspended_actor_at_finalize_decision() {
+        let _guard = crate::runtime_test_guard();
+        let _scheduler = scheduler::NoWorkerSchedulerForTest::install();
+        let _tracing = crate::tracing::tracing_test_guard();
+
+        CLEANUP_SUSPENDED_LEAK_STATE_DROP_COUNT.store(0, Ordering::SeqCst);
+
+        // Non-null state so the state-drop callback is the "was finalized" signal.
+        // SAFETY: malloc returns a valid 8-byte allocation or null.
+        let src = unsafe { libc::malloc(8) };
+        assert!(!src.is_null());
+        // SAFETY: spawn deep-copies the bytes; src is released immediately after.
+        let actor = unsafe { hew_actor_spawn(src, 8, Some(noop_dispatch)) };
+        assert!(!actor.is_null());
+        // SAFETY: spawn copied the bytes; release the source allocation.
+        unsafe { libc::free(src) };
+
+        // SAFETY: actor is valid and not being dispatched.
+        unsafe {
+            hew_actor_set_state_drop(actor, cleanup_suspended_leak_state_drop_callback);
+            assert!(
+                !(*actor).state.is_null(),
+                "spawn must produce a non-null state for the state-drop signal"
+            );
+            // Park the actor at a suspend point (non-quiescent). The finalize
+            // decision reads only `actor_state`, so this state store is the
+            // faithful observable of a parked actor at shutdown.
+            (*actor)
+                .actor_state
+                .store(HewActorState::Suspended as i32, Ordering::Release);
+        }
+
+        // SAFETY: scheduler is stopped (NoWorkerSchedulerForTest installed); no
+        // dispatch is in progress.
+        unsafe { cleanup_all_actors() };
+
+        // A `Suspended` actor is non-quiescent: cleanup must SKIP (leak) it,
+        // never finalize a parked actor.  counter != 0 means it freed one
+        // (and leaked the continuation frame).  Reads only the global counter.
+        assert_eq!(
+            CLEANUP_SUSPENDED_LEAK_STATE_DROP_COUNT.load(Ordering::SeqCst),
+            0,
+            "cleanup_all_actors must SKIP (leak) a Suspended actor; a non-zero \
+             count means it finalized a parked actor (freeing its box and leaking \
+             the continuation frame)"
+        );
+
+        // Untracked even though cleanup skipped finalize. Pointer-identity; no deref.
+        assert!(
+            !live_actors::is_actor_live(actor),
+            "actor must be untracked even when cleanup skips finalize"
+        );
+
+        // Manual reclaim so the test itself does not leak.  Drop to a terminal
+        // state first (no real frame was parked, so no destroy_parked needed).
+        // SAFETY: actor is valid, untracked, pin-free, no concurrent access.
+        unsafe {
+            (*actor)
+                .actor_state
+                .store(HewActorState::Stopped as i32, Ordering::Release);
+            finalize_quiescent_actor_cleanup(actor, HewActorState::Stopped as i32);
+        }
+        assert_eq!(
+            CLEANUP_SUSPENDED_LEAK_STATE_DROP_COUNT.load(Ordering::SeqCst),
+            1,
+            "manual reclaim must run state-drop exactly once (no leak)"
+        );
     }
 
     #[test]

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1087,10 +1087,13 @@ pub struct HewActor {
     /// `with_actor_send_by_id` increments this field (atomically, under
     /// `LIVE_ACTORS`) before releasing the registry lock, then decrements it
     /// via a RAII guard when the operation completes.  The free path in
-    /// `hew_actor_free_inner` treats `send_pin_count > 0` as non-quiescent:
-    /// it will not call `untrack_actor` or free the box until every in-flight
-    /// pin has been released, guaranteeing the allocation remains valid for
-    /// the duration of any by-ID mailbox send or actor stop.
+    /// `hew_actor_free_inner` calls `untrack_actor` first (removing the actor
+    /// from `LIVE_ACTORS` so no new pins can be taken), then spins until
+    /// `send_pin_count` reaches 0 (draining any in-flight pins taken before
+    /// the untrack) before calling `finalize`.  This untrack-first ordering
+    /// makes the pin-drain and the liveness check mutually exclusive: either
+    /// the sender pins before the freer untracks (freer waits), or the freer
+    /// untracks before the sender's map lookup (sender gets `None`, no pin).
     ///
     /// **Why not `dispatch_active`**: `dispatch_active` serialises the
     /// scheduler worker's activation ownership; reusing it for external sends
@@ -1392,6 +1395,11 @@ pub(crate) unsafe fn cleanup_all_actors() {
     live_actors::drain_deferred_teardown_threads();
 
     let actors = live_actors::drain_all_for_cleanup();
+    // After drain_all_for_cleanup LIVE_ACTORS is empty: any subsequent
+    // `with_actor_send_by_id` for these actors returns None (map lookup
+    // fails), so no new send pins can be taken.  Drain any in-flight pins
+    // before finalizing each actor.  LIVE_ACTORS is not held here, so
+    // pinned senders can re-acquire it freely (e.g. enqueue_resume).
 
     for live_actors::ActorPtr(actor) in actors.into_values() {
         if actor.is_null() {
@@ -1420,11 +1428,52 @@ pub(crate) unsafe fn cleanup_all_actors() {
             crate::scheduler_wasm::cancel_actor_sleep_queue_entry(actor);
         }
 
+        // Drain send pins.  All worker threads are joined before this runs,
+        // so send_pin_count should be 0.  The spin is a safety net for
+        // unusual paths (e.g. a non-runtime thread that holds a pin during
+        // shutdown); on timeout we log and skip finalize for this actor
+        // (fail-closed: leak) to avoid freeing under an active pin.
+        // SAFETY: LIVE_ACTORS is not held here; no deadlock risk.
+        {
+            // SAFETY: actor came from LIVE_ACTORS (non-null check above);
+            // the scheduler is shut down, so no concurrent dispatch is possible.
+            let a = unsafe { &*actor };
+            debug_assert_eq!(
+                a.send_pin_count.load(Ordering::Acquire),
+                0,
+                "send_pin_count must be 0 in cleanup_all_actors (single-threaded)"
+            );
+            let pin_deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            let mut pinned = false;
+            loop {
+                if a.send_pin_count.load(Ordering::Acquire) == 0 {
+                    break;
+                }
+                if std::time::Instant::now() >= pin_deadline {
+                    eprintln!(
+                        "hew: runtime error: actor {:#x} send pins did not drain \
+                     during shutdown cleanup; actor leaked to avoid UAF",
+                        a.id
+                    );
+                    pinned = true;
+                    break;
+                }
+                #[cfg(target_arch = "wasm32")]
+                std::hint::spin_loop();
+                #[cfg(not(target_arch = "wasm32"))]
+                std::thread::yield_now();
+            }
+            if pinned {
+                continue;
+            }
+        }
+
         // Run terminate for actors that never reached a terminal state
         // (still IDLE at process exit). Skip crashed actors — their state
         // may be corrupted. `finalize_quiescent_actor_cleanup` performs the
         // terminate-or-skip dance plus the resource free.
-        // SAFETY: actor is quiescent and no longer tracked.
+        // SAFETY: actor is quiescent, no longer tracked, and all send pins
+        // have drained (verified above).
         unsafe { finalize_quiescent_actor_cleanup(actor, state) };
     }
 }
@@ -2847,14 +2896,19 @@ pub unsafe extern "C" fn hew_actor_send_by_id(
     data: *mut c_void,
     size: usize,
 ) -> c_int {
-    // Hold LIVE_ACTORS across the lookup and dispatch to close the TOCTOU
-    // window between pointer retrieval and dereference.  A concurrent
-    // hew_actor_free_inner cannot free the actor while the closure runs
-    // (untrack_actor runs under the same lock, before hew_actor_free_box).
+    // Use the liveness-pin protocol: under LIVE_ACTORS, validate the actor
+    // and increment its `send_pin_count`; release the lock; run the send;
+    // the RAII SendPinGuard decrements the pin on return.  The free path
+    // calls `untrack_actor` first (so no new pins can be taken after that
+    // point), then spins until `send_pin_count == 0` before finalizing.
+    // Because pin-increment and map-removal are both under LIVE_ACTORS, the
+    // two are mutually exclusive: this send either pins before the freer
+    // untracks (freer waits) or the freer untracks before this map lookup
+    // (lookup returns None, no pin, no UAF).
     let sent = live_actors::with_actor_send_by_id(actor_id, |actor| {
-        // SAFETY: `actor` is tracked in LIVE_ACTORS and the registry lock is
-        // held for this closure; the allocation is valid for the send.  Same
-        // data/size preconditions as hew_actor_send.
+        // SAFETY: `actor` is pinned live by `with_actor_send_by_id`;
+        // the allocation is guaranteed valid for the duration of this
+        // closure.  Same data/size preconditions as hew_actor_send.
         unsafe { actor_send_internal(actor, msg_type, data, size) }
     });
     if sent == Some(true) {
@@ -3251,16 +3305,14 @@ unsafe fn hew_actor_free_inner(actor: *mut HewActor, suppress_state_drop: bool) 
             // pairs with the guard's `Release` clear so we also observe every
             // write the activation made before we proceed to free.
             //
-            // `send_pin_count > 0` means a `with_actor_send_by_id` operation is
-            // currently using the actor pointer after releasing `LIVE_ACTORS`.
-            // We must not free until the pin drops (the send/stop finishes),
-            // otherwise we get a use-after-free in the send path.  The pin is
-            // decremented with `Release` ordering, so this `Acquire` load
-            // observes the end of the by-ID operation before we proceed.
-            if actor_free_state_is_quiescent(state)
-                && !a.dispatch_active.load(Ordering::Acquire)
-                && a.send_pin_count.load(Ordering::Acquire) == 0
-            {
+            // `send_pin_count` is NOT checked here.  Instead we untrack the actor
+            // first (so no new pins can be taken) and then drain any in-flight
+            // pins after the untrack — see below.  The untrack-first ordering
+            // makes the two operations mutually exclusive: either the sender pins
+            // before the freer's map removal (freer waits in the drain loop), or
+            // the freer removes the map entry before the sender's lookup (sender
+            // gets `None`, no pin, no UAF).
+            if actor_free_state_is_quiescent(state) && !a.dispatch_active.load(Ordering::Acquire) {
                 break;
             }
             if std::time::Instant::now() >= deadline {
@@ -3347,8 +3399,27 @@ unsafe fn hew_actor_free_inner(actor: *mut HewActor, suppress_state_drop: bool) 
         return -1;
     }
 
+    // After untrack_actor the map entry is removed: any subsequent
+    // `with_actor_send_by_id` for this actor gets `None` from the map
+    // lookup, so no new send pins can be taken.  Drain any in-flight pins
+    // that were incremented before the untrack (e.g. a concurrent by-ID
+    // send that pinned the actor just before the map entry was removed).
+    // LIVE_ACTORS is NOT held here, so pinned senders can freely re-acquire
+    // it (e.g. via `enqueue_resume` → `with_live_actor`) without deadlock.
+    // The `Release` in `SendPinGuard::drop` pairs with this `Acquire` load.
+    loop {
+        if a.send_pin_count.load(Ordering::Acquire) == 0 {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            crate::set_last_error("hew_actor_free: send pins did not drain after timeout");
+            return -2;
+        }
+        std::thread::yield_now();
+    }
+
     // SAFETY: actor is quiescent (re-verified after detach), no longer tracked,
-    // and not being dispatched.
+    // all send pins drained, and not being dispatched.
     unsafe { finalize_quiescent_actor_cleanup_with_options(actor, state, suppress_state_drop) };
     0
 }
@@ -3395,14 +3466,38 @@ fn drain_backoff_duration(delay: std::time::Duration) -> std::time::Duration {
 /// in `LIVE_ACTORS`. `state` must be the value loaded from `actor_state`
 /// immediately before this call.
 #[cfg(not(target_arch = "wasm32"))]
-unsafe fn drain_quiesced_actor(actor_id: ActorId, expected: *mut HewActor, state: i32) {
+unsafe fn drain_quiesced_actor(
+    actor_id: ActorId,
+    expected: *mut HewActor,
+    state: i32,
+    deadline: std::time::Instant,
+) {
     // SAFETY: caller guarantees `expected` is quiescent and still tracked in
     // LIVE_ACTORS. prepare_quiescent_actor_for_cleanup must run before
     // untracking so that any in-flight timer callback or signal propagation
     // still observes the actor as live and bails out cooperatively.
     unsafe { prepare_quiescent_actor_for_cleanup(expected) };
     if let Some(actor) = live_actors::take_actor_by_id(actor_id, expected) {
-        // SAFETY: the actor is quiescent, prepared for cleanup, and no longer tracked.
+        // After take_actor_by_id the map entry is removed: no new send pins
+        // can be taken.  Drain any in-flight pins before finalizing.
+        // LIVE_ACTORS is not held here; pinned senders can re-acquire it.
+        // SAFETY: actor is a live pointer returned by take_actor_by_id.
+        let a = unsafe { &*actor };
+        loop {
+            if a.send_pin_count.load(Ordering::Acquire) == 0 {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                crate::set_last_error(
+                    "drain_quiesced_actor: send pins did not drain after timeout",
+                );
+                // Fail-closed: actor is untracked but not freed (leak).
+                return;
+            }
+            std::thread::yield_now();
+        }
+        // SAFETY: the actor is quiescent, prepared for cleanup, no longer tracked,
+        // and all send pins have drained.
         unsafe { finalize_quiescent_actor_cleanup(actor, state) };
     }
 }
@@ -3447,7 +3542,7 @@ pub fn drain_actors(ids: &[ActorId], deadline: std::time::Instant) -> DrainOutco
                 }
                 Some(state) if actor_free_state_is_quiescent(state) => {
                     // SAFETY: `expected` is quiescent and still tracked in LIVE_ACTORS.
-                    unsafe { drain_quiesced_actor(actor_id, expected, state) };
+                    unsafe { drain_quiesced_actor(actor_id, expected, state, deadline) };
                     pending.swap_remove(index);
                 }
                 Some(_) => {
@@ -3482,7 +3577,7 @@ pub fn drain_actors(ids: &[ActorId], deadline: std::time::Instant) -> DrainOutco
             Some(state) if state == HewActorState::Crashed as i32 => crashed.push(actor_id),
             Some(state) if actor_free_state_is_quiescent(state) => {
                 // SAFETY: `expected` is quiescent and still tracked in LIVE_ACTORS.
-                unsafe { drain_quiesced_actor(actor_id, expected, state) };
+                unsafe { drain_quiesced_actor(actor_id, expected, state, deadline) };
             }
             Some(_) => still_live.push(actor_id),
         }
@@ -4530,17 +4625,15 @@ pub(crate) unsafe fn hew_actor_ask_by_id(
     // closure preserves the same actor-ID/data preconditions.
     let send_result_code = unsafe {
         submit_ask_with_reply_channel(ch, AskReplyChannelFailureCleanup::FreeCreatorRef, |ch| {
-            // Hold LIVE_ACTORS across the lookup and dispatch to close the
-            // TOCTOU window between pointer retrieval and dereference.  A
-            // concurrent hew_actor_free_inner cannot free the actor while the
-            // closure runs (untrack_actor runs under the same lock, before
-            // hew_actor_free_box).
+            // Use the liveness-pin protocol (same as hew_actor_send_by_id):
+            // under LIVE_ACTORS, validate + pin; release lock; run the send;
+            // SendPinGuard decrements on return.  The untrack-first free path
+            // cannot finalize while this pin is held.
             live_actors::with_actor_send_by_id(actor_id, |actor| {
-                // SAFETY: `actor` is tracked in LIVE_ACTORS and the registry
-                // lock is held for this closure; the allocation is valid.  `ch`
-                // is a live reply channel retained above.  Same data/size
-                // preconditions as hew_actor_ask.  Outer `unsafe` block covers
-                // this call.
+                // SAFETY: `actor` is pinned live by `with_actor_send_by_id`;
+                // allocation valid for the closure.  `ch` is a live reply
+                // channel retained above.  Same data/size preconditions as
+                // hew_actor_ask.  Outer `unsafe` block covers this call.
                 actor_send_result_internal_reply(actor, msg_type, data, size, ch.cast())
             })
             .unwrap_or(HewError::ErrActorStopped as i32)
@@ -5571,6 +5664,14 @@ pub(crate) unsafe fn actor_free_wasm_impl(actor: *mut HewActor) -> c_int {
         crate::set_last_error("hew_actor_free: actor already freed or not tracked");
         return -1;
     }
+
+    // WASM is single-threaded: no concurrent by-ID operations can hold a
+    // pin after we reach this point.
+    debug_assert_eq!(
+        a.send_pin_count.load(Ordering::Acquire),
+        0,
+        "send_pin_count must be 0 before finalize in actor_free_wasm_impl"
+    );
 
     // SAFETY: actor is quiescent, no longer tracked, and not being dispatched.
     unsafe { finalize_quiescent_actor_cleanup(actor, state) };
@@ -6773,6 +6874,141 @@ mod tests {
             queued_after_free, None,
             "no actor pointer may remain queued after free (a queued pointer here \
              would dangle — the use-after-free)"
+        );
+        drop(sched);
+    }
+
+    // ── Forced-ordering test: free must drain send pins before finalizing ──
+
+    /// Set to `true` by the background thread spawned by
+    /// `post_latch_inject_send_pin` BEFORE it decrements `send_pin_count`.
+    /// On the fixed code the freer spins until the pin drops, so the bg
+    /// thread runs while the freer is blocked and `SEND_PIN_DRAIN_WAITED` is
+    /// `true` when the freer proceeds to finalize.  On 520ad161d (no drain
+    /// loop) the freer proceeds to finalize immediately (no spin); the bg
+    /// thread is still sleeping so `SEND_PIN_DRAIN_WAITED` is `false` when
+    /// `hew_actor_free` returns → assertion fails → test fails.
+    static SEND_PIN_DRAIN_WAITED: AtomicBool = AtomicBool::new(false);
+
+    /// Set to `true` by the test thread immediately after `hew_actor_free`
+    /// returns.  The background thread checks this flag before decrementing
+    /// the pin: on the old (unfixed) code, free returned while the bg thread
+    /// was still sleeping; setting CANCEL prevents the bg thread from
+    /// performing a use-after-free write to the freed actor box.
+    static SEND_PIN_TEST_CANCEL: AtomicBool = AtomicBool::new(false);
+
+    /// Post-latch hook for `free_waits_for_send_pin_drain_before_finalize`.
+    ///
+    /// Simulates a concurrent by-ID sender that managed to pin the actor
+    /// after the quiescence check but before `untrack_actor`.  Increments
+    /// `send_pin_count` directly (as `with_actor_send_by_id` would) and
+    /// spawns a background thread that will release the pin after a delay
+    /// long enough to distinguish "free waited" from "free raced ahead".
+    fn post_latch_inject_send_pin(actor: *mut HewActor) {
+        // Simulate pin-increment (the step with_actor_send_by_id performs
+        // under LIVE_ACTORS before releasing the lock).
+        // SAFETY: the actor is still live; free holds it across this hook.
+        unsafe { (*actor).send_pin_count.fetch_add(1, Ordering::AcqRel) };
+
+        // Cast to usize so the closure captures a Send-safe integer.
+        // (RFC 2229 field-level capture would capture `ap.0: *mut HewActor`
+        // — not Send — if we used a newtype wrapper with a field access.)
+        let actor_addr = actor as usize;
+        std::thread::spawn(move || {
+            // Sleep long enough that an unblocked freer returns before we run.
+            std::thread::sleep(std::time::Duration::from_millis(60));
+
+            // Check the cancel flag set by the test thread after free returns.
+            // On 520ad161d (no pin drain spin) free returns immediately and
+            // CANCEL is set before we wake — we must NOT do the fetch_sub on
+            // the now-freed box.
+            if SEND_PIN_TEST_CANCEL.load(Ordering::Acquire) {
+                return;
+            }
+
+            // Record that we ran before decrementing — the freer must observe
+            // this flag as `true` when it proceeds past the pin drain loop.
+            SEND_PIN_DRAIN_WAITED.store(true, Ordering::Release);
+
+            // Release the pin.  The freer's Acquire load of send_pin_count
+            // pairs with this Release, so it sees all writes we made above.
+            let actor_ptr = actor_addr as *mut HewActor;
+            // SAFETY: CANCEL was false → free is still spinning (pin drain loop),
+            // so the actor box is still live and the atomic write is valid.
+            unsafe { (*actor_ptr).send_pin_count.fetch_sub(1, Ordering::Release) };
+        });
+    }
+
+    /// Verify that `hew_actor_free` drains all send pins **before** finalizing
+    /// (calling terminate + freeing the box), not before the quiescence check.
+    ///
+    /// **Why this test catches the TOCTOU bug in 520ad161d:**
+    ///
+    /// 520ad161d checked `send_pin_count == 0` inside the quiescence *wait
+    /// loop* (before the latch), not after `untrack_actor`.  The post-latch
+    /// hook fires AFTER the latch succeeds but BEFORE `untrack_actor`.  In
+    /// that window, `with_actor_send_by_id` can still find the actor in the
+    /// map and increment the pin — the quiescence check that passed was
+    /// already stale.  520ad161d then proceeded to `untrack_actor` +
+    /// `finalize` without waiting → use-after-free.
+    ///
+    /// **On 520ad161d (FAIL):** the hook increments `send_pin_count`; free
+    /// has no pin-drain loop after `untrack_actor` → proceeds to finalize
+    /// immediately → returns in < 5 ms.  The bg thread wakes at 60 ms, finds
+    /// `CANCEL == true` (set just after free returned), skips the `fetch_sub`
+    /// (no UAF).  `SEND_PIN_DRAIN_WAITED` is `false` → assertion fails.
+    ///
+    /// **On fixed code (PASS):** free calls `untrack_actor`, then spins on
+    /// `send_pin_count`.  The bg thread wakes at 60 ms, sees `CANCEL ==
+    /// false` (free still spinning), stores `SEND_PIN_DRAIN_WAITED = true`,
+    /// decrements pin.  Free sees pin == 0, finalize, return.  Assertion
+    /// passes.
+    #[test]
+    fn free_waits_for_send_pin_drain_before_finalize() {
+        let _guard = crate::runtime_test_guard();
+        // Worker-less scheduler: same setup as the latch / reactor tests.
+        let sched = scheduler::NoWorkerSchedulerForTest::install();
+        let _tracing = crate::tracing::tracing_test_guard();
+
+        // SAFETY: null state + valid dispatch are valid spawn args.
+        let actor = unsafe { hew_actor_spawn(ptr::null_mut(), 0, Some(noop_dispatch)) };
+        assert!(!actor.is_null());
+
+        // Freshly spawned actors are Idle — the quiescence wait passes
+        // immediately so the post-latch hook fires before untrack.
+        // SAFETY: actor is valid (just spawned); the state field is always initialized.
+        let spawned_state = unsafe { (*actor).actor_state.load(Ordering::Acquire) };
+        assert_eq!(spawned_state, HewActorState::Idle as i32);
+
+        SEND_PIN_DRAIN_WAITED.store(false, Ordering::Release);
+        SEND_PIN_TEST_CANCEL.store(false, Ordering::Release);
+        set_free_post_latch_hook_for_test(Some(post_latch_inject_send_pin));
+
+        // SAFETY: actor is valid; free is the operation under test.
+        let rc = unsafe { hew_actor_free(actor) };
+
+        set_free_post_latch_hook_for_test(None);
+        // Signal the bg thread: if free returned before the bg thread ran
+        // (the 520ad161d regression path), the bg thread must not touch the
+        // freed box.
+        SEND_PIN_TEST_CANCEL.store(true, Ordering::Release);
+
+        // Fixed code: free spun until the bg thread decremented send_pin_count;
+        // the bg thread stored WAITED = true before decrementing, so when free
+        // proceeded to finalize it observed WAITED = true, meaning all pins
+        // were drained before finalize ran.
+        //
+        // 520ad161d: free returned before the bg thread ran → WAITED = false.
+        assert!(
+            SEND_PIN_DRAIN_WAITED.load(Ordering::Acquire),
+            "hew_actor_free must drain all send pins before finalizing the actor \
+             box; if this assertion fails, finalize ran while a send pin was held \
+             (use-after-free window)"
+        );
+        assert_eq!(rc, 0, "hew_actor_free must succeed (got {rc})");
+        assert!(
+            !live_actors::is_actor_live(actor),
+            "freed actor must no longer be tracked in LIVE_ACTORS"
         );
         drop(sched);
     }

--- a/hew-runtime/src/actor_group.rs
+++ b/hew-runtime/src/actor_group.rs
@@ -283,11 +283,27 @@ pub unsafe extern "C" fn hew_actor_group_stop_all(g: *mut HewActorGroup) {
     let group = unsafe { &*g };
 
     let _guard = group.lock.lock_or_recover();
-    for &(_actor_id, actor_ptr) in &group.actors {
-        if !actor_ptr.is_null() {
-            // SAFETY: actor pointer is valid per add contract.
-            unsafe { actor::hew_actor_stop(actor_ptr.cast()) };
+    for &(actor_id, actor_ptr) in &group.actors {
+        if actor_ptr.is_null() {
+            continue;
         }
+        // G-1 fix: use the same send-pin mechanism as the by-ID send paths so
+        // that a concurrent supervisor free cannot reclaim the actor allocation
+        // between the registry lookup and the `hew_actor_stop` call.
+        //
+        // `with_actor_send_by_id` increments `send_pin_count` under
+        // `LIVE_ACTORS` before releasing the registry lock, so the free path's
+        // quiescence loop waits for the pin to drop before calling
+        // `untrack_actor` + `finalize`.  `hew_actor_stop` does NOT hold
+        // `LIVE_ACTORS`, so the terminate callback (user `#[on(stop)]` code)
+        // can safely call `hew_actor_send_by_id` without self-deadlocking.
+        //
+        // `None` means the actor was already freed by the supervisor; that is
+        // terminal and requires no stop signal.
+        live_actors::with_actor_send_by_id(actor_id, |a| {
+            // SAFETY: `a` is pinned live for the duration of this closure.
+            unsafe { actor::hew_actor_stop(a.cast()) };
+        });
     }
 }
 
@@ -428,6 +444,7 @@ mod tests {
             suspended_cancel_token: AtomicPtr::new(ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
             runtime: ptr::null(),
+            send_pin_count: std::sync::atomic::AtomicU32::new(0),
         }
     }
 
@@ -531,5 +548,176 @@ mod tests {
         // SAFETY: group is valid and no longer used after this.
         unsafe { hew_actor_group_destroy(group) };
         // TrackedActor::drop calls untrack_actor idempotently (no-op) then frees box.
+    }
+
+    /// F-2 deadlock regression: `with_actor_send_by_id` must NOT hold `LIVE_ACTORS`
+    /// while the mailbox send is in progress.
+    ///
+    /// The old implementation held `LIVE_ACTORS` for the entire send closure.
+    /// For a `Block`-policy mailbox at capacity this caused a self-deadlock: the
+    /// condvar wait parks the thread while `LIVE_ACTORS` is held, and ANY
+    /// concurrent `with_live_actor` (e.g. `enqueue_resume` on a `DropOld` eviction)
+    /// tries to re-acquire the same non-reentrant mutex on the same thread.
+    ///
+    /// The fix (liveness-pin): increment `send_pin_count` under `LIVE_ACTORS`,
+    /// RELEASE the lock, then do the mailbox send.  The free path defers the free
+    /// until `send_pin_count` drops to 0.
+    ///
+    /// This test verifies the no-deadlock property deterministically:
+    ///  1. An actor with a Block mailbox of capacity 1 is created and tracked.
+    ///  2. The mailbox is filled (1 message).
+    ///  3. A background thread calls `hew_actor_send_by_id` — this enters the
+    ///     Block condvar wait OUTSIDE `LIVE_ACTORS`.
+    ///  4. The main thread closes the mailbox → the Block wait wakes with Closed
+    ///     → the background thread returns promptly (no deadlock).
+    ///  5. The whole sequence completes within a 1-second timeout (a deadlock
+    ///     would hang for 30+ seconds and cause the test to fail).
+    ///
+    /// Self-send variant: we also confirm that calling `with_actor_send_by_id`
+    /// from the main thread and then calling `is_actor_live` (which acquires
+    /// `LIVE_ACTORS`) from another thread during the send does not deadlock.
+    #[test]
+    fn send_by_id_block_mailbox_full_does_not_deadlock() {
+        let _rt = crate::runtime_test_guard();
+
+        // Build an actor with a Block mailbox of capacity 1.
+        let actor_id = next_id();
+        // SAFETY: hew_mailbox_new_with_policy returns a Box-allocated mailbox.
+        let mb = unsafe {
+            crate::mailbox::hew_mailbox_new_with_policy(1, crate::mailbox::OverflowPolicy::Block)
+        };
+        assert!(!mb.is_null());
+
+        let actor = TrackedActor::install(HewActor {
+            sched_link_next: AtomicPtr::new(ptr::null_mut()),
+            id: actor_id,
+            state: ptr::null_mut(),
+            state_size: 0,
+            dispatch: None,
+            mailbox: mb.cast(),
+            actor_state: AtomicI32::new(HewActorState::Idle as i32),
+            budget: AtomicI32::new(HEW_MSG_BUDGET),
+            init_state: ptr::null_mut(),
+            init_state_size: 0,
+            coalesce_key_fn: None,
+            terminate_fn: None,
+            state_drop_fn: None,
+            state_clone_fn: None,
+            terminate_called: AtomicBool::new(false),
+            terminate_finished: AtomicBool::new(false),
+            dispatch_active: AtomicBool::new(false),
+            error_code: AtomicI32::new(0),
+            supervisor: ptr::null_mut(),
+            supervisor_child_index: -1,
+            priority: AtomicI32::new(HEW_PRIORITY_NORMAL),
+            reductions: AtomicI32::new(HEW_DEFAULT_REDUCTIONS),
+            idle_count: AtomicI32::new(0),
+            hibernation_threshold: AtomicI32::new(0),
+            hibernating: AtomicI32::new(0),
+            prof_messages_processed: AtomicU64::new(0),
+            prof_processing_time_ns: AtomicU64::new(0),
+            arena: ptr::null_mut(),
+            suspended_cont: AtomicPtr::new(ptr::null_mut()),
+            cont_tag: AtomicI32::new(0),
+            pending_wake: AtomicBool::new(false),
+            suspended_reply_channel: AtomicPtr::new(ptr::null_mut()),
+            suspended_cancel_token: AtomicPtr::new(ptr::null_mut()),
+            runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+            runtime: ptr::null(),
+            send_pin_count: std::sync::atomic::AtomicU32::new(0),
+        });
+
+        // Fill the mailbox to capacity (capacity = 1).
+        let msg: i32 = 42;
+        // SAFETY: mb is valid; msg has size 4 bytes.
+        let sent = unsafe {
+            crate::mailbox::hew_mailbox_send(
+                mb,
+                1,
+                (&raw const msg).cast_mut().cast(),
+                std::mem::size_of::<i32>(),
+            )
+        };
+        assert_eq!(sent, 0, "first send into empty mailbox must succeed");
+
+        // Coordinate the test: background thread signals when it enters the
+        // Block wait; main thread then closes the mailbox.
+        let bg_entered = std::sync::Arc::new(AtomicBool::new(false));
+        let bg_entered_clone = bg_entered.clone();
+        let mb_addr = mb as usize;
+
+        let bg = std::thread::spawn(move || {
+            bg_entered_clone.store(true, Ordering::Release);
+            // With the OLD fix (lock held): this would DEADLOCK if the main
+            // thread called is_actor_live concurrently (same lock, same thread
+            // would deadlock only if same-thread re-entry; but across two threads
+            // the Block condvar wait holds the lock and prevents the main thread
+            // from acquiring it).
+            //
+            // With the NEW fix (pin + release lock): the condvar wait is
+            // entirely outside the LIVE_ACTORS lock.  The main thread can freely
+            // acquire LIVE_ACTORS while we wait.  When the mailbox is closed,
+            // the Block wait returns SendOutcome::Closed → send returns an error.
+            //
+            // This call blocks on the condvar until mb is closed below.
+            let actor_id_for_bg = actor_id;
+            crate::lifetime::live_actors::with_actor_send_by_id(actor_id_for_bg, |actor_ptr| {
+                // SAFETY: `actor_ptr` is pinned-live for the duration of this
+                // closure; `mb_ptr` was allocated by `hew_mailbox_new_with_policy`
+                // and is valid until `hew_mailbox_free` on the main thread.
+                // `msg2` is a stack i32 valid for the duration of this block.
+                let mb_ptr = mb_addr as *mut crate::mailbox::HewMailbox;
+                let msg2: i32 = 99;
+                // This send BLOCKS on condvar (mailbox at capacity) — the
+                // key property: `LIVE_ACTORS` must NOT be held here.
+                // SAFETY: `mb_ptr` was allocated by `hew_mailbox_new_with_policy`
+                // and is valid until `hew_mailbox_free` on the main thread;
+                // `msg2` is a stack `i32` valid for this block.
+                unsafe {
+                    crate::mailbox::hew_mailbox_send(
+                        mb_ptr,
+                        1,
+                        (&raw const msg2).cast_mut().cast(),
+                        std::mem::size_of::<i32>(),
+                    )
+                };
+                let _ = actor_ptr;
+            });
+        });
+
+        // Wait for the background thread to start (spin with bounded wait).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !bg_entered.load(Ordering::Acquire) {
+            std::thread::yield_now();
+            assert!(
+                std::time::Instant::now() < deadline,
+                "bg thread never started"
+            );
+        }
+
+        // Give the BG thread a moment to enter the condvar wait before closing.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+
+        // Verify LIVE_ACTORS is NOT held by the background thread: call
+        // is_actor_live from the main thread — this must return immediately,
+        // not deadlock.
+        let live = crate::lifetime::live_actors::is_actor_live(actor.ptr());
+        assert!(live, "actor must still be live while bg thread is sending");
+
+        // Close the mailbox → Block condvar wakes with Closed.
+        // SAFETY: mb is valid; actor.ptr() is valid (still tracked).
+        unsafe { crate::mailbox::mailbox_close(mb) };
+
+        // Background thread must return promptly (no deadlock).
+        let join_result = bg.join().is_ok();
+        assert!(join_result, "background thread panicked");
+
+        // Drain the mailbox and free it.
+        // SAFETY: mb is exclusively owned after bg thread returns.
+        unsafe { crate::mailbox::hew_mailbox_free(mb) };
+        // actor.ptr().mailbox is now dangling; zero it out before TrackedActor::drop
+        // (which calls untrack_actor and drops the box but does NOT access mailbox).
+        // SAFETY: actor allocation is valid; we own it exclusively here.
+        unsafe { (*actor.ptr()).mailbox = ptr::null_mut() };
     }
 }

--- a/hew-runtime/src/actor_group.rs
+++ b/hew-runtime/src/actor_group.rs
@@ -21,6 +21,7 @@ use std::sync::{Arc, LazyLock};
 
 use crate::actor::{self, HewActor};
 use crate::internal::types::{HewActorState, HewError};
+use crate::lifetime::live_actors;
 use crate::util::{CondvarExt, MutexExt};
 
 /// Initial capacity of the actor array.
@@ -66,7 +67,13 @@ pub(crate) fn notify_actor_death(actor_id: u64) {
 /// Dynamic actor group (opaque, Box-allocated).
 #[derive(Debug)]
 pub struct HewActorGroup {
-    actors: Vec<*mut c_void>,
+    /// Each entry is `(actor_id, *mut HewActor)`.
+    ///
+    /// Storing the actor-ID alongside the pointer lets `all_stopped`
+    /// validate liveness through `LIVE_ACTORS` (keyed by ID) rather than
+    /// dereferencing the raw pointer bare — closing the UAF window that
+    /// opens when a supervisor frees a sibling while `wait_all` loops.
+    actors: Vec<(u64, *mut c_void)>,
     lock: std::sync::Mutex<()>,
     done_cond: Arc<std::sync::Condvar>,
 }
@@ -111,13 +118,8 @@ pub unsafe extern "C" fn hew_actor_group_destroy(g: *mut HewActorGroup) {
     let group = unsafe { Box::from_raw(g) }; // ALLOCATOR-PAIRING: GlobalAlloc
 
     // Unregister death notifiers for all tracked actors.
-    for &actor_ptr in &group.actors {
-        if !actor_ptr.is_null() {
-            let a = actor_ptr.cast::<HewActor>();
-            // SAFETY: actor pointers are valid per add contract.
-            let actor_id = unsafe { (*a).id };
-            unregister_death_notifier(actor_id, &group.done_cond);
-        }
+    for &(actor_id, _actor_ptr) in &group.actors {
+        unregister_death_notifier(actor_id, &group.done_cond);
     }
 
     drop(group);
@@ -149,7 +151,7 @@ pub unsafe extern "C" fn hew_actor_group_add(g: *mut HewActorGroup, actor: *mut 
     let actor_id = unsafe { (*a).id };
     register_death_notifier(actor_id, Arc::clone(&group.done_cond));
 
-    group.actors.push(actor);
+    group.actors.push((actor_id, actor));
     0
 }
 
@@ -164,15 +166,34 @@ fn is_terminal(state: i32) -> bool {
 /// Check whether all actors in the group are in a terminal state.
 ///
 /// Must be called with the group's lock held.
+///
+/// Reads each actor's state through `live_actors::with_live_actor_by_id`,
+/// which holds the `LIVE_ACTORS` registry lock for the duration of each
+/// state read.  This closes the UAF window that opens when a supervisor
+/// frees a sibling actor between `wait_all`'s condvar wake and the state
+/// read — the actor cannot be reclaimed while the registry lock is held.
+///
+/// If an actor has already been removed from `LIVE_ACTORS` (freed by a
+/// supervisor before we reach it), we treat it as terminal: a freed actor
+/// is no longer running.
 fn all_stopped(group: &HewActorGroup) -> bool {
-    for &actor_ptr in &group.actors {
+    for &(actor_id, actor_ptr) in &group.actors {
         if actor_ptr.is_null() {
             continue;
         }
         let a = actor_ptr.cast::<HewActor>();
-        // SAFETY: actor pointers are valid per add contract.
-        let state = unsafe { (*a).actor_state.load(Ordering::Acquire) };
-        if !is_terminal(state) {
+        // Hold LIVE_ACTORS across the state read.  A concurrent
+        // hew_actor_free_inner cannot free `a` while the closure runs
+        // (untrack_actor removes the entry under the same lock, and the
+        // free is deferred until after the lock is released).
+        let is_term = live_actors::with_live_actor_by_id(actor_id, a, |actor_ref| {
+            is_terminal(actor_ref.actor_state.load(Ordering::Acquire))
+        })
+        // None means the actor is no longer in LIVE_ACTORS (already freed
+        // by a supervisor restart); treat that as terminal — a freed actor
+        // is not running.
+        .unwrap_or(true);
+        if !is_term {
             return false;
         }
     }
@@ -262,7 +283,7 @@ pub unsafe extern "C" fn hew_actor_group_stop_all(g: *mut HewActorGroup) {
     let group = unsafe { &*g };
 
     let _guard = group.lock.lock_or_recover();
-    for &actor_ptr in &group.actors {
+    for &(_actor_id, actor_ptr) in &group.actors {
         if !actor_ptr.is_null() {
             // SAFETY: actor pointer is valid per add contract.
             unsafe { actor::hew_actor_stop(actor_ptr.cast()) };
@@ -341,4 +362,174 @@ pub unsafe extern "C" fn hew_actor_await_all(actors: *const *mut HewActor, count
         }
     }
     first_error
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+//
+// These tests cover the lock-discipline fix in `all_stopped`:
+//
+// - F-1 regression: `all_stopped` now reads actor state through
+//   `live_actors::with_live_actor_by_id`, holding `LIVE_ACTORS` for the
+//   duration of the read.  Direct pointer dereference (the UAF source) is
+//   gone.
+// - The untracked-as-terminal path is exercised: if a supervisor removes an
+//   actor from `LIVE_ACTORS` while the group holds the raw pointer,
+//   `all_stopped` treats the entry as terminal rather than dereferencing freed
+//   memory.
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use crate::actor::{HEW_DEFAULT_REDUCTIONS, HEW_MSG_BUDGET, HEW_PRIORITY_NORMAL};
+    use std::ptr;
+    use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU64};
+
+    // IDs in the high range to avoid clashing with concurrent tests.
+    static NEXT_TEST_ID: AtomicU64 = AtomicU64::new(0x00ff_0000_0000_0000);
+    fn next_id() -> u64 {
+        NEXT_TEST_ID.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Minimal `HewActor` stub sufficient for actor-group liveness tests.
+    /// Only `id` and `actor_state` are exercised by `all_stopped`.
+    fn stub_actor(id: u64, state: HewActorState) -> HewActor {
+        HewActor {
+            sched_link_next: AtomicPtr::new(ptr::null_mut()),
+            id,
+            state: ptr::null_mut(),
+            state_size: 0,
+            dispatch: None,
+            mailbox: ptr::null_mut(),
+            actor_state: AtomicI32::new(state as i32),
+            budget: AtomicI32::new(HEW_MSG_BUDGET),
+            init_state: ptr::null_mut(),
+            init_state_size: 0,
+            coalesce_key_fn: None,
+            terminate_fn: None,
+            state_drop_fn: None,
+            state_clone_fn: None,
+            terminate_called: AtomicBool::new(false),
+            terminate_finished: AtomicBool::new(false),
+            dispatch_active: AtomicBool::new(false),
+            error_code: AtomicI32::new(0),
+            supervisor: ptr::null_mut(),
+            supervisor_child_index: -1,
+            priority: AtomicI32::new(HEW_PRIORITY_NORMAL),
+            reductions: AtomicI32::new(HEW_DEFAULT_REDUCTIONS),
+            idle_count: AtomicI32::new(0),
+            hibernation_threshold: AtomicI32::new(0),
+            hibernating: AtomicI32::new(0),
+            prof_messages_processed: AtomicU64::new(0),
+            prof_processing_time_ns: AtomicU64::new(0),
+            arena: ptr::null_mut(),
+            suspended_cont: AtomicPtr::new(ptr::null_mut()),
+            cont_tag: AtomicI32::new(0),
+            pending_wake: AtomicBool::new(false),
+            suspended_reply_channel: AtomicPtr::new(ptr::null_mut()),
+            suspended_cancel_token: AtomicPtr::new(ptr::null_mut()),
+            runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
+            runtime: ptr::null(),
+        }
+    }
+
+    /// RAII guard: allocates actor on heap, tracks in `LIVE_ACTORS`, untracks + frees on drop.
+    struct TrackedActor {
+        ptr: *mut HewActor,
+    }
+
+    impl TrackedActor {
+        fn install(actor: HewActor) -> Self {
+            let ptr = Box::into_raw(Box::new(actor));
+            // SAFETY: `ptr` is a freshly-boxed, fully-initialised actor.
+            unsafe { crate::lifetime::live_actors::track_actor(ptr) };
+            Self { ptr }
+        }
+
+        fn ptr(&self) -> *mut HewActor {
+            self.ptr
+        }
+
+        /// Untrack without freeing: models a supervisor removing the actor from
+        /// `LIVE_ACTORS` before (or instead of) freeing the allocation.  The box
+        /// stays live so the test can safely proceed; in production the allocation
+        /// is freed by `hew_actor_free_box` immediately after `untrack_actor`.
+        fn untrack(&self) {
+            crate::lifetime::live_actors::untrack_actor(self.ptr);
+        }
+    }
+
+    impl Drop for TrackedActor {
+        fn drop(&mut self) {
+            // Idempotent: returns false if already removed by `untrack()`.
+            crate::lifetime::live_actors::untrack_actor(self.ptr);
+            // SAFETY: `ptr` came from Box::into_raw above; freed exactly once.
+            unsafe { drop(Box::from_raw(self.ptr)) };
+        }
+    }
+
+    /// `wait_all` exits immediately when all actors are already in a terminal
+    /// state and tracked in `LIVE_ACTORS`.
+    #[test]
+    fn wait_all_returns_for_stopped_actors() {
+        let _rt = crate::runtime_test_guard();
+
+        let actor_a = TrackedActor::install(stub_actor(next_id(), HewActorState::Stopped));
+        let actor_b = TrackedActor::install(stub_actor(next_id(), HewActorState::Crashed));
+
+        // SAFETY: group was just returned by hew_actor_group_new.
+        let group = unsafe { hew_actor_group_new() };
+        assert!(!group.is_null());
+        // SAFETY: group and actor pointers are valid per their respective constructors.
+        let _ = unsafe { hew_actor_group_add(group, actor_a.ptr().cast()) };
+        // SAFETY: same as above.
+        let _ = unsafe { hew_actor_group_add(group, actor_b.ptr().cast()) };
+
+        // All actors already terminal — should complete well within 200 ms.
+        // SAFETY: group is valid and not concurrently destroyed.
+        let rc = unsafe { hew_actor_group_wait_timeout(group, 200) };
+        assert_eq!(rc, 0, "wait_all should succeed for already-stopped actors");
+
+        // SAFETY: group is valid and no longer used after this.
+        unsafe { hew_actor_group_destroy(group) };
+    }
+
+    /// F-1 regression: when an actor is removed from `LIVE_ACTORS` (simulating a
+    /// supervisor free), `all_stopped` must NOT dereference the raw pointer; it
+    /// must treat the untracked actor as terminal and return true without a UAF.
+    ///
+    /// Deterministic concurrent-race reproduction is infeasible in a unit test, so
+    /// this test verifies the corrected code path: `all_stopped` sees
+    /// `with_live_actor_by_id` return `None` (actor gone from registry) and
+    /// `unwrap_or(true)` → terminal, rather than performing a bare dereference.
+    #[test]
+    fn wait_all_treats_untracked_actor_as_terminal() {
+        let _rt = crate::runtime_test_guard();
+
+        // Actor starts Runnable (not terminal).
+        let actor_a = TrackedActor::install(stub_actor(next_id(), HewActorState::Runnable));
+
+        // SAFETY: group was just returned by hew_actor_group_new.
+        let group = unsafe { hew_actor_group_new() };
+        // SAFETY: group and actor_a pointer are valid per their constructors.
+        let rc_add = unsafe { hew_actor_group_add(group, actor_a.ptr().cast()) };
+        assert_eq!(rc_add, 0);
+
+        // Verify baseline: actor is not stopped → wait_timeout should time out.
+        // SAFETY: group is valid and not concurrently destroyed.
+        let rc_timeout = unsafe { hew_actor_group_wait_timeout(group, 30) };
+        assert_ne!(rc_timeout, 0, "should time out: actor is still running");
+
+        // Simulate supervisor removing the actor from LIVE_ACTORS.
+        // In production, hew_actor_free_box would immediately follow; here the
+        // box stays live so the test can safely call wait_timeout again.
+        actor_a.untrack();
+
+        // all_stopped sees the actor is not in LIVE_ACTORS → treats as terminal.
+        // SAFETY: group is valid and not concurrently destroyed.
+        let rc_done = unsafe { hew_actor_group_wait_timeout(group, 200) };
+        assert_eq!(rc_done, 0, "untracked actor should be treated as terminal");
+
+        // SAFETY: group is valid and no longer used after this.
+        unsafe { hew_actor_group_destroy(group) };
+        // TrackedActor::drop calls untrack_actor idempotently (no-op) then frees box.
+    }
 }

--- a/hew-runtime/src/coro_exec.rs
+++ b/hew-runtime/src/coro_exec.rs
@@ -647,6 +647,7 @@ mod tests {
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
             runtime: ptr::null(),
+            send_pin_count: std::sync::atomic::AtomicU32::new(0),
         })
     }
 
@@ -1081,6 +1082,7 @@ mod forced_ordering_probe {
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
             runtime: ptr::null(),
+            send_pin_count: std::sync::atomic::AtomicU32::new(0),
         })
     }
 

--- a/hew-runtime/src/encryption.rs
+++ b/hew-runtime/src/encryption.rs
@@ -857,6 +857,12 @@ pub unsafe extern "C" fn hew_allowlist_new(mode: c_int) -> *mut HewPeerAllowlist
     let ptr = Box::into_raw(Box::new(list.clone())); // ALLOCATOR-PAIRING: GlobalAlloc
     #[cfg(not(test))]
     {
+        // Acquire the ops lock before modifying ACTIVE_ALLOWLIST, consistent
+        // with all other mutating paths (hew_allowlist_add / remove / free).
+        // Without it, a concurrent hew_allowlist_free could read ACTIVE_ALLOWLIST
+        // between our write and the strict-latch store, producing an inconsistent
+        // view of the active list / latch pair.
+        let _guard = ALLOWLIST_OPS_LOCK.lock_or_recover();
         let mut active = ACTIVE_ALLOWLIST.write_or_recover();
         *active = Some(ActiveAllowlist {
             ptr: ptr as usize,

--- a/hew-runtime/src/lifetime/live_actors.rs
+++ b/hew-runtime/src/lifetime/live_actors.rs
@@ -249,20 +249,58 @@ pub(crate) fn with_live_actor_by_id<R>(
 ///
 /// The lock is *not* held after this returns.  Call sites that can tolerate
 /// a narrow TOCTOU window (e.g. remote routing that fails gracefully if the
-/// actor disappears) may use this; call sites that need the pointer to stay
-/// valid must use `with_live_actor_by_id` instead.
+/// actor disappears, or drain paths that immediately re-validate with
+/// `with_live_actor_by_id`) may use this.
 ///
-/// SHIM: `hew_actor_send_by_id` and `hew_actor_ask_by_id` use this variant to
-/// avoid serialising mailbox sends under a single registry mutex. When sharded
-/// `LIVE_ACTORS` lands (see module-level doc), this can be replaced with a
-/// handle-per-shard approach.
-// live on not(wasm32) — hew_actor_send_by_id / hew_actor_ask_by_id / hew_node; dead on wasm32
+/// **Do not use this for send/ask dispatch** — use [`with_actor_send_by_id`]
+/// instead so the actor cannot be freed between lookup and dereference.
+// live on not(wasm32) — collect_pending_actor / hew_node; dead on wasm32
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) fn get_actor_ptr_by_id(actor_id: u64) -> Option<*mut HewActor> {
     with_live_actors_opt(|map| {
         map.as_ref()
             .and_then(|m| m.get(&actor_id).map(|ptr| ptr.0))
             .filter(|ptr| !ptr.is_null())
+    })
+    .flatten()
+}
+
+/// Look up an actor by ID and, if live, call `f` with its raw pointer while
+/// the `LIVE_ACTORS` registry lock is held.
+///
+/// Unlike [`get_actor_ptr_by_id`], the registry lock is **not** released
+/// before the caller accesses the pointer.  The lock is held for the entire
+/// duration of `f`, preventing a concurrent `hew_actor_free_inner` from
+/// freeing the actor while `f` accesses it.
+///
+/// **Use this for send and ask by-id paths** where the pointer must remain
+/// valid for the duration of the mailbox enqueue and scheduler wake.
+///
+/// # Lock ordering
+///
+/// `f` must not attempt to re-acquire `LIVE_ACTORS` (it is already held) or
+/// any lock that might transitively acquire it.  Mailbox-send internals and
+/// `sched_enqueue` (crossbeam deque + condvar notify) are safe to call from
+/// `f`; neither acquires `LIVE_ACTORS`.
+///
+/// Returns `Some(f(ptr))` if the actor is live, `None` if not found.
+// live on not(wasm32) — hew_actor_send_by_id / hew_actor_ask_by_id; dead on wasm32
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub(crate) fn with_actor_send_by_id<R>(
+    actor_id: u64,
+    f: impl FnOnce(*mut HewActor) -> R,
+) -> Option<R> {
+    with_live_actors_opt(|map| {
+        let ptr = map
+            .as_ref()
+            .and_then(|m| m.get(&actor_id).map(|p| p.0))
+            .filter(|p| !p.is_null())?;
+        // SAFETY: `ptr` is tracked in LIVE_ACTORS; the registry lock is held
+        // for the entire closure, preventing concurrent `hew_actor_free_inner`
+        // from reclaiming the allocation while `f` runs.  All free paths call
+        // `untrack_actor` (under this same lock) before `hew_actor_free_box`,
+        // so the allocation is valid for the duration of this closure.
+        Some(f(ptr))
     })
     .flatten()
 }

--- a/hew-runtime/src/lifetime/live_actors.rs
+++ b/hew-runtime/src/lifetime/live_actors.rs
@@ -265,23 +265,58 @@ pub(crate) fn get_actor_ptr_by_id(actor_id: u64) -> Option<*mut HewActor> {
     .flatten()
 }
 
+/// RAII guard that decrements `HewActor.send_pin_count` on drop.
+///
+/// Taken by [`with_actor_send_by_id`] after the liveness validation
+/// (under `LIVE_ACTORS`) so the free path cannot reclaim the actor
+/// allocation while the by-ID operation is in progress.
+///
+/// The `Release` ordering on drop pairs with the free path's `Acquire`
+/// load of `send_pin_count`, ensuring all writes from the pinned
+/// operation are visible to the freer before it reclaims the allocation.
+// live on not(wasm32); dead on wasm32.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+struct SendPinGuard(*mut HewActor);
+
+// SAFETY: `HewActor` is `Send`; the guard only touches the atomic
+// `send_pin_count` field.
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+unsafe impl Send for SendPinGuard {}
+
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+impl Drop for SendPinGuard {
+    fn drop(&mut self) {
+        // SAFETY: the pointer was validated-live when the pin was taken.
+        // The free path defers the free until `send_pin_count` reaches 0,
+        // so the allocation remains valid until this drop runs.
+        unsafe { (*self.0).send_pin_count.fetch_sub(1, Ordering::Release) };
+    }
+}
+
 /// Look up an actor by ID and, if live, call `f` with its raw pointer while
-/// the `LIVE_ACTORS` registry lock is held.
+/// guaranteeing the allocation cannot be freed for the duration of `f`.
 ///
-/// Unlike [`get_actor_ptr_by_id`], the registry lock is **not** released
-/// before the caller accesses the pointer.  The lock is held for the entire
-/// duration of `f`, preventing a concurrent `hew_actor_free_inner` from
-/// freeing the actor while `f` accesses it.
+/// **Lock discipline**: unlike an older design that held `LIVE_ACTORS` across
+/// `f`, this function:
 ///
-/// **Use this for send and ask by-id paths** where the pointer must remain
-/// valid for the duration of the mailbox enqueue and scheduler wake.
+/// 1. Acquires `LIVE_ACTORS`, validates liveness, increments `send_pin_count`
+///    on the actor, then **releases** `LIVE_ACTORS`.
+/// 2. Calls `f(ptr)` with the lock fully released.
+/// 3. Decrements `send_pin_count` via a RAII guard on return **or panic**.
 ///
-/// # Lock ordering
+/// The free path in `hew_actor_free_inner` treats `send_pin_count > 0` as
+/// non-quiescent and defers `untrack_actor` + `finalize` until all pins are
+/// released.  Because `LIVE_ACTORS` is not held across `f`, blocking mailbox
+/// operations (the `Block` overflow condvar wait) and eviction retire paths
+/// (`DropOld` → `hew_msg_node_free` → `retire_orphaned_ask_sender_ref` →
+/// `scheduler::enqueue_resume` → `with_live_actor`) are both safe to call
+/// from `f` without deadlocking.
 ///
-/// `f` must not attempt to re-acquire `LIVE_ACTORS` (it is already held) or
-/// any lock that might transitively acquire it.  Mailbox-send internals and
-/// `sched_enqueue` (crossbeam deque + condvar notify) are safe to call from
-/// `f`; neither acquires `LIVE_ACTORS`.
+/// # Lock ordering (unchanged from the module invariant)
+///
+/// `f` is free to acquire any lock that does not transitively re-acquire
+/// `LIVE_ACTORS`.  `LIVE_ACTORS` is fully released before `f` runs, so
+/// `enqueue_resume` → `with_live_actor` does not self-deadlock.
 ///
 /// Returns `Some(f(ptr))` if the actor is live, `None` if not found.
 // live on not(wasm32) — hew_actor_send_by_id / hew_actor_ask_by_id; dead on wasm32
@@ -290,19 +325,28 @@ pub(crate) fn with_actor_send_by_id<R>(
     actor_id: u64,
     f: impl FnOnce(*mut HewActor) -> R,
 ) -> Option<R> {
-    with_live_actors_opt(|map| {
+    // Phase 1: validate liveness and take a send pin — all under LIVE_ACTORS.
+    // Incrementing send_pin_count here (before releasing the lock) ensures that
+    // if a concurrent hew_actor_free_inner sees pin_count > 0 in its quiescence
+    // loop, it defers the free until the pin drops.
+    let ptr = with_live_actors_opt(|map| {
         let ptr = map
             .as_ref()
             .and_then(|m| m.get(&actor_id).map(|p| p.0))
             .filter(|p| !p.is_null())?;
-        // SAFETY: `ptr` is tracked in LIVE_ACTORS; the registry lock is held
-        // for the entire closure, preventing concurrent `hew_actor_free_inner`
-        // from reclaiming the allocation while `f` runs.  All free paths call
-        // `untrack_actor` (under this same lock) before `hew_actor_free_box`,
-        // so the allocation is valid for the duration of this closure.
-        Some(f(ptr))
+        // SAFETY: `ptr` is tracked-live under the registry lock.  The
+        // fetch_add happens before the lock is released, so the free path
+        // observes pin_count > 0 before it can call untrack_actor.
+        unsafe { (*ptr).send_pin_count.fetch_add(1, Ordering::AcqRel) };
+        Some(ptr)
     })
-    .flatten()
+    .flatten()?;
+
+    // Phase 2: LIVE_ACTORS is released; call `f` with the pinned pointer.
+    // `_pin` drops after `f` returns: decrements send_pin_count with Release
+    // ordering, paired with the free path's Acquire load.
+    let _pin = SendPinGuard(ptr);
+    Some(f(ptr))
 }
 
 /// Resolve the per-actor-TYPE dispatch function pointer for a live actor id,

--- a/hew-runtime/src/lifetime/live_actors.rs
+++ b/hew-runtime/src/lifetime/live_actors.rs
@@ -304,10 +304,18 @@ impl Drop for SendPinGuard {
 /// 2. Calls `f(ptr)` with the lock fully released.
 /// 3. Decrements `send_pin_count` via a RAII guard on return **or panic**.
 ///
-/// The free path in `hew_actor_free_inner` treats `send_pin_count > 0` as
-/// non-quiescent and defers `untrack_actor` + `finalize` until all pins are
-/// released.  Because `LIVE_ACTORS` is not held across `f`, blocking mailbox
-/// operations (the `Block` overflow condvar wait) and eviction retire paths
+/// The free paths (`hew_actor_free_inner`, `drain_quiesced_actor`) call
+/// `untrack_actor` (or `take_actor_by_id`) FIRST — under `LIVE_ACTORS` — so no
+/// new pins can be taken after the map entry is removed.  They then spin until
+/// `send_pin_count` drops to 0 (draining any pins taken before the removal)
+/// before calling `finalize`.  Because the pin-increment and the map-removal
+/// both run under `LIVE_ACTORS`, the two are mutually exclusive: either this
+/// function pins before the freer removes the entry (freer waits for the pin to
+/// drain), or the freer removes the entry before this function's map lookup
+/// (lookup returns `None` → no pin, no use of a freed pointer).
+///
+/// Because `LIVE_ACTORS` is not held across `f`, blocking mailbox operations
+/// (the `Block` overflow condvar wait) and eviction retire paths
 /// (`DropOld` → `hew_msg_node_free` → `retire_orphaned_ask_sender_ref` →
 /// `scheduler::enqueue_resume` → `with_live_actor`) are both safe to call
 /// from `f` without deadlocking.

--- a/hew-runtime/src/lifetime/live_actors.rs
+++ b/hew-runtime/src/lifetime/live_actors.rs
@@ -326,17 +326,25 @@ pub(crate) fn with_actor_send_by_id<R>(
     f: impl FnOnce(*mut HewActor) -> R,
 ) -> Option<R> {
     // Phase 1: validate liveness and take a send pin — all under LIVE_ACTORS.
-    // Incrementing send_pin_count here (before releasing the lock) ensures that
-    // if a concurrent hew_actor_free_inner sees pin_count > 0 in its quiescence
-    // loop, it defers the free until the pin drops.
+    // Incrementing send_pin_count here (before releasing the lock) makes the
+    // pin-increment and the freer's map-removal mutually exclusive: both
+    // operations run under LIVE_ACTORS, so either this fetch_add completes
+    // before the freer's untrack_actor (freer will then spin until the pin
+    // drops before finalizing), or the freer's untrack_actor completes first
+    // (this map lookup returns None → we return None without taking a pin).
+    // The allocation cannot be freed while the pin is held.
     let ptr = with_live_actors_opt(|map| {
         let ptr = map
             .as_ref()
             .and_then(|m| m.get(&actor_id).map(|p| p.0))
             .filter(|p| !p.is_null())?;
         // SAFETY: `ptr` is tracked-live under the registry lock.  The
-        // fetch_add happens before the lock is released, so the free path
-        // observes pin_count > 0 before it can call untrack_actor.
+        // fetch_add runs before the lock is released and before any
+        // concurrent untrack_actor (which also runs under the lock), so the
+        // two are mutually exclusive — the freer cannot remove the map entry
+        // while we are incrementing the pin, and we cannot increment the pin
+        // after the freer has removed the map entry (the map.get above would
+        // return None first).
         unsafe { (*ptr).send_pin_count.fetch_add(1, Ordering::AcqRel) };
         Some(ptr)
     })

--- a/hew-runtime/src/link.rs
+++ b/hew-runtime/src/link.rs
@@ -469,6 +469,7 @@ mod tests {
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
             runtime: std::ptr::null(),
+            send_pin_count: std::sync::atomic::AtomicU32::new(0),
         }
     }
 

--- a/hew-runtime/src/monitor.rs
+++ b/hew-runtime/src/monitor.rs
@@ -532,6 +532,7 @@ mod tests {
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
             runtime: std::ptr::null(),
+            send_pin_count: std::sync::atomic::AtomicU32::new(0),
         }
     }
 

--- a/hew-runtime/src/reply_channel.rs
+++ b/hew-runtime/src/reply_channel.rs
@@ -1284,6 +1284,7 @@ mod tests {
                 suspended_cancel_token: AtomicPtr::new(ptr::null_mut()),
                 runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
                 runtime: ptr::null(),
+                send_pin_count: std::sync::atomic::AtomicU32::new(0),
             })
         }
 

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -2999,6 +2999,7 @@ mod tests {
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
             runtime: ptr::null(),
+            send_pin_count: std::sync::atomic::AtomicU32::new(0),
         }
     }
 
@@ -3844,6 +3845,7 @@ mod tests {
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
             runtime: ptr::null(),
+            send_pin_count: std::sync::atomic::AtomicU32::new(0),
         };
         let actor_ptr: *mut HewActor = (&raw const actor).cast_mut();
 
@@ -5302,6 +5304,7 @@ mod tests {
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
             runtime: ptr::null(),
+            send_pin_count: std::sync::atomic::AtomicU32::new(0),
         };
         let actor_ptr: *mut HewActor = (&raw const actor).cast_mut();
 

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -23,7 +23,7 @@
 use std::collections::VecDeque;
 use std::ffi::{c_int, c_void};
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU32, AtomicU64, Ordering};
 
 #[cfg(test)]
 use crate::actor::HEW_PRIORITY_NORMAL;
@@ -130,6 +130,11 @@ pub struct HewActor {
     // Native stores `*const RuntimeInner`; WASM has no native runtime module, so
     // keep this opaque while preserving size/alignment/offset parity.
     pub runtime: *const c_void,
+    // ── Send-pin counter (appended; matches native exactly) ──────────────────
+    // Incremented by `with_actor_send_by_id` before releasing LIVE_ACTORS and
+    // decremented after the by-ID operation completes.  The free path waits for
+    // this counter to reach 0 before reclaiming the allocation.
+    pub send_pin_count: AtomicU32,
 }
 
 // SAFETY: Single-threaded on WASM; on native (tests), the struct is only
@@ -192,6 +197,7 @@ const _: () = {
     assert!(offset_of!(W, suspended_cancel_token) == offset_of!(N, suspended_cancel_token));
     assert!(offset_of!(W, runtime_id) == offset_of!(N, runtime_id));
     assert!(offset_of!(W, runtime) == offset_of!(N, runtime));
+    assert!(offset_of!(W, send_pin_count) == offset_of!(N, send_pin_count));
 };
 
 // ── HewMsgNode layout (strict prefix of native mailbox.rs) ──────────────
@@ -2132,6 +2138,7 @@ mod tests {
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
             runtime: ptr::null(),
+            send_pin_count: std::sync::atomic::AtomicU32::new(0),
         }
     }
 
@@ -5066,6 +5073,7 @@ mod tests {
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
             runtime: ptr::null(),
+            send_pin_count: std::sync::atomic::AtomicU32::new(0),
         }));
 
         // ── 3. Enqueue one message and run dispatch ───────────────────────────

--- a/hew-runtime/src/timer_periodic.rs
+++ b/hew-runtime/src/timer_periodic.rs
@@ -711,6 +711,7 @@ mod tests {
             suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
             runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
             runtime: std::ptr::null(),
+            send_pin_count: std::sync::atomic::AtomicU32::new(0),
         }
     }
 

--- a/hew-runtime/src/timer_periodic_wasm.rs
+++ b/hew-runtime/src/timer_periodic_wasm.rs
@@ -530,6 +530,7 @@ mod tests {
                 suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
                 runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
                 runtime: ptr::null(),
+                send_pin_count: std::sync::atomic::AtomicU32::new(0),
             }));
             Self { actor, counter }
         }

--- a/hew-runtime/src/wasm_parity_tests.rs
+++ b/hew-runtime/src/wasm_parity_tests.rs
@@ -170,6 +170,7 @@ fn stub_wasm_actor(mailbox: *mut c_void) -> Box<HewActor> {
         suspended_cancel_token: AtomicPtr::new(std::ptr::null_mut()),
         runtime_id: crate::runtime_id::RuntimeId::DEFAULT,
         runtime: std::ptr::null(),
+        send_pin_count: std::sync::atomic::AtomicU32::new(0),
     })
 }
 


### PR DESCRIPTION
## Summary
Hardens the actor lifecycle against a family of use-after-free and deadlock races between actor teardown (free / drain / shutdown cleanup) and concurrent by-id sends (`send pid <- msg`):

- A by-id send takes a short pin on the actor (`send_pin_count`) under the actor registry lock, then releases the lock before the (possibly blocking) mailbox send, so blocking-mailbox backpressure and reply-retire paths no longer deadlock against the registry.
- Every actor-free site (single free, drain, and process-shutdown cleanup, plus the WASM path) untracks the actor first (so no new pin can be taken), drains outstanding pins with the registry lock released, and decides whether to finalize from the result of a `compare_exchange(Idle → Stopped)` on the actor's state — never from a previously loaded snapshot. If a concurrent send has already moved the actor to a runnable/non-quiescent state, the actor is left untracked-but-not-freed (a bounded, fail-closed leak) rather than freed while still queued.
- Closes a related shutdown-cleanup window where an actor re-enqueued during teardown could be finalized while a raw pointer to it remained in the scheduler queue, and a parked (suspended) actor could be finalized without releasing its continuation frame.

## Verification
- `cargo clippy --workspace --tests -- -D warnings` and `cargo fmt --check` clean.
- New forced-ordering regression tests reproduce each closed window (a send pinning/enqueuing the actor in the teardown window) and assert the actor is leaked-not-freed; they fail on the pre-fix code and pass after. The existing deadlock regression and full `hew-runtime` test suite stay green (flake-gated 3×).
- `make test-hew-ratchet` drop-leak == 0.
- WASM mirror struct/offset parity assertions intact.

## Out of scope
No change to actor semantics or the public actor API; this is purely teardown/send race hardening.
