### PR TITLE
Resolve match-arm identifiers by name resolution and reject native-only stdlib values on wasm32

### DIFF
--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -368,10 +368,15 @@ impl Checker {
                 // cover its variant; `variant_covered` recurses into nested
                 // payload patterns so a jointly-exhaustive set of nested arms
                 // still counts.
+                //
+                // Use the resolution-aware `is_catch_all_for_scrutinee` so
+                // that a bare unqualified identifier (even uppercase) that does
+                // not resolve as a variant of the scrutinee type is treated as
+                // a binding catch-all rather than a failed constructor.
                 let leaves = Self::unguarded_leaf_patterns(arms);
                 if leaves
                     .iter()
-                    .any(|p| super::patterns::pattern_is_catch_all(p))
+                    .any(|p| self.is_catch_all_for_scrutinee(p, scrutinee_ty))
                 {
                     return;
                 }

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -5202,6 +5202,68 @@ impl Checker {
                                     self.current_module.clone(),
                                     name.clone(),
                                 ));
+                                // Apply the same wasm native-only guard used for call
+                                // expressions (#2135): a value-position reference to a
+                                // native-only stdlib function is itself a
+                                // `PlatformLimitation` rejection on wasm32, mirroring
+                                // the call-form guard in methods.rs.
+                                if self.wasm_target && !self.user_modules.contains(name.as_str()) {
+                                    match name.as_str() {
+                                        "stream" => self.reject_wasm_feature(
+                                            span,
+                                            WasmUnsupportedFeature::Streams,
+                                        ),
+                                        "http" => self.reject_wasm_feature(
+                                            span,
+                                            WasmUnsupportedFeature::HttpServer,
+                                        ),
+                                        "net" => self.reject_wasm_feature(
+                                            span,
+                                            WasmUnsupportedFeature::TcpNetworking,
+                                        ),
+                                        "process" => self.reject_wasm_feature(
+                                            span,
+                                            WasmUnsupportedFeature::ProcessExecution,
+                                        ),
+                                        "tls" => self
+                                            .reject_wasm_feature(span, WasmUnsupportedFeature::Tls),
+                                        "quic" => self.reject_wasm_feature(
+                                            span,
+                                            WasmUnsupportedFeature::Quic,
+                                        ),
+                                        "dns" => self
+                                            .reject_wasm_feature(span, WasmUnsupportedFeature::Dns),
+                                        "os" => self.reject_wasm_feature(
+                                            span,
+                                            WasmUnsupportedFeature::OsEnv,
+                                        ),
+                                        "encrypt" => self.reject_wasm_feature(
+                                            span,
+                                            WasmUnsupportedFeature::CryptoEncrypt,
+                                        ),
+                                        "sign" => self.reject_wasm_feature(
+                                            span,
+                                            WasmUnsupportedFeature::CryptoSign,
+                                        ),
+                                        "http_client" => self.reject_wasm_feature(
+                                            span,
+                                            WasmUnsupportedFeature::HttpClient,
+                                        ),
+                                        "smtp" => self.reject_wasm_feature(
+                                            span,
+                                            WasmUnsupportedFeature::Smtp,
+                                        ),
+                                        _ => {}
+                                    }
+                                    // crypto.random_bytes depends on a native-only secure
+                                    // entropy source absent from the wasm32 link set.
+                                    if name.as_str() == "crypto" && field == "random_bytes" {
+                                        self.reject_wasm_feature(
+                                            span,
+                                            WasmUnsupportedFeature::CryptoRandom,
+                                        );
+                                    }
+                                }
                                 return ty;
                             }
                             self.report_error(

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -4253,7 +4253,7 @@ impl Checker {
                 ..
             } => {
                 let mut then_scopes = scopes.to_vec();
-                Self::shadow_pattern_bindings(&pattern.0, &mut then_scopes);
+                self.shadow_pattern_bindings(&pattern.1, &mut then_scopes);
                 self.scan_block_for_rc_param_return(body, &mut then_scopes);
                 if let Some(else_blk) = else_body {
                     let mut else_scopes = scopes.to_vec();
@@ -4263,7 +4263,7 @@ impl Checker {
             Expr::Match { arms, .. } => {
                 for arm in arms {
                     let mut arm_scopes = scopes.to_vec();
-                    Self::shadow_pattern_bindings(&arm.pattern.0, &mut arm_scopes);
+                    self.shadow_pattern_bindings(&arm.pattern.1, &mut arm_scopes);
                     self.check_expr_is_rc_param_return(&arm.body.0, &arm.body.1, &arm_scopes);
                 }
             }
@@ -4348,30 +4348,27 @@ impl Checker {
         Self::define_dangerous_binding(scopes, name.to_string(), binding);
     }
 
-    fn shadow_pattern_bindings(pattern: &Pattern, scopes: &mut [DangerousRcScope]) {
-        match pattern {
-            Pattern::Identifier(name) => {
+    /// Shadow the borrowed-Rc bindings introduced by a match-arm / if-let /
+    /// loop / destructuring pattern.
+    ///
+    /// Routes through the single binder authority instead of re-deriving the
+    /// binder-vs-constructor decision locally (#2116): `bind_pattern` already
+    /// recorded the exact set of names this pattern binds — its env delta —
+    /// keyed by the pattern span in `pattern_bound_names`. We shadow precisely
+    /// those names. A constructor identifier (e.g. `Red` in `Red | Green`, or a
+    /// bare unit-variant arm) binds nothing, so it is absent from the set and
+    /// does NOT shadow a dangerous param of the same name — keeping the escape
+    /// analysis consistent with the real binding env. A pattern that bound
+    /// nothing (or was never type-checked, e.g. a cascade off an earlier error)
+    /// has no entry and shadows nothing, which is the fail-closed direction:
+    /// the scanner then still sees the dangerous param and flags a genuine
+    /// escape rather than silently masking it.
+    fn shadow_pattern_bindings(&self, pattern_span: &Span, scopes: &mut [DangerousRcScope]) {
+        let key = super::types::SpanKey::in_module(pattern_span, self.current_module_idx);
+        if let Some(names) = self.pattern_bound_names.get(&key) {
+            for name in names {
                 Self::define_dangerous_binding(scopes, name.clone(), None);
             }
-            Pattern::Constructor { patterns, .. } | Pattern::Tuple(patterns) => {
-                for (pattern, _) in patterns {
-                    Self::shadow_pattern_bindings(pattern, scopes);
-                }
-            }
-            Pattern::Struct { fields, .. } | Pattern::RecordShorthand { fields } => {
-                for field in fields {
-                    if let Some((pattern, _)) = &field.pattern {
-                        Self::shadow_pattern_bindings(pattern, scopes);
-                    } else {
-                        Self::define_dangerous_binding(scopes, field.name.clone(), None);
-                    }
-                }
-            }
-            Pattern::Or(left, right) => {
-                Self::shadow_pattern_bindings(&left.0, scopes);
-                Self::shadow_pattern_bindings(&right.0, scopes);
-            }
-            Pattern::Wildcard | Pattern::Literal(_) | Pattern::Regex { .. } => {}
         }
     }
 
@@ -4544,7 +4541,7 @@ impl Checker {
                             Self::define_dangerous_binding(scopes, name.clone(), binding);
                         }
                         _ => {
-                            Self::shadow_pattern_bindings(&pattern.0, scopes);
+                            self.shadow_pattern_bindings(&pattern.1, scopes);
                         }
                     }
                 }
@@ -4630,7 +4627,7 @@ impl Checker {
                 }
                 Stmt::For { pattern, body, .. } => {
                     scopes.push(HashMap::new());
-                    Self::shadow_pattern_bindings(&pattern.0, scopes);
+                    self.shadow_pattern_bindings(&pattern.1, scopes);
                     self.scan_stmts_for_rc_param_return(&body.stmts, scopes);
                     if let Some(trailing) = &body.trailing_expr {
                         self.check_expr_is_rc_param_return(&trailing.0, &trailing.1, scopes);
@@ -4642,7 +4639,7 @@ impl Checker {
                 }
                 Stmt::WhileLet { pattern, body, .. } => {
                     scopes.push(HashMap::new());
-                    Self::shadow_pattern_bindings(&pattern.0, scopes);
+                    self.shadow_pattern_bindings(&pattern.1, scopes);
                     self.scan_stmts_for_rc_param_return(&body.stmts, scopes);
                     if let Some(trailing) = &body.trailing_expr {
                         self.check_expr_is_rc_param_return(&trailing.0, &trailing.1, scopes);
@@ -4656,7 +4653,7 @@ impl Checker {
                     ..
                 } => {
                     scopes.push(HashMap::new());
-                    Self::shadow_pattern_bindings(&pattern.0, scopes);
+                    self.shadow_pattern_bindings(&pattern.1, scopes);
                     self.scan_stmts_for_rc_param_return(&body.stmts, scopes);
                     if let Some(then_trailing) = &body.trailing_expr {
                         self.check_expr_is_rc_param_return(
@@ -4673,7 +4670,7 @@ impl Checker {
                 Stmt::Match { arms, .. } => {
                     for arm in arms {
                         scopes.push(HashMap::new());
-                        Self::shadow_pattern_bindings(&arm.pattern.0, scopes);
+                        self.shadow_pattern_bindings(&arm.pattern.1, scopes);
                         // Match arm body is an Expr — check if it's a bare Rc param
                         self.check_expr_is_rc_param_return(&arm.body.0, &arm.body.1, scopes);
                         scopes.pop();

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -5207,53 +5207,15 @@ impl Checker {
                                 // native-only stdlib function is itself a
                                 // `PlatformLimitation` rejection on wasm32, mirroring
                                 // the call-form guard in methods.rs.
+                                // NATIVE_ONLY_WASM_MODULE_REJECTIONS is the single source
+                                // of truth; both guards iterate the same slice.
                                 if self.wasm_target && !self.user_modules.contains(name.as_str()) {
-                                    match name.as_str() {
-                                        "stream" => self.reject_wasm_feature(
-                                            span,
-                                            WasmUnsupportedFeature::Streams,
-                                        ),
-                                        "http" => self.reject_wasm_feature(
-                                            span,
-                                            WasmUnsupportedFeature::HttpServer,
-                                        ),
-                                        "net" => self.reject_wasm_feature(
-                                            span,
-                                            WasmUnsupportedFeature::TcpNetworking,
-                                        ),
-                                        "process" => self.reject_wasm_feature(
-                                            span,
-                                            WasmUnsupportedFeature::ProcessExecution,
-                                        ),
-                                        "tls" => self
-                                            .reject_wasm_feature(span, WasmUnsupportedFeature::Tls),
-                                        "quic" => self.reject_wasm_feature(
-                                            span,
-                                            WasmUnsupportedFeature::Quic,
-                                        ),
-                                        "dns" => self
-                                            .reject_wasm_feature(span, WasmUnsupportedFeature::Dns),
-                                        "os" => self.reject_wasm_feature(
-                                            span,
-                                            WasmUnsupportedFeature::OsEnv,
-                                        ),
-                                        "encrypt" => self.reject_wasm_feature(
-                                            span,
-                                            WasmUnsupportedFeature::CryptoEncrypt,
-                                        ),
-                                        "sign" => self.reject_wasm_feature(
-                                            span,
-                                            WasmUnsupportedFeature::CryptoSign,
-                                        ),
-                                        "http_client" => self.reject_wasm_feature(
-                                            span,
-                                            WasmUnsupportedFeature::HttpClient,
-                                        ),
-                                        "smtp" => self.reject_wasm_feature(
-                                            span,
-                                            WasmUnsupportedFeature::Smtp,
-                                        ),
-                                        _ => {}
+                                    for &(module, feature) in
+                                        Self::NATIVE_ONLY_WASM_MODULE_REJECTIONS
+                                    {
+                                        if name.as_str() == module {
+                                            self.reject_wasm_feature(span, feature);
+                                        }
                                     }
                                     // crypto.random_bytes depends on a native-only secure
                                     // entropy source absent from the wasm32 link set.

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -4537,8 +4537,22 @@ impl Checker {
                         .as_ref()
                         .and_then(|(expr, _)| self.dangerous_source_in_expr(expr, scopes));
                     match &pattern.0 {
-                        Pattern::Identifier(name) => {
+                        // A let-position identifier that resolves to a unit
+                        // variant is a refutable tag-test (`let None = opt else
+                        // { … }`, `let red = color else { … }`) that binds
+                        // NOTHING — the checker skips `bind_pattern` for it
+                        // (statements.rs). Consult that SAME authority so the
+                        // escape scanner does not invent a dangerous-scope
+                        // shadow for such a name, which would otherwise mask an
+                        // outer borrowed param of the same name and miss a real
+                        // escape. A genuine binder still propagates the RHS
+                        // danger (and shadows an outer dangerous param when the
+                        // RHS is safe).
+                        Pattern::Identifier(name) if !self.let_identifier_is_unit_variant(name) => {
                             Self::define_dangerous_binding(scopes, name.clone(), binding);
+                        }
+                        Pattern::Identifier(_) => {
+                            // Unit-variant tag-test: binds nothing, shadows nothing.
                         }
                         _ => {
                             self.shadow_pattern_bindings(&pattern.1, scopes);
@@ -4764,12 +4778,17 @@ impl Checker {
             match stmt {
                 // Track `let p = receiver.field` when `field` is an owned
                 // handle — a subsequent `return p` is the same double-free risk
-                // as `return receiver.field` directly.
+                // as `return receiver.field` directly. A unit-variant let-else
+                // (`let None = receiver.field else { … }`) binds nothing, so it
+                // is excluded via the shared binder authority — it must not
+                // register a phantom owned-handle binding.
                 Stmt::Let {
                     pattern: (Pattern::Identifier(var_name), _),
                     value: Some((Expr::FieldAccess { object, field }, _)),
                     ..
-                } if matches!(&object.0, Expr::Identifier(n) if n == receiver_name) => {
+                } if matches!(&object.0, Expr::Identifier(n) if n == receiver_name)
+                    && !self.let_identifier_is_unit_variant(var_name) =>
+                {
                     if let Some((field_name, handle_name)) =
                         self.owned_handle_field_return_by_name(field, type_name)
                     {

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -4209,11 +4209,12 @@ impl Checker {
             }
             // Aggregate escapes: enum-variant constructors like Some(r), Ok(r),
             // Err(r) embed an Rc param in a container, transferring the borrowed
-            // pointer without a clone.  Only check calls whose callee looks like
-            // a constructor (uppercase-initial identifier or Type::Variant path)
-            // — regular lowercase function calls are borrows under call-boundary
-            // ownership and are safe.
-            Expr::Call { function, args, .. } if Self::looks_like_constructor(&function.0) => {
+            // pointer without a clone.  Only check calls whose callee constructs
+            // an aggregate (variant constructor or `Type::assoc` path) — regular
+            // function calls are borrows under call-boundary ownership and safe.
+            Expr::Call { function, args, .. }
+                if self.callee_is_aggregate_constructor(&function.0) =>
+            {
                 for arg in args {
                     let (e, s) = arg.expr();
                     self.check_expr_is_rc_param_return(e, s, scopes);
@@ -4270,21 +4271,40 @@ impl Checker {
         }
     }
 
-    /// Returns `true` when the callee expression looks like a value constructor
-    /// (enum variant or type-associated constructor like `Rc::new`).
+    /// Returns `true` when a call's callee constructs an aggregate that may embed
+    /// the argument into its result — an enum/struct variant constructor, or a
+    /// `Type::assoc` path such as `Rc::new`.  Such a result, when returned,
+    /// aliases the embedded argument, so the borrowed-param escape analysis must
+    /// descend into the call's arguments.  Regular function calls pass arguments
+    /// as borrows under call-boundary ownership (the callee owns the escape
+    /// question), so they are NOT descended into.
     ///
-    /// Heuristic: an uppercase-initial bare identifier (`Some`, `Ok`, `Err`,
-    /// user-defined variants) or a `Type::method` / field-access path where
-    /// the receiver is uppercase-initial (`Rc::new`, `MyEnum::Variant`).
-    pub(super) fn looks_like_constructor(expr: &Expr) -> bool {
-        match expr {
-            Expr::Identifier(name) => name.starts_with(char::is_uppercase),
-            Expr::FieldAccess { object, .. } => {
-                // Rc::new, MyEnum::Variant, etc.
-                matches!(&object.0, Expr::Identifier(name) if name.starts_with(char::is_uppercase))
-            }
-            _ => false,
+    /// Classification is resolution-based, not casing-based (#2116): a bare
+    /// identifier is a constructor iff it is a builtin `Option`/`Result` variant
+    /// or resolves via `lookup_variant_constructor`.  This fixes two casing bugs:
+    /// an uppercase regular function (`Helper(r)`) is no longer a false hit
+    /// (spurious `BorrowedParamReturn`), and a lowercase user variant (`wrap(r)`)
+    /// is no longer a false miss (a real aggregate escape that the old uppercase
+    /// heuristic silently dropped).
+    pub(super) fn callee_is_aggregate_constructor(&self, function: &Expr) -> bool {
+        let Expr::Identifier(name) = function else {
+            // Calling a function-valued field or closure (`(obj.f)(arg)`) passes
+            // the argument as a borrow; it is never an aggregate constructor.
+            return false;
+        };
+        // `Type::assoc` / `E::Variant` paths construct or wrap a value and may
+        // embed the argument (`Rc::new(r)`, `MyEnum::Variant(r)`).  Fail-closed:
+        // descend on every qualified call so an aggregate escape is never missed.
+        if name.contains("::") {
+            return true;
         }
+        // Builtin Option/Result variant constructors embed their payload.
+        if matches!(name.as_str(), "Some" | "Ok" | "Err" | "None") {
+            return true;
+        }
+        // User enum / struct tuple-variant constructors, resolved by name
+        // (any casing) rather than an uppercase-first heuristic.
+        self.lookup_variant_constructor(name).is_some()
     }
 
     /// Return the nearest visible dangerous Rc binding for `name`.
@@ -4437,9 +4457,10 @@ impl Checker {
     /// Check if `expr` directly names or structurally contains a visible
     /// dangerous Rc binding. Returns the first match or `None`.
     ///
-    /// Structural descent mirrors `check_expr_is_rc_param_return`: constructors
-    /// (uppercase-initial calls), tuples, struct inits, and blocks are
-    /// containers that embed the value.  Regular lowercase function/method
+    /// Structural descent mirrors `check_expr_is_rc_param_return`: aggregate
+    /// constructors (variant constructors and `Type::assoc` paths, classified by
+    /// resolution — see `callee_is_aggregate_constructor`), tuples, struct inits,
+    /// and blocks are containers that embed the value.  Regular function/method
     /// calls are borrows under call-boundary ownership — the return value is
     /// unrelated, so we do NOT recurse into those.
     pub(super) fn dangerous_source_in_expr(
@@ -4449,7 +4470,9 @@ impl Checker {
     ) -> Option<DangerousRcBinding> {
         match expr {
             Expr::Identifier(name) => Self::lookup_dangerous_binding(name, scopes),
-            Expr::Call { function, args, .. } if Self::looks_like_constructor(&function.0) => {
+            Expr::Call { function, args, .. }
+                if self.callee_is_aggregate_constructor(&function.0) =>
+            {
                 for arg in args {
                     let (e, _) = arg.expr();
                     if let Some(hit) = self.dangerous_source_in_expr(e, scopes) {

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -630,6 +630,11 @@ impl Checker {
         let prev_function = self.current_function.take();
         self.current_function = Some(fn_name.to_string());
         self.env.push_scope();
+        // Scratch map of per-pattern bound names is function-local: the
+        // borrowed-Rc escape scanner (`warn_rc_param_return`, run at the end of
+        // this same call) consumes only this function's pattern spans. Clear so
+        // it never accumulates across the whole program.
+        self.pattern_bound_names.clear();
 
         // Push this fn's type-param bounds onto the resolver stack so
         // `T::Bar` projections inside `let x: T::Bar = ...` and other in-body

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -272,6 +272,37 @@ impl CollectionTyCx {
 }
 
 impl Checker {
+    /// Stdlib modules that have no wasm32 runtime support.  Any call
+    /// expression or value-position reference to a function in one of these
+    /// modules is rejected with a `PlatformLimitation` diagnostic when
+    /// targeting wasm32.
+    ///
+    /// `crypto.random_bytes` is handled separately (it is a single function
+    /// within the otherwise-supported `crypto` module) and does NOT appear in
+    /// this table.
+    ///
+    /// Both the call-form guard (`check_method_call`) and the value-position
+    /// guard (`check_field_access`) iterate this slice via
+    /// `Self::NATIVE_ONLY_WASM_MODULE_REJECTIONS` so the two paths cannot
+    /// drift out of sync.
+    pub(super) const NATIVE_ONLY_WASM_MODULE_REJECTIONS: &'static [(
+        &'static str,
+        WasmUnsupportedFeature,
+    )] = &[
+        ("stream", WasmUnsupportedFeature::Streams),
+        ("http", WasmUnsupportedFeature::HttpServer),
+        ("net", WasmUnsupportedFeature::TcpNetworking),
+        ("process", WasmUnsupportedFeature::ProcessExecution),
+        ("tls", WasmUnsupportedFeature::Tls),
+        ("quic", WasmUnsupportedFeature::Quic),
+        ("dns", WasmUnsupportedFeature::Dns),
+        ("os", WasmUnsupportedFeature::OsEnv),
+        ("encrypt", WasmUnsupportedFeature::CryptoEncrypt),
+        ("sign", WasmUnsupportedFeature::CryptoSign),
+        ("http_client", WasmUnsupportedFeature::HttpClient),
+        ("smtp", WasmUnsupportedFeature::Smtp),
+    ];
+
     fn numeric_method_signedness(ty: &Ty) -> Option<NumericSignedness> {
         match ty {
             Ty::I8 | Ty::I16 | Ty::I32 | Ty::I64 | Ty::Isize => Some(NumericSignedness::Signed),
@@ -1800,17 +1831,6 @@ impl Checker {
         let key = format!("{module_name}.{method}");
         if self.fn_sigs.contains_key(&key) {
             self.record_module_qualified_method_call_rewrite(span, key);
-        }
-    }
-
-    fn reject_if_wasm_native_only_network_module_call(&mut self, module_name: &str, span: &Span) {
-        if self.user_modules.contains(module_name) {
-            return;
-        }
-        match module_name {
-            "http_client" => self.reject_wasm_feature(span, WasmUnsupportedFeature::HttpClient),
-            "smtp" => self.reject_wasm_feature(span, WasmUnsupportedFeature::Smtp),
-            _ => {}
         }
     }
 
@@ -5760,40 +5780,15 @@ impl Checker {
                     }
                 }
                 self.require_unsafe(&key, span);
-                self.reject_if_wasm_native_only_network_module_call(name, span);
                 // Native-only stdlib modules are rejected on wasm32 because
                 // their runtime implementations are not compiled there.
+                // NATIVE_ONLY_WASM_MODULE_REJECTIONS is the single source of
+                // truth shared with the value-position guard in expressions.rs.
                 if !self.user_modules.contains(name) {
-                    match name.as_str() {
-                        "stream" => self.reject_wasm_feature(span, WasmUnsupportedFeature::Streams),
-                        "http" => {
-                            self.reject_wasm_feature(span, WasmUnsupportedFeature::HttpServer);
+                    for &(module, feature) in Self::NATIVE_ONLY_WASM_MODULE_REJECTIONS {
+                        if name == module {
+                            self.reject_wasm_feature(span, feature);
                         }
-                        "net" => {
-                            self.reject_wasm_feature(span, WasmUnsupportedFeature::TcpNetworking);
-                        }
-                        "process" => {
-                            self.reject_wasm_feature(
-                                span,
-                                WasmUnsupportedFeature::ProcessExecution,
-                            );
-                        }
-                        "tls" => self.reject_wasm_feature(span, WasmUnsupportedFeature::Tls),
-                        "quic" => self.reject_wasm_feature(span, WasmUnsupportedFeature::Quic),
-                        "dns" => self.reject_wasm_feature(span, WasmUnsupportedFeature::Dns),
-                        "os" => self.reject_wasm_feature(span, WasmUnsupportedFeature::OsEnv),
-                        // std::crypto::encrypt and std::crypto::sign are backed by
-                        // native-only staticlib companion crates absent from the wasm32
-                        // link set.  Reject at check time so the caller gets a structured
-                        // diagnostic rather than a `wasm-ld` undefined-symbol failure.
-                        // WASM-TODO(#1451): design WASI-capable crypto surfaces.
-                        "encrypt" => {
-                            self.reject_wasm_feature(span, WasmUnsupportedFeature::CryptoEncrypt);
-                        }
-                        "sign" => {
-                            self.reject_wasm_feature(span, WasmUnsupportedFeature::CryptoSign);
-                        }
-                        _ => {}
                     }
                     // crypto.random_bytes depends on a native-only secure entropy
                     // source absent from the wasm32 link set; reject so secure

--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -7,6 +7,18 @@ use super::*;
 fn collect_pattern_bound_names(pattern: &Pattern) -> HashSet<String> {
     match pattern {
         Pattern::Wildcard | Pattern::Literal(_) | Pattern::Regex { .. } => HashSet::new(),
+        // JUSTIFIED casing: this free function has no scrutinee-type context, so it
+        // cannot call `resolve_variant_match`.  Threading `&Checker` + `&Ty` through
+        // every recursive arm is feasible but deferred; for now the heuristic is kept.
+        //
+        // Consequence of the heuristic:
+        //   false-miss — uppercase binder (`FOO | BAR`) is not counted; the branches
+        //     pass the equality check vacuously, and the left branch's binding wins.
+        //   false-hit — if removed, uppercase constructor (`Red | Green`) would be
+        //     counted as a binder, causing a spurious OrPatternBindingMismatch.
+        //
+        // The conservative choice (keep casing) avoids false-hit cascades.
+        // bind_pattern IS resolution-aware so arm-body types are always correct.
         Pattern::Identifier(name) => {
             let is_constructor_like =
                 name.contains("::") || name.chars().next().is_some_and(char::is_uppercase);
@@ -102,25 +114,20 @@ fn binding_name_for_pattern(pattern: &Pattern) -> Option<String> {
 /// Returns `Some(label)` for unsupported forms that must be rejected.
 fn unsupported_payload_subpattern_label(pattern: &Pattern) -> Option<&'static str> {
     match pattern {
-        // Plain binding, wildcard, literal predicates, and aggregate
-        // destructures are supported.
+        // Qualified identifier — always a constructor path in subpattern position.
+        // Bare identifiers (any casing) are resolved against the slot type by the
+        // CALL SITE via `resolve_variant_match` before this function is reached.
+        // Returning `None` here is the safe default for any call site that has not
+        // yet added the resolution guard (false-accept rather than false-reject).
+        Pattern::Identifier(name) if name.contains("::") => Some("nested constructor"),
+        // Plain binding (bare identifier), wildcard, literal predicates, and aggregate
+        // destructures are supported or deferred to the call site.
         Pattern::Wildcard
         | Pattern::Literal(_)
         | Pattern::Struct { .. }
         | Pattern::RecordShorthand { .. }
-        | Pattern::Tuple(_) => None,
-        Pattern::Identifier(name) => {
-            let is_constructor_like =
-                name.contains("::") || name.chars().next().is_some_and(char::is_uppercase);
-            if is_constructor_like {
-                // An uppercase/qualified name in payload position is a nested
-                // constructor (unit variant), e.g. `Shape::Line(Other::Foo)`.
-                Some("nested constructor")
-            } else {
-                // Plain lowercase identifier — a binding.  Supported.
-                None
-            }
-        }
+        | Pattern::Tuple(_)
+        | Pattern::Identifier(_) => None,
         Pattern::Constructor { .. } => Some("nested constructor"),
         Pattern::Or(_, _) => Some("or-pattern"),
         // Regex literals are only legal as top-level match-arm predicates
@@ -139,16 +146,13 @@ fn unsupported_payload_subpattern_label(pattern: &Pattern) -> Option<&'static st
 /// shapes fail-closed until project predicates grow nested comparisons.
 fn unsupported_project_subpattern_label(pattern: &Pattern) -> Option<&'static str> {
     match pattern {
-        Pattern::Wildcard => None,
-        Pattern::Identifier(name) => {
-            let is_constructor_like =
-                name.contains("::") || name.chars().next().is_some_and(char::is_uppercase);
-            if is_constructor_like {
-                Some("nested constructor")
-            } else {
-                None
-            }
-        }
+        // Qualified identifier — always a constructor path in project position.
+        // Bare identifiers are resolved against the slot type by the CALL SITE
+        // via `resolve_variant_match` before this function is reached; returning
+        // `None` here is the safe default for call sites that skip that guard.
+        Pattern::Identifier(name) if name.contains("::") => Some("nested constructor"),
+        // Wildcard and bare identifiers: allowed or deferred to call site.
+        Pattern::Wildcard | Pattern::Identifier(_) => None,
         Pattern::Tuple(pats) if pats.is_empty() => None,
         Pattern::Literal(lit) => Some(literal_pattern_label(lit)),
         Pattern::Constructor { .. } => Some("nested constructor"),
@@ -571,8 +575,17 @@ impl Checker {
                 }
             }
             Pattern::Identifier(name) => {
-                let is_constructor_like =
-                    name.contains("::") || name.chars().next().is_some_and(char::is_uppercase);
+                // Determine if this identifier names a constructor (unit variant) so we
+                // can gate `reject_machine_event_pattern_outside_transition`.  Use scope
+                // resolution rather than the old uppercase-first casing heuristic (#2116):
+                // a bare name is a constructor only if `resolve_variant_match` returns a
+                // match; otherwise it is a plain binding regardless of case.
+                let is_constructor_like = if name.contains("::") {
+                    true
+                } else {
+                    let short = name.rsplit("::").next().unwrap_or(name);
+                    self.resolve_variant_match(short, ty, name).is_some()
+                };
                 if is_constructor_like
                     && self.reject_machine_event_pattern_outside_transition(ty, span)
                 {
@@ -1291,6 +1304,45 @@ impl Checker {
                 if is_enum_variant {
                     for pf in fields {
                         if let Some((sub_pat, sub_span)) = &pf.pattern {
+                            // Resolve bare identifier subpatterns against the field type
+                            // (#2116): a bare name is a nested constructor only if it
+                            // resolves as a variant of the field type; otherwise it is a
+                            // binder and must be accepted.  Qualified names (containing
+                            // `::`) are always constructor paths and are rejected.
+                            if let Pattern::Identifier(n) = sub_pat {
+                                let is_nested_ctor = if n.contains("::") {
+                                    true
+                                } else {
+                                    let field_ty =
+                                        field_tys.get(&pf.name).cloned().unwrap_or(Ty::Error);
+                                    let resolved_field =
+                                        self.project_assoc_types(&self.subst.resolve(&field_ty));
+                                    self.resolve_variant_match(n, &resolved_field, n).is_some()
+                                };
+                                if is_nested_ctor {
+                                    self.report_error_with_note(
+                                        crate::error::TypeErrorKind::UnsupportedPayloadSubpattern {
+                                            variant_name: short_name.to_string(),
+                                            kind_label: "nested constructor".to_string(),
+                                        },
+                                        sub_span,
+                                        format!(
+                                            "payload subpattern `nested constructor` in `{short_name} {{ {} }}` is not yet supported",
+                                            pf.name
+                                        ),
+                                        pattern_span,
+                                        "v0.5 payload subpatterns must be a plain binding (`x`) or wildcard (`_`); \
+                                         and literal predicates; nested patterns are reserved for a future \
+                                         match-destructure stage"
+                                            .to_string(),
+                                    );
+                                    return;
+                                }
+                                // Bare name that does not resolve as a variant of the
+                                // field type — it is a binder.  Allowed; skip the
+                                // unsupported-label check below.
+                                continue;
+                            }
                             if let Some(label) = unsupported_payload_subpattern_label(sub_pat) {
                                 self.report_error_with_note(
                                     crate::error::TypeErrorKind::UnsupportedPayloadSubpattern {
@@ -1315,6 +1367,40 @@ impl Checker {
                 } else {
                     for pf in fields {
                         if let Some((sub_pat, sub_span)) = &pf.pattern {
+                            // Resolve bare identifier subpatterns against the field type
+                            // (#2116): a bare name is a nested constructor only if it
+                            // resolves as a variant of the field type; otherwise it is a
+                            // binder and must be accepted.
+                            if let Pattern::Identifier(n) = sub_pat {
+                                let is_nested_ctor = if n.contains("::") {
+                                    true
+                                } else {
+                                    let field_ty =
+                                        field_tys.get(&pf.name).cloned().unwrap_or(Ty::Error);
+                                    let resolved_field =
+                                        self.project_assoc_types(&self.subst.resolve(&field_ty));
+                                    self.resolve_variant_match(n, &resolved_field, n).is_some()
+                                };
+                                if is_nested_ctor {
+                                    self.report_error_with_note(
+                                        crate::error::TypeErrorKind::InvalidOperation,
+                                        sub_span,
+                                        format!(
+                                            "field subpattern `nested constructor` in `{name} {{ {} }}` is not yet supported",
+                                            pf.name
+                                        ),
+                                        pattern_span,
+                                        "v0.5 record match destructure supports field bindings (`x`), \
+                                         explicit binding aliases (`x: y`), and wildcards (`x: _`); \
+                                         nested/literal field predicates are reserved for a future \
+                                         match-destructure stage"
+                                            .to_string(),
+                                    );
+                                    return;
+                                }
+                                // Bare binder (any casing) — allowed; skip the label check.
+                                continue;
+                            }
                             if let Some(label) = unsupported_project_subpattern_label(sub_pat) {
                                 self.report_error_with_note(
                                     crate::error::TypeErrorKind::InvalidOperation,
@@ -1412,7 +1498,41 @@ impl Checker {
                 return;
             }
             Pattern::Tuple(pats) => {
-                for (sub_pat, sub_span) in pats {
+                // Compute element types before the subpattern validation loop so we can
+                // resolve bare identifier subpatterns against their slot types (#2116).
+                let elem_tys: Vec<Ty> = if let Ty::Tuple(tys) = scrutinee_ty {
+                    tys.clone()
+                } else {
+                    vec![Ty::Error; pats.len()]
+                };
+                for (idx, (sub_pat, sub_span)) in pats.iter().enumerate() {
+                    // Resolve bare identifier subpatterns against the element type (#2116).
+                    if let Pattern::Identifier(n) = sub_pat {
+                        let is_nested_ctor = if n.contains("::") {
+                            true
+                        } else {
+                            let elem_ty = elem_tys.get(idx).cloned().unwrap_or(Ty::Error);
+                            let resolved_elem =
+                                self.project_assoc_types(&self.subst.resolve(&elem_ty));
+                            self.resolve_variant_match(n, &resolved_elem, n).is_some()
+                        };
+                        if is_nested_ctor {
+                            self.report_error_with_note(
+                                crate::error::TypeErrorKind::InvalidOperation,
+                                sub_span,
+                                "tuple subpattern `nested constructor` in match destructure is not yet supported"
+                                    .to_string(),
+                                pattern_span,
+                                "v0.5 tuple match destructure supports element bindings (`x`), \
+                                 wildcards (`_`), and unit subpatterns (`()`); nested/literal \
+                                 element predicates are reserved for a future match-destructure stage"
+                                    .to_string(),
+                            );
+                            return;
+                        }
+                        // Bare binder (any casing) — allowed; skip the label check.
+                        continue;
+                    }
                     if let Some(label) = unsupported_project_subpattern_label(sub_pat) {
                         self.report_error_with_note(
                             crate::error::TypeErrorKind::InvalidOperation,
@@ -1429,11 +1549,6 @@ impl Checker {
                         return;
                     }
                 }
-                let elem_tys: Vec<Ty> = if let Ty::Tuple(tys) = scrutinee_ty {
-                    tys.clone()
-                } else {
-                    vec![Ty::Error; pats.len()]
-                };
                 let payload_bindings: Vec<PayloadBinding> = pats
                     .iter()
                     .zip(elem_tys.iter())

--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -484,12 +484,63 @@ impl Checker {
         }
     }
 
+    /// Pattern binding — the single authority on which pattern identifiers are
+    /// binders (introduce a name) versus constructors (introduce none). Every
+    /// consumer that needs that decision routes through the env delta this
+    /// records, never a private re-derivation.
+    ///
+    /// The top-level call snapshots the innermost scope, runs the binding via
+    /// [`Self::bind_pattern_inner`], then records the set of names introduced
+    /// (keyed by the pattern span) into `pattern_bound_names`. A constructor
+    /// identifier binds nothing, so it never appears in that set — which is why
+    /// the borrowed-Rc escape scanner can shadow exactly the real binders
+    /// (`shadow_pattern_bindings`) without duplicating the resolution logic.
+    /// Nested sub-pattern binds re-enter through `bind_pattern` but the
+    /// `bind_pattern_recording` guard keeps them part of the one top-level
+    /// delta.
+    pub(super) fn bind_pattern(
+        &mut self,
+        pattern: &Pattern,
+        ty: &Ty,
+        is_mutable: bool,
+        span: &Span,
+    ) {
+        if self.bind_pattern_recording {
+            // Nested sub-pattern: its binders belong to the top-level delta
+            // already being recorded by an enclosing call.
+            self.bind_pattern_inner(pattern, ty, is_mutable, span);
+            return;
+        }
+        self.bind_pattern_recording = true;
+        let before: HashSet<String> = self
+            .env
+            .current_scope_bindings()
+            .map(|(name, _)| name.to_string())
+            .collect();
+        self.bind_pattern_inner(pattern, ty, is_mutable, span);
+        let bound: Vec<String> = self
+            .env
+            .current_scope_bindings()
+            .filter(|(name, _)| !before.contains(*name))
+            .map(|(name, _)| name.to_string())
+            .collect();
+        self.bind_pattern_recording = false;
+        let key = super::types::SpanKey::in_module(span, self.current_module_idx);
+        if bound.is_empty() {
+            // A pure-constructor pattern (e.g. `Red | Green`) binds nothing;
+            // ensure no stale entry survives for this span.
+            self.pattern_bound_names.remove(&key);
+        } else {
+            self.pattern_bound_names.insert(key, bound);
+        }
+    }
+
     /// Pattern binding
     #[expect(
         clippy::too_many_lines,
         reason = "impl method resolution requires many cases"
     )]
-    pub(super) fn bind_pattern(
+    pub(super) fn bind_pattern_inner(
         &mut self,
         pattern: &Pattern,
         ty: &Ty,

--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -4,49 +4,32 @@
 )]
 use super::*;
 
-fn collect_pattern_bound_names(pattern: &Pattern) -> HashSet<String> {
-    match pattern {
-        Pattern::Wildcard | Pattern::Literal(_) | Pattern::Regex { .. } => HashSet::new(),
-        // JUSTIFIED casing: this free function has no scrutinee-type context, so it
-        // cannot call `resolve_variant_match`.  Threading `&Checker` + `&Ty` through
-        // every recursive arm is feasible but deferred; for now the heuristic is kept.
-        //
-        // Consequence of the heuristic:
-        //   false-miss — uppercase binder (`FOO | BAR`) is not counted; the branches
-        //     pass the equality check vacuously, and the left branch's binding wins.
-        //   false-hit — if removed, uppercase constructor (`Red | Green`) would be
-        //     counted as a binder, causing a spurious OrPatternBindingMismatch.
-        //
-        // The conservative choice (keep casing) avoids false-hit cascades.
-        // bind_pattern IS resolution-aware so arm-body types are always correct.
-        Pattern::Identifier(name) => {
-            let is_constructor_like =
-                name.contains("::") || name.chars().next().is_some_and(char::is_uppercase);
-            if is_constructor_like {
-                HashSet::new()
-            } else {
-                HashSet::from([name.clone()])
-            }
-        }
-        Pattern::Constructor { patterns, .. } | Pattern::Tuple(patterns) => patterns
-            .iter()
-            .flat_map(|pattern| collect_pattern_bound_names(&pattern.0))
-            .collect(),
-        Pattern::Struct { fields, .. } | Pattern::RecordShorthand { fields } => fields
-            .iter()
-            .flat_map(|field| {
-                field.pattern.as_ref().map_or_else(
-                    || HashSet::from([field.name.clone()]),
-                    |(pattern, _)| collect_pattern_bound_names(pattern),
-                )
-            })
-            .collect(),
-        Pattern::Or(left, right) => {
-            let mut names = collect_pattern_bound_names(&left.0);
-            names.extend(collect_pattern_bound_names(&right.0));
-            names
-        }
-    }
+fn or_branch_bound_names(
+    before: &crate::env::TypeEnv,
+    after: &crate::env::TypeEnv,
+) -> HashSet<String> {
+    // The set of names an or-pattern branch introduced is computed from the
+    // authoritative binding result — the delta between the env before binding
+    // the branch and the env after — rather than re-derived from pattern syntax
+    // by casing. This removes the case heuristic from the binding-consistency
+    // path entirely (#2116): a bare identifier counts as a binder iff
+    // `bind_pattern` actually defined it (which it does only when the name does
+    // not resolve as a constructor of the scrutinee type), so uppercase binders
+    // (`FOO | BAR`) are detected and inconsistent constructors (`Red | Green`,
+    // which bind nothing) are not. Regex captures, struct-field shorthands, and
+    // nested payload binders are all captured uniformly, with no duplication of
+    // `bind_pattern`'s type recursion.
+    //
+    // A name counts as newly bound when it is absent from `before` or rebound to
+    // a fresh binding id (shadowing within the same scope), so a branch that
+    // re-binds an outer name to a different type is still observed.
+    let before_ids: HashMap<&str, crate::env::TypeBindingId> =
+        before.current_scope_bindings().collect();
+    after
+        .current_scope_bindings()
+        .filter(|(name, id)| before_ids.get(name) != Some(id))
+        .map(|(name, _)| name.to_owned())
+        .collect()
 }
 
 fn sorted_pattern_bound_names(names: &HashSet<String>) -> Vec<String> {
@@ -586,9 +569,15 @@ impl Checker {
                     let short = name.rsplit("::").next().unwrap_or(name);
                     self.resolve_variant_match(short, ty, name).is_some()
                 };
-                if is_constructor_like
-                    && self.reject_machine_event_pattern_outside_transition(ty, span)
-                {
+                if is_constructor_like {
+                    // A unit-variant constructor pattern introduces no binding. Gate the
+                    // machine-event rejection for its side effect, then return WITHOUT
+                    // defining a name: a constructor is not a binder, so the env must not
+                    // record one. This keeps the env an authoritative record of real
+                    // binders, which the or-pattern arm diffs to check binding
+                    // consistency (a constructor branch like `Red | Green` correctly
+                    // binds nothing on both sides).
+                    self.reject_machine_event_pattern_outside_transition(ty, span);
                     return;
                 }
                 self.check_shadowing(name, span);
@@ -933,18 +922,33 @@ impl Checker {
                 }
             }
             Pattern::Or(a, b) => {
-                let left_names = collect_pattern_bound_names(&a.0);
-                let right_names = collect_pattern_bound_names(&b.0);
                 let env_before = self.env.clone();
 
                 self.bind_pattern(&a.0, ty, is_mutable, &a.1);
                 let left_env = self.env.clone();
+                let left_names = or_branch_bound_names(&env_before, &left_env);
+
                 self.env = env_before.clone();
                 self.bind_pattern(&b.0, ty, is_mutable, &b.1);
                 let right_env = self.env.clone();
+                let right_names = or_branch_bound_names(&env_before, &right_env);
 
-                if self.or_pattern_bindings_match(&left_env, &right_env, &left_names, &right_names)
-                {
+                if matches!(ty, Ty::Var(_) | Ty::Error) {
+                    // The scrutinee type is unresolvable — an earlier error, or a
+                    // not-yet-inferred type variable. A bare identifier then cannot
+                    // be classified as constructor-or-binder (`resolve_variant_match`
+                    // has nothing to resolve against), so the branch binder sets are
+                    // unreliable and a consistency verdict would be a cascade off an
+                    // already-broken scrutinee. Bind the left branch for recovery and
+                    // emit nothing, matching the Constructor/Tuple/Struct arms which
+                    // already treat `Ty::Var | Ty::Error` as silent.
+                    self.env = left_env;
+                } else if self.or_pattern_bindings_match(
+                    &left_env,
+                    &right_env,
+                    &left_names,
+                    &right_names,
+                ) {
                     self.env = left_env;
                 } else {
                     self.env = env_before;

--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -76,32 +76,21 @@ fn substitute_pattern_field_ty(raw_field_ty: &Ty, type_params: &[String], type_a
 
 /// Extract the single binding name introduced by a sub-pattern, if any.
 ///
-/// Returns `Some(name)` only for plain lowercase `Identifier` bindings.
-/// Returns `None` for wildcards, literals, constructors, structs, tuples,
-/// and or-patterns — those either introduce no name, or introduce names
-/// that the caller handles recursively.
+/// Returns `Some(name)` for any plain unqualified `Identifier` — both
+/// lowercase and uppercase — because qualified names (containing `::`) are
+/// always constructor paths, while bare names (of any casing) bind a new
+/// variable.
+///
+/// Returns `None` for wildcards, literals, qualified identifiers,
+/// constructors, structs, tuples, and or-patterns — those either introduce
+/// no name, or introduce names the caller handles recursively.
 ///
 /// This is intentionally shallow (top-level only) so the caller decides
 /// whether to recurse into constructor payloads.
 fn binding_name_for_pattern(pattern: &Pattern) -> Option<String> {
     match pattern {
-        Pattern::Identifier(name) => {
-            let is_constructor_like =
-                name.contains("::") || name.chars().next().is_some_and(char::is_uppercase);
-            if is_constructor_like {
-                None
-            } else {
-                Some(name.clone())
-            }
-        }
-        Pattern::Wildcard
-        | Pattern::Literal(_)
-        | Pattern::Regex { .. }
-        | Pattern::Constructor { .. }
-        | Pattern::Struct { .. }
-        | Pattern::RecordShorthand { .. }
-        | Pattern::Tuple(_)
-        | Pattern::Or(_, _) => None,
+        Pattern::Identifier(name) if !name.contains("::") => Some(name.clone()),
+        _ => None,
     }
 }
 
@@ -170,26 +159,22 @@ fn unsupported_project_subpattern_label(pattern: &Pattern) -> Option<&'static st
     }
 }
 
-/// True for patterns that match every value of any type: `_` and plain
-/// lowercase identifier bindings.
-pub(super) fn pattern_is_catch_all(pattern: &Pattern) -> bool {
-    match pattern {
-        Pattern::Wildcard => true,
-        Pattern::Identifier(name) => {
-            !(name.contains("::") || name.chars().next().is_some_and(char::is_uppercase))
-        }
-        _ => false,
-    }
-}
-
 /// True for payload subpatterns that match every value of their slot type:
-/// wildcards, plain bindings, and the unit tuple `()`.
+/// wildcards, plain bindings (any casing), and the unit tuple `()`.
+///
+/// Bare unqualified identifiers — whether lowercase or uppercase — are
+/// treated as irrefutable bindings here.  Qualified names (containing `::`
+/// such as `Shape::Line`) are always constructor paths and therefore
+/// refutable.  This is used for struct-variant field position exhaustiveness
+/// where concrete field types are not threaded through
+/// `VariantPayloadShape::Struct`; for tuple-payload positions use the
+/// resolution-aware `is_payload_irrefutable_for_ty` method instead.
 fn payload_subpattern_is_irrefutable(pattern: &Pattern) -> bool {
     match pattern {
         Pattern::Wildcard => true,
-        Pattern::Identifier(name) => {
-            !(name.contains("::") || name.chars().next().is_some_and(char::is_uppercase))
-        }
+        // Qualified name — always a constructor path, never a binder.
+        // Bare name (any casing) — treated as a binding (irrefutable).
+        Pattern::Identifier(name) => !name.contains("::"),
         Pattern::Tuple(pats) => pats.is_empty(),
         _ => false,
     }
@@ -265,6 +250,33 @@ impl Checker {
         )
     }
 
+    /// Resolution-aware catch-all test for top-level arm patterns.
+    ///
+    /// A pattern is a catch-all (covers every value of the scrutinee type) when:
+    /// - It is a wildcard `_`, OR
+    /// - It is an unqualified plain identifier that does **not** resolve as a
+    ///   variant of `scrutinee_ty` — i.e., it is a binding, not a constructor.
+    ///
+    /// Qualified identifiers (containing `::`) are always constructor paths
+    /// and are never catch-alls.  An unresolved scrutinee type (`Ty::Var`)
+    /// causes `resolve_variant_match` to return `None`, conservatively treating
+    /// the identifier as a binder; this avoids false exhaustiveness errors when
+    /// the scrutinee type is not yet fully known.
+    pub(super) fn is_catch_all_for_scrutinee(&self, pattern: &Pattern, scrutinee_ty: &Ty) -> bool {
+        match pattern {
+            Pattern::Wildcard => true,
+            Pattern::Identifier(name) => {
+                if name.contains("::") {
+                    return false;
+                }
+                let resolved = self.project_assoc_types(&self.subst.resolve(scrutinee_ty));
+                let short = name.rsplit("::").next().unwrap_or(name);
+                self.resolve_variant_match(short, &resolved, name).is_none()
+            }
+            _ => false,
+        }
+    }
+
     /// True when `patterns` (the flattened, unguarded match-arm leaf patterns)
     /// cover every value of `ty`.
     ///
@@ -276,7 +288,10 @@ impl Checker {
     /// resolved by the user adding a catch-all arm; under-rejection would
     /// push a reachable miss onto the runtime exhaustiveness trap).
     pub(super) fn patterns_cover_type(&self, patterns: &[&Pattern], ty: &Ty) -> bool {
-        if patterns.iter().any(|p| pattern_is_catch_all(p)) {
+        if patterns
+            .iter()
+            .any(|p| self.is_catch_all_for_scrutinee(p, ty))
+        {
             return true;
         }
         let resolved = self.subst.resolve(ty);

--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -300,6 +300,35 @@ impl Checker {
             .all(|(name, shape)| self.variant_covered(patterns, name, shape))
     }
 
+    /// Resolution-based irrefutability test for a single payload subpattern
+    /// slot.  Replaces the static `payload_subpattern_is_irrefutable` for
+    /// contexts where the concrete payload type is known.
+    ///
+    /// A subpattern is irrefutable (catches every value of `payload_ty`) when:
+    /// - It is a wildcard `_` or the empty-tuple unit `()`.
+    /// - It is a plain identifier that does **not** resolve as a variant of
+    ///   `payload_ty` — i.e., it is a binding, not a constructor.
+    ///
+    /// Constructor identifiers (qualified with `::`, or resolving to a known
+    /// variant) are refutable and return `false`.
+    fn is_payload_irrefutable_for_ty(&self, pattern: &Pattern, payload_ty: &Ty) -> bool {
+        match pattern {
+            Pattern::Wildcard => true,
+            Pattern::Identifier(name) => {
+                // Qualified name — always a constructor path, never a binder.
+                if name.contains("::") {
+                    return false;
+                }
+                // Unqualified: irrefutable iff it does NOT resolve as a variant.
+                let resolved = self.project_assoc_types(&self.subst.resolve(payload_ty));
+                let short = name.rsplit("::").next().unwrap_or(name);
+                self.resolve_variant_match(short, &resolved, name).is_none()
+            }
+            Pattern::Tuple(pats) => pats.is_empty(),
+            _ => false,
+        }
+    }
+
     /// True when at least one row of `patterns` headed by `variant_name`
     /// covers every value of the variant's payload.
     pub(super) fn variant_covered(
@@ -344,11 +373,18 @@ impl Checker {
             VariantPayloadShape::Unit => has_unit_row || !ctor_rows.is_empty(),
             VariantPayloadShape::Struct => has_struct_cover,
             VariantPayloadShape::Tuple(payload_tys) => {
+                // Use resolution-based irrefutability so that a plain uppercase
+                // binder (e.g. `Some(MAX)` where `MAX` is not a variant of the
+                // payload type) is treated as covering the slot rather than being
+                // mistaken for an unresolvable constructor.
                 if ctor_rows.iter().any(|row| {
                     row.len() == payload_tys.len()
                         && row
                             .iter()
-                            .all(|(sub, _)| payload_subpattern_is_irrefutable(sub))
+                            .zip(payload_tys.iter())
+                            .all(|((sub, _), payload_ty)| {
+                                self.is_payload_irrefutable_for_ty(sub, payload_ty)
+                            })
                 }) {
                     return true;
                 }
@@ -974,6 +1010,10 @@ impl Checker {
         pattern_span: &Span,
         scrutinee_ty: &Ty,
     ) {
+        // Resolve inference variables before pattern classification so that
+        // Option<T>, Result<T,E>, and user-enum scrutinees are identifiable
+        // even when the type was supplied as an in-flight inference var.
+        let scrutinee_ty = &self.project_assoc_types(&self.subst.resolve(scrutinee_ty));
         let key = super::types::SpanKey::in_module(pattern_span, self.current_module_idx);
 
         let resolution = match pattern {
@@ -990,13 +1030,15 @@ impl Checker {
                 payload_variant_patterns: vec![],
             },
             Pattern::Identifier(name) => {
-                // Use the same heuristic as `bind_pattern` to distinguish an
-                // uppercase/qualified constructor-as-unit-variant from a
-                // plain binding.
-                let is_constructor_like =
-                    name.contains("::") || name.chars().next().is_some_and(char::is_uppercase);
-                if is_constructor_like {
-                    // Unit variant written as an identifier (e.g. `None`).
+                // Resolve whether this identifier names a unit-variant constructor
+                // or is a plain binder.  Path-qualified names (`name.contains("::")`)
+                // are always constructors (a binder cannot contain `::`). For bare
+                // names, use scope resolution against the scrutinee type rather than
+                // the old uppercase-first heuristic (#2116): if the name resolves to
+                // a known unit-variant, classify it as a VariantCtor; otherwise it
+                // is a Binding regardless of case. This allows uppercase plain
+                // binders like `INF` or `MAX` against non-enum types.
+                if name.contains("::") {
                     let short_name = name.rsplit("::").next().unwrap_or(name);
                     let variant_match = self.resolve_variant_match(short_name, scrutinee_ty, name);
                     ArmResolution {
@@ -1006,11 +1048,21 @@ impl Checker {
                         payload_variant_patterns: vec![],
                     }
                 } else {
-                    ArmResolution {
-                        pattern_kind: PatternKind::Binding,
-                        variant_match: None,
-                        payload_bindings: vec![],
-                        payload_variant_patterns: vec![],
+                    let variant_match = self.resolve_variant_match(name, scrutinee_ty, name);
+                    if variant_match.is_some() {
+                        ArmResolution {
+                            pattern_kind: PatternKind::VariantCtor,
+                            variant_match,
+                            payload_bindings: vec![],
+                            payload_variant_patterns: vec![],
+                        }
+                    } else {
+                        ArmResolution {
+                            pattern_kind: PatternKind::Binding,
+                            variant_match: None,
+                            payload_bindings: vec![],
+                            payload_variant_patterns: vec![],
+                        }
                     }
                 }
             }
@@ -1020,15 +1072,43 @@ impl Checker {
                 let payload_tys = self
                     .lookup_variant_types(name, scrutinee_ty, patterns.len())
                     .unwrap_or_else(|| vec![Ty::Error; patterns.len()]);
-                // Validate payload subpatterns. Plain bindings, wildcards,
-                // literal predicates, and (recursively) nested constructor
-                // subpatterns are admitted; aggregate destructures and
-                // or-patterns in payload position remain fail-closed.
+                // Validate payload subpatterns using resolution-based nested
+                // constructor detection (#2116) rather than the old case heuristic.
+                // Track which payload slots were classified as nested constructors so
+                // the binding-collection pass below can skip them.
+                let mut ctor_field_idxs: std::collections::HashSet<usize> =
+                    std::collections::HashSet::new();
                 let mut payload_variant_patterns: Vec<PayloadVariantPattern> = Vec::new();
                 for (field_idx, (sub_pat, sub_span)) in patterns.iter().enumerate() {
                     let payload_ty = payload_tys.get(field_idx).cloned().unwrap_or(Ty::Error);
-                    match Self::nested_ctor_subpattern(sub_pat) {
+                    let resolved_payload =
+                        self.project_assoc_types(&self.subst.resolve(&payload_ty));
+                    // Classify the subpattern: qualified identifiers and
+                    // Pattern::Constructor are always constructors; bare identifiers
+                    // are resolved against the payload type.
+                    let nested_ctor_opt: Option<(&str, &[(Pattern, Span)])> = match sub_pat {
+                        Pattern::Constructor { name, patterns } => {
+                            Some((name.as_str(), patterns.as_slice()))
+                        }
+                        Pattern::Identifier(n) if n.contains("::") => {
+                            Some((n.as_str(), &[] as &[(Pattern, Span)]))
+                        }
+                        Pattern::Identifier(n) => {
+                            let short = n.rsplit("::").next().unwrap_or(n);
+                            if self
+                                .resolve_variant_match(short, &resolved_payload, n)
+                                .is_some()
+                            {
+                                Some((n.as_str(), &[] as &[(Pattern, Span)]))
+                            } else {
+                                None // plain binding regardless of case
+                            }
+                        }
+                        _ => None,
+                    };
+                    match nested_ctor_opt {
                         Some((ctor_name, inner_patterns)) => {
+                            ctor_field_idxs.insert(field_idx);
                             let Some(pvp) = self.build_payload_variant_pattern(
                                 field_idx,
                                 &payload_ty,
@@ -1042,38 +1122,56 @@ impl Checker {
                             payload_variant_patterns.push(pvp);
                         }
                         None => {
-                            if let Some(label) = unsupported_payload_subpattern_label(sub_pat) {
-                                self.report_error_with_note(
-                                    crate::error::TypeErrorKind::UnsupportedPayloadSubpattern {
-                                        variant_name: short_name.to_string(),
-                                        kind_label: label.to_string(),
-                                    },
-                                    sub_span,
-                                    format!(
-                                        "payload subpattern `{label}` in `{short_name}(...)` is not yet supported"
-                                    ),
-                                    pattern_span,
-                                    "v0.5 payload subpatterns support plain bindings (`x`), wildcards (`_`), \
-                                     literal predicates, and nested constructor patterns; aggregate \
-                                     destructures and or-patterns are reserved for a future \
-                                     match-destructure stage"
-                                        .to_string(),
-                                );
-                                return;
+                            // Plain `Pattern::Identifier` patterns (including
+                            // uppercase ones that did not resolve as constructors)
+                            // are valid payload bindings — do not report them as
+                            // unsupported.  Only check unsupported shapes for
+                            // non-Identifier patterns.
+                            if !matches!(sub_pat, Pattern::Identifier(_)) {
+                                if let Some(label) = unsupported_payload_subpattern_label(sub_pat) {
+                                    self.report_error_with_note(
+                                        crate::error::TypeErrorKind::UnsupportedPayloadSubpattern {
+                                            variant_name: short_name.to_string(),
+                                            kind_label: label.to_string(),
+                                        },
+                                        sub_span,
+                                        format!(
+                                            "payload subpattern `{label}` in `{short_name}(...)` is not yet supported"
+                                        ),
+                                        pattern_span,
+                                        "v0.5 payload subpatterns support plain bindings (`x`), wildcards (`_`), \
+                                         literal predicates, and nested constructor patterns; aggregate \
+                                         destructures and or-patterns are reserved for a future \
+                                         match-destructure stage"
+                                            .to_string(),
+                                    );
+                                    return;
+                                }
                             }
                         }
                     }
                 }
+                // Collect payload bindings for slots not classified as nested
+                // constructors.  All plain `Pattern::Identifier` bindings are
+                // admitted — including uppercase names that resolution determined
+                // are not constructors in this payload position.
                 let payload_bindings: Vec<PayloadBinding> = patterns
                     .iter()
                     .zip(payload_tys.iter())
                     .enumerate()
                     .filter_map(|(field_idx, ((sub_pat, _sub_span), ty))| {
-                        binding_name_for_pattern(sub_pat).map(|binding_name| PayloadBinding {
-                            field_idx,
-                            binding_name,
-                            ty: self.project_assoc_types(ty),
-                        })
+                        if ctor_field_idxs.contains(&field_idx) {
+                            return None; // Handled as nested constructor above.
+                        }
+                        if let Pattern::Identifier(binding_name) = sub_pat {
+                            Some(PayloadBinding {
+                                field_idx,
+                                binding_name: binding_name.clone(),
+                                ty: self.project_assoc_types(ty),
+                            })
+                        } else {
+                            None
+                        }
                     })
                     .collect();
                 ArmResolution {
@@ -1391,27 +1489,6 @@ impl Checker {
         self.pending_pattern_resolutions.insert(key, resolution);
     }
 
-    /// Classify a payload subpattern as a nested constructor, returning the
-    /// constructor's surface name and its own payload subpatterns.
-    ///
-    /// Matches both shapes a nested variant takes in payload position:
-    /// `Pattern::Constructor` (`Err(ParseError::Invalid(_))`) and a
-    /// constructor-like `Pattern::Identifier` (`Err(IoError::NotFound)` — a
-    /// unit variant, which parses as an identifier). Returns `None` for every
-    /// other subpattern kind so the caller falls through to the
-    /// binding/wildcard/literal handling.
-    fn nested_ctor_subpattern(pattern: &Pattern) -> Option<(&str, &[(Pattern, Span)])> {
-        match pattern {
-            Pattern::Constructor { name, patterns } => Some((name, patterns.as_slice())),
-            Pattern::Identifier(name) => {
-                let is_constructor_like =
-                    name.contains("::") || name.chars().next().is_some_and(char::is_uppercase);
-                is_constructor_like.then_some((name.as_str(), &[] as &[(Pattern, Span)]))
-            }
-            _ => None,
-        }
-    }
-
     /// Recursively resolve a nested constructor subpattern at payload slot
     /// `field_idx` (whose checker type is `payload_ty`) into a
     /// [`PayloadVariantPattern`].
@@ -1425,6 +1502,11 @@ impl Checker {
     /// Returns `None` after reporting (or when `bind_pattern` already
     /// reported, for unresolvable constructor names) so the caller abandons
     /// the arm resolution — a missing side-table entry fails closed in HIR.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "inline resolution logic for nested constructor subpatterns requires \
+                  one branch per sub-pattern shape; extraction would hide the control flow"
+    )]
     fn build_payload_variant_pattern(
         &mut self,
         field_idx: usize,
@@ -1469,7 +1551,31 @@ impl Checker {
                 .get(inner_idx)
                 .cloned()
                 .unwrap_or(Ty::Error);
-            if let Some((inner_ctor, inner_subs)) = Self::nested_ctor_subpattern(sub_pat) {
+            // Resolution-based nested constructor detection for deeply-nested
+            // payload subpatterns, replacing the old case heuristic in
+            // `nested_ctor_subpattern` (#2116).
+            let resolved_inner = self.project_assoc_types(&self.subst.resolve(&inner_ty));
+            let inner_nested_opt: Option<(&str, &[(Pattern, Span)])> = match sub_pat {
+                Pattern::Constructor { name, patterns } => {
+                    Some((name.as_str(), patterns.as_slice()))
+                }
+                Pattern::Identifier(n) if n.contains("::") => {
+                    Some((n.as_str(), &[] as &[(Pattern, Span)]))
+                }
+                Pattern::Identifier(n) => {
+                    let short = n.rsplit("::").next().unwrap_or(n);
+                    if self
+                        .resolve_variant_match(short, &resolved_inner, n)
+                        .is_some()
+                    {
+                        Some((n.as_str(), &[] as &[(Pattern, Span)]))
+                    } else {
+                        None // plain binding regardless of case
+                    }
+                }
+                _ => None,
+            };
+            if let Some((inner_ctor, inner_subs)) = inner_nested_opt {
                 let pvp = self.build_payload_variant_pattern(
                     inner_idx,
                     &inner_ty,
@@ -1485,8 +1591,8 @@ impl Checker {
                 Pattern::Wildcard => {}
                 Pattern::Tuple(pats) if pats.is_empty() => {}
                 Pattern::Identifier(binding_name) => {
-                    // Constructor-like identifiers were consumed by
-                    // `nested_ctor_subpattern` above; this is a plain binding.
+                    // All plain identifiers (including uppercase ones that did
+                    // not resolve as constructors above) are plain bindings.
                     bindings.push(PayloadBinding {
                         field_idx: inner_idx,
                         binding_name: binding_name.clone(),

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -462,6 +462,19 @@ impl Checker {
             .any(|td| matches!(td.variants.get(name), Some(VariantDef::Unit)))
     }
 
+    /// Does an identifier in `let`/binding position name a unit variant — a
+    /// refutable tag-test that binds NOTHING — rather than introduce a fresh
+    /// binder? This is the single authority for the let-side binder-vs-tag-test
+    /// decision: `check_stmt`'s `let` arm uses it to skip `bind_pattern` for a
+    /// unit-variant identifier (a `let None = … else { … }` / `let red = color
+    /// else { … }` tag-test), and the borrowed-Rc escape scanner consults the
+    /// SAME predicate so it never invents a dangerous-scope shadow for a name
+    /// that did not actually bind. Detection is by resolution (a `::`-qualified
+    /// path or a bare name resolving to a known unit variant), never by casing.
+    pub(super) fn let_identifier_is_unit_variant(&self, name: &str) -> bool {
+        name.contains("::") || self.bare_identifier_resolves_to_unit_variant(name)
+    }
+
     #[expect(
         clippy::too_many_lines,
         reason = "statement checking covers many Stmt variants"
@@ -610,10 +623,7 @@ impl Checker {
                 // mismatched value type is then a clean type error); otherwise
                 // it binds.
                 let identifier_is_unit_variant = match &pattern.0 {
-                    Pattern::Identifier(name) if name.contains("::") => true,
-                    Pattern::Identifier(name) => {
-                        self.bare_identifier_resolves_to_unit_variant(name)
-                    }
+                    Pattern::Identifier(name) => self.let_identifier_is_unit_variant(name),
                     _ => false,
                 };
                 // For simple identifier patterns, track the definition span.

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -20290,6 +20290,55 @@ mod wasm_rejects {
 
     // ── Native sibling tests: no platform error on non-wasm target ────────
 
+    // ── Additional value-position coverage: net, http_client, encrypt (#2135) ─
+    // These tests verify that the NATIVE_ONLY_WASM_MODULE_REJECTIONS table
+    // covers a representative subset of the 12 native-only modules in the
+    // value-position path so a future accidental deletion is caught.
+
+    #[test]
+    fn wasm_rejects_net_connect_value_position() {
+        let source = concat!(
+            "import std::net;\n",
+            "fn main() { let _f = net.connect; }\n",
+        );
+        let output = check_wasm_with_registry(source);
+        assert!(
+            has_platform_limitation_error(&output),
+            "net.connect value-position reference must be a compile-time error on WASM; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_rejects_http_client_request_value_position() {
+        let source = concat!(
+            "import std::net::http::http_client;\n",
+            "fn main() { let _f = http_client.request; }\n",
+        );
+        let output = check_wasm_with_registry(source);
+        assert!(
+            has_platform_limitation_error(&output),
+            "http_client.request value-position reference must be a compile-time error on WASM; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_rejects_encrypt_seal_value_position() {
+        let source = concat!(
+            "import std::crypto::encrypt;\n",
+            "fn main() { let _f = encrypt.seal; }\n",
+        );
+        let output = check_wasm_with_registry(source);
+        assert!(
+            has_platform_limitation_error(&output),
+            "encrypt.seal value-position reference must be a compile-time error on WASM; got: {:?}",
+            output.errors
+        );
+    }
+
+    // ── Native sibling tests: no platform error on non-wasm target ────────
+
     #[test]
     fn native_tls_no_platform_error() {
         let source = concat!(
@@ -25987,6 +26036,26 @@ fn foo(opt: Option<i64>) -> i64 {
         assert!(
             some_arm.payload_variant_patterns.is_empty(),
             "uppercase binder MAX must not be recorded as a nested constructor"
+        );
+    }
+
+    #[test]
+    fn top_level_uppercase_binder_over_option_compiles() {
+        // Concrete repro for issue #2116 follow-up: a bare uppercase identifier
+        // that does NOT resolve as a variant of the scrutinee type (here
+        // `Option<i64>` has variants `Some` / `None`, neither of which is `INF`)
+        // must be treated as a binding catch-all, making the match exhaustive.
+        // The old code used a casing heuristic which caused a false
+        // NonExhaustiveMatch error for this shape.
+        let output = check_source(
+            r"fn foo(opt: Option<i64>) -> i64 {
+    match opt { INF => 0 }
+}",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "match opt {{ INF => 0 }} with uppercase binder must compile without errors; got: {:#?}",
+            output.errors
         );
     }
 }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -5318,6 +5318,132 @@ fn borrowed_param_escape_consistent_or_binder_not_overflagged() {
 }
 
 #[test]
+fn borrowed_param_escape_let_else_unit_variant_collision_flagged() {
+    // #2116 residual (6th finding): a `let`-else whose pattern is a unit-variant
+    // identifier colliding with a borrow param binds NOTHING — the checker
+    // classifies `red` as a refutable tag-test and skips `bind_pattern` for it
+    // (statements.rs). The borrow-escape scanner must consult that SAME
+    // authority (`let_identifier_is_unit_variant`) and NOT invent a shadow, so
+    // the trailing `red` resolves to the borrow param and returning it raises
+    // BorrowedParamReturn.
+    //
+    // Before the fix the scanner's `Stmt::Let` arm blindly treated the
+    // identifier as a binder and shadowed the dangerous param, masking the
+    // escape; it surfaced only later (confusingly) as a sibling MIR
+    // `DecisionMapTotal` / HIR no-binding error.
+    let (errors, _) = parse_and_check(concat!(
+        "enum Color { red; green; }\n",
+        "fn leak(red: &i64, color: Color) -> &i64 {\n",
+        "    let red = color else { panic(\"no\") };\n",
+        "    red\n",
+        "}\n",
+    ));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::BorrowedParamReturn)),
+        "let-else unit-variant `let red = color else …` binds nothing — the \
+        trailing `red` is the borrow param and must raise BorrowedParamReturn; \
+        got: {errors:?}"
+    );
+}
+
+#[test]
+fn borrowed_param_escape_let_else_intermediate_binding_flagged() {
+    // The masked param flows through a genuine intermediate binder. After the
+    // unit-variant `let red = color else …` (which binds nothing), `let x = red`
+    // copies the still-dangerous borrow param into `x`; returning `x` must be
+    // flagged. Exercises both the unit-variant skip AND the genuine-binder
+    // danger-propagation path in the same function.
+    let (errors, _) = parse_and_check(concat!(
+        "enum Color { red; green; }\n",
+        "fn leak(red: &i64, color: Color) -> &i64 {\n",
+        "    let red = color else { panic(\"no\") };\n",
+        "    let x = red;\n",
+        "    x\n",
+        "}\n",
+    ));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::BorrowedParamReturn)),
+        "the borrow param survives the unit-variant let-else and is copied into \
+        `x`; returning `x` must raise BorrowedParamReturn; got: {errors:?}"
+    );
+}
+
+#[test]
+fn borrowed_param_escape_while_let_unit_variant_collision_flagged() {
+    // The `while let` binding form already routes through the shared authority
+    // (`shadow_pattern_bindings` → `pattern_bound_names`); a unit-variant pattern
+    // records no binder, so `return red` inside the loop resolves to the borrow
+    // param and is flagged. Locks that consistency in alongside the let-else fix.
+    let (errors, _) = parse_and_check(concat!(
+        "enum Color { red; green; }\n",
+        "fn leak(red: &i64, color: Color) -> &i64 {\n",
+        "    while let red = color {\n",
+        "        return red;\n",
+        "    }\n",
+        "    red\n",
+        "}\n",
+    ));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::BorrowedParamReturn)),
+        "while-let unit-variant `while let red = color` binds nothing — \
+        `return red` is the borrow param and must raise BorrowedParamReturn; \
+        got: {errors:?}"
+    );
+}
+
+#[test]
+fn borrowed_param_escape_simple_let_binder_propagation_preserved() {
+    // Guard against the fix over-reaching: a genuine simple `let` binder (`let y
+    // = red`, where `y` is NOT a unit variant) must still copy the borrow
+    // param's danger forward, so returning `y` is flagged. Proves the
+    // unit-variant guard did not disable danger-propagation for real binders.
+    let (errors, _) = parse_and_check(concat!(
+        "fn leak(red: &i64) -> &i64 {\n",
+        "    let y = red;\n",
+        "    y\n",
+        "}\n",
+    ));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::BorrowedParamReturn)),
+        "a genuine binder `let y = red` must still carry the borrow param's \
+        danger forward; returning `y` must raise BorrowedParamReturn; \
+        got: {errors:?}"
+    );
+}
+
+#[test]
+fn var_named_like_unit_variant_still_binds() {
+    // Inertness proof for the escape scanner's `Stmt::Var` arm (which records
+    // the var name as a dangerous binding unconditionally): a `var` has no
+    // pattern and no refutability, so its name is ALWAYS a fresh binder — even
+    // when it spells a unit variant. If `var a` were ever classified as a
+    // constructor (non-binding), `a = a + 1; a` would fail to resolve. It does
+    // not, so treating the var name as a binder can never disagree with the
+    // checker.
+    let (errors, _) = parse_and_check(concat!(
+        "enum E { a; b; }\n",
+        "fn f() -> i64 {\n",
+        "    var a = 0;\n",
+        "    a = a + 1;\n",
+        "    a\n",
+        "}\n",
+    ));
+    assert!(
+        errors.is_empty(),
+        "`var a` must bind a fresh i64 even though `a` is a unit variant of E; \
+        got: {errors:?}"
+    );
+}
+
+#[test]
 fn typecheck_error_scrutinee_constructor_pattern_stays_fail_closed() {
     let (errors, _) = parse_and_check(concat!(
         "fn main() {\n",

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -5108,6 +5108,115 @@ fn typecheck_or_pattern_error_scrutinee_no_cascade() {
     );
 }
 
+// ── Borrowed-param escape: constructor classification (#2116 audit) ──────────
+// `callee_is_aggregate_constructor` decides whether the borrowed-param escape
+// analysis descends into a call's arguments.  It must classify by resolution,
+// not by the callee's casing, or it both falsely rejects valid programs (an
+// uppercase regular function) and falsely accepts memory-unsafe ones (a
+// lowercase variant constructor that embeds a borrowed parameter).
+
+#[test]
+fn borrowed_param_escape_uppercase_function_call_not_flagged() {
+    // Regression for the casing false-positive: a regular function that merely
+    // *happens* to be uppercase-named is not a constructor, so passing a borrow
+    // parameter to it is a safe borrow under call-boundary ownership — it must
+    // NOT raise BorrowedParamReturn.
+    let (errors, _) = parse_and_check(concat!(
+        "fn Helper(x: &i64) -> i64 { 5 }\n",
+        "fn f(r: &i64) -> i64 { Helper(r) }\n",
+    ));
+    assert!(
+        !errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::BorrowedParamReturn)),
+        "passing a borrow param to the uppercase regular fn `Helper` is safe and must \
+         not raise BorrowedParamReturn; got: {errors:?}"
+    );
+}
+
+#[test]
+fn borrowed_param_escape_lowercase_function_call_not_flagged() {
+    // Control for the above: the lowercase spelling was already accepted; it must
+    // stay accepted.
+    let (errors, _) = parse_and_check(concat!(
+        "fn helper(x: &i64) -> i64 { 5 }\n",
+        "fn f(r: &i64) -> i64 { helper(r) }\n",
+    ));
+    assert!(
+        !errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::BorrowedParamReturn)),
+        "passing a borrow param to a regular fn is safe; got: {errors:?}"
+    );
+}
+
+#[test]
+fn borrowed_param_escape_lowercase_variant_constructor_flagged() {
+    // Regression for the casing false-NEGATIVE (a memory-safety hole): a
+    // lowercase enum variant constructor that embeds a borrow parameter in the
+    // returned aggregate must raise BorrowedParamReturn.  The old uppercase-first
+    // heuristic dropped this, letting a returned reference outlive its owner.
+    let (errors, _) = parse_and_check(concat!(
+        "enum Holder { wrap(&i64); empty }\n",
+        "fn f(r: &i64) -> Holder { wrap(r) }\n",
+    ));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::BorrowedParamReturn)),
+        "embedding a borrow param in the lowercase variant `wrap` must raise \
+         BorrowedParamReturn; got: {errors:?}"
+    );
+}
+
+#[test]
+fn borrowed_param_escape_uppercase_variant_constructor_flagged() {
+    // The uppercase variant spelling was already caught and must stay caught —
+    // proves the fix does not regress the originally-handled direction.
+    let (errors, _) = parse_and_check(concat!(
+        "enum Holder { Wrap(&i64); Empty }\n",
+        "fn f(r: &i64) -> Holder { Wrap(r) }\n",
+    ));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::BorrowedParamReturn)),
+        "embedding a borrow param in the variant `Wrap` must raise \
+         BorrowedParamReturn; got: {errors:?}"
+    );
+}
+
+#[test]
+fn borrowed_param_escape_builtin_variant_constructor_flagged() {
+    // Builtin Option/Result variant constructors must remain classified as
+    // aggregate constructors so an embedded borrow param is still flagged.
+    let (errors, _) = parse_and_check("fn f(r: &i64) -> Option<&i64> { Some(r) }\n");
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::BorrowedParamReturn)),
+        "embedding a borrow param in `Some(_)` must raise BorrowedParamReturn; \
+         got: {errors:?}"
+    );
+}
+
+#[test]
+fn borrowed_param_escape_qualified_path_constructor_flagged() {
+    // A `Type::Variant` qualified path constructor must remain classified as an
+    // aggregate constructor (fail-closed for all `::` paths, including `Rc::new`).
+    let (errors, _) = parse_and_check(concat!(
+        "enum Holder { V(&i64); E }\n",
+        "fn f(r: &i64) -> Holder { Holder::V(r) }\n",
+    ));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::BorrowedParamReturn)),
+        "embedding a borrow param in the qualified variant `Holder::V` must raise \
+         BorrowedParamReturn; got: {errors:?}"
+    );
+}
+
 #[test]
 fn typecheck_error_scrutinee_constructor_pattern_stays_fail_closed() {
     let (errors, _) = parse_and_check(concat!(

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -26058,6 +26058,163 @@ fn foo(opt: Option<i64>) -> i64 {
             output.errors
         );
     }
+
+    // ── Struct-variant field position binders (#2116 closing sweep) ──────────
+
+    #[test]
+    fn struct_variant_field_uppercase_binder_compiles() {
+        // The concrete repro from issue #2116:
+        //   enum Packet { Data { value: i64 }; Empty }
+        //   match p { Packet::Data { value: MAX } => MAX, Empty => 0 }
+        //
+        // `MAX` does not resolve as a variant of `i64`, so it must be classified
+        // as a binder rather than a "nested constructor".  The old casing heuristic
+        // in `unsupported_payload_subpattern_label` caused a false
+        // `UnsupportedPayloadSubpattern` error for this shape.
+        let output = check_source(
+            r"
+enum Packet { Data { value: i64 }; Empty }
+fn f(p: Packet) -> i64 {
+    match p {
+        Packet::Data { value: MAX } => MAX,
+        Empty => 0,
+    }
+}",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "struct-variant field uppercase binder `MAX` must compile without errors; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn struct_variant_field_real_constructor_still_rejected() {
+        // Soundness guard: a bare identifier that DOES resolve as a variant of the
+        // field type is still a nested constructor and must be rejected.
+        // `Packet::Data { value: Red }` where `Red` is a unit variant of `Color`
+        // must remain an `UnsupportedPayloadSubpattern` error.
+        let output = check_source(
+            r"
+enum Color { Red; Blue }
+enum Packet { Data { value: Color }; Empty }
+fn f(p: Packet) -> i64 {
+    match p {
+        Packet::Data { value: Red } => 1,
+        Packet::Data { value: _ } => 2,
+        Empty => 0,
+    }
+}",
+        );
+        let has_unsupported = output.errors.iter().any(|e| {
+            matches!(
+                &e.kind,
+                crate::error::TypeErrorKind::UnsupportedPayloadSubpattern {
+                    kind_label,
+                    ..
+                } if kind_label == "nested constructor"
+            )
+        });
+        assert!(
+            has_unsupported,
+            "enum variant `Red` in struct field position must remain UnsupportedPayloadSubpattern; \
+             got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn struct_variant_field_qualified_binder_rejected() {
+        // A path-qualified identifier like `Packet::Empty` in struct field position
+        // is always a constructor path regardless of resolution.
+        let output = check_source(
+            r"
+enum Packet { Data { value: i64 }; Empty }
+fn f(p: Packet) -> i64 {
+    match p {
+        Packet::Data { value: Packet::Empty } => 0,
+        _ => 1,
+    }
+}",
+        );
+        let has_unsupported = output.errors.iter().any(|e| {
+            matches!(
+                &e.kind,
+                crate::error::TypeErrorKind::UnsupportedPayloadSubpattern { .. }
+            )
+        });
+        assert!(
+            has_unsupported,
+            "qualified identifier in struct-variant field position must be UnsupportedPayloadSubpattern; \
+             got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn record_field_uppercase_binder_compiles() {
+        // A plain record (not an enum struct-variant) with an uppercase binder in
+        // a field subpattern position must also be accepted after the casing fix.
+        let output = check_source(
+            r"
+type Point { x: i64; y: i64 }
+fn f(p: Point) -> i64 {
+    match p {
+        Point { x: MAX, y: _ } => MAX,
+    }
+}",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "plain record field uppercase binder `MAX` must compile without errors; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn tuple_pattern_uppercase_binder_compiles() {
+        // An uppercase binder in a tuple destructure element position must be
+        // accepted after the casing fix.
+        let output = check_source(
+            r"
+fn f(pair: (i64, i64)) -> i64 {
+    match pair {
+        (A, B) => A,
+    }
+}",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "tuple pattern uppercase binders `A`, `B` must compile without errors; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn struct_variant_non_exhaustive_still_errors() {
+        // Soundness guard: dropping a real variant arm must still produce a
+        // NonExhaustiveMatch error even after the casing-to-resolution migration.
+        // An uppercase binder must NOT make an otherwise non-exhaustive match pass.
+        let output = check_source(
+            r"
+enum Packet { Data { value: i64 }; Empty }
+fn f(p: Packet) -> i64 {
+    match p {
+        Packet::Data { value: MAX } => MAX,
+        // Empty arm intentionally omitted
+    }
+}",
+        );
+        let has_non_exhaustive = output
+            .errors
+            .iter()
+            .any(|e| matches!(e.kind, crate::error::TypeErrorKind::NonExhaustiveMatch));
+        assert!(
+            has_non_exhaustive,
+            "match missing `Empty` arm must still emit NonExhaustiveMatch; got: {:#?}",
+            output.errors
+        );
+    }
 }
 
 // ── Unsupported payload subpatterns (fail-closed gate) ──────────────────────

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -4914,6 +4914,201 @@ fn typecheck_or_pattern_incompatible_binding_types_error() {
 }
 
 #[test]
+fn typecheck_or_pattern_uppercase_binders_inconsistent_error() {
+    // #2116 closing blocker: the or-pattern binding-consistency check must be
+    // driven by the AUTHORITATIVE binding result (the env delta), not a casing
+    // re-derivation.  `FOO` and `BAR` do not resolve as variants of `i64`, so
+    // both are *binders*.  The two branches bind different names → inconsistent
+    // → must raise OrPatternBindingMismatch.  The former casing heuristic dropped
+    // uppercase binders, yielding two empty sets that compared equal and silently
+    // accepted the mismatch (the left branch's binding won).
+    let (errors, _) = parse_and_check(concat!(
+        "fn f(x: i64) -> i64 {\n",
+        "    match x {\n",
+        "        FOO | BAR => FOO,\n",
+        "        _ => 0,\n",
+        "    }\n",
+        "}\n",
+    ));
+    let err = errors
+        .iter()
+        .find(|e| matches!(e.kind, TypeErrorKind::OrPatternBindingMismatch))
+        .expect("FOO | BAR distinct uppercase binders must raise OrPatternBindingMismatch");
+    assert!(
+        err.notes
+            .iter()
+            .any(|(_, note)| note.contains("left branch binds `FOO`")),
+        "expected left-branch binding note for `FOO`, got: {err:?}"
+    );
+    assert!(
+        err.notes
+            .iter()
+            .any(|(_, note)| note.contains("right branch binds `BAR`")),
+        "expected right-branch binding note for `BAR`, got: {err:?}"
+    );
+}
+
+#[test]
+fn typecheck_or_pattern_uppercase_binders_consistent_ok() {
+    // The dual of the blocker: same uppercase binder on both sides is a
+    // *consistent* binding and must be accepted (any casing).  This is the case
+    // the old casing heuristic accepted only vacuously (by dropping both names);
+    // the resolution/env-delta path accepts it because both branches genuinely
+    // bind `FOO` at the same type.
+    let (errors, warnings) = parse_and_check(concat!(
+        "fn main() -> i64 {\n",
+        "    let x = 5;\n",
+        "    match x {\n",
+        "        FOO | FOO => FOO,\n",
+        "        _ => 0,\n",
+        "    }\n",
+        "}\n",
+    ));
+    assert!(
+        !errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::OrPatternBindingMismatch)),
+        "consistent uppercase binder `FOO | FOO` must not raise OrPatternBindingMismatch; got: {errors:?}"
+    );
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+}
+
+#[test]
+fn typecheck_or_pattern_unit_variants_bind_nothing_ok() {
+    // Soundness guard against the false-hit the old `// JUSTIFIED` comment feared:
+    // two unit-variant constructors bind NOTHING on both sides, so the branches
+    // are consistent (empty == empty) and must be accepted.  Because constructor
+    // identifiers are no longer over-defined as env bindings, the env delta for
+    // each branch is empty and no spurious mismatch is raised.
+    let (errors, _) = parse_and_check(concat!(
+        "enum Color { Red; Green; Blue }\n",
+        "fn f(c: Color) -> i64 {\n",
+        "    match c {\n",
+        "        Red | Green => 1,\n",
+        "        Blue => 0,\n",
+        "    }\n",
+        "}\n",
+    ));
+    assert!(
+        !errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::OrPatternBindingMismatch)),
+        "constructor or-pattern `Red | Green` (binds nothing) must not raise \
+         OrPatternBindingMismatch; got: {errors:?}"
+    );
+}
+
+#[test]
+fn typecheck_or_pattern_constructor_vs_binder_inconsistent_error() {
+    // Mixed branch: a unit variant (`Red`, binds nothing) or a binder (`x`).
+    // The binder is present in only one branch → inconsistent → must error.
+    // This proves the classification is resolution-driven on BOTH sides: `Red`
+    // resolves as a variant (no binder) while `x` does not (a binder).
+    let (errors, _) = parse_and_check(concat!(
+        "enum Color { Red; Green; Blue }\n",
+        "fn f(c: Color) -> i64 {\n",
+        "    match c {\n",
+        "        Red | x => 1,\n",
+        "        Blue => 0,\n",
+        "    }\n",
+        "}\n",
+    ));
+    let err = errors
+        .iter()
+        .find(|e| matches!(e.kind, TypeErrorKind::OrPatternBindingMismatch))
+        .expect("`Red | x` (constructor vs binder) must raise OrPatternBindingMismatch");
+    assert!(
+        err.notes
+            .iter()
+            .any(|(_, note)| note.contains("left branch binds no names")),
+        "expected left-branch 'binds no names' note for unit variant `Red`, got: {err:?}"
+    );
+    assert!(
+        err.notes
+            .iter()
+            .any(|(_, note)| note.contains("right branch binds `x`")),
+        "expected right-branch binding note for `x`, got: {err:?}"
+    );
+}
+
+#[test]
+fn typecheck_or_pattern_regex_capture_inconsistent_error() {
+    // The env-delta consistency check sees regex capture binders, which the old
+    // `collect_pattern_bound_names` dropped for ALL `Pattern::Regex` (returning an
+    // empty set).  A capturing branch (`x`) versus a non-capturing branch is
+    // inconsistent and must error — previously this was silently accepted.
+    let (errors, _) = parse_and_check(concat!(
+        "fn f(s: string) -> i64 {\n",
+        "    match s {\n",
+        "        re\"(?P<x>a+)\" | re\"b+\" => 1,\n",
+        "        _ => 0,\n",
+        "    }\n",
+        "}\n",
+    ));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::OrPatternBindingMismatch)),
+        "regex capture `x` present in only one or-branch must raise \
+         OrPatternBindingMismatch; got: {errors:?}"
+    );
+}
+
+#[test]
+fn typecheck_or_pattern_unit_variant_vs_payload_binder_inconsistent_error() {
+    // `Some(v) | None` over Option: the left binds the payload `v`, the right
+    // (a unit variant) binds nothing → inconsistent.  Confirms payload binders
+    // and unit-variant non-binders are reconciled by the same env-delta path.
+    let (errors, _) = parse_and_check(concat!(
+        "fn f(opt: Option<i64>) -> i64 {\n",
+        "    match opt {\n",
+        "        Some(v) | None => v,\n",
+        "    }\n",
+        "}\n",
+    ));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::OrPatternBindingMismatch)),
+        "`Some(v) | None` must raise OrPatternBindingMismatch (payload binder absent \
+         from the unit-variant branch); got: {errors:?}"
+    );
+}
+
+#[test]
+fn typecheck_or_pattern_error_scrutinee_no_cascade() {
+    // Error-recovery guard: when the scrutinee type is unresolvable (here an
+    // undefined function makes it `Ty::Error`), a bare identifier cannot be
+    // classified as constructor-or-binder, so the binding-consistency check is
+    // suppressed rather than cascading off the already-broken scrutinee.  Only
+    // the root-cause error (the undefined function) is reported — NO
+    // OrPatternBindingMismatch is piled on, even though `Red` and `Green` would
+    // otherwise look like two distinct binders against an unknown type.
+    let (errors, _) = parse_and_check(concat!(
+        "enum Colour { Red; Green }\n",
+        "fn main() {\n",
+        "    let _ = match missing() {\n",
+        "        Red | Green => 0,\n",
+        "    };\n",
+        "}\n",
+    ));
+    assert!(
+        !errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::OrPatternBindingMismatch)),
+        "an or-pattern over an error-typed scrutinee must not cascade an \
+         OrPatternBindingMismatch; got: {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::UndefinedFunction)),
+        "the root-cause undefined-function error must still be reported; got: {errors:?}"
+    );
+}
+
+#[test]
 fn typecheck_error_scrutinee_constructor_pattern_stays_fail_closed() {
     let (errors, _) = parse_and_check(concat!(
         "fn main() {\n",

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -20242,6 +20242,52 @@ mod wasm_rejects {
         );
     }
 
+    // ── Issue #2135: value-position (first-class fn reference) wasm rejects ──
+
+    #[test]
+    fn wasm_rejects_crypto_random_bytes_value_position() {
+        // Taking crypto.random_bytes as a first-class function value on wasm32
+        // must be rejected with PlatformLimitation, not silently allowed.
+        let source = concat!(
+            "import std::crypto::crypto;\n",
+            "fn main() { let _f = crypto.random_bytes; }\n",
+        );
+        let output = check_wasm_with_registry(source);
+        assert!(
+            has_platform_limitation_error(&output),
+            "crypto.random_bytes value-position reference must be a compile-time error on WASM; got errors: {:?}",
+            output.errors
+        );
+        assert!(
+            platform_error_contains(&output, "random_bytes"),
+            "error message should mention random_bytes; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn native_crypto_random_bytes_value_position_no_error() {
+        // The same value-position reference must be accepted on native (non-wasm)
+        // targets so the guard does not break native builds.
+        let source = concat!(
+            "import std::crypto::crypto;\n",
+            "fn main() { let _f = crypto.random_bytes; }\n",
+        );
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        let output = checker.check_program(&result.program);
+        assert!(
+            !has_platform_limitation_error(&output),
+            "crypto.random_bytes value-position must not error on native target; got: {:?}",
+            output.errors
+        );
+    }
+
     // ── Native sibling tests: no platform error on non-wasm target ────────
 
     #[test]
@@ -25850,6 +25896,97 @@ fn foo(t: Tri) -> i64 {
         assert_eq!(
             bar_arm.payload_bindings[0].field_idx, 1,
             "field_idx must reflect declaration order, not alphabetical order"
+        );
+    }
+
+    // ── Issue #2116: resolution-based constructor vs binder detection ─────────
+
+    #[test]
+    fn uppercase_binder_not_constructor_records_binding_kind() {
+        // An uppercase plain identifier that does NOT resolve to a unit variant
+        // of the scrutinee type must be classified as `PatternKind::Binding`,
+        // not as `PatternKind::VariantCtor`. The old case heuristic mis-classified
+        // `INF` as a constructor and then failed to resolve it.
+        let resolutions = pattern_resolutions(
+            r"
+fn foo(x: i64) -> i64 {
+    match x {
+        INF => INF,
+    }
+}",
+        );
+        assert_eq!(resolutions.len(), 1);
+        let arm = resolutions.values().next().unwrap();
+        assert_eq!(
+            arm.pattern_kind,
+            PatternKind::Binding,
+            "uppercase binder `INF` against non-enum type must record Binding, not VariantCtor"
+        );
+        assert!(
+            arm.variant_match.is_none(),
+            "uppercase binder must not have a variant_match"
+        );
+    }
+
+    #[test]
+    fn known_unit_variant_still_records_ctor_kind() {
+        // Ensure the resolution-based fix does NOT accidentally reclassify a
+        // genuine unit-variant constructor (`None`) as a binder when it DOES
+        // resolve against the scrutinee type.
+        let resolutions = pattern_resolutions(
+            r"
+fn foo(opt: Option<i64>) -> i64 {
+    match opt {
+        None => 0,
+        Some(v) => v,
+    }
+}",
+        );
+        let none_arm = resolutions
+            .values()
+            .find(|r| {
+                r.variant_match
+                    .as_ref()
+                    .is_some_and(|vm| vm.variant_name == "None")
+            })
+            .expect("None arm must be recorded with a variant_match");
+        assert_eq!(
+            none_arm.pattern_kind,
+            PatternKind::VariantCtor,
+            "`None` against Option<i64> must record VariantCtor"
+        );
+    }
+
+    #[test]
+    fn uppercase_binder_in_payload_position_records_as_binding() {
+        // An uppercase name in a constructor-payload slot that does NOT resolve
+        // as a variant of the payload type must become a plain PayloadBinding
+        // rather than a failed nested-constructor attempt.
+        let resolutions = pattern_resolutions(
+            r"
+fn foo(opt: Option<i64>) -> i64 {
+    match opt {
+        Some(MAX) => MAX,
+        None => 0,
+    }
+}",
+        );
+        let some_arm = resolutions
+            .values()
+            .find(|r| {
+                r.variant_match
+                    .as_ref()
+                    .is_some_and(|vm| vm.variant_name == "Some")
+            })
+            .expect("Some arm must be recorded");
+        assert_eq!(some_arm.payload_bindings.len(), 1);
+        assert_eq!(
+            some_arm.payload_bindings[0].binding_name, "MAX",
+            "uppercase payload binder MAX must appear in payload_bindings"
+        );
+        assert!(
+            some_arm.payload_variant_patterns.is_empty(),
+            "uppercase binder MAX must not be recorded as a nested constructor"
         );
     }
 }

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -5218,6 +5218,106 @@ fn borrowed_param_escape_qualified_path_constructor_flagged() {
 }
 
 #[test]
+fn borrowed_param_escape_match_arm_variant_collision_flagged() {
+    // Residual fix (#2116): a match-arm pattern that is a *unit-variant
+    // constructor* whose name collides with a borrow parameter must NOT shadow
+    // that parameter in the escape scanner. The arm body `red` therefore
+    // resolves to the borrowed param (the constructor `red` bound nothing), and
+    // returning it is a genuine escape that must raise BorrowedParamReturn.
+    //
+    // Before the fix `shadow_pattern_bindings` blindly treated every
+    // `Pattern::Identifier` as a binder, masking the `red => red` arm; the
+    // escape only surfaced (confusingly, via a sibling HIR/MIR pass) when a
+    // second non-colliding arm also returned the param. This fixture would
+    // regress to a missed escape on the colliding arm if the binder-vs-
+    // constructor decision were re-derived locally again.
+    let (errors, _) = parse_and_check(concat!(
+        "enum Color { red; green; }\n",
+        "fn leak(red: &i64, color: Color) -> &i64 {\n",
+        "    match color { red => red, green => red }\n",
+        "}\n",
+    ));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::BorrowedParamReturn)),
+        "a unit-variant arm `red` colliding with borrow param `red` must not \
+         shadow it — returning the param must raise BorrowedParamReturn; \
+         got: {errors:?}"
+    );
+}
+
+#[test]
+fn borrowed_param_escape_or_pattern_variant_collision_flagged() {
+    // The reviewer's exact repro shape, with a borrow param so the escape
+    // scanner actually runs: an or-pattern of unit-variant constructors that
+    // collide with the borrow param name. Both `red` and `green` are
+    // constructors (bind nothing), so the arm body `red` is the borrowed param
+    // and returning it must raise BorrowedParamReturn — not a confusing
+    // InitialisedBeforeUse / MIR-decision-map diagnostic from a sibling pass.
+    let (errors, _) = parse_and_check(concat!(
+        "enum Color { red; green; }\n",
+        "fn leak(red: &i64, color: Color) -> &i64 {\n",
+        "    match color { red | green => red }\n",
+        "}\n",
+    ));
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::BorrowedParamReturn)),
+        "an or-pattern of constructors `red | green` must not shadow the \
+         borrow param `red`; returning it must raise BorrowedParamReturn; \
+         got: {errors:?}"
+    );
+}
+
+#[test]
+fn borrowed_param_escape_match_payload_binder_not_overflagged() {
+    // Guard against over-flagging: a genuine payload *binder* (`Some(inner)`)
+    // must shadow the dangerous param so returning the bound payload is NOT an
+    // escape, while a sibling arm that returns the borrow param directly still
+    // is. Exactly one BorrowedParamReturn — the `None => red` arm — must fire;
+    // the `Some(inner) => inner` arm must stay clean.
+    let (errors, _) = parse_and_check(concat!(
+        "fn leak(red: &i64, opt: Option<&i64>) -> &i64 {\n",
+        "    match opt { Some(inner) => inner, None => red }\n",
+        "}\n",
+    ));
+    let escapes = errors
+        .iter()
+        .filter(|e| matches!(e.kind, TypeErrorKind::BorrowedParamReturn))
+        .count();
+    assert_eq!(
+        escapes, 1,
+        "only the `None => red` arm escapes; the `Some(inner) => inner` binder \
+         arm must not be over-flagged; got {escapes} BorrowedParamReturn in: \
+         {errors:?}"
+    );
+}
+
+#[test]
+fn borrowed_param_escape_consistent_or_binder_not_overflagged() {
+    // End-to-end of the or-pattern binder path: `Ok(x) | Err(x) => x` binds a
+    // consistent `x` in both alternatives (recorded as the env delta of
+    // `bind_pattern`), which `shadow_pattern_bindings` then shadows. Returning
+    // the bound payload `x` (not the borrow param `p`) is safe and must raise
+    // NO BorrowedParamReturn — a regression here would mean the or-pattern
+    // binder set was not threaded through the single authority.
+    let (errors, _) = parse_and_check(concat!(
+        "fn leak(p: &i64, r: Result<&i64, &i64>) -> &i64 {\n",
+        "    match r { Ok(x) | Err(x) => x }\n",
+        "}\n",
+    ));
+    assert!(
+        !errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::BorrowedParamReturn)),
+        "returning a consistent or-pattern binder `x` (not the borrow param) \
+         must not raise BorrowedParamReturn; got: {errors:?}"
+    );
+}
+
+#[test]
 fn typecheck_error_scrutinee_constructor_pattern_stays_fail_closed() {
     let (errors, _) = parse_and_check(concat!(
         "fn main() {\n",

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -2594,6 +2594,18 @@ pub struct Checker {
     pub(super) current_function: Option<String>,
     /// Whether we are currently inside a for-loop binding (suppress shadowing for loop vars).
     pub(super) in_for_binding: bool,
+    /// Names actually bound by each top-level pattern, keyed by the pattern's
+    /// span. Recorded by `bind_pattern` — the single binder-vs-constructor
+    /// authority — as the env delta it introduces (a constructor identifier
+    /// binds nothing and so contributes no name). Consumed by the borrowed-Rc
+    /// escape scanner's `shadow_pattern_bindings`, which shadows exactly the
+    /// recorded names rather than re-deriving the binder/constructor decision.
+    /// Scratch state: cleared at the start of each function body check.
+    pub(super) pattern_bound_names: HashMap<SpanKey, Vec<String>>,
+    /// Re-entrancy guard ensuring only the *top-level* `bind_pattern` call
+    /// records its env delta into `pattern_bound_names`; nested sub-pattern
+    /// binds are already part of that single delta.
+    pub(super) bind_pattern_recording: bool,
     /// Whether we are currently inside an actor receive function body.
     /// Used to warn about blocking calls that can starve the scheduler.
     pub(super) in_receive_fn: bool,
@@ -3013,6 +3025,8 @@ impl Checker {
             call_graph: HashMap::new(),
             current_function: None,
             in_for_binding: false,
+            pattern_bound_names: HashMap::new(),
+            bind_pattern_recording: false,
             in_receive_fn: false,
             in_actor_handler_context: false,
             in_lambda_actor_body: false,

--- a/hew-types/src/env.rs
+++ b/hew-types/src/env.rs
@@ -274,6 +274,21 @@ impl TypeEnv {
             .flat_map(|scope| scope.keys().map(String::as_str))
     }
 
+    /// Yield `(name, binding id)` for every binding in the innermost (current)
+    /// scope only.
+    ///
+    /// The binding id is part of the pair so a shadowing re-`define` (which
+    /// replaces the entry with a fresh id) is observable: comparing two
+    /// snapshots by `(name, id)` distinguishes "same binding untouched" from
+    /// "rebound in place". Used to compute the exact set of names a pattern
+    /// branch introduced (see `bind_pattern`'s or-pattern arm).
+    pub fn current_scope_bindings(&self) -> impl Iterator<Item = (&str, TypeBindingId)> {
+        self.scopes
+            .last()
+            .into_iter()
+            .flat_map(|scope| scope.iter().map(|(name, b)| (name.as_str(), b.id)))
+    }
+
     /// Undo the `is_used` mark on a variable (used for plain assignment LHS).
     /// Decrements the read count so that write-only variables are still detected.
     pub fn unmark_used(&mut self, name: &str) {


### PR DESCRIPTION
## Summary

Two type-checker fixes:
- **Match-arm identifier classification (#2116):** whether a bare identifier in a pattern is a constructor or a binder is now decided by name resolution, not by an uppercase-first-letter heuristic. This makes uppercase binders (`Some(MAX)`, `match opt { INF => 0 }`, struct-variant field binders, or-pattern binders) work correctly, and routes every pattern-classification consumer (exhaustiveness catch-all, payload/field labels, or-pattern binding consistency, and the borrowed-parameter escape scanner) through a single authoritative binding result rather than re-deriving the decision per site.
- **wasm32 value-position reject (#2135):** taking a native-only stdlib function as a first-class value on the wasm32 target is now rejected with the same diagnostic as calling it (previously only the call form was rejected), closing a fail-open. The native-only module set is shared between the call-form and value-form guards so they cannot drift.

## Verification

- `cargo nextest run -p hew-types` green (incl. new fixtures for uppercase binders, or-pattern binding consistency, struct-variant field binders, the borrowed-param escape cases, and the wasm value-position rejects).
- `make checked-mir-verify`, `make fuzz-oracle`, `cargo clippy --workspace --tests -- -D warnings`, `cargo fmt --check` all clean. Exhaustiveness soundness preserved (a real missing variant still errors; a genuine borrowed-parameter escape is still flagged).

## Out of scope

The browser-sandbox value-position reject parity is tracked separately (#2199).
