### PR TITLE
fix(sandbox-wasm): reject value-position native-only stdlib fn refs with PlatformLimitation

### DIFF
--- a/hew-sandbox-wasm/src/lib.rs
+++ b/hew-sandbox-wasm/src/lib.rs
@@ -903,11 +903,10 @@ fn main() {
 
     #[test]
     fn crypto_random_bytes_is_rejected_with_platform_limitation() {
-        // crypto.random_bytes depends on a native-only entropy source absent
-        // from the wasm32 link set. The sandbox compiler now calls
-        // enable_wasm_target() so the checker emits a PlatformLimitation
-        // diagnostic — a security-focused, actionable rejection rather than a
-        // generic "unknown import" from the profile level.
+        // crypto.random_bytes(n) — the call form — depends on a native-only entropy
+        // source absent from the wasm32 link set.  The sandbox profile gate
+        // (Expr::MethodCall) emits a PlatformLimitation diagnostic for the call
+        // form; the value-position form (FieldAccess) is covered by a separate test.
         set_test_hewpath();
         let source = "import std::crypto::crypto;\nfn main() { let _ = crypto.random_bytes(32); }";
         let output = compile_to_sandbox_bytecode(source, Some("sandbox-vm-export"))
@@ -926,6 +925,234 @@ fn main() {
             "expected PlatformLimitation error for crypto.random_bytes, got {:#?}",
             output.diagnostics
         );
+    }
+
+    #[test]
+    fn sandbox_rejects_value_position_crypto_random_bytes() {
+        // `let f = crypto.random_bytes` is a FieldAccess (not a MethodCall) and
+        // must be rejected in the browser sandbox with a PlatformLimitation
+        // diagnostic, matching the call-form rejection and the native wasm32
+        // target guard.  Without the profile gate fix the FieldAccess arm would
+        // silently pass through, producing bytecode that the VM cannot execute
+        // securely (the entropy source is absent from the wasm32 link set).
+        set_test_hewpath();
+        let source = "import std::crypto::crypto;\nfn main() { let f = crypto.random_bytes; }";
+        let output = compile_to_sandbox_bytecode(source, Some("sandbox-vm-export"))
+            .expect("compile should not throw");
+        assert!(
+            output.bytecode.is_none(),
+            "value-position crypto.random_bytes must not produce bytecode; got {:#?}",
+            output.bytecode
+        );
+        assert!(
+            output.diagnostics.iter().any(|d| {
+                d.severity == "error"
+                    && d.kind == "PlatformLimitation"
+                    && d.message.contains("random_bytes")
+            }),
+            "expected PlatformLimitation error for value-position crypto.random_bytes, got {:#?}",
+            output.diagnostics
+        );
+    }
+
+    #[test]
+    fn sandbox_rejects_value_position_net_module() {
+        // `let f = net.connect` is a value-position FieldAccess on the native-only
+        // `net` stdlib module.  The sandbox must reject with PlatformLimitation,
+        // matching the wasm32 target guard in the type checker and maintaining
+        // native/wasm parity for the full native-only module set.
+        set_test_hewpath();
+        let source = "import std::net::net;\nfn main() { let f = net.connect; }";
+        let output = compile_to_sandbox_bytecode(source, Some("sandbox-vm-export"))
+            .expect("compile should not throw");
+        assert!(
+            output.bytecode.is_none(),
+            "value-position net.connect must not produce bytecode; got {:#?}",
+            output.bytecode
+        );
+        assert!(
+            output.diagnostics.iter().any(|d| {
+                d.severity == "error" && d.kind == "PlatformLimitation" && d.message.contains("net")
+            }),
+            "expected PlatformLimitation error for value-position net.connect, got {:#?}",
+            output.diagnostics
+        );
+    }
+
+    #[test]
+    fn sandbox_admits_value_position_user_record_field_access() {
+        // `let v = rec.x` where `rec` is a user-defined record must NOT be
+        // rejected: the native-only guard is gated on the object being one of the
+        // specific stdlib module short-names and NOT a user-declared type, so
+        // legitimate field access on user records must continue to compile.
+        let source = r"
+type Point { x: i64; y: i64; }
+
+fn main() {
+    let p = Point { x: 3, y: 7 };
+    let v = p.x;
+    println(v);
+}
+";
+        let output = compile_to_sandbox_bytecode(source, Some("sandbox-vm-export"))
+            .expect("compile should not throw");
+        assert!(
+            output.diagnostics.iter().all(|d| d.severity != "error"),
+            "user record field access must not produce error diagnostics; got {:#?}",
+            output.diagnostics
+        );
+        assert!(
+            output.bytecode.is_some(),
+            "user record field access must emit bytecode; diagnostics {:#?}",
+            output.diagnostics
+        );
+    }
+
+    #[test]
+    fn sandbox_admits_local_binding_named_net() {
+        // A local let-binding whose name collides with the native-only module
+        // short-name `net` must NOT be rejected: the guard fires only when the
+        // object resolves to a stdlib module identifier (ty_for_expr returns None),
+        // not when it resolves to a typed local variable.
+        //
+        // Over-reject regression: the previous `is_user_local` guard only tracked
+        // top-level declarations and would have falsely rejected `net.connect` here.
+        let source = r"
+type Conn { connect: i64; }
+
+fn main() {
+    let net = Conn { connect: 42 };
+    println(net.connect);
+}
+";
+        let output = compile_to_sandbox_bytecode(source, Some("sandbox-vm-export"))
+            .expect("compile should not throw");
+        assert!(
+            output.diagnostics.iter().all(|d| d.severity != "error"),
+            "local binding named `net` must not trigger PlatformLimitation; got {:#?}",
+            output.diagnostics
+        );
+        assert!(
+            output.bytecode.is_some(),
+            "local binding named `net` must emit bytecode; diagnostics {:#?}",
+            output.diagnostics
+        );
+    }
+
+    #[test]
+    fn sandbox_admits_local_binding_named_stream() {
+        // Same regression check for `stream` (another common collision name).
+        let source = r"
+type Packet { value: i64; }
+
+fn process(stream: Packet) -> i64 {
+    stream.value
+}
+
+fn main() {
+    let pkt = Packet { value: 7 };
+    println(process(pkt));
+}
+";
+        let output = compile_to_sandbox_bytecode(source, Some("sandbox-vm-export"))
+            .expect("compile should not throw");
+        assert!(
+            output.diagnostics.iter().all(|d| d.severity != "error"),
+            "function param named `stream` must not trigger PlatformLimitation; got {:#?}",
+            output.diagnostics
+        );
+        assert!(
+            output.bytecode.is_some(),
+            "function param named `stream` must emit bytecode; diagnostics {:#?}",
+            output.diagnostics
+        );
+    }
+
+    #[test]
+    fn sandbox_admits_local_binding_named_os() {
+        // Same regression check for `os`.
+        let source = r"
+type Cfg { name: i64; }
+
+fn main() {
+    let os = Cfg { name: 1 };
+    println(os.name);
+}
+";
+        let output = compile_to_sandbox_bytecode(source, Some("sandbox-vm-export"))
+            .expect("compile should not throw");
+        assert!(
+            output.diagnostics.iter().all(|d| d.severity != "error"),
+            "local binding named `os` must not trigger PlatformLimitation; got {:#?}",
+            output.diagnostics
+        );
+        assert!(
+            output.bytecode.is_some(),
+            "local binding named `os` must emit bytecode; diagnostics {:#?}",
+            output.diagnostics
+        );
+    }
+
+    #[test]
+    fn sandbox_native_only_module_set_drift_guard() {
+        // Drift guard: every module in the authoritative NATIVE_ONLY_WASM_MODULES
+        // const must be rejected by the sandbox in value-position.  This test
+        // fails if a new module is added to the const but not handled by the
+        // profile gate, or vice-versa.
+        //
+        // Structural drift is architecturally impossible: the profile gate uses
+        // `hew_types::NATIVE_ONLY_WASM_MODULES.contains()` directly, so any change
+        // to the const is automatically reflected.  This test verifies:
+        //   1. The const has the expected number of entries (catches silent additions).
+        //   2. Each expected short-name appears in the const.
+        //   3. End-to-end rejection for the three modules with well-known import
+        //      paths (net, tls, dns) as a representative sample.
+        let expected: &[&str] = &[
+            "stream",
+            "http",
+            "net",
+            "process",
+            "tls",
+            "quic",
+            "dns",
+            "os",
+            "encrypt",
+            "sign",
+            "http_client",
+            "smtp",
+        ];
+        assert_eq!(
+            expected.len(),
+            hew_types::NATIVE_ONLY_WASM_MODULES.len(),
+            "NATIVE_ONLY_WASM_MODULES length changed; update this expected list"
+        );
+        for name in expected {
+            assert!(
+                hew_types::NATIVE_ONLY_WASM_MODULES.contains(name),
+                "expected `{name}` to be in NATIVE_ONLY_WASM_MODULES"
+            );
+        }
+        // End-to-end: sample three modules with well-known import paths.
+        set_test_hewpath();
+        let sample: &[(&str, &str, &str)] = &[
+            ("net", "std::net::net", "connect"),
+            ("tls", "std::net::tls", "connect"),
+            ("dns", "std::net::dns", "resolve"),
+        ];
+        for (module, import_path, func) in sample {
+            let source = format!("import {import_path};\nfn main() {{ let f = {module}.{func}; }}");
+            let output = compile_to_sandbox_bytecode(&source, Some("sandbox-vm-export"))
+                .expect("compile should not throw");
+            let has_platform_error = output
+                .diagnostics
+                .iter()
+                .any(|d| d.severity == "error" && d.kind == "PlatformLimitation");
+            assert!(
+                has_platform_error,
+                "value-position `{module}.{func}` must produce PlatformLimitation; got {:#?}",
+                output.diagnostics
+            );
+        }
     }
 
     #[test]

--- a/hew-sandbox-wasm/src/profile.rs
+++ b/hew-sandbox-wasm/src/profile.rs
@@ -704,7 +704,52 @@ impl<'a> ProfileChecker<'a> {
                     }
                 }
             }
-            Expr::FieldAccess { object, .. } => self.check_expr(object),
+            Expr::FieldAccess { object, field } => {
+                // Value-position references to native-only stdlib functions must
+                // produce a named PlatformLimitation rejection — the same diagnostic
+                // the call form emits (Expr::MethodCall above).
+                //
+                // Guard: a FieldAccess fires on a *module name* only when the
+                // type checker did NOT record a type for the object expression.
+                // The type checker's check_field_access early-returns for module
+                // identifiers without calling synthesize(object), so their spans
+                // are absent from expr_types.  For local let-bindings and function
+                // parameters (even ones whose name collides with a native-only
+                // module short-name such as `net` or `stream`), synthesize(object)
+                // IS called and the type IS recorded — so ty_for_expr returns Some
+                // and this guard does not fire.  This is the correct scoping that
+                // prevents the over-reject bug.
+                if let Expr::Identifier(name) = &object.0 {
+                    if self.ty_for_expr(object).is_none() {
+                        // crypto.random_bytes: native-only secure-entropy source.
+                        if name == "crypto" && field == "random_bytes" {
+                            self.reject(
+                                span.clone(),
+                                "PlatformLimitation",
+                                "`crypto.random_bytes` is not available in the browser sandbox: \
+                                 secure entropy requires a native entropy source absent from the \
+                                 wasm32 link set",
+                            );
+                            return;
+                        }
+                        // Native-only stdlib modules: any value-position field access
+                        // on these module short-names must fail-closed.  Module set is
+                        // the single authoritative constant from hew_types — no drift.
+                        if hew_types::NATIVE_ONLY_WASM_MODULES.contains(&name.as_str()) {
+                            self.reject(
+                                span.clone(),
+                                "PlatformLimitation",
+                                format!(
+                                    "`{name}` is a native-only stdlib module that is not \
+                                     available in the browser sandbox"
+                                ),
+                            );
+                            return;
+                        }
+                    }
+                }
+                self.check_expr(object);
+            }
             Expr::Index { object, index } => {
                 self.check_expr(object);
                 self.check_expr(index);

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -272,9 +272,10 @@ impl CollectionTyCx {
 }
 
 impl Checker {
-    /// Stdlib modules that have no wasm32 runtime support.  Any call
-    /// expression or value-position reference to a function in one of these
-    /// modules is rejected with a `PlatformLimitation` diagnostic when
+    /// Stdlib modules that have no wasm32 runtime support, together with the
+    /// [`WasmUnsupportedFeature`] variant used in the rejection diagnostic.
+    /// Any call expression or value-position reference to a function in one of
+    /// these modules is rejected with a `PlatformLimitation` error when
     /// targeting wasm32.
     ///
     /// `crypto.random_bytes` is handled separately (it is a single function
@@ -282,9 +283,15 @@ impl Checker {
     /// this table.
     ///
     /// Both the call-form guard (`check_method_call`) and the value-position
-    /// guard (`check_field_access`) iterate this slice via
-    /// `Self::NATIVE_ONLY_WASM_MODULE_REJECTIONS` so the two paths cannot
-    /// drift out of sync.
+    /// guard (`check_field_access`) iterate this slice, so neither path can
+    /// silently miss a module the other rejects.
+    ///
+    /// **The module short-names in this table must exactly match
+    /// [`crate::NATIVE_ONLY_WASM_MODULES`]** (the public API const consumed by
+    /// `hew-sandbox-wasm`'s profile gate).  The test
+    /// `wasm_rejects::native_only_wasm_modules_const_matches_rejection_table`
+    /// enforces parity between the two at test time; update both together when
+    /// the native-only module set changes.
     pub(super) const NATIVE_ONLY_WASM_MODULE_REJECTIONS: &'static [(
         &'static str,
         WasmUnsupportedFeature,

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -20867,6 +20867,66 @@ mod wasm_rejects {
         );
     }
 
+    // ── Over-reject regression: local bindings / params must not trigger guard ─
+
+    #[test]
+    fn wasm_admits_local_binding_named_net() {
+        // A local let-binding named `net` must NOT trigger the value-position
+        // guard because receiver_is_binding=true for local variables — the type
+        // checker records a type for the object and check_field_access takes the
+        // normal path.
+        let source = r"
+type Conn { connect: i64; }
+fn main() {
+    let net = Conn { connect: 42 };
+    println(net.connect);
+}
+";
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        checker.enable_wasm_target();
+        let output = checker.check_program(&result.program);
+        assert!(
+            !has_platform_limitation_error(&output),
+            "local binding named `net` must not produce PlatformLimitation on WASM; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_admits_function_param_named_stream() {
+        // A function parameter named `stream` must NOT trigger the guard.
+        let source = r"
+type Packet { value: i64; }
+fn process(stream: Packet) -> i64 {
+    stream.value
+}
+fn main() {
+    let p = Packet { value: 7 };
+    println(process(p));
+}
+";
+        let result = hew_parser::parse(source);
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let mut checker = Checker::new(test_registry());
+        checker.enable_wasm_target();
+        let output = checker.check_program(&result.program);
+        assert!(
+            !has_platform_limitation_error(&output),
+            "function param named `stream` must not produce PlatformLimitation on WASM; got: {:?}",
+            output.errors
+        );
+    }
+
     // ── Native sibling tests: no platform error on non-wasm target ────────
 
     #[test]
@@ -21460,6 +21520,40 @@ mod wasm_rejects {
             kinds,
             vec![TypeErrorKind::UndefinedMethod],
             "expected exactly [UndefinedMethod] — chain must stay suppressed; got: {kinds:?}",
+        );
+    }
+
+    // ── Dedup parity: public const ↔ internal rejection table ────────────────
+
+    #[test]
+    fn native_only_wasm_modules_const_matches_rejection_table() {
+        // Verify that the public API const `crate::NATIVE_ONLY_WASM_MODULES`
+        // (consumed by hew-sandbox-wasm's profile gate) and the internal
+        // `Checker::NATIVE_ONLY_WASM_MODULE_REJECTIONS` table (consumed by
+        // `check_method_call` and `check_field_access`) enumerate the exact same
+        // set of module short-names.  Drift between the two means:
+        //   - a module added to the public const but missing from the table
+        //     → the compiler silently accepts it on wasm32 (fail-open)
+        //   - a module in the table but not in the public const
+        //     → the sandbox's profile gate silently accepts it (parity gap)
+        //
+        // To intentionally verify the test catches drift: temporarily comment
+        // out one entry from either list and confirm this test fails.
+        let mut from_const: Vec<&str> = crate::NATIVE_ONLY_WASM_MODULES.to_vec();
+        from_const.sort_unstable();
+
+        let mut from_table: Vec<&str> = Checker::NATIVE_ONLY_WASM_MODULE_REJECTIONS
+            .iter()
+            .map(|(name, _)| *name)
+            .collect();
+        from_table.sort_unstable();
+
+        assert_eq!(
+            from_const, from_table,
+            "NATIVE_ONLY_WASM_MODULES (public API const) and \
+             Checker::NATIVE_ONLY_WASM_MODULE_REJECTIONS (internal table) must \
+             list the same module short-names; add or remove the entry from BOTH \
+             when the native-only module set changes"
         );
     }
 }

--- a/hew-types/src/lib.rs
+++ b/hew-types/src/lib.rs
@@ -73,3 +73,30 @@ pub use runtime_call::{
 pub use runtime_calling_convention::RuntimeCallingConvention;
 pub use ty::{TraitObjectBound, Ty};
 pub use type_descriptor::TypeDescriptor;
+
+/// Native-only stdlib module short-names that are rejected on the wasm32 target
+/// and in the browser sandbox.
+///
+/// This is the single authoritative list shared between the type checker's
+/// call-form and value-position wasm32 guards (`check_method_call` in
+/// `methods.rs`, `check_field_access` in `expressions.rs`) and the browser
+/// sandbox profile gate (`hew-sandbox-wasm/src/profile.rs`).  Every guard that
+/// rejects a value-position or call-position reference to these modules on
+/// wasm32 must reference this const rather than maintaining its own copy.
+///
+/// Note: `crypto` is intentionally absent — only the specific symbol
+/// `crypto.random_bytes` is rejected, not the entire `crypto` module.
+pub const NATIVE_ONLY_WASM_MODULES: &[&str] = &[
+    "stream",
+    "http",
+    "net",
+    "process",
+    "tls",
+    "quic",
+    "dns",
+    "os",
+    "encrypt",
+    "sign",
+    "http_client",
+    "smtp",
+];


### PR DESCRIPTION
## Summary

The browser-wasm sandbox now rejects value-position references to native-only stdlib module functions (e.g. `crypto.random_bytes` used as a value rather than called) with a `PlatformLimitation` diagnostic, closing a fail-open where such references compiled in the sandbox despite not being runnable there. Closes #2199.

The reject is resolution-scoped so it fires only on bare native-only module identifiers — a local binding or parameter whose name happens to collide with a module short-name (`net`, `stream`, `os`, …) is not affected. A single `NATIVE_ONLY_WASM_MODULES` constant in hew-types is the authoritative module set consumed by the sandbox, and a parity test guards it against drift from the compiler's internal rejection table, giving consistent native / wasm32 / sandbox behaviour.

## Verification

- `cargo nextest run -p hew-types -p hew-sandbox-wasm` — 2634 passed (3/3 flake runs).
- Admit cases (local `net.connect`, param `stream.value`, local `os.name`) compile; reject cases (`crypto.random_bytes`, `net.connect`, `tls.connect`, `dns.resolve`) emit `PlatformLimitation`.
- Sandbox parity ratchet (`playground_sources_match_native_or_catalogued_divergence`) green; drift-guard test fails if the two module sets diverge.

## Out of scope

None.
