### PR TITLE
fix(mir): consume funcupdate base and close owned-field carry UAFs

### DIFF
--- a/examples/v05/checked-mir/golden/scope_fork_spawn_generic.elab.mir
+++ b/examples/v05/checked-mir/golden/scope_fork_spawn_generic.elab.mir
@@ -34,6 +34,7 @@ fn Driver__recv__run_value -> i64
     use BindingId(1) t site=SiteId(15) ty=<task<i64>> intent=Consume
     bind BindingId(2) v site=SiteId(15) ty=i64
     use BindingId(2) v site=SiteId(17) ty=i64 intent=Consume
+    bind BindingId(0) out site=SiteId(16) ty=i64
     eval site=SiteId(17) ty=()
     eval site=SiteId(9) ty=()
     use BindingId(0) out site=SiteId(18) ty=i64 intent=Consume

--- a/examples/v05/checked-mir/golden/scope_fork_spawn_generic.raw.mir
+++ b/examples/v05/checked-mir/golden/scope_fork_spawn_generic.raw.mir
@@ -71,6 +71,7 @@ fn Driver__recv__run_value() -> i64 [conv=actor_handler]
   bb1:
     stmt: bind BindingId(2) v site=SiteId(15) ty=i64
     stmt: use BindingId(2) v site=SiteId(17) ty=i64 intent=Consume
+    stmt: bind BindingId(0) out site=SiteId(16) ty=i64
     stmt: eval site=SiteId(17) ty=()
     stmt: eval site=SiteId(9) ty=()
     stmt: use BindingId(0) out site=SiteId(18) ty=i64 intent=Consume

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.elab.mir
@@ -410,8 +410,10 @@ fn fs$last_slash_pos -> i64
     eval site=SiteId(251) ty=()
     use BindingId(23) search_from site=SiteId(254) ty=i64 intent=Read
     use BindingId(25) next site=SiteId(255) ty=i64 intent=Read
+    bind BindingId(22) last site=SiteId(252) ty=i64
     eval site=SiteId(253) ty=()
     use BindingId(22) last site=SiteId(258) ty=i64 intent=Read
+    bind BindingId(23) search_from site=SiteId(256) ty=i64
     eval site=SiteId(257) ty=()
     drop BindingId(24) rest ty=string
   drop_plans:

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
@@ -770,6 +770,7 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb21:
     trap(IntegerOverflow)
   bb22:
+    stmt: bind BindingId(22) last site=SiteId(252) ty=i64
     stmt: eval site=SiteId(253) ty=()
     stmt: use BindingId(22) last site=SiteId(258) ty=i64 intent=Read
     _10 = move _26
@@ -779,6 +780,7 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb23:
     trap(IntegerOverflow)
   bb24:
+    stmt: bind BindingId(23) search_from site=SiteId(256) ty=i64
     stmt: eval site=SiteId(257) ty=()
     _14 = move _29
     goto bb10

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.elab.mir
@@ -21,6 +21,7 @@ fn Echo__recv__run -> ()
     use BindingId(8) item site=SiteId(35) ty=Option<bytes> intent=Read
     bind BindingId(9) b site=SiteId(36) ty=bytes
     use BindingId(9) b site=SiteId(38) ty=bytes intent=Read
+    bind BindingId(7) done site=SiteId(42) ty=bool
     eval site=SiteId(43) ty=()
     eval site=SiteId(45) ty=()
     drop BindingId(9) b ty=bytes
@@ -441,8 +442,10 @@ fn fs$last_slash_pos -> i64
     eval site=SiteId(270) ty=()
     use BindingId(28) search_from site=SiteId(273) ty=i64 intent=Read
     use BindingId(30) next site=SiteId(274) ty=i64 intent=Read
+    bind BindingId(27) last site=SiteId(271) ty=i64
     eval site=SiteId(272) ty=()
     use BindingId(27) last site=SiteId(277) ty=i64 intent=Read
+    bind BindingId(28) search_from site=SiteId(275) ty=i64
     eval site=SiteId(276) ty=()
     drop BindingId(29) rest ty=string
   drop_plans:

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -126,6 +126,7 @@ fn Echo__recv__run(i64) -> () [conv=actor_handler]
     _33 = move mvar26.0.0
     _34 = call hew_bytes_to_string(_33) -> bb23
   bb20:
+    stmt: bind BindingId(7) done site=SiteId(42) ty=bool
     stmt: eval site=SiteId(43) ty=()
     _35 = const.i64 1
     _23 = move _35
@@ -828,6 +829,7 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb21:
     trap(IntegerOverflow)
   bb22:
+    stmt: bind BindingId(27) last site=SiteId(271) ty=i64
     stmt: eval site=SiteId(272) ty=()
     stmt: use BindingId(27) last site=SiteId(277) ty=i64 intent=Read
     _10 = move _26
@@ -837,6 +839,7 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb23:
     trap(IntegerOverflow)
   bb24:
+    stmt: bind BindingId(28) search_from site=SiteId(275) ty=i64
     stmt: eval site=SiteId(276) ty=()
     _14 = move _29
     goto bb10

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.elab.mir
@@ -377,8 +377,10 @@ fn fs$last_slash_pos -> i64
     eval site=SiteId(238) ty=()
     use BindingId(23) search_from site=SiteId(241) ty=i64 intent=Read
     use BindingId(25) next site=SiteId(242) ty=i64 intent=Read
+    bind BindingId(22) last site=SiteId(239) ty=i64
     eval site=SiteId(240) ty=()
     use BindingId(22) last site=SiteId(245) ty=i64 intent=Read
+    bind BindingId(23) search_from site=SiteId(243) ty=i64
     eval site=SiteId(244) ty=()
     drop BindingId(24) rest ty=string
   drop_plans:

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
@@ -718,6 +718,7 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb21:
     trap(IntegerOverflow)
   bb22:
+    stmt: bind BindingId(22) last site=SiteId(239) ty=i64
     stmt: eval site=SiteId(240) ty=()
     stmt: use BindingId(22) last site=SiteId(245) ty=i64 intent=Read
     _10 = move _26
@@ -727,6 +728,7 @@ fn fs$last_slash_pos(string) -> i64 [conv=default]
   bb23:
     trap(IntegerOverflow)
   bb24:
+    stmt: bind BindingId(23) search_from site=SiteId(243) ty=i64
     stmt: eval site=SiteId(244) ty=()
     _14 = move _29
     goto bb10

--- a/examples/v05/checked-mir/golden/vec_scalar_ops.elab.mir
+++ b/examples/v05/checked-mir/golden/vec_scalar_ops.elab.mir
@@ -71,6 +71,7 @@ fn main -> ()
     bind BindingId(16) x site=SiteId(122) ty=i64
     use BindingId(11) total site=SiteId(118) ty=i64 intent=Read
     use BindingId(16) x site=SiteId(119) ty=i64 intent=Read
+    bind BindingId(11) total site=SiteId(120) ty=i64
     eval site=SiteId(121) ty=()
     eval site=SiteId(127) ty=()
     drop BindingId(13) __hew_for_iter_12 ty=VecIter<i64>

--- a/examples/v05/checked-mir/golden/vec_scalar_ops.raw.mir
+++ b/examples/v05/checked-mir/golden/vec_scalar_ops.raw.mir
@@ -380,6 +380,7 @@ fn main() -> () [conv=default]
   bb59:
     trap(IntegerOverflow)
   bb60:
+    stmt: bind BindingId(11) total site=SiteId(120) ty=i64
     stmt: eval site=SiteId(121) ty=()
     _64 = move _97
     goto bb54

--- a/hew-cli/tests/funcupdate_consume_semantics.rs
+++ b/hew-cli/tests/funcupdate_consume_semantics.rs
@@ -1572,3 +1572,51 @@ fn main() {
         "expected the fail-closed carry diagnostic; got:\n{out}"
     );
 }
+
+/// A functional update that CARRIES a `Vec<closure>`-element field while
+/// OVERRIDING a sibling single-pointer COW field must emit the clean
+/// `E_NOT_YET_IMPLEMENTED` diagnostic in BOTH debug and release builds — never
+/// an internal compiler panic.
+///
+/// The carried `Vec<fn() -> string>` has a single-pointer inline-drop symbol
+/// (`hew_vec_free_closure_pairs`), so the per-field carry gate admits it in
+/// isolation. But the WHOLE record is not a consume-markable owned-aggregate
+/// (its `Vec`-of-closure element fails `supports_value_class_drop_spine`), so
+/// the base was never consume-marked. Releasing the overridden `churn` field in
+/// place on a non-consume-marked base previously tripped the debug coupling
+/// assertion (an ICE) before the downstream W3.029 value-class gate rejected the
+/// record in release. The whole-record consume-markability pre-flight now fails
+/// closed with the clean diagnostic at the same point in both profiles.
+#[test]
+fn reject_carry_vec_closure_field_clean_no_panic() {
+    let source = r#"
+import std::string;
+record P { keep: Vec<fn() -> string>, churn: string }
+fn main() {
+    let v: Vec<fn() -> string> = Vec::new();
+    v.push(|| -> string { string.repeat("k", 8) });
+    let b = P { keep: v, churn: string.repeat("a", 8) };
+    let u = P { churn: string.repeat("b", 8), ..b };
+    println(u.keep.len());
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "Vec<closure>-carry + single-pointer override must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("E_NOT_YET_IMPLEMENTED"),
+        "expected the clean fail-closed NYI diagnostic; got:\n{out}"
+    );
+    // The whole point of the fix: the debug build must NOT panic. A surviving
+    // `debug_assert!` would surface as a panic / RUST_BACKTRACE message rather
+    // than the clean diagnostic above.
+    assert!(
+        !out.contains("panicked")
+            && !out.contains("NOT consume-marked")
+            && !out.contains("RUST_BACKTRACE")
+            && !out.contains("internal error"),
+        "compiler must not panic on this input; got:\n{out}"
+    );
+}

--- a/hew-cli/tests/funcupdate_consume_semantics.rs
+++ b/hew-cli/tests/funcupdate_consume_semantics.rs
@@ -56,6 +56,20 @@
 //! external Guard-Malloc + `MallocScribble` repro matrix (the in-suite `run`
 //! fixtures use plain malloc).
 //!
+//! ## Wrapper completeness — value-passthrough forms (block / if / match)
+//!
+//! The allowlist is COMPLETE THROUGH value-passthrough wrappers: a block tail,
+//! both `if` branches, and every `match` arm body are looked THROUGH, and the
+//! base is admitted only when EVERY reachable value is itself a materialised
+//! owner. A wrapper that can yield a live-binding projection is rejected
+//! fail-closed — `..if c { o.inner } else { makeInner() }`,
+//! `..{ let _z = 0; o.inner }`, `..match c { _ => o.inner }` — and so is a
+//! block-wrapped bare binding (`..{ base }`): the consume cannot peel the
+//! block, so the base must prove materialised, which a bare-binding tail fails
+//! (admitting it while the consume silently no-ops on the block is itself a
+//! UAF). An all-rvalue wrapper whose every branch / arm / tail is a fresh owned
+//! value is accepted and runs clean (`..if c { makeInner() } else { makeOther() }`).
+//!
 //! ## Owned-aggregate override + closure-pair / Generator inline-drop
 //!
 //! Overriding an owned-AGGREGATE field (record / tuple / enum) is a
@@ -470,6 +484,136 @@ fn main() {
     );
 }
 
+// ── reject: value-passthrough WRAPPER bases (block / if / match) ────────────
+//
+// A wrapper — a block (`{ ..; tail }`), an `if`, or a `match` — is a value-
+// passthrough form: its value is the tail / the selected branch / the winning
+// arm. The allowlist looks THROUGH each wrapper (`expr_is_materialized_owner`)
+// and admits the base only when EVERY reachable value is a materialised owner.
+// A live-binding projection reachable through ANY wrapper is rejected fail-
+// closed: the consume does not peel the wrapper, and a conditionally-selected
+// binding cannot be soundly consumed, so the override-drop would free storage
+// the live owner still references. The `if`/`block` wrapper-escape was a
+// residual use-after-free an earlier denylist shipped (a live projection
+// hidden behind `if true { … }` / `{ … }`); these pin it closed.
+
+/// `..if true { o.inner } else { makeInner() }`: the then-branch yields a
+/// projection of the live binding `o`. One reachable value aliases `o`'s
+/// interior, so the whole `if` base is rejected — even though the else-branch
+/// is a materialised owner. (The `if`-wrapper escape this completes.)
+#[test]
+fn reject_wrapper_if_live_projection_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn makeInner() -> Inner { Inner { label: string.repeat("a", 32), n: 1 } }
+fn main() {
+    let o = Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 };
+    let u = Inner { label: string.repeat("b", 32), ..if true { o.inner } else { makeInner() } };
+    println(u.label);
+    println(o.inner.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "if-wrapper over a live-binding projection must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value"),
+        "expected the fail-closed allowlist NotYetImplemented; got:\n{out}"
+    );
+}
+
+/// `..{ let _z = 0; o.inner }`: a non-empty block whose tail projects the live
+/// binding `o`. The block is looked through to its tail (statements are side-
+/// effecting only); the tail aliases `o`, so the base is rejected. (The
+/// block-wrapper escape this completes.)
+#[test]
+fn reject_block_wrapper_live_projection_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn main() {
+    let o = Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 };
+    let u = Inner { label: string.repeat("b", 32), ..{ let _z: i64 = 0; o.inner } };
+    println(u.label);
+    println(o.inner.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "block-wrapper over a live-binding projection must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value"),
+        "expected the fail-closed allowlist NotYetImplemented; got:\n{out}"
+    );
+}
+
+/// `..match flag { true => o.inner, false => makeInner() }`: a `match` arm body
+/// projects the live binding `o`. Every arm body must be a materialised owner;
+/// the `true` arm aliases `o`, so the whole `match` base is rejected.
+#[test]
+fn reject_match_wrapper_live_projection_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn makeInner() -> Inner { Inner { label: string.repeat("a", 32), n: 1 } }
+fn main() {
+    let o = Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 };
+    let flag = true;
+    let u = Inner { label: string.repeat("b", 32), ..match flag { true => o.inner, false => makeInner() } };
+    println(u.label);
+    println(o.inner.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "match-wrapper over a live-binding projection must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value"),
+        "expected the fail-closed allowlist NotYetImplemented; got:\n{out}"
+    );
+}
+
+/// `..{ base }`: a block-wrapped bare binding. The consume marker
+/// (`alias_moved_owned_operand`) fires only on a SYNTACTICALLY bare `BindingRef`
+/// — it does NOT peel the block, so `base` is never consume-marked. Admitting
+/// this as the bare-binding case while the consume silently no-ops would leave
+/// `base` live AND destructively release its overridden field — a use-after-
+/// free plus a double-free at `base`'s scope-exit drop. The base must instead
+/// prove materialised (it cannot: the tail is a bare binding), so it is
+/// rejected fail-closed.
+#[test]
+fn reject_block_wrapped_binding_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+fn main() {
+    let base = Inner { label: string.repeat("a", 32), n: 1 };
+    let u = Inner { label: string.repeat("b", 32), ..{ base } };
+    println(u.label);
+    println(base.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "block-wrapped bare-binding base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value"),
+        "expected the fail-closed allowlist NotYetImplemented; got:\n{out}"
+    );
+}
+
 // ── reject: overriding an owned-AGGREGATE field ────────────────────────────
 
 /// Overriding a record/tuple/enum field (`inner: Inner` here) in a
@@ -645,6 +789,95 @@ fn main() {
     assert!(
         out.contains(&"a".repeat(32)) && out.contains(&"b".repeat(32)),
         "clone-of-projection base should apply override and leave source intact; got:\n{out}"
+    );
+}
+
+// ── accept: all-rvalue WRAPPER bases (block / if / match) ──────────────────
+
+/// `..if c { makeInner() } else { makeOther() }`: every branch is a fresh owned
+/// call result, so whichever branch is selected the base is a materialised
+/// owner with no live alias. The allowlist looks through the `if` and admits
+/// it. Must `check` and `run` cleanly (the sound sibling of the rejected
+/// `if`-wrapper-over-live-projection).
+#[test]
+fn accept_all_rvalue_if_wrapper_base_runs_clean() {
+    require_codegen();
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+fn makeInner() -> Inner { Inner { label: string.repeat("a", 32), n: 1 } }
+fn makeOther() -> Inner { Inner { label: string.repeat("c", 32), n: 2 } }
+fn main() {
+    let c = true;
+    let u = Inner { label: string.repeat("b", 32), ..if c { makeInner() } else { makeOther() } };
+    println(u.label);
+    println(u.n);
+}
+"#;
+    let (ok, out) = hew_run(source);
+    assert!(
+        ok,
+        "all-rvalue if-wrapper base must run cleanly; got:\n{out}"
+    );
+    assert!(
+        out.contains(&"b".repeat(32)) && out.contains('1'),
+        "all-rvalue if-wrapper should apply the override and carry n=1 from makeInner(); got:\n{out}"
+    );
+}
+
+/// `..match flag { true => makeInner(), false => makeOther() }`: every arm body
+/// is a fresh owned call result. The allowlist looks through the `match` and
+/// admits it. Must `check` and `run` cleanly.
+#[test]
+fn accept_all_rvalue_match_wrapper_base_runs_clean() {
+    require_codegen();
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+fn makeInner() -> Inner { Inner { label: string.repeat("a", 32), n: 1 } }
+fn makeOther() -> Inner { Inner { label: string.repeat("c", 32), n: 2 } }
+fn main() {
+    let flag = true;
+    let u = Inner { label: string.repeat("b", 32), ..match flag { true => makeInner(), false => makeOther() } };
+    println(u.n);
+}
+"#;
+    let (ok, out) = hew_run(source);
+    assert!(
+        ok,
+        "all-rvalue match-wrapper base must run cleanly; got:\n{out}"
+    );
+    assert!(
+        out.contains('1'),
+        "all-rvalue match-wrapper should carry n=1 from the true arm; got:\n{out}"
+    );
+}
+
+/// `..{ println("seed"); makeInner() }`: a non-empty block whose tail is a
+/// materialised owner. The block's statement is side-effecting only; its VALUE
+/// is the tail call result, which has no live alias. The allowlist peels to the
+/// tail regardless of statement count and admits it. Must `check` and `run`
+/// cleanly (the sound sibling of the rejected block-wrapper-over-live-projection).
+#[test]
+fn accept_block_statements_rvalue_tail_base_runs_clean() {
+    require_codegen();
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+fn makeInner() -> Inner { Inner { label: string.repeat("a", 32), n: 1 } }
+fn main() {
+    let u = Inner { label: string.repeat("b", 32), ..{ println("seed"); makeInner() } };
+    println(u.n);
+}
+"#;
+    let (ok, out) = hew_run(source);
+    assert!(
+        ok,
+        "block-with-statements rvalue-tail base must run cleanly; got:\n{out}"
+    );
+    assert!(
+        out.contains("seed") && out.contains('1'),
+        "block tail should run the side-effecting statement and carry n=1; got:\n{out}"
     );
 }
 

--- a/hew-cli/tests/funcupdate_consume_semantics.rs
+++ b/hew-cli/tests/funcupdate_consume_semantics.rs
@@ -940,3 +940,263 @@ fn main() {
         "wildcard destructure should bind n=5; got:\n{out}"
     );
 }
+
+// ── reject: a binding REBOUND from a live-owner projection ──────────────────
+//
+// The fifth use-after-free this fix closes. A syntactically bare `BindingRef`
+// is NOT sufficient for the destructive update: `let b = o.inner` lowers to an
+// aliasing shallow copy that shares `o.inner`'s heap pointer (it is not a
+// move — `o` stays live), so consuming `b` and releasing its overridden owned
+// field in place frees storage `o.inner` still references → use-after-free and
+// a double-free at `o`'s scope-exit drop. The base allowlist therefore admits a
+// bare binding ONLY when a per-function provenance prescan proves every
+// definition of that binding is a freshly-owned value (a call/clone/literal/Vec
+// element, or a move-chain of those). A binding whose initialiser is a
+// projection of a still-live owner is rejected by construction.
+
+/// `let b = o.inner; { ..b, f }`: `b` aliases the live `o.inner`. The prescan
+/// classifies `b` unproven (its initialiser is a `FieldAccess` of a live
+/// binding, not a materialised owner) so the base gate fails closed.
+#[test]
+fn reject_rebind_field_projection_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn main() {
+    let o = Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 };
+    let b = o.inner;
+    let u = Inner { label: string.repeat("b", 32), ..b };
+    println(u.label);
+    println(o.inner.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "rebind-of-field-projection base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value")
+            && out.contains("unique owner")
+            && out.contains("REBOUND from such a projection"),
+        "expected the provenance-aware fail-closed reject; got:\n{out}"
+    );
+}
+
+/// `let b = t.0; { ..b, f }`: `b` aliases the live tuple element `t.0` (a
+/// `TupleFieldLoad`, not a materialising clone). Same alias-of-live-owner hole
+/// as the field-projection rebind; must fail closed.
+#[test]
+fn reject_rebind_tuple_index_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+fn main() {
+    let t: (Inner, i64) = (Inner { label: string.repeat("a", 32), n: 1 }, 9);
+    let b = t.0;
+    let u = Inner { label: string.repeat("b", 32), ..b };
+    println(u.label);
+    println(t.0.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "rebind-of-tuple-index base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value")
+            && out.contains("unique owner")
+            && out.contains("REBOUND from such a projection"),
+        "expected the provenance-aware fail-closed reject; got:\n{out}"
+    );
+}
+
+/// `let b = if c { o.inner } else { makeInner() }; { ..b, f }`: ONE branch of
+/// the wrapper initialiser is a live-owner projection, so `b` is not provably a
+/// unique owner on every path. The prescan is flow-insensitive (it requires
+/// EVERY definition to prove) and rejects — the conditional-materialise shape
+/// that a last-write map would unsoundly admit.
+#[test]
+fn reject_rebind_wrapper_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn makeInner() -> Inner { Inner { label: string.repeat("c", 32), n: 2 } }
+fn main() {
+    let o = Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 };
+    let b = if true { o.inner } else { makeInner() };
+    let u = Inner { label: string.repeat("b", 32), ..b };
+    println(u.label);
+    println(o.inner.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "rebind-of-wrapper-over-live-projection base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value") && out.contains("unique owner"),
+        "expected the provenance-aware fail-closed reject; got:\n{out}"
+    );
+}
+
+/// `let b = o.inner; let c = b; { ..c, f }`: a move-chain whose ROOT is a
+/// live-owner projection. The whole-binding move `let c = b` consumes `b`, but
+/// `b` itself aliases `o.inner`, so `c` transitively aliases the live owner.
+/// The prescan follows the move-chain to `b`'s unproven origin and rejects —
+/// the move-chain admit must not launder an aliasing root.
+#[test]
+fn reject_move_chain_of_alias_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn main() {
+    let o = Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 };
+    let b = o.inner;
+    let c = b;
+    let u = Inner { label: string.repeat("b", 32), ..c };
+    println(u.label);
+    println(o.inner.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "move-chain rooted at a live projection must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value") && out.contains("unique owner"),
+        "expected the provenance-aware fail-closed reject; got:\n{out}"
+    );
+}
+
+/// The rebind hole reaches through closure bodies too: the prescan runs over
+/// the WHOLE top-level body (recursing into closures) and the child builder
+/// inherits the parent provenance map. A closure that binds `let b = o.inner`
+/// off a captured `o` and updates `..b` must fail closed exactly as at top
+/// level — not slip through for want of the map.
+#[test]
+fn reject_closure_rebind_projection_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn main() {
+    let o = Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 };
+    let f = || -> Inner {
+        let b = o.inner;
+        Inner { label: string.repeat("b", 32), ..b }
+    };
+    let u = f();
+    println(u.label);
+    println(o.inner.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "closure rebind-of-projection base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value") && out.contains("unique owner"),
+        "expected the provenance-aware fail-closed reject inside a closure; got:\n{out}"
+    );
+}
+
+// ── accept: bare bindings the provenance prescan PROVES uniquely owned ──────
+
+/// A move-chain of a materialised owner (`let base = makeInner(); let c = base;
+/// { ..c, f }`): `base` is a call result (fresh owner), and `let c = base` is a
+/// move that consumes it, so `c` is the sole live owner. The prescan follows
+/// the chain to the materialised root and admits it. Must `check` and `run`
+/// cleanly — the sound sibling of `reject_move_chain_of_alias_base`.
+#[test]
+fn accept_move_chain_materialized_base_runs_clean() {
+    require_codegen();
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+fn makeInner() -> Inner { Inner { label: string.repeat("a", 32), n: 7 } }
+fn main() {
+    let base = makeInner();
+    let c = base;
+    let u = Inner { label: string.repeat("b", 32), ..c };
+    println(u.label);
+    println(u.n);
+}
+"#;
+    let (ok, out) = hew_run(source);
+    assert!(
+        ok,
+        "move-chain of a materialised owner must run cleanly; got:\n{out}"
+    );
+    assert!(
+        out.contains(&"b".repeat(32)) && out.contains('7'),
+        "move-chain base should apply the override and carry n=7; got:\n{out}"
+    );
+}
+
+/// A by-value parameter base (`fn upd(p: Cfg) -> Cfg { { ..p, name: new } }`):
+/// the caller moved `p` in, so the handler is its unique owner — the idiomatic
+/// "update one field of an owned argument" shape. The prescan seeds by-value
+/// params as proven owners. Must `check` and `run` cleanly.
+#[test]
+fn accept_param_base_runs_clean() {
+    require_codegen();
+    let source = r#"
+import std::string;
+record Cfg { name: string, k: i64 }
+fn upd(p: Cfg) -> Cfg { Cfg { name: string.repeat("z", 16), ..p } }
+fn main() {
+    let c = Cfg { name: string.repeat("a", 16), k: 3 };
+    let r = upd(c);
+    println(r.name);
+    println(r.k);
+}
+"#;
+    let (ok, out) = hew_run(source);
+    assert!(ok, "by-value parameter base must run cleanly; got:\n{out}");
+    assert!(
+        out.contains(&"z".repeat(16)) && out.contains('3'),
+        "param base should apply the name override and carry k=3; got:\n{out}"
+    );
+}
+
+/// A closure that updates a materialised base bound in its own body
+/// (`|| { let base = makeInner(); { ..base, f } }`): the prescan reaches the
+/// closure-local `let` and the child builder inherits the proof, so the bare
+/// base is admitted inside the closure exactly as at top level. Must `check`
+/// and `run` cleanly — the accept sibling of
+/// `reject_closure_rebind_projection_base`.
+#[test]
+fn accept_closure_materialized_base_runs_clean() {
+    require_codegen();
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+fn makeInner(s: string) -> Inner { Inner { label: string.repeat(s, 16), n: 1 } }
+fn main() {
+    let f = |s: string| -> Inner {
+        let base = makeInner(s);
+        Inner { label: string.repeat("z", 8), ..base }
+    };
+    let r = f("a");
+    println(r.label);
+    println(r.n);
+}
+"#;
+    let (ok, out) = hew_run(source);
+    assert!(
+        ok,
+        "closure materialised base must run cleanly; got:\n{out}"
+    );
+    assert!(
+        out.contains(&"z".repeat(8)) && out.contains('1'),
+        "closure base should apply the override and carry n=1; got:\n{out}"
+    );
+}

--- a/hew-cli/tests/funcupdate_consume_semantics.rs
+++ b/hew-cli/tests/funcupdate_consume_semantics.rs
@@ -1141,29 +1141,43 @@ fn main() {
     );
 }
 
-/// A by-value parameter base (`fn upd(p: Cfg) -> Cfg { { ..p, name: new } }`):
-/// the caller moved `p` in, so the handler is its unique owner — the idiomatic
-/// "update one field of an owned argument" shape. The prescan seeds by-value
-/// params as proven owners. Must `check` and `run` cleanly.
+/// A by-value parameter base (`fn upd(p: Cfg) -> Cfg { Cfg { name: new, ..p } }`)
+/// must be REJECTED. A by-value heap parameter is a BORROW
+/// (LESSONS `by-value-heap-params-are-borrows`), and the funcupdate gate sees
+/// only the callee body, never the call site. The same `upd` is sound for
+/// `upd(moved_in_local)` but a use-after-free for `upd(o.cfg)` while the
+/// caller's `o` stays live — the in-place override-drop frees `o.cfg.name`
+/// under the still-live owner. Empirically (Guard Malloc, `MallocScribble`):
+/// admitting `..p` lets `upd(o.cfg)` reach run and SIGSEGV on the live
+/// `o.cfg.name` read (scribble-poisoned freed memory). Indistinguishable at the
+/// definition, so `..p` fails closed. This intentionally diverges from an
+/// earlier "param base is the unique owner" assumption: the moved-in call is a
+/// special case the gate cannot confirm, and the projection-of-live call is a
+/// real hole. Clone the base (`Cfg { ..p.clone(), name: new }`) to update an
+/// owned argument.
 #[test]
-fn accept_param_base_runs_clean() {
-    require_codegen();
+fn reject_by_value_param_base() {
     let source = r#"
 import std::string;
 record Cfg { name: string, k: i64 }
+record Wrap { cfg: Cfg, tag: i64 }
 fn upd(p: Cfg) -> Cfg { Cfg { name: string.repeat("z", 16), ..p } }
 fn main() {
-    let c = Cfg { name: string.repeat("a", 16), k: 3 };
-    let r = upd(c);
+    let o = Wrap { cfg: Cfg { name: string.repeat("a", 16), k: 3 }, tag: 9 };
+    let r = upd(o.cfg);
     println(r.name);
-    println(r.k);
+    println(o.cfg.name);
 }
 "#;
-    let (ok, out) = hew_run(source);
-    assert!(ok, "by-value parameter base must run cleanly; got:\n{out}");
+    let (ok, out) = hew_check(source);
     assert!(
-        out.contains(&"z".repeat(16)) && out.contains('3'),
-        "param base should apply the name override and carry k=3; got:\n{out}"
+        !ok,
+        "by-value parameter base must fail check (it admits the upd(o.cfg) UAF); got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value")
+            && out.contains("not provably the unique owner"),
+        "expected the fail-closed funcupdate allowlist diagnostic; got:\n{out}"
     );
 }
 
@@ -1198,5 +1212,202 @@ fn main() {
     assert!(
         out.contains(&"z".repeat(8)) && out.contains('1'),
         "closure base should apply the override and carry n=1; got:\n{out}"
+    );
+}
+
+// ── reject: a call result that LAUNDERS a borrowed parameter ────────────────
+//
+// The call-returns-borrowed-param use-after-free class. A by-value heap
+// parameter is a BORROW (LESSONS `by-value-heap-params-are-borrows`); a callee
+// can hand that borrow straight back (or embedded in a construction) WITHOUT a
+// refcount bump, so a `..f(live_projection)` base interior-aliases the caller's
+// still-live storage. The interprocedural freshness summary classifies such a
+// callee NOT-fresh, so the funcupdate gate rejects the base. Each shape below
+// SIGSEGVs / double-frees under Guard Malloc when admitted (empirically
+// reproduced); all must fail `check` fail-closed.
+
+/// 6th hole, unbound: `..id_inner(o.inner)` where `fn id_inner(p) { p }` returns
+/// the borrowed parameter verbatim. The override-drop frees the live
+/// `o.inner.label`.
+#[test]
+fn reject_call_returns_borrowed_param_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn id_inner(p: Inner) -> Inner { p }
+fn main() {
+    let o = Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 };
+    let u = Inner { label: string.repeat("b", 32), ..id_inner(o.inner) };
+    println(u.label);
+    println(o.inner.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "call-returns-borrowed-param base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value")
+            && out.contains("not provably the unique owner"),
+        "expected the fail-closed funcupdate allowlist diagnostic; got:\n{out}"
+    );
+}
+
+/// 6th hole, bound: `let b = id_inner(o.inner); ..b`. Binding the laundered
+/// call result does not change provenance — the prescan classifies `b`'s
+/// definition (a non-fresh call) as not materialised.
+#[test]
+fn reject_call_returns_borrowed_param_base_bound() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn id_inner(p: Inner) -> Inner { p }
+fn main() {
+    let o = Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 };
+    let b = id_inner(o.inner);
+    let u = Inner { label: string.repeat("b", 32), ..b };
+    println(u.label);
+    println(o.inner.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "bound call-returns-borrowed-param base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value")
+            && out.contains("not provably the unique owner"),
+        "expected the fail-closed funcupdate allowlist diagnostic; got:\n{out}"
+    );
+}
+
+/// 7th hole, inline: a `..Wrap { s: p }` base that constructs a record EMBEDDING
+/// a whole by-value parameter. The constructor stores the param operand without
+/// a refcount bump, so the constructed base interior-aliases the caller's
+/// argument; the override-drop then frees the live `str0`.
+#[test]
+fn reject_struct_init_embeds_param_base() {
+    let source = r#"
+import std::string;
+record Wrap { s: string, n: i64 }
+fn leak(p: string) -> Wrap {
+    Wrap { s: string.repeat("new", 8), ..Wrap { s: p, n: 0 } }
+}
+fn main() {
+    let str0 = string.repeat("a", 32);
+    let r = leak(str0);
+    println(r.s);
+    println(str0);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "struct-init-embeds-param base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value")
+            && out.contains("not provably the unique owner"),
+        "expected the fail-closed funcupdate allowlist diagnostic; got:\n{out}"
+    );
+}
+
+/// 7th hole, bound: `let b = Wrap { s: p, n: 0 }; ..b`. Binding the
+/// param-embedding constructor first does not launder it — the prescan sees the
+/// `StructInit` definition embeds a whole parameter and rejects.
+#[test]
+fn reject_bound_struct_init_embeds_param_base() {
+    let source = r#"
+import std::string;
+record Wrap { s: string, n: i64 }
+fn leak(p: string) -> Wrap {
+    let b = Wrap { s: p, n: 0 };
+    Wrap { s: string.repeat("new", 8), ..b }
+}
+fn main() {
+    let str0 = string.repeat("a", 32);
+    let r = leak(str0);
+    println(r.s);
+    println(str0);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "bound struct-init-embeds-param base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value")
+            && out.contains("not provably the unique owner"),
+        "expected the fail-closed funcupdate allowlist diagnostic; got:\n{out}"
+    );
+}
+
+/// 7th hole, through a call return: `..wrap(o.inner).inner` where `fn wrap(p) {
+/// Outer { inner: p, tag: 0 } }` returns a constructor EMBEDDING the borrowed
+/// parameter. The freshness summary classifies `wrap` not-fresh because its
+/// return embeds a parameter, so the projection of its result is not a
+/// materialised owner.
+#[test]
+fn reject_call_embeds_param_in_return_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn wrap(p: Inner) -> Outer { Outer { inner: p, tag: 0 } }
+fn main() {
+    let o = Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 };
+    let u = Inner { label: string.repeat("b", 32), ..wrap(o.inner).inner };
+    println(u.label);
+    println(o.inner.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "call-embeds-param-in-return base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value")
+            && out.contains("not provably the unique owner"),
+        "expected the fail-closed funcupdate allowlist diagnostic; got:\n{out}"
+    );
+}
+
+/// accept (interprocedural-fresh): `..makeInner(seed)` where
+/// `fn makeInner(s) { Inner { label: string.repeat(s, 16), n: 1 } }` FORWARDS
+/// its parameter into a fresh-allocating runtime primitive (`string.repeat`).
+/// The result is a freshly-owned record that does not alias `seed`, so the base
+/// is admitted. This is the interprocedural-completeness counterpart of the
+/// rejected `id_inner`/`wrap` shapes: a callee whose only use of a parameter is
+/// to feed an owned-returning primitive stays fresh. Must `check` and `run`
+/// cleanly with `seed` still readable afterwards.
+#[test]
+fn accept_call_forwards_param_through_fresh_builtin_base() {
+    require_codegen();
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+fn makeInner(s: string) -> Inner { Inner { label: string.repeat(s, 16), n: 1 } }
+fn main() {
+    let seed = string.repeat("q", 4);
+    let u = Inner { label: string.repeat("b", 32), ..makeInner(seed) };
+    println(u.label);
+    println(u.n);
+    println(seed);
+}
+"#;
+    let (ok, out) = hew_run(source);
+    assert!(
+        ok,
+        "interprocedural-fresh call base must run cleanly; got:\n{out}"
+    );
+    assert!(
+        out.contains(&"b".repeat(32)) && out.contains('1') && out.contains(&"q".repeat(4)),
+        "interprocedural-fresh base should override label, carry n=1, leave seed live; got:\n{out}"
     );
 }

--- a/hew-cli/tests/funcupdate_consume_semantics.rs
+++ b/hew-cli/tests/funcupdate_consume_semantics.rs
@@ -1,0 +1,201 @@
+//! Functional-update CONSUME-semantics fixtures.
+//!
+//! `T { field: new, ..base }` over an owned (heap-carrying) record CONSUMES
+//! `base`: its carried fields move into the new record and its overridden
+//! owned fields are destructively released at the construction site. That
+//! destructive release is sound ONLY because the move-checker forbids any
+//! later read of `base` — so the freed old value has no surviving reader.
+//!
+//! These fixtures pin both halves of that contract:
+//!
+//! * **reject** — programs that read `base` after it is consumed (a second
+//!   `..base` from the same source; a `base.field` read) must FAIL `hew check`
+//!   with `UseAfterConsume`. Before the consume-mark landed they compiled and
+//!   corrupted memory (use-after-free / double-free of `base`'s overridden
+//!   owned field). The compile error IS the safe outcome.
+//!
+//! * **reject** — a self-referential override whose value bare-aliases the
+//!   consumed base (`{ items: s.items, ..s }`) must FAIL `hew check`
+//!   (`NotYetImplemented`): the override reads the very field the destructive
+//!   release would free.
+//!
+//! * **accept** — the canonical reassign-loop idiom (`c = T { ..c, f: new }`)
+//!   and the explicit-clone override (`{ items: s.items.clone(), ..s }`) must
+//!   `check` and `run` cleanly. The reassign re-defines `c`, so the consume of
+//!   the old `c` is immediately superseded by the fresh binding — the loop
+//!   stays legal. (Leak-freedom of the reassign loop is pinned separately by
+//!   `funcupdate_owned_field_drop_leak_oracle`.)
+//!
+//! The two reject fixtures are the empirical P0 repros that originally
+//! miscompiled; turning them into compile errors is the fix's headline
+//! observable.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::process::Command;
+
+use support::{hew_binary, repo_root, require_codegen};
+
+/// Run `hew check <source>` and return `(success, combined_output)`.
+fn hew_check(source: &str) -> (bool, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("fixture.hew");
+    std::fs::write(&src, source).expect("write source");
+    let output = Command::new(hew_binary())
+        .arg("check")
+        .arg(&src)
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew check");
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    (output.status.success(), combined)
+}
+
+/// Run `hew run <source>` and return `(success, combined_output)`.
+fn hew_run(source: &str) -> (bool, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("fixture.hew");
+    std::fs::write(&src, source).expect("write source");
+    let output = Command::new(hew_binary())
+        .arg("run")
+        .arg(&src)
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew run");
+    let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    (output.status.success(), combined)
+}
+
+// ── reject: base reused after consume ─────────────────────────────────────
+
+/// Repro A: the same `base` feeds two functional updates. The first `..base`
+/// consumes it; the second reads consumed storage whose overridden owned
+/// field has already been destructively freed → double-free at run time.
+/// `hew check` must reject the SECOND `..base`.
+#[test]
+fn reject_base_reused_in_two_updates_is_use_after_consume() {
+    let source = r#"
+record VHolder { items: Vec<i64>, tag: string }
+fn main() {
+    let init: Vec<i64> = Vec::new(); init.push(1);
+    let base = VHolder { items: init, tag: "base" };
+    let next1: Vec<i64> = Vec::new(); next1.push(2);
+    let updated1 = VHolder { items: next1, ..base };
+    let next2: Vec<i64> = Vec::new(); next2.push(3);
+    let updated2 = VHolder { items: next2, ..base };
+    println(updated1.items.len());
+    println(updated2.items.len());
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(!ok, "base-reuse must fail check; got success:\n{out}");
+    assert!(
+        out.contains("used after it was consumed") || out.contains("UseAfterConsume"),
+        "expected UseAfterConsume on the second `..base`; got:\n{out}"
+    );
+}
+
+/// A `base.field` READ after the base was consumed by `..base` must also be
+/// rejected (the single-override-then-reuse shape, repro T3).
+#[test]
+fn reject_base_field_read_after_consume_is_use_after_consume() {
+    let source = r#"
+record VHolder { items: Vec<i64>, tag: string }
+fn main() {
+    let init: Vec<i64> = Vec::new(); init.push(7);
+    let base = VHolder { items: init, tag: "base" };
+    let next: Vec<i64> = Vec::new(); next.push(8);
+    let updated = VHolder { items: next, ..base };
+    println(updated.items.len());
+    println(base.items.len());
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(!ok, "base.field read after consume must fail check:\n{out}");
+    assert!(
+        out.contains("used after it was consumed") || out.contains("UseAfterConsume"),
+        "expected UseAfterConsume on the post-update `base.items` read; got:\n{out}"
+    );
+}
+
+// ── reject: self-override aliasing the consumed base ───────────────────────
+
+/// Repro B: the override value `s.items` bare-aliases the same field the
+/// destructive release would free. Until the COW value model lands this is a
+/// fail-closed `NotYetImplemented`, not a silent miscompile.
+#[test]
+fn reject_self_override_aliasing_consumed_base() {
+    let source = r#"
+record VHolder { items: Vec<i64>, tag: string }
+fn main() {
+    let init: Vec<i64> = Vec::new(); init.push(7);
+    let s = VHolder { items: init, tag: "base" };
+    let s2 = VHolder { items: s.items, ..s };
+    println(s2.items.len());
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(!ok, "self-override aliasing base must fail check:\n{out}");
+    assert!(
+        out.contains("aliasing the consumed base") || out.contains("E_NOT_YET_IMPLEMENTED"),
+        "expected NotYetImplemented for the self-aliasing override; got:\n{out}"
+    );
+}
+
+// ── accept: the canonical reassign-loop idiom ──────────────────────────────
+
+/// `h = T { ..h, f: new }` in a loop re-defines `h` each iteration, so the
+/// consume of the old `h` is superseded by the fresh binding. Must `check`
+/// and `run` cleanly — this is the load-bearing functional-update idiom.
+#[test]
+fn accept_reassign_loop_idiom_runs_clean() {
+    require_codegen();
+    let source = r"
+record VecHolder { items: Vec<i64>, tag: i64 }
+fn main() {
+    let init: Vec<i64> = Vec::new(); init.push(99);
+    var h = VecHolder { items: init, tag: 0 };
+    var i: i64 = 0;
+    while i < 8 {
+        let next: Vec<i64> = Vec::new(); next.push(i);
+        h = VecHolder { items: next, ..h };
+        i = i + 1;
+    }
+    println(h.items.len());
+}
+";
+    let (ok, out) = hew_run(source);
+    assert!(ok, "reassign-loop idiom must run cleanly; got:\n{out}");
+    assert!(
+        out.contains('1'),
+        "reassign loop should leave a 1-element vec; got:\n{out}"
+    );
+}
+
+/// The explicit-clone override `{ items: s.items.clone(), ..s }` is the safe
+/// way to thread a base field through an update: the clone is a fresh +1
+/// owner, so consuming `s` and releasing its old `items` cannot dangle. Must
+/// `check` and `run` cleanly.
+#[test]
+fn accept_clone_override_runs_clean() {
+    require_codegen();
+    let source = r"
+record VecHolder { items: Vec<i64>, tag: i64 }
+fn main() {
+    let init: Vec<i64> = Vec::new(); init.push(5);
+    let s = VecHolder { items: init, tag: 1 };
+    let s2 = VecHolder { items: s.items.clone(), ..s };
+    println(s2.items.len());
+}
+";
+    let (ok, out) = hew_run(source);
+    assert!(ok, "clone-override must run cleanly; got:\n{out}");
+    assert!(
+        out.contains('1'),
+        "clone-override should yield a 1-element vec; got:\n{out}"
+    );
+}

--- a/hew-cli/tests/funcupdate_consume_semantics.rs
+++ b/hew-cli/tests/funcupdate_consume_semantics.rs
@@ -29,6 +29,32 @@
 //! The two reject fixtures are the empirical P0 repros that originally
 //! miscompiled; turning them into compile errors is the fix's headline
 //! observable.
+//!
+//! ## Base-shape fixtures (projection / temporary / index / rvalue)
+//!
+//! A `..base` whose base is a PROJECTION of a live binding (`{ ..o.inner,
+//! f: new }`) interior-aliases that binding's storage: the binding stays live
+//! (a projection is not consume-marked), yet the overridden owned field is
+//! released in place — a use-after-free of `o.inner.<field>` and a double-free
+//! at `o`'s scope-exit drop. That shape is rejected fail-closed
+//! (`NotYetImplemented`). The base shapes that are NOT interior aliases of a
+//! surviving binding stay legal and run clean: an owned rvalue base
+//! (`{ ..makeInner(), f: new }`), a projection of a TEMPORARY
+//! (`{ ..makeOuter().inner, f: new }` — rooted at a call), and an INDEXED base
+//! (`{ ..v[i], f: new }` — materialises an independent element).
+//!
+//! ## Owned-aggregate override + closure-pair / Generator inline-drop
+//!
+//! Overriding an owned-AGGREGATE field (record / tuple / enum) is a
+//! fail-closed `NotYetImplemented` (the in-place aggregate drop kinds are
+//! function-scope, not inline `Instr::Drop` targets). Separately, the
+//! single-pointer COW leaf-release authority `project_field_inline_drop_symbol`
+//! — shared by the functional-update override-drop AND the match-destructure
+//! wildcard inline-drop — must agree with codegen's `cow_heap_release_symbol`
+//! for EVERY type, including a closure-pair `Vec<fn>` (release symbol
+//! `hew_vec_free_closure_pairs`, not `hew_vec_free`) and a `Generator`
+//! (`hew_gen_coro_destroy`). A tuple wildcard-destructure over those element
+//! types exercises the shared authority end-to-end and must run clean.
 
 #![cfg(unix)]
 
@@ -197,5 +223,241 @@ fn main() {
     assert!(
         out.contains('1'),
         "clone-override should yield a 1-element vec; got:\n{out}"
+    );
+}
+
+// ── reject: projection of a LIVE binding base (the residual P0 UAF) ─────────
+
+/// `{ ..o.inner, label: new }` projects a field of the live binding `o`. The
+/// projection is NOT consume-marked (`o` stays live), but the overridden owned
+/// `label` is released in place — so a later `o.inner.label` read is a
+/// use-after-free and `o`'s scope-exit drop double-frees it. Empirically this
+/// compiled clean and corrupted memory (a `free_cstring` double-free abort;
+/// a crash on the freed read under Guard Malloc). It must now FAIL `hew check`
+/// fail-closed (`NotYetImplemented`); the compile error is the safe outcome.
+#[test]
+fn reject_projection_of_live_binding_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn main() {
+    let o = Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 };
+    let u = Inner { label: string.repeat("b", 32), ..o.inner };
+    println(u.label);
+    println(o.inner.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "projection-of-live-binding base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("projecting a live binding")
+            || out.contains("projects a field of a live binding"),
+        "expected the projection-of-live-binding NotYetImplemented; got:\n{out}"
+    );
+}
+
+/// Carry variant: `{ ..o.inner, n: 5 }` overrides only the `BitCopy` `n` and
+/// CARRIES the owned `label` from the live projection. No override-drop fires,
+/// but the carried owned field is raw-loaded (aliased) into the new record
+/// while `o` stays live — so `u` and `o.inner` share one `label` buffer and
+/// `o`'s scope-exit drop double-frees it. The reject is therefore gated on the
+/// base TYPE being an owned aggregate (not on the overridden field being
+/// owned): a bare-binding carry is safe only because `..base` consumes the
+/// base, which a live projection never does.
+#[test]
+fn reject_projection_of_live_binding_base_carry_only() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn main() {
+    let o = Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 };
+    let u = Inner { n: 5, ..o.inner };
+    println(u.label);
+    println(o.inner.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "projection-of-live-binding carry-only base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("projecting a live binding")
+            || out.contains("projects a field of a live binding"),
+        "expected the projection-of-live-binding NotYetImplemented; got:\n{out}"
+    );
+}
+
+// ── reject: overriding an owned-AGGREGATE field ────────────────────────────
+
+/// Overriding a record/tuple/enum field (`inner: Inner` here) in a
+/// functional-update has no single-pointer leaf release symbol — the in-place
+/// aggregate drop kinds (`RecordInPlace` / `TupleInPlace` / `EnumInPlace`) are
+/// function-scope drops, not inline `Instr::Drop` targets. Fail-closed
+/// `NotYetImplemented` rather than emit a leak / wrong-ABI free.
+#[test]
+fn reject_owned_aggregate_field_override() {
+    let source = r#"
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn main() {
+    let init = Outer { inner: Inner { label: "x", n: 1 }, tag: 0 };
+    let updated = Outer { inner: Inner { label: "y", n: 2 }, ..init };
+    println(updated.tag);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "owned-aggregate field override must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("override of owned-aggregate field") || out.contains("owned-aggregate type"),
+        "expected the owned-aggregate override NotYetImplemented; got:\n{out}"
+    );
+}
+
+// ── accept: base shapes that are NOT interior aliases of a live binding ─────
+
+/// An owned rvalue base (`{ ..makeInner(), f: new }`): the call result is a
+/// consumed temporary with no surviving named alias. The overridden owned
+/// `label` of the temporary is released, the temporary's other fields move
+/// into the new record. Must `check` and `run` cleanly (no false reject).
+#[test]
+fn accept_owned_rvalue_base_runs_clean() {
+    require_codegen();
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+fn makeInner() -> Inner { Inner { label: string.repeat("a", 32), n: 1 } }
+fn main() {
+    let u = Inner { label: string.repeat("b", 32), ..makeInner() };
+    println(u.n);
+}
+"#;
+    let (ok, out) = hew_run(source);
+    assert!(ok, "owned-rvalue base must run cleanly; got:\n{out}");
+    assert!(
+        out.contains('1'),
+        "owned-rvalue base should carry n=1 from the temporary; got:\n{out}"
+    );
+}
+
+/// A projection of a TEMPORARY (`{ ..makeOuter().inner, f: new }`): the base
+/// is rooted at a call, not a live binding, so there is no surviving alias of
+/// the released field. Must `check` and `run` cleanly (not caught by the
+/// projection-of-live-binding reject).
+#[test]
+fn accept_projection_of_temporary_base_runs_clean() {
+    require_codegen();
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn makeOuter() -> Outer { Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 } }
+fn main() {
+    let u = Inner { label: string.repeat("b", 32), ..makeOuter().inner };
+    println(u.n);
+}
+"#;
+    let (ok, out) = hew_run(source);
+    assert!(
+        ok,
+        "projection-of-temporary base must run cleanly; got:\n{out}"
+    );
+    assert!(
+        out.contains('1'),
+        "projection-of-temporary base should carry n=1; got:\n{out}"
+    );
+}
+
+/// An INDEXED base (`{ ..v[0], f: new }`): indexing materialises an
+/// independent element value, so the overridden field released in the new
+/// record does not dangle `v[0]`. Must `check` and `run` cleanly, and the
+/// source element stays intact.
+#[test]
+fn accept_index_of_live_binding_base_runs_clean() {
+    require_codegen();
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+fn main() {
+    let v: Vec<Inner> = Vec::new();
+    v.push(Inner { label: string.repeat("a", 32), n: 7 });
+    let u = Inner { label: string.repeat("b", 32), ..v[0] };
+    println(u.n);
+    println(v[0].n);
+}
+"#;
+    let (ok, out) = hew_run(source);
+    assert!(ok, "indexed base must run cleanly; got:\n{out}");
+    assert!(
+        out.matches('7').count() >= 2,
+        "indexed base should carry n=7 and leave v[0] intact; got:\n{out}"
+    );
+}
+
+// ── accept: closure-pair Vec / Generator inline-drop release-symbol parity ──
+
+/// A tuple `(Vec<fn(...)>, i64)` wildcard-destructure releases the discarded
+/// `Vec<fn>` field via the shared `project_field_inline_drop_symbol` authority.
+/// Its release symbol is `hew_vec_free_closure_pairs` (the per-element env
+/// thunk + pair-box walk), NOT `hew_vec_free`. Before the parity fix the MIR
+/// authority emitted `hew_vec_free`, which codegen rejected as incongruent
+/// with the field type (a hard fail-closed). It must now `check` and `run`
+/// cleanly.
+#[test]
+fn accept_closure_pair_vec_tuple_wildcard_runs_clean() {
+    require_codegen();
+    let source = r"
+fn double(x: i64) -> i64 { x * 2 }
+fn main() {
+    let t: (Vec<fn(i64) -> i64>, i64) = ([double], 5);
+    match t {
+        (_, n) => println(n),
+    }
+}
+";
+    let (ok, out) = hew_run(source);
+    assert!(
+        ok,
+        "closure-pair Vec tuple wildcard-destructure must run cleanly; got:\n{out}"
+    );
+    assert!(
+        out.contains('5'),
+        "wildcard destructure should bind n=5; got:\n{out}"
+    );
+}
+
+/// A tuple `(Generator<Y, R>, i64)` wildcard-destructure releases the
+/// discarded `Generator` field via `hew_gen_coro_destroy` (the coro-frame
+/// teardown). Exercises the `Generator` arm of the shared inline-drop
+/// authority end-to-end (the funcupdate override path cannot reach it — a
+/// record carrying a `Generator` field is blocked earlier at the record-clone
+/// front-stop, since the pointer-backed handle has no dup symbol).
+#[test]
+fn accept_generator_tuple_wildcard_runs_clean() {
+    require_codegen();
+    let source = r"
+fn main() {
+    let t: (Generator<i64, ()>, i64) = (gen { yield 1; yield 2; }, 5);
+    match t {
+        (_, n) => println(n),
+    }
+}
+";
+    let (ok, out) = hew_run(source);
+    assert!(
+        ok,
+        "Generator tuple wildcard-destructure must run cleanly; got:\n{out}"
+    );
+    assert!(
+        out.contains('5'),
+        "wildcard destructure should bind n=5; got:\n{out}"
     );
 }

--- a/hew-cli/tests/funcupdate_consume_semantics.rs
+++ b/hew-cli/tests/funcupdate_consume_semantics.rs
@@ -30,18 +30,31 @@
 //! miscompiled; turning them into compile errors is the fix's headline
 //! observable.
 //!
-//! ## Base-shape fixtures (projection / temporary / index / rvalue)
+//! ## Base-shape fixtures — fail-closed ALLOWLIST (projection / index / rvalue)
 //!
-//! A `..base` whose base is a PROJECTION of a live binding (`{ ..o.inner,
-//! f: new }`) interior-aliases that binding's storage: the binding stays live
-//! (a projection is not consume-marked), yet the overridden owned field is
-//! released in place — a use-after-free of `o.inner.<field>` and a double-free
-//! at `o`'s scope-exit drop. That shape is rejected fail-closed
-//! (`NotYetImplemented`). The base shapes that are NOT interior aliases of a
-//! surviving binding stay legal and run clean: an owned rvalue base
-//! (`{ ..makeInner(), f: new }`), a projection of a TEMPORARY
-//! (`{ ..makeOuter().inner, f: new }` — rooted at a call), and an INDEXED base
-//! (`{ ..v[i], f: new }` — materialises an independent element).
+//! The destructive base is gated by a fail-closed ALLOWLIST
+//! (`base_is_safe_for_destructive_funcupdate`): the override-drop and the
+//! shallow carry proceed ONLY when the base is PROVABLY safe — a bare
+//! consume-marked binding, or a materialised owner with no live alias (a
+//! call / `.clone()` result, a `Vec` element `v[i]`, or a projection rooted at
+//! one). EVERY other base is rejected `NotYetImplemented`. This replaced an
+//! earlier denylist that enumerated unsafe projection shapes and repeatedly
+//! missed cases: `FieldAccess` (`..o.inner`), then `Index`, then `TupleIndex`
+//! (`..t.0`, which lowers to an aliasing `TupleFieldLoad`) — each a fresh
+//! use-after-free of the projected field plus a double-free at the live
+//! binding's scope-exit drop. The allowlist is complete by construction: no
+//! projection shape — field, tuple-index, nested, machine-state (`self.field`),
+//! or any future expr form — can slip.
+//!
+//! Rejected (interior-alias a live binding): `..o.inner`, `..t.0`,
+//! `..o.pair.0`, `..t.0.inner`, and a machine-state `..self.payload`. Accepted
+//! (consumed binding or materialised owner): a bare base (`..base`), an owned
+//! rvalue (`..makeInner()`), a projection of a temporary (`..makeOuter().inner`
+//! — rooted at a call), an indexed base (`..v[i]`), a projection through an
+//! index (`..o.items[0].inner`), and the `.clone()` escape hatch
+//! (`..o.inner.clone()`). The authoritative memory-safety oracle is the
+//! external Guard-Malloc + `MallocScribble` repro matrix (the in-suite `run`
+//! fixtures use plain malloc).
 //!
 //! ## Owned-aggregate override + closure-pair / Generator inline-drop
 //!
@@ -254,9 +267,9 @@ fn main() {
         "projection-of-live-binding base must fail check; got success:\n{out}"
     );
     assert!(
-        out.contains("projecting a live binding")
-            || out.contains("projects a field of a live binding"),
-        "expected the projection-of-live-binding NotYetImplemented; got:\n{out}"
+        out.contains("not a binding or owned value")
+            && out.contains("field projection of a live binding"),
+        "expected the fail-closed allowlist NotYetImplemented; got:\n{out}"
     );
 }
 
@@ -287,9 +300,173 @@ fn main() {
         "projection-of-live-binding carry-only base must fail check; got success:\n{out}"
     );
     assert!(
-        out.contains("projecting a live binding")
-            || out.contains("projects a field of a live binding"),
-        "expected the projection-of-live-binding NotYetImplemented; got:\n{out}"
+        out.contains("not a binding or owned value")
+            && out.contains("field projection of a live binding"),
+        "expected the fail-closed allowlist NotYetImplemented; got:\n{out}"
+    );
+}
+
+// ── reject: TupleIndex / nested / machine-state projection bases ────────────
+//
+// These pin the STRUCTURAL fix: the destructive base allowlist
+// (`base_is_safe_for_destructive_funcupdate`). The prior denylist enumerated
+// only `FieldAccess` projections, so a base that projects an owned record out
+// of a live binding through a `TupleIndex` (`..t.0`) — which lowers to an
+// aliasing `TupleFieldLoad`, not a materialising clone — slipped through and
+// reopened the use-after-free. The allowlist admits a base ONLY when it is a
+// bare consume-marked binding or a materialised owner, so EVERY projection of
+// a live binding (field, tuple-index, nested, machine-state) is rejected by
+// construction.
+
+/// `..t.0` override: a `TupleIndex` projection of a live tuple binding. The
+/// overridden owned `label` would be released in place on `t.0` while `t`
+/// stays live — a use-after-free of `t.0.label` and a double-free at `t`'s
+/// scope-exit drop. (The `TupleIndex` use-after-free this fix closes.)
+#[test]
+fn reject_tuple_index_of_live_binding_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+fn main() {
+    let t = (Inner { label: string.repeat("a", 32), n: 1 }, 7);
+    let u = Inner { label: string.repeat("b", 32), ..t.0 };
+    println(u.label);
+    println(t.0.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "tuple-index-of-live-binding base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value"),
+        "expected the fail-closed allowlist NotYetImplemented; got:\n{out}"
+    );
+}
+
+/// `..t.0` carry-only: overrides only the `BitCopy` `n`, CARRIES the owned
+/// `label`. The carry is a shallow `RecordFieldLoad` aliasing `t.0.label`
+/// while `t` stays live — `u` and `t.0` share one buffer, double-freed at
+/// scope exit. Rejected on the base TYPE (owned aggregate), not the overridden
+/// field.
+#[test]
+fn reject_tuple_index_of_live_binding_base_carry_only() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+fn main() {
+    let t = (Inner { label: string.repeat("a", 32), n: 1 }, 7);
+    let u = Inner { n: 5, ..t.0 };
+    println(u.label);
+    println(t.0.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "tuple-index carry-only base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value"),
+        "expected the fail-closed allowlist NotYetImplemented; got:\n{out}"
+    );
+}
+
+/// `..o.pair.0`: a `TupleIndex` reached THROUGH a `FieldAccess` of a live
+/// binding. The projection chain bottoms out at the live `o`, so it aliases
+/// `o.pair.0`'s storage. Rejected fail-closed.
+#[test]
+fn reject_tuple_index_through_field_of_live_binding_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { pair: (Inner, i64), tag: i64 }
+fn main() {
+    let o = Outer { pair: (Inner { label: string.repeat("a", 32), n: 1 }, 7), tag: 9 };
+    let u = Inner { label: string.repeat("b", 32), ..o.pair.0 };
+    println(u.label);
+    println(o.pair.0.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "tuple-index-through-field base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value"),
+        "expected the fail-closed allowlist NotYetImplemented; got:\n{out}"
+    );
+}
+
+/// `..t.0.inner`: a `FieldAccess` reached THROUGH a `TupleIndex` of a live
+/// binding. The chain bottoms out at the live `t`, so it aliases
+/// `t.0.inner`'s storage. Rejected fail-closed.
+#[test]
+fn reject_field_through_tuple_index_of_live_binding_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Mid { inner: Inner, k: i64 }
+fn main() {
+    let t = (Mid { inner: Inner { label: string.repeat("a", 32), n: 1 }, k: 3 }, 7);
+    let u = Inner { label: string.repeat("b", 32), ..t.0.inner };
+    println(u.label);
+    println(t.0.inner.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "field-through-tuple-index base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value"),
+        "expected the fail-closed allowlist NotYetImplemented; got:\n{out}"
+    );
+}
+
+/// `..self.payload`: a machine-state field projection (`MachineFieldAccess`)
+/// inside a reenter transition, where `payload` is an owned record. This is a
+/// SECOND shape the old `FieldAccess`-only denylist missed (`MachineFieldAccess`
+/// is a distinct HIR variant). The projection aliases the live machine state's
+/// payload storage; the override-drop would free it in place. Rejected
+/// fail-closed by the allowlist (which admits only bindings / materialised
+/// owners). A `BitCopy` payload base is exempt (no override-drop) and is NOT
+/// rejected — the destructive base allowlist is type-fenced on the base being
+/// an owned aggregate.
+#[test]
+fn reject_machine_state_field_projection_base() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+machine Holder {
+    events { Bump; }
+    state Empty;
+    state Full { payload: Inner; }
+    on Bump: Empty => Full {
+        Full { payload: Inner { label: string.repeat("a", 32), n: 1 } }
+    }
+    on Bump: Full => Full reenter {
+        Full { payload: Inner { label: string.repeat("b", 32), ..self.payload } }
+    }
+}
+fn main() {
+    var m = Empty;
+    m.step(Bump);
+    m.step(Bump);
+    println(m.state_name());
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "machine-state field projection base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not a binding or owned value") && out.contains("self.field"),
+        "expected the fail-closed allowlist NotYetImplemented naming self.field; got:\n{out}"
     );
 }
 
@@ -376,10 +553,14 @@ fn main() {
     );
 }
 
-/// An INDEXED base (`{ ..v[0], f: new }`): indexing materialises an
-/// independent element value, so the overridden field released in the new
-/// record does not dangle `v[0]`. Must `check` and `run` cleanly, and the
-/// source element stays intact.
+/// An INDEXED base (`{ ..v[0], f: new }`): a `Vec<T>` element load. The
+/// element is independent of any live binding — `hew_vec_push_owned`
+/// deep-clones on insert and the buffer carries its own refcount, so the
+/// override-drop's in-place release decrements a shared count rather than
+/// freeing storage `v[0]` still references. Must `check` and `run` cleanly
+/// with the source element's OWNED `label` left intact (not just the `BitCopy`
+/// `n`). (The external Guard-Malloc matrix is the authoritative oracle; this
+/// reads the owned field under plain malloc as a coarse in-suite check.)
 #[test]
 fn accept_index_of_live_binding_base_runs_clean() {
     require_codegen();
@@ -390,15 +571,80 @@ fn main() {
     let v: Vec<Inner> = Vec::new();
     v.push(Inner { label: string.repeat("a", 32), n: 7 });
     let u = Inner { label: string.repeat("b", 32), ..v[0] };
-    println(u.n);
+    println(u.label);
+    println(v[0].label);
     println(v[0].n);
 }
 "#;
     let (ok, out) = hew_run(source);
     assert!(ok, "indexed base must run cleanly; got:\n{out}");
     assert!(
-        out.matches('7').count() >= 2,
-        "indexed base should carry n=7 and leave v[0] intact; got:\n{out}"
+        out.contains(&"b".repeat(32)),
+        "indexed base should apply the override label; got:\n{out}"
+    );
+    assert!(
+        out.contains(&"a".repeat(32)),
+        "indexed base should leave v[0]'s owned label intact; got:\n{out}"
+    );
+    assert!(
+        out.contains('7'),
+        "indexed base should carry n=7; got:\n{out}"
+    );
+}
+
+/// A projection THROUGH an index (`{ ..o.items[0].inner, f: new }`): the chain
+/// bottoms out at a `Vec` element load, which materialises an independent
+/// owner — NOT an alias of the live binding `o`. Must `check` and `run`
+/// cleanly (the allowlist recurses the projection to the `Index` root).
+#[test]
+fn accept_field_through_index_base_runs_clean() {
+    require_codegen();
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Mid { inner: Inner, k: i64 }
+record Outer { items: Vec<Mid>, tag: i64 }
+fn main() {
+    let v: Vec<Mid> = Vec::new();
+    v.push(Mid { inner: Inner { label: string.repeat("a", 32), n: 7 }, k: 3 });
+    let o = Outer { items: v, tag: 9 };
+    let u = Inner { label: string.repeat("b", 32), ..o.items[0].inner };
+    println(u.label);
+    println(o.items[0].inner.label);
+}
+"#;
+    let (ok, out) = hew_run(source);
+    assert!(ok, "field-through-index base must run cleanly; got:\n{out}");
+    assert!(
+        out.contains(&"a".repeat(32)) && out.contains(&"b".repeat(32)),
+        "field-through-index base should apply override and leave source intact; got:\n{out}"
+    );
+}
+
+/// The `.clone()` escape hatch the reject diagnostic recommends: cloning a
+/// projection of a live binding (`..o.inner.clone()`) materialises a fresh
+/// owned value (`RecordCloneCall`), which the allowlist admits. Must `check`
+/// and `run` cleanly with the source binding left intact — this is the
+/// sanctioned rewrite for the rejected `..o.inner` shape.
+#[test]
+fn accept_clone_of_projection_base_runs_clean() {
+    require_codegen();
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn main() {
+    let o = Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 };
+    let u = Inner { label: string.repeat("b", 32), ..o.inner.clone() };
+    println(u.label);
+    println(o.inner.label);
+}
+"#;
+    let (ok, out) = hew_run(source);
+    assert!(ok, "clone-of-projection base must run cleanly; got:\n{out}");
+    assert!(
+        out.contains(&"a".repeat(32)) && out.contains(&"b".repeat(32)),
+        "clone-of-projection base should apply override and leave source intact; got:\n{out}"
     );
 }
 

--- a/hew-cli/tests/funcupdate_consume_semantics.rs
+++ b/hew-cli/tests/funcupdate_consume_semantics.rs
@@ -1226,7 +1226,7 @@ fn main() {
 // SIGSEGVs / double-frees under Guard Malloc when admitted (empirically
 // reproduced); all must fail `check` fail-closed.
 
-/// 6th hole, unbound: `..id_inner(o.inner)` where `fn id_inner(p) { p }` returns
+/// Unbound: `..id_inner(o.inner)` where `fn id_inner(p) { p }` returns
 /// the borrowed parameter verbatim. The override-drop frees the live
 /// `o.inner.label`.
 #[test]
@@ -1255,7 +1255,7 @@ fn main() {
     );
 }
 
-/// 6th hole, bound: `let b = id_inner(o.inner); ..b`. Binding the laundered
+/// Bound: `let b = id_inner(o.inner); ..b`. Binding the laundered
 /// call result does not change provenance — the prescan classifies `b`'s
 /// definition (a non-fresh call) as not materialised.
 #[test]
@@ -1285,7 +1285,7 @@ fn main() {
     );
 }
 
-/// 7th hole, inline: a `..Wrap { s: p }` base that constructs a record EMBEDDING
+/// Inline: a `..Wrap { s: p }` base that constructs a record EMBEDDING
 /// a whole by-value parameter. The constructor stores the param operand without
 /// a refcount bump, so the constructed base interior-aliases the caller's
 /// argument; the override-drop then frees the live `str0`.
@@ -1316,7 +1316,7 @@ fn main() {
     );
 }
 
-/// 7th hole, bound: `let b = Wrap { s: p, n: 0 }; ..b`. Binding the
+/// Bound: `let b = Wrap { s: p, n: 0 }; ..b`. Binding the
 /// param-embedding constructor first does not launder it — the prescan sees the
 /// `StructInit` definition embeds a whole parameter and rejects.
 #[test]
@@ -1347,7 +1347,7 @@ fn main() {
     );
 }
 
-/// 7th hole, through a call return: `..wrap(o.inner).inner` where `fn wrap(p) {
+/// Through a call return: `..wrap(o.inner).inner` where `fn wrap(p) {
 /// Outer { inner: p, tag: 0 } }` returns a constructor EMBEDDING the borrowed
 /// parameter. The freshness summary classifies `wrap` not-fresh because its
 /// return embeds a parameter, so the projection of its result is not a
@@ -1409,5 +1409,166 @@ fn main() {
     assert!(
         out.contains(&"b".repeat(32)) && out.contains('1') && out.contains(&"q".repeat(4)),
         "interprocedural-fresh base should override label, carry n=1, leave seed live; got:\n{out}"
+    );
+}
+
+// ── reject: hole-8 — closure-capture-return launders a borrowed param ──────
+
+/// A zero-argument closure call returns a by-value heap parameter the closure
+/// CAPTURED (`fn f(p) { let g = || -> Inner { p }; g() }`). The freshness
+/// summary's call channel only saw EXPLICIT arguments, so `..f(o.inner)` — a
+/// call with no visible args — was mistaken for a fresh owner and admitted,
+/// double-freeing `o.inner.label` (Guard-Malloc 3/3). A call whose callee is
+/// not a statically-resolved Item (a closure / fn-value / indirect dispatch)
+/// is now treated as may-alias regardless of args, so the base fails closed.
+#[test]
+fn reject_funcupdate_base_closure_capture_return() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: i64 }
+fn capture_return(p: Inner) -> Inner { let f = || -> Inner { p }; f() }
+fn main() {
+    let o = Outer { inner: Inner { label: string.repeat("a", 32), n: 1 }, tag: 9 };
+    let u = Inner { label: string.repeat("b", 32), ..capture_return(o.inner) };
+    println(u.label);
+    println(o.inner.label);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "closure-capture-return base must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("not provably the unique owner") || out.contains("E_NOT_YET_IMPLEMENTED"),
+        "expected the fail-closed funcupdate base diagnostic; got:\n{out}"
+    );
+}
+
+// ── carry axis: nested owned-record field carried ──────────────────────────
+
+/// Carrying a NON-overridden nested owned-record field (`Outer { tag: new, ..b }`
+/// where `b.inner: Inner` is carried) must `check` and `run` cleanly. Before the
+/// binder-detection fix the carried record's heap leaves were freed twice — once
+/// by the consumed base's in-place drop, once by the result's drop (SIGSEGV,
+/// Guard-Malloc 3/3). `ty_contains_heap_owning` is record-layout blind, so a
+/// nested record was not recognised as a heap-owning binder and the base was
+/// not excluded from its composite drop; unioning `is_owned_aggregate_record_ty`
+/// into the binder predicate closes it. This is the headline correct-carry.
+#[test]
+fn accept_carry_nested_record_field_runs_clean() {
+    require_codegen();
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record Outer { inner: Inner, tag: string }
+fn mk() -> Outer {
+    let b = Outer { inner: Inner { label: string.repeat("i", 32), n: 1 }, tag: string.repeat("x", 32) };
+    Outer { tag: string.repeat("y", 32), ..b }
+}
+fn main() {
+    let r = mk();
+    println(r.tag);
+    println(r.inner.label);
+    println(r.inner.n);
+}
+"#;
+    let (ok, out) = hew_run(source);
+    assert!(ok, "nested-record carry must run cleanly; got:\n{out}");
+    assert!(
+        out.contains(&"y".repeat(32)) && out.contains(&"i".repeat(32)) && out.contains('1'),
+        "carry must override tag, preserve the carried record's label and n; got:\n{out}"
+    );
+}
+
+// ── carry axis: fail-closed for owned field types without a sound shallow carry
+
+/// Carrying a closure / `fn`-typed field (`Boxx { tag: new, ..b }` where
+/// `b.cb: fn() -> string` is carried) must FAIL `hew check` fail-closed. The
+/// closure pair is a heap-boxed capture env with no retain/release carry spine,
+/// so the consumed base's drop and the result's drop both released it — a
+/// double-free at teardown even when the closure captured a FRESH local
+/// (Guard-Malloc 3/3). Fail-closed is the floor until the env carry spine lands.
+#[test]
+fn reject_carry_closure_field() {
+    let source = r#"
+import std::string;
+record Boxx { tag: string, cb: fn() -> string }
+fn upd(p: string) -> Boxx {
+    let b = Boxx { tag: string.repeat("x", 32), cb: || -> string { p } };
+    Boxx { tag: string.repeat("y", 32), ..b }
+}
+fn main() {
+    let s = string.repeat("a", 32);
+    let r = upd(s);
+    println(r.tag);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "closure-field carry must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("carry of owned non-record field") || out.contains("E_NOT_YET_IMPLEMENTED"),
+        "expected the fail-closed carry diagnostic; got:\n{out}"
+    );
+}
+
+/// Carrying a tuple-of-owned field must FAIL `hew check` fail-closed: a
+/// `(string, i64)` tuple has no single inline-drop leaf symbol and is not an
+/// owned user record, so the shallow carry has no proven-sound transfer path.
+#[test]
+fn reject_carry_tuple_of_owned_field() {
+    let source = r#"
+import std::string;
+record T { pair: (string, i64), tag: string }
+fn mk() -> T {
+    let b = T { pair: (string.repeat("k", 32), 7), tag: string.repeat("x", 32) };
+    T { tag: string.repeat("y", 32), ..b }
+}
+fn main() {
+    let r = mk();
+    println(r.tag);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "tuple-of-owned carry must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("carry of owned non-record field") || out.contains("E_NOT_YET_IMPLEMENTED"),
+        "expected the fail-closed carry diagnostic; got:\n{out}"
+    );
+}
+
+/// Carrying an `Option<owned-record>` field must FAIL `hew check` fail-closed:
+/// an enum-shaped owned composite has no single inline-drop leaf symbol and is
+/// not a bare owned user record, so the shallow carry fails closed.
+#[test]
+fn reject_carry_option_of_owned_field() {
+    let source = r#"
+import std::string;
+record Inner { label: string, n: i64 }
+record O { maybe: Option<Inner>, tag: string }
+fn mk() -> O {
+    let b = O { maybe: Some(Inner { label: string.repeat("k", 32), n: 1 }), tag: string.repeat("x", 32) };
+    O { tag: string.repeat("y", 32), ..b }
+}
+fn main() {
+    let r = mk();
+    println(r.tag);
+}
+"#;
+    let (ok, out) = hew_check(source);
+    assert!(
+        !ok,
+        "Option-of-owned carry must fail check; got success:\n{out}"
+    );
+    assert!(
+        out.contains("carry of owned non-record field") || out.contains("E_NOT_YET_IMPLEMENTED"),
+        "expected the fail-closed carry diagnostic; got:\n{out}"
     );
 }

--- a/hew-cli/tests/funcupdate_owned_field_drop_leak_oracle.rs
+++ b/hew-cli/tests/funcupdate_owned_field_drop_leak_oracle.rs
@@ -1,11 +1,10 @@
 //! Functional-update owned-field drop leak oracle.
 //!
 //! Exercises `{ ..base, field: new_value }` where `field` is an owned
-//! heap type (`string`, `bytes`, `Vec<T>`).
+//! heap type (`string`, `bytes`, `Vec<T>`, `HashMap`, `HashSet`).
 //!
 //! Before the fix (the functional-update overridden-owned-field leak in
-//! `hew-mir/src/lower.rs` — NOT GitHub issue #14, which is unrelated), every
-//! iteration of a
+//! `hew-mir/src/lower.rs`), every iteration of a
 //! `{ ..base, label: new_string }` loop that overrides a heap-owning field
 //! leaked exactly ONE allocation node (the old value of `label` from
 //! `base` was never released — the new record owned the replacement, the
@@ -15,10 +14,18 @@
 //! After the fix, the functional-update arm emits, before the `RecordInit`:
 //!
 //! 1. `RecordFieldDrop { record: base, field_offset: N, … }` for every
-//!    single-pointer COW field (`string`, `Vec<T>`, `HashMap`, `HashSet`,
-//!    `Generator`): raw load → release → null-store.
+//!    single-pointer COW field (`string`, `Vec<T>`, `HashMap`, `HashSet`):
+//!    raw load → release → null-store.
 //! 2. `RecordFieldLoad + Instr::Drop` for the fat `bytes` `{ptr,len,cap}`
 //!    triple, whose destructor takes the whole by-value value.
+//!
+//! `Generator` is also a single-pointer COW field handled by
+//! `RecordFieldDrop`, but a *functional update* can never reach one: a record
+//! carrying a `Generator` field is front-stopped before this lowering by
+//! record-clone-thunk synthesis (the coroutine handle has no per-field `dup`
+//! symbol). The `hew_gen_coro_destroy` override-drop arm is therefore
+//! exercised out of band (via tuple/enum match-destructure), not by this
+//! oracle, and is deliberately NOT claimed here.
 //!
 //! …so every replaced owned value is released at the construction site on
 //! every execution path. The release is sound because `..base` consumes the
@@ -33,6 +40,10 @@
 //!   the `hew_bytes_drop` inline-drop arm is correctly selected.
 //! * **Vec<i64> field** — override a plain `Vec<i64>` field (no owned
 //!   elements); exercises `hew_vec_free`.
+//! * **`HashMap` field** — override a `HashMap<string,i64>` field; exercises
+//!   the `hew_hashmap_free_layout` single-pointer COW release.
+//! * **`HashSet` field** — override a `HashSet<i64>` field; exercises the
+//!   `hew_hashset_free_layout` single-pointer COW release.
 //! * **multi-field** — override a `string` AND a `Vec<i64>` in the same
 //!   update expression; each must be independently released.
 //!
@@ -140,6 +151,62 @@ fn vec_field_source(frames: usize) -> String {
          \x20       let next: Vec<i64> = Vec::new();\n\
          \x20       next.push(i);\n\
          \x20       h = VecHolder {{ items: next, ..h }};\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   h.tag\n\
+         }}\n"
+    )
+}
+
+/// Functional update overriding a `HashMap<string,i64>` field in a loop.
+///
+/// Each iteration replaces `m` with a fresh map allocation.
+/// Pre-fix: one leaked HashMap-control node per iteration.
+/// Post-fix: the old `m` is released via `hew_hashmap_free_layout`.
+fn hashmap_field_source(frames: usize) -> String {
+    format!(
+        "record MapHolder {{\n\
+         \x20   m: HashMap<string, i64>,\n\
+         \x20   tag: i64,\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let init: HashMap<string, i64> = HashMap::new();\n\
+         \x20   init.insert(\"seed\", 1);\n\
+         \x20   var h = MapHolder {{ m: init, tag: 0 }};\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let next: HashMap<string, i64> = HashMap::new();\n\
+         \x20       next.insert(\"k\", i);\n\
+         \x20       h = MapHolder {{ m: next, ..h }};\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   h.tag\n\
+         }}\n"
+    )
+}
+
+/// Functional update overriding a `HashSet<i64>` field in a loop.
+///
+/// Each iteration replaces `s` with a fresh set allocation.
+/// Pre-fix: one leaked HashSet-control node per iteration.
+/// Post-fix: the old `s` is released via `hew_hashset_free_layout`.
+fn hashset_field_source(frames: usize) -> String {
+    format!(
+        "record SetHolder {{\n\
+         \x20   s: HashSet<i64>,\n\
+         \x20   tag: i64,\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let init: HashSet<i64> = HashSet::<i64>::new();\n\
+         \x20   init.insert(99);\n\
+         \x20   var h = SetHolder {{ s: init, tag: 0 }};\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let next: HashSet<i64> = HashSet::<i64>::new();\n\
+         \x20       next.insert(i);\n\
+         \x20       h = SetHolder {{ s: next, ..h }};\n\
          \x20       i = i + 1;\n\
          \x20   }}\n\
          \x20   h.tag\n\
@@ -349,6 +416,20 @@ fn funcupdate_bytes_field_no_per_frame_leak_slope() {
 #[test]
 fn funcupdate_vec_field_no_per_frame_leak_slope() {
     assert_frame_slope_below_tolerance("funcupdate_vec_field", vec_field_source);
+}
+
+/// `HashMap<string,i64>` field override: pre-fix slope ~1.0 node/frame
+/// (one leaked map-control node per iteration); post-fix slope 0.
+#[test]
+fn funcupdate_hashmap_field_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance("funcupdate_hashmap_field", hashmap_field_source);
+}
+
+/// `HashSet<i64>` field override: pre-fix slope ~1.0 node/frame (one
+/// leaked set-control node per iteration); post-fix slope 0.
+#[test]
+fn funcupdate_hashset_field_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance("funcupdate_hashset_field", hashset_field_source);
 }
 
 /// Multi-field override (`string` + `Vec<i64>`): pre-fix slope ~2.0

--- a/hew-cli/tests/funcupdate_owned_field_drop_leak_oracle.rs
+++ b/hew-cli/tests/funcupdate_owned_field_drop_leak_oracle.rs
@@ -1,0 +1,359 @@
+//! Functional-update owned-field drop leak oracle.
+//!
+//! Exercises `{ ..base, field: new_value }` where `field` is an owned
+//! heap type (`string`, `bytes`, `Vec<T>`).
+//!
+//! Before the fix (the functional-update overridden-owned-field leak in
+//! `hew-mir/src/lower.rs` — NOT GitHub issue #14, which is unrelated), every
+//! iteration of a
+//! `{ ..base, label: new_string }` loop that overrides a heap-owning field
+//! leaked exactly ONE allocation node (the old value of `label` from
+//! `base` was never released — the new record owned the replacement, the
+//! base's composite drop was suppressed by `derive_owned_record_drop_allowed`,
+//! but the overridden field's old allocation was abandoned).
+//!
+//! After the fix, the functional-update arm emits, before the `RecordInit`:
+//!
+//! 1. `RecordFieldDrop { record: base, field_offset: N, … }` for every
+//!    single-pointer COW field (`string`, `Vec<T>`, `HashMap`, `HashSet`,
+//!    `Generator`): raw load → release → null-store.
+//! 2. `RecordFieldLoad + Instr::Drop` for the fat `bytes` `{ptr,len,cap}`
+//!    triple, whose destructor takes the whole by-value value.
+//!
+//! …so every replaced owned value is released at the construction site on
+//! every execution path. The release is sound because `..base` consumes the
+//! base (the move-checker rejects any later read), so the freed old value has
+//! no surviving reader.
+//!
+//! ## Shape coverage
+//!
+//! * **string field** — the most common override case; pre-fix slope ~1.0
+//!   node/frame.
+//! * **bytes field** — override a `bytes` field in a local loop; verifies
+//!   the `hew_bytes_drop` inline-drop arm is correctly selected.
+//! * **Vec<i64> field** — override a plain `Vec<i64>` field (no owned
+//!   elements); exercises `hew_vec_free`.
+//! * **multi-field** — override a `string` AND a `Vec<i64>` in the same
+//!   update expression; each must be independently released.
+//!
+//! ## Slope methodology
+//!
+//! Mirrors `bytes_drop_leak_oracle.rs`: compile the same shape at LOW
+//! and HIGH frame counts, measure leak NODE counts under `leaks --atExit`
+//! with the poisoned-allocator triple (`MallocScribble` et al.), and assert
+//! the delta stays within `SLOPE_TOLERANCE` nodes regardless of frame count.
+//!
+//! macOS-only: the `leaks(1)` allocator inspector is a Darwin tool.  The
+//! oracle skips (with an explanatory message) when `leaks` is unavailable.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+/// Low frame count: stays close to the constant-overhead floor.
+const LOW_FRAMES: usize = 3;
+
+/// High frame count for the slope check.  A slope of 1.0 leak/frame
+/// (pre-fix measurement) produces `50 - 3 = 47` excess nodes against
+/// the tolerance of `5`.
+const HIGH_FRAMES: usize = 50;
+
+/// Maximum permitted leak-node delta between the HIGH and LOW probes.
+const SLOPE_TOLERANCE: usize = 5;
+
+// ── fixture sources ──────────────────────────────────────────────────────
+
+/// Functional update overriding a `string` field in a plain local loop.
+///
+/// `label` is replaced each iteration with a fresh `hew_string_repeat`
+/// allocation.  Pre-fix: one leaked `cstring` node per iteration.
+/// Post-fix: the old `label` is released via `hew_string_drop` before
+/// the new record is built.
+fn string_field_source(frames: usize) -> String {
+    format!(
+        "import std::string;\n\
+         \n\
+         record Cfg {{\n\
+         \x20   label: string,\n\
+         \x20   count: i64,\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var c = Cfg {{ label: string.repeat(\"a\", 32), count: 0 }};\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       c = Cfg {{ label: string.repeat(\"b\", 32), ..c }};\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   c.count\n\
+         }}\n"
+    )
+}
+
+/// Functional update overriding a `bytes` field in a local loop.
+///
+/// Each iteration replaces `buf` with a fresh `to_bytes()` allocation.
+/// Pre-fix: one leaked bytes-buffer node per iteration.
+/// Post-fix: the old `buf` is released via `hew_bytes_drop`.
+fn bytes_field_source(frames: usize) -> String {
+    format!(
+        "record ByteHolder {{\n\
+         \x20   buf: bytes,\n\
+         \x20   count: i64,\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var h = ByteHolder {{ buf: \"initial\".to_bytes(), count: 0 }};\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       h = ByteHolder {{ buf: \"loop-payload\".to_bytes(), ..h }};\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   h.count\n\
+         }}\n"
+    )
+}
+
+/// Functional update overriding a `Vec<i64>` field in a local loop.
+///
+/// Each iteration replaces `items` with a fresh Vec allocation.
+/// Pre-fix: one leaked Vec-header node per iteration.
+/// Post-fix: the old `items` is released via `hew_vec_free`.
+fn vec_field_source(frames: usize) -> String {
+    format!(
+        "record VecHolder {{\n\
+         \x20   items: Vec<i64>,\n\
+         \x20   tag: i64,\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let init: Vec<i64> = Vec::new();\n\
+         \x20   init.push(99);\n\
+         \x20   var h = VecHolder {{ items: init, tag: 0 }};\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let next: Vec<i64> = Vec::new();\n\
+         \x20       next.push(i);\n\
+         \x20       h = VecHolder {{ items: next, ..h }};\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   h.tag\n\
+         }}\n"
+    )
+}
+
+/// Functional update overriding both a `string` AND a `Vec<i64>` field.
+///
+/// Pre-fix: two leaked nodes per iteration (one per overridden field).
+/// Post-fix: both fields independently released before `RecordInit`.
+fn multi_field_source(frames: usize) -> String {
+    format!(
+        "import std::string;\n\
+         \n\
+         record Multi {{\n\
+         \x20   label: string,\n\
+         \x20   items: Vec<i64>,\n\
+         \x20   id: i64,\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let init: Vec<i64> = Vec::new();\n\
+         \x20   init.push(0);\n\
+         \x20   var m = Multi {{ label: string.repeat(\"z\", 16), items: init, id: 0 }};\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let next: Vec<i64> = Vec::new();\n\
+         \x20       next.push(i);\n\
+         \x20       m = Multi {{ label: string.repeat(\"y\", 16), items: next, ..m }};\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   m.id\n\
+         }}\n"
+    )
+}
+
+// ── plumbing (same shape as bytes_drop_leak_oracle) ───────────────────────
+
+/// Compile `source` to a native binary via `hew compile --emit-dir` and
+/// return the binary path.
+fn compile_to_native(source: &str, dir: &std::path::Path, name: &str) -> PathBuf {
+    let hew_src = dir.join(format!("{name}.hew"));
+    std::fs::write(&hew_src, source).expect("write hew source");
+
+    let output = Command::new(hew_binary())
+        .args([
+            "compile",
+            "--emit-dir",
+            dir.to_str().expect("emit-dir utf-8"),
+            hew_src.to_str().expect("hew src utf-8"),
+        ])
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew compile");
+
+    assert!(
+        output.status.success(),
+        "hew compile failed for {name}:\n{}",
+        describe_output(&output)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let bin = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("native: "))
+        .unwrap_or_else(|| panic!("no `native:` line for {name}:\n{stdout}"))
+        .to_string();
+    PathBuf::from(bin)
+}
+
+/// Run `bin` under the poisoned-allocator triple + `leaks --atExit` and
+/// return `Some(leak_count)` when `leaks` produced a usable report.
+fn measure_leaks(bin: &std::path::Path) -> Option<usize> {
+    let output = Command::new("leaks")
+        .arg("--atExit")
+        .arg("--")
+        .arg(bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .ok()?;
+    if !output.status.success() && output.stdout.is_empty() {
+        eprintln!(
+            "skip: leaks declined to attach to {}: {}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+    let report = String::from_utf8_lossy(&output.stdout);
+    let mut parsed: Option<usize> = None;
+    for line in report.lines() {
+        if !line.contains(" leaks for ") && !line.contains(" leak for ") {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("Process ") {
+            if !rest.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+                continue;
+            }
+            if let Some(after_colon) = rest.split_once(": ").map(|(_, s)| s) {
+                if let Some(n) = after_colon.split_whitespace().next() {
+                    if let Ok(n) = n.parse::<usize>() {
+                        eprintln!("  parsed leak count from line: {line}");
+                        parsed = Some(n);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    if parsed.is_none() {
+        eprintln!(
+            "skip: leaks did not emit a `Process <pid>: N leak(s) ...` summary for {}: \
+             stderr=\n{}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    parsed
+}
+
+/// Build the shape at LOW and HIGH frame counts, measure leak NODE
+/// counts, and assert the delta stays within `SLOPE_TOLERANCE`.
+fn assert_frame_slope_below_tolerance(shape_name: &str, source_fn: fn(usize) -> String) {
+    if !cfg!(target_os = "macos") {
+        eprintln!("skip: {shape_name}: leaks(1) is macOS-only");
+        return;
+    }
+    let leaks_avail = Command::new("which")
+        .arg("leaks")
+        .output()
+        .is_ok_and(|o| o.status.success());
+    if !leaks_avail {
+        eprintln!("skip: {shape_name}: `leaks` binary not on PATH");
+        return;
+    }
+
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("funcupdate-leak-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+
+    let bin_low = compile_to_native(
+        &source_fn(LOW_FRAMES),
+        dir.path(),
+        &format!("{shape_name}_low"),
+    );
+    let bin_high = compile_to_native(
+        &source_fn(HIGH_FRAMES),
+        dir.path(),
+        &format!("{shape_name}_high"),
+    );
+
+    let Some(low_leaks) = measure_leaks(&bin_low) else {
+        return;
+    };
+    let Some(high_leaks) = measure_leaks(&bin_high) else {
+        return;
+    };
+
+    eprintln!(
+        "{shape_name}: low_frames={LOW_FRAMES} low_leaks={low_leaks} \
+         high_frames={HIGH_FRAMES} high_leaks={high_leaks} \
+         tolerance={SLOPE_TOLERANCE}"
+    );
+    assert!(
+        high_leaks <= low_leaks + SLOPE_TOLERANCE,
+        "{shape_name}: per-frame leak SLOPE — low_frames={LOW_FRAMES} low_leaks={low_leaks}, \
+         high_frames={HIGH_FRAMES} high_leaks={high_leaks}. Excess of {} NODES over the \
+         tolerance of {SLOPE_TOLERANCE} indicates the old field value is not being released \
+         at the functional-update site (pre-fix slope: ~1 node/frame per overridden owned \
+         field). Re-run with `MallocStackLogging=1 leaks --atExit -- {}` to identify the \
+         leaked stack.",
+        high_leaks.saturating_sub(low_leaks + SLOPE_TOLERANCE),
+        bin_high.display()
+    );
+    assert!(
+        high_leaks + SLOPE_TOLERANCE >= low_leaks,
+        "{shape_name}: HIGH leak count is more than {SLOPE_TOLERANCE} below LOW \
+         (low={low_leaks}, high={high_leaks}) — the binary did not finish before \
+         `leaks --atExit` snapshotted. Increase the iteration count."
+    );
+}
+
+// ── oracles ───────────────────────────────────────────────────────────────
+
+/// `string` field override: pre-fix slope ~1.0 node/frame (one leaked
+/// `cstring` buffer per iteration); post-fix slope 0.
+#[test]
+fn funcupdate_string_field_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance("funcupdate_string_field", string_field_source);
+}
+
+/// `bytes` field override: pre-fix slope ~1.0 node/frame (one leaked
+/// `BytesTriple` data-ptr per iteration); post-fix slope 0.
+#[test]
+fn funcupdate_bytes_field_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance("funcupdate_bytes_field", bytes_field_source);
+}
+
+/// `Vec<i64>` field override: pre-fix slope ~1.0 node/frame (one leaked
+/// Vec header per iteration); post-fix slope 0.
+#[test]
+fn funcupdate_vec_field_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance("funcupdate_vec_field", vec_field_source);
+}
+
+/// Multi-field override (`string` + `Vec<i64>`): pre-fix slope ~2.0
+/// nodes/frame (two leaked allocations per iteration); post-fix slope 0.
+#[test]
+fn funcupdate_multi_field_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance("funcupdate_multi_field", multi_field_source);
+}

--- a/hew-cli/tests/funcupdate_owned_field_drop_leak_oracle.rs
+++ b/hew-cli/tests/funcupdate_owned_field_drop_leak_oracle.rs
@@ -244,6 +244,159 @@ fn multi_field_source(frames: usize) -> String {
     )
 }
 
+// ── carry-axis sources ─────────────────────────────────────────────────────
+//
+// Every override source above CARRIES only a BitCopy (`count` / `tag` / `id`)
+// field — the coverage gap that let the carried-record SIGSEGV and the
+// carried-closure double-free ship while the prior suites passed. These
+// sources invert the axis: each OVERRIDES a churn `string` and CARRIES the
+// owned field under test every frame, so a per-frame leak in the carry path
+// (the consumed base's field not transferred, or transferred without the base
+// excluded from its composite drop) shows as slope. Slope-0 confirms the
+// carried field is moved exactly once per frame.
+
+/// Carry a nested owned-RECORD field while churning a `string`.
+fn carry_record_field_source(frames: usize) -> String {
+    format!(
+        "import std::string;\n\
+         \n\
+         record Inner {{\n\
+         \x20   label: string,\n\
+         \x20   n: i64,\n\
+         }}\n\
+         record Pair {{\n\
+         \x20   keep: Inner,\n\
+         \x20   churn: string,\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var p = Pair {{ keep: Inner {{ label: string.repeat(\"k\", 32), n: 1 }}, churn: string.repeat(\"a\", 32) }};\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       p = Pair {{ churn: string.repeat(\"b\", 32), ..p }};\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   p.keep.n\n\
+         }}\n"
+    )
+}
+
+/// Carry a `string` field while churning a different `string` field.
+fn carry_string_field_source(frames: usize) -> String {
+    format!(
+        "import std::string;\n\
+         \n\
+         record Pair {{\n\
+         \x20   keep: string,\n\
+         \x20   churn: string,\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var p = Pair {{ keep: string.repeat(\"k\", 32), churn: string.repeat(\"a\", 32) }};\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       p = Pair {{ churn: string.repeat(\"b\", 32), ..p }};\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   p.keep.len()\n\
+         }}\n"
+    )
+}
+
+/// Carry a `Vec<string>` (owned-element) field while churning a `string`.
+fn carry_vec_field_source(frames: usize) -> String {
+    format!(
+        "import std::string;\n\
+         \n\
+         record Pair {{\n\
+         \x20   keep: Vec<string>,\n\
+         \x20   churn: string,\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let v: Vec<string> = Vec::new();\n\
+         \x20   v.push(string.repeat(\"k\", 32));\n\
+         \x20   var p = Pair {{ keep: v, churn: string.repeat(\"a\", 32) }};\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       p = Pair {{ churn: string.repeat(\"b\", 32), ..p }};\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   p.keep.len()\n\
+         }}\n"
+    )
+}
+
+/// Carry a `HashMap<string,string>` field while churning a `string`.
+fn carry_hashmap_field_source(frames: usize) -> String {
+    format!(
+        "import std::string;\n\
+         \n\
+         record Pair {{\n\
+         \x20   keep: HashMap<string, string>,\n\
+         \x20   churn: string,\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let m: HashMap<string, string> = HashMap::new();\n\
+         \x20   m.insert(string.repeat(\"k\", 32), string.repeat(\"v\", 32));\n\
+         \x20   var p = Pair {{ keep: m, churn: string.repeat(\"a\", 32) }};\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       p = Pair {{ churn: string.repeat(\"b\", 32), ..p }};\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   p.keep.len()\n\
+         }}\n"
+    )
+}
+
+/// Carry a `HashSet<string>` field while churning a `string`.
+fn carry_hashset_field_source(frames: usize) -> String {
+    format!(
+        "import std::string;\n\
+         \n\
+         record Pair {{\n\
+         \x20   keep: HashSet<string>,\n\
+         \x20   churn: string,\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let s: HashSet<string> = HashSet::new();\n\
+         \x20   s.insert(string.repeat(\"k\", 32));\n\
+         \x20   var p = Pair {{ keep: s, churn: string.repeat(\"a\", 32) }};\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       p = Pair {{ churn: string.repeat(\"b\", 32), ..p }};\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   p.keep.len()\n\
+         }}\n"
+    )
+}
+
+/// Carry a `bytes` field while churning a `string`.
+fn carry_bytes_field_source(frames: usize) -> String {
+    format!(
+        "import std::string;\n\
+         \n\
+         record Pair {{\n\
+         \x20   keep: bytes,\n\
+         \x20   churn: string,\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var p = Pair {{ keep: string.repeat(\"k\", 32).to_bytes(), churn: string.repeat(\"a\", 32) }};\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       p = Pair {{ churn: string.repeat(\"b\", 32), ..p }};\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   p.keep.len()\n\
+         }}\n"
+    )
+}
+
 // ── plumbing (same shape as bytes_drop_leak_oracle) ───────────────────────
 
 /// Compile `source` to a native binary via `hew compile --emit-dir` and
@@ -437,4 +590,53 @@ fn funcupdate_hashset_field_no_per_frame_leak_slope() {
 #[test]
 fn funcupdate_multi_field_no_per_frame_leak_slope() {
     assert_frame_slope_below_tolerance("funcupdate_multi_field", multi_field_source);
+}
+
+// ── carry-axis oracles (coverage-gap closure) ──────────────────────────────
+
+/// Carried nested owned-RECORD field: pre-fix this SIGSEGV'd on the
+/// double-freed carried record; post-fix the carry transfers it once per
+/// frame — slope 0.
+#[test]
+fn funcupdate_carry_record_field_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance("funcupdate_carry_record_field", carry_record_field_source);
+}
+
+/// Carried `string` field (the retain-vs-exclude question): the
+/// carried string is moved once per frame, not retained-without-release —
+/// slope 0.
+#[test]
+fn funcupdate_carry_string_field_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance("funcupdate_carry_string_field", carry_string_field_source);
+}
+
+/// Carried `Vec<string>` (owned-element) field: moved once per frame, slope 0.
+#[test]
+fn funcupdate_carry_vec_field_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance("funcupdate_carry_vec_field", carry_vec_field_source);
+}
+
+/// Carried `HashMap<string,string>` field: moved once per frame, slope 0.
+#[test]
+fn funcupdate_carry_hashmap_field_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "funcupdate_carry_hashmap_field",
+        carry_hashmap_field_source,
+    );
+}
+
+/// Carried `HashSet<string>` field: moved once per frame, slope 0.
+#[test]
+fn funcupdate_carry_hashset_field_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "funcupdate_carry_hashset_field",
+        carry_hashset_field_source,
+    );
+}
+
+/// Carried `bytes` field: the fat `{ptr,len,cap}` triple is moved once per
+/// frame, slope 0.
+#[test]
+fn funcupdate_carry_bytes_field_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance("funcupdate_carry_bytes_field", carry_bytes_field_source);
 }

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -4537,13 +4537,14 @@ pub(crate) fn primitive_to_llvm<'ctx>(
                 Some(hew_types::BuiltinType::Generator | hew_types::BuiltinType::AsyncGenerator),
             ..
         } => {
-            // A `Generator<Yield, Return>` value is the thread-based generator
-            // context handle `*mut HewGenCtx`, returned by `hew_gen_ctx_create`
-            // and released by `hew_gen_free`. Codegen materialises the slot as a
+            // A `Generator<Yield, Return>` value is the heap companion of an
+            // `llvm.coro` switched-resume coroutine — `{ handle, env,
+            // out_drop_thunk, started, pending, out }` — released by
+            // `hew_gen_coro_destroy`. Codegen materialises the slot as a
             // bare opaque `ptr`, the same representation used for every other
             // runtime handle (Duplex, Vec, HewTask, CancellationToken). The
-            // construction site stores the `hew_gen_ctx_create` result here;
-            // `.next()` loads it to drive `hew_gen_next`.
+            // construction site stores the companion pointer here; `.next()`
+            // loads it to drive the coroutine (`hew_cont_resume` / `hew_cont_poll`).
             //
             // Dispatched on the `builtin` discriminant, NOT the `name` string: a
             // user-declared `type Generator { ... }` resolves to
@@ -42120,6 +42121,63 @@ mod tests {
         assert_eq!(
             cow_heap_release_symbol(&fn_ctx, &owned_vec),
             Some("hew_vec_free_owned")
+        );
+    }
+
+    /// A `Vec` whose element is a `fn` / closure releases via
+    /// `hew_vec_free_closure_pairs` (each slot owns a heap pair-box + env box),
+    /// checked BEFORE the owned-element and plain arms. This must match the MIR
+    /// authority `project_field_inline_drop_symbol`: when the two disagreed,
+    /// the closure-pair Vec routed to a `RecordFieldDrop` whose `drop_fn`
+    /// (`hew_vec_free`) failed the codegen congruence assert
+    /// (`cow_heap_release_symbol` expected `hew_vec_free_closure_pairs`) — a
+    /// fail-closed hard error on a previously-leaking shape. Pin both the
+    /// dispatch and that the symbol is in the permitted closed set.
+    #[test]
+    fn cow_heap_release_symbol_routes_closure_pair_vec() {
+        let ctx = Context::create();
+        let llvm_mod = ctx.create_module("cow_heap_release_closure_pair_test");
+        let harness = build_harness(&ctx, &[], &[]);
+        let fn_ctx = make_test_fn_ctx(&ctx, &llvm_mod, &harness, "cow_heap_closure_pair_probe");
+
+        // `Vec<fn() -> ()>` — a bare function element.
+        let vec_of_fn = ResolvedTy::Named {
+            name: "Vec".to_string(),
+            args: vec![ResolvedTy::Function {
+                params: vec![],
+                ret: Box::new(ResolvedTy::Unit),
+            }],
+            builtin: Some(hew_types::BuiltinType::Vec),
+            is_opaque: false,
+        };
+        assert_eq!(
+            cow_heap_release_symbol(&fn_ctx, &vec_of_fn),
+            Some("hew_vec_free_closure_pairs"),
+            "a `Vec<fn>` element must release via the closure-pair ABI"
+        );
+
+        // `Vec<closure>` — a capturing closure element.
+        let vec_of_closure = ResolvedTy::Named {
+            name: "Vec".to_string(),
+            args: vec![ResolvedTy::Closure {
+                params: vec![ResolvedTy::I64],
+                ret: Box::new(ResolvedTy::I64),
+                captures: vec![ResolvedTy::String],
+            }],
+            builtin: Some(hew_types::BuiltinType::Vec),
+            is_opaque: false,
+        };
+        assert_eq!(
+            cow_heap_release_symbol(&fn_ctx, &vec_of_closure),
+            Some("hew_vec_free_closure_pairs"),
+            "a `Vec<closure>` element must release via the closure-pair ABI"
+        );
+
+        // The closure-pair symbol must be admitted by the closed congruence set
+        // codegen validates RecordFieldDrop / inline-Drop symbols against.
+        assert!(
+            is_known_cow_heap_drop_symbol("hew_vec_free_closure_pairs"),
+            "hew_vec_free_closure_pairs must be in the permitted CowHeap release set"
         );
     }
 

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -13726,6 +13726,15 @@ fn lower_instruction(
             lower_record_field_load(fn_ctx, *record, *field_offset, *dest)?;
             let _ = ctx;
         }
+        Instr::RecordFieldDrop {
+            record,
+            field_offset,
+            ty,
+            drop_fn,
+        } => {
+            lower_record_field_drop(fn_ctx, *record, *field_offset, ty, drop_fn)?;
+            let _ = ctx;
+        }
         Instr::RecordFieldStore {
             record,
             field_offset,
@@ -14528,6 +14537,134 @@ fn lower_record_field_load(
         .builder
         .build_store(dest_ptr, field_val)
         .llvm_ctx_with(|| format!("RecordFieldLoad field {idx} store"))?;
+    Ok(())
+}
+
+/// Release an owned record field in-place without retaining it first.
+///
+/// Emits: GEP to the field slot → raw load (no `hew_string_clone` retain) →
+/// call `drop_fn` release symbol → null-store the field slot.
+///
+/// Unlike `lower_record_field_load`, which always retains `string`-typed fields
+/// via `hew_string_clone` (to avoid aliasing the parent record's buffer), this
+/// function loads the raw pointer directly.  That makes it correct for the
+/// functional-update pre-drop case: the field being dropped is the sole owner of
+/// its heap data (rc == 1), so calling the release symbol drives the refcount to
+/// zero and frees the allocation.
+///
+/// ## Safety precondition
+///
+/// The caller (MIR `RecordFieldDrop` emitter) is responsible for ensuring the
+/// record field is a sole owner at the instruction's execution point.  Dropping
+/// a shared field (rc > 1) via this path would incorrectly decrement the
+/// refcount below the expected floor.
+///
+/// ## Supported field types
+///
+/// Only `DropFnSpec::Release` COW-heap scalar fields (string, Vec, HashMap,
+/// HashSet, Generator) are handled here.  `bytes` fields use the
+/// `RecordFieldLoad` + `Instr::Drop` path (which doesn't retain for bytes)
+/// and are not dispatched to this function.  Arriving with an unsupported
+/// `drop_fn` variant fails closed.
+fn lower_record_field_drop(
+    fn_ctx: &FnCtx<'_, '_>,
+    record: Place,
+    field_offset: hew_mir::FieldOffset,
+    ty: &ResolvedTy,
+    drop_fn: &hew_mir::DropFnSpec,
+) -> CodegenResult<()> {
+    let hew_mir::DropFnSpec::Release(symbol) = drop_fn else {
+        return Err(CodegenError::FailClosed(format!(
+            "RecordFieldDrop only supports DropFnSpec::Release; got {drop_fn:?}. \
+             RecordFieldDrop is emitted exclusively by functional-update lowering \
+             for COW-heap scalar fields (LESSONS: boundary-fail-closed)"
+        )));
+    };
+    // Validate symbol/type congruence before emitting any call. If the MIR
+    // emitter drifted from the codegen table, fail loudly rather than silently
+    // calling an unrelated release function (LESSONS: boundary-fail-closed,
+    // dedup-semantic-boundary).
+    if cow_heap_release_symbol(fn_ctx, ty) != Some(symbol) {
+        return Err(CodegenError::FailClosed(format!(
+            "RecordFieldDrop @ field[{idx}]: drop_fn=Release({symbol:?}) is \
+             incongruent with field type {ty:?} (expected release symbol \
+             {expected:?}); refusing to emit (LESSONS: boundary-fail-closed)",
+            idx = field_offset.0,
+            expected = cow_heap_release_symbol(fn_ctx, ty),
+        )));
+    }
+    let (record_ptr, record_slot_ty) = place_pointer(fn_ctx, record)?;
+    let struct_ty = match record_slot_ty {
+        BasicTypeEnum::StructType(st) => st,
+        other => {
+            return Err(CodegenError::FailClosed(format!(
+                "RecordFieldDrop record place has non-struct slot type: {other:?}"
+            )));
+        }
+    };
+    let idx = field_offset.0;
+    let idx_usize = usize::try_from(idx).map_err(|_| {
+        CodegenError::FailClosed(format!(
+            "RecordFieldDrop field offset {idx} exceeds usize::MAX — impossible"
+        ))
+    })?;
+    let element_tys = struct_ty.get_field_types();
+    if idx_usize >= element_tys.len() {
+        return Err(CodegenError::FailClosed(format!(
+            "RecordFieldDrop field offset {idx} is out of bounds for struct with \
+             {} fields",
+            element_tys.len()
+        )));
+    }
+    // Field-slot-is-pointer guard. The raw load below reads the slot as a single
+    // pointer (`ptr_ty` → `into_pointer_value`) and hands it to a COW-heap
+    // release symbol. That is only valid when the field slot IS one pointer.
+    // The MIR emitter routes exactly the single-pointer COW types here
+    // (`field_override_uses_record_field_drop`: string / Vec / HashMap / HashSet
+    // / Generator) and keeps the fat `bytes` `{ptr,len,cap}` triple on the
+    // `RecordFieldLoad` + `Drop` path. If a future emitter change ever steered a
+    // non-pointer field (a BitCopy scalar, or the fat triple) into this op, the
+    // load would type-confuse the slot. Fail closed instead of mis-loading
+    // (LESSONS: boundary-fail-closed, dedup-semantic-boundary).
+    if !element_tys[idx_usize].is_pointer_type() {
+        return Err(CodegenError::FailClosed(format!(
+            "RecordFieldDrop @ field[{idx}]: slot type {slot:?} is not a single \
+             pointer; RecordFieldDrop is emitted only for single-pointer COW-heap \
+             fields (string / Vec / HashMap / HashSet / Generator). A fat or \
+             BitCopy field reached this op — refusing to load the slot as a \
+             pointer (LESSONS: boundary-fail-closed)",
+            slot = element_tys[idx_usize],
+        )));
+    }
+    let field_ptr = fn_ctx
+        .builder
+        .build_struct_gep(struct_ty, record_ptr, idx, &format!("rfd_{idx}_gep"))
+        .llvm_ctx_with(|| format!("RecordFieldDrop struct_gep field {idx}"))?;
+    // Raw load: NO hew_string_clone retain. This is intentional — the field is
+    // the sole owner (rc == 1) and we want to drive rc to zero via the release
+    // symbol. A retain here would produce a clone+immediate-drop no-op (the
+    // same bug we're fixing in RecordFieldLoad's string path).
+    let ptr_ty = fn_ctx.ctx.ptr_type(inkwell::AddressSpace::default());
+    let field_val = fn_ctx
+        .builder
+        .build_load(ptr_ty, field_ptr, &format!("rfd_{idx}_raw_load"))
+        .llvm_ctx_with(|| format!("RecordFieldDrop field {idx} raw load"))?
+        .into_pointer_value();
+    let helper =
+        get_or_declare_drop_helper(fn_ctx.ctx, fn_ctx.llvm_mod, &DropHelper { name: symbol });
+    fn_ctx
+        .builder
+        .build_call(helper, &[field_val.into()], &format!("{symbol}_rfd_call"))
+        .llvm_ctx_with(|| format!("RecordFieldDrop field {idx} {symbol} call"))?;
+    // Null-store the field slot so any structurally-reachable second drop fires
+    // `release_symbol(null)` — a no-op for all COW-heap release symbols
+    // (null-tolerant). Same idempotency posture as `emit_cow_heap_drop`
+    // (LESSONS: raii-null-after-move, lifecycle-symmetry).
+    let null_ptr = ptr_ty.const_null();
+    fn_ctx
+        .builder
+        .build_store(field_ptr, null_ptr)
+        .llvm_ctx_with(|| format!("RecordFieldDrop field {idx} post-drop null-store"))?;
     Ok(())
 }
 

--- a/hew-mir/src/dataflow.rs
+++ b/hew-mir/src/dataflow.rs
@@ -597,6 +597,18 @@ pub(crate) fn instr_reads_writes(instr: &Instr) -> (Vec<Place>, Vec<Place>) {
             (reads, vec![*dest])
         }
         Instr::RecordFieldLoad { record, dest, .. } => (vec![*record], vec![*dest]),
+        Instr::RecordFieldDrop { record, .. } => {
+            // RecordFieldDrop GEPs into `record` (the functional-update BASE
+            // aggregate) to release the OLD value of an overridden owned field
+            // in place and null-store that one slot. It is a READ of `record`,
+            // not a move: the base's overall move-state is governed separately
+            // (the base binding is marked consumed by `alias_moved_owned_operand`
+            // at the `..base` ingress). It defines no place. Note the base is
+            // NOT the record `RecordInit` builds — `RecordInit` constructs a
+            // distinct new aggregate from the carried/override sources; this op
+            // only neutralises the orphaned old field value on the consumed base.
+            (vec![*record], vec![])
+        }
         Instr::RecordFieldStore { record, src, .. } => {
             // Field-store reads both the aggregate (to GEP into it) and
             // the source. The aggregate stays Live — only the field bytes

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -948,6 +948,17 @@ fn render_instr(instr: &Instr) -> String {
             render_place(record),
             field_offset.0
         ),
+        Instr::RecordFieldDrop {
+            record,
+            field_offset,
+            ty,
+            drop_fn,
+        } => format!(
+            "drop_field {}.field[{}] ty={} fn={drop_fn:?}",
+            render_place(record),
+            field_offset.0,
+            ty.user_facing()
+        ),
         Instr::TupleFieldLoad {
             tuple,
             field_index,

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -9739,6 +9739,66 @@ impl Builder {
                     }
                 }
 
+                // (1b) Projection-of-a-live-binding base reject (fail-closed).
+                // A `..base` that PROJECTS a field of a live binding
+                // (`{ ..o.inner, f: new }`) interior-aliases that binding's
+                // storage. Unlike a bare-binding base, the projection does NOT
+                // consume the root binding (`alias_moved_owned_operand` only
+                // marks a bare `BindingRef`, so `o` stays live) and the root is
+                // NOT excluded from its scope-exit drop. The OVERRIDDEN owned
+                // field is still destructively released at the construction site
+                // below — so the freed storage is reachable through
+                // `o.inner.<field>` (use-after-free) and is freed a second time
+                // when `o` drops (double-free).
+                //
+                // Only OWNED-aggregate projection bases reach the override-drop
+                // path, so the reject is gated on `aggregate_ingress_moves_-
+                // binding_ty`: a `BitCopy` projection base bit-copies and stays
+                // valid. Bases that are NOT a projection of a live binding are
+                // unaffected: a bare-binding base is consumed (handled above);
+                // an owned rvalue / temporary base (`makeInner()`,
+                // `makeOuter().inner` — rooted at a call, not a binding) has no
+                // surviving named alias; an indexed base (`v[i]`) materialises an
+                // independent element value rather than an interior alias. Until
+                // the deep field-move (COW) value model lands, reject with
+                // clone / bind-first guidance — the fail-closed safe outcome,
+                // matching the self-aliasing-override reject above.
+                if let Some(base_expr) = base.as_deref() {
+                    if Self::functional_update_base_projects_live_binding(base_expr) {
+                        let base_ty = self.subst_ty(&base_expr.ty);
+                        if self.aggregate_ingress_moves_binding_ty(&base_ty) {
+                            // Walk every sub-expression for checker-stream
+                            // coverage before bailing, mirroring the paths above.
+                            for (_, fe) in fields {
+                                let _ = self.lower_value(fe);
+                            }
+                            let _ = self.lower_value(base_expr);
+                            self.diagnostics.push(MirDiagnostic {
+                                kind: MirDiagnosticKind::NotYetImplemented {
+                                    construct: "functional-update base projecting a live binding"
+                                        .to_string(),
+                                    site: expr.site,
+                                },
+                                note: format!(
+                                    "the `..base` of `{name}` projects a field of a live binding \
+                                     (`<binding>.<field>`) whose owned record would be consumed \
+                                     in place by the update: an overridden owned field is released \
+                                     at the construction site while the binding stays live, so a \
+                                     later read (`<binding>.<field>...`) or the binding's \
+                                     scope-exit drop would touch freed memory. Bind the projection \
+                                     into its own variable first \
+                                     (`let b = <binding>.<field>; {name} {{ ..b, <field>: new }}`) \
+                                     or clone the overridden field; a bare-binding base \
+                                     (`{name} {{ ..base, <field>: new }}`) is consumed safely. \
+                                     (The COW value model that keeps the source live after an \
+                                     update is not yet implemented.)"
+                                ),
+                            });
+                            return None;
+                        }
+                    }
+                }
+
                 // Lower each explicit field value to a Place, keyed by name.
                 let mut explicit: HashMap<String, Place> = HashMap::new();
                 for (fname, fexpr) in fields {
@@ -9784,10 +9844,9 @@ impl Builder {
                 // fields via `RecordFieldDrop`, the fat `bytes` triple via
                 // `RecordFieldLoad` + inline `Instr::Drop` (see the per-field
                 // routing comment below). Without this release the overwritten
-                // allocation is orphaned — the original functional-update
-                // overridden-owned-field LEAK (the bug the leak oracle pins; NOT
-                // GitHub issue #14, which is an unrelated, merged matter). The
-                // release is now correct for single-pointer COW leaf fields;
+                // allocation is orphaned — the functional-update
+                // overridden-owned-field LEAK (the bug the leak oracle pins).
+                // The release is now correct for single-pointer COW leaf fields;
                 // owned-aggregate overrides (record / tuple / enum) remain a
                 // follow-on guarded by the fail-closed pre-flight below.
                 //
@@ -9860,6 +9919,52 @@ impl Builder {
                     }
                 }
                 let mut field_pairs: Vec<(FieldOffset, Place)> = Vec::new();
+                // Predicate-coupling backstop (debug builds only). The
+                // destructive override-drop below frees the OLD value of each
+                // overridden owned field IN PLACE on `base_place`. That is sound
+                // ONLY because the base does not interior-alias a surviving
+                // reader:
+                //   * a bare-binding base is consume-marked (`AggregateAlias`),
+                //     so the move-checker rejects any later read of it;
+                //   * a projection of a live binding is REJECTED above
+                //     (fail-closed); and
+                //   * a temporary / rvalue base has no surviving named alias.
+                // Assert the first arm explicitly: if an owned-aggregate base
+                // BINDING reaches an override-drop WITHOUT a consume mark, some
+                // future change (e.g. admitting an opaque-handle record as
+                // `CowValue`, which would make `alias_moved_owned_operand`
+                // skip it) has silently reopened the use-after-free. The base
+                // consume and the override-drop are coupled invariants and must
+                // ship together.
+                #[cfg(debug_assertions)]
+                if base_place.is_some() {
+                    if let Some(base_id) = base_binding {
+                        let emits_override_drop = field_order.iter().any(|(fname, fty)| {
+                            explicit.contains_key(fname.as_str())
+                                && self
+                                    .project_field_inline_drop_symbol(&self.subst_ty(fty))
+                                    .is_some()
+                        });
+                        if emits_override_drop {
+                            let consume_marked = self.statements.iter().any(|stmt| {
+                                matches!(
+                                    stmt,
+                                    MirStatement::AggregateAlias { binding, .. }
+                                        if *binding == base_id
+                                )
+                            });
+                            debug_assert!(
+                                consume_marked,
+                                "functional-update override-drop on base binding {base_id:?} that \
+                                 was NOT consume-marked: the in-place field release would be a \
+                                 use-after-free. The base consume (`alias_moved_owned_operand`) \
+                                 and the override-drop are coupled invariants — a change that \
+                                 admits an owned-aggregate base without the `AggregateAlias` mark \
+                                 has reopened the UAF."
+                            );
+                        }
+                    }
+                }
                 for (idx, (fname, fty)) in field_order.iter().enumerate() {
                     let offset = FieldOffset(
                         u32::try_from(idx)
@@ -13155,10 +13260,11 @@ impl Builder {
     /// lower_inline_drop`) is allowed to emit:
     ///   - `string` → `hew_string_drop`
     ///   - `bytes`  → `hew_bytes_drop` (triple-field-0 release)
-    ///   - `Vec<T>` → `hew_vec_free` or `hew_vec_free_owned` (per-element-owns-heap)
+    ///   - `Vec<T>` → `hew_vec_free`, `hew_vec_free_owned` (per-element-owns-heap),
+    ///     or `hew_vec_free_closure_pairs` (`Vec<fn>` / `Vec<closure>` element)
     ///   - `HashMap<K,V>` → `hew_hashmap_free_layout`
     ///   - `HashSet<T>` → `hew_hashset_free_layout`
-    ///   - `Generator<Y,R>` / `AsyncGenerator<Y>` → `hew_gen_free`
+    ///   - `Generator<Y,R>` / `AsyncGenerator<Y>` → `hew_gen_coro_destroy`
     ///
     /// Returns `None` for owned-aggregate fields (records/tuples/enums) — their
     /// in-place drop is `DropKind::RecordInPlace` / `TupleInPlace` /
@@ -13178,7 +13284,26 @@ impl Builder {
                 ref args,
                 ..
             } => {
-                if args.first().is_some_and(|e| self.is_owned_vec_element(e)) {
+                // Mirror codegen's `cow_heap_release_symbol` Vec arm EXACTLY,
+                // including order: a closure-pair element (`Vec<fn>` /
+                // `Vec<closure>`) is checked FIRST and releases via
+                // `hew_vec_free_closure_pairs` (per-element env-thunk + pair-box
+                // walk, then buffer/handle free). A fn element is neither an
+                // owned composite nor a plain leaf, so it must not fall through
+                // to the owned/plain arms. Omitting this arm made the MIR symbol
+                // authority disagree with codegen (`hew_vec_free` vs
+                // `hew_vec_free_closure_pairs`): every consumer — the
+                // functional-update override-drop AND the match-destructure
+                // wildcard inline-drop — then emitted an incongruent release
+                // that codegen rejects fail-closed
+                // (`is_known_cow_heap_drop_symbol` / the RecordFieldDrop
+                // congruence assert). Both authorities are documented to agree;
+                // this restores that agreement.
+                if args.first().is_some_and(|e| {
+                    matches!(e, ResolvedTy::Function { .. } | ResolvedTy::Closure { .. })
+                }) {
+                    Some("hew_vec_free_closure_pairs")
+                } else if args.first().is_some_and(|e| self.is_owned_vec_element(e)) {
                     Some("hew_vec_free_owned")
                 } else {
                     Some("hew_vec_free")
@@ -24306,6 +24431,52 @@ impl Builder {
                     ValueClass::of_ty(&self.subst_ty(&value.ty), &self.type_classes),
                     ValueClass::BitCopy | ValueClass::View | ValueClass::PersistentShare
                 )
+            }
+            _ => false,
+        }
+    }
+
+    /// True when a functional-update base, peeled of transparent tail-only
+    /// blocks, is a field PROJECTION whose object chain bottoms out at a live
+    /// local binding (`o.inner`, `o.a.b`) — as opposed to a temporary, call,
+    /// or indexed value.
+    ///
+    /// Such a base interior-aliases the binding's storage: the binding stays
+    /// live (a projection is not consume-marked by `alias_moved_owned_operand`,
+    /// which only marks a bare `BindingRef`) yet the update's override-drop
+    /// would destructively free a field the binding still owns. The caller
+    /// rejects these bases (fail-closed) when the projected type is an owned
+    /// aggregate. A base rooted at a CALL (`makeOuter().inner`) is a consumed
+    /// temporary with no surviving named alias and is NOT flagged; an INDEXED
+    /// base (`v[i]`) materialises an independent element value, also not an
+    /// interior alias of a surviving binding.
+    fn functional_update_base_projects_live_binding(base: &HirExpr) -> bool {
+        match &base.kind {
+            // Peel a transparent tail-only block wrapper (`{ o.inner }`).
+            HirExprKind::Block(block) if block.statements.is_empty() => block
+                .tail
+                .as_deref()
+                .is_some_and(Self::functional_update_base_projects_live_binding),
+            // A field projection whose object chain roots at a live binding.
+            HirExprKind::FieldAccess { object, .. } => {
+                Self::projection_object_roots_at_live_binding(object)
+            }
+            _ => false,
+        }
+    }
+
+    /// Recurse through a projection's object chain (peeling only further
+    /// `FieldAccess`) to decide whether it bottoms out at a bare live
+    /// `BindingRef`. An `Index`, call, or any other root short-circuits to
+    /// false — those are not interior aliases of a surviving named binding.
+    fn projection_object_roots_at_live_binding(object: &HirExpr) -> bool {
+        match &object.kind {
+            HirExprKind::BindingRef {
+                resolved: ResolvedRef::Binding(_),
+                ..
+            } => true,
+            HirExprKind::FieldAccess { object, .. } => {
+                Self::projection_object_roots_at_live_binding(object)
             }
             _ => false,
         }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -8729,6 +8729,25 @@ impl Builder {
             } => {
                 if let Some(dest) = self.binding_locals.get(binding).copied() {
                     self.push_instr(Instr::Move { dest, src });
+                    // A simple-variable assignment RE-DEFINES its target: after
+                    // `h = <rhs>` the binding `h` holds a fresh value and is
+                    // unconditionally Live, regardless of any move/consume the
+                    // RHS performed on `h` itself. Emit a checker-stream `Bind`
+                    // so move-state tracking resets `h` to Live. Without this the
+                    // self-consuming reassign idiom `h = T { ..h, f: new }`
+                    // (the canonical functional-update loop body) would leave `h`
+                    // flagged `Consumed` from the `..h` ingress and every
+                    // subsequent read — including the next loop iteration — would
+                    // spuriously trip `UseAfterConsume`. This re-`Bind` carries no
+                    // drop semantics (it does not touch `owned_locals`, which is
+                    // populated only at `let`/param sites), so scope-exit drop
+                    // accounting for `h` is unchanged.
+                    self.statements.push(MirStatement::Bind {
+                        binding: *binding,
+                        name: name.clone(),
+                        site: target.site,
+                        ty: self.subst_ty(&target.ty),
+                    });
                 } else {
                     self.diagnostics.push(MirDiagnostic {
                         kind: MirDiagnosticKind::UnresolvedPlace {
@@ -9655,6 +9674,71 @@ impl Builder {
                     return None;
                 };
 
+                // ── Functional-update base is CONSUMED ──────────────────────
+                // Owned-record `..base` moves the base into the new record:
+                // its carried fields escape via `RecordFieldLoad` and its
+                // OVERRIDDEN owned fields are destructively released at the
+                // construction site (below). Two fail-closed guards keep the
+                // consume sound, so every admitted program is memory-safe:
+                //
+                //   (1) Self-reference reject (here): an overriding field value
+                //       that bare-aliases the base's heap (`{ items: s.items,
+                //       ..s }`) would be freed by the override-drop before the
+                //       new record reads it. Reject at lowering.
+                //
+                //   (2) Use-after-move (consume-marking after the base is
+                //       lowered, below): any later use of the base — including a
+                //       second `..base` from the same source, or a `base.field`
+                //       read — is flagged `UseAfterConsume` by the move-checker.
+                //
+                // The long-term value model targets COW (`cow_share` +
+                // `ensure_unique`, base stays valid — see
+                // tests/corpus/v05-value-model/18_record_update_syntax) where
+                // these shapes become legal. Until the retain-on-share spine
+                // lands, the consume semantics are the fail-closed interim: the
+                // rejected shapes are exactly the ones that would otherwise
+                // miscompile (use-after-free / double-free). BitCopy records are
+                // exempt — they bit-copy and the base stays valid.
+                let base_binding: Option<BindingId> = match base.as_deref().map(|b| &b.kind) {
+                    Some(HirExprKind::BindingRef {
+                        resolved: ResolvedRef::Binding(id),
+                        ..
+                    }) => Some(*id),
+                    _ => None,
+                };
+                if let Some(base_id) = base_binding {
+                    if let Some((fname, _)) = fields.iter().find(|(_, fexpr)| {
+                        self.functional_update_value_aliases_base(fexpr, base_id)
+                    }) {
+                        // Walk every sub-expression for checker-stream coverage
+                        // before bailing, mirroring the field-order-miss path.
+                        for (_, fe) in fields {
+                            let _ = self.lower_value(fe);
+                        }
+                        if let Some(base_expr) = base.as_deref() {
+                            let _ = self.lower_value(base_expr);
+                        }
+                        self.diagnostics.push(MirDiagnostic {
+                            kind: MirDiagnosticKind::NotYetImplemented {
+                                construct: "functional-update override aliasing the consumed base"
+                                    .to_string(),
+                                site: expr.site,
+                            },
+                            note: format!(
+                                "field `{fname}` of `{name}` is initialised from a bare \
+                                 projection of the functional-update base `..base`, which is \
+                                 consumed by the update; the base's overridden owned fields \
+                                 are released at the construction site, so the new record \
+                                 would alias freed memory. Clone the value \
+                                 (`<base>.<field>.clone()`) or bind it into a separate \
+                                 variable before the update. (The COW value model that keeps \
+                                 the base live after an update is not yet implemented.)"
+                            ),
+                        });
+                        return None;
+                    }
+                }
+
                 // Lower each explicit field value to a Place, keyed by name.
                 let mut explicit: HashMap<String, Place> = HashMap::new();
                 for (fname, fexpr) in fields {
@@ -9676,7 +9760,16 @@ impl Builder {
 
                 // Lower the functional-update base, if any.
                 let base_place: Option<Place> = if let Some(base_expr) = base {
-                    self.lower_value(base_expr)
+                    let place = self.lower_value(base_expr);
+                    // (2) Consume the base — see the guard note above. An owned
+                    // record handed in via `..base` moves into the new record,
+                    // so mark the source binding consumed: a later use (a second
+                    // `..base`, or a `base.field` read) is `UseAfterConsume`.
+                    // `alias_moved_owned_operand` is drop-neutral (it does NOT
+                    // suppress the base's scope-exit drop) and self-skips BitCopy
+                    // records via `aggregate_ingress_moves_binding_ty`.
+                    self.alias_moved_owned_operand(base_expr);
+                    place
                 } else {
                     None
                 };
@@ -9685,22 +9778,87 @@ impl Builder {
                 // For each field: use the explicit value if present; otherwise
                 // emit a RecordFieldLoad from the base and use that intermediate.
                 //
-                // SHIM / FAIL-CLOSED (W5.021 Finding 3): for an OVERRIDDEN owned
-                // field, the base's old value is never loaded here (the explicit
-                // value replaces it), so it is not moved into the new record. The
-                // `base` binding itself is then excluded from drop by
-                // `derive_owned_record_drop_allowed` (its kept fields escape into
-                // the new record via these RecordFieldLoads), so the overridden
-                // field's OLD heap value is never released -> it LEAKS. This is
-                // fail-closed (leak, never double-free): the new record owns the
-                // replacement; nothing double-frees the old value.
-                // WHEN OBSOLETE: when functional update over owned records gets a
-                // precise per-field drop (drop the overridden base field at the
-                // RecordInit site). REAL SOLUTION: emit a targeted drop of
-                // `base.<overridden_offset>` for each owned overridden field
-                // before/at construction. Only string-literal overrides are
-                // common today (no heap leak), so the cost is bounded; tracked as
-                // a v0.5.1 follow-on.
+                // For OVERRIDDEN fields with heap-owning types (string / bytes /
+                // Vec<T> / HashMap / HashSet / Generator), destructively release
+                // the OLD base value at the construction site: single-pointer COW
+                // fields via `RecordFieldDrop`, the fat `bytes` triple via
+                // `RecordFieldLoad` + inline `Instr::Drop` (see the per-field
+                // routing comment below). Without this release the overwritten
+                // allocation is orphaned — the original functional-update
+                // overridden-owned-field LEAK (the bug the leak oracle pins; NOT
+                // GitHub issue #14, which is an unrelated, merged matter). The
+                // release is now correct for single-pointer COW leaf fields;
+                // owned-aggregate overrides (record / tuple / enum) remain a
+                // follow-on guarded by the fail-closed pre-flight below.
+                //
+                // SOUNDNESS depends on `..base` consuming the base: the base is
+                // marked consumed (above), so the move-checker rejects any later
+                // read of `base` (a second `..base`, a `base.field`). The old
+                // value freed here therefore has no surviving reader. Were the
+                // base reusable, this destructive release would be a
+                // use-after-free / double-free — which is exactly why the
+                // consume guard and this release ship together.
+                //
+                // Drop-safety across all three exit contexts (sync return, async
+                // cancel, actor shutdown): the drops are emitted BEFORE RecordInit
+                // in the same basic block, so they fire on every execution path
+                // that reaches the functional-update site.  No scope-exit /
+                // suspend-point interleaving exists between the old-value release
+                // and the new-record construction.
+                //
+                // Double-drop avoidance: each emitted RecordFieldLoad+Drop temp
+                // appears in `derive_owned_record_drop_allowed`'s `field_binders`
+                // set AND its `release_owner_bases` set (the Defect-1 guard),
+                // which then excludes the base binding from composite drop —
+                // complementing the existing exclusion from non-overridden field
+                // binders escaping via RecordInit.  No owned field of `base` is
+                // ever dropped twice.
+                //
+                // Fail-closed pre-flight: owned-aggregate field overrides (record /
+                // tuple / enum) have no single-ptr leaf release symbol and surface
+                // a NotYetImplemented diagnostic rather than leaking silently.
+                if base_place.is_some() {
+                    for (fname, fty) in &field_order {
+                        if !explicit.contains_key(fname.as_str()) {
+                            continue; // Not overridden — carries into new record normally.
+                        }
+                        let subst_fty = self.subst_ty(fty);
+                        let vc = ValueClass::of_ty(&subst_fty, &self.type_classes);
+                        if matches!(
+                            vc,
+                            ValueClass::BitCopy | ValueClass::View | ValueClass::PersistentShare
+                        ) {
+                            // No heap ownership — no destructor to emit.
+                            continue;
+                        }
+                        if self.project_field_inline_drop_symbol(&subst_fty).is_none() {
+                            // Owned-aggregate field (record / tuple / enum): in-place
+                            // drop kinds are function-scope only and cannot be emitted
+                            // as inline `Instr::Drop` here.  Fail closed.
+                            self.diagnostics.push(MirDiagnostic {
+                                kind: MirDiagnosticKind::NotYetImplemented {
+                                    construct:
+                                        "functional-update override of owned-aggregate field"
+                                            .to_string(),
+                                    site: expr.site,
+                                },
+                                note: format!(
+                                    "field `{fname}` of `{name}` has owned-aggregate type \
+                                     `{ty}` (record / tuple / enum with heap fields); \
+                                     overriding an owned-aggregate field in a \
+                                     functional-update expression is not yet supported — \
+                                     in-place drop kinds (`RecordInPlace` / `TupleInPlace` \
+                                     / `EnumInPlace`) cannot be emitted as inline \
+                                     `Instr::Drop` here (follow-on to the \
+                                     functional-update overridden-owned-field \
+                                     leak fix)",
+                                    ty = subst_fty.user_facing(),
+                                ),
+                            });
+                            return None;
+                        }
+                    }
+                }
                 let mut field_pairs: Vec<(FieldOffset, Place)> = Vec::new();
                 for (idx, (fname, fty)) in field_order.iter().enumerate() {
                     let offset = FieldOffset(
@@ -9708,6 +9866,73 @@ impl Builder {
                             .expect("record field count exceeds u32::MAX — impossible in Hew"),
                     );
                     if let Some(&src) = explicit.get(fname.as_str()) {
+                        // Emit an inline drop of the OLD base field value when it
+                        // is heap-owning.  The pre-flight above guarantees every
+                        // non-BitCopy overridden field has a known inline drop
+                        // symbol; BitCopy / View / PersistentShare fields need no
+                        // destructor.
+                        if let Some(base_rec) = base_place {
+                            let subst_fty = self.subst_ty(fty);
+                            if let Some(symbol) = self.project_field_inline_drop_symbol(&subst_fty)
+                            {
+                                // Destructively release the OLD value of the
+                                // overridden field, in declaration order, BEFORE
+                                // the new record is constructed. The base is
+                                // CONSUMED by `..base` (the move-checker rejects
+                                // any later use — see the consume guard above), so
+                                // this old value is orphaned and must be freed here
+                                // or it leaks (the functional-update
+                                // overridden-owned-field leak the oracle pins).
+                                //
+                                // SINGLE MECHANISM for single-pointer COW fields
+                                // (`string` / `Vec<T>` / `HashMap` / `HashSet` /
+                                // `Generator`): `RecordFieldDrop` (raw load → release
+                                // → null-store). It is the purpose-built op for an
+                                // in-place field destructor and gives three things
+                                // the old `RecordFieldLoad` + `Drop` split did not:
+                                //   * it bypasses `RecordFieldLoad`'s `string` retain
+                                //     (a retain+drop no-op that LEAVES the original
+                                //     un-freed — the original string-vs-rest split
+                                //     existed only to dodge this);
+                                //   * it does NOT depend on the incidental fact that
+                                //     `RecordFieldLoad` skips retain for `Vec`/map —
+                                //     when the retain-on-share spine lands and that
+                                //     load starts retaining, a `load` + `Drop` here
+                                //     would silently regress to a leak; and
+                                //   * it null-stores the freed slot, so the exotic
+                                //     residual-alias path frees `null` (a no-op for
+                                //     every COW release symbol) instead of a dangle.
+                                //
+                                // `bytes` is the ONE exception: it is a fat
+                                // `{ ptr, len, cap }` triple, not a single pointer,
+                                // so its destructor takes the whole by-value triple
+                                // and must be reached through `RecordFieldLoad` +
+                                // `Instr::Drop` (which materialises the fat value).
+                                // `field_override_uses_record_field_drop` mirrors
+                                // codegen's `cow_heap_release_symbol` single-ptr set
+                                // so the `RecordFieldDrop` congruence assert agrees.
+                                if field_override_uses_record_field_drop(&subst_fty) {
+                                    self.push_instr(Instr::RecordFieldDrop {
+                                        record: base_rec,
+                                        field_offset: offset,
+                                        ty: subst_fty,
+                                        drop_fn: crate::model::DropFnSpec::Release(symbol),
+                                    });
+                                } else {
+                                    let old_val = self.alloc_local(subst_fty.clone());
+                                    self.push_instr(Instr::RecordFieldLoad {
+                                        record: base_rec,
+                                        field_offset: offset,
+                                        dest: old_val,
+                                    });
+                                    self.push_instr(Instr::Drop {
+                                        place: old_val,
+                                        ty: subst_fty,
+                                        drop_fn: Some(crate::model::DropFnSpec::Release(symbol)),
+                                    });
+                                }
+                            }
+                        }
                         field_pairs.push((offset, src));
                     } else if let Some(base_rec) = base_place {
                         // Field absent from the explicit list — load it from base.
@@ -24037,6 +24262,55 @@ impl Builder {
         });
     }
 
+    /// True when an overriding functional-update field VALUE is, at its
+    /// value-producing root, a bare interior alias of the consumed base's
+    /// heap: a whole `base` reference or a `base.field` projection of an
+    /// OWNED (heap-owning) field.
+    ///
+    /// Owned-record `..base` consumes the base (its carried fields escape via
+    /// `RecordFieldLoad` into the new record and its OVERRIDDEN owned fields
+    /// are destructively released at the construction site). An override value
+    /// that bare-projects an owned field of that same base is a non-retaining
+    /// interior alias; the override-drop frees it before the new record is
+    /// built — a use-after-free (the repro-B self-override shape
+    /// `{ items: s.items, ..s }`). Fail closed: the caller rejects.
+    ///
+    /// Values whose root is a method/function call, operator, index, or
+    /// literal are NOT flagged even when they READ `base.field` internally:
+    /// they produce a fresh or copied value (`base.items.clone()`,
+    /// `base.n + 1`, `base.items.len()`), which the override-drop cannot
+    /// dangle. A `BitCopy` / `View` / `PersistentShare` field projection
+    /// (`base.count`) is a copied scalar that is never released, so it is not
+    /// a hazard either. Transparent tail-only blocks are peeled.
+    fn functional_update_value_aliases_base(&self, value: &HirExpr, base_id: BindingId) -> bool {
+        match &value.kind {
+            // Peel a transparent tail-only block wrapper (`{ base.items }`).
+            HirExprKind::Block(block) if block.statements.is_empty() => block
+                .tail
+                .as_deref()
+                .is_some_and(|tail| self.functional_update_value_aliases_base(tail, base_id)),
+            // A whole `base` value handed into a field position.
+            HirExprKind::BindingRef {
+                resolved: ResolvedRef::Binding(id),
+                ..
+            } => *id == base_id,
+            // A bare `base.field` projection of an owned (heap-owning) field.
+            HirExprKind::FieldAccess { object, .. } => {
+                matches!(
+                    &object.kind,
+                    HirExprKind::BindingRef {
+                        resolved: ResolvedRef::Binding(id),
+                        ..
+                    } if *id == base_id
+                ) && !matches!(
+                    ValueClass::of_ty(&self.subst_ty(&value.ty), &self.type_classes),
+                    ValueClass::BitCopy | ValueClass::View | ValueClass::PersistentShare
+                )
+            }
+            _ => false,
+        }
+    }
+
     /// Emit a `MirStatement::Use(Consume)` for a managed-type binding that is
     /// moved into a builtin aggregate method (HashMap/HashSet insert).
     ///
@@ -25749,6 +26023,7 @@ fn instr_places(instr: &Instr) -> Vec<Place> {
             places
         }
         Instr::RecordFieldLoad { record, dest, .. } => vec![*record, *dest],
+        Instr::RecordFieldDrop { record, .. } => vec![*record],
         Instr::RecordFieldStore { record, src, .. } => vec![*record, *src],
         Instr::ActorStateFieldLoad { dest, .. } => vec![*dest],
         Instr::ActorStateFieldStore { src, .. } => vec![*src],
@@ -26037,6 +26312,7 @@ pub fn instr_source_places(instr: &Instr) -> Vec<Place> {
         // (and, for the interior-aliasing loads, a projection seed — see
         // `projection_alias_dest`).
         Instr::RecordFieldLoad { record, .. } => vec![*record],
+        Instr::RecordFieldDrop { record, .. } => vec![*record],
         Instr::TupleFieldLoad { tuple, .. } => vec![*tuple],
         Instr::ClosureEnvFieldLoad { env, .. } => vec![*env],
         // Field stores: both the target aggregate and the stored value are
@@ -26393,6 +26669,7 @@ fn generator_yield_instr_escapes(instr: &Instr, local: u32) -> bool {
         | Instr::BytesLit { .. }
         | Instr::ConstGlobalLoad { .. }
         | Instr::RecordFieldLoad { .. }
+        | Instr::RecordFieldDrop { .. }
         | Instr::TupleFieldLoad { .. }
         | Instr::ClosureEnvFieldLoad { .. }
         | Instr::ActorStateFieldLoad { .. }
@@ -26634,6 +26911,7 @@ fn projection_alias_dest(instr: &Instr) -> Option<Place> {
         | Instr::SpawnTaskDirect { .. }
         | Instr::SpawnTaskClosure { .. }
         | Instr::Drop { .. }
+        | Instr::RecordFieldDrop { .. }
         | Instr::WitnessSizeOf { .. }
         | Instr::WitnessAlignOf { .. }
         | Instr::WitnessDropGlue { .. }
@@ -28315,7 +28593,16 @@ fn derive_owned_record_drop_allowed(
             // alias member or a field binder is an escape. Fail-closed.
             if !matches!(
                 instr,
-                Instr::Move { .. } | Instr::Drop { .. } | Instr::RecordFieldLoad { .. }
+                Instr::Move { .. }
+                    | Instr::Drop { .. }
+                    | Instr::RecordFieldLoad { .. }
+                    // `RecordFieldDrop` is an interior operation (GEP+drop on one
+                    // field slot) and does not transfer ownership of the whole
+                    // record out of the scope, so it must not count as an escape
+                    // of the record root. It is emitted by functional-update
+                    // lowering to release overridden fields; the surrounding record
+                    // binding is still live (and should receive its composite drop).
+                    | Instr::RecordFieldDrop { .. }
             ) {
                 for p in instr_source_places(instr) {
                     if let Some(l) = base_local(p) {
@@ -31839,6 +32126,43 @@ fn cow_value_leaf_drop_symbol(ty: &ResolvedTy) -> Option<&'static str> {
         ResolvedTy::String => Some("hew_string_drop"),
         _ => None,
     }
+}
+
+/// True when an overridden owned record field in a functional-update
+/// expression must be destructively released via the `RecordFieldDrop` op
+/// (raw load → release → null-store) rather than the `RecordFieldLoad` +
+/// `Instr::Drop` pair.
+///
+/// The predicate selects every SINGLE-POINTER COW-heap field — `string`,
+/// `Vec<T>`, `HashMap`, `HashSet`, and the `Generator` / `AsyncGenerator`
+/// companion handle — whose runtime value is exactly one pointer, so the
+/// `RecordFieldDrop` single-slot GEP + release is the whole destructor.
+///
+/// `bytes` is deliberately EXCLUDED: it is a fat `{ ptr, len, cap }` triple,
+/// not a single pointer. Its destructor takes the by-value triple, so it is
+/// reached through `RecordFieldLoad` + `Instr::Drop` (which materialises the
+/// fat value into a temp). The set mirrors codegen's `cow_heap_release_symbol`
+/// (which returns `None` for `bytes`), so the `RecordFieldDrop` symbol/type
+/// congruence assertion in codegen always agrees with what is emitted here.
+///
+/// Dispatch is on the `builtin` discriminant, never the `name` string, so a
+/// user-defined `type Vec { ... }` (`builtin: None`) is never mis-routed to a
+/// runtime release symbol (LESSONS: boundary-fail-closed, checker-authority).
+fn field_override_uses_record_field_drop(ty: &ResolvedTy) -> bool {
+    matches!(
+        ty,
+        ResolvedTy::String
+            | ResolvedTy::Named {
+                builtin: Some(
+                    hew_types::BuiltinType::Vec
+                        | hew_types::BuiltinType::HashMap
+                        | hew_types::BuiltinType::HashSet
+                        | hew_types::BuiltinType::Generator
+                        | hew_types::BuiltinType::AsyncGenerator,
+                ),
+                ..
+            }
+    )
 }
 
 /// True when `ty` is a builtin `Generator<Y, R>` / `AsyncGenerator<Y>` handle.

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -1933,6 +1933,14 @@ pub fn lower_hir_module_with_facts(
         }
     }
 
+    // Module-global interprocedural freshness summary, computed ONCE over every
+    // function item (a least-fixpoint). Threaded into every body-lowering
+    // builder so the destructive-funcupdate base gate can admit a `..f(args)`
+    // base ONLY when `f` provably returns a fresh owner — closing the
+    // call-returns-borrowed-param use-after-free. `Rc` so child builders share
+    // it without re-cloning the map.
+    let funcupdate_fn_returns_fresh: Rc<HashMap<hew_hir::ItemId, bool>> =
+        Rc::new(compute_fn_returns_fresh_owner(&origin_fns));
     for item in &module.items {
         match item {
             HirItem::Function(func) => {
@@ -1972,6 +1980,7 @@ pub fn lower_hir_module_with_facts(
                         None,
                         &module_fn_names,
                         &module_generic_fn_names,
+                        &funcupdate_fn_returns_fresh,
                         &trait_impl_index,
                         &module.call_site_type_args,
                         Some(&module.vec_generic_element_abi),
@@ -2021,6 +2030,7 @@ pub fn lower_hir_module_with_facts(
                     None,
                     &module_fn_names,
                     &module_generic_fn_names,
+                    &funcupdate_fn_returns_fresh,
                     &trait_impl_index,
                     &module.call_site_type_args,
                     Some(&module.vec_generic_element_abi),
@@ -2061,6 +2071,7 @@ pub fn lower_hir_module_with_facts(
                     &opaque_handle_names,
                     &module_fn_names,
                     &module_generic_fn_names,
+                    &funcupdate_fn_returns_fresh,
                     &module.call_site_type_args,
                     &module.supervisor_child_slots,
                     actor_send_aliasing,
@@ -2103,6 +2114,7 @@ pub fn lower_hir_module_with_facts(
                     &opaque_handle_names,
                     &module_fn_names,
                     &module_generic_fn_names,
+                    &funcupdate_fn_returns_fresh,
                     &module.call_site_type_args,
                     &module.supervisor_child_slots,
                     actor_send_aliasing,
@@ -2176,6 +2188,7 @@ pub fn lower_hir_module_with_facts(
                     &classification_enum_layouts,
                     &module_fn_names,
                     &module_generic_fn_names,
+                    &funcupdate_fn_returns_fresh,
                     &module.call_site_type_args,
                     &module.supervisor_child_slots,
                     actor_send_aliasing,
@@ -2240,6 +2253,7 @@ pub fn lower_hir_module_with_facts(
             None,
             &module_fn_names,
             &module_generic_fn_names,
+            &funcupdate_fn_returns_fresh,
             &trait_impl_index,
             &module.call_site_type_args,
             Some(&module.vec_generic_element_abi),
@@ -2403,6 +2417,7 @@ fn lower_actor_receive_handlers(
     opaque_handle_names: &[String],
     module_fn_names: &HashSet<String>,
     module_generic_fn_names: &HashSet<String>,
+    funcupdate_fn_returns_fresh: &Rc<HashMap<hew_hir::ItemId, bool>>,
     call_site_type_args: &HashMap<hew_hir::SiteId, Vec<ResolvedTy>>,
     supervisor_child_slots: &HashMap<hew_hir::SiteId, ChildSlot>,
     actor_send_aliasing: &HashMap<hew_types::SpanKey, hew_types::ActorSendAliasing>,
@@ -2500,6 +2515,7 @@ fn lower_actor_receive_handlers(
             Some(actor.qualified_name().as_str()),
             module_fn_names,
             module_generic_fn_names,
+            funcupdate_fn_returns_fresh,
             &HashMap::new(),
             call_site_type_args,
             None,
@@ -2528,6 +2544,7 @@ fn lower_actor_body_handlers(
     opaque_handle_names: &[String],
     module_fn_names: &HashSet<String>,
     module_generic_fn_names: &HashSet<String>,
+    funcupdate_fn_returns_fresh: &Rc<HashMap<hew_hir::ItemId, bool>>,
     call_site_type_args: &HashMap<hew_hir::SiteId, Vec<ResolvedTy>>,
     supervisor_child_slots: &HashMap<hew_hir::SiteId, ChildSlot>,
     actor_send_aliasing: &HashMap<hew_types::SpanKey, hew_types::ActorSendAliasing>,
@@ -2549,6 +2566,7 @@ fn lower_actor_body_handlers(
             opaque_handle_names,
             module_fn_names,
             module_generic_fn_names,
+            funcupdate_fn_returns_fresh,
             call_site_type_args,
             supervisor_child_slots,
             actor_send_aliasing,
@@ -2570,6 +2588,7 @@ fn lower_actor_body_handlers(
         opaque_handle_names,
         module_fn_names,
         module_generic_fn_names,
+        funcupdate_fn_returns_fresh,
         call_site_type_args,
         supervisor_child_slots,
         actor_send_aliasing,
@@ -2588,6 +2607,7 @@ fn lower_actor_body_handlers(
         opaque_handle_names,
         module_fn_names,
         module_generic_fn_names,
+        funcupdate_fn_returns_fresh,
         call_site_type_args,
         supervisor_child_slots,
         actor_send_aliasing,
@@ -2614,6 +2634,7 @@ fn lower_actor_init_handler(
     opaque_handle_names: &[String],
     module_fn_names: &HashSet<String>,
     module_generic_fn_names: &HashSet<String>,
+    funcupdate_fn_returns_fresh: &Rc<HashMap<hew_hir::ItemId, bool>>,
     call_site_type_args: &HashMap<hew_hir::SiteId, Vec<ResolvedTy>>,
     supervisor_child_slots: &HashMap<hew_hir::SiteId, ChildSlot>,
     actor_send_aliasing: &HashMap<hew_types::SpanKey, hew_types::ActorSendAliasing>,
@@ -2664,6 +2685,7 @@ fn lower_actor_init_handler(
         Some(&actor.name),
         module_fn_names,
         module_generic_fn_names,
+        funcupdate_fn_returns_fresh,
         &HashMap::new(),
         call_site_type_args,
         None,
@@ -2693,6 +2715,7 @@ fn lower_actor_lifecycle_handlers(
     opaque_handle_names: &[String],
     module_fn_names: &HashSet<String>,
     module_generic_fn_names: &HashSet<String>,
+    funcupdate_fn_returns_fresh: &Rc<HashMap<hew_hir::ItemId, bool>>,
     call_site_type_args: &HashMap<hew_hir::SiteId, Vec<ResolvedTy>>,
     supervisor_child_slots: &HashMap<hew_hir::SiteId, ChildSlot>,
     actor_send_aliasing: &HashMap<hew_types::SpanKey, hew_types::ActorSendAliasing>,
@@ -2748,6 +2771,7 @@ fn lower_actor_lifecycle_handlers(
                     Some(actor.qualified_name().as_str()),
                     module_fn_names,
                     module_generic_fn_names,
+                    funcupdate_fn_returns_fresh,
                     &HashMap::new(),
                     call_site_type_args,
                     None,
@@ -2796,6 +2820,7 @@ fn lower_actor_lifecycle_handlers(
                     Some(actor.qualified_name().as_str()),
                     module_fn_names,
                     module_generic_fn_names,
+                    funcupdate_fn_returns_fresh,
                     &HashMap::new(),
                     call_site_type_args,
                     None,
@@ -2982,6 +3007,7 @@ fn lower_actor_lifecycle_handlers(
                     Some(actor.qualified_name().as_str()),
                     module_fn_names,
                     module_generic_fn_names,
+                    funcupdate_fn_returns_fresh,
                     &HashMap::new(),
                     call_site_type_args,
                     None,
@@ -3163,6 +3189,7 @@ fn synthesize_machine_step_fn(
     enum_layouts: &[crate::model::EnumLayout],
     module_fn_names: &HashSet<String>,
     module_generic_fn_names: &HashSet<String>,
+    funcupdate_fn_returns_fresh: &Rc<HashMap<hew_hir::ItemId, bool>>,
     call_site_type_args: &HashMap<hew_hir::SiteId, Vec<ResolvedTy>>,
     supervisor_child_slots: &HashMap<hew_hir::SiteId, ChildSlot>,
     actor_send_aliasing: &HashMap<hew_types::SpanKey, hew_types::ActorSendAliasing>,
@@ -3211,6 +3238,7 @@ fn synthesize_machine_step_fn(
         enum_layouts: enum_layouts.to_vec(),
         module_fn_names: module_fn_names.clone(),
         module_generic_fn_names: module_generic_fn_names.clone(),
+        funcupdate_fn_returns_fresh: funcupdate_fn_returns_fresh.clone(),
         call_site_type_args: call_site_type_args.clone(),
         supervisor_child_slots: supervisor_child_slots.clone(),
         actor_send_aliasing: actor_send_aliasing.clone(),
@@ -3999,6 +4027,7 @@ fn lower_supervisor_bootstrap(
     opaque_handle_names: &[String],
     module_fn_names: &HashSet<String>,
     module_generic_fn_names: &HashSet<String>,
+    funcupdate_fn_returns_fresh: &Rc<HashMap<hew_hir::ItemId, bool>>,
     call_site_type_args: &HashMap<hew_hir::SiteId, Vec<ResolvedTy>>,
     supervisor_child_slots: &HashMap<hew_hir::SiteId, ChildSlot>,
     actor_send_aliasing: &HashMap<hew_types::SpanKey, hew_types::ActorSendAliasing>,
@@ -4246,6 +4275,7 @@ fn lower_supervisor_bootstrap(
         None,
         module_fn_names,
         module_generic_fn_names,
+        funcupdate_fn_returns_fresh,
         &HashMap::new(),
         call_site_type_args,
         None,
@@ -4675,7 +4705,10 @@ fn collect_unknown_self_fields_in_expr(
 /// makeThing() } { ..c, f }` is unsafe on the `p == false` path). The reassign-
 /// loop idiom (`var c = Record { .. }; while .. { c = Record { ..c, f } }`) stays
 /// admitted because every definition is a record literal / funcupdate result.
-fn compute_funcupdate_base_provenance(func: &HirFn) -> HashMap<BindingId, bool> {
+fn compute_funcupdate_base_provenance<'f>(
+    func: &'f HirFn,
+    fresh: &'f HashMap<hew_hir::ItemId, bool>,
+) -> HashMap<BindingId, bool> {
     let mut defs: HashMap<BindingId, Vec<&HirExpr>> = HashMap::new();
     let mut let_or_param: HashSet<BindingId> = HashSet::new();
     let mut params: HashSet<BindingId> = HashSet::new();
@@ -4690,6 +4723,7 @@ fn compute_funcupdate_base_provenance(func: &HirFn) -> HashMap<BindingId, bool> 
         let_or_param,
         params,
         memo: HashMap::new(),
+        fresh,
     };
     let ids: Vec<BindingId> = resolver.let_or_param.iter().copied().collect();
     for id in ids {
@@ -4702,12 +4736,15 @@ fn compute_funcupdate_base_provenance(func: &HirFn) -> HashMap<BindingId, bool> 
 /// Memoised resolver for `compute_funcupdate_base_provenance`. `defs` maps each
 /// binding to every initialiser/reassignment expression that defines it;
 /// `let_or_param` is the set of bindings introduced by a `let` or a parameter
-/// (any other origin is unproven); `params` is the by-value parameter subset.
+/// (any other origin is unproven); `params` is the by-value parameter subset;
+/// `fresh` is the module interprocedural freshness summary
+/// (`compute_fn_returns_fresh_owner`) consulted when a definition is a call.
 struct BaseOwnerResolver<'f> {
     defs: HashMap<BindingId, Vec<&'f HirExpr>>,
     let_or_param: HashSet<BindingId>,
     params: HashSet<BindingId>,
     memo: HashMap<BindingId, bool>,
+    fresh: &'f HashMap<hew_hir::ItemId, bool>,
 }
 
 impl<'f> BaseOwnerResolver<'f> {
@@ -4732,13 +4769,28 @@ impl<'f> BaseOwnerResolver<'f> {
         // Clone out the def references (cheap: each is a pointer) so the borrow
         // of `self.defs` is released before the recursive `init_proves` calls.
         let inits: Vec<&'f HirExpr> = self.defs.get(&binding).cloned().unwrap_or_default();
-        let result = if !is_param && inits.is_empty() {
+        let result = if is_param {
+            // A by-value heap parameter is a BORROW, not a move (LESSONS
+            // `by-value-heap-params-are-borrows`): the caller retains ownership,
+            // so the parameter's incoming value is NEVER a proven unique owner.
+            // Flow-insensitively the borrowed origin reaches every use that a
+            // reassignment does not provably dominate (`fn f(mut p) { if c { p =
+            // makeInner() } { ..p, x } }` aliases the caller's argument on the
+            // `!c` path), so a parameter-introduced base fails closed regardless
+            // of any reassignment. The gate sees only the callee body, never the
+            // call site: `fn upd(p: Cfg) -> Cfg { Cfg { name: .., ..p } }` is
+            // sound for `upd(moved_in_local)` but a use-after-free for
+            // `upd(o.cfg)` where the caller's `o` stays live — the override-drop
+            // frees `o.cfg.name` under the live owner (empirically: SIGSEGV /
+            // scribble-poison read under Guard Malloc). Indistinguishable here,
+            // so reject.
+            false
+        } else if inits.is_empty() {
             // A `let x;` with no initialiser and no reassignment is
             // uninitialised (the move-checker rejects a read) — not an owner.
             false
         } else {
-            // A by-value parameter origin is itself a unique owner (the caller
-            // moved the value in); every recorded definition must also prove.
+            // Every recorded definition must prove a materialised owner.
             inits.iter().all(|init| self.init_proves(init, visiting))
         };
         visiting.remove(&binding);
@@ -4759,10 +4811,13 @@ impl<'f> BaseOwnerResolver<'f> {
                 ..
             } => self.resolve(*source, visiting),
             // Every other initialiser must be a materialised owner directly (a
-            // call / clone / record-or-tuple literal / funcupdate result / Vec
-            // element, or a projection rooted at one). A projection of a live
-            // binding (`o.inner`, `t.0`) is NOT materialised and fails here.
-            _ => Builder::expr_is_materialized_owner(init),
+            // call to a proven-fresh fn / clone / record-or-tuple literal /
+            // funcupdate result / Vec element, or a projection rooted at one). A
+            // projection of a live binding (`o.inner`, `t.0`) is NOT materialised
+            // and fails here; a call is checked against the freshness summary; a
+            // construction embedding a whole by-value parameter is rejected via
+            // the prescan's `params` set.
+            _ => Builder::expr_is_materialized_owner(init, self.fresh, &self.params),
         }
     }
 }
@@ -5086,6 +5141,523 @@ fn collect_binding_defs_in_expr<'f>(
     }
 }
 
+/// Per-function summary for the destructive-funcupdate base gate: does function
+/// `f` provably return a FRESH MATERIALISED owner on EVERY return path — a value
+/// in its own storage that does NOT originate from a by-value heap parameter?
+///
+/// A by-value heap parameter is a BORROW, not a move (LESSONS
+/// `by-value-heap-params-are-borrows`): the caller retains ownership, so a
+/// function that hands one of its params back — directly (`fn id(p) { p }`), as
+/// a projection (`fn g(p) { p.inner }`), or laundered through another such call
+/// (`fn h(p) { id(p) }`) — returns a value that ALIASES the caller's still-live
+/// argument WITHOUT a refcount bump. Using that result as a `{ ..base, f: new }`
+/// base then frees the caller's live storage at the override-drop: the
+/// call-returns-borrowed-param use-after-free. This summary lets
+/// `expr_is_materialized_owner` admit a `..f(args)` base ONLY when `f` cannot
+/// leak a borrowed argument through its return — for ANY arguments, since the
+/// call site cannot know whether a given argument is itself live elsewhere.
+///
+/// Least-fixpoint from all-false (a function earns `true` only by positive
+/// proof). `fresh[f] == true` iff every return path of `f` is a construction /
+/// `.clone()` / `Vec` element / funcupdate result, a projection rooted at one,
+/// or a `Call` to an ALREADY-proven-fresh function. A return that is (or
+/// projects, or is laundered through a call to) a parameter or a bare local
+/// binding, a method call (which can return borrowed `self`/param), or a call to
+/// an unproven / external / mutually-recursive callee fails the function closed.
+/// Methods, extern fns, and builtins are absent from `fns` and read as `false`.
+///
+/// Conservative by construction: a helper that returns a let-bound local
+/// (`fn make() { let x = Inner { .. }; x }`) is classified non-fresh — sound
+/// (fail-closed), at the cost of over-rejecting that idiom as a funcupdate base.
+fn compute_fn_returns_fresh_owner(
+    fns: &HashMap<hew_hir::ItemId, &HirFn>,
+) -> HashMap<hew_hir::ItemId, bool> {
+    let mut fresh: HashMap<hew_hir::ItemId, bool> = fns.keys().map(|&id| (id, false)).collect();
+    // Monotone least-fixpoint: a pass only ever flips false→true, and a flip
+    // requires every return path fresh under the CURRENT table, so iteration
+    // converges in at most (longest fresh call chain) passes.
+    loop {
+        let mut changed = false;
+        for (&id, &f) in fns {
+            if fresh[&id] {
+                continue;
+            }
+            if fn_body_returns_fresh_owner(f, &fresh) {
+                fresh.insert(id, true);
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    fresh
+}
+
+/// True when EVERY value-bearing return path of `f` — every `return <expr>`
+/// anywhere in the body that is not inside a nested closure, plus the
+/// fall-through tail when it yields a value — is a fresh materialised owner
+/// under the current `fresh` table. A body with no value-bearing return path is
+/// not a fresh owner (fail closed).
+fn fn_body_returns_fresh_owner(f: &HirFn, fresh: &HashMap<hew_hir::ItemId, bool>) -> bool {
+    // Every explicit `return <expr>` value (statement and expression forms, at
+    // any depth, NOT descending into closures whose `return` exits the closure
+    // rather than `f`).
+    let mut return_values: Vec<&HirExpr> = Vec::new();
+    collect_return_values_in_block(&f.body, &mut return_values);
+    // The fall-through tail is the remaining return path — but only when it
+    // actually produces a value. A unit-/never-typed tail (`if c { return x }
+    // else { return y }`, or a block ending in a `return`) is a diverging
+    // continuation, not a value the function hands back, so it does not gate
+    // freshness.
+    if let Some(tail) = &f.body.tail {
+        if !matches!(tail.ty, ResolvedTy::Unit | ResolvedTy::Never) {
+            return_values.push(tail);
+        }
+    }
+    if return_values.is_empty() {
+        return false;
+    }
+    // Fresh iff NO return path aliases a by-value parameter (directly, via a
+    // projection, embedded in a construction, or laundered through a call that
+    // forwards a parameter). The aliasing question is param-INDEPENDENT — it
+    // composes through nested calls without arg-flow tracking — so a single
+    // module-global fixpoint suffices.
+    return_values
+        .iter()
+        .all(|e| !return_value_may_alias_borrow(e, fresh))
+}
+
+/// True when `expr`, used as a function's return value, MAY alias a by-value
+/// heap parameter of that function — i.e. the returned value is (or transitively
+/// embeds / projects / launders) a borrow the caller still owns. The negation is
+/// "provably a fresh owner". This is the leaf of the module freshness fixpoint.
+///
+/// WHY a dedicated may-alias predicate and not "is the operand itself fresh":
+/// a constructor operand like `string.repeat("a", 32)` is a `Call` to a callee
+/// the summary cannot prove fresh (its body bottoms out in a runtime method),
+/// yet its result CANNOT alias the enclosing function's parameters because every
+/// argument is a literal. Asking "is the operand fresh" would reject it (and
+/// collapse every `Record { f: string.repeat(..) }` helper); asking "does the
+/// operand alias a parameter" admits it. A `Call(g, args)` aliases a parameter
+/// ONLY when `g` is not proven fresh AND some argument itself aliases a
+/// parameter — the param-flow that composes interprocedurally.
+///
+/// EXHAUSTIVE and fail-closed: every form that is not provably non-aliasing
+/// (a bare binding, a method call, a deref, any unmodelled form) returns `true`.
+fn return_value_may_alias_borrow(expr: &HirExpr, fresh: &HashMap<hew_hir::ItemId, bool>) -> bool {
+    match &expr.kind {
+        // Value-passthrough wrappers: the value flows from the tail / both
+        // branches / every arm — aliasing iff ANY reachable value aliases.
+        HirExprKind::Block(block) => block
+            .tail
+            .as_deref()
+            .is_none_or(|t| return_value_may_alias_borrow(t, fresh)),
+        HirExprKind::If {
+            then_expr,
+            else_expr,
+            ..
+        } => {
+            return_value_may_alias_borrow(then_expr, fresh)
+                || else_expr
+                    .as_deref()
+                    .is_none_or(|e| return_value_may_alias_borrow(e, fresh))
+        }
+        HirExprKind::Match { arms, .. } => {
+            arms.is_empty()
+                || arms
+                    .iter()
+                    .any(|arm| return_value_may_alias_borrow(&arm.body, fresh))
+        }
+        // A nested `return <e>` in value position (`... else { return p }`)
+        // contributes its own value; it aliases iff that value does.
+        HirExprKind::Return { value } => value
+            .as_deref()
+            .is_none_or(|v| return_value_may_alias_borrow(v, fresh)),
+        // Fresh leaves — NEVER an alias of a caller-owned value. A `.clone()` is
+        // a deep copy; a `Vec<T>` element load / slice is an independent heap
+        // element (push-clone + refcount); a literal owns nothing borrowed.
+        HirExprKind::RecordCloneCall { .. }
+        | HirExprKind::Index { .. }
+        | HirExprKind::Slice { .. }
+        | HirExprKind::Literal(_) => false,
+        // A construction aliases a parameter iff one of its owned operands does.
+        // Storing a managed operand into a field/element refcount-bumps or
+        // COW-copies a PROJECTION/temporary, but a WHOLE by-value parameter is
+        // moved without a bump (`Outer { inner: p }` returns a value whose
+        // `inner` aliases the caller's argument — the call-returns-a-constructor-
+        // embedding-a-borrow use-after-free). The recursion bottoms a bare
+        // parameter operand out at the `_ => true` arm, so it is caught.
+        HirExprKind::StructInit { fields, base, .. } => {
+            fields
+                .iter()
+                .any(|(_, v)| return_value_may_alias_borrow(v, fresh))
+                || base
+                    .as_deref()
+                    .is_some_and(|b| return_value_may_alias_borrow(b, fresh))
+        }
+        HirExprKind::TupleLiteral { elements } => elements
+            .iter()
+            .any(|e| return_value_may_alias_borrow(e, fresh)),
+        HirExprKind::MachineVariantCtor { payload, .. } => payload.as_ref().is_some_and(|fields| {
+            fields
+                .iter()
+                .any(|(_, v)| return_value_may_alias_borrow(v, fresh))
+        }),
+        // A free-function call aliases a parameter iff the callee is NOT proven
+        // to return a fresh owner AND some argument itself aliases a parameter
+        // (the callee could forward that argument out). A proven-fresh callee
+        // never aliases regardless of arguments; a non-fresh callee with only
+        // non-aliasing arguments (`string.repeat("a", 32)`) cannot alias the
+        // ENCLOSING function's parameters. Param-flow, composed through the
+        // fixpoint.
+        HirExprKind::Call { callee, args } => {
+            !callee_returns_fresh_owner(callee, fresh)
+                && args.iter().any(|a| return_value_may_alias_borrow(a, fresh))
+        }
+        // A projection aliases a parameter iff its object chain does: `p.inner`
+        // / `t.0` bottoms out at a bare parameter (`_ => true`) and carries that
+        // up; `makeOuter().inner` bottoms out at a fresh `Call` and does not.
+        HirExprKind::FieldAccess { object, .. } => return_value_may_alias_borrow(object, fresh),
+        HirExprKind::TupleIndex { tuple, .. } => return_value_may_alias_borrow(tuple, fresh),
+        // A by-value parameter is a BORROW; a bare local may itself hold a
+        // borrow (`let x = p; x`); a method call can return borrowed `self` /
+        // a parameter; a deref and every other form are not provably fresh.
+        // Fail closed: assume the value MAY alias.
+        _ => true,
+    }
+}
+
+/// Resolve a `Call` callee to its freshness fact.
+///
+/// - A statically-resolved item callee (`BindingRef { resolved: Item(id) }`)
+///   that names a function body IN THIS MODULE reads that body's summary entry
+///   (the analyzed `fresh` verdict — a HEW function that forwards a by-value
+///   parameter is `false`, caught by the interprocedural fixpoint).
+/// - A resolved item callee with NO body in this module is an extern / runtime
+///   primitive (`hew_string_repeat`, `hew_vec_*`, …) or an aggregate
+///   constructor. Both return a freshly-owned value by the cross-ABI
+///   owned-return contract: a callee returning a heap type hands back a value
+///   the caller owns and must free, so it cannot be a borrowed alias of an
+///   argument (an extern that returned an un-retained borrow would double-free
+///   in EVERY caller that frees the result, not just funcupdate — that is an
+///   ABI violation at the extern boundary, the same trust the `RecordCloneCall`
+///   / `Index` / `Slice` arms already extend to the `hew_*_clone` /
+///   `hew_*_get_clone` primitives they lower to). Classified fresh.
+/// - Any other callee shape (an unresolved name, a value-typed fn pointer, an
+///   indirect/closure call) is not statically resolvable and fails closed.
+fn callee_returns_fresh_owner(callee: &HirExpr, fresh: &HashMap<hew_hir::ItemId, bool>) -> bool {
+    if let HirExprKind::BindingRef {
+        resolved: ResolvedRef::Item(item_id),
+        ..
+    } = &callee.kind
+    {
+        // `Some(f)` — a module function body the summary analyzed; trust its
+        // verdict. `None` — a resolved item with no analyzable body here
+        // (extern primitive or constructor); fresh by the owned-return ABI.
+        fresh.get(item_id).copied().unwrap_or(true)
+    } else {
+        false
+    }
+}
+
+/// Collect every explicit `return <expr>` value in `block` (statement form),
+/// recursing into nested control flow but NOT into closures. Exhaustive over
+/// `HirStmtKind`: a missed return statement would let a borrowed-param return
+/// escape the freshness summary (a use-after-free), so every form is handled.
+fn collect_return_values_in_block<'f>(block: &'f HirBlock, out: &mut Vec<&'f HirExpr>) {
+    for stmt in &block.statements {
+        match &stmt.kind {
+            HirStmtKind::Let(_, init) => {
+                if let Some(init) = init {
+                    collect_return_values_in_expr(init, out);
+                }
+            }
+            HirStmtKind::Assign { target, value } => {
+                collect_return_values_in_expr(target, out);
+                collect_return_values_in_expr(value, out);
+            }
+            HirStmtKind::Expr(expr) => collect_return_values_in_expr(expr, out),
+            HirStmtKind::Return(Some(expr)) => {
+                out.push(expr);
+                collect_return_values_in_expr(expr, out);
+            }
+            HirStmtKind::Return(None) => {}
+            HirStmtKind::Defer { body, .. } => collect_return_values_in_expr(body, out),
+            HirStmtKind::LetElse {
+                scrutinee,
+                success_prelude,
+                else_body,
+                ..
+            } => {
+                collect_return_values_in_expr(scrutinee, out);
+                for prelude_stmt in success_prelude {
+                    if let HirStmtKind::Let(_, Some(value)) = &prelude_stmt.kind {
+                        collect_return_values_in_expr(value, out);
+                    }
+                }
+                collect_return_values_in_block(else_body, out);
+            }
+        }
+    }
+    if let Some(tail) = &block.tail {
+        collect_return_values_in_expr(tail, out);
+    }
+}
+
+/// Collect every explicit `return <expr>` value reachable from `expr` (the
+/// `HirExprKind::Return` expression form plus any buried in sub-expressions and
+/// nested blocks), recursing into all sub-expressions EXCEPT closure /
+/// lambda-actor bodies (whose `return` exits the closure, not the enclosing
+/// function). Exhaustive over the sealed `HirExprKind` surface (mirrors
+/// `collect_binding_defs_in_expr`) so no buried return is missed.
+#[allow(
+    clippy::too_many_lines,
+    clippy::match_same_arms,
+    reason = "visitor mirrors the sealed HirExprKind surface so return-value collection is exhaustive; the closure/lambda-actor arm is kept separate from the leaf no-op arm to document the do-NOT-descend invariant (a `return` inside a closure exits the closure, not the enclosing function)"
+)]
+fn collect_return_values_in_expr<'f>(expr: &'f HirExpr, out: &mut Vec<&'f HirExpr>) {
+    match &expr.kind {
+        HirExprKind::Literal(_)
+        | HirExprKind::RegexLiteralRef { .. }
+        | HirExprKind::BindingRef { .. }
+        | HirExprKind::AwaitTask { .. }
+        | HirExprKind::ContextReader { .. }
+        | HirExprKind::MachineFieldAccess { .. }
+        | HirExprKind::MachineEventFieldAccess { .. }
+        | HirExprKind::Continue { .. }
+        | HirExprKind::ActorSelf
+        | HirExprKind::Unsupported(_) => {}
+        HirExprKind::Binary { left, right, .. } | HirExprKind::IdentityCompare { left, right } => {
+            collect_return_values_in_expr(left, out);
+            collect_return_values_in_expr(right, out);
+        }
+        HirExprKind::Unary { operand, .. } | HirExprKind::WireCodec { operand, .. } => {
+            collect_return_values_in_expr(operand, out);
+        }
+        HirExprKind::ConnAwaitRead { conn, .. } => collect_return_values_in_expr(conn, out),
+        HirExprKind::ListenerAwaitAccept { listener, .. } => {
+            collect_return_values_in_expr(listener, out);
+        }
+        HirExprKind::StreamRecvAwait { stream, .. } => {
+            collect_return_values_in_expr(stream, out);
+        }
+        HirExprKind::NumericCast { value, .. }
+        | HirExprKind::SaturatingWidthCast { value, .. }
+        | HirExprKind::CoerceToDynTrait { value, .. } => {
+            collect_return_values_in_expr(value, out);
+        }
+        HirExprKind::TupleLiteral { elements } => {
+            for elem in elements {
+                collect_return_values_in_expr(elem, out);
+            }
+        }
+        HirExprKind::NumericMethod { receiver, arg, .. } => {
+            collect_return_values_in_expr(receiver, out);
+            collect_return_values_in_expr(arg, out);
+        }
+        HirExprKind::Call { callee, args } | HirExprKind::SpawnedCall { callee, args, .. } => {
+            collect_return_values_in_expr(callee, out);
+            for arg in args {
+                collect_return_values_in_expr(arg, out);
+            }
+        }
+        HirExprKind::Spawn { args, .. } => {
+            for (_, arg) in args {
+                collect_return_values_in_expr(arg, out);
+            }
+        }
+        HirExprKind::ActorSend { receiver, args, .. }
+        | HirExprKind::ActorAsk { receiver, args, .. }
+        | HirExprKind::CallDynMethod { receiver, args, .. }
+        | HirExprKind::ResolvedImplCall { receiver, args, .. }
+        | HirExprKind::CallTraitMethodStatic { receiver, args, .. }
+        | HirExprKind::VarSelfMethodCall { receiver, args, .. } => {
+            collect_return_values_in_expr(receiver, out);
+            for arg in args {
+                collect_return_values_in_expr(arg, out);
+            }
+        }
+        HirExprKind::RemoteActorAsk {
+            receiver,
+            msg,
+            timeout_ms,
+            ..
+        } => {
+            collect_return_values_in_expr(receiver, out);
+            collect_return_values_in_expr(msg, out);
+            collect_return_values_in_expr(timeout_ms, out);
+        }
+        HirExprKind::Block(block)
+        | HirExprKind::Scope { body: block }
+        | HirExprKind::ForkBlock { body: block, .. }
+        | HirExprKind::GenBlock { body: block, .. } => {
+            collect_return_values_in_block(block, out);
+        }
+        // `return <e>` — the value escapes the FUNCTION; collect it and recurse
+        // for nested returns inside `e`. `yield`/`break` carry values out of a
+        // generator/loop, NOT the function, so recurse but do not collect.
+        HirExprKind::Return { value } => {
+            if let Some(value) = value {
+                out.push(value);
+                collect_return_values_in_expr(value, out);
+            }
+        }
+        HirExprKind::Yield { value, .. } | HirExprKind::Break { value, .. } => {
+            if let Some(value) = value {
+                collect_return_values_in_expr(value, out);
+            }
+        }
+        HirExprKind::If {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            collect_return_values_in_expr(condition, out);
+            collect_return_values_in_expr(then_expr, out);
+            if let Some(else_expr) = else_expr {
+                collect_return_values_in_expr(else_expr, out);
+            }
+        }
+        HirExprKind::StructInit { fields, base, .. } => {
+            for (_, field_expr) in fields {
+                collect_return_values_in_expr(field_expr, out);
+            }
+            if let Some(base) = base {
+                collect_return_values_in_expr(base, out);
+            }
+        }
+        HirExprKind::FieldAccess { object, .. } => collect_return_values_in_expr(object, out),
+        HirExprKind::ScopeDeadline { duration, body } => {
+            collect_return_values_in_expr(duration, out);
+            collect_return_values_in_block(body, out);
+        }
+        HirExprKind::Select(select) => {
+            for arm in &select.arms {
+                match &arm.kind {
+                    hew_hir::HirSelectArmKind::StreamNext { stream } => {
+                        collect_return_values_in_expr(stream, out);
+                    }
+                    hew_hir::HirSelectArmKind::ActorAsk { actor, args, .. } => {
+                        collect_return_values_in_expr(actor, out);
+                        for arg in args {
+                            collect_return_values_in_expr(arg, out);
+                        }
+                    }
+                    hew_hir::HirSelectArmKind::TaskAwait { task } => {
+                        collect_return_values_in_expr(task, out);
+                    }
+                    hew_hir::HirSelectArmKind::ChannelRecv { receiver, .. } => {
+                        collect_return_values_in_expr(receiver, out);
+                    }
+                    hew_hir::HirSelectArmKind::AfterTimer { duration } => {
+                        collect_return_values_in_expr(duration, out);
+                    }
+                }
+                collect_return_values_in_expr(&arm.body, out);
+            }
+        }
+        HirExprKind::Join(join) => {
+            for branch in &join.branches {
+                collect_return_values_in_expr(&branch.actor, out);
+                for arg in &branch.args {
+                    collect_return_values_in_expr(arg, out);
+                }
+            }
+        }
+        // Closure / lambda-actor bodies: a `return` inside exits the CLOSURE,
+        // not the enclosing function, so do NOT descend.
+        HirExprKind::SpawnLambdaActor { .. } | HirExprKind::Closure { .. } => {}
+        HirExprKind::TupleIndex { tuple, .. } => collect_return_values_in_expr(tuple, out),
+        HirExprKind::Index { container, index } => {
+            collect_return_values_in_expr(container, out);
+            collect_return_values_in_expr(index, out);
+        }
+        HirExprKind::Slice {
+            container,
+            start,
+            end,
+            ..
+        } => {
+            collect_return_values_in_expr(container, out);
+            if let Some(start) = start {
+                collect_return_values_in_expr(start, out);
+            }
+            if let Some(end) = end {
+                collect_return_values_in_expr(end, out);
+            }
+        }
+        HirExprKind::MachineEmit { fields, .. } => {
+            for (_, field_val) in fields {
+                collect_return_values_in_expr(field_val, out);
+            }
+        }
+        HirExprKind::MachineStep {
+            receiver, event, ..
+        } => {
+            collect_return_values_in_expr(receiver, out);
+            collect_return_values_in_expr(event, out);
+        }
+        HirExprKind::ChannelRecvAwait { receiver, .. }
+        | HirExprKind::CancellationTokenIsCancelled { receiver }
+        | HirExprKind::GeneratorNext { receiver, .. }
+        | HirExprKind::MachineStateName { receiver, .. }
+        | HirExprKind::RecordCloneCall { src: receiver, .. } => {
+            collect_return_values_in_expr(receiver, out);
+        }
+        HirExprKind::MachineVariantCtor { payload, .. } => {
+            if let Some(fields) = payload {
+                for (_, val) in fields {
+                    collect_return_values_in_expr(val, out);
+                }
+            }
+        }
+        HirExprKind::While {
+            condition, body, ..
+        } => {
+            collect_return_values_in_expr(condition, out);
+            collect_return_values_in_block(body, out);
+        }
+        HirExprKind::ForRange {
+            start,
+            end,
+            step,
+            body,
+            ..
+        } => {
+            collect_return_values_in_expr(start, out);
+            collect_return_values_in_expr(end, out);
+            collect_return_values_in_expr(step, out);
+            collect_return_values_in_block(body, out);
+        }
+        HirExprKind::Match { scrutinee, arms } => {
+            collect_return_values_in_expr(scrutinee, out);
+            for arm in arms {
+                collect_return_values_in_expr(&arm.body, out);
+            }
+        }
+        HirExprKind::WhileLet {
+            scrutinee, body, ..
+        } => {
+            collect_return_values_in_expr(scrutinee, out);
+            collect_return_values_in_block(body, out);
+        }
+        HirExprKind::IfLet {
+            scrutinee,
+            body,
+            else_body,
+            ..
+        } => {
+            collect_return_values_in_expr(scrutinee, out);
+            collect_return_values_in_block(body, out);
+            if let Some(eb) = else_body {
+                collect_return_values_in_block(eb, out);
+            }
+        }
+        HirExprKind::Loop { body, .. } => collect_return_values_in_block(body, out),
+    }
+}
+
 #[derive(Debug)]
 struct LoweredFunction {
     thir: ThirFunction,
@@ -5141,6 +5713,7 @@ fn lower_function(
     current_actor_name: Option<&str>,
     module_fn_names: &HashSet<String>,
     module_generic_fn_names: &HashSet<String>,
+    funcupdate_fn_returns_fresh: &Rc<HashMap<hew_hir::ItemId, bool>>,
     trait_impl_index: &HashMap<
         hew_hir::dispatch::TraitImplKey,
         hew_hir::dispatch::TraitImplMethodEntry,
@@ -5186,6 +5759,7 @@ fn lower_function(
             .unwrap_or_default(),
         module_fn_names: module_fn_names.clone(),
         module_generic_fn_names: module_generic_fn_names.clone(),
+        funcupdate_fn_returns_fresh: funcupdate_fn_returns_fresh.clone(),
         trait_impl_index: trait_impl_index.clone(),
         subst,
         call_site_type_args: call_site_type_args.clone(),
@@ -5208,7 +5782,8 @@ fn lower_function(
     // Codegen emits a parameter-prologue that stores each LLVM function
     // argument into the corresponding alloca slot before the first instruction.
     builder.lower_params(func);
-    builder.funcupdate_base_proven = compute_funcupdate_base_provenance(func);
+    builder.funcupdate_base_proven =
+        compute_funcupdate_base_provenance(func, funcupdate_fn_returns_fresh);
     builder.function_body(func);
 
     // Effective return type after type-parameter substitution.
@@ -5971,6 +6546,27 @@ struct Builder {
     /// (match-arm payload, let-else, loop var), is ABSENT or `false` — the gate
     /// then fails closed. See `base_is_safe_for_destructive_funcupdate`.
     funcupdate_base_proven: HashMap<BindingId, bool>,
+    /// Module-global interprocedural freshness summary: maps each free-function
+    /// `ItemId` to whether it provably returns a FRESH MATERIALISED owner on
+    /// every return path (`compute_fn_returns_fresh_owner`). Consulted by
+    /// `expr_is_materialized_owner` so a `..f(args)` funcupdate base is admitted
+    /// ONLY when `f` cannot launder a borrowed by-value parameter through its
+    /// return (the call-returns-borrowed-param use-after-free). `Rc` so child
+    /// builders share it cheaply; the empty default fails every call-base
+    /// closed, which is sound. See `compute_fn_returns_fresh_owner`.
+    funcupdate_fn_returns_fresh: Rc<HashMap<hew_hir::ItemId, bool>>,
+    /// Binding ids of the CURRENT function's by-value parameters, captured in
+    /// `lower_params`. A funcupdate base that is (or embeds in a construction) a
+    /// WHOLE by-value parameter is NOT a unique owner — the parameter is a
+    /// borrow (LESSONS `by-value-heap-params-are-borrows`) stored without a
+    /// refcount bump (`{ ..Wrap { s: p, .. }, s: new }` frees the caller's `p`
+    /// at the override-drop). Consulted by `expr_is_materialized_owner` to reject
+    /// such bases. `Rc` so child builders (closures) inherit the enclosing
+    /// parameters cheaply; the empty default is sound (admits nothing extra).
+    /// Projections of a parameter (`p.inner`) and bare locals are NOT listed —
+    /// a field read refcount-bumps and a local move consumes, both empirically
+    /// owner-preserving.
+    funcupdate_param_ids: Rc<HashSet<BindingId>>,
     /// F-04 fungible supervisor-child reference table. Maps the handle local id
     /// produced by `lower_supervisor_child_get` (`Place::ActorHandle(N)`) to the
     /// stable `(supervisor, slot)` reference it stands for.
@@ -7249,6 +7845,11 @@ impl Builder {
     /// produce indices ≥ `params.len()`, maintaining the invariant documented
     /// on `RawMirFunction.params`.
     fn lower_params(&mut self, func: &HirFn) {
+        // Record the by-value parameter binding ids for the destructive-
+        // funcupdate base gate: a base that embeds a WHOLE parameter is a borrow,
+        // not a unique owner. Captured here so every entry point that lowers a
+        // parameterised body through `lower_params` participates.
+        self.funcupdate_param_ids = Rc::new(func.params.iter().map(|p| p.id).collect());
         for param in &func.params {
             let slot = self.alloc_local(param.ty.clone());
             self.binding_locals.insert(param.id, slot);
@@ -18696,6 +19297,7 @@ impl Builder {
             machine_layout_names: self.machine_layout_names.clone(),
             module_fn_names: self.module_fn_names.clone(),
             module_generic_fn_names: self.module_generic_fn_names.clone(),
+            funcupdate_fn_returns_fresh: self.funcupdate_fn_returns_fresh.clone(),
             subst: self.subst.clone(),
             call_site_type_args: self.call_site_type_args.clone(),
             supervisor_child_slots: self.supervisor_child_slots.clone(),
@@ -22886,6 +23488,7 @@ impl Builder {
             machine_layout_names: self.machine_layout_names.clone(),
             module_fn_names: self.module_fn_names.clone(),
             module_generic_fn_names: self.module_generic_fn_names.clone(),
+            funcupdate_fn_returns_fresh: self.funcupdate_fn_returns_fresh.clone(),
             subst: self.subst.clone(),
             call_site_type_args: self.call_site_type_args.clone(),
             supervisor_child_slots: self.supervisor_child_slots.clone(),
@@ -22902,6 +23505,10 @@ impl Builder {
             // a `{ ..base, f }` inside a closure is gated by the same proof
             // instead of failing closed for want of the map.
             funcupdate_base_proven: self.funcupdate_base_proven.clone(),
+            // Same rationale: the enclosing function's by-value parameters are
+            // globally-unique bindings a closure can capture and embed in a
+            // funcupdate base, so the child must see them to reject the borrow.
+            funcupdate_param_ids: self.funcupdate_param_ids.clone(),
             ..Builder::default()
         }
     }
@@ -23081,6 +23688,7 @@ impl Builder {
             machine_layout_names: self.machine_layout_names.clone(),
             module_fn_names: self.module_fn_names.clone(),
             module_generic_fn_names: self.module_generic_fn_names.clone(),
+            funcupdate_fn_returns_fresh: self.funcupdate_fn_returns_fresh.clone(),
             subst: self.subst.clone(),
             call_site_type_args: self.call_site_type_args.clone(),
             supervisor_child_slots: self.supervisor_child_slots.clone(),
@@ -24160,6 +24768,7 @@ impl Builder {
             machine_layout_names: self.machine_layout_names.clone(),
             module_fn_names: self.module_fn_names.clone(),
             module_generic_fn_names: self.module_generic_fn_names.clone(),
+            funcupdate_fn_returns_fresh: self.funcupdate_fn_returns_fresh.clone(),
             subst: self.subst.clone(),
             call_site_type_args: self.call_site_type_args.clone(),
             supervisor_child_slots: self.supervisor_child_slots.clone(),
@@ -24988,7 +25597,11 @@ impl Builder {
         }
         // (b) Every other base — INCLUDING every wrapper — is safe only if
         //     every reachable value is a materialised owner with no live alias.
-        Self::expr_is_materialized_owner(base)
+        Self::expr_is_materialized_owner(
+            base,
+            &self.funcupdate_fn_returns_fresh,
+            &self.funcupdate_param_ids,
+        )
     }
 
     /// True when `expr` evaluates to a freshly MATERIALISED owner — a value in
@@ -25006,9 +25619,17 @@ impl Builder {
     /// rejected because a reachable value aliases the live `o`.
     ///
     /// Materialised leaves:
-    ///   * a call / method / `.clone()` result — a fresh value written into its
-    ///     own return slot (`Call`, the four method-call variants,
-    ///     `RecordCloneCall`);
+    ///   * a `.clone()` result (`RecordCloneCall`) — a fresh deep copy;
+    ///   * a free-function `Call` whose callee is PROVEN to return a fresh owner
+    ///     by the module interprocedural summary (`compute_fn_returns_fresh_-
+    ///     owner`, threaded as `fresh`). A call is NOT blanket-fresh: a function
+    ///     can launder a by-value heap parameter (a BORROW — LESSONS
+    ///     `by-value-heap-params-are-borrows`) through its return without a
+    ///     refcount bump (`fn id(p: Inner) -> Inner { p }`), so `..id(o.inner)`
+    ///     would free the caller's live `o.inner` at the override-drop. Method
+    ///     calls (`CallDynMethod`/`CallTraitMethodStatic`/`VarSelfMethodCall`/
+    ///     `ResolvedImplCall`) can likewise return borrowed `self`/params and are
+    ///     NOT summarised, so they fail closed;
     ///   * a `Vec<T>` element load (`v[i]`) or slice (`v[a..b]`). The element
     ///     is independent of any live binding: `hew_vec_push_owned` deep-clones
     ///     each element on insert (`clone_fn`) and the buffer carries its own
@@ -25027,16 +25648,20 @@ impl Builder {
     /// EVERY other form — a `BindingRef` (live local, `Const`, or `Item`), a
     /// `MachineFieldAccess` (`self.field`), a deref, a loop-break value, or any
     /// expression form added later — returns false (fail closed).
-    // The owned-rvalue arm and the `Index`/`Slice` arm both yield `true` but
-    // are kept separate: they admit a leaf for DIFFERENT safety reasons (a
-    // call result is a fresh return-slot value; a `Vec` element is heap-
-    // independent via push-clone + refcount). Merging them would erase that
-    // distinction in a security-critical allowlist.
+    // The `RecordCloneCall`/`Call` arm and the `Index`/`Slice` arm both can
+    // yield `true` but are kept separate: they admit a leaf for DIFFERENT safety
+    // reasons (a clone / proven-fresh call is a fresh return-slot value; a `Vec`
+    // element is heap-independent via push-clone + refcount). Merging them would
+    // erase that distinction in a security-critical allowlist.
     #[allow(
         clippy::match_same_arms,
         reason = "distinct safety rationales per arm in a security-critical allowlist"
     )]
-    fn expr_is_materialized_owner(expr: &HirExpr) -> bool {
+    fn expr_is_materialized_owner(
+        expr: &HirExpr,
+        fresh: &HashMap<hew_hir::ItemId, bool>,
+        params: &HashSet<BindingId>,
+    ) -> bool {
         match &expr.kind {
             // ---- value-passthrough wrappers: ALL reachable values must be
             //      materialised (look THROUGH; reject any bare-binding leaf) ----
@@ -25045,7 +25670,7 @@ impl Builder {
             HirExprKind::Block(block) => block
                 .tail
                 .as_deref()
-                .is_some_and(Self::expr_is_materialized_owner),
+                .is_some_and(|t| Self::expr_is_materialized_owner(t, fresh, params)),
             // BOTH `if` branches must be materialised. A missing `else` cannot
             // produce an owned-record value, so it fails closed.
             HirExprKind::If {
@@ -25053,10 +25678,10 @@ impl Builder {
                 else_expr,
                 ..
             } => {
-                Self::expr_is_materialized_owner(then_expr)
+                Self::expr_is_materialized_owner(then_expr, fresh, params)
                     && else_expr
                         .as_deref()
-                        .is_some_and(Self::expr_is_materialized_owner)
+                        .is_some_and(|e| Self::expr_is_materialized_owner(e, fresh, params))
             }
             // EVERY `match` arm body must be materialised (an arm body that is a
             // bare payload binding aliases the scrutinee and fails closed).
@@ -25064,42 +25689,96 @@ impl Builder {
                 !arms.is_empty()
                     && arms
                         .iter()
-                        .all(|arm| Self::expr_is_materialized_owner(&arm.body))
+                        .all(|arm| Self::expr_is_materialized_owner(&arm.body, fresh, params))
             }
             // ---- materialised leaves ----
-            // Owned rvalues: a call / method / clone result is a fresh value
-            // materialised into its own slot. Conservatively limited to the
-            // call-like variants whose result is an owned value; any unlisted
-            // form fails closed.
-            HirExprKind::Call { .. }
-            | HirExprKind::CallDynMethod { .. }
-            | HirExprKind::CallTraitMethodStatic { .. }
-            | HirExprKind::VarSelfMethodCall { .. }
-            | HirExprKind::ResolvedImplCall { .. }
-            | HirExprKind::RecordCloneCall { .. } => true,
+            // A `.clone()` result is a fresh deep copy materialised into its own
+            // slot — unconditionally an owner.
+            HirExprKind::RecordCloneCall { .. } => true,
+            // A free-function call is a materialised owner ONLY when the module
+            // interprocedural summary proves the callee returns a fresh owner on
+            // every path. A blanket `Call => true` is UNSOUND: a function can
+            // launder a by-value heap parameter (a BORROW) through its return
+            // without a refcount bump (`fn id(p: Inner) -> Inner { p }`), so
+            // `..id(o.inner)` would free the caller's live `o.inner` at the
+            // override-drop (the call-returns-borrowed-param use-after-free).
+            // Method-call variants can likewise return borrowed `self`/params
+            // and are not summarised — they fall to the fail-closed `_` arm.
+            HirExprKind::Call { callee, .. } => callee_returns_fresh_owner(callee, fresh),
             // A `Vec<T>` element load / slice — an independent heap element
             // (see the push-clone + refcount note above), not an interior alias
             // of a surviving named binding.
             HirExprKind::Index { .. } | HirExprKind::Slice { .. } => true,
             // A record/tuple/enum literal AND a functional-update result
             // (`Record { f: .. }`, `Record { ..base, f: new }`) — construction
-            // writes a FRESH record into its own storage. Each owned field
-            // operand is stored with value semantics (a field read like
-            // `o.inner.label` is COW-copied / refcount-bumped into the new
-            // slot, NOT shallow-aliased — empirically a destructive funcupdate
-            // over `let b = Record { label: o.inner.label, .. }` does not
-            // dangle `o`), so the constructed record uniquely owns its fields.
-            // A `..base` funcupdate result is likewise fresh; that inner base's
-            // own safety is enforced when IT lowers, independently of this
-            // classification. This is the leaf that keeps `let base = Record {
-            // .. }; { ..base, f }` (and the reassign-loop) admitted.
-            HirExprKind::StructInit { .. } => true,
+            // writes a FRESH record into its own storage. A field operand that is
+            // a PROJECTION (`o.inner.label`), a bare LOCAL (moved-in), a CALL
+            // result, or a `.clone()` is refcount-bumped / COW-copied / consumed
+            // into the new slot — empirically owner-preserving (a destructive
+            // funcupdate over such a record does not dangle the source). The ONE
+            // exception is a WHOLE by-value PARAMETER operand: a parameter is a
+            // borrow stored WITHOUT a refcount bump, so `{ ..Wrap { s: p, .. },
+            // s: new }` frees the caller's `p` at the override-drop. Reject a
+            // construction that embeds (directly or through nested constructions)
+            // a whole parameter; admit every other construction. A nested `..base`
+            // is checked too — its own embedded parameters dangle identically.
+            HirExprKind::StructInit { fields, base, .. } => {
+                !fields
+                    .iter()
+                    .any(|(_, v)| Self::expr_embeds_whole_param(v, params))
+                    && base
+                        .as_deref()
+                        .is_none_or(|b| !Self::expr_embeds_whole_param(b, params))
+            }
             // A projection is materialised iff its object chain is.
-            HirExprKind::FieldAccess { object, .. } => Self::expr_is_materialized_owner(object),
-            HirExprKind::TupleIndex { tuple, .. } => Self::expr_is_materialized_owner(tuple),
-            // Bare/`Const` binding ref, machine-state field projection, deref,
-            // or any future expression form — not provably a materialised
-            // owner. Fail closed.
+            HirExprKind::FieldAccess { object, .. } => {
+                Self::expr_is_materialized_owner(object, fresh, params)
+            }
+            HirExprKind::TupleIndex { tuple, .. } => {
+                Self::expr_is_materialized_owner(tuple, fresh, params)
+            }
+            // Bare/`Const` binding ref, machine-state field projection, deref, a
+            // method call (can return borrowed `self`/param), or any future
+            // expression form — not provably a materialised owner. Fail closed.
+            _ => false,
+        }
+    }
+
+    /// True when `expr` is, or embeds through a construction, a WHOLE by-value
+    /// parameter — the borrow that a constructor stores without a refcount bump.
+    ///
+    /// Recurses only through constructions (struct / tuple / machine-variant
+    /// literals), which embed operands by value. A PROJECTION (`p.inner`), a
+    /// CALL, a `.clone()`, a `Vec` element, and a literal are NOT embeds of a
+    /// whole parameter — a field read bumps, a call/clone materialises a fresh
+    /// value — so they stop the recursion (return `false`). A bare parameter
+    /// binding is the borrow this catches; a bare LOCAL is move-consumed into the
+    /// construction and stays an owner, so only `params` membership returns
+    /// `true`.
+    fn expr_embeds_whole_param(expr: &HirExpr, params: &HashSet<BindingId>) -> bool {
+        match &expr.kind {
+            HirExprKind::BindingRef {
+                resolved: ResolvedRef::Binding(id),
+                ..
+            } => params.contains(id),
+            HirExprKind::StructInit { fields, base, .. } => {
+                fields
+                    .iter()
+                    .any(|(_, v)| Self::expr_embeds_whole_param(v, params))
+                    || base
+                        .as_deref()
+                        .is_some_and(|b| Self::expr_embeds_whole_param(b, params))
+            }
+            HirExprKind::TupleLiteral { elements } => elements
+                .iter()
+                .any(|e| Self::expr_embeds_whole_param(e, params)),
+            HirExprKind::MachineVariantCtor { payload, .. } => {
+                payload.as_ref().is_some_and(|fields| {
+                    fields
+                        .iter()
+                        .any(|(_, v)| Self::expr_embeds_whole_param(v, params))
+                })
+            }
             _ => false,
         }
     }
@@ -33781,6 +34460,7 @@ mod slice3_invariants {
                 None,
                 &HashSet::new(),
                 &HashSet::new(),
+                &std::rc::Rc::new(std::collections::HashMap::new()),
                 &HashMap::new(),
                 &HashMap::new(),
                 None,

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -4653,6 +4653,439 @@ fn collect_unknown_self_fields_in_expr(
     }
 }
 
+/// Flow-insensitive prescan deciding, for every binding in `func`, whether a
+/// destructive `{ ..<binding>, f: new }` is a PROVEN unique owner of its heap
+/// fields — see the `Builder::funcupdate_base_proven` field and
+/// `base_is_safe_for_destructive_funcupdate`.
+///
+/// A binding is proven iff it is introduced by a `let` or a by-value parameter
+/// AND every one of its definitions (the `let` initialiser, every `=`
+/// reassignment, and the parameter origin) is a materialised owner
+/// (`Builder::expr_is_materialized_owner`) or a move-chain of such
+/// (`let c = makeThing(); let d = c; { ..d, f }`). A binding bound from a
+/// projection of a still-live owner (`let b = o.inner`), or introduced by any
+/// other form (match-arm payload, let-else binder, loop variable), is left
+/// UNPROVEN so the base gate fails closed.
+///
+/// FLOW-INSENSITIVE BY DESIGN: EVERY definition must prove safe, regardless of
+/// control flow. This is conservative (a binding that is safely materialised at
+/// the update site but aliased on a dead branch is rejected) but SOUND — it
+/// cannot admit a binding that aliases a live owner on ANY path, which a
+/// last-write-wins flow-sensitive map would (`var c = o.inner; if p { c =
+/// makeThing() } { ..c, f }` is unsafe on the `p == false` path). The reassign-
+/// loop idiom (`var c = Record { .. }; while .. { c = Record { ..c, f } }`) stays
+/// admitted because every definition is a record literal / funcupdate result.
+fn compute_funcupdate_base_provenance(func: &HirFn) -> HashMap<BindingId, bool> {
+    let mut defs: HashMap<BindingId, Vec<&HirExpr>> = HashMap::new();
+    let mut let_or_param: HashSet<BindingId> = HashSet::new();
+    let mut params: HashSet<BindingId> = HashSet::new();
+    for param in &func.params {
+        params.insert(param.id);
+        let_or_param.insert(param.id);
+    }
+    collect_binding_defs_in_block(&func.body, &mut defs, &mut let_or_param);
+
+    let mut resolver = BaseOwnerResolver {
+        defs,
+        let_or_param,
+        params,
+        memo: HashMap::new(),
+    };
+    let ids: Vec<BindingId> = resolver.let_or_param.iter().copied().collect();
+    for id in ids {
+        let mut visiting: HashSet<BindingId> = HashSet::new();
+        resolver.resolve(id, &mut visiting);
+    }
+    resolver.memo
+}
+
+/// Memoised resolver for `compute_funcupdate_base_provenance`. `defs` maps each
+/// binding to every initialiser/reassignment expression that defines it;
+/// `let_or_param` is the set of bindings introduced by a `let` or a parameter
+/// (any other origin is unproven); `params` is the by-value parameter subset.
+struct BaseOwnerResolver<'f> {
+    defs: HashMap<BindingId, Vec<&'f HirExpr>>,
+    let_or_param: HashSet<BindingId>,
+    params: HashSet<BindingId>,
+    memo: HashMap<BindingId, bool>,
+}
+
+impl<'f> BaseOwnerResolver<'f> {
+    /// True iff `{ ..<binding>, f: new }` is a proven unique owner: `binding` is
+    /// `let`/param-introduced and EVERY definition proves a materialised owner.
+    fn resolve(&mut self, binding: BindingId, visiting: &mut HashSet<BindingId>) -> bool {
+        if let Some(&cached) = self.memo.get(&binding) {
+            return cached;
+        }
+        // A binding NOT introduced by a `let`/parameter (match-arm payload,
+        // let-else binder, loop variable, or an origin the prescan does not
+        // model) cannot be proven a unique owner — fail closed.
+        if !self.let_or_param.contains(&binding) {
+            return false;
+        }
+        // A definition cycle (only reachable via pathological reassignment) is
+        // not provable — fail closed without recursing forever.
+        if !visiting.insert(binding) {
+            return false;
+        }
+        let is_param = self.params.contains(&binding);
+        // Clone out the def references (cheap: each is a pointer) so the borrow
+        // of `self.defs` is released before the recursive `init_proves` calls.
+        let inits: Vec<&'f HirExpr> = self.defs.get(&binding).cloned().unwrap_or_default();
+        let result = if !is_param && inits.is_empty() {
+            // A `let x;` with no initialiser and no reassignment is
+            // uninitialised (the move-checker rejects a read) — not an owner.
+            false
+        } else {
+            // A by-value parameter origin is itself a unique owner (the caller
+            // moved the value in); every recorded definition must also prove.
+            inits.iter().all(|init| self.init_proves(init, visiting))
+        };
+        visiting.remove(&binding);
+        self.memo.insert(binding, result);
+        result
+    }
+
+    /// Classify a single definition expression of a binding.
+    fn init_proves(&mut self, init: &HirExpr, visiting: &mut HashSet<BindingId>) -> bool {
+        match &init.kind {
+            // A whole-binding move (`let d = c`) CONSUMES the source — the
+            // move-checker rejects a later use of `c` — so `d` inherits `c`'s
+            // unique-ownership provenance. Recurse: a move-chain of materialised
+            // owners is proven; a chain rooted at a live-projection rebind
+            // (`let b = o.inner; let c = b; { ..c, f }`) is not.
+            HirExprKind::BindingRef {
+                resolved: ResolvedRef::Binding(source),
+                ..
+            } => self.resolve(*source, visiting),
+            // Every other initialiser must be a materialised owner directly (a
+            // call / clone / record-or-tuple literal / funcupdate result / Vec
+            // element, or a projection rooted at one). A projection of a live
+            // binding (`o.inner`, `t.0`) is NOT materialised and fails here.
+            _ => Builder::expr_is_materialized_owner(init),
+        }
+    }
+}
+
+/// Collect every binding definition in `block` into `defs` (and record each
+/// `let`-introduced binding in `let_ids`) for `compute_funcupdate_base_-
+/// provenance`. EXHAUSTIVE over statements: a missed reassignment to a live-
+/// projection alias would reopen the funcupdate use-after-free, whereas a missed
+/// binding merely fails the gate closed.
+fn collect_binding_defs_in_block<'f>(
+    block: &'f HirBlock,
+    defs: &mut HashMap<BindingId, Vec<&'f HirExpr>>,
+    let_ids: &mut HashSet<BindingId>,
+) {
+    for stmt in &block.statements {
+        match &stmt.kind {
+            HirStmtKind::Let(binding, init) => {
+                let_ids.insert(binding.id);
+                if let Some(init) = init {
+                    defs.entry(binding.id).or_default().push(init);
+                    collect_binding_defs_in_expr(init, defs, let_ids);
+                }
+            }
+            HirStmtKind::Assign { target, value } => {
+                // A reassignment of a whole binding redefines its provenance; a
+                // field/index assignment (`o.f = ..`) does not rebind the name.
+                if let HirExprKind::BindingRef {
+                    resolved: ResolvedRef::Binding(binding_id),
+                    ..
+                } = &target.kind
+                {
+                    defs.entry(*binding_id).or_default().push(value);
+                }
+                collect_binding_defs_in_expr(target, defs, let_ids);
+                collect_binding_defs_in_expr(value, defs, let_ids);
+            }
+            HirStmtKind::Expr(expr) | HirStmtKind::Return(Some(expr)) => {
+                collect_binding_defs_in_expr(expr, defs, let_ids);
+            }
+            HirStmtKind::Return(None) => {}
+            HirStmtKind::Defer { body, .. } => {
+                collect_binding_defs_in_expr(body, defs, let_ids);
+            }
+            HirStmtKind::LetElse {
+                scrutinee,
+                success_prelude,
+                else_body,
+                ..
+            } => {
+                // The escaping let-else binders are deliberately NOT recorded in
+                // `let_ids`: a binder destructured from a scrutinee projection is
+                // not a proven unique owner, so it must fail the base gate
+                // closed. Still recurse for nested defs/reassignments.
+                collect_binding_defs_in_expr(scrutinee, defs, let_ids);
+                for prelude_stmt in success_prelude {
+                    if let HirStmtKind::Let(_, Some(value)) = &prelude_stmt.kind {
+                        collect_binding_defs_in_expr(value, defs, let_ids);
+                    }
+                }
+                collect_binding_defs_in_block(else_body, defs, let_ids);
+            }
+        }
+    }
+    if let Some(tail) = &block.tail {
+        collect_binding_defs_in_expr(tail, defs, let_ids);
+    }
+}
+
+/// Recurse into every sub-expression and nested block of `expr` so
+/// `collect_binding_defs_in_block` reaches every `let`/`=` in inner scopes.
+/// Mirrors the sealed `HirExprKind` surface (cf.
+/// `collect_unknown_self_fields_in_expr`) so no nested reassignment is missed.
+#[allow(
+    clippy::too_many_lines,
+    reason = "visitor mirrors the sealed HirExprKind surface so binding-def collection is exhaustive"
+)]
+fn collect_binding_defs_in_expr<'f>(
+    expr: &'f HirExpr,
+    defs: &mut HashMap<BindingId, Vec<&'f HirExpr>>,
+    let_ids: &mut HashSet<BindingId>,
+) {
+    match &expr.kind {
+        HirExprKind::Literal(_)
+        | HirExprKind::RegexLiteralRef { .. }
+        | HirExprKind::BindingRef { .. }
+        | HirExprKind::AwaitTask { .. }
+        | HirExprKind::ContextReader { .. }
+        | HirExprKind::MachineFieldAccess { .. }
+        | HirExprKind::MachineEventFieldAccess { .. }
+        | HirExprKind::Continue { .. }
+        | HirExprKind::ActorSelf
+        | HirExprKind::Unsupported(_) => {}
+        HirExprKind::Binary { left, right, .. } | HirExprKind::IdentityCompare { left, right } => {
+            collect_binding_defs_in_expr(left, defs, let_ids);
+            collect_binding_defs_in_expr(right, defs, let_ids);
+        }
+        HirExprKind::Unary { operand, .. } | HirExprKind::WireCodec { operand, .. } => {
+            collect_binding_defs_in_expr(operand, defs, let_ids);
+        }
+        HirExprKind::ConnAwaitRead { conn, .. } => {
+            collect_binding_defs_in_expr(conn, defs, let_ids);
+        }
+        HirExprKind::ListenerAwaitAccept { listener, .. } => {
+            collect_binding_defs_in_expr(listener, defs, let_ids);
+        }
+        HirExprKind::StreamRecvAwait { stream, .. } => {
+            collect_binding_defs_in_expr(stream, defs, let_ids);
+        }
+        HirExprKind::NumericCast { value, .. }
+        | HirExprKind::SaturatingWidthCast { value, .. }
+        | HirExprKind::CoerceToDynTrait { value, .. } => {
+            collect_binding_defs_in_expr(value, defs, let_ids);
+        }
+        HirExprKind::TupleLiteral { elements } => {
+            for elem in elements {
+                collect_binding_defs_in_expr(elem, defs, let_ids);
+            }
+        }
+        HirExprKind::NumericMethod { receiver, arg, .. } => {
+            collect_binding_defs_in_expr(receiver, defs, let_ids);
+            collect_binding_defs_in_expr(arg, defs, let_ids);
+        }
+        HirExprKind::Call { callee, args } | HirExprKind::SpawnedCall { callee, args, .. } => {
+            collect_binding_defs_in_expr(callee, defs, let_ids);
+            for arg in args {
+                collect_binding_defs_in_expr(arg, defs, let_ids);
+            }
+        }
+        HirExprKind::Spawn { args, .. } => {
+            for (_, arg) in args {
+                collect_binding_defs_in_expr(arg, defs, let_ids);
+            }
+        }
+        HirExprKind::ActorSend { receiver, args, .. }
+        | HirExprKind::ActorAsk { receiver, args, .. }
+        | HirExprKind::CallDynMethod { receiver, args, .. }
+        | HirExprKind::ResolvedImplCall { receiver, args, .. }
+        | HirExprKind::CallTraitMethodStatic { receiver, args, .. }
+        | HirExprKind::VarSelfMethodCall { receiver, args, .. } => {
+            collect_binding_defs_in_expr(receiver, defs, let_ids);
+            for arg in args {
+                collect_binding_defs_in_expr(arg, defs, let_ids);
+            }
+        }
+        HirExprKind::RemoteActorAsk {
+            receiver,
+            msg,
+            timeout_ms,
+            ..
+        } => {
+            collect_binding_defs_in_expr(receiver, defs, let_ids);
+            collect_binding_defs_in_expr(msg, defs, let_ids);
+            collect_binding_defs_in_expr(timeout_ms, defs, let_ids);
+        }
+        HirExprKind::Block(block)
+        | HirExprKind::Scope { body: block }
+        | HirExprKind::ForkBlock { body: block, .. }
+        | HirExprKind::GenBlock { body: block, .. } => {
+            collect_binding_defs_in_block(block, defs, let_ids);
+        }
+        HirExprKind::Yield { value, .. }
+        | HirExprKind::Break { value, .. }
+        | HirExprKind::Return { value } => {
+            if let Some(value) = value {
+                collect_binding_defs_in_expr(value, defs, let_ids);
+            }
+        }
+        HirExprKind::If {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            collect_binding_defs_in_expr(condition, defs, let_ids);
+            collect_binding_defs_in_expr(then_expr, defs, let_ids);
+            if let Some(else_expr) = else_expr {
+                collect_binding_defs_in_expr(else_expr, defs, let_ids);
+            }
+        }
+        HirExprKind::StructInit { fields, base, .. } => {
+            for (_, field_expr) in fields {
+                collect_binding_defs_in_expr(field_expr, defs, let_ids);
+            }
+            if let Some(base) = base {
+                collect_binding_defs_in_expr(base, defs, let_ids);
+            }
+        }
+        HirExprKind::FieldAccess { object, .. } => {
+            collect_binding_defs_in_expr(object, defs, let_ids);
+        }
+        HirExprKind::ScopeDeadline { duration, body } => {
+            collect_binding_defs_in_expr(duration, defs, let_ids);
+            collect_binding_defs_in_block(body, defs, let_ids);
+        }
+        HirExprKind::Select(select) => {
+            for arm in &select.arms {
+                match &arm.kind {
+                    hew_hir::HirSelectArmKind::StreamNext { stream } => {
+                        collect_binding_defs_in_expr(stream, defs, let_ids);
+                    }
+                    hew_hir::HirSelectArmKind::ActorAsk { actor, args, .. } => {
+                        collect_binding_defs_in_expr(actor, defs, let_ids);
+                        for arg in args {
+                            collect_binding_defs_in_expr(arg, defs, let_ids);
+                        }
+                    }
+                    hew_hir::HirSelectArmKind::TaskAwait { task } => {
+                        collect_binding_defs_in_expr(task, defs, let_ids);
+                    }
+                    hew_hir::HirSelectArmKind::ChannelRecv { receiver, .. } => {
+                        collect_binding_defs_in_expr(receiver, defs, let_ids);
+                    }
+                    hew_hir::HirSelectArmKind::AfterTimer { duration } => {
+                        collect_binding_defs_in_expr(duration, defs, let_ids);
+                    }
+                }
+                collect_binding_defs_in_expr(&arm.body, defs, let_ids);
+            }
+        }
+        HirExprKind::Join(join) => {
+            for branch in &join.branches {
+                collect_binding_defs_in_expr(&branch.actor, defs, let_ids);
+                for arg in &branch.args {
+                    collect_binding_defs_in_expr(arg, defs, let_ids);
+                }
+            }
+        }
+        HirExprKind::SpawnLambdaActor { body, .. } | HirExprKind::Closure { body, .. } => {
+            collect_binding_defs_in_expr(body, defs, let_ids);
+        }
+        HirExprKind::TupleIndex { tuple, .. } => {
+            collect_binding_defs_in_expr(tuple, defs, let_ids);
+        }
+        HirExprKind::Index { container, index } => {
+            collect_binding_defs_in_expr(container, defs, let_ids);
+            collect_binding_defs_in_expr(index, defs, let_ids);
+        }
+        HirExprKind::Slice {
+            container,
+            start,
+            end,
+            ..
+        } => {
+            collect_binding_defs_in_expr(container, defs, let_ids);
+            if let Some(start) = start {
+                collect_binding_defs_in_expr(start, defs, let_ids);
+            }
+            if let Some(end) = end {
+                collect_binding_defs_in_expr(end, defs, let_ids);
+            }
+        }
+        HirExprKind::MachineEmit { fields, .. } => {
+            for (_, field_val) in fields {
+                collect_binding_defs_in_expr(field_val, defs, let_ids);
+            }
+        }
+        HirExprKind::MachineStep {
+            receiver, event, ..
+        } => {
+            collect_binding_defs_in_expr(receiver, defs, let_ids);
+            collect_binding_defs_in_expr(event, defs, let_ids);
+        }
+        HirExprKind::ChannelRecvAwait { receiver, .. }
+        | HirExprKind::CancellationTokenIsCancelled { receiver }
+        | HirExprKind::GeneratorNext { receiver, .. }
+        | HirExprKind::MachineStateName { receiver, .. }
+        | HirExprKind::RecordCloneCall { src: receiver, .. } => {
+            collect_binding_defs_in_expr(receiver, defs, let_ids);
+        }
+        HirExprKind::MachineVariantCtor { payload, .. } => {
+            if let Some(fields) = payload {
+                for (_, val) in fields {
+                    collect_binding_defs_in_expr(val, defs, let_ids);
+                }
+            }
+        }
+        HirExprKind::While {
+            condition, body, ..
+        } => {
+            collect_binding_defs_in_expr(condition, defs, let_ids);
+            collect_binding_defs_in_block(body, defs, let_ids);
+        }
+        HirExprKind::ForRange {
+            start,
+            end,
+            step,
+            body,
+            ..
+        } => {
+            collect_binding_defs_in_expr(start, defs, let_ids);
+            collect_binding_defs_in_expr(end, defs, let_ids);
+            collect_binding_defs_in_expr(step, defs, let_ids);
+            collect_binding_defs_in_block(body, defs, let_ids);
+        }
+        HirExprKind::Match { scrutinee, arms } => {
+            collect_binding_defs_in_expr(scrutinee, defs, let_ids);
+            for arm in arms {
+                collect_binding_defs_in_expr(&arm.body, defs, let_ids);
+            }
+        }
+        HirExprKind::WhileLet {
+            scrutinee, body, ..
+        } => {
+            collect_binding_defs_in_expr(scrutinee, defs, let_ids);
+            collect_binding_defs_in_block(body, defs, let_ids);
+        }
+        HirExprKind::IfLet {
+            scrutinee,
+            body,
+            else_body,
+            ..
+        } => {
+            collect_binding_defs_in_expr(scrutinee, defs, let_ids);
+            collect_binding_defs_in_block(body, defs, let_ids);
+            if let Some(eb) = else_body {
+                collect_binding_defs_in_block(eb, defs, let_ids);
+            }
+        }
+        HirExprKind::Loop { body, .. } => {
+            collect_binding_defs_in_block(body, defs, let_ids);
+        }
+    }
+}
+
 #[derive(Debug)]
 struct LoweredFunction {
     thir: ThirFunction,
@@ -4775,6 +5208,7 @@ fn lower_function(
     // Codegen emits a parameter-prologue that stores each LLVM function
     // argument into the corresponding alloca slot before the first instruction.
     builder.lower_params(func);
+    builder.funcupdate_base_proven = compute_funcupdate_base_provenance(func);
     builder.function_body(func);
 
     // Effective return type after type-parameter substitution.
@@ -5523,6 +5957,20 @@ struct Builder {
     /// initialiser. Cluster 1 reads the slot directly; later clusters add
     /// drop-cleanup and rebinding semantics.
     binding_locals: HashMap<BindingId, Place>,
+    /// Per-function destructive-funcupdate base provenance. Maps a `BindingId`
+    /// to whether `{ ..<binding>, f: new }` over it is a PROVEN unique owner of
+    /// its heap fields — i.e. consuming it leaves no live alias, so the
+    /// override-drop's in-place field release is sound. Populated once per
+    /// function by `compute_funcupdate_base_provenance` (a flow-insensitive
+    /// prescan of the body) BEFORE the body is lowered, so the base allowlist
+    /// gate sees every reassignment. A binding is proven iff EVERY definition
+    /// (its `let` initialiser, every `=` reassignment, or a by-value parameter
+    /// origin) is a materialised owner (`expr_is_materialized_owner`) or a
+    /// move-chain of such; a binding bound from a projection of a still-live
+    /// owner (`let b = o.inner`), or introduced by any non-`let`/non-param form
+    /// (match-arm payload, let-else, loop var), is ABSENT or `false` — the gate
+    /// then fails closed. See `base_is_safe_for_destructive_funcupdate`.
+    funcupdate_base_proven: HashMap<BindingId, bool>,
     /// F-04 fungible supervisor-child reference table. Maps the handle local id
     /// produced by `lower_supervisor_child_get` (`Place::ActorHandle(N)`) to the
     /// stable `(supervisor, slot)` reference it stands for.
@@ -9743,17 +10191,20 @@ impl Builder {
                 // The override-drop below frees an overridden owned field of
                 // `base` IN PLACE, and the non-overridden owned fields escape
                 // via shallow `RecordFieldLoad`. Both are sound ONLY when the
-                // base does not interior-alias storage that stays live after the
-                // update. Rather than denylist the unsafe projection shapes (a
-                // list that has repeatedly missed cases — `FieldAccess`, then
-                // `Index`, then `TupleIndex` — each a fresh use-after-free), the
-                // base must POSITIVELY prove safe via
-                // `base_is_safe_for_destructive_funcupdate`: a bare consume-
-                // marked binding, or a materialised owner with no live alias
-                // (call / `.clone()` result, `Vec` element `v[i]`, or a
+                // base is the UNIQUE live owner of its heap fields. Rather than
+                // denylist the unsafe projection shapes (a list that has
+                // repeatedly missed cases — `FieldAccess`, then `Index`, then
+                // `TupleIndex`, then a bare binding REBOUND from a projection —
+                // each a fresh use-after-free), the base must POSITIVELY prove
+                // safe via `base_is_safe_for_destructive_funcupdate`: a bare
+                // binding whose PROVENANCE proves unique ownership (every
+                // definition a materialised owner — consume-marked in place), or
+                // a directly-materialised owner with no live alias (call /
+                // `.clone()` result, record literal, `Vec` element `v[i]`, or a
                 // projection rooted at one). Any other base — a projection of a
-                // LIVE binding (`o.inner`, `t.0`, `o.pair.0`, nested), a
-                // machine-state field (`self.field`), a `Const`/`Item` ref, a
+                // LIVE binding (`o.inner`, `t.0`, `o.pair.0`, nested), a bare
+                // binding bound from such a projection (`let b = o.inner; ..b`),
+                // a machine-state field (`self.field`), a `Const`/`Item` ref, a
                 // deref, or any future expression form — is rejected. This is
                 // complete by construction: no base shape can slip the gate.
                 //
@@ -9764,7 +10215,7 @@ impl Builder {
                 if let Some(base_expr) = base.as_deref() {
                     let base_ty = self.subst_ty(&base_expr.ty);
                     if self.aggregate_ingress_moves_binding_ty(&base_ty)
-                        && !Self::base_is_safe_for_destructive_funcupdate(base_expr)
+                        && !self.base_is_safe_for_destructive_funcupdate(base_expr)
                     {
                         // Walk every sub-expression for checker-stream
                         // coverage before bailing, mirroring the paths above.
@@ -9780,23 +10231,27 @@ impl Builder {
                                 site: expr.site,
                             },
                             note: format!(
-                                "the `..base` of `{name}` is neither a bare binding (consumed \
-                                 in place by the update) nor a freshly-owned value, so it \
-                                 interior-aliases storage that stays live after the update — a \
-                                 field projection of a live binding (`b.field`, `b.0`, \
-                                 `t.0.field`), a machine-state field (`self.field`), or another \
-                                 aliasing shape. The update's in-place release of an overridden \
-                                 owned field (and the shallow carry of the non-overridden owned \
-                                 fields) would then free memory the live owner still references \
-                                 — a use-after-free, and a double-free at its scope-exit drop. \
-                                 Clone the base into a fresh owned value \
+                                "the `..base` of `{name}` is not provably the unique owner of \
+                                 its heap fields, so it may interior-alias storage that stays \
+                                 live after the update — a field projection of a live binding \
+                                 (`b.field`, `b.0`, `t.0.field`), a machine-state field \
+                                 (`self.field`), a binding REBOUND from such a projection \
+                                 (`let b = o.inner; ..b` — `b` shares `o.inner`'s storage), or \
+                                 another aliasing shape. The update's in-place release of an \
+                                 overridden owned field (and the shallow carry of the \
+                                 non-overridden owned fields) would then free memory the live \
+                                 owner still references — a use-after-free, and a double-free at \
+                                 its scope-exit drop. Clone the base into a fresh owned value \
                                  (`{name} {{ ..<base>.clone(), <field>: new }}`), or clone the \
                                  overridden field. (Binding the projection first — \
                                  `let b = <base>` — does NOT help: it re-aliases the same \
-                                 storage. Accepted as-is: a bare owned-binding base (`..base`), \
-                                 and an owned-rvalue base — a call result or a `Vec` element \
-                                 `v[i]`.) The COW value model that keeps a projected source live \
-                                 after an update is not yet implemented."
+                                 storage; clone or consume the source instead. Accepted: a bare \
+                                 binding whose every definition is a freshly-owned value — a call \
+                                 result, a `.clone()`, a record literal, a `Vec` element `v[i]`, \
+                                 or a move-chain of those (this admits the reassign-loop idiom) \
+                                 — and an owned-rvalue base directly.) The COW value model that \
+                                 keeps a projected source live after an update is not yet \
+                                 implemented."
                             ),
                         });
                         return None;
@@ -9957,7 +10412,7 @@ impl Builder {
                         if emits_override_drop {
                             // (A) Allowlist backstop — fires for every base shape.
                             debug_assert!(
-                                Self::base_is_safe_for_destructive_funcupdate(base_expr),
+                                self.base_is_safe_for_destructive_funcupdate(base_expr),
                                 "functional-update override-drop on a base that did NOT pass \
                                  `base_is_safe_for_destructive_funcupdate`: the in-place field \
                                  release would be a use-after-free. The allowlist gate (1b) and \
@@ -22440,6 +22895,13 @@ impl Builder {
             // inherit the parent's target pointer width so an isize/usize
             // div/shift lowered inside a closure emits the same per-target guard.
             pointer_width: self.pointer_width,
+            // Destructive-funcupdate base provenance is computed once per
+            // top-level function over the WHOLE body (the prescan recurses into
+            // closure/gen bodies), and `BindingId`s are globally unique, so the
+            // parent map already classifies this child's bindings. Inherit it so
+            // a `{ ..base, f }` inside a closure is gated by the same proof
+            // instead of failing closed for want of the map.
+            funcupdate_base_proven: self.funcupdate_base_proven.clone(),
             ..Builder::default()
         }
     }
@@ -24471,38 +24933,58 @@ impl Builder {
     /// or as new expression forms are added — can silently reopen the UAF.
     ///
     /// A base is provably safe in exactly two ways:
-    ///   (a) a SYNTACTICALLY bare live `BindingRef` — `alias_moved_owned_-
-    ///       operand` consume-marks it, so the move-checker rejects any later
-    ///       read and the binding is excluded from its scope-exit drop: its
-    ///       fields are dead after the update. A binding wrapped in ANY
-    ///       control/block form does NOT qualify as (a): the consume does not
-    ///       peel wrappers, and a conditionally-selected binding cannot be
-    ///       soundly consumed — such a wrapper is held to (b) below, which
-    ///       rejects a bare-binding leaf. (Admitting `..{ base }` as (a) while
-    ///       the consume silently no-ops on the block is itself a UAF.)
+    ///   (a) a SYNTACTICALLY bare live `BindingRef` whose PROVENANCE proves it
+    ///       is the unique live owner of its heap fields. `alias_moved_owned_-
+    ///       operand` consume-marks the binding so the move-checker rejects any
+    ///       later read and excludes it from its scope-exit drop — but consuming
+    ///       the NAME does not make the destructive release sound if the
+    ///       binding's heap fields are ALIASED by a still-live owner. A binding
+    ///       bound from a projection of a live value (`let b = o.inner; ..b`)
+    ///       shares `o.inner`'s leaf pointers; consuming `b` then frees storage
+    ///       `o` still references — a double-free (the 5th UAF this allowlist
+    ///       leaked). So (a) holds ONLY when the per-function provenance prescan
+    ///       (`compute_funcupdate_base_provenance`, consulted via
+    ///       `funcupdate_base_proven`) proves EVERY definition of the binding is
+    ///       a materialised owner — its `let` initialiser, every `=`
+    ///       reassignment, or a by-value parameter origin — or a move-chain of
+    ///       such (`let c = makeThing(); let d = c; ..d`). A binding wrapped in
+    ///       ANY control/block form does NOT qualify as (a): the consume does
+    ///       not peel wrappers, and a conditionally-selected binding cannot be
+    ///       soundly consumed — such a wrapper is held to (b) below.
     ///   (b) a materialised owner with no live named alias — see
     ///       `expr_is_materialized_owner`, which looks THROUGH wrapper forms
     ///       (block tail, `if` branches, `match` arms) and requires EVERY
     ///       reachable value to be a fresh owned rvalue (`makeInner()`,
-    ///       `o.inner.clone()`), a `Vec<T>` element / slice (`v[i]`), or a
+    ///       `o.inner.clone()`), a record/tuple/enum literal or funcupdate
+    ///       result (`Record { .. }`), a `Vec<T>` element / slice (`v[i]`), or a
     ///       projection rooted at one (`makeOuter().inner`, `o.items[0].inner`).
     ///
-    /// ANY other base — a projection of a LIVE binding (`o.inner`, `t.0`,
-    /// `o.pair.0`, `t.0.inner`, nested), a machine-state field (`self.field`),
-    /// a `Const`/`Item` ref, a deref, a wrapper whose tail/branch/arm is any
-    /// of those (`{ base }`, `if c { o.inner } else { makeInner() }`), or any
-    /// future expression form — is NOT provably safe and is rejected
-    /// fail-closed.
-    fn base_is_safe_for_destructive_funcupdate(base: &HirExpr) -> bool {
-        // (a) ONLY a syntactically bare binding is the consume case. NO wrapper
-        //     peeling here: a block/if/match-wrapped binding is not reliably
-        //     consume-marked, so it must instead prove materialised via (b).
+    /// ANY other base — a bare binding whose provenance is unproven (a rebind of
+    /// a live projection `let b = o.inner`/`let b = t.0`, a match-arm payload, a
+    /// let-else binder, a loop variable), a projection of a LIVE binding
+    /// (`o.inner`, `t.0`, `o.pair.0`, `t.0.inner`, nested), a machine-state field
+    /// (`self.field`), a `Const`/`Item` ref, a deref, a wrapper whose
+    /// tail/branch/arm is any of those (`{ base }`, `if c { o.inner } else {
+    /// makeInner() }`), or any future expression form — is NOT provably safe and
+    /// is rejected fail-closed.
+    fn base_is_safe_for_destructive_funcupdate(&self, base: &HirExpr) -> bool {
+        // (a) A syntactically bare binding is the consume case — but ONLY when
+        //     its provenance proves it is the unique live owner of its heap
+        //     fields. Fail closed (reject) for any binding the prescan did not
+        //     prove (a live-projection rebind, a match/let-else/loop binder, or
+        //     an unseen origin). NO wrapper peeling here: a block/if/match-
+        //     wrapped binding is not reliably consume-marked, so it must instead
+        //     prove materialised via (b).
         if let HirExprKind::BindingRef {
-            resolved: ResolvedRef::Binding(_),
+            resolved: ResolvedRef::Binding(binding_id),
             ..
         } = &base.kind
         {
-            return true;
+            return self
+                .funcupdate_base_proven
+                .get(binding_id)
+                .copied()
+                .unwrap_or(false);
         }
         // (b) Every other base — INCLUDING every wrapper — is safe only if
         //     every reachable value is a materialised owner with no live alias.
@@ -24599,6 +25081,19 @@ impl Builder {
             // (see the push-clone + refcount note above), not an interior alias
             // of a surviving named binding.
             HirExprKind::Index { .. } | HirExprKind::Slice { .. } => true,
+            // A record/tuple/enum literal AND a functional-update result
+            // (`Record { f: .. }`, `Record { ..base, f: new }`) — construction
+            // writes a FRESH record into its own storage. Each owned field
+            // operand is stored with value semantics (a field read like
+            // `o.inner.label` is COW-copied / refcount-bumped into the new
+            // slot, NOT shallow-aliased — empirically a destructive funcupdate
+            // over `let b = Record { label: o.inner.label, .. }` does not
+            // dangle `o`), so the constructed record uniquely owns its fields.
+            // A `..base` funcupdate result is likewise fresh; that inner base's
+            // own safety is enforced when IT lowers, independently of this
+            // classification. This is the leaf that keeps `let base = Record {
+            // .. }; { ..base, f }` (and the reassign-loop) admitted.
+            HirExprKind::StructInit { .. } => true,
             // A projection is materialised iff its object chain is.
             HirExprKind::FieldAccess { object, .. } => Self::expr_is_materialized_owner(object),
             HirExprKind::TupleIndex { tuple, .. } => Self::expr_is_materialized_owner(tuple),

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -9739,63 +9739,67 @@ impl Builder {
                     }
                 }
 
-                // (1b) Projection-of-a-live-binding base reject (fail-closed).
-                // A `..base` that PROJECTS a field of a live binding
-                // (`{ ..o.inner, f: new }`) interior-aliases that binding's
-                // storage. Unlike a bare-binding base, the projection does NOT
-                // consume the root binding (`alias_moved_owned_operand` only
-                // marks a bare `BindingRef`, so `o` stays live) and the root is
-                // NOT excluded from its scope-exit drop. The OVERRIDDEN owned
-                // field is still destructively released at the construction site
-                // below — so the freed storage is reachable through
-                // `o.inner.<field>` (use-after-free) and is freed a second time
-                // when `o` drops (double-free).
+                // (1b) Fail-closed ALLOWLIST gate for the destructive base.
+                // The override-drop below frees an overridden owned field of
+                // `base` IN PLACE, and the non-overridden owned fields escape
+                // via shallow `RecordFieldLoad`. Both are sound ONLY when the
+                // base does not interior-alias storage that stays live after the
+                // update. Rather than denylist the unsafe projection shapes (a
+                // list that has repeatedly missed cases — `FieldAccess`, then
+                // `Index`, then `TupleIndex` — each a fresh use-after-free), the
+                // base must POSITIVELY prove safe via
+                // `base_is_safe_for_destructive_funcupdate`: a bare consume-
+                // marked binding, or a materialised owner with no live alias
+                // (call / `.clone()` result, `Vec` element `v[i]`, or a
+                // projection rooted at one). Any other base — a projection of a
+                // LIVE binding (`o.inner`, `t.0`, `o.pair.0`, nested), a
+                // machine-state field (`self.field`), a `Const`/`Item` ref, a
+                // deref, or any future expression form — is rejected. This is
+                // complete by construction: no base shape can slip the gate.
                 //
-                // Only OWNED-aggregate projection bases reach the override-drop
-                // path, so the reject is gated on `aggregate_ingress_moves_-
-                // binding_ty`: a `BitCopy` projection base bit-copies and stays
-                // valid. Bases that are NOT a projection of a live binding are
-                // unaffected: a bare-binding base is consumed (handled above);
-                // an owned rvalue / temporary base (`makeInner()`,
-                // `makeOuter().inner` — rooted at a call, not a binding) has no
-                // surviving named alias; an indexed base (`v[i]`) materialises an
-                // independent element value rather than an interior alias. Until
-                // the deep field-move (COW) value model lands, reject with
-                // clone / bind-first guidance — the fail-closed safe outcome,
-                // matching the self-aliasing-override reject above.
+                // Only OWNED-aggregate bases reach the override-drop / shallow-
+                // carry path, so the gate is type-fenced by
+                // `aggregate_ingress_moves_binding_ty`: a `BitCopy` base
+                // bit-copies and stays valid regardless of shape.
                 if let Some(base_expr) = base.as_deref() {
-                    if Self::functional_update_base_projects_live_binding(base_expr) {
-                        let base_ty = self.subst_ty(&base_expr.ty);
-                        if self.aggregate_ingress_moves_binding_ty(&base_ty) {
-                            // Walk every sub-expression for checker-stream
-                            // coverage before bailing, mirroring the paths above.
-                            for (_, fe) in fields {
-                                let _ = self.lower_value(fe);
-                            }
-                            let _ = self.lower_value(base_expr);
-                            self.diagnostics.push(MirDiagnostic {
-                                kind: MirDiagnosticKind::NotYetImplemented {
-                                    construct: "functional-update base projecting a live binding"
-                                        .to_string(),
-                                    site: expr.site,
-                                },
-                                note: format!(
-                                    "the `..base` of `{name}` projects a field of a live binding \
-                                     (`<binding>.<field>`) whose owned record would be consumed \
-                                     in place by the update: an overridden owned field is released \
-                                     at the construction site while the binding stays live, so a \
-                                     later read (`<binding>.<field>...`) or the binding's \
-                                     scope-exit drop would touch freed memory. Bind the projection \
-                                     into its own variable first \
-                                     (`let b = <binding>.<field>; {name} {{ ..b, <field>: new }}`) \
-                                     or clone the overridden field; a bare-binding base \
-                                     (`{name} {{ ..base, <field>: new }}`) is consumed safely. \
-                                     (The COW value model that keeps the source live after an \
-                                     update is not yet implemented.)"
-                                ),
-                            });
-                            return None;
+                    let base_ty = self.subst_ty(&base_expr.ty);
+                    if self.aggregate_ingress_moves_binding_ty(&base_ty)
+                        && !Self::base_is_safe_for_destructive_funcupdate(base_expr)
+                    {
+                        // Walk every sub-expression for checker-stream
+                        // coverage before bailing, mirroring the paths above.
+                        for (_, fe) in fields {
+                            let _ = self.lower_value(fe);
                         }
+                        let _ = self.lower_value(base_expr);
+                        self.diagnostics.push(MirDiagnostic {
+                            kind: MirDiagnosticKind::NotYetImplemented {
+                                construct:
+                                    "functional-update base that is not a binding or owned value"
+                                        .to_string(),
+                                site: expr.site,
+                            },
+                            note: format!(
+                                "the `..base` of `{name}` is neither a bare binding (consumed \
+                                 in place by the update) nor a freshly-owned value, so it \
+                                 interior-aliases storage that stays live after the update — a \
+                                 field projection of a live binding (`b.field`, `b.0`, \
+                                 `t.0.field`), a machine-state field (`self.field`), or another \
+                                 aliasing shape. The update's in-place release of an overridden \
+                                 owned field (and the shallow carry of the non-overridden owned \
+                                 fields) would then free memory the live owner still references \
+                                 — a use-after-free, and a double-free at its scope-exit drop. \
+                                 Clone the base into a fresh owned value \
+                                 (`{name} {{ ..<base>.clone(), <field>: new }}`), or clone the \
+                                 overridden field. (Binding the projection first — \
+                                 `let b = <base>` — does NOT help: it re-aliases the same \
+                                 storage. Accepted as-is: a bare owned-binding base (`..base`), \
+                                 and an owned-rvalue base — a call result or a `Vec` element \
+                                 `v[i]`.) The COW value model that keeps a projected source live \
+                                 after an update is not yet implemented."
+                            ),
+                        });
+                        return None;
                     }
                 }
 
@@ -9926,19 +9930,24 @@ impl Builder {
                 // reader:
                 //   * a bare-binding base is consume-marked (`AggregateAlias`),
                 //     so the move-checker rejects any later read of it;
-                //   * a projection of a live binding is REJECTED above
-                //     (fail-closed); and
-                //   * a temporary / rvalue base has no surviving named alias.
-                // Assert the first arm explicitly: if an owned-aggregate base
-                // BINDING reaches an override-drop WITHOUT a consume mark, some
-                // future change (e.g. admitting an opaque-handle record as
-                // `CowValue`, which would make `alias_moved_owned_operand`
-                // skip it) has silently reopened the use-after-free. The base
-                // consume and the override-drop are coupled invariants and must
-                // ship together.
+                //   * a materialised owner (call / `.clone()` result, `Vec`
+                //     element) has no surviving named alias; and
+                //   * any other base shape is REJECTED by the allowlist gate
+                //     (1b) above (fail-closed).
+                // Assert BOTH coupled invariants at EVERY override-drop site:
+                //   (A) the base passed `base_is_safe_for_destructive_funcupdate`
+                //       — reaching an override-drop with an unsafe base means the
+                //       (1b) allowlist gate was bypassed (a new expr form, a
+                //       refactor) and the UAF is reopened; and
+                //   (B) for the bare-binding sub-case, the consume mark actually
+                //       fired — the allowlist returns true for ANY binding shape,
+                //       but that arm's safety depends on `alias_moved_owned_-
+                //       operand` having emitted the `AggregateAlias` (a record
+                //       newly admitted as `CowValue` would be skipped, silently
+                //       reopening the UAF — the predicate-coupling guard).
                 #[cfg(debug_assertions)]
                 if base_place.is_some() {
-                    if let Some(base_id) = base_binding {
+                    if let Some(base_expr) = base.as_deref() {
                         let emits_override_drop = field_order.iter().any(|(fname, fty)| {
                             explicit.contains_key(fname.as_str())
                                 && self
@@ -9946,22 +9955,34 @@ impl Builder {
                                     .is_some()
                         });
                         if emits_override_drop {
-                            let consume_marked = self.statements.iter().any(|stmt| {
-                                matches!(
-                                    stmt,
-                                    MirStatement::AggregateAlias { binding, .. }
-                                        if *binding == base_id
-                                )
-                            });
+                            // (A) Allowlist backstop — fires for every base shape.
                             debug_assert!(
-                                consume_marked,
-                                "functional-update override-drop on base binding {base_id:?} that \
-                                 was NOT consume-marked: the in-place field release would be a \
-                                 use-after-free. The base consume (`alias_moved_owned_operand`) \
-                                 and the override-drop are coupled invariants — a change that \
-                                 admits an owned-aggregate base without the `AggregateAlias` mark \
-                                 has reopened the UAF."
+                                Self::base_is_safe_for_destructive_funcupdate(base_expr),
+                                "functional-update override-drop on a base that did NOT pass \
+                                 `base_is_safe_for_destructive_funcupdate`: the in-place field \
+                                 release would be a use-after-free. The allowlist gate (1b) and \
+                                 the override-drop are coupled invariants — a change that admits \
+                                 an unsafe base shape has reopened the UAF."
                             );
+                            // (B) Bare-binding sub-case: assert the consume fired.
+                            if let Some(base_id) = base_binding {
+                                let consume_marked = self.statements.iter().any(|stmt| {
+                                    matches!(
+                                        stmt,
+                                        MirStatement::AggregateAlias { binding, .. }
+                                            if *binding == base_id
+                                    )
+                                });
+                                debug_assert!(
+                                    consume_marked,
+                                    "functional-update override-drop on base binding {base_id:?} \
+                                     that was NOT consume-marked: the in-place field release would \
+                                     be a use-after-free. The base consume \
+                                     (`alias_moved_owned_operand`) and the override-drop are \
+                                     coupled invariants — a change that admits an owned-aggregate \
+                                     base without the `AggregateAlias` mark has reopened the UAF."
+                                );
+                            }
                         }
                     }
                 }
@@ -24436,48 +24457,114 @@ impl Builder {
         }
     }
 
-    /// True when a functional-update base, peeled of transparent tail-only
-    /// blocks, is a field PROJECTION whose object chain bottoms out at a live
-    /// local binding (`o.inner`, `o.a.b`) — as opposed to a temporary, call,
-    /// or indexed value.
+    /// Fail-closed ALLOWLIST for the destructive functional-update base.
     ///
-    /// Such a base interior-aliases the binding's storage: the binding stays
-    /// live (a projection is not consume-marked by `alias_moved_owned_operand`,
-    /// which only marks a bare `BindingRef`) yet the update's override-drop
-    /// would destructively free a field the binding still owns. The caller
-    /// rejects these bases (fail-closed) when the projected type is an owned
-    /// aggregate. A base rooted at a CALL (`makeOuter().inner`) is a consumed
-    /// temporary with no surviving named alias and is NOT flagged; an INDEXED
-    /// base (`v[i]`) materialises an independent element value, also not an
-    /// interior alias of a surviving binding.
-    fn functional_update_base_projects_live_binding(base: &HirExpr) -> bool {
+    /// An owned-record `..base` consumes the base in place: its non-overridden
+    /// owned fields escape via shallow `RecordFieldLoad` into the new record,
+    /// and its OVERRIDDEN owned fields are destructively released at the
+    /// construction site (the override-drop). Both operations are sound ONLY
+    /// when the base does not interior-alias storage that stays live after the
+    /// update. Rather than enumerate the unsafe shapes (a denylist that has
+    /// repeatedly missed cases — `FieldAccess`, then `Index`, then `TupleIndex`
+    /// — each a fresh use-after-free), this admits a base ONLY when it is
+    /// PROVABLY safe and rejects everything else, so no projection shape — now
+    /// or as new expression forms are added — can silently reopen the UAF.
+    ///
+    /// A base is provably safe in exactly two ways:
+    ///   (a) a bare live `BindingRef` — `alias_moved_owned_operand` consume-
+    ///       marks it, so the move-checker rejects any later read and the
+    ///       binding is excluded from its scope-exit drop: its fields are dead
+    ///       after the update; or
+    ///   (b) a materialised owner with no live named alias — a call/method/
+    ///       clone result (`makeInner()`, `o.inner.clone()`), a `Vec<T>`
+    ///       element load (`v[i]`) or slice, or a projection whose object chain
+    ///       bottoms out at one of those (`makeOuter().inner`,
+    ///       `o.items[0].inner`). See `expr_is_materialized_owner`.
+    ///
+    /// ANY other base — a projection of a LIVE binding (`o.inner`, `t.0`,
+    /// `o.pair.0`, `t.0.inner`, nested), a machine-state field (`self.field`),
+    /// a `Const`/`Item` ref, a deref, an `if`/`match` value, or any future
+    /// expression form — is NOT provably safe and is rejected fail-closed.
+    fn base_is_safe_for_destructive_funcupdate(base: &HirExpr) -> bool {
         match &base.kind {
-            // Peel a transparent tail-only block wrapper (`{ o.inner }`).
+            // Peel a transparent tail-only block wrapper (`{ ..; b }`).
             HirExprKind::Block(block) if block.statements.is_empty() => block
                 .tail
                 .as_deref()
-                .is_some_and(Self::functional_update_base_projects_live_binding),
-            // A field projection whose object chain roots at a live binding.
-            HirExprKind::FieldAccess { object, .. } => {
-                Self::projection_object_roots_at_live_binding(object)
-            }
-            _ => false,
-        }
-    }
-
-    /// Recurse through a projection's object chain (peeling only further
-    /// `FieldAccess`) to decide whether it bottoms out at a bare live
-    /// `BindingRef`. An `Index`, call, or any other root short-circuits to
-    /// false — those are not interior aliases of a surviving named binding.
-    fn projection_object_roots_at_live_binding(object: &HirExpr) -> bool {
-        match &object.kind {
+                .is_some_and(Self::base_is_safe_for_destructive_funcupdate),
+            // (a) Bare live binding — consume-marked, fields dead after update.
             HirExprKind::BindingRef {
                 resolved: ResolvedRef::Binding(_),
                 ..
             } => true,
-            HirExprKind::FieldAccess { object, .. } => {
-                Self::projection_object_roots_at_live_binding(object)
-            }
+            // (b) Materialised owner / temporary with no live named alias.
+            _ => Self::expr_is_materialized_owner(base),
+        }
+    }
+
+    /// True when `expr` evaluates to a freshly MATERIALISED owner — a value in
+    /// its own storage that does not alias any surviving named binding's inline
+    /// fields. Used for the `(b)` arm of the funcupdate base allowlist and to
+    /// recurse a projection's object chain.
+    ///
+    /// Materialised owners:
+    ///   * a call / method / `.clone()` result — a fresh value written into its
+    ///     own return slot (`Call`, the four method-call variants,
+    ///     `RecordCloneCall`);
+    ///   * a `Vec<T>` element load (`v[i]`) or slice (`v[a..b]`). The element
+    ///     is independent of any live binding: `hew_vec_push_owned` deep-clones
+    ///     each element on insert (`clone_fn`) and the buffer carries its own
+    ///     refcount, so the override-drop's in-place release of an element
+    ///     field decrements a shared count rather than freeing storage a live
+    ///     binding still references. (NOTE: `hew_vec_get_owned` itself returns a
+    ///     BORROW into the buffer, not a clone — the safety comes from the
+    ///     push-time deep clone + refcount, not from a materialising getter.
+    ///     `Index` is checker-restricted to `Vec<T>`; a future aliasing
+    ///     container would need re-evaluation here.)
+    ///
+    /// A projection (`expr.field`, `expr.0`) is materialised ONLY when its
+    /// object chain bottoms out at a materialised owner — `makeOuter().inner`
+    /// is safe, `o.inner` (rooted at a live binding) is not.
+    ///
+    /// EVERY other form — a `BindingRef` (live local, `Const`, or `Item`), a
+    /// `MachineFieldAccess` (`self.field`), a deref, an `if`/`match`, or any
+    /// expression form added later — returns false (fail closed).
+    // The owned-rvalue arm and the `Index`/`Slice` arm both yield `true` but
+    // are kept separate: they admit a base for DIFFERENT safety reasons (a
+    // call result is a fresh return-slot value; a `Vec` element is heap-
+    // independent via push-clone + refcount). Merging them would erase that
+    // distinction in a security-critical allowlist.
+    #[allow(
+        clippy::match_same_arms,
+        reason = "distinct safety rationales per arm in a security-critical allowlist"
+    )]
+    fn expr_is_materialized_owner(expr: &HirExpr) -> bool {
+        match &expr.kind {
+            // Peel a transparent tail-only block wrapper.
+            HirExprKind::Block(block) if block.statements.is_empty() => block
+                .tail
+                .as_deref()
+                .is_some_and(Self::expr_is_materialized_owner),
+            // Owned rvalues: a call / method / clone result is a fresh value
+            // materialised into its own slot. Conservatively limited to the
+            // call-like variants whose result is an owned value; any unlisted
+            // form fails closed.
+            HirExprKind::Call { .. }
+            | HirExprKind::CallDynMethod { .. }
+            | HirExprKind::CallTraitMethodStatic { .. }
+            | HirExprKind::VarSelfMethodCall { .. }
+            | HirExprKind::ResolvedImplCall { .. }
+            | HirExprKind::RecordCloneCall { .. } => true,
+            // A `Vec<T>` element load / slice — an independent heap element
+            // (see the push-clone + refcount note above), not an interior alias
+            // of a surviving named binding.
+            HirExprKind::Index { .. } | HirExprKind::Slice { .. } => true,
+            // A projection is materialised iff its object chain is.
+            HirExprKind::FieldAccess { object, .. } => Self::expr_is_materialized_owner(object),
+            HirExprKind::TupleIndex { tuple, .. } => Self::expr_is_materialized_owner(tuple),
+            // Bare/`Const` binding ref, machine-state field projection, deref,
+            // `if`/`match`, or any future expression form — not provably a
+            // materialised owner. Fail closed.
             _ => false,
         }
     }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -5163,8 +5163,13 @@ fn collect_binding_defs_in_expr<'f>(
 /// or a `Call` to an ALREADY-proven-fresh function. A return that is (or
 /// projects, or is laundered through a call to) a parameter or a bare local
 /// binding, a method call (which can return borrowed `self`/param), or a call to
-/// an unproven / external / mutually-recursive callee fails the function closed.
-/// Methods, extern fns, and builtins are absent from `fns` and read as `false`.
+/// an unproven / mutually-recursive callee fails the function closed. A return
+/// whose value is produced by a closure / function-pointer / indirect call also
+/// fails closed (the closure can hand back a captured parameter — see the
+/// `callee_is_resolved_item` guard in `return_value_may_alias_borrow`). User
+/// functions read their analyzed `fns` entry; a resolved Item with no body in
+/// this module (an extern / runtime primitive / aggregate constructor) is fresh
+/// by the owned-return ABI (`callee_returns_fresh_owner` → `true`).
 ///
 /// Conservative by construction: a helper that returns a let-bound local
 /// (`fn make() { let x = Inner { .. }; x }`) is classified non-fresh — sound
@@ -5304,16 +5309,28 @@ fn return_value_may_alias_borrow(expr: &HirExpr, fresh: &HashMap<hew_hir::ItemId
                 .iter()
                 .any(|(_, v)| return_value_may_alias_borrow(v, fresh))
         }),
-        // A free-function call aliases a parameter iff the callee is NOT proven
-        // to return a fresh owner AND some argument itself aliases a parameter
-        // (the callee could forward that argument out). A proven-fresh callee
-        // never aliases regardless of arguments; a non-fresh callee with only
-        // non-aliasing arguments (`string.repeat("a", 32)`) cannot alias the
-        // ENCLOSING function's parameters. Param-flow, composed through the
-        // fixpoint.
+        // A call that is NOT to a statically-resolved Item — a closure value, a
+        // function-pointer parameter, or any indirect/dynamic dispatch — can hand
+        // back a CAPTURED by-value heap parameter through its environment, a
+        // HIDDEN argument the explicit-arg flow below cannot see:
+        // `fn f(p) { let g = || -> Inner { p }; g() }` returns `p` with ZERO
+        // explicit arguments, so an `args`-only test would conclude "no args ⇒ no
+        // alias ⇒ fresh" and admit `..f(o.inner)` — the closure-capture-return
+        // use-after-free. Trust ONLY a resolved Item (a free function whose body
+        // the fixpoint analyzed, or an owned-return-ABI extern / constructor);
+        // every other callee may-alias regardless of arguments. Fail closed.
         HirExprKind::Call { callee, args } => {
-            !callee_returns_fresh_owner(callee, fresh)
-                && args.iter().any(|a| return_value_may_alias_borrow(a, fresh))
+            !callee_is_resolved_item(callee)
+                // A resolved free-function / owned-ABI extern / constructor call
+                // aliases a parameter iff the callee is NOT proven to return a
+                // fresh owner AND some argument itself aliases a parameter (the
+                // callee could forward that argument out). A proven-fresh callee
+                // never aliases regardless of arguments; a non-fresh callee with
+                // only non-aliasing arguments (`string.repeat("a", 32)`) cannot
+                // alias the ENCLOSING function's parameters. Param-flow, composed
+                // through the fixpoint.
+                || (!callee_returns_fresh_owner(callee, fresh)
+                    && args.iter().any(|a| return_value_may_alias_borrow(a, fresh)))
         }
         // A projection aliases a parameter iff its object chain does: `p.inner`
         // / `t.0` bottoms out at a bare parameter (`_ => true`) and carries that
@@ -5359,6 +5376,24 @@ fn callee_returns_fresh_owner(callee: &HirExpr, fresh: &HashMap<hew_hir::ItemId,
     } else {
         false
     }
+}
+
+/// True when `callee` names a statically-resolved Item — a free function (whose
+/// body the freshness fixpoint analyzed), an extern / runtime primitive, or an
+/// aggregate constructor. False for a closure value, a function-pointer
+/// parameter, a method receiver, or any indirect/dynamic dispatch, whose return
+/// the summary cannot prove fresh because the called body (and any environment
+/// it captures) is not statically in hand. This is the gate that stops a
+/// zero-argument closure call (`g()`) from being mistaken for a fresh owner when
+/// `g` captures a by-value heap parameter.
+fn callee_is_resolved_item(callee: &HirExpr) -> bool {
+    matches!(
+        &callee.kind,
+        HirExprKind::BindingRef {
+            resolved: ResolvedRef::Item(_),
+            ..
+        }
+    )
 }
 
 /// Collect every explicit `return <expr>` value in `block` (statement form),
@@ -6944,6 +6979,17 @@ struct Builder {
     /// than the direct `Instr::CallClosure`. A non-suspending closure is never
     /// inserted, keeping it on the direct path (no spurious coroutine driving).
     suspending_closure_bindings: HashSet<BindingId>,
+    /// `let` bindings whose initializer failed to lower (returned `None`) AND
+    /// emitted at least one diagnostic of its own. A later `BindingRef` to such
+    /// a binding has no `binding_locals` Place, which would otherwise raise a
+    /// follow-on `UnresolvedPlace` ("could not resolve binding `u`") — pure
+    /// cascade noise stacked on the root error the user must actually fix (e.g.
+    /// a fail-closed functional-update base/carry reject on `let u = { ..base }`).
+    /// The `BindingRef` resolver consults this set and returns `None` silently
+    /// for a poisoned binding, so only the root diagnostic surfaces. Guarded on
+    /// "a diagnostic was emitted" so a genuinely-unresolved binding (a real bug
+    /// with no prior error) still reports.
+    poisoned_let_bindings: HashSet<BindingId>,
     /// Transient: set by `lower_closure_literal` to the just-lowered closure's
     /// body-suspends verdict (derived from its shim's MIR carriers) so the `Let`
     /// handler can attribute it to the bound binding. Reset around each closure
@@ -9074,7 +9120,17 @@ impl Builder {
                 };
                 self.pending_closure_literal_suspends = None;
                 self.pending_closure_literal_heap = None;
+                let diag_len_before_value = self.diagnostics.len();
                 let value_place = self.lower_value(value);
+                // Cascade suppression: a `let` whose initializer failed to lower
+                // (`None`) AFTER emitting its own diagnostic poisons the binding,
+                // so a later `BindingRef` to it stays silent instead of stacking
+                // an `UnresolvedPlace` follow-on on the root error. Guarded on a
+                // diagnostic actually having been emitted, so a silent-`None`
+                // producer (a real defect with no prior error) still surfaces.
+                if value_place.is_none() && self.diagnostics.len() > diag_len_before_value {
+                    self.poisoned_let_bindings.insert(binding.id);
+                }
                 if pending {
                     self.pending_lambda_actor_handle = None;
                 }
@@ -10064,6 +10120,13 @@ impl Builder {
                 }
                 let place = self.binding_locals.get(id).copied();
                 if place.is_none() {
+                    if self.poisoned_let_bindings.contains(id) {
+                        // The binding's `let` initializer already failed to lower
+                        // and reported the root error; this read is pure cascade.
+                        // Stay silent (the compile already fails) instead of
+                        // stacking an `UnresolvedPlace` follow-on.
+                        return None;
+                    }
                     // Function parameters and other bindings without a
                     // backend slot are out of Cluster 1's spine. Without a
                     // Place, the emitter would silently load an
@@ -10976,6 +11039,75 @@ impl Builder {
                             });
                             return None;
                         }
+                    }
+                }
+                // Fail-closed CARRY pre-flight (complement of the override
+                // pre-flight above). A NON-overridden owned field is CARRIED out
+                // of the consumed base into the new record by a shallow
+                // `RecordFieldLoad`, with the base excluded from its composite
+                // `RecordInPlace` drop (`derive_owned_record_drop_allowed`). That
+                // shallow move soundly transfers ownership ONLY for field types
+                // whose whole value is one pointer / handle (or a record of such):
+                //   * `BitCopy` / `View` — no heap ownership; nothing to transfer
+                //     or to double-free.
+                //   * single-pointer COW / handle leaves (string, bytes, `Vec`,
+                //     `HashMap`, `HashSet`, `Generator`) — `project_field_inline_-
+                //     drop_symbol` is `Some`; the binder-escape exclusion hands the
+                //     one allocation to the result, freed exactly once.
+                //   * owned user records — `is_owned_aggregate_record_ty`; the
+                //     nested record's heap leaves transfer with the base excluded
+                //     (the binder-detection fix that also recognises nested records
+                //     as heap-owning binders).
+                // Every OTHER owned field type has NO sound shallow carry and
+                // would be released twice — once by the base's in-place drop and
+                // once by the result's drop (a double-free / use-after-free at
+                // teardown):
+                //   * a closure / `fn` / trait-object value (`PersistentShare`) is
+                //     a heap-boxed capture env with no retain/release carry spine;
+                //   * an `@resource` / `CancellationToken` / `Task` handle is a
+                //     single-release affine/linear value the inline-drop authority
+                //     does not cover here;
+                //   * an owned composite the leaf authority does not cover
+                //     (tuple-of-owned, `Option<owned>`, enum-with-heap, or any
+                //     `Unknown`-class owned Named type).
+                // Fail closed with an NYI diagnostic mirroring the override
+                // pre-flight rather than emit the double-free. Lifting a specific
+                // type's carry is tracked in hew-lang/hew#2207 (closure/`fn` env
+                // carry needs the env retain/release spine that clone also lacks).
+                if base_place.is_some() {
+                    for (fname, fty) in &field_order {
+                        if explicit.contains_key(fname.as_str()) {
+                            continue; // Overridden — handled by the override path.
+                        }
+                        let subst_fty = self.subst_ty(fty);
+                        let vc = ValueClass::of_ty(&subst_fty, &self.type_classes);
+                        let sound_carry = matches!(vc, ValueClass::BitCopy | ValueClass::View)
+                            || self.project_field_inline_drop_symbol(&subst_fty).is_some()
+                            || self.is_owned_aggregate_record_ty(&subst_fty);
+                        if sound_carry {
+                            continue;
+                        }
+                        self.diagnostics.push(MirDiagnostic {
+                            kind: MirDiagnosticKind::NotYetImplemented {
+                                construct: "functional-update carry of owned non-record field"
+                                    .to_string(),
+                                site: expr.site,
+                            },
+                            note: format!(
+                                "field `{fname}` of `{name}` has owned type `{ty}` whose \
+                                 ownership cannot be transferred by the functional-update's \
+                                 shallow field carry: a closure / `fn` / trait-object capture \
+                                 env, an `@resource` / cancellation-token / task handle, or an \
+                                 owned composite (tuple / `Option` / enum) with heap fields. \
+                                 The `..base` consumes the base, so the base's scope-exit drop \
+                                 and the new record's drop would both release this carried field \
+                                 — a double-free. Set `{fname}` explicitly to a fresh value in \
+                                 the update instead of carrying it through `..base`, or clone \
+                                 the base into a fresh owned value first.",
+                                ty = subst_fty.user_facing(),
+                            ),
+                        });
+                        return None;
                     }
                 }
                 let mut field_pairs: Vec<(FieldOffset, Place)> = Vec::new();
@@ -29881,10 +30013,25 @@ fn derive_owned_record_drop_allowed(
     // A local carries a heap-owning value iff its registered type says so. Used
     // to decide whether a `RecordFieldLoad` dest is an owned-field binder (a
     // BitCopy field load is harmless to alias out).
+    //
+    // `ty_contains_heap_owning` is record-layout BLIND — it recurses into enum
+    // variant payloads, tuple/array elements, and generic type arguments, but a
+    // bare nested user-record type (`Inner { label: string, n: i64 }`) is a
+    // `Named` that is neither a builtin nor an enum layout, so it answers
+    // `false`. A nested-record field loaded out of the base record and then
+    // ESCAPED into an owning sink (the functional-update result's `RecordInit`,
+    // a `return b.inner`, …) must mark its binder so the base root is excluded
+    // from its composite `RecordInPlace` drop — otherwise the base frees the
+    // nested record's heap leaves while the escapee still owns them
+    // (use-after-free / double-free). `is_owned_record` consults the record
+    // layout (`is_owned_aggregate_record_ty`) and answers `true` for any user
+    // record with an owned field, closing that blindness without widening
+    // `ty_contains_heap_owning`'s 50-plus call sites. The two are unioned: a
+    // field is a heap-owning binder iff EITHER authority says so.
     let local_is_heap_owning = |local: u32| -> bool {
-        local_tys
-            .get(local as usize)
-            .is_some_and(|ty| crate::model::ty_contains_heap_owning(ty, enum_layouts))
+        local_tys.get(local as usize).is_some_and(|ty| {
+            crate::model::ty_contains_heap_owning(ty, enum_layouts) || is_owned_record(ty)
+        })
     };
 
     // Candidate record locals: base locals of owned-aggregate-record bindings.

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -24471,35 +24471,42 @@ impl Builder {
     /// or as new expression forms are added — can silently reopen the UAF.
     ///
     /// A base is provably safe in exactly two ways:
-    ///   (a) a bare live `BindingRef` — `alias_moved_owned_operand` consume-
-    ///       marks it, so the move-checker rejects any later read and the
-    ///       binding is excluded from its scope-exit drop: its fields are dead
-    ///       after the update; or
-    ///   (b) a materialised owner with no live named alias — a call/method/
-    ///       clone result (`makeInner()`, `o.inner.clone()`), a `Vec<T>`
-    ///       element load (`v[i]`) or slice, or a projection whose object chain
-    ///       bottoms out at one of those (`makeOuter().inner`,
-    ///       `o.items[0].inner`). See `expr_is_materialized_owner`.
+    ///   (a) a SYNTACTICALLY bare live `BindingRef` — `alias_moved_owned_-
+    ///       operand` consume-marks it, so the move-checker rejects any later
+    ///       read and the binding is excluded from its scope-exit drop: its
+    ///       fields are dead after the update. A binding wrapped in ANY
+    ///       control/block form does NOT qualify as (a): the consume does not
+    ///       peel wrappers, and a conditionally-selected binding cannot be
+    ///       soundly consumed — such a wrapper is held to (b) below, which
+    ///       rejects a bare-binding leaf. (Admitting `..{ base }` as (a) while
+    ///       the consume silently no-ops on the block is itself a UAF.)
+    ///   (b) a materialised owner with no live named alias — see
+    ///       `expr_is_materialized_owner`, which looks THROUGH wrapper forms
+    ///       (block tail, `if` branches, `match` arms) and requires EVERY
+    ///       reachable value to be a fresh owned rvalue (`makeInner()`,
+    ///       `o.inner.clone()`), a `Vec<T>` element / slice (`v[i]`), or a
+    ///       projection rooted at one (`makeOuter().inner`, `o.items[0].inner`).
     ///
     /// ANY other base — a projection of a LIVE binding (`o.inner`, `t.0`,
     /// `o.pair.0`, `t.0.inner`, nested), a machine-state field (`self.field`),
-    /// a `Const`/`Item` ref, a deref, an `if`/`match` value, or any future
-    /// expression form — is NOT provably safe and is rejected fail-closed.
+    /// a `Const`/`Item` ref, a deref, a wrapper whose tail/branch/arm is any
+    /// of those (`{ base }`, `if c { o.inner } else { makeInner() }`), or any
+    /// future expression form — is NOT provably safe and is rejected
+    /// fail-closed.
     fn base_is_safe_for_destructive_funcupdate(base: &HirExpr) -> bool {
-        match &base.kind {
-            // Peel a transparent tail-only block wrapper (`{ ..; b }`).
-            HirExprKind::Block(block) if block.statements.is_empty() => block
-                .tail
-                .as_deref()
-                .is_some_and(Self::base_is_safe_for_destructive_funcupdate),
-            // (a) Bare live binding — consume-marked, fields dead after update.
-            HirExprKind::BindingRef {
-                resolved: ResolvedRef::Binding(_),
-                ..
-            } => true,
-            // (b) Materialised owner / temporary with no live named alias.
-            _ => Self::expr_is_materialized_owner(base),
+        // (a) ONLY a syntactically bare binding is the consume case. NO wrapper
+        //     peeling here: a block/if/match-wrapped binding is not reliably
+        //     consume-marked, so it must instead prove materialised via (b).
+        if let HirExprKind::BindingRef {
+            resolved: ResolvedRef::Binding(_),
+            ..
+        } = &base.kind
+        {
+            return true;
         }
+        // (b) Every other base — INCLUDING every wrapper — is safe only if
+        //     every reachable value is a materialised owner with no live alias.
+        Self::expr_is_materialized_owner(base)
     }
 
     /// True when `expr` evaluates to a freshly MATERIALISED owner — a value in
@@ -24507,7 +24514,16 @@ impl Builder {
     /// fields. Used for the `(b)` arm of the funcupdate base allowlist and to
     /// recurse a projection's object chain.
     ///
-    /// Materialised owners:
+    /// COMPLETE THROUGH WRAPPERS: a value-passthrough form (a block tail, both
+    /// `if` branches, all `match` arm bodies) is materialised ONLY when EVERY
+    /// reachable value-producing position is itself materialised. A bare-binding
+    /// or live-projection leaf anywhere inside a wrapper fails the whole base
+    /// (it is not consume-marked through the wrapper, and a conditionally-
+    /// selected binding cannot be soundly consumed) — e.g.
+    /// `if c { o.inner } else { makeInner() }` and `{ let z = 0; o.inner }` are
+    /// rejected because a reachable value aliases the live `o`.
+    ///
+    /// Materialised leaves:
     ///   * a call / method / `.clone()` result — a fresh value written into its
     ///     own return slot (`Call`, the four method-call variants,
     ///     `RecordCloneCall`);
@@ -24527,10 +24543,10 @@ impl Builder {
     /// is safe, `o.inner` (rooted at a live binding) is not.
     ///
     /// EVERY other form — a `BindingRef` (live local, `Const`, or `Item`), a
-    /// `MachineFieldAccess` (`self.field`), a deref, an `if`/`match`, or any
+    /// `MachineFieldAccess` (`self.field`), a deref, a loop-break value, or any
     /// expression form added later — returns false (fail closed).
     // The owned-rvalue arm and the `Index`/`Slice` arm both yield `true` but
-    // are kept separate: they admit a base for DIFFERENT safety reasons (a
+    // are kept separate: they admit a leaf for DIFFERENT safety reasons (a
     // call result is a fresh return-slot value; a `Vec` element is heap-
     // independent via push-clone + refcount). Merging them would erase that
     // distinction in a security-critical allowlist.
@@ -24540,11 +24556,35 @@ impl Builder {
     )]
     fn expr_is_materialized_owner(expr: &HirExpr) -> bool {
         match &expr.kind {
-            // Peel a transparent tail-only block wrapper.
-            HirExprKind::Block(block) if block.statements.is_empty() => block
+            // ---- value-passthrough wrappers: ALL reachable values must be
+            //      materialised (look THROUGH; reject any bare-binding leaf) ----
+            // A block's value is its tail (statements are side-effecting only);
+            // peel to the tail regardless of statement count.
+            HirExprKind::Block(block) => block
                 .tail
                 .as_deref()
                 .is_some_and(Self::expr_is_materialized_owner),
+            // BOTH `if` branches must be materialised. A missing `else` cannot
+            // produce an owned-record value, so it fails closed.
+            HirExprKind::If {
+                then_expr,
+                else_expr,
+                ..
+            } => {
+                Self::expr_is_materialized_owner(then_expr)
+                    && else_expr
+                        .as_deref()
+                        .is_some_and(Self::expr_is_materialized_owner)
+            }
+            // EVERY `match` arm body must be materialised (an arm body that is a
+            // bare payload binding aliases the scrutinee and fails closed).
+            HirExprKind::Match { arms, .. } => {
+                !arms.is_empty()
+                    && arms
+                        .iter()
+                        .all(|arm| Self::expr_is_materialized_owner(&arm.body))
+            }
+            // ---- materialised leaves ----
             // Owned rvalues: a call / method / clone result is a fresh value
             // materialised into its own slot. Conservatively limited to the
             // call-like variants whose result is an owned value; any unlisted
@@ -24563,8 +24603,8 @@ impl Builder {
             HirExprKind::FieldAccess { object, .. } => Self::expr_is_materialized_owner(object),
             HirExprKind::TupleIndex { tuple, .. } => Self::expr_is_materialized_owner(tuple),
             // Bare/`Const` binding ref, machine-state field projection, deref,
-            // `if`/`match`, or any future expression form — not provably a
-            // materialised owner. Fail closed.
+            // or any future expression form — not provably a materialised
+            // owner. Fail closed.
             _ => false,
         }
     }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -10996,6 +10996,73 @@ impl Builder {
                 // binders escaping via RecordInit.  No owned field of `base` is
                 // ever dropped twice.
                 //
+                // Fail-closed WHOLE-RECORD pre-flight: both the override-drop and
+                // the shallow carry below are sound ONLY when the base record is
+                // CONSUME-MARKED — `alias_moved_owned_operand` emits the
+                // `AggregateAlias` iff `aggregate_ingress_moves_binding_ty` admits
+                // the WHOLE record. The override-drop's debug coupling assertion
+                // (B) assumes exactly that precondition. But the per-field carry /
+                // override gates below admit a field IN ISOLATION when it has a
+                // single-pointer inline-drop symbol (`project_field_inline_drop_-
+                // symbol`), and a `Vec<closure>` / `Vec<opaque>` element DOES have
+                // one (`hew_vec_free_closure_pairs` / `hew_vec_free`) even though
+                // the whole record is NOT a consume-markable owned-aggregate
+                // (`is_owned_aggregate_record_ty` is false — its element fails
+                // `supports_value_class_drop_spine`). That record is never
+                // consume-marked, yet an override-drop on a sibling single-pointer
+                // COW field would still fire, tripping the coupling assertion in
+                // debug BEFORE the downstream W3.029 value-class gate
+                // (`UnsupportedUserRecordValueClass`) rejects it in release.
+                //
+                // Close the divergence at its source: when the base carries an
+                // owned heap field (so an override-drop / shallow carry would run)
+                // but the whole record is not consume-markable as an owned
+                // aggregate, fail closed HERE with the same clean
+                // `E_NOT_YET_IMPLEMENTED` the release build already emits — never
+                // panic. This mirrors the fail-closed posture the per-field gates
+                // already take for closure / tuple / `Option` fields.
+                if base_place.is_some() {
+                    if let Some(base_expr) = base.as_deref() {
+                        let base_ty = self.subst_ty(&base_expr.ty);
+                        let record_has_owned_heap_field = field_order.iter().any(|(_, fty)| {
+                            let subst_fty = self.subst_ty(fty);
+                            !matches!(
+                                ValueClass::of_ty(&subst_fty, &self.type_classes),
+                                ValueClass::BitCopy | ValueClass::View
+                            )
+                        });
+                        if record_has_owned_heap_field
+                            && !self.aggregate_ingress_moves_binding_ty(&base_ty)
+                        {
+                            // Walk every sub-expression for checker-stream coverage
+                            // before bailing, mirroring the gates above.
+                            for (_, fe) in fields {
+                                let _ = self.lower_value(fe);
+                            }
+                            self.diagnostics.push(MirDiagnostic {
+                                kind: MirDiagnosticKind::NotYetImplemented {
+                                    construct: "functional-update over a record whose value class \
+                                                MIR cannot lower yet"
+                                        .to_string(),
+                                    site: expr.site,
+                                },
+                                note: format!(
+                                    "the `..base` of `{name}` carries or overrides an owned heap \
+                                     field, but `{ty}` is not a consume-markable owned-aggregate \
+                                     record: at least one field has a value class MIR cannot lower \
+                                     yet (for example a `Vec` of closures or of opaque handles). \
+                                     Without the whole-record consume mark the functional-update \
+                                     in-place field release has no sound base, so it is rejected \
+                                     here rather than emitted. Set the affected fields explicitly \
+                                     in a plain constructor instead of carrying them through \
+                                     `..base`.",
+                                    ty = base_ty.user_facing(),
+                                ),
+                            });
+                            return None;
+                        }
+                    }
+                }
                 // Fail-closed pre-flight: owned-aggregate field overrides (record /
                 // tuple / enum) have no single-ptr leaf release symbol and surface
                 // a NotYetImplemented diagnostic rather than leaking silently.

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -4736,7 +4736,7 @@ pub enum ExitPath {
 /// - [`DropFnSpec::Release`] — a cow-heap / fresh-value release C
 ///   symbol (`hew_string_drop`, `hew_bytes_drop`, `hew_vec_free`,
 ///   `hew_vec_free_owned`, `hew_hashmap_free_layout`,
-///   `hew_hashset_free_layout`, `hew_gen_free`). Selected by a closed
+///   `hew_hashset_free_layout`, `hew_gen_coro_destroy`). Selected by a closed
 ///   MIR-side type-shape authority (`generator_yield_drop_symbol`,
 ///   `drop_kind_for`'s cow tables) and congruence-checked against the
 ///   value's type in codegen before any call is emitted — the string is

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -3801,6 +3801,85 @@ pub enum Instr {
         /// Destination place that receives the loaded field value.
         dest: Place,
     },
+    /// Release an owned field of a record value in-place, without copying it
+    /// into an intermediate local first.
+    ///
+    /// Codegen lowers this to: GEP to the field slot → raw load (no
+    /// `hew_string_clone` retain — unlike `RecordFieldLoad`) → call the
+    /// `drop_fn` release symbol → null-store the field slot so any
+    /// structurally-reachable second drop observes a null and short-circuits.
+    ///
+    /// ## Ownership invariant
+    ///
+    /// The field value must be a sole-owner reference (refcount == 1 for
+    /// COW-heap scalars) at the point this instruction executes.  Emitting this
+    /// instruction for a shared reference (refcount > 1) would decrement below
+    /// expected — use `RecordFieldLoad` + `Drop` for shared/borrowed reads.
+    ///
+    /// ## Why not `RecordFieldLoad` + `Drop`?
+    ///
+    /// Two reasons, both pointing at `RecordFieldDrop` as the canonical
+    /// in-place field destructor for single-pointer COW fields:
+    ///
+    /// 1. `RecordFieldLoad` retains `string` fields via `hew_string_clone` to
+    ///    avoid aliasing the parent record's buffer. When the caller
+    ///    immediately drops the loaded copy, the retain and the drop cancel out
+    ///    (no-op), leaving the original field value in the record slot un-freed.
+    ///    `RecordFieldDrop` bypasses the retain and drops the original directly.
+    ///
+    /// 2. For `Vec` / map / `Generator` fields `RecordFieldLoad` happens to skip
+    ///    the retain TODAY, so `load` + `Drop` is currently correct for them —
+    ///    but that is an incidental consequence of the not-yet-landed
+    ///    retain-on-share spine. When that spine lands and `RecordFieldLoad`
+    ///    starts retaining those types too, a `load` + `Drop` here would silently
+    ///    regress to a leak. Routing every single-pointer COW field through
+    ///    `RecordFieldDrop` (raw load, never retained) is robust against that
+    ///    future change and additionally null-stores the freed slot.
+    ///
+    /// ## Scope
+    ///
+    /// Emitted only by functional-update lowering
+    /// (`HirExprKind::StructInit { base: Some(_) }`) to release each overridden
+    /// owned field of `base` before the new `RecordInit` is constructed.  The
+    /// field domain is every SINGLE-POINTER COW-heap type — `string`, `Vec<T>`,
+    /// `HashMap`, `HashSet`, and the `Generator` / `AsyncGenerator` companion
+    /// handle (see `field_override_uses_record_field_drop` in `lower.rs`).  All
+    /// three exit contexts (sync return, async cancel, actor shutdown) are
+    /// covered: the instruction is positioned in the basic block that executes
+    /// on the hot path, and any error path that bypasses the functional-update
+    /// block keeps the original `base` alive (never drops a field that hasn't
+    /// been loaded/consumed).  Soundness additionally rests on `..base`
+    /// CONSUMING the base: the move-checker rejects any later read of `base`, so
+    /// the released old value has no surviving reader.
+    ///
+    /// ## Type compatibility
+    ///
+    /// `ty` and `drop_fn` must be mutually consistent: `ty == ResolvedTy::String`
+    /// pairs with `DropFnSpec::Release("hew_string_drop")`, a
+    /// `Vec`-typed field with `Release("hew_vec_free")` / `"hew_vec_free_owned"`,
+    /// etc.  Codegen validates congruence and fails closed on a mismatch.
+    ///
+    /// ## Bytes fields
+    ///
+    /// `bytes` fields are **not** lowered via this instruction.  `bytes` is a fat
+    /// `{ ptr, len, cap }` triple, not a single pointer, so its destructor takes
+    /// the whole by-value value and cannot be expressed as a single-slot GEP +
+    /// pointer-load + release.  `bytes` overrides stay on the `RecordFieldLoad` +
+    /// `Instr::Drop` path (which materialises the fat value into a temp).  Codegen
+    /// fails closed if a non-pointer field slot ever reaches this instruction.
+    RecordFieldDrop {
+        /// The record value whose field is to be dropped.
+        record: Place,
+        /// 0-based index of the field within the record's declared field order.
+        field_offset: FieldOffset,
+        /// Hew type of the field being dropped.  Must match the field's declared
+        /// type in the record; used by codegen to resolve the LLVM slot type and
+        /// to validate `drop_fn` congruence.
+        ty: ResolvedTy,
+        /// The release ritual to call.  Must be `DropFnSpec::Release` carrying
+        /// a known COW-heap release symbol (e.g. `"hew_string_drop"`).
+        drop_fn: DropFnSpec,
+    },
     /// Load a single element from a tuple value by its 0-based positional index.
     ///
     /// Produced from `HirExprKind::TupleIndex { tuple, index }` when the tuple

--- a/hew-mir/src/state_clone.rs
+++ b/hew-mir/src/state_clone.rs
@@ -1067,14 +1067,15 @@ fn classify_named(
     }
 
     // `Generator<Y, R>` / `AsyncGenerator<Y>` pointer-backed runtime handle.
-    // Same posture as Stream/Sink: drop routes to `hew_gen_free` (the standalone
-    // generator-binding release symbol), no dup helper, clone/restart fails
-    // closed. Without this arm a tuple/record/enum carrying a generator handle
-    // falls through to `classify_user_record` and fails as `MissingRecordLayout`,
-    // and (before this fix) the composite was mis-classified non-heap-owning so
-    // its member-drop never ran — leaking the context + OS thread. A generator's
-    // generic args (`i64`, `()`) never make the handle itself non-heap-owning, so
-    // classification is by name alone, independent of `args`.
+    // Same posture as Stream/Sink: drop routes to `hew_gen_coro_destroy` (the
+    // standalone generator-binding release symbol), no dup helper, clone/restart
+    // fails closed. Without this arm a tuple/record/enum carrying a generator
+    // handle falls through to `classify_user_record` and fails as
+    // `MissingRecordLayout`, and (before this fix) the composite was
+    // mis-classified non-heap-owning so its member-drop never ran — leaking the
+    // coroutine frame + companion. A generator's generic args (`i64`, `()`)
+    // never make the handle itself non-heap-owning, so classification is by name
+    // alone, independent of `args`.
     if matches!(name, "Generator" | "AsyncGenerator") {
         return Ok(StateFieldCloneKind::IoHandle {
             kind: IoHandleKind::Generator,

--- a/tests/hew/funcupdate_owned_field_drop_test.hew
+++ b/tests/hew/funcupdate_owned_field_drop_test.hew
@@ -1,0 +1,98 @@
+//! Regression tests: functional-update syntax `{ ..base, field: new }` must
+//! drop the old owned value of the overridden field, not leak it.
+//!
+//! Before the fix (`hew-mir/src/lower.rs` NYI #14), overriding a `string`,
+//! `bytes`, or `Vec<T>` field in a functional-update expression never called
+//! `hew_string_drop` / `hew_bytes_drop` / `hew_vec_free*` for the REPLACED
+//! value. The new record owned the replacement; the old allocation leaked
+//! permanently — one heap node per loop iteration.
+//!
+//! After the fix, `lower_value`'s `HirExprKind::StructInit { base: Some(_) }`
+//! arm emits a `RecordFieldLoad` + inline `Instr::Drop` for each overridden
+//! field whose type has a known leaf release symbol, before the `RecordInit`
+//! that builds the new record.
+//!
+//! These tests verify correctness (not just non-crash): the new field value
+//! is the replacement, the non-overridden fields carry over intact, and the
+//! loop terminates with the expected state.  The no-leak property is verified
+//! out of band by `hew-cli/tests/funcupdate_owned_field_drop_leak_oracle.rs`
+//! which runs the compiled binary under `leaks --atExit` (macOS only).
+
+import std::testing;
+import std::string;
+
+record FlatConfig {
+    label: string,
+    count: i64,
+}
+
+record VecHolder {
+    items: Vec<i64>,
+    tag: string,
+}
+
+/// Overriding a `string` field replaces the heap buffer each iteration.
+/// The non-overridden `count` field carries over via functional-update base.
+#[test]
+fn test_funcupdate_string_field_override_drops_old() {
+    var c = FlatConfig { label: string.repeat("a", 32), count: 7 };
+    var i = 0;
+    while i < 20 {
+        c = FlatConfig { label: string.repeat("b", 32), ..c };
+        i = i + 1;
+    }
+    // Non-overridden `count` carries over from base each iteration.
+    testing.assert_eq(c.count, 7);
+    // Final value of `label` is the replacement.
+    testing.assert_eq_str(c.label, string.repeat("b", 32));
+}
+
+/// Overriding the `count` (BitCopy) field leaves `label` intact.
+/// BitCopy fields need no drop; non-BitCopy `label` carries over as-is.
+#[test]
+fn test_funcupdate_bitcopy_field_override_carries_label() {
+    var c = FlatConfig { label: string.repeat("x", 16), count: 0 };
+    var i = 0;
+    while i < 5 {
+        c = FlatConfig { count: c.count + 1, ..c };
+        i = i + 1;
+    }
+    testing.assert_eq(c.count, 5);
+    testing.assert_eq_str(c.label, string.repeat("x", 16));
+}
+
+/// Overriding a `Vec<i64>` field: old Vec buffer is released each iteration.
+#[test]
+fn test_funcupdate_vec_field_override_drops_old() {
+    let init: Vec<i64> = Vec::new();
+    init.push(99);
+    var s = VecHolder { items: init, tag: "initial" };
+    var i = 0;
+    while i < 15 {
+        let next: Vec<i64> = Vec::new();
+        next.push(i);
+        s = VecHolder { items: next, ..s };
+        i = i + 1;
+    }
+    // Non-overridden `tag` carries over from base each iteration.
+    testing.assert_eq_str(s.tag, "initial");
+    // Final Vec has the last iteration's element.
+    testing.assert_eq(s.items.len(), 1);
+}
+
+/// Both `string` and `Vec` fields overridden simultaneously.
+#[test]
+fn test_funcupdate_multi_field_override_drops_old() {
+    let init: Vec<i64> = Vec::new();
+    init.push(0);
+    var s = VecHolder { items: init, tag: string.repeat("z", 8) };
+    var i = 0;
+    while i < 10 {
+        let next: Vec<i64> = Vec::new();
+        next.push(i);
+        s = VecHolder { items: next, tag: string.repeat("y", 8), ..s };
+        i = i + 1;
+    }
+    testing.assert_eq(s.items.len(), 1);
+    testing.assert_eq_str(s.tag, string.repeat("y", 8));
+}

--- a/tests/hew/funcupdate_owned_field_drop_test.hew
+++ b/tests/hew/funcupdate_owned_field_drop_test.hew
@@ -1,16 +1,19 @@
 //! Regression tests: functional-update syntax `{ ..base, field: new }` must
 //! drop the old owned value of the overridden field, not leak it.
 //!
-//! Before the fix (`hew-mir/src/lower.rs` NYI #14), overriding a `string`,
-//! `bytes`, or `Vec<T>` field in a functional-update expression never called
-//! `hew_string_drop` / `hew_bytes_drop` / `hew_vec_free*` for the REPLACED
-//! value. The new record owned the replacement; the old allocation leaked
-//! permanently — one heap node per loop iteration.
+//! Before the fix (the functional-update overridden-owned-field leak in
+//! `hew-mir/src/lower.rs`), overriding a `string`, `bytes`, or `Vec<T>`
+//! field in a functional-update expression never called `hew_string_drop`
+//! / `hew_bytes_drop` / `hew_vec_free*` for the REPLACED value. The new
+//! record owned the replacement; the old allocation leaked permanently —
+//! one heap node per loop iteration.
 //!
 //! After the fix, `lower_value`'s `HirExprKind::StructInit { base: Some(_) }`
-//! arm emits a `RecordFieldLoad` + inline `Instr::Drop` for each overridden
-//! field whose type has a known leaf release symbol, before the `RecordInit`
-//! that builds the new record.
+//! arm releases each overridden owned field's OLD value before the
+//! `RecordInit` that builds the new record: a single-pointer COW field
+//! (`string` / `Vec<T>` / `HashMap` / `HashSet`) via `Instr::RecordFieldDrop`,
+//! the fat `bytes` triple via `RecordFieldLoad` + inline `Instr::Drop`. The
+//! release is sound because `..base` consumes the base.
 //!
 //! These tests verify correctness (not just non-crash): the new field value
 //! is the replacement, the non-overridden fields carry over intact, and the
@@ -29,6 +32,16 @@ record FlatConfig {
 record VecHolder {
     items: Vec<i64>,
     tag: string,
+}
+
+record MapHolder {
+    m: HashMap<string, i64>,
+    tag: i64,
+}
+
+record SetHolder {
+    s: HashSet<i64>,
+    tag: i64,
 }
 
 /// Overriding a `string` field replaces the heap buffer each iteration.
@@ -95,4 +108,43 @@ fn test_funcupdate_multi_field_override_drops_old() {
     }
     testing.assert_eq(s.items.len(), 1);
     testing.assert_eq_str(s.tag, string.repeat("y", 8));
+}
+
+/// Overriding a `HashMap` field releases the old map (single-pointer COW
+/// handle) via `RecordFieldDrop` (`hew_hashmap_free_layout`) each iteration.
+/// The non-overridden `tag` carries over from the base.
+#[test]
+fn test_funcupdate_hashmap_field_override_drops_old() {
+    let init: HashMap<string, i64> = HashMap::new();
+    init.insert("seed", 1);
+    var h = MapHolder { m: init, tag: 42 };
+    var i = 0;
+    while i < 12 {
+        let next: HashMap<string, i64> = HashMap::new();
+        next.insert("k", i);
+        h = MapHolder { m: next, ..h };
+        i = i + 1;
+    }
+    // Non-overridden `tag` carries over from base each iteration.
+    testing.assert_eq(h.tag, 42);
+    // Final map has the last iteration's single entry.
+    testing.assert_eq(h.m.len(), 1);
+}
+
+/// Overriding a `HashSet` field releases the old set (single-pointer COW
+/// handle) via `RecordFieldDrop` (`hew_hashset_free_layout`) each iteration.
+#[test]
+fn test_funcupdate_hashset_field_override_drops_old() {
+    let init: HashSet<i64> = HashSet::<i64>::new();
+    init.insert(99);
+    var h = SetHolder { s: init, tag: 7 };
+    var i = 0;
+    while i < 12 {
+        let next: HashSet<i64> = HashSet::<i64>::new();
+        next.insert(i);
+        h = SetHolder { s: next, ..h };
+        i = i + 1;
+    }
+    testing.assert_eq(h.tag, 7);
+    testing.assert_eq(h.s.len(), 1);
 }


### PR DESCRIPTION
## Summary

Functional-record-update over an owned record now consumes the base by construction. Every aliasing or borrow-laundering base shape (projection of a live binding, by-value heap parameter, closure-capture return, self-override) is rejected at compile time with a clean diagnostic. For the shapes that are admitted, non-overridden owned fields are destructively carried via a proven single-move transfer — the carry admit-set ({string, bytes, Vec, HashMap, HashSet, Generator, nested owned record}) is exhaustive against the value-class lattice, and every field type outside that set fails closed with `E_NOT_YET_IMPLEMENTED` rather than admitting a shape whose deep-retain isn't lowered. This closes a class of use-after-free and double-free bugs where a funcupdate over a uniquely-owned base would free an overridden field's storage while a carried or still-live field aliased it.

The fix is structured as three independent closures: the base-provenance interprocedural fixpoint (ruling out aliased and borrow-forwarding bases), the nested-record carry extension (widening the drop-classifier to exclude the base when a nested owned field is carried — monotone-safe, can only suppress a composite drop, never add a double-free), and the carry pre-flight (failing closed on any non-overridden owned field whose deep-retain the compiler hasn't lowered).

## Verification

- Guard-Malloc matrix (base-provenance × owned-field-type × carry/override): all 12 leak-oracle fixtures slope-0, 0 failed
- `hew-mir` nextest: 785 passed, 0 failed
- `funcupdate_consume_semantics`: 47 passed, 0 failed (covers full reject/accept matrix including closure-capture return, nested-record carry, tuple/Option/closure carry rejection, and the Vec-closure-field clean-no-panic regression)
- Checked-mir golden suite: byte-identical to prior baseline (FIX2 reclassified zero existing record-drop shapes in the corpus — confirmed non-regression)
- Ratchet + fuzz-oracle: pass
- Preflight: ready-to-push

## Out of scope

- The extract-return sibling-field leak (#2212): when a field is extracted out of an owned record and returned, a pre-existing fail-closed leak in the general drop-elaboration path needs a per-field-escape rework that goes beyond funcupdate. Tracked in #2212.
- Lifting the carry restriction for closure, tuple, Option, and handle fields (#2207): these fail closed today with `E_NOT_YET_IMPLEMENTED`. Implementing their deep-retain lowering and admitting them to the carry set is the planned follow-on. Tracked in #2207.

References #2207, #2212.