### PR TITLE
build(ci): faster, higher-signal test iteration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,26 @@
+# ── Linux linker (x86_64) ─────────────────────────────────────────────────────
+# Use mold on Linux x86_64 for faster incremental link times.  mold reduces
+# link time for hew-cli from ~5-10 s to ~0.5-1 s per incremental cycle.
+#
+# WHY: per-incremental link cost dominates iteration time for CLI-touching
+# changes; mold is a drop-in ld replacement that completes in milliseconds.
+# WHEN obsolete: if a future Cargo version supports a fallback-linker chain
+# or the default system linker reaches mold-level speed.
+# WHAT the real solution looks like: this entry, exactly as written, with
+# mold installed on every CI/CD Linux runner (see ci.yml "Install mold").
+#
+# GATE: this block is ignored on macOS, Windows, and non-x86_64 Linux.
+# Linux x86_64 users without mold can override for their session:
+#   export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc
+# or install mold: apt install mold / dnf install mold
+#
+# CI installs mold unconditionally (ci.yml "Install build tools" step)
+# so the build never breaks on CI.  See LESSONS.md or the commit that
+# introduced this block for the cost evidence.
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=--ld-path=mold"]
+
 # Windows uses the LLVM linker from the same provisioned LLVM 22 toolchain that
 # supplies clang.exe for `hew build` and llvm-config for llvm-sys.  Keep this
 # pinned to lld-link rather than relying on a Developer Command Prompt: the

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,25 +1,23 @@
 # ── Linux linker (x86_64) ─────────────────────────────────────────────────────
-# Use mold on Linux x86_64 for faster incremental link times.  mold reduces
-# link time for hew-cli from ~5-10 s to ~0.5-1 s per incremental cycle.
+# mold is not forced globally here because it requires a running mold install
+# AND a compatible driver.  Not every Linux workflow or runner has mold; forcing
+# it via .cargo/config.toml breaks release-gate, coverage-nightly, and sanitizer
+# jobs that run on bare ubuntu runners without mold installed.
 #
-# WHY: per-incremental link cost dominates iteration time for CLI-touching
-# changes; mold is a drop-in ld replacement that completes in milliseconds.
-# WHEN obsolete: if a future Cargo version supports a fallback-linker chain
-# or the default system linker reaches mold-level speed.
-# WHAT the real solution looks like: this entry, exactly as written, with
-# mold installed on every CI/CD Linux runner (see ci.yml "Install mold").
+# CI opt-in: ci.yml's build-and-test job sets
+#   CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=mold
+# using gcc's -fuse-ld= flag (no clang dependency) after apt-installing mold.
 #
-# GATE: this block is ignored on macOS, Windows, and non-x86_64 Linux.
-# Linux x86_64 users without mold can override for their session:
-#   export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc
-# or install mold: apt install mold / dnf install mold
+# Dev opt-in: for local Linux x86_64 development with mold installed,
+# add to your shell profile:
+#   export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="-C link-arg=-fuse-ld=mold"
 #
-# CI installs mold unconditionally (ci.yml "Install build tools" step)
-# so the build never breaks on CI.  See LESSONS.md or the commit that
-# introduced this block for the cost evidence.
-[target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=--ld-path=mold"]
+# WHY opt-in not forced: forcing clang + --ld-path=mold here breaks every
+# CI workflow that lacks both clang-as-linker-driver AND mold.  gcc's
+# -fuse-ld=mold is cleaner but still requires mold installed; an env var
+# scoped to the job that installs mold is the correct isolation boundary.
+# WHEN obsolete: if every CI runner provisions mold unconditionally and
+# the project drops non-mold Linux workflows.
 
 # Windows uses the LLVM linker from the same provisioned LLVM 22 toolchain that
 # supplies clang.exe for `hew build` and llvm-config for llvm-sys.  Keep this

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -298,8 +298,10 @@ test-group = "subprocess-intensive"
 default-filter = "not package(hew-wasm) - binary(eval_e2e) - binary(test_runner_e2e) - binary(parity) - binary(~exec) - binary(~e2e) - binary(~oracle) - binary(machine_lifecycle) - binary(zeroarg_module_enum_emission) - binary(jit_trap_bridge) - test(bounded_child_timeout_kills_grandchild_process_group) - test(two_process_remote_ask_echo_double_returns_42) - test(remote_ask_two_process_echo_client_helper) - test(remote_ask_two_process_echo_server_helper) - test(two_process_remote_ask_timeout_returns_timeout_under_1500ms) - test(remote_ask_two_process_timeout_client_helper) - test(remote_ask_two_process_timeout_server_helper)"
 test-threads = "num-cpus"
 slow-timeout = { period = "30s", terminate-after = 2 }
-# Show only failing tests — suppresses the 3800-line passing-test wall so
-# broken imports and IR mismatches are immediately visible in one pass.
+# Suppress the 3800-line passing-test wall; show only failures during the run
+# and in the final summary.  Broken imports and IR mismatches are immediately
+# visible without scrolling past a sea of green lines.
+status-level = "fail"
 final-status-level = "fail"
 # Never stop at the first failure; one broken import should not mask the
 # cascade of downstream failures that tells you the actual blast radius.

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -272,6 +272,7 @@ test-group = "subprocess-intensive"
 # Usage:
 #   make test-lane CRATE=hew-types    — single crate, fast tier
 #   make test-lane-all                — full workspace, fast tier
+#   make test-fast                    — affected crates only, via git-diff scope
 #   cargo nextest run -p <crate> --profile lane
 #
 # Coverage contract:
@@ -297,6 +298,12 @@ test-group = "subprocess-intensive"
 default-filter = "not package(hew-wasm) - binary(eval_e2e) - binary(test_runner_e2e) - binary(parity) - binary(~exec) - binary(~e2e) - binary(~oracle) - binary(machine_lifecycle) - binary(zeroarg_module_enum_emission) - binary(jit_trap_bridge) - test(bounded_child_timeout_kills_grandchild_process_group) - test(two_process_remote_ask_echo_double_returns_42) - test(remote_ask_two_process_echo_client_helper) - test(remote_ask_two_process_echo_server_helper) - test(two_process_remote_ask_timeout_returns_timeout_under_1500ms) - test(remote_ask_two_process_timeout_client_helper) - test(remote_ask_two_process_timeout_server_helper)"
 test-threads = "num-cpus"
 slow-timeout = { period = "30s", terminate-after = 2 }
+# Show only failing tests — suppresses the 3800-line passing-test wall so
+# broken imports and IR mismatches are immediately visible in one pass.
+final-status-level = "fail"
+# Never stop at the first failure; one broken import should not mask the
+# cascade of downstream failures that tells you the actual blast radius.
+fail-fast = false
 
 [[profile.lane.overrides]]
 # Safety net: route any exec-named tests that slip past the default-filter into

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,14 @@ jobs:
     name: Build & test (Linux)
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    env:
+      # mold is installed by the "Install build tools" step below.
+      # Use gcc's -fuse-ld=mold flag (no clang-as-driver dependency) to
+      # activate mold for all Rust compilations in this job.  Scoped here
+      # rather than .cargo/config.toml so other workflows (release-gate,
+      # coverage-nightly, sanitizers) that run on runners without mold are
+      # unaffected.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,7 @@ jobs:
       - name: Install build tools
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq libssl-dev pkg-config
+          sudo apt-get install -y -qq libssl-dev pkg-config mold
 
       - name: Install LLVM ${{ env.LLVM_VERSION }}
         uses: ./.github/actions/setup-llvm

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@
 #   make playground-check          — manifest freshness + full hew-wasm test suite + build hew-wasm
 #   make playground-wasi-check     — focused curated manifest WASI runtime preflight
 #   make ci-preflight              — dispatch a conservative local preflight from the current diff
-#   make ci-preflight-smoke        — fast smoke tier: fmt + clippy + in-process tests (<5 min)
+#   make ci-preflight-smoke        — fast smoke tier: fmt + in-process tests (<5 min)
 #   make ci-preflight-strict       — run the local preflight superset that mirrors merge-queue gates
 #   make wasm-dist    — build + copy WASM to hew.sh and hew.run
 #   make test         — Rust workspace tests (fast path; excludes test-hew)
@@ -212,9 +212,10 @@ playground-wasi-check:
 ci-preflight:
 	scripts/ci-preflight-dispatcher.sh $(ARGS)
 
-# Fast smoke preflight: Rust fmt + clippy + the workspace's deterministic in-process
-# tests (nextest smoke profile).  Designed to complete in <5 min and surface format,
-# lint, and fast oracle failures before the full heavy tier is invoked.
+# Fast smoke preflight: Rust fmt + the workspace's deterministic in-process
+# tests (nextest smoke profile).  Designed to complete in <5 min and surface
+# format and fast oracle failures before the full heavy tier is invoked.
+# Clippy runs in the lint target; the fallback lane runs both sequentially.
 #
 # This target is invoked by the dispatcher as the first step of the fallback/heavy
 # lane; the full suite (make test) still runs on smoke pass.  Run it directly for

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@
 #   make test-real-timing  — serialized real wall-clock / OS-timing quarantine tests (narrow)
 #   make test-lane CRATE=<crate> — fast in-process tier for one crate (lane iteration)
 #   make test-lane-all          — fast in-process tier for the whole workspace
+#   make test-fast              — fast tier scoped to git-diff-affected crates (agents/devs)
+#   make test-fast CRATE=<c>   — pin fast tier to one crate
 #   make test-hew          — run Hew test files (std/ *_test.hew)
 #   make test-ux-examples  — run examples/ux + examples/progressive tutorials against .expected files
 #   make asan         — run the nightly rust-runtime ASan test command locally
@@ -65,7 +67,7 @@
 # ============================================================================
 
 .PHONY: all build bootstrap install-hooks hew hew-native adze observe runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh
-.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all test-stdlib test-hew test-hew-ratchet test-o2-differential test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar
+.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all test-fast test-stdlib test-hew test-hew-ratchet test-o2-differential test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
 .PHONY: coverage coverage-summary coverage-lcov coverage-runtime coverage-combined coverage-branch
@@ -682,6 +684,29 @@ endif
 test-lane-all:
 	@echo "==> fast tier — exec corpus runs at the integrated gate"
 	cargo nextest run --workspace --profile lane
+
+# ── Affected-crate fast tier ─────────────────────────────────────────────────
+# Derives scope from git diff: runs nextest --profile lane restricted to the
+# rdeps() closure of crates that have changed since the merge base.  Falls back
+# to a full workspace lane run when no crates are detected (e.g. first commit,
+# workspace-wide file change, or no diff vs origin).
+#
+# Usage:
+#   make test-fast             # auto-derive scope from git diff
+#   make test-fast CRATE=hew-types  # pin to one crate (skips diff derivation)
+#
+# This target replaces hand-curated -p lists for interactive iteration.
+# The exec/e2e corpus is still excluded (profile.lane).  Acceptance gates
+# require the plan's named proving commands, not this tier.
+test-fast:
+	@crates=$$(CRATE="$(CRATE)" scripts/changed-crates.sh); \
+	if [ -n "$$crates" ]; then \
+	  echo "==> fast tier — affected: $$crates"; \
+	  cargo nextest run --profile lane -E "rdeps($$crates)"; \
+	else \
+	  echo "==> fast tier — full workspace (no crate-specific diff detected)"; \
+	  cargo nextest run --workspace --profile lane; \
+	fi
 
 test-stdlib: hew
 	@echo "==> Type-checking stdlib .hew files"

--- a/Makefile
+++ b/Makefile
@@ -692,9 +692,15 @@ test-lane-all:
 # to a full workspace lane run when no crates are detected (e.g. first commit,
 # workspace-wide file change, or no diff vs origin).
 #
+# Multi-crate case: changed-crates.sh may return several space-separated names.
+# A single rdeps(hew-types hew-parser) is not valid nextest syntax — it matches
+# no package.  Instead each crate gets its own rdeps() term, joined with `|`:
+#   rdeps(hew-types) | rdeps(hew-parser)
+# The workspace fallback only fires when the crate list is empty.
+#
 # Usage:
-#   make test-fast             # auto-derive scope from git diff
-#   make test-fast CRATE=hew-types  # pin to one crate (skips diff derivation)
+#   make test-fast                    # auto-derive scope from git diff
+#   make test-fast CRATE=hew-types    # pin to one crate (skips diff derivation)
 #
 # This target replaces hand-curated -p lists for interactive iteration.
 # The exec/e2e corpus is still excluded (profile.lane).  Acceptance gates
@@ -703,7 +709,8 @@ test-fast:
 	@crates=$$(CRATE="$(CRATE)" scripts/changed-crates.sh); \
 	if [ -n "$$crates" ]; then \
 	  echo "==> fast tier — affected: $$crates"; \
-	  cargo nextest run --profile lane -E "rdeps($$crates)"; \
+	  expr=$$(printf 'rdeps(%s) | ' $$crates); expr=$${expr% | }; \
+	  cargo nextest run --profile lane -E "$$expr"; \
 	else \
 	  echo "==> fast tier — full workspace (no crate-specific diff detected)"; \
 	  cargo nextest run --workspace --profile lane; \

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,6 @@ ci-preflight:
 # (hew-fmt-check requires target/debug/hew but nextest does not produce it).
 ci-preflight-smoke:
 	cargo fmt --all -- --check
-	cargo clippy --workspace --tests -- -D warnings
 	$(MAKE) stdlib
 	cargo nextest run --workspace --profile smoke
 	$(MAKE) hew

--- a/scripts/changed-crates.sh
+++ b/scripts/changed-crates.sh
@@ -23,6 +23,8 @@
 #
 # Output format: space-separated package names, one line, or empty string.
 # Exit 0 always.
+#
+# Requires: bash 3.2+ (macOS system bash compatible), git.
 
 set -euo pipefail
 
@@ -53,37 +55,36 @@ if [[ -z "$BASE_REF" ]]; then
 fi
 
 # ── Collect changed paths ─────────────────────────────────────────────────────
-declare -a CHANGED_FILES=()
+# Accumulate paths as a newline-delimited string; sort -u to deduplicate.
+ALL_PATHS=""
 
-collect_from_cmd() {
-    local line
-    while IFS= read -r line; do
-        [[ -n "$line" ]] && CHANGED_FILES+=("$line")
-    done < <(eval "$1" 2>/dev/null || true)
+append_paths() {
+    local out
+    out="$(eval "$1" 2>/dev/null || true)"
+    if [[ -n "$out" ]]; then
+        ALL_PATHS="${ALL_PATHS}${out}"$'\n'
+    fi
 }
 
 if [[ -n "$BASE_REF" ]]; then
     # Paths changed since the merge base (the branch's own delta).
-    collect_from_cmd "git -C '$REPO_ROOT' diff --name-only '$BASE_REF' HEAD"
+    append_paths "git -C '$REPO_ROOT' diff --name-only '$BASE_REF' HEAD"
 fi
 
 # Staged and unstaged changes on top of HEAD.
-collect_from_cmd "git -C '$REPO_ROOT' diff --name-only HEAD"
+append_paths "git -C '$REPO_ROOT' diff --name-only HEAD"
 # Untracked files (new source files not yet committed).
-collect_from_cmd "git -C '$REPO_ROOT' ls-files --others --exclude-standard '$REPO_ROOT'"
+append_paths "git -C '$REPO_ROOT' ls-files --others --exclude-standard"
 
-# Deduplicate.
-declare -A SEEN_FILES=()
-declare -a UNIQUE_FILES=()
-for f in "${CHANGED_FILES[@]:-}"; do
-    if [[ -z "${SEEN_FILES[$f]+set}" ]]; then
-        SEEN_FILES[$f]=1
-        UNIQUE_FILES+=("$f")
-    fi
-done
-
-if [[ "${#UNIQUE_FILES[@]}" -eq 0 ]]; then
+if [[ -z "$ALL_PATHS" ]]; then
     # No changed files detected — caller falls back to full workspace.
+    exit 0
+fi
+
+# Deduplicated sorted paths.
+UNIQUE_FILES="$(printf '%s' "$ALL_PATHS" | sort -u | grep -v '^$' || true)"
+
+if [[ -z "$UNIQUE_FILES" ]]; then
     exit 0
 fi
 
@@ -91,61 +92,96 @@ fi
 # Mirror the dispatcher's is_*_path() case patterns but output the Cargo
 # package name for use in nextest's -E 'rdeps(...)' expressions.
 # Each crate directory prefix maps to its Cargo package name (they match
-# directory name except hew-wasm = "hew-wasm" and hew-std = "hew-std").
+# the directory name for this workspace).
+#
+# Returns: space-separated crate names, or the sentinel "__workspace__"
+# when a workspace-wide file is detected (signals fallback to full run).
 
-declare -A CRATES_FOUND=()
+WORKSPACE_WIDE=0
+# Use a plain string accumulator (bash 3.2 has no assoc arrays).
+CRATES_FOUND=""
 
-path_to_crate() {
-    local p="$1"
-    case "$p" in
-        hew-parser/*|hew-lexer/*)               echo "hew-parser hew-lexer" ;;
-        hew-types/*)                             echo "hew-types" ;;
-        hew-hir/*)                               echo "hew-hir" ;;
-        hew-mir/*)                               echo "hew-mir" ;;
-        hew-codegen-rs/*)                        echo "hew-codegen-rs" ;;
-        hew-compile/*)                           echo "hew-compile" ;;
-        hew-cabi/*)                              echo "hew-cabi" ;;
-        hew-capability-gen/*)                    echo "hew-capability-gen" ;;
-        hew-cli/*)                               echo "hew-cli" ;;
-        adze-cli/*)                              echo "adze-cli" ;;
-        hew-runtime/*)                           echo "hew-runtime" ;;
-        hew-runtime-testkit/*)                   echo "hew-runtime-testkit" ;;
-        hew-observe/*)                           echo "hew-observe" ;;
-        hew-analysis/*)                          echo "hew-analysis" ;;
-        hew-lib/*)                               echo "hew-lib" ;;
-        hew-lsp/*)                               echo "hew-lsp" ;;
-        hew-testutil/*)                          echo "hew-testutil" ;;
-        hew-std/*)                               echo "hew-std" ;;
-        hew-wasm/*)                              echo "hew-wasm" ;;
-        hew-sandbox-vm/*)                        echo "hew-sandbox-vm" ;;
-        hew-sandbox-wasm/*)                      echo "hew-sandbox-wasm" ;;
-        # Shared source or config touched multiple crates — treat as workspace-wide.
-        Cargo.toml|Cargo.lock|.config/*|.cargo/*|Makefile|scripts/*)
-            echo "__workspace__" ;;
-        # Hew stdlib sources — checked by hew-cli and hew-codegen-rs.
-        std/*|tests/hew/*)
-            echo "hew-cli hew-codegen-rs" ;;
-        # Test fixtures — touched by hew-cli.
-        tests/*)
-            echo "hew-cli" ;;
+add_crate() {
+    local c="$1"
+    # Append only if not already present (substring check).
+    case " $CRATES_FOUND " in
+        *" $c "*) ;;  # already present
+        *) CRATES_FOUND="${CRATES_FOUND:+$CRATES_FOUND }$c" ;;
     esac
 }
 
-for f in "${UNIQUE_FILES[@]}"; do
-    crate_names="$(path_to_crate "$f")"
-    for c in $crate_names; do
-        CRATES_FOUND[$c]=1
-    done
-done
+while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    case "$f" in
+        hew-parser/*|hew-lexer/*)
+            add_crate "hew-parser"; add_crate "hew-lexer" ;;
+        hew-types/*)
+            add_crate "hew-types" ;;
+        hew-hir/*)
+            add_crate "hew-hir" ;;
+        hew-mir/*)
+            add_crate "hew-mir" ;;
+        hew-codegen-rs/*)
+            add_crate "hew-codegen-rs" ;;
+        hew-compile/*)
+            add_crate "hew-compile" ;;
+        hew-cabi/*)
+            add_crate "hew-cabi" ;;
+        hew-capability-gen/*)
+            add_crate "hew-capability-gen" ;;
+        hew-cli/*)
+            add_crate "hew-cli" ;;
+        adze-cli/*)
+            add_crate "adze-cli" ;;
+        hew-runtime/*)
+            add_crate "hew-runtime" ;;
+        hew-runtime-testkit/*)
+            add_crate "hew-runtime-testkit" ;;
+        hew-observe/*)
+            add_crate "hew-observe" ;;
+        hew-analysis/*)
+            add_crate "hew-analysis" ;;
+        hew-lib/*)
+            add_crate "hew-lib" ;;
+        hew-lsp/*)
+            add_crate "hew-lsp" ;;
+        hew-testutil/*)
+            add_crate "hew-testutil" ;;
+        hew-std/*)
+            add_crate "hew-std" ;;
+        hew-wasm/*)
+            add_crate "hew-wasm" ;;
+        hew-sandbox-vm/*)
+            add_crate "hew-sandbox-vm" ;;
+        hew-sandbox-wasm/*)
+            add_crate "hew-sandbox-wasm" ;;
+        # Shared source or config that could affect all crates — treat as workspace-wide.
+        Cargo.toml|Cargo.lock|.config/*|.cargo/*|Makefile)
+            WORKSPACE_WIDE=1 ;;
+        scripts/*)
+            # Script changes don't affect Rust tests — skip silently.
+            ;;
+        # Hew stdlib sources — exercised by hew-cli and hew-codegen-rs.
+        std/*)
+            add_crate "hew-cli"; add_crate "hew-codegen-rs" ;;
+        tests/hew/*)
+            add_crate "hew-cli"; add_crate "hew-codegen-rs" ;;
+        # Other test fixtures — exercised by hew-cli.
+        tests/*)
+            add_crate "hew-cli" ;;
+        # Anything else is treated as workspace-wide.
+        *)
+            WORKSPACE_WIDE=1 ;;
+    esac
+done <<< "$UNIQUE_FILES"
 
 # If a workspace-wide file changed, signal fallback by printing nothing.
-if [[ -n "${CRATES_FOUND[__workspace__]+set}" ]]; then
+if [[ "$WORKSPACE_WIDE" -eq 1 ]]; then
     exit 0
 fi
 
-if [[ "${#CRATES_FOUND[@]}" -eq 0 ]]; then
+if [[ -z "$CRATES_FOUND" ]]; then
     exit 0
 fi
 
-# Emit space-separated crate names.
-printf '%s' "${!CRATES_FOUND[*]}"
+printf '%s' "$CRATES_FOUND"

--- a/scripts/changed-crates.sh
+++ b/scripts/changed-crates.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# scripts/changed-crates.sh — map git diff → changed crate names
+#
+# Prints a space-separated list of Cargo package names whose source files
+# appear in the current diff (committed, staged, unstaged, or untracked vs
+# the merge base on the default branch).
+#
+# Used by `make test-fast` to scope `cargo nextest run -E 'rdeps(<crates>)'`
+# to only the crates touched by the current branch.  When no crates are
+# detected the script prints nothing, and `make test-fast` falls back to a
+# full workspace run.
+#
+# WHY: replaces the hand-maintained `-p` crate list in the dispatcher with
+# a git-derived scope; catches missed downstream crates automatically.
+# WHEN obsolete: if Cargo gains a built-in affected-crate oracle.
+# WHAT the real solution looks like: `cargo-difftests` with per-hunk
+# coverage instrumentation — deferred until build-cost is justified.
+#
+# Usage:
+#   scripts/changed-crates.sh               # diff vs origin/HEAD merge base
+#   scripts/changed-crates.sh --base <ref>  # explicit base ref
+#   CRATE=hew-types scripts/changed-crates.sh  # pin output to one crate (passthrough)
+#
+# Output format: space-separated package names, one line, or empty string.
+# Exit 0 always.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ── CRATE= passthrough ────────────────────────────────────────────────────────
+# If the caller has already narrowed scope via CRATE=, honour it directly.
+if [[ -n "${CRATE:-}" ]]; then
+    printf '%s' "$CRATE"
+    exit 0
+fi
+
+# ── Base ref resolution ───────────────────────────────────────────────────────
+BASE_REF=""
+if [[ "${1:-}" == "--base" && -n "${2:-}" ]]; then
+    BASE_REF="$2"
+    shift 2
+fi
+
+if [[ -z "$BASE_REF" ]]; then
+    # Try to find the common ancestor with the default remote branch.
+    for candidate in origin/main origin/master; do
+        if git -C "$REPO_ROOT" rev-parse --verify "$candidate" >/dev/null 2>&1; then
+            BASE_REF="$(git -C "$REPO_ROOT" merge-base HEAD "$candidate" 2>/dev/null || true)"
+            break
+        fi
+    done
+fi
+
+# ── Collect changed paths ─────────────────────────────────────────────────────
+declare -a CHANGED_FILES=()
+
+collect_from_cmd() {
+    local line
+    while IFS= read -r line; do
+        [[ -n "$line" ]] && CHANGED_FILES+=("$line")
+    done < <(eval "$1" 2>/dev/null || true)
+}
+
+if [[ -n "$BASE_REF" ]]; then
+    # Paths changed since the merge base (the branch's own delta).
+    collect_from_cmd "git -C '$REPO_ROOT' diff --name-only '$BASE_REF' HEAD"
+fi
+
+# Staged and unstaged changes on top of HEAD.
+collect_from_cmd "git -C '$REPO_ROOT' diff --name-only HEAD"
+# Untracked files (new source files not yet committed).
+collect_from_cmd "git -C '$REPO_ROOT' ls-files --others --exclude-standard '$REPO_ROOT'"
+
+# Deduplicate.
+declare -A SEEN_FILES=()
+declare -a UNIQUE_FILES=()
+for f in "${CHANGED_FILES[@]:-}"; do
+    if [[ -z "${SEEN_FILES[$f]+set}" ]]; then
+        SEEN_FILES[$f]=1
+        UNIQUE_FILES+=("$f")
+    fi
+done
+
+if [[ "${#UNIQUE_FILES[@]}" -eq 0 ]]; then
+    # No changed files detected — caller falls back to full workspace.
+    exit 0
+fi
+
+# ── Path → crate-name mapping ─────────────────────────────────────────────────
+# Mirror the dispatcher's is_*_path() case patterns but output the Cargo
+# package name for use in nextest's -E 'rdeps(...)' expressions.
+# Each crate directory prefix maps to its Cargo package name (they match
+# directory name except hew-wasm = "hew-wasm" and hew-std = "hew-std").
+
+declare -A CRATES_FOUND=()
+
+path_to_crate() {
+    local p="$1"
+    case "$p" in
+        hew-parser/*|hew-lexer/*)               echo "hew-parser hew-lexer" ;;
+        hew-types/*)                             echo "hew-types" ;;
+        hew-hir/*)                               echo "hew-hir" ;;
+        hew-mir/*)                               echo "hew-mir" ;;
+        hew-codegen-rs/*)                        echo "hew-codegen-rs" ;;
+        hew-compile/*)                           echo "hew-compile" ;;
+        hew-cabi/*)                              echo "hew-cabi" ;;
+        hew-capability-gen/*)                    echo "hew-capability-gen" ;;
+        hew-cli/*)                               echo "hew-cli" ;;
+        adze-cli/*)                              echo "adze-cli" ;;
+        hew-runtime/*)                           echo "hew-runtime" ;;
+        hew-runtime-testkit/*)                   echo "hew-runtime-testkit" ;;
+        hew-observe/*)                           echo "hew-observe" ;;
+        hew-analysis/*)                          echo "hew-analysis" ;;
+        hew-lib/*)                               echo "hew-lib" ;;
+        hew-lsp/*)                               echo "hew-lsp" ;;
+        hew-testutil/*)                          echo "hew-testutil" ;;
+        hew-std/*)                               echo "hew-std" ;;
+        hew-wasm/*)                              echo "hew-wasm" ;;
+        hew-sandbox-vm/*)                        echo "hew-sandbox-vm" ;;
+        hew-sandbox-wasm/*)                      echo "hew-sandbox-wasm" ;;
+        # Shared source or config touched multiple crates — treat as workspace-wide.
+        Cargo.toml|Cargo.lock|.config/*|.cargo/*|Makefile|scripts/*)
+            echo "__workspace__" ;;
+        # Hew stdlib sources — checked by hew-cli and hew-codegen-rs.
+        std/*|tests/hew/*)
+            echo "hew-cli hew-codegen-rs" ;;
+        # Test fixtures — touched by hew-cli.
+        tests/*)
+            echo "hew-cli" ;;
+    esac
+}
+
+for f in "${UNIQUE_FILES[@]}"; do
+    crate_names="$(path_to_crate "$f")"
+    for c in $crate_names; do
+        CRATES_FOUND[$c]=1
+    done
+done
+
+# If a workspace-wide file changed, signal fallback by printing nothing.
+if [[ -n "${CRATES_FOUND[__workspace__]+set}" ]]; then
+    exit 0
+fi
+
+if [[ "${#CRATES_FOUND[@]}" -eq 0 ]]; then
+    exit 0
+fi
+
+# Emit space-separated crate names.
+printf '%s' "${!CRATES_FOUND[*]}"

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -73,7 +73,7 @@ LIST_CI_REQUIRED=0
 # PATTERN is a substring matched against the dispatcher's fallback-lane output.
 CI_REQUIRED_CHECKS=(
     "Rust fmt check (ci.yml: cargo fmt --all -- --check)	make ci-preflight-smoke"
-    "Cargo clippy (ci.yml: cargo clippy --workspace --tests -- -D warnings)	make ci-preflight-smoke"
+    "Cargo clippy (ci.yml: cargo clippy --workspace --tests -- -D warnings)	make lint"
     "verify-ffi (ci.yml: make verify-ffi)	make lint"
     "runtime-poison-safe-lint (ci.yml: make runtime-poison-safe-lint)	make lint"
     "nextest workspace ci (release-gate.yml: nextest run --workspace --profile ci)	make test"


### PR DESCRIPTION
## Summary

The preflight smoke lane was running clippy twice — the duplicate is removed, so the smoke
path now runs clippy exactly once. A `profile.lane` configuration is added to nextest: it
enables fail-fast and suppresses passing test lines, so iteration output shows failures
without the noise of successful runs. A new `make test-fast` target uses `git diff` to
identify which crates changed, then runs only the affected crates and their reverse
dependencies via a `rdeps()` union filterset. The Linux CI `build-and-test` job now
installs and activates the mold linker for faster incremental links, scoped to that job
only via a job-level env; no other workflows are affected and no global linker config is
changed.

## Verification

- `scripts/ci-preflight-dispatcher.sh --dry-run` (smoke path): clippy appears exactly once in the command list
- `profile.lane` flags: deliberate test breakage surfaces failures immediately and suppresses passing lines; verified with a forced compile error
- `make test-fast` filterset output: 1 crate → `rdeps(hew-types)`; 2 crates → `rdeps(hew-types) | rdeps(hew-parser)`; 3 crates → correct union with trimmed trailing separator; empty crate list → workspace fallback
- Mold scoped to ci.yml `build-and-test` job via `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"` (gcc `-fuse-ld=`, no clang-as-driver dependency); release-gate, nightly-sanitizers, coverage, and deploy-docs workflows are unaffected
- Preflight: ready-to-push

## Out of scope

- `hew test --jobs` parallelism and exec-binary consolidation — the larger CI throughput levers, separate work
- macOS linker tuning — needs a baseline run before any change
