### PR TITLE
feat(clone): generic clone — type parameters, generic enums, record-of-Vec, and HashMap/HashSet deep copy

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -17887,11 +17887,13 @@ fn is_hashmap_layout_runtime_symbol(symbol: &str) -> bool {
             | "hew_hashmap_len_layout"
             | "hew_hashmap_keys_layout"
             | "hew_hashmap_values_layout"
+            | "hew_hashmap_clone_layout"
             | "hew_hashset_insert_layout"
             | "hew_hashset_contains_layout"
             | "hew_hashset_remove_layout"
             | "hew_hashset_len_layout"
             | "hew_hashset_is_empty_layout"
+            | "hew_hashset_clone_layout"
     )
 }
 
@@ -18061,6 +18063,8 @@ fn layout_hashmap_fn_type<'ctx>(
         "hew_hashmap_keys_layout" => Ok(ptr_ty.fn_type(&[ptr_ty.into()], false)),
         // `*mut HewVec hew_hashmap_values_layout(map)`
         "hew_hashmap_values_layout" => Ok(ptr_ty.fn_type(&[ptr_ty.into()], false)),
+        // `*mut HewLayoutHashMap hew_hashmap_clone_layout(map)`
+        "hew_hashmap_clone_layout" => Ok(ptr_ty.fn_type(&[ptr_ty.into()], false)),
         // `bool hew_hashset_insert_layout(set, elem_ptr)`
         "hew_hashset_insert_layout" => Ok(i1_ty.fn_type(&[ptr_ty.into(), ptr_ty.into()], false)),
         // `bool hew_hashset_contains_layout(set, elem_ptr)`
@@ -18071,6 +18075,8 @@ fn layout_hashmap_fn_type<'ctx>(
         "hew_hashset_len_layout" => Ok(i64_ty.fn_type(&[ptr_ty.into()], false)),
         // `bool hew_hashset_is_empty_layout(set)`
         "hew_hashset_is_empty_layout" => Ok(i1_ty.fn_type(&[ptr_ty.into()], false)),
+        // `*mut HewLayoutHashSet hew_hashset_clone_layout(set)`
+        "hew_hashset_clone_layout" => Ok(ptr_ty.fn_type(&[ptr_ty.into()], false)),
         _ => Err(CodegenError::FailClosed(format!(
             "not a layout HashMap/HashSet runtime symbol: {symbol}"
         ))),
@@ -19293,11 +19299,15 @@ fn lower_hashmap_layout_direct_call(
     let expected_arity: usize = match callee {
         "hew_hashmap_insert_layout" => 3,
         "hew_hashmap_contains_key_layout" | "hew_hashmap_remove_layout" => 2,
-        "hew_hashmap_len_layout" | "hew_hashmap_keys_layout" | "hew_hashmap_values_layout" => 1,
+        "hew_hashmap_len_layout"
+        | "hew_hashmap_keys_layout"
+        | "hew_hashmap_values_layout"
+        | "hew_hashmap_clone_layout" => 1,
         "hew_hashset_insert_layout"
         | "hew_hashset_contains_layout"
         | "hew_hashset_remove_layout" => 2,
         "hew_hashset_len_layout" | "hew_hashset_is_empty_layout" => 1,
+        "hew_hashset_clone_layout" => 1,
         _ => {
             return Err(CodegenError::FailClosed(format!(
                 "lower_hashmap_layout_direct_call called with non-layout symbol `{callee}`"
@@ -19472,6 +19482,31 @@ fn lower_hashmap_layout_direct_call(
                 .build_store(dest_ptr, vec_ptr)
                 .llvm_ctx("hew_hashmap_values_layout store")?;
         }
+        "hew_hashmap_clone_layout" => {
+            // `*mut HewLayoutHashMap hew_hashmap_clone_layout(map)` — returns a
+            // deep-cloned map; caller is the sole owner. The runtime duplicates
+            // every owned key/value blob via the descriptor clone discipline and
+            // fails closed on a missing clone thunk, so the result is an
+            // independent map that the dest's type-driven scope-exit drop frees
+            // exactly once (the `HASHMAP_FREE_LAYOUT_SYMBOL` half of the pair).
+            let dest_place = dest.ok_or_else(|| {
+                CodegenError::FailClosed(
+                    "hew_hashmap_clone_layout returns *mut map; call must supply a dest".into(),
+                )
+            })?;
+            let call = fn_ctx
+                .builder
+                .build_call(fv, &[map_ptr.into()], "hew_hashmap_clone_layout_call")
+                .llvm_ctx("hew_hashmap_clone_layout call")?;
+            let cloned_ptr = call.try_as_basic_value().basic().ok_or_else(|| {
+                CodegenError::FailClosed("hew_hashmap_clone_layout returned void".into())
+            })?;
+            let (dest_ptr, _dest_ty) = place_pointer(fn_ctx, *dest_place)?;
+            fn_ctx
+                .builder
+                .build_store(dest_ptr, cloned_ptr)
+                .llvm_ctx("hew_hashmap_clone_layout store")?;
+        }
         "hew_hashset_insert_layout" => {
             // `bool hew_hashset_insert_layout(set, elem_ptr)`.
             let (elem_ptr, _elem_ty) = place_pointer(fn_ctx, args[1])?;
@@ -19604,6 +19639,31 @@ fn lower_hashmap_layout_direct_call(
                 .builder
                 .build_store(dest_ptr, widened)
                 .llvm_ctx("hew_hashset_is_empty_layout store")?;
+        }
+        "hew_hashset_clone_layout" => {
+            // `*mut HewLayoutHashSet hew_hashset_clone_layout(set)` — returns a
+            // deep-cloned set (delegates to the map clone for the inner storage);
+            // caller is the sole owner. Elements are constrained to Plain/string
+            // by the same Hash+Eq admission as map keys, so the runtime's
+            // layout-managed abort is unreachable; the dest's type-driven
+            // scope-exit drop frees it once via `HASHSET_FREE_LAYOUT_SYMBOL`.
+            let dest_place = dest.ok_or_else(|| {
+                CodegenError::FailClosed(
+                    "hew_hashset_clone_layout returns *mut set; call must supply a dest".into(),
+                )
+            })?;
+            let call = fn_ctx
+                .builder
+                .build_call(fv, &[map_ptr.into()], "hew_hashset_clone_layout_call")
+                .llvm_ctx("hew_hashset_clone_layout call")?;
+            let cloned_ptr = call.try_as_basic_value().basic().ok_or_else(|| {
+                CodegenError::FailClosed("hew_hashset_clone_layout returned void".into())
+            })?;
+            let (dest_ptr, _dest_ty) = place_pointer(fn_ctx, *dest_place)?;
+            fn_ctx
+                .builder
+                .build_store(dest_ptr, cloned_ptr)
+                .llvm_ctx("hew_hashset_clone_layout store")?;
         }
         _ => unreachable!("matched above"),
     }

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -9051,6 +9051,51 @@ fn collect_record_clone_inplace_seeds(
     seeds
 }
 
+/// Collect the monomorphised tagged-union layout key of every `EnumCloneInplace`
+/// instruction in raw MIR so its `__hew_enum_clone_inplace_<key>` /
+/// `__hew_enum_drop_inplace_<key>` thunk PAIR is synthesised by
+/// `emit_state_clone_drop_synthesis`. The enum twin of
+/// `collect_record_clone_inplace_seeds`.
+///
+/// `clone <enum>` lowers to `EnumCloneInplace { enum_name, .. }`, where
+/// `enum_name` is the monomorphised layout key (the bare name for a monomorphic
+/// enum, the mangled `Maybe$$i64` for a generic instantiation — see
+/// `enum_clone_layout_key` in hew-mir). A generic enum whose every variant
+/// payload is `BitCopy` (`Maybe<i64>`) is cloned but never earns an
+/// `EnumInPlace` drop, so the drop-side seed (`collect_enum_inplace_drop_seeds`)
+/// does NOT cover it; seeding the clone site directly closes that gap. Because
+/// the synthesis loop emits the clone AND drop body together per key, the thunk
+/// pair stays symmetric — there is no clone without its matching drop (the leak
+/// / double-free hazard on unwind).
+///
+/// A seed is registered only when `enum_name` names a registered layout, so the
+/// key the synthesis pass emits a body under is exactly the key the clone call
+/// resolves; a `enum_name` with no registered layout is left unseeded and fails
+/// closed loudly at LLVM verify rather than silently aliasing.
+fn collect_enum_clone_inplace_seeds(
+    raw_mir: &[RawMirFunction],
+    enum_layouts: &[EnumLayout],
+) -> Vec<String> {
+    let mut seeds: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for func in raw_mir {
+        for block in &func.blocks {
+            for instr in &block.instructions {
+                let Instr::EnumCloneInplace { enum_name, .. } = instr else {
+                    continue;
+                };
+                if !enum_layouts.iter().any(|el| el.name == *enum_name) {
+                    continue;
+                }
+                if seen.insert(enum_name.clone()) {
+                    seeds.push(enum_name.clone());
+                }
+            }
+        }
+    }
+    seeds
+}
+
 /// D2 / W3.031 — collect the record/enum layout keys of every type that
 /// appears as a `dyn Trait` CONCRETE so its
 /// `__hew_{record,enum}_drop_inplace_<key>` body is synthesised before
@@ -12023,6 +12068,13 @@ fn lower_instruction(
             record_name,
         } => {
             lower_record_clone_inplace_instr(fn_ctx, *dest, *src, record_name)?;
+        }
+        Instr::EnumCloneInplace {
+            dest,
+            src,
+            enum_name,
+        } => {
+            lower_enum_clone_inplace_instr(fn_ctx, *dest, *src, enum_name)?;
         }
         Instr::ContextField { dest, offset } => {
             lower_context_field(fn_ctx, *dest, *offset)?;
@@ -15634,6 +15686,108 @@ fn lower_record_clone_inplace_instr<'ctx>(
     builder
         .build_unreachable()
         .llvm_ctx_with(|| format!("record_clone_inplace unreachable {record_name}"))?;
+    builder.position_at_end(ok_bb);
+    Ok(())
+}
+
+/// Lower `Instr::EnumCloneInplace { dest, src, enum_name }` — the enum twin of
+/// [`lower_record_clone_inplace_instr`]. Identical three-step protocol, differing
+/// only in the synthesised helper symbol (`__hew_enum_clone_inplace_<E>`):
+///   1. `memcpy(dest_ptr, src_ptr, abi_sizeof(E))` — copies the tag and the
+///      inactive/`BitCopy` payload bytes and byte-aliases the active variant's
+///      owned-heap payload pointers into `dest`.
+///   2. `i32 rc = __hew_enum_clone_inplace_<E>(src_ptr, dest_ptr)` — the
+///      synthesised thunk tag-dispatches and overwrites only the active
+///      variant's owned-heap payload fields in `dest` with independent deep
+///      clones; on partial failure it rolls back and returns non-zero.
+///   3. Trap (`llvm.trap`) on `rc != 0` — fail-closed; no partial clone survives.
+///
+/// `src` is the already-lowered source Place; `dest` is a freshly-alloc'd Place
+/// of the same enum tagged-union type. Both are stack pointers in the current
+/// function frame.
+fn lower_enum_clone_inplace_instr<'ctx>(
+    fn_ctx: &FnCtx<'_, 'ctx>,
+    dest: Place,
+    src: Place,
+    enum_name: &str,
+) -> CodegenResult<()> {
+    let ctx = fn_ctx.ctx;
+    let builder = &fn_ctx.builder;
+    let (src_ptr, src_ty) = place_pointer(fn_ctx, src)?;
+    let (dest_ptr, _) = place_pointer(fn_ctx, dest)?;
+
+    // Step 1: wholesale bitwise copy into dest.
+    // The ABI size gives the exact byte count including tagged-union padding.
+    let size_bytes = match src_ty {
+        BasicTypeEnum::StructType(st) => fn_ctx.target_data.get_abi_size(&st),
+        _ => {
+            return Err(CodegenError::FailClosed(format!(
+                "EnumCloneInplace: src place for enum `{enum_name}` has non-struct LLVM \
+                 type {src_ty:?}; expected the tagged-union StructType"
+            )));
+        }
+    };
+    let align = match src_ty {
+        BasicTypeEnum::StructType(st) => fn_ctx.target_data.get_abi_alignment(&st),
+        _ => unreachable!("checked above"),
+    };
+    let size_i64 = ctx.i64_type().const_int(size_bytes, false);
+    builder
+        .build_memcpy(dest_ptr, align, src_ptr, align, size_i64)
+        .llvm_ctx_with(|| format!("enum_clone_inplace memcpy {enum_name}"))?;
+
+    // Step 2: call the synthesised in-place clone thunk.
+    let clone_fn = get_or_declare_enum_clone_inplace(ctx, fn_ctx.llvm_mod, enum_name);
+    let call_site = builder
+        .build_call(
+            clone_fn,
+            &[src_ptr.into(), dest_ptr.into()],
+            &format!("enum_clone_{enum_name}"),
+        )
+        .llvm_ctx_with(|| format!("enum_clone_inplace call {enum_name}"))?;
+    let rc = call_site
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| {
+            CodegenError::FailClosed(format!(
+                "EnumCloneInplace: clone thunk for `{enum_name}` returned void"
+            ))
+        })?
+        .into_int_value();
+
+    // Step 3: trap on non-zero return (fail-closed; the thunk already rolled back).
+    let i32_ty = ctx.i32_type();
+    let zero = i32_ty.const_int(0, false);
+    let failed = builder
+        .build_int_compare(
+            inkwell::IntPredicate::NE,
+            rc,
+            zero,
+            &format!("enum_clone_{enum_name}_failed"),
+        )
+        .llvm_ctx_with(|| format!("enum_clone_inplace NE cmp {enum_name}"))?;
+    let ok_bb = ctx.append_basic_block(
+        builder.get_insert_block().unwrap().get_parent().unwrap(),
+        "clone_ok",
+    );
+    let trap_bb = ctx.append_basic_block(
+        builder.get_insert_block().unwrap().get_parent().unwrap(),
+        "clone_trap",
+    );
+    builder
+        .build_conditional_branch(failed, trap_bb, ok_bb)
+        .llvm_ctx_with(|| format!("enum_clone_inplace branch {enum_name}"))?;
+    builder.position_at_end(trap_bb);
+    let trap_fn = inkwell::intrinsics::Intrinsic::find("llvm.trap")
+        .ok_or_else(|| CodegenError::FailClosed("llvm.trap intrinsic not found".into()))?
+        .get_declaration(fn_ctx.llvm_mod, &[])
+        .ok_or_else(|| CodegenError::FailClosed("llvm.trap declaration failed".into()))?;
+    builder
+        .build_call(trap_fn, &[], "trap")
+        .llvm_ctx_with(|| format!("enum_clone_inplace trap {enum_name}"))?;
+    builder
+        .build_unreachable()
+        .llvm_ctx_with(|| format!("enum_clone_inplace unreachable {enum_name}"))?;
     builder.position_at_end(ok_bb);
     Ok(())
 }
@@ -33053,6 +33207,18 @@ fn build_module_for_target<'ctx>(
     for seed in collect_record_clone_inplace_seeds(&pipeline.raw_mir, &pipeline.record_layouts) {
         if !vec_owned_record_seeds.contains(&seed) {
             vec_owned_record_seeds.push(seed);
+        }
+    }
+    // Generic/top-level enum-clone instantiations: `clone Maybe<i64>` lowers to
+    // an `EnumCloneInplace` keyed by the monomorphised tagged-union layout
+    // (`Maybe$$i64`). An all-`BitCopy`-payload enum is cloned but never earns an
+    // `EnumInPlace` drop, so the drop-side `collect_enum_inplace_drop_seeds`
+    // above does not cover it. Seed the clone site directly so the per-key
+    // clone/drop thunk PAIR is synthesised together (the enum twin of the
+    // record clone-site seed loop directly above).
+    for seed in collect_enum_clone_inplace_seeds(&pipeline.raw_mir, &pipeline.enum_layouts) {
+        if !enum_inplace_drop_seeds.contains(&seed) {
+            enum_inplace_drop_seeds.push(seed);
         }
     }
     emit_state_clone_drop_synthesis(

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -18411,9 +18411,12 @@ impl LowerCtx {
         // (e.g. a user-declared `trait Clone { fn clone(val: Self) -> Self; }`).
         //
         // Fail-closed per the no-silent-stub invariant (M-COW P0):
-        // `.clone()` must never silently return the same handle.  The runtime
-        // copy path (e.g. `hew_bytes_clone_ref` for `Bytes`) will be wired
-        // into the HIR→MIR→codegen pipeline in P2.  Until then, every
+        // `.clone()` must never silently return the same handle.  Collection
+        // clones with a ready runtime deep-copy (`HashMap`/`HashSet` via
+        // `hew_hashmap_clone_layout` / `hew_hashset_clone_layout`) are resolved
+        // by the checker to a `ResolvedCall` and never reach this gate.  The
+        // remaining heap types whose copy path is not yet wired (e.g.
+        // `hew_bytes_clone_ref` for `Bytes`) stay fail-closed here: every
         // unresolved `.clone()` call is a compile error with an explicit
         // diagnostic so the user is never left guessing why their code "works"
         // but produces aliased references instead of independent copies.

--- a/hew-mir/src/dataflow.rs
+++ b/hew-mir/src/dataflow.rs
@@ -542,6 +542,7 @@ pub(crate) fn instr_reads_writes(instr: &Instr) -> (Vec<Place>, Vec<Place>) {
         Instr::GeneratorNext { dest, ctx, .. } => (vec![*ctx], vec![*dest]),
         Instr::WireCodec { dest, operand, .. } => (vec![*operand], vec![*dest]),
         Instr::RecordCloneInplace { dest, src, .. } => (vec![*src], vec![*dest]),
+        Instr::EnumCloneInplace { dest, src, .. } => (vec![*src], vec![*dest]),
         Instr::BoolNot { dest, operand }
         | Instr::FloatNeg { dest, operand, .. }
         | Instr::IntBitNot { dest, operand } => (vec![*operand], vec![*dest]),

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -705,6 +705,16 @@ fn render_instr(instr: &Instr) -> String {
             render_place(src),
             record_name
         ),
+        Instr::EnumCloneInplace {
+            dest,
+            src,
+            enum_name,
+        } => format!(
+            "{} = enum_clone {} enum={}",
+            render_place(dest),
+            render_place(src),
+            enum_name
+        ),
 
         // Data movement
         Instr::Move { dest, src } => {

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -12847,7 +12847,7 @@ impl Builder {
             } => {
                 let src_place = self.lower_value(src)?;
                 let record_ty = self.subst_ty(&expr.ty);
-                // A2-a: a clone of a bare type parameter
+                // A clone of a bare type parameter
                 // (`fn f<T: Clone>(x: T) -> T { x.clone() }`) is admitted by the
                 // checker through the record-clone rewrite, but after
                 // monomorphisation the concrete `T` is frequently a NON-record
@@ -12902,8 +12902,9 @@ impl Builder {
                 // closed loudly rather than admit a clone we cannot yet lower
                 // safely (`admit-only-what-you-lower`,
                 // `unclonable-leaf-fails-closed-transitively`). The generic
-                // `Vec<T>`-field surface is tracked separately (A2-b); generic
-                // enum clone is A2-c.
+                // record-of-`Vec` field surface is tracked under its own issue;
+                // generic enum clone is handled by the `EnumCloneInplace` arm
+                // below.
                 if matches!(
                     record_ty,
                     ResolvedTy::Bytes

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -12820,6 +12820,91 @@ impl Builder {
             } => {
                 let src_place = self.lower_value(src)?;
                 let record_ty = self.subst_ty(&expr.ty);
+                // A2-a: a clone of a bare type parameter
+                // (`fn f<T: Clone>(x: T) -> T { x.clone() }`) is admitted by the
+                // checker through the record-clone rewrite, but after
+                // monomorphisation the concrete `T` is frequently a NON-record
+                // value. The record-thunk protocol below only lowers user
+                // structs, so the concrete non-record monomorphisations are
+                // dispatched here by value class. Concrete user records and the
+                // abstract origin bucket — where `record_ty` is
+                // `ResolvedTy::TypeParam`, value-class `Unknown` — fall through
+                // to the byte-identical thunk path, so existing behaviour is
+                // unchanged.
+                //
+                // RecordCloneCall is only produced for a `Named { builtin: None }`
+                // receiver (a user record or a bare type parameter), so a
+                // concrete `string`/`Vec`/tuple `clone` never reaches these arms
+                // — only a type-parameter monomorphisation does.
+                //
+                // A `BitCopy` value (`i64`/`bool`/…, a `#[copy]` record)
+                // duplicates on every use, so the clone is the source place
+                // itself, exactly what the concrete scalar `CopyCloneNoop` path
+                // yields. No new owner is created, so no drop is owed.
+                if ValueClass::of_ty(&record_ty, &self.type_classes) == ValueClass::BitCopy {
+                    return Some(src_place);
+                }
+                // A `string` is a refcounted copy-on-write owner. `clone`
+                // produces an independent `+1` owner via `hew_string_clone` (a
+                // header-aware refcount bump). Emitting it as a `Terminator::Call`
+                // — the `hew_hashmap_get_clone_layout` pattern — seeds the dest as
+                // a `fresh_string_producer_term_dest`, so drop-elaboration adds
+                // the symmetric `hew_string_drop` in all three exit contexts
+                // (sync return, async cancel, actor shutdown). A plain read would
+                // alias the source at rc==1 and double-free when both are dropped
+                // (`by-value-heap-params-are-borrows` P0), so the explicit clone
+                // is load-bearing here.
+                if is_string_const_ty(&record_ty) {
+                    let dest = self.alloc_local(record_ty);
+                    let next = self.alloc_block();
+                    self.finish_current_block(Terminator::Call {
+                        callee: "hew_string_clone".to_string(),
+                        builtin: None,
+                        args: vec![src_place],
+                        dest: Some(dest),
+                        next,
+                    });
+                    self.start_block(next);
+                    return Some(dest);
+                }
+                // A type parameter that monomorphises to a builtin heap value
+                // (`Vec`/`HashMap`/`HashSet`/`bytes`/tuple/array) needs the
+                // owned-clone + element-drop machinery the concrete `clone` path
+                // drives from the checker. Synthesising it from a bare type
+                // parameter here would risk an unbalanced retain/drop, so fail
+                // closed loudly rather than admit a clone we cannot yet lower
+                // safely (`admit-only-what-you-lower`,
+                // `unclonable-leaf-fails-closed-transitively`). The generic
+                // `Vec<T>`-field surface is tracked separately (A2-b); generic
+                // enum clone is A2-c.
+                if matches!(
+                    record_ty,
+                    ResolvedTy::Bytes
+                        | ResolvedTy::Tuple(_)
+                        | ResolvedTy::Array(_, _)
+                        | ResolvedTy::Named {
+                            builtin: Some(
+                                BuiltinType::Vec | BuiltinType::HashMap | BuiltinType::HashSet
+                            ),
+                            ..
+                        }
+                ) {
+                    self.diagnostics.push(MirDiagnostic {
+                        kind: MirDiagnosticKind::NotYetImplemented {
+                            construct: format!(
+                                "clone of a generic type parameter monomorphised to `{record_ty}` \
+                                 is not yet lowered; clone of a `Clone`-bound type parameter \
+                                 currently supports scalar, `string`, and user-record \
+                                 instantiations"
+                            ),
+                            site: expr.site,
+                        },
+                        note: "a type parameter that resolves to a Vec/HashMap/HashSet/bytes/\
+                               tuple/array clone is not yet synthesised from a bare parameter"
+                            .to_string(),
+                    });
+                    return None;
+                }
                 // Key the clone thunk by the MONOMORPHISED record layout: a
                 // generic instantiation (`clone Pair<i64, i64>`) must resolve
                 // `__hew_record_clone_inplace_Pair$$i64$i64`, not the bare

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -8443,6 +8443,33 @@ impl Builder {
             .map(|layout| layout.name.clone())
     }
 
+    /// Resolve the monomorphised tagged-union layout key for an enum `clone`
+    /// site, covering BOTH fieldless and payload-carrying enums (clone applies
+    /// to every enum kind, unlike the eq helpers which split the two). Mirrors
+    /// `payload_enum_layout_key_for_eq`'s key resolution but without the
+    /// payload filter: a generic instantiation (`Maybe<i64>`) resolves the
+    /// mangled `Maybe$$i64`, a monomorphic enum keeps its bare declared name.
+    /// `None` when `ty` is not a registered enum — the caller then falls
+    /// through to the record path (the two layout registries are disjoint, so a
+    /// `Some` here is authoritative).
+    fn enum_clone_layout_key(&self, ty: &ResolvedTy) -> Option<String> {
+        let ResolvedTy::Named { name, args, .. } = ty else {
+            return None;
+        };
+        let short = short_name(name);
+        let key = if args.is_empty() {
+            name.clone()
+        } else {
+            mangle_layout_key(short, args)
+        };
+        self.enum_layouts
+            .iter()
+            .find(|layout| {
+                layout.name == key || layout.name == *name || short_name(&layout.name) == short
+            })
+            .map(|layout| layout.name.clone())
+    }
+
     fn is_structural_eq_comparison(&self, lhs_ty: &ResolvedTy, rhs_ty: &ResolvedTy) -> bool {
         if let (Some(lhs_key), Some(rhs_key)) = (
             self.record_layout_key_for_eq(lhs_ty),
@@ -12904,6 +12931,29 @@ impl Builder {
                             .to_string(),
                     });
                     return None;
+                }
+                // An enum monomorphisation routes to the enum twin of the
+                // record thunk. `clone <enum>` — a top-level enum, or (defence
+                // in depth) a `Clone`-bound type parameter that monomorphises to
+                // one — lowers to `EnumCloneInplace`, keyed by the SAME
+                // monomorphised tagged-union layout the drop side keys
+                // (`Maybe$$i64` for a generic instantiation, the bare name for a
+                // monomorphic enum). Codegen emits the memcpy +
+                // `__hew_enum_clone_inplace_<E>` + trap protocol and seeds the
+                // clone/drop helper PAIR together, so the scope-exit drop of
+                // `dest` stays symmetric (no leak, no double-free).
+                // `enum_clone_layout_key` returns `Some` only for a registered
+                // enum; the record and enum layout registries are disjoint, so
+                // this never shadows a record clone, and a `TypeParam` (the
+                // abstract origin bucket) is not `Named` so it falls through.
+                if let Some(enum_key) = self.enum_clone_layout_key(&record_ty) {
+                    let dest = self.alloc_local(record_ty);
+                    self.instructions.push(Instr::EnumCloneInplace {
+                        dest,
+                        src: src_place,
+                        enum_name: enum_key,
+                    });
+                    return Some(dest);
                 }
                 // Key the clone thunk by the MONOMORPHISED record layout: a
                 // generic instantiation (`clone Pair<i64, i64>`) must resolve
@@ -27731,6 +27781,7 @@ fn instr_places(instr: &Instr) -> Vec<Place> {
         Instr::GeneratorNext { dest, ctx, .. } => vec![*dest, *ctx],
         Instr::WireCodec { dest, operand, .. } => vec![*dest, *operand],
         Instr::RecordCloneInplace { dest, src, .. } => vec![*dest, *src],
+        Instr::EnumCloneInplace { dest, src, .. } => vec![*dest, *src],
         Instr::IntArithChecked {
             dest,
             lhs,
@@ -28043,6 +28094,8 @@ pub fn instr_source_places(instr: &Instr) -> Vec<Place> {
         // `RecordCloneInplace` reads `src` (borrows it; does not consume).
         // The original `src` binding stays live after the clone.
         Instr::RecordCloneInplace { src, .. } => vec![*src],
+        // `EnumCloneInplace` likewise borrows `src` (non-consuming read).
+        Instr::EnumCloneInplace { src, .. } => vec![*src],
         Instr::BoolNot { operand, .. }
         | Instr::FloatNeg { operand, .. }
         | Instr::IntBitNot { operand, .. }
@@ -28444,7 +28497,9 @@ fn generator_yield_instr_escapes(instr: &Instr, local: u32) -> bool {
         | Instr::MachineStateName { .. }
         // RecordCloneInplace borrows src (non-consuming read); it does not
         // transfer ownership of any local out of the frame.
-        | Instr::RecordCloneInplace { .. } => false,
+        | Instr::RecordCloneInplace { .. }
+        // EnumCloneInplace has the same non-consuming-read semantics.
+        | Instr::EnumCloneInplace { .. } => false,
     }
 }
 
@@ -28696,7 +28751,10 @@ fn projection_alias_dest(instr: &Instr) -> Option<Place> {
         // RecordCloneInplace allocates a fresh clone — its dest does NOT alias
         // the src or any parent aggregate field (the thunk overwrites heap
         // pointer fields in dst with independently-owned clones).
-        | Instr::RecordCloneInplace { .. } => None,
+        | Instr::RecordCloneInplace { .. }
+        // EnumCloneInplace allocates a fresh enum clone with the same
+        // non-aliasing guarantee (tag-dispatched payload deep-clone).
+        | Instr::EnumCloneInplace { .. } => None,
     }
 }
 

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -3449,6 +3449,33 @@ pub enum Instr {
         src: Place,
         record_name: String,
     },
+    /// Deep-clone a user enum via `__hew_enum_clone_inplace_<E>`.
+    ///
+    /// The enum twin of [`Instr::RecordCloneInplace`]. `dest` is the
+    /// freshly-alloc'd destination Place (same tagged-union type as `src`).
+    /// Codegen emits the identical three-step protocol, differing only in the
+    /// synthesised helper symbol:
+    ///   1. `memcpy(dst_ptr, src_ptr, sizeof(E))` — copies the tag and the
+    ///      inactive/`BitCopy` payload bytes; owned-heap payload pointers in
+    ///      the active variant are byte-aliased.
+    ///   2. `i32 rc = __hew_enum_clone_inplace_<E>(src_ptr, dst_ptr)` —
+    ///      tag-dispatches and overwrites only the active variant's owned-heap
+    ///      payload fields in `dst` with deep clones; on failure rolls back.
+    ///   3. Trap on `rc != 0` (fail-closed; no partial clone surviving).
+    ///
+    /// `enum_name` is the monomorphised tagged-union layout key (the bare name
+    /// for a monomorphic enum, the mangled `Maybe$$i64` for a generic
+    /// instantiation), used to build the thunk symbol and index the layout. The
+    /// matching `__hew_enum_drop_inplace_<E>` is synthesised as a unit with the
+    /// clone helper (clone/drop seeded together per key), so the scope-exit drop
+    /// of `dest` stays symmetric with the clone — no leak, no double-free.
+    ///
+    /// WASM-TODO(#2050): not yet lowered in sandbox emitter (as `RecordCloneInplace`).
+    EnumCloneInplace {
+        dest: Place,
+        src: Place,
+        enum_name: String,
+    },
     /// `dest = <src>` — load `src`, store into `dest`.
     Move { dest: Place, src: Place },
     /// Explicit checker-admitted numeric `as` cast.

--- a/hew-types/src/check/dispatch.rs
+++ b/hew-types/src/check/dispatch.rs
@@ -232,6 +232,7 @@ pub enum HashMapMethod {
     Len,
     Keys,
     Values,
+    Clone,
 }
 
 /// `HashSet` dispatch methods. Mirrors the methods registered for the
@@ -243,6 +244,7 @@ pub enum HashSetMethod {
     Remove,
     Len,
     IsEmpty,
+    Clone,
 }
 
 /// Vec dispatch methods. Mirrors the methods registered for the

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -6279,6 +6279,21 @@ impl Checker {
                 }
             }
 
+            // Pre-seed every still-unbound type parameter with a fresh inference
+            // var so a field whose declared type CONTAINS a parameter (e.g.
+            // `items: Vec<T>`) constrains that parameter from its initializer,
+            // exactly as a field whose type IS the bare parameter (`val: T`)
+            // already does. Without this the nested parameter stays the raw
+            // type-def symbol `T` in the initializer's own type and never
+            // monomorphises (`E_MIR: unknown type T` at the MIR boundary). The
+            // vars unify during field checking below and are resolved back to
+            // concrete types before the result type is built.
+            for tp in &td.type_params {
+                type_arg_map
+                    .entry(tp.clone())
+                    .or_insert_with(|| Ty::Var(TypeVar::fresh()));
+            }
+
             for (field_name, (expr, es)) in fields {
                 if let Some(declared_ty) = td.fields.get(field_name) {
                     // Substitute already-inferred type params into the expected type.
@@ -6368,10 +6383,10 @@ impl Checker {
                 .type_params
                 .iter()
                 .map(|tp| {
-                    type_arg_map
-                        .get(tp)
-                        .cloned()
-                        .unwrap_or_else(|| Ty::Var(TypeVar::fresh()))
+                    type_arg_map.get(tp).map_or_else(
+                        || Ty::Var(TypeVar::fresh()),
+                        |bound| self.subst.resolve(bound),
+                    )
                 })
                 .collect();
             // Record the resolved type arguments for downstream monomorphisation

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -78,6 +78,13 @@ pub(super) enum RecordCloneAdmissibility {
     OpaqueField { opaque_name: String },
     /// The record has un-substituted generic type parameters; not yet supported.
     GenericRecord,
+    /// The receiver is a bare type parameter (`x: T`) carrying a `Clone` bound
+    /// (`fn f<T: Clone>(x: T)`). The clone is admitted and deferred to
+    /// monomorphization: MIR re-lowers the body per concrete instantiation,
+    /// `subst_ty(T)` resolves the concrete leaf, and the per-value-class clone
+    /// dispatch (`lower.rs` `RecordCloneCall`) emits the matching copy path.
+    /// No bare-name thunk is seeded — `T` names no monomorphic layout.
+    AbstractParamClone,
     /// The named type is not a clone-eligible record kind (actor, machine, enum).
     NotARecord,
 }
@@ -2482,6 +2489,22 @@ impl Checker {
                         );
                         return Ty::Error;
                     }
+                    RecordCloneAdmissibility::AbstractParamClone => {
+                        // Bare type param `x: T` with `T: Clone`. Record the
+                        // clone rewrite but DO NOT seed `user_clone_record_seeds`
+                        // — `T` names no monomorphic record layout; codegen
+                        // would synthesise a dead `__hew_record_clone_inplace_T`.
+                        // The concrete copy path is selected per-mono in MIR
+                        // (`subst_ty(T)` → value-class dispatch).
+                        let param_ty = receiver_ty.clone();
+                        self.record_method_call_rewrite(
+                            span,
+                            MethodCallRewrite::RecordCloneInplace {
+                                record_name: name.clone(),
+                            },
+                        );
+                        return param_ty;
+                    }
                     RecordCloneAdmissibility::NotARecord => {
                         // Fall through to `UndefinedMethod` below for non-record Named types
                         // (actors, machines, enums, etc.).
@@ -2614,6 +2637,18 @@ impl Checker {
     ) -> RecordCloneAdmissibility {
         use TypeDefKind::{Record, Struct};
         let Some(type_def) = self.type_defs.get(name) else {
+            // A bare type parameter (`x: T`) has no `type_defs` entry. When it
+            // carries a `Clone` bound in scope (`fn f<T: Clone>(x: T)`), admit
+            // the clone and defer the concrete copy path to monomorphization
+            // (`AbstractParamClone`). This is the abstract-`T: Clone` spine
+            // (mirrors `type_param_has_marker_bound` as used by abstract-key
+            // HashMap dispatch). Without the bound, fall through to `NotARecord`
+            // → `UndefinedMethod` (fail closed — `admit-only-what-you-lower`).
+            if self.is_type_param_in_scope(name)
+                && self.type_param_has_marker_bound(name, MarkerTrait::Clone)
+            {
+                return RecordCloneAdmissibility::AbstractParamClone;
+            }
             return RecordCloneAdmissibility::NotARecord;
         };
         // Only Record and Struct (value-type) kinds are clone-eligible.
@@ -7967,6 +8002,18 @@ impl Checker {
                                     ),
                                 );
                                 return Ty::Error;
+                            }
+                            RecordCloneAdmissibility::AbstractParamClone => {
+                                // Bare type param `x: T` with `T: Clone`; defer
+                                // the concrete copy path to monomorphization. No
+                                // seed: `T` names no monomorphic record layout.
+                                self.record_method_call_rewrite(
+                                    span,
+                                    MethodCallRewrite::RecordCloneInplace {
+                                        record_name: name.clone(),
+                                    },
+                                );
+                                return resolved;
                             }
                             RecordCloneAdmissibility::NotARecord => {
                                 // Fall through to UndefinedMethod below.

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -85,7 +85,12 @@ pub(super) enum RecordCloneAdmissibility {
     /// dispatch (`lower.rs` `RecordCloneCall`) emits the matching copy path.
     /// No bare-name thunk is seeded — `T` names no monomorphic layout.
     AbstractParamClone,
-    /// The named type is not a clone-eligible record kind (actor, machine, enum).
+    /// The receiver is a user enum, clone-eligible via the enum twin of the
+    /// record thunk (`__hew_enum_clone_inplace_<E>`). `enum_name` is the bare
+    /// declared name; MIR keys the synthesised helper by the monomorphised
+    /// tagged-union layout (`Maybe$$i64` for a generic instantiation).
+    EnumClone { enum_name: String },
+    /// The named type is not a clone-eligible record kind (actor, machine).
     NotARecord,
 }
 
@@ -2472,7 +2477,7 @@ impl Checker {
                             TypeErrorKind::UndefinedMethod,
                             span,
                             format!(
-                                "record `{name}` contains an opaque field `{opaque_name}` \
+                                "type `{name}` contains an opaque field `{opaque_name}` \
                                  and cannot be cloned"
                             ),
                         );
@@ -2505,9 +2510,29 @@ impl Checker {
                         );
                         return param_ty;
                     }
+                    RecordCloneAdmissibility::EnumClone { enum_name } => {
+                        // A user enum routes through the SAME rewrite + HIR node
+                        // as a record clone; MIR demuxes record-vs-enum by the
+                        // resolved monomorphised layout (`enum_clone_layout_key`)
+                        // and emits `EnumCloneInplace`, lowered to
+                        // `__hew_enum_clone_inplace_<E>`. No bare-name seed: the
+                        // enum clone-site is seeded from the `EnumCloneInplace`
+                        // walk in codegen (`collect_enum_clone_inplace_seeds`),
+                        // keyed by the monomorphised layout, so a generic
+                        // instantiation never registers a dead bare key.
+                        let enum_ty = receiver_ty.clone();
+                        self.record_method_call_rewrite(
+                            span,
+                            MethodCallRewrite::RecordCloneInplace {
+                                record_name: enum_name,
+                            },
+                        );
+                        return enum_ty;
+                    }
                     RecordCloneAdmissibility::NotARecord => {
-                        // Fall through to `UndefinedMethod` below for non-record Named types
-                        // (actors, machines, enums, etc.).
+                        // Fall through to `UndefinedMethod` below for non-record
+                        // Named types (actors, machines, etc.); enums are
+                        // handled by the `EnumClone` arm above.
                     }
                 }
             }
@@ -2616,7 +2641,7 @@ impl Checker {
     }
 
     /// Decide whether a user-defined `Ty::Named` record type is admissible for
-    /// `clone`. Returns one of four outcomes:
+    /// `clone`. Returns one of the following outcomes:
     ///
     /// - `Admissible`: the record can be cloned end-to-end via the synthesised
     ///   `__hew_record_clone_inplace_<R>` thunk.
@@ -2624,8 +2649,10 @@ impl Checker {
     ///   field) contains an opaque handle — fail closed with a named diagnostic.
     /// - `GenericRecord`: the record has un-substituted generic type parameters
     ///   — not yet supported; fail closed with an NYI diagnostic.
-    /// - `NotARecord`: not a clone-eligible named type (actor, machine, enum,
-    ///   etc.) — fall through to `UndefinedMethod`.
+    /// - `EnumClone { enum_name }`: the receiver is a user enum — clone via the
+    ///   enum twin `__hew_enum_clone_inplace_<E>` (tag-dispatched payload clone).
+    /// - `NotARecord`: not a clone-eligible named type (actor, machine, etc.) —
+    ///   fall through to `UndefinedMethod`.
     ///
     /// LESSONS: `checker-authority` (sole authority for clone admissibility),
     /// `unclonable-leaf-fails-closed-transitively`, `admit-only-what-you-lower`.
@@ -2635,7 +2662,7 @@ impl Checker {
         type_args: &[Ty],
         _span: &Span,
     ) -> RecordCloneAdmissibility {
-        use TypeDefKind::{Record, Struct};
+        use TypeDefKind::{Enum, Record, Struct};
         let Some(type_def) = self.type_defs.get(name) else {
             // A bare type parameter (`x: T`) has no `type_defs` entry. When it
             // carries a `Clone` bound in scope (`fn f<T: Clone>(x: T)`), admit
@@ -2651,6 +2678,33 @@ impl Checker {
             }
             return RecordCloneAdmissibility::NotARecord;
         };
+        // An enum is clone-eligible via the enum twin of the record thunk. It is
+        // checked BEFORE the Record/Struct gate because the two paths diverge:
+        // an enum's owned leaves live in variant payloads, not declared fields.
+        if matches!(type_def.kind, Enum) {
+            // A generic enum with still-unresolved type params (`Maybe<_>`) is
+            // not yet monomorphisable here — fail closed (NYI). A concrete
+            // instantiation (`Maybe<i64>`, args = [i64]) carries no `Ty::Var`
+            // and proceeds, exactly as the record arm below.
+            if !type_def.type_params.is_empty() && type_args.iter().any(|a| matches!(a, Ty::Var(_)))
+            {
+                return RecordCloneAdmissibility::GenericRecord;
+            }
+            // Fail closed on a transitively-reachable opaque payload — an
+            // unclonable leaf inside an enum variant must reject the whole
+            // clone, never silently shallow-copy a handle
+            // (`unclonable-leaf-fails-closed-transitively`).
+            if let Some(opaque_name) = self.enum_variant_contains_opaque(
+                name,
+                type_args,
+                &mut std::collections::HashSet::new(),
+            ) {
+                return RecordCloneAdmissibility::OpaqueField { opaque_name };
+            }
+            return RecordCloneAdmissibility::EnumClone {
+                enum_name: name.to_string(),
+            };
+        }
         // Only Record and Struct (value-type) kinds are clone-eligible.
         if !matches!(type_def.kind, Record | Struct) {
             return RecordCloneAdmissibility::NotARecord;
@@ -2711,6 +2765,50 @@ impl Checker {
         found
     }
 
+    /// Transitive, substitution-aware walk of a (possibly generic) enum's
+    /// variant payloads looking for an opaque-handle leaf — the enum twin of
+    /// [`Self::record_field_contains_opaque`]. Each variant payload type
+    /// (`Tuple` positional, `Struct` named) is instantiated with the concrete
+    /// clone-site `type_args` before recursing, so `Maybe<Handle>` resolves its
+    /// `Some(T)` payload to `Some(Handle)` and the opaque leaf is detected. A
+    /// monomorphic enum passes `type_args = []` (a no-op substitution). Returns
+    /// the first opaque payload-type name found, or `None` if clean. Shares the
+    /// `ty_field_contains_opaque` leaf classifier with the record walk, so the
+    /// two stay in lockstep.
+    fn enum_variant_contains_opaque(
+        &self,
+        name: &str,
+        type_args: &[Ty],
+        visiting: &mut std::collections::HashSet<String>,
+    ) -> Option<String> {
+        if !visiting.insert(name.to_string()) {
+            return None; // cycle protection
+        }
+        let mut found = None;
+        if let Some(type_def) = self.type_defs.get(name) {
+            'variants: for variant in type_def.variants.values() {
+                let payload_tys: Vec<Ty> = match variant {
+                    VariantDef::Unit => Vec::new(),
+                    VariantDef::Tuple(tys) => tys.clone(),
+                    VariantDef::Struct(fields) => fields.iter().map(|(_, ty)| ty.clone()).collect(),
+                };
+                for payload_ty in &payload_tys {
+                    let payload_ty = Self::instantiate_type_def_member(
+                        payload_ty,
+                        &type_def.type_params,
+                        type_args,
+                    );
+                    if let Some(opaque) = self.ty_field_contains_opaque(&payload_ty, visiting) {
+                        found = Some(opaque);
+                        break 'variants;
+                    }
+                }
+            }
+        }
+        visiting.remove(name);
+        found
+    }
+
     fn ty_field_contains_opaque(
         &self,
         ty: &Ty,
@@ -2737,6 +2835,15 @@ impl Checker {
                 // Recurse into the type def's fields, substituting the def's
                 // params with the concrete `args` at this use site.
                 if let Some(n) = self.record_field_contains_opaque(name, args, visiting) {
+                    return Some(n);
+                }
+                // Recurse into enum variant payloads too — a nested enum with a
+                // hard-coded opaque payload (`enum Inner { B(Handle) }`) is
+                // reachable from neither the type-arg walk nor the record-field
+                // walk, so without this an outer clone would admit an
+                // unclonable leaf. (`record_field_contains_opaque` is a no-op
+                // for an enum, and vice-versa, so both calls are kind-safe.)
+                if let Some(n) = self.enum_variant_contains_opaque(name, args, visiting) {
                     return Some(n);
                 }
                 None
@@ -7986,7 +8093,7 @@ impl Checker {
                                     TypeErrorKind::UndefinedMethod,
                                     span,
                                     format!(
-                                        "record `{name}` contains an opaque field \
+                                        "type `{name}` contains an opaque field \
                                          `{opaque_name}` and cannot be cloned"
                                     ),
                                 );
@@ -8011,6 +8118,20 @@ impl Checker {
                                     span,
                                     MethodCallRewrite::RecordCloneInplace {
                                         record_name: name.clone(),
+                                    },
+                                );
+                                return resolved;
+                            }
+                            RecordCloneAdmissibility::EnumClone { enum_name } => {
+                                // User enum: same rewrite + HIR node as a record
+                                // clone; MIR demuxes by the resolved layout and
+                                // emits `EnumCloneInplace`. No bare-name seed —
+                                // codegen's `collect_enum_clone_inplace_seeds`
+                                // keys the per-mono helper.
+                                self.record_method_call_rewrite(
+                                    span,
+                                    MethodCallRewrite::RecordCloneInplace {
+                                        record_name: enum_name,
                                     },
                                 );
                                 return resolved;

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -4170,7 +4170,14 @@ impl Checker {
                 }
                 if matches!(
                     method,
-                    "insert" | "get" | "remove" | "contains_key" | "len" | "keys" | "values"
+                    "insert"
+                        | "get"
+                        | "remove"
+                        | "contains_key"
+                        | "len"
+                        | "keys"
+                        | "values"
+                        | "clone"
                 ) {
                     self.record_resolved_hashmap_call(method, &cx.key, &cx.val, span);
                 }
@@ -4189,7 +4196,7 @@ impl Checker {
                 self.record_hashset_lowering_fact(span, &cx.elem);
                 if matches!(
                     method,
-                    "insert" | "contains" | "remove" | "len" | "is_empty"
+                    "insert" | "contains" | "remove" | "len" | "is_empty" | "clone"
                 ) {
                     self.record_resolved_hashset_call(method, &cx.elem, span);
                 }
@@ -8486,6 +8493,16 @@ fn collection_dispatch_registry_impl() -> ImplRegistry {
                     consumes_receiver: false,
                 },
             ),
+            (
+                "clone".to_string(),
+                MethodTarget {
+                    symbol_name: "hew_hashmap_clone_layout".to_string(),
+                    family: MethodTargetFamily::HashMap(HashMapMethod::Clone),
+                    abi: RuntimeAbi::ByRef,
+                    call_hint: CallAbiHint::RuntimeShim,
+                    consumes_receiver: false,
+                },
+            ),
         ],
     });
     registry.register(ImplDef {
@@ -8550,6 +8567,16 @@ fn collection_dispatch_registry_impl() -> ImplRegistry {
                 MethodTarget {
                     symbol_name: "hew_hashset_is_empty_layout".to_string(),
                     family: MethodTargetFamily::HashSet(HashSetMethod::IsEmpty),
+                    abi: RuntimeAbi::ByRef,
+                    call_hint: CallAbiHint::RuntimeShim,
+                    consumes_receiver: false,
+                },
+            ),
+            (
+                "clone".to_string(),
+                MethodTarget {
+                    symbol_name: "hew_hashset_clone_layout".to_string(),
+                    family: MethodTargetFamily::HashSet(HashSetMethod::Clone),
                     abi: RuntimeAbi::ByRef,
                     call_hint: CallAbiHint::RuntimeShim,
                     consumes_receiver: false,

--- a/hew-types/tests/resolved_call_kernel_symbols.rs
+++ b/hew-types/tests/resolved_call_kernel_symbols.rs
@@ -63,11 +63,13 @@ extern "C" {
     fn hew_hashmap_len_layout(m: *const c_void) -> i64;
     fn hew_hashmap_keys_layout(m: *const c_void) -> *mut c_void;
     fn hew_hashmap_values_layout(m: *const c_void) -> *mut c_void;
+    fn hew_hashmap_clone_layout(m: *const c_void) -> *mut c_void;
     fn hew_hashset_insert_layout(s: *mut c_void, elem: *const c_void) -> bool;
     fn hew_hashset_contains_layout(s: *const c_void, elem: *const c_void) -> bool;
     fn hew_hashset_remove_layout(s: *mut c_void, elem: *const c_void) -> bool;
     fn hew_hashset_len_layout(s: *const c_void) -> i64;
     fn hew_hashset_is_empty_layout(s: *const c_void) -> bool;
+    fn hew_hashset_clone_layout(s: *const c_void) -> *mut c_void;
 }
 
 /// Statically-known set of kernel symbols this gate has *proved linkable*.
@@ -106,6 +108,10 @@ fn known_linked_kernel_symbols() -> HashMap<&'static str, *const ()> {
         hew_hashmap_values_layout as *const (),
     );
     m.insert(
+        "hew_hashmap_clone_layout",
+        hew_hashmap_clone_layout as *const (),
+    );
+    m.insert(
         "hew_hashset_insert_layout",
         hew_hashset_insert_layout as *const (),
     );
@@ -124,6 +130,10 @@ fn known_linked_kernel_symbols() -> HashMap<&'static str, *const ()> {
     m.insert(
         "hew_hashset_is_empty_layout",
         hew_hashset_is_empty_layout as *const (),
+    );
+    m.insert(
+        "hew_hashset_clone_layout",
+        hew_hashset_clone_layout as *const (),
     );
     m
 }
@@ -272,13 +282,14 @@ fn every_stage_b_method_target_symbol_is_link_resolved() {
         checked.len(),
     );
 
-    // Defensive lower-bound: the Stage B registry seeds 7 HashMap methods
-    // (insert, get, contains_key, remove, len, keys, values)
-    // + 5 HashSet methods = 12 symbols. A drift below this means the
-    // registry shrank silently; the gate forces an explicit reckoning.
+    // Defensive lower-bound: the Stage B registry seeds 8 HashMap methods
+    // (insert, get, contains_key, remove, len, keys, values, clone)
+    // + 6 HashSet methods (insert, contains, remove, len, is_empty, clone)
+    // = 14 symbols. A drift below this means the registry shrank silently;
+    // the gate forces an explicit reckoning.
     assert!(
-        checked.len() >= 12,
-        "expected ≥ 11 distinct kernel symbols in the Stage B registry, \
+        checked.len() >= 14,
+        "expected ≥ 14 distinct kernel symbols in the Stage B registry, \
          saw {} ({:?})",
         checked.len(),
         checked,

--- a/scripts/hew-suite-expected-failures.txt
+++ b/scripts/hew-suite-expected-failures.txt
@@ -11,6 +11,5 @@
 #
 # Format: <test_function_name>  # <root_cause>; converging lane: <lane>
 #
-# Total: 2 unique failing test function names.
+# Total: 1 unique failing test function names.
 test_generic_vec_iter_i64  # G5 split follow-on: Hew-level Vec<T>::iter substrate
-test_generic_record_of_vec_clone  # G6 scope-out: generic record with a Vec<T> field hits an orthogonal MIR-boundary gap (E_MIR: unknown type T; no ValueClass for T); converging lane: generic-record-Vec-field follow-on

--- a/scripts/hew-suite-expected-failures.txt
+++ b/scripts/hew-suite-expected-failures.txt
@@ -11,7 +11,6 @@
 #
 # Format: <test_function_name>  # <root_cause>; converging lane: <lane>
 #
-# Total: 3 unique failing test function names.
+# Total: 2 unique failing test function names.
 test_generic_vec_iter_i64  # G5 split follow-on: Hew-level Vec<T>::iter substrate
 test_generic_record_of_vec_clone  # G6 scope-out: generic record with a Vec<T> field hits an orthogonal MIR-boundary gap (E_MIR: unknown type T; no ValueClass for T); converging lane: generic-record-Vec-field follow-on
-test_generic_enum_clone  # G6 scope-out: generic enum clone (clone Maybe<T>) is a separate synthesis path — clone is not yet a method on enums (no method clone on Maybe<i64>); converging lane: generic-enum-clone follow-on

--- a/tests/hew/generic_enum_clone_test.hew
+++ b/tests/hew/generic_enum_clone_test.hew
@@ -1,14 +1,21 @@
-//! FAILABLE (tracked NYI): cloning a generic enum (`clone Maybe<T>`) is a
-//! SEPARATE synthesis path from record/aggregate clone — `clone` is not even a
-//! method on enums today (`no method clone on Maybe<i64>`). Explicitly OUT of
-//! scope for generic record/aggregate clone; registered here so the gap
-//! stays visible. Registered in scripts/hew-suite-expected-failures.txt; the
-//! ratchet flips to an unexpected-pass the instant generic enum clone lands,
-//! forcing this test's promotion to a positive regression guard.
+//! Generic and concrete enum `clone` — regression guard.
+//!
+//! `clone <enum>` deep-clones a tagged-union value through the enum twin of the
+//! record-clone thunk (`__hew_enum_clone_inplace_<E>`), keyed by the
+//! monomorphised layout (`Maybe$$i64` for a generic instantiation). An
+//! owned-heap payload (a `string`) is duplicated into an INDEPENDENT owner, so
+//! the source and the clone can each be dropped without a double-free; an
+//! all-`BitCopy` payload (`i64`) is duplicated by the wholesale memcpy. An enum
+//! whose payload is an unclonable opaque leaf fails closed at the checker
+//! (covered by the vertical-slice reject suite).
+//!
+//! Was a tracked NYI (`no method clone on Maybe<i64>`); promoted to a positive
+//! guard when top-level enum clone landed.
 
 import std::testing;
 
 enum Maybe<T> { Some(T); None }
+enum Shape { Named(string); Tagged(string); Empty }
 
 #[test]
 fn test_generic_enum_clone() {
@@ -19,4 +26,40 @@ fn test_generic_enum_clone() {
         Maybe::None => 0,
     };
     testing.assert_eq(v, 42);
+}
+
+#[test]
+fn test_generic_enum_clone_source_still_live() {
+    // The clone is independent: the source `m` remains usable afterwards.
+    let m = Maybe::Some(7);
+    let n = clone m;
+    let a = match m { Maybe::Some(x) => x, Maybe::None => -1 };
+    let b = match n { Maybe::Some(x) => x, Maybe::None => -1 };
+    testing.assert_eq(a, 7);
+    testing.assert_eq(b, 7);
+}
+
+#[test]
+fn test_generic_enum_clone_owned_string_payload() {
+    // Owned-heap payload: clone retains an INDEPENDENT string buffer. Both the
+    // source and the clone are consumed (each drops its payload); if the clone
+    // aliased the source buffer at rc==1 this would double-free under a strict
+    // allocator.
+    let m = Maybe::Some("a heap allocated generic payload string");
+    let n = clone m;
+    let sa = match m { Maybe::Some(s) => s, Maybe::None => "" };
+    let sb = match n { Maybe::Some(s) => s, Maybe::None => "" };
+    testing.assert_eq_str(sa, "a heap allocated generic payload string");
+    testing.assert_eq_str(sb, "a heap allocated generic payload string");
+}
+
+#[test]
+fn test_concrete_enum_clone_owned_payload() {
+    // Concrete (non-generic) enum with a string payload routes the same path.
+    let a = Shape::Named("first owned payload xxxxxxxxxxxxxxxxxxxx");
+    let b = clone a;
+    let ta = match a { Shape::Named(s) => 1, Shape::Tagged(s) => 2, Shape::Empty => 0 };
+    let tb = match b { Shape::Named(s) => 1, Shape::Tagged(s) => 2, Shape::Empty => 0 };
+    testing.assert_eq(ta, 1);
+    testing.assert_eq(tb, 1);
 }

--- a/tests/hew/generic_param_clone_test.hew
+++ b/tests/hew/generic_param_clone_test.hew
@@ -1,0 +1,65 @@
+//! Behavioural tests for cloning a BARE TYPE PARAMETER inside a generic
+//! function: `fn dup<T: Clone>(x: T) -> T { x.clone() }`.
+//!
+//! Before this lane the body was rejected at check time ("no method clone on
+//! `T`") even though every concrete instantiation has a clone path — the
+//! abstract-`T: Clone` clone gap. The checker now admits the clone through the
+//! `Clone` marker bound (the same `type_param_has_marker_bound` spine the
+//! abstract `K: Hash + Eq` dispatch uses), and MIR dispatches each concrete
+//! monomorphisation by value class: a `BitCopy` scalar duplicates on use; a
+//! `string` is cloned with `hew_string_clone` (a `+1` owner) and dropped with
+//! the symmetric `hew_string_drop`.
+//!
+//! Each test asserts EXACT cloned values; the scalar test mutates the source
+//! after cloning to prove the clone is an independent value, not an alias
+//! (a behavioural-green `exit 0` is non-evidence).
+//!
+//! Instantiation is limited to the value classes a `T: Clone` call site admits
+//! today (scalars and `string`). A record / `Vec` argument is rejected at the
+//! call site by the pre-existing marker-bound satisfaction check (`type … does
+//! not implement trait Clone required by T`), identically to a `T: Send` bound;
+//! that is an orthogonal generic-marker-satisfaction gap, not a clone gap.
+
+import std::testing;
+
+fn dup<T: Clone>(x: T) -> T { x.clone() }
+
+// Scalar `T = i64`: clone is a `BitCopy` duplicate. Mutate the source after
+// cloning and assert the clone keeps its own value (a copy, not an alias).
+#[test]
+fn test_generic_param_clone_scalar_independence() {
+    var n = 10;
+    let c = dup(n);
+    n = 99;
+    testing.assert_eq(c, 10);
+    testing.assert_eq(n, 99);
+}
+
+// Scalar `T = bool`.
+#[test]
+fn test_generic_param_clone_bool() {
+    testing.assert_true(dup(true));
+    testing.assert_false(dup(false));
+}
+
+// `T = string`: clone is a `hew_string_clone` `+1` owner. The source stays
+// live and usable after the clone; both are dropped exactly once (verified
+// drop-balanced — no double-free under the ratchet sanitiser).
+#[test]
+fn test_generic_param_clone_string() {
+    let s = "hello";
+    let t = dup(s);
+    testing.assert_eq_str(t, "hello");
+    testing.assert_eq_str(s, "hello");
+}
+
+// Two distinct instantiations of the same generic clone in one program
+// (`dup$$i64` and `dup$$string`) must monomorphise to distinct dispatch arms
+// with no symbol collision.
+#[test]
+fn test_generic_param_clone_multi_instantiation() {
+    let a = dup(7);
+    let b = dup("world");
+    testing.assert_eq(a, 7);
+    testing.assert_eq_str(b, "world");
+}

--- a/tests/hew/generic_param_clone_test.hew
+++ b/tests/hew/generic_param_clone_test.hew
@@ -1,7 +1,7 @@
 //! Behavioural tests for cloning a BARE TYPE PARAMETER inside a generic
 //! function: `fn dup<T: Clone>(x: T) -> T { x.clone() }`.
 //!
-//! Before this lane the body was rejected at check time ("no method clone on
+//! Previously the body was rejected at check time ("no method clone on
 //! `T`") even though every concrete instantiation has a clone path — the
 //! abstract-`T: Clone` clone gap. The checker now admits the clone through the
 //! `Clone` marker bound (the same `type_param_has_marker_bound` spine the

--- a/tests/hew/generic_record_of_vec_clone_test.hew
+++ b/tests/hew/generic_record_of_vec_clone_test.hew
@@ -1,11 +1,16 @@
-//! FAILABLE (tracked NYI): cloning a generic record whose field is `Vec<T>` is
-//! blocked by an ORTHOGONAL, pre-existing gap — the element type `T` has no
-//! known ValueClass at the MIR boundary (`E_MIR: unknown type T`). This is
-//! independent of the per-mono clone/drop synthesis for generic records (a generic
-//! record with scalar / string / nested-record fields clones correctly); it is
-//! the generic-record `Vec<T>`-field surface, tracked as a follow-on. Registered
-//! in scripts/hew-suite-expected-failures.txt; the ratchet flips to an
-//! unexpected-pass the instant the MIR-boundary gap is closed.
+//! Cloning a generic record whose field is `Vec<T>` — regression guard.
+//!
+//! `Bag { items: Vec::new() }` constructs a generic record whose `items` field
+//! type (`Vec<T>`) CONTAINS the type parameter without being the bare parameter.
+//! Inference now seeds that parameter from the field initializer, so the
+//! construction monomorphises to `Bag<i64>` (previously the initializer kept the
+//! raw `Vec<T>` and tripped `E_MIR: unknown type T` at the MIR boundary). The
+//! deep clone of the monomorphised record duplicates the `Vec` field into an
+//! INDEPENDENT buffer: mutating the source after the clone leaves the clone
+//! untouched, and both owners drop their buffer without a double-free.
+//!
+//! Was a tracked NYI; promoted to a positive guard when generic record-literal
+//! inference for contained type parameters landed.
 
 import std::testing;
 
@@ -15,6 +20,25 @@ type Bag<T> { items: Vec<T>; }
 fn test_generic_record_of_vec_clone() {
     let b = Bag { items: Vec::new() };
     b.items.push(7);
+    b.items.push(8);
     let c = clone b;
-    testing.assert_eq(c.items.len(), 1);
+    // Mutate the source AFTER cloning: a shallow (aliased) clone would observe
+    // this push. The clone must keep its own two-element buffer.
+    b.items.push(9);
+    testing.assert_eq(c.items.len(), 2);
+    testing.assert_eq(b.items.len(), 3);
 }
+
+#[test]
+fn test_generic_record_of_vec_clone_owned_payload() {
+    // Owned-heap element type (`string`): the clone retains INDEPENDENT element
+    // buffers. Both the source and the clone drop their strings at scope exit;
+    // an aliased buffer would double-free under a strict allocator.
+    let b = Bag { items: Vec::new() };
+    b.items.push("a heap allocated payload string xxxxxxxx");
+    let c = clone b;
+    b.items.push("second element yyyyyyyyyyyyyyyyyyyy");
+    testing.assert_eq(c.items.len(), 1);
+    testing.assert_eq(b.items.len(), 2);
+}
+

--- a/tests/hew/hashmap_clone_test.hew
+++ b/tests/hew/hashmap_clone_test.hew
@@ -1,0 +1,97 @@
+//! `HashMap.clone()` / `HashSet.clone()` — regression guard.
+//!
+//! The method surface resolves to the runtime deep-clone (`hew_hashmap_clone_layout`
+//! / `hew_hashset_clone_layout`), which duplicates every owned key/value blob via
+//! the descriptor clone discipline and yields an INDEPENDENT collection. The
+//! result is owned by the binding and freed exactly once at scope exit through
+//! the type-driven free pair (`HASHMAP_FREE_LAYOUT_SYMBOL` /
+//! `HASHSET_FREE_LAYOUT_SYMBOL`) — the same clone+free pair already used for a
+//! collection field nested inside a record/enum clone, so the deep copy and its
+//! drop are proven in all three drop contexts (sync return, actor shutdown,
+//! coroutine suspend).
+//!
+//! Key/value admission is shared with `insert`/`get`: a layout-managed key or a
+//! value with no map-value clone thunk fails closed at the checker (covered by
+//! the vertical-slice reject suite), so the runtime's fail-closed abort paths
+//! are unreachable from admitted programs.
+//!
+//! Independence is proven by mutating the SOURCE after the clone and asserting
+//! the clone is unaffected — a shallow alias would observe the mutation.
+
+import std::testing;
+
+record Point { x: i64, y: i64 }
+
+#[test]
+fn test_hashmap_clone_scalar_value_independent() {
+    let m: HashMap<string, i64> = HashMap::new();
+    m.insert("a", 1);
+    m.insert("b", 2);
+    let c: HashMap<string, i64> = m.clone();
+    m.insert("c", 3);
+    testing.assert_eq(m.len(), 3);
+    testing.assert_eq(c.len(), 2);
+    match c.get("a") {
+        Some(v) => testing.assert_eq(v, 1),
+        None => testing.assert_true(false),
+    }
+    match c.get("c") {
+        Some(_) => testing.assert_true(false),
+        None => testing.assert_true(true),
+    }
+}
+
+#[test]
+fn test_hashmap_clone_string_value_deep() {
+    let m: HashMap<string, string> = HashMap::new();
+    m.insert("alpha", "one");
+    m.insert("beta", "two");
+    let c: HashMap<string, string> = m.clone();
+    m.insert("gamma", "three");
+    testing.assert_eq(m.len(), 3);
+    testing.assert_eq(c.len(), 2);
+    match c.get("alpha") {
+        Some(v) => testing.assert_eq_str(v, "one"),
+        None => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn test_hashmap_clone_nested_owned_value() {
+    let inner: Vec<string> = Vec::new();
+    inner.push("x");
+    inner.push("y");
+    let m: HashMap<string, Vec<string>> = HashMap::new();
+    m.insert("k", inner);
+    let c: HashMap<string, Vec<string>> = m.clone();
+    testing.assert_eq(c.len(), 1);
+    match c.get("k") {
+        Some(v) => testing.assert_eq(v.len(), 2),
+        None => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn test_hashmap_clone_copy_record_key() {
+    let m: HashMap<Point, string> = HashMap::new();
+    m.insert(Point { x: 1, y: 2 }, "a");
+    let c: HashMap<Point, string> = m.clone();
+    testing.assert_eq(c.len(), 1);
+    match c.get(Point { x: 1, y: 2 }) {
+        Some(v) => testing.assert_eq_str(v, "a"),
+        None => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn test_hashset_clone_independent() {
+    let s: HashSet<string> = HashSet::new();
+    s.insert("x");
+    s.insert("y");
+    let c: HashSet<string> = s.clone();
+    s.insert("z");
+    testing.assert_eq(s.len(), 3);
+    testing.assert_eq(c.len(), 2);
+    testing.assert_true(c.contains("x"));
+    testing.assert_true(!c.contains("z"));
+}

--- a/tests/vertical-slice/reject/enum_clone_unclonable_payload.hew
+++ b/tests/vertical-slice/reject/enum_clone_unclonable_payload.hew
@@ -1,0 +1,34 @@
+// Reject fixture: enum_clone_unclonable_payload — an enum whose variant
+// payload is an `#[opaque]` runtime handle must fail closed when cloned.
+//
+// The enum twin of record_clone_unclonable_field. Opaque handles are
+// pointer-width values managed by the runtime; a shallow copy would alias the
+// original handle so both the source and the clone point at the same runtime
+// resource, and freeing one dangles the other. The checker's admissibility
+// walk recurses into enum variant payloads, so `clone` on any enum whose
+// variants (or their transitive payloads) include an opaque handle is refused
+// (`unclonable-leaf-fails-closed-transitively`).
+//
+// Harness verb: hew check
+// Expected: rejected with an error mentioning the opaque payload type name
+// ("contains an opaque field").
+
+#[opaque]
+type Handle {}
+
+extern "C" {
+    fn hew_handle_create() -> Handle;
+    fn hew_handle_free(h: Handle);
+}
+
+enum Resource {
+    Live(Handle);
+    Dead
+}
+
+fn main() -> i64 {
+    let r = Resource::Live(unsafe { hew_handle_create() });
+    let _ = clone r;
+    unsafe { hew_handle_free(hew_handle_create()) };
+    0
+}

--- a/tests/vertical-slice/reject/hashmap_clone_unclonable_opaque_value.hew
+++ b/tests/vertical-slice/reject/hashmap_clone_unclonable_opaque_value.hew
@@ -1,0 +1,26 @@
+// Reject fixture: HashMap.clone() must fail closed when V contains no clone_fn.
+//
+// `m.clone()` deep-clones every value blob through the descriptor clone
+// discipline. A value containing an `#[opaque]` runtime handle has no map-value
+// clone thunk, so admitting the clone would require a shallow pointer copy that
+// would later double-free. The checker rejects it at the same admission seam
+// that guards `HashMap::get` / `insert`.
+
+#[opaque]
+type Handle {}
+
+record WrappedHandle {
+    h: Handle,
+}
+
+extern "C" {
+    fn hew_handle_create() -> Handle;
+}
+
+fn main() -> i64 {
+    let m: HashMap<string, WrappedHandle> = HashMap::new();
+    let h = unsafe { hew_handle_create() };
+    m.insert("h", WrappedHandle { h: h });
+    let _c = m.clone();
+    0
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -2485,6 +2485,13 @@ expect_check_fail_contains \
   "no map value clone_fn" \
   "hashmap_get_unclonable_opaque_value"
 
+# `m.clone()` deep-clones every value blob, so a value with no map value
+# clone_fn must fail closed at the same admission seam as `get`.
+expect_check_fail_contains \
+  "${ROOT}/tests/vertical-slice/reject/hashmap_clone_unclonable_opaque_value.hew" \
+  "no map value clone_fn" \
+  "hashmap_clone_unclonable_opaque_value"
+
 # ---------------------------------------------------------------------------
 # NEW-6b — `await … | after d` deadlines on suspendable actor asks
 # ---------------------------------------------------------------------------

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -2991,6 +2991,17 @@ if "${HEW}" check \
 fi
 grep -q 'contains an opaque field' "${reject_output}"
 
+# Enum twin: `clone <enum>` on an enum whose variant payload is an opaque handle
+# must be rejected too — the admissibility opaque walk recurses into enum
+# variant payloads (`unclonable-leaf-fails-closed-transitively`).
+if "${HEW}" check \
+    "${ROOT}/tests/vertical-slice/reject/enum_clone_unclonable_payload.hew" \
+    >"${reject_output}" 2>&1; then
+  echo "expected enum_clone_unclonable_payload fixture to fail" >&2
+  exit 1
+fi
+grep -q 'contains an opaque field' "${reject_output}"
+
 # ---------------------------------------------------------------------------
 # let-destructure: record/struct product-type irrefutable patterns
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Clone now works across the four new generic shapes. A `Clone`-bound type parameter
propagates through monomorphisation so that `clone_item<T: Clone>(x: T) -> T`
produces a deep copy at every instantiation site. Generic enum clone gains a new
in-place enum-clone MIR op (`EnumCloneInplace`) that selects and copies the correct
variant without intermediate heap allocation. Record fields of type `Vec<T>` clone
element-by-element, producing an independent copy of the backing storage. HashMap
and HashSet deep-copy clone duplicate both keys and values, leaving the original and
the copy with no shared backing.

Types whose payloads are not clonable (opaque handles, non-`Clone` enum variants,
non-`Clone` map values) fail closed: the checker rejects the clone call with a
diagnostic rather than emitting a partial or silent no-op copy.

## Verification

- `cargo nextest run` (3371 tests): pass
- Clone fixture suite (15/15 fixtures): pass
- `funcupdate` coexistence suite (6/6 + 47/47): pass
- Guard-Malloc clone→mutate→drop-both across every new clone path: clean
- Reject fixtures for unclonable enum payloads and map values: pass
- Preflight: ready-to-push

## Out of scope

- Sandbox-VM lowering of `EnumCloneInplace` (#2050 tracks this)
- The broader generic-marker argument-satisfaction gap, which is orthogonal to clone
  and will be addressed separately
