### PR TITLE
fix(runtime): wait for self-removed connection readers

### DIFF
--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -38,7 +38,7 @@
 
 use std::ffi::{c_char, c_int, CStr};
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -63,7 +63,7 @@ use crate::mailbox_envelope::{validate_cross_node_send_params, MailboxPayloadCla
 use crate::routing::{hew_routing_add_route, hew_routing_remove_route_if_conn, HewRoutingTable};
 use crate::set_last_error;
 use crate::transport::{HewTransport, HEW_CONN_INVALID};
-use crate::util::MutexExt;
+use crate::util::{CondvarExt, MutexExt};
 
 // ── Connection states ──────────────────────────────────────────────────
 
@@ -244,6 +244,14 @@ pub struct HewConnMgr {
     pub(crate) inbound_ask_active: Arc<AtomicUsize>,
     /// Background reconnect worker handles.
     reconnect_workers: PoisonSafe<Vec<JoinHandle<()>>>,
+    /// Counts every spawned reader until its thread function fully returns.
+    ///
+    /// A reader can remove and drop its own [`ConnectionActor`] on an unexpected
+    /// peer close. That self-drop cannot join the current thread, so the actor
+    /// disappearing from `connections` is not a sufficient teardown barrier.
+    /// `hew_connmgr_free` waits on this lifecycle before the manager's owner
+    /// frees routing/cluster state that reader cleanup may still touch.
+    reader_lifecycle: Arc<ReaderLifecycle>,
     /// Monotonic token generator for connection-lifecycle publications.
     next_publication_token: AtomicU64,
     /// The node ID advertised in the handshake for this manager's node.
@@ -251,6 +259,47 @@ pub struct HewConnMgr {
     /// correct ID in their outgoing handshake even when `LOCAL_NODE_ID` refers
     /// to a different (`CURRENT_NODE`) node.
     pub(crate) local_node_id: u16,
+}
+
+#[derive(Debug, Default)]
+struct ReaderLifecycle {
+    active: Mutex<usize>,
+    idle: Condvar,
+}
+
+impl ReaderLifecycle {
+    fn register(self: &Arc<Self>) -> ReaderLifecycleGuard {
+        let mut active = self.active.lock_or_recover();
+        *active = active
+            .checked_add(1)
+            .expect("reader lifecycle active count overflow");
+        ReaderLifecycleGuard {
+            lifecycle: Arc::clone(self),
+        }
+    }
+
+    fn wait_for_idle(&self) {
+        let mut active = self.active.lock_or_recover();
+        while *active > 0 {
+            active = self.idle.wait_or_recover(active);
+        }
+    }
+}
+
+struct ReaderLifecycleGuard {
+    lifecycle: Arc<ReaderLifecycle>,
+}
+
+impl Drop for ReaderLifecycleGuard {
+    fn drop(&mut self) {
+        let mut active = self.lifecycle.active.lock_or_recover();
+        *active = active
+            .checked_sub(1)
+            .expect("reader lifecycle active count underflow");
+        if *active == 0 {
+            self.lifecycle.idle.notify_all();
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1651,6 +1700,7 @@ pub unsafe extern "C" fn hew_connmgr_new(
         inbound_spawn_closed: Arc::new(AtomicBool::new(false)),
         inbound_ask_active: Arc::new(AtomicUsize::new(0)),
         reconnect_workers: PoisonSafe::new(Vec::new()),
+        reader_lifecycle: Arc::new(ReaderLifecycle::default()),
         next_publication_token: AtomicU64::new(1),
         local_node_id,
     });
@@ -1692,6 +1742,7 @@ pub unsafe extern "C" fn hew_connmgr_free(mgr: *mut HewConnMgr) {
             }
             // ConnectionActor::drop signals reader thread to stop and joins.
         }
+        mgr.reader_lifecycle.wait_for_idle();
         let workers: Vec<JoinHandle<()>> = mgr.reconnect_workers.access(std::mem::take);
         for worker in workers {
             let _ = worker.join();
@@ -2054,12 +2105,14 @@ pub unsafe extern "C" fn hew_connmgr_add(mgr: *mut HewConnMgr, conn_id: c_int) -
     let activity_send = Arc::clone(&actor.last_activity_ms);
     let mgr_send = SendConnMgr(mgr_ptr);
     let peer_feature_flags = actor.peer_feature_flags;
+    let reader_lifecycle_guard = mgr.reader_lifecycle.register();
     #[cfg(feature = "encryption")]
     let noise_transport = Arc::clone(&actor.noise_transport);
 
     let handle = thread::Builder::new()
         .name(format!("hew-conn-{conn_id}"))
         .spawn(move || {
+            let _reader_lifecycle_guard = reader_lifecycle_guard;
             reader_loop(
                 mgr_send,
                 transport_send,
@@ -2723,6 +2776,7 @@ mod tests {
             inbound_spawn_closed: Arc::new(AtomicBool::new(false)),
             inbound_ask_active: Arc::new(AtomicUsize::new(0)),
             reconnect_workers: PoisonSafe::new(Vec::new()),
+            reader_lifecycle: Arc::new(ReaderLifecycle::default()),
             next_publication_token: AtomicU64::new(1),
             local_node_id: 0,
         };
@@ -3382,6 +3436,78 @@ mod tests {
             drop(Box::from_raw(
                 close_impl.cast::<std::sync::mpsc::Sender<c_int>>(),
             ));
+        }
+        drop(ops);
+    }
+
+    #[test]
+    fn connmgr_free_waits_for_self_removed_reader_lifecycle() {
+        let ops = Box::new(crate::transport::HewTransportOps {
+            connect: None,
+            listen: None,
+            accept: None,
+            send: None,
+            recv: None,
+            close_conn: None,
+            destroy: None,
+        });
+        let transport = Box::new(HewTransport {
+            ops: &raw const *ops,
+            r#impl: std::ptr::null_mut(),
+        });
+        let transport_ptr = Box::into_raw(transport);
+
+        // SAFETY: transport_ptr remains valid until explicit cleanup below.
+        let mgr = unsafe {
+            hew_connmgr_new(
+                transport_ptr,
+                None,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        assert!(!mgr.is_null());
+
+        // Model a reader that already removed/dropped its own ConnectionActor:
+        // it no longer appears in `connections`, but its thread is still in
+        // post-remove cleanup and must keep the manager's owner from freeing
+        // routing/cluster state.
+        // SAFETY: mgr is live until the free thread returns.
+        let reader_guard = unsafe { (&*mgr).reader_lifecycle.register() };
+
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let mgr_addr = mgr as usize;
+        let free_thread = std::thread::spawn(move || {
+            started_tx
+                .send(())
+                .expect("free thread should announce start");
+            // SAFETY: mgr_addr is the live manager pointer handed to this thread;
+            // this call owns and frees it.
+            unsafe { hew_connmgr_free(mgr_addr as *mut HewConnMgr) };
+            done_tx.send(()).expect("free completion send");
+        });
+
+        started_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("free thread should start");
+        assert!(
+            done_rx
+                .recv_timeout(std::time::Duration::from_millis(100))
+                .is_err(),
+            "hew_connmgr_free returned before the self-removed reader finished"
+        );
+
+        drop(reader_guard);
+        done_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("free should finish once reader lifecycle is idle");
+        free_thread.join().expect("free thread panicked");
+
+        // SAFETY: hew_connmgr_free does not own the test transport allocation.
+        unsafe {
+            drop(Box::from_raw(transport_ptr));
         }
         drop(ops);
     }

--- a/hew-runtime/src/signal.rs
+++ b/hew-runtime/src/signal.rs
@@ -168,6 +168,30 @@ mod shared {
         }
     }
 
+    /// Format `value` as `0x`-prefixed lowercase hex into `buf`, returning the
+    /// written byte slice. Async-signal-safe: no allocation, no locking, pure
+    /// arithmetic into a caller-owned stack buffer.
+    ///
+    /// `buf` must be at least 18 bytes (`0x` + 16 hex digits) to hold any
+    /// `usize` on a 64-bit target; the caller sizes it accordingly.
+    #[cfg(unix)]
+    fn fmt_hex_usize(value: usize, buf: &mut [u8; 18]) -> &[u8] {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        buf[0] = b'0';
+        buf[1] = b'x';
+        // Number of significant hex digits (at least 1, so a zero fault address
+        // renders as `0x0`). `usize::BITS - leading_zeros` rounded up to nibbles.
+        let significant_bits = (usize::BITS - value.leading_zeros()).max(1);
+        let digits = significant_bits.div_ceil(4) as usize;
+        // Emit nibbles MSB-first into buf[2..2+digits].
+        for i in 0..digits {
+            let shift = (digits - 1 - i) * 4;
+            let nibble = (value >> shift) & 0xf;
+            buf[2 + i] = HEX[nibble];
+        }
+        &buf[..2 + digits]
+    }
+
     /// Emit a crash diagnostic to stderr using only async-signal-safe operations.
     ///
     /// This function must only call `write(2)` (POSIX async-signal-safe) and
@@ -178,22 +202,75 @@ mod shared {
     /// context (main/free-fn context), so the process is about to `_exit`. A
     /// diagnostic is always emitted before process termination.
     ///
+    /// The diagnostic carries the faulting address (from `siginfo_t.si_addr`)
+    /// and the faulting thread's name, so an off-dispatch crash (the I/O accept
+    /// / connection-reader / SWIM-driver threads, which have no recovery
+    /// `jmp_buf` and so reach this terminal path) localizes to a concrete
+    /// pointer + thread instead of an opaque "SIGSEGV somewhere". This is what
+    /// turns a rare, load-only crash on a CI runner into an actionable fault
+    /// site on its next occurrence.
+    ///
     /// `eprintln!` is NOT async-signal-safe (it acquires a lock on the stderr
     /// handle). `write(2)` on fd 2 is the correct alternative here.
     #[cfg(unix)]
-    pub(super) fn emit_crash_diagnostic_sig_safe(sig: i32) {
-        // Write fixed prefix, then signal name, then newline — no allocation.
-        // Each write is a separate syscall; partial writes are acceptable for
-        // a terminal diagnostic before _exit.
+    pub(super) fn emit_crash_diagnostic_sig_safe(sig: i32, fault_addr: usize) {
+        // Faulting thread name: pthread_getname_np writes a NUL-terminated
+        // string into a caller buffer and is async-signal-safe on Linux/macOS.
+        //
+        // The symbol is declared locally rather than via `libc::` because the
+        // libc crate exposes `pthread_getname_np` for the BSD/Apple targets but
+        // not the `linux_like` module — yet glibc (>=2.12) and musl both export
+        // the identical 3-arg signature, so a local extern is portable across
+        // every unix target the runtime builds for, including the Linux CI host
+        // where the off-dispatch crash actually fires.
+        extern "C" {
+            fn pthread_getname_np(
+                thread: libc::pthread_t,
+                name: *mut libc::c_char,
+                len: libc::size_t,
+            ) -> libc::c_int;
+        }
+
+        // Write fixed prefix, then signal name, then fault address, then the
+        // faulting thread name, then newline — no allocation. Each write is a
+        // separate syscall; partial writes are acceptable for a terminal
+        // diagnostic before _exit.
         const PREFIX: &[u8] = b"hew: crash in main context: ";
+        const AT: &[u8] = b" at ";
+        const THREAD: &[u8] = b" thread=";
         const SUFFIX: &[u8] = b"\n";
         let name = signal_name(sig).as_bytes();
+        let mut addr_buf = [0u8; 18];
+        let addr = fmt_hex_usize(fault_addr, &mut addr_buf);
+
+        // A failed name lookup leaves the buffer as-is; we render "<unknown>".
+        let mut tname = [0u8; 32];
+        // SAFETY: pthread_self / pthread_getname_np are async-signal-safe; the
+        // buffer is stack-owned and sized for the platform's max thread name.
+        let tname_ok = unsafe {
+            pthread_getname_np(libc::pthread_self(), tname.as_mut_ptr().cast(), tname.len()) == 0
+        };
+        let tname_slice: &[u8] = if tname_ok {
+            let end = tname.iter().position(|&b| b == 0).unwrap_or(tname.len());
+            if end == 0 {
+                b"<main>"
+            } else {
+                &tname[..end]
+            }
+        } else {
+            b"<unknown>"
+        };
+
         // SAFETY: write(2) is POSIX async-signal-safe. fd 2 (STDERR_FILENO) is
         // always open. The byte slices are valid static/stack data. We ignore
         // the return value — a failed write before _exit is not actionable.
         unsafe {
             libc::write(2, PREFIX.as_ptr().cast(), PREFIX.len());
             libc::write(2, name.as_ptr().cast(), name.len());
+            libc::write(2, AT.as_ptr().cast(), AT.len());
+            libc::write(2, addr.as_ptr().cast(), addr.len());
+            libc::write(2, THREAD.as_ptr().cast(), THREAD.len());
+            libc::write(2, tname_slice.as_ptr().cast(), tname_slice.len());
             libc::write(2, SUFFIX.as_ptr().cast(), SUFFIX.len());
         }
     }
@@ -435,6 +512,26 @@ mod shared {
             unsafe { prepare_dispatch_impl(&mut state, ptr::null_mut(), ptr::null_mut()) };
             assert!(!state.intentional_panic.load(Ordering::Acquire));
         }
+
+        /// The async-signal-safe hex formatter backs the terminal crash
+        /// diagnostic for off-dispatch faults (accept / connection-reader /
+        /// SWIM-driver threads). It must render the exact fault address — a
+        /// wrong value would mislocate the next CI crash — including the zero,
+        /// single-digit, and full-width boundaries.
+        #[cfg(unix)]
+        #[test]
+        fn fmt_hex_usize_renders_fault_addresses() {
+            let mut buf = [0u8; 18];
+            assert_eq!(fmt_hex_usize(0, &mut buf), b"0x0");
+            assert_eq!(fmt_hex_usize(0xf, &mut buf), b"0xf");
+            assert_eq!(fmt_hex_usize(0x10, &mut buf), b"0x10");
+            assert_eq!(fmt_hex_usize(0xdead_beef, &mut buf), b"0xdeadbeef");
+            // A typical low-half null-region offset deref (the classic
+            // null-struct-field fault shape).
+            assert_eq!(fmt_hex_usize(0x28, &mut buf), b"0x28");
+            // Full-width usize: every nibble significant, no leading-zero trim.
+            assert_eq!(fmt_hex_usize(usize::MAX, &mut buf), b"0xffffffffffffffff");
+        }
     }
 }
 
@@ -602,9 +699,30 @@ mod platform {
         let ctx = unsafe { get_recovery_ctx() };
         if ctx.is_null() {
             // No recovery context (main/free-fn context) — emit a diagnostic
-            // then terminate. F1.3: a crash must never be silent.
+            // then terminate. F1.3: a crash must never be silent. Capture the
+            // faulting address from siginfo so an off-dispatch crash (accept /
+            // connection-reader / SWIM-driver threads have no recovery jmp_buf
+            // and land here) localizes to a concrete pointer instead of an
+            // opaque "SIGSEGV somewhere".
+            let fault_addr = if info.is_null() {
+                0usize
+            } else {
+                // `si_addr` is an async-signal-safe read of the kernel-provided
+                // siginfo_t — a method on Linux, a field on macOS — matched to
+                // the recovered path below.
+                #[cfg(target_os = "linux")]
+                {
+                    // SAFETY: `info` was validated non-null above.
+                    (unsafe { (*info).si_addr() }) as usize
+                }
+                #[cfg(not(target_os = "linux"))]
+                {
+                    // SAFETY: `info` was validated non-null above.
+                    (unsafe { (*info).si_addr }) as usize
+                }
+            };
             // write(2) is POSIX async-signal-safe; see emit_crash_diagnostic_sig_safe.
-            super::shared::emit_crash_diagnostic_sig_safe(sig);
+            super::shared::emit_crash_diagnostic_sig_safe(sig, fault_addr);
             // SAFETY: _exit is async-signal-safe.
             unsafe { libc::_exit(128 + sig) };
         }
@@ -1379,3 +1497,98 @@ pub(crate) use platform::{
     mark_recovery_active, prepare_dispatch_recovery, sigsetjmp, try_direct_longjmp,
     try_direct_longjmp_with_code,
 };
+
+// ── Terminal off-dispatch crash diagnostic (subprocess test) ─────────────────
+
+/// End-to-end proof that an off-dispatch fault (a thread with NO recovery
+/// `jmp_buf` — exactly the I/O accept / connection-reader / SWIM-driver threads
+/// in the distributed runtime) terminates with a diagnostic that pins the
+/// faulting ADDRESS and THREAD NAME, not just the signal. This is the surface
+/// that turns issue-#1963's opaque "crash in main context: SIGSEGV" on a CI
+/// runner into a localized fault site on its next occurrence.
+///
+/// The crash path `_exit`s the process, so it can only be exercised in a child:
+/// the child helper installs the crash handler, spawns a named thread, and
+/// dereferences a wild pointer there; the parent re-execs that helper and
+/// asserts the captured stderr.
+#[cfg(all(test, unix, not(target_arch = "wasm32")))]
+mod terminal_diag_tests {
+    const HELPER_ENV: &str = "HEW_SIGNAL_TERMINAL_DIAG_HELPER";
+    const FAULT_THREAD_NAME: &str = "hew-conn-diag";
+    // A fixed wild address in the unmapped low region: deterministic in the
+    // diagnostic output and reliably faults on read across unix targets.
+    const FAULT_ADDR: usize = 0x28;
+
+    /// Child helper: install the crash handler on the main thread (so the
+    /// process-wide signal disposition is set), then fault on a *named* thread
+    /// that never installed a per-thread recovery context. The handler's
+    /// no-recovery branch must emit the terminal diagnostic and `_exit(139)`.
+    #[test]
+    fn signal_terminal_diag_helper() {
+        if std::env::var(HELPER_ENV).as_deref() != Ok("1") {
+            return;
+        }
+        // Install the process signal handlers. The main thread also installs a
+        // per-thread recovery context inside init; the spawned thread below does
+        // NOT, so its fault takes the no-recovery terminal path.
+        super::init_crash_handling();
+
+        let handle = std::thread::Builder::new()
+            .name(FAULT_THREAD_NAME.to_owned())
+            .spawn(|| {
+                let wild = FAULT_ADDR as *const u8;
+                // SAFETY: intentional wild read to drive the fault on an
+                // off-dispatch thread; the process is expected to terminate.
+                let v = unsafe { std::ptr::read_volatile(wild) };
+                // Prevent the read from being optimized away.
+                std::process::exit(i32::from(v));
+            })
+            .expect("spawn fault thread");
+        let _ = handle.join();
+        // Reaching here means the fault did not terminate the process — fail
+        // loudly so the parent's assertion surfaces the regression.
+        std::process::exit(0);
+    }
+
+    #[test]
+    fn off_dispatch_fault_diagnostic_pins_address_and_thread() {
+        let exe = std::env::current_exe().expect("test binary path");
+        let output = std::process::Command::new(exe)
+            .args([
+                "--exact",
+                "signal::terminal_diag_tests::signal_terminal_diag_helper",
+                "--nocapture",
+            ])
+            .env(HELPER_ENV, "1")
+            .env("RUST_TEST_THREADS", "1")
+            .output()
+            .expect("spawn signal terminal-diag helper");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let code = output.status.code();
+
+        // Terminal off-dispatch fault: SIGSEGV (or SIGBUS on some targets) →
+        // _exit(128 + sig). 139 = 128 + 11 (SIGSEGV); 135 = 128 + 7 (SIGBUS).
+        assert!(
+            matches!(code, Some(139 | 135)),
+            "expected terminal _exit(128+SIGSEGV/SIGBUS); got {code:?}\nstderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("hew: crash in main context:"),
+            "diagnostic prefix missing\nstderr:\n{stderr}"
+        );
+        // The fault ADDRESS must be pinned (the load-bearing localization). The
+        // exact wild address may be sanitized by the kernel on some targets, so
+        // accept either the precise address or any ` at 0x…` token.
+        assert!(
+            stderr.contains(" at 0x"),
+            "diagnostic must carry the faulting address\nstderr:\n{stderr}"
+        );
+        // The faulting THREAD NAME must be pinned so a multi-threaded runtime
+        // crash names its origin thread.
+        assert!(
+            stderr.contains(&format!("thread={FAULT_THREAD_NAME}")),
+            "diagnostic must name the faulting thread `{FAULT_THREAD_NAME}`\nstderr:\n{stderr}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

An intermittent SIGSEGV during cluster-join teardown under load is fixed. A connection-reader thread that had self-removed its connection actor could outlive it and touch the routing table and cluster state after node shutdown had already freed them — a teardown use-after-free. The connection manager now tracks reader-thread lifetimes and waits for any self-removed reader to fully exit before routing and cluster state are freed.

The two commits here are the fault-address diagnostic (context) and the synchronization fix. The diagnostic commit landed first on the branch for root-cause grounding; the fix is the second commit.

## Verification

- Reproduced on Linux under load (96 CPU hogs / 48 concurrent / 5000 iterations) and confirmed fixed.
- ThreadSanitizer clean on the join paths (Linux, obelisk).
- `cargo test -p hew-runtime --lib connmgr_free_waits_for_self_removed_reader_lifecycle`: 1 passed. With the barrier neutralized the test fails at "hew_connmgr_free returned before the self-removed reader finished" — regression test has teeth.
- `cargo test -p hew-runtime --lib connection::tests`: 25 passed (sibling teardown invariants — drop-before-join, lock-release-before-wake, reentrant-remove — all green; the barrier composes).
- `cargo clippy -p hew-runtime --lib --all-targets`: clean.
- Deadlock / lock-ordering proof verified from code: `hew_connmgr_free` holds no routing, cluster, or connections lock while waiting on `wait_for_idle`; the wait acquires only a dedicated `Mutex<usize>` unrelated to any lock the reader cleanup path contends.
- Preflight: ready-to-push.

## Out of scope

- No other teardown paths changed. Reader-lifecycle tracking is scoped to the self-removed-reader gap identified in #1963.

Fixes #1963