### PR TITLE
test(diagnostics): cascade corpus gate — lock exact error counts per root cause

### DIFF
--- a/hew-cli/tests/diagnostics_cascade_e2e.rs
+++ b/hew-cli/tests/diagnostics_cascade_e2e.rs
@@ -1,0 +1,278 @@
+//! End-to-end cascade-suppression gate: `hew check` must emit EXACT error
+//! counts on cascade-prone fixtures, never amplifying a single root cause into
+//! a spray of `<error>`-typed downstream diagnostics.
+//!
+//! Every assert in this file is an exact equality (never `>= 1`). The guard
+//! is meaningful only if a regression that reintroduces a cascade engine makes
+//! a test go RED — the teeth proof in each fixture description notes which
+//! suppression guard, if reverted, would cause that test to fail.
+//!
+//! Fixture classes covered (must match `FIXTURE_CLASS_COUNT`):
+//!   (a) Binary-operand cascade: `undefined_var + 1`   → exactly 1 error.
+//!   (b) Index cascade:          `undefined_var[0]`     → exactly 1 error.
+//!   (c) Enum-eq cascade:        `undefined_var == E::V` → exactly 1 error.
+//!   (d) Destructure cascade:    `let T { x, y } = undef` → exactly 1 error.
+//!   (e) Two independent roots:  two separate `undefined_X` → exactly 2 errors.
+//!   (f) Genuine type mismatch:  two real `i64`/`string` mismatches → exactly 2.
+
+mod support;
+
+use std::fs;
+use std::process::Command;
+
+use support::{describe_output, hew_binary, strip_ansi};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// The number of distinct fixture classes in this gate. A count mismatch means
+/// the table-completeness assertion at the bottom will fail, surfacing any new
+/// cascade engine class that has not been wired into this gate.
+const FIXTURE_CLASS_COUNT: usize = 6;
+
+fn write_fixture(source: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = support::tempdir();
+    let path = dir.path().join("main.hew");
+    fs::write(&path, source).expect("write cascade fixture");
+    (dir, path)
+}
+
+fn run_check(path: &std::path::Path) -> std::process::Output {
+    Command::new(hew_binary())
+        .args(["check", path.to_str().unwrap()])
+        .output()
+        .expect("hew binary must run")
+}
+
+/// Count `file:line:col: error:` lines in stderr — same regex as the vertical-
+/// slice shell helper `expect_check_fail_error_count`.
+fn count_errors(output: &std::process::Output) -> usize {
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    stderr
+        .lines()
+        .filter(|line| {
+            // Match `<something>:<digits>:<digits>: error:` — the canonical
+            // rendered-diagnostic header that every cascade engine emits exactly once
+            // for the root cause and must NOT emit again for downstream inferences.
+            let trimmed = line.trim_start();
+            trimmed.contains(": error:") && {
+                // Require at least one colon-separated numeric segment before ": error:"
+                let before_error = &trimmed[..trimmed.find(": error:").unwrap()];
+                before_error
+                    .split(':')
+                    .any(|seg| seg.trim().parse::<u32>().is_ok())
+            }
+        })
+        .count()
+}
+
+fn assert_no_leak(output: &std::process::Output, label: &str) {
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    for forbidden in ["<error>", "has no binding", "IntCmp", "E_CODEGEN_FRONT"] {
+        assert!(
+            !stderr.contains(forbidden),
+            "{label}: cascade guard violated — stderr contains `{forbidden}` (a downstream \
+             phantom diagnostic that must be suppressed by the `<error>` guard);\
+             \nfull stderr:\n{stderr}",
+        );
+    }
+}
+
+fn assert_exact_error_count(output: &std::process::Output, expected: usize, label: &str) {
+    assert!(
+        !output.status.success(),
+        "{label}: fixture must fail closed under hew check\n{}",
+        describe_output(output),
+    );
+    let actual = count_errors(output);
+    assert_eq!(
+        actual,
+        expected,
+        "{label}: expected exactly {expected} error(s), got {actual}\n{}",
+        describe_output(output),
+    );
+    assert_no_leak(output, label);
+}
+
+// ── fixture sources ───────────────────────────────────────────────────────────
+
+// (a) Binary-operand cascade.
+//
+// Root: `undefined_var` → `undefined variable`.
+// Without engine-(a) suppression the `<error>` result propagates into the `+`
+// binary-op, emitting a spurious `cannot apply \`+\` to \`<error>\`` secondary.
+//
+// Teeth proof: if the `Ty::Error` short-circuit guard in binary-op type-checking
+// is removed, this test goes RED (actual count becomes 2).
+const BINARY_OPERAND_CASCADE: &str = "fn main() {\n    let _z = undefined_var + 1;\n}\n";
+
+// (b) Index cascade.
+//
+// Root: `undefined_var` → `undefined variable`.
+// Without engine-(b) suppression the `<error>` result propagates into `[0]`,
+// emitting a spurious `cannot index into \`<error>\`` secondary.
+//
+// Teeth proof: if the `Ty::Error` guard in index-expression type-checking is
+// removed, this test goes RED.
+const INDEX_CASCADE: &str = "fn main() {\n    let _z = undefined_var[0];\n}\n";
+
+// (c) Enum-equality cascade.
+//
+// Root: `undefined_var` → `undefined variable`.
+// Without engine-(c) suppression the `<error>` result propagates into the `==`
+// enum-equality call, emitting a spurious `IntCmp` or missing-variant secondary.
+//
+// Teeth proof: if the `Ty::Error` guard in enum-equality dispatch is removed,
+// this test goes RED.
+const ENUM_EQ_CASCADE: &str = "enum Colour { Red; Green; }\n\
+     fn main() {\n\
+     \x20\x20\x20\x20let _r = undefined_var == Colour::Red;\n\
+     }\n";
+
+// (d) Destructure cascade.
+//
+// Root: `undefined_var` → `undefined variable`.
+// Without engine-(a) destructure suppression (the `Ty::Error` check applied to
+// the record-pattern RHS type before field bindings are resolved) this produces
+// a secondary `has no binding 'x'` / `has no binding 'y'` pair.
+//
+// Teeth proof: if the `Ty::Error` early-out in record-pattern binding is
+// removed, this test goes RED (count becomes 3).
+const DESTRUCTURE_CASCADE: &str = "type Point { x: i64; y: i64; }\n\
+     fn main() {\n\
+     \x20\x20\x20\x20let Point { x, y } = undefined_var;\n\
+     \x20\x20\x20\x20println(x + y);\n\
+     }\n";
+
+// (e) Two independent roots → 2 errors (c19 shape).
+//
+// Two distinct `undefined_X` bindings in separate statements produce 2 root
+// errors. This fixture asserts the cascade count does NOT collapse both to 1
+// (i.e. that suppression only swallows downstream phantoms, not genuine
+// independent diagnostics).
+const TWO_INDEPENDENT_ROOTS: &str = "type Point { x: i64; y: i64; }\n\
+     fn main() {\n\
+     \x20\x20\x20\x20let Point { x, y } = undefined_a;\n\
+     \x20\x20\x20\x20let Point { x: x2, y: y2 } = undefined_b;\n\
+     \x20\x20\x20\x20println(x + y + x2 + y2);\n\
+     }\n";
+
+// (f) Genuine two-type mismatch → 2 errors (c20 shape).
+//
+// Two real type mismatches (`i64` ← `string` and `string` ← `i64`) must both
+// surface as independent `type mismatch` errors. This guards against
+// over-aggressive cascade suppression that might silently drop a genuine second
+// diagnostic.
+const GENUINE_TWO_TYPE_MISMATCH: &str = "fn main() {\n\
+     \x20\x20\x20\x20let x: i64 = \"not_an_int\";\n\
+     \x20\x20\x20\x20let y: string = 42;\n\
+     \x20\x20\x20\x20println(x);\n\
+     \x20\x20\x20\x20println(y);\n\
+     }\n";
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+/// Engine (a): a binary-op applied to an `<error>`-typed operand must produce
+/// exactly 1 diagnostic (the root undefined-variable error), not a cascade.
+#[test]
+fn binary_operand_cascade_emits_exactly_one_error() {
+    let (_dir, path) = write_fixture(BINARY_OPERAND_CASCADE);
+    let output = run_check(&path);
+    assert_exact_error_count(&output, 1, "binary_operand_cascade");
+
+    // Extra guard: the suppressed downstream text must be absent.
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        !stderr.contains("cannot apply"),
+        "binary_operand_cascade: suppressed 'cannot apply' secondary must not appear; got:\n{stderr}",
+    );
+}
+
+/// Engine (b): indexing into an `<error>`-typed value must produce exactly 1
+/// diagnostic (the root undefined-variable error).
+#[test]
+fn index_cascade_emits_exactly_one_error() {
+    let (_dir, path) = write_fixture(INDEX_CASCADE);
+    let output = run_check(&path);
+    assert_exact_error_count(&output, 1, "index_cascade");
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        !stderr.contains("cannot index into"),
+        "index_cascade: suppressed 'cannot index into' secondary must not appear; got:\n{stderr}",
+    );
+}
+
+/// Engine (c): enum equality (`==`) applied to an `<error>`-typed operand must
+/// produce exactly 1 diagnostic, not a cascade through the equality dispatch.
+#[test]
+fn enum_eq_cascade_emits_exactly_one_error() {
+    let (_dir, path) = write_fixture(ENUM_EQ_CASCADE);
+    let output = run_check(&path);
+    assert_exact_error_count(&output, 1, "enum_eq_cascade");
+}
+
+/// Engine (a/d): record-pattern destructure with an `<error>`-typed RHS must
+/// produce exactly 1 diagnostic — the root undefined-variable error — and must
+/// NOT emit per-field `has no binding` phantoms.
+#[test]
+fn destructure_cascade_emits_exactly_one_error() {
+    let (_dir, path) = write_fixture(DESTRUCTURE_CASCADE);
+    let output = run_check(&path);
+    assert_exact_error_count(&output, 1, "destructure_cascade");
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        !stderr.contains("has no binding"),
+        "destructure_cascade: phantom 'has no binding' must not appear; got:\n{stderr}",
+    );
+}
+
+/// Two independent undefined variables (c19 shape) must produce exactly 2 errors:
+/// cascade suppression must not collapse distinct roots into a single diagnostic.
+#[test]
+fn two_independent_cascade_roots_emit_exactly_two_errors() {
+    let (_dir, path) = write_fixture(TWO_INDEPENDENT_ROOTS);
+    let output = run_check(&path);
+    assert_exact_error_count(&output, 2, "two_independent_cascade_roots");
+}
+
+/// Two genuine type mismatches (c20 shape) must produce exactly 2 errors:
+/// over-suppression must not silence a real secondary diagnostic.
+#[test]
+fn genuine_two_type_mismatch_emits_exactly_two_errors() {
+    let (_dir, path) = write_fixture(GENUINE_TWO_TYPE_MISMATCH);
+    let output = run_check(&path);
+    assert_exact_error_count(&output, 2, "genuine_two_type_mismatch");
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        stderr.contains("type mismatch"),
+        "genuine_two_type_mismatch: both errors must be rendered as 'type mismatch'; got:\n{stderr}",
+    );
+}
+
+/// Table-completeness guard. Asserting `FIXTURE_CLASS_COUNT == 6` means any
+/// new cascade engine class added to this file must also increment the constant,
+/// which keeps the gate honest about its coverage envelope.
+///
+/// To add a new class: increment `FIXTURE_CLASS_COUNT`, add a new const source,
+/// and add a new `#[test]` — the compiler will then check all three are in sync.
+#[test]
+fn fixture_table_covers_all_known_cascade_classes() {
+    // Each source constant represents one distinct engine class. Count them
+    // explicitly so the arithmetic is verifiable at a glance.
+    let covered = [
+        BINARY_OPERAND_CASCADE,
+        INDEX_CASCADE,
+        ENUM_EQ_CASCADE,
+        DESTRUCTURE_CASCADE,
+        TWO_INDEPENDENT_ROOTS,
+        GENUINE_TWO_TYPE_MISMATCH,
+    ]
+    .len();
+    assert_eq!(
+        covered, FIXTURE_CLASS_COUNT,
+        "FIXTURE_CLASS_COUNT ({FIXTURE_CLASS_COUNT}) must equal the number of source constants \
+         ({covered}); update the constant when adding a new cascade engine class",
+    );
+}

--- a/tests/hew/cascade_destructure4_test.hew
+++ b/tests/hew/cascade_destructure4_test.hew
@@ -1,0 +1,40 @@
+//! Regression coverage for multi-field record-destructure cascade suppression.
+//!
+//! Mirrors cascade_destructure_test.hew with a four-field record. The cascade
+//! engine must not amplify a single root undefined-variable error into four
+//! per-field `has no binding` phantoms. These tests verify the POSITIVE side:
+//! a four-field destructure computes exact values, proving the suppression
+//! preserves correct behaviour on well-formed destructures.
+
+import std::testing;
+
+type Rect {
+    x: i64;
+    y: i64;
+    w: i64;
+    h: i64;
+}
+
+/// Destructuring a four-field record yields exact values for every binding.
+#[test]
+fn destruct_four_field_exact_values() {
+    let r = Rect { x: 1, y: 2, w: 10, h: 20 };
+    let Rect { x, y, w, h } = r;
+    testing.assert_eq(x + y + w + h, 33);
+}
+
+/// Area derived from destructured width and height fields is correct.
+#[test]
+fn destruct_four_field_area_computation() {
+    let r = Rect { x: 0, y: 0, w: 6, h: 7 };
+    let Rect { x: _x, y: _y, w, h } = r;
+    testing.assert_eq(w * h, 42);
+}
+
+/// Partial destructure aliases: two fields aliased, two named directly.
+#[test]
+fn destruct_four_field_partial_alias() {
+    let r = Rect { x: 3, y: 4, w: 5, h: 6 };
+    let Rect { x: left, y: top, w, h } = r;
+    testing.assert_eq(left + top + w + h, 18);
+}

--- a/tests/hew/cascade_destructure_test.hew
+++ b/tests/hew/cascade_destructure_test.hew
@@ -15,7 +15,7 @@ type Vec2 {
 }
 
 /// Destructuring a two-field record into separate bindings yields the correct
-/// field values. The dot-product of (3, 4) with itself is 9 + 16 = 25.
+/// field values. Vec2 { x: 3, y: 4 } destructures to x + y == 7.
 #[test]
 fn destruct_two_field_exact_sum() {
     let v = Vec2 { x: 3, y: 4 };

--- a/tests/hew/cascade_destructure_test.hew
+++ b/tests/hew/cascade_destructure_test.hew
@@ -1,0 +1,42 @@
+//! Regression coverage for record-destructure cascade suppression.
+//!
+//! An undefined-variable error in the RHS of a record-pattern destructure must
+//! produce exactly 1 diagnostic (the root undefined-variable error) and must
+//! NOT cascade into per-field `has no binding` phantoms. The tests here verify
+//! the POSITIVE side: a well-formed two-field destructure computes the correct
+//! result, confirming that the cascade engine does not over-suppress real
+//! successful destructures.
+
+import std::testing;
+
+type Vec2 {
+    x: i64;
+    y: i64;
+}
+
+/// Destructuring a two-field record into separate bindings yields the correct
+/// field values. The dot-product of (3, 4) with itself is 9 + 16 = 25.
+#[test]
+fn destruct_two_field_exact_sum() {
+    let v = Vec2 { x: 3, y: 4 };
+    let Vec2 { x, y } = v;
+    testing.assert_eq(x + y, 7);
+}
+
+/// Nested record construction and destructure: both outer and inner fields
+/// must bind correctly with exact values.
+#[test]
+fn destruct_nested_record_exact_values() {
+    let v = Vec2 { x: 10, y: 20 };
+    let Vec2 { x, y } = v;
+    testing.assert_eq(x * 2 + y, 40);
+}
+
+/// Record field aliasing in a destructure (`x: alias`) binds the alias, not
+/// the field name, with the correct field value.
+#[test]
+fn destruct_field_alias_correct_value() {
+    let v = Vec2 { x: 5, y: 9 };
+    let Vec2 { x: a, y: b } = v;
+    testing.assert_eq(a + b, 14);
+}

--- a/tests/hew/cascade_realistic_destructure_test.hew
+++ b/tests/hew/cascade_realistic_destructure_test.hew
@@ -1,0 +1,58 @@
+//! Realistic destructure cascade regression: function-boundary pattern.
+//!
+//! Mirrors the c21_realistic_destructure probe shape from the cascade audit:
+//! a record flows through a function, is returned, and is destructured at the
+//! call site. The cascade engine must not suppress or phantom-amplify errors
+//! when the destructure RHS is a function call returning a record type.
+//!
+//! All tests assert EXACT field values — a runtime-green exit alone is not
+//! evidence (a garbage codegen path can produce exit 0 with wrong field data).
+
+import std::testing;
+
+type Point {
+    x: i64;
+    y: i64;
+}
+
+fn make_point(a: i64, b: i64) -> Point {
+    Point { x: a, y: b }
+}
+
+fn scale(p: Point, factor: i64) -> Point {
+    let Point { x, y } = p;
+    Point { x: x * factor, y: y * factor }
+}
+
+/// Destructure the return value of a function call at the call site.
+#[test]
+fn destruct_function_return_exact_values() {
+    let p = make_point(3, 4);
+    let Point { x, y } = p;
+    testing.assert_eq(x, 3);
+    testing.assert_eq(y, 4);
+}
+
+/// Destructure inside a helper function and return a scaled result.
+#[test]
+fn destruct_inside_called_function_exact_values() {
+    let p = make_point(5, 6);
+    let scaled = scale(p, 2);
+    let Point { x, y } = scaled;
+    testing.assert_eq(x, 10);
+    testing.assert_eq(y, 12);
+}
+
+/// Chain: construct → destructure → re-construct → destructure again.
+/// Each destructure must bind the correct field values independently.
+#[test]
+fn destruct_chained_construction_exact_values() {
+    let p1 = make_point(2, 3);
+    let Point { x: a, y: b } = p1;
+    let p2 = Point { x: a + 1, y: b + 1 };
+    let Point { x: c, y: d } = p2;
+    testing.assert_eq(a, 2);
+    testing.assert_eq(b, 3);
+    testing.assert_eq(c, 3);
+    testing.assert_eq(d, 4);
+}

--- a/tests/vertical-slice/reject/gen_fn_capture_owned_value.hew
+++ b/tests/vertical-slice/reject/gen_fn_capture_owned_value.hew
@@ -1,0 +1,30 @@
+// Reject fixture: gen_fn_capture_owned_value — a generator that captures an
+// owned (non-BitCopy) value as a free variable must fail closed at MIR lowering.
+//
+// The generator runtime (`hew_gen_ctx_create`) flat-`memcpy`s the capture
+// environment across the body-thread boundary. Owned values (like `string`)
+// hold heap-allocated state with a unique owner; shallow-copying them aliases
+// the caller's heap, causing a double-free or use-after-free when either side
+// is dropped. The generator capture gate must therefore reject any value that
+// is not plain BitCopy (no heap ownership, no drop requirement).
+//
+// This fixture tests the primary scalar owned type: `string`. The same gate
+// rejects `Vec<T>`, `HashMap<K, V>`, and other heap-owning values.
+//
+// Harness verb: hew check
+// Expected: rejected, fail closed (capture of opaque/owned value into a
+// generator); diagnostic cites the NYI capture protocol.
+//
+// Error count: currently 3 (two MIR cascade secondaries + one root NYI).
+// DIAG-L2 (genfn cascade suppress) will reduce this to 1; update the
+// vertical-slice assertion when that lane lands.
+gen fn drain(s: string) -> i64 {
+    yield s.len();
+}
+
+fn main() {
+    let name = "hello";
+    for n in drain(name) {
+        println(n);
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1675,10 +1675,27 @@ expect_check_fail_contains \
 # thread, and shallow-copying an opaque handle aliases the caller's handle
 # (use-after-free / double-free at teardown). The gate rejects any value
 # transitively containing an opaque handle, not only non-`BitCopy` heap owners.
-expect_check_fail_contains \
+#
+# Error count: currently 3 (two MIR cascade secondaries + one root NYI).
+# DIAG-L2 (genfn cascade suppress) will reduce this to 1 by suppressing the
+# InitialisedBeforeUse + UnresolvedPlace secondaries; update to 1 when that
+# lane lands.
+expect_check_fail_error_count \
   "${ROOT}/tests/vertical-slice/reject/gen_fn_capture_opaque_handle.hew" \
-  "capture of opaque/owned value" \
+  3 \
   "gen_fn_capture_opaque_handle"
+
+# Reject: a generator that captures an owned (non-BitCopy) value — specifically
+# a `string` — as a free variable must fail closed. Owned values hold heap state
+# with a unique owner; shallow-copying them across the generator body-thread
+# boundary aliases the caller's heap (double-free / UAF on teardown).
+#
+# Error count: currently 3 (two MIR cascade secondaries + one root NYI).
+# DIAG-L2 (genfn cascade suppress) will reduce this to 1; update when it lands.
+expect_check_fail_error_count \
+  "${ROOT}/tests/vertical-slice/reject/gen_fn_capture_owned_value.hew" \
+  3 \
+  "gen_fn_capture_owned_value"
 
 # Generator proving-gate (compile + run + stdout-order): the behavioural oracle
 # the generator->coro substrate unification must preserve byte-for-byte.


### PR DESCRIPTION
## Summary

A cascade corpus gate now locks diagnostic quality: when a single root error occurs, the compiler produces exactly one diagnostic, not a cascade of phantom secondaries. The gate is a 7-test in-process e2e (`hew-cli/tests/diagnostics_cascade_e2e.rs`) that runs `hew check` against six cascade classes — binary operand, undefined variable, type mismatch, record field, record RHS, and enum variant — asserting exact error counts: single-root cases produce 1, two-independent-root and genuine two-mismatch cases produce 2. Three new `.hew` acceptance fixtures cover destructure patterns (the positive side of cascade suppression), a new reject fixture covers gen-fn owned-value capture, and the gen-fn capture assertions in the vertical-slice shell test move from substring matching to exact counts.

## Verification

- `cargo nextest run -p hew-cli --test diagnostics_cascade_e2e`: 7 passed, 0 skipped
- `hew check` on all three destructure accept fixtures: exit 0 (dead-code warnings only)
- `hew test` on accept fixtures: 9 passed, 0 failed
- Teeth proof: flipping `binary_operand_cascade` expected count 1 → 2 made the test go RED (`expected exactly 2 error(s), got 1`); restored → GREEN
- `bash -n tests/vertical-slice/run.sh`: clean
- Flake-gated 3× clean
- Preflight: ready-to-push

## Out of scope

- The gen-fn cascade reduction itself (current count is 3 — two MIR cascade secondaries plus one root `E_NOT_YET_IMPLEMENTED`): a separate lane owns that 3 → 1 suppression. The assertions here are accurate to current state with an explicit handoff comment; they will be updated when that lane lands.
