### PR TITLE
fix(types): wire from_json/from_yaml return Result<Self, string>

### DIFF
--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -2611,11 +2611,17 @@ impl Checker {
             }
         }
 
+        // `decode` returns bare `Self` (binary CBOR is trap-on-failure); the
+        // text-format `from_json`/`from_yaml` parsers can fail on arbitrary
+        // user input (config files, HTTP bodies), so they return
+        // `Result<Self, string>` — the only honest shape for a fallible parse.
+        // This matches the non-wire `Encode` path (`register_encode_methods`).
+        let from_result_ty = Ty::result(self_ty.clone(), Ty::String);
         let static_methods = if is_wire_struct || is_serial_wire_enum {
             vec![
-                ("decode", vec![bytes_ty], self_ty.clone()),
-                ("from_json", vec![Ty::String], self_ty.clone()),
-                ("from_yaml", vec![Ty::String], self_ty),
+                ("decode", vec![bytes_ty], self_ty),
+                ("from_json", vec![Ty::String], from_result_ty.clone()),
+                ("from_yaml", vec![Ty::String], from_result_ty),
             ]
         } else {
             vec![]

--- a/hew-types/src/check/tests.rs
+++ b/hew-types/src/check/tests.rs
@@ -258,6 +258,51 @@ fn wire_text_format_methods_record_no_codec_rewrite() {
 }
 
 #[test]
+fn wire_from_json_returns_result_self_string() {
+    // A `#[wire]` type's `from_json`/`from_yaml` static parsers are fallible
+    // (arbitrary user input — config files, HTTP bodies), so they return
+    // `Result<Self, string>`, matching the non-wire `Encode` path. This pins
+    // the ratified return shape on the wire registration path.
+    let output = check_source(
+        r#"
+        #[wire]
+        struct Point { x: i64 @1, y: i64 @2 }
+
+        fn main() {
+            let _r: Result<Point, string> = Point.from_json("{\"x\":1,\"y\":2}");
+            let _y: Result<Point, string> = Point.from_yaml("x: 1");
+        }
+        "#,
+    );
+    assert!(
+        output.errors.is_empty(),
+        "wire from_json/from_yaml must type-check as Result<Self, string>; got: {:?}",
+        output.errors
+    );
+}
+
+#[test]
+fn wire_from_json_bare_self_is_type_error() {
+    // Assigning a wire `from_json` result directly to `Self` (not
+    // `Result<Self, …>`) must be a type error — the bare-`Self` registration
+    // is gone.
+    let output = check_source(
+        r#"
+        #[wire]
+        struct Point { x: i64 @1, y: i64 @2 }
+
+        fn main() {
+            let _p: Point = Point.from_json("{\"x\":1,\"y\":2}");
+        }
+        "#,
+    );
+    assert!(
+        !output.errors.is_empty(),
+        "assigning Result<Point, string> to Point must be a type error"
+    );
+}
+
+#[test]
 fn wire_layout_table_populated_from_wire_struct() {
     let output = check_source(
         r"


### PR DESCRIPTION
## Summary

`#[wire]`-derived `from_json` and `from_yaml` previously returned bare `Self`, which is the wrong shape for fallible parsing of untrusted input. They now return `Result<Self, string>`, matching the non-wire decode path. Callers that previously discarded parse failures now see them at the type level.

## Verification

- `make test-types`: 3393 tests pass
- `verify-ffi`: pass
- `checked-mir`: pass
- `clippy -p hew-types`: clean
- `cargo fmt --check`: clean
- Positive regression test: `from_json`/`from_yaml` return `Result<Self, string>`
- Negative regression test: bare `Self` return is a type error
- Preflight: ready-to-push

## Out of scope

- The runtime JSON/YAML codec and codegen text-thunk emitter — a separate, larger change whose architecture is under active discussion.
