### PR TITLE
feat(types,codegen): HashMap/HashSet accept string-bearing record keys with structural hash and owned-key drop

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -1764,6 +1764,11 @@ pub(crate) fn intern_runtime_decl<'ctx>(
         // hew_string_equals(a: *const c_char, b: *const c_char) -> i32
         // (`hew-runtime/src/string.rs`). Returns 1 when equal, 0 otherwise.
         "hew_string_equals" => i32_ty.fn_type(&[ptr_ty.into(), ptr_ty.into()], false),
+        // hew_string_hash_fnv1a(s: *const c_char) -> i64
+        // (`hew-runtime/src/string.rs`). FNV-1a-64 over the NUL-terminated
+        // payload — the hash twin of `hew_string_equals`. Called by the
+        // per-record hash thunk when descending into a `string` key field.
+        "hew_string_hash_fnv1a" => i64_ty.fn_type(&[ptr_ty.into()], false),
         // hew_string_compare(a: *const c_char, b: *const c_char) -> i32
         // (`hew-runtime/src/string.rs`). strcmp-style: negative when a < b,
         // 0 when equal, positive when a > b.  Used by string ordering (`<`,
@@ -9403,6 +9408,15 @@ fn collect_vec_owned_element_seeds(
                         on_vec_elem(elem);
                     }
                 } else if name == "HashMap" || short_name(name) == "HashMap" {
+                    // Seed BOTH the value (heap-owning V drop thunk) AND the key
+                    // (managed-record-key drop thunk). A `string`-bearing record
+                    // key is owned by the map and dropped via its per-record
+                    // `__hew_record_drop_inplace_<R>` body; without seeding the
+                    // key, that body would be declared-but-undefined and LLVM
+                    // verify would reject the module.
+                    if let Some(key) = args.first() {
+                        on_vec_elem(key);
+                    }
                     if let Some(value) = args.get(1) {
                         on_vec_elem(value);
                     }
@@ -17376,7 +17390,43 @@ fn hashmap_key_layout_descriptor_ptr<'ctx>(
     }
     let (size, align) = abi_size_align(elem_ty, Some(fn_ctx.target_data))?;
     let key = crate::thunks::eq_thunk_struct_key(elem_ty);
-    let global_name = format!("__hew_map_key_layout_{size}_{align}_{key}_plain");
+
+    // A record key whose every field is hash-eligible-or-`string` is admitted by
+    // the checker (`ty_is_hash_eligible`) with a heap leaf. Such a key is owned
+    // by the map: insert MOVEs the key blob into the slot (the caller's key is
+    // consumed), and remove/free drop the slot key exactly once via a per-record
+    // drop thunk (`__hew_record_drop_inplace_<R>`, whose body is seeded into the
+    // clone/drop synthesis through `collect_vec_owned_element_seeds`'s HashMap
+    // key arm). Map-clone and `.keys()` over a layout-managed key remain
+    // fail-closed in the runtime (out of scope here). `ownership_kind` is
+    // `LayoutManaged` (2) so the runtime's drop discipline fires; a Copy record
+    // (no heap leaf) keeps Plain (0) and a null drop_fn.
+    let key_drop_fn = if resolved_ty
+        .is_some_and(|rty| resolved_ty_contains_heap_leaf(fn_ctx, rty, &mut HashSet::new()))
+    {
+        let rty = resolved_ty.expect("heap-leaf check requires a resolved type");
+        match crate::thunks::owned_elem_thunk_key(fn_ctx, rty) {
+            Some((OwnedElemThunkKind::Record, record_key)) => Some(
+                get_or_declare_record_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &record_key),
+            ),
+            _ => {
+                return Err(CodegenError::FailClosed(format!(
+                    "managed HashMap key `{rty:?}` admitted by the checker but has no \
+                     per-record drop thunk path; only string-bearing record keys are \
+                     supported as layout-managed keys"
+                )));
+            }
+        }
+    } else {
+        None
+    };
+
+    let ownership_suffix = if key_drop_fn.is_some() {
+        "managed"
+    } else {
+        "plain"
+    };
+    let global_name = format!("__hew_map_key_layout_{size}_{align}_{key}_{ownership_suffix}");
     if let Some(g) = fn_ctx.llvm_mod.get_global(&global_name) {
         return Ok(g.as_pointer_value());
     }
@@ -17407,15 +17457,21 @@ fn hashmap_key_layout_descriptor_ptr<'ctx>(
     let hash_fn = crate::thunks::get_or_emit_hash_thunk(fn_ctx, elem_ty, resolved_ty)?;
     let eq_fn = crate::thunks::get_or_emit_eq_thunk(fn_ctx, elem_ty, resolved_ty)?;
 
+    // ownership_kind: Plain (0) for Copy keys, LayoutManaged (2) for keys with
+    // an owned (string) leaf. The drop_fn slot carries the per-record drop
+    // thunk for managed keys; null for Plain. The runtime's `validate_key_layout`
+    // requires drop_fn = Some for LayoutManaged ownership.
+    let (ownership_kind, drop_fn_value) = match key_drop_fn {
+        Some(drop_fn) => (2u64, drop_fn.as_global_value().as_pointer_value().into()),
+        None => (0u64, ptr_ty.const_null().into()),
+    };
     let init = layout_ty.const_named_struct(&[
         usize_ty.const_int(size, false).into(),
         usize_ty.const_int(u64::from(align), false).into(),
-        i8_ty.const_zero().into(),
+        i8_ty.const_int(ownership_kind, false).into(),
         hash_fn.as_global_value().as_pointer_value().into(),
         eq_fn.as_global_value().as_pointer_value().into(),
-        // drop_fn = None (Plain ownership; W4.001 Stage C0a). Represented as
-        // a null function pointer per the Option<extern "C" fn> niche layout.
-        ptr_ty.const_null().into(),
+        drop_fn_value,
     ]);
     let g = fn_ctx.llvm_mod.add_global(layout_ty, None, &global_name);
     g.set_constant(true);

--- a/hew-codegen-rs/src/thunks.rs
+++ b/hew-codegen-rs/src/thunks.rs
@@ -1765,12 +1765,45 @@ fn emit_hash_thunk_body<'ctx>(
         BasicTypeEnum::FloatType(_) => Err(CodegenError::FailClosed(
             "hash_thunk: float field reached codegen — checker eligibility gate bypassed".into(),
         )),
-        BasicTypeEnum::PointerType(_)
-        | BasicTypeEnum::VectorType(_)
-        | BasicTypeEnum::ScalableVectorType(_) => Err(CodegenError::FailClosed(format!(
-            "hash_thunk: unsupported field shape {ty:?} — checker eligibility \
-             gate should have rejected this field type"
-        ))),
+        BasicTypeEnum::PointerType(_) => match resolved_ty {
+            // A `string` field inside a hash key: load the owned `*const c_char`
+            // and hash its NUL-terminated payload via `hew_string_hash_fnv1a`
+            // (the hash twin of the eq thunk's `hew_string_equals`). Hashing the
+            // payload — not the pointer word — keeps distinct-but-equal record
+            // keys in the same bucket and equal-by-value keys colliding, exactly
+            // as the equality witness compares them.
+            Some(ResolvedTy::String) => {
+                let str_ptr = fn_ctx
+                    .builder
+                    .build_load(ty, base_ptr, "hash_string_load")
+                    .llvm_ctx("hash_thunk string load")?
+                    .into_pointer_value();
+                let hash = fn_ctx.call_runtime_int(
+                    "hew_string_hash_fnv1a",
+                    &[str_ptr.into()],
+                    "hash_string_fnv1a",
+                    "hash_thunk string hash",
+                )?;
+                mix_into_hash_acc(fn_ctx, acc_slot, hash)?;
+                Ok(())
+            }
+            // No fail-open pointer-hash fallback: any other pointer-shaped field
+            // means the checker eligibility gate was bypassed. Refuse loudly
+            // rather than mix the raw pointer word (which would silently break
+            // hash/eq agreement). LESSONS: no-fail-open-fallback-after-authority.
+            Some(other) => Err(CodegenError::FailClosed(format!(
+                "hash_thunk: pointer field of type `{other:?}` has no structural hash path"
+            ))),
+            None => Err(CodegenError::FailClosed(
+                "hash_thunk: pointer field reached hash thunk without resolved Hew type".into(),
+            )),
+        },
+        BasicTypeEnum::VectorType(_) | BasicTypeEnum::ScalableVectorType(_) => {
+            Err(CodegenError::FailClosed(format!(
+                "hash_thunk: unsupported field shape {ty:?} — checker eligibility \
+                 gate should have rejected this field type"
+            )))
+        }
     }
 }
 

--- a/hew-runtime/src/string.rs
+++ b/hew-runtime/src/string.rs
@@ -586,6 +586,39 @@ pub unsafe extern "C" fn hew_string_equals(a: *const c_char, b: *const c_char) -
     i32::from(unsafe { libc::strcmp(a, b) } == 0)
 }
 
+/// FNV-1a-64 hash of a C string's NUL-terminated payload bytes.
+///
+/// This is the hash twin of [`hew_string_equals`]: it hashes exactly the byte
+/// range `strcmp` compares (`s[0..strlen(s)]`), so two strings that compare
+/// equal hash equal. The codegen per-record hash thunk calls this when it
+/// reaches a `string` field of a layout `HashMap` key — loading the field's
+/// `*const c_char` and hashing the payload it points at, rather than mixing the
+/// pointer word (which would make distinct-but-equal record keys collide-or-miss
+/// against the equality witness). A null pointer hashes to the FNV offset basis
+/// (consistent with hashing the empty byte range).
+///
+/// # Safety
+///
+/// `s` must be a valid NUL-terminated C string, or null.
+#[no_mangle]
+pub unsafe extern "C" fn hew_string_hash_fnv1a(s: *const c_char) -> u64 {
+    const FNV_OFFSET_64: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME_64: u64 = 0x0000_0100_0000_01b3;
+    let mut h = FNV_OFFSET_64;
+    if s.is_null() {
+        return h;
+    }
+    // SAFETY: `s` is a valid NUL-terminated C string per caller contract.
+    let len = unsafe { libc::strlen(s) };
+    // SAFETY: `s[0..len]` are valid bytes (the payload up to the NUL).
+    let slice = unsafe { core::slice::from_raw_parts(s.cast::<u8>(), len) };
+    for &b in slice {
+        h ^= u64::from(b);
+        h = h.wrapping_mul(FNV_PRIME_64);
+    }
+    h
+}
+
 /// Split a string by `delim` into a `HewVec` of strings. Caller must free
 /// the returned vec with [`crate::vec::hew_vec_free`].
 ///

--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -41,15 +41,7 @@ pub(crate) fn primitive_copy_layout(
         // for completeness so this function can serve as a general primitive sizer.
         Ty::I32 | Ty::U32 | Ty::Char | Ty::F32 => Some((4, 4)),
         // f64 is hash-ineligible but included for the same reason.
-        //
-        // String: the in-record slot blob is a single owned `*const c_char`
-        // pointer (the heap payload lives elsewhere). Pointer-width / pointer-
-        // aligned (8/8 on the 64-bit targets this sizer serves, matching the
-        // hardcoded 8-byte primitives above). Eligibility (`ty_is_hash_eligible`)
-        // gates admission; the owned string is hashed by payload-descent and
-        // dropped via the per-record key drop thunk (codegen). Hash/Eq remain
-        // structural.
-        Ty::I64 | Ty::U64 | Ty::Duration | Ty::F64 | Ty::String => Some((8, 8)),
+        Ty::I64 | Ty::U64 | Ty::Duration | Ty::F64 => Some((8, 8)),
         Ty::Array(elem, count) => {
             let (elem_size, elem_align) = primitive_copy_layout(elem, type_defs)?;
             let count = usize::try_from(*count).ok()?;
@@ -147,6 +139,111 @@ pub(crate) fn compute_copy_record_layout(
     }
 
     // Round the total size up to the struct's natural alignment.
+    let total_size = align_up(offset, max_align);
+    if total_size == 0 {
+        return None;
+    }
+
+    Some((total_size, max_align))
+}
+
+/// Slot-blob size/alignment of a hash-key leaf, admitting `string` as a single
+/// owned pointer in addition to the fixed-size Copy primitives.
+///
+/// This is the hash-key counterpart of [`primitive_copy_layout`] and must NOT be
+/// confused with it: `primitive_copy_layout` is the **Copy authority** (`None`
+/// for `string`) consulted by `vec_element_has_copy_layout` and the by-value
+/// aggregate-param check, where a `string` field makes a type non-Copy. Here we
+/// answer a different question — "what is the byte layout of this leaf when it
+/// sits in a `HashMap` key slot?" — for which a `string` is a pointer-width blob
+/// (its heap payload is hashed by descent and freed by the per-record key drop
+/// thunk). Eligibility (`ty_is_hash_eligible`) gates which leaves reach this
+/// sizer; this only computes the layout of an already-admitted key.
+fn primitive_hash_key_layout(
+    ty: &Ty,
+    type_defs: &HashMap<String, TypeDef>,
+) -> Option<(usize, usize)> {
+    match ty {
+        // String slot blob: a single owned `*const c_char` (pointer-width /
+        // pointer-aligned; 8/8 on the 64-bit targets this sizer serves).
+        Ty::String => Some((8, 8)),
+        Ty::Array(elem, count) => {
+            let (elem_size, elem_align) = primitive_hash_key_layout(elem, type_defs)?;
+            let count = usize::try_from(*count).ok()?;
+            Some((elem_size.checked_mul(count)?, elem_align))
+        }
+        Ty::Named { name, args, .. } => {
+            let type_def = type_defs.get(name.as_str()).or_else(|| {
+                name.split_once('.')
+                    .and_then(|(_, local)| type_defs.get(local))
+            })?;
+            if args.is_empty() {
+                hash_key_record_layout(type_def, type_defs)
+            } else {
+                if type_def.type_params.len() != args.len() {
+                    return None;
+                }
+                let subst: HashMap<String, Ty> = type_def
+                    .type_params
+                    .iter()
+                    .zip(args.iter())
+                    .map(|(param, arg)| (param.clone(), arg.clone()))
+                    .collect();
+                let mut instantiated = type_def.clone();
+                instantiated.fields = type_def
+                    .fields
+                    .iter()
+                    .map(|(field, ty)| (field.clone(), ty.substitute_named_params_parallel(&subst)))
+                    .collect();
+                hash_key_record_layout(&instantiated, type_defs)
+            }
+        }
+        // All other leaves: defer to the Copy sizer (fixed-size primitives /
+        // nested Copy records). A non-Copy, non-string leaf returns `None`,
+        // matching `ty_is_hash_eligible`'s fail-closed conjunction.
+        _ => primitive_copy_layout(ty, type_defs),
+    }
+}
+
+/// `(total_size, max_align)` for a hash-key record whose fields are each
+/// hash-eligible-or-`string`. The hash-key counterpart of
+/// [`compute_copy_record_layout`]: identical field-walk and padding rules, but
+/// it sizes a `string` field as a pointer blob via [`primitive_hash_key_layout`]
+/// rather than rejecting it. Used only at the HashMap/HashSet key/element
+/// admission sites; never as a Copy-ness decision.
+pub(crate) fn hash_key_record_layout(
+    type_def: &TypeDef,
+    type_defs: &HashMap<String, TypeDef>,
+) -> Option<(usize, usize)> {
+    if type_def.fields.is_empty() {
+        return None;
+    }
+
+    let mut offset: usize = 0;
+    let mut max_align: usize = 1;
+
+    let ordered_names: Vec<&String>;
+    let mut alpha_sorted: Vec<&String>;
+    let field_names: &[&String] = if type_def.field_order.is_empty() {
+        alpha_sorted = type_def.fields.keys().collect();
+        alpha_sorted.sort();
+        &alpha_sorted
+    } else {
+        ordered_names = type_def.field_order.iter().collect();
+        &ordered_names
+    };
+
+    for name in field_names {
+        let field_ty = type_def.fields.get(*name)?;
+        let (field_size, field_align) = primitive_hash_key_layout(field_ty, type_defs)?;
+
+        offset = align_up(offset, field_align);
+        offset = offset.checked_add(field_size)?;
+        if field_align > max_align {
+            max_align = field_align;
+        }
+    }
+
     let total_size = align_up(offset, max_align);
     if total_size == 0 {
         return None;
@@ -2967,13 +3064,51 @@ mod tests {
     }
 
     #[test]
-    fn primitive_copy_layout_string_is_pointer_width() {
-        // A `string` field's in-record slot blob is a single owned pointer; the
-        // heap payload lives elsewhere and is hashed/dropped by descent.
+    fn primitive_copy_layout_string_returns_none() {
+        // String is heap-managed; not a fixed-layout Copy type. The hash-key
+        // sizer (`primitive_hash_key_layout`) admits it separately as a pointer
+        // blob — `primitive_copy_layout` stays the Copy authority.
+        assert_eq!(primitive_copy_layout(&Ty::String, &HashMap::new()), None);
+    }
+
+    #[test]
+    fn primitive_hash_key_layout_string_is_pointer_width() {
+        // The hash-key sizer admits a `string` leaf as a single owned pointer
+        // (the heap payload lives elsewhere and is hashed/dropped by descent).
         assert_eq!(
-            primitive_copy_layout(&Ty::String, &HashMap::new()),
+            primitive_hash_key_layout(&Ty::String, &HashMap::new()),
             Some((8, 8))
         );
+    }
+
+    #[test]
+    fn hash_key_record_layout_admits_string_field() {
+        // A record key with a string field has a well-defined slot layout: the
+        // string is a pointer-width blob, sized after the i64 field.
+        let mut tds = HashMap::new();
+        tds.insert(
+            "Person".to_string(),
+            TypeDef {
+                kind: TypeDefKind::Record,
+                name: "Person".to_string(),
+                type_params: vec![],
+                bounds: HashMap::new(),
+                fields: [
+                    ("name".to_string(), Ty::String),
+                    ("age".to_string(), Ty::I64),
+                ]
+                .into_iter()
+                .collect(),
+                field_order: vec!["name".to_string(), "age".to_string()],
+                variants: HashMap::new(),
+                methods: HashMap::new(),
+                doc_comment: None,
+                is_indirect: false,
+            },
+        );
+        let td = tds.get("Person").unwrap().clone();
+        // name (8/8 pointer) + age (8/8) => 16 bytes, align 8.
+        assert_eq!(hash_key_record_layout(&td, &tds), Some((16, 8)));
     }
 
     #[test]

--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -41,7 +41,15 @@ pub(crate) fn primitive_copy_layout(
         // for completeness so this function can serve as a general primitive sizer.
         Ty::I32 | Ty::U32 | Ty::Char | Ty::F32 => Some((4, 4)),
         // f64 is hash-ineligible but included for the same reason.
-        Ty::I64 | Ty::U64 | Ty::Duration | Ty::F64 => Some((8, 8)),
+        //
+        // String: the in-record slot blob is a single owned `*const c_char`
+        // pointer (the heap payload lives elsewhere). Pointer-width / pointer-
+        // aligned (8/8 on the 64-bit targets this sizer serves, matching the
+        // hardcoded 8-byte primitives above). Eligibility (`ty_is_hash_eligible`)
+        // gates admission; the owned string is hashed by payload-descent and
+        // dropped via the per-record key drop thunk (codegen). Hash/Eq remain
+        // structural.
+        Ty::I64 | Ty::U64 | Ty::Duration | Ty::F64 | Ty::String => Some((8, 8)),
         Ty::Array(elem, count) => {
             let (elem_size, elem_align) = primitive_copy_layout(elem, type_defs)?;
             let count = usize::try_from(*count).ok()?;
@@ -2959,9 +2967,13 @@ mod tests {
     }
 
     #[test]
-    fn primitive_copy_layout_string_returns_none() {
-        // String is heap-managed; not a fixed-layout Copy type.
-        assert_eq!(primitive_copy_layout(&Ty::String, &HashMap::new()), None);
+    fn primitive_copy_layout_string_is_pointer_width() {
+        // A `string` field's in-record slot blob is a single owned pointer; the
+        // heap payload lives elsewhere and is hashed/dropped by descent.
+        assert_eq!(
+            primitive_copy_layout(&Ty::String, &HashMap::new()),
+            Some((8, 8))
+        );
     }
 
     #[test]

--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -3615,8 +3615,11 @@ mod tests {
     // ── Additional admissibility tests from independent review ────────────────
 
     #[test]
-    fn hashmap_string_field_key_rejected() {
-        // record K { s: string } — string field makes K ineligible (IneligibleManaged)
+    fn hashmap_string_field_key_admitted() {
+        // record K { s: string } — a string field is structurally hashable, so
+        // K is admitted as a layout key (string field hashed by descent, owned
+        // key dropped via the per-record key drop thunk). A layout fact is
+        // produced and no diagnostic is emitted.
         let mut checker = Checker::new(ModuleRegistry::new(vec![]));
         let span = 1..10;
         let mut td = make_record("K", vec![("s", Ty::String)]);
@@ -3634,19 +3637,13 @@ mod tests {
         );
         checker.finalize_hashmap_admission();
         assert!(
-            !checker.errors.is_empty(),
-            "string-field key must be rejected; errors: {:?}",
+            checker.errors.is_empty(),
+            "string-field key must be admitted; errors: {:?}",
             checker.errors
         );
         assert!(
-            checker.hashmap_layout_facts.is_empty(),
-            "no layout fact must be produced for string-field key"
-        );
-        // Diagnostic must name the field or type clearly
-        let msg = &checker.errors[0].message;
-        assert!(
-            msg.contains('K') || msg.contains("string"),
-            "error must reference the type or field kind; got: {msg:?}"
+            !checker.hashmap_layout_facts.is_empty(),
+            "a layout fact must be produced for an admitted string-field key"
         );
     }
 

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -4,7 +4,7 @@
 )]
 use super::*;
 use crate::builtin_names::BuiltinNamedType;
-use crate::check::admissibility::compute_copy_record_layout;
+use crate::check::admissibility::{compute_copy_record_layout, hash_key_record_layout};
 use crate::check::calls::SignatureArgApplication;
 use crate::check::dispatch::resolve_method_call;
 use crate::check::types::BareActorResolution;
@@ -433,8 +433,11 @@ impl Checker {
                         match ty_is_hash_eligible(&resolved_ty, &type_defs_snapshot) {
                             HashEligibility::Eligible => {
                                 if let Some(ref td) = self.lookup_type_def(name) {
+                                    // hash-key sizer: admits string-bearing
+                                    // records (string field => pointer blob),
+                                    // unlike the Copy sizer.
                                     if let Some((elem_size, elem_align)) =
-                                        compute_copy_record_layout(td, &type_defs_snapshot)
+                                        hash_key_record_layout(td, &type_defs_snapshot)
                                     {
                                         let fact = hashset_layout_fact(
                                             name.clone(),
@@ -668,7 +671,10 @@ impl Checker {
                         let key_type_def = self.lookup_type_def(key_name);
                         match key_type_def {
                             Some(ref td) => {
-                                match compute_copy_record_layout(td, &type_defs_snapshot) {
+                                // hash-key sizer: admits a string-bearing record
+                                // key (string field => pointer-width slot blob),
+                                // unlike the Copy sizer used for values.
+                                match hash_key_record_layout(td, &type_defs_snapshot) {
                                     Some((key_size, key_align)) => {
                                         // Determine value type routing.
                                         match HashMapValueType::from_ty(&resolved_val) {

--- a/hew-types/src/hash_eligibility.rs
+++ b/hew-types/src/hash_eligibility.rs
@@ -15,11 +15,17 @@
 //! hash-equality contract: two NaN values may be `!=` yet hash to the same bucket,
 //! making every `HashMap<FloatRecord, V>` lookup semantically broken.
 //!
-//! Strings and other heap-managed types are ineligible because layout-ABI hashing
-//! operates on the fixed-size stack blob, not the heap contents. String equality
-//! must go through the existing string-ABI path, not the layout path.
+//! Strings are heap-managed but structurally hashable: a `string` field inside a
+//! record key is hashed by dereferencing the field's pointer and hashing the
+//! NUL-terminated payload bytes (codegen descends into the field, mirroring the
+//! `eq_eligibility.rs` string descent), and the owned key is deep-cloned on
+//! insert and dropped exactly once on remove/free. A bare `string` key routes
+//! through the runtime's canonical `hew_layout_key_string` descriptor. Other
+//! heap-managed leaves (`bytes`, owned aggregates, handles) remain ineligible —
+//! their per-record clone/drop discipline is a separate, larger surface.
 //!
-//! Named records are eligible only when every field is itself hash-eligible.
+//! Named records are eligible only when every field is itself hash-eligible
+//! (including `string`-or-string-bearing fields).
 //! Indirect (handle/managed) records are ineligible regardless of field content.
 //! Tuples are tracked but ineligible as layout hash keys in this slice; the
 //! admissibility gate (C-2c) will reject them before they reach codegen.
@@ -64,6 +70,15 @@ fn hash_ineligibility(ty: &Ty, type_defs: &HashMap<String, TypeDef>) -> Option<H
         // Fixed-width integer primitives — hash the exact-width value load.
         // bool: hash the low bit as i8. char: hash 4-byte Unicode scalar as i32.
         // Duration: hash 8-byte i64 nanosecond value — deterministic fixed width.
+        // Fixed-width primitives hash on the exact-width value load.
+        //
+        // String is heap-managed but structurally hashable: a bare `string` key
+        // routes through the runtime's `hew_layout_key_string` descriptor, and a
+        // `string` field *inside* a record key is hashed by descending into the
+        // payload bytes (codegen) and dropped exactly once on remove/free via a
+        // per-record drop thunk. The owned-string deep-clone-on-insert / drop
+        // discipline mirrors the already-shipped eq side (`eq_eligibility.rs`,
+        // `Ty::String => None`), so admit it here too — eligible like a primitive.
         Ty::I8
         | Ty::I16
         | Ty::I32
@@ -74,13 +89,11 @@ fn hash_ineligibility(ty: &Ty, type_defs: &HashMap<String, TypeDef>) -> Option<H
         | Ty::U64
         | Ty::Bool
         | Ty::Char
-        | Ty::Duration => None,
+        | Ty::Duration
+        | Ty::String => None,
 
         // Floats: NaN != NaN violates the hash-equality contract.
         Ty::F32 | Ty::F64 => Some(HashEligibility::IneligibleFloat(ty.clone())),
-
-        // String: heap-managed; hashing must go through the string ABI, not layout.
-        Ty::String => Some(HashEligibility::IneligibleManaged(ty.clone())),
 
         // Tuples: tracked but not admitted as layout hash keys in this slice.
         Ty::Tuple(_) => Some(HashEligibility::IneligibleTuple(ty.clone())),
@@ -252,11 +265,13 @@ mod tests {
     }
 
     #[test]
-    fn hash_ineligible_string() {
+    fn hash_eligible_string() {
+        // A bare `string` is structurally hashable (routed through the runtime's
+        // canonical `hew_layout_key_string` descriptor at the key-layout seam).
         let tds = empty_type_defs();
         assert_eq!(
             ty_is_hash_eligible(&Ty::String, &tds),
-            HashEligibility::IneligibleManaged(Ty::String)
+            HashEligibility::Eligible
         );
     }
 
@@ -286,16 +301,38 @@ mod tests {
     }
 
     #[test]
-    fn hash_ineligible_record_with_string_field() {
+    fn hash_eligible_record_with_string_field() {
+        // A record key whose every field is hash-eligible-or-string is admitted:
+        // codegen descends into the string field to hash its payload, and a
+        // per-record drop thunk frees the owned string on remove/free.
         let mut tds = HashMap::new();
         tds.insert(
             "Named".to_string(),
-            make_record("Named", vec![("label", Ty::String)], false),
+            make_record(
+                "Named",
+                vec![("label", Ty::String), ("age", Ty::I64)],
+                false,
+            ),
         );
         let ty = Ty::normalize_named("Named".to_string(), vec![]);
+        assert_eq!(ty_is_hash_eligible(&ty, &tds), HashEligibility::Eligible);
+    }
+
+    #[test]
+    fn hash_ineligible_record_with_owned_vec_field() {
+        // The eligibility predicate stays a conjunction over leaves: an owned
+        // `Vec<T>` field is not hash-eligible (its per-key deep clone/drop is a
+        // larger surface), so the record key stays rejected fail-closed.
+        let mut tds = HashMap::new();
+        let vec_field = Ty::normalize_named("Vec".to_string(), vec![Ty::I64]);
+        tds.insert(
+            "Bag".to_string(),
+            make_record("Bag", vec![("items", vec_field.clone())], false),
+        );
+        let ty = Ty::normalize_named("Bag".to_string(), vec![]);
         assert_eq!(
             ty_is_hash_eligible(&ty, &tds),
-            HashEligibility::IneligibleManaged(Ty::String)
+            HashEligibility::IneligibleOwned(vec_field)
         );
     }
 

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -529,6 +529,7 @@ stable = [
   "hew_string_equals",
   "hew_string_find",
   "hew_string_from_char",
+  "hew_string_hash_fnv1a",
   "hew_string_index",
   "hew_string_index_of",
   "hew_string_index_of_start",

--- a/tests/vertical-slice/accept/hashmap_managed_key_drop.hew
+++ b/tests/vertical-slice/accept/hashmap_managed_key_drop.hew
@@ -1,0 +1,29 @@
+// Accept fixture (owned-key drop ratchet): churn a HashMap<Person, i64> with an
+// owned `string` key field through insert / overwrite / remove / map-free so the
+// per-record key drop thunk fires on every release path. Run under the guard
+// allocator (MallocScribble / MallocGuardEdges) in CI: each owned string key is
+// dropped exactly once, with no double-free and no scribble-read.
+
+record Person { name: string, age: i64 }
+
+fn churn() -> i64 {
+    let m: HashMap<Person, i64> = HashMap::new();
+    var i = 0;
+    while i < 64 {
+        m.insert(Person { name: "user", age: i }, i);
+        i = i + 1;
+    }
+    // Overwrite an existing key: the new value replaces the old; the slot key is
+    // reused (not re-cloned), the caller's probe key is the caller's to drop.
+    m.insert(Person { name: "user", age: 10 }, 999);
+    // Remove drops the slot key exactly once.
+    if !m.remove(Person { name: "user", age: 20 }) { return 40; }
+    if m.len() != 63 { return 41; }
+    if match m.get(Person { name: "user", age: 10 }) { Some(v) => v, None => -1 } != 999 {
+        return 42;
+    }
+    // Map-free at scope end drops every remaining owned key exactly once.
+    0
+}
+
+fn main() -> i64 { churn() }

--- a/tests/vertical-slice/accept/hashmap_managed_record_key.hew
+++ b/tests/vertical-slice/accept/hashmap_managed_record_key.hew
@@ -1,0 +1,37 @@
+// Accept fixture: HashMap keyed by a record with a `string` field.
+//
+// Exercises the structural hash + owned-key drop discipline for a managed
+// record key end to end: distinct-but-equal keys (same name, different age)
+// land in distinct slots; equal-by-fields keys collide and overwrite; get on
+// an absent key returns None; remove drops the owned slot key exactly once.
+//
+// Exit code encodes the verification: each failed assertion returns a distinct
+// non-zero code, so a green run (exit 0) means every value-oracle held.
+
+record Person { name: string, age: i64 }
+
+fn main() -> i64 {
+    let m: HashMap<Person, i64> = HashMap::new();
+    m.insert(Person { name: "alice", age: 30 }, 1);
+    m.insert(Person { name: "bob", age: 25 }, 2);
+    // Distinct: same name, different age => a different slot.
+    m.insert(Person { name: "alice", age: 31 }, 3);
+    // Collision: equal by every field => overwrite the existing slot's value.
+    m.insert(Person { name: "bob", age: 25 }, 99);
+
+    let a30 = match m.get(Person { name: "alice", age: 30 }) { Some(v) => v, None => -1 };
+    let a31 = match m.get(Person { name: "alice", age: 31 }) { Some(v) => v, None => -1 };
+    let b = match m.get(Person { name: "bob", age: 25 }) { Some(v) => v, None => -1 };
+    let missing = match m.get(Person { name: "carol", age: 0 }) { Some(v) => v, None => -1 };
+
+    if a30 != 1 { return 10; }
+    if a31 != 3 { return 11; }
+    if b != 99 { return 12; }
+    if missing != -1 { return 13; }
+    if m.len() != 3 { return 14; }
+
+    // Remove drops the owned slot key exactly once; the key is then absent.
+    if !m.remove(Person { name: "alice", age: 30 }) { return 20; }
+    if m.len() != 2 { return 21; }
+    match m.get(Person { name: "alice", age: 30 }) { Some(_) => 22, None => 0 }
+}

--- a/tests/vertical-slice/accept/hashset_managed_record_elem.hew
+++ b/tests/vertical-slice/accept/hashset_managed_record_elem.hew
@@ -1,0 +1,22 @@
+// Accept fixture: HashSet of a record with a `string` field.
+//
+// A HashSet over a managed record element shares the same key eligibility and
+// the same structural hash + owned-key drop discipline as a HashMap key. This
+// pins dedupe (equal-by-fields elements collapse to one slot) and membership
+// (contains is true for an equal-by-value probe, false for a distinct one).
+
+record Tag { name: string, kind: i64 }
+
+fn main() -> i64 {
+    let s: HashSet<Tag> = HashSet::new();
+    s.insert(Tag { name: "red", kind: 1 });
+    s.insert(Tag { name: "red", kind: 1 });   // duplicate => no new slot
+    s.insert(Tag { name: "blue", kind: 2 });
+    s.insert(Tag { name: "red", kind: 9 });   // same name, different kind => distinct
+
+    if s.len() != 3 { return 30; }
+    if !s.contains(Tag { name: "red", kind: 1 }) { return 31; }
+    if !s.contains(Tag { name: "red", kind: 9 }) { return 32; }
+    if s.contains(Tag { name: "green", kind: 1 }) { return 33; }
+    0
+}

--- a/tests/vertical-slice/reject/hashmap_key_owned_vec_field.hew
+++ b/tests/vertical-slice/reject/hashmap_key_owned_vec_field.hew
@@ -1,0 +1,13 @@
+// Reject ratchet (boundary): a record key whose field is an owned `Vec<T>` is
+// NOT hash-eligible. The eligibility predicate stays a conjunction over leaves:
+// admitting `string` leaves does not admit owned-aggregate leaves, whose
+// per-key deep clone/drop is a larger surface. The key stays rejected
+// fail-closed at the checker, before any codegen.
+
+record Bag { items: Vec<i64>, id: i64 }
+
+fn main() {
+    let m: HashMap<Bag, i64> = HashMap::new();
+    let xs: Vec<i64> = Vec::new();
+    m.insert(Bag { items: xs, id: 1 }, 7);
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -379,6 +379,24 @@ run_accept_expect_status "hashmap_for_in_call" 66
 # MallocGuardEdges) alongside the other owned for-in fixtures.
 run_accept_expect_status "hashset_for_in_field_owned" 9
 
+# Generic HashMap<K, V> over a record key with a `string` field. The key is
+# hashed by descending into the string payload (not the pointer word), compared
+# by the structural eq thunk, and dropped exactly once on remove/free via the
+# per-record key drop thunk (LayoutManaged ownership). Each fixture's exit code
+# encodes a value oracle; 0 means every assertion held.
+# Insert / get / overwrite / remove / distinct-vs-collision oracle.
+run_accept_expect_status "hashmap_managed_record_key" 0
+# HashSet over a record element with a string field: dedupe + membership oracle.
+run_accept_expect_status "hashset_managed_record_elem" 0
+# Owned-key drop ratchet: insert/overwrite/remove/free churn of owned string
+# keys. Verified clean under the guard allocator (MallocScribble / GuardEdges).
+run_accept_expect_status "hashmap_managed_key_drop" 0
+# Boundary: a record key with an owned Vec<T> field stays rejected fail-closed.
+expect_check_fail_contains \
+  "${ROOT}/tests/vertical-slice/reject/hashmap_key_owned_vec_field.hew" \
+  "is not a fixed-size Copy type" \
+  "hashmap_key_owned_vec_field"
+
 # Reject: spawned closures must not capture non-Send values. This fixture uses
 # a real Checker-produced `Rc<i64>` capture fact and asserts the targeted HIR
 # diagnostic rather than unrelated Rc construction or lowering diagnostics.


### PR DESCRIPTION
## Summary

`HashMap<K,V>` and `HashSet<T>` now accept string-bearing record keys (and bare `string` keys). Structural hashing descends string fields via `hew_string_hash_fnv1a` (FNV-1a-64), which is the hash twin of structural equality — equal-by-fields keys hash identically. Managed-record keys are owned: the key blob is moved into the slot on insert (no copy/retain), and the per-record drop fires exactly once on remove, overwrite, and free.

Keys with owned `Vec<T>` or `bytes` fields, float keys, and other non-fixed-size-Copy shapes are rejected fail-closed at the checker boundary.

## Verification

- `cargo test -p hew-types`: 51 pass, including the flipped admissibility/eligibility tests and the new owned-Vec reject ratchet (`IneligibleOwned`).
- `cargo test -p hew-runtime string`: pass; `fnv1a_64_matches_known_vectors` confirms the canonical FNV-1a-64-64 vectors.
- Vertical slice — new fixtures:
  - `PASS hashmap_managed_record_key` — insert/get/overwrite/remove/distinct/collision/nested record key value oracle.
  - `PASS hashset_managed_record_elem` — dedupe and membership oracle.
  - `PASS hashmap_managed_key_drop` — insert/overwrite/remove/free drop-churn oracle.
  - `PASS hashmap_key_owned_vec_field` (reject ratchet) — checker rejects an owned-Vec-field key with "is not a fixed-size Copy type".
- Guard Malloc (`MallocScribble=1 MallocGuardEdges=1 MallocPreScribble=1`): all three owned-key fixtures exit 0 — no double-free, no UAF, no scribble-read.
- `leaks --atExit`: 0 leaks for 0 total leaked bytes on all three fixtures including overwrite paths — drop fires exactly once, no overwrite-path key leak.
- Copy-layout authority preserved: a record with a `string` field remains non-Copy and is correctly rejected for by-value-aggregate uses (separate reject ratchet).
- Float key (`f32`/`f64`): `IneligibleFloat` — rejected.
- Preflight: ready-to-push.

## Out of scope

- Map clone over managed keys and `keys()`/`values()` iteration over managed keys — kept fail-closed/NYI.
- Sandbox-VM `HashMap` — native-only for this change; sandbox divergence tracked separately.
