### PR TITLE
feat(hir,mir,codegen): supervisor child init args at all integer widths and nested accessor

### DIFF
--- a/hew-cli/tests/supervisor_init_args_e2e.rs
+++ b/hew-cli/tests/supervisor_init_args_e2e.rs
@@ -195,6 +195,126 @@ fn main() {
     );
 }
 
+/// Every narrow and unsigned integer width is seeded width-exact: i8, i16,
+/// u8, u16, u32, u64 fields packed in reversed declaration order must each
+/// carry the correct value at runtime.
+///
+/// This is the regression test for NYI #4 (narrow/unsigned init-arg widths).
+/// Before the fix, the MIR post-loop pass emitted `NotYetImplemented` for any
+/// integer literal against a sub-i32 or unsigned field. The values are chosen
+/// to use the high bit of each width (u8=200, u16=60000, u32=4000000000,
+/// u64=18000000000) so a wrong-width store, or a sign-extension instead of a
+/// zero-extension, would corrupt the value or clobber an adjacent field.
+///
+/// The actor compares each field against its expected value and prints a
+/// match-count: narrow integer widths are not `Display`-printable directly, so
+/// an equality oracle is the width-exact assertion (each `==` is evaluated at
+/// the field's own width). `ok=6` means every field round-tripped exactly.
+///
+/// Green condition: exit 0 AND stdout contains "ok=6".
+#[test]
+fn supervisor_child_narrow_and_unsigned_widths_reversed_arg_order() {
+    require_codegen();
+
+    let source = r#"actor Worker {
+    let a: i8;
+    let b: i16;
+    let c: u8;
+    let d: u16;
+    let e: u32;
+    let f: u64;
+    receive fn report() {
+        var ok: i64 = 0;
+        if a == 120 { ok = ok + 1; }
+        if b == 30000 { ok = ok + 1; }
+        if c == 200 { ok = ok + 1; }
+        if d == 60000 { ok = ok + 1; }
+        if e == 4000000000 { ok = ok + 1; }
+        if f == 18000000000 { ok = ok + 1; }
+        print("ok="); println(ok);
+    }
+}
+supervisor Pool {
+    strategy: one_for_one;
+    intensity: 3 within 60s;
+    child w: Worker(f: 18000000000, e: 4000000000, d: 60000, c: 200, b: 30000, a: 120);
+}
+fn main() {
+    let sup = spawn Pool;
+    sleep_ms(30);
+    let w = sup.w;
+    w.report();
+    sleep_ms(50);
+}
+"#;
+
+    let (_dir, path) = write_fixture(source);
+
+    let output = Command::new(hew_binary())
+        .args(["run", path.to_str().unwrap()])
+        .output()
+        .expect("hew binary must run");
+
+    let stdout = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(
+        output.status.success(),
+        "narrow/unsigned width init-args oracle must exit 0; stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("ok=6"),
+        "every narrow/unsigned init arg must be seeded width-exact (ok=6); \
+         got stdout: {stdout}"
+    );
+}
+
+/// An init-arg literal that overflows its declared narrow field is a compile
+/// error, not a silent truncation: u8 cannot hold 300.
+///
+/// Green condition: `hew check` exits non-zero.
+#[test]
+fn supervisor_child_narrow_width_overflow_is_compile_error() {
+    require_codegen();
+
+    let source = r#"actor Worker {
+    let a: u8;
+    receive fn report() { print("a="); println(a); }
+}
+supervisor Pool {
+    strategy: one_for_one;
+    intensity: 3 within 60s;
+    child w: Worker(a: 300);
+}
+fn main() {
+    let sup = spawn Pool;
+    sleep_ms(30);
+    let w = sup.w;
+    w.report();
+    sleep_ms(50);
+}
+"#;
+
+    let (_dir, path) = write_fixture(source);
+
+    let output = Command::new(hew_binary())
+        .args(["check", path.to_str().unwrap()])
+        .output()
+        .expect("hew binary must run");
+
+    assert!(
+        !output.status.success(),
+        "an init-arg literal that overflows its declared narrow field (u8 = 300) \
+         must be a compile error, not a silent truncation"
+    );
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        stderr.contains("does not fit in `u8`"),
+        "the overflow diagnostic must name the field width; stderr: {stderr}"
+    );
+}
+
 /// A supervisor with a stateful child actor but no init args must fail at
 /// compile time (`CodegenError::FailClosed`), not at runtime with a SIGSEGV.
 ///

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -6563,9 +6563,23 @@ fn emit_supervisor_child_spec_and_register<'ctx>(
                         ))
                     })?;
 
+                // Materialise each init arg at the field's exact width. LLVM
+                // integer types are sign-agnostic — the const's bit pattern
+                // carries the value — so the unsigned variants share the same
+                // `iN` type as their signed siblings; `build_store` then writes
+                // exactly N/8 bytes into the field slot. The signed widths
+                // sign-extend the literal into the const (`true`); the unsigned
+                // widths zero-extend (`false`), so a value that uses the high
+                // bit (e.g. `u8` 200) keeps its bit pattern.
                 let field_val: BasicValueEnum<'ctx> = match init_arg {
-                    ChildInitArg::I64(n) => i64_ty.const_int(*n as u64, true).into(),
+                    ChildInitArg::I8(n) => ctx.i8_type().const_int(*n as u64, true).into(),
+                    ChildInitArg::I16(n) => ctx.i16_type().const_int(*n as u64, true).into(),
                     ChildInitArg::I32(n) => i32_ty.const_int(*n as u64, true).into(),
+                    ChildInitArg::I64(n) => i64_ty.const_int(*n as u64, true).into(),
+                    ChildInitArg::U8(n) => ctx.i8_type().const_int(u64::from(*n), false).into(),
+                    ChildInitArg::U16(n) => ctx.i16_type().const_int(u64::from(*n), false).into(),
+                    ChildInitArg::U32(n) => i32_ty.const_int(u64::from(*n), false).into(),
+                    ChildInitArg::U64(n) => i64_ty.const_int(*n, false).into(),
                     ChildInitArg::Bool(b) => ctx
                         .bool_type()
                         .const_int(if *b { 1 } else { 0 }, false)

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -2604,6 +2604,17 @@ pub(crate) fn intern_runtime_decl<'ctx>(
         // Returns 0 on success or -1 on null/OOM; the bootstrap currently
         // discards the result — restart/diagnostic wiring lands in a follow-on.
         "hew_supervisor_add_child_spec" => i32_ty.fn_type(&[ptr_ty.into(), ptr_ty.into()], false),
+        // hew_supervisor_add_child_supervisor_with_init(
+        //     parent: *mut HewSupervisor, child: *mut HewSupervisor,
+        //     init_fn: SupervisorInitFn) -> c_int
+        // (`hew-runtime/src/supervisor.rs:3664`). Attaches an already-started
+        // child supervisor (returned by its own bootstrap) to `parent` and
+        // records the bootstrap as the restart init_fn for subtree escalation.
+        // Sets the child's parent back-pointer and unregisters it from the
+        // top-level shutdown list. Returns 0 on success, -1 on null/self.
+        "hew_supervisor_add_child_supervisor_with_init" => {
+            i32_ty.fn_type(&[ptr_ty.into(), ptr_ty.into(), ptr_ty.into()], false)
+        }
         // hew_supervisor_set_child_state_clone(sup: *mut HewSupervisor,
         //                                      child_index: c_int,
         //                                      state_clone_fn: HewStateCloneFn) -> void
@@ -6324,23 +6335,59 @@ fn emit_supervisor_bootstrap_body<'ctx>(
         &mut runtime_decls,
         "hew_supervisor_set_child_lifecycle",
     )?;
-    for (idx, child) in layout.children.iter().enumerate() {
-        emit_supervisor_child_spec_and_register(
-            ctx,
-            llvm_mod,
-            &builder,
-            &child_spec_ty,
-            sup,
-            add_child_spec,
-            set_child_state_drop,
-            set_child_state_clone,
-            set_child_lifecycle,
-            idx,
-            child,
-            &layout.name,
-            actor_layouts,
-            record_layouts,
-        )?;
+    // A nested-supervisor child (`child api: AuthSupervisor;`) registers through
+    // a different runtime seam than an actor child: call the child supervisor's
+    // own bootstrap function (which builds and starts the child supervisor and
+    // returns its `*mut HewSupervisor`), then register it with the parent via
+    // `hew_supervisor_add_child_supervisor_with_init`, passing the same
+    // bootstrap as the restart init_fn. Interned once outside the loop so all
+    // nested children share the same FunctionValue.
+    let add_child_supervisor_with_init = intern_runtime_decl(
+        ctx,
+        llvm_mod,
+        &mut runtime_decls,
+        "hew_supervisor_add_child_supervisor_with_init",
+    )?;
+    // Actor children and nested supervisors are registered into two separate
+    // runtime tables, each 0-based. `hew_supervisor_add_child_spec` pushes actor
+    // children sequentially into `children[]`, so an actor child's runtime index
+    // is its position among ACTOR children only — NOT the combined loop index.
+    // The per-child setters (`set_child_state_drop/clone/lifecycle`) key by that
+    // runtime index, so passing the combined loop index would target the wrong
+    // slot whenever a nested supervisor precedes an actor child. Track an
+    // actor-only counter that advances only for actor children, mirroring the
+    // accessor's `partitioned_static_slot_index`.
+    let mut actor_child_index = 0usize;
+    for child in &layout.children {
+        if let Some(nested_bootstrap) = &child.nested_bootstrap_symbol {
+            emit_nested_supervisor_register(
+                llvm_mod,
+                &builder,
+                sup,
+                add_child_supervisor_with_init,
+                nested_bootstrap,
+                child,
+                &layout.name,
+            )?;
+        } else {
+            emit_supervisor_child_spec_and_register(
+                ctx,
+                llvm_mod,
+                &builder,
+                &child_spec_ty,
+                sup,
+                add_child_spec,
+                set_child_state_drop,
+                set_child_state_clone,
+                set_child_lifecycle,
+                actor_child_index,
+                child,
+                &layout.name,
+                actor_layouts,
+                record_layouts,
+            )?;
+            actor_child_index += 1;
+        }
     }
 
     // ── %rc = call hew_supervisor_start(%sup); trap on non-zero ─────────
@@ -6383,6 +6430,72 @@ fn emit_supervisor_bootstrap_body<'ctx>(
     builder
         .build_return(Some(&sup))
         .llvm_ctx("sup bootstrap ret")?;
+    Ok(())
+}
+
+/// Register a nested-supervisor child with its parent.
+///
+/// Unlike an actor child (which lowers to a `HewChildSpec` + dispatch
+/// trampoline), a nested supervisor is brought up by its own bootstrap
+/// function — the same function `spawn ChildSupervisor` would call. That
+/// bootstrap builds the child supervisor, registers its children, starts it,
+/// and returns its `*mut HewSupervisor`. We then attach it to the parent via
+/// `hew_supervisor_add_child_supervisor_with_init`, passing the same bootstrap
+/// as the restart `init_fn` so the parent can rebuild the subtree on
+/// escalation.
+///
+/// The child's bootstrap is a real MIR function declared ahead of supervisor
+/// body emission; fail closed if it is missing — a null child supervisor would
+/// SIGSEGV at the first nested accessor.
+fn emit_nested_supervisor_register<'ctx>(
+    llvm_mod: &LlvmModule<'ctx>,
+    builder: &Builder<'ctx>,
+    sup: PointerValue<'ctx>,
+    add_child_supervisor_with_init: FunctionValue<'ctx>,
+    nested_bootstrap: &str,
+    child: &SupervisorChildLayout,
+    sup_name: &str,
+) -> CodegenResult<()> {
+    let bootstrap_fn = llvm_mod.get_function(nested_bootstrap).ok_or_else(|| {
+        CodegenError::FailClosed(format!(
+            "supervisor `{sup_name}` nested child `{}` requires the child supervisor \
+             bootstrap function `{nested_bootstrap}`, which was not declared before \
+             body emission",
+            child.name
+        ))
+    })?;
+
+    // %child_sup = call <nested_bootstrap>()
+    let child_sup = builder
+        .build_call(
+            bootstrap_fn,
+            &[],
+            &format!("nested_sup_{}_bootstrap", child.name),
+        )
+        .llvm_ctx("nested supervisor bootstrap call")?
+        .try_as_basic_value()
+        .basic()
+        .ok_or_else(|| {
+            CodegenError::FailClosed(format!(
+                "nested supervisor `{}` bootstrap `{nested_bootstrap}` returned void; \
+                 expected a *mut HewSupervisor",
+                child.name
+            ))
+        })?
+        .into_pointer_value();
+
+    // call hew_supervisor_add_child_supervisor_with_init(%parent, %child_sup,
+    //                                                    <nested_bootstrap>)
+    // The bootstrap doubles as the restart init_fn (() -> *mut HewSupervisor).
+    let init_fn_ptr = bootstrap_fn.as_global_value().as_pointer_value();
+    builder
+        .build_call(
+            add_child_supervisor_with_init,
+            &[sup.into(), child_sup.into(), init_fn_ptr.into()],
+            &format!("nested_sup_{}_register", child.name),
+        )
+        .llvm_ctx("hew_supervisor_add_child_supervisor_with_init call")?;
+
     Ok(())
 }
 

--- a/hew-codegen-rs/src/runtime_abi.rs
+++ b/hew-codegen-rs/src/runtime_abi.rs
@@ -2309,20 +2309,23 @@ pub(crate) fn lower_call_runtime_abi(
         //
         // WASM: `uses_wasm_excluded_symbol` gates this symbol before WASM
         //   emission; supervisor tree requires the native scheduler runtime.
-        F::SupervisorChildGet => {
+        // `hew_supervisor_child_get` (actor child) and `hew_supervisor_nested_get`
+        // (child supervisor) share an identical C ABI — `(ptr sup, u32 key) ->
+        // ChildLookupResult` — and identical struct-return handling. The only
+        // difference is the runtime symbol, which `symbol` (derived from the
+        // call's family) already carries, so both families ride this one arm.
+        F::SupervisorChildGet | F::SupervisorNestedGet => {
             if args.len() != 2 {
                 return Err(CodegenError::FailClosed(format!(
-                    "Instr::CallRuntimeAbi(hew_supervisor_child_get): expected 2 args \
-                     (sup, key), got {}",
+                    "Instr::CallRuntimeAbi({symbol}): expected 2 args (sup, key), got {}",
                     args.len()
                 )));
             }
             let dest_place = dest.ok_or_else(|| {
-                CodegenError::FailClosed(
-                    "hew_supervisor_child_get: producer must supply a dest place \
+                CodegenError::FailClosed(format!(
+                    "{symbol}: producer must supply a dest place \
                      (the __HewChildLookupResult alloca)"
-                        .to_string(),
-                )
+                ))
             })?;
 
             // arg0: supervisor handle — ptr-typed (ActorHandle or actor-derived ptr).
@@ -2369,7 +2372,7 @@ pub(crate) fn lower_call_runtime_abi(
                 fn_ctx.llvm_mod,
                 fn_ctx.target_data,
                 &triple_str,
-                "hew_supervisor_child_get",
+                symbol,
                 child_result_ty,
                 &[ptr_ty.into(), i32_ty.into()],
             )?;
@@ -2825,7 +2828,6 @@ pub(crate) fn lower_call_runtime_abi(
         // `Instr::CallRuntimeAbi`, so it has no MIR-ABI lowering arm here and
         // fails closed if it ever reaches this dispatch, like `BytesGet`.
         | F::StringGet
-        | F::SupervisorNestedGet
         | F::TcpAttachLocal
         | F::TaskCompleteThreaded
         | F::TaskCompletionObserve

--- a/hew-codegen-rs/tests/supervisor_emission.rs
+++ b/hew-codegen-rs/tests/supervisor_emission.rs
@@ -164,6 +164,7 @@ fn supervisor_pipeline() -> IrPipeline {
             max_heap_bytes: None,
             cycle_capable: false,
             init_state_fields: vec![],
+            nested_bootstrap_symbol: None,
         }],
     };
 
@@ -420,6 +421,7 @@ fn on_crash_pipeline() -> IrPipeline {
             max_heap_bytes: None,
             cycle_capable: false,
             init_state_fields: vec![],
+            nested_bootstrap_symbol: None,
         }],
     };
 
@@ -586,5 +588,218 @@ fn supervisor_bootstrap_rejects_invalid_window() {
     assert!(
         msg.contains("sixty") || msg.contains("duration literal"),
         "expected fail-closed diagnostic to name the bad window literal; got: {msg}"
+    );
+}
+
+/// Build a pipeline where `RootSupervisor` has one nested-supervisor child
+/// (`sub: InnerSupervisor`) and one actor child (`direct: Worker`). Both
+/// supervisor bootstrap functions are declared so the parent bootstrap can call
+/// the inner bootstrap and register it.
+fn nested_supervisor_pipeline() -> IrPipeline {
+    let root_bootstrap = "RootSupervisor__bootstrap".to_string();
+    let inner_bootstrap = "InnerSupervisor__bootstrap".to_string();
+
+    let worker_layout = ActorLayout {
+        name: "Worker".to_string(),
+        defining_module: None,
+        state_field_names: vec![],
+        state_field_tys: vec![],
+        state_field_defaults: vec![],
+        init_param_names: vec![],
+        init_param_tys: vec![],
+        init_symbol: None,
+        on_start_symbol: None,
+        on_stop_symbols: vec![],
+        on_crash_symbol: None,
+        max_heap_bytes: None,
+        cycle_capable: false,
+        handlers: vec![],
+        state_clone_fn_symbol: None,
+        state_drop_fn_symbol: None,
+        state_field_clone_kinds: None,
+    };
+
+    let stub_bootstrap = |symbol: &str, ret: ResolvedTy| RawMirFunction {
+        name: symbol.to_string(),
+        return_ty: ret.clone(),
+        call_conv: FunctionCallConv::Default,
+        params: vec![],
+        locals: vec![ret],
+        local_names: Vec::new(),
+        local_scopes: Vec::new(),
+        local_decl_bytes: Vec::new(),
+        scope_table: Vec::new(),
+        blocks: vec![BasicBlock {
+            id: 0,
+            statements: vec![],
+            instructions: vec![],
+            terminator: Terminator::Return,
+        }],
+        decisions: vec![],
+        intrinsic_id: None,
+        await_deadline_ns: std::collections::HashMap::new(),
+        suspend_kinds: std::collections::HashMap::new(),
+        lambda_actor_user_param_locals: Vec::new(),
+        span: None,
+        instr_spans: ::std::collections::BTreeMap::new(),
+    };
+
+    let root_fn = stub_bootstrap(&root_bootstrap, local_pid_of("RootSupervisor"));
+    let inner_fn = stub_bootstrap(&inner_bootstrap, local_pid_of("InnerSupervisor"));
+
+    let main_fn = RawMirFunction {
+        name: "main".to_string(),
+        return_ty: ResolvedTy::I64,
+        call_conv: FunctionCallConv::Default,
+        params: vec![],
+        locals: vec![ResolvedTy::I64],
+        local_names: Vec::new(),
+        local_scopes: Vec::new(),
+        local_decl_bytes: Vec::new(),
+        scope_table: Vec::new(),
+        blocks: vec![BasicBlock {
+            id: 0,
+            statements: vec![],
+            instructions: vec![
+                hew_mir::Instr::ConstI64 {
+                    dest: hew_mir::Place::Local(0),
+                    value: 0,
+                },
+                hew_mir::Instr::Move {
+                    dest: hew_mir::Place::ReturnSlot,
+                    src: hew_mir::Place::Local(0),
+                },
+            ],
+            terminator: Terminator::Return,
+        }],
+        decisions: vec![],
+        intrinsic_id: None,
+        await_deadline_ns: std::collections::HashMap::new(),
+        suspend_kinds: std::collections::HashMap::new(),
+        lambda_actor_user_param_locals: Vec::new(),
+        span: None,
+        instr_spans: ::std::collections::BTreeMap::new(),
+    };
+
+    let inner_layout = SupervisorLayout {
+        name: "InnerSupervisor".to_string(),
+        strategy: Some(HirSupervisorStrategy::OneForOne),
+        max_restarts: Some(3),
+        window: Some("60".to_string()),
+        bootstrap_symbol: inner_bootstrap.clone(),
+        children: vec![SupervisorChildLayout {
+            name: "leaf".to_string(),
+            actor_name: "Worker".to_string(),
+            restart_policy: None,
+            is_pool: false,
+            slot_index: 0,
+            wired_to: Default::default(),
+            spawn_order: 0,
+            on_crash_symbol: None,
+            lifecycle_symbol: None,
+            max_heap_bytes: None,
+            cycle_capable: false,
+            init_state_fields: vec![],
+            nested_bootstrap_symbol: None,
+        }],
+    };
+
+    let root_layout = SupervisorLayout {
+        name: "RootSupervisor".to_string(),
+        strategy: Some(HirSupervisorStrategy::OneForOne),
+        max_restarts: Some(3),
+        window: Some("60".to_string()),
+        bootstrap_symbol: root_bootstrap.clone(),
+        children: vec![
+            SupervisorChildLayout {
+                name: "direct".to_string(),
+                actor_name: "Worker".to_string(),
+                restart_policy: None,
+                is_pool: false,
+                slot_index: 0,
+                wired_to: Default::default(),
+                spawn_order: 0,
+                on_crash_symbol: None,
+                lifecycle_symbol: None,
+                max_heap_bytes: None,
+                cycle_capable: false,
+                init_state_fields: vec![],
+                nested_bootstrap_symbol: None,
+            },
+            SupervisorChildLayout {
+                name: "sub".to_string(),
+                actor_name: "InnerSupervisor".to_string(),
+                restart_policy: None,
+                is_pool: false,
+                slot_index: 1,
+                wired_to: Default::default(),
+                spawn_order: 1,
+                on_crash_symbol: None,
+                lifecycle_symbol: None,
+                max_heap_bytes: None,
+                cycle_capable: false,
+                init_state_fields: vec![],
+                nested_bootstrap_symbol: Some(inner_bootstrap.clone()),
+            },
+        ],
+    };
+
+    IrPipeline {
+        thir: vec![],
+        raw_mir: vec![root_fn, inner_fn, main_fn],
+        checked_mir: vec![],
+        elaborated_mir: vec![],
+        diagnostics: vec![],
+        wire_layouts: std::sync::Arc::default(),
+        opaque_handle_names: vec![],
+        record_layouts: vec![],
+        actor_layouts: vec![worker_layout],
+        supervisor_layouts: vec![inner_layout, root_layout],
+        machine_layouts: vec![],
+        enum_layouts: vec![],
+        regex_literals: vec![],
+        user_consts: Vec::new(),
+        extern_decls: vec![],
+        dyn_vtable_registry: vec![],
+        hashmap_lowering_facts: vec![],
+        hashset_lowering_facts: vec![],
+        actor_send_aliasing: std::collections::HashMap::new(),
+        polymorphic_mir: Vec::new(),
+        user_clone_record_seeds: vec![],
+        lint_warnings: vec![],
+    }
+}
+
+/// A nested-supervisor child registers through
+/// `hew_supervisor_add_child_supervisor_with_init` (passing the inner
+/// bootstrap as both the constructor and the restart init_fn), NOT through the
+/// actor `hew_supervisor_add_child_spec` path.
+#[test]
+fn supervisor_bootstrap_registers_nested_child_supervisor() {
+    let ir = emit_to_string(&nested_supervisor_pipeline(), "nested-register");
+    // The root bootstrap calls the inner bootstrap to construct the subtree.
+    assert!(
+        ir.contains("@InnerSupervisor__bootstrap"),
+        "root bootstrap must call the inner supervisor bootstrap; got:\n{ir}"
+    );
+    // ... and registers it via the child-supervisor seam.
+    assert!(
+        ir.contains("@hew_supervisor_add_child_supervisor_with_init"),
+        "nested child must register via hew_supervisor_add_child_supervisor_with_init; got:\n{ir}"
+    );
+}
+
+/// The actor child (`direct`) still rides the `add_child_spec` path even when a
+/// nested supervisor child is also present — the two registration seams coexist.
+#[test]
+fn supervisor_bootstrap_actor_child_coexists_with_nested() {
+    let ir = emit_to_string(&nested_supervisor_pipeline(), "nested-coexist");
+    assert!(
+        ir.contains("@hew_supervisor_add_child_spec"),
+        "the actor child must still register via add_child_spec; got:\n{ir}"
+    );
+    assert!(
+        ir.contains("@__hew_actor_dispatch_Worker"),
+        "the actor child spec must reference the Worker dispatch trampoline; got:\n{ir}"
     );
 }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -2265,7 +2265,7 @@ pub fn lower_program_with_mono_cap(
     // backing ABI calls (`hew_supervisor_pool_route`, `hew_supervisor_nested_get`)
     // are scheduled for v0.6. Gate runs unconditionally on every target
     // because the underlying ABI gap is target-independent.
-    check_supervisor_child_accessor_gates(&mut ctx, program, type_check_output);
+    check_supervisor_child_accessor_gates(&mut ctx, type_check_output);
 
     // FC-P1-D: HIR pre-pass binary-operator gates. Dispatched HERE (after
     // diagnostics.clear above) so the gate's diagnostics survive into the
@@ -24117,45 +24117,22 @@ fn check_coroutine_gate(ctx: &mut LowerCtx, program: &Program) {
 /// Check for unsupported supervisor child accessor patterns (P1-C).
 ///
 /// Reads the checker side-table `supervisor_child_slots` (keyed by the
-/// `SpanKey` of the `sup.child_name` field-access expression) and emits
-/// fail-closed diagnostics for two unsupported v0.5 forms:
+/// `SpanKey` of the `sup.child_name` field-access expression) and emits a
+/// fail-closed diagnostic for the one remaining unsupported form:
 ///
-/// 1. **Pool child accessor** — `slot.kind == ChildKind::Pool`. Routing pool
-///    slots requires the `hew_supervisor_pool_route` ABI call (v0.6).
-///    Currently fail-closed at `hew-mir/src/lower.rs:4413` as
-///    `NotYetImplemented`.
+/// - **Pool child accessor** — `slot.kind == ChildKind::Pool`. Routing pool
+///   slots requires a dynamic member index the bare `sup.pool` accessor does
+///   not express, so it stays fail-closed here.
 ///
-/// 2. **Nested supervisor accessor** — `slot.kind == ChildKind::Static` AND
-///    the declared child type is itself a supervisor (i.e. the result type
-///    is `LocalPid<Supervisor>`). Multi-segment supervisor dotted access
-///    requires the `hew_supervisor_nested_get` ABI call (v0.6). Currently
-///    fail-closed at `hew-mir/src/lower.rs:4443` as `NotYetImplemented`.
-///
-/// The set of supervisor names is built by scanning `program.items` for
-/// `Item::Supervisor` declarations — this is the cheapest source of truth
-/// available at this dispatch point and matches the precedent set by other
-/// HIR pre-passes that scan `program.items` directly rather than requiring
-/// the checker to publish a new side-table.
+/// A `ChildKind::Static` child whose declared type is itself a supervisor
+/// (`child api: AuthSupervisor;`) is a NESTED supervisor accessor; it now
+/// lowers through the `hew_supervisor_nested_get` ABI call (MIR
+/// `lower_supervisor_nested_get`) and is no longer gated.
 ///
 /// LESSONS P0 `boundary-fail-closed` / slepp A222: surface the gap as a
 /// compile-time diagnostic rather than letting the program reach a MIR
 /// `NotYetImplemented` trap (or worse, a runtime panic).
-fn check_supervisor_child_accessor_gates(
-    ctx: &mut LowerCtx,
-    program: &Program,
-    tc_output: &TypeCheckOutput,
-) {
-    // Build the set of supervisor names from program items. Cheap one-pass
-    // scan; no need to depend on a new TypeCheckOutput side-table.
-    let supervisor_names: std::collections::HashSet<&str> = program
-        .items
-        .iter()
-        .filter_map(|(item, _)| match item {
-            Item::Supervisor(decl) => Some(decl.name.as_str()),
-            _ => None,
-        })
-        .collect();
-
+fn check_supervisor_child_accessor_gates(ctx: &mut LowerCtx, tc_output: &TypeCheckOutput) {
     // Iterate checker side-table. ChildSlot now carries authoritative
     // `supervisor` and `child_name` set by the checker at construction —
     // no reverse lookup, no string-identifier fragility (A39 invariant),
@@ -24185,29 +24162,12 @@ fn check_supervisor_child_accessor_gates(
             }
             ChildKind::Static => {
                 // Nested supervisor: the declared child type is itself a
-                // supervisor. The result of the field access is
-                // `LocalPid<NestedSupervisor>`, which the MIR lowering
-                // currently rejects as `NotYetImplemented` because the
-                // multi-hop ABI call (`hew_supervisor_nested_get`) is not
-                // yet implemented.
-                if supervisor_names.contains(slot.child_ty.as_str()) {
-                    ctx.diagnostics.push(HirDiagnostic::new(
-                        HirDiagnosticKind::NestedSupervisorAccessorUnsupported {
-                            supervisor: sup_name.to_string(),
-                            child: child_name.to_string(),
-                            nested_supervisor: slot.child_ty.clone(),
-                        },
-                        span,
-                        format!(
-                            "nested supervisor accessor `{sup_name}.{child_name}` \
-                             (result type `LocalPid<{nested}>`) is not yet \
-                             implemented: multi-segment supervisor dotted access \
-                             requires the `hew_supervisor_nested_get` ABI call \
-                             which lands in v0.6.",
-                            nested = slot.child_ty,
-                        ),
-                    ));
-                }
+                // supervisor, so the result of the field access is
+                // `LocalPid<NestedSupervisor>`. This lowers through the
+                // `hew_supervisor_nested_get` ABI call (MIR
+                // `lower_supervisor_nested_get`), so it is no longer gated
+                // here. A plain actor child (the common case) also routes
+                // through this `Static` arm and needs no gate.
             }
         }
     }

--- a/hew-hir/tests/supervisor_child_accessor_gates.rs
+++ b/hew-hir/tests/supervisor_child_accessor_gates.rs
@@ -178,10 +178,10 @@ fn pool_child_access_rejected_at_hir() {
     );
 }
 
-// ── Negative case: nested supervisor accessor ────────────────────────────────
+// ── Nested supervisor accessor: now implemented (no longer gated) ────────────
 
 #[test]
-fn nested_supervisor_accessor_rejected_at_hir() {
+fn nested_supervisor_accessor_lowers_without_gate() {
     let output = lower(
         r"
         actor Worker {
@@ -203,6 +203,8 @@ fn nested_supervisor_accessor_rejected_at_hir() {
         }
         ",
     );
+    // A nested-supervisor accessor now lowers through `hew_supervisor_nested_get`
+    // (MIR `lower_supervisor_nested_get`), so the HIR gate must NOT fire.
     let nested_diag = output.diagnostics.iter().find(|d| {
         matches!(
             d.kind,
@@ -210,31 +212,19 @@ fn nested_supervisor_accessor_rejected_at_hir() {
         )
     });
     assert!(
-        nested_diag.is_some(),
-        "nested supervisor accessor must emit NestedSupervisorAccessorUnsupported; \
-         diagnostics: {:#?}",
+        nested_diag.is_none(),
+        "nested supervisor accessor must lower cleanly, not emit \
+         NestedSupervisorAccessorUnsupported; diagnostics: {:#?}",
         output.diagnostics
     );
-    if let Some(d) = nested_diag {
-        if let HirDiagnosticKind::NestedSupervisorAccessorUnsupported {
-            supervisor,
-            child,
-            nested_supervisor,
-        } = &d.kind
-        {
-            assert_eq!(supervisor, "RootSupervisor");
-            assert_eq!(child, "sub");
-            assert_eq!(nested_supervisor, "SubSupervisor");
-        }
-    }
     assert!(
-        output.into_result().is_err(),
-        "nested supervisor accessor diagnostic must be fatal (into_result() Err)"
+        output.into_result().is_ok(),
+        "nested supervisor accessor must no longer be a fatal error"
     );
 }
 
 #[test]
-fn nested_supervisor_chained_accessor_rejected_at_first_hop() {
+fn nested_supervisor_chained_accessor_lowers_without_gate() {
     let output = lower(
         r"
         actor Worker {
@@ -256,7 +246,8 @@ fn nested_supervisor_chained_accessor_rejected_at_first_hop() {
         }
         ",
     );
-    // The first hop `root.sub` is a nested-supervisor access and MUST fire.
+    // The chained `root.sub.worker` resolves the nested supervisor on the first
+    // hop and the leaf actor on the second; neither hop is gated any longer.
     let nested_diag = output.diagnostics.iter().find(|d| {
         matches!(
             d.kind,
@@ -264,14 +255,13 @@ fn nested_supervisor_chained_accessor_rejected_at_first_hop() {
         )
     });
     assert!(
-        nested_diag.is_some(),
-        "chained `root.sub.worker` must trigger nested-supervisor gate on the \
-         first hop; diagnostics: {:#?}",
+        nested_diag.is_none(),
+        "chained `root.sub.worker` must lower cleanly; diagnostics: {:#?}",
         output.diagnostics
     );
     assert!(
-        output.into_result().is_err(),
-        "chained nested-supervisor access must be fatal"
+        output.into_result().is_ok(),
+        "chained nested-supervisor access must no longer be fatal"
     );
 }
 
@@ -345,9 +335,9 @@ fn pool_child_accessor_disambiguated_with_two_same_type_children() {
 }
 
 #[test]
-fn nested_supervisor_accessor_disambiguated_with_two_same_type_subs() {
-    // Two nested-supervisor children of the same supervisor type. Accessing
-    // `sub_a` must name `sub_a`, not `sub_b`.
+fn nested_supervisor_accessor_two_same_type_subs_lowers_without_gate() {
+    // Two nested-supervisor children of the same supervisor type. Both accessors
+    // now lower through `hew_supervisor_nested_get`; neither is gated.
     let output = lower(
         r"
         actor Worker {
@@ -373,30 +363,20 @@ fn nested_supervisor_accessor_disambiguated_with_two_same_type_subs() {
     let nested_diags: Vec<_> = output
         .diagnostics
         .iter()
-        .filter_map(|d| match &d.kind {
-            HirDiagnosticKind::NestedSupervisorAccessorUnsupported {
-                supervisor,
-                child,
-                nested_supervisor,
-            } => Some((supervisor.clone(), child.clone(), nested_supervisor.clone())),
-            _ => None,
+        .filter(|d| {
+            matches!(
+                d.kind,
+                HirDiagnosticKind::NestedSupervisorAccessorUnsupported { .. }
+            )
         })
         .collect();
-    assert_eq!(
-        nested_diags.len(),
-        1,
-        "exactly one nested gate diagnostic expected; got: {nested_diags:?}"
-    );
-    let (sup, child, nested) = &nested_diags[0];
-    assert_eq!(sup, "RootSupervisor");
-    assert_eq!(
-        child, "sub_a",
-        "diagnostic must name the accessed child `sub_a`, NOT the sibling \
-         `sub_b`; reverse-by-type lookup would mis-attribute"
-    );
-    assert_eq!(nested, "SubSupervisor");
     assert!(
-        output.into_result().is_err(),
-        "nested supervisor accessor diagnostic must be fatal"
+        nested_diags.is_empty(),
+        "nested supervisor accessors must lower cleanly with no gate diagnostic; \
+         got: {nested_diags:#?}"
+    );
+    assert!(
+        output.into_result().is_ok(),
+        "nested supervisor accessor must no longer be fatal"
     );
 }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -1561,13 +1561,31 @@ pub fn lower_hir_module_with_facts(
     let actor_layout_map = actor_layout_map;
 
     // Post-loop pass: populate on_crash_symbol, max_heap_bytes, cycle_capable,
-    // and init_state_fields on each SupervisorChildLayout using the now-complete
-    // actor_layout_map.
+    // init_state_fields, and nested_bootstrap_symbol on each
+    // SupervisorChildLayout using the now-complete actor_layout_map.
     // build_supervisor_layout runs inside the single-pass item loop, so actor
     // declarations that follow a supervisor in source order would not have been
     // visible yet. Deferring the lookup here makes ordering irrelevant.
+    //
+    // The set of declared supervisor names lets the loop distinguish a
+    // nested-supervisor child (`child api: AuthSupervisor;`) from an actor
+    // child: a child whose declared type names another supervisor is registered
+    // through the child-supervisor seam, not the actor `HewChildSpec` path.
+    let supervisor_names: std::collections::HashSet<String> =
+        supervisor_layouts.iter().map(|l| l.name.clone()).collect();
     for sup_layout in &mut supervisor_layouts {
         for child in &mut sup_layout.children {
+            // A nested-supervisor child carries the child supervisor's bootstrap
+            // symbol; codegen routes it through
+            // `hew_supervisor_add_child_supervisor_with_init` instead of the
+            // actor `HewChildSpec` path. Mark it before the actor-layout lookups
+            // below — those all resolve to None/empty for a supervisor type, so
+            // the remaining per-child fields stay correctly null for a nested
+            // child.
+            if supervisor_names.contains(&child.actor_name) {
+                child.nested_bootstrap_symbol =
+                    Some(mangle_supervisor_bootstrap(&child.actor_name));
+            }
             let al = actor_layout_map.get(&child.actor_name);
             child.on_crash_symbol = al.and_then(|al| al.on_crash_symbol.clone());
             // Lifecycle wrapper: emit a wrapper symbol only when the actor has
@@ -3996,6 +4014,10 @@ fn build_supervisor_layout(
             cycle_capable: false,
             // Populated in the post-loop pass along with actor layout fields.
             init_state_fields: Vec::new(),
+            // Populated in the post-loop pass, where the full set of declared
+            // supervisor names is known. `Some` when this child's type is itself
+            // a supervisor (nested supervision tree); `None` for actor children.
+            nested_bootstrap_symbol: None,
             // accepted-only: the per-child `shutdown:` directive
             // (HirSupervisorChild.shutdown) is parsed, checked, and round-trips
             // through the formatter, but is NOT lowered into the runtime ABI in
@@ -4113,11 +4135,19 @@ fn lower_supervisor_bootstrap(
     // diagnostic if so).
     let ordered = supervisor_children_in_spawn_order(sup)?;
 
-    // Verify every child names an actor we know about. Unknown actor
-    // -> NotYetImplemented, skip emission. The checker validates child
-    // types but a stale stdlib/registry could in principle desync; this
-    // is the MIR-side fail-closed boundary.
+    // Verify every child names an actor we know about — UNLESS the child's
+    // declared type is itself a supervisor (a nested supervision subtree). A
+    // nested-supervisor child is brought up by codegen's bootstrap emitter
+    // (which calls the child supervisor's own bootstrap and registers it via
+    // `hew_supervisor_add_child_supervisor_with_init`), not by this synthetic
+    // `spawn ChildActor` stub, so it has no actor layout and must be skipped
+    // here. For a genuine actor child, an unknown actor is still a fail-closed
+    // boundary (the checker is the user-facing gate; a stale registry desync
+    // lands here).
     for child in &ordered {
+        if supervisor_layouts.contains_key(&child.ty) {
+            continue;
+        }
         if !actor_layouts.contains_key(&child.ty) {
             diagnostics.push(MirDiagnostic {
                 kind: MirDiagnosticKind::NotYetImplemented {
@@ -4181,6 +4211,16 @@ fn lower_supervisor_bootstrap(
 
     let mut statements: Vec<HirStmt> = Vec::with_capacity(ordered.len());
     for child in &ordered {
+        // Nested-supervisor children are registered by codegen's bootstrap
+        // emitter (it calls the child's own bootstrap and attaches it via
+        // `hew_supervisor_add_child_supervisor_with_init`). They have no
+        // `spawn ChildActor` statement in this synthetic stub — skip them so
+        // the stub does not synthesise a `spawn Supervisor` (which would route
+        // through the actor-spawn path the supervisor type does not have).
+        if supervisor_layouts.contains_key(&child.ty) {
+            continue;
+        }
+
         let handle_ty = local_pid_of(&child.ty);
 
         // Build the spawn's args vec from the wired_to map. We iterate
@@ -11494,12 +11534,15 @@ impl Builder {
                         ChildKind::Static => {
                             // Nested-supervisor result: when the RESULT of the
                             // field access (`expr.ty`) is `LocalPid<T>` where T
-                            // is itself a supervisor with declared children, we
-                            // would need `hew_supervisor_nested_get` (v0.6).
-                            // This is distinct from the common case where the
-                            // LHS is a supervisor and the result is an actor PID.
-                            // We detect nesting on `expr.ty`, not `object.ty`
-                            // (which is always `LocalPid<ParentSupervisor>`).
+                            // is itself a supervisor with declared children, the
+                            // child slot resolves through `hew_supervisor_nested_get`
+                            // (over the parent's `child_supervisors` table) rather
+                            // than `hew_supervisor_child_get` (over its actor
+                            // `children`). This is distinct from the common case
+                            // where the LHS is a supervisor and the result is an
+                            // actor PID. We detect nesting on `expr.ty`, not
+                            // `object.ty` (which is always
+                            // `LocalPid<ParentSupervisor>`).
                             let is_nested = matches!(&expr.ty,
                                 ResolvedTy::Named { name, args, .. }
                                 if name == "LocalPid"
@@ -11508,23 +11551,39 @@ impl Builder {
                                         ResolvedTy::Named { name: inner, .. }
                                         if self.supervisor_layout_map.contains_key(inner.as_str()))
                             );
+
+                            // The checker's `slot.index` is the child's position in
+                            // the COMBINED static list (actor children + nested
+                            // supervisors, in source order). The runtime keeps two
+                            // separate tables — actor children in `children[]`
+                            // (indexed by `hew_supervisor_child_get`) and nested
+                            // supervisors in `child_supervisors[]` (indexed by
+                            // `hew_supervisor_nested_get`) — each 0-based within its
+                            // own kind. Translate the combined index to the
+                            // kind-partitioned runtime index so both accessors hit
+                            // the right slot even when actor and nested children are
+                            // interleaved. MIR owns the runtime-index translation;
+                            // codegen registers each kind into its own table in the
+                            // same source order, so the partitioned index agrees.
+                            let runtime_index = self.partitioned_static_slot_index(
+                                &slot.supervisor,
+                                &slot.child_name,
+                                is_nested,
+                            );
+
                             if is_nested {
-                                let _ = self.lower_value(object);
-                                self.diagnostics.push(MirDiagnostic {
-                                    kind: MirDiagnosticKind::NotYetImplemented {
-                                        construct: "nested supervisor child accessor (v0.6)"
-                                            .to_string(),
-                                        site: expr.site,
-                                    },
-                                    note: "multi-segment supervisor dotted access requires \
-                                           `hew_supervisor_nested_get`, which lands in v0.6"
-                                        .to_string(),
-                                });
-                                return None;
+                                return self.lower_supervisor_nested_get(
+                                    object,
+                                    runtime_index,
+                                    &expr.ty,
+                                );
                             }
 
                             return self.lower_supervisor_child_get(
-                                object, slot.index, &expr.ty, expr.site,
+                                object,
+                                runtime_index,
+                                &expr.ty,
+                                expr.site,
                             );
                         }
                     }
@@ -21594,6 +21653,127 @@ impl Builder {
         // The `instr_places` function in lower.rs surfaces `handle_place` to the
         // dataflow seed pass, maintaining the same bookkeeping invariant as
         // `lower_spawn_actor`.
+
+        Some(handle_place)
+    }
+
+    /// Translate a supervisor child's combined-static checker index into its
+    /// kind-partitioned runtime slot index.
+    ///
+    /// The runtime keeps actor children and nested supervisors in two separate
+    /// 0-based tables. Codegen registers each kind into its own table while
+    /// iterating `SupervisorLayout.children` (topological spawn order), so a
+    /// child's runtime index is its position among same-kind children in that
+    /// same iteration order. Count the same-kind children that precede this one
+    /// in the layout to recover that index.
+    ///
+    /// Falls back to a 0 index if the supervisor or child is not found in the
+    /// layout map (an upstream diagnostic already covers the unknown-supervisor
+    /// case); the accessor's runtime null-guard then fail-closes the lookup.
+    fn partitioned_static_slot_index(
+        &self,
+        supervisor: &str,
+        child_name: &str,
+        want_nested: bool,
+    ) -> u32 {
+        let Some(layout) = self.supervisor_layout_map.get(supervisor) else {
+            return 0;
+        };
+        let mut index = 0u32;
+        for child in &layout.children {
+            if child.is_pool {
+                continue;
+            }
+            let child_is_nested = child.nested_bootstrap_symbol.is_some();
+            if child_is_nested != want_nested {
+                continue;
+            }
+            if child.name == child_name {
+                return index;
+            }
+            index += 1;
+        }
+        // Child not found among same-kind siblings — return the running count as
+        // a best-effort index; an upstream diagnostic covers the genuine
+        // unknown-child case.
+        index
+    }
+
+    /// Lower a nested-supervisor child accessor (`app.api` where `api` is itself
+    /// a supervisor) to a `hew_supervisor_nested_get(sup, slot)` call.
+    ///
+    /// Distinct from `lower_supervisor_child_get`: the parent resolves a nested
+    /// child through its `child_supervisors` table (not its actor `children`
+    /// table), so the runtime symbol is `hew_supervisor_nested_get`. The runtime
+    /// returns the child supervisor pointer in field 1 of the same
+    /// `__HewChildLookupResult` struct; the result type is
+    /// `LocalPid<NestedSupervisor>`, so a subsequent dotted segment
+    /// (`app.api.auth`) routes back through this intercept against the nested
+    /// supervisor pointer.
+    ///
+    /// The handle is a plain `*mut HewSupervisor` reinterpreted as a PID — it is
+    /// NOT registered as a fungible child ref. A fungible ref drives per-send
+    /// re-resolution of an *actor* handle; a supervisor handle is only ever used
+    /// as the receiver of a further child-get, which itself re-resolves the leaf
+    /// actor at the moment of the send. Resolving the nested supervisor once per
+    /// accessor expression is sufficient: the child supervisor's identity is
+    /// stable across its own children's restarts, and a nested-supervisor
+    /// escalation restart is re-resolved on the next `app.api` access.
+    fn lower_supervisor_nested_get(
+        &mut self,
+        object: &HirExpr,
+        slot_index: u32,
+        result_ty: &ResolvedTy,
+    ) -> Option<Place> {
+        let sup_place = self.lower_value(object)?;
+
+        // Allocate the handle typed as the checker-authority
+        // `LocalPid<NestedSupervisor>` result type for this site.
+        let handle_local = self.alloc_local(result_ty.clone());
+        let Place::Local(handle_id) = handle_local else {
+            unreachable!("alloc_local always returns Place::Local");
+        };
+        let handle_place = Place::ActorHandle(handle_id);
+
+        // Emit a constant for the static nested slot index.
+        let idx_place = self.alloc_local(ResolvedTy::I64);
+        self.push_instr(Instr::ConstI64 {
+            dest: idx_place,
+            value: i64::from(slot_index),
+        });
+
+        // Allocate a local typed as the opaque `__HewChildLookupResult` record.
+        // Codegen recognises this type name and emits a struct-return LLVM call.
+        let result_place = self.alloc_local(ResolvedTy::Named {
+            name: CHILD_LOOKUP_RESULT_TY_NAME.to_string(),
+            args: vec![],
+            builtin: None,
+            is_opaque: false,
+        });
+
+        // Emit the nested-get runtime call. The dest carries the 16-byte struct.
+        self.push_instr(Instr::CallRuntimeAbi(
+            crate::model::RuntimeCall::new(
+                "hew_supervisor_nested_get",
+                vec![sup_place, idx_place],
+                Some(result_place),
+            )
+            .expect("hew_supervisor_nested_get is an allowlisted runtime symbol"),
+        ));
+
+        // Extract the child supervisor pointer (field 1, i64 at MIR level).
+        let raw_handle = self.alloc_local(ResolvedTy::I64);
+        self.push_instr(Instr::RecordFieldLoad {
+            record: result_place,
+            field_offset: FieldOffset(1),
+            dest: raw_handle,
+        });
+
+        // Move the i64 wire value into the typed supervisor handle slot.
+        self.push_instr(Instr::Move {
+            dest: handle_place,
+            src: raw_handle,
+        });
 
         Some(handle_place)
     }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -1689,61 +1689,117 @@ pub fn lower_hir_module_with_facts(
                         // adjacent field and writes past the end of the struct.
                         let init_arg = match &source_expr.kind {
                             HirExprKind::Literal(HirLiteral::Integer(n)) => {
+                                // Materialise the literal at the declared field's
+                                // exact width. Each integer width gets its own
+                                // `ChildInitArg` variant so codegen emits a store
+                                // of exactly `sizeof(field_ty)` bytes — a wider
+                                // store would clobber the adjacent field and run
+                                // past the end of the state template. The literal
+                                // is range-checked against the field's bounds so an
+                                // out-of-range constant is a compile error rather
+                                // than a silent truncation. An unresolved field type
+                                // (`None`) falls back to I64, preserving the prior
+                                // behaviour when the field type is unavailable.
+                                //
+                                // The literal carrier is `i64`, so a negative value
+                                // can never satisfy an unsigned field's `try_from`,
+                                // and a value beyond `i64::MAX` cannot be expressed
+                                // as a literal at all; `u64` therefore widens from
+                                // the non-negative `i64` range only.
+                                let overflow = |target: &str| MirDiagnostic {
+                                    kind: MirDiagnosticKind::NotYetImplemented {
+                                        construct: format!(
+                                            "supervisor `{}` child `{}` field `{field_name}` \
+                                             value {n} does not fit in `{target}`",
+                                            sup_layout.name, child.name
+                                        ),
+                                        site: source_expr.site,
+                                    },
+                                    note: "integer literal must fit in the declared field type"
+                                        .to_string(),
+                                };
                                 match field_ty {
-                                    // 32-bit signed: use I32 so codegen emits a
-                                    // 4-byte store that doesn't clobber the
-                                    // adjacent field.  Range-check the literal so
-                                    // an out-of-range constant is a compile error
-                                    // rather than a silent truncation.
+                                    Some(ResolvedTy::I8) => {
+                                        let Ok(v) = i8::try_from(*n) else {
+                                            diagnostics.push(overflow("i8"));
+                                            all_ok = false;
+                                            continue 'fields;
+                                        };
+                                        crate::model::ChildInitArg::I8(v)
+                                    }
+                                    Some(ResolvedTy::I16) => {
+                                        let Ok(v) = i16::try_from(*n) else {
+                                            diagnostics.push(overflow("i16"));
+                                            all_ok = false;
+                                            continue 'fields;
+                                        };
+                                        crate::model::ChildInitArg::I16(v)
+                                    }
                                     Some(ResolvedTy::I32) => {
                                         let Ok(v) = i32::try_from(*n) else {
-                                            diagnostics.push(MirDiagnostic {
-                                                kind: MirDiagnosticKind::NotYetImplemented {
-                                                    construct: format!(
-                                                        "supervisor `{}` child `{}` field \
-                                                         `{field_name}` value {n} overflows i32",
-                                                        sup_layout.name, child.name
-                                                    ),
-                                                    site: source_expr.site,
-                                                },
-                                                note: "integer literal must fit in the declared \
-                                                       field type"
-                                                    .to_string(),
-                                            });
+                                            diagnostics.push(overflow("i32"));
                                             all_ok = false;
                                             continue 'fields;
                                         };
                                         crate::model::ChildInitArg::I32(v)
                                     }
-                                    // 64-bit signed (or unresolved — fail-open to
+                                    Some(ResolvedTy::U8) => {
+                                        let Ok(v) = u8::try_from(*n) else {
+                                            diagnostics.push(overflow("u8"));
+                                            all_ok = false;
+                                            continue 'fields;
+                                        };
+                                        crate::model::ChildInitArg::U8(v)
+                                    }
+                                    Some(ResolvedTy::U16) => {
+                                        let Ok(v) = u16::try_from(*n) else {
+                                            diagnostics.push(overflow("u16"));
+                                            all_ok = false;
+                                            continue 'fields;
+                                        };
+                                        crate::model::ChildInitArg::U16(v)
+                                    }
+                                    Some(ResolvedTy::U32) => {
+                                        let Ok(v) = u32::try_from(*n) else {
+                                            diagnostics.push(overflow("u32"));
+                                            all_ok = false;
+                                            continue 'fields;
+                                        };
+                                        crate::model::ChildInitArg::U32(v)
+                                    }
+                                    Some(ResolvedTy::U64) => {
+                                        let Ok(v) = u64::try_from(*n) else {
+                                            diagnostics.push(overflow("u64"));
+                                            all_ok = false;
+                                            continue 'fields;
+                                        };
+                                        crate::model::ChildInitArg::U64(v)
+                                    }
+                                    // 64-bit signed (or unresolved — fall back to
                                     // I64 preserving the original behaviour when
                                     // the field type is unavailable).
                                     Some(ResolvedTy::I64) | None => {
                                         crate::model::ChildInitArg::I64(*n)
                                     }
-                                    // Sub-i32 widths and unsigned integers are not
-                                    // yet represented in ChildInitArg.  Emit NYI
-                                    // rather than silently widening to I64, which
-                                    // would clobber adjacent fields.
-                                    //
-                                    // WHY: ChildInitArg lacks I8/I16/U* variants.
-                                    // WHEN: obsolete once those variants are added.
-                                    // WHAT: add ChildInitArg::I8/I16/U8/U16/U32/U64
-                                    //       and matching codegen arms.
+                                    // Non-integer field types are handled by the
+                                    // bool/float arms below or rejected by the
+                                    // checker before reaching MIR; an integer
+                                    // literal against a non-integer field is a
+                                    // type error the checker already caught, so
+                                    // fail closed here.
                                     Some(other_ty) => {
                                         diagnostics.push(MirDiagnostic {
                                             kind: MirDiagnosticKind::NotYetImplemented {
                                                 construct: format!(
                                                     "supervisor `{}` child `{}` field \
-                                                     `{field_name}` has type `{other_ty}` which \
-                                                     is not yet supported as a child init arg \
-                                                     (only i32 and i64 are supported in this slice)",
+                                                     `{field_name}` has integer literal value \
+                                                     {n} for non-integer type `{other_ty}`",
                                                     sup_layout.name, child.name
                                                 ),
                                                 site: source_expr.site,
                                             },
-                                            note: "add ChildInitArg variants for the required \
-                                                   integer width"
+                                            note: "integer literal supplied for a non-integer \
+                                                   child init field"
                                                 .to_string(),
                                         });
                                         all_ok = false;

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -905,6 +905,23 @@ pub struct SupervisorChildLayout {
     /// WHEN obsolete: follow-up slice after clone verification is proven.
     /// WHAT: extend `ChildInitArg` and verify `state_clone_fn` covers owned types.
     pub init_state_fields: Vec<(String, ChildInitArg)>,
+    /// `Some(bootstrap_symbol)` when this child's declared type is itself a
+    /// supervisor (`child api: AuthSupervisor;`) rather than an actor; `None`
+    /// for the common actor-child case.
+    ///
+    /// A nested-supervisor child is registered with the parent through a
+    /// different runtime seam than an actor child: codegen calls the child's
+    /// own bootstrap function (which builds and starts the child supervisor and
+    /// returns its `*mut HewSupervisor`), then registers it via
+    /// `hew_supervisor_add_child_supervisor_with_init`, passing the same
+    /// bootstrap symbol as the restart `init_fn`. It must NOT go through the
+    /// `HewChildSpec` / `__hew_actor_dispatch_<actor>` path — a supervisor has
+    /// no actor dispatch trampoline, so that path fails closed at codegen.
+    ///
+    /// Populated in the post-loop pass in `lower_hir_module`, where the full
+    /// set of declared supervisor names is known, so declaration order between
+    /// the parent and the nested supervisor is irrelevant.
+    pub nested_bootstrap_symbol: Option<String>,
 }
 
 /// A self-contained literal value for a supervisor child init arg.

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -910,11 +910,21 @@ pub struct SupervisorChildLayout {
 /// A self-contained literal value for a supervisor child init arg.
 ///
 /// Kept separate from MIR instructions so codegen can read these directly
-/// without a running `FnCtx`. Only covers POD types in the first slice.
+/// without a running `FnCtx`. Covers every scalar `BitCopy` primitive width
+/// (signed/unsigned 8/16/32/64-bit integers, `bool`, `f64`). Each width gets
+/// its own variant so codegen materialises a value of exactly the field's
+/// allocated width — a wider store would clobber the adjacent field and write
+/// past the end of the state template.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ChildInitArg {
-    I64(i64),
+    I8(i8),
+    I16(i16),
     I32(i32),
+    I64(i64),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
     Bool(bool),
     F64(f64),
 }

--- a/tests/vertical-slice/accept/supervisor_nested_accessor.hew
+++ b/tests/vertical-slice/accept/supervisor_nested_accessor.hew
@@ -1,0 +1,49 @@
+// Acceptance fixture: nested-supervisor child accessor round-trip.
+//
+// Exercises a two-level supervision tree end-to-end:
+//   1. `spawn Root` runs Root's bootstrap, which builds its actor child
+//      (`direct`) via hew_supervisor_add_child_spec AND brings up the nested
+//      `Inner` supervisor by calling InnerSupervisor's own bootstrap, then
+//      registers it via hew_supervisor_add_child_supervisor_with_init.
+//   2. `root.sub` lowers through hew_supervisor_nested_get, returning the
+//      child supervisor pointer as a LocalPid<Inner>.
+//   3. `inner.leaf` lowers through hew_supervisor_child_get on that nested
+//      supervisor, returning a LocalPid<Worker>.
+//   4. `leaf.echo(42)` asks the leaf actor, which replies with its argument.
+//   5. `main` returns the reply as the process exit code; exit 42 proves the
+//      nested + leaf accessor chain and the cross-actor ask all went through.
+//
+// A wrong nested slot index, a mis-registered child supervisor, or a broken
+// nested-get would surface as a non-42 exit (a Dead/Transient lookup yields
+// the Err arm → exit 0).
+actor Worker {
+    let tag: i64;
+    receive fn echo(n: i64) -> i64 {
+        n + tag
+    }
+}
+
+supervisor Inner {
+    strategy: one_for_one;
+    intensity: 3 within 60s;
+
+    child leaf: Worker(tag: 0);
+}
+
+supervisor Root {
+    strategy: one_for_one;
+    intensity: 3 within 60s;
+
+    child direct: Worker(tag: 0);
+    child sub: Inner;
+}
+
+fn main() -> i64 {
+    let root = spawn Root;
+    let inner = root.sub;
+    let leaf = inner.leaf;
+    match await leaf.echo(42) {
+        Ok(v) => v,
+        Err(_e) => 0,
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -839,6 +839,13 @@ run_accept_expect_status "supervisor_basic" 42
 # Exercises the { i64, i64 } ABI fix for hew_supervisor_child_get.
 run_accept_expect_status "supervised_ingest_race" 42
 
+# Nested-supervisor accessor: spawn Root → hew_supervisor_nested_get resolves
+# the child supervisor (root.sub) → hew_supervisor_child_get on the nested
+# supervisor (inner.leaf) → ask the leaf → echo 42 back as exit code. Root mixes
+# an actor child (direct) with a nested supervisor (sub), so this also proves the
+# kind-partitioned slot indices and the add_child_supervisor_with_init seam.
+run_accept_expect_status "supervisor_nested_accessor" 42
+
 # Supervisor graceful stop: spawn AppSupervisor → supervisor_stop(sup) lowers to
 # hew_supervisor_stop; main returns 0. Exercises the user-name → C-ABI bridge and
 # the void-return (dest: None) MIR + codegen path.


### PR DESCRIPTION
## Summary

Supervisor children gain two new capabilities. First, child init arguments now work at every integer width — i8, i16, u8, u16, u32, and u64 — each materialized width-exact with correct sign extension (signed) or zero extension (unsigned). Out-of-range literals such as `u8 = 300` are a compile error, not a silent truncation. Second, nested supervisor children are now accessible via chained field syntax (`root.sub.leaf`), with a nested supervisor's bootstrap function doubling as its restart initializer.

## Verification

- `cargo test -p hew-cli --test supervisor_init_args_e2e`: 12 passed / 0 failed — reversed-declaration-order oracle across all six integer widths with high-bit values (u8=200, u16=60000, u32=4e9, u64=1.8e10) each asserted `ok=6`; `u8 = 300` rejected at compile time with `does not fit in 'u8'`.
- `cargo test -p hew-codegen-rs --test supervisor_emission`: 12 passed — `…registers_nested_child_supervisor` and `…actor_child_coexists_with_nested` confirmed; bootstrap wired as restart `init_fn`.
- `cargo test -p hew-hir --test supervisor_child_accessor_gates`: 7 passed — pool still gated, nested no longer gated, chained nested lowers.
- `tests/vertical-slice/accept/supervisor_nested_accessor.hew`: exits 42 over the real `hew` binary under a mixed actor child + nested supervisor parent; reordered fixture (nested supervisor declared before actor child) also exits 42, confirming no cross-indexing under child reordering.
- `make verify-ffi`: EXIT 0.
- `checked-mir-corpus.sh verify`: OK (31 fixtures × 2 stages byte-identical).
- Pool accessor (`pool_child_access_rejected_at_hir`): still rejected; MIR pool arm remains `NotYetImplemented`.
- Preflight: ready-to-push.

## Out of scope

- Supervisor accessor typing as `Option`/fungible and `await_restart` — separate language-surface decisions.
- Pool member-index accessor — a separate feature requiring pool routing to land first.
- `restart_fn` owned-heap init shim and `#[every]`-in-children — separate runtime-ABI features.
- Friendlier "value -5 does not fit in `u16`" diagnostic for negative init-arg literals (negative literals reach the HIR unary-lowering boundary before the `try_from` arm; fail-closed holds, error message is cryptic). Tracked as a follow-up.
- Removal or documentation of the now-unreachable `HirDiagnosticKind::NestedSupervisorAccessorUnsupported` variant. Tracked as a follow-up.
- A debug-assert or comment tying `partitioned_static_slot_index` to `actor_child_index` on the pool axis (latent pre-existing divergence, unreachable while pool accessors are gated). Tracked as a follow-up.
