### PR TITLE
feat(codegen,link): emit CodeView debug info and a sidecar PDB for windows-msvc -g builds

### DIFF
--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -264,6 +264,22 @@ pub fn link_executable(
         cmd.arg("-g");
     }
 
+    // ── Windows CodeView PDB (target-driven via NativeLinkPlan) ───────
+    // On ELF/Mach-O, `-g` carries debug info inside the object/executable. On
+    // Windows the CodeView channel is written to a standalone `.pdb` that
+    // lld-link only produces when asked: `-g` alone leaves the CodeView records
+    // (emitted by codegen for windows-msvc) on the floor and no PDB is written.
+    // `/DEBUG:FULL` writes complete line+local info (not the `/DEBUG:GHASH`
+    // fast-link variant) and `/PDB:<output>.pdb` names the sidecar next to the
+    // `.exe` so cdb/WinDbg/Visual Studio find it. The flags pass through the
+    // clang driver to lld-link as `-Wl,/DEBUG:FULL -Wl,/PDB:<path>`, mirroring
+    // the CRT-fixup `-Wl,/...` spellings below. Only attached on a debug build.
+    if debug && plan.needs_pdb_debug {
+        let pdb_path = pdb_output_path(&safe_output);
+        cmd.arg("-Wl,/DEBUG:FULL");
+        cmd.arg(format!("-Wl,/PDB:{pdb_path}"));
+    }
+
     // ── Dead-code elimination (target-driven via NativeLinkPlan) ──────
     // Under coverage instrumentation, skip GC and symbol stripping so the
     // `__llvm_prf_*`/`__llvm_cov*` sections and their symbol records survive
@@ -376,6 +392,20 @@ fn run_dsymutil_for_darwin(binary_path: &str) {
     run_dsymutil(binary_path);
     #[cfg(not(target_os = "macos"))]
     let _ = binary_path;
+}
+
+/// Derive the PDB sidecar path for a Windows debug link from the executable
+/// output path: replace a trailing `.exe` with `.pdb`, otherwise append `.pdb`.
+///
+/// `lld-link`'s `/PDB:<path>` names the standalone `CodeView` database. Placing
+/// it next to the `.exe` (same stem) is what cdb/WinDbg/Visual Studio expect: the
+/// executable's debug directory records the PDB path the linker wrote here, and
+/// a sibling-stem PDB is found even if the recorded absolute path moves.
+fn pdb_output_path(output: &str) -> String {
+    match output.strip_suffix(".exe") {
+        Some(stem) => format!("{stem}.pdb"),
+        None => format!("{output}.pdb"),
+    }
 }
 
 /// Run `dsymutil` on a linked binary to produce a `.dSYM` bundle.
@@ -1308,6 +1338,25 @@ mod tests {
     #[test]
     fn extract_symbol_no_match_empty_string() {
         assert_eq!(extract_undefined_hew_symbol(""), None);
+    }
+
+    // ── pdb_output_path ───────────────────────────────────────────────
+
+    #[test]
+    fn pdb_path_replaces_exe_suffix() {
+        // The common case: a `.exe` output gets a sibling-stem `.pdb`.
+        assert_eq!(pdb_output_path("app.exe"), "app.pdb");
+        assert_eq!(
+            pdb_output_path(r"C:\build\shadow.exe"),
+            r"C:\build\shadow.pdb"
+        );
+    }
+
+    #[test]
+    fn pdb_path_appends_when_no_exe_suffix() {
+        // A suffixless output (cross-link with no `.exe`) appends `.pdb` so the
+        // PDB is still a distinct sibling file, never overwriting the binary.
+        assert_eq!(pdb_output_path("app"), "app.pdb");
     }
 
     // ── symbol_to_feature_hint ────────────────────────────────────────

--- a/hew-cli/src/target.rs
+++ b/hew-cli/src/target.rs
@@ -64,6 +64,12 @@ pub struct ExecutionTarget {
 /// Host-side concerns (which linker binary to invoke, whether lld is installed,
 /// whether `dsymutil` is available) are intentionally *not* captured here —
 /// those remain runtime checks in `link.rs`.
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "each needs_* bool is an independent, named, target-keyed linker \
+              decision (SDK anchoring, CRT fixup, dsymutil pass, PDB emission); \
+              this is a plan-of-record, not a god-struct conflating unrelated state"
+)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NativeLinkPlan {
     /// Dead-code-elimination flags passed to the linker unconditionally.
@@ -95,6 +101,19 @@ pub struct NativeLinkPlan {
     /// Set for Darwin targets; whether the tool is actually present on the
     /// host is checked at link time — the step is skipped if unavailable.
     pub needs_dsymutil: bool,
+
+    /// `true` when a debug (`-g`) link must emit a separate PDB via the
+    /// MSVC-style `/DEBUG:FULL` + `/PDB:<output>.pdb` linker flags.
+    ///
+    /// Set for Windows targets. Unlike ELF/Mach-O (where `-g` carries debug
+    /// info inside the object/executable), the Windows `CodeView` channel is
+    /// written to a standalone `.pdb` next to the `.exe`; without `/DEBUG` the
+    /// linker discards the `CodeView` records and no PDB is produced, so a
+    /// `-g` build silently under-delivers on Windows. `/DEBUG:FULL` (not the
+    /// `/DEBUG:GHASH` fast-link variant) writes complete line+local info that
+    /// cdb/WinDbg/Visual Studio read. The flags only attach on a debug build;
+    /// a release Windows link sets nothing here.
+    pub needs_pdb_debug: bool,
 }
 
 impl TargetSpec {
@@ -173,6 +192,7 @@ impl TargetSpec {
                 needs_darwin_sdk: true,
                 needs_windows_crt_fixup: false,
                 needs_dsymutil: true,
+                needs_pdb_debug: false,
             },
             TargetOs::Linux => NativeLinkPlan {
                 gc_flags: &["-Wl,--gc-sections"],
@@ -181,6 +201,7 @@ impl TargetSpec {
                 needs_darwin_sdk: false,
                 needs_windows_crt_fixup: false,
                 needs_dsymutil: false,
+                needs_pdb_debug: false,
             },
             TargetOs::FreeBsd => NativeLinkPlan {
                 gc_flags: &["-Wl,--gc-sections"],
@@ -191,6 +212,7 @@ impl TargetSpec {
                 needs_darwin_sdk: false,
                 needs_windows_crt_fixup: false,
                 needs_dsymutil: false,
+                needs_pdb_debug: false,
             },
             TargetOs::Windows => NativeLinkPlan {
                 // The Windows linker (lld-link) does not accept ELF-style -Wl
@@ -217,6 +239,9 @@ impl TargetSpec {
                 // runtime uses the DLL CRT (msvcrt).  The CRT linkage must match.
                 needs_windows_crt_fixup: true,
                 needs_dsymutil: false,
+                // A `-g` Windows link must request the PDB explicitly so lld-link
+                // writes the CodeView records to a `.pdb` next to the `.exe`.
+                needs_pdb_debug: true,
             },
             TargetOs::Wasi | TargetOs::WasmFreestanding => NativeLinkPlan {
                 gc_flags: &[],
@@ -225,6 +250,7 @@ impl TargetSpec {
                 needs_darwin_sdk: false,
                 needs_windows_crt_fixup: false,
                 needs_dsymutil: false,
+                needs_pdb_debug: false,
             },
         }
     }
@@ -853,6 +879,7 @@ mod tests {
         assert!(plan.needs_darwin_sdk, "Darwin must request SDK anchoring");
         assert!(plan.needs_dsymutil, "Darwin must request dsymutil pass");
         assert!(!plan.needs_windows_crt_fixup);
+        assert!(!plan.needs_pdb_debug, "Darwin carries DWARF, not a PDB");
     }
 
     #[test]
@@ -881,6 +908,7 @@ mod tests {
         assert!(!plan.needs_darwin_sdk);
         assert!(!plan.needs_dsymutil);
         assert!(!plan.needs_windows_crt_fixup);
+        assert!(!plan.needs_pdb_debug, "Linux carries DWARF, not a PDB");
     }
 
     #[test]
@@ -903,6 +931,7 @@ mod tests {
         assert!(!plan.needs_darwin_sdk);
         assert!(!plan.needs_dsymutil);
         assert!(!plan.needs_windows_crt_fixup);
+        assert!(!plan.needs_pdb_debug, "FreeBSD carries DWARF, not a PDB");
     }
 
     #[test]
@@ -939,6 +968,19 @@ mod tests {
     }
 
     #[test]
+    fn windows_link_plan_requests_pdb_debug() {
+        let spec = TargetSpec::from_requested(Some("x86_64-pc-windows-msvc")).expect("target");
+        let plan = spec.native_link_plan();
+        assert!(
+            plan.needs_pdb_debug,
+            "Windows must request a PDB on a -g link so CodeView records reach a .pdb"
+        );
+        // The other targets carry their CodeView channel inside the object, so
+        // none of them request a standalone PDB — assert the field is Windows-only.
+        assert!(!plan.needs_dsymutil);
+    }
+
+    #[test]
     fn wasm_link_plan_is_empty() {
         let spec = TargetSpec::from_requested(Some("wasm32-wasi")).expect("target");
         let plan = spec.native_link_plan();
@@ -948,6 +990,7 @@ mod tests {
         assert!(!plan.needs_darwin_sdk);
         assert!(!plan.needs_dsymutil);
         assert!(!plan.needs_windows_crt_fixup);
+        assert!(!plan.needs_pdb_debug);
     }
 
     // ── wasm32-unknown-unknown (bare wasm / WasmFreestanding) ──────────

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -33666,21 +33666,26 @@ fn build_module_for_target<'ctx>(
             .to_string_lossy()
             .starts_with("wasm32")
     });
-    let target_data = if let Some(machine) = target_machine {
+    // The module triple string drives the debug-info *format* selection below:
+    // Windows-MSVC targets emit CodeView (the format MSVC-toolchain debuggers —
+    // cdb/WinDbg/Visual Studio — read), every other target emits DWARF. Capture
+    // it from whichever arm sets the triple so the decision needs no new plumbing.
+    let (target_data, module_triple) = if let Some(machine) = target_machine {
         let triple = machine.get_triple();
         llvm_mod.set_triple(&triple);
         let data = machine.get_target_data();
         let layout = data.get_data_layout();
         llvm_mod.set_data_layout(&layout);
-        data
+        (data, triple.as_str().to_string_lossy().into_owned())
     } else {
         // No target machine (the in-process IR build / `hew check`): still
         // declare the host triple on the module so target-keyed lowering — the
         // aggregate ABI classifier, `runtime_size_ty` — reads the correct
         // target rather than an empty triple. `host_target_data()` IS the host's
         // layout, so the host triple is the matching authority.
-        llvm_mod.set_triple(&TargetTriple::create(&native_emission_triple()));
-        host_target_data()
+        let native = native_emission_triple();
+        llvm_mod.set_triple(&TargetTriple::create(&native));
+        (host_target_data(), native)
     };
 
     // DWARF compile unit + file for `hew build -g` (W0.060). Created once per
@@ -33730,6 +33735,27 @@ fn build_module_for_target<'ctx>(
                 inkwell::module::FlagBehavior::Warning,
                 debug_metadata_version,
             );
+            // Debug-format selection: windows-msvc targets need the module-level
+            // "CodeView" flag (= 1) so the LLVM backend emits CodeView records
+            // (`.debug$S`/`.debug$T` COFF sections) instead of — well, alongside —
+            // DWARF. The shared `DICompileUnit`/`DISubprogram`/`DILocalVariable`
+            // DIE graph below is format-agnostic; only this module flag (and the
+            // backend's COFF object writer) differs. Without it, a `-g`
+            // windows-msvc build emits DWARF-in-PE that cdb/WinDbg cannot read.
+            // Every non-Windows target keeps DWARF only (no CodeView flag), so
+            // the Linux/macOS path is byte-for-byte unchanged.
+            //
+            // Mirror `abi_class::is_windows_msvc`: match the `-msvc` environment,
+            // not the arch. `FlagBehavior::Warning` matches how clang emits this
+            // flag (it tolerates a module that also carries DWARF metadata).
+            if module_triple.contains("windows-msvc") || module_triple.ends_with("-msvc") {
+                let codeview_enabled = ctx.i32_type().const_int(1, false);
+                llvm_mod.add_basic_value_flag(
+                    "CodeView",
+                    inkwell::module::FlagBehavior::Warning,
+                    codeview_enabled,
+                );
+            }
             let file = compile_unit.get_file();
             Some((di_builder, compile_unit, file))
         } else {
@@ -38736,6 +38762,70 @@ mod tests {
             user_clone_record_seeds: vec![],
             lint_warnings: vec![],
         }
+    }
+
+    /// Build `empty_pipeline_with_const_42` for `triple` with a `-g` debug input
+    /// and return the printed module IR. Threading a `DebugInput` is what makes
+    /// `build_module_for_target` construct the `DICompileUnit` and add the
+    /// module-level debug-format flags — the locus under test.
+    fn debug_module_ir_for_triple(triple: &str) -> String {
+        let ctx = Context::create();
+        let pipeline = empty_pipeline_with_const_42();
+        let machine = target_machine_for_triple(triple)
+            .unwrap_or_else(|e| panic!("target machine for {triple}: {e:?}"));
+        let src_path = Path::new("codeview_flag_probe.hew");
+        let debug = DebugInput {
+            source_path: src_path,
+            source_text: "fn main() -> i64 { 42 }\n",
+        };
+        let module = build_module_for_target(
+            &ctx,
+            &pipeline,
+            "codeview_flag_probe",
+            Some(&machine),
+            Some(debug),
+        )
+        .unwrap_or_else(|e| panic!("debug module must build for {triple}: {e:?}"));
+        module.print_to_string().to_string()
+    }
+
+    /// A `-g` build for a `*-windows-msvc` triple must add the module-level
+    /// `"CodeView"` flag (= 1) so the LLVM COFF backend emits CodeView records
+    /// (`.debug$S`/`.debug$T`) that cdb/WinDbg can read. Without it, a `-g`
+    /// windows-msvc build emits DWARF-in-PE that Windows-native debuggers ignore
+    /// (#2117). The flag is what the value-asserting cdb e2e on the Windows host
+    /// ultimately depends on; this is its cross-platform-emittable lower tier.
+    #[test]
+    fn windows_msvc_debug_build_adds_codeview_module_flag() {
+        let ir = debug_module_ir_for_triple("x86_64-pc-windows-msvc");
+        // The module-flags metadata records the flag as `!"CodeView", i32 1`.
+        assert!(
+            ir.contains("\"CodeView\""),
+            "windows-msvc `-g` IR must carry the CodeView module flag:\n{ir}"
+        );
+        // The shared DIE graph (DWARF compile unit) is still constructed — only
+        // the format flag differs — so the "Debug Info Version" flag stays too.
+        assert!(
+            ir.contains("\"Debug Info Version\""),
+            "windows-msvc `-g` IR must still carry the Debug Info Version flag:\n{ir}"
+        );
+    }
+
+    /// The CodeView flag is Windows-MSVC-only: a `-g` build for a non-Windows
+    /// triple keeps DWARF and must NOT carry the CodeView flag, so the
+    /// Linux/macOS DWARF path is byte-for-byte unchanged (the shared-DIE-graph
+    /// regression guard at the module-flag level).
+    #[test]
+    fn non_windows_debug_build_omits_codeview_module_flag() {
+        let ir = debug_module_ir_for_triple("x86_64-unknown-linux-gnu");
+        assert!(
+            !ir.contains("\"CodeView\""),
+            "linux `-g` IR must NOT carry the CodeView module flag (DWARF only):\n{ir}"
+        );
+        assert!(
+            ir.contains("\"Debug Info Version\""),
+            "linux `-g` IR must carry the Debug Info Version flag:\n{ir}"
+        );
     }
 
     /// Decode the architecture tag from a relocatable object's header without

--- a/hew-codegen-rs/tests/dwarf_emitted_object.rs
+++ b/hew-codegen-rs/tests/dwarf_emitted_object.rs
@@ -14,6 +14,11 @@
 //! neither is found the test is a no-op skip (it cannot run, it must not
 //! fail-open into a false green — but a missing host tool is not a code defect).
 //!
+//! The object is always compiled for `x86_64-unknown-linux-gnu` (ELF+DWARF),
+//! regardless of the host. On Windows CI the host default triple is
+//! `x86_64-pc-windows-msvc`, which emits CodeView instead of DWARF; pinning to
+//! the Linux triple keeps these DWARF assertions deterministic on every platform.
+//!
 //! LESSONS applied:
 //! - `ci_gate_trust` / proving-gate-is-the-compiled-artefact (P1): assert on the
 //!   object the toolchain emits, not an intermediate the emitter may rewrite.
@@ -105,7 +110,12 @@ fn emit_object(slug: &str) -> PathBuf {
         out_dir: &tmp,
         native: true,
         wasm: false,
-        target_triple: None,
+        // Pin to an explicit DWARF target so these assertions hold on every
+        // host. Without this, Windows CI defaults to x86_64-pc-windows-msvc,
+        // which emits CodeView instead of DWARF and the dwarfdump assertions
+        // fail. x86_64-unknown-linux-gnu produces ELF+DWARF on any host;
+        // llvm-dwarfdump is format-agnostic and can read ELF on Windows.
+        target_triple: Some("x86_64-unknown-linux-gnu"),
         debug: true,
         opt_level: hew_codegen_rs::OptLevel::O0,
         source_path: Some(src_path.as_path()),


### PR DESCRIPTION
## Summary

Windows-MSVC `-g` builds now emit CodeView debug info and a sidecar `.pdb` so cdb, WinDbg, and Visual Studio can read symbols, source lines, and locals. Previously, `-g` on a `windows-msvc` target produced DWARF embedded in the PE — a format Windows-native debuggers don't read — leaving the debug channel effectively silent on Windows.

Codegen adds the LLVM `"CodeView" = i32 1` module flag when the target triple is `windows-msvc`; this is what tells the LLVM COFF backend to write `.debug$S`/`.debug$T` sections instead of DWARF. The shared `DICompileUnit`/`DISubprogram`/`DILocalVariable` DIE graph is unchanged and used by both paths. The linker attaches `/DEBUG:FULL /PDB:<output>.pdb` only when `debug && plan.needs_pdb_debug`; a release Windows link and all non-Windows debug links are untouched.

## Verification

- `windows_msvc_debug_build_adds_codeview_module_flag`: IR for `x86_64-pc-windows-msvc -g` carries `!"CodeView", i32 1` and `!"Debug Info Version", i32 3` — pass
- `non_windows_debug_build_omits_codeview_module_flag`: IR for `x86_64-unknown-linux-gnu -g` carries no CodeView flag — pass
- `windows_link_plan_requests_pdb_debug`: Windows link plan sets `needs_pdb_debug = true`; Darwin/Linux/FreeBSD/Wasi/WasmFreestanding assert `false` — pass
- `pdb_path_replaces_exe_suffix` / `pdb_path_appends_when_no_exe_suffix`: PDB path derivation (sibling-stem `.pdb`) — pass
- `dwarf_emitted_object` (4), `dwarf_variable_dies` (6): non-Windows DWARF DIE path untouched — pass
- Full targeted run: 24/24 pass (CodeView, PDB, link-plan, debug-build); DWARF object/variable suites 10/10 pass
- Cross-ecosystem review: COFF output parsed on macOS — `.debug$S` signature `0x4` (CV_SIGNATURE_C13), `S_GPROC32_ID ×1`, `S_LOCAL ×3` with names `['selector', 'first', 'first']` matching the shadowed-local fixture exactly
- Windows host end-to-end: `hew build -g` produced `shadow.exe` + `shadow.pdb`; under `cdb`, `shadow!probe` resolved by name (not bare address), `.lines -e` bound source breakpoints, `dv /v` showed inner `first = 0n43` and outer `first = 0n42` — correct distinct values for the shadowed-local test
- Preflight: ready-to-push

## Out of scope

- CI codeview-debugger-locals e2e (mirroring the existing DWARF e2e with a Windows-native debugger check in CI) — to be filed as a follow-up
- Aligning `needs_pdb_debug` in the link plan to the `msvc` environment predicate (currently keyed on `TargetOs::Windows`, covering `windows-gnu` too; the entire Windows link layer is already MSVC-flavoured so this is cosmetic, but the predicates should match) — to be filed as a follow-up
- Updating the `-g` help text (still references the old "DWARF-in-PE on Windows … tracked #2117" language) — to be filed as a follow-up

Fixes #2117