### PR TITLE
ci(windows): cap cargo build parallelism to avoid rustc OOM on giant codegen crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,6 +450,17 @@ jobs:
       # pregenerated assembly objects, so the test-time hew-lib bootstrap links
       # without a NASM toolchain. (Parity with release-gate.yml / release.yml.)
       AWS_LC_SYS_PREBUILT_NASM: "1"
+      # Cap concurrent rustc invocations on the Windows runner to avoid OOM.
+      # hew-codegen-rs/llvm.rs (~33k lines) consumes ~2-3 GB of RSS per rustc
+      # process under the LLVM backend; with the default job count equal to the
+      # runner's CPU count (4), peak concurrent RSS exceeds the runner's 16 GB
+      # and the kernel kills rustc (STATUS_STACK_BUFFER_OVERRUN / 0xc0000409).
+      # Two concurrent jobs fit comfortably (2 × 3 GB = 6 GB peak for codegen,
+      # leaving headroom for the OS, LLVM headers, and the linker pass).
+      # Linux and macOS runners have more headroom at their default parallelism
+      # and are unaffected. Revisit when hew-codegen-rs/llvm.rs is split into
+      # smaller modules, or when the Windows runner gains more memory.
+      CARGO_BUILD_JOBS: "2"
     steps:
       - name: No-op for docs-only changes
         if: env.RUN_CODE_PATH != 'true'


### PR DESCRIPTION
## Summary

The workspace build has been OOMing on the Windows CI runner consistently across two recent PRs. The cause: hew-codegen-rs/llvm.rs (~33k lines) consumes roughly 2–3 GB of RSS per rustc invocation under the LLVM backend. With the default `CARGO_BUILD_JOBS` equal to the 4-core windows-2022 runner's CPU count, the combined peak RSS exceeds the 16 GB ceiling and the kernel terminates rustc with STATUS_STACK_BUFFER_OVERRUN (0xc0000409 / "memory allocation of N bytes failed").

Confirmed as a systemic threshold: a single-crate `cargo build -p hew-codegen-rs` completes cleanly in ~26s, proving this is parallel-rustc memory contention under the workspace build, not a code or linker bug. The v0.6 substrate growth tipped the total resident demand past the runner limit.

Fix: set `CARGO_BUILD_JOBS=2` in the Windows job's `env:` block only. Two concurrent rustc invocations stay comfortably within the budget (~6 GB peak for codegen, leaving headroom for the OS, LLVM, and the linker pass). Linux and macOS runners have more headroom at their default parallelism and are unaffected.

## Verification

This PR's own Windows Build & test job is the proof: a green run means the cap resolves the OOM. Local gate: leak-scan clean, `cargo fmt --all -- --check` clean, `make test-rust` 10270/10270 pass on macOS. No Rust source changed.

## Out of scope

Splitting hew-codegen-rs/llvm.rs into smaller modules or crates is the durable fix, eliminating the per-crate memory spike at source. Tracked separately. If the Windows runner spec gains more memory, the CARGO_BUILD_JOBS cap can be revisited or removed at that time.