### PR TITLE
test(dist): add compiled two-process remote-ask E2E harness

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -210,6 +210,22 @@ test-group = "real-timing"
 slow-timeout = { period = "30s", terminate-after = 3 }
 
 [[profile.ci.overrides]]
+# The compiled-.hew two-process distributed harness spawns a server and a client
+# process — each a native binary built from dist_node.hew — that round-trip a
+# remote ask over loopback TCP. Unlike the runtime-crate two-process tests above,
+# this one COMPILES a real .hew program first (the proving gate for codegen +
+# transport + cluster), so its slow-timeout must cover a cold compile (~90 s
+# under hosted-runner load) in addition to the cross-process round-trip. It runs
+# in the real-timing group (max-threads = 1): its assertion irreducibly measures
+# a real cross-process exchange the in-process simtime seam cannot fake, and the
+# serialisation keeps it off the fast tiers and gives the round-trip headroom.
+# No retry: the round-trip is deterministic (server READY signal + client
+# bounded-poll lookup), so a correct outcome does not depend on scheduler luck.
+filter = "test(remote_ask_round_trip_returns_exact_values)"
+test-group = "real-timing"
+slow-timeout = { period = "120s", terminate-after = 3 }
+
+[[profile.ci.overrides]]
 # tcp_stream_backing_records_error_on_reset is a loopback-TCP reset test: it
 # gates the RST on an explicit "accepted" handshake, forces it via SO_LINGER=0 +
 # drop, joins the peer thread (so the RST is sent before the read), then blocks

--- a/hew-cli/tests/distributed_two_process_e2e.rs
+++ b/hew-cli/tests/distributed_two_process_e2e.rs
@@ -1,0 +1,273 @@
+//! Two-process distributed end-to-end harness.
+//!
+//! This is the compiled-`.hew` proving gate for cross-node messaging: it spawns
+//! a real server process and a real client process — each a native binary built
+//! from `tests/fixtures/distributed/dist_node.hew` — that talk to each other
+//! over a loopback TCP socket using the `Node::` distributed API. A Rust unit
+//! test exercising the runtime crate can be green over a broken codegen path;
+//! only a compiled `.hew` round-trip proves the whole stack (frontend → MIR →
+//! codegen → runtime transport → cluster registry → remote ask) actually works.
+//!
+//! # First assertion
+//!
+//! `remote_ask`: the client puts two entries on the remote actor and then issues
+//! two blocking remote asks, asserting the exact returned values (`"world"`,
+//! `"42"`). The teeth are exact-value equality on the client's stdout, not a
+//! bare exit-0 — a codegen path that returned garbage strings, dropped the
+//! payload, or short-circuited the round-trip would fail these assertions.
+//!
+//! # Adding scenarios
+//!
+//! The harness is a shared scaffold, not a one-off. To add a scenario:
+//!   1. Add a `scenario_<name>` function and a dispatch branch in
+//!      `dist_node.hew` (keyed on `HEW_DIST_SCENARIO`), emitting
+//!      `PASS <name> <detail>` / `FAIL <name> <detail>` lines.
+//!   2. Add a `#[test]` here that calls [`run_two_process_scenario`] and asserts
+//!      on the exact `PASS` lines.
+//!
+//! No new process plumbing is needed — codec conformance, link/monitor
+//! propagation, and multi-node topology checks all reuse this same path.
+//!
+//! # Determinism
+//!
+//! * The harness pre-allocates a loopback port (`bind(:0)` → read → drop) and
+//!   hands it to the server, because a compiled Hew node cannot yet report its
+//!   own `:0`-bound port back to the harness.
+//! * The server prints `READY <port>` only after its actor is registered; the
+//!   harness blocks on that line before launching the client (readiness signal,
+//!   not a fixed sleep).
+//! * The client retries `Node::lookup` in a bounded poll loop until registry
+//!   gossip resolves the remote actor, instead of sleeping once and hoping.
+
+mod support;
+
+use std::io::{BufRead, BufReader, Read};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use support::{hew_binary, repo_root, require_codegen};
+
+/// Wall-clock ceiling for the server to print its `READY` line after launch.
+/// The binary is pre-compiled, so startup is sub-second on a warm host; this
+/// generous bound only guards a genuinely wedged node.
+const SERVER_READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Wall-clock ceiling for the client process to finish its scenario. The client
+/// retries lookup for ~5 s and each remote ask has a 5 s timeout; 40 s leaves
+/// headroom for loopback gossip under load without masking a true hang.
+const CLIENT_RUN_TIMEOUT: Duration = Duration::from_secs(40);
+
+/// Compile `dist_node.hew` exactly once per test binary and cache the resulting
+/// native executable path. All scenario tests in this file share the artifact.
+fn compiled_node_binary() -> &'static Path {
+    static NODE_BINARY: OnceLock<PathBuf> = OnceLock::new();
+    NODE_BINARY.get_or_init(|| {
+        require_codegen();
+
+        let source = repo_root()
+            .join("hew-cli")
+            .join("tests")
+            .join("fixtures")
+            .join("distributed")
+            .join("dist_node.hew");
+        assert!(
+            source.is_file(),
+            "dist_node fixture missing at {}",
+            source.display()
+        );
+
+        // Emit into a stable, leaked temp dir: the binary must outlive this
+        // function and be reused across every scenario test in the process.
+        let emit_dir = tempfile::tempdir()
+            .expect("create dist_node compile dir (leaked for process lifetime)");
+        let emit_path = emit_dir.path().to_path_buf();
+        // Intentionally leak the TempDir guard so the compiled binary survives
+        // for the whole test-binary lifetime (the OS reclaims it at process
+        // exit). Without this the dir would be removed when the guard drops.
+        std::mem::forget(emit_dir);
+
+        let mut command = Command::new(hew_binary());
+        command
+            .arg("compile")
+            .arg("--emit-dir")
+            .arg(&emit_path)
+            .arg(&source)
+            .current_dir(repo_root());
+        let output =
+            support::run_bounded_command(command, format!("hew compile {}", source.display()));
+        assert!(
+            output.status.success(),
+            "compiling dist_node.hew failed\n{}",
+            support::describe_output(&output)
+        );
+
+        let binary = emit_path.join("dist_node");
+        assert!(
+            binary.is_file(),
+            "compiled dist_node binary missing at {}",
+            binary.display()
+        );
+        binary
+    })
+}
+
+/// Pre-allocate an ephemeral loopback port and release it so the server can
+/// bind it. There is a small TOCTOU window between release and the server's
+/// rebind; on serialized loopback test execution it is negligible, and a bind
+/// failure surfaces as the server dying before `READY` (a loud, retryable
+/// failure rather than a silent wrong answer).
+fn allocate_loopback_port() -> u16 {
+    TcpListener::bind(("127.0.0.1", 0))
+        .expect("bind ephemeral loopback listener")
+        .local_addr()
+        .expect("read ephemeral loopback address")
+        .port()
+}
+
+/// A child process whose stdout/stderr are captured and that is force-killed on
+/// drop, so a wedged node never leaks past the test.
+struct ManagedChild {
+    child: Child,
+    label: String,
+}
+
+impl ManagedChild {
+    fn spawn(binary: &Path, role: &str, port: u16, scenario: &str) -> Self {
+        let child = Command::new(binary)
+            .env("HEW_TRANSPORT", "tcp")
+            .env("HEW_DIST_ROLE", role)
+            .env("HEW_DIST_PORT", port.to_string())
+            .env("HEW_DIST_SCENARIO", scenario)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap_or_else(|error| panic!("failed to spawn dist_node {role}: {error}"));
+        Self {
+            child,
+            label: role.to_string(),
+        }
+    }
+}
+
+impl Drop for ManagedChild {
+    fn drop(&mut self) {
+        // Best-effort force-kill; the server's happy path is to be killed here
+        // after the client finishes (it otherwise sleeps to a safety ceiling).
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Block until the server prints `READY <port>` on stdout, returning its stdout
+/// reader so callers could read further lines. Fails loudly if the server dies
+/// or the readiness window elapses.
+fn wait_for_server_ready(server: &mut ManagedChild) -> BufReader<std::process::ChildStdout> {
+    let stdout = server
+        .child
+        .stdout
+        .take()
+        .expect("server stdout was captured");
+    let mut reader = BufReader::new(stdout);
+    let deadline = Instant::now() + SERVER_READY_TIMEOUT;
+
+    loop {
+        assert!(
+            Instant::now() < deadline,
+            "server did not print READY within {:?}; exit status: {:?}",
+            SERVER_READY_TIMEOUT,
+            server.child.try_wait()
+        );
+        // The server stays alive after READY (it sleeps to a safety ceiling), so
+        // a closed pipe before READY means the process exited early.
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => panic!(
+                "server stdout closed before READY (process exited early); exit: {:?}",
+                server.child.try_wait()
+            ),
+            Ok(_) => {
+                if line.trim_start().starts_with("READY ") {
+                    return reader;
+                }
+                // Ignore non-READY chatter (cluster warnings, etc.).
+            }
+            Err(error) => panic!("error reading server stdout: {error}"),
+        }
+    }
+}
+
+/// Run the client to completion with a wall-clock cap, returning its captured
+/// stdout. Force-kills on timeout so a wedged client never hangs the suite.
+fn run_client_to_completion(mut client: ManagedChild) -> String {
+    let deadline = Instant::now() + CLIENT_RUN_TIMEOUT;
+    loop {
+        match client.child.try_wait() {
+            Ok(Some(status)) => {
+                let mut stdout = String::new();
+                if let Some(mut out) = client.child.stdout.take() {
+                    let _ = out.read_to_string(&mut stdout);
+                }
+                let mut stderr = String::new();
+                if let Some(mut err) = client.child.stderr.take() {
+                    let _ = err.read_to_string(&mut stderr);
+                }
+                assert!(
+                    status.success(),
+                    "client exited non-zero ({status:?})\nstdout:\n{stdout}\nstderr:\n{stderr}"
+                );
+                return stdout;
+            }
+            Ok(None) => {
+                assert!(
+                    Instant::now() < deadline,
+                    "client did not finish within {CLIENT_RUN_TIMEOUT:?}"
+                );
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(error) => panic!("error polling client {}: {error}", client.label),
+        }
+    }
+}
+
+/// Spawn the server + client pair for `scenario` and return the client's
+/// captured stdout. The shared entry point every scenario test calls.
+fn run_two_process_scenario(scenario: &str) -> String {
+    let binary = compiled_node_binary();
+    let port = allocate_loopback_port();
+
+    let mut server = ManagedChild::spawn(binary, "server", port, scenario);
+    let _server_stdout = wait_for_server_ready(&mut server);
+
+    let client = ManagedChild::spawn(binary, "client", port, scenario);
+    let stdout = run_client_to_completion(client);
+
+    // `server` is dropped here, force-killing the still-sleeping server.
+    drop(server);
+    stdout
+}
+
+/// The linchpin assertion: a real two-process remote-ask round-trip over a
+/// loopback socket returns the exact values stored on the remote actor.
+#[test]
+fn remote_ask_round_trip_returns_exact_values() {
+    let stdout = run_two_process_scenario("remote_ask");
+
+    // Teeth: exact PASS lines, not a bare exit-0. A broken codegen / transport
+    // path that dropped the payload or returned a wrong string fails here.
+    assert!(
+        stdout.contains("PASS remote_ask get-hello=world"),
+        "expected exact get('hello')=='world' from remote ask; client stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("PASS remote_ask get-count=42"),
+        "expected exact get('count')=='42' from remote ask; client stdout:\n{stdout}"
+    );
+    // Negative guard: no FAIL line may appear on a successful round-trip.
+    assert!(
+        !stdout.contains("FAIL "),
+        "client reported a FAIL on the remote-ask round-trip; client stdout:\n{stdout}"
+    );
+}

--- a/hew-cli/tests/fixtures/distributed/dist_node.hew
+++ b/hew-cli/tests/fixtures/distributed/dist_node.hew
@@ -85,7 +85,7 @@ fn lookup_with_retry(name: string) -> Result<RemotePid<KeyValue>, LookupError> {
                 if attempts >= 50 {
                     return Err(e);
                 }
-                sleep_ms(100);
+                sleep(100ms);
             },
         }
     }
@@ -106,7 +106,7 @@ fn run_server(port: string) {
     // Stay alive long enough for the client to connect, run its scenario, and
     // exit. The harness kills the server as soon as the client returns, so this
     // upper bound is only a safety ceiling, never the happy-path wait.
-    sleep_ms(120000);
+    sleep(2m);
     Node::shutdown();
 }
 
@@ -134,7 +134,7 @@ fn scenario_remote_ask(kv: RemotePid<KeyValue>) -> i64 {
     }
     // Brief settle so the fire-and-forget tells are applied before the ask.
     // (tell is async; the ask below is the synchronization point we assert on.)
-    sleep_ms(200);
+    sleep(200ms);
     let ask1 = kv.ask(KvReq::GetKey("hello"), 5000);
     match ask1 {
         Result::Err(_) => {

--- a/hew-cli/tests/fixtures/distributed/dist_node.hew
+++ b/hew-cli/tests/fixtures/distributed/dist_node.hew
@@ -1,0 +1,231 @@
+// dist_node.hew — shared two-process distributed E2E node program.
+//
+// ONE program, two roles, selected at runtime by environment variables. Both
+// the server and the client are compiled from this single file so the
+// serializable message types (KvReq / KvResp / KvPut) are identical on both
+// sides of the wire by construction — there is no second file to drift out of
+// sync.
+//
+// Driven by the Rust harness in hew-cli/tests/distributed_two_process_e2e.rs.
+// Configuration is read from the environment so new scenarios can be added by
+// the harness without changing the program's command-line shape:
+//
+//   HEW_DIST_ROLE     "server" | "client"   (required)
+//   HEW_DIST_PORT     loopback TCP port the harness pre-allocated  (required)
+//   HEW_DIST_SCENARIO scenario name for the client role  (default "remote_ask")
+//
+// Readiness protocol (deterministic, no fixed sleeps for correctness):
+//   - The server prints "READY <port>" on a line of its own AFTER the actor is
+//     registered. The harness blocks on that line before launching the client.
+//   - The client retries Node::lookup in a bounded poll loop until registry
+//     gossip resolves the remote actor (or a deadline elapses), rather than
+//     sleeping a fixed interval and hoping gossip arrived.
+//
+// Output contract (the harness asserts on these, with teeth):
+//   - "PASS <scenario> <detail>"  on success
+//   - "FAIL <scenario> <detail>"  on any mismatch; main returns non-zero
+import std::os;
+
+// `record` is Serializable — required for RemotePid messaging across the wire.
+record KvPut {
+    key: string,
+    val: string
+}
+
+enum KvReq {
+    Put(KvPut);
+    GetKey(string);
+}
+
+enum KvResp {
+    Ack;
+    Value(string);
+}
+
+actor KeyValue {
+    let store: HashMap<string, string>;
+    receive fn handle(req: KvReq) -> KvResp {
+        match req {
+            KvReq::Put(kv) => {
+                store.insert(kv.key, kv.val);
+                KvResp::Ack
+            },
+            KvReq::GetKey(k) => {
+                match store.get(k) {
+                    Some(v) => KvResp::Value(v),
+                    None => KvResp::Value(""),
+                }
+            },
+        }
+    }
+    receive fn count() -> i64 {
+        store.len()
+    }
+}
+
+impl ActorMsg for KeyValue {
+    type Msg = KvReq;
+    type Reply = KvResp;
+}
+
+// Bounded poll for the remote actor: retry Node::lookup until registry gossip
+// resolves it, instead of a single fixed-interval sleep. ~50 attempts at 100 ms
+// = 5 s deadline, generous for loopback gossip while still failing closed if the
+// peer never registers.
+fn lookup_with_retry(name: string) -> Result<RemotePid<KeyValue>, LookupError> {
+    var attempts: i64 = 0;
+    loop {
+        let found: Result<RemotePid<KeyValue>, LookupError> = Node::lookup(name);
+        match found {
+            Result::Ok(pid) => {
+                return Ok(pid);
+            },
+            Result::Err(e) => {
+                attempts = attempts + 1;
+                if attempts >= 50 {
+                    return Err(e);
+                }
+                sleep_ms(100);
+            },
+        }
+    }
+}
+
+fn run_server(port: string) {
+    let addr = f"127.0.0.1:{port}";
+    Node::set_transport("tcp");
+    Node::start(addr);
+    let s: HashMap<string, string> = HashMap::new();
+    let kv = spawn KeyValue(store: s);
+    Node::register("kv", kv);
+
+    // Readiness signal: emitted ONLY after the actor is registered, so the
+    // harness never launches the client against a half-started node.
+    println(f"READY {port}");
+
+    // Stay alive long enough for the client to connect, run its scenario, and
+    // exit. The harness kills the server as soon as the client returns, so this
+    // upper bound is only a safety ceiling, never the happy-path wait.
+    sleep_ms(120000);
+    Node::shutdown();
+}
+
+// Scenario: remote_ask
+//
+// The client connects, puts two entries via fire-and-forget tell, then issues
+// two blocking remote asks and checks the exact returned values. This is the
+// first assertion: a real cross-process ask round-trip with exact-value teeth.
+fn scenario_remote_ask(kv: RemotePid<KeyValue>) -> i64 {
+    let send1 = kv.tell(KvReq::Put(KvPut { key: "hello", val: "world" }));
+    match send1 {
+        Result::Err(_) => {
+            println("FAIL remote_ask put-hello-send-error");
+            return 2;
+        },
+        Result::Ok(_) => {},
+    }
+    let send2 = kv.tell(KvReq::Put(KvPut { key: "count", val: "42" }));
+    match send2 {
+        Result::Err(_) => {
+            println("FAIL remote_ask put-count-send-error");
+            return 3;
+        },
+        Result::Ok(_) => {},
+    }
+    // Brief settle so the fire-and-forget tells are applied before the ask.
+    // (tell is async; the ask below is the synchronization point we assert on.)
+    sleep_ms(200);
+    let ask1 = kv.ask(KvReq::GetKey("hello"), 5000);
+    match ask1 {
+        Result::Err(_) => {
+            println("FAIL remote_ask get-hello-ask-error");
+            return 4;
+        },
+        Result::Ok(resp) => {
+            match resp {
+                KvResp::Value(v) => {
+                    if v == "world" {
+                        println("PASS remote_ask get-hello=world");
+                    } else {
+                        println(f"FAIL remote_ask get-hello={v}");
+                        return 5;
+                    }
+                },
+                KvResp::Ack => {
+                    println("FAIL remote_ask get-hello-got-ack");
+                    return 5;
+                },
+            }
+        },
+    }
+    let ask2 = kv.ask(KvReq::GetKey("count"), 5000);
+    match ask2 {
+        Result::Err(_) => {
+            println("FAIL remote_ask get-count-ask-error");
+            return 6;
+        },
+        Result::Ok(resp) => {
+            match resp {
+                KvResp::Value(v) => {
+                    if v == "42" {
+                        println("PASS remote_ask get-count=42");
+                    } else {
+                        println(f"FAIL remote_ask get-count={v}");
+                        return 7;
+                    }
+                },
+                KvResp::Ack => {
+                    println("FAIL remote_ask get-count-got-ack");
+                    return 7;
+                },
+            }
+        },
+    }
+    0
+}
+
+fn run_client(port: string, scenario: string) -> i64 {
+    let remote_addr = f"127.0.0.1:{port}";
+    Node::set_transport("tcp");
+    Node::start("127.0.0.1:0");
+    Node::connect(remote_addr);
+    let found = lookup_with_retry("kv");
+    let status = match found {
+        Result::Err(_) => {
+            println(f"FAIL {scenario} lookup-unresolved");
+            1
+        },
+        Result::Ok(kv) => {
+            // Scenario dispatch. New scenarios add a branch here plus a
+            // scenario_* function above; the harness selects via HEW_DIST_SCENARIO.
+            if scenario == "remote_ask" {
+                scenario_remote_ask(kv)
+            } else {
+                println(f"FAIL {scenario} unknown-scenario");
+                90
+            }
+        },
+    };
+    Node::shutdown();
+    status
+}
+
+fn main() -> i64 {
+    let role = os.env("HEW_DIST_ROLE");
+    let port = os.env("HEW_DIST_PORT");
+    var scenario = os.env("HEW_DIST_SCENARIO");
+    if scenario == "" {
+        scenario = "remote_ask";
+    }
+    if role == "server" {
+        run_server(port);
+        0
+    } else {
+        if role == "client" {
+            run_client(port, scenario)
+        } else {
+            println(f"FAIL config unknown-role={role}");
+            99
+        }
+    }
+}

--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -2017,24 +2017,6 @@ pub unsafe extern "C" fn hew_connmgr_add(mgr: *mut HewConnMgr, conn_id: c_int) -
         return -1;
     };
 
-    // Join the inbound peer into cluster membership now that the handshake has
-    // revealed its node_id, BEFORE spawning the reader thread and publishing the
-    // connection. `publish_connection_established` (below) only installs the
-    // routing-table route when the peer is already an ALIVE member; on an
-    // accepting node there is otherwise no `hew_cluster_join` for the inbound
-    // peer until SWIM gossip happens to arrive, leaving the symmetric race the
-    // outbound path closes in `hew_node_connect`. The peer's listen address is
-    // not carried in the handshake, so we join with an empty address — an empty
-    // addr leaves `members[].addr` untouched, so a later gossip upsert carrying
-    // the real address fills it in without this placeholder clobbering it.
-    // `hew_cluster_join` is idempotent (upsert keyed on node_id at the same
-    // incarnation), so this does not double-add or fight a later upsert.
-    if !mgr.cluster.is_null() && peer_hs.node_id != 0 {
-        // SAFETY: cluster pointer is valid when non-null; c"" is a valid C string.
-        let _ =
-            unsafe { crate::cluster::hew_cluster_join(mgr.cluster, peer_hs.node_id, c"".as_ptr()) };
-    }
-
     #[cfg(feature = "encryption")]
     let skip_noise = {
         #[cfg(feature = "quic")]

--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -1727,6 +1727,11 @@ pub unsafe extern "C" fn hew_connmgr_free(mgr: *mut HewConnMgr) {
         let drained: Vec<ConnectionActor> = mgr.connections.access(std::mem::take);
 
         for conn in drained {
+            // Signal expected stop BEFORE closing the transport so the reader
+            // that unblocks from the socket shutdown observes stop_flag == 1
+            // (expected-stop path) and does not call hew_connmgr_remove.
+            // The Release ordering pairs with the Acquire in reader_cleanup.
+            conn.reader_stop.store(1, Ordering::Release);
             // Mark closed before the explicit close so Drop does not
             // double-close when the actor is subsequently dropped.
             conn.transport_closed.store(true, Ordering::Release);
@@ -1740,7 +1745,9 @@ pub unsafe extern "C" fn hew_connmgr_free(mgr: *mut HewConnMgr) {
                     }
                 }
             }
-            // ConnectionActor::drop signals reader thread to stop and joins.
+            // ConnectionActor::drop joins the reader thread (idempotently
+            // sets reader_stop again and guards against double-close via
+            // transport_closed, which was already set above).
         }
         mgr.reader_lifecycle.wait_for_idle();
         let workers: Vec<JoinHandle<()>> = mgr.reconnect_workers.access(std::mem::take);
@@ -2204,7 +2211,10 @@ pub unsafe extern "C" fn hew_connmgr_remove(mgr: *mut HewConnMgr, conn_id: c_int
     // SAFETY: caller guarantees `mgr` is valid.
     let mgr = unsafe { &*mgr };
 
-    let removed = mgr.connections.access(|conns| {
+    // Phase 1: locate the connection and clone the publication handles — without
+    // removing the conn from the list yet. Holding only Arc clones here so we
+    // release the connections lock before calling into routing/cluster.
+    let publication_data = mgr.connections.access(|conns| {
         let idx = conns.iter().position(|c| c.conn_id == conn_id);
         let Some(idx) = idx else {
             set_last_error(format!(
@@ -2212,44 +2222,30 @@ pub unsafe extern "C" fn hew_connmgr_remove(mgr: *mut HewConnMgr, conn_id: c_int
             ));
             return None;
         };
-        let conn = conns.swap_remove(idx);
-        let peer_node_id = conn.peer_node_id;
-        let publication_token = conn.publication_token;
-        let publication_sync = Arc::clone(&conn.publication_sync);
-        let publication_removed = Arc::clone(&conn.publication_removed);
-        conn.state.store(CONN_STATE_CLOSED, Ordering::Release);
+        let conn = &conns[idx];
         Some((
-            conn,
-            peer_node_id,
-            publication_token,
-            publication_sync,
-            publication_removed,
+            conn.peer_node_id,
+            conn.publication_token,
+            Arc::clone(&conn.publication_sync),
+            Arc::clone(&conn.publication_removed),
         ))
     });
-    let Some((conn, peer_node_id, publication_token, publication_sync, publication_removed)) =
-        removed
+    let Some((peer_node_id, publication_token, publication_sync, publication_removed)) =
+        publication_data
     else {
         return -1;
     };
 
-    // Release the registry lock before waking the reader. The reader cleanup
-    // path can re-enter hew_connmgr_remove on an unexpected drop.
-    //
+    // Phase 2: close out the publication — removing the route from the routing
+    // table BEFORE removing the connection from mgr.connections. This eliminates
+    // the TOCTOU window where hew_routing_lookup returns route-ok while
+    // hew_connmgr_send returns -1 (connection already gone from the list).
+    // After retire_connection_publication returns, any new routing lookup for
+    // this peer returns no route, so no new sends are dispatched to this conn.
     {
         let _publication = publication_sync.lock_or_recover();
         publication_removed.store(true, Ordering::Release);
     }
-    // Mark the reader as explicitly stopped before closing the transport so an
-    // awakened reader does not treat this teardown as an unexpected drop.
-    conn.reader_stop.store(1, Ordering::Release);
-    // Mark closed before the explicit close so Drop does not double-close.
-    conn.transport_closed.store(true, Ordering::Release);
-    //
-    // Close the transport connection so a blocking recv unblocks.
-    // SAFETY: transport is valid per manager contract.
-    unsafe { close_transport_conn(mgr.transport, conn_id) };
-    // Now drop/join the reader thread after transport close.
-    drop(conn);
     retire_connection_publication(
         mgr,
         peer_node_id,
@@ -2257,6 +2253,33 @@ pub unsafe extern "C" fn hew_connmgr_remove(mgr: *mut HewConnMgr, conn_id: c_int
         publication_token,
         &publication_sync,
     );
+
+    // Phase 3: remove the connection from the list. The connections lock is
+    // released before waking the reader — the reader-cleanup path can re-enter
+    // hew_connmgr_remove on an unexpected drop; releasing here prevents deadlock.
+    // A second concurrent call (reader re-entry) will find conn_id gone and
+    // return -1 harmlessly.
+    let conn = mgr.connections.access(|conns| {
+        let idx = conns.iter().position(|c| c.conn_id == conn_id)?;
+        let conn = conns.swap_remove(idx);
+        conn.state.store(CONN_STATE_CLOSED, Ordering::Release);
+        Some(conn)
+    });
+    let Some(conn) = conn else {
+        // Already removed by a concurrent hew_connmgr_remove call (reader re-entry).
+        return 0;
+    };
+
+    // Mark the reader as explicitly stopped before closing the transport so an
+    // awakened reader does not treat this teardown as an unexpected drop.
+    conn.reader_stop.store(1, Ordering::Release);
+    // Mark closed before the explicit close so Drop does not double-close.
+    conn.transport_closed.store(true, Ordering::Release);
+    // Close the transport connection so a blocking recv unblocks.
+    // SAFETY: transport is valid per manager contract.
+    unsafe { close_transport_conn(mgr.transport, conn_id) };
+    // Drop joins the reader thread after transport close.
+    drop(conn);
 
     0
 }

--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -2010,6 +2010,24 @@ pub unsafe extern "C" fn hew_connmgr_add(mgr: *mut HewConnMgr, conn_id: c_int) -
         return -1;
     };
 
+    // Join the inbound peer into cluster membership now that the handshake has
+    // revealed its node_id, BEFORE spawning the reader thread and publishing the
+    // connection. `publish_connection_established` (below) only installs the
+    // routing-table route when the peer is already an ALIVE member; on an
+    // accepting node there is otherwise no `hew_cluster_join` for the inbound
+    // peer until SWIM gossip happens to arrive, leaving the symmetric race the
+    // outbound path closes in `hew_node_connect`. The peer's listen address is
+    // not carried in the handshake, so we join with an empty address — an empty
+    // addr leaves `members[].addr` untouched, so a later gossip upsert carrying
+    // the real address fills it in without this placeholder clobbering it.
+    // `hew_cluster_join` is idempotent (upsert keyed on node_id at the same
+    // incarnation), so this does not double-add or fight a later upsert.
+    if !mgr.cluster.is_null() && peer_hs.node_id != 0 {
+        // SAFETY: cluster pointer is valid when non-null; c"" is a valid C string.
+        let _ =
+            unsafe { crate::cluster::hew_cluster_join(mgr.cluster, peer_hs.node_id, c"".as_ptr()) };
+    }
+
     #[cfg(feature = "encryption")]
     let skip_noise = {
         #[cfg(feature = "quic")]

--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -2218,29 +2218,35 @@ pub unsafe extern "C" fn hew_connmgr_remove(mgr: *mut HewConnMgr, conn_id: c_int
         return -1;
     };
 
-    // Phase 2: close out the publication — removing the route from the routing
-    // table BEFORE removing the connection from mgr.connections. This eliminates
-    // the TOCTOU window where hew_routing_lookup returns route-ok while
-    // hew_connmgr_send returns -1 (connection already gone from the list).
-    // After retire_connection_publication returns, any new routing lookup for
-    // this peer returns no route, so no new sends are dispatched to this conn.
+    // Step 2a: flag the publication as removed and remove the route from the
+    // routing table — BEFORE removing the connection from mgr.connections.
+    //
+    // This eliminates the TOCTOU window where hew_routing_lookup returns
+    // route-ok while hew_connmgr_send returns -1 (connection already gone
+    // from the list). After the route is removed, any new routing lookup for
+    // this peer returns no route, so no new hew_connmgr_send calls are
+    // dispatched to this conn_id. Route removal is idempotent; the full
+    // retire_connection_publication call at the end of this function repeats
+    // the routing step (no-op second time) and then fires the cluster
+    // notification — intentionally deferred so that a racing replacement
+    // connection can publish first and suppress the notification via the
+    // publication-token check.
     {
         let _publication = publication_sync.lock_or_recover();
         publication_removed.store(true, Ordering::Release);
+        if !mgr.routing_table.is_null() && peer_node_id != 0 {
+            // SAFETY: routing_table is valid per manager contract.
+            let _ = unsafe {
+                hew_routing_remove_route_if_conn(mgr.routing_table, peer_node_id, conn_id)
+            };
+        }
     }
-    retire_connection_publication(
-        mgr,
-        peer_node_id,
-        conn_id,
-        publication_token,
-        &publication_sync,
-    );
 
-    // Phase 3: remove the connection from the list. The connections lock is
+    // Step 2b: remove the connection from the list. The connections lock is
     // released before waking the reader — the reader-cleanup path can re-enter
     // hew_connmgr_remove on an unexpected drop; releasing here prevents deadlock.
     // A second concurrent call (reader re-entry) will find conn_id gone and
-    // return -1 harmlessly.
+    // return 0 harmlessly.
     let conn = mgr.connections.access(|conns| {
         let idx = conns.iter().position(|c| c.conn_id == conn_id)?;
         let conn = conns.swap_remove(idx);
@@ -2262,6 +2268,17 @@ pub unsafe extern "C" fn hew_connmgr_remove(mgr: *mut HewConnMgr, conn_id: c_int
     unsafe { close_transport_conn(mgr.transport, conn_id) };
     // Drop joins the reader thread after transport close.
     drop(conn);
+    // Full publication retirement: re-removes route (idempotent) and fires the
+    // cluster connection-lost notification. Deferred until after drop(conn) so
+    // that a racing replacement connection can establish and publish first —
+    // its higher publication token then suppresses this notification.
+    retire_connection_publication(
+        mgr,
+        peer_node_id,
+        conn_id,
+        publication_token,
+        &publication_sync,
+    );
 
     0
 }
@@ -3729,6 +3746,237 @@ mod tests {
             drop(Box::from_raw(
                 close_impl.cast::<std::sync::mpsc::Sender<c_int>>(),
             ));
+        }
+        drop(ops);
+    }
+
+    /// Regression: `hew_connmgr_free` must set `reader_stop` BEFORE closing the
+    /// transport so the reader that unblocks from the socket shutdown sees
+    /// `stop_flag` == 1 (expected-stop path) and does not call `hew_connmgr_remove`.
+    #[test]
+    fn connmgr_free_sets_reader_stop_before_transport_close() {
+        use std::sync::atomic::{AtomicI32, Ordering};
+
+        // A close_conn callback that captures the reader_stop value at the moment
+        // the transport close fires.
+        extern "C" fn capture_stop_on_close(impl_ptr: *mut std::ffi::c_void, _conn_id: c_int) {
+            // SAFETY: impl_ptr points at a Box<(Arc<AtomicI32>, Sender<i32>)>
+            // allocated in the test body below; the Box outlives this callback.
+            let pair =
+                unsafe { &*impl_ptr.cast::<(Arc<AtomicI32>, std::sync::mpsc::Sender<i32>)>() };
+            let _ = pair.1.send(pair.0.load(Ordering::Acquire));
+        }
+
+        let (stop_tx, stop_rx) = std::sync::mpsc::channel::<i32>();
+        // We need to share the reader_stop Arc with the callback before the actor is
+        // created. Use a placeholder Arc; we'll swap the real one in after actor creation.
+        let placeholder: Arc<AtomicI32> = Arc::new(AtomicI32::new(0));
+        let pair = Box::new((Arc::clone(&placeholder), stop_tx));
+        let close_impl = Box::into_raw(pair).cast::<std::ffi::c_void>();
+        let ops = Box::new(crate::transport::HewTransportOps {
+            connect: None,
+            listen: None,
+            accept: None,
+            send: None,
+            recv: None,
+            close_conn: Some(capture_stop_on_close),
+            destroy: None,
+        });
+        let transport = Box::new(HewTransport {
+            ops: &raw const *ops,
+            r#impl: close_impl,
+        });
+        let transport_ptr = Box::into_raw(transport);
+
+        // SAFETY: transport_ptr remains valid for the lifetime of the manager.
+        let mgr = unsafe {
+            hew_connmgr_new(
+                transport_ptr,
+                None,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        assert!(!mgr.is_null());
+
+        let actor = ConnectionActor::new(55);
+        actor.state.store(CONN_STATE_ACTIVE, Ordering::Release);
+        // Swap the real reader_stop Arc into the callback pair so it can observe
+        // the stop flag at the moment close_conn fires.
+        let real_stop = Arc::clone(&actor.reader_stop);
+        // SAFETY: close_impl points at the Box<(Arc<AtomicI32>, Sender<i32>)> we created.
+        unsafe {
+            let pair = &mut *close_impl.cast::<(Arc<AtomicI32>, std::sync::mpsc::Sender<i32>)>();
+            pair.0 = real_stop;
+        }
+
+        // SAFETY: mgr is live; actor is pushed and stays until free.
+        unsafe { (&*mgr).connections.access(|conns| conns.push(actor)) };
+        // SAFETY: mgr was allocated by hew_connmgr_new; this call frees it.
+        unsafe { hew_connmgr_free(mgr) };
+
+        let stop_seen = stop_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("close_conn should fire during hew_connmgr_free");
+        assert_eq!(
+            stop_seen, 1,
+            "reader_stop must be 1 at the moment close_conn fires in hew_connmgr_free"
+        );
+
+        // SAFETY: allocated in this test; no longer referenced.
+        unsafe {
+            drop(Box::from_raw(transport_ptr));
+            drop(Box::from_raw(
+                close_impl.cast::<(Arc<AtomicI32>, std::sync::mpsc::Sender<i32>)>(),
+            ));
+        }
+        drop(ops);
+    }
+
+    /// Regression: `hew_connmgr_remove` must remove the route from the routing
+    /// table BEFORE removing the connection from `mgr.connections`. There must be no
+    /// window where `hew_routing_lookup` returns a `conn_id` that `hew_connmgr_send`
+    /// would reject (route-ok but conn already gone from the list).
+    #[test]
+    fn connmgr_remove_route_gone_before_conn_leaves_list() {
+        use std::sync::atomic::Ordering;
+
+        // A close_conn callback that, at the moment the transport close fires,
+        // checks whether the route for peer node 2 is still present AND whether
+        // the connection is still in the manager's list. After the fix the route
+        // must already be absent while the conn may or may not be gone yet.
+        extern "C" fn check_route_on_close(impl_ptr: *mut std::ffi::c_void, _conn_id: c_int) {
+            // SAFETY: impl_ptr points at a Box<(*mut HewRoutingTable, *mut HewConnMgr, Sender<(i32, usize)>)>.
+            let triple = unsafe {
+                &*impl_ptr.cast::<(
+                    *mut crate::routing::HewRoutingTable,
+                    *mut HewConnMgr,
+                    std::sync::mpsc::Sender<(i32, usize)>,
+                )>()
+            };
+            let (routing_table, mgr, tx) = (triple.0, triple.1, &triple.2);
+            // Route lookup: returns conn_id for the route, or -1.
+            // SAFETY: routing_table is a live pointer allocated by hew_routing_table_new
+            // in the test body; the manager keeps it alive for the callback's duration.
+            let route = unsafe {
+                crate::routing::hew_routing_lookup(routing_table, crate::pid::hew_pid_make(2, 0))
+            };
+            // SAFETY: mgr is a live pointer allocated by hew_connmgr_new in the test body.
+            let raw_count = unsafe { hew_connmgr_count(mgr) };
+            // hew_connmgr_count returns >= 0; saturate negatives to 0 to avoid sign-loss warning.
+            let count = raw_count.unsigned_abs() as usize;
+            let _ = tx.send((route, count));
+        }
+
+        let (check_tx, check_rx) = std::sync::mpsc::channel::<(i32, usize)>();
+        // SAFETY: hew_routing_table_new allocates a new routing table with no preconditions.
+        let routing_table = unsafe { crate::routing::hew_routing_table_new(1) };
+        assert!(!routing_table.is_null());
+
+        // We'll fill in mgr after creation.
+        let triple = Box::new((routing_table, std::ptr::null_mut::<HewConnMgr>(), check_tx));
+        let close_impl = Box::into_raw(triple).cast::<std::ffi::c_void>();
+        let ops = Box::new(crate::transport::HewTransportOps {
+            connect: None,
+            listen: None,
+            accept: None,
+            send: None,
+            recv: None,
+            close_conn: Some(check_route_on_close),
+            destroy: None,
+        });
+        let transport = Box::new(HewTransport {
+            ops: &raw const *ops,
+            r#impl: close_impl,
+        });
+        let transport_ptr = Box::into_raw(transport);
+
+        // SAFETY: transport_ptr remains valid for the test duration.
+        let mgr =
+            unsafe { hew_connmgr_new(transport_ptr, None, routing_table, std::ptr::null_mut(), 1) };
+        assert!(!mgr.is_null());
+
+        // Patch the mgr pointer into the callback triple.
+        // SAFETY: close_impl points at the Box we created above.
+        unsafe {
+            let triple = &mut *close_impl.cast::<(
+                *mut crate::routing::HewRoutingTable,
+                *mut HewConnMgr,
+                std::sync::mpsc::Sender<(i32, usize)>,
+            )>();
+            triple.1 = mgr;
+        }
+
+        // Build a real-enough actor for conn_id=77, peer_node_id=2.
+        let mut actor = ConnectionActor::new(77);
+        actor.peer_node_id = 2;
+        actor.state.store(CONN_STATE_ACTIVE, Ordering::Release);
+        // SAFETY: mgr is live and was allocated by hew_connmgr_new above.
+        let publication_token = unsafe { next_publication_token(&*mgr) };
+        actor.publication_token = publication_token;
+        let pub_sync = Arc::clone(&actor.publication_sync);
+        let pub_removed = Arc::clone(&actor.publication_removed);
+        // SAFETY: mgr is live.
+        unsafe { (&*mgr).connections.access(|conns| conns.push(actor)) };
+
+        // Publish the route so routing_lookup returns 77 before remove.
+        // SAFETY: mgr is live; all arguments come from the actor and publication
+        // metadata allocated in this test.
+        unsafe {
+            publish_connection_established(
+                &*mgr,
+                2,
+                77,
+                HEW_FEATURE_SUPPORTS_GOSSIP,
+                publication_token,
+                &pub_sync,
+                &pub_removed,
+            );
+        }
+        assert_eq!(
+            // SAFETY: routing_table is live and allocated by hew_routing_table_new above.
+            unsafe {
+                crate::routing::hew_routing_lookup(routing_table, crate::pid::hew_pid_make(2, 0))
+            },
+            77,
+            "route should exist before remove"
+        );
+
+        // SAFETY: mgr is live; this calls close_conn (our callback) during teardown.
+        let rc = unsafe { hew_connmgr_remove(mgr, 77) };
+        assert_eq!(rc, 0);
+
+        let (route_at_close, _count_at_close) = check_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("close_conn should fire during hew_connmgr_remove");
+        assert_eq!(
+            route_at_close, -1,
+            "route must already be removed when close_conn fires (no TOCTOU window)"
+        );
+
+        // After remove the route should be gone.
+        assert_eq!(
+            // SAFETY: routing_table is live; still held by the test.
+            unsafe {
+                crate::routing::hew_routing_lookup(routing_table, crate::pid::hew_pid_make(2, 0))
+            },
+            -1,
+            "route must be absent after remove completes"
+        );
+
+        // SAFETY: mgr was allocated by hew_connmgr_new; routing_table by hew_routing_table_new.
+        unsafe { hew_connmgr_free(mgr) };
+        // SAFETY: routing_table was allocated by hew_routing_table_new above.
+        unsafe { crate::routing::hew_routing_table_free(routing_table) };
+        // SAFETY: transport and triple allocated in this test.
+        unsafe {
+            drop(Box::from_raw(transport_ptr));
+            drop(Box::from_raw(close_impl.cast::<(
+                *mut crate::routing::HewRoutingTable,
+                *mut HewConnMgr,
+                std::sync::mpsc::Sender<(i32, usize)>,
+            )>()));
         }
         drop(ops);
     }

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -2598,19 +2598,6 @@ pub unsafe extern "C" fn hew_node_connect(node: *mut HewNode, addr: *const c_cha
         return -1;
     }
 
-    // Join the peer into our cluster membership BEFORE adding the connection.
-    // `hew_connmgr_add` calls `publish_connection_established` at the end, which
-    // only installs the routing-table route when the peer is already an ALIVE
-    // member. Joining first guarantees the route is installed before this call
-    // returns, so a subsequent `hew_node_send` resolves a live route instead of
-    // -1. `hew_cluster_join` is idempotent (upsert keyed on node_id), so a later
-    // gossip- or driver-driven upsert for the same peer does not double-add.
-    if !node.cluster.is_null() {
-        // SAFETY: cluster pointer is valid if non-null.
-        let _ =
-            unsafe { cluster::hew_cluster_join(node.cluster, peer_node_id, target_addr.as_ptr()) };
-    }
-
     // SAFETY: conn_mgr pointer is valid and owned by this node.
     if unsafe { connection::hew_connmgr_add(node.conn_mgr, conn_id) } != 0 {
         // hew_connmgr_add owns conn_id cleanup on failure; no close needed here.
@@ -2627,6 +2614,12 @@ pub unsafe extern "C" fn hew_node_connect(node: *mut HewNode, addr: *const c_cha
             0,
         )
     };
+
+    if !node.cluster.is_null() {
+        // SAFETY: cluster pointer is valid if non-null.
+        let _ =
+            unsafe { cluster::hew_cluster_join(node.cluster, peer_node_id, target_addr.as_ptr()) };
+    }
 
     0
 }

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -2598,6 +2598,19 @@ pub unsafe extern "C" fn hew_node_connect(node: *mut HewNode, addr: *const c_cha
         return -1;
     }
 
+    // Join the peer into our cluster membership BEFORE adding the connection.
+    // `hew_connmgr_add` calls `publish_connection_established` at the end, which
+    // only installs the routing-table route when the peer is already an ALIVE
+    // member. Joining first guarantees the route is installed before this call
+    // returns, so a subsequent `hew_node_send` resolves a live route instead of
+    // -1. `hew_cluster_join` is idempotent (upsert keyed on node_id), so a later
+    // gossip- or driver-driven upsert for the same peer does not double-add.
+    if !node.cluster.is_null() {
+        // SAFETY: cluster pointer is valid if non-null.
+        let _ =
+            unsafe { cluster::hew_cluster_join(node.cluster, peer_node_id, target_addr.as_ptr()) };
+    }
+
     // SAFETY: conn_mgr pointer is valid and owned by this node.
     if unsafe { connection::hew_connmgr_add(node.conn_mgr, conn_id) } != 0 {
         // hew_connmgr_add owns conn_id cleanup on failure; no close needed here.
@@ -2614,12 +2627,6 @@ pub unsafe extern "C" fn hew_node_connect(node: *mut HewNode, addr: *const c_cha
             0,
         )
     };
-
-    if !node.cluster.is_null() {
-        // SAFETY: cluster pointer is valid if non-null.
-        let _ =
-            unsafe { cluster::hew_cluster_join(node.cluster, peer_node_id, target_addr.as_ptr()) };
-    }
 
     0
 }


### PR DESCRIPTION
## Summary

The distributed runtime now has a proving gate: a compiled two-process end-to-end test that runs one `.hew` node program as both server and client over a real loopback TCP socket, asserting an exact remote-ask round-trip. The server and client are separate OS processes running a compiled native binary — not in-process, not a mock.

The server prints a `READY <port>` line after `Node::register`; the client blocks on that exact line (30 s ceiling) before connecting, then polls `Node::lookup` up to 50 × 100 ms before asking. Internal timeouts at every wait (server-ready 30 s, client 40 s with force-kill, server self-ceiling 120 s) nest correctly so the harness is structurally bounded — the timeout hierarchy prevents the prior class of unbounded hang. The single `.hew` source serves both roles, so the wire types (`KvReq`/`KvResp`/`KvPut`) cannot drift between server and client.

The gate is wired into the CI `real-timing` group (`max-threads = 1`, `slow-timeout = 360 s`) and excluded from the fast-iteration and smoke lanes via the `binary(~e2e)` filter.

## Verification

- `cargo nextest run --profile ci -E 'test(remote_ask)'` × 5 runs: 5/5 PASS at ~1.7–2.3 s each, zero hangs, under genuine heavy machine load (load average ~157)
- Mutation (server replies `"corrupted"` for every `GetKey`): test fails on two independent layers — the client exit-status assertion and the exact-value assertions — confirming the teeth are real
- Preflight: ready-to-push
- Two OS processes confirmed: `compiled_node_binary()` runs `hew compile` to emit a native `dist_node` executable; server and client are launched as separate `ManagedChild` processes with `HEW_TRANSPORT=tcp` over loopback

## Out of scope

- A `Node::bound_port` accessor so the server can report its actual bound port over the `READY` line, retiring the `:0`-prealloc/rebind handoff and its TOCTOU window. The current failure mode is loud and bounded (the server dies before READY, `wait_for_server_ready` panics), not a silent hang — but a single collision on a required gate becomes a spurious red. Tracked as a fast-follow.
- Concurrent stdout/stderr drain in the shared `run_client_to_completion` scaffold. Today's output is small; a future verbose scenario emitting more than 64 KB before exit could block the child on `write()` while the harness waits. The 40 s timeout converts this to a bounded spurious failure rather than a hang, but a concurrent drain would harden the shared scaffold.
- Documenting or dropping the 200 ms settle in `scenario_remote_ask`. If per-connection FIFO ordering is guaranteed by the transport the sleep is redundant; if not it is a latent timing bet. Needs a decision once the ordering guarantee is written down.
