### PR TITLE
build(licenses): add rc1 license-compliance gate and regenerate THIRD-PARTY-LICENSES

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,12 +198,13 @@ jobs:
 
   # ─────────────────────────────────────────────────────────────────────────
   # License gate — enforce the deny.toml allow-list so no copyleft or unknown
-  # dep silently enters the shipping graph. Runs on every push/PR; fast (~5 s).
+  # dep silently enters the shipping graph, and assert THIRD-PARTY-LICENSES is
+  # current relative to Cargo.lock. Runs on every push/PR; fast (~30 s).
   # ─────────────────────────────────────────────────────────────────────────
   license-check:
-    name: License policy (cargo deny)
+    name: License policy (cargo deny + THIRD-PARTY-LICENSES freshness)
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
@@ -219,6 +220,12 @@ jobs:
 
       - name: Check bans and sources
         run: cargo deny check bans sources
+
+      - name: Install cargo-about
+        run: cargo install cargo-about --locked --version 0.9.0
+
+      - name: Verify THIRD-PARTY-LICENSES is current
+        run: scripts/check-licenses-fresh.sh --quiet
 
   # ─────────────────────────────────────────────────────────────────────────
   # Browser/playground smoke — repo-local browser tooling coverage only.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
         run: cargo deny check bans sources
 
       - name: Install cargo-about
-        run: cargo install cargo-about --locked --version 0.9.0
+        run: cargo install cargo-about --locked --version 0.9.0 --features cli
 
       - name: Verify THIRD-PARTY-LICENSES is current
         run: scripts/check-licenses-fresh.sh --quiet

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@
 #   make sandbox-parity            — native hew run ↔ sandbox VM parity harness
 #   make playground-check          — manifest freshness + full hew-wasm test suite + build hew-wasm
 #   make playground-wasi-check     — focused curated manifest WASI runtime preflight
+#   make licenses                  — regenerate THIRD-PARTY-LICENSES from current Cargo.lock
+#   make licenses-check            — verify THIRD-PARTY-LICENSES is current (used in CI)
 #   make ci-preflight              — dispatch a conservative local preflight from the current diff
 #   make ci-preflight-smoke        — fast smoke tier: fmt + in-process tests (<5 min)
 #   make ci-preflight-strict       — run the local preflight superset that mirrors merge-queue gates
@@ -67,7 +69,7 @@
 #   make clean        — remove build/, target/
 # ============================================================================
 
-.PHONY: all build bootstrap install-hooks hew hew-native adze observe observe-functional-test runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh
+.PHONY: all build bootstrap install-hooks hew hew-native adze observe observe-functional-test runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh licenses licenses-check
 .PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all test-fast test-stdlib test-hew test-hew-ratchet test-o2-differential test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
@@ -183,6 +185,16 @@ sandbox-fixtures:
 
 sandbox-fixtures-check:
 	cargo run -p xtask -- sandbox-fixtures --check
+
+# Regenerate THIRD-PARTY-LICENSES from the current dependency tree.
+# Requires cargo-about: cargo install cargo-about --locked
+licenses:
+	cargo about generate about.hbs --workspace > THIRD-PARTY-LICENSES
+
+# Verify THIRD-PARTY-LICENSES is current relative to Cargo.lock and about.hbs.
+# Exits non-zero if the file is stale; run 'make licenses' to regenerate.
+licenses-check:
+	scripts/check-licenses-fresh.sh
 
 sandbox-parity: hew stdlib
 	@set -e; \

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -13,10 +13,11 @@ License summary by SPDX identifier:
   BSD 3-Clause "New" or "Revised" License (5 packages)
   Boost Software License 1.0 (2 packages)
   Community Data License Agreement Permissive 2.0 (2 packages)
-  zlib License (2 packages)
   BSD Zero Clause License (1 package)
   Creative Commons Zero v1.0 Universal (1 package)
   Mozilla Public License 2.0 (1 package)
+  Unicode License Agreement - Data Files and Software (2016) (1 package)
+  zlib License (1 package)
 
 ================================================================================
 
@@ -669,8 +670,8 @@ Apache License 2.0
   * static_assertions 1.1.0 — https://github.com/nvzqz/static-assertions-rs
   * tinyvec 1.11.0 — https://github.com/Lokathor/tinyvec
   * utf8_iter 1.0.4 — https://github.com/hsivonen/utf8_iter
-  * zeroize 1.8.2 — https://github.com/RustCrypto/utils
-  * zeroize_derive 1.4.3 — https://github.com/RustCrypto/utils/tree/master/zeroize/derive
+  * zeroize 1.9.0 — https://github.com/RustCrypto/utils
+  * zeroize_derive 1.5.0 — https://github.com/RustCrypto/utils
 
 
                                  Apache License
@@ -1112,7 +1113,6 @@ Apache License 2.0
   * windows-strings 0.5.1 — https://github.com/microsoft/windows-rs
   * windows-sys 0.45.0 — https://github.com/microsoft/windows-rs
   * windows-sys 0.52.0 — https://github.com/microsoft/windows-rs
-  * windows-sys 0.59.0 — https://github.com/microsoft/windows-rs
   * windows-sys 0.60.2 — https://github.com/microsoft/windows-rs
   * windows-sys 0.61.2 — https://github.com/microsoft/windows-rs
   * windows-targets 0.42.2 — https://github.com/microsoft/windows-rs
@@ -3867,7 +3867,7 @@ limitations under the License.
 
 ================================================================================
 Apache License 2.0
-  * reqwest 0.13.3 — https://github.com/seanmonstar/reqwest
+  * reqwest 0.13.4 — https://github.com/seanmonstar/reqwest
 
                               Apache License
                         Version 2.0, January 2004
@@ -5733,11 +5733,217 @@ limitations under the License.
 
 ================================================================================
 Apache License 2.0
+  * page_size 0.6.0 — https://github.com/Elzair/page_size_rs
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+================================================================================
+Apache License 2.0
   * atomic-waker 1.1.2 — https://github.com/smol-rs/atomic-waker
   * autocfg 1.5.0 — https://github.com/cuviper/autocfg
   * base64 0.22.1 — https://github.com/marshallpierce/rust-base64
   * bitflags 1.3.2 — https://github.com/bitflags/bitflags
-  * bitflags 2.11.1 — https://github.com/bitflags/bitflags
+  * bitflags 2.13.0 — https://github.com/bitflags/bitflags
   * bstr 1.12.1 — https://github.com/BurntSushi/bstr
   * bumpalo 3.20.2 — https://github.com/fitzgen/bumpalo
   * cast 0.3.0 — https://github.com/japaric/cast.rs
@@ -5748,8 +5954,9 @@ Apache License 2.0
   * core-foundation-sys 0.8.7 — https://github.com/servo/core-foundation-rs
   * core-foundation 0.10.1 — https://github.com/servo/core-foundation-rs
   * core-foundation 0.9.4 — https://github.com/servo/core-foundation-rs
-  * criterion-plot 0.5.0 — https://github.com/bheisler/criterion.rs
-  * criterion 0.5.1 — https://github.com/bheisler/criterion.rs
+  * criterion-plot 0.8.2 — https://github.com/criterion-rs/criterion.rs
+  * criterion 0.8.2 — https://github.com/criterion-rs/criterion.rs
+  * critical-section 1.2.0 — https://github.com/rust-embedded/critical-section
   * crossbeam-deque 0.8.6 — https://github.com/crossbeam-rs/crossbeam
   * crossbeam-epoch 0.9.18 — https://github.com/crossbeam-rs/crossbeam
   * crossbeam-utils 0.8.21 — https://github.com/crossbeam-rs/crossbeam
@@ -5766,21 +5973,19 @@ Apache License 2.0
   * form_urlencoded 1.2.2 — https://github.com/servo/rust-url
   * getopts 0.2.24 — https://github.com/rust-lang/getopts
   * hashbrown 0.14.5 — https://github.com/rust-lang/hashbrown
-  * hashbrown 0.15.5 — https://github.com/rust-lang/hashbrown
   * hashbrown 0.16.1 — https://github.com/rust-lang/hashbrown
   * hashbrown 0.17.1 — https://github.com/rust-lang/hashbrown
   * heck 0.5.0 — https://github.com/withoutboats/heck
-  * hermit-abi 0.5.2 — https://github.com/hermit-os/hermit-rs
   * httparse 1.10.1 — https://github.com/seanmonstar/httparse
   * hyper-rustls 0.27.9 — https://github.com/rustls/hyper-rustls
   * idna 1.1.0 — https://github.com/servo/rust-url/
   * idna_adapter 1.2.2 — https://github.com/hsivonen/idna_adapter
   * indexmap 2.14.0 — https://github.com/indexmap-rs/indexmap
-  * itertools 0.10.5 — https://github.com/rust-itertools/itertools
+  * itertools 0.13.0 — https://github.com/rust-itertools/itertools
   * itertools 0.14.0 — https://github.com/rust-itertools/itertools
   * jni 0.21.1 — https://github.com/jni-rs/jni-rs
   * jobserver 0.1.34 — https://github.com/rust-lang/jobserver-rs
-  * js-sys 0.3.98 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys
+  * js-sys 0.3.102 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys
   * lazy_static 1.5.0 — https://github.com/rust-lang-nursery/lazy-static.rs
   * linux-raw-sys 0.12.1 — https://github.com/sunfishcode/linux-raw-sys
   * lock_api 0.4.14 — https://github.com/Amanieu/parking_lot
@@ -5800,8 +6005,8 @@ Apache License 2.0
   * rayon 1.12.0 — https://github.com/rayon-rs/rayon
   * regex-automata 0.4.14 — https://github.com/rust-lang/regex
   * regex-lite 0.1.9 — https://github.com/rust-lang/regex
-  * regex-syntax 0.8.10 — https://github.com/rust-lang/regex
-  * regex 1.12.3 — https://github.com/rust-lang/regex
+  * regex-syntax 0.8.11 — https://github.com/rust-lang/regex
+  * regex 1.12.4 — https://github.com/rust-lang/regex
   * ring 0.17.14 — https://github.com/briansmith/ring
   * rustc_version 0.4.1 — https://github.com/djc/rustc-version-rs
   * rustix 1.1.4 — https://github.com/bytecodealliance/rustix
@@ -5816,7 +6021,7 @@ Apache License 2.0
   * signal-hook 0.3.18 — https://github.com/vorner/signal-hook
   * simd_cesu8 1.1.1 — https://github.com/seancroach/simd_cesu8
   * smallvec 1.15.1 — https://github.com/servo/rust-smallvec
-  * socket2 0.6.3 — https://github.com/rust-lang/socket2
+  * socket2 0.6.4 — https://github.com/rust-lang/socket2
   * stable_deref_trait 1.2.1 — https://github.com/storyyeller/stable_deref_trait
   * stacker 0.1.24 — https://github.com/rust-lang/stacker
   * system-configuration-sys 0.6.0 — https://github.com/mullvad/system-configuration-rs
@@ -5833,20 +6038,22 @@ Apache License 2.0
   * unicode-truncate 2.0.1 — https://github.com/Aetf/unicode-truncate
   * unicode-width 0.2.2 — https://github.com/unicode-rs/unicode-width
   * url 2.5.8 — https://github.com/servo/rust-url
-  * uuid 1.23.1 — https://github.com/uuid-rs/uuid
+  * uuid 1.23.3 — https://github.com/uuid-rs/uuid
   * version_check 0.9.5 — https://github.com/SergioBenitez/version_check
   * wait-timeout 0.2.1 — https://github.com/alexcrichton/wait-timeout
   * wasi 0.11.1+wasi-snapshot-preview1 — https://github.com/bytecodealliance/wasi
   * wasip2 1.0.3+wasi-0.2.9 — https://github.com/bytecodealliance/wasi-rs
-  * wasm-bindgen-futures 0.4.71 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures
-  * wasm-bindgen-macro-support 0.2.121 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support
-  * wasm-bindgen-macro 0.2.121 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro
-  * wasm-bindgen-shared 0.2.121 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared
-  * wasm-bindgen 0.2.121 — https://github.com/wasm-bindgen/wasm-bindgen
-  * web-sys 0.3.98 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys
+  * wasm-bindgen-futures 0.4.75 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures
+  * wasm-bindgen-macro-support 0.2.125 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support
+  * wasm-bindgen-macro 0.2.125 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro
+  * wasm-bindgen-shared 0.2.125 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared
+  * wasm-bindgen 0.2.125 — https://github.com/wasm-bindgen/wasm-bindgen
+  * wasmparser 0.252.0 — https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser
+  * web-sys 0.3.102 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys
   * wit-bindgen 0.51.0 — https://github.com/bytecodealliance/wit-bindgen
   * wit-bindgen 0.57.1 — https://github.com/bytecodealliance/wit-bindgen
   * xattr 1.6.1 — https://github.com/Stebalien/xattr
+  * yasna 0.6.0 — https://github.com/qnighy/yasna.rs
 
                               Apache License
                         Version 2.0, January 2004
@@ -7978,6 +8185,7 @@ Apache License 2.0
   * dunce 1.0.5 — https://gitlab.com/kornelski/dunce
   * fastbloom 0.14.1 — https://github.com/tomtomwombat/fastbloom/
   * fiat-crypto 0.2.9 — https://github.com/mit-plv/fiat-crypto
+  * finl_unicode 1.4.0 — https://github.com/dahosek/finl_unicode
   * half 2.7.1 — https://github.com/VoidStarKat/half-rs
   * ident_case 1.0.1 — https://github.com/TedDriggs/ident_case
   * indoc 2.0.7 — https://github.com/dtolnay/indoc
@@ -8002,7 +8210,7 @@ Apache License 2.0
   * rand 0.9.4 — https://github.com/rust-random/rand
   * rand_chacha 0.9.0 — https://github.com/rust-random/rand
   * rand_xorshift 0.4.0 — https://github.com/rust-random/rngs
-  * rcgen 0.14.7 — https://github.com/rustls/rcgen
+  * rcgen 0.14.8 — https://github.com/rustls/rcgen
   * rustc-hash 2.1.2 — https://github.com/rust-lang/rustc-hash
   * rustls-platform-verifier-android 0.1.1 — https://github.com/rustls/rustls-platform-verifier
   * rustversion 1.0.22 — https://github.com/dtolnay/rustversion
@@ -8032,10 +8240,8 @@ Apache License 2.0
   * utf8-zero 0.8.1 — https://github.com/algesten/utf8-zero
   * utf8parse 0.2.2 — https://github.com/alacritty/vte
   * wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06 — https://github.com/bytecodealliance/wasi-rs
-  * wasmparser 0.244.0 — https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser
   * winapi-i686-pc-windows-gnu 0.4.0 — https://github.com/retep998/winapi-rs
   * winapi-x86_64-pc-windows-gnu 0.4.0 — https://github.com/retep998/winapi-rs
-  * yasna 0.5.2 — https://github.com/qnighy/yasna.rs
   * zstd-safe 7.2.4 — https://github.com/gyscos/zstd-rs
   * zstd-sys 2.0.16+zstd.1.5.7 — https://github.com/gyscos/zstd-rs
 
@@ -8116,7 +8322,7 @@ limitations under the License.
 
 ================================================================================
 Apache License 2.0
-  * chrono 0.4.44 — https://github.com/chronotope/chrono
+  * chrono 0.4.45 — https://github.com/chronotope/chrono
 
 Rust-chrono is dual-licensed under The MIT License [1] and
 Apache 2.0 License [2]. Copyright (c) 2014--2026, Kang Seonghoon and
@@ -8832,7 +9038,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 MIT License
-  * lettre 0.11.21 — https://github.com/lettre/lettre
+  * lettre 0.11.22 — https://github.com/lettre/lettre
 
 Copyright (c) 2014-2024 Alexis Mousset <contact@amousset.me>
 Copyright (c) 2019-2025 Paolo Barbolini <paolo@paolo565.org>
@@ -8865,7 +9071,7 @@ DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 MIT License
-  * hyper 1.9.0 — https://github.com/hyperium/hyper
+  * hyper 1.10.1 — https://github.com/hyperium/hyper
 
 Copyright (c) 2014-2026 Sean McArthur
 
@@ -9340,7 +9546,7 @@ THE SOFTWARE.
 
 ================================================================================
 MIT License
-  * ratatui-macros 0.7.0 — https://github.com/ratatui/ratatui
+  * ratatui-macros 0.7.1 — https://github.com/ratatui/ratatui
 
 Copyright (c) 2024 Dheepak Krishnamurthy
 Copyright (c) 2025 The Ratatui Developers
@@ -9404,7 +9610,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ================================================================================
 MIT License
-  * lru 0.16.4 — https://github.com/jeromefroe/lru-rs.git
+  * lru 0.18.0 — https://github.com/jeromefroe/lru-rs.git
 
 MIT License
 
@@ -9515,7 +9721,7 @@ SOFTWARE.
 ================================================================================
 MIT License
   * dashmap 5.5.3 — https://github.com/xacrimon/dashmap
-  * dashmap 6.1.0 — https://github.com/xacrimon/dashmap
+  * dashmap 6.2.1 — https://github.com/xacrimon/dashmap
 
 MIT License
 
@@ -9569,8 +9775,8 @@ SOFTWARE.
 
 ================================================================================
 MIT License
-  * strum 0.27.2 — https://github.com/Peternator7/strum
-  * strum_macros 0.27.2 — https://github.com/Peternator7/strum
+  * strum 0.28.0 — https://github.com/Peternator7/strum
+  * strum_macros 0.28.0 — https://github.com/Peternator7/strum
 
 MIT License
 
@@ -9663,6 +9869,33 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+================================================================================
+MIT License
+  * alloca 0.4.0 — https://github.com/playXE/alloca-rs
+
+MIT License
+
+Copyright (c) 2021 Adel Prokurov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 ================================================================================
@@ -9779,10 +10012,6 @@ MIT License
   * plotters-backend 0.3.7 — https://github.com/plotters-rs/plotters
   * plotters-svg 0.3.7 — https://github.com/plotters-rs/plotters.git
   * plotters 0.3.7 — https://github.com/plotters-rs/plotters
-  * ratatui-core 0.1.0 — https://github.com/ratatui/ratatui
-  * ratatui-crossterm 0.1.0 — https://github.com/ratatui/ratatui
-  * ratatui-widgets 0.3.0 — https://github.com/ratatui/ratatui
-  * ratatui 0.30.0 — https://github.com/ratatui/ratatui
 
 MIT License
 
@@ -9889,7 +10118,6 @@ SOFTWARE.
 
 ================================================================================
 MIT License
-  * is-terminal 0.4.17 — https://github.com/sunfishcode/is-terminal
   * unsafe-libyaml 0.2.11 — https://github.com/dtolnay/unsafe-libyaml
   * zmij 1.0.21 — https://github.com/dtolnay/zmij
 
@@ -9946,7 +10174,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ================================================================================
 MIT License
   * pulldown-cmark-escape 0.11.0 — https://github.com/raphlinus/pulldown-cmark
-  * pulldown-cmark 0.13.3 — https://github.com/raphlinus/pulldown-cmark
+  * pulldown-cmark 0.13.4 — https://github.com/raphlinus/pulldown-cmark
 
 The MIT License
 
@@ -10254,7 +10482,7 @@ SOFTWARE.
 
 ================================================================================
 MIT License
-  * jsonwebtoken 10.3.0 — https://github.com/Keats/jsonwebtoken
+  * jsonwebtoken 10.4.0 — https://github.com/Keats/jsonwebtoken
 
 The MIT License (MIT)
 
@@ -10370,6 +10598,37 @@ MIT License
 The MIT License (MIT)
 
 Copyright (c) 2016 Jonathan Creekmore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+================================================================================
+MIT License
+  * ratatui-core 0.1.1 — https://github.com/ratatui/ratatui
+  * ratatui-crossterm 0.1.1 — https://github.com/ratatui/ratatui
+  * ratatui-widgets 0.3.1 — https://github.com/ratatui/ratatui
+  * ratatui 0.30.1 — https://github.com/ratatui/ratatui
+
+The MIT License (MIT)
+
+Copyright (c) 2016-2022 Florian Dehau
+Copyright (c) 2023-2025 The Ratatui Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -10569,7 +10828,7 @@ SOFTWARE.
 
 ================================================================================
 MIT License
-  * quick-xml 0.39.4 — https://github.com/tafia/quick-xml
+  * quick-xml 0.40.1 — https://github.com/tafia/quick-xml
 
 The MIT License (MIT)
 
@@ -11118,8 +11377,35 @@ ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation a
 
 
 ================================================================================
+Unicode License Agreement - Data Files and Software (2016)
+  * finl_unicode 1.4.0 — https://github.com/dahosek/finl_unicode
+
+UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
+
+Unicode Data Files include all data files under the directories http://www.unicode.org/Public/, http://www.unicode.org/reports/, http://www.unicode.org/cldr/data/, http://source.icu-project.org/repos/icu/, and http://www.unicode.org/utility/trac/browser/.
+
+Unicode Data Files do not include PDF online code charts under the directory http://www.unicode.org/Public/.
+
+Software includes any source code published in the Unicode Standard or under the directories http://www.unicode.org/Public/, http://www.unicode.org/reports/, http://www.unicode.org/cldr/data/, http://source.icu-project.org/repos/icu/, and http://www.unicode.org/utility/trac/browser/.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"), YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2016 Unicode, Inc. All rights reserved. Distributed under the Terms of Use in http://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of the Unicode data files and any associated documentation (the "Data Files") or Unicode software and any associated documentation (the "Software") to deal in the Data Files or Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, and/or sell copies of the Data Files or Software, and to permit persons to whom the Data Files or Software are furnished to do so, provided that either
+
+     (a) this copyright and permission notice appear with all copies of the Data Files or Software, or
+     (b) this copyright and permission notice appear in associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall not be used in advertising or otherwise to promote the sale, use or other dealings in these Data Files or Software without prior written authorization of the copyright holder.
+
+
+================================================================================
 zlib License
-  * foldhash 0.1.5 — https://github.com/orlp/foldhash
   * foldhash 0.2.0 — https://github.com/orlp/foldhash
 
 Copyright (c) 2024 Orson Peters

--- a/scripts/check-licenses-fresh.sh
+++ b/scripts/check-licenses-fresh.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# check-licenses-fresh.sh — assert that THIRD-PARTY-LICENSES is not stale
+# relative to Cargo.lock and the about.toml/about.hbs templates.
+#
+# Regenerates the file in a temp location and diffs it against the committed
+# copy. Exits 0 if they match; exits 1 and shows the diff if they differ.
+#
+# Prerequisites: cargo-about must be installed.
+#   cargo install cargo-about --locked
+#
+# Usage: scripts/check-licenses-fresh.sh [--quiet]
+#   --quiet   Suppress progress messages; only print failures.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+QUIET=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --quiet) QUIET=1; shift ;;
+        *) echo "error: unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+COMMITTED="${REPO_ROOT}/THIRD-PARTY-LICENSES"
+
+if [[ ! -f "$COMMITTED" ]]; then
+    echo "error: THIRD-PARTY-LICENSES not found at ${COMMITTED}" >&2
+    echo "  Run 'make licenses' to generate it." >&2
+    exit 1
+fi
+
+if ! command -v cargo-about &>/dev/null && ! cargo about --version &>/dev/null 2>&1; then
+    echo "error: cargo-about not found — install with:" >&2
+    echo "  cargo install cargo-about --locked" >&2
+    exit 1
+fi
+
+TMPFILE="$(mktemp "/tmp/third-party-licenses.XXXXXX")"
+trap 'rm -f "$TMPFILE"' EXIT
+
+(( QUIET == 0 )) && echo "Regenerating THIRD-PARTY-LICENSES for freshness check..."
+
+# Suppress cargo-about's own progress chatter; capture only the generated output.
+cargo about generate "${REPO_ROOT}/about.hbs" --workspace \
+    --manifest-path "${REPO_ROOT}/Cargo.toml" \
+    2>/dev/null > "$TMPFILE"
+
+if diff -u "$COMMITTED" "$TMPFILE"; then
+    (( QUIET == 0 )) && echo "ok: THIRD-PARTY-LICENSES is current"
+    exit 0
+else
+    echo "" >&2
+    echo "error: THIRD-PARTY-LICENSES is stale (Cargo.lock or about.hbs changed)." >&2
+    echo "  Run 'make licenses' and commit the updated file." >&2
+    exit 1
+fi

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -353,6 +353,11 @@ is_scripts_config_path() {
         Makefile|.gitignore|scripts/*|.config/nextest.toml|.github/workflows/*|Cargo.toml|Cargo.lock|.cargo/*|rust-toolchain*)
             return 0
             ;;
+        # License and attribution files: THIRD-PARTY-LICENSES, NOTICE,
+        # about.toml, about.hbs, deny.toml — all build/policy config.
+        THIRD-PARTY-LICENSES|NOTICE|about.toml|about.hbs|deny.toml|LICENSE-*|LICENSE)
+            return 0
+            ;;
     esac
     return 1
 }


### PR DESCRIPTION
## Summary

`THIRD-PARTY-LICENSES` is now a regenerated, complete attribution file for the distributed dependency graph (465 crates, generated via cargo-about). A freshness gate (`scripts/check-licenses-fresh.sh`) is wired into CI and exposed as `make licenses` / `make licenses-check`, so the attribution file cannot silently drift from the dependency set — any dep change that affects the shipping graph will cause CI to fail until the file is regenerated. The cargo-deny license, bans, and sources policy is unchanged.

## Verification

- `scripts/check-licenses-fresh.sh`: passes clean; byte-identical to a fresh `cargo about generate` (11,432 lines, 465 crates, zero warnings)
- Drift simulation: simulated a stale committed copy and confirmed `diff` returns non-zero with the intended "stale — run `make licenses`" message
- `cargo deny check licenses`: `licenses ok`
- `cargo deny check bans sources`: `bans ok, sources ok`
- 66-crate metadata delta vs `cargo metadata` (507 packages): all confirmed dev/build/non-default-feature deps not reachable in the normal shipping graph — exclusion is correct
- CI step is blocking (no `continue-on-error`); timeout raised to 10 min to cover install + generate
- Preflight: ready-to-push

## Out of scope

- Wiring `cargo deny check advisories` into CI and bumping `quinn-proto` to address RUSTSEC-2026-0185 — pre-existing advisory, handled in a separate security lane
- Freshness script: surfacing `cargo-about` stderr on failure (currently `2>/dev/null`) and honouring `$TMPDIR` instead of hardcoded `/tmp`
- Cosmetic commit-message nit (`page_size` attribution claim)
- Adding `make licenses-check` to the `scripts-config` preflight lane (CI remains authoritative for now)
