### PR TITLE
feat(wire): describe the internode #[wire] CBOR body in CDDL and gate it

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -221,7 +221,10 @@ slow-timeout = { period = "30s", terminate-after = 3 }
 # serialisation keeps it off the fast tiers and gives the round-trip headroom.
 # No retry: the round-trip is deterministic (server READY signal + client
 # bounded-poll lookup), so a correct outcome does not depend on scheduler luck.
-filter = "test(remote_ask_round_trip_returns_exact_values)"
+# wire_cbor_cross_process_round_trip is the same harness with a #[wire]-typed
+# payload (explicit @N tags); it shares the compiled binary via OnceLock and runs
+# in the same serialized group for the same reasons.
+filter = "test(remote_ask_round_trip_returns_exact_values) | test(wire_cbor_cross_process_round_trip)"
 test-group = "real-timing"
 slow-timeout = { period = "120s", terminate-after = 3 }
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,37 @@
 version = 4
 
 [[package]]
+name = "abnf"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33741baa462d86e43fdec5e8ffca7c6ac82847ad06cbfb382c1bdbf527de9e6b"
+dependencies = [
+ "abnf-core",
+ "nom 7.1.3",
+]
+
+[[package]]
+name = "abnf-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c44e09c43ae1c368fb91a03a566472d0087c26cf7e1b9e8e289c14ede681dd7d"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
+name = "abnf_to_pest"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "939d59666dd9a7964a3a5312b9d24c9c107630752ee64f2dd5038189a23fe331"
+dependencies = [
+ "abnf",
+ "indexmap 1.9.3",
+ "itertools 0.10.5",
+ "pretty",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,7 +171,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -151,7 +182,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -189,6 +220,12 @@ dependencies = [
  "cpufeatures 0.2.17",
  "password-hash",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "ascii"
@@ -317,10 +354,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
+
+[[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-url"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261c4eaab63106ddf34d377f47e5428aa863b61e4a647c872778d9caf8e2c819"
+dependencies = [
+ "base64",
+]
 
 [[package]]
 name = "base64ct"
@@ -469,6 +527,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "cddl"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de674f6a75ba97c777b9d8a57edb9ff30dd238f4a99c2adcaee44198883da4d3"
+dependencies = [
+ "abnf_to_pest",
+ "base16",
+ "base45",
+ "base64-url",
+ "chrono",
+ "ciborium",
+ "ciborium-io",
+ "ciborium-ll",
+ "clap",
+ "codespan-reporting",
+ "console_error_panic_hook",
+ "csv",
+ "data-encoding",
+ "displaydoc",
+ "fancy-regex 0.17.0",
+ "hex",
+ "hexf-parse",
+ "itertools 0.14.0",
+ "js-sys",
+ "log",
+ "pest",
+ "pest_derive",
+ "pest_meta",
+ "pest_vm",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "simplelog",
+ "uriparse",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "web-sys",
+]
+
+[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,7 +628,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -644,6 +746,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +784,16 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -714,7 +837,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -914,6 +1037,27 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1126,7 +1270,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1230,7 +1374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1256,6 +1400,17 @@ checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set 0.5.3",
  "regex",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1548,7 +1703,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1565,6 +1720,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1780,6 +1941,7 @@ name = "hew-runtime"
 version = "0.5.6"
 dependencies = [
  "bytes",
+ "cddl",
  "ciborium",
  "criterion",
  "crossbeam-deque",
@@ -1920,6 +2082,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "home"
@@ -2187,6 +2355,16 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -2283,6 +2461,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2666,6 +2853,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2779,7 +2976,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2825,6 +3022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3038,6 +3236,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pest_vm"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f487f488a1eb0c345bb9137bf2c24583937dad7b85b9c1d7d337fa39694cc9c"
+dependencies = [
+ "pest",
+ "pest_meta",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,6 +3445,18 @@ checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f3aa1e3ca87d3b124db7461265ac176b40c277f37e503eaa29c9c75c037846"
+dependencies = [
+ "arrayvec",
+ "log",
+ "typed-arena",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3777,7 +3997,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3836,7 +4056,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3857,7 +4077,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3996,6 +4216,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4054,7 +4285,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -4172,6 +4403,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simplelog"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16257adbfaef1ee58b1363bdc0664c9b8e1e30aed86049635fb5f147d065a9c0"
+dependencies = [
+ "log",
+ "termcolor",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4213,7 +4455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4242,7 +4484,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4368,7 +4610,16 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -4407,7 +4658,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bitflags 2.13.0",
- "fancy-regex",
+ "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
  "fixedbitset",
@@ -4626,7 +4877,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -4839,6 +5090,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4955,6 +5212,16 @@ dependencies = [
  "http",
  "httparse",
  "log",
+]
+
+[[package]]
+name = "uriparse"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
+dependencies = [
+ "fnv",
+ "lazy_static",
 ]
 
 [[package]]
@@ -5129,6 +5396,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16931d57bcdd6a0dcc11254bdd1388827690c1b6807f0d2836f59a4f9eb30ac"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fccaddcb2cd722baa7453b4c3d2cb2a3071597bb91f7a4373e8775bdb151778c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3746ad029217960123cf2ebf939dda51eb931ba9f8f09c117e39c820b96aa794"
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5145,7 +5451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser 0.244.0",
 ]
@@ -5158,7 +5464,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -5170,7 +5476,7 @@ checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
  "serde",
 ]
@@ -5307,7 +5613,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5657,7 +5963,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -5688,7 +5994,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5707,7 +6013,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -6,15 +6,15 @@ with the Hew compiler, runtime, and tools. Hew itself is dual-licensed under
 MIT OR Apache-2.0 (see LICENSE-MIT and LICENSE-APACHE in this archive).
 
 License summary by SPDX identifier:
-  Apache License 2.0 (376 packages)
-  MIT License (104 packages)
+  Apache License 2.0 (399 packages)
+  MIT License (116 packages)
   Unicode License v3 (19 packages)
   ISC License (8 packages)
   BSD 3-Clause "New" or "Revised" License (5 packages)
+  Creative Commons Zero v1.0 Universal (3 packages)
   Boost Software License 1.0 (2 packages)
   Community Data License Agreement Permissive 2.0 (2 packages)
   BSD Zero Clause License (1 package)
-  Creative Commons Zero v1.0 Universal (1 package)
   Mozilla Public License 2.0 (1 package)
   Unicode License Agreement - Data Files and Software (2016) (1 package)
   zlib License (1 package)
@@ -2178,9 +2178,12 @@ Apache License 2.0
 
 ================================================================================
 Apache License 2.0
+  * abnf-core 0.5.0 — https://github.com/duesee/abnf-core
+  * abnf 0.12.0 — https://github.com/duesee/abnf
   * ciborium-io 0.2.2 — https://github.com/enarx/ciborium
   * ciborium-ll 0.2.2 — https://github.com/enarx/ciborium
   * ciborium 0.2.2 — https://github.com/enarx/ciborium
+  * codespan-reporting 0.13.1 — https://github.com/brendanzab/codespan
   * email-encoding 0.4.1 — https://github.com/lettre/email-encoding
   * quinn-proto 0.11.15 — https://github.com/quinn-rs/quinn
   * quinn-udp 0.5.14 — https://github.com/quinn-rs/quinn
@@ -3030,6 +3033,7 @@ Apache License 2.0
   * clap_lex 1.1.0 — https://github.com/clap-rs/clap
   * colorchoice 1.0.5 — https://github.com/rust-cli/anstyle.git
   * crc32fast 1.5.0 — https://github.com/srijs/rust-crc32fast
+  * hex 0.4.3 — https://github.com/KokaKiwi/rust-hex
   * is_terminal_polyfill 1.70.2 — https://github.com/polyfill-rs/is_terminal_polyfill
   * jni-sys 0.3.1 — https://github.com/jni-rs/jni-sys
   * jni-sys 0.4.1 — https://github.com/jni-rs/jni-sys
@@ -5939,6 +5943,7 @@ limitations under the License.
 
 ================================================================================
 Apache License 2.0
+  * arrayvec 0.5.2 — https://github.com/bluss/arrayvec
   * atomic-waker 1.1.2 — https://github.com/smol-rs/atomic-waker
   * autocfg 1.5.0 — https://github.com/cuviper/autocfg
   * base64 0.22.1 — https://github.com/marshallpierce/rust-base64
@@ -5972,6 +5977,7 @@ Apache License 2.0
   * fnv 1.0.7 — https://github.com/servo/rust-fnv
   * form_urlencoded 1.2.2 — https://github.com/servo/rust-url
   * getopts 0.2.24 — https://github.com/rust-lang/getopts
+  * hashbrown 0.12.3 — https://github.com/rust-lang/hashbrown
   * hashbrown 0.14.5 — https://github.com/rust-lang/hashbrown
   * hashbrown 0.16.1 — https://github.com/rust-lang/hashbrown
   * hashbrown 0.17.1 — https://github.com/rust-lang/hashbrown
@@ -5980,7 +5986,9 @@ Apache License 2.0
   * hyper-rustls 0.27.9 — https://github.com/rustls/hyper-rustls
   * idna 1.1.0 — https://github.com/servo/rust-url/
   * idna_adapter 1.2.2 — https://github.com/hsivonen/idna_adapter
+  * indexmap 1.9.3 — https://github.com/bluss/indexmap
   * indexmap 2.14.0 — https://github.com/indexmap-rs/indexmap
+  * itertools 0.10.5 — https://github.com/rust-itertools/itertools
   * itertools 0.13.0 — https://github.com/rust-itertools/itertools
   * itertools 0.14.0 — https://github.com/rust-itertools/itertools
   * jni 0.21.1 — https://github.com/jni-rs/jni-rs
@@ -5991,6 +5999,7 @@ Apache License 2.0
   * lock_api 0.4.14 — https://github.com/Amanieu/parking_lot
   * log 0.4.29 — https://github.com/rust-lang/log
   * mime 0.3.17 — https://github.com/hyperium/mime
+  * minicov 0.3.8 — https://github.com/Amanieu/minicov
   * num-traits 0.2.19 — https://github.com/rust-num/num-traits
   * object 0.37.3 — https://github.com/gimli-rs/object
   * object 0.39.1 — https://github.com/gimli-rs/object
@@ -5999,6 +6008,10 @@ Apache License 2.0
   * parking_lot 0.12.5 — https://github.com/Amanieu/parking_lot
   * parking_lot_core 0.9.12 — https://github.com/Amanieu/parking_lot
   * percent-encoding 2.3.2 — https://github.com/servo/rust-url/
+  * pest 2.8.6 — https://github.com/pest-parser/pest
+  * pest_derive 2.8.6 — https://github.com/pest-parser/pest
+  * pest_generator 2.8.6 — https://github.com/pest-parser/pest
+  * pest_meta 2.8.6 — https://github.com/pest-parser/pest
   * pkg-config 0.3.33 — https://github.com/rust-lang/pkg-config-rs
   * proptest 1.11.0 — https://github.com/proptest-rs/proptest
   * rayon-core 1.13.0 — https://github.com/rayon-rs/rayon
@@ -6033,6 +6046,7 @@ Apache License 2.0
   * tinytemplate 1.2.1 — https://github.com/bheisler/TinyTemplate
   * tower-lsp 0.20.0 — https://github.com/ebkalderon/tower-lsp
   * tungstenite 0.29.0 — https://github.com/snapview/tungstenite-rs
+  * ucd-trie 0.1.7 — https://github.com/BurntSushi/ucd-generate
   * unicase 2.9.0 — https://github.com/seanmonstar/unicase
   * unicode-segmentation 1.13.2 — https://github.com/unicode-rs/unicode-segmentation
   * unicode-truncate 2.0.1 — https://github.com/Aetf/unicode-truncate
@@ -6047,6 +6061,9 @@ Apache License 2.0
   * wasm-bindgen-macro-support 0.2.125 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support
   * wasm-bindgen-macro 0.2.125 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro
   * wasm-bindgen-shared 0.2.125 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared
+  * wasm-bindgen-test-macro 0.3.75 — https://github.com/wasm-bindgen/wasm-bindgen
+  * wasm-bindgen-test-shared 0.2.125 — https://github.com/rustwasm/wasm-bindgen/tree/master/crates/test-shared
+  * wasm-bindgen-test 0.3.75 — https://github.com/wasm-bindgen/wasm-bindgen
   * wasm-bindgen 0.2.125 — https://github.com/wasm-bindgen/wasm-bindgen
   * wasmparser 0.252.0 — https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser
   * web-sys 0.3.102 — https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys
@@ -6263,6 +6280,7 @@ Apache License 2.0
   * auto_impl 1.3.0 — https://github.com/auto-impl-rs/auto_impl/
   * bit-set 0.8.0 — https://github.com/contain-rs/bit-set
   * bit-vec 0.8.0 — https://github.com/contain-rs/bit-vec
+  * minimal-lexical 0.2.1 — https://github.com/Alexhuszagh/minimal-lexical
 
                               Apache License
                         Version 2.0, January 2004
@@ -6910,6 +6928,213 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
+
+
+================================================================================
+Apache License 2.0
+  * console_error_panic_hook 0.1.7 — https://github.com/rustwasm/console_error_panic_hook
+
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 
 ================================================================================
@@ -8147,6 +8372,213 @@ limitations under the License.
 
 ================================================================================
 Apache License 2.0
+  * simplelog 0.12.2 — https://github.com/drakulix/simplelog.rs
+
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "{}"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright {yyyy} {name of copyright owner}
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+================================================================================
+Apache License 2.0
   * adze-cli 0.5.6 — https://github.com/hew-lang/hew
   * hew-analysis 0.5.6 — https://github.com/hew-lang/hew
   * hew-cabi 0.5.6 — https://github.com/hew-lang/hew
@@ -8171,6 +8603,7 @@ Apache License 2.0
   * hew-std-encoding-binary 0.5.6 — https://github.com/hew-lang/hew
   * hew-std-text-template 0.5.6 — https://github.com/hew-lang/hew
   * xtask 0.5.6 — https://github.com/hew-lang/hew
+  * abnf_to_pest 0.5.1 — https://github.com/Nadrieril/dhall-rust
   * allocator-api2 0.2.21 — https://github.com/zakarumych/allocator-api2
   * android_system_properties 0.1.5 — https://github.com/nical/android_system_properties
   * anes 0.1.6 — https://github.com/zrzka/anes-rs
@@ -8198,6 +8631,7 @@ Apache License 2.0
   * litrs 1.0.0 — https://github.com/LukasKalbertodt/litrs
   * miniz_oxide 0.8.9 — https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide
   * num-conv 0.2.1 — https://github.com/jhpratt/num-conv
+  * pest_vm 2.8.6 — https://github.com/pest-parser/pest
   * pin-project-internal 1.1.12 — https://github.com/taiki-e/pin-project
   * pin-project-lite 0.2.17 — https://github.com/taiki-e/pin-project-lite
   * pin-project 1.1.12 — https://github.com/taiki-e/pin-project
@@ -8233,6 +8667,7 @@ Apache License 2.0
   * thiserror 1.0.69 — https://github.com/dtolnay/thiserror
   * thiserror 2.0.18 — https://github.com/dtolnay/thiserror
   * time-core 0.1.8 — https://github.com/time-rs/time
+  * time-macros 0.2.27 — https://github.com/time-rs/time
   * time 0.3.47 — https://github.com/time-rs/time
   * tower-lsp-macros 0.9.0 — https://github.com/ebkalderon/tower-lsp
   * unicode-ident 1.0.24 — https://github.com/dtolnay/unicode-ident
@@ -8774,6 +9209,134 @@ For these and/or other purposes and motivations, and without any expectation of 
      d. Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work. 
 
 ================================================================================
+Creative Commons Zero v1.0 Universal
+  * base16 0.2.1 — https://github.com/thomcc/rust-base16
+  * hexf-parse 0.2.1 — https://github.com/lifthrasiir/hexf
+
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.
+
+
+================================================================================
 Community Data License Agreement Permissive 2.0
   * webpki-root-certs 1.0.7 — https://github.com/rustls/webpki-roots
   * webpki-roots 1.0.7 — https://github.com/rustls/webpki-roots
@@ -9012,6 +9575,7 @@ THE SOFTWARE.
 
 ================================================================================
 MIT License
+  * nom 7.1.3 — https://github.com/Geal/nom
   * nom 8.0.0 — https://github.com/rust-bakery/nom
 
 Copyright (c) 2014-2019 Geoffroy Couprie
@@ -9720,6 +10284,60 @@ SOFTWARE.
 
 ================================================================================
 MIT License
+  * typed-arena 2.0.2 — https://github.com/SimonSapin/rust-typed-arena
+
+MIT License
+
+Copyright (c) 2018 The typed-arena developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+================================================================================
+MIT License
+  * base64-url 3.0.4 — https://github.com/magiclen/base64-url
+
+MIT License
+
+Copyright (c) 2018 magiclen.org (Ron Li)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+================================================================================
+MIT License
   * dashmap 5.5.3 — https://github.com/xacrimon/dashmap
   * dashmap 6.2.1 — https://github.com/xacrimon/dashmap
 
@@ -9745,6 +10363,32 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
+================================================================================
+MIT License
+  * cddl 0.10.5 — https://github.com/anweiss/cddl
+
+MIT License
+
+Copyright (c) 2019 Andrew Weiss
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ================================================================================
 MIT License
@@ -10007,6 +10651,7 @@ SOFTWARE.
 
 ================================================================================
 MIT License
+  * base45 3.2.0 — https://github.com/opendevtools/base45
   * difflib 0.4.0 — https://github.com/DimaKudosh/difflib
   * libm 0.2.16 — https://github.com/rust-lang/compiler-builtins
   * plotters-backend 0.3.7 — https://github.com/plotters-rs/plotters
@@ -10068,6 +10713,60 @@ MIT License
 MIT License
 
 Copyright (c) [2021] [Marvin Countryman]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+================================================================================
+MIT License
+  * uriparse 0.6.4 — https://github.com/sgodwincs/uriparse-rs
+
+MIT License
+
+Copyright (c) 2017 sgodwincs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+================================================================================
+MIT License
+  * serde-wasm-bindgen 0.6.5 — https://github.com/RReverser/serde-wasm-bindgen
+
+MIT License
+
+Copyright (c) 2019 Cloudflare, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -10201,6 +10900,33 @@ THE SOFTWARE.
 
 ================================================================================
 MIT License
+  * fancy-regex 0.17.0 — https://github.com/fancy-regex/fancy-regex
+
+The MIT License
+
+Copyright 2015 The Fancy Regex Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+================================================================================
+MIT License
   * phf 0.11.3 — https://github.com/rust-phf/rust-phf
   * phf_generator 0.11.3 — https://github.com/rust-phf/rust-phf
   * phf_macros 0.11.3 — https://github.com/rust-phf/rust-phf
@@ -10259,7 +10985,10 @@ SOFTWARE.
 ================================================================================
 MIT License
   * aho-corasick 1.1.4 — https://github.com/BurntSushi/aho-corasick
+  * csv-core 0.1.13 — https://github.com/BurntSushi/rust-csv
+  * csv 1.4.0 — https://github.com/BurntSushi/rust-csv
   * memchr 2.8.0 — https://github.com/BurntSushi/memchr
+  * termcolor 1.4.1 — https://github.com/BurntSushi/termcolor
   * walkdir 2.5.0 — https://github.com/BurntSushi/walkdir
 
 The MIT License (MIT)
@@ -10756,6 +11485,32 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+================================================================================
+MIT License
+  * pretty 0.11.3 — https://github.com/Marwes/pretty.rs
+
+The MIT License (MIT)
+Copyright (c) 2014 Jonathan Sterling and Darin Morrison
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ================================================================================

--- a/docs/specs/HEW-WIRE-FORMAT-DOCTRINE.md
+++ b/docs/specs/HEW-WIRE-FORMAT-DOCTRINE.md
@@ -89,6 +89,26 @@ The body shapes (the `wire-body` rule and its parts):
   type outside this floor fails closed at codegen ("unsupported value type …
   outside the supported wire-body floor") and never reaches the wire.
 
+### Tag-stability asymmetry — explicit `@N` vs ordinal
+
+Struct fields and enum variants carry their wire tag differently, and this
+creates an **important stability asymmetry**:
+
+- **`#[wire]` struct fields** use the **explicit `@N` tag** from the wire
+  layout (`cbor_field_key` picks the declared tag, not the field's
+  declaration position). Reordering struct fields in source is
+  **wire-safe**: the tag is the `@N` annotation, not the position.
+- **`#[wire]` enum variants** use the **declaration ordinal** as their tag
+  (`cbor_variant_tag` falls back to `variant_idx` when no explicit tag is
+  present). Reordering enum variants in source **changes their ordinals**
+  and is a **breaking wire change**: a sender's `Ping` at ordinal 0 is
+  no longer the receiver's `Ping` at ordinal 1.
+
+In short: reordering `#[wire]` struct fields is safe; reordering `#[wire]`
+enum variants is a breaking change. If you need reorder-stable enum variants,
+assign an explicit tag annotation — the `@N` mechanism is available on enum
+variants for exactly this reason.
+
 The CDDL is an **additive description**, not a second decoder: a body that
 does not match `wire-body.cddl` still fails closed at the runtime reader
 (`xnode_serial.rs::decode_payload` returns null; the codec thunks trap on

--- a/docs/specs/HEW-WIRE-FORMAT-DOCTRINE.md
+++ b/docs/specs/HEW-WIRE-FORMAT-DOCTRINE.md
@@ -55,6 +55,60 @@ The Rust mirror is `EnvelopeFrame` (and `ControlFrame`) in
 [`hew-runtime/src/envelope.rs`][envelope-rs] starting near line 30. The
 CDDL integer keys are mirrored as field-doc comments on each struct field.
 
+### The message body — CDDL-described tagged CBOR
+
+The `envelope-frame` `payload` (key `6`) is a `bstr` to the *frame* schema:
+the frame does not interpret it. The bytes inside that `bstr` are the
+**per-`#[wire]`-type CBOR body** the codegen serializer emits for the
+message being sent, and they have their own doc-of-truth schema in
+[`hew-runtime/schemas/wire-body.cddl`][wire-body-cddl]. Together,
+`envelope.cddl` (the container) and `wire-body.cddl` (the body) make the
+whole internode wire — frame and body — CDDL-described.
+
+[wire-body-cddl]: ../../hew-runtime/schemas/wire-body.cddl
+
+The body shapes (the `wire-body` rule and its parts):
+
+- A **`#[wire]` struct** (or any cross-node `Serializable` record) encodes
+  as a CBOR **map keyed by the unsigned `@N` field tags** — `cbor_field_key`
+  uses the explicit `@N` from the wire layout, or a 1-based positional
+  fallback for layout-less records. Keys are emitted in canonical
+  (ascending) order. Forward-compatible: a decoder tolerates unknown keys
+  and treats absent keys as optional/default.
+- A **`#[wire]` enum** encodes as either a **bare unsigned tag `N`** (a unit
+  variant) or a **single-entry map `{ N => [field0, field1, …] }`** (a
+  payload variant, the "map-of-one"). The variant tag is the declaration
+  ordinal (the `#[wire]` enum surface tags variants positionally). The
+  runtime reader `hew_cbor_de_enum_begin` accepts exactly these two shapes
+  and fails closed on a negative tag, a multi-entry map, or a single value
+  that is not an array.
+- The **leaf floor** is scalars (CBOR int / uint / bool / float), `string`
+  (CBOR text), `bytes` (CBOR byte string), `Option<T>` (`null` for `None`,
+  the inner encoding for `Some`), `Vec<T>` (a CBOR array), and nested
+  `#[wire]` structs/enums (nested maps / unit-tag / map-of-one). A value
+  type outside this floor fails closed at codegen ("unsupported value type …
+  outside the supported wire-body floor") and never reaches the wire.
+
+The CDDL is an **additive description**, not a second decoder: a body that
+does not match `wire-body.cddl` still fails closed at the runtime reader
+(`xnode_serial.rs::decode_payload` returns null; the codec thunks trap on
+malformed / out-of-range / arity-mismatch input). The conformance test
+[`hew-runtime/tests/wire_body_cddl_conformance.rs`][wire-body-test]
+validates the emitted bytes against `wire-body.cddl` with a real RFC 8610
+validator, and a compiled cross-process round-trip
+(`distributed_two_process_e2e.rs::wire_cbor_cross_process_round_trip`)
+proves an explicit-`@N` `#[wire]` payload decodes to exact values in a
+second OS process. The legacy positional codec is retired — the tagged CBOR
+body is the sole internode body format.
+
+[wire-body-test]: ../../hew-runtime/tests/wire_body_cddl_conformance.rs
+
+A cross-node payload whose type is **neither `#[wire]` nor otherwise
+`Serializable`** has no registered codec, so `encode_payload` fails closed
+(returns null, `*out_len = 0`) rather than sending raw bytes — the
+fail-closed posture extends to "no codec for this type", not just malformed
+input.
+
 ### Why CBOR, not JSON / msgpack / Protobuf / HBF
 
 - **JSON.** Text-based, ambiguous numeric typing (no native `i64` vs
@@ -99,7 +153,9 @@ The round-trip and version-rejection tests live in
 
 - Add new envelope fields **first to the CDDL**, then to `EnvelopeFrame`.
   The CDDL is the doc-of-truth; the Rust struct conforms to it, not the
-  other way around.
+  other way around. The same rule holds for the body: a change to the
+  per-type body shape the codegen serializer emits must be reflected in
+  `wire-body.cddl`, and the conformance test keeps the two from drifting.
 - New frame kinds extend the `wire-frame` rule alternatives. Do not
   invent a parallel framing layer.
 - Decoders must reject unknown `version` values rather than degrading.
@@ -335,8 +391,11 @@ only one with an active obsolescence trigger.
 
 - Runtime substrate provenance: commits `63a486d6`, `bb8826e7`, `04bfb422`
   on `v05-integration`.
-- CDDL schema: [`hew-runtime/schemas/envelope.cddl`](../../hew-runtime/schemas/envelope.cddl).
+- CDDL frame schema: [`hew-runtime/schemas/envelope.cddl`](../../hew-runtime/schemas/envelope.cddl).
+- CDDL body schema: [`hew-runtime/schemas/wire-body.cddl`](../../hew-runtime/schemas/wire-body.cddl).
 - Runtime envelope types: [`hew-runtime/src/envelope.rs`](../../hew-runtime/src/envelope.rs).
-- Round-trip tests: [`hew-runtime/tests/envelope_round_trip.rs`](../../hew-runtime/tests/envelope_round_trip.rs).
+- Frame round-trip tests: [`hew-runtime/tests/envelope_round_trip.rs`](../../hew-runtime/tests/envelope_round_trip.rs).
+- Body conformance test: [`hew-runtime/tests/wire_body_cddl_conformance.rs`](../../hew-runtime/tests/wire_body_cddl_conformance.rs).
+- Cross-process body round-trip: [`hew-cli/tests/distributed_two_process_e2e.rs`](../../hew-cli/tests/distributed_two_process_e2e.rs).
 - Stdlib `Value` contract: [`std/encoding/wire/README.md`](../../std/encoding/wire/README.md), issue #1247.
 - Distributed actor companion doc: [`HEW-DIST-SPEC.md`](./HEW-DIST-SPEC.md).

--- a/hew-cli/tests/distributed_two_process_e2e.rs
+++ b/hew-cli/tests/distributed_two_process_e2e.rs
@@ -271,3 +271,47 @@ fn remote_ask_round_trip_returns_exact_values() {
         "client reported a FAIL on the remote-ask round-trip; client stdout:\n{stdout}"
     );
 }
+
+/// A `#[wire]`-annotated payload with EXPLICIT `@N` field tags round-trips across
+/// two OS processes. The `remote_ask` scenario above sends plain `record`/`enum`
+/// types, which get `@N` tags by the codec's positional fallback; this scenario
+/// sends `#[wire]` types (`WireCmd` enum request, `WireResult` struct reply) with
+/// explicit `@N` field tags, exercising the tag-keyed CBOR body the positional
+/// path does not — the struct `@N`-keyed map and the enum unit-tag / map-of-one
+/// body, in both the request and the reply direction. The body shape conforms to
+/// `hew-runtime/schemas/wire-body.cddl` (validated in
+/// `hew-runtime/tests/wire_body_cddl_conformance.rs`).
+///
+/// Cross-platform note (`elf-init-array-ctors`, PR #2246): the codec registers
+/// via a program-start constructor, which on ELF must land in `.init_array`. A
+/// successful cross-process send IS the proof the constructor ran and registered
+/// the codec; macOS masked the pre-#2246 ELF defect, so this scenario must also
+/// be validated on a real Linux host (done out-of-band).
+#[test]
+fn wire_cbor_cross_process_round_trip() {
+    let stdout = run_two_process_scenario("wire_cbor");
+
+    // Teeth: exact field values on the #[wire] struct reply for both the payload
+    // variant (Move → tag 1, sum 7) and the unit variant (Ping → tag 0, sum 0).
+    assert!(
+        stdout.contains("PASS wire_cbor move-tag=1"),
+        "expected Move variant tag 1 from the #[wire] reply; client stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("PASS wire_cbor move-sum=7"),
+        "expected Move x+y == 7 from the #[wire] struct field round-trip; client stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("PASS wire_cbor ping-tag=0"),
+        "expected Ping unit-variant tag 0 from the #[wire] reply; client stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("PASS wire_cbor ping-sum=0"),
+        "expected Ping sum 0 from the #[wire] reply; client stdout:\n{stdout}"
+    );
+    // Negative guard: no FAIL line may appear on a successful round-trip.
+    assert!(
+        !stdout.contains("FAIL "),
+        "client reported a FAIL on the #[wire] cross-process round-trip; client stdout:\n{stdout}"
+    );
+}

--- a/hew-cli/tests/fixtures/distributed/dist_node.hew
+++ b/hew-cli/tests/fixtures/distributed/dist_node.hew
@@ -42,6 +42,38 @@ enum KvResp {
     Value(string);
 }
 
+// ── #[wire] cross-process body types (DIST-4) ────────────────────────────────
+//
+// The KV types above are plain record/enum: they cross the wire as Serializable
+// types and get @N tags by the codec's positional fallback. The types below are
+// explicitly #[wire]-annotated with EXPLICIT @N field/variant tags, so they
+// exercise the tag-keyed CBOR body the positional path does not — a struct as an
+// @N-keyed map, an enum as a unit tag (Ping) or a map-of-one (Move). Both the
+// request (WireCmd) and the reply (WireResult) are #[wire] types, so the
+// explicit-@N body is proven crossing the wire in BOTH directions.
+#[wire]
+struct WirePoint {
+    x: i64 @1,
+    y: i64 @2,
+}
+
+// Enum variant wire tags are the declaration ordinal (Ping = 0, Move = 1);
+// the #[wire] enum surface tags variants positionally. The struct fields above
+// carry EXPLICIT @N tags — that is the explicit-tag body this scenario proves.
+#[wire]
+enum WireCmd {
+    Ping;
+    Move(WirePoint);
+}
+
+// WireResult is the #[wire] struct reply: `tag` is which variant the server saw
+// (0 = Ping, 1 = Move); `sum` is x + y for Move, or 0 for Ping.
+#[wire]
+struct WireResult {
+    tag: i64 @1,
+    sum: i64 @2,
+}
+
 actor KeyValue {
     let store: HashMap<string, string>;
     receive fn handle(req: KvReq) -> KvResp {
@@ -68,6 +100,24 @@ impl ActorMsg for KeyValue {
     type Reply = KvResp;
 }
 
+// Actor for the #[wire] cross-process scenario. It receives a #[wire] enum and
+// replies with a #[wire] struct, so the explicit-@N tagged body is exercised on
+// both the request and the reply leg of a remote ask.
+actor WireProbe {
+    let calls: i64;
+    receive fn handle(cmd: WireCmd) -> WireResult {
+        match cmd {
+            WireCmd::Ping => WireResult { tag: 0, sum: 0 },
+            WireCmd::Move(p) => WireResult { tag: 1, sum: p.x + p.y },
+        }
+    }
+}
+
+impl ActorMsg for WireProbe {
+    type Msg = WireCmd;
+    type Reply = WireResult;
+}
+
 // Bounded poll for the remote actor: retry Node::lookup until registry gossip
 // resolves it, instead of a single fixed-interval sleep. ~50 attempts at 100 ms
 // = 5 s deadline, generous for loopback gossip while still failing closed if the
@@ -91,6 +141,26 @@ fn lookup_with_retry(name: string) -> Result<RemotePid<KeyValue>, LookupError> {
     }
 }
 
+// Same bounded poll, typed for the WireProbe actor (the #[wire] scenario).
+fn lookup_wire_with_retry(name: string) -> Result<RemotePid<WireProbe>, LookupError> {
+    var attempts: i64 = 0;
+    loop {
+        let found: Result<RemotePid<WireProbe>, LookupError> = Node::lookup(name);
+        match found {
+            Result::Ok(pid) => {
+                return Ok(pid);
+            },
+            Result::Err(e) => {
+                attempts = attempts + 1;
+                if attempts >= 50 {
+                    return Err(e);
+                }
+                sleep(100ms);
+            },
+        }
+    }
+}
+
 fn run_server(port: string) {
     let addr = f"127.0.0.1:{port}";
     Node::set_transport("tcp");
@@ -98,8 +168,12 @@ fn run_server(port: string) {
     let s: HashMap<string, string> = HashMap::new();
     let kv = spawn KeyValue(store: s);
     Node::register("kv", kv);
+    // Also register the #[wire] probe actor so the wire_cbor scenario has a
+    // remote target. Registering both keeps run_server scenario-independent.
+    let wp = spawn WireProbe(calls: 0);
+    Node::register("wire", wp);
 
-    // Readiness signal: emitted ONLY after the actor is registered, so the
+    // Readiness signal: emitted ONLY after the actors are registered, so the
     // harness never launches the client against a half-started node.
     println(f"READY {port}");
 
@@ -184,27 +258,99 @@ fn scenario_remote_ask(kv: RemotePid<KeyValue>) -> i64 {
     0
 }
 
+// Scenario: wire_cbor
+//
+// Sends a #[wire] enum (WireCmd) with EXPLICIT @N variant tags via two remote
+// asks — a payload variant (Move, the map-of-one body) and a unit variant (Ping,
+// the bare-tag body) — and checks the #[wire] struct reply (WireResult, an
+// @N-keyed map) field-by-field. This is the distinct thing DIST-4 proves: an
+// explicit-@N tagged CBOR body crossing two OS processes in both directions,
+// which the plain-record/enum remote_ask scenario does not exercise.
+fn scenario_wire_cbor(wp: RemotePid<WireProbe>) -> i64 {
+    // Payload variant: Move(WirePoint { x: 3, y: 4 }) → server replies
+    // WireResult { tag: 1, sum: 7 }.
+    let ask_move = wp.ask(WireCmd::Move(WirePoint { x: 3, y: 4 }), 5000);
+    match ask_move {
+        Result::Err(_) => {
+            println("FAIL wire_cbor move-ask-error");
+            return 2;
+        },
+        Result::Ok(res) => {
+            if res.tag == 1 {
+                println(f"PASS wire_cbor move-tag={res.tag}");
+            } else {
+                println(f"FAIL wire_cbor move-tag={res.tag}");
+                return 3;
+            }
+            if res.sum == 7 {
+                println(f"PASS wire_cbor move-sum={res.sum}");
+            } else {
+                println(f"FAIL wire_cbor move-sum={res.sum}");
+                return 4;
+            }
+        },
+    }
+    // Unit variant: Ping → server replies WireResult { tag: 0, sum: 0 }.
+    let ask_ping = wp.ask(WireCmd::Ping, 5000);
+    match ask_ping {
+        Result::Err(_) => {
+            println("FAIL wire_cbor ping-ask-error");
+            return 5;
+        },
+        Result::Ok(res) => {
+            if res.tag == 0 {
+                println(f"PASS wire_cbor ping-tag={res.tag}");
+            } else {
+                println(f"FAIL wire_cbor ping-tag={res.tag}");
+                return 6;
+            }
+            if res.sum == 0 {
+                println(f"PASS wire_cbor ping-sum={res.sum}");
+            } else {
+                println(f"FAIL wire_cbor ping-sum={res.sum}");
+                return 7;
+            }
+        },
+    }
+    0
+}
+
 fn run_client(port: string, scenario: string) -> i64 {
     let remote_addr = f"127.0.0.1:{port}";
     Node::set_transport("tcp");
     Node::start("127.0.0.1:0");
     Node::connect(remote_addr);
-    let found = lookup_with_retry("kv");
-    let status = match found {
-        Result::Err(_) => {
-            println(f"FAIL {scenario} lookup-unresolved");
-            1
-        },
-        Result::Ok(kv) => {
-            // Scenario dispatch. New scenarios add a branch here plus a
-            // scenario_* function above; the harness selects via HEW_DIST_SCENARIO.
-            if scenario == "remote_ask" {
-                scenario_remote_ask(kv)
-            } else {
-                println(f"FAIL {scenario} unknown-scenario");
-                90
-            }
-        },
+    // Scenario dispatch. New scenarios add a branch here plus a scenario_*
+    // function above; the harness selects via HEW_DIST_SCENARIO. The #[wire]
+    // scenario targets the WireProbe actor ("wire"); the rest target KeyValue
+    // ("kv").
+    let status = if scenario == "wire_cbor" {
+        let found_wire = lookup_wire_with_retry("wire");
+        match found_wire {
+            Result::Err(_) => {
+                println(f"FAIL {scenario} lookup-unresolved");
+                1
+            },
+            Result::Ok(wp) => {
+                scenario_wire_cbor(wp)
+            },
+        }
+    } else {
+        let found = lookup_with_retry("kv");
+        match found {
+            Result::Err(_) => {
+                println(f"FAIL {scenario} lookup-unresolved");
+                1
+            },
+            Result::Ok(kv) => {
+                if scenario == "remote_ask" {
+                    scenario_remote_ask(kv)
+                } else {
+                    println(f"FAIL {scenario} unknown-scenario");
+                    90
+                }
+            },
+        }
     };
     Node::shutdown();
     status

--- a/hew-runtime/Cargo.toml
+++ b/hew-runtime/Cargo.toml
@@ -141,6 +141,13 @@ harness = false
 # native-only, so this scoping costs no test coverage on wasm.
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 proptest = "1"
+# CDDL validator (DIST-4): the wire-body conformance test feeds the authored
+# `schemas/wire-body.cddl` text + the codegen-emitted CBOR bytes into a real
+# RFC 8610 validator so the schema is the authority, not a hand-mirrored
+# structural assertion that could silently drift from the CDDL. Test-only and
+# native-only (the crate pulls a full CDDL parser/AST it never needs in the
+# runtime binary, and is irrelevant on wasm where there is no internode wire).
+cddl = "0.10"
 # Safe handle wrappers for integration tests (RAII over runtime FFI). Native
 # only: wraps FFI (e.g. hew_actor_trap) the runtime does not export on wasm32.
 hew-runtime-testkit = { path = "../hew-runtime-testkit" }

--- a/hew-runtime/schemas/README.md
+++ b/hew-runtime/schemas/README.md
@@ -15,9 +15,19 @@ remain consistent with these definitions.
 
 | File | Covers |
 |------|--------|
-| `envelope.cddl` | Control frames and data envelope frames (CBOR wire layer, v1) |
+| `envelope.cddl` | Control frames and data envelope frames (CBOR wire layer, v1) — the transport CONTAINER |
+| `wire-body.cddl` | The per-`#[wire]`-type CBOR body carried inside an envelope frame's `payload` (`bstr`) slot — the message BODY |
 
 > W2 will add `handshake.cddl` once the CBOR handshake codec lands.
+
+### Frame vs body
+
+`envelope.cddl` describes the frame map and treats `payload` (key 6) as an
+opaque `bstr`. `wire-body.cddl` describes the bytes INSIDE that `bstr`: the
+tagged-CBOR body the codegen serializer emits for each message type (a struct as
+an `@N`-keyed map, an enum as a unit tag or a single-entry map-of-one). The
+conformance test `hew-runtime/tests/wire_body_cddl_conformance.rs` validates
+emitted bytes against `wire-body.cddl` so the schema stays an enforced contract.
 
 ## Design decisions
 

--- a/hew-runtime/schemas/envelope.cddl
+++ b/hew-runtime/schemas/envelope.cddl
@@ -63,7 +63,10 @@ envelope-frame = {
     target_actor_id:  3 => actor-id,
     source_actor_id:  4 => actor-id,
     msg_type:         5 => int,          ; signed; valid range 0..=2^30-1 (zigzag legacy)
-    payload:          6 => bstr,         ; serialised message body; 0..* bytes
+    payload:          6 => bstr,         ; serialised message body; 0..* bytes.
+                                         ; The bytes inside this bstr are the
+                                         ; per-`#[wire]`-type CBOR body described
+                                         ; by `wire-body.cddl` (`wire-body` rule).
     request_id:       7 => uint,         ; 0 = fire-and-forget
     source_node_id:   8 => node-id,      ; 0 on reply envelopes
 }

--- a/hew-runtime/schemas/wire-body.cddl
+++ b/hew-runtime/schemas/wire-body.cddl
@@ -1,0 +1,114 @@
+; Hew wire BODY CDDL schema — doc-of-truth for the per-`#[wire]`-type CBOR body
+; that travels inside an envelope frame's `payload` slot.
+;
+; `envelope.cddl` describes the transport CONTAINER (the `wire-frame` map and its
+; `payload: 6 => bstr` slot). This schema describes what lives INSIDE that
+; `bstr`: the tagged-CBOR body the codegen serializer emits for each
+; `#[wire]`-annotated (or otherwise `Serializable`) message type. Together the two
+; schemas make the whole internode wire — frame and body — CDDL-described.
+;
+; ── Provenance: schema ⇄ code ────────────────────────────────────────────────
+;
+; The shapes below mirror the codegen emitter and the runtime reader EXACTLY.
+; When either side changes, this schema changes with it; the conformance test
+; (`hew-runtime/tests/wire_body_cddl_conformance.rs`) feeds emitted bytes through
+; a real CDDL validator against these rules so drift is caught, not narrated.
+;
+;   struct body  — emitter `emit_ser_value_cbor` / `cbor_field_key`
+;                  (`hew-codegen-rs/src/llvm.rs`, `hew_cbor_ser_begin_map`).
+;   enum body    — emitter `emit_ser_enum_cbor` / `cbor_variant_tag`
+;                  (`hew-codegen-rs/src/llvm.rs`); reader
+;                  `hew_cbor_de_enum_begin` (`hew-runtime/src/cbor_serial.rs`).
+;
+; ── Fail-closed posture (do NOT relax) ───────────────────────────────────────
+;
+; This CDDL is an ADDITIVE description, not a replacement for the runtime
+; reader's validation. A body that does not match these rules still fails closed
+; at the runtime decoder (`xnode_serial.rs::decode_payload` → null; the codec
+; thunks trap on malformed/out-of-range/arity-mismatch input). The CDDL makes the
+; contract machine-checkable in tests; the runtime reader is the trust boundary.
+
+; ── Top-level body rule ──────────────────────────────────────────────────────
+;
+; A wire body is the CBOR encoding of one `#[wire]` value: either a struct body
+; (a tag-keyed map) or an enum body (a unit tag or a map-of-one). A scalar-leaf
+; value is never a top-level body on its own — every internode message type is a
+; struct or an enum.
+
+wire-body = wire-struct-body / wire-enum-body
+
+; ── Struct body — `@N`-keyed map ─────────────────────────────────────────────
+;
+; A `#[wire]` struct serializes as a CBOR map whose keys are the unsigned field
+; tags (`@N`, or a 1-based positional fallback for layout-less records — see
+; `cbor_field_key`) and whose values are the per-field leaf encodings. Keys are
+; emitted in canonical (ascending) order. Forward-compatibility: a decoder
+; tolerates extra keys it does not know and treats absent keys as
+; optional/default, so the generic shape is an open map of `uint => value`.
+;
+; A per-type refinement names each tag explicitly; `wire-point-body` below is the
+; worked example used by the conformance test and the cross-process fixture.
+
+wire-struct-body = { * uint => wire-value }
+
+; Worked example: `#[wire] struct WirePoint { x: i64 @1, y: i64 @2 }`.
+; The conformance test asserts the emitted bytes for this type validate against
+; this exact rule.
+wire-point-body = {
+    1 => int,            ; x  (@1)
+    2 => int,            ; y  (@2)
+}
+
+; ── Enum body — unit tag OR map-of-one ───────────────────────────────────────
+;
+; A `#[wire]` enum serializes one of two ways, selected by whether the active
+; variant carries a payload:
+;   * a UNIT variant  → a bare unsigned tag `N` (the variant's `@N`, or its
+;     ordinal index as a fallback — see `cbor_variant_tag`);
+;   * a PAYLOAD variant → a single-entry map `{ N => [ field0, field1, ... ] }`,
+;     the variant's positional payload array under its tag.
+; The reader `hew_cbor_de_enum_begin` accepts exactly these two shapes and fails
+; closed on a negative tag, a multi-entry map, or a single value that is not an
+; array.
+
+wire-enum-body = wire-enum-unit / wire-enum-payload
+
+wire-enum-unit    = uint                    ; bare variant tag
+wire-enum-payload = { uint => [* wire-value] }  ; single-entry map-of-one
+
+; Worked example: `#[wire] enum WireCmd { Ping; Move(WirePoint); }` — the
+; cross-process fixture type. `Ping` (ordinal 0, unit) → `0`; `Move(p)`
+; (ordinal 1, payload) → `{ 1 => [ <wire-point-body> ] }`.
+wire-cmd-body = wire-enum-unit / { 1 => [ wire-point-body ] }
+
+; ── Leaf value floor ─────────────────────────────────────────────────────────
+;
+; The values a struct field or enum payload element may take. This is the
+; supported wire-body floor (`emit_ser_value_cbor`); a type outside it fails
+; closed at codegen ("unsupported value type … outside the supported wire-body
+; floor"), so it never reaches the wire.
+
+wire-value = wire-scalar
+           / wire-text
+           / wire-bytes
+           / wire-optional
+           / wire-vector
+           / wire-struct-body   ; nested `#[wire]` struct → nested map
+           / wire-enum-body     ; nested `#[wire]` enum   → unit tag / map-of-one
+
+; Scalars. Signed integer types (`i8`..`i64`, `isize`, `Duration`, `char`) and
+; `bool` encode as CBOR int / bool; unsigned types (`u8`..`u64`, `usize`) encode
+; as CBOR uint (a subset of `int`); floats (`f32`/`f64`) widen to a CBOR float.
+wire-scalar = int / bool / float
+
+; `string` → CBOR text string; `bytes` → CBOR byte string.
+wire-text  = tstr
+wire-bytes = bstr
+
+; `Option<T>`: `None` → CBOR `null`; `Some(v)` → the inner value's encoding
+; directly (no wrapper). `Option<Option<_>>` is rejected at codegen as ambiguous
+; under this null encoding.
+wire-optional = null / wire-value
+
+; `Vec<T>` → a CBOR array of element encodings.
+wire-vector = [* wire-value]

--- a/hew-runtime/schemas/wire-body.cddl
+++ b/hew-runtime/schemas/wire-body.cddl
@@ -112,3 +112,11 @@ wire-optional = null / wire-value
 
 ; `Vec<T>` → a CBOR array of element encodings.
 wire-vector = [* wire-value]
+
+; ── Body-shape disambiguation note ───────────────────────────────────────────
+;
+; A single-field struct whose field is a Vec encodes as `{ N: [...] }` —
+; byte-identical to an enum payload variant (`wire-enum-payload`). The runtime
+; decoder disambiguates by static type, not by inspecting the bytes; this is not
+; schema drift. The `wire-body` rule admits both alternatives and both are valid
+; encodings of their respective types.

--- a/hew-runtime/tests/wire_body_cddl_conformance.rs
+++ b/hew-runtime/tests/wire_body_cddl_conformance.rs
@@ -1,0 +1,291 @@
+//! CDDL conformance gate for the internode `#[wire]` CBOR body.
+//!
+//! `schemas/wire-body.cddl` claims to describe the bytes the codegen serializer
+//! emits for each `#[wire]` type. This test makes that claim *checked*: it drives
+//! the runtime's CBOR serializer primitives in the exact sequence the codegen
+//! emitter calls them (`hew_cbor_ser_begin_map`, then per-field
+//! `hew_cbor_ser_key_u64` and the value primitives — see `emit_ser_value_cbor` /
+//! `emit_ser_enum_cbor` in `hew-codegen-rs/src/llvm.rs`), then feeds the finished
+//! bytes through a real RFC 8610 CDDL validator (`cddl`) against the rules in
+//! `wire-body.cddl`.
+//!
+//! Driving the same FFI primitives the emitter calls produces byte-identical
+//! output to a compiled `#[wire]` send — the emitter's whole job is to sequence
+//! these primitives — so this is a genuine conformance check on the wire body,
+//! not a hand-mirrored structural guess that could silently drift from the CDDL.
+//! The cross-process round-trip in `distributed_two_process_e2e.rs::
+//! wire_cbor_cross_process_round_trip` proves the full compiled-binary path.
+//!
+//! Fail-closed (CLAUDE.md §2, `serializer-fail-closed`): the CDDL check here is
+//! ADDITIVE. A non-conforming body still fails closed at the runtime decoder
+//! regardless of the validator — the negative cases below assert both that the
+//! CDDL rejects a malformed body AND that a malformed body decodes to a
+//! fail-closed result (never a fabricated value).
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::ffi::CString;
+use std::path::PathBuf;
+
+use hew_runtime::cbor_serial::{
+    hew_cbor_de_enum_begin, hew_cbor_de_free, hew_cbor_de_new, hew_cbor_ser_begin_array,
+    hew_cbor_ser_begin_map, hew_cbor_ser_end_array, hew_cbor_ser_end_map, hew_cbor_ser_finish,
+    hew_cbor_ser_i64, hew_cbor_ser_key_u64, hew_cbor_ser_new, hew_cbor_ser_string,
+    hew_cbor_ser_u64,
+};
+use hew_runtime::xnode_serial::hew_ser_free_bytes;
+
+/// The committed CDDL schema text. Loaded from the file so the test validates
+/// against the SAME schema that ships, not an inline copy that could drift.
+fn wire_body_cddl() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("schemas")
+        .join("wire-body.cddl");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Finish a serializer buffer into an owned `Vec<u8>`, freeing the FFI buffer.
+/// Panics on a fail-closed (null) finish — a well-formed encode must produce
+/// bytes.
+///
+/// # Safety
+/// `buf` must be a live handle from `hew_cbor_ser_new` whose container frames are
+/// balanced, and must not have been finished or aborted already.
+unsafe fn finish_to_vec(buf: *mut std::ffi::c_void) -> Vec<u8> {
+    let mut len: usize = 0;
+    // SAFETY: `buf` is a live, balanced handle per this fn's contract; `len` is a
+    // valid writable `*mut usize`.
+    let ptr = unsafe { hew_cbor_ser_finish(buf, &raw mut len) };
+    assert!(
+        !ptr.is_null(),
+        "serializer finished null (fail-closed) on a well-formed encode"
+    );
+    assert!(len > 0, "serializer produced zero-length output");
+    // SAFETY: `hew_cbor_ser_finish` returned a non-null buffer of exactly `len`
+    // bytes (asserted above).
+    let bytes = unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec();
+    // SAFETY: `ptr` came from `hew_cbor_ser_finish` and is freed exactly once here.
+    unsafe { hew_ser_free_bytes(ptr) };
+    bytes
+}
+
+/// Validate `bytes` against a single named CDDL rule, returning the validator's
+/// result. The rule is selected by prepending a one-line root alias so the
+/// validator entry rule is unambiguous.
+fn validate_against_rule(rule: &str, bytes: &[u8]) -> Result<(), String> {
+    // The `cddl` validator uses the first rule as the root unless told otherwise;
+    // prepend a root that aliases the rule under test so we validate exactly it.
+    let schema = format!("start = {rule}\n\n{}", wire_body_cddl());
+    cddl::validate_cbor_from_slice(&schema, bytes, None).map_err(|e| format!("{e:?}"))
+}
+
+/// `#[wire] struct WirePoint { x: i64 @1, y: i64 @2 }` body, encoded exactly as
+/// `emit_ser_value_cbor` would: `begin_map`, key 1 → i64, key 2 → i64, `end_map`.
+#[test]
+fn wire_struct_body_conforms_to_cddl() {
+    let buf = hew_cbor_ser_new();
+    // SAFETY: `buf` is a live handle from `hew_cbor_ser_new`, balanced
+    // begin_map/end_map, and is consumed exactly once by `finish_to_vec`.
+    unsafe {
+        hew_cbor_ser_begin_map(buf);
+        hew_cbor_ser_key_u64(buf, 1);
+        hew_cbor_ser_i64(buf, 3);
+        hew_cbor_ser_key_u64(buf, 2);
+        hew_cbor_ser_i64(buf, 4);
+        hew_cbor_ser_end_map(buf);
+    }
+    // SAFETY: `buf` is the same live handle, not yet finished elsewhere.
+    let bytes = unsafe { finish_to_vec(buf) };
+
+    validate_against_rule("wire-point-body", &bytes)
+        .expect("WirePoint body must validate against wire-point-body");
+    // The generic open-map rule must also accept it (forward-compat shape).
+    validate_against_rule("wire-struct-body", &bytes)
+        .expect("WirePoint body must validate against wire-struct-body");
+    // And the top-level body rule.
+    validate_against_rule("wire-body", &bytes)
+        .expect("WirePoint body must validate against wire-body");
+}
+
+/// `#[wire] enum WireCmd { Ping; Move(WirePoint); }` unit variant `Ping`
+/// (ordinal 0) → bare uint `0`, exactly as `emit_ser_enum_cbor`'s unit arm
+/// (`hew_cbor_ser_u64(tag)`).
+#[test]
+fn wire_enum_unit_body_conforms_to_cddl() {
+    let buf = hew_cbor_ser_new();
+    // SAFETY: `buf` is a live handle from `hew_cbor_ser_new`; a unit enum body is
+    // a single bare uint, consumed once by `finish_to_vec`.
+    unsafe {
+        hew_cbor_ser_u64(buf, 0);
+    }
+    // SAFETY: `buf` is the same live handle, not yet finished elsewhere.
+    let bytes = unsafe { finish_to_vec(buf) };
+
+    validate_against_rule("wire-enum-unit", &bytes)
+        .expect("Ping unit body must validate against wire-enum-unit");
+    validate_against_rule("wire-enum-body", &bytes)
+        .expect("Ping unit body must validate against wire-enum-body");
+    validate_against_rule("wire-body", &bytes)
+        .expect("Ping unit body must validate against wire-body");
+}
+
+/// `WireCmd::Move(WirePoint { x: 3, y: 4 })` payload variant (ordinal 1) →
+/// `{ 1 => [ {1: 3, 2: 4} ] }`, exactly as `emit_ser_enum_cbor`'s payload arm
+/// (`begin_map`, `key_u64(tag)`, `begin_array`, <field encodes>, `end_array`,
+/// `end_map`).
+#[test]
+fn wire_enum_payload_body_conforms_to_cddl() {
+    let buf = hew_cbor_ser_new();
+    // SAFETY: `buf` is a live handle from `hew_cbor_ser_new`; every begin_* is
+    // matched by an end_* (outer map / payload array / nested struct map) and the
+    // handle is consumed exactly once by `finish_to_vec`.
+    unsafe {
+        hew_cbor_ser_begin_map(buf);
+        hew_cbor_ser_key_u64(buf, 1); // variant tag 1 (Move)
+        hew_cbor_ser_begin_array(buf); // positional payload array
+                                       // payload field 0: the nested WirePoint struct body
+        hew_cbor_ser_begin_map(buf);
+        hew_cbor_ser_key_u64(buf, 1);
+        hew_cbor_ser_i64(buf, 3);
+        hew_cbor_ser_key_u64(buf, 2);
+        hew_cbor_ser_i64(buf, 4);
+        hew_cbor_ser_end_map(buf);
+        hew_cbor_ser_end_array(buf);
+        hew_cbor_ser_end_map(buf);
+    }
+    // SAFETY: `buf` is the same live handle, not yet finished elsewhere.
+    let bytes = unsafe { finish_to_vec(buf) };
+
+    validate_against_rule("wire-enum-payload", &bytes)
+        .expect("Move payload body must validate against wire-enum-payload");
+    validate_against_rule("wire-enum-body", &bytes)
+        .expect("Move payload body must validate against wire-enum-body");
+    validate_against_rule("wire-body", &bytes)
+        .expect("Move payload body must validate against wire-body");
+}
+
+/// A `#[wire] struct WireGreeting { name: string @1 }` body exercises the
+/// text-leaf rule (`hew_cbor_ser_string`).
+#[test]
+fn wire_struct_string_field_conforms_to_cddl() {
+    let buf = hew_cbor_ser_new();
+    let name = CString::new("hew").unwrap();
+    // SAFETY: `buf` is a live handle; `name` is a valid NUL-terminated C string
+    // that outlives the call; begin_map/end_map are balanced.
+    unsafe {
+        hew_cbor_ser_begin_map(buf);
+        hew_cbor_ser_key_u64(buf, 1);
+        hew_cbor_ser_string(buf, name.as_ptr());
+        hew_cbor_ser_end_map(buf);
+    }
+    // SAFETY: `buf` is the same live handle, not yet finished elsewhere.
+    let bytes = unsafe { finish_to_vec(buf) };
+
+    validate_against_rule("wire-struct-body", &bytes)
+        .expect("string-field struct body must validate against wire-struct-body");
+}
+
+// ── Fail-closed (negative) axis ──────────────────────────────────────────────
+
+/// A body that does not match the struct map shape (a bare text string) is
+/// rejected by the CDDL struct rule. The CDDL is a real contract: it says no to
+/// a shape the emitter never produces for a struct body.
+#[test]
+fn non_conforming_struct_body_is_rejected_by_cddl() {
+    // A bare CBOR text string — never a valid struct body (which is a map).
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(
+        &ciborium::value::Value::Text("not a struct".into()),
+        &mut bytes,
+    )
+    .unwrap();
+
+    let result = validate_against_rule("wire-struct-body", &bytes);
+    assert!(
+        result.is_err(),
+        "a bare text string must NOT validate as a struct body; got Ok"
+    );
+}
+
+/// An enum body shaped as a MULTI-entry map (two keys) is not a well-formed
+/// map-of-one; the CDDL enum-payload rule rejects it. This is the same shape the
+/// runtime reader `hew_cbor_de_enum_begin` fails closed on — the test below
+/// asserts that runtime fail-closed behaviour directly.
+#[test]
+fn multi_entry_enum_body_is_rejected_by_cddl() {
+    let mut bytes = Vec::new();
+    let bad = ciborium::value::Value::Map(vec![
+        (
+            ciborium::value::Value::Integer(1.into()),
+            ciborium::value::Value::Array(vec![]),
+        ),
+        (
+            ciborium::value::Value::Integer(2.into()),
+            ciborium::value::Value::Array(vec![]),
+        ),
+    ]);
+    ciborium::ser::into_writer(&bad, &mut bytes).unwrap();
+
+    let result = validate_against_rule("wire-enum-payload", &bytes);
+    assert!(
+        result.is_err(),
+        "a two-entry map must NOT validate as a map-of-one enum body; got Ok"
+    );
+}
+
+/// The runtime decoder fails CLOSED on the same malformed enum bodies the CDDL
+/// rejects: a multi-entry map and a single entry whose value is not an array
+/// both make `hew_cbor_de_enum_begin` return 0 (tag 0) and set the reader's
+/// failed flag — it never fabricates a variant. This is the load-bearing
+/// guarantee: the CDDL check is additive, the runtime reader is the trust
+/// boundary, and they agree on what is malformed.
+#[test]
+fn malformed_enum_body_fails_closed_at_runtime_decoder() {
+    // Multi-entry map: `{1: [], 2: []}` — not a map-of-one.
+    let mut multi = Vec::new();
+    ciborium::ser::into_writer(
+        &ciborium::value::Value::Map(vec![
+            (
+                ciborium::value::Value::Integer(1.into()),
+                ciborium::value::Value::Array(vec![]),
+            ),
+            (
+                ciborium::value::Value::Integer(2.into()),
+                ciborium::value::Value::Array(vec![]),
+            ),
+        ]),
+        &mut multi,
+    )
+    .unwrap();
+    // SAFETY: `multi` is a live slice valid for its length; `hew_cbor_de_new`
+    // borrows it only for the duration of parsing.
+    let reader = unsafe { hew_cbor_de_new(multi.as_ptr(), multi.len()) };
+    assert!(!reader.is_null(), "decoder handle for multi-entry body");
+    // SAFETY: `reader` is the live handle just created.
+    let tag = unsafe { hew_cbor_de_enum_begin(reader) };
+    assert_eq!(tag, 0, "multi-entry enum body must fail closed to tag 0");
+    // SAFETY: `reader` is the same handle, freed exactly once.
+    unsafe { hew_cbor_de_free(reader) };
+
+    // Single entry whose value is NOT an array: `{1: 7}`.
+    let mut not_array = Vec::new();
+    ciborium::ser::into_writer(
+        &ciborium::value::Value::Map(vec![(
+            ciborium::value::Value::Integer(1.into()),
+            ciborium::value::Value::Integer(7.into()),
+        )]),
+        &mut not_array,
+    )
+    .unwrap();
+    // SAFETY: `not_array` is a live slice valid for its length.
+    let reader2 = unsafe { hew_cbor_de_new(not_array.as_ptr(), not_array.len()) };
+    assert!(!reader2.is_null(), "decoder handle for non-array body");
+    // SAFETY: `reader2` is the live handle just created.
+    let tag2 = unsafe { hew_cbor_de_enum_begin(reader2) };
+    assert_eq!(
+        tag2, 0,
+        "single-entry-non-array enum body must fail closed to tag 0"
+    );
+    // SAFETY: `reader2` is the same handle, freed exactly once.
+    unsafe { hew_cbor_de_free(reader2) };
+}

--- a/hew-runtime/tests/wire_body_cddl_conformance.rs
+++ b/hew-runtime/tests/wire_body_cddl_conformance.rs
@@ -28,10 +28,10 @@ use std::ffi::CString;
 use std::path::PathBuf;
 
 use hew_runtime::cbor_serial::{
-    hew_cbor_de_enum_begin, hew_cbor_de_free, hew_cbor_de_new, hew_cbor_ser_begin_array,
-    hew_cbor_ser_begin_map, hew_cbor_ser_end_array, hew_cbor_ser_end_map, hew_cbor_ser_finish,
-    hew_cbor_ser_i64, hew_cbor_ser_key_u64, hew_cbor_ser_new, hew_cbor_ser_string,
-    hew_cbor_ser_u64,
+    hew_cbor_de_enum_begin, hew_cbor_de_failed, hew_cbor_de_free, hew_cbor_de_new,
+    hew_cbor_ser_begin_array, hew_cbor_ser_begin_map, hew_cbor_ser_end_array, hew_cbor_ser_end_map,
+    hew_cbor_ser_finish, hew_cbor_ser_i64, hew_cbor_ser_key_u64, hew_cbor_ser_new,
+    hew_cbor_ser_string, hew_cbor_ser_u64,
 };
 use hew_runtime::xnode_serial::hew_ser_free_bytes;
 
@@ -235,10 +235,17 @@ fn multi_entry_enum_body_is_rejected_by_cddl() {
 
 /// The runtime decoder fails CLOSED on the same malformed enum bodies the CDDL
 /// rejects: a multi-entry map and a single entry whose value is not an array
-/// both make `hew_cbor_de_enum_begin` return 0 (tag 0) and set the reader's
-/// failed flag — it never fabricates a variant. This is the load-bearing
-/// guarantee: the CDDL check is additive, the runtime reader is the trust
-/// boundary, and they agree on what is malformed.
+/// both make `hew_cbor_de_enum_begin` set the reader's `failed` flag and return
+/// 0 — it never fabricates a variant. This is the load-bearing guarantee: the
+/// CDDL check is additive, the runtime reader is the trust boundary, and they
+/// agree on what is malformed.
+///
+/// The `failed` flag (`hew_cbor_de_failed == 1`) is the structural sentinel that
+/// distinguishes "decoder failed closed" from "decoded a real tag-0 unit variant
+/// (e.g. `Ping`)": a clean tag-0 decode leaves `failed == 0`; these malformed
+/// inputs latch `failed == 1`. Asserting the flag (not just `tag == 0`) ensures
+/// this test has real teeth — it would catch a decoder that silently decoded a
+/// well-formed variant-0 body instead of failing closed.
 #[test]
 fn malformed_enum_body_fails_closed_at_runtime_decoder() {
     // Multi-entry map: `{1: [], 2: []}` — not a map-of-one.
@@ -261,9 +268,19 @@ fn malformed_enum_body_fails_closed_at_runtime_decoder() {
     // borrows it only for the duration of parsing.
     let reader = unsafe { hew_cbor_de_new(multi.as_ptr(), multi.len()) };
     assert!(!reader.is_null(), "decoder handle for multi-entry body");
-    // SAFETY: `reader` is the live handle just created.
+    // SAFETY: `reader` is the live handle just created; `hew_cbor_de_enum_begin`
+    // and `hew_cbor_de_failed` each take a live handle for the reader's lifetime.
     let tag = unsafe { hew_cbor_de_enum_begin(reader) };
     assert_eq!(tag, 0, "multi-entry enum body must fail closed to tag 0");
+    // The `failed` flag distinguishes "failed closed" from "decoded a real tag-0
+    // variant": a malformed body MUST latch failed == 1.
+    // SAFETY: `reader` is a live handle for the same decoder object just used
+    // for `hew_cbor_de_enum_begin` above; it has not been freed yet.
+    let failed = unsafe { hew_cbor_de_failed(reader) };
+    assert_eq!(
+        failed, 1,
+        "multi-entry enum body must set the failed flag (not just return tag 0)"
+    );
     // SAFETY: `reader` is the same handle, freed exactly once.
     unsafe { hew_cbor_de_free(reader) };
 
@@ -285,6 +302,14 @@ fn malformed_enum_body_fails_closed_at_runtime_decoder() {
     assert_eq!(
         tag2, 0,
         "single-entry-non-array enum body must fail closed to tag 0"
+    );
+    // Again, the structural sentinel is the `failed` flag, not the sentinel tag value.
+    // SAFETY: `reader2` is a live handle for the same decoder object just used
+    // for `hew_cbor_de_enum_begin` above; it has not been freed yet.
+    let failed2 = unsafe { hew_cbor_de_failed(reader2) };
+    assert_eq!(
+        failed2, 1,
+        "single-entry-non-array enum body must set the failed flag"
     );
     // SAFETY: `reader2` is the same handle, freed exactly once.
     unsafe { hew_cbor_de_free(reader2) };


### PR DESCRIPTION
## Summary

The envelope payload for `#[wire]`-annotated internode messages was previously an opaque `bstr`. This PR gives it a formal schema: `hew-runtime/schemas/wire-body.cddl` describes the CBOR body in RFC 8610 CDDL — a struct encodes as a uint-keyed map (field tag from explicit `@N`, else 1-based positional), and an enum encodes as a bare uint unit-tag or a single-entry map `{uint => [...]}` for payload variants. A conformance test validates the runtime serializer's actual emitted bytes against the committed CDDL using a real RFC 8610 validator (`cddl` crate, test-only, native-only). A cross-process `#[wire]` round-trip E2E exercises explicit-`@N` tagged structs and an ordinal-tagged enum across a real process boundary. The wire-format doctrine doc is added alongside, covering the serializer/decoder trust boundary, tag stability rules (struct `@N` fields are reorder-stable; enum ordinal variants are not — reordering is a breaking wire change), and the static-type disambiguation that resolves the struct/enum body ambiguity. Fail-closed: a non-conforming or malformed message decodes to null at the runtime decoder; the CDDL schema is additive documentation, not a runtime gate.

## Verification

- `cargo test -p hew-runtime --test wire_body_cddl_conformance`: 7 passed, 0 failed — real emitted bytes through the RFC 8610 validator
- `malformed_enum_body_fails_closed_at_runtime_decoder`: asserts the decoder's fail-closed flag directly on malformed input (distinguishes "failed closed" from a real tag-0 decode structurally)
- `wire_cbor_cross_process_round_trip` (macOS): explicit-`@N` struct + ordinal enum cross-process round-trip passes
- `wire_cbor_cross_process_round_trip` (Linux, real host): 8/8 pass — codec registers via `.init_array` on ELF; confirmed the codec-constructor path without a mock registry
- No dispatch pointer on the wire: `CodecKey.dispatch` is process-local only; source-verified at `xnode_serial.rs:117` and `:342`
- Preflight: ready-to-push

## Out of scope

- DIST-5 (HBF deletion) and the remainder of the distributed runtime chain are not part of this PR.
