### PR TITLE
fix(corpus): remove stale sleep-duration NYI markers

### DIFF
--- a/hew-runtime/src/io_time.rs
+++ b/hew-runtime/src/io_time.rs
@@ -1,6 +1,6 @@
 //! File I/O, sleep, clock, and I/O poller for the Hew runtime.
 //!
-//! Provides `hew_read_file`, `hew_sleep_ms`, `hew_sleep_ns`, `hew_sleep_until_ns`,
+//! Provides `hew_read_file`, `hew_sleep_ns`, `hew_sleep_until_ns`,
 //! `hew_now_ms`, duration helpers,
 //! and a platform I/O poller (epoll on Linux, kqueue on FreeBSD/macOS, stub
 //! elsewhere).

--- a/scripts/hew-corpus-expected-failures.txt
+++ b/scripts/hew-corpus-expected-failures.txt
@@ -5,12 +5,11 @@
 # list) or UNEXPECTED PASS (listed here but now compiles — delete the entry).
 #
 # Classification categories:
-#   deferred-nyi    — Feature not yet implemented in the compiler (sleep
-#                     duration literals, select/channel, link_monitor MIR,
-#                     hashmap/hashset for-in, lambdas with await, await_restart
-#                     syntax, clone on generic types, etc.). The fixture is
-#                     correctly written Hew; the compiler just hasn't landed
-#                     the feature yet.
+#   deferred-nyi    — Feature not yet implemented in the compiler (select/channel,
+#                     link_monitor MIR, hashmap/hashset for-in, lambdas with await,
+#                     await_restart syntax, clone on generic types, etc.). The
+#                     fixture is correctly written Hew; the compiler just hasn't
+#                     landed the feature yet.
 #   stale-syntax    — File uses pre-v0.5 syntax that was removed (e.g.
 #                     `struct` → `type`, `event` → `events { }` block,
 #                     `let x = channel()` → new channel API). Needs migrating
@@ -35,8 +34,6 @@
 # Gate: make hew-check-all (scripts/hew-corpus-check.sh)
 
 # ── examples/ ────────────────────────────────────────────────────────────────
-
-# deferred-nyi: sleep duration literals (50ms / 0ns) not yet accepted
 
 # deferred-nyi: channel/select syntax not yet lowered
 examples/benchmark_demo.hew
@@ -153,8 +150,8 @@ hew-parser/tests/fmt_roundtrip_corpus/assoc_types/self_projection_signatures.hew
 # demonstration for the sandbox VM — it is designed to fail hew check
 hew-sandbox-vm/fixtures/09-compile-type-error/main.hew
 
-# deferred-nyi: sandbox fixtures using NYI features (sleep duration, actor
-# ask/reply, channel select, supervisor, machine events, stdin, random)
+# deferred-nyi: sandbox fixtures using NYI features (actor ask/reply, channel
+# select, supervisor, machine events, stdin, random)
 hew-sandbox-vm/fixtures/15-actor-counter/main.hew
 hew-sandbox-vm/fixtures/16-actor-ask-reply/main.hew
 hew-sandbox-vm/fixtures/17-channel-select/main.hew
@@ -204,9 +201,9 @@ tests/corpus/v05-value-model/19_actor_scope.hew
 
 # ── tests/hew/ ───────────────────────────────────────────────────────────────
 
-# deferred-nyi: hew test suite files using NYI features (sleep duration,
-# actor select/suspend, generic clone, hashmap clone, instant methods, process,
-# generic vec iter, this-send)
+# deferred-nyi: hew test suite files using NYI features (actor select/suspend,
+# generic clone, hashmap clone, instant methods, process, generic vec iter,
+# this-send)
 tests/hew/generic_vec_iter_surface_test.hew
 
 # ── tests/ll-oracle/ ─────────────────────────────────────────────────────────
@@ -304,8 +301,6 @@ tests/vertical-slice/accept/local_fn_msg_actor_method_allowed.hew
 tests/vertical-slice/accept/regex_match_arm.hew
 
 # deferred-nyi: select recv guard NYI
-
-# deferred-nyi: sleep duration literal NYI
 
 # deferred-nyi: supervisor NYI features
 


### PR DESCRIPTION
## Summary

`sleep(duration)` and `sleep_until(instant)` landed in #2232. The
`scripts/hew-corpus-expected-failures.txt` file still contained comment
markers labelling these as NYI, even though no allowlist entry was ever
added for them — the markers were orphaned from the moment #2232 merged.
The `io_time` module doc also referenced `hew_sleep_ms`, a symbol that
no longer exists. Both are now removed. No behaviour change; no
allowlist entries were touched.

## Verification

- `git diff origin/main --stat`: 2 files changed — `hew-corpus-expected-failures.txt` and `hew-runtime/src/io_time.rs` only
- `cargo check`: clean
- Pre-push hook (fmt + orchestration-leak lint): passed
- No allowlist entry removed from the corpus file — only stale comments

## Out of scope

No test behaviour was changed. The sleep E2E coverage itself is already
exercised by the corpus since #2232; this PR only removes the misleading
comments that suggested otherwise.