### PR TITLE
fix(typecheck): normalize named primitives to flat variants in trait-sig comparison

### DIFF
--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -6382,7 +6382,31 @@ impl Checker {
                             .filter(|qualified| (ctx.defines_qualified)(qualified))
                             .unwrap_or_else(|| name.clone()),
                     };
-                    Ty::normalize_named(canonical, args.iter().map(rec).collect())
+                    // Primitive types (i64, bool, f64, …) are represented in two
+                    // ways: as the flat `Ty::I64` / `Ty::Bool` / … variants (from
+                    // `resolve_type_expr` hitting the `Ty::from_name` fast-path)
+                    // and as `Ty::Named { name: "i64", builtin: Some(I64), … }`
+                    // (from `Ty::normalize_named` when a `Self` annotation is
+                    // eagerly substituted via `current_self_type` during
+                    // `lookup_trait_method` resolution).  Both representations are
+                    // semantically identical, but `Ty::Named { … } != Ty::I64` as
+                    // Rust enum discriminants, so trait-impl signature comparison
+                    // falsely rejects them.
+                    //
+                    // Collapsing the canonical name to the flat primitive variant
+                    // here is the canonical reconcile point: both the expected
+                    // (trait) and actual (impl) sides pass through this function
+                    // before comparison, so a single normalization here handles
+                    // every path (fn_sigs registered before impl, lookup_trait_method
+                    // eager substitution, and substitute_trait_sig_for_impl output).
+                    // Only fires for zero-arg names (primitives never carry type args).
+                    let canonical_args = args.iter().map(rec).collect::<Vec<_>>();
+                    if canonical_args.is_empty() {
+                        if let Some(prim) = Ty::from_name(&canonical) {
+                            return prim;
+                        }
+                    }
+                    Ty::normalize_named(canonical, canonical_args)
                 }
                 Ty::Function { params, ret } => Ty::Function {
                     params: params.iter().map(rec).collect(),
@@ -6517,10 +6541,30 @@ impl Checker {
             }
         }
 
-        let impl_self = Ty::Named {
-            builtin: None,
-            name: type_name.to_string(),
-            args: self_type_args.to_vec(),
+        // Construct `impl_self` as the canonical `Ty` for the implementing
+        // type. For primitive types (i64, bool, f64, …) `Ty::from_name`
+        // returns the flat primitive variant (e.g. `Ty::I64`), which is what
+        // the impl's annotation resolves to via
+        // `resolve_registered_annotation_ty_no_holes`.  Using `Ty::Named` for
+        // a primitive name produces a different enum variant than the impl's
+        // resolved param type, causing a false "has type i64 but requires i64"
+        // mismatch on non-receiver Self params.  `Ty::from_name` is the single
+        // source of truth for primitive name → variant; non-primitive names
+        // that have no flat variant (user-defined types, generics) take the
+        // `Ty::Named` path as before.  Primitive types never carry type args,
+        // so the from_name path only fires when self_type_args is empty.
+        let impl_self = if self_type_args.is_empty() {
+            Ty::from_name(type_name).unwrap_or_else(|| Ty::Named {
+                builtin: None,
+                name: type_name.to_string(),
+                args: Vec::new(),
+            })
+        } else {
+            Ty::Named {
+                builtin: None,
+                name: type_name.to_string(),
+                args: self_type_args.to_vec(),
+            }
         };
 
         // Materialise the expected impl-side signature.

--- a/hew-types/tests/trait_self_primitive_impl.rs
+++ b/hew-types/tests/trait_self_primitive_impl.rs
@@ -1,0 +1,249 @@
+//! Tests that `Self` in non-receiver parameter and return position of a trait
+//! impl for a primitive type resolves correctly.
+//!
+//! Prior to this fix, `substitute_trait_sig_for_impl` substituted `Self` with
+//! `Ty::Named { name: "i64", builtin: None }`, while the impl's annotation
+//! resolved to the flat `Ty::I64` variant.  `canonicalize_type_identity` does
+//! not collapse `Ty::Named { name: "i64" }` → `Ty::I64`, so the comparison
+//! always failed — yielding a self-contradictory "has type i64 but requires i64".
+
+mod common;
+
+use common::typecheck_isolated as typecheck;
+
+// ---------------------------------------------------------------------------
+// Non-receiver Self in parameter position
+// ---------------------------------------------------------------------------
+
+/// `impl Compare for i64` — both `a` and `b` params are `Self` in the trait.
+/// Previously this raised a false "has type i64 but requires i64" error on `b`.
+#[test]
+fn self_non_receiver_param_i64_typechecks() {
+    let output = typecheck(
+        r"
+        trait Compare {
+            fn eq_to(a: Self, b: Self) -> bool;
+        }
+
+        impl Compare for i64 {
+            fn eq_to(a: i64, b: i64) -> bool {
+                a == b
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected no errors for i64 impl; got: {:#?}",
+        output.errors
+    );
+}
+
+/// Same trait impl for `bool`.
+#[test]
+fn self_non_receiver_param_bool_typechecks() {
+    let output = typecheck(
+        r"
+        trait Compare {
+            fn eq_to(a: Self, b: Self) -> bool;
+        }
+
+        impl Compare for bool {
+            fn eq_to(a: bool, b: bool) -> bool {
+                a == b
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected no errors for bool impl; got: {:#?}",
+        output.errors
+    );
+}
+
+/// Same trait impl for `f64`.
+#[test]
+fn self_non_receiver_param_f64_typechecks() {
+    let output = typecheck(
+        r"
+        trait Compare {
+            fn eq_to(a: Self, b: Self) -> bool;
+        }
+
+        impl Compare for f64 {
+            fn eq_to(a: f64, b: f64) -> bool {
+                a == b
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected no errors for f64 impl; got: {:#?}",
+        output.errors
+    );
+}
+
+/// Same trait impl for `i32`.
+#[test]
+fn self_non_receiver_param_i32_typechecks() {
+    let output = typecheck(
+        r"
+        trait Compare {
+            fn eq_to(a: Self, b: Self) -> bool;
+        }
+
+        impl Compare for i32 {
+            fn eq_to(a: i32, b: i32) -> bool {
+                a == b
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected no errors for i32 impl; got: {:#?}",
+        output.errors
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Self in return position
+// ---------------------------------------------------------------------------
+
+/// `Self` used as a return type must also match the primitive variant.
+#[test]
+fn self_in_return_position_i64_typechecks() {
+    let output = typecheck(
+        r"
+        trait Clone {
+            fn clone(self) -> Self;
+        }
+
+        impl Clone for i64 {
+            fn clone(v: i64) -> i64 {
+                v
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected no errors for i64 Clone impl; got: {:#?}",
+        output.errors
+    );
+}
+
+/// `Self` in both param and return position (e.g. an `Add` style trait).
+#[test]
+fn self_in_param_and_return_position_i64_typechecks() {
+    let output = typecheck(
+        r"
+        trait Add {
+            fn add(a: Self, b: Self) -> Self;
+        }
+
+        impl Add for i64 {
+            fn add(a: i64, b: i64) -> i64 {
+                a + b
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected no errors for i64 Add impl; got: {:#?}",
+        output.errors
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Receiver-position Self (must still work — no regression)
+// ---------------------------------------------------------------------------
+
+/// A receiver-only Self method on a primitive must still typecheck.
+#[test]
+fn self_receiver_position_i64_no_regression() {
+    let output = typecheck(
+        r#"
+        trait Stringify {
+            fn to_str(self) -> string;
+        }
+
+        impl Stringify for i64 {
+            fn to_str(v: i64) -> string {
+                "num"
+            }
+        }
+        "#,
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected no errors for receiver-position i64 impl; got: {:#?}",
+        output.errors
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Non-primitive impl type (must still work — no regression)
+// ---------------------------------------------------------------------------
+
+/// A non-primitive struct impl must still typecheck after the fix.
+#[test]
+fn self_non_receiver_param_struct_no_regression() {
+    let output = typecheck(
+        r"
+        trait Compare {
+            fn eq_to(a: Self, b: Self) -> bool;
+        }
+
+        type Point { x: i64, y: i64 }
+
+        impl Compare for Point {
+            fn eq_to(a: Point, b: Point) -> bool {
+                a.x == b.x
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected no errors for struct impl; got: {:#?}",
+        output.errors
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Type mismatch must still be caught (regression guard)
+// ---------------------------------------------------------------------------
+
+/// A genuinely wrong impl (wrong param type) must still be rejected.
+#[test]
+fn wrong_impl_param_type_is_rejected() {
+    use hew_types::error::TypeErrorKind;
+
+    let output = typecheck(
+        r"
+        trait Compare {
+            fn eq_to(a: Self, b: Self) -> bool;
+        }
+
+        impl Compare for i64 {
+            fn eq_to(a: i64, b: bool) -> bool {
+                a == 0
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.iter().any(|e| e.kind
+            == TypeErrorKind::TraitImplSignatureMismatch {
+                trait_name: "Compare".to_string(),
+                method_name: "eq_to".to_string(),
+                detail: "parameter",
+            }),
+        "expected TraitImplSignatureMismatch for wrong param type; got: {:#?}",
+        output.errors
+    );
+}

--- a/hew-types/tests/trait_self_primitive_impl.rs
+++ b/hew-types/tests/trait_self_primitive_impl.rs
@@ -247,3 +247,81 @@ fn wrong_impl_param_type_is_rejected() {
         output.errors
     );
 }
+
+// ---------------------------------------------------------------------------
+// Nested Self on a primitive impl (recursion through composite types)
+// ---------------------------------------------------------------------------
+//
+// `canonicalize_type_identity` recurses into composite type variants
+// (Vec/Option/tuple/…), so a `Self` nested inside `Vec<Self>`, `Option<Self>`,
+// or a tuple must also collapse `Ty::Named { name: "i64" }` → `Ty::I64` on
+// both sides. These lock the recursive path against future regression.
+
+/// `Self` nested inside `Vec<Self>` in return position.
+#[test]
+fn nested_self_in_vec_return_i64_typechecks() {
+    let output = typecheck(
+        r"
+        trait Dup {
+            fn dup(a: Self) -> Vec<Self>;
+        }
+
+        impl Dup for i64 {
+            fn dup(a: i64) -> Vec<i64> {
+                Vec::new()
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected no errors for Vec<Self> return; got: {:#?}",
+        output.errors
+    );
+}
+
+/// `Self` nested inside `Option<Self>` in return position.
+#[test]
+fn nested_self_in_option_return_i64_typechecks() {
+    let output = typecheck(
+        r"
+        trait Wrap {
+            fn wrap(a: Self) -> Option<Self>;
+        }
+
+        impl Wrap for i64 {
+            fn wrap(a: i64) -> Option<i64> {
+                Some(a)
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected no errors for Option<Self> return; got: {:#?}",
+        output.errors
+    );
+}
+
+/// `Self` nested inside a tuple in both param and return position.
+#[test]
+fn nested_self_in_tuple_return_i64_typechecks() {
+    let output = typecheck(
+        r"
+        trait Pair {
+            fn mk(a: Self, b: Self) -> (Self, Self);
+        }
+
+        impl Pair for i64 {
+            fn mk(a: i64, b: i64) -> (i64, i64) {
+                (a, b)
+            }
+        }
+        ",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "expected no errors for (Self, Self) return; got: {:#?}",
+        output.errors
+    );
+}


### PR DESCRIPTION
## Summary

`Self` in a non-receiver parameter or return position of a trait impl for a primitive type was rejected with a self-contradictory error: "parameter has type `i64` but trait requires `i64`". This blocked clean Eq/Ord/Add/Clone-style trait impls on primitive types.

The underlying cause was a representation mismatch: when the trait side resolves a bare `Self` annotation during method lookup, it produces `Ty::Named { name: "i64", builtin: Some(I64) }`. The impl side, going through `resolve_type_expr`, hits the `Ty::from_name` fast-path and produces the flat `Ty::I64` variant. These two representations are semantically identical but structurally distinct Rust enum discriminants, so the equality check falsely rejected them.

`canonicalize_type_identity` now collapses named primitive spellings to their flat variant before comparison — the reconcile fires on both the expected (trait) and actual (impl) sides, since all four operands (params + return for each side) pass through the same function. `impl_self` is also built via `Ty::from_name` for the same reason. Nested `Self` in composite positions (`Vec<Self>`, `Option<Self>`, `(Self, Self)`) is handled by the existing recursion through `Ty::Named` args.

## Verification

- `cargo test -p hew-types --test trait_self_primitive_impl`: 12 passed (non-receiver Self param, Self return, nested Self in Vec/Option/tuple, multiple primitives, receiver-position + struct no-regression, wrong-type-still-rejected)
- `cargo test -p hew-types`: full suite green, no regressions
- `make test-compiler-pipeline`: 6637 passed
- Fuzz-oracle and leak-scan: clean
- Clippy + fmt: clean
- Preflight: ready-to-push

## Out of scope

- A pre-existing array-literal inference quirk where `[a, a]` infers `Vec<T>` instead of `[T; N]` when the element type is known — surfaced incidentally while testing `[Self; 2]` return positions, but not caused by this fix. Tracked separately.
