### PR TITLE
fix(stdlib): delegate string.split free function to s.split method

### DIFF
--- a/std/string.hew
+++ b/std/string.hew
@@ -571,32 +571,10 @@ pub fn replace(s: string, old: string, new_val: string) -> string {
 /// let empty = string.split("", "");        // []
 /// ```
 pub fn split(s: string, sep: string) -> Vec<string> {
-    let result: Vec<string> = Vec::new();
-    let slen = s.len();
-    let dlen = sep.len();
-    if dlen == 0 {
-        // Split into individual Unicode codepoints.
-        // char_count_utf8 returns the number of Unicode scalar values; for ASCII
-        // strings this equals len(). codepoint_at_utf8(i) returns the i-th scalar.
-        let nchars = s.char_count_utf8();
-        for i in 0 .. nchars {
-            let cp = s.codepoint_at_utf8(i);
-            result.push(from_char(cp));
-        }
-        return result;
-    }
-    var start = 0;
-    while start <= slen {
-        let rest = s.slice(start, slen);
-        let idx = rest.find(sep);
-        if idx < 0 {
-            result.push(rest);
-            break;
-        }
-        result.push(s.slice(start, start + idx));
-        start = start + idx + dlen;
-    }
-    result
+    // Delegate to the method, which routes to hew_string_split FFI.
+    // That implementation is O(n) for both the empty-separator (codepoints)
+    // and non-empty-separator (windows scan) paths.
+    s.split(sep)
 }
 
 /// Split a string into lines, stripping `\r\n` or `\n` endings.

--- a/tests/hew/string_test.hew
+++ b/tests/hew/string_test.hew
@@ -271,3 +271,47 @@ fn test_is_ascii_rejects_128_and_above() {
     // A string containing a non-ASCII multibyte sequence is also rejected.
     testing.assert_false(string.is_ascii("héllo"));
 }
+
+// ── from_char multi-byte round-trip (regression lock for A195 fix) ───────────
+
+#[test]
+fn test_from_char_emits_full_utf8_for_two_byte_codepoint() {
+    // U+00E9 (é) is a two-byte UTF-8 sequence: 0xC3 0xA9.
+    // Before the A195 fix, only the first byte was encoded, producing a
+    // one-byte garbage string rather than "é".
+    testing.assert_eq_str(string.from_char(233), "é");
+}
+
+#[test]
+fn test_from_char_emits_full_utf8_for_four_byte_codepoint() {
+    // U+1F600 (😀) encodes as four UTF-8 bytes: 0xF0 0x9F 0x98 0x80.
+    testing.assert_eq_str(string.from_char(128512), "😀");
+}
+
+// ── split empty-separator multi-byte exact values ─────────────────────────────
+
+#[test]
+fn test_split_empty_separator_returns_multibyte_codepoints_as_individual_elements() {
+    // "café" is 5 bytes but 4 Unicode codepoints. The empty-separator split
+    // must yield 4 elements with "é" as a single two-byte string, never split
+    // at the byte boundary.
+    let expected: Vec<string> = Vec::new();
+    expected.push("c");
+    expected.push("a");
+    expected.push("f");
+    expected.push("é");
+    assert_string_vec_eq(string.split("café", ""), expected);
+}
+
+// ── split non-empty separator exact element values ────────────────────────────
+
+#[test]
+fn test_split_returns_exact_element_values_for_nonempty_separator() {
+    // Checks each element, not just the count, to catch off-by-one errors in
+    // the split position that a len()-only assertion would miss.
+    let expected: Vec<string> = Vec::new();
+    expected.push("red");
+    expected.push("green");
+    expected.push("blue");
+    assert_string_vec_eq(string.split("red,green,blue", ","), expected);
+}

--- a/tests/vertical-slice/accept/string_split_nonempty.hew
+++ b/tests/vertical-slice/accept/string_split_nonempty.hew
@@ -1,0 +1,28 @@
+// Vertical slice: string.split with non-empty separators — exact element values.
+//
+// Verifies the delegation path (free function → method → hew_string_split FFI)
+// produces correct results for non-empty separators. Assertions use exact element
+// values, not length-only checks, so a wrong split position would be caught.
+import std::string;
+
+fn main() {
+    // Basic comma-separated split — three elements.
+    let parts = string.split("a,b,c", ",");
+    assert_eq(parts.len(), 3);
+    assert_eq(parts[0], "a");
+    assert_eq(parts[1], "b");
+    assert_eq(parts[2], "c");
+
+    // Trailing delimiter produces a trailing empty element.
+    let trail = string.split("a,b,", ",");
+    assert_eq(trail.len(), 3);
+    assert_eq(trail[0], "a");
+    assert_eq(trail[1], "b");
+    assert_eq(trail[2], "");
+
+    // Multi-byte separator with a multi-byte character in the value.
+    let mb = string.split("héllo::world", "::");
+    assert_eq(mb.len(), 2);
+    assert_eq(mb[0], "héllo");
+    assert_eq(mb[1], "world");
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -3500,4 +3500,10 @@ echo "PASS loop_break_in_iflet_scrutinee (reject)"
 run_accept_expect_status "string_split_to_chars_ascii" 0
 run_accept_expect_status "string_split_to_chars_multibyte" 0
 run_accept_expect_status "string_split_to_chars_empty" 0
+# ---------------------------------------------------------------------------
+# Non-empty separator split — exact element values.
+# Confirms the free-function-to-method delegation handles comma-separated
+# input, trailing delimiters, and multi-byte separator / multi-byte value.
+# ---------------------------------------------------------------------------
+run_accept_expect_status "string_split_nonempty" 0
 


### PR DESCRIPTION
## Summary

The `string.split` free function in `std/string.hew` previously implemented its own 27-line byte-based loop that allocated a fresh copy of the remaining string on each iteration — a latent O(n²) in both allocations and work. It now delegates to `s.split(sep)`, which routes to the `hew_string_split` FFI (`hew-runtime/src/string.rs`). The FFI uses sub-slices for non-empty separators (O(n)) and a single `chars()` pass for the empty separator (O(n)), eliminating the quadratic pattern entirely. Behaviour is identical on every edge: empty/non-empty separator, leading, trailing, and consecutive delimiters, separator longer than the string, separator absent, empty input, and multibyte content with a multibyte separator.

Exact-value test coverage is added for the edges that matter most: `from_char` round-trips for 2-byte (`é`) and 4-byte (`😀`) codepoints (regression lock for the codepoint-encoding fix that underpins the empty-separator path), `split("café","")` asserting the four exact elements, and a vertical-slice fixture asserting exact elements for a trailing-delimiter case and a multibyte-separator (`::`) split against multibyte content (`héllo`).

## Verification

- `make test-lane CRATE=hew-runtime`: 2423 tests pass
- `make test-lane CRATE=hew-cli`: 379 tests pass
- Vertical slice (`string_split_nonempty.hew`): pass, exit 0
- `hew test` string suite: 32/32 pass
- `verify-ffi`: no new symbols introduced
- Flake gate: 3/3 clean runs
- Cross-ecosystem review: behaviour-equivalence confirmed analytically and by simulation across all 14 split edges; O(n²)→O(n) improvement confirmed
- Preflight: ready-to-push

## Out of scope

- Hew-level fixtures for `split("","")→[]` and `split("","x")→[""]` (empty-input edge cases): equivalence is proven analytically and covered by Rust unit tests in `hew-runtime`; pinning these at the Hew fixture level is a completeness nicety that can be added independently.
