### PR TITLE
fix(mir): normalise generic machine field types before record-field classification

### DIFF
--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -8133,8 +8133,27 @@ impl Builder {
             is_opaque,
         } = ty
         {
+            // Strip type args only for machine decl types, never for generic
+            // enums (Option, Result, etc.).  Both sets are present in
+            // `machine_layout_names` — machine names are added directly from
+            // HirItem::Machine, and generic enum origin names are added from
+            // module.enum_layouts so that `is_known_actor_runtime_ty` resolves
+            // them as BitCopy.  The distinguishing property: every generic enum
+            // instantiation has at least one EnumLayout whose name begins with
+            // `{short_name}$$` (the mangled form), while machine types never
+            // produce a `$$`-mangled layout entry (machines always register
+            // under the bare decl name).  If we stripped args from a generic
+            // enum, the bare-name lookup would miss the mangled layout (e.g.
+            // "Option" instead of "Option$$i64") and produce MissingRecordLayout
+            // on any record with an Option<i64> field.
+            let sname = short_name(name);
+            let is_generic_enum_origin = self
+                .enum_layouts
+                .iter()
+                .any(|el| el.name.starts_with(&format!("{sname}$$")));
             if !args.is_empty()
                 && args.iter().all(|a| matches!(a, ResolvedTy::I64))
+                && !is_generic_enum_origin
                 && machine_layout_name_matches(&self.machine_layout_names, name)
             {
                 return ResolvedTy::Named {

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -8116,6 +8116,38 @@ impl Builder {
             .collect()
     }
 
+    /// Strip type args from a machine-typed field when the outer name is a
+    /// known machine decl and every arg is `i64`.  This mirrors the
+    /// `normalize_machine_field_ty` closure used in the actor-state
+    /// classification path (lower.rs ~1513): generic machine instantiations
+    /// are canonicalised to the bare decl name because the machine layout is
+    /// always registered under that bare name, never mangled.
+    ///
+    /// Non-machine types and non-all-i64 instantiations are returned unchanged
+    /// so they fail closed through the normal classification miss.
+    fn normalize_machine_field_ty(&self, ty: &ResolvedTy) -> ResolvedTy {
+        if let ResolvedTy::Named {
+            name,
+            args,
+            builtin,
+            is_opaque,
+        } = ty
+        {
+            if !args.is_empty()
+                && args.iter().all(|a| matches!(a, ResolvedTy::I64))
+                && machine_layout_name_matches(&self.machine_layout_names, name)
+            {
+                return ResolvedTy::Named {
+                    name: name.clone(),
+                    args: vec![],
+                    builtin: *builtin,
+                    is_opaque: *is_opaque,
+                };
+            }
+        }
+        ty.clone()
+    }
+
     /// True when `ty` may be admitted as a generator-env capture field: a
     /// plain, recursively-copyable value — every leaf `BitCopy` AND the whole
     /// transitively free of `#[opaque]` runtime handles.
@@ -8253,7 +8285,22 @@ impl Builder {
         if fields.is_empty() {
             return Ok(None);
         }
-        let field_tys: Vec<ResolvedTy> = fields.iter().map(|(_, ty)| ty.clone()).collect();
+        // Normalize machine-typed fields before classification: a generic
+        // machine instantiation in a record field (e.g. `m: Lifecycle<i64>`)
+        // arrives as `Named { name: "Lifecycle", args: [I64] }`.  The machine
+        // view is registered under the bare name "Lifecycle" (never mangled),
+        // so `lookup_enum_layout` misses the mangled probe and falls through to
+        // `classify_user_record`, which finds no RecordLayout for a machine →
+        // MissingRecordLayout → UnsupportedUserRecordValueClass.  Strip the
+        // args when the named type is a known machine (all-i64 args, same
+        // condition as the actor-state normalize pass at lower.rs ~1513) so the
+        // bare-name machine view is found.  Any other instantiation keeps its
+        // args and fails closed — matching the Move-type refusal such programs
+        // already hit at codegen.
+        let field_tys: Vec<ResolvedTy> = fields
+            .iter()
+            .map(|(_, ty)| self.normalize_machine_field_ty(ty))
+            .collect();
         let record_layouts = self.record_layouts_for_classification();
         let kinds = crate::state_clone::classify_actor_state_fields_with_opaque_handles(
             &field_tys,

--- a/hew-mir/src/state_clone.rs
+++ b/hew-mir/src/state_clone.rs
@@ -1264,9 +1264,12 @@ fn lookup_enum_layout<'a>(
             .collect();
         let full_mangled = hew_hir::mangle(name, &short_args);
         let short_mangled = hew_hir::mangle(short, &short_args);
+        // Also probe the bare name: a machine registered under "Lifecycle"
+        // (never mangled) is found when the use-site carries type args
+        // (e.g. `Lifecycle<i64>`), mirroring model::find_enum_layout.
         enum_layouts
             .iter()
-            .find(|el| el.name == full_mangled || el.name == short_mangled)
+            .find(|el| el.name == full_mangled || el.name == short_mangled || el.name == name)
     }
 }
 

--- a/hew-mir/tests/state_clone_classification.rs
+++ b/hew-mir/tests/state_clone_classification.rs
@@ -902,6 +902,44 @@ fn string_payload_machine_record_field_admits() {
     );
 }
 
+/// A GENERIC machine field (`m: Lifecycle<i64>`) in a user record classifies
+/// clean: the machine view is registered under the bare name "Lifecycle", so
+/// the field type must be normalised (args stripped) before the lookup.
+/// Regression guard for the "record type Box has a value class MIR cannot
+/// lower yet" / "could not resolve `RecordLayout` for nested user record
+/// Lifecycle" failure path.
+#[test]
+fn generic_machine_record_field_admits() {
+    let pipeline = lower_source(
+        "
+        machine Lifecycle<T> {
+            events { ev; }
+            state Start;
+            state Mid;
+            on ev: Start => Mid { Mid }
+            on ev: _ => _ { state }
+        }
+
+        type Box { m: Lifecycle<i64>, x: i64 }
+
+        fn main() {
+            let b = Box { m: Lifecycle::Start, x: 0 };
+            println(b.x);
+        }
+    ",
+    );
+    assert!(
+        !has_unsupported_record_value_class(&pipeline, "Box"),
+        "generic machine record field must not be rejected with UnsupportedUserRecordValueClass; got: {:#?}",
+        pipeline.diagnostics
+    );
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "generic machine record field must lower clean; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
 // ─── LocalPid<T> phantom-arg fix (chat_server regression) ───────────────────
 //
 // `LocalPid<T>`, `ActorRef<T>`, and `Actor<T>` are bit-copy actor handles; T

--- a/tests/vertical-slice/accept/machine_generic_record_field.hew
+++ b/tests/vertical-slice/accept/machine_generic_record_field.hew
@@ -1,0 +1,29 @@
+// Accept fixture: a generic machine used as a record field (`m: Lifecycle<i64>`)
+// must compile end to end without "record type Box has a value class MIR
+// cannot lower yet" / "could not resolve RecordLayout for nested user record
+// Lifecycle".
+//
+// The type parameter T is i64 at the use site; the machine layout is
+// registered under the bare name "Lifecycle" and the field type must be
+// normalised to the bare name before classification probes the enum-layout
+// table.  Previously the record was rejected at the MIR value-class gate;
+// this fixture guards the fix.
+//
+// Harness verb: compile_accept (compile only — main allocates the record but
+// does not run the machine through transitions; the MIR admit path is the
+// load-bearing assertion)
+
+machine Lifecycle<T> {
+    events { ev; }
+    state Start;
+    state Mid;
+    on ev: Start => Mid { Mid }
+    on ev: _ => _ { state }
+}
+
+type Box { m: Lifecycle<i64>, x: i64 }
+
+fn main() {
+    let b = Box { m: Lifecycle::Start, x: 0 };
+    println(b.x);
+}

--- a/tests/vertical-slice/accept/record_generic_enum_field.hew
+++ b/tests/vertical-slice/accept/record_generic_enum_field.hew
@@ -1,0 +1,19 @@
+// Regression guard: a plain (non-wire) record whose field type is a generic
+// enum with an i64 argument (Option<i64>) must compile and run.
+//
+// The MIR record-field classifier normalises machine-typed fields before the
+// enum-layout probe, but must NOT strip args from generic enum types like
+// Option<i64>.  Stripping the args produces a bare-name "Option" probe that
+// misses the mangled "Option$$i64" layout and fails with MissingRecordLayout.
+// This fixture catches any regression where that guard is widened to include
+// generic enum origin names.
+type Holder { val: Option<i64> }
+
+fn main() -> i64 {
+    let a = Holder { val: Some(7) };
+    let _b = Holder { val: None };
+    match a.val {
+        Some(v) => v,
+        None => -1,
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -307,6 +307,13 @@ compile_accept "machine_fork_args_spawn"
 # type is normalised before the enum-layout probe so the bare-name view is found.
 run_accept_expect_status "machine_generic_record_field" 0
 
+# Regression guard: a plain record with an Option<i64> field must compile and
+# run.  The MIR field classifier must NOT strip args from generic enum types
+# (Option, Result) even though their origin names appear in machine_layout_names.
+# Stripping "Option<i64>" to bare "Option" causes MissingRecordLayout; this
+# fixture catches any widening of the machine-field normalisation guard.
+run_accept_expect_status "record_generic_enum_field" 7
+
 # Stage-2 lazy iterator wrappers: structural smoke. The fixture's wrapper
 # records and `impl Iterator` blocks compile cleanly through the parser and
 # the type checker. The generic adapter bodies only lower through MIR once

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -301,6 +301,12 @@ grep -q 'Blocking channel receive operations are not supported on WASM32' "${rej
 # Item::Machine task-gate walker directly.
 compile_accept "machine_fork_args_spawn"
 
+# A generic machine used as a record field (`m: Lifecycle<i64>`) must compile
+# and run without "record type Box has a value class MIR cannot lower yet".
+# The machine layout is registered under the bare name "Lifecycle"; the field
+# type is normalised before the enum-layout probe so the bare-name view is found.
+run_accept_expect_status "machine_generic_record_field" 0
+
 # Stage-2 lazy iterator wrappers: structural smoke. The fixture's wrapper
 # records and `impl Iterator` blocks compile cleanly through the parser and
 # the type checker. The generic adapter bodies only lower through MIR once


### PR DESCRIPTION
## Summary

A record type with a generic machine field (e.g. `type Box { m: Lifecycle<i64> }`) previously failed to compile with "could not resolve RecordLayout for nested user record Lifecycle". The MIR record-field classifier collected the field type verbatim (`Lifecycle<i64>`) and looked up the mangled key, but a machine's enum-view is registered under its bare name — so the lookup missed and the record was rejected with `UnsupportedUserRecordValueClass`.

Two coordinated fixes: the field-type normalizer in `hew-mir/src/lower.rs` now strips all-`i64` args from generic machine fields before classification (mirroring the existing actor-state path at ~1513), and `state_clone::lookup_enum_layout` gains a bare-name fallback consistent with the established `model::find_enum_layout` precedent. Generic machine fields in records now compile and run correctly.

## Verification

- `cargo nextest run -p hew-mir`: 799/799 passed, 0 skipped
- `generic_machine_record_field_admits` (new admit test): passes; reverted both fixes → test fails with the exact target diagnostic (revert-verified)
- Monomorphic regression tests (`payload_free_machine_record_field_admits`, `i64_payload_machine_record_field_admits`, `string_payload_machine_record_field_admits`): all pass
- Fix A alone and Fix B alone each independently sufficient (confirmed via revert)
- Compiled and ran the repro program: exit 0
- Linux gate (workspace nextest 10520/10520, verify-ffi, checked-mir, ratchet, vertical-slice): all green; ASAN shows pre-existing 8-byte leak only, no new leak
- Preflight: ready-to-push

## Out of scope

- A unit test exercising the `lookup_enum_layout` bare-name fallback (Fix B) in isolation — non-blocking, tracked as a follow-up.

Fixes #1959