### PR TITLE
fix(hir): emit private enum HirTypeDecls into imported module items

### DIFF
--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -2866,6 +2866,35 @@ fn cross_module_generic_fn_value_context_determined_accepted() {
     );
 }
 
+/// A private (non-pub) enum returned from a pub fn across a module boundary
+/// must compile and run correctly.  Previously the §4b pre-pass cached the
+/// `HirTypeDecl` for all enums, but the fourth-pass emission guard was missing
+/// the enum arm, so the private enum's layout never reached MIR and produced
+/// `E_MIR: unknown type`.  Regression fixture for #2195.
+#[test]
+fn cross_module_private_enum_returned_from_pub_fn() {
+    require_codegen();
+
+    let source = repo_root().join("tests/vertical-slice/accept/cross_module_private_enum/main.hew");
+    let output = run_bounded_hew_run(&source, repo_root());
+
+    assert!(
+        output.status.success(),
+        "cross_module_private_enum should succeed; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let actual = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    let expected = std::fs::read_to_string(
+        repo_root().join("tests/vertical-slice/accept/cross_module_private_enum/main.expected"),
+    )
+    .expect("read main.expected");
+    assert_eq!(
+        actual, expected,
+        "expected 'not found' from cross_module_private_enum; got: {actual:?}"
+    );
+}
+
 /// A Vec element type containing a function value fails closed at the
 /// checker (the layout/owned byte-copy would alias the sole-owner env).
 #[test]

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -3137,6 +3137,7 @@ pub fn lower_program_with_mono_cap(
                         }
                         Item::TypeDecl(decl)
                             if decl.visibility.is_pub()
+                                || decl.kind == TypeDeclKind::Enum
                                 || (decl.kind == TypeDeclKind::Struct
                                     && decl.type_params.is_none()) =>
                         {

--- a/tests/vertical-slice/accept/cross_module_private_enum/errors.hew
+++ b/tests/vertical-slice/accept/cross_module_private_enum/errors.hew
@@ -1,0 +1,13 @@
+// Private (non-pub) enum returned from a pub fn across a module boundary.
+// Regression fixture for the §4b / fourth-pass emission asymmetry: the
+// pre-pass cached the HirTypeDecl for any enum, but the emission guard
+// previously only emitted pub types and non-generic structs, so a private
+// enum's layout was invisible to MIR and produced "E_MIR: unknown type".
+enum AppErr {
+    NotFound;
+    Forbidden;
+}
+
+pub fn make_error() -> AppErr {
+    AppErr::NotFound
+}

--- a/tests/vertical-slice/accept/cross_module_private_enum/main.expected
+++ b/tests/vertical-slice/accept/cross_module_private_enum/main.expected
@@ -1,0 +1,1 @@
+not found

--- a/tests/vertical-slice/accept/cross_module_private_enum/main.hew
+++ b/tests/vertical-slice/accept/cross_module_private_enum/main.hew
@@ -1,0 +1,12 @@
+// Verifies that a private enum returned from a cross-module pub fn compiles
+// and runs correctly.  The consumer matches against the enum's variants
+// without needing a pub qualifier on the enum itself.
+import errors;
+
+fn main() {
+    let e = errors.make_error();
+    match e {
+        AppErr::NotFound => println("not found"),
+        AppErr::Forbidden => println("forbidden"),
+    }
+}


### PR DESCRIPTION
## Summary

A private (non-`pub`) enum returned from a `pub fn` across a module boundary failed to compile with `E_MIR: unknown type`. The HIR fourth-pass type-decl emitter was missing the enum arm that its own §4b pre-pass already had, so a private enum's cached declaration was never emitted into the importing module's items — MIR couldn't resolve its layout. The one-line guard restores symmetry between the two passes: private non-root enums are now emitted, so MIR sees the type and resolves its value class correctly.

A cross-module-private-enum vertical-slice fixture and an e2e regression test are added to hold this invariant.

## Verification

- `hew-hir` suite: 490/490 passed
- `hew-cli` e2e: cross-module private-enum program compiles and runs correctly
- Linux gate (full workspace nextest): 10520/10520 passed
- `verify-ffi`, `checked-mir`, ratchet, vertical-slice: all passed
- Repo-wide corpus sweep (`hew-check-all`): passed
- ASan: no new leaks; pre-existing 8-byte leak unaffected
- Cross-ecosystem review: confirmed over-emit-safe (MIR skips generic decls; collision-aware layout keys) and regression-free
- Preflight: ready-to-push

## Out of scope

No other HIR emission asymmetries were addressed in this change; any additional pass-alignment work is tracked separately.

Fixes #2195