### PR TITLE
refactor(stdlib): canonicalize builtin method names, drop aliases

### DIFF
--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -499,7 +499,7 @@ fn main() {
 
 `v.set(i, value)` overwrites the element at index `i` in place. It complements `v[i]` (read) — reading uses the subscript, writing uses `.set()`. Out-of-bounds traps at runtime; guard with `i < v.len()`.
 
-### .contains(), .clear(), .extend()
+### .contains(), .clear(), .append()
 
 ```hew
 fn main() {
@@ -510,7 +510,7 @@ fn main() {
 
     let v2: Vec<i64> = Vec::new();
     v2.push(4); v2.push(5);
-    v.extend(v2);             // v is now [1, 2, 3, 4, 5]
+    v.append(v2);             // v is now [1, 2, 3, 4, 5]
     println(v.len());         // 5
 
     v.clear();                // removes all elements
@@ -518,7 +518,7 @@ fn main() {
 }
 ```
 
-`.contains(x)` returns `bool` — works for scalars, strings, and records. `.extend(v2)` appends every element of `v2` to `v` in order. `.clear()` empties the Vec without freeing it (you can push again afterward).
+`.contains(x)` returns `bool` — works for scalars, strings, and records. `.append(v2)` appends every element of `v2` to `v` in order. `.clear()` empties the Vec without freeing it (you can push again afterward).
 
 ### Vec<Vec<T>> — nested Vecs
 
@@ -1888,7 +1888,7 @@ For a fallible operation with no meaningful success value, return `Result<i64, E
 fn main() {
     let name = "world";
     let n = 42;
-    println(f"n={n} expr={n + 1} up={name.to_uppercase()}");
+    println(f"n={n} expr={n + 1} up={name.to_upper()}");
 }
 ```
 
@@ -2330,7 +2330,7 @@ fn main() {
 import std::encoding::json;
 
 fn main() {
-    let s = json.from_string("hello");
+    let s = json.string_value("hello");
     println(s.type_of());   // 4
     s.free();
 }

--- a/examples/grep/grep.hew
+++ b/examples/grep/grep.hew
@@ -126,7 +126,7 @@ fn grep_content(content: string, pat: regex.Pattern, cfg: Config, label: string,
         // For -i, fold the line to lowercase before matching.
         // The pattern was already folded when the Pattern was compiled.
         let test_line = if cfg.flag_i {
-            raw_line.to_lowercase()
+            raw_line.to_lower()
         } else {
             raw_line
         };
@@ -242,7 +242,7 @@ fn main() -> i64 {
         Ok(cfg) => {
             // For -i, fold the pattern to lowercase so it matches lowercased input.
             let compiled_pattern = if cfg.flag_i {
-                cfg.pattern.to_lowercase()
+                cfg.pattern.to_lower()
             } else {
                 cfg.pattern
             };

--- a/examples/string_methods_smoke.expected
+++ b/examples/string_methods_smoke.expected
@@ -1,7 +1,6 @@
 el
 xbx
 2
-2
 3
 2
 hahaha

--- a/examples/string_methods_smoke.hew
+++ b/examples/string_methods_smoke.hew
@@ -3,7 +3,6 @@ fn main() {
     println(s.slice(1, 3));
     println("aba".replace("a", "x"));
     println("banana".find("na"));
-    println("banana".index_of("na"));
     let parts = "a,b,c".split(",");
     println(parts.len());
     let ls = "x\ny".lines();

--- a/examples/v05/vec_run_pass.hew
+++ b/examples/v05/vec_run_pass.hew
@@ -23,8 +23,6 @@ fn main() -> i64 {
     let _copy = nums.clone();
     let more: Vec<i64> = Vec::new();
     nums.append(more);
-    let extra: Vec<i64> = Vec::new();
-    nums.extend(extra);
     nums.clear();
     let words: Vec<string> = Vec::new();
     words.push("a");

--- a/hew-analysis/src/rename.rs
+++ b/hew-analysis/src/rename.rs
@@ -491,7 +491,6 @@ mod tests {
             "string_slice",
             "string_trim",
             "string_to_int",
-            "string_find",
             "string_replace",
             "string_to_upper",
             "string_to_lower",

--- a/hew-cli/tests/ask_reply_owned_leak_oracle.rs
+++ b/hew-cli/tests/ask_reply_owned_leak_oracle.rs
@@ -89,7 +89,7 @@ fn cancelled_owned_reply_source(iters: usize) -> String {
         "actor SlowReplier {{\n\
          \x20   receive fn fetch() -> string {{\n\
          \x20       sleep(5ms);\n\
-         \x20       \"owned-reply-heap-payload\".to_uppercase()\n\
+         \x20       \"owned-reply-heap-payload\".to_upper()\n\
          \x20   }}\n\
          }}\n\
          fn main() -> i64 {{\n\
@@ -117,7 +117,7 @@ fn never_consumed_owned_reply_source(iters: usize) -> String {
     format!(
         "actor Replier {{\n\
          \x20   let tag: string;\n\
-         \x20   receive fn fetch() -> string {{ tag.to_uppercase() }}\n\
+         \x20   receive fn fetch() -> string {{ tag.to_upper() }}\n\
          }}\n\
          fn main() -> i64 {{\n\
          \x20   var i: i64 = 0;\n\

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -2791,7 +2791,7 @@ fn match_wrong_variant_against_result_scrutinee_is_compile_time_type_error() {
     );
 }
 
-/// Positive probe: a `.len()` / `.starts_with(...)` / `.to_uppercase()` chain
+/// Positive probe: a `.len()` / `.starts_with(...)` / `.to_upper()` chain
 /// on a string runs end-to-end via the `impl string` block in
 /// std/builtins.hew rather than the legacy per-symbol FFI dispatch table
 /// in `check_string_method`.  Asserts byte-level stdout so codegen actually
@@ -2810,7 +2810,7 @@ fn run_string_methods_dispatch_through_impl_block() {
          \x20   if s.starts_with(\"hello\") {\n\
          \x20       println(\"matched\");\n\
          \x20   }\n\
-         \x20   let upper = s.to_uppercase();\n\
+         \x20   let upper = s.to_upper();\n\
          \x20   println(upper);\n\
          }\n",
     )

--- a/hew-cli/tests/nested_payload_leak_oracle.rs
+++ b/hew-cli/tests/nested_payload_leak_oracle.rs
@@ -88,13 +88,13 @@ fn nested_match_source(iters: usize) -> String {
         "enum ParseError {{ Invalid(string); }}\n\
          enum Tri {{ A(string); B(string); C(string); }}\n\
          fn make(n: i64) -> Result<i64, ParseError> {{\n\
-         \x20   if n == 0 {{ Ok(1) }} else {{ Err(ParseError::Invalid(\"bad-input\".to_uppercase())) }}\n\
+         \x20   if n == 0 {{ Ok(1) }} else {{ Err(ParseError::Invalid(\"bad-input\".to_upper())) }}\n\
          }}\n\
          fn pick(n: i64) -> Result<i64, Tri> {{\n\
          \x20   match n % 3 {{\n\
-         \x20       0 => Err(Tri::A(\"alpha\".to_uppercase())),\n\
-         \x20       1 => Err(Tri::B(\"beta\".to_uppercase())),\n\
-         \x20       _ => Err(Tri::C(\"gamma\".to_uppercase())),\n\
+         \x20       0 => Err(Tri::A(\"alpha\".to_upper())),\n\
+         \x20       1 => Err(Tri::B(\"beta\".to_upper())),\n\
+         \x20       _ => Err(Tri::C(\"gamma\".to_upper())),\n\
          \x20   }}\n\
          }}\n\
          fn wild(n: i64) -> i64 {{\n\

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -1341,7 +1341,7 @@ fn run_fn_local_string_is_dropped_bounded_memory() {
 }
 
 /// W5.011 P3 owned-`string` temporary substrate double-free guard: a fresh-owned
-/// `string` produced by `+`/concat, `.to_uppercase()`, or the `Vec<string>`
+/// `string` produced by `+`/concat, `.to_upper()`, or the `Vec<string>`
 /// getter and then used in a borrowing context (`.len()`) — whether bound
 /// (`let y = <producer>; y.len()`), nested (`(<producer>).len()`), or discarded
 /// (`<producer>;`) — must be released exactly once. A regressed substrate that

--- a/hew-cli/tests/state_overwrite_leak_oracle.rs
+++ b/hew-cli/tests/state_overwrite_leak_oracle.rs
@@ -116,7 +116,7 @@ fn collection_overwrite_source(frames: usize) -> String {
 /// missed release leaks one node per frame; an over-eager release of the
 /// aliased `label` is a use-after-free the poisoned-allocator triple
 /// crashes on. The durable `label` is built on the HEAP at spawn
-/// (`.to_uppercase()`) so `hew_string_drop` would actually free it — a
+/// (`.to_upper()`) so `hew_string_drop` would actually free it — a
 /// static literal would make the alias guard vacuous.
 fn record_functional_update_source(frames: usize) -> String {
     format!(
@@ -138,7 +138,7 @@ fn record_functional_update_source(frames: usize) -> String {
          \x20       cur = Outer {{\n\
          \x20           label: cur.label,\n\
          \x20           payload: \"outer-payload\".to_bytes(),\n\
-         \x20           inner: Inner {{ note: \"inner-note\".to_uppercase() }},\n\
+         \x20           inner: Inner {{ note: \"inner-note\".to_upper() }},\n\
          \x20           count: cur.count + 1,\n\
          \x20       }};\n\
          \x20   }}\n\
@@ -150,7 +150,7 @@ fn record_functional_update_source(frames: usize) -> String {
          \n\
          fn main() -> i64 {{\n\
          \x20   let k = spawn Keeper(cur: Outer {{\n\
-         \x20       label: \"durable-label\".to_uppercase(),\n\
+         \x20       label: \"durable-label\".to_upper(),\n\
          \x20       payload: bytes::new(),\n\
          \x20       inner: Inner {{ note: \"first\" }},\n\
          \x20       count: 0,\n\
@@ -186,8 +186,8 @@ fn enum_overwrite_source(frames: usize) -> String {
          \x20   receive fn advance(n: i64) {{\n\
          \x20       status = match n % 3 {{\n\
          \x20           0 => Status::Idle,\n\
-         \x20           1 => Status::Working(\"busy\".to_uppercase()),\n\
-         \x20           _ => Status::Done(\"finished\".to_uppercase(), n),\n\
+         \x20           1 => Status::Working(\"busy\".to_upper()),\n\
+         \x20           _ => Status::Done(\"finished\".to_upper(), n),\n\
          \x20       }};\n\
          \x20   }}\n\
          \n\
@@ -218,10 +218,10 @@ fn enum_overwrite_source(frames: usize) -> String {
 
 /// Whole-value self-store: `prof = prof` byte-copies every leaf, so the
 /// release must neutralise them ALL (drop nothing). The aliased `name`
-/// leaf is HEAP-allocated at spawn (`.to_uppercase()`) so an over-eager
+/// leaf is HEAP-allocated at spawn (`.to_upper()`) so an over-eager
 /// release would actually free it; the trailing read then crashes under
 /// the poisoned triple (a static literal would never be freed, making
-/// the pin vacuous). `"self-store-name".to_uppercase()` stays length 15.
+/// the pin vacuous). `"self-store-name".to_upper()` stays length 15.
 const RECORD_SELF_STORE_SOURCE: &str = "\
 record Profile {
     name: string,
@@ -241,7 +241,7 @@ actor Keeper {
 }
 
 fn main() -> i64 {
-    let k = spawn Keeper(prof: Profile { name: \"self-store-name\".to_uppercase(), hits: 1 });
+    let k = spawn Keeper(prof: Profile { name: \"self-store-name\".to_upper(), hits: 1 });
     var i: i64 = 0;
     while i < 25 {
         k.refresh();
@@ -258,7 +258,7 @@ fn main() -> i64 {
 /// Cross-position swap: the new value reuses BOTH old leaves at swapped
 /// positions. A per-position-only guard would free `a` while the new `b`
 /// still points at it; the full-set neutralise keeps both alive. Both
-/// leaves are HEAP-allocated at spawn (`.to_uppercase()`) so a wrongful
+/// leaves are HEAP-allocated at spawn (`.to_upper()`) so a wrongful
 /// release actually frees them. After an odd number of swaps `a` holds
 /// the original `b` string (`"RIGHT-SIDE"`, length 10).
 const RECORD_SWAP_SOURCE: &str = "\
@@ -280,7 +280,7 @@ actor Swapper {
 }
 
 fn main() -> i64 {
-    let s = spawn Swapper(pair: Pair { a: \"left\".to_uppercase(), b: \"right-side\".to_uppercase() });
+    let s = spawn Swapper(pair: Pair { a: \"left\".to_upper(), b: \"right-side\".to_upper() });
     var i: i64 = 0;
     while i < 25 {
         s.swap();

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -3245,8 +3245,8 @@ fn declare_print_runtime<'ctx>(
 ///
 /// WHY: the stdlib catalog records the **Hew-facing** type of each shim (e.g.
 /// `string.find -> i64`), but several runtime functions actually return `i32`
-/// (`hew_string_find`, `hew_string_index_of_start`, `hew_string_length`,
-/// `hew_string_char_at`). Declaring the LLVM extern with the Hew-facing width
+/// (`hew_string_find`, `hew_string_length`, `hew_string_char_at`). Declaring
+/// the LLVM extern with the Hew-facing width
 /// (i64) does not match the C ABI: a `-> i32` C function leaves the upper 32
 /// bits of the return register undefined, so reading a 64-bit result yields
 /// garbage (the `-1` not-found sentinel surfaces as `4294967295`). The LLVM
@@ -3264,7 +3264,7 @@ fn declare_print_runtime<'ctx>(
 fn runtime_ffi_return_abi_bits(symbol: &str) -> Option<u32> {
     match symbol {
         // `*const c_char -> i32`: -1 not-found sentinel must sign-extend to i64.
-        "hew_string_find" | "hew_string_index_of_start" => Some(32),
+        "hew_string_find" => Some(32),
         // `*const c_char -> i32` length / char code: non-negative in practice,
         // but the i64-declared call still reads undefined high bits. Declaring
         // the true i32 and sign-extending is the ABI-correct path.
@@ -28746,8 +28746,8 @@ fn lower_terminator<'ctx>(
                         let stored = if dest_ty == return_ty {
                             // Reconcile the runtime C-ABI return width against the
                             // Hew dest width. A runtime function declared `-> i32`
-                            // (e.g. `hew_string_find` / `hew_string_index_of_start`,
-                            // returning the `-1` not-found sentinel) must
+                            // (e.g. `hew_string_find`, returning the `-1`
+                            // not-found sentinel) must
                             // sign-extend its result up to the Hew-facing i64 dest,
                             // so `-1` stays `-1` rather than `4294967295`. Equal
                             // widths and matching types pass through; genuinely
@@ -33388,8 +33388,8 @@ fn scalar_di_basic(ty: &ResolvedTy, target_data: &TargetData) -> Option<(&'stati
         ResolvedTy::Char => ("char", 32, DW_ATE_UNSIGNED_CHAR),
         ResolvedTy::F32 => ("f32", 32, DW_ATE_FLOAT),
         ResolvedTy::F64 => ("f64", 64, DW_ATE_FLOAT),
-        // Duration is i64 nanoseconds at the ABI.
-        ResolvedTy::Duration => ("Duration", 64, DW_ATE_SIGNED),
+        // duration is i64 nanoseconds at the ABI.
+        ResolvedTy::Duration => ("duration", 64, DW_ATE_SIGNED),
         _ => return None,
     })
 }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -8326,7 +8326,31 @@ impl LowerCtx {
         // callable `<SelfType>::<method>` functions. Older declarative receiver
         // FFI blocks with all-`#[extern_symbol]` methods are also metadata-only.
         // Skip these blocks as already-consumed metadata.
-        if decl.trait_bound.is_none() && hew_types::lookup_builtin_type(self_type_name).is_some() {
+        //
+        // The `duration` constructor block (`from_nanos`/`from_micros`/
+        // `from_millis`/`from_secs`, each taking a non-receiver `i64`) is the
+        // exception that must fall through to normal lowering: its arithmetic
+        // bodies (`n * 1<unit>`) run, so it is registered as real `duration::from_*`
+        // HIR fns via the user-impl spine (see `is_builtin_duration_ctor_impl`).
+        // It carries no `#[extern_symbol]`, so without this bypass the guard
+        // below would reject `duration` as a builtin nominal once its canonical
+        // name became a recognised builtin lookup key.
+        let duration_ctors = ["from_nanos", "from_micros", "from_millis", "from_secs"];
+        let is_duration_ctor_block = self_type_name == "duration"
+            && decl.methods.len() == duration_ctors.len()
+            && decl.methods.iter().all(|m| {
+                duration_ctors.contains(&m.name.as_str())
+                    && m.params.first().is_none_or(|param| {
+                        !matches!(
+                            &param.ty.0,
+                            TypeExpr::Named { name, .. } if name == "Self" || name == "duration"
+                        )
+                    })
+            });
+        if !is_duration_ctor_block
+            && decl.trait_bound.is_none()
+            && hew_types::lookup_builtin_type(self_type_name).is_some()
+        {
             let declared_resource_close_impl = self
                 .type_classes
                 .get(self_type_name)

--- a/hew-hir/src/stdlib_catalog.rs
+++ b/hew-hir/src/stdlib_catalog.rs
@@ -858,8 +858,8 @@ pub const CATALOG: &[BuiltinEntry] = &[
         },
     ),
     overload(
-        "to_lowercase_str",
-        "to_lowercase",
+        "to_lower_str",
+        "to_lower",
         STRING,
         BuiltinTy::String,
         BuiltinLinkage::RuntimeFfiShim {
@@ -867,8 +867,8 @@ pub const CATALOG: &[BuiltinEntry] = &[
         },
     ),
     overload(
-        "to_uppercase_str",
-        "to_uppercase",
+        "to_upper_str",
+        "to_upper",
         STRING,
         BuiltinTy::String,
         BuiltinLinkage::RuntimeFfiShim {
@@ -927,15 +927,6 @@ pub const CATALOG: &[BuiltinEntry] = &[
         BuiltinTy::I64,
         BuiltinLinkage::RuntimeFfiShim {
             symbol: "hew_string_find",
-        },
-    ),
-    overload(
-        "index_of_str",
-        "index_of",
-        STRING_STRING,
-        BuiltinTy::I64,
-        BuiltinLinkage::RuntimeFfiShim {
-            symbol: "hew_string_index_of_start",
         },
     ),
     overload(

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -6848,7 +6848,6 @@ machine Traffic {
             "slice",
             "replace",
             "find",
-            "index_of",
             "split",
             "lines",
             "repeat",

--- a/hew-lsp/tests/fixtures/v05_string_methods.hew
+++ b/hew-lsp/tests/fixtures/v05_string_methods.hew
@@ -2,7 +2,6 @@ fn string_methods_probe(text: string) -> i64 {
     let sliced: string = text.slice(0, 1);
     let replaced: string = text.replace("a", "b");
     let found: i64 = text.find("a");
-    let indexed: i64 = text.index_of("a");
     let parts: Vec<string> = text.split(",");
     let line_parts: Vec<string> = text.lines();
     let repeated: string = text.repeat(2);
@@ -12,7 +11,7 @@ fn string_methods_probe(text: string) -> i64 {
     let alpha: bool = text.is_alpha();
     let alnum: bool = text.is_alphanumeric();
     let cloned: string = text.clone();
-    found + indexed + ch
+    found + ch
 }
 
 fn string_methods_use() -> i64 {

--- a/hew-mir/src/runtime_symbols.rs
+++ b/hew-mir/src/runtime_symbols.rs
@@ -737,7 +737,6 @@ pub fn is_borrowing_string_use(symbol: &str) -> bool {
             | "hew_string_is_alpha"
             | "hew_string_is_alphanumeric"
             | "hew_string_find"
-            | "hew_string_index_of_start"
             | "hew_string_to_bytes"
             | "hew_string_split"
             | "hew_string_lines"

--- a/hew-mir/tests/owned_string_temp_drop_canary.rs
+++ b/hew-mir/tests/owned_string_temp_drop_canary.rs
@@ -205,14 +205,14 @@ fn canary2_nested_vec_get_in_loop_balances() {
 }
 
 // ---------------------------------------------------------------------------
-// Canary 3 — BOUND string producers: `let y = s.to_uppercase(); y.len()` and
+// Canary 3 — BOUND string producers: `let y = s.to_upper(); y.len()` and
 // `let y = a + b; y.len()` each release exactly once.
 // ---------------------------------------------------------------------------
 
 #[test]
 fn canary3_bound_string_producers_release_once() {
     let pl = pipeline_with_tc(
-        "fn upper(s: string) -> i64 {\n    let y = s.to_uppercase();\n    y.len() as i64\n}\nfn concat(a: string, b: string) -> i64 {\n    let y = a + b;\n    y.len() as i64\n}\n",
+        "fn upper(s: string) -> i64 {\n    let y = s.to_upper();\n    y.len() as i64\n}\nfn concat(a: string, b: string) -> i64 {\n    let y = a + b;\n    y.len() as i64\n}\n",
     );
     assert_no_nyi(&pl);
     assert_eq!(
@@ -234,13 +234,13 @@ fn canary3_bound_string_producers_release_once() {
 
 // ---------------------------------------------------------------------------
 // Canary 3b — NESTED string producers: `(a + b).len()` and
-// `s.to_uppercase().len()` each release the bare temp once, inline.
+// `s.to_upper().len()` each release the bare temp once, inline.
 // ---------------------------------------------------------------------------
 
 #[test]
 fn canary3b_nested_string_producers_release_once() {
     let pl = pipeline_with_tc(
-        "fn nconcat(a: string, b: string) -> i64 {\n    (a + b).len() as i64\n}\nfn nupper(s: string) -> i64 {\n    s.to_uppercase().len() as i64\n}\n",
+        "fn nconcat(a: string, b: string) -> i64 {\n    (a + b).len() as i64\n}\nfn nupper(s: string) -> i64 {\n    s.to_upper().len() as i64\n}\n",
     );
     assert_no_nyi(&pl);
     assert_eq!(

--- a/hew-runtime/src/string.rs
+++ b/hew-runtime/src/string.rs
@@ -1014,57 +1014,6 @@ pub unsafe extern "C" fn hew_string_repeat(s: *const c_char, count: i32) -> *mut
     result.cast::<c_char>()
 }
 
-/// Find the first occurrence of `substr` in `s` starting at position `from`.
-/// Returns byte offset or -1 if not found.
-///
-/// # Safety
-///
-/// Both `s` and `substr` must be valid NUL-terminated C strings (or null).
-#[expect(
-    clippy::cast_possible_truncation,
-    clippy::cast_possible_wrap,
-    clippy::cast_sign_loss,
-    reason = "Matching C ABI: string offsets are i32 per Hew convention"
-)]
-#[no_mangle]
-pub unsafe extern "C" fn hew_string_index_of(
-    s: *const c_char,
-    substr: *const c_char,
-    from: i32,
-) -> i32 {
-    cabi_guard!(s.is_null() || substr.is_null(), -1);
-    // SAFETY: Both pointers are valid NUL-terminated C strings per caller contract.
-    let slen = unsafe { cstr_len(s) };
-    let start = if from < 0 { 0usize } else { from as usize };
-    if start >= slen {
-        // SAFETY: substr is a valid NUL-terminated C string per caller contract.
-        let sublen = unsafe { cstr_len(substr) };
-        if sublen == 0 && start == slen {
-            return start as i32;
-        }
-        return -1;
-    }
-    // SAFETY: start < slen, so s + start is within the string.
-    let p = unsafe { libc::strstr(s.add(start), substr) };
-    cabi_guard!(p.is_null(), -1);
-    // SAFETY: p points within s, so the offset is non-negative.
-    unsafe { p.offset_from(s) as i32 }
-}
-
-/// Method-call shim for `string.index_of(needle)`.
-///
-/// The language surface takes no explicit `from` argument; it always starts at
-/// the beginning of the string.
-///
-/// # Safety
-///
-/// Both `s` and `substr` must be valid NUL-terminated C strings (or null).
-#[no_mangle]
-pub unsafe extern "C" fn hew_string_index_of_start(s: *const c_char, substr: *const c_char) -> i32 {
-    // SAFETY: Delegates to `hew_string_index_of` with a fixed start offset.
-    unsafe { hew_string_index_of(s, substr, 0) }
-}
-
 // ── Static string detection ─────────────────────────────────────────────
 //
 // String literals live in the binary's read-only data segment. We must
@@ -2177,28 +2126,6 @@ mod tests {
         let result = unsafe { hew_string_repeat(s.as_ptr(), 0) };
         // SAFETY: result is a valid malloc'd C string.
         assert_eq!(unsafe { read_and_free(result) }, "");
-    }
-
-    #[test]
-    fn test_string_index_of() {
-        let s = CString::new("abcabc").unwrap();
-        let sub = CString::new("bc").unwrap();
-        assert_eq!(
-            // SAFETY: Both args are valid NUL-terminated C strings.
-            unsafe { hew_string_index_of(s.as_ptr(), sub.as_ptr(), 0) },
-            1
-        );
-    }
-
-    #[test]
-    fn test_string_index_of_start() {
-        let s = CString::new("banana").unwrap();
-        let sub = CString::new("na").unwrap();
-        assert_eq!(
-            // SAFETY: Both args are valid NUL-terminated C strings.
-            unsafe { hew_string_index_of_start(s.as_ptr(), sub.as_ptr()) },
-            2
-        );
     }
 
     #[test]

--- a/hew-runtime/tests/ffi_boundary.rs
+++ b/hew-runtime/tests/ffi_boundary.rs
@@ -38,11 +38,11 @@ use hew_runtime::string::{
     hew_bool_to_string, hew_float_to_string, hew_int_to_string, hew_string_byte_length,
     hew_string_char_at, hew_string_char_at_utf8, hew_string_char_count, hew_string_clone,
     hew_string_concat, hew_string_contains, hew_string_drop, hew_string_ends_with,
-    hew_string_equals, hew_string_find, hew_string_from_char, hew_string_index_of,
-    hew_string_is_ascii, hew_string_length, hew_string_repeat, hew_string_replace,
-    hew_string_reverse_utf8, hew_string_slice, hew_string_split, hew_string_starts_with,
-    hew_string_substring_utf8, hew_string_to_bytes, hew_string_to_int, hew_string_to_lowercase,
-    hew_string_to_uppercase, hew_string_trim,
+    hew_string_equals, hew_string_find, hew_string_from_char, hew_string_is_ascii,
+    hew_string_length, hew_string_repeat, hew_string_replace, hew_string_reverse_utf8,
+    hew_string_slice, hew_string_split, hew_string_starts_with, hew_string_substring_utf8,
+    hew_string_to_bytes, hew_string_to_int, hew_string_to_lowercase, hew_string_to_uppercase,
+    hew_string_trim,
 };
 use hew_runtime::vec::{
     hew_vec_clear, hew_vec_clone, hew_vec_contains_f64, hew_vec_contains_i32, hew_vec_contains_i64,
@@ -1856,53 +1856,6 @@ mod string_extended {
             let r = hew_string_repeat(s.as_ptr(), 1);
             assert_eq!(read_cstr(r), "hello");
             free_hew_string(r);
-        }
-    }
-
-    #[test]
-    fn index_of_basic() {
-        unsafe {
-            let s = cstr("hello world");
-            let sub = cstr("world");
-            assert_eq!(hew_string_index_of(s.as_ptr(), sub.as_ptr(), 0), 6);
-        }
-    }
-
-    #[test]
-    fn index_of_from_position() {
-        unsafe {
-            let s = cstr("abcabc");
-            let sub = cstr("abc");
-            assert_eq!(hew_string_index_of(s.as_ptr(), sub.as_ptr(), 0), 0);
-            assert_eq!(hew_string_index_of(s.as_ptr(), sub.as_ptr(), 1), 3);
-        }
-    }
-
-    #[test]
-    fn index_of_not_found() {
-        unsafe {
-            let s = cstr("hello");
-            let sub = cstr("xyz");
-            assert_eq!(hew_string_index_of(s.as_ptr(), sub.as_ptr(), 0), -1);
-        }
-    }
-
-    #[test]
-    fn index_of_null_args() {
-        unsafe {
-            let s = cstr("hello");
-            assert_eq!(hew_string_index_of(ptr::null(), s.as_ptr(), 0), -1);
-            assert_eq!(hew_string_index_of(s.as_ptr(), ptr::null(), 0), -1);
-        }
-    }
-
-    #[test]
-    fn index_of_negative_from() {
-        unsafe {
-            let s = cstr("abc");
-            let sub = cstr("a");
-            // Negative from is clamped to 0.
-            assert_eq!(hew_string_index_of(s.as_ptr(), sub.as_ptr(), -5), 0);
         }
     }
 }

--- a/hew-types/src/builtin_type.rs
+++ b/hew-types/src/builtin_type.rs
@@ -194,7 +194,7 @@ builtin_types! {
     CloseError => "CloseError",
     Iterator => "Iterator",
     Unit => "Unit",
-    Duration => "Duration",
+    Duration => "duration",
     Instant => "instant",
     Trap => "Trap",
     CancellationToken => "CancellationToken",

--- a/hew-types/src/check/closure_inference.rs
+++ b/hew-types/src/check/closure_inference.rs
@@ -38,8 +38,8 @@ pub(super) struct LambdaBodyFacts {
 /// Narrow on purpose — only the runtime's documented mutating-in-place
 /// methods are listed. Extending this list is a deliberate decision.
 const MUTATING_METHODS: &[&str] = &[
-    "push", "pop", "insert", "remove", "clear", "extend", "append", "set", "swap", "sort",
-    "reverse", "truncate", "drain", "retain", "send",
+    "push", "pop", "insert", "remove", "clear", "append", "set", "swap", "sort", "reverse",
+    "truncate", "drain", "retain", "send",
 ];
 
 pub(super) fn scan_lambda_body(body: &Spanned<Expr>) -> LambdaBodyFacts {

--- a/hew-types/src/check/dispatch.rs
+++ b/hew-types/src/check/dispatch.rs
@@ -264,7 +264,6 @@ pub enum VecMethod {
     Clear,
     Clone,
     Append,
-    Extend,
     Join,
 }
 

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -4753,7 +4753,7 @@ impl Checker {
                     },
                     _,
                 )) => {
-                    const STORING_METHODS: &[&str] = &["push", "set", "insert", "extend", "append"];
+                    const STORING_METHODS: &[&str] = &["push", "set", "insert", "append"];
                     if STORING_METHODS.contains(&method.as_str()) {
                         if let Expr::Identifier(recv_name) = &receiver.0 {
                             for arg in args {

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -225,7 +225,7 @@ fn collection_method_desc(kind: CollectionKind, method: &str) -> Option<Collecti
             "clear" => desc(Some(0), &[], Unit),
             "clone" => desc(Some(0), &[], SelfTy),
             "set" => desc(None, &[I64, Elem], Unit),
-            "append" | "extend" => desc(None, &[Receiver], Unit),
+            "append" => desc(None, &[Receiver], Unit),
             _ => return None,
         },
     })
@@ -4189,10 +4189,7 @@ impl Checker {
             CollectionKind::Vec => {
                 // Element Rc-rejection on the mutating/element-consuming arms;
                 // fire-and-continue (does NOT short-circuit, matching history).
-                if matches!(
-                    method,
-                    "push" | "pop" | "get" | "remove" | "set" | "append" | "extend"
-                ) {
+                if matches!(method, "push" | "pop" | "get" | "remove" | "set" | "append") {
                     self.reject_rc_collection_element("Vec", &cx.elem, span);
                 }
                 // Every table-driven Vec arm records via the symbol-override
@@ -4532,7 +4529,7 @@ impl Checker {
         // releases — fail closed with a precise diagnostic rather than alias
         // owners (`boundary-fail-closed`, `ffi-ownership-contracts`).
         if matches!(elem_ty, Ty::Function { .. } | Ty::Closure { .. })
-            && matches!(method, "clone" | "append" | "extend")
+            && matches!(method, "clone" | "append")
         {
             self.report_error(
                 TypeErrorKind::InvalidOperation,
@@ -8680,7 +8677,6 @@ fn collection_dispatch_registry_impl() -> ImplRegistry {
             vec_method_target("clear", VecMethod::Clear, RuntimeAbi::ByRefMut),
             vec_method_target("clone", VecMethod::Clone, RuntimeAbi::ByRef),
             vec_method_target("append", VecMethod::Append, RuntimeAbi::ByRefMut),
-            vec_method_target("extend", VecMethod::Extend, RuntimeAbi::ByRefMut),
             vec_method_target("join", VecMethod::Join, RuntimeAbi::ByRef),
         ],
     });
@@ -9139,10 +9135,9 @@ mod tests {
                 "{kind:?}::is_empty skips arity"
             );
         }
-        // Vec `set`/`append`/`extend` also historically skipped arity.
+        // Vec `set`/`append` skip arity.
         assert_eq!(arity_of(CollectionKind::Vec, "set"), None);
         assert_eq!(arity_of(CollectionKind::Vec, "append"), None);
-        assert_eq!(arity_of(CollectionKind::Vec, "extend"), None);
     }
 
     #[test]

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -631,8 +631,6 @@ impl Checker {
         self.register_builtin_fn("len", vec![Ty::Var(TypeVar::fresh())], Ty::I64);
 
         // I/O and system
-        self.register_builtin_fn("read_file", vec![Ty::String], Ty::String);
-        self.register_builtin_fn("write_file", vec![Ty::String, Ty::String], Ty::Unit);
         self.register_builtin_fn("sleep", vec![Ty::Duration], Ty::Unit);
         self.register_builtin_fn(
             "sleep_until",
@@ -829,7 +827,6 @@ impl Checker {
         );
         self.register_builtin_fn("string_trim", vec![Ty::String], Ty::String);
         self.register_builtin_fn("string_to_int", vec![Ty::String], Ty::I64);
-        self.register_builtin_fn("string_find", vec![Ty::String, Ty::String], Ty::I64);
         self.register_builtin_fn(
             "string_replace",
             vec![Ty::String, Ty::String, Ty::String],

--- a/hew-types/src/declarative_vec_ffi.rs
+++ b/hew-types/src/declarative_vec_ffi.rs
@@ -67,7 +67,7 @@ pub fn vec_method_template(method: &str) -> Option<&'static str> {
         "is_empty" => Some("hew_vec_is_empty"),
         "clear" => Some("hew_vec_clear"),
         "clone" => Some("hew_vec_clone"),
-        "append" | "extend" => Some("hew_vec_append"),
+        "append" => Some("hew_vec_append"),
         // `Vec::remove(i64)` removes by index — runtime symbol is
         // monomorphic (`hew_vec_remove_at`); mirrors the legacy
         // `resolve_vec_method` "remove" arm.
@@ -202,7 +202,6 @@ mod tests {
             ("clear", "hew_vec_clear"),
             ("clone", "hew_vec_clone"),
             ("append", "hew_vec_append"),
-            ("extend", "hew_vec_append"),
             ("remove", "hew_vec_remove_at"),
             ("join", "hew_vec_join_str"),
         ] {

--- a/hew-types/src/stdlib.rs
+++ b/hew-types/src/stdlib.rs
@@ -366,7 +366,7 @@ pub fn resolve_vec_method<S: std::hash::BuildHasher>(
             Some("layout") => Some("hew_vec_clone_layout"),
             _ => Some("hew_vec_clone"),
         },
-        "append" | "extend" => match vec_element_runtime_suffix(elem_ty, type_defs) {
+        "append" => match vec_element_runtime_suffix(elem_ty, type_defs) {
             Some("layout") => Some("hew_vec_append_layout"),
             _ => Some("hew_vec_append"),
         },
@@ -572,7 +572,6 @@ mod tests {
             ("clear", "hew_vec_clear"),
             ("clone", "hew_vec_clone"),
             ("append", "hew_vec_append"),
-            ("extend", "hew_vec_append"),
             ("remove", "hew_vec_remove_at"),
         ] {
             assert_eq!(
@@ -854,10 +853,6 @@ mod tests {
             Some("hew_vec_append_layout")
         );
         assert_eq!(
-            resolve_vec_method("extend", &point, &record_defs),
-            Some("hew_vec_append_layout")
-        );
-        assert_eq!(
             resolve_vec_method("remove", &point, &record_defs),
             Some("hew_vec_remove_at_layout")
         );
@@ -891,10 +886,6 @@ mod tests {
         );
         assert_eq!(
             resolve_vec_method("append", &tup, &type_defs),
-            Some("hew_vec_append_layout")
-        );
-        assert_eq!(
-            resolve_vec_method("extend", &tup, &type_defs),
             Some("hew_vec_append_layout")
         );
 

--- a/hew-types/tests/declarative_string_bytes_ffi_differential.rs
+++ b/hew-types/tests/declarative_string_bytes_ffi_differential.rs
@@ -26,9 +26,7 @@ fn string_methods_resolve_through_std_string_extern_symbols() {
             let _: bool = s.contains("ell");
             let _: bool = s.starts_with("he");
             let _: bool = s.ends_with("lo");
-            let _: string = s.to_uppercase();
             let _: string = s.to_upper();
-            let _: string = s.to_lowercase();
             let _: string = s.to_lower();
             let _: string = s.trim();
             let _: bool = s.is_digit();
@@ -39,7 +37,6 @@ fn string_methods_resolve_through_std_string_extern_symbols() {
             let _: Vec<string> = s.split("l");
             let _: Vec<string> = s.lines();
             let _: i64 = s.find("e");
-            let _: i64 = s.index_of("e");
             let _: string = s.slice(0, 1);
             let _: string = s.repeat(2);
             let _: i64 = s.char_at(0);
@@ -71,7 +68,6 @@ fn string_methods_resolve_through_std_string_extern_symbols() {
         "hew_string_split",
         "hew_string_lines",
         "hew_string_find",
-        "hew_string_index_of_start",
         "hew_string_slice",
         "hew_string_repeat",
         "hew_string_char_at",
@@ -101,7 +97,6 @@ fn bytes_methods_resolve_through_std_io_extern_symbols() {
             let _: bool = buf.contains(66);
             let _: string = buf.to_string();
             buf.append(other);
-            buf.extend(other);
         }
     ";
     let output = typecheck(source);

--- a/hew-types/tests/declarative_vec_ffi_differential.rs
+++ b/hew-types/tests/declarative_vec_ffi_differential.rs
@@ -2,13 +2,13 @@
 //!
 //! Pins the **declarative** `#[extern_symbol]` resolution path against
 //! the **legacy** magic table (`hew_types::stdlib::resolve_vec_method`)
-//! across the full 91-cell matrix from plan §6 Stage 3 plus W3.003 bool/char
+//! across the full 84-cell matrix from plan §6 Stage 3 plus W3.003 bool/char
 //! scalar ABI additions:
 //!
 //! ```text
-//! 13 methods × 7 element types = 91 cells.
+//! 12 methods × 7 element types = 84 cells.
 //! Methods : push pop get set contains len is_empty clear clone
-//!           append extend remove join
+//!           append remove join
 //! Element : Vec<bool> Vec<char> Vec<i32> Vec<i64> Vec<f64>
 //!           Vec<string> Vec<Vec<i32>>
 //! ```
@@ -65,10 +65,10 @@ fn element_types() -> Vec<(&'static str, Ty)> {
     ]
 }
 
-/// The 13 method names in plan §6 Stage 3 matrix order.
+/// The Vec method names in plan §6 Stage 3 matrix order.
 const METHODS: &[&str] = &[
     "push", "pop", "get", "set", "contains", "len", "is_empty", "clear", "clone", "append",
-    "extend", "remove", "join",
+    "remove", "join",
 ];
 
 /// Stage-3 substrate: minimal `TypeDef` map seeded with the heap-handle
@@ -274,20 +274,20 @@ fn vec_ffi_differential_matrix_65_cells() {
     }
 
     assert_eq!(
-        cells_checked, 91,
-        "differential matrix must cover 13 × 7 = 91 cells exactly",
+        cells_checked, 84,
+        "differential matrix must cover 12 × 7 = 84 cells exactly",
     );
 
     assert!(
         failures.is_empty(),
-        "differential test: {} cell(s) failed out of 91:\n  {}",
+        "differential test: {} cell(s) failed out of 84:\n  {}",
         failures.len(),
         failures.join("\n  ")
     );
 
     assert_eq!(
         cells_matched + cells_aliased_len + cells_both_none + cells_join_gap,
-        91,
+        84,
         "every cell must be accounted for: matched={cells_matched}, \
          aliased_len={cells_aliased_len}, both_none={cells_both_none}, \
          join_gap={cells_join_gap}",

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -3480,15 +3480,15 @@ fn rc_vec_set_rejected() {
 }
 
 #[test]
-fn rc_vec_extend_rejected() {
+fn rc_vec_append_rejected() {
     assert_unsafe_collection_element(
         r"
         fn main() {
             var v: Vec<Rc<i64>> = Vec::new();
             let w: Vec<Rc<i64>> = Vec::new();
-            v.extend(w);
+            v.append(w);
         }",
-        "Vec.extend(Vec<Rc<i64>>)",
+        "Vec.append(Vec<Rc<i64>>)",
     );
 }
 

--- a/hew-types/tests/resolved_call_registry_lookup.rs
+++ b/hew-types/tests/resolved_call_registry_lookup.rs
@@ -332,7 +332,7 @@ fn production_registry_exposes_vec_seq_methods_with_one_type_arg() {
         .collect();
     let expected = BTreeSet::from([
         "push", "pop", "len", "get", "set", "remove", "contains", "is_empty", "clear", "clone",
-        "append", "extend", "join",
+        "append", "join",
     ]);
     assert_eq!(methods, expected);
 

--- a/hew-types/tests/type_system_negative.rs
+++ b/hew-types/tests/type_system_negative.rs
@@ -2582,7 +2582,10 @@ fn vec_append_record_element_is_layout_fail_closed() {
 }
 
 #[test]
-fn vec_extend_record_element_is_layout_fail_closed() {
+fn vec_extend_retired_is_undefined_method() {
+    // `.extend` was retired; the canonical bulk-append method is `.append`.
+    // The type-checker must reject `.extend` with UndefinedMethod so callers
+    // are steered to the replacement rather than silently doing nothing.
     let output = typecheck(
         r"
         type Point {
@@ -2600,12 +2603,8 @@ fn vec_extend_record_element_is_layout_fail_closed() {
         output
             .errors
             .iter()
-            .any(|e| e.kind == TypeErrorKind::InvalidOperation
-                && e.message.contains("`Vec::extend`")
-                && e.message.contains("not runtime-backed yet")
-                // extend maps to the append runtime entry
-                && e.message.contains("hew_vec_append_layout")),
-        "Expected layout fail-closed diagnostic for Vec<Point>::extend, got: {:?}",
+            .any(|e| e.kind == TypeErrorKind::UndefinedMethod && e.message.contains("extend")),
+        "Expected UndefinedMethod for retired Vec::extend, got: {:?}",
         output.errors
     );
 }

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -537,8 +537,6 @@ stable = [
   "hew_string_from_char",
   "hew_string_hash_fnv1a",
   "hew_string_index",
-  "hew_string_index_of",
-  "hew_string_index_of_start",
   "hew_string_is_alpha",
   "hew_string_is_alphanumeric",
   "hew_string_is_ascii",

--- a/std/builtins.hew
+++ b/std/builtins.hew
@@ -886,24 +886,6 @@ pub fn string_to_int(s: string) -> i64 {
     0
 }
 
-/// Find the first occurrence of `needle` in `haystack`.
-///
-/// Returns the byte offset, or -1 if not found.
-pub fn string_find(haystack: string, needle: string) -> i32 {
-    0 as i32
-}
-
-// ---------------------------------------------------------------------------
-// File I/O  (convenience wrappers — see also `import std::fs;`)
-// ---------------------------------------------------------------------------
-/// Read the entire contents of a file as a string.
-pub fn read_file(path: string) -> string {
-    ""
-}
-
-/// Write a string to a file, creating or overwriting it.
-pub fn write_file(path: string, content: string) {}
-
 // ---------------------------------------------------------------------------
 // Program control
 // ---------------------------------------------------------------------------

--- a/std/encoding/json/json.hew
+++ b/std/encoding/json/json.hew
@@ -309,8 +309,8 @@ pub fn from_float(val: f64) -> Value {
     }
 }
 
-/// Create a JSON Value from a string.
-pub fn from_string(val: string) -> Value {
+/// Create a JSON Value wrapping a string.
+pub fn string_value(val: string) -> Value {
     unsafe {
         hew_json_from_string(val)
     }

--- a/std/io.hew
+++ b/std/io.hew
@@ -86,8 +86,6 @@ impl bytes {
     }
     #[extern_symbol(hew_vec_append)]
     fn append(buf: bytes, other: bytes) {}
-    #[extern_symbol(hew_vec_append)]
-    fn extend(buf: bytes, other: bytes) {}
 }
 
 // ── FFI bindings ──────────────────────────────────────────────────────

--- a/std/net/http/http_async_client.hew
+++ b/std/net/http/http_async_client.hew
@@ -230,7 +230,7 @@ fn scheme_of(url_str: string) -> string {
     if mark < 0 {
         "http"
     } else {
-        string.to_lower(url_str.slice(0, mark))
+        url_str.slice(0, mark).to_lower()
     }
 }
 
@@ -371,7 +371,7 @@ fn find_response_header(header_section: string, name: string) -> string {
     if string.is_empty(header_section) {
         return "";
     }
-    let target = string.to_lower(name);
+    let target = name.to_lower();
     let lines = string.split(header_section, "\r\n");
     let n = lines.len();
     var found = "";
@@ -379,7 +379,7 @@ fn find_response_header(header_section: string, name: string) -> string {
         let line = lines[i];
         let colon = line.find(":");
         if colon > 0 {
-            let key = string.to_lower(string.trim(line.slice(0, colon)));
+            let key = string.trim(line.slice(0, colon)).to_lower();
             if key == target {
                 found = string.trim(line.slice(colon + 1, line.len()));
             }

--- a/std/net/http/http_async_server.hew
+++ b/std/net/http/http_async_server.hew
@@ -366,7 +366,7 @@ fn find_header(header_section: string, name: string) -> string {
     if string.is_empty(header_section) {
         return "";
     }
-    let target = string.to_lower(name);
+    let target = name.to_lower();
     let lines = string.split(header_section, "\r\n");
     let n = lines.len();
     var found = "";
@@ -374,7 +374,7 @@ fn find_header(header_section: string, name: string) -> string {
         let line = lines[i];
         let colon = line.find(":");
         if colon > 0 {
-            let key = string.to_lower(string.trim(line.slice(0, colon)));
+            let key = string.trim(line.slice(0, colon)).to_lower();
             if key == target {
                 found = string.trim(line.slice(colon + 1, line.len()));
             }
@@ -389,7 +389,7 @@ fn header_count(header_section: string, name: string) -> i64 {
     if string.is_empty(header_section) {
         return 0;
     }
-    let target = string.to_lower(name);
+    let target = name.to_lower();
     let lines = string.split(header_section, "\r\n");
     let n = lines.len();
     var count: i64 = 0;
@@ -397,7 +397,7 @@ fn header_count(header_section: string, name: string) -> i64 {
         let line = lines[i];
         let colon = line.find(":");
         if colon > 0 {
-            let key = string.to_lower(string.trim(line.slice(0, colon)));
+            let key = string.trim(line.slice(0, colon)).to_lower();
             if key == target {
                 count = count + 1;
             }

--- a/std/path.hew
+++ b/std/path.hew
@@ -12,7 +12,7 @@
 //!     let dir = path.dirname("/home/user/file.txt");
 //!     let ext = path.extension("photo.jpg");
 //!     let result = path.glob("*.hew");
-//!     for i in 0..result.count() {
+//!     for i in 0..result.len() {
 //!         println(result.get(i));
 //!     }
 //!     result.free();
@@ -30,7 +30,7 @@ pub type GlobResult {
 /// Methods available on a `GlobResult`.
 trait GlobResultMethods {
     /// Return the number of matched paths.
-    fn count(self) -> i64;
+    fn len(self) -> i64;
 
     /// Return the matched path at the given index.
     fn get(self, index: i64) -> string;
@@ -41,7 +41,7 @@ trait GlobResultMethods {
 
 impl GlobResultMethods for GlobResult {
     /// Return the number of matched paths.
-    fn count(res: GlobResult) -> i64 {
+    fn len(res: GlobResult) -> i64 {
         unsafe {
             hew_glob_count(res) as i64
         }

--- a/std/string.hew
+++ b/std/string.hew
@@ -534,16 +534,6 @@ pub fn is_ascii(s: string) -> bool {
     true
 }
 
-/// Convert a string to lowercase.
-pub fn to_lower(s: string) -> string {
-    s.to_lowercase()
-}
-
-/// Convert a string to uppercase.
-pub fn to_upper(s: string) -> string {
-    s.to_uppercase()
-}
-
 /// Trim leading and trailing whitespace from a string.
 pub fn trim(s: string) -> string {
     s.trim()
@@ -665,15 +655,7 @@ impl string {
         false
     }
     #[extern_symbol(hew_string_to_uppercase)]
-    fn to_uppercase(s: string) -> string {
-        ""
-    }
-    #[extern_symbol(hew_string_to_uppercase)]
     fn to_upper(s: string) -> string {
-        ""
-    }
-    #[extern_symbol(hew_string_to_lowercase)]
-    fn to_lowercase(s: string) -> string {
         ""
     }
     #[extern_symbol(hew_string_to_lowercase)]
@@ -714,10 +696,6 @@ impl string {
     }
     #[extern_symbol(hew_string_find)]
     fn find(s: string, needle: string) -> i64 {
-        0
-    }
-    #[extern_symbol(hew_string_index_of_start)]
-    fn index_of(s: string, needle: string) -> i64 {
         0
     }
     #[extern_symbol(hew_string_slice)]

--- a/tests/hew/json_test.hew
+++ b/tests/hew/json_test.hew
@@ -244,7 +244,7 @@ fn test_builder_with_consumes_child() {
 #[test]
 fn test_builder_push_consumes_element() {
     // elem consumed by push(); do not free elem.
-    let elem = json.from_string("hi");
+    let elem = json.string_value("hi");
     let arr = json.array().push(elem); // elem consumed here
     let got = arr.array_get(0);
     testing.assert_eq_str(got.get_string(), "hi");
@@ -314,7 +314,7 @@ fn test_try_parse_truncated_array_returns_err() {
     }
 }
 
-// ── from_float / from_string round-trips ─────────────────────────────
+// ── from_float / string_value round-trips ────────────────────────────
 
 #[test]
 fn test_from_float_stringify_parse_round_trip() {
@@ -334,8 +334,8 @@ fn test_from_float_stringify_parse_round_trip() {
 }
 
 #[test]
-fn test_from_string_get_string_round_trip() {
-    let val = json.from_string("hello");
+fn test_string_value_get_string_round_trip() {
+    let val = json.string_value("hello");
     testing.assert_eq_str(val.get_string(), "hello");
     val.free();
 }

--- a/tests/vertical-slice/accept/ask_reply_owned_select_loser.hew
+++ b/tests/vertical-slice/accept/ask_reply_owned_select_loser.hew
@@ -10,14 +10,14 @@
 //   - after 100ms: safety-net arm, also an owned `string`; should never fire.
 //
 // Exit-code contract: main returns the winning reply's length. FastWorker's
-// "winner-owned-reply".to_uppercase() is "WINNER-OWNED-REPLY" = 18 chars, so
+// "winner-owned-reply".to_upper() is "WINNER-OWNED-REPLY" = 18 chars, so
 // the process exits 18. A crash on the loser teardown leg (double-free / UAF)
 // or a hang would fail this fixture instead.
 actor FastWorker {
     receive fn label() -> string {
 
         // No sleep — reply immediately with an owned (heap) string.
-        "winner-owned-reply".to_uppercase()
+        "winner-owned-reply".to_upper()
     }
 }
 
@@ -26,7 +26,7 @@ actor SlowWorker {
 
         // Park 50 ms so FastWorker's reply wins; this owned reply is abandoned.
         sleep(50ms);
-        "loser-owned-reply".to_uppercase()
+        "loser-owned-reply".to_upper()
     }
 }
 
@@ -36,7 +36,7 @@ fn main() -> i64 {
     let winner = select {
         reply from fast.label() => reply,
         reply from slow.label() => reply,
-        after 100ms => "timeout-owned-reply".to_uppercase(),
+        after 100ms => "timeout-owned-reply".to_upper(),
     };
     // "WINNER-OWNED-REPLY" is 18 characters; exit code == 18.
     winner.len()

--- a/tests/vertical-slice/accept/ask_reply_owned_timeout.hew
+++ b/tests/vertical-slice/accept/ask_reply_owned_timeout.hew
@@ -17,7 +17,7 @@ actor SlowWorker {
 
         // Reply arrives well after the 10 ms deadline → cancel leg.
         sleep(50ms);
-        "late-owned-reply".to_uppercase()
+        "late-owned-reply".to_upper()
     }
 }
 

--- a/tests/vertical-slice/accept/owned_string_temp_no_double_free.hew
+++ b/tests/vertical-slice/accept/owned_string_temp_no_double_free.hew
@@ -2,7 +2,7 @@
 //!
 //! A fresh-owned `string` result used in a non-consuming (borrowing) context
 //! must be released exactly once. `string` is refcounted; every fresh producer
-//! (`+`/concat, `.to_uppercase()`, the `Vec<string>` getter) hands the caller
+//! (`+`/concat, `.to_upper()`, the `Vec<string>` getter) hands the caller
 //! one drop obligation, and a borrowing use (`.len()`) reads the buffer without
 //! consuming the refcount. The substrate releases the owner once per use:
 //!
@@ -28,10 +28,10 @@ fn main() -> i64 {
         // NESTED concat (inline drop after the borrowing `len`).
         let _b = ("p-" + "q").len();
         // BOUND transform (scope-exit drop).
-        let y2 = "lower".to_uppercase();
+        let y2 = "lower".to_upper();
         let _c = y2.len();
         // NESTED transform (inline drop).
-        let _d = "more".to_uppercase().len();
+        let _d = "more".to_upper().len();
         // BOUND Vec<string> getter — retained owner, scope-exit drop.
         let y3 = xs[0];
         let _e = y3.len();


### PR DESCRIPTION
## Summary

The stdlib is now on a single set of canonical method names across nine previously-duplicated surfaces. `string.find` replaces `.index_of` and the `string_find` free function (which also fixes its `i32` return coerced to `i64`); `string.to_lower`/`to_upper` replace `to_lowercase`/`to_uppercase`; `fs.read`/`fs.write` replace the `read_file`/`write_file` builtins; `GlobResult.len` replaces `.count`; `Vec`/`bytes` `.append` replaces `.extend`; and `json.string_value` replaces `json.from_string`. The builtin `Duration` type name is lowercased to `duration`, consistent with all other builtin type names. All former aliases are removed — callers in examples, tests, and the corpus are migrated.

A narrow lowering fix rides along: the inherent-impl-on-builtin guard was preventing the stdlib `duration` constructor block from resolving its own type. The fix exempts that one constructor block; every other builtin (instant, i64, etc.) is still rejected by the guard.

## Verification

- `hew check --all` (corpus sweep): clean, zero new diagnostics
- `cargo test -p hew-types -p hew-hir`: all tests pass
- `cargo test -p hew-cli -p hew-mir`: all tests pass
- `make checked-mir-verify`: byte-identical across all checked-MIR fixtures
- ASan baseline (obelisk): no new leaks vs. pre-change baseline
- Negative tests assert `UndefinedMethod` on all nine retired names — aliases are gone, not shadowed
- Preflight: ready-to-push

## Out of scope

- No deprecation period or compatibility shims — this is a hard cutover per the ratified naming policy.
