### PR TITLE
refactor(types): retire ActorRef/Actor/bare-Pid and close unsound unify arm

### DIFF
--- a/docs/specs/Hew.g4
+++ b/docs/specs/Hew.g4
@@ -855,7 +855,7 @@ yieldExpr
 //  Built-in generic types (Task<T>, Vec<T>, HashMap<K,V>, etc.)
 //  are syntactically just ident typeArgs?, so they are folded
 //  into the first alternative.  Listed in comments for reference:
-//    Task<T>, ActorRef<T>, Actor<M,R>, Arc<T>, Rc<T>,
+//    Task<T>, LocalPid<A>, RemotePid<A>, LambdaPid<M,R>, Arc<T>, Rc<T>,
 //    Weak<T>, Result<T,E>, Option<T>, Generator<Y>,
 //    AsyncGenerator<Y>, Vec<T>, HashMap<K,V>
 // ----------------------------------------------------------------

--- a/docs/specs/grammar.ebnf
+++ b/docs/specs/grammar.ebnf
@@ -322,8 +322,9 @@ YieldExpr      = "yield" Expr? ;
 (* Integer literals default to int (i64), float literals default to float (f64) *)
 Type           = Ident TypeArgs?
                | "Task" "<" Type ">"              (* Task type: Task<T> *)
-               | "ActorRef" "<" Type ">"          (* Actor reference: ActorRef<A> *)
-               | "Actor" "<" Type ("," Type)? ">" (* Actor type: Actor<M> or Actor<M, R> *)
+               | "LocalPid" "<" Type ">"          (* In-process actor pid: LocalPid<A> *)
+               | "RemotePid" "<" Type ">"         (* Cross-node actor pid: RemotePid<A> *)
+               | "LambdaPid" "<" Type "," Type ">" (* Lambda-actor handle: LambdaPid<M, R> *)
                | "Arc" "<" Type ">"               (* Atomic refcount: Arc<T> *)
                | "Rc" "<" Type ">"                (* Single-actor refcount: Rc<T> *)
                | "Weak" "<" Type ">"              (* Weak reference: Weak<T> *)

--- a/docs/syntax-data.json
+++ b/docs/syntax-data.json
@@ -311,7 +311,9 @@
       "None"
     ],
     "concurrency": [
-      "ActorRef",
+      "LocalPid",
+      "RemotePid",
+      "LambdaPid",
       "Stream",
       "Sink",
       "Task",

--- a/editors/sublime/Hew.tmLanguage.json
+++ b/editors/sublime/Hew.tmLanguage.json
@@ -336,7 +336,7 @@
         {
           "comment": "Concurrency types",
           "name": "storage.type.concurrency.hew",
-          "match": "\\b(ActorRef|AsyncGenerator|Generator|Scope|Sink|Stream|Task)\\b"
+          "match": "\\b(LocalPid|RemotePid|LambdaPid|AsyncGenerator|Generator|Scope|Sink|Stream|Task)\\b"
         },
         {
           "comment": "Built-in trait names",

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -4158,12 +4158,12 @@ fn resolved_ty_contains_channel_handle(ty: &ResolvedTy) -> bool {
 }
 
 /// True when `ty` is — or transitively carries through generic args, tuples,
-/// arrays, or slices — a process-local actor-pid / actor-handle builtin
-/// (`Pid` / `LocalPid` / `RemotePid` / `ActorRef` / `Actor`).
+/// arrays, or slices — an actor-pid / actor-handle builtin
+/// (`LocalPid` / `RemotePid`).
 ///
 /// These are the actor-identity siblings of the channel handles above. A
-/// `LocalPid`/`ActorRef`/`Actor` lowers to a process-local `*mut HewActor`
-/// pointer word and `RemotePid` to a bare packed `i64` — none has a cross-node
+/// `LocalPid` lowers to a process-local `*mut HewActor` pointer word and
+/// `RemotePid` to a bare packed `i64` — neither has a cross-node
 /// wire layout, and none implements `Serializable` (see `hew-types`
 /// `implements_marker`), so the checker already refuses every one of them at
 /// the `RemotePid` boundary with a named diagnostic. A same-node send transfers
@@ -4192,13 +4192,7 @@ fn resolved_ty_contains_actor_handle(ty: &ResolvedTy) -> bool {
         ResolvedTy::Named { args, builtin, .. } => {
             matches!(
                 builtin,
-                Some(
-                    hew_types::BuiltinType::Pid
-                        | hew_types::BuiltinType::LocalPid
-                        | hew_types::BuiltinType::RemotePid
-                        | hew_types::BuiltinType::ActorRef
-                        | hew_types::BuiltinType::Actor
-                )
+                Some(hew_types::BuiltinType::LocalPid | hew_types::BuiltinType::RemotePid)
             ) || args.iter().any(resolved_ty_contains_actor_handle)
         }
         ResolvedTy::Tuple(elems) => elems.iter().any(resolved_ty_contains_actor_handle),
@@ -4633,7 +4627,7 @@ pub(crate) fn primitive_to_llvm<'ctx>(
         ResolvedTy::Named { name, .. }
             if matches!(
                 name.as_str(),
-                "Duplex" | "LambdaPid" | "LocalPid" | "ActorRef" | "Actor" | "Stream" | "Sink"
+                "Duplex" | "LambdaPid" | "LocalPid" | "Stream" | "Sink"
             ) =>
         {
             // M2 substrate handle. The producer (`hew-mir/src/lower.rs`
@@ -21060,7 +21054,7 @@ fn resolved_ty_is_plain_bitcopy(
             Ok(true)
         }
         ResolvedTy::Named { name, args, .. } => {
-            if matches!(name.as_str(), "ActorRef" | "Actor" | "LocalPid") {
+            if name.as_str() == "LocalPid" {
                 return Ok(true);
             }
             let lookup_key = if args.is_empty() {
@@ -29712,7 +29706,7 @@ fn lower_terminator<'ctx>(
             // the message. We must not silently proceed — that could leave the
             // caller operating on stale state or attempting a follow-up ask
             // on a dead actor.
-            // `Terminator::Send` targets a LOCAL actor handle (`ActorRef`/`Pid`);
+            // `Terminator::Send` targets a LOCAL actor handle (`LocalPid`);
             // it delivers into a local mailbox and never reaches the cross-node
             // serialize path (that is the `RemotePid<T>` `emit_remote_pid_tell_call`
             // spine). So the `(dispatch, msg_type)` codec key is irrelevant here —
@@ -40579,7 +40573,7 @@ fn emit_actor_codec_module_init<'ctx>(
                 continue;
             };
             // Channel handles (`Sender<T>`/`Receiver<T>`) and actor-identity
-            // handles (`LocalPid`/`RemotePid`/`ActorRef`/`Actor`/`Pid`) are
+            // handles (`LocalPid`/`RemotePid`) are
             // process-local runtime resources: the local mailbox transfers the
             // retained handle pointer or packed pid by value (ownership moves;
             // the checker consumes the caller binding for resources), and the
@@ -41382,7 +41376,7 @@ mod tests {
         // name but carrying `builtin: None` must NOT be treated as a handle —
         // directly, module-qualified, behind a tuple, or behind a generic arg —
         // so its cross-node codec is still emitted (never silently skipped).
-        for shadow in ["Pid", "LocalPid", "RemotePid", "ActorRef", "Actor"] {
+        for shadow in ["LocalPid", "RemotePid"] {
             let user_ty = named_record_ty(shadow);
             assert!(
                 !resolved_ty_contains_actor_handle(&user_ty),
@@ -41412,11 +41406,8 @@ mod tests {
         // of the actor-pid family carrying its `builtin` discriminator must
         // match — directly, behind a tuple, and behind a non-handle generic arg.
         for (name, kind) in [
-            ("Pid", BuiltinType::Pid),
             ("LocalPid", BuiltinType::LocalPid),
             ("RemotePid", BuiltinType::RemotePid),
-            ("ActorRef", BuiltinType::ActorRef),
-            ("Actor", BuiltinType::Actor),
         ] {
             let handle = builtin_handle(name, kind);
             assert!(

--- a/hew-codegen-rs/tests/actor_dispatch_borrow_abi.rs
+++ b/hew-codegen-rs/tests/actor_dispatch_borrow_abi.rs
@@ -29,7 +29,7 @@ use hew_mir::{
     BasicBlock, EnumLayout, FunctionCallConv, Instr, IrPipeline, MachineVariantLayout, Place,
     RawMirFunction, Terminator,
 };
-use hew_types::{module_registry::ModuleRegistry, Checker, ResolvedTy};
+use hew_types::{module_registry::ModuleRegistry, BuiltinType, Checker, ResolvedTy};
 
 fn pipeline_from_source(source: &str) -> hew_mir::IrPipeline {
     let parsed = hew_parser::parse(source);
@@ -765,15 +765,14 @@ fn receive_handler_move_into_owned_aggregate_retains_under_live_borrow() {
 /// original envelope still owns. Hand-assembled so the `Terminator::Send` is
 /// exercised directly without the actor-method-call lowering surface.
 fn relay_resend_recv_pipeline() -> IrPipeline {
-    let actor_ty = ResolvedTy::Named {
-        name: "Actor".to_string(),
-        args: vec![],
-        builtin: None,
-        is_opaque: false,
-    };
+    // `LocalPid<Unit>` is the canonical actor-dispatch-local handle — the
+    // unit inner type is irrelevant for the ABI shape (it only determines
+    // the message-type layout, not the handle alloca).
+    let actor_ty =
+        ResolvedTy::named_builtin("LocalPid", BuiltinType::LocalPid, vec![ResolvedTy::Unit]);
     // Receive handler `Relay.forward(s: string)`:
-    //   local 0: string  // borrowed receive param (taint root)
-    //   local 1: Actor    // opaque actor handle (the re-send target)
+    //   local 0: string      // borrowed receive param (taint root)
+    //   local 1: LocalPid    // canonical actor-local handle (the re-send target)
     // Block 0: EnterContext; Send { actor: ActorHandle(1), value: Local(0) }
     // Block 1: ExitContext; Return
     let handler = RawMirFunction {
@@ -781,7 +780,7 @@ fn relay_resend_recv_pipeline() -> IrPipeline {
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::ActorHandler,
         params: vec![ResolvedTy::String],
-        locals: vec![ResolvedTy::String, actor_ty],
+        locals: vec![ResolvedTy::String, actor_ty], // local 0: string (taint root), local 1: LocalPid
         local_names: Vec::new(),
         local_scopes: Vec::new(),
         local_decl_bytes: Vec::new(),

--- a/hew-codegen-rs/tests/actor_send_status_check.rs
+++ b/hew-codegen-rs/tests/actor_send_status_check.rs
@@ -19,26 +19,23 @@ use hew_mir::{
     BasicBlock, BlockKind, CheckedMirFunction, DropPlan, ElabBlock, ElaboratedMirFunction,
     ExitPath, IrPipeline, Place, RawMirFunction, Terminator,
 };
-use hew_types::ResolvedTy;
+use hew_types::{BuiltinType, ResolvedTy};
 use std::path::Path;
 
 /// Build a minimal `IrPipeline` containing one function whose only block
 /// terminates with `Terminator::Send`. The function has:
 ///
-/// - `local 0` — `ResolvedTy::Named { name: "Actor" }` (opaque `ptr`):
-///   the actor handle used as the send target.
+/// - `local 0` — `LocalPid<Unit>` (opaque `ptr`):
+///   the canonical actor-local handle used as the send target.
 /// - `local 1` — `ResolvedTy::Unit`: the payload value. `actor_payload_ptr_size`
 ///   short-circuits to `(null, 0)` for Unit, so no payload alloca is needed.
 /// - Block 0: `Terminator::Send { actor: ActorHandle(0), msg_type: 1, value: Local(1), next: 1 }`
 /// - Block 1: `Terminator::Return` (the success continuation; reachable only
 ///   when send status == 0).
 fn send_status_pipeline() -> IrPipeline {
-    let actor_ty = ResolvedTy::Named {
-        name: "Actor".to_string(),
-        args: vec![],
-        builtin: None,
-        is_opaque: false,
-    };
+    // `LocalPid<Unit>` is the canonical actor-dispatch-local handle.
+    let actor_ty =
+        ResolvedTy::named_builtin("LocalPid", BuiltinType::LocalPid, vec![ResolvedTy::Unit]);
     let raw_blocks = vec![
         BasicBlock {
             id: 0,

--- a/hew-hir/src/builtin_type_classes.rs
+++ b/hew-hir/src/builtin_type_classes.rs
@@ -129,9 +129,6 @@ const BUILTIN_TYPE_REGISTRATIONS: &[BuiltinTypeRegistration] = &[
     registration!(HashMap, BuiltinTypeShape::Opaque),
     registration!(HashSet, BuiltinTypeShape::Opaque),
     registration!(CancellationToken, BuiltinTypeShape::Opaque),
-    registration!(ActorRef, BuiltinTypeShape::Opaque),
-    registration!(Actor, BuiltinTypeShape::Opaque),
-    registration!(Pid, BuiltinTypeShape::Opaque),
     registration!(LocalPid, BuiltinTypeShape::Opaque),
     registration!(RemotePid, BuiltinTypeShape::Opaque),
     registration!(HewActor, BuiltinTypeShape::Opaque),
@@ -395,21 +392,8 @@ mod tests {
     }
 
     #[test]
-    #[expect(
-        clippy::too_many_lines,
-        reason = "table-driven registry coverage keeps each handle fact visible"
-    )]
     fn handle_and_project_cap_registrations_carry_shape_marker_and_roles() {
         let expected = [
-            (
-                BuiltinType::Pid,
-                ResourceMarker::None,
-                None,
-                BuiltinTypeShape::Opaque,
-                Some(BuiltinHandleFamily::ActorPid),
-                0,
-                &[][..],
-            ),
             (
                 BuiltinType::LocalPid,
                 ResourceMarker::Resource,

--- a/hew-hir/src/stdlib_catalog.rs
+++ b/hew-hir/src/stdlib_catalog.rs
@@ -1125,9 +1125,9 @@ pub const CATALOG: &[BuiltinEntry] = &[
             symbol: "hew_vec_push_str",
         },
     ),
-    // Pointer-shaped element family (`Vec<LocalPid<T>>` / `Vec<ActorRef<T>>` /
-    // `Vec<Actor<T>>`): the actor-handle builtins lower to a single
-    // pointer-sized word (`*mut HewActor`) and the checker classifies them via
+    // Pointer-shaped element family (`Vec<LocalPid<T>>`): the local actor-handle
+    // builtin lowers to a single pointer-sized word (`*mut HewActor`) and the
+    // checker classifies it via
     // `BuiltinType::lowers_as_pointer_vec_element` → `"ptr"`. The runtime ABI
     // (`hew_vec_new_ptr` + `hew_vec_{push,get,set,pop}_ptr`) already exists;
     // these rows register the symbols with HIR's `fn_registry` and codegen's

--- a/hew-hir/tests/m3_surface_pid_lower.rs
+++ b/hew-hir/tests/m3_surface_pid_lower.rs
@@ -116,9 +116,8 @@ fn lower_with_types(source: &str) -> (hew_types::TypeCheckOutput, hew_hir::Lower
 #[test]
 fn spawn_expr_type_is_local_pid() {
     // After type-checking, the `spawn` expression must be recorded as
-    // `LocalPid<Counter>` (not `ActorRef<Counter>`).  This ensures that
-    // the checker's discriminator survives into the type-check output that
-    // HIR lowering consumes.
+    // `LocalPid<Counter>`. This ensures that the checker's discriminator
+    // survives into the type-check output that HIR lowering consumes.
     let source = r"
         actor Counter {
             let n: i32;
@@ -137,13 +136,15 @@ fn spawn_expr_type_is_local_pid() {
         has_local_pid,
         "expr_types should contain at least one LocalPid<Counter> entry"
     );
-    let has_actor_ref_for_spawn = tc
+    // `LocalPid` is the spawn-return type; no stray `ActorRef`-named handle
+    // exists anywhere in the type table (the family is LocalPid/RemotePid).
+    let has_stray_actor_ref = tc
         .expr_types
         .values()
         .any(|ty| matches!(ty, Ty::Named { name, .. } if name == "ActorRef"));
     assert!(
-        !has_actor_ref_for_spawn,
-        "spawn should no longer produce ActorRef — found one in expr_types: {:#?}",
+        !has_stray_actor_ref,
+        "spawn must produce LocalPid; no `ActorRef`-named handle should appear: {:#?}",
         tc.expr_types
             .values()
             .filter(|ty| matches!(ty, Ty::Named { name, .. } if name == "ActorRef"))

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -473,9 +473,7 @@ fn signed_min_value(ty: &ResolvedTy, ptr_width: PointerWidth) -> Option<i64> {
 
 fn actor_name_from_handle_ty(ty: &ResolvedTy) -> Option<&str> {
     match ty {
-        ResolvedTy::Named { name, args, .. }
-            if matches!(name.as_str(), "LocalPid" | "ActorRef" | "Actor") && args.len() == 1 =>
-        {
+        ResolvedTy::Named { name, args, .. } if name.as_str() == "LocalPid" && args.len() == 1 => {
             match &args[0] {
                 ResolvedTy::Named { name, args, .. } if args.is_empty() => Some(name.as_str()),
                 _ => None,
@@ -7226,12 +7224,7 @@ fn push_unknown_type_diagnostics(
 fn is_phantom_arg_pid(builtin: Option<BuiltinType>) -> bool {
     matches!(
         builtin,
-        Some(
-            BuiltinType::LocalPid
-                | BuiltinType::RemotePid
-                | BuiltinType::Pid
-                | BuiltinType::ActorRef
-        )
+        Some(BuiltinType::LocalPid | BuiltinType::RemotePid)
     )
 }
 
@@ -26237,7 +26230,7 @@ impl Builder {
         //     self reference preserves stop-on-last-external-handle-drop.
         //   - Strong BitCopy scalar: the field store copies the value;
         //     the caller's binding stays live and untouched.
-        //   - Strong pid (`LocalPid`/`ActorRef`): a BitCopy alias of an
+        //   - Strong pid (`LocalPid`): a BitCopy alias of an
         //     opaque identity reference with no drop glue. The field store
         //     copies the handle word; the caller's binding stays live and
         //     the env field gets no retain and no release — the actor's
@@ -26318,7 +26311,7 @@ impl Builder {
                         | ResolvedTy::Bool
                         | ResolvedTy::Char
                         | ResolvedTy::Named {
-                            builtin: Some(BuiltinType::LocalPid | BuiltinType::ActorRef),
+                            builtin: Some(BuiltinType::LocalPid),
                             ..
                         },
                     ) => crate::model::LambdaEnvFieldDrop::None,
@@ -27504,11 +27497,7 @@ impl Builder {
             {
                 true
             }
-            ResolvedTy::Named { name, .. }
-                if matches!(name.as_str(), "LocalPid" | "ActorRef" | "Actor") =>
-            {
-                true
-            }
+            ResolvedTy::Named { name, .. } if name.as_str() == "LocalPid" => true,
             // `Generator<Y, R>` is the checker-supplied type for a gen-block
             // expression. The S3a shell allocates a local of this type as a
             // placeholder; S3b replaces it with the real state-record type.

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -1797,9 +1797,9 @@ fn ty_contains_unclonable_opaque_inner(
                     }
                 }
             }
-            // 4. Bit-copy actor-handle types: LocalPid<T>, ActorRef<T>, Actor<T>.
+            // 4. Bit-copy actor-handle type: LocalPid<T>.
             //    Placed AFTER the record/enum-layout lookups (steps 2-3) so a
-            //    user record/enum that genuinely shadows one of these names
+            //    user record/enum that genuinely shadows this name
             //    (proven by EXACT layout-name match, not short-name-only) is
             //    already handled above and never reaches this arm.
             //    Uses the `builtin` identity discriminator (authoritative) rather
@@ -1808,16 +1808,9 @@ fn ty_contains_unclonable_opaque_inner(
             //    here only if it ALSO has no layout in scope. With `builtin: None`
             //    the match below does NOT fire, so the args recursion (step 5)
             //    walks the type args and finds any opaque payload. Only a real
-            //    builtin handle (stamped `builtin: Some(ActorRef|Actor|LocalPid)`
-            //    by the checker) earns the bit-copy skip.
-            if matches!(
-                builtin,
-                Some(
-                    hew_types::BuiltinType::ActorRef
-                        | hew_types::BuiltinType::Actor
-                        | hew_types::BuiltinType::LocalPid
-                )
-            ) {
+            //    builtin handle (stamped `builtin: Some(LocalPid)` by the
+            //    checker) earns the bit-copy skip.
+            if matches!(builtin, Some(hew_types::BuiltinType::LocalPid)) {
                 return false;
             }
             // 5. Type arguments (generic builtins with no layout: Vec<T>,

--- a/hew-mir/src/state_clone.rs
+++ b/hew-mir/src/state_clone.rs
@@ -29,7 +29,7 @@
 //! "Connection", args: [] }`. The classifier therefore looks
 //! `record_layouts` up FIRST for every `Named` arm; only when the name
 //! is not user-shadowed does it fall through to the builtin-name match
-//! (`Connection` / `ActorRef` / `Vec` / `HashMap` / `HashSet` /
+//! (`Connection` / `LocalPid` / `Vec` / `HashMap` / `HashSet` /
 //! `string` / `bytes`).
 //!
 //! This is the local mitigation for dispatch-invariant #10
@@ -986,7 +986,7 @@ fn classify_named(
     // Connection { ... }` and the runtime builtin `net.Connection` both reach
     // this function as `Named { name: "Connection", args: [] }`. Routing on
     // name alone would silently misclassify a user record named after
-    // a builtin (Connection / Vec / HashMap / HashSet / ActorRef /
+    // a builtin (Connection / Vec / HashMap / HashSet / LocalPid /
     // string / bytes) — bypassing the recursive-record arm and the
     // owned-heap drop helpers, which would leak (Stage 3) or UAF
     // (post-Q185(c) lift, plan §8.8).
@@ -1055,19 +1055,11 @@ fn classify_named(
     // an emitted generic instantiation layout has `builtin: None` and
     // must NOT collapse to BitCopy — its type args must be inspected for
     // opaques. Only a real builtin handle (stamped
-    // `builtin: Some(ActorRef|Actor|LocalPid)` by the checker) earns
-    // the bit-copy skip. Generic user shadows with no layout reached
-    // this arm previously (the record_layouts lookup at line ~916 missed
-    // the absent mangled key); the discriminator closes that gap without
-    // requiring the layout to exist.
-    if matches!(
-        builtin,
-        Some(
-            hew_types::BuiltinType::ActorRef
-                | hew_types::BuiltinType::Actor
-                | hew_types::BuiltinType::LocalPid
-        )
-    ) {
+    // `builtin: Some(LocalPid)` by the checker) earns the bit-copy skip.
+    // Generic user shadows with no layout reach this arm only with
+    // `builtin: None`; the discriminator closes that gap without requiring
+    // the layout to exist.
+    if matches!(builtin, Some(hew_types::BuiltinType::LocalPid)) {
         return Ok(StateFieldCloneKind::BitCopy { size_bytes: 0 });
     }
 
@@ -1497,25 +1489,21 @@ mod tests {
     }
 
     #[test]
-    fn actor_ref_classifies_as_bitcopy_per_audit_section_1() {
-        // Plan §4.5 A: `HewActorRef` is `#[repr(C)]` bit-copyable, NOT
-        // refcount-bump. This test pins the contract — if a future
-        // change reintroduces a dedicated `ActorRef` variant, this test
-        // breaks and forces a re-read of plan §4.5 A.
+    fn local_pid_classifies_as_bitcopy() {
+        // A `LocalPid<T>` lowers to the `#[repr(C)]` bit-copyable runtime handle
+        // word, NOT a refcount-bump. The classifier routes on the `builtin`
+        // discriminator the checker stamps, so a real `LocalPid<T>` must reach
+        // the bit-copy skip regardless of its name string.
         let mut v = HashSet::new();
-        // `builtin: Some(ActorRef)` is the discriminator the HIR checker stamps
-        // on real `ActorRef<T>` types. The classifier now routes on this field
-        // rather than the name string, so the `builtin` discriminator must
-        // accurately reflect the type identity.
         let ty = ResolvedTy::Named {
-            name: "ActorRef".to_string(),
+            name: "LocalPid".to_string(),
             args: vec![ResolvedTy::Named {
                 name: "SomeActor".to_string(),
                 args: vec![],
                 builtin: None,
                 is_opaque: false,
             }],
-            builtin: Some(hew_types::BuiltinType::ActorRef),
+            builtin: Some(hew_types::BuiltinType::LocalPid),
             is_opaque: false,
         };
         assert_eq!(

--- a/hew-mir/tests/state_clone_classification.rs
+++ b/hew-mir/tests/state_clone_classification.rs
@@ -163,18 +163,18 @@ fn classification_is_paired_some_some_or_none_none() {
 // ─── Per-actor representative classifications (audit §3) ────────────
 
 #[test]
-fn chatroom_shape_classifies_vec_of_string_and_vec_of_actor_ref() {
-    // Audit row #1 of stdlib-supervision-relevant shapes:
-    // `ChatRoom { handlers: Vec<ActorRef<ClientHandler>>, names: Vec<string> }`.
-    // The classifier sees `Vec<ActorRef<ClientHandler>>` (Vec of
-    // BitCopy because ActorRef is repr(C) bit-copy per audit §1) and
+fn chatroom_shape_classifies_vec_of_string_and_vec_of_local_pid() {
+    // Stdlib-supervision-relevant shape:
+    // `ChatRoom { handlers: Vec<LocalPid<ClientHandler>>, names: Vec<string> }`.
+    // The classifier sees `Vec<LocalPid<ClientHandler>>` (Vec of BitCopy
+    // because a LocalPid is a repr(C) bit-copy handle word) and
     // `Vec<string>` (Vec of String, needs per-element deep clone).
     let src = r"
         actor ClientHandler {
             receive fn msg(text: string) {}
         }
         actor ChatRoom {
-            let handlers: Vec<ActorRef<ClientHandler>>;
+            let handlers: Vec<LocalPid<ClientHandler>>;
             let names: Vec<string>;
         }
     ";
@@ -192,9 +192,9 @@ fn chatroom_shape_classifies_vec_of_string_and_vec_of_actor_ref() {
     assert_eq!(kinds.len(), 2);
     match &kinds[0] {
         StateFieldCloneKind::Vec { elem } => match elem.as_ref() {
-            // ActorRef collapses to BitCopy per plan §4.5 A.
+            // A LocalPid handle word is a repr(C) bit-copy.
             StateFieldCloneKind::BitCopy { .. } => {}
-            other => panic!("Vec<ActorRef<...>> element should be BitCopy, got {other:?}"),
+            other => panic!("Vec<LocalPid<...>> element should be BitCopy, got {other:?}"),
         },
         other => panic!("field 0 should be Vec, got {other:?}"),
     }
@@ -323,20 +323,21 @@ fn user_type_named_vec_does_not_route_to_container_arm() {
 }
 
 #[test]
-fn user_type_named_actor_ref_does_not_route_to_bitcopy_arm() {
-    // Same hazard for the handle-typed builtins (ActorRef / Actor /
-    // LocalPid). A user record shadowing one of these names must NOT
-    // collapse to BitCopy — that would skip the per-field drop of any
-    // owned fields the user declared.
+fn user_type_named_local_pid_does_not_route_to_bitcopy_arm() {
+    // Same hazard for the local actor-handle builtin (`LocalPid`). A user
+    // record shadowing that name with `builtin: None` must NOT collapse to
+    // BitCopy — that would skip the per-field drop of any owned fields the
+    // user declared. The classifier routes on the `builtin` discriminator,
+    // not the name string, so the shadow stays a UserRecord.
     let mut visited = HashSet::new();
     let records = vec![hew_mir::model::RecordLayout {
-        name: "ActorRef".to_string(),
+        name: "LocalPid".to_string(),
         field_tys: vec![ResolvedTy::String],
         field_names: vec![],
     }];
     let result = hew_mir::classify_state_field(
         &ResolvedTy::Named {
-            name: "ActorRef".to_string(),
+            name: "LocalPid".to_string(),
             args: vec![],
             builtin: None,
             is_opaque: false,
@@ -348,7 +349,7 @@ fn user_type_named_actor_ref_does_not_route_to_bitcopy_arm() {
     assert_eq!(
         result,
         StateFieldCloneKind::UserRecord {
-            name: "ActorRef".to_string(),
+            name: "LocalPid".to_string(),
         },
     );
 }
@@ -372,7 +373,7 @@ fn router_shape_vec_of_user_connection_carries_user_record_through() {
         }
         actor Router {
             let conns: Vec<Connection>;
-            let clients: Vec<ActorRef<Client>>;
+            let clients: Vec<LocalPid<Client>>;
             let qos: Vec<i32>;
         }
     ";
@@ -396,7 +397,7 @@ fn router_shape_vec_of_user_connection_carries_user_record_through() {
     match &kinds[1] {
         StateFieldCloneKind::Vec { elem } => assert!(
             matches!(elem.as_ref(), StateFieldCloneKind::BitCopy { .. }),
-            "Vec<ActorRef<Client>> element should be BitCopy, got {elem:?}",
+            "Vec<LocalPid<Client>> element should be BitCopy, got {elem:?}",
         ),
         other => panic!("field 1 should be Vec, got {other:?}"),
     }
@@ -528,7 +529,7 @@ fn coverage_report_against_audit_representatives() {
     //   trivial-state             → Counter      (89 actors in class)
     //   string + Vec<String>      → ChatRoom-like (covered in §1 test)
     //   Vec<Connection>           → Router-like   (covered in §1 test)
-    //   ActorRef in state         → Router/Listener (covered in §1)
+    //   LocalPid in state         → Router/Listener (covered in §1)
     //   nested user record        → Workspace fixture (covered above)
     //
     // The substrate-level claim is: "if Stage 0's 110-actor enumeration
@@ -942,7 +943,7 @@ fn generic_machine_record_field_admits() {
 
 // ─── LocalPid<T> phantom-arg fix (chat_server regression) ───────────────────
 //
-// `LocalPid<T>`, `ActorRef<T>`, and `Actor<T>` are bit-copy actor handles; T
+// `LocalPid<T>` is a bit-copy actor handle; T
 // is a phantom actor-name tag, not a value stored inside the handle.
 // `ty_contains_unclonable_opaque_inner` must NOT recurse into that arg — doing
 // so walks the actor's OWN state-mirror record and finds any #[opaque] fields

--- a/hew-sandbox-wasm/src/profile.rs
+++ b/hew-sandbox-wasm/src/profile.rs
@@ -893,8 +893,8 @@ impl<'a> ProfileChecker<'a> {
 
         // Actor asks: `await ref.handler(...)` where `handler` is a declared
         // receive function AND the receiver is a handle to an admitted actor.
-        // Type-check the receiver: actor handles are `LocalPid<ActorName>` or
-        // `ActorRef` where `ActorName` is in the program's declared actors set.
+        // Type-check the receiver: an actor handle is `LocalPid<ActorName>`
+        // where `ActorName` is in the program's declared actors set.
         // A name-only check without the receiver type would admit spurious method
         // calls on non-actor receivers that happen to share a handler name.
         if self.actor_methods.contains(method) {
@@ -962,16 +962,13 @@ impl<'a> ProfileChecker<'a> {
     }
 
     /// True if `ty` is an actor handle type for a declared actor in this program.
-    /// Actor handles are `LocalPid<ActorName>` (the standard actor ref type) or
-    /// `Named { name: ActorName }` when the typechecker inlines the actor type
-    /// directly. Both are present in practice depending on the call site.
+    /// Actor handles are `LocalPid<ActorName>` (the standard actor handle type)
+    /// or `Named { name: ActorName }` when the typechecker inlines the actor
+    /// type directly. Both are present in practice depending on the call site.
     fn ty_is_actor_handle(&self, ty: &Ty) -> bool {
         match ty.materialize_literal_defaults() {
             // `LocalPid<ActorName>` — the standard form from `spawn Actor(...)`.
-            Ty::Named { name, args, .. }
-                if (name == "LocalPid" || name == "Pid" || name == "ActorRef")
-                    && args.len() == 1 =>
-            {
+            Ty::Named { name, args, .. } if name == "LocalPid" && args.len() == 1 => {
                 if let Ty::Named {
                     name: actor_name, ..
                 } = &args[0]

--- a/hew-types/src/builtin_names.rs
+++ b/hew-types/src/builtin_names.rs
@@ -307,7 +307,7 @@ builtin_named_types! {
     //
     // A `LocalPid<T>` is process-local: it refers to an actor running in the current
     // node. Built-in actor functions (`close`, `link`, `monitor`, etc.) use
-    // `LocalPid<T>` directly; it is nominally distinct from `ActorRef<T>`.
+    // `LocalPid<T>` directly; it is nominally distinct from `RemotePid<T>`.
     //
     // Methods (`.tell`) are declared in `std/builtins.hew` as `impl LocalPid<T>` and
     // resolved via the normal user-type method dispatch path.
@@ -321,7 +321,7 @@ builtin_named_types! {
     // RemotePid<T>: actor pid on a remote node.
     //
     // A `RemotePid<T>` is produced by peer-discovery or explicit construction
-    // (`RemotePid::from_raw`). It does NOT unify with `ActorRef<T>` or `LocalPid<T>`.
+    // (`RemotePid::from_raw`). It does NOT unify with `LocalPid<T>`.
     // Coercion from local → remote is explicit: `local_pid.to_remote_via(node_handle)`.
     //
     // `.tell` returns Result<(), SendError> and fails closed until actual routing arrives.
@@ -371,15 +371,12 @@ pub fn builtin_named_type(name: &str) -> Option<BuiltinNamedType> {
             | BuiltinType::Vec
             | BuiltinType::HashMap
             | BuiltinType::HashSet
-            | BuiltinType::ActorRef
-            | BuiltinType::Actor
             | BuiltinType::Task
             | BuiltinType::StreamPair
             | BuiltinType::Generator
             | BuiltinType::AsyncGenerator
             | BuiltinType::Range
             | BuiltinType::Rc
-            | BuiltinType::Pid
             | BuiltinType::HewActor
             | BuiltinType::HewDuplex
             | BuiltinType::HewSendHalf

--- a/hew-types/src/builtin_type.rs
+++ b/hew-types/src/builtin_type.rs
@@ -13,8 +13,6 @@ pub enum BuiltinType {
     Vec,
     HashMap,
     HashSet,
-    ActorRef,
-    Actor,
     Task,
     StreamPair,
     Generator,
@@ -26,7 +24,6 @@ pub enum BuiltinType {
     Stream,
     Sink,
     Duplex,
-    Pid,
     LocalPid,
     RemotePid,
     HewActor,
@@ -154,8 +151,6 @@ builtin_types! {
     Vec => "Vec",
     HashMap => "HashMap",
     HashSet => "HashSet",
-    ActorRef => "ActorRef",
-    Actor => "Actor",
     Task => "Task",
     StreamPair => "StreamPair",
     Generator => "Generator",
@@ -167,7 +162,6 @@ builtin_types! {
     Stream => "Stream",
     Sink => "Sink",
     Duplex => "Duplex",
-    Pid => "Pid",
     LocalPid => "LocalPid",
     RemotePid => "RemotePid",
     HewActor => "HewActor",
@@ -259,7 +253,7 @@ impl BuiltinType {
     #[must_use]
     pub const fn handle_family(self) -> Option<BuiltinHandleFamily> {
         match self {
-            Self::Pid | Self::LocalPid | Self::RemotePid | Self::LambdaPid => {
+            Self::LocalPid | Self::RemotePid | Self::LambdaPid => {
                 Some(BuiltinHandleFamily::ActorPid)
             }
             Self::HewActor | Self::BoxedActor => Some(BuiltinHandleFamily::ActorRuntime),
@@ -281,8 +275,6 @@ impl BuiltinType {
             Self::Option
             | Self::Vec
             | Self::HashSet
-            | Self::ActorRef
-            | Self::Actor
             | Self::Task
             | Self::Generator
             | Self::AsyncGenerator
@@ -305,8 +297,7 @@ impl BuiltinType {
             | Self::HewDuplex
             | Self::LambdaActorHandle
             | Self::LambdaPid => 2,
-            Self::Pid
-            | Self::HewActor
+            Self::HewActor
             | Self::HewSendHalf
             | Self::HewRecvHalf
             | Self::BoxedActor
@@ -334,9 +325,7 @@ impl BuiltinType {
     #[must_use]
     pub const fn roles(self) -> &'static [BuiltinTypeRole] {
         match self {
-            Self::ActorRef | Self::Actor | Self::LambdaPid => {
-                &[BuiltinTypeRole::ActorDispatchLocal]
-            }
+            Self::LambdaPid => &[BuiltinTypeRole::ActorDispatchLocal],
             Self::LocalPid => &[
                 BuiltinTypeRole::ActorDispatchLocal,
                 BuiltinTypeRole::SupervisorLocalPid,
@@ -377,14 +366,13 @@ impl BuiltinType {
         )
     }
 
-    /// True for the local actor-handle builtins that lower to a single
-    /// pointer-shaped runtime word (`*mut HewActor`) — `LocalPid<T>`,
-    /// `ActorRef<T>`, and `Actor<T>`.
+    /// True for the local actor-handle builtin that lowers to a single
+    /// pointer-shaped runtime word (`*mut HewActor`) — `LocalPid<T>`.
     ///
-    /// These are the builtins whose codegen `resolve_ty` arm produces an opaque
+    /// This is the builtin whose codegen `resolve_ty` arm produces an opaque
     /// `ptr` and whose `Vec<T>` constructor routes to `hew_vec_new_ptr` (see
     /// `resolve_ty` + `resolved_ty_is_plain_bitcopy` in `hew-codegen-rs`). The
-    /// checker MUST classify them as the pointer-shaped (`"ptr"`) Vec-element
+    /// checker MUST classify it as the pointer-shaped (`"ptr"`) Vec-element
     /// ABI so `push`/`get`/`set`/`pop` route to the `hew_vec_*_ptr` family
     /// rather than the layout-descriptor family — otherwise the constructor and
     /// the element ops disagree (null-layout `hew_vec_new_ptr` + layout push),
@@ -396,7 +384,7 @@ impl BuiltinType {
     /// move-only resources and are not admitted as Vec elements here.
     #[must_use]
     pub const fn lowers_as_pointer_vec_element(self) -> bool {
-        matches!(self, Self::LocalPid | Self::ActorRef | Self::Actor)
+        matches!(self, Self::LocalPid)
     }
 }
 
@@ -459,14 +447,6 @@ mod tests {
     #[allow(clippy::too_many_lines, reason = "single builtin fact table")]
     fn handle_and_project_cap_facts_are_registered() {
         let expected = [
-            (
-                BuiltinType::Pid,
-                BuiltinTypeMarker::None,
-                None,
-                Some(BuiltinHandleFamily::ActorPid),
-                0,
-                &[][..],
-            ),
             (
                 BuiltinType::LocalPid,
                 BuiltinTypeMarker::Resource,

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -419,8 +419,8 @@ impl Checker {
                 // await Task<T> → T (simplified)
                 match inner_ty {
                     Ty::Task(inner) => *inner,
-                    // `await close(actor)` or bare actor ref → Unit (actor termination).
-                    // But NOT for method calls that happen to return an ActorRef —
+                    // `await close(actor)` or bare actor handle → Unit (actor termination).
+                    // But NOT for method calls that happen to return an actor handle —
                     // those should pass through the method's declared return type.
                     _ if inner_ty.as_actor_handle().is_some()
                         && !matches!(effective_expr, Expr::MethodCall { .. }) =>
@@ -644,7 +644,7 @@ impl Checker {
             // `record` types, tuples, ranges, fn/closures.
             //
             // Result is always `bool`. Cross-class mismatches (e.g.
-            // `ActorRef<T> is Vec<int>`) collapse into a single
+            // `LocalPid<T> is Vec<int>`) collapse into a single
             // `TypeErrorKind::Mismatch` diagnostic that requires the operands
             // share the same resolved type. Move/consumed-self semantics
             // follow the existing use-after-move rule (plan §D-D4, Q-N3).
@@ -7270,7 +7270,7 @@ impl Checker {
         }
 
         // Cross-class / cross-instantiation mismatch (e.g. `Vec<int> is Vec<String>`
-        // or `ActorRef<Foo> is Vec<int>`) — only reported when both sides are
+        // or `LocalPid<Foo> is Vec<int>`) — only reported when both sides are
         // independently identity-capable; otherwise the value-type rejection
         // above carries the diagnostic.
         if lhs_ok && rhs_ok && lhs_resolved != rhs_resolved {
@@ -7397,8 +7397,8 @@ impl Checker {
     /// Returns `true` when `is` is valid on values of this type:
     ///
     /// * Machines (`TypeDefKind::Machine`).
-    /// * Actors and actor handles: `TypeDefKind::Actor` named types,
-    ///   `ActorRef<T>`, and `Actor<T>`.
+    /// * Actors and actor handles: `TypeDefKind::Actor` named types and
+    ///   `LocalPid<T>`.
     /// * Heap-backed collections: `Vec<T>`, `HashMap<K,V>`, `HashSet<T>`.
     /// * `bytes`.
     /// * User `type Foo { ... }` declarations (`TypeDefKind::Struct` and
@@ -7416,7 +7416,7 @@ impl Checker {
             // Named types: actor handles, collection builtins, and any user
             // `TypeDef` whose kind carries heap/reference identity.
             Ty::Named { name, builtin, .. } => {
-                // Actor handles (`ActorRef<T>` / `Actor<T>`).
+                // Actor handles (`LocalPid<T>`).
                 if ty.as_actor_handle().is_some() {
                     return true;
                 }

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -3917,7 +3917,7 @@ impl Checker {
     /// and `string` elements unconditionally, and pointer / layout-descriptor
     /// elements **only when the element is `Copy`**. The `Copy` gate is what
     /// makes the pointer and layout arms safe: it admits identity handles
-    /// (`LocalPid`/`ActorRef`) and bit-copy value records, while deferring
+    /// (`LocalPid`) and bit-copy value records, while deferring
     /// every shape with an ownership contract — owned heap-handles, non-`Copy`
     /// records, closures (each owns a captured environment), and nested
     /// collections (each owns a backing store). Those would alias an owner
@@ -6919,109 +6919,6 @@ impl Checker {
                 );
                 Ty::Error
             }
-            // ActorRef methods
-            (resolved, _) if resolved.as_actor_ref().is_some() => {
-                let inner = resolved.as_actor_ref().unwrap();
-                // A user-defined `receive fn send(...)` takes precedence over the
-                // builtin fire-and-forget path.  When no such handler exists the
-                // anonymous-payload surface is not lowerable — reject it here with
-                // an actionable diagnostic rather than accepting and failing closed
-                // in HIR with `MethodCallNoRewrite`.
-                let has_user_send_handler = method == "send" && {
-                    if let Ty::Named {
-                        name: ref actor_name,
-                        ..
-                    } = inner
-                    {
-                        self.fn_sigs.contains_key(&format!("{actor_name}::send"))
-                    } else {
-                        false
-                    }
-                };
-                if method == "send" && !has_user_send_handler {
-                    // Synthesize args so downstream bindings resolve cleanly.
-                    for arg in args {
-                        let (expr, sp) = arg.expr();
-                        self.synthesize(expr, sp);
-                    }
-                    let actor_hint = if let Ty::Named { name, .. } = inner {
-                        name.clone()
-                    } else {
-                        "this actor".to_string()
-                    };
-                    self.report_error(
-                        TypeErrorKind::UndefinedMethod,
-                        span,
-                        format!(
-                            "actor `{actor_hint}` has no `receive fn send` handler; \
-                             anonymous-payload `.send()` is not supported — \
-                             add `receive fn send(payload: T) {{ ... }}` to the actor, \
-                             or dispatch through a named handler: `ref.method_name(payload)`"
-                        ),
-                    );
-                    Ty::Error
-                } else {
-                    // Try to dispatch to the actor's receive methods
-                    if let Ty::Named {
-                        name: actor_name, ..
-                    } = inner
-                    {
-                        let method_key = format!("{actor_name}::{method}");
-                        if let Some(sig) = self.fn_sigs.get(&method_key).cloned() {
-                            for (i, arg) in args.iter().enumerate() {
-                                let (expr, sp) = arg.expr();
-                                let ty = if let Some(param_ty) = sig.params.get(i) {
-                                    self.check_against(expr, sp, param_ty)
-                                } else {
-                                    self.synthesize(expr, sp)
-                                };
-                                self.enforce_actor_boundary_send(expr, sp, sp, &ty);
-                            }
-                            self.record_method_call_receiver_kind(
-                                span,
-                                MethodCallReceiverKind::ActorInstance {
-                                    actor_name: actor_name.clone(),
-                                },
-                            );
-                            // Ask-without-await guard: ask-shaped receive fn must be
-                            // awaited. Generator methods (`receive gen fn`) use `for
-                            // await` at the call site and are exempt from this guard.
-                            let resolved_ret = self.subst.resolve(&sig.return_type);
-                            if !matches!(resolved_ret, Ty::Unit)
-                                && !self.receive_generator_methods.contains(&method_key)
-                                && !self.inside_await_expr
-                            {
-                                self.report_error(
-                                    TypeErrorKind::InvalidOperation,
-                                    span,
-                                    format!(
-                                        "actor ask `{actor_name}::{method}` requires `await`; \
-                                         write `let v? = await ref.{method}(...)` \
-                                         or `match await ref.{method}(...) {{ Ok(v) => ..., Err(e) => ... }}`",
-                                    ),
-                                );
-                            }
-                            self.record_actor_method_dispatch(
-                                span,
-                                method_key,
-                                sig.return_type.clone(),
-                            );
-                            return sig.return_type;
-                        }
-                    }
-                    for arg in args {
-                        let (expr, sp) = arg.expr();
-                        self.synthesize(expr, sp);
-                    }
-                    self.report_error_with_suggestions(
-                        TypeErrorKind::UndefinedMethod,
-                        span,
-                        format!("no method `{method}` on `{}`", resolved.user_facing()),
-                        self.similar_methods(resolved, method),
-                    );
-                    Ty::Error
-                }
-            }
             // Duplex<S, R>: bidirectional channel handle (raw channel substrate
             // from `duplex` / `duplex_pair`).
             //
@@ -7080,26 +6977,6 @@ impl Checker {
                 },
                 _,
             ) => self.check_recv_half_method(type_args, receiver, method, args, span),
-            // Named types that have built-in methods (Actor<T> from lambda actors)
-            (
-                Ty::Named {
-                    builtin: Some(BuiltinType::Actor),
-                    args: type_args,
-                    ..
-                },
-                "send",
-            ) => {
-                for arg in args {
-                    let (expr, sp) = arg.expr();
-                    let ty = if let Some(param_ty) = type_args.first() {
-                        self.check_against(expr, sp, param_ty)
-                    } else {
-                        self.synthesize(expr, sp)
-                    };
-                    self.enforce_actor_boundary_send(expr, sp, sp, &ty);
-                }
-                Ty::Unit
-            }
             // String methods are declared in `std/string.hew` with
             // monomorphic `#[extern_symbol]` annotations.
             (Ty::String, _) => self.dispatch_string_method(method, args, span),
@@ -7681,7 +7558,7 @@ impl Checker {
                     // `fn_sigs` keyed `{Actor}::{method}`, but a value of bare
                     // actor type `W` is still an actor handle, not a struct: the
                     // call must cross the mailbox boundary exactly like the
-                    // `LocalPid<W>` / `ActorRef<W>` arms above. Route it through
+                    // `LocalPid<W>` arm above. Route it through
                     // the same send/ask dispatch machinery instead of falling
                     // through to the synchronous `W::method(self, ...)`
                     // `RewriteToFunction` path (which HIR cannot lower — there is
@@ -7710,7 +7587,7 @@ impl Checker {
                         self.enforce_actor_method_send_args(args);
                         // Ask-without-await guard: an ask-shaped receive fn
                         // (non-unit return, non-generator) must be invoked under
-                        // `await`. Mirrors the `LocalPid` / `ActorRef` arms.
+                        // `await`. Mirrors the `LocalPid` arm.
                         let method_key = format!("{name}::{method}");
                         let resolved_ret = self.subst.resolve(&applied_sig.return_type);
                         if !matches!(resolved_ret, Ty::Unit)

--- a/hew-types/src/check/tests/collections.rs
+++ b/hew-types/src/check/tests/collections.rs
@@ -1679,21 +1679,21 @@ fn actor_decl_registers_rcfree_members_for_collection_checks() {
 
     let mut checker = Checker::new(ModuleRegistry::new(vec![]));
     let _ = checker.check_program(&parsed.program);
-    let actor_ref_ty = Ty::actor_ref(Ty::Named {
+    let local_pid_ty = Ty::local_pid(Ty::Named {
         builtin: None,
         name: "Worker".to_string(),
         args: vec![],
     });
 
     assert!(
-        checker.reject_rc_collection_element("HashSet", &actor_ref_ty, &(0..0)),
-        "ActorRef<Worker> should pass RcFree collection admissibility even when Worker stores Rc"
+        checker.reject_rc_collection_element("HashSet", &local_pid_ty, &(0..0)),
+        "LocalPid<Worker> should pass RcFree collection admissibility even when Worker stores Rc"
     );
     assert!(
         !checker.errors.iter().any(|err| {
             err.kind == TypeErrorKind::UnsafeCollectionElement && err.message.contains("HashSet")
         }),
-        "ActorRef<Worker> should not emit a HashSet UnsafeCollectionElement error, got: {:?}",
+        "LocalPid<Worker> should not emit a HashSet UnsafeCollectionElement error, got: {:?}",
         checker.errors
     );
 }

--- a/hew-types/src/check/tests/control_flow.rs
+++ b/hew-types/src/check/tests/control_flow.rs
@@ -970,9 +970,9 @@ mod for_loop_iterable_fail_closed {
 
     #[test]
     fn closure_captures_duplex_handle_does_not_affect_pid_captures() {
-        // Regression guard: the new Duplex gate must NOT fire for ActorRef/LocalPid
-        // captures. A closure capturing a declared-actor's pid is accepted (the
-        // main feature of this PR). Only Duplex (lambda-actor handles) is refused.
+        // Regression guard: the Duplex gate must NOT fire for LocalPid captures.
+        // A closure capturing a declared-actor's pid is accepted; only Duplex
+        // (lambda-actor handles) is refused.
         let output = check_source(
             r"
             actor Counter {
@@ -991,7 +991,7 @@ mod for_loop_iterable_fail_closed {
                 .errors
                 .iter()
                 .any(|e| matches!(&e.kind, TypeErrorKind::ClosureCapturesDuplexHandle { .. })),
-            "pid (ActorRef) captures must NOT trip ClosureCapturesDuplexHandle; got: {:#?}",
+            "LocalPid captures must NOT trip ClosureCapturesDuplexHandle; got: {:#?}",
             output.errors
         );
     }

--- a/hew-types/src/check/tests/generics.rs
+++ b/hew-types/src/check/tests/generics.rs
@@ -907,10 +907,10 @@ actor Greeter {
 fn actor_ref_cycle_warning_uses_first_actor_decl_span() {
     let source = concat!(
         "actor Alpha {\n",
-        "    let beta: ActorRef<Beta>;\n",
+        "    let beta: LocalPid<Beta>;\n",
         "}\n",
         "actor Beta {\n",
-        "    let alpha: ActorRef<Alpha>;\n",
+        "    let alpha: LocalPid<Alpha>;\n",
         "}\n",
         "fn main() {}\n",
     );
@@ -1124,7 +1124,7 @@ fn recursive_value_type_allows_pointer_self_reference() {
 }
 
 #[test]
-fn typecheck_await_actor_ref_returns_unit() {
+fn typecheck_await_local_pid_returns_unit() {
     let output = check_source(
         r#"
         actor Greeter {
@@ -1183,13 +1183,13 @@ fn named_actor_receive_dispatch_reports_bad_arg_once() {
 }
 
 #[test]
-fn typecheck_await_close_actor_ref() {
+fn typecheck_await_close_local_pid() {
     let mut checker = Checker::new(ModuleRegistry::new(vec![]));
     checker.register_builtins();
 
     checker.env.define(
         "g".to_string(),
-        Ty::actor_ref(Ty::Named {
+        Ty::local_pid(Ty::Named {
             builtin: None,
             name: "Greeter".to_string(),
             args: vec![],
@@ -1221,17 +1221,17 @@ fn typecheck_await_close_actor_ref() {
 }
 
 #[test]
-fn typecheck_await_close_lambda_actor() {
+fn typecheck_await_close_local_pid_worker() {
     let mut checker = Checker::new(ModuleRegistry::new(vec![]));
     checker.register_builtins();
 
     checker.env.define(
         "worker".to_string(),
-        Ty::Named {
-            builtin: Some(crate::BuiltinType::Actor),
-            name: "Actor".to_string(),
-            args: vec![Ty::I64],
-        },
+        Ty::local_pid(Ty::Named {
+            builtin: None,
+            name: "Worker".to_string(),
+            args: vec![],
+        }),
         false,
     );
 

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -337,7 +337,7 @@ pub struct TypeCheckOutput {
     ///
     /// Keyed by the `SpanKey` of the field-access expression (e.g. the span of
     /// `app.cache` in `app.cache.query(req)`). Populated during type-checking
-    /// of field-access expressions whose object resolves to an `ActorRef<S>`
+    /// of field-access expressions whose object resolves to a `LocalPid<S>`
     /// where `S` is a known supervisor type.
     ///
     /// The `index` field is the position of the child within its own slot space:

--- a/hew-types/src/cycle.rs
+++ b/hew-types/src/cycle.rs
@@ -1,6 +1,6 @@
 //! Compile-time detection of actor reference cycles.
 //!
-//! Builds a directed graph of actor-to-actor references via `ActorRef<X>`
+//! Builds a directed graph of actor-to-actor references via `LocalPid<X>`
 //! fields and runs Tarjan's SCC algorithm to find strongly connected
 //! components (cycles). Actors in cycles are returned as "cycle-capable"
 //! so the runtime can selectively enable cycle scanning for them.
@@ -505,7 +505,7 @@ fn is_value_type_node(td: &TypeDef) -> bool {
         )
 }
 
-/// Recursively collect actor names referenced via `ActorRef<X>` in a type,
+/// Recursively collect actor names referenced via `LocalPid<X>` in a type,
 /// looking through containers (`Vec`, `Array`, `Slice`, `Tuple`, `Option`,
 /// `Result`, `HashMap`) and transitively through struct fields.
 fn collect_actor_refs<'a>(
@@ -528,11 +528,8 @@ fn collect_actor_refs<'a>(
             args,
             builtin,
         } => {
-            if matches!(
-                builtin,
-                Some(crate::BuiltinType::ActorRef | crate::BuiltinType::LocalPid)
-            ) {
-                // ActorRef<X> / LocalPid<X> — record X if it's a known actor
+            if matches!(builtin, Some(crate::BuiltinType::LocalPid)) {
+                // LocalPid<X> — record X if it's a known actor
                 if let Some(Ty::Named {
                     name: actor_name, ..
                 }) = args.first()
@@ -569,7 +566,7 @@ fn collect_actor_refs<'a>(
                         }
                     }
                 }
-                // Also check type arguments (e.g. Vec<ActorRef<B>>)
+                // Also check type arguments (e.g. Vec<LocalPid<B>>)
                 for arg in args {
                     collect_actor_refs(arg, type_defs, out, visited_structs);
                 }
@@ -697,8 +694,8 @@ mod tests {
         )
     }
 
-    fn actor_ref(name: &str) -> Ty {
-        Ty::actor_ref(Ty::Named {
+    fn local_pid(name: &str) -> Ty {
+        Ty::local_pid(Ty::Named {
             builtin: None,
             name: name.to_string(),
             args: vec![],
@@ -761,8 +758,8 @@ mod tests {
     fn no_cycles_linear() {
         // A -> B -> C (no cycle)
         let type_defs: HashMap<String, TypeDef> = [
-            make_actor("A", HashMap::from([("b".to_string(), actor_ref("B"))])),
-            make_actor("B", HashMap::from([("c".to_string(), actor_ref("C"))])),
+            make_actor("A", HashMap::from([("b".to_string(), local_pid("B"))])),
+            make_actor("B", HashMap::from([("c".to_string(), local_pid("C"))])),
             make_actor("C", HashMap::from([("x".to_string(), Ty::I32)])),
         ]
         .into_iter()
@@ -918,10 +915,10 @@ mod tests {
 
     #[test]
     fn simple_two_actor_cycle() {
-        // A has ActorRef<B>, B has ActorRef<A>
+        // A has LocalPid<B>, B has LocalPid<A>
         let type_defs: HashMap<String, TypeDef> = [
-            make_actor("A", HashMap::from([("b".to_string(), actor_ref("B"))])),
-            make_actor("B", HashMap::from([("a".to_string(), actor_ref("A"))])),
+            make_actor("A", HashMap::from([("b".to_string(), local_pid("B"))])),
+            make_actor("B", HashMap::from([("a".to_string(), local_pid("A"))])),
         ]
         .into_iter()
         .collect();
@@ -934,10 +931,10 @@ mod tests {
 
     #[test]
     fn self_referential() {
-        // A has ActorRef<A>
+        // A has LocalPid<A>
         let type_defs: HashMap<String, TypeDef> = [make_actor(
             "A",
-            HashMap::from([("me".to_string(), actor_ref("A"))]),
+            HashMap::from([("me".to_string(), local_pid("A"))]),
         )]
         .into_iter()
         .collect();
@@ -949,7 +946,7 @@ mod tests {
 
     #[test]
     fn transitive_through_struct() {
-        // A has field of struct S, S has ActorRef<B>, B has ActorRef<A>
+        // A has field of struct S, S has LocalPid<B>, B has LocalPid<A>
         let type_defs: HashMap<String, TypeDef> = [
             make_actor(
                 "A",
@@ -962,8 +959,8 @@ mod tests {
                     },
                 )]),
             ),
-            make_struct("S", HashMap::from([("b".to_string(), actor_ref("B"))])),
-            make_actor("B", HashMap::from([("a".to_string(), actor_ref("A"))])),
+            make_struct("S", HashMap::from([("b".to_string(), local_pid("B"))])),
+            make_actor("B", HashMap::from([("a".to_string(), local_pid("A"))])),
         ]
         .into_iter()
         .collect();
@@ -976,13 +973,13 @@ mod tests {
 
     #[test]
     fn through_option() {
-        // A has Option<ActorRef<B>>, B has ActorRef<A>
+        // A has Option<LocalPid<B>>, B has LocalPid<A>
         let type_defs: HashMap<String, TypeDef> = [
             make_actor(
                 "A",
-                HashMap::from([("b".to_string(), Ty::option(actor_ref("B")))]),
+                HashMap::from([("b".to_string(), Ty::option(local_pid("B")))]),
             ),
-            make_actor("B", HashMap::from([("a".to_string(), actor_ref("A"))])),
+            make_actor("B", HashMap::from([("a".to_string(), local_pid("A"))])),
         ]
         .into_iter()
         .collect();
@@ -994,8 +991,8 @@ mod tests {
 
     #[test]
     fn through_vec_named_type() {
-        // A has Vec<ActorRef<B>> (as Named { name: "Vec", args: [ActorRef<B>] })
-        // B has ActorRef<A>
+        // A has Vec<LocalPid<B>> (as Named { name: "Vec", args: [LocalPid<B>] })
+        // B has LocalPid<A>
         let type_defs: HashMap<String, TypeDef> = [
             make_actor(
                 "A",
@@ -1004,11 +1001,11 @@ mod tests {
                     Ty::Named {
                         builtin: None,
                         name: "Vec".to_string(),
-                        args: vec![actor_ref("B")],
+                        args: vec![local_pid("B")],
                     },
                 )]),
             ),
-            make_actor("B", HashMap::from([("a".to_string(), actor_ref("A"))])),
+            make_actor("B", HashMap::from([("a".to_string(), local_pid("A"))])),
         ]
         .into_iter()
         .collect();
@@ -1020,13 +1017,13 @@ mod tests {
 
     #[test]
     fn through_array() {
-        // A has [ActorRef<B>; 3], B has ActorRef<A>
+        // A has [LocalPid<B>; 3], B has LocalPid<A>
         let type_defs: HashMap<String, TypeDef> = [
             make_actor(
                 "A",
-                HashMap::from([("bs".to_string(), Ty::Array(Box::new(actor_ref("B")), 3))]),
+                HashMap::from([("bs".to_string(), Ty::Array(Box::new(local_pid("B")), 3))]),
             ),
-            make_actor("B", HashMap::from([("a".to_string(), actor_ref("A"))])),
+            make_actor("B", HashMap::from([("a".to_string(), local_pid("A"))])),
         ]
         .into_iter()
         .collect();
@@ -1040,9 +1037,9 @@ mod tests {
     fn three_actor_cycle() {
         // A -> B -> C -> A
         let type_defs: HashMap<String, TypeDef> = [
-            make_actor("A", HashMap::from([("b".to_string(), actor_ref("B"))])),
-            make_actor("B", HashMap::from([("c".to_string(), actor_ref("C"))])),
-            make_actor("C", HashMap::from([("a".to_string(), actor_ref("A"))])),
+            make_actor("A", HashMap::from([("b".to_string(), local_pid("B"))])),
+            make_actor("B", HashMap::from([("c".to_string(), local_pid("C"))])),
+            make_actor("C", HashMap::from([("a".to_string(), local_pid("A"))])),
         ]
         .into_iter()
         .collect();
@@ -1058,9 +1055,9 @@ mod tests {
     fn mixed_cycle_and_no_cycle() {
         // A <-> B cycle, C -> D no cycle
         let type_defs: HashMap<String, TypeDef> = [
-            make_actor("A", HashMap::from([("b".to_string(), actor_ref("B"))])),
-            make_actor("B", HashMap::from([("a".to_string(), actor_ref("A"))])),
-            make_actor("C", HashMap::from([("d".to_string(), actor_ref("D"))])),
+            make_actor("A", HashMap::from([("b".to_string(), local_pid("B"))])),
+            make_actor("B", HashMap::from([("a".to_string(), local_pid("A"))])),
+            make_actor("C", HashMap::from([("d".to_string(), local_pid("D"))])),
             make_actor("D", HashMap::from([("x".to_string(), Ty::I32)])),
         ]
         .into_iter()
@@ -1076,7 +1073,7 @@ mod tests {
 
     #[test]
     fn struct_without_actor_ref_no_false_positive() {
-        // A has struct S with only i32 fields, no ActorRef
+        // A has struct S with only i32 fields, no LocalPid
         let type_defs: HashMap<String, TypeDef> = [
             make_actor(
                 "A",
@@ -1110,7 +1107,7 @@ mod tests {
                 bounds: HashMap::new(),
                 fields: HashMap::from([(
                     "target".to_string(),
-                    Ty::actor_ref(Ty::Named {
+                    Ty::local_pid(Ty::Named {
                         builtin: None,
                         name: "T".to_string(),
                         args: vec![],
@@ -1140,7 +1137,7 @@ mod tests {
                     },
                 )]),
             ),
-            make_actor("B", HashMap::from([("a".to_string(), actor_ref("A"))])),
+            make_actor("B", HashMap::from([("a".to_string(), local_pid("A"))])),
         ]
         .into_iter()
         .collect();
@@ -1157,7 +1154,7 @@ mod tests {
         // Regression for dedup-by-bare-name: prior code keyed visited_structs
         // on `"Wrapper"` alone, so the second encounter of `Wrapper<_>` was
         // skipped *within a single traversal*. With args-dependent substitution
-        // that meant ActorRef<C> was never recorded. Key is now (name, args)
+        // that meant LocalPid<C> was never recorded. Key is now (name, args)
         // so both instantiations are followed.
         //
         // The two `Wrapper<_>` instantiations MUST share a single
@@ -1172,7 +1169,7 @@ mod tests {
                 bounds: HashMap::new(),
                 fields: HashMap::from([(
                     "target".to_string(),
-                    Ty::actor_ref(Ty::Named {
+                    Ty::local_pid(Ty::Named {
                         builtin: None,
                         name: "T".to_string(),
                         args: vec![],
@@ -1214,7 +1211,7 @@ mod tests {
                 )]),
             ),
             make_actor("B", HashMap::new()),
-            make_actor("C", HashMap::from([("a".to_string(), actor_ref("A"))])),
+            make_actor("C", HashMap::from([("a".to_string(), local_pid("A"))])),
         ]
         .into_iter()
         .collect();
@@ -1223,7 +1220,7 @@ mod tests {
 
         // A→Wrapper<C>→C→A cycle must be detected. Before the fix, the
         // Tuple traversal visited Wrapper<B> first, poisoning the bare-name
-        // key and skipping Wrapper<C>, so ActorRef<C> was never recorded
+        // key and skipping Wrapper<C>, so LocalPid<C> was never recorded
         // and no cycle was found.
         assert!(capable.contains("A"));
         assert!(capable.contains("C"));

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -559,7 +559,7 @@ pub enum TypeErrorKind {
     UseAfterMove,
     /// Yield used outside a generator function
     YieldOutsideGenerator,
-    /// Actor types form a reference cycle via `ActorRef` fields
+    /// Actor types form a reference cycle via `LocalPid` fields
     ActorRefCycle,
     /// A value-typed enum/record/struct contains itself by value, directly or
     /// through another inline value type, making its layout infinitely sized.

--- a/hew-types/src/method_resolution.rs
+++ b/hew-types/src/method_resolution.rs
@@ -89,18 +89,18 @@ fn named_receiver_parts(ty: &Ty) -> Option<(&str, &[Ty])> {
         Ty::Bytes => Some(("bytes", &[])),
         Ty::CancellationToken => Some(("CancellationToken", &[])),
         Ty::Duration => Some(("duration", &[])),
-        // ActorRef<T>/LocalPid<T> wrap an actor type T.
+        // LocalPid<T> wraps an actor type T.
         // RemotePid<T> is intentionally NOT unwrapped here: its methods are
         // resolved against RemotePid itself, not T.
         //
-        // NOTE: `collect_method_sigs_for_receiver` handles LocalPid/ActorRef
-        // specially (collecting own handle methods + actor receive handlers)
-        // and does NOT call this helper for those types. This arm covers the
-        // single-method `lookup_method_sig` path used by the checker's fallback
-        // for actor receive-fn dispatch — it unwraps to T so e.g.
-        // `pid.increment(arg)` resolves against `Counter::increment` in fn_sigs.
+        // NOTE: `collect_method_sigs_for_receiver` handles LocalPid specially
+        // (collecting own handle methods + actor receive handlers) and does NOT
+        // call this helper for that type. This arm covers the single-method
+        // `lookup_method_sig` path used by the checker's fallback for actor
+        // receive-fn dispatch — it unwraps to T so e.g. `pid.increment(arg)`
+        // resolves against `Counter::increment` in fn_sigs.
         Ty::Named {
-            builtin: Some(BuiltinType::ActorRef | BuiltinType::LocalPid),
+            builtin: Some(BuiltinType::LocalPid),
             args,
             ..
         } if args.len() == 1 => named_receiver_parts(&args[0]),
@@ -246,9 +246,9 @@ pub fn lookup_type_def(type_defs: &HashMap<String, TypeDef>, type_name: &str) ->
 
 /// Look up the type definition for a named receiver.
 ///
-/// Returns `None` for `LocalPid<T>` and `ActorRef<T>`: actor-handle types do
-/// not expose the actor's internal fields to callers. Method completions on
-/// handles come from `collect_method_sigs_for_receiver` instead.
+/// Returns `None` for `LocalPid<T>`: actor-handle types do not expose the
+/// actor's internal fields to callers. Method completions on handles come
+/// from `collect_method_sigs_for_receiver` instead.
 #[must_use]
 pub fn lookup_type_def_for_receiver(
     type_defs: &HashMap<String, TypeDef>,
@@ -256,7 +256,7 @@ pub fn lookup_type_def_for_receiver(
 ) -> Option<TypeDef> {
     // Actor handles have no public fields accessible via the handle.
     if let Ty::Named {
-        builtin: Some(BuiltinType::LocalPid | BuiltinType::ActorRef),
+        builtin: Some(BuiltinType::LocalPid),
         ..
     } = receiver_ty
     {
@@ -330,13 +330,13 @@ pub fn collect_method_sigs_for_named_type(
 
 /// Collect all method signatures visible on a receiver type.
 ///
-/// For `LocalPid<T>` and `ActorRef<T>`, this produces two groups:
+/// For `LocalPid<T>`, this produces two groups:
 /// 1. The handle's own impl methods (`tell`, `to_remote_via`, etc.) registered
-///    in `fn_sigs` as `"LocalPid::{method}"` / `"ActorRef::{method}"`.
+///    in `fn_sigs` as `"LocalPid::{method}"`.
 /// 2. The actor's receive handlers (the methods callers can dispatch to via the
 ///    handle), resolved against the inner actor type T.
 ///
-/// This two-group collection is why the handle types are NOT unwrapped through
+/// This two-group collection is why the handle type is NOT unwrapped through
 /// `named_receiver_parts` for this call path — the checker's own `LocalPid` arm
 /// in `methods.rs` handles the dispatch logic; this path drives LSP completions.
 #[must_use]
@@ -353,11 +353,6 @@ pub fn collect_method_sigs_for_receiver(
             args,
             ..
         } if args.len() == 1 => Some(("LocalPid", &args[0])),
-        Ty::Named {
-            builtin: Some(BuiltinType::ActorRef),
-            args,
-            ..
-        } if args.len() == 1 => Some(("ActorRef", &args[0])),
         _ => None,
     };
 

--- a/hew-types/src/runtime_calling_convention.rs
+++ b/hew-types/src/runtime_calling_convention.rs
@@ -128,7 +128,7 @@ pub enum RuntimeCallingConvention {
     /// [`Ty::Named`] that is a **proven** heap-handle nominal
     /// — that is, a name whose resolved
     /// [`TypeDef::is_indirect`](crate::check::TypeDef) is
-    /// `true` (`Vec`, `HashMap`, `HashSet`, `ActorRef`, opaque
+    /// `true` (`Vec`, `HashMap`, `HashSet`, `LocalPid`, opaque
     /// handles like `net.Listener`, and any user `type T {}` whose
     /// `is_indirect` is `true`).
     ///

--- a/hew-types/src/stdlib.rs
+++ b/hew-types/src/stdlib.rs
@@ -111,16 +111,16 @@ pub fn vec_element_runtime_suffix<S: std::hash::BuildHasher>(
         crate::Ty::String => Some("string"),
         // Tuples lower through the layout-descriptor protocol.
         crate::Ty::Tuple(_) => Some("layout"),
-        // Local actor-handle builtins (`LocalPid<T>` / `ActorRef<T>` /
-        // `Actor<T>`) lower to a single pointer-shaped runtime word and their
-        // `Vec<T>` constructor routes to `hew_vec_new_ptr` in codegen. Classify
-        // them by the `builtin` discriminant — NOT the `TypeDef.is_indirect`
-        // field, which these builtins leave `false` — so the element ops route
-        // to the `hew_vec_*_ptr` family and agree with the constructor. Missing
-        // this arm sent them to `"layout"`, which built a null-layout vec via
-        // `hew_vec_new_ptr` and then pushed via `hew_vec_push_layout`, tripping
-        // the runtime "layout-aware operation is not implemented" abort
-        // (constructor-vs-push authority split).
+        // The local actor-handle builtin (`LocalPid<T>`) lowers to a single
+        // pointer-shaped runtime word and its `Vec<T>` constructor routes to
+        // `hew_vec_new_ptr` in codegen. Classify it by the `builtin`
+        // discriminant — NOT the `TypeDef.is_indirect` field, which this builtin
+        // leaves `false` — so the element ops route to the `hew_vec_*_ptr`
+        // family and agree with the constructor. Routing it to `"layout"`
+        // instead would build a null-layout vec via `hew_vec_new_ptr` and then
+        // push via `hew_vec_push_layout`, tripping the runtime "layout-aware
+        // operation is not implemented" abort (constructor-vs-push authority
+        // split).
         crate::Ty::Named {
             builtin: Some(b), ..
         } if b.lowers_as_pointer_vec_element() => Some("ptr"),

--- a/hew-types/src/traits.rs
+++ b/hew-types/src/traits.rs
@@ -365,11 +365,10 @@ impl TraitRegistry {
                     RcFreeStatus::ContainsRc
                 }
             }
-            // ActorRef<T>/LocalPid<T>/RemotePid<T> are opaque identity references;
+            // LocalPid<T>/RemotePid<T> are opaque identity references;
             // their T parameter is phantom for rc-free structural checks.
             Ty::Named {
-                builtin:
-                    Some(BuiltinType::ActorRef | BuiltinType::LocalPid | BuiltinType::RemotePid),
+                builtin: Some(BuiltinType::LocalPid | BuiltinType::RemotePid),
                 ..
             } => RcFreeStatus::RcFree,
             // Heap-indirecting collections (`Vec`/`HashMap`/`HashSet`): the
@@ -665,7 +664,7 @@ impl TraitRegistry {
     /// Marker traits are derived automatically based on the structure of the type:
     /// - Primitives implement most marker traits
     /// - Composite types implement a trait if all their components do
-    /// - `ActorRef` is always `Send` and `Frozen`
+    /// - `LocalPid`/`RemotePid` are always `Send` and `Frozen`
     /// - Negative impls can override automatic derivation
     #[must_use]
     pub fn implements_marker(&self, ty: &Ty, marker: MarkerTrait) -> bool {
@@ -791,22 +790,9 @@ impl TraitRegistry {
                     | MarkerTrait::Resource
             ),
 
-            // ActorRef: always Send + Sync + Frozen + Copy (identity reference)
-            Ty::Named {
-                builtin: Some(BuiltinType::ActorRef),
-                ..
-            } => matches!(
-                marker,
-                MarkerTrait::Send
-                    | MarkerTrait::Sync
-                    | MarkerTrait::Frozen
-                    | MarkerTrait::Copy
-                    | MarkerTrait::Clone
-                    | MarkerTrait::Debug
-            ),
-
             // LocalPid<T>: process-local actor pid returned by `spawn`.
-            // Same marker set as ActorRef — an opaque identity reference, not a resource.
+            // An opaque identity reference, not a resource: Send + Sync + Frozen
+            // + Copy + Clone + Debug.
             Ty::Named {
                 builtin: Some(BuiltinType::LocalPid),
                 ..
@@ -833,16 +819,6 @@ impl TraitRegistry {
                     | MarkerTrait::Copy
                     | MarkerTrait::Clone
                     | MarkerTrait::Debug
-            ),
-
-            // Actor<T>: the built-in lambda-actor handle; always Send + Sync + Clone + Debug.
-            // Actor references are channel handles — safe to capture in spawned actors.
-            Ty::Named {
-                builtin: Some(BuiltinType::Actor),
-                ..
-            } => matches!(
-                marker,
-                MarkerTrait::Send | MarkerTrait::Sync | MarkerTrait::Clone | MarkerTrait::Debug
             ),
 
             // Stream<T> and Sink<T>: Send/Sync iff T: Send; NOT Clone, Copy, or Frozen (move-only)
@@ -1283,32 +1259,6 @@ mod tests {
     }
 
     #[test]
-    fn test_actor_ref_is_send_and_frozen() {
-        let registry = TraitRegistry::new();
-        let actor_ref = Ty::actor_ref(Ty::Named {
-            builtin: None,
-            name: "MyActor".to_string(),
-            args: vec![],
-        });
-        assert!(registry.is_send(&actor_ref));
-        assert!(registry.is_frozen(&actor_ref));
-    }
-
-    #[test]
-    fn test_actor_handle_is_send() {
-        // Actor<T> (the lambda actor handle returned by spawn) must be Send so it can
-        // be captured inside another spawned actor (pipeline pattern).
-        let registry = TraitRegistry::new();
-        let actor_int = Ty::Named {
-            builtin: Some(BuiltinType::Actor),
-            name: "Actor".to_string(),
-            args: vec![Ty::I32],
-        };
-        assert!(registry.is_send(&actor_int));
-        assert!(registry.is_sync(&actor_int));
-    }
-
-    #[test]
     fn test_tuple_send_if_all_elements_send() {
         let registry = TraitRegistry::new();
         let tuple = Ty::Tuple(vec![Ty::I32, Ty::Bool]);
@@ -1475,17 +1425,6 @@ mod tests {
     }
 
     #[test]
-    fn test_actor_ref_is_sync() {
-        let registry = TraitRegistry::new();
-        let actor_ref = Ty::actor_ref(Ty::Named {
-            builtin: None,
-            name: "MyActor".to_string(),
-            args: vec![],
-        });
-        assert!(registry.is_sync(&actor_ref));
-    }
-
-    #[test]
     fn test_vec_is_send_when_element_is_send() {
         let registry = TraitRegistry::new();
         let vec_i32 = Ty::Named {
@@ -1579,31 +1518,31 @@ mod tests {
     }
 
     #[test]
-    fn actorref_with_rc_bearing_actor_is_rc_free() {
+    fn local_pid_with_rc_bearing_actor_is_rc_free() {
         let mut registry = TraitRegistry::new();
         registry.register_rcfree_members("Worker".to_string(), vec![Ty::rc(Ty::I32)]);
-        let actor_ref = Ty::actor_ref(Ty::Named {
+        let handle = Ty::local_pid(Ty::Named {
             builtin: None,
             name: "Worker".to_string(),
             args: vec![],
         });
 
-        assert_eq!(registry.rc_free_status(&actor_ref), RcFreeStatus::RcFree);
-        assert!(registry.implements_marker(&actor_ref, MarkerTrait::RcFree));
+        assert_eq!(registry.rc_free_status(&handle), RcFreeStatus::RcFree);
+        assert!(registry.implements_marker(&handle, MarkerTrait::RcFree));
     }
 
     #[test]
-    fn actorref_simple_is_rc_free() {
+    fn local_pid_simple_is_rc_free() {
         let mut registry = TraitRegistry::new();
         registry.register_rcfree_members("SimpleActor".to_string(), vec![Ty::I32, Ty::Bool]);
-        let actor_ref = Ty::actor_ref(Ty::Named {
+        let handle = Ty::local_pid(Ty::Named {
             builtin: None,
             name: "SimpleActor".to_string(),
             args: vec![],
         });
 
-        assert_eq!(registry.rc_free_status(&actor_ref), RcFreeStatus::RcFree);
-        assert!(registry.implements_marker(&actor_ref, MarkerTrait::RcFree));
+        assert_eq!(registry.rc_free_status(&handle), RcFreeStatus::RcFree);
+        assert!(registry.implements_marker(&handle, MarkerTrait::RcFree));
     }
 
     #[test]
@@ -1620,7 +1559,7 @@ mod tests {
     }
 
     #[test]
-    fn mutual_actorref_cycle_is_rc_free_not_recursive() {
+    fn mutual_local_pid_cycle_is_rc_free_not_recursive() {
         let mut registry = TraitRegistry::new();
         let a = Ty::Named {
             builtin: None,
@@ -1632,11 +1571,11 @@ mod tests {
             name: "B".to_string(),
             args: vec![],
         };
-        registry.register_rcfree_members("A".to_string(), vec![Ty::actor_ref(b.clone())]);
-        registry.register_rcfree_members("B".to_string(), vec![Ty::actor_ref(a.clone())]);
+        registry.register_rcfree_members("A".to_string(), vec![Ty::local_pid(b.clone())]);
+        registry.register_rcfree_members("B".to_string(), vec![Ty::local_pid(a.clone())]);
 
-        let a_ref = Ty::actor_ref(a);
-        let b_ref = Ty::actor_ref(b);
+        let a_ref = Ty::local_pid(a);
+        let b_ref = Ty::local_pid(b);
 
         assert_eq!(registry.rc_free_status(&a_ref), RcFreeStatus::RcFree);
         assert_eq!(registry.rc_free_status(&b_ref), RcFreeStatus::RcFree);

--- a/hew-types/src/ty.rs
+++ b/hew-types/src/ty.rs
@@ -33,15 +33,12 @@ fn builtin_named_type_from_builtin(builtin: Option<BuiltinType>) -> Option<Built
             | BuiltinType::Vec
             | BuiltinType::HashMap
             | BuiltinType::HashSet
-            | BuiltinType::ActorRef
-            | BuiltinType::Actor
             | BuiltinType::Task
             | BuiltinType::StreamPair
             | BuiltinType::Generator
             | BuiltinType::AsyncGenerator
             | BuiltinType::Range
             | BuiltinType::Rc
-            | BuiltinType::Pid
             | BuiltinType::HewActor
             | BuiltinType::HewDuplex
             | BuiltinType::HewSendHalf
@@ -803,12 +800,6 @@ impl Ty {
         Self::builtin_named(BuiltinType::Result, vec![ok, err])
     }
 
-    /// Construct `ActorRef<inner>`.
-    #[must_use]
-    pub fn actor_ref(inner: Ty) -> Ty {
-        Self::builtin_named(BuiltinType::ActorRef, vec![inner])
-    }
-
     /// Construct `LocalPid<inner>` — actor pid in this process, returned by `spawn`.
     #[must_use]
     pub fn local_pid(inner: Ty) -> Ty {
@@ -1045,19 +1036,6 @@ impl Ty {
         }
     }
 
-    /// If this is `ActorRef<T>`, return `Some(&T)`.
-    #[must_use]
-    pub fn as_actor_ref(&self) -> Option<&Ty> {
-        match self {
-            Ty::Named {
-                builtin: Some(BuiltinType::ActorRef),
-                args,
-                ..
-            } if args.len() == 1 => Some(&args[0]),
-            _ => None,
-        }
-    }
-
     /// If this is `LocalPid<T>`, return `Some(&T)`.
     #[must_use]
     pub fn as_local_pid(&self) -> Option<&Ty> {
@@ -1084,10 +1062,10 @@ impl Ty {
         }
     }
 
-    /// If this is a local actor handle (`ActorRef<T>`, `Actor<T>`, or `LocalPid<T>`), return `Some(&T)`.
+    /// If this is a local actor handle (`LocalPid<T>`), return `Some(&T)`.
     ///
-    /// `LocalPid<T>` is the default spawn-return type. `ActorRef<T>` remains
-    /// recognized for legacy local references. `RemotePid<T>` is intentionally
+    /// `LocalPid<T>` is the spawn-return type and the single-argument carrier
+    /// of the `ActorDispatchLocal` role. `RemotePid<T>` is intentionally
     /// excluded — it is a distinct type that does not participate in the local
     /// supervisor graph.
     #[must_use]

--- a/hew-types/src/unify.rs
+++ b/hew-types/src/unify.rs
@@ -271,33 +271,11 @@ pub fn unify(subst: &mut Substitution, a: &Ty, b: &Ty) -> Result<(), UnifyError>
             unify(subst, ar, br)
         }
 
-        // Named types with same name — unify type args.
-        // ActorRef<T> ↔ ActorRef: typed and untyped actor refs are compatible.
-        // Both are representationally identical (actor pointers). Allow
-        // passing ActorRef<T> where ActorRef is expected, and vice versa.
-        (
-            Ty::Named {
-                builtin: ab,
-                args: aa,
-                ..
-            },
-            Ty::Named {
-                builtin: bb,
-                args: ba,
-                ..
-            },
-        ) if matches!(
-            ab,
-            Some(crate::BuiltinType::ActorRef | crate::BuiltinType::Actor)
-        ) && matches!(
-            bb,
-            Some(crate::BuiltinType::ActorRef | crate::BuiltinType::Actor)
-        ) && matches!((aa.len(), ba.len()), (0, 1) | (1, 0)) =>
-        {
-            Ok(())
-        }
-
-        // Also handles module-qualified names: "json.Value" matches "Value"
+        // Named types with same name — unify type args. Arity must match: a
+        // handle's type parameter is load-bearing, so `RemotePid<A>` only
+        // unifies with `RemotePid<A>` (and `RemotePid<A1>` ≠ `RemotePid<A2>`
+        // when `A1 != A2`). Also handles module-qualified names: "json.Value"
+        // matches "Value".
         (
             Ty::Named {
                 name: an, args: aa, ..
@@ -555,23 +533,59 @@ mod tests {
     }
 
     #[test]
-    fn test_typed_actor_ref_unifies_with_untyped() {
-        let typed = Ty::actor_ref(Ty::Named {
+    fn remote_pid_same_actor_unifies_distinct_actor_rejects() {
+        // The handle's type parameter is load-bearing: `RemotePid<A>` unifies
+        // only with `RemotePid<A>`, and two remote pids over different actors
+        // never unify. This is the sound generic-arm behaviour the checker
+        // depends on — a wrong-actor handle must surface a mismatch, never a
+        // silent accept that drops the type argument.
+        let actor_a = Ty::Named {
             builtin: None,
             name: "ClientHandler".to_string(),
             args: vec![],
-        });
-        let untyped = Ty::builtin_named(crate::BuiltinType::ActorRef, vec![]);
-        // Both directions should work
+        };
+        let actor_b = Ty::Named {
+            builtin: None,
+            name: "Supervisor".to_string(),
+            args: vec![],
+        };
+
         let mut subst = Substitution::new();
         assert!(
-            unify(&mut subst, &typed, &untyped).is_ok(),
-            "ActorRef<T> should unify with ActorRef"
+            unify(
+                &mut subst,
+                &Ty::remote_pid(actor_a.clone()),
+                &Ty::remote_pid(actor_a.clone()),
+            )
+            .is_ok(),
+            "RemotePid<A> must unify with RemotePid<A>"
         );
+
         let mut subst = Substitution::new();
         assert!(
-            unify(&mut subst, &untyped, &typed).is_ok(),
-            "ActorRef should unify with ActorRef<T>"
+            unify(
+                &mut subst,
+                &Ty::remote_pid(actor_a.clone()),
+                &Ty::remote_pid(actor_b),
+            )
+            .is_err(),
+            "RemotePid<A> must NOT unify with RemotePid<B> when A != B"
+        );
+
+        // A typed handle never collapses with a zero-arg same-name shadow:
+        // arity is enforced, so the dropped-type-argument hole stays closed.
+        let mut subst = Substitution::new();
+        let untyped = Ty::Named {
+            builtin: Some(crate::BuiltinType::RemotePid),
+            name: "RemotePid".to_string(),
+            args: vec![],
+        };
+        assert!(
+            matches!(
+                unify(&mut subst, &Ty::remote_pid(actor_a), &untyped),
+                Err(UnifyError::ArityMismatch { .. })
+            ),
+            "RemotePid<A> vs RemotePid (no arg) must be an arity mismatch"
         );
     }
 
@@ -700,16 +714,16 @@ mod tests {
     }
 
     #[test]
-    fn test_actor_ref_arity_mismatch_rejects_nonstandard_pairs() {
+    fn same_name_handle_arity_mismatch_rejects_nonstandard_pairs() {
         let mut subst = Substitution::new();
         let typed = Ty::Named {
             builtin: None,
-            name: "ActorRef".to_string(),
+            name: "RemotePid".to_string(),
             args: vec![Ty::I32, Ty::Bool],
         };
         let untyped = Ty::Named {
             builtin: None,
-            name: "ActorRef".to_string(),
+            name: "RemotePid".to_string(),
             args: vec![],
         };
 

--- a/hew-types/tests/actor_send_aliasing_metadata.rs
+++ b/hew-types/tests/actor_send_aliasing_metadata.rs
@@ -86,11 +86,11 @@ fn actor_send_aliasing_map_populated_for_copy_send() {
 }
 
 /// Receive-method dispatch through a *bare actor field* (typed as the
-/// actor name, e.g. `let target: Printer`, not `ActorRef<Printer>`) routes
-/// through `check_named_method_fallback` rather than the `ActorRef` path.
-/// That fallback used to skip `enforce_actor_boundary_send`, leaving the
-/// `actor_send_aliasing` map empty for those sites — a producer gap that
-/// blocks the codegen-side fail-closed lookup.
+/// actor name, e.g. `let target: Printer`, not `LocalPid<Printer>`) routes
+/// through `check_named_method_fallback` rather than the handle path.
+/// That fallback must run `enforce_actor_boundary_send` so the
+/// `actor_send_aliasing` map is populated for those sites — otherwise a
+/// producer gap blocks the codegen-side fail-closed lookup.
 ///
 /// This test pins the fix: every arg of a receive-method dispatch on a
 /// named-actor field must produce an entry in `actor_send_aliasing`.
@@ -126,7 +126,7 @@ fn actor_send_aliasing_records_named_actor_field_receive_dispatch() {
     // Four accepted send sites in this program:
     //   1. `amount: 10` arg in `spawn Adder(...)` (spawn args)
     //   2. `target: printer` arg in `spawn Adder(...)` (spawn args)
-    //   3. `adder.add(5)` from main (ActorRef receive dispatch)
+    //   3. `adder.add(5)` from main (LocalPid receive dispatch)
     //   4. `target.print_result(result)` from inside Adder::add (the
     //      named-actor field receive dispatch — the gap this test pins).
     //

--- a/hew-types/tests/link_monitor_sigs.rs
+++ b/hew-types/tests/link_monitor_sigs.rs
@@ -1,8 +1,8 @@
 //! Type-checker signature tests for `link(handle)` and `monitor(handle)`.
 //!
 //! B2 slice: pins that
-//!   - `link(actor_ref)` → `Result<(), LinkError>`
-//!   - `monitor(actor_ref)` → `MonitorRef`
+//!   - `link(handle)` → `Result<(), LinkError>`
+//!   - `monitor(handle)` → `MonitorRef`
 //!   - `link(non_actor)` → `TYPE_MISMATCH`
 //!   - `monitor(non_actor)` → `TYPE_MISMATCH`
 
@@ -120,7 +120,7 @@ fn monitor_ref_not_assignable_to_int() {
 
 #[test]
 fn link_non_actor_produces_mismatch() {
-    // `link` requires `ActorRef<_>`; passing a plain `i64` must be rejected.
+    // `link` requires `LocalPid<_>`; passing a plain `i64` must be rejected.
     let src = r"
 fn main() {
     let x: i64 = 42;
@@ -142,7 +142,7 @@ fn main() {
 
 #[test]
 fn monitor_non_actor_produces_mismatch() {
-    // `monitor` requires `ActorRef<_>`; passing a `string` must be rejected.
+    // `monitor` requires `LocalPid<_>`; passing a `string` must be rejected.
     let src = r#"
 fn main() {
     let s: string = "hello";

--- a/hew-types/tests/m3_surface_pid_types.rs
+++ b/hew-types/tests/m3_surface_pid_types.rs
@@ -43,7 +43,7 @@ fn spawn_returns_local_pid() {
         })
         .expect("no spawn expression in let");
     let key = hew_types::check::SpanKey::from(&spawn_span);
-    // spawn should produce LocalPid<Counter>, not ActorRef<Counter>.
+    // spawn should produce LocalPid<Counter>.
     // Scan all expr_types for any LocalPid entry if the exact span is off.
     let ty = output.expr_types.get(&key).cloned().unwrap_or_else(|| {
         output
@@ -111,10 +111,15 @@ fn remote_pid_is_send_sync_copy() {
     }
 }
 
-// ── Unification: LocalPid and ActorRef are distinct nominal types ─────────────
+// ── Unification: LocalPid and RemotePid are distinct nominal types ────────────
 
 #[test]
-fn localpid_actorref_no_longer_unify() {
+fn local_pid_and_remote_pid_do_not_unify() {
+    // The local and remote handle families are distinct nominal types over the
+    // same actor: a `LocalPid<T>` must never be accepted where a `RemotePid<T>`
+    // is expected, and vice versa. Their discriminators carry different ABI
+    // shapes (`*mut HewActor` vs a packed `i64`), so a silent unify would be a
+    // miscompile.
     use hew_types::ty::Substitution;
     use hew_types::unify::unify;
     let actor = Ty::Named {
@@ -123,46 +128,17 @@ fn localpid_actorref_no_longer_unify() {
         args: vec![],
     };
     let local_pid = Ty::local_pid(actor.clone());
-    let actor_ref = Ty::actor_ref(actor);
+    let remote_pid = Ty::remote_pid(actor);
 
     let mut subst = Substitution::new();
     assert!(
-        unify(&mut subst, &local_pid, &actor_ref).is_err(),
-        "LocalPid<T> must not unify with ActorRef<T>"
+        unify(&mut subst, &local_pid, &remote_pid).is_err(),
+        "LocalPid<T> must not unify with RemotePid<T>"
     );
     let mut subst = Substitution::new();
     assert!(
-        unify(&mut subst, &actor_ref, &local_pid).is_err(),
-        "ActorRef<T> must not unify with LocalPid<T>"
-    );
-}
-
-// ── Unification: RemotePid does NOT unify with ActorRef ──────────────────────
-
-#[test]
-fn remote_pid_does_not_unify_with_actor_ref() {
-    // RemotePid<T> must not be accepted where ActorRef<T> is expected.
-    // The test verifies the discriminator is preserved.
-    //
-    // We can't construct a RemotePid<T> at the Hew source level yet
-    // (from_raw requires SHIM wiring); test via the Rust type API instead.
-    use hew_types::ty::Substitution;
-    use hew_types::unify::unify;
-    let mut subst = Substitution::new();
-    let actor_ref = Ty::actor_ref(Ty::Named {
-        builtin: None,
-        name: "Counter".into(),
-        args: vec![],
-    });
-    let remote_pid = Ty::remote_pid(Ty::Named {
-        builtin: None,
-        name: "Counter".into(),
-        args: vec![],
-    });
-    let result = unify(&mut subst, &remote_pid, &actor_ref);
-    assert!(
-        result.is_err(),
-        "RemotePid<T> must NOT unify with ActorRef<T>; got Ok"
+        unify(&mut subst, &remote_pid, &local_pid).is_err(),
+        "RemotePid<T> must not unify with LocalPid<T>"
     );
 }
 

--- a/hew-types/tests/trait_coverage.rs
+++ b/hew-types/tests/trait_coverage.rs
@@ -174,10 +174,10 @@ fn string_is_not_frozen() {
 }
 
 #[test]
-fn actor_ref_is_frozen() {
+fn local_pid_is_frozen() {
     let reg = TraitRegistry::new();
-    let aref = Ty::actor_ref(named("MyActor"));
-    assert!(reg.is_frozen(&aref));
+    let pid = Ty::local_pid(named("MyActor"));
+    assert!(reg.is_frozen(&pid));
 }
 
 // ===========================================================================
@@ -749,17 +749,17 @@ fn method_sig_mutable_self() {
 }
 
 // ===========================================================================
-// ActorRef special handling
+// Actor-handle marker traits
 // ===========================================================================
 
 #[test]
-fn actor_ref_is_copy_clone_debug() {
+fn local_pid_is_copy_clone_debug() {
     let reg = TraitRegistry::new();
-    let aref = Ty::actor_ref(named("Logger"));
-    assert!(reg.implements_marker(&aref, MarkerTrait::Copy));
-    assert!(reg.implements_marker(&aref, MarkerTrait::Clone));
-    assert!(reg.implements_marker(&aref, MarkerTrait::Debug));
-    assert!(!reg.implements_marker(&aref, MarkerTrait::Eq));
+    let pid = Ty::local_pid(named("Logger"));
+    assert!(reg.implements_marker(&pid, MarkerTrait::Copy));
+    assert!(reg.implements_marker(&pid, MarkerTrait::Clone));
+    assert!(reg.implements_marker(&pid, MarkerTrait::Debug));
+    assert!(!reg.implements_marker(&pid, MarkerTrait::Eq));
 }
 
 // ===========================================================================

--- a/hew-types/tests/ty_coverage.rs
+++ b/hew-types/tests/ty_coverage.rs
@@ -353,17 +353,12 @@ fn canonical_lowering_name_round_trips_through_from_name() {
 
 #[test]
 fn actor_handle_accessor() {
-    // ActorRef<T> is an actor handle
-    let ty = Ty::actor_ref(Ty::I32);
+    // LocalPid<T> is the local actor handle.
+    let ty = Ty::local_pid(Ty::I32);
     assert_eq!(ty.as_actor_handle(), Some(&Ty::I32));
 
-    // Actor<T> is also an actor handle
-    let actor = Ty::Named {
-        builtin: Some(hew_types::BuiltinType::Actor),
-        name: "Actor".to_string(),
-        args: vec![Ty::Bool],
-    };
-    assert_eq!(actor.as_actor_handle(), Some(&Ty::Bool));
+    // RemotePid<T> is a distinct remote handle — NOT a local actor handle.
+    assert_eq!(Ty::remote_pid(Ty::Bool).as_actor_handle(), None);
 
     // Non-actor returns None
     assert_eq!(Ty::I32.as_actor_handle(), None);
@@ -408,14 +403,15 @@ fn accessor_wrong_arity_returns_none() {
     };
     assert_eq!(bad_async_gen.as_async_generator(), None);
 
-    // ActorRef with wrong arity
-    let bad_actor = Ty::Named {
-        builtin: None,
-        name: "ActorRef".to_string(),
+    // LocalPid with wrong arity — the accessor's arity guard rejects it even
+    // when the builtin discriminator is stamped.
+    let bad_pid = Ty::Named {
+        builtin: Some(hew_types::BuiltinType::LocalPid),
+        name: "LocalPid".to_string(),
         args: vec![Ty::I32, Ty::Bool],
     };
-    assert_eq!(bad_actor.as_actor_ref(), None);
-    assert_eq!(bad_actor.as_actor_handle(), None);
+    assert_eq!(bad_pid.as_local_pid(), None);
+    assert_eq!(bad_pid.as_actor_handle(), None);
 
     // Stream/Sink with wrong arity
     let bad_stream = Ty::Named {

--- a/tests/vertical-slice/reject/actor_ref_unknown_type.hew
+++ b/tests/vertical-slice/reject/actor_ref_unknown_type.hew
@@ -1,0 +1,15 @@
+// Reject fixture: actor_ref_unknown_type — `ActorRef<T>` is not a known type.
+// The canonical actor-reference family is `LocalPid<A>` (in-process),
+// `RemotePid<A>` (cross-node), and `LambdaPid<M, R>` (lambda actors). Writing
+// `ActorRef<T>` as a type annotation resolves to an unknown type and fails
+// closed at the checker/MIR boundary rather than silently typechecking.
+//
+// Harness verb: hew check
+// Expected: rejected with `unknown type` for the unresolved `ActorRef` name.
+actor Greeter {
+    receive fn greet(name: string) {}
+}
+
+fn use_handle(g: ActorRef<Greeter>) {}
+
+fn main() {}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -724,6 +724,16 @@ expect_check_fail_contains \
     'cannot assign to immutable field `count`' \
     "actor_let_field_assign"
 
+# Reject: `ActorRef<T>` is not a known type. The canonical actor-reference
+# family is `LocalPid`/`RemotePid`/`LambdaPid`; an `ActorRef<T>` annotation
+# resolves to an unknown type and fails closed rather than silently
+# typechecking (closes the FND-14 dropped-type-argument hole at its source).
+# shellcheck disable=SC2016  # backticks in the pattern are Hew diagnostic syntax, not shell expansion
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/actor_ref_unknown_type.hew" \
+    'unknown type `ActorRef`' \
+    "actor_ref_unknown_type"
+
 # Reject: `ref.send(msg)` on a named actor with NO `receive fn send` handler is
 # rejected at the type-checker with an actionable UndefinedMethod diagnostic.
 # The anonymous-payload path has no lowerable mailbox slot; the checker now


### PR DESCRIPTION
## Summary

`ActorRef<T>`, `Actor`, and bare `Pid` are removed from the type system, HIR, MIR, codegen, sandbox, grammar, and editor keywords in favour of the canonical `LocalPid<A>` / `RemotePid<A>` / `LambdaPid<M,R>` actor-handle family. The deletion also closes a soundness hole: the actor-ref unify arm dropped the message-type argument when the arity didn't match, so a wrong-message `tell` on a typed actor handle would type-check silently. Deleting the arm closes it — `RemotePid<A>` rides the correct generic arm, and `RemotePid<A1>` no longer unifies with `RemotePid<A2>`.

## Verification

- `cargo test -p hew-types`: all actor, trait, and unify tests green; new oracle confirms `RemotePid<A1>` vs `RemotePid<A2>` = `Err`
- `cargo test -p hew-hir`: surface PID lowering and stdlib-catalog tests green
- `cargo test -p hew-mir`: state-clone classification tests green; checked-mir output byte-identical
- `cargo test -p hew-codegen-rs`: borrow-ABI and send-status fixtures migrated to `LocalPid`, green
- `make hew-check-all` + ratchet: full corpus green
- `tests/vertical-slice/reject/actor_ref_unknown_type.hew`: confirms `ActorRef<T>` in source now fails closed
- `cargo fmt --check` + `cargo clippy`: clean
- Preflight: ready-to-push

## Out of scope

No further actor-handle surface changes are in this PR. Future work on `LambdaPid` ergonomics and distributed `RemotePid` wire serialisation is tracked separately.
