### PR TITLE
fix(codegen): drop owned captures in the escaping closure-env free thunk

### DIFF
--- a/hew-cli/tests/closure_capture_owned_leak_oracle.rs
+++ b/hew-cli/tests/closure_capture_owned_leak_oracle.rs
@@ -1,0 +1,368 @@
+//! Constant-leak / double-free oracle for the closure-env KEYSTONE: an
+//! escaping (heap-boxed) closure that captures an OWNED value (`string`,
+//! `Vec`) must free that captured value EXACTLY once when the closure is
+//! dropped.
+//!
+//! ## What this proves
+//!
+//! A closure that escapes its introducing scope (returned, stored, passed to a
+//! higher-order callee) has its capture environment heap-boxed at the literal
+//! site: `[free_thunk: ptr][captures...]`. The captured owning value's handle
+//! is byte-copied into the captures region and the caller's own binding drop is
+//! suppressed (its local is read by the env `RecordInit` ingress → marked
+//! aliased → excluded from the kept-drop set), so the env becomes the SOLE
+//! owner of that handle.
+//!
+//! Before the keystone, the per-closure free thunk freed ONLY the box
+//! (`hew_dyn_box_free`) and never released the captured owning handle — every
+//! escaping closure that captured a runtime-built `string`/`Vec` leaked it (2
+//! leaks under `leaks --atExit`). The keystone wires the free thunk to drop
+//! each owned captured field through the canonical per-field drop authority
+//! (`emit_field_drop_step`) BEFORE freeing the box, so the captured value is
+//! released exactly once as the env's sole owner.
+//!
+//! The failure modes this oracle catches:
+//!   * a LEAK (the env frees the box but not the captured handle) — a `leaks`
+//!     node above the control floor (the pre-keystone bug);
+//!   * a SECOND owner (the caller binding AND the env both freeing the handle)
+//!     — a double-free that crashes under `MallocScribble`/`MallocGuardEdges`;
+//!   * an OVER-DROP corrupting a live value — a scribbled output / non-zero
+//!     exit.
+//!
+//! ## Methodology: absolute count against a no-capture control
+//!
+//! Each capturing fixture is measured under `leaks --atExit` with the
+//! poisoned-allocator triple and its absolute leak-node count is compared
+//! against a CONTROL program that builds the SAME owned value but does NOT
+//! capture it into an escaping closure — it builds the value, reads it, and
+//! lets the owned `let` binding drop at function scope (the already-correct
+//! local owned-value drop path). The control establishes the runtime's
+//! one-alloc/one-free floor; a correct escaping capture must sit at that SAME
+//! floor. Pre-keystone the capturing fixture sits ABOVE the floor (the leaked
+//! handle); post-keystone it matches within a tiny scheduler/runtime jitter
+//! tolerance.
+//!
+//! This is the floor-EQUALITY assertion the LESSONS `assert-distinguishes-
+//! garbage` / `drop-allowset-from-value-flow` rules call for, not a happy-path
+//! `> 0`.
+//!
+//! ## Skip behaviour
+//!
+//! `leaks(1)` is Darwin's allocator inspector; on non-macOS hosts the leak
+//! probes log `skip:` and return. The `MallocScribble` no-double-free pin runs
+//! on any unix host.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+/// Permitted leak-node delta between a capturing fixture and the no-capture
+/// control. A correct escaping capture frees the owned handle exactly once,
+/// matching the control's floor; the tolerance of 1 absorbs the +/-1
+/// scheduler/runtime one-off jitter the sibling leak oracles document. A
+/// pre-keystone leak stands one or more nodes above this floor.
+const FLOOR_TOLERANCE: usize = 1;
+
+// -- fixtures ----------------------------------------------------------------
+
+/// Control (string): build a runtime-concatenated owned `string`, read it, and
+/// let the owned `let` binding drop at function scope. No closure capture is
+/// involved — this is the already-correct local string drop path. It
+/// establishes the one-alloc/one-free floor the capturing fixture is measured
+/// against.
+const CONTROL_STRING_NO_CAPTURE_SOURCE: &str = "\
+fn build(n: i64) -> i64 {\n\
+\x20   let label = \"row:\" + to_string(n);\n\
+\x20   label.len()\n\
+}\n\
+\n\
+fn main() -> i64 {\n\
+\x20   let r = build(7);\n\
+\x20   if r != 5 { return 80; }\n\
+\x20   0\n\
+}\n";
+
+/// Test (string): a returned closure captures the runtime-built owned
+/// `string`. The closure escapes `make_label`, so its env is heap-boxed and
+/// the captured `label` handle is owned by the env. `make_label`'s own `label`
+/// drop is suppressed; the env's free thunk must release the captured `string`
+/// exactly once when the returned closure is dropped in `main`. Same
+/// one-alloc/one-free floor as the control.
+const RETURN_CLOSURE_CAPTURES_STRING_SOURCE: &str = "\
+fn make_label(n: i64) -> fn() -> i64 {\n\
+\x20   let label = \"row:\" + to_string(n);\n\
+\x20   || label.len()\n\
+}\n\
+\n\
+fn main() -> i64 {\n\
+\x20   let f = make_label(7);\n\
+\x20   let r = f();\n\
+\x20   if r != 5 { return 81; }\n\
+\x20   0\n\
+}\n";
+
+/// Control (Vec): build an owned `Vec<i64>`, read its length, and let the owned
+/// `let` binding drop at function scope. The already-correct local owned-Vec
+/// drop path; establishes the floor for the Vec-capture fixture.
+const CONTROL_VEC_NO_CAPTURE_SOURCE: &str = "\
+fn build() -> i64 {\n\
+\x20   var xs: Vec<i64> = Vec::new();\n\
+\x20   xs.push(10);\n\
+\x20   xs.push(20);\n\
+\x20   xs.len()\n\
+}\n\
+\n\
+fn main() -> i64 {\n\
+\x20   let r = build();\n\
+\x20   if r != 2 { return 82; }\n\
+\x20   0\n\
+}\n";
+
+/// Test (Vec): a returned closure captures the owned `Vec<i64>`. The closure
+/// escapes, its env is heap-boxed, and the captured `xs` handle is owned by the
+/// env. The free thunk must release the captured `Vec` exactly once at the
+/// returned closure's drop. Same floor as the control.
+const RETURN_CLOSURE_CAPTURES_VEC_SOURCE: &str = "\
+fn make_counter() -> fn() -> i64 {\n\
+\x20   var xs: Vec<i64> = Vec::new();\n\
+\x20   xs.push(10);\n\
+\x20   xs.push(20);\n\
+\x20   || xs.len()\n\
+}\n\
+\n\
+fn main() -> i64 {\n\
+\x20   let f = make_counter();\n\
+\x20   let r = f();\n\
+\x20   if r != 2 { return 83; }\n\
+\x20   0\n\
+}\n";
+
+// -- leak measurement plumbing (same shape as the sibling leak oracles) ------
+
+fn compile_to_native(source: &str, dir: &std::path::Path, name: &str) -> PathBuf {
+    let hew_src = dir.join(format!("{name}.hew"));
+    std::fs::write(&hew_src, source).expect("write hew source");
+
+    let output = Command::new(hew_binary())
+        .args([
+            "compile",
+            "--emit-dir",
+            dir.to_str().expect("emit-dir utf-8"),
+            hew_src.to_str().expect("hew src utf-8"),
+        ])
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew compile");
+
+    assert!(
+        output.status.success(),
+        "hew compile failed for {name}:\n{}",
+        describe_output(&output)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let bin = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("native: "))
+        .unwrap_or_else(|| panic!("no `native:` line for {name}:\n{stdout}"))
+        .to_string();
+    PathBuf::from(bin)
+}
+
+/// Run `bin` under the poisoned-allocator triple + `leaks --atExit` and return
+/// `Some(leak_count)` when `leaks` produced a usable report.
+fn measure_leaks(bin: &std::path::Path) -> Option<usize> {
+    let output = Command::new("leaks")
+        .arg("--atExit")
+        .arg("--")
+        .arg(bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .ok()?;
+    if !output.status.success() && output.stdout.is_empty() {
+        eprintln!(
+            "skip: leaks declined to attach to {}: {}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+    let report = String::from_utf8_lossy(&output.stdout);
+    let mut parsed: Option<usize> = None;
+    for line in report.lines() {
+        if !line.contains(" leaks for ") && !line.contains(" leak for ") {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("Process ") {
+            if !rest.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+                continue;
+            }
+            if let Some(after_colon) = rest.split_once(": ").map(|(_, s)| s) {
+                if let Some(n) = after_colon.split_whitespace().next() {
+                    if let Ok(n) = n.parse::<usize>() {
+                        eprintln!("  parsed leak count from line: {line}");
+                        parsed = Some(n);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    if parsed.is_none() {
+        eprintln!(
+            "skip: leaks did not emit a `Process <pid>: N leak(s) for B total leaked bytes.` \
+             summary for {}: stderr=\n{}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    parsed
+}
+
+/// macOS + `leaks(1)` availability guard shared by every leak probe.
+fn leaks_available(shape_name: &str) -> bool {
+    if !cfg!(target_os = "macos") {
+        eprintln!("skip: {shape_name}: leaks(1) is macOS-only");
+        return false;
+    }
+    let avail = Command::new("which")
+        .arg("leaks")
+        .output()
+        .is_ok_and(|o| o.status.success());
+    if !avail {
+        eprintln!("skip: {shape_name}: `leaks` binary not on PATH");
+    }
+    avail
+}
+
+/// Compile + measure `fixture` against `control` and assert the fixture sits at
+/// the control's allocation floor (within `FLOOR_TOLERANCE`). A leaked capture
+/// puts the fixture above the floor; a double-free crashes the fixture under
+/// the poisoned allocator before `leaks` reports.
+fn assert_capture_freed_once_at_floor(shape_name: &str, control: &str, fixture: &str) {
+    if !leaks_available(shape_name) {
+        return;
+    }
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("closure-capture-owned-leak-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+
+    let control_bin = compile_to_native(control, dir.path(), "control");
+    let fixture_bin = compile_to_native(fixture, dir.path(), shape_name);
+
+    let Some(control_leaks) = measure_leaks(&control_bin) else {
+        return;
+    };
+    let Some(fixture_leaks) = measure_leaks(&fixture_bin) else {
+        return;
+    };
+
+    eprintln!(
+        "{shape_name}: control_leaks={control_leaks} fixture_leaks={fixture_leaks} \
+         tolerance={FLOOR_TOLERANCE}"
+    );
+    assert!(
+        fixture_leaks <= control_leaks + FLOOR_TOLERANCE,
+        "{shape_name}: closure-captured owned value LEAKED -- the escaping-capture fixture \
+         leaked {fixture_leaks} nodes against the no-capture control's floor of {control_leaks} \
+         (tolerance {FLOOR_TOLERANCE}). An excess of {} nodes means the captured owning handle \
+         was byte-copied into the heap env but the env free thunk freed only the box, never the \
+         handle. Re-run with `MallocStackLogging=1 leaks --atExit -- {}` to see the leaked stack.",
+        fixture_leaks.saturating_sub(control_leaks + FLOOR_TOLERANCE),
+        fixture_bin.display()
+    );
+}
+
+/// Run `source` to native, execute under the poisoned-allocator triple, and
+/// assert exit 0. A crash here is a double-free (the caller binding AND the env
+/// both freeing the captured handle); a non-zero exit is a miscomputed read off
+/// a scribbled capture.
+fn assert_no_double_free(shape_name: &str, source: &str) {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!(
+            "closure-capture-owned-no-double-free-{shape_name}-"
+        ))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), shape_name);
+
+    let output = Command::new(&bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .expect("run no-double-free binary");
+
+    assert!(
+        output.status.success(),
+        "{shape_name}: escaping closure capture must free the owned value exactly once -- a \
+         crash here indicates a double-free: the caller binding freed the same handle the env \
+         now owns. The env must be the sole owner (the caller's scope-exit drop is suppressed by \
+         the aliased-local scan);\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{shape_name}: the captured value must read back correctly through the closure; a \
+         non-zero exit means a scribbled capture corrupted the read;\n{}",
+        describe_output(&output)
+    );
+}
+
+// -- oracles -----------------------------------------------------------------
+
+/// Keystone (string): a returned closure capturing a runtime-built owned
+/// `string` frees the captured handle exactly once at the closure's drop.
+/// Floor-equal with the no-capture control. Pre-keystone this leaked the
+/// captured string (the free thunk freed only the box).
+#[test]
+fn return_closure_captures_string_freed_once() {
+    assert_capture_freed_once_at_floor(
+        "return_closure_captures_string",
+        CONTROL_STRING_NO_CAPTURE_SOURCE,
+        RETURN_CLOSURE_CAPTURES_STRING_SOURCE,
+    );
+}
+
+/// Keystone (Vec): a returned closure capturing an owned `Vec<i64>` frees the
+/// captured handle exactly once at the closure's drop. Floor-equal with the
+/// no-capture control. Pre-keystone this leaked the captured Vec.
+#[test]
+fn return_closure_captures_vec_freed_once() {
+    assert_capture_freed_once_at_floor(
+        "return_closure_captures_vec",
+        CONTROL_VEC_NO_CAPTURE_SOURCE,
+        RETURN_CLOSURE_CAPTURES_VEC_SOURCE,
+    );
+}
+
+/// No-double-free pin (string): the escaping capture frees the owned `string`
+/// EXACTLY once. A second owner crashes under `MallocScribble`/
+/// `MallocGuardEdges`. Runs on any unix host.
+#[test]
+fn return_closure_captures_string_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free(
+        "string_no_double_free",
+        RETURN_CLOSURE_CAPTURES_STRING_SOURCE,
+    );
+}
+
+/// No-double-free pin (Vec): the escaping capture frees the owned `Vec` EXACTLY
+/// once. Runs on any unix host.
+#[test]
+fn return_closure_captures_vec_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free("vec_no_double_free", RETURN_CLOSURE_CAPTURES_VEC_SOURCE);
+}

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -9435,7 +9435,7 @@ fn emit_field_clone_step<'ctx>(
 /// the synthesised in-place record-drop helper. BitCopy / Connection
 /// fields are no-ops (caller filters them out, but this helper is
 /// defensive).
-fn emit_field_drop_step<'ctx>(
+pub(crate) fn emit_field_drop_step<'ctx>(
     ctx: &'ctx Context,
     llvm_mod: &LlvmModule<'ctx>,
     builder: &Builder<'ctx>,
@@ -18323,6 +18323,73 @@ fn lower_make_closure(
     Ok(())
 }
 
+/// Derive the per-capture drop manifest for an escaping closure env: classify
+/// each captured field's `ResolvedTy` (read off the env record registry under
+/// the env Place's Named type) through the canonical
+/// `classify_state_field_with_enum_layouts` authority into a
+/// [`StateFieldCloneKind`] the free thunk drops with `emit_field_drop_step`.
+///
+/// Reconstructs the `RecordLayout` slice the classifier needs from
+/// `fn_ctx.record_field_resolved_tys` exactly as `ask_reply_drop_thunk_ptr`
+/// does — the codegen record registry is the single source of field-type
+/// truth, so the closure-env drop path and every other owned-value drop path
+/// agree on what a field owns.
+///
+/// Fail-closed: a capture whose type the classifier cannot map to a drop kind
+/// is a `CodegenError::FailClosed` (the owned capture would otherwise leak by
+/// omission), and an env whose record type is missing from the registry is a
+/// hard error rather than a silent empty (which would reinstate the leak).
+fn closure_env_capture_drop_kinds(
+    fn_ctx: &FnCtx<'_, '_>,
+    fn_symbol: &str,
+    env: Place,
+) -> CodegenResult<Vec<StateFieldCloneKind>> {
+    let env_ty = place_resolved_ty(fn_ctx, env)?;
+    let ResolvedTy::Named { name: env_name, .. } = env_ty else {
+        return Err(CodegenError::FailClosed(format!(
+            "closure env for `{fn_symbol}` has non-Named place type {env_ty:?}; \
+             expected the `__hew_closure_env_*` record"
+        )));
+    };
+    let Some(field_tys) = fn_ctx.record_field_resolved_tys.get(env_name.as_str()) else {
+        return Err(CodegenError::FailClosed(format!(
+            "closure env `{env_name}` for `{fn_symbol}` is not in the codegen record \
+             registry; its captured-field drop manifest cannot be derived and owned \
+             captures would leak (boundary-fail-closed)"
+        )));
+    };
+    // Reconstruct the RecordLayout slice the classifier consumes from the same
+    // registry, mirroring `ask_reply_drop_thunk_ptr`.
+    let record_layouts: Vec<hew_mir::RecordLayout> = fn_ctx
+        .record_field_resolved_tys
+        .iter()
+        .map(|(name, tys)| hew_mir::RecordLayout {
+            name: name.clone(),
+            field_tys: tys.clone(),
+            field_names: Vec::new(),
+        })
+        .collect();
+    let mut kinds = Vec::with_capacity(field_tys.len());
+    for (idx, field_ty) in field_tys.iter().enumerate() {
+        let mut visited = std::collections::HashSet::new();
+        let kind = hew_mir::classify_state_field_with_enum_layouts(
+            field_ty,
+            &record_layouts,
+            fn_ctx.enum_layouts,
+            &mut visited,
+        )
+        .map_err(|e| {
+            CodegenError::FailClosed(format!(
+                "closure env `{env_name}` capture field {idx} (type {field_ty:?}) is not \
+                 drop-classifiable: {e}; an owned capture would leak when the escaping \
+                 closure is dropped (borrow-classifier-completeness-or-leak)"
+            ))
+        })?;
+        kinds.push(kind);
+    }
+    Ok(kinds)
+}
+
 /// Heap-promote a closure env: allocate the box, plant the free thunk in
 /// the header slot, copy the stack-materialised env record into the
 /// captures region, and return the captures address (the pair's env_ptr).
@@ -18377,9 +18444,32 @@ fn emit_closure_env_heap_box<'ctx>(
             )
         })?
         .into_pointer_value();
-    // Header slot 0: the per-closure free thunk.
-    let free_thunk =
-        crate::thunks::get_or_emit_closure_env_free_thunk(fn_ctx, fn_symbol, total_size)?;
+    // Header slot 0: the per-closure free thunk. Derive its per-capture drop
+    // manifest here — the SINGLE place that knows both the env record type and
+    // the box layout. Classify each captured field's `ResolvedTy` through the
+    // canonical `classify_state_field_with_enum_layouts` authority (the same
+    // classifier the actor-`state_drop_fn`, ask-reply, and owned-Vec paths
+    // use); the thunk then drops each owning field via `emit_field_drop_step`
+    // before freeing the box. An owned capture the classifier cannot map to a
+    // drop strategy fails closed HERE rather than leaking by omission
+    // (boundary-fail-closed / borrow-classifier-completeness-or-leak).
+    let env_struct = match env_llvm_ty {
+        BasicTypeEnum::StructType(st) => st,
+        other => {
+            return Err(CodegenError::FailClosed(format!(
+                "closure env for `{fn_symbol}` has non-struct captures region {other:?}; \
+                 the env record layout and the heap-box convention have drifted"
+            )));
+        }
+    };
+    let field_kinds = closure_env_capture_drop_kinds(fn_ctx, fn_symbol, env)?;
+    let free_thunk = crate::thunks::get_or_emit_closure_env_free_thunk(
+        fn_ctx,
+        fn_symbol,
+        total_size,
+        env_struct,
+        &field_kinds,
+    )?;
     fn_ctx
         .builder
         .build_store(box_ptr, free_thunk.as_global_value().as_pointer_value())

--- a/hew-codegen-rs/src/thunks.rs
+++ b/hew-codegen-rs/src/thunks.rs
@@ -584,14 +584,41 @@ pub(crate) fn emit_spawn_task_closure(
 }
 
 /// Synthesise (once per closure shim) the `void(ptr env)` free thunk the
-/// env box's header slot carries: `hew_dyn_box_free(env - HEADER, total,
-/// align)` with the exact layout the matching `hew_dyn_box_alloc` used.
+/// env box's header slot carries. The thunk is the SOLE teardown owner of an
+/// escaping (heap-boxed) closure env — it runs in two acts, both keyed to the
+/// captures region pointer the pair stores:
+///
+///   1. **Drop each owned captured field** in reverse (LIFO) declaration
+///      order through the canonical per-field drop authority
+///      ([`crate::llvm::emit_field_drop_step`] over the captures region's
+///      [`StructType`]). A `string` capture is released via `hew_string_drop`,
+///      a `Vec`/`HashMap`/`HashSet` via its managed free, a captured
+///      closure-pair via its OWN planted free thunk (the recursive
+///      env-of-env case), a record/enum via its in-place drop helper — the
+///      identical classifier+step the actor-`state_drop_fn` and ask-reply
+///      paths use, so a captured value drops byte-for-byte as it would in any
+///      other owning aggregate (`lifecycle-symmetry`). BitCopy fields are
+///      no-ops. A field whose type the classifier cannot map to a drop
+///      strategy fails closed at synthesis (caller side), never silently
+///      leaks-by-omission.
+///   2. **Free the box**: `hew_dyn_box_free(env - HEADER, total, align)` with
+///      the exact (size, align) the matching `hew_dyn_box_alloc` used.
+///
+/// Before this fix the thunk freed only the box, leaking every owned capture
+/// (a runtime-built `string`/`Vec` captured into a returned closure → 2 leaks
+/// under `leaks --atExit`). The drop manifest is derived once at the
+/// `emit_closure_env_heap_box` call site (classifying the env record's field
+/// `ResolvedTy`s) and passed in as `field_kinds`, paired with the captures-
+/// region `env_struct` so the per-field GEPs land on the validated layout.
+///
 /// Private linkage — internal to the module, referenced only through the
 /// header slot planted by `emit_closure_env_heap_box`.
 pub(crate) fn get_or_emit_closure_env_free_thunk<'ctx>(
     fn_ctx: &FnCtx<'_, 'ctx>,
     fn_symbol: &str,
     total_size: u64,
+    env_struct: StructType<'ctx>,
+    field_kinds: &[StateFieldCloneKind],
 ) -> CodegenResult<FunctionValue<'ctx>> {
     let symbol = format!("__hew_closure_env_free_{fn_symbol}");
     if let Some(existing) = fn_ctx.llvm_mod.get_function(&symbol) {
@@ -627,7 +654,33 @@ pub(crate) fn get_or_emit_closure_env_free_thunk<'ctx>(
             ))
         })?
         .into_pointer_value();
-    // box = env - HEADER (in-bounds: the header is part of the allocation).
+
+    // Act 1: drop each owned captured field in reverse declaration order
+    // (LIFO — the same order the elaboration pass drops scope-exit locals and
+    // the record/actor-state drop bodies use). `env` IS the captures region
+    // pointer (the header sits BEFORE it at `env - HEADER`), so the env struct
+    // GEPs land directly on the capture fields. BitCopy / Connection / opaque
+    // arms are no-ops inside `emit_field_drop_step`; every owning class routes
+    // to its single canonical release.
+    for (idx, kind) in field_kinds.iter().enumerate().rev() {
+        let field_idx = u32::try_from(idx).map_err(|_| {
+            CodegenError::FailClosed(format!(
+                "closure env free thunk `{symbol}`: capture field count exceeds u32::MAX"
+            ))
+        })?;
+        crate::llvm::emit_field_drop_step(
+            ctx,
+            fn_ctx.llvm_mod,
+            &builder,
+            Some(env_struct),
+            env,
+            field_idx,
+            kind,
+        )?;
+    }
+
+    // Act 2: free the box. box = env - HEADER (in-bounds: the header is part
+    // of the allocation).
     let neg_header = i64_ty.const_int(CLOSURE_ENV_BOX_HEADER.wrapping_neg(), true);
     let box_ptr =
         unsafe { builder.build_in_bounds_gep(ctx.i8_type(), env, &[neg_header], "env_box_base") }

--- a/hew-codegen-rs/tests/closure_env_drop_manifest.rs
+++ b/hew-codegen-rs/tests/closure_env_drop_manifest.rs
@@ -1,0 +1,209 @@
+//! LLVM-IR emission teeth for the closure-env drop KEYSTONE: the per-closure
+//! env free thunk (`__hew_closure_env_free_*`) must drop every OWNED captured
+//! field before freeing the box, through the canonical per-field drop authority
+//! (`emit_field_drop_step`).
+//!
+//! ## What this proves (and what it would have caught)
+//!
+//! Before the keystone the free thunk freed only the heap box
+//! (`hew_dyn_box_free`) and never released the captured owning handle — an
+//! escaping closure that captured a runtime-built `string`/`Vec` leaked it.
+//! These tests assert the EXACT release symbol now appears inside the
+//! per-closure free thunk:
+//!   * a captured `string` → a `hew_string_drop` call inside
+//!     `__hew_closure_env_free_*`;
+//!   * a captured `Vec<i64>` → the managed Vec free inside the same thunk.
+//!
+//! A BitCopy-only capture (`i64`) must NOT gain any owned-field release — its
+//! free thunk frees only the box, the pre-keystone posture for non-owning
+//! captures. This is the negative control distinguishing a wired manifest from
+//! a blanket "drop everything" (which would double-free a BitCopy alias).
+//!
+//! LESSONS applied:
+//! - `drop-allowset-from-value-flow` (P0): the test asserts the exact emitted
+//!   release symbol against a fix-disabled-equivalent negative control (the
+//!   BitCopy capture), not a happy-path `> 0`.
+//! - `borrow-classifier-completeness-or-leak` (P0): enumerates the emitted
+//!   owned-field release per capture class.
+//! - `boundary-fail-closed` (P0): absence of the release inside the free thunk
+//!   is the gate condition.
+
+use std::path::Path;
+
+use hew_codegen_rs::{emit_module, EmitOptions};
+use hew_types::module_registry::ModuleRegistry;
+use hew_types::Checker;
+
+/// Full pipeline (parse → typecheck → HIR → MIR → emit) returning the textual
+/// LLVM IR. Type-checking is REQUIRED so closure capture facts and method-call
+/// rewrites are produced — a `TypeCheckOutput::default()` would trip the HIR
+/// `CheckerBoundaryViolation` guard that requires real typecheck output.
+fn emit_ll(source: &str, module_name: &str) -> String {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    let output = hew_hir::lower_program(
+        &parsed.program,
+        &tc_output,
+        &hew_hir::ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    assert!(
+        output.diagnostics.is_empty(),
+        "hir diagnostics: {:?}",
+        output.diagnostics
+    );
+    let pipeline = hew_mir::lower_hir_module(&output.module);
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "mir diagnostics: {:?}",
+        pipeline.diagnostics
+    );
+    let tmp = std::env::temp_dir().join(format!("hew-closure-env-drop-{module_name}"));
+    std::fs::create_dir_all(&tmp).expect("create out_dir");
+    let options = EmitOptions {
+        module_name,
+        out_dir: &tmp,
+        native: false,
+        wasm: false,
+        target_triple: None,
+        debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
+        source_path: None,
+    };
+    let artefacts = emit_module(&pipeline, &options).expect("closure pipeline must emit");
+    let ll_path: &Path = artefacts
+        .ll_path
+        .as_deref()
+        .expect("emit_module must populate ll_path");
+    std::fs::read_to_string(ll_path).expect("read emitted .ll")
+}
+
+/// Extract the body of the named function from emitted LLVM-IR text: every line
+/// from `define ... @<name>(` through the matching closing `}`. Returns an
+/// empty string if the function is not defined.
+fn function_body(ll: &str, fn_name: &str) -> String {
+    let needle = format!("@{fn_name}(");
+    let mut body = String::new();
+    let mut in_fn = false;
+    for line in ll.lines() {
+        if !in_fn && line.starts_with("define") && line.contains(&needle) {
+            in_fn = true;
+        }
+        if in_fn {
+            body.push_str(line);
+            body.push('\n');
+            if line.trim() == "}" {
+                break;
+            }
+        }
+    }
+    body
+}
+
+/// The single per-closure env free thunk symbol emitted for the (only) closure
+/// literal in these single-closure fixtures. The owner component is the
+/// enclosing function symbol; the lone closure literal is id 0.
+const FREE_THUNK: &str = "__hew_closure_env_free___hew_closure_invoke_make_0";
+
+// ---------------------------------------------------------------------------
+// String capture: the free thunk must release the captured string.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn captured_string_freed_inside_env_free_thunk() {
+    let ll = emit_ll(
+        "fn make(a: string, b: string) -> fn() -> i64 {\n\
+        \x20   let label = a + b;\n\
+        \x20   || label.len()\n\
+        }\n\
+        fn main() -> i64 { let f = make(\"x\", \"y\"); f() }\n",
+        "string_capture",
+    );
+    let thunk = function_body(&ll, FREE_THUNK);
+    assert!(
+        !thunk.is_empty(),
+        "no env free thunk `{FREE_THUNK}` emitted; the escaping string-capturing \
+         closure must plant a per-closure free thunk. Emitted IR:\n{ll}"
+    );
+    assert!(
+        thunk.contains("hew_string_drop"),
+        "the env free thunk must release the captured `string` via `hew_string_drop` \
+         BEFORE freeing the box -- without it the captured handle leaks. Thunk body:\n{thunk}"
+    );
+    assert!(
+        thunk.contains("hew_dyn_box_free"),
+        "the env free thunk must still free the box after dropping captures. \
+         Thunk body:\n{thunk}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Vec capture: the free thunk must release the captured Vec.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn captured_vec_freed_inside_env_free_thunk() {
+    let ll = emit_ll(
+        "fn make() -> fn() -> i64 {\n\
+        \x20   var xs: Vec<i64> = Vec::new();\n\
+        \x20   xs.push(10);\n\
+        \x20   || xs.len()\n\
+        }\n\
+        fn main() -> i64 { let f = make(); f() }\n",
+        "vec_capture",
+    );
+    let thunk = function_body(&ll, FREE_THUNK);
+    assert!(
+        !thunk.is_empty(),
+        "no env free thunk `{FREE_THUNK}` emitted for the Vec-capturing closure. \
+         Emitted IR:\n{ll}"
+    );
+    assert!(
+        thunk.contains("hew_vec_free"),
+        "the env free thunk must release the captured `Vec` via a `hew_vec_free*` call \
+         before freeing the box. Thunk body:\n{thunk}"
+    );
+    assert!(
+        thunk.contains("hew_dyn_box_free"),
+        "the env free thunk must still free the box. Thunk body:\n{thunk}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative control: a BitCopy (i64) capture must NOT gain an owned-field
+// release. Its free thunk frees only the box -- a blanket "drop every field"
+// would double-free the BitCopy alias of the caller's live binding.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bitcopy_capture_has_no_owned_release_in_free_thunk() {
+    let ll = emit_ll(
+        "fn make(n: i64) -> fn() -> i64 {\n\
+        \x20   || n\n\
+        }\n\
+        fn main() -> i64 { let f = make(7); f() }\n",
+        "bitcopy_capture",
+    );
+    let thunk = function_body(&ll, FREE_THUNK);
+    assert!(
+        !thunk.is_empty(),
+        "no env free thunk `{FREE_THUNK}` emitted for the i64-capturing closure. \
+         Emitted IR:\n{ll}"
+    );
+    assert!(
+        !thunk.contains("hew_string_drop") && !thunk.contains("hew_vec_free"),
+        "a BitCopy (i64) capture must NOT emit any owned-field release in its free \
+         thunk -- the value is a byte-copy, not an owned handle; releasing it would \
+         corrupt unrelated memory. Thunk body:\n{thunk}"
+    );
+    assert!(
+        thunk.contains("hew_dyn_box_free"),
+        "the BitCopy-capture free thunk must still free the box. Thunk body:\n{thunk}"
+    );
+}


### PR DESCRIPTION
## Summary

Returned or otherwise escaping closures that capture owned values (strings, Vecs, records, or nested closures) previously leaked those values. The heap-boxed closure env's free thunk freed only the box and never released the captured owning handles. The free thunk now drops each owned captured field in LIFO order via the canonical per-field drop authority before freeing the box. The caller-binding drop is suppressed because the env is the sole owner after the closure escapes, so no double-free is possible. An unclassifiable capture fails closed at the heap-box site — no new surface form is enabled.

## Verification

- Cross-ecosystem memory-safety review: accept — adversarial probes (owned Vec, owned string, multi-capture LIFO, record capture, BitCopy/scalar negative, nested env-of-env) all drop exactly once at the leak floor with no double-free under MallocScribble / PreScribble / GuardEdges; field-class coverage complete; fail-closed posture intact
- Full suite (types, hir, mir, codegen, cli, verify-ffi, checked-mir, ratchet, hew-check-all, fuzz-oracle, vertical-slice, both closure leak oracles, fmt, clippy): green
- Preflight: ready-to-push

## Out of scope

Nested closures capturing mutable bindings, mutate-through-capture, and generic-T capture forms remain compile-rejected (fail-closed) and are tracked separately. This PR is scoped to the memory-safety fix for the already-compiling escaping-closure capture forms.