### PR TITLE
fix(impl-trait): mangle symbols for concrete specialised impl-Trait blocks

### DIFF
--- a/hew-hir/src/dispatch.rs
+++ b/hew-hir/src/dispatch.rs
@@ -45,6 +45,13 @@ pub type TraitImplKey = (String, String, String);
 /// and zips `method_names` with `method_symbols` (parallel arrays maintained
 /// by `lower_impl_block`). Inherent impls (no trait bound) do not participate
 /// in static trait dispatch and are skipped.
+///
+/// For concrete specialised impls (empty `type_params`, non-empty
+/// `self_type_concrete_args`), the key self-type name is the mangled form
+/// incorporating the concrete args — e.g. `"Wrapper$$i64"` for
+/// `impl Describe for Wrapper<i64>`. This ensures `impl Describe for Wrapper<i64>`
+/// and `impl Describe for Wrapper<string>` produce distinct keys and never
+/// collide in the index.
 #[must_use]
 pub fn build_trait_impl_method_index(
     items: &[HirItem],
@@ -55,6 +62,15 @@ pub fn build_trait_impl_method_index(
         if block.trait_name.is_none() {
             continue;
         }
+        // Key self-type name: bare for generic impls (type_params non-empty)
+        // or impls with no target type args; mangled for concrete specialised
+        // impls (`impl Trait for Wrapper<i64>` → `"Wrapper$$i64"`).
+        let key_self_type =
+            if block.type_params.is_empty() && !block.self_type_concrete_args.is_empty() {
+                crate::monomorph::mangle(&block.self_type_name, &block.self_type_concrete_args)
+            } else {
+                block.self_type_name.clone()
+            };
         // `method_names` and `method_symbols` are produced together in
         // `lower_impl_block` and MUST be parallel. Defensive zip: any
         // length mismatch indicates upstream HIR construction drift and
@@ -67,7 +83,7 @@ pub fn build_trait_impl_method_index(
         {
             let key = (
                 declaring_trait.clone(),
-                block.self_type_name.clone(),
+                key_self_type.clone(),
                 method_name.clone(),
             );
             index.insert(
@@ -93,13 +109,50 @@ pub fn build_trait_impl_method_index(
 /// nominal the impl block declared. Look up the key as given first, then retry
 /// with the bare leaf so an imported generic adapter resolves the same way it
 /// does in its defining module.
+///
+/// `self_type_concrete_args` carries the resolved type arguments of the receiver
+/// at the call site (e.g. `[ResolvedTy::I64]` for a `Wrapper<i64>` receiver).
+/// When non-empty, the lookup first tries the mangled self-type key
+/// (`"Wrapper$$i64"`) to find a concrete specialised impl, then falls back to
+/// the bare name for a generic impl (`impl<U> Trait for Wrapper<U>`). This
+/// ensures two concrete instantiations with distinct args resolve to their own
+/// impl entries rather than colliding on the bare name.
 #[must_use]
 pub fn lookup_trait_impl_entry<'a, S: std::hash::BuildHasher>(
     index: &'a HashMap<TraitImplKey, TraitImplMethodEntry, S>,
     declaring_trait: &str,
     self_type_name: &str,
     method_name: &str,
+    self_type_concrete_args: &[hew_types::ResolvedTy],
 ) -> Option<&'a TraitImplMethodEntry> {
+    // 1. When the receiver has concrete type args, try the mangled concrete key
+    //    first — this matches `impl Describe for Wrapper<i64>` over
+    //    `impl<U> Describe for Wrapper<U>` when both are present.
+    if !self_type_concrete_args.is_empty() {
+        let mangled = crate::monomorph::mangle(self_type_name, self_type_concrete_args);
+        let concrete_key = (
+            declaring_trait.to_string(),
+            mangled.clone(),
+            method_name.to_string(),
+        );
+        if let Some(entry) = index.get(&concrete_key) {
+            return Some(entry);
+        }
+        // Also try bare-leaf of the mangled name for module-qualified receivers.
+        let bare_mangled = mangled.rsplit('.').next().unwrap_or(&mangled);
+        if bare_mangled != mangled {
+            let bare_concrete_key = (
+                declaring_trait.to_string(),
+                bare_mangled.to_string(),
+                method_name.to_string(),
+            );
+            if let Some(entry) = index.get(&bare_concrete_key) {
+                return Some(entry);
+            }
+        }
+    }
+    // 2. Fall back to bare self_type_name (generic impls and impls without
+    //    target type args — the common case prior to this fix).
     let key = (
         declaring_trait.to_string(),
         self_type_name.to_string(),

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -1671,13 +1671,43 @@ pub fn lower_program_with_mono_cap(
                 // resolve them in the second pass. The Index special-case is
                 // a subset of this — its methods landed in `fn_registry`
                 // historically via the same key shape.
-                if let TypeExpr::Named { name, .. } = &impl_decl.target_type.0 {
+                if let TypeExpr::Named {
+                    name,
+                    type_args: target_type_args,
+                } = &impl_decl.target_type.0
+                {
                     if impl_decl.where_clause.is_none()
                         || classify_unsupported_where_clause(impl_decl).is_none()
                     {
                         let impl_type_params = impl_type_param_names(impl_decl);
+                        // For concrete specialised impls (empty impl type-params,
+                        // non-empty target type args), compute the mangled self-type
+                        // name so the fn_registry key is distinct per instantiation.
+                        // Mirrors the identical logic in `lower_impl_block` (#2270).
+                        let symbol_name: std::borrow::Cow<str> = if impl_type_params.is_empty() {
+                            let concrete_args: Vec<hew_types::ResolvedTy> = target_type_args
+                                .as_deref()
+                                .unwrap_or(&[])
+                                .iter()
+                                .map(|a| ctx.lower_type(a))
+                                .collect();
+                            if concrete_args.is_empty() {
+                                std::borrow::Cow::Borrowed(name.as_str())
+                            } else {
+                                std::borrow::Cow::Owned(crate::monomorph::mangle(
+                                    name,
+                                    &concrete_args,
+                                ))
+                            }
+                        } else {
+                            std::borrow::Cow::Borrowed(name.as_str())
+                        };
                         for method in &impl_decl.methods {
-                            ctx.register_impl_method_fn_entry(name, method, &impl_type_params);
+                            ctx.register_impl_method_fn_entry(
+                                &symbol_name,
+                                method,
+                                &impl_type_params,
+                            );
                         }
                         // Also register trait default methods that are NOT
                         // overridden in this impl block — they need fn_registry
@@ -1692,7 +1722,7 @@ pub fn lower_program_with_mono_cap(
                                     if !overridden.contains(default_method.name.as_str()) {
                                         let fn_decl = trait_method_to_fn_decl(default_method);
                                         ctx.register_impl_method_fn_entry(
-                                            name,
+                                            &symbol_name,
                                             &fn_decl,
                                             &impl_type_params,
                                         );
@@ -3999,11 +4029,13 @@ fn closure_under_substitution(
             // structured fields only — no symbol-name parsing. Tolerant of a
             // module-qualified receiver name: an imported generic adapter
             // (`iter.Map`) keys its impl block on the bare `Map`.
+            // Pass `type_args` to resolve concrete-specialised impls (#2270).
             let Some(entry) = crate::dispatch::lookup_trait_impl_entry(
                 &impl_index,
                 &tms.declaring_trait,
                 &self_type_name,
                 &tms.method_name,
+                &type_args,
             ) else {
                 continue;
             };
@@ -7037,9 +7069,16 @@ impl LowerCtx {
         method: &FnDecl,
         impl_type_params: &[String],
     ) {
+        // `self_type_name` is the symbol-prefix name — may be the mangled form
+        // for concrete specialised impls (e.g. `"Wrapper$$i64"`). The var-self
+        // check must use the bare AST receiver type name (e.g. `"Wrapper"`) so
+        // the param-type annotation `Wrapper<i64>` still matches (#2270).
+        let bare_type_name = self_type_name
+            .split_once("$$")
+            .map_or(self_type_name, |(bare, _)| bare);
         let symbol = crate::node::HirImplBlock::method_symbol(self_type_name, &method.name);
         self.register_fn_entry(&symbol, method);
-        if Self::is_var_self_method_for_type(method, self_type_name) {
+        if Self::is_var_self_method_for_type(method, bare_type_name) {
             if let Some(entry) = self.fn_registry.get_mut(&symbol) {
                 let Some(receiver_ty) = entry.param_tys.first().cloned() else {
                     unreachable!(
@@ -8526,7 +8565,7 @@ impl LowerCtx {
         }
         let TypeExpr::Named {
             name: self_type_name,
-            ..
+            type_args: target_type_args,
         } = &decl.target_type.0
         else {
             self.diagnostics.push(HirDiagnostic::new(
@@ -8546,6 +8585,36 @@ impl LowerCtx {
             .as_ref()
             .map(|ps| ps.iter().map(|p| p.name.clone()).collect())
             .unwrap_or_default();
+        // For concrete specialised impls (`impl Describe for Wrapper<i64>`, i.e.
+        // empty type_params with non-empty target type args), lower the target's
+        // type args and compute a mangled self-type name for use in method symbols.
+        // This prevents `impl Describe for Wrapper<i64>` and
+        // `impl Describe for Wrapper<string>` from both emitting the symbol
+        // `"Wrapper::describe"` and colliding in fn_registry / codegen (#2270).
+        //
+        // Generic impls (`impl<U> Describe for Wrapper<U>`, non-empty type_params)
+        // are excluded: their method symbols stay bare (`"Wrapper::describe"`)
+        // and monomorphisation suffixes them at instantiation time.
+        let self_type_concrete_args: Vec<hew_types::ResolvedTy> = if type_params.is_empty() {
+            target_type_args
+                .as_deref()
+                .unwrap_or(&[])
+                .iter()
+                .map(|a| self.lower_type(a))
+                .collect()
+        } else {
+            Vec::new()
+        };
+        // Symbol name for this impl's methods: mangled when the impl is a concrete
+        // specialisation of a generic type, bare otherwise.
+        let symbol_self_name: std::borrow::Cow<str> = if self_type_concrete_args.is_empty() {
+            std::borrow::Cow::Borrowed(self_type_name.as_str())
+        } else {
+            std::borrow::Cow::Owned(crate::monomorph::mangle(
+                self_type_name,
+                &self_type_concrete_args,
+            ))
+        };
         // Blanket-impl guard: reject `impl<T> Trait for T` (target name is
         // itself one of the outer type parameters) — V0b does not handle the
         // monomorphisation of blanket impls.
@@ -8698,7 +8767,7 @@ impl LowerCtx {
                     continue;
                 }
             }
-            let symbol = crate::node::HirImplBlock::method_symbol(self_type_name, &method.name);
+            let symbol = crate::node::HirImplBlock::method_symbol(&symbol_self_name, &method.name);
             // Pass impl-level type params so that methods of e.g. `impl<U> Trait for Wrapper<U>`
             // carry `U` as a `HirFn::type_params` entry — required for monomorphization
             // of generic-over-generic impl methods (W3.022 Stage 3).
@@ -8736,7 +8805,7 @@ impl LowerCtx {
                     }
                     let fn_decl = trait_method_to_fn_decl(default_method);
                     let symbol =
-                        crate::node::HirImplBlock::method_symbol(self_type_name, &fn_decl.name);
+                        crate::node::HirImplBlock::method_symbol(&symbol_self_name, &fn_decl.name);
                     items.push(HirItem::Function(self.lower_fn_with_name_and_impl_params(
                         &fn_decl,
                         &symbol,
@@ -8770,6 +8839,7 @@ impl LowerCtx {
             trait_name: decl.trait_bound.as_ref().map(|b| b.name.clone()),
             self_type_name: self_type_name.clone(),
             type_params,
+            self_type_concrete_args,
             type_aliases,
             method_symbols,
             method_names,

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -276,6 +276,13 @@ pub struct HirImplBlock {
     /// Outer type parameters on the impl, e.g. `["T"]` for
     /// `impl<T> Iterator for VecIter<T>`.
     pub type_params: Vec<String>,
+    /// Concrete self-type arguments for a concrete specialised impl, e.g.
+    /// `[ResolvedTy::I64]` for `impl Describe for Wrapper<i64>`. Always empty
+    /// when `type_params` is non-empty (generic impl) or when the target type
+    /// carries no type arguments. Used to distinguish two concrete impls for
+    /// the same base nominal (`Wrapper<i64>` vs `Wrapper<string>`) so the
+    /// dispatch index key and method symbol are distinct per instantiation.
+    pub self_type_concrete_args: Vec<ResolvedTy>,
     /// Associated-type bindings declared on the impl
     /// (e.g. `type Item = T;` → `("Item", ResolvedTy::TypeParam("T"))`).
     pub type_aliases: Vec<(String, ResolvedTy)>,

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -13300,11 +13300,15 @@ impl Builder {
                 };
                 // (3) structured registry lookup (tolerant of a
                 // module-qualified receiver name for imported impls).
+                // Pass `type_args` so the lookup finds concrete-specialised impls
+                // (`impl Describe for Wrapper<i64>`) keyed under the mangled name
+                // (`"Wrapper$$i64"`) before falling back to generic impls (#2270).
                 let Some(entry) = hew_hir::dispatch::lookup_trait_impl_entry(
                     &self.trait_impl_index,
                     declaring_trait,
                     &self_type_name,
                     method_name,
+                    &type_args,
                 )
                 .cloned() else {
                     self.diagnostics.push(MirDiagnostic {
@@ -21259,11 +21263,13 @@ impl Builder {
             });
             return None;
         };
+        // Pass `type_args` so concrete-specialised impls resolve correctly (#2270).
         let Some(entry) = hew_hir::dispatch::lookup_trait_impl_entry(
             &self.trait_impl_index,
             declaring_trait,
             &self_type_name,
             method_name,
+            &type_args,
         )
         .cloned() else {
             self.diagnostics.push(MirDiagnostic {

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -5469,6 +5469,37 @@ impl Checker {
             true,
         );
         let method_key = format!("{canonical}::{method}");
+        // Concrete-specialised primitive impl (#2270): when the builtin receiver
+        // has non-empty type args (e.g. `Vec<i64>`) and the impl is a concrete
+        // specialisation (`impl Summable for Vec<i64>` — no generic impl type
+        // params), the HIR fn_registry key is the mangled form
+        // (`"Vec$$i64::total"`), not the bare `"Vec::total"`. The HIR first pass
+        // mangled the key to prevent `impl Trait for Vec<i64>` and
+        // `impl Trait for Vec<string>` from registering the same LLVM symbol.
+        // Use the mangled c_symbol here so HIR can resolve it to a
+        // `ResolvedRef::Item`; fall back to the bare key for generic impls and
+        // for any type arg that cannot be mangled.
+        let c_symbol = if let Ty::Named {
+            args: receiver_type_args,
+            ..
+        } = &defaulted_receiver
+        {
+            if receiver_type_args.is_empty() {
+                method_key.clone()
+            } else {
+                let resolved_args: Option<Vec<ResolvedTy>> = receiver_type_args
+                    .iter()
+                    .map(|ty| ResolvedTy::from_ty(ty).ok())
+                    .collect();
+                resolved_args
+                    .as_ref()
+                    .and_then(|args| crate::resolved_ty::mangle_impl_self_name(&canonical, args))
+                    .filter(|m| self.fn_sigs.contains_key(&format!("{m}::{method}")))
+                    .map_or_else(|| method_key.clone(), |m| format!("{m}::{method}"))
+            }
+        } else {
+            method_key.clone()
+        };
         self.record_method_call_receiver_kind(
             span,
             MethodCallReceiverKind::PrimitiveTraitImpl {
@@ -5476,11 +5507,11 @@ impl Checker {
                 canonical_receiver: canonical,
             },
         );
-        if self.fn_sigs.contains_key(&method_key) {
+        if self.fn_sigs.contains_key(&method_key) || self.fn_sigs.contains_key(&c_symbol) {
             self.record_method_call_rewrite(
                 span,
                 MethodCallRewrite::RewriteToFunction {
-                    c_symbol: method_key,
+                    c_symbol,
                     // User-fn dispatch into a primitive trait impl
                     // (`i64::fmt` etc.) is open-set; the typed runtime-call
                     // catalog does not enumerate user-defined method keys.

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -7808,11 +7808,61 @@ impl Checker {
                                     );
                                 }
                             }
-                        } else if self.fn_sigs.contains_key(&method_key) {
+                        } else if self.fn_sigs.contains_key(&method_key)
+                            || (!type_args.is_empty() && {
+                                // Concrete-specialised-impl check (#2270): the
+                                // type_args may resolve to a mangled key even
+                                // when the bare key is absent (e.g. after the
+                                // first concrete impl was registered and the bare
+                                // key was clobbered by the second).
+                                let resolved_args: Option<Vec<ResolvedTy>> = type_args
+                                    .iter()
+                                    .map(|ty| ResolvedTy::from_ty(&self.subst.resolve(ty)).ok())
+                                    .collect();
+                                resolved_args
+                                    .as_ref()
+                                    .and_then(|args| {
+                                        crate::resolved_ty::mangle_impl_self_name(
+                                            method_owner,
+                                            args,
+                                        )
+                                    })
+                                    .is_some_and(|m| {
+                                        self.fn_sigs.contains_key(&format!("{m}::{method}"))
+                                    })
+                            })
+                        {
+                            // For concrete-specialised impls, use the mangled
+                            // c_symbol so HIR looks up the right `fn_registry`
+                            // entry.  Falls back to the bare key for all other
+                            // cases (generic impls, inherent methods, etc.).
+                            let dispatch_key = if type_args.is_empty() {
+                                method_key.clone()
+                            } else {
+                                let resolved_args: Option<Vec<ResolvedTy>> = type_args
+                                    .iter()
+                                    .map(|ty| ResolvedTy::from_ty(&self.subst.resolve(ty)).ok())
+                                    .collect();
+                                resolved_args
+                                    .as_ref()
+                                    .and_then(|args| {
+                                        crate::resolved_ty::mangle_impl_self_name(
+                                            method_owner,
+                                            args,
+                                        )
+                                    })
+                                    .filter(|m| {
+                                        self.fn_sigs.contains_key(&format!("{m}::{method}"))
+                                    })
+                                    .map_or_else(
+                                        || method_key.clone(),
+                                        |m| format!("{m}::{method}"),
+                                    )
+                            };
                             self.record_method_call_rewrite(
                                 span,
                                 MethodCallRewrite::RewriteToFunction {
-                                    c_symbol: method_key,
+                                    c_symbol: dispatch_key,
                                     // User-defined `Type::method` dispatch is
                                     // open-set; the typed runtime-call catalog
                                     // does not enumerate user method keys.

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -5719,6 +5719,55 @@ impl Checker {
         if method.consumes_self {
             self.consume_receiver_methods.insert(method_key.clone());
         }
+
+        // Concrete-specialised-impl dual registration (#2270).
+        //
+        // When two `impl Trait for Wrapper<i64>` and `impl Trait for Wrapper<string>`
+        // blocks are present, both produce `method_key = "Wrapper::describe"`.  The
+        // second call clobbers the first in `fn_sigs`, and codegen later emits two
+        // LLVM functions under the same name → linkage crash.
+        //
+        // Detection: no impl-level type params (concrete impl, not `impl<T>`),
+        // AND the enclosing impl's self-type has non-empty concrete type args
+        // (from `current_self_type`).  For such impls we ALSO register a
+        // mangled-key entry (`"Wrapper$$i64::describe"`), and that mangled key is
+        // what method-call dispatch and HIR will actually use.  The bare key entry
+        // in `fn_sigs` is kept as a fallback for lookup paths that have not yet
+        // been updated (e.g. method-set validation, external lookup).
+        let is_concrete_specialised_impl = impl_type_params.is_none_or(Vec::is_empty); // None → no impl type params → concrete
+        if is_concrete_specialised_impl {
+            if let Some((self_type_name, self_type_args)) = &self.current_self_type.clone() {
+                if self_type_name == type_name && !self_type_args.is_empty() {
+                    // Try to resolve each type arg to a concrete `ResolvedTy` and
+                    // compute the mangled self-type name.  Fails gracefully if any
+                    // arg contains an inference variable or error node (which cannot
+                    // appear for a concrete specialised impl, but we are defensive).
+                    let resolved_args: Option<Vec<ResolvedTy>> = self_type_args
+                        .iter()
+                        .map(|ty| ResolvedTy::from_ty(ty).ok())
+                        .collect();
+                    if let Some(resolved_args) = resolved_args {
+                        if let Some(mangled_self) = crate::resolved_ty::mangle_impl_self_name(
+                            self_type_name,
+                            &resolved_args,
+                        ) {
+                            let mangled_method_key = format!("{mangled_self}::{}", method.name);
+                            // Register the full sig under the mangled key.  A
+                            // previous concrete-impl registration may already be
+                            // present; overwriting is correct because each impl
+                            // block processes its own concrete args in sequence.
+                            self.fn_sigs.insert(mangled_method_key.clone(), sig.clone());
+                            // Propagate consume-receiver membership to the mangled key
+                            // so HIR dispatch does not lose the move contract.
+                            if method.consumes_self {
+                                self.consume_receiver_methods.insert(mangled_method_key);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         sig
     }
 

--- a/hew-types/src/method_resolution.rs
+++ b/hew-types/src/method_resolution.rs
@@ -10,6 +10,7 @@ use crate::builtin_names::{builtin_named_type, builtin_type_def as builtin_named
 #[cfg(test)]
 use crate::check::TypeDefKind;
 use crate::check::{FnSig, TypeDef};
+use crate::resolved_ty::{mangle_impl_self_name, ResolvedTy};
 use crate::BuiltinType;
 use crate::Ty;
 
@@ -169,6 +170,40 @@ pub fn lookup_named_method_sig(
     }
 
     let type_params = lookup_user_type_def(type_defs, type_name).map(|td| td.type_params.clone());
+
+    // Concrete-specialised-impl lookup (#2270): when the receiver has non-empty
+    // concrete type args (e.g. `Wrapper<i64>`), try the mangled key first
+    // (`"Wrapper$$i64::describe"`).  This resolves to the correct impl when two
+    // concrete specialisations (`Wrapper<i64>` and `Wrapper<string>`) both exist.
+    // Falls back to the bare key for generic impls (`impl<T> Trait for Wrapper<T>`),
+    // inherent methods, and any arg that cannot be mangled.
+    //
+    // IMPORTANT: use a direct `fn_sigs.get` (not `lookup_user_fn_sig`) for the
+    // mangled key.  `lookup_user_fn_sig` has a module-stripping fallback that
+    // strips after the last `.` in the type-name part of the key.  A mangled key
+    // like `"LocalPid$$bank.Account::who"` contains a `.` in the mangled segment,
+    // causing the fallback to strip `"LocalPid$$bank"` and resolve `"Account::who"` —
+    // i.e. the root-module actor's method — instead of failing.  The mangled
+    // key is an exact, unambiguous identifier; it must only match via direct lookup.
+    if !type_args.is_empty() {
+        let resolved_args: Option<Vec<ResolvedTy>> = type_args
+            .iter()
+            .map(|ty| ResolvedTy::from_ty(ty).ok())
+            .collect();
+        if let Some(resolved_args) = resolved_args {
+            if let Some(mangled_self) = mangle_impl_self_name(type_name, &resolved_args) {
+                let mangled_key = format!("{mangled_self}::{method}");
+                // Direct lookup only — no module-stripping fallback (see comment above).
+                if let Some(sig) = fn_sigs.get(&mangled_key).cloned() {
+                    // The mangled-key entry has no generic type params (it was
+                    // registered for a concrete specialised impl), so we
+                    // instantiate with the type-def params (empty for concrete).
+                    let tps = type_params.clone().unwrap_or_default();
+                    return Some(instantiate_named_method_sig(sig, &tps, type_args));
+                }
+            }
+        }
+    }
 
     lookup_user_fn_sig(fn_sigs, &format!("{type_name}::{method}"))
         .cloned()

--- a/hew-types/src/resolved_ty.rs
+++ b/hew-types/src/resolved_ty.rs
@@ -713,6 +713,120 @@ impl fmt::Display for UserFacingResolvedTy<'_> {
     }
 }
 
+// ── Symbol-key mangling for concrete specialised impls ───────────────────────
+//
+// When two `impl Trait for Wrapper<i64>` and `impl Trait for Wrapper<string>`
+// blocks coexist, their methods are registered and looked up under the bare
+// key `"Wrapper::method"` which causes the second registration to clobber the
+// first, and codegen to emit two LLVM functions with the same name (the
+// linkage error that #2270 surfaced). The fix: for concrete specialised impls
+// (no generic type params on the impl, non-empty target type args), use a
+// mangled self-type name that embeds the concrete args — e.g. `"Wrapper$$i64"`
+// — so `"Wrapper$$i64::describe"` and `"Wrapper$$string::describe"` are
+// distinct throughout the checker–HIR–MIR–codegen pipeline.
+//
+// The mangle format matches `hew-hir::monomorph::mangle` for
+// `SymbolClass::Function`: `"{origin}$$" + args joined by "$"`, where each
+// arg is its canonical string segment (primitives → their keyword, named
+// types → their bare name, compounds → recursively rendered).
+//
+// These helpers live in `hew-types` (not `hew-hir`) because `hew-types` does
+// not depend on `hew-hir` and the checker must compute mangled keys without
+// introducing a circular dependency. `hew-hir` calls its own `mangle()` entry
+// point over `ResolvedTy` values; both produce byte-identical output for the
+// inputs that a concrete specialised impl target can carry.
+//
+// Scope: only concrete specialised impls ever produce mangled keys here.
+// Generic impls (`impl<T> Trait for Wrapper<T>`) and impls with no target type
+// args keep the bare name as before. This change is strictly additive on the
+// checker side: when the mangled key is absent from `fn_sigs` (e.g. an
+// unresolved or complex type arg), we fall back to the bare key so existing
+// behaviour is preserved.
+
+/// Render a single `ResolvedTy` as the canonical mangle segment used by
+/// `hew-hir::monomorph::mangle_resolved_ty`. Returns `None` for shapes that
+/// cannot be embedded (inference variables, error placeholders, abstract
+/// type-parameter references).
+///
+/// The output for every concrete type matches `hew-hir`'s rendering
+/// byte-for-byte: scalar keywords (`i64`, `string`, …), named types by their
+/// bare name (compound args separated by `_`), and compound shapes recursively.
+/// This function must be kept in sync with `hew-hir/src/monomorph.rs::mangle_resolved_ty`.
+#[must_use]
+pub fn mangle_resolved_ty_segment(ty: &ResolvedTy) -> Option<String> {
+    match ty {
+        ResolvedTy::I8 => Some("i8".to_string()),
+        ResolvedTy::I16 => Some("i16".to_string()),
+        ResolvedTy::I32 => Some("i32".to_string()),
+        ResolvedTy::I64 => Some("i64".to_string()),
+        ResolvedTy::U8 => Some("u8".to_string()),
+        ResolvedTy::U16 => Some("u16".to_string()),
+        ResolvedTy::U32 => Some("u32".to_string()),
+        ResolvedTy::U64 => Some("u64".to_string()),
+        ResolvedTy::Isize => Some("isize".to_string()),
+        ResolvedTy::Usize => Some("usize".to_string()),
+        ResolvedTy::F32 => Some("f32".to_string()),
+        ResolvedTy::F64 => Some("f64".to_string()),
+        ResolvedTy::Bool => Some("bool".to_string()),
+        ResolvedTy::Char => Some("char".to_string()),
+        ResolvedTy::String => Some("string".to_string()),
+        ResolvedTy::Bytes => Some("bytes".to_string()),
+        ResolvedTy::CancellationToken => Some("CancellationToken".to_string()),
+        ResolvedTy::Duration => Some("duration".to_string()),
+        ResolvedTy::Unit => Some("unit".to_string()),
+        ResolvedTy::Never => Some("never".to_string()),
+        ResolvedTy::Named { name, args, .. } => {
+            // Bare name, args joined by `_` — mirrors the HIR rendering.
+            let mut out = name.replace("::", "_");
+            for arg in args {
+                out.push('_');
+                out.push_str(&mangle_resolved_ty_segment(arg)?);
+            }
+            Some(out)
+        }
+        // Abstract type parameters, inference leftovers, and complex shapes
+        // (closures, tuples, pointers, …) produce None — callers fall back to
+        // the bare key, preserving existing behaviour.
+        ResolvedTy::TypeParam { .. }
+        | ResolvedTy::Tuple(_)
+        | ResolvedTy::Array(_, _)
+        | ResolvedTy::Slice(_)
+        | ResolvedTy::Function { .. }
+        | ResolvedTy::Closure { .. }
+        | ResolvedTy::Pointer { .. }
+        | ResolvedTy::Borrow { .. }
+        | ResolvedTy::TraitObject { .. }
+        | ResolvedTy::Task(_) => None,
+    }
+}
+
+/// Produce the mangled self-type name for a concrete specialised impl.
+///
+/// For `impl Describe for Wrapper<i64>`: returns `Some("Wrapper$$i64")`.
+/// For `impl Describe for Wrapper<string>`: returns `Some("Wrapper$$string")`.
+/// Returns `None` when any type arg cannot be mangled (e.g. abstract type
+/// parameters, inference variables), in which case callers fall back to the
+/// bare `name`.
+///
+/// The produced name matches `hew-hir::monomorph::mangle(name, type_args)` for
+/// `SymbolClass::Function` — both omit a class prefix and join args with `$$`
+/// + `$` separators.
+#[must_use]
+pub fn mangle_impl_self_name(name: &str, type_args: &[ResolvedTy]) -> Option<String> {
+    if type_args.is_empty() {
+        return None;
+    }
+    let mut out = String::from(name);
+    out.push_str("$$");
+    for (i, ty) in type_args.iter().enumerate() {
+        if i > 0 {
+            out.push('$');
+        }
+        out.push_str(&mangle_resolved_ty_segment(ty)?);
+    }
+    Some(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/vertical-slice/accept/impl_trait_concrete_specialisation.hew
+++ b/tests/vertical-slice/accept/impl_trait_concrete_specialisation.hew
@@ -1,0 +1,31 @@
+// Accept fixture: concrete impl-Trait specialisations — two distinct impls
+// for the same generic type (#2270).
+//
+// Two `impl Describe for Wrapper<i64>` and `impl Describe for Wrapper<string>`
+// blocks previously produced a mangled-symbol collision: both registered the
+// same `"Wrapper::describe"` symbol in fn_registry, the second clobbering the
+// first. Codegen then emitted two LLVM globals with the same name → linkage
+// error. The fix: concrete specialised impls mangle the self-type name with
+// the concrete type args (`"Wrapper$$i64"`, `"Wrapper$$string"`), producing
+// distinct symbols through the entire checker→HIR→MIR→codegen pipeline.
+trait Describe {
+    fn describe(val: Self) -> string;
+}
+
+type Wrapper<T> { inner: T; }
+
+impl Describe for Wrapper<i64> {
+    fn describe(w: Wrapper<i64>) -> string { "i64-wrapper" }
+}
+
+impl Describe for Wrapper<string> {
+    fn describe(w: Wrapper<string>) -> string { "string-wrapper" }
+}
+
+fn main() -> i64 {
+    let a = Wrapper<i64> { inner: 42 };
+    let b = Wrapper<string> { inner: "hello" };
+    let da = a.describe();
+    let db = b.describe();
+    if da == "i64-wrapper" && db == "string-wrapper" { 0 } else { 1 }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -510,6 +510,9 @@ if grep -qF 'E_CODEGEN_FRONT' "${reject_output}" || \
 fi
 run_accept_expect_stdout "static_trait_dispatch_inline_supertrait"
 run_accept_expect_stdout "static_trait_dispatch_intermediate_inline_supertrait"
+# Two concrete impl-Trait instantiations for the same generic type must produce
+# distinct codegen symbols (#2270: mangled-symbol collision → LLVM linkage crash).
+run_accept_expect_status "impl_trait_concrete_specialisation" 0
 
 run_accept_expect_status "assert_eq_fail" 134
 grep -q 'assertion failed: assert_eq(4, 5)' "${stderr_output}"


### PR DESCRIPTION
## Summary

Two concrete instantiations of an impl-Trait-returning generic were mangling to the same symbol name. LLVM received two globals with the same name, causing a codegen crash; `hew check` also failed on the same path. Concrete-specialised impl-Trait self-type names are now mangled with their concrete type-arg suffixes, so distinct instantiations get distinct symbols. impl methods are dual-registered under bare and mangled keys, and dispatch resolves the mangled key first, bypassing a module-stripping fallback that could false-match a qualified name.

## Verification

- Multi-instantiation probes: distinct symbol defines with correctly-targeted call sites — no collision, no crash, no duplicate-global
- Method-resolution / dispatch / run_e2e / wasi suites: regression-clean
- Unresolvable instantiation: fails closed at compile time
- New fixture: two concrete instantiations compile, check, and run with distinct correct values
- Preflight: ready-to-push

## Out of scope

- A checker↔HIR mangle asymmetry for compound type-args — no regression from current behaviour; tracked as a hardening follow-up.

Fixes #2270