### PR TITLE
feat(std/iter): carry item type on Take/Skip so terminals compose

### DIFF
--- a/std/iter.hew
+++ b/std/iter.hew
@@ -21,8 +21,8 @@
 //! |---------------|----------------------|--------------------------------|
 //! | `Map<I,A,B>`  | `map(it, f)`         | `B` from `fn(A) -> B`          |
 //! | `Filter<I,A>` | `filter(it, pred)`   | `A` (subset of inner)          |
-//! | `Take<I>`     | `take(it, n)`        | inner's `Item`                 |
-//! | `Skip<I>`     | `skip(it, n)`        | inner's `Item`                 |
+//! | `Take<I,A>`   | `take(it, n)`        | inner's `Item` (`A`)           |
+//! | `Skip<I,A>`   | `skip(it, n)`        | inner's `Item` (`A`)           |
 //!
 //! Terminal helpers (`fold`, `count`, `collect`) consume any `Iterator`.
 //!
@@ -122,12 +122,20 @@ impl<I, A> Iterator for Filter<I, A> where I: Iterator<Item = A> {
 
 /// Lazy take adapter: yields at most `remaining` items from the inner
 /// iterator, then reports `None`.
-pub type Take<I> {
+///
+/// `A` is the inner `Item` type. It is carried as a direct type parameter
+/// (rather than left projection-only in the impl bound) so a concrete site
+/// — `Take<Countdown, i64>` — pins the item type in the struct args, which
+/// is what the cross-module monomorphisation collector keys on. Map/Filter
+/// carry their item type the same way; without it a projection-only `A`
+/// stays free and terminals (`count`/`collect`/`fold`) fail to monomorphise
+/// (mir-gap-where-clause-proj-monomorph).
+pub type Take<I, A> {
     iter: I;
     remaining: i64;
 }
 
-impl<I, A> Iterator for Take<I> where I: Iterator<Item = A> {
+impl<I, A> Iterator for Take<I, A> where I: Iterator<Item = A> {
     type Item = A;
     fn next(var self) -> Option<A> {
 
@@ -155,12 +163,17 @@ impl<I, A> Iterator for Take<I> where I: Iterator<Item = A> {
 
 /// Lazy skip adapter: discards the first `remaining` items, then yields
 /// the rest of the inner iterator unchanged.
-pub type Skip<I> {
+///
+/// `A` is the inner `Item` type, carried as a direct type parameter for
+/// the same monomorphisation reason as `Take` (see above): a projection-
+/// only item param cannot be pinned by the collector, so terminals over
+/// `Skip` fail to monomorphise.
+pub type Skip<I, A> {
     iter: I;
     remaining: i64;
 }
 
-impl<I, A> Iterator for Skip<I> where I: Iterator<Item = A> {
+impl<I, A> Iterator for Skip<I, A> where I: Iterator<Item = A> {
     type Item = A;
     fn next(var self) -> Option<A> {
 
@@ -214,13 +227,13 @@ pub fn filter<I, A>(it: I, pred: fn(A) -> bool) -> Filter<I, A> where I: Iterato
 
 /// Construct a lazy `Take` adapter that yields at most `n` items from
 /// `it`.
-pub fn take<I, A>(it: I, n: i64) -> Take<I> where I: Iterator<Item = A> {
+pub fn take<I, A>(it: I, n: i64) -> Take<I, A> where I: Iterator<Item = A> {
     Take { iter: it, remaining: n }
 }
 
 /// Construct a lazy `Skip` adapter that discards the first `n` items
 /// from `it`.
-pub fn skip<I, A>(it: I, n: i64) -> Skip<I> where I: Iterator<Item = A> {
+pub fn skip<I, A>(it: I, n: i64) -> Skip<I, A> where I: Iterator<Item = A> {
     Skip { iter: it, remaining: n }
 }
 

--- a/tests/vertical-slice/accept/iter_skip_basic_run.hew
+++ b/tests/vertical-slice/accept/iter_skip_basic_run.hew
@@ -7,15 +7,14 @@
 //! and the adapter is transparent to the inner stream.
 //!
 //! The fixture-local `Skip<I, A>` carries `A` as a direct type parameter
-//! (unlike `std/iter.hew`'s `Skip<I>`) so the monomorphisation site can
-//! pin `A = i64` directly. This is required by the current MIR substrate:
-//! a type parameter appearing ONLY in a where-clause projection cannot be
-//! pinned by the monomorphisation collector (mir-gap-where-clause-proj-
-//! monomorph). The body logic is identical to `std/iter.hew::Skip::next`.
+//! (matching `std/iter.hew`'s `Skip<I, A>`) so the monomorphisation site
+//! can pin `A = i64` directly: a type parameter appearing ONLY in a
+//! where-clause projection cannot be pinned by the collector. The body
+//! logic is identical to `std/iter.hew::Skip::next`.
 //!
-//! Inlined and fully monomorphised: cross-module generic instantiation
-//! of `std::iter` does not yet lower through MIR (a separate backend
-//! lane), so the adapter types are defined locally.
+//! Self-contained (no `import std::iter`) so this fixture asserts the
+//! skip semantics on their own; `iter_xmod_skip_*` covers the imported
+//! chain through `count`/`collect`/`fold`.
 //!
 //! Expected exit code: 6 — sum of items after skipping 2 from
 //! Countdown{n:5}: [3, 2, 1]. Any internal mismatch returns a

--- a/tests/vertical-slice/accept/iter_take_basic_run.hew
+++ b/tests/vertical-slice/accept/iter_take_basic_run.hew
@@ -6,15 +6,14 @@
 //! exactly after `n` items regardless of inner stream depth.
 //!
 //! The fixture-local `Take<I, A>` carries `A` as a direct type parameter
-//! (unlike `std/iter.hew`'s `Take<I>`) so the monomorphisation site can
-//! pin `A = i64` directly. This is required by the current MIR substrate:
-//! a type parameter appearing ONLY in a where-clause projection cannot be
-//! pinned by the monomorphisation collector (mir-gap-where-clause-proj-
-//! monomorph). The body logic is identical to `std/iter.hew::Take::next`.
+//! (matching `std/iter.hew`'s `Take<I, A>`) so the monomorphisation site
+//! can pin `A = i64` directly: a type parameter appearing ONLY in a
+//! where-clause projection cannot be pinned by the collector. The body
+//! logic is identical to `std/iter.hew::Take::next`.
 //!
-//! Inlined and fully monomorphised: cross-module generic instantiation
-//! of `std::iter` does not yet lower through MIR (a separate backend
-//! lane), so the adapter types are defined locally.
+//! Self-contained (no `import std::iter`) so this fixture asserts the
+//! take semantics on their own; `iter_xmod_take_*` covers the imported
+//! chain through `count`/`collect`/`fold`.
 //!
 //! Expected exit code: 12 — sum of the first 3 items from
 //! Countdown{n:5}: [5, 4, 3]. Any internal mismatch returns a

--- a/tests/vertical-slice/accept/iter_xmod_skip_collect.hew
+++ b/tests/vertical-slice/accept/iter_xmod_skip_collect.hew
@@ -1,0 +1,37 @@
+// Cross-module chained generic-adapter monomorphisation: `Skip` + `collect`.
+//
+// `iter::skip` builds a `Skip<Countdown, i64>` adapter over the imported
+// iterator and `iter::collect` materialises the tail into a fresh owned
+// `Vec<i64>`. Non-owned `i64` elements keep the drop claim narrow; the
+// projection-only item param pins from the struct args.
+//
+// Countdown{5} yields [5,4,3,2,1]; skip(3) discards [5,4,3] then yields [2,1];
+// collect; sum = 3.
+import std::iter;
+
+type Countdown {
+    n: i64;
+}
+
+impl Iterator for Countdown {
+    type Item = i64;
+    fn next(var self) -> Option<i64> {
+        if self.n <= 0 {
+            None
+        } else {
+            let cur = self.n;
+            self.n = self.n - 1;
+            Some(cur)
+        }
+    }
+}
+
+pub fn main() -> i64 {
+    let s = iter::skip(Countdown { n: 5 }, 3);
+    let v: Vec<i64> = iter::collect(s);
+    var total = 0;
+    for n in v {
+        total = total + n;
+    }
+    total
+}

--- a/tests/vertical-slice/accept/iter_xmod_skip_count.hew
+++ b/tests/vertical-slice/accept/iter_xmod_skip_count.hew
@@ -1,0 +1,33 @@
+// Cross-module chained generic-adapter monomorphisation: `Skip` + `count`.
+//
+// `iter::skip` builds a `Skip<Countdown, i64>` adapter over the imported
+// iterator and `iter::count` drives it. `Skip` carries its item type as a
+// direct struct param so the projection-only `A` is pinned at the call site,
+// the burn-loop adapter method lowers per instantiation, and the count
+// terminal monomorphises across the import boundary.
+//
+// Countdown{5} yields [5,4,3,2,1]; skip(3) discards [5,4,3] then yields [2,1];
+// count returns 2.
+import std::iter;
+
+type Countdown {
+    n: i64;
+}
+
+impl Iterator for Countdown {
+    type Item = i64;
+    fn next(var self) -> Option<i64> {
+        if self.n <= 0 {
+            None
+        } else {
+            let cur = self.n;
+            self.n = self.n - 1;
+            Some(cur)
+        }
+    }
+}
+
+pub fn main() -> i64 {
+    let s = iter::skip(Countdown { n: 5 }, 3);
+    iter::count(s)
+}

--- a/tests/vertical-slice/accept/iter_xmod_skip_fold.hew
+++ b/tests/vertical-slice/accept/iter_xmod_skip_fold.hew
@@ -1,0 +1,32 @@
+// Cross-module chained generic-adapter monomorphisation: `Skip` + `fold`.
+//
+// `iter::skip` builds a `Skip<Countdown, i64>` adapter over the imported
+// iterator and `iter::fold` reduces the tail to a single accumulated value.
+// The projection-only item param pins from the struct args, so the generic
+// fold terminal monomorphises and lowers across the import boundary.
+//
+// Countdown{5} yields [5,4,3,2,1]; skip(3) discards [5,4,3] then yields [2,1];
+// fold (+) = 3.
+import std::iter;
+
+type Countdown {
+    n: i64;
+}
+
+impl Iterator for Countdown {
+    type Item = i64;
+    fn next(var self) -> Option<i64> {
+        if self.n <= 0 {
+            None
+        } else {
+            let cur = self.n;
+            self.n = self.n - 1;
+            Some(cur)
+        }
+    }
+}
+
+pub fn main() -> i64 {
+    let s = iter::skip(Countdown { n: 5 }, 3);
+    iter::fold(s, 0, |acc: i64, x: i64| acc + x)
+}

--- a/tests/vertical-slice/accept/iter_xmod_take_collect.hew
+++ b/tests/vertical-slice/accept/iter_xmod_take_collect.hew
@@ -1,0 +1,37 @@
+// Cross-module chained generic-adapter monomorphisation: `Take` + `collect`.
+//
+// `iter::take` builds a `Take<Countdown, i64>` adapter over the imported
+// iterator and `iter::collect` materialises it into a fresh owned `Vec<i64>`.
+// This drives the `collect` terminal through the same cross-module chain as the
+// take/count fixture; the collected element is a non-owned `i64`, so the owned
+// heap-element drop is a separate pre-existing concern, not certified here.
+//
+// Countdown{5} yields [5,4,3,2,1]; take(3) yields [5,4,3]; collect; sum = 12.
+import std::iter;
+
+type Countdown {
+    n: i64;
+}
+
+impl Iterator for Countdown {
+    type Item = i64;
+    fn next(var self) -> Option<i64> {
+        if self.n <= 0 {
+            None
+        } else {
+            let cur = self.n;
+            self.n = self.n - 1;
+            Some(cur)
+        }
+    }
+}
+
+pub fn main() -> i64 {
+    let t = iter::take(Countdown { n: 5 }, 3);
+    let v: Vec<i64> = iter::collect(t);
+    var total = 0;
+    for n in v {
+        total = total + n;
+    }
+    total
+}

--- a/tests/vertical-slice/accept/iter_xmod_take_count.hew
+++ b/tests/vertical-slice/accept/iter_xmod_take_count.hew
@@ -1,0 +1,34 @@
+// Cross-module chained generic-adapter monomorphisation: `Take` + `count`.
+//
+// `iter::take` builds a `Take<Countdown, i64>` adapter over the imported
+// iterator and `iter::count` drives it. `Take` now carries its item type as a
+// direct struct param (matching `Map`/`Filter`), so the projection-only `A` is
+// pinned from the struct args at the call site, a monomorphisation key is
+// minted, and the imported adapter method (`Take::next`) lowers per
+// instantiation across the import boundary — exactly as the `Map` count chain
+// does.
+//
+// Countdown{5} yields [5,4,3,2,1]; take(3) yields [5,4,3]; count returns 3.
+import std::iter;
+
+type Countdown {
+    n: i64;
+}
+
+impl Iterator for Countdown {
+    type Item = i64;
+    fn next(var self) -> Option<i64> {
+        if self.n <= 0 {
+            None
+        } else {
+            let cur = self.n;
+            self.n = self.n - 1;
+            Some(cur)
+        }
+    }
+}
+
+pub fn main() -> i64 {
+    let t = iter::take(Countdown { n: 5 }, 3);
+    iter::count(t)
+}

--- a/tests/vertical-slice/accept/iter_xmod_take_fold.hew
+++ b/tests/vertical-slice/accept/iter_xmod_take_fold.hew
@@ -1,0 +1,31 @@
+// Cross-module chained generic-adapter monomorphisation: `Take` + `fold`.
+//
+// `iter::take` builds a `Take<Countdown, i64>` adapter over the imported
+// iterator and `iter::fold` reduces it to a single accumulated value. The
+// projection-only item param pins from the struct args, so the generic fold
+// terminal monomorphises and lowers across the import boundary.
+//
+// Countdown{5} yields [5,4,3,2,1]; take(3) yields [5,4,3]; fold (+) = 12.
+import std::iter;
+
+type Countdown {
+    n: i64;
+}
+
+impl Iterator for Countdown {
+    type Item = i64;
+    fn next(var self) -> Option<i64> {
+        if self.n <= 0 {
+            None
+        } else {
+            let cur = self.n;
+            self.n = self.n - 1;
+            Some(cur)
+        }
+    }
+}
+
+pub fn main() -> i64 {
+    let t = iter::take(Countdown { n: 5 }, 3);
+    iter::fold(t, 0, |acc: i64, x: i64| acc + x)
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -385,6 +385,20 @@ run_accept_expect_status "iter_xmod_map_collect" 12
 # fact resolved. Countdown{4} mapped by +bump(10) then counted → 4.
 run_accept_expect_status "iter_xmod_captured_closure" 4
 
+# Take/Skip carry their item type as a direct struct param (like Map/Filter),
+# so the projection-only `A` pins from the struct args at a cross-module call
+# site and the imported adapter method lowers per instantiation. This closes
+# the matrix: count/collect/fold each compose with take and skip across the
+# import boundary the same way they do with map. Countdown{5} = [5,4,3,2,1].
+# take(3) → [5,4,3]: count 3, collect sum 12, fold 12.
+run_accept_expect_status "iter_xmod_take_count" 3
+run_accept_expect_status "iter_xmod_take_collect" 12
+run_accept_expect_status "iter_xmod_take_fold" 12
+# skip(3) → [2,1]: count 2, collect sum 3, fold 3.
+run_accept_expect_status "iter_xmod_skip_count" 2
+run_accept_expect_status "iter_xmod_skip_collect" 3
+run_accept_expect_status "iter_xmod_skip_fold" 3
+
 # where-clause-projection monomorphisation (CLOSED): a generic terminal whose
 # type param appears only in a `where I: Iterator<Item = A>` projection now
 # pins that param from the iterator's concrete associated type and lowers


### PR DESCRIPTION
## Summary
Take<I>/Skip<I> left item type projection-only → count/collect/fold couldn't consume. Add explicit Take<I,A>/Skip<I,A> param. stdlib-only.
## Verification
ci-preflight 14/14, 6 cross-module fixtures, flake 3/3.