### PR TITLE
feat(mir): bytes push/set/clear/append in value position

### DIFF
--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -21852,6 +21852,21 @@ impl Builder {
         }
     }
 
+    /// Materialise the `()` result for a bytes mutator (`push`/`set`/`clear`/
+    /// `append`) used in value/match-arm position. The op already emitted its
+    /// side-effecting `push_runtime_call`; the write-back and drop accounting
+    /// are identical to statement position. In value position the caller binds
+    /// a unit, so allocate a fresh zero-sized Unit and define it; in statement
+    /// position the result is discarded and we return `None`.
+    fn lower_bytes_unit_result(&mut self, context: RuntimeCallContext) -> Option<Place> {
+        if context != RuntimeCallContext::ValueNeeded {
+            return None;
+        }
+        let dest = self.alloc_local(ResolvedTy::Unit);
+        self.push_instr(Instr::UnitLit { dest });
+        Some(dest)
+    }
+
     fn lower_bytes_push(
         &mut self,
         hir_args: &[hew_hir::HirExpr],
@@ -21871,23 +21886,10 @@ impl Builder {
             });
             return None;
         }
-        if context == RuntimeCallContext::ValueNeeded {
-            self.diagnostics.push(MirDiagnostic {
-                kind: MirDiagnosticKind::NotYetImplemented {
-                    construct: "runtime call `hew_bytes_push` value result".to_string(),
-                    site,
-                },
-                note: "`hew_bytes_push` returns unit and is currently wired for \
-                       statement-position mutation only"
-                    .to_string(),
-            });
-            return None;
-        }
-
         let bytes = self.lower_value(&hir_args[0])?;
         let byte = self.lower_value(&hir_args[1])?;
         self.push_runtime_call("hew_bytes_push", vec![bytes, byte], None);
-        None
+        self.lower_bytes_unit_result(context)
     }
 
     /// Emit `hew_bytes_pop(&mut BytesTriple) -> i64` for `bytes.pop()`.
@@ -21949,23 +21951,11 @@ impl Builder {
             });
             return None;
         }
-        if context == RuntimeCallContext::ValueNeeded {
-            self.diagnostics.push(MirDiagnostic {
-                kind: MirDiagnosticKind::NotYetImplemented {
-                    construct: "runtime call `hew_bytes_set` value result".to_string(),
-                    site,
-                },
-                note: "`hew_bytes_set` returns unit and is wired for statement-position \
-                       mutation only"
-                    .to_string(),
-            });
-            return None;
-        }
         let buf = self.lower_value(&hir_args[0])?;
         let idx = self.lower_value(&hir_args[1])?;
         let byte = self.lower_value(&hir_args[2])?;
         self.push_runtime_call("hew_bytes_set", vec![buf, idx, byte], None);
-        None
+        self.lower_bytes_unit_result(context)
     }
 
     /// Emit `hew_bytes_is_empty(*const BytesTriple) -> bool` for
@@ -22051,21 +22041,9 @@ impl Builder {
             });
             return None;
         }
-        if context == RuntimeCallContext::ValueNeeded {
-            self.diagnostics.push(MirDiagnostic {
-                kind: MirDiagnosticKind::NotYetImplemented {
-                    construct: "runtime call `hew_bytes_clear` value result".to_string(),
-                    site,
-                },
-                note: "`hew_bytes_clear` returns unit and is wired for statement-position \
-                       mutation only"
-                    .to_string(),
-            });
-            return None;
-        }
         let buf = self.lower_value(&hir_args[0])?;
         self.push_runtime_call("hew_bytes_clear", vec![buf], None);
-        None
+        self.lower_bytes_unit_result(context)
     }
 
     /// Emit `hew_bytes_append(&mut dst, ...)` for `bytes.append(other)`.
@@ -22096,22 +22074,10 @@ impl Builder {
             });
             return None;
         }
-        if context == RuntimeCallContext::ValueNeeded {
-            self.diagnostics.push(MirDiagnostic {
-                kind: MirDiagnosticKind::NotYetImplemented {
-                    construct: "runtime call `hew_bytes_append` value result".to_string(),
-                    site,
-                },
-                note: "`hew_bytes_append` returns unit and is wired for statement-position \
-                       mutation only"
-                    .to_string(),
-            });
-            return None;
-        }
         let dst = self.lower_value(&hir_args[0])?;
         let other = self.lower_value(&hir_args[1])?;
         self.push_runtime_call("hew_bytes_append", vec![dst, other], None);
-        None
+        self.lower_bytes_unit_result(context)
     }
 
     /// Emit `hew_vec_len(buf) -> i64` for `bytes.len()` calls.

--- a/tests/vertical-slice/accept/bytes_unitop_match_value.hew
+++ b/tests/vertical-slice/accept/bytes_unitop_match_value.hew
@@ -1,0 +1,62 @@
+// bytes mutators (push/set/clear/append) in match-arm (value) position. Each
+// op types as unit; bound as the match result, MIR must materialise a fresh
+// () rather than fail closed, while the buffer write-back stays identical to
+// statement position. Returns 0 only when every read-back assertion holds.
+fn main() -> i64 {
+    let b: bytes = bytes::new();
+    // push from a match arm (3x): the arm yields unit, bound by `let _`.
+    for i in 0..3 {
+        let _ = match i {
+            0 => b.push(10),
+            1 => b.push(20),
+            _ => b.push(30),
+        };
+    }
+    if b.len() != 3 {
+        return 11;
+    }
+    // set from a match arm.
+    let _ = match b.len() {
+        3 => b.set(1, 99),
+        _ => (),
+    };
+    if b[0] != 10 {
+        return 12;
+    }
+    if b[1] != 99 {
+        return 13;
+    }
+    if b[2] != 30 {
+        return 14;
+    }
+    // append from a match arm: source is copied, not consumed.
+    let other: bytes = bytes::new();
+    other.push(40);
+    other.push(50);
+    let _ = match true {
+        true => b.append(other),
+        false => (),
+    };
+    if b.len() != 5 {
+        return 15;
+    }
+    if b[4] != 50 {
+        return 16;
+    }
+    if other.len() != 2 {
+        return 17;
+    }
+    // clear from a match arm: buffer empties and is reusable.
+    let _ = match 1 {
+        1 => b.clear(),
+        _ => (),
+    };
+    if !b.is_empty() {
+        return 18;
+    }
+    b.push(7);
+    if b.len() != 1 {
+        return 19;
+    }
+    0
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1277,6 +1277,13 @@ run_accept_expect_status "bytes_contains" 0
 run_accept_expect_status "bytes_clear" 0
 run_accept_expect_status "bytes_append" 0
 
+# Bytes mutators in match-arm (value) position: push/set/clear/append each
+# type as unit, so binding the match result must materialise a fresh () in
+# MIR rather than fail closed, with write-back identical to statement
+# position. Drives all four from match arms and reads back exact bytes;
+# exits 0 only when every assertion holds.
+run_accept_expect_status "bytes_unitop_match_value" 0
+
 # Fail-closed negatives: pop on an empty buffer and set past the end abort via
 # the bytes runtime trap (exit 134 = SIGABRT+128), the same fail-closed
 # termination as bytes_index_oob_traps.


### PR DESCRIPTION
## Summary
Remove NYI gates; materialise unit when value needed; write-back identical to stmt position.
## Verification
ci-preflight RC=0, match-arm fixture, flake 3/3.