### PR TITLE
feat(types): must_use lint for discarded WriteError/SendError

### DIFF
--- a/docs/design/lint-pass.md
+++ b/docs/design/lint-pass.md
@@ -7,7 +7,7 @@ M1 + M2 have landed: the lint infrastructure (`LintId` / `LintLevel` /
 `LintLevels`), the checker `run_lints` sweep, the CLI `--allow` / `--warn` /
 `--deny` flags, and in-source `// hew:allow(...)` suppression — plus six
 checker lints (`needless_range_loop`, `redundant_else_after_return`,
-`needless_match_to_if_let`, `len_zero_comparison`, `needless_bool`) and the two
+`needless_match_to_if_let`, `len_zero_comparison`, `needless_bool`, `must_use`) and the two
 ad-hoc warnings (`clone_on_copy`, `dead_code`) migrated onto the registry so
 they are now re-levelable and suppressible. M3 has landed too: a backward
 liveness dataflow pass in `hew-mir`, the `dead_store` MIR lint built on it, and
@@ -215,6 +215,13 @@ the precise subset that is actually convertible.
     `!c`. *Guards:* each branch must be exactly one boolean literal (no other statements); the two
     branches must be opposite polarities (a matching pair is a constant, not this lint); `else if`
     chains never collapse the outer `if`. Position-agnostic (the rewrite is valid anywhere).
+  - **`must_use`** — a discarded value carrying a write/send error that must not be ignored:
+    `WriteError` / `SendError`, bare or as the error arm of a `Result<_, E>`. *Guards:* statement
+    position only (a trailing block value, a `let`/`var` binding, a `match`/`if let` scrutinee, and
+    `expr?` are all "used" and never flagged); the resolved type must be exactly the must-use error
+    or a `Result` over it, matched by canonical name so the builtin `SendError` and the stdlib
+    `WriteError` both qualify. Discarding either fails open — a dropped backpressure/disconnect
+    signal or an unnoticed undelivered send. Opt out with `let _ = …` or `// hew:allow(must_use)`.
   - **Migrations.** `clone_on_copy` (clone on a Copy/BitCopy type; `hew-types/src/check/methods.rs`)
     and `dead_code` (unreachable functions; `hew-types/src/check/diagnostics.rs`) now emit through
     `Checker::emit_main_pass_lint`, giving them a `LintId` with `default_level() = Warn`. Default

--- a/hew-cli/tests/lint_pass_e2e.rs
+++ b/hew-cli/tests/lint_pass_e2e.rs
@@ -434,3 +434,74 @@ fn clean_counter_is_unregistered_and_fails_closed() {
         "expected a clear unknown-lint error naming clean_counter:\n{stderr}"
     );
 }
+
+// ── checker-stage lint: must_use ─────────────────────────────────────
+
+/// A program whose only diagnostic is `must_use`: the `Result<(), WriteError>`
+/// returned by `w()` is discarded in statement position, so a write error is
+/// silently dropped. `main` and `w` are both reachable (no `dead_code` noise).
+const MUST_USE_DISCARD: &str = "enum WriteError { Disconnected(i64); }\n\
+     fn w() -> Result<(), WriteError> { Ok(()) }\n\
+     fn main() {\n\
+     w();\n\
+     }\n";
+
+/// The same program with an in-source allow directive on the line above.
+const MUST_USE_SUPPRESSED: &str = "enum WriteError { Disconnected(i64); }\n\
+     fn w() -> Result<(), WriteError> { Ok(()) }\n\
+     fn main() {\n\
+     // hew:allow(must_use)\n\
+     w();\n\
+     }\n";
+
+const MUST_USE_MESSAGE: &str = "an ignored write/send error fails open";
+
+#[test]
+fn must_use_warning_renders_by_default() {
+    let output = run_check(MUST_USE_DISCARD, &[]);
+    let stderr = stderr_of(&output);
+    assert!(
+        output.status.success(),
+        "a must_use warning must not fail the build:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("warning:") && stderr.contains(MUST_USE_MESSAGE),
+        "expected the must_use warning to render:\n{stderr}"
+    );
+}
+
+#[test]
+fn must_use_allow_flag_suppresses() {
+    let output = run_check(MUST_USE_DISCARD, &["--allow", "must_use"]);
+    let stderr = stderr_of(&output);
+    assert!(output.status.success(), "check should pass:\n{stderr}");
+    assert!(
+        !stderr.contains(MUST_USE_MESSAGE),
+        "--allow must_use must suppress the lint:\n{stderr}"
+    );
+}
+
+#[test]
+fn must_use_deny_flag_promotes_to_error() {
+    let output = run_check(MUST_USE_DISCARD, &["--deny", "must_use"]);
+    let stderr = stderr_of(&output);
+    assert!(
+        !output.status.success(),
+        "--deny must_use must fail the build:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("error:") && stderr.contains(MUST_USE_MESSAGE),
+        "--deny must render must_use as an error:\n{stderr}"
+    );
+}
+
+#[test]
+fn must_use_inline_directive_suppresses() {
+    let output = run_check(MUST_USE_SUPPRESSED, &[]);
+    let stderr = stderr_of(&output);
+    assert!(output.status.success(), "check should pass:\n{stderr}");
+    assert!(
+        !stderr.contains(MUST_USE_MESSAGE),
+        "an in-source `// hew:allow(must_use)` must suppress the lint:\n{stderr}"
+    );
+}

--- a/hew-types/src/check/lints/mod.rs
+++ b/hew-types/src/check/lints/mod.rs
@@ -44,6 +44,7 @@ use crate::ty::{Substitution, Ty};
 use super::types::SpanKey;
 
 mod len_zero_comparison;
+mod must_use;
 mod needless_bool;
 mod needless_match_to_if_let;
 mod needless_range_loop;
@@ -82,6 +83,12 @@ pub enum LintId {
     /// is overwritten or goes out of scope — the store is dead. Emitted by the
     /// MIR-stage liveness pass (`hew-mir`), not the HIR checker sweep.
     DeadStore,
+    /// A discarded value carries a write/send error that must not be ignored —
+    /// `WriteError` / `SendError`, bare or as the error arm of a `Result`. A
+    /// statement-position discard fails open (a dropped backpressure /
+    /// disconnect signal, an unnoticed undelivered send); handle it or bind
+    /// `let _ = …`.
+    MustUse,
     // NOTE: a `clean_counter` lint (a loop-carried accumulator that is
     // incremented but never read after the loop) is deliberately NOT registered
     // here. It has no emission code yet, and registering an un-emitted lint
@@ -105,6 +112,7 @@ impl LintId {
         LintId::CloneOnCopy,
         LintId::DeadCode,
         LintId::DeadStore,
+        LintId::MustUse,
     ];
 
     /// The stable, lowercase string name for this lint.
@@ -123,6 +131,7 @@ impl LintId {
             LintId::CloneOnCopy => "clone_on_copy",
             LintId::DeadCode => "dead_code",
             LintId::DeadStore => "dead_store",
+            LintId::MustUse => "must_use",
         }
     }
 
@@ -147,7 +156,8 @@ impl LintId {
             | LintId::NeedlessBool
             | LintId::CloneOnCopy
             | LintId::DeadCode
-            | LintId::DeadStore => LintLevel::Warn,
+            | LintId::DeadStore
+            | LintId::MustUse => LintLevel::Warn,
         }
     }
 }
@@ -413,6 +423,7 @@ pub(super) fn lint_block(
     needless_match_to_if_let::check(ctx, levels, body, out);
     len_zero_comparison::check(ctx, levels, body, out);
     needless_bool::check(ctx, levels, body, out);
+    must_use::check(ctx, levels, body, out);
 }
 
 // ── shared read-only body walker ─────────────────────────────────────

--- a/hew-types/src/check/lints/must_use.rs
+++ b/hew-types/src/check/lints/must_use.rs
@@ -1,0 +1,112 @@
+//! The `must_use` lint.
+//!
+//! Flags a *discarded* value whose type carries a write/send failure that must
+//! not be ignored — `WriteError` and `SendError`, the error arms returned by
+//! `Connection.write` and the pid `tell` family. Dropping such a value on the
+//! floor silently fails open: a backpressure or disconnect signal vanishes, an
+//! undelivered message is never noticed. A program should handle it (`?`,
+//! `match`) or discard it explicitly (`let _ = …`).
+//!
+//! The value is flagged in two shapes:
+//!
+//! - the bare error: `WriteError` / `SendError`;
+//! - a `Result<_, E>` whose error arm is one of those — the common case, since
+//!   `write()` returns `Result<(), WriteError>` and `tell()` returns
+//!   `Result<(), SendError>`.
+//!
+//! ## Precision over recall
+//!
+//! - Only fires in **statement position** (a `Stmt::Expression` whose value the
+//!   block discards). A trailing expression (the block's value), a `let` /
+//!   `var` binding, and a `match` / `if let` scrutinee are all "used" and never
+//!   flagged. `expr?` lands here typed as the unwrapped ok arm, so a handled
+//!   call is silent; only the unhandled discard remains.
+//! - The discarded expression's resolved type must be exactly `WriteError` /
+//!   `SendError` or `Result<_, WriteError|SendError>`, verified through
+//!   [`LintCtx::resolved_type_at`]; an unresolved type stays silent.
+//! - `// hew:allow(must_use)` (or an explicit `let _ = …`) is the documented
+//!   opt-out, mirroring the registry's other suppressible lints.
+
+use hew_parser::ast::{Block, Span, Stmt};
+
+use crate::error::TypeError;
+use crate::ty::Ty;
+
+use super::{LintCtx, LintId, LintLevels, NodeVisitor};
+
+/// Entry point: walk `body` and flag every discarded must-use error value.
+pub(super) fn check(ctx: &LintCtx, levels: &LintLevels, body: &Block, out: &mut Vec<TypeError>) {
+    let mut visitor = MustUse {
+        ctx,
+        hits: Vec::new(),
+    };
+    super::walk_body(body, &mut visitor);
+    for hit in visitor.hits {
+        ctx.emit(
+            levels,
+            LintId::MustUse,
+            &hit.span,
+            format!("discarded `{}` value; an ignored write/send error fails open", hit.error),
+            format!("handle it (`?`, `match`) or discard explicitly with `let _ = …` — `{}` reports backpressure, disconnect, or undelivered sends", hit.error),
+            out,
+        );
+    }
+}
+
+struct Hit {
+    span: Span,
+    /// Stable name of the offending error type (`WriteError` / `SendError`),
+    /// used to render the message and suggestion.
+    error: &'static str,
+}
+
+struct MustUse<'a> {
+    ctx: &'a LintCtx<'a>,
+    hits: Vec<Hit>,
+}
+
+impl NodeVisitor for MustUse<'_> {
+    fn visit_block(&mut self, block: &Block) {
+        // Statement position only: a block's `stmts` are evaluated for effect
+        // (value discarded); its `trailing_expr` is the block's value and is
+        // therefore used. Bindings (`Stmt::Let`/`Stmt::Var`), matches, and the
+        // `?` operator are distinct stmt/expr shapes and never reach here.
+        for (stmt, _span) in &block.stmts {
+            let Stmt::Expression((_expr, expr_span)) = stmt else {
+                continue;
+            };
+            if let Some(error) = self
+                .ctx
+                .resolved_type_at(expr_span)
+                .as_ref()
+                .and_then(must_use_error)
+            {
+                self.hits.push(Hit {
+                    span: expr_span.clone(),
+                    error,
+                });
+            }
+        }
+    }
+}
+
+/// The stable name of the must-use error a discarded value carries, or `None`.
+///
+/// Matches the bare error type and a `Result<_, E>` whose error arm is one. The
+/// match is by canonical name so it covers both the builtin `SendError` and the
+/// stdlib `WriteError` enum identically.
+fn must_use_error(ty: &Ty) -> Option<&'static str> {
+    if let Some((_, err)) = ty.as_result() {
+        return error_name(err);
+    }
+    error_name(ty)
+}
+
+/// `WriteError` / `SendError` named-type detection.
+fn error_name(ty: &Ty) -> Option<&'static str> {
+    match ty {
+        Ty::Named { name, .. } if name == "WriteError" => Some("WriteError"),
+        Ty::Named { name, .. } if name == "SendError" => Some("SendError"),
+        _ => None,
+    }
+}

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -3564,6 +3564,147 @@ fn warn_dead_code_self_recursive_function() {
 }
 
 // -----------------------------------------------------------------------
+// must_use lint
+// -----------------------------------------------------------------------
+
+fn count_must_use(diags: &[TypeError]) -> usize {
+    diags
+        .iter()
+        .filter(|d| d.kind == TypeErrorKind::Lint(LintId::MustUse))
+        .count()
+}
+
+/// A local `WriteError`/`SendError` plus a fn returning each as a `Result` error
+/// arm — enough to exercise the lint without loading the stdlib (the lint keys
+/// on the canonical type name, which matches both the stdlib and these locals).
+const MUST_USE_PRELUDE: &str = "enum WriteError { Disconnected(i64); }\n\
+     enum SendError { Closed; }\n\
+     fn w() -> Result<(), WriteError> { Ok(()) }\n\
+     fn s() -> Result<(), SendError> { Ok(()) }\n";
+
+#[test]
+fn must_use_flags_discarded_write_result() {
+    let src = format!("{MUST_USE_PRELUDE}fn caller() {{ w(); }}");
+    let (errors, warnings) = parse_and_check(&src);
+    assert!(errors.is_empty(), "fixture should type-check: {errors:?}");
+    let hit = warnings
+        .iter()
+        .find(|w| w.kind == TypeErrorKind::Lint(LintId::MustUse))
+        .expect("a discarded Result<(), WriteError> must fire must_use");
+    assert!(hit.message.contains("WriteError"), "msg: {}", hit.message);
+}
+
+#[test]
+fn must_use_flags_discarded_send_result() {
+    let src = format!("{MUST_USE_PRELUDE}fn caller() {{ s(); }}");
+    let (_, warnings) = parse_and_check(&src);
+    let hit = warnings
+        .iter()
+        .find(|w| w.kind == TypeErrorKind::Lint(LintId::MustUse))
+        .expect("a discarded Result<(), SendError> must fire must_use");
+    assert!(hit.message.contains("SendError"), "msg: {}", hit.message);
+}
+
+#[test]
+fn must_use_flags_bare_error_value() {
+    let src = "enum WriteError { Disconnected(i64); }\n\
+         fn make() -> WriteError { WriteError::Disconnected(1) }\n\
+         fn caller() { make(); }";
+    let (_, warnings) = parse_and_check(src);
+    assert_eq!(
+        count_must_use(&warnings),
+        1,
+        "a bare discarded WriteError must fire, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn must_use_not_flagged_when_handled_by_question() {
+    let src = format!("{MUST_USE_PRELUDE}fn caller() -> Result<(), WriteError> {{ w()?; Ok(()) }}");
+    let (_, warnings) = parse_and_check(&src);
+    assert_eq!(
+        count_must_use(&warnings),
+        0,
+        "`?` consumes the Result, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn must_use_not_flagged_when_explicitly_bound() {
+    let src = format!("{MUST_USE_PRELUDE}fn caller() {{ let _ = w(); }}");
+    let (_, warnings) = parse_and_check(&src);
+    assert_eq!(
+        count_must_use(&warnings),
+        0,
+        "`let _ =` is the documented opt-out, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn must_use_not_flagged_in_tail_position() {
+    // The trailing expression is the block's value (used), not a discard.
+    let src = format!("{MUST_USE_PRELUDE}fn caller() -> Result<(), WriteError> {{ w() }}");
+    let (_, warnings) = parse_and_check(&src);
+    assert_eq!(
+        count_must_use(&warnings),
+        0,
+        "a tail Result is the function's value, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn must_use_not_flagged_when_matched() {
+    let src =
+        format!("{MUST_USE_PRELUDE}fn caller() {{ match w() {{ Ok(_) => {{}} Err(_) => {{}} }} }}");
+    let (_, warnings) = parse_and_check(&src);
+    assert_eq!(
+        count_must_use(&warnings),
+        0,
+        "a matched Result is handled, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn must_use_not_flagged_for_ordinary_result() {
+    // Only WriteError/SendError are must-use; an unrelated error is left alone.
+    let src = "fn g() -> Result<(), i64> { Ok(()) }\nfn caller() { g(); }";
+    let (_, warnings) = parse_and_check(src);
+    assert_eq!(
+        count_must_use(&warnings),
+        0,
+        "a non-must-use error must not fire, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn must_use_deny_routes_to_errors() {
+    let src = format!("{MUST_USE_PRELUDE}fn caller() {{ w(); }}");
+    let out = check_with_lint_level(&src, LintId::MustUse, LintLevel::Deny);
+    assert_eq!(count_must_use(&out.errors), 1, "errors: {:?}", out.errors);
+    assert_eq!(count_must_use(&out.warnings), 0);
+}
+
+#[test]
+fn must_use_allow_suppresses() {
+    let src = format!("{MUST_USE_PRELUDE}fn caller() {{ w(); }}");
+    let out = check_with_lint_level(&src, LintId::MustUse, LintLevel::Allow);
+    assert_eq!(count_must_use(&out.warnings), 0);
+    assert_eq!(count_must_use(&out.errors), 0);
+}
+
+#[test]
+fn must_use_suppressed_by_directive() {
+    let src = format!("{MUST_USE_PRELUDE}fn caller() {{\n    // hew:allow(must_use)\n    w();\n}}");
+    let out = check_with_lint_level(&src, LintId::MustUse, LintLevel::Warn);
+    assert_eq!(
+        count_must_use(&out.warnings),
+        0,
+        "a directive above the discard must suppress, warnings: {:?}",
+        out.warnings
+    );
+}
+
+// -----------------------------------------------------------------------
 // Module namespacing tests
 // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Warn on statement-position discarded WriteError/SendError (bare or Result err-arm); ?/let/match/tail silent. -A/-W/-D + // hew:allow.
## Verification
174 lint units, 25 e2e, flake 3/3, checked-mir byte-identical.