### PR TITLE
fix: dogfood lint false-positives (RAII unused, _-discard, local-actor orphan, MustConsume caret)

### DIFF
--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -525,7 +525,7 @@ fn mir_primary_site(kind: &hew_mir::MirDiagnosticKind) -> Option<hew_hir::SiteId
         hew_mir::MirDiagnosticKind::DecisionMapTotal { offending_sites } => {
             offending_sites.first().copied()
         }
-        hew_mir::MirDiagnosticKind::MustConsume { exit_site, .. } => Some(*exit_site),
+        hew_mir::MirDiagnosticKind::MustConsume { bind_site, .. } => Some(*bind_site),
         hew_mir::MirDiagnosticKind::SelectArmNotImplemented { site, .. }
         | hew_mir::MirDiagnosticKind::NotYetImplemented { site, .. }
         | hew_mir::MirDiagnosticKind::InvalidActorSpawnArgument { site, .. }

--- a/hew-cli/tests/lint_pass_e2e.rs
+++ b/hew-cli/tests/lint_pass_e2e.rs
@@ -336,6 +336,19 @@ const FOR_RANGE_CLEAN: &str = "fn sum(n: i64) -> i64 {\n\
 
 const DEAD_STORE_MESSAGE: &str = "is never read before it is overwritten";
 
+/// The same shape as `DEAD_STORE`, but the discarded local is `_`-prefixed:
+/// the documented "intentionally unused" idiom. A dead store into an
+/// underscore binding must stay silent — the user already declared the value
+/// disposable — even when `dead_store` is escalated to `-D`.
+const DEAD_STORE_UNDERSCORE: &str = "fn f() -> i64 {\n\
+     var _x = 5;\n\
+     _x = 6;\n\
+     _x\n\
+     }\n\
+     fn main() {\n\
+     let _ = f();\n\
+     }\n";
+
 #[test]
 fn dead_store_warns_by_default() {
     let output = run_check(DEAD_STORE, &[]);
@@ -414,6 +427,24 @@ fn for_range_loop_does_not_trip_dead_store() {
     assert!(
         !stderr.contains(DEAD_STORE_MESSAGE),
         "dead_store must not misfire on a normal counting loop:\n{stderr}"
+    );
+}
+
+#[test]
+fn underscore_local_does_not_trip_dead_store() {
+    // `let _r = t.consume();` keeps the side-effecting call but throws the
+    // result away on purpose. The `_` prefix is the documented discard idiom,
+    // so a dead store into it must stay silent even under -D — nagging the user
+    // to prefix what is already prefixed would be a false positive.
+    let output = run_check(DEAD_STORE_UNDERSCORE, &["-D", "dead_store"]);
+    let stderr = stderr_of(&output);
+    assert!(
+        output.status.success(),
+        "a dead store into an `_`-prefixed local must not fail the build:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains(DEAD_STORE_MESSAGE),
+        "dead_store must not fire on an underscore-prefixed binding:\n{stderr}"
     );
 }
 

--- a/hew-mir/src/dataflow.rs
+++ b/hew-mir/src/dataflow.rs
@@ -202,7 +202,7 @@ fn transfer_block(
     entry: BTreeMap<BindingId, BindingState>,
     block: &BasicBlock,
     type_classes: &TypeClassTable,
-    linear_bindings: &mut BTreeMap<BindingId, (String, ResolvedTy)>,
+    linear_bindings: &mut BTreeMap<BindingId, (String, ResolvedTy, SiteId)>,
     checks: &mut Vec<MirCheck>,
     use_after_consume_seen: &mut HashSet<(BindingId, SiteId)>,
     init_before_use_seen: &mut HashSet<(BindingId, SiteId)>,
@@ -211,11 +211,14 @@ fn transfer_block(
     for statement in &block.statements {
         match statement {
             MirStatement::Bind {
-                binding, name, ty, ..
+                binding,
+                name,
+                ty,
+                site,
             } => {
                 state.insert(*binding, BindingState::Live);
                 if ValueClass::of_ty(ty, type_classes) == ValueClass::Linear {
-                    linear_bindings.insert(*binding, (name.clone(), ty.clone()));
+                    linear_bindings.insert(*binding, (name.clone(), ty.clone(), *site));
                 }
             }
             MirStatement::Use {
@@ -843,7 +846,7 @@ pub fn analyze(
     // we only evaluate `Use` nodes against states that reflect every
     // reachable path.
     let mut exit_states: HashMap<u32, BTreeMap<BindingId, BindingState>> = HashMap::new();
-    let mut linear_bindings: BTreeMap<BindingId, (String, ResolvedTy)> = BTreeMap::new();
+    let mut linear_bindings: BTreeMap<BindingId, (String, ResolvedTy, SiteId)> = BTreeMap::new();
 
     // Worklist seeded in Reverse Post-Order (RPO). RPO ensures every
     // block's dominators on the acyclic spanning tree are processed
@@ -992,7 +995,7 @@ pub fn analyze(
             continue;
         };
         for (binding, state) in exit_state {
-            let Some((name, ty)) = linear_bindings.get(binding) else {
+            let Some((name, ty, bind_site)) = linear_bindings.get(binding) else {
                 continue;
             };
             let needs_report = matches!(
@@ -1006,6 +1009,7 @@ pub fn analyze(
                 checks.push(MirCheck::MustConsume {
                     binding: *binding,
                     name: name.clone(),
+                    bind_site: *bind_site,
                     exit_site,
                     ty: ty.clone(),
                 });

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -1251,10 +1251,11 @@ fn render_mir_check(check: &MirCheck) -> String {
         MirCheck::MustConsume {
             binding,
             name,
+            bind_site,
             exit_site,
             ty,
         } => format!(
-            "MustConsume {binding:?} {name} exit={exit_site:?} ty={}",
+            "MustConsume {binding:?} {name} bind={bind_site:?} exit={exit_site:?} ty={}",
             ty.user_facing()
         ),
         MirCheck::DropPlanUndetermined { block, reason } => {
@@ -1388,10 +1389,11 @@ fn render_diag_kind(kind: &MirDiagnosticKind) -> String {
         MirDiagnosticKind::MustConsume {
             binding,
             name,
+            bind_site,
             exit_site,
             ty,
         } => format!(
-            "MustConsume {binding:?} {name} exit={exit_site:?} ty={}",
+            "MustConsume {binding:?} {name} bind={bind_site:?} exit={exit_site:?} ty={}",
             ty.user_facing()
         ),
         MirDiagnosticKind::UnknownType { name } => format!("UnknownType {name}"),

--- a/hew-mir/src/liveness.rs
+++ b/hew-mir/src/liveness.rs
@@ -322,6 +322,14 @@ fn dead_store_target_name(func: &RawMirFunction, n: u32, param_count: usize) -> 
     if name.is_empty() {
         return None;
     }
+    // An `_`-prefixed name is the documented "intentionally discarded" idiom
+    // (`let _r = t.commit();` keeps the consuming call but explicitly throws the
+    // value away). Flagging it as a dead store would nag the user for following
+    // the very convention that silences the unused-variable lint, so skip it —
+    // matching the scope-exit unused-binding lint's `_` exemption.
+    if name.starts_with('_') {
+        return None;
+    }
     // Must be a no-drop scalar; anything heap-owning / aggregate / handle is
     // excluded so we never reason about a value a `Drop` could observe.
     match func.locals.get(idx) {

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -28936,12 +28936,14 @@ fn check_to_diagnostic(check: &MirCheck) -> Option<MirDiagnostic> {
         MirCheck::MustConsume {
             binding,
             name,
+            bind_site,
             exit_site,
             ty,
         } => Some(MirDiagnostic {
             kind: MirDiagnosticKind::MustConsume {
                 binding: *binding,
                 name: name.clone(),
+                bind_site: *bind_site,
                 exit_site: *exit_site,
                 ty: ty.clone(),
             },

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -4929,6 +4929,9 @@ pub enum MirCheck {
     MustConsume {
         binding: BindingId,
         name: String,
+        /// Where the binding was introduced — the caret anchors here so the
+        /// diagnostic points at the unconsumed binding, not the distant exit.
+        bind_site: SiteId,
         exit_site: SiteId,
         ty: ResolvedTy,
     },
@@ -5674,6 +5677,8 @@ pub enum MirDiagnosticKind {
     MustConsume {
         binding: BindingId,
         name: String,
+        /// The binding's introduction site — diagnostic caret anchor.
+        bind_site: SiteId,
         exit_site: SiteId,
         ty: ResolvedTy,
     },

--- a/hew-mir/tests/vertical.rs
+++ b/hew-mir/tests/vertical.rs
@@ -87,6 +87,24 @@ fn linear_unconsumed_single_exit_fires_must_consume() {
         "MustConsume should fire for unconsumed @linear binding `t`; checks: {:?}",
         func.checks
     );
+    // The caret must anchor at the binding, not the distant exit: `bind_site`
+    // (the `let t = …` introduction) is distinct from `exit_site` (the implicit
+    // tail return). Pointing the diagnostic at the unconsumed binding is the
+    // whole reason both sites are carried.
+    let sites = func.checks.iter().find_map(|check| match check {
+        MirCheck::MustConsume {
+            name,
+            bind_site,
+            exit_site,
+            ..
+        } if name == "t" => Some((*bind_site, *exit_site)),
+        _ => None,
+    });
+    let (bind_site, exit_site) = sites.expect("MustConsume carries bind/exit sites");
+    assert_ne!(
+        bind_site, exit_site,
+        "bind_site must differ from exit_site so the caret lands on the binding"
+    );
     // A declared `#[linear]` type must not produce a spurious UnknownType
     // diagnostic — the MIR layer must honour the HIR checker's type_classes
     // registry rather than treating every Named type as unknown.

--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -288,6 +288,15 @@ impl Checker {
         for w in scope_warnings {
             match w.kind {
                 ScopeWarningKind::Unused => {
+                    // A RAII handle (`#[resource]` / `#[linear]` / an owned
+                    // stdlib handle) is bound for the express purpose of being
+                    // dropped or consumed: the scope-exit drop IS the use, and
+                    // an unconsumed linear binding already raises a hard
+                    // MustConsume error. Nagging "prefix with `_`" here is a
+                    // false positive, so suppress the unused-binding lint for it.
+                    if self.is_raii_handle_ty(&w.ty) {
+                        continue;
+                    }
                     self.warnings.push(TypeError {
                         severity: crate::error::Severity::Warning,
                         kind: TypeErrorKind::UnusedVariable,
@@ -314,6 +323,19 @@ impl Checker {
                 }
             }
         }
+    }
+
+    /// Whether a binding of type `ty` is a RAII handle whose entire purpose is
+    /// drop / consume — a `#[resource]` or `#[linear]` user type, or an owned
+    /// stdlib/builtin handle (drop type / handle type). Used to suppress the
+    /// unused-binding lint: such a binding is meaningful even when never read.
+    fn is_raii_handle_ty(&self, ty: &Ty) -> bool {
+        let Ty::Named { name, .. } = ty else {
+            return false;
+        };
+        self.registry.is_resource(name)
+            || self.registry.is_linear(name)
+            || self.canonical_owned_handle_type_name(name).is_some()
     }
 
     #[expect(

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -261,6 +261,14 @@ impl Checker {
                                 self.local_type_defs.insert(event_type_name.clone());
                                 self.source_type_defs.insert(event_type_name);
                             }
+                            Item::Actor(ad) => {
+                                // An actor declares a nominal type; an
+                                // `impl ImportedTrait for ThisActor` is therefore
+                                // local-typed, not an orphan. Seed both sets so the
+                                // orphan rule treats it like any other local type.
+                                self.local_type_defs.insert(ad.name.clone());
+                                self.source_type_defs.insert(ad.name.clone());
+                            }
                             Item::Trait(tr) => {
                                 self.local_trait_defs.insert(tr.name.clone());
                             }

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -1451,6 +1451,7 @@ impl Checker {
                         continue;
                     }
                     self.register_actor_decl(ad);
+                    self.local_type_defs.insert(ad.name.clone());
                     self.source_type_defs.insert(ad.name.clone());
                 }
                 Item::TypeAlias(ta) => {

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -2009,6 +2009,9 @@ impl Checker {
         if td.resource_marker == hew_parser::ast::ResourceMarker::Resource {
             self.registry.register_resource_type(td.name.clone());
         }
+        if td.resource_marker == hew_parser::ast::ResourceMarker::Linear {
+            self.registry.register_linear_type(td.name.clone());
+        }
         let kind = match td.kind {
             TypeDeclKind::Struct => TypeDefKind::Struct,
             TypeDeclKind::Enum => TypeDefKind::Enum,
@@ -2260,6 +2263,9 @@ impl Checker {
         // diagnostics (W3.030); the checker only needs the marker fact here.
         if td.resource_marker == hew_parser::ast::ResourceMarker::Resource {
             self.registry.register_resource_type(td.name.clone());
+        }
+        if td.resource_marker == hew_parser::ast::ResourceMarker::Linear {
+            self.registry.register_linear_type(td.name.clone());
         }
         // Track user-declared `#[opaque]` types so `record_clone_admissibility`
         // can detect opaque fields transitively. The module_registry only

--- a/hew-types/src/check/tests/imports.rs
+++ b/hew-types/src/check/tests/imports.rs
@@ -1728,6 +1728,61 @@ fn local_type_impl_no_orphan_warning() {
 }
 
 #[test]
+fn local_actor_impl_no_orphan_warning() {
+    use hew_parser::ast::{ActorDecl, TraitBound, Visibility};
+    // A same-file actor declares a nominal type, so `impl ExternalTrait for
+    // Counter` is local-typed — not an orphan. Mirrors the struct case above:
+    // the actor's name must seed `local_type_defs` like any other type.
+    let actor = ActorDecl {
+        visibility: Visibility::Pub,
+        name: "Counter".to_string(),
+        type_params: vec![],
+        super_traits: None,
+        init: None,
+        fields: vec![],
+        receive_fns: vec![],
+        methods: vec![],
+        mailbox_capacity: None,
+        overflow_policy: None,
+        is_isolated: false,
+        doc_comment: None,
+        max_heap_bytes: None,
+    };
+    let impl_decl = ImplDecl {
+        type_params: None,
+        trait_bound: Some(TraitBound {
+            name: "ExternalTrait".to_string(),
+            type_args: None,
+            assoc_type_bindings: vec![],
+        }),
+        target_type: (
+            TypeExpr::Named {
+                name: "Counter".to_string(),
+                type_args: None,
+            },
+            0..0,
+        ),
+        where_clause: None,
+        type_aliases: vec![],
+        methods: vec![],
+    };
+    let output = check_items(vec![
+        (Item::Actor(actor), 0..0),
+        (Item::Impl(impl_decl), 0..0),
+    ]);
+
+    let has_orphan = output
+        .warnings
+        .iter()
+        .any(|w| w.kind == crate::error::TypeErrorKind::OrphanImpl);
+    assert!(
+        !has_orphan,
+        "impl on a locally defined actor must NOT produce an orphan warning; warnings: {:?}",
+        output.warnings
+    );
+}
+
+#[test]
 fn test_file_import_private_items_not_visible() {
     use hew_parser::ast::{
         Block, ConstDecl, Expr, FnDecl, ImportDecl, Item, Literal, Program, Spanned, TypeDecl,

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -22,6 +22,49 @@ fn warn_unused_variable() {
 }
 
 #[test]
+fn raii_handle_bindings_suppress_unused_lint_but_plain_still_warns() {
+    // A `#[resource]` and a `#[linear]` handle exist to be dropped/consumed:
+    // binding one for its scope-exit drop is the use, so the unused-binding lint
+    // must stay silent. A plain scalar in the same scope must still warn — the
+    // suppression is type-targeted, not a blanket disable.
+    let source = "\
+#[resource]\n\
+type Guard { id: i64; }\n\
+impl Guard { fn close(g: Guard) { } }\n\
+fn open() -> Guard { Guard { id: 1 } }\n\
+#[linear]\n\
+type Txn { id: i64; }\n\
+impl Txn { fn commit(consuming self) -> i64 { 0 } }\n\
+fn mk() -> Txn { Txn { id: 0 } }\n\
+fn main() { let g = open(); let t = mk(); let plain = 42; }\n";
+    let result = hew_parser::parse(source);
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let output = checker.check_program(&result.program);
+    assert!(output.errors.is_empty(), "errors: {:?}", output.errors);
+    let unused = |n: &str| {
+        output
+            .warnings
+            .iter()
+            .any(|w| w.message.contains(&format!("unused variable `{n}`")))
+    };
+    assert!(
+        !unused("g"),
+        "resource handle must not warn unused: {:?}",
+        output.warnings
+    );
+    assert!(
+        !unused("t"),
+        "linear handle must not warn unused: {:?}",
+        output.warnings
+    );
+    assert!(
+        unused("plain"),
+        "plain scalar must still warn unused: {:?}",
+        output.warnings
+    );
+}
+
+#[test]
 fn warn_var_never_mutated() {
     let source = "fn main() { var x = 10; println(x); }";
     let result = hew_parser::parse(source);

--- a/hew-types/src/env.rs
+++ b/hew-types/src/env.rs
@@ -41,6 +41,9 @@ pub struct ScopeWarning {
     pub span: Span,
     /// What kind of warning
     pub kind: ScopeWarningKind,
+    /// The bound value's type, so the diagnostic layer can suppress the
+    /// unused-binding lint for RAII handle types (their drop is the use).
+    pub ty: Ty,
 }
 
 /// The kind of scope-level warning.
@@ -176,12 +179,14 @@ impl TypeEnv {
                     name: name.clone(),
                     span: span.clone(),
                     kind: ScopeWarningKind::Unused,
+                    ty: binding.ty.clone(),
                 });
             } else if binding.is_mutable && !binding.is_written {
                 warnings.push(ScopeWarning {
                     name: name.clone(),
                     span: span.clone(),
                     kind: ScopeWarningKind::NeverMutated,
+                    ty: binding.ty.clone(),
                 });
             }
         }

--- a/hew-types/src/traits.rs
+++ b/hew-types/src/traits.rs
@@ -195,6 +195,11 @@ pub struct TraitRegistry {
     /// user/stdlib `#[resource]` declarations keyed by name. Both are owned by
     /// the registry so the checker no longer keeps a parallel allowlist.
     resource_types: HashSet<String>,
+    /// Names of types declared with the `#[linear]` marker. Single-owner, no
+    /// implicit drop; tracked so the unused-binding lint can treat their handles
+    /// as RAII (suppress) rather than nagging for an `_` prefix. See
+    /// `register_linear_type` / `is_linear`.
+    linear_types: HashSet<String>,
     /// Declared type-parameter names for generic user types.
     ///
     /// Maps a type's declared (bare) name to the ordered list of its type
@@ -578,6 +583,16 @@ impl TraitRegistry {
         self.resource_types.insert(name);
     }
 
+    /// Record `name` as a `#[linear]` type.
+    ///
+    /// Mirrors `register_resource_type`. A `#[linear]` type is single-owner with
+    /// no implicit drop: leaving its handle unconsumed is already a hard
+    /// `MustConsume` error, so the diagnostic layer treats it as a RAII handle and
+    /// suppresses the redundant unused-binding warning. `is_linear` is the query.
+    pub fn register_linear_type(&mut self, name: String) {
+        self.linear_types.insert(name);
+    }
+
     /// Register the declared type-parameter names for a generic type.
     ///
     /// **Must be called alongside `register_type`** at every type, record, or
@@ -620,6 +635,17 @@ impl TraitRegistry {
         }
         let unqualified = name.rsplit_once('.').map_or(name, |(_, suffix)| suffix);
         self.resource_types.contains(unqualified)
+    }
+
+    /// Report whether `name` is a `#[linear]` type. Matches the bare and
+    /// module-qualified-suffix spellings, mirroring `is_resource`.
+    #[must_use]
+    pub fn is_linear(&self, name: &str) -> bool {
+        if self.linear_types.contains(name) {
+            return true;
+        }
+        let unqualified = name.rsplit_once('.').map_or(name, |(_, suffix)| suffix);
+        self.linear_types.contains(unqualified)
     }
 
     /// Register a negative impl (type does NOT implement trait).


### PR DESCRIPTION
## Summary
4 fixes: #[resource]/#[linear] handles no longer 'prefix _'; _-prefixed locals exempt dead_store; local actors count locally-defined; MustConsume caret at binding.
## Verification
ci-preflight 8/8, flake 3/3, no oracle change.