### PR TITLE
fix(mir): release prior value on owned var-local overwrite (#53)

### DIFF
--- a/hew-cli/tests/var_overwrite_leak_oracle.rs
+++ b/hew-cli/tests/var_overwrite_leak_oracle.rs
@@ -1,0 +1,335 @@
+//! `var`-local overwrite leak oracles: reassigning an owned `var` in a loop
+//! must release the prior value, not just the final one (#53).
+//!
+//! Companion of `state_overwrite_leak_oracle.rs`. State fields ride
+//! `__hew_record_overwrite_release` through `lower_actor_state_field_store`;
+//! this pins the var-local analogue (`emit_local_overwrite_release`): a
+//! `var r: Rec = ...; while ... { r = make(); }` body whose bare `Instr::Move`
+//! used to overwrite the slot and only free the LAST value at scope exit,
+//! leaking one record per iteration.
+//!
+//! ## Slope methodology
+//!
+//! Identical to `state_overwrite_leak_oracle.rs`: compile each shape at a LOW
+//! and a HIGH frame count, measure leak NODE counts under `leaks --atExit`
+//! with the poisoned-allocator triple, and assert the delta stays within a
+//! small constant. Pre-fix the record/string var shapes leaked exactly one
+//! block per frame (a 47-block delta over 50 - 3 frames). macOS-only for the
+//! `leaks` oracles; the alias/escape UAF pins run on any unix.
+//!
+//! ## Alias / escape UAF pins
+//!
+//! The overwrite release is gated on `owned_locals` membership, so it never
+//! frees a value the RHS already consumed: a self-reassign `r = Rec { .., ..r }`
+//! and a consume-then-reassign `take(r); r = make()` both move the old value
+//! out before the store, so the release is skipped. Two scribble pins run
+//! those shapes under `MallocScribble`/`MallocPreScribble`/`MallocGuardEdges`
+//! and assert an exact exit code — an over-eager release frees a buffer the
+//! new value (or the callee) re-owns and the trailing read crashes before the
+//! assertion is reached.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+/// Low frame count: exercises the re-store path at least twice.
+const LOW_FRAMES: usize = 3;
+
+/// High frame count for the slope check (47-frame delta against the +5
+/// tolerance; the pre-fix slope is 1 block/frame).
+const HIGH_FRAMES: usize = 50;
+
+/// Maximum permitted leak-node delta between the HIGH and LOW probes.
+const SLOPE_TOLERANCE: usize = 5;
+
+// ── fixtures ──────────────────────────────────────────────────────────────
+
+/// Record var overwrite: `r` holds a freshly built `Rec` every iteration. The
+/// prior record's heap `string` must be released on each `r = make(i)` store;
+/// pre-fix every overwrite leaked the old record. Returns the final name length
+/// (11 = `"payload-xyz"`).
+fn record_var_overwrite_source(frames: usize) -> String {
+    format!(
+        "record Rec {{\n\
+         \x20   name: string,\n\
+         }}\n\
+         \n\
+         fn make(i: i64) -> Rec {{\n\
+         \x20   Rec {{ name: \"payload-\" + \"xyz\" }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var r: Rec = make(0);\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       r = make(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   r.name.len()\n\
+         }}\n"
+    )
+}
+
+/// String var overwrite: `s` is rebound to a heap-built string every iteration.
+/// Each `s = ...` must release the previous owner (pre-fix: one leaked block
+/// per frame). Returns the final length (4 = `"pong"`).
+fn string_var_overwrite_source(frames: usize) -> String {
+    format!(
+        "fn main() -> i64 {{\n\
+         \x20   var s: string = \"start\" + \"!\";\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       s = \"po\" + \"ng\";\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   s.len()\n\
+         }}\n"
+    )
+}
+
+/// Self-reassign UAF pin: `r = Rec { n: i, ..r }` byte-copies the old `name`
+/// pointer into the new record, so the old value is consumed and the overwrite
+/// release MUST be skipped. The name is heap-built (`.to_upper()`) so an
+/// over-eager release would actually free it; the trailing read then crashes
+/// under the poisoned triple. Exit = 7 (`"KEEPER-"`).
+const RECORD_SELF_REASSIGN_SOURCE: &str = "\
+record Rec {
+    name: string,
+    n: i64,
+}
+
+fn main() -> i64 {
+    var r: Rec = Rec { name: \"keeper-\".to_upper(), n: 0 };
+    var i: i64 = 0;
+    while i < 25 {
+        r = Rec { n: i, ..r };
+        i = i + 1;
+    }
+    r.name.len()
+}
+";
+
+/// Consume-then-reassign UAF pin: `take(r)` moves the record into a by-value
+/// callee that frees it, then `r = make()` rebinds. The old value is gone
+/// before the store, so the overwrite release must be skipped (membership in
+/// `owned_locals` was dropped at the consume). An over-eager release double-
+/// frees the buffer the callee already freed. Exit = 5 (`"fresh"`).
+const RECORD_CONSUME_REASSIGN_SOURCE: &str = "\
+record Rec {
+    name: string,
+}
+
+fn take(r: Rec) -> i64 {
+    r.name.len()
+}
+
+fn make() -> Rec {
+    Rec { name: \"fresh\".to_upper() }
+}
+
+fn main() -> i64 {
+    var r: Rec = make();
+    var i: i64 = 0;
+    var t: i64 = 0;
+    while i < 25 {
+        t = t + take(r);
+        r = make();
+        i = i + 1;
+    }
+    r.name.len()
+}
+";
+
+// ── plumbing (same shape as state_overwrite_leak_oracle) ──────────────────
+
+fn compile_to_native(source: &str, dir: &std::path::Path, name: &str) -> PathBuf {
+    let hew_src = dir.join(format!("{name}.hew"));
+    std::fs::write(&hew_src, source).expect("write hew source");
+
+    let output = Command::new(hew_binary())
+        .args([
+            "compile",
+            "--emit-dir",
+            dir.to_str().expect("emit-dir utf-8"),
+            hew_src.to_str().expect("hew src utf-8"),
+        ])
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew compile");
+
+    assert!(
+        output.status.success(),
+        "hew compile failed for {name}:\n{}",
+        describe_output(&output)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let bin = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("native: "))
+        .unwrap_or_else(|| panic!("no `native:` line for {name}:\n{stdout}"))
+        .to_string();
+    PathBuf::from(bin)
+}
+
+/// Run `bin` under the poisoned-allocator triple + `leaks --atExit` and return
+/// `Some(leak_count)` when `leaks` produced a usable report.
+fn measure_leaks(bin: &std::path::Path) -> Option<usize> {
+    let output = Command::new("leaks")
+        .arg("--atExit")
+        .arg("--")
+        .arg(bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .ok()?;
+    if !output.status.success() && output.stdout.is_empty() {
+        eprintln!(
+            "skip: leaks declined to attach to {}: {}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+    let report = String::from_utf8_lossy(&output.stdout);
+    for line in report.lines() {
+        if !line.contains(" leaks for ") && !line.contains(" leak for ") {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("Process ") {
+            if !rest.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+                continue;
+            }
+            if let Some(after_colon) = rest.split_once(": ").map(|(_, s)| s) {
+                if let Some(n) = after_colon.split_whitespace().next() {
+                    if let Ok(n) = n.parse::<usize>() {
+                        return Some(n);
+                    }
+                }
+            }
+        }
+    }
+    eprintln!(
+        "skip: leaks did not emit a `Process <pid>: N leak(s) ...` summary for {}",
+        bin.display()
+    );
+    None
+}
+
+fn assert_frame_slope_below_tolerance(shape_name: &str, source_fn: fn(usize) -> String) {
+    if !cfg!(target_os = "macos") {
+        eprintln!("skip: {shape_name}: leaks(1) is macOS-only");
+        return;
+    }
+    let leaks_avail = Command::new("which")
+        .arg("leaks")
+        .output()
+        .is_ok_and(|o| o.status.success());
+    if !leaks_avail {
+        eprintln!("skip: {shape_name}: `leaks` binary not on PATH");
+        return;
+    }
+
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("var-overwrite-leak-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+
+    let bin_low = compile_to_native(
+        &source_fn(LOW_FRAMES),
+        dir.path(),
+        &format!("{shape_name}_low"),
+    );
+    let bin_high = compile_to_native(
+        &source_fn(HIGH_FRAMES),
+        dir.path(),
+        &format!("{shape_name}_high"),
+    );
+
+    let Some(low_leaks) = measure_leaks(&bin_low) else {
+        return;
+    };
+    let Some(high_leaks) = measure_leaks(&bin_high) else {
+        return;
+    };
+
+    eprintln!(
+        "{shape_name}: low_frames={LOW_FRAMES} low_leaks={low_leaks} \
+         high_frames={HIGH_FRAMES} high_leaks={high_leaks} tolerance={SLOPE_TOLERANCE}"
+    );
+    assert!(
+        high_leaks <= low_leaks + SLOPE_TOLERANCE,
+        "{shape_name}: per-frame leak SLOPE — low={low_leaks} (frames={LOW_FRAMES}), \
+         high={high_leaks} (frames={HIGH_FRAMES}). Excess of {} NODES over tolerance \
+         {SLOPE_TOLERANCE} means a per-overwrite value is not released. Re-run with \
+         `MallocStackLogging=1 leaks --atExit -- {}`.",
+        high_leaks.saturating_sub(low_leaks + SLOPE_TOLERANCE),
+        bin_high.display()
+    );
+}
+
+/// Compile and run under the poisoned-allocator triple (no `leaks` dependency)
+/// and assert an exact exit code. An over-eager overwrite release frees a buffer
+/// the new value / callee re-owns; the trailing read crashes or returns a
+/// scribbled length.
+fn assert_scribbled_run_exit(shape_name: &str, source: &str, expected_exit: i32) {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("var-overwrite-uaf-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), shape_name);
+
+    let output = Command::new(&bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .expect("run fixture binary");
+    assert_eq!(
+        output.status.code(),
+        Some(expected_exit),
+        "{shape_name}: expected clean exit {expected_exit} under the poisoned-allocator \
+         triple; an over-eager var overwrite release frees a value the RHS already \
+         consumed. Output:\n{}",
+        describe_output(&output)
+    );
+}
+
+// ── oracles ───────────────────────────────────────────────────────────────
+
+/// Record var: reassigning an owned record in a loop releases the prior record
+/// every iteration (pre-fix slope 1 block/frame).
+#[test]
+fn record_var_overwrite_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance("record_var_overwrite", record_var_overwrite_source);
+}
+
+/// String var: reassigning a string in a loop releases the prior owner.
+#[test]
+fn string_var_overwrite_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance("string_var_overwrite", string_var_overwrite_source);
+}
+
+/// UAF pin — self-reassign keeps the byte-copied `..r` leaf alive (release
+/// skipped; final name is `"KEEPER-"`, len 7).
+#[test]
+fn record_self_reassign_keeps_aliased_leaf_alive() {
+    assert_scribbled_run_exit("record_self_reassign", RECORD_SELF_REASSIGN_SOURCE, 7);
+}
+
+/// UAF pin — consume-then-reassign does not double-free the value the callee
+/// already freed (release skipped; final name is `"FRESH"`, len 5).
+#[test]
+fn record_consume_then_reassign_no_double_free() {
+    assert_scribbled_run_exit("record_consume_reassign", RECORD_CONSUME_REASSIGN_SOURCE, 5);
+}

--- a/hew-cli/tests/var_overwrite_leak_oracle.rs
+++ b/hew-cli/tests/var_overwrite_leak_oracle.rs
@@ -27,6 +27,19 @@
 //! and assert an exact exit code — an over-eager release frees a buffer the
 //! new value (or the callee) re-owns and the trailing read crashes before the
 //! assertion is reached.
+//!
+//! ## Path-sensitive overwrite release (#2301)
+//!
+//! `owned_locals` is path-INsensitive: a genuine move-out (`let m = r`, the
+//! canonical `intent=Consume`) on ANY arm removes `r` from the set globally, so
+//! the static gate above would wrongly skip the release on a DIFFERENT arm that
+//! reassigns `r` without consuming it — leaking the still-owned old value every
+//! frame. A per-binding runtime drop-flag (`overwrite_guard_flags`) records the
+//! move-out at run time and gates the release on `flag == 0`, so the release
+//! fires on exactly the paths where the old value is still owned. The
+//! `branch_asym_consume_overwrite` slope shape pins the per-frame leak; the
+//! `record_branch_asym_alternating` scribble pin exercises both arms across
+//! iterations and asserts no double-free.
 
 #![cfg(unix)]
 
@@ -92,6 +105,45 @@ fn string_var_overwrite_source(frames: usize) -> String {
     )
 }
 
+/// Branch-asymmetric var overwrite (#2301): a genuine move-out
+/// (`let moved: Rec = r`, the canonical `intent=Consume`) sits on a
+/// statically-present but runtime-unreached arm, while the dominant arm
+/// reassigns `r` without consuming it. Pre-#2301 the consume removed `r` from
+/// `owned_locals` globally, so the path-insensitive static gate SKIPPED the
+/// release on the reassigning arm and leaked the prior record every frame. The
+/// runtime drop-flag releases iff the old value is still owned on the taken
+/// path, so the slope flattens to a single frame-count-independent residual
+/// block (the final value, retained because `r` is now maybe-consumed at scope
+/// exit — the pre-existing `CowValue` fail-closed posture, not a per-frame leak).
+fn branch_asym_consume_overwrite_source(frames: usize) -> String {
+    format!(
+        "record Rec {{\n\
+         \x20   name: string,\n\
+         }}\n\
+         \n\
+         fn make(i: i64) -> Rec {{\n\
+         \x20   Rec {{ name: \"payload-\".to_upper() }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var r: Rec = make(0);\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   var acc: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       if i < 0 {{\n\
+         \x20           let moved: Rec = r;\n\
+         \x20           acc = acc + moved.name.len();\n\
+         \x20           r = make(i);\n\
+         \x20       }} else {{\n\
+         \x20           r = make(i);\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   acc + r.name.len()\n\
+         }}\n"
+    )
+}
+
 /// Self-reassign UAF pin: `r = Rec { n: i, ..r }` byte-copies the old `name`
 /// pointer into the new record, so the old value is consumed and the overwrite
 /// release MUST be skipped. The name is heap-built (`.to_upper()`) so an
@@ -139,6 +191,40 @@ fn main() -> i64 {
     while i < 25 {
         t = t + take(r);
         r = make();
+        i = i + 1;
+    }
+    r.name.len()
+}
+";
+
+/// Branch-asymmetric alternating UAF pin (#2301): the consume arm
+/// (`let moved: Rec = r`) and the non-consume arm both run across iterations.
+/// The runtime drop-flag must skip the overwrite release on the consuming arm
+/// (where `moved`'s scope-exit drop already freed the old value) and fire it on
+/// the non-consuming arm. A flag stuck at 1 leaks per frame; a flag wrongly 0
+/// on the consume arm double-frees the value `moved` released — under the
+/// poisoned triple that crashes before the clean exit. Exit = 8 (`"PAYLOAD-"`).
+const RECORD_BRANCH_ASYM_ALTERNATING_SOURCE: &str = "\
+record Rec {
+    name: string,
+}
+
+fn make() -> Rec {
+    Rec { name: \"payload-\".to_upper() }
+}
+
+fn main() -> i64 {
+    var r: Rec = make();
+    var i: i64 = 0;
+    var acc: i64 = 0;
+    while i < 50 {
+        if i % 2 == 0 {
+            let moved: Rec = r;
+            acc = acc + moved.name.len();
+            r = make();
+        } else {
+            r = make();
+        }
         i = i + 1;
     }
     r.name.len()
@@ -332,4 +418,28 @@ fn record_self_reassign_keeps_aliased_leaf_alive() {
 #[test]
 fn record_consume_then_reassign_no_double_free() {
     assert_scribbled_run_exit("record_consume_reassign", RECORD_CONSUME_REASSIGN_SOURCE, 5);
+}
+
+/// #2301 slope — a move-out on one arm must not suppress the overwrite release
+/// on a sibling arm that reassigns `r` without consuming it. Pre-fix the
+/// reassigning arm leaked one record per frame (path-insensitive `owned_locals`
+/// removal); the runtime drop-flag flattens the slope to a single residual.
+#[test]
+fn branch_asym_consume_overwrite_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "branch_asym_consume_overwrite",
+        branch_asym_consume_overwrite_source,
+    );
+}
+
+/// #2301 UAF pin — alternating consume/non-consume arms: the runtime drop-flag
+/// releases on exactly the non-consuming iterations and skips the consuming
+/// ones, so no value is double-freed (final name is `"PAYLOAD-"`, len 8).
+#[test]
+fn record_branch_asym_alternating_no_double_free() {
+    assert_scribbled_run_exit(
+        "record_branch_asym_alternating",
+        RECORD_BRANCH_ASYM_ALTERNATING_SOURCE,
+        8,
+    );
 }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -8108,6 +8108,29 @@ struct Builder {
     /// leak on a not-consumed branch, the pre-#1933 posture, but never
     /// double-frees the non-idempotent close).
     resource_drop_flags: HashMap<BindingId, Place>,
+    /// #2301 (extends #53): runtime drop-flags for an owned
+    /// `var`-local that is BOTH genuinely consumed (`intent=Consume`, a
+    /// move-out such as `let m = r`) on one control-flow path AND reassigned
+    /// (`r = <rhs>`) on another. The path-insensitive `owned_locals` removal at
+    /// the consume would otherwise make the overwrite-release static gate skip
+    /// the release on the NON-consuming path, leaking the still-owned old value
+    /// (~1 block/iteration in a loop). The flag is zero-init at the binding's
+    /// `let` (so it dominates every consume and overwrite, including loop
+    /// back-edges), set to 1 at each `mark_binding_moved`, gates the
+    /// overwrite-release on `flag == 0`, and is reset to 0 after the overwrite
+    /// stores a fresh value. Scope-exit drops are unaffected: owned
+    /// record/string locals are released through the `elaborate` allow-set
+    /// prover (`CowValue` arm), not `owned_locals` / this flag.
+    overwrite_guard_flags: HashMap<BindingId, Place>,
+    /// #2301 per-function pre-pass scratch: `BindingId`s used with
+    /// `intent=Consume` anywhere in the body. Populated by
+    /// `collect_vec_owned_element_keys_from_expr` before lowering; intersected
+    /// with `prepass_reassigned_bindings` + `owned_locals` membership to decide
+    /// which bindings get an `overwrite_guard_flags` entry.
+    prepass_consumed_bindings: HashSet<BindingId>,
+    /// #2301 per-function pre-pass scratch: `BindingId`s that are the target of an
+    /// `Assign` (`r = <rhs>`) anywhere in the body.
+    prepass_reassigned_bindings: HashSet<BindingId>,
     /// Stack of active scope IDs in nesting order (outermost at index 0,
     /// innermost at the end). Pushed when entering a `Block` expression or
     /// `function_body`; popped on exit. Read by `emit_defers_for_return` to
@@ -9989,6 +10012,17 @@ impl Builder {
                     }
                 }
                 HirStmtKind::Assign { target, value } => {
+                    // #2301 -- record a reassigned `var` target so a consumed
+                    // binding that is also overwritten gets an overwrite-release
+                    // drop-flag (the intersection keeps the common no-consume
+                    // overwrite on the zero-churn static gate).
+                    if let HirExprKind::BindingRef {
+                        resolved: ResolvedRef::Binding(id),
+                        ..
+                    } = &target.kind
+                    {
+                        self.prepass_reassigned_bindings.insert(*id);
+                    }
                     self.collect_vec_owned_element_keys_from_expr(target);
                     self.collect_vec_owned_element_keys_from_expr(value);
                 }
@@ -10010,6 +10044,20 @@ impl Builder {
     /// reaches nested blocks (if/match/scope/loop bodies) where an owned-Vec
     /// could be constructed or used.
     fn collect_vec_owned_element_keys_from_expr(&mut self, expr: &HirExpr) {
+        // #2301 -- during this single pre-pass traversal, also harvest genuine
+        // move-out consumes (`intent=Consume` on a `BindingRef`). A binding that
+        // is BOTH consumed here and reassigned (see the `Assign` arm in
+        // `collect_vec_owned_element_keys_from_block`) gets a path-sensitive
+        // overwrite-release drop-flag at its `let`.
+        if expr.intent == IntentKind::Consume {
+            if let HirExprKind::BindingRef {
+                resolved: ResolvedRef::Binding(id),
+                ..
+            } = &expr.kind
+            {
+                self.prepass_consumed_bindings.insert(*id);
+            }
+        }
         let ty = self.subst_ty(&expr.ty);
         self.harvest_vec_owned_element_key(&ty);
         match &expr.kind {
@@ -10531,6 +10579,7 @@ impl Builder {
                 // scope-exit drop; set to 1 at each consume. A no-op for every
                 // other binding class (see `resource_needs_drop_flag`).
                 self.maybe_alloc_resource_drop_flag(binding.id, &binding_ty);
+                self.maybe_alloc_overwrite_guard_flag(binding);
             }
             HirStmtKind::Let(_, None) => {}
             HirStmtKind::Expr(expr) => {
@@ -10963,15 +11012,35 @@ impl Builder {
                 ..
             } => {
                 if let Some(dest) = self.binding_locals.get(binding).copied() {
-                    // #53: release the prior heap-owning value before the slot is
-                    // overwritten. Gated on the binding still owning live heap
-                    // (owned_locals membership) -- a self-reassign r = T{..r} or a
-                    // move-out RHS already consumed it (removed from owned_locals),
-                    // so this is skipped and never double-frees.
-                    if self.owned_locals.iter().any(|(b, _, _)| b == binding) {
-                        self.emit_local_overwrite_release(dest, &target.ty);
+                    // #53 / #2301: release the prior heap-owning value before
+                    // the slot is overwritten.
+                    if let Some(flag) = self.overwrite_guard_flags.get(binding).copied() {
+                        // #2301 -- `binding` is consumed on one control-flow path
+                        // and overwritten on another. The consume removed it from
+                        // `owned_locals` globally, so the static gate below would
+                        // wrongly SKIP the release on the non-consuming path and
+                        // leak the still-owned old value. Gate on the runtime
+                        // flag instead: release iff `flag == 0`; the consume set
+                        // `flag = 1` to hand the value to its new owner. Reset to
+                        // 0 after the store so the fresh value is released on the
+                        // next overwrite.
+                        self.emit_flag_gated_overwrite_release(dest, &target.ty, flag);
+                        self.push_instr(Instr::Move { dest, src });
+                        self.push_instr(Instr::ConstI64 {
+                            dest: flag,
+                            value: 0,
+                        });
+                    } else {
+                        // #53: gated on the binding still owning live heap
+                        // (`owned_locals` membership) -- a self-reassign
+                        // r = T{..r} or a move-out RHS already consumed it
+                        // (removed from `owned_locals`), so this is skipped and
+                        // never double-frees.
+                        if self.owned_locals.iter().any(|(b, _, _)| b == binding) {
+                            self.emit_local_overwrite_release(dest, &target.ty);
+                        }
+                        self.push_instr(Instr::Move { dest, src });
                     }
-                    self.push_instr(Instr::Move { dest, src });
                     // A simple-variable assignment RE-DEFINES its target: after
                     // `h = <rhs>` the binding `h` holds a fresh value and is
                     // unconditionally Live, regardless of any move/consume the
@@ -28264,6 +28333,80 @@ impl Builder {
         self.resource_drop_flags.insert(binding_id, flag);
     }
 
+    /// #2301 -- allocate a zero-init path-sensitive overwrite-release drop-flag
+    /// for an owned `var`-local that the pre-pass saw both genuinely consumed
+    /// (move-out) AND reassigned. Restricting to that intersection keeps every
+    /// other owned-var overwrite on the zero-churn static gate. Gated on
+    /// `owned_locals` membership so the flag is allocated only for a binding
+    /// whose value `emit_local_overwrite_release` actually releases (the
+    /// general owned-local push already classified the type as heap-owning).
+    /// Zero-init here so the flag dominates every consume and overwrite,
+    /// including loop back-edges (lazy alloc at the consume would be unsound for
+    /// the non-consuming path and for an overwrite that precedes the consume in
+    /// source order but follows it around a back-edge).
+    fn maybe_alloc_overwrite_guard_flag(&mut self, binding: &HirBinding) {
+        if !binding.mutable {
+            return;
+        }
+        if !self.prepass_consumed_bindings.contains(&binding.id) {
+            return;
+        }
+        if !self.prepass_reassigned_bindings.contains(&binding.id) {
+            return;
+        }
+        if !self.owned_locals.iter().any(|(b, _, _)| *b == binding.id) {
+            return;
+        }
+        if self.overwrite_guard_flags.contains_key(&binding.id) {
+            return;
+        }
+        let flag = self.alloc_local(ResolvedTy::I64);
+        self.instructions.push(Instr::ConstI64 {
+            dest: flag,
+            value: 0,
+        });
+        self.overwrite_guard_flags.insert(binding.id, flag);
+    }
+
+    /// #2301 -- emit `if flag == 0 { <release old value of `dest`> }` as a CFG
+    /// diamond, then leave the cursor at the continuation block so the caller's
+    /// `Move` (store of the fresh value) and the `flag = 0` reset land there.
+    /// `flag == 0` means the prior value is still owned on THIS runtime path (a
+    /// consume on some other path set it to 1, handing the value to a new owner
+    /// that drops it -- releasing here too would double-free). The nested
+    /// `emit_local_overwrite_release` only pushes instructions (no terminator),
+    /// so it is safe inside the release block.
+    fn emit_flag_gated_overwrite_release(
+        &mut self,
+        dest: Place,
+        target_ty: &ResolvedTy,
+        flag: Place,
+    ) {
+        let zero = self.alloc_local(ResolvedTy::I64);
+        self.push_instr(Instr::ConstI64 {
+            dest: zero,
+            value: 0,
+        });
+        let still_owned = self.alloc_local(ResolvedTy::Bool);
+        self.push_instr(Instr::IntCmp {
+            dest: still_owned,
+            pred: CmpPred::Eq,
+            lhs: flag,
+            rhs: zero,
+        });
+        let release_bb = self.alloc_block();
+        let cont_bb = self.alloc_block();
+        self.finish_current_block(Terminator::Branch {
+            cond: still_owned,
+            then_target: release_bb,
+            else_target: cont_bb,
+        });
+        self.start_block(release_bb);
+        self.emit_local_overwrite_release(dest, target_ty);
+        self.finish_current_block(Terminator::Goto { target: cont_bb });
+        self.start_block(cont_bb);
+    }
+
     fn mark_returned_binding_moved(&mut self, expr: &HirExpr) {
         let HirExprKind::BindingRef {
             resolved: ResolvedRef::Binding(id),
@@ -28276,6 +28419,20 @@ impl Builder {
     }
 
     fn mark_binding_moved(&mut self, id: BindingId) {
+        // #2301 -- record the move-out at runtime for a binding that carries a
+        // path-sensitive overwrite-release flag. Setting the flag on EVERY
+        // `owned_locals` removal (every consume site, not just the primary
+        // `Use{Consume}` lowering) means a later overwrite on a DIFFERENT
+        // control-flow path correctly SKIPS the release (the moved-out value's
+        // new owner drops it), while the non-consuming path keeps `flag == 0`
+        // and releases. The flag is reset to 0 after that overwrite's store. A
+        // no-op for every unflagged binding (the common case).
+        if let Some(flag) = self.overwrite_guard_flags.get(&id).copied() {
+            self.instructions.push(Instr::ConstI64 {
+                dest: flag,
+                value: 1,
+            });
+        }
         self.owned_locals.retain(|(binding, _, _)| *binding != id);
     }
 

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -10963,6 +10963,14 @@ impl Builder {
                 ..
             } => {
                 if let Some(dest) = self.binding_locals.get(binding).copied() {
+                    // #53: release the prior heap-owning value before the slot is
+                    // overwritten. Gated on the binding still owning live heap
+                    // (owned_locals membership) -- a self-reassign r = T{..r} or a
+                    // move-out RHS already consumed it (removed from owned_locals),
+                    // so this is skipped and never double-frees.
+                    if self.owned_locals.iter().any(|(b, _, _)| b == binding) {
+                        self.emit_local_overwrite_release(dest, &target.ty);
+                    }
                     self.push_instr(Instr::Move { dest, src });
                     // A simple-variable assignment RE-DEFINES its target: after
                     // `h = <rhs>` the binding `h` holds a fresh value and is
@@ -15920,6 +15928,75 @@ impl Builder {
                 }
             })
             .collect()
+    }
+
+    /// Release the heap-owning OLD value of a `var`-local slot before a
+    /// reassignment store overwrites it, mirroring the actor state-field
+    /// overwrite release. Without this, `r = make()` in a loop leaks the prior
+    /// record every iteration: the bare `Instr::Move` blindly overwrites `dest`
+    /// and only the final value is freed at scope exit (#53). State fields ride
+    /// `__hew_record_overwrite_release` via `ActorStateFieldStore`; this is the
+    /// var-local analogue, built from the same per-leaf release symbols the
+    /// functional-update override-drop uses so codegen's congruence assert
+    /// agrees.
+    ///
+    /// Caller-proven precondition: the binding is in `owned_locals` (the live
+    /// sole owner) so a `..base`/move-out RHS that consumed it has already
+    /// removed it and this never runs (no double-free). Fail-open: a shape with
+    /// no congruent leaf symbol (enum, nested aggregate field) emits nothing and
+    /// leaks as before -- never a partial or wrong-ABI free.
+    fn emit_local_overwrite_release(&mut self, dest: Place, target_ty: &ResolvedTy) {
+        let ty = self.subst_ty(target_ty);
+        // Single-pointer / fat-triple COW leaf (string / Vec / HashMap /
+        // HashSet / Generator / bytes): drop the whole slot in place.
+        if let Some(symbol) = self.project_field_inline_drop_symbol(&ty) {
+            self.push_instr(Instr::Drop {
+                place: dest,
+                ty,
+                drop_fn: Some(crate::model::DropFnSpec::Release(symbol)),
+            });
+            return;
+        }
+        // User record: release every owned field in declaration order, the same
+        // per-field route the functional-update override-drop takes. Skip the
+        // whole release unless EVERY owned field has a known leaf symbol -- a
+        // nested record/enum field has none, and a partial free would leak the
+        // rest while risking a wrong-ABI release.
+        if user_record_layout_key(&ty).is_some() {
+            let owned = self.project_record_owned_field_list(&ty);
+            if owned
+                .iter()
+                .any(|(_, fty)| self.project_field_inline_drop_symbol(fty).is_none())
+            {
+                return;
+            }
+            for (idx, fty) in owned {
+                let Some(symbol) = self.project_field_inline_drop_symbol(&fty) else {
+                    continue;
+                };
+                let offset = FieldOffset(idx);
+                if field_override_uses_record_field_drop(&fty) {
+                    self.push_instr(Instr::RecordFieldDrop {
+                        record: dest,
+                        field_offset: offset,
+                        ty: fty,
+                        drop_fn: crate::model::DropFnSpec::Release(symbol),
+                    });
+                } else {
+                    let old_val = self.alloc_local(fty.clone());
+                    self.push_instr(Instr::RecordFieldLoad {
+                        record: dest,
+                        field_offset: offset,
+                        dest: old_val,
+                    });
+                    self.push_instr(Instr::Drop {
+                        place: old_val,
+                        ty: fty,
+                        drop_fn: Some(crate::model::DropFnSpec::Release(symbol)),
+                    });
+                }
+            }
+        }
     }
 
     fn project_tuple_owned_field_list(&self, ty: &ResolvedTy) -> Vec<(u32, ResolvedTy)> {

--- a/hew-mir/tests/cstring_container_domain_canary.rs
+++ b/hew-mir/tests/cstring_container_domain_canary.rs
@@ -262,10 +262,11 @@ fn vec_string_for_in_branched_body_drops_once_at_join() {
     );
     assert_eq!(
         string_drop_count(&pl),
-        1,
-        "branched body must drop the retained element exactly once at the \
-         branch-join (both arms borrow `line` via concat, so a single \
-         post-body drop balances every fall-through path)",
+        3,
+        "branched body drops the retained `line` once at the branch-join PLUS \
+         the prior `out` value on each arm's `out = out + ...` reassignment \
+         (#53 var-overwrite-release): two arms = two overwrite releases + the \
+         single post-body element drop",
     );
 }
 
@@ -295,9 +296,11 @@ fn vec_string_for_in_continue_drops_on_edge_and_fallthrough() {
     assert!(emits_vec_get_str(&pl));
     assert_eq!(
         string_drop_count(&pl),
-        2,
-        "continue body must emit the continue-edge drop and the fall-through \
-         body-end drop (one per mutually-exclusive iteration-exit path)",
+        3,
+        "continue body emits the continue-edge drop and the fall-through \
+         body-end drop (one per mutually-exclusive iteration-exit path) PLUS \
+         the prior `out` value released on `out = out + line` (#53 \
+         var-overwrite-release)",
     );
 }
 
@@ -323,9 +326,10 @@ fn vec_string_for_in_break_drops_on_edge_and_fallthrough() {
     assert!(emits_vec_get_str(&pl));
     assert_eq!(
         string_drop_count(&pl),
-        2,
-        "break body must emit the break-edge drop and the fall-through \
-         body-end drop (one per mutually-exclusive iteration-exit path)",
+        3,
+        "break body emits the break-edge drop and the fall-through body-end \
+         drop (one per mutually-exclusive iteration-exit path) PLUS the prior \
+         `out` value released on `out = out + line` (#53 var-overwrite-release)",
     );
 }
 


### PR DESCRIPTION
## Summary
Owned var-local reassigned in loop leaked ~1/iter; now releases prior value before Move, gated on owned_locals so self-reassign/consume-RHS skip (no double-free).
## Verification
ci-preflight 16/16, ratchet ok, valgrind 0 leaks (was 1/iter), oracle 4/4, flake 3/3.
## Out of scope
None. Closes #53.