### PR TITLE
feat: suppress gen-fn capture cascade + structured codegen-front diagnostic codes (CAP-18)

### DIFF
--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -143,9 +143,36 @@ pub(crate) fn mir_diagnostic_prefix(kind: &hew_mir::MirDiagnosticKind) -> &'stat
     }
 }
 
+/// Map a codegen-front `CodegenError` to its stable, structured diagnostic
+/// code. Mirrors `mir_diagnostic_prefix`/`hir_diagnostic_prefix`: every variant
+/// gets a distinct machine-greppable code so tooling (and humans) can branch on
+/// the failure class instead of substring-matching the free-form Display text.
+///
+/// All codes are namespaced under the `E_CODEGEN_FRONT` family — the stable
+/// gate identity that the check/compile e2e suites and the vertical-slice /
+/// pkg-import harnesses grep for — so widening the flat code into per-variant
+/// codes does not break the family contract. The match is exhaustive on
+/// purpose: a new `CodegenError` variant must be classified here rather than
+/// silently inheriting a generic code.
+pub(crate) fn codegen_diagnostic_prefix(error: &hew_codegen_rs::CodegenError) -> &'static str {
+    match error {
+        hew_codegen_rs::CodegenError::Llvm(_) => "E_CODEGEN_FRONT_LLVM",
+        hew_codegen_rs::CodegenError::Unsupported(_) => "E_CODEGEN_FRONT_UNSUPPORTED",
+        hew_codegen_rs::CodegenError::FailClosed(_) => "E_CODEGEN_FRONT_FAIL_CLOSED",
+        hew_codegen_rs::CodegenError::LlvmVerify(_) => "E_CODEGEN_FRONT_LLVM_VERIFY",
+        hew_codegen_rs::CodegenError::TargetSetup { .. } => "E_CODEGEN_FRONT_TARGET_SETUP",
+        hew_codegen_rs::CodegenError::Link(_) => "E_CODEGEN_FRONT_LINK",
+        hew_codegen_rs::CodegenError::Io(_) => "E_CODEGEN_FRONT_IO",
+        hew_codegen_rs::CodegenError::WasmUnsupportedSubstrate { .. } => {
+            "E_CODEGEN_FRONT_WASM_UNSUPPORTED"
+        }
+    }
+}
+
 pub(crate) fn render_codegen_front_diagnostic(error: &hew_codegen_rs::CodegenError) {
     emit_plain_diagnostic_line(&format!(
-        "E_CODEGEN_FRONT: codegen-front validation failed: {error}"
+        "{}: codegen-front validation failed: {error}",
+        codegen_diagnostic_prefix(error),
     ));
 }
 

--- a/hew-cli/tests/check_deep_gates_e2e.rs
+++ b/hew-cli/tests/check_deep_gates_e2e.rs
@@ -175,6 +175,11 @@ fn check_fails_on_codegen_front_gate_before_ok_without_artifacts() {
         "codegen-front failure should use a stable diagnostic family; got:\n{stderr}",
     );
     assert!(
+        stderr.contains("E_CODEGEN_FRONT_UNSUPPORTED"),
+        "codegen-front failure should carry a structured per-variant code \
+         (the array return type maps to CodegenError::Unsupported); got:\n{stderr}",
+    );
+    assert!(
         stderr.contains("unsupported construct"),
         "codegen-front failure should render CodegenError Display, not Debug; got:\n{stderr}",
     );

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -7966,6 +7966,20 @@ struct Builder {
     /// "a diagnostic was emitted" so a genuinely-unresolved binding (a real bug
     /// with no prior error) still reports.
     poisoned_let_bindings: HashSet<BindingId>,
+    /// Generator/`gen fn` capture bindings the enclosing `lower_gen_block`
+    /// rejected with a root `NotYetImplemented` (an inadmissible opaque/owned
+    /// value that cannot cross the generator's thread boundary). The synthetic
+    /// body still names the capture as a free variable, but it was never
+    /// materialised into the env record — so its body-side `BindingRef` would
+    /// otherwise stack two cascade secondaries on the root: a
+    /// `MirStatement::Use` of an un-`Bind`-ed binding (→ dataflow
+    /// `InitialisedBeforeUse`) and an `UnresolvedPlace` (no backend slot). The
+    /// `BindingRef` resolver consults this set and returns `None` silently for a
+    /// poisoned capture, so only the actionable root rejection surfaces. Scoped
+    /// to the body sub-builder: it carries only the specific failing capture
+    /// ids, never the enclosing frame's bindings, and the body's own `let`
+    /// bindings have distinct ids so they are unaffected.
+    poisoned_capture_ids: HashSet<BindingId>,
     /// Transient: set by `lower_closure_literal` to the just-lowered closure's
     /// body-suspends verdict (derived from its shim's MIR carriers) so the `Let`
     /// handler can attribute it to the bound binding. Reset around each closure
@@ -11203,6 +11217,19 @@ impl Builder {
                             .push(Instr::ActorStateFieldLoad { field_offset, dest });
                         return Some(dest);
                     }
+                }
+                // A `gen`/`gen fn` capture the enclosing `lower_gen_block`
+                // already rejected with a root `NotYetImplemented` (an
+                // inadmissible opaque/owned value). The synthetic body still
+                // references the capture, but it was never materialised into the
+                // env record, so resolving it here would stack two cascade
+                // secondaries on the root: the `MirStatement::Use` below would
+                // read an un-`Bind`-ed binding (→ dataflow
+                // `InitialisedBeforeUse`), and place resolution would emit
+                // `UnresolvedPlace` (no backend slot). Both are pure cascade;
+                // only the root capture rejection is actionable. Fail silent.
+                if self.poisoned_capture_ids.contains(id) {
+                    return None;
                 }
                 let use_ty = self.subst_ty(&expr.ty);
                 // Skip `MirStatement::Use` for captured bindings: the
@@ -27519,6 +27546,11 @@ impl Builder {
         let mut env_place: Option<Place> = None;
         let mut env_ty: Option<ResolvedTy> = None;
         let mut env_capture_field_tys: Vec<ResolvedTy> = Vec::new();
+        // Capture bindings rejected below as inadmissible to the flat env. Each
+        // gets a root `NotYetImplemented`; the body sub-builder reads this set
+        // to suppress the downstream `InitialisedBeforeUse`/`UnresolvedPlace`
+        // cascade for the same bindings (only the root rejection is actionable).
+        let mut poisoned_captures: HashSet<BindingId> = HashSet::new();
         if !captures.is_empty() {
             let mut field_tys: Vec<ResolvedTy> = Vec::with_capacity(captures.len());
             let mut init_fields: Vec<(FieldOffset, Place)> = Vec::new();
@@ -27598,6 +27630,13 @@ impl Builder {
                                 ty.user_facing()
                             ),
                         });
+                        // Poison this capture's binding id: the root
+                        // `NotYetImplemented` above is the one actionable
+                        // diagnostic. The body sub-builder's `BindingRef`
+                        // resolution consults `poisoned_capture_ids` and stays
+                        // silent, suppressing the `InitialisedBeforeUse` +
+                        // `UnresolvedPlace` cascade for this binding.
+                        poisoned_captures.insert(capture.binding);
                         all_materialisable = false;
                     }
                     _ => {
@@ -27657,6 +27696,12 @@ impl Builder {
             in_gen_body: true,
             ..Builder::default()
         };
+        // Propagate the inadmissible-capture poison set into the body builder so
+        // its `BindingRef` resolution stays silent for those bindings — the root
+        // rejection already fired in the enclosing frame, and the un-materialised
+        // capture would otherwise cascade into `InitialisedBeforeUse` +
+        // `UnresolvedPlace`.
+        body_builder.poisoned_capture_ids = poisoned_captures;
 
         // Prepend the coroutine-ramp parameters. The generator body is lowered
         // as an `llvm.coro.*` switched-resume coroutine ramp (the same substrate

--- a/hew-mir/tests/gen_block_mir_lowering.rs
+++ b/hew-mir/tests/gen_block_mir_lowering.rs
@@ -384,6 +384,66 @@ fn gen_block_capturing_opaque_handle_fails_closed() {
     );
 }
 
+/// The single-diagnostic guarantee for an inadmissible generator capture: the
+/// root `NotYetImplemented` is the ONLY diagnostic. The synthetic body still
+/// names the rejected capture as a free variable, but `lower_gen_block` poisons
+/// its binding id, so the body sub-builder suppresses the two cascade
+/// secondaries it would otherwise stack on the root — a `MirStatement::Use` of
+/// an un-`Bind`-ed binding (→ dataflow `InitialisedBeforeUse`) and an
+/// `UnresolvedPlace` (no backend slot). Only the actionable rejection surfaces.
+#[test]
+fn gen_block_inadmissible_capture_emits_single_diagnostic() {
+    let pipeline = lower_checked(
+        r#"
+        #[opaque]
+        type Dq {}
+
+        extern "C" {
+            fn hew_deque_new() -> Dq;
+            fn hew_deque_len(dq: Dq) -> i64;
+        }
+
+        fn main() {
+            let dq = unsafe { hew_deque_new() };
+            let g = gen { yield unsafe { hew_deque_len(dq) }; };
+        }
+        "#,
+    );
+
+    assert_eq!(
+        pipeline.diagnostics.len(),
+        1,
+        "an inadmissible gen capture must emit exactly one diagnostic (the root \
+         NotYetImplemented); the InitialisedBeforeUse/UnresolvedPlace cascade must \
+         be suppressed; got: {:#?}",
+        pipeline.diagnostics
+    );
+    assert!(
+        matches!(
+            &pipeline.diagnostics[0].kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("opaque/owned value")
+        ),
+        "the single diagnostic must be the root NotYetImplemented capture \
+         rejection; got: {:#?}",
+        pipeline.diagnostics[0]
+    );
+    // Defence in depth: neither cascade secondary may appear anywhere in the
+    // pipeline diagnostics, even if the count assertion above is later relaxed.
+    let cascade = pipeline.diagnostics.iter().find(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::InitialisedBeforeUse { .. }
+                | MirDiagnosticKind::UnresolvedPlace { .. }
+        )
+    });
+    assert!(
+        cascade.is_none(),
+        "no InitialisedBeforeUse/UnresolvedPlace cascade may follow the root \
+         capture rejection; got: {cascade:#?}",
+    );
+}
+
 /// Regression companion to the opaque-capture gate: a plain `BitCopy` scalar
 /// capture (`i64`) must STILL be admitted — the tightened predicate
 /// (`gen_env_capture_admissible`) must not over-reject the supported path. No

--- a/tests/vertical-slice/reject/gen_fn_capture_owned_value.hew
+++ b/tests/vertical-slice/reject/gen_fn_capture_owned_value.hew
@@ -15,9 +15,10 @@
 // Expected: rejected, fail closed (capture of opaque/owned value into a
 // generator); diagnostic cites the NYI capture protocol.
 //
-// Error count: currently 3 (two MIR cascade secondaries + one root NYI).
-// DIAG-L2 (genfn cascade suppress) will reduce this to 1; update the
-// vertical-slice assertion when that lane lands.
+// Error count: exactly 1 — the root NotYetImplemented. The inadmissible
+// capture's binding id is poisoned in `lower_gen_block`, so the synthetic body
+// emits neither the InitialisedBeforeUse nor the UnresolvedPlace cascade
+// secondary; only the actionable root rejection surfaces.
 gen fn drain(s: string) -> i64 {
     yield s.len();
 }

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -205,6 +205,38 @@ expect_check_fail_error_count() {
   fi
 }
 
+# Like expect_check_fail_error_count, but ALSO asserts that none of the trailing
+# substrings appear anywhere in the diagnostic output. Used by the gen-capture
+# reject fixtures to pin the single-root-diagnostic guarantee: an inadmissible
+# capture must emit ONLY the root NotYetImplemented, never the downstream
+# InitialisedBeforeUse / UnresolvedPlace cascade the body sub-builder would
+# otherwise stack on it.
+expect_check_fail_error_count_no_cascade() {
+  local fixture_path="$1"
+  local expected_count="$2"
+  local label="$3"
+  shift 3
+  if "${HEW}" check "${fixture_path}" >"${reject_output}" 2>&1; then
+    echo "expected ${label} to fail closed under hew check" >&2
+    exit 1
+  fi
+  local actual_count
+  actual_count="$(grep -Ec '^[^:]+:[0-9]+:[0-9]+: error:' "${reject_output}" || true)"
+  if [[ "${actual_count}" -ne "${expected_count}" ]]; then
+    echo "expected ${label} to emit ${expected_count} error(s), got ${actual_count}" >&2
+    cat "${reject_output}" >&2
+    exit 1
+  fi
+  local forbidden
+  for forbidden in "$@"; do
+    if grep -qF -- "${forbidden}" "${reject_output}"; then
+      echo "expected ${label} to suppress cascade secondary '${forbidden}', but it was present" >&2
+      cat "${reject_output}" >&2
+      exit 1
+    fi
+  done
+}
+
 # Compile a fixture to a native binary (no memory cap — the LLVM codegen +
 # clang/ld.lld link pipeline mmaps the multi-hundred-MB `libhew.a` and needs
 # well over 1 GB of address space), then run ONLY the produced binary under a
@@ -2101,26 +2133,28 @@ expect_check_fail_contains \
 # (use-after-free / double-free at teardown). The gate rejects any value
 # transitively containing an opaque handle, not only non-`BitCopy` heap owners.
 #
-# Error count: currently 3 (two MIR cascade secondaries + one root NYI).
-# DIAG-L2 (genfn cascade suppress) will reduce this to 1 by suppressing the
-# InitialisedBeforeUse + UnresolvedPlace secondaries; update to 1 when that
-# lane lands.
-expect_check_fail_error_count \
+# Error count: exactly 1 — the root NotYetImplemented naming the capture. The
+# enclosing `lower_gen_block` poisons the inadmissible capture's binding id, so
+# the synthetic body's `BindingRef` to it stays silent instead of stacking the
+# InitialisedBeforeUse + UnresolvedPlace cascade secondaries on the root.
+expect_check_fail_error_count_no_cascade \
   "${ROOT}/tests/vertical-slice/reject/gen_fn_capture_opaque_handle.hew" \
-  3 \
-  "gen_fn_capture_opaque_handle"
+  1 \
+  "gen_fn_capture_opaque_handle" \
+  "InitialisedBeforeUse" "UnresolvedPlace"
 
 # Reject: a generator that captures an owned (non-BitCopy) value — specifically
 # a `string` — as a free variable must fail closed. Owned values hold heap state
 # with a unique owner; shallow-copying them across the generator body-thread
 # boundary aliases the caller's heap (double-free / UAF on teardown).
 #
-# Error count: currently 3 (two MIR cascade secondaries + one root NYI).
-# DIAG-L2 (genfn cascade suppress) will reduce this to 1; update when it lands.
-expect_check_fail_error_count \
+# Error count: exactly 1 — the root NotYetImplemented; the cascade secondaries
+# are suppressed by the same capture-poisoning path.
+expect_check_fail_error_count_no_cascade \
   "${ROOT}/tests/vertical-slice/reject/gen_fn_capture_owned_value.hew" \
-  3 \
-  "gen_fn_capture_owned_value"
+  1 \
+  "gen_fn_capture_owned_value" \
+  "InitialisedBeforeUse" "UnresolvedPlace"
 
 # Generator proving-gate (compile + run + stdout-order): the behavioural oracle
 # the generator->coro substrate unification must preserve byte-for-byte.


### PR DESCRIPTION
## Summary
(1) Inadmissible generator captures emit only the root NYI (poison-set suppresses 2 cascade secondaries); covers actor-generator via same lower_gen_block. (2) codegen-front diagnostics get structured E_CODEGEN_FRONT_<VARIANT> codes.
## Verification
ci-preflight 9/9, flake 3/3, vertical-slice count 3→1.