### PR TITLE
fix(runtime): fail closed when Node peer-auth setup fails

### DIFF
--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -527,6 +527,133 @@ fn run_node_peer_auth_surface_persists_keys_and_runs() {
     );
 }
 
+/// F6 fail-closed: a bad-hex `Node::allow_peer` argument is rejected and
+/// surfaced (`hew_last_error` + a `hew:` stderr diagnostic), and the subsequent
+/// `Node::start` refuses to bind a listener (fail-closed) rather than silently
+/// coming up with an incomplete peer allowlist. The Hew call form discards the
+/// `-1`, so the operator-visible signal is the stderr diagnostic.
+#[test]
+fn run_node_allow_peer_bad_hex_is_surfaced_and_start_fails_closed() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let path = dir.path().join("allow_peer_bad_hex.hew");
+    std::fs::write(
+        &path,
+        r#"
+        fn main() {
+            Node::set_transport("quic-mesh");
+            Node::allow_peer("zznothexzz");
+            Node::start("127.0.0.1:0");
+            println("after-start");
+        }
+        "#,
+    )
+    .expect("write bad-hex fixture");
+
+    let output = run_bounded_hew_run(&path, dir.path());
+    let stdout = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(
+        stderr.contains("Node::allow_peer") && stderr.contains("hex-encoded SPKI"),
+        "bad-hex allow_peer must be surfaced on stderr; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Node::start: refusing to bind listener") && stderr.contains("fail-closed"),
+        "Node::start must refuse after a failed allow_peer (fail-closed); stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("after-start"),
+        "program continues past the Unit-returning start; stdout: {stdout}"
+    );
+}
+
+/// F6 fail-closed: a corrupt keyfile makes `Node::load_keys` fail and surface
+/// the error, and `Node::start` then refuses to bind a listener rather than
+/// silently presenting an ephemeral self-signed identity (the operator's pinned
+/// identity failed to load).
+#[test]
+fn run_node_load_keys_corrupt_keyfile_is_surfaced_and_start_fails_closed() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    // A keyfile that exists but is not a valid mesh keyfile frame.
+    std::fs::write(dir.path().join("node.key"), b"not-a-keyfile-frame")
+        .expect("write corrupt keyfile");
+    let path = dir.path().join("load_keys_corrupt.hew");
+    std::fs::write(
+        &path,
+        r#"
+        fn main() {
+            Node::set_transport("quic-mesh");
+            Node::load_keys("node.key");
+            Node::start("127.0.0.1:0");
+            println("after-start");
+        }
+        "#,
+    )
+    .expect("write corrupt-keyfile fixture");
+
+    let output = run_bounded_hew_run(&path, dir.path());
+    let stdout = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(
+        stderr.contains("Node::load_keys") && stderr.contains("fail-closed"),
+        "a corrupt keyfile must be surfaced on stderr; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Node::start: refusing to bind listener"),
+        "Node::start must refuse after a failed load_keys (fail-closed); stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("after-start"),
+        "program continues past the Unit-returning start; stdout: {stdout}"
+    );
+}
+
+/// F6 fail-closed: when the keyfile path cannot establish an identity (here, a
+/// parent directory that does not exist, so the fresh identity cannot be
+/// persisted), `Node::load_keys` fails and `Node::start` refuses to bind a
+/// listener — fail-closed without any identity, never an ephemeral fallback.
+#[test]
+fn run_node_start_fails_closed_when_identity_cannot_be_established() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let path = dir.path().join("load_keys_missing_dir.hew");
+    std::fs::write(
+        &path,
+        r#"
+        fn main() {
+            Node::set_transport("quic-mesh");
+            Node::load_keys("no_such_dir/node.key");
+            Node::start("127.0.0.1:0");
+            println("after-start");
+        }
+        "#,
+    )
+    .expect("write missing-keyfile fixture");
+
+    let output = run_bounded_hew_run(&path, dir.path());
+    let stdout = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(
+        stderr.contains("Node::load_keys") && stderr.contains("fail-closed"),
+        "an unestablishable identity must be surfaced on stderr; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Node::start: refusing to bind listener"),
+        "Node::start must refuse without an identity (fail-closed); stderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("after-start"),
+        "program continues past the Unit-returning start; stdout: {stdout}"
+    );
+}
+
 #[test]
 fn run_generic_vec_into_iter_static_dispatch_outputs_first_value() {
     require_codegen();

--- a/hew-hir/src/stdlib_catalog.rs
+++ b/hew-hir/src/stdlib_catalog.rs
@@ -2228,7 +2228,12 @@ pub const CATALOG: &[BuiltinEntry] = &[
     // them as void-returning and the call is emitted without a destination slot.
     // On x86-64 and arm64 the callee's return value sits in rax/x0 and is
     // harmlessly discarded by the caller — this is the standard C idiom for
-    // ignoring a return value.  Error surfacing is deferred to a follow-on lane.
+    // ignoring a return value.  The runtime still surfaces a peer-auth setup
+    // failure even though the `-1` is discarded: `Node::load_keys` /
+    // `Node::allow_peer` set `hew_last_error`, print a `hew:` stderr diagnostic,
+    // and record a sticky failure so a later `Node::start` refuses to bind a
+    // listener (fail-closed) rather than silently presenting an ephemeral
+    // identity. See `node_peer_auth_setup_failed` in `hew_node.rs`.
     direct(
         "Node::set_transport",
         BuiltinClass::ClassB,

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -3787,6 +3787,23 @@ pub unsafe extern "C" fn hew_node_api_start(addr: *const c_char) -> c_int {
         set_last_error("Node::start: address is null");
         return -1;
     }
+    // Fail-closed: if a pre-start peer-auth step (`Node::load_keys` /
+    // `Node::allow_peer`) failed, refuse to start. Otherwise the node would bind
+    // a listener with an *ephemeral* self-signed identity (the operator's pinned
+    // key failed to load) or an *incomplete* peer allowlist — silently
+    // downgrading the configured mTLS posture (the F6 fail-open). The Hew call
+    // form discards this `-1`, so the operator-visible signal is the `hew: `
+    // diagnostic on stderr; the mesh `ensure_identity` boundary re-checks the
+    // same record as defence in depth.
+    #[cfg(feature = "quic")]
+    if let Some(reason) = crate::quic_mesh::mesh_auth_setup_error() {
+        let msg = format!(
+            "Node::start: refusing to bind listener — peer-auth setup failed (fail-closed): {reason}"
+        );
+        eprintln!("hew: {msg}");
+        set_last_error(msg);
+        return -1;
+    }
     // Each call within the same process adds a small offset to the process
     // base so multiple Node::start calls don't collide with each other.
     let offset = NODE_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -4050,6 +4067,25 @@ pub unsafe extern "C" fn hew_node_api_set_transport(name: *const c_char) -> c_in
     }
 }
 
+/// Surface a `Node::load_keys` / `Node::allow_peer` peer-auth setup failure on
+/// every channel:
+///
+/// - `hew_last_error` — the thread-local programmatic surface (unchanged from
+///   the pre-F6 behaviour);
+/// - a `hew: ` stderr diagnostic — operator-visible, because the Hew call form
+///   discards the `-1` return (these builtins are typed `Unit`);
+/// - the sticky mesh peer-auth failure record (quic-mesh builds only), which
+///   makes the next `Node::start` refuse to bind a listener (fail-closed) so a
+///   node never silently comes up with an ephemeral identity or an incomplete
+///   peer allowlist after the operator's setup failed.
+fn node_peer_auth_setup_failed(msg: impl Into<String>) {
+    let msg = msg.into();
+    eprintln!("hew: {msg} (fail-closed)");
+    #[cfg(feature = "quic")]
+    crate::quic_mesh::mesh_auth_record_failure(msg.clone());
+    set_last_error(msg);
+}
+
 /// `Node::load_keys(path)` — Load (or, if absent, mint-and-persist) this node's
 /// stable mesh TLS identity from `path`. Must be called **before**
 /// `Node::start` so the listener presents the loaded key. Peers pin the
@@ -4058,6 +4094,9 @@ pub unsafe extern "C" fn hew_node_api_set_transport(name: *const c_char) -> c_in
 ///
 /// Returns `0` on success, `-1` on a null/invalid path or key I/O failure
 /// (error string available via `hew_last_error`). Never fabricates an identity.
+/// On failure the peer-auth setup is marked failed so a subsequent `Node::start`
+/// refuses to bind a listener (fail-closed) rather than silently presenting an
+/// ephemeral identity.
 ///
 /// # Safety
 ///
@@ -4066,6 +4105,7 @@ pub unsafe extern "C" fn hew_node_api_set_transport(name: *const c_char) -> c_in
 pub unsafe extern "C" fn hew_node_api_load_keys(path: *const c_char) -> c_int {
     // SAFETY: caller guarantees path is a valid C string (or null).
     let Some(p) = (unsafe { crate::util::cstr_to_str(&path, "Node::load_keys") }) else {
+        node_peer_auth_setup_failed("Node::load_keys: invalid path argument");
         return -1;
     };
     #[cfg(feature = "quic")]
@@ -4073,7 +4113,7 @@ pub unsafe extern "C" fn hew_node_api_load_keys(path: *const c_char) -> c_int {
         match crate::quic_mesh::mesh_identity_load_or_create(std::path::Path::new(p)) {
             Ok(_spki) => 0,
             Err(err) => {
-                set_last_error(format!("Node::load_keys: {err}"));
+                node_peer_auth_setup_failed(format!("Node::load_keys: {err}"));
                 -1
             }
         }
@@ -4081,7 +4121,9 @@ pub unsafe extern "C" fn hew_node_api_load_keys(path: *const c_char) -> c_int {
     #[cfg(not(feature = "quic"))]
     {
         let _ = p;
-        set_last_error("Node::load_keys: quic-mesh transport not built (peer auth unavailable)");
+        node_peer_auth_setup_failed(
+            "Node::load_keys: quic-mesh transport not built (peer auth unavailable)",
+        );
         -1
     }
 }
@@ -4092,7 +4134,9 @@ pub unsafe extern "C" fn hew_node_api_load_keys(path: *const c_char) -> c_int {
 /// by the mTLS handshake. Native quic-mesh only.
 ///
 /// Returns `0` on success, `-1` on a null/odd/non-hex string or empty/oversize
-/// SPKI. Adds nothing on error.
+/// SPKI. Adds nothing on error. On failure the peer-auth setup is marked failed
+/// so a subsequent `Node::start` refuses to bind a listener (fail-closed) rather
+/// than silently coming up with an incomplete peer allowlist.
 ///
 /// # Safety
 ///
@@ -4101,21 +4145,29 @@ pub unsafe extern "C" fn hew_node_api_load_keys(path: *const c_char) -> c_int {
 pub unsafe extern "C" fn hew_node_api_allow_peer(spki_hex: *const c_char) -> c_int {
     // SAFETY: caller guarantees spki_hex is a valid C string (or null).
     let Some(s) = (unsafe { crate::util::cstr_to_str(&spki_hex, "Node::allow_peer") }) else {
+        node_peer_auth_setup_failed("Node::allow_peer: invalid SPKI argument");
         return -1;
     };
     let Some(bytes) = decode_hex(s) else {
-        set_last_error("Node::allow_peer: peer key must be hex-encoded SPKI bytes");
+        node_peer_auth_setup_failed("Node::allow_peer: peer key must be hex-encoded SPKI bytes");
         return -1;
     };
     #[cfg(feature = "quic")]
     {
         // SAFETY: bytes is a live Vec; ptr+len describe its contents.
-        unsafe { crate::quic_mesh::hew_quic_mesh_peer_spki_add(bytes.as_ptr(), bytes.len()) }
+        let rc =
+            unsafe { crate::quic_mesh::hew_quic_mesh_peer_spki_add(bytes.as_ptr(), bytes.len()) };
+        if rc != 0 {
+            node_peer_auth_setup_failed("Node::allow_peer: SPKI rejected by mesh allowlist");
+        }
+        rc
     }
     #[cfg(not(feature = "quic"))]
     {
         let _ = bytes;
-        set_last_error("Node::allow_peer: quic-mesh transport not built (peer auth unavailable)");
+        node_peer_auth_setup_failed(
+            "Node::allow_peer: quic-mesh transport not built (peer auth unavailable)",
+        );
         -1
     }
 }
@@ -5828,6 +5880,73 @@ mod tests {
                 NODE_STATE_STOPPED
             );
         }
+    }
+
+    /// F6 fail-closed (C ABI): a failed `Node::load_keys` / `Node::allow_peer`
+    /// records a sticky peer-auth failure, so the next `Node::start` refuses to
+    /// bind a listener (returns -1) rather than silently coming up with an
+    /// ephemeral identity or an incomplete allowlist. This is the closed half of
+    /// the worst-case fail-open F6 addresses: pre-fix, `load_keys` returned -1
+    /// (discarded by the `Unit` Hew form) yet `start` proceeded.
+    #[cfg(feature = "quic")]
+    #[test]
+    fn start_refuses_after_failed_peer_auth_setup_fail_closed() {
+        // Serialise against quic_mesh tests that mint identities / mutate the
+        // global allowlist: this test records a peer-auth failure in the shared
+        // process-global flag, which would otherwise fail-close a concurrent
+        // `ensure_identity` in another module. Held as the outermost guard.
+        let _state_guard = crate::quic_mesh::MESH_GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = crate::runtime_test_guard();
+        let bind = CString::new("127.0.0.1:0").expect("valid bind addr");
+
+        // --- corrupt keyfile: load_keys must fail and poison start ---
+        crate::quic_mesh::mesh_auth_setup_reset();
+        let dir = std::env::temp_dir().join(format!("f6-cabi-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let key = dir.join("corrupt.key");
+        std::fs::write(&key, b"not-a-keyfile-frame").unwrap();
+        let c_key = CString::new(key.to_str().unwrap()).unwrap();
+        // SAFETY: c_key is a valid NUL-terminated C string for this call.
+        let rc_load = unsafe { hew_node_api_load_keys(c_key.as_ptr()) };
+        // SAFETY: bind is a valid NUL-terminated C string for this call.
+        let rc_start_after_load = unsafe { hew_node_api_start(bind.as_ptr()) };
+        // A fail-closed start never created a node; clean up if the gate regressed.
+        if rc_start_after_load == 0 {
+            // SAFETY: shutdown reclaims the current node, if any; takes no arguments.
+            unsafe { hew_node_api_shutdown() };
+        }
+        crate::quic_mesh::mesh_auth_setup_reset();
+        let _ = std::fs::remove_file(&key);
+
+        // --- bad-hex allow_peer: must fail and poison start ---
+        crate::quic_mesh::mesh_auth_setup_reset();
+        let bad_hex = CString::new("nothex!!").expect("valid C string");
+        // SAFETY: bad_hex is a valid NUL-terminated C string for this call.
+        let rc_allow = unsafe { hew_node_api_allow_peer(bad_hex.as_ptr()) };
+        // SAFETY: bind is a valid NUL-terminated C string for this call.
+        let rc_start_after_allow = unsafe { hew_node_api_start(bind.as_ptr()) };
+        if rc_start_after_allow == 0 {
+            // SAFETY: shutdown reclaims the current node, if any; takes no arguments.
+            unsafe { hew_node_api_shutdown() };
+        }
+        // Reset BEFORE asserting so a failed assertion can't poison sibling tests.
+        crate::quic_mesh::mesh_auth_setup_reset();
+
+        assert_eq!(rc_load, -1, "a corrupt keyfile must report a load failure");
+        assert_eq!(
+            rc_start_after_load, -1,
+            "Node::start must refuse after a failed load_keys (fail-closed)"
+        );
+        assert_eq!(
+            rc_allow, -1,
+            "a bad-hex SPKI must be rejected by allow_peer"
+        );
+        assert_eq!(
+            rc_start_after_allow, -1,
+            "Node::start must refuse after a failed allow_peer (fail-closed)"
+        );
     }
 
     #[test]

--- a/hew-runtime/src/quic_mesh.rs
+++ b/hew-runtime/src/quic_mesh.rs
@@ -686,6 +686,71 @@ fn mesh_identity_clear() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Mesh peer-auth setup failure (fail-closed gate for the listener identity)
+// ---------------------------------------------------------------------------
+
+/// Sticky record of a failed mesh peer-auth setup step — a `Node::load_keys`
+/// that could not load/persist the operator's identity, or a `Node::allow_peer`
+/// that rejected a malformed SPKI. Both are pre-`Node::start` configuration; the
+/// C ABI already surfaces each failure via `hew_last_error` and a `-1` return,
+/// but the Hew call form discards that return (the builtins are `Unit`). Without
+/// this record, a failed step is invisible to `Node::start`, which then binds a
+/// listener with an *ephemeral* self-signed cert (the pinned identity failed to
+/// load) or an *incomplete* peer allowlist — a silent downgrade of the
+/// configured mTLS posture (the F6 fail-open).
+///
+/// Once set, [`QuicMeshTransport::ensure_identity`] refuses to mint or reuse an
+/// identity, so the listener cannot bind (fail-closed). The record is sticky: a
+/// failed identity is not recoverable by retrying `start`; production only
+/// clears it by fixing the configuration and re-running. Tests reset it via
+/// [`mesh_auth_setup_reset`].
+static MESH_AUTH_SETUP_ERROR: LazyLock<RwLock<Option<String>>> =
+    LazyLock::new(|| RwLock::new(None));
+
+/// Record that a mesh peer-auth setup step failed. The recorded reason blocks
+/// the next listener bind (see [`MESH_AUTH_SETUP_ERROR`]). Last failure wins so
+/// the most recently reported cause is echoed at `Node::start`.
+pub fn mesh_auth_record_failure(reason: impl Into<String>) {
+    let reason = reason.into();
+    match MESH_AUTH_SETUP_ERROR.write() {
+        Ok(mut g) => *g = Some(reason),
+        Err(p) => *p.into_inner() = Some(reason),
+    }
+}
+
+/// Returns the recorded peer-auth setup failure reason, if any. `Some` means a
+/// `Node::load_keys` / `Node::allow_peer` step failed and the mesh listener must
+/// refuse to bind (fail-closed).
+#[must_use]
+pub fn mesh_auth_setup_error() -> Option<String> {
+    MESH_AUTH_SETUP_ERROR
+        .read()
+        .map_or_else(|p| p.into_inner().clone(), |s| s.clone())
+}
+
+/// Clear the sticky peer-auth setup failure. Test-only: production never
+/// recovers a failed identity by clearing the record.
+#[cfg(test)]
+pub fn mesh_auth_setup_reset() {
+    match MESH_AUTH_SETUP_ERROR.write() {
+        Ok(mut g) => *g = None,
+        Err(p) => *p.into_inner() = None,
+    }
+}
+
+/// Serialises every test that mutates process-global mesh state — the identity
+/// override ([`mesh_identity_clear`]), the global allowlist, and the sticky
+/// peer-auth setup record ([`MESH_AUTH_SETUP_ERROR`]). These tests live in both
+/// the `quic_mesh` and `hew_node` test modules, which otherwise serialise on
+/// *different* locks (`SchedTestLock`), so this shared mutex is the single
+/// cross-module point that stops one test's recorded failure from poisoning an
+/// unrelated `ensure_identity` mint (which would then fail-closed). Acquire it
+/// as the outermost guard before touching any of that state.
+#[cfg(test)]
+pub(crate) static MESH_GLOBAL_STATE_TEST_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
+
 impl MeshTls {
     /// Serialize this identity to the dependency-free keyfile frame. The mesh
     /// always carries a single leaf cert; serialization rejects any other shape.
@@ -988,6 +1053,16 @@ impl QuicMeshTransport {
     /// transport. Returns a clone of the cached `MeshTls` (without an
     /// allowlist applied) and the local SPKI bytes.
     fn ensure_identity(&self) -> Result<(MeshTls, Vec<u8>), MeshError> {
+        // Fail-closed: a failed `Node::load_keys` / `Node::allow_peer` poisons
+        // the mesh identity. Refuse to mint or reuse any identity so the
+        // listener can never bind with an ephemeral self-signed cert (the
+        // operator's pinned identity failed to load) or an incomplete allowlist.
+        // See `MESH_AUTH_SETUP_ERROR`.
+        if let Some(reason) = mesh_auth_setup_error() {
+            return Err(MeshError::Tls(format!(
+                "peer-auth setup failed; refusing to mint mesh listener identity (fail-closed): {reason}"
+            )));
+        }
         let mut guard = self
             .identity
             .lock()
@@ -2379,11 +2454,6 @@ impl PeerConn {
 mod tests {
     use super::*;
 
-    // Serialise every test that touches the process-global allowlist so that
-    // parallel test threads don't observe each other's mutations.
-    static TEST_ALLOWLIST_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
-        std::sync::LazyLock::new(|| std::sync::Mutex::new(()));
-
     /// Verify that the ASN.1 DER walk correctly extracts the SPKI from a
     /// rcgen-generated certificate.
     #[test]
@@ -2445,7 +2515,7 @@ mod tests {
     /// bounding allocation. Fail-closed, no fabricated identity.
     #[test]
     fn load_keys_rejects_oversize_keyfile() {
-        let _g = TEST_ALLOWLIST_LOCK
+        let _g = MESH_GLOBAL_STATE_TEST_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         mesh_identity_clear();
@@ -2469,7 +2539,7 @@ mod tests {
     #[test]
     fn load_keys_writes_owner_only_perms() {
         use std::os::unix::fs::PermissionsExt;
-        let _g = TEST_ALLOWLIST_LOCK
+        let _g = MESH_GLOBAL_STATE_TEST_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         mesh_identity_clear();
@@ -2488,10 +2558,11 @@ mod tests {
     /// `ensure_identity` adopts; a second load is byte-identical.
     #[test]
     fn load_keys_persists_and_overrides_identity() {
-        let _g = TEST_ALLOWLIST_LOCK
+        let _g = MESH_GLOBAL_STATE_TEST_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         mesh_identity_clear();
+        mesh_auth_setup_reset();
         let dir = std::env::temp_dir().join(format!("cap12-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("node.key");
@@ -2690,7 +2761,7 @@ mod tests {
     /// `MAX_SPKI_BYTES` cap (`DoS` guard for an externally-driven C ABI).
     #[test]
     fn mesh_peer_spki_add_rejects_invalid_lengths() {
-        let _guard = TEST_ALLOWLIST_LOCK.lock().unwrap();
+        let _guard = MESH_GLOBAL_STATE_TEST_LOCK.lock().unwrap();
         mesh_peer_spki_clear();
         assert!(
             !mesh_peer_spki_add(Vec::new()),
@@ -2706,7 +2777,7 @@ mod tests {
     /// Add + remove + clear cycle through the allowlist.
     #[test]
     fn mesh_peer_spki_add_remove_clear_roundtrip() {
-        let _guard = TEST_ALLOWLIST_LOCK.lock().unwrap();
+        let _guard = MESH_GLOBAL_STATE_TEST_LOCK.lock().unwrap();
         mesh_peer_spki_clear();
         let spki = vec![0xAAu8; 64];
         assert!(mesh_peer_spki_add(spki.clone()));
@@ -2733,6 +2804,10 @@ mod tests {
     /// bytes that the eventual `listen` uses).
     #[test]
     fn transport_identity_is_cached() {
+        let _guard = MESH_GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        mesh_auth_setup_reset();
         let rt = Arc::new(
             tokio::runtime::Builder::new_current_thread()
                 .enable_all()
@@ -2753,7 +2828,8 @@ mod tests {
     /// peers must be trusted; un-registered SPKIs must NOT be trusted.
     #[test]
     fn listen_tls_unions_global_allowlist_with_own_spki() {
-        let _guard = TEST_ALLOWLIST_LOCK.lock().unwrap();
+        let _guard = MESH_GLOBAL_STATE_TEST_LOCK.lock().unwrap();
+        mesh_auth_setup_reset();
         mesh_peer_spki_clear();
         let rt = Arc::new(
             tokio::runtime::Builder::new_current_thread()
@@ -2782,6 +2858,68 @@ mod tests {
             "unregistered SPKI must not be in the snapshot"
         );
         mesh_peer_spki_clear();
+    }
+
+    /// F6 fail-closed: a recorded peer-auth setup failure (a failed
+    /// `Node::load_keys` / `Node::allow_peer`) makes `ensure_identity` refuse to
+    /// mint or reuse an identity, so the mesh listener cannot bind with an
+    /// ephemeral cert or an incomplete allowlist. Clearing the record restores
+    /// the loopback-dev default (a fresh self-signed identity), so the gate only
+    /// fires after an *actual* failure, never when peer-auth was simply never
+    /// configured.
+    #[test]
+    fn recorded_peer_auth_failure_makes_ensure_identity_fail_closed() {
+        let _guard = MESH_GLOBAL_STATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        mesh_identity_clear();
+        mesh_auth_setup_reset();
+
+        // No failure recorded: the loopback-dev default mints a self-signed
+        // identity (peer-auth was never configured — not a failure).
+        let rt0 = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap(),
+        );
+        assert!(
+            QuicMeshTransport::new(rt0).ensure_identity().is_ok(),
+            "with no recorded failure, ensure_identity mints the dev default"
+        );
+
+        // A recorded failure poisons the identity: ensure_identity fails closed.
+        mesh_auth_record_failure("test: simulated load_keys failure");
+        let rt1 = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap(),
+        );
+        let blocked = QuicMeshTransport::new(rt1).ensure_identity();
+        assert!(
+            blocked.is_err(),
+            "a recorded peer-auth failure must block the listener identity (fail-closed)"
+        );
+        let msg = format!("{}", blocked.unwrap_err());
+        assert!(
+            msg.contains("fail-closed") && msg.contains("simulated load_keys failure"),
+            "the fail-closed error must echo the recorded reason, got: {msg}"
+        );
+
+        // Clearing the record restores the dev default.
+        mesh_auth_setup_reset();
+        let rt2 = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap(),
+        );
+        assert!(
+            QuicMeshTransport::new(rt2).ensure_identity().is_ok(),
+            "clearing the recorded failure restores the dev default"
+        );
+        mesh_identity_clear();
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
load_keys/allow_peer (typed Unit) silently discarded the C-ABI -1, so start() bound a mesh listener with an ephemeral self-signed cert (operator's pinned mTLS identity never loaded) — a fail-open. Now every peer-auth setup failure is surfaced (hew_last_error + hew: stderr + sticky record) and start() refuses to bind without the intended identity (two fail-closed gates).
## Verification
ci-preflight 13/13 (test 10607 pass), 3 e2e (bad-hex/corrupt-keyfile/no-identity assert start refuses), flake 3/3, RED-confirmed.
## Out of scope
Typed Result surface (kept Unit; surfaces via stderr+gate) — scoped follow-on if preferred.