### PR TITLE
feat(closures): complete closures-N (nested/type-param-capture/captured-var write-back)

### DIFF
--- a/hew-cli/tests/closure_env_drop_leak_oracle.rs
+++ b/hew-cli/tests/closure_env_drop_leak_oracle.rs
@@ -1,0 +1,427 @@
+//! Closure-environment scope-exit drop oracles: per-iteration leak slope plus
+//! poisoned-allocator no-double-free pins for the heap-env closure shapes this
+//! lane completes (nested env-of-env, type-parameterised owned capture, and the
+//! `BorrowMut` counter-factory write-back).
+//!
+//! ## Why this oracle exists
+//!
+//! Closures capture heap into their environment. An escaping closure promotes
+//! its env to a `hew_dyn_box_alloc` box with a leading free-thunk slot; when the
+//! closure pair drops — on normal scope exit, an early return, or the
+//! cancel/actor-shutdown drop path — the env free thunk must release every owned
+//! capture field (Act 1) and then free the box (Act 2). A captured field that is
+//! ITSELF a closure pair recurses into the inner env's free thunk, so a nested
+//! capture must drop transitively. This oracle is the binary-level proof that
+//! the manifest is complete for the shapes the lane admits: a missing field-drop
+//! leaks per iteration (caught by the slope), and a double-counted field
+//! double-frees (caught by the poisoned allocator).
+//!
+//! ## Slope methodology
+//!
+//! Mirrors `vec_local_drop_leak_oracle.rs`: compile the same shape at a LOW and
+//! a HIGH frame count, measure leak NODE counts under `leaks --atExit` with the
+//! `MallocScribble`/`MallocPreScribble`/`MallocGuardEdges` triple, and assert
+//! the delta stays within a small constant independent of frame count. A
+//! per-iteration leak (one un-dropped env box, or an un-dropped owned capture
+//! inside it) grows ~1+ node/frame and lands an order of magnitude above the
+//! tolerance across the `50 - 3 = 47`-frame delta. Absolute counts are not
+//! asserted — runtime one-off allocations jitter by a few nodes.
+//!
+//! ## No-double-free pin
+//!
+//! The combined shape exercises a nested env-of-env, a counter factory, and a
+//! type-parameterised owned capture in one process, then prints a deterministic
+//! checksum. Under the poisoned-allocator triple, a producer-side double-drop of
+//! any env box (or a captured field the inner free thunk also releases) corrupts
+//! the heap or aborts before the checksum is printed, so a clean
+//! `125OK` is the no-double-free witness.
+//!
+//! ## Skip behaviour
+//!
+//! The slope oracles are macOS-only (`leaks(1)` is Darwin's allocator
+//! inspector); on other platforms they log `skip:` and return. The scribble pin
+//! runs on any unix host.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+/// Low frame count: exercises the loop back-edge at least twice while staying
+/// near the constant-overhead floor.
+const LOW_FRAMES: usize = 3;
+
+/// High frame count for the slope check. A slope of >= 1.0 leak/frame (one
+/// un-dropped env box per iteration) produces `HIGH_FRAMES - LOW_FRAMES = 47`+
+/// excess nodes against the tolerance.
+const HIGH_FRAMES: usize = 50;
+
+/// Maximum permitted leak-node delta between the HIGH and LOW probes. Same
+/// headroom rationale as the sibling oracles: absorbs one-off scheduler/runtime
+/// allocations that appear only in the HIGH run while still catching a slope of
+/// ~0.1 leaks/frame.
+const SLOPE_TOLERANCE: usize = 5;
+
+// ── fixtures ──────────────────────────────────────────────────────────────
+
+/// Fixture A — nested env-of-env (#4b heap). `make_pair` returns an outer
+/// closure that captured an INNER closure binding; the outer escapes, so its
+/// env is heap-boxed and the inner closure pair is heap-promoted and rides into
+/// the outer env. Each iteration creates and drops the whole env-of-env, so the
+/// outer free thunk must recurse into the inner env's free thunk every frame.
+/// Pre-recursion: the inner box leaks one node/frame.
+fn env_of_env_loop_source(frames: usize) -> String {
+    format!(
+        "fn make_pair(base: i64) -> fn(i64) -> i64 {{\n\
+         \x20   let inner = |x: i64| x + base;\n\
+         \x20   |y: i64| inner(y) + 1\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let f = make_pair(i);\n\
+         \x20       total = total + f(10);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Fixture B — type-parameterised OWNED capture (#6). `pick<T>` captures a `T`
+/// into a closure; instantiated at `string`, the env field is a heap string the
+/// escaping env free thunk must release. The `make_str` indirection forces the
+/// closure to escape its constructor frame (heap env) so the drop runs through
+/// the box free thunk, not a stack scope exit.
+fn owned_type_param_loop_source(frames: usize) -> String {
+    format!(
+        "fn hold<T>(x: T) -> fn() -> i64 {{\n\
+         \x20   || {{ let _h = x; 0 }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let g = hold(\"per-iteration-owned-captured-string\");\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+/// Fixture C — `BorrowMut` counter factory (#1′). `make_counter` returns a closure
+/// capturing a local `count` by `BorrowMut`; the env is heap-boxed and mutated in
+/// place via `ClosureEnvFieldStore`. The scalar field is `BitCopy` (no owned
+/// drop), so this isolates the ENV BOX free path: each iteration's box must be
+/// released even though the closure was invoked and mutated.
+fn counter_factory_loop_source(frames: usize) -> String {
+    format!(
+        "fn make_counter() -> fn() -> i64 {{\n\
+         \x20   var count: i64 = 0;\n\
+         \x20   || {{ count = count + 1; count }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let c = make_counter();\n\
+         \x20       total = total + c() + c();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Fixture D — flat OWNED capture baseline (non-generic). An escaping closure
+/// captures a concrete `string` and borrows it. The env free thunk must release
+/// the string; this isolates the single-owned-field drop from the generic
+/// substitution path (Fixture B) and the nesting recursion (Fixture A).
+fn flat_owned_capture_loop_source(frames: usize) -> String {
+    format!(
+        "fn make_holder(label: string) -> fn() -> i64 {{\n\
+         \x20   || label.len()\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let h = make_holder(\"per-iteration-flat-owned-string\");\n\
+         \x20       total = total + h();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// No-double-free pin source — exercises a nested env-of-env, a counter factory,
+/// and a type-parameterised owned capture in one process, then prints the
+/// checksum `111 + 6 + 8 = 125`. A double-drop of any env box (or a captured
+/// field the inner free thunk also releases) aborts or scribbles before the
+/// checksum prints under the poisoned allocator.
+const NO_DOUBLE_FREE_SOURCE: &str = "\
+fn make_pair(base: i64) -> fn(i64) -> i64 {\n\
+\x20   let inner = |x: i64| x + base;\n\
+\x20   |y: i64| inner(y) + 1\n\
+}\n\
+fn make_counter() -> fn() -> i64 {\n\
+\x20   var count: i64 = 0;\n\
+\x20   || { count = count + 1; count }\n\
+}\n\
+fn pick<T>(x: T) -> T {\n\
+\x20   let get = || x;\n\
+\x20   get()\n\
+}\n\
+fn main() {\n\
+\x20   let f = make_pair(100);\n\
+\x20   let a = f(10);\n\
+\x20   let c = make_counter();\n\
+\x20   let b = c() + c() + c();\n\
+\x20   let s = pick(\"captured\");\n\
+\x20   let d = s.len();\n\
+\x20   print(a + b + d);\n\
+\x20   print(\"OK\");\n\
+}\n";
+
+// ── leak measurement plumbing (same shape as vec_local_drop_leak_oracle) ────
+
+/// Compile `source` to a native binary via `hew compile --emit-dir` and return
+/// the binary path.
+fn compile_to_native(source: &str, dir: &std::path::Path, name: &str) -> PathBuf {
+    let hew_src = dir.join(format!("{name}.hew"));
+    std::fs::write(&hew_src, source).expect("write hew source");
+
+    let output = Command::new(hew_binary())
+        .args([
+            "compile",
+            "--emit-dir",
+            dir.to_str().expect("emit-dir utf-8"),
+            hew_src.to_str().expect("hew src utf-8"),
+        ])
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew compile");
+
+    assert!(
+        output.status.success(),
+        "hew compile failed for {name}:\n{}",
+        describe_output(&output)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let bin = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("native: "))
+        .unwrap_or_else(|| panic!("no `native:` line for {name}:\n{stdout}"))
+        .to_string();
+    PathBuf::from(bin)
+}
+
+/// Run `bin` under the poisoned-allocator triple + `leaks --atExit` and return
+/// `Some(leak_count)` when `leaks` produced a usable report.
+fn measure_leaks(bin: &std::path::Path) -> Option<usize> {
+    let output = Command::new("leaks")
+        .arg("--atExit")
+        .arg("--")
+        .arg(bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .ok()?;
+    if !output.status.success() && output.stdout.is_empty() {
+        eprintln!(
+            "skip: leaks declined to attach to {}: {}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+    let report = String::from_utf8_lossy(&output.stdout);
+    let mut parsed: Option<usize> = None;
+    for line in report.lines() {
+        if !line.contains(" leaks for ") && !line.contains(" leak for ") {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("Process ") {
+            if !rest.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+                continue;
+            }
+            if let Some(after_colon) = rest.split_once(": ").map(|(_, s)| s) {
+                if let Some(n) = after_colon.split_whitespace().next() {
+                    if let Ok(n) = n.parse::<usize>() {
+                        eprintln!("  parsed leak count from line: {line}");
+                        parsed = Some(n);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    if parsed.is_none() {
+        eprintln!(
+            "skip: leaks did not emit a `Process <pid>: N leak(s) for B total leaked bytes.` \
+             summary for {}: stderr=\n{}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    parsed
+}
+
+/// Build the shape at `low_frames` and `high_frames`, measure leak NODE counts,
+/// and assert the delta stays within `SLOPE_TOLERANCE`.
+fn assert_frame_slope_below_tolerance(
+    shape_name: &str,
+    source_fn: fn(usize) -> String,
+    low_frames: usize,
+    high_frames: usize,
+) {
+    if !cfg!(target_os = "macos") {
+        eprintln!("skip: {shape_name}: leaks(1) is macOS-only");
+        return;
+    }
+    let leaks_avail = Command::new("which")
+        .arg("leaks")
+        .output()
+        .is_ok_and(|o| o.status.success());
+    if !leaks_avail {
+        eprintln!("skip: {shape_name}: `leaks` binary not on PATH");
+        return;
+    }
+
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("closure-leak-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+
+    let bin_low = compile_to_native(
+        &source_fn(low_frames),
+        dir.path(),
+        &format!("{shape_name}_low"),
+    );
+    let bin_high = compile_to_native(
+        &source_fn(high_frames),
+        dir.path(),
+        &format!("{shape_name}_high"),
+    );
+
+    let Some(low_leaks) = measure_leaks(&bin_low) else {
+        return;
+    };
+    let Some(high_leaks) = measure_leaks(&bin_high) else {
+        return;
+    };
+
+    eprintln!(
+        "{shape_name}: low_frames={low_frames} low_leaks={low_leaks} \
+         high_frames={high_frames} high_leaks={high_leaks} tolerance={SLOPE_TOLERANCE}"
+    );
+    assert!(
+        high_leaks <= low_leaks + SLOPE_TOLERANCE,
+        "{shape_name}: per-frame leak SLOPE — low_frames={low_frames} low_leaks={low_leaks}, \
+         high_frames={high_frames} high_leaks={high_leaks}. Excess of {} NODES over the \
+         tolerance of {SLOPE_TOLERANCE} indicates a per-iteration closure env (or an owned \
+         capture inside it) is not being released. Re-run with \
+         `MallocStackLogging=1 leaks --atExit -- {}` to see the leaked block's stack.",
+        high_leaks.saturating_sub(low_leaks + SLOPE_TOLERANCE),
+        bin_high.display()
+    );
+}
+
+// ── oracles ───────────────────────────────────────────────────────────────
+
+/// Nested env-of-env (#4b heap): the outer escaping env's free thunk must
+/// recurse into the captured inner closure's env free thunk every frame.
+#[test]
+fn closure_env_of_env_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "closure_env_of_env",
+        env_of_env_loop_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// Type-parameterised owned capture (#6): a `string` captured through a generic
+/// `T` is released by the escaping env free thunk after monomorphisation
+/// substitutes the env field to its concrete owned type.
+#[test]
+fn closure_owned_type_param_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "closure_owned_type_param",
+        owned_type_param_loop_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// `BorrowMut` counter factory (#1′): the heap env box of an invoked-and-mutated
+/// escaping closure is released every frame.
+#[test]
+fn closure_counter_factory_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "closure_counter_factory",
+        counter_factory_loop_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// Flat owned capture baseline: a single concrete-`string` capture field is
+/// released by the env free thunk, isolating the owned-field drop from nesting
+/// and generics.
+#[test]
+fn closure_flat_owned_capture_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "closure_flat_owned_capture",
+        flat_owned_capture_loop_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// No-double-free pin: the combined nested + counter + owned-capture shape runs
+/// to completion under the poisoned-allocator triple and prints the `125`
+/// checksum. A double-drop of any env box (or a captured field the inner free
+/// thunk also releases) aborts or scribbles the value before it prints.
+#[test]
+fn closure_env_shapes_run_clean_under_malloc_scribble() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("closure-leak-no-double-free-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(NO_DOUBLE_FREE_SOURCE, dir.path(), "no_double_free");
+
+    let output = Command::new(&bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .expect("run closure no-double-free binary");
+
+    assert!(
+        output.status.success(),
+        "closure env shapes must run clean under the poisoned allocator — a \
+         crash here indicates a double-drop of an escaped closure env box;\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        "125OK",
+        "closure env shapes must print the 111 + 6 + 8 checksum untouched — a \
+         scribbled value indicates a producer-side double-drop of an env field;\n{}",
+        describe_output(&output)
+    );
+}

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -2765,7 +2765,54 @@ fn closure_nested_noncapturing_runs() {
     assert_eq!(actual, "16\n", "expected 16; got: {actual:?}");
 }
 
-/// `Vec<fn(i64) -> i64>` storage surface: array literal, indexing, push,
+/// Type-parameterized closure capture: a closure inside `fn pick<T>(x: T) -> T`
+/// captures the type-parameter-typed value and returns it, instantiated at two
+/// concrete types.
+///
+/// Previously `E_MIR` `UnknownType` `T`: the closure env field type and the
+/// invoke shim's return ABI were left as the bare type-parameter symbol. The
+/// codegen-readiness walk over the env record layout has no per-monomorphisation
+/// subst map, so an un-substituted `T` was rejected at the MIR boundary. The
+/// closure-literal lowering now substitutes capture/param/return types through
+/// the monomorphisation map. The `string` instantiation also exercises an OWNED
+/// capture (heap buffer released by the escaping env free thunk).
+#[test]
+fn closure_type_param_capture_runs() {
+    require_codegen();
+
+    let source = repo_root().join("tests/vertical-slice/accept/closure_type_param_capture.hew");
+    let output = run_bounded_hew_run(&source, repo_root());
+    assert!(
+        output.status.success(),
+        "closure_type_param_capture should succeed; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let actual = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    assert_eq!(
+        actual, "42\nclosure\n",
+        "expected 42 then closure; got: {actual:?}"
+    );
+}
+
+/// Type-parameterized closure capture with TWO type parameters captured by the
+/// same closure env. Each capture field substitutes to its concrete type
+/// independently (`i64`, `string`).
+#[test]
+fn closure_type_param_multi_runs() {
+    require_codegen();
+
+    let source = repo_root().join("tests/vertical-slice/accept/closure_type_param_multi.hew");
+    let output = run_bounded_hew_run(&source, repo_root());
+    assert!(
+        output.status.success(),
+        "closure_type_param_multi should succeed; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let actual = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    assert_eq!(actual, "99\n", "expected 99; got: {actual:?}");
+}
 /// get, and pop over boxed-pair elements riding the pointer-element ABI.
 #[test]
 fn vec_of_fn_storage_ops_run() {

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -2694,6 +2694,77 @@ fn returned_closure_survives_stack_clobber() {
     assert_eq!(actual, "15\n", "expected 15; got: {actual:?}");
 }
 
+/// Nested closure captures the OUTER closure literal's own parameter.
+///
+/// Previously `E_HIR` `DanglingRef`: the HIR verifier walked a closure literal's
+/// body without first registering the literal's own parameters as declared
+/// bindings (only named-fn and actor-method params were registered), so the
+/// inner literal's capture of the outer param resolved to a binding the
+/// verifier believed undeclared.
+#[test]
+fn closure_nested_captures_outer_param_runs() {
+    require_codegen();
+
+    let source =
+        repo_root().join("tests/vertical-slice/accept/closure_nested_captures_outer_param.hew");
+    let output = run_bounded_hew_run(&source, repo_root());
+    assert!(
+        output.status.success(),
+        "closure_nested_captures_outer_param should succeed; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let actual = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    assert_eq!(actual, "15\n", "expected 15; got: {actual:?}");
+}
+
+/// A closure captures another closure BINDING from the enclosing scope and
+/// dispatches it as a bare-identifier callee.
+///
+/// Previously `E_HIR` `CheckerBoundaryViolation`: the call checker resolved a
+/// bare-identifier closure callee directly, without recording the
+/// `ClosureCaptureFact` the identifier-read path records, so HIR capture
+/// materialization found the captured binding with no checker metadata.
+#[test]
+fn closure_captures_closure_binding_runs() {
+    require_codegen();
+
+    let source =
+        repo_root().join("tests/vertical-slice/accept/closure_captures_closure_binding.hew");
+    let output = run_bounded_hew_run(&source, repo_root());
+    assert!(
+        output.status.success(),
+        "closure_captures_closure_binding should succeed; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let actual = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    assert_eq!(actual, "42\n", "expected 42; got: {actual:?}");
+}
+
+/// A non-capturing closure literal nested inside another closure's body.
+///
+/// Previously `E_NOT_YET_IMPLEMENTED` (missing closure invoke shim): the nested
+/// literal's invoke shim is produced while the parent shim is being lowered, so
+/// it lands in the parent's `generated.generated`, and the module driver
+/// flattened only one level — `MakeClosure` then referenced a shim symbol
+/// codegen never emitted. The driver now flattens the generated tree fully.
+#[test]
+fn closure_nested_noncapturing_runs() {
+    require_codegen();
+
+    let source = repo_root().join("tests/vertical-slice/accept/closure_nested_noncapturing.hew");
+    let output = run_bounded_hew_run(&source, repo_root());
+    assert!(
+        output.status.success(),
+        "closure_nested_noncapturing should succeed; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let actual = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    assert_eq!(actual, "16\n", "expected 16; got: {actual:?}");
+}
+
 /// `Vec<fn(i64) -> i64>` storage surface: array literal, indexing, push,
 /// get, and pop over boxed-pair elements riding the pointer-element ABI.
 #[test]

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -2857,6 +2857,30 @@ fn closure_counter_factory_runs() {
     let actual = strip_ansi(&String::from_utf8_lossy(&output.stdout));
     assert_eq!(actual, "1\n2\n3\n", "expected 1,2,3; got: {actual:?}");
 }
+
+/// A closure that captures a non-Copy `string` binding WITHOUT `move` is
+/// accepted: the checker infers a read-only Borrow capture (the closure only
+/// reads `name`), so the legacy `ClosureExplicitMoveRequired` diagnostic is
+/// dead for this site. Because it is a borrow, the outer binding still owns the
+/// string and `main` reads it again after the closure — the string is freed
+/// exactly once at scope exit. Replaces the stale `closure_explicit_move_required`
+/// reject fixture, which asserted the now-removed reject behaviour.
+#[test]
+fn closure_noncopy_inferred_borrow_runs() {
+    require_codegen();
+
+    let source =
+        repo_root().join("tests/vertical-slice/accept/closure_noncopy_inferred_borrow.hew");
+    let output = run_bounded_hew_run(&source, repo_root());
+    assert!(
+        output.status.success(),
+        "closure_noncopy_inferred_borrow should succeed; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let actual = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    assert_eq!(actual, "hew\nhew\n", "expected hew,hew; got: {actual:?}");
+}
 /// get, and pop over boxed-pair elements riding the pointer-element ABI.
 #[test]
 fn vec_of_fn_storage_ops_run() {

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -2813,6 +2813,50 @@ fn closure_type_param_multi_runs() {
     let actual = strip_ansi(&String::from_utf8_lossy(&output.stdout));
     assert_eq!(actual, "99\n", "expected 99; got: {actual:?}");
 }
+
+/// `BorrowMut` write-back (#1′): a closure reassigns a captured scalar `var`.
+///
+/// Previously `E_MIR` `UnresolvedPlace` ("assignment target binding has no MIR
+/// place"): the assignment lowering resolved only `binding_locals` targets, so
+/// a reassigned captured binding (which lives in the closure env, not a local
+/// slot) had no write path. The lowering now emits a `ClosureEnvFieldStore`
+/// into the env field. The env owns the mutable scalar (Option B): `acc`
+/// accumulates 0 -> 5 -> 8 while the caller's original `total` stays 0.
+#[test]
+fn closure_captured_var_writeback_runs() {
+    require_codegen();
+
+    let source = repo_root().join("tests/vertical-slice/accept/closure_captured_var_writeback.hew");
+    let output = run_bounded_hew_run(&source, repo_root());
+    assert!(
+        output.status.success(),
+        "closure_captured_var_writeback should succeed; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let actual = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    assert_eq!(actual, "5\n8\n0\n", "expected 5,8,0; got: {actual:?}");
+}
+
+/// `BorrowMut` write-back (#1′) through an ESCAPING heap-boxed env: the stateful
+/// counter-factory idiom. `make_counter` returns a closure capturing its local
+/// `count` by `BorrowMut`, so the env is heap-promoted and each call mutates the
+/// heap field in place, accumulating 1 -> 2 -> 3.
+#[test]
+fn closure_counter_factory_runs() {
+    require_codegen();
+
+    let source = repo_root().join("tests/vertical-slice/accept/closure_counter_factory.hew");
+    let output = run_bounded_hew_run(&source, repo_root());
+    assert!(
+        output.status.success(),
+        "closure_counter_factory should succeed; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let actual = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    assert_eq!(actual, "1\n2\n3\n", "expected 1,2,3; got: {actual:?}");
+}
 /// get, and pop over boxed-pair elements riding the pointer-element ABI.
 #[test]
 fn vec_of_fn_storage_ops_run() {

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -16644,6 +16644,15 @@ fn lower_instruction(
             lower_closure_env_field_load(fn_ctx, *env, env_ty, *field_offset, *dest)?;
             let _ = ctx;
         }
+        Instr::ClosureEnvFieldStore {
+            env,
+            env_ty,
+            field_offset,
+            src,
+        } => {
+            lower_closure_env_field_store(fn_ctx, *env, env_ty, *field_offset, *src)?;
+            let _ = ctx;
+        }
         Instr::CallClosure {
             callee,
             args,
@@ -19381,6 +19390,64 @@ fn lower_closure_env_field_load(
         .builder
         .build_store(dest_ptr, value)
         .llvm_ctx("ClosureEnvFieldLoad store")?;
+    Ok(())
+}
+
+/// Store one value into a closure invoke shim's environment field — the
+/// write-back twin of [`lower_closure_env_field_load`]. Emitted for `#1′`
+/// BorrowMut write-back (a closure body reassigning a captured scalar `var`).
+/// Mirrors the load's pointer chase (load the env pointer, GEP to the field),
+/// then stores `src` into the field instead of loading out of it. Restricted to
+/// `BitCopy` scalar fields by the MIR lowering, so no overwrite-release of a
+/// prior owned value is needed here.
+fn lower_closure_env_field_store(
+    fn_ctx: &FnCtx<'_, '_>,
+    env: Place,
+    env_ty: &ResolvedTy,
+    field_offset: FieldOffset,
+    src: Place,
+) -> CodegenResult<()> {
+    let env_struct = record_struct_for(fn_ctx, env_ty)?;
+    let (env_slot, env_slot_ty) = place_pointer(fn_ctx, env)?;
+    if !matches!(env_slot_ty, BasicTypeEnum::PointerType(_)) {
+        return Err(CodegenError::FailClosed(format!(
+            "ClosureEnvFieldStore env slot must hold a pointer, got {env_slot_ty:?}"
+        )));
+    }
+    let env_ptr = fn_ctx
+        .builder
+        .build_load(env_slot_ty, env_slot, "closure_env_ptr_load")
+        .llvm_ctx("ClosureEnvFieldStore env load")?
+        .into_pointer_value();
+    let idx = field_offset.0;
+    let idx_usize = usize::try_from(idx).map_err(|_| {
+        CodegenError::FailClosed(format!(
+            "ClosureEnvFieldStore field offset {idx} exceeds usize::MAX — impossible"
+        ))
+    })?;
+    let field_ty = *env_struct.get_field_types().get(idx_usize).ok_or_else(|| {
+        CodegenError::FailClosed(format!(
+            "ClosureEnvFieldStore field offset {idx} out of bounds"
+        ))
+    })?;
+    let (src_ptr, src_ty) = place_pointer(fn_ctx, src)?;
+    if src_ty != field_ty {
+        return Err(CodegenError::FailClosed(format!(
+            "ClosureEnvFieldStore src type {src_ty:?} does not match field type {field_ty:?}"
+        )));
+    }
+    let field_ptr = fn_ctx
+        .builder
+        .build_struct_gep(env_struct, env_ptr, idx, "closure_capture_ptr")
+        .llvm_ctx("ClosureEnvFieldStore gep")?;
+    let value = fn_ctx
+        .builder
+        .build_load(field_ty, src_ptr, "closure_capture_store_val")
+        .llvm_ctx("ClosureEnvFieldStore src load")?;
+    fn_ctx
+        .builder
+        .build_store(field_ptr, value)
+        .llvm_ctx("ClosureEnvFieldStore field store")?;
     Ok(())
 }
 

--- a/hew-codegen-rs/tests/closure_env_drop_manifest.rs
+++ b/hew-codegen-rs/tests/closure_env_drop_manifest.rs
@@ -19,6 +19,12 @@
 //! captures. This is the negative control distinguishing a wired manifest from
 //! a blanket "drop everything" (which would double-free a BitCopy alias).
 //!
+//! The type-parameterised case (`fn make<T>(x: T) -> fn() -> T`) extends this to
+//! the #6 owned-generic capture: after monomorphisation the `T=string`
+//! instantiation's free thunk releases the captured string exactly once while
+//! the `T=i64` instantiation of the same generic function gains no release —
+//! distinct, correctly-keyed per-monomorphisation thunks.
+//!
 //! LESSONS applied:
 //! - `drop-allowset-from-value-flow` (P0): the test asserts the exact emitted
 //!   release symbol against a fix-disabled-equivalent negative control (the
@@ -27,6 +33,9 @@
 //!   owned-field release per capture class.
 //! - `boundary-fail-closed` (P0): absence of the release inside the free thunk
 //!   is the gate condition.
+//! - `monomorphization-site-key-scope` (§6): the type-parameterised test pins
+//!   that the per-monomorphisation free thunk is keyed on the inner capture
+//!   site, so `T=string` and `T=i64` get distinct drop behaviour.
 
 use std::path::Path;
 
@@ -205,5 +214,85 @@ fn bitcopy_capture_has_no_owned_release_in_free_thunk() {
     assert!(
         thunk.contains("hew_dyn_box_free"),
         "the BitCopy-capture free thunk must still free the box. Thunk body:\n{thunk}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Type-parameterised owned capture (#6): a closure inside `fn make<T>(x: T)`
+// captures the generic-`T` value by move and escapes (returned as `fn() -> T`).
+// After monomorphisation the env field `T` is concrete, so the OWNED (`string`)
+// instantiation's free thunk releases the captured handle exactly once, while
+// the BitCopy (`i64`) instantiation of the SAME generic function gains no
+// release. This is the direct release-COUNT proof for the #6 owned-generic
+// capture WITH a built-in negative control (the i64 mono) — not a leak floor.
+//
+// It also pins `monomorphization-site-key-scope`: the per-monomorphisation free
+// thunk is keyed by the inner capture site, so `T=string` and `T=i64` get
+// DISTINCT thunks with DISTINCT drop behaviour. A mono keyed on the outer
+// wrapper would hand both the same thunk — either leaking the string (i64
+// thunk) or double-freeing the i64 alias (string thunk).
+// ---------------------------------------------------------------------------
+
+const TYPE_PARAM_STRING_THUNK: &str = "__hew_closure_env_free___hew_closure_invoke_make__string_0";
+const TYPE_PARAM_I64_THUNK: &str = "__hew_closure_env_free___hew_closure_invoke_make__i64_0";
+
+#[test]
+fn type_param_owned_capture_freed_once_per_monomorphisation() {
+    let ll = emit_ll(
+        "fn make<T>(x: T) -> fn() -> T {\n\
+        \x20   || x\n\
+        }\n\
+        fn main() -> i64 {\n\
+        \x20   let f = make(\"closure\");\n\
+        \x20   let g = make(7);\n\
+        \x20   let _ = f();\n\
+        \x20   g()\n\
+        }\n",
+        "type_param_capture",
+    );
+
+    // OWNED instantiation (`T = string`): the substituted env field is a real
+    // owned handle, released exactly once before the box is freed.
+    let string_thunk = function_body(&ll, TYPE_PARAM_STRING_THUNK);
+    assert!(
+        !string_thunk.is_empty(),
+        "no monomorphised free thunk `{TYPE_PARAM_STRING_THUNK}` emitted for the \
+         escaping `T=string` instantiation; the owned generic-`T` capture must plant \
+         a per-monomorphisation free thunk. Emitted IR:\n{ll}"
+    );
+    assert_eq!(
+        string_thunk.matches("hew_string_drop").count(),
+        1,
+        "the `T=string` env free thunk must release the captured string EXACTLY once \
+         (release-COUNT==1) — a missing release leaks, a doubled release double-frees. \
+         Thunk body:\n{string_thunk}"
+    );
+    assert!(
+        string_thunk.contains("hew_dyn_box_free"),
+        "the `T=string` env free thunk must free the box after releasing the capture. \
+         Thunk body:\n{string_thunk}"
+    );
+
+    // NEGATIVE CONTROL — BitCopy instantiation (`T = i64`) of the SAME generic
+    // function: no owned-field release, box free only. A wrong mono key or a
+    // blanket "drop every field" would emit `hew_string_drop` here and
+    // double-free the BitCopy alias of the caller's live binding.
+    let i64_thunk = function_body(&ll, TYPE_PARAM_I64_THUNK);
+    assert!(
+        !i64_thunk.is_empty(),
+        "no monomorphised free thunk `{TYPE_PARAM_I64_THUNK}` emitted for the escaping \
+         `T=i64` instantiation. Emitted IR:\n{ll}"
+    );
+    assert_eq!(
+        i64_thunk.matches("hew_string_drop").count(),
+        0,
+        "the `T=i64` env free thunk must NOT release any owned handle — `i64` is a \
+         BitCopy capture; a release here would corrupt unrelated memory. This is the \
+         negative control proving the drop manifest is wired per-monomorphisation, not \
+         blanket. Thunk body:\n{i64_thunk}"
+    );
+    assert!(
+        i64_thunk.contains("hew_dyn_box_free"),
+        "the `T=i64` env free thunk must still free the box. Thunk body:\n{i64_thunk}"
     );
 }

--- a/hew-hir/src/verify.rs
+++ b/hew-hir/src/verify.rs
@@ -480,7 +480,23 @@ impl Verifier {
                     }
                 }
             }
-            HirExprKind::Closure { body, captures, .. } => {
+            HirExprKind::Closure {
+                params,
+                body,
+                captures,
+                ..
+            } => {
+                // Register the closure's own parameters BEFORE walking the
+                // body: a nested closure in the body may capture one of these
+                // params (`|x| { |y| x + y }`), and the capture-declared check
+                // below resolves `capture.binding` against `self.bindings`.
+                // Without this the inner capture of an outer-closure param is
+                // a spurious DanglingRef — exactly the path actor methods and
+                // named-fn bodies already register (see the actor-method and
+                // Function arms). Mirrors that registration here.
+                for param in params {
+                    self.binding(param.id, param.span.clone());
+                }
                 self.expr(body);
                 let mut seen = std::collections::HashSet::new();
                 for capture in captures {

--- a/hew-mir/src/dataflow.rs
+++ b/hew-mir/src/dataflow.rs
@@ -625,6 +625,11 @@ pub(crate) fn instr_reads_writes(instr: &Instr) -> (Vec<Place>, Vec<Place>) {
             (vec![*record, *src], vec![])
         }
         Instr::ActorStateFieldStore { src, .. } => (vec![*src], vec![]),
+        // Closure-env write-back (#1′): reads the env pointer (to GEP into it)
+        // and the stored value. The env stays Live — only the field bytes are
+        // overwritten through the pointer, opaque to the MIR lattice — so the
+        // env is a read, not a write, exactly like `RecordFieldStore`.
+        Instr::ClosureEnvFieldStore { env, src, .. } => (vec![*env, *src], vec![]),
         Instr::TupleFieldLoad { tuple, dest, .. } => (vec![*tuple], vec![*dest]),
         Instr::TupleConstruct { elements, dest } => (elements.clone(), vec![*dest]),
         Instr::SpawnActor {

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -798,6 +798,18 @@ fn render_instr(instr: &Instr) -> String {
             field_offset.0,
             env_ty.user_facing()
         ),
+        Instr::ClosureEnvFieldStore {
+            env,
+            env_ty,
+            field_offset,
+            src,
+        } => format!(
+            "closure_env_store {}.field[{}] = {} env_ty={}",
+            render_place(env),
+            field_offset.0,
+            render_place(src),
+            env_ty.user_facing()
+        ),
         Instr::ActorStateFieldLoad { field_offset, dest } => {
             format!(
                 "{} = actor_state_load field[{}]",

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -35559,6 +35559,14 @@ fn detect_unproven_aggregate_handle_double_free(
 /// borrow reads the fixpoint and tally already account for — including
 /// `CallRuntimeAbi`, whose operands are the *container* being read (`hew_vec_len`
 /// / `hew_vec_get_ptr`), never an owned-handle leaf aliased out.
+#[allow(
+    clippy::match_same_arms,
+    reason = "the closure-env-field arms intentionally share the empty-escape \
+              result of the `_` arm but are named explicitly so the closure \
+              write-back/read path's escape classification is visible on the \
+              diff and is forced to be re-examined if the `#1'` BitCopy gate is \
+              ever loosened to owned captures (exhaustive-traversal-and-lowering)"
+)]
 fn instr_escape_places(instr: &Instr) -> Vec<Place> {
     match instr {
         // A value stored into a still-live aggregate / actor state is aliased
@@ -35582,6 +35590,19 @@ fn instr_escape_places(instr: &Instr) -> Vec<Place> {
             places
         }
         Instr::CoerceToDynTrait { value, .. } => vec![*value],
+        // Closure-env field write-back (`#1'`) stores a BitCopy scalar: the
+        // store is gated to `ValueClass::BitCopy`, and an owned capture
+        // reassignment fails closed with NotYetImplemented. A scalar `src`
+        // carries no owned handle, so nothing is aliased out of the tracked
+        // dataflow — no escape place. If that gate is ever loosened to admit
+        // owned captures, `src` would alias into the env's independently-dropped
+        // storage and MUST surface here as `vec![*src]`, mirroring
+        // `RecordFieldStore` above. Named explicitly (not left to the `_` arm)
+        // so this invariant is visible on the closure path (exhaustive-traversal).
+        Instr::ClosureEnvFieldStore { .. } => Vec::new(),
+        // Reading a field OUT of the env is a borrow into tracked dataflow, not
+        // an alias of an owned handle into untracked storage — no escape place.
+        Instr::ClosureEnvFieldLoad { .. } => Vec::new(),
         // Dispatched calls take their arguments (and the receiver) by value.
         Instr::CallClosure { args, .. } => args.clone(),
         Instr::CallTraitMethod {

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -26386,7 +26386,7 @@ impl Builder {
                 id: crate::closure_env::CaptureId(
                     u32::try_from(idx).expect("closure capture count exceeds u32::MAX"),
                 ),
-                ty: cap.ty.clone(),
+                ty: self.subst_ty(&cap.ty),
                 mode: cap.mode,
                 is_sync: cap.is_sync,
             })
@@ -26476,10 +26476,23 @@ impl Builder {
             is_opaque: false,
         };
 
+        // Each capture field's `ResolvedTy` is substituted through the
+        // per-monomorphisation map: a closure inside `fn f<T>(x: T)` that
+        // captures `x` records the env field as the CONCRETE argument (`i64`,
+        // `string`, …), never the bare type-parameter `T`. The env record
+        // layout is walked verbatim by the codegen-readiness diagnostic
+        // (`collect_layout_field_diagnostics`) with no subst map of its own, so
+        // an un-substituted `T` here surfaces as `E_MIR UnknownType T`; it is
+        // also the struct codegen lays out, so the field MUST be concrete for a
+        // correct ABI. A non-generic origin takes the identity-map fast path.
+        let env_field_tys: Vec<ResolvedTy> = captures
+            .iter()
+            .map(|capture| self.subst_ty(&capture.ty))
+            .collect();
         self.closure_record_layouts
             .push(crate::model::RecordLayout {
                 name: env_name,
-                field_tys: captures.iter().map(|capture| capture.ty.clone()).collect(),
+                field_tys: env_field_tys,
                 // Compiler-internal closure-env record: positional `-g` names.
                 field_names: Vec::new(),
             });
@@ -26633,6 +26646,14 @@ impl Builder {
         body: &HirExpr,
         captures: &[hew_hir::HirClosureCapture],
     ) -> LoweredFunction {
+        // Resolve the shim's return type through the per-monomorphisation subst
+        // map: a closure in `fn f<T>() -> T` lowers its invoke shim with the
+        // CONCRETE return ABI, never the bare `T`. The child builder inherits
+        // `subst`, so the body's locals already substitute via `alloc_local`;
+        // the shim's raw `return_ty`/`params` are built directly here and must
+        // be substituted explicitly so codegen sees a concrete ABI.
+        let ret_ty_subst = self.subst_ty(ret_ty);
+        let ret_ty = &ret_ty_subst;
         let env_ptr_ty = Self::closure_env_pointer_ty(env_ty);
         // `child_builder_tables` carries the full shared-table list — notably
         // `actor_layouts`, so a closure body that sends to a captured pid
@@ -26655,7 +26676,7 @@ impl Builder {
                     field_offset: FieldOffset(
                         u32::try_from(idx).expect("closure capture count exceeds u32::MAX"),
                     ),
-                    ty: capture.ty.clone(),
+                    ty: self.subst_ty(&capture.ty),
                 },
             );
         }
@@ -26687,7 +26708,7 @@ impl Builder {
         };
         let mut raw_params = Vec::with_capacity(params.len() + 1);
         raw_params.push(env_ptr_ty);
-        raw_params.extend(params.iter().map(|param| param.ty.clone()));
+        raw_params.extend(params.iter().map(|param| self.subst_ty(&param.ty)));
         let raw = RawMirFunction {
             name: shim_name.to_string(),
             return_ty: ret_ty.clone(),

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -2519,19 +2519,16 @@ pub fn lower_hir_module_with_facts(
                 checked_mir.push(lowered.checked);
                 elaborated_mir.push(lowered.elaborated);
                 record_layouts.extend(lowered.record_layouts);
-                for generated in lowered.generated {
-                    if generated.raw.name.starts_with("__hew_named_fn_invoke_")
-                        && !emitted_named_fn_shims.insert(generated.raw.name.clone())
-                    {
-                        continue; // duplicate shim from a second use-site — body already emitted
-                    }
-                    thir.push(generated.thir);
-                    raw_mir.push(generated.raw);
-                    checked_mir.push(generated.checked);
-                    elaborated_mir.push(generated.elaborated);
-                    diagnostics.extend(generated.diagnostics);
-                    record_layouts.extend(generated.record_layouts);
-                }
+                flatten_generated_functions(
+                    lowered.generated,
+                    &mut thir,
+                    &mut raw_mir,
+                    &mut checked_mir,
+                    &mut elaborated_mir,
+                    &mut diagnostics,
+                    &mut record_layouts,
+                    &mut emitted_named_fn_shims,
+                );
                 diagnostics.extend(lowered.diagnostics);
             }
             HirItem::Actor(actor) => {
@@ -2561,19 +2558,16 @@ pub fn lower_hir_module_with_facts(
                     checked_mir.push(lowered.checked);
                     elaborated_mir.push(lowered.elaborated);
                     record_layouts.extend(lowered.record_layouts);
-                    for generated in lowered.generated {
-                        if generated.raw.name.starts_with("__hew_named_fn_invoke_")
-                            && !emitted_named_fn_shims.insert(generated.raw.name.clone())
-                        {
-                            continue; // duplicate shim — body already emitted
-                        }
-                        thir.push(generated.thir);
-                        raw_mir.push(generated.raw);
-                        checked_mir.push(generated.checked);
-                        elaborated_mir.push(generated.elaborated);
-                        diagnostics.extend(generated.diagnostics);
-                        record_layouts.extend(generated.record_layouts);
-                    }
+                    flatten_generated_functions(
+                        lowered.generated,
+                        &mut thir,
+                        &mut raw_mir,
+                        &mut checked_mir,
+                        &mut elaborated_mir,
+                        &mut diagnostics,
+                        &mut record_layouts,
+                        &mut emitted_named_fn_shims,
+                    );
                     diagnostics.extend(lowered.diagnostics);
                 }
             }
@@ -2604,19 +2598,16 @@ pub fn lower_hir_module_with_facts(
                     checked_mir.push(lowered.checked);
                     elaborated_mir.push(lowered.elaborated);
                     record_layouts.extend(lowered.record_layouts);
-                    for generated in lowered.generated {
-                        if generated.raw.name.starts_with("__hew_named_fn_invoke_")
-                            && !emitted_named_fn_shims.insert(generated.raw.name.clone())
-                        {
-                            continue; // duplicate shim — body already emitted
-                        }
-                        thir.push(generated.thir);
-                        raw_mir.push(generated.raw);
-                        checked_mir.push(generated.checked);
-                        elaborated_mir.push(generated.elaborated);
-                        diagnostics.extend(generated.diagnostics);
-                        record_layouts.extend(generated.record_layouts);
-                    }
+                    flatten_generated_functions(
+                        lowered.generated,
+                        &mut thir,
+                        &mut raw_mir,
+                        &mut checked_mir,
+                        &mut elaborated_mir,
+                        &mut diagnostics,
+                        &mut record_layouts,
+                        &mut emitted_named_fn_shims,
+                    );
                     diagnostics.extend(lowered.diagnostics);
                 }
             }
@@ -2745,19 +2736,16 @@ pub fn lower_hir_module_with_facts(
         checked_mir.push(lowered.checked);
         elaborated_mir.push(lowered.elaborated);
         record_layouts.extend(lowered.record_layouts);
-        for generated in lowered.generated {
-            if generated.raw.name.starts_with("__hew_named_fn_invoke_")
-                && !emitted_named_fn_shims.insert(generated.raw.name.clone())
-            {
-                continue; // duplicate shim — body already emitted
-            }
-            thir.push(generated.thir);
-            raw_mir.push(generated.raw);
-            checked_mir.push(generated.checked);
-            elaborated_mir.push(generated.elaborated);
-            diagnostics.extend(generated.diagnostics);
-            record_layouts.extend(generated.record_layouts);
-        }
+        flatten_generated_functions(
+            lowered.generated,
+            &mut thir,
+            &mut raw_mir,
+            &mut checked_mir,
+            &mut elaborated_mir,
+            &mut diagnostics,
+            &mut record_layouts,
+            &mut emitted_named_fn_shims,
+        );
         diagnostics.extend(lowered.diagnostics);
     }
 
@@ -6544,6 +6532,62 @@ struct LoweredFunction {
     diagnostics: Vec<MirDiagnostic>,
     generated: Vec<LoweredFunction>,
     record_layouts: Vec<crate::model::RecordLayout>,
+}
+
+/// Recursively drain a `LoweredFunction::generated` tree into the module
+/// output vectors.
+///
+/// A generated function (a closure invoke shim, a named-fn reference shim, an
+/// ask-reply thunk, …) can itself produce generated functions: a *nested*
+/// closure literal's invoke shim is lowered while the *parent* shim is being
+/// built, so it lands in the parent's `builder.generated_functions` — i.e.
+/// `generated.generated`, depth 2. A single-level `for g in lowered.generated`
+/// loop (the historical shape at every dispatch site) surfaces only depth 1,
+/// so a `MakeClosure` for the inner literal references a shim symbol codegen
+/// never emitted (`E_NOT_YET_IMPLEMENTED: missing closure invoke shim`).
+///
+/// Walk the whole tree so EVERY generated function at EVERY depth is surfaced
+/// exactly once (`exhaustive-coverage`). The `__hew_named_fn_invoke_` dedup is
+/// preserved: a duplicate shim (and the subtree below it, which is the same
+/// already-emitted bodies) is skipped wholesale.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "threads the same module-output sinks the four dispatch sites already hold as locals"
+)]
+fn flatten_generated_functions(
+    generated: Vec<LoweredFunction>,
+    thir: &mut Vec<ThirFunction>,
+    raw_mir: &mut Vec<RawMirFunction>,
+    checked_mir: &mut Vec<CheckedMirFunction>,
+    elaborated_mir: &mut Vec<ElaboratedMirFunction>,
+    diagnostics: &mut Vec<MirDiagnostic>,
+    record_layouts: &mut Vec<crate::model::RecordLayout>,
+    emitted_named_fn_shims: &mut HashSet<String>,
+) {
+    for generated in generated {
+        if generated.raw.name.starts_with("__hew_named_fn_invoke_")
+            && !emitted_named_fn_shims.insert(generated.raw.name.clone())
+        {
+            continue; // duplicate shim from a second use-site — body (and its subtree) already emitted
+        }
+        let nested = generated.generated;
+        thir.push(generated.thir);
+        raw_mir.push(generated.raw);
+        checked_mir.push(generated.checked);
+        elaborated_mir.push(generated.elaborated);
+        diagnostics.extend(generated.diagnostics);
+        record_layouts.extend(generated.record_layouts);
+        flatten_generated_functions(
+            nested,
+            thir,
+            raw_mir,
+            checked_mir,
+            elaborated_mir,
+            diagnostics,
+            record_layouts,
+            emitted_named_fn_shims,
+        );
+    }
 }
 
 /// Insert execution-context carrier markers into a context-bearing CFG.
@@ -26409,7 +26453,20 @@ impl Builder {
             .next_closure_id
             .checked_add(1)
             .expect("closure id overflow");
-        let owner = Self::sanitize_symbol_component(&self.current_function_symbol);
+        // A NESTED closure literal is lowered while `current_function_symbol`
+        // is the PARENT closure's invoke shim (`__hew_closure_invoke_<path>`).
+        // Using it verbatim as the owner re-prefixes the symbol on every level
+        // (`__hew_closure_invoke___hew_closure_invoke_main_0_0`) — redundant and
+        // unbounded in nesting depth. Strip the shim prefix so the owner is the
+        // stable nesting PATH (`main_0`): child builders reset `next_closure_id`
+        // to 0, so the parent path is what keeps sibling/cross-level shim names
+        // unique. The `MakeClosure` and the shim both derive their symbol from
+        // this single site, so they stay in lockstep.
+        let owner_src = self
+            .current_function_symbol
+            .strip_prefix("__hew_closure_invoke_")
+            .unwrap_or(&self.current_function_symbol);
+        let owner = Self::sanitize_symbol_component(owner_src);
         let env_name = format!("__hew_closure_env_{owner}_{closure_id}");
         let shim_name = format!("__hew_closure_invoke_{owner}_{closure_id}");
         let env_ty = ResolvedTy::Named {

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -11118,6 +11118,47 @@ impl Builder {
                         site: target.site,
                         ty: self.subst_ty(&target.ty),
                     });
+                } else if let Some(source) = self.capture_env_sources.get(binding).cloned() {
+                    // #1′ BorrowMut write-back: the assignment target is a
+                    // captured `var` reassigned inside the closure body
+                    // (`var total; |n| { total = total + n; total }`). The
+                    // binding has no `binding_locals` slot — it lives in the
+                    // closure env — so the write lands in the env field via the
+                    // store twin of `ClosureEnvFieldLoad`. The env owns the
+                    // mutable scalar (Option B): mutations accumulate across
+                    // calls through the persistent env pointer, and the caller's
+                    // original binding is independent.
+                    //
+                    // Restricted to `BitCopy` scalar fields. An owned captured
+                    // field (string/Vec/record) would leak its prior value on
+                    // overwrite without an env-field release — out of this
+                    // lane's scope (the §1′ non-suspend scalar write-back) — so
+                    // fail closed with a spanned diagnostic rather than emit a
+                    // silently-leaking store.
+                    let field_class = ValueClass::of_ty(&source.ty, &self.type_classes);
+                    if field_class == ValueClass::BitCopy {
+                        self.push_instr(Instr::ClosureEnvFieldStore {
+                            env: source.env,
+                            env_ty: source.env_ty,
+                            field_offset: source.field_offset,
+                            src,
+                        });
+                    } else {
+                        self.diagnostics.push(MirDiagnostic {
+                            kind: MirDiagnosticKind::NotYetImplemented {
+                                construct: format!(
+                                    "reassigning owned captured `{name}` inside a closure"
+                                ),
+                                site: target.site,
+                            },
+                            note: format!(
+                                "captured `{name}` has a non-`BitCopy` type ({:?}); the closure-env \
+                                 write-back supports scalar captures only — an owned field would \
+                                 need an overwrite-release of its prior value",
+                                source.ty
+                            ),
+                        });
+                    }
                 } else {
                     self.diagnostics.push(MirDiagnostic {
                         kind: MirDiagnosticKind::UnresolvedPlace {
@@ -30808,6 +30849,7 @@ fn instr_places(instr: &Instr) -> Vec<Place> {
         }
         Instr::MakeClosure { env, dest, .. } => vec![*env, *dest],
         Instr::ClosureEnvFieldLoad { env, dest, .. } => vec![*env, *dest],
+        Instr::ClosureEnvFieldStore { env, src, .. } => vec![*env, *src],
         Instr::CallClosure {
             callee,
             args,
@@ -31198,6 +31240,9 @@ pub fn instr_source_places(instr: &Instr) -> Vec<Place> {
         // read (the aggregate stays live; the value is shared into it).
         Instr::RecordFieldStore { record, src, .. } => vec![*record, *src],
         Instr::ActorStateFieldStore { src, .. } => vec![*src],
+        // Closure-env write-back reads both the env pointer (the aggregate
+        // stays live) and the value being stored into it.
+        Instr::ClosureEnvFieldStore { env, src, .. } => vec![*env, *src],
         Instr::MakeClosure { env, .. } => vec![*env],
         Instr::CallClosure { callee, args, .. } => {
             let mut places = vec![*callee];
@@ -31503,6 +31548,9 @@ fn generator_yield_instr_escapes(instr: &Instr, local: u32) -> bool {
         Instr::TupleConstruct { elements, .. } => elements.iter().any(|p| refs(*p)),
         Instr::RecordFieldStore { src, .. } => refs(*src),
         Instr::ActorStateFieldStore { src, .. } => refs(*src),
+        // A closure-env write-back stores `src` into the env; like the other
+        // field stores it escapes the local iff `src` is the tracked local.
+        Instr::ClosureEnvFieldStore { src, .. } => refs(*src),
         Instr::MakeClosure { env, .. } => refs(*env),
         Instr::CoerceToDynTrait { value, .. } => refs(*value),
         Instr::SpawnActor {
@@ -31796,6 +31844,7 @@ fn projection_alias_dest(instr: &Instr) -> Option<Place> {
         | Instr::AutoLockRelease { .. }
         | Instr::MakeClosure { .. }
         | Instr::ActorStateFieldStore { .. }
+        | Instr::ClosureEnvFieldStore { .. }
         | Instr::SpawnActor { .. }
         | Instr::CallClosure { .. }
         | Instr::SpawnTaskDirect { .. }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -11131,9 +11131,9 @@ impl Builder {
                     //
                     // Restricted to `BitCopy` scalar fields. An owned captured
                     // field (string/Vec/record) would leak its prior value on
-                    // overwrite without an env-field release — out of this
-                    // lane's scope (the §1′ non-suspend scalar write-back) — so
-                    // fail closed with a spanned diagnostic rather than emit a
+                    // overwrite without an env-field release — out of scope for
+                    // the non-suspend scalar write-back path — so fail closed
+                    // with a spanned diagnostic rather than emit a
                     // silently-leaking store.
                     let field_class = ValueClass::of_ty(&source.ty, &self.type_classes);
                     if field_class == ValueClass::BitCopy {

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -4074,6 +4074,26 @@ pub enum Instr {
         /// Destination place receiving the field value.
         dest: Place,
     },
+    /// Store one value into a closure invoke shim's environment field — the
+    /// write-back twin of [`Instr::ClosureEnvFieldLoad`]. Emitted when a closure
+    /// body REASSIGNS a captured `var` (an inferred `BorrowMut` capture): the
+    /// env owns the mutable scalar slot, so the store lands in the env field and
+    /// accumulates across calls through the persistent env pointer. The caller's
+    /// original binding is independent (captures are materialised through the
+    /// env, never a surface reference). Restricted to `BitCopy` scalar fields —
+    /// an owned captured field would need an overwrite-release on the prior
+    /// value, which the lowering fails closed on.
+    ClosureEnvFieldStore {
+        /// Local holding the opaque env pointer parameter.
+        env: Place,
+        /// Named env-record type whose layout defines `field_offset`.
+        env_ty: ResolvedTy,
+        /// Capture field index in first-use order (identical to the matching
+        /// load's offset).
+        field_offset: FieldOffset,
+        /// Place holding the value to store into the field.
+        src: Place,
+    },
     ActorStateFieldLoad {
         field_offset: FieldOffset,
         dest: Place,

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -535,7 +535,15 @@ const CONSTRUCTS: &[Construct] = &[
     },
     Construct {
         id: "closure / lambda value",
-        probe: "fn main() {\n    let f = |x: i64| x + 1;\n    println(f(2));\n}\n",
+        // The profile rejects `Expr::Lambda { .. }` structurally, before walking
+        // the body — so EVERY closure form is fail-closed-rejected for sandbox
+        // export, including the capturing / nested / type-parameterised /
+        // write-back forms the C7 lane newly admits on native. The probe
+        // captures an outer `var` and reassigns it (the most permissive native
+        // form, #1') to pin that even a mutable capture produces no bytecode:
+        // the sandbox stays strictly more conservative than native, never the
+        // reverse (`native-wasm-parity`).
+        probe: "fn main() {\n    var total = 0;\n    let acc = |n: i64| { total = total + n; total };\n    println(acc(2));\n}\n",
         coverage: Coverage::RejectedByProfile {
             diagnostic_kind: "reserved_runtime_feature",
         },

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -1313,6 +1313,11 @@ impl Checker {
             }
 
             let func_ty = binding.ty.clone();
+            // Captured-closure-as-callee identity, snapshotted while `binding`
+            // is still borrowable (the mutable `self` operations below end its
+            // borrow). Used by the capture-fact push after the LambdaPid gate.
+            let callee_binding_id = binding.id;
+            let callee_def_span = binding.def_span.clone();
 
             // Explicit fail-closed gate: a regular fn-closure must not capture a
             // lambda-actor handle (`LambdaPid<M,R>`) and call it with call syntax.
@@ -1356,6 +1361,42 @@ impl Checker {
                         );
                         return Ty::Error;
                     }
+                }
+            }
+
+            // A captured CLOSURE used as a call callee (`|y| base(y)` where
+            // `base` is a closure binding from an enclosing scope) is a capture
+            // exactly as reading its identifier would be — but the call
+            // dispatch resolves the bare callee HERE rather than through
+            // `check_identifier`, so without this push the capture fact is never
+            // recorded and HIR's `materialize_closure_captures` later finds the
+            // binding with no metadata (E_HIR CheckerBoundaryViolation). Record
+            // it now, mirroring the identifier path; `check_lambda` refines the
+            // placeholder mode from a body scan. LambdaPid handles are excluded:
+            // their capture is rejected (above) or routed through the dedicated
+            // lambda-actor protocol, never the closure-env protocol.
+            if let Some(capture_depth) = self.lambda_capture_depth {
+                if binding_depth < capture_depth
+                    && !matches!(
+                        &resolved_func_ty,
+                        Ty::Named {
+                            builtin: Some(crate::BuiltinType::LambdaPid),
+                            ..
+                        }
+                    )
+                {
+                    self.lambda_captures.push(func_ty.clone());
+                    self.lambda_capture_facts.push(ClosureCaptureFact {
+                        binding_id: callee_binding_id,
+                        name: func_name.clone(),
+                        ty: func_ty.clone(),
+                        mode: ClosureCaptureMode::Borrow,
+                        mode_origin: CaptureModeOrigin::InferredBorrow,
+                        is_send: false,
+                        is_sync: false,
+                        use_span: span.clone(),
+                        def_span: callee_def_span.clone(),
+                    });
                 }
             }
 

--- a/hew-wasm/src/lib.rs
+++ b/hew-wasm/src/lib.rs
@@ -508,17 +508,20 @@ struct AnalysisResult {
 struct AnalyzedSource {
     parse_result: hew_parser::ParseResult,
     type_output: Option<hew_types::TypeCheckOutput>,
-    /// Diagnostics from HIR lowering, run after type-checking so that errors
-    /// such as `CheckerBoundaryViolation` (e.g. nested closure captures that
-    /// the checker leaves unresolved) are surfaced in the browser editor.
+    /// Diagnostics from HIR lowering, run after type-checking so that a
+    /// `CheckerBoundaryViolation` — code the type checker accepts but HIR
+    /// lowering rejects — is surfaced in the browser editor instead of shown
+    /// as false-green.
     ///
-    /// WHY: Without HIR lowering the browser checker silently accepts closure
-    /// expressions that `hew run` rejects at lowering time — a false-green.
+    /// WHY: Without HIR lowering the browser checker would silently accept
+    /// constructs that `hew run` rejects at lowering time — a false-green.
     /// Fail-closed per the checker-authority doctrine: the editor must never
     /// show green for code that the native compiler rejects.
     ///
-    /// REAL FIX: once the checker materialises closure capture metadata fully,
-    /// these diagnostics will be empty for well-formed closure code.
+    /// Nested closure captures (a closure that captures another closure
+    /// binding) now lower cleanly, so well-formed closure code produces no
+    /// boundary-violation diagnostics; this gate remains for any construct the
+    /// checker still leaves unresolved at the HIR boundary.
     hir_diagnostics: Vec<hew_hir::HirDiagnostic>,
 }
 

--- a/hew-wasm/tests/v05_wasm_coverage.rs
+++ b/hew-wasm/tests/v05_wasm_coverage.rs
@@ -75,14 +75,6 @@ const ANALYSIS_ERROR_FIXTURES: &[&str] = &[
     // rejects them.  The corresponding fail-closed LSP test is
     // `v05_async_await_is_rejected_with_parse_errors`.
     "v05_async_await",
-    // hir-rejected: nested closure captures are not yet materialised in the
-    // checker side-table.  The type checker accepts the fixture, but HIR
-    // lowering surfaces a `CheckerBoundaryViolation` for `twice` (which
-    // captures `inc`, itself a closure variable).  The browser editor must not
-    // show green for code the native compiler rejects at HIR.  Fail-closed per
-    // checker-authority doctrine.  Dedicated test:
-    // `v05_wasm_coverage_closure_hir_gap_surfaces_error`.
-    "v05_closures",
     // accepted (intentional type error): `obj[key]` on a type that does not
     // implement Indexable — type error by design, exercising error-recovery in
     // the index-expression checker.
@@ -174,8 +166,8 @@ fn v05_wasm_coverage_fixture_count() {
     );
     assert_eq!(
         ANALYSIS_ERROR_FIXTURES.len(),
-        10,
-        "ANALYSIS_ERROR_FIXTURES must list exactly 10 known-error fixtures"
+        9,
+        "ANALYSIS_ERROR_FIXTURES must list exactly 9 known-error fixtures"
     );
 }
 
@@ -199,7 +191,7 @@ fn v05_wasm_coverage_type_check_all_api_valid() {
     }
 }
 
-// ── Zero-error: 28 clean fixtures produce no error-severity diagnostics ───
+// ── Zero-error: 29 clean fixtures produce no error-severity diagnostics ───
 
 #[test]
 fn v05_wasm_coverage_analyze_clean_fixtures() {
@@ -261,17 +253,19 @@ fn v05_wasm_coverage_async_await_api_valid() {
     );
 }
 
-/// Nested closure captures that the type-checker leaves unresolved surface as
-/// a `CheckerBoundaryViolation` at HIR lowering.  The browser editor must show
-/// an error for this code: accepting it silently would present the editor as
-/// green for a program that `hew run` rejects.
+/// Nested closure captures (a closure that captures another closure binding —
+/// `let twice = |x: i32| -> i32 { inc(inc(x)) }` where `inc` is itself a
+/// closure variable) now lower cleanly through HIR.  The browser editor must
+/// show this well-formed program as green: `analyze` produces no
+/// error-severity diagnostics and, in particular, no `CheckerBoundaryViolation`.
 ///
-/// Specific repro: `let twice = |x: i32| -> i32 { inc(inc(x)) }` where `inc`
-/// is itself a closure variable — the checker does not materialise capture
-/// metadata for the nested `inc` call, and HIR lowering fires
-/// `CheckerBoundaryViolation`.  Fail-closed per checker-authority doctrine.
+/// Before the C7 closure work this fixture surfaced a `CheckerBoundaryViolation`
+/// at HIR lowering (the checker did not materialise capture metadata for the
+/// nested `inc` call); that gap is now closed and the fixture is part of the
+/// clean set (covered by the zero-error loops, plus this dedicated assertion
+/// that the boundary violation specifically no longer fires).
 #[test]
-fn v05_wasm_coverage_closure_hir_gap_surfaces_error() {
+fn v05_wasm_coverage_closures_analyze_clean() {
     const FIXTURE: &str = "v05_closures";
     let source = include_str!("../../hew-lsp/tests/fixtures/v05_closures.hew");
     let json = hew_wasm::analyze(source)
@@ -281,19 +275,30 @@ fn v05_wasm_coverage_closure_hir_gap_surfaces_error() {
         .as_array()
         .unwrap_or_else(|| panic!("fixture {FIXTURE}: missing diagnostics array"));
 
-    let hir_errors: Vec<&serde_json::Value> = diags
+    // The nested closure capture resolves: no `CheckerBoundaryViolation` at any
+    // phase.  This is the exact diagnostic the pre-C7 gap produced.
+    let boundary_violations: Vec<&serde_json::Value> = diags
         .iter()
-        .filter(|d| {
-            d["severity"].as_str() == Some("error")
-                && d["phase"].as_str() == Some("hir")
-                && d["kind"].as_str() == Some("CheckerBoundaryViolation")
-        })
+        .filter(|d| d["kind"].as_str() == Some("CheckerBoundaryViolation"))
         .collect();
     assert!(
-        !hir_errors.is_empty(),
-        "fixture {FIXTURE}: expected ≥1 hir-phase CheckerBoundaryViolation error diagnostic \
-         for nested closure capture; got {} diagnostics: {diags:?}",
+        boundary_violations.is_empty(),
+        "fixture {FIXTURE}: nested closure capture must lower cleanly — no \
+         CheckerBoundaryViolation expected; got {} diagnostics: {diags:?}",
         diags.len()
+    );
+
+    // And no error-severity diagnostics at all.  Warnings (the escape advisory,
+    // unused-function) are permitted — only errors would present false-green.
+    let errors: Vec<&serde_json::Value> = diags
+        .iter()
+        .filter(|d| d["severity"].as_str() == Some("error"))
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "fixture {FIXTURE}: expected zero error-severity diagnostics for the now-clean \
+         closure fixture; got {} error(s): {errors:?}",
+        errors.len()
     );
 }
 

--- a/scripts/hew-corpus-expected-failures.txt
+++ b/scripts/hew-corpus-expected-failures.txt
@@ -100,7 +100,6 @@ examples/v05/vec_unsupported_method_fails.hew
 # deferred-nyi: LSP test fixtures covering NYI language features
 hew-lsp/tests/fixtures/v05_async_await.hew
 hew-lsp/tests/fixtures/v05_await_deadline.hew
-hew-lsp/tests/fixtures/v05_closures.hew
 hew-lsp/tests/fixtures/v05_cross_module_machine_main.hew
 hew-lsp/tests/fixtures/v05_index_trait.hew
 hew-lsp/tests/fixtures/v05_machine_generics.hew

--- a/tests/vertical-slice/accept/closure_captured_var_writeback.hew
+++ b/tests/vertical-slice/accept/closure_captured_var_writeback.hew
@@ -1,0 +1,24 @@
+// BorrowMut write-back (#1′): a closure REASSIGNS a captured scalar `var`. The
+// body's `total = total + n` has no `binding_locals` slot for `total` — the
+// binding lives in the closure env — so the store lands in the env field
+// through the `ClosureEnvFieldStore` write-back twin of `ClosureEnvFieldLoad`.
+//
+// Previously failed with E_MIR UnresolvedPlace ("assignment target binding has
+// no MIR place"): the assignment lowering resolved only `binding_locals`
+// targets, never the captured-env case.
+//
+// Semantics (Option B): the env OWNS the mutable scalar. Mutations accumulate
+// across calls through the persistent env, and the caller's original `total`
+// binding is independent — captures are materialised through the env, never a
+// surface reference. So `acc` accumulates 0 -> 5 -> 8 while the outer `total`
+// stays 0.
+fn main() {
+    var total: i64 = 0;
+    let acc = |n: i64| {
+        total = total + n;
+        total
+    };
+    println(acc(5)); // 5
+    println(acc(3)); // 8
+    println(total);  // 0
+}

--- a/tests/vertical-slice/accept/closure_captures_closure_binding.hew
+++ b/tests/vertical-slice/accept/closure_captures_closure_binding.hew
@@ -1,0 +1,13 @@
+// A closure captures another closure BINDING and calls it. `wrap` captures
+// `base` (itself a closure) from the enclosing scope and dispatches it as
+// `base(y)`.
+//
+// Previously failed with E_HIR CheckerBoundaryViolation: the call checker
+// resolved a bare-identifier closure callee directly, without recording the
+// `ClosureCaptureFact` that the identifier-read path records — so HIR's capture
+// materialization found the captured binding with no checker metadata.
+fn main() {
+    let base = |x: i64| x + 1;
+    let wrap = |y: i64| base(y);
+    println(wrap(41)); // 42
+}

--- a/tests/vertical-slice/accept/closure_counter_factory.hew
+++ b/tests/vertical-slice/accept/closure_counter_factory.hew
@@ -1,0 +1,23 @@
+// BorrowMut write-back (#1′) through an ESCAPING (heap-boxed) env: the classic
+// stateful counter-factory idiom. `make_counter` captures its local `count` by
+// BorrowMut into a closure it RETURNS, so the env is promoted to a heap box
+// that outlives the factory frame. Each call mutates the heap env field in
+// place via `ClosureEnvFieldStore`, accumulating across calls.
+//
+// Exercises the write-back on the heap allocation strategy (not just the stack
+// env) and confirms the heap env is freed exactly once when the closure drops
+// (see closure_env_drop_leak_oracle: zero leaks, no double-free).
+fn make_counter() -> fn() -> i64 {
+    var count: i64 = 0;
+    || {
+        count = count + 1;
+        count
+    }
+}
+
+fn main() {
+    let c = make_counter();
+    println(c()); // 1
+    println(c()); // 2
+    println(c()); // 3
+}

--- a/tests/vertical-slice/accept/closure_nested_captures_outer_param.hew
+++ b/tests/vertical-slice/accept/closure_nested_captures_outer_param.hew
@@ -1,0 +1,13 @@
+// A nested closure captures the OUTER closure's parameter. The inner literal
+// `|y| x + y` reads `x`, which is the enclosing closure literal's own
+// parameter.
+//
+// Previously failed with E_HIR DanglingRef: the HIR verifier walked a closure
+// literal's body without first registering the literal's own parameters as
+// declared bindings (only named-fn and actor-method parameters were), so the
+// inner capture of `x` resolved to a binding the verifier believed undeclared.
+fn main() {
+    let outer = |x: i64| -> fn(i64) -> i64 { |y: i64| x + y };
+    let add5 = outer(5);
+    println(add5(10)); // 15
+}

--- a/tests/vertical-slice/accept/closure_nested_noncapturing.hew
+++ b/tests/vertical-slice/accept/closure_nested_noncapturing.hew
@@ -1,0 +1,16 @@
+// A non-capturing closure literal nested inside another closure's body. The
+// inner `|y| y * 2` captures nothing; it is created and called entirely within
+// the outer closure's shim.
+//
+// Previously failed with E_NOT_YET_IMPLEMENTED (missing closure invoke shim):
+// the nested literal's invoke shim is produced while the parent shim is being
+// lowered, so it lands in the parent's `generated.generated`, and the module
+// driver flattened only one level — `MakeClosure` then referenced a shim symbol
+// codegen never emitted.
+fn main() {
+    let outer = |x: i64| {
+        let g = |y: i64| y * 2;
+        g(x)
+    };
+    println(outer(8)); // 16
+}

--- a/tests/vertical-slice/accept/closure_noncopy_inferred_borrow.hew
+++ b/tests/vertical-slice/accept/closure_noncopy_inferred_borrow.hew
@@ -1,0 +1,18 @@
+// Substrate gain: a closure that captures a non-Copy `string` binding WITHOUT
+// the `move` keyword is ACCEPTED. The closure only reads `name`, so the checker
+// infers a read-only Borrow capture and the lowerer materialises a reference —
+// the legacy `ClosureExplicitMoveRequired` diagnostic is dead for this site.
+//
+// Because the capture is a borrow (not a move), the outer binding still owns the
+// string and remains usable after the closure is created: `main` reads `name`
+// again on the last line. The string is freed exactly once at scope exit (the
+// closure env holds only a borrow and has no drop responsibility) — verified
+// 0-leak / no-double-free under the poisoned allocator.
+//
+// This was previously a reject fixture asserting the now-dead diagnostic.
+fn main() {
+    let name: string = "hew";
+    let greet = || println(name);
+    greet();        // hew
+    println(name);  // hew — outer binding still owns it (borrow, not move)
+}

--- a/tests/vertical-slice/accept/closure_type_param_capture.hew
+++ b/tests/vertical-slice/accept/closure_type_param_capture.hew
@@ -1,0 +1,24 @@
+// Type-parameterized closure capture (#6). A closure inside a generic function
+// captures a value whose type is the function's type parameter `T`, and the
+// closure's return type is also `T`. Each monomorphisation substitutes `T` to
+// the concrete argument type in BOTH the closure env record layout and the
+// invoke shim's ABI.
+//
+// Previously failed with E_MIR UnknownType `T`: the env field type and the
+// shim return ABI were left as the bare type-parameter symbol, which the
+// codegen-readiness walk (which has no per-monomorphisation subst map of its
+// own) rejected at the MIR boundary.
+//
+// Instantiated at two concrete types so two distinct monomorphised invoke
+// shims are emitted: `i64` (a `BitCopy` capture, copied into the env) and
+// `string` (an OWNED capture, whose heap buffer the escaping env free thunk
+// must release — see closure_env_drop_leak_oracle).
+fn pick<T>(x: T) -> T {
+    let get = || x;
+    get()
+}
+
+fn main() {
+    println(pick(42));        // i64 monomorphisation
+    println(pick("closure")); // string monomorphisation (owned capture)
+}

--- a/tests/vertical-slice/accept/closure_type_param_multi.hew
+++ b/tests/vertical-slice/accept/closure_type_param_multi.hew
@@ -1,0 +1,20 @@
+// Type-parameterized closure capture (#6) with TWO type parameters captured by
+// the same closure. The closure captures `a: A` and `b: B` (both type-parameter
+// typed) and returns a concrete `i64`. Each capture field is substituted to its
+// concrete type in the env record layout independently.
+//
+// Exercises the multi-type-parameter substitution path: a single closure env
+// whose fields resolve to a heterogeneous concrete tuple (`i64`, `string`)
+// rather than the bare `A`/`B` symbols.
+fn combine<A, B>(a: A, b: B, n: i64) -> i64 {
+    let f = || {
+        let _x = a;
+        let _y = b;
+        n
+    };
+    f()
+}
+
+fn main() {
+    println(combine(1, "two", 99)); // 99
+}

--- a/tests/vertical-slice/reject/closure_explicit_move_required.hew
+++ b/tests/vertical-slice/reject/closure_explicit_move_required.hew
@@ -1,7 +1,0 @@
-// Reject fixture: ClosureExplicitMoveRequired
-// A closure that captures a non-Copy binding (string) without "move" is rejected.
-// Expected: type error ClosureExplicitMoveRequired
-fn main() {
-    let s: string = "hew";
-    let _f = || s;
-}


### PR DESCRIPTION
## Summary
Completes the 5 remaining closure forms: nested-captures-outer-param, nested-captures-closure-binding, non-capturing-nested-literal, type-parameterized capture, and reassigned captured-var write-back. Reconciles 3 stale gates the capability unblocked.
## Verification
ci-preflight 14/14, test-hew-ratchet, closure drop/leak oracle (release-count==1 proof + 4 slope shapes + no-double-free), WASM sandbox-parity, flake 3/3.
## Out of scope
Pre-existing non-escaping stack-env capture leak + f-string-temp leak (tracked separately).