### PR TITLE
feat(types): warn on discarded await/ask AskError values

### DIFF
--- a/docs/design/lint-pass.md
+++ b/docs/design/lint-pass.md
@@ -215,13 +215,15 @@ the precise subset that is actually convertible.
     `!c`. *Guards:* each branch must be exactly one boolean literal (no other statements); the two
     branches must be opposite polarities (a matching pair is a constant, not this lint); `else if`
     chains never collapse the outer `if`. Position-agnostic (the rewrite is valid anywhere).
-  - **`must_use`** — a discarded value carrying a write/send error that must not be ignored:
-    `WriteError` / `SendError`, bare or as the error arm of a `Result<_, E>`. *Guards:* statement
-    position only (a trailing block value, a `let`/`var` binding, a `match`/`if let` scrutinee, and
-    `expr?` are all "used" and never flagged); the resolved type must be exactly the must-use error
-    or a `Result` over it, matched by canonical name so the builtin `SendError` and the stdlib
-    `WriteError` both qualify. Discarding either fails open — a dropped backpressure/disconnect
-    signal or an unnoticed undelivered send. Opt out with `let _ = …` or `// hew:allow(must_use)`.
+  - **`must_use`** — a discarded value carrying a write/send/ask error that must not be ignored:
+    `WriteError` / `SendError` / `AskError`, bare or as the error arm of a `Result<_, E>`.
+    *Guards:* statement position only (a trailing block value, a `let`/`var` binding, a
+    `match`/`if let` scrutinee, and `expr?` are all "used" and never flagged); the resolved type
+    must be exactly a must-use error or a `Result` over it, matched by canonical name so the
+    builtins `SendError` / `AskError` and the stdlib `WriteError` all qualify. Discarding any
+    fails open — a dropped backpressure/disconnect signal, an unnoticed undelivered send, or a
+    timed-out / mailbox-full / stopped-actor `ask` (`await actor.msg()`) mistaken for a reply.
+    Opt out with `let _ = …` or `// hew:allow(must_use)`.
   - **Migrations.** `clone_on_copy` (clone on a Copy/BitCopy type; `hew-types/src/check/methods.rs`)
     and `dead_code` (unreachable functions; `hew-types/src/check/diagnostics.rs`) now emit through
     `Checker::emit_main_pass_lint`, giving them a `LintId` with `default_level() = Warn`. Default

--- a/examples/actor_live_demo.hew
+++ b/examples/actor_live_demo.hew
@@ -17,11 +17,11 @@ fn main() {
     println("Spawning Counter actor on its own thread...");
     let counter = spawn Counter(count: 0);
     println("[main] Sending increment(10)");
-    await counter.increment(10);
+    let _ = await counter.increment(10);
     println("[main] Sending increment(20)");
-    await counter.increment(20);
+    let _ = await counter.increment(20);
     println("[main] Sending increment(12)");
-    await counter.increment(12);
+    let _ = await counter.increment(12);
     println("[main] All messages processed. Stopping actor.");
     println("[main] Done. Expected final count: 42");
 }

--- a/examples/async_void.hew
+++ b/examples/async_void.hew
@@ -11,6 +11,6 @@ actor Messenger {
 
 fn main() {
     let messenger = spawn Messenger;
-    await messenger.print_message(100);
+    let _ = await messenger.print_message(100);
     println(999);
 }

--- a/examples/chat_service.hew
+++ b/examples/chat_service.hew
@@ -59,8 +59,7 @@ fn main() {
     room.say("bob", "hey alice!");
     room.say("alice", "how is the weather?");
     room.exit_room("bob");
-    await room.history();
-
+    let _ = await room.history();
     // Node::shutdown();
     println("[main] chat demo complete");
 }

--- a/examples/concurrent_counter.hew
+++ b/examples/concurrent_counter.hew
@@ -22,5 +22,5 @@ fn main() {
     c.increment(10);
     c.increment(20);
     c.increment(12);
-    await c.print_total();
+    let _ = await c.print_total();
 }

--- a/examples/playground/concurrency/counter_actor.hew
+++ b/examples/playground/concurrency/counter_actor.hew
@@ -12,10 +12,13 @@ actor Counter {
 
 fn main() {
     let c = spawn Counter(count: 0);
-    // Statement-position match is not yet sandbox-admitted, so the first
-    // two replies are awaited bare and the last is an expression match
-    // (-1 marks a failed ask).
+    // Statement-position match is not yet sandbox-admitted, so the first two
+    // replies are awaited bare (with an explicit must_use allow for the
+    // discarded ask reply) and the last is an expression match (-1 marks a
+    // failed ask).
+    // hew:allow(must_use)
     await c.increment(5);
+    // hew:allow(must_use)
     await c.increment(3);
     let total = match await c.increment(12) {
         Ok(v) => v,

--- a/examples/services/circuit_breaker.hew
+++ b/examples/services/circuit_breaker.hew
@@ -104,10 +104,9 @@ fn main() {
     let breaker = spawn CircuitBreaker(backend: backend, state: 0, failure_count: 0, max_failures: 3);
     // ── Normal operation: requests succeed ──
     println("--- Normal operation ---");
-    await breaker.request(1);
-    await breaker.request(2);
-    await breaker.request(3);
-
+    let _ = await breaker.request(1);
+    let _ = await breaker.request(2);
+    let _ = await breaker.request(3);
     // ── Backend degrades ──
     println("");
     println("--- Backend goes down ---");
@@ -115,10 +114,9 @@ fn main() {
     sleep(20ms);
 
     // Three failures trip the breaker (max_failures=3)
-    await breaker.request(4);
-    await breaker.request(5);
-    await breaker.request(6);
-
+    let _ = await breaker.request(4);
+    let _ = await breaker.request(5);
+    let _ = await breaker.request(6);
     // Breaker is now open — requests rejected immediately
     println("");
     println("--- Breaker is open (fast-fail) ---");
@@ -142,8 +140,8 @@ fn main() {
     // Breaker should be closed again — normal operation resumes
     println("");
     println("--- Back to normal ---");
-    await breaker.request(10);
-    await breaker.request(11);
+    let _ = await breaker.request(10);
+    let _ = await breaker.request(11);
     let final_state = await breaker.get_state();
     println(f"Final breaker state: {final_state} (0=Closed)");
     println("");

--- a/examples/services/health_monitor.hew
+++ b/examples/services/health_monitor.hew
@@ -114,15 +114,13 @@ fn main() {
     println("--- All services healthy ---");
     await monitor.check_all();
     sleep(30ms);
-    await monitor.report();
-
+    let _ = await monitor.report();
     // ── Normal traffic ──
     println("");
     println("--- Normal traffic ---");
-    await auth.handle(1);
-    await api.handle(2);
-    await cache.handle(3);
-
+    let _ = await auth.handle(1);
+    let _ = await api.handle(2);
+    let _ = await cache.handle(3);
     // ── Make cache unhealthy ──
     println("");
     println("--- Cache goes down ---");
@@ -130,13 +128,12 @@ fn main() {
     sleep(30ms);
     await monitor.check_all();
     sleep(600ms);
-    await monitor.report();
-
+    let _ = await monitor.report();
     // ── Remaining services still serve traffic ──
     println("");
     println("--- Healthy services still operational ---");
-    await auth.handle(4);
-    await api.handle(5);
+    let _ = await auth.handle(4);
+    let _ = await api.handle(5);
     println("");
     println("Health monitoring complete. The select timeout detects");
     println("unresponsive services without blocking the monitor.");

--- a/examples/services/pub_sub.hew
+++ b/examples/services/pub_sub.hew
@@ -111,10 +111,10 @@ fn main() {
     // ── Collect stats ──
     println("");
     println("--- Stats ---");
-    await broker.stats();
-    await alice.count();
-    await bob.count();
-    await carol.count();
+    let _ = await broker.stats();
+    let _ = await alice.count();
+    let _ = await bob.count();
+    let _ = await carol.count();
     println("");
     println("Pub/sub complete. No channels, no mutexes, no select loops.");
     println("The broker actor serialises all routing — data-race free.");

--- a/examples/services/rate_limiter.hew
+++ b/examples/services/rate_limiter.hew
@@ -136,8 +136,8 @@ fn main() {
     sleep(100ms);
     println("");
     println("--- Worker stats ---");
-    await w1.stats();
-    await w2.stats();
+    let _ = await w1.stats();
+    let _ = await w2.stats();
     println("");
     println("Rate limiting complete. No mutexes, no channels — just actors.");
 }

--- a/examples/stress_ping_pong.hew
+++ b/examples/stress_ping_pong.hew
@@ -37,9 +37,8 @@ fn main() {
         pinger.ping(ping_value);
         ponger.pong(pong_value);
     }
-    await pinger.report();
-    await ponger.report();
-
+    let _ = await pinger.report();
+    let _ = await ponger.report();
     // Second burst: stress with higher volume
     println("--- Round 2: 5000 rounds ---");
     for j in 0 .. 5000 {
@@ -48,7 +47,7 @@ fn main() {
         pinger.ping(ping_value);
         ponger.pong(pong_value);
     }
-    await pinger.report();
-    await ponger.report();
+    let _ = await pinger.report();
+    let _ = await ponger.report();
     println("PASS: 6000 ping-pong rounds completed");
 }

--- a/examples/test_compound_assign.hew
+++ b/examples/test_compound_assign.hew
@@ -24,5 +24,5 @@ fn main() {
     counter.set(3);
     counter.double();
     counter.scale(4);
-    await counter.print_value();
+    let _ = await counter.print_value();
 }

--- a/hew-cli/tests/lint_pass_e2e.rs
+++ b/hew-cli/tests/lint_pass_e2e.rs
@@ -536,3 +536,57 @@ fn must_use_inline_directive_suppresses() {
         "an in-source `// hew:allow(must_use)` must suppress the lint:\n{stderr}"
     );
 }
+
+// ── checker-stage lint: must_use on a discarded `await actor.msg()` ───
+
+/// A program whose only diagnostic is `must_use`: `await d.process(5)` is
+/// discarded in statement position, dropping the `Result<i64, AskError>` it
+/// returns — a silently lost timeout / full-mailbox / stopped-actor signal.
+const ASK_MUST_USE_DISCARD: &str = "actor Doubler {\n\
+     receive fn process(n: i64) -> i64 { n * 2 }\n\
+     }\n\
+     fn main() {\n\
+     let d = spawn Doubler;\n\
+     await d.process(5);\n\
+     }\n";
+
+/// The same program, but the ask result is explicitly discarded with `let _`,
+/// which the lint treats as a deliberate drop (silent).
+const ASK_MUST_USE_HANDLED: &str = "actor Doubler {\n\
+     receive fn process(n: i64) -> i64 { n * 2 }\n\
+     }\n\
+     fn main() {\n\
+     let d = spawn Doubler;\n\
+     let _ = await d.process(5);\n\
+     }\n";
+
+const ASK_MUST_USE_MESSAGE: &str = "an ignored ask error fails open";
+
+#[test]
+fn must_use_await_ask_warning_renders_by_default() {
+    let output = run_check(ASK_MUST_USE_DISCARD, &[]);
+    let stderr = stderr_of(&output);
+    assert!(
+        output.status.success(),
+        "a must_use warning must not fail the build:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("warning:") && stderr.contains(ASK_MUST_USE_MESSAGE),
+        "expected the discarded-await must_use warning to render:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("AskError"),
+        "the warning should name the AskError type:\n{stderr}"
+    );
+}
+
+#[test]
+fn must_use_await_ask_handled_is_silent() {
+    let output = run_check(ASK_MUST_USE_HANDLED, &[]);
+    let stderr = stderr_of(&output);
+    assert!(output.status.success(), "check should pass:\n{stderr}");
+    assert!(
+        !stderr.contains(ASK_MUST_USE_MESSAGE),
+        "`let _ = await …` must not warn:\n{stderr}"
+    );
+}

--- a/hew-lsp/tests/fixtures/v05_std_channels.hew
+++ b/hew-lsp/tests/fixtures/v05_std_channels.hew
@@ -10,7 +10,7 @@ fn std_channels(
 ) -> i32 {
     stream.recv();
     sink.send(std_channels_probe());
-    duplex.send(1);
+    let _ = duplex.send(1);
     channel.close();
     std_channels_probe()
 }

--- a/hew-types/src/check/lints/mod.rs
+++ b/hew-types/src/check/lints/mod.rs
@@ -83,11 +83,12 @@ pub enum LintId {
     /// is overwritten or goes out of scope — the store is dead. Emitted by the
     /// MIR-stage liveness pass (`hew-mir`), not the HIR checker sweep.
     DeadStore,
-    /// A discarded value carries a write/send error that must not be ignored —
-    /// `WriteError` / `SendError`, bare or as the error arm of a `Result`. A
-    /// statement-position discard fails open (a dropped backpressure /
-    /// disconnect signal, an unnoticed undelivered send); handle it or bind
-    /// `let _ = …`.
+    /// A discarded value carries a write/send/ask error that must not be
+    /// ignored — `WriteError` / `SendError` / `AskError`, bare or as the error
+    /// arm of a `Result`. A statement-position discard fails open (a dropped
+    /// backpressure / disconnect signal, an unnoticed undelivered send, or a
+    /// timed-out / mailbox-full / stopped-actor `ask` mistaken for a reply);
+    /// handle it or bind `let _ = …`.
     MustUse,
     // NOTE: a `clean_counter` lint (a loop-carried accumulator that is
     // incremented but never read after the loop) is deliberately NOT registered

--- a/hew-types/src/check/lints/must_use.rs
+++ b/hew-types/src/check/lints/must_use.rs
@@ -1,18 +1,20 @@
 //! The `must_use` lint.
 //!
-//! Flags a *discarded* value whose type carries a write/send failure that must
-//! not be ignored — `WriteError` and `SendError`, the error arms returned by
-//! `Connection.write` and the pid `tell` family. Dropping such a value on the
-//! floor silently fails open: a backpressure or disconnect signal vanishes, an
-//! undelivered message is never noticed. A program should handle it (`?`,
-//! `match`) or discard it explicitly (`let _ = …`).
+//! Flags a *discarded* value whose type carries a failure that must not be
+//! ignored — `WriteError`, `SendError`, and `AskError`, the error arms returned
+//! by `Connection.write`, the pid `tell` family, and an actor `ask`
+//! (`await actor.msg()`). Dropping such a value on the floor silently fails
+//! open: a backpressure or disconnect signal vanishes, an undelivered message
+//! is never noticed, or a timed-out / mailbox-full / stopped-actor ask is
+//! mistaken for a reply. A program should handle it (`?`, `match`) or discard
+//! it explicitly (`let _ = …`).
 //!
 //! The value is flagged in two shapes:
 //!
-//! - the bare error: `WriteError` / `SendError`;
+//! - the bare error: `WriteError` / `SendError` / `AskError`;
 //! - a `Result<_, E>` whose error arm is one of those — the common case, since
-//!   `write()` returns `Result<(), WriteError>` and `tell()` returns
-//!   `Result<(), SendError>`.
+//!   `write()` returns `Result<(), WriteError>`, `tell()` returns
+//!   `Result<(), SendError>`, and an `ask` returns `Result<Reply, AskError>`.
 //!
 //! ## Precision over recall
 //!
@@ -21,9 +23,10 @@
 //!   `var` binding, and a `match` / `if let` scrutinee are all "used" and never
 //!   flagged. `expr?` lands here typed as the unwrapped ok arm, so a handled
 //!   call is silent; only the unhandled discard remains.
-//! - The discarded expression's resolved type must be exactly `WriteError` /
-//!   `SendError` or `Result<_, WriteError|SendError>`, verified through
-//!   [`LintCtx::resolved_type_at`]; an unresolved type stays silent.
+//! - The discarded expression's resolved type must be exactly one of the
+//!   must-use errors (`WriteError` / `SendError` / `AskError`) or a `Result<_,
+//!   E>` over one, verified through [`LintCtx::resolved_type_at`]; an
+//!   unresolved type stays silent.
 //! - `// hew:allow(must_use)` (or an explicit `let _ = …`) is the documented
 //!   opt-out, mirroring the registry's other suppressible lints.
 
@@ -46,8 +49,14 @@ pub(super) fn check(ctx: &LintCtx, levels: &LintLevels, body: &Block, out: &mut 
             levels,
             LintId::MustUse,
             &hit.span,
-            format!("discarded `{}` value; an ignored write/send error fails open", hit.error),
-            format!("handle it (`?`, `match`) or discard explicitly with `let _ = …` — `{}` reports backpressure, disconnect, or undelivered sends", hit.error),
+            format!(
+                "discarded `{}` value; an ignored {} error fails open",
+                hit.error.name, hit.error.class
+            ),
+            format!(
+                "handle it (`?`, `match`) or discard explicitly with `let _ = …` — `{}` reports {}",
+                hit.error.name, hit.error.reports
+            ),
             out,
         );
     }
@@ -55,9 +64,8 @@ pub(super) fn check(ctx: &LintCtx, levels: &LintLevels, body: &Block, out: &mut 
 
 struct Hit {
     span: Span,
-    /// Stable name of the offending error type (`WriteError` / `SendError`),
-    /// used to render the message and suggestion.
-    error: &'static str,
+    /// The must-use error the discarded value carries.
+    error: MustUseError,
 }
 
 struct MustUse<'a> {
@@ -90,23 +98,63 @@ impl NodeVisitor for MustUse<'_> {
     }
 }
 
-/// The stable name of the must-use error a discarded value carries, or `None`.
+/// A must-use error type and the failure it loses when silently discarded.
 ///
-/// Matches the bare error type and a `Result<_, E>` whose error arm is one. The
-/// match is by canonical name so it covers both the builtin `SendError` and the
-/// stdlib `WriteError` enum identically.
-fn must_use_error(ty: &Ty) -> Option<&'static str> {
-    if let Some((_, err)) = ty.as_result() {
-        return error_name(err);
-    }
-    error_name(ty)
+/// `class` keys the primary diagnostic ("an ignored {class} error fails open");
+/// `reports` names the concrete failure in the suggestion. Grouping by class
+/// keeps the message identical for every error that fails the same way.
+#[derive(Clone, Copy)]
+struct MustUseError {
+    /// Stable name of the offending error type, shown in the diagnostic.
+    name: &'static str,
+    /// Error-class phrase for the primary message (`write/send`, `ask`).
+    class: &'static str,
+    /// What the discarded error silently drops, for the suggestion.
+    reports: &'static str,
 }
 
-/// `WriteError` / `SendError` named-type detection.
-fn error_name(ty: &Ty) -> Option<&'static str> {
-    match ty {
-        Ty::Named { name, .. } if name == "WriteError" => Some("WriteError"),
-        Ty::Named { name, .. } if name == "SendError" => Some("SendError"),
+impl MustUseError {
+    /// `WriteError` — backpressure / disconnect from `Connection.write`.
+    const WRITE: Self = Self {
+        name: "WriteError",
+        class: "write/send",
+        reports: "backpressure, disconnect, or undelivered sends",
+    };
+    /// `SendError` — an undelivered message from the pid `tell` family.
+    const SEND: Self = Self {
+        name: "SendError",
+        class: "write/send",
+        reports: "backpressure, disconnect, or undelivered sends",
+    };
+    /// `AskError` — a failed `await actor.msg()` / lambda-actor `ask`.
+    const ASK: Self = Self {
+        name: "AskError",
+        class: "ask",
+        reports: "a timeout, a full mailbox, or a stopped actor",
+    };
+}
+
+/// The must-use error a discarded value carries, or `None`.
+///
+/// Matches the bare error type and a `Result<_, E>` whose error arm is one. The
+/// match is by canonical name so it covers the builtin `SendError` / `AskError`
+/// and the stdlib `WriteError` enum identically.
+fn must_use_error(ty: &Ty) -> Option<MustUseError> {
+    if let Some((_, err)) = ty.as_result() {
+        return error_kind(err);
+    }
+    error_kind(ty)
+}
+
+/// `WriteError` / `SendError` / `AskError` named-type detection.
+fn error_kind(ty: &Ty) -> Option<MustUseError> {
+    let Ty::Named { name, .. } = ty else {
+        return None;
+    };
+    match name.as_str() {
+        "WriteError" => Some(MustUseError::WRITE),
+        "SendError" => Some(MustUseError::SEND),
+        "AskError" => Some(MustUseError::ASK),
         _ => None,
     }
 }

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -3747,6 +3747,91 @@ fn must_use_suppressed_by_directive() {
     );
 }
 
+/// A fieldless actor whose `process` reply makes `await d.process(_)` resolve to
+/// `Result<i64, AskError>` — the ask-shaped must-use case. `AskError` is a
+/// builtin error type, so no prelude enum is needed (unlike WriteError/SendError).
+const ASK_ACTOR: &str = "actor Doubler { receive fn process(n: i64) -> i64 { n * 2 } }\n";
+
+#[test]
+fn must_use_flags_discarded_await_ask() {
+    // A bare `await actor.msg()` in statement position drops a
+    // `Result<_, AskError>` — a lost timeout/full-mailbox/stopped-actor signal.
+    let src = format!("{ASK_ACTOR}fn main() {{ let d = spawn Doubler; await d.process(5); }}");
+    let (errors, warnings) = parse_and_check(&src);
+    assert!(errors.is_empty(), "fixture should type-check: {errors:?}");
+    let hit = warnings
+        .iter()
+        .find(|w| w.kind == TypeErrorKind::Lint(LintId::MustUse))
+        .expect("a discarded `await actor.msg()` (Result<_, AskError>) must fire must_use");
+    assert!(
+        hit.message.contains("AskError") && hit.message.contains("ask error"),
+        "primary message should name AskError and the ask class: {}",
+        hit.message
+    );
+    assert!(
+        hit.suggestions.iter().any(|s| {
+            s.contains("timeout") && s.contains("mailbox") && s.contains("stopped actor")
+        }),
+        "suggestion should name the concrete ask failures: {:?}",
+        hit.suggestions
+    );
+}
+
+#[test]
+fn must_use_not_flagged_when_await_matched() {
+    let src = format!(
+        "{ASK_ACTOR}fn main() {{ let d = spawn Doubler; \
+         match await d.process(5) {{ Ok(_) => {{}} Err(_) => {{}} }} }}"
+    );
+    let (_, warnings) = parse_and_check(&src);
+    assert_eq!(
+        count_must_use(&warnings),
+        0,
+        "a matched await ask is handled, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn must_use_not_flagged_when_await_explicitly_bound() {
+    let src =
+        format!("{ASK_ACTOR}fn main() {{ let d = spawn Doubler; let _ = await d.process(5); }}");
+    let (_, warnings) = parse_and_check(&src);
+    assert_eq!(
+        count_must_use(&warnings),
+        0,
+        "`let _ = await …` is an explicit discard, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn must_use_not_flagged_when_await_in_tail_position() {
+    let src = format!(
+        "{ASK_ACTOR}fn caller() -> Result<i64, AskError> \
+         {{ let d = spawn Doubler; await d.process(5) }}"
+    );
+    let (_, warnings) = parse_and_check(&src);
+    assert_eq!(
+        count_must_use(&warnings),
+        0,
+        "a tail await is the function's value, warnings: {warnings:?}"
+    );
+}
+
+#[test]
+fn must_use_await_suppressed_by_directive() {
+    let src = format!(
+        "{ASK_ACTOR}fn main() {{\n    let d = spawn Doubler;\n    \
+         // hew:allow(must_use)\n    await d.process(5);\n}}"
+    );
+    let out = check_with_lint_level(&src, LintId::MustUse, LintLevel::Warn);
+    assert_eq!(
+        count_must_use(&out.warnings),
+        0,
+        "a directive above the discarded await must suppress, warnings: {:?}",
+        out.warnings
+    );
+}
+
 // -----------------------------------------------------------------------
 // Module namespacing tests
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Extends the must_use lint to AskError: a discarded `await actor.msg()` (Result<_,AskError>) silently loses a timeout/full-mailbox/stopped-actor. Now warns in statement position; ?/let/match/tail/// hew:allow stay silent. Updates 11 examples to the suggested fix.
## Verification
ci-preflight 14/14, 5 unit + 2 e2e, flake 3/3.