### PR TITLE
chore: remove tombstone comments referring to replaced implementations

### DIFF
--- a/examples/actor/select_suspend_race.hew
+++ b/examples/actor/select_suspend_race.hew
@@ -1,12 +1,11 @@
 // cut-select-waitset — the live non-blocking actor `select{}`.
 //
 // `Coordinator.race_two` runs a `select{}` over two actor-ask arms (plus a
-// safety-net `after` deadline) from INSIDE a handler. Before this change the
-// select called `hew_select_first`, a busy-poll that PINNED the worker until an
-// arm became ready. Now the select registers each arm's readiness observer on a
-// shared await-cancel arbiter, arms the deadline on the global timer wheel, and
-// `coro.suspend`s — freeing the worker. The first arm to become ready wins the
-// arbiter and RESUMES the coordinator; the losing arm is cancelled.
+// safety-net `after` deadline) from INSIDE a handler. The select registers each
+// arm's readiness observer on a shared await-cancel arbiter, arms the deadline
+// on the global timer wheel, and `coro.suspend`s — freeing the worker. The first
+// arm to become ready wins the arbiter and RESUMES the coordinator; the losing
+// arm is cancelled.
 //
 // Running with HEW_WORKERS=1 is the worker-freeing proof: a single worker must
 // suspend the coordinator, run the two worker actors, then resume the

--- a/hew-cli/build.rs
+++ b/hew-cli/build.rs
@@ -5,9 +5,8 @@ const UNKNOWN_GIT_METADATA: &str = "unknown";
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    // The retired legacy codegen subtree is no longer a selectable build
-    // substrate.  Keep this build script focused on version metadata only; the
-    // active compiler path is the Rust MIR/codegen-rs pipeline.
+    // Keep this build script focused on version metadata; the active
+    // compiler path is the Rust MIR/codegen-rs pipeline.
 
     let repo_dir = Path::new("..");
     emit_git_metadata(repo_dir);

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -762,13 +762,12 @@ pub(crate) fn uses_wasm_excluded_symbol(pipeline: &IrPipeline) -> Option<String>
                     // defence-in-depth catch for direct-MIR paths — W2.006,
                     // WASM-TODO(#1451)).
                     //
-                    // `hew_tcp_stream_from_conn` was historically listed here
-                    // but is unreachable through `Instr::CallRuntimeAbi`: it
-                    // is not in `MIR_EMITTER_RUNTIME_SYMBOLS`, so
-                    // `RuntimeCall::new` refuses it at construction; std/net's
-                    // extern-block calls bypass this scan entirely and rely on
-                    // the wasm32 runtime stub (the original note already said
-                    // so). WASM-TODO(#1451): TCP transport gap.
+                    // `hew_tcp_stream_from_conn` is unreachable through
+                    // `Instr::CallRuntimeAbi`: it is not in
+                    // `MIR_EMITTER_RUNTIME_SYMBOLS`, so `RuntimeCall::new`
+                    // refuses it at construction. std/net's extern-block calls
+                    // bypass this scan entirely and rely on the wasm32 runtime
+                    // stub. WASM-TODO(#1451): TCP transport gap.
                     Instr::CallRuntimeAbi(call) => {
                         wasm_excluded_call_family(call.family()).then(|| call.symbol().to_string())
                     }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -456,15 +456,11 @@ const SYNTHETIC_STREAM_TRY_NEXT_LAYOUT_ITEM: ItemId = ItemId(u32::MAX / 2 - 16);
 const SYNTHETIC_STREAM_SEND_LAYOUT_ITEM: ItemId = ItemId(u32::MAX / 2 - 17);
 
 // NB the synthetic-builtin sentinel band (`u32::MAX / 2 - N`) is
-// documentation/segregation only since `ResolvedRef::Builtin` landed: MIR
-// no longer consults a band predicate to decide whether an Item-resolved
-// name may reach a user-name → C-symbol bridge (that bridge is deleted;
-// the typed family travels on the resolution itself). The former
-// `SYNTHETIC_BUILTIN_ITEM_FLOOR` constant had no remaining consumers and
-// was removed; the load-bearing invariant — every minted sentinel id is
-// pairwise distinct (two colliding ids silently overwrite each other's
-// `fn_registry` row) — is pinned by
-// `synthetic_builtin_sentinel_ids_are_pairwise_distinct`.
+// documentation/segregation only. Item-resolved builtin names carry their
+// typed family on the resolution itself, not through a numeric band predicate.
+// The load-bearing invariant — every minted sentinel id is pairwise distinct
+// (two colliding ids silently overwrite each other's `fn_registry` row) — is
+// pinned by `synthetic_builtin_sentinel_ids_are_pairwise_distinct`.
 
 /// Bare-name variants of built-in tagged unions. Counted into the pre-pass's
 /// `bare_counts` so a user enum that redeclares one of them correctly marks
@@ -1669,8 +1665,8 @@ pub fn lower_program_with_mono_cap(
                 // Register methods of any V0b-acceptable impl block under the
                 // qualified `<SelfType>::<method>` name so call sites can
                 // resolve them in the second pass. The Index special-case is
-                // a subset of this — its methods landed in `fn_registry`
-                // historically via the same key shape.
+                // a subset of this because its methods use the same
+                // `fn_registry` key shape.
                 if let TypeExpr::Named {
                     name,
                     type_args: target_type_args,
@@ -3381,11 +3377,9 @@ pub fn lower_program_with_mono_cap(
                             {
                                 // Conservatively lower only the imported impl
                                 // methods that are provably safe cross-module;
-                                // skip the rest so they stay dropped exactly as
-                                // before this change (the module still imports
-                                // cleanly, and an actual call to a skipped method
-                                // fails closed downstream just as it did on the
-                                // prior, drop-everything path).
+                                // skip the rest so the module still imports
+                                // cleanly and an actual call to a skipped method
+                                // fails closed downstream.
                                 //
                                 // A method is skipped when EITHER:
                                 //  - its body calls a bare name that resolves in

--- a/hew-lsp/src/server/analysis.rs
+++ b/hew-lsp/src/server/analysis.rs
@@ -41,9 +41,8 @@ pub(super) fn source_for_path(
 /// Recursively populate `ImportDecl::resolved_items` for user and file imports.
 ///
 /// After parsing a document the `resolved_items` field on every `ImportDecl`
-/// is `None`.  The CLI fills these in by reading files from disk; the LSP
-/// historically skipped this step, so imported modules were only resolved via
-/// the stdlib `ModuleRegistry` and not from the project tree.
+/// is `None`. The LSP must resolve imported modules from the project tree, not
+/// just through the stdlib `ModuleRegistry`.
 ///
 /// This function walks `items`, finds unresolved `Import` nodes, locates the
 /// corresponding `.hew` file relative to `source_dir`, reads it — **preferring

--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -1519,9 +1519,8 @@ pub(crate) unsafe fn cleanup_all_actors() {
         // Cancel periodic timers, drop link/monitor entries, and unregister
         // named-node bindings BEFORE running terminate or freeing the
         // allocation. This matches the canonical ordering used by
-        // `hew_actor_free` and `drain_actors`; previously this path inverted
-        // the order and skipped the named-node unregister entirely, which
-        // leaked global registry entries on shutdown.
+        // `hew_actor_free` and `drain_actors`, preventing dangling registry
+        // entries on shutdown.
         // SAFETY: actor is quiescent (scheduler is shut down) and the helper
         // tolerates already-untracked actors when no concurrent dispatch is
         // possible.
@@ -5934,9 +5933,8 @@ pub(crate) unsafe fn actor_free_wasm_impl(actor: *mut HewActor) -> c_int {
     }
 
     // Cancel periodic timers, drop link/monitor entries, and unregister
-    // named-node bindings BEFORE untracking. Previously this path called
-    // only `cancel_all_timers_for_actor`, leaving dangling link/monitor
-    // entries on WASM so DOWN signals never fired against a freed actor.
+    // named-node bindings BEFORE untracking. This prevents dangling
+    // link/monitor entries on WASM so DOWN signals cannot target a freed actor.
     // SAFETY: the wait loop above ensures the actor is quiescent and not dispatching.
     unsafe { prepare_quiescent_actor_for_cleanup(actor) };
 
@@ -9543,8 +9541,7 @@ mod tests {
     fn drain_actors_with_pending_timer_cancels_timer() {
         // Pin the canonical ordering: when an actor with a registered
         // periodic timer is drained, the timer must be cancelled before
-        // the actor is freed. This guards against the inverted ordering
-        // that previously lived in `cleanup_all_actors`.
+        // the actor is freed.
         let _guard = crate::runtime_test_guard();
         let _scheduler = NativeSchedulerGuard::new();
         let _ticker_guard = crate::timer_periodic::TICKER_TEST_MUTEX

--- a/hew-runtime/src/hashset.rs
+++ b/hew-runtime/src/hashset.rs
@@ -380,11 +380,10 @@ pub unsafe extern "C" fn hew_hashset_to_vec_layout(set: *const HewLayoutHashSet)
 /// element layout's clone discipline and fails closed on unsupported
 /// layout-managed key paths.
 ///
-/// Pairs with [`hew_hashset_free_layout`]. Using the retired legacy
-/// `hew_hashset_clone` against a `HewLayoutHashSet*` would reinterpret the
+/// Pairs with [`hew_hashset_free_layout`]. Layout-backed sets must not be
+/// cloned through the non-layout `hew_hashset_clone` ABI: that would reinterpret
 /// 16-byte-stride layout entries as 48-byte `HewMapEntry` records (W4.045
-/// use-after-free, `lifecycle-symmetry` / `codegen-abi-authority` P0) —
-/// that symbol is no longer exported (W5.003).
+/// use-after-free, `lifecycle-symmetry` / `codegen-abi-authority` P0).
 ///
 /// # Safety
 ///

--- a/hew-runtime/src/lib.rs
+++ b/hew-runtime/src/lib.rs
@@ -694,8 +694,8 @@ pub mod mailbox_wasm;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod mpsc;
 /// Runtime-instance state — the de-globalized home for process-wide
-/// authorities that previously lived as free `static`s (native-only; the WASM
-/// cooperative scheduler keeps its own state model).
+/// authorities (native-only; the WASM cooperative scheduler keeps its own state
+/// model).
 #[cfg(not(target_arch = "wasm32"))]
 pub mod runtime;
 /// Public host/embedder handle to a Hew runtime — the external, refcounted

--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -1,20 +1,18 @@
-//! Runtime instance state — the de-globalized home for the process-wide
-//! authorities that were previously free `static`s.
+//! Runtime instance state — the de-globalized home for process-wide
+//! authorities.
 //!
 //! # Why this module exists
 //!
-//! Historically every runtime authority (the scheduler, the live-actor table,
-//! the name registry, shutdown phase, timers, the reactor, the node slot, …)
-//! lived as an independent process-global `static`. That made it impossible
-//! for more than one Hew runtime to exist in one process, forced test
-//! serialization on the shared globals, and left ownership of the teardown
-//! order spread across modules.
+//! Runtime authorities (the scheduler, the live-actor table, the name registry,
+//! shutdown phase, timers, the reactor, the node slot, …) need a single owned
+//! teardown root. That keeps teardown order explicit and makes multi-runtime
+//! support possible without shared-global test serialization.
 //!
 //! [`RuntimeInner`] gathers those authorities into one owned struct. A single
 //! **droppable** default slot ([`DEFAULT_RUNTIME`]) holds the one runtime that
 //! today's AOT and JIT programs use. The slot is an [`AtomicPtr`] (not a
-//! `OnceLock`) for the same reason the old `SCHEDULER` pointer was: the runtime
-//! must be *freeable* on `hew_runtime_cleanup`, releasing the scheduler's
+//! `OnceLock`) because the runtime must be *freeable* on
+//! `hew_runtime_cleanup`, releasing the scheduler's
 //! crossbeam deques, parkers, and stealer handles. A bare `OnceLock<RuntimeInner>`
 //! could never free.
 //!
@@ -52,9 +50,8 @@ pub use crate::runtime_id::RuntimeId;
 
 /// The owned state of one Hew runtime instance.
 ///
-/// Each field is an authority that previously lived as a process-global
-/// `static`. Subsystems are migrated into this struct one per commit; fields
-/// are added as each subsystem's statics move here.
+/// Each field is an owned runtime authority. Subsystems migrate into this
+/// struct one authority at a time.
 ///
 /// Dropping a `RuntimeInner` drops every owned field in declaration order.
 /// For the scheduler this releases the crossbeam deques, parkers, stealer
@@ -163,9 +160,8 @@ pub(crate) static RUNTIME_INNER_DROPS: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
 /// Test-only drop observer. Production builds compile no `Drop` impl, so the
-/// inner frees by field-drop exactly as the old `Box<Scheduler>` did; the
-/// `#[cfg(test)]` impl only records that the field-drop happened, then lets the
-/// fields drop normally as it returns.
+/// inner frees by field-drop; the `#[cfg(test)]` impl only records that the
+/// field-drop happened, then lets the fields drop normally as it returns.
 #[cfg(test)]
 impl Drop for RuntimeInner {
     fn drop(&mut self) {
@@ -190,7 +186,7 @@ pub(crate) static DEFAULT_RUNTIME: AtomicPtr<RuntimeInner> = AtomicPtr::new(std:
 /// The reference is valid until `hew_runtime_cleanup()` detaches and drops the
 /// inner. Cleanup runs only after all worker threads have been joined, so any
 /// caller reachable from worker/dispatch code holds a valid reference for the
-/// duration of its use. This mirrors the old `get_scheduler()` contract.
+/// duration of its use.
 #[inline]
 pub(crate) fn rt_default() -> Option<&'static RuntimeInner> {
     let ptr = DEFAULT_RUNTIME.load(Ordering::Acquire);
@@ -508,8 +504,8 @@ impl Drop for EnterGuard {
 /// Publish `inner` as the default runtime via compare-exchange.
 ///
 /// Returns `true` when this call installed `inner`. Returns `false` when a
-/// runtime was already installed; in that case the passed-in box is dropped,
-/// matching the old "second `hew_sched_init` is a harmless no-op" semantics.
+/// runtime was already installed; in that case the passed-in box is dropped so a
+/// second `hew_sched_init` remains a harmless no-op.
 pub(crate) fn install_default(inner: Box<RuntimeInner>) -> bool {
     let ptr = Box::into_raw(inner);
     if DEFAULT_RUNTIME

--- a/hew-runtime/src/send_ptr.rs
+++ b/hew-runtime/src/send_ptr.rs
@@ -3,13 +3,7 @@
 //! Several runtime subsystems need to keep a `*mut T` inside a container that
 //! must itself be `Send` (e.g. a `HashMap` shared between profiler threads, a
 //! crossbeam queue exercised from multiple producer threads, or a registry
-//! reachable from a worker thread).  Each subsystem previously open-coded the
-//! same wrapper:
-//!
-//! ```ignore
-//! struct SendPtr(*mut T);
-//! unsafe impl Send for SendPtr {}
-//! ```
+//! reachable from a worker thread).
 //!
 //! This helper centralizes the marker boilerplate while keeping the safety
 //! discipline local.  The constructor is `unsafe` and the inner pointer is

--- a/hew-std/src/lib.rs
+++ b/hew-std/src/lib.rs
@@ -1,8 +1,8 @@
 //! Hew standard library — the Rust-backed FFI surface for every `std` module.
 //!
-//! This crate folds the formerly-separate per-module std crates into a single
-//! `hew-std` crate so the workspace builds one staticlib (`libhew_std.a`) and
-//! `hew-lib` carries one stdlib dependency. Each module keeps its own
+//! This crate contains the Rust-backed implementation for all std modules, so
+//! the workspace builds one staticlib (`libhew_std.a`) and `hew-lib` carries one
+//! stdlib dependency. Each module keeps its own
 //! `#[no_mangle]` C ABI symbols (`hew_json_*`, `hew_http_*`, `hew_cron_*`, …) in
 //! the shared global namespace; the linker's per-function dead-strip prunes
 //! whichever modules a program does not reference, so consolidation is


### PR DESCRIPTION
## Summary
Strips dead historical framing in source comments ("before this change…", "was historically…", "the retired legacy…") that refers to replaced implementations and adds no value — git carries that history. Preserves live rationale, ordering notes, SAFETY/WASM-TODO markers. Comment-only; no code change.
## Verification
11 files, +54/-78, comments only; cargo fmt --check + cargo check --workspace green.
## Out of scope
Borderline rationale-bearing comments left untouched; LESSONS/CHANGELOG/docs history untouched.