### PR TITLE
test(raii): pin consume on the leak-oracle deque-free extern (main red hotfix)

### DIFF
--- a/hew-cli/tests/raii1_record_resource_field_leak_oracle.rs
+++ b/hew-cli/tests/raii1_record_resource_field_leak_oracle.rs
@@ -77,7 +77,7 @@ impl Dq {\n\
 }\n\
 extern \"C\" {\n\
     fn hew_deque_new() -> Dq;\n\
-    fn hew_deque_free(dq: Dq);\n\
+    fn hew_deque_free(consume dq: Dq);\n\
 }\n\
 type Holder { dq: Dq }\n";
 


### PR DESCRIPTION
## Old failure mode
RAII-1 + RAII-2 merge-interaction: RAII-2 (#2311) added the fail-closed ResourceBoundaryParamMustConsume check; RAII-1's leak-oracle prelude still declared `fn hew_deque_free(dq: Dq)` unannotated (Dq is #[resource]) → 10 raii1 tests fail at the prelude on main.
## Invariant preserved
An extern that frees/owns a resource param must declare `consume`; the check is correct, the corpus needed the annotation.
## Why this boundary
Dq::close(self) hands the deque to hew_deque_free which frees it → the param is consumed. Workspace sweep found exactly this one site (all other externs already annotated by #2311 or not resource-bearing).
## Verification
raii1 oracle 10/10 pass (ResourceBoundaryParamMustConsume gone); workspace 10690/10691 (sole fail = pre-existing cross-arch env artifact, diff byte-identical to main); fmt/clippy/leak-scan green; flake 3/3.
## Out of scope
The intended-reject fixtures stay unannotated.