### PR TITLE
fix(types): fail closed on Node:: and RemotePid messaging for wasm32

### DIFF
--- a/docs/wasm-capability-matrix.md
+++ b/docs/wasm-capability-matrix.md
@@ -101,6 +101,7 @@ The **Checker disposition** column documents what the type checker emits when
 | **`std::net::quic.*`, `quic.QUICEndpoint.*`, `quic.QUICConnection.*`, `quic.QUICStream.*`, `quic.QUICEvent.*`** | 🚫 Error (`Quic`) | `quic_transport` is feature-gated and not compiled for wasm32 | WASM-TODO |
 | **`std::net::dns.resolve`, `dns.lookup_host`** | 🚫 Error (`Dns`) | Native OS resolver; not compiled for wasm32 | WASM-TODO |
 | **`std::os.*`** | 🚫 Error (`OsEnv`) | Hew OS/env helpers are native-only today even where WASI may offer host data | WASM-TODO |
+| **`Node::*` (`start`, `shutdown`, `connect`, `set_transport`, `load_keys`, `allow_peer`, `register`, `lookup`), `RemotePid<T>::tell` / `::ask`** | 🚫 Error (`Distributed`) | Native mesh transport (`hew_node_api_*` / `hew_remote_pid_tell`); not compiled for wasm32 | WASM-TODO |
 | **`std::crypto::crypto.random_bytes`** | 🚫 Error (`CryptoRandom`) | Secure entropy source is native-only; fail-closed rejection until wasm32 cryptographic entropy exists | WASM-TODO |
 | Generators on WASM | ✅ Pass (basic syntax) | Cooperative scheduler | Note below |
 
@@ -200,6 +201,21 @@ would otherwise end in a trap or linker failure:
   feature-specific diagnostic rather than a native-symbol failure downstream.
   - WASM-TODO: define a host capability model for subprocess execution.
 
+- **Distributed node API / remote-actor messaging**: The `Node::*` cluster API
+  (`start`, `shutdown`, `connect`, `set_transport`, `load_keys`, `allow_peer`,
+  `register`, `lookup`) and `RemotePid<T>::tell` / `RemotePid<T>::ask` lower to
+  the native mesh transport (`hew_node_api_*` and `hew_remote_pid_tell` →
+  `hew_actor_send_by_id`), which is gated behind
+  `#[cfg(not(target_arch = "wasm32"))]` and absent from the wasm32 link set.
+  Before this gate the checker admitted these on wasm32 and codegen emitted a
+  module importing an undefined `env::hew_node_api_*` symbol that failed at
+  instantiation (admit-then-abort). The checker now rejects the whole `Node::`
+  namespace and remote messaging with `Distributed`, so distributed programs
+  fail closed at check time the same way `net.*` / `quic.*` / `tls.*` already
+  do. Basic single-process actors (`spawn` / `send` / `ask`) remain available.
+  - WASM-TODO: decide a wasm peer transport before exposing any distributed
+    surface on wasm32.
+
 - **`std::crypto::crypto.random_bytes`**: Secure randomness is backed by
   `ring::SystemRandom`, which is native-only and absent from the wasm32 link set.
   The checker rejects `crypto.random_bytes` on wasm32 so key material generation
@@ -254,12 +270,13 @@ reject_wasm_feature   → Severity::Error    → self.errors
 
 **Reject group** is wired in:
 - `hew-types/src/check/expressions.rs :: reject_if_wasm_incompatible_expr` (scope/tasks)
-- `hew-types/src/check/calls.rs :: reject_if_wasm_incompatible_call` (link/monitor/supervisor/`random_bytes`)
+- `hew-types/src/check/calls.rs :: reject_if_wasm_incompatible_call` (link/monitor/supervisor/`random_bytes`/`Node::*`)
 - `hew-types/src/check/registration.rs` (supervisor actor declarations)
 - `hew-types/src/check/methods.rs :: check_method_call` (stream.* / `http_client.*` / `smtp.*` / http.* / net.* / process.* / tls.* / quic.* / dns.* / os.* / `crypto.random_bytes` module calls)
 - `hew-types/src/check/methods.rs` Receiver match arm (`recv` → `BlockingChannelRecv`)
 - `hew-types/src/check/methods.rs` semaphore handle gate (`acquire` / `acquire_timeout` → `BlockingSemaphoreAcquire`)
 - `hew-types/src/check/methods.rs` Stream / http.Server / http.Request / net.Listener / net.Connection / process.Child / tls.TlsStream / quic.QUIC* handle match arms
+- `hew-types/src/check/methods.rs` RemotePid match arm (`tell` / `ask` → `Distributed`)
 
 Rows marked **WASM-TODO (not checker-gated)** currently have no dedicated
 `WasmUnsupportedFeature` guard point. As of main, that bucket includes raw WASI
@@ -286,6 +303,7 @@ These gaps are explicitly deferred and tracked here:
 | `std::os` parity | WASI-backed args/env/path/system shims for the current stdlib surface | `WASM-TODO: os` |
 | `crypto.random_bytes` parity | Secure wasm32 entropy source and explicit capability classification | `WASM-TODO: crypto-random` |
 | Process execution parity | Explicit host capability model for subprocesses | `WASM-TODO: process-execution` |
+| Distributed node API / remote-actor messaging parity | wasm peer transport for the `Node::*` cluster API and `RemotePid` routing (`hew_node_api_*` is native-only) | `WASM-TODO: distributed` |
 | Supervision tree restart strategies | OS-thread-free supervision design | `WASM-TODO: supervision` |
 | Actor link/monitor fault propagation | OS-thread-free exit propagation | `WASM-TODO: link-monitor` |
 | Structured concurrency scopes | Thread-free scope scheduler | `WASM-TODO: scope` |

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -638,6 +638,16 @@ impl Checker {
             "random_bytes" => {
                 self.reject_wasm_feature(span, WasmUnsupportedFeature::CryptoRandom);
             }
+            // The `Node::*` distributed cluster API (`Node::start`,
+            // `Node::connect`, `Node::load_keys`, `Node::register`,
+            // `Node::lookup`, …) lowers to the native mesh transport
+            // (`hew_node_api_*`), which is not compiled for wasm32. Reject at
+            // check time so the call fails closed with a structured diagnostic
+            // instead of compiling to a wasm module that imports an undefined
+            // `env::hew_node_api_*` symbol and traps at instantiation.
+            name if name.starts_with("Node::") => {
+                self.reject_wasm_feature(span, WasmUnsupportedFeature::Distributed);
+            }
             _ => {}
         }
     }

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -6943,6 +6943,14 @@ impl Checker {
                             applied_sig.return_type.clone()
                         };
                         if matches!(method, "tell" | "ask") {
+                            // `RemotePid<T>::tell` / `::ask` route to the native
+                            // mesh transport (`hew_remote_pid_tell` →
+                            // `hew_actor_send_by_id`), which is not compiled for
+                            // wasm32. Reject at check time so remote messaging
+                            // fails closed with a structured diagnostic instead
+                            // of compiling to a module that imports undefined
+                            // native send symbols and traps at instantiation.
+                            self.reject_wasm_feature(span, WasmUnsupportedFeature::Distributed);
                             self.enforce_actor_method_send_args(args);
                             // A640/S3: this is only a compile-time floor. The
                             // native RemotePid lowering still wraps raw

--- a/hew-types/src/check/tests/wasm.rs
+++ b/hew-types/src/check/tests/wasm.rs
@@ -1313,6 +1313,171 @@ fn main() {
         );
     }
 
+    // ── Node:: distributed namespace + RemotePid messaging reject ──────────
+    //
+    // The `Node::*` cluster API (`start`, `connect`, `load_keys`, `register`,
+    // `lookup`, …) and `RemotePid<T>::tell` / `RemotePid<T>::ask` remote
+    // messaging lower to the native mesh transport (`hew_node_api_*` /
+    // `hew_remote_pid_tell`), which is not compiled for wasm32.  Without a
+    // check-time gate the checker admitted these on wasm32 and codegen emitted a
+    // module importing an undefined `env::hew_node_api_*` symbol that fails at
+    // instantiation (admit-then-abort).  They must fail closed AT CHECK, like
+    // every other native-only surface in this file.
+
+    fn remote_pid_tell_source() -> &'static str {
+        concat!(
+            "record Ping { n: i64 }\n",
+            "actor Worker { receive fn ping(msg: Ping) {} }\n",
+            "impl ActorMsg for Worker { type Msg = Ping; type Reply = (); }\n",
+            "fn main() {\n",
+            "    let pid: RemotePid<Worker> = RemotePid::from_raw<Worker>(1, 0);\n",
+            "    let _ = pid.tell(Ping { n: 0 });\n",
+            "}\n",
+        )
+    }
+
+    fn remote_pid_ask_source() -> &'static str {
+        concat!(
+            "record Ping { n: i64 }\n",
+            "actor Worker { receive fn ping(msg: Ping) -> i64 { 0 } }\n",
+            "impl ActorMsg for Worker { type Msg = Ping; type Reply = i64; }\n",
+            "fn main() {\n",
+            "    let pid: RemotePid<Worker> = RemotePid::from_raw<Worker>(1, 0);\n",
+            "    let _ = pid.ask(Ping { n: 0 }, 1000);\n",
+            "}\n",
+        )
+    }
+
+    #[test]
+    fn wasm_rejects_node_start() {
+        let output = check_wasm(r#"fn main() { Node::start("a@127.0.0.1:9000"); }"#);
+        assert!(
+            has_platform_limitation_error(&output),
+            "Node::start should be a compile-time error on WASM; got errors: {:?}",
+            output.errors
+        );
+        assert!(
+            platform_error_contains(&output, "Distributed node"),
+            "error message should mention the Distributed node feature; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_rejects_node_connect() {
+        let output = check_wasm(r#"fn main() { Node::connect("b@127.0.0.1:9001"); }"#);
+        assert!(
+            platform_error_contains(&output, "Distributed node"),
+            "Node::connect should be a Distributed-node WASM error; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_rejects_node_load_keys() {
+        let output = check_wasm(r#"fn main() { Node::load_keys("/keys/node.pem"); }"#);
+        assert!(
+            platform_error_contains(&output, "Distributed node"),
+            "Node::load_keys should be a Distributed-node WASM error; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_rejects_node_register_and_lookup() {
+        // `Node::register` (LocalPid arg) and `Node::lookup` (RemotePid result)
+        // both ride the native registry transport and must fail closed too.
+        let source = concat!(
+            "actor Worker { receive fn ping() {} }\n",
+            "fn main() {\n",
+            "    let w = spawn Worker;\n",
+            "    Node::register(\"w\", w);\n",
+            "    let _ = Node::lookup<Worker>(\"w\");\n",
+            "}\n",
+        );
+        let output = check_wasm(source);
+        let count = output
+            .errors
+            .iter()
+            .filter(|e| {
+                e.kind == TypeErrorKind::PlatformLimitation
+                    && e.message.contains("Distributed node")
+            })
+            .count();
+        assert!(
+            count >= 2,
+            "Node::register and Node::lookup should each fail closed on WASM; got errors: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn native_node_calls_no_platform_error() {
+        let source = concat!(
+            "fn main() {\n",
+            "    Node::start(\"a@127.0.0.1:9000\");\n",
+            "    Node::connect(\"b@127.0.0.1:9001\");\n",
+            "    Node::load_keys(\"/keys/node.pem\");\n",
+            "}\n",
+        );
+        let output = check_native(source);
+        assert!(
+            !has_platform_limitation_error(&output),
+            "Node:: calls must not emit PlatformLimitation on native; got: {:?}",
+            output.errors
+        );
+        assert!(
+            output.errors.is_empty(),
+            "Node:: calls should typecheck cleanly on native; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_rejects_remote_pid_tell() {
+        let output = check_wasm(remote_pid_tell_source());
+        assert!(
+            platform_error_contains(&output, "remote-actor"),
+            "RemotePid::tell should be a Distributed remote-actor WASM error; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn wasm_rejects_remote_pid_ask() {
+        let output = check_wasm(remote_pid_ask_source());
+        assert!(
+            platform_error_contains(&output, "remote-actor"),
+            "RemotePid::ask should be a Distributed remote-actor WASM error; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn native_remote_pid_tell_no_platform_error() {
+        let output = check_native(remote_pid_tell_source());
+        assert!(
+            !has_platform_limitation_error(&output),
+            "RemotePid::tell must not emit PlatformLimitation on native; got: {:?}",
+            output.errors
+        );
+        assert!(
+            output.errors.is_empty(),
+            "RemotePid::tell should typecheck cleanly on native; got: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn native_remote_pid_ask_no_platform_error() {
+        let output = check_native(remote_pid_ask_source());
+        assert!(
+            !has_platform_limitation_error(&output),
+            "RemotePid::ask must not emit PlatformLimitation on native; got: {:?}",
+            output.errors
+        );
+    }
+
     #[test]
     fn wasm_multi_arm_literal_timed_select_is_not_warning() {
         let output = check_wasm(

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -1907,6 +1907,17 @@ pub(super) enum WasmUnsupportedFeature {
     /// POSIX APIs and is not compiled for wasm32. WASM-TODO(#1451): route through a
     /// capability-scoped WASI surface.
     OsEnv,
+    /// `Node::*` distributed cluster API (`start`, `shutdown`, `connect`,
+    /// `set_transport`, `load_keys`, `allow_peer`, `register`, `lookup`) and
+    /// `RemotePid<T>::tell` / `RemotePid<T>::ask` remote messaging: these lower
+    /// to the native mesh transport (`hew_node_api_*` / `hew_remote_pid_tell`),
+    /// which is gated behind `#[cfg(not(target_arch = "wasm32"))]` and absent
+    /// from the wasm32 link set. Reject at check time so the caller sees a
+    /// structured diagnostic rather than a wasm module importing an undefined
+    /// `env::hew_node_api_*` symbol that fails at instantiation.
+    /// WASM-TODO(#1451): decide a wasm peer transport before exposing any
+    /// distributed surface on wasm32.
+    Distributed,
     // ── Crypto reject additions ─────────────────────────────────────────────
     /// `crypto.random_bytes`: the secure entropy source (`ring::SystemRandom`)
     /// is native-only and absent from the wasm32 link set. Reject so callers
@@ -1949,6 +1960,7 @@ impl WasmUnsupportedFeature {
             Self::Quic => "std::net::quic operations",
             Self::Dns => "std::net::dns resolver operations",
             Self::OsEnv => "std::os environment and path operations",
+            Self::Distributed => "Distributed node and remote-actor operations",
             Self::CryptoRandom => "std::crypto::crypto.random_bytes operations",
             Self::CryptoEncrypt => "std::crypto::encrypt operations",
             Self::CryptoSign => "std::crypto::sign operations",
@@ -2017,6 +2029,11 @@ impl WasmUnsupportedFeature {
             Self::OsEnv => {
                 "the std::os helpers rely on native POSIX APIs; \
                  the os runtime layer is not compiled for wasm32"
+            }
+            Self::Distributed => {
+                "the Node:: cluster API and RemotePid messaging route through the \
+                 native mesh transport (hew_node_api_* / hew_remote_pid_tell), which \
+                 is not compiled for wasm32; no wasm32 distributed runtime exists yet"
             }
             Self::CryptoRandom => {
                 "the std::crypto.random_bytes secure entropy source (ring::SystemRandom) is \

--- a/tests/vertical-slice/reject/node_wasm_distributed_failclosed.hew
+++ b/tests/vertical-slice/reject/node_wasm_distributed_failclosed.hew
@@ -1,0 +1,19 @@
+// Totality-at-boundary reject fixture: the `Node::` distributed cluster API
+// must fail closed AT CHECK on wasm32 targets.
+//
+// `Node::start` / `Node::connect` / `Node::load_keys` lower to the native mesh
+// transport (`hew_node_api_*`), which is gated behind
+// `#[cfg(not(target_arch = "wasm32"))]` and absent from the wasm32 link set.
+// Before this gate the checker admitted the program on wasm32 and codegen
+// emitted a module importing an undefined `env::hew_node_api_*` symbol that
+// failed at instantiation (admit-then-abort) — the exact fail-open this gate
+// closes. `net`/`quic`/`tls` already fail closed via `WasmUnsupportedFeature`;
+// `Node::` now matches with `WasmUnsupportedFeature::Distributed`.
+//
+// run.sh exercises this under BOTH wasm triples (wasm32-unknown-unknown and
+// wasm32-wasip1) and confirms the identical source still type-checks on native.
+fn main() {
+    Node::start("node-a@127.0.0.1:9000");
+    Node::connect("node-b@127.0.0.1:9001");
+    Node::load_keys("/keys/node.pem");
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -326,6 +326,30 @@ if "${HEW}" compile --target wasm32-unknown-unknown \
 fi
 grep -q 'Blocking channel receive operations are not supported on WASM32' "${reject_output}"
 
+# Reject (totality at the wasm boundary): the `Node::` distributed cluster API
+# (`Node::start` / `connect` / `load_keys`) must fail closed AT CHECK on BOTH
+# wasm triples. These calls lower to the native mesh transport
+# (`hew_node_api_*`), which is not compiled for wasm32; before this gate the
+# checker admitted them and codegen emitted a module importing an undefined
+# `env::hew_node_api_*` symbol that trapped at instantiation (admit-then-abort).
+# `hew check` accepts both wasm triples (codegen-free), so it is the precise
+# surface for the check-time gate; `hew compile` only emits wasm32-unknown-unknown.
+node_wasm_fixture="${ROOT}/tests/vertical-slice/reject/node_wasm_distributed_failclosed.hew"
+for triple in wasm32-unknown-unknown wasm32-wasip1; do
+  if "${HEW}" check --target "${triple}" "${node_wasm_fixture}" >"${reject_output}" 2>&1; then
+    echo "expected node_wasm_distributed_failclosed to fail closed under ${triple}" >&2
+    cat "${reject_output}" >&2
+    exit 1
+  fi
+  grep -q 'Distributed node and remote-actor operations are not supported on WASM32' "${reject_output}"
+done
+# Native parity: the identical Node:: program type-checks cleanly off-wasm.
+if ! "${HEW}" check "${node_wasm_fixture}" >"${reject_output}" 2>&1; then
+  echo "expected node_wasm_distributed_failclosed to pass hew check on native" >&2
+  cat "${reject_output}" >&2
+  exit 1
+fi
+
 # Accept: `fork child = worker(42)` inside a machine state entry block
 # compiles end to end — machine entry blocks are spawn-capable contexts and
 # arg-bearing named forks ride the fork-entry shim env. Compile-only (main

--- a/wasm-capability-manifest.toml
+++ b/wasm-capability-manifest.toml
@@ -67,7 +67,7 @@ use_case = "WASI execution — `hew build --target=wasm32-wasi`"
 runnable = true
 
 # ---------------------------------------------------------------------------
-# Feature disposition table (30 rows; mirror of the markdown table).
+# Feature disposition table (31 rows; mirror of the markdown table).
 # Row order matches docs/wasm-capability-matrix.md top-to-bottom.
 # ---------------------------------------------------------------------------
 
@@ -395,6 +395,19 @@ tracking = "WASM-TODO"
 tracking_label = "WASM-TODO: os"
 
 [[feature]]
+id = "distributed"
+enum_variant = "Distributed"
+label = "`Node::*`, `RemotePid<T>::tell` / `::ask`"
+prose_label = "`Node::*` (`start`, `shutdown`, `connect`, `set_transport`, `load_keys`, `allow_peer`, `register`, `lookup`), `RemotePid<T>::tell` / `::ask`"
+reason = "the Node:: cluster API and RemotePid messaging route through the native mesh transport (hew_node_api_* / hew_remote_pid_tell), which is not compiled for wasm32; no wasm32 distributed runtime exists yet"
+checker = "reject"
+runtime = "native-only"
+runtime_status = "Native mesh transport (hew_node_api_* / hew_remote_pid_tell); not compiled for wasm32"
+categories = ["stdlib", "distributed", "actor"]
+tracking = "WASM-TODO"
+tracking_label = "WASM-TODO: distributed"
+
+[[feature]]
 id = "crypto-random"
 enum_variant = "CryptoRandom"
 label = "`std::crypto::crypto.random_bytes`"
@@ -419,7 +432,7 @@ tracking_label = "Note below"
 note = "Basic generator syntax and the cooperative scheduler do work on Tier 2. Generators that depend on blocking I/O (e.g. a generator that calls `stream.next()` internally) encounter the Streams reject at the point of the stream call, not at the generator declaration itself. Purely computational generators work on WASM unchanged."
 
 # ---------------------------------------------------------------------------
-# WASM-TODO backlog (15 rows; mirror of the backlog table).
+# WASM-TODO backlog (16 rows; mirror of the backlog table).
 # ---------------------------------------------------------------------------
 
 [[backlog]]
@@ -493,6 +506,12 @@ id = "process-execution"
 gap = "Process execution parity"
 blocker = "Explicit host capability model for subprocesses"
 tracking_label = "WASM-TODO: process-execution"
+
+[[backlog]]
+id = "distributed"
+gap = "Distributed node API / remote-actor messaging parity"
+blocker = "wasm peer transport for the `Node::*` cluster API and `RemotePid` routing (`hew_node_api_*` is native-only)"
+tracking_label = "WASM-TODO: distributed"
 
 [[backlog]]
 id = "supervision"


### PR DESCRIPTION
## Old failure mode
Node::* + RemotePid tell/ask admitted on wasm32 → codegen emits a module importing undefined env::hew_node_api_* → traps at instantiation (admit-then-abort).
## Invariant (totality at boundary)
Reject the Node:: namespace + remote messaging AT CHECK on wasm32 (new WasmUnsupportedFeature::Distributed), mirroring net/quic/tls. Never emit broken imports.
## Verification
9 unit (6 wasm-reject + 3 native-parity) both triples; vertical-slice reject fixture; sandbox-parity 2/2+5/5; capability-matrix row. clippy/fmt clean; flake 3/3.
## Out of scope
Native unchanged.