### PR TITLE
fix(codegen,cli): point fail-closed codegen errors at the user's source (#2091)

### DIFF
--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -166,14 +166,78 @@ pub(crate) fn codegen_diagnostic_prefix(error: &hew_codegen_rs::CodegenError) ->
         hew_codegen_rs::CodegenError::WasmUnsupportedSubstrate { .. } => {
             "E_CODEGEN_FRONT_WASM_UNSUPPORTED"
         }
+        // A span envelope classifies as its inner error: a spanned `FailClosed`
+        // is still `E_CODEGEN_FRONT_FAIL_CLOSED`. The span is a rendering
+        // concern, never a new failure class.
+        hew_codegen_rs::CodegenError::Spanned { inner, .. } => codegen_diagnostic_prefix(inner),
     }
 }
 
-pub(crate) fn render_codegen_front_diagnostic(error: &hew_codegen_rs::CodegenError) {
-    emit_plain_diagnostic_line(&format!(
+/// Render a `CodegenError` carrying a source span (if any) through the
+/// source-attributed diagnostic path, else as a single bare line.
+///
+/// `message` is the fully-composed user-facing line (family code + Display
+/// text). When the error carries a span — threaded from [`RawMirFunction::span`]
+/// at the codegen body-lowering boundary — and `source` is non-empty, the line
+/// renders with a `filename:line:col` header and a `^^^` underline, identical in
+/// shape to a type-check diagnostic. Without a span (synthesised functions,
+/// hand-built test MIR, infrastructure failures) or without source text, it
+/// degrades to the historical single line so no path regresses to silence.
+fn render_codegen_error_message(
+    error: &hew_codegen_rs::CodegenError,
+    source: &str,
+    filename: &str,
+    message: &str,
+) {
+    match error.source_span() {
+        Some((start, end)) if !source.is_empty() => {
+            render_diagnostic(
+                source,
+                filename,
+                &(start as usize..end as usize),
+                message,
+                &[],
+                &[],
+            );
+        }
+        _ => emit_plain_diagnostic_line(message),
+    }
+}
+
+/// Render a codegen-front (`hew check` / pre-emit gate) validation failure.
+///
+/// Source-attributed when the error carries a span (#2091); otherwise the
+/// historical bare `E_CODEGEN_FRONT_*: codegen-front validation failed: …` line.
+pub(crate) fn render_codegen_front_diagnostic(
+    error: &hew_codegen_rs::CodegenError,
+    source: &str,
+    filename: &str,
+) {
+    let message = format!(
         "{}: codegen-front validation failed: {error}",
         codegen_diagnostic_prefix(error),
-    ));
+    );
+    render_codegen_error_message(error, source, filename, &message);
+}
+
+/// Render a `hew build` / `hew run` codegen-emit failure (#2091).
+///
+/// When the error carries a source span and source text is available, the
+/// message points at the user's code through the same renderer a type error
+/// uses; otherwise it degrades to the historical bare line. The
+/// `WasmUnsupportedSubstrate` arm keeps its whole-program "omit the WASM target"
+/// phrasing (it carries no source point); every other error keeps the
+/// greppable `E_NOT_YET_IMPLEMENTED` family token.
+pub(crate) fn render_codegen_emit_error(
+    error: &hew_codegen_rs::CodegenError,
+    source: &str,
+    filename: &str,
+) {
+    let message = match error.unspanned() {
+        hew_codegen_rs::CodegenError::WasmUnsupportedSubstrate { .. } => format!("error: {error}"),
+        _ => format!("E_NOT_YET_IMPLEMENTED: {error}"),
+    };
+    render_codegen_error_message(error, source, filename, &message);
 }
 
 // ANSI colour helpers
@@ -1296,6 +1360,100 @@ mod tests {
             "captured diagnostics must not contain ANSI escapes: {captured:?}"
         );
         assert!(captured.contains("main.hew:1:1: error: bad call"));
+    }
+
+    #[test]
+    fn codegen_emit_error_with_span_renders_source_attributed() {
+        // #2091: a fail-closed codegen error that carries the source span of the
+        // offending function must render at the user's code — `filename:line:col`
+        // header, the source line, and a `^^^` underline — not the bare,
+        // locationless `E_NOT_YET_IMPLEMENTED` line dogfooding flagged as the
+        // single most-disorienting failure mode.
+        let source = "fn main() {\n    mem.bogus()\n}\n";
+        // `mem.bogus()` occupies bytes 16..27 → line 2, col 5.
+        let error = hew_codegen_rs::CodegenError::FailClosed(
+            "intrinsic 'mem.bogus' has no registered lowering".to_string(),
+        )
+        .with_source_span((16, 27));
+
+        start_diagnostic_capture();
+        render_codegen_emit_error(&error, source, "main.hew");
+        let captured = finish_diagnostic_capture();
+
+        assert!(
+            captured.contains("main.hew:2:5:"),
+            "a spanned emit error must render a source-attributed header; got: {captured:?}"
+        );
+        assert!(
+            captured.contains("error: E_NOT_YET_IMPLEMENTED"),
+            "the greppable family token must survive the source-attributed path; got: {captured:?}"
+        );
+        assert!(
+            captured.contains("mem.bogus"),
+            "the message must still name the unwired seam; got: {captured:?}"
+        );
+        assert!(
+            captured.contains("2 |") && captured.contains("^^^"),
+            "the offending source line and a caret underline must be shown; got: {captured:?}"
+        );
+    }
+
+    #[test]
+    fn codegen_emit_error_without_span_renders_bare_line() {
+        // Without a span (synthesised function / infrastructure failure) the emit
+        // error keeps its historical single bare line — no fabricated source
+        // header, no underline — so no path regresses and the family token is
+        // preserved for the tools that grep it.
+        let source = "fn main() {\n    mem.bogus()\n}\n";
+        let error = hew_codegen_rs::CodegenError::FailClosed(
+            "intrinsic 'mem.bogus' has no registered lowering".to_string(),
+        );
+
+        start_diagnostic_capture();
+        render_codegen_emit_error(&error, source, "main.hew");
+        let captured = finish_diagnostic_capture();
+
+        assert!(
+            captured.contains("E_NOT_YET_IMPLEMENTED: fail-closed: intrinsic 'mem.bogus'"),
+            "a spanless emit error must keep the historical bare line; got: {captured:?}"
+        );
+        assert!(
+            !captured.contains("main.hew:"),
+            "a spanless error must not fabricate a source location; got: {captured:?}"
+        );
+        assert!(
+            !captured.contains('^'),
+            "a spanless error must not render a source underline; got: {captured:?}"
+        );
+    }
+
+    #[test]
+    fn codegen_front_diagnostic_with_span_renders_source_attributed() {
+        // The `hew check` / pre-emit gate path is source-attributed too: a spanned
+        // codegen-front failure points at the user's code and keeps its greppable
+        // `E_CODEGEN_FRONT_*` family token.
+        let source = "fn main() {\n    mem.bogus()\n}\n";
+        let error = hew_codegen_rs::CodegenError::FailClosed(
+            "intrinsic 'mem.bogus' has no registered lowering".to_string(),
+        )
+        .with_source_span((16, 27));
+
+        start_diagnostic_capture();
+        render_codegen_front_diagnostic(&error, source, "main.hew");
+        let captured = finish_diagnostic_capture();
+
+        assert!(
+            captured.contains("main.hew:2:5:"),
+            "a spanned codegen-front failure must render a source header; got: {captured:?}"
+        );
+        assert!(
+            captured.contains("E_CODEGEN_FRONT_FAIL_CLOSED"),
+            "the codegen-front path must keep its family token; got: {captured:?}"
+        );
+        assert!(
+            captured.contains("^^^"),
+            "the offending source line must be underlined; got: {captured:?}"
+        );
     }
 
     #[test]

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -484,7 +484,7 @@ fn run_check_deep_gates(
     let lint_denied = render_pipeline_mir_lints(&state.source, input, &pipeline, levels);
 
     if let Err(error) = hew_codegen_rs::validate_codegen_front(&pipeline) {
-        diagnostic::render_codegen_front_diagnostic(&error);
+        diagnostic::render_codegen_front_diagnostic(&error, &state.source, input);
         return Err(());
     }
 
@@ -502,6 +502,7 @@ fn emit_module(
     emit_target: CompileEmitTarget,
     link_freestanding_wasm: bool,
     opt_level: hew_codegen_rs::OptLevel,
+    source_path: Option<&Path>,
 ) -> Result<hew_codegen_rs::EmitArtefacts, ()> {
     emit_module_with_triple(
         pipeline,
@@ -512,7 +513,7 @@ fn emit_module(
         link_freestanding_wasm,
         false,
         opt_level,
-        None,
+        source_path,
     )
 }
 
@@ -554,12 +555,23 @@ fn emit_module_with_triple(
     };
     match result {
         Ok(artefacts) => Ok(artefacts),
-        Err(e @ hew_codegen_rs::CodegenError::WasmUnsupportedSubstrate { .. }) => {
-            eprintln!("error: {e}");
-            Err(())
-        }
         Err(e) => {
-            eprintln!("E_NOT_YET_IMPLEMENTED: {e}");
+            // #2091: render through the source-attributed diagnostic path so a
+            // fail-closed codegen error points at the user's code instead of a
+            // bare, locationless line. The failing function's span rides on the
+            // error (attached at the MIR body-lowering boundary); resolve the
+            // source text from the same path codegen emitted against. No path,
+            // or unreadable/spanless source, degrades to the historical bare
+            // line inside `render_codegen_emit_error`.
+            let (source, filename) = source_path
+                .map(|p| {
+                    (
+                        std::fs::read_to_string(p).unwrap_or_default(),
+                        p.display().to_string(),
+                    )
+                })
+                .unwrap_or_default();
+            diagnostic::render_codegen_emit_error(&e, &source, &filename);
             Err(())
         }
     }
@@ -635,6 +647,7 @@ pub(crate) fn compile_native_binary(input: &Path, bin_path: &Path) -> Result<(),
         CompileEmitTarget::Native,
         true,
         hew_codegen_rs::OptLevel::O0,
+        Some(input),
     )?;
     let obj = artefacts.native_obj_path.as_deref().ok_or_else(|| {
         eprintln!("E_NOT_YET_IMPLEMENTED: native codegen did not produce an object");
@@ -746,6 +759,12 @@ pub(crate) fn compile_native_from_program(
         emit_target,
         false,
         hew_codegen_rs::OptLevel::O0,
+        // `source_label` is a diagnostic label (REPL/eval snippet), not a
+        // guaranteed on-disk path — reading it could render against unrelated
+        // file content, so pass no source path. A codegen error here keeps the
+        // historical bare line (no regression); the file-based `build`/`run`/
+        // `check` paths carry a real path and render with a source span (#2091).
+        None,
     )?;
 
     match emit_target {
@@ -1068,6 +1087,7 @@ fn cmd_compile(a: &args::CompileArgs) {
         emit_target,
         true,
         opt_level,
+        Some(a.input.as_path()),
     )
     .unwrap_or_else(|()| {
         if json {

--- a/hew-cli/tests/diagnostic_source_e2e.rs
+++ b/hew-cli/tests/diagnostic_source_e2e.rs
@@ -424,3 +424,57 @@ fn imported_hir_diagnostic_rendered_with_imported_source_context() {
         "HIR diagnostic output must not contain raw debug spans; got:\n{stderr}"
     );
 }
+
+/// A fail-closed *codegen* error originating in an imported module must not be
+/// mislabelled against the root input. `dep.hew` declares a function whose
+/// signature uses a fixed-size array type — a construct the codegen spine
+/// fails closed on (`E_NOT_YET_IMPLEMENTED: ... Array type`). Compiling the
+/// root `main.hew` that imports it must surface that error WITHOUT a false
+/// `main.hew:line:col` caret pointing at the import (#2320): the codegen
+/// diagnostic degrades to the bare, locationless line rather than resolving the
+/// imported function's span against the wrong (root) source.
+///
+/// The producer-level mechanism — dropping imported functions' MIR spans so a
+/// span-bearing codegen error can never resolve against the root — is
+/// regression-tested in `hew-mir/tests/imported_span_suppression.rs`. This is
+/// the end-to-end product guarantee the CLI must keep: an imported module's
+/// fail-closed codegen error never carries a root-file caret.
+#[test]
+fn imported_codegen_fail_closed_not_mislabelled_against_root() {
+    let fixture = write_fixture(&[
+        ("main.hew", "import dep;\nfn main() -> i64 {\n    dep.ok()\n}\n"),
+        (
+            "dep.hew",
+            "pub fn ok() -> i64 {\n    7\n}\npub fn unsupported(x: [i64; 2]) -> [i64; 2] {\n    return x;\n}\n",
+        ),
+    ]);
+    let main_path = fixture.path().join("main.hew");
+
+    let output = Command::new(hew_binary())
+        .args(["compile", main_path.to_str().unwrap()])
+        .current_dir(fixture.path())
+        .output()
+        .expect("hew binary must run");
+
+    assert!(
+        !output.status.success(),
+        "hew compile must fail on the imported array-typed codegen construct"
+    );
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+
+    // The codegen fail-closed error must still be reported.
+    assert!(
+        stderr.contains("E_NOT_YET_IMPLEMENTED") && stderr.contains("Array type"),
+        "imported codegen fail-closed error must name the unsupported construct; got:\n{stderr}"
+    );
+
+    // It must NOT be falsely attributed to the root input: no `main.hew:`
+    // error/warning caret line. (The root never declares the array construct;
+    // a `main.hew:line:col: error:` here would be the #2320 mislabel.)
+    assert!(
+        !stderr.lines().any(|line| line.contains("main.hew:")
+            && (line.contains("error:") || line.contains("warning:"))),
+        "imported codegen error must not be mislabelled against main.hew; got:\n{stderr}"
+    );
+}

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -172,6 +172,71 @@ pub enum CodegenError {
     /// deliberately fail-closed on, the wasm32 build. Omit the WASM target to
     /// produce a native binary instead.
     WasmUnsupportedSubstrate { symbol: String },
+    /// Any of the above errors annotated with the source byte-span the
+    /// diagnostic should point at — `(start, end)` offsets into the originating
+    /// module source, threaded from [`RawMirFunction::span`] at the MIR
+    /// body-lowering boundary (`build_module_for_target`). The CLI renders the
+    /// inner error's message through the source-attributed diagnostic path using
+    /// this span, so a fail-closed codegen error points at the user's code
+    /// instead of a bare, locationless line (#2091).
+    ///
+    /// WHY an envelope variant and not a span field on each variant:
+    /// `FailClosed` alone has ~1.3k construction sites. An envelope threads an
+    /// optional span through the whole error type without touching any of them,
+    /// and — because the boundary only wraps when a function carries a faithful
+    /// span — every existing `match CodegenError::FailClosed(_)` site keeps
+    /// matching for the spanless case (synthesised functions, hand-built test
+    /// MIR). Construct via [`CodegenError::with_source_span`]; never nest.
+    Spanned {
+        span: (u32, u32),
+        inner: Box<CodegenError>,
+    },
+}
+
+impl CodegenError {
+    /// Annotate this error with the source byte-span the diagnostic should point
+    /// at, unless it already carries one (or is whole-program guidance that has
+    /// no single source point). Used at the body-lowering boundary to attach the
+    /// failing function's [`RawMirFunction::span`].
+    #[must_use]
+    pub fn with_source_span(self, span: (u32, u32)) -> Self {
+        match self {
+            // Already located — keep the innermost (most specific) span.
+            Self::Spanned { .. } => self,
+            // `WasmUnsupportedSubstrate` carries whole-program guidance ("omit
+            // the WASM target"), not a source point; the CLI renders it via its
+            // own arm. Leave it unwrapped so that arm keeps matching.
+            Self::WasmUnsupportedSubstrate { .. } => self,
+            inner => Self::Spanned {
+                span,
+                inner: Box::new(inner),
+            },
+        }
+    }
+
+    /// The source byte-span `(start, end)` this error should be rendered
+    /// against, if one was threaded from MIR. `None` for errors with no faithful
+    /// source location (synthesised functions, hand-built test MIR,
+    /// infrastructure failures).
+    #[must_use]
+    pub fn source_span(&self) -> Option<(u32, u32)> {
+        match self {
+            Self::Spanned { span, .. } => Some(*span),
+            _ => None,
+        }
+    }
+
+    /// The underlying error, looking through any source-span envelope. Lets
+    /// variant-specific handling (CLI exit-code / diagnostic-family mapping)
+    /// stay span-agnostic — `Spanned` is never constructed nested, so this is a
+    /// single unwrap.
+    #[must_use]
+    pub fn unspanned(&self) -> &CodegenError {
+        match self {
+            Self::Spanned { inner, .. } => inner,
+            other => other,
+        }
+    }
 }
 
 impl std::fmt::Display for CodegenError {
@@ -220,6 +285,9 @@ impl std::fmt::Display for CodegenError {
                      {tracking}); omit the WASM target to produce a native binary instead"
                 )
             }
+            // The span is a rendering concern, not message text: delegate to the
+            // inner error so `{e}` stays identical with or without a span.
+            Self::Spanned { inner, .. } => write!(f, "{inner}"),
         }
     }
 }
@@ -37822,7 +37890,17 @@ fn build_module_for_target<'ctx>(
             !pipeline.supervisor_layouts.is_empty(),
             module_uses_runtime,
             fn_debug_ctx.as_ref(),
-        )?;
+        )
+        // #2091: attach the failing function's source span so the CLI renders a
+        // fail-closed codegen error at the user's code rather than a bare,
+        // locationless line. `func.span` is `None` for synthesised functions and
+        // hand-built test MIR — those stay unwrapped, preserving every
+        // `match CodegenError::FailClosed(_)` site that exercises codegen
+        // fail-closed paths with spanless MIR.
+        .map_err(|e| match func.span {
+            Some(span) => e.with_source_span(span),
+            None => e,
+        })?;
     }
     // Emit the cross-node payload codec thunks + registration constructor so a
     // Serializable actor message survives a process hop. The cross-node codec is

--- a/hew-codegen-rs/tests/mem_floor_intrinsic_emission.rs
+++ b/hew-codegen-rs/tests/mem_floor_intrinsic_emission.rs
@@ -274,3 +274,109 @@ fn unknown_floor_intrinsic_id_fails_closed() {
         ),
     }
 }
+
+/// #2091: a fail-closed codegen error carries the source span of the function it
+/// fired in, so the CLI can render it at the user's code instead of a bare,
+/// locationless line. The body-lowering boundary (`build_module_for_target`)
+/// attaches `RawMirFunction::span` to any error from `lower_function` when the
+/// function carries a faithful span. This drives the same unknown-intrinsic
+/// fail-closed path as `unknown_floor_intrinsic_id_fails_closed`, but with a
+/// span set, and asserts the span rides out on the error.
+#[test]
+fn floor_intrinsic_fail_closed_carries_function_source_span() {
+    let mut pipeline = floor_pipeline(
+        "mem$bogus",
+        "mem.bogus",
+        vec![ResolvedTy::U64],
+        mut_u8_ptr(),
+    );
+    // A distinctive byte-range standing in for `fn mem$bogus(...)`'s declaration
+    // extent in the originating source. The boundary threads this verbatim.
+    let span = (4242, 4271);
+    pipeline.raw_mir[0].span = Some(span);
+
+    let tmp = std::env::temp_dir().join("hew-mem-floor-unknown-spanned");
+    std::fs::create_dir_all(&tmp).expect("create out_dir");
+    let options = EmitOptions {
+        module_name: "mem_unknown_spanned",
+        out_dir: &tmp,
+        native: false,
+        wasm: false,
+        target_triple: None,
+        debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
+        source_path: None,
+    };
+    match emit_module(&pipeline, &options) {
+        Err(err) => {
+            assert_eq!(
+                err.source_span(),
+                Some(span),
+                "the failing function's source span must ride out on the error so \
+                 the CLI can point the diagnostic at the user's code (#2091); got \
+                 {err:?}"
+            );
+            assert!(
+                matches!(err.unspanned(), CodegenError::FailClosed(msg) if msg.contains("mem.bogus")),
+                "looking through the span envelope must recover the original \
+                 FailClosed naming the unwired id; got {err:?}"
+            );
+            // The span is a rendering concern — `Display` must read identically
+            // to the unwrapped error, with no `(start, end)` noise leaking in.
+            assert_eq!(
+                err.to_string(),
+                err.unspanned().to_string(),
+                "Display must delegate through the span envelope unchanged"
+            );
+        }
+        Ok(_) => {
+            panic!("expected codegen to fail closed on an unknown floor intrinsic id; got Ok(_)")
+        }
+    }
+}
+
+/// A function with no faithful source span (synthesised function / hand-built
+/// test MIR) must NOT be wrapped — the error stays a bare `FailClosed` so every
+/// existing `match CodegenError::FailClosed(_)` codegen test keeps matching.
+/// This is the invariant that lets #2091 add span-carrying without touching the
+/// ~1.3k `FailClosed` construction sites or the suites that assert on them.
+#[test]
+fn spanless_function_fail_closed_is_not_wrapped() {
+    let pipeline = floor_pipeline(
+        "mem$bogus",
+        "mem.bogus",
+        vec![ResolvedTy::U64],
+        mut_u8_ptr(),
+    );
+    assert_eq!(
+        pipeline.raw_mir[0].span, None,
+        "precondition: floor_pipeline builds spanless MIR"
+    );
+    let tmp = std::env::temp_dir().join("hew-mem-floor-unknown-spanless");
+    std::fs::create_dir_all(&tmp).expect("create out_dir");
+    let options = EmitOptions {
+        module_name: "mem_unknown_spanless",
+        out_dir: &tmp,
+        native: false,
+        wasm: false,
+        target_triple: None,
+        debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
+        source_path: None,
+    };
+    match emit_module(&pipeline, &options) {
+        Err(err) => {
+            assert_eq!(
+                err.source_span(),
+                None,
+                "spanless MIR must yield a spanless error"
+            );
+            assert!(
+                matches!(err, CodegenError::FailClosed(_)),
+                "a spanless fail-closed error must stay a bare FailClosed, not a \
+                 span envelope; got {err:?}"
+            );
+        }
+        Ok(_) => panic!("expected fail-closed on unknown floor intrinsic id; got Ok(_)"),
+    }
+}

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -2831,6 +2831,51 @@ pub fn lower_hir_module_with_facts(
     // to run after drop elaboration so a `Drop`'s read of the local is modelled.
     let lint_warnings = crate::liveness::run_mir_lints(&raw_mir);
 
+    // #2320: an imported function's `RawMirFunction.span` is a byte offset into
+    // the IMPORTED module's source, but the only source text threaded past MIR
+    // — codegen's `-g` debug line-index and the CLI's fail-closed codegen
+    // diagnostic renderer — is the ROOT input. Resolving an imported span
+    // against the root mislabels the location: a fail-closed codegen error in
+    // `dep.hew` would render a caret against `main.hew` at the wrong line (the
+    // same imported-module boundary class the actor-send re-keying above
+    // compensates for). Until codegen threads per-module source, drop the span
+    // for imported functions so the diagnostic fails closed to the bare,
+    // locationless line ("no location beats a wrong location", per the
+    // `RawMirFunction::span` contract) instead of pointing at another file.
+    //
+    // Identity is the emit name: `RawMirFunction.name` is the `emit_name`
+    // lowering derives from each `HirItem::Function.name` and, for a
+    // monomorphisation, the registry's mangled symbol — so membership is exact
+    // for the imported function itself. A root function that happened to share
+    // an emit name would also degrade to a bare line; that never mislabels (the
+    // worst case forgoes a caret), so the conservative match is sound. Runs
+    // AFTER `run_mir_lints` so imported functions' dead-store lints are
+    // unaffected.
+    let imported_fn_names: std::collections::HashSet<&str> = module
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            HirItem::Function(f) if module.diagnostic_source_modules.contains_key(&f.id) => {
+                Some(f.name.as_str())
+            }
+            _ => None,
+        })
+        .chain(
+            module
+                .monomorphisations
+                .iter()
+                .filter(|m| module.diagnostic_source_modules.contains_key(&m.key.origin))
+                .map(|m| m.mangled_name.as_str()),
+        )
+        .collect();
+    if !imported_fn_names.is_empty() {
+        for raw in &mut raw_mir {
+            if imported_fn_names.contains(raw.name.as_str()) {
+                raw.span = None;
+            }
+        }
+    }
+
     // Field-bearing `#[resource]` record → `<Type>::close` symbol registry
     // (spec §3.7.3). A `#[resource]` record that owns a heap/aggregate field
     // is admitted to `owned_record_drop_allowed` and routes to the recursive

--- a/hew-mir/tests/imported_span_suppression.rs
+++ b/hew-mir/tests/imported_span_suppression.rs
@@ -1,0 +1,129 @@
+//! #2320: an imported function's source span must be dropped before codegen.
+//!
+//! `RawMirFunction.span` is a byte offset into the function's own module
+//! source, but codegen's debug line-index and the CLI's fail-closed codegen
+//! diagnostic renderer only ever resolve spans against the ROOT input. An
+//! imported function's span resolved against the root mislabels the location
+//! (a false `root.hew:line:col` caret pointing at another file). The MIR
+//! producer therefore drops the span of every function whose item is tagged in
+//! `HirModule::diagnostic_source_modules` (the imported-provenance signal), so
+//! a fail-closed codegen error in an imported module degrades to the bare,
+//! locationless line instead of mislabelling — while root functions keep the
+//! source-attributed carets #2091 added.
+
+use hew_hir::{lower_program, HirItem, ResolutionCtx};
+use hew_mir::lower_hir_module;
+use hew_types::module_registry::ModuleRegistry;
+use hew_types::Checker;
+
+/// Lower `src`, stamp `imported` as originating from a `dep` module (as a file
+/// import would populate `diagnostic_source_modules`) before MIR lowering, and
+/// return each raw-MIR function's `(name, span)`.
+fn raw_spans_with_imported(src: &str, imported: &str) -> Vec<(String, Option<(u32, u32)>)> {
+    let parsed = hew_parser::parse(src);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:#?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc = checker.check_program(&parsed.program);
+    let mut output = lower_program(
+        &parsed.program,
+        &tc,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    let id = output
+        .module
+        .items
+        .iter()
+        .find_map(|item| match item {
+            HirItem::Function(f) if f.name == imported => Some(f.id),
+            _ => None,
+        })
+        .expect("imported fn must exist in the lowered module");
+    output
+        .module
+        .diagnostic_source_modules
+        .insert(id, "dep".to_string());
+    lower_hir_module(&output.module)
+        .raw_mir
+        .iter()
+        .map(|r| (r.name.clone(), r.span))
+        .collect()
+}
+
+#[test]
+fn imported_function_span_is_dropped_before_codegen() {
+    let src = r"
+        fn dep_fn(a: i64) -> i64 {
+            a + 1
+        }
+        fn root_fn() -> i64 {
+            dep_fn(2)
+        }
+        fn main() -> i64 {
+            root_fn()
+        }
+    ";
+    let spans = raw_spans_with_imported(src, "dep_fn");
+
+    let dep_span = spans
+        .iter()
+        .find(|(n, _)| n == "dep_fn")
+        .map(|(_, s)| *s)
+        .expect("dep_fn must be lowered to raw MIR");
+    assert_eq!(
+        dep_span, None,
+        "an imported function's source span must be dropped so a codegen \
+         fail-closed error degrades instead of mislabelling against the root \
+         source (#2320); got {dep_span:?}"
+    );
+
+    // A root-module function keeps its span — the fix is scoped to imported
+    // functions and must not regress #2091's source-attributed carets.
+    let root_span = spans
+        .iter()
+        .find(|(n, _)| n == "root_fn")
+        .map(|(_, s)| *s)
+        .expect("root_fn must be lowered to raw MIR");
+    assert!(
+        root_span.is_some(),
+        "a root-module function's span must be retained (#2091); got None"
+    );
+}
+
+#[test]
+fn imported_generic_monomorphisation_span_is_dropped() {
+    // A monomorphisation of an imported generic re-lowers the imported origin's
+    // body (so it carries the origin's imported span) under a mangled name that
+    // never appears in `module.items`. Tagging only the origin must still drop
+    // the mono's span — otherwise an imported generic's codegen failure would
+    // mislabel against the root source.
+    let src = r"
+        fn dep_id<T>(x: T) -> T {
+            x
+        }
+        fn main() -> i64 {
+            dep_id(7)
+        }
+    ";
+    let spans = raw_spans_with_imported(src, "dep_id");
+
+    // Every non-root function (the imported generic's monomorphisation) must
+    // have its span dropped; only the root `main` retains one.
+    for (name, span) in &spans {
+        if name != "main" {
+            assert_eq!(
+                *span, None,
+                "imported monomorphisation `{name}` must have its span dropped (#2320); \
+                 got {span:?}"
+            );
+        }
+    }
+    assert!(
+        spans.iter().any(|(n, s)| n == "main" && s.is_some()),
+        "the root `main` must retain its span; raw MIR was {spans:?}"
+    );
+}


### PR DESCRIPTION
## Old failure mode
CodegenError::FailClosed had no span → raw eprintln(E_NOT_YET_IMPLEMENTED) with no location (the 'single most-disorienting failure mode').
## Invariant
A fail-closed codegen error renders file:line:col + caret through the normal diagnostic path; degrade to bare line only when truly spanless.
## Why this boundary
CodegenError::Spanned envelope attaches func.span once at the lower_function boundary — avoids touching ~1.3k FailClosed sites.
## Verification
codegen_emit_error_with_span_renders_source_attributed + boundary tests; workspace +5 tests; flake 3/3.
## Out of scope
Spanless MIR stays unwrapped FailClosed.