### PR TITLE
refactor(codegen,mir): retire CBOR heap walker onto the single ownership authority

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -40132,60 +40132,159 @@ fn json_string_literal(s: &str) -> String {
     out
 }
 
-/// Standalone heap-ownership probe for a CBOR Vec element type, using only the
-/// pipeline record/enum layouts the thunk emitter has on hand (no `FnCtx`).
-/// Returns true when `ty` is — or transitively contains — a heap-owning leaf
-/// (string / bytes / collection / boxed handle): a value a plain BitCopy Vec
-/// slot could not own without leaking. A `visiting` set breaks layout cycles
-/// (recursive records/enums) by treating a back-edge as non-owning — the
-/// cycle's owning leaves, if any, are already seen on the first visit.
+/// [`hew_mir::HeapOwnershipLayouts`] view over the standalone pipeline
+/// record/enum layout slices the CBOR thunk emitter carries (it has no
+/// `FnCtx`). Resolves user record / enum members through [`xnode_registry_key`]
+/// — the SAME registry-key strategy the retired `cbor_ty_owns_heap` walker used
+/// — so routing the CBOR element heap-ownership probe through the single
+/// `hew_mir::ty_owns_heap` authority is byte-identical for every shape the old
+/// walker classified, while inheriting the authority's correct leaf set. This
+/// is the CBOR sibling of [`CgHeapLayouts`] (which resolves the same members
+/// through a live `FnCtx`).
+struct CborHeapLayouts<'a> {
+    pipeline_records: &'a [RecordLayout],
+    enum_layouts: &'a [EnumLayout],
+}
+
+impl hew_mir::HeapOwnershipLayouts for CborHeapLayouts<'_> {
+    fn record_field_tys(&self, name: &str, args: &[ResolvedTy]) -> Option<Vec<ResolvedTy>> {
+        let key = xnode_registry_key(name, args, self.pipeline_records, self.enum_layouts);
+        self.pipeline_records
+            .iter()
+            .find(|r| r.name == key)
+            .map(|r| r.field_tys.clone())
+    }
+
+    fn enum_variant_field_tys(
+        &self,
+        name: &str,
+        args: &[ResolvedTy],
+    ) -> Option<Vec<Vec<ResolvedTy>>> {
+        let key = xnode_registry_key(name, args, self.pipeline_records, self.enum_layouts);
+        self.enum_layouts
+            .iter()
+            .find(|e| e.name == key)
+            .map(|e| e.variants.iter().map(|v| v.field_tys.clone()).collect())
+    }
+}
+
+/// RETIRED parallel heap walker (ownership/drop/ABI unification) —
+/// superseded by the single `hew_mir::ty_owns_heap` authority. It now delegates
+/// straight to that authority via [`CborHeapLayouts`]; it is retained ONLY as
+/// the sealed seam its sole sanctioned caller ([`cbor_vec_elem_kind`]) routes
+/// through. New code must call `hew_mir::ty_owns_heap` directly.
+///
+/// GUARD: the `#[deprecated]` seal plus the workspace
+/// `cargo clippy --workspace --tests -- -D warnings` CI step
+/// (`.github/workflows/ci.yml`) is the re-entry tripwire — any NEW caller is a
+/// hard CI failure unless it is explicitly `#[allow(deprecated)]`-listed (the
+/// allow-list). `-D deprecated` is implied by `-D warnings`, and the lint fires
+/// for same-crate callers, so no new test plumbing is needed.
+///
+/// Behaviour vs the retired walker (every delta is leak-SAFER, never a new
+/// leak): the old walker's `_ => false` arm BitCopied a heap-owning element
+/// when it was a `CancellationToken` (own variant) or hid behind a
+/// tuple/array/slice record field — a latent under-drop the authority's leaf
+/// set / structural recursion correctly fails closed. Those shapes are
+/// currently unreachable (they fail closed upstream at the clone-helper /
+/// wire-body floor), so this is a consistency hardening, not an observable
+/// change. The old walker's coarse `_ => true` over-defer for non-`Option`
+/// builtins is preserved at the caller (see [`cbor_vec_elem_kind`]), so
+/// reachable behaviour is byte-identical.
+#[deprecated(
+    note = "retired parallel heap walker — call `hew_mir::ty_owns_heap` (the single \
+            ownership authority) directly; this shim exists only as the sealed, \
+            allow-listed seam its sole caller routes through"
+)]
 fn cbor_ty_owns_heap(
+    ty: &ResolvedTy,
+    pipeline_records: &[RecordLayout],
+    enum_layouts: &[EnumLayout],
+) -> bool {
+    hew_mir::ty_owns_heap(
+        ty,
+        &CborHeapLayouts {
+            pipeline_records,
+            enum_layouts,
+        },
+    )
+}
+
+/// True when `ty` IS — or transitively contains, through type arguments, record
+/// fields, enum/machine variant payloads, or tuple/array elements — an *indirect
+/// enum*. An `indirect enum` value is a heap-owned pointer to a tagged-union
+/// struct (`EnumLayout::is_indirect`) even when every payload field is scalar, so
+/// each element must be released on drop and crosses the ABI by pointer.
+///
+/// The single `hew_mir::ty_owns_heap` authority resolves user types through the
+/// [`hew_mir::HeapOwnershipLayouts`] trait, which conveys only payload *field
+/// types* — not an enum's indirectness. Neither this path's [`CborHeapLayouts`]
+/// nor the `FnCtx`-backed [`CgHeapLayouts`] can signal indirectness through the
+/// authority, so an indirect enum with scalar payloads classifies
+/// `ty_owns_heap == false`. The CBOR element codec therefore detects it directly
+/// and fails closed — matching the pointer ABI the `Vec` constructor (indirect
+/// enum elements stored as `ptr`) and the CBOR decoder (`emit_de_enum_cbor`
+/// allocates and stores a heap node) already use — never BitCopying a heap-owned
+/// node. (The drop elaborator releases such values via `DropKind::IndirectEnum`,
+/// a path independent of `ty_owns_heap`, which is why this gap is CBOR-local.)
+///
+/// Resolution uses the SAME [`xnode_registry_key`] strategy as
+/// [`CborHeapLayouts`], so the layout whose `is_indirect` flag this reads is the
+/// exact layout the authority recursion walks.
+fn cbor_ty_contains_indirect_enum(
     ty: &ResolvedTy,
     pipeline_records: &[RecordLayout],
     enum_layouts: &[EnumLayout],
     visiting: &mut std::collections::HashSet<String>,
 ) -> bool {
     match ty {
-        ResolvedTy::String | ResolvedTy::Bytes => true,
-        ResolvedTy::Named {
-            builtin: Some(b),
-            args,
-            ..
-        } => match b {
-            // An `Option` is inline (tag + payload); it owns heap iff its
-            // payload does.
-            BuiltinType::Option => args
-                .first()
-                .is_some_and(|a| cbor_ty_owns_heap(a, pipeline_records, enum_layouts, visiting)),
-            // Every other builtin admitted as a field is a heap handle.
-            _ => true,
-        },
         ResolvedTy::Named { name, args, .. } => {
+            // Type arguments first (`Option<indirect enum>`, `Rc<…>`, …).
+            if args.iter().any(|a| {
+                cbor_ty_contains_indirect_enum(a, pipeline_records, enum_layouts, visiting)
+            }) {
+                return true;
+            }
             let key = xnode_registry_key(name, args, pipeline_records, enum_layouts);
+            // An indirect enum is heap-owned irrespective of its payload field
+            // types — check before the recursion guard so a re-encounter on a
+            // cyclic type still reports it.
+            if enum_layouts.iter().any(|e| e.name == key && e.is_indirect) {
+                return true;
+            }
             if !visiting.insert(key.clone()) {
+                // Already walking this type: its own indirectness was checked on
+                // first entry; break to keep the field recursion bounded.
                 return false;
             }
-            if let Some(rl) = pipeline_records.iter().find(|r| r.name == key) {
-                return rl
-                    .field_tys
-                    .iter()
-                    .any(|f| cbor_ty_owns_heap(f, pipeline_records, enum_layouts, visiting));
-            }
-            if let Some(el) = enum_layouts.iter().find(|e| e.name == key) {
-                return el.variants.iter().any(|v| {
-                    v.field_tys
-                        .iter()
-                        .any(|f| cbor_ty_owns_heap(f, pipeline_records, enum_layouts, visiting))
-                });
-            }
-            false
+            let found = if let Some(rl) = pipeline_records.iter().find(|r| r.name == key) {
+                rl.field_tys.iter().any(|f| {
+                    cbor_ty_contains_indirect_enum(f, pipeline_records, enum_layouts, visiting)
+                })
+            } else if let Some(el) = enum_layouts.iter().find(|e| e.name == key) {
+                el.variants.iter().any(|v| {
+                    v.field_tys.iter().any(|f| {
+                        cbor_ty_contains_indirect_enum(f, pipeline_records, enum_layouts, visiting)
+                    })
+                })
+            } else {
+                false
+            };
+            visiting.remove(&key);
+            found
+        }
+        ResolvedTy::Tuple(elems) => elems
+            .iter()
+            .any(|e| cbor_ty_contains_indirect_enum(e, pipeline_records, enum_layouts, visiting)),
+        ResolvedTy::Array(inner, _) | ResolvedTy::Slice(inner) => {
+            cbor_ty_contains_indirect_enum(inner, pipeline_records, enum_layouts, visiting)
         }
         _ => false,
     }
 }
 
 /// Backing-store kind a decoded CBOR array needs for its element type.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum CborVecElemKind {
     /// Scalar BitCopy element (bool / int / float / char / duration): a plain
     /// `hew_vec_new_with_elem_size` buffer filled by byte-copy
@@ -40238,16 +40337,41 @@ fn cbor_vec_elem_kind(
         | ResolvedTy::F32
         | ResolvedTy::F64 => CborVecElemKind::Plain,
         ResolvedTy::String => CborVecElemKind::Str,
+        // Non-`Option` builtins (`Vec` / `HashMap` / `HashSet` / `Generator` /
+        // `Result` / `Range` / `Rc` / …) need the owned (thunk-bearing) Vec ABI
+        // the standalone codec cannot synthesise: fail closed. This preserves the
+        // retired `cbor_ty_owns_heap` walker's coarse `_ => true` builtin rule
+        // EXACTLY. The single authority's finer arg-recursion (which would admit
+        // a heap-free `Result<i64, i64>` as BitCopy) is intentionally NOT applied
+        // here: enabling those element shapes needs matching codec support and is
+        // deferred to a future consolidation, so reachable behaviour stays byte-identical.
+        ResolvedTy::Named {
+            builtin: Some(b), ..
+        } if !matches!(b, BuiltinType::Option) => CborVecElemKind::Defer,
+        // `Option<T>` and user record / enum elements: route the heap-ownership
+        // question through the single `hew_mir::ty_owns_heap` authority (was the
+        // parallel `cbor_ty_owns_heap` walker). A heap-owning element needs the
+        // owned (thunk-bearing) Vec ABI the standalone codec cannot synthesise →
+        // fail closed; a heap-free record/enum element is the layout-aware
+        // BitCopy vec `Vec::new` constructs (`hew_vec_new_with_layout`), so the
+        // codec MUST round-trip it through the layout-aware accessors.
         ResolvedTy::Named { .. } => {
+            // SEALED retired-walker seam: the sole sanctioned caller.
+            #[allow(deprecated)]
+            let owns_heap = cbor_ty_owns_heap(elem, pipeline_records, enum_layouts);
+            // The single authority sees only enum payload *field types* through
+            // the layout adapter, not an enum's indirectness, so an indirect enum
+            // with scalar payloads classifies `owns_heap == false`. Such an
+            // element is nonetheless a heap-owned pointer — the `Vec` constructor
+            // and the CBOR decoder both use pointer ABI for it — so fail closed
+            // for any element that IS or transitively contains one, never
+            // BitCopying a heap-owned node.
             let mut visiting = std::collections::HashSet::new();
-            if cbor_ty_owns_heap(elem, pipeline_records, enum_layouts, &mut visiting) {
-                // A heap-owning record/enum needs the owned (thunk-bearing) Vec
-                // ABI the standalone codec cannot synthesise: fail closed.
+            let contains_indirect_enum =
+                cbor_ty_contains_indirect_enum(elem, pipeline_records, enum_layouts, &mut visiting);
+            if owns_heap || contains_indirect_enum {
                 CborVecElemKind::Defer
             } else {
-                // A heap-free record/enum element: `Vec::new` constructs this as
-                // a layout-aware BitCopy vec (`hew_vec_new_with_layout`), so the
-                // codec MUST round-trip it through the layout-aware accessors.
                 CborVecElemKind::LayoutBitCopy
             }
         }
@@ -47566,6 +47690,235 @@ mod tests {
         assert!(
             is_known_cow_heap_drop_symbol("hew_vec_free_closure_pairs"),
             "hew_vec_free_closure_pairs must be in the permitted CowHeap release set"
+        );
+    }
+
+    /// Pin `cbor_vec_elem_kind` over every REACHABLE element shape so the
+    /// retire of the parallel `cbor_ty_owns_heap` walker (now a sealed
+    /// shim over `hew_mir::ty_owns_heap`) is byte-identical: scalars stay
+    /// `Plain`, `string` stays `Str`, a heap-free user record stays
+    /// `LayoutBitCopy` (the `Vec<#[wire] struct>` shape), a heap-owning record
+    /// stays `Defer`, `Option<T>` mirrors its payload, and every non-`Option`
+    /// builtin stays `Defer` (the retired walker's coarse `_ => true` rule,
+    /// preserved at the caller rather than routed through the finer authority).
+    #[test]
+    fn cbor_vec_elem_kind_pins_reachable_classification() {
+        let no_recs: Vec<RecordLayout> = vec![];
+        let no_enums: Vec<EnumLayout> = vec![];
+
+        // Scalars → Plain (generic, null-layout vec).
+        for s in [
+            ResolvedTy::I64,
+            ResolvedTy::U8,
+            ResolvedTy::Bool,
+            ResolvedTy::F64,
+            ResolvedTy::Char,
+            ResolvedTy::Duration,
+        ] {
+            assert_eq!(
+                cbor_vec_elem_kind(&s, &no_recs, &no_enums),
+                CborVecElemKind::Plain,
+                "{s:?} must be a Plain element"
+            );
+        }
+        // `string` → Str.
+        assert_eq!(
+            cbor_vec_elem_kind(&ResolvedTy::String, &no_recs, &no_enums),
+            CborVecElemKind::Str
+        );
+
+        // A heap-free user record → LayoutBitCopy (the `Vec<Inner>` wire shape).
+        let inner = RecordLayout {
+            name: "Inner".to_string(),
+            field_tys: vec![ResolvedTy::I64],
+            field_names: vec!["v".to_string()],
+        };
+        assert_eq!(
+            cbor_vec_elem_kind(
+                &ResolvedTy::named_user("Inner", vec![]),
+                &[inner],
+                &no_enums
+            ),
+            CborVecElemKind::LayoutBitCopy,
+            "a heap-free record element is the layout-aware BitCopy vec `Vec::new` builds"
+        );
+        // A heap-OWNING user record (a `string` field) → Defer.
+        let owns = RecordLayout {
+            name: "Owns".to_string(),
+            field_tys: vec![ResolvedTy::String],
+            field_names: vec!["s".to_string()],
+        };
+        assert_eq!(
+            cbor_vec_elem_kind(&ResolvedTy::named_user("Owns", vec![]), &[owns], &no_enums),
+            CborVecElemKind::Defer,
+            "a string-bearing record element needs the owned Vec ABI → fail closed"
+        );
+
+        // `Option<scalar>` → LayoutBitCopy; `Option<string>` → Defer (the payload
+        // recursion, byte-identical to the retired walker's `Option` arm).
+        assert_eq!(
+            cbor_vec_elem_kind(
+                &ResolvedTy::named_builtin("Option", BuiltinType::Option, vec![ResolvedTy::I64]),
+                &no_recs,
+                &no_enums
+            ),
+            CborVecElemKind::LayoutBitCopy
+        );
+        assert_eq!(
+            cbor_vec_elem_kind(
+                &ResolvedTy::named_builtin("Option", BuiltinType::Option, vec![ResolvedTy::String]),
+                &no_recs,
+                &no_enums
+            ),
+            CborVecElemKind::Defer
+        );
+
+        // Non-`Option` builtins → Defer, preserving the retired walker's coarse
+        // rule. `Result<i64, i64>` is genuinely heap-free, yet stays Defer here
+        // (the authority's finer recursion that would admit it as BitCopy is
+        // deferred to a future consolidation, gated on matching codec support).
+        for b in [
+            ResolvedTy::named_builtin("Vec", BuiltinType::Vec, vec![ResolvedTy::I64]),
+            ResolvedTy::named_builtin(
+                "HashMap",
+                BuiltinType::HashMap,
+                vec![ResolvedTy::String, ResolvedTy::I64],
+            ),
+            ResolvedTy::named_builtin(
+                "Result",
+                BuiltinType::Result,
+                vec![ResolvedTy::I64, ResolvedTy::I64],
+            ),
+        ] {
+            assert_eq!(
+                cbor_vec_elem_kind(&b, &no_recs, &no_enums),
+                CborVecElemKind::Defer,
+                "{b:?} must fail closed (coarse non-Option builtin rule)"
+            );
+        }
+    }
+
+    /// G6: routing the CBOR element probe through the single
+    /// `hew_mir::ty_owns_heap` authority fixes a latent under-drop leak. A user
+    /// record whose field is a `CancellationToken` (an owned runtime handle) was
+    /// classified heap-FREE by the retired `cbor_ty_owns_heap` walker — its
+    /// `_ => false` arm did not recognise the `CancellationToken` own-variant —
+    /// so the codec BitCopied (and leaked) the handle as a `LayoutBitCopy`
+    /// element. The authority recognises `CancellationToken` as a leaf, so the
+    /// record owns heap and the codec correctly fails closed (`Defer`).
+    #[test]
+    fn cbor_retire_fixes_latent_cancellation_token_leak() {
+        let rec = RecordLayout {
+            name: "WithTok".to_string(),
+            field_tys: vec![ResolvedTy::CancellationToken],
+            field_names: vec!["tok".to_string()],
+        };
+        let no_enums: Vec<EnumLayout> = vec![];
+        assert_eq!(
+            cbor_vec_elem_kind(
+                &ResolvedTy::named_user("WithTok", vec![]),
+                &[rec],
+                &no_enums
+            ),
+            CborVecElemKind::Defer,
+            "a CancellationToken-bearing record element must fail closed, not BitCopy-leak the handle"
+        );
+    }
+
+    /// A CBOR `Vec` element that IS — or transitively contains — an `indirect
+    /// enum` must fail closed (`Defer`), never `LayoutBitCopy`. An indirect enum
+    /// with scalar payloads is a heap-owned pointer (the `Vec` constructor stores
+    /// it as `ptr`; the CBOR decoder allocates and stores a heap node), yet the
+    /// single `hew_mir::ty_owns_heap` authority sees only payload field types
+    /// through the layout adapter and so classifies it heap-FREE. The codec
+    /// detects indirectness directly (`cbor_ty_contains_indirect_enum`) and
+    /// defers, matching the pointer ABI both endpoints already use — without it
+    /// the codec would BitCopy on encode while the constructor/decoder used
+    /// pointer ABI, leaking the heap-owned node.
+    ///
+    /// Revert-repro: drop the `contains_indirect_enum` term in
+    /// `cbor_vec_elem_kind` (or the `is_indirect` check in
+    /// `cbor_ty_contains_indirect_enum`) and the indirect-enum assertions below
+    /// report `LayoutBitCopy`.
+    #[test]
+    fn cbor_vec_elem_kind_fails_closed_for_indirect_enum_element() {
+        // `indirect enum Node { Leaf(i64); Nil; }` — scalar payloads, yet every
+        // value is a heap-owned pointer to a tagged-union struct.
+        let indirect = EnumLayout {
+            name: "Node".to_string(),
+            tag_width: 1,
+            variants: vec![
+                MachineVariantLayout {
+                    name: "Leaf".to_string(),
+                    field_tys: vec![ResolvedTy::I64],
+                    field_names: vec!["v".to_string()],
+                },
+                MachineVariantLayout {
+                    name: "Nil".to_string(),
+                    field_tys: vec![],
+                    field_names: vec![],
+                },
+            ],
+            is_indirect: true,
+        };
+        let no_recs: Vec<RecordLayout> = vec![];
+
+        // The indirect enum itself → Defer (NOT LayoutBitCopy).
+        assert_eq!(
+            cbor_vec_elem_kind(
+                &ResolvedTy::named_user("Node", vec![]),
+                &no_recs,
+                std::slice::from_ref(&indirect),
+            ),
+            CborVecElemKind::Defer,
+            "an indirect-enum element is a heap-owned pointer — must fail closed, not BitCopy"
+        );
+
+        // A record that transitively CONTAINS the indirect enum → Defer.
+        let wrapper = RecordLayout {
+            name: "Wrapper".to_string(),
+            field_tys: vec![ResolvedTy::named_user("Node", vec![])],
+            field_names: vec!["node".to_string()],
+        };
+        assert_eq!(
+            cbor_vec_elem_kind(
+                &ResolvedTy::named_user("Wrapper", vec![]),
+                std::slice::from_ref(&wrapper),
+                std::slice::from_ref(&indirect),
+            ),
+            CborVecElemKind::Defer,
+            "a record transitively containing an indirect enum must fail closed"
+        );
+
+        // Control: a NON-indirect enum with the SAME scalar payloads stays
+        // LayoutBitCopy — the fail-closed term must not over-defer a heap-free
+        // direct enum (over-drop is the floor, but never at the cost of a
+        // spurious defer that would refuse a legitimately reachable BitCopy).
+        let direct = EnumLayout {
+            name: "Flat".to_string(),
+            tag_width: 1,
+            variants: vec![
+                MachineVariantLayout {
+                    name: "A".to_string(),
+                    field_tys: vec![ResolvedTy::I64],
+                    field_names: vec!["v".to_string()],
+                },
+                MachineVariantLayout {
+                    name: "B".to_string(),
+                    field_tys: vec![],
+                    field_names: vec![],
+                },
+            ],
+            is_indirect: false,
+        };
+        assert_eq!(
+            cbor_vec_elem_kind(
+                &ResolvedTy::named_user("Flat", vec![]),
+                &no_recs,
+                std::slice::from_ref(&direct),
+            ),
+            CborVecElemKind::LayoutBitCopy,
+            "a heap-free direct enum must stay BitCopy — the fix must not over-defer"
         );
     }
 

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -44404,6 +44404,95 @@ mod binding_ty_is_plain_vec_tuple {
             "Vec<i64> must be admitted as a plain Vec (scalar `BitCopy` arm)"
         );
     }
+
+    /// Boundary-totality: the `Vec<E>` release-bucket predicates'
+    /// UNION must be total over the heap-owning `Vec` shapes. The outer `Vec`
+    /// ALWAYS owns heap (`ty_owns_heap(Vec<_>)` is `true` unconditionally — a
+    /// `Vec` owns its backing buffer for ANY element), so every `Vec<E>` local
+    /// must be claimed by exactly one release bucket or its scope-exit drop is
+    /// silently skipped → leak. The three Vec buckets are
+    /// `binding_ty_is_plain_vec` (buffer-only `hew_vec_free`; the runtime walks
+    /// `string` elements itself via `ElemKind::String`),
+    /// `binding_ty_is_owned_element_vec` (`hew_vec_free_owned`, per-element
+    /// drop), and `ty_is_closure_pair_vec` (`hew_vec_free_closure_pairs`).
+    ///
+    /// KNOWN-GAP — `Vec<bytes>`: claimed by NEITHER `binding_ty_is_plain_vec`
+    /// (`Bytes` is absent from its scalar/string allow-list) NOR
+    /// `binding_ty_is_owned_element_vec` (`is_owned_vec_element(Bytes)` hits its
+    /// `_ => false` arm), yet `ty_owns_heap(Vec<bytes>)` is `true`. This is a
+    /// LATENT non-totality, not a live leak: `Vec<bytes>` is currently
+    /// unconstructible — `Vec::new` fails closed at codegen with
+    /// `E_NOT_YET_IMPLEMENTED: Vec::new has no constructor lowering for element
+    /// type Bytes`, so a `Vec<bytes>` local can never reach a scope-exit drop
+    /// (the `_ => false` invariant — no silent ABI/drop fall-through — is
+    /// satisfied upstream at construction). This assertion is the tripwire:
+    /// enabling `Vec<bytes>` construction WITHOUT extending the release partition
+    /// (add `Bytes` to a bucket, or route the binding through the typed
+    /// `OwnershipDecision` authority — future release-bucket consolidation) must fail here first. Bare
+    /// runtime-handle elements (`Vec<CancellationToken>`) share this gap class
+    /// and the same NYI gate.
+    #[test]
+    fn release_bucket_partition_is_total_over_vec_elements() {
+        let builder = Builder::default();
+        let claimed = |elem: ResolvedTy| {
+            let v = vec_of_ty(elem);
+            builder.binding_ty_is_plain_vec(&v)
+                || builder.binding_ty_is_owned_element_vec(&v)
+                || ty_is_closure_pair_vec(&v)
+        };
+
+        // Plain bucket: BitCopy scalar / string / all-BitCopy aggregate elements.
+        for elem in [
+            ResolvedTy::I64,
+            ResolvedTy::Bool,
+            ResolvedTy::F64,
+            ResolvedTy::Char,
+            ResolvedTy::Duration,
+            ResolvedTy::String,
+            ResolvedTy::Tuple(vec![ResolvedTy::I64, ResolvedTy::I64]),
+        ] {
+            assert!(
+                builder.named_elem_owns_heap(&vec_of_ty(elem.clone())),
+                "Vec<{elem:?}> must own heap (the authority's Vec leaf rule)"
+            );
+            assert!(
+                claimed(elem.clone()),
+                "Vec<{elem:?}> owns heap but no release bucket claims it (plain arm)"
+            );
+        }
+
+        // Owned-element bucket: nested collections + heap-owning tuples.
+        for elem in [
+            ResolvedTy::named_builtin("Vec", BuiltinType::Vec, vec![ResolvedTy::I64]),
+            ResolvedTy::named_builtin(
+                "HashMap",
+                BuiltinType::HashMap,
+                vec![ResolvedTy::String, ResolvedTy::I64],
+            ),
+            ResolvedTy::named_builtin("HashSet", BuiltinType::HashSet, vec![ResolvedTy::I64]),
+            ResolvedTy::Tuple(vec![ResolvedTy::String, ResolvedTy::I64]),
+        ] {
+            assert!(
+                claimed(elem.clone()),
+                "Vec<{elem:?}> owns heap through its element but no release bucket claims it"
+            );
+        }
+
+        // The authority agrees the gap element's Vec owns heap (so it MUST be
+        // released): `ty_owns_heap(Vec<bytes>)` is true.
+        assert!(
+            builder.named_elem_owns_heap(&vec_of_ty(ResolvedTy::Bytes)),
+            "ty_owns_heap(Vec<bytes>) must be true — the outer Vec owns its buffer"
+        );
+        // THE KNOWN GAP: Vec<bytes> is claimed by no release bucket.
+        assert!(
+            !claimed(ResolvedTy::Bytes),
+            "KNOWN-GAP: Vec<bytes> is expected to be claimed by NO release bucket \
+             (the known partition gap, NYI-gated by `Vec::new`'s fail-closed on \
+             Bytes elements). If you enabled Vec<bytes> construction, extend the \
+             release partition and update this tripwire."
+        );
+    }
 }
 
 #[cfg(test)]

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -1504,6 +1504,24 @@ pub trait HeapOwnershipLayouts {
 /// congruence) and a heap-owning record field can no longer be silently missed
 /// at a call site that forgot a separate record-aware check
 /// (`dedup-semantic-boundary`, `drop-allowset-from-value-flow`).
+///
+/// # Typed seam (the typed inventory boundary)
+///
+/// This boolean is the heap axis of the typed
+/// [`OwnershipDecision`](crate::OwnershipDecision) — the single typed
+/// ownership/drop/ABI decision the consolidation routes the shape-specialised
+/// walkers onto (see the walker inventory in `ownership.rs`). The typed entry
+/// is [`OwnershipDecision::classify`](crate::OwnershipDecision::classify); the
+/// complete carried fact is [`ValueOwnership`](crate::ValueOwnership), whose
+/// [`owns_heap`](crate::ValueOwnership::owns_heap) projection **is this
+/// authority, `≡` by construction** — `ValueOwnership::classify` seeds it by
+/// calling `ty_owns_heap` directly, and the congruence is pinned over every
+/// canonical shape by `carried_seed_projections_equal_the_live_authorities`
+/// (`ownership.rs`). That equality is the contract a future consolidation seam
+/// relies on when it swaps its direct `ty_owns_heap` call for the carried
+/// projection:
+/// the boolean a consumer reads off the value is exactly the boolean this
+/// authority would re-derive, so the swap is byte-identical by construction.
 #[must_use]
 pub fn ty_owns_heap(ty: &ResolvedTy, layouts: &impl HeapOwnershipLayouts) -> bool {
     ty_owns_heap_inner(ty, layouts, &mut HashSet::new())

--- a/hew-mir/src/ownership.rs
+++ b/hew-mir/src/ownership.rs
@@ -27,13 +27,13 @@
 //! `true`; a closure env is [`OwnsHeap`] yet `ty_owns_heap` answers `false`. So
 //! the seed must travel with the value, making [`ValueOwnership::owns_heap`] `≡`
 //! `ty_owns_heap` and [`ValueOwnership::to_value_class`] `≡` `ValueClass::of_ty`
-//! **exactly**, for every shape — the contract Phase 1 relies on when it swaps a
+//! **exactly**, for every shape — the contract the consolidation relies on when it swaps a
 //! seam's direct authority call for the projection.
 //!
-//! This Phase-0 landing is **additive and unused**: it defines the types, the
+//! This landing is **additive and unused**: it defines the types, the
 //! [`ValueOwnership::classify`] / [`OwnershipDecision::classify`] constructor
 //! scaffold, the seed conversions, and the totality + round-trip tests. It
-//! switches **no** production call site — Phases 1A-1D route the existing
+//! switches **no** production call site — the release-bucket consolidation routes the existing
 //! authorities through it.
 //!
 //! # Subsumes (does not reinvent) the existing seeds
@@ -45,6 +45,31 @@
 //! | [`ValueClass`] | `value_class.rs` | Carried verbatim — [`ValueOwnership::to_value_class`] returns it (`≡`); `classify` also consumes it for the marker seed. |
 //! | [`Strategy::UnknownBlocked`] | `model.rs` | The fail-closed move strategy — [`Unsupported`] projects to it ([`OwnershipDecision::move_strategy_floor`]). |
 //! | `DropPlanUndetermined` | `lower.rs` | The fail-closed diagnostic — [`Unsupported`]'s [`FailClosedReason`] names the cause. |
+//!
+//! # Walker inventory
+//!
+//! The shape-specialised ownership/drop/ABI walkers that re-answer the heap /
+//! release / ABI question by matching on [`ResolvedTy`] at their own call site,
+//! with their disposition. This list is the consolidation worklist:
+//! every `bypasses` row is a seam the release-bucket consolidation routes through [`ValueOwnership`]
+//! / the single authority. The `_ => false` / `_ => None` fall-through arms are
+//! the leak surface (an unenumerated heap shape silently classified non-owning).
+//!
+//! | Walker | Crate · entry | Re-derives | Status |
+//! |---|---|---|---|
+//! | `ty_owns_heap` / `ty_owns_heap_inner` | `hew-mir` · `model.rs` | heap-ownership leaf set + structural recursion | **AUTHORITY** — the single source of truth; [`OwnershipDecision::classify`] and every routed walker resolve the heap axis here. |
+//! | `cbor_ty_owns_heap` | `hew-codegen-rs` · `llvm.rs` | CBOR `Vec` element heap probe (own leaf set, divergent `_ => false`) | **RETIRED** — now a `#[deprecated]` shim delegating to `ty_owns_heap` via `CborHeapLayouts`; sole caller `cbor_vec_elem_kind` is `#[allow(deprecated)]`-listed. The workspace `clippy -D warnings` CI step guards re-entry. Fixed a latent `CancellationToken` / tuple-field under-drop for free. |
+//! | owned-locals seed gate (`ValueClass::of_ty(ty) != BitCopy`) | `hew-mir` · `lower.rs` → `hew-hir` · `value_class.rs` | which locals enter drop elaboration | **PENDING (release-bucket consolidation)** — record-blind via [`ValueClass`]; the consolidation seeds from [`ValueOwnership`] instead. Not yet switched. |
+//! | `cow_value_leaf_drop_symbol` | `hew-mir` · `lower.rs` | scalar-leaf release symbol (`string` → `hew_string_drop`, else `None`) | **PENDING (release-bucket consolidation)** — a release bucket; see the partition-totality test below. |
+//! | `binding_ty_is_plain_vec` · `binding_ty_is_owned_element_vec` · `is_owned_vec_element` · `tuple_is_all_bitcopy` | `hew-mir` · `lower.rs` | `Vec<E>` release partition (plain-BitCopy vs owned-element) | **PENDING (release-bucket consolidation)** — release buckets; their UNION must be total vs the authority leaf set (the `Vec<bytes>` gap is pinned by the partition-totality test below). |
+//! | `ty_is_closure_pair_vec` · `ty_is_local_collection_handle` | `hew-mir` · `lower.rs` | closure-pair / collection-handle release | **PENDING (release-bucket consolidation)** — release buckets. |
+//! | `cow_heap_release_symbol` | `hew-codegen-rs` · `llvm.rs` | codegen-side release-symbol picker | **PENDING (release-bucket consolidation)** — the codegen sibling the MIR release buckets must agree with (`dedup-semantic-boundary`). |
+//!
+//! The boundary-totality tests pin both axes: [`OwnershipDecision::classify`] is
+//! total over the twelve canonical shapes (`classify_is_total_over_the_twelve_shapes`),
+//! and the release-bucket predicates' union is total vs the authority leaf set
+//! (`release_bucket_partition_is_total_over_vec_elements` in `lower.rs`, which
+//! surfaces the `Vec<bytes>` partition gap).
 //!
 //! [`NoHeap`]: OwnershipDecision::NoHeap
 //! [`OwnsHeap`]: OwnershipDecision::OwnsHeap
@@ -123,7 +148,7 @@ pub enum OwnershipDecision {
 
     /// The ownership fact could not be decided. The single fail-closed sink: a
     /// heap-bearing value whose release protocol no arm could name reaches here,
-    /// and Phase 1 routes it to [`Strategy::UnknownBlocked`] /
+    /// and the consolidation routes it to [`Strategy::UnknownBlocked`] /
     /// `MirCheck::DropPlanUndetermined` instead of silently leaking or
     /// double-freeing. `reason` names *why* so the diagnostic is actionable.
     Unsupported {
@@ -135,13 +160,13 @@ pub enum OwnershipDecision {
 // ──────────────────────── drop protocol (subsumes DropKind) ───────────────
 
 /// Release-protocol family for an [`OwnsHeap`](OwnershipDecision::OwnsHeap)
-/// value. A Phase-0 mirror of [`DropKind`] that carries no codegen-only payload
+/// value. A scaffold mirror of [`DropKind`] that carries no codegen-only payload
 /// except the discriminators that *are* the classification ([`Direction`],
 /// [`TraitObjectStorage`], the [`HeapLeaf`]).
 ///
 /// Every [`DropKind`] maps to exactly one `DropClass`
 /// (`TryFrom<DropKind>`) and every `DropClass` maps back to a canonical
-/// [`DropKind`] ([`DropClass::canonical_drop_kind`]), so Phase 1 can route the
+/// [`DropKind`] ([`DropClass::canonical_drop_kind`]), so the consolidation can route the
 /// existing dispatcher (`drop_kind_for`) through this axis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DropClass {
@@ -256,7 +281,7 @@ pub enum LayoutClass {
 // ──────────────────────────────── fail-closed ────────────────────────────
 
 /// Why an [`OwnershipDecision::Unsupported`] failed closed. Each reason maps to
-/// the actionable diagnostic Phase 1 emits instead of a silent leak; see
+/// the actionable diagnostic the consolidation emits instead of a silent leak; see
 /// [`FailClosedReason::diagnostic_note`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FailClosedReason {
@@ -282,7 +307,7 @@ pub enum FailClosedReason {
     LinearConsumeOnce,
     /// A `dyn Trait` whose `TraitObjectStorage` (`FrameOwned` vs `HeapBoxed`) is
     /// not available to the classifier (the `dyn_trait_storage` side table
-    /// Phase 1 threads). Fail-closed rather than guessing the release ritual.
+    /// the consolidation threads). Fail-closed rather than guessing the release ritual.
     DynStorageUnresolved,
     /// A heap-owning aggregate whose exactly-once free the drop analysis cannot
     /// prove (e.g. owned-handle aggregate extraction). Mirrors
@@ -292,7 +317,7 @@ pub enum FailClosedReason {
 
 // ──────────────────────────────── provenance ─────────────────────────────
 
-/// A MIR storage location an ownership fact can be anchored to. The Phase-0
+/// A MIR storage location an ownership fact can be anchored to. The scaffold
 /// place-provenance carrier — a thin, [`Place`]-convertible family so a
 /// [`Borrowed`](OwnershipDecision::Borrowed) /
 /// [`InteriorAlias`](OwnershipDecision::InteriorAlias) decision names its owner
@@ -314,7 +339,7 @@ pub enum PlaceProvenance {
         role: HandleRole,
     },
     /// The place is known to exist but not yet threaded through (scaffold
-    /// sentinel; Phase 1 replaces with the concrete place).
+    /// sentinel; the consolidation replaces with the concrete place).
     Unanchored,
 }
 
@@ -466,7 +491,7 @@ impl From<Place> for PlaceProvenance {
 // ─────────────────────────── classify context + scaffold ─────────────────
 
 /// Layout + value-class registries the [`OwnershipDecision::classify`] scaffold
-/// reads, mirroring exactly what the MIR `Builder` holds. Phase 1 wires
+/// reads, mirroring exactly what the MIR `Builder` holds. The consolidation wires
 /// `classify` by building one of these from the `Builder` — no new registry is
 /// introduced.
 #[derive(Debug)]
@@ -512,14 +537,20 @@ impl OwnershipDecision {
     /// Classify the ownership/drop/ABI decision for a value of type `ty` held in
     /// `place`.
     ///
-    /// **Phase-0 scaffold: lands unused.** It is the constructor every Phase-1
+    /// **Scaffold (lands unused).** It is the constructor every consolidation
     /// call site will route through; the coarse arms (e.g. picking the plain
-    /// `Vec` release symbol, deferring `dyn Trait` storage) are refined in
-    /// Phase 1. It is **total** in the load-bearing sense: the type-driven match
+    /// `Vec` release symbol, deferring `dyn Trait` storage) are refined by
+    /// the consolidation. It is **total** in the load-bearing sense: the type-driven match
     /// is exhaustive over [`ResolvedTy`] (no `_ => …` fallthrough), so a new
     /// `ResolvedTy` variant is a compile error here, and every shape resolves to
     /// a non-`Unsupported` decision or to a *tracked* [`Unsupported`] naming a
     /// [`FailClosedReason`].
+    ///
+    /// This is the **typed inventory boundary** the walker inventory (module
+    /// doc) routes the shape-specialised classifiers onto: its heap axis is the
+    /// [`ty_owns_heap`] authority (`≡`, carried by
+    /// [`ValueOwnership`]), so a future consolidation seam swapping a direct authority
+    /// call for this typed decision is byte-identical by construction.
     ///
     /// [`Unsupported`]: OwnershipDecision::Unsupported
     #[must_use]
@@ -611,7 +642,7 @@ impl OwnershipDecision {
             }
 
             // `dyn Trait` release needs the `FrameOwned`/`HeapBoxed` storage hint
-            // the scaffold does not carry — tracked-Unsupported (Phase 1 threads
+            // the scaffold does not carry — tracked-Unsupported (the consolidation threads
             // it).
             ResolvedTy::TraitObject { .. } => OwnershipDecision::Unsupported {
                 reason: FailClosedReason::DynStorageUnresolved,
@@ -965,7 +996,7 @@ impl OwnershipDecision {
 /// a `Generator` is `OwnsHeap { CowHeapLeaf }` yet `AffineResource`). Because the
 /// facts are carried, [`owns_heap`](Self::owns_heap) `≡` `ty_owns_heap` and
 /// [`to_value_class`](Self::to_value_class) `≡` `ValueClass::of_ty` **exactly**,
-/// so a Phase-1 seam can swap its direct authority call for the projection with
+/// so a future consolidation seam can swap its direct authority call for the projection with
 /// byte-identical behaviour.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValueOwnership {
@@ -1012,7 +1043,7 @@ impl ValueOwnership {
 
     /// The carried `ty_owns_heap` seed — equal to `ty_owns_heap(ty, …)` for the
     /// classified `ty` **by construction**. This is the exact projection a
-    /// Phase-1 seam reads instead of re-walking the type.
+    /// future consolidation seam reads instead of re-walking the type.
     #[must_use]
     pub fn owns_heap(&self) -> bool {
         self.owns_heap
@@ -1045,7 +1076,7 @@ impl ValueOwnership {
 }
 
 impl FailClosedReason {
-    /// The actionable diagnostic note Phase 1 attaches when this reason reaches
+    /// The actionable diagnostic note the consolidation attaches when this reason reaches
     /// the `MirCheck::DropPlanUndetermined` / `Strategy::UnknownBlocked` path.
     #[must_use]
     pub fn diagnostic_note(self) -> &'static str {
@@ -1422,7 +1453,7 @@ mod tests {
         );
     }
 
-    /// The shapes that are *tracked* `Unsupported` in Phase 0: each carries a
+    /// The shapes that are *tracked* `Unsupported`: each carries a
     /// reason (no silent `_ => false`), and each names a real ownership mode the
     /// 5-variant decision does not model yet. This is the explicit complement to
     /// the totality test — the only legal way to be `Unsupported`.
@@ -1596,7 +1627,7 @@ mod tests {
     }
 
     /// Assert the carried seed projections of `ty` (held in `place`) equal the
-    /// **live** authorities for the same `ty` — the exact contract Phase 1 swaps
+    /// **live** authorities for the same `ty` — the exact contract the consolidation swaps
     /// a seam's `ty_owns_heap(ty)` / `ValueClass::of_ty(ty)` call for.
     fn assert_carries_live_seeds(
         label: &str,


### PR DESCRIPTION
## Summary

The CBOR `Vec`-element codec carried its own heap-ownership walker (`cbor_ty_owns_heap`) that re-derived the heap-leaf set and structural recursion independently of the MIR drop elaborator's authority (`hew_mir::ty_owns_heap`). Its leaf set had drifted: a `CancellationToken` own-variant field and tuple/array record fields fell through a `_ => false` arm and were classified heap-free — a latent under-drop the codec would have BitCopy-leaked had those shapes been reachable.

This routes the probe through the single `ty_owns_heap` authority via a `CborHeapLayouts` adapter (the CBOR sibling of the `FnCtx`-backed `CgHeapLayouts`), inheriting the correct leaf set. The old function becomes a `#[deprecated]`-sealed shim over the authority; its sole caller (`cbor_vec_elem_kind`) is the only `#[allow(deprecated)]` site, and the workspace `cargo clippy --tests -- -D warnings` step turns any new caller into a hard failure — the re-entry tripwire needs no new plumbing.

Also lands the scaffolding the single authority needs:

- A **walker inventory** (`ownership.rs` module doc) cataloguing every shape-specialised ownership/drop/ABI walker and its retirement disposition, giving the remaining release-bucket predicates a tracked worklist.
- **Boundary-totality tests**: the authority is total over the twelve canonical shapes, and the `Vec` release-bucket predicates' union is total against the authority leaf set. The latter surfaces a tracked partition gap — `Vec<bytes>` owns heap yet no release bucket claims it. Latent, not a live leak: `Vec::new` fails closed on `Bytes` elements (the value is unconstructible), and the assertion is the tripwire that fires if that gate is ever lifted without first extending the release partition.
- `OwnershipDecision` exposed at the typed inventory boundary (docs plus the existing seed/projection congruence test) — the seam later classifier consolidation routes through.

The heap-leaf retire is byte-identical for reachable shapes: the coarse "every non-`Option` builtin defers" rule is preserved at the caller, so a genuinely heap-free `Result<i64, i64>` element still fails closed. The leaf-set divergences are all leak-safer and currently unreachable (they fail closed upstream at the clone-helper / wire-body floor) — a consistency hardening, not an observable runtime change.

**One deliberate fail-closed correction is _not_ byte-identical — `Vec<indirect enum>`.** The `HeapOwnershipLayouts` trait carries no indirectness axis (both the CBOR `CborHeapLayouts` and codegen `CgHeapLayouts` adapters expose only variant payload field types), so `ty_owns_heap` classifies an indirect enum with scalar payloads as heap-free even though each value is a heap-owned pointer. The **old** `cbor_ty_owns_heap` shared this exact blind spot — it inspected only `field_tys`, never `is_indirect` — so a `Vec<indirect enum>` was mis-BitCopied by both the old walker and the bare retire: a **pre-existing latent leak, not a regression** introduced here, so the byte-identical claim above holds for the retire itself. `cbor_vec_elem_kind` now detects elements that are or transitively contain an indirect enum (`cbor_ty_contains_indirect_enum`) and fails closed, matching the pointer ABI that `Vec` construction and CBOR enum decode (`emit_de_enum_cbor`) already use on both sides. The codegen drop path was already correct via the independent `DropKind::IndirectEnum` (not `ty_owns_heap`) — the gap was CBOR-local.

## Verification

- `make ci-preflight` — green (fmt + clippy `-D warnings` + workspace nextest + vertical-slice + ratchet + fuzz-oracle).
- New totality tests: `classify_is_total_over_the_twelve_shapes`, `release_bucket_partition_is_total_over_vec_elements` (pins the `Vec<bytes>` gap), `carried_seed_projections_equal_the_live_authorities`.
- `cbor_vec_elem_kind_fails_closed_for_indirect_enum_element` — pins that an indirect-enum CBOR `Vec` element (and a record transitively containing one) classifies owns-heap / defers rather than `LayoutBitCopy`, while a direct (non-indirect) enum control still BitCopies. Reverting the detector reproduces the indirect enum being BitCopied.
- Reverting the delegation reproduces the `CancellationToken` / tuple-field under-classification.

## Out of scope

- Consolidating the remaining release-bucket predicates (`cow_value_leaf_drop_symbol`, the `Vec`-element partition, closure-pair / collection-handle buckets) onto the carried decision — tracked by the inventory.
- Fixing the `Vec<bytes>` release-partition gap (pinned latent by the totality test).
- Threading an indirectness axis through `HeapOwnershipLayouts` so `ty_owns_heap` classifies indirect enums directly instead of the CBOR-local detector — a broader latent gap the codegen adapter shares (its drop path stays correct via `DropKind::IndirectEnum`); the CBOR path now fails closed regardless.