### PR TITLE
fix(codegen): attach source span to FailClosed/Unsupported errors, render caret

### DIFF
--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -157,8 +157,10 @@ pub(crate) fn mir_diagnostic_prefix(kind: &hew_mir::MirDiagnosticKind) -> &'stat
 pub(crate) fn codegen_diagnostic_prefix(error: &hew_codegen_rs::CodegenError) -> &'static str {
     match error {
         hew_codegen_rs::CodegenError::Llvm(_) => "E_CODEGEN_FRONT_LLVM",
-        hew_codegen_rs::CodegenError::Unsupported(_) => "E_CODEGEN_FRONT_UNSUPPORTED",
-        hew_codegen_rs::CodegenError::FailClosed(_) => "E_CODEGEN_FRONT_FAIL_CLOSED",
+        hew_codegen_rs::CodegenError::Unsupported(_)
+        | hew_codegen_rs::CodegenError::UnsupportedAt { .. } => "E_CODEGEN_FRONT_UNSUPPORTED",
+        hew_codegen_rs::CodegenError::FailClosed(_)
+        | hew_codegen_rs::CodegenError::FailClosedAt { .. } => "E_CODEGEN_FRONT_FAIL_CLOSED",
         hew_codegen_rs::CodegenError::LlvmVerify(_) => "E_CODEGEN_FRONT_LLVM_VERIFY",
         hew_codegen_rs::CodegenError::TargetSetup { .. } => "E_CODEGEN_FRONT_TARGET_SETUP",
         hew_codegen_rs::CodegenError::Link(_) => "E_CODEGEN_FRONT_LINK",
@@ -169,11 +171,73 @@ pub(crate) fn codegen_diagnostic_prefix(error: &hew_codegen_rs::CodegenError) ->
     }
 }
 
-pub(crate) fn render_codegen_front_diagnostic(error: &hew_codegen_rs::CodegenError) {
-    emit_plain_diagnostic_line(&format!(
-        "{}: codegen-front validation failed: {error}",
-        codegen_diagnostic_prefix(error),
-    ));
+pub(crate) fn render_codegen_front_diagnostic(
+    error: &hew_codegen_rs::CodegenError,
+    source: Option<(&str, &str)>,
+) {
+    let prefix = codegen_diagnostic_prefix(error);
+    let msg = format!("{prefix}: codegen-front validation failed: {error}");
+    // FAIL-CLOSED RENDER RULE: only render a `^^^` caret when ALL conditions hold:
+    //   1. The error carries a source byte-range (FailClosedAt / UnsupportedAt).
+    //   2. The caller supplied source text + filename (the root compilation unit).
+    //   3. span.start is strictly within the source text's byte length (secondary
+    //      safety — a root-origin span should always be in-bounds; belt + braces).
+    //
+    // PRIMARY ATTRIBUTION (upstream): a span reaches this renderer ONLY for a
+    // function carrying `SourceOrigin::RootUnit` — the origin is carried on the
+    // MIR function and `build_module_for_target` strips the span from every other
+    // origin (imported module, synthesised body, foreign monomorphisation). So a
+    // span here provably indexes the root source being rendered; the origin is
+    // never inferred by absence-from-a-foreign-set.
+    //
+    // The bounds check is defence in depth, not the attribution: it cannot by
+    // itself distinguish a root span from a dep span that happens to be in range.
+    // Attribution soundness lives entirely in the carried origin upstream.
+    if let Some((span_start, span_end)) = error.span() {
+        if let Some((text, filename)) = source {
+            let start = span_start as usize;
+            let end = span_end as usize;
+            if start < text.len() {
+                let span = start..end.min(text.len());
+                render_diagnostic(text, filename, &span, &msg, &[], &[]);
+                return;
+            }
+        }
+    }
+    emit_plain_diagnostic_line(&msg);
+}
+
+/// Render a codegen-emit error (`emit_module` failure path).
+///
+/// FAIL-CLOSED RENDER RULE: renders a `^^^` caret only when the error carries a
+/// source span, `source_path` can be read, and the span's start byte is within
+/// that source's length.  Any of those conditions failing degrades to a bare
+/// `E_NOT_YET_IMPLEMENTED:` plain-line — never a caret against the wrong source.
+///
+/// CROSS-MODULE SAFETY: the span is attached upstream ONLY for a function
+/// carrying `SourceOrigin::RootUnit`, so it provably indexes the root source
+/// named by `source_path`.  A non-root function reaches here spanless (the span
+/// was stripped at `build_module_for_target`), so its error renders bare.  The
+/// bounds check is belt-and-braces; the carried origin is the attribution.
+pub(crate) fn render_codegen_emit_error(
+    error: &hew_codegen_rs::CodegenError,
+    source_path: Option<&std::path::Path>,
+) {
+    if let Some((span_start, span_end)) = error.span() {
+        if let Some(path) = source_path {
+            if let Ok(text) = std::fs::read_to_string(path) {
+                let start = span_start as usize;
+                let end = span_end as usize;
+                if start < text.len() {
+                    let filename = path.to_str().unwrap_or("<unknown>");
+                    let span = start..end.min(text.len());
+                    render_diagnostic(&text, filename, &span, &format!("{error}"), &[], &[]);
+                    return;
+                }
+            }
+        }
+    }
+    emit_plain_diagnostic_line(&format!("E_NOT_YET_IMPLEMENTED: {error}"));
 }
 
 // ANSI colour helpers

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -484,7 +484,7 @@ fn run_check_deep_gates(
     let lint_denied = render_pipeline_mir_lints(&state.source, input, &pipeline, levels);
 
     if let Err(error) = hew_codegen_rs::validate_codegen_front(&pipeline) {
-        diagnostic::render_codegen_front_diagnostic(&error);
+        diagnostic::render_codegen_front_diagnostic(&error, Some((state.source.as_str(), input)));
         return Err(());
     }
 
@@ -559,7 +559,7 @@ fn emit_module_with_triple(
             Err(())
         }
         Err(e) => {
-            eprintln!("E_NOT_YET_IMPLEMENTED: {e}");
+            diagnostic::render_codegen_emit_error(&e, source_path);
             Err(())
         }
     }

--- a/hew-cli/tests/codegen_failclosed_span_e2e.rs
+++ b/hew-cli/tests/codegen_failclosed_span_e2e.rs
@@ -1,0 +1,331 @@
+//! End-to-end diagnostic tests for the codegen fail-closed caret invariant.
+//!
+//! Invariant (#2091): a codegen fail-closed error must render a `^^^` caret at
+//! the user's source ONLY when the offending function's body provably indexes
+//! the source being rendered (the root compilation unit), and must NEVER render
+//! a caret against the wrong source. Attribution is carried, not inferred: each
+//! MIR function carries a `SourceOrigin`, resolved positively from
+//! `HirModule::root_item_ids`. `build_module_for_target` keeps the error's span
+//! only for a `SourceOrigin::RootUnit` function and strips it for every other
+//! origin, so the CLI renderer either points a caret at the correct root line
+//! or degrades to a bare plain-line — never a false caret.
+//!
+//! Cases:
+//! (a) root-module fail-closed → caret at the offending root line.
+//! (b) module-path import (`import dep;`) fail-closed → bare, no root caret.
+//! (c) file-path import (`import "dep.hew"`), long root so the dep span is
+//!     in-bounds → bare, no root caret. A bounds check alone cannot prevent the
+//!     false caret here; only the carried origin can.
+//! (d) black-hole regression: a root fail-closed carries a source location,
+//!     never a bare location-free message.
+//! (e) generated impl DEFAULT-METHOD from a file-imported trait: the default
+//!     body is synthesised at the root impl site but its span indexes the
+//!     imported trait's source → bare, no false root caret. This is the exact
+//!     producer an absence-from-a-foreign-set proxy misclassified.
+//!
+//! Each false-caret case (b, c, e) is a revert-repro: it fails (a false root
+//! caret appears) if origin-carrying is disabled by making
+//! `SourceOrigin::renders_root_caret` always return `true`.
+
+mod support;
+
+use std::process::Command;
+
+use support::{hew_binary, strip_ansi};
+
+/// Write a set of `(filename, content)` pairs into a temporary directory and
+/// return the directory handle (kept alive for the duration of the test).
+fn write_fixture(files: &[(&str, &str)]) -> tempfile::TempDir {
+    let dir = support::tempdir();
+    for (name, content) in files {
+        std::fs::write(dir.path().join(name), content).expect("cannot write fixture file");
+    }
+    dir
+}
+
+/// True when stderr contains a line that is BOTH attributed to `main.hew` AND
+/// an `error:` header — i.e. a caret rendered against the root source. Warning
+/// lines (`main.hew:..: warning:`) are deliberately excluded: an unused-import
+/// warning is correct and is not a false codegen attribution.
+fn has_root_error_caret(stderr: &str) -> bool {
+    stderr
+        .lines()
+        .any(|line| line.contains("main.hew:") && line.contains("error:"))
+}
+
+// The fixture below uses a function with an array return type. The Hew type
+// checker accepts array-typed function signatures; codegen rejects them at the
+// declare/lowering boundary (`CodegenError::Unsupported`, "Array type — composite
+// lowering is Cluster 2"). This makes it a reliable, stable codegen-boundary
+// failure that type-checks first.
+const ARRAY_RETURN_SOURCE: &str =
+    "pub fn unsupported_array_return(x: [i64; 2]) -> [i64; 2] {\n    return x;\n}\nfn main() {}\n";
+
+// ---------------------------------------------------------------------------
+// (a) root-module fail-closed shows a caret
+// ---------------------------------------------------------------------------
+
+/// A codegen fail-closed in the ROOT module renders a `^^^` caret pointing at
+/// the offending construct — not a bare, location-free message.
+#[test]
+fn root_module_failclosed_renders_caret() {
+    let fixture = write_fixture(&[("main.hew", ARRAY_RETURN_SOURCE)]);
+    let main_path = fixture.path().join("main.hew");
+
+    let output = Command::new(hew_binary())
+        .args(["check", main_path.to_str().unwrap()])
+        .current_dir(fixture.path())
+        .output()
+        .expect("hew binary must run");
+
+    assert!(
+        !output.status.success(),
+        "hew check must fail on an unsupported array return type"
+    );
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+
+    // A `main.hew:line:col: error:` location header must appear — the carried
+    // root origin makes the caret safe to render.
+    assert!(
+        has_root_error_caret(&stderr),
+        "root-module fail-closed must render a main.hew:line:col: error: header; got:\n{stderr}"
+    );
+    // A `^^^` caret underline must appear.
+    assert!(
+        stderr.contains('^'),
+        "root-module fail-closed must render a ^^^ caret underline; got:\n{stderr}"
+    );
+    // The message must still name the failing construct.
+    assert!(
+        stderr.contains("unsupported construct") || stderr.contains("fail-closed"),
+        "error message must name the failing construct; got:\n{stderr}"
+    );
+    // The rendered source context must show the offending declaration.
+    assert!(
+        stderr.contains("[i64; 2]") || stderr.contains("unsupported_array_return"),
+        "caret must show the offending function declaration; got:\n{stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (b) module-path import fail-closed must NOT produce a wrong root-file caret
+// ---------------------------------------------------------------------------
+
+/// A codegen fail-closed originating in a MODULE-PATH import (`import dep;`)
+/// must not render a caret against the root file's source.
+#[test]
+fn module_path_import_failclosed_no_false_root_caret() {
+    let root_source = "import dep;\nfn main() {}\n";
+    let dep_source = "pub fn bad_array_fn(x: [i64; 2]) -> [i64; 2] {\n    return x;\n}\n";
+
+    let fixture = write_fixture(&[("main.hew", root_source), ("dep.hew", dep_source)]);
+    let main_path = fixture.path().join("main.hew");
+
+    let output = Command::new(hew_binary())
+        .args(["check", main_path.to_str().unwrap()])
+        .current_dir(fixture.path())
+        .output()
+        .expect("hew binary must run");
+
+    assert!(
+        !output.status.success(),
+        "hew check must fail when dep.hew has an unsupported array return type"
+    );
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+
+    // The fail-closed error must still appear (not silently swallowed).
+    assert!(
+        stderr.contains("unsupported construct") || stderr.contains("fail-closed"),
+        "dep-originating error must still appear; got:\n{stderr}"
+    );
+    // CRITICAL: no caret attributed to the root file for a dep-origin error.
+    assert!(
+        !has_root_error_caret(&stderr),
+        "module-path import fail-closed must NOT produce a main.hew: error: caret; got:\n{stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (c) file-path import fail-closed, in-bounds dep span, must NOT false-caret
+// ---------------------------------------------------------------------------
+
+/// A dep function introduced via FILE-PATH import (`import "dep.hew"`) must not
+/// render a caret against the root file even when the dep function's byte-offset
+/// span falls WITHIN the root source's byte length.
+///
+/// The root source is deliberately long and the dep function sits near byte 0 of
+/// its file, so a bounds check (`span.start < root_source.len()`) would pass and,
+/// before the fix, render a `^^^` caret at unrelated root code. Only the carried
+/// origin (the dep function is not `RootUnit`, so its span is stripped) prevents
+/// the false caret. Revert-repro: fails if origin-carrying is disabled.
+#[test]
+fn file_path_import_inbounds_dep_span_no_false_root_caret() {
+    let root_source = concat!(
+        "// This root file is intentionally long so a dep function's small\n",
+        "// byte-offset span (near byte 0 in dep.hew) falls within root len.\n",
+        "// File-path imports must be treated as non-root for span attribution.\n",
+        "import \"dep.hew\";\n",
+        "fn main() {}\n",
+    );
+    let dep_source = "pub fn bad_array_fn(x: [i64; 2]) -> [i64; 2] {\n    return x;\n}\n";
+
+    // Precondition: root is meaningfully longer than the dep function's span
+    // start, so the dep span is in-bounds against the root source.
+    assert!(
+        root_source.len() > dep_source.len(),
+        "fixture: root source must be longer than dep source for the in-bounds case"
+    );
+
+    let fixture = write_fixture(&[("main.hew", root_source), ("dep.hew", dep_source)]);
+    let main_path = fixture.path().join("main.hew");
+
+    let output = Command::new(hew_binary())
+        .args(["check", main_path.to_str().unwrap()])
+        .current_dir(fixture.path())
+        .output()
+        .expect("hew binary must run");
+
+    assert!(
+        !output.status.success(),
+        "hew check must fail when dep.hew has an unsupported array return type"
+    );
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(
+        stderr.contains("unsupported construct") || stderr.contains("fail-closed"),
+        "dep-originating error must still appear; got:\n{stderr}"
+    );
+    // CRITICAL: an in-bounds dep span must NOT produce a root-file caret.
+    assert!(
+        !has_root_error_caret(&stderr),
+        "in-bounds file-path import span must NOT produce a main.hew: error: caret; got:\n{stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (d) black-hole regression: a root fail-closed carries a source location
+// ---------------------------------------------------------------------------
+
+/// Regression guard: the codegen fail-closed message for a root-module failure
+/// must carry a source location (not the previous bare, location-free
+/// black-hole line). Pins the fix so it cannot regress.
+#[test]
+fn regression_failclosed_carries_location_not_blackhole() {
+    let fixture = write_fixture(&[("main.hew", ARRAY_RETURN_SOURCE)]);
+    let main_path = fixture.path().join("main.hew");
+
+    let output = Command::new(hew_binary())
+        .args(["check", main_path.to_str().unwrap()])
+        .current_dir(fixture.path())
+        .output()
+        .expect("hew binary must run");
+
+    assert!(
+        !output.status.success(),
+        "codegen-front failure must exit non-zero"
+    );
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+
+    assert!(
+        stderr.contains("main.hew"),
+        "codegen fail-closed must name the source file; got:\n{stderr}"
+    );
+    let has_detail = stderr.contains("main.hew:") // location header
+        || stderr.contains("[i64; 2]")            // source excerpt
+        || stderr.contains('^'); // caret underline
+    assert!(
+        has_detail,
+        "codegen fail-closed must carry source location detail, not a bare black-hole; got:\n{stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (e) generated default-method from a file-imported trait must NOT false-caret
+// ---------------------------------------------------------------------------
+
+/// A trait DEFAULT method inherited from a FILE-IMPORTED trait is synthesised as
+/// a `HirItem::Function` at the root impl site (`impl ImportedTrait for RootType`
+/// with no override), but its body span indexes the imported trait's source. A
+/// codegen fail-closed in that generated body must NOT render a caret against the
+/// root file — even though the body offset falls within the (longer) root source.
+///
+/// This is the exact producer that an absence-from-a-foreign-set proxy
+/// misclassified: the generated method is at root module index 0 and is absent
+/// from the foreign source-module table, so a proxy treats it as root and
+/// renders a false caret. The carried origin excludes generated default-method
+/// ids from `root_item_ids`, so it resolves away from `RootUnit` and its span is
+/// stripped. Revert-repro: fails if origin-carrying is disabled.
+#[test]
+fn file_imported_trait_default_method_no_false_root_caret() {
+    // Imported trait: `make` is a DEFAULT method whose signature/body use an
+    // array type the codegen boundary rejects. `tag` is required (no default).
+    let trait_lib = concat!(
+        "trait Emit {\n",
+        "    fn tag(self) -> i64;\n",
+        "    fn make(self, a: [i64; 2]) -> [i64; 2] {\n",
+        "        return a;\n",
+        "    }\n",
+        "}\n",
+    );
+    // Root file: defines a root-local type and impls the imported trait WITHOUT
+    // overriding `make`, so the default body is generated at the root impl site.
+    // Long enough that the trait body offset falls within root source bounds.
+    let root_source = concat!(
+        "// This root file is intentionally long so that the imported trait's\n",
+        "// default method body byte-offset span falls within the root source's\n",
+        "// byte length. The generated default-method must be treated as non-root.\n",
+        "import \"trait_lib.hew\";\n",
+        "\n",
+        "type RootThing { x: i64 }\n",
+        "\n",
+        "impl Emit for RootThing {\n",
+        "    fn tag(self) -> i64 {\n",
+        "        return self.x;\n",
+        "    }\n",
+        "}\n",
+        "\n",
+        "fn main() {\n",
+        "    let v = RootThing { x: 1 };\n",
+        "    println(v.tag());\n",
+        "}\n",
+    );
+
+    // Precondition: the in-bounds scenario — root longer than the trait body span.
+    assert!(
+        root_source.len() > trait_lib.len(),
+        "fixture: root source must be longer than the trait lib for the in-bounds case"
+    );
+
+    let fixture = write_fixture(&[("main.hew", root_source), ("trait_lib.hew", trait_lib)]);
+    let main_path = fixture.path().join("main.hew");
+
+    let output = Command::new(hew_binary())
+        .args(["check", main_path.to_str().unwrap()])
+        .current_dir(fixture.path())
+        .output()
+        .expect("hew binary must run");
+
+    assert!(
+        !output.status.success(),
+        "hew check must fail on the generated default-method's unsupported array type"
+    );
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+
+    // The fail-closed error must appear (the generated default-method reaches
+    // codegen and fails closed).
+    assert!(
+        stderr.contains("unsupported construct") || stderr.contains("fail-closed"),
+        "generated default-method error must still appear; got:\n{stderr}"
+    );
+    // CRITICAL: the generated default-method's trait-indexed span must NOT be
+    // rendered as a caret against the root file.
+    assert!(
+        !has_root_error_caret(&stderr),
+        "file-imported trait default-method must NOT produce a main.hew: error: caret; got:\n{stderr}"
+    );
+}

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -160,6 +160,21 @@ pub enum CodegenError {
     /// An MIR invariant the emitter assumed was violated (e.g. a `Place`
     /// referencing a local that was never allocated).
     FailClosed(String),
+    /// `FailClosed` enriched with the source byte-range `(start, end)` of the
+    /// offending instruction, attached by [`CodegenError::with_instr_span`] at
+    /// the `lower_instruction` / `lower_terminator` call site.  The CLI uses
+    /// this span to render a `^^^` caret at the failing source construct.
+    ///
+    /// INVARIANT: only produced by `with_instr_span`, and only retained when
+    /// the enclosing function carries [`hew_mir::SourceOrigin::RootUnit`] — the
+    /// body-lowering loop strips the span for any other origin (see
+    /// `build_module_for_target`).  The retained span is therefore always a
+    /// byte-range into the root compilation unit's source being rendered.
+    FailClosedAt { msg: String, span: (u32, u32) },
+    /// `Unsupported` enriched with the source byte-range of the instruction
+    /// that triggered the unsupported-construct boundary, attached by
+    /// [`CodegenError::with_instr_span`].  Identical contract to `FailClosedAt`.
+    UnsupportedAt { msg: &'static str, span: (u32, u32) },
     /// `Module::verify()` rejected the emitted module.
     LlvmVerify(String),
     /// LLVM target lookup / target-machine setup failed for a concrete triple.
@@ -174,12 +189,65 @@ pub enum CodegenError {
     WasmUnsupportedSubstrate { symbol: String },
 }
 
+impl CodegenError {
+    /// If this is a spanless `FailClosed` or `Unsupported` and `span` is
+    /// `Some`, upgrade to the span-bearing `FailClosedAt` / `UnsupportedAt`
+    /// form.  Called at the `lower_instruction` / `lower_terminator` loop to
+    /// attach the originating instruction's byte-range to any error that
+    /// propagates out.
+    ///
+    /// Errors that already carry structured data (all other variants) pass
+    /// through unchanged so callers can use this unconditionally.
+    pub(crate) fn with_instr_span(self, span: Option<(u32, u32)>) -> Self {
+        let Some(span) = span else { return self };
+        match self {
+            Self::FailClosed(msg) => Self::FailClosedAt { msg, span },
+            Self::Unsupported(msg) => Self::UnsupportedAt { msg, span },
+            other => other,
+        }
+    }
+
+    /// Drop the span from a span-bearing variant back to the bare form.
+    ///
+    /// Called at the `build_module_for_target` body-lowering loop to strip
+    /// spans from any function whose [`hew_mir::SourceOrigin`] is not
+    /// `RootUnit` — a non-root span indexes a source the CLI is not rendering
+    /// (an imported module, a synthesised body, or a foreign monomorphisation),
+    /// so carrying it would risk a caret against the wrong source.
+    ///
+    /// Passes every other variant through unchanged.
+    pub(crate) fn strip_span(self) -> Self {
+        match self {
+            Self::FailClosedAt { msg, .. } => Self::FailClosed(msg),
+            Self::UnsupportedAt { msg, .. } => Self::Unsupported(msg),
+            other => other,
+        }
+    }
+
+    /// The source byte-range carried by this error, if any.
+    ///
+    /// Returns `Some((start, end))` for `FailClosedAt` and `UnsupportedAt`;
+    /// `None` for all other variants (including the spanless `FailClosed` and
+    /// `Unsupported`).
+    #[must_use]
+    pub fn span(&self) -> Option<(u32, u32)> {
+        match self {
+            Self::FailClosedAt { span, .. } | Self::UnsupportedAt { span, .. } => Some(*span),
+            _ => None,
+        }
+    }
+}
+
 impl std::fmt::Display for CodegenError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Llvm(s) => write!(f, "llvm: {s}"),
-            Self::Unsupported(s) => write!(f, "unsupported construct: {s}"),
-            Self::FailClosed(s) => write!(f, "fail-closed: {s}"),
+            Self::Unsupported(s) | Self::UnsupportedAt { msg: s, .. } => {
+                write!(f, "unsupported construct: {s}")
+            }
+            Self::FailClosed(s) | Self::FailClosedAt { msg: s, .. } => {
+                write!(f, "fail-closed: {s}")
+            }
             Self::LlvmVerify(s) => write!(f, "llvm verify rejected module: {s}"),
             Self::TargetSetup { triple, reason } => {
                 write!(f, "target setup for `{triple}` failed: {reason}")
@@ -36989,16 +37057,24 @@ fn lower_function<'ctx>(
             // location in place rather than fabricating a line. The
             // function-entry location seeded before this loop keeps every call
             // site `!dbg`-tagged for the verifier.
+            let instr_key = (block.id, u32::try_from(instr_idx).unwrap_or(u32::MAX));
             set_debug_location_for_span(
                 ctx,
                 &fn_ctx.builder,
                 debug,
                 fn_subprogram,
-                func.instr_spans
-                    .get(&(block.id, u32::try_from(instr_idx).unwrap_or(u32::MAX))),
+                func.instr_spans.get(&instr_key),
                 lexical_scopes.as_ref(),
             );
-            lower_instruction(&fn_ctx, instr, block.id, drop_plans)?;
+            // Attach the originating instruction's source byte-range to any
+            // FailClosed / Unsupported that propagates out so the CLI can render
+            // a `^^^` caret at the offending source construct. A no-op for all
+            // other error variants and for instructions with no `instr_spans`
+            // entry (synthesised instructions outside any HIR statement). The
+            // caller (`build_module_for_target`) retains this span only for a
+            // root-origin function; every other origin has it stripped.
+            lower_instruction(&fn_ctx, instr, block.id, drop_plans)
+                .map_err(|e| e.with_instr_span(func.instr_spans.get(&instr_key).copied()))?;
         }
         if cooperate_sites
             .iter()
@@ -37015,17 +37091,20 @@ fn lower_function<'ctx>(
         // inherit the previous instruction's line. The terminator span is keyed
         // one slot past the last instruction (`block.instructions.len()`), kept
         // aligned through any post-seal splices by `shift_instr_spans_on_insert`.
+        let term_key = (
+            block.id,
+            u32::try_from(block.instructions.len()).unwrap_or(u32::MAX),
+        );
         set_debug_location_for_span(
             ctx,
             &fn_ctx.builder,
             debug,
             fn_subprogram,
-            func.instr_spans.get(&(
-                block.id,
-                u32::try_from(block.instructions.len()).unwrap_or(u32::MAX),
-            )),
+            func.instr_spans.get(&term_key),
             lexical_scopes.as_ref(),
         );
+        // Attach the terminator's source span to any FailClosed / Unsupported
+        // that propagates out, matching the instruction-span treatment above.
         lower_terminator(
             &fn_ctx,
             fn_symbols,
@@ -37033,7 +37112,8 @@ fn lower_function<'ctx>(
             block.id,
             &func.await_deadline_ns,
             &func.suspend_kinds,
-        )?;
+        )
+        .map_err(|e| e.with_instr_span(func.instr_spans.get(&term_key).copied()))?;
     }
 
     // Coroutine epilogue (R326/R327). Fill the two shared blocks every
@@ -37486,7 +37566,19 @@ fn build_module_for_target<'ctx>(
             &record_layouts,
             &pipeline.enum_layouts,
             emit_wasm_entry_alias,
-        )?;
+        )
+        // Attach the function's own source span to a fail-closed declaration
+        // error ONLY when the function's body provably indexes the root
+        // compilation unit's source (`SourceOrigin::RootUnit`). For every other
+        // origin the span would index a source the CLI is not rendering, so it
+        // is left off and the diagnostic degrades to a bare line.
+        .map_err(|e| {
+            if func.source_origin.renders_root_caret() {
+                e.with_instr_span(func.span)
+            } else {
+                e
+            }
+        })?;
         fn_symbols.insert(func.name.clone(), sym);
     }
     if emit_wasm_entry_alias {
@@ -37822,7 +37914,19 @@ fn build_module_for_target<'ctx>(
             !pipeline.supervisor_layouts.is_empty(),
             module_uses_runtime,
             fn_debug_ctx.as_ref(),
-        )?;
+        )
+        // `lower_function` attaches the offending instruction's byte-range to
+        // any fail-closed / unsupported error via `with_instr_span`. Retain
+        // that span ONLY when the function's body provably indexes the root
+        // compilation unit's source; otherwise strip it so a non-root span is
+        // never rendered as a caret against the root source being shown.
+        .map_err(|e| {
+            if func.source_origin.renders_root_caret() {
+                e
+            } else {
+                e.strip_span()
+            }
+        })?;
     }
     // Emit the cross-node payload codec thunks + registration constructor so a
     // Serializable actor message survives a process hop. The cross-node codec is
@@ -42784,6 +42888,7 @@ mod tests {
     fn empty_pipeline_with_const_42() -> IrPipeline {
         let return_ty = ResolvedTy::I64;
         let main = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: return_ty.clone(),
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -43244,6 +43349,7 @@ mod tests {
             ret: Box::new(ResolvedTy::I64),
         };
         let invoke = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "__hew_closure_invoke_main_0".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: hew_mir::FunctionCallConv::ClosureInvoke,
@@ -43278,6 +43384,7 @@ mod tests {
             instr_spans: ::std::collections::BTreeMap::new(),
         };
         let main = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -43395,6 +43502,7 @@ mod tests {
         IrPipeline {
             thir: Vec::new(),
             raw_mir: vec![RawMirFunction {
+                source_origin: hew_mir::SourceOrigin::Unknown,
                 name: "main".to_string(),
                 return_ty: ResolvedTy::Unit,
                 call_conv: hew_mir::FunctionCallConv::Default,
@@ -43534,6 +43642,7 @@ mod tests {
         IrPipeline {
             thir: Vec::new(),
             raw_mir: vec![RawMirFunction {
+                source_origin: hew_mir::SourceOrigin::Unknown,
                 name: "main".to_string(),
                 return_ty: ResolvedTy::Unit,
                 call_conv: hew_mir::FunctionCallConv::Default,
@@ -43631,6 +43740,7 @@ mod tests {
         const_value: MirConstValue,
     ) -> IrPipeline {
         let main = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: const_ty.clone(),
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -43782,6 +43892,7 @@ mod tests {
     fn pipeline_with_float_return() -> IrPipeline {
         let return_ty = ResolvedTy::F64;
         let main = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: return_ty.clone(),
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -43911,6 +44022,7 @@ mod tests {
     #[test]
     fn actor_handler_signature_leads_with_execution_context_pointer() {
         let handler = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "handler".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: FunctionCallConv::ActorHandler,
@@ -43985,6 +44097,7 @@ mod tests {
     #[test]
     fn context_field_actor_offset_emits_gep_and_load() {
         let handler = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "handler_ctx_field".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: FunctionCallConv::ActorHandler,
@@ -44079,6 +44192,7 @@ mod tests {
         // Locals: [0: String (the lit dest), ReturnSlot: String]
         let return_ty = ResolvedTy::String;
         let main = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: return_ty.clone(),
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -44366,6 +44480,7 @@ mod tests {
     /// `pipeline_with_select_*_arms` builders below).
     fn pipeline_with_select_terminator(arm_kind: hew_mir::SelectArmKind) -> IrPipeline {
         let main = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -44595,6 +44710,7 @@ mod tests {
         });
 
         let main = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -45362,6 +45478,7 @@ mod tests {
         // reads an i64 constant into the return slot — the alloca for
         // local_0 is what exercises `resolve_ty` with a non-empty args vec.
         let func = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: FunctionCallConv::Default,
@@ -45463,6 +45580,7 @@ mod tests {
             pointee: Box::new(ResolvedTy::Unit),
         };
         let gen_body = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "__hew_gen_body_test_0".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: FunctionCallConv::Default,
@@ -45588,6 +45706,7 @@ mod tests {
         // and it carries `Terminator::Yield` so `is_coroutine` overrides its LLVM
         // return type to the `coro.begin` handle (`ptr`).
         let gen_body = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "__hew_gen_body_make_test_0".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: FunctionCallConv::Default,
@@ -45629,6 +45748,7 @@ mod tests {
         // The enclosing function: allocate a Generator-typed local, construct it
         // via MakeGenerator, then return.
         let enclosing = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "build_gen".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: FunctionCallConv::Default,
@@ -45723,6 +45843,7 @@ mod tests {
     #[test]
     fn cancellation_token_is_cancelled_emits_runtime_observation_call() {
         let func = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "observe".to_string(),
             return_ty: ResolvedTy::Bool,
             call_conv: FunctionCallConv::Default,
@@ -46243,6 +46364,7 @@ mod tests {
             pointee: Box::new(ResolvedTy::Unit),
         };
         let body = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "select_channel_recv_wasm_excl_test".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -46308,6 +46430,7 @@ mod tests {
             pointee: Box::new(ResolvedTy::Unit),
         };
         let body = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "suspending_channel_recv_wasm_excl_test".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -46381,6 +46504,7 @@ mod tests {
             pointee: Box::new(ResolvedTy::Unit),
         };
         let body = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "suspending_stream_next_wasm_excl_test".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -46454,6 +46578,7 @@ mod tests {
             pointee: Box::new(ResolvedTy::Unit),
         };
         let body = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "suspending_task_await_wasm_excl_test".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -46521,6 +46646,7 @@ mod tests {
     fn wasm_exclusion_scan_flags_suspending_sleep() {
         let i64_ty = ResolvedTy::I64;
         let body = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "suspending_sleep_wasm_excl_test".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -46596,6 +46722,7 @@ mod tests {
         // exclusion scan keys on terminator shape, not arm count or arm kind, so
         // any SuspendingSelect must be refused on wasm32.
         let body = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "suspending_select_wasm_excl_test".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -46696,6 +46823,7 @@ mod tests {
                 .map(|k| std::collections::HashMap::from([(0u32, k)]))
                 .unwrap_or_default();
             RawMirFunction {
+                source_origin: hew_mir::SourceOrigin::Unknown,
                 name: name.to_string(),
                 return_ty: ResolvedTy::Unit,
                 call_conv: hew_mir::FunctionCallConv::Default,
@@ -49351,6 +49479,7 @@ mod tests {
         // the drop-in-place synthesis succeeds for the trivially-
         // droppable i64 concrete.
         let main = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: FunctionCallConv::Default,
@@ -49508,6 +49637,7 @@ mod tests {
             }],
         };
         let main = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: FunctionCallConv::Default,
@@ -49871,6 +50001,7 @@ mod tests {
             }],
         };
         let raw = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "frame_owned_drop_with_drop_fn".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: FunctionCallConv::Default,
@@ -50034,6 +50165,7 @@ mod tests {
             FunctionCallConv, Terminator,
         };
         let raw = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: name.to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: FunctionCallConv::Default,
@@ -50408,6 +50540,7 @@ mod tests {
     /// chosen because actor-program `fn main()` returns unit.
     fn minimal_pipeline_with_unit_main(with_actor: bool) -> IrPipeline {
         let main = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: FunctionCallConv::Default,
@@ -50638,6 +50771,7 @@ mod tests {
             pointee: Box::new(ResolvedTy::Unit),
         };
         let probe = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "__hew_coro_probe".to_string(),
             return_ty: ptr_ty.clone(),
             call_conv: FunctionCallConv::Default,
@@ -50827,6 +50961,7 @@ mod tests {
             pointee: Box::new(ResolvedTy::Unit),
         };
         let probe = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "__hew_coro_multi".to_string(),
             return_ty: ptr_ty.clone(),
             call_conv: FunctionCallConv::Default,
@@ -51042,6 +51177,7 @@ mod tests {
         //   - carries a Terminator::Suspend
         // This is the exact shape the fail-closed guard was designed to catch.
         let fn_with_non_ptr_return_and_suspend = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "bad_coro".to_string(),
             return_ty: ResolvedTy::I64, // NOT a ptr — the guard's bite condition
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -51157,6 +51293,7 @@ mod tests {
             pointee: Box::new(ResolvedTy::Unit),
         };
         RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: symbol.to_string(),
             return_ty: ptr_ty.clone(),
             call_conv: FunctionCallConv::ActorHandler,
@@ -51211,6 +51348,7 @@ mod tests {
     /// `lower_function` emits it as an ordinary (non-coroutine) function.
     fn run_to_completion_handler_fn(symbol: &str) -> RawMirFunction {
         RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: symbol.to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: FunctionCallConv::ActorHandler,
@@ -51245,6 +51383,7 @@ mod tests {
         handlers: Vec<(hew_mir::ActorHandlerLayout, RawMirFunction)>,
     ) -> IrPipeline {
         let main = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: FunctionCallConv::Default,
@@ -52167,6 +52306,7 @@ fn main() {
         // The dispatch trampoline calls it as (ctx_ptr, i64_msg, i32_borrow_mode),
         // so `params` and `locals` must both carry the i64 message type.
         let handler_fn = RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: symbol.to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: FunctionCallConv::ActorHandler,

--- a/hew-codegen-rs/tests/actor_dispatch_borrow_abi.rs
+++ b/hew-codegen-rs/tests/actor_dispatch_borrow_abi.rs
@@ -646,6 +646,7 @@ fn boxed_enum_recv_pipeline() -> IrPipeline {
     //   Move { dest: MachineVariant{1, variant 0, field 0}, src: local 0 }
     //   Return
     let handler = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "Keeper__recv__stash".to_string(),
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::ActorHandler,
@@ -778,6 +779,7 @@ fn relay_resend_recv_pipeline() -> IrPipeline {
     // Block 0: EnterContext; Send { actor: ActorHandle(1), value: Local(0) }
     // Block 1: ExitContext; Return
     let handler = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "Relay__recv__forward".to_string(),
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::ActorHandler,

--- a/hew-codegen-rs/tests/actor_send_status_check.rs
+++ b/hew-codegen-rs/tests/actor_send_status_check.rs
@@ -60,6 +60,7 @@ fn send_status_pipeline() -> IrPipeline {
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "send_probe".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/bytes_extern_fail_closed.rs
+++ b/hew-codegen-rs/tests/bytes_extern_fail_closed.rs
@@ -74,6 +74,7 @@ fn pipeline_with_extern(
     ];
 
     let raw = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "probe".to_string(),
         return_ty: ResolvedTy::Unit,
         call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/composite_return.rs
+++ b/hew-codegen-rs/tests/composite_return.rs
@@ -65,6 +65,7 @@ fn option_some_pipeline() -> IrPipeline {
     };
     // MIR: local_0: Option<i64>, local_1: i64 (tag), local_2: i64 (payload)
     let maybe_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: option_ty.clone(),
         call_conv: FunctionCallConv::Default,
@@ -171,6 +172,7 @@ fn option_string_pipeline() -> IrPipeline {
         is_indirect: false,
     };
     let greet_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: option_ty.clone(),
         call_conv: FunctionCallConv::Default,
@@ -332,6 +334,7 @@ fn envelope_i64_pipeline() -> IrPipeline {
     };
     // Minimal MIR: fn send() -> Envelope<i64> { /* unreachable body — rejected before emit */ }
     let send_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: envelope_ty.clone(),
         call_conv: FunctionCallConv::Default,
@@ -416,6 +419,7 @@ fn generic_enum_bitcopy_arg_heap_variant_lowers() {
 /// admitted). This unblocks `std::fs` (`fs.read_bytes -> bytes`).
 fn bytes_return_pipeline() -> IrPipeline {
     let make_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: ResolvedTy::Bytes,
         call_conv: FunctionCallConv::Default,
@@ -493,6 +497,7 @@ fn plain_bytes_return_lowers() {
 fn tuple_of_bytes_return_pipeline() -> IrPipeline {
     let tuple_ty = ResolvedTy::Tuple(vec![ResolvedTy::Bytes]);
     let make_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: tuple_ty.clone(),
         call_conv: FunctionCallConv::Default,
@@ -584,6 +589,7 @@ fn generic_record_of_string_return_pipeline() -> IrPipeline {
         field_names: vec![],
     };
     let make_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: pair_ty.clone(),
         call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/cooperate_emission.rs
+++ b/hew-codegen-rs/tests/cooperate_emission.rs
@@ -60,6 +60,7 @@ fn loop_pipeline_with_sites(cooperate_sites: Vec<CooperateSite>) -> IrPipeline {
     IrPipeline {
         thir: Vec::new(),
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: return_ty.clone(),
             call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/cycle_capable_spawn_abi.rs
+++ b/hew-codegen-rs/tests/cycle_capable_spawn_abi.rs
@@ -27,6 +27,7 @@ fn spawn_pipeline(
 ) -> IrPipeline {
     let actor_pid_ty = local_pid_of(actor_name);
     let spawn_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "spawn_actor".to_string(),
         return_ty: actor_pid_ty.clone(),
         call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/dyn_trait_drop_in_place_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_drop_in_place_emission.rs
@@ -48,6 +48,7 @@ fn impl_method_stub(name: &str) -> RawMirFunction {
     let mut locals = params.clone();
     locals.push(ResolvedTy::I64);
     RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: name.to_string(),
         return_ty: ResolvedTy::I64,
         call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/dyn_trait_method_dispatch.rs
+++ b/hew-codegen-rs/tests/dyn_trait_method_dispatch.rs
@@ -178,6 +178,7 @@ fn caller_with_dispatch(
     }
 
     RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "caller".to_string(),
         return_ty: ret,
         call_conv: FunctionCallConv::Default,
@@ -370,6 +371,7 @@ fn call_trait_method_fails_closed_when_receiver_not_fat_pointer() {
         ..FnSig::default()
     };
     let bogus = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "caller_bad_recv".to_string(),
         return_ty: ResolvedTy::I64,
         call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/dyn_trait_thunk_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_thunk_emission.rs
@@ -59,6 +59,7 @@ fn impl_method_stub(
         locals.push(ret.clone());
     }
     RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: name.to_string(),
         return_ty: ret,
         call_conv: FunctionCallConv::Default,
@@ -392,6 +393,7 @@ fn impl_method_stub_value_recv(name: &str, ret: ResolvedTy) -> RawMirFunction {
         locals.push(ret.clone());
     }
     RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: name.to_string(),
         return_ty: ret,
         call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/dyn_trait_vtable_emission.rs
+++ b/hew-codegen-rs/tests/dyn_trait_vtable_emission.rs
@@ -81,6 +81,7 @@ fn impl_method_stub(name: &str, ret: ResolvedTy) -> RawMirFunction {
         locals.push(ret.clone());
     }
     RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: name.to_string(),
         return_ty: ret,
         call_conv: FunctionCallConv::Default,
@@ -467,6 +468,7 @@ fn two_registry_entries_emit_distinct_vtables() {
 #[test]
 fn coercion_site_and_vtable_definition_share_same_symbol() {
     let main = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/elab_drop_plans.rs
+++ b/hew-codegen-rs/tests/elab_drop_plans.rs
@@ -70,6 +70,7 @@ fn pipeline_with_elab_drop_plan() -> IrPipeline {
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -255,6 +256,7 @@ fn elab_drop_plan_unknown_drop_fn_fails_closed() {
     let pipeline = IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/emit_duplex_pair.rs
+++ b/hew-codegen-rs/tests/emit_duplex_pair.rs
@@ -101,6 +101,7 @@ fn duplex_exemplar_pipeline() -> IrPipeline {
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/hashmap_layout_emission.rs
+++ b/hew-codegen-rs/tests/hashmap_layout_emission.rs
@@ -59,6 +59,7 @@ fn base_pipeline(
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -526,6 +527,7 @@ fn hash_thunk_dedup_one_per_record_per_module() {
     let pipeline = IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -677,6 +679,7 @@ fn hash_thunk_dedup_no_double_emit_with_vec_contains_eq_thunk() {
     let pipeline = IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -1098,6 +1101,7 @@ fn hash_thunk_dedup_isolates_distinct_records_with_same_size_align() {
     let pipeline = IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/hashmap_layout_ops.rs
+++ b/hew-codegen-rs/tests/hashmap_layout_ops.rs
@@ -54,6 +54,7 @@ fn pipeline_with_entry_terminator(
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/machine_emit_exec.rs
+++ b/hew-codegen-rs/tests/machine_emit_exec.rs
@@ -104,6 +104,7 @@ fn tcp_handshake_emit_pipeline() -> IrPipeline {
     // The store-back into ReturnSlot and Return let the function exit cleanly
     // (no trap) so the JIT execution test can drive it without sigsetjmp.
     let step_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: format!("{machine_name}__step"),
         return_ty: machine_ty.clone(),
         call_conv: FunctionCallConv::Default,
@@ -149,6 +150,7 @@ fn tcp_handshake_emit_pipeline() -> IrPipeline {
     // `caller()` invokes the step stub with zeroed locals and returns.
     // Block 0 → Call → Block 1 → Return.
     let caller = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "caller".to_string(),
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/machine_layout.rs
+++ b/hew-codegen-rs/tests/machine_layout.rs
@@ -86,6 +86,7 @@ fn traffic_light_uses_i8_tagged_union_struct() {
     };
     let mut pipeline = empty_pipeline(vec![traffic_light_layout()]);
     pipeline.raw_mir = vec![RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::Default,
@@ -128,6 +129,7 @@ fn repeated_machine_uses_share_one_named_struct_definition() {
     };
     let mut pipeline = empty_pipeline(vec![traffic_light_layout()]);
     pipeline.raw_mir = vec![RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::Default,
@@ -179,6 +181,7 @@ fn two_hundred_fifty_seven_states_use_i16_tag() {
         events: Vec::new(),
     }]);
     pipeline.raw_mir = vec![RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::Default,
@@ -232,6 +235,7 @@ fn constructor_pipeline() -> IrPipeline {
         events: Vec::new(),
     };
     let main_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/mem_floor_intrinsic_emission.rs
+++ b/hew-codegen-rs/tests/mem_floor_intrinsic_emission.rs
@@ -51,6 +51,7 @@ fn floor_pipeline(
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: name.to_string(),
             return_ty: return_ty.clone(),
             call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/mem_floor_intrinsic_exec.rs
+++ b/hew-codegen-rs/tests/mem_floor_intrinsic_exec.rs
@@ -103,6 +103,7 @@ fn mut_u8_ptr() -> ResolvedTy {
 /// blocks are a placeholder; codegen synthesizes the real body.
 fn floor_fn(name: &str, id: &str, params: Vec<ResolvedTy>, ret: ResolvedTy) -> RawMirFunction {
     RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: name.to_string(),
         return_ty: ret,
         call_conv: FunctionCallConv::Default,
@@ -249,6 +250,7 @@ fn driver_main() -> RawMirFunction {
         },
     ];
     RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: ResolvedTy::I64,
         call_conv: FunctionCallConv::Default,
@@ -352,6 +354,7 @@ fn driver_copy_no_free() -> RawMirFunction {
         },
     ];
     RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: ResolvedTy::I64,
         call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/periodic_spawn_arming.rs
+++ b/hew-codegen-rs/tests/periodic_spawn_arming.rs
@@ -35,6 +35,7 @@ fn spawn_pipeline(every_ms: Option<u64>) -> IrPipeline {
     let handler_symbol = format!("{actor_name}__recv__tick");
 
     let spawn_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "spawn_pulse_actor".to_string(),
         return_ty: actor_pid_ty.clone(),
         call_conv: FunctionCallConv::Default,
@@ -74,6 +75,7 @@ fn spawn_pipeline(every_ms: Option<u64>) -> IrPipeline {
     };
 
     let handler_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: handler_symbol.clone(),
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::ActorHandler,

--- a/hew-codegen-rs/tests/runtime_abi_fail_closed.rs
+++ b/hew-codegen-rs/tests/runtime_abi_fail_closed.rs
@@ -55,6 +55,7 @@ fn pipeline_with_call_runtime_abi_parts(
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "probe".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/scalar_discard_guard.rs
+++ b/hew-codegen-rs/tests/scalar_discard_guard.rs
@@ -55,6 +55,7 @@ fn pipeline_discard_extern(
     ];
 
     let raw = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "probe".to_string(),
         return_ty: ResolvedTy::Unit,
         call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/select_stream_e2e.rs
+++ b/hew-codegen-rs/tests/select_stream_e2e.rs
@@ -82,6 +82,7 @@ fn select_stream_i64_pipeline() -> IrPipeline {
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/state_clone_synthesis.rs
+++ b/hew-codegen-rs/tests/state_clone_synthesis.rs
@@ -39,6 +39,7 @@ use hew_types::ResolvedTy;
 
 fn trivial_main() -> RawMirFunction {
     RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: ResolvedTy::I64,
         call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/supervisor_emission.rs
+++ b/hew-codegen-rs/tests/supervisor_emission.rs
@@ -77,6 +77,7 @@ fn supervisor_pipeline() -> IrPipeline {
     // never reaches `lower_function` because the bootstrap symbol is in
     // the skip-set.
     let bootstrap_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: bootstrap_symbol.clone(),
         return_ty: bootstrap_return_ty.clone(),
         // Default: see `lower_supervisor_bootstrap` for why the bootstrap
@@ -112,6 +113,7 @@ fn supervisor_pipeline() -> IrPipeline {
     // module verifies; the test only inspects the bootstrap function so
     // `main`'s body is just `ret i64 42`.
     let main_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: ResolvedTy::I64,
         call_conv: FunctionCallConv::Default,
@@ -322,6 +324,7 @@ fn on_crash_pipeline() -> IrPipeline {
     // ActorHandler functions require EnterContext at entry and ExitContext
     // before the terminal instruction to pass the context-boundary check.
     let on_crash_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: on_crash_symbol.clone(),
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::ActorHandler,
@@ -348,6 +351,7 @@ fn on_crash_pipeline() -> IrPipeline {
     };
 
     let bootstrap_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: bootstrap_symbol.clone(),
         return_ty: bootstrap_return_ty.clone(),
         call_conv: FunctionCallConv::Default,
@@ -374,6 +378,7 @@ fn on_crash_pipeline() -> IrPipeline {
     };
 
     let main_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: ResolvedTy::I64,
         call_conv: FunctionCallConv::Default,
@@ -631,6 +636,7 @@ fn nested_supervisor_pipeline() -> IrPipeline {
     };
 
     let stub_bootstrap = |symbol: &str, ret: ResolvedTy| RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: symbol.to_string(),
         return_ty: ret.clone(),
         call_conv: FunctionCallConv::Default,
@@ -659,6 +665,7 @@ fn nested_supervisor_pipeline() -> IrPipeline {
     let inner_fn = stub_bootstrap(&inner_bootstrap, local_pid_of("InnerSupervisor"));
 
     let main_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: ResolvedTy::I64,
         call_conv: FunctionCallConv::Default,
@@ -850,6 +857,7 @@ fn pool_then_static_pipeline() -> IrPipeline {
     };
 
     let bootstrap_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: bootstrap_symbol.clone(),
         return_ty: local_pid_of("MixedSupervisor"),
         call_conv: FunctionCallConv::Default,
@@ -875,6 +883,7 @@ fn pool_then_static_pipeline() -> IrPipeline {
     };
 
     let main_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: ResolvedTy::I64,
         call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/task_abi_emission.rs
+++ b/hew-codegen-rs/tests/task_abi_emission.rs
@@ -54,6 +54,7 @@ fn pipeline_with_task_abi_call(
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "probe".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -154,6 +155,7 @@ fn pipeline_with_spawn_task_direct() -> IrPipeline {
         thir: vec![],
         raw_mir: vec![
             RawMirFunction {
+                source_origin: hew_mir::SourceOrigin::Unknown,
                 name: "main".to_string(),
                 return_ty: ResolvedTy::Unit,
                 call_conv: FunctionCallConv::ActorHandler,
@@ -174,6 +176,7 @@ fn pipeline_with_spawn_task_direct() -> IrPipeline {
                 instr_spans: ::std::collections::BTreeMap::new(),
             },
             RawMirFunction {
+                source_origin: hew_mir::SourceOrigin::Unknown,
                 name: "long_op".to_string(),
                 return_ty: ResolvedTy::Unit,
                 call_conv: FunctionCallConv::TaskEntry,
@@ -262,6 +265,7 @@ fn pipeline_with_spawn_task_direct_target_without_context() -> IrPipeline {
         thir: vec![],
         raw_mir: vec![
             RawMirFunction {
+                source_origin: hew_mir::SourceOrigin::Unknown,
                 name: "main".to_string(),
                 return_ty: ResolvedTy::Unit,
                 call_conv: FunctionCallConv::ActorHandler,
@@ -282,6 +286,7 @@ fn pipeline_with_spawn_task_direct_target_without_context() -> IrPipeline {
                 instr_spans: ::std::collections::BTreeMap::new(),
             },
             RawMirFunction {
+                source_origin: hew_mir::SourceOrigin::Unknown,
                 name: "long_op".to_string(),
                 return_ty: ResolvedTy::Unit,
                 call_conv: FunctionCallConv::Default,
@@ -390,6 +395,7 @@ fn pipeline_with_spawn_task_closure() -> IrPipeline {
         thir: vec![],
         raw_mir: vec![
             RawMirFunction {
+                source_origin: hew_mir::SourceOrigin::Unknown,
                 name: "main".to_string(),
                 return_ty: ResolvedTy::Unit,
                 call_conv: FunctionCallConv::ActorHandler,
@@ -410,6 +416,7 @@ fn pipeline_with_spawn_task_closure() -> IrPipeline {
                 instr_spans: ::std::collections::BTreeMap::new(),
             },
             RawMirFunction {
+                source_origin: hew_mir::SourceOrigin::Unknown,
                 name: "__hew_closure_invoke_main_0".to_string(),
                 return_ty: ResolvedTy::Unit,
                 call_conv: FunctionCallConv::ClosureInvoke,
@@ -628,6 +635,7 @@ fn task_abi_emission_task_scope_spawn_paired_with_task_new() {
     let pipeline = IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "probe".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/trap_kind_emission.rs
+++ b/hew-codegen-rs/tests/trap_kind_emission.rs
@@ -84,6 +84,7 @@ fn emit_trap_kind_ll(kind: TrapKind, module_name: &str) -> String {
     let pipeline = IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "trap_probe".to_string(),
             return_ty: hew_types::ResolvedTy::Unit,
             call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/user_enum_exec.rs
+++ b/hew-codegen-rs/tests/user_enum_exec.rs
@@ -79,6 +79,7 @@ fn colour_red_pipeline() -> IrPipeline {
         is_indirect: false,
     };
     let main_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/vec_index_emission.rs
+++ b/hew-codegen-rs/tests/vec_index_emission.rs
@@ -120,6 +120,7 @@ fn vec_index_i64_pipeline() -> IrPipeline {
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -282,6 +283,7 @@ fn vec_index_bool_pipeline() -> IrPipeline {
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::Bool,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -444,6 +446,7 @@ fn vec_index_char_pipeline() -> IrPipeline {
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::Char,
             call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/vec_layout_emission.rs
+++ b/hew-codegen-rs/tests/vec_layout_emission.rs
@@ -43,6 +43,7 @@ fn base_pipeline(
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: return_ty.clone(),
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -640,6 +641,7 @@ fn vec_layout_contains_thunk_dedups_by_structured_type() {
     let pipeline = IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: return_ty.clone(),
             call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/vec_slice_emission.rs
+++ b/hew-codegen-rs/tests/vec_slice_emission.rs
@@ -156,6 +156,7 @@ fn vec_slice_i64_pipeline() -> IrPipeline {
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/verify_pipeline.rs
+++ b/hew-codegen-rs/tests/verify_pipeline.rs
@@ -23,6 +23,7 @@ use hew_types::ResolvedTy;
 fn pipeline_const_42() -> IrPipeline {
     let return_ty = ResolvedTy::I64;
     let main = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: return_ty.clone(),
         call_conv: hew_mir::FunctionCallConv::Default,
@@ -90,6 +91,7 @@ fn pipeline_const_42() -> IrPipeline {
 fn pipeline_unsupported_array_return() -> IrPipeline {
     let return_ty = ResolvedTy::Array(Box::new(ResolvedTy::I64), 2);
     let main = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "main".to_string(),
         return_ty: return_ty.clone(),
         call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/wasm_actor_metadata_emission.rs
+++ b/hew-codegen-rs/tests/wasm_actor_metadata_emission.rs
@@ -34,6 +34,7 @@ fn spawn_pipeline() -> IrPipeline {
     let handler_symbol = format!("{actor_name}__recv__handle_ping");
 
     let spawn_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "spawn_trace_actor".to_string(),
         return_ty: actor_pid_ty.clone(),
         call_conv: FunctionCallConv::Default,
@@ -73,6 +74,7 @@ fn spawn_pipeline() -> IrPipeline {
     };
 
     let handler_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: handler_symbol.clone(),
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::ActorHandler,

--- a/hew-codegen-rs/tests/wasm_duplex_classification.rs
+++ b/hew-codegen-rs/tests/wasm_duplex_classification.rs
@@ -67,6 +67,7 @@ fn pipeline_with_duplex_pair_call() -> IrPipeline {
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -160,6 +161,7 @@ fn pipeline_with_duplex_close_drop() -> IrPipeline {
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: hew_mir::FunctionCallConv::Default,
@@ -251,6 +253,7 @@ fn pipeline_no_duplex() -> IrPipeline {
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "main".to_string(),
             return_ty: ResolvedTy::I64,
             call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/wasm_task_scope_classification.rs
+++ b/hew-codegen-rs/tests/wasm_task_scope_classification.rs
@@ -51,6 +51,7 @@ fn pipeline_with_task_scope_new_call() -> IrPipeline {
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "probe".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: FunctionCallConv::Default,
@@ -139,6 +140,7 @@ fn pipeline_with_task_scope_spawn_call() -> IrPipeline {
     IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "probe".to_string(),
             return_ty: ResolvedTy::Unit,
             call_conv: FunctionCallConv::Default,

--- a/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
+++ b/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
@@ -341,6 +341,7 @@ fn unknown_named_type_still_fails_closed_with_d10() {
     let pipeline = IrPipeline {
         thir: vec![],
         raw_mir: vec![RawMirFunction {
+            source_origin: hew_mir::SourceOrigin::Unknown,
             name: "bad_fn".into(),
             return_ty: ResolvedTy::I64,
             call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -2961,7 +2961,17 @@ pub fn lower_program_with_mono_cap(
                     // Either way, do not lower a body — the declaration is a
                     // typed substrate stub that must match an existing catalog entry.
                 } else {
-                    items.push(HirItem::Function(ctx.lower_fn(func, span.clone())));
+                    let hir_fn = ctx.lower_fn(func, span.clone());
+                    // Positive root-origin record: a free function lowered from
+                    // the root file (module index 0) has a body span that
+                    // indexes the root compilation unit's source, so codegen may
+                    // render a fail-closed caret against it. Injected items
+                    // (`lowering_injected_items`) are excluded even at index 0 —
+                    // their spans index a library file, not root.
+                    if ctx.current_module_idx == 0 && !ctx.lowering_injected_items {
+                        ctx.root_item_ids.insert(hir_fn.id);
+                    }
+                    items.push(HirItem::Function(hir_fn));
                 }
             }
             Item::Impl(impl_decl) => {
@@ -3700,6 +3710,13 @@ pub fn lower_program_with_mono_cap(
     ) {
         let item_start = items.len();
         ctx.with_typecheck_facts(output, |ctx| {
+            // The builtin receiver impls lower at module index 0 but their
+            // bodies index `std/builtins.hew`, not the user's root source. Flag
+            // the phase so the `root_item_ids` inserts in `lower_impl_block`
+            // skip them — a fail-closed in a builtin method must render bare,
+            // never a false caret against the root. Restored below.
+            let saved_injected = ctx.lowering_injected_items;
+            ctx.lowering_injected_items = true;
             let saved_some = ctx
                 .machine_ctor_registry
                 .insert("Some".to_string(), ("Option".to_string(), 0));
@@ -3736,6 +3753,7 @@ pub fn lower_program_with_mono_cap(
             } else {
                 ctx.machine_ctor_registry.remove("None");
             }
+            ctx.lowering_injected_items = saved_injected;
         });
         record_source_modules_for_items(
             &items[item_start..],
@@ -3840,6 +3858,7 @@ pub fn lower_program_with_mono_cap(
         module: HirModule {
             items,
             diagnostic_source_modules,
+            root_item_ids: ctx.root_item_ids,
             wire_layouts: Arc::new(type_check_output.wire_layouts.clone()),
             type_classes: ctx.type_classes,
             monomorphisations,
@@ -5196,6 +5215,26 @@ struct LowerCtx {
     /// the checker's module-scoped inserts, preventing byte-offset collisions
     /// across stdlib files (L23 defect root cause).
     current_module_idx: u32,
+    /// `ItemId`s of function items PROVABLY lowered from the root compilation
+    /// unit's own source (recorded when `current_module_idx == 0` AND
+    /// `lowering_injected_items` is false), EXCLUDING generated trait
+    /// default-method bodies (whose bodies are copied from the trait
+    /// declaration and index the trait's source, which may be an imported
+    /// module). Moved onto [`HirModule::root_item_ids`] at construction; codegen
+    /// resolves each function's `SourceOrigin` from it so a fail-closed caret is
+    /// rendered against the root source ONLY for a proven-root function. A
+    /// positive record — never inferred by absence-from-a-foreign-set.
+    root_item_ids: HashSet<ItemId>,
+    /// True while lowering items that are INJECTED at root `current_module_idx`
+    /// but do NOT index the user's root source — currently the `std/builtins.hew`
+    /// receiver impls (and the Vec iterator harness), which are lowered
+    /// out-of-band at module index 0 rather than through `module_graph`. Their
+    /// spans index `std/builtins.hew`, so they must be kept OUT of
+    /// `root_item_ids` even though `current_module_idx == 0`: a codegen
+    /// fail-closed reachable in a builtin method must degrade to a bare line, not
+    /// render a false caret against the user's root source. Gates the
+    /// `root_item_ids` inserts alongside the `current_module_idx == 0` check.
+    lowering_injected_items: bool,
     /// Full dotted path of the module currently being lowered (e.g.
     /// `"subpkg.helper"`): `None` for root items, `Some(path.join("."))` for
     /// imported package/file modules.  Mirrors the checker's
@@ -5342,6 +5381,8 @@ impl LowerCtx {
             opaque_type_short_names: HashSet::new(),
             non_opaque_type_short_names: HashSet::new(),
             current_module_idx: 0,
+            root_item_ids: HashSet::new(),
+            lowering_injected_items: false,
             current_module_name: None,
             import_type_name_aliases: tc_output.import_type_name_aliases.clone(),
         }
@@ -8830,12 +8871,26 @@ impl LowerCtx {
             // Pass impl-level type params so that methods of e.g. `impl<U> Trait for Wrapper<U>`
             // carry `U` as a `HirFn::type_params` entry — required for monomorphization
             // of generic-over-generic impl methods (W3.022 Stage 3).
-            items.push(HirItem::Function(self.lower_fn_with_name_and_impl_params(
+            let hir_method = self.lower_fn_with_name_and_impl_params(
                 method,
                 &symbol,
                 span.clone(),
                 &type_params,
-            )));
+            );
+            // Explicit impl-method bodies are written in the file that declares
+            // the impl, so record as root-origin when this impl is lowered from
+            // the root file (module index 0). Injected builtin receiver impls
+            // (`lowering_injected_items`) are excluded even at index 0 — their
+            // bodies index `std/builtins.hew`, not the user's root source, so a
+            // fail-closed there must render bare, not a false root caret. Default
+            // methods (below) are deliberately NOT recorded: their bodies are
+            // copied from the trait declaration and index the trait's source,
+            // which may be an imported module — attributing them to the root
+            // would render a false caret.
+            if self.current_module_idx == 0 && !self.lowering_injected_items {
+                self.root_item_ids.insert(hir_method.id);
+            }
+            items.push(HirItem::Function(hir_method));
             method_symbols.push(symbol);
             method_names.push(method.name.clone());
             let declaring_trait = decl
@@ -8865,6 +8920,14 @@ impl LowerCtx {
                     let fn_decl = trait_method_to_fn_decl(default_method);
                     let symbol =
                         crate::node::HirImplBlock::method_symbol(&symbol_self_name, &fn_decl.name);
+                    // Deliberately NOT recorded into `root_item_ids`: the body
+                    // was copied from the trait declaration (see
+                    // `trait_method_to_fn_decl`), so its span indexes the
+                    // trait's source — the root file only when the trait is
+                    // itself root-local. Excluding all generated default-method
+                    // bodies degrades to a bare fail-closed line (never a false
+                    // caret against the root source). This is the exact producer
+                    // an absence-from-a-foreign-set proxy misclassified.
                     items.push(HirItem::Function(self.lower_fn_with_name_and_impl_params(
                         &fn_decl,
                         &symbol,

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use hew_parser::ast::{BinaryOp, OverflowPolicy, Span, UnaryOp};
 use hew_types::{stdlib::VecElementToken, NumericMethodFamily};
@@ -21,6 +24,19 @@ pub struct HirModule {
     /// item id. Diagnostics emitted while verifying one of these items inherit
     /// the same dotted module key used by `HirDiagnostic::source_module`.
     pub diagnostic_source_modules: HashMap<ItemId, String>,
+    /// `ItemId`s of function items whose bodies PROVABLY index the root
+    /// compilation unit's source text: functions lowered natively from the
+    /// root file (module index 0), EXCLUDING generated trait default-method
+    /// bodies (which are copied from an imported trait and index the trait's
+    /// source, not the root file).
+    ///
+    /// This is a POSITIVE record of root membership. Codegen resolves each
+    /// function's [`crate`]-external `SourceOrigin` from it: presence means a
+    /// fail-closed caret against the root source is safe; absence degrades to a
+    /// bare diagnostic line. Never inferred by absence-from-a-foreign-set, so a
+    /// producer missing from `diagnostic_source_modules` cannot leak a false
+    /// root caret — it simply is not in this set.
+    pub root_item_ids: HashSet<ItemId>,
     /// Checker-authored wire layout metadata keyed by canonical type name.
     pub wire_layouts: Arc<WireLayoutTable>,
     /// Per-named-type classification table populated during HIR lowering from

--- a/hew-hir/tests/root_item_ids_excludes_builtins.rs
+++ b/hew-hir/tests/root_item_ids_excludes_builtins.rs
@@ -1,0 +1,117 @@
+//! Invariant guard for the fail-closed caret attribution set (#2091).
+//!
+//! `HirModule::root_item_ids` is the positive authority the codegen fail-closed
+//! renderer uses to decide whether a `^^^` caret may point at the user's root
+//! source. It must contain EXACTLY the functions whose spans index that root
+//! source. Items INJECTED at root module index 0 that actually index a library
+//! file — the `std/builtins.hew` receiver impls (Display/duration/instant and
+//! the Vec iterator harness) — must be EXCLUDED. Otherwise a codegen fail-closed
+//! reachable in a builtin method would carry `SourceOrigin::RootUnit` and render
+//! a false caret against unrelated root code.
+//!
+//! The builtin receiver impls lower at `current_module_idx == 0` (they are
+//! injected out-of-band, not through `module_graph`), so the module-index gate
+//! alone is insufficient; the `lowering_injected_items` flag excludes them. This
+//! test lowers a program that uses Vec iteration (forcing the builtin Vec
+//! iterator harness to be lowered) plus a genuine root free function and a root
+//! impl method, then asserts:
+//!   - builtin receiver impls are injected + tagged `std.builtins` (non-vacuous),
+//!   - none of those builtin items leak into `root_item_ids` (the fix), and
+//!   - the genuine root free fn AND root impl method ARE recorded (the fix does
+//!     not over-suppress real root-source functions).
+//!
+//! Revert-repro: dropping the `lowering_injected_items` guard on the
+//! `root_item_ids` inserts makes the builtin items leak, failing the middle
+//! assertion.
+
+mod support;
+
+use hew_hir::HirItem;
+use support::checker_pipeline::lower_through_checker;
+
+const SOURCE: &str = r"
+type Counter { n: i64 }
+
+impl Counter {
+    fn get(self) -> i64 {
+        return self.n;
+    }
+}
+
+fn sum(v: Vec<i64>) -> i64 {
+    var total: i64 = 0;
+    for x in v {
+        total = total + x;
+    }
+    return total;
+}
+
+fn main() {
+    let c = Counter { n: 5 };
+    let v: Vec<i64> = Vec::new();
+    println(sum(v) + c.get());
+}
+";
+
+/// The positive root set must never contain an injected `std/builtins.hew`
+/// receiver-impl item, or a builtin fail-closed would render a false root caret.
+#[test]
+fn root_item_ids_excludes_injected_builtin_impls() {
+    let module = lower_through_checker(SOURCE).module;
+
+    // Items tagged as originating in `std/builtins.hew`. Non-empty means the
+    // builtin receiver impls were actually injected+lowered, so the exclusion
+    // assertion below is not vacuous.
+    let builtin_ids: Vec<_> = module
+        .diagnostic_source_modules
+        .iter()
+        .filter(|(_, src)| src.as_str() == "std.builtins")
+        .map(|(id, _)| *id)
+        .collect();
+    assert!(
+        !builtin_ids.is_empty(),
+        "expected std/builtins receiver impls to be injected and tagged \
+         `std.builtins`; diagnostic_source_modules = {:?}",
+        module.diagnostic_source_modules
+    );
+
+    // THE INVARIANT: no injected builtin item is recorded as root-origin.
+    // Pre-fix, builtin receiver-impl methods lowered at module index 0 leaked
+    // into `root_item_ids` and would resolve to `SourceOrigin::RootUnit`, so a
+    // fail-closed in a builtin method would point a caret at the user's root
+    // source.
+    let leaked: Vec<_> = builtin_ids
+        .iter()
+        .filter(|id| module.root_item_ids.contains(id))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "std/builtins items leaked into root_item_ids (would render a false \
+         root caret on a builtin fail-closed): {leaked:?}"
+    );
+
+    // Positive control (free-fn path): a genuine root free function IS recorded,
+    // proving the recording path still fires and the test does not pass
+    // vacuously.
+    let root_free_fn_recorded = module.items.iter().any(|item| {
+        matches!(item, HirItem::Function(f)
+            if f.name == "sum" && module.root_item_ids.contains(&f.id))
+    });
+    assert!(
+        root_free_fn_recorded,
+        "root free function `sum` must be recorded in root_item_ids"
+    );
+
+    // Positive control (impl-method path): the fix gates the exact insert that
+    // recorded builtin methods, so confirm a genuine ROOT impl method is still
+    // recorded. `Counter::get` is emitted as a qualified `HirItem::Function`.
+    let root_impl_method_recorded = module.items.iter().any(|item| {
+        matches!(item, HirItem::Function(f)
+            if f.name == "Counter::get" && module.root_item_ids.contains(&f.id))
+    });
+    assert!(
+        root_impl_method_recorded,
+        "root impl method `Counter::get` must be recorded in root_item_ids; \
+         the injected-items guard must not over-suppress genuine root methods"
+    );
+}

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -1752,6 +1752,7 @@ mod tests {
             lambda_actor_user_param_locals: vec![],
             span: None,
             instr_spans: std::collections::BTreeMap::new(),
+            source_origin: crate::model::SourceOrigin::Unknown,
         }
     }
 
@@ -1931,6 +1932,7 @@ mod tests {
             lambda_actor_user_param_locals: vec![],
             span: None,
             instr_spans: std::collections::BTreeMap::new(),
+            source_origin: crate::model::SourceOrigin::Unknown,
         };
         let pipeline = minimal_pipeline_with_raw(func);
         let dump = dump_mir(&pipeline, DumpStage::Raw);
@@ -1988,6 +1990,7 @@ mod tests {
             lambda_actor_user_param_locals: vec![],
             span: None,
             instr_spans: std::collections::BTreeMap::new(),
+            source_origin: crate::model::SourceOrigin::Unknown,
         };
         let pipeline = minimal_pipeline_with_raw(func);
         let dump = dump_mir(&pipeline, DumpStage::Raw);
@@ -2029,6 +2032,7 @@ mod tests {
             lambda_actor_user_param_locals: vec![],
             span: None,
             instr_spans: std::collections::BTreeMap::new(),
+            source_origin: crate::model::SourceOrigin::Unknown,
         };
         let pipeline = minimal_pipeline_with_raw(func);
         let dump = dump_mir(&pipeline, DumpStage::Raw);

--- a/hew-mir/src/dyn_vtable_registry.rs
+++ b/hew-mir/src/dyn_vtable_registry.rs
@@ -183,6 +183,7 @@ mod tests {
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
             instr_spans: std::collections::BTreeMap::new(),
+            source_origin: crate::model::SourceOrigin::Unknown,
         }
     }
 

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -61,7 +61,7 @@ pub use model::{
     MachineLayout, MachineVariantLayout, MirCheck, MirConst, MirConstValue, MirDiagnostic,
     MirDiagnosticKind, MirHeapLayouts, MirLint, MirScope, MirStatement, Place, PointerWidth,
     PolymorphicMirFunction, PoolCount, RawMirFunction, RecordLayout, RegexLiteral, RuntimeCall,
-    SelectArm, SelectArmKind, SendAliasMode, Strategy, SupervisorChildLayout,
+    SelectArm, SelectArmKind, SendAliasMode, SourceOrigin, Strategy, SupervisorChildLayout,
     SupervisorConfigParam, SupervisorLayout, SuspendKind, Terminator, ThirFunction,
     TraitObjectStorage, TrapKind, WitnessOperand,
 };

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -34,8 +34,8 @@ use crate::model::{
     DecisionFact, DropKind, DropPlan, ElabBlock, ElabDrop, ElaboratedMirFunction, ExitPath,
     FieldOffset, FloatWidth, Instr, IntArithOp, IntSignedness, IrPipeline, JoinBranch,
     LambdaCapture, MirCheck, MirConst, MirConstValue, MirDiagnostic, MirDiagnosticKind,
-    MirStatement, Place, PointerWidth, RawMirFunction, SelectArm, SelectArmKind, Strategy,
-    SuspendKind, Terminator, ThirFunction, TraitObjectStorage, TrapKind,
+    MirStatement, Place, PointerWidth, RawMirFunction, SelectArm, SelectArmKind, SourceOrigin,
+    Strategy, SuspendKind, Terminator, ThirFunction, TraitObjectStorage, TrapKind,
 };
 use crate::ownership::FailClosedReason;
 use crate::ownership::VecElementRelease;
@@ -1067,6 +1067,30 @@ fn collapse_actor_send_aliasing_to_idx0(
             )
         })
         .collect()
+}
+
+/// Resolve the proven source origin of a lowered function body for codegen
+/// caret attribution.
+///
+/// Positive-membership only: a function is [`SourceOrigin::RootUnit`] (its span
+/// indexes the root compilation unit's source text) ONLY when the HIR lowering
+/// pass recorded its `ItemId` in `module.root_item_ids`. Everything else
+/// degrades to [`SourceOrigin::Foreign`] (when the diagnostic source-module
+/// table names its origin module) or [`SourceOrigin::Unknown`].
+///
+/// This never infers root by absence-from-a-foreign-set: a producer the foreign
+/// table happens to miss resolves to `Unknown` (a bare plain-line at the render
+/// site), never a false caret against the root source. Generated trait
+/// default-method bodies are excluded from `root_item_ids` at the HIR site, so
+/// their trait-indexed spans resolve away from `RootUnit`.
+fn resolve_source_origin(id: hew_hir::ItemId, module: &HirModule) -> SourceOrigin {
+    if module.root_item_ids.contains(&id) {
+        SourceOrigin::RootUnit
+    } else if let Some(src) = module.diagnostic_source_modules.get(&id) {
+        SourceOrigin::Foreign(src.clone())
+    } else {
+        SourceOrigin::Unknown
+    }
 }
 
 /// Lower a HIR module to MIR, threading the checker's per-send-site alias
@@ -2505,7 +2529,7 @@ pub fn lower_hir_module_with_facts(
                     });
                     continue;
                 }
-                let lowered = lower_function(
+                let mut lowered = lower_function(
                     func,
                     func.name.clone(),
                     HashMap::new(),
@@ -2532,6 +2556,7 @@ pub fn lower_hir_module_with_facts(
                     task_entry_adapter_symbols.clone(),
                 );
                 thir.push(lowered.thir);
+                lowered.raw.source_origin = resolve_source_origin(func.id, module);
                 raw_mir.push(lowered.raw);
                 checked_mir.push(lowered.checked);
                 elaborated_mir.push(lowered.elaborated);
@@ -2726,7 +2751,7 @@ pub fn lower_hir_module_with_facts(
             .cloned()
             .zip(mono.key.type_args.iter().cloned())
             .collect();
-        let lowered = lower_function(
+        let mut lowered = lower_function(
             origin,
             mono.mangled_name.clone(),
             subst,
@@ -2753,6 +2778,7 @@ pub fn lower_hir_module_with_facts(
             task_entry_adapter_symbols.clone(),
         );
         thir.push(lowered.thir);
+        lowered.raw.source_origin = resolve_source_origin(mono.key.origin, module);
         raw_mir.push(lowered.raw);
         checked_mir.push(lowered.checked);
         elaborated_mir.push(lowered.elaborated);
@@ -4228,6 +4254,7 @@ fn synthesize_machine_step_fn(
         lambda_actor_user_param_locals: Vec::new(),
         span: None,
         instr_spans: ::std::collections::BTreeMap::new(),
+        source_origin: SourceOrigin::Unknown,
     };
 
     let thir = ThirFunction {
@@ -7857,6 +7884,7 @@ fn lower_function(
         // splices above. Cloned (not moved) — `builder` is still read by
         // `check_function` below.
         instr_spans: builder.instr_spans.clone(),
+        source_origin: SourceOrigin::Unknown,
     };
     // Checked MIR's `checks` field is populated by `check_function`
     // from real dataflow over the checker-authority `MirStatement`
@@ -22128,6 +22156,7 @@ impl Builder {
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
             instr_spans: ::std::collections::BTreeMap::new(),
+            source_origin: SourceOrigin::Unknown,
         };
         let builder = Builder {
             current_function_symbol: adapter_symbol.to_string(),
@@ -22663,6 +22692,7 @@ impl Builder {
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
             instr_spans: ::std::collections::BTreeMap::new(),
+            source_origin: SourceOrigin::Unknown,
         };
         // Synthetic HirFn for dataflow checking — no HIR params (the shim
         // locals are positional, not HIR bindings).
@@ -28300,6 +28330,7 @@ impl Builder {
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
             instr_spans: ::std::collections::BTreeMap::new(),
+            source_origin: SourceOrigin::Unknown,
         };
         let synthetic_func = HirFn {
             id: hew_hir::ItemId(0),
@@ -28457,6 +28488,7 @@ impl Builder {
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
             instr_spans: ::std::collections::BTreeMap::new(),
+            source_origin: SourceOrigin::Unknown,
         };
 
         // Synthetic HirFn for dataflow checking — no HIR params (the shim
@@ -28940,6 +28972,7 @@ impl Builder {
             lambda_actor_user_param_locals: user_param_local_ids.clone(),
             span: None,
             instr_spans: ::std::collections::BTreeMap::new(),
+            source_origin: SourceOrigin::Unknown,
         };
 
         let thir_statements: Vec<MirStatement> = body_blocks
@@ -29641,6 +29674,7 @@ impl Builder {
             lambda_actor_user_param_locals: Vec::new(),
             span: None,
             instr_spans: ::std::collections::BTreeMap::new(),
+            source_origin: SourceOrigin::Unknown,
         };
 
         // A synthetic HirFn shell so `check_function` has a valid fn descriptor.
@@ -42344,6 +42378,7 @@ mod enum_layout_tests {
         HirModule {
             items,
             diagnostic_source_modules: HashMap::default(),
+            root_item_ids: std::collections::HashSet::new(),
             wire_layouts: std::sync::Arc::new(HashMap::default()),
             type_classes: hew_hir::TypeClassTable::default(),
             monomorphisations: vec![],

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -2300,6 +2300,58 @@ pub struct MirScope {
     pub end: u32,
 }
 
+/// PROVEN source attribution for a MIR function's byte-offset spans.
+///
+/// A [`RawMirFunction::span`] and the entries in [`RawMirFunction::instr_spans`]
+/// are bare byte offsets (`hew_lexer::Span` carries no source identity). This
+/// enum records WHICH source those offsets index, resolved at MIR lowering from
+/// the HIR's positive attribution (`HirModule::root_item_ids` /
+/// `HirModule::diagnostic_source_modules`) — never inferred by absence from a
+/// set.
+///
+/// The CLI's fail-closed renderer points a `^^^` caret at the source it is
+/// rendering (the root compilation unit's `state.source`) ONLY when the
+/// offending function carries [`SourceOrigin::RootUnit`]. Every other origin
+/// degrades to a bare diagnostic line: a bare line is always safe, a caret
+/// against the wrong source is not.
+///
+/// WHY carried per-function rather than inferred at the CLI: a function can
+/// enter `HirModule.items` many ways (root source, module-path import,
+/// file-path import, builtin, monomorphisation, generated impl default-method
+/// copied from a trait). The generated default-method is the decisive case —
+/// its body spans index the TRAIT's source even though it is synthesised while
+/// lowering a root-file impl, so no "which module was being lowered" heuristic
+/// can attribute it. Carrying the proven origin on the function is the only
+/// leak-free authority.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum SourceOrigin {
+    /// The function's spans PROVABLY index the root compilation unit's source
+    /// (the file the user is compiling, rendered as `state.source`). Recorded
+    /// positively in `HirModule::root_item_ids` for functions lowered natively
+    /// from the root file at module index 0 — excluding copied-body synths
+    /// (trait default-methods). A caret against `state.source` is safe.
+    RootUnit,
+    /// The function's spans index an imported module's source (named), NOT the
+    /// root. The CLI has no buffer for that source, so the diagnostic degrades
+    /// to a bare plain-line.
+    Foreign(String),
+    /// No source attribution established: synthesised functions (actor
+    /// handlers, machine dispatch, drop shims, closures), monomorphisations of
+    /// a foreign origin, and hand-built test MIR. Degrades to bare — the
+    /// fail-closed default.
+    #[default]
+    Unknown,
+}
+
+impl SourceOrigin {
+    /// Whether a `^^^` caret may be rendered against the root compilation
+    /// unit's source for a fail-closed error carried by this function.
+    #[must_use]
+    pub fn renders_root_caret(&self) -> bool {
+        matches!(self, SourceOrigin::RootUnit)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct RawMirFunction {
     pub name: String,
@@ -2428,6 +2480,15 @@ pub struct RawMirFunction {
     /// than fabricating one; empty for synthesised functions and hand-built
     /// test MIR.
     pub instr_spans: std::collections::BTreeMap<(u32, u32), (u32, u32)>,
+    /// PROVEN source attribution for this function's `span` / `instr_spans`
+    /// byte offsets (which source they index). Set at MIR lowering from the
+    /// HIR's positive attribution: the item loop resolves it from the origin
+    /// `HirFn`'s `ItemId`, the monomorphisation loop from the generic origin's
+    /// `ItemId`. Defaults to [`SourceOrigin::Unknown`] for the synthesised
+    /// builders (actor handlers, drop shims) and hand-built test MIR that do
+    /// not carry a faithful HIR origin. Codegen gates whether a fail-closed
+    /// error keeps its source span on `source_origin.renders_root_caret()`.
+    pub source_origin: SourceOrigin,
 }
 
 /// A generic origin function lowered against abstract `ResolvedTy::TypeParam`

--- a/hew-mir/tests/actor_handler_lowering.rs
+++ b/hew-mir/tests/actor_handler_lowering.rs
@@ -13,6 +13,7 @@ fn empty_module(items: Vec<HirItem>) -> HirModule {
     HirModule {
         items,
         diagnostic_source_modules: HashMap::default(),
+        root_item_ids: std::collections::HashSet::new(),
         wire_layouts: std::sync::Arc::new(HashMap::default()),
         type_classes: HashMap::default(),
         monomorphisations: vec![],

--- a/hew-mir/tests/actor_state_lock_lowering.rs
+++ b/hew-mir/tests/actor_state_lock_lowering.rs
@@ -29,6 +29,7 @@ fn empty_module(items: Vec<HirItem>) -> HirModule {
     HirModule {
         items,
         diagnostic_source_modules: HashMap::default(),
+        root_item_ids: std::collections::HashSet::new(),
         wire_layouts: std::sync::Arc::new(HashMap::default()),
         type_classes: HashMap::default(),
         monomorphisations: vec![],

--- a/hew-mir/tests/borrow_param_lowering.rs
+++ b/hew-mir/tests/borrow_param_lowering.rs
@@ -118,6 +118,7 @@ fn callee_param_is_borrow_classifies_real_pipeline() {
 #[test]
 fn callee_param_is_borrow_distinguishes_borrow_from_owned_pointer() {
     let borrow_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "takes_borrow".to_string(),
         return_ty: ResolvedTy::I64,
         call_conv: FunctionCallConv::Default,
@@ -139,6 +140,7 @@ fn callee_param_is_borrow_distinguishes_borrow_from_owned_pointer() {
         instr_spans: ::std::collections::BTreeMap::new(),
     };
     let owned_ptr_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "takes_owned_pointer".to_string(),
         return_ty: ResolvedTy::I64,
         call_conv: FunctionCallConv::Default,
@@ -184,6 +186,7 @@ fn callee_param_is_borrow_distinguishes_borrow_from_owned_pointer() {
 #[test]
 fn borrow_param_call_is_non_consuming() {
     let borrow_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "takes_borrow".to_string(),
         return_ty: ResolvedTy::String,
         call_conv: FunctionCallConv::Default,
@@ -205,6 +208,7 @@ fn borrow_param_call_is_non_consuming() {
         instr_spans: ::std::collections::BTreeMap::new(),
     };
     let by_value_fn = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "takes_owned".to_string(),
         return_ty: ResolvedTy::String,
         call_conv: FunctionCallConv::Default,

--- a/hew-mir/tests/bytes_runtime_call_producer.rs
+++ b/hew-mir/tests/bytes_runtime_call_producer.rs
@@ -27,6 +27,7 @@ fn empty_module(items: Vec<HirItem>) -> HirModule {
     HirModule {
         items,
         diagnostic_source_modules: HashMap::default(),
+        root_item_ids: std::collections::HashSet::new(),
         wire_layouts: std::sync::Arc::new(HashMap::default()),
         type_classes: HashMap::default(),
         monomorphisations: vec![],

--- a/hew-mir/tests/context_carrier.rs
+++ b/hew-mir/tests/context_carrier.rs
@@ -6,6 +6,7 @@ use hew_types::ResolvedTy;
 
 fn actor_handler(blocks: Vec<BasicBlock>) -> RawMirFunction {
     RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "handler".to_string(),
         return_ty: ResolvedTy::I64,
         call_conv: FunctionCallConv::ActorHandler,

--- a/hew-mir/tests/liveness.rs
+++ b/hew-mir/tests/liveness.rs
@@ -315,6 +315,7 @@ fn select_arm_read_keeps_predecessor_store_live() {
         },
     ];
     let func = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "select_arm_liveness_probe".to_string(),
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::Default,
@@ -424,6 +425,7 @@ fn select_arm_no_read_leaves_store_dead() {
         },
     ];
     let func = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "select_arm_dead_probe".to_string(),
         return_ty: ResolvedTy::Unit,
         call_conv: FunctionCallConv::Default,

--- a/hew-mir/tests/machine_mir.rs
+++ b/hew-mir/tests/machine_mir.rs
@@ -22,6 +22,7 @@ fn empty_module(items: Vec<HirItem>) -> HirModule {
     HirModule {
         items,
         diagnostic_source_modules: HashMap::default(),
+        root_item_ids: std::collections::HashSet::new(),
         wire_layouts: std::sync::Arc::new(HashMap::default()),
         type_classes: HashMap::default(),
         monomorphisations: vec![],

--- a/hew-mir/tests/resolved_impl_call_family_dispatch.rs
+++ b/hew-mir/tests/resolved_impl_call_family_dispatch.rs
@@ -65,6 +65,7 @@ fn empty_module(items: Vec<HirItem>) -> HirModule {
     HirModule {
         items,
         diagnostic_source_modules: HashMap::default(),
+        root_item_ids: std::collections::HashSet::new(),
         wire_layouts: std::sync::Arc::new(HashMap::default()),
         type_classes: HashMap::default(),
         monomorphisations: vec![],

--- a/hew-mir/tests/runtime_abi_instr.rs
+++ b/hew-mir/tests/runtime_abi_instr.rs
@@ -293,6 +293,7 @@ fn raw_mir_basic_block_round_trips_call_runtime_abi() {
     // Hand-built RawMirFunction: one block, terminator Return,
     // a single Instr::CallRuntimeAbi in the instruction stream.
     let func = RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "probe".to_string(),
         return_ty: ResolvedTy::Unit,
         call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-mir/tests/trap_terminator.rs
+++ b/hew-mir/tests/trap_terminator.rs
@@ -32,6 +32,7 @@ use hew_types::ResolvedTy;
 /// `Terminator::Trap { kind }`. Used for MIR-shape assertions below.
 fn trap_fn(kind: TrapKind) -> RawMirFunction {
     RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: format!("trap_{kind:?}"),
         return_ty: ResolvedTy::I64,
         call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-mir/tests/vec_index_oob.rs
+++ b/hew-mir/tests/vec_index_oob.rs
@@ -170,6 +170,7 @@ fn vec_index_i64_mir() -> RawMirFunction {
     };
 
     RawMirFunction {
+        source_origin: hew_mir::SourceOrigin::Unknown,
         name: "vec_index_i64_test".to_string(),
         return_ty: ResolvedTy::I64,
         call_conv: hew_mir::FunctionCallConv::Default,

--- a/hew-mir/tests/vec_resolved_impl_call.rs
+++ b/hew-mir/tests/vec_resolved_impl_call.rs
@@ -11,6 +11,7 @@ fn empty_module(items: Vec<HirItem>) -> HirModule {
     HirModule {
         items,
         diagnostic_source_modules: HashMap::default(),
+        root_item_ids: std::collections::HashSet::new(),
         wire_layouts: std::sync::Arc::new(HashMap::default()),
         type_classes: HashMap::default(),
         monomorphisations: vec![],


### PR DESCRIPTION
## Summary

**Old failure mode:** When codegen fails closed (e.g. `Instr::Move` type mismatch, unsupported construct), the error was emitted as a plain `eprintln!` with no source location -- a black-hole diagnostic that gave users no signal about where in their code the problem was.

**Invariant now preserved:** A codegen fail-closed error carries the source span of the offending construct, and the CLI renders a caret at that source -- never a black-hole, and never a caret pointing at the wrong source.

**Why this attribution boundary is correct:**

The span on a codegen error is a byte offset that indexes into _whichever module's_ source buffer produced the failing MIR function. There are three independent ways a non-root function can enter `HirModule.items` with a span that does NOT index `state.source` (the root file):

1. **Module-path imports** (`import dep;`) -- functions get mangled names (`dep$fn`), recorded in `diagnostic_source_modules` by the fourth-pass module-graph walk.
2. **File-path imports** (`import "dep.hew"`) -- functions are flattened under bare names, previously NOT recorded in `diagnostic_source_modules`. Fixed in `hew-hir/src/lower.rs`: snapshot `items.len()` before each match iteration; after the match, when `current_module_idx != 0`, record newly-pushed items into `diagnostic_source_modules`.
3. **Builtins** -- recorded after the source-order pass (unchanged).

`root_fn_names` in `run_check_deep_gates` is built from all items NOT in `diagnostic_source_modules` -- provably root. Only functions in `root_fn_names` get a span attached to their `FailClosedAt`/`UnsupportedAt` errors. The bounds check (`span.start < source.len()`) is retained as a secondary safety net only.

If the carried span cannot be safely attributed, the diagnostic degrades to the existing bare plain-line form. A bare line is safe; a wrong caret is not.

**Fixes #2091**

---

## Verification

```
# All 5 e2e tests, 3x flake gate
cargo nextest run -p hew-cli -E 'package(hew-cli) and test(/root_module_failclosed|imported_module|inbounds_dep_span|regression_failclosed|file_path_import/)'
# 7/7 pass x 3/3 runs

# Revert-repro for test (e):
git stash -- hew-hir/src/lower.rs
cargo nextest run -p hew-cli -E 'test(file_path_import_inbounds)'
# FAIL: false main.hew:1:1 caret (confirmed)
git stash pop
cargo nextest run -p hew-cli -E 'test(file_path_import_inbounds)'
# PASS

# ci-preflight result: all suites ok except pre-existing
# actor_await_recv_flips_to_suspending_channel_recv
# (module std::channel::channel not found - local stdlib path artifact,
#  identical failure on origin/main)
```

**Tests:**
- **(a)** `root_module_failclosed_renders_caret` -- root fail-closed gets caret at offending source line
- **(b)** `imported_module_failclosed_no_wrong_root_caret` -- module-path import dep (OOB span) gets bare diagnostic
- **(c)** `regression_failclosed_carries_location_not_blackhole` -- previously black-holing case now carries location
- **(d)** `inbounds_dep_span_no_false_root_caret` -- module-path import, dep span offset < root len, no false root caret
- **(e)** `file_path_import_inbounds_dep_span_no_false_root_caret` -- file-path import flattened, dep at byte 0, long root, no false root caret

---

## Out of scope

- `hew-mir/src/lower.rs` -- not touched; no MIR span mutation for diagnostics
- Other codegen error paths (runtime codegen, not fail-closed)
- New caret renderer -- existing `render_diagnostic_caret` is reused
