### PR TITLE
fix(test): make remote-ask-under-partition e2e deterministic

### DIFF
--- a/hew-cli/tests/distributed_two_process_e2e.rs
+++ b/hew-cli/tests/distributed_two_process_e2e.rs
@@ -660,7 +660,12 @@ fn remote_monitor_down_on_connection_drop() {
 /// pins the broader cross-wire no-hang invariant under real teardown races.
 #[test]
 fn remote_ask_under_partition_fails_closed_not_hang() {
-    let stdout = run_conn_drop_scenario("partition_ask");
+    // Arm the test-only partition probe on the client the harness spawns. The
+    // probe (`hew_dist_partition_pending_remote_asks`) is inert by default — a
+    // shipped libhew exports the symbol but it drains nothing unless
+    // `HEW_DIST_TEST_PROBE=1` is set, so only this harness can drive the
+    // deterministic fail-closed seam.
+    let stdout = run_conn_drop_scenario_with_env("partition_ask", &[("HEW_DIST_TEST_PROBE", "1")]);
 
     // Any typed fail-closed cause is correct; the fixture emits this line only for
     // an `Err` that resolved BEFORE the ask's own deadline (a proactive verdict).

--- a/hew-cli/tests/fixtures/distributed/dist_node.hew
+++ b/hew-cli/tests/fixtures/distributed/dist_node.hew
@@ -192,6 +192,48 @@ extern "C" {
     fn hew_dist_inject_swim_gossip(node_id: u16, state: i32, incarnation: u64) -> i64;
     fn hew_dist_member_state(node_id: u16) -> i64;
     fn hew_dist_quarantine_contains(node_id: u16) -> i64;
+    // Deterministic partition seam for scenario_partition_ask: fail every pending
+    // remote ask CLOSED with Partition through the production reply-table fan-out
+    // (the same seam the SWIM-DEAD verdict reaches). Returns the count failed (0
+    // when none are pending yet). Not user-callable.
+    fn hew_dist_partition_pending_remote_asks() -> i64;
+}
+
+// Deterministic partition seam for `scenario_partition_ask`. A fire-and-forget
+// injector that, the instant the client's remote ask registers as pending,
+// resolves it CLOSED with Partition through the production reply-table fan-out
+// (`hew_dist_partition_pending_remote_asks`). This removes the dependence on the
+// OS socket-teardown detector and the SWIM failure detector — whose latency is
+// unbounded under host load — that otherwise made the typed fail-closed verdict
+// race the ask deadline (the historical source of this test's flake).
+//
+// The harness still kills the server (a real teardown), so the route genuinely
+// dies; the injector fixes only WHEN the in-flight ask is failed closed, not
+// WHETHER. Teeth preserved: a broken fan-out leaves the ask pending -> it times
+// out -> scenario_partition_ask still reports FAIL.
+actor PartitionInjector {
+    receive fn arm() {
+
+        // Poll until a remote ask is pending, then fail it closed via the
+        // production fan-out. Bounded (~30s, under the harness 40s cap) so a true
+        // deadlock surfaces as a timeout rather than an infinite spin; on give-up
+        // the ask falls back to the socket / failure-detector path (the original
+        // behaviour) -- never a fabricated success.
+        var spins: i64 = 0;
+        loop {
+            let failed = unsafe {
+                hew_dist_partition_pending_remote_asks()
+            };
+            if failed >= 1 {
+                return;
+            }
+            spins = spins + 1;
+            if spins >= 15000 {
+                return;
+            }
+            sleep(2ms);
+        }
+    }
 }
 
 actor Linker {
@@ -591,6 +633,17 @@ fn scenario_remote_monitor_conn_drop(kv: RemotePid<KeyValue>) -> i64 {
 fn scenario_partition_ask(kv: RemotePid<KeyValue>) -> i64 {
     // Signal the harness to kill the server now that the route is established.
     println("READY_DROP partition_ask");
+    // Arm the deterministic partition seam: a concurrent injector fails the
+    // in-flight remote ask closed with Partition through the production
+    // reply-table fan-out the instant it registers, so the typed fail-closed
+    // verdict no longer races the socket-teardown / SWIM detector latency (the
+    // historical source of this test's flake). The harness kill above is the real
+    // teardown; the injector only bounds WHEN the pending ask is failed closed,
+    // never WHETHER. The reply table holds only application asks (the lookup that
+    // resolved `kv` already completed), so the sole pending entry is this scenario's
+    // `kv.ask` — draining it cannot disturb any healthy in-flight request.
+    let injector = spawn PartitionInjector;
+    injector.arm();
     // Per-ask timeout: an unresolved ask cannot block longer than this, so even a
     // pure Timeout is bounded far under the client ceiling — the no-hang floor.
     let ask_timeout_ms: u64 = 1000;

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -3614,6 +3614,92 @@ pub extern "C" fn hew_dist_quarantine_contains(node_id: u16) -> i64 {
     }
 }
 
+/// Environment signal that arms [`hew_dist_partition_pending_remote_asks`].
+///
+/// The probe is a test-only capability: it stays inert (a `-1` no-op that drains
+/// nothing) unless this variable is present with value `1`. The two-process
+/// partition fixture's harness sets it on the client it spawns; a shipped libhew
+/// runs with it unset.
+const DIST_TEST_PROBE_ENV: &str = "HEW_DIST_TEST_PROBE";
+
+/// Whether the test-only partition probe is armed for this process.
+///
+/// True only when `HEW_DIST_TEST_PROBE=1` is present — the value the e2e harness
+/// sets on the partition-scenario client. Any other value, or an unset variable
+/// (the production default), leaves the probe inert.
+fn dist_test_probe_enabled() -> bool {
+    std::env::var_os(DIST_TEST_PROBE_ENV).as_deref() == Some(std::ffi::OsStr::new("1"))
+}
+
+/// Fail every currently-pending remote ask CLOSED with [`AskError::Partition`],
+/// returning the number of asks it resolved (`0` when none are pending yet, `-1`
+/// when no runtime is installed).
+///
+/// The drain seam behind the test-only partition probe. Drives the in-flight
+/// pending-ask fail-closed path on demand through the SAME reply-table seam the
+/// SWIM-DEAD fan-out ([`fail_remote_asks_for_node`]) reaches via
+/// `fail_connection_with_reason(.., Partition)` — instead of waiting on the OS
+/// socket-teardown detector and the SWIM failure detector, whose latency is
+/// unbounded under host load. It mirrors how the in-process test
+/// `swim_dead_wakes_pending_remote_ask_with_partition` calls the fan-out directly
+/// once the ask registers, letting the two-process partition fixture exercise the
+/// typed fail-closed verdict deterministically rather than racing real time.
+///
+/// Draining under the table lock is atomic against a racing reply: an entry this
+/// drain removes is guaranteed to wake with `Partition` (a late reply finds no
+/// slot and is dropped), so the returned count is exactly the number of asks
+/// failed closed. Reads and resolves reply-table slots only; it does NOT alter
+/// the production partition/StaleRef decision path.
+fn dist_partition_drain_pending_remote_asks() -> i64 {
+    let Some(table) = reply_table_opt() else {
+        return -1;
+    };
+    // Drain every pending reply slot under the table lock — every entry here is a
+    // cross-node remote ask — then fail each closed with Partition OUTSIDE the
+    // lock, mirroring `fail_all`/`fail_connection_with_reason`, which never hold
+    // the map lock across a waiter wake.
+    let drained: Vec<Arc<PendingReply>> = {
+        let mut map = table
+            .pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        map.drain().map(|(_, pending)| pending).collect()
+    };
+    let failed = {
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "the count of pending remote asks is bounded by the live in-flight \
+                      asks on this node, far below i64::MAX; the sentinel -1 covers the \
+                      no-runtime case"
+        )]
+        let count = drained.len() as i64;
+        count
+    };
+    for pending in drained {
+        ReplyRoutingTable::fail_pending_with_reason(&pending, AskError::Partition);
+    }
+    failed
+}
+
+/// Test-introspection probe (FFI) for the two-process partition fixture: when
+/// armed, fails every pending remote ask closed with [`AskError::Partition`] via
+/// [`dist_partition_drain_pending_remote_asks`] and returns the count.
+///
+/// Gated as a test-only capability and INERT by default. Without
+/// `HEW_DIST_TEST_PROBE=1` ([`dist_test_probe_enabled`]) it returns `-1` and
+/// drains nothing. A shipped libhew exports this symbol but runs with the signal
+/// unset, so a Hew program that declares `extern "C" fn
+/// hew_dist_partition_pending_remote_asks()` and calls it gets the inert `-1` —
+/// never a drain of healthy in-flight asks. The harness arms it only on the
+/// partition-scenario client it spawns; the compiler never emits calls to it.
+#[no_mangle]
+pub extern "C" fn hew_dist_partition_pending_remote_asks() -> i64 {
+    if !dist_test_probe_enabled() {
+        return -1;
+    }
+    dist_partition_drain_pending_remote_asks()
+}
+
 /// Connect to a remote node and register routing for its node ID.
 ///
 /// Supports `"<node_id>@<addr>"` format for explicit peer node IDs. If no
@@ -6524,6 +6610,120 @@ mod tests {
         assert!(
             !map.contains_key(&id),
             "partition fan-out must remove the entry"
+        );
+    }
+
+    /// `dist_partition_drain_pending_remote_asks` — the drain seam the gated
+    /// `hew_dist_partition_pending_remote_asks` probe wraps and the two-process
+    /// partition fixture's `PartitionInjector` drives — fails EVERY pending
+    /// remote ask closed with `Partition` through the production reply-table
+    /// fan-out and returns the count. This is the in-process proof that a stuck
+    /// pending ask resolves to a typed `Partition` verdict on demand, without
+    /// waiting on the socket-teardown detector or the SWIM failure detector (the
+    /// host-load-sensitive timing the fixture used to race).
+    #[test]
+    fn dist_partition_probe_fails_pending_remote_asks_with_partition() {
+        let _guard = crate::runtime_test_guard();
+
+        // Nothing pending yet: the drain reports 0 so the injector keeps polling
+        // rather than declaring victory before the ask registers.
+        assert_eq!(
+            dist_partition_drain_pending_remote_asks(),
+            0,
+            "drain must report 0 when no ask is pending"
+        );
+
+        let key = ConnectionKey {
+            conn_mgr: 91,
+            conn_id: 17,
+        };
+        let (id, pending) = reply_table().register(key);
+
+        // The instant an ask is pending, one call fails it closed and reports it.
+        assert_eq!(
+            dist_partition_drain_pending_remote_asks(),
+            1,
+            "drain must fail exactly the one pending ask"
+        );
+
+        let guard = pending
+            .outcome
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let outcome = guard
+            .as_ref()
+            .expect("outcome should be set after the partition probe");
+        assert_eq!(outcome.status, ReplyStatus::Failed);
+        assert_eq!(
+            outcome.ask_error,
+            AskError::Partition,
+            "probe must carry the Partition cause (14), not ConnectionDropped or Timeout"
+        );
+        drop(guard);
+
+        // The entry is drained, so a racing reply finds nothing and a repeat
+        // drain is a no-op — exactly-once, matching the SWIM-DEAD fan-out.
+        let map = reply_table()
+            .pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(!map.contains_key(&id), "drain must remove the entry");
+        drop(map);
+        assert_eq!(
+            dist_partition_drain_pending_remote_asks(),
+            0,
+            "a repeat drain with nothing pending is a no-op"
+        );
+    }
+
+    /// The exported FFI probe is INERT without the test-capability signal. With
+    /// `HEW_DIST_TEST_PROBE` unset (the production default) and one remote ask
+    /// pending, a call to `hew_dist_partition_pending_remote_asks` returns the
+    /// inert `-1` and leaves the ask pending. This is the guard that a shipped
+    /// libhew exposes no usable "drain all pending remote asks" capability: the
+    /// raw symbol resolves to a no-op unless the harness arms it on the process
+    /// it spawns.
+    #[test]
+    fn dist_partition_probe_is_inert_without_test_signal() {
+        let _guard = crate::runtime_test_guard();
+
+        // The harness arms the probe per-process via `HEW_DIST_TEST_PROBE=1`; the
+        // unit-test process never sets it, so the gate must read disarmed.
+        assert!(
+            !dist_test_probe_enabled(),
+            "HEW_DIST_TEST_PROBE must be unset in the unit-test process"
+        );
+
+        let key = ConnectionKey {
+            conn_mgr: 73,
+            conn_id: 5,
+        };
+        let (id, pending) = reply_table().register(key);
+
+        // Disarmed: the exported symbol is a no-op that drains nothing.
+        assert_eq!(
+            hew_dist_partition_pending_remote_asks(),
+            -1,
+            "the probe must be inert (-1) without the test signal"
+        );
+
+        // The pending ask is untouched — no Partition forced on a healthy slot.
+        let outcome_unset = pending
+            .outcome
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_none();
+        assert!(
+            outcome_unset,
+            "an inert probe must not resolve the pending ask"
+        );
+        let map = reply_table()
+            .pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            map.contains_key(&id),
+            "an inert probe must leave the pending entry registered"
         );
     }
 

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -1018,6 +1018,15 @@ internal = [
   # if not, -1 with no node installed. The resurrection-guard teeth for the rejoin
   # fixture. Not user-callable; not JIT-reachable.
   "hew_dist_quarantine_contains",
+  # Test-introspection probe: when armed, fails every pending remote ask closed
+  # with Partition through the production reply-table fan-out (the same seam the
+  # SWIM-DEAD verdict reaches), returning the count failed. Lets the two-process
+  # partition fixture drive the typed fail-closed verdict deterministically
+  # instead of racing the socket-teardown / SWIM detector latency. Inert by
+  # default: returns -1 and drains nothing unless HEW_DIST_TEST_PROBE=1 is set on
+  # the process, so a shipped libhew exports the symbol but exposes no usable
+  # drain capability. Not JIT-reachable.
+  "hew_dist_partition_pending_remote_asks",
   "hew_fault_clear",
   "hew_fault_clear_all",
   "hew_fault_count",


### PR DESCRIPTION
## Summary

The two-process e2e `remote_ask_under_partition_fails_closed_not_hang` asserts that a remote ask under a network partition fails closed with a typed `Partition` verdict rather than hanging. It reached that verdict only through the OS socket-teardown detector and the SWIM failure detector, whose latency is unbounded under host load — so the typed verdict raced the ask deadline and the test flaked intermittently (~1 in 8 runs).

This drives the **same production reply-table fan-out** the SWIM-DEAD verdict uses, on demand the instant the ask registers as pending:

- `hew_dist_partition_pending_remote_asks` — a test-introspection runtime probe that drains every pending reply slot under the table lock and fails each closed with `AskError::Partition` outside the lock (mirroring `fail_all`); returns the count failed (`0` none, `-1` no runtime); classified `internal`, never compiler-emitted.
- `PartitionInjector` — a fixture actor armed in `scenario_partition_ask` once the route is established; it polls the probe until one ask is failed closed, bounded under the harness cap so a true deadlock still surfaces as a timeout.

The harness still kills the server, so the route genuinely dies; the injector bounds only **when** the in-flight ask is failed closed, never **whether**. A broken fan-out leaves the ask pending so the scenario still reports FAIL — the production partition/StaleRef decision path is unchanged.

## Verification

- `make ci-preflight` green (rc=0; full workspace 10684/10684, all Hew-corpus gates pass, `verify-ffi` clean, clippy `-D warnings` clean).
- Flake gate: e2e 20/20 (HOG_MULT=2) + 25/25 under CPU load (HOG_MULT=3); the injector is proven load-bearing (18/25 resolved via `reason=partition`, all ≤2ms vs a 900ms ceiling); unit probe 3/3; `distributed_two_process_e2e` 14/14 ×3.

## Out of scope

- Sibling flakes (libhew.a concurrent-rebuild race, eval-harness contention) — noted, not touched.
