### PR TITLE
fix(mir): release Vec<direct-enum> via heap-ownership authority

### DIFF
--- a/examples/v05/checked-mir/golden/vec_descriptor_slice.elab.mir
+++ b/examples/v05/checked-mir/golden/vec_descriptor_slice.elab.mir
@@ -68,13 +68,14 @@ fn main -> ()
     branch[bb4: bb5/bb6] ->
       (none)
     panic[bb5] ->
-      (none)
+      drop _1 ty=Vec<CheckedMirColour> kind=cow_heap(hew_vec_free)
     branch[bb6: bb5/bb7] ->
       (none)
     branch[bb7: bb8/bb9] ->
       (none)
     panic[bb8] ->
-      (none)
+      drop _14 ty=Vec<CheckedMirColour> kind=cow_heap(hew_vec_free)
+      drop _1 ty=Vec<CheckedMirColour> kind=cow_heap(hew_vec_free)
     call[bb9 checked_mir_colour_tag -> bb10] ->
       (none)
     call[bb10 println_i64 -> bb11] ->
@@ -89,6 +90,8 @@ fn main -> ()
       (none)
     panic[bb15] ->
       drop _21 ty=Vec<CheckedMirPoint> kind=cow_heap(hew_vec_free)
+      drop _14 ty=Vec<CheckedMirColour> kind=cow_heap(hew_vec_free)
+      drop _1 ty=Vec<CheckedMirColour> kind=cow_heap(hew_vec_free)
     branch[bb16: bb15/bb17] ->
       (none)
     branch[bb17: bb18/bb19] ->
@@ -96,11 +99,15 @@ fn main -> ()
     panic[bb18] ->
       drop _34 ty=Vec<CheckedMirPoint> kind=cow_heap(hew_vec_free)
       drop _21 ty=Vec<CheckedMirPoint> kind=cow_heap(hew_vec_free)
+      drop _14 ty=Vec<CheckedMirColour> kind=cow_heap(hew_vec_free)
+      drop _1 ty=Vec<CheckedMirColour> kind=cow_heap(hew_vec_free)
     call[bb19 println_i64 -> bb20] ->
       (none)
     return[bb20] ->
       drop _34 ty=Vec<CheckedMirPoint> kind=cow_heap(hew_vec_free)
       drop _21 ty=Vec<CheckedMirPoint> kind=cow_heap(hew_vec_free)
+      drop _14 ty=Vec<CheckedMirColour> kind=cow_heap(hew_vec_free)
+      drop _1 ty=Vec<CheckedMirColour> kind=cow_heap(hew_vec_free)
 
 fn i8::fmt -> string
   statements:

--- a/hew-cli/tests/vec_enum_element_leak_oracle.rs
+++ b/hew-cli/tests/vec_enum_element_leak_oracle.rs
@@ -1,0 +1,422 @@
+//! `Vec<enum>` local scope-exit drop oracles: per-iteration leak slope for the
+//! direct-enum element class, plus an owned-route-intact pin and a
+//! poisoned-allocator no-double-free pin for the escape shapes.
+//!
+//! Empirical oracle for the direct-enum Vec leak class. A local `Vec<E>` whose
+//! element `E` is a direct (fieldless / non-indirect) user enum owns no heap,
+//! so it must ride the PLAIN release path (`hew_vec_free`, buffer + handle).
+//! Pre-fix, the plain-vs-owned routing in `hew-mir/src/lower.rs` decided
+//! plainness from `ValueClass::of_ty(elem) == ValueClass::BitCopy` alone.
+//! `ValueClass` deliberately excludes user enums (hew-hir's
+//! `finalize_user_record_value_classes` covers records only), so a direct
+//! enum was never `BitCopy`: `is_plain_vec_element` said "not plain" and
+//! `is_owned_vec_element` said "not owned", `classify_vec_element_release`
+//! returned `Unsupported(UnenumeratedShape)`, and — because the compile-time
+//! reject only fires on `NoReleaseProtocol` — the program still compiled with
+//! NO drop emitted. Every `Vec<direct-enum>` local leaked its buffer AND its
+//! handle at scope exit: two nodes per frame.
+//!
+//! The fix reads the single heap-ownership authority instead of re-deriving
+//! heap-ness from the value class: the plain-Vec admission arms gained the
+//! additive `ty_is_direct_enum_element(elem) && !named_elem_owns_heap(elem)`
+//! disjunct, so a heap-free direct enum is correctly PLAIN and gets the plain
+//! release. The `ValueClass::BitCopy` disjunct is retained unchanged for
+//! records and `BitCopy` builtins.
+//!
+//! ## Slope methodology
+//!
+//! Mirrors `vec_local_drop_leak_oracle.rs`: compile the same shape at a LOW
+//! frame count and a HIGH frame count, measure leak NODE counts under
+//! `leaks --atExit` with the poisoned-allocator triple, and assert the delta
+//! stays within a small constant independent of frames. The pre-fix bug class
+//! is PER-FRAME GROWTH (one leaked vec per loop iteration — two nodes for a
+//! direct enum: handle + buffer), which over a `50 - 3 = 47`-frame delta lands
+//! ~94 nodes above the +5 tolerance. Absolute counts are deliberately not
+//! asserted — runtime/scheduler one-off allocations jitter by +/-1 node.
+//!
+//! ## Owned-route-intact pin
+//!
+//! The fix is additive and surgical: it flips ONLY heap-free direct enums to
+//! plain. A payload-carrying enum (`Label(string)`) still owns heap, so it
+//! must keep riding the OWNED release path (`hew_vec_free_owned`, which walks
+//! and releases each element's payload). `payload_enum_vec_loop` asserts that
+//! shape stays flat too — a regression that mis-routed it to plain would leak
+//! the per-element `string` payloads (slope), and an over-drop that released a
+//! payload twice would crash under the scribble triple. Zero leaks + clean
+//! exit proves the owned route survived and the fix does not over-drop.
+//!
+//! ## No-double-free pin
+//!
+//! The escape shapes the prover must EXCLUDE (a returned vec, a vec consumed
+//! by a by-value call) run to completion under
+//! `MallocScribble`/`MallocPreScribble`/`MallocGuardEdges` and must exit with
+//! the expected value: a producer-side drop of a handle the new owner also
+//! releases would crash (or corrupt the result) under the poisoned allocator
+//! before any assertion is read.
+//!
+//! ## Skip behaviour
+//!
+//! The slope oracles are macOS-only (`leaks(1)` is Darwin's allocator
+//! inspector); on other platforms they log `skip:` and return. The scribble
+//! pin runs on any unix host.
+//!
+//! The tuple-of-enum variant (`Vec<(Colour, i64)>`) that also exercises the
+//! `tuple_is_all_bitcopy` release arm is intentionally NOT a runtime fixture
+//! here: `Vec::new`/array-literal construction of a tuple-element vec is a
+//! separate NYI on trunk (`no constructor lowering for element type
+//! Tuple(..)`), so the shape is unreachable at runtime. That arm's routing is
+//! covered by the `release_bucket_partition_is_total_over_vec_elements`
+//! totality test in `hew-mir/src/lower.rs`.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+/// Low frame count: exercises the loop back-edge path at least twice while
+/// staying close to the constant-overhead floor.
+const LOW_FRAMES: usize = 3;
+
+/// High frame count for the slope check. A slope of ~2.0 leaks/frame (the
+/// pre-fix measurement for the direct-enum Vec leak class: buffer + handle)
+/// produces roughly `2 * (HIGH_FRAMES - LOW_FRAMES) = 94` excess nodes against
+/// the tolerance of 5.
+const HIGH_FRAMES: usize = 50;
+
+/// Maximum permitted leak-node delta between the HIGH and LOW probes. Same
+/// headroom rationale as the sibling oracles: absorbs one-off
+/// scheduler/runtime allocations that appear only in the HIGH run while still
+/// catching a slope of ~0.1 leaks/frame.
+const SLOPE_TOLERANCE: usize = 5;
+
+// ── fixtures ──────────────────────────────────────────────────────────────
+
+/// Fixture A — the probe's primary leaking shape. A `while` loop creates one
+/// fresh `Vec<Colour>` per iteration (`Colour` is a direct, fieldless user
+/// enum that owns no heap), pushes into it, and reads it back, then lets it go
+/// out of scope on the back-edge. Pre-fix: the handle and its buffer leak
+/// every iteration (the enum was classified neither plain nor owned, so no
+/// drop was emitted). Post-fix: the direct enum is proven heap-free by
+/// `named_elem_owns_heap`, routed PLAIN, and released on every back-edge plus
+/// the final fall-through.
+fn colour_vec_loop_source(frames: usize) -> String {
+    format!(
+        "enum Colour {{ Red; Green; Blue; }}\n\
+         \n\
+         fn tag(c: Colour) -> i64 {{\n\
+         \x20   match c {{\n\
+         \x20       Colour::Red => 1,\n\
+         \x20       Colour::Green => 2,\n\
+         \x20       Colour::Blue => 3,\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let v: Vec<Colour> = Vec::new();\n\
+         \x20       v.push(Colour::Red);\n\
+         \x20       v.push(Colour::Green);\n\
+         \x20       total = total + v.len() + tag(v[0]);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Fixture B — the owned-route-intact pin. `Shape::Label(string)` owns heap,
+/// so `Vec<Shape>` must keep riding the OWNED release path even after the
+/// fix. The `hew_vec_free_owned` walk releases each element's `string`
+/// payload along with the buffer and handle, so the slope stays flat. A
+/// regression that mis-routed this to plain would leak the per-element
+/// payloads (a slope); this fixture is the complement to Fixture A that
+/// proves the fix flips ONLY heap-free direct enums.
+fn payload_enum_vec_loop_source(frames: usize) -> String {
+    format!(
+        "enum Shape {{ Dot; Label(string); }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let v: Vec<Shape> = Vec::new();\n\
+         \x20       v.push(Shape::Label(\"heap-owning-per-iteration-payload\"));\n\
+         \x20       v.push(Shape::Dot);\n\
+         \x20       total = total + v.len();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Escape shapes — the no-double-free side. `make()` returns its vec (the
+/// caller owns the release), and `total()` consumes one by value (the callee
+/// owns the release). A producer-side scope-exit drop on either handle would
+/// free what the new owner also frees; under the poisoned-allocator triple
+/// that crashes before main can print its checksum. Values: `make()` yields
+/// `[Green, Blue]` (tags 2 + 3 = 5); the consumed vec is `[Blue, Blue]`
+/// (tags 3 + 3 = 6); the sum is 11.
+const ESCAPE_SHAPES_SOURCE: &str = "\
+enum Colour { Red; Green; Blue; }\n\
+\n\
+fn tag(c: Colour) -> i64 {\n\
+\x20   match c {\n\
+\x20       Colour::Red => 1,\n\
+\x20       Colour::Green => 2,\n\
+\x20       Colour::Blue => 3,\n\
+\x20   }\n\
+}\n\
+\n\
+fn make() -> Vec<Colour> {\n\
+\x20   let v: Vec<Colour> = Vec::new();\n\
+\x20   v.push(Colour::Green);\n\
+\x20   v.push(Colour::Blue);\n\
+\x20   return v;\n\
+}\n\
+\n\
+fn total(xs: Vec<Colour>) -> i64 {\n\
+\x20   tag(xs[0]) + tag(xs[1])\n\
+}\n\
+\n\
+fn main() {\n\
+\x20   let made = make();\n\
+\x20   let a = tag(made[0]) + tag(made[1]);\n\
+\x20   let v: Vec<Colour> = Vec::new();\n\
+\x20   v.push(Colour::Blue);\n\
+\x20   v.push(Colour::Blue);\n\
+\x20   let b = total(v);\n\
+\x20   print(a + b);\n\
+\x20   print(\"OK\");\n\
+}\n";
+
+// ── leak measurement plumbing (same shape as vec_local_drop_leak_oracle) ──
+
+/// Compile `source` to a native binary via `hew compile --emit-dir` and
+/// return the binary path.
+fn compile_to_native(source: &str, dir: &std::path::Path, name: &str) -> PathBuf {
+    let hew_src = dir.join(format!("{name}.hew"));
+    std::fs::write(&hew_src, source).expect("write hew source");
+
+    let output = Command::new(hew_binary())
+        .args([
+            "compile",
+            "--emit-dir",
+            dir.to_str().expect("emit-dir utf-8"),
+            hew_src.to_str().expect("hew src utf-8"),
+        ])
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew compile");
+
+    assert!(
+        output.status.success(),
+        "hew compile failed for {name}:\n{}",
+        describe_output(&output)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let bin = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("native: "))
+        .unwrap_or_else(|| panic!("no `native:` line for {name}:\n{stdout}"))
+        .to_string();
+    PathBuf::from(bin)
+}
+
+/// Run `bin` under the poisoned-allocator triple + `leaks --atExit` and
+/// return `Some(leak_count)` when `leaks` produced a usable report.
+fn measure_leaks(bin: &std::path::Path) -> Option<usize> {
+    let output = Command::new("leaks")
+        .arg("--atExit")
+        .arg("--")
+        .arg(bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .ok()?;
+    if !output.status.success() && output.stdout.is_empty() {
+        eprintln!(
+            "skip: leaks declined to attach to {}: {}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        return None;
+    }
+    let report = String::from_utf8_lossy(&output.stdout);
+    let mut parsed: Option<usize> = None;
+    for line in report.lines() {
+        if !line.contains(" leaks for ") && !line.contains(" leak for ") {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("Process ") {
+            if !rest.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+                continue;
+            }
+            if let Some(after_colon) = rest.split_once(": ").map(|(_, s)| s) {
+                if let Some(n) = after_colon.split_whitespace().next() {
+                    if let Ok(n) = n.parse::<usize>() {
+                        eprintln!("  parsed leak count from line: {line}");
+                        parsed = Some(n);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    if parsed.is_none() {
+        eprintln!(
+            "skip: leaks did not emit a `Process <pid>: N leak(s) for B total leaked bytes.` \
+             summary for {}: stderr=\n{}",
+            bin.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    parsed
+}
+
+/// Build the shape at `low_frames` and `high_frames`, measure leak NODE
+/// counts, and assert the delta stays within `SLOPE_TOLERANCE`.
+fn assert_frame_slope_below_tolerance(
+    shape_name: &str,
+    source_fn: fn(usize) -> String,
+    low_frames: usize,
+    high_frames: usize,
+) {
+    if !cfg!(target_os = "macos") {
+        eprintln!("skip: {shape_name}: leaks(1) is macOS-only");
+        return;
+    }
+    let leaks_avail = Command::new("which")
+        .arg("leaks")
+        .output()
+        .is_ok_and(|o| o.status.success());
+    if !leaks_avail {
+        eprintln!("skip: {shape_name}: `leaks` binary not on PATH");
+        return;
+    }
+
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("vec-enum-leak-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+
+    let bin_low = compile_to_native(
+        &source_fn(low_frames),
+        dir.path(),
+        &format!("{shape_name}_low"),
+    );
+    let bin_high = compile_to_native(
+        &source_fn(high_frames),
+        dir.path(),
+        &format!("{shape_name}_high"),
+    );
+
+    let Some(low_leaks) = measure_leaks(&bin_low) else {
+        return;
+    };
+    let Some(high_leaks) = measure_leaks(&bin_high) else {
+        return;
+    };
+
+    eprintln!(
+        "{shape_name}: low_frames={low_frames} low_leaks={low_leaks} \
+         high_frames={high_frames} high_leaks={high_leaks} \
+         tolerance={SLOPE_TOLERANCE}"
+    );
+    assert!(
+        high_leaks <= low_leaks + SLOPE_TOLERANCE,
+        "{shape_name}: per-frame leak SLOPE — low_frames={low_frames} low_leaks={low_leaks}, \
+         high_frames={high_frames} high_leaks={high_leaks}. Excess of {} NODES over the \
+         tolerance of {SLOPE_TOLERANCE} indicates a per-iteration Vec allocation is not being \
+         released. For the direct-enum shape this is the pre-fix leak class (routing read \
+         `ValueClass::BitCopy` instead of the `named_elem_owns_heap` authority, so the enum was \
+         neither plain nor owned and no drop was emitted; slope ~2.0 leaks/frame). \
+         Re-run with `MallocStackLogging=1 leaks --atExit -- {}` to see which stack the leaked \
+         block came from.",
+        high_leaks.saturating_sub(low_leaks + SLOPE_TOLERANCE),
+        bin_high.display()
+    );
+}
+
+// ── oracles ───────────────────────────────────────────────────────────────
+
+/// Fixture A: per-iteration `Vec<Colour>` locals (direct fieldless enum) must
+/// not leak. Pre-fix slope is ~2.0 leaks/frame (buffer + handle, no drop
+/// emitted because the enum was neither plain nor owned); post-fix the
+/// per-iteration handle and buffer are released on every back-edge. Reverting
+/// the `ty_is_direct_enum_element(elem) && !named_elem_owns_heap(elem)`
+/// disjunct in `is_plain_vec_element` fails this by ~94 nodes.
+#[test]
+fn vec_colour_local_loop_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "vec_colour_local_loop",
+        colour_vec_loop_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// Fixture B: per-iteration `Vec<Shape>` locals where `Shape::Label(string)`
+/// owns heap must ALSO stay flat — via the OWNED route, not plain. This is the
+/// complement to Fixture A: it proves the fix is surgical (flips only heap-free
+/// direct enums) and does not over-drop. A mis-route to plain would leak the
+/// per-element `string` payloads; an over-drop would crash under the scribble
+/// triple that `leaks` runs with.
+#[test]
+fn vec_payload_enum_local_loop_stays_on_owned_route() {
+    assert_frame_slope_below_tolerance(
+        "vec_payload_enum_local_loop",
+        payload_enum_vec_loop_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// No-double-free pin: the returned-vec and consumed-by-value shapes run to
+/// completion under the poisoned-allocator triple and print the expected
+/// checksum (5 + 6 = 11). A producer-side drop of either escaped `Vec<Colour>`
+/// handle would free memory the new owner also frees — under
+/// `MallocScribble`/`MallocGuardEdges` that aborts (or scribbles the values)
+/// before the checksum is printed.
+#[test]
+fn vec_enum_escape_shapes_run_clean_under_malloc_scribble() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("vec-enum-leak-escape-shapes-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(ESCAPE_SHAPES_SOURCE, dir.path(), "escape_shapes");
+
+    let output = Command::new(&bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .expect("run escape-shapes binary");
+
+    assert!(
+        output.status.success(),
+        "escape shapes must run clean under the poisoned allocator — a crash here indicates a \
+         producer-side drop of a moved-out vec (double free);\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        "11OK",
+        "escape shapes must print the 5 + 6 checksum untouched — a scribbled value indicates the \
+         producer freed a handle the new owner still reads;\n{}",
+        describe_output(&output)
+    );
+}

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -10699,13 +10699,16 @@ impl Builder {
         if !is_enum && !is_record {
             return false;
         }
-        // ONLY a genuinely heap-owning (non-BitCopy) element is an owned-Vec
-        // element. An all-BitCopy record/enum (e.g. `type Point { x: i64; y:
-        // i64 }`) is `Copy` and stays on the existing BitCopy `_layout` path —
-        // harvesting it would mis-route its Vec's element loads through the
-        // owned getter (which reads an owned descriptor the Copy Vec never
-        // carries). Check field/variant heap-ownership via the record/enum
-        // registries.
+        // ONLY a genuinely heap-owning element is an owned-Vec element, decided
+        // by the `named_elem_owns_heap` authority (NOT by `ValueClass::BitCopy`,
+        // which finalises records only). A heap-free record (e.g.
+        // `type Point { x: i64; y: i64 }`, which is `BitCopy`) OR a heap-free
+        // direct enum (e.g. `enum Colour { Red; Green; Blue }`, which is NOT
+        // `BitCopy`) owns no heap and stays on the plain-Vec path
+        // (`is_plain_vec_element`); harvesting it would mis-route its Vec's
+        // element loads through the owned getter (which reads an owned
+        // descriptor the plain Vec never carries). Check field/variant
+        // heap-ownership via the record/enum registries.
         if !self.named_elem_owns_heap(elem) {
             return false;
         }
@@ -11230,15 +11233,37 @@ impl Builder {
             .collect()
     }
 
-    /// True when `elem` is a PLAIN `Vec` element — a `BitCopy` scalar, `string`
-    /// (whose element release is the runtime's `ElemKind::String` walk under the
-    /// buffer-only `hew_vec_free`), a `BitCopy` value aggregate (a record /
-    /// direct enum), or an all-`BitCopy` tuple. This is the element-level core of
-    /// [`Builder::binding_ty_is_plain_vec`], factored so
-    /// [`Builder::classify_vec_element_release`] shares the exact same
-    /// plain-element authority — one body, no second copy to drift. See
-    /// `binding_ty_is_plain_vec` for why the `Named` arm uses `ValueClass::of_ty`
-    /// and the `Tuple` arm uses `tuple_is_all_bitcopy` (the `Tuple` value class
+    /// True when `elem` is a PLAIN `Vec` element — one released by the
+    /// buffer-only `hew_vec_free` (with the runtime's own `ElemKind` walk for
+    /// `string`/layout elements), carrying NO owned-descriptor or closure-pair
+    /// release. Covers: a `BitCopy` scalar or `string`; a `BitCopy` value record
+    /// (and scalar builtins that reach the classifier as `Named`, e.g.
+    /// `Instant`); a DIRECT (non-indirect) user enum that owns no heap; and an
+    /// all-plain tuple.
+    ///
+    /// The `Named` arm reads the heap-ownership AUTHORITY, not `ValueClass`
+    /// alone. `ValueClass::of_ty` finalises records only, so a fieldless /
+    /// scalar-payload user enum is NEVER `BitCopy`; gating solely on
+    /// `ValueClass::of_ty == BitCopy` (the pre-fix form) classified such an enum
+    /// NEITHER plain nor owned, leaving its `Vec` with no scope-exit release — a
+    /// whole-buffer+handle leak. The arm therefore also admits a direct enum via
+    /// `ty_is_direct_enum_element(elem) && !named_elem_owns_heap(elem)`: a
+    /// heap-free direct enum is plain, a heap-owning one still routes owned. The
+    /// `BitCopy` disjunct is retained for the shapes `ValueClass` classifies
+    /// correctly (records, `Instant`), where a pure heap-authority gate would
+    /// wrongly exclude a `BitCopy` builtin not in the layout registry.
+    ///
+    /// The direct-enum membership is `ty_is_direct_enum_element`, extracted
+    /// verbatim from the layout-Vec constructor authority
+    /// (`vec_element_uses_layout_descriptor`), so a direct enum is RELEASED as a
+    /// plain layout Vec exactly when it was CONSTRUCTED as one — the
+    /// construct/release symmetry the runtime relies on, and congruent with the
+    /// vec-index getter's non-indirect-enum `hew_vec_get_layout` arm.
+    ///
+    /// This is the element-level core of [`Builder::binding_ty_is_plain_vec`],
+    /// factored so [`Builder::classify_vec_element_release`] shares the exact
+    /// same plain-element authority — one body, no second copy to drift. The
+    /// `Tuple` arm delegates to `tuple_is_all_bitcopy` (the `Tuple` value class
     /// is unconditionally `CowValue`, so it cannot discriminate field types).
     fn is_plain_vec_element(&self, elem: &ResolvedTy) -> bool {
         if matches!(
@@ -11262,8 +11287,21 @@ impl Builder {
         ) {
             return true;
         }
+        // A `Named` element is plain when it is BitCopy (records, and scalar
+        // builtins that reach the classifier as `Named` such as `Instant`), OR
+        // when it is a DIRECT user enum that owns no heap. The enum disjunct is
+        // load-bearing: `ValueClass::of_ty` finalises records only, so a
+        // fieldless / scalar-payload user enum is NEVER `BitCopy` and would
+        // otherwise be classified NEITHER plain nor owned — leaving its Vec with
+        // no scope-exit release (a buffer+handle leak). Heap-ness is read from
+        // the `named_elem_owns_heap` authority, never re-derived from BitCopy, so
+        // a heap-owning enum still routes owned. `ty_is_direct_enum_element` is
+        // the layout-Vec constructor's own membership, so release matches
+        // construction; it is congruent with the vec-index getter's non-indirect
+        // enum `hew_vec_get_layout` arm (`dedup-semantic-boundary`).
         (matches!(elem, ResolvedTy::Named { .. })
-            && ValueClass::of_ty(elem, &self.type_classes) == ValueClass::BitCopy)
+            && (ValueClass::of_ty(elem, &self.type_classes) == ValueClass::BitCopy
+                || (self.ty_is_direct_enum_element(elem) && !self.named_elem_owns_heap(elem))))
             || (matches!(elem, ResolvedTy::Tuple(_)) && self.tuple_is_all_bitcopy(elem))
     }
 
@@ -11291,34 +11329,35 @@ impl Builder {
     /// True when `ty` is the builtin `Vec<T>` whose element `T` is a PLAIN
     /// element — a `BitCopy` scalar (`i64`, `u8`, `bool`, `f64`, `char`,
     /// `Duration`, …), `string` (whose element release lives inside the
-    /// runtime's `ElemKind::String` walk), or a `BitCopy` value aggregate
-    /// (a record / direct enum / tuple whose fields are all `BitCopy`, e.g.
-    /// `type Point { x: i64, y: i64 }`). These are exactly the Vecs codegen
-    /// constructs WITHOUT an owned-element descriptor — the scalar/string ABIs
-    /// and the inline value-aggregate `hew_vec_new_with_layout` /
-    /// `hew_vec_get_layout` path — so the matching scope-exit release is the
-    /// plain `hew_vec_free` (buffer + handle; the runtime walks string elements
-    /// itself, and a `BitCopy` aggregate element owns no heap so no per-element
-    /// drop is needed). Substitutes through the monomorphisation map first
-    /// (mirroring `vec_receiver_has_owned_element`) so a polymorphic binding
-    /// type resolves to its concrete element.
+    /// runtime's `ElemKind::String` walk), a `BitCopy` value record (e.g.
+    /// `type Point { x: i64, y: i64 }`), a DIRECT (non-indirect) user enum that
+    /// owns no heap, or a tuple whose fields are all plain. These are exactly
+    /// the Vecs codegen constructs WITHOUT an owned-element descriptor — the
+    /// scalar/string ABIs and the inline value-aggregate
+    /// `hew_vec_new_with_layout` / `hew_vec_get_layout` path — so the matching
+    /// scope-exit release is the plain `hew_vec_free` (buffer + handle; the
+    /// runtime walks string elements itself, and a heap-free value-aggregate
+    /// element owns no heap so no per-element drop is needed). Substitutes
+    /// through the monomorphisation map first (mirroring
+    /// `vec_receiver_has_owned_element`) so a polymorphic binding type resolves
+    /// to its concrete element.
     ///
     /// Default-deny: ONLY the positively enumerated plain element shapes admit.
-    /// The `BitCopy` value-aggregate arm is the precise complement of the owned
-    /// arm: an owned-element Vec (record/enum/tuple with a string/bytes/nested-
-    /// collection field) is never admitted here and continues to route to its
-    /// dedicated `hew_vec_free_owned` release; a closure-pair `Vec<fn>` is
-    /// also excluded and routes to `hew_vec_free_closure_pairs`.
+    /// The plain arm is the precise complement of the owned arm: an owned-element
+    /// Vec (record/enum/tuple with a string/bytes/nested-collection field) is
+    /// never admitted here and continues to route to its dedicated
+    /// `hew_vec_free_owned` release; a closure-pair `Vec<fn>` is also excluded
+    /// and routes to `hew_vec_free_closure_pairs`.
     ///
-    /// For named records/enums the `ValueClass::of_ty(Named{..}) == BitCopy`
-    /// check is the exact discriminant. For tuples it cannot be used:
+    /// For named records the `ValueClass::of_ty(Named{..}) == BitCopy` check is
+    /// the discriminant. For direct user ENUMS it is NOT — `ValueClass` finalises
+    /// records only, so a fieldless / scalar-payload enum is never `BitCopy`;
+    /// `is_plain_vec_element` admits those via the `named_elem_owns_heap`
+    /// authority instead (see its doc). For tuples `ValueClass` cannot be used:
     /// `ValueClass::of_ty(Tuple(_))` ALWAYS returns `CowValue` regardless of
-    /// field types, so the tuple path delegates instead to `tuple_is_all_bitcopy`,
-    /// which recurses structurally: a tuple element is all-`BitCopy` iff every
-    /// field is a `BitCopy` scalar, a `Named` type with `ValueClass::of_ty ==
-    /// BitCopy`, or a nested tuple that satisfies the same predicate. This is the
-    /// correct complement of the owned authority; using `!is_owned_vec_element`
-    /// is unsound here because its backing `ty_contains_heap_owning` omits
+    /// field types, so the tuple path delegates to `tuple_is_all_bitcopy`, which
+    /// recurses structurally. Using `!is_owned_vec_element` as the complement is
+    /// unsound here because its backing `ty_contains_heap_owning` omits
     /// `record_field_resolved_tys` and can mis-classify a named record inside a
     /// tuple as non-heap-owning. An unresolved type parameter has no known value
     /// class and stays on the leak-as-before posture rather than risking a
@@ -11335,22 +11374,26 @@ impl Builder {
         // Element-level plain check factored into `is_plain_vec_element` so the
         // typed `classify_vec_element_release` partition shares the exact same
         // authority (no second copy to drift). The doc above this function
-        // records why the `Named` arm uses `ValueClass::of_ty` and the `Tuple`
-        // arm uses `tuple_is_all_bitcopy`.
+        // records why the `Named` arm reads the `named_elem_owns_heap` authority
+        // (not `ValueClass` alone) and the `Tuple` arm uses `tuple_is_all_bitcopy`.
         args.first()
             .is_some_and(|elem| self.is_plain_vec_element(elem))
     }
 
-    /// True when `ty` is a `Tuple` whose every element is all-`BitCopy` by
-    /// structural recursion.
+    /// True when `ty` is a `Tuple` whose every element is plain-releasable by
+    /// structural recursion (a plain tuple field carries no per-element heap
+    /// drop, so the tuple Vec releases via the buffer-only `hew_vec_free`).
     ///
-    /// A tuple element is all-`BitCopy` if it is:
+    /// A tuple element is plain if it is:
     /// - a `BitCopy` scalar (same allow-list as the scalar arm of
     ///   `binding_ty_is_plain_vec`),
-    /// - a `Named` type whose `ValueClass::of_ty` is `BitCopy` (the correct
-    ///   authority for records and direct enums — it is what
-    ///   `harvest_vec_owned_element_key` consults; a heap-owning record is never
-    ///   `BitCopy`), or
+    /// - a `Named` type that is either `ValueClass::of_ty == BitCopy` (the
+    ///   authority for records — a heap-owning record is never `BitCopy`) OR a
+    ///   DIRECT user enum that owns no heap. The enum disjunct is load-bearing:
+    ///   `ValueClass` finalises records only, so a fieldless / scalar-payload
+    ///   enum is never `BitCopy` and must be admitted through the
+    ///   `named_elem_owns_heap` authority, exactly as `is_plain_vec_element`
+    ///   does — or a `(Colour, i64)` tuple element would leak, or
     /// - a nested `Tuple` that also satisfies this predicate recursively.
     ///
     /// This is the correct complement of the owned authority for tuples.
@@ -11360,9 +11403,9 @@ impl Builder {
     /// tuple that transitively owns a `string` field can be mis-classified as
     /// non-heap-owning, silently admitting a `Vec<(Rec, i64)>` (where `Rec` has
     /// a `string` field) to the plain-Vec path and emitting `hew_vec_free`
-    /// where `hew_vec_free_owned` is required. `ValueClass::of_ty` for `Named`
-    /// types is the correct, complete authority and agrees with codegen's
-    /// `resolved_ty_contains_heap_leaf` (`dedup-semantic-boundary`).
+    /// where `hew_vec_free_owned` is required. The `BitCopy`-plus-`named_elem_
+    /// owns_heap` discriminant is complete for `Named` fields and agrees with
+    /// codegen's `resolved_ty_contains_heap_leaf` (`dedup-semantic-boundary`).
     fn tuple_is_all_bitcopy(&self, ty: &ResolvedTy) -> bool {
         let ResolvedTy::Tuple(elems) = ty else {
             return false;
@@ -11384,7 +11427,14 @@ impl Builder {
             | ResolvedTy::Char
             | ResolvedTy::Duration => true,
             ResolvedTy::Named { .. } => {
+                // A tuple field is BitCopy-compatible when it is itself BitCopy
+                // (records / scalar builtins), OR a direct user enum owning no
+                // heap. The enum disjunct mirrors `is_plain_vec_element`: user
+                // enums are never `ValueClass::BitCopy`, so without it a
+                // `(Colour, i64)` tuple element would leak. Heap-ness comes from
+                // the `named_elem_owns_heap` authority.
                 ValueClass::of_ty(e, &self.type_classes) == ValueClass::BitCopy
+                    || (self.ty_is_direct_enum_element(e) && !self.named_elem_owns_heap(e))
             }
             ResolvedTy::Tuple(_) => self.tuple_is_all_bitcopy(e),
             // Exhaustive (no `_ => false` fall-through): a new `ResolvedTy`
@@ -11432,13 +11482,39 @@ impl Builder {
                 self.record_field_orders
                     .keys()
                     .any(|known| known == &key || short_name(known) == short)
-                    || self.enum_layouts.iter().any(|el| {
-                        !el.is_indirect
-                            && (el.name == key || el.name == *name || short_name(&el.name) == short)
-                    })
+                    || self.ty_is_direct_enum_element(elem_ty)
             }
             _ => false,
         }
+    }
+
+    /// True when `elem_ty` is a registered DIRECT (non-indirect) user enum.
+    ///
+    /// A direct enum is stored inline in the vec buffer at its full
+    /// tagged-union stride — the same layout-descriptor path a `BitCopy` record
+    /// takes — whereas an indirect (heap-boxed, `is_indirect`) enum holds an
+    /// 8-byte pointer per slot and routes through the pointer ABI.
+    ///
+    /// This membership is the seam shared by the vec-index getter
+    /// (`hew_vec_get_layout` arm), the range-slice getter, and the plain-release
+    /// predicate. It is load-bearing for release routing because a payload-free
+    /// or scalar-payload direct enum owns no heap yet is NEVER marked `BitCopy`
+    /// in the HIR value-class table (`finalize_user_record_value_classes`
+    /// covers records only). Callers pair it with the `named_elem_owns_heap`
+    /// authority so a heap-owning direct enum still routes owned.
+    fn ty_is_direct_enum_element(&self, elem_ty: &ResolvedTy) -> bool {
+        let ResolvedTy::Named { name, args, .. } = elem_ty else {
+            return false;
+        };
+        let short = short_name(name);
+        let key = if args.is_empty() {
+            name.clone()
+        } else {
+            mangle_layout_key(short, args)
+        };
+        self.enum_layouts.iter().any(|el| {
+            !el.is_indirect && (el.name == key || el.name == *name || short_name(&el.name) == short)
+        })
     }
 
     /// True when `vec_ty` is a `Vec<T>` whose element `T` is an owned-Vec element.
@@ -17300,14 +17376,25 @@ impl Builder {
                 args,
                 ..
             } => {
-                // Owned-element Vec (element owns heap) releases via
-                // `hew_vec_free_owned` (per-element descriptor drop then buffer
-                // free); a plain (BitCopy / string) element Vec uses
-                // `hew_vec_free`. The owned-element predicate routes through the
-                // SAME `is_owned_vec_element` authority codegen's
-                // `resolved_ty_element_owns_heap_for_owned_vec` agrees with
+                // Closure-pair Vec<fn>/Vec<closure>: each slot owns a heap-boxed
+                // {code, env} pair (and the pair's env box); release walks the
+                // elements before the buffer/handle free via
+                // `hew_vec_free_closure_pairs`. Codegen's `cow_heap_release_symbol`
+                // checks the fn/closure element FIRST — a closure pair is neither
+                // an owned composite nor a plain leaf — so this arm must dispatch
+                // in the same order, or a yielded `Vec<fn>` computes `hew_vec_free`
+                // and fails the inline-drop congruence check
                 // (`dedup-semantic-boundary`).
-                if args.first().is_some_and(|e| self.is_owned_vec_element(e)) {
+                if ty_is_closure_pair_vec(ty) {
+                    Some("hew_vec_free_closure_pairs")
+                } else if args.first().is_some_and(|e| self.is_owned_vec_element(e)) {
+                    // Owned-element Vec (element owns heap) releases via
+                    // `hew_vec_free_owned` (per-element descriptor drop then buffer
+                    // free); a plain (BitCopy / string) element Vec uses
+                    // `hew_vec_free`. The owned-element predicate routes through the
+                    // SAME `is_owned_vec_element` authority codegen's
+                    // `resolved_ty_element_owns_heap_for_owned_vec` agrees with
+                    // (`dedup-semantic-boundary`).
                     Some("hew_vec_free_owned")
                 } else {
                     Some("hew_vec_free")
@@ -17609,9 +17696,11 @@ impl Builder {
                 // (`is_known_cow_heap_drop_symbol` / the RecordFieldDrop
                 // congruence assert). Both authorities are documented to agree;
                 // this restores that agreement.
-                if args.first().is_some_and(|e| {
-                    matches!(e, ResolvedTy::Function { .. } | ResolvedTy::Closure { .. })
-                }) {
+                // The closure-pair leaf test shares `ty_is_closure_pair` with
+                // `ty_is_closure_pair_vec` (used by the generator-yield picker),
+                // so every drop-symbol authority detects a fn/closure element
+                // through one predicate and cannot drift.
+                if args.first().is_some_and(ty_is_closure_pair) {
                     Some("hew_vec_free_closure_pairs")
                 } else if args.first().is_some_and(|e| self.is_owned_vec_element(e)) {
                     Some("hew_vec_free_owned")
@@ -45144,8 +45233,71 @@ mod binding_ty_is_plain_vec_tuple {
     /// path, swap its expected arm here — the test fails first if a bucket
     /// silently starts (or stops) claiming it.
     #[test]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the length is intrinsic: this is the single partition-totality \
+                  matrix over every Vec<E> element shape (scalars, string, tuple, \
+                  the four enum classes, nested collections, closure pair, and the \
+                  fail-closed entries), each asserted against the typed decision \
+                  and its three projected buckets — splitting it would scatter the \
+                  disjoint-cover proof across functions"
+    )]
     fn release_bucket_partition_is_total_over_vec_elements() {
-        let builder = builder_with_indirect_enum();
+        // Register the full USER-ENUM matrix alongside the indirect scalar
+        // `Foo`, so the partition is proven total over enums (not just over the
+        // builtin/scalar/tuple shapes the loops below already cover). User
+        // enums are never marked `ValueClass::BitCopy` (the HIR value-class pass
+        // finalises records only), so the Plain bucket must claim heap-free
+        // enums via the heap-ownership authority, not the value-class table:
+        //   - `Colour` — a DIRECT fieldless enum, owns no heap → Plain.
+        //   - `Tone`   — a DIRECT scalar-payload enum, owns no heap → Plain.
+        //   - `DirE`   — a DIRECT heap-payload (`string`) enum, owns heap →
+        //                OwnedElement (proves the Plain swap does NOT over-drop
+        //                a genuinely heap-owning enum — it still routes owned).
+        //   - `Foo`    — the indirect scalar enum from `builder_with_indirect_enum`
+        //                → Unsupported(NoReleaseProtocol) (heap-boxed node, no
+        //                wired per-element release).
+        // Compact non-indirect enum-layout builder: one `EnumLayout` whose
+        // variants carry the given field types (empty = fieldless).
+        fn direct_enum(
+            name: &str,
+            variants: &[(&str, Vec<ResolvedTy>)],
+        ) -> crate::model::EnumLayout {
+            crate::model::EnumLayout {
+                name: name.to_string(),
+                tag_width: 1,
+                variants: variants
+                    .iter()
+                    .map(|(vname, field_tys)| crate::model::MachineVariantLayout {
+                        name: (*vname).to_string(),
+                        field_tys: field_tys.clone(),
+                        field_names: vec![],
+                    })
+                    .collect(),
+                is_indirect: false,
+            }
+        }
+        let mut builder = builder_with_indirect_enum();
+        builder.enum_layouts.push(direct_enum(
+            "Colour",
+            &[("Red", vec![]), ("Green", vec![]), ("Blue", vec![])],
+        ));
+        builder.enum_layouts.push(direct_enum(
+            "Tone",
+            &[
+                ("Bright", vec![ResolvedTy::I64]),
+                ("Dark", vec![ResolvedTy::I64]),
+            ],
+        ));
+        builder.enum_layouts.push(direct_enum(
+            "DirE",
+            &[("A", vec![ResolvedTy::String]), ("B", vec![])],
+        ));
+        // Harvest DirE's owned-element key exactly as lowering would when it
+        // observes a `Vec<DirE>` construction, so `is_owned_vec_element` claims
+        // it (the owned bucket is keyed off the harvested set, not re-derived).
+        builder.harvest_vec_owned_element_key(&vec_of_ty(unregistered_named("DirE")));
+        let builder = builder;
 
         // Assert `elem` resolves to `want`, the outer `Vec<elem>` owns heap, and
         // the three bool buckets project EXACTLY from the typed decision (so the
@@ -45178,7 +45330,9 @@ mod binding_ty_is_plain_vec_tuple {
             );
         };
 
-        // Plain bucket: BitCopy scalar / string / all-BitCopy aggregate elements.
+        // Plain bucket: BitCopy scalar / string / all-BitCopy aggregate
+        // elements, plus heap-free DIRECT user enums (fieldless + scalar
+        // payload) and a tuple whose fields include a heap-free direct enum.
         for elem in [
             ResolvedTy::I64,
             ResolvedTy::Bool,
@@ -45187,11 +45341,19 @@ mod binding_ty_is_plain_vec_tuple {
             ResolvedTy::Duration,
             ResolvedTy::String,
             ResolvedTy::Tuple(vec![ResolvedTy::I64, ResolvedTy::I64]),
+            // Heap-free direct enums: never `ValueClass::BitCopy`, claimed by
+            // the Plain bucket through `!named_elem_owns_heap` instead.
+            unregistered_named("Colour"),
+            unregistered_named("Tone"),
+            // A tuple containing a heap-free direct enum is all-`BitCopy` too.
+            ResolvedTy::Tuple(vec![unregistered_named("Colour"), ResolvedTy::I64]),
         ] {
             assert_disposition(elem, VecElementRelease::Plain);
         }
 
-        // Owned-element bucket: nested collections + heap-owning tuples.
+        // Owned-element bucket: nested collections + heap-owning tuples, plus a
+        // heap-owning DIRECT enum (inline storage, owned-element ABI) and a
+        // tuple carrying one — the swap must NOT reclassify these as Plain.
         for elem in [
             ResolvedTy::named_builtin("Vec", BuiltinType::Vec, vec![ResolvedTy::I64]),
             ResolvedTy::named_builtin(
@@ -45201,6 +45363,8 @@ mod binding_ty_is_plain_vec_tuple {
             ),
             ResolvedTy::named_builtin("HashSet", BuiltinType::HashSet, vec![ResolvedTy::I64]),
             ResolvedTy::Tuple(vec![ResolvedTy::String, ResolvedTy::I64]),
+            unregistered_named("DirE"),
+            ResolvedTy::Tuple(vec![unregistered_named("DirE"), ResolvedTy::I64]),
         ] {
             assert_disposition(elem, VecElementRelease::OwnedElement);
         }
@@ -45225,6 +45389,51 @@ mod binding_ty_is_plain_vec_tuple {
                 VecElementRelease::Unsupported(FailClosedReason::NoReleaseProtocol),
             );
         }
+    }
+
+    /// Closure-pair release-symbol pin: the generator-yield and match-field
+    /// release-symbol pickers must check the closure-pair bucket BEFORE the
+    /// owned/plain split, matching codegen's `cow_heap_release_symbol` dispatch
+    /// order. A yielded or match-destructured `Vec<fn>` releases via
+    /// `hew_vec_free_closure_pairs`; the pre-fix `generator_yield_drop_symbol`
+    /// had only an owned/plain split and computed `hew_vec_free`, which diverges
+    /// from codegen and fails the inline-drop congruence check closed. The owned
+    /// and plain arms are pinned too so the closure-pair arm cannot displace them.
+    #[test]
+    fn vec_closure_pair_yield_and_field_drop_symbol_is_closure_pairs() {
+        let builder = builder_with_indirect_enum();
+        let vec_fn = vec_of_ty(ResolvedTy::Function {
+            params: vec![],
+            ret: Box::new(ResolvedTy::Unit),
+        });
+        assert_eq!(
+            builder.generator_yield_drop_symbol(&vec_fn),
+            Some("hew_vec_free_closure_pairs"),
+            "a yielded Vec<fn> must release via hew_vec_free_closure_pairs, not hew_vec_free"
+        );
+        assert_eq!(
+            builder.project_field_inline_drop_symbol(&vec_fn),
+            Some("hew_vec_free_closure_pairs"),
+            "a match-destructured Vec<fn> field must release via hew_vec_free_closure_pairs"
+        );
+        // The owned and plain Vec arms are unchanged and dispatch AFTER the
+        // closure-pair arm (a fn element is neither owned composite nor plain
+        // leaf, so it must not fall through to either).
+        assert_eq!(
+            builder.generator_yield_drop_symbol(&vec_of_ty(ResolvedTy::String)),
+            Some("hew_vec_free"),
+            "Vec<string> is a plain release (buffer + runtime string walk)"
+        );
+        assert_eq!(
+            builder.generator_yield_drop_symbol(&vec_of_ty(vec_of_ty(ResolvedTy::I64))),
+            Some("hew_vec_free_owned"),
+            "Vec<Vec<i64>> is an owned-element release"
+        );
+        assert_eq!(
+            builder.project_field_inline_drop_symbol(&vec_of_ty(vec_of_ty(ResolvedTy::I64))),
+            Some("hew_vec_free_owned"),
+            "match-destructured Vec<Vec<i64>> field is an owned-element release"
+        );
     }
 
     /// Focused pin: a scalar-payload `indirect enum` Vec element must fail closed

--- a/hew-mir/src/ownership.rs
+++ b/hew-mir/src/ownership.rs
@@ -61,7 +61,8 @@
 //! | `cbor_ty_owns_heap` | `hew-codegen-rs` · `llvm.rs` | CBOR `Vec` element heap probe (own leaf set, divergent `_ => false`) | **RETIRED** — now a `#[deprecated]` shim delegating to `ty_owns_heap` via `CborHeapLayouts`; sole caller `cbor_vec_elem_kind` is `#[allow(deprecated)]`-listed. The workspace `clippy -D warnings` CI step guards re-entry. Fixed a latent `CancellationToken` / tuple-field under-drop for free. |
 //! | owned-locals seed gate (`ValueClass::of_ty(ty) != BitCopy`) | `hew-mir` · `lower.rs` → `hew-hir` · `value_class.rs` | which locals enter drop elaboration | **PENDING (release-bucket consolidation)** — record-blind via [`ValueClass`]; the consolidation seeds from [`ValueOwnership`] instead. Not yet switched. |
 //! | `cow_value_leaf_drop_symbol` | `hew-mir` · `lower.rs` | scalar-leaf release symbol (`string` → `hew_string_drop`, else `None`) | **LANDED (release-bucket consolidation)** — routed through the typed decision; see the partition-totality test below. |
-//! | `binding_ty_is_plain_vec` · `binding_ty_is_owned_element_vec` · `is_owned_vec_element` · `tuple_is_all_bitcopy` | `hew-mir` · `lower.rs` | `Vec<E>` release partition (plain-BitCopy vs owned-element) | **LANDED (release-bucket consolidation)** — release buckets now PROJECT from the typed `classify_vec_element_release` decision; their union is total vs the authority leaf set. The unwired `Vec<bytes>` / `Vec<indirect_enum>` elements (`Unsupported(NoReleaseProtocol)`) are REJECTED at compile by `Builder::unsupported_vec_element_diagnostics` rather than silently leaked at scope exit. |
+//! | `binding_ty_is_plain_vec` · `is_plain_vec_element` · `binding_ty_is_owned_element_vec` · `is_owned_vec_element` · `tuple_is_all_bitcopy` | `hew-mir` · `lower.rs` | `Vec<E>` release partition (plain vs owned-element) | **LANDED (release-bucket consolidation)** — release buckets PROJECT from the typed `classify_vec_element_release` decision; their union is total vs the authority leaf set. The Plain bucket's `Named` arm reads the `named_elem_owns_heap` AUTHORITY, not `ValueClass::of_ty == BitCopy` alone: a heap-free DIRECT user enum is never `BitCopy` (value-class finalisation covers records only), so the pre-fix `BitCopy`-only gate classified `Vec<fieldless-enum>` NEITHER plain nor owned and leaked its whole buffer+handle at every scope exit — now closed by the `ty_is_direct_enum_element(e) && !named_elem_owns_heap(e)` disjunct. The unwired `Vec<bytes>` / `Vec<indirect_enum>` elements (`Unsupported(NoReleaseProtocol)`) are REJECTED at compile by `Builder::unsupported_vec_element_diagnostics` rather than silently leaked at scope exit. |
+//! | `generator_yield_drop_symbol` · `project_field_inline_drop_symbol` | `hew-mir` · `lower.rs` | per-yield / per-field `Vec<E>` release-symbol picker | **LANDED (release-bucket consolidation)** — both check the closure-pair bucket (`ty_is_closure_pair_vec` / `ty_is_closure_pair`) BEFORE the owned/plain split, so a yielded or match-destructured `Vec<fn>` / `Vec<closure>` picks `hew_vec_free_closure_pairs` congruent with codegen's `cow_heap_release_symbol` (`dedup-semantic-boundary`) rather than mis-computing `hew_vec_free` and failing the inline-drop congruence check closed. |
 //! | `ty_is_closure_pair_vec` · `ty_is_local_collection_handle` | `hew-mir` · `lower.rs` | closure-pair / collection-handle release | **PENDING (release-bucket consolidation)** — release buckets. |
 //! | `cow_heap_release_symbol` | `hew-codegen-rs` · `llvm.rs` | codegen-side release-symbol picker | **PENDING (release-bucket consolidation)** — the codegen sibling the MIR release buckets must agree with (`dedup-semantic-boundary`). |
 //!
@@ -297,6 +298,18 @@ pub enum FailClosedReason {
     /// anti-drift sentinel: adding a `ResolvedTy` variant without a `classify`
     /// arm lands here (a compile error in the exhaustive match), never a silent
     /// `false`.
+    ///
+    /// NOTE: unlike `NoReleaseProtocol`, an `Unsupported(UnenumeratedShape)`
+    /// `Vec` element is NOT compile-rejected by
+    /// `Builder::unsupported_vec_element_diagnostics` — it falls through both the
+    /// Plain and Owned buckets and emits NO scope-exit release, silently leaking
+    /// the OUTER Vec's own handle+buffer (a different thing from the element's
+    /// heap that `NoReleaseProtocol` guards). A heap-free direct user enum was a
+    /// live instance of this — never `BitCopy`, so the `BitCopy`-only Plain gate
+    /// mis-bucketed it here — now closed by routing direct enums through the
+    /// `named_elem_owns_heap` authority into the Plain bucket. Any future shape
+    /// that legitimately owns heap yet lands here must be added to a release
+    /// bucket or to the `NoReleaseProtocol` reject, never left on this arm.
     UnenumeratedShape,
     /// A heap-owning value reached a release path with no release symbol / drop
     /// protocol assigned. Routes to `MirCheck::DropPlanUndetermined`.


### PR DESCRIPTION
## Summary

The plain-vs-owned `Vec<E>` element release routing in `hew-mir` decided element
plainness from `ValueClass::of_ty(elem) == ValueClass::BitCopy` alone. Value-class
finalisation covers records only, so a **direct** (fieldless or scalar-payload) user
enum is never `BitCopy`. Two consequences, both fixed here:

**Old failure mode 1 — a live leak.** A `Vec<direct-enum>` element was classified
NEITHER plain nor owned: `classify_vec_element_release` returned
`Unsupported(UnenumeratedShape)`, which the compile-time reject does not cover (it
fires only on `NoReleaseProtocol`). The program built with **no scope-exit release
emitted**, so every `Vec<direct-enum>` local leaked its whole backing buffer AND its
handle at every scope exit — two nodes per frame.

**Old failure mode 2 — a congruent drop-symbol gap.** `generator_yield_drop_symbol`
never consulted the closure-pair bucket, so a yielded `Vec<fn>` computed `hew_vec_free`
instead of `hew_vec_free_closure_pairs`. Unlike the leak this failed *closed* at
codegen's inline-drop congruence check (no runtime harm), but it was still incorrect —
the identical bug in the sibling `project_field_inline_drop_symbol` was fixed earlier
in 42d78b3e5.

## Invariant restored

The plain-vs-owned / drop-symbol routing decision now **reads the single
heap-ownership authority** (`named_elem_owns_heap`), never re-derives heap-ness from
`ValueClass::of_ty == BitCopy`. `is_plain_vec_element` and `tuple_is_all_bitcopy` gain
the additive disjunct `ty_is_direct_enum_element(e) && !named_elem_owns_heap(e)`:

- a heap-free direct enum is now correctly **plain** and gets `hew_vec_free` (no leak);
- a heap-owning enum (`Label(string)`) still routes **owned** via `hew_vec_free_owned`.

`generator_yield_drop_symbol` and `project_field_inline_drop_symbol` now check the
closure-pair bucket (`ty_is_closure_pair_vec` / `ty_is_closure_pair`) **before** the
owned/plain split, mirroring codegen's `cow_heap_release_symbol` dispatch order through
one shared closure-pair predicate.

## Why this boundary (additive, not a bare swap)

The `ValueClass::BitCopy` disjunct is **retained deliberately**. A pure
`!named_elem_owns_heap` swap was rejected two ways:

- it admits an unregistered `Named` (breaks the soundness pin), and
- gating solely on layout-registry membership regresses `Vec<Instant>` — `Instant` is
  `BitCopy` but is not in the layout registry, so it would fall to `Unsupported` and
  leak.

The change is therefore **provably additive**: the set where it differs from the
pre-fix `BitCopy`-only gate is exactly the registered non-indirect enums that own no
heap — the heap-free direct enums. Records, `Instant`, and other `BitCopy` builtins are
untouched. Over-drop is the worse failure (double-free), so the owned side is pinned
explicitly: a heap-owning direct enum still routes owned (see the totality test and the
owned-route leak fixture).

`ty_is_direct_enum_element` is extracted **verbatim** from the layout-Vec constructor
authority (`vec_element_uses_layout_descriptor`), so a direct enum is *released* as a
plain layout Vec exactly when it was *constructed* as one — congruent with the
vec-index getter's `hew_vec_get_layout` arm. The MIR-to-codegen congruence check stays
green.

## Verification

- **Leak-oracle revert-repro** (`vec_enum_element_leak_oracle.rs`, macOS `leaks --atExit`
  under the MallocScribble/PreScribble/GuardEdges triple):
  - post-fix `Vec<Colour>`: **0 leaks at both 3 and 50 frames** (flat);
  - reverting only the enum disjunct reproduces **6 → 100 leaked nodes** across the
    3 → 50 frame sweep — exactly 2 nodes/frame (buffer + handle), 72 B/node — and the
    oracle fails by ~94 nodes;
  - a heap-owning `Vec<Shape>` stays flat (owned route intact, no over-drop);
  - escape shapes (returned vec + consumed-by-value) run clean and print the expected
    checksum under the poisoned allocator (no double-free).
- **Totality test** `release_bucket_partition_is_total_over_vec_elements` extended to
  exercise fieldless, scalar-payload, heap-payload, and indirect enums plus
  tuple-of-enum; it now **fails against pre-fix code** with
  `Vec<Colour>` resolving to `Unsupported(UnenumeratedShape)` instead of `Plain`.
- **Drop-symbol pin** `vec_closure_pair_yield_and_field_drop_symbol_is_closure_pairs`
  pins both pickers to `hew_vec_free_closure_pairs` for `Vec<fn>` (fails pre-fix).
- Corrected the walker-inventory rows and the doc comments that falsely asserted direct
  enums were `ValueClass::BitCopy`-covered.
- Suites: `hew-mir` lib 277 passed; `hew-codegen-rs` lib 186 passed; enum leak oracle
  3 passed; vertical-slice corpus 390 fixtures pass (incl. `vec_enum_range_slice`
  producing 0 leaks under the scribble triple and `vec_enum_index_oob_traps` still
  trapping); fuzz-oracle gate PASS; pkg-import PASS; `await_e2e` 17 passed;
  `cargo clippy --workspace --tests -- -D warnings` clean; `cargo fmt --check` clean.
  (The preflight's cross-arch `native_link_darwin_cross_arch` failure and the
  `libhew.a not found` bails are pre-existing custom-target-dir / cross-arch archive
  environment artifacts, unrelated to this change; the underlying suites pass when the
  default-path archive is present.)

## Out of scope

- Making codegen **consume** the MIR release decision directly (the codegen side still
  re-derives its own symbol and agrees via the congruence check rather than reading the
  MIR verdict). A follow-up.
- Borrow-symbol matching. Untouched here.
- Constructing a `Vec` of tuples-of-enum via `Vec::new` or an array literal remains a
  separate NYI (`no constructor lowering for element type Tuple`); the tuple-of-enum
  release arm is covered by the totality test rather than a runtime fixture.
