### PR TITLE
fix(runtime): ignore SIGPIPE in compiled-program startup so broken-pipe sends fail closed

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -224,7 +224,12 @@ slow-timeout = { period = "30s", terminate-after = 3 }
 # wire_cbor_cross_process_round_trip is the same harness with a #[wire]-typed
 # payload (explicit @N tags); it shares the compiled binary via OnceLock and runs
 # in the same serialized group for the same reasons.
-filter = "test(remote_ask_round_trip_returns_exact_values) | test(wire_cbor_cross_process_round_trip)"
+# remote_ask_under_partition_fails_closed_not_hang is the same compiled harness
+# (server + client processes built from dist_node.hew) exercising the fail-closed
+# no-hang partition gate; it belongs in the same serialized real-timing group as
+# its siblings above (it was the only one in this binary missing the assignment,
+# which left it exposed to the concurrent-load timing flake).
+filter = "test(remote_ask_round_trip_returns_exact_values) | test(wire_cbor_cross_process_round_trip) | test(remote_ask_under_partition_fails_closed_not_hang)"
 test-group = "real-timing"
 slow-timeout = { period = "120s", terminate-after = 3 }
 

--- a/hew-cli/src/signal.rs
+++ b/hew-cli/src/signal.rs
@@ -43,12 +43,14 @@ unsafe extern "C" fn forward_to_child(sig: libc::c_int) {
 pub fn forward_signals_to_child(child_pid: u32) {
     set_child_pid(child_pid);
 
+    // Restore SIGPIPE's DEFAULT disposition for THIS (CLI) process so a closed
+    // output pipe terminates cleanly. See `reset_sigpipe_to_default`.
+    let pipe_ok = reset_sigpipe_to_default();
+
     // SAFETY: zeroed sigaction is a valid starting value; `forward_to_child`
     // performs only async-signal-safe operations.  SA_RESTART ensures that
     // syscalls interrupted by the signal (e.g. waitpid) are restarted.
     unsafe {
-        let pipe_result = libc::signal(libc::SIGPIPE, libc::SIG_DFL);
-
         let mut sa: libc::sigaction = std::mem::zeroed();
         sa.sa_sigaction = forward_to_child as *const () as libc::sighandler_t;
         libc::sigemptyset(&raw mut sa.sa_mask);
@@ -57,11 +59,28 @@ pub fn forward_signals_to_child(child_pid: u32) {
         let term_result = libc::sigaction(libc::SIGTERM, &raw const sa, std::ptr::null_mut());
         let int_result = libc::sigaction(libc::SIGINT, &raw const sa, std::ptr::null_mut());
 
-        if pipe_result == libc::SIG_ERR || term_result != 0 || int_result != 0 {
+        if !pipe_ok || term_result != 0 || int_result != 0 {
             clear_child_pid();
             eprintln!("hew: warning: failed to install signal handlers");
         }
     }
+}
+
+/// Restore SIGPIPE's DEFAULT disposition for the CLI process so a closed output
+/// pipe (`hew run foo | head`) terminates this process cleanly instead of
+/// surfacing as a Rust I/O panic. Returns `false` if the reset failed.
+///
+/// This is deliberately the OPPOSITE of the compiled-program runtime, which
+/// IGNORES SIGPIPE (`hew-runtime`'s `ignore_sigpipe`, installed in
+/// `hew_sched_init`) so a broken-pipe network send fails closed to a typed
+/// error instead of killing the program. The CLI and the emitted program are
+/// separate binaries/processes and the CLI never calls `hew_sched_init`, so the
+/// two dispositions never collide.
+fn reset_sigpipe_to_default() -> bool {
+    // SAFETY: `signal(2)` with SIG_DFL for SIGPIPE is async-signal-safe and the
+    // canonical "restore default disposition" call.
+    let prev = unsafe { libc::signal(libc::SIGPIPE, libc::SIG_DFL) };
+    prev != libc::SIG_ERR
 }
 
 #[cfg(test)]
@@ -107,5 +126,40 @@ mod tests {
                 "child should have been killed by signal, not exited normally"
             );
         }
+    }
+
+    /// The CLI must RESET SIGPIPE to its default disposition (unlike the
+    /// compiled-program runtime, which IGNORES it) so `hew run foo | head`
+    /// terminates cleanly. Simulate an inherited `SIG_IGN` and verify the reset
+    /// flips it back to `SIG_DFL`. This touches ONLY SIGPIPE — not the
+    /// process-global SIGTERM/SIGINT handlers the other test avoids.
+    #[test]
+    fn reset_sigpipe_restores_default_disposition() {
+        // SAFETY: installing SIG_IGN for SIGPIPE is async-signal-safe and valid.
+        unsafe {
+            assert_ne!(
+                libc::signal(libc::SIGPIPE, libc::SIG_IGN),
+                libc::SIG_ERR,
+                "test setup: could not install SIG_IGN"
+            );
+        }
+
+        assert!(
+            reset_sigpipe_to_default(),
+            "reset_sigpipe_to_default must succeed"
+        );
+
+        // SAFETY: an all-zero `libc::sigaction` is a valid initialised value (a
+        // plain C struct); it is immediately overwritten by the query below.
+        let mut cur: libc::sigaction = unsafe { std::mem::zeroed() };
+        // SAFETY: a null `act` makes `sigaction` a pure query into the valid
+        // `cur` out-param; the signal number is valid.
+        let rc = unsafe { libc::sigaction(libc::SIGPIPE, std::ptr::null(), &raw mut cur) };
+        assert_eq!(rc, 0, "sigaction(SIGPIPE) query failed");
+        assert_eq!(
+            cur.sa_sigaction,
+            libc::SIG_DFL,
+            "the CLI must leave SIGPIPE at SIG_DFL so `hew run | head` terminates cleanly"
+        );
     }
 }

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -953,6 +953,16 @@ impl ReplyRoutingTable {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         map.remove(&request_id)
     }
+
+    /// Number of registered-but-unresolved pending replies. Test-only: used to
+    /// assert the reply slot does not leak on the fail-closed send path.
+    #[cfg(test)]
+    fn pending_len(&self) -> usize {
+        self.pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
+    }
 }
 
 static REMOTE_VOID_REPLY_SENTINEL: u8 = 0;
@@ -6970,6 +6980,40 @@ mod tests {
         assert_eq!(outcome.status, ReplyStatus::Failed);
         assert_eq!(outcome.ask_error, AskError::OrphanedAsk);
         assert!(outcome.data.is_empty());
+    }
+
+    #[test]
+    fn send_failure_removes_pending_reply_slot_no_leak() {
+        // `setup_remote_ask` registers a pending reply BEFORE the outbound send;
+        // on a fail-closed send (the SIGPIPE→EPIPE path that returns
+        // `AskError::SendFailed`) it must `remove` the slot so a failed ask
+        // cannot leak a pending entry. This pins that cleanup contract on a
+        // fresh table, isolated from the process-global one.
+        let table = ReplyRoutingTable::new();
+        assert_eq!(table.pending_len(), 0);
+
+        let (request_id, _pending) = table.register(ConnectionKey {
+            conn_mgr: 42,
+            conn_id: 7,
+        });
+        assert_eq!(
+            table.pending_len(),
+            1,
+            "register must install exactly one pending reply slot"
+        );
+
+        // Mirror `setup_remote_ask`'s `!send_ok` branch: remove the slot the ask
+        // registered before the send that just failed.
+        let removed = table.remove(request_id);
+        assert!(
+            removed.is_some(),
+            "the fail-closed send path must find and remove the registered slot"
+        );
+        assert_eq!(
+            table.pending_len(),
+            0,
+            "AskError::SendFailed cleanup must not leak the reply slot"
+        );
     }
 
     #[test]

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -433,6 +433,16 @@ pub extern "C" fn hew_sched_init() -> c_int {
         return 0;
     }
 
+    // Ignore SIGPIPE process-wide, before ANY background thread is spawned or
+    // any socket I/O runs. A broken-pipe write on the main thread (where a
+    // networked program runs its synchronous top-level `ask` / send) or on any
+    // reactor / SWIM / accept / reader thread would otherwise be KILLED by the
+    // default SIGPIPE disposition, before the fallible send path could convert
+    // the EPIPE into a typed fail-closed error. This is the compiled program's
+    // runtime only; the `hew` CLI is a separate process that resets SIGPIPE to
+    // SIG_DFL and never calls this. See `signal::ignore_sigpipe`.
+    crate::signal::ignore_sigpipe();
+
     // Install crash signal handlers for the entire process.
     crate::signal::init_crash_handling();
 

--- a/hew-runtime/src/signal.rs
+++ b/hew-runtime/src/signal.rs
@@ -824,6 +824,48 @@ mod platform {
         }
     }
 
+    /// Ignore `SIGPIPE` process-wide.
+    ///
+    /// A broken-pipe write on ANY thread — the OS main thread (where a compiled
+    /// Hew program runs its synchronous top-level `ask` / send code), the
+    /// reactor, the SWIM driver, the accept loop, the reconnect worker, or a
+    /// per-connection reader thread — returns `EPIPE` from the syscall instead
+    /// of raising `SIGPIPE`, whose default disposition would KILL the process.
+    /// With SIGPIPE ignored the `EPIPE` surfaces as an ordinary `io::Error`, so
+    /// the fallible send path converts it into a typed fail-closed error
+    /// (`AskError::SendFailed` / a transport write error) rather than the
+    /// program dying silently.
+    ///
+    /// Installed once, very early in `hew_sched_init`, BEFORE any background
+    /// thread is spawned or any socket I/O runs. One process-wide disposition
+    /// uniformly protects every thread — unlike the per-worker `SIGPIPE` block
+    /// installed in [`init_worker_recovery`] (a `pthread_sigmask` that never
+    /// covers the main thread or the network background threads).
+    ///
+    /// Scope: this is the COMPILED PROGRAM's runtime. The `hew` CLI is a
+    /// separate binary/process that deliberately RESETS SIGPIPE to `SIG_DFL`
+    /// (`hew-cli/src/signal.rs`) so `hew run foo | head` terminates cleanly;
+    /// that binary never calls `hew_sched_init`, so this ignore never reaches
+    /// it.
+    pub(crate) fn ignore_sigpipe() {
+        // SAFETY: `sa` is zero-initialised then fully populated before use.
+        // Installing `SIG_IGN` for `SIGPIPE` is the canonical, async-signal-safe
+        // "ignore broken pipe" disposition; `sigaction` for this signal number
+        // is always valid.
+        unsafe {
+            let mut sa: libc::sigaction = std::mem::zeroed();
+            sa.sa_sigaction = libc::SIG_IGN;
+            libc::sigemptyset(&raw mut sa.sa_mask);
+            sa.sa_flags = 0;
+            let ret = sigaction(libc::SIGPIPE, &raw const sa, ptr::null_mut());
+            // Non-fatal if it somehow fails: the per-worker SIGPIPE block and the
+            // send-path MSG_NOSIGNAL / SO_NOSIGPIPE remain as defenses. Catch a
+            // regression in debug builds without aborting a production startup.
+            debug_assert_eq!(ret, 0, "sigaction(SIGPIPE, SIG_IGN) failed");
+            let _ = ret;
+        }
+    }
+
     /// Set up per-worker recovery infrastructure.
     ///
     /// Allocates a 128 KiB alternate signal stack and a recovery context.
@@ -1289,6 +1331,13 @@ mod platform {
         }
     }
 
+    /// No-op on Windows: there is no `SIGPIPE`. A write to a broken pipe /
+    /// reset socket surfaces directly as an `io::Error` (`ERROR_BROKEN_PIPE` /
+    /// `WSAECONNRESET`), which the fallible send path already converts to a
+    /// typed fail-closed error. See the Unix impl for the disposition this
+    /// mirrors.
+    pub(crate) fn ignore_sigpipe() {}
+
     pub(crate) fn init_worker_recovery(worker_id: u32) {
         let ctx = WorkerRecoveryCtx::new_boxed(worker_id);
         let ctx_ptr = Box::into_raw(ctx); // ALLOCATOR-PAIRING: GlobalAlloc
@@ -1442,6 +1491,14 @@ mod platform {
     pub(crate) fn init_crash_handling() {}
     pub(crate) fn init_worker_recovery(_worker_id: u32) {}
 
+    /// No-op on WASM: wasm32 has no POSIX signals, so there is no `SIGPIPE` to
+    /// ignore. A broken-pipe / reset condition on the simulated transport
+    /// surfaces as a typed error through the normal fallible send path.
+    // WASM-TODO(#1451): revisit if a future wasm target grows a signal-like
+    // disposition for pipe/socket teardown; today the process-wide SIGPIPE
+    // ignore is native-only (the real impl lives in the `#[cfg(unix)]` module).
+    pub(crate) fn ignore_sigpipe() {}
+
     /// # Safety
     ///
     /// No-op on WASM. Always returns null.
@@ -1493,9 +1550,9 @@ mod platform {
 
 // Re-export platform-specific implementations.
 pub(crate) use platform::{
-    clear_dispatch_recovery, handle_crash_recovery, init_crash_handling, init_worker_recovery,
-    mark_recovery_active, prepare_dispatch_recovery, sigsetjmp, try_direct_longjmp,
-    try_direct_longjmp_with_code,
+    clear_dispatch_recovery, handle_crash_recovery, ignore_sigpipe, init_crash_handling,
+    init_worker_recovery, mark_recovery_active, prepare_dispatch_recovery, sigsetjmp,
+    try_direct_longjmp, try_direct_longjmp_with_code,
 };
 
 // ── Terminal off-dispatch crash diagnostic (subprocess test) ─────────────────
@@ -1590,5 +1647,75 @@ mod terminal_diag_tests {
             stderr.contains(&format!("thread={FAULT_THREAD_NAME}")),
             "diagnostic must name the faulting thread `{FAULT_THREAD_NAME}`\nstderr:\n{stderr}"
         );
+    }
+}
+
+/// Tests for the process-wide `SIGPIPE` ignore that `hew_sched_init` installs
+/// (via [`ignore_sigpipe`]) so a broken-pipe network write in a compiled Hew
+/// program fails closed to a typed error instead of killing the process.
+#[cfg(all(test, unix, not(target_arch = "wasm32")))]
+mod sigpipe_tests {
+    use std::io::Write;
+    use std::os::unix::net::UnixStream;
+    use std::ptr;
+
+    /// After the runtime installs its process-wide SIGPIPE ignore, SIGPIPE's
+    /// disposition must be `SIG_IGN` — the invariant that lets a broken-pipe
+    /// write return `EPIPE` (surfacing as a typed fail-closed error) rather
+    /// than terminate the process.
+    #[test]
+    fn ignore_sigpipe_sets_disposition_to_sig_ign() {
+        super::ignore_sigpipe();
+
+        // SAFETY: an all-zero `libc::sigaction` is a valid initialised value (a
+        // plain C struct of integers/pointers); it is immediately overwritten by
+        // the query below.
+        let mut cur: libc::sigaction = unsafe { std::mem::zeroed() };
+        // SAFETY: a null `act` makes `sigaction` a pure query into the valid,
+        // fully-owned `cur` out-param; the signal number is valid.
+        let rc = unsafe { libc::sigaction(libc::SIGPIPE, ptr::null(), &raw mut cur) };
+        assert_eq!(rc, 0, "sigaction(SIGPIPE) query failed");
+        assert_eq!(
+            cur.sa_sigaction,
+            libc::SIG_IGN,
+            "SIGPIPE must be ignored in the program runtime after startup"
+        );
+    }
+
+    /// Deterministic reproduction of the fixed crash: with SIGPIPE ignored, a
+    /// write to a socket whose peer has closed returns a typed I/O error
+    /// (`BrokenPipe` / `ConnectionReset`) instead of killing the process with
+    /// the default SIGPIPE disposition. Reaching the final assertion at all
+    /// proves the process was NOT terminated by a signal.
+    #[test]
+    fn broken_pipe_write_returns_error_not_signal_death() {
+        super::ignore_sigpipe();
+
+        let (mut writer, reader) = UnixStream::pair().expect("socketpair");
+        drop(reader); // fully close the peer
+
+        // The peer is gone, so the write fails closed with EPIPE. Bound the
+        // loop so an unexpected kernel buffering regime cannot hang the test.
+        // `write_all` surfaces the peer-gone error (and handles the byte count)
+        // rather than looping on partial writes.
+        let payload = [0xA5u8; 4096];
+        let mut observed = None;
+        for _ in 0..1024 {
+            if let Err(e) = writer.write_all(&payload) {
+                observed = Some(e);
+                break;
+            }
+        }
+
+        let err = observed.expect("broken-pipe write should surface an error, not hang");
+        assert!(
+            matches!(
+                err.kind(),
+                std::io::ErrorKind::BrokenPipe | std::io::ErrorKind::ConnectionReset
+            ),
+            "expected a fail-closed peer-gone error, got {err:?}"
+        );
+        // Had SIGPIPE not been ignored, the first write above would have killed
+        // this process before we could observe the error.
     }
 }

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -441,6 +441,10 @@ impl TcpTransport {
     }
 
     fn store_conn(&self, sock: Socket) -> c_int {
+        // macOS parity: mark the socket SO_NOSIGPIPE so a broken-pipe write
+        // fails closed with EPIPE instead of raising SIGPIPE (no-op elsewhere;
+        // Linux uses MSG_NOSIGNAL in framed_send).
+        suppress_sigpipe(&sock);
         if let Ok(conn) = self.conns.write(|conns| {
             for (i, slot) in conns.iter_mut().enumerate() {
                 if slot.is_none() {
@@ -518,6 +522,68 @@ fn parse_host_port(addr: &str) -> Option<SocketAddr> {
     addr.parse::<SocketAddr>().ok()
 }
 
+/// Extra `send(2)` flags for [`framed_send`].
+///
+/// On Linux/Android, `MSG_NOSIGNAL` suppresses `SIGPIPE` for THIS send even if
+/// the process-wide disposition were ever reset — a belt-and-suspenders partner
+/// to the `hew_sched_init` process-wide SIGPIPE ignore, so a broken-pipe write
+/// returns `EPIPE` (surfacing as a typed fail-closed error) instead of killing
+/// the process. macOS/iOS have no `MSG_NOSIGNAL`; they get the equivalent via
+/// the `SO_NOSIGPIPE` socket option set in [`suppress_sigpipe`]. Windows has no
+/// `SIGPIPE`.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const FRAMED_SEND_FLAGS: c_int = libc::MSG_NOSIGNAL;
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+const FRAMED_SEND_FLAGS: c_int = 0;
+
+/// Suppress `SIGPIPE` for writes on a stored connection socket (macOS parity).
+///
+/// macOS/iOS/tvOS/watchOS have no `MSG_NOSIGNAL` send flag, so the Linux
+/// [`FRAMED_SEND_FLAGS`] path has no analogue there; instead the `SO_NOSIGPIPE`
+/// socket option is set once, at connection-store time, so a broken-pipe write
+/// on this socket returns `EPIPE` rather than raising `SIGPIPE`. This is
+/// defense-in-depth behind the process-wide SIGPIPE ignore installed in
+/// `hew_sched_init`. No-op on platforms without `SO_NOSIGPIPE`.
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos"
+))]
+fn suppress_sigpipe(sock: &Socket) {
+    use std::os::fd::AsRawFd;
+    let enable: c_int = 1;
+    // SAFETY: `sock` owns a valid file descriptor for the duration of this call.
+    // `SO_NOSIGPIPE` at `SOL_SOCKET` takes an `int`-sized option value; a failure
+    // is non-fatal (the process-wide ignore still applies), so the result is
+    // intentionally not surfaced.
+    unsafe {
+        libc::setsockopt(
+            sock.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_NOSIGPIPE,
+            (&raw const enable).cast(),
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "sizeof(c_int) is 4, fits in socklen_t (u32)"
+            )]
+            {
+                std::mem::size_of::<c_int>() as libc::socklen_t
+            },
+        );
+    }
+}
+
+/// No-op on platforms without `SO_NOSIGPIPE` (Linux/Android use
+/// [`FRAMED_SEND_FLAGS`] `MSG_NOSIGNAL`; Windows has no `SIGPIPE`).
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos"
+)))]
+fn suppress_sigpipe(_sock: &Socket) {}
+
 /// Send exactly `buf` bytes over a socket with length-prefixed framing.
 fn framed_send(sock: &Socket, data: &[u8]) -> c_int {
     if data.len() > u32::MAX as usize {
@@ -527,10 +593,13 @@ fn framed_send(sock: &Socket, data: &[u8]) -> c_int {
     let frame_len = data.len() as u32;
     let header = frame_len.to_le_bytes();
 
-    // Write header.
+    // Write header. `send_with_flags` (not `write`) so `MSG_NOSIGNAL` can
+    // suppress SIGPIPE on Linux; on macOS the socket carries `SO_NOSIGPIPE`
+    // (see `suppress_sigpipe`). Either way a broken pipe returns `EPIPE` here
+    // instead of killing the process, and we fail closed with `-1`.
     let mut written = 0usize;
     while written < 4 {
-        match (&*sock).write(&header[written..]) {
+        match sock.send_with_flags(&header[written..], FRAMED_SEND_FLAGS) {
             Ok(0) => {
                 set_last_error("transport framed_send: peer closed while writing header");
                 return -1;
@@ -545,7 +614,7 @@ fn framed_send(sock: &Socket, data: &[u8]) -> c_int {
     // Write payload.
     written = 0;
     while written < data.len() {
-        match (&*sock).write(&data[written..]) {
+        match sock.send_with_flags(&data[written..], FRAMED_SEND_FLAGS) {
             Ok(0) => {
                 set_last_error("transport framed_send: peer closed while writing payload");
                 return -1;
@@ -1747,6 +1816,37 @@ mod tests {
         (server, client)
     }
 
+    /// A broken-pipe outbound `framed_send` must fail closed with `-1` instead
+    /// of killing the process with SIGPIPE. This exercises the send-path
+    /// defense-in-depth in isolation — `MSG_NOSIGNAL` on Linux/Android
+    /// ([`FRAMED_SEND_FLAGS`]) and `SO_NOSIGPIPE` on macOS ([`suppress_sigpipe`])
+    /// — WITHOUT installing the process-wide SIGPIPE ignore, so a regression in
+    /// either per-socket defense would terminate the test process (a loud
+    /// failure) rather than pass silently.
+    #[cfg(unix)]
+    #[test]
+    fn framed_send_to_broken_pipe_fails_closed_without_signal() {
+        use std::os::fd::OwnedFd;
+        use std::os::unix::net::UnixStream;
+
+        let (near, far) = UnixStream::pair().expect("socketpair");
+        // Wrap the near end as the transport's socket type and apply the same
+        // macOS SIGPIPE suppression the connection-store path applies.
+        let sock: Socket = OwnedFd::from(near).into();
+        suppress_sigpipe(&sock);
+        drop(far); // fully close the peer
+
+        // The peer is gone, so the header write inside framed_send hits EPIPE
+        // and the function fails closed. Reaching the assertion proves the
+        // process was not killed by SIGPIPE.
+        let payload = [0xABu8; 4096];
+        let rc = framed_send(&sock, &payload);
+        assert_eq!(
+            rc, -1,
+            "framed_send to a broken pipe must fail closed with -1, not raise SIGPIPE"
+        );
+    }
+
     fn register_stream(stream: TcpStream) -> c_int {
         TCP_API_STATE.access(|state| {
             let handle = state.alloc_handle();
@@ -2691,8 +2791,8 @@ pub extern "C" fn hew_connection_is_valid(handle: c_int) -> bool {
 mod unix_transport {
     use super::{
         accept_with_optional_timeout, c_char, c_int, c_void, framed_recv, framed_send,
-        report_conn_table_poison, CStr, ConnLookupError, Domain, HewTransport, HewTransportOps,
-        PoisonSafeRw, SockAddr, Socket, Type, HEW_CONN_INVALID, MAX_CONNS,
+        report_conn_table_poison, suppress_sigpipe, CStr, ConnLookupError, Domain, HewTransport,
+        HewTransportOps, PoisonSafeRw, SockAddr, Socket, Type, HEW_CONN_INVALID, MAX_CONNS,
     };
     use std::net::Shutdown;
     use std::sync::atomic::AtomicBool;
@@ -2716,6 +2816,9 @@ mod unix_transport {
         }
 
         fn store_conn(&self, sock: Socket) -> c_int {
+            // macOS parity: see the TCP `store_conn` note — SO_NOSIGPIPE so a
+            // broken-pipe write fails closed with EPIPE instead of SIGPIPE.
+            suppress_sigpipe(&sock);
             if let Ok(conn) = self.conns.write(|conns| {
                 for (i, slot) in conns.iter_mut().enumerate() {
                     if slot.is_none() {


### PR DESCRIPTION
## Summary

A networked compiled Hew program could be **killed by `SIGPIPE`** on a broken-pipe send instead of the send failing closed to a typed error. This changes the process-wide signal disposition so a broken-pipe write surfaces as a typed, fail-closed error (`AskError::SendFailed`) and never terminates the process.

**Invariant:** a broken-pipe write in a networked Hew program must surface as a typed, fail-closed error — never kill the process.

## Old failure mode

A program's top-level `ask` / send code runs synchronously on the OS **main thread**, and the reactor, SWIM driver, accept loop, reconnect worker, and per-connection readers run on their own background threads. Only scheduler **worker** threads blocked `SIGPIPE` (via the per-worker `pthread_sigmask` in `init_worker_recovery`); the main thread and every network background thread did not.

So when an outbound `send`/`sendto` hit a peer whose socket was just torn down, the kernel returned `EPIPE` **and** raised `SIGPIPE`, whose default disposition terminated the process **before** the fallible send path could convert `EPIPE` into `AskError::SendFailed`. There was no process-wide `SIGPIPE` ignore / `MSG_NOSIGNAL` / `SO_NOSIGPIPE` anywhere in the runtime.

This surfaced as the intermittently-flaky `remote_ask_under_partition_fails_closed_not_hang` distributed end-to-end test, but the defect is in product runtime code, not the test.

## The fix

Ignore `SIGPIPE` process-wide, once, very early in `hew_sched_init` — before any background thread is spawned or any socket I/O runs. One process-wide disposition uniformly protects every thread (main + all background threads), and the existing fail-closed path then observes an ordinary `EPIPE` and returns the typed error.

Defense-in-depth on the send path, behind the process-wide ignore:
- `MSG_NOSIGNAL` on the `framed_send` `send` (Linux/Android).
- `SO_NOSIGPIPE` set on each stored connection socket (macOS/iOS, where there is no `MSG_NOSIGNAL`).

## Why this boundary — program runtime, not the CLI

The ignore is scoped to the **compiled program's** runtime startup only. The `hew` CLI is a separate binary/process that deliberately **resets `SIGPIPE` to `SIG_DFL`** (in `forward_signals_to_child`) so `hew run foo | head` terminates cleanly. The CLI never calls `hew_sched_init`, so the two dispositions never collide.

That reset is factored into `reset_sigpipe_to_default()` with a test (`reset_sigpipe_restores_default_disposition`) pinning the CLI's `SIG_DFL` contract, so a future change that accidentally makes the CLI ignore `SIGPIPE` (regressing `hew run | head`) fails the test.

## WASM note

The disposition change is native-only: wasm32 has no POSIX signals, so `ignore_sigpipe` is a documented no-op there (`WASM-TODO(#1451)`). The wasm platform module compiles unchanged.

## Verification

- `broken_pipe_write_returns_error_not_signal_death` — a broken-pipe write surfaces a typed peer-gone error rather than killing the process (this test would terminate the process on Linux without the fix).
- `ignore_sigpipe_sets_disposition_to_sig_ign` — disposition is `SIG_IGN` after startup.
- `framed_send_to_broken_pipe_fails_closed_without_signal` — the per-socket `MSG_NOSIGNAL` / `SO_NOSIGPIPE` path fails closed with `-1` **without** relying on the process-wide ignore (isolates the defense-in-depth layer).
- `send_failure_removes_pending_reply_slot_no_leak` — the `SendFailed` path removes the pending reply slot (drop-safety; the ask is registered pending before the send).
- `reset_sigpipe_restores_default_disposition` — the CLI still resets `SIGPIPE` to `SIG_DFL`.
- `remote_ask_under_partition_fails_closed_not_hang` — the originally-flaky test is now deterministic (5/5 runs), and is added to the serialized `real-timing` nextest group alongside its two-process siblings.
- Full `hew-runtime` suite: 2479/2479. `distributed_two_process_e2e`: 16/16. `hew-cli` signal tests pass.

## Out of scope

- No change to the CLI's `SIGPIPE` handling — its `SIG_DFL` reset is deliberately preserved.
- No change to the fail-closed send path itself (`EPIPE` → `AskError::SendFailed` already existed; this change lets it actually run instead of being pre-empted by process death).
- No new WASM signal handling (wasm has no POSIX signals; tracked by #1451).
