### PR TITLE
fix(types): infer array literals as fixed arrays in expected [T; N] positions

### DIFF
--- a/hew-cli/tests/codegen_failclosed_span_e2e.rs
+++ b/hew-cli/tests/codegen_failclosed_span_e2e.rs
@@ -61,6 +61,37 @@ fn has_root_error_caret(stderr: &str) -> bool {
 const ARRAY_RETURN_SOURCE: &str =
     "pub fn unsupported_array_return(x: [i64; 2]) -> [i64; 2] {\n    return x;\n}\nfn main() {}\n";
 
+const ARRAY_LITERAL_RETURN_SOURCE: &str =
+    "fn one(a: i64) -> [i64; 2] {\n    [a, a]\n}\nfn main() {}\n";
+
+#[test]
+fn array_literal_fixed_array_return_reaches_codegen_boundary() {
+    let fixture = write_fixture(&[("main.hew", ARRAY_LITERAL_RETURN_SOURCE)]);
+    let main_path = fixture.path().join("main.hew");
+
+    let output = Command::new(hew_binary())
+        .args(["check", main_path.to_str().unwrap()])
+        .current_dir(fixture.path())
+        .output()
+        .expect("hew binary must run");
+
+    assert!(
+        !output.status.success(),
+        "hew check must fail on fixed-size array value codegen"
+    );
+
+    let stderr = strip_ansi(&String::from_utf8_lossy(&output.stderr));
+    assert!(
+        stderr.contains("E_CODEGEN_FRONT_UNSUPPORTED")
+            && stderr.contains("Array type — composite lowering is Cluster 2"),
+        "fixed-size array value should fail at the codegen boundary; got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("found `Vec<i64>`"),
+        "fixed-size array literal should not fall back to Vec inference; got:\n{stderr}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // (a) root-module fail-closed shows a caret
 // ---------------------------------------------------------------------------

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -2706,19 +2706,16 @@ impl Checker {
 
             // Array literals checked against [T; N] require exact arity.
             (Expr::Array(elems), Ty::Array(elem_ty, size)) => {
-                let actual_len = match u64::try_from(elems.len()) {
-                    Ok(actual_len) => actual_len,
-                    Err(_) => {
-                        self.report_error(
-                            TypeErrorKind::ArityMismatch,
-                            span,
-                            format!(
-                                "array literal has {} elements, which exceeds the supported fixed-array length",
-                                elems.len()
-                            ),
-                        );
-                        return Ty::Error;
-                    }
+                let Ok(actual_len) = u64::try_from(elems.len()) else {
+                    self.report_error(
+                        TypeErrorKind::ArityMismatch,
+                        span,
+                        format!(
+                            "array literal has {} elements, which exceeds the supported fixed-array length",
+                            elems.len()
+                        ),
+                    );
+                    return Ty::Error;
                 };
 
                 if actual_len != *size {

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -2704,6 +2704,42 @@ impl Checker {
                 expected.clone()
             }
 
+            // Array literals checked against [T; N] require exact arity.
+            (Expr::Array(elems), Ty::Array(elem_ty, size)) => {
+                let actual_len = match u64::try_from(elems.len()) {
+                    Ok(actual_len) => actual_len,
+                    Err(_) => {
+                        self.report_error(
+                            TypeErrorKind::ArityMismatch,
+                            span,
+                            format!(
+                                "array literal has {} elements, which exceeds the supported fixed-array length",
+                                elems.len()
+                            ),
+                        );
+                        return Ty::Error;
+                    }
+                };
+
+                if actual_len != *size {
+                    self.report_error(
+                        TypeErrorKind::ArityMismatch,
+                        span,
+                        format!(
+                            "array literal length mismatch: expected {size} elements for `{}`, found {actual_len}",
+                            expected.user_facing()
+                        ),
+                    );
+                    return Ty::Error;
+                }
+
+                for elem in elems {
+                    self.check_against(&elem.0, &elem.1, elem_ty);
+                }
+                self.record_type(span, expected);
+                expected.clone()
+            }
+
             // Map literal can coerce to HashMap<K,V> when expected
             (
                 Expr::MapLiteral { entries },

--- a/hew-types/src/check/tests/collections.rs
+++ b/hew-types/src/check/tests/collections.rs
@@ -5,6 +5,91 @@
 pub(super) use super::*;
 
 #[test]
+fn literal_coercion_array_literal_to_fixed_array() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let span = 0..6;
+    let expected = Ty::Array(Box::new(Ty::I64), 2);
+    let expr = Expr::Array(vec![make_int_literal(1, 1..2), make_int_literal(2, 4..5)]);
+
+    let result = checker.check_against(&expr, &span, &expected);
+
+    assert_eq!(result, expected);
+    assert!(
+        checker.errors.is_empty(),
+        "array literal should coerce to fixed array cleanly: {:#?}",
+        checker.errors
+    );
+    assert_eq!(
+        checker.expr_types.get(&SpanKey::from(&span)),
+        Some(&expected)
+    );
+}
+
+#[test]
+fn literal_coercion_array_literal_length_mismatch() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let span = 0..9;
+    let expected = Ty::Array(Box::new(Ty::I64), 2);
+    let expr = Expr::Array(vec![
+        make_int_literal(1, 1..2),
+        make_int_literal(2, 4..5),
+        make_int_literal(3, 7..8),
+    ]);
+
+    let result = checker.check_against(&expr, &span, &expected);
+
+    assert_eq!(result, Ty::Error);
+    assert_eq!(
+        checker.errors.len(),
+        1,
+        "length mismatch should emit one targeted diagnostic: {:#?}",
+        checker.errors
+    );
+    let error = &checker.errors[0];
+    assert_eq!(error.kind, TypeErrorKind::ArityMismatch);
+    assert_eq!(error.span, span);
+    assert!(
+        error.message.contains("expected 2") && error.message.contains("found 3"),
+        "diagnostic should name expected and actual arity: {error:#?}"
+    );
+}
+
+#[test]
+fn literal_coercion_array_literal_element_mismatch() {
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let span = 0..8;
+    let string_span = 1..4;
+    let expected = Ty::Array(Box::new(Ty::I64), 2);
+    let expr = Expr::Array(vec![
+        (
+            Expr::Literal(Literal::String("x".to_string())),
+            string_span.clone(),
+        ),
+        make_int_literal(2, 6..7),
+    ]);
+
+    let result = checker.check_against(&expr, &span, &expected);
+
+    assert_eq!(result, expected);
+    assert_eq!(
+        checker.errors.len(),
+        1,
+        "element mismatch should emit one element diagnostic: {:#?}",
+        checker.errors
+    );
+    let error = &checker.errors[0];
+    assert_eq!(error.span, string_span);
+    assert!(
+        matches!(
+            &error.kind,
+            TypeErrorKind::Mismatch { expected, actual }
+                if expected == "i64" && actual == "string"
+        ),
+        "element mismatch should cite the element type mismatch: {error:#?}"
+    );
+}
+
+#[test]
 fn vec_copy_record_new_constructor_typechecks() {
     let output = check_source(
         r"

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -100,6 +100,90 @@ fn assert_inline_typechecks_cleanly(source: &str, context: &str) {
 }
 
 #[test]
+fn array_literal_typechecks_against_fixed_array_return() {
+    assert_inline_typechecks_cleanly(
+        r"
+fn one(a: i64) -> [i64; 2] {
+    [a, a]
+}
+",
+        "array literal in fixed-array return position",
+    );
+}
+
+#[test]
+fn array_literal_typechecks_against_fixed_array_let_annotation() {
+    assert_inline_typechecks_cleanly(
+        r"
+fn main() {
+    let xs: [i64; 2] = [1, 2];
+}
+",
+        "array literal in fixed-array let annotation",
+    );
+}
+
+#[test]
+fn unannotated_array_literal_still_infers_vec() {
+    assert_inline_typechecks_cleanly(
+        r"
+fn take_vec(xs: Vec<i64>) {}
+
+fn main() {
+    let xs = [1, 2];
+    take_vec(xs);
+}
+",
+        "unannotated array literal should infer Vec<i64>",
+    );
+}
+
+#[test]
+fn fixed_array_literal_length_mismatch_is_targeted() {
+    let output = typecheck_inline(
+        r"
+fn one(a: i64) -> [i64; 2] {
+    [a, a, a]
+}
+",
+    );
+
+    assert_eq!(
+        output.errors.len(),
+        1,
+        "length mismatch should emit one targeted diagnostic: {:#?}",
+        output.errors
+    );
+    let error = &output.errors[0];
+    assert_eq!(error.kind, TypeErrorKind::ArityMismatch);
+    assert!(
+        error.message.contains("expected 2") && error.message.contains("found 3"),
+        "length mismatch diagnostic should name expected and actual arity: {error:#?}"
+    );
+}
+
+#[test]
+fn fixed_array_literal_element_mismatch_cites_element() {
+    let output = typecheck_inline(
+        r#"
+fn one(a: string) -> [i64; 2] {
+    [a, a]
+}
+"#,
+    );
+
+    assert!(
+        output.errors.iter().any(|error| matches!(
+            &error.kind,
+            TypeErrorKind::Mismatch { expected, actual }
+                if expected == "i64" && actual == "string"
+        )),
+        "element mismatch should cite the element type mismatch: {:#?}",
+        output.errors
+    );
+}
+
+#[test]
 fn hashmap_remove_typechecks_as_bool() {
     assert_inline_typechecks_cleanly(
         r#"

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -165,11 +165,11 @@ fn one(a: i64) -> [i64; 2] {
 #[test]
 fn fixed_array_literal_element_mismatch_cites_element() {
     let output = typecheck_inline(
-        r#"
+        r"
 fn one(a: string) -> [i64; 2] {
     [a, a]
 }
-"#,
+",
     );
 
     assert!(


### PR DESCRIPTION
## Summary

An array literal in an expected-`[T; N]` position always inferred `Vec<T>`, so any function returning a fixed-size array — or any `let` with a `[T; N]` annotation — failed with a spurious `type mismatch: expected [i64; 2], found Vec<i64>`.

The checker now has a dedicated `check_against` arm for `(Expr::Array, Ty::Array(T, N))`: each element is checked bidirectionally against `T`, the literal records as `[T; N]`, and a length mismatch gets a dedicated arity diagnostic on the literal's span (element-type mismatches cite the offending element's own span). The arm fires only on a subst-resolved concrete `Ty::Array` — unannotated array literals still infer `Vec<T>` exactly as before.

**Invariant:** an array literal checked against `[T; N]` *is* a `[T; N]` — the expectation is honoured at the checking boundary instead of being dropped on the floor.

With the checker fixed, the original repro now compiles through typechecking and reaches the pre-existing fail-closed codegen boundary for array *values* (`E_CODEGEN_FRONT_UNSUPPORTED`), which is tracked separately in #2329 — a correct rejection with an honest diagnostic rather than a wrong type error.

## Verification

- New unit + e2e checker tests: literal-against-return-type, literal-against-annotation, length mismatch (arity diagnostic + span), element-type mismatch (element span), no-expectation still infers `Vec<T>`.
- New CLI e2e `array_literal_fixed_array_return_reaches_codegen_boundary` pins that the repro reaches the codegen boundary rather than a checker mismatch.
- Full `hew-types` suite, workspace `clippy -D warnings`, `fmt --check`, corpus + ratchet suites all green.

## Out of scope

- Codegen support for `[T; N]` values in value-bearing positions — #2329.
- Validating the `[x; count]` repeat-literal count against the declared `N` — #2330.

Fixes #2257.