### PR TITLE
fix(codegen): declare uint to_string at its runtime width so O2 cannot fold a truncation

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -3356,6 +3356,86 @@ pub(crate) fn fn_type_for_return<'ctx>(
     }
 }
 
+fn basic_type_signature_label(ty: BasicTypeEnum<'_>) -> String {
+    match ty {
+        BasicTypeEnum::ArrayType(t) => t.print_to_string().to_string(),
+        BasicTypeEnum::FloatType(t) => t.print_to_string().to_string(),
+        BasicTypeEnum::IntType(t) => t.print_to_string().to_string(),
+        BasicTypeEnum::PointerType(t) => t.print_to_string().to_string(),
+        BasicTypeEnum::StructType(t) => t.print_to_string().to_string(),
+        BasicTypeEnum::VectorType(t) => t.print_to_string().to_string(),
+        BasicTypeEnum::ScalableVectorType(t) => t.print_to_string().to_string(),
+    }
+}
+
+fn metadata_type_signature_label(ty: BasicMetadataTypeEnum<'_>) -> String {
+    match ty {
+        BasicMetadataTypeEnum::ArrayType(t) => t.print_to_string().to_string(),
+        BasicMetadataTypeEnum::FloatType(t) => t.print_to_string().to_string(),
+        BasicMetadataTypeEnum::IntType(t) => t.print_to_string().to_string(),
+        BasicMetadataTypeEnum::PointerType(t) => t.print_to_string().to_string(),
+        BasicMetadataTypeEnum::StructType(t) => t.print_to_string().to_string(),
+        BasicMetadataTypeEnum::VectorType(t) => t.print_to_string().to_string(),
+        BasicMetadataTypeEnum::ScalableVectorType(t) => t.print_to_string().to_string(),
+        BasicMetadataTypeEnum::MetadataType(t) => t.print_to_string().to_string(),
+    }
+}
+
+fn return_type_signature_label(return_ty: Option<BasicTypeEnum<'_>>) -> String {
+    return_ty
+        .map(basic_type_signature_label)
+        .unwrap_or_else(|| "void".to_string())
+}
+
+fn ensure_catalog_ffi_signature_matches<'ctx>(
+    symbol: &str,
+    existing: FunctionValue<'ctx>,
+    return_ty: Option<BasicTypeEnum<'ctx>>,
+    param_tys: &[BasicMetadataTypeEnum<'ctx>],
+) -> CodegenResult<()> {
+    let fn_ty = existing.get_type();
+    let existing_param_tys = fn_ty.get_param_types();
+    let expected_params = param_tys
+        .iter()
+        .copied()
+        .map(metadata_type_signature_label)
+        .collect::<Vec<_>>();
+    let actual_params = existing_param_tys
+        .iter()
+        .copied()
+        .map(metadata_type_signature_label)
+        .collect::<Vec<_>>();
+    let expected_return = return_type_signature_label(return_ty);
+    let actual_return = return_type_signature_label(fn_ty.get_return_type());
+
+    if expected_params != actual_params || expected_return != actual_return {
+        return Err(CodegenError::FailClosed(format!(
+            "catalog FFI declaration for `{symbol}` conflicts with existing LLVM declaration: \
+             expected ({}) -> {}, got ({}) -> {}",
+            expected_params.join(", "),
+            expected_return,
+            actual_params.join(", "),
+            actual_return
+        )));
+    }
+
+    Ok(())
+}
+
+fn get_or_declare_catalog_ffi<'ctx>(
+    llvm_mod: &LlvmModule<'ctx>,
+    symbol: &str,
+    fn_ty: FunctionType<'ctx>,
+    return_ty: Option<BasicTypeEnum<'ctx>>,
+    param_tys: &[BasicMetadataTypeEnum<'ctx>],
+) -> CodegenResult<FunctionValue<'ctx>> {
+    if let Some(existing) = llvm_mod.get_function(symbol) {
+        ensure_catalog_ffi_signature_matches(symbol, existing, return_ty, param_tys)?;
+        return Ok(existing);
+    }
+    Ok(llvm_mod.add_function(symbol, fn_ty, Some(Linkage::External)))
+}
+
 fn builtin_type_to_llvm<'ctx>(
     ctx: &'ctx Context,
     ty: BuiltinTy,
@@ -3437,14 +3517,16 @@ fn runtime_ffi_return_abi_bits(symbol: &str) -> Option<u32> {
 }
 
 /// Per-parameter runtime C-ABI integer width (in bits) for catalog FFI symbols
-/// whose runtime parameter is *narrower* than the Hew-facing catalog type.
+/// whose runtime parameter width differs from the Hew-facing catalog type.
 ///
 /// Mirror of `runtime_ffi_return_abi_bits` for the argument direction:
 /// `hew_string_char_at(s, idx: i32)` takes an `i32`, but the catalog declares
 /// the index parameter as `i64`. Declaring the extern with the Hew-facing width
 /// passes a 64-bit value where the C function reads a 32-bit register; the call
-/// boundary truncates the i64 argument down to the declared i32. Returns `None`
-/// to keep the catalog-declared width when there is no narrower override.
+/// boundary truncates the i64 argument down to the declared i32. Shared runtime
+/// symbols can also use a wider runtime width than one Hew-facing overload, such
+/// as `hew_uint_to_string(n: u32)` serving both `u16` and `u32` catalog entries.
+/// Returns `None` to keep the catalog-declared width when there is no override.
 ///
 /// `param_idx` is zero-based over the catalog `entry.params` slice.
 fn runtime_ffi_param_abi_bits(symbol: &str, param_idx: usize) -> Option<u32> {
@@ -3453,6 +3535,8 @@ fn runtime_ffi_param_abi_bits(symbol: &str, param_idx: usize) -> Option<u32> {
         ("hew_string_char_at", 1) => Some(32),
         // `hew_string_char_at_utf8(s: ptr, index: i32) -> i32`.
         ("hew_string_char_at_utf8", 1) => Some(32),
+        // `hew_uint_to_string(n: u32) -> ptr`.
+        ("hew_uint_to_string", 0) => Some(32),
         _ => None,
     }
 }
@@ -3582,14 +3666,10 @@ fn declare_catalog_ffi<'ctx>(
         let mut raw_param_tys = param_tys.clone();
         raw_param_tys.push(ctx.ptr_type(AddressSpace::default()).into());
         let raw_fn_ty = ctx.void_type().fn_type(&raw_param_tys, false);
-        llvm_mod
-            .get_function(&raw_name)
-            .unwrap_or_else(|| llvm_mod.add_function(&raw_name, raw_fn_ty, Some(Linkage::External)))
+        get_or_declare_catalog_ffi(llvm_mod, &raw_name, raw_fn_ty, None, &raw_param_tys)?
     } else {
         let fn_ty = fn_type_for_return(ctx, return_ty, &param_tys);
-        llvm_mod
-            .get_function(symbol)
-            .unwrap_or_else(|| llvm_mod.add_function(symbol, fn_ty, Some(Linkage::External)))
+        get_or_declare_catalog_ffi(llvm_mod, symbol, fn_ty, return_ty, &param_tys)?
     };
     Ok(FnSymbol::Real {
         value,
@@ -42889,7 +42969,45 @@ mod tests {
     fn uint_to_string_runtime_arg_width_is_u32() {
         // The runtime signature is `hew_uint_to_string(n: u32)` at
         // `hew-runtime/src/string.rs:253`, so arg 0 must be declared as i32.
-        assert_eq!(runtime_ffi_param_abi_bits("hew_uint_to_string", 0), Some(32));
+        assert_eq!(
+            runtime_ffi_param_abi_bits("hew_uint_to_string", 0),
+            Some(32)
+        );
+    }
+
+    #[test]
+    fn catalog_ffi_redeclaration_mismatch_fails_closed() {
+        let ctx = Context::create();
+        let llvm_mod = ctx.create_module("catalog_ffi_redeclaration_mismatch");
+        let wrong_ty = ctx
+            .ptr_type(AddressSpace::default())
+            .fn_type(&[ctx.i16_type().into()], false);
+        llvm_mod.add_function("hew_uint_to_string", wrong_ty, Some(Linkage::External));
+
+        let entry = stdlib_catalog::entries()
+            .iter()
+            .find(|entry| entry.name == "to_string_u32")
+            .expect("to_string_u32 catalog entry");
+        let record_layouts = RecordLayoutMap::new();
+        let result = declare_catalog_ffi(
+            &ctx,
+            &llvm_mod,
+            entry,
+            "hew_uint_to_string",
+            &record_layouts,
+        );
+
+        let Err(err) = result else {
+            panic!("mismatched catalog FFI redeclaration must fail closed");
+        };
+        match err {
+            CodegenError::FailClosed(msg) => {
+                assert!(msg.contains("hew_uint_to_string"));
+                assert!(msg.contains("expected (i32) -> ptr"));
+                assert!(msg.contains("got (i16) -> ptr"));
+            }
+            other => panic!("expected fail-closed redeclaration error, got {other}"),
+        }
     }
 
     fn empty_pipeline_with_const_42() -> IrPipeline {

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -42885,6 +42885,13 @@ mod tests {
     use super::*;
     use hew_mir::{BasicBlock, DecisionFact, IrPipeline};
 
+    #[test]
+    fn uint_to_string_runtime_arg_width_is_u32() {
+        // The runtime signature is `hew_uint_to_string(n: u32)` at
+        // `hew-runtime/src/string.rs:253`, so arg 0 must be declared as i32.
+        assert_eq!(runtime_ffi_param_abi_bits("hew_uint_to_string", 0), Some(32));
+    }
+
     fn empty_pipeline_with_const_42() -> IrPipeline {
         let return_ty = ResolvedTy::I64;
         let main = RawMirFunction {

--- a/tests/hew/display_primitive_coverage_test.hew
+++ b/tests/hew/display_primitive_coverage_test.hew
@@ -24,6 +24,7 @@ fn test_generic_println_accepts_canonical_numeric_primitives() {
     let u8v: u8 = 250;
     let u16v: u16 = 65000;
     let u32v: u32 = 4000000000;
+    let u32_boundary: u32 = 65536;
     let u64v: u64 = (-1) as u64;
     let isizev: isize = -4096;
     let usizev: usize = 4000000000;
@@ -37,6 +38,7 @@ fn test_generic_println_accepts_canonical_numeric_primitives() {
     print_generic(u8v);
     print_generic(u16v);
     print_generic(u32v);
+    print_generic(u32_boundary);
     print_generic(u64v);
     print_generic(isizev);
     print_generic(usizev);
@@ -53,6 +55,7 @@ fn test_generic_to_string_formats_canonical_numeric_primitives() {
     let u8v: u8 = 250;
     let u16v: u16 = 65000;
     let u32v: u32 = 4000000000;
+    let u32_boundary: u32 = 65536;
     let u64v: u64 = (-1) as u64;
     let isizev: isize = -4096;
     let usizev: usize = 4000000000;
@@ -66,6 +69,7 @@ fn test_generic_to_string_formats_canonical_numeric_primitives() {
     testing.assert_eq_str(render_generic(u8v), "250");
     testing.assert_eq_str(render_generic(u16v), "65000");
     testing.assert_eq_str(render_generic(u32v), "4000000000");
+    testing.assert_eq_str(render_generic(u32_boundary), "65536");
     testing.assert_eq_str(render_generic(u64v), "18446744073709551615");
     testing.assert_eq_str(render_generic(isizev), "-4096");
     testing.assert_eq_str(render_generic(usizev), "4000000000");
@@ -82,6 +86,7 @@ fn test_generic_fstring_formats_canonical_numeric_primitives() {
     let u8v: u8 = 250;
     let u16v: u16 = 65000;
     let u32v: u32 = 4000000000;
+    let u32_boundary: u32 = 65536;
     let u64v: u64 = (-1) as u64;
     let isizev: isize = -4096;
     let usizev: usize = 4000000000;
@@ -95,6 +100,7 @@ fn test_generic_fstring_formats_canonical_numeric_primitives() {
     testing.assert_eq_str(interpolate_generic(u8v), "250");
     testing.assert_eq_str(interpolate_generic(u16v), "65000");
     testing.assert_eq_str(interpolate_generic(u32v), "4000000000");
+    testing.assert_eq_str(interpolate_generic(u32_boundary), "65536");
     testing.assert_eq_str(interpolate_generic(u64v), "18446744073709551615");
     testing.assert_eq_str(interpolate_generic(isizev), "-4096");
     testing.assert_eq_str(interpolate_generic(usizev), "4000000000");


### PR DESCRIPTION
## Summary

`to_string(x)` and `f"{x}"` for a `u32` produced wrong output at `-O2`: `4000000000` printed as `10240`. This was a real miscompile caught by the O0-vs-O2 differential gate on its first corpus run (#2328).

**Old failure mode.** The stdlib catalog routes both `to_string_u16` and `to_string_u32` to the shared runtime symbol `hew_uint_to_string`, whose export is `extern "C" fn(u32)`. Catalog FFI declaration deduplicates by symbol name and cached the *first-processed* entry's computed type — `to_string_u16` precedes `to_string_u32` in catalog order, so the function was declared `(i16) -> ptr`, and every u32 call site carried a licensed `trunc i32 → i16`. At O0 the truncation stayed latent (the full value happened to remain in the argument register); at O2, LLVM legitimately materializes only the declared width and constant-folds `4000000000` (`0xee6b2800`) to `10240` (`0x2800`).

**The fix.** Declare `hew_uint_to_string` at its true C-ABI width (`i32`) via the runtime FFI width table, and make catalog FFI redeclaration fail closed: any shared runtime symbol whose freshly-computed signature disagrees with the already-cached declaration is now a compile-time error with the exact mismatch (`expected (i32) -> ptr, got (i16) -> ptr`) instead of a silent reuse — the whole defect class, not just this symbol. The `u16` caller path zero-extends explicitly.

**Invariant:** a runtime symbol's LLVM declaration always matches its `extern "C"` export, and two catalog entries can never silently disagree about a shared symbol's signature.

## Verification

- Tests-first: the new unit pin (`runtime_ffi_param_abi_bits("hew_uint_to_string", 0) == Some(32)`) and the fixture additions were both verified red before the fix with the exact wrong values.
- `make test-o2-differential`: **O0 and O2 outcome sets identical across all 1010 corpus tests.**
- Fixture matrix: `u32 = 65536` and `u32 = 4000000000` boundary asserts, `u16v = 65000` (top-bit-set) zero-extension check, `u8`/`u64` no-regression — all exact-value assertions, green at O0 and O2, 3× stable.
- Full integrated preflight green (corpus, ratchets, fuzz oracle, sandbox parity, doc examples, lint).
- The differential gate scripts are untouched — the pipeline was never weakened.

## Out of scope

- The systematic runtime↔catalog FFI signature-parity gate across all symbols — #1884. This change lands the one-symbol pin and the fail-closed redeclaration guard as its seed.
- Wiring `make test-o2-differential` into CI — follows separately on top of this fix.

Fixes #2328.