### PR TITLE
feat(types): warn when an actor sleep loop can never observe its mailbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Actor sleep-loop mailbox lint.** `hew check` now warns when an actor
+  receive handler loops around `sleep`/`sleep_until` without an in-handler exit
+  path, and the guide documents the cancellable `#[every(duration)]` + flag
+  pattern. (closes #2271)
+
 ### Removed (breaking)
 
 - **User `impl Drop` is rejected.** Declaring `impl Drop for T` is now a

--- a/docs/design/lint-pass.md
+++ b/docs/design/lint-pass.md
@@ -5,10 +5,11 @@ maintainers · Companion to the ast-grep rule set
 
 M1 + M2 have landed: the lint infrastructure (`LintId` / `LintLevel` /
 `LintLevels`), the checker `run_lints` sweep, the CLI `--allow` / `--warn` /
-`--deny` flags, and in-source `// hew:allow(...)` suppression — plus six
+`--deny` flags, and in-source `// hew:allow(...)` suppression — plus seven
 checker lints (`needless_range_loop`, `redundant_else_after_return`,
-`needless_match_to_if_let`, `len_zero_comparison`, `needless_bool`, `must_use`) and the two
-ad-hoc warnings (`clone_on_copy`, `dead_code`) migrated onto the registry so
+`needless_match_to_if_let`, `len_zero_comparison`, `needless_bool`,
+`must_use`, `sleep_loop_blocks_mailbox`) and the two ad-hoc warnings
+(`clone_on_copy`, `dead_code`) migrated onto the registry so
 they are now re-levelable and suppressible. M3 has landed too: a backward
 liveness dataflow pass in `hew-mir`, the `dead_store` MIR lint built on it, and
 the CLI plumbing that surfaces MIR-stage lints as level-controlled, suppressible
@@ -224,6 +225,17 @@ the precise subset that is actually convertible.
     fails open — a dropped backpressure/disconnect signal, an unnoticed undelivered send, or a
     timed-out / mailbox-full / stopped-actor `ask` (`await actor.msg()`) mistaken for a reply.
     Opt out with `let _ = …` or `// hew:allow(must_use)`.
+  - **`sleep_loop_blocks_mailbox`** — an actor `receive fn` contains a `loop`, `while true`,
+    `while flag`, or `while !flag` whose body directly reaches `sleep` or `sleep_until`, has no
+    reachable `break` for that loop, and does not assign the bare guard name inside the loop body.
+    The lint runs only through the receive-function dispatch seam, never on free functions, actor
+    helper methods, impl methods, or trait methods, because the hazard is actor mailbox
+    run-to-completion. *Guards:* compound or derived-progress conditions (`while i < count`,
+    `while running && !paused`) are not candidates; `loop_body_has_break` suppresses loops with an
+    in-handler break path; the sleep scan stops at nested loop and lambda/generator boundaries so an
+    inner loop owns its own finding; the guard-assignment scan is permissive and crosses nested
+    bodies to avoid false positives. The suggestion points users at `#[every(duration)]` periodic
+    receive handlers plus a boolean flag, where each tick is a separate mailbox dispatch.
   - **Migrations.** `clone_on_copy` (clone on a Copy/BitCopy type; `hew-types/src/check/methods.rs`)
     and `dead_code` (unreachable functions; `hew-types/src/check/diagnostics.rs`) now emit through
     `Checker::emit_main_pass_lint`, giving them a `LintId` with `default_level() = Warn`. Default

--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -1372,6 +1372,90 @@ handlers convert to 0 ms (next tick); in `fn main` the OS sleep is
 nanosecond-precise (subject to OS granularity, typically ≥ 1 µs on
 Linux/macOS).
 
+### Periodic receive handlers — `#[every(duration)]`
+
+`#[every(duration)]` marks a zero-argument `receive fn` as periodic. The timer
+starts when the actor is spawned and repeats until the actor stops. Each firing
+is dispatched through the actor mailbox as its own message, so ordinary receive
+handlers can run between ticks.
+
+```hew
+actor Pulse {
+    var count: i64 = 0;
+
+    #[every(50ms)]
+    receive fn tick() {
+        count = count + 1;
+    }
+
+    receive fn total() -> i64 {
+        count
+    }
+}
+
+fn main() {
+    let p = spawn Pulse(count: 0);
+    sleep(250ms);
+    let r = await p.total();
+    match r {
+        Ok(n) => println(f"ticks={n}"),
+        Err(_) => println("ask failed"),
+    }
+}
+```
+
+Periodic handlers preserve the actor's single-threaded state model: a tick never
+runs concurrently with another receive handler on the same actor. It is just a
+separate mailbox dispatch armed by the runtime timer.
+
+### Cancellable long-running work in actor handlers
+
+A receive handler runs to completion before the actor observes the next message.
+If a handler writes `while running { sleep(...) }` and expects another receive
+handler to set `running = false`, the stop message cannot be dispatched until
+the loop exits. Use a periodic receive handler and a flag instead:
+
+```hew
+actor Worker {
+    var running: bool = true;
+    var ticks: i64 = 0;
+
+    #[every(25ms)]
+    receive fn tick() {
+        if !running {
+            return;
+        }
+        ticks = ticks + 1;
+    }
+
+    receive fn stop() {
+        running = false;
+    }
+
+    receive fn total() -> i64 {
+        ticks
+    }
+}
+
+fn main() {
+    let worker = spawn Worker(running: true, ticks: 0);
+    sleep(150ms);
+    worker.stop();
+    sleep(150ms);
+    let r = await worker.total();
+    match r {
+        Ok(n) => println(f"ticks={n}"),
+        Err(_) => println("ask failed"),
+    }
+}
+```
+
+Here `receive fn stop()` is a user-defined actor message. It is unrelated to the
+`#[on(stop)]` lifecycle hook, which is a plain `fn` invoked when the actor is
+tearing down. The `sleep_loop_blocks_mailbox` lint warns on the mailbox
+starvation shape where a receive handler loops around `sleep`/`sleep_until`
+without an in-loop exit path.
+
 ## State machines
 
 ### Machine declaration: events, states, transitions, step(), state_name()

--- a/hew-cli/tests/lint_pass_e2e.rs
+++ b/hew-cli/tests/lint_pass_e2e.rs
@@ -215,6 +215,69 @@ fn len_zero_comparison_inline_directive_suppresses() {
     );
 }
 
+// ── receive-handler lint: sleep_loop_blocks_mailbox ───────────────────
+
+const SLEEP_LOOP_BLOCKS_MAILBOX: &str = "actor Worker {\n\
+     var running: bool = true;\n\
+     receive fn run() { while running { sleep(10ms); } }\n\
+     receive fn stop() { running = false; }\n\
+     }\n";
+
+const SLEEP_LOOP_BLOCKS_MAILBOX_SUPPRESSED: &str = "actor Worker {\n\
+     var running: bool = true;\n\
+     receive fn run() {\n\
+     // hew:allow(sleep_loop_blocks_mailbox)\n\
+     while running { sleep(10ms); }\n\
+     }\n\
+     receive fn stop() { running = false; }\n\
+     }\n";
+
+const SLEEP_LOOP_BLOCKS_MAILBOX_MESSAGE: &str = "actor's mailbox is never observed";
+
+#[test]
+fn sleep_loop_blocks_mailbox_renders_by_default() {
+    let output = run_check(SLEEP_LOOP_BLOCKS_MAILBOX, &[]);
+    let stderr = stderr_of(&output);
+    assert!(
+        output.status.success(),
+        "a lint warning must not fail the build:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("warning:")
+            && stderr.contains(SLEEP_LOOP_BLOCKS_MAILBOX_MESSAGE)
+            && stderr.contains("#[every"),
+        "expected the sleep_loop_blocks_mailbox warning and suggestion:\n{stderr}"
+    );
+}
+
+#[test]
+fn sleep_loop_blocks_mailbox_deny_promotes_to_error() {
+    let output = run_check(
+        SLEEP_LOOP_BLOCKS_MAILBOX,
+        &["--deny", "sleep_loop_blocks_mailbox"],
+    );
+    let stderr = stderr_of(&output);
+    assert!(
+        !output.status.success(),
+        "--deny must fail the build:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("error:") && stderr.contains(SLEEP_LOOP_BLOCKS_MAILBOX_MESSAGE),
+        "--deny must render the lint as an error:\n{stderr}"
+    );
+}
+
+#[test]
+fn sleep_loop_blocks_mailbox_inline_directive_suppresses() {
+    let output = run_check(SLEEP_LOOP_BLOCKS_MAILBOX_SUPPRESSED, &[]);
+    let stderr = stderr_of(&output);
+    assert!(output.status.success(), "check should pass:\n{stderr}");
+    assert!(
+        !stderr.contains(SLEEP_LOOP_BLOCKS_MAILBOX_MESSAGE),
+        "an in-source `// hew:allow(...)` directive must suppress the lint:\n{stderr}"
+    );
+}
+
 // ── migrated warning: dead_code is now registry-controlled ───────────
 
 /// `helper` is never called, so the migrated `dead_code` lint flags it.

--- a/hew-types/src/check/lints/mod.rs
+++ b/hew-types/src/check/lints/mod.rs
@@ -49,6 +49,7 @@ mod needless_bool;
 mod needless_match_to_if_let;
 mod needless_range_loop;
 mod redundant_else_after_return;
+mod sleep_loop_blocks_mailbox;
 
 /// Stable identifier for a single compiler lint.
 ///
@@ -90,6 +91,10 @@ pub enum LintId {
     /// timed-out / mailbox-full / stopped-actor `ask` mistaken for a reply);
     /// handle it or bind `let _ = …`.
     MustUse,
+    /// A receive handler contains a sleep/sleep_until loop whose only obvious
+    /// exit is a sibling actor message, but the mailbox is not observed until
+    /// the current handler returns.
+    SleepLoopBlocksMailbox,
     // NOTE: a `clean_counter` lint (a loop-carried accumulator that is
     // incremented but never read after the loop) is deliberately NOT registered
     // here. It has no emission code yet, and registering an un-emitted lint
@@ -114,6 +119,7 @@ impl LintId {
         LintId::DeadCode,
         LintId::DeadStore,
         LintId::MustUse,
+        LintId::SleepLoopBlocksMailbox,
     ];
 
     /// The stable, lowercase string name for this lint.
@@ -133,6 +139,7 @@ impl LintId {
             LintId::DeadCode => "dead_code",
             LintId::DeadStore => "dead_store",
             LintId::MustUse => "must_use",
+            LintId::SleepLoopBlocksMailbox => "sleep_loop_blocks_mailbox",
         }
     }
 
@@ -158,7 +165,8 @@ impl LintId {
             | LintId::CloneOnCopy
             | LintId::DeadCode
             | LintId::DeadStore
-            | LintId::MustUse => LintLevel::Warn,
+            | LintId::MustUse
+            | LintId::SleepLoopBlocksMailbox => LintLevel::Warn,
         }
     }
 }
@@ -425,6 +433,19 @@ pub(super) fn lint_block(
     len_zero_comparison::check(ctx, levels, body, out);
     needless_bool::check(ctx, levels, body, out);
     must_use::check(ctx, levels, body, out);
+}
+
+/// Run receive-handler-only lints over one actor message handler body.
+///
+/// These diagnostics depend on actor mailbox run-to-completion semantics and
+/// must not run on free functions, actor helper methods, or trait/impl methods.
+pub(super) fn lint_receive_fn(
+    ctx: &LintCtx,
+    levels: &LintLevels,
+    body: &Block,
+    out: &mut Vec<TypeError>,
+) {
+    sleep_loop_blocks_mailbox::check(ctx, levels, body, out);
 }
 
 // ── shared read-only body walker ─────────────────────────────────────

--- a/hew-types/src/check/lints/mod.rs
+++ b/hew-types/src/check/lints/mod.rs
@@ -91,7 +91,7 @@ pub enum LintId {
     /// timed-out / mailbox-full / stopped-actor `ask` mistaken for a reply);
     /// handle it or bind `let _ = …`.
     MustUse,
-    /// A receive handler contains a sleep/sleep_until loop whose only obvious
+    /// A receive handler contains a `sleep`/`sleep_until` loop whose only obvious
     /// exit is a sibling actor message, but the mailbox is not observed until
     /// the current handler returns.
     SleepLoopBlocksMailbox,

--- a/hew-types/src/check/lints/sleep_loop_blocks_mailbox.rs
+++ b/hew-types/src/check/lints/sleep_loop_blocks_mailbox.rs
@@ -12,6 +12,9 @@
 //! Compound conditions and derived progress checks are not candidates. A
 //! reachable `break` or an assignment to the bare guard name inside the loop is
 //! treated as an in-handler exit path and suppresses the diagnostic.
+//! Closure/lambda and generator bodies are traversal boundaries: closures do
+//! not block the enclosing handler's mailbox when they are spawned or passed
+//! elsewhere.
 
 use hew_parser::{
     ast::{
@@ -167,7 +170,6 @@ fn find_in_expr(ctx: &LintCtx, levels: &LintLevels, expr: &Expr, out: &mut Vec<T
             find_in_block(ctx, levels, block, out);
         }
         Expr::UnsafeBlock(block) => find_in_block(ctx, levels, block, out),
-        Expr::GenBlock { body } => find_in_block(ctx, levels, body, out),
         Expr::If {
             condition,
             then_block,
@@ -196,9 +198,6 @@ fn find_in_expr(ctx: &LintCtx, levels: &LintLevels, expr: &Expr, out: &mut Vec<T
             for arm in arms {
                 find_in_arm(ctx, levels, arm, out);
             }
-        }
-        Expr::Lambda { body, .. } | Expr::SpawnLambdaActor { body, .. } => {
-            find_in_expr(ctx, levels, &body.0, out);
         }
         Expr::Spawn { target, args, .. } => {
             find_in_expr(ctx, levels, &target.0, out);
@@ -307,7 +306,10 @@ fn find_in_expr(ctx: &LintCtx, levels: &LintLevels, expr: &Expr, out: &mut Vec<T
                 find_in_expr(ctx, levels, &value.0, out);
             }
         }
-        Expr::Literal(_)
+        Expr::Lambda { .. }
+        | Expr::SpawnLambdaActor { .. }
+        | Expr::GenBlock { .. }
+        | Expr::Literal(_)
         | Expr::Identifier(_)
         | Expr::This
         | Expr::RegexLiteral(_)

--- a/hew-types/src/check/lints/sleep_loop_blocks_mailbox.rs
+++ b/hew-types/src/check/lints/sleep_loop_blocks_mailbox.rs
@@ -1,0 +1,889 @@
+//! The `sleep_loop_blocks_mailbox` lint.
+//!
+//! Flags actor receive handlers that loop around `sleep`/`sleep_until` without
+//! an in-loop exit path. Actor message handlers run to completion, so another
+//! message to the same actor cannot update the loop guard until the current
+//! handler returns.
+//!
+//! ## Precision over recall
+//!
+//! The lint only considers loops whose continuation condition is obviously
+//! mailbox-controlled: `loop`, `while true`, `while flag`, or `while !flag`.
+//! Compound conditions and derived progress checks are not candidates. A
+//! reachable `break` or an assignment to the bare guard name inside the loop is
+//! treated as an in-handler exit path and suppresses the diagnostic.
+
+use hew_parser::{
+    ast::{
+        Block, CallArg, ElseBlock, Expr, Literal, MatchArm, SelectArm, Span, Stmt, StringPart,
+        UnaryOp,
+    },
+    loop_body_has_break,
+};
+
+use crate::error::TypeError;
+
+use super::{LintCtx, LintId, LintLevels};
+
+/// Entry point: discover candidate sleep loops inside one actor receive body.
+pub(super) fn check(ctx: &LintCtx, levels: &LintLevels, body: &Block, out: &mut Vec<TypeError>) {
+    find_in_block(ctx, levels, body, out);
+}
+
+fn find_in_block(ctx: &LintCtx, levels: &LintLevels, block: &Block, out: &mut Vec<TypeError>) {
+    for (stmt, span) in &block.stmts {
+        find_in_stmt(ctx, levels, stmt, span, out);
+    }
+    if let Some(trailing) = &block.trailing_expr {
+        find_in_expr(ctx, levels, &trailing.0, out);
+    }
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "statement visitor enumerates every block-bearing stmt shape"
+)]
+fn find_in_stmt(
+    ctx: &LintCtx,
+    levels: &LintLevels,
+    stmt: &Stmt,
+    span: &Span,
+    out: &mut Vec<TypeError>,
+) {
+    match stmt {
+        Stmt::Loop { label, body } => {
+            try_flag(
+                ctx,
+                levels,
+                Candidate::Unconditional,
+                label,
+                body,
+                span,
+                out,
+            );
+            find_in_block(ctx, levels, body, out);
+        }
+        Stmt::While {
+            label,
+            condition,
+            body,
+        } => {
+            if let Some(candidate) = candidate_from_condition(&condition.0) {
+                try_flag(ctx, levels, candidate, label, body, span, out);
+            }
+            find_in_expr(ctx, levels, &condition.0, out);
+            find_in_block(ctx, levels, body, out);
+        }
+        Stmt::For { iterable, body, .. } => {
+            find_in_expr(ctx, levels, &iterable.0, out);
+            find_in_block(ctx, levels, body, out);
+        }
+        Stmt::WhileLet { expr, body, .. } => {
+            find_in_expr(ctx, levels, &expr.0, out);
+            find_in_block(ctx, levels, body, out);
+        }
+        Stmt::If {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            find_in_expr(ctx, levels, &condition.0, out);
+            find_in_block(ctx, levels, then_block, out);
+            if let Some(else_block) = else_block {
+                find_in_else(ctx, levels, else_block, out);
+            }
+        }
+        Stmt::IfLet {
+            expr,
+            body,
+            else_body,
+            ..
+        } => {
+            find_in_expr(ctx, levels, &expr.0, out);
+            find_in_block(ctx, levels, body, out);
+            if let Some(else_body) = else_body {
+                find_in_block(ctx, levels, else_body, out);
+            }
+        }
+        Stmt::Match { scrutinee, arms } => {
+            find_in_expr(ctx, levels, &scrutinee.0, out);
+            for arm in arms {
+                find_in_arm(ctx, levels, arm, out);
+            }
+        }
+        Stmt::Let {
+            value, else_block, ..
+        } => {
+            if let Some(value) = value {
+                find_in_expr(ctx, levels, &value.0, out);
+            }
+            if let Some(else_block) = else_block {
+                find_in_block(ctx, levels, else_block, out);
+            }
+        }
+        Stmt::Var { value, .. } | Stmt::Break { value, .. } | Stmt::Return(value) => {
+            if let Some(value) = value {
+                find_in_expr(ctx, levels, &value.0, out);
+            }
+        }
+        Stmt::Assign { target, value, .. } => {
+            find_in_expr(ctx, levels, &target.0, out);
+            find_in_expr(ctx, levels, &value.0, out);
+        }
+        Stmt::Defer(expr) => find_in_expr(ctx, levels, &expr.0, out),
+        Stmt::Expression(expr) => find_in_expr(ctx, levels, &expr.0, out),
+        Stmt::Continue { .. } => {}
+    }
+}
+
+fn find_in_else(
+    ctx: &LintCtx,
+    levels: &LintLevels,
+    else_block: &ElseBlock,
+    out: &mut Vec<TypeError>,
+) {
+    if let Some(if_stmt) = &else_block.if_stmt {
+        find_in_stmt(ctx, levels, &if_stmt.0, &if_stmt.1, out);
+    }
+    if let Some(block) = &else_block.block {
+        find_in_block(ctx, levels, block, out);
+    }
+}
+
+fn find_in_arm(ctx: &LintCtx, levels: &LintLevels, arm: &MatchArm, out: &mut Vec<TypeError>) {
+    if let Some(guard) = &arm.guard {
+        find_in_expr(ctx, levels, &guard.0, out);
+    }
+    find_in_expr(ctx, levels, &arm.body.0, out);
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "expression visitor enumerates every block-bearing expr shape"
+)]
+fn find_in_expr(ctx: &LintCtx, levels: &LintLevels, expr: &Expr, out: &mut Vec<TypeError>) {
+    match expr {
+        Expr::Block(block) | Expr::Scope { body: block } | Expr::ForkBlock { body: block } => {
+            find_in_block(ctx, levels, block, out);
+        }
+        Expr::UnsafeBlock(block) => find_in_block(ctx, levels, block, out),
+        Expr::GenBlock { body } => find_in_block(ctx, levels, body, out),
+        Expr::If {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            find_in_expr(ctx, levels, &condition.0, out);
+            find_in_expr(ctx, levels, &then_block.0, out);
+            if let Some(else_block) = else_block {
+                find_in_expr(ctx, levels, &else_block.0, out);
+            }
+        }
+        Expr::IfLet {
+            expr,
+            body,
+            else_body,
+            ..
+        } => {
+            find_in_expr(ctx, levels, &expr.0, out);
+            find_in_block(ctx, levels, body, out);
+            if let Some(else_body) = else_body {
+                find_in_block(ctx, levels, else_body, out);
+            }
+        }
+        Expr::Match { scrutinee, arms } => {
+            find_in_expr(ctx, levels, &scrutinee.0, out);
+            for arm in arms {
+                find_in_arm(ctx, levels, arm, out);
+            }
+        }
+        Expr::Lambda { body, .. } | Expr::SpawnLambdaActor { body, .. } => {
+            find_in_expr(ctx, levels, &body.0, out);
+        }
+        Expr::Spawn { target, args, .. } => {
+            find_in_expr(ctx, levels, &target.0, out);
+            for (_, value) in args {
+                find_in_expr(ctx, levels, &value.0, out);
+            }
+        }
+        Expr::ScopeDeadline { duration, body } => {
+            find_in_expr(ctx, levels, &duration.0, out);
+            find_in_block(ctx, levels, body, out);
+        }
+        Expr::Timeout { expr, duration } => {
+            find_in_expr(ctx, levels, &expr.0, out);
+            find_in_expr(ctx, levels, &duration.0, out);
+        }
+        Expr::Call { function, args, .. } => {
+            find_in_expr(ctx, levels, &function.0, out);
+            for arg in args {
+                find_in_expr(ctx, levels, &arg.expr().0, out);
+            }
+        }
+        Expr::MethodCall { receiver, args, .. } => {
+            find_in_expr(ctx, levels, &receiver.0, out);
+            for arg in args {
+                find_in_expr(ctx, levels, &arg.expr().0, out);
+            }
+        }
+        Expr::StructInit { fields, base, .. } => {
+            for (_, value) in fields {
+                find_in_expr(ctx, levels, &value.0, out);
+            }
+            if let Some(base) = base {
+                find_in_expr(ctx, levels, &base.0, out);
+            }
+        }
+        Expr::Select { arms, timeout } => {
+            for arm in arms {
+                find_in_expr(ctx, levels, &arm.source.0, out);
+                find_in_expr(ctx, levels, &arm.body.0, out);
+            }
+            if let Some(timeout) = timeout {
+                find_in_expr(ctx, levels, &timeout.duration.0, out);
+                find_in_expr(ctx, levels, &timeout.body.0, out);
+            }
+        }
+        Expr::InterpolatedString(parts) => {
+            for part in parts {
+                if let StringPart::Expr(expr) = part {
+                    find_in_expr(ctx, levels, &expr.0, out);
+                }
+            }
+        }
+        Expr::Tuple(items) | Expr::Array(items) | Expr::Join(items) => {
+            for item in items {
+                find_in_expr(ctx, levels, &item.0, out);
+            }
+        }
+        Expr::ArrayRepeat { value, count } => {
+            find_in_expr(ctx, levels, &value.0, out);
+            find_in_expr(ctx, levels, &count.0, out);
+        }
+        Expr::MapLiteral { entries } => {
+            for (key, value) in entries {
+                find_in_expr(ctx, levels, &key.0, out);
+                find_in_expr(ctx, levels, &value.0, out);
+            }
+        }
+        Expr::Binary { left, right, .. } => {
+            find_in_expr(ctx, levels, &left.0, out);
+            find_in_expr(ctx, levels, &right.0, out);
+        }
+        Expr::Unary { operand, .. }
+        | Expr::Clone(operand)
+        | Expr::Await(operand)
+        | Expr::AwaitRestart(operand)
+        | Expr::PostfixTry(operand)
+        | Expr::ForkChild { expr: operand, .. } => {
+            find_in_expr(ctx, levels, &operand.0, out);
+        }
+        Expr::Cast { expr, .. } | Expr::FieldAccess { object: expr, .. } => {
+            find_in_expr(ctx, levels, &expr.0, out);
+        }
+        Expr::Index { object, index } => {
+            find_in_expr(ctx, levels, &object.0, out);
+            find_in_expr(ctx, levels, &index.0, out);
+        }
+        Expr::Range { start, end, .. } => {
+            if let Some(start) = start {
+                find_in_expr(ctx, levels, &start.0, out);
+            }
+            if let Some(end) = end {
+                find_in_expr(ctx, levels, &end.0, out);
+            }
+        }
+        Expr::Is { lhs, rhs } => {
+            find_in_expr(ctx, levels, &lhs.0, out);
+            find_in_expr(ctx, levels, &rhs.0, out);
+        }
+        Expr::MachineEmit { fields, .. } => {
+            for (_, value) in fields {
+                find_in_expr(ctx, levels, &value.0, out);
+            }
+        }
+        Expr::Yield(value) | Expr::Return(value) => {
+            if let Some(value) = value {
+                find_in_expr(ctx, levels, &value.0, out);
+            }
+        }
+        Expr::Literal(_)
+        | Expr::Identifier(_)
+        | Expr::This
+        | Expr::RegexLiteral(_)
+        | Expr::ByteStringLiteral(_)
+        | Expr::ByteArrayLiteral(_) => {}
+    }
+}
+
+#[derive(Debug, Clone)]
+enum Candidate {
+    Unconditional,
+    Guard(String),
+}
+
+fn candidate_from_condition(condition: &Expr) -> Option<Candidate> {
+    match condition {
+        Expr::Literal(Literal::Bool(true)) => Some(Candidate::Unconditional),
+        Expr::Identifier(name) => Some(Candidate::Guard(name.clone())),
+        Expr::Unary {
+            op: UnaryOp::Not,
+            operand,
+        } => match &operand.0 {
+            Expr::Identifier(name) => Some(Candidate::Guard(name.clone())),
+            Expr::Binary { .. }
+            | Expr::Unary { .. }
+            | Expr::Clone(_)
+            | Expr::Literal(_)
+            | Expr::Tuple(_)
+            | Expr::Array(_)
+            | Expr::ArrayRepeat { .. }
+            | Expr::MapLiteral { .. }
+            | Expr::Block(_)
+            | Expr::If { .. }
+            | Expr::IfLet { .. }
+            | Expr::Match { .. }
+            | Expr::Lambda { .. }
+            | Expr::Spawn { .. }
+            | Expr::SpawnLambdaActor { .. }
+            | Expr::Scope { .. }
+            | Expr::ForkChild { .. }
+            | Expr::ForkBlock { .. }
+            | Expr::ScopeDeadline { .. }
+            | Expr::InterpolatedString(_)
+            | Expr::Call { .. }
+            | Expr::MethodCall { .. }
+            | Expr::StructInit { .. }
+            | Expr::Select { .. }
+            | Expr::Join(_)
+            | Expr::Timeout { .. }
+            | Expr::UnsafeBlock(_)
+            | Expr::Yield(_)
+            | Expr::Return(_)
+            | Expr::This
+            | Expr::FieldAccess { .. }
+            | Expr::Index { .. }
+            | Expr::Cast { .. }
+            | Expr::PostfixTry(_)
+            | Expr::Range { .. }
+            | Expr::Await(_)
+            | Expr::AwaitRestart(_)
+            | Expr::RegexLiteral(_)
+            | Expr::ByteStringLiteral(_)
+            | Expr::ByteArrayLiteral(_)
+            | Expr::Is { .. }
+            | Expr::MachineEmit { .. }
+            | Expr::GenBlock { .. } => None,
+        },
+        Expr::Binary { .. }
+        | Expr::Unary { .. }
+        | Expr::Clone(_)
+        | Expr::Literal(_)
+        | Expr::Tuple(_)
+        | Expr::Array(_)
+        | Expr::ArrayRepeat { .. }
+        | Expr::MapLiteral { .. }
+        | Expr::Block(_)
+        | Expr::If { .. }
+        | Expr::IfLet { .. }
+        | Expr::Match { .. }
+        | Expr::Lambda { .. }
+        | Expr::Spawn { .. }
+        | Expr::SpawnLambdaActor { .. }
+        | Expr::Scope { .. }
+        | Expr::ForkChild { .. }
+        | Expr::ForkBlock { .. }
+        | Expr::ScopeDeadline { .. }
+        | Expr::InterpolatedString(_)
+        | Expr::Call { .. }
+        | Expr::MethodCall { .. }
+        | Expr::StructInit { .. }
+        | Expr::Select { .. }
+        | Expr::Join(_)
+        | Expr::Timeout { .. }
+        | Expr::UnsafeBlock(_)
+        | Expr::Yield(_)
+        | Expr::Return(_)
+        | Expr::This
+        | Expr::FieldAccess { .. }
+        | Expr::Index { .. }
+        | Expr::Cast { .. }
+        | Expr::PostfixTry(_)
+        | Expr::Range { .. }
+        | Expr::Await(_)
+        | Expr::AwaitRestart(_)
+        | Expr::RegexLiteral(_)
+        | Expr::ByteStringLiteral(_)
+        | Expr::ByteArrayLiteral(_)
+        | Expr::Is { .. }
+        | Expr::MachineEmit { .. }
+        | Expr::GenBlock { .. } => None,
+    }
+}
+
+fn try_flag(
+    ctx: &LintCtx,
+    levels: &LintLevels,
+    candidate: Candidate,
+    label: &Option<String>,
+    body: &Block,
+    span: &Span,
+    out: &mut Vec<TypeError>,
+) {
+    if !bounded_contains_sleep(body) || loop_body_has_break(body, label.as_deref()) {
+        return;
+    }
+    if let Candidate::Guard(name) = &candidate {
+        if assigns_identifier(body, name) {
+            return;
+        }
+    }
+
+    ctx.emit(
+        levels,
+        LintId::SleepLoopBlocksMailbox,
+        span,
+        "this loop suspends on `sleep`/`sleep_until` but the actor's mailbox is never observed until it exits — a sibling message (e.g. a stop handler) cannot be dispatched until this loop returns".to_string(),
+        "use a `#[every(duration)]` periodic receive handler with a boolean flag checked each tick instead — each firing is a separate dispatched message, so a stop-style handler can interleave between ticks".to_string(),
+        out,
+    );
+}
+
+fn bounded_contains_sleep(block: &Block) -> bool {
+    block
+        .stmts
+        .iter()
+        .any(|(stmt, _)| bounded_stmt_has_sleep(stmt))
+        || block
+            .trailing_expr
+            .as_ref()
+            .is_some_and(|expr| bounded_expr_has_sleep(&expr.0))
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "statement visitor enumerates every Stmt shape to preserve boundary decisions"
+)]
+fn bounded_stmt_has_sleep(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Loop { .. } | Stmt::For { .. } | Stmt::While { .. } | Stmt::WhileLet { .. } => false,
+        Stmt::If {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            bounded_expr_has_sleep(&condition.0)
+                || bounded_contains_sleep(then_block)
+                || else_block.as_ref().is_some_and(bounded_else_has_sleep)
+        }
+        Stmt::IfLet {
+            expr,
+            body,
+            else_body,
+            ..
+        } => {
+            bounded_expr_has_sleep(&expr.0)
+                || bounded_contains_sleep(body)
+                || else_body.as_ref().is_some_and(bounded_contains_sleep)
+        }
+        Stmt::Match { scrutinee, arms } => {
+            bounded_expr_has_sleep(&scrutinee.0) || arms.iter().any(bounded_arm_has_sleep)
+        }
+        Stmt::Let {
+            value, else_block, ..
+        } => {
+            value
+                .as_ref()
+                .is_some_and(|value| bounded_expr_has_sleep(&value.0))
+                || else_block.as_ref().is_some_and(bounded_contains_sleep)
+        }
+        Stmt::Var { value, .. } | Stmt::Break { value, .. } | Stmt::Return(value) => value
+            .as_ref()
+            .is_some_and(|value| bounded_expr_has_sleep(&value.0)),
+        Stmt::Assign { target, value, .. } => {
+            bounded_expr_has_sleep(&target.0) || bounded_expr_has_sleep(&value.0)
+        }
+        Stmt::Defer(expr) => bounded_expr_has_sleep(&expr.0),
+        Stmt::Expression(expr) => bounded_expr_has_sleep(&expr.0),
+        Stmt::Continue { .. } => false,
+    }
+}
+
+fn bounded_else_has_sleep(else_block: &ElseBlock) -> bool {
+    else_block
+        .if_stmt
+        .as_ref()
+        .is_some_and(|stmt| bounded_stmt_has_sleep(&stmt.0))
+        || else_block
+            .block
+            .as_ref()
+            .is_some_and(bounded_contains_sleep)
+}
+
+fn bounded_arm_has_sleep(arm: &MatchArm) -> bool {
+    arm.guard
+        .as_ref()
+        .is_some_and(|guard| bounded_expr_has_sleep(&guard.0))
+        || bounded_expr_has_sleep(&arm.body.0)
+}
+
+fn bounded_call_args_have_sleep(args: &[CallArg]) -> bool {
+    args.iter().any(|arg| bounded_expr_has_sleep(&arg.expr().0))
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "expression visitor enumerates every Expr shape to preserve boundary decisions"
+)]
+fn bounded_expr_has_sleep(expr: &Expr) -> bool {
+    match expr {
+        Expr::Call { function, args, .. } => {
+            matches!(&function.0, Expr::Identifier(name) if name == "sleep" || name == "sleep_until")
+                || bounded_expr_has_sleep(&function.0)
+                || bounded_call_args_have_sleep(args)
+        }
+        Expr::Lambda { .. } | Expr::SpawnLambdaActor { .. } | Expr::GenBlock { .. } => false,
+        Expr::Block(block) | Expr::Scope { body: block } | Expr::ForkBlock { body: block } => {
+            bounded_contains_sleep(block)
+        }
+        Expr::UnsafeBlock(block) => bounded_contains_sleep(block),
+        Expr::If {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            bounded_expr_has_sleep(&condition.0)
+                || bounded_expr_has_sleep(&then_block.0)
+                || else_block
+                    .as_ref()
+                    .is_some_and(|else_block| bounded_expr_has_sleep(&else_block.0))
+        }
+        Expr::IfLet {
+            expr,
+            body,
+            else_body,
+            ..
+        } => {
+            bounded_expr_has_sleep(&expr.0)
+                || bounded_contains_sleep(body)
+                || else_body.as_ref().is_some_and(bounded_contains_sleep)
+        }
+        Expr::Match { scrutinee, arms } => {
+            bounded_expr_has_sleep(&scrutinee.0) || arms.iter().any(bounded_arm_has_sleep)
+        }
+        Expr::Spawn { target, args, .. } => {
+            bounded_expr_has_sleep(&target.0)
+                || args
+                    .iter()
+                    .any(|(_, value)| bounded_expr_has_sleep(&value.0))
+        }
+        Expr::ScopeDeadline { duration, body } => {
+            bounded_expr_has_sleep(&duration.0) || bounded_contains_sleep(body)
+        }
+        Expr::Timeout { expr, duration } => {
+            bounded_expr_has_sleep(&expr.0) || bounded_expr_has_sleep(&duration.0)
+        }
+        Expr::MethodCall { receiver, args, .. } => {
+            bounded_expr_has_sleep(&receiver.0) || bounded_call_args_have_sleep(args)
+        }
+        Expr::StructInit { fields, base, .. } => {
+            fields
+                .iter()
+                .any(|(_, value)| bounded_expr_has_sleep(&value.0))
+                || base
+                    .as_ref()
+                    .is_some_and(|base| bounded_expr_has_sleep(&base.0))
+        }
+        Expr::Select { arms, timeout } => {
+            arms.iter().any(bounded_select_arm_has_sleep)
+                || timeout.as_ref().is_some_and(|timeout| {
+                    bounded_expr_has_sleep(&timeout.duration.0)
+                        || bounded_expr_has_sleep(&timeout.body.0)
+                })
+        }
+        Expr::InterpolatedString(parts) => parts.iter().any(|part| match part {
+            StringPart::Literal(_) => false,
+            StringPart::Expr(expr) => bounded_expr_has_sleep(&expr.0),
+        }),
+        Expr::Tuple(items) | Expr::Array(items) | Expr::Join(items) => {
+            items.iter().any(|item| bounded_expr_has_sleep(&item.0))
+        }
+        Expr::ArrayRepeat { value, count } => {
+            bounded_expr_has_sleep(&value.0) || bounded_expr_has_sleep(&count.0)
+        }
+        Expr::MapLiteral { entries } => entries
+            .iter()
+            .any(|(key, value)| bounded_expr_has_sleep(&key.0) || bounded_expr_has_sleep(&value.0)),
+        Expr::Binary { left, right, .. } => {
+            bounded_expr_has_sleep(&left.0) || bounded_expr_has_sleep(&right.0)
+        }
+        Expr::Unary { operand, .. }
+        | Expr::Clone(operand)
+        | Expr::Await(operand)
+        | Expr::AwaitRestart(operand)
+        | Expr::PostfixTry(operand)
+        | Expr::ForkChild { expr: operand, .. } => bounded_expr_has_sleep(&operand.0),
+        Expr::Cast { expr, .. } | Expr::FieldAccess { object: expr, .. } => {
+            bounded_expr_has_sleep(&expr.0)
+        }
+        Expr::Index { object, index } => {
+            bounded_expr_has_sleep(&object.0) || bounded_expr_has_sleep(&index.0)
+        }
+        Expr::Range { start, end, .. } => {
+            start
+                .as_ref()
+                .is_some_and(|start| bounded_expr_has_sleep(&start.0))
+                || end
+                    .as_ref()
+                    .is_some_and(|end| bounded_expr_has_sleep(&end.0))
+        }
+        Expr::Is { lhs, rhs } => bounded_expr_has_sleep(&lhs.0) || bounded_expr_has_sleep(&rhs.0),
+        Expr::MachineEmit { fields, .. } => fields
+            .iter()
+            .any(|(_, value)| bounded_expr_has_sleep(&value.0)),
+        Expr::Yield(value) | Expr::Return(value) => value
+            .as_ref()
+            .is_some_and(|value| bounded_expr_has_sleep(&value.0)),
+        Expr::Literal(_)
+        | Expr::Identifier(_)
+        | Expr::This
+        | Expr::RegexLiteral(_)
+        | Expr::ByteStringLiteral(_)
+        | Expr::ByteArrayLiteral(_) => false,
+    }
+}
+
+fn bounded_select_arm_has_sleep(arm: &SelectArm) -> bool {
+    bounded_expr_has_sleep(&arm.source.0) || bounded_expr_has_sleep(&arm.body.0)
+}
+
+fn assigns_identifier(block: &Block, name: &str) -> bool {
+    block
+        .stmts
+        .iter()
+        .any(|(stmt, _)| stmt_assigns_identifier(stmt, name))
+        || block
+            .trailing_expr
+            .as_ref()
+            .is_some_and(|expr| expr_assigns_identifier(&expr.0, name))
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "statement visitor enumerates every Stmt shape so assignment sites are not missed"
+)]
+fn stmt_assigns_identifier(stmt: &Stmt, name: &str) -> bool {
+    match stmt {
+        Stmt::Assign { target, value, .. } => {
+            matches!(&target.0, Expr::Identifier(target_name) if target_name == name)
+                || expr_assigns_identifier(&target.0, name)
+                || expr_assigns_identifier(&value.0, name)
+        }
+        Stmt::Loop { body, .. } => assigns_identifier(body, name),
+        Stmt::For { iterable, body, .. } => {
+            expr_assigns_identifier(&iterable.0, name) || assigns_identifier(body, name)
+        }
+        Stmt::While {
+            condition, body, ..
+        } => expr_assigns_identifier(&condition.0, name) || assigns_identifier(body, name),
+        Stmt::WhileLet { expr, body, .. } => {
+            expr_assigns_identifier(&expr.0, name) || assigns_identifier(body, name)
+        }
+        Stmt::If {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            expr_assigns_identifier(&condition.0, name)
+                || assigns_identifier(then_block, name)
+                || else_block
+                    .as_ref()
+                    .is_some_and(|else_block| else_assigns_identifier(else_block, name))
+        }
+        Stmt::IfLet {
+            expr,
+            body,
+            else_body,
+            ..
+        } => {
+            expr_assigns_identifier(&expr.0, name)
+                || assigns_identifier(body, name)
+                || else_body
+                    .as_ref()
+                    .is_some_and(|else_body| assigns_identifier(else_body, name))
+        }
+        Stmt::Match { scrutinee, arms } => {
+            expr_assigns_identifier(&scrutinee.0, name)
+                || arms.iter().any(|arm| arm_assigns_identifier(arm, name))
+        }
+        Stmt::Let {
+            value, else_block, ..
+        } => {
+            value
+                .as_ref()
+                .is_some_and(|value| expr_assigns_identifier(&value.0, name))
+                || else_block
+                    .as_ref()
+                    .is_some_and(|else_block| assigns_identifier(else_block, name))
+        }
+        Stmt::Var { value, .. } | Stmt::Break { value, .. } | Stmt::Return(value) => value
+            .as_ref()
+            .is_some_and(|value| expr_assigns_identifier(&value.0, name)),
+        Stmt::Defer(expr) => expr_assigns_identifier(&expr.0, name),
+        Stmt::Expression(expr) => expr_assigns_identifier(&expr.0, name),
+        Stmt::Continue { .. } => false,
+    }
+}
+
+fn else_assigns_identifier(else_block: &ElseBlock, name: &str) -> bool {
+    else_block
+        .if_stmt
+        .as_ref()
+        .is_some_and(|stmt| stmt_assigns_identifier(&stmt.0, name))
+        || else_block
+            .block
+            .as_ref()
+            .is_some_and(|block| assigns_identifier(block, name))
+}
+
+fn arm_assigns_identifier(arm: &MatchArm, name: &str) -> bool {
+    arm.guard
+        .as_ref()
+        .is_some_and(|guard| expr_assigns_identifier(&guard.0, name))
+        || expr_assigns_identifier(&arm.body.0, name)
+}
+
+fn call_args_assign_identifier(args: &[CallArg], name: &str) -> bool {
+    args.iter()
+        .any(|arg| expr_assigns_identifier(&arg.expr().0, name))
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "expression visitor enumerates every Expr shape so assignment sites are not missed"
+)]
+fn expr_assigns_identifier(expr: &Expr, name: &str) -> bool {
+    match expr {
+        Expr::Block(block)
+        | Expr::Scope { body: block }
+        | Expr::ForkBlock { body: block }
+        | Expr::GenBlock { body: block } => assigns_identifier(block, name),
+        Expr::UnsafeBlock(block) => assigns_identifier(block, name),
+        Expr::If {
+            condition,
+            then_block,
+            else_block,
+        } => {
+            expr_assigns_identifier(&condition.0, name)
+                || expr_assigns_identifier(&then_block.0, name)
+                || else_block
+                    .as_ref()
+                    .is_some_and(|else_block| expr_assigns_identifier(&else_block.0, name))
+        }
+        Expr::IfLet {
+            expr,
+            body,
+            else_body,
+            ..
+        } => {
+            expr_assigns_identifier(&expr.0, name)
+                || assigns_identifier(body, name)
+                || else_body
+                    .as_ref()
+                    .is_some_and(|else_body| assigns_identifier(else_body, name))
+        }
+        Expr::Match { scrutinee, arms } => {
+            expr_assigns_identifier(&scrutinee.0, name)
+                || arms.iter().any(|arm| arm_assigns_identifier(arm, name))
+        }
+        Expr::Lambda { body, .. } | Expr::SpawnLambdaActor { body, .. } => {
+            expr_assigns_identifier(&body.0, name)
+        }
+        Expr::Spawn { target, args, .. } => {
+            expr_assigns_identifier(&target.0, name)
+                || args
+                    .iter()
+                    .any(|(_, value)| expr_assigns_identifier(&value.0, name))
+        }
+        Expr::ScopeDeadline { duration, body } => {
+            expr_assigns_identifier(&duration.0, name) || assigns_identifier(body, name)
+        }
+        Expr::Timeout { expr, duration } => {
+            expr_assigns_identifier(&expr.0, name) || expr_assigns_identifier(&duration.0, name)
+        }
+        Expr::Call { function, args, .. } => {
+            expr_assigns_identifier(&function.0, name) || call_args_assign_identifier(args, name)
+        }
+        Expr::MethodCall { receiver, args, .. } => {
+            expr_assigns_identifier(&receiver.0, name) || call_args_assign_identifier(args, name)
+        }
+        Expr::StructInit { fields, base, .. } => {
+            fields
+                .iter()
+                .any(|(_, value)| expr_assigns_identifier(&value.0, name))
+                || base
+                    .as_ref()
+                    .is_some_and(|base| expr_assigns_identifier(&base.0, name))
+        }
+        Expr::Select { arms, timeout } => {
+            arms.iter().any(|arm| {
+                expr_assigns_identifier(&arm.source.0, name)
+                    || expr_assigns_identifier(&arm.body.0, name)
+            }) || timeout.as_ref().is_some_and(|timeout| {
+                expr_assigns_identifier(&timeout.duration.0, name)
+                    || expr_assigns_identifier(&timeout.body.0, name)
+            })
+        }
+        Expr::InterpolatedString(parts) => parts.iter().any(|part| match part {
+            StringPart::Literal(_) => false,
+            StringPart::Expr(expr) => expr_assigns_identifier(&expr.0, name),
+        }),
+        Expr::Tuple(items) | Expr::Array(items) | Expr::Join(items) => items
+            .iter()
+            .any(|item| expr_assigns_identifier(&item.0, name)),
+        Expr::ArrayRepeat { value, count } => {
+            expr_assigns_identifier(&value.0, name) || expr_assigns_identifier(&count.0, name)
+        }
+        Expr::MapLiteral { entries } => entries.iter().any(|(key, value)| {
+            expr_assigns_identifier(&key.0, name) || expr_assigns_identifier(&value.0, name)
+        }),
+        Expr::Binary { left, right, .. } => {
+            expr_assigns_identifier(&left.0, name) || expr_assigns_identifier(&right.0, name)
+        }
+        Expr::Unary { operand, .. }
+        | Expr::Clone(operand)
+        | Expr::Await(operand)
+        | Expr::AwaitRestart(operand)
+        | Expr::PostfixTry(operand)
+        | Expr::ForkChild { expr: operand, .. } => expr_assigns_identifier(&operand.0, name),
+        Expr::Cast { expr, .. } | Expr::FieldAccess { object: expr, .. } => {
+            expr_assigns_identifier(&expr.0, name)
+        }
+        Expr::Index { object, index } => {
+            expr_assigns_identifier(&object.0, name) || expr_assigns_identifier(&index.0, name)
+        }
+        Expr::Range { start, end, .. } => {
+            start
+                .as_ref()
+                .is_some_and(|start| expr_assigns_identifier(&start.0, name))
+                || end
+                    .as_ref()
+                    .is_some_and(|end| expr_assigns_identifier(&end.0, name))
+        }
+        Expr::Is { lhs, rhs } => {
+            expr_assigns_identifier(&lhs.0, name) || expr_assigns_identifier(&rhs.0, name)
+        }
+        Expr::MachineEmit { fields, .. } => fields
+            .iter()
+            .any(|(_, value)| expr_assigns_identifier(&value.0, name)),
+        Expr::Yield(value) | Expr::Return(value) => value
+            .as_ref()
+            .is_some_and(|value| expr_assigns_identifier(&value.0, name)),
+        Expr::Literal(_)
+        | Expr::Identifier(_)
+        | Expr::This
+        | Expr::RegexLiteral(_)
+        | Expr::ByteStringLiteral(_)
+        | Expr::ByteArrayLiteral(_) => false,
+    }
+}

--- a/hew-types/src/check/lints/sleep_loop_blocks_mailbox.rs
+++ b/hew-types/src/check/lints/sleep_loop_blocks_mailbox.rs
@@ -55,8 +55,8 @@ fn find_in_stmt(
             try_flag(
                 ctx,
                 levels,
-                Candidate::Unconditional,
-                label,
+                &Candidate::Unconditional,
+                label.as_ref(),
                 body,
                 span,
                 out,
@@ -69,7 +69,7 @@ fn find_in_stmt(
             body,
         } => {
             if let Some(candidate) = candidate_from_condition(&condition.0) {
-                try_flag(ctx, levels, candidate, label, body, span, out);
+                try_flag(ctx, levels, &candidate, label.as_ref(), body, span, out);
             }
             find_in_expr(ctx, levels, &condition.0, out);
             find_in_block(ctx, levels, body, out);
@@ -424,16 +424,16 @@ fn candidate_from_condition(condition: &Expr) -> Option<Candidate> {
 fn try_flag(
     ctx: &LintCtx,
     levels: &LintLevels,
-    candidate: Candidate,
-    label: &Option<String>,
+    candidate: &Candidate,
+    label: Option<&String>,
     body: &Block,
     span: &Span,
     out: &mut Vec<TypeError>,
 ) {
-    if !bounded_contains_sleep(body) || loop_body_has_break(body, label.as_deref()) {
+    if !bounded_contains_sleep(body) || loop_body_has_break(body, label.map(String::as_str)) {
         return;
     }
-    if let Candidate::Guard(name) = &candidate {
+    if let Candidate::Guard(name) = candidate {
         if assigns_identifier(body, name) {
             return;
         }
@@ -466,7 +466,11 @@ fn bounded_contains_sleep(block: &Block) -> bool {
 )]
 fn bounded_stmt_has_sleep(stmt: &Stmt) -> bool {
     match stmt {
-        Stmt::Loop { .. } | Stmt::For { .. } | Stmt::While { .. } | Stmt::WhileLet { .. } => false,
+        Stmt::Loop { .. }
+        | Stmt::For { .. }
+        | Stmt::While { .. }
+        | Stmt::WhileLet { .. }
+        | Stmt::Continue { .. } => false,
         Stmt::If {
             condition,
             then_block,
@@ -505,7 +509,6 @@ fn bounded_stmt_has_sleep(stmt: &Stmt) -> bool {
         }
         Stmt::Defer(expr) => bounded_expr_has_sleep(&expr.0),
         Stmt::Expression(expr) => bounded_expr_has_sleep(&expr.0),
-        Stmt::Continue { .. } => false,
     }
 }
 
@@ -542,7 +545,15 @@ fn bounded_expr_has_sleep(expr: &Expr) -> bool {
                 || bounded_expr_has_sleep(&function.0)
                 || bounded_call_args_have_sleep(args)
         }
-        Expr::Lambda { .. } | Expr::SpawnLambdaActor { .. } | Expr::GenBlock { .. } => false,
+        Expr::Lambda { .. }
+        | Expr::SpawnLambdaActor { .. }
+        | Expr::GenBlock { .. }
+        | Expr::Literal(_)
+        | Expr::Identifier(_)
+        | Expr::This
+        | Expr::RegexLiteral(_)
+        | Expr::ByteStringLiteral(_)
+        | Expr::ByteArrayLiteral(_) => false,
         Expr::Block(block) | Expr::Scope { body: block } | Expr::ForkBlock { body: block } => {
             bounded_contains_sleep(block)
         }
@@ -644,12 +655,6 @@ fn bounded_expr_has_sleep(expr: &Expr) -> bool {
         Expr::Yield(value) | Expr::Return(value) => value
             .as_ref()
             .is_some_and(|value| bounded_expr_has_sleep(&value.0)),
-        Expr::Literal(_)
-        | Expr::Identifier(_)
-        | Expr::This
-        | Expr::RegexLiteral(_)
-        | Expr::ByteStringLiteral(_)
-        | Expr::ByteArrayLiteral(_) => false,
     }
 }
 

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -927,6 +927,7 @@ impl Checker {
                 }
                 for rec in &actor.receive_fns {
                     lints::lint_block(&ctx, levels, &rec.body, out);
+                    lints::lint_receive_fn(&ctx, levels, &rec.body, out);
                 }
             }
             Item::Trait(trait_decl) => {

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -3833,6 +3833,174 @@ fn must_use_await_suppressed_by_directive() {
 }
 
 // -----------------------------------------------------------------------
+// sleep_loop_blocks_mailbox lint
+// -----------------------------------------------------------------------
+
+fn count_sleep_loop_blocks_mailbox(diags: &[TypeError]) -> usize {
+    diags
+        .iter()
+        .filter(|d| d.kind == TypeErrorKind::Lint(LintId::SleepLoopBlocksMailbox))
+        .count()
+}
+
+const SLEEP_LOOP_REPRO: &str = "actor Worker {\n\
+     var running: bool = true;\n\
+     receive fn run() { while running { sleep(10ms); } }\n\
+     receive fn stop() { running = false; }\n\
+     }\n";
+
+#[test]
+fn sleep_loop_blocks_mailbox_flags_sibling_stopped_loop() {
+    let (errors, warnings) = parse_and_check(SLEEP_LOOP_REPRO);
+    assert!(errors.is_empty(), "fixture should type-check: {errors:?}");
+    let hit = warnings
+        .iter()
+        .find(|w| w.kind == TypeErrorKind::Lint(LintId::SleepLoopBlocksMailbox))
+        .expect("a sleep loop stopped only by a sibling message must warn");
+    assert_eq!(hit.severity, crate::error::Severity::Warning);
+    assert!(
+        hit.message.contains("mailbox") && hit.message.contains("cannot be dispatched"),
+        "message should explain mailbox starvation: {}",
+        hit.message
+    );
+    assert!(
+        hit.suggestions.iter().any(|s| s.contains("#[every")),
+        "suggestion should name the periodic receive alternative: {:?}",
+        hit.suggestions
+    );
+}
+
+#[test]
+fn sleep_loop_blocks_mailbox_flags_unconditional_loop() {
+    let (errors, warnings) = parse_and_check(
+        "actor Worker { receive fn run() { let t = instant::now(); loop { sleep_until(t); } } }\n",
+    );
+    assert!(errors.is_empty(), "fixture should type-check: {errors:?}");
+    assert_eq!(
+        count_sleep_loop_blocks_mailbox(&warnings),
+        1,
+        "unconditional sleep_until loop should warn: {warnings:?}"
+    );
+}
+
+#[test]
+fn sleep_loop_blocks_mailbox_ignores_bounded_counter_loop() {
+    let (errors, warnings) = parse_and_check(
+        "actor Ticker {\n\
+         receive fn tick(count: i64) {\n\
+             var i: i64 = 0;\n\
+             while i < count {\n\
+                 sleep(5ms);\n\
+                 i = i + 1;\n\
+             }\n\
+         }\n\
+         }\n",
+    );
+    assert!(errors.is_empty(), "fixture should type-check: {errors:?}");
+    assert_eq!(
+        count_sleep_loop_blocks_mailbox(&warnings),
+        0,
+        "derived-progress loop conditions are not candidates: {warnings:?}"
+    );
+}
+
+#[test]
+fn sleep_loop_blocks_mailbox_ignores_non_actor_function() {
+    let (errors, warnings) =
+        parse_and_check("fn main() { var running: bool = true; while running { sleep(10ms); } }\n");
+    assert!(errors.is_empty(), "fixture should type-check: {errors:?}");
+    assert_eq!(
+        count_sleep_loop_blocks_mailbox(&warnings),
+        0,
+        "sleep loops outside receive handlers must be silent: {warnings:?}"
+    );
+}
+
+#[test]
+fn sleep_loop_blocks_mailbox_ignores_loop_with_reachable_break() {
+    let (errors, warnings) = parse_and_check(
+        "actor Worker {\n\
+         var flag: bool = false;\n\
+         receive fn run() { while true { sleep(1s); if flag { break; } } }\n\
+         }\n",
+    );
+    assert!(errors.is_empty(), "fixture should type-check: {errors:?}");
+    assert_eq!(
+        count_sleep_loop_blocks_mailbox(&warnings),
+        0,
+        "a reachable break is an in-handler exit path: {warnings:?}"
+    );
+}
+
+#[test]
+fn sleep_loop_blocks_mailbox_ignores_bare_sleep_without_loop() {
+    let (errors, warnings) =
+        parse_and_check("actor Worker { receive fn run() { sleep(100ms); } }\n");
+    assert!(errors.is_empty(), "fixture should type-check: {errors:?}");
+    assert_eq!(
+        count_sleep_loop_blocks_mailbox(&warnings),
+        0,
+        "a one-shot sleep does not starve the mailbox forever: {warnings:?}"
+    );
+}
+
+#[test]
+fn sleep_loop_blocks_mailbox_ignores_loop_assigning_its_guard() {
+    let (errors, warnings) = parse_and_check(
+        "actor Worker {\n\
+         var running: bool = true;\n\
+         receive fn run() { while running { sleep(10ms); running = false; } }\n\
+         }\n",
+    );
+    assert!(errors.is_empty(), "fixture should type-check: {errors:?}");
+    assert_eq!(
+        count_sleep_loop_blocks_mailbox(&warnings),
+        0,
+        "an assignment to the guard inside the loop is an in-handler exit path: {warnings:?}"
+    );
+}
+
+#[test]
+fn sleep_loop_blocks_mailbox_suppressed_by_directive() {
+    const SOURCE: &str = "actor Worker {\n\
+         var running: bool = true;\n\
+         receive fn run() {\n\
+             // hew:allow(sleep_loop_blocks_mailbox)\n\
+             while running { sleep(10ms); }\n\
+         }\n\
+         receive fn stop() { running = false; }\n\
+         }\n";
+    let out = check_with_lint_level(SOURCE, LintId::SleepLoopBlocksMailbox, LintLevel::Warn);
+    assert!(
+        out.errors.is_empty(),
+        "fixture should type-check: {:?}",
+        out.errors
+    );
+    assert_eq!(
+        count_sleep_loop_blocks_mailbox(&out.warnings),
+        0,
+        "a directive above the loop must suppress the lint: {:?}",
+        out.warnings
+    );
+}
+
+#[test]
+fn sleep_loop_blocks_mailbox_deny_routes_to_errors() {
+    let out = check_with_lint_level(
+        SLEEP_LOOP_REPRO,
+        LintId::SleepLoopBlocksMailbox,
+        LintLevel::Deny,
+    );
+    assert_eq!(
+        count_sleep_loop_blocks_mailbox(&out.errors),
+        1,
+        "deny should route the lint into errors: {:?}",
+        out.errors
+    );
+    assert_eq!(count_sleep_loop_blocks_mailbox(&out.warnings), 0);
+}
+
+// -----------------------------------------------------------------------
 // Module namespacing tests
 // -----------------------------------------------------------------------
 

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -3917,6 +3917,23 @@ fn sleep_loop_blocks_mailbox_ignores_non_actor_function() {
 }
 
 #[test]
+fn sleep_loop_blocks_mailbox_ignores_sleep_loop_inside_lambda() {
+    let (errors, warnings) = parse_and_check(
+        "actor Worker {\n\
+         var running: bool = true;\n\
+         receive fn run() { let f = || { while running { sleep(10ms); } }; let _ = f; }\n\
+         receive fn stop() { running = false; }\n\
+         }\n",
+    );
+    assert!(errors.is_empty(), "fixture should type-check: {errors:?}");
+    assert_eq!(
+        count_sleep_loop_blocks_mailbox(&warnings),
+        0,
+        "sleep loops inside closures do not block the enclosing handler's mailbox: {warnings:?}"
+    );
+}
+
+#[test]
 fn sleep_loop_blocks_mailbox_ignores_loop_with_reachable_break() {
     let (errors, warnings) = parse_and_check(
         "actor Worker {\n\

--- a/tests/hew/actor_every_cancellable_loop_test.hew
+++ b/tests/hew/actor_every_cancellable_loop_test.hew
@@ -1,0 +1,54 @@
+//! Runtime coverage for cancellable actor work expressed as periodic receive
+//! handlers.
+//!
+//! The worker checks a boolean flag on each `#[every]` tick. The `stop` receive
+//! handler is a normal actor message, so it can interleave between ticks because
+//! each tick returns control to the mailbox.
+
+import std::testing;
+
+actor Worker {
+    var running: bool = true;
+    var ticks: i64 = 0;
+
+    #[every(25ms)]
+    receive fn tick() {
+        if !running {
+            return;
+        }
+        ticks += 1;
+    }
+
+    receive fn stop() {
+        running = false;
+    }
+
+    receive fn total() -> i64 {
+        ticks
+    }
+}
+
+#[test]
+fn stop_message_prevents_more_periodic_work() {
+    let worker = spawn Worker(running: true, ticks: 0);
+    sleep(250ms);
+
+    let before = await worker.total();
+    let _ = worker.stop();
+    sleep(150ms);
+    let after = await worker.total();
+    sleep(150ms);
+    let final = await worker.total();
+
+    match before {
+        Ok(n) => testing.assert_true(n >= 2),
+        Err(_) => testing.assert_true(false),
+    }
+    match after {
+        Ok(a) => match final {
+            Ok(f) => testing.assert_eq(a, f),
+            Err(_) => testing.assert_true(false),
+        },
+        Err(_) => testing.assert_true(false),
+    }
+}


### PR DESCRIPTION
## Summary

A long-running actor loop built on `sleep()` cannot be stopped by another message: receive handlers run to completion, so a `while running { sleep(...) }` body never yields to the mailbox and the `stop()` message that would flip the flag is never delivered. That behaviour is by design — but it compiled with zero warnings and no documented alternative, which made it a silent footgun (#2271).

This lands the real wiring, not a doc-note:

- **New lint `sleep_loop_blocks_mailbox`** (warn by default): fires on a `loop` / `while true` / bare-flag `while` whose body suspends with `sleep`/`sleep_until` and has no in-handler exit path, scoped strictly to actor receive handlers — plain functions, actor methods, bounded loops, loops with `break`/`return`, and compound conditions are deliberately outside the detection boundary (precision over recall; the excluded shapes are documented in the lint module). Suppressible per site, promotable with `--deny`.
- **The cancellable pattern proven end-to-end**: a new runtime fixture shows the `#[every(duration)]` periodic handler + boolean flag pattern actually halting on a `stop()` message, asserted by exact equality between two post-stop readings across a full extra tick window — not a happy-path count.
- **Docs**: the language guide's Actors section now documents `#[every(duration)]` (previously entirely undocumented) and the cancellable-loop pattern; the lint-pass design ledger and CHANGELOG are updated.

## Verification

- Nine checker unit tests: the issue's exact repro fires; four named false-positive shapes stay silent; suppression and `--deny` promotion covered.
- CLI e2e coverage through real `hew check` rendering.
- The new fixture and both new doc fences compile and pass in the corpus and doc-example suites; ratchets untouched.
- Full integrated preflight lanes green (corpus, ratchets, fuzz oracle, sandbox parity, doc examples, lint, smoke).

## Out of scope

- Stopping the `#[every]` timer's no-op ticks after the flag flips (efficiency hygiene, tracked separately).
- A "cancel this one timer" API.

Fixes #2271.