### PR TITLE
test(runtime): pin exactly-once frees on suspend normal-completion and select late-reply

### DIFF
--- a/hew-runtime/src/await_cancel.rs
+++ b/hew-runtime/src/await_cancel.rs
@@ -18,6 +18,19 @@ use crate::task_scope::{hew_cancel_token_release, hew_cancel_token_retain, HewCa
 use crate::timer_wheel::{hew_timer_wheel_cancel, hew_timer_wheel_schedule_handle};
 use crate::timer_wheel::{HewTimerEntry, HewTimerWheel};
 
+#[cfg(test)]
+static AWAIT_CANCEL_FINAL_FREE_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(crate) fn reset_await_cancel_final_free_count_for_test() {
+    AWAIT_CANCEL_FINAL_FREE_COUNT.store(0, Ordering::Release);
+}
+
+#[cfg(test)]
+pub(crate) fn await_cancel_final_free_count_for_test() -> usize {
+    AWAIT_CANCEL_FINAL_FREE_COUNT.load(Ordering::Acquire)
+}
+
 /// Terminal state for an internal suspended await registration.
 ///
 /// Values are ABI-visible to codegen/runtime adapters.
@@ -253,6 +266,8 @@ pub unsafe extern "C" fn hew_await_cancel_free(reg: *mut HewAwaitCancel) {
     if prev != 1 {
         return;
     }
+    #[cfg(test)]
+    AWAIT_CANCEL_FINAL_FREE_COUNT.fetch_add(1, Ordering::AcqRel);
     // SAFETY: last ref; no timer ref can still be held or refs would exceed 1.
     let boxed = unsafe { Box::from_raw(reg) };
     // SAFETY: this registration retained the token at creation.

--- a/hew-runtime/src/read_slot.rs
+++ b/hew-runtime/src/read_slot.rs
@@ -32,6 +32,19 @@ use crate::await_cancel::{
 use crate::await_cancel::{AwaitCancelStatus, HewAwaitCancel};
 use crate::bytes::BytesTriple;
 
+#[cfg(test)]
+static READ_SLOT_FINAL_FREE_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(crate) fn reset_read_slot_final_free_count_for_test() {
+    READ_SLOT_FINAL_FREE_COUNT.store(0, Ordering::Release);
+}
+
+#[cfg(test)]
+pub(crate) fn read_slot_final_free_count_for_test() -> usize {
+    READ_SLOT_FINAL_FREE_COUNT.load(Ordering::Acquire)
+}
+
 /// The sentinel an accept slot carries until a handle is deposited, and the
 /// value a failed accept deposits so the resume edge binds an invalid
 /// `Connection` (`hew_connection_is_valid` rejects it) rather than panicking.
@@ -205,6 +218,8 @@ pub unsafe extern "C" fn hew_read_slot_free(slot: *mut HewReadSlot) {
     if prev != 1 {
         return;
     }
+    #[cfg(test)]
+    READ_SLOT_FINAL_FREE_COUNT.fetch_add(1, Ordering::AcqRel);
     // Last ref — reclaim the box. SAFETY: refs reached 0, so no other thread
     // holds a live reference; we own the box exclusively.
     let boxed = unsafe { Box::from_raw(slot) };

--- a/hew-runtime/src/reply_channel.rs
+++ b/hew-runtime/src/reply_channel.rs
@@ -1125,17 +1125,20 @@ mod tests {
     /// N-arm + deadline select):
     /// 1. `hew_await_cancel_new` allocates the shared arbiter (refs = 1, the
     ///    codegen frame ref).
-    /// 2. Per arm: `hew_reply_channel_new` + a retained observer ref +
+    /// 2. Per arm: `hew_reply_channel_new` + a retained sender ref +
     ///    `hew_reply_channel_set_await_cancel(ch, reg)` (retains the arbiter)
     ///    + `hew_reply_channel_set_parked_waiter(ch, self)`.
     /// 3. `hew_await_cancel_schedule_deadline_ms` arms the deadline (retains the
     ///    arbiter for the timer callback).
     /// 4. Abandon: `hew_await_cancel_cancel(Cancelled, no_wake)` wins the
     ///    one-shot transition and cancels the armed timer (releasing the timer
-    ///    ref); then each channel is cancelled + freed (each free releases the
-    ///    arbiter ref the channel took and the observer ref); then
-    ///    `hew_await_cancel_free` drops the codegen frame ref.
-    /// 5. The arbiter and every channel are reclaimed exactly once — the active
+    ///    ref); then each channel is cancelled + the parked waiter ref is freed;
+    ///    then `hew_await_cancel_free` drops the codegen frame ref. The abandoned
+    ///    channels still hold their sender refs, so the arbiter remains retained
+    ///    by the channels until the late replies arrive.
+    /// 5. Each late reply observes cancellation and releases exactly one sender
+    ///    ref. The last channel free releases the last channel-held arbiter ref.
+    /// 6. The arbiter and every channel are reclaimed exactly once — the active
     ///    channel count returns to baseline and a post-abandon wheel tick does
     ///    not fire the cancelled deadline against the freed arbiter.
     ///
@@ -1163,13 +1166,14 @@ mod tests {
                 crate::await_cancel::hew_await_cancel_new(ptr::null_mut(), None, ptr::null_mut());
 
             // (2) three arm channels, each carrying the SAME arbiter + a retained
-            // observer ref (the channel-poll / stream-poll / task-observe
-            // readiness reference the setup ramp takes).
+            // sender ref. This is the actor-ask abandon shape: codegen abandons
+            // the parked waiter ref immediately, while each late handler reply
+            // consumes its own sender ref later.
             let n = 3;
             let mut chans = Vec::with_capacity(n);
             for _ in 0..n {
                 let ch = hew_reply_channel_new();
-                hew_reply_channel_retain(ch); // the readiness-observer ref
+                hew_reply_channel_retain(ch); // the late handler's sender ref
                 hew_reply_channel_set_await_cancel(ch, reg);
                 hew_reply_channel_set_parked_waiter(ch, ptr::null_mut());
                 chans.push(ch);
@@ -1180,8 +1184,9 @@ mod tests {
             assert_eq!(rc, 0, "arming the select deadline must succeed");
 
             // (4) ABANDON: cancel the arbiter (no wake) — wins the one-shot and
-            // cancels the timer — then deregister + free each channel (cancel
-            // before free), then free the codegen arbiter ref.
+            // cancels the timer — then cancel + free each parked waiter channel
+            // ref, then free the codegen arbiter ref. Sender refs intentionally
+            // remain live until the late replies below.
             let won = crate::await_cancel::hew_await_cancel_cancel(
                 reg,
                 AwaitCancelStatus::Cancelled as i32,
@@ -1190,12 +1195,34 @@ mod tests {
             assert_eq!(won, 1, "abandon must win the one-shot terminal transition");
             for &ch in &chans {
                 hew_reply_channel_cancel(ch);
-                hew_reply_channel_free(ch); // releases the channel's arbiter ref
-                hew_reply_channel_free(ch); // releases the readiness-observer ref
+                hew_reply_channel_free(ch); // releases the parked waiter ref
             }
             crate::await_cancel::hew_await_cancel_free(reg);
 
-            // (5) every channel is reclaimed exactly once.
+            assert_eq!(
+                active_channel_count(),
+                pre + n,
+                "abandoned select channels must remain alive only for their late sender refs"
+            );
+
+            // (5) late replies arrive after abandon. Each loses to cancellation,
+            // releases exactly one sender ref, and must not touch the cancelled
+            // timer/arbiter except by releasing the channel-held arbiter ref.
+            for (i, &ch) in chans.iter().enumerate() {
+                let payload = i32::try_from(i).expect("test arm count fits in i32");
+                let delivered = hew_reply(
+                    ch,
+                    (&raw const payload).cast_mut().cast(),
+                    std::mem::size_of::<i32>(),
+                );
+                assert!(
+                    !delivered,
+                    "late reply on an abandoned select arm must observe cancellation"
+                );
+            }
+
+            // (6) every channel is reclaimed exactly once, after late sender refs
+            // are consumed.
             assert_eq!(
                 active_channel_count(),
                 pre,

--- a/hew-runtime/src/reply_channel.rs
+++ b/hew-runtime/src/reply_channel.rs
@@ -1149,11 +1149,11 @@ mod tests {
         let _guard = crate::runtime_test_guard();
         let pre = active_channel_count();
         // NOTE: this test is a ref-COUNT proof, not a literal codegen replay.
-        // The emitted abandon arm releases the observer ref on each arm channel
-        // via the deregister call (which drains the readiness-poll registration
-        // and drops its retained channel ref).  Here the observer ref is freed
-        // with an explicit second `hew_reply_channel_free` so the arithmetic is
-        // directly visible; both paths are ref-correct and net the same count.
+        // Abandon cancels and frees only the parked waiter ref on each arm
+        // channel; the ask-protocol sender ref is the second reference, and
+        // each late `hew_reply` releases it when it observes cancellation.
+        // Both refs are freed here through the same calls codegen emits, so
+        // the arithmetic is directly visible.
         // SAFETY: the test owns the wheel, arbiter, and channels for the whole
         // lifecycle and drives each transition in order; all pointers are valid
         // at each call.

--- a/hew-runtime/src/task_scope.rs
+++ b/hew-runtime/src/task_scope.rs
@@ -837,6 +837,19 @@ pub const TASK_AWAIT_SUSPEND: i32 = 0;
 /// binds the result on the immediate edge.
 pub const TASK_AWAIT_READY: i32 = 1;
 
+#[cfg(test)]
+static TASK_AWAIT_WAITER_FINAL_FREE_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(test)]
+fn reset_task_await_waiter_final_free_count_for_test() {
+    TASK_AWAIT_WAITER_FINAL_FREE_COUNT.store(0, Ordering::Release);
+}
+
+#[cfg(test)]
+fn task_await_waiter_final_free_count_for_test() -> usize {
+    TASK_AWAIT_WAITER_FINAL_FREE_COUNT.load(Ordering::Acquire)
+}
+
 /// One parked task-await waiter: the awaiting actor + its readiness slot. The
 /// task's completion observer owns one retained in-flight ref on `slot` and
 /// fires `wake` exactly once on `Done`.
@@ -865,6 +878,8 @@ unsafe extern "C" fn task_await_wake(ctx: *mut c_void) {
     // `Box::into_raw`; the observer fires exactly once, so reclaiming it here is
     // the single free.
     let waiter = unsafe { Box::from_raw(ctx.cast::<TaskAwaitWaiter>()) };
+    #[cfg(test)]
+    TASK_AWAIT_WAITER_FINAL_FREE_COUNT.fetch_add(1, Ordering::AcqRel);
     // SAFETY: the observer holds an in-flight ref on the slot; depositing a
     // terminal status is the documented reactor-deposit contract. A no-op + no
     // wake if the abandon edge cancelled the slot first (the channel-core race
@@ -2875,6 +2890,134 @@ mod tests {
             assert_eq!((*task).error, HewTaskError::Cancelled);
 
             hew_task_scope_destroy(scope);
+        }
+    }
+
+    #[test]
+    fn suspending_unit_task_await_cancel_frees_waiter_and_slot_once() {
+        crate::read_slot::reset_read_slot_final_free_count_for_test();
+        reset_task_await_waiter_final_free_count_for_test();
+
+        // SAFETY: the test owns scope/task/slot pointers and drives the exact
+        // await-detach-then-cancel ordering before destroying the scope.
+        unsafe {
+            let scope = hew_task_scope_new();
+            let task = hew_task_new();
+            hew_task_scope_spawn(scope, task);
+            let slot = crate::read_slot::hew_read_slot_new();
+
+            assert_eq!(
+                hew_task_await_suspend(scope, task, ptr::null_mut(), slot),
+                TASK_AWAIT_SUSPEND
+            );
+            assert_eq!(crate::read_slot::read_slot_refs_for_test(slot), 2);
+
+            hew_task_detach_await(scope, task, slot);
+            assert_eq!(
+                crate::read_slot::read_slot_final_free_count_for_test(),
+                0,
+                "detach must release only the creator ref while the observer still owns its ref"
+            );
+            assert_eq!(task_await_waiter_final_free_count_for_test(), 0);
+
+            assert_eq!(hew_task_scope_cancel_one(scope, task), 0);
+            assert_eq!((*task).error, HewTaskError::Cancelled);
+            assert_eq!(task_await_waiter_final_free_count_for_test(), 1);
+            assert_eq!(
+                crate::read_slot::read_slot_final_free_count_for_test(),
+                1,
+                "cancelled task completion must release the observer ref and free the read slot exactly once"
+            );
+
+            hew_task_scope_destroy(scope);
+        }
+    }
+
+    #[test]
+    fn suspending_unit_task_await_normal_completion_frees_waiter_and_slot_once() {
+        crate::read_slot::reset_read_slot_final_free_count_for_test();
+        reset_task_await_waiter_final_free_count_for_test();
+
+        // SAFETY: the test owns scope/task/slot pointers and simulates the codegen
+        // bind edge by releasing the creator ref after task completion wakes.
+        unsafe {
+            let scope = hew_task_scope_new();
+            let task = hew_task_new();
+            hew_task_scope_spawn(scope, task);
+            let slot = crate::read_slot::hew_read_slot_new();
+
+            assert_eq!(
+                hew_task_await_suspend(scope, task, ptr::null_mut(), slot),
+                TASK_AWAIT_SUSPEND
+            );
+            hew_task_scope_complete_task(scope, task);
+
+            assert_eq!(task_await_waiter_final_free_count_for_test(), 1);
+            assert_eq!(
+                crate::read_slot::read_slot_final_free_count_for_test(),
+                0,
+                "observer completion must leave the creator ref for the bind edge"
+            );
+
+            crate::read_slot::hew_read_slot_free(slot);
+            assert_eq!(
+                crate::read_slot::read_slot_final_free_count_for_test(),
+                1,
+                "bind edge must free the read slot exactly once"
+            );
+
+            hew_task_scope_destroy(scope);
+        }
+    }
+
+    #[test]
+    fn suspending_sleep_cancel_and_completion_free_deadline_registration_once() {
+        use crate::await_cancel::{
+            await_cancel_final_free_count_for_test, hew_await_cancel_cancel,
+            hew_await_cancel_complete, hew_await_cancel_free, hew_await_cancel_new,
+            hew_await_cancel_schedule_deadline_ms, reset_await_cancel_final_free_count_for_test,
+            AwaitCancelStatus,
+        };
+        use crate::timer_wheel::{hew_timer_wheel_free, hew_timer_wheel_new, hew_timer_wheel_tick};
+        use std::time::Duration;
+
+        reset_await_cancel_final_free_count_for_test();
+        // SAFETY: the registration and wheel are owned by this test; cancellation
+        // wins before the wheel fires, mirroring suspending sleep abandon.
+        unsafe {
+            let tw = hew_timer_wheel_new();
+            let reg = hew_await_cancel_new(ptr::null_mut(), None, ptr::null_mut());
+            assert_eq!(hew_await_cancel_schedule_deadline_ms(reg, tw, 1_000), 0);
+            assert_eq!(
+                hew_await_cancel_cancel(reg, AwaitCancelStatus::Cancelled as i32, 0),
+                1
+            );
+            hew_await_cancel_free(reg);
+            assert_eq!(
+                await_cancel_final_free_count_for_test(),
+                1,
+                "sleep cancel must free the deadline registration exactly once"
+            );
+            hew_timer_wheel_free(tw);
+        }
+
+        reset_await_cancel_final_free_count_for_test();
+        // SAFETY: the test manually ticks the wheel so the timer callback wins,
+        // then releases the creator ref as the sleep bind edge does.
+        unsafe {
+            let tw = hew_timer_wheel_new();
+            let reg = hew_await_cancel_new(ptr::null_mut(), None, ptr::null_mut());
+            assert_eq!(hew_await_cancel_schedule_deadline_ms(reg, tw, 1), 0);
+            std::thread::sleep(Duration::from_millis(2));
+            assert_eq!(hew_timer_wheel_tick(tw), 1);
+            assert_eq!(hew_await_cancel_complete(reg), 0);
+            hew_await_cancel_free(reg);
+            assert_eq!(
+                await_cancel_final_free_count_for_test(),
+                1,
+                "sleep completion must free the deadline registration exactly once"
+            );
+            hew_timer_wheel_free(tw);
         }
     }
 


### PR DESCRIPTION
## Summary

The suspend substrate's exactly-once-free guarantees were only pinned on the abandon/cancel paths — the normal-completion directions had no coverage, and the select-abandon test modelled a ref ladder the emitted code doesn't actually produce.

- **Final-free counters** (`#[cfg(test)]`, compiled out of non-test builds) on the await-cancel registration, the read slot, and the task-await waiter, each incremented exactly at the irrevocable last-ref reclaim.
- **Three new task-scope tests** covering the normal-completion directions: a unit-task await completing without detach frees the waiter exactly once while the creator's slot ref survives for the bind edge; a sleep whose timer actually fires frees its deadline registration exactly once after completion; cancel-one converges on the same single-free ladder.
- **The select-abandon test now asserts the sender-ref model** the runtime and codegen actually implement: ActorAsk arms retain no observer ref — the second reference on each channel is the ask-protocol sender ref retained before mailbox enqueue — so abandoned select channels remain alive for their in-flight handler replies, and each late reply observes cancellation and releases exactly one sender ref before the final channel free releases the last arbiter ref. The old model freed each channel twice at abandon, a path the emitted code never takes for ask arms.

All assertions are exact-equality (an extra free reads 2, a leak reads 0 — either fails). The counter tests assert process-wide statics and rely on the per-process test execution model.

## Verification

- `hew-runtime` lib suite green (2007 tests, three consecutive runs); the four new/changed tests 12/12 across three runs under the per-process runner.
- Workspace `clippy -D warnings` and `fmt` clean; full integrated preflight lanes green (corpus, ratchets, fuzz oracle, sandbox parity, doc examples).
- Test-only change: zero production lines touched.

## Out of scope

- No changes to the suspend substrate itself — this pins existing behaviour.