### PR TITLE
fix(types,hir,mir): honest payload-destructure diagnostics and platform-sized literal matches

### DIFF
--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -2495,6 +2495,35 @@ fn i32_match_integer_literal_arm_runs_correct_branch() {
     );
 }
 
+#[test]
+fn platform_sized_match_integer_literal_arms_run_correct_branches() {
+    require_codegen();
+
+    let source = repo_root().join("tests/vertical-slice/accept/platform_sized_match_literal.hew");
+    let expected = std::fs::read_to_string(
+        repo_root().join("tests/vertical-slice/accept/platform_sized_match_literal.expected"),
+    )
+    .expect("read platform_sized_match_literal.expected");
+
+    let output = run_bounded_hew_run(&source, repo_root());
+
+    assert_eq!(
+        output.status.code(),
+        Some(43),
+        "expected exit 43 from isize + usize literal match arms; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "expected no diagnostics; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let actual = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    assert_eq!(actual, expected, "stdout mismatch for {}", source.display());
+}
+
 /// Regression oracle — mixed-width range bounds (i32..i64) produce a loop
 /// variable typed at the wider bound (i64), not the narrower start bound.
 ///

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -255,17 +255,13 @@ enum ForIterNextCall {
 
 fn literal_match_supported(lit: &HirLiteral, ty: &ResolvedTy) -> bool {
     match (lit, ty) {
-        (HirLiteral::Integer(_), ty) => literal_match_integer_ty(ty),
+        (HirLiteral::Integer(_), ty) => ty.is_integer_literal_match_scrutinee(),
         (HirLiteral::Float(_), ResolvedTy::F32 | ResolvedTy::F64)
         | (HirLiteral::Bool(_), ResolvedTy::Bool)
         | (HirLiteral::Char(_), ResolvedTy::Char)
         | (HirLiteral::String(_), ResolvedTy::String) => true,
         _ => false,
     }
-}
-
-fn literal_match_integer_ty(ty: &ResolvedTy) -> bool {
-    ty.is_integer()
 }
 
 impl TargetArch {
@@ -22816,7 +22812,7 @@ impl LowerCtx {
                     let (lit, literal_ty) = literal_to_hir(lit);
                     let ty = match (&lit, &scrutinee_hir.ty) {
                         (HirLiteral::Integer(_), scrutinee_ty)
-                            if literal_match_integer_ty(scrutinee_ty) =>
+                            if scrutinee_ty.is_integer_literal_match_scrutinee() =>
                         {
                             scrutinee_ty.clone()
                         }
@@ -28680,6 +28676,11 @@ mod tests {
             "platform-sized literal match diagnostics: {:#?}",
             lowered.diagnostics
         );
+        let verify_diagnostics = crate::verify_hir(&lowered.module);
+        assert!(
+            verify_diagnostics.is_empty(),
+            "platform-sized literal match verifier diagnostics: {verify_diagnostics:#?}"
+        );
         assert_match_literal_ty(&lowered, "signed", &ResolvedTy::Isize);
         assert_match_literal_ty(&lowered, "unsigned", &ResolvedTy::Usize);
     }
@@ -28690,7 +28691,10 @@ mod tests {
             panic!("expected `{function_name}` to have a match tail");
         };
         let HirExprKind::Match { arms, .. } = &tail.kind else {
-            panic!("expected `{function_name}` tail to be a match, got {:#?}", tail.kind);
+            panic!(
+                "expected `{function_name}` tail to be a match, got {:#?}",
+                tail.kind
+            );
         };
         let Some(first_arm) = arms.first() else {
             panic!("expected `{function_name}` match to have a literal arm");

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -265,7 +265,7 @@ fn literal_match_supported(lit: &HirLiteral, ty: &ResolvedTy) -> bool {
 }
 
 fn literal_match_integer_ty(ty: &ResolvedTy) -> bool {
-    ty.is_integer() && !matches!(ty, ResolvedTy::Isize | ResolvedTy::Usize)
+    ty.is_integer()
 }
 
 impl TargetArch {
@@ -28653,6 +28653,54 @@ mod tests {
             args: vec![],
             builtin: None,
             is_opaque: false,
+        }
+    }
+
+    #[test]
+    fn match_integer_literals_use_platform_sized_scrutinee_type() {
+        let (_, _, lowered) = parse_typecheck_and_lower(
+            r"
+            fn signed(x: isize) -> i64 {
+                match x {
+                    5 => 1,
+                    _ => 0,
+                }
+            }
+
+            fn unsigned(x: usize) -> i64 {
+                match x {
+                    5 => 1,
+                    _ => 0,
+                }
+            }
+            ",
+        );
+        assert!(
+            lowered.diagnostics.is_empty(),
+            "platform-sized literal match diagnostics: {:#?}",
+            lowered.diagnostics
+        );
+        assert_match_literal_ty(&lowered, "signed", &ResolvedTy::Isize);
+        assert_match_literal_ty(&lowered, "unsigned", &ResolvedTy::Usize);
+    }
+
+    fn assert_match_literal_ty(output: &LowerOutput, function_name: &str, expected: &ResolvedTy) {
+        let function = function_named(output, function_name);
+        let Some(tail) = &function.body.tail else {
+            panic!("expected `{function_name}` to have a match tail");
+        };
+        let HirExprKind::Match { arms, .. } = &tail.kind else {
+            panic!("expected `{function_name}` tail to be a match, got {:#?}", tail.kind);
+        };
+        let Some(first_arm) = arms.first() else {
+            panic!("expected `{function_name}` match to have a literal arm");
+        };
+        match &first_arm.predicate {
+            HirMatchArmPredicate::Literal {
+                lit: HirLiteral::Integer(5),
+                ty,
+            } => assert_eq!(ty, expected),
+            other => panic!("expected integer literal predicate, got {other:#?}"),
         }
     }
 

--- a/hew-hir/src/verify.rs
+++ b/hew-hir/src/verify.rs
@@ -792,9 +792,7 @@ impl Verifier {
 
     fn match_literal_predicate(&mut self, lit: &HirLiteral, ty: &ResolvedTy, span: Range<usize>) {
         let valid = match (lit, ty) {
-            (HirLiteral::Integer(_), ty) => {
-                ty.is_integer() && !matches!(ty, ResolvedTy::Isize | ResolvedTy::Usize)
-            }
+            (HirLiteral::Integer(_), ty) => ty.is_integer_literal_match_scrutinee(),
             (HirLiteral::Float(_), ResolvedTy::F32 | ResolvedTy::F64)
             | (HirLiteral::Bool(_), ResolvedTy::Bool)
             | (HirLiteral::Char(_), ResolvedTy::Char)

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -296,7 +296,7 @@ fn context_reader_offset(reader: ExecutionContextReader) -> usize {
 }
 
 fn literal_match_scrutinee_ty(ty: &ResolvedTy) -> bool {
-    (ty.is_integer() && !matches!(ty, ResolvedTy::Isize | ResolvedTy::Usize))
+    ty.is_integer_literal_match_scrutinee()
         || matches!(ty, ResolvedTy::Bool | ResolvedTy::Char | ResolvedTy::String)
 }
 
@@ -18698,9 +18698,7 @@ impl Builder {
         site: SiteId,
     ) -> Option<Place> {
         match (lit, ty) {
-            (HirLiteral::Integer(value), ty)
-                if ty.is_integer() && !matches!(ty, ResolvedTy::Isize | ResolvedTy::Usize) =>
-            {
+            (HirLiteral::Integer(value), ty) if ty.is_integer_literal_match_scrutinee() => {
                 let dest = self.alloc_local(ty.clone());
                 self.push_instr(Instr::ConstI64 {
                     dest,

--- a/hew-mir/tests/match_literal_string.rs
+++ b/hew-mir/tests/match_literal_string.rs
@@ -98,3 +98,37 @@ fn classify(s: string) -> i64 {
         "string literal match should compare once per literal arm"
     );
 }
+
+#[test]
+fn platform_sized_integer_literal_matches_lower_to_constants() {
+    let pipeline = pipeline_with_tc(
+        r"
+fn signed(x: isize) -> i64 {
+    match x {
+        5 => 1,
+        _ => 0,
+    }
+}
+
+fn unsigned(x: usize) -> i64 {
+    match x {
+        5 => 1,
+        _ => 0,
+    }
+}",
+    );
+
+    for name in ["signed", "unsigned"] {
+        let func = find_fn(&pipeline, name);
+        let literal_constants = func
+            .blocks
+            .iter()
+            .flat_map(|block| block.instructions.iter())
+            .filter(|instr| matches!(instr, Instr::ConstI64 { value: 5, .. }))
+            .count();
+        assert_eq!(
+            literal_constants, 1,
+            "{name} should lower the platform-sized literal predicate exactly once"
+        );
+    }
+}

--- a/hew-types/src/check/diagnostics.rs
+++ b/hew-types/src/check/diagnostics.rs
@@ -361,6 +361,9 @@ impl Checker {
         if matches!(scrutinee_ty, Ty::Error) {
             return;
         }
+        if self.has_unsupported_payload_subpattern_error_for_arms(arms) {
+            return;
+        }
         let scrutinee_ty = self.subst.resolve(scrutinee_ty);
         let scrutinee_ty = &scrutinee_ty;
 
@@ -559,6 +562,19 @@ impl Checker {
                 }
             }
         }
+    }
+
+    fn has_unsupported_payload_subpattern_error_for_arms(&self, arms: &[MatchArm]) -> bool {
+        self.errors.iter().any(|error| {
+            error.source_module == self.current_module
+                && matches!(
+                    error.kind,
+                    crate::error::TypeErrorKind::UnsupportedPayloadSubpattern { .. }
+                )
+                && arms.iter().any(|arm| {
+                    error.span.start >= arm.pattern.1.start && error.span.end <= arm.pattern.1.end
+                })
+        })
     }
 
     /// Emit a hard error for genuinely non-exhaustive enum-like matches (Option, Result,

--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -103,14 +103,13 @@ fn unsupported_payload_subpattern_label(pattern: &Pattern) -> Option<&'static st
         // Returning `None` here is the safe default for any call site that has not
         // yet added the resolution guard (false-accept rather than false-reject).
         Pattern::Identifier(name) if name.contains("::") => Some("nested constructor"),
-        // Plain binding (bare identifier), wildcard, literal predicates, and aggregate
-        // destructures are supported or deferred to the call site.
+        // Plain binding (bare identifier), wildcard, literal predicates, and tuple
+        // payload aggregates are supported or deferred to the call site.
         Pattern::Wildcard
         | Pattern::Literal(_)
-        | Pattern::Struct { .. }
-        | Pattern::RecordShorthand { .. }
         | Pattern::Tuple(_)
         | Pattern::Identifier(_) => None,
+        Pattern::Struct { .. } | Pattern::RecordShorthand { .. } => Some("record destructure"),
         Pattern::Constructor { .. } => Some("nested constructor"),
         Pattern::Or(_, _) => Some("or-pattern"),
         // Regex literals are only legal as top-level match-arm predicates
@@ -1793,7 +1792,7 @@ impl Checker {
                     let label = match other {
                         Pattern::Literal(_) => "literal predicate inside a nested constructor",
                         Pattern::Struct { .. } | Pattern::RecordShorthand { .. } => {
-                            "struct destructure"
+                            "record destructure"
                         }
                         Pattern::Tuple(_) => "tuple destructure",
                         Pattern::Or(_, _) => "or-pattern",

--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -105,10 +105,9 @@ fn unsupported_payload_subpattern_label(pattern: &Pattern) -> Option<&'static st
         Pattern::Identifier(name) if name.contains("::") => Some("nested constructor"),
         // Plain binding (bare identifier), wildcard, literal predicates, and tuple
         // payload aggregates are supported or deferred to the call site.
-        Pattern::Wildcard
-        | Pattern::Literal(_)
-        | Pattern::Tuple(_)
-        | Pattern::Identifier(_) => None,
+        Pattern::Wildcard | Pattern::Literal(_) | Pattern::Tuple(_) | Pattern::Identifier(_) => {
+            None
+        }
         Pattern::Struct { .. } | Pattern::RecordShorthand { .. } => Some("record destructure"),
         Pattern::Constructor { .. } => Some("nested constructor"),
         Pattern::Or(_, _) => Some("or-pattern"),

--- a/hew-types/src/check/tests/exhaustiveness.rs
+++ b/hew-types/src/check/tests/exhaustiveness.rs
@@ -129,7 +129,7 @@ fn typecheck_integer_literal_missing_catchall_is_error_for_all_widths() {
 
 #[test]
 fn typecheck_integer_literal_with_catchall_is_exhaustive() {
-    for ty in ["i32", "u8"] {
+    for ty in ["i32", "u8", "isize", "usize"] {
         let (errors, warnings) = parse_and_check(&format!(
             "fn main() {{\n\
                  let x: {ty} = 1;\n\
@@ -152,6 +152,39 @@ fn typecheck_integer_literal_with_catchall_is_exhaustive() {
             "catch-all {ty} match must not warn as non-exhaustive: {warnings:?}"
         );
     }
+}
+
+#[test]
+fn unsupported_payload_subpattern_suppresses_non_exhaustive_follow_on() {
+    let (errors, warnings) = parse_and_check(
+        r"
+enum Color { Red; Blue }
+enum Packet { Data { value: Color }; Empty }
+fn f(p: Packet) -> i64 {
+    match p {
+        Packet::Data { value: Red } => 1,
+    }
+}",
+    );
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::UnsupportedPayloadSubpattern { .. })),
+        "expected unsupported payload subpattern root error, got: {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .all(|e| !matches!(e.kind, TypeErrorKind::NonExhaustiveMatch)),
+        "unsupported payload subpattern must suppress non-exhaustive cascade: {errors:?}"
+    );
+    assert!(
+        warnings
+            .iter()
+            .all(|w| !matches!(w.kind, TypeErrorKind::NonExhaustiveMatch)),
+        "unsupported payload subpattern must suppress non-exhaustive warnings: {warnings:?}"
+    );
 }
 
 #[test]

--- a/hew-types/src/resolved_ty.rs
+++ b/hew-types/src/resolved_ty.rs
@@ -288,6 +288,18 @@ impl ResolvedTy {
         )
     }
 
+    /// Returns `true` when an integer literal pattern can be compared directly
+    /// against a match scrutinee of this type.
+    ///
+    /// This is the checker/HIR/MIR semantic boundary for integer literal-match
+    /// admission. Keep all downstream literal-match gates routed through this
+    /// predicate so platform-sized integers cannot drift from fixed-width
+    /// integers again.
+    #[must_use]
+    pub fn is_integer_literal_match_scrutinee(&self) -> bool {
+        self.is_integer()
+    }
+
     /// Returns `true` for the concrete floating-point types admitted by the
     /// checker numeric matrix.
     #[must_use]
@@ -836,6 +848,41 @@ pub fn mangle_impl_self_name(name: &str, type_args: &[ResolvedTy]) -> Option<Str
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn integer_literal_match_scrutinee_admits_all_integer_widths_only() {
+        for ty in [
+            ResolvedTy::I8,
+            ResolvedTy::I16,
+            ResolvedTy::I32,
+            ResolvedTy::I64,
+            ResolvedTy::U8,
+            ResolvedTy::U16,
+            ResolvedTy::U32,
+            ResolvedTy::U64,
+            ResolvedTy::Isize,
+            ResolvedTy::Usize,
+        ] {
+            assert!(
+                ty.is_integer_literal_match_scrutinee(),
+                "{ty:?} must admit integer literal match predicates"
+            );
+        }
+
+        for ty in [
+            ResolvedTy::F32,
+            ResolvedTy::F64,
+            ResolvedTy::Bool,
+            ResolvedTy::Char,
+            ResolvedTy::String,
+            ResolvedTy::Unit,
+        ] {
+            assert!(
+                !ty.is_integer_literal_match_scrutinee(),
+                "{ty:?} must not admit integer literal match predicates"
+            );
+        }
+    }
 
     #[test]
     fn from_ty_rejects_ty_var() {

--- a/tests/vertical-slice/accept/platform_sized_match_literal.expected
+++ b/tests/vertical-slice/accept/platform_sized_match_literal.expected
@@ -1,0 +1,1 @@
+platform-sized literal match total=43

--- a/tests/vertical-slice/accept/platform_sized_match_literal.hew
+++ b/tests/vertical-slice/accept/platform_sized_match_literal.hew
@@ -1,0 +1,22 @@
+// Regression: integer literal match predicates must admit platform-sized
+// scrutinees through HIR verification, MIR strategy selection, MIR constant
+// lowering, and native execution.
+fn pick_signed(x: isize) -> i64 {
+    match x {
+        5 => 40,
+        _ => 0,
+    }
+}
+
+fn pick_unsigned(x: usize) -> i64 {
+    match x {
+        7 => 3,
+        _ => 0,
+    }
+}
+
+fn main() -> i64 {
+    let total = pick_signed(5) + pick_unsigned(7);
+    println(f"platform-sized literal match total={total}");
+    total
+}


### PR DESCRIPTION
## Summary

Two independent pattern-surface fixes:

**Payload record-destructure diagnostics.** A record destructure nested in an enum-variant payload (`Wrapper::W(Pair { a, b })`) produced a misleading `non-exhaustive match: missing W` suggesting `W(_)` as the fix, instead of naming the actual restriction. Both `Pattern::Struct` and record-shorthand payloads now route through the unsupported-payload-subpattern diagnostic with the label `record destructure`, and the follow-on exhaustiveness cascade is suppressed for arms already rejected that way — span-scoped, so a genuinely non-exhaustive match with no unsupported subpattern still gets its exhaustiveness error (pinned by test). Tuple payload destructures are untouched: they are a supported shape and keep lowering.

**Platform-sized literal matches.** `match (x: isize) { 5 => ..., _ => ... }` was rejected with `E_NOT_YET_IMPLEMENTED` for `isize`/`usize` scrutinees. The admissibility rule turned out to live in four independent copies (HIR lowering, HIR verify, MIR strategy selection, MIR constant lowering) — fixing one leaves the feature broken end-to-end, which review caught when a lowering-only unit test masked exactly that. The rule now lives once, as `ResolvedTy::is_integer_literal_match_scrutinee` in hew-types, consumed by all four sites, with no residual copy anywhere in the workspace. Proven end-to-end: `hew check` and `hew run` on `isize` and `usize` literal matches, with a vertical-slice fixture asserting the matched-arm outputs and the fallback path.

**Invariant:** one admission rule, one home — a literal-match scrutinee admissible at HIR lowering is admissible at every downstream gate.

## Verification

- Vertical-slice accept fixture (`isize` + `usize` literal matches, run-asserted exit and output) plus a CLI e2e test proving arm discrimination.
- Unit tests across hew-types/hew-hir/hew-mir, including the negative direction (missing catch-all still errors for every integer width) and the suppression boundary.
- Full integrated preflight green (16/16 lanes); workspace `clippy -D warnings` clean.

## Out of scope

- Record rest-patterns, or-patterns in payloads, and the owned-aggregate wildcard family — the staged pattern-cluster work this opens (#2339).