### PR TITLE
build(deps): upgrade quick-xml past RUSTSEC-2026-0194 and RUSTSEC-2026-0195

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3534,9 +3534,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -11583,7 +11583,7 @@ SOFTWARE.
 
 ================================================================================
 MIT License
-  * quick-xml 0.40.1 — https://github.com/tafia/quick-xml
+  * quick-xml 0.41.0 — https://github.com/tafia/quick-xml
 
 The MIT License (MIT)
 

--- a/hew-std/Cargo.toml
+++ b/hew-std/Cargo.toml
@@ -50,7 +50,7 @@ lettre = { version = "0.11.22", default-features = false, features = [
 ] }
 parking_lot = "0.12"
 pulldown-cmark = "0.13.4"
-quick-xml = "0.40.1"
+quick-xml = "0.41.0"
 quinn = "0.11"
 rcgen = "0.14.8"
 regex = "1.12.4"


### PR DESCRIPTION
## Summary

Two advisories published today fail the security-advisory gate on every branch, including main: RUSTSEC-2026-0194 (quadratic duplicate-attribute checking in `BytesStart::attributes()`) and RUSTSEC-2026-0195 (unbounded namespace-declaration allocation in `NsReader`), both against `quick-xml 0.40.1` — both DoS-class.

The sole consumer is `hew-std`'s XML module, which uses the plain `Reader` with the default duplicate-attribute check enabled — exactly RUSTSEC-2026-0194's affected path (`NsReader` is unused, so -0195 doesn't reach our code today, but the one bump remediates both). There is no patched 0.40.x, so the manifest moves to `0.41.0` with the lockfile updated and `THIRD-PARTY-LICENSES` regenerated for the embedded version string.

## Verification

- `cargo deny check advisories` / `licenses` / `bans sources` all green (same pinned cargo-deny as CI).
- `THIRD-PARTY-LICENSES` freshness check green after regeneration.
- Targeted XML consumer tests 15/15; `hew-std` lane suite 636/636; full workspace build clean — no API break from the bump.

## Out of scope

- A pre-existing full-crate in-process test abort in TLS scheduler cleanup, found and 3-step-verified on unmodified main while gating this change — tracked in #2348.