### PR TITLE
fix(types): recurse element-wise into tuple payload patterns

### DIFF
--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -311,6 +311,12 @@ impl Checker {
     ///
     /// Constructor identifiers (qualified with `::`, or resolving to a known
     /// variant) are refutable and return `false`.
+    ///
+    /// A tuple sub-pattern is irrefutable when it is the empty tuple `()`, or
+    /// when its resolved payload type is itself `Ty::Tuple` of equal arity and
+    /// every element sub-pattern is (recursively) irrefutable against its
+    /// corresponding element type. Any arity mismatch or non-tuple resolved
+    /// payload type stays refutable (fail-closed) rather than being credited.
     fn is_payload_irrefutable_for_ty(&self, pattern: &Pattern, payload_ty: &Ty) -> bool {
         match pattern {
             Pattern::Wildcard => true,
@@ -324,7 +330,20 @@ impl Checker {
                 let short = name.rsplit("::").next().unwrap_or(name);
                 self.resolve_variant_match(short, &resolved, name).is_none()
             }
-            Pattern::Tuple(pats) => pats.is_empty(),
+            Pattern::Tuple(pats) => {
+                if pats.is_empty() {
+                    return true;
+                }
+                let resolved = self.project_assoc_types(&self.subst.resolve(payload_ty));
+                let Ty::Tuple(elem_tys) = &resolved else {
+                    return false;
+                };
+                pats.len() == elem_tys.len()
+                    && pats
+                        .iter()
+                        .zip(elem_tys.iter())
+                        .all(|((sub, _), elem_ty)| self.is_payload_irrefutable_for_ty(sub, elem_ty))
+            }
             _ => false,
         }
     }

--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -144,35 +144,15 @@ fn unsupported_project_subpattern_label(pattern: &Pattern) -> Option<&'static st
     }
 }
 
-/// True for payload subpatterns that match every value of their slot type:
-/// wildcards, plain bindings (any casing), and the unit tuple `()`.
-///
-/// Bare unqualified identifiers — whether lowercase or uppercase — are
-/// treated as irrefutable bindings here.  Qualified names (containing `::`
-/// such as `Shape::Line`) are always constructor paths and therefore
-/// refutable.  This is used for struct-variant field position exhaustiveness
-/// where concrete field types are not threaded through
-/// `VariantPayloadShape::Struct`; for tuple-payload positions use the
-/// resolution-aware `is_payload_irrefutable_for_ty` method instead.
-fn payload_subpattern_is_irrefutable(pattern: &Pattern) -> bool {
-    match pattern {
-        Pattern::Wildcard => true,
-        // Qualified name — always a constructor path, never a binder.
-        // Bare name (any casing) — treated as a binding (irrefutable).
-        Pattern::Identifier(name) => !name.contains("::"),
-        Pattern::Tuple(pats) => pats.is_empty(),
-        _ => false,
-    }
-}
-
 /// Payload shape of one enum variant for exhaustiveness coverage.
 pub(super) enum VariantPayloadShape {
     Unit,
     Tuple(Vec<Ty>),
-    /// Struct-variant fields; coverage only needs the names, not the types,
-    /// because nested constructor subpatterns are not admitted in
-    /// struct-variant field position.
-    Struct,
+    /// Struct-variant fields with their (substituted) resolved types, so
+    /// field-position sub-patterns can be checked for irrefutability against
+    /// their real payload type via `Checker::is_payload_irrefutable_for_ty`
+    /// instead of the type-blind free function this shape used to require.
+    Struct(Vec<(String, Ty)>),
 }
 
 impl Checker {
@@ -227,7 +207,17 @@ impl Checker {
                                 .map(|f| substitute_pattern_field_ty(f, &type_params, &type_args))
                                 .collect(),
                         ),
-                        VariantDef::Struct(_) => VariantPayloadShape::Struct,
+                        VariantDef::Struct(fields) => VariantPayloadShape::Struct(
+                            fields
+                                .iter()
+                                .map(|(name, f)| {
+                                    (
+                                        name.clone(),
+                                        substitute_pattern_field_ty(f, &type_params, &type_args),
+                                    )
+                                })
+                                .collect(),
+                        ),
                     };
                     (name.clone(), shape)
                 })
@@ -300,9 +290,10 @@ impl Checker {
             .all(|(name, shape)| self.variant_covered(patterns, name, shape))
     }
 
-    /// Resolution-based irrefutability test for a single payload subpattern
-    /// slot.  Replaces the static `payload_subpattern_is_irrefutable` for
-    /// contexts where the concrete payload type is known.
+    /// Resolution-based irrefutability test for a payload subpattern slot,
+    /// used for every context where the concrete payload type is known:
+    /// tuple-variant payload slots and (via their substituted field types)
+    /// struct-variant fields.
     ///
     /// A subpattern is irrefutable (catches every value of `payload_ty`) when:
     /// - It is a wildcard `_` or the empty-tuple unit `()`.
@@ -356,6 +347,13 @@ impl Checker {
         variant_name: &str,
         shape: &VariantPayloadShape,
     ) -> bool {
+        let struct_field_tys: HashMap<&str, &Ty> = match shape {
+            VariantPayloadShape::Struct(fields) => fields
+                .iter()
+                .map(|(name, ty)| (name.as_str(), ty))
+                .collect(),
+            _ => HashMap::new(),
+        };
         let mut ctor_rows: Vec<&[(Pattern, Span)]> = Vec::new();
         let mut has_unit_row = false;
         let mut has_struct_cover = false;
@@ -377,9 +375,13 @@ impl Checker {
                     let short = name.rsplit("::").next().unwrap_or(name);
                     if short == variant_name
                         && fields.iter().all(|pf| {
-                            pf.pattern
-                                .as_ref()
-                                .is_none_or(|(sub, _)| payload_subpattern_is_irrefutable(sub))
+                            pf.pattern.as_ref().is_none_or(|(sub, _)| {
+                                struct_field_tys
+                                    .get(pf.name.as_str())
+                                    .is_some_and(|field_ty| {
+                                        self.is_payload_irrefutable_for_ty(sub, field_ty)
+                                    })
+                            })
                         })
                     {
                         has_struct_cover = true;
@@ -390,7 +392,7 @@ impl Checker {
         }
         match shape {
             VariantPayloadShape::Unit => has_unit_row || !ctor_rows.is_empty(),
-            VariantPayloadShape::Struct => has_struct_cover,
+            VariantPayloadShape::Struct(_) => has_struct_cover,
             VariantPayloadShape::Tuple(payload_tys) => {
                 // Use resolution-based irrefutability so that a plain uppercase
                 // binder (e.g. `Some(MAX)` where `MAX` is not a variant of the

--- a/hew-types/src/check/tests/exhaustiveness.rs
+++ b/hew-types/src/check/tests/exhaustiveness.rs
@@ -1482,6 +1482,63 @@ fn main() {
     );
 }
 
+/// Sibling of the #2340 fix: a struct-variant field typed as a tuple, fully
+/// destructured with bindings, must also be credited as irrefutable via the
+/// same unified predicate (routed through the now-typed
+/// `VariantPayloadShape::Struct`).
+#[test]
+fn typecheck_struct_variant_tuple_field_destructure_is_exhaustive() {
+    let (errors, _) = parse_and_check(
+        r"
+enum Packet { Data { value: (i64, i64) }; Empty }
+fn main() {
+    let p: Packet = Data { value: (1, 2) };
+    let r = match p {
+        Data { value: (a, b) } => a + b,
+        Empty => 0,
+    };
+    let _done = r;
+}",
+    );
+    assert!(
+        errors.is_empty(),
+        "irrefutable tuple-typed struct-variant field destructure must be exhaustive: {errors:?}"
+    );
+}
+
+/// Negative control mirroring the struct-variant sibling: a literal inside
+/// the tuple-typed field makes the field sub-pattern refutable, so the match
+/// must still be non-exhaustive.
+#[test]
+fn typecheck_struct_variant_tuple_field_with_literal_still_non_exhaustive() {
+    let (errors, warnings) = parse_and_check(
+        r"
+enum Packet { Data { value: (i64, i64) }; Empty }
+fn main() {
+    let p: Packet = Data { value: (1, 2) };
+    match p {
+        Data { value: (1, b) } => b,
+        Empty => 0,
+    }
+    let _done = 0;
+}",
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::NonExhaustiveMatch)),
+        "literal element inside a tuple-typed struct-variant field must keep the match \
+         non-exhaustive: {errors:?}"
+    );
+    assert!(
+        warnings
+            .iter()
+            .all(|w| !matches!(w.kind, TypeErrorKind::NonExhaustiveMatch)),
+        "non-exhaustive struct-variant tuple-field match must not be downgraded to a warning: \
+         {warnings:?}"
+    );
+}
+
 /// Negative control: a literal inside one tuple element makes the whole
 /// element-wise AND-recursion refutable, so the match must still be
 /// non-exhaustive. Catches an over-eager fix that credits any non-empty

--- a/hew-types/src/check/tests/exhaustiveness.rs
+++ b/hew-types/src/check/tests/exhaustiveness.rs
@@ -1459,3 +1459,113 @@ fn explicit_cooperate_expression_is_parse_error() {
         result.errors
     );
 }
+
+/// #2340: a non-empty tuple payload destructure with every element
+/// irrefutable (plain bindings) must be credited as covering the variant,
+/// not rejected as non-exhaustive.
+#[test]
+fn typecheck_tuple_payload_destructure_is_exhaustive() {
+    let (errors, _) = parse_and_check(
+        r"
+fn main() {
+    let x: Option<(i64, i64)> = Some((1, 2));
+    let r = match x {
+        Some((a, b)) => a + b,
+        None => 0,
+    };
+    let _done = r;
+}",
+    );
+    assert!(
+        errors.is_empty(),
+        "irrefutable tuple payload destructure must be exhaustive: {errors:?}"
+    );
+}
+
+/// Negative control: a literal inside one tuple element makes the whole
+/// element-wise AND-recursion refutable, so the match must still be
+/// non-exhaustive. Catches an over-eager fix that credits any non-empty
+/// tuple instead of recursing element-wise.
+#[test]
+fn typecheck_tuple_payload_with_literal_element_still_non_exhaustive() {
+    let (errors, warnings) = parse_and_check(
+        r"
+fn main() {
+    let x: Option<(i64, i64)> = Some((1, 2));
+    match x {
+        Some((1, b)) => b,
+        None => 0,
+    }
+    let _done = 0;
+}",
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::NonExhaustiveMatch)),
+        "literal element inside tuple payload must keep the match non-exhaustive: {errors:?}"
+    );
+    assert!(
+        warnings
+            .iter()
+            .all(|w| !matches!(w.kind, TypeErrorKind::NonExhaustiveMatch)),
+        "non-exhaustive tuple-payload match must not be downgraded to a warning: {warnings:?}"
+    );
+}
+
+/// Negative control: arity mismatch between the tuple pattern and the
+/// resolved tuple payload type must stay refutable — the new recursive
+/// predicate must not credit a shape it can't actually zip element-wise.
+/// The parser-adjacent `bind_pattern` arity check (patterns.rs, the
+/// `Ty::Tuple` binding arm) independently reports `ArityMismatch` for the
+/// same shape; this test additionally confirms the exhaustiveness predicate
+/// does not compensate by wrongly crediting the arm, which would otherwise
+/// suppress the `NonExhaustiveMatch` alongside it.
+#[test]
+fn typecheck_tuple_payload_arity_mismatch_still_non_exhaustive() {
+    let (errors, _) = parse_and_check(
+        r"
+fn main() {
+    let x: Option<(i64, i64)> = Some((1, 2));
+    match x {
+        Some((a, b, c)) => a,
+        None => 0,
+    }
+    let _done = 0;
+}",
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::ArityMismatch)),
+        "expected the pre-existing tuple-pattern arity check to fire: {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|e| matches!(e.kind, TypeErrorKind::NonExhaustiveMatch)),
+        "arity-mismatched tuple payload must not be credited as covering Some: {errors:?}"
+    );
+}
+
+/// Recursion depth: a two-level nested tuple (tuple-in-tuple) with every
+/// leaf a plain binding must be credited as irrefutable, proving the
+/// recursion is not hardcoded to a single level.
+#[test]
+fn typecheck_nested_tuple_payload_destructure_is_exhaustive() {
+    let (errors, _) = parse_and_check(
+        r"
+fn main() {
+    let x: Option<(i64, (i64, i64))> = Some((1, (2, 3)));
+    let r = match x {
+        Some((a, (b, c))) => a + b + c,
+        None => 0,
+    };
+    let _done = r;
+}",
+    );
+    assert!(
+        errors.is_empty(),
+        "two-level nested tuple payload destructure must be exhaustive: {errors:?}"
+    );
+}

--- a/hew-types/src/check/tests/patterns.rs
+++ b/hew-types/src/check/tests/patterns.rs
@@ -861,17 +861,14 @@ fn main() -> i64 {
     let p = Pair::Both((1, 2));
     match p {
         Pair::Both((a, b)) => a,
-        Pair::Both(_) => 0,
         Pair::None => 0,
     }
 }",
     );
     assert!(
-        !output.errors.iter().any(|e| matches!(
-            &e.kind,
-            crate::error::TypeErrorKind::UnsupportedPayloadSubpattern { .. }
-        )),
-        "tuple-in-payload must not emit UnsupportedPayloadSubpattern; got errors: {:#?}",
+        output.errors.is_empty(),
+        "tuple-in-payload destructure must be fully accepted (both HIR-supported \
+         and exhaustiveness-credited) without an extra catch-all arm; got errors: {:#?}",
         output.errors
     );
 }


### PR DESCRIPTION
## Summary

A match on an enum variant with a tuple payload destructured element-wise (e.g. `Some((a, b))` / `None` on `Option<(i64, i64)>`) was wrongly rejected as non-exhaustive — the irrefutability predicate credited only empty tuple payloads instead of recursing element-wise into the payload's sub-patterns. The fix recurses with AND-combination across tuple elements, and fails closed on arity mismatch or a non-tuple resolved type.

A second commit threads real field types through the struct-variant payload shape, routes struct-variant field crediting through the same unified predicate, and deletes the old duplicate predicate. That predecessor was also over-crediting bare variant names as irrefutable binders in struct-field position — a latent under-rejection hole that's now closed as a side effect of the unification.

## Verification

- Both repros (`Option<(i64, i64)>` match, struct-variant tuple field) verified red before the fix and green after.
- 4 new exhaustiveness tests plus 2 struct-variant tests, including negative controls: a literal tuple element and an arity mismatch both correctly stay refutable.
- `hew-types` suite green; workspace `clippy -D warnings` clean.
- Compiled repro runs end-to-end through `hew run`.

## Out of scope

- Destructuring a tuple *inside* a struct-variant field now passes the exhaustiveness checker but still fails HIR lowering — a pre-existing gap that this fix makes reachable. Tracked in #2354.

Fixes #2340.