### PR TITLE
build(ci): wire the O2 differential gate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,6 +395,13 @@ jobs:
         # gates on a fully-green suite with no special handling.
         run: make test-hew-ratchet
 
+      - name: Run -O0-vs-O2 differential-exec parity gate
+        # Every compiled `.hew` program must behave identically at -O0 and -O2;
+        # a divergence is a miscompile in the LLVM middle-end optimizer pipeline.
+        # Runs the Linux/x86_64 portion of the cross-platform parity matrix
+        # tracked in #2104; Windows-MSVC and wasm32 remain separate platform gates.
+        run: make test-o2-differential
+
       - name: Run stdlib type-check suite (ratcheted)
         # Type-checks every std/*.hew file through scripts/stdlib-ratchet.sh.
         # Known failures tracked in scripts/stdlib-expected-failures.txt.

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@
 # ============================================================================
 
 .PHONY: all build bootstrap install-hooks hew hew-native adze observe observe-functional-test runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh licenses licenses-check
-.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all test-fast test-stdlib test-hew test-hew-ratchet test-o2-differential test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar
+.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all test-fast test-stdlib test-hew test-hew-ratchet test-o2-differential o2-differential-selftest test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
 .PHONY: coverage coverage-summary coverage-lcov coverage-runtime coverage-combined coverage-branch
@@ -772,6 +772,9 @@ test-hew-ratchet: hew runtime stdlib
 test-o2-differential: hew runtime stdlib
 	@echo "==> Running -O0-vs-O2 differential-exec parity gate"
 	scripts/o2-differential.sh
+
+o2-differential-selftest:
+	bash scripts/o2-differential-selftest.sh
 
 test-stdlib-ratchet: hew
 	@echo "==> Type-checking stdlib (ratcheted)"

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -32,6 +32,7 @@ command_timeout_floor() {
         "make test-pkg-import") echo 60 ;;
         "make fuzz-oracle") echo 210 ;;
         "make test-hew-ratchet") echo 600 ;;
+        "make test-o2-differential") echo 1200 ;;
         "make test-stdlib-ratchet") echo 45 ;;
         "make test-doc-examples") echo 45 ;;
         "make sandbox-parity") echo 150 ;;
@@ -80,6 +81,7 @@ CI_REQUIRED_CHECKS=(
     "nextest workspace ci (release-gate.yml: nextest run --workspace --profile ci)	make test"
     "playground-check (release-gate.yml: make playground-check)	make playground-check"
     "Hew test suite ratchet (ci.yml: make test-hew-ratchet)	make test-hew-ratchet"
+    "O2 differential-exec parity gate (ci.yml: make test-o2-differential)	make test-o2-differential"
     "Stdlib type-check ratchet (ci.yml: make test-stdlib-ratchet)	make test-stdlib-ratchet"
     "Vertical slice oracle (ci.yml: make test-vertical-slice)	make test-vertical-slice"
     "Package-import oracle (ci.yml: make test-pkg-import)	make test-pkg-import"
@@ -786,6 +788,7 @@ case "$LANE" in
         add_command "make test-pkg-import"
         add_command "make fuzz-oracle"
         add_command "make test-hew-ratchet"
+        add_command "make test-o2-differential"
         add_command "make test-stdlib-ratchet"
         add_command "make test-doc-examples"
         add_command "make sandbox-parity"

--- a/scripts/o2-differential-selftest.sh
+++ b/scripts/o2-differential-selftest.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# o2-differential-selftest.sh - Self-proof for scripts/o2-differential.sh.
+#
+# Three independently-failable cases prove the differential gate distinguishes
+# O0/O2 outcome sets, accepts identical outcome sets, and fails closed when a
+# test runner does not produce a summary.
+#
+# Exit codes:
+#   0  all cases pass
+#   1  one or more cases fail (details on stderr)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="$SCRIPT_DIR/o2-differential.sh"
+
+TMPDIR_BASE="$(mktemp -d /tmp/hew-o2-differential-selftest.XXXXXX)"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+TESTS_DIR="$TMPDIR_BASE/tests"
+STUB="$TMPDIR_BASE/hew-stub"
+mkdir -p "$TESTS_DIR"
+
+pass() { echo "PASS $1"; }
+fail() { echo "FAIL $1: $2" >&2; exit 1; }
+
+cat > "$STUB" <<'EOF'
+#!/usr/bin/env bash
+set -u
+
+case "${O2_DIFF_SELFTEST_CASE:-}" in
+  divergence-caught)
+    echo "test alpha ... PASSED"
+    if [[ "${HEW_OPT_LEVEL:-0}" == "2" ]]; then
+      echo "test beta ... FAILED"
+      echo "test result: FAILED. 1 passed; 1 failed; 0 ignored"
+    else
+      echo "test beta ... PASSED"
+      echo "test result: ok. 2 passed; 0 failed; 0 ignored"
+    fi
+    ;;
+  baseline-identical)
+    echo "test alpha ... PASSED"
+    echo "test beta ... ignored"
+    echo "test result: ok. 1 passed; 0 failed; 1 ignored"
+    ;;
+  no-summary-fail-closed)
+    echo "test alpha ... PASSED"
+    echo "runner terminated before summary"
+    ;;
+  *)
+    echo "unknown O2_DIFF_SELFTEST_CASE: ${O2_DIFF_SELFTEST_CASE:-}" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$STUB"
+
+run_case() {
+  local name="$1"
+  local expected_rc="$2"
+  local log="$TMPDIR_BASE/$name.log"
+  local rc=0
+
+  echo "--- Case: $name ---"
+  O2_DIFF_SELFTEST_CASE="$name" HEW_BIN="$STUB" \
+    bash "$GATE" --tests-dir "$TESTS_DIR" > "$log" 2>&1 || rc=$?
+
+  if [[ "$rc" -eq "$expected_rc" ]]; then
+    pass "$name"
+  else
+    sed 's/^/  /' "$log" >&2
+    fail "$name" "gate exited $rc (expected $expected_rc)"
+  fi
+}
+
+run_case "divergence-caught" 1
+run_case "baseline-identical" 0
+run_case "no-summary-fail-closed" 1
+
+echo ""
+echo "o2-differential-selftest: all 3 cases PASS"


### PR DESCRIPTION
## Summary

The O0-vs-O2 differential-exec gate (`scripts/o2-differential.sh`) caught a real optimization-dependent miscompile on its first corpus run (#2328) — generic f-string/`to_string` formatting of numeric primitives diverged between O0 and O2. Now that the underlying bug is fixed and the gate is green on main, this wires it into CI: a new step in the `build-and-test` job (`.github/workflows/ci.yml`), a `make test-o2-differential` target, and a preflight-dispatcher lane so local `make ci-preflight` runs it too. A new selftest script (`scripts/o2-differential-selftest.sh`) proves the gate itself fails when the two optimization levels diverge, so it can't silently rot into a no-op.

## Verification

- `make o2-differential-selftest`: negative probe — divergence and missing-summary cases both correctly fail the gate, exit 0 overall.
- `make test-o2-differential`: O0 and O2 outcome sets identical across all 1010 corpus tests.
- Full test suite green on the rebased tip, with one exception: `hew-codegen-rs/tests/supervised_handler_name_registration.rs` intermittently fails under whole-suite parallelism from a shared hardcoded temp-path race (#2357, unrelated to this change — reproduces 5/5 isolated on both this branch and main). A clean rerun of the full suite passed 10759/10759.

## Out of scope

- CI wall-clock calibration for the new job — `timeout-minutes` and the dispatcher's timeout floor are set from an estimate; tuning comes after the first few live runs.

Related: #2104, #2328