### PR TITLE
feat(types): lint invisible Unicode in comments

### DIFF
--- a/docs/design/lint-pass.md
+++ b/docs/design/lint-pass.md
@@ -5,26 +5,31 @@ maintainers · Companion to the ast-grep rule set
 
 M1 + M2 have landed: the lint infrastructure (`LintId` / `LintLevel` /
 `LintLevels`), the checker `run_lints` sweep, the CLI `--allow` / `--warn` /
-`--deny` flags, and in-source `// hew:allow(...)` suppression — plus seven
+`--deny` flags, and in-source `// hew:allow(...)` suppression — plus nine
 checker lints (`needless_range_loop`, `redundant_else_after_return`,
 `needless_match_to_if_let`, `len_zero_comparison`, `needless_bool`,
-`must_use`, `sleep_loop_blocks_mailbox`) and the two ad-hoc warnings
-(`clone_on_copy`, `dead_code`) migrated onto the registry so
+`must_use`, `sleep_loop_blocks_mailbox`,
+`text_direction_codepoint_in_comment`, `invisible_codepoint_in_comment`) and the
+two ad-hoc warnings (`clone_on_copy`, `dead_code`) migrated onto the registry so
 they are now re-levelable and suppressible. M3 has landed too: a backward
 liveness dataflow pass in `hew-mir`, the `dead_store` MIR lint built on it, and
 the CLI plumbing that surfaces MIR-stage lints as level-controlled, suppressible
-warnings (see §10). `clean_counter` is deferred and intentionally **not
-registered** — so `-D clean_counter` fails closed as an unknown lint rather than
-silently no-opping; the reasoning is in §10 (tracked in issue #2178). Editor/web
-surfacing of MIR lints is deferred to issue #2176.
+warnings (see §10). M4 has landed too: comment-side Trojan-Source scanning over
+raw module source, with the text-direction tier denied by default and the broader
+invisible-codepoint tier warning by default (see §11). `clean_counter` is
+deferred and intentionally **not registered** — so `-D clean_counter` fails
+closed as an unknown lint rather than silently no-opping; the reasoning is in §10
+(tracked in issue #2178). Editor/web surfacing of MIR lints is deferred to issue
+#2176.
 
 ## 1. Goal
 
 Add a **lint layer in the Hew compiler** for idiom/code-smell findings that need more than
 syntax — the cases ast-grep (purely syntactic) cannot do precisely: "is this index only used to
 index that collection?", "is this value ever read again?", "does this branch always diverge?".
-Model: Clippy (HIR/MIR lints on top of the compiler's own analysis). Lints are **non-fatal
-warnings**, **suppressible**, and surfaced in the CLI, editors, and the website.
+Model: Clippy (HIR/MIR lints on top of the compiler's own analysis). Lints are **level-controlled**,
+**suppressible**, and surfaced in the CLI, editors, and the website; most default to warnings, while
+narrow security/correctness lints may be denied by default.
 
 Non-goals: replacing the ast-grep rules (they stay as the cheap, build-free, CI/grep layer);
 a general plugin system; cross-crate/interprocedural analysis.
@@ -306,8 +311,43 @@ the precise subset that is actually convertible.
     and the over-approximation contract; `dead_store` positives and precision-guard negatives live
     alongside them and in the CLI e2e suite (`hew-cli/tests/lint_pass_e2e.rs`), including the
     `for i in 0..n` regression that must stay silent even under `-D dead_store`.
+- **M4 — comment-side Trojan-Source lints. (Implemented in this change.)** Two source-text checker
+  lints scan comments (`//`, `///`, `//!`, `/* */`) for codepoints that can make source review lie
+  about the bytes the compiler sees. See §11.
 
-## 11. Division of labour with ast-grep
+## 11. M4: comment-side Trojan-Source lints
+
+The formatter already escapes invisible and bidirectional codepoints when it emits string, f-string,
+byte-string, char, and regex literal content. M4 covers the remaining checker-stage source surface:
+comments, including doc-comments.
+
+- **Detect:** `hew-parser::fmt::extract_comments(source, true)` scans raw module source once per
+  module, including doc-comments for the checker while `hew fmt` still excludes them for formatting.
+  Each non-ASCII comment codepoint is classified with the same readability predicate the formatter
+  uses for literal emission. The deny tier, `text_direction_codepoint_in_comment`, is exactly the nine
+  Unicode explicit bidirectional formatting controls (U+202A–U+202E and U+2066–U+2069). The warning
+  tier, `invisible_codepoint_in_comment`, catches other non-printable/default-ignorable scalars such
+  as zero-width spaces and variation selectors.
+- **Guards:** readable non-ASCII prose (`café`, CJK, emoji, arrows, em dashes) is silent. The comment
+  scanner skips string/char/regex literal bodies, so a `//` inside a literal is not a comment start.
+  Literal content remains out of scope for `hew check`; formatter escaping owns literal output.
+- **Suggest:** remove the hidden codepoint, or spell out the intended directionality/codepoint in
+  visible text.
+- **Emit:** both lints use the shared `LintId`/`LintLevels`/`LintCtx::emit` path, so `--allow`,
+  `--warn`, `--deny`, and `// hew:allow(...)` work like every other registry lint. The text-direction
+  tier defaults to `Deny` because the fixed UAX #9 control set has no legitimate Hew-comment use and
+  maps to the CVE-2021-42574 class. The broader invisible-codepoint tier defaults to `Warn` because it
+  is still suspicious but less specifically a reordering attack.
+- **Surfacing:** CLI and wasm already installed lint sources. The LSP analysis path now installs the
+  root buffer and resolved module sources on the checker before type-checking, so comment-scanning
+  diagnostics and in-source allow directives reach editor diagnostics too.
+- **Tests:** checker unit tests cover all comment forms, deny/warn defaults, allow/warn/deny
+  overrides, suppression, readable-Unicode negatives, literal-boundary negatives, and once-per-module
+  source scanning. CLI e2e tests run real `hew check` subprocesses for default denial, `--allow`,
+  `--warn`, `--deny`, directive suppression, and unknown-lint fail-closed behaviour. LSP tests pin the
+  editor diagnostic and suppression path.
+
+## 12. Division of labour with ast-grep
 
 ast-grep stays the cheap syntactic/CI/IDE-grep layer (the 15+ rules). The compiler lint pass is the
 authoritative semantic layer. They compose: ast-grep cheaply flags candidate shapes; the compiler

--- a/hew-cli/tests/lint_pass_e2e.rs
+++ b/hew-cli/tests/lint_pass_e2e.rs
@@ -1,9 +1,9 @@
 //! End-to-end coverage for the compiler lint pass surfaced through `hew check`:
-//! lints render as warnings by default, the `--allow` / `--warn` / `--deny`
+//! lints render at their default levels, the `--allow` / `--warn` / `--deny`
 //! flags re-level them, an in-source `// hew:allow(...)` directive suppresses
 //! them, and an unknown lint name fails closed at the CLI boundary. Covers the
-//! `needless_range_loop` and `len_zero_comparison` checker lints plus the
-//! `dead_code` warning now routed through the same registry.
+//! `needless_range_loop`, `len_zero_comparison`, and comment Unicode checker
+//! lints plus the `dead_code` warning now routed through the same registry.
 
 mod support;
 
@@ -399,6 +399,90 @@ fn stdlib_lints_do_not_leak_through_implicit_import() {
     assert!(
         !stderr.contains(LEN_ZERO_MESSAGE),
         "a len_zero_comparison finding must not leak from stdlib bodies:\n{stderr}"
+    );
+}
+
+// ── checker-stage source lint: Trojan-Source comments ──────────────────
+
+const COMMENT_TEXT_DIRECTION: &str = "/// \u{202E}\nfn main() {}\n";
+const COMMENT_TEXT_DIRECTION_SUPPRESSED: &str =
+    "// hew:allow(text_direction_codepoint_in_comment)\n/// \u{202E}\nfn main() {}\n";
+const COMMENT_INVISIBLE: &str = "// hidden\u{200B}gap\nfn main() {}\n";
+const TEXT_DIRECTION_LINT: &str = "text_direction_codepoint_in_comment";
+const INVISIBLE_LINT: &str = "invisible_codepoint_in_comment";
+
+#[test]
+fn comment_text_direction_denies_by_default() {
+    let output = run_check(COMMENT_TEXT_DIRECTION, &[]);
+    let stderr = stderr_of(&output);
+    assert!(
+        !output.status.success(),
+        "the deny-default text-direction lint must fail the build:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("error:") && stderr.contains(TEXT_DIRECTION_LINT),
+        "expected the text-direction lint to render as an error:\n{stderr}"
+    );
+}
+
+#[test]
+fn comment_text_direction_allow_flag_suppresses() {
+    let output = run_check(COMMENT_TEXT_DIRECTION, &["--allow", TEXT_DIRECTION_LINT]);
+    let stderr = stderr_of(&output);
+    assert!(output.status.success(), "check should pass:\n{stderr}");
+    assert!(
+        !stderr.contains(TEXT_DIRECTION_LINT),
+        "--allow must suppress the deny-default lint:\n{stderr}"
+    );
+}
+
+#[test]
+fn comment_text_direction_warn_flag_downgrades_to_warning() {
+    let output = run_check(COMMENT_TEXT_DIRECTION, &["--warn", TEXT_DIRECTION_LINT]);
+    let stderr = stderr_of(&output);
+    assert!(
+        output.status.success(),
+        "--warn must downgrade the deny-default lint:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("warning:") && stderr.contains(TEXT_DIRECTION_LINT),
+        "--warn must render the text-direction lint as a warning:\n{stderr}"
+    );
+}
+
+#[test]
+fn comment_text_direction_inline_directive_suppresses() {
+    let output = run_check(COMMENT_TEXT_DIRECTION_SUPPRESSED, &[]);
+    let stderr = stderr_of(&output);
+    assert!(output.status.success(), "check should pass:\n{stderr}");
+    assert!(
+        !stderr.contains(TEXT_DIRECTION_LINT),
+        "an in-source `// hew:allow(...)` directive must suppress the lint:\n{stderr}"
+    );
+}
+
+#[test]
+fn comment_invisible_warns_by_default_and_deny_promotes() {
+    let default = run_check(COMMENT_INVISIBLE, &[]);
+    let default_stderr = stderr_of(&default);
+    assert!(
+        default.status.success(),
+        "the invisible-codepoint lint is warning-tier by default:\n{default_stderr}"
+    );
+    assert!(
+        default_stderr.contains("warning:") && default_stderr.contains(INVISIBLE_LINT),
+        "expected the invisible-codepoint lint warning:\n{default_stderr}"
+    );
+
+    let denied = run_check(COMMENT_INVISIBLE, &["--deny", INVISIBLE_LINT]);
+    let denied_stderr = stderr_of(&denied);
+    assert!(
+        !denied.status.success(),
+        "--deny must promote the invisible-codepoint lint:\n{denied_stderr}"
+    );
+    assert!(
+        denied_stderr.contains("error:") && denied_stderr.contains(INVISIBLE_LINT),
+        "--deny must render the invisible-codepoint lint as an error:\n{denied_stderr}"
     );
 }
 

--- a/hew-lsp/src/server/analysis.rs
+++ b/hew-lsp/src/server/analysis.rs
@@ -9,7 +9,7 @@ use hew_parser::ast::{ImportDecl, Item};
 use hew_parser::{ParseDiagnosticKind, ParseResult};
 use hew_types::error::{Severity, TypeErrorKind};
 use hew_types::module_registry::{build_module_search_paths, build_module_search_paths_for};
-use hew_types::{Checker, LintId, TypeCheckOutput};
+use hew_types::{Checker, LintId, LintSources, TypeCheckOutput};
 use tower_lsp::lsp_types::{
     Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, DiagnosticTag, Location,
     NumberOrString, Url,
@@ -911,6 +911,12 @@ pub(super) fn analyze_document(
             };
         program.module_graph = module_graph;
         let module_sources = build_module_source_map(&program, documents);
+        let mut lint_sources = LintSources::new();
+        lint_sources.set_root(source.to_string());
+        for (module_name, module_source) in &module_sources {
+            lint_sources.set_module(module_name.clone(), module_source.source.clone());
+        }
+        checker.set_lint_sources(lint_sources);
         let type_output = checker.check_program(&program);
         let hir_diagnostics = if type_output.errors.is_empty() {
             collect_hir_diagnostics(&program, &type_output)
@@ -1614,6 +1620,51 @@ mod tests {
                 .iter()
                 .any(|diagnostic| diagnostic.source.as_deref() == Some("hew-hir")),
             "expected HIR diagnostics after successful typecheck: {root_diags:?}"
+        );
+    }
+
+    #[test]
+    fn analyze_document_reports_comment_text_direction_lint() {
+        let uri = Url::parse("file:///project/main.hew").unwrap();
+        let document = analyze_document(&uri, "// \u{202E}\nfn main() {}\n", &DashMap::new(), &[]);
+        let root_diags = document
+            .diagnostics_by_uri
+            .get(&uri)
+            .expect("root document should always have diagnostics");
+
+        assert!(
+            root_diags.iter().any(|diagnostic| {
+                diagnostic.source.as_deref() == Some("hew-types")
+                    && diagnostic.severity == Some(DiagnosticSeverity::ERROR)
+                    && diagnostic.code
+                        == Some(NumberOrString::String(
+                            "text_direction_codepoint_in_comment".to_string(),
+                        ))
+            }),
+            "expected text_direction_codepoint_in_comment diagnostic: {root_diags:?}"
+        );
+    }
+
+    #[test]
+    fn analyze_document_honours_comment_lint_allow_directive() {
+        let uri = Url::parse("file:///project/main.hew").unwrap();
+        let source =
+            "// hew:allow(text_direction_codepoint_in_comment)\n// \u{202E}\nfn main() {}\n";
+        let document = analyze_document(&uri, source, &DashMap::new(), &[]);
+        let root_diags = document
+            .diagnostics_by_uri
+            .get(&uri)
+            .map(|diagnostics| diagnostics.as_slice())
+            .unwrap_or(&[]);
+
+        assert!(
+            !root_diags.iter().any(|diagnostic| {
+                diagnostic.code
+                    == Some(NumberOrString::String(
+                        "text_direction_codepoint_in_comment".to_string(),
+                    ))
+            }),
+            "allow directive must suppress the source lint: {root_diags:?}"
         );
     }
 

--- a/hew-lsp/src/server/analysis.rs
+++ b/hew-lsp/src/server/analysis.rs
@@ -1651,11 +1651,10 @@ mod tests {
         let source =
             "// hew:allow(text_direction_codepoint_in_comment)\n// \u{202E}\nfn main() {}\n";
         let document = analyze_document(&uri, source, &DashMap::new(), &[]);
-        let root_diags = document
+        let root_diags: &[Diagnostic] = document
             .diagnostics_by_uri
             .get(&uri)
-            .map(|diagnostics| diagnostics.as_slice())
-            .unwrap_or(&[]);
+            .map_or(&[], Vec::as_slice);
 
         assert!(
             !root_diags.iter().any(|diagnostic| {

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -3433,6 +3433,7 @@ fn compound_assign_op_str(op: CompoundAssignOp) -> &'static str {
 ///
 /// Note: Cs (Surrogate) codepoints are not valid Rust `char` values and
 /// therefore never reach this function.
+#[must_use]
 pub fn is_printable_non_ascii(c: char) -> bool {
     debug_assert!(!c.is_ascii(), "only call for non-ASCII chars");
 
@@ -3698,6 +3699,7 @@ pub struct Comment {
 /// skipped because the parser captures their content into AST fields
 /// (`doc_comment` / `module_doc`) and the formatter re-emits them via
 /// `write_outer_doc` / `format_program`.
+#[must_use]
 pub fn extract_comments(source: &str, include_doc_comments: bool) -> Vec<Comment> {
     let mut comments = Vec::new();
     let bytes = source.as_bytes();

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -48,7 +48,7 @@ pub fn format_program(program: &Program) -> String {
 /// Format an AST [`Program`] as canonical Hew source text, preserving comments from `source`.
 #[must_use]
 pub fn format_source(source: &str, program: &Program) -> String {
-    let comments = extract_comments(source);
+    let comments = extract_comments(source, false);
     let mut f = Formatter::new(source, comments);
     f.format_program(program);
     f.flush_comments_before(usize::MAX);
@@ -3433,7 +3433,7 @@ fn compound_assign_op_str(op: CompoundAssignOp) -> &'static str {
 ///
 /// Note: Cs (Surrogate) codepoints are not valid Rust `char` values and
 /// therefore never reach this function.
-fn is_printable_non_ascii(c: char) -> bool {
+pub fn is_printable_non_ascii(c: char) -> bool {
     debug_assert!(!c.is_ascii(), "only call for non-ASCII chars");
 
     // Escape the C categories that are invisible, confusable, or unrendered.
@@ -3687,19 +3687,18 @@ fn escape_char_literal(c: char, out: &mut String) {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone)]
-struct Comment {
-    text: String,
-    span: Range<usize>,
+pub struct Comment {
+    pub text: String,
+    pub span: Range<usize>,
 }
 
 /// Scan source text and extract all comments with their byte positions.
 ///
-/// Doc-comments (`///` and `//!`) are intentionally skipped: the parser
-/// captures their content into AST fields (`doc_comment` / `module_doc`),
-/// and the formatter re-emits them via `write_outer_doc` /
-/// `format_program`. Including them here as raw comments would cause
-/// double emission and break AST round-trip.
-fn extract_comments(source: &str) -> Vec<Comment> {
+/// When `include_doc_comments` is false, doc-comments (`///` and `//!`) are
+/// skipped because the parser captures their content into AST fields
+/// (`doc_comment` / `module_doc`) and the formatter re-emits them via
+/// `write_outer_doc` / `format_program`.
+pub fn extract_comments(source: &str, include_doc_comments: bool) -> Vec<Comment> {
     let mut comments = Vec::new();
     let bytes = source.as_bytes();
     let mut i = 0;
@@ -3714,7 +3713,7 @@ fn extract_comments(source: &str) -> Vec<Comment> {
                     while i < bytes.len() && bytes[i] != b'\n' {
                         i += 1;
                     }
-                    if !is_doc_comment {
+                    if include_doc_comments || !is_doc_comment {
                         comments.push(Comment {
                             text: source[start..i].to_string(),
                             span: start..i,

--- a/hew-types/src/check/lints/mod.rs
+++ b/hew-types/src/check/lints/mod.rs
@@ -2,10 +2,12 @@
 //!
 //! This module hosts the *semantic* lint layer — idiom / code-smell findings
 //! that need more than syntax (def-use, types) and therefore live in the
-//! compiler rather than in the syntactic ast-grep rule set. Lints are
-//! non-fatal by default: each is emitted through the checker's existing
-//! [`TypeError`] warning channel ([`super::TypeCheckOutput::warnings`]), which
-//! already reaches the CLI, the LSP, and the website with no extra plumbing.
+//! compiler rather than in the syntactic ast-grep rule set. Most lints are
+//! non-fatal by default, while narrowly-scoped correctness/security lints may be
+//! `Deny` by default. The Trojan-Source text-direction lint uses a fixed
+//! UAX #9 explicit-formatting codepoint set with no legitimate Hew-comment use,
+//! so it fails closed for the CVE-2021-42574 class instead of emitting a warning
+//! heuristic.
 //!
 //! ## Public surface (for the CLI / suppression integration)
 //!
@@ -50,6 +52,7 @@ mod needless_match_to_if_let;
 mod needless_range_loop;
 mod redundant_else_after_return;
 mod sleep_loop_blocks_mailbox;
+mod trojan_source;
 
 /// Stable identifier for a single compiler lint.
 ///
@@ -99,6 +102,12 @@ pub enum LintId {
     /// concrete handle dispatch uses the handler while generic pid dispatch keeps
     /// the builtin method surface.
     ActorHandleBuiltinShadow,
+    /// A comment contains one of Unicode's explicit bidirectional text controls,
+    /// which can visually reorder source around the bytes the compiler sees.
+    TextDirectionCodepointInComment,
+    /// A comment contains an invisible/default-ignorable Unicode codepoint that
+    /// can hide text or create visually indistinguishable source.
+    InvisibleCodepointInComment,
     // NOTE: a `clean_counter` lint (a loop-carried accumulator that is
     // incremented but never read after the loop) is deliberately NOT registered
     // here. It has no emission code yet, and registering an un-emitted lint
@@ -125,6 +134,8 @@ impl LintId {
         LintId::MustUse,
         LintId::SleepLoopBlocksMailbox,
         LintId::ActorHandleBuiltinShadow,
+        LintId::TextDirectionCodepointInComment,
+        LintId::InvisibleCodepointInComment,
     ];
 
     /// The stable, lowercase string name for this lint.
@@ -146,6 +157,8 @@ impl LintId {
             LintId::MustUse => "must_use",
             LintId::SleepLoopBlocksMailbox => "sleep_loop_blocks_mailbox",
             LintId::ActorHandleBuiltinShadow => "actor_handle_builtin_shadow",
+            LintId::TextDirectionCodepointInComment => "text_direction_codepoint_in_comment",
+            LintId::InvisibleCodepointInComment => "invisible_codepoint_in_comment",
         }
     }
 
@@ -173,7 +186,9 @@ impl LintId {
             | LintId::DeadStore
             | LintId::MustUse
             | LintId::SleepLoopBlocksMailbox
-            | LintId::ActorHandleBuiltinShadow => LintLevel::Warn,
+            | LintId::ActorHandleBuiltinShadow
+            | LintId::InvisibleCodepointInComment => LintLevel::Warn,
+            LintId::TextDirectionCodepointInComment => LintLevel::Deny,
         }
     }
 }
@@ -491,6 +506,20 @@ fn shadowed_actor_handle_builtin(name: &str) -> Option<&'static str> {
         "ask" => Some("`RemotePid<T>::ask`"),
         _ => None,
     }
+}
+
+/// Run source-text lints over one module's raw source.
+///
+/// Invoked once per module by [`super::Checker::run_lints`], outside the
+/// per-body sweep, so comments before, between, and after items are scanned
+/// exactly once.
+pub(super) fn lint_source(
+    ctx: &LintCtx,
+    levels: &LintLevels,
+    source: &str,
+    out: &mut Vec<TypeError>,
+) {
+    trojan_source::check(ctx, levels, source, out);
 }
 
 // ── shared read-only body walker ─────────────────────────────────────

--- a/hew-types/src/check/lints/trojan_source.rs
+++ b/hew-types/src/check/lints/trojan_source.rs
@@ -31,52 +31,58 @@ pub(super) fn check(ctx: &LintCtx, levels: &LintLevels, source: &str, out: &mut 
 
             let span = comment.span.start + offset..comment.span.start + offset + c.len_utf8();
             if is_bidi_reorder_control(c) {
-                emit(
-                    ctx,
-                    levels,
-                    LintId::TextDirectionCodepointInComment,
-                    &span,
-                    c,
-                    "text-direction control",
-                    "remove the codepoint or describe the directionality in visible text",
-                    out,
-                );
+                emit(ctx, levels, &Kind::TEXT_DIRECTION, &span, c, out);
             } else if !hew_parser::fmt::is_printable_non_ascii(c) {
-                emit(
-                    ctx,
-                    levels,
-                    LintId::InvisibleCodepointInComment,
-                    &span,
-                    c,
-                    "invisible Unicode codepoint",
-                    "remove the codepoint or spell it out visibly in the comment",
-                    out,
-                );
+                emit(ctx, levels, &Kind::INVISIBLE, &span, c, out);
             }
         }
     }
 }
 
+/// The two comment lint tiers this pass emits, bundled because `id`,
+/// `class`, and `suggestion` always vary together per tier — see
+/// [`Kind::TEXT_DIRECTION`] and [`Kind::INVISIBLE`].
+struct Kind {
+    id: LintId,
+    /// Noun phrase naming the codepoint class in the diagnostic message.
+    class: &'static str,
+    suggestion: &'static str,
+}
+
+impl Kind {
+    /// Deny-by-default: bidirectional reordering controls.
+    const TEXT_DIRECTION: Self = Self {
+        id: LintId::TextDirectionCodepointInComment,
+        class: "text-direction control",
+        suggestion: "remove the codepoint or describe the directionality in visible text",
+    };
+    /// Warning-tier: other invisible/default-ignorable scalars.
+    const INVISIBLE: Self = Self {
+        id: LintId::InvisibleCodepointInComment,
+        class: "invisible Unicode codepoint",
+        suggestion: "remove the codepoint or spell it out visibly in the comment",
+    };
+}
+
 fn emit(
     ctx: &LintCtx,
     levels: &LintLevels,
-    id: LintId,
+    kind: &Kind,
     span: &Span,
     c: char,
-    class: &str,
-    suggestion: &str,
     out: &mut Vec<TypeError>,
 ) {
     ctx.emit(
         levels,
-        id,
+        kind.id,
         span,
         format!(
-            "{}: comment contains {class} U+{:04X}",
-            id.as_str(),
+            "{}: comment contains {} U+{:04X}",
+            kind.id.as_str(),
+            kind.class,
             c as u32
         ),
-        suggestion.to_string(),
+        kind.suggestion.to_string(),
         out,
     );
 }

--- a/hew-types/src/check/lints/trojan_source.rs
+++ b/hew-types/src/check/lints/trojan_source.rs
@@ -1,0 +1,85 @@
+//! The comment-side Trojan-Source lints.
+//!
+//! Flags invisible Unicode codepoints in comments while leaving readable
+//! non-ASCII prose alone. Bidirectional reordering controls are a deny-by-default
+//! tier because they can make reviewed comment/source text appear in an order
+//! different from the bytes the compiler consumes; other invisible/default-
+//! ignorable scalars are warning-tier spoofing hazards.
+//!
+//! ## Precision over recall
+//!
+//! - Only scans comments extracted by the parser formatter's source scanner, so
+//!   `//` inside string, char, and regex literals is never treated as a comment.
+//! - The deny tier is exactly Unicode's nine explicit directional formatting
+//!   controls: U+202A–U+202E and U+2066–U+2069.
+//! - Readable non-ASCII (`é`, CJK, emoji, arrows, em dashes) is preserved by the
+//!   same classifier the formatter uses for literal emission.
+
+use hew_parser::ast::Span;
+
+use crate::error::TypeError;
+
+use super::{LintCtx, LintId, LintLevels};
+
+/// Entry point: scan all comments in `source` and flag invisible codepoints.
+pub(super) fn check(ctx: &LintCtx, levels: &LintLevels, source: &str, out: &mut Vec<TypeError>) {
+    for comment in hew_parser::fmt::extract_comments(source, true) {
+        for (offset, c) in comment.text.char_indices() {
+            if c.is_ascii() {
+                continue;
+            }
+
+            let span = comment.span.start + offset..comment.span.start + offset + c.len_utf8();
+            if is_bidi_reorder_control(c) {
+                emit(
+                    ctx,
+                    levels,
+                    LintId::TextDirectionCodepointInComment,
+                    &span,
+                    c,
+                    "text-direction control",
+                    "remove the codepoint or describe the directionality in visible text",
+                    out,
+                );
+            } else if !hew_parser::fmt::is_printable_non_ascii(c) {
+                emit(
+                    ctx,
+                    levels,
+                    LintId::InvisibleCodepointInComment,
+                    &span,
+                    c,
+                    "invisible Unicode codepoint",
+                    "remove the codepoint or spell it out visibly in the comment",
+                    out,
+                );
+            }
+        }
+    }
+}
+
+fn emit(
+    ctx: &LintCtx,
+    levels: &LintLevels,
+    id: LintId,
+    span: &Span,
+    c: char,
+    class: &str,
+    suggestion: &str,
+    out: &mut Vec<TypeError>,
+) {
+    ctx.emit(
+        levels,
+        id,
+        span,
+        format!("comment contains {class} U+{:04X}", c as u32),
+        suggestion.to_string(),
+        out,
+    );
+}
+
+fn is_bidi_reorder_control(c: char) -> bool {
+    matches!(
+        c as u32,
+        0x202A..=0x202E | 0x2066..=0x2069
+    )
+}

--- a/hew-types/src/check/lints/trojan_source.rs
+++ b/hew-types/src/check/lints/trojan_source.rs
@@ -71,7 +71,11 @@ fn emit(
         levels,
         id,
         span,
-        format!("comment contains {class} U+{:04X}", c as u32),
+        format!(
+            "{}: comment contains {class} U+{:04X}",
+            id.as_str(),
+            c as u32
+        ),
         suggestion.to_string(),
         out,
     );

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -840,9 +840,10 @@ impl Checker {
     /// Run the semantic lint sweep over every function/method body in the
     /// program and collect findings into `out`.
     ///
-    /// Read-only over checker state (`&self`): it walks each item's bodies,
-    /// builds a [`lints::LintCtx`] carrying the resolved-type facts, and tags
-    /// each body with the right `module_idx` / `source_module`. The module
+    /// Read-only over checker state (`&self`): it scans each module's raw source
+    /// once, walks each item's bodies, builds a [`lints::LintCtx`] carrying the
+    /// resolved-type facts, and tags each finding with the right `module_idx` /
+    /// `source_module`. The module
     /// walk mirrors `classify_closure_escapes` and the body-check loop in
     /// [`Checker::check_program`] (root items at index 0, then each non-root
     /// module in topo order at a 1-based index, with the same dotted module
@@ -850,6 +851,9 @@ impl Checker {
     /// and diagnostics route to the correct source file. Severity routing
     /// (`Deny` → error, otherwise warning) is left to the caller.
     pub fn run_lints(&self, program: &Program, levels: &LintLevels, out: &mut Vec<TypeError>) {
+        if let Some(source) = self.lint_sources.source_for(None) {
+            self.lint_source(source, 0, None, levels, out);
+        }
         for (item, _) in &program.items {
             self.lint_item(item, 0, None, levels, out);
         }
@@ -890,11 +894,34 @@ impl Checker {
                     continue;
                 }
                 let module_name = mod_id.path.join(".");
+                if let Some(source) = self.lint_sources.source_for(Some(&module_name)) {
+                    self.lint_source(source, module_idx, Some(&module_name), levels, out);
+                }
                 for (item, _) in &module.items {
                     self.lint_item(item, module_idx, Some(&module_name), levels, out);
                 }
             }
         }
+    }
+
+    /// Lint a module's raw source text once, for findings that do not live in
+    /// the AST body structure (such as comments).
+    fn lint_source(
+        &self,
+        source: &str,
+        module_idx: u32,
+        source_module: Option<&str>,
+        levels: &LintLevels,
+        out: &mut Vec<TypeError>,
+    ) {
+        let ctx = lints::LintCtx {
+            subst: &self.subst,
+            expr_types: &self.expr_types,
+            module_idx,
+            source_module,
+            source: Some(source),
+        };
+        lints::lint_source(&ctx, levels, source, out);
     }
 
     /// Lint every body carried by a single top-level item (mirrors

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -1405,6 +1405,20 @@ fn check_with_lint_level(source: &str, id: LintId, level: LintLevel) -> TypeChec
     checker.check_program(&parsed.program)
 }
 
+fn check_with_lint_defaults(source: &str) -> TypeCheckOutput {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "fixture should parse cleanly: {:?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let mut sources = LintSources::new();
+    sources.set_root(source.to_string());
+    checker.set_lint_sources(sources);
+    checker.check_program(&parsed.program)
+}
+
 // ---- redundant_else_after_return ----
 
 fn count_redundant_else(diags: &[TypeError]) -> usize {
@@ -4010,6 +4024,183 @@ fn sleep_loop_blocks_mailbox_deny_routes_to_errors() {
         out.errors
     );
     assert_eq!(count_sleep_loop_blocks_mailbox(&out.warnings), 0);
+}
+
+// -----------------------------------------------------------------------
+// comment-side Trojan-Source lints
+// -----------------------------------------------------------------------
+
+fn count_text_direction_codepoint(diags: &[TypeError]) -> usize {
+    diags
+        .iter()
+        .filter(|d| d.kind == TypeErrorKind::Lint(LintId::TextDirectionCodepointInComment))
+        .count()
+}
+
+fn count_invisible_codepoint(diags: &[TypeError]) -> usize {
+    diags
+        .iter()
+        .filter(|d| d.kind == TypeErrorKind::Lint(LintId::InvisibleCodepointInComment))
+        .count()
+}
+
+#[test]
+fn text_direction_codepoint_flags_line_comment_by_default_as_error() {
+    let out = check_with_lint_defaults("// \u{202E}\nfn main() {}\n");
+    let hit = out
+        .errors
+        .iter()
+        .find(|e| e.kind == TypeErrorKind::Lint(LintId::TextDirectionCodepointInComment))
+        .expect("RLO in a line comment must be denied by default");
+    assert_eq!(hit.severity, crate::error::Severity::Error);
+    assert_eq!(count_text_direction_codepoint(&out.warnings), 0);
+}
+
+#[test]
+fn text_direction_codepoint_flags_outer_doc_comment() {
+    let out = check_with_lint_defaults("/// \u{202E}\nfn main() {}\n");
+    assert_eq!(
+        count_text_direction_codepoint(&out.errors),
+        1,
+        "outer doc comments are source comments for this lint: {:?}",
+        out.errors
+    );
+}
+
+#[test]
+fn text_direction_codepoint_flags_inner_doc_comment() {
+    let out = check_with_lint_defaults("//! \u{202E}\nfn main() {}\n");
+    assert_eq!(
+        count_text_direction_codepoint(&out.errors),
+        1,
+        "inner doc comments are source comments for this lint: {:?}",
+        out.errors
+    );
+}
+
+#[test]
+fn text_direction_codepoint_flags_nested_block_comment() {
+    let out = check_with_lint_defaults("/* outer /* inner \u{2066} */ done */\nfn main() {}\n");
+    assert_eq!(
+        count_text_direction_codepoint(&out.errors),
+        1,
+        "nested block comments must be scanned once: {:?}",
+        out.errors
+    );
+}
+
+#[test]
+fn invisible_codepoint_flags_zero_width_space_without_bidi_duplication() {
+    let out = check_with_lint_defaults("// hidden\u{200B}gap\nfn main() {}\n");
+    assert_eq!(
+        count_invisible_codepoint(&out.warnings),
+        1,
+        "zero-width space should warn: {:?}",
+        out.warnings
+    );
+    assert_eq!(count_invisible_codepoint(&out.errors), 0);
+    assert_eq!(count_text_direction_codepoint(&out.errors), 0);
+    assert_eq!(count_text_direction_codepoint(&out.warnings), 0);
+}
+
+#[test]
+fn comment_lints_allow_readable_non_ascii_prose() {
+    let out = check_with_lint_defaults(
+        "// café — déjà vu, naïve façade\n// 世界 😀 → value\nfn main() {}\n",
+    );
+    assert_eq!(count_text_direction_codepoint(&out.errors), 0);
+    assert_eq!(count_text_direction_codepoint(&out.warnings), 0);
+    assert_eq!(count_invisible_codepoint(&out.errors), 0);
+    assert_eq!(count_invisible_codepoint(&out.warnings), 0);
+}
+
+#[test]
+fn comment_lints_do_not_scan_literal_content() {
+    // Issue #2109 scopes this lint to comments; literal output escaping is owned
+    // by the formatter, so raw literal content is a boundary case here.
+    let out = check_with_lint_defaults(
+        "fn main() {\n    let _url = \"http://example.com\";\n    let _s = \"\u{202E}\";\n}\n",
+    );
+    assert_eq!(count_text_direction_codepoint(&out.errors), 0);
+    assert_eq!(count_text_direction_codepoint(&out.warnings), 0);
+    assert_eq!(count_invisible_codepoint(&out.errors), 0);
+    assert_eq!(count_invisible_codepoint(&out.warnings), 0);
+}
+
+#[test]
+fn source_comment_scan_runs_once_per_module() {
+    let out = check_with_lint_defaults(
+        "// top \u{202E}\nfn a() {}\nfn b() {}\nfn main() { a(); b(); }\n",
+    );
+    assert_eq!(
+        count_text_direction_codepoint(&out.errors),
+        1,
+        "a top-of-file comment must not be re-scanned for each item: {:?}",
+        out.errors
+    );
+}
+
+#[test]
+fn text_direction_codepoint_suppressed_by_directive_above_comment() {
+    let out = check_with_lint_defaults(
+        "// hew:allow(text_direction_codepoint_in_comment)\n// \u{202E}\nfn main() {}\n",
+    );
+    assert_eq!(count_text_direction_codepoint(&out.errors), 0);
+    assert_eq!(count_text_direction_codepoint(&out.warnings), 0);
+}
+
+#[test]
+fn text_direction_codepoint_warn_level_routes_to_warnings() {
+    let out = check_with_lint_level(
+        "// \u{202E}\nfn main() {}\n",
+        LintId::TextDirectionCodepointInComment,
+        LintLevel::Warn,
+    );
+    assert_eq!(count_text_direction_codepoint(&out.errors), 0);
+    assert_eq!(
+        count_text_direction_codepoint(&out.warnings),
+        1,
+        "explicit warn should downgrade the deny-default lint: {:?}",
+        out.warnings
+    );
+}
+
+#[test]
+fn text_direction_codepoint_allow_level_suppresses() {
+    let out = check_with_lint_level(
+        "// \u{202E}\nfn main() {}\n",
+        LintId::TextDirectionCodepointInComment,
+        LintLevel::Allow,
+    );
+    assert_eq!(count_text_direction_codepoint(&out.errors), 0);
+    assert_eq!(count_text_direction_codepoint(&out.warnings), 0);
+}
+
+#[test]
+fn invisible_codepoint_deny_level_routes_to_errors() {
+    let out = check_with_lint_level(
+        "// hidden\u{FE0F}\nfn main() {}\n",
+        LintId::InvisibleCodepointInComment,
+        LintLevel::Deny,
+    );
+    assert_eq!(
+        count_invisible_codepoint(&out.errors),
+        1,
+        "explicit deny should promote the invisible-codepoint lint: {:?}",
+        out.errors
+    );
+    assert_eq!(count_invisible_codepoint(&out.warnings), 0);
+}
+
+#[test]
+fn invisible_codepoint_allow_level_suppresses() {
+    let out = check_with_lint_level(
+        "// hidden\u{FE0F}\nfn main() {}\n",
+        LintId::InvisibleCodepointInComment,
+        LintLevel::Allow,
+    );
+    assert_eq!(count_invisible_codepoint(&out.errors), 0);
+    assert_eq!(count_invisible_codepoint(&out.warnings), 0);
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Hew now flags invisible and bidirectional-override Unicode hidden in comments — the CVE-2021-42574 Trojan-Source class. `text_direction_codepoint_in_comment` denies the nine UAX #9 explicit directional-formatting controls (LRE/RLE/PDF/LRO/RLO, LRI/RLI/FSI/PDI) by default, matching rustc's own deny set for the same attack. A second, warn-tier lint (`invisible_codepoint_in_comment`) flags other non-printable non-ASCII codepoints — zero-width characters, default-ignorables — without double-firing on the same character as the deny tier. Both run across all four comment forms (`//`, `///`, `//!`, `/* */`), re-level through the existing `--allow`/`--warn`/`--deny` and `hew:allow(...)` suppression infrastructure, and now surface through the LSP as editor diagnostics — `analyze_document` previously never installed lint sources, so no HIR lint reached the editor; that gap is closed here.

`hew-parser/src/fmt.rs` exposes its existing comment-scanning and printable-non-ASCII classifier so the lint reuses the same logic the formatter already applies to literal escaping. The widened API is additive: the sole in-crate caller (`format_source`) keeps discarding doc comments as before, so `hew fmt` output is byte-for-byte unchanged.

## Verification

- `cargo test -p hew-types --lib check::tests::lints`: 13 new tests (202 total in the module) — all four comment forms, deny/warn tier boundaries, `--allow`/`--warn`/`--deny` re-leveling, in-source suppression under the deny default, once-per-module dedup, a clean-non-ASCII negative, and a literal-boundary negative (a BiDi override inside a string literal produces zero findings — literal escaping is the formatter's job, not this lint's).
- `cargo test -p hew-lsp --lib`: 276 passed, 0 failed, 2 ignored, including both new `analyze_document` tests pinning the editor diagnostic and its suppression.
- `cargo test -p hew-cli --test lint_pass_e2e`: exercises the `errors → non-zero exit` path end to end.
- No tracked `.hew` file (stdlib, examples, tutorials) contains a BiDi control or default-ignorable codepoint, so the new deny-by-default lint doesn't newly break the existing corpus.
- Full `make ci-preflight` (comprehensive lane — lint, fmt, the compiled `.hew` corpus, fuzz-oracle, sandbox parity, checked-MIR verification, and the rest) green.

## Out of scope

- Renderer-level confusable-glyph detection (visually similar but distinct codepoints) — a separate follow-up from the comment/BiDi defense this issue asks for.

Fixes #2109