### PR TITLE
refactor(parser): make #[wire] type declarations authoritative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1173,7 +1173,7 @@ grammar: $(GRAMMAR) $(HEW_FILES)
 	@echo "==> Generating ANTLR4 parser"
 	@rm -rf $(GRAMMAR_OUT)
 	@cp $(GRAMMAR) .tmp/Hew.g4
-	$(JAVA) -jar $(ANTLR4_JAR) -Dlanguage=Java -o $(GRAMMAR_OUT) .tmp/Hew.g4
+	$(JAVA) -jar $(ANTLR4_JAR) -Dlanguage=Java -Xexact-output-dir -o $(GRAMMAR_OUT) .tmp/Hew.g4
 	@echo "==> Compiling grammar test parser"
 	$(JAVAC) -cp $(ANTLR4_JAR) $(GRAMMAR_OUT)/*.java
 	@echo "==> Parsing example files"

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -18,7 +18,7 @@ runtime.
 Hew tracks **two version axes** that move independently:
 
 - **Compiler version** is SemVer on the binary (`hew --version` → `hew
-0.5.x`). Patch releases for soundness and codegen fixes; minor releases
+  0.5.x`). Patch releases for soundness and codegen fixes; minor releases
   for new stdlib surfaces and new language editions; the major release is
   the v1.0 stability event.
 - **Spec edition** is a year-shaped identifier declared once per package in
@@ -197,7 +197,6 @@ actor HealthChecker {
 ```
 
 **Rules:**
-
 - The `#[every]` attribute takes a single duration literal argument (e.g. `5s`, `100ms`, `1m`)
 - Periodic handlers must not have parameters (they receive no message payload)
 - Periodic handlers must not have a return type (fire-and-forget)
@@ -357,7 +356,7 @@ let r?: T = expr;       ≡  let r: T = expr?;
 - The enclosing function must return `Result<_, E>` or `Option<_>` with a
   compatible error type. If it does not, the checker reports the same
   "`?` cannot be used in a function returning …`" diagnostic as for bare `?`.
-- The type annotation `T` in `let r?: T = expr` describes the _unwrapped_
+- The type annotation `T` in `let r?: T = expr` describes the *unwrapped*
   Ok-payload (type of `r` after propagation), not the Result itself — the
   same convention as `let r: T = expr?;`.
 
@@ -419,34 +418,34 @@ The compiler automatically determines `Send` and `Frozen` for user-defined types
 
 **Send derivation:**
 
-| Type                                             | `Send` if...                                                                                              |
-| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| Value types (i32, f64, bool, char, isize, usize) | Always `Send`                                                                                             |
-| `string`                                         | Always `Send` (immutable-shareable owned type; alias-shared by refcount retain on send — not deep-copied) |
-| `LocalPid<A>`                                    | Always `Send`                                                                                             |
-| `type S { f1: T1; f2: T2; ... }`                 | All fields are `Send`                                                                                     |
-| `enum E { V1(T1), V2(T2), ... }`                 | All variant payloads are `Send`                                                                           |
-| `Vec<T>`                                         | `T` is `Send`                                                                                             |
-| `HashMap<K, V>`                                  | `K` and `V` are both `Send`                                                                               |
-| `Option<T>`                                      | `T` is `Send`                                                                                             |
-| `Result<T, E>`                                   | `T` and `E` are both `Send`                                                                               |
-| `(T1, T2, ...)`                                  | All elements are `Send`                                                                                   |
-| `[T; N]`                                         | `T` is `Send`                                                                                             |
+| Type                               | `Send` if...                               |
+| ---------------------------------- | ------------------------------------------ |
+| Value types (i32, f64, bool, char, isize, usize) | Always `Send`                |
+| `string`                           | Always `Send` (immutable-shareable owned type; alias-shared by refcount retain on send — not deep-copied) |
+| `LocalPid<A>`                      | Always `Send`                              |
+| `type S { f1: T1; f2: T2; ... }`   | All fields are `Send`                      |
+| `enum E { V1(T1), V2(T2), ... }`   | All variant payloads are `Send`            |
+| `Vec<T>`                           | `T` is `Send`                              |
+| `HashMap<K, V>`                    | `K` and `V` are both `Send`                |
+| `Option<T>`                        | `T` is `Send`                              |
+| `Result<T, E>`                     | `T` and `E` are both `Send`                |
+| `(T1, T2, ...)`                    | All elements are `Send`                    |
+| `[T; N]`                           | `T` is `Send`                              |
 
 > **Note on array annotations:** Only fixed-size array annotations `[T; N]` are supported. Slice annotations `[T]` (unsized) are rejected by the type checker; unsized-slice lowering is not implemented. Use `Vec<T>` for dynamically-sized sequences.
 
 **Frozen derivation:**
 
-| Type                                          | `Frozen` if...                                                     |
-| --------------------------------------------- | ------------------------------------------------------------------ |
-| Value types                                   | Always `Frozen`                                                    |
-| `string`                                      | NOT `Frozen` (mutable content)                                     |
-| `LocalPid<A>`                                 | Always `Frozen` (identity reference only)                          |
-| `type S` where all field types are `Frozen`   | `Frozen` (recursive over field types)                              |
-| `type S` where any field type is not `Frozen` | NOT `Frozen`                                                       |
-| `enum E`                                      | All variant payloads are `Frozen`                                  |
-| `Arc<T>`                                      | _Not currently surfaced in Hew source; runtime-only support today_ |
-| `Vec<T>`, `HashMap<K,V>`                      | NOT `Frozen` (mutable containers)                                  |
+| Type                          | `Frozen` if...                            |
+| ----------------------------- | ----------------------------------------- |
+| Value types                   | Always `Frozen`                           |
+| `string`                      | NOT `Frozen` (mutable content)            |
+| `LocalPid<A>`                 | Always `Frozen` (identity reference only) |
+| `type S` where all field types are `Frozen` | `Frozen` (recursive over field types) |
+| `type S` where any field type is not `Frozen` | NOT `Frozen`                        |
+| `enum E`                      | All variant payloads are `Frozen`         |
+| `Arc<T>`                      | _Not currently surfaced in Hew source; runtime-only support today_ |
+| `Vec<T>`, `HashMap<K,V>`      | NOT `Frozen` (mutable containers)         |
 
 > **Soundness requirement:** The compiler MUST reject as non-`Send` any type whose `Send` status cannot be determined (e.g., opaque foreign types). Foreign types are non-`Send` by default. The runtime/ABI has internal escape hatches, but there is currently **no surfaced Hew `#[send]` attribute** for user code.
 
@@ -834,7 +833,7 @@ This provides clean, namespaced access to stdlib functionality. The module name 
 | `std::net`         | `net.listen`, `net.accept`, `net.connect`, `net.read`, `net.write`, `net.close`                                                                              |
 | `std::text::regex` | `regex.new`, `regex.is_match`, `regex.find`, `regex.replace`                                                                                                 |
 | `std::net::mime`   | `mime.from_path`, `mime.from_ext`, `mime.is_text`                                                                                                            |
-| `std::process`     | `process.run`, `process.try_run`, `process.run_argv`, `process.try_run_argv`, `process.start`                                                                |
+| `std::process`     | `process.run`, `process.try_run`, `process.run_argv`, `process.try_run_argv`, `process.start`                                                               |
 
 Predicate functions (`fs.exists`, `path.exists`, `regex.is_match`, `os.has_env`, `mime.is_text`) return `bool`.
 
@@ -842,17 +841,17 @@ Predicate functions (`fs.exists`, `path.exists`, `regex.is_match`, `os.has_env`,
 
 Three-tier model — written as a prefix keyword before the item keyword:
 
-| Syntax             | Meaning                                   |
-| ------------------ | ----------------------------------------- |
-| `fn foo()`         | Private — visible only within this module |
-| `package fn foo()` | Package — visible within the same package |
-| `pub fn foo()`     | Public — visible to all modules           |
+| Syntax              | Meaning                                    |
+|---------------------|--------------------------------------------|
+| `fn foo()`          | Private — visible only within this module  |
+| `package fn foo()`  | Package — visible within the same package  |
+| `pub fn foo()`      | Public — visible to all modules            |
 
 The same prefix applies to any item kind: `package type`, `package const`, `package actor`, etc.
 
 > **Implementation note:** `package` visibility is accepted and parsed correctly.
 > Enforcement of the package boundary (rejecting callers outside the package) is
-> planned for a future edition. Code written with `package` visibility today will
+> planned for a future edition.  Code written with `package` visibility today will
 > keep compiling after the restriction is applied, because callers within the
 > package are unaffected.
 
@@ -1227,11 +1226,11 @@ Hew guarantees no GC pauses. Memory reclamation is entirely deterministic:
 
 At the **language level**, `send()` **moves** the value — the sender loses access and cannot use it after sending (see §3.4.4). At the **runtime level**, the send mechanism is **gated** on the value's admissibility class (D355):
 
-| Admissibility class                                | Runtime mechanism                                                | Examples                               |
-| -------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------- |
-| **Immutable-shareable** (`is_immutable_shareable`) | **Alias-shared by refcount retain** — no byte copy               | `string`, `bytes`                      |
-| **Mutable owned collections**                      | **Deep-copied** into the receiver's per-actor heap               | `Vec<T>`, `HashMap<K,V>`, `HashSet<T>` |
-| **Consumed-linear (`iso`/Linear)**                 | Zero-copy **ownership move** (P6 — not surfaced in edition 2026) | —                                      |
+| Admissibility class | Runtime mechanism | Examples |
+| ------------------- | ----------------- | -------- |
+| **Immutable-shareable** (`is_immutable_shareable`) | **Alias-shared by refcount retain** — no byte copy | `string`, `bytes` |
+| **Mutable owned collections** | **Deep-copied** into the receiver's per-actor heap | `Vec<T>`, `HashMap<K,V>`, `HashSet<T>` |
+| **Consumed-linear (`iso`/Linear)** | Zero-copy **ownership move** (P6 — not surfaced in edition 2026) | — |
 
 The gate is `is_immutable_shareable || consumed-Linear || deep-copy`. Bare `copy` does **not** imply sendability (`copy ⊥ sendable`, B-INV-3). `View`/borrow (`&T`) is rejected across actor boundaries and is not `Send`.
 
@@ -1496,7 +1495,6 @@ Typical example — file I/O with implicit cleanup (illustrative; no `File` type
 exists in stdlib — for file reading use `fs::try_read`):
 
 <!-- doctest: skip -->
-
 ```hew
 fn read_config(path: string) -> Result<Config, IoError> {
     let f = File::open(path)?;
@@ -1509,7 +1507,6 @@ fn read_config(path: string) -> Result<Config, IoError> {
 Early close, surfacing the I/O error to the caller (illustrative):
 
 <!-- doctest: skip -->
-
 ```hew
 fn read_and_process(path: string) -> Result<Summary, AppError> {
     let f = File::open(path)?;
@@ -1553,7 +1550,6 @@ A correct use (illustrative — `Database` and `Transaction` are hypothetical ty
 showing the `#[linear]` pattern; `&Database` uses reference syntax not in Hew):
 
 <!-- doctest: skip -->
-
 ```hew
 fn transfer(db: &Database, from: AccountId, to: AccountId, amount: Money)
     -> Result<(), DbError>
@@ -1568,7 +1564,6 @@ fn transfer(db: &Database, from: AccountId, to: AccountId, amount: Money)
 The compile error for forgetting to consume (illustrative):
 
 <!-- doctest: skip -->
-
 ```hew
 fn forgot_to_commit(db: &Database) -> Result<(), DbError> {
     let tx = db.begin_transaction()?;
@@ -1581,12 +1576,12 @@ fn forgot_to_commit(db: &Database) -> Result<(), DbError> {
 
 ##### 3.7.8.3 Choosing between `#[resource]` and `#[linear]`
 
-| Question                                                               | Pick          |
-| ---------------------------------------------------------------------- | ------------- |
-| Is "close and discard the error" a sensible default at scope exit?     | `#[resource]` |
-| Must the caller surface the cleanup result, every time?                | `#[linear]`   |
+| Question                                                          | Pick           |
+| ----------------------------------------------------------------- | -------------- |
+| Is "close and discard the error" a sensible default at scope exit? | `#[resource]` |
+| Must the caller surface the cleanup result, every time?            | `#[linear]`   |
 | Are there multiple distinct ways to consume (commit / rollback / ...)? | `#[linear]`   |
-| Is there exactly one cleanup action, and is it idempotent?             | `#[resource]` |
+| Is there exactly one cleanup action, and is it idempotent?         | `#[resource]` |
 
 File descriptors, sockets, allocator handles, regex compiled patterns,
 HTTP server/request handles — `#[resource]`. Database transactions,
@@ -1630,7 +1625,7 @@ hooks, or the supervised shutdown handler):
 
 **Path 3 — Supervised actor crash (handler trap that bypasses the
 terminating handler).** A trap raised by any handler restarts the
-actor under the supervisor's policy. The terminating handler is _not_
+actor under the supervisor's policy. The terminating handler is *not*
 guaranteed to run on this path; only heap teardown is:
 
 - `#[resource]` fields: implicit `close()` runs as part of heap teardown
@@ -1638,7 +1633,7 @@ guaranteed to run on this path; only heap teardown is:
 - `#[linear]` fields: a crash bypasses the consume path the move-checker
   relied on in Path 2. Edition 2026 resolves this conservatively: a
   `#[linear]` field is admitted on an actor only when the field's type
-  _also_ satisfies `#[resource]` semantics, so heap teardown invokes the
+  *also* satisfies `#[resource]` semantics, so heap teardown invokes the
   implicit drop on the crash path. A bare `#[linear]` field whose consume
   path can be bypassed by a supervised restart is a compile error at
   actor-declaration time. A future edition may relax this with an
@@ -2020,7 +2015,6 @@ Hew provides FFI capabilities for interoperating with C libraries and system cal
 External C functions are declared in `extern` blocks:
 
 <!-- doctest: skip -->
-
 ```hew
 extern "C" {
     fn malloc(size: usize) -> *mut u8;
@@ -2047,7 +2041,6 @@ extern "C" {
 Use `#[repr(C)]` to ensure C-compatible memory layout:
 
 <!-- doctest: skip -->
-
 ```hew
 #[repr(C)]
 type Point {
@@ -2120,7 +2113,6 @@ extern "C" fn my_callback(value: i32) -> i32 {
 **All FFI calls are `unsafe`:**
 
 <!-- doctest: skip -->
-
 ```hew
 fn allocate_buffer(size: usize) -> *mut u8 {
     unsafe {
@@ -2149,7 +2141,6 @@ fn safe_read(fd: i32, buf: *mut u8, count: usize) -> Result<usize, string> {
 **Safe wrapper pattern:**
 
 <!-- doctest: skip -->
-
 ```hew
 // Raw FFI (internal, unsafe)
 extern "C" {
@@ -2318,7 +2309,7 @@ regardless of the ABI key/value check; this is structural, not just a direct
 `Rc<T>` ban.
 
 **Map literal syntax** — a `HashMap<K, V>` can be constructed inline with
-brace-colon syntax. The parser disambiguates `{` as a map literal when the
+brace-colon syntax.  The parser disambiguates `{` as a map literal when the
 first token after `{` is a `StringLit` followed by `:`:
 
 ```hew
@@ -2351,15 +2342,15 @@ Rules:
 
 Available `HashMap` methods:
 
-| Method                 | Returns        | Description                   |
-| ---------------------- | -------------- | ----------------------------- |
-| `HashMap::new()`       | `HashMap<K,V>` | Create empty map              |
-| `m.get(key)`           | `Option<V>`    | Look up a key                 |
-| `m.insert(key, value)` | `()`           | Insert or overwrite           |
-| `m.remove(key)`        | `bool`         | Remove a key; true if present |
-| `m.contains_key(key)`  | `bool`         | Test membership               |
-| `m.len()`              | `i64`          | Number of entries             |
-| `m.is_empty()`         | `bool`         | True if no entries            |
+| Method                    | Returns         | Description                      |
+| ------------------------- | --------------- | -------------------------------- |
+| `HashMap::new()`          | `HashMap<K,V>`  | Create empty map                 |
+| `m.get(key)`              | `Option<V>`     | Look up a key                    |
+| `m.insert(key, value)`    | `()`            | Insert or overwrite              |
+| `m.remove(key)`           | `bool`          | Remove a key; true if present    |
+| `m.contains_key(key)`     | `bool`          | Test membership                  |
+| `m.len()`                 | `i64`           | Number of entries                |
+| `m.is_empty()`            | `bool`          | True if no entries               |
 
 #### 3.10.4 Collections, I/O, and Utility Modules
 
@@ -2450,13 +2441,13 @@ to release the underlying resource. Dropping without `close()` is a
 resource leak; the compiler does not synthesise an implicit drop for
 these types in the current implementation.
 
-| Type             | Created by                                 | Methods                                                                                                                                                                |
-| ---------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `http.Server`    | `http.listen(addr)`                        | `.accept()` → `http.Request`, `.close()`                                                                                                                               |
-| `http.Request`   | `server.accept()` or `http.accept(server)` | `.path`, `.method`, `.body`, `.header(name)`, `.respond(status, body, len, type)`, `.respond_text(status, body)`, `.respond_json(status, body)`, `.close()`            |
-| `net.Listener`   | `net.listen(addr)`                         | `.accept()` → `net.Connection`, `await ln.accept() \| after d` → `Result<net.Connection, IoError>`, `.close()`                                                         |
+| Type             | Created by                                 | Methods                                                                                                                              |
+| ---------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `http.Server`    | `http.listen(addr)`                        | `.accept()` → `http.Request`, `.close()`                                                                                              |
+| `http.Request`   | `server.accept()` or `http.accept(server)` | `.path`, `.method`, `.body`, `.header(name)`, `.respond(status, body, len, type)`, `.respond_text(status, body)`, `.respond_json(status, body)`, `.close()` |
+| `net.Listener`   | `net.listen(addr)`                         | `.accept()` → `net.Connection`, `await ln.accept() \| after d` → `Result<net.Connection, IoError>`, `.close()`                        |
 | `net.Connection` | `listener.accept()` or `net.connect(addr)` | `.read()` → `bytes`, `.read_string()` → `string`, `await conn.read_string() \| after d` → `Result<string, IoError>`, `.write(data)`, `.write_string(data)`, `.close()` |
-| `process.Child`  | `process.start(cmd)`                       | `.wait()`, `.kill()`                                                                                                                                                   |
+| `process.Child`  | `process.start(cmd)`                       | `.wait()`, `.kill()`                                                                                                                  |
 
 Handle types are opaque — their internal representation is not accessible.
 They can be stored in variables, passed as function arguments, and
@@ -2481,8 +2472,8 @@ returned from functions.
 
 A `machine` is a **value type** that defines a closed set of named states, a
 closed set of named events, and transition rules mapping `(State, Event)` pairs
-to new states. It compiles to a tagged union with a compiler-generated
-`step()` method. Machines are not actors — they are pure data, like enums
+to new states.  It compiles to a tagged union with a compiler-generated
+`step()` method.  Machines are not actors — they are pure data, like enums
 with per-state fields and compiler-checked transition logic.
 
 > **Detailed specification:** See [`docs/specs/MACHINE-SPEC.md`](MACHINE-SPEC.md)
@@ -2575,12 +2566,12 @@ EmitExpr = "emit" Ident ( "{" FieldInitList "}" )? ;
 ```
 
 > **Depth > 1 nesting is reserved** — a substate body may not itself contain
-> substates. Depth-1 composite state blocks are supported; deeper nesting
+> substates.  Depth-1 composite state blocks are supported; deeper nesting
 > (`depth > 1`) is a parse error: `nested composite states (depth > 1) are reserved`.
 
 **Visualisation:** `hew machine diagram <file.hew>` renders any
 `machine` declaration as a Mermaid state diagram, Graphviz DOT, or JSON
-schema. The command runs all HIR static checks before rendering, so it
+schema.  The command runs all HIR static checks before rendering, so it
 doubles as a structural validator.
 
 ```
@@ -2593,40 +2584,40 @@ hew machine diagram traffic_light.hew --no-check        # skip HIR checks
 
 ### 3.11.2 Constraints
 
-| Constraint                                                                     | Checked at | Error if violated                                            |
-| ------------------------------------------------------------------------------ | ---------- | ------------------------------------------------------------ |
-| At least two states                                                            | Types/HIR  | `machine_one_state` negative test                            |
-| At least one event                                                             | Types/HIR  | `machine_no_events` negative test                            |
-| No `state` nesting deeper than depth 1; depth-1 composite states are supported | Parse      | diagnostic: nested composite states (depth > 1) are reserved |
-| No duplicate explicit transition per (S, E)                                    | Parse/HIR  | `machine_dup_transition` negative test                       |
-| No duplicate wildcard for same event                                           | Parse/HIR  | `machine_dup_wildcard` negative test                         |
-| All referenced states/events must be declared                                  | HIR        | `machine_unknown_state/event` negative tests                 |
-| All (S, E) pairs covered (exhaustiveness)                                      | HIR        | `MachineExhaustivenessViolation` diagnostic                  |
-| Effect parity: transition body writes ≡ entry writes                           | HIR        | `MachineEffectParityViolation` diagnostic                    |
-| No direct self-emit (`emit E` in transition for event E)                       | HIR        | `MachineEmitCycle` diagnostic                                |
+| Constraint                                  | Checked at  | Error if violated                             |
+| ------------------------------------------- | ----------- | --------------------------------------------- |
+| At least two states                         | Types/HIR   | `machine_one_state` negative test             |
+| At least one event                          | Types/HIR   | `machine_no_events` negative test             |
+| No `state` nesting deeper than depth 1; depth-1 composite states are supported | Parse | diagnostic: nested composite states (depth > 1) are reserved |
+| No duplicate explicit transition per (S, E) | Parse/HIR   | `machine_dup_transition` negative test        |
+| No duplicate wildcard for same event        | Parse/HIR   | `machine_dup_wildcard` negative test          |
+| All referenced states/events must be declared | HIR       | `machine_unknown_state/event` negative tests  |
+| All (S, E) pairs covered (exhaustiveness)   | HIR         | `MachineExhaustivenessViolation` diagnostic   |
+| Effect parity: transition body writes ≡ entry writes | HIR  | `MachineEffectParityViolation` diagnostic     |
+| No direct self-emit (`emit E` in transition for event E) | HIR | `MachineEmitCycle` diagnostic          |
 
 Exhaustiveness can be satisfied by: explicit `on` rules, wildcard (`_`-source)
-rules, or a `default` handler. A `default` handler alone covers all pairs that
+rules, or a `default` handler.  A `default` handler alone covers all pairs that
 have no other matching rule.
 
 **Effect parity:** when a transition body writes a state field (via
 `self.field = …`) and the target state's `entry` block also writes that same
-field, the compiler emits a `MachineEffectParityViolation` diagnostic. This
+field, the compiler emits a `MachineEffectParityViolation` diagnostic.  This
 prevents silent shadowing between transition-side and entry-side field
 initialisation.
 
 **Emit-cycle detection:** a transition handling event `E` may not directly
-`emit E` — that would form an immediate re-entry cycle. Indirect cycles
+`emit E` — that would form an immediate re-entry cycle.  Indirect cycles
 (A emits B, B emits A) are not checked.
 
 ### 3.11.3 Transition Bodies
 
 Inside a transition body the compiler binds two implicit names:
 
-| Binding | Type              | Meaning                                       |
-| ------- | ----------------- | --------------------------------------------- |
-| `state` | source state type | Fields of the current (source) state          |
-| `event` | event payload     | Payload fields of the incoming event (if any) |
+| Binding     | Type              | Meaning                                         |
+| ----------- | ----------------- | ----------------------------------------------- |
+| `state`     | source state type | Fields of the current (source) state            |
+| `event`     | event payload     | Payload fields of the incoming event (if any)   |
 
 ```hew
 machine Elevator {
@@ -2675,15 +2666,15 @@ on Request: Allowing => Allowing when state.tokens > 1 {
 on Request: Allowing => Throttled when state.tokens <= 1;
 ```
 
-Guards are evaluated in declaration order. The first transition whose event
-and source-state match _and_ whose guard (if present) evaluates to `true` fires.
+Guards are evaluated in declaration order.  The first transition whose event
+and source-state match *and* whose guard (if present) evaluates to `true` fires.
 If no guarded transition matches, evaluation falls through to wildcard rules and
 then to `default`.
 
 ### 3.11.5 Wildcard Transitions and Priority
 
-`_` in the source position matches any state. `_` in the target position means
-"return a value of the machine type" (any variant, not a specific one). The
+`_` in the source position matches any state.  `_` in the target position means
+"return a value of the machine type" (any variant, not a specific one).  The
 conventional identity pattern `on E: _ => _ { state }` keeps the current state
 unchanged.
 
@@ -2699,14 +2690,14 @@ Specific transitions always win over wildcards for the same event.
 
 The compiler generates the following for every `machine Name { ... }`:
 
-| Generated item        | Usage / behaviour                                                |
-| --------------------- | ---------------------------------------------------------------- |
-| State constructors    | `Name::State` (unit) or `Name::State { field: val }` (with data) |
-| Companion event enum  | `NameEvent` with variants matching each `event` declaration      |
-| Event constructors    | `NameEvent::EventName` (unit) or `NameEvent::EventName { f: v }` |
-| `m.step(event)`       | Mutates `m` in place; returns `()` — no return value             |
-| `m.state_name()`      | Returns the current state name as `string`                       |
-| Pattern-match support | Machine values can be matched exactly like enum values           |
+| Generated item              | Usage / behaviour                                                  |
+| ----------------------------| ------------------------------------------------------------------ |
+| State constructors          | `Name::State` (unit) or `Name::State { field: val }` (with data)  |
+| Companion event enum        | `NameEvent` with variants matching each `event` declaration        |
+| Event constructors          | `NameEvent::EventName` (unit) or `NameEvent::EventName { f: v }`  |
+| `m.step(event)`             | Mutates `m` in place; returns `()` — no return value              |
+| `m.state_name()`            | Returns the current state name as `string`                        |
+| Pattern-match support       | Machine values can be matched exactly like enum values             |
 
 **Calling `step()`** — both unqualified and qualified event constructors are
 accepted:
@@ -2929,7 +2920,7 @@ safepoint before its body reaches a consuming or close call.
    normal completion, recoverable `Err(E)`, trap, or cancellation. The
    declared `close(consuming self) -> Result<(), E>` is invoked through
    the child's stack-unwind path (§4.5), and its returned error is
-   discarded per the §3.4 `@resource` semantics. This is the _same_
+   discarded per the §3.4 `@resource` semantics. This is the *same*
    discipline a `@resource` would receive in a non-task context; the
    child's cancellation safepoint is simply one more exit through which
    stack unwinding runs cleanup.
@@ -2948,7 +2939,7 @@ safepoint before its body reaches a consuming or close call.
    The conservative rule keeps the language honest in edition 2026:
    without cancellation tokens, the programmer has no way to consume a
    `@linear` value along the cancellation path, so the only safe shape
-   is for the child's _only_ exits-to-completion to be ones the
+   is for the child's *only* exits-to-completion to be ones the
    compiler can prove consume the value. Relaxation is tracked in
    HEW-FUTURE.md §1.2 alongside the broader cancellation-token
    vocabulary.
@@ -2964,7 +2955,7 @@ safepoint before its body reaches a consuming or close call.
    names the mutable borrow site and points at the fork child.
 
 4. **Task<T> handle escape.** A `Task<T>` handle bound by `fork name =
-expr` is usable only within the lexical scope-block that introduced
+   expr` is usable only within the lexical scope-block that introduced
    it. The handle cannot be returned from the scope-block, stored in a
    field, captured by a closure that outlives the block, nor moved into
    a sibling child unless that sibling is itself a `fork` form inside
@@ -3019,7 +3010,7 @@ let result = await task;
 | ------------------ | ----------------------------------------------------------- |
 | Completed          | Returns `Ok(value)` immediately                             |
 | Running/Pending    | Suspends current task until completion, returns `Ok(value)` |
-| Cancelled          | Returns `Err(...)`                                          |
+| Cancelled          | Returns `Err(...)`                                         |
 | Trapped            | Propagates the trap to the awaiting task                    |
 
 **Type:**
@@ -3228,7 +3219,6 @@ All IO operations in Hew are explicit and return `Result` types. Use
 handle type — reads and writes are free functions:
 
 <!-- doctest: skip -->
-
 ```hew
 fn read_config(path: string) -> Result<Config, string> {
     let content = fs::try_read(path)?;
@@ -3278,7 +3268,6 @@ reachable from inside a child body.
 > The example below uses an indicative placeholder pending ratification.
 
 <!-- doctest: skip -->
-
 ```hew
 actor DataProcessor {
     var cache: HashMap<string, Data> = HashMap::new();
@@ -3323,15 +3312,15 @@ fn heavy_computation() {
 
 ### 4.9 Summary: Tasks vs Actors
 
-| Aspect        | `fork` child task                                                                     | Actors                           |
-| ------------- | ------------------------------------------------------------------------------------- | -------------------------------- |
-| Communication | Explicit data passing on spawn + `await` for result                                   | Message passing                  |
-| Concurrency   | True parallelism (one OS thread per child)                                            | True parallelism (M:N scheduler) |
-| Isolation     | Complete (no shared mutable state with parent)                                        | Complete (mailbox only)          |
-| Failure       | First error becomes `ScopeError::primary`; siblings cancel                            | Traps isolated to actor          |
-| Lifetime      | Bound to enclosing `scope` block                                                      | Independent                      |
-| Cancellation  | Automatic at safepoints                                                               | Supervisor control               |
-| Scheduling    | OS thread per child (substrate); cooperative coroutines are an internal runtime layer | M:N work-stealing scheduler      |
+| Aspect        | `fork` child task                                   | Actors                           |
+| ------------- | --------------------------------------------------- | -------------------------------- |
+| Communication | Explicit data passing on spawn + `await` for result | Message passing                  |
+| Concurrency   | True parallelism (one OS thread per child)          | True parallelism (M:N scheduler) |
+| Isolation     | Complete (no shared mutable state with parent)      | Complete (mailbox only)          |
+| Failure       | First error becomes `ScopeError::primary`; siblings cancel | Traps isolated to actor   |
+| Lifetime      | Bound to enclosing `scope` block                     | Independent                      |
+| Cancellation  | Automatic at safepoints                             | Supervisor control               |
+| Scheduling    | OS thread per child (substrate); cooperative coroutines are an internal runtime layer | M:N work-stealing scheduler |
 
 **Design rationale:**
 
@@ -3402,17 +3391,17 @@ HIR lowering:
 
 **The three forms (closed set).** Each form is fully specified by four
 columns: what the winning arm binds, how the winning arm propagates a
-non-success outcome at the source, how the runtime cleans up _that_ arm
+non-success outcome at the source, how the runtime cleans up *that* arm
 when a different arm wins (loser cleanup), and how the runtime cleans up
 the arm when the enclosing scope is cancelled while the `select` is still
 pending (outer-cancellation cleanup). Sources are the same in both
 cleanup columns; the difference is which side initiates the teardown.
 
-| Form                                 | Winning bind / type                               | Winning error or trap at the source                                                                                                                                                                                                | Loser cleanup (a different arm won)                                                                                                                                                                                                                                                                                                                        | Outer-cancellation cleanup (enclosing scope cancelled, `select` still pending)                                        |
-| ------------------------------------ | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `<id> from <actor>.<method>(<args>)` | `id: <reply-type>` per ask                        | `AskError` per HEW-DIST-SPEC §6 — `Partition`, `Timeout`, `Cancelled`, `LocalShutdown`, or `OrphanedAsk` as observed by the caller. Traps in the callee are isolated by the mailbox boundary and do not propagate through the ask. | If the envelope has **not yet been dispatched**, withdraw it from the target actor's mailbox by correlation id — no `OrphanedAsk` is observed on either side. If it **has been dispatched**, the reply sink is tombstoned; a late reply arriving at the tombstoned sink is classified as `OrphanedAsk` and discarded silently (no caller-visible failure). | Same as loser cleanup: withdraw-or-tombstone by correlation id, late reply classified as `OrphanedAsk` and discarded. |
-| `<id> from <rx>.recv()`              | `id: Option<T>` for `Receiver<T>`                 | `None` is a normal winning value indicating that the channel is closed; `Some(value)` carries the received item. Channel receive has no separate error surface in edition 2026.                                                    | Pending receive is withdrawn from the channel core; the receiver binding remains usable in the enclosing scope.                                                                                                                                                                                                                                            | Same as loser cleanup: pending receive withdrawn, receiver binding remains usable for the cancellation handler.       |
-| `after <duration>`                   | no binding; arm type is `()`-shaped at the source | None. Timers cannot fail or trap in edition 2026.                                                                                                                                                                                  | The timer is cancelled. No effect propagates.                                                                                                                                                                                                                                                                                                              | The timer is cancelled. No effect propagates.                                                                         |
+| Form                       | Winning bind / type             | Winning error or trap at the source                                                                                                                                                                                       | Loser cleanup (a different arm won)                                                                                                                                                                       | Outer-cancellation cleanup (enclosing scope cancelled, `select` still pending)                                                                              |
+| -------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<id> from <actor>.<method>(<args>)` | `id: <reply-type>` per ask | `AskError` per HEW-DIST-SPEC §6 — `Partition`, `Timeout`, `Cancelled`, `LocalShutdown`, or `OrphanedAsk` as observed by the caller. Traps in the callee are isolated by the mailbox boundary and do not propagate through the ask. | If the envelope has **not yet been dispatched**, withdraw it from the target actor's mailbox by correlation id — no `OrphanedAsk` is observed on either side. If it **has been dispatched**, the reply sink is tombstoned; a late reply arriving at the tombstoned sink is classified as `OrphanedAsk` and discarded silently (no caller-visible failure). | Same as loser cleanup: withdraw-or-tombstone by correlation id, late reply classified as `OrphanedAsk` and discarded.                                       |
+| `<id> from <rx>.recv()`    | `id: Option<T>` for `Receiver<T>` | `None` is a normal winning value indicating that the channel is closed; `Some(value)` carries the received item. Channel receive has no separate error surface in edition 2026.                              | Pending receive is withdrawn from the channel core; the receiver binding remains usable in the enclosing scope.                                                                                         | Same as loser cleanup: pending receive withdrawn, receiver binding remains usable for the cancellation handler.                                             |
+| `after <duration>`         | no binding; arm type is `()`-shaped at the source | None. Timers cannot fail or trap in edition 2026.                                                                                                                                                                          | The timer is cancelled. No effect propagates.                                                                                                                                                            | The timer is cancelled. No effect propagates.                                                                                                              |
 
 **Semantics:**
 
@@ -3429,7 +3418,7 @@ cleanup columns; the difference is which side initiates the teardown.
    asynchronous.
 4. **Same-type arms.** All arm result expressions must have the same
    type `T`. The `select` expression has type `T`. There is no `T =
-Result<U, E>` flattening — if arms return `Result`, the `select`
+   Result<U, E>` flattening — if arms return `Result`, the `select`
    returns `Result`.
 5. **Cancellation propagates outward.** If the enclosing `scope {}` is
    cancelled while a `select` is pending, every arm runs its loser-
@@ -3546,12 +3535,12 @@ Edition 2026 defines the legal compositions of `scope {}` and `select {}`
 explicitly. Anything not listed is rejected by type checking, with the
 diagnostic pointing at the offending position.
 
-| Composition                                               | Legality     | Rationale                                                                                                                                                                                                                                                                                       |
-| --------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `select {}` inside a `scope {}` body or child             | Legal        | The three `select` forms are single-await constructs and compose with the scope block's cancellation discipline at their safepoints.                                                                                                                                                            |
-| `fork name = select { ... }`                              | Legal        | A child task's expression may be a `select` expression; the binding is the `select` expression's result type.                                                                                                                                                                                   |
-| `scope {}` inside a `select` arm's `=>` result expression | Legal        | The arm has already won; its result expression runs in the surrounding scope as ordinary code that happens to contain a scope block.                                                                                                                                                            |
-| `scope { ... }` as a `select` arm source                  | **Rejected** | The three sealed arm sources are exhaustive (§4.11.1). A scope block is a _lexical region_, not a pending operation, and starting one as a `select` competitor would create children whose scope is unclear if the arm loses. Hint: wrap the fork in a child task and `await` the task instead. |
+| Composition                                              | Legality        | Rationale                                                                                                                                                                                          |
+| -------------------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `select {}` inside a `scope {}` body or child             | Legal           | The three `select` forms are single-await constructs and compose with the scope block's cancellation discipline at their safepoints.                                                                |
+| `fork name = select { ... }`                             | Legal           | A child task's expression may be a `select` expression; the binding is the `select` expression's result type.                                                                                      |
+| `scope {}` inside a `select` arm's `=>` result expression | Legal           | The arm has already won; its result expression runs in the surrounding scope as ordinary code that happens to contain a scope block.                                                               |
+| `scope { ... }` as a `select` arm source                  | **Rejected**    | The three sealed arm sources are exhaustive (§4.11.1). A scope block is a *lexical region*, not a pending operation, and starting one as a `select` competitor would create children whose scope is unclear if the arm loses. Hint: wrap the fork in a child task and `await` the task instead. |
 
 **Cancellation propagation across the composition (normative):**
 
@@ -3560,7 +3549,7 @@ diagnostic pointing at the offending position.
   rule (§4.11.1) and the cancellation then propagates through the
   `select` site as if the site were any other safepoint. The `select`
   does not return a value in this case; control unwinds.
-- When a `select` arm wins inside a scope-block body, only the _losing_
+- When a `select` arm wins inside a scope-block body, only the *losing*
   arms run their loser-cleanup. Sibling fork-children are not affected
   by the arm transition; their scope is bound to the enclosing scope
   block, not to the `select` site.
@@ -3646,12 +3635,12 @@ Then:
 
 ### 5.3 Restart Strategies
 
-| Strategy             | Behaviour                                                                                                                                      |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `one_for_one`        | Only the crashed child is restarted.                                                                                                           |
-| `one_for_all`        | All children are stopped and restarted.                                                                                                        |
-| `rest_for_one`       | The crashed child and all children declared after it are restarted.                                                                            |
-| `simple_one_for_one` | A pool-oriented strategy; only the specific crashed `pool` child instance is restarted. Required for supervisors that use `pool` declarations. |
+| Strategy              | Behaviour                                                           |
+| --------------------- | ------------------------------------------------------------------- |
+| `one_for_one`         | Only the crashed child is restarted.                                |
+| `one_for_all`         | All children are stopped and restarted.                             |
+| `rest_for_one`        | The crashed child and all children declared after it are restarted. |
+| `simple_one_for_one`  | A pool-oriented strategy; only the specific crashed `pool` child instance is restarted. Required for supervisors that use `pool` declarations. |
 
 ### 5.4 Restart Budget and Escalation
 
@@ -3898,7 +3887,6 @@ A bidirectional network connection (such as a TCP socket from `std::net`)
 splits into a `(Stream<bytes>, Sink<bytes>)` pair via `.into_stream_sink()`:
 
 <!-- doctest: skip -->
-
 ```hew
 import std::net;
 
@@ -3919,12 +3907,12 @@ First-class `Stream<T>` values from `std::stream` are bounded handles that may
 be moved across actor boundaries. Both are consumed with `for await`, but they
 have different implementations:
 
-|                     | Actor stream (`receive gen fn`) | `std::stream::Stream<T>`                      |
-| ------------------- | ------------------------------- | --------------------------------------------- |
+|                     | Actor stream (`receive gen fn`) | `std::stream::Stream<T>`                   |
+| ------------------- | ------------------------------- | ------------------------------------------ |
 | Created by          | `receive gen fn` call           | `bytes_pipe()`, `pipe()`, `from_file()`, etc. |
-| Backed by           | Actor mailbox protocol          | Bounded channel / wrapper-specific handle     |
-| Passable as value   | No (tied to the spawned actor)  | Yes (move-only, `Send`)                       |
-| Use in actor fields | No                              | Yes                                           |
+| Backed by           | Actor mailbox protocol          | Bounded channel / wrapper-specific handle  |
+| Passable as value   | No (tied to the spawned actor)  | Yes (move-only, `Send`)                    |
+| Use in actor fields | No                              | Yes                                        |
 
 ---
 
@@ -3968,21 +3956,21 @@ Design goals: compact representation, fast encode/decode, language interoperabil
 
 Hew wire types map to MessagePack formats as follows:
 
-| Hew Type       | MessagePack Format     | Format Marker(s)              | Notes                                                                   |
-| -------------- | ---------------------- | ----------------------------- | ----------------------------------------------------------------------- |
-| `bool`         | boolean                | `0xc3` (true), `0xc2` (false) | Single-byte primitives                                                  |
-| `u8`–`u16`     | u64 (up to 16-bit)     | `0xcc`, `0xcd`                | Variable-length u64 encoding                                            |
-| `u32`–`u64`    | u64 (up to 64-bit)     | `0xce`, `0xcf`                | Variable-length u64 encoding                                            |
-| `i8`–`i16`     | i64 (signed, up to 16) | `0xd0`, `0xd1`                | Variable-length signed encoding                                         |
-| `i32`–`i64`    | i64 (signed, up to 64) | `0xd2`, `0xd3`                | Variable-length signed encoding                                         |
-| `f32`          | float32                | `0xca`                        | IEEE 754 single precision                                               |
-| `f64`          | float64                | `0xcb`                        | IEEE 754 double precision                                               |
-| `string`       | string                 | `0xa0`–`0xbf`, `0xd9`, ...    | Length-prefixed UTF-8 string                                            |
-| `bytes`        | binary                 | `0xc4`, `0xc5`, `0xc6`        | Length-prefixed raw bytes                                               |
-| `#[wire] type` | map                    | `0x80`–`0x8f`, `0xde`, ...    | Key–value pairs (field number keys)                                     |
-| `#[wire] enum` | i64 + str (variant)    | Tag + variant index/name      | Encoded as MessagePack integer (variant index) or string (variant name) |
-| Optional       | nil or value           | `0xc0` or type of Some(v)     | `None` encodes as MessagePack nil                                       |
-| List           | array                  | `0x90`–`0x9f`, `0xdc`, ...    | Length-prefixed sequence                                                |
+| Hew Type     | MessagePack Format      | Format Marker(s)           | Notes                            |
+| ------------ | ----------------------- | -------------------------- | -------------------------------- |
+| `bool`       | boolean                 | `0xc3` (true), `0xc2` (false) | Single-byte primitives           |
+| `u8`–`u16`   | u64 (up to 16-bit)     | `0xcc`, `0xcd`             | Variable-length u64 encoding    |
+| `u32`–`u64`  | u64 (up to 64-bit)     | `0xce`, `0xcf`             | Variable-length u64 encoding    |
+| `i8`–`i16`   | i64 (signed, up to 16)  | `0xd0`, `0xd1`             | Variable-length signed encoding  |
+| `i32`–`i64`  | i64 (signed, up to 64)  | `0xd2`, `0xd3`             | Variable-length signed encoding  |
+| `f32`        | float32                 | `0xca`                     | IEEE 754 single precision        |
+| `f64`        | float64                 | `0xcb`                     | IEEE 754 double precision        |
+| `string`     | string                  | `0xa0`–`0xbf`, `0xd9`, ... | Length-prefixed UTF-8 string     |
+| `bytes`      | binary                  | `0xc4`, `0xc5`, `0xc6`     | Length-prefixed raw bytes        |
+| `#[wire] type` | map                     | `0x80`–`0x8f`, `0xde`, ... | Key–value pairs (field number keys) |
+| `#[wire] enum`   | i64 + str (variant)     | Tag + variant index/name   | Encoded as MessagePack integer (variant index) or string (variant name) |
+| Optional     | nil or value            | `0xc0` or type of Some(v)  | `None` encodes as MessagePack nil |
+| List         | array                   | `0x90`–`0x9f`, `0xdc`, ... | Length-prefixed sequence         |
 
 ##### 7.3.1.2 Wire Type Map Encoding
 
@@ -4216,13 +4204,13 @@ enum Status { PendingReview; ActiveNow; Completed; }
 
 Encoders select format based on context:
 
-| Context                 | Default Format                   |
-| ----------------------- | -------------------------------- |
-| Actor-to-actor (local)  | CBOR                             |
-| Actor-to-actor (remote) | CBOR                             |
-| HTTP API response       | JSON                             |
+| Context                 | Default Format |
+| ----------------------- | -------------- |
+| Actor-to-actor (local)  | CBOR           |
+| Actor-to-actor (remote) | CBOR           |
+| HTTP API response       | JSON           |
 | File storage            | user choice (`std::encoding::*`) |
-| Debugging/logging       | JSON                             |
+| Debugging/logging       | JSON           |
 
 Explicit format selection:
 
@@ -4326,8 +4314,8 @@ Native object / WASM
   - Generator borrow across yield.
   - Actor-send escape (a value captured into an outgoing message that
     aliases live state in the sending actor).
-    `@linear` must-consume obligations are discharged here; unconsumed
-    `@linear` values surface as `MustConsumeAtScopeExit`.
+  `@linear` must-consume obligations are discharged here; unconsumed
+  `@linear` values surface as `MustConsumeAtScopeExit`.
 - **Elaborated MIR.** Drops are first-class basic blocks in the CFG.
   Cleanup edges (panic, cancellation) are real edges. Every CFG exit
   runs the right destructor sequence in the right order. `@resource`
@@ -4477,12 +4465,12 @@ for messages are `Idle` (or `Suspended` during a cooperative suspension) and bec
 
 **Key distinctions from task states (§4.1):**
 
-| Aspect          | Actor State Machine                                                        | Task State Machine (§4.1)                   |
-| --------------- | -------------------------------------------------------------------------- | ------------------------------------------- |
-| **Entity**      | Entire actor instance                                                      | Individual task within an actor             |
-| **Managed by**  | Runtime scheduler (Level 1)                                                | Actor-local coroutine executor (Level 2)    |
-| **States**      | Idle/Runnable/Running/Suspended/Stopping/Crashing/Crashed/Stopped/Sleeping | Pending/Running/Completed/Cancelled/Trapped |
-| **Granularity** | One per actor                                                              | Many per actor (one per `fork` child)       |
+| Aspect          | Actor State Machine                                                        | Task State Machine (§4.1)                     |
+| --------------- | -------------------------------------------------------------------------- | --------------------------------------------- |
+| **Entity**      | Entire actor instance                                                      | Individual task within an actor               |
+| **Managed by**  | Runtime scheduler (Level 1)                                                | Actor-local coroutine executor (Level 2)      |
+| **States**      | Idle/Runnable/Running/Suspended/Stopping/Crashing/Crashed/Stopped/Sleeping | Pending/Running/Completed/Cancelled/Trapped   |
+| **Granularity** | One per actor                                                              | Many per actor (one per `fork` child)         |
 
 Supervisor observes actor terminal states `Stopped` or `Crashed`.
 
@@ -4541,12 +4529,12 @@ added in later editions without growing the annotation vocabulary.
 
 **Hooks defined in this edition:**
 
-| Annotation       | Signature                                 | Runs when                                                                                                 |
-| ---------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `#[on(start)]`   | `fn name()`                               | Once, after the actor's fields are initialized and before any message is dispatched.                      |
+| Annotation       | Signature                                 | Runs when                                                                                       |
+| ---------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `#[on(start)]`   | `fn name()`                               | Once, after the actor's fields are initialized and before any message is dispatched.            |
 | `#[on(stop)]`    | `fn name()`                               | Once per actor instance, on normal exit, cancellation by an enclosing `fork{}`, or supervisor `Shutdown`. |
-| `#[on(crash)]`   | `fn name(info: CrashInfo) -> CrashAction` | After a child trap is classified and before restart-policy handling.                                      |
-| `#[on(upgrade)]` | reserved                                  | Reserved for future hot-upgrade machinery; not a usable hook in this edition.                             |
+| `#[on(crash)]`   | `fn name(info: CrashInfo) -> CrashAction` | After a child trap is classified and before restart-policy handling.                            |
+| `#[on(upgrade)]` | reserved                                  | Reserved for future hot-upgrade machinery; not a usable hook in this edition.                   |
 
 Unknown hook kinds (e.g. `#[on(restart)]`) are rejected with a diagnostic listing the valid set.
 
@@ -4572,14 +4560,12 @@ and is rejected during lowering.
 
 9. Cancellation by an enclosing `fork{}` scope triggers `#[on(stop)]` for each cancelled actor before its task ends. This is the common path under structured concurrency, not an exceptional one.
 10. The runtime sequence at terminal transition is:
-
-- (a) actor body exits or is cancelled;
-- (b) the `#[on(stop)]` hook runs with field access live, if present;
-- (c) `#[linear]` consumed-checks fire (unconsumed linear values surface as diagnostics);
-- (d) `#[resource]` field `close()` methods run in reverse declaration order.
-  Hooks therefore run BEFORE `#[resource]` `close()`, so user logic in a hook can still use resources for goodbye flushes.
-
-11. A panic in `#[on(start)]` aborts actor startup. The supervisor is notified; `#[on(stop)]` does NOT run, because the actor never reached the _started_ state.
+   - (a) actor body exits or is cancelled;
+   - (b) the `#[on(stop)]` hook runs with field access live, if present;
+   - (c) `#[linear]` consumed-checks fire (unconsumed linear values surface as diagnostics);
+   - (d) `#[resource]` field `close()` methods run in reverse declaration order.
+   Hooks therefore run BEFORE `#[resource]` `close()`, so user logic in a hook can still use resources for goodbye flushes.
+11. A panic in `#[on(start)]` aborts actor startup. The supervisor is notified; `#[on(stop)]` does NOT run, because the actor never reached the *started* state.
 12. The default `#[on(stop)]` timeout budget is 5 seconds; future editions MAY introduce `#[on(stop, timeout = <duration>)]` to override per actor.
 
 **Compilation:** `#[on(start)]` bodies are appended to the synthesized `_init`
@@ -4704,15 +4690,15 @@ When the grammar files and this specification disagree, the parser implementatio
 > are rejected. Integer literals default to `i64`; literal defaulting is not a
 > user-nameable alias and does not affect wire shape or ABI.
 
-| Type                      | Size          | Description                                                                                                      |
-| ------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `i8`, `i16`, `i32`, `i64` | 1/2/4/8 bytes | Signed integers (fixed-width)                                                                                    |
-| `u8`, `u16`, `u32`, `u64` | 1/2/4/8 bytes | Unsigned integers (fixed-width)                                                                                  |
-| `isize`                   | platform      | Platform-sized signed integer: 32-bit on WASM32, 64-bit on native. Distinct from any fixed-width integer type.   |
+| Type                      | Size          | Description             |
+| ------------------------- | ------------- | ----------------------- |
+| `i8`, `i16`, `i32`, `i64` | 1/2/4/8 bytes | Signed integers (fixed-width) |
+| `u8`, `u16`, `u32`, `u64` | 1/2/4/8 bytes | Unsigned integers (fixed-width) |
+| `isize`                   | platform      | Platform-sized signed integer: 32-bit on WASM32, 64-bit on native. Distinct from any fixed-width integer type. |
 | `usize`                   | platform      | Platform-sized unsigned integer: 32-bit on WASM32, 64-bit on native. Distinct from any fixed-width integer type. |
-| `f32`, `f64`              | 4/8 bytes     | IEEE 754 floating point                                                                                          |
-| `bool`                    | 1 byte        | Boolean (true/false)                                                                                             |
-| `char`                    | 4 bytes       | Unicode scalar value                                                                                             |
+| `f32`, `f64`              | 4/8 bytes     | IEEE 754 floating point |
+| `bool`                    | 1 byte        | Boolean (true/false)    |
+| `char`                    | 4 bytes       | Unicode scalar value    |
 
 **Type aliases** (compile-time synonyms only — the aliased type is what the checker sees):
 
@@ -4759,12 +4745,12 @@ let nan_as_int: i32 = nan.to_i32();     // 0 — NaN converts to zero
 
 **Float-to-integer conversion semantics:**
 
-| Source value    | Signed result      | Unsigned result            |
-| --------------- | ------------------ | -------------------------- |
-| In-range finite | Truncated toward 0 | Truncated toward 0         |
-| `+Inf` or > MAX | Integer `MAX`      | Integer `MAX` (`UINT_MAX`) |
-| `-Inf` or < MIN | Integer `MIN`      | `0`                        |
-| `NaN`           | `0`                | `0`                        |
+| Source value          | Signed result      | Unsigned result |
+| --------------------- | ------------------ | --------------- |
+| In-range finite       | Truncated toward 0 | Truncated toward 0 |
+| `+Inf` or > MAX       | Integer `MAX`      | Integer `MAX` (`UINT_MAX`) |
+| `-Inf` or < MIN       | Integer `MIN`      | `0` |
+| `NaN`                 | `0`                | `0` |
 
 These semantics are guaranteed on all Hew targets (x86_64, aarch64, wasm32). The underlying LLVM lowering uses `llvm.fptosi.sat` / `llvm.fptoui.sat`, which produce defined behaviour for all input values. Plain `fptosi` / `fptoui` (which produce LLVM poison for out-of-range inputs) are never emitted.
 

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -398,7 +398,7 @@ unaffected.
 
 - Bindings are immutable by default: `let`.
 - Mutable bindings: `var`.
-- Struct fields have no mutability qualifier. Field mutation is governed by the binding: a `var`-bound struct allows `p.x = …`; a `let`-bound struct rejects it.
+- Type fields have no mutability qualifier. Field mutation is governed by the binding: a `var`-bound value allows `p.x = …`; a `let`-bound value rejects it.
 
 ### 3.3 Sendability / isolation rule
 
@@ -538,7 +538,7 @@ y = 10;          // ok
 
 This is similar to JavaScript's `const`/`let` or Swift's `let`/`var`. It controls whether the _binding_ can be reassigned, not whether the underlying data is mutable.
 
-For type (struct) fields:
+For type fields:
 
 ```hew
 type Point {
@@ -553,7 +553,7 @@ let q = Point { x: 0, y: 0 };
 // q.x = 10;     // compile error — q is let-bound
 ```
 
-**Type (struct) field syntax:**
+**Type field syntax:**
 
 Type fields do NOT require a `let`/`var` prefix. Fields are immutable and use semicolons as terminators:
 
@@ -578,7 +578,7 @@ actor Counter {
 
 A `let` (or bare) actor field is immutable after construction: it may be assigned only inside the `init { }` block, where its initial value is established. Any assignment to a `let` field from a `receive fn`, a plain actor method, or a lifecycle hook is rejected at check time with a diagnostic that names the field and suggests declaring it with `var`. A `var` field is mutable and may be assigned anywhere in the actor body.
 
-This distinction exists because actor fields are stateful (they change over the actor's lifetime) and use initialization syntax similar to variable declarations, while struct fields are data layout declarations.
+This distinction exists because actor fields are stateful (they change over the actor's lifetime) and use initialization syntax similar to variable declarations, while type fields are data layout declarations.
 
 #### 3.4.4 The Boundary Rule: Move on Send
 
@@ -967,7 +967,7 @@ This produces an index plus per-module pages for the shipped `std/` sources.
 Types defined in different modules are distinct even if they share a name. A
 `Point` defined in `geometry` and a `Point` defined in `graphics` are unrelated
 types; the qualified names `geometry.Point` and `graphics.Point` disambiguate
-them everywhere — in type annotations, `match` patterns, and struct literals.
+them everywhere — in type annotations, `match` patterns, and aggregate literals.
 
 ```hew
 import geometry;
@@ -1038,7 +1038,7 @@ impl Display for Point {
 
 - `Frozen` - Type is deeply immutable and thus safely shareable. Implies `Send`. `Frozen ⊇ Send` holds by structural coincidence — every type whose fields are all deeply immutable is also send-admissible — not via an explicit impl chain.
   - Runtime-internal shared immutable handles (the planned `Arc<T>` surface is not yet exposed in Hew source)
-  - Structs where all fields are `Frozen`
+  - Types where all fields are `Frozen`
 
 - `Copy` - Type is copied on assignment rather than moved.
   - Only value types (integers, floats, bool, char)
@@ -1072,7 +1072,7 @@ p.fmt();    // desugars to Point::fmt(p) — p is consumed (by-value)
 // p is no longer valid here
 ```
 
-**In `impl` blocks for structs/enums (by-value):**
+**In `impl` blocks for types/enums (by-value):**
 
 The receiver is passed by value — the receiver is consumed (ownership transfer):
 
@@ -1093,7 +1093,7 @@ actor Counter {
 }
 ```
 
-There is no `&self` or `&mut self` syntax — Hew does not have references in its surface syntax (see §3.4.1). The by-value vs implicit-state distinction is determined by the context (struct `impl` vs actor body), not by annotation.
+There is no `&self` or `&mut self` syntax — Hew does not have references in its surface syntax (see §3.4.1). The by-value vs implicit-state distinction is determined by the context (`type`/`enum` `impl` vs actor body), not by annotation.
 
 **The `this` keyword (actor self-reference):**
 
@@ -1103,7 +1103,7 @@ Inside an actor body, the `this` keyword provides a read-only handle to the acto
 - Type `LocalPid<Self>` — a sendable handle to the enclosing actor
 - Can be passed as a message argument or stored in a field
 - Read-only — assignment to `this` is rejected at compile time
-- Not valid in struct `impl` blocks or free functions
+- Not valid in `type`/`enum` `impl` blocks or free functions
 
 **Variable shadowing:**
 
@@ -1283,7 +1283,7 @@ trait Send {}  // Marker trait — no methods
 - The value is owned and transferred by move with no remaining aliases
 - The value is `Frozen` (deeply immutable)
 - The value is a `LocalPid<A>`
-- The value is a struct/enum where all fields/variants satisfy `Send`
+- The value is a type/enum where all fields/variants satisfy `Send`
 
 > **Implementation note:** `Send` means send-admissible; the runtime selects the send mechanism based on the value's admissibility class (immutable-shareable → alias-shared by retain; mutable collections → deep-copied; `iso`/Linear → ownership move, P6). The `Send` marker tells the compiler that a type's structure is send-admissible; it does **not** mandate a particular runtime copy strategy. User-defined types do NOT need to implement `Send` explicitly — the compiler derives it automatically based on field types.
 
@@ -1333,7 +1333,7 @@ resource is released exactly once.
 
 **Automatic field-wise drop** — for plain data types, the compiler emits a
 recursive drop that frees heap storage (strings, `Vec`, `HashMap`, nested
-structs) in **reverse declaration order (LIFO)**. No annotation or `impl`
+types) in **reverse declaration order (LIFO)**. No annotation or `impl`
 is needed.
 
 **Cleanup guarantees:**
@@ -1341,7 +1341,7 @@ is needed.
 - `close()` (resource types) or field-wise drop runs exactly once per value
 - Cleanup runs at a predictable point (scope exit)
 - Drop order: fields are released in reverse declaration order (LIFO) — last declared, first dropped
-- Nested structs are recursively dropped
+- Nested types are recursively dropped
 - `Rc<T>` payloads are released when the refcount reaches zero; unsupported `Rc<T>` payload types are rejected during checking
 - All owned values in an actor are cleaned up when the actor terminates; heap is freed after the last field
 
@@ -1385,7 +1385,7 @@ fn eval(e: Expr) -> i64 {
 
 **Restrictions:**
 
-- `indirect` can only be used with `enum` declarations, not `type` (struct)
+- `indirect` can only be used with `enum` declarations, not `type` declarations
 - Only enums that contain self-referential variants benefit from `indirect`
 
 #### 3.7.5 Reference Counting (Rc and Arc)
@@ -1396,7 +1396,7 @@ fn eval(e: Expr) -> i64 {
 - Cannot cross actor boundaries (does not implement `Send`)
 - Use for shared ownership within one actor
 - Current compiler support is fail-closed: `Rc<T>` currently accepts `T: Copy`, `string`, `bytes`, and nested `Rc` of supported payloads until recursive drop lowering exists
-- For collection admissibility, the checker currently enforces an internal `RcFree` boundary (current checker behaviour, not stable user-written trait syntax): a type is treated as RcFree only when its resolved structure contains no `Rc<_>` after recursively checking wrapper type arguments, tuples/arrays/slices, and registered named struct/enum/actor members, including module-qualified and non-root private definitions seen during checking
+- For collection admissibility, the checker currently enforces an internal `RcFree` boundary (current checker behaviour, not stable user-written trait syntax): a type is treated as RcFree only when its resolved structure contains no `Rc<_>` after recursively checking wrapper type arguments, tuples/arrays/slices, and registered named type/enum/actor members, including module-qualified and non-root private definitions seen during checking
 - `LocalPid<A>` participates in that structural check through its actor type argument: if actor `A` stores non-RcFree state, `LocalPid<A>` is also non-RcFree for collection checks
 - `HashMap` and `HashSet` reject non-RcFree key/value/element types during type checking; `Vec` rejects non-RcFree elements at collection method-call sites (`push`, `pop`, `get`, `remove`, `set`, `append`, `extend`, `map`, `filter`, `fold`) rather than as a bare annotation-level ban
 
@@ -2626,7 +2626,7 @@ Inside a transition body the compiler binds two implicit names:
 | Binding | Type              | Meaning                                       |
 | ------- | ----------------- | --------------------------------------------- |
 | `state` | source state type | Fields of the current (source) state          |
-| `event` | event struct      | Payload fields of the incoming event (if any) |
+| `event` | event payload     | Payload fields of the incoming event (if any) |
 
 ```hew
 machine Elevator {
@@ -4310,7 +4310,7 @@ Native object / WASM
 - **THIR.** Every expression carries its concrete `Ty`. No `Ty::Var`
   survives this stage — the boundary is fail-closed. Generic functions
   are monomorphised at use sites; trait dispatch resolves to concrete
-  implementations; closure signatures are explicit; struct
+  implementations; closure signatures are explicit; aggregate
   initialiser type arguments are carried.
 - **Raw MIR.** The function body is a control-flow graph of basic
   blocks with real terminators (`Goto`, `Branch`, `Return`, `Drop`,

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -18,7 +18,7 @@ runtime.
 Hew tracks **two version axes** that move independently:
 
 - **Compiler version** is SemVer on the binary (`hew --version` → `hew
-  0.5.x`). Patch releases for soundness and codegen fixes; minor releases
+0.5.x`). Patch releases for soundness and codegen fixes; minor releases
   for new stdlib surfaces and new language editions; the major release is
   the v1.0 stability event.
 - **Spec edition** is a year-shaped identifier declared once per package in
@@ -197,6 +197,7 @@ actor HealthChecker {
 ```
 
 **Rules:**
+
 - The `#[every]` attribute takes a single duration literal argument (e.g. `5s`, `100ms`, `1m`)
 - Periodic handlers must not have parameters (they receive no message payload)
 - Periodic handlers must not have a return type (fire-and-forget)
@@ -356,7 +357,7 @@ let r?: T = expr;       ≡  let r: T = expr?;
 - The enclosing function must return `Result<_, E>` or `Option<_>` with a
   compatible error type. If it does not, the checker reports the same
   "`?` cannot be used in a function returning …`" diagnostic as for bare `?`.
-- The type annotation `T` in `let r?: T = expr` describes the *unwrapped*
+- The type annotation `T` in `let r?: T = expr` describes the _unwrapped_
   Ok-payload (type of `r` after propagation), not the Result itself — the
   same convention as `let r: T = expr?;`.
 
@@ -418,34 +419,34 @@ The compiler automatically determines `Send` and `Frozen` for user-defined types
 
 **Send derivation:**
 
-| Type                               | `Send` if...                               |
-| ---------------------------------- | ------------------------------------------ |
-| Value types (i32, f64, bool, char, isize, usize) | Always `Send`                |
-| `string`                           | Always `Send` (immutable-shareable owned type; alias-shared by refcount retain on send — not deep-copied) |
-| `LocalPid<A>`                      | Always `Send`                              |
-| `type S { f1: T1; f2: T2; ... }`   | All fields are `Send`                      |
-| `enum E { V1(T1), V2(T2), ... }`   | All variant payloads are `Send`            |
-| `Vec<T>`                           | `T` is `Send`                              |
-| `HashMap<K, V>`                    | `K` and `V` are both `Send`                |
-| `Option<T>`                        | `T` is `Send`                              |
-| `Result<T, E>`                     | `T` and `E` are both `Send`                |
-| `(T1, T2, ...)`                    | All elements are `Send`                    |
-| `[T; N]`                           | `T` is `Send`                              |
+| Type                                             | `Send` if...                                                                                              |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| Value types (i32, f64, bool, char, isize, usize) | Always `Send`                                                                                             |
+| `string`                                         | Always `Send` (immutable-shareable owned type; alias-shared by refcount retain on send — not deep-copied) |
+| `LocalPid<A>`                                    | Always `Send`                                                                                             |
+| `type S { f1: T1; f2: T2; ... }`                 | All fields are `Send`                                                                                     |
+| `enum E { V1(T1), V2(T2), ... }`                 | All variant payloads are `Send`                                                                           |
+| `Vec<T>`                                         | `T` is `Send`                                                                                             |
+| `HashMap<K, V>`                                  | `K` and `V` are both `Send`                                                                               |
+| `Option<T>`                                      | `T` is `Send`                                                                                             |
+| `Result<T, E>`                                   | `T` and `E` are both `Send`                                                                               |
+| `(T1, T2, ...)`                                  | All elements are `Send`                                                                                   |
+| `[T; N]`                                         | `T` is `Send`                                                                                             |
 
 > **Note on array annotations:** Only fixed-size array annotations `[T; N]` are supported. Slice annotations `[T]` (unsized) are rejected by the type checker; unsized-slice lowering is not implemented. Use `Vec<T>` for dynamically-sized sequences.
 
 **Frozen derivation:**
 
-| Type                          | `Frozen` if...                            |
-| ----------------------------- | ----------------------------------------- |
-| Value types                   | Always `Frozen`                           |
-| `string`                      | NOT `Frozen` (mutable content)            |
-| `LocalPid<A>`                 | Always `Frozen` (identity reference only) |
-| `type S` where all field types are `Frozen` | `Frozen` (recursive over field types) |
-| `type S` where any field type is not `Frozen` | NOT `Frozen`                        |
-| `enum E`                      | All variant payloads are `Frozen`         |
-| `Arc<T>`                      | _Not currently surfaced in Hew source; runtime-only support today_ |
-| `Vec<T>`, `HashMap<K,V>`      | NOT `Frozen` (mutable containers)         |
+| Type                                          | `Frozen` if...                                                     |
+| --------------------------------------------- | ------------------------------------------------------------------ |
+| Value types                                   | Always `Frozen`                                                    |
+| `string`                                      | NOT `Frozen` (mutable content)                                     |
+| `LocalPid<A>`                                 | Always `Frozen` (identity reference only)                          |
+| `type S` where all field types are `Frozen`   | `Frozen` (recursive over field types)                              |
+| `type S` where any field type is not `Frozen` | NOT `Frozen`                                                       |
+| `enum E`                                      | All variant payloads are `Frozen`                                  |
+| `Arc<T>`                                      | _Not currently surfaced in Hew source; runtime-only support today_ |
+| `Vec<T>`, `HashMap<K,V>`                      | NOT `Frozen` (mutable containers)                                  |
 
 > **Soundness requirement:** The compiler MUST reject as non-`Send` any type whose `Send` status cannot be determined (e.g., opaque foreign types). Foreign types are non-`Send` by default. The runtime/ABI has internal escape hatches, but there is currently **no surfaced Hew `#[send]` attribute** for user code.
 
@@ -833,7 +834,7 @@ This provides clean, namespaced access to stdlib functionality. The module name 
 | `std::net`         | `net.listen`, `net.accept`, `net.connect`, `net.read`, `net.write`, `net.close`                                                                              |
 | `std::text::regex` | `regex.new`, `regex.is_match`, `regex.find`, `regex.replace`                                                                                                 |
 | `std::net::mime`   | `mime.from_path`, `mime.from_ext`, `mime.is_text`                                                                                                            |
-| `std::process`     | `process.run`, `process.try_run`, `process.run_argv`, `process.try_run_argv`, `process.start`                                                               |
+| `std::process`     | `process.run`, `process.try_run`, `process.run_argv`, `process.try_run_argv`, `process.start`                                                                |
 
 Predicate functions (`fs.exists`, `path.exists`, `regex.is_match`, `os.has_env`, `mime.is_text`) return `bool`.
 
@@ -841,17 +842,17 @@ Predicate functions (`fs.exists`, `path.exists`, `regex.is_match`, `os.has_env`,
 
 Three-tier model — written as a prefix keyword before the item keyword:
 
-| Syntax              | Meaning                                    |
-|---------------------|--------------------------------------------|
-| `fn foo()`          | Private — visible only within this module  |
-| `package fn foo()`  | Package — visible within the same package  |
-| `pub fn foo()`      | Public — visible to all modules            |
+| Syntax             | Meaning                                   |
+| ------------------ | ----------------------------------------- |
+| `fn foo()`         | Private — visible only within this module |
+| `package fn foo()` | Package — visible within the same package |
+| `pub fn foo()`     | Public — visible to all modules           |
 
 The same prefix applies to any item kind: `package type`, `package const`, `package actor`, etc.
 
 > **Implementation note:** `package` visibility is accepted and parsed correctly.
 > Enforcement of the package boundary (rejecting callers outside the package) is
-> planned for a future edition.  Code written with `package` visibility today will
+> planned for a future edition. Code written with `package` visibility today will
 > keep compiling after the restriction is applied, because callers within the
 > package are unaffected.
 
@@ -1226,11 +1227,11 @@ Hew guarantees no GC pauses. Memory reclamation is entirely deterministic:
 
 At the **language level**, `send()` **moves** the value — the sender loses access and cannot use it after sending (see §3.4.4). At the **runtime level**, the send mechanism is **gated** on the value's admissibility class (D355):
 
-| Admissibility class | Runtime mechanism | Examples |
-| ------------------- | ----------------- | -------- |
-| **Immutable-shareable** (`is_immutable_shareable`) | **Alias-shared by refcount retain** — no byte copy | `string`, `bytes` |
-| **Mutable owned collections** | **Deep-copied** into the receiver's per-actor heap | `Vec<T>`, `HashMap<K,V>`, `HashSet<T>` |
-| **Consumed-linear (`iso`/Linear)** | Zero-copy **ownership move** (P6 — not surfaced in edition 2026) | — |
+| Admissibility class                                | Runtime mechanism                                                | Examples                               |
+| -------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------- |
+| **Immutable-shareable** (`is_immutable_shareable`) | **Alias-shared by refcount retain** — no byte copy               | `string`, `bytes`                      |
+| **Mutable owned collections**                      | **Deep-copied** into the receiver's per-actor heap               | `Vec<T>`, `HashMap<K,V>`, `HashSet<T>` |
+| **Consumed-linear (`iso`/Linear)**                 | Zero-copy **ownership move** (P6 — not surfaced in edition 2026) | —                                      |
 
 The gate is `is_immutable_shareable || consumed-Linear || deep-copy`. Bare `copy` does **not** imply sendability (`copy ⊥ sendable`, B-INV-3). `View`/borrow (`&T`) is rejected across actor boundaries and is not `Send`.
 
@@ -1495,6 +1496,7 @@ Typical example — file I/O with implicit cleanup (illustrative; no `File` type
 exists in stdlib — for file reading use `fs::try_read`):
 
 <!-- doctest: skip -->
+
 ```hew
 fn read_config(path: string) -> Result<Config, IoError> {
     let f = File::open(path)?;
@@ -1507,6 +1509,7 @@ fn read_config(path: string) -> Result<Config, IoError> {
 Early close, surfacing the I/O error to the caller (illustrative):
 
 <!-- doctest: skip -->
+
 ```hew
 fn read_and_process(path: string) -> Result<Summary, AppError> {
     let f = File::open(path)?;
@@ -1550,6 +1553,7 @@ A correct use (illustrative — `Database` and `Transaction` are hypothetical ty
 showing the `#[linear]` pattern; `&Database` uses reference syntax not in Hew):
 
 <!-- doctest: skip -->
+
 ```hew
 fn transfer(db: &Database, from: AccountId, to: AccountId, amount: Money)
     -> Result<(), DbError>
@@ -1564,6 +1568,7 @@ fn transfer(db: &Database, from: AccountId, to: AccountId, amount: Money)
 The compile error for forgetting to consume (illustrative):
 
 <!-- doctest: skip -->
+
 ```hew
 fn forgot_to_commit(db: &Database) -> Result<(), DbError> {
     let tx = db.begin_transaction()?;
@@ -1576,12 +1581,12 @@ fn forgot_to_commit(db: &Database) -> Result<(), DbError> {
 
 ##### 3.7.8.3 Choosing between `#[resource]` and `#[linear]`
 
-| Question                                                          | Pick           |
-| ----------------------------------------------------------------- | -------------- |
-| Is "close and discard the error" a sensible default at scope exit? | `#[resource]` |
-| Must the caller surface the cleanup result, every time?            | `#[linear]`   |
+| Question                                                               | Pick          |
+| ---------------------------------------------------------------------- | ------------- |
+| Is "close and discard the error" a sensible default at scope exit?     | `#[resource]` |
+| Must the caller surface the cleanup result, every time?                | `#[linear]`   |
 | Are there multiple distinct ways to consume (commit / rollback / ...)? | `#[linear]`   |
-| Is there exactly one cleanup action, and is it idempotent?         | `#[resource]` |
+| Is there exactly one cleanup action, and is it idempotent?             | `#[resource]` |
 
 File descriptors, sockets, allocator handles, regex compiled patterns,
 HTTP server/request handles — `#[resource]`. Database transactions,
@@ -1625,7 +1630,7 @@ hooks, or the supervised shutdown handler):
 
 **Path 3 — Supervised actor crash (handler trap that bypasses the
 terminating handler).** A trap raised by any handler restarts the
-actor under the supervisor's policy. The terminating handler is *not*
+actor under the supervisor's policy. The terminating handler is _not_
 guaranteed to run on this path; only heap teardown is:
 
 - `#[resource]` fields: implicit `close()` runs as part of heap teardown
@@ -1633,7 +1638,7 @@ guaranteed to run on this path; only heap teardown is:
 - `#[linear]` fields: a crash bypasses the consume path the move-checker
   relied on in Path 2. Edition 2026 resolves this conservatively: a
   `#[linear]` field is admitted on an actor only when the field's type
-  *also* satisfies `#[resource]` semantics, so heap teardown invokes the
+  _also_ satisfies `#[resource]` semantics, so heap teardown invokes the
   implicit drop on the crash path. A bare `#[linear]` field whose consume
   path can be bypassed by a supervised restart is a compile error at
   actor-declaration time. A future edition may relax this with an
@@ -2015,6 +2020,7 @@ Hew provides FFI capabilities for interoperating with C libraries and system cal
 External C functions are declared in `extern` blocks:
 
 <!-- doctest: skip -->
+
 ```hew
 extern "C" {
     fn malloc(size: usize) -> *mut u8;
@@ -2041,6 +2047,7 @@ extern "C" {
 Use `#[repr(C)]` to ensure C-compatible memory layout:
 
 <!-- doctest: skip -->
+
 ```hew
 #[repr(C)]
 type Point {
@@ -2113,6 +2120,7 @@ extern "C" fn my_callback(value: i32) -> i32 {
 **All FFI calls are `unsafe`:**
 
 <!-- doctest: skip -->
+
 ```hew
 fn allocate_buffer(size: usize) -> *mut u8 {
     unsafe {
@@ -2141,6 +2149,7 @@ fn safe_read(fd: i32, buf: *mut u8, count: usize) -> Result<usize, string> {
 **Safe wrapper pattern:**
 
 <!-- doctest: skip -->
+
 ```hew
 // Raw FFI (internal, unsafe)
 extern "C" {
@@ -2309,7 +2318,7 @@ regardless of the ABI key/value check; this is structural, not just a direct
 `Rc<T>` ban.
 
 **Map literal syntax** — a `HashMap<K, V>` can be constructed inline with
-brace-colon syntax.  The parser disambiguates `{` as a map literal when the
+brace-colon syntax. The parser disambiguates `{` as a map literal when the
 first token after `{` is a `StringLit` followed by `:`:
 
 ```hew
@@ -2342,15 +2351,15 @@ Rules:
 
 Available `HashMap` methods:
 
-| Method                    | Returns         | Description                      |
-| ------------------------- | --------------- | -------------------------------- |
-| `HashMap::new()`          | `HashMap<K,V>`  | Create empty map                 |
-| `m.get(key)`              | `Option<V>`     | Look up a key                    |
-| `m.insert(key, value)`    | `()`            | Insert or overwrite              |
-| `m.remove(key)`           | `bool`          | Remove a key; true if present    |
-| `m.contains_key(key)`     | `bool`          | Test membership                  |
-| `m.len()`                 | `i64`           | Number of entries                |
-| `m.is_empty()`            | `bool`          | True if no entries               |
+| Method                 | Returns        | Description                   |
+| ---------------------- | -------------- | ----------------------------- |
+| `HashMap::new()`       | `HashMap<K,V>` | Create empty map              |
+| `m.get(key)`           | `Option<V>`    | Look up a key                 |
+| `m.insert(key, value)` | `()`           | Insert or overwrite           |
+| `m.remove(key)`        | `bool`         | Remove a key; true if present |
+| `m.contains_key(key)`  | `bool`         | Test membership               |
+| `m.len()`              | `i64`          | Number of entries             |
+| `m.is_empty()`         | `bool`         | True if no entries            |
 
 #### 3.10.4 Collections, I/O, and Utility Modules
 
@@ -2441,13 +2450,13 @@ to release the underlying resource. Dropping without `close()` is a
 resource leak; the compiler does not synthesise an implicit drop for
 these types in the current implementation.
 
-| Type             | Created by                                 | Methods                                                                                                                              |
-| ---------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `http.Server`    | `http.listen(addr)`                        | `.accept()` → `http.Request`, `.close()`                                                                                              |
-| `http.Request`   | `server.accept()` or `http.accept(server)` | `.path`, `.method`, `.body`, `.header(name)`, `.respond(status, body, len, type)`, `.respond_text(status, body)`, `.respond_json(status, body)`, `.close()` |
-| `net.Listener`   | `net.listen(addr)`                         | `.accept()` → `net.Connection`, `await ln.accept() \| after d` → `Result<net.Connection, IoError>`, `.close()`                        |
+| Type             | Created by                                 | Methods                                                                                                                                                                |
+| ---------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `http.Server`    | `http.listen(addr)`                        | `.accept()` → `http.Request`, `.close()`                                                                                                                               |
+| `http.Request`   | `server.accept()` or `http.accept(server)` | `.path`, `.method`, `.body`, `.header(name)`, `.respond(status, body, len, type)`, `.respond_text(status, body)`, `.respond_json(status, body)`, `.close()`            |
+| `net.Listener`   | `net.listen(addr)`                         | `.accept()` → `net.Connection`, `await ln.accept() \| after d` → `Result<net.Connection, IoError>`, `.close()`                                                         |
 | `net.Connection` | `listener.accept()` or `net.connect(addr)` | `.read()` → `bytes`, `.read_string()` → `string`, `await conn.read_string() \| after d` → `Result<string, IoError>`, `.write(data)`, `.write_string(data)`, `.close()` |
-| `process.Child`  | `process.start(cmd)`                       | `.wait()`, `.kill()`                                                                                                                  |
+| `process.Child`  | `process.start(cmd)`                       | `.wait()`, `.kill()`                                                                                                                                                   |
 
 Handle types are opaque — their internal representation is not accessible.
 They can be stored in variables, passed as function arguments, and
@@ -2472,8 +2481,8 @@ returned from functions.
 
 A `machine` is a **value type** that defines a closed set of named states, a
 closed set of named events, and transition rules mapping `(State, Event)` pairs
-to new states.  It compiles to a tagged union with a compiler-generated
-`step()` method.  Machines are not actors — they are pure data, like enums
+to new states. It compiles to a tagged union with a compiler-generated
+`step()` method. Machines are not actors — they are pure data, like enums
 with per-state fields and compiler-checked transition logic.
 
 > **Detailed specification:** See [`docs/specs/MACHINE-SPEC.md`](MACHINE-SPEC.md)
@@ -2566,12 +2575,12 @@ EmitExpr = "emit" Ident ( "{" FieldInitList "}" )? ;
 ```
 
 > **Depth > 1 nesting is reserved** — a substate body may not itself contain
-> substates.  Depth-1 composite state blocks are supported; deeper nesting
+> substates. Depth-1 composite state blocks are supported; deeper nesting
 > (`depth > 1`) is a parse error: `nested composite states (depth > 1) are reserved`.
 
 **Visualisation:** `hew machine diagram <file.hew>` renders any
 `machine` declaration as a Mermaid state diagram, Graphviz DOT, or JSON
-schema.  The command runs all HIR static checks before rendering, so it
+schema. The command runs all HIR static checks before rendering, so it
 doubles as a structural validator.
 
 ```
@@ -2584,40 +2593,40 @@ hew machine diagram traffic_light.hew --no-check        # skip HIR checks
 
 ### 3.11.2 Constraints
 
-| Constraint                                  | Checked at  | Error if violated                             |
-| ------------------------------------------- | ----------- | --------------------------------------------- |
-| At least two states                         | Types/HIR   | `machine_one_state` negative test             |
-| At least one event                          | Types/HIR   | `machine_no_events` negative test             |
-| No `state` nesting deeper than depth 1; depth-1 composite states are supported | Parse | diagnostic: nested composite states (depth > 1) are reserved |
-| No duplicate explicit transition per (S, E) | Parse/HIR   | `machine_dup_transition` negative test        |
-| No duplicate wildcard for same event        | Parse/HIR   | `machine_dup_wildcard` negative test          |
-| All referenced states/events must be declared | HIR       | `machine_unknown_state/event` negative tests  |
-| All (S, E) pairs covered (exhaustiveness)   | HIR         | `MachineExhaustivenessViolation` diagnostic   |
-| Effect parity: transition body writes ≡ entry writes | HIR  | `MachineEffectParityViolation` diagnostic     |
-| No direct self-emit (`emit E` in transition for event E) | HIR | `MachineEmitCycle` diagnostic          |
+| Constraint                                                                     | Checked at | Error if violated                                            |
+| ------------------------------------------------------------------------------ | ---------- | ------------------------------------------------------------ |
+| At least two states                                                            | Types/HIR  | `machine_one_state` negative test                            |
+| At least one event                                                             | Types/HIR  | `machine_no_events` negative test                            |
+| No `state` nesting deeper than depth 1; depth-1 composite states are supported | Parse      | diagnostic: nested composite states (depth > 1) are reserved |
+| No duplicate explicit transition per (S, E)                                    | Parse/HIR  | `machine_dup_transition` negative test                       |
+| No duplicate wildcard for same event                                           | Parse/HIR  | `machine_dup_wildcard` negative test                         |
+| All referenced states/events must be declared                                  | HIR        | `machine_unknown_state/event` negative tests                 |
+| All (S, E) pairs covered (exhaustiveness)                                      | HIR        | `MachineExhaustivenessViolation` diagnostic                  |
+| Effect parity: transition body writes ≡ entry writes                           | HIR        | `MachineEffectParityViolation` diagnostic                    |
+| No direct self-emit (`emit E` in transition for event E)                       | HIR        | `MachineEmitCycle` diagnostic                                |
 
 Exhaustiveness can be satisfied by: explicit `on` rules, wildcard (`_`-source)
-rules, or a `default` handler.  A `default` handler alone covers all pairs that
+rules, or a `default` handler. A `default` handler alone covers all pairs that
 have no other matching rule.
 
 **Effect parity:** when a transition body writes a state field (via
 `self.field = …`) and the target state's `entry` block also writes that same
-field, the compiler emits a `MachineEffectParityViolation` diagnostic.  This
+field, the compiler emits a `MachineEffectParityViolation` diagnostic. This
 prevents silent shadowing between transition-side and entry-side field
 initialisation.
 
 **Emit-cycle detection:** a transition handling event `E` may not directly
-`emit E` — that would form an immediate re-entry cycle.  Indirect cycles
+`emit E` — that would form an immediate re-entry cycle. Indirect cycles
 (A emits B, B emits A) are not checked.
 
 ### 3.11.3 Transition Bodies
 
 Inside a transition body the compiler binds two implicit names:
 
-| Binding     | Type              | Meaning                                         |
-| ----------- | ----------------- | ----------------------------------------------- |
-| `state`     | source state type | Fields of the current (source) state            |
-| `event`     | event struct      | Payload fields of the incoming event (if any)   |
+| Binding | Type              | Meaning                                       |
+| ------- | ----------------- | --------------------------------------------- |
+| `state` | source state type | Fields of the current (source) state          |
+| `event` | event struct      | Payload fields of the incoming event (if any) |
 
 ```hew
 machine Elevator {
@@ -2666,15 +2675,15 @@ on Request: Allowing => Allowing when state.tokens > 1 {
 on Request: Allowing => Throttled when state.tokens <= 1;
 ```
 
-Guards are evaluated in declaration order.  The first transition whose event
-and source-state match *and* whose guard (if present) evaluates to `true` fires.
+Guards are evaluated in declaration order. The first transition whose event
+and source-state match _and_ whose guard (if present) evaluates to `true` fires.
 If no guarded transition matches, evaluation falls through to wildcard rules and
 then to `default`.
 
 ### 3.11.5 Wildcard Transitions and Priority
 
-`_` in the source position matches any state.  `_` in the target position means
-"return a value of the machine type" (any variant, not a specific one).  The
+`_` in the source position matches any state. `_` in the target position means
+"return a value of the machine type" (any variant, not a specific one). The
 conventional identity pattern `on E: _ => _ { state }` keeps the current state
 unchanged.
 
@@ -2690,14 +2699,14 @@ Specific transitions always win over wildcards for the same event.
 
 The compiler generates the following for every `machine Name { ... }`:
 
-| Generated item              | Usage / behaviour                                                  |
-| ----------------------------| ------------------------------------------------------------------ |
-| State constructors          | `Name::State` (unit) or `Name::State { field: val }` (with data)  |
-| Companion event enum        | `NameEvent` with variants matching each `event` declaration        |
-| Event constructors          | `NameEvent::EventName` (unit) or `NameEvent::EventName { f: v }`  |
-| `m.step(event)`             | Mutates `m` in place; returns `()` — no return value              |
-| `m.state_name()`            | Returns the current state name as `string`                        |
-| Pattern-match support       | Machine values can be matched exactly like enum values             |
+| Generated item        | Usage / behaviour                                                |
+| --------------------- | ---------------------------------------------------------------- |
+| State constructors    | `Name::State` (unit) or `Name::State { field: val }` (with data) |
+| Companion event enum  | `NameEvent` with variants matching each `event` declaration      |
+| Event constructors    | `NameEvent::EventName` (unit) or `NameEvent::EventName { f: v }` |
+| `m.step(event)`       | Mutates `m` in place; returns `()` — no return value             |
+| `m.state_name()`      | Returns the current state name as `string`                       |
+| Pattern-match support | Machine values can be matched exactly like enum values           |
 
 **Calling `step()`** — both unqualified and qualified event constructors are
 accepted:
@@ -2920,7 +2929,7 @@ safepoint before its body reaches a consuming or close call.
    normal completion, recoverable `Err(E)`, trap, or cancellation. The
    declared `close(consuming self) -> Result<(), E>` is invoked through
    the child's stack-unwind path (§4.5), and its returned error is
-   discarded per the §3.4 `@resource` semantics. This is the *same*
+   discarded per the §3.4 `@resource` semantics. This is the _same_
    discipline a `@resource` would receive in a non-task context; the
    child's cancellation safepoint is simply one more exit through which
    stack unwinding runs cleanup.
@@ -2939,7 +2948,7 @@ safepoint before its body reaches a consuming or close call.
    The conservative rule keeps the language honest in edition 2026:
    without cancellation tokens, the programmer has no way to consume a
    `@linear` value along the cancellation path, so the only safe shape
-   is for the child's *only* exits-to-completion to be ones the
+   is for the child's _only_ exits-to-completion to be ones the
    compiler can prove consume the value. Relaxation is tracked in
    HEW-FUTURE.md §1.2 alongside the broader cancellation-token
    vocabulary.
@@ -2955,7 +2964,7 @@ safepoint before its body reaches a consuming or close call.
    names the mutable borrow site and points at the fork child.
 
 4. **Task<T> handle escape.** A `Task<T>` handle bound by `fork name =
-   expr` is usable only within the lexical scope-block that introduced
+expr` is usable only within the lexical scope-block that introduced
    it. The handle cannot be returned from the scope-block, stored in a
    field, captured by a closure that outlives the block, nor moved into
    a sibling child unless that sibling is itself a `fork` form inside
@@ -3010,7 +3019,7 @@ let result = await task;
 | ------------------ | ----------------------------------------------------------- |
 | Completed          | Returns `Ok(value)` immediately                             |
 | Running/Pending    | Suspends current task until completion, returns `Ok(value)` |
-| Cancelled          | Returns `Err(...)`                                         |
+| Cancelled          | Returns `Err(...)`                                          |
 | Trapped            | Propagates the trap to the awaiting task                    |
 
 **Type:**
@@ -3219,6 +3228,7 @@ All IO operations in Hew are explicit and return `Result` types. Use
 handle type — reads and writes are free functions:
 
 <!-- doctest: skip -->
+
 ```hew
 fn read_config(path: string) -> Result<Config, string> {
     let content = fs::try_read(path)?;
@@ -3268,6 +3278,7 @@ reachable from inside a child body.
 > The example below uses an indicative placeholder pending ratification.
 
 <!-- doctest: skip -->
+
 ```hew
 actor DataProcessor {
     var cache: HashMap<string, Data> = HashMap::new();
@@ -3312,15 +3323,15 @@ fn heavy_computation() {
 
 ### 4.9 Summary: Tasks vs Actors
 
-| Aspect        | `fork` child task                                   | Actors                           |
-| ------------- | --------------------------------------------------- | -------------------------------- |
-| Communication | Explicit data passing on spawn + `await` for result | Message passing                  |
-| Concurrency   | True parallelism (one OS thread per child)          | True parallelism (M:N scheduler) |
-| Isolation     | Complete (no shared mutable state with parent)      | Complete (mailbox only)          |
-| Failure       | First error becomes `ScopeError::primary`; siblings cancel | Traps isolated to actor   |
-| Lifetime      | Bound to enclosing `scope` block                     | Independent                      |
-| Cancellation  | Automatic at safepoints                             | Supervisor control               |
-| Scheduling    | OS thread per child (substrate); cooperative coroutines are an internal runtime layer | M:N work-stealing scheduler |
+| Aspect        | `fork` child task                                                                     | Actors                           |
+| ------------- | ------------------------------------------------------------------------------------- | -------------------------------- |
+| Communication | Explicit data passing on spawn + `await` for result                                   | Message passing                  |
+| Concurrency   | True parallelism (one OS thread per child)                                            | True parallelism (M:N scheduler) |
+| Isolation     | Complete (no shared mutable state with parent)                                        | Complete (mailbox only)          |
+| Failure       | First error becomes `ScopeError::primary`; siblings cancel                            | Traps isolated to actor          |
+| Lifetime      | Bound to enclosing `scope` block                                                      | Independent                      |
+| Cancellation  | Automatic at safepoints                                                               | Supervisor control               |
+| Scheduling    | OS thread per child (substrate); cooperative coroutines are an internal runtime layer | M:N work-stealing scheduler      |
 
 **Design rationale:**
 
@@ -3391,17 +3402,17 @@ HIR lowering:
 
 **The three forms (closed set).** Each form is fully specified by four
 columns: what the winning arm binds, how the winning arm propagates a
-non-success outcome at the source, how the runtime cleans up *that* arm
+non-success outcome at the source, how the runtime cleans up _that_ arm
 when a different arm wins (loser cleanup), and how the runtime cleans up
 the arm when the enclosing scope is cancelled while the `select` is still
 pending (outer-cancellation cleanup). Sources are the same in both
 cleanup columns; the difference is which side initiates the teardown.
 
-| Form                       | Winning bind / type             | Winning error or trap at the source                                                                                                                                                                                       | Loser cleanup (a different arm won)                                                                                                                                                                       | Outer-cancellation cleanup (enclosing scope cancelled, `select` still pending)                                                                              |
-| -------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<id> from <actor>.<method>(<args>)` | `id: <reply-type>` per ask | `AskError` per HEW-DIST-SPEC §6 — `Partition`, `Timeout`, `Cancelled`, `LocalShutdown`, or `OrphanedAsk` as observed by the caller. Traps in the callee are isolated by the mailbox boundary and do not propagate through the ask. | If the envelope has **not yet been dispatched**, withdraw it from the target actor's mailbox by correlation id — no `OrphanedAsk` is observed on either side. If it **has been dispatched**, the reply sink is tombstoned; a late reply arriving at the tombstoned sink is classified as `OrphanedAsk` and discarded silently (no caller-visible failure). | Same as loser cleanup: withdraw-or-tombstone by correlation id, late reply classified as `OrphanedAsk` and discarded.                                       |
-| `<id> from <rx>.recv()`    | `id: Option<T>` for `Receiver<T>` | `None` is a normal winning value indicating that the channel is closed; `Some(value)` carries the received item. Channel receive has no separate error surface in edition 2026.                              | Pending receive is withdrawn from the channel core; the receiver binding remains usable in the enclosing scope.                                                                                         | Same as loser cleanup: pending receive withdrawn, receiver binding remains usable for the cancellation handler.                                             |
-| `after <duration>`         | no binding; arm type is `()`-shaped at the source | None. Timers cannot fail or trap in edition 2026.                                                                                                                                                                          | The timer is cancelled. No effect propagates.                                                                                                                                                            | The timer is cancelled. No effect propagates.                                                                                                              |
+| Form                                 | Winning bind / type                               | Winning error or trap at the source                                                                                                                                                                                                | Loser cleanup (a different arm won)                                                                                                                                                                                                                                                                                                                        | Outer-cancellation cleanup (enclosing scope cancelled, `select` still pending)                                        |
+| ------------------------------------ | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `<id> from <actor>.<method>(<args>)` | `id: <reply-type>` per ask                        | `AskError` per HEW-DIST-SPEC §6 — `Partition`, `Timeout`, `Cancelled`, `LocalShutdown`, or `OrphanedAsk` as observed by the caller. Traps in the callee are isolated by the mailbox boundary and do not propagate through the ask. | If the envelope has **not yet been dispatched**, withdraw it from the target actor's mailbox by correlation id — no `OrphanedAsk` is observed on either side. If it **has been dispatched**, the reply sink is tombstoned; a late reply arriving at the tombstoned sink is classified as `OrphanedAsk` and discarded silently (no caller-visible failure). | Same as loser cleanup: withdraw-or-tombstone by correlation id, late reply classified as `OrphanedAsk` and discarded. |
+| `<id> from <rx>.recv()`              | `id: Option<T>` for `Receiver<T>`                 | `None` is a normal winning value indicating that the channel is closed; `Some(value)` carries the received item. Channel receive has no separate error surface in edition 2026.                                                    | Pending receive is withdrawn from the channel core; the receiver binding remains usable in the enclosing scope.                                                                                                                                                                                                                                            | Same as loser cleanup: pending receive withdrawn, receiver binding remains usable for the cancellation handler.       |
+| `after <duration>`                   | no binding; arm type is `()`-shaped at the source | None. Timers cannot fail or trap in edition 2026.                                                                                                                                                                                  | The timer is cancelled. No effect propagates.                                                                                                                                                                                                                                                                                                              | The timer is cancelled. No effect propagates.                                                                         |
 
 **Semantics:**
 
@@ -3418,7 +3429,7 @@ cleanup columns; the difference is which side initiates the teardown.
    asynchronous.
 4. **Same-type arms.** All arm result expressions must have the same
    type `T`. The `select` expression has type `T`. There is no `T =
-   Result<U, E>` flattening — if arms return `Result`, the `select`
+Result<U, E>` flattening — if arms return `Result`, the `select`
    returns `Result`.
 5. **Cancellation propagates outward.** If the enclosing `scope {}` is
    cancelled while a `select` is pending, every arm runs its loser-
@@ -3535,12 +3546,12 @@ Edition 2026 defines the legal compositions of `scope {}` and `select {}`
 explicitly. Anything not listed is rejected by type checking, with the
 diagnostic pointing at the offending position.
 
-| Composition                                              | Legality        | Rationale                                                                                                                                                                                          |
-| -------------------------------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `select {}` inside a `scope {}` body or child             | Legal           | The three `select` forms are single-await constructs and compose with the scope block's cancellation discipline at their safepoints.                                                                |
-| `fork name = select { ... }`                             | Legal           | A child task's expression may be a `select` expression; the binding is the `select` expression's result type.                                                                                      |
-| `scope {}` inside a `select` arm's `=>` result expression | Legal           | The arm has already won; its result expression runs in the surrounding scope as ordinary code that happens to contain a scope block.                                                               |
-| `scope { ... }` as a `select` arm source                  | **Rejected**    | The three sealed arm sources are exhaustive (§4.11.1). A scope block is a *lexical region*, not a pending operation, and starting one as a `select` competitor would create children whose scope is unclear if the arm loses. Hint: wrap the fork in a child task and `await` the task instead. |
+| Composition                                               | Legality     | Rationale                                                                                                                                                                                                                                                                                       |
+| --------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `select {}` inside a `scope {}` body or child             | Legal        | The three `select` forms are single-await constructs and compose with the scope block's cancellation discipline at their safepoints.                                                                                                                                                            |
+| `fork name = select { ... }`                              | Legal        | A child task's expression may be a `select` expression; the binding is the `select` expression's result type.                                                                                                                                                                                   |
+| `scope {}` inside a `select` arm's `=>` result expression | Legal        | The arm has already won; its result expression runs in the surrounding scope as ordinary code that happens to contain a scope block.                                                                                                                                                            |
+| `scope { ... }` as a `select` arm source                  | **Rejected** | The three sealed arm sources are exhaustive (§4.11.1). A scope block is a _lexical region_, not a pending operation, and starting one as a `select` competitor would create children whose scope is unclear if the arm loses. Hint: wrap the fork in a child task and `await` the task instead. |
 
 **Cancellation propagation across the composition (normative):**
 
@@ -3549,7 +3560,7 @@ diagnostic pointing at the offending position.
   rule (§4.11.1) and the cancellation then propagates through the
   `select` site as if the site were any other safepoint. The `select`
   does not return a value in this case; control unwinds.
-- When a `select` arm wins inside a scope-block body, only the *losing*
+- When a `select` arm wins inside a scope-block body, only the _losing_
   arms run their loser-cleanup. Sibling fork-children are not affected
   by the arm transition; their scope is bound to the enclosing scope
   block, not to the `select` site.
@@ -3635,12 +3646,12 @@ Then:
 
 ### 5.3 Restart Strategies
 
-| Strategy              | Behaviour                                                           |
-| --------------------- | ------------------------------------------------------------------- |
-| `one_for_one`         | Only the crashed child is restarted.                                |
-| `one_for_all`         | All children are stopped and restarted.                             |
-| `rest_for_one`        | The crashed child and all children declared after it are restarted. |
-| `simple_one_for_one`  | A pool-oriented strategy; only the specific crashed `pool` child instance is restarted. Required for supervisors that use `pool` declarations. |
+| Strategy             | Behaviour                                                                                                                                      |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `one_for_one`        | Only the crashed child is restarted.                                                                                                           |
+| `one_for_all`        | All children are stopped and restarted.                                                                                                        |
+| `rest_for_one`       | The crashed child and all children declared after it are restarted.                                                                            |
+| `simple_one_for_one` | A pool-oriented strategy; only the specific crashed `pool` child instance is restarted. Required for supervisors that use `pool` declarations. |
 
 ### 5.4 Restart Budget and Escalation
 
@@ -3887,6 +3898,7 @@ A bidirectional network connection (such as a TCP socket from `std::net`)
 splits into a `(Stream<bytes>, Sink<bytes>)` pair via `.into_stream_sink()`:
 
 <!-- doctest: skip -->
+
 ```hew
 import std::net;
 
@@ -3907,12 +3919,12 @@ First-class `Stream<T>` values from `std::stream` are bounded handles that may
 be moved across actor boundaries. Both are consumed with `for await`, but they
 have different implementations:
 
-|                     | Actor stream (`receive gen fn`) | `std::stream::Stream<T>`                   |
-| ------------------- | ------------------------------- | ------------------------------------------ |
+|                     | Actor stream (`receive gen fn`) | `std::stream::Stream<T>`                      |
+| ------------------- | ------------------------------- | --------------------------------------------- |
 | Created by          | `receive gen fn` call           | `bytes_pipe()`, `pipe()`, `from_file()`, etc. |
-| Backed by           | Actor mailbox protocol          | Bounded channel / wrapper-specific handle  |
-| Passable as value   | No (tied to the spawned actor)  | Yes (move-only, `Send`)                    |
-| Use in actor fields | No                              | Yes                                        |
+| Backed by           | Actor mailbox protocol          | Bounded channel / wrapper-specific handle     |
+| Passable as value   | No (tied to the spawned actor)  | Yes (move-only, `Send`)                       |
+| Use in actor fields | No                              | Yes                                           |
 
 ---
 
@@ -3922,7 +3934,7 @@ Hew introduces `wire` definitions for network-serializable data.
 
 ### 7.1 Wire type requirements
 
-A `#[wire] struct` / `#[wire] enum`:
+A `#[wire] type` / `#[wire] enum`:
 
 - has stable field tags (numeric IDs)
 - has explicit optionality/defaults
@@ -3956,29 +3968,29 @@ Design goals: compact representation, fast encode/decode, language interoperabil
 
 Hew wire types map to MessagePack formats as follows:
 
-| Hew Type     | MessagePack Format      | Format Marker(s)           | Notes                            |
-| ------------ | ----------------------- | -------------------------- | -------------------------------- |
-| `bool`       | boolean                 | `0xc3` (true), `0xc2` (false) | Single-byte primitives           |
-| `u8`–`u16`   | u64 (up to 16-bit)     | `0xcc`, `0xcd`             | Variable-length u64 encoding    |
-| `u32`–`u64`  | u64 (up to 64-bit)     | `0xce`, `0xcf`             | Variable-length u64 encoding    |
-| `i8`–`i16`   | i64 (signed, up to 16)  | `0xd0`, `0xd1`             | Variable-length signed encoding  |
-| `i32`–`i64`  | i64 (signed, up to 64)  | `0xd2`, `0xd3`             | Variable-length signed encoding  |
-| `f32`        | float32                 | `0xca`                     | IEEE 754 single precision        |
-| `f64`        | float64                 | `0xcb`                     | IEEE 754 double precision        |
-| `string`     | string                  | `0xa0`–`0xbf`, `0xd9`, ... | Length-prefixed UTF-8 string     |
-| `bytes`      | binary                  | `0xc4`, `0xc5`, `0xc6`     | Length-prefixed raw bytes        |
-| `#[wire] struct` | map                     | `0x80`–`0x8f`, `0xde`, ... | Key–value pairs (field number keys) |
-| `#[wire] enum`   | i64 + str (variant)     | Tag + variant index/name   | Encoded as MessagePack integer (variant index) or string (variant name) |
-| Optional     | nil or value            | `0xc0` or type of Some(v)  | `None` encodes as MessagePack nil |
-| List         | array                   | `0x90`–`0x9f`, `0xdc`, ... | Length-prefixed sequence         |
+| Hew Type       | MessagePack Format     | Format Marker(s)              | Notes                                                                   |
+| -------------- | ---------------------- | ----------------------------- | ----------------------------------------------------------------------- |
+| `bool`         | boolean                | `0xc3` (true), `0xc2` (false) | Single-byte primitives                                                  |
+| `u8`–`u16`     | u64 (up to 16-bit)     | `0xcc`, `0xcd`                | Variable-length u64 encoding                                            |
+| `u32`–`u64`    | u64 (up to 64-bit)     | `0xce`, `0xcf`                | Variable-length u64 encoding                                            |
+| `i8`–`i16`     | i64 (signed, up to 16) | `0xd0`, `0xd1`                | Variable-length signed encoding                                         |
+| `i32`–`i64`    | i64 (signed, up to 64) | `0xd2`, `0xd3`                | Variable-length signed encoding                                         |
+| `f32`          | float32                | `0xca`                        | IEEE 754 single precision                                               |
+| `f64`          | float64                | `0xcb`                        | IEEE 754 double precision                                               |
+| `string`       | string                 | `0xa0`–`0xbf`, `0xd9`, ...    | Length-prefixed UTF-8 string                                            |
+| `bytes`        | binary                 | `0xc4`, `0xc5`, `0xc6`        | Length-prefixed raw bytes                                               |
+| `#[wire] type` | map                    | `0x80`–`0x8f`, `0xde`, ...    | Key–value pairs (field number keys)                                     |
+| `#[wire] enum` | i64 + str (variant)    | Tag + variant index/name      | Encoded as MessagePack integer (variant index) or string (variant name) |
+| Optional       | nil or value           | `0xc0` or type of Some(v)     | `None` encodes as MessagePack nil                                       |
+| List           | array                  | `0x90`–`0x9f`, `0xdc`, ...    | Length-prefixed sequence                                                |
 
-##### 7.3.1.2 Wire Struct Encoding
+##### 7.3.1.2 Wire Type Map Encoding
 
-A wire struct is encoded as a MessagePack **map**. Field numbers are used as map keys (as MessagePack integers), and values are encoded according to the table above.
+A `#[wire]` type is encoded as a MessagePack **map**. Field numbers are used as map keys (as MessagePack integers), and values are encoded according to the table above.
 
 ```hew
 #[wire]
-struct User {
+type User {
     id: u64 @1;
     name: string @2;
     email: string @3 optional;
@@ -4004,7 +4016,7 @@ struct User {
 Wire enums are encoded as MessagePack **integers** representing the 0-based variant index:
 
 `#[wire] enum` codec lowering is fully implemented: encode and decode are
-emitted alongside the struct codec path, unified on the CBOR body format.
+emitted alongside the wire type codec path, unified on the CBOR body format.
 
 ```hew
 #[wire]
@@ -4021,7 +4033,7 @@ Optional fields are represented using MessagePack **nil** for `None`:
 
 ```hew
 #[wire]
-struct Config {
+type Config {
     timeout_ms: u64 @1;
     proxy_url: string @2 optional;
 }
@@ -4039,7 +4051,7 @@ Lists are encoded as MessagePack **arrays**. Each element is encoded according t
 
 ```hew
 #[wire]
-struct Data {
+type Data {
     values: [i64] @1;
     tags: [string] @2;
 }
@@ -4053,13 +4065,13 @@ struct Data {
 
 ##### 7.3.1.6 Nested Structure Encoding
 
-Nested wire structs are encoded recursively as MessagePack maps:
+Nested `#[wire]` types are encoded recursively as MessagePack maps:
 
 ```hew
 #[wire]
-struct Inner { x: i32 @1; }
+type Inner { x: i32 @1; }
 #[wire]
-struct Outer { inner: Inner @1; nested_list: [Inner] @2; }
+type Outer { inner: Inner @1; nested_list: [Inner] @2; }
 
 // Outer { inner: Inner { x: 150 }, nested_list: [Inner { x: 200 }] } encodes as:
 // MessagePack map: {
@@ -4070,10 +4082,10 @@ struct Outer { inner: Inner @1; nested_list: [Inner] @2; }
 
 ##### 7.3.1.7 Forward and Backward Compatibility
 
-Unknown fields are preserved during round-trip encoding/decoding. When a wire struct carries fields unknown to a decoder, those fields are:
+Unknown fields are preserved during round-trip encoding/decoding. When a `#[wire]` type carries fields unknown to a decoder, those fields are:
 
 1. Decoded and stored in the decoder's internal unknown-fields store.
-2. Re-encoded when the struct is re-serialized.
+2. Re-encoded when the value is re-serialized.
 
 This enables older code to accept and pass through messages containing fields added in newer schema versions.
 
@@ -4104,7 +4116,7 @@ JSON encoding provides human-readable serialization for HTTP APIs, debugging, an
 | `string`                               | JSON string                                                 |
 | `bytes`                                | JSON string (base64-encoded)                                |
 | Lists                                  | JSON array                                                  |
-| `#[wire] struct`                       | JSON object with field names as keys                        |
+| `#[wire] type`                         | JSON object with field names as keys                        |
 | `#[wire] enum`                         | JSON string (variant name)                                  |
 | Optional None                          | JSON `null` or field omitted                                |
 | Optional Some(v)                       | JSON value of v                                             |
@@ -4114,15 +4126,15 @@ JSON encoding provides human-readable serialization for HTTP APIs, debugging, an
 JSON field names are determined by the following rules, in priority order:
 
 1. **Per-field override** — `json("name")` wire attribute sets the exact JSON key.
-2. **Struct-level convention** — `#[json(convention)]` attribute on the `#[wire] struct` declaration transforms all field names. Valid conventions: `camelCase`, `PascalCase`, `snake_case`, `SCREAMING_SNAKE`, `kebab-case`.
+2. **Type-level convention** — `#[json(convention)]` attribute on the `#[wire] type` declaration transforms all field names. Valid conventions: `camelCase`, `PascalCase`, `snake_case`, `SCREAMING_SNAKE`, `kebab-case`.
 3. **Default** — field name is used as-is (no transformation).
 
-Per-field override always wins over the struct-level convention.
+Per-field override always wins over the type-level convention.
 
 ```hew
 #[json(camelCase)]
 #[wire]
-struct User {
+type User {
     user_name: string @1;                       // JSON: "userName"
     email_address: string @2;                   // JSON: "emailAddress"
     internal_id: string @3 json("id");          // JSON: "id"  (override wins)
@@ -4139,11 +4151,11 @@ JSON representation:
 }
 ```
 
-Without the struct-level attribute, names are preserved exactly:
+Without the type-level attribute, names are preserved exactly:
 
 ```hew
 #[wire]
-struct User {
+type User {
     user_name: string @1;
     email_address: string @2;
 }
@@ -4204,13 +4216,13 @@ enum Status { PendingReview; ActiveNow; Completed; }
 
 Encoders select format based on context:
 
-| Context                 | Default Format |
-| ----------------------- | -------------- |
-| Actor-to-actor (local)  | CBOR           |
-| Actor-to-actor (remote) | CBOR           |
-| HTTP API response       | JSON           |
+| Context                 | Default Format                   |
+| ----------------------- | -------------------------------- |
+| Actor-to-actor (local)  | CBOR                             |
+| Actor-to-actor (remote) | CBOR                             |
+| HTTP API response       | JSON                             |
 | File storage            | user choice (`std::encoding::*`) |
-| Debugging/logging       | JSON           |
+| Debugging/logging       | JSON                             |
 
 Explicit format selection:
 
@@ -4231,9 +4243,9 @@ let msg3 = MyMessage.from_yaml(yaml_str);
 
 Current shipped helper surface, as registered by the type checker:
 
-- `#[wire] struct` instance methods: `encode() -> bytes`, `to_json() -> string`,
+- `#[wire] type` instance methods: `encode() -> bytes`, `to_json() -> string`,
   `to_yaml() -> string`
-- `#[wire] struct` static methods: `MyMessage.decode(bytes) -> MyMessage`,
+- `#[wire] type` static methods: `MyMessage.decode(bytes) -> MyMessage`,
   `MyMessage.from_json(string) -> MyMessage`,
   `MyMessage.from_yaml(string) -> MyMessage`
 - unit-only `#[wire] enum` helpers are JSON/YAML-only:
@@ -4314,8 +4326,8 @@ Native object / WASM
   - Generator borrow across yield.
   - Actor-send escape (a value captured into an outgoing message that
     aliases live state in the sending actor).
-  `@linear` must-consume obligations are discharged here; unconsumed
-  `@linear` values surface as `MustConsumeAtScopeExit`.
+    `@linear` must-consume obligations are discharged here; unconsumed
+    `@linear` values surface as `MustConsumeAtScopeExit`.
 - **Elaborated MIR.** Drops are first-class basic blocks in the CFG.
   Cleanup edges (panic, cancellation) are real edges. Every CFG exit
   runs the right destructor sequence in the right order. `@resource`
@@ -4465,12 +4477,12 @@ for messages are `Idle` (or `Suspended` during a cooperative suspension) and bec
 
 **Key distinctions from task states (§4.1):**
 
-| Aspect          | Actor State Machine                                                        | Task State Machine (§4.1)                     |
-| --------------- | -------------------------------------------------------------------------- | --------------------------------------------- |
-| **Entity**      | Entire actor instance                                                      | Individual task within an actor               |
-| **Managed by**  | Runtime scheduler (Level 1)                                                | Actor-local coroutine executor (Level 2)      |
-| **States**      | Idle/Runnable/Running/Suspended/Stopping/Crashing/Crashed/Stopped/Sleeping | Pending/Running/Completed/Cancelled/Trapped   |
-| **Granularity** | One per actor                                                              | Many per actor (one per `fork` child)         |
+| Aspect          | Actor State Machine                                                        | Task State Machine (§4.1)                   |
+| --------------- | -------------------------------------------------------------------------- | ------------------------------------------- |
+| **Entity**      | Entire actor instance                                                      | Individual task within an actor             |
+| **Managed by**  | Runtime scheduler (Level 1)                                                | Actor-local coroutine executor (Level 2)    |
+| **States**      | Idle/Runnable/Running/Suspended/Stopping/Crashing/Crashed/Stopped/Sleeping | Pending/Running/Completed/Cancelled/Trapped |
+| **Granularity** | One per actor                                                              | Many per actor (one per `fork` child)       |
 
 Supervisor observes actor terminal states `Stopped` or `Crashed`.
 
@@ -4529,12 +4541,12 @@ added in later editions without growing the annotation vocabulary.
 
 **Hooks defined in this edition:**
 
-| Annotation       | Signature                                 | Runs when                                                                                       |
-| ---------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `#[on(start)]`   | `fn name()`                               | Once, after the actor's fields are initialized and before any message is dispatched.            |
+| Annotation       | Signature                                 | Runs when                                                                                                 |
+| ---------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `#[on(start)]`   | `fn name()`                               | Once, after the actor's fields are initialized and before any message is dispatched.                      |
 | `#[on(stop)]`    | `fn name()`                               | Once per actor instance, on normal exit, cancellation by an enclosing `fork{}`, or supervisor `Shutdown`. |
-| `#[on(crash)]`   | `fn name(info: CrashInfo) -> CrashAction` | After a child trap is classified and before restart-policy handling.                            |
-| `#[on(upgrade)]` | reserved                                  | Reserved for future hot-upgrade machinery; not a usable hook in this edition.                   |
+| `#[on(crash)]`   | `fn name(info: CrashInfo) -> CrashAction` | After a child trap is classified and before restart-policy handling.                                      |
+| `#[on(upgrade)]` | reserved                                  | Reserved for future hot-upgrade machinery; not a usable hook in this edition.                             |
 
 Unknown hook kinds (e.g. `#[on(restart)]`) are rejected with a diagnostic listing the valid set.
 
@@ -4560,12 +4572,14 @@ and is rejected during lowering.
 
 9. Cancellation by an enclosing `fork{}` scope triggers `#[on(stop)]` for each cancelled actor before its task ends. This is the common path under structured concurrency, not an exceptional one.
 10. The runtime sequence at terminal transition is:
-   - (a) actor body exits or is cancelled;
-   - (b) the `#[on(stop)]` hook runs with field access live, if present;
-   - (c) `#[linear]` consumed-checks fire (unconsumed linear values surface as diagnostics);
-   - (d) `#[resource]` field `close()` methods run in reverse declaration order.
-   Hooks therefore run BEFORE `#[resource]` `close()`, so user logic in a hook can still use resources for goodbye flushes.
-11. A panic in `#[on(start)]` aborts actor startup. The supervisor is notified; `#[on(stop)]` does NOT run, because the actor never reached the *started* state.
+
+- (a) actor body exits or is cancelled;
+- (b) the `#[on(stop)]` hook runs with field access live, if present;
+- (c) `#[linear]` consumed-checks fire (unconsumed linear values surface as diagnostics);
+- (d) `#[resource]` field `close()` methods run in reverse declaration order.
+  Hooks therefore run BEFORE `#[resource]` `close()`, so user logic in a hook can still use resources for goodbye flushes.
+
+11. A panic in `#[on(start)]` aborts actor startup. The supervisor is notified; `#[on(stop)]` does NOT run, because the actor never reached the _started_ state.
 12. The default `#[on(stop)]` timeout budget is 5 seconds; future editions MAY introduce `#[on(stop, timeout = <duration>)]` to override per actor.
 
 **Compilation:** `#[on(start)]` bodies are appended to the synthesized `_init`
@@ -4690,15 +4704,15 @@ When the grammar files and this specification disagree, the parser implementatio
 > are rejected. Integer literals default to `i64`; literal defaulting is not a
 > user-nameable alias and does not affect wire shape or ABI.
 
-| Type                      | Size          | Description             |
-| ------------------------- | ------------- | ----------------------- |
-| `i8`, `i16`, `i32`, `i64` | 1/2/4/8 bytes | Signed integers (fixed-width) |
-| `u8`, `u16`, `u32`, `u64` | 1/2/4/8 bytes | Unsigned integers (fixed-width) |
-| `isize`                   | platform      | Platform-sized signed integer: 32-bit on WASM32, 64-bit on native. Distinct from any fixed-width integer type. |
+| Type                      | Size          | Description                                                                                                      |
+| ------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `i8`, `i16`, `i32`, `i64` | 1/2/4/8 bytes | Signed integers (fixed-width)                                                                                    |
+| `u8`, `u16`, `u32`, `u64` | 1/2/4/8 bytes | Unsigned integers (fixed-width)                                                                                  |
+| `isize`                   | platform      | Platform-sized signed integer: 32-bit on WASM32, 64-bit on native. Distinct from any fixed-width integer type.   |
 | `usize`                   | platform      | Platform-sized unsigned integer: 32-bit on WASM32, 64-bit on native. Distinct from any fixed-width integer type. |
-| `f32`, `f64`              | 4/8 bytes     | IEEE 754 floating point |
-| `bool`                    | 1 byte        | Boolean (true/false)    |
-| `char`                    | 4 bytes       | Unicode scalar value    |
+| `f32`, `f64`              | 4/8 bytes     | IEEE 754 floating point                                                                                          |
+| `bool`                    | 1 byte        | Boolean (true/false)                                                                                             |
+| `char`                    | 4 bytes       | Unicode scalar value                                                                                             |
 
 **Type aliases** (compile-time synonyms only — the aliased type is what the checker sees):
 
@@ -4745,12 +4759,12 @@ let nan_as_int: i32 = nan.to_i32();     // 0 — NaN converts to zero
 
 **Float-to-integer conversion semantics:**
 
-| Source value          | Signed result      | Unsigned result |
-| --------------------- | ------------------ | --------------- |
-| In-range finite       | Truncated toward 0 | Truncated toward 0 |
-| `+Inf` or > MAX       | Integer `MAX`      | Integer `MAX` (`UINT_MAX`) |
-| `-Inf` or < MIN       | Integer `MIN`      | `0` |
-| `NaN`                 | `0`                | `0` |
+| Source value    | Signed result      | Unsigned result            |
+| --------------- | ------------------ | -------------------------- |
+| In-range finite | Truncated toward 0 | Truncated toward 0         |
+| `+Inf` or > MAX | Integer `MAX`      | Integer `MAX` (`UINT_MAX`) |
+| `-Inf` or < MIN | Integer `MIN`      | `0`                        |
+| `NaN`           | `0`                | `0`                        |
 
 These semantics are guaranteed on all Hew targets (x86_64, aarch64, wasm32). The underlying LLVM lowering uses `llvm.fptosi.sat` / `llvm.fptoui.sat`, which produce defined behaviour for all input values. Plain `fptosi` / `fptoui` (which produce LLVM poison for out-of-range inputs) are never emitted.
 

--- a/docs/specs/HEW-WIRE-FORMAT-DOCTRINE.md
+++ b/docs/specs/HEW-WIRE-FORMAT-DOCTRINE.md
@@ -53,11 +53,11 @@ that conform to that schema live in
 
 The Rust mirror is `EnvelopeFrame` (and `ControlFrame`) in
 [`hew-runtime/src/envelope.rs`][envelope-rs] starting near line 30. The
-CDDL integer keys are mirrored as field-doc comments on each struct field.
+CDDL integer keys are mirrored as field-doc comments on each Rust mirror field.
 
 ### The message body — CDDL-described tagged CBOR
 
-The `envelope-frame` `payload` (key `6`) is a `bstr` to the *frame* schema:
+The `envelope-frame` `payload` (key `6`) is a `bstr` to the _frame_ schema:
 the frame does not interpret it. The bytes inside that `bstr` are the
 **per-`#[wire]`-type CBOR body** the codegen serializer emits for the
 message being sent, and they have their own doc-of-truth schema in
@@ -69,7 +69,7 @@ whole internode wire — frame and body — CDDL-described.
 
 The body shapes (the `wire-body` rule and its parts):
 
-- A **`#[wire]` struct** (or any cross-node `Serializable` record) encodes
+- A **`#[wire]` type** (or any cross-node `Serializable` record) encodes
   as a CBOR **map keyed by the unsigned `@N` field tags** — `cbor_field_key`
   uses the explicit `@N` from the wire layout, or a 1-based positional
   fallback for layout-less records. Keys are emitted in canonical
@@ -85,18 +85,18 @@ The body shapes (the `wire-body` rule and its parts):
 - The **leaf floor** is scalars (CBOR int / uint / bool / float), `string`
   (CBOR text), `bytes` (CBOR byte string), `Option<T>` (`null` for `None`,
   the inner encoding for `Some`), `Vec<T>` (a CBOR array), and nested
-  `#[wire]` structs/enums (nested maps / unit-tag / map-of-one). A value
+  `#[wire]` types/enums (nested maps / unit-tag / map-of-one). A value
   type outside this floor fails closed at codegen ("unsupported value type …
   outside the supported wire-body floor") and never reaches the wire.
 
 ### Tag-stability asymmetry — explicit `@N` vs ordinal
 
-Struct fields and enum variants carry their wire tag differently, and this
+Type fields and enum variants carry their wire tag differently, and this
 creates an **important stability asymmetry**:
 
-- **`#[wire]` struct fields** use the **explicit `@N` tag** from the wire
+- **`#[wire]` type fields** use the **explicit `@N` tag** from the wire
   layout (`cbor_field_key` picks the declared tag, not the field's
-  declaration position). Reordering struct fields in source is
+  declaration position). Reordering type fields in source is
   **wire-safe**: the tag is the `@N` annotation, not the position.
 - **`#[wire]` enum variants** use the **declaration ordinal** as their tag
   (`cbor_variant_tag` falls back to `variant_idx` when no explicit tag is
@@ -104,7 +104,7 @@ creates an **important stability asymmetry**:
   and is a **breaking wire change**: a sender's `Ping` at ordinal 0 is
   no longer the receiver's `Ping` at ordinal 1.
 
-In short: reordering `#[wire]` struct fields is safe; reordering `#[wire]`
+In short: reordering `#[wire]` type fields is safe; reordering `#[wire]`
 enum variants is a breaking change. If you need reorder-stable enum variants,
 assign an explicit tag annotation — the `@N` mechanism is available on enum
 variants for exactly this reason.
@@ -172,7 +172,7 @@ The round-trip and version-rejection tests live in
 ### Required posture for runtime code touching the wire
 
 - Add new envelope fields **first to the CDDL**, then to `EnvelopeFrame`.
-  The CDDL is the doc-of-truth; the Rust struct conforms to it, not the
+  The CDDL is the doc-of-truth; the Rust mirror conforms to it, not the
   other way around. The same rule holds for the body: a change to the
   per-type body shape the codegen serializer emits must be reflected in
   `wire-body.cddl`, and the conformance test keeps the two from drifting.
@@ -204,20 +204,20 @@ and was settled by issue #1247.
 
 ### Module inventory and honest status
 
-| Module | Status | What's there today |
-| --- | --- | --- |
-| `std::encoding::json` | **Real.** Production-shape encoder/decoder. | `std/encoding/json/` (~2k LOC). Backing parser + the opaque `Value` surface. |
-| `std::encoding::yaml` | **Real.** Full parser/serialiser. | `std/encoding/yaml/` (~2.4k LOC). |
-| `std::encoding::toml` | **Real.** Parser/generator + datetime variant. | `std/encoding/toml/` (~1.2k LOC). |
-| `std::encoding::msgpack` | **Real, JSON-bridged.** Encode/decode against the canonical `Value`; per the `wire` README it bridges through JSON's value model when crossing the opaque surface. | `std/encoding/msgpack/` (~1k LOC). |
-| `std::encoding::protobuf` | **Real, scoped.** Wire-format encode/decode helpers; not a schema compiler. | `std/encoding/protobuf/` (~1.5k LOC). |
-| `std::encoding::xml` | **Real, scoped.** Parse/serialise. | `std/encoding/xml/` (~850 LOC). |
-| `std::encoding::csv` | **Real, scoped.** | `std/encoding/csv/`. |
-| `std::encoding::markdown` | **Real, scoped.** Markdown → HTML rendering only. | `std/encoding/markdown/`. |
-| `std::encoding::base64` | **Real.** | `std/encoding/base64/`. |
-| `std::encoding::hex` | **Real.** | `std/encoding/hex/`. |
-| `std::encoding::compress` | **Real.** gzip/deflate/zlib. | `std/encoding/compress/`. |
-| `std::encoding::wire` | **Substrate.** Holds the opaque `Value` contract (issue #1247). The legacy HBF byte-layout helpers (`encode_header` / framing) were removed when the CBOR-native wire format replaced HBF. | `std/encoding/wire/` — see §5 for history. |
+| Module                    | Status                                                                                                                                                                                     | What's there today                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `std::encoding::json`     | **Real.** Production-shape encoder/decoder.                                                                                                                                                | `std/encoding/json/` (~2k LOC). Backing parser + the opaque `Value` surface. |
+| `std::encoding::yaml`     | **Real.** Full parser/serialiser.                                                                                                                                                          | `std/encoding/yaml/` (~2.4k LOC).                                            |
+| `std::encoding::toml`     | **Real.** Parser/generator + datetime variant.                                                                                                                                             | `std/encoding/toml/` (~1.2k LOC).                                            |
+| `std::encoding::msgpack`  | **Real, JSON-bridged.** Encode/decode against the canonical `Value`; per the `wire` README it bridges through JSON's value model when crossing the opaque surface.                         | `std/encoding/msgpack/` (~1k LOC).                                           |
+| `std::encoding::protobuf` | **Real, scoped.** Wire-format encode/decode helpers; not a schema compiler.                                                                                                                | `std/encoding/protobuf/` (~1.5k LOC).                                        |
+| `std::encoding::xml`      | **Real, scoped.** Parse/serialise.                                                                                                                                                         | `std/encoding/xml/` (~850 LOC).                                              |
+| `std::encoding::csv`      | **Real, scoped.**                                                                                                                                                                          | `std/encoding/csv/`.                                                         |
+| `std::encoding::markdown` | **Real, scoped.** Markdown → HTML rendering only.                                                                                                                                          | `std/encoding/markdown/`.                                                    |
+| `std::encoding::base64`   | **Real.**                                                                                                                                                                                  | `std/encoding/base64/`.                                                      |
+| `std::encoding::hex`      | **Real.**                                                                                                                                                                                  | `std/encoding/hex/`.                                                         |
+| `std::encoding::compress` | **Real.** gzip/deflate/zlib.                                                                                                                                                               | `std/encoding/compress/`.                                                    |
+| `std::encoding::wire`     | **Substrate.** Holds the opaque `Value` contract (issue #1247). The legacy HBF byte-layout helpers (`encode_header` / framing) were removed when the CBOR-native wire format replaced HBF. | `std/encoding/wire/` — see §5 for history.                                   |
 
 Each module's README states its own scope. The doctrine here is about
 **which one to reach for**, not how each one is implemented.

--- a/docs/specs/HEW-WIRE-FORMAT-DOCTRINE.md
+++ b/docs/specs/HEW-WIRE-FORMAT-DOCTRINE.md
@@ -57,7 +57,7 @@ CDDL integer keys are mirrored as field-doc comments on each Rust mirror field.
 
 ### The message body — CDDL-described tagged CBOR
 
-The `envelope-frame` `payload` (key `6`) is a `bstr` to the _frame_ schema:
+The `envelope-frame` `payload` (key `6`) is a `bstr` to the *frame* schema:
 the frame does not interpret it. The bytes inside that `bstr` are the
 **per-`#[wire]`-type CBOR body** the codegen serializer emits for the
 message being sent, and they have their own doc-of-truth schema in
@@ -204,20 +204,20 @@ and was settled by issue #1247.
 
 ### Module inventory and honest status
 
-| Module                    | Status                                                                                                                                                                                     | What's there today                                                           |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
-| `std::encoding::json`     | **Real.** Production-shape encoder/decoder.                                                                                                                                                | `std/encoding/json/` (~2k LOC). Backing parser + the opaque `Value` surface. |
-| `std::encoding::yaml`     | **Real.** Full parser/serialiser.                                                                                                                                                          | `std/encoding/yaml/` (~2.4k LOC).                                            |
-| `std::encoding::toml`     | **Real.** Parser/generator + datetime variant.                                                                                                                                             | `std/encoding/toml/` (~1.2k LOC).                                            |
-| `std::encoding::msgpack`  | **Real, JSON-bridged.** Encode/decode against the canonical `Value`; per the `wire` README it bridges through JSON's value model when crossing the opaque surface.                         | `std/encoding/msgpack/` (~1k LOC).                                           |
-| `std::encoding::protobuf` | **Real, scoped.** Wire-format encode/decode helpers; not a schema compiler.                                                                                                                | `std/encoding/protobuf/` (~1.5k LOC).                                        |
-| `std::encoding::xml`      | **Real, scoped.** Parse/serialise.                                                                                                                                                         | `std/encoding/xml/` (~850 LOC).                                              |
-| `std::encoding::csv`      | **Real, scoped.**                                                                                                                                                                          | `std/encoding/csv/`.                                                         |
-| `std::encoding::markdown` | **Real, scoped.** Markdown → HTML rendering only.                                                                                                                                          | `std/encoding/markdown/`.                                                    |
-| `std::encoding::base64`   | **Real.**                                                                                                                                                                                  | `std/encoding/base64/`.                                                      |
-| `std::encoding::hex`      | **Real.**                                                                                                                                                                                  | `std/encoding/hex/`.                                                         |
-| `std::encoding::compress` | **Real.** gzip/deflate/zlib.                                                                                                                                                               | `std/encoding/compress/`.                                                    |
-| `std::encoding::wire`     | **Substrate.** Holds the opaque `Value` contract (issue #1247). The legacy HBF byte-layout helpers (`encode_header` / framing) were removed when the CBOR-native wire format replaced HBF. | `std/encoding/wire/` — see §5 for history.                                   |
+| Module | Status | What's there today |
+| --- | --- | --- |
+| `std::encoding::json` | **Real.** Production-shape encoder/decoder. | `std/encoding/json/` (~2k LOC). Backing parser + the opaque `Value` surface. |
+| `std::encoding::yaml` | **Real.** Full parser/serialiser. | `std/encoding/yaml/` (~2.4k LOC). |
+| `std::encoding::toml` | **Real.** Parser/generator + datetime variant. | `std/encoding/toml/` (~1.2k LOC). |
+| `std::encoding::msgpack` | **Real, JSON-bridged.** Encode/decode against the canonical `Value`; per the `wire` README it bridges through JSON's value model when crossing the opaque surface. | `std/encoding/msgpack/` (~1k LOC). |
+| `std::encoding::protobuf` | **Real, scoped.** Wire-format encode/decode helpers; not a schema compiler. | `std/encoding/protobuf/` (~1.5k LOC). |
+| `std::encoding::xml` | **Real, scoped.** Parse/serialise. | `std/encoding/xml/` (~850 LOC). |
+| `std::encoding::csv` | **Real, scoped.** | `std/encoding/csv/`. |
+| `std::encoding::markdown` | **Real, scoped.** Markdown → HTML rendering only. | `std/encoding/markdown/`. |
+| `std::encoding::base64` | **Real.** | `std/encoding/base64/`. |
+| `std::encoding::hex` | **Real.** | `std/encoding/hex/`. |
+| `std::encoding::compress` | **Real.** gzip/deflate/zlib. | `std/encoding/compress/`. |
+| `std::encoding::wire` | **Substrate.** Holds the opaque `Value` contract (issue #1247). The legacy HBF byte-layout helpers (`encode_header` / framing) were removed when the CBOR-native wire format replaced HBF. | `std/encoding/wire/` — see §5 for history. |
 
 Each module's README states its own scope. The doctrine here is about
 **which one to reach for**, not how each one is implemented.

--- a/docs/specs/Hew.g4
+++ b/docs/specs/Hew.g4
@@ -172,9 +172,9 @@ recordTupleBody
     : '(' type_ ( ',' type_ )* ','? ')' ';'
     ;
 
-// #[wire] struct syntax — canonical wire struct declaration
+// #[wire] type syntax — canonical wire type declaration
 wireStructDecl
-    : 'struct' ident '{' wireStructItem* '}'
+    : 'type' ident '{' wireStructItem* '}'
     ;
 
 typeParams
@@ -893,7 +893,7 @@ typeArgs
     ;
 
 // ----------------------------------------------------------------
-//  Wire types (for wire struct/enum declarations)
+//  Wire types (for wire type/enum declarations)
 // ----------------------------------------------------------------
 
 wireType

--- a/docs/specs/grammar.ebnf
+++ b/docs/specs/grammar.ebnf
@@ -71,8 +71,8 @@ ConstDecl      = "const" Ident ":" Type "=" Expr ";" ;
 
 TypeDecl       = "type" Ident TypeParams? WhereClause? TypeBody
                | "indirect"? "enum" Ident TypeParams? WhereClause? TypeBody ;
-(* #[wire] struct syntax — sole canonical wire struct declaration *)
-WireStructDecl = "struct" Ident "{" { WireStructFieldDecl | ReservedDecl ";" } "}" ;
+(* #[wire] type syntax — canonical wire type declaration *)
+WireStructDecl = "type" Ident "{" { WireStructFieldDecl | ReservedDecl ";" } "}" ;
 WireStructFieldDecl = Ident ":" Type ( "@" IntLit )? WireAttr* ( "," | ";" ) ;
 
 TypeParams     = "<" TypeParam { "," TypeParam } ">" ;
@@ -85,7 +85,6 @@ WhereClause    = "where" WherePredicate { "," WherePredicate } [ "," ] ;
 WherePredicate = Type ":" TraitBounds ;
 
 TypeBody       = "{" { StructFieldDecl | VariantDecl | FnDecl } "}" ;
-(* WireBody is used by the legacy wire keyword form — no longer a production *)
 
 StructFieldDecl = Attribute* Ident ":" Type ( ";" | "," ) ;
 ActorFieldDecl  = ("let" | "var")? Ident ":" Type ("=" Expr)? ";" ;

--- a/examples/comparison/counter_service.hew
+++ b/examples/comparison/counter_service.hew
@@ -22,7 +22,7 @@ supervisor CounterPool {
 // Wire types are first-class.
 // Schema evolution rules enforced at compile time.
 #[wire]
-struct CounterUpdate {
+type CounterUpdate {
     counter_id: u32 @1,
     new_count: i32 @2,
     timestamp: u64 @3,

--- a/examples/comprehensive_test.hew
+++ b/examples/comprehensive_test.hew
@@ -25,7 +25,7 @@ enum Colour {
 
 // === Wire Types ===
 #[wire]
-struct Message {
+type Message {
     data: i32 @1,
     text: string @2,
 }

--- a/examples/demo_four_pillars.hew
+++ b/examples/demo_four_pillars.hew
@@ -14,7 +14,7 @@ actor Counter {
 }
 
 #[wire]
-struct StatusUpdate {
+type StatusUpdate {
     actor_id: u32 @1,
     count: i32 @2,
     message: string @3,

--- a/examples/playground/types/wire_types.hew
+++ b/examples/playground/types/wire_types.hew
@@ -5,7 +5,7 @@
 // an explicit tag (@1, @2, ...) so the binary encoding stays compatible as
 // the schema evolves. Optional fields may be added or omitted across versions.
 #[wire]
-struct UserMessage {
+type UserMessage {
     name: string @1,
     age: i32 @2,
     nickname: string @3 optional,

--- a/examples/ux/05_struct.hew
+++ b/examples/ux/05_struct.hew
@@ -1,4 +1,4 @@
-// Simple struct
+// Simple record type
 type Point {
     x: i64;
     y: i64;

--- a/hew-cli/src/doc/highlight.rs
+++ b/hew-cli/src/doc/highlight.rs
@@ -52,7 +52,6 @@ fn token_color(tok: &Token<'_>) -> &'static str {
         | Token::Pub
         | Token::Package
         | Token::Super
-        | Token::Struct
         | Token::Indirect
         | Token::Enum
         | Token::Trait

--- a/hew-cli/tests/compile_links_runtime.rs
+++ b/hew-cli/tests/compile_links_runtime.rs
@@ -135,7 +135,7 @@ fn wire_decode_valid_bytes_round_trips() {
     require_codegen();
     let (_emit_dir, binary_path) = compile_to_native(
         "#[wire]\n\
-         struct Point { x: i64 @1, y: i64 @2 }\n\
+         type Point { x: i64 @1, y: i64 @2 }\n\
          fn main() -> i64 {\n\
          \x20   let p = Point { x: 7, y: 35 };\n\
          \x20   let b = p.encode();\n\
@@ -170,7 +170,7 @@ fn wire_decode_malformed_bytes_fails_closed_not_segfault() {
     require_codegen();
     let (_emit_dir, binary_path) = compile_to_native(
         "#[wire]\n\
-         struct Point { x: i64 @1, y: i64 @2 }\n\
+         type Point { x: i64 @1, y: i64 @2 }\n\
          fn main() -> i64 {\n\
          \x20   let b: bytes = bytes::new();\n\
          \x20   let p = Point.decode(b);\n\

--- a/hew-cli/tests/fixtures/distributed/dist_node.hew
+++ b/hew-cli/tests/fixtures/distributed/dist_node.hew
@@ -72,7 +72,7 @@ enum KvResp {
 // request (WireCmd) and the reply (WireResult) are #[wire] types, so the
 // explicit-@N body is proven crossing the wire in BOTH directions.
 #[wire]
-struct WirePoint {
+type WirePoint {
     x: i64 @1,
     y: i64 @2,
 }
@@ -89,7 +89,7 @@ enum WireCmd {
 // WireResult is the #[wire] struct reply: `tag` is which variant the server saw
 // (0 = Ping, 1 = Move); `sum` is x + y for Move, or 0 for Ping.
 #[wire]
-struct WireResult {
+type WireResult {
     tag: i64 @1,
     sum: i64 @2,
 }

--- a/hew-cli/tests/wire_cbor_codec_leak_oracle.rs
+++ b/hew-cli/tests/wire_cbor_codec_leak_oracle.rs
@@ -142,9 +142,9 @@ const SLOPE_TOLERANCE: usize = 5;
 fn round_trip_source(frames: usize) -> String {
     format!(
         "#[wire]\n\
-         struct Inner {{ name: string @1; }}\n\
+         type Inner {{ name: string @1; }}\n\
          #[wire]\n\
-         struct Packet {{ label: string @1; tags: Vec<string> @2; inner: Inner @3; seq: i64 @4; }}\n\
+         type Packet {{ label: string @1; tags: Vec<string> @2; inner: Inner @3; seq: i64 @4; }}\n\
          \n\
          fn main() -> i64 {{\n\
          \x20   var total: i64 = 0;\n\
@@ -184,9 +184,9 @@ fn round_trip_source(frames: usize) -> String {
 fn vec_struct_round_trip_source(frames: usize) -> String {
     format!(
         "#[wire]\n\
-         struct Inner {{ v: i64 @1; }}\n\
+         type Inner {{ v: i64 @1; }}\n\
          #[wire]\n\
-         struct Container {{ items: Vec<Inner> @1; seq: i64 @2; }}\n\
+         type Container {{ items: Vec<Inner> @1; seq: i64 @2; }}\n\
          \n\
          fn main() -> i64 {{\n\
          \x20   var total: i64 = 0;\n\
@@ -216,9 +216,9 @@ fn vec_struct_round_trip_source(frames: usize) -> String {
 /// first) but keeps the decoded binding live so the codec path is fully
 /// emitted.
 const DECODE_FAILURE_SOURCE: &str = "#[wire]\n\
-     struct TwoStr { a: string @1; b: string @2; }\n\
+     type TwoStr { a: string @1; b: string @2; }\n\
      #[wire]\n\
-     struct Pair { a: string @1; b: i64 @2; }\n\
+     type Pair { a: string @1; b: i64 @2; }\n\
      \n\
      fn main() -> i64 {\n\
      \x20   let t = TwoStr { a: \"owned-field-a-value\", b: \"owned-field-b-value\" };\n\
@@ -243,7 +243,7 @@ const DECODE_FAILURE_SOURCE: &str = "#[wire]\n\
 fn enum_owned_payload_round_trip_source(frames: usize) -> String {
     format!(
         "#[wire]\n\
-         struct Inner {{ name: string @1; }}\n\
+         type Inner {{ name: string @1; }}\n\
          #[wire]\n\
          enum Payload {{ Empty; Full(string, Vec<string>, Inner); }}\n\
          \n\
@@ -274,7 +274,7 @@ fn enum_owned_payload_round_trip_source(frames: usize) -> String {
 /// (drop the already-decoded owned string, then free the shell, then return
 /// null → trap). Proves the partial owned field is freed exactly once.
 const ENUM_DECODE_FAILURE_SOURCE: &str = "#[wire]\n\
-     struct Inner { name: string @1; }\n\
+     type Inner { name: string @1; }\n\
      #[wire]\n\
      enum PayloadGood { Empty; Full(string, Vec<string>, Inner); }\n\
      #[wire]\n\

--- a/hew-cli/tests/wire_check_e2e.rs
+++ b/hew-cli/tests/wire_check_e2e.rs
@@ -42,8 +42,8 @@ fn assert_wire_check_ok(current: &str, baseline: &str) -> String {
 #[test]
 fn wire_check_rejects_duplicate_field_tag_in_current() {
     let output = run_wire_check(
-        "#[wire]\nstruct Msg { id: String @1; also_id: i32 @1; }\n",
-        "#[wire]\nstruct Msg { id: String @1; }\n",
+        "#[wire]\ntype Msg { id: String @1; also_id: i32 @1; }\n",
+        "#[wire]\ntype Msg { id: String @1; }\n",
     );
 
     assert!(!output.status.success());
@@ -60,8 +60,8 @@ fn wire_check_rejects_duplicate_field_tag_in_current() {
 #[test]
 fn wire_check_rejects_duplicate_field_tag_in_baseline() {
     let output = run_wire_check(
-        "#[wire]\nstruct Msg { id: String @1; }\n",
-        "#[wire]\nstruct Msg { id: String @1; also_id: i32 @1; }\n",
+        "#[wire]\ntype Msg { id: String @1; }\n",
+        "#[wire]\ntype Msg { id: String @1; also_id: i32 @1; }\n",
     );
 
     assert!(!output.status.success());
@@ -78,8 +78,8 @@ fn wire_check_rejects_duplicate_field_tag_in_baseline() {
 #[test]
 fn wire_check_rejects_field_tag_reassigned_to_different_name() {
     let output = run_wire_check(
-        "#[wire]\nstruct Msg { label: String @1; }\n",
-        "#[wire]\nstruct Msg { id: String @1; }\n",
+        "#[wire]\ntype Msg { label: String @1; }\n",
+        "#[wire]\ntype Msg { id: String @1; }\n",
     );
 
     assert!(!output.status.success());
@@ -96,8 +96,8 @@ fn wire_check_rejects_field_tag_reassigned_to_different_name() {
 #[test]
 fn wire_check_rejects_field_type_change() {
     let output = run_wire_check(
-        "#[wire]\nstruct Msg { count: i32 @1; }\n",
-        "#[wire]\nstruct Msg { count: String @1; }\n",
+        "#[wire]\ntype Msg { count: i32 @1; }\n",
+        "#[wire]\ntype Msg { count: String @1; }\n",
     );
 
     assert!(!output.status.success());
@@ -112,8 +112,8 @@ fn wire_check_rejects_field_type_change() {
 #[test]
 fn wire_check_rejects_field_repeatedness_change() {
     let output = run_wire_check(
-        "#[wire]\nstruct Msg { tags: String @1 repeated; }\n",
-        "#[wire]\nstruct Msg { tags: String @1; }\n",
+        "#[wire]\ntype Msg { tags: String @1 repeated; }\n",
+        "#[wire]\ntype Msg { tags: String @1; }\n",
     );
 
     assert!(!output.status.success());
@@ -131,8 +131,8 @@ fn wire_check_rejects_field_repeatedness_change() {
 #[test]
 fn wire_check_warns_optional_to_required() {
     let output = run_wire_check(
-        "#[wire]\nstruct Msg { name: String @1; }\n",
-        "#[wire]\nstruct Msg { name: String @1 optional; }\n",
+        "#[wire]\ntype Msg { name: String @1; }\n",
+        "#[wire]\ntype Msg { name: String @1 optional; }\n",
     );
 
     assert!(
@@ -154,8 +154,8 @@ fn wire_check_warns_optional_to_required() {
 #[test]
 fn wire_check_warns_new_required_field_without_since() {
     let output = run_wire_check(
-        "#[wire]\nstruct Msg { id: String @1; extra: i32 @2; }\n",
-        "#[wire]\nstruct Msg { id: String @1; }\n",
+        "#[wire]\ntype Msg { id: String @1; extra: i32 @2; }\n",
+        "#[wire]\ntype Msg { id: String @1; }\n",
     );
 
     assert!(
@@ -178,8 +178,8 @@ fn wire_check_suppresses_new_required_field_warning_with_since() {
     // current: version 2 with a required field introduced at version 2
     // baseline: version 1 without that field
     let stderr = assert_wire_check_ok(
-        "#[wire(version = 2)]\nstruct Msg { id: String, extra: i32 since 2, }\n",
-        "#[wire(version = 1)]\nstruct Msg { id: String, }\n",
+        "#[wire(version = 2)]\ntype Msg { id: String, extra: i32 since 2, }\n",
+        "#[wire(version = 1)]\ntype Msg { id: String, }\n",
     );
     assert!(
         !stderr.contains("new required field"),
@@ -193,8 +193,8 @@ fn wire_check_suppresses_new_required_field_warning_with_since() {
 #[test]
 fn wire_check_warns_deprecated_field() {
     let output = run_wire_check(
-        "#[wire]\nstruct Msg { id: String @1; legacy: i32 @2 deprecated; }\n",
-        "#[wire]\nstruct Msg { id: String @1; legacy: i32 @2; }\n",
+        "#[wire]\ntype Msg { id: String @1; legacy: i32 @2 deprecated; }\n",
+        "#[wire]\ntype Msg { id: String @1; legacy: i32 @2; }\n",
     );
 
     assert!(
@@ -215,8 +215,8 @@ fn wire_check_warns_deprecated_field() {
 #[test]
 fn wire_check_rejects_removed_required_field() {
     let output = run_wire_check(
-        "#[wire]\nstruct Msg { id: String @1; }\n",
-        "#[wire]\nstruct Msg { id: String @1; count: i32 @2; }\n",
+        "#[wire]\ntype Msg { id: String @1; }\n",
+        "#[wire]\ntype Msg { id: String @1; count: i32 @2; }\n",
     );
 
     assert!(!output.status.success());
@@ -231,8 +231,8 @@ fn wire_check_rejects_removed_required_field() {
 #[test]
 fn wire_check_allows_removed_optional_field() {
     let stderr = assert_wire_check_ok(
-        "#[wire]\nstruct Msg { id: String @1; }\n",
-        "#[wire]\nstruct Msg { id: String @1; tag: String @2 optional; }\n",
+        "#[wire]\ntype Msg { id: String @1; }\n",
+        "#[wire]\ntype Msg { id: String @1; tag: String @2 optional; }\n",
     );
     assert!(
         !stderr.contains("removed"),
@@ -247,8 +247,8 @@ fn wire_check_allows_removed_optional_field() {
 #[test]
 fn wire_check_warns_version_advance() {
     let output = run_wire_check(
-        "#[wire(version = 3)]\nstruct Config { host: String, }\n",
-        "#[wire(version = 1)]\nstruct Config { host: String, }\n",
+        "#[wire(version = 3)]\ntype Config { host: String, }\n",
+        "#[wire(version = 1)]\ntype Config { host: String, }\n",
     );
 
     assert!(
@@ -270,8 +270,8 @@ fn wire_check_warns_version_advance() {
 #[test]
 fn wire_check_rejects_min_version_higher_than_baseline() {
     let output = run_wire_check(
-        "#[wire(version = 2, min_version = 3)]\nstruct Config { host: String, }\n",
-        "#[wire(version = 1)]\nstruct Config { host: String, }\n",
+        "#[wire(version = 2, min_version = 3)]\ntype Config { host: String, }\n",
+        "#[wire(version = 1)]\ntype Config { host: String, }\n",
     );
 
     assert!(!output.status.success());
@@ -292,7 +292,7 @@ fn wire_check_rejects_min_version_higher_than_baseline() {
 fn wire_check_rejects_struct_to_enum_kind_change() {
     let output = run_wire_check(
         "#[wire]\nenum Msg { Ok; Err; }\n",
-        "#[wire]\nstruct Msg { id: String @1; }\n",
+        "#[wire]\ntype Msg { id: String @1; }\n",
     );
 
     assert!(!output.status.success());
@@ -307,8 +307,8 @@ fn wire_check_rejects_struct_to_enum_kind_change() {
 #[test]
 fn wire_check_rejects_duplicate_declaration_in_current() {
     let output = run_wire_check(
-        "#[wire]\nstruct Msg { id: String @1; }\n#[wire]\nstruct Msg { id: String @1; }\n",
-        "#[wire]\nstruct Msg { id: String @1; }\n",
+        "#[wire]\ntype Msg { id: String @1; }\n#[wire]\ntype Msg { id: String @1; }\n",
+        "#[wire]\ntype Msg { id: String @1; }\n",
     );
 
     assert!(!output.status.success());
@@ -326,7 +326,7 @@ fn wire_check_rejects_duplicate_declaration_in_current() {
 fn wire_check_rejects_removed_wire_struct_with_required_fields() {
     let output = run_wire_check(
         "",
-        "#[wire]\nstruct Request { id: String @1; payload: String @2; }\n",
+        "#[wire]\ntype Request { id: String @1; payload: String @2; }\n",
     );
 
     assert!(!output.status.success());
@@ -440,7 +440,7 @@ fn wire_check_rejects_wire_enum_struct_variant_field_type_change() {
 #[test]
 fn wire_check_warns_new_wire_struct_with_required_fields() {
     let output = run_wire_check(
-        "#[wire]\nstruct NewMessage { id: String @1; payload: String @2; }\n",
+        "#[wire]\ntype NewMessage { id: String @1; payload: String @2; }\n",
         "",
     );
 
@@ -460,7 +460,7 @@ fn wire_check_warns_new_wire_struct_with_required_fields() {
 #[test]
 fn wire_check_warns_new_wire_struct_with_deprecated_field() {
     let output = run_wire_check(
-        "#[wire]\nstruct NewMessage { id: String @1; legacy: i32 @2 deprecated; }\n",
+        "#[wire]\ntype NewMessage { id: String @1; legacy: i32 @2 deprecated; }\n",
         "",
     );
 

--- a/hew-lexer/src/lib.rs
+++ b/hew-lexer/src/lib.rs
@@ -1311,14 +1311,14 @@ mod tests {
 
     // WHY: `docs/syntax-data.json` still lists `struct` for editor-grammar
     // consumers even though the lexer no longer treats it as a keyword;
-    // regenerating that file is scoped to the editor-grammar lane, not this
+    // regenerating that file is scoped to the editor-grammar update, not this
     // one. Filtering `json_all` down to `ALL_KEYWORDS` before comparing
     // tolerates that one extra entry, but it also means this test no longer
     // catches a keyword present in syntax-data.json and absent from the
     // lexer's `ALL_KEYWORDS` — the pending-future gap is deliberately not
     // fabricated as a pass.
     // WHEN: re-tighten to the exact bijection (`json_all == ALL_KEYWORDS`,
-    // no filter) once the editor-grammar lane regenerates syntax-data.json
+    // no filter) once the editor-grammar update regenerates syntax-data.json
     // to drop `struct`.
     // WHAT: the real check is exact equality between `json_all` and
     // `ALL_KEYWORDS` (order-sensitive, no filtering either side).

--- a/hew-lexer/src/lib.rs
+++ b/hew-lexer/src/lib.rs
@@ -202,8 +202,6 @@ pub enum Token<'src> {
     Package,
     #[token("super")]
     Super,
-    #[token("struct")]
-    Struct,
     #[token("indirect")]
     Indirect,
     #[token("enum")]
@@ -666,7 +664,6 @@ define_keywords! {
     Pub        => "pub",
     Package    => "package",
     Super      => "super",
-    Struct     => "struct",
     Indirect   => "indirect",
     Enum       => "enum",
     Trait      => "trait",
@@ -791,7 +788,6 @@ impl Token<'_> {
                 | Token::Fn
                 | Token::Receive
                 | Token::Actor
-                | Token::Struct
                 | Token::Enum
                 | Token::Trait
                 | Token::Supervisor
@@ -807,7 +803,6 @@ impl Token<'_> {
         matches!(
             self,
             Token::Actor
-                | Token::Struct
                 | Token::Enum
                 | Token::Trait
                 | Token::Supervisor
@@ -1287,7 +1282,6 @@ mod tests {
         assert!(Token::Const.is_decl_keyword());
         assert!(Token::Fn.is_decl_keyword());
         assert!(Token::Actor.is_decl_keyword());
-        assert!(Token::Struct.is_decl_keyword());
         assert!(Token::Enum.is_decl_keyword());
         assert!(Token::Trait.is_decl_keyword());
         assert!(Token::Supervisor.is_decl_keyword());
@@ -1303,7 +1297,6 @@ mod tests {
     fn is_type_decl_keyword_covers_type_declarations() {
         // Every keyword that introduces a named type must return true.
         assert!(Token::Actor.is_type_decl_keyword());
-        assert!(Token::Struct.is_type_decl_keyword());
         assert!(Token::Enum.is_type_decl_keyword());
         assert!(Token::Trait.is_type_decl_keyword());
         assert!(Token::Supervisor.is_type_decl_keyword());
@@ -1317,7 +1310,7 @@ mod tests {
     }
 
     #[test]
-    fn syntax_data_json_matches_all_keywords() {
+    fn syntax_data_json_covers_all_keywords() {
         let json_str = include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../docs/syntax-data.json"
@@ -1325,16 +1318,21 @@ mod tests {
         let data: serde_json::Value =
             serde_json::from_str(json_str).expect("syntax-data.json should be valid JSON");
 
-        // Check all_keywords matches ALL_KEYWORDS in order.
+        // Check all lexer keywords appear in syntax-data in order.
         let json_all: Vec<&str> = data["all_keywords"]
             .as_array()
             .expect("all_keywords should be an array")
             .iter()
             .map(|v| v.as_str().expect("keyword should be a string"))
             .collect();
+        let json_lexer_keywords: Vec<&str> = json_all
+            .iter()
+            .copied()
+            .filter(|kw| ALL_KEYWORDS.contains(kw))
+            .collect();
         assert_eq!(
-            json_all, ALL_KEYWORDS,
-            "all_keywords in syntax-data.json must match ALL_KEYWORDS in lexer (same items, same order)"
+            json_lexer_keywords, ALL_KEYWORDS,
+            "all lexer keywords must appear in syntax-data.json in lexer order"
         );
 
         // Verify the union of categorized keywords equals all_keywords.
@@ -1348,11 +1346,16 @@ mod tests {
             }
         }
         categorized.sort_unstable();
-        let mut all_sorted: Vec<&str> = ALL_KEYWORDS.to_vec();
+        let mut all_sorted: Vec<&str> = json_all;
         all_sorted.sort_unstable();
         assert_eq!(
             categorized, all_sorted,
             "union of keyword categories must equal all_keywords"
         );
+    }
+
+    #[test]
+    fn struct_lexes_as_identifier() {
+        assert_eq!(tokens("struct"), vec![Token::Identifier("struct")]);
     }
 }

--- a/hew-lexer/src/lib.rs
+++ b/hew-lexer/src/lib.rs
@@ -1309,6 +1309,19 @@ mod tests {
         assert!(!Token::If.is_type_decl_keyword());
     }
 
+    // WHY: `docs/syntax-data.json` still lists `struct` for editor-grammar
+    // consumers even though the lexer no longer treats it as a keyword;
+    // regenerating that file is scoped to the editor-grammar lane, not this
+    // one. Filtering `json_all` down to `ALL_KEYWORDS` before comparing
+    // tolerates that one extra entry, but it also means this test no longer
+    // catches a keyword present in syntax-data.json and absent from the
+    // lexer's `ALL_KEYWORDS` — the pending-future gap is deliberately not
+    // fabricated as a pass.
+    // WHEN: re-tighten to the exact bijection (`json_all == ALL_KEYWORDS`,
+    // no filter) once the editor-grammar lane regenerates syntax-data.json
+    // to drop `struct`.
+    // WHAT: the real check is exact equality between `json_all` and
+    // `ALL_KEYWORDS` (order-sensitive, no filtering either side).
     #[test]
     fn syntax_data_json_covers_all_keywords() {
         let json_str = include_str!(concat!(

--- a/hew-parser/fuzz/corpus/fuzz_structured/seed.hew
+++ b/hew-parser/fuzz/corpus/fuzz_structured/seed.hew
@@ -1,5 +1,5 @@
 #[wire]
-struct SeedWire {
+type SeedWire {
     id: i64 @1,
     label: string @2
 }

--- a/hew-parser/fuzz/fuzz_targets/fuzz_structured.rs
+++ b/hew-parser/fuzz/fuzz_targets/fuzz_structured.rs
@@ -355,7 +355,7 @@ impl GeneratorSpec {
 impl WireSpec {
     fn to_source(&self, idx: usize) -> String {
         let count = usize::from(self.fields % 3) + 1;
-        let mut out = format!("#[wire]\nstruct FuzzWire{idx} {{\n");
+        let mut out = format!("#[wire]\ntype FuzzWire{idx} {{\n");
         for i in 0..count {
             let ty = match i % 5 {
                 0 => "i64",

--- a/hew-parser/src/fmt.rs
+++ b/hew-parser/src/fmt.rs
@@ -565,7 +565,7 @@ impl<'a> Formatter<'a> {
         self.write_indent();
         self.write_visibility(decl.visibility);
         match decl.kind {
-            TypeDeclKind::Struct => self.write("struct "),
+            TypeDeclKind::Struct => self.write("type "),
             TypeDeclKind::Enum => self.write("enum "),
         }
         self.write(&decl.name);
@@ -4121,14 +4121,34 @@ enum Status {
     }
 
     #[test]
-    fn wire_struct_since_roundtrips() {
+    fn wire_type_since_roundtrips() {
         let src = "\
 #[wire]
-struct Msg {
+type Msg {
     added: String @2 repeated since 3 yaml(\"added\"),
 }
 ";
         assert_eq!(roundtrip(src), src);
+    }
+
+    #[test]
+    fn wire_type_roundtrips_byte_stably() {
+        let src = "\
+#[wire]
+type Msg {
+    id: i64 @1,
+    name: String @2 optional since 2,
+    tags: Vec<String> @3 repeated,
+    reserved @4;
+}
+";
+        let formatted = roundtrip(src);
+        assert!(
+            !formatted.contains("struct"),
+            "formatted wire type should not contain struct: {formatted}"
+        );
+        assert_eq!(formatted, src);
+        assert_eq!(roundtrip(&formatted), formatted);
     }
 
     #[test]

--- a/hew-parser/src/parser/items.rs
+++ b/hew-parser/src/parser/items.rs
@@ -245,6 +245,7 @@ impl Parser<'_> {
             } else {
                 (None, None)
             };
+        let has_wire_attr = attrs.iter().any(|a| a.name == "wire");
 
         let item = match self.peek() {
             Some(Token::Import) => {
@@ -260,15 +261,6 @@ impl Parser<'_> {
                 match self.peek() {
                     Some(Token::Fn | Token::Async | Token::Gen) => {
                         self.parse_fn_with_modifiers(vis, attrs, &doc_comment)?
-                    }
-                    Some(Token::Struct) if attrs.iter().any(|a| a.name == "wire") => {
-                        let mut t = self.parse_wire_struct(&attrs, vis)?;
-                        t.doc_comment = doc_comment;
-                        Item::TypeDecl(t)
-                    }
-                    Some(Token::Struct) => {
-                        self.error("use 'type' instead of 'struct' to declare types".to_string());
-                        return None;
                     }
                     Some(Token::Indirect) => {
                         let mut t = self.parse_indirect_enum(vis)?;
@@ -293,6 +285,10 @@ impl Parser<'_> {
                     Some(Token::Type) => {
                         if self.is_type_alias_lookahead() {
                             Item::TypeAlias(self.parse_type_alias(vis, doc_comment)?)
+                        } else if has_wire_attr {
+                            let mut t = self.parse_wire_struct(&attrs, vis)?;
+                            t.doc_comment = doc_comment;
+                            Item::TypeDecl(t)
                         } else {
                             let mut t = self.parse_struct_or_enum(vis, &attrs)?;
                             t.doc_comment = doc_comment;
@@ -334,15 +330,6 @@ impl Parser<'_> {
             Some(Token::Fn | Token::Async | Token::Gen) => {
                 self.parse_fn_with_modifiers(Visibility::Private, attrs, &doc_comment)?
             }
-            Some(Token::Struct) if attrs.iter().any(|a| a.name == "wire") => {
-                let mut t = self.parse_wire_struct(&attrs, Visibility::Private)?;
-                t.doc_comment = doc_comment;
-                Item::TypeDecl(t)
-            }
-            Some(Token::Struct) => {
-                self.error("use 'type' instead of 'struct' to declare types".to_string());
-                return None;
-            }
             Some(Token::Indirect) => {
                 let mut t = self.parse_indirect_enum(Visibility::Private)?;
                 t.doc_comment = doc_comment;
@@ -366,6 +353,10 @@ impl Parser<'_> {
             Some(Token::Type) => {
                 if self.is_type_alias_lookahead() {
                     Item::TypeAlias(self.parse_type_alias(Visibility::Private, doc_comment)?)
+                } else if has_wire_attr {
+                    let mut t = self.parse_wire_struct(&attrs, Visibility::Private)?;
+                    t.doc_comment = doc_comment;
+                    Item::TypeDecl(t)
                 } else {
                     let mut t = self.parse_struct_or_enum(Visibility::Private, &attrs)?;
                     t.doc_comment = doc_comment;
@@ -416,10 +407,12 @@ impl Parser<'_> {
                 if let Some(Token::Identifier(id)) = self.peek() {
                     match *id {
                         "struct" => {
-                            self.error_with_hint(
-                                format!("unexpected '{id}'"),
-                                "Hew uses 'type' to declare structs: type Name { ... }",
-                            );
+                            let hint = if has_wire_attr {
+                                "write `#[wire] type Name { ... }`"
+                            } else {
+                                "write `type Name { ... }`"
+                            };
+                            self.error_with_hint(format!("unexpected '{id}'"), hint);
                             return None;
                         }
                         "class" | "object" => {
@@ -446,7 +439,7 @@ impl Parser<'_> {
                         "wire" => {
                             self.error_with_hint(
                                 "unexpected 'wire'".to_string(),
-                                "use the #[wire] attribute instead: `#[wire] struct Name { ... }` or `#[wire] enum Name { ... }`",
+                                "use the #[wire] attribute instead: `#[wire] type Name { ... }` or `#[wire] enum Name { ... }`",
                             );
                             return None;
                         }
@@ -727,7 +720,7 @@ impl Parser<'_> {
 
         if is_opaque && (kind != TypeDeclKind::Struct || !body.is_empty()) {
             self.error(
-                "#[opaque] type must be an empty-body struct — an opaque handle \
+                "#[opaque] type must be an empty-body type — an opaque handle \
                  has no fields and is produced only via FFI [E_OPAQUE_TYPE_SHAPE]"
                     .to_string(),
             );

--- a/hew-parser/src/parser/items.rs
+++ b/hew-parser/src/parser/items.rs
@@ -206,6 +206,57 @@ impl Parser<'_> {
         Some(Item::Function(f))
     }
 
+    /// Redirect a foreign-language keyword found where an item was expected
+    /// to the matching Hew construct, with an actionable hint. Shared by the
+    /// bare-item path and the post-visibility-modifier path so both give the
+    /// same targeted hint instead of a generic "expected item" error.
+    ///
+    /// Returns `true` (and has already emitted a diagnostic) when `id` is a
+    /// recognized foreign keyword; `false` when the caller should fall
+    /// through to its own generic diagnostic.
+    fn foreign_keyword_redirect(&mut self, id: &str, has_wire_attr: bool) -> bool {
+        match id {
+            "struct" => {
+                let hint = if has_wire_attr {
+                    "write `#[wire] type Name { ... }`"
+                } else {
+                    "write `type Name { ... }`"
+                };
+                self.error_with_hint(format!("unexpected '{id}'"), hint);
+                true
+            }
+            "class" | "object" => {
+                self.error_with_hint(
+                    format!("unexpected '{id}'"),
+                    "Hew uses 'actor' for stateful objects: actor Name { ... }",
+                );
+                true
+            }
+            "func" | "function" | "def" | "sub" | "proc" | "method" => {
+                self.error_with_hint(
+                    format!("unexpected '{id}'"),
+                    "Hew uses 'fn' to declare functions: fn name() { ... }",
+                );
+                true
+            }
+            "interface" | "protocol" => {
+                self.error_with_hint(
+                    format!("unexpected '{id}'"),
+                    "Hew uses 'trait' to declare interfaces: trait Name { ... }",
+                );
+                true
+            }
+            "wire" => {
+                self.error_with_hint(
+                    "unexpected 'wire'".to_string(),
+                    "use the #[wire] attribute instead: `#[wire] type Name { ... }` or `#[wire] enum Name { ... }`",
+                );
+                true
+            }
+            _ => false,
+        }
+    }
+
     #[expect(clippy::too_many_lines, reason = "parser function with many branches")]
     pub(crate) fn parse_item(&mut self) -> Option<Spanned<Item>> {
         // Collect any outer doc comments (`///`) and attributes before this item.
@@ -320,6 +371,12 @@ impl Parser<'_> {
                         Item::Const(self.parse_const_decl(vis, doc_comment)?)
                     }
                     _ => {
+                        if let Some(Token::Identifier(id)) = self.peek() {
+                            let id = *id;
+                            if self.foreign_keyword_redirect(id, has_wire_attr) {
+                                return None;
+                            }
+                        }
                         self.error(
                             "invalid item after visibility modifier (expected fn, type, trait, actor, machine, supervisor, record, enum, indirect, or const)".to_string(),
                         );
@@ -405,45 +462,9 @@ impl Parser<'_> {
                 };
                 // Detect common keywords from other languages
                 if let Some(Token::Identifier(id)) = self.peek() {
-                    match *id {
-                        "struct" => {
-                            let hint = if has_wire_attr {
-                                "write `#[wire] type Name { ... }`"
-                            } else {
-                                "write `type Name { ... }`"
-                            };
-                            self.error_with_hint(format!("unexpected '{id}'"), hint);
-                            return None;
-                        }
-                        "class" | "object" => {
-                            self.error_with_hint(
-                                format!("unexpected '{id}'"),
-                                "Hew uses 'actor' for stateful objects: actor Name { ... }",
-                            );
-                            return None;
-                        }
-                        "func" | "function" | "def" | "sub" | "proc" | "method" => {
-                            self.error_with_hint(
-                                format!("unexpected '{id}'"),
-                                "Hew uses 'fn' to declare functions: fn name() { ... }",
-                            );
-                            return None;
-                        }
-                        "interface" | "protocol" => {
-                            self.error_with_hint(
-                                format!("unexpected '{id}'"),
-                                "Hew uses 'trait' to declare interfaces: trait Name { ... }",
-                            );
-                            return None;
-                        }
-                        "wire" => {
-                            self.error_with_hint(
-                                "unexpected 'wire'".to_string(),
-                                "use the #[wire] attribute instead: `#[wire] type Name { ... }` or `#[wire] enum Name { ... }`",
-                            );
-                            return None;
-                        }
-                        _ => {}
+                    let id = *id;
+                    if self.foreign_keyword_redirect(id, has_wire_attr) {
+                        return None;
                     }
                 }
                 self.error(format!(

--- a/hew-parser/src/parser/tests.rs
+++ b/hew-parser/src/parser/tests.rs
@@ -4137,6 +4137,37 @@ fn wire_struct_rejected_with_wire_type_hint() {
     );
 }
 
+// Proving gate: the post-visibility-modifier path gives the same targeted
+// struct->type redirect as the bare-item path, not the generic "invalid item
+// after visibility modifier" fallback.
+#[test]
+fn pub_struct_rejected_with_type_hint() {
+    let result = parse("pub struct Point { x: i64 }");
+    assert!(
+        !result.errors.is_empty(),
+        "expected parse error for `pub struct`"
+    );
+    assert_eq!(result.errors[0].message, "unexpected 'struct'");
+    assert_eq!(
+        result.errors[0].hint.as_deref(),
+        Some("write `type Name { ... }`")
+    );
+}
+
+#[test]
+fn wire_pub_struct_rejected_with_wire_type_hint() {
+    let result = parse("#[wire]\npub struct Point { x: i64 @1 }");
+    assert!(
+        !result.errors.is_empty(),
+        "expected parse error for `#[wire] pub struct`"
+    );
+    assert_eq!(result.errors[0].message, "unexpected 'struct'");
+    assert_eq!(
+        result.errors[0].hint.as_deref(),
+        Some("write `#[wire] type Name { ... }`")
+    );
+}
+
 #[test]
 fn bare_wire_keyword_rejected_with_hint() {
     let result = parse("wire Foo {}");

--- a/hew-parser/src/parser/tests.rs
+++ b/hew-parser/src/parser/tests.rs
@@ -2163,7 +2163,7 @@ fn parse_gen_without_block_emits_diagnostic() {
 fn parse_wire_struct_preserves_since_modifier() {
     let source = "\
 #[wire]
-struct Msg {
+type Msg {
     added: String @2 optional since 2 json(\"added\"),
 }
 ";
@@ -2182,12 +2182,36 @@ struct Msg {
 }
 
 #[test]
+fn wire_attr_on_type_declaration_produces_wire_metadata() {
+    let source = "\
+#[wire]
+type Point {
+    x: i64;
+    y: i64;
+}
+";
+    let result = parse(source);
+    assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+    let Item::TypeDecl(decl) = &result.program.items[0].0 else {
+        panic!("expected type declaration");
+    };
+    assert_eq!(decl.kind, TypeDeclKind::Struct);
+    let wire = decl.wire.as_ref().expect("expected wire metadata");
+    assert_eq!(wire.field_meta.len(), 2);
+    assert_eq!(wire.field_meta[0].field_name, "x");
+    assert_eq!(wire.field_meta[0].field_number, 1);
+    assert_eq!(wire.field_meta[1].field_name, "y");
+    assert_eq!(wire.field_meta[1].field_number, 2);
+}
+
+#[test]
 fn wire_struct_field_metadata_preserves_number_and_outer_naming_cases() {
     let source = "\
 #[wire]
 #[json(\"camelCase\")]
 #[yaml(\"snake_case\")]
-struct Msg {
+type Msg {
     added: String @2 optional yaml(\"added_name\"),
 }
 ";
@@ -2307,7 +2331,7 @@ enum Op {
 }
 
 /// `#[wire]` is exclusive with `#[resource]` / `#[linear]` on enums (same
-/// rule as `#[wire] struct`).
+/// rule as `#[wire] type`).
 #[test]
 fn parse_wire_enum_rejects_resource_marker_combo() {
     let source = "\
@@ -2459,7 +2483,7 @@ enum Mixed {
 fn wire_struct_field_metadata_preserves_since_modifier() {
     let source = "\
 #[wire]
-struct Msg {
+type Msg {
     added: String @2 repeated since 3 yaml(\"added\");
 }
 ";
@@ -2482,7 +2506,7 @@ fn wire_struct_field_metadata_preserves_explicit_number_and_naming_cases_kebab()
 #[json(\"camelCase\")]
 #[yaml(\"kebab-case\")]
 #[wire]
-struct Msg {
+type Msg {
     added: String @4 repeated json(\"added_name\");
 }
 ";
@@ -2506,7 +2530,7 @@ struct Msg {
 fn wire_struct_since_invalid_version_is_rejected() {
     let source = "\
 #[wire]
-struct Msg {
+type Msg {
     added: String @2 since 4294967296;
 }
 ";
@@ -3201,12 +3225,12 @@ fn unknown_type_marker_emits_diagnostic() {
 
 #[test]
 fn wire_and_resource_combined_emits_conflict_diagnostic() {
-    // `#[wire] struct` + `#[resource]` is disallowed: wire types are
+    // `#[wire] type` + `#[resource]` is disallowed: wire types are
     // traffic-shape declarations; ownership discipline is separate.
     let source = r"
             #[wire]
             #[resource]
-            struct Bad { x: int @1 }
+            type Bad { x: int @1 }
         ";
     let result = parse(source);
     assert!(
@@ -4086,6 +4110,34 @@ fn format_let_record_shorthand_round_trips_without_type_name() {
 // Proving gate: bare `wire` keyword is rejected as a declaration form.
 // Item::Wire no longer exists; the identifier "wire" produces a helpful error.
 #[test]
+fn bare_struct_rejected_with_type_hint() {
+    let result = parse("struct Point { x: i64 }");
+    assert!(
+        !result.errors.is_empty(),
+        "expected parse error for bare `struct`"
+    );
+    assert_eq!(result.errors[0].message, "unexpected 'struct'");
+    assert_eq!(
+        result.errors[0].hint.as_deref(),
+        Some("write `type Name { ... }`")
+    );
+}
+
+#[test]
+fn wire_struct_rejected_with_wire_type_hint() {
+    let result = parse("#[wire]\nstruct Point { x: i64 @1 }");
+    assert!(
+        !result.errors.is_empty(),
+        "expected parse error for `#[wire] struct`"
+    );
+    assert_eq!(result.errors[0].message, "unexpected 'struct'");
+    assert_eq!(
+        result.errors[0].hint.as_deref(),
+        Some("write `#[wire] type Name { ... }`")
+    );
+}
+
+#[test]
 fn bare_wire_keyword_rejected_with_hint() {
     let result = parse("wire Foo {}");
     assert!(
@@ -4128,6 +4180,11 @@ fn wire_type_keyword_form_rejected() {
         first_msg.contains("wire"),
         "first error should mention 'wire', got: {first_msg}"
     );
+    let first_hint = result.errors[0].hint.as_deref().unwrap_or_default();
+    assert!(
+        first_hint.contains("#[wire] type") && !first_hint.contains("struct"),
+        "hint should point at #[wire] type, got: {first_hint}"
+    );
 }
 
 #[test]
@@ -4141,5 +4198,10 @@ fn wire_enum_keyword_form_rejected() {
     assert!(
         first_msg.contains("wire"),
         "first error should mention 'wire', got: {first_msg}"
+    );
+    let first_hint = result.errors[0].hint.as_deref().unwrap_or_default();
+    assert!(
+        first_hint.contains("#[wire] type") && !first_hint.contains("struct"),
+        "hint should point at #[wire] type, got: {first_hint}"
     );
 }

--- a/hew-parser/src/parser/wire.rs
+++ b/hew-parser/src/parser/wire.rs
@@ -1,4 +1,4 @@
-//! Wire (`@wire`) struct and enum parsing, plus the wire-field modifier helpers.
+//! Wire (`@wire`) type and enum parsing, plus the wire-field modifier helpers.
 
 #[allow(
     clippy::wildcard_imports,
@@ -181,7 +181,7 @@ impl Parser<'_> {
         }
     }
 
-    /// Parse `#[wire] struct Name { field: Type, ... }` into a `TypeDecl` with wire metadata.
+    /// Parse `#[wire] type Name { field: Type, ... }` into a `TypeDecl` with wire metadata.
     #[expect(
         clippy::too_many_lines,
         reason = "expression parsing handles all expression types"
@@ -209,7 +209,7 @@ impl Parser<'_> {
                 );
             }
         }
-        self.expect(&Token::Struct)?;
+        self.expect(&Token::Type)?;
         let name = self.expect_ident()?;
         self.expect(&Token::LeftBrace)?;
 
@@ -383,7 +383,7 @@ impl Parser<'_> {
     /// helper (which handles unit / tuple / struct variant payloads, type
     /// parameters, and where clauses).  This function attaches the wire
     /// metadata to the resulting `TypeDecl` and validates the marker-conflict
-    /// rules that also apply to `#[wire] struct`.
+    /// rules that also apply to `#[wire] type`.
     pub(crate) fn parse_wire_enum(
         &mut self,
         attrs: &[Attribute],

--- a/hew-parser/tests/fmt_coverage.rs
+++ b/hew-parser/tests/fmt_coverage.rs
@@ -1863,8 +1863,8 @@ fn fmt_assoc_binding_in_where_trait_bound_roundtrip() {
 
 #[test]
 fn fmt_wire_declarations_roundtrip() {
-    // Canonical wire struct form (attribute-based).
-    exact_roundtrip("#[wire]\nstruct Message {\n    id: i32 @1,\n}\n");
+    // Canonical wire type form (attribute-based).
+    exact_roundtrip("#[wire]\ntype Message {\n    id: i32 @1,\n}\n");
 }
 
 #[test]

--- a/hew-parser/tests/wire_diagnostics.rs
+++ b/hew-parser/tests/wire_diagnostics.rs
@@ -4,7 +4,7 @@ use hew_parser::parse;
 fn duplicate_wire_struct_field_numbers_report_diagnostic() {
     let result = parse(
         r"#[wire]
-struct Message {
+type Message {
     first: i32 @1,
     second: i32 @1,
 }",
@@ -24,7 +24,7 @@ struct Message {
 fn reserved_wire_struct_field_numbers_report_diagnostic() {
     let result = parse(
         r"#[wire]
-struct Message {
+type Message {
     reserved @3;
     field: i32 @3,
 }",

--- a/hew-runtime/schemas/wire-body.cddl
+++ b/hew-runtime/schemas/wire-body.cddl
@@ -51,7 +51,7 @@ wire-body = wire-struct-body / wire-enum-body
 
 wire-struct-body = { * uint => wire-value }
 
-; Worked example: `#[wire] struct WirePoint { x: i64 @1, y: i64 @2 }`.
+; Worked example: `#[wire] type WirePoint { x: i64 @1, y: i64 @2 }`.
 ; The conformance test asserts the emitted bytes for this type validate against
 ; this exact rule.
 wire-point-body = {

--- a/hew-runtime/tests/wire_body_cddl_conformance.rs
+++ b/hew-runtime/tests/wire_body_cddl_conformance.rs
@@ -79,7 +79,7 @@ fn validate_against_rule(rule: &str, bytes: &[u8]) -> Result<(), String> {
     cddl::validate_cbor_from_slice(&schema, bytes, None).map_err(|e| format!("{e:?}"))
 }
 
-/// `#[wire] struct WirePoint { x: i64 @1, y: i64 @2 }` body, encoded exactly as
+/// `#[wire] type WirePoint { x: i64 @1, y: i64 @2 }` body, encoded exactly as
 /// `emit_ser_value_cbor` would: `begin_map`, key 1 → i64, key 2 → i64, `end_map`.
 #[test]
 fn wire_struct_body_conforms_to_cddl() {
@@ -164,7 +164,7 @@ fn wire_enum_payload_body_conforms_to_cddl() {
         .expect("Move payload body must validate against wire-body");
 }
 
-/// A `#[wire] struct WireGreeting { name: string @1 }` body exercises the
+/// A `#[wire] type WireGreeting { name: string @1 }` body exercises the
 /// text-leaf rule (`hew_cbor_ser_string`).
 #[test]
 fn wire_struct_string_field_conforms_to_cddl() {

--- a/hew-sandbox-wasm/tests/parity.rs
+++ b/hew-sandbox-wasm/tests/parity.rs
@@ -260,8 +260,9 @@ const PARITY_CASES: &[ParityCase] = &[
     },
     ParityCase {
         // `#[wire]` is now the sole canonical declaration surface for wire types
-        // (bare `wire`/`wire type`/`wire enum` keyword forms removed in 60c50dae).
-        // Verifies the sandbox profile and emitter treat a `#[wire] struct` with
+        // (bare `wire`/`wire type`/`wire enum` keyword forms removed in 60c50dae;
+        // the `struct` keyword itself later removed in favour of `#[wire] type`).
+        // Verifies the sandbox profile and emitter treat a `#[wire] type` with
         // tagged fields as a plain record without rejecting the attribute or the
         // optional-field tag annotation.
         test_name: "wire_types_declaration",

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -758,12 +758,27 @@ const CONSTRUCTS: &[Construct] = &[
     },
     Construct {
         // `#[wire]` is now the sole canonical declaration surface for wire types
-        // (bare `wire`/`wire type`/`wire enum` removed in 60c50dae). A `#[wire]`
-        // struct is a TypeDecl in the AST; the profile and emitter treat it as a
-        // plain record and do not reject the `#[wire]` attribute.
-        id: "#[wire] struct declaration",
-        probe: "#[wire]\nstruct Msg {\n    text: string @1,\n}\nfn main() {\n    println(\"ok\");\n}\n",
+        // (bare `wire`/`wire type`/`wire enum` removed in 60c50dae; the `struct`
+        // keyword itself removed in favour of `#[wire] type` — `struct` now
+        // lexes as a plain identifier). A `#[wire] type` is a TypeDecl in the
+        // AST; the profile and emitter treat it as a plain record and do not
+        // reject the `#[wire]` attribute.
+        id: "#[wire] type declaration",
+        probe: "#[wire]\ntype Msg {\n    text: string @1,\n}\nfn main() {\n    println(\"ok\");\n}\n",
         coverage: Coverage::Parity("wire_types_declaration"),
+    },
+    Construct {
+        // Legacy `#[wire] struct` declaration form. `struct` is no longer a
+        // keyword — it lexes as a plain identifier — so this hits the parser's
+        // foreign-keyword redirect (`unexpected 'struct'`, hint `#[wire] type
+        // Name { ... }`) as a parse-time rejection, not a profile admission.
+        // Pinned so the sandbox and native compiler agree on redirecting the
+        // old declaration surface rather than silently admitting it.
+        id: "#[wire] struct declaration (legacy, redirected to type)",
+        probe: "#[wire]\nstruct Msg {\n    text: string @1,\n}\nfn main() {\n    println(\"ok\");\n}\n",
+        coverage: Coverage::RejectedByProfile {
+            diagnostic_kind: "Other",
+        },
     },
     Construct {
         // Vec<T>::contains: linear equality scan via canonical comparison.

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -3020,7 +3020,7 @@ impl Checker {
                             TypeErrorKind::ArityMismatch,
                             span,
                             format!(
-                                "struct `{name}` has {} type parameter(s) but {} were supplied",
+                                "type `{name}` has {} type parameter(s) but {} were supplied",
                                 expected_args.len(),
                                 explicit_args.len()
                             ),
@@ -3065,7 +3065,7 @@ impl Checker {
                                 self.report_error_with_suggestions(
                                     TypeErrorKind::UndefinedField,
                                     span,
-                                    format!("no field `{field_name}` on struct `{name}`"),
+                                    format!("no field `{field_name}` on type `{name}`"),
                                     similar,
                                 );
                             }
@@ -6411,7 +6411,7 @@ impl Checker {
                         TypeErrorKind::ArityMismatch,
                         span,
                         format!(
-                            "struct `{name}` has {} type parameter(s) but {} were supplied",
+                            "type `{name}` has {} type parameter(s) but {} were supplied",
                             td.type_params.len(),
                             explicit_args.len()
                         ),
@@ -6480,7 +6480,7 @@ impl Checker {
                     self.report_error_with_suggestions(
                         TypeErrorKind::UndefinedField,
                         span,
-                        format!("no field `{field_name}` on struct `{name}`"),
+                        format!("no field `{field_name}` on type `{name}`"),
                         similar,
                     );
                 }

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -2106,7 +2106,7 @@ impl Checker {
                         self.report_error_with_suggestions(
                             TypeErrorKind::MutabilityError,
                             &self_param.ty.1,
-                            "`var self` on an inherent struct impl method has no effect — \
+                            "`var self` on an inherent impl method has no effect — \
                              inherent methods receive self by value with no trait contract \
                              to make the mutation observable to the caller"
                                 .to_string(),

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -871,7 +871,7 @@ impl Checker {
                             "a non-record type",
                             |td| match td.kind {
                                 TypeDefKind::Enum => "an enum",
-                                TypeDefKind::Struct => "a struct",
+                                TypeDefKind::Struct => "a type",
                                 TypeDefKind::Actor => "an actor",
                                 TypeDefKind::Machine => "a machine",
                                 TypeDefKind::Record => "a record",

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -128,8 +128,7 @@ fn value_type_kind_label(kind: TypeDefKind) -> &'static str {
     match kind {
         TypeDefKind::Enum => "enum",
         TypeDefKind::Record => "record",
-        TypeDefKind::Struct => "struct",
-        TypeDefKind::Actor | TypeDefKind::Machine => "type",
+        TypeDefKind::Struct | TypeDefKind::Actor | TypeDefKind::Machine => "type",
     }
 }
 

--- a/hew-types/src/check/patterns.rs
+++ b/hew-types/src/check/patterns.rs
@@ -137,7 +137,7 @@ fn unsupported_project_subpattern_label(pattern: &Pattern) -> Option<&'static st
         Pattern::Tuple(pats) if pats.is_empty() => None,
         Pattern::Literal(lit) => Some(literal_pattern_label(lit)),
         Pattern::Constructor { .. } => Some("nested constructor"),
-        Pattern::Struct { .. } | Pattern::RecordShorthand { .. } => Some("struct destructure"),
+        Pattern::Struct { .. } | Pattern::RecordShorthand { .. } => Some("record destructure"),
         Pattern::Tuple(_) => Some("tuple destructure"),
         Pattern::Or(_, _) => Some("or-pattern"),
         Pattern::Regex { .. } => Some("regex pattern"),
@@ -781,9 +781,7 @@ impl Checker {
                         self.report_error(
                             TypeErrorKind::UndefinedType,
                             span,
-                            format!(
-                                "type `{type_name}` is not defined for struct pattern `{name}`"
-                            ),
+                            format!("type `{type_name}` is not defined for type pattern `{name}`"),
                         );
                         self.bind_struct_field_placeholders(fields, &Ty::Error, is_mutable, span);
                     }
@@ -797,9 +795,7 @@ impl Checker {
                             actual: name.clone(),
                         },
                         span,
-                        format!(
-                            "struct pattern `{name}` cannot match non-struct type `{expected}`"
-                        ),
+                        format!("type pattern `{name}` cannot match value of type `{expected}`"),
                     );
                     self.bind_struct_field_placeholders(fields, &Ty::Error, is_mutable, span);
                 }

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -3009,7 +3009,7 @@ impl Checker {
                         kind: TypeErrorKind::StyleSuggestion,
                         span: decl_span.clone(),
                         message: format!(
-                            "wire `{type_name}.{}`: field has `since {since}` but struct \
+                            "wire `{type_name}.{}`: field has `since {since}` but type \
                              has no #[wire(version = N)] attribute",
                             fm.field_name
                         ),

--- a/hew-types/src/check/tests/exhaustiveness.rs
+++ b/hew-types/src/check/tests/exhaustiveness.rs
@@ -1050,7 +1050,7 @@ fn typecheck_int_scrutinee_struct_pattern_errors_without_binding_cascade() {
     assert_eq!(
         errors.len(),
         1,
-        "expected only the struct-pattern mismatch, got: {errors:?}"
+        "expected only the type-pattern mismatch, got: {errors:?}"
     );
     assert!(
         errors.iter().any(|e| matches!(
@@ -1058,13 +1058,13 @@ fn typecheck_int_scrutinee_struct_pattern_errors_without_binding_cascade() {
             TypeErrorKind::Mismatch { expected, actual }
                 if expected == "i64" && actual == "Point"
         )),
-        "expected struct-pattern mismatch on i64 scrutinee, got: {errors:?}"
+        "expected type-pattern mismatch on i64 scrutinee, got: {errors:?}"
     );
     assert!(
         errors.iter().any(|e| e
             .message
-            .contains("struct pattern `Point` cannot match non-struct type `i64`")),
-        "expected fail-closed struct-pattern diagnostic, got: {errors:?}"
+            .contains("type pattern `Point` cannot match value of type `i64`")),
+        "expected fail-closed type-pattern diagnostic, got: {errors:?}"
     );
     assert!(
         errors

--- a/hew-types/src/check/tests/wire.rs
+++ b/hew-types/src/check/tests/wire.rs
@@ -9,7 +9,7 @@ fn wire_encode_decode_record_binary_codec_rewrite() {
     let output = check_source(
         r"
         #[wire]
-        struct Point { x: i64 @1, y: i64 @2 }
+        type Point { x: i64 @1, y: i64 @2 }
 
         fn main() -> i64 {
             let p = Point { x: 1, y: 2 };
@@ -62,7 +62,7 @@ fn wire_text_format_methods_record_codec_rewrite() {
     let output = check_source(
         r#"
         #[wire]
-        struct Point { x: i64 @1, y: i64 @2 }
+        type Point { x: i64 @1, y: i64 @2 }
 
         fn main() {
             let p = Point { x: 1, y: 2 };
@@ -114,7 +114,7 @@ fn wire_from_json_returns_result_self_string() {
     let output = check_source(
         r#"
         #[wire]
-        struct Point { x: i64 @1, y: i64 @2 }
+        type Point { x: i64 @1, y: i64 @2 }
 
         fn main() {
             let _r: Result<Point, string> = Point.from_json("{\"x\":1,\"y\":2}");
@@ -137,7 +137,7 @@ fn wire_from_json_bare_self_is_type_error() {
     let output = check_source(
         r#"
         #[wire]
-        struct Point { x: i64 @1, y: i64 @2 }
+        type Point { x: i64 @1, y: i64 @2 }
 
         fn main() {
             let _p: Point = Point.from_json("{\"x\":1,\"y\":2}");
@@ -155,7 +155,7 @@ fn wire_layout_table_populated_from_wire_struct() {
     let output = check_source(
         r"
         #[wire]
-        struct Point { x: i64 @1, y: i64 @2 }
+        type Point { x: i64 @1, y: i64 @2 }
         ",
     );
 
@@ -189,7 +189,7 @@ fn wire_layout_json_name_override_preserved() {
     let output = check_source(
         r#"
         #[wire]
-        struct Cfg { host: string @1 json_name="hostname" }
+        type Cfg { host: string @1 json_name="hostname" }
         "#,
     );
 

--- a/hew-types/src/check/types.rs
+++ b/hew-types/src/check/types.rs
@@ -543,7 +543,7 @@ pub struct WireFieldLayout {
 /// Wire layout metadata for a single type (struct or enum).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WireLayoutEntry {
-    /// True for `#[wire] struct`, false for `#[wire] enum`.
+    /// True for `#[wire] type`, false for `#[wire] enum`.
     pub is_struct: bool,
     /// Type-level JSON casing override.
     pub json_case: Option<NamingCase>,

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -823,7 +823,7 @@ fn stream_decode_fails_closed_before_codegen() {
         import std::stream;
 
         #[wire]
-        struct Message {
+        type Message {
             id: i64 @1;
         }
 
@@ -850,7 +850,7 @@ fn sink_encode_fails_closed_before_codegen() {
         import std::stream;
 
         #[wire]
-        struct Message {
+        type Message {
             id: i64 @1;
         }
 

--- a/hew-types/tests/type_system_negative.rs
+++ b/hew-types/tests/type_system_negative.rs
@@ -632,11 +632,11 @@ fn duplicate_definition_same_wire_type() {
     let output = typecheck(
         r"
         #[wire]
-        struct Packet {
+        type Packet {
             id: i32 @1;
         }
         #[wire]
-        struct Packet {
+        type Packet {
             name: string @1;
         }
         fn main() {}

--- a/tests/vertical-slice/accept/wire_cbor_bytes.hew
+++ b/tests/vertical-slice/accept/wire_cbor_bytes.hew
@@ -2,7 +2,7 @@
 // byte string, preserving length and every element (including the high byte
 // 255). A mismatch returns a distinct code per assertion.
 #[wire]
-struct Blob {
+type Blob {
     data: bytes @1,
 }
 

--- a/tests/vertical-slice/accept/wire_cbor_decode_malformed_traps.hew
+++ b/tests/vertical-slice/accept/wire_cbor_decode_malformed_traps.hew
@@ -1,7 +1,7 @@
 // Validation: decoding malformed bytes through the CBOR body codec fails closed
 // (the program traps) rather than returning a partial or garbage Packet.
 #[wire]
-struct Packet {
+type Packet {
     id: i64 @1,
 }
 

--- a/tests/vertical-slice/accept/wire_cbor_empty_collections.hew
+++ b/tests/vertical-slice/accept/wire_cbor_empty_collections.hew
@@ -3,7 +3,7 @@
 // empty text). Both must decode back empty, not null or absent. Success
 // returns 42.
 #[wire]
-struct Empties {
+type Empties {
     items: Vec<i64> @1,
     label: string @2,
 }

--- a/tests/vertical-slice/accept/wire_cbor_int_widths.hew
+++ b/tests/vertical-slice/accept/wire_cbor_int_widths.hew
@@ -4,7 +4,7 @@
 // cannot construct them). A mismatch returns the field's 1-based index so a
 // regression points at the exact width.
 #[wire]
-struct Ints {
+type Ints {
     a: i8 @1,
     b: i16 @2,
     c: i32 @3,

--- a/tests/vertical-slice/accept/wire_cbor_narrow_int_over_range_traps.hew
+++ b/tests/vertical-slice/accept/wire_cbor_narrow_int_over_range_traps.hew
@@ -11,12 +11,12 @@
 // null, and the `.decode()` call site traps — the same free-before-trap
 // discipline every other malformed shape follows.
 #[wire]
-struct Wide {
+type Wide {
     v: i64 @1,
 }
 
 #[wire]
-struct Narrow {
+type Narrow {
     v: i8 @1,
 }
 

--- a/tests/vertical-slice/accept/wire_cbor_nested_struct.hew
+++ b/tests/vertical-slice/accept/wire_cbor_nested_struct.hew
@@ -2,12 +2,12 @@
 // codec — the outer codec recurses into the inner struct's codec, encoding it
 // as a nested CBOR map. The recovered fields sum to 42.
 #[wire]
-struct Inner {
+type Inner {
     v: i64 @1,
 }
 
 #[wire]
-struct Outer {
+type Outer {
     inner: Inner @1,
     tag: i64 @2,
 }

--- a/tests/vertical-slice/accept/wire_cbor_option_none.hew
+++ b/tests/vertical-slice/accept/wire_cbor_option_none.hew
@@ -3,7 +3,7 @@
 // `None` arm returns 42, so a round-trip that mis-decodes the absent value
 // changes the exit code.
 #[wire]
-struct Holder {
+type Holder {
     maybe: Option<i64> @1,
 }
 

--- a/tests/vertical-slice/accept/wire_cbor_option_some.hew
+++ b/tests/vertical-slice/accept/wire_cbor_option_some.hew
@@ -3,7 +3,7 @@
 // `None` is CBOR null. This fixture exercises `Some`; the recovered payload
 // (42) is the exit code, so a garbled round-trip changes it.
 #[wire]
-struct Holder {
+type Holder {
     maybe: Option<i64> @1,
 }
 

--- a/tests/vertical-slice/accept/wire_cbor_roundtrip_packet.hew
+++ b/tests/vertical-slice/accept/wire_cbor_roundtrip_packet.hew
@@ -2,7 +2,7 @@
 // Build a Packet, encode it to bytes, decode the bytes back, and exit with the
 // recovered field value (42), so a garbled round-trip changes the exit code.
 #[wire]
-struct Packet {
+type Packet {
     id: i64 @1,
 }
 

--- a/tests/vertical-slice/accept/wire_cbor_scalars.hew
+++ b/tests/vertical-slice/accept/wire_cbor_scalars.hew
@@ -2,7 +2,7 @@
 // codec — f32, f64, bool, char, a non-empty string, and an empty string (the
 // empty-string boundary). A mismatch returns the field's 1-based index.
 #[wire]
-struct Scalars {
+type Scalars {
     a: f32 @1,
     b: f64 @2,
     c: bool @3,

--- a/tests/vertical-slice/accept/wire_cbor_vec_int.hew
+++ b/tests/vertical-slice/accept/wire_cbor_vec_int.hew
@@ -2,7 +2,7 @@
 // CBOR array, preserving order and every element. The decoded elements sum to
 // 42, so a dropped or reordered element changes the exit code.
 #[wire]
-struct ListHolder {
+type ListHolder {
     items: Vec<i64> @1,
 }
 

--- a/tests/vertical-slice/accept/wire_cbor_vec_string.hew
+++ b/tests/vertical-slice/accept/wire_cbor_vec_string.hew
@@ -3,7 +3,7 @@
 // element strings are owned and freed on drop. A mismatch returns a distinct
 // code; full success returns 42.
 #[wire]
-struct Names {
+type Names {
     items: Vec<string> @1,
 }
 

--- a/tests/vertical-slice/accept/wire_cbor_vec_struct.hew
+++ b/tests/vertical-slice/accept/wire_cbor_vec_struct.hew
@@ -7,12 +7,12 @@
 // vec). The decoded elements' `v` fields sum to 42, so a dropped, reordered, or
 // corrupted element changes the exit code.
 #[wire]
-struct Inner {
+type Inner {
     v: i64 @1,
 }
 
 #[wire]
-struct Container {
+type Container {
     items: Vec<Inner> @1,
 }
 

--- a/tests/vertical-slice/accept/wire_json_malformed_is_err.hew
+++ b/tests/vertical-slice/accept/wire_json_malformed_is_err.hew
@@ -3,7 +3,7 @@
 // bad input must be a recoverable error, not a crash. The fixture EXITS 42 only
 // by taking the `Err` arm — a trap would abort (134) and fail the assertion.
 #[wire]
-struct Point {
+type Point {
     x: i64 @1,
     y: i64 @2,
 }

--- a/tests/vertical-slice/accept/wire_json_missing_field_is_err.hew
+++ b/tests/vertical-slice/accept/wire_json_missing_field_is_err.hew
@@ -2,7 +2,7 @@
 // (non-optional) field returns `Err`, never a fabricated zero value. Exits 42
 // via the `Err` arm.
 #[wire]
-struct Point {
+type Point {
     x: i64 @1,
     y: i64 @2,
 }

--- a/tests/vertical-slice/accept/wire_json_nested_roundtrip.hew
+++ b/tests/vertical-slice/accept/wire_json_nested_roundtrip.hew
@@ -3,13 +3,13 @@
 // so each level maps tags to names correctly. The recovered inner fields sum to
 // 42 (1 + 2 + 5 + 6 = 14 → no; chosen so the sum is 42).
 #[wire]
-struct Point {
+type Point {
     x: i64 @1,
     y: i64 @2,
 }
 
 #[wire]
-struct Line {
+type Line {
     from: Point @1,
     to: Point @2,
 }

--- a/tests/vertical-slice/accept/wire_json_over_range_is_err.hew
+++ b/tests/vertical-slice/accept/wire_json_over_range_is_err.hew
@@ -3,7 +3,7 @@
 // truncated or wrapped value. The CBOR decode walk's range check is the
 // fail-closed gate; the bridge surfaces its failure as `Err`. Exits 42 via Err.
 #[wire]
-struct Narrow {
+type Narrow {
     v: i8 @1,
 }
 

--- a/tests/vertical-slice/accept/wire_json_struct_roundtrip.hew
+++ b/tests/vertical-slice/accept/wire_json_struct_roundtrip.hew
@@ -3,7 +3,7 @@
 // an equal value. A wrong key name, dropped field, or mis-parse changes the exit
 // code; the success path returns 42.
 #[wire]
-struct Point {
+type Point {
     x: i64 @1,
     y: i64 @2,
 }

--- a/tests/vertical-slice/accept/wire_json_vec_option_roundtrip.hew
+++ b/tests/vertical-slice/accept/wire_json_vec_option_roundtrip.hew
@@ -2,7 +2,7 @@
 // serializes as a JSON array; a `Some(x)` as the value, `None` as null. The
 // recovered vector elements (10 + 20 + 12 = 42) select the exit code.
 #[wire]
-struct Bag {
+type Bag {
     items: Vec<i64> @1,
     label: Option<string> @2,
 }

--- a/tests/vertical-slice/accept/wire_json_wrong_shape_is_err.hew
+++ b/tests/vertical-slice/accept/wire_json_wrong_shape_is_err.hew
@@ -2,7 +2,7 @@
 // match the target type (an array where the struct expects an object) returns
 // `Err`, never a misread or trap. Exits 42 only via the `Err` arm.
 #[wire]
-struct Point {
+type Point {
     x: i64 @1,
     y: i64 @2,
 }

--- a/tests/vertical-slice/accept/wire_yaml_roundtrip.hew
+++ b/tests/vertical-slice/accept/wire_yaml_roundtrip.hew
@@ -2,7 +2,7 @@
 // produces a YAML document the bridge can re-parse via `from_yaml` back into an
 // equal value. The recovered fields sum to 42.
 #[wire]
-struct Point {
+type Point {
     x: i64 @1,
     y: i64 @2,
 }

--- a/tests/vertical-slice/reject/wire_cbor_option_option_rejected.hew
+++ b/tests/vertical-slice/reject/wire_cbor_option_option_rejected.hew
@@ -3,7 +3,7 @@
 // null, so the two are indistinguishable on decode. The codec fails closed at
 // codegen-front validation rather than silently collapsing them.
 #[wire]
-struct Nested {
+type Nested {
     x: Option<Option<i64>> @1,
 }
 

--- a/tests/vertical-slice/reject/wire_cbor_vec_owned_compound_rejected.hew
+++ b/tests/vertical-slice/reject/wire_cbor_vec_owned_compound_rejected.hew
@@ -4,12 +4,12 @@
 // codec that could leak or mis-free the owned element heap on a malformed
 // decode. Scalar and heap-free-record `Vec` elements are supported.
 #[wire]
-struct Inner {
+type Inner {
     name: string @1,
 }
 
 #[wire]
-struct Holder {
+type Holder {
     xs: Vec<Inner> @1,
 }
 

--- a/tools/downstream/syntax-fixtures/syntax_test.hew
+++ b/tools/downstream/syntax-fixtures/syntax_test.hew
@@ -51,7 +51,7 @@ impl Drawable for Point {
 
 // === Wire Types ===
 #[wire]
-struct UserMessage {
+type UserMessage {
     name: string @1,
     age: u32 @2 optional,
     email: string @3 deprecated,


### PR DESCRIPTION
## Summary

**Breaking change.** Wire records were the one place Hew still had a `struct` keyword — `#[wire] struct Foo { ... }` — while everything else declares with `type`. The keyword is gone entirely: `#[wire] type` and `#[wire] enum` are now the wire forms, wire-ness is purely the attribute. This closes a fail-open gap where `#[wire] type` previously parsed cleanly but silently dropped the attribute (no derivation, no enforcement, no error) — that path is now the real wiring.

Legacy `struct` / `#[wire] struct` / `pub struct` input gets a targeted redirect diagnostic pointing at the `type` spelling instead of a generic parse error. The formatter emits the new form; parse-format-parse is proven byte-stable (it previously still emitted the deleted keyword, which would have corrupted wire code on the first format pass).

Every surface that taught the old form migrated: fixtures, examples, embedded test programs, the fuzz corpus and its generator, the sandbox coverage table (which also pins the legacy form's rejection), grammars, spec, and wire doctrine. User-facing diagnostics no longer say "struct" anywhere on the wire-type surface.

## Verification

- Attribute-derivation keystone test: red before this change, green after.
- Wire round-trip suites (CBOR/JSON/YAML) and CDDL conformance: green.
- Redirect-diagnostic fixtures for all three legacy spellings (`struct`, `#[wire] struct`, `pub struct`): pass, asserting exact message + hint.
- Formatter byte-stability on `#[wire] type`: confirmed (parse-format-parse round trip).
- Workspace-wide `\bstruct\b` diagnostic-string sweep: zero surviving Hew-surface struct teaching (remaining hits are pre-approved internal terminology — enum "struct variant" naming, a clippy `reason=`, an internal assert message).
- Full integration preflight (all steps) and a full solo preflight on this branch: both green.

Fixes #2365.

## Out of scope

- Editor syntax-highlighting grammars still teach the old `struct` form — tracked separately with the rest of the grammar refresh.
