### PR TITLE
fix(runtime): guard root-supervisor escalate against null parent

### DIFF
--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -2260,8 +2260,12 @@ unsafe fn apply_restart(
             }
             Some(CRASH_ACTION_ESCALATE) => {
                 // Propagate the failure to the supervisor's supervisor instead
-                // of restarting locally.
-                escalate_to_parent(sup);
+                // of restarting locally. A root supervisor has no parent to
+                // escalate to; treat escalation with no parent as a safe
+                // no-op rather than dereferencing a null parent pointer.
+                if !sup.parent.is_null() {
+                    escalate_to_parent(sup);
+                }
                 return;
             }
             // Some(CRASH_ACTION_RESTART) or any out-of-range tag (fail-closed

--- a/hew-runtime/tests/on_crash_invocation.rs
+++ b/hew-runtime/tests/on_crash_invocation.rs
@@ -390,3 +390,109 @@ fn on_crash_kill_return_terminates_child_overriding_restart_policy() {
 
     hew_deterministic_reset();
 }
+
+/// G-S-A: a handler returning `CrashAction::Escalate` (tag 1) on a ROOT
+/// supervisor must not dereference a null parent pointer.
+///
+/// `TestSupervisor::new` constructs a root supervisor: `hew_supervisor_new`
+/// sets `parent: ptr::null_mut()`. Before the fix, `apply_restart`'s
+/// `CRASH_ACTION_ESCALATE` arm called `escalate_to_parent(sup)`
+/// unconditionally, which dereferenced that null parent
+/// (`hew-runtime/src/supervisor.rs:987`) and aborted the process. The fixed
+/// arm guards the call exactly like the sibling `stop_and_maybe_escalate`,
+/// so escalating past the root is a safe no-op: the handler still fires,
+/// the restart is suppressed (same shape as `Kill`), and the supervisor
+/// keeps running.
+unsafe extern "C" fn escalate_on_crash(
+    _ctx: *mut hew_runtime::execution_context::HewExecutionContext,
+    crash_code: i64,
+    _crash_message: *const std::ffi::c_char,
+    _actor_state_ptr: *mut c_void,
+) -> HewCrashActionAbi {
+    ON_CRASH_CALLS.fetch_add(1, Ordering::SeqCst);
+    LAST_CRASH_CODE.store(crash_code, Ordering::SeqCst);
+    HewCrashActionAbi {
+        tag: 1, // CrashAction::Escalate
+        payload_pad: [0],
+    }
+}
+
+#[test]
+fn on_crash_escalate_on_root_supervisor_does_not_abort() {
+    let _guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    ensure_scheduler();
+    hew_deterministic_reset();
+    DISPATCH_COUNT.store(0, Ordering::SeqCst);
+    ON_CRASH_CALLS.store(0, Ordering::SeqCst);
+
+    let sup = TestSupervisor::new(STRATEGY_ONE_FOR_ONE, 10, 60);
+    let name = cstr("escalate-on-crash-worker");
+    let mut state: i32 = 0;
+
+    // SAFETY: sup is live; spec lives across the FFI call.
+    unsafe {
+        hew_supervisor_set_restart_notify(sup.as_ptr());
+
+        let spec = HewChildSpec {
+            name: name.as_ptr(),
+            init_state: (&raw mut state).cast(),
+            init_state_size: std::mem::size_of::<i32>(),
+            dispatch: Some(noop_dispatch),
+            restart_policy: RESTART_PERMANENT,
+            mailbox_capacity: -1,
+            overflow: OVERFLOW_DROP_NEW,
+            arena_cap_bytes: 0,
+            cycle_capable: 0,
+            on_crash: Some(escalate_on_crash),
+            lifecycle_fn: None,
+            init_fn: None,
+            config: std::ptr::null_mut(),
+            config_size: 0,
+        };
+        assert_eq!(
+            hew_supervisor_add_child_spec(sup.as_ptr(), &raw const spec),
+            0
+        );
+        assert_eq!(sup.start(), 0);
+
+        let child = wait_for_child(sup.as_ptr(), 0, 2000);
+        crash_child(child);
+
+        // The handler fires; Escalate (like Kill) short-circuits the
+        // restart path entirely — no restart cycle should occur.
+        let count = hew_supervisor_wait_restart(sup.as_ptr(), 1, 1500);
+        assert_eq!(
+            count, 0,
+            "Escalate return must suppress the restart cycle (got {count})"
+        );
+        assert_eq!(
+            ON_CRASH_CALLS.load(Ordering::SeqCst),
+            1,
+            "the Escalate handler must still fire exactly once"
+        );
+
+        // The process did not abort: the supervisor is still alive and
+        // running. This is the guard under test — escalating past a root
+        // supervisor with no parent must not null-deref `sup.parent`.
+        assert!(
+            sup.is_running(),
+            "supervisor must remain running after an Escalate return with no parent to escalate to"
+        );
+
+        // The child slot stays null: no restart happened, matching the
+        // Kill-return shape.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(800);
+        while std::time::Instant::now() < deadline {
+            let slot = hew_runtime::supervisor::hew_supervisor_get_child(sup.as_ptr(), 0);
+            assert!(
+                slot.is_null(),
+                "Escalate return with no parent must leave child slot 0 null (no restart)"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
+    hew_deterministic_reset();
+}

--- a/tests/vertical-slice/accept/on_crash_escalate_root.hew
+++ b/tests/vertical-slice/accept/on_crash_escalate_root.hew
@@ -1,0 +1,60 @@
+// Acceptance fixture (G-S-A): a #[on(crash)] hook returning
+// `CrashAction::Escalate` on a ROOT supervisor (no parent) must not abort
+// the process.
+//
+// `App` is a root supervisor: `hew_supervisor_new` sets its `parent` field
+// to null. When `Worker`'s crash hook returns `CrashAction::Escalate`, the
+// pre-fix arm in `apply_restart` (`hew-runtime/src/supervisor.rs`) called
+// `escalate_to_parent(sup)` unconditionally, which dereferenced the null
+// `sup.parent` and aborted the process with SIGABRT. The fixed arm guards
+// the call exactly like the sibling `stop_and_maybe_escalate`: escalating
+// past the root has nowhere to go, so it becomes a safe no-op — the crash
+// is recorded, the child is not restarted, and the supervisor (and the
+// process) keep running.
+//
+// Teeth: before the fix, this binary aborts (exit 134, SIGABRT) the moment
+// `Worker` crashes. After the fix, the process survives and the independent
+// `Probe` actor still answers a fresh `ask`, proving the scheduler stayed
+// healthy through the escalation — not just that the process happened to
+// exit before the abort landed.
+import std::failure;
+
+actor Worker {
+    #[on(crash)]
+    fn on_crash(info: CrashInfo) -> CrashAction {
+        CrashAction::Escalate
+    }
+
+    receive fn boom() {
+        panic("forced crash to fire on(crash)");
+    }
+}
+
+actor Probe {
+    receive fn ping() -> i64 {
+        0
+    }
+}
+
+supervisor App {
+    strategy: one_for_one;
+    intensity: 5 within 60s;
+
+    child w: Worker;
+}
+
+fn main() -> i64 {
+    let sup = spawn App;
+    let probe = spawn Probe;
+    let w = sup.w;
+    // Fire-and-forget crash: the on_crash hook returns Escalate, which the
+    // root supervisor has nowhere to route.
+    w.boom();
+    // Give the crash-handling dispatch time to run to completion. A
+    // pre-fix binary aborts the whole process during this window.
+    sleep(300ms);
+    match await probe.ping() {
+        Ok(v) => v,
+        Err(_) => 1,
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1442,6 +1442,15 @@ run_accept_expect_status "on_crash_action_restart" 42
 # scripts/asan-fixture-check.sh (Linux) and the macOS leaks oracle.
 run_accept_expect_status "on_crash_action_restart_real_crash" 42
 
+# Accept (G-S-A): a REAL crash fires an #[on(crash)] hook that returns
+# CrashAction::Escalate on a ROOT supervisor (no parent). Before the fix,
+# the Escalate arm in apply_restart dereferenced the root's null parent
+# pointer and aborted the process (exit 134, SIGABRT). The fixed arm guards
+# the call like the sibling stop_and_maybe_escalate, so the escalation is a
+# safe no-op: the process survives and an independent probe actor still
+# answers, proving the scheduler stayed healthy through the crash.
+run_accept_expect_status "on_crash_escalate_root" 0
+
 # Accept: #[on(exit)] linked-actor exit hook compiles end-to-end (M-7-R). The
 # checker accepts `fn on_peer_exit(note: CrashNotification)`; MIR emits
 # Watcher__on_exit; codegen routes SYS_MSG_EXIT to it in the dispatch


### PR DESCRIPTION
## Summary

A root supervisor has no parent (`sup.parent` is null by construction), but the `CrashAction::Escalate` path in `apply_restart` called `escalate_to_parent` unconditionally, which dereferences that null pointer on its first line. Any root-level crash hook that returned `Escalate` aborted the process (SIGABRT). Escalation on a root supervisor is now a safe no-op, mirroring the existing null-parent guard already present in the sibling `stop_and_maybe_escalate` path.

## Verification

- Compiled-binary regression: exits cleanly (0) where it previously aborted (134) — reverting the guard reproduces `Abort trap: 6` at the exact null-deref site, confirming the fix is load-bearing rather than incidental.
- Escalation for a supervisor with a real parent is unchanged: the guard only special-cases `parent == null`; for `parent != null` the same call, event construction, and scheduler wake-up path runs exactly as before.
- `cargo test -p hew-runtime --test on_crash_invocation`: new unit test drives `CrashAction::Escalate` on a root supervisor and asserts the restart is suppressed, the crash hook fires exactly once, and the supervisor keeps running (no abort).
- New vertical-slice fixture (`on_crash_escalate_root.hew`): after the crash and escalation no-op, the program awaits an independent actor and returns its result as the exit code — proving the scheduler stays alive and responsive after the crash, not just that the process didn't abort.

## Out of scope

None.
