### PR TITLE
fix(mir): compensate sibling-field drops along multi-hop alias chains

### DIFF
--- a/hew-cli/tests/match_bound_field_original_leak_oracle.rs
+++ b/hew-cli/tests/match_bound_field_original_leak_oracle.rs
@@ -1,0 +1,362 @@
+//! Bound-string original discharge oracle for match destructures that
+//! CONSUME the scrutinee root — the empirical (compiled-binary) half of the
+//! per-field accounting matrix whose skipped-field sibling lives in
+//! `match_skipped_field_drop_leak_oracle.rs`.
+//!
+//! ## The stranded original
+//!
+//! When a `match` binds a `string`-typed field of an owned record/tuple and
+//! the scrutinee root is CONSUMED by the destructure (a non-captured,
+//! non-alias `BindingRef` with bindings), the binder owns a CLONE — codegen
+//! retains string field loads via `hew_string_clone` — while the ORIGINAL
+//! handle still sits in the root slot. The root's composite drop is
+//! suppressed (the binder seeds `release_owner_bases`) and the consume mark
+//! retracts the root from `owned_locals`, so nothing releases the original:
+//! it leaks one buffer per destructure.
+//!
+//! The bind loop discharges the original IN PLACE right after the load —
+//! `Instr::FieldDropInPlace` raw-loads the root's field handle, releases it,
+//! and null-stores the slot. The binder is then the sole owner (its own drop
+//! balances the retained clone), so the shape is leak-free AND double-free
+//! free even when the arm returns the binder.
+//!
+//! ## Gating (the three double-free guards)
+//!
+//! The discharge fires ONLY when all three hold — each false gate would
+//! double-free:
+//!   - the scrutinee earns the consume mark (a non-consumed root keeps its
+//!     composite drop, which frees the original);
+//!   - the root is NOT an interior alias (an alias's original belongs to the
+//!     OUTER composite, which frees it — `FieldDropInPlace` would null-store
+//!     the alias slot, not the owner's);
+//!   - the bound field is `string`-typed (the retaining-load class; non-
+//!     string binders take the one handle and leave a dead root slot).
+//!
+//! ## De-flake: slope, not single-shot exact-zero
+//!
+//! Each shape compiles at LOW and HIGH iteration counts and the leak-NODE
+//! delta must stay within tolerance (`support::leak_slope`). A regressed
+//! discharge leaks one node per iteration — an order of magnitude above the
+//! tolerance. macOS-only for the slope legs (`leaks(1)`); the scribble and
+//! MIR pins run on any unix host.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::process::Command;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+// ── looped slope fixtures ───────────────────────────────────────────────
+
+/// Record parent, BOUND `string` field, `BitCopy` sibling wildcarded, root
+/// consumed, binder USED in the arm body. Pre-fix behaviour leaked one
+/// `to_upper()` original per iteration (the binder held the clone, the root
+/// slot's original was never released); the in-place discharge holds the
+/// slope flat.
+fn bound_string_record_loop_source(frames: usize) -> String {
+    format!(
+        "type Inner {{\n\
+         \x20   v: i64,\n\
+         }}\n\
+         \n\
+         type Outer {{\n\
+         \x20   inner: Inner,\n\
+         \x20   c: string,\n\
+         }}\n\
+         \n\
+         fn run_cycle(k: i64) -> i64 {{\n\
+         \x20   let o = Outer {{ inner: Inner {{ v: k }}, c: \"bound-string-heap\".to_upper() }};\n\
+         \x20   let x = match o {{\n\
+         \x20       Outer {{ inner: _, c }} => c.len(),\n\
+         \x20   }};\n\
+         \x20   x\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + run_cycle(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total >= 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// Tuple parent, BOUND `string` element, `BitCopy` element also bound, root
+/// consumed — the same stranded-original hazard through `FieldAddr::Tuple`
+/// addressing.
+fn bound_string_tuple_loop_source(frames: usize) -> String {
+    format!(
+        "fn run_cycle(k: i64) -> i64 {{\n\
+         \x20   let o = (k, \"bound-tuple-heap\".to_upper());\n\
+         \x20   let x = match o {{\n\
+         \x20       (a, c) => a + c.len(),\n\
+         \x20   }};\n\
+         \x20   x\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + run_cycle(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total >= 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+// ── scribble / escape fixtures (single-cycle, exact stdout) ─────────────
+
+/// Single-cycle bound-string destructure that USES the binder (`c.len()`)
+/// and prints a sentinel. A double-free of the discharged original — or of
+/// the binder's clone — aborts under the poisoned allocator.
+const BOUND_STRING_USED_SCRIBBLE_SOURCE: &str = "\
+type Inner {\n\
+\x20   v: i64,\n\
+}\n\
+\n\
+type Outer {\n\
+\x20   inner: Inner,\n\
+\x20   c: string,\n\
+}\n\
+\n\
+fn main() -> i64 {\n\
+\x20   let o = Outer { inner: Inner { v: 7 }, c: \"scribble-heap\".to_upper() };\n\
+\x20   let n = match o {\n\
+\x20       Outer { inner: _, c } => c.len(),\n\
+\x20   };\n\
+\x20   if n == 13 {\n\
+\x20       print(\"k\");\n\
+\x20   }\n\
+\x20   0\n\
+}\n";
+
+/// Single-cycle destructure where the arm RETURNS the bound string and the
+/// caller reads it. The binder carries its own `+1` (balanced by the
+/// caller-side drop); the in-place discharge releases ONLY the root's share,
+/// so returning the binder is neither a leak nor a use-after-free.
+const BOUND_STRING_ESCAPE_SOURCE: &str = "\
+type Inner {\n\
+\x20   v: i64,\n\
+}\n\
+\n\
+type Outer {\n\
+\x20   inner: Inner,\n\
+\x20   c: string,\n\
+}\n\
+\n\
+fn take(o: Outer) -> string {\n\
+\x20   match o {\n\
+\x20       Outer { inner: _, c } => c,\n\
+\x20   }\n\
+}\n\
+\n\
+fn main() -> i64 {\n\
+\x20   let o = Outer { inner: Inner { v: 1 }, c: \"ESCAPE-HEAP\" };\n\
+\x20   let s = take(o);\n\
+\x20   print(s);\n\
+\x20   0\n\
+}\n";
+
+/// Interior-alias scrutinee (`let mid = o.a;` byte-copies the member) with a
+/// bound `string` field. The original belongs to the OUTER composite, so the
+/// discharge MUST be gated off — this fixture pins that NO
+/// `FieldDropInPlace` is emitted through the alias slot.
+const ALIAS_SCRUTINEE_BOUND_STRING_SOURCE: &str = "\
+type Alias {\n\
+\x20   s: string,\n\
+\x20   n: i64,\n\
+}\n\
+\n\
+type Holder {\n\
+\x20   a: Alias,\n\
+\x20   h: i64,\n\
+}\n\
+\n\
+fn f(o: Holder) -> i64 {\n\
+\x20   let mid = o.a;\n\
+\x20   let x = match mid {\n\
+\x20       Alias { s, n } => s.len() + n,\n\
+\x20   };\n\
+\x20   x\n\
+}\n\
+\n\
+fn main() -> i64 {\n\
+\x20   f(Holder { a: Alias { s: \"x\".to_upper(), n: 1 }, h: 2 })\n\
+}\n";
+
+// ── slope oracles ───────────────────────────────────────────────────────
+
+/// Bound `string` record field on a consumed root holds a flat leak slope —
+/// the stranded-original pin (record parent). Losing the in-place discharge
+/// leaks one original per iteration and trips the tolerance.
+#[test]
+fn bound_string_record_field_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("bound_string_record", bound_string_record_loop_source);
+}
+
+/// Bound `string` tuple element on a consumed root holds a flat leak slope —
+/// the stranded-original pin (tuple parent).
+#[test]
+fn bound_string_tuple_element_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("bound_string_tuple", bound_string_tuple_loop_source);
+}
+
+// ── scribble (double-free / use-after-free) pins ────────────────────────
+
+/// The binder-used destructure runs clean under the poisoned allocator and
+/// prints its sentinel — an over-eager free of the discharged original (or a
+/// re-drop of the binder's clone) aborts here.
+#[test]
+fn bound_string_binder_used_no_double_free_under_malloc_scribble() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("bound-string-used-scribble-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(
+        BOUND_STRING_USED_SCRIBBLE_SOURCE,
+        dir.path(),
+        "bound_string_used_scribble",
+    );
+    let output = run_under_malloc_scribble(&bin);
+
+    assert!(
+        output.status.success(),
+        "bound-string destructure must run clean under the poisoned allocator — a crash \
+         here means the original discharge double-freed the binder's clone;\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        "k",
+        "sentinel mismatch — scribbled output indicates a use-after-free;\n{}",
+        describe_output(&output)
+    );
+}
+
+/// The escaping-binder shape runs clean under the poisoned allocator and
+/// prints the returned string exactly — the in-place discharge releases only
+/// the root's share, so the binder survives the return and the caller reads
+/// live memory.
+#[test]
+fn bound_string_binder_escapes_no_double_free_under_malloc_scribble() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("bound-string-escape-scribble-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(
+        BOUND_STRING_ESCAPE_SOURCE,
+        dir.path(),
+        "bound_string_escape_scribble",
+    );
+    let output = run_under_malloc_scribble(&bin);
+
+    assert!(
+        output.status.success(),
+        "escaping bound-string binder must run clean under the poisoned allocator — a crash \
+         here means the discharge freed the binder's handle out from under the caller;\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        "ESCAPE-HEAP",
+        "returned-binder output mismatch — indicates a use-after-free of the escaped string;\n{}",
+        describe_output(&output)
+    );
+}
+
+// ── MIR emission pins ────────────────────────────────────────────────────
+
+/// Run `hew compile --dump-mir raw` over `source` and return the dump.
+/// Panics (with the compiler output) if MIR construction fails.
+fn dump_raw_mir(name: &str, source: &str) -> String {
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("bound-string-mir-pin-{name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let hew_src = dir.path().join(format!("{name}.hew"));
+    std::fs::write(&hew_src, source).expect("write hew source");
+
+    let output = Command::new(hew_binary())
+        .args(["compile", "--dump-mir", "raw"])
+        .arg(&hew_src)
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew compile --dump-mir");
+    assert!(
+        output.status.success(),
+        "MIR construction must succeed for {name}:\n{}",
+        describe_output(&output)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// A bound `string` field on a CONSUMED, non-alias root emits exactly one
+/// `FieldDropInPlace` carrying the string type — the stranded-original
+/// discharge at the MIR level (the record parent).
+#[test]
+fn consumed_root_bound_string_emits_field_drop_in_place_mir() {
+    require_codegen();
+
+    let source = "\
+type Inner {\n\
+\x20   v: i64,\n\
+}\n\
+\n\
+type Outer {\n\
+\x20   inner: Inner,\n\
+\x20   c: string,\n\
+}\n\
+\n\
+fn consume(o: Outer) -> i64 {\n\
+\x20   let x = match o {\n\
+\x20       Outer { inner: _, c } => c.len(),\n\
+\x20   };\n\
+\x20   x\n\
+}\n\
+\n\
+fn main() -> i64 {\n\
+\x20   consume(Outer { inner: Inner { v: 0 }, c: \"s\" })\n\
+}\n";
+    let dump = dump_raw_mir("consumed_bound_string", source);
+    let discharges = dump.matches("drop_field_in_place").count();
+    assert_eq!(
+        discharges, 1,
+        "a bound string field on a consumed root must emit exactly one FieldDropInPlace; dump:\n{dump}"
+    );
+    assert!(
+        dump.contains("ty=string"),
+        "the bound-string discharge must carry the string type; dump:\n{dump}"
+    );
+}
+
+/// An interior-alias scrutinee with a bound `string` field emits NO
+/// `FieldDropInPlace` through the alias — the original belongs to the outer
+/// composite, so discharging through the alias slot would double-free. The
+/// alias gate is the authority.
+#[test]
+fn alias_scrutinee_bound_string_emits_no_field_discharge_mir() {
+    require_codegen();
+
+    let dump = dump_raw_mir("alias_bound_string", ALIAS_SCRUTINEE_BOUND_STRING_SOURCE);
+    assert!(
+        !dump.contains("drop_field_in_place"),
+        "an interior-alias scrutinee must emit NO FieldDropInPlace — the outer composite owns \
+         the original; discharging through the alias would double-free. dump:\n{dump}"
+    );
+}

--- a/hew-cli/tests/nested_projection_chain_leak_oracle.rs
+++ b/hew-cli/tests/nested_projection_chain_leak_oracle.rs
@@ -525,6 +525,30 @@ fn bystander_root_leak_slope_below_tolerance() {
     assert_frame_slope_below_tolerance("chain_bystander", bystander_root_source);
 }
 
+/// Escaped-return record holds a FLAT slope: when the deep alias escapes into
+/// the return, the owner's composite drop is excluded (so the caller frees the
+/// escapee's subtree exactly once), and the multi-hop sibling-discharge walk
+/// releases the non-escaped siblings ALONG the chain — the outer `c` through the
+/// owner and the intermediate `mid.x` through the `mid` alias — each exactly
+/// once. Without that walk the widened exclusion removed the composite drop
+/// while nothing discharged the deeper siblings, so `mid.x` and the outer `c`
+/// leaked every frame (2 strings / call). This is the slope check that was
+/// missing for the escape shapes; the double-free pin below only proved no
+/// re-free, not the absence of a per-iteration leak.
+#[test]
+fn escaped_return_record_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("chain_escaped_return", escaped_return_record_source);
+}
+
+/// Escaped-into-record holds a FLAT slope: the deep alias is stored into a fresh
+/// owning record the caller keeps, so the owner's composite is excluded and the
+/// same multi-hop sibling walk discharges the non-escaped siblings along the
+/// chain exactly once. The `RecordInit` twin of the returned-record slope.
+#[test]
+fn escaped_into_record_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("chain_escaped_store", escaped_into_record_source);
+}
+
 // ── scribble (double-free / use-after-free) pins ────────────────────────
 
 fn assert_scribble_clean(name: &str, source: &str) {

--- a/hew-cli/tests/nested_projection_chain_leak_oracle.rs
+++ b/hew-cli/tests/nested_projection_chain_leak_oracle.rs
@@ -1,0 +1,708 @@
+//! Nested-projection-chain ownership oracle — the compiled-binary pins for a
+//! MULTI-level field-projection alias chain.
+//!
+//! ## The shape
+//!
+//! ```text
+//! let o    = make_outer(k);   // fresh owner of the whole tree
+//! let mid  = o.mid;           // byte-copy interior alias of `o`
+//! let leaf = mid.leaf;        // byte-copy interior alias of `mid` (of `o`)
+//! match leaf { Leaf { s, t: _ } => … }
+//! ```
+//!
+//! Each `let x = agg.field` where the field is an inline aggregate
+//! (record / tuple / inline-enum) byte-copies the member with NO retain, so
+//! `mid` and `leaf` are interior ALIASES of the still-live `o` — not
+//! independent owners. `o`'s composite in-place drop frees every original in
+//! the tree exactly once; `mid` and `leaf` must emit NO composite drop of
+//! their own (a re-walk of storage `o` still owns is a double-free — inline
+//! composites have no null-store, so the second free lands on live memory).
+//!
+//! ## What regressed without the fix (reproduced, fresh builds)
+//!
+//! `mid` is a NON-consumed field-binder of `o` that seeded the record
+//! composite prover's `release_owner_bases` (it registered as an owned local
+//! by TYPE alone), so the prover's Defect-1 blanket tripped and excluded
+//! EVERY root — `o`, `mid`, and `leaf` — from its composite drop. The whole
+//! tree leaked (~4 nodes / iteration for the record chain, the outer `c`, the
+//! `mid.x`, and both leaf strings). Classifying the projection as a
+//! byte-copy alias (`Disposition::AliasOf`) takes `mid`/`leaf` out of the
+//! release-owner set, so the blanket no longer trips and `o` stays admitted.
+//!
+//! Unrecorded provenance keeps the fail-closed blanket (leak, never
+//! double-free): only a projection whose owner root is named at the defining
+//! write is reclassified.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::process::Command;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+// ── looped slope fixtures ───────────────────────────────────────────────
+
+/// Two-level record chain (#2375). The outer root's composite must free the
+/// outer `c`, `mid.x`, and both leaf strings — each exactly once.
+fn two_level_record_chain_source(frames: usize) -> String {
+    format!(
+        "type Leaf {{\n\
+         \x20   s: string,\n\
+         \x20   t: string,\n\
+         }}\n\
+         \n\
+         type Mid {{\n\
+         \x20   leaf: Leaf,\n\
+         \x20   x: string,\n\
+         }}\n\
+         \n\
+         type Outer {{\n\
+         \x20   mid: Mid,\n\
+         \x20   c: string,\n\
+         }}\n\
+         \n\
+         fn make_outer(k: i64) -> Outer {{\n\
+         \x20   Outer {{\n\
+         \x20       mid: Mid {{\n\
+         \x20           leaf: Leaf {{\n\
+         \x20               s: \"leaf-s-heap-payload\".to_upper(),\n\
+         \x20               t: \"leaf-t-heap-payload\".to_upper(),\n\
+         \x20           }},\n\
+         \x20           x: \"mid-x-heap-payload\".to_upper(),\n\
+         \x20       }},\n\
+         \x20       c: \"outer-c-heap-payload\".to_upper(),\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn run_cycle(k: i64) -> i64 {{\n\
+         \x20   let o = make_outer(k);\n\
+         \x20   let mid = o.mid;\n\
+         \x20   let leaf = mid.leaf;\n\
+         \x20   let x = match leaf {{\n\
+         \x20       Leaf {{ s, t: _ }} => s.len(),\n\
+         \x20   }};\n\
+         \x20   x\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + run_cycle(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// Two-level record chain, both leaf fields SKIPPED (`{ s: _, t: _ }`). The
+/// outer composite still owns and frees the whole tree; nothing is bound out.
+fn two_level_double_skip_source(frames: usize) -> String {
+    format!(
+        "type Leaf {{\n\
+         \x20   s: string,\n\
+         \x20   t: string,\n\
+         }}\n\
+         \n\
+         type Mid {{\n\
+         \x20   leaf: Leaf,\n\
+         \x20   x: string,\n\
+         }}\n\
+         \n\
+         type Outer {{\n\
+         \x20   mid: Mid,\n\
+         \x20   c: string,\n\
+         }}\n\
+         \n\
+         fn make_outer(k: i64) -> Outer {{\n\
+         \x20   Outer {{\n\
+         \x20       mid: Mid {{\n\
+         \x20           leaf: Leaf {{\n\
+         \x20               s: \"leaf-s-heap-payload\".to_upper(),\n\
+         \x20               t: \"leaf-t-heap-payload\".to_upper(),\n\
+         \x20           }},\n\
+         \x20           x: \"mid-x-heap-payload\".to_upper(),\n\
+         \x20       }},\n\
+         \x20       c: \"outer-c-heap-payload\".to_upper(),\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn run_cycle(k: i64) -> i64 {{\n\
+         \x20   let o = make_outer(k);\n\
+         \x20   let mid = o.mid;\n\
+         \x20   let leaf = mid.leaf;\n\
+         \x20   let x = match leaf {{\n\
+         \x20       Leaf {{ s: _, t: _ }} => 1,\n\
+         \x20   }};\n\
+         \x20   x\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + run_cycle(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// Two-level TUPLE chain — the tuple composite prover's twin of the record
+/// path. `o.0` then `mid.0`, both byte-copy aliases; the outer tuple frees
+/// every original.
+fn two_level_tuple_chain_source(frames: usize) -> String {
+    format!(
+        "fn make_nested(k: i64) -> (((string, string), string), string) {{\n\
+         \x20   let a = \"tup-a-heap-payload\".to_upper();\n\
+         \x20   let b = \"tup-b-heap-payload\".to_upper();\n\
+         \x20   let c = \"tup-c-heap-payload\".to_upper();\n\
+         \x20   let d = \"tup-d-heap-payload\".to_upper();\n\
+         \x20   ((( a, b ), c ), d)\n\
+         }}\n\
+         \n\
+         fn run_cycle(k: i64) -> i64 {{\n\
+         \x20   let o = make_nested(k);\n\
+         \x20   let mid = o.0;\n\
+         \x20   let leaf = mid.0;\n\
+         \x20   let x = match leaf {{\n\
+         \x20       (s, _) => s.len(),\n\
+         \x20   }};\n\
+         \x20   x\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + run_cycle(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// Bystander control: an aliased chain AND an unrelated standalone owned
+/// record in the same frame. Admitting the chain's outer root must not
+/// disturb the standalone — it keeps its own composite drop and neither
+/// leaks nor double-frees.
+fn bystander_root_source(frames: usize) -> String {
+    format!(
+        "type Mid {{\n\
+         \x20   a: string,\n\
+         \x20   b: string,\n\
+         }}\n\
+         \n\
+         type Outer {{\n\
+         \x20   mid: Mid,\n\
+         \x20   c: string,\n\
+         }}\n\
+         \n\
+         type Bystander {{\n\
+         \x20   name: string,\n\
+         }}\n\
+         \n\
+         fn make_outer(k: i64) -> Outer {{\n\
+         \x20   Outer {{\n\
+         \x20       mid: Mid {{\n\
+         \x20           a: \"by-a-heap-payload\".to_upper(),\n\
+         \x20           b: \"by-b-heap-payload\".to_upper(),\n\
+         \x20       }},\n\
+         \x20       c: \"by-c-heap-payload\".to_upper(),\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn make_bystander(k: i64) -> Bystander {{\n\
+         \x20   Bystander {{ name: \"bystander-heap-payload\".to_upper() }}\n\
+         }}\n\
+         \n\
+         fn run_cycle(k: i64) -> i64 {{\n\
+         \x20   let o = make_outer(k);\n\
+         \x20   let mid = o.mid;\n\
+         \x20   let extra = make_bystander(k);\n\
+         \x20   let n = match mid {{\n\
+         \x20       Mid {{ a, b: _ }} => a.len(),\n\
+         \x20   }};\n\
+         \x20   n + extra.name.len()\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + run_cycle(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// `HandleTransfer` control: `let g = h.g` extracts a `Generator` field — a
+/// single-pointer heap leaf the load TRANSFERS to the binder. The binder
+/// becomes the owner (consumed by the for-loop here); the record's whole-root
+/// exclusion posture is correct and UNCHANGED by the alias fix (a `Generator`
+/// is never classified `ByteCopyAlias`). The pin is no double-free.
+fn handle_transfer_control_source(frames: usize) -> String {
+    format!(
+        "type Holder {{\n\
+         \x20   g: Generator<i64, i64>,\n\
+         \x20   label: string,\n\
+         }}\n\
+         \n\
+         fn counter() -> Generator<i64, i64> {{\n\
+         \x20   gen {{\n\
+         \x20       yield 1;\n\
+         \x20       yield 2;\n\
+         \x20       return 0;\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn make_holder(k: i64) -> Holder {{\n\
+         \x20   Holder {{ g: counter(), label: \"held-heap-payload\".to_upper() }}\n\
+         }}\n\
+         \n\
+         fn run_cycle(k: i64) -> i64 {{\n\
+         \x20   let h = make_holder(k);\n\
+         \x20   let g = h.g;\n\
+         \x20   var acc: i64 = 0;\n\
+         \x20   for n in g {{ acc = acc + n; }}\n\
+         \x20   acc\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + run_cycle(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total >= 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// Owner-consumed control: the alias binds, then the OWNER root is moved out
+/// (`sink(o)` takes it by value). The alias must emit NO drop of its own —
+/// the consumer frees the tree. The pin is no double-free (the alias never
+/// re-frees storage the consumer already released).
+fn owner_consumed_control_source(frames: usize) -> String {
+    format!(
+        "type Mid {{\n\
+         \x20   a: string,\n\
+         \x20   b: string,\n\
+         }}\n\
+         \n\
+         type Outer {{\n\
+         \x20   mid: Mid,\n\
+         \x20   c: string,\n\
+         }}\n\
+         \n\
+         fn make_outer(k: i64) -> Outer {{\n\
+         \x20   Outer {{\n\
+         \x20       mid: Mid {{\n\
+         \x20           a: \"oc-a-heap-payload\".to_upper(),\n\
+         \x20           b: \"oc-b-heap-payload\".to_upper(),\n\
+         \x20       }},\n\
+         \x20       c: \"oc-c-heap-payload\".to_upper(),\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn sink(o: Outer) -> i64 {{ o.c.len() }}\n\
+         \n\
+         fn run_cycle(k: i64) -> i64 {{\n\
+         \x20   let o = make_outer(k);\n\
+         \x20   let mid = o.mid;\n\
+         \x20   let n = sink(o);\n\
+         \x20   n\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + run_cycle(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// Escaped-deep-alias control (record): the deep projection alias is RETURNED
+/// to the caller, which reads it. The alias points into the owner's still-live
+/// subtree, so the owner's composite must NOT free that subtree — otherwise the
+/// caller reads (and frees) storage the owner already released (double-free /
+/// use-after-free). Fail-closed: the owner is excluded and its non-escaped
+/// siblings leak; the pin is no double-free, not a flat slope.
+fn escaped_return_record_source(frames: usize) -> String {
+    format!(
+        "type Leaf {{\n\
+         \x20   s: string,\n\
+         \x20   t: string,\n\
+         }}\n\
+         \n\
+         type Mid {{\n\
+         \x20   leaf: Leaf,\n\
+         \x20   x: string,\n\
+         }}\n\
+         \n\
+         type Outer {{\n\
+         \x20   mid: Mid,\n\
+         \x20   c: string,\n\
+         }}\n\
+         \n\
+         fn make_outer(k: i64) -> Outer {{\n\
+         \x20   Outer {{\n\
+         \x20       mid: Mid {{\n\
+         \x20           leaf: Leaf {{\n\
+         \x20               s: \"esc-s-heap-payload\".to_upper(),\n\
+         \x20               t: \"esc-t-heap-payload\".to_upper(),\n\
+         \x20           }},\n\
+         \x20           x: \"esc-x-heap-payload\".to_upper(),\n\
+         \x20       }},\n\
+         \x20       c: \"esc-c-heap-payload\".to_upper(),\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn deep(k: i64) -> Leaf {{\n\
+         \x20   let o = make_outer(k);\n\
+         \x20   let mid = o.mid;\n\
+         \x20   let leaf = mid.leaf;\n\
+         \x20   leaf\n\
+         }}\n\
+         \n\
+         fn run_cycle(k: i64) -> i64 {{\n\
+         \x20   let l = deep(k);\n\
+         \x20   l.s.len()\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + run_cycle(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// Escaped-deep-alias control (store into an owning record): the deep alias is
+/// stored into a fresh owning record (`Holder {{ held: leaf }}`) the caller
+/// keeps and reads. Same double-free boundary as the returned variant — the
+/// owner must not free the aliased subtree the escapee now shares.
+fn escaped_into_record_source(frames: usize) -> String {
+    format!(
+        "type Leaf {{\n\
+         \x20   s: string,\n\
+         \x20   t: string,\n\
+         }}\n\
+         \n\
+         type Mid {{\n\
+         \x20   leaf: Leaf,\n\
+         \x20   x: string,\n\
+         }}\n\
+         \n\
+         type Outer {{\n\
+         \x20   mid: Mid,\n\
+         \x20   c: string,\n\
+         }}\n\
+         \n\
+         type Holder {{\n\
+         \x20   held: Leaf,\n\
+         }}\n\
+         \n\
+         fn make_outer(k: i64) -> Outer {{\n\
+         \x20   Outer {{\n\
+         \x20       mid: Mid {{\n\
+         \x20           leaf: Leaf {{\n\
+         \x20               s: \"esc-s-heap-payload\".to_upper(),\n\
+         \x20               t: \"esc-t-heap-payload\".to_upper(),\n\
+         \x20           }},\n\
+         \x20           x: \"esc-x-heap-payload\".to_upper(),\n\
+         \x20       }},\n\
+         \x20       c: \"esc-c-heap-payload\".to_upper(),\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn deep(k: i64) -> Holder {{\n\
+         \x20   let o = make_outer(k);\n\
+         \x20   let mid = o.mid;\n\
+         \x20   let leaf = mid.leaf;\n\
+         \x20   Holder {{ held: leaf }}\n\
+         }}\n\
+         \n\
+         fn run_cycle(k: i64) -> i64 {{\n\
+         \x20   let h = deep(k);\n\
+         \x20   h.held.s.len()\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + run_cycle(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// Escaped-deep-alias control (TUPLE twin): the deep tuple alias is returned to
+/// the caller, which reads it. The tuple prover's twin of the returned-record
+/// double-free boundary.
+fn escaped_return_tuple_source(frames: usize) -> String {
+    format!(
+        "fn make_nested(k: i64) -> (((string, string), string), string) {{\n\
+         \x20   let a = \"esc-a-heap-payload\".to_upper();\n\
+         \x20   let b = \"esc-b-heap-payload\".to_upper();\n\
+         \x20   let c = \"esc-c-heap-payload\".to_upper();\n\
+         \x20   let d = \"esc-d-heap-payload\".to_upper();\n\
+         \x20   ((( a, b ), c ), d)\n\
+         }}\n\
+         \n\
+         fn deep(k: i64) -> (string, string) {{\n\
+         \x20   let o = make_nested(k);\n\
+         \x20   let mid = o.0;\n\
+         \x20   let leaf = mid.0;\n\
+         \x20   leaf\n\
+         }}\n\
+         \n\
+         fn run_cycle(k: i64) -> i64 {{\n\
+         \x20   let l = deep(k);\n\
+         \x20   l.0.len()\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + run_cycle(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+// ── slope oracles (leak half) ───────────────────────────────────────────
+
+/// Two-level record chain holds a flat slope — the outer composite frees the
+/// whole tree; the intermediate aliases free nothing (#2375).
+#[test]
+fn two_level_record_chain_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("chain_record", two_level_record_chain_source);
+}
+
+/// Double-skip destructure holds a flat slope — nothing bound out, the outer
+/// composite owns the whole tree.
+#[test]
+fn two_level_double_skip_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("chain_double_skip", two_level_double_skip_source);
+}
+
+/// Two-level tuple chain holds a flat slope — the tuple prover's twin of the
+/// record path.
+#[test]
+fn two_level_tuple_chain_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("chain_tuple", two_level_tuple_chain_source);
+}
+
+/// Bystander standalone record is freed exactly once alongside the admitted
+/// chain root — flat slope.
+#[test]
+fn bystander_root_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("chain_bystander", bystander_root_source);
+}
+
+// ── scribble (double-free / use-after-free) pins ────────────────────────
+
+fn assert_scribble_clean(name: &str, source: &str) {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("chain-scribble-{name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), name);
+    let output = run_under_malloc_scribble(&bin);
+
+    assert!(
+        output.status.success(),
+        "{name} must run clean under the poisoned allocator — an abort/crash \
+         here means a projection alias re-freed storage the owner's composite \
+         drop already released (double-free through the projection \
+         alias);\n{}",
+        describe_output(&output)
+    );
+}
+
+/// Two-level record chain: no composite re-walk of the aliased tree.
+#[test]
+fn two_level_record_chain_no_double_free_under_malloc_scribble() {
+    assert_scribble_clean("chain_record", &two_level_record_chain_source(6));
+}
+
+/// Two-level tuple chain: no re-walk of the aliased tuple tree.
+#[test]
+fn two_level_tuple_chain_no_double_free_under_malloc_scribble() {
+    assert_scribble_clean("chain_tuple", &two_level_tuple_chain_source(6));
+}
+
+/// Double-skip: the outer composite frees the whole tree once, no re-walk.
+#[test]
+fn two_level_double_skip_no_double_free_under_malloc_scribble() {
+    assert_scribble_clean("chain_double_skip", &two_level_double_skip_source(6));
+}
+
+/// `HandleTransfer` control: the transferred `Generator` handle is released
+/// exactly once (by the for-loop consume); the record's whole-root exclusion
+/// keeps its composite from re-freeing the moved handle.
+#[test]
+fn handle_transfer_control_no_double_free_under_malloc_scribble() {
+    assert_scribble_clean("chain_handle_transfer", &handle_transfer_control_source(6));
+}
+
+/// Owner-consumed control: the alias emits no drop; the consumer frees the
+/// tree, and nothing re-frees it.
+#[test]
+fn owner_consumed_control_no_double_free_under_malloc_scribble() {
+    assert_scribble_clean("chain_owner_consumed", &owner_consumed_control_source(6));
+}
+
+/// Escaped-return record: the deep alias is handed to the caller. The owner's
+/// composite must not free the escapee's still-shared subtree — a re-walk here
+/// is the double-free the projection-alias classification must exclude.
+#[test]
+fn escaped_return_record_no_double_free_under_malloc_scribble() {
+    assert_scribble_clean("chain_escaped_return", &escaped_return_record_source(6));
+}
+
+/// Escaped into an owning record: the deep alias is stored into a fresh record
+/// the caller keeps. Same double-free boundary as the returned variant.
+#[test]
+fn escaped_into_record_no_double_free_under_malloc_scribble() {
+    assert_scribble_clean("chain_escaped_store", &escaped_into_record_source(6));
+}
+
+/// Escaped-return TUPLE twin: the deep tuple alias is handed to the caller —
+/// the tuple prover's twin of the returned-record double-free boundary.
+#[test]
+fn escaped_return_tuple_no_double_free_under_malloc_scribble() {
+    assert_scribble_clean("chain_escaped_tuple", &escaped_return_tuple_source(6));
+}
+
+// ── MIR emission pins ────────────────────────────────────────────────────
+
+fn elab_dump(source: &str, prefix: &str) -> String {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix(prefix)
+        .tempdir()
+        .expect("tempdir");
+    let hew_src = dir.path().join("chain_pin.hew");
+    std::fs::write(&hew_src, source).expect("write hew source");
+
+    let output = Command::new(hew_binary())
+        .args(["compile", "--dump-mir", "elab"])
+        .arg(&hew_src)
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew compile --dump-mir elab");
+    assert!(
+        output.status.success(),
+        "elaborated-MIR dump must succeed:\n{}",
+        describe_output(&output)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// The distinct MIR locals dropped via `record_in_place` in a dump section —
+/// the same composite may appear on several exit edges (return + cancel), so
+/// membership, not line count, is the fact under test.
+fn record_in_place_locals(section: &str) -> std::collections::BTreeSet<String> {
+    section
+        .lines()
+        .filter(|line| line.contains("kind=record_in_place"))
+        .filter_map(|line| {
+            let rest = line.trim_start().strip_prefix("drop ")?;
+            let local = rest.split_whitespace().next()?;
+            Some(local.to_string())
+        })
+        .collect()
+}
+
+/// The two-level chain admits exactly ONE composite in-place drop — the outer
+/// root's — and emits none for the intermediate aliases. Only a single local
+/// (the outer `Outer` root) appears with `record_in_place`; the alias binders
+/// `mid` / `leaf` emit none (though the outer's own drop repeats across exit
+/// edges).
+#[test]
+fn two_level_record_chain_admits_only_the_outer_composite() {
+    let dump = elab_dump(&two_level_record_chain_source(4), "chain-record-mir-");
+    let run_cycle = dump
+        .split("fn ")
+        .find(|section| section.starts_with("run_cycle"))
+        .expect("run_cycle section present in dump");
+    let composites = record_in_place_locals(run_cycle);
+    assert_eq!(
+        composites.len(),
+        1,
+        "exactly the outer root keeps its composite in-place drop; the \
+         intermediate projection aliases emit none; got {composites:?}\n{run_cycle}"
+    );
+}
+
+/// Escaped-return record: when the deep alias escapes into the return, the
+/// owner `o` is EXCLUDED from its composite in-place drop (fail-closed: the
+/// escapee shares the owner's subtree, so the owner must not free it). `deep`
+/// emits zero `record_in_place` drops — neither the aliases (they never own)
+/// nor the owner (its subtree escaped).
+#[test]
+fn escaped_return_record_excludes_the_owner_composite() {
+    let dump = elab_dump(
+        &escaped_return_record_source(4),
+        "chain-escaped-return-mir-",
+    );
+    let deep = dump
+        .split("fn ")
+        .find(|section| section.starts_with("deep"))
+        .expect("deep section present in dump");
+    assert_eq!(
+        deep.matches("kind=record_in_place").count(),
+        0,
+        "the deep alias escapes into the return, so the owner is excluded from \
+         its composite drop (leak-not-double-free); got a composite drop:\n{deep}"
+    );
+}
+
+/// Owner-consumed control: the alias `mid` emits no drop and the consumed
+/// owner `o` emits no scope-exit composite drop in the caller (the consumer
+/// `sink` owns it) — so `run_cycle` emits zero `record_in_place` drops.
+#[test]
+fn owner_consumed_control_emits_no_alias_or_owner_drop() {
+    let dump = elab_dump(
+        &owner_consumed_control_source(4),
+        "chain-owner-consumed-mir-",
+    );
+    let run_cycle = dump
+        .split("fn ")
+        .find(|section| section.starts_with("run_cycle"))
+        .expect("run_cycle section present in dump");
+    assert_eq!(
+        run_cycle.matches("kind=record_in_place").count(),
+        0,
+        "the alias emits no drop and the consumed owner is freed by the \
+         callee, so the caller emits no composite drop;\n{run_cycle}"
+    );
+}

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -18292,17 +18292,19 @@ fn lower_record_field_drop(
              for COW-heap scalar fields (LESSONS: boundary-fail-closed)"
         )));
     };
-    // Validate symbol/type congruence before emitting any call. If the MIR
-    // emitter drifted from the codegen table, fail loudly rather than silently
-    // calling an unrelated release function (LESSONS: boundary-fail-closed,
-    // dedup-semantic-boundary).
-    if cow_heap_release_symbol(fn_ctx, ty) != Some(symbol) {
+    // Fail closed on an unknown release symbol before emitting any call: a
+    // `RecordFieldDrop` carries its `Release` symbol as a MIR literal, so a
+    // symbol outside the closed copy-on-write release set is producer drift
+    // and must not reach a call to an unvalidated runtime entry
+    // (LESSONS: boundary-fail-closed). The per-type congruence re-derivation
+    // is retired with the Row-C dual-derivation seam — codegen no longer keeps
+    // its own `(type, symbol)` table to double-check the MIR pick against.
+    if !is_known_cow_heap_drop_symbol(symbol) {
         return Err(CodegenError::FailClosed(format!(
-            "RecordFieldDrop @ field[{idx}]: drop_fn=Release({symbol:?}) is \
-             incongruent with field type {ty:?} (expected release symbol \
-             {expected:?}); refusing to emit (LESSONS: boundary-fail-closed)",
+            "RecordFieldDrop @ field[{idx}] (type {ty:?}): drop_fn=Release({symbol:?}) \
+             is not a known copy-on-write release symbol; refusing to emit \
+             (LESSONS: boundary-fail-closed)",
             idx = field_offset.0,
-            expected = cow_heap_release_symbol(fn_ctx, ty),
         )));
     }
     let (record_ptr, record_slot_ty) = place_pointer(fn_ctx, record)?;
@@ -25300,7 +25302,7 @@ fn lower_inline_drop(
     // { ptr, i32, i32 }`, NOT a single owned pointer. The data buffer's sole
     // release is `hew_bytes_drop(data_ptr)` (`hew-runtime/src/bytes.rs`'s
     // refcount-decrement-and-free-at-zero entry), where `data_ptr` is the
-    // FIRST field of the triple. The generic `cow_heap_release_symbol` path
+    // FIRST field of the triple. The generic `resolved_ty_cow_heap_release` path
     // (single-`ptr`-load → call) does not fit this shape, so Bytes is
     // deliberately absent from that table; intercept here BEFORE the cow_heap
     // congruence check and route to the triple-field-0 emitter.
@@ -25327,16 +25329,19 @@ fn lower_inline_drop(
         return emit_bytes_inplace_drop(fn_ctx, place);
     }
     if let hew_mir::DropFnSpec::Release(symbol) = drop_fn {
-        // A release ritual is only ever congruent with its own type's cow
-        // release symbol; anything else would free through the wrong ABI.
-        if cow_heap_release_symbol(fn_ctx, ty) == Some(symbol) {
+        // A `Release` ritual carries its symbol as a MIR literal; fail closed on
+        // one outside the closed copy-on-write release set rather than free
+        // through an unvalidated runtime entry (LESSONS: boundary-fail-closed).
+        // The per-type congruence re-derivation is retired with the Row-C
+        // dual-derivation seam — codegen no longer keeps its own `(type,
+        // symbol)` table to re-check the MIR pick against.
+        if is_known_cow_heap_drop_symbol(symbol) {
             return emit_cow_heap_drop(fn_ctx, place, symbol);
         }
         return Err(CodegenError::FailClosed(format!(
-            "inline Instr::Drop @ {place:?} carries release ritual {symbol:?} \
-             incongruent with its type {ty:?} (whose release symbol is {expected:?}); \
-             refusing to route a heap-owning value through the generic drop dispatcher",
-            expected = cow_heap_release_symbol(fn_ctx, ty),
+            "inline Instr::Drop @ {place:?} carries release ritual {symbol:?} that is \
+             not a known copy-on-write release symbol; refusing to route a heap-owning \
+             value through the generic drop dispatcher (LESSONS: boundary-fail-closed)",
         )));
     }
     lower_drop(fn_ctx, place, drop_fn)
@@ -26339,9 +26344,9 @@ fn emit_one_elab_drop_unguarded(fn_ctx: &FnCtx<'_, '_>, drop: &ElabDrop) -> Code
         // their release symbol (or recursion intent) in `kind`, not in
         // `drop_fn`, so they bypass the W3.030 runtime-vs-user
         // `resolve_drop_fn` dispatch entirely.
-        hew_mir::DropKind::CowHeap { drop_fn } => {
+        hew_mir::DropKind::CowHeap { release } => {
             // Fail-closed (release-mode, not debug_assert): a CowHeap drop
-            // MUST carry its release symbol in the kind. A populated
+            // MUST carry its release protocol in the kind. A populated
             // ElabDrop::drop_fn signals a producer that mixed the W3.030
             // close-symbol path with the W5.011 kind-carried path; refuse
             // rather than silently ignore it.
@@ -26349,71 +26354,29 @@ fn emit_one_elab_drop_unguarded(fn_ctx: &FnCtx<'_, '_>, drop: &ElabDrop) -> Code
                 return Err(CodegenError::FailClosed(format!(
                     "CowHeap ElabDrop @ {place:?} unexpectedly carries \
                      ElabDrop::drop_fn = {df:?}; a CowHeap drop MUST carry its \
-                     release symbol in the kind, not in drop_fn — refusing to emit \
+                     release protocol in the kind, not in drop_fn — refusing to emit \
                      (LESSONS: boundary-fail-closed).",
                     place = drop.place,
                     df = drop.drop_fn,
                 )));
             }
+            // The release protocol is a typed `CowHeapRelease`, so the C-ABI
+            // symbol is resolved from the carried fact — never re-derived from
+            // `drop.ty` and cross-checked (the dual-derivation congruence the
+            // literal `drop_fn` carrier required is gone with the literal). An
+            // unknown or type-incongruent release symbol is unrepresentable.
+            //
             // Bytes ABI intercept: a native `bytes` value is a stack-resident
             // `BytesTriple { ptr, i32, i32 }`, NOT a single owned pointer, so
-            // it does not fit the single-`ptr`-load shape the generic CowHeap
-            // path (and its `cow_heap_release_symbol` congruence table)
-            // describes. Route it through the triple-field-0 emitter — the
-            // SAME `emit_bytes_inplace_drop` the inline `Instr::Drop` bytes
-            // path uses (`lower_inline_drop`), so scope-exit and inline bytes
-            // drops cannot drift on which field of the triple owns the heap
-            // allocation. The MIR-side symbol authority is `drop_kind_for`'s
-            // Bytes arm; any other symbol on a Bytes drop is producer drift —
-            // refuse (LESSONS: boundary-fail-closed, dedup-semantic-boundary,
-            // lifecycle-symmetry).
-            if matches!(drop.ty, ResolvedTy::Bytes) {
-                if drop_fn != "hew_bytes_drop" {
-                    return Err(CodegenError::FailClosed(format!(
-                        "CowHeap ElabDrop @ {place:?} on type Bytes carries release \
-                         symbol {drop_fn:?}; the only admissible Bytes release is \
-                         `hew_bytes_drop` (the `drop_kind_for` Bytes-arm authority — \
-                         `hew-mir/src/lower.rs`). Refusing to route a BytesTriple \
-                         through the generic single-ptr-load CowHeap path \
-                         (LESSONS: boundary-fail-closed).",
-                        place = drop.place,
-                    )));
-                }
+            // it does not fit the single-`ptr`-load shape. Route it through the
+            // triple-field-0 emitter — the SAME `emit_bytes_inplace_drop` the
+            // inline `Instr::Drop` bytes path uses (`lower_inline_drop`), so
+            // scope-exit and inline bytes drops cannot drift on which field of
+            // the triple owns the heap allocation.
+            if matches!(release, hew_mir::CowHeapRelease::Bytes) {
                 return emit_bytes_inplace_drop(fn_ctx, drop.place);
             }
-            // Validate the kind-carried symbol against the closed release
-            // table before emitting any call (Fix #2.3).
-            if !is_known_cow_heap_drop_symbol(drop_fn) {
-                return Err(CodegenError::FailClosed(format!(
-                    "CowHeap ElabDrop @ {place:?} carries unknown release symbol \
-                     {drop_fn:?}; only the closed set {{hew_string_drop, hew_vec_free, \
-                     hew_hashmap_free_layout, hew_hashset_free_layout}} is permitted — \
-                     refusing to emit a call to an unvalidated runtime entry \
-                     (LESSONS: boundary-fail-closed).",
-                    place = drop.place,
-                )));
-            }
-            // Membership alone is insufficient: a symbol in the closed set
-            // that does NOT match `drop.ty`'s own release symbol would emit a
-            // wrong-ABI free (e.g. `hew_vec_free` on a `string` handle frees
-            // a non-Vec layout). Require congruence with the type-directed
-            // `(type, symbol)` table — the same table `cow_value_leaf_drop_symbol`
-            // / the `AggregateRecursive` walk use — so the kind-carried symbol
-            // and the leaf type can never silently diverge (LESSONS:
-            // boundary-fail-closed, lifecycle-symmetry).
-            if cow_heap_release_symbol(fn_ctx, &drop.ty) != Some(drop_fn) {
-                return Err(CodegenError::FailClosed(format!(
-                    "CowHeap ElabDrop @ {place:?} carries release symbol {drop_fn:?} \
-                     incongruent with its leaf type {ty:?} (whose release symbol is \
-                     {expected:?}); emitting this call would free a {ty:?} handle through \
-                     the wrong-ABI release entry — refusing \
-                     (LESSONS: boundary-fail-closed, lifecycle-symmetry).",
-                    place = drop.place,
-                    ty = drop.ty,
-                    expected = cow_heap_release_symbol(fn_ctx, &drop.ty),
-                )));
-            }
-            emit_cow_heap_drop(fn_ctx, drop.place, drop_fn)
+            emit_cow_heap_drop(fn_ctx, drop.place, release.release_symbol())
         }
         hew_mir::DropKind::AggregateRecursive => {
             if drop.drop_fn.is_some() {
@@ -26871,7 +26834,7 @@ pub(crate) fn resolved_ty_element_owns_heap_for_owned_vec(
         // Nested collection elements (Vec<E> / HashMap / HashSet) are owned
         // heap handles — route the outer Vec through the W5.016 owned descriptor
         // ABI (#1722). A closure-pair Vec<fn>/Vec<closure> keeps its
-        // pointer/closure-pairs release (`cow_heap_release_symbol` checks
+        // pointer/closure-pairs release (`resolved_ty_cow_heap_release` checks
         // fn/closure FIRST); exclude it here so the constructor never builds an
         // owned descriptor for a closure-pair element (which has no managed
         // clone primitive — `collection_elem_clone_drop_syms` returns None).
@@ -26968,9 +26931,24 @@ fn resolved_ty_contains_heap_leaf(
     hew_mir::ty_owns_heap(ty, &CgHeapLayouts { fn_ctx })
 }
 
-fn cow_heap_release_symbol(fn_ctx: &FnCtx<'_, '_>, ty: &ResolvedTy) -> Option<&'static str> {
+/// Resolve a `ResolvedTy` to its typed [`hew_mir::CowHeapRelease`] protocol, or
+/// `None` when the type is not a single copy-on-write heap leaf. This is the
+/// address-based aggregate walk's per-field picker (`emit_heap_slot_drop`), the
+/// one place codegen still classifies a bare type to a release — nested
+/// aggregate fields carry no MIR fact of their own. It reads the SINGLE symbol
+/// authority (`CowHeapRelease::release_symbol`, built on
+/// `HeapLeaf::release_symbol`) rather than a codegen-local string table, so MIR
+/// and codegen agree per shape by construction (`dedup-semantic-boundary`).
+///
+/// `Bytes` is deliberately absent — a `BytesTriple` is not a single-`ptr` load,
+/// so `emit_heap_slot_drop` intercepts it before consulting this picker.
+fn resolved_ty_cow_heap_release(
+    fn_ctx: &FnCtx<'_, '_>,
+    ty: &ResolvedTy,
+) -> Option<hew_mir::CowHeapRelease> {
+    use hew_mir::CowHeapRelease;
     match ty {
-        ResolvedTy::String => Some("hew_string_drop"),
+        ResolvedTy::String => Some(CowHeapRelease::String),
         // Dispatch on the compiler-known `builtin` discriminant, NOT the
         // `name` string: a user-defined `type Vec { ... }` resolves to
         // `Named { name: "Vec", builtin: None }` and must NOT be routed to
@@ -26995,24 +26973,24 @@ fn cow_heap_release_symbol(fn_ctx: &FnCtx<'_, '_>, ty: &ResolvedTy) -> Option<&'
             if args.first().is_some_and(|e| {
                 matches!(e, ResolvedTy::Function { .. } | ResolvedTy::Closure { .. })
             }) {
-                Some("hew_vec_free_closure_pairs")
+                Some(CowHeapRelease::VecClosurePairs)
             } else if args
                 .first()
                 .is_some_and(|e| resolved_ty_element_owns_heap_for_owned_vec(fn_ctx, e))
             {
-                Some("hew_vec_free_owned")
+                Some(CowHeapRelease::VecOwnedElement)
             } else {
-                Some("hew_vec_free")
+                Some(CowHeapRelease::VecPlain)
             }
         }
         ResolvedTy::Named {
             builtin: Some(hew_types::BuiltinType::HashMap),
             ..
-        } => Some(HASHMAP_FREE_LAYOUT_SYMBOL),
+        } => Some(CowHeapRelease::HashMap),
         ResolvedTy::Named {
             builtin: Some(hew_types::BuiltinType::HashSet),
             ..
-        } => Some(HASHSET_FREE_LAYOUT_SYMBOL),
+        } => Some(CowHeapRelease::HashSet),
         // A `Generator<Y, R>` / `AsyncGenerator<Y>` value releases via
         // `hew_gen_coro_destroy`: the value is the heap companion
         // `{ ptr handle, ptr env, ptr out_drop_thunk, i8 started, i8 pending,
@@ -27027,7 +27005,7 @@ fn cow_heap_release_symbol(fn_ctx: &FnCtx<'_, '_>, ty: &ResolvedTy) -> Option<&'
             builtin:
                 Some(hew_types::BuiltinType::Generator | hew_types::BuiltinType::AsyncGenerator),
             ..
-        } => Some("hew_gen_coro_destroy"),
+        } => Some(CowHeapRelease::Generator),
         _ => None,
     }
 }
@@ -27336,7 +27314,8 @@ fn emit_heap_slot_drop<'ctx>(
     if matches!(ty, ResolvedTy::Bytes) {
         return emit_bytes_slot_drop(fn_ctx, slot_ptr, label);
     }
-    if let Some(symbol) = cow_heap_release_symbol(fn_ctx, ty) {
+    if let Some(release) = resolved_ty_cow_heap_release(fn_ctx, ty) {
+        let symbol = release.release_symbol();
         let ptr_ty = fn_ctx.ctx.ptr_type(AddressSpace::default());
         let handle = fn_ctx
             .builder
@@ -48286,7 +48265,7 @@ mod tests {
         fn_ctx.builder.build_return(Some(&zero)).expect("ret 0");
     }
 
-    /// W5.011 Slice 1: a `DropKind::CowHeap { drop_fn: "hew_string_drop" }`
+    /// W5.011 Slice 1: a `DropKind::CowHeap { release: String }`
     /// ElabDrop on a `string` local must emit a single-`ptr`-arg call to
     /// `hew_string_drop` and null-store the slot afterwards
     /// (`raii-null-after-move`).
@@ -48303,7 +48282,7 @@ mod tests {
             ty: ResolvedTy::String,
             drop_fn: None,
             kind: DropKind::CowHeap {
-                drop_fn: "hew_string_drop",
+                release: hew_mir::CowHeapRelease::String,
             },
             guard: None,
         };
@@ -48347,7 +48326,7 @@ mod tests {
             ty: ResolvedTy::String,
             drop_fn: None,
             kind: DropKind::CowHeap {
-                drop_fn: "hew_string_drop",
+                release: hew_mir::CowHeapRelease::String,
             },
             guard: Some(Place::Local(1)),
         };
@@ -48398,7 +48377,7 @@ mod tests {
             ty: ResolvedTy::String,
             drop_fn: None,
             kind: DropKind::CowHeap {
-                drop_fn: "hew_string_drop",
+                release: hew_mir::CowHeapRelease::String,
             },
             guard: None,
         };
@@ -48420,7 +48399,7 @@ mod tests {
         );
     }
 
-    /// A `DropKind::CowHeap { drop_fn: "hew_bytes_drop" }` ElabDrop on a
+    /// A `DropKind::CowHeap { release: Bytes }` ElabDrop on a
     /// `bytes` local must route through the BytesTriple-aware emitter
     /// (`emit_bytes_inplace_drop`): GEP field 0, load the data pointer, call
     /// `hew_bytes_drop(data_ptr)`, null-store the field — NOT the generic
@@ -48439,7 +48418,7 @@ mod tests {
             ty: ResolvedTy::Bytes,
             drop_fn: None,
             kind: DropKind::CowHeap {
-                drop_fn: "hew_bytes_drop",
+                release: hew_mir::CowHeapRelease::Bytes,
             },
             guard: None,
         };
@@ -48468,44 +48447,13 @@ mod tests {
         );
     }
 
-    /// A `DropKind::CowHeap` on a `bytes` local carrying any symbol other
-    /// than `hew_bytes_drop` is producer drift and must fail closed before
-    /// emitting any call (a wrong-ABI free of the triple's buffer).
-    #[test]
-    fn cow_heap_bytes_drop_wrong_symbol_fails_closed() {
-        use hew_mir::{DropKind, ElabDrop};
-        let ctx = Context::create();
-        let m = ctx.create_module("cow_heap_bytes_wrong_sym_test");
-        let harness = build_harness(&ctx, &[], &[]);
-        let mut fn_ctx = make_test_fn_ctx(&ctx, &m, &harness, "drv");
-        alloc_local(&mut fn_ctx, 0, ResolvedTy::Bytes);
-        let drop = ElabDrop {
-            place: Place::Local(0),
-            ty: ResolvedTy::Bytes,
-            drop_fn: None,
-            kind: DropKind::CowHeap {
-                // In the closed set, but the wrong release for Bytes.
-                drop_fn: "hew_string_drop",
-            },
-            guard: None,
-        };
-        let err = emit_one_elab_drop(&fn_ctx, &drop)
-            .expect_err("non-hew_bytes_drop symbol on a Bytes drop must fail closed");
-        match err {
-            CodegenError::FailClosed(msg) => assert!(
-                msg.contains("Bytes"),
-                "diagnostic must name the Bytes intercept; got: {msg}"
-            ),
-            other => panic!("expected FailClosed, got {other:?}"),
-        }
-        let ir = m.print_to_string().to_string();
-        assert!(
-            !ir.contains("call void @hew_string_drop("),
-            "no call must be emitted for a rejected Bytes symbol; got:\n{ir}"
-        );
-    }
+    // (Removed `cow_heap_bytes_drop_wrong_symbol_fails_closed`: a wrong release
+    // symbol on a Bytes drop is now unrepresentable. `DropKind::CowHeap` carries
+    // a typed `CowHeapRelease`, and the Bytes-triple emitter is selected by
+    // `CowHeapRelease::Bytes` — the type system enforces what the runtime
+    // congruence check used to.)
 
-    /// W5.011 Slice 1: a `DropKind::CowHeap { drop_fn: "hew_vec_free" }`
+    /// W5.011 Slice 1: a `DropKind::CowHeap { release: VecPlain }`
     /// ElabDrop on a `Vec<string>` local must emit the `hew_vec_free`
     /// release call (the designated local-Vec free symbol).
     #[test]
@@ -48520,8 +48468,7 @@ mod tests {
             args: vec![ResolvedTy::String],
             // Canonical compiler-produced Vec: the `builtin` discriminant is
             // what routes to `hew_vec_free` (a user `type Vec` with
-            // `builtin: None` must NOT — see `cow_heap_release_symbol`). The
-            // congruence guard in `emit_one_elab_drop` now enforces this.
+            // `builtin: None` must NOT — see `resolved_ty_cow_heap_release`).
             builtin: Some(hew_types::BuiltinType::Vec),
             is_opaque: false,
         };
@@ -48531,7 +48478,7 @@ mod tests {
             ty: vec_ty,
             drop_fn: None,
             kind: DropKind::CowHeap {
-                drop_fn: "hew_vec_free",
+                release: hew_mir::CowHeapRelease::VecPlain,
             },
             guard: None,
         };
@@ -48622,84 +48569,15 @@ mod tests {
         finish_test_fn(&fn_ctx);
     }
 
-    /// W5.011 P3 (Fix #2.3): a `DropKind::CowHeap` carrying a release symbol
-    /// outside the closed table must fail closed BEFORE emitting any call —
-    /// codegen never calls an unvalidated runtime entry against a loaded
-    /// handle (`boundary-fail-closed`).
-    #[test]
-    fn cow_heap_drop_unknown_symbol_fails_closed() {
-        use hew_mir::{DropKind, ElabDrop};
-        let ctx = Context::create();
-        let m = ctx.create_module("cow_heap_unknown_sym_test");
-        let harness = build_harness(&ctx, &[], &[]);
-        let mut fn_ctx = make_test_fn_ctx(&ctx, &m, &harness, "drv");
-        alloc_local(&mut fn_ctx, 0, ResolvedTy::String);
-        let drop = ElabDrop {
-            place: Place::Local(0),
-            ty: ResolvedTy::String,
-            drop_fn: None,
-            kind: DropKind::CowHeap {
-                drop_fn: "free", // not in the closed release table
-            },
-            guard: None,
-        };
-        let err = emit_one_elab_drop(&fn_ctx, &drop)
-            .expect_err("unknown CowHeap release symbol must fail closed");
-        match err {
-            CodegenError::FailClosed(msg) => assert!(
-                msg.contains("unknown release symbol"),
-                "diagnostic must name the unknown symbol; got: {msg}"
-            ),
-            other => panic!("expected FailClosed, got {other:?}"),
-        }
-        let ir = m.print_to_string().to_string();
-        assert!(
-            !ir.contains("call void @free("),
-            "no call must be emitted for a rejected symbol; got:\n{ir}"
-        );
-    }
-
-    /// W5.011 P3 (round-3 Fix #2): a `DropKind::CowHeap` carrying a symbol
-    /// that IS in the closed release table but is INCONGRUENT with the
-    /// drop's leaf `ty` (e.g. `hew_vec_free` on a `string` handle) must fail
-    /// closed. Membership alone would let a malformed producer free a
-    /// `string` through the Vec-layout release entry (wrong-ABI free);
-    /// requiring `cow_heap_release_symbol(&ty) == Some(symbol)` keeps the
-    /// kind-carried symbol and the leaf type from silently diverging
-    /// (`boundary-fail-closed`, `lifecycle-symmetry`).
-    #[test]
-    fn cow_heap_drop_symbol_incongruent_with_type_fails_closed() {
-        use hew_mir::{DropKind, ElabDrop};
-        let ctx = Context::create();
-        let m = ctx.create_module("cow_heap_incongruent_test");
-        let harness = build_harness(&ctx, &[], &[]);
-        let mut fn_ctx = make_test_fn_ctx(&ctx, &m, &harness, "drv");
-        alloc_local(&mut fn_ctx, 0, ResolvedTy::String);
-        let drop = ElabDrop {
-            place: Place::Local(0),
-            ty: ResolvedTy::String,
-            drop_fn: None,
-            kind: DropKind::CowHeap {
-                // In the closed set, but the wrong release for `String`.
-                drop_fn: "hew_vec_free",
-            },
-            guard: None,
-        };
-        let err = emit_one_elab_drop(&fn_ctx, &drop)
-            .expect_err("type-incongruent CowHeap release symbol must fail closed");
-        match err {
-            CodegenError::FailClosed(msg) => assert!(
-                msg.contains("incongruent"),
-                "diagnostic must name the type/symbol incongruence; got: {msg}"
-            ),
-            other => panic!("expected FailClosed, got {other:?}"),
-        }
-        let ir = m.print_to_string().to_string();
-        assert!(
-            !ir.contains("call void @hew_vec_free("),
-            "no wrong-ABI free must be emitted for an incongruent symbol; got:\n{ir}"
-        );
-    }
+    // (Removed `cow_heap_drop_unknown_symbol_fails_closed` and
+    // `cow_heap_drop_symbol_incongruent_with_type_fails_closed`: both tested
+    // producer drift on the pre-consolidation literal `drop_fn` carrier — an
+    // unknown symbol, and a known-but-type-incongruent symbol. With the typed
+    // `CowHeapRelease` carrier neither is constructible (there is no symbol to
+    // fabricate and no `(leaf, refinement)` pair the type system does not
+    // enforce), so the ElabDrop arm resolves the symbol from the carried fact
+    // with no re-derivation or congruence check. The type system now provides
+    // the guarantee these runtime checks used to.)
 
     /// W5.011 P3 (Fix #2.4): a `DropKind::CowHeap` whose `ElabDrop::drop_fn`
     /// is also populated mixes the W3.030 close-symbol path with the
@@ -48718,7 +48596,7 @@ mod tests {
             ty: ResolvedTy::String,
             drop_fn: Some(hew_mir::DropFnSpec::Release("hew_string_drop")),
             kind: DropKind::CowHeap {
-                drop_fn: "hew_string_drop",
+                release: hew_mir::CowHeapRelease::String,
             },
             guard: None,
         };
@@ -48726,7 +48604,7 @@ mod tests {
             .expect_err("CowHeap with populated drop_fn must fail closed");
         match err {
             CodegenError::FailClosed(msg) => assert!(
-                msg.contains("MUST carry its release symbol in the kind"),
+                msg.contains("MUST carry its release protocol in the kind"),
                 "diagnostic must explain the kind-vs-drop_fn rule; got: {msg}"
             ),
             other => panic!("expected FailClosed, got {other:?}"),
@@ -48787,16 +48665,20 @@ mod tests {
         finish_test_fn(&fn_ctx);
     }
 
-    /// W5.011 P3 (Fix #2.2): `cow_heap_release_symbol` dispatches on the
+    /// W5.011 P3 (Fix #2.2): `resolved_ty_cow_heap_release` dispatches on the
     /// `builtin` discriminant, NOT the `name` string. A user-defined type
     /// named "Vec" with `builtin: None` must NOT be routed to `hew_vec_free`
-    /// (which would free a non-Vec layout).
+    /// (which would free a non-Vec layout). The resolved release's symbol reads
+    /// the single `CowHeapRelease::release_symbol` authority.
     #[test]
-    fn cow_heap_release_symbol_ignores_user_named_collision() {
+    fn resolved_ty_cow_heap_release_ignores_user_named_collision() {
         let ctx = Context::create();
         let llvm_mod = ctx.create_module("cow_heap_release_test");
         let harness = build_harness(&ctx, &[], &[]);
         let fn_ctx = make_test_fn_ctx(&ctx, &llvm_mod, &harness, "cow_heap_release_probe");
+
+        let sym =
+            |ty: &ResolvedTy| resolved_ty_cow_heap_release(&fn_ctx, ty).map(|r| r.release_symbol());
 
         // User type literally named "Vec" but not the builtin.
         let user_vec = ResolvedTy::Named {
@@ -48806,7 +48688,7 @@ mod tests {
             is_opaque: false,
         };
         assert_eq!(
-            cow_heap_release_symbol(&fn_ctx, &user_vec),
+            sym(&user_vec),
             None,
             "a user `Named {{ name: \"Vec\", builtin: None }}` must not resolve to hew_vec_free"
         );
@@ -48819,9 +48701,10 @@ mod tests {
             is_opaque: false,
         };
         assert_eq!(
-            cow_heap_release_symbol(&fn_ctx, &builtin_vec),
-            Some("hew_vec_free")
+            resolved_ty_cow_heap_release(&fn_ctx, &builtin_vec),
+            Some(hew_mir::CowHeapRelease::VecPlain)
         );
+        assert_eq!(sym(&builtin_vec), Some("hew_vec_free"));
         // W5.016: a Vec of an owned tuple releases via the owned ABI.
         let owned_vec = ResolvedTy::Named {
             name: "Vec".to_string(),
@@ -48833,9 +48716,10 @@ mod tests {
             is_opaque: false,
         };
         assert_eq!(
-            cow_heap_release_symbol(&fn_ctx, &owned_vec),
-            Some("hew_vec_free_owned")
+            resolved_ty_cow_heap_release(&fn_ctx, &owned_vec),
+            Some(hew_mir::CowHeapRelease::VecOwnedElement)
         );
+        assert_eq!(sym(&owned_vec), Some("hew_vec_free_owned"));
     }
 
     /// A `Vec` whose element is a `fn` / closure releases via
@@ -48843,12 +48727,11 @@ mod tests {
     /// checked BEFORE the owned-element and plain arms. This must match the MIR
     /// authority `project_field_inline_drop_symbol`: when the two disagreed,
     /// the closure-pair Vec routed to a `RecordFieldDrop` whose `drop_fn`
-    /// (`hew_vec_free`) failed the codegen congruence assert
-    /// (`cow_heap_release_symbol` expected `hew_vec_free_closure_pairs`) — a
-    /// fail-closed hard error on a previously-leaking shape. Pin both the
-    /// dispatch and that the symbol is in the permitted closed set.
+    /// (`hew_vec_free`) previously failed a codegen congruence assert that
+    /// expected `hew_vec_free_closure_pairs`. Pin both the dispatch and that the
+    /// symbol is in the permitted closed set.
     #[test]
-    fn cow_heap_release_symbol_routes_closure_pair_vec() {
+    fn resolved_ty_cow_heap_release_routes_closure_pair_vec() {
         let ctx = Context::create();
         let llvm_mod = ctx.create_module("cow_heap_release_closure_pair_test");
         let harness = build_harness(&ctx, &[], &[]);
@@ -48865,8 +48748,8 @@ mod tests {
             is_opaque: false,
         };
         assert_eq!(
-            cow_heap_release_symbol(&fn_ctx, &vec_of_fn),
-            Some("hew_vec_free_closure_pairs"),
+            resolved_ty_cow_heap_release(&fn_ctx, &vec_of_fn),
+            Some(hew_mir::CowHeapRelease::VecClosurePairs),
             "a `Vec<fn>` element must release via the closure-pair ABI"
         );
 
@@ -48882,7 +48765,7 @@ mod tests {
             is_opaque: false,
         };
         assert_eq!(
-            cow_heap_release_symbol(&fn_ctx, &vec_of_closure),
+            resolved_ty_cow_heap_release(&fn_ctx, &vec_of_closure).map(|r| r.release_symbol()),
             Some("hew_vec_free_closure_pairs"),
             "a `Vec<closure>` element must release via the closure-pair ABI"
         );

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -1704,7 +1704,7 @@ fn render_drop_kind(kind: DropKind) -> String {
         DropKind::DuplexHalfClose(dir) => format!("duplex_half_close({})", render_direction(dir)),
         DropKind::LambdaActorRelease => "lambda_actor_release".to_string(),
         DropKind::TraitObject { storage } => format!("trait_object({storage:?})"),
-        DropKind::CowHeap { drop_fn } => format!("cow_heap({drop_fn})"),
+        DropKind::CowHeap { release } => format!("cow_heap({})", release.release_symbol()),
         DropKind::RecordInPlace => "record_in_place".to_string(),
         DropKind::AggregateRecursive => "aggregate_recursive".to_string(),
         DropKind::EnumInPlace => "enum_in_place".to_string(),

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -66,8 +66,8 @@ pub use model::{
     ThirFunction, TraitObjectStorage, TrapKind, WitnessOperand,
 };
 pub use ownership::{
-    AbiClass, DropClass, FailClosedReason, HandleRole, HeapLeaf, LayoutClass, OwnershipCtx,
-    OwnershipDecision, PlaceProvenance, Projection, ProvenanceOrigin, ValueOwnership,
+    AbiClass, CowHeapRelease, DropClass, FailClosedReason, HandleRole, HeapLeaf, LayoutClass,
+    OwnershipCtx, OwnershipDecision, PlaceProvenance, Projection, ProvenanceOrigin, ValueOwnership,
     ValueProvenance,
 };
 pub use runtime_symbols::UnknownRuntimeSymbol;

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -38,7 +38,10 @@ use crate::model::{
     Strategy, SuspendKind, Terminator, ThirFunction, TraitObjectStorage, TrapKind,
 };
 use crate::ownership::FailClosedReason;
+use crate::ownership::OwnershipCtx;
 use crate::ownership::ReleaseSymbolVerdict;
+use crate::ownership::ValueOwnership;
+use crate::ownership::ValueProvenance;
 use crate::ownership::VecElementRelease;
 
 type TaskEntryAdapterSymbols = Rc<RefCell<HashSet<String>>>;
@@ -7831,6 +7834,11 @@ fn lower_function(
         &builder.binding_locals,
         &mut builder.instr_spans,
     );
+    // The scope-exit-live owned-locals view, materialised once for the
+    // escaped-sibling emitter and the double-free gate below — the same
+    // `(binding, name, ty)` tuples they read before the ledger carried richer
+    // facts.
+    let owned_locals_snapshot = builder.owned_locals_snapshot();
     // #2212 — an owned record whose field escapes through a binder loses its
     // composite scope-exit drop (the sole-owner prover excludes it); the
     // record's NON-escaped owned sibling fields still need their release.
@@ -7848,7 +7856,7 @@ fn lower_function(
         apply_escaped_record_sibling_field_drops(
             &mut blocks,
             &builder.suspend_kinds,
-            &builder.owned_locals,
+            &owned_locals_snapshot,
             &builder.binding_locals,
             &builder.locals,
             &builder.record_field_orders,
@@ -8049,12 +8057,12 @@ fn lower_function(
     //     the double-free this gate refuses.
     let returned_aggregate_members = derive_returned_aggregate_member_bindings(
         &raw.blocks,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
     );
     let consumed_local_aggregate_members = derive_consumed_local_aggregate_member_bindings(
         &raw.blocks,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         &builder.locals,
         &builder.record_field_orders,
@@ -8065,7 +8073,7 @@ fn lower_function(
     let tuple_composite_drop_allowed = derive_tuple_composite_drop_allowed(
         &raw.blocks,
         &raw.suspend_kinds,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         &builder.locals,
         &builder.record_field_orders,
@@ -8075,7 +8083,7 @@ fn lower_function(
     let owned_record_drop_allowed = derive_owned_record_drop_allowed(
         &raw.blocks,
         &raw.suspend_kinds,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         &builder.locals,
         &is_owned_record,
@@ -8087,7 +8095,7 @@ fn lower_function(
     for check in detect_unproven_aggregate_handle_double_free(
         &raw.blocks,
         &raw.suspend_kinds,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         &builder.locals,
         &builder.record_field_orders,
@@ -8675,6 +8683,76 @@ struct FungibleChildRef {
     slot_index: u32,
 }
 
+/// How an owned local's release obligation is currently dispositioned within the
+/// per-function ledger. The live drop-elaboration view is exactly the
+/// `ScopeExit` entries — a binding whose release is handled elsewhere (moved
+/// into an aggregate, consumed, closed at an inner scope) is dispositioned off
+/// the scope-exit set rather than physically removed, so an end-of-pass scan can
+/// still see the whole ledger.
+///
+/// This stage records only `ScopeExit`; the retraction-to-disposition migration
+/// that adds the moved/consumed/inner-scope dispositions is a later drop
+/// stage. Every entry the registration authority mints is `ScopeExit`, so the
+/// live-view filter is a no-op here and behaviour is unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Disposition {
+    /// Released by the function-exit LIFO drop pass, narrowed per exit edge —
+    /// the default, and the only disposition this stage records.
+    ScopeExit,
+}
+
+/// One entry in the per-function owned-locals ledger: the binding whose
+/// scope-exit release drop elaboration owns, recorded ONCE at its defining write
+/// through [`Builder::register_owned_local`] (the single registration
+/// authority) instead of pushed ad hoc at each lowering seam.
+///
+/// The tracked unit is the whole binding. The `(binding, name, ty)` triple is
+/// the shape every downstream allow-set prover, `build_lifo_drops`, and the
+/// unwired-`Vec`-element diagnostic already consume (via
+/// [`Builder::owned_locals_snapshot`]); the richer facts (`ownership`,
+/// `provenance`, `disposition`) are carried on the value so later drop stages
+/// read a written-down fact rather than re-deriving ownership from the
+/// instruction stream at each pass.
+#[derive(Debug, Clone)]
+struct OwnedLocalEntry {
+    /// The HIR binding this owned local backs.
+    binding: BindingId,
+    /// Source-level binding name (drop-statement rendering + diagnostics).
+    name: String,
+    /// The binding's (substituted) resolved type — the drop-shape input.
+    ty: ResolvedTy,
+    /// The rich ownership/drop/ABI decision classified once at registration.
+    ///
+    /// Recorded here so ownership is a fact written at the defining write; the
+    /// provenance-aware provers and the type-directed drop-table selection in
+    /// later drop-elaboration stages read it instead of re-classifying the type
+    /// per pass. Not yet consumed at this stage — the drop passes still read the
+    /// `(binding, name, ty)` view.
+    #[allow(
+        dead_code,
+        reason = "written-once ownership fact; consumed by the provenance-aware \
+                  provers and the type-directed drop-table selection in later \
+                  drop-elaboration stages"
+    )]
+    ownership: ValueOwnership,
+    /// Where the value's ownership traces to, when trivially proven at the
+    /// defining write (an interior-alias projection of a still-live owner names
+    /// its root). `None` = the value owns itself / provenance not recorded, which
+    /// is today's semantics for every entry this stage mints.
+    ///
+    /// Not yet consumed at this stage — the interior-alias suppression that reads
+    /// it is a later drop stage.
+    #[allow(
+        dead_code,
+        reason = "carried provenance consumed by the interior-alias drop \
+                  suppression in a later drop-elaboration stage"
+    )]
+    provenance: Option<ValueProvenance>,
+    /// How this entry's release obligation is dispositioned. `ScopeExit` (the
+    /// only value this stage records) means the function-exit LIFO pass owns it.
+    disposition: Disposition,
+}
+
 #[derive(Debug, Default)]
 struct Builder {
     /// Checker-authority stream for the *current* basic block. Drained
@@ -8823,7 +8901,7 @@ struct Builder {
     /// carrier/Terminator field) so the carriers collapse onto one
     /// `Terminator::Suspend` while the emitted IR stays byte-identical.
     suspend_kinds: HashMap<u32, SuspendKind>,
-    owned_locals: Vec<(hew_hir::BindingId, String, ResolvedTy)>,
+    owned_locals: Vec<OwnedLocalEntry>,
     /// Generator/`AsyncGenerator` owned bindings tagged with the HIR scope they
     /// were declared in, recorded so a per-scope-exit `hew_gen_coro_destroy`
     /// fires when that scope closes — INCLUDING when the scope is re-executed
@@ -9584,6 +9662,64 @@ impl Builder {
         }
     }
 
+    /// The ownership classify context over this builder's live registries — the
+    /// same three tables the drop derivations read, bundled so
+    /// [`ValueOwnership::classify`] builds its answer from the one authority.
+    fn ownership_ctx(&self) -> OwnershipCtx<'_> {
+        OwnershipCtx::new(
+            &self.record_field_orders,
+            &self.enum_layouts,
+            &self.type_classes,
+        )
+    }
+
+    /// The single registration authority for the per-function owned-locals
+    /// ledger: every seam that introduces a scope-exit drop obligation routes
+    /// through here instead of pushing a bare tuple. Ownership is classified
+    /// ONCE at this defining write and recorded on the entry; the drop passes
+    /// read the written-down fact rather than re-deriving it per pass.
+    ///
+    /// The binding's backing place drives classify's handle-vs-type dispatch. It
+    /// is resolved from `binding_locals` when the slot is already wired (the
+    /// `let` / param / dyn-trait seams insert it first); a match binder registers
+    /// before its `Place` insert, but a match binder always stores into a plain
+    /// local, so the type-driven arm is the correct one and the exact local id is
+    /// immaterial (the fallback local only feeds the never-firing handle
+    /// dispatch). Provenance stays `None` at this stage — it is recorded only
+    /// where a later stage can trivially prove it at the defining write. Every
+    /// entry is `Disposition::ScopeExit`.
+    fn register_owned_local(&mut self, binding: BindingId, name: String, ty: ResolvedTy) {
+        let place = self
+            .binding_locals
+            .get(&binding)
+            .copied()
+            .unwrap_or(Place::Local(0));
+        let ownership = ValueOwnership::classify(&ty, place, &self.ownership_ctx());
+        self.owned_locals.push(OwnedLocalEntry {
+            binding,
+            name,
+            ty,
+            ownership,
+            provenance: None,
+            disposition: Disposition::ScopeExit,
+        });
+    }
+
+    /// The scope-exit-live owned locals as `(binding, name, ty)` tuples — the
+    /// compat shape the twelve allow-set provers, `build_lifo_drops`, and the
+    /// double-free gate consume. Every entry this stage records is
+    /// `Disposition::ScopeExit`, so the live-view filter admits all of them and
+    /// the snapshot is byte-identical to the former `owned_locals` vec (same
+    /// contents, same declaration order). The disposition seam is where a later
+    /// stage narrows the live set without a per-pass re-scan.
+    fn owned_locals_snapshot(&self) -> Vec<(BindingId, String, ResolvedTy)> {
+        self.owned_locals
+            .iter()
+            .filter(|entry| entry.disposition == Disposition::ScopeExit)
+            .map(|entry| (entry.binding, entry.name.clone(), entry.ty.clone()))
+            .collect()
+    }
+
     /// Apply the per-monomorphisation substitution map to a type.
     /// Returns the input unchanged when `subst` is empty (the
     /// non-generic-function case).
@@ -10039,7 +10175,7 @@ impl Builder {
             let Some(place) = self.binding_locals.get(&binding).copied() else {
                 continue;
             };
-            self.owned_locals.retain(|(b, _, _)| *b != binding);
+            self.owned_locals.retain(|entry| entry.binding != binding);
             self.push_instr(Instr::Drop {
                 place,
                 ty,
@@ -10098,7 +10234,7 @@ impl Builder {
                 builtin: Some(BuiltinType::Vec),
                 is_opaque: false,
             };
-            self.owned_locals.retain(|(b, _, _)| *b != binding);
+            self.owned_locals.retain(|entry| entry.binding != binding);
             self.push_instr(Instr::RecordFieldDrop {
                 record: place,
                 field_offset: crate::model::FieldOffset(0),
@@ -10365,8 +10501,7 @@ impl Builder {
                 == Some(true)
             {
                 let owned_ty = self.subst_ty(&param.ty);
-                self.owned_locals
-                    .push((param.id, param.name.clone(), owned_ty.clone()));
+                self.register_owned_local(param.id, param.name.clone(), owned_ty.clone());
                 // Register the param in the function's top body scope so it
                 // participates in the elaborator's path-sensitive drop passes
                 // (forward-`Goto` scope-close + per-exit narrowing) exactly like
@@ -11325,9 +11460,11 @@ impl Builder {
     ) -> Vec<MirDiagnostic> {
         self.owned_locals
             .iter()
-            .filter_map(|(binding, name, ty)| {
-                let elem = self.unsupported_vec_element_in_ty(ty)?;
-                let site = bind_sites.get(binding).copied().unwrap_or(SiteId(0));
+            .filter(|entry| entry.disposition == Disposition::ScopeExit)
+            .filter_map(|entry| {
+                let name = &entry.name;
+                let elem = self.unsupported_vec_element_in_ty(&entry.ty)?;
+                let site = bind_sites.get(&entry.binding).copied().unwrap_or(SiteId(0));
                 Some(MirDiagnostic {
                     kind: MirDiagnosticKind::NotYetImplemented {
                         construct: format!(
@@ -12228,11 +12365,11 @@ impl Builder {
                     match classify_dyn_trait_storage(value, &self.dyn_trait_storage) {
                         Ok(storage) => {
                             self.dyn_trait_storage.insert(binding.id, storage);
-                            self.owned_locals.push((
+                            self.register_owned_local(
                                 binding.id,
                                 binding.name.clone(),
                                 value_ty.clone(),
-                            ));
+                            );
                             // Transitive `dyn -> dyn` rebind suppression.
                             //
                             // For `let d2 = d1;` (and `let d3 = { d2 };`
@@ -12314,8 +12451,7 @@ impl Builder {
                     // no backend Place, so it must not enter
                     // `owned_locals` either. LESSONS:
                     // boundary-fail-closed, raii-null-after-move.
-                    self.owned_locals
-                        .push((binding.id, binding.name.clone(), binding_ty.clone()));
+                    self.register_owned_local(binding.id, binding.name.clone(), binding_ty.clone());
                     // Tag generator/`AsyncGenerator` handle bindings with their
                     // declaring scope so a per-scope-exit `hew_gen_coro_destroy` fires
                     // when the scope closes — covering the loop-re-entry case the
@@ -12626,8 +12762,11 @@ impl Builder {
             });
             self.record_binding_scope(binding.binding);
             if self.binding_seeds_drop_elaboration(&binding_ty) {
-                self.owned_locals
-                    .push((binding.binding, binding.name.clone(), binding_ty.clone()));
+                self.register_owned_local(
+                    binding.binding,
+                    binding.name.clone(),
+                    binding_ty.clone(),
+                );
             }
             let dest = self.alloc_local(binding.ty.clone());
             self.push_instr(Instr::Move {
@@ -12651,8 +12790,11 @@ impl Builder {
             });
             self.record_binding_scope(binding.binding);
             if self.binding_seeds_drop_elaboration(&binding_ty) {
-                self.owned_locals
-                    .push((binding.binding, binding.name.clone(), binding_ty.clone()));
+                self.register_owned_local(
+                    binding.binding,
+                    binding.name.clone(),
+                    binding_ty.clone(),
+                );
             }
             let dest = self.alloc_local(binding.ty.clone());
             self.push_instr(Instr::Move {
@@ -12881,7 +13023,11 @@ impl Builder {
                         // r = T{..r} or a move-out RHS already consumed it
                         // (removed from `owned_locals`), so this is skipped and
                         // never double-frees.
-                        if self.owned_locals.iter().any(|(b, _, _)| b == binding) {
+                        if self
+                            .owned_locals
+                            .iter()
+                            .any(|entry| &entry.binding == binding)
+                        {
                             self.emit_local_overwrite_release(dest, &target.ty);
                         }
                         self.push_instr(Instr::Move { dest, src });
@@ -18836,8 +18982,11 @@ impl Builder {
             let keep_for_drop_elab = self.binding_seeds_drop_elaboration(&binding_ty);
             let binding_is_string = matches!(binding_ty, ResolvedTy::String);
             if keep_for_drop_elab {
-                self.owned_locals
-                    .push((binding.binding, binding.name.clone(), binding_ty.clone()));
+                self.register_owned_local(
+                    binding.binding,
+                    binding.name.clone(),
+                    binding_ty.clone(),
+                );
                 // A generator/AsyncGenerator handle bound via match destructure
                 // gets the same per-scope-exit `hew_gen_coro_destroy` registration the
                 // `Let` path uses, so the per-iteration release fires for a
@@ -20342,11 +20491,11 @@ impl Builder {
                 self.record_binding_scope(binding.binding);
                 let keep_for_drop_elab = self.binding_seeds_drop_elaboration(&binding_ty);
                 if keep_for_drop_elab {
-                    self.owned_locals.push((
+                    self.register_owned_local(
                         binding.binding,
                         binding.name.clone(),
                         binding_ty.clone(),
-                    ));
+                    );
                 }
                 let dest = self.alloc_local(binding.ty.clone());
                 self.push_instr(Instr::Move {
@@ -20377,7 +20526,8 @@ impl Builder {
                     // the reference to a longer-lived owner), matching the
                     // generator-yield posture.
                     if keep_for_drop_elab {
-                        self.owned_locals.retain(|(b, _, _)| *b != binding.binding);
+                        self.owned_locals
+                            .retain(|entry| entry.binding != binding.binding);
                     }
                     retained_vec_string_iter_bindings.push((
                         binding.binding,
@@ -20412,7 +20562,8 @@ impl Builder {
                             // fresh heap allocation the consumer alone is
                             // responsible for releasing.
                             if keep_for_drop_elab {
-                                self.owned_locals.retain(|(b, _, _)| *b != binding.binding);
+                                self.owned_locals
+                                    .retain(|entry| entry.binding != binding.binding);
                             }
                             generator_yield_drop_bindings.push((
                                 binding.binding,
@@ -20438,7 +20589,8 @@ impl Builder {
                             // final-`owned_locals` scan does not stack a
                             // second diagnostic on the same construct.
                             if keep_for_drop_elab {
-                                self.owned_locals.retain(|(b, _, _)| *b != binding.binding);
+                                self.owned_locals
+                                    .retain(|entry| entry.binding != binding.binding);
                             }
                             let elem = self
                                 .unsupported_vec_element_in_ty(&binding_ty)
@@ -20487,8 +20639,7 @@ impl Builder {
                 self.record_binding_scope(binding.binding);
                 let keep_for_drop_elab = self.binding_seeds_drop_elaboration(&binding_ty);
                 if keep_for_drop_elab {
-                    self.owned_locals
-                        .push((binding.binding, binding.name.clone(), binding_ty));
+                    self.register_owned_local(binding.binding, binding.name.clone(), binding_ty);
                 }
                 let dest = self.alloc_local(binding.ty.clone());
                 self.push_instr(Instr::Move {
@@ -21008,8 +21159,11 @@ impl Builder {
             });
             self.record_binding_scope(binding.binding);
             if self.binding_seeds_drop_elaboration(&binding_ty) {
-                self.owned_locals
-                    .push((binding.binding, binding.name.clone(), binding_ty.clone()));
+                self.register_owned_local(
+                    binding.binding,
+                    binding.name.clone(),
+                    binding_ty.clone(),
+                );
             }
             let dest = self.alloc_local(binding.ty.clone());
             self.push_instr(Instr::Move {
@@ -21033,8 +21187,11 @@ impl Builder {
             });
             self.record_binding_scope(binding.binding);
             if self.binding_seeds_drop_elaboration(&binding_ty) {
-                self.owned_locals
-                    .push((binding.binding, binding.name.clone(), binding_ty.clone()));
+                self.register_owned_local(
+                    binding.binding,
+                    binding.name.clone(),
+                    binding_ty.clone(),
+                );
             }
             let dest = self.alloc_local(binding.ty.clone());
             self.push_instr(Instr::Move {
@@ -21231,8 +21388,11 @@ impl Builder {
             });
             self.record_binding_scope(binding.binding);
             if self.binding_seeds_drop_elaboration(&binding_ty) {
-                self.owned_locals
-                    .push((binding.binding, binding.name.clone(), binding_ty.clone()));
+                self.register_owned_local(
+                    binding.binding,
+                    binding.name.clone(),
+                    binding_ty.clone(),
+                );
             }
             let dest = self.alloc_local(binding.ty.clone());
             self.push_instr(Instr::Move {
@@ -21256,8 +21416,11 @@ impl Builder {
             });
             self.record_binding_scope(binding.binding);
             if self.binding_seeds_drop_elaboration(&binding_ty) {
-                self.owned_locals
-                    .push((binding.binding, binding.name.clone(), binding_ty.clone()));
+                self.register_owned_local(
+                    binding.binding,
+                    binding.name.clone(),
+                    binding_ty.clone(),
+                );
             }
             let dest = self.alloc_local(binding.ty.clone());
             self.push_instr(Instr::Move {
@@ -24061,10 +24224,9 @@ impl Builder {
             && !self
                 .owned_locals
                 .iter()
-                .any(|(binding, _, _)| *binding == binding_id)
+                .any(|entry| entry.binding == binding_id)
         {
-            self.owned_locals
-                .push((binding_id, name.to_string(), ty.clone()));
+            self.register_owned_local(binding_id, name.to_string(), ty.clone());
         }
     }
 
@@ -31085,7 +31247,11 @@ impl Builder {
         if !self.prepass_reassigned_bindings.contains(&binding.id) {
             return;
         }
-        if !self.owned_locals.iter().any(|(b, _, _)| *b == binding.id) {
+        if !self
+            .owned_locals
+            .iter()
+            .any(|entry| entry.binding == binding.id)
+        {
             return;
         }
         if self.overwrite_guard_flags.contains_key(&binding.id) {
@@ -31164,7 +31330,7 @@ impl Builder {
                 value: 1,
             });
         }
-        self.owned_locals.retain(|(binding, _, _)| *binding != id);
+        self.owned_locals.retain(|entry| entry.binding != id);
     }
 
     // JUSTIFIED: this predicate deliberately stays adjacent to the aggregate
@@ -32110,7 +32276,12 @@ fn elaborate(
     // block's `statements` in construction order — Slice 1 maintains
     // pre-CFG snapshot continuity by feeding the same union here.
     let mut elaborated_statements: Vec<MirStatement> = flat_statements.to_vec();
-    for (binding, name, ty) in builder.owned_locals.iter().rev() {
+    // The scope-exit-live owned-locals view, materialised once for the
+    // reverse-declaration drop stream and every per-class allow-set derivation
+    // below — the same `(binding, name, ty)` tuples the provers read before the
+    // ledger carried richer facts, in the same declaration order.
+    let owned_locals_snapshot = builder.owned_locals_snapshot();
+    for (binding, name, ty) in owned_locals_snapshot.iter().rev() {
         elaborated_statements.push(MirStatement::Drop {
             binding: *binding,
             name: name.clone(),
@@ -32158,7 +32329,7 @@ fn elaborate(
     let mut cow_drop_allowed = derive_cow_sole_owner(
         &checked.blocks,
         &builder.suspend_kinds,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         &builder.match_project_consumed_binder_locals,
         &builder.locals,
@@ -32175,7 +32346,7 @@ fn elaborate(
     cow_drop_allowed.extend(derive_cow_fresh_borrowed_owner(
         &checked.blocks,
         &builder.suspend_kinds,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         &builder.locals,
     ));
@@ -32200,7 +32371,7 @@ fn elaborate(
     let enum_composite_drop_allowed = derive_enum_composite_drop_allowed(
         &checked.blocks,
         &builder.suspend_kinds,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         &builder.binding_scope,
         &builder.locals,
@@ -32235,7 +32406,7 @@ fn elaborate(
     let mut owned_vec_drop_allowed = derive_local_collection_drop_allowed(
         &checked.blocks,
         &builder.suspend_kinds,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         |ty| builder.binding_ty_is_owned_element_vec(ty),
     );
@@ -32300,7 +32471,7 @@ fn elaborate(
     let mut local_collection_drop_allowed = derive_local_collection_drop_allowed(
         &checked.blocks,
         &builder.suspend_kinds,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         ty_is_local_collection_handle,
     );
@@ -32330,7 +32501,7 @@ fn elaborate(
     let mut local_bytes_drop_allowed = derive_local_bytes_drop_allowed(
         &checked.blocks,
         &builder.suspend_kinds,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
     );
     for states in dataflow_result.exit_states.values() {
@@ -32354,7 +32525,7 @@ fn elaborate(
     let mut closure_vec_drop_allowed = derive_local_collection_drop_allowed(
         &checked.blocks,
         &builder.suspend_kinds,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         ty_is_closure_pair_vec,
     );
@@ -32388,7 +32559,7 @@ fn elaborate(
     let mut plain_vec_drop_allowed = derive_local_collection_drop_allowed(
         &checked.blocks,
         &builder.suspend_kinds,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         |ty| builder.binding_ty_is_plain_vec(ty),
     );
@@ -32440,7 +32611,7 @@ fn elaborate(
     let owned_record_drop_allowed = derive_owned_record_drop_allowed(
         &checked.blocks,
         &builder.suspend_kinds,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         &builder.locals,
         &is_owned_record,
@@ -32461,7 +32632,7 @@ fn elaborate(
     let tuple_composite_drop_allowed = derive_tuple_composite_drop_allowed(
         &checked.blocks,
         &builder.suspend_kinds,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         &builder.locals,
         &builder.record_field_orders,
@@ -32472,7 +32643,7 @@ fn elaborate(
     // aggregate; excluded from every drop class below (see the function doc).
     let returned_aggregate_members = derive_returned_aggregate_member_bindings(
         &checked.blocks,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
     );
 
@@ -32483,7 +32654,7 @@ fn elaborate(
     // `returned_aggregate_members` (see the function doc).
     let consumed_local_aggregate_members = derive_consumed_local_aggregate_member_bindings(
         &checked.blocks,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         &builder.locals,
         &builder.record_field_orders,
@@ -32527,7 +32698,7 @@ fn elaborate(
     // skip and the `Consumed`/`MaybeConsumed` exit filter below complete it.
     let mut indirect_enum_drop_allowed = derive_indirect_enum_drop_allowed(
         &checked.blocks,
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         &builder.enum_layouts,
     );
@@ -32543,7 +32714,7 @@ fn elaborate(
     }
 
     let lifo_drops = build_lifo_drops(
-        &builder.owned_locals,
+        &owned_locals_snapshot,
         &builder.binding_locals,
         &builder.type_classes,
         &builder.dyn_trait_storage,
@@ -49002,11 +49173,11 @@ mod binding_ty_is_plain_vec_tuple {
     #[test]
     fn unsupported_vec_element_diagnostics_rejects_unwired_owned_local() {
         let mut builder = builder_with_indirect_enum();
-        builder.owned_locals = vec![(
+        builder.register_owned_local(
             BindingId(7),
             "nodes".to_string(),
             vec_of_ty(unregistered_named("Foo")),
-        )];
+        );
         // The construction site is sourced from the finalized `Bind` statements,
         // keyed by the owned local's binding id.
         let bind_sites = std::collections::HashMap::from([(BindingId(7), SiteId(42))]);
@@ -49026,15 +49197,53 @@ mod binding_ty_is_plain_vec_tuple {
         // A releasable owned `Vec<string>` local emits nothing — behaviour
         // preserved for every constructible, releasable shape.
         let mut ok = builder_with_indirect_enum();
-        ok.owned_locals = vec![(
+        ok.register_owned_local(
             BindingId(8),
             "names".to_string(),
             vec_of_ty(ResolvedTy::String),
-        )];
+        );
         assert!(
             ok.unsupported_vec_element_diagnostics(&bind_sites)
                 .is_empty(),
             "a Vec<string> owned local has a wired release — no diagnostic"
+        );
+    }
+
+    /// The single registration authority records the classified ownership fact
+    /// ONCE at the defining write, defaults the disposition to scope exit, and
+    /// exposes the binding through the `(binding, name, ty)` compat view every
+    /// drop prover consumes — the byte-identical shape of the former tuple
+    /// ledger.
+    #[test]
+    fn register_owned_local_records_classified_ownership_and_scope_exit() {
+        use crate::ownership::{DropClass, HeapLeaf};
+
+        let mut builder = builder_with_indirect_enum();
+        builder.register_owned_local(BindingId(3), "s".to_string(), ResolvedTy::String);
+
+        // The compat view is exactly the registered triple, in registration
+        // order — what `owned_locals_snapshot` feeds the provers.
+        assert_eq!(
+            builder.owned_locals_snapshot(),
+            vec![(BindingId(3), "s".to_string(), ResolvedTy::String)],
+            "the live view is the registered (binding, name, ty) triple"
+        );
+
+        // The richer facts are carried on the entry: a `string` owns a single
+        // copy-on-write heap leaf, the disposition is scope exit, and no
+        // provenance is proven at this seam.
+        let entry = &builder.owned_locals[0];
+        assert_eq!(entry.disposition, Disposition::ScopeExit);
+        assert_eq!(
+            entry.ownership.drop_class(),
+            Some(DropClass::CowHeapLeaf {
+                leaf: HeapLeaf::String
+            }),
+            "ownership is classified once at registration and recorded on the entry"
+        );
+        assert_eq!(
+            entry.provenance, None,
+            "no provenance is proven at this seam"
         );
     }
 
@@ -49261,7 +49470,7 @@ mod drop_admission_type_shape_pins {
     //! reclassification. An admission that widens over-drops (double-free,
     //! the worst outcome); one that narrows leaks.
     use super::*;
-    use crate::ownership::{DropClass, HeapLeaf, OwnershipCtx, OwnershipDecision};
+    use crate::ownership::{DropClass, HeapLeaf, OwnershipDecision};
 
     fn vec_of(elem: ResolvedTy) -> ResolvedTy {
         ResolvedTy::named_builtin("Vec", BuiltinType::Vec, vec![elem])

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -18801,6 +18801,17 @@ impl Builder {
             _ => None,
         };
 
+        // Classify the scrutinee's storage once, above the bind loop, so both
+        // the bound-string discharge inside it and the skipped-field discharge
+        // below read the same verdict. `local_storage_is_interior_alias` is a
+        // pure classifier over the already-emitted loads that define
+        // `scrutinee_local` (an interior alias is minted by a `let inner =
+        // outer.field` byte copy BEFORE this match lowers); the bind loop only
+        // adds loads whose dest is a binder, never `scrutinee_local`, so the
+        // verdict is invariant to where it is read.
+        let scrutinee_is_interior_alias =
+            scrutinee_is_non_bitcopy && self.local_storage_is_interior_alias(scrutinee_local);
+
         let mut overwritten_bindings = Vec::with_capacity(selected.bindings.len());
         for binding in &selected.bindings {
             let binding_ty = self.subst_ty(&binding.ty);
@@ -18823,6 +18834,7 @@ impl Builder {
             // BitCopy bindings stay out: their copy is free of heap ownership
             // and the surrounding scrutinee's composite drop covers them.
             let keep_for_drop_elab = self.binding_seeds_drop_elaboration(&binding_ty);
+            let binding_is_string = matches!(binding_ty, ResolvedTy::String);
             if keep_for_drop_elab {
                 self.owned_locals
                     .push((binding.binding, binding.name.clone(), binding_ty.clone()));
@@ -18911,6 +18923,48 @@ impl Builder {
                     panic!("checker invariant violated: refutable arm in project match lowering");
                 }
             }
+            // Bound-string original discharge. A `string`-typed field bound on
+            // a consumed, non-alias root strands its original. Codegen retains
+            // the string on the field load (`retain_string_field_load` →
+            // `hew_string_clone`, rc 2): the binder owns the clone, but the
+            // ORIGINAL handle still sits in the root slot with a `+1` nothing
+            // releases — the root's composite drop is suppressed (the binder
+            // seeds `release_owner_bases`) and the consume mark below retracts
+            // the root from `owned_locals`. Discharge the original IN PLACE
+            // right after the load: `FieldDropInPlace` raw-loads the root's
+            // field handle, releases it (rc 1), and null-stores the slot; the
+            // binder is then the sole owner — safe even when the arm returns
+            // the binder (its own drop balances the retained clone).
+            //
+            // Gated exactly like the skipped-field discharge below:
+            //   - consume-marked scrutinee: a non-consumed root keeps its
+            //     composite drop, which frees the original — discharging here
+            //     would double-free.
+            //   - non-alias root: on an interior alias the original belongs to
+            //     the OUTER composite, which frees it; `FieldDropInPlace`
+            //     null-stores the alias slot, not the owner's (the alias gate
+            //     below is the authority) — discharging would double-free.
+            //   - `string`-typed field only: the retaining-load class. Non-
+            //     string bound fields (`Vec` / `bytes` / handles / aggregates)
+            //     load without a retain, so the binder takes the one handle and
+            //     the root slot is dead — they do not strand and MUST NOT be
+            //     discharged here.
+            if consume_scrutinee.is_some() && !scrutinee_is_interior_alias && binding_is_string {
+                let field = match &selected.predicate {
+                    hew_hir::HirMatchArmPredicate::RecordProject { .. } => {
+                        crate::model::FieldAddr::Record(FieldOffset(binding.field_idx))
+                    }
+                    hew_hir::HirMatchArmPredicate::TupleProject { .. } => {
+                        crate::model::FieldAddr::Tuple(binding.field_idx)
+                    }
+                    _ => unreachable!("bound-string discharge only reached for project predicates"),
+                };
+                self.push_instr(Instr::FieldDropInPlace {
+                    base: Place::Local(scrutinee_local),
+                    field,
+                    ty: ResolvedTy::String,
+                });
+            }
             let previous = self.binding_locals.insert(binding.binding, dest);
             overwritten_bindings.push((binding.binding, previous, keep_for_drop_elab));
         }
@@ -18978,8 +19032,6 @@ impl Builder {
         // leak — fail-closed — and the provers' direct `FieldDropInPlace`
         // binder rules remain the net for any emitter that does discharge
         // through an alias.
-        let scrutinee_is_interior_alias =
-            scrutinee_is_non_bitcopy && self.local_storage_is_interior_alias(scrutinee_local);
         if !selected.bindings.is_empty() && scrutinee_is_non_bitcopy && !scrutinee_is_interior_alias
         {
             let extracted: HashSet<u32> = selected.bindings.iter().map(|b| b.field_idx).collect();

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -11585,7 +11585,7 @@ impl Builder {
     /// union is total over `ResolvedTy` by construction — a `Vec<E>` local can
     /// never silently fall through every bucket and skip its release.
     ///
-    /// Order matters and mirrors codegen's `cow_heap_release_symbol`: a closure
+    /// Order matters and mirrors codegen's `resolved_ty_cow_heap_release`: a closure
     /// pair is checked BEFORE the owned/plain arms (a `fn`/closure element is
     /// neither an owned composite nor a plain leaf — it has its own pair-box
     /// release), and the owned composite is checked before the plain leaf (an
@@ -14982,7 +14982,7 @@ impl Builder {
                                 // and must be reached through `RecordFieldLoad` +
                                 // `Instr::Drop` (which materialises the fat value).
                                 // `field_override_uses_record_field_drop` mirrors
-                                // codegen's `cow_heap_release_symbol` single-ptr set
+                                // codegen's `resolved_ty_cow_heap_release` single-ptr set
                                 // so the `RecordFieldDrop` congruence assert agrees.
                                 if field_override_uses_record_field_drop(&subst_fty) {
                                     self.push_instr(Instr::RecordFieldDrop {
@@ -18070,17 +18070,17 @@ impl Builder {
     /// the construct at compile time — never emit a wrong-ABI free.
     ///
     /// The `Wired` selection MUST mirror codegen's
-    /// `cow_heap_release_symbol` so the inline-drop validator
+    /// `resolved_ty_cow_heap_release` so the inline-drop validator
     /// (`lower_inline_drop` → congruence check) accepts the emitted symbol
     /// (`dedup-semantic-boundary`).
     ///
-    /// `Bytes` does NOT appear in `cow_heap_release_symbol` (a native `bytes`
+    /// `Bytes` does NOT appear in `resolved_ty_cow_heap_release` (a native `bytes`
     /// value is a stack-resident `BytesTriple { ptr, i32, i32 }`, not a single
     /// owned pointer, so the generic single-`ptr`-load release shape that
-    /// `cow_heap_release_symbol` describes does not apply). The inline-drop
+    /// `resolved_ty_cow_heap_release` describes does not apply). The inline-drop
     /// dispatcher (`lower_inline_drop`) intercepts the
     /// `(ty == Bytes, drop_fn == "hew_bytes_drop")` pair BEFORE the
-    /// `cow_heap_release_symbol` congruence check and routes it through the
+    /// `resolved_ty_cow_heap_release` congruence check and routes it through the
     /// `BytesTriple`-aware emitter (`emit_bytes_inplace_drop`): GEP field 0,
     /// load the data ptr, call `hew_bytes_drop(data_ptr)`, null-store the
     /// field to make a structurally-reachable second drop a no-op against
@@ -18111,7 +18111,7 @@ impl Builder {
                 // The element's release bucket selects the Vec verdict, read
                 // from the one typed classification. Its dispatch checks the
                 // closure-pair bucket FIRST, mirroring codegen's
-                // `cow_heap_release_symbol` (a fn/closure element is neither
+                // `resolved_ty_cow_heap_release` (a fn/closure element is neither
                 // an owned composite nor a plain leaf; the inline-drop
                 // congruence check rejects a mis-picked `hew_vec_free` for a
                 // yielded `Vec<fn>` — `dedup-semantic-boundary`), and its
@@ -18529,7 +18529,7 @@ impl Builder {
     /// inline `Instr::Drop`. The caller fails closed for these rather than
     /// emit a wrong-ABI free (leak-not-double-free posture).
     ///
-    /// The symbol authority MUST agree with codegen's `cow_heap_release_symbol`
+    /// The symbol authority MUST agree with codegen's `resolved_ty_cow_heap_release`
     /// + Bytes-intercept in `lower_inline_drop` (`dedup-semantic-boundary`,
     ///   `lifecycle-symmetry`). A symbol absent from that authority would be
     ///   rejected at codegen-emit time as a wrong-ABI free.
@@ -18547,7 +18547,7 @@ impl Builder {
                 // generator-yield picker consults, so every drop-symbol
                 // authority detects each bucket through one decision and
                 // cannot drift. The dispatch checks the closure-pair bucket
-                // FIRST, mirroring codegen's `cow_heap_release_symbol` (see
+                // FIRST, mirroring codegen's `resolved_ty_cow_heap_release` (see
                 // `classify_vec_element_release`'s order doc; both
                 // authorities are documented to agree —
                 // `dedup-semantic-boundary`, `is_known_cow_heap_drop_symbol`
@@ -18592,7 +18592,7 @@ impl Builder {
     /// dispatcher can resolve?"), so MIR admission and codegen capability
     /// cannot drift (`dedup-semantic-boundary` — the same discipline
     /// `project_field_inline_drop_symbol` documents against codegen's
-    /// `cow_heap_release_symbol`).
+    /// `resolved_ty_cow_heap_release`).
     ///
     /// Admitted top-level shapes, mirroring `emit_heap_slot_drop`'s dispatch:
     ///   - user record with a registered layout — every field dischargeable
@@ -33298,19 +33298,19 @@ fn expected_drop_kind_for_validation(drop: &ElabDrop) -> DropKind {
         // re-derives via the dispatcher so a non-Vec place cannot silently
         // carry the owned-Vec release symbol.
         DropKind::CowHeap {
-            drop_fn: "hew_vec_free_owned",
+            release: crate::ownership::CowHeapRelease::VecOwnedElement,
         } if matches!(drop.place, Place::Local(_)) && ty_is_vec(&drop.ty) => DropKind::CowHeap {
-            drop_fn: "hew_vec_free_owned",
+            release: crate::ownership::CowHeapRelease::VecOwnedElement,
         },
         // Closure-pair `Vec<fn(...)>` scope-exit release: same dedicated-kind
         // acceptance shape as the owned-Vec arm — a local Vec whose element
         // is a closure pair may carry the closure-pair release symbol; any
         // other shape re-derives via the Place-driven dispatcher.
         DropKind::CowHeap {
-            drop_fn: "hew_vec_free_closure_pairs",
+            release: crate::ownership::CowHeapRelease::VecClosurePairs,
         } if matches!(drop.place, Place::Local(_)) && ty_is_closure_pair_vec(&drop.ty) => {
             DropKind::CowHeap {
-                drop_fn: "hew_vec_free_closure_pairs",
+                release: crate::ownership::CowHeapRelease::VecClosurePairs,
             }
         }
         // Plain `Vec<T>` scope-exit release: same dedicated-kind acceptance
@@ -33322,9 +33322,9 @@ fn expected_drop_kind_for_validation(drop: &ElabDrop) -> DropKind {
         // carry the plain-Vec release symbol. Codegen re-validates the
         // (type, symbol) congruence again before emitting the call.
         DropKind::CowHeap {
-            drop_fn: "hew_vec_free",
+            release: crate::ownership::CowHeapRelease::VecPlain,
         } if matches!(drop.place, Place::Local(_)) && ty_is_vec(&drop.ty) => DropKind::CowHeap {
-            drop_fn: "hew_vec_free",
+            release: crate::ownership::CowHeapRelease::VecPlain,
         },
         // W5.021 — heap-owning tuple drops are keyed by both kind and
         // `ElabDrop::ty` (the structural tuple shape selects the synthesized
@@ -35843,7 +35843,7 @@ fn cow_owned_string_terminator_escapes(
 /// W5.011 P3 — borrowing-read-aware owned-`string` cleanup. Returns the subset
 /// of `owned_locals` that hold a **proven fresh sole owner used only in
 /// borrowing reads**, which therefore earns a scope-exit
-/// `DropKind::CowHeap { drop_fn: "hew_string_drop" }`.
+/// `DropKind::CowHeap { release: String }` (`hew_string_drop`).
 ///
 /// ## Why this exists (the leak `derive_cow_sole_owner` leaves behind)
 ///
@@ -38117,7 +38117,7 @@ fn derive_local_collection_drop_allowed(
 /// Fail-closed sole-owner derivation for **local `bytes`** bindings. Returns
 /// the subset of `owned_locals` whose `BytesTriple` is proven to still solely
 /// own its refcounted data buffer at every exit, and therefore earns a
-/// `DropKind::CowHeap { drop_fn: "hew_bytes_drop" }` scope-exit drop (lowered
+/// `DropKind::CowHeap { release: Bytes }` (`hew_bytes_drop`) scope-exit drop (lowered
 /// by codegen's `emit_bytes_inplace_drop`: GEP field 0, load the data pointer,
 /// `hew_bytes_drop(data_ptr)`, null-store the field).
 ///
@@ -40332,7 +40332,7 @@ fn drop_kind_for(
         // identical kind (see `cow_value_leaf_drop_symbol`).
         Place::Local(_) | Place::ReturnSlot if matches!(ty, ResolvedTy::String) => {
             DropKind::CowHeap {
-                drop_fn: "hew_string_drop",
+                release: crate::ownership::CowHeapRelease::String,
             }
         }
         // A `bytes` owned local is a by-value `BytesTriple { ptr, i32, i32 }`
@@ -40350,7 +40350,7 @@ fn drop_kind_for(
         // `derive_local_bytes_drop_allowed`).
         Place::Local(_) | Place::ReturnSlot if matches!(ty, ResolvedTy::Bytes) => {
             DropKind::CowHeap {
-                drop_fn: "hew_bytes_drop",
+                release: crate::ownership::CowHeapRelease::Bytes,
             }
         }
         // A `Generator<Y, R>` / `AsyncGenerator<Y>` owned local holds the heap
@@ -40373,7 +40373,7 @@ fn drop_kind_for(
             ) =>
         {
             DropKind::CowHeap {
-                drop_fn: "hew_gen_coro_destroy",
+                release: crate::ownership::CowHeapRelease::Generator,
             }
         }
         // A local `HashMap<K, V>` / `HashSet<E>` owned binding holds a single
@@ -40408,7 +40408,7 @@ fn drop_kind_for(
             ) =>
         {
             DropKind::CowHeap {
-                drop_fn: "hew_hashmap_free_layout",
+                release: crate::ownership::CowHeapRelease::HashMap,
             }
         }
         Place::Local(_) | Place::ReturnSlot
@@ -40421,7 +40421,7 @@ fn drop_kind_for(
             ) =>
         {
             DropKind::CowHeap {
-                drop_fn: "hew_hashset_free_layout",
+                release: crate::ownership::CowHeapRelease::HashSet,
             }
         }
         // Machine tag and variant fields are sub-structure of a machine value,
@@ -41318,7 +41318,7 @@ fn build_lifo_drops(
                 ty: ty.clone(),
                 drop_fn: None,
                 kind: DropKind::CowHeap {
-                    drop_fn: "hew_vec_free_closure_pairs",
+                    release: crate::ownership::CowHeapRelease::VecClosurePairs,
                 },
                 guard: None,
             });
@@ -41337,7 +41337,7 @@ fn build_lifo_drops(
                 ty: ty.clone(),
                 drop_fn: None,
                 kind: DropKind::CowHeap {
-                    drop_fn: "hew_vec_free_owned",
+                    release: crate::ownership::CowHeapRelease::VecOwnedElement,
                 },
                 guard: None,
             });
@@ -41374,7 +41374,7 @@ fn build_lifo_drops(
                 ty: ty.clone(),
                 drop_fn: None,
                 kind: DropKind::CowHeap {
-                    drop_fn: "hew_vec_free",
+                    release: crate::ownership::CowHeapRelease::VecPlain,
                 },
                 guard: None,
             });
@@ -41855,7 +41855,7 @@ fn cow_value_leaf_drop_symbol(ty: &ResolvedTy) -> Option<&'static str> {
 /// `bytes` is deliberately EXCLUDED: it is a fat `{ ptr, len, cap }` triple,
 /// not a single pointer. Its destructor takes the by-value triple, so it is
 /// reached through `RecordFieldLoad` + `Instr::Drop` (which materialises the
-/// fat value into a temp). The set mirrors codegen's `cow_heap_release_symbol`
+/// fat value into a temp). The set mirrors codegen's `resolved_ty_cow_heap_release`
 /// (which returns `None` for `bytes`), so the `RecordFieldDrop` symbol/type
 /// congruence assertion in codegen always agrees with what is emitted here.
 ///
@@ -49371,7 +49371,7 @@ mod binding_ty_is_plain_vec_tuple {
 
     /// Closure-pair release-symbol pin: the generator-yield and match-field
     /// release-symbol pickers must check the closure-pair bucket BEFORE the
-    /// owned/plain split, matching codegen's `cow_heap_release_symbol` dispatch
+    /// owned/plain split, matching codegen's `resolved_ty_cow_heap_release` dispatch
     /// order. A yielded or match-destructured `Vec<fn>` releases via
     /// `hew_vec_free_closure_pairs`; the pre-fix `generator_yield_drop_symbol`
     /// had only an owned/plain split and computed `hew_vec_free`, which diverges

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -7852,6 +7852,12 @@ fn lower_function(
     // the dataflow observes the discharges and codegen emits them.
     {
         let mut instr_spans = std::mem::take(&mut builder.instr_spans);
+        // The immediate-parent chain of every recorded byte-copy alias, so the
+        // sibling-discharge emitter can walk a MULTI-HOP escape (`let mid = o.mid;
+        // let leaf = mid.leaf; return leaf`) and compensate the non-escaped
+        // siblings at every level — the reach `close_alias_binders_forward` gave
+        // the composite-drop prover's exclusion.
+        let alias_chain = builder.alias_projection_chain();
         let is_owned_record = |ty: &ResolvedTy| builder.is_owned_aggregate_record_ty(ty);
         let owned_field_list = |ty: &ResolvedTy| builder.project_record_owned_field_list(ty);
         let field_dischargeable = |ty: &ResolvedTy| {
@@ -7865,6 +7871,7 @@ fn lower_function(
             &builder.locals,
             &builder.record_field_orders,
             &builder.enum_layouts,
+            &alias_chain,
             &is_owned_record,
             &owned_field_list,
             &field_dischargeable,
@@ -9987,6 +9994,48 @@ impl Builder {
             resolved.push((alias_local, owner));
         }
         resolved
+    }
+
+    /// The `(alias_local, immediate_parent_local, field_ordinal)` triples for
+    /// every recorded byte-copy interior alias ([`Disposition::AliasOf`]) whose
+    /// provenance is a single record/tuple field projection of a nameable parent
+    /// local — the IMMEDIATE hop of a `let mid = o.mid; let leaf = mid.leaf`
+    /// chain (`leaf -> (mid, 0)`, `mid -> (o, 0)`). Unlike
+    /// [`Builder::alias_owner_field_binders`], which resolves each alias straight
+    /// to its ultimate owner, this preserves the intermediate structure so the
+    /// escaped-record sibling-discharge emitter can walk the chain and compensate
+    /// the non-escaped siblings at EVERY level (the outer `c` through the root,
+    /// the intermediate `mid.x` through the `mid` alias) — matching the multi-hop
+    /// reach `close_alias_binders_forward` gave the composite-drop prover's
+    /// exclusion. Without it the widened exclusion removes the owner's composite
+    /// drop while the one-hop sibling emitter (blind past a one-hop alias) leaves
+    /// every deeper sibling to leak unconditionally.
+    ///
+    /// An entry whose parent is not a named local, or whose provenance path is
+    /// not a single field step, is dropped — the emitter keeps its fail-closed
+    /// leak-as-before for it (leak, never a double-free).
+    fn alias_projection_chain(&self) -> Vec<(u32, u32, u32)> {
+        let mut chain = Vec::new();
+        for entry in &self.owned_locals {
+            let Some(provenance) = entry.provenance.as_ref() else {
+                continue;
+            };
+            let PlaceProvenance::Local(parent_local) = provenance.root else {
+                continue;
+            };
+            let [Projection::Field(field)] = provenance.path.as_slice() else {
+                continue;
+            };
+            let Some(alias_local) = self
+                .binding_locals
+                .get(&entry.binding)
+                .and_then(|p| base_local(*p))
+            else {
+                continue;
+            };
+            chain.push((alias_local, parent_local, *field));
+        }
+        chain
     }
 
     /// The scope-exit-live owned locals as `(binding, name, ty)` tuples — the
@@ -36540,6 +36589,7 @@ fn apply_escaped_record_sibling_field_drops(
     local_tys: &[ResolvedTy],
     record_field_orders: &HashMap<String, Vec<(String, ResolvedTy)>>,
     enum_layouts: &[crate::model::EnumLayout],
+    alias_chain: &[(u32, u32, u32)],
     is_owned_record: &dyn Fn(&ResolvedTy) -> bool,
     owned_field_list: &dyn Fn(&ResolvedTy) -> Vec<(u32, ResolvedTy)>,
     field_dischargeable: &dyn Fn(&ResolvedTy) -> bool,
@@ -36871,6 +36921,22 @@ fn apply_escaped_record_sibling_field_drops(
         }
         insertions.push((esc_block, esc_idx + 1, siblings));
     }
+    // The one-hop scan above sees only a binder loaded DIRECTLY off a whole-value
+    // alias member, so a ≥2-hop escape (`let mid = o.mid; let leaf = mid.leaf;
+    // return leaf`) is invisible to it — yet the composite-drop prover DOES
+    // exclude the owner for it (via `close_alias_binders_forward`). Walk the
+    // recorded alias chain and discharge the non-escaped siblings at every level
+    // so the widened exclusion never outruns its compensation.
+    insertions.extend(compute_escaped_record_chain_sibling_drops(
+        blocks,
+        suspend_kinds,
+        &root_record_ty,
+        &alias_of,
+        alias_chain,
+        local_tys,
+        owned_field_list,
+        field_dischargeable,
+    ));
     if insertions.is_empty() {
         return;
     }
@@ -36898,6 +36964,278 @@ fn apply_escaped_record_sibling_field_drops(
             }
         }
     }
+}
+
+/// Multi-hop sibling discharge for the ESCAPED deep-alias chain
+/// (`let mid = o.mid; let leaf = mid.leaf; return leaf`), the ≥2-hop companion
+/// to the one-hop scan in [`apply_escaped_record_sibling_field_drops`].
+///
+/// `derive_owned_record_drop_allowed` folds the recorded deep aliases into its
+/// exclusion via `close_alias_binders_forward`, so when a ≥2-hop alias escapes
+/// into an owning sink it suppresses the OWNER root's whole composite drop —
+/// otherwise the owner would free a subtree the escapee already handed to the
+/// caller (the #2375 double-free). The one-hop scan cannot see a ≥2-hop alias
+/// (its field-binder scan reaches only a binder loaded DIRECTLY off a whole-
+/// value alias member), so the widened exclusion removed the composite drop but
+/// nothing discharged the non-escaped siblings ALONG the chain — the outer `c`
+/// and the intermediate `mid.x` leaked unconditionally (the P0 regression).
+///
+/// This walk mirrors the exclusion's reach: from the escapee up its immediate-
+/// parent chain to the owning root, it emits one `FieldDropInPlace` per owned
+/// field that does NOT lead to the next (escaping) hop, addressed through the
+/// still-live byte-copy alias local at each level (`mid.x` through `mid`, `o.c`
+/// through `o`). Exactly-once invariant: the escaped field at each level is
+/// never discharged (the escapee owns that subtree), every other owned field is
+/// discharged exactly once through its level's alias slot.
+///
+/// Fail-closed, coupled to the prover's exclusion so the two never disagree:
+/// exactly ONE chain alias may escape, at a single INSTRUCTION whose escape
+/// trigger (a `Move` to a non-member/non-carrier slot, a `RecordInit` field, a
+/// `RecordFieldStore` source) is a strict subset of the prover's exclusion
+/// triggers; the chain must resolve cleanly to a single candidate root through
+/// ≥2 byte-copy hops (a one-hop escape is the scan above's job); the escape
+/// block must not be reachable from itself (no loop — the inline-composite
+/// discharges have no null-store to make a re-run idempotent); and NO node of
+/// the chain may be read after the escape point. Any use of a chain alias this
+/// walk cannot model bails the whole pass (leak-as-before, never a double-free).
+#[allow(
+    clippy::too_many_arguments,
+    reason = "each argument is a distinct caller-owned input the walk needs — \
+              the MIR, the suspend table, the candidate-root and whole-value \
+              alias maps, the recorded chain, the local type table, and the two \
+              type-shape predicates; bundling them into a struct would only \
+              relocate the same fields at the single call site"
+)]
+#[allow(
+    clippy::too_many_lines,
+    reason = "one linear pipeline — carrier closure, escape scan, chain walk, \
+              after-escape liveness guard, per-level discharge — whose \
+              fail-closed ordering the soundness argument depends on; splitting \
+              it would scatter the shared carrier/escape state"
+)]
+#[allow(
+    clippy::similar_names,
+    reason = "`escapee` (the escaping alias) and `escapes` (the collected escape \
+              events) are the domain terms; renaming either obscures the walk"
+)]
+fn compute_escaped_record_chain_sibling_drops(
+    blocks: &[BasicBlock],
+    suspend_kinds: &HashMap<u32, SuspendKind>,
+    root_record_ty: &HashMap<u32, ResolvedTy>,
+    alias_of: &HashMap<u32, u32>,
+    alias_chain: &[(u32, u32, u32)],
+    local_tys: &[ResolvedTy],
+    owned_field_list: &dyn Fn(&ResolvedTy) -> Vec<(u32, ResolvedTy)>,
+    field_dischargeable: &dyn Fn(&ResolvedTy) -> bool,
+) -> Vec<(u32, usize, Vec<Instr>)> {
+    // Immediate-parent map: alias_local -> (parent_local, field ordinal it reads).
+    let parent_of: HashMap<u32, (u32, u32)> = alias_chain
+        .iter()
+        .copied()
+        .map(|(alias, parent, field)| (alias, (parent, field)))
+        .collect();
+    if parent_of.is_empty() {
+        return Vec::new();
+    }
+
+    // Forward whole-value-`Move` closure of the chain alias binding locals: every
+    // slot a chain alias value flows into (`let l2 = leaf`) carries the same
+    // escapee identity, so a later escape of the copy is still attributed to the
+    // recorded alias — and, symmetrically, a `Move` INTO a carrier is a benign
+    // hand-off, never an escape (so the escape scan below can never disagree with
+    // the prover's `field_binders`-benign move rule).
+    let mut carrier_of: HashMap<u32, u32> = parent_of.keys().map(|&a| (a, a)).collect();
+    loop {
+        let mut changed = false;
+        for block in blocks {
+            for instr in &block.instructions {
+                if let Instr::Move { dest, src } = instr {
+                    if let (Some(sl), Some(dl)) = (base_local(*src), base_local(*dest)) {
+                        if matches!(src, Place::Local(_)) && matches!(dest, Place::Local(_)) {
+                            if let Some(&alias) = carrier_of.get(&sl) {
+                                if let std::collections::hash_map::Entry::Vacant(slot) =
+                                    carrier_of.entry(dl)
+                                {
+                                    slot.insert(alias);
+                                    changed = true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    // Escape scan. A chain carrier read into an owning sink is an escape; an
+    // interior descent (`RecordFieldLoad`/`TupleFieldLoad` reading the carrier —
+    // the next hop of the chain, or the consumed-match destructure) and a
+    // benign whole-value hand-off into another carrier/alias member are not.
+    // Any owning use this walk cannot classify bails the whole pass.
+    let mut escapes: Vec<(u32, u32, usize)> = Vec::new();
+    for block in blocks {
+        for (idx, instr) in block.instructions.iter().enumerate() {
+            match instr {
+                // Interior descent read: feeds the next hop, never escapes.
+                Instr::RecordFieldLoad { .. } | Instr::TupleFieldLoad { .. } => {}
+                Instr::Move { dest, src } => {
+                    if let Some(sl) = base_local(*src).filter(|_| matches!(src, Place::Local(_))) {
+                        if let Some(&escapee) = carrier_of.get(&sl) {
+                            let dest_local =
+                                base_local(*dest).filter(|_| matches!(dest, Place::Local(_)));
+                            let benign = dest_local.is_some_and(|dl| {
+                                carrier_of.contains_key(&dl) || alias_of.contains_key(&dl)
+                            });
+                            if !benign {
+                                escapes.push((escapee, block.id, idx));
+                            }
+                        }
+                    }
+                }
+                Instr::RecordInit { fields, .. } => {
+                    for (_, place) in fields {
+                        if let Some(l) = base_local(*place) {
+                            if let Some(&escapee) = carrier_of.get(&l) {
+                                escapes.push((escapee, block.id, idx));
+                            }
+                        }
+                    }
+                }
+                Instr::RecordFieldStore { src, .. } => {
+                    if let Some(l) = base_local(*src) {
+                        if let Some(&escapee) = carrier_of.get(&l) {
+                            escapes.push((escapee, block.id, idx));
+                        }
+                    }
+                }
+                other => {
+                    let (reads, _) = crate::dataflow::instr_reads_writes(other);
+                    for place in reads {
+                        if let Some(l) = base_local(place) {
+                            if carrier_of.contains_key(&l)
+                                && !binder_read_is_borrow_safe_instr(other, l)
+                            {
+                                // An owning use of a chain alias this walk does
+                                // not model: fail closed (leak-as-before).
+                                return Vec::new();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        for place in terminator_source_places(&block.terminator, suspend_kinds.get(&block.id)) {
+            if let Some(l) = base_local(place) {
+                if carrier_of.contains_key(&l)
+                    && !binder_read_is_borrow_safe_terminator(
+                        &block.terminator,
+                        suspend_kinds.get(&block.id),
+                        l,
+                    )
+                {
+                    // A terminator escape has no post-escape insertion point.
+                    return Vec::new();
+                }
+            }
+        }
+    }
+
+    // Exactly one chain alias may escape, at a single instruction.
+    let &[(escapee, esc_block, esc_idx)] = &escapes[..] else {
+        return Vec::new();
+    };
+
+    // Walk the escapee's immediate-parent chain to its candidate root, recording
+    // `(node_local, field-that-leads-to-the-next-hop)` at each level. Requires ≥2
+    // byte-copy hops and a clean termination at a candidate record root.
+    let mut chain_nodes: Vec<(u32, u32)> = Vec::new();
+    let mut cursor = escapee;
+    let mut reached_root = false;
+    for _ in 0..=parent_of.len() {
+        let Some(&(parent, field)) = parent_of.get(&cursor) else {
+            break;
+        };
+        chain_nodes.push((parent, field));
+        if root_record_ty.contains_key(&parent) {
+            reached_root = true;
+            break;
+        }
+        cursor = parent;
+    }
+    if !reached_root || chain_nodes.len() < 2 {
+        return Vec::new();
+    }
+
+    // No node of the chain (root, intermediate aliases, escapee carriers) may be
+    // read after the escape point — discharging a sibling before a live read
+    // would free a slot the read still observes. A self-reachable escape block is
+    // a loop the inline-composite discharges cannot make idempotent.
+    let node_locals: HashSet<u32> = chain_nodes
+        .iter()
+        .map(|&(node, _)| node)
+        .chain(carrier_of.keys().copied())
+        .collect();
+    let reach = blocks_reachable_from(blocks, esc_block);
+    if reach.contains(&esc_block) {
+        return Vec::new();
+    }
+    let in_region = |block_id: u32, position: Option<usize>| -> bool {
+        if block_id == esc_block {
+            position.is_none_or(|i| i > esc_idx)
+        } else {
+            reach.contains(&block_id)
+        }
+    };
+    for block in blocks {
+        for (idx, instr) in block.instructions.iter().enumerate() {
+            if block.id == esc_block && idx == esc_idx {
+                // The escape instruction itself reads the escapee; that read is
+                // AT the escape, not after it.
+                continue;
+            }
+            let reads_node = instr_source_places(instr)
+                .into_iter()
+                .filter_map(base_local)
+                .any(|l| node_locals.contains(&l));
+            if reads_node && in_region(block.id, Some(idx)) {
+                return Vec::new();
+            }
+        }
+        let term_reads_node =
+            terminator_source_places(&block.terminator, suspend_kinds.get(&block.id))
+                .into_iter()
+                .filter_map(base_local)
+                .any(|l| node_locals.contains(&l));
+        if term_reads_node && in_region(block.id, None) {
+            return Vec::new();
+        }
+    }
+
+    // Emit the per-level sibling discharges: at each chain node, every owned
+    // field except the one that leads to the next (escaping) hop.
+    let mut siblings: Vec<Instr> = Vec::new();
+    for &(node_local, escaped_field) in &chain_nodes {
+        let Some(node_ty) = local_tys.get(node_local as usize) else {
+            continue;
+        };
+        for (field_idx, field_ty) in owned_field_list(node_ty) {
+            if field_idx == escaped_field || !field_dischargeable(&field_ty) {
+                continue;
+            }
+            siblings.push(Instr::FieldDropInPlace {
+                base: Place::Local(node_local),
+                field: crate::model::FieldAddr::Record(FieldOffset(field_idx)),
+                ty: field_ty,
+            });
+        }
+    }
+    if siblings.is_empty() {
+        return Vec::new();
+    }
+    vec![(esc_block, esc_idx + 1, siblings)]
 }
 
 /// W5.020 — fail-closed sole-owner derivation for **heap-owning enum
@@ -46392,6 +46730,7 @@ mod escaped_sibling_field_discharge {
             local_tys,
             &field_orders(),
             &[],
+            &[],
             &is_rec,
             &owned_fields,
             &dischargeable,
@@ -46750,6 +47089,7 @@ mod escaped_sibling_field_discharge {
             &binding_locals,
             &local_tys,
             &field_orders(),
+            &[],
             &[],
             &is_rec,
             &three_fields,

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -38,7 +38,11 @@ use crate::model::{
     Strategy, SuspendKind, Terminator, ThirFunction, TraitObjectStorage, TrapKind,
 };
 use crate::ownership::FailClosedReason;
+use crate::ownership::LayoutClass;
 use crate::ownership::OwnershipCtx;
+use crate::ownership::OwnershipDecision;
+use crate::ownership::PlaceProvenance;
+use crate::ownership::Projection;
 use crate::ownership::ReleaseSymbolVerdict;
 use crate::ownership::ValueOwnership;
 use crate::ownership::ValueProvenance;
@@ -8070,6 +8074,7 @@ fn lower_function(
     );
     let mut source_excluded = returned_aggregate_members;
     source_excluded.extend(consumed_local_aggregate_members);
+    let alias_field_binders = builder.alias_owner_field_binders();
     let tuple_composite_drop_allowed = derive_tuple_composite_drop_allowed(
         &raw.blocks,
         &raw.suspend_kinds,
@@ -8078,6 +8083,7 @@ fn lower_function(
         &builder.locals,
         &builder.record_field_orders,
         &builder.enum_layouts,
+        &alias_field_binders,
     );
     let is_owned_record = |ty: &ResolvedTy| builder.is_owned_aggregate_record_ty(ty);
     let owned_record_drop_allowed = derive_owned_record_drop_allowed(
@@ -8089,6 +8095,7 @@ fn lower_function(
         &is_owned_record,
         &builder.record_field_orders,
         &builder.enum_layouts,
+        &alias_field_binders,
     );
     let mut composite_drop_allowed = tuple_composite_drop_allowed;
     composite_drop_allowed.extend(owned_record_drop_allowed);
@@ -8714,6 +8721,44 @@ enum Disposition {
     /// `VecIter` cursor handle declared in a nested block), so the release fires
     /// once per outer-loop iteration instead of accumulating to function exit.
     ScopeReleased,
+    /// A byte-copy interior ALIAS of a still-live owner: the binder of a
+    /// `let mid = o.mid` / `let inner = t.0` field projection whose field type
+    /// is an inline aggregate (record / tuple / inline-enum). Codegen byte-copies
+    /// such a field with no retain, so the binder does not own the copied heap —
+    /// the projected root's composite drop frees every original exactly once.
+    /// Dispositioned off the scope-exit-live set so (a) the function-exit LIFO
+    /// pass emits no composite drop for the alias (a re-walk of heap the root
+    /// still owns would double-free), and (b) the alias's base local is excluded
+    /// from the record/tuple provers' `release_owner_bases` derivation, so an
+    /// alias binder no longer trips their Defect-1 blanket every-root exclusion.
+    /// The owner it aliases is named on the entry's `provenance`
+    /// ([`OwnershipDecision::InteriorAlias`]-shaped). This is the recorded twin
+    /// of the whole-local alias classifier
+    /// [`Builder::local_storage_is_interior_alias`].
+    AliasOf,
+}
+
+/// The three-way ownership class of a `let`-bound field load — the frozen
+/// classification [`Builder::classify_field_load`] returns, mirroring exactly
+/// what codegen emits for a `RecordFieldLoad` / `TupleFieldLoad`. Only
+/// [`ByteCopyAlias`](FieldLoadClass::ByteCopyAlias) changes drop behaviour (it
+/// dispositions the binder [`Disposition::AliasOf`]); the other two keep today's
+/// `ScopeExit` ownership. Misassigning a class is the load-bearing double-free
+/// risk, so it keys on the same facts codegen implements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FieldLoadClass {
+    /// A `string` field: codegen `hew_string_clone`s the load, so the binder
+    /// owns a fresh `+1` released by its own drop; the root keeps the original.
+    Retained,
+    /// An inline aggregate field (record / tuple / array / inline-enum): the load
+    /// byte-copies the member with no retain, so the binder is an interior ALIAS
+    /// — the projected root's composite drop frees every original exactly once.
+    ByteCopyAlias,
+    /// A single-pointer heap leaf (`Vec` / `bytes` / `HashMap` / `HashSet` /
+    /// `Generator` / indirect-enum node): the load transfers the one owned
+    /// handle, so the binder becomes the owner and the root's whole-root
+    /// exclusion posture is correct.
+    HandleTransfer,
 }
 
 /// One entry in the per-function owned-locals ledger: the binding whose
@@ -9723,6 +9768,218 @@ impl Builder {
             provenance: None,
             disposition: Disposition::ScopeExit,
         });
+    }
+
+    /// Register a `let`-bound field projection whose result is a byte-copy
+    /// interior ALIAS of the still-live owner named by `provenance` — the
+    /// [`ByteCopyAlias`](FieldLoadClass::ByteCopyAlias) class of the field-load
+    /// three-way split (record / tuple / inline-enum aggregate field). The entry
+    /// carries its
+    /// [`OwnershipDecision::InteriorAlias`]-shaped provenance and is minted
+    /// [`Disposition::AliasOf`], so it drops out of the scope-exit-live view the
+    /// drop-elaboration provers and `build_lifo_drops` read: the alias emits no
+    /// composite drop of its own (the owner's composite frees the whole tree),
+    /// and its base local never seeds the record/tuple provers'
+    /// `release_owner_bases`, so it no longer trips their Defect-1 blanket
+    /// exclusion of every root (#2375).
+    fn register_owned_local_alias(
+        &mut self,
+        binding: BindingId,
+        name: String,
+        ty: ResolvedTy,
+        provenance: ValueProvenance,
+    ) {
+        let place = self
+            .binding_locals
+            .get(&binding)
+            .copied()
+            .unwrap_or(Place::Local(0));
+        let ownership = ValueOwnership::classify(&ty, place, &self.ownership_ctx());
+        self.owned_locals.push(OwnedLocalEntry {
+            binding,
+            name,
+            ty,
+            ownership,
+            provenance: Some(provenance),
+            disposition: Disposition::AliasOf,
+        });
+    }
+
+    /// Provenance of a `let`-bound field projection that is a byte-copy interior
+    /// ALIAS of a still-live owner — the
+    /// [`ByteCopyAlias`](FieldLoadClass::ByteCopyAlias) class of the three-way
+    /// field-load classification. Returns `Some` ONLY for a `root.field` /
+    /// `root.N` projection (`let mid = o.mid`, `let inner = t.0`) of a live
+    /// binding whose FIELD type is an inline aggregate
+    /// (`OwnsHeap { layout: Product | TaggedUnion }` — record / tuple /
+    /// inline-enum). Codegen byte-copies such a field with no retain, so the
+    /// binder does not own the copied heap; the projected root's composite drop
+    /// frees every original exactly once.
+    ///
+    /// Returns `None` — keeping today's `ScopeExit` ownership — for the other two
+    /// load classes the split names, so their behaviour is unchanged:
+    /// [`Retained`](FieldLoadClass::Retained) (a `string` field: codegen
+    /// `hew_string_clone`s the load, so the binder owns a fresh `+1` released by
+    /// its own drop) and [`HandleTransfer`](FieldLoadClass::HandleTransfer) (a
+    /// single-pointer heap leaf — `Vec` / `bytes` / `HashMap` / `HashSet` /
+    /// `Generator` / indirect-enum node: the load transfers the one handle, the
+    /// binder becomes the owner, and the root's whole-root exclusion posture is
+    /// correct).
+    ///
+    /// It also returns `None` for any non-projection RHS (a fresh call result /
+    /// constructor owns itself) and whenever the owner root cannot be named at
+    /// this defining write — so unrecorded provenance keeps the fail-closed
+    /// blanket (leak-never-double-free).
+    ///
+    /// The mirror of the whole-local classifier
+    /// [`Builder::local_storage_is_interior_alias`]; this one keys on the FIELD
+    /// TYPE so the `string`-retain class is separated from the aggregate
+    /// byte-copy class, which the whole-local walk does not distinguish.
+    fn field_projection_alias_provenance(
+        &self,
+        value: &HirExpr,
+        binding_ty: &ResolvedTy,
+    ) -> Option<ValueProvenance> {
+        // Only an inline aggregate field is a ByteCopyAlias. `string` (Retained)
+        // and single-pointer handles (HandleTransfer) keep `ScopeExit`
+        // ownership — the exact facts codegen implements (retain vs copy vs
+        // transfer), so the classification cannot admit an owner the binder
+        // also releases (the load-bearing double-free risk).
+        if self.classify_field_load(binding_ty) != Some(FieldLoadClass::ByteCopyAlias) {
+            return None;
+        }
+        // The RHS must be a field projection of a live owner: `root.field` /
+        // `root.N`. A fresh producer (call result / constructor) owns itself.
+        let (root_binding, projection) = match &value.kind {
+            HirExprKind::FieldAccess { object, field } => {
+                let root = binding_ref_target(object)?;
+                let ordinal = self.record_field_ordinal(object, field)?;
+                (root, Projection::Field(ordinal))
+            }
+            HirExprKind::TupleIndex { tuple, index } => {
+                let root = binding_ref_target(tuple)?;
+                let ordinal = u32::try_from(*index).ok()?;
+                (root, Projection::Field(ordinal))
+            }
+            _ => return None,
+        };
+        let root_place = self.binding_locals.get(&root_binding).copied()?;
+        Some(ValueProvenance::projection(
+            PlaceProvenance::from(root_place),
+            vec![projection],
+        ))
+    }
+
+    /// The three-way ownership class of a `let`-bound field LOAD, keyed on the
+    /// field type and frozen to mirror exactly what codegen emits for the load.
+    /// Returns `None` for a heap-free field (no drop obligation to classify).
+    /// This is the authority the field-projection alias seam and its verdict-
+    /// table pin read; misassigning a class here is the load-bearing double-free
+    /// risk, so it keys on the same facts codegen implements.
+    fn classify_field_load(&self, ty: &ResolvedTy) -> Option<FieldLoadClass> {
+        let ty = self.subst_ty(ty);
+        let owned = ValueOwnership::classify(&ty, Place::Local(0), &self.ownership_ctx());
+        match owned.decision() {
+            // Inline aggregate (record / tuple / array / inline-enum): the load
+            // byte-copies the member with no retain, so the binder is an
+            // interior alias the owner's composite still frees.
+            OwnershipDecision::OwnsHeap {
+                layout: LayoutClass::Product | LayoutClass::TaggedUnion,
+                ..
+            } => Some(FieldLoadClass::ByteCopyAlias),
+            // Every other heap-owning field is a single release handle. `string`
+            // is the ONE retaining leaf (codegen `hew_string_clone`s the load →
+            // the binder owns a fresh `+1`); every other leaf (`Vec` / `bytes` /
+            // `HashMap` / `HashSet` / `Generator` / indirect-enum node) transfers
+            // its one handle to the binder.
+            OwnershipDecision::OwnsHeap { .. } => {
+                if matches!(ty, ResolvedTy::String) {
+                    Some(FieldLoadClass::Retained)
+                } else {
+                    Some(FieldLoadClass::HandleTransfer)
+                }
+            }
+            // Heap-free / borrowed / already-an-alias / unsupported: no
+            // scope-exit drop obligation for the field-projection seam to record.
+            _ => None,
+        }
+    }
+
+    /// Declaration-order ordinal of `field` on the record type of `object`, from
+    /// the field-order table. `None` when the object type is not a registered
+    /// record (a tuple projection uses its literal index instead).
+    fn record_field_ordinal(&self, object: &HirExpr, field: &str) -> Option<u32> {
+        let ResolvedTy::Named {
+            name: type_name, ..
+        } = self.subst_ty(&object.ty)
+        else {
+            return None;
+        };
+        let order = self.lookup_record_field_order(type_name.as_str())?;
+        let idx = order.iter().position(|(f, _)| f == field)?;
+        u32::try_from(idx).ok()
+    }
+
+    /// The `(alias_local, owner_root_local)` pairs for every `AliasOf` ledger
+    /// entry: a `let mid = o.mid` / `let leaf = mid.leaf` byte-copy interior
+    /// alias mapped to the base local of the still-live OWNER root its recorded
+    /// provenance chains to, resolving intermediate aliases to the first
+    /// non-alias owner (a `leaf -> mid -> o` chain resolves both `leaf` and
+    /// `mid` to `o`).
+    ///
+    /// The record and tuple composite provers fold these into their field-
+    /// binder set. The whole-value alias map and the field-load scan they build
+    /// from the instruction stream only reach a ONE-hop alias (`mid` reads the
+    /// root directly, so it is collected); a DEEPER alias (`leaf` reads `mid`,
+    /// not the root) is invisible to them. Without the carried provenance a deep
+    /// alias that ESCAPES into an owning sink (returned, stored into an owning
+    /// record, sent) would leave the owner's composite admitted to free a
+    /// subtree the escapee already handed to the caller — a double-free. Folding
+    /// the recorded alias in, attributed to its owner, excludes exactly that
+    /// owner when the deep alias escapes, and leaves the owner admitted when the
+    /// alias is only read interiorly (the consumed-match path).
+    ///
+    /// An entry whose owner root is not a nameable local is dropped — the prover
+    /// keeps its fail-closed blanket for it (leak, never double-free).
+    fn alias_owner_field_binders(&self) -> Vec<(u32, u32)> {
+        // One hop: each alias's base local -> its recorded provenance root local.
+        // Keyed on the carried alias PROVENANCE, not the live disposition: a
+        // recorded byte-copy alias that is later consumed (moved into the return
+        // slot / a sink) is dispositioned off `AliasOf`, but consuming an alias
+        // moves no ownership — the owner still holds the heap. Its escape must
+        // still exclude the owner, so the provenance keeps it in scope here even
+        // after the disposition flips.
+        let mut one_hop: HashMap<u32, u32> = HashMap::new();
+        for entry in &self.owned_locals {
+            let Some(PlaceProvenance::Local(root_local)) =
+                entry.provenance.as_ref().map(|p| p.root)
+            else {
+                continue;
+            };
+            let Some(alias_local) = self
+                .binding_locals
+                .get(&entry.binding)
+                .and_then(|p| base_local(*p))
+            else {
+                continue;
+            };
+            one_hop.insert(alias_local, root_local);
+        }
+        // Resolve each alias to the ultimate owner by chasing intermediate
+        // aliases. The hop count is bounded by the alias count, so the walk
+        // terminates even if a (malformed) cycle ever appears.
+        let mut resolved = Vec::with_capacity(one_hop.len());
+        for (&alias_local, &first_root) in &one_hop {
+            let mut owner = first_root;
+            for _ in 0..one_hop.len() {
+                match one_hop.get(&owner) {
+                    Some(&next) => owner = next,
+                    None => break,
+                }
+            }
+            resolved.push((alias_local, owner));
+        }
+        resolved
     }
 
     /// The scope-exit-live owned locals as `(binding, name, ty)` tuples — the
@@ -12512,7 +12769,29 @@ impl Builder {
                     // no backend Place, so it must not enter
                     // `owned_locals` either. LESSONS:
                     // boundary-fail-closed, raii-null-after-move.
-                    self.register_owned_local(binding.id, binding.name.clone(), binding_ty.clone());
+                    //
+                    // A `let mid = o.mid` / `let inner = t.0` projection whose
+                    // field is an inline aggregate is a byte-copy interior ALIAS
+                    // (`field_projection_alias_provenance` — the ByteCopyAlias
+                    // class): register it `AliasOf` so the owner's composite
+                    // frees the tree and the alias never trips the composite
+                    // provers' blanket (#2375). Every other binding — including
+                    // the `string`-Retained and single-pointer HandleTransfer
+                    // load classes, and every fresh producer — keeps its
+                    // `ScopeExit` ownership.
+                    match self.field_projection_alias_provenance(value, &binding_ty) {
+                        Some(provenance) => self.register_owned_local_alias(
+                            binding.id,
+                            binding.name.clone(),
+                            binding_ty.clone(),
+                            provenance,
+                        ),
+                        None => self.register_owned_local(
+                            binding.id,
+                            binding.name.clone(),
+                            binding_ty.clone(),
+                        ),
+                    }
                     // Tag generator/`AsyncGenerator` handle bindings with their
                     // declaring scope so a per-scope-exit `hew_gen_coro_destroy` fires
                     // when the scope closes — covering the loop-re-entry case the
@@ -32673,6 +32952,7 @@ fn elaborate(
     // arm but live on another is still dropped on the live arm. The legacy
     // `owned_string_record_bindings` membership is folded into the same gate (a
     // string record is a subset of the owned-aggregate records covered here).
+    let alias_field_binders = builder.alias_owner_field_binders();
     let is_owned_record = |ty: &ResolvedTy| builder.is_owned_aggregate_record_ty(ty);
     let owned_record_drop_allowed = derive_owned_record_drop_allowed(
         &checked.blocks,
@@ -32683,6 +32963,7 @@ fn elaborate(
         &is_owned_record,
         &builder.record_field_orders,
         &builder.enum_layouts,
+        &alias_field_binders,
     );
 
     // W5.021 — fail-closed sole-owner allow-set for heap-owning **tuple**
@@ -32703,6 +32984,7 @@ fn elaborate(
         &builder.locals,
         &builder.record_field_orders,
         &builder.enum_layouts,
+        &alias_field_binders,
     );
 
     // W5.021 (defect #1) — owned members the caller now owns via a returned
@@ -34051,6 +34333,41 @@ fn propagate_whole_value_alias_roots(
 /// `derive_owned_record_drop_allowed` (the composite-drop prover) and
 /// `apply_escaped_record_sibling_field_drops` (the #2212 sibling-discharge
 /// emitter) so the two agree on what counts as a field binder.
+/// Forward whole-value-`Move` closure of the recorded interior-alias binders:
+/// starting from each `(alias_local, owner_local)` seed, every local the alias
+/// value flows into via `Move { dest, src }` inherits the same owner. The
+/// record and tuple composite provers fold the whole closure into their binder
+/// set (and, for records, its provenance) so a deep projection alias that
+/// escapes through a return / hand-off temp (`ret = move leaf`) still names the
+/// owner it aliases — the field-load scan's own move-propagation runs before
+/// the alias is folded in, so it never reaches these copies.
+fn close_alias_binders_forward(blocks: &[BasicBlock], seeds: &[(u32, u32)]) -> HashMap<u32, u32> {
+    let mut owner_of: HashMap<u32, u32> = seeds.iter().copied().collect();
+    loop {
+        let mut changed = false;
+        for block in blocks {
+            for instr in &block.instructions {
+                if let Instr::Move { dest, src } = instr {
+                    if let (Some(sl), Some(dl)) = (base_local(*src), base_local(*dest)) {
+                        if let Some(&owner) = owner_of.get(&sl) {
+                            if let std::collections::hash_map::Entry::Vacant(slot) =
+                                owner_of.entry(dl)
+                            {
+                                slot.insert(owner);
+                                changed = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    owner_of
+}
+
 fn collect_record_field_binders(
     blocks: &[BasicBlock],
     alias_of: &HashMap<u32, u32>,
@@ -34311,6 +34628,20 @@ fn place_is_interior_projection(place: Place) -> bool {
         | Place::RecvHalf(_)
         | Place::MachineTag(_)
         | Place::EnumTag(_) => true,
+    }
+}
+
+/// The [`BindingId`] a `root.field` / `root.N` projection's object resolves to
+/// when it is a direct reference to a live binding. `None` for a nested or
+/// non-binding object (a projection chain, a call result, `this`) — the caller
+/// then fails closed and records no alias provenance.
+fn binding_ref_target(object: &HirExpr) -> Option<BindingId> {
+    match &object.kind {
+        HirExprKind::BindingRef {
+            resolved: ResolvedRef::Binding(id),
+            ..
+        } => Some(*id),
+        _ => None,
     }
 }
 
@@ -37120,6 +37451,7 @@ fn derive_owned_record_drop_allowed(
     is_owned_record: &dyn Fn(&ResolvedTy) -> bool,
     record_field_orders: &HashMap<String, Vec<(String, ResolvedTy)>>,
     enum_layouts: &[crate::model::EnumLayout],
+    alias_field_binders: &[(u32, u32)],
 ) -> HashSet<BindingId> {
     // A local carries a heap-owning value iff its registered type says so. Used
     // to decide whether a `RecordFieldLoad` dest is an owned-field binder (a
@@ -37168,11 +37500,35 @@ fn derive_owned_record_drop_allowed(
     // Owned-field-binder set: destinations of `RecordFieldLoad { record: alias-
     // set member }` whose loaded field is itself heap-owning, closed forward
     // through whole-value Move so a binder copied onward is still tracked.
-    let field_binders = collect_record_field_binders(blocks, &alias_of, &local_is_heap_owning);
+    let mut field_binders = collect_record_field_binders(blocks, &alias_of, &local_is_heap_owning);
     // Per-binder escape attribution (#2212): where the load scan + alias map
     // prove which root a binder came from, its escape excludes exactly that
     // root; unprovable provenance keeps the blanket every-root exclusion.
-    let binder_provenance = attribute_field_binder_provenance(blocks, &alias_of, &field_binders);
+    let mut binder_provenance =
+        attribute_field_binder_provenance(blocks, &alias_of, &field_binders);
+
+    // Fold the recorded byte-copy interior-alias binders (the `let mid = o.mid;
+    // let leaf = mid.leaf` projection chain) into the field-binder set,
+    // attributed to the OWNER root their carried provenance chains to. The
+    // whole-value alias map + the `RecordFieldLoad` scan above only reach a ONE-
+    // hop alias (`mid` reads the record root directly); a deeper alias (`leaf`
+    // reads `mid`, not the root) is invisible to them, so its ESCAPE would leave
+    // the owner admitted to free a subtree the escapee handed to the caller (the
+    // #2375 double-free). Recording it here excludes exactly the owner when the
+    // deep alias escapes, and — because a `RecordFieldLoad` reading the alias is
+    // interior (exempt) — leaves the owner admitted when the alias is only read
+    // interiorly (the consumed-match path). `or_insert` never overrides the
+    // precise `Unique { root, field }` a one-hop binder already earned (the
+    // sibling-discharge emitter needs that field).
+    for (&alias_local, &owner_local) in &close_alias_binders_forward(blocks, alias_field_binders) {
+        if !candidate_local_to_binding.contains_key(&owner_local) {
+            continue;
+        }
+        field_binders.insert(alias_local);
+        binder_provenance
+            .entry(alias_local)
+            .or_insert(FieldBinderProvenance::RootOnly { root: owner_local });
+    }
 
     let mut excluded_roots: HashSet<u32> = HashSet::new();
 
@@ -38018,6 +38374,13 @@ fn derive_local_bytes_drop_allowed(
               escape scan) sharing fixpoint state, mirroring derive_owned_\
               record_drop_allowed; splitting scatters the fail-closed ordering"
 )]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the function's MIR + binding registries + the layout lookups + the \
+              carried interior-alias binder pairs the composite prover reads; a \
+              struct would only relocate the same fields, mirroring \
+              derive_owned_record_drop_allowed"
+)]
 fn derive_tuple_composite_drop_allowed(
     blocks: &[BasicBlock],
     suspend_kinds: &HashMap<u32, SuspendKind>,
@@ -38026,6 +38389,7 @@ fn derive_tuple_composite_drop_allowed(
     local_tys: &[ResolvedTy],
     record_field_orders: &HashMap<String, Vec<(String, ResolvedTy)>>,
     enum_layouts: &[crate::model::EnumLayout],
+    alias_field_binders: &[(u32, u32)],
 ) -> HashSet<BindingId> {
     // A local carries a heap-owning value iff its registered type says so. Used
     // to decide whether a `TupleFieldLoad` dest is an owned-element binder (a
@@ -38097,6 +38461,21 @@ fn derive_tuple_composite_drop_allowed(
         }
         if !changed {
             break;
+        }
+    }
+
+    // Fold the recorded byte-copy interior-alias binders (the `let mid = o.0;
+    // let leaf = mid.0` projection chain) into the element-binder set. The
+    // `TupleFieldLoad` scan above only reaches a ONE-hop alias (`mid` reads the
+    // tuple root directly); a deeper alias (`leaf` reads `mid`, not the root) is
+    // invisible to it, so its ESCAPE would leave the owner admitted to free a
+    // subtree the escapee handed to the caller (the tuple twin of the #2375
+    // double-free). Recording it here makes `note_elem_escape` exclude the tuple
+    // roots when the deep alias escapes; a `TupleFieldLoad` reading the alias is
+    // interior (exempt), so the owner stays admitted on the consumed-match path.
+    for (&alias_local, &owner_local) in &close_alias_binders_forward(blocks, alias_field_binders) {
+        if candidate_local_to_binding.contains_key(&owner_local) {
+            elem_binders.insert(alias_local);
         }
     }
 
@@ -45421,6 +45800,7 @@ mod owned_record_drop_derivation {
             &is_rec,
             &record_field_orders,
             &[],
+            &[],
         )
     }
 
@@ -46420,6 +46800,7 @@ mod tuple_composite_field_drop_exclusion {
             &local_tys,
             &HashMap::new(),
             &[],
+            &[],
         );
         (b, allowed)
     }
@@ -46496,6 +46877,7 @@ mod tuple_composite_field_drop_exclusion {
             &binding_locals,
             &local_tys,
             &HashMap::new(),
+            &[],
             &[],
         );
         assert!(
@@ -49313,6 +49695,112 @@ mod binding_ty_is_plain_vec_tuple {
         );
     }
 
+    /// Frozen three-way verdict table for the `let`-bound field-load
+    /// classification — the load-bearing double-free boundary. A `string` field retains
+    /// (codegen clones), an inline aggregate (record / tuple) byte-copies to an
+    /// interior alias, and every single-pointer heap leaf (`Vec` / `bytes` /
+    /// `Generator` / indirect-enum node) transfers its one handle. Only
+    /// `ByteCopyAlias` dispositions its binder `AliasOf`; the table freezes the
+    /// class each shape maps to so a mis-tag (which would admit an owner the
+    /// binder also releases — a double-free) fails this test first.
+    #[test]
+    fn classify_field_load_freezes_the_three_way_verdict_table() {
+        let mut builder = builder_with_indirect_enum();
+        // A heap-owning user record `Rec { a: string }`.
+        builder.record_field_orders.insert(
+            "Rec".to_string(),
+            vec![("a".to_string(), ResolvedTy::String)],
+        );
+
+        // Retained: `string` — codegen `hew_string_clone`s the load.
+        assert_eq!(
+            builder.classify_field_load(&ResolvedTy::String),
+            Some(FieldLoadClass::Retained),
+        );
+
+        // ByteCopyAlias: inline aggregates — record and tuple.
+        assert_eq!(
+            builder.classify_field_load(&unregistered_named("Rec")),
+            Some(FieldLoadClass::ByteCopyAlias),
+            "a heap-owning record field is byte-copied to an interior alias",
+        );
+        assert_eq!(
+            builder.classify_field_load(&ResolvedTy::Tuple(vec![
+                ResolvedTy::String,
+                ResolvedTy::String,
+            ])),
+            Some(FieldLoadClass::ByteCopyAlias),
+            "a heap-owning tuple field is byte-copied to an interior alias",
+        );
+
+        // HandleTransfer: every single-pointer heap leaf.
+        for (label, ty) in [
+            ("Vec", vec_of_ty(ResolvedTy::String)),
+            ("bytes", ResolvedTy::Bytes),
+            (
+                "Generator",
+                ResolvedTy::named_builtin(
+                    "Generator",
+                    BuiltinType::Generator,
+                    vec![ResolvedTy::I64, ResolvedTy::Unit],
+                ),
+            ),
+            ("indirect enum", unregistered_named("Foo")),
+        ] {
+            assert_eq!(
+                builder.classify_field_load(&ty),
+                Some(FieldLoadClass::HandleTransfer),
+                "{label} transfers its one owned handle to the binder",
+            );
+        }
+
+        // Heap-free field: no scope-exit drop obligation to classify.
+        assert_eq!(builder.classify_field_load(&ResolvedTy::I64), None);
+    }
+
+    /// A byte-copy aggregate field projection registers its binder `AliasOf`
+    /// with the owner's provenance recorded — and that disposition removes it
+    /// from the scope-exit-live view the record/tuple provers and
+    /// `build_lifo_drops` read, so the alias emits no composite drop of its own
+    /// and its base local never seeds the provers' `release_owner_bases` (the
+    /// #2375 blanket no longer trips). The entry survives in the whole ledger.
+    #[test]
+    fn byte_copy_alias_registers_aliasof_and_leaves_the_live_view() {
+        let mut builder = builder_with_indirect_enum();
+        builder.record_field_orders.insert(
+            "Rec".to_string(),
+            vec![("a".to_string(), ResolvedTy::String)],
+        );
+        builder.binding_locals.insert(BindingId(1), Place::Local(7));
+
+        let provenance =
+            ValueProvenance::projection(PlaceProvenance::Local(3), vec![Projection::Field(0)]);
+        builder.register_owned_local_alias(
+            BindingId(1),
+            "mid".to_string(),
+            unregistered_named("Rec"),
+            provenance.clone(),
+        );
+
+        let entry = &builder.owned_locals[0];
+        assert_eq!(entry.disposition, Disposition::AliasOf);
+        assert_eq!(
+            entry.provenance.as_ref(),
+            Some(&provenance),
+            "the owner it aliases is recorded on the entry",
+        );
+        assert!(
+            builder.owned_locals_snapshot().is_empty(),
+            "an AliasOf entry is excluded from the scope-exit-live drop view — no \
+             composite drop, and it never seeds the provers' release_owner_bases",
+        );
+        assert_eq!(
+            builder.owned_locals_ledger().len(),
+            1,
+            "the alias survives in the whole ledger regardless of disposition",
+        );
+    }
+
     /// Retraction is a disposition write, not a physical removal: a binding
     /// dispositioned off the scope-exit set leaves the live drop view
     /// (`owned_locals_snapshot`) yet stays observable in the whole ledger
@@ -49589,7 +50077,7 @@ mod drop_admission_type_shape_pins {
     //! reclassification. An admission that widens over-drops (double-free,
     //! the worst outcome); one that narrows leaks.
     use super::*;
-    use crate::ownership::{DropClass, HeapLeaf, OwnershipDecision};
+    use crate::ownership::{DropClass, HeapLeaf};
 
     fn vec_of(elem: ResolvedTy) -> ResolvedTy {
         ResolvedTy::named_builtin("Vec", BuiltinType::Vec, vec![elem])

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -7993,14 +7993,21 @@ fn lower_function(
     // built; emits an ElaboratedMirFunction whose `blocks` + `drop_plans`
     // are the authoritative description of what fires on every exit.
     //
-    // The integer-only spine never lowers `@resource` or `@linear`
-    // bindings (no construction surface yet for those types — see
-    // R-C3.5), so on the current ladder `owned_locals` is empty
-    // whenever the function passed type-checking AND the only
-    // non-BitCopy class reaching MIR is `CowValue` (e.g. String) which
-    // does not emit a Drop. The elaboration shape is exercised by
-    // hew-mir's unit tests that hand-construct CheckedMirFunction
-    // inputs with synthesized DecisionFact::value_class values.
+    // `owned_locals` is the per-function ownership ledger. Every binding
+    // whose type obliges a scope-exit drop (`binding_seeds_drop_elaboration`
+    // — `string`, `Vec<E>`, records, collection handles, generators, closure
+    // pairs, resource fields) is registered once at its defining write
+    // through `Builder::register_owned_local`, carrying its classified
+    // `ValueOwnership`, any interior-alias `ValueProvenance`, and a
+    // `Disposition`. The elaborator reads the scope-exit-live view of that
+    // ledger (a consumed / body-end-released binding carries a
+    // non-`ScopeExit` disposition rather than being physically removed), and
+    // the carried provenance keeps a byte-copy field alias from being
+    // mistaken for an independent owner. The pass runs on every function
+    // body and is exercised end-to-end by the compiled leak-oracle
+    // fixtures — real programs whose native binaries are proven leak- and
+    // double-free-clean under `leaks --atExit` and the poisoned allocator —
+    // as well as by hew-mir's hand-constructed CheckedMirFunction unit inputs.
     let elaborated = elaborate(&checked, &builder, &thir.statements, &dataflow_result);
 
     // Fail-closed validation of the elaborated drop plan. Surfaces a

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -8683,22 +8683,37 @@ struct FungibleChildRef {
     slot_index: u32,
 }
 
-/// How an owned local's release obligation is currently dispositioned within the
-/// per-function ledger. The live drop-elaboration view is exactly the
-/// `ScopeExit` entries — a binding whose release is handled elsewhere (moved
-/// into an aggregate, consumed, closed at an inner scope) is dispositioned off
-/// the scope-exit set rather than physically removed, so an end-of-pass scan can
-/// still see the whole ledger.
-///
-/// This stage records only `ScopeExit`; the retraction-to-disposition migration
-/// that adds the moved/consumed/inner-scope dispositions is a later drop
-/// stage. Every entry the registration authority mints is `ScopeExit`, so the
-/// live-view filter is a no-op here and behaviour is unchanged.
+/// How an owned local's release obligation is dispositioned within the
+/// per-function ledger. The live drop-elaboration view
+/// ([`Builder::owned_locals_snapshot`]) is exactly the `ScopeExit` entries — a
+/// binding whose release is handled elsewhere (consumed, released at the end of
+/// a consuming body, closed at an inner scope) is dispositioned OFF the
+/// scope-exit set rather than physically removed. The whole ledger
+/// ([`Builder::owned_locals_ledger`]) still carries the retracted entry, so an
+/// end-of-pass scan can observe a binding whose release was handled
+/// mid-lowering — the retraction-invisible class that a physical
+/// `owned_locals.retain(...)` removal used to make unobservable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Disposition {
     /// Released by the function-exit LIFO drop pass, narrowed per exit edge —
-    /// the default, and the only disposition this stage records.
+    /// the default for every entry the registration authority mints.
     ScopeExit,
+    /// Released at the end of the consuming body on every exit edge rather than
+    /// at function scope exit: a generator-yielded / channel-received `Some(x)`
+    /// payload, or a `for x in vec` string cursor, whose per-iteration heap
+    /// reference the body owns and releases each frame. Dispositioned off the
+    /// scope-exit set so the function-exit LIFO pass cannot fire a second
+    /// release on the same slot (double-free guard).
+    BodyEndReleased,
+    /// Consumed (moved out) before scope exit — the value's new owner drops it,
+    /// so the scope-exit release is suppressed. A later overwrite on a different
+    /// control-flow path is gated by the path-sensitive drop flag, independent
+    /// of this disposition.
+    ConsumedAt,
+    /// Released inline when an INNER scope closes (a generator coro frame or a
+    /// `VecIter` cursor handle declared in a nested block), so the release fires
+    /// once per outer-loop iteration instead of accumulating to function exit.
+    ScopeReleased,
 }
 
 /// One entry in the per-function owned-locals ledger: the binding whose
@@ -8748,8 +8763,10 @@ struct OwnedLocalEntry {
                   suppression in a later drop-elaboration stage"
     )]
     provenance: Option<ValueProvenance>,
-    /// How this entry's release obligation is dispositioned. `ScopeExit` (the
-    /// only value this stage records) means the function-exit LIFO pass owns it.
+    /// How this entry's release obligation is dispositioned. Minted `ScopeExit`
+    /// (the function-exit LIFO pass owns it) and retracted off that set by a
+    /// [`Builder::set_owned_local_disposition`] write when its release is handled
+    /// mid-lowering (consumed, body-end-released, inner-scope-released).
     disposition: Disposition,
 }
 
@@ -9687,7 +9704,10 @@ impl Builder {
     /// immaterial (the fallback local only feeds the never-firing handle
     /// dispatch). Provenance stays `None` at this stage — it is recorded only
     /// where a later stage can trivially prove it at the defining write. Every
-    /// entry is `Disposition::ScopeExit`.
+    /// entry is minted `Disposition::ScopeExit`; a retraction seam later
+    /// dispositions it off the scope-exit set via
+    /// [`Builder::set_owned_local_disposition`] when its release is handled
+    /// mid-lowering.
     fn register_owned_local(&mut self, binding: BindingId, name: String, ty: ResolvedTy) {
         let place = self
             .binding_locals
@@ -9707,17 +9727,58 @@ impl Builder {
 
     /// The scope-exit-live owned locals as `(binding, name, ty)` tuples — the
     /// compat shape the twelve allow-set provers, `build_lifo_drops`, and the
-    /// double-free gate consume. Every entry this stage records is
-    /// `Disposition::ScopeExit`, so the live-view filter admits all of them and
-    /// the snapshot is byte-identical to the former `owned_locals` vec (same
-    /// contents, same declaration order). The disposition seam is where a later
-    /// stage narrows the live set without a per-pass re-scan.
+    /// double-free gate consume. The `Disposition::ScopeExit` filter narrows the
+    /// ledger to exactly the bindings the function-exit LIFO pass still owns:
+    /// entries retracted by a [`Builder::set_owned_local_disposition`] write
+    /// (consumed, body-end-released, inner-scope-released) are excluded, which is
+    /// the same set the former `owned_locals.retain(...)` physical removals left
+    /// behind — so the drop-elaboration view is byte-identical to the pre-
+    /// disposition ledger. The retracted entries survive in the whole ledger
+    /// ([`Builder::owned_locals_ledger`]) for an end-of-pass scan to observe.
     fn owned_locals_snapshot(&self) -> Vec<(BindingId, String, ResolvedTy)> {
         self.owned_locals
             .iter()
             .filter(|entry| entry.disposition == Disposition::ScopeExit)
             .map(|entry| (entry.binding, entry.name.clone(), entry.ty.clone()))
             .collect()
+    }
+
+    /// The WHOLE per-function owned-locals ledger — every entry regardless of
+    /// disposition, in registration order — including bindings retracted off the
+    /// scope-exit-live set by a [`Builder::set_owned_local_disposition`] write.
+    ///
+    /// An end-of-pass scan reads this (rather than [`owned_locals_snapshot`],
+    /// the scope-exit-live view) when it must observe a binding whose release
+    /// was handled mid-lowering. Under the former physical-removal model that
+    /// binding was gone from the ledger by scan time — the retraction-invisible
+    /// class behind the double-free and #2375. The disposition write keeps the
+    /// entry observable while excluding it from the live drop set.
+    ///
+    /// [`owned_locals_snapshot`]: Builder::owned_locals_snapshot
+    #[allow(
+        dead_code,
+        reason = "whole-ledger scan option consumed by the provenance-aware \
+                  provers and end-of-pass scans in later drop-elaboration stages"
+    )]
+    fn owned_locals_ledger(&self) -> &[OwnedLocalEntry] {
+        &self.owned_locals
+    }
+
+    /// Disposition a binding OFF the scope-exit-live set — the retraction-to-
+    /// disposition replacement for `owned_locals.retain(|e| e.binding != b)`.
+    /// The entry stays in the ledger (an end-of-pass whole-ledger scan can still
+    /// observe it via [`Builder::owned_locals_ledger`]) but leaves the
+    /// scope-exit view [`Builder::owned_locals_snapshot`] projects, so the
+    /// function-exit LIFO drop pass no longer fires on it — byte-identical to the
+    /// physical removal it replaces. Sets every entry matching `binding`,
+    /// mirroring `retain`'s remove-all semantics (at most one exists in
+    /// practice).
+    fn set_owned_local_disposition(&mut self, binding: BindingId, disposition: Disposition) {
+        for entry in &mut self.owned_locals {
+            if entry.binding == binding {
+                entry.disposition = disposition;
+            }
+        }
     }
 
     /// Apply the per-monomorphisation substitution map to a type.
@@ -10175,7 +10236,7 @@ impl Builder {
             let Some(place) = self.binding_locals.get(&binding).copied() else {
                 continue;
             };
-            self.owned_locals.retain(|entry| entry.binding != binding);
+            self.set_owned_local_disposition(binding, Disposition::ScopeReleased);
             self.push_instr(Instr::Drop {
                 place,
                 ty,
@@ -10234,7 +10295,7 @@ impl Builder {
                 builtin: Some(BuiltinType::Vec),
                 is_opaque: false,
             };
-            self.owned_locals.retain(|entry| entry.binding != binding);
+            self.set_owned_local_disposition(binding, Disposition::ScopeReleased);
             self.push_instr(Instr::RecordFieldDrop {
                 record: place,
                 field_offset: crate::model::FieldOffset(0),
@@ -13019,15 +13080,14 @@ impl Builder {
                         });
                     } else {
                         // #53: gated on the binding still owning live heap
-                        // (`owned_locals` membership) -- a self-reassign
-                        // r = T{..r} or a move-out RHS already consumed it
-                        // (removed from `owned_locals`), so this is skipped and
-                        // never double-frees.
-                        if self
-                            .owned_locals
-                            .iter()
-                            .any(|entry| &entry.binding == binding)
-                        {
+                        // (scope-exit-live `owned_locals` membership) -- a
+                        // self-reassign r = T{..r} or a move-out RHS already
+                        // consumed it (dispositioned off the scope-exit set by
+                        // `mark_binding_moved`, so absent from the live view),
+                        // so this is skipped and never double-frees.
+                        if self.owned_locals.iter().any(|entry| {
+                            &entry.binding == binding && entry.disposition == Disposition::ScopeExit
+                        }) {
                             self.emit_local_overwrite_release(dest, &target.ty);
                         }
                         self.push_instr(Instr::Move { dest, src });
@@ -20526,8 +20586,10 @@ impl Builder {
                     // the reference to a longer-lived owner), matching the
                     // generator-yield posture.
                     if keep_for_drop_elab {
-                        self.owned_locals
-                            .retain(|entry| entry.binding != binding.binding);
+                        self.set_owned_local_disposition(
+                            binding.binding,
+                            Disposition::BodyEndReleased,
+                        );
                     }
                     retained_vec_string_iter_bindings.push((
                         binding.binding,
@@ -20562,8 +20624,10 @@ impl Builder {
                             // fresh heap allocation the consumer alone is
                             // responsible for releasing.
                             if keep_for_drop_elab {
-                                self.owned_locals
-                                    .retain(|entry| entry.binding != binding.binding);
+                                self.set_owned_local_disposition(
+                                    binding.binding,
+                                    Disposition::BodyEndReleased,
+                                );
                             }
                             generator_yield_drop_bindings.push((
                                 binding.binding,
@@ -20589,8 +20653,10 @@ impl Builder {
                             // final-`owned_locals` scan does not stack a
                             // second diagnostic on the same construct.
                             if keep_for_drop_elab {
-                                self.owned_locals
-                                    .retain(|entry| entry.binding != binding.binding);
+                                self.set_owned_local_disposition(
+                                    binding.binding,
+                                    Disposition::BodyEndReleased,
+                                );
                             }
                             let elem = self
                                 .unsupported_vec_element_in_ty(&binding_ty)
@@ -24221,10 +24287,9 @@ impl Builder {
         });
         self.record_binding_scope(binding_id);
         if self.binding_seeds_drop_elaboration(ty)
-            && !self
-                .owned_locals
-                .iter()
-                .any(|entry| entry.binding == binding_id)
+            && !self.owned_locals.iter().any(|entry| {
+                entry.binding == binding_id && entry.disposition == Disposition::ScopeExit
+            })
         {
             self.register_owned_local(binding_id, name.to_string(), ty.clone());
         }
@@ -31250,7 +31315,7 @@ impl Builder {
         if !self
             .owned_locals
             .iter()
-            .any(|entry| entry.binding == binding.id)
+            .any(|entry| entry.binding == binding.id && entry.disposition == Disposition::ScopeExit)
         {
             return;
         }
@@ -31318,8 +31383,9 @@ impl Builder {
     fn mark_binding_moved(&mut self, id: BindingId) {
         // #2301 -- record the move-out at runtime for a binding that carries a
         // path-sensitive overwrite-release flag. Setting the flag on EVERY
-        // `owned_locals` removal (every consume site, not just the primary
-        // `Use{Consume}` lowering) means a later overwrite on a DIFFERENT
+        // consume retraction (the `ConsumedAt` disposition write below, every
+        // consume site, not just the primary `Use{Consume}` lowering) means a
+        // later overwrite on a DIFFERENT
         // control-flow path correctly SKIPS the release (the moved-out value's
         // new owner drops it), while the non-consuming path keeps `flag == 0`
         // and releases. The flag is reset to 0 after that overwrite's store. A
@@ -31330,7 +31396,7 @@ impl Builder {
                 value: 1,
             });
         }
-        self.owned_locals.retain(|entry| entry.binding != id);
+        self.set_owned_local_disposition(id, Disposition::ConsumedAt);
     }
 
     // JUSTIFIED: this predicate deliberately stays adjacent to the aggregate
@@ -49244,6 +49310,59 @@ mod binding_ty_is_plain_vec_tuple {
         assert_eq!(
             entry.provenance, None,
             "no provenance is proven at this seam"
+        );
+    }
+
+    /// Retraction is a disposition write, not a physical removal: a binding
+    /// dispositioned off the scope-exit set leaves the live drop view
+    /// (`owned_locals_snapshot`) yet stays observable in the whole ledger
+    /// (`owned_locals_ledger`). This is the invariant that kills the
+    /// retracted-invisible-to-final-scan class — the mechanism behind the
+    /// double-free and #2375, where a physically-removed binding was gone from
+    /// the ledger before an end-of-pass scan could see it.
+    #[test]
+    fn dispositioned_binding_leaves_live_view_but_survives_whole_ledger() {
+        let mut builder = builder_with_indirect_enum();
+        builder.register_owned_local(BindingId(3), "kept".to_string(), ResolvedTy::String);
+        builder.register_owned_local(BindingId(4), "moved".to_string(), ResolvedTy::String);
+
+        // Both are scope-exit-live before any retraction.
+        assert_eq!(
+            builder.owned_locals_snapshot(),
+            vec![
+                (BindingId(3), "kept".to_string(), ResolvedTy::String),
+                (BindingId(4), "moved".to_string(), ResolvedTy::String),
+            ],
+            "both registered bindings are in the live view before retraction"
+        );
+
+        // Retract one via a consume disposition (what `mark_binding_moved` does).
+        builder.set_owned_local_disposition(BindingId(4), Disposition::ConsumedAt);
+
+        // The live view now excludes the retracted binding — exactly the set the
+        // former `owned_locals.retain(...)` physical removal would have left.
+        assert_eq!(
+            builder.owned_locals_snapshot(),
+            vec![(BindingId(3), "kept".to_string(), ResolvedTy::String)],
+            "the retracted binding leaves the scope-exit-live view"
+        );
+
+        // The whole ledger still carries BOTH entries, in registration order —
+        // the retracted one is observable to an end-of-pass scan, carrying its
+        // recorded disposition. Physical removal made this impossible.
+        let ledger = builder.owned_locals_ledger();
+        assert_eq!(
+            ledger.len(),
+            2,
+            "the whole ledger keeps the retracted entry"
+        );
+        assert_eq!(ledger[0].binding, BindingId(3));
+        assert_eq!(ledger[0].disposition, Disposition::ScopeExit);
+        assert_eq!(ledger[1].binding, BindingId(4));
+        assert_eq!(
+            ledger[1].disposition,
+            Disposition::ConsumedAt,
+            "the retracted entry survives carrying its recorded disposition"
         );
     }
 

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -5606,13 +5606,21 @@ pub enum DropKind {
     /// `hew_hashset_free_layout`. Codegen loads the pointer, calls the
     /// symbol, and null-stores the slot (`raii-null-after-move`).
     ///
-    /// `ElabDrop::drop_fn` stays `None` for this kind — the symbol lives in
-    /// the variant so the runtime-vs-user `resolve_drop_fn` dispatch (which
-    /// only fires for `ElabDrop::drop_fn = Some(_)`) is not consulted and
-    /// the `CowHeap` arm is a single, self-describing release call. The symbol
-    /// is `&'static str` (a fixed runtime release-symbol literal); the
-    /// emitter declares it as `void(ptr)` via `get_or_declare_drop_helper`.
-    CowHeap { drop_fn: &'static str },
+    /// `ElabDrop::drop_fn` stays `None` for this kind — the release protocol
+    /// lives in the variant so the runtime-vs-user `resolve_drop_fn` dispatch
+    /// (which only fires for `ElabDrop::drop_fn = Some(_)`) is not consulted and
+    /// the `CowHeap` arm is a single, self-describing release call.
+    ///
+    /// The protocol is a typed [`CowHeapRelease`] — the heap-leaf identity
+    /// folded with the `Vec<E>` element refinement — not a `&'static str`
+    /// literal. Codegen resolves the C-ABI symbol from the carried fact
+    /// (`CowHeapRelease::release_symbol`, declared `void(ptr)` via
+    /// `get_or_declare_drop_helper`); because the fact is typed, an unknown or
+    /// type-incongruent release symbol is unrepresentable, so the codegen
+    /// congruence re-derivation the literal carrier required is gone.
+    CowHeap {
+        release: crate::ownership::CowHeapRelease,
+    },
     /// owned-string-record — function-scope in-place drop of a stack-local user record whose
     /// direct fields are only `BitCopy` values plus one or more `string` fields.
     /// The record identity lives in the paired [`ElabDrop::ty`], so the kind can

--- a/hew-mir/src/ownership.rs
+++ b/hew-mir/src/ownership.rs
@@ -63,9 +63,9 @@
 //! | owned-locals seed gate (`Builder::binding_seeds_drop_elaboration`) | `hew-mir` · `lower.rs` → `hew-hir` · `value_class.rs` | which locals enter drop elaboration | **LANDED (seed-authority consolidation)** — one named authority answers "does this binding's type oblige drop elaboration?" at every `owned_locals` seed site AND the consume-side removal mirror, so the two sides of the ledger cannot desynchronise (a looser consume side keeps a moved-out binding in `owned_locals` and double-frees at function exit; a tighter one leaks). The verdict remains the value-class seed — record-blind via [`ValueClass`] (an unmarked user record classifies `Unknown`, which seeds); a record-aware seed upgrade reads [`ValueOwnership`] at this one seam when it lands. Pinned by a frozen verdict table over every value class plus a source-inventory scan keeping the authority's body the only seed-fact spelling (`seed_gate_matches_value_class_authority` / `seed_fact_comparison_site_inventory_is_closed` in `lower.rs`). |
 //! | `cow_value_leaf_drop_symbol` | `hew-mir` · `lower.rs` | scalar-leaf release symbol (`string` → `hew_string_drop`, else `None`) | **LANDED (release-bucket consolidation)** — routed through the typed decision; see the partition-totality test below. |
 //! | `binding_ty_is_plain_vec` · `is_plain_vec_element` · `binding_ty_is_owned_element_vec` · `is_owned_vec_element` · `tuple_is_all_bitcopy` | `hew-mir` · `lower.rs` | `Vec<E>` release partition (plain vs owned-element) | **LANDED (release-bucket consolidation)** — release buckets PROJECT from the typed `classify_vec_element_release` decision; their union is total vs the authority leaf set. The Plain bucket's `Named` arm reads the `named_elem_owns_heap` AUTHORITY, not `ValueClass::of_ty == BitCopy` alone: a heap-free DIRECT user enum is never `BitCopy` (value-class finalisation covers records only), so the pre-fix `BitCopy`-only gate classified `Vec<fieldless-enum>` NEITHER plain nor owned and leaked its whole buffer+handle at every scope exit — now closed by the `ty_is_direct_enum_element(e) && !named_elem_owns_heap(e)` disjunct. The unwired `Vec<bytes>` / `Vec<indirect_enum>` elements (`Unsupported(NoReleaseProtocol)`) are REJECTED at compile by `Builder::unsupported_vec_element_diagnostics` rather than silently leaked at scope exit. |
-//! | `generator_yield_drop_symbol` · `project_field_inline_drop_symbol` | `hew-mir` · `lower.rs` | per-yield / per-field `Vec<E>` release-symbol picker | **LANDED (release-bucket consolidation)** — both check the closure-pair bucket (`ty_is_closure_pair_vec` / `ty_is_closure_pair`) BEFORE the owned/plain split, so a yielded or match-destructured `Vec<fn>` / `Vec<closure>` picks `hew_vec_free_closure_pairs` congruent with codegen's `cow_heap_release_symbol` (`dedup-semantic-boundary`) rather than mis-computing `hew_vec_free` and failing the inline-drop congruence check closed. |
+//! | `generator_yield_drop_symbol` · `project_field_inline_drop_symbol` | `hew-mir` · `lower.rs` | per-yield / per-field `Vec<E>` release-symbol picker | **LANDED (release-bucket consolidation)** — both check the closure-pair bucket (`ty_is_closure_pair_vec` / `ty_is_closure_pair`) BEFORE the owned/plain split, so a yielded or match-destructured `Vec<fn>` / `Vec<closure>` picks `hew_vec_free_closure_pairs` congruent with codegen's `resolved_ty_cow_heap_release` (`dedup-semantic-boundary`) rather than mis-computing `hew_vec_free` and failing the inline-drop release-symbol membership check closed. |
 //! | `ty_is_closure_pair_vec` · `ty_is_local_collection_handle` | `hew-mir` · `lower.rs` | closure-pair / collection-handle release | **LANDED (release-bucket consolidation)** — both are documented projections of the typed decision. `ty_is_closure_pair_vec` projects [`VecElementRelease::ClosurePair`] for `Builder`-free contexts (pinned by the partition-totality test) and the `Builder`-side release-symbol pickers read `classify_vec_element_release` itself; `ty_is_local_collection_handle` is the single ABI-shape authority for the `HashMap`/`HashSet` bucket, pinned against the [`HeapLeaf`] classification with a release-symbol tripwire (`collection_handle_predicate_projects_from_heap_leaf` in `lower.rs`). |
-//! | `cow_heap_release_symbol` | `hew-codegen-rs` · `llvm.rs` | codegen-side release-symbol picker | **PENDING (type-directed drop consolidation)** — the codegen sibling the MIR release buckets must agree with (`dedup-semantic-boundary`). Retires with the type-directed drop operation: per-shape release tables replace the per-site symbol pick, and the congruence validators that re-derive MIR-carried `drop_fn` symbols retire with the dual derivation they guard. |
+//! | `resolved_ty_cow_heap_release` | `hew-codegen-rs` · `llvm.rs` | codegen-side aggregate-walk release picker | **LANDED (type-directed drop consolidation)** — [`DropKind::CowHeap`] now carries a typed [`CowHeapRelease`] fact (not a `&'static str` literal), so codegen resolves the release symbol from the carried fact via [`CowHeapRelease::release_symbol`] with no per-site re-derivation. The three congruence validators that re-derived MIR-carried `drop_fn` symbols are deleted with the literal carrier they guarded; the sole surviving picker is the address-based aggregate walk (`resolved_ty_cow_heap_release` → [`CowHeapRelease`]), for nested fields that carry no MIR fact of their own, and it reads the same [`CowHeapRelease::release_symbol`] authority (`dedup-semantic-boundary`). |
 //!
 //! The boundary-totality tests pin both axes: [`OwnershipDecision::classify`] is
 //! total over the twelve canonical shapes (`classify_is_total_over_the_twelve_shapes`),
@@ -343,7 +343,7 @@ pub enum FailClosedReason {
 /// union is total over [`ResolvedTy`](hew_types::ResolvedTy) by construction: a
 /// `Vec<E>` local can never silently fall through every bucket and skip its
 /// release (the leak surface the `_ => false` bucket arms used to be). The
-/// codegen siblings (`cow_heap_release_symbol`,
+/// codegen siblings (`resolved_ty_cow_heap_release`,
 /// `resolved_ty_element_owns_heap_for_owned_vec`) pick the matching release
 /// symbol; the two sides agree per shape (`dedup-semantic-boundary`).
 ///
@@ -946,11 +946,13 @@ impl TryFrom<DropKind> for DropClass {
             DropKind::DuplexHalfClose(direction) => DropClass::DuplexHalfClose { direction },
             DropKind::LambdaActorRelease => DropClass::LambdaActorRelease,
             DropKind::TraitObject { storage } => DropClass::DynTrait { storage },
-            DropKind::CowHeap { drop_fn } => {
-                let leaf = HeapLeaf::from_release_symbol(drop_fn)
-                    .ok_or(FailClosedReason::UnrecognisedReleaseSymbol)?;
-                DropClass::CowHeapLeaf { leaf }
-            }
+            DropKind::CowHeap { release } => DropClass::CowHeapLeaf {
+                // The typed carrier names its leaf directly — no symbol to
+                // parse, so this arm is now infallible (an unrecognised release
+                // is unrepresentable). `CowHeapRelease` is never a
+                // `CancellationToken` leaf, so `CowHeapLeaf` stays copy-on-write.
+                leaf: release.heap_leaf(),
+            },
             DropKind::RecordInPlace => DropClass::RecordInPlace,
             DropKind::AggregateRecursive => DropClass::AggregateRecursive,
             DropKind::EnumInPlace => DropClass::EnumInPlace,
@@ -974,7 +976,7 @@ impl DropClass {
         match self {
             DropClass::Resource => DropKind::Resource,
             DropClass::CowHeapLeaf { leaf } => DropKind::CowHeap {
-                drop_fn: leaf.release_symbol(),
+                release: leaf.cow_heap_release(),
             },
             DropClass::RecordInPlace => DropKind::RecordInPlace,
             DropClass::TupleInPlace => DropKind::TupleInPlace,
@@ -1055,6 +1057,33 @@ impl HeapLeaf {
         }
     }
 
+    /// The canonical [`CowHeapRelease`] for this leaf — the reverse of
+    /// [`CowHeapRelease::heap_leaf`]. [`HeapLeaf::Vec`] chooses the *plain*
+    /// family ([`CowHeapRelease::VecPlain`]); the owned / closure-pair element
+    /// refinement is resolved separately from the element's own decision, so
+    /// this round-trips the leaf identity, not a byte-identical Vec symbol.
+    ///
+    /// # Panics
+    ///
+    /// [`HeapLeaf::CancellationToken`] is an `@resource` close, never a
+    /// copy-on-write release; it is never a `DropClass::CowHeapLeaf` leaf
+    /// ([`HeapLeaf::drop_class`] enforces it), so this arm is unreachable.
+    #[must_use]
+    pub fn cow_heap_release(self) -> CowHeapRelease {
+        match self {
+            HeapLeaf::String => CowHeapRelease::String,
+            HeapLeaf::Bytes => CowHeapRelease::Bytes,
+            HeapLeaf::Vec => CowHeapRelease::VecPlain,
+            HeapLeaf::HashMap => CowHeapRelease::HashMap,
+            HeapLeaf::HashSet => CowHeapRelease::HashSet,
+            HeapLeaf::Generator => CowHeapRelease::Generator,
+            HeapLeaf::CancellationToken => unreachable!(
+                "CancellationToken is an @resource close, never a CowHeapLeaf release; \
+                 DropClass::CowHeapLeaf is never constructed with it (HeapLeaf::drop_class)"
+            ),
+        }
+    }
+
     /// The full [`OwnsHeap`](OwnershipDecision::OwnsHeap) decision for a value
     /// that *is* this leaf.
     #[must_use]
@@ -1064,6 +1093,116 @@ impl HeapLeaf {
             abi: self.abi_class(),
             layout: LayoutClass::HeapBuffer,
         }
+    }
+}
+
+/// The typed release protocol a [`DropKind::CowHeap`] carries: the heap-leaf
+/// identity ([`HeapLeaf`]) folded with the three-way `Vec<E>` element
+/// refinement ([`VecElementRelease`]), as a single fail-closed discriminant.
+///
+/// This is the type-directed replacement for the pre-consolidation
+/// `DropKind::CowHeap { drop_fn: &'static str }` literal carrier: a `CowHeap`
+/// drop that reaches elaboration is, by construction, a supported, wired
+/// release, so the payload names its protocol by type instead of a symbol the
+/// producer chose and codegen re-derived. There is no invalid `(leaf,
+/// refinement)` pair to represent, so codegen resolves the C-ABI symbol from
+/// the carried fact directly — the dual-derivation congruence checks the
+/// literal carrier required disappear with the literal.
+///
+/// [`release_symbol`](Self::release_symbol) is the single symbol authority: the
+/// non-Vec arms delegate to [`HeapLeaf::release_symbol`] (so codegen and MIR
+/// read one table, `dedup-semantic-boundary`); the three Vec arms name the
+/// element-refined symbols the runtime's owned-descriptor / closure-pair frees
+/// require. [`heap_leaf`](Self::heap_leaf) projects back to the leaf identity
+/// (all three Vec arms → [`HeapLeaf::Vec`]), matching the deliberate Vec-family
+/// collapse [`HeapLeaf::from_release_symbol`] already documents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CowHeapRelease {
+    /// `string` — `hew_string_drop`. [`HeapLeaf::String`].
+    String,
+    /// `bytes` — `hew_bytes_drop` (the `{ptr,len,cap}` triple; codegen routes
+    /// it through the triple-field-0 emitter, not the single-`ptr` path).
+    /// [`HeapLeaf::Bytes`].
+    Bytes,
+    /// `Vec<E>` with a plain element (`BitCopy` scalar/aggregate, or a `string`
+    /// the runtime walks itself) — `hew_vec_free`. The plain family of
+    /// [`HeapLeaf::Vec`], refinement [`VecElementRelease::Plain`].
+    VecPlain,
+    /// `Vec<E>` with an owned-heap composite element (record/enum/tuple/nested
+    /// collection) — `hew_vec_free_owned` (per-element descriptor `drop_fn`
+    /// then buffer free). Refinement [`VecElementRelease::OwnedElement`].
+    VecOwnedElement,
+    /// `Vec<fn>` / `Vec<closure>` — `hew_vec_free_closure_pairs` (per-slot env
+    /// thunk + pair-box free). Refinement [`VecElementRelease::ClosurePair`].
+    VecClosurePairs,
+    /// `HashMap<K,V>` — `hew_hashmap_free_layout`. [`HeapLeaf::HashMap`].
+    HashMap,
+    /// `HashSet<E>` — `hew_hashset_free_layout`. [`HeapLeaf::HashSet`].
+    HashSet,
+    /// `Generator<Y,R>` / `AsyncGenerator<Y>` — `hew_gen_coro_destroy`.
+    /// [`HeapLeaf::Generator`].
+    Generator,
+}
+
+impl CowHeapRelease {
+    /// The C-ABI runtime release symbol for this protocol. The single symbol
+    /// authority a [`DropKind::CowHeap`] resolves through: the non-Vec arms
+    /// delegate to [`HeapLeaf::release_symbol`]; the Vec arms name the
+    /// element-refined frees.
+    #[must_use]
+    pub fn release_symbol(self) -> &'static str {
+        match self {
+            CowHeapRelease::String => HeapLeaf::String.release_symbol(),
+            CowHeapRelease::Bytes => HeapLeaf::Bytes.release_symbol(),
+            CowHeapRelease::HashMap => HeapLeaf::HashMap.release_symbol(),
+            CowHeapRelease::HashSet => HeapLeaf::HashSet.release_symbol(),
+            CowHeapRelease::Generator => HeapLeaf::Generator.release_symbol(),
+            // The Vec element refinement: the plain family is
+            // `HeapLeaf::Vec.release_symbol()`; the owned / closure-pair frees
+            // are element-directed and have no bare-leaf symbol.
+            CowHeapRelease::VecPlain => HeapLeaf::Vec.release_symbol(),
+            CowHeapRelease::VecOwnedElement => "hew_vec_free_owned",
+            CowHeapRelease::VecClosurePairs => "hew_vec_free_closure_pairs",
+        }
+    }
+
+    /// The [`HeapLeaf`] identity this protocol releases. All three Vec arms
+    /// project to [`HeapLeaf::Vec`] (the element refinement is not part of the
+    /// leaf identity), matching [`HeapLeaf::from_release_symbol`]'s Vec-family
+    /// collapse — so `TryFrom<DropKind> for DropClass` maps every Vec release
+    /// to `CowHeapLeaf { leaf: Vec }`.
+    #[must_use]
+    pub fn heap_leaf(self) -> HeapLeaf {
+        match self {
+            CowHeapRelease::String => HeapLeaf::String,
+            CowHeapRelease::Bytes => HeapLeaf::Bytes,
+            CowHeapRelease::VecPlain
+            | CowHeapRelease::VecOwnedElement
+            | CowHeapRelease::VecClosurePairs => HeapLeaf::Vec,
+            CowHeapRelease::HashMap => HeapLeaf::HashMap,
+            CowHeapRelease::HashSet => HeapLeaf::HashSet,
+            CowHeapRelease::Generator => HeapLeaf::Generator,
+        }
+    }
+
+    /// Parse a release symbol into its typed protocol. Returns `None` for an
+    /// unrecognised symbol (fail-closed) — the boundary where an unknown
+    /// release string is rejected now that the typed carrier makes an invalid
+    /// `CowHeap` payload unrepresentable downstream. Round-trips
+    /// `release_symbol` for every variant.
+    #[must_use]
+    pub fn from_symbol(symbol: &str) -> Option<Self> {
+        Some(match symbol {
+            "hew_string_drop" => CowHeapRelease::String,
+            "hew_bytes_drop" => CowHeapRelease::Bytes,
+            "hew_vec_free" => CowHeapRelease::VecPlain,
+            "hew_vec_free_owned" => CowHeapRelease::VecOwnedElement,
+            "hew_vec_free_closure_pairs" => CowHeapRelease::VecClosurePairs,
+            "hew_hashmap_free_layout" => CowHeapRelease::HashMap,
+            "hew_hashset_free_layout" => CowHeapRelease::HashSet,
+            "hew_gen_coro_destroy" => CowHeapRelease::Generator,
+            _ => return None,
+        })
     }
 }
 
@@ -1648,22 +1787,22 @@ mod tests {
                 storage: TraitObjectStorage::HeapBoxed,
             },
             DropKind::CowHeap {
-                drop_fn: "hew_string_drop",
+                release: CowHeapRelease::String,
             },
             DropKind::CowHeap {
-                drop_fn: "hew_bytes_drop",
+                release: CowHeapRelease::Bytes,
             },
             DropKind::CowHeap {
-                drop_fn: "hew_vec_free",
+                release: CowHeapRelease::VecPlain,
             },
             DropKind::CowHeap {
-                drop_fn: "hew_hashmap_free_layout",
+                release: CowHeapRelease::HashMap,
             },
             DropKind::CowHeap {
-                drop_fn: "hew_hashset_free_layout",
+                release: CowHeapRelease::HashSet,
             },
             DropKind::CowHeap {
-                drop_fn: "hew_gen_coro_destroy",
+                release: CowHeapRelease::Generator,
             },
             DropKind::RecordInPlace,
             DropKind::AggregateRecursive,
@@ -1691,12 +1830,12 @@ mod tests {
     /// class. The refinement is carried by the element's own decision.
     #[test]
     fn vec_element_release_symbols_collapse_to_the_vec_family() {
-        for sym in [
-            "hew_vec_free",
-            "hew_vec_free_owned",
-            "hew_vec_free_closure_pairs",
+        for release in [
+            CowHeapRelease::VecPlain,
+            CowHeapRelease::VecOwnedElement,
+            CowHeapRelease::VecClosurePairs,
         ] {
-            let class = DropClass::try_from(DropKind::CowHeap { drop_fn: sym }).unwrap();
+            let class = DropClass::try_from(DropKind::CowHeap { release }).unwrap();
             assert_eq!(
                 class,
                 DropClass::CowHeapLeaf {
@@ -1706,15 +1845,32 @@ mod tests {
         }
     }
 
-    /// A copy-on-write-heap symbol outside the leaf set fails closed rather than
-    /// silently mis-mapping.
+    /// A copy-on-write-heap symbol outside the leaf set fails closed at the
+    /// parse boundary rather than silently mis-mapping. The typed
+    /// `CowHeapRelease` carrier makes an unknown symbol unrepresentable on a
+    /// `DropKind::CowHeap`, so the fail-closed reject now lives on the round-trip
+    /// parser (`CowHeapRelease::from_symbol` / `HeapLeaf::from_release_symbol`),
+    /// and every valid symbol round-trips.
     #[test]
     fn unrecognised_cow_heap_symbol_fails_closed() {
-        let err = DropClass::try_from(DropKind::CowHeap {
-            drop_fn: "hew_not_a_real_symbol",
-        })
-        .unwrap_err();
-        assert_eq!(err, FailClosedReason::UnrecognisedReleaseSymbol);
+        assert_eq!(CowHeapRelease::from_symbol("hew_not_a_real_symbol"), None);
+        assert_eq!(HeapLeaf::from_release_symbol("hew_not_a_real_symbol"), None);
+        for release in [
+            CowHeapRelease::String,
+            CowHeapRelease::Bytes,
+            CowHeapRelease::VecPlain,
+            CowHeapRelease::VecOwnedElement,
+            CowHeapRelease::VecClosurePairs,
+            CowHeapRelease::HashMap,
+            CowHeapRelease::HashSet,
+            CowHeapRelease::Generator,
+        ] {
+            assert_eq!(
+                CowHeapRelease::from_symbol(release.release_symbol()),
+                Some(release),
+                "release symbol must round-trip through from_symbol",
+            );
+        }
     }
 
     /// `CancellationToken` is a heap leaf but an `@resource` close — never a

--- a/hew-mir/src/ownership.rs
+++ b/hew-mir/src/ownership.rs
@@ -30,11 +30,18 @@
 //! **exactly**, for every shape — the contract the consolidation relies on when it swaps a
 //! seam's direct authority call for the projection.
 //!
-//! This landing is **additive and unused**: it defines the types, the
-//! [`ValueOwnership::classify`] / [`OwnershipDecision::classify`] constructor
-//! scaffold, the seed conversions, and the totality + round-trip tests. It
-//! switches **no** production call site — the release-bucket consolidation routes the existing
-//! authorities through it.
+//! This carrier is now **read**, not merely defined. The per-function
+//! owned-locals ledger records a [`ValueOwnership`] on every entry at its
+//! defining write ([`OwnershipDecision::classify`] time), and the record /
+//! tuple composite drop provers consume the carried
+//! [`InteriorAlias`](OwnershipDecision::InteriorAlias)-shaped
+//! [`ValueProvenance`] so a byte-copy field alias names its owner by location
+//! instead of each prover re-deriving it from the instruction stream. The
+//! coarser per-value facts (fresh / parameter provenance, and the drop / ABI
+//! kind on non-alias entries) travel on the ledger and are read as their
+//! consuming seams land; the release-bucket and type-directed drop
+//! consolidations route the remaining shape-walkers through it (see the Walker
+//! inventory below).
 //!
 //! # Subsumes (does not reinvent) the existing seeds
 //!

--- a/hew-mir/tests/lowering_expr/elaborate.rs
+++ b/hew-mir/tests/lowering_expr/elaborate.rs
@@ -149,7 +149,7 @@ fn nonescaping_cowvalue_string_gets_function_scope_drop() {
         matches!(
             return_plan.1.drops[0].kind,
             DropKind::CowHeap {
-                drop_fn: "hew_string_drop"
+                release: hew_mir::CowHeapRelease::String
             }
         ),
         "the drop must be a CowHeap release via hew_string_drop; got {:?}",

--- a/hew-mir/tests/lowering_expr/hashmap_hashset_local_drop.rs
+++ b/hew-mir/tests/lowering_expr/hashmap_hashset_local_drop.rs
@@ -85,7 +85,7 @@ fn drops_matching(
 
 /// True when `drop` is a `CowHeap` release naming `symbol`.
 fn is_cow_heap_free(drop: &ElabDrop, symbol: &str) -> bool {
-    matches!(drop.kind, DropKind::CowHeap { drop_fn } if drop_fn == symbol)
+    matches!(drop.kind, DropKind::CowHeap { release } if release.release_symbol() == symbol)
 }
 
 fn count_free(drops: &[ElabDrop], symbol: &str) -> usize {
@@ -163,10 +163,11 @@ fn hashmap_hashset_local_drop_admits_map_and_set_in_lifo_order() {
     let frees: Vec<&str> = drops
         .iter()
         .filter_map(|d| match d.kind {
-            DropKind::CowHeap { drop_fn }
-                if drop_fn == "hew_hashmap_free_layout" || drop_fn == "hew_hashset_free_layout" =>
+            DropKind::CowHeap { release }
+                if release.release_symbol() == "hew_hashmap_free_layout"
+                    || release.release_symbol() == "hew_hashset_free_layout" =>
             {
-                Some(drop_fn)
+                Some(release.release_symbol())
             }
             _ => None,
         })

--- a/hew-mir/tests/lowering_expr/owned_string_temp_drop_canary.rs
+++ b/hew-mir/tests/lowering_expr/owned_string_temp_drop_canary.rs
@@ -100,7 +100,7 @@ fn return_exit_string_drops(pl: &IrPipeline, fn_name: &str) -> usize {
                 .filter(|d| {
                     matches!(
                         &d.kind,
-                        DropKind::CowHeap { drop_fn } if *drop_fn == "hew_string_drop"
+                        DropKind::CowHeap { release } if release.release_symbol() == "hew_string_drop"
                     )
                 })
                 .count()
@@ -138,7 +138,7 @@ fn panic_exit_string_drops(pl: &IrPipeline, fn_name: &str) -> usize {
                 .filter(|d| {
                     matches!(
                         &d.kind,
-                        DropKind::CowHeap { drop_fn } if *drop_fn == "hew_string_drop"
+                        DropKind::CowHeap { release } if release.release_symbol() == "hew_string_drop"
                     )
                 })
                 .count()

--- a/hew-mir/tests/lowering_expr/plain_vec_local_drop.rs
+++ b/hew-mir/tests/lowering_expr/plain_vec_local_drop.rs
@@ -93,7 +93,7 @@ fn drops_matching(
 
 /// True when `drop` is a `CowHeap` release naming `symbol`.
 fn is_cow_heap_free(drop: &ElabDrop, symbol: &str) -> bool {
-    matches!(drop.kind, DropKind::CowHeap { drop_fn } if drop_fn == symbol)
+    matches!(drop.kind, DropKind::CowHeap { release } if release.release_symbol() == symbol)
 }
 
 fn count_free(drops: &[ElabDrop], symbol: &str) -> usize {


### PR DESCRIPTION
## Summary

This completes the MIR ownership drop-elaboration work: bound-string originals on consumed match roots are now discharged (fixes #2373), byte-copy field projections are classified as interior aliases (fixes #2375), owned locals are routed through a single registration authority, owned locals are retracted by disposition rather than removed outright, cow-heap drop release is carried as a typed fact instead of a bare symbol string, and sibling-field drops are compensated along multi-hop alias chains so every owned field drops exactly once.

The last piece is the multi-hop compensation: when a byte-copy field is projected through two or more `let` hops and the innermost projection escapes the function (by `return` or into another record), the owner's whole-tree composite drop is correctly excluded to avoid a double-free — but the sibling fields along that chain (e.g. `mid.x`, `outer.c`) need their own compensating drop, since nothing else frees them. `Builder::alias_projection_chain` now keeps the intermediate structure of each alias hop, and `compute_escaped_record_chain_sibling_drops` walks it to emit exactly one `FieldDropInPlace` per owned field that isn't on the escaping path.

## Verification

- Guard-Malloc: leak-free and double-free-free across the projection/escape drop shapes this branch touches (record chains, tuple/record mixes, deep-alias escape via `return` and into a holder record, dual-escape, field aliased-and-read both before and after the escape point).
- New leak-slope oracles added to `nested_projection_chain_leak_oracle.rs` (`escaped_return_record_leak_slope_below_tolerance`, `escaped_into_record_leak_slope_below_tolerance`) — red on the pre-fix commit, green after.
- Full test corpus: 10928/10928 passing.
- O0/O2 differential: identical output.
- All ratchets: green.

## Out of scope

- A pre-existing leak on the tuple-composite path (`escaped_return_tuple`, e.g. `let pair = o.pair; let leaf = pair.0;`) — the tuple composite prover is a separate code path this branch doesn't touch. Leak count is unchanged before and after this branch.
- A pre-existing double-free when an intermediate alias hop is bound via a `match` pattern instead of a plain field projection (`let leaf = match mid { Mid { leaf, x: _ } => leaf }; return leaf;`). Reproduces identically on `origin/main` and on both the pre- and post-fix commits of this branch — the composite-drop prover's alias provenance tracking doesn't recognize a match-destructured binder the way it recognizes a plain field load, so the owner's composite drop is never excluded and the returned value is freed twice.

Both are real, pre-existing bugs distinct from the two this PR fixes; tracking them as separate follow-ups.

Fixes #2373
Fixes #2375