### PR TITLE
fix(mir): extend chain-sibling drop compensator to match-hop and tuple-chain escapes

### DIFF
--- a/hew-cli/tests/nested_projection_chain_leak_oracle.rs
+++ b/hew-cli/tests/nested_projection_chain_leak_oracle.rs
@@ -495,6 +495,109 @@ fn escaped_return_tuple_source(frames: usize) -> String {
     )
 }
 
+/// Match-hop escape (record): an INTERMEDIATE hop of the return alias chain is
+/// destructured via `match` (not a field projection) and the leaf bound out of
+/// the destructure is returned. The match-bound leaf is a byte-copy alias of
+/// the owner's subtree (the destructure load copies the inline aggregate with
+/// no retain), so the owner's composite must NOT free the subtree the caller
+/// now holds — a re-walk here is the #2384 double-free (`free_cstring` header
+/// sentinel abort). Fail-closed posture: the owner is excluded and its
+/// non-escaped siblings leak; the pin is no double-free, not a flat slope.
+fn match_intermediate_return_leaf_source(frames: usize) -> String {
+    format!(
+        "type Leaf {{\n\
+         \x20   s: string,\n\
+         \x20   t: string,\n\
+         }}\n\
+         \n\
+         type Mid {{\n\
+         \x20   leaf: Leaf,\n\
+         \x20   x: string,\n\
+         }}\n\
+         \n\
+         type Outer {{\n\
+         \x20   mid: Mid,\n\
+         \x20   c: string,\n\
+         }}\n\
+         \n\
+         fn make_outer(k: i64) -> Outer {{\n\
+         \x20   Outer {{\n\
+         \x20       mid: Mid {{\n\
+         \x20           leaf: Leaf {{\n\
+         \x20               s: \"esc-s-heap-payload\".to_upper(),\n\
+         \x20               t: \"esc-t-heap-payload\".to_upper(),\n\
+         \x20           }},\n\
+         \x20           x: \"esc-x-heap-payload\".to_upper(),\n\
+         \x20       }},\n\
+         \x20       c: \"esc-c-heap-payload\".to_upper(),\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn deep(k: i64) -> Leaf {{\n\
+         \x20   let o = make_outer(k);\n\
+         \x20   let mid = o.mid;\n\
+         \x20   let leaf = match mid {{\n\
+         \x20       Mid {{ leaf, x: _ }} => leaf,\n\
+         \x20   }};\n\
+         \x20   leaf\n\
+         }}\n\
+         \n\
+         fn run_cycle(k: i64) -> i64 {{\n\
+         \x20   let l = deep(k);\n\
+         \x20   l.s.len()\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + run_cycle(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// Match-hop escape (TUPLE twin): the intermediate tuple hop is destructured
+/// via `match (l, _)` and the bound element returned — the tuple prover's twin
+/// of the match-hop double-free boundary.
+fn match_intermediate_return_tuple_source(frames: usize) -> String {
+    format!(
+        "fn make_nested(k: i64) -> (((string, string), string), string) {{\n\
+         \x20   let a = \"esc-a-heap-payload\".to_upper();\n\
+         \x20   let b = \"esc-b-heap-payload\".to_upper();\n\
+         \x20   let c = \"esc-c-heap-payload\".to_upper();\n\
+         \x20   let d = \"esc-d-heap-payload\".to_upper();\n\
+         \x20   ((( a, b ), c ), d)\n\
+         }}\n\
+         \n\
+         fn deep(k: i64) -> (string, string) {{\n\
+         \x20   let o = make_nested(k);\n\
+         \x20   let mid = o.0;\n\
+         \x20   let leaf = match mid {{\n\
+         \x20       (l, _) => l,\n\
+         \x20   }};\n\
+         \x20   leaf\n\
+         }}\n\
+         \n\
+         fn run_cycle(k: i64) -> i64 {{\n\
+         \x20   let l = deep(k);\n\
+         \x20   l.0.len()\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + run_cycle(i);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
 // ── slope oracles (leak half) ───────────────────────────────────────────
 
 /// Two-level record chain holds a flat slope — the outer composite frees the
@@ -624,6 +727,32 @@ fn escaped_into_record_no_double_free_under_malloc_scribble() {
 #[test]
 fn escaped_return_tuple_no_double_free_under_malloc_scribble() {
     assert_scribble_clean("chain_escaped_tuple", &escaped_return_tuple_source(6));
+}
+
+/// #2384 — match-hop escape (record): the leaf bound out of a `match` on an
+/// intermediate alias hop and returned must run clean under the poisoned
+/// allocator. Before the fix the match-bound binder was invisible to the
+/// composite-drop prover (the alias forward-walk followed only whole-value
+/// `Move`s, and the destructure hop is a field load off the scrutinee copy),
+/// so the owner's composite re-freed the strings the returned `Leaf` still
+/// owns — the `free_cstring` header-sentinel abort.
+#[test]
+fn match_intermediate_return_leaf_no_double_free_under_malloc_scribble() {
+    assert_scribble_clean(
+        "chain_match_hop_return",
+        &match_intermediate_return_leaf_source(6),
+    );
+}
+
+/// #2384 tuple twin: the element bound out of a `match` on an intermediate
+/// tuple hop and returned — same double-free boundary through the tuple
+/// prover.
+#[test]
+fn match_intermediate_return_tuple_no_double_free_under_malloc_scribble() {
+    assert_scribble_clean(
+        "chain_match_hop_return_tuple",
+        &match_intermediate_return_tuple_source(6),
+    );
 }
 
 // ── MIR emission pins ────────────────────────────────────────────────────

--- a/hew-cli/tests/nested_projection_chain_leak_oracle.rs
+++ b/hew-cli/tests/nested_projection_chain_leak_oracle.rs
@@ -652,6 +652,21 @@ fn escaped_into_record_leak_slope_below_tolerance() {
     assert_frame_slope_below_tolerance("chain_escaped_store", escaped_into_record_source);
 }
 
+/// Escaped-return TUPLE holds a FLAT slope (#2383): when the deep tuple alias
+/// escapes into the return, the tuple prover excludes the owner's composite
+/// drop (the caller frees the escapee's pair exactly once), and the multi-hop
+/// chain-sibling walk discharges the non-escaped siblings ALONG the chain —
+/// the intermediate `mid.1` through the `mid` alias and the outer `o.1`
+/// through the owner — each exactly once. Before the walk covered tuple
+/// roots, the widened exclusion removed the composite drop while nothing
+/// discharged the deeper siblings, so all four strings of the nested tuple
+/// leaked every frame (slope 4/call; the double-free pin above only proved no
+/// re-free, not the absence of a per-iteration leak).
+#[test]
+fn escaped_return_tuple_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("chain_escaped_tuple", escaped_return_tuple_source);
+}
+
 // ── scribble (double-free / use-after-free) pins ────────────────────────
 
 fn assert_scribble_clean(name: &str, source: &str) {

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -7860,6 +7860,7 @@ fn lower_function(
         let alias_chain = builder.alias_projection_chain();
         let is_owned_record = |ty: &ResolvedTy| builder.is_owned_aggregate_record_ty(ty);
         let owned_field_list = |ty: &ResolvedTy| builder.project_record_owned_field_list(ty);
+        let owned_tuple_field_list = |ty: &ResolvedTy| builder.project_tuple_owned_field_list(ty);
         let field_dischargeable = |ty: &ResolvedTy| {
             matches!(ty, ResolvedTy::String) || builder.field_drop_in_place_admissible(ty)
         };
@@ -7874,6 +7875,7 @@ fn lower_function(
             &alias_chain,
             &is_owned_record,
             &owned_field_list,
+            &owned_tuple_field_list,
             &field_dischargeable,
             &mut instr_spans,
         );
@@ -36678,7 +36680,7 @@ struct RootScan {
 #[allow(
     clippy::too_many_arguments,
     reason = "each argument is a distinct Builder-owned input (blocks, the \
-              ownership ledgers, the layout tables, the three type-shape \
+              ownership ledgers, the layout tables, the four type-shape \
               predicates, the debug line table); bundling them into a struct \
               would add indirection at the single call site"
 )]
@@ -36701,6 +36703,7 @@ fn apply_escaped_record_sibling_field_drops(
     alias_chain: &[(u32, u32, u32)],
     is_owned_record: &dyn Fn(&ResolvedTy) -> bool,
     owned_field_list: &dyn Fn(&ResolvedTy) -> Vec<(u32, ResolvedTy)>,
+    owned_tuple_field_list: &dyn Fn(&ResolvedTy) -> Vec<(u32, ResolvedTy)>,
     field_dischargeable: &dyn Fn(&ResolvedTy) -> bool,
     instr_spans: &mut BTreeMap<(u32, u32), (u32, u32)>,
 ) {
@@ -36719,11 +36722,31 @@ fn apply_escaped_record_sibling_field_drops(
         };
         root_record_ty.insert(local, ty.clone());
     }
-    if root_record_ty.is_empty() {
+    // Tuple candidate roots (#2383): base locals of owned heap-owning TUPLE
+    // bindings — the tuple composite prover's candidate set. The one-hop scan
+    // below is record-only; the multi-hop chain compensator walks BOTH root
+    // kinds, because `derive_tuple_composite_drop_allowed` folds the recorded
+    // deep aliases into its exclusion exactly as the record prover does, and
+    // a widened exclusion without compensation leaks every chain sibling.
+    let mut root_tuple_ty: HashMap<u32, ResolvedTy> = HashMap::new();
+    for (binding, _name, ty) in owned_locals {
+        if !ty_is_heap_owning_tuple(ty, record_field_orders, enum_layouts) {
+            continue;
+        }
+        let Some(place) = binding_locals.get(binding) else {
+            continue;
+        };
+        let Some(local) = base_local(*place) else {
+            continue;
+        };
+        root_tuple_ty.insert(local, ty.clone());
+    }
+    if root_record_ty.is_empty() && root_tuple_ty.is_empty() {
         return;
     }
 
     let alias_of = propagate_whole_value_alias_roots(blocks, root_record_ty.keys().copied());
+    let tuple_alias_of = propagate_whole_value_alias_roots(blocks, root_tuple_ty.keys().copied());
     let local_is_heap_owning = |local: u32| -> bool {
         local_tys
             .get(local as usize)
@@ -37032,18 +37055,22 @@ fn apply_escaped_record_sibling_field_drops(
     }
     // The one-hop scan above sees only a binder loaded DIRECTLY off a whole-value
     // alias member, so a ≥2-hop escape (`let mid = o.mid; let leaf = mid.leaf;
-    // return leaf`) is invisible to it — yet the composite-drop prover DOES
+    // return leaf`) is invisible to it — yet the composite-drop provers DO
     // exclude the owner for it (via `close_alias_binders_forward`). Walk the
-    // recorded alias chain and discharge the non-escaped siblings at every level
-    // so the widened exclusion never outruns its compensation.
-    insertions.extend(compute_escaped_record_chain_sibling_drops(
+    // recorded alias chain — record AND tuple roots (#2383) — and discharge the
+    // non-escaped siblings at every level so the widened exclusion never
+    // outruns its compensation.
+    insertions.extend(compute_escaped_chain_sibling_drops(
         blocks,
         suspend_kinds,
         &root_record_ty,
+        &root_tuple_ty,
         &alias_of,
+        &tuple_alias_of,
         alias_chain,
         local_tys,
         owned_field_list,
+        owned_tuple_field_list,
         field_dischargeable,
     ));
     if insertions.is_empty() {
@@ -37076,31 +37103,39 @@ fn apply_escaped_record_sibling_field_drops(
 }
 
 /// Multi-hop sibling discharge for the ESCAPED deep-alias chain
-/// (`let mid = o.mid; let leaf = mid.leaf; return leaf`), the ≥2-hop companion
-/// to the one-hop scan in [`apply_escaped_record_sibling_field_drops`].
+/// (`let mid = o.mid; let leaf = mid.leaf; return leaf` and its tuple twin
+/// `let mid = o.0; let leaf = mid.0; leaf`), the ≥2-hop companion to the
+/// one-hop scan in [`apply_escaped_record_sibling_field_drops`].
 ///
-/// `derive_owned_record_drop_allowed` folds the recorded deep aliases into its
-/// exclusion via `close_alias_binders_forward`, so when a ≥2-hop alias escapes
-/// into an owning sink it suppresses the OWNER root's whole composite drop —
-/// otherwise the owner would free a subtree the escapee already handed to the
-/// caller (the #2375 double-free). The one-hop scan cannot see a ≥2-hop alias
-/// (its field-binder scan reaches only a binder loaded DIRECTLY off a whole-
-/// value alias member), so the widened exclusion removed the composite drop but
+/// `derive_owned_record_drop_allowed` and `derive_tuple_composite_drop_allowed`
+/// fold the recorded deep aliases into their exclusion via
+/// `close_alias_binders_forward`, so when a ≥2-hop alias escapes into an owning
+/// sink they suppress the OWNER root's whole composite drop — otherwise the
+/// owner would free a subtree the escapee already handed to the caller (the
+/// #2375 double-free). The one-hop scan cannot see a ≥2-hop alias (its
+/// field-binder scan reaches only a binder loaded DIRECTLY off a whole-value
+/// alias member), so the widened exclusion removed the composite drop but
 /// nothing discharged the non-escaped siblings ALONG the chain — the outer `c`
-/// and the intermediate `mid.x` leaked unconditionally (the P0 regression).
+/// and the intermediate `mid.x` leaked unconditionally (the P0 regression),
+/// and the tuple path leaked every chain sibling the same way (#2383,
+/// ~4 strings/call on the nested-tuple return shape).
 ///
 /// This walk mirrors the exclusion's reach: from the escapee up its immediate-
 /// parent chain to the owning root, it emits one `FieldDropInPlace` per owned
 /// field that does NOT lead to the next (escaping) hop, addressed through the
 /// still-live byte-copy alias local at each level (`mid.x` through `mid`, `o.c`
-/// through `o`). Exactly-once invariant: the escaped field at each level is
-/// never discharged (the escapee owns that subtree), every other owned field is
-/// discharged exactly once through its level's alias slot.
+/// through `o`; `mid.1` / `o.1` on the tuple chain). Each node's address kind
+/// follows its own type — `FieldAddr::Tuple` for a tuple node,
+/// `FieldAddr::Record` otherwise — so a mixed record/tuple chain discharges
+/// each level through the matching selector. Exactly-once invariant: the
+/// escaped field at each level is never discharged (the escapee owns that
+/// subtree), every other owned field is discharged exactly once through its
+/// level's alias slot.
 ///
-/// Fail-closed, coupled to the prover's exclusion so the two never disagree:
+/// Fail-closed, coupled to the provers' exclusion so the two never disagree:
 /// exactly ONE chain alias may escape, at a single INSTRUCTION whose escape
 /// trigger (a `Move` to a non-member/non-carrier slot, a `RecordInit` field, a
-/// `RecordFieldStore` source) is a strict subset of the prover's exclusion
+/// `RecordFieldStore` source) is a strict subset of the provers' exclusion
 /// triggers; the chain must resolve cleanly to a single candidate root through
 /// ≥2 byte-copy hops (a one-hop escape is the scan above's job); the escape
 /// block must not be reachable from itself (no loop — the inline-composite
@@ -37110,10 +37145,10 @@ fn apply_escaped_record_sibling_field_drops(
 #[allow(
     clippy::too_many_arguments,
     reason = "each argument is a distinct caller-owned input the walk needs — \
-              the MIR, the suspend table, the candidate-root and whole-value \
-              alias maps, the recorded chain, the local type table, and the two \
-              type-shape predicates; bundling them into a struct would only \
-              relocate the same fields at the single call site"
+              the MIR, the suspend table, the record/tuple candidate-root and \
+              whole-value alias maps, the recorded chain, the local type table, \
+              and the three type-shape predicates; bundling them into a struct \
+              would only relocate the same fields at the single call site"
 )]
 #[allow(
     clippy::too_many_lines,
@@ -37127,14 +37162,17 @@ fn apply_escaped_record_sibling_field_drops(
     reason = "`escapee` (the escaping alias) and `escapes` (the collected escape \
               events) are the domain terms; renaming either obscures the walk"
 )]
-fn compute_escaped_record_chain_sibling_drops(
+fn compute_escaped_chain_sibling_drops(
     blocks: &[BasicBlock],
     suspend_kinds: &HashMap<u32, SuspendKind>,
     root_record_ty: &HashMap<u32, ResolvedTy>,
+    root_tuple_ty: &HashMap<u32, ResolvedTy>,
     alias_of: &HashMap<u32, u32>,
+    tuple_alias_of: &HashMap<u32, u32>,
     alias_chain: &[(u32, u32, u32)],
     local_tys: &[ResolvedTy],
     owned_field_list: &dyn Fn(&ResolvedTy) -> Vec<(u32, ResolvedTy)>,
+    owned_tuple_field_list: &dyn Fn(&ResolvedTy) -> Vec<(u32, ResolvedTy)>,
     field_dischargeable: &dyn Fn(&ResolvedTy) -> bool,
 ) -> Vec<(u32, usize, Vec<Instr>)> {
     // Immediate-parent map: alias_local -> (parent_local, field ordinal it reads).
@@ -37196,7 +37234,9 @@ fn compute_escaped_record_chain_sibling_drops(
                             let dest_local =
                                 base_local(*dest).filter(|_| matches!(dest, Place::Local(_)));
                             let benign = dest_local.is_some_and(|dl| {
-                                carrier_of.contains_key(&dl) || alias_of.contains_key(&dl)
+                                carrier_of.contains_key(&dl)
+                                    || alias_of.contains_key(&dl)
+                                    || tuple_alias_of.contains_key(&dl)
                             });
                             if !benign {
                                 escapes.push((escapee, block.id, idx));
@@ -37259,7 +37299,7 @@ fn compute_escaped_record_chain_sibling_drops(
 
     // Walk the escapee's immediate-parent chain to its candidate root, recording
     // `(node_local, field-that-leads-to-the-next-hop)` at each level. Requires ≥2
-    // byte-copy hops and a clean termination at a candidate record root.
+    // byte-copy hops and a clean termination at a candidate record or tuple root.
     let mut chain_nodes: Vec<(u32, u32)> = Vec::new();
     let mut cursor = escapee;
     let mut reached_root = false;
@@ -37268,7 +37308,7 @@ fn compute_escaped_record_chain_sibling_drops(
             break;
         };
         chain_nodes.push((parent, field));
-        if root_record_ty.contains_key(&parent) {
+        if root_record_ty.contains_key(&parent) || root_tuple_ty.contains_key(&parent) {
             reached_root = true;
             break;
         }
@@ -37324,19 +37364,34 @@ fn compute_escaped_record_chain_sibling_drops(
     }
 
     // Emit the per-level sibling discharges: at each chain node, every owned
-    // field except the one that leads to the next (escaping) hop.
+    // field except the one that leads to the next (escaping) hop. The address
+    // selector follows the NODE's own type — `FieldAddr::Tuple` on a tuple
+    // node, `FieldAddr::Record` otherwise — so mixed record/tuple chains
+    // discharge each level through the matching selector; a node shape neither
+    // list recognizes contributes no discharges (leak-as-before at that level).
     let mut siblings: Vec<Instr> = Vec::new();
     for &(node_local, escaped_field) in &chain_nodes {
         let Some(node_ty) = local_tys.get(node_local as usize) else {
             continue;
         };
-        for (field_idx, field_ty) in owned_field_list(node_ty) {
+        let node_is_tuple = matches!(node_ty, ResolvedTy::Tuple(_));
+        let owned_fields = if node_is_tuple {
+            owned_tuple_field_list(node_ty)
+        } else {
+            owned_field_list(node_ty)
+        };
+        for (field_idx, field_ty) in owned_fields {
             if field_idx == escaped_field || !field_dischargeable(&field_ty) {
                 continue;
             }
+            let field = if node_is_tuple {
+                crate::model::FieldAddr::Tuple(field_idx)
+            } else {
+                crate::model::FieldAddr::Record(FieldOffset(field_idx))
+            };
             siblings.push(Instr::FieldDropInPlace {
                 base: Place::Local(node_local),
-                field: crate::model::FieldAddr::Record(FieldOffset(field_idx)),
+                field,
                 ty: field_ty,
             });
         }
@@ -39045,6 +39100,25 @@ fn derive_tuple_composite_drop_allowed(
     // emitted Drop places recovers every consumer regardless of which mechanism
     // (owned_locals standalone drop, loop-scope drop, or break/continue edge)
     // released it.
+    //
+    // EXCEPT the string read-temps (#54, the record prover's exemption mirrored
+    // for tuples — #2383): the spliced `hew_string_drop` for a `string`
+    // `TupleFieldLoad` dest (`apply_nested_fresh_string_temp_drops`) releases a
+    // FRESH, codegen-cloned (`retain_string_field_load` → `hew_string_clone`)
+    // refcount of the element — NOT the tuple's original `+1`. Counting it as a
+    // `release_owner_base` treats a benign borrowing READ of a tuple element
+    // (`l.0.len()`, `println(pair.1)`) as an element-ownership EXTRACTION and
+    // wrongly drops the whole tuple's `TupleInPlace` — the caller-side half of
+    // the #2383 leak (a returned pair whose elements were only read leaked both
+    // strings every call). A NON-string element extracted into an owning
+    // binding (a generator handle `let g = pair.0`) is not a
+    // `string_field_load_producer_dest` and still seeds.
+    let exempt_read_temp_locals: HashSet<u32> = blocks
+        .iter()
+        .flat_map(|block| block.instructions.iter())
+        .filter_map(|instr| string_field_load_producer_dest(instr, local_tys))
+        .filter_map(base_local)
+        .collect();
     for block in blocks {
         for instr in &block.instructions {
             if let Instr::Drop {
@@ -39054,6 +39128,9 @@ fn derive_tuple_composite_drop_allowed(
             } = instr
             {
                 if let Some(l) = base_local(*place) {
+                    if exempt_read_temp_locals.contains(&l) {
+                        continue;
+                    }
                     release_owner_bases.insert(l);
                 }
             }
@@ -46861,6 +46938,19 @@ mod escaped_sibling_field_discharge {
         matches!(ty, ResolvedTy::String)
     }
 
+    /// Tuple owned-element list: every `string` element of a tuple node.
+    fn owned_tuple_fields(ty: &ResolvedTy) -> Vec<(u32, ResolvedTy)> {
+        let ResolvedTy::Tuple(items) = ty else {
+            return Vec::new();
+        };
+        items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| matches!(item, ResolvedTy::String))
+            .filter_map(|(idx, item)| u32::try_from(idx).ok().map(|i| (i, item.clone())))
+            .collect()
+    }
+
     fn field_orders() -> HashMap<String, Vec<(String, ResolvedTy)>> {
         let mut orders = HashMap::new();
         orders.insert(
@@ -46900,6 +46990,7 @@ mod escaped_sibling_field_discharge {
             &[],
             &is_rec,
             &owned_fields,
+            &owned_tuple_fields,
             &dischargeable,
             &mut instr_spans,
         );
@@ -47260,6 +47351,7 @@ mod escaped_sibling_field_discharge {
             &[],
             &is_rec,
             &three_fields,
+            &owned_tuple_fields,
             &dischargeable,
             &mut instr_spans,
         );

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -34424,6 +34424,115 @@ fn close_alias_binders_forward(blocks: &[BasicBlock], seeds: &[(u32, u32)]) -> H
     owner_of
 }
 
+/// True when `Place::Local(local)` holds a heap-owning INLINE aggregate — a
+/// tuple, fixed array, user record, or inline enum — whose field/element load
+/// codegen BYTE-COPIES with no retain (the
+/// [`ByteCopyAlias`](FieldLoadClass::ByteCopyAlias) load class). The free-
+/// function mirror of [`Builder::classify_field_load`]'s `ByteCopyAlias` arm
+/// for the drop-allow provers, which have no `Builder` in scope.
+///
+/// Deliberately under-approximating (fail-closed): `string` (codegen retains
+/// the load — the dest owns a fresh `+1`), the single-pointer handle leaves
+/// (`Vec` / `bytes` / `HashMap` / `Generator` / …, which TRANSFER their one
+/// handle), indirect enums (a single owned node pointer), and opaque types are
+/// all refused. Refusing keeps a dest invisible to the match-hop descent —
+/// exactly today's posture for it — never a wrong alias attribution.
+fn local_is_byte_copy_aggregate(
+    local: u32,
+    local_tys: &[ResolvedTy],
+    record_field_orders: &HashMap<String, Vec<(String, ResolvedTy)>>,
+    enum_layouts: &[crate::model::EnumLayout],
+) -> bool {
+    let Some(ty) = local_tys.get(local as usize) else {
+        return false;
+    };
+    if !crate::model::ty_owns_heap_mir(ty, record_field_orders, enum_layouts) {
+        return false;
+    }
+    match ty {
+        ResolvedTy::Tuple(_) | ResolvedTy::Array(_, _) => true,
+        ResolvedTy::Named {
+            builtin: None,
+            is_opaque: false,
+            ..
+        } => !ty_is_indirect_enum(ty, enum_layouts),
+        _ => false,
+    }
+}
+
+/// #2384 — forward closure of the interior-alias binders through MATCH-BOUND
+/// hops. [`close_alias_binders_forward`] follows only whole-value `Move`s, so
+/// a chain hop bound via `match` (`let leaf = match mid { Mid { leaf, x: _ }
+/// => leaf }`) is invisible to the composite-drop provers: the destructure
+/// lowers to a `RecordFieldLoad` / `TupleFieldLoad` off the scrutinee COPY
+/// (itself a `Move` of the alias), and the loaded inline aggregate byte-copies
+/// the member with no retain — the binder is still an alias of the OWNER
+/// root's storage, not a fresh owner. When such a binder then escaped
+/// (returned), the owner's composite stayed admitted and re-freed the subtree
+/// the escapee handed to the caller (the `free_cstring` sentinel abort).
+///
+/// This walk extends the `Move` closure with one gated descent rule: a
+/// `RecordFieldLoad` / `TupleFieldLoad` whose base is a tracked local marks
+/// the DEST as an alias of the same owner IFF the dest is a byte-copy inline
+/// aggregate ([`local_is_byte_copy_aggregate`] — a retained `string` or a
+/// transferred handle dest is a real owner and must NOT be attributed).
+///
+/// Consumers fold the result into their ESCAPE arms only — never into the
+/// `release_owner_bases` Defect-1 blanket. A match-bound binder is an owned
+/// binding with its own (prover-suppressed) release path, so blanket-scanning
+/// it would newly exclude owners in today-clean non-escaping shapes (turning
+/// an exactly-once composite into a whole-tree leak); the escape arms widen
+/// exclusion only when the binder actually leaves the function.
+fn descend_match_bound_hop_aliases(
+    blocks: &[BasicBlock],
+    seeds: &HashMap<u32, u32>,
+    dest_is_byte_copy_aggregate: &dyn Fn(u32) -> bool,
+) -> HashMap<u32, u32> {
+    let mut owner_of: HashMap<u32, u32> = seeds.clone();
+    loop {
+        let mut changed = false;
+        for block in blocks {
+            for instr in &block.instructions {
+                let (base, dest) = match instr {
+                    Instr::Move { dest, src } => (*src, *dest),
+                    Instr::RecordFieldLoad { record, dest, .. } => {
+                        let Some(dl) = base_local(*dest) else {
+                            continue;
+                        };
+                        if !dest_is_byte_copy_aggregate(dl) {
+                            continue;
+                        }
+                        (*record, *dest)
+                    }
+                    Instr::TupleFieldLoad { tuple, dest, .. } => {
+                        let Some(dl) = base_local(*dest) else {
+                            continue;
+                        };
+                        if !dest_is_byte_copy_aggregate(dl) {
+                            continue;
+                        }
+                        (*tuple, *dest)
+                    }
+                    _ => continue,
+                };
+                if let (Some(sl), Some(dl)) = (base_local(base), base_local(dest)) {
+                    if let Some(&owner) = owner_of.get(&sl) {
+                        if let std::collections::hash_map::Entry::Vacant(slot) = owner_of.entry(dl)
+                        {
+                            slot.insert(owner);
+                            changed = true;
+                        }
+                    }
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    owner_of
+}
+
 fn collect_record_field_binders(
     blocks: &[BasicBlock],
     alias_of: &HashMap<u32, u32>,
@@ -37865,7 +37974,8 @@ fn derive_owned_record_drop_allowed(
     // interiorly (the consumed-match path). `or_insert` never overrides the
     // precise `Unique { root, field }` a one-hop binder already earned (the
     // sibling-discharge emitter needs that field).
-    for (&alias_local, &owner_local) in &close_alias_binders_forward(blocks, alias_field_binders) {
+    let folded_aliases = close_alias_binders_forward(blocks, alias_field_binders);
+    for (&alias_local, &owner_local) in &folded_aliases {
         if !candidate_local_to_binding.contains_key(&owner_local) {
             continue;
         }
@@ -37874,6 +37984,39 @@ fn derive_owned_record_drop_allowed(
             .entry(alias_local)
             .or_insert(FieldBinderProvenance::RootOnly { root: owner_local });
     }
+
+    // #2384 — match-bound hop aliases: a chain hop bound out of a `match`
+    // destructure (a byte-copy aggregate loaded off the scrutinee COPY of a
+    // recorded alias) is still an alias of the OWNER root's storage. The
+    // `Move`-only closure above cannot see through the destructure's field
+    // load, so such a binder's ESCAPE left the owner admitted to re-free the
+    // subtree the escapee handed to the caller (the `free_cstring` sentinel
+    // double-free). Fold the gated field-load descent into the ESCAPE arms
+    // only — deliberately NOT into `field_binders`, whose
+    // `release_owner_bases` Defect-1 blanket below would newly exclude owners
+    // in today-clean NON-escaping match shapes (the binder is an owned
+    // binding, so the blanket would always trip and leak the whole tree).
+    let candidate_owned_aliases: HashMap<u32, u32> = folded_aliases
+        .iter()
+        .filter(|(_, owner)| candidate_local_to_binding.contains_key(owner))
+        .map(|(&alias, &owner)| (alias, owner))
+        .collect();
+    let dest_is_byte_copy_aggregate = |local: u32| -> bool {
+        local_is_byte_copy_aggregate(local, local_tys, record_field_orders, enum_layouts)
+    };
+    let mut match_hop_binders = descend_match_bound_hop_aliases(
+        blocks,
+        &candidate_owned_aliases,
+        &dest_is_byte_copy_aggregate,
+    );
+    match_hop_binders.retain(|binder, _| !field_binders.contains(binder));
+    for (&binder, &owner_local) in &match_hop_binders {
+        binder_provenance
+            .entry(binder)
+            .or_insert(FieldBinderProvenance::RootOnly { root: owner_local });
+    }
+    let is_escape_binder =
+        |l: u32| field_binders.contains(&l) || match_hop_binders.contains_key(&l);
 
     let mut excluded_roots: HashSet<u32> = HashSet::new();
 
@@ -38022,7 +38165,7 @@ fn derive_owned_record_drop_allowed(
                     if alias_of.contains_key(&l) {
                         note_alias_escape(l, &mut excluded_roots);
                     }
-                    if field_binders.contains(&l) {
+                    if is_escape_binder(l) {
                         note_field_escape(l, &mut excluded_roots);
                     }
                 }
@@ -38043,8 +38186,8 @@ fn derive_owned_record_drop_allowed(
                     if src_is_member && !dest_is_member {
                         note_alias_escape(sl, &mut excluded_roots);
                     }
-                    if field_binders.contains(&sl) {
-                        let benign = dest_local.is_some_and(|dl| field_binders.contains(&dl))
+                    if is_escape_binder(sl) {
+                        let benign = dest_local.is_some_and(is_escape_binder)
                             && matches!(dest, Place::Local(_));
                         if !benign {
                             note_field_escape(sl, &mut excluded_roots);
@@ -38102,8 +38245,7 @@ fn derive_owned_record_drop_allowed(
                         {
                             note_alias_escape(l, &mut excluded_roots);
                         }
-                        if field_binders.contains(&l) && !binder_read_is_borrow_safe_instr(instr, l)
-                        {
+                        if is_escape_binder(l) && !binder_read_is_borrow_safe_instr(instr, l) {
                             note_field_escape(l, &mut excluded_roots);
                         }
                     }
@@ -38127,7 +38269,7 @@ fn derive_owned_record_drop_allowed(
                 {
                     note_alias_escape(l, &mut excluded_roots);
                 }
-                if field_binders.contains(&l)
+                if is_escape_binder(l)
                     && !binder_read_is_borrow_safe_terminator(
                         &block.terminator,
                         suspend_kinds.get(&block.id),
@@ -38818,11 +38960,37 @@ fn derive_tuple_composite_drop_allowed(
     // double-free). Recording it here makes `note_elem_escape` exclude the tuple
     // roots when the deep alias escapes; a `TupleFieldLoad` reading the alias is
     // interior (exempt), so the owner stays admitted on the consumed-match path.
-    for (&alias_local, &owner_local) in &close_alias_binders_forward(blocks, alias_field_binders) {
+    let folded_aliases = close_alias_binders_forward(blocks, alias_field_binders);
+    for (&alias_local, &owner_local) in &folded_aliases {
         if candidate_local_to_binding.contains_key(&owner_local) {
             elem_binders.insert(alias_local);
         }
     }
+
+    // #2384 (tuple twin) — match-bound hop aliases: an element bound out of a
+    // `match` destructure of a chain alias (`let leaf = match mid { (l, _) =>
+    // l }`) byte-copies the owner root's storage; the `Move`-only closure
+    // above cannot see through the destructure's `TupleFieldLoad`, so such a
+    // binder's escape left the owner admitted to re-free the subtree the
+    // caller now holds. Folded into the ESCAPE arms only — never into
+    // `elem_binders`, whose `release_owner_bases` Defect-1 blanket below would
+    // newly exclude owners in today-clean non-escaping match shapes (the
+    // binder is an owned binding, so the blanket would always trip).
+    let candidate_owned_aliases: HashMap<u32, u32> = folded_aliases
+        .iter()
+        .filter(|(_, owner)| candidate_local_to_binding.contains_key(owner))
+        .map(|(&alias, &owner)| (alias, owner))
+        .collect();
+    let dest_is_byte_copy_aggregate = |local: u32| -> bool {
+        local_is_byte_copy_aggregate(local, local_tys, record_field_orders, enum_layouts)
+    };
+    let mut match_hop_binders = descend_match_bound_hop_aliases(
+        blocks,
+        &candidate_owned_aliases,
+        &dest_is_byte_copy_aggregate,
+    );
+    match_hop_binders.retain(|binder, _| !elem_binders.contains(binder));
+    let is_escape_binder = |l: u32| elem_binders.contains(&l) || match_hop_binders.contains_key(&l);
 
     let mut excluded_roots: HashSet<u32> = HashSet::new();
 
@@ -38959,7 +39127,7 @@ fn derive_tuple_composite_drop_allowed(
                     if alias_of.contains_key(&l) {
                         note_alias_escape(l, &mut excluded_roots);
                     }
-                    if elem_binders.contains(&l) {
+                    if is_escape_binder(l) {
                         note_elem_escape(&mut excluded_roots);
                     }
                 }
@@ -38980,8 +39148,8 @@ fn derive_tuple_composite_drop_allowed(
                     if src_is_member && !dest_is_member {
                         note_alias_escape(sl, &mut excluded_roots);
                     }
-                    if elem_binders.contains(&sl) {
-                        let benign = dest_local.is_some_and(|dl| elem_binders.contains(&dl))
+                    if is_escape_binder(sl) {
+                        let benign = dest_local.is_some_and(is_escape_binder)
                             && matches!(dest, Place::Local(_));
                         if !benign {
                             note_elem_escape(&mut excluded_roots);
@@ -39021,8 +39189,7 @@ fn derive_tuple_composite_drop_allowed(
                         {
                             note_alias_escape(l, &mut excluded_roots);
                         }
-                        if elem_binders.contains(&l) && !binder_read_is_borrow_safe_instr(instr, l)
-                        {
+                        if is_escape_binder(l) && !binder_read_is_borrow_safe_instr(instr, l) {
                             note_elem_escape(&mut excluded_roots);
                         }
                     }
@@ -39046,7 +39213,7 @@ fn derive_tuple_composite_drop_allowed(
                 {
                     note_alias_escape(l, &mut excluded_roots);
                 }
-                if elem_binders.contains(&l)
+                if is_escape_binder(l)
                     && !binder_read_is_borrow_safe_terminator(
                         &block.terminator,
                         suspend_kinds.get(&block.id),


### PR DESCRIPTION
## Summary

I extended the multi-hop chain-sibling drop compensator to two more escape shapes: a `match`-bound intermediate alias hop (previously double-freed the intermediate, #2384) and a multi-hop tuple return chain (previously leaked sibling fields, #2383). Both reach exactly-once drop behaviour for the covered shapes. The compensator's escape triggers stay a strict subset of the provers' exclusion triggers, so it never double-frees — a discharge only ever lands where the composite drop is already suppressed.

## Verification

- Poisoned-allocator + leak harness: the match-hop shape and its tuple twin go from exit 139 (SIGSEGV, double-free) to exit 0 — and this generalizes to 3-hop, dual-escape, and interior-read shapes, confirmed by rebuilding the pre-fix commit and reproducing the crash there.
- Tuple leak: 4 strings/call down to 0.
- Re-confirmed clean (no regression): the record chain and the prior #2373/#2375 shapes.
- 3 new regression oracles added, each verified red-before / green-after against the pre-fix commit.
- `cargo test -p hew-mir`: 879/879 passed.
- `cargo test -p hew-cli --test nested_projection_chain_leak_oracle --release`: 20/20 passed.
- `cargo clippy -p hew-mir --all-targets -- -D warnings`: clean.
- `cargo fmt --check -p hew-mir -p hew-cli`: clean.

## Out of scope

Both pre-existing, bounded, safe, and tracked as follow-ups — neither is touched or made worse by this change:

- A residual fail-closed leak (~2 strings/call) on the match-bound-hop shape where the compensator can't fully attribute the hop back to its owner (only let-bound projections are recorded in the alias projection chain today).
- A tuple-of-user-record composite coverage gap: the tuple composite prover only recognizes `string` tuple elements as dischargeable, so a tuple whose elements are user records still leaks unconditionally in the caller. Confirmed identical before and after this change.

Fixes #2383, fixes #2384.