### PR TITLE
chore(release): prepare v0.6.0-rc1 version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,26 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.0-rc1] — unreleased (in preparation)
 
-### Added
+This is the first release candidate for v0.6. **The tag is not cut yet** — this
+entry tracks the major work landed on the v0.6 line and will be finalized when
+the candidate ships. v0.6 completes the ownership model, closes a batch of
+actor and machine correctness gaps, and reshapes several language surfaces. The
+headline change is that ownership and drop elaboration are now unconditional and
+type-directed: every owned value is released exactly once, with no reliance on
+ad-hoc per-shape heap walkers.
 
-- **Actor sleep-loop mailbox lint.** `hew check` now warns when an actor
-  receive handler loops around `sleep`/`sleep_until` without an in-handler exit
-  path, and the guide documents the cancellable `#[every(duration)]` + flag
-  pattern. (closes #2271)
+### Changed — ownership and drop elaboration
+
+- **Unconditional, type-directed exactly-once drop elaboration.** MIR drop
+  elaboration now walks each owned value's type and drops its fields exactly
+  once from a single seed authority, replacing the conditional per-shape release
+  paths. Match-bound and tuple-chain escapes are compensated so no owned value
+  is dropped twice or leaked, the legacy CBOR heap walker is retired onto the one
+  ownership authority, and borrow classification is unified into a single
+  ownership table. (#2382, #2386)
+- **`#[resource]` fields embedded in records are released.** A record that embeds
+  a `#[resource]` field now runs field-wise close on scope exit. (#2312)
 
 ### Removed (breaking)
 
@@ -19,6 +32,40 @@
   required. Stdlib `Child` (`std::process`) and `MonitorRef`
   (`std::link_monitor`) have been migrated to the `#[resource]` close model.
   (#1986)
+
+### Fixed — actor and machine correctness (correctness fence)
+
+- **Bounded mailboxes.** Codegen now honours a declared mailbox capacity and its
+  overflow policy instead of treating every mailbox as unbounded. (#2389)
+- **Machine `when` guards are evaluated.** A state-machine `when` guard is now
+  evaluated at the transition, and an exhaustiveness fallthrough traps instead of
+  silently taking a wrong edge. (#2390)
+- **Machine `emit` delivery.** Unit `emit` from a machine is delivered through
+  `take_emits` so emitted events are not dropped. (#2393)
+- **`for-in` over an array literal is drop-safe.** HIR captures the array-literal
+  iterator source, so iterating a temporary array no longer double-frees. (#2394)
+- **Fault-isolation hardening.** Root-supervisor escalation guards against a null
+  parent, collection bounds failures route through actor fault isolation, and
+  `SIGPIPE` is ignored so a broken-pipe send fails closed rather than killing the
+  process. (#2327)
+
+### Added — language surface
+
+- **`try_to_*` numeric conversions.** Fallible numeric conversions with exactness
+  checking (`try_to_i32`, `try_to_u8`, …) return an error on an out-of-range or
+  lossy conversion instead of truncating silently. (#2368)
+- **Unified `.send()`.** Actor fire-and-forget sends use one `.send()` verb
+  across local and remote targets. (#2369)
+- **`#[wire]` types.** Wire-format declarations use the `#[wire]` type attribute;
+  the `struct` keyword has been removed. (#2370, closes #2365)
+- **Iterator-trait completion.** The iterator surface is completed across
+  diagnostics, docs, and the standard collections, including `Vec<T>::iter()`
+  non-consuming iteration and `HashMap::into_iter()`, so pipeline and `for-in`
+  forms match across collections. (#2323, #2299)
+- **Actor sleep-loop mailbox lint.** `hew check` now warns when an actor receive
+  handler loops around `sleep`/`sleep_until` without an in-handler exit path, and
+  the guide documents the cancellable `#[every(duration)]` + flag pattern.
+  (closes #2271)
 
 ## [0.5.1] — 2026-06-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adze-cli"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "base64",
  "clap",
@@ -1774,7 +1774,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hew-analysis"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "hew-lexer",
  "hew-parser",
@@ -1785,14 +1785,14 @@ dependencies = [
 
 [[package]]
 name = "hew-cabi"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-capability-gen"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "serde",
  "toml",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "hew-cli"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "adze-cli",
  "clap",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "hew-codegen-rs"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "hew-cabi",
  "hew-hir",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "hew-compile"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "hew-hir",
  "hew-lexer",
@@ -1860,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "hew-hir"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "hew-parser",
  "hew-types",
@@ -1869,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lexer"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "logos",
  "serde_json",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lib"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "hew-runtime",
  "hew-std",
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "hew-lsp"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "dashmap 6.2.1",
  "hew-analysis",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "hew-mir"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "hew-hir",
  "hew-parser",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "hew-observe"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "clap",
  "crossterm",
@@ -1929,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "hew-parser"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "finl_unicode",
  "hew-lexer",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "bytes",
  "cddl",
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "hew-runtime-testkit"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "hew-runtime",
  "libc",
@@ -1986,7 +1986,7 @@ dependencies = [
 
 [[package]]
 name = "hew-sandbox-wasm"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "assert_cmd",
  "hew-parser",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "hew-std"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "argon2",
  "base64",
@@ -2037,22 +2037,22 @@ dependencies = [
 
 [[package]]
 name = "hew-std-encoding-binary"
-version = "0.5.6"
+version = "0.6.0-rc1"
 
 [[package]]
 name = "hew-std-text-template"
-version = "0.5.6"
+version = "0.6.0-rc1"
 
 [[package]]
 name = "hew-testutil"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "hew-types"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "hew-cabi",
  "hew-parser",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "hew-wasm"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "hew-analysis",
  "hew-hir",
@@ -6061,7 +6061,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.5.6"
+version = "0.6.0-rc1"
 dependencies = [
  "hew-sandbox-wasm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = ["hew-parser/fuzz"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.6"
+version = "0.6.0-rc1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Stephen Olesen <slepp@slepp.ca>"]

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -8579,30 +8579,30 @@ limitations under the License.
 
 ================================================================================
 Apache License 2.0
-  * adze-cli 0.5.6 — https://github.com/hew-lang/hew
-  * hew-analysis 0.5.6 — https://github.com/hew-lang/hew
-  * hew-cabi 0.5.6 — https://github.com/hew-lang/hew
-  * hew-capability-gen 0.5.6 — https://github.com/hew-lang/hew
-  * hew-cli 0.5.6 — https://github.com/hew-lang/hew
-  * hew-codegen-rs 0.5.6 — https://github.com/hew-lang/hew
-  * hew-compile 0.5.6 — https://github.com/hew-lang/hew
-  * hew-hir 0.5.6 — https://github.com/hew-lang/hew
-  * hew-lexer 0.5.6 — https://github.com/hew-lang/hew
-  * hew-lib 0.5.6
-  * hew-lsp 0.5.6 — https://github.com/hew-lang/hew
-  * hew-mir 0.5.6 — https://github.com/hew-lang/hew
-  * hew-observe 0.5.6 — https://github.com/hew-lang/hew
-  * hew-parser 0.5.6 — https://github.com/hew-lang/hew
-  * hew-runtime 0.5.6 — https://github.com/hew-lang/hew
-  * hew-runtime-testkit 0.5.6 — https://github.com/hew-lang/hew
-  * hew-sandbox-wasm 0.5.6 — https://github.com/hew-lang/hew
-  * hew-std 0.5.6 — https://github.com/hew-lang/hew
-  * hew-testutil 0.5.6
-  * hew-types 0.5.6 — https://github.com/hew-lang/hew
-  * hew-wasm 0.5.6 — https://github.com/hew-lang/hew
-  * hew-std-encoding-binary 0.5.6 — https://github.com/hew-lang/hew
-  * hew-std-text-template 0.5.6 — https://github.com/hew-lang/hew
-  * xtask 0.5.6 — https://github.com/hew-lang/hew
+  * adze-cli 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-analysis 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-cabi 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-capability-gen 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-cli 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-codegen-rs 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-compile 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-hir 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-lexer 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-lib 0.6.0-rc1
+  * hew-lsp 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-mir 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-observe 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-parser 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-runtime 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-runtime-testkit 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-sandbox-wasm 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-std 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-testutil 0.6.0-rc1
+  * hew-types 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-wasm 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-std-encoding-binary 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * hew-std-text-template 0.6.0-rc1 — https://github.com/hew-lang/hew
+  * xtask 0.6.0-rc1 — https://github.com/hew-lang/hew
   * abnf_to_pest 0.5.1 — https://github.com/Nadrieril/dhall-rust
   * allocator-api2 0.2.21 — https://github.com/zakarumych/allocator-api2
   * android_system_properties 0.1.5 — https://github.com/nical/android_system_properties

--- a/hew-sandbox-vm/fixtures/01-hello-world/bytecode.json
+++ b/hew-sandbox-vm/fixtures/01-hello-world/bytecode.json
@@ -9,7 +9,7 @@
       ]
     }
   ],
-  "compiler_version": "hew-sandbox-wasm-0.5.6",
+  "compiler_version": "hew-sandbox-wasm-0.6.0-rc1",
   "functions": [
     {
       "blocks": [
@@ -100,7 +100,7 @@
       "span": "span:0-45"
     }
   ],
-  "hew_version": "0.5.6",
+  "hew_version": "0.6.0-rc1",
   "layouts": {
     "actors": [],
     "enums": [],

--- a/hew-sandbox-vm/fixtures/02-arithmetic-checked/bytecode.json
+++ b/hew-sandbox-vm/fixtures/02-arithmetic-checked/bytecode.json
@@ -9,7 +9,7 @@
       ]
     }
   ],
-  "compiler_version": "hew-sandbox-wasm-0.5.6",
+  "compiler_version": "hew-sandbox-wasm-0.6.0-rc1",
   "functions": [
     {
       "blocks": [
@@ -180,7 +180,7 @@
       "span": "span:0-64"
     }
   ],
-  "hew_version": "0.5.6",
+  "hew_version": "0.6.0-rc1",
   "layouts": {
     "actors": [],
     "enums": [],

--- a/hew-sandbox-vm/fixtures/04-record-fields/bytecode.json
+++ b/hew-sandbox-vm/fixtures/04-record-fields/bytecode.json
@@ -9,7 +9,7 @@
       ]
     }
   ],
-  "compiler_version": "hew-sandbox-wasm-0.5.6",
+  "compiler_version": "hew-sandbox-wasm-0.6.0-rc1",
   "functions": [
     {
       "blocks": [
@@ -268,7 +268,7 @@
       "span": "span:40-111"
     }
   ],
-  "hew_version": "0.5.6",
+  "hew_version": "0.6.0-rc1",
   "layouts": {
     "actors": [],
     "enums": [],

--- a/hew-sandbox-vm/fixtures/05-enum-match/bytecode.json
+++ b/hew-sandbox-vm/fixtures/05-enum-match/bytecode.json
@@ -9,7 +9,7 @@
       ]
     }
   ],
-  "compiler_version": "hew-sandbox-wasm-0.5.6",
+  "compiler_version": "hew-sandbox-wasm-0.6.0-rc1",
   "functions": [
     {
       "blocks": [
@@ -657,7 +657,7 @@
       "span": "span:182-231"
     }
   ],
-  "hew_version": "0.5.6",
+  "hew_version": "0.6.0-rc1",
   "layouts": {
     "actors": [],
     "enums": [

--- a/hew-sandbox-vm/fixtures/06-vector-basics/bytecode.json
+++ b/hew-sandbox-vm/fixtures/06-vector-basics/bytecode.json
@@ -9,7 +9,7 @@
       ]
     }
   ],
-  "compiler_version": "hew-sandbox-wasm-0.5.6",
+  "compiler_version": "hew-sandbox-wasm-0.6.0-rc1",
   "functions": [
     {
       "blocks": [
@@ -672,7 +672,7 @@
       "span": "span:0-213"
     }
   ],
-  "hew_version": "0.5.6",
+  "hew_version": "0.6.0-rc1",
   "layouts": {
     "actors": [],
     "enums": [

--- a/hew-sandbox-vm/fixtures/07-string-interpolation/bytecode.json
+++ b/hew-sandbox-vm/fixtures/07-string-interpolation/bytecode.json
@@ -9,7 +9,7 @@
       ]
     }
   ],
-  "compiler_version": "hew-sandbox-wasm-0.5.6",
+  "compiler_version": "hew-sandbox-wasm-0.6.0-rc1",
   "functions": [
     {
       "blocks": [
@@ -220,7 +220,7 @@
       "span": "span:0-74"
     }
   ],
-  "hew_version": "0.5.6",
+  "hew_version": "0.6.0-rc1",
   "layouts": {
     "actors": [],
     "enums": [],

--- a/hew-sandbox-vm/fixtures/08-regex-match/bytecode.json
+++ b/hew-sandbox-vm/fixtures/08-regex-match/bytecode.json
@@ -19,7 +19,7 @@
       ]
     }
   ],
-  "compiler_version": "hew-sandbox-wasm-0.5.6",
+  "compiler_version": "hew-sandbox-wasm-0.6.0-rc1",
   "functions": [
     {
       "blocks": [
@@ -250,7 +250,7 @@
       "span": "span:26-120"
     }
   ],
-  "hew_version": "0.5.6",
+  "hew_version": "0.6.0-rc1",
   "layouts": {
     "actors": [],
     "enums": [],

--- a/hew-sandbox-vm/fixtures/11-runtime-panic/bytecode.json
+++ b/hew-sandbox-vm/fixtures/11-runtime-panic/bytecode.json
@@ -1,6 +1,6 @@
 {
   "capabilities": [],
-  "compiler_version": "hew-sandbox-wasm-0.5.6",
+  "compiler_version": "hew-sandbox-wasm-0.6.0-rc1",
   "functions": [
     {
       "blocks": [
@@ -87,7 +87,7 @@
       "span": "span:0-41"
     }
   ],
-  "hew_version": "0.5.6",
+  "hew_version": "0.6.0-rc1",
   "layouts": {
     "actors": [],
     "enums": [],

--- a/hew-sandbox-vm/fixtures/12-divide-by-zero-trap/bytecode.json
+++ b/hew-sandbox-vm/fixtures/12-divide-by-zero-trap/bytecode.json
@@ -9,7 +9,7 @@
       ]
     }
   ],
-  "compiler_version": "hew-sandbox-wasm-0.5.6",
+  "compiler_version": "hew-sandbox-wasm-0.6.0-rc1",
   "functions": [
     {
       "blocks": [
@@ -180,7 +180,7 @@
       "span": "span:0-68"
     }
   ],
-  "hew_version": "0.5.6",
+  "hew_version": "0.6.0-rc1",
   "layouts": {
     "actors": [],
     "enums": [],

--- a/hew-sandbox-vm/fixtures/23-direct-call/bytecode.json
+++ b/hew-sandbox-vm/fixtures/23-direct-call/bytecode.json
@@ -9,7 +9,7 @@
       ]
     }
   ],
-  "compiler_version": "hew-sandbox-wasm-0.5.6",
+  "compiler_version": "hew-sandbox-wasm-0.6.0-rc1",
   "functions": [
     {
       "blocks": [
@@ -178,7 +178,7 @@
       "span": "span:39-73"
     }
   ],
-  "hew_version": "0.5.6",
+  "hew_version": "0.6.0-rc1",
   "layouts": {
     "actors": [],
     "enums": [],


### PR DESCRIPTION
## Summary

I'm bringing the in-repo version forward to v0.6.0-rc1 in preparation for the release tag (I'm not tagging yet). The workspace `[workspace.package].version` is the single source of truth (0.5.6 → 0.6.0-rc1); all 24 crates inherit it and `hew --version` tracks it automatically. I added a `## [0.6.0-rc1] — unreleased (in preparation)` CHANGELOG section summarising the major v0.6 work — the ownership-consolidation program, the correctness fence, the language-surface changes, and iterator-trait completion — and regenerated `THIRD-PARTY-LICENSES` (the 24 workspace crates) and the 10 auto-derived sandbox bytecode fixtures to match.

## Verification

- `make lint`: green
- `hew --version`: `hew 0.6.0-rc1`
- `scripts/check-licenses-fresh.sh`: clean — the CI license-freshness gate is satisfied
- No remaining Hew-own `0.5.6` references

## Out of scope

- The actual git tag stays held until the ship-gate criteria are met.