### PR TITLE
ci: raise the Linux build-and-test timeout to unblock the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,13 @@ jobs:
   build-and-test:
     name: Build & test (Linux)
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    # Was 60. Successful runs on main land at 51-56 min wall time (checked
+    # 2026-07-04 across 5 recent green runs), leaving only 4-9 min of
+    # headroom against normal runner-to-runner variance -- PRs #2396 and
+    # #2397 both got CANCELLED at exactly 60m00-16s. 90 min restores real
+    # headroom without masking a genuine regression (see the diagnosis in
+    # the commit that introduced this change).
+    timeout-minutes: 90
     env:
       # mold is installed by the "Install build tools" step below.
       # Use gcc's -fuse-ld=mold flag (no clang-as-driver dependency) to


### PR DESCRIPTION
## Summary

The "Build & test (Linux)" job was hitting its 60-minute ceiling and getting cancelled, which blocked the merge queue (confirmed on two separate PRs; the Windows and macOS jobs finish in ~23 min). Linux legitimately does far more work: it owns ~8 additional full-corpus oracle/ratchet gates the other platforms don't run (vertical-slice, fuzz-oracle, hew-ratchet, o2-differential, stdlib-ratchet, doc-examples, sandbox-parity, checked-mir-verify, hew-check-all, observe-functional-test — Linux owns full correctness on every change). Its baseline is 51-56 min, only 4-9 min under the ceiling, and recent additions tipped it over. I raised the Linux job's `timeout-minutes` to 90 to restore headroom; Windows and macOS stay at 60.

## Verification

- The workflow YAML parses cleanly.
- `timeout-minutes: 90` lands specifically on the Linux `build-and-test` job; `build-and-test-windows` and `build-and-test-macos` remain at 60.

## Follow-up (not this PR)

`scripts/o2-differential.sh` runs the full `tests/hew` corpus twice serially (O0 then O2, ~16 min); parallelizing those two passes is the real runtime reduction. I'm tracking that as a separate performance follow-up rather than treating a raised ceiling as the long-term answer.