### PR TITLE
fix(hir,codegen): link http server and client in one compilation unit

### DIFF
--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -1879,6 +1879,62 @@ fn run_match_record_wildcard_owned_aggregate_field_drops_once() {
     assert_eq!(actual, expected, "stdout mismatch for {}", source.display());
 }
 
+/// Fail-closed boundary (#2391 sibling class): two imported modules each
+/// define a DISTINCT type named `Server` with an `impl ServerMethods for
+/// Server`, so both lower `Server::accept` / `Server::close` under the same
+/// unqualified raw-MIR symbol. The #2391 HIR dedup only covers ONE shared file
+/// re-imported under two overlapping package modules; two genuinely different
+/// bodies cannot share the symbol namespace until impl symbols become
+/// module-qualified (#2400). Codegen must reject this with a STRUCTURED
+/// duplicate-symbol diagnostic — not the opaque LLVM verifier dump ("Global is
+/// external, but doesn't have external or weak linkage!"), and not a silent
+/// linkonce merge of the two distinct bodies.
+#[test]
+fn check_dual_module_same_type_name_impl_fails_closed() {
+    require_codegen();
+
+    let source =
+        repo_root().join("tests/vertical-slice/reject/dual_module_same_type_name_impl.hew");
+    let output = Command::new(hew_binary())
+        .arg("check")
+        .arg(&source)
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew check");
+
+    assert!(
+        !output.status.success(),
+        "expected check to fail; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Pin on the symbol-independent phrasing (which of `Server::accept` /
+    // `Server::close` collides first is declaration-order dependent), plus the
+    // duplicate-symbol lead and the follow-up issue reference, so the guard
+    // stays diagnosable and cannot silently regress to the LLVM dump.
+    assert!(
+        combined.contains("duplicate function symbol"),
+        "expected duplicate-symbol diagnostic; got: {combined}"
+    );
+    assert!(
+        combined.contains("distinct same-named types cannot yet share one compilation unit"),
+        "expected the actionable distinct-same-named-types cause; got: {combined}"
+    );
+    assert!(
+        combined.contains("#2400"),
+        "expected the follow-up issue reference; got: {combined}"
+    );
+    assert!(
+        !combined.contains("doesn't have external or weak linkage"),
+        "must not degrade to the raw LLVM verifier dump; got: {combined}"
+    );
+}
+
 /// Fail-closed boundary: match-destructure wildcard on a CLOSURE-typed
 /// field. Neither discharge path can place it — no leaf release symbol
 /// (`project_field_inline_drop_symbol` returns `None`) and the in-place

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -38601,7 +38601,37 @@ fn build_module_for_target<'ctx>(
         &pipeline.extern_decls,
         &record_layouts,
     )?;
+    // #2391 fail-closed guard: two raw-MIR functions sharing one name (e.g. two
+    // imported modules each defining a DISTINCT type with the same bare name and
+    // method — `std::net::http` and `std::net::websocket` both define a `Server`
+    // with `impl ServerMethods for Server`, so both emit `Server::accept` /
+    // `Server::close`). Without this, `add_function` is called twice with the
+    // same name; LLVM auto-renames the second, `lower_function` appends BOTH
+    // bodies to the winner, and the first survives as a bodiless
+    // internal-linkage declaration that `Module::verify()` rejects with the
+    // opaque "Global is external, but doesn't have external or weak linkage!"
+    // dump. Weak/linkonce linkage would be FAIL-OPEN here — it would silently
+    // keep one of the two DISTINCT bodies — so the collision is converted to a
+    // structured diagnosable error instead. Any duplicate raw-MIR name today
+    // already produces that verify failure or a silent garbage block, so this
+    // guard cannot regress a working program; it also fences the
+    // impossible-today partial-overlap edge left by the HIR subsumed-module
+    // dedup. Names are tracked WITHIN this loop ONLY: raw-MIR functions may
+    // legitimately share a name with a predeclared stdlib-catalog / extern
+    // symbol (the intrinsic-floor path relies on lookup-or-declare), so the
+    // predeclared sets are deliberately NOT consulted.
+    let mut seen_raw_mir_symbols: HashSet<&str> = HashSet::new();
     for func in &pipeline.raw_mir {
+        if !seen_raw_mir_symbols.insert(func.name.as_str()) {
+            return Err(CodegenError::FailClosed(format!(
+                "duplicate function symbol `{}`: two impl blocks lowered to the same \
+                 unqualified symbol. Two imported modules each define a type named the \
+                 same with this method; distinct same-named types cannot yet share one \
+                 compilation unit (see #2400). Rename one of the types, or import only \
+                 one of the modules.",
+                func.name
+            )));
+        }
         let sym = declare_function(
             ctx,
             &llvm_mod,

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -1556,6 +1556,106 @@ fn file_import_module_ids(program: &Program) -> HashSet<hew_parser::module::Modu
     ids
 }
 
+/// Identify, by PROVENANCE (file-set subsumption), the package-import graph
+/// modules whose `impl` blocks must NOT be re-lowered by the fourth pass
+/// because a *superset* package module already lowers the identical impl
+/// items under the same unqualified `<SelfType>::<method>` symbols.
+///
+/// WHY this exists: a directory module (`import std::net::http` resolves to
+/// `std/net/http/http.hew`, whose stem matches its directory, so it is a
+/// *directory module* that peer-absorbs every sibling `.hew`) and an explicit
+/// sub-file import of one of those peers (`import std::net::http::http_client`)
+/// register as two distinct graph modules whose `source_paths` sets are
+/// `{http_client.hew} ⊂ {http.hew, http_client.hew, …}`. Both survive the
+/// `file_import_module_ids` guard (both are PACKAGE imports, not file-path
+/// imports), so `lower_impl_block` runs on `http_client.hew`'s
+/// `impl ResponseMethods for Response` TWICE — once per module — emitting
+/// `Response::status` … `Response::free` under identical bare symbols. Two
+/// `RawMirFunction`s with one name make codegen declare the LLVM function
+/// twice; the first stays a bodiless internal-linkage declaration and
+/// `Module::verify()` rejects it ("Global is external, but doesn't have
+/// external or weak linkage!"). See #2391.
+///
+/// SEMANTICS: over package modules only (the root and every
+/// `file_import_modules` id are excluded — file-import doubles are already
+/// handled by the splice-dedup guard), treat each module's `source_paths` as a
+/// canonical path set. Module M is *subsumed* iff some N ≠ M has
+/// `files(M) ⊆ files(N)` and EITHER `files(M) ⊊ files(N)` (a strict subset
+/// always loses, so the maximal superset survives — subset is transitive) OR
+/// the sets are equal and N precedes M in `topo_order` (a deterministic
+/// tiebreak that keeps exactly one of two identical modules). Today's loader
+/// only ever yields disjoint, equal, or single-file ⊂ directory sets (peer
+/// absorption is a non-recursive `read_dir`), so partial overlap cannot arise;
+/// if it ever did, both copies lower and the codegen duplicate-raw-symbol guard
+/// catches the collision fail-closed rather than silently.
+///
+/// WHY only impl methods: pub free fns lower under module-qualified
+/// `{module_short}$fn` names (both copies are needed — `http_client.get(...)`
+/// binds `http_client$get`), consts under `{module_short}.NAME`, actors under
+/// per-module layouts; only impl methods use the bare `<SelfType>::<method>`
+/// family, so the subsumed skip is applied ONLY in the `Item::Impl` arm.
+///
+/// WHEN OBSOLETE / WHAT REPLACES IT: this provenance dedup disappears once
+/// impl-method symbols become module-qualified (the foundational fix that also
+/// unblocks two DISTINCT same-named types in one unit, e.g. http + websocket
+/// each defining `Server`); tracked as the #2391 follow-up. Until then this
+/// keeps the #2391 flagship shape (one program importing both `std::net::http`
+/// and `std::net::http::http_client`) linking.
+fn subsumed_package_module_ids(
+    program: &Program,
+    file_import_modules: &HashSet<hew_parser::module::ModuleId>,
+) -> HashSet<hew_parser::module::ModuleId> {
+    use std::path::{Path, PathBuf};
+
+    let mut subsumed = HashSet::new();
+    let Some(mg) = &program.module_graph else {
+        return subsumed;
+    };
+
+    // Candidate = package module actually visited by the fourth pass. Build in
+    // `topo_order` so each carries its position, giving the equal-set tiebreak
+    // for free (earlier position survives). Modules absent from `mg.modules`
+    // are never lowered, so they cannot subsume or be subsumed.
+    let mut candidates: Vec<(&hew_parser::module::ModuleId, HashSet<&Path>, usize)> = Vec::new();
+    for (pos, id) in mg.topo_order.iter().enumerate() {
+        if *id == mg.root || file_import_modules.contains(id) {
+            continue;
+        }
+        let Some(module) = mg.modules.get(id) else {
+            continue;
+        };
+        let files: HashSet<&Path> = module.source_paths.iter().map(PathBuf::as_path).collect();
+        // A module with no source paths cannot meaningfully subset another;
+        // leave it to lower normally.
+        if files.is_empty() {
+            continue;
+        }
+        candidates.push((id, files, pos));
+    }
+
+    for i in 0..candidates.len() {
+        let (m_files, m_pos) = (&candidates[i].1, candidates[i].2);
+        for j in 0..candidates.len() {
+            if i == j {
+                continue;
+            }
+            let (n_files, n_pos) = (&candidates[j].1, candidates[j].2);
+            if !m_files.is_subset(n_files) {
+                continue;
+            }
+            // files(M) ⊆ files(N). A strict subset is always subsumed; equal
+            // sets subsume only the one later in topo order, so exactly one of
+            // the pair survives.
+            let equal = m_files.len() == n_files.len();
+            if !equal || n_pos < m_pos {
+                subsumed.insert(candidates[i].0.clone());
+                break;
+            }
+        }
+    }
+    subsumed
+}
+
 #[must_use]
 pub fn lower_program(
     program: &Program,
@@ -3154,6 +3254,13 @@ pub fn lower_program_with_mono_cap(
         // impl. `file_import_module_ids` cannot misroute a package impl: package
         // modules are never in the set, so this walk emits them exactly once.
         let file_import_modules = file_import_module_ids(program);
+        // Package modules whose impl blocks are byte-identical clones of a
+        // superset package module's (a directory module and an explicit
+        // sub-file import of one of its peers). Their impls MUST be skipped
+        // here or they lower twice under the same bare `<SelfType>::<method>`
+        // symbols — the #2391 dual-import link failure. See
+        // `subsumed_package_module_ids` for the full mechanism.
+        let subsumed_modules = subsumed_package_module_ids(program, &file_import_modules);
         // Mirror the checker's 1-based non-root module index. The checker
         // increments `current_module_idx` before each non-root topo-order
         // module and uses it to stamp `SpanKey`s in `expr_types`. The HIR
@@ -3414,7 +3521,29 @@ pub fn lower_program_with_mono_cap(
                             // identity, so a package-import impl that merely
                             // shares a bare type/trait name with a file-import
                             // or root impl is never skipped.
-                            if file_import_modules.contains(mod_id) {
+                            //
+                            // Also skip SUBSUMED package modules: a directory
+                            // module (`import std::net::http`) peer-absorbs a
+                            // file that an explicit sub-file import
+                            // (`import std::net::http::http_client`) re-imports
+                            // as its own module. Both survive the file-import
+                            // guard, so without this the shared file's impl
+                            // (`impl ResponseMethods for Response`) lowers twice
+                            // under identical bare symbols → the #2391
+                            // dual-import LLVM-verify failure. The superset
+                            // module lowers the identical items once; its larger
+                            // `same_module_pub_fns`/`fn_registry` view means it
+                            // resolves a SUPERSET of names, so the surviving copy
+                            // skips no method the subsumed copy would have kept
+                            // (strictly fewer `skip_methods`, never more). Both
+                            // guards are per-ITEM `continue`s — the enclosing
+                            // module loop and its `module_idx` increment are
+                            // never skipped, keeping the HIR/checker module-index
+                            // mirroring in sync. See
+                            // `subsumed_package_module_ids`.
+                            if file_import_modules.contains(mod_id)
+                                || subsumed_modules.contains(mod_id)
+                            {
                                 continue;
                             }
                             if let TypeExpr::Named {

--- a/tests/hew/http_dual_import_link_test.hew
+++ b/tests/hew/http_dual_import_link_test.hew
@@ -1,0 +1,50 @@
+//! #2391: an HTTP server (`std::net::http`) and client
+//! (`std::net::http::http_client`) in ONE compilation unit must link and run.
+//!
+//! `import std::net::http` resolves to a directory module that peer-absorbs
+//! `http_client.hew`; `import std::net::http::http_client` re-imports the same
+//! file as its own module. Before the fix, `impl ResponseMethods for Response`
+//! lowered once PER MODULE under identical bare `Response::<method>` symbols, so
+//! codegen declared each twice and the first stayed a bodiless internal-linkage
+//! declaration that `Module::verify()` rejected:
+//!   Global is external, but doesn't have external or weak linkage!
+//!   ptr @"Response::status"  (and ::body ::header ::content_type ::headers ::free)
+//! After the fix the shared file's impl lowers exactly once and every
+//! previously-bodiless accessor is executable.
+
+import std::net::http;
+
+import std::net::http::http_client;
+
+import std::testing;
+
+/// Server-side impl (`impl ServerMethods for Server`) is reachable and
+/// executable in the dual-import unit. `:0` binds an ephemeral port (the
+/// CI-safe pattern, cf. `net_try_api_test.hew` `net.try_listen(":0")`), so no
+/// fixed port is held across the test run.
+#[test]
+fn test_server_impl_linked_in_dual_import_unit() {
+    let server = http.listen(":0");
+    let _prev = server.set_request_timeout_ms(1000);
+    server.close();
+    testing.assert_true(true);
+}
+
+/// Every `Response` accessor that was previously a bodiless declaration is now
+/// executable. Nothing listens on 127.0.0.1:1, so the request fails at the
+/// transport and `status()` returns the documented -1 error status (see
+/// `http_client.hew` `status()` doc: "Returns -1 on error"). Each of the six
+/// accessors named in the pre-fix verify failure is invoked, so a regression
+/// re-introducing the bodiless declaration would fail to link this test.
+#[test]
+fn test_response_accessors_linked_in_dual_import_unit() {
+    http_client.set_timeout(100);
+    let resp = http_client.get("http://127.0.0.1:1");
+    testing.assert_eq(resp.status(), -1);
+    let _body = resp.body();
+    let _content_type = resp.content_type();
+    let _header = resp.header("content-type");
+    let _headers = resp.headers();
+    resp.free();
+    testing.assert_true(true);
+}

--- a/tests/hew/http_server_client_roundtrip_test.hew
+++ b/tests/hew/http_server_client_roundtrip_test.hew
@@ -1,0 +1,77 @@
+//! #2391 behavioural proof: a blocking HTTP server (`std::net::http`) and the
+//! HTTP client (`std::net::http::http_client`) do a REAL loopback round-trip in
+//! ONE process. This proves the impl-dedup fix picked a WORKING surviving copy
+//! (Fix A keeps the superset `std::net::http` module's lowering of the shared
+//! `Response`/`Server` impls) — not merely that the unit links.
+//!
+//! Imports are in the REVERSE order of `http_dual_import_link_test.hew`
+//! (client first, server second) so the subsumption dedup is proven
+//! order-independent (#2391 validation): whichever package module the loader
+//! visits first, the maximal superset survives and one definition serves both
+//! import paths.
+//!
+//! Shape: `main`/the test fn binds the listener synchronously (kernel backlog
+//! then holds the client connection), a `Client` actor runs the blocking
+//! `http_client.get` on a worker while the test thread `accept`s and responds,
+//! and mailbox ordering (`fetch` before `status_result`) makes the readback
+//! race-free without any sleep. The `Client` holds only `string`/`i64` state —
+//! no opaque handle crosses the actor boundary (the supervisor-restart clone
+//! gate rejects opaque handles in actor state).
+
+import std::net::http::http_client;
+
+import std::net::http;
+
+import std::testing;
+
+/// The `Client` runs the blocking outbound request on its own worker; the test
+/// thread serves the single request. `status`/`body` are read back via asks
+/// that the mailbox necessarily processes AFTER `fetch` completes.
+actor Client {
+    let url: string;
+    var status: i64;
+    var body: string;
+
+    receive fn fetch(unused: i64) {
+        http_client.set_timeout(3000);
+        let resp = http_client.get(url);
+        status = resp.status();
+        body = resp.body();
+        resp.free();
+    }
+
+    receive fn status_result() -> i64 {
+        status
+    }
+
+    receive fn body_result() -> string {
+        body
+    }
+}
+
+/// One-process round-trip: bind, fire the client, accept + respond 200 with the
+/// request path echoed, then assert the client observed EXACTLY 200 and the
+/// echoed body. A wrong surviving impl copy (topo-order risk) would either fail
+/// to respond or corrupt the body — a `> 0` smoke check would not catch that,
+/// so the assertions pin the exact status and the exact echoed body.
+#[test]
+fn test_server_client_roundtrip_returns_200_and_echoes_path() {
+    let server = http.listen("127.0.0.1:19717");
+    let client = spawn Client(url: "http://127.0.0.1:19717/ping", status: 0, body: "");
+    client.fetch(0);
+
+    let req = server.accept();
+    let path = req.path();
+    let _ = req.try_respond_text(200, "pong:" + path);
+    req.free();
+    server.close();
+
+    match await client.status_result() {
+        Ok(status) => testing.assert_eq(status, 200),
+        Err(_e) => testing.assert_true(false),
+    }
+    match await client.body_result() {
+        Ok(body) => testing.assert_eq_str(body, "pong:/ping"),
+        Err(_e) => testing.assert_true(false),
+    }
+}

--- a/tests/vertical-slice/reject/dual_module_same_type_name_impl.hew
+++ b/tests/vertical-slice/reject/dual_module_same_type_name_impl.hew
@@ -1,0 +1,23 @@
+// Reject (#2391 follow-up class): two imported modules each define a DISTINCT
+// type named `Server` with an `impl ServerMethods for Server` block. Impl
+// methods lower under the unqualified `Server::<method>` symbol family, so the
+// http and websocket `Server::accept` / `Server::close` bodies collide on one
+// raw-MIR name. Unlike the #2391 dual-import case (one file re-imported under
+// two overlapping package modules — deduped in HIR), these are two genuinely
+// different function bodies that cannot share a compilation unit until impl
+// symbols become module-qualified.
+//
+// Codegen must fail CLOSED with a structured duplicate-symbol diagnostic
+// naming the colliding symbol and the actionable cause — NOT the raw LLVM
+// "Global is external, but doesn't have external or weak linkage!" verifier
+// dump, and NOT a silent linkonce merge of the two distinct bodies.
+import std::net::http;
+
+import std::net::websocket;
+
+fn main() {
+    let http_server = http.listen(":0");
+    http_server.close();
+    let ws_server = websocket.listen(":0");
+    ws_server.close();
+}


### PR DESCRIPTION
## Summary

Importing `std::net::http` and `std::net::http::http_client` together failed LLVM verification: the directory module absorbs the client file, so the explicit import created a second overlapping module, the shared `Response` impl was lowered once per module under unqualified `<Type>::<method>` symbols, and codegen's bare-name keying left one copy as a bodiless external declaration. The impl is now deduplicated at lowering — a subsumed package module skips items its superset already lowers, per item — and codegen fails closed with a structured diagnostic on any remaining duplicate raw symbol (genuinely distinct same-named types, e.g. the http and websocket `Server`s in one unit, tracked as #2400) instead of the opaque LLVM dump. Weak linkage was rejected as fail-open: it would silently merge distinct bodies.

## Verification

- Dual-import fixture red→green: LLVM verify reject → builds, links, runs; the MIR carries exactly one copy of each method
- One-process server+client round-trip asserting exact status 200 and exact echoed body, run 200 iterations under GuardMalloc: clean
- Both isolated imports and reversed import order still pass
- Stdlib import-parity sweep over 72 modules: unchanged
- hew-ratchet and vertical-slice: green
- Independently reproduced end-to-end by a second review

## Out of scope

- Module-qualified impl symbols (the full fix for distinct same-named types), tracked in #2400

Fixes #2391