### PR TITLE
fix(lsp): classify record declarations and wrapping operators

### DIFF
--- a/hew-analysis/src/semantic_tokens.rs
+++ b/hew-analysis/src/semantic_tokens.rs
@@ -34,7 +34,9 @@ fn classify_token(token: &Token<'_>) -> Option<u32> {
         Token::StringLit(_)
         | Token::RawString(_)
         | Token::InterpolatedString(_)
-        | Token::RegexLiteral(_) => Some(token_types::STRING),
+        | Token::RegexLiteral(_)
+        | Token::CharLit(_)
+        | Token::ByteStringLit(_) => Some(token_types::STRING),
 
         // Identifiers
         Token::Identifier(_) | Token::Label(_) => Some(token_types::VARIABLE),
@@ -287,6 +289,28 @@ mod tests {
     }
 
     #[test]
+    fn record_declaration_name_is_type_and_declaration() {
+        let source = "record Point { x: i32, y: i32 }";
+        let point = build_semantic_tokens(source)
+            .into_iter()
+            .find(|t| &source[t.start..t.start + t.length] == "Point")
+            .expect("Point should produce a token");
+        assert_eq!(point.token_type, token_types::TYPE);
+        assert_ne!(point.modifiers & token_modifiers::DECLARATION, 0);
+    }
+
+    #[test]
+    fn machine_state_name_gets_declaration_modifier() {
+        let source = "machine Traffic { state Red {} }";
+        let red = build_semantic_tokens(source)
+            .into_iter()
+            .find(|t| &source[t.start..t.start + t.length] == "Red")
+            .expect("Red should produce a token");
+        assert_eq!(red.token_type, token_types::VARIABLE);
+        assert_ne!(red.modifiers & token_modifiers::DECLARATION, 0);
+    }
+
+    #[test]
     fn param_type_annotation_classified_as_type() {
         let tokens = build_semantic_tokens("fn f(x: i32) {}");
         // `i32` at byte offset 8 should be TYPE, not VARIABLE
@@ -422,6 +446,40 @@ mod tests {
             token_types::VARIABLE,
             "plain variable should stay VARIABLE"
         );
+    }
+
+    #[test]
+    fn char_and_byte_string_literals_are_classified_as_strings() {
+        let source = "let c = 'a'; let bytes = b\"hi\";";
+        let tokens = build_semantic_tokens(source);
+        for literal in ["'a'", "b\"hi\""] {
+            let token = tokens
+                .iter()
+                .find(|t| &source[t.start..t.start + t.length] == literal)
+                .unwrap_or_else(|| panic!("{literal} should produce a token"));
+            assert_eq!(
+                token.token_type,
+                token_types::STRING,
+                "{literal} should be classified as STRING"
+            );
+        }
+    }
+
+    #[test]
+    fn wrapping_arithmetic_operators_are_classified_as_operators() {
+        let source = "let x = a &+ b; let y = a &- b; let z = a &* b;";
+        let tokens = build_semantic_tokens(source);
+        for op in ["&+", "&-", "&*"] {
+            let token = tokens
+                .iter()
+                .find(|t| &source[t.start..t.start + t.length] == op)
+                .unwrap_or_else(|| panic!("{op} should produce a token"));
+            assert_eq!(
+                token.token_type,
+                token_types::OPERATOR,
+                "{op} should be classified as OPERATOR"
+            );
+        }
     }
 
     #[test]

--- a/hew-lexer/src/lib.rs
+++ b/hew-lexer/src/lib.rs
@@ -742,6 +742,9 @@ impl Token<'_> {
                 | Token::Star
                 | Token::Slash
                 | Token::Percent
+                | Token::AmpPlus
+                | Token::AmpMinus
+                | Token::AmpStar
                 | Token::Equal
                 | Token::Bang
                 | Token::Less
@@ -789,10 +792,12 @@ impl Token<'_> {
                 | Token::Receive
                 | Token::Actor
                 | Token::Enum
+                | Token::Record
                 | Token::Trait
                 | Token::Supervisor
                 | Token::Type
                 | Token::Machine
+                | Token::State
         )
     }
 
@@ -804,6 +809,7 @@ impl Token<'_> {
             self,
             Token::Actor
                 | Token::Enum
+                | Token::Record
                 | Token::Trait
                 | Token::Supervisor
                 | Token::Type
@@ -1275,6 +1281,13 @@ mod tests {
     }
 
     #[test]
+    fn is_operator_covers_wrapping_arithmetic() {
+        assert!(Token::AmpPlus.is_operator());
+        assert!(Token::AmpMinus.is_operator());
+        assert!(Token::AmpStar.is_operator());
+    }
+
+    #[test]
     fn is_decl_keyword_covers_named_declarations() {
         // Every keyword that introduces a named binding must return true.
         assert!(Token::Let.is_decl_keyword());
@@ -1283,11 +1296,14 @@ mod tests {
         assert!(Token::Fn.is_decl_keyword());
         assert!(Token::Actor.is_decl_keyword());
         assert!(Token::Enum.is_decl_keyword());
+        assert!(Token::Record.is_decl_keyword());
         assert!(Token::Trait.is_decl_keyword());
         assert!(Token::Supervisor.is_decl_keyword());
         assert!(Token::Type.is_decl_keyword());
         // `machine` introduces a named state-machine type — must be included.
         assert!(Token::Machine.is_decl_keyword());
+        // `state` introduces a named state declaration inside a machine body.
+        assert!(Token::State.is_decl_keyword());
         // A non-decl keyword must return false.
         assert!(!Token::If.is_decl_keyword());
         assert!(!Token::Return.is_decl_keyword());
@@ -1298,6 +1314,7 @@ mod tests {
         // Every keyword that introduces a named type must return true.
         assert!(Token::Actor.is_type_decl_keyword());
         assert!(Token::Enum.is_type_decl_keyword());
+        assert!(Token::Record.is_type_decl_keyword());
         assert!(Token::Trait.is_type_decl_keyword());
         assert!(Token::Supervisor.is_type_decl_keyword());
         assert!(Token::Type.is_type_decl_keyword());


### PR DESCRIPTION
## Summary

An LSP-vs-implementation grammar audit found the hand-maintained keyword/type classification helpers in `hew-lexer` had drifted from the actual token surface:

- `is_type_decl_keyword()` / `is_decl_keyword()` were missing `Token::Record`, so `hew-analysis`'s semantic-token classifier never marked a `record Point { }` declaration's name as `TYPE` + `DECLARATION` — it silently fell through to a plain `VARIABLE`.
- `is_decl_keyword()` was also missing `Token::State` (machine `state Name { }` declarations never got the `DECLARATION` modifier).
- `classify_token()` in `hew-analysis::semantic_tokens` never classified `Token::CharLit`/`Token::ByteStringLit` as `STRING` — char literals (`'a'`) and byte-strings (`b"hi"`) rendered with no semantic color at all.
- `is_operator()` was missing the wrapping-arithmetic tokens `&+`/`&-`/`&*`, so they also rendered uncolored.

## What

- **hew-lexer**: add `Record` to `is_type_decl_keyword()` and `is_decl_keyword()`; add `State` to `is_decl_keyword()` only (state names are machine-internal declarations, not part of the type system); add `AmpPlus`/`AmpMinus`/`AmpStar` to `is_operator()`.
- **hew-analysis**: classify `CharLit`/`ByteStringLit` as `STRING` in `semantic_tokens::classify_token()`.

## Test

- New unit tests in `hew-lexer` assert `is_decl_keyword()`/`is_type_decl_keyword()`/`is_operator()` cover the above tokens.
- New tests in `hew-analysis::semantic_tokens` assert the exact previously-broken behavior end to end: `record Point {}` → `Point` is `TYPE` + `DECLARATION`; `state Red {}` inside a machine → `Red` gets the `DECLARATION` modifier but stays `VARIABLE` (state names are not part of the type system); char/byte-string literals → `STRING`; `&+`/`&-`/`&*` → `OPERATOR`.
- `cargo test -p hew-lexer -p hew-analysis`: pass. `make test-fast` (full reverse-dependency closure via cargo nextest): 6308 passed, 0 failed.

## Out of scope

- `.`, `::`, `#[`, and bare `@` remain unscoped as operators — conventional for LSP semantic highlighters to leave punctuation/path-separators uncolored, not a regression.
- The equivalent operator-scoping gaps in the `vscode-hew` TextMate grammar (`&+`/`&-`/`&*`, etc.) are fixed in a companion `vscode-hew` PR.