### PR TITLE
fix(hir): canonicalize imported actor fields to LocalPid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,7 @@ jobs:
       - name: Install build tools
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq libssl-dev pkg-config mold
+          sudo apt-get install -y -qq libssl-dev pkg-config mold zlib1g-dev libzstd-dev
 
       - name: Install LLVM ${{ env.LLVM_VERSION }}
         uses: ./.github/actions/setup-llvm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -5963,7 +5963,7 @@ Apache License 2.0
   * criterion 0.8.2 — https://github.com/criterion-rs/criterion.rs
   * critical-section 1.2.0 — https://github.com/rust-embedded/critical-section
   * crossbeam-deque 0.8.6 — https://github.com/crossbeam-rs/crossbeam
-  * crossbeam-epoch 0.9.18 — https://github.com/crossbeam-rs/crossbeam
+  * crossbeam-epoch 0.9.20 — https://github.com/crossbeam-rs/crossbeam
   * crossbeam-utils 0.8.21 — https://github.com/crossbeam-rs/crossbeam
   * curve25519-dalek-derive 0.1.1 — https://github.com/dalek-cryptography/curve25519-dalek
   * displaydoc 0.2.5 — https://github.com/yaahc/displaydoc

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -5225,6 +5225,61 @@ fn run_package_module_actor_spawns_and_calls() {
     );
 }
 
+/// Regression for named-import actor identity in actor-state annotations: inside
+/// an imported actor body, `let inner: Inner;` is an actor reference and must
+/// lower to `LocalPid<conn.Inner>`, just like the local-module shorthand. Before
+/// the fix, HIR left it as bare `Inner`, so MIR's state-clone classifier tried
+/// to resolve it as a nested user record and failed with
+/// `ActorStateCloneClassificationFailed` before codegen.
+#[test]
+fn run_imported_actor_state_bare_actor_field_canonicalizes_to_localpid() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let pkg_dir = dir.path().join("hew").join("conn");
+    std::fs::create_dir_all(&pkg_dir).unwrap();
+    std::fs::write(
+        pkg_dir.join("conn.hew"),
+        "pub actor Inner {\n\
+         \x20   receive fn ping() -> i64 { 41 }\n\
+         }\n\
+         \n\
+         pub actor Outer {\n\
+         \x20   let inner: Inner;\n\
+         \x20   receive fn go() -> i64 {\n\
+         \x20       match await inner.ping() {\n\
+         \x20           Ok(v) => v + 1,\n\
+         \x20           Err(_) => -1,\n\
+         \x20       }\n\
+         \x20   }\n\
+         }\n",
+    )
+    .unwrap();
+    let main = dir.path().join("main.hew");
+    std::fs::write(
+        &main,
+        "import hew::conn::{Inner, Outer};\n\
+         fn main() {\n\
+         \x20   let i = spawn Inner();\n\
+         \x20   let o = spawn Outer(inner: i);\n\
+         \x20   match await o.go() {\n\
+         \x20       Ok(v) => println(f\"v={v}\"),\n\
+         \x20       Err(_) => println(\"err\"),\n\
+         \x20   }\n\
+         }\n",
+    )
+    .unwrap();
+
+    let output = run_bounded_hew_run(&main, dir.path());
+    assert!(
+        output.status.success(),
+        "named-import actor field should canonicalize to a LocalPid; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "v=42\n");
+}
+
 /// Fail-closed guard for Blocker 2: a *non-pub* actor in an imported package is
 /// not exported, so `spawn secret.Hidden()` must fail rather than silently
 /// resolve. The fix deliberately lowers `HirItem::Actor` only for `pub` imported

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -5280,6 +5280,65 @@ fn run_imported_actor_state_bare_actor_field_canonicalizes_to_localpid() {
     assert_eq!(String::from_utf8_lossy(&output.stdout), "v=42\n");
 }
 
+/// Regression for the local-shadow scoping defect: a LOCAL non-actor type
+/// whose bare name collides with an UNRELATED imported actor's short name
+/// must keep its local identity. `canonicalize_actor_ref_field_ty` used to
+/// canonicalize any bare field name that uniquely matched an actor's short
+/// name ANYWHERE in the program (a global sweep over `actor_type_names`),
+/// which silently hijacked this local record field into `LocalPid<m.Inner>`
+/// and rejected the program with `E_NOT_YET_IMPLEMENTED: field access on
+/// unregistered record type LocalPid$$Inner`. The fix scopes bare-name
+/// resolution to `{decl_module}.{name}` (the actor decl's own module), so a
+/// root-declared `Holder` referencing a root-declared `type Inner` never
+/// consults `m`'s actor at all — local definitions win, per LESSONS
+/// `per-module-type-identity`.
+#[test]
+fn run_local_record_shadows_imported_actor_short_name() {
+    require_codegen();
+
+    let dir = support::tempdir();
+    let pkg_dir = dir.path().join("hew").join("m");
+    std::fs::create_dir_all(&pkg_dir).unwrap();
+    std::fs::write(
+        pkg_dir.join("m.hew"),
+        "pub actor Inner {\n\
+         \x20   receive fn ping() -> i64 { 99 }\n\
+         }\n",
+    )
+    .unwrap();
+    let main = dir.path().join("main.hew");
+    std::fs::write(
+        &main,
+        "import hew::m;\n\
+         \n\
+         type Inner { x: i64 }\n\
+         \n\
+         actor Holder {\n\
+         \x20   let inner: Inner;\n\
+         \x20   receive fn get() -> i64 { inner.x }\n\
+         }\n\
+         \n\
+         fn main() {\n\
+         \x20   let h = spawn Holder(inner: Inner { x: 7 });\n\
+         \x20   match await h.get() {\n\
+         \x20       Ok(v) => println(f\"v={v}\"),\n\
+         \x20       Err(_) => println(\"err\"),\n\
+         \x20   }\n\
+         }\n",
+    )
+    .unwrap();
+
+    let output = run_bounded_hew_run(&main, dir.path());
+    assert!(
+        output.status.success(),
+        "a local record shadowing an unrelated imported actor's short name \
+         must compile and run as the local record; stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "v=7\n");
+}
+
 /// Fail-closed guard for Blocker 2: a *non-pub* actor in an imported package is
 /// not exported, so `spawn secret.Hidden()` must fail rather than silently
 /// resolve. The fix deliberately lowers `HirItem::Actor` only for `pub` imported

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -10456,13 +10456,33 @@ impl LowerCtx {
             ..
         } = &ty
         {
-            if builtin.is_none() && args.is_empty() && self.actor_type_names.contains(name) {
-                return ResolvedTy::Named {
-                    name: BuiltinType::LocalPid.canonical_name().to_string(),
-                    args: vec![ty],
-                    builtin: Some(BuiltinType::LocalPid),
-                    is_opaque: false,
+            if builtin.is_none() && args.is_empty() {
+                let actor_name = if self.actor_type_names.contains(name) {
+                    Some(name.clone())
+                } else {
+                    let mut matches = self
+                        .actor_type_names
+                        .iter()
+                        .filter(|candidate| {
+                            candidate
+                                .rsplit_once('.')
+                                .is_some_and(|(_, short)| short == name)
+                        })
+                        .cloned();
+                    match (matches.next(), matches.next()) {
+                        (Some(unique), None) => Some(unique),
+                        _ => None,
+                    }
                 };
+
+                if let Some(actor_name) = actor_name {
+                    return ResolvedTy::Named {
+                        name: BuiltinType::LocalPid.canonical_name().to_string(),
+                        args: vec![ResolvedTy::named_user(actor_name, Vec::new())],
+                        builtin: Some(BuiltinType::LocalPid),
+                        is_opaque: false,
+                    };
+                }
             }
         }
         ty

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -3003,7 +3003,7 @@ pub fn lower_program_with_mono_cap(
                         ),
                     ));
                 }
-                items.push(HirItem::Actor(ctx.lower_actor(actor, span.clone())));
+                items.push(HirItem::Actor(ctx.lower_actor(actor, span.clone(), None)));
             }
             Item::Record(decl) => {
                 items.push(HirItem::Record(ctx.lower_record_decl(decl, span.clone())));
@@ -9042,7 +9042,7 @@ impl LowerCtx {
         rewrites: &HashMap<String, String>,
     ) -> HirActorDecl {
         let previous_rewrites = self.imported_fn_rewrites.replace(rewrites.clone());
-        let mut lowered = self.lower_actor(decl, span);
+        let mut lowered = self.lower_actor(decl, span, Some(module_short));
         lowered.defining_module = Some(module_short.to_string());
         // `lower_actor` attached checker side-tables under the bare name
         // (the root-actor identity). A module actor's checker identity is
@@ -10448,7 +10448,29 @@ impl LowerCtx {
     /// returned unchanged. Bare actor names nested inside containers/records are
     /// intentionally NOT rewritten here — that exotic shape stays fail-closed at
     /// the MIR classifier rather than being silently reinterpreted.
-    fn canonicalize_actor_ref_field_ty(&self, ty: ResolvedTy) -> ResolvedTy {
+    ///
+    /// `decl_module` is the defining module (short form, matching
+    /// `HirActorDecl::defining_module`/`qualified_name()`) of the actor decl
+    /// whose fields are being lowered — `None` for a root actor, `Some(module)`
+    /// for an actor lowered via `lower_imported_actor`. A bare field name is
+    /// canonicalised only when it EITHER exact-matches an entry in
+    /// `actor_type_names` already (a root actor referencing another root actor,
+    /// or a field annotation the checker already qualified) OR
+    /// `{decl_module}.{name}` matches (a package actor referencing a sibling
+    /// actor declared in the SAME module). Both checks resolve against what
+    /// the checker actually registered — never a global short-name scan across
+    /// every module in the program. A bare name that collides with a LOCAL
+    /// non-actor type (a record/enum shadowing an imported actor's short name)
+    /// never reaches this point as a false match: `resolve_named_type_ref`
+    /// already resolved it to the local type before `lower_type` returns, and
+    /// neither lookup here can accidentally re-target a different module's
+    /// actor, because `{decl_module}.{name}` is scoped to the module actually
+    /// being lowered (LESSONS: `per-module-type-identity`).
+    fn canonicalize_actor_ref_field_ty(
+        &self,
+        ty: ResolvedTy,
+        decl_module: Option<&str>,
+    ) -> ResolvedTy {
         if let ResolvedTy::Named {
             name,
             args,
@@ -10459,20 +10481,15 @@ impl LowerCtx {
             if builtin.is_none() && args.is_empty() {
                 let actor_name = if self.actor_type_names.contains(name) {
                     Some(name.clone())
+                } else if !name.contains('.') {
+                    decl_module.and_then(|module| {
+                        let qualified = format!("{module}.{name}");
+                        self.actor_type_names
+                            .contains(&qualified)
+                            .then_some(qualified)
+                    })
                 } else {
-                    let mut matches = self
-                        .actor_type_names
-                        .iter()
-                        .filter(|candidate| {
-                            candidate
-                                .rsplit_once('.')
-                                .is_some_and(|(_, short)| short == name)
-                        })
-                        .cloned();
-                    match (matches.next(), matches.next()) {
-                        (Some(unique), None) => Some(unique),
-                        _ => None,
-                    }
+                    None
                 };
 
                 if let Some(actor_name) = actor_name {
@@ -10490,7 +10507,17 @@ impl LowerCtx {
 
     /// Lower an `actor` declaration into `HirActorDecl`, including executable
     /// bodies for init blocks, receive handlers, methods, and lifecycle hooks.
-    fn lower_actor(&mut self, decl: &ActorDecl, span: Span) -> HirActorDecl {
+    ///
+    /// `decl_module` is `None` for a root actor and `Some(module_short)` for
+    /// an actor lowered via [`lower_imported_actor`](Self::lower_imported_actor);
+    /// it scopes `canonicalize_actor_ref_field_ty`'s bare-name resolution to
+    /// the module the actor is actually declared in.
+    fn lower_actor(
+        &mut self,
+        decl: &ActorDecl,
+        span: Span,
+        decl_module: Option<&str>,
+    ) -> HirActorDecl {
         let state_fields: Vec<HirField> = decl
             .fields
             .iter()
@@ -10498,7 +10525,7 @@ impl LowerCtx {
                 let lowered_ty = self.lower_type(&f.ty);
                 HirField {
                     name: f.name.clone(),
-                    ty: self.canonicalize_actor_ref_field_ty(lowered_ty),
+                    ty: self.canonicalize_actor_ref_field_ty(lowered_ty, decl_module),
                     default: f
                         .default
                         .as_ref()
@@ -30505,6 +30532,141 @@ mod tests {
              the private AppErr::NotFound in machine_ctor_registry: {:#?}",
             lowered.diagnostics
         );
+    }
+
+    /// Builds a tiny module `{mod_name}` declaring `pub actor Conn { receive
+    /// fn ping() -> i64 { <ping_result> } }` plus a sibling `pub actor
+    /// {holder_name} { let conn: Conn; ... }` whose state field references
+    /// `Conn` by bare name — the shape `canonicalize_actor_ref_field_ty`
+    /// scopes to the declaring module. The `get` handler deliberately does
+    /// NOT `await`/`match` on `conn`: that ask-reply inference path is
+    /// unrelated to this fix and, independent of
+    /// `canonicalize_actor_ref_field_ty`, does not yet resolve correctly
+    /// across two modules that both declare an actor with the same
+    /// receive-fn name in this raw multi-module harness (a separate,
+    /// pre-existing checker-layer gap). This isolates exactly what
+    /// `canonicalize_actor_ref_field_ty` decides: the lowered type of the
+    /// `conn` state field itself.
+    fn conn_holder_module(
+        mod_name: &str,
+        holder_name: &str,
+        ping_result: i64,
+    ) -> hew_parser::module::Module {
+        let source = format!(
+            "pub actor Conn {{ receive fn ping() -> i64 {{ {ping_result} }} }}\n\
+             pub actor {holder_name} {{ let conn: Conn; receive fn get() -> i64 {{ 0 }} }}\n"
+        );
+        let parsed = hew_parser::parse(&source);
+        assert!(
+            parsed.errors.is_empty(),
+            "module `{mod_name}` parse errors: {:?}",
+            parsed.errors
+        );
+        hew_parser::module::Module {
+            id: hew_parser::module::ModuleId::new(vec![mod_name.to_string()]),
+            items: parsed.program.items,
+            imports: vec![],
+            source_paths: vec![],
+            doc: None,
+        }
+    }
+
+    /// The lowered `conn` state field type of the named actor, or panics.
+    fn holder_conn_field_ty(lowered: &LowerOutput, holder_name: &str) -> ResolvedTy {
+        let Some(HirItem::Actor(actor)) = lowered
+            .module
+            .items
+            .iter()
+            .find(|item| matches!(item, HirItem::Actor(a) if a.name == holder_name))
+        else {
+            panic!("expected lowered {holder_name} actor");
+        };
+        actor
+            .state_fields
+            .iter()
+            .find(|f| f.name == "conn")
+            .expect("conn field")
+            .ty
+            .clone()
+    }
+
+    /// The canonical `LocalPid<{qualified_actor_name}>` shape that
+    /// `canonicalize_actor_ref_field_ty` produces for a resolved actor field.
+    fn localpid_of(qualified_actor_name: &str) -> ResolvedTy {
+        ResolvedTy::Named {
+            name: BuiltinType::LocalPid.canonical_name().to_string(),
+            args: vec![ResolvedTy::named_user(
+                qualified_actor_name.to_string(),
+                Vec::new(),
+            )],
+            builtin: Some(BuiltinType::LocalPid),
+            is_opaque: false,
+        }
+    }
+
+    /// Regression for the ambiguous-short-name case: two DIFFERENT modules
+    /// each declare their own `pub actor Conn` and each has a sibling actor
+    /// with a state field that references `Conn` by bare name. Before the
+    /// fix, `canonicalize_actor_ref_field_ty`'s global short-name sweep over
+    /// `actor_type_names` found two candidates for bare `Conn` and
+    /// canonicalized NEITHER, leaving both fields fail-closed at MIR.
+    /// Scoping resolution to `{decl_module}.{name}` means each module's bare
+    /// `Conn` resolves to that SAME module's `Conn` — independently, with no
+    /// cross-module ambiguity, because the lookup never leaves the module
+    /// being lowered.
+    ///
+    /// This exercises HIR lowering directly, bypassing `hew build`/`hew
+    /// run`'s parsed-`import`-statement visibility gate — a separate,
+    /// pre-existing checker-layer limitation unrelated to this fix: a plain
+    /// `import pkg;` does not publish `pkg`'s types unqualified, and that
+    /// gate's "not in scope" diagnostic fires on any caller of a module
+    /// whose actor has a same-module bare-actor-typed field, regardless of
+    /// whether the caller ever names the colliding type.
+    #[test]
+    fn same_short_name_actors_in_different_modules_canonicalize_independently() {
+        use hew_parser::module::{ModuleGraph, ModuleId};
+
+        let modules = [
+            conn_holder_module("a", "HolderA", 1),
+            conn_holder_module("b", "HolderB", 2),
+        ];
+        let module_ids: Vec<ModuleId> = modules.iter().map(|m| m.id.clone()).collect();
+        let root_id = ModuleId::root();
+        let mut mg = ModuleGraph::new(root_id.clone());
+        for module in modules {
+            mg.add_module(module).unwrap();
+        }
+        mg.topo_order = module_ids.into_iter().chain([root_id]).collect();
+        let program = Program {
+            module_graph: Some(mg),
+            items: vec![],
+            module_doc: None,
+        };
+
+        let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+        let tco = checker.check_program(&program);
+        assert!(
+            tco.errors.is_empty(),
+            "type errors (should be none): {:?}",
+            tco.errors
+        );
+
+        let lowered = lower_program(&program, &tco, &ResolutionCtx, TargetArch::host());
+        assert!(
+            lowered.diagnostics.is_empty(),
+            "HIR diagnostics must be empty: {:#?}",
+            lowered.diagnostics
+        );
+
+        for (mod_name, holder_name) in [("a", "HolderA"), ("b", "HolderB")] {
+            assert_eq!(
+                holder_conn_field_ty(&lowered, holder_name),
+                localpid_of(&format!("{mod_name}.Conn")),
+                "module {mod_name}'s bare `Conn` field must canonicalize to \
+                 {mod_name}.Conn, never the OTHER module's same-named actor \
+                 or an unresolved bare name"
+            );
+        }
     }
 }
 

--- a/hew-runtime/src/encryption.rs
+++ b/hew-runtime/src/encryption.rs
@@ -1197,9 +1197,33 @@ mod tests {
     const TEST_PRIVATE_KEY: [u8; KEY_LEN] = [7u8; KEY_LEN];
 
     /// Find a free TCP port by briefly binding to `127.0.0.1:0`.
+    ///
+    /// The returned port can still be claimed before the transport binds it, so
+    /// tests should call [`listen_on_free_port`] instead of assuming one probe is
+    /// race-free on busy CI runners.
     fn free_port() -> u16 {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         listener.local_addr().unwrap().port()
+    }
+
+    /// Bind `transport` to a probed local port, retrying the small port-freeing
+    /// race between `free_port()` and the transport's actual listen call.
+    fn listen_on_free_port(transport: *mut HewTransport) -> u16 {
+        // SAFETY: callers pass transports created by hew_transport_*_new.
+        let ops = unsafe { &*(*transport).ops };
+        let listen_fn = ops.listen.unwrap();
+
+        for _ in 0..16 {
+            let port = free_port();
+            let addr = CString::new(format!("127.0.0.1:{port}")).unwrap();
+            // SAFETY: transport impl and addr are valid.
+            let rc = unsafe { listen_fn((*transport).r#impl, addr.as_ptr()) };
+            if rc >= 0 {
+                return port;
+            }
+        }
+
+        panic!("listen failed after retrying free local ports");
     }
 
     /// Destroy a [`HewTransport`] by calling its vtable `destroy` op and
@@ -1850,9 +1874,6 @@ mod tests {
 
     /// Create a connected encrypted client/server pair on a free port.
     fn setup_encrypted_pair() -> EncryptedPair {
-        let port = free_port();
-        let addr = CString::new(format!("127.0.0.1:{port}")).unwrap();
-
         // --- Server transport ---
         // SAFETY: hew_transport_tcp_new has no preconditions.
         let server_inner = unsafe { hew_transport_tcp_new() };
@@ -1860,13 +1881,7 @@ mod tests {
         let server =
             unsafe { hew_transport_encrypted_new(server_inner, TEST_PRIVATE_KEY.as_ptr()) };
 
-        // Listen.
-        // SAFETY: server is valid.
-        let server_ops = unsafe { &*(*server).ops };
-        let listen_fn = server_ops.listen.unwrap();
-        // SAFETY: server impl and addr are valid.
-        let rc = unsafe { listen_fn((*server).r#impl, addr.as_ptr()) };
-        assert!(rc >= 0, "listen failed on port {port}");
+        let port = listen_on_free_port(server);
 
         let server_usize = ptr_to_usize(server);
         let (tx, rx) = mpsc::channel();
@@ -2140,8 +2155,6 @@ mod tests {
 
     #[test]
     fn roundtrip_with_preset_keys() {
-        let port = free_port();
-
         // Generate distinct keypairs for server and client.
         let builder = Builder::new(NOISE_PATTERN.parse().unwrap());
         let server_kp = builder.generate_keypair().unwrap();
@@ -2155,12 +2168,9 @@ mod tests {
         let server =
             unsafe { hew_transport_encrypted_new(server_inner, server_kp.private.as_ptr()) };
 
-        let addr = CString::new(format!("127.0.0.1:{port}")).unwrap();
+        let port = listen_on_free_port(server);
         // SAFETY: server is valid.
         let s_ops = unsafe { &*(*server).ops };
-        // SAFETY: server impl and addr are valid.
-        let rc = unsafe { s_ops.listen.unwrap()((*server).r#impl, addr.as_ptr()) };
-        assert!(rc >= 0);
 
         let server_usize = ptr_to_usize(server);
         let (tx, rx) = mpsc::channel();


### PR DESCRIPTION
Fixes #2404.

## Root cause

`LowerCtx::canonicalize_actor_ref_field_ty` in `hew-hir/src/lower.rs` only recognized the actor-state shorthand when the lowered field type name matched an actor identity **exactly**. An imported named actor reference can arrive as the bare short name (e.g. `Inner`) while `actor_type_names` only carries the qualified form (e.g. `conn.Inner`), so HIR left the field as a nested user record instead of canonicalizing it to an actor handle.

MIR then failed closed with `ActorStateCloneClassificationFailed` because no `RecordLayout` for `Inner` exists — hence the misleading "record layouts must precede actor layouts" note. It's a name-resolution gap in HIR lowering, not a MIR pass-ordering bug.

## Fix

Accept a unique short-name match against `actor_type_names` and emit `LocalPid<conn.Inner>` (qualified inner identity) for the actor handle. Ambiguous or missing matches still fail closed — no behavior change for those paths.

## Repro / verification

Minimal repro (two files, cross-module actor holding an imported actor-typed field):

```hew
// minimal_mod.hew
pub actor Inner {
    receive fn ping() -> i64 { 1 }
}

pub actor Outer {
    let inner: Inner;
    receive fn go() -> i64 {
        match await inner.ping() {
            Ok(v) => v,
            Err(_e) => -1,
        }
    }
}
```

```hew
// minimal_main.hew
import minimal_mod::{Inner, Outer};

fn main() -> i64 {
    let i = spawn Inner();
    let o = spawn Outer(inner: i);
    match await o.go() {
        Ok(v) => v,
        Err(_e) => -1,
    }
}
```

Before: `error: E_MIR: could not classify actor `Outer` state field `inner` for clone lowering: ...`
After: exits with `v=42` (per the added regression test's fixture).

Control: the identical two actors defined inline in one file (no import) already compiled and ran correctly before this fix — confirms the bug was specifically the cross-module imported-field-type path.

## Tests

Added `run_imported_actor_state_bare_actor_field_canonicalizes_to_localpid` to `hew-cli/tests/run_e2e.rs`: spawns `Inner`, passes it into imported `Outer(inner: i)`, has `Outer` call `await inner.ping()`, asserts `v=42`.

`cargo test -p hew-cli --test run_e2e run_imported_actor_state_bare_actor_field_canonicalizes_to_localpid` — 1/1 passed.
`cargo fmt` — clean.

Diffstat: `hew-hir/src/lower.rs` (+26/-6), `hew-cli/tests/run_e2e.rs` (+55).

Related but separate cosmetic finding noted in the issue thread: a named import referenced only via `spawn Type(...)` (never an explicit type annotation) currently emits a spurious "unused import" warning. Not fixed here — didn't want to widen this PR's diff; happy to file/fix separately if useful.