### PR TITLE
fix(editors): sync sublime and emacs grammar updates

### DIFF
--- a/editors/emacs/hew-mode.el
+++ b/editors/emacs/hew-mode.el
@@ -85,7 +85,7 @@
     "bool" "char" "string" "bytes" "void"
     "Result" "Option" "Vec" "HashMap" "HashSet"
     "Box" "Arc" "Rc" "Weak"
-    "Actor" "LocalPid" "RemotePid" "LambdaPid" "Task" "Scope"
+    "LocalPid" "RemotePid" "LambdaPid" "Task" "Scope"
     "Generator" "AsyncGenerator" "Stream" "Sink"
     "Self")
   "Hew built-in types.")

--- a/editors/sublime/Hew.tmLanguage.json
+++ b/editors/sublime/Hew.tmLanguage.json
@@ -244,7 +244,7 @@
         {
           "comment": "Control flow",
           "name": "keyword.control.hew",
-          "match": "\\b(after|await_restart|await|break|continue|cooperate|defer|else|for|from|if|in|join|loop|match|return|scope|select|while|yield)\\b"
+          "match": "\\b(after|await_restart|await|break|continue|defer|else|for|from|if|in|join|loop|match|return|scope|select|while|yield)\\b"
         },
         {
           "comment": "Declarations",
@@ -294,7 +294,7 @@
         {
           "comment": "Removed/rejected keywords — parser explicitly rejects these with migration diagnostics. Highlight as invalid so users know these are not valid v0.5 syntax.",
           "name": "invalid.removed.hew",
-          "match": "\\b(catch|foreign|race|try)\\b"
+          "match": "\\b(catch|cooperate|foreign|race|try)\\b"
         },
         {
           "comment": "Reserved keywords (not yet used in the language)",
@@ -631,8 +631,8 @@
           "match": "\\.\\.=|\\.\\.(?!\\.)"
         },
         {
-          "comment": "Regex match operators",
-          "name": "keyword.operator.regex.hew",
+          "comment": "Removed regex match operators — parser rejects with E_REGEX_OP_REMOVED",
+          "name": "invalid.removed.hew",
           "match": "=~|!~"
         },
         {
@@ -641,14 +641,19 @@
           "match": "&&|\\|\\|"
         },
         {
-          "comment": "Comparison operators",
-          "name": "keyword.operator.comparison.hew",
-          "match": "==|!=|<=|>=|<|>"
-        },
-        {
           "comment": "Bitwise shift compound assignment",
           "name": "keyword.operator.assignment.compound.hew",
           "match": "<<=|>>="
+        },
+        {
+          "comment": "Bitwise shift operators",
+          "name": "keyword.operator.bitwise.shift.hew",
+          "match": "<<|>>"
+        },
+        {
+          "comment": "Comparison operators",
+          "name": "keyword.operator.comparison.hew",
+          "match": "==|!=|<=|>=|<|>"
         },
         {
           "comment": "Bitwise compound assignment",
@@ -666,14 +671,19 @@
           "match": "="
         },
         {
-          "comment": "Bitwise shift operators",
-          "name": "keyword.operator.bitwise.shift.hew",
-          "match": "<<|>>"
+          "comment": "Bitwise XOR operator",
+          "name": "keyword.operator.bitwise.xor.hew",
+          "match": "\\^"
         },
         {
           "comment": "Bitwise NOT operator",
           "name": "keyword.operator.bitwise.not.hew",
           "match": "~"
+        },
+        {
+          "comment": "Wrapping arithmetic operators: &+ &- &* (two's-complement overflow semantics, maximal-munch — only when no whitespace separates & from the following +/-/*)",
+          "name": "keyword.operator.wrapping.hew",
+          "match": "&[+\\-*]"
         },
         {
           "comment": "Arithmetic operators",


### PR DESCRIPTION
## Summary

`editors/sublime/Hew.tmLanguage.json` and `editors/emacs/hew-mode.el` are hand-maintained and had fallen slightly behind the current v0.6 surface — both were resynced 2026-07-03 but missed two grammar-correctness fixes that landed in the canonical `vscode-hew` template afterward, plus one leftover stale type name.

## What

- **sublime**: `cooperate` was scoped as valid `keyword.control.hew` even though the parser rejects it as compiler-internal — moved to `invalid.removed.hew` alongside `catch`/`foreign`/`race`/`try`.
- **sublime**: operator scoping gaps ported from the already-fixed `vscode-hew` template — `<<`/`>>`/`<<=`/`>>=` were splitting into comparison-operator tokens (pattern-ordering bug); bare `^` (XOR) and `&+`/`&-`/`&*` (wrapping arithmetic) were unstyled; removed regex-match operators `=~`/`!~` were scoped as if still valid.
- **emacs**: removed a stale bare `"Actor"` entry from `hew-builtin-types` — that type was retired alongside `ActorRef` in favor of `LocalPid`/`RemotePid`/`LambdaPid`.

## Test

Verified `editors/sublime/Hew.tmLanguage.json` remains valid JSON. No compiler/runtime code touched (`cargo fmt --all -- --check` is a no-op). Cross-checked the operator-section port against the reference `vscode-hew` template for exact scope-name/ordering parity.

## Out of scope

None.