### PR TITLE
fix(cli): honour --link-lib in hew run and ship a link-safe libhew.a

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Build all release crates
         run: |
           cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
-          cargo build -p hew-lib --release
+          cargo build -p hew-lib --profile release-lib
 
       - name: Build WASM runtime
         run: |
@@ -151,7 +151,8 @@ jobs:
           target/release/adze --version
           target/release/hew-lsp --version
           target/release/hew-observe --version
-          test -f target/release/libhew.a && echo "✅ libhew.a exists"
+          test -f target/release-lib/libhew.a && echo "✅ libhew.a exists"
+          ar t target/release-lib/libhew.a | grep -q '^std-' && echo "✅ libhew.a carries verbatim libstd members"
 
       - name: Smoke test — compile and run a .hew program
         run: |
@@ -254,7 +255,7 @@ jobs:
       - name: Build all release crates
         run: |
           cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
-          cargo build -p hew-lib --release
+          cargo build -p hew-lib --profile release-lib
 
       - name: Build WASM runtime
         run: |
@@ -267,7 +268,8 @@ jobs:
           target/release/adze --version
           target/release/hew-lsp --version
           target/release/hew-observe --version
-          test -f target/release/libhew.a && echo "✅ libhew.a exists"
+          test -f target/release-lib/libhew.a && echo "✅ libhew.a exists"
+          ar t target/release-lib/libhew.a | grep -q '^std-' && echo "✅ libhew.a carries verbatim libstd members"
 
       - name: Smoke test — compile and run a .hew program
         run: |
@@ -338,7 +340,7 @@ jobs:
       - name: Build all release crates
         run: |
           cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
-          cargo build -p hew-lib --release
+          cargo build -p hew-lib --profile release-lib
 
       - name: Verify release binaries
         run: |
@@ -346,7 +348,8 @@ jobs:
           target/release/adze --version
           target/release/hew-lsp --version
           target/release/hew-observe --version
-          test -f target/release/libhew.a && echo "✅ libhew.a exists"
+          test -f target/release-lib/libhew.a && echo "✅ libhew.a exists"
+          ar t target/release-lib/libhew.a | grep -q '^std-' && echo "✅ libhew.a carries verbatim libstd members"
 
       - name: Smoke test — compile and run a .hew program
         run: |
@@ -465,13 +468,14 @@ jobs:
             command -v wasm-ld && wasm-ld --version
 
             cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
-            cargo build -p hew-lib --release
+            cargo build -p hew-lib --profile release-lib
 
             target/release/hew --version
             target/release/adze --version
             target/release/hew-lsp --version
             target/release/hew-observe --version
-            test -f target/release/libhew.a
+            test -f target/release-lib/libhew.a
+            ar t target/release-lib/libhew.a | grep -q '^std-'
 
             # Smoke test — compile and run a .hew program
             echo 'fn main() { println("smoke-ok") }' > _smoke.hew
@@ -546,13 +550,14 @@ jobs:
             command -v wasm-ld && wasm-ld --version
 
             cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
-            cargo build -p hew-lib --release
+            cargo build -p hew-lib --profile release-lib
 
             target/release/hew --version
             target/release/adze --version
             target/release/hew-lsp --version
             target/release/hew-observe --version
-            test -f target/release/libhew.a
+            test -f target/release-lib/libhew.a
+            ar t target/release-lib/libhew.a | grep -q '^std-'
 
             # Smoke test — compile and run a .hew program
             echo 'fn main() { println("smoke-ok") }' > _smoke.hew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,9 +356,14 @@ jobs:
       - name: Package archive (Windows)
         if: startsWith(matrix.target, 'windows')
         run: |
+          # Fail closed: without Stop, Copy-Item against a missing source is a
+          # non-terminating error and the step can go green while shipping a
+          # broken archive.
+          $ErrorActionPreference = 'Stop'
+
           $Version = $env:RELEASE_TAG.TrimStart("v")
           $ArchiveName = "hew-v${Version}-${{ matrix.target }}"
-          $ReleaseDir = "target/${{ matrix.rust_target }}/release"
+          $ReleaseLibDir = "target/${{ matrix.rust_target }}/release-lib"
 
           New-Item -ItemType Directory -Path "${ArchiveName}/bin", "${ArchiveName}/lib", "${ArchiveName}/std", "${ArchiveName}/completions" -Force | Out-Null
 
@@ -366,7 +371,18 @@ jobs:
           Copy-Item "target/${{ matrix.rust_target }}/release/adze.exe"         "${ArchiveName}/bin/"
           Copy-Item "target/${{ matrix.rust_target }}/release/hew-lsp.exe"            "${ArchiveName}/bin/"
           Copy-Item "target/${{ matrix.rust_target }}/release/hew-observe.exe"        "${ArchiveName}/bin/"
-          Copy-Item "${ReleaseDir}/hew.lib"                                      "${ArchiveName}/lib/"
+
+          # Combined runtime + stdlib library (non-LTO release-lib profile).
+          # Fail-closed shape check: the shipped archive must carry verbatim
+          # prebuilt libstd members (std-*.o); a fat-LTO archive cannot link
+          # external Rust staticlibs and must never ship. llvm-ar comes from
+          # the C:\llvm-22\bin PATH entry configured above (BSD ar / MSVC lib
+          # do not resolve the COFF long-name table carrying the member names).
+          $StdMembers = & llvm-ar t "${ReleaseLibDir}/hew.lib" | Select-String -Pattern '^std-'
+          if (-not $StdMembers) {
+            throw "${ReleaseLibDir}/hew.lib has no verbatim libstd members (std-*.o) — built with LTO; refusing to package"
+          }
+          Copy-Item "${ReleaseLibDir}/hew.lib"                                   "${ArchiveName}/lib/"
 
           # Standard library sources (all .hew files, including subdirectories)
           Copy-Item "std" "${ArchiveName}/std" -Recurse

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,7 +250,10 @@ jobs:
         run: cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release --target ${{ matrix.rust_target }}
 
       - name: Build libhew.a (runtime + stdlib)
-        run: cargo build -p hew-lib --release --target ${{ matrix.rust_target }}
+        # The shipped archive builds under the non-LTO release-lib profile:
+        # external Rust staticlibs (--link-lib packages) cannot dedupe their
+        # verbatim libstd members against a fat-LTO archive.
+        run: cargo build -p hew-lib --profile release-lib --target ${{ matrix.rust_target }}
 
       - name: Smoke test hew-lsp and hew-observe (Unix)
         if: "!startsWith(matrix.target, 'windows')"
@@ -280,6 +283,7 @@ jobs:
           VERSION="${RELEASE_TAG#v}"
           ARCHIVE_NAME="hew-v${VERSION}-${{ matrix.target }}"
           RELEASE_DIR="target/${{ matrix.rust_target }}/release"
+          RELEASE_LIB_DIR="target/${{ matrix.rust_target }}/release-lib"
 
           mkdir -p "${ARCHIVE_NAME}/bin" "${ARCHIVE_NAME}/lib" \
                    "${ARCHIVE_NAME}/std" "${ARCHIVE_NAME}/completions"
@@ -291,13 +295,20 @@ jobs:
           cp "target/${{ matrix.rust_target }}/release/hew-observe"      "${ARCHIVE_NAME}/bin/"
           chmod +x "${ARCHIVE_NAME}/bin/"*
 
-          # Combined runtime + stdlib library (flat path — universal fallback)
-          cp "${RELEASE_DIR}/libhew.a" "${ARCHIVE_NAME}/lib/"
+          # Combined runtime + stdlib library (flat path — universal fallback),
+          # from the non-LTO release-lib profile. Fail-closed shape check: the
+          # shipped archive must carry verbatim libstd members (std-*.o) or
+          # external Rust staticlibs cannot link against it.
+          ar t "${RELEASE_LIB_DIR}/libhew.a" | grep -q '^std-' || {
+            echo "::error::${RELEASE_LIB_DIR}/libhew.a has no verbatim libstd members — built with LTO; refusing to package"
+            exit 1
+          }
+          cp "${RELEASE_LIB_DIR}/libhew.a" "${ARCHIVE_NAME}/lib/"
 
           # Target-specific lib subtree so find_hew_lib() prefers lib/<triple>/
           # on installed native targets before falling back to the flat path.
           mkdir -p "${ARCHIVE_NAME}/lib/${{ matrix.rust_target }}"
-          cp "${RELEASE_DIR}/libhew.a" "${ARCHIVE_NAME}/lib/${{ matrix.rust_target }}/"
+          cp "${RELEASE_LIB_DIR}/libhew.a" "${ARCHIVE_NAME}/lib/${{ matrix.rust_target }}/"
 
           # Standard library sources (all .hew files, including subdirectories)
           cp -r std/. "${ARCHIVE_NAME}/std/"
@@ -639,7 +650,9 @@ jobs:
         run: cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release --target ${{ matrix.rust_target }}
 
       - name: Build libhew.a (runtime + stdlib)
-        run: cargo build -p hew-lib --release --target ${{ matrix.rust_target }}
+        # Non-LTO release-lib profile: the shipped archive must keep verbatim
+        # libstd members so external Rust staticlibs (--link-lib) can dedupe.
+        run: cargo build -p hew-lib --profile release-lib --target ${{ matrix.rust_target }}
 
       - name: Install cargo-about
         run: cargo install cargo-about --locked --features cli --version 0.9.0
@@ -654,7 +667,7 @@ jobs:
           "target/${{ matrix.rust_target }}/release/adze" --version
           "target/${{ matrix.rust_target }}/release/hew-lsp" --version
           "target/${{ matrix.rust_target }}/release/hew-observe" --version
-          test -f "target/${{ matrix.rust_target }}/release/libhew.a"
+          test -f "target/${{ matrix.rust_target }}/release-lib/libhew.a"
 
           if ldd "target/${{ matrix.rust_target }}/release/hew" | grep -Eqi 'llvm|mlir'; then
             echo "::error::Linux release binary dynamically links LLVM-family libraries"
@@ -666,6 +679,7 @@ jobs:
           VERSION="${RELEASE_TAG#v}"
           ARCHIVE_NAME="hew-v${VERSION}-${{ matrix.target }}"
           RELEASE_DIR="target/${{ matrix.rust_target }}/release"
+          RELEASE_LIB_DIR="target/${{ matrix.rust_target }}/release-lib"
 
           mkdir -p "${ARCHIVE_NAME}/bin" "${ARCHIVE_NAME}/lib" \
                    "${ARCHIVE_NAME}/std" "${ARCHIVE_NAME}/completions"
@@ -676,9 +690,15 @@ jobs:
           cp "${RELEASE_DIR}/hew-observe" "${ARCHIVE_NAME}/bin/"
           chmod +x "${ARCHIVE_NAME}/bin/"*
 
-          cp "${RELEASE_DIR}/libhew.a" "${ARCHIVE_NAME}/lib/"
+          # Fail-closed shape check: the shipped archive must carry verbatim
+          # libstd members (std-*.o); a fat-LTO archive is refused.
+          ar t "${RELEASE_LIB_DIR}/libhew.a" | grep -q '^std-' || {
+            echo "::error::${RELEASE_LIB_DIR}/libhew.a has no verbatim libstd members — built with LTO; refusing to package"
+            exit 1
+          }
+          cp "${RELEASE_LIB_DIR}/libhew.a" "${ARCHIVE_NAME}/lib/"
           mkdir -p "${ARCHIVE_NAME}/lib/${{ matrix.rust_target }}"
-          cp "${RELEASE_DIR}/libhew.a" "${ARCHIVE_NAME}/lib/${{ matrix.rust_target }}/"
+          cp "${RELEASE_LIB_DIR}/libhew.a" "${ARCHIVE_NAME}/lib/${{ matrix.rust_target }}/"
 
           cp -r std/. "${ARCHIVE_NAME}/std/"
 
@@ -782,7 +802,7 @@ jobs:
 
             # ── Rust builds (release) ──────────────────────────────────────
             cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
-            cargo build -p hew-lib --release
+            cargo build -p hew-lib --profile release-lib
 
             # ── Third-party license attribution ────────────────────────────
             cargo install cargo-about --locked --features cli --version 0.9.0
@@ -801,8 +821,13 @@ jobs:
             cp target/release/hew-observe   "${ARCHIVE_NAME}/bin/"
             chmod +x "${ARCHIVE_NAME}/bin/"*
 
-            # Combined runtime + stdlib library
-            cp target/release/libhew.a "${ARCHIVE_NAME}/lib/"
+            # Combined runtime + stdlib library (non-LTO release-lib profile).
+            # Fail-closed shape check: verbatim libstd members must be present.
+            ar t target/release-lib/libhew.a | grep -q '^std-' || {
+              echo "ERROR: target/release-lib/libhew.a has no verbatim libstd members — built with LTO; refusing to package"
+              exit 1
+            }
+            cp target/release-lib/libhew.a "${ARCHIVE_NAME}/lib/"
 
             # Standard library sources (all .hew files, including subdirectories)
             cp -r std/. "${ARCHIVE_NAME}/std/"
@@ -903,7 +928,7 @@ jobs:
 
             # ── Rust builds (release) ──────────────────────────────────────
             cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
-            cargo build -p hew-lib --release
+            cargo build -p hew-lib --profile release-lib
 
             # ── Third-party license attribution ────────────────────────────
             cargo install cargo-about --locked --features cli --version 0.9.0
@@ -922,8 +947,13 @@ jobs:
             cp target/release/hew-observe   "${ARCHIVE_NAME}/bin/"
             chmod +x "${ARCHIVE_NAME}/bin/"*
 
-            # Combined runtime + stdlib library
-            cp target/release/libhew.a "${ARCHIVE_NAME}/lib/"
+            # Combined runtime + stdlib library (non-LTO release-lib profile).
+            # Fail-closed shape check: verbatim libstd members must be present.
+            ar t target/release-lib/libhew.a | grep -q '^std-' || {
+              echo "ERROR: target/release-lib/libhew.a has no verbatim libstd members — built with LTO; refusing to package"
+              exit 1
+            }
+            cp target/release-lib/libhew.a "${ARCHIVE_NAME}/lib/"
 
             # Standard library sources (all .hew files, including subdirectories)
             cp -r std/. "${ARCHIVE_NAME}/std/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,3 +88,15 @@ lto = true
 codegen-units = 1
 strip = true
 panic = "abort"
+
+# Profile for the SHIPPED `libhew.a` (and other consumer-facing staticlibs).
+# Fat LTO folds prebuilt libstd into the archive's merged codegen unit, which
+# breaks the byte-identical-libstd dedupe contract with external Rust
+# staticlibs (`--link-lib` packages): their verbatim `std-*` member then
+# collides on `rust_eh_personality` / std-internal exports. Building the
+# archive without LTO keeps the prebuilt libstd members verbatim, so a package
+# built with the same pinned rustc dedupes naturally at link time (see
+# hew-cli/src/native_link.rs module docs). Binaries keep the LTO'd `release`.
+[profile.release-lib]
+inherits = "release"
+lto = "off"

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,11 @@ COMMON_GIT_DIR := $(shell git rev-parse --git-common-dir 2>/dev/null)
 # Cargo profile directory names
 DEBUG_DIR  := target/debug
 RELEASE_DIR := target/release
+# The SHIPPED libhew.a builds under the non-LTO `release-lib` cargo profile:
+# a fat-LTO archive cannot dedupe its folded libstd against external Rust
+# staticlibs (`--link-lib` packages), so packaging must never ship the
+# `target/release` archive. See `[profile.release-lib]` in Cargo.toml.
+RELEASE_LIB_DIR := target/release-lib
 WASM_DEBUG_DIR  := target/wasm32-wasip1/debug
 WASM_RELEASE_DIR := target/wasm32-wasip1/release
 
@@ -479,7 +484,7 @@ assemble: | hew adze runtime stdlib wasm-runtime
 RELEASE_PREP = @:
 RELEASE_ENV =
 ifeq ($(shell uname -s),Darwin)
-  RELEASE_PREP = cargo clean --profile release
+  RELEASE_PREP = cargo clean --profile release && cargo clean --profile release-lib
   RELEASE_ENV = MACOSX_DEPLOYMENT_TARGET=13.0
 endif
 
@@ -488,7 +493,7 @@ release:
 	$(RELEASE_ENV) cargo build -p hew-cli --release
 	$(RELEASE_ENV) cargo build -p adze-cli --release
 	$(RELEASE_ENV) cargo build -p hew-observe --release
-	$(RELEASE_ENV) cargo build -p hew-lib --release
+	$(RELEASE_ENV) cargo build -p hew-lib --profile release-lib
 	$(RELEASE_ENV) cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features --release
 	$(RELEASE_ENV) cargo build -p hew-std --target wasm32-wasip1 --release
 	$(MAKE) assemble-release
@@ -511,14 +516,26 @@ publish-docs: target/release/hew ## Build stdlib docs; print wrangler deploy com
 	@echo "Docs generated at target/doc/."
 	@echo "Deploy with: wrangler pages deploy target/doc/ --project-name hew-docs"
 
+# Fail-closed shape check for a shipped libhew.a: the archive must carry
+# verbatim prebuilt libstd members (std-*.o). A fat-LTO build folds libstd
+# into the merged codegen unit — such an archive links Hew programs fine but
+# breaks every external Rust staticlib (--link-lib package), so it must be
+# rejected at packaging time, never shipped. Single logical line so it can be
+# spliced into shell for-loops inside recipes.
+define check_libhew_shape
+ar t $(1) | grep -q '^std-' || { echo "Error: $(1) has no verbatim libstd members (std-*.o) — it was built with LTO and cannot link external Rust staticlibs. Build the shipped archive with: cargo build -p hew-lib --profile release-lib"; exit 1; }
+endef
+
 # Assemble build/ with release symlinks.
 assemble-release:
 	@mkdir -p $(BUILD_DIR)/bin $(BUILD_DIR)/lib $(BUILD_DIR)/std
 	@ln -sfn ../../$(RELEASE_DIR)/hew              $(BUILD_DIR)/bin/hew
 	@ln -sfn ../../$(RELEASE_DIR)/adze             $(BUILD_DIR)/bin/adze
 	@ln -sfn ../../$(RELEASE_DIR)/hew-observe      $(BUILD_DIR)/bin/hew-observe
-	@# Combined Hew library (runtime + all stdlib packages)
-	@ln -sfn ../../$(RELEASE_DIR)/libhew.a         $(BUILD_DIR)/lib/libhew.a
+	@# Combined Hew library (runtime + all stdlib packages), from the non-LTO
+	@# release-lib profile — never the fat-LTO target/release archive.
+	@$(call check_libhew_shape,$(RELEASE_LIB_DIR)/libhew.a)
+	@ln -sfn ../../$(RELEASE_LIB_DIR)/libhew.a     $(BUILD_DIR)/lib/libhew.a
 	@for lib in libhew_runtime.a libhew_std.a; do \
 		if [ -f $(WASM_RELEASE_DIR)/$$lib ]; then \
 			mkdir -p $(BUILD_DIR)/lib/wasm32-wasip1; \
@@ -530,13 +547,14 @@ assemble-release:
 	@for triple in $(NATIVE_LIB_TRIPLES); do \
 		[ -n "$$triple" ] || continue; \
 		lib_path=""; \
-		if [ -f target/$$triple/release/libhew.a ]; then \
-			lib_path="target/$$triple/release/libhew.a"; \
-		elif [ "$$triple" = "$(HOST_TRIPLE)" ] && [ -f $(RELEASE_DIR)/libhew.a ]; then \
-			lib_path="$(RELEASE_DIR)/libhew.a"; \
+		if [ -f target/$$triple/release-lib/libhew.a ]; then \
+			lib_path="target/$$triple/release-lib/libhew.a"; \
+		elif [ "$$triple" = "$(HOST_TRIPLE)" ] && [ -f $(RELEASE_LIB_DIR)/libhew.a ]; then \
+			lib_path="$(RELEASE_LIB_DIR)/libhew.a"; \
 		else \
 			continue; \
 		fi; \
+		$(call check_libhew_shape,$$lib_path); \
 		mkdir -p $(BUILD_DIR)/lib/$$triple; \
 		ln -sfn ../../../$$lib_path $(BUILD_DIR)/lib/$$triple/libhew.a; \
 	done
@@ -1217,7 +1235,8 @@ install: install-check
 	install -m 755 $(RELEASE_DIR)/hew                $(DESTDIR)$(PREFIX)/bin/hew
 	install -m 755 $(RELEASE_DIR)/adze               $(DESTDIR)$(PREFIX)/bin/adze
 	install -m 755 $(RELEASE_DIR)/hew-observe        $(DESTDIR)$(PREFIX)/bin/hew-observe
-	install -m 644 $(RELEASE_DIR)/libhew.a           $(DESTDIR)$(PREFIX)/lib/libhew.a
+	@$(call check_libhew_shape,$(RELEASE_LIB_DIR)/libhew.a)
+	install -m 644 $(RELEASE_LIB_DIR)/libhew.a       $(DESTDIR)$(PREFIX)/lib/libhew.a
 	@for lib in libhew_runtime.a libhew_std.a; do \
 		if [ -f $(WASM_RELEASE_DIR)/$$lib ]; then \
 			install -d $(DESTDIR)$(PREFIX)/lib/wasm32-wasip1; \
@@ -1230,13 +1249,14 @@ install: install-check
 	@for triple in $(NATIVE_LIB_TRIPLES); do \
 		[ -n "$$triple" ] || continue; \
 		lib_path=""; \
-		if [ -f target/$$triple/release/libhew.a ]; then \
-			lib_path="target/$$triple/release/libhew.a"; \
-		elif [ "$$triple" = "$(HOST_TRIPLE)" ] && [ -f $(RELEASE_DIR)/libhew.a ]; then \
-			lib_path="$(RELEASE_DIR)/libhew.a"; \
+		if [ -f target/$$triple/release-lib/libhew.a ]; then \
+			lib_path="target/$$triple/release-lib/libhew.a"; \
+		elif [ "$$triple" = "$(HOST_TRIPLE)" ] && [ -f $(RELEASE_LIB_DIR)/libhew.a ]; then \
+			lib_path="$(RELEASE_LIB_DIR)/libhew.a"; \
 		else \
 			continue; \
 		fi; \
+		$(call check_libhew_shape,$$lib_path); \
 		install -d $(DESTDIR)$(PREFIX)/lib/$$triple; \
 		install -m 644 $$lib_path $(DESTDIR)$(PREFIX)/lib/$$triple/libhew.a; \
 	done
@@ -1258,7 +1278,7 @@ install-check:
 		|| { echo "Error: release adze not built. Run 'make release' first."; exit 1; }
 	@test -f $(RELEASE_DIR)/hew-observe \
 		|| { echo "Error: release hew-observe not built. Run 'make release' first."; exit 1; }
-	@test -f $(RELEASE_DIR)/libhew.a \
+	@test -f $(RELEASE_LIB_DIR)/libhew.a \
 		|| { echo "Error: libhew.a not built. Run 'make release' first."; exit 1; }
 	@test -f $(WASM_RELEASE_DIR)/libhew_runtime.a \
 		|| { echo "Error: wasm runtime not built. Run 'make release' first."; exit 1; }

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -814,7 +814,17 @@ fn hew_lib_candidates(
         exe_dir.join("../lib").join(name),
         exe_dir.join("../lib/hew").join(name), // /usr/lib/hew/
         exe_dir.join("../lib64/hew").join(name), // /usr/lib64/hew/
-        // Cargo target-dir outputs for cross-target dev/test builds.
+        // Cargo target-dir outputs for cross-target dev/test builds. The
+        // `release-lib` profile dir (the shipped, non-LTO archive build —
+        // see `[profile.release-lib]` in the workspace Cargo.toml) is probed
+        // BEFORE the plain `release` dir: a stale fat-LTO `target/release`
+        // archive from a workspace binary build must not shadow a linkable
+        // `release-lib` one when both exist.
+        exe_dir
+            .join("../../target")
+            .join(triple)
+            .join("release-lib")
+            .join(name),
         exe_dir
             .join("../../target")
             .join(triple)
@@ -825,7 +835,10 @@ fn hew_lib_candidates(
             .join(triple)
             .join("debug")
             .join(name),
-        // Same dir as the binary (target/debug/ or target/release/) for host-target dev builds.
+        // Same dir as the binary (target/debug/ or target/release/) for
+        // host-target dev builds, preferring the release-lib sibling dir.
+        exe_dir.join("../release-lib").join(name),
+        exe_dir.join("../../target/release-lib").join(name),
         exe_dir.join(name),
         exe_dir.join("../../target/release").join(name),
         exe_dir.join("../../target/debug").join(name),
@@ -928,6 +941,7 @@ pub(crate) fn diagnose_linker_errors(stderr: &str) -> Vec<String> {
     let mut seen: std::collections::BTreeSet<(&'static str, &'static str)> =
         std::collections::BTreeSet::new();
     let mut dup_hew: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut dup_rust_internal = false;
     let mut dup_generic = false;
 
     for line in stderr.lines() {
@@ -941,6 +955,8 @@ pub(crate) fn diagnose_linker_errors(stderr: &str) -> Vec<String> {
             let norm = sym.strip_prefix('_').unwrap_or(sym);
             if norm.starts_with("hew_") {
                 dup_hew.insert(norm.to_string());
+            } else if is_rust_toolchain_internal_symbol(norm) {
+                dup_rust_internal = true;
             } else {
                 dup_generic = true;
             }
@@ -971,6 +987,16 @@ pub(crate) fn diagnose_linker_errors(stderr: &str) -> Vec<String> {
              Build the package as a `staticlib` with `panic = \"abort\"`, then link it with \
              --link-lib; do not re-export or bundle the runtime."
         ));
+    } else if dup_rust_internal {
+        hints.push(
+            "hint: duplicate Rust-internal symbol(s) (libstd / personality) during link. \
+             A library passed via --link-lib embeds a Rust standard library that does not \
+             byte-match the one inside libhew.a — the usual cause is a package built with \
+             a DIFFERENT Rust toolchain than libhew.a.\n      \
+             Rebuild the package with the Hew toolchain's pinned rustc (as a `staticlib` \
+             with `panic = \"abort\"`) and retry."
+                .to_string(),
+        );
     } else if dup_generic {
         hints.push(
             "hint: duplicate symbol(s) during link: two linked inputs define the same symbol. \
@@ -981,6 +1007,28 @@ pub(crate) fn diagnose_linker_errors(stderr: &str) -> Vec<String> {
     }
 
     hints
+}
+
+/// Classify a duplicate NON-`hew_*` symbol as belonging to the Rust toolchain
+/// itself (prebuilt libstd members, the panic personality, allocator shims).
+/// Such duplicates mean two linked inputs carry libstd copies that did not
+/// dedupe — the byte-identical-libstd contract (same pinned rustc, see
+/// `native_link.rs` module docs) is broken, almost always by a `--link-lib`
+/// archive built with a different rustc than `libhew.a`. lld demangles in its
+/// error lines, so both mangled (`_ZN3std…`) and demangled (`std::…`) shapes
+/// appear depending on linker and platform.
+fn is_rust_toolchain_internal_symbol(symbol: &str) -> bool {
+    symbol == "rust_eh_personality"
+        || symbol.starts_with("__rust")
+        || symbol.starts_with("std::")
+        || symbol.starts_with("core::")
+        || symbol.starts_with("alloc::")
+        || symbol.starts_with("_ZN3std")
+        || symbol.starts_with("_ZN4core")
+        || symbol.starts_with("_ZN5alloc")
+        || symbol.starts_with("ZN3std")
+        || symbol.starts_with("ZN4core")
+        || symbol.starts_with("ZN5alloc")
 }
 
 /// Extract a `hew_`-prefixed symbol name from a linker error line, or `None`
@@ -1520,6 +1568,46 @@ mod tests {
     }
 
     #[test]
+    fn diagnose_duplicate_rust_internal_symbol_names_toolchain_mismatch() {
+        // Captured shape from linking a fat-LTO libhew.a against a package
+        // archive whose verbatim libstd member could not dedupe: ld64.lld
+        // demangles, so both raw and demangled std symbols appear.
+        let stderr = "\
+            ld64.lld: error: duplicate symbol: rust_eh_personality\n\
+            >>> defined in /toolchain/libhew.a(hew-140483c00b278068.hew.deadbeef-cgu.0.rcgu.o)\n\
+            >>> defined in /pkg/libhew_hew_queue_mqtt.a(std-9cc64aabf2d9c512.std.cafe-cgu.0.rcgu.o)\n\
+            ld64.lld: error: duplicate symbol: std::panicking::EMPTY_PANIC::h0123456789abcdef\n";
+        let hints = diagnose_linker_errors(stderr);
+        assert_eq!(hints.len(), 1);
+        assert!(hints[0].contains("DIFFERENT Rust toolchain"));
+        assert!(hints[0].contains("pinned rustc"));
+        // The toolchain-mismatch hint, NOT the mis-shaped-package recipe.
+        assert!(!hints[0].contains("hew-cabi"));
+    }
+
+    #[test]
+    fn diagnose_duplicate_rust_internal_symbol_gnu_ld_mangled() {
+        // GNU ld does not demangle: the libstd internals arrive as `_ZN3std…`.
+        let stderr = "b.o: multiple definition of \
+             `_ZN3std9panicking11EMPTY_PANIC17h0123456789abcdefE'; a.o: first defined here\n";
+        let hints = diagnose_linker_errors(stderr);
+        assert_eq!(hints.len(), 1);
+        assert!(hints[0].contains("DIFFERENT Rust toolchain"));
+    }
+
+    #[test]
+    fn diagnose_duplicate_hew_takes_precedence_over_rust_internal() {
+        // A mis-shaped package that bundles the runtime usually collides on
+        // BOTH hew_* and libstd symbols; the actionable recipe is the hew one.
+        let stderr = "\
+            ld64.lld: error: duplicate symbol: hew_stream_last_error\n\
+            ld64.lld: error: duplicate symbol: rust_eh_personality\n";
+        let hints = diagnose_linker_errors(stderr);
+        assert_eq!(hints.len(), 1);
+        assert!(hints[0].contains("duplicate Hew runtime symbol"));
+    }
+
+    #[test]
     fn diagnose_duplicate_folds_multiple_hew_symbols_into_one_hint() {
         // lld prints one error per duplicate plus ">>> defined in" provenance
         // lines, which must be ignored. Two hew dups fold into one recipe hint.
@@ -1857,6 +1945,38 @@ mod tests {
         .map(std::path::PathBuf::from)
         .collect();
         assert_eq!(&candidates[..expected.len()], expected.as_slice());
+    }
+
+    #[test]
+    fn hew_lib_candidates_prefer_release_lib_over_stale_release() {
+        // The shipped archive builds under `[profile.release-lib]` (non-LTO).
+        // A plain `cargo build --release` still leaves a fat-LTO archive in
+        // `target/release/`, which cannot dedupe against external staticlibs —
+        // when both exist, the linkable release-lib one must win.
+        let exe_dir = std::path::Path::new("/repo/target/debug");
+        let candidates = hew_lib_candidates(exe_dir, "libhew.a", "aarch64-apple-darwin");
+        let position = |suffix: &str| {
+            candidates
+                .iter()
+                .position(|path| path.display().to_string().ends_with(suffix))
+                .unwrap_or_else(|| panic!("candidate ending `{suffix}` missing: {candidates:?}"))
+        };
+
+        // Host-fallback block: release-lib before same-dir and target/release.
+        assert!(
+            position("../../target/release-lib/libhew.a") < position("/repo/target/debug/libhew.a")
+        );
+        assert!(
+            position("../../target/release-lib/libhew.a")
+                < position("../../target/release/libhew.a")
+        );
+        assert!(position("../release-lib/libhew.a") < position("/repo/target/debug/libhew.a"));
+
+        // Cross-target block: <triple>/release-lib before <triple>/release.
+        assert!(
+            position("aarch64-apple-darwin/release-lib/libhew.a")
+                < position("aarch64-apple-darwin/release/libhew.a")
+        );
     }
 
     #[test]

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -235,28 +235,17 @@ pub fn link_executable(
         cmd.arg("-fsanitize=address");
     }
 
+    // `libhew.a` is the SINGLE provider of runtime + stdlib symbols on the
+    // native link line — `hew-lib` depends on both `hew-runtime` and `hew-std`,
+    // so direct extern declarations naming `hew_datetime_*` and similar
+    // stable-stdlib symbols resolve from it. A second stdlib archive
+    // (`libhew_std.a`) used to be probed in best-effort here; it embeds its own
+    // full copy of hew-runtime (cargo staticlib packaging bundles transitive
+    // rlib deps), so whenever an FFI consumer archive pulled members from both,
+    // the link died on duplicate `hew_*` symbols. Consumer archives must
+    // reference runtime/stdlib symbols as *undefined* (see the re-list comment
+    // below and `diagnose_linker_errors`' dup hint).
     cmd.arg(object_path).arg(&hew_lib);
-
-    // ── Stdlib staticlib the user may reference via `extern "rt"` ────
-    // Pull in the consolidated stdlib archive (libhew_std.a) so direct extern
-    // declarations naming `hew_datetime_*` and similar stable-stdlib symbols
-    // resolve at link time. A missing archive is ignored (best-effort) so users
-    // who never reach for stdlib FFI from a source build that skipped the stdlib
-    // crate still link plain programs.
-    if let Ok(exe) = std::env::current_exe() {
-        let exe_dir = exe.parent().expect("exe should have a parent directory");
-        let triple = target.normalized_triple();
-        for archive in NATIVE_STDLIB_ARCHIVES {
-            let path = if target.can_run_on_host() {
-                find_optional_hew_lib(exe_dir, archive, triple)
-            } else {
-                find_optional_target_hew_lib(exe_dir, archive, triple)
-            };
-            if let Some(path) = path {
-                cmd.arg(path);
-            }
-        }
-    }
 
     cmd.arg("-o").arg(&safe_output);
 
@@ -329,12 +318,15 @@ pub fn link_executable(
 
     // ── Re-list the runtime archive after the consumer archives ───────
     // libhew.a appears once above (resolving the program object's *direct*
-    // runtime references) and again here, after the stdlib/native-package
-    // archives. Native packages and stdlib staticlibs reference runtime symbols
-    // (`hew_vec_*`, `hew_stream_*`, …) as *undefined* and resolve them against
-    // libhew.a at the final link rather than bundling their own copy — bundling
-    // is the duplicate-symbol failure this change fixes. A single-pass archive
-    // linker (GNU ld / ld.lld on ELF) only pulls an archive member to satisfy an
+    // runtime references) and again here, after the native-package/--link-lib
+    // archives. It is the ONLY runtime/stdlib archive permitted on the native
+    // link line: native packages and `--link-lib` staticlibs reference runtime
+    // symbols (`hew_vec_*`, `hew_stream_*`, …) as *undefined* and resolve them
+    // against libhew.a at the final link rather than bundling their own copy —
+    // bundling (or listing a second runtime-carrying archive such as
+    // libhew_std.a) is exactly the duplicate-symbol failure `diagnose_linker_
+    // errors`' dup hint describes. A single-pass archive linker (GNU ld /
+    // ld.lld on ELF) only pulls an archive member to satisfy an
     // already-pending undefined symbol, so a consumer archive listed *after* the
     // first libhew.a needs libhew.a repeated here for its backward references to
     // resolve; the system libraries above are shared objects and stay globally
@@ -650,12 +642,6 @@ fn link_wasm(object_path: &str, output_path: &str, target: &str) -> Result<(), S
 const WASM_OPTIONAL_LINK_ARCHIVES: [&str; 1] = ["libhew_std.a"];
 const WASM_RUNTIME_ARCHIVE: &str = "libhew_runtime.a";
 
-/// Sibling stdlib staticlib the native linker pulls in (best-effort) so
-/// `extern "rt"` declarations naming `stable-stdlib` symbols resolve.
-/// Keep in sync with the `stable-stdlib` block in
-/// `scripts/jit-symbol-classification.toml`.
-const NATIVE_STDLIB_ARCHIVES: &[&str] = &["libhew_std.a"];
-
 fn find_wasm_link_libs(target: &str) -> Result<Vec<String>, String> {
     let exe = std::env::current_exe().map_err(|e| format!("cannot find self: {e}"))?;
     let exe_dir = exe.parent().expect("exe should have a parent directory");
@@ -670,42 +656,6 @@ fn find_wasm_link_libs(target: &str) -> Result<Vec<String>, String> {
     libs.push(find_required_wasm_runtime_lib(exe_dir, rust_target)?);
 
     Ok(libs)
-}
-
-fn find_optional_hew_lib(exe_dir: &std::path::Path, name: &str, triple: &str) -> Option<String> {
-    for candidate in hew_lib_candidates(exe_dir, name, triple) {
-        if candidate.exists() {
-            return Some(
-                candidate
-                    .canonicalize()
-                    .unwrap_or(candidate)
-                    .display()
-                    .to_string(),
-            );
-        }
-    }
-
-    None
-}
-
-fn find_optional_target_hew_lib(
-    exe_dir: &std::path::Path,
-    name: &str,
-    triple: &str,
-) -> Option<String> {
-    for candidate in hew_target_lib_candidates(exe_dir, name, triple) {
-        if candidate.exists() {
-            return Some(
-                candidate
-                    .canonicalize()
-                    .unwrap_or(candidate)
-                    .display()
-                    .to_string(),
-            );
-        }
-    }
-
-    None
 }
 
 fn wasm_runtime_target(target: &str) -> &str {
@@ -885,30 +835,6 @@ fn hew_lib_candidates(
             .join(name),
         exe_dir.join("../../target/wasm32-wasip1/debug").join(name),
         exe_dir.join("../../hew-runtime/target/release").join(name),
-    ]
-}
-
-fn hew_target_lib_candidates(
-    exe_dir: &std::path::Path,
-    name: &str,
-    triple: &str,
-) -> Vec<std::path::PathBuf> {
-    vec![
-        // Installed target-aware layouts.
-        exe_dir.join("../lib").join(triple).join(name),
-        exe_dir.join("../lib/hew").join(triple).join(name), // /usr/lib/hew/<triple>/
-        exe_dir.join("../lib64/hew").join(triple).join(name), // /usr/lib64/hew/<triple>/
-        // Cargo target-dir outputs for cross-target dev/test builds.
-        exe_dir
-            .join("../../target")
-            .join(triple)
-            .join("release")
-            .join(name),
-        exe_dir
-            .join("../../target")
-            .join(triple)
-            .join("debug")
-            .join(name),
     ]
 }
 
@@ -1958,27 +1884,6 @@ mod tests {
             .expect("same-dir host fallback candidate");
         assert!(cross_release_index < host_same_dir_index);
         assert!(cross_debug_index < host_same_dir_index);
-    }
-
-    #[test]
-    fn hew_target_lib_candidates_exclude_host_fallbacks() {
-        let exe_dir = std::path::Path::new("/repo/target/debug");
-        let candidates =
-            hew_target_lib_candidates(exe_dir, "libhew_std.a", "aarch64-unknown-linux-gnu");
-
-        assert!(
-            !candidates.contains(&std::path::PathBuf::from("/repo/target/debug/libhew_std.a")),
-            "cross-target stdlib lookup must not accept a host archive"
-        );
-        assert!(
-            !candidates.contains(&std::path::PathBuf::from(
-                "/repo/target/debug/../../target/debug/libhew_std.a"
-            )),
-            "cross-target stdlib lookup must not accept a host target-dir archive"
-        );
-        assert!(candidates.contains(&std::path::PathBuf::from(
-            "/repo/target/debug/../../target/aarch64-unknown-linux-gnu/debug/libhew_std.a"
-        )));
     }
 
     #[test]

--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -1952,31 +1952,44 @@ mod tests {
         // The shipped archive builds under `[profile.release-lib]` (non-LTO).
         // A plain `cargo build --release` still leaves a fat-LTO archive in
         // `target/release/`, which cannot dedupe against external staticlibs —
-        // when both exist, the linkable release-lib one must win.
-        let exe_dir = std::path::Path::new("/repo/target/debug");
-        let candidates = hew_lib_candidates(exe_dir, "libhew.a", "aarch64-apple-darwin");
-        let position = |suffix: &str| {
-            candidates
-                .iter()
-                .position(|path| path.display().to_string().ends_with(suffix))
-                .unwrap_or_else(|| panic!("candidate ending `{suffix}` missing: {candidates:?}"))
-        };
+        // when both exist, the linkable release-lib one must win. The ordering
+        // must hold for both platform archive names; matching is component-wise
+        // (`Path::ends_with`) so `Path::join`'s host separator cannot skew it.
+        for (name, triple) in [
+            ("libhew.a", "aarch64-apple-darwin"),
+            ("hew.lib", "x86_64-pc-windows-msvc"),
+        ] {
+            let exe_dir = std::path::Path::new("/repo/target/debug");
+            let candidates = hew_lib_candidates(exe_dir, name, triple);
+            let position = |suffix: String| {
+                candidates
+                    .iter()
+                    .position(|path| path.ends_with(&suffix))
+                    .unwrap_or_else(|| {
+                        panic!("candidate ending `{suffix}` missing: {candidates:?}")
+                    })
+            };
 
-        // Host-fallback block: release-lib before same-dir and target/release.
-        assert!(
-            position("../../target/release-lib/libhew.a") < position("/repo/target/debug/libhew.a")
-        );
-        assert!(
-            position("../../target/release-lib/libhew.a")
-                < position("../../target/release/libhew.a")
-        );
-        assert!(position("../release-lib/libhew.a") < position("/repo/target/debug/libhew.a"));
+            // Host-fallback block: release-lib before same-dir and target/release.
+            assert!(
+                position(format!("../../target/release-lib/{name}"))
+                    < position(format!("/repo/target/debug/{name}"))
+            );
+            assert!(
+                position(format!("../../target/release-lib/{name}"))
+                    < position(format!("../../target/release/{name}"))
+            );
+            assert!(
+                position(format!("../release-lib/{name}"))
+                    < position(format!("/repo/target/debug/{name}"))
+            );
 
-        // Cross-target block: <triple>/release-lib before <triple>/release.
-        assert!(
-            position("aarch64-apple-darwin/release-lib/libhew.a")
-                < position("aarch64-apple-darwin/release/libhew.a")
-        );
+            // Cross-target block: <triple>/release-lib before <triple>/release.
+            assert!(
+                position(format!("{triple}/release-lib/{name}"))
+                    < position(format!("{triple}/release/{name}"))
+            );
+        }
     }
 
     #[test]

--- a/hew-cli/src/main.rs
+++ b/hew-cli/src/main.rs
@@ -955,6 +955,18 @@ fn cmd_build(a: &args::BuildArgs) {
         eprintln!("Error: {e}");
         std::process::exit(2);
     });
+
+    // `--link-lib` names a NATIVE archive; a wasm module cannot link one. The
+    // wasm branch of `compile_build_binary` has no use for the archives, so
+    // reject loudly here instead of silently dropping the flag (fail-open).
+    if target.is_wasm() && !a.link_libs.is_empty() {
+        eprintln!(
+            "Error: --link-lib is not supported for wasm targets \
+             (native archives cannot be linked into a wasm module)"
+        );
+        std::process::exit(2);
+    }
+
     let options = a.to_compile_options();
 
     // The clap `value_parser` already constrains `--opt-level` to {"0","2"}, so
@@ -1126,19 +1138,33 @@ fn compile_temp_debug_artifact(
     input: &str,
     options: &compile::CompileOptions,
     target: &target::ExecutionTarget,
+    extra_libs: &[String],
 ) -> Result<CompiledTempExecutable, ()> {
     // `hew debug` launches a native debugger on the artifact, so it must carry
     // DWARF debug info — emit it even though the shared `hew run` path does not.
-    compile_temp_artifact(input, create_debug_temp_artifact(target), options, true)
+    compile_temp_artifact(
+        input,
+        create_debug_temp_artifact(target),
+        options,
+        true,
+        extra_libs,
+    )
 }
 
 fn compile_temp_run_artifact(
     input: &str,
     options: &compile::CompileOptions,
     target: &target::ExecutionTarget,
+    extra_libs: &[String],
 ) -> Result<CompiledTempExecutable, ()> {
     // `hew run` is the fast-exec path; no debug info.
-    compile_temp_artifact(input, create_run_temp_artifact(target), options, false)
+    compile_temp_artifact(
+        input,
+        create_run_temp_artifact(target),
+        options,
+        false,
+        extra_libs,
+    )
 }
 
 /// Compile a `.hew` source file to a temporary `.wasm` module for WASI execution.
@@ -1231,10 +1257,12 @@ fn compile_temp_artifact(
     artifact: CompiledTempExecutable,
     options: &compile::CompileOptions,
     debug: bool,
+    extra_libs: &[String],
 ) -> Result<CompiledTempExecutable, ()> {
     // Route through the same path as `hew build` so `hew run` honours
-    // `--pkg-path` (resolving `hew::<pkg>` imports) and auto-links the native
-    // (FFI) staticlibs declared by imported packages.
+    // `--pkg-path` (resolving `hew::<pkg>` imports), auto-links the native
+    // (FFI) staticlibs declared by imported packages, and threads explicit
+    // `--link-lib` archives into the final link.
     let target = match target::TargetSpec::from_requested(options.target.as_deref()) {
         Ok(target) => target,
         Err(e) => {
@@ -1251,7 +1279,7 @@ fn compile_temp_artifact(
         // `hew run` is debug-default O0; the `HEW_OPT_LEVEL` env floor lifts the
         // whole corpus to O2 for the differential-exec parity gate.
         hew_codegen_rs::OptLevel::O0,
-        &[],
+        extra_libs,
         options,
     )
     .is_ok()
@@ -1308,6 +1336,18 @@ fn cmd_run(a: &args::RunArgs) {
     let input = a.input.display().to_string();
     let options = a.to_compile_options();
     let target = resolve_run_target(options.target.as_deref());
+
+    // `--link-lib` names a NATIVE archive; a wasm module cannot link one.
+    // Reject loudly before any compilation — silently dropping the flag would
+    // produce a module missing the user's symbols (fail-open).
+    if target.is_wasi() && !a.link_libs.is_empty() {
+        eprintln!(
+            "Error: --link-lib is not supported for WASI targets \
+             (native archives cannot be linked into a wasm module)"
+        );
+        std::process::exit(2);
+    }
+
     let timeout = a.timeout.as_deref().map(|raw| {
         crate::util::parse_timeout(raw).unwrap_or_else(|e| {
             eprintln!("Error: {e}");
@@ -1379,7 +1419,7 @@ fn cmd_run_native(
     target: &target::ExecutionTarget,
     timeout: Option<std::time::Duration>,
 ) -> ! {
-    let artifact = compile_temp_run_artifact(input, options, target)
+    let artifact = compile_temp_run_artifact(input, options, target, &a.link_libs)
         .unwrap_or_else(|()| std::process::exit(1));
 
     let mut command = std::process::Command::new(artifact.path());
@@ -1518,7 +1558,7 @@ fn cmd_debug(a: &args::DebugArgs) {
     let input = a.input.display().to_string();
     let options = a.to_compile_options();
     let target = resolve_debug_target(options.target.as_deref());
-    let artifact = compile_temp_debug_artifact(&input, &options, &target)
+    let artifact = compile_temp_debug_artifact(&input, &options, &target, &a.link_libs)
         .unwrap_or_else(|()| std::process::exit(1));
     let (debugger, debugger_args) =
         match resolve_debugger_invocation(artifact.path(), &a.program_args) {

--- a/hew-cli/tests/ffi_link_e2e.rs
+++ b/hew-cli/tests/ffi_link_e2e.rs
@@ -234,6 +234,137 @@ fn hew_build(
     run_bounded_command(cmd, "hew build --link-lib")
 }
 
+/// `hew run --link-lib <archive>` must thread the archive into the native link
+/// step exactly like `hew build --link-lib` does. Before the fix,
+/// `compile_temp_artifact` passed a literal `&[]` to `compile_build_binary`,
+/// silently dropping the flag — the link then failed with an undefined
+/// `hew_fixture_value` reference.
+#[test]
+fn run_link_lib_links_and_executes() {
+    require_codegen();
+    let dir = tempdir();
+
+    let Some(lib) = build_staticlib(
+        dir.path(),
+        "run_ffi",
+        r#"#[no_mangle]
+pub extern "C" fn hew_fixture_value() -> i32 { 42 }
+"#,
+    ) else {
+        return;
+    };
+
+    let prog = write_program(
+        dir.path(),
+        "run_prog",
+        r#"extern "C" { fn hew_fixture_value() -> i32; }
+fn main() {
+    let v: i32 = unsafe { hew_fixture_value() };
+    println(f"{v}");
+}
+"#,
+    );
+
+    let mut cmd = Command::new(hew_binary());
+    cmd.arg("run")
+        .arg("--link-lib")
+        .arg(&lib)
+        .arg(&prog)
+        .current_dir(dir.path());
+    let out = run_bounded_command(cmd, "hew run --link-lib");
+    assert!(
+        out.status.success(),
+        "`hew run --link-lib` must link the archive and execute:\n{}",
+        describe_output(&out),
+    );
+    // Exact value: `len() > 0`-style assertions pass on garbage.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        stdout.trim(),
+        "42",
+        "expected the extern's exact value on stdout:\n{}",
+        describe_output(&out),
+    );
+}
+
+/// `hew run --target wasm32-wasi --link-lib …` must be rejected loudly (exit 2)
+/// BEFORE any compilation — a native archive cannot be linked into a wasm
+/// module, and silently dropping the flag is fail-open. The archive path
+/// deliberately does not exist: the guard must fire before anything touches it.
+#[test]
+fn run_wasi_link_lib_rejected() {
+    let dir = tempdir();
+    let prog = write_program(
+        dir.path(),
+        "wasi_prog",
+        "fn main() {\n    println(\"unreachable\");\n}\n",
+    );
+
+    let mut cmd = Command::new(hew_binary());
+    cmd.arg("run")
+        .arg("--target")
+        .arg("wasm32-wasi")
+        .arg("--link-lib")
+        .arg("libdoes_not_exist.a")
+        .arg(&prog)
+        .current_dir(dir.path());
+    let out = run_bounded_command(cmd, "hew run --target wasm32-wasi --link-lib");
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "wasi run with --link-lib must exit 2 (usage error):\n{}",
+        describe_output(&out),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--link-lib is not supported for WASI targets"),
+        "expected the loud WASI rejection message:\n{}",
+        describe_output(&out),
+    );
+    assert!(
+        out.stdout.is_empty(),
+        "the program must not run:\n{}",
+        describe_output(&out),
+    );
+}
+
+/// `hew build --target wasm32-unknown-unknown --link-lib …` must be rejected
+/// loudly (exit 2) — the wasm branch of the build path used to silently ignore
+/// the archives.
+#[test]
+fn build_wasm_link_lib_rejected() {
+    let dir = tempdir();
+    let prog = write_program(
+        dir.path(),
+        "wasm_prog",
+        "fn main() {\n    println(\"unreachable\");\n}\n",
+    );
+
+    let mut cmd = Command::new(hew_binary());
+    cmd.arg("build")
+        .arg("--target")
+        .arg("wasm32-unknown-unknown")
+        .arg("--link-lib")
+        .arg("libdoes_not_exist.a")
+        .arg(&prog)
+        .arg("-o")
+        .arg(dir.path().join("wasm_out"))
+        .current_dir(dir.path());
+    let out = run_bounded_command(cmd, "hew build --target wasm32-unknown-unknown --link-lib");
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "wasm build with --link-lib must exit 2 (usage error):\n{}",
+        describe_output(&out),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--link-lib is not supported for wasm targets"),
+        "expected the loud wasm rejection message:\n{}",
+        describe_output(&out),
+    );
+}
+
 /// A minimal `extern "C"` function resolves and runs when its staticlib is
 /// supplied via `--link-lib`. (`mvp_add(2, 3) == 5`.)
 #[test]

--- a/hew-cli/tests/ffi_link_e2e.rs
+++ b/hew-cli/tests/ffi_link_e2e.rs
@@ -234,6 +234,207 @@ fn hew_build(
     run_bounded_command(cmd, "hew build --link-lib")
 }
 
+/// Resolve a tool on the CURRENT PATH (before any shadowing), mirroring the
+/// `which` probe `select_native_compiler` performs. Returns the absolute path.
+fn resolve_tool(name: &str) -> Option<PathBuf> {
+    let out = Command::new("which").arg(name).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if path.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(path))
+    }
+}
+
+/// The native link line must carry `libhew.a` as the ONLY runtime/stdlib
+/// archive: the `--link-lib` fixture appears exactly once and NO
+/// `libhew_std.a` token appears — even when a stray dev-build
+/// `target/{debug,release}/libhew_std.a` exists. Before the fix,
+/// `link_executable` probed for that archive best-effort and dev layouts
+/// carried a second full runtime copy on the line; an FFI consumer archive
+/// then died on duplicate `hew_*` symbols against the fat-LTO release
+/// `libhew.a`. The compiler argv is captured with a PATH shim that logs one
+/// argument per line, then execs the real driver.
+#[test]
+fn link_line_carries_single_runtime_archive() {
+    require_codegen();
+    let dir = tempdir();
+
+    // Shadow whichever driver the host resolves (`select_native_compiler`
+    // prefers clang, falls back to cc). Resolve the REAL path before
+    // prepending the shim dir to PATH.
+    let Some((tool_name, real_tool)) = ["clang", "cc"]
+        .iter()
+        .find_map(|name| resolve_tool(name).map(|path| (*name, path)))
+    else {
+        eprintln!("SKIP: neither clang nor cc is resolvable on this host");
+        return;
+    };
+
+    let shim_dir = dir.path().join("shim-bin");
+    std::fs::create_dir_all(&shim_dir).expect("create shim dir");
+    let argv_log = dir.path().join("argv.log");
+    let shim_path = shim_dir.join(tool_name);
+    std::fs::write(
+        &shim_path,
+        format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" >> {}\nexec {} \"$@\"\n",
+            argv_log.display(),
+            real_tool.display(),
+        ),
+    )
+    .expect("write shim script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&shim_path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod shim script");
+    }
+
+    let Some(lib) = build_staticlib(
+        dir.path(),
+        "argv_ffi",
+        r#"#[no_mangle]
+pub extern "C" fn argv_fixture_value() -> i64 { 7 }
+"#,
+    ) else {
+        return;
+    };
+
+    let prog = write_program(
+        dir.path(),
+        "argv_prog",
+        r#"extern "C" { fn argv_fixture_value() -> i64; }
+fn main() {
+    let v: i64 = unsafe { argv_fixture_value() };
+    println(f"{v}");
+}
+"#,
+    );
+    let out_bin = dir.path().join("argv_out");
+
+    let orig_path = std::env::var("PATH").unwrap_or_default();
+    let mut cmd = Command::new(hew_binary());
+    cmd.arg("build")
+        .arg("--link-lib")
+        .arg(&lib)
+        .arg(&prog)
+        .arg("-o")
+        .arg(&out_bin)
+        .env("PATH", format!("{}:{orig_path}", shim_dir.display()))
+        .current_dir(dir.path());
+    let out = run_bounded_command(cmd, "hew build --link-lib (argv shim)");
+    assert!(
+        out.status.success(),
+        "shimmed link must succeed:\n{}",
+        describe_output(&out),
+    );
+
+    let log = std::fs::read_to_string(&argv_log).expect("shim must have captured a linker argv");
+    let tokens: Vec<&str> = log.lines().collect();
+    let fixture_count = tokens
+        .iter()
+        .filter(|token| token.ends_with("libargv_ffi.a"))
+        .count();
+    assert_eq!(
+        fixture_count, 1,
+        "the --link-lib archive must appear exactly once on the link line:\n{log}",
+    );
+    assert!(
+        !tokens.iter().any(|token| token.contains("libhew_std.a")),
+        "libhew.a is the single runtime/stdlib archive — libhew_std.a must \
+         never be on the native link line:\n{log}",
+    );
+    assert!(
+        tokens.iter().any(|token| token.ends_with("libhew.a")),
+        "the runtime archive libhew.a must be on the link line:\n{log}",
+    );
+}
+
+/// In-repo miniature of the mqtt/nats ecosystem shape: a hew-cabi-dependent
+/// package archive plus a program that BOTH spawns an actor (pulling the
+/// actor-runtime members) and calls the package's extern (pulling the package
+/// member whose `hew_*` refs are undefined imports). Pre-fix, dev layouts
+/// carried TWO runtime-defining archives on the line, and this exact pull
+/// pattern is what turned the redundancy into a duplicate-symbol hard error.
+#[test]
+fn actor_spawn_with_cabi_staticlib_links_and_runs() {
+    require_codegen();
+    let dir = tempdir();
+
+    let Some(lib) = build_cabi_wrapper_staticlib(
+        dir.path(),
+        "actorcabi",
+        r#"//! Fixture package: hew-cabi-dependent, exercised alongside an actor spawn.
+use hew_cabi::sink::set_last_error;
+
+#[no_mangle]
+pub extern "C" fn actorcabi_probe() -> i64 {
+    set_last_error("actorcabi: probe".to_string());
+    11
+}
+"#,
+    ) else {
+        return;
+    };
+    assert_archive_symbol_is_undefined(&lib, "hew_stream_set_last_error");
+
+    let prog = write_program(
+        dir.path(),
+        "actorcabi_prog",
+        r#"extern "C" { fn actorcabi_probe() -> i64; }
+
+actor Adder {
+    var total: i64 = 0;
+    receive fn add(n: i64) -> i64 {
+        total = total + n;
+        total
+    }
+}
+
+fn main() {
+    let ffi: i64 = unsafe { actorcabi_probe() };
+    let adder = spawn Adder();
+    match await adder.add(ffi) {
+        Ok(v) => println(f"total={v}"),
+        Err(_) => println("err"),
+    }
+}
+"#,
+    );
+    let out_bin = dir.path().join("actorcabi_out");
+
+    let link = hew_build(Some(&lib), &prog, &out_bin, dir.path());
+    assert!(
+        link.status.success(),
+        "an actor-spawning program with a hew-cabi package must link cleanly:\n{}",
+        describe_output(&link),
+    );
+    let link_stderr = String::from_utf8_lossy(&link.stderr);
+    assert!(
+        !link_stderr.contains("duplicate"),
+        "unexpected duplicate-symbol error linking actor + hew-cabi package:\n{link_stderr}",
+    );
+
+    let mut run = Command::new(&out_bin);
+    run.current_dir(dir.path());
+    let run = run_bounded_command(run, "run actorcabi_out");
+    assert!(
+        run.status.success(),
+        "linked binary must run:\n{}",
+        describe_output(&run)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout).trim(),
+        "total=11",
+        "expected the actor to echo the extern's exact value:\n{}",
+        describe_output(&run),
+    );
+}
+
 /// `hew run --link-lib <archive>` must thread the archive into the native link
 /// step exactly like `hew build --link-lib` does. Before the fix,
 /// `compile_temp_artifact` passed a literal `&[]` to `compile_build_binary`,

--- a/hew-cli/tests/raii1_record_resource_field_leak_oracle.rs
+++ b/hew-cli/tests/raii1_record_resource_field_leak_oracle.rs
@@ -66,7 +66,7 @@ use support::{describe_output, hew_binary, repo_root, require_codegen};
 // ── fixtures ────────────────────────────────────────────────────────────────
 
 /// Shared prelude: a `#[resource] #[opaque]` handle backed by the runtime deque
-/// (real global heap, links via `libhew_std.a` with no custom C shim) and a plain
+/// (real global heap, links via `libhew.a` with no custom C shim) and a plain
 /// record that owns one. `close(self)` frees the deque and prints `closed`.
 const PRELUDE: &str = "\
 #[resource]\n\

--- a/scripts/pre-release-validate.sh
+++ b/scripts/pre-release-validate.sh
@@ -107,6 +107,22 @@ banner() {
     echo -e "\n${CYAN}═══ $1 ═══${RESET}"
 }
 
+# Fail-closed shape check for a shipped libhew.a: it must carry verbatim
+# prebuilt libstd members (std-*.o). A fat-LTO archive folds libstd into the
+# merged codegen unit and cannot link external Rust staticlibs (--link-lib
+# packages) — reject it at packaging, never ship it. Remote validation blocks
+# inline the same `ar t | grep -q '^std-'` check (this function does not exist
+# on the remote hosts).
+check_libhew_shape() {
+    local archive="$1"
+    if ! ar t "$archive" | grep -q '^std-'; then
+        echo "FATAL: ${archive} has no verbatim libstd members (std-*.o) — built with LTO;"
+        echo "       it cannot link external Rust staticlibs. Build it with:"
+        echo "       cargo build -p hew-lib --profile release-lib"
+        return 1
+    fi
+}
+
 # ── Determine which platforms to validate ────────────────────────────────────
 
 if [[ $# -eq 0 ]]; then
@@ -166,16 +182,19 @@ validate_linux() {
     if (
         set -e
         echo "==> Step 1: Static-link release build"
-        # This is the exact build that the release CI does
+        # This is the exact build that the release CI does. libhew.a ships
+        # from the non-LTO release-lib profile (external Rust staticlibs
+        # cannot dedupe libstd against a fat-LTO archive).
         run_with_timeout "${LOCAL_BUILD_TIMEOUT}" cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release 2>&1
-        run_with_timeout "${LOCAL_BUILD_TIMEOUT}" cargo build -p hew-lib --release 2>&1
+        run_with_timeout "${LOCAL_BUILD_TIMEOUT}" cargo build -p hew-lib --profile release-lib 2>&1
 
         echo "==> Step 2: Verify binaries exist and run"
         target/release/hew --version
         target/release/adze --version
         target/release/hew-lsp --version
         target/release/hew-observe --version
-        test -f target/release/libhew.a
+        test -f target/release-lib/libhew.a
+        check_libhew_shape target/release-lib/libhew.a
 
         echo "==> Step 3: Smoke test — compile and run a Hew program"
         local smoke_file_base
@@ -222,8 +241,9 @@ validate_linux() {
 
         cp target/release/hew target/release/adze target/release/hew-lsp target/release/hew-observe "${package_root}/bin/"
         chmod +x "${package_root}/bin/"*
-        cp target/release/libhew.a "${package_root}/lib/"
-        cp target/release/libhew.a "${package_root}/lib/x86_64-unknown-linux-gnu/"
+        check_libhew_shape target/release-lib/libhew.a
+        cp target/release-lib/libhew.a "${package_root}/lib/"
+        cp target/release-lib/libhew.a "${package_root}/lib/x86_64-unknown-linux-gnu/"
         cp -r std/. "${package_root}/std/"
 
         tar czf "${package_tarball}" -C "${archive_root}" "${archive_name}"
@@ -280,12 +300,13 @@ validate_macos() {
             export LLVM_PREFIX=\"\$(brew --prefix llvm@22 2>/dev/null || echo /opt/homebrew/opt/llvm)\"
 
             cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
-            cargo build -p hew-lib --release
+            cargo build -p hew-lib --profile release-lib
 
             target/release/hew --version
             target/release/adze --version
             target/release/hew-lsp --version
             target/release/hew-observe --version
+            ar t target/release-lib/libhew.a | grep -q '^std-'
 
             echo \"==> Smoke test: hew run (guards against process-exit SIGABRT — issue #1606)\"
             make stdlib
@@ -358,7 +379,7 @@ validate_linux_aarch64() {
             export CXX=clang++-22
 
             cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
-            cargo build -p hew-lib --release
+            cargo build -p hew-lib --profile release-lib
             rustup target add wasm32-wasip1
             cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features --release
 
@@ -366,7 +387,8 @@ validate_linux_aarch64() {
             target/release/adze --version
             target/release/hew-lsp --version
             target/release/hew-observe --version
-            test -f target/release/libhew.a
+            test -f target/release-lib/libhew.a
+            ar t target/release-lib/libhew.a | grep -q '^std-'
 
             printf '%s\n' \"fn main() { println(\\\"Hello from Hew release test\\\") }\" > _smoke.hew
             target/release/hew _smoke.hew -o _smoke_bin
@@ -433,12 +455,13 @@ validate_freebsd() {
             export CXX=clang++
 
             cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
-            cargo build -p hew-lib --release
+            cargo build -p hew-lib --profile release-lib
 
             target/release/hew --version
             target/release/adze --version
             target/release/hew-lsp --version
             target/release/hew-observe --version
+            ar t target/release-lib/libhew.a | grep -q '^std-'
 
             echo \"FreeBSD build succeeded\"
         '"
@@ -505,7 +528,7 @@ if (-not (Test-Path '${WINDOWS_LLVM_CONFIG}')) {
 cargo build -p hew-cli -p adze-cli -p hew-lsp -p hew-observe --release
 Assert-NativeSuccess 'cargo build release binaries'
 
-cargo build -p hew-lib --release
+cargo build -p hew-lib --profile release-lib
 Assert-NativeSuccess 'cargo build hew-lib'
 
 & .\\target\\release\\hew.exe --version

--- a/scripts/pre-release-validate.sh
+++ b/scripts/pre-release-validate.sh
@@ -531,6 +531,19 @@ Assert-NativeSuccess 'cargo build release binaries'
 cargo build -p hew-lib --profile release-lib
 Assert-NativeSuccess 'cargo build hew-lib'
 
+if (-not (Test-Path '.\\target\\release-lib\\hew.lib')) {
+    throw 'target/release-lib/hew.lib missing after cargo build --profile release-lib'
+}
+# Fail-closed shape check: the shipped archive must carry verbatim libstd
+# members (std-*.o); a fat-LTO archive cannot link external Rust staticlibs.
+# llvm-ar comes from the LLVM_PREFIX\\bin PATH entry above (BSD ar / MSVC lib
+# do not resolve the COFF long-name table carrying the member names).
+\$StdMembers = & llvm-ar t '.\\target\\release-lib\\hew.lib' | Select-String -Pattern '^std-'
+Assert-NativeSuccess 'llvm-ar t hew.lib'
+if (-not \$StdMembers) {
+    throw 'target/release-lib/hew.lib has no verbatim libstd members (std-*.o) — built with LTO; refusing to validate'
+}
+
 & .\\target\\release\\hew.exe --version
 Assert-NativeSuccess 'hew.exe --version'
 


### PR DESCRIPTION
## Summary

`hew run --link-lib` silently dropped the flag: the archive never reached the temp-artifact link, so FFI programs that worked under `hew build` failed with undefined symbols under `hew run`. The flag is now threaded through to the temp-artifact link for `hew run` and `hew debug`, and wasm/WASI targets now loudly reject `--link-lib` with exit 2 instead of silently ignoring it — native archives can't be linked into a wasm module.

The native link line also carried both `libhew.a` and a redundant `libhew_std.a` with identical export sets, so the moment an FFI archive pulled in runtime members the link died with duplicate symbols. The link line now carries exactly one runtime archive.

The shipped `libhew.a` itself was built with the fat-LTO release profile, which strips the verbatim libstd members that prebuilt Rust staticlib packages need to link cleanly. I added a non-LTO `release-lib` profile for the shipped archive and guarded every packaging path with a fail-closed archive-shape check (`ar t | grep '^std-'`) — including the Windows leg, which uses `llvm-ar` because BSD ar and MSVC lib don't resolve the COFF long-name table. When duplicate Rust-internal symbols do surface at link time, the linker diagnostic now names the likely cause: an FFI archive built with a mismatched rustc version.

## Verification

- `cargo nextest run -p hew-cli --test ffi_link_e2e`: 10/10 pass — red/green coverage for the dropped `hew run` flag, the loud wasm/WASI rejection, and the single-runtime-archive link line (proven via an argv shim with a stray `libhew_std.a` on disk).
- Archive shape check red/green: a fat-LTO `libhew.a` has zero `^std-` members and is rejected by `make assemble-release`, `make install`, and the packaging workflows; the `release-lib` archive (one verbatim `std-*` member) passes.
- Windows check mechanics proven on real MSVC archives (`rustc --target x86_64-pc-windows-msvc --crate-type staticlib`): the non-LTO archive is accepted, a `-C lto=fat` archive is rejected.
- Live end-to-end: an MQTT client program linked against an unmodified prebuilt FFI package archive completes a subscribe/publish round-trip against a local broker via both `hew build --link-lib` and `hew run --link-lib`, with a single runtime archive on the link line.
- `make test-lane CRATE=hew-cli`: 379/379 pass (re-run after rebasing onto current main).
- `make lint` (includes `cargo clippy --workspace --tests -- -D warnings` and FFI symbol classification): pass.
- `bash tests/vertical-slice/run.sh`: full pass.
- Preflight: ready-to-push.

## Out of scope

- Runtime-performance comparison of the non-LTO `release-lib` archive against the fat-LTO build — follow-up measurement. Only the shipped staticlib profile changed; the shipped binaries still build with the fat-LTO release profile.
- CI test lanes that build `hew-lib --release` for test execution are untouched: they never ship the archive, and the candidate ordering plus the packaging shape checks cover the actual shipping paths.
- The wasm link line is untouched — wasm targets keep their own archive set.
- #2402 (actor init argument width) is unchanged; the MQTT example keeps its existing workaround.

Fixes #2403