### PR TITLE
fix(mir): drop owned locals on coroutine destroy and f-string temps

### DIFF
--- a/examples/v05/checked-mir/golden/await_ask_deadline.elab.mir
+++ b/examples/v05/checked-mir/golden/await_ask_deadline.elab.mir
@@ -16,7 +16,7 @@ fn Caller__recv__go -> i64
     drop BindingId(0) f ty=LocalPid<Fast>
   drop_plans:
     suspend[bb0 resume=bb1 cleanup=bb1] ->
-      (none)
+      drop actor0 ty=LocalPid<Fast> kind=resource
     cancel[bb0] ->
       (none)
     branch[bb1: bb3/bb6] ->

--- a/examples/v05/checked-mir/golden/hashmap_ops.raw.mir
+++ b/examples/v05/checked-mir/golden/hashmap_ops.raw.mir
@@ -121,27 +121,33 @@ fn main() -> () [conv=default]
   bb14:
     _24 = call string_concat(_22, _23) -> bb15
   bb15:
+    drop _23 ty=string fn=release(hew_string_drop)
     _25 = string_lit " removed="
     _26 = call string_concat(_24, _25) -> bb16
   bb16:
     stmt: use BindingId(3) removed site=SiteId(33) ty=bool intent=Read
+    drop _24 ty=string fn=release(hew_string_drop)
     _27 = call to_string_bool(_21) -> bb17
   bb17:
     _28 = call string_concat(_26, _27) -> bb18
   bb18:
+    drop _27 ty=string fn=release(hew_string_drop)
     _29 = string_lit " len="
     _30 = call string_concat(_28, _29) -> bb19
   bb19:
     stmt: use BindingId(0) m site=SiteId(38) ty=HashMap<string, i64> intent=Read
+    drop _28 ty=string fn=release(hew_string_drop)
     _31 = call hew_hashmap_len_layout(_1) [builtin=HashMapLenLayout] -> bb20
   bb20:
     _32 = call to_string_i64(_31) -> bb21
   bb21:
     _33 = call string_concat(_30, _32) -> bb22
   bb22:
+    drop _32 ty=string fn=release(hew_string_drop)
     call println_str(_33) -> bb23
   bb23:
     stmt: eval site=SiteId(26) ty=()
+    drop _33 ty=string fn=release(hew_string_drop)
     _34 = call HashMap::new() [builtin=HashMapNew] -> bb24
   bb24:
     stmt: bind BindingId(4) flags site=SiteId(52) ty=HashMap<string, bool>

--- a/examples/v05/checked-mir/golden/hashset_ops.raw.mir
+++ b/examples/v05/checked-mir/golden/hashset_ops.raw.mir
@@ -89,26 +89,32 @@ fn main() -> () [conv=default]
   bb8:
     _18 = call string_concat(_16, _17) -> bb9
   bb9:
+    drop _17 ty=string fn=release(hew_string_drop)
     _19 = string_lit " has1="
     _20 = call string_concat(_18, _19) -> bb10
   bb10:
     stmt: use BindingId(2) has1 site=SiteId(26) ty=bool intent=Read
+    drop _18 ty=string fn=release(hew_string_drop)
     _21 = call to_string_bool(_12) -> bb11
   bb11:
     _22 = call string_concat(_20, _21) -> bb12
   bb12:
+    drop _21 ty=string fn=release(hew_string_drop)
     _23 = string_lit " removed="
     _24 = call string_concat(_22, _23) -> bb13
   bb13:
     stmt: use BindingId(3) removed site=SiteId(30) ty=bool intent=Read
+    drop _22 ty=string fn=release(hew_string_drop)
     _25 = call to_string_bool(_15) -> bb14
   bb14:
     _26 = call string_concat(_24, _25) -> bb15
   bb15:
+    drop _25 ty=string fn=release(hew_string_drop)
     call println_str(_26) -> bb16
   bb16:
     stmt: eval site=SiteId(19) ty=()
     stmt: use BindingId(0) s site=SiteId(45) ty=HashSet<i64> intent=Read
+    drop _26 ty=string fn=release(hew_string_drop)
     _27 = call hew_hashset_is_empty_layout(_1) [builtin=HashSetIsEmptyLayout] -> bb17
   bb17:
     stmt: bind BindingId(4) empty site=SiteId(44) ty=bool
@@ -145,17 +151,21 @@ fn main() -> () [conv=default]
   bb24:
     _41 = call string_concat(_38, _40) -> bb25
   bb25:
+    drop _40 ty=string fn=release(hew_string_drop)
     _42 = string_lit " hasc="
     _43 = call string_concat(_41, _42) -> bb26
   bb26:
     stmt: use BindingId(6) hasc site=SiteId(68) ty=bool intent=Read
+    drop _41 ty=string fn=release(hew_string_drop)
     _44 = call to_string_bool(_37) -> bb27
   bb27:
     _45 = call string_concat(_43, _44) -> bb28
   bb28:
+    drop _44 ty=string fn=release(hew_string_drop)
     call println_str(_45) -> bb29
   bb29:
     stmt: eval site=SiteId(60) ty=()
+    drop _45 ty=string fn=release(hew_string_drop)
     return
 
 fn i8::fmt(i8) -> string [conv=default]

--- a/examples/v05/checked-mir/golden/match_skip_leaf_field_drops.raw.mir
+++ b/examples/v05/checked-mir/golden/match_skip_leaf_field_drops.raw.mir
@@ -106,6 +106,7 @@ fn skip_vec_record(i64) -> i64 [conv=default]
     stmt: agg_alias BindingId(9) v site=SiteId(30) ty=Vec<string>
     stmt: bind BindingId(10) t site=SiteId(28) ty=TaggedVec
     stmt: use BindingId(10) t site=SiteId(32) ty=TaggedVec intent=Read
+    drop _5 ty=string fn=release(hew_string_drop)
     _6 = record_init TaggedVec { .0=_0, .1=_2 }
     _7 = move _6
     goto bb5

--- a/examples/v05/checked-mir/golden/metric_register_record.raw.mir
+++ b/examples/v05/checked-mir/golden/metric_register_record.raw.mir
@@ -192,6 +192,7 @@ fn metrics$counter(string) -> Counter [conv=default]
     _10 = string_lit "`"
     _11 = call string_concat(_9, _10) -> bb6
   bb6:
+    drop _9 ty=string fn=release(hew_string_drop)
     call panic(_11) -> bb7
   bb7:
     stmt: eval site=SiteId(80) ty=!
@@ -295,6 +296,7 @@ fn metrics$gauge(string) -> Gauge [conv=default]
     _10 = string_lit "`"
     _11 = call string_concat(_9, _10) -> bb6
   bb6:
+    drop _9 ty=string fn=release(hew_string_drop)
     call panic(_11) -> bb7
   bb7:
     stmt: eval site=SiteId(119) ty=!
@@ -398,6 +400,7 @@ fn metrics$histogram(string) -> Histogram [conv=default]
     _10 = string_lit "`"
     _11 = call string_concat(_9, _10) -> bb6
   bb6:
+    drop _9 ty=string fn=release(hew_string_drop)
     call panic(_11) -> bb7
   bb7:
     stmt: eval site=SiteId(158) ty=!

--- a/examples/v05/checked-mir/golden/option_result_unwrap.raw.mir
+++ b/examples/v05/checked-mir/golden/option_result_unwrap.raw.mir
@@ -576,15 +576,18 @@ fn main() -> i64 [conv=default]
     _160 = call string_concat(_158, _159) -> bb80
   bb80:
     stmt: use BindingId(28) err site=SiteId(108) ty=bool intent=Read
+    drop _158 ty=string fn=release(hew_string_drop)
     _161 = call to_string_bool(_157) -> bb81
   bb81:
     _162 = call string_concat(_160, _161) -> bb82
   bb82:
+    drop _161 ty=string fn=release(hew_string_drop)
     call println_str(_162) -> bb83
   bb83:
     stmt: eval site=SiteId(102) ty=()
     stmt: use BindingId(6) cv site=SiteId(120) ty=i32 intent=Read
     stmt: use BindingId(13) gv site=SiteId(122) ty=i32 intent=Read
+    drop _162 ty=string fn=release(hew_string_drop)
     _163 = cast _36 i32 -> i64
     _164 = cast _73 i32 -> i64
     _165 ovf=_166 = add.checked.s _163 _164

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
@@ -385,49 +385,61 @@ fn fs$io_error_message(IoError) -> string [conv=default]
   bb14:
     _18 = call string_concat(_16, _17) -> bb15
   bb15:
+    drop _17 ty=string fn=release(hew_string_drop)
     _19 = string_lit ")"
     _20 = call string_concat(_18, _19) -> bb16
   bb16:
+    drop _18 ty=string fn=release(hew_string_drop)
     _1 = move _20
     goto bb1
   bb17:
     _24 = call string_concat(_22, _23) -> bb18
   bb18:
+    drop _23 ty=string fn=release(hew_string_drop)
     _25 = string_lit ")"
     _26 = call string_concat(_24, _25) -> bb19
   bb19:
+    drop _24 ty=string fn=release(hew_string_drop)
     _1 = move _26
     goto bb1
   bb20:
     _30 = call string_concat(_28, _29) -> bb21
   bb21:
+    drop _29 ty=string fn=release(hew_string_drop)
     _31 = string_lit ")"
     _32 = call string_concat(_30, _31) -> bb22
   bb22:
+    drop _30 ty=string fn=release(hew_string_drop)
     _1 = move _32
     goto bb1
   bb23:
     _36 = call string_concat(_34, _35) -> bb24
   bb24:
+    drop _35 ty=string fn=release(hew_string_drop)
     _37 = string_lit ")"
     _38 = call string_concat(_36, _37) -> bb25
   bb25:
+    drop _36 ty=string fn=release(hew_string_drop)
     _1 = move _38
     goto bb1
   bb26:
     _42 = call string_concat(_40, _41) -> bb27
   bb27:
+    drop _41 ty=string fn=release(hew_string_drop)
     _43 = string_lit ")"
     _44 = call string_concat(_42, _43) -> bb28
   bb28:
+    drop _42 ty=string fn=release(hew_string_drop)
     _1 = move _44
     goto bb1
   bb29:
     _48 = call string_concat(_46, _47) -> bb30
   bb30:
+    drop _47 ty=string fn=release(hew_string_drop)
     _49 = string_lit ")"
     _50 = call string_concat(_48, _49) -> bb31
   bb31:
+    drop _48 ty=string fn=release(hew_string_drop)
     _1 = move _50
     goto bb1
 
@@ -1069,6 +1081,7 @@ fn fs$read(string) -> string [conv=default]
     _18 = call string_concat(_16, _17) -> bb13
   bb13:
     stmt: use BindingId(33) errno site=SiteId(344) ty=i32 intent=Read
+    drop _16 ty=string fn=release(hew_string_drop)
     _19 = cast _4 i32 -> i64
     _20 = call fs$io_error_from_errno(_19) -> bb14
   bb14:
@@ -1089,6 +1102,7 @@ fn fs$read(string) -> string [conv=default]
     _28 = call string_concat(_26, _27) -> bb21
   bb21:
     stmt: use BindingId(34) detail site=SiteId(364) ty=string intent=Read
+    drop _26 ty=string fn=release(hew_string_drop)
     _29 = call string::fmt(_9) -> bb22
   bb22:
     _30 = call string_concat(_28, _29) -> bb23

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -84,8 +84,10 @@ fn Echo__recv__run(i64) -> () [conv=actor_handler]
   bb8:
     _19 = call string_concat(_17, _18) -> bb9
   bb9:
+    drop _18 ty=string fn=release(hew_string_drop)
     _20 = call hew_string_to_bytes(_19) -> bb10
   bb10:
+    drop _19 ty=string fn=release(hew_string_drop)
     suspend [stream_send] is_final=false -> resume=bb11 cleanup=bb11
   bb11:
     stmt: eval site=SiteId(11) ty=()
@@ -444,49 +446,61 @@ fn fs$io_error_message(IoError) -> string [conv=default]
   bb14:
     _18 = call string_concat(_16, _17) -> bb15
   bb15:
+    drop _17 ty=string fn=release(hew_string_drop)
     _19 = string_lit ")"
     _20 = call string_concat(_18, _19) -> bb16
   bb16:
+    drop _18 ty=string fn=release(hew_string_drop)
     _1 = move _20
     goto bb1
   bb17:
     _24 = call string_concat(_22, _23) -> bb18
   bb18:
+    drop _23 ty=string fn=release(hew_string_drop)
     _25 = string_lit ")"
     _26 = call string_concat(_24, _25) -> bb19
   bb19:
+    drop _24 ty=string fn=release(hew_string_drop)
     _1 = move _26
     goto bb1
   bb20:
     _30 = call string_concat(_28, _29) -> bb21
   bb21:
+    drop _29 ty=string fn=release(hew_string_drop)
     _31 = string_lit ")"
     _32 = call string_concat(_30, _31) -> bb22
   bb22:
+    drop _30 ty=string fn=release(hew_string_drop)
     _1 = move _32
     goto bb1
   bb23:
     _36 = call string_concat(_34, _35) -> bb24
   bb24:
+    drop _35 ty=string fn=release(hew_string_drop)
     _37 = string_lit ")"
     _38 = call string_concat(_36, _37) -> bb25
   bb25:
+    drop _36 ty=string fn=release(hew_string_drop)
     _1 = move _38
     goto bb1
   bb26:
     _42 = call string_concat(_40, _41) -> bb27
   bb27:
+    drop _41 ty=string fn=release(hew_string_drop)
     _43 = string_lit ")"
     _44 = call string_concat(_42, _43) -> bb28
   bb28:
+    drop _42 ty=string fn=release(hew_string_drop)
     _1 = move _44
     goto bb1
   bb29:
     _48 = call string_concat(_46, _47) -> bb30
   bb30:
+    drop _47 ty=string fn=release(hew_string_drop)
     _49 = string_lit ")"
     _50 = call string_concat(_48, _49) -> bb31
   bb31:
+    drop _48 ty=string fn=release(hew_string_drop)
     _1 = move _50
     goto bb1
 
@@ -1128,6 +1142,7 @@ fn fs$read(string) -> string [conv=default]
     _18 = call string_concat(_16, _17) -> bb13
   bb13:
     stmt: use BindingId(38) errno site=SiteId(363) ty=i32 intent=Read
+    drop _16 ty=string fn=release(hew_string_drop)
     _19 = cast _4 i32 -> i64
     _20 = call fs$io_error_from_errno(_19) -> bb14
   bb14:
@@ -1148,6 +1163,7 @@ fn fs$read(string) -> string [conv=default]
     _28 = call string_concat(_26, _27) -> bb21
   bb21:
     stmt: use BindingId(39) detail site=SiteId(383) ty=string intent=Read
+    drop _26 ty=string fn=release(hew_string_drop)
     _29 = call string::fmt(_9) -> bb22
   bb22:
     _30 = call string_concat(_28, _29) -> bb23

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
@@ -333,49 +333,61 @@ fn fs$io_error_message(IoError) -> string [conv=default]
   bb14:
     _18 = call string_concat(_16, _17) -> bb15
   bb15:
+    drop _17 ty=string fn=release(hew_string_drop)
     _19 = string_lit ")"
     _20 = call string_concat(_18, _19) -> bb16
   bb16:
+    drop _18 ty=string fn=release(hew_string_drop)
     _1 = move _20
     goto bb1
   bb17:
     _24 = call string_concat(_22, _23) -> bb18
   bb18:
+    drop _23 ty=string fn=release(hew_string_drop)
     _25 = string_lit ")"
     _26 = call string_concat(_24, _25) -> bb19
   bb19:
+    drop _24 ty=string fn=release(hew_string_drop)
     _1 = move _26
     goto bb1
   bb20:
     _30 = call string_concat(_28, _29) -> bb21
   bb21:
+    drop _29 ty=string fn=release(hew_string_drop)
     _31 = string_lit ")"
     _32 = call string_concat(_30, _31) -> bb22
   bb22:
+    drop _30 ty=string fn=release(hew_string_drop)
     _1 = move _32
     goto bb1
   bb23:
     _36 = call string_concat(_34, _35) -> bb24
   bb24:
+    drop _35 ty=string fn=release(hew_string_drop)
     _37 = string_lit ")"
     _38 = call string_concat(_36, _37) -> bb25
   bb25:
+    drop _36 ty=string fn=release(hew_string_drop)
     _1 = move _38
     goto bb1
   bb26:
     _42 = call string_concat(_40, _41) -> bb27
   bb27:
+    drop _41 ty=string fn=release(hew_string_drop)
     _43 = string_lit ")"
     _44 = call string_concat(_42, _43) -> bb28
   bb28:
+    drop _42 ty=string fn=release(hew_string_drop)
     _1 = move _44
     goto bb1
   bb29:
     _48 = call string_concat(_46, _47) -> bb30
   bb30:
+    drop _47 ty=string fn=release(hew_string_drop)
     _49 = string_lit ")"
     _50 = call string_concat(_48, _49) -> bb31
   bb31:
+    drop _48 ty=string fn=release(hew_string_drop)
     _1 = move _50
     goto bb1
 
@@ -1017,6 +1029,7 @@ fn fs$read(string) -> string [conv=default]
     _18 = call string_concat(_16, _17) -> bb13
   bb13:
     stmt: use BindingId(33) errno site=SiteId(331) ty=i32 intent=Read
+    drop _16 ty=string fn=release(hew_string_drop)
     _19 = cast _4 i32 -> i64
     _20 = call fs$io_error_from_errno(_19) -> bb14
   bb14:
@@ -1037,6 +1050,7 @@ fn fs$read(string) -> string [conv=default]
     _28 = call string_concat(_26, _27) -> bb21
   bb21:
     stmt: use BindingId(34) detail site=SiteId(351) ty=string intent=Read
+    drop _26 ty=string fn=release(hew_string_drop)
     _29 = call string::fmt(_9) -> bb22
   bb22:
     _30 = call string_concat(_28, _29) -> bb23

--- a/hew-cli/tests/fstring_interp_temp_leak_oracle.rs
+++ b/hew-cli/tests/fstring_interp_temp_leak_oracle.rs
@@ -1,0 +1,197 @@
+//! Per-iteration leak / double-free oracle for f-string interpolation of a
+//! non-string value: the `Display::fmt` conversion temp (`hew_i64_to_string`)
+//! and — outside a moved/yielded position — the `hew_string_concat` join
+//! result must each be released exactly once per interpolation.
+//!
+//! ## What this proves
+//!
+//! `f"item-{i}"` desugars (`hew-hir/src/lower.rs::lower_interpolated_string`)
+//! to a chain of `stdlib_catalog` presentation-name calls: `to_string_i64(i)`
+//! producing a fresh conversion temp, then `string_concat(lit, temp)` joining
+//! it with the literal segment. Both calls reach MIR as
+//! `Terminator::Call { callee: <catalog name>, .. }`, and the catalog name
+//! `string_concat` (unlike its `hew_string_concat` c-symbol sibling, and
+//! unlike the already-covered `to_string_i64`/`println_str` catalog names)
+//! had no `callee_ownership_contract` row — it fell through to
+//! `CalleeOwnershipContract::FAIL_CLOSED`, so
+//! `collect_nested_fresh_string_temp_drops`
+//! (`hew-mir/src/lower.rs`, W5.011 P3) could never admit either the concat's
+//! own fresh-owned result OR the conversion temp feeding it as a borrowed
+//! argument. Fixed by dual-listing `"string_concat"` alongside
+//! `"hew_string_concat"` in `hew-mir/src/runtime_symbols.rs`'s
+//! `callee_ownership_contract` — the runtime behaviour is byte-identical (the
+//! catalog entry is a `BuiltinLinkage::RuntimeFfiShim` over the same symbol),
+//! so the contract must be too.
+//!
+//! A SEPARATE, second gap affected only generator bodies: `gen fn`/`gen {}`
+//! coroutine ramps are lowered via `lower_gen_block`'s own hand-rolled
+//! `RawMirFunction` construction, which never called
+//! `apply_nested_fresh_string_temp_drops` at all (every ordinary function
+//! gets it via `lower_function`'s shared post-`finalize_blocks` pipeline).
+//! Fixed by adding the identical call at the analogous point in
+//! `lower_gen_block`.
+//!
+//! ## Failure modes this oracle catches
+//!
+//!   * a LEAK (the conversion temp or the concat result is never released) —
+//!     a positive per-iteration leak slope;
+//!   * a SECOND owner (the concat result double-freed by both the inline temp
+//!     drop and its downstream consumer) — a double-free that aborts under
+//!     the poisoned-allocator triple;
+//!   * an OVER-DROP corrupting a live value — a scribbled output / non-zero
+//!     exit.
+//!
+//! ## Methodology: per-iteration leak slope
+//!
+//! Each shape loops `frames` times, interpolating the loop counter into an
+//! f-string every iteration. Compiled at a LOW and a HIGH iteration count and
+//! the leak NODE counts are differenced (see [`support::leak_slope`]): a
+//! correct release holds the slope flat; a leaked temp grows the node count
+//! with the iteration count.
+//!
+//! ## Two shapes
+//!
+//!   * **statement position** (`fstring_scalar_interp_loop_source`) — a plain
+//!     `while` loop `println`-ing `f"item-{i}"`; both the conversion temp AND
+//!     the concat result are unbound nested temps (red: 2 leaked nodes/iter
+//!     on main pre-fix).
+//!   * **gen-body** (`fstring_gen_yield_interp_loop_source`) — a standalone
+//!     `gen fn` yielding `f"item-{i}"` per iteration; the concat result is
+//!     consumed by the yield-transport (already correctly handled elsewhere),
+//!     so only the conversion temp is at risk (red: 1 leaked node/iter
+//!     pre-fix, reproduces with zero receive-gen/actor surface).
+//!
+//! ## Skip behaviour
+//!
+//! `leaks(1)` is Darwin's allocator inspector; on non-macOS hosts the slope
+//! probes log `skip:` and return. The `MallocScribble` no-double-free pins run
+//! on any unix host.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+// -- fixtures ----------------------------------------------------------------
+
+/// Statement position: `println(f"item-{i}")` in a `while` loop. Both the
+/// `hew_i64_to_string` conversion temp and the `hew_string_concat` join
+/// result are unbound nested temps fed straight into `println`, never a
+/// `let` binding — exactly the shape `collect_nested_fresh_string_temp_drops`
+/// must admit without a scope-exit binding to anchor on. `total` sums the
+/// loop counter so the calls cannot be eliminated and `main` self-checks it.
+fn fstring_scalar_interp_loop_source(frames: usize) -> String {
+    let expected_total: usize = (0..frames).sum();
+    format!(
+        "fn main() -> i64 {{\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       println(f\"item-{{i}}\");\n\
+         \x20       total = total + i;\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total != {expected_total} {{ return 95; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+/// Gen-body: a standalone `gen fn` yields `f"item-{i}"` per iteration. The
+/// concat result is published through the yield-transport (a MOVE, correctly
+/// excluded from this mechanism's admission), but the `hew_i64_to_string`
+/// conversion temp feeding the concat is still an unbound nested temp INSIDE
+/// the coroutine ramp — the second (pipeline-wiring) gap this oracle covers.
+/// No receive-gen or actor surface is involved.
+fn fstring_gen_yield_interp_loop_source(frames: usize) -> String {
+    let expected_total: usize = (0..frames).sum();
+    format!(
+        "gen fn items(n: i64) -> string {{\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < n {{\n\
+         \x20       yield f\"item-{{i}}\";\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var idx: i64 = 0;\n\
+         \x20   for v in items({frames}) {{\n\
+         \x20       println(v);\n\
+         \x20       total = total + idx;\n\
+         \x20       idx = idx + 1;\n\
+         \x20   }}\n\
+         \x20   if total != {expected_total} {{ return 96; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+// -- correctness pins --------------------------------------------------------
+
+/// Run `source` to native, execute under the poisoned-allocator triple, and
+/// assert clean exit. A crash here is a double-free (the conversion temp or
+/// the concat result released twice); a non-zero exit is a scribbled-read
+/// miscompute or the fixture's own total check failing.
+fn assert_no_double_free(shape_name: &str, source: &str) {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("fstring-interp-temp-df-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), shape_name);
+    let output = run_under_malloc_scribble(&bin);
+
+    assert!(
+        output.status.success(),
+        "{shape_name}: f-string interpolation temps must be released exactly once -- a crash \
+         here indicates a double-free of the conversion temp or the concat result; a non-zero \
+         exit is a scribbled-read miscompute or the fixture's own total check;\n{}",
+        describe_output(&output)
+    );
+}
+
+// -- oracles -----------------------------------------------------------------
+
+/// Slope oracle (statement position): `println(f"item-{i}")` releases both
+/// nested temps every iteration — flat leak slope. Pre-fix this leaked 2
+/// nodes/iteration (`hew_i64_to_string` + `hew_string_concat`).
+#[test]
+fn fstring_scalar_interp_statement_position_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("fstring_scalar_stmt", fstring_scalar_interp_loop_source);
+}
+
+/// Slope oracle (gen-body): a standalone `gen fn` yielding `f"item-{i}"`
+/// releases the conversion temp every iteration — flat leak slope. Pre-fix
+/// this leaked 1 node/iteration, reproducing with zero receive-gen/actor
+/// surface (string-yield plan E4 control).
+#[test]
+fn fstring_scalar_interp_gen_yield_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("fstring_scalar_gen", fstring_gen_yield_interp_loop_source);
+}
+
+/// No-double-free pin (statement position): both nested temps release
+/// EXACTLY once across 200 iterations. A second owner aborts under the
+/// poisoned allocator. Runs on any unix host.
+#[test]
+fn fstring_scalar_interp_statement_position_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free(
+        "fstring_scalar_stmt_df",
+        &fstring_scalar_interp_loop_source(200),
+    );
+}
+
+/// No-double-free pin (gen-body): the conversion temp releases EXACTLY once
+/// per yield across 200 iterations. Runs on any unix host.
+#[test]
+fn fstring_scalar_interp_gen_yield_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free(
+        "fstring_scalar_gen_df",
+        &fstring_gen_yield_interp_loop_source(200),
+    );
+}

--- a/hew-cli/tests/parked_destroy_owned_local_leak_oracle.rs
+++ b/hew-cli/tests/parked_destroy_owned_local_leak_oracle.rs
@@ -1,0 +1,161 @@
+//! Destroy-while-parked owned-local leak / double-free oracle (#2395).
+//!
+//! ## What this proves
+//!
+//! A coroutine (actor handler / receive-gen pump / generator body) parked at a
+//! suspend point and then DESTROYED without resuming — a supervisor stopping a
+//! parked child, teardown — must drop the Hew heap values owned by its live
+//! locals on the destroy (abandon) edge, before its frame is freed. Before the
+//! fix the frame was freed but its owned locals leaked (2 leaks / 176 B on the
+//! plain-actor `Vec` shape); the fix emits the suspend exit's elaborated drop
+//! plan on the `coro.suspend` case-1 edge.
+//!
+//! The failure modes this oracle catches:
+//!   * a LEAK — the owned local is not dropped on the abandon edge (a non-zero
+//!     leak count on the deterministic single-shot shape);
+//!   * a DOUBLE-FREE — a value MOVED OUT across the suspend is wrongly dropped on
+//!     the abandon edge as well as by its new owner, which the poisoned allocator
+//!     turns into an abort (the moved-out wall).
+//!
+//! ## Methodology
+//!
+//! These shapes are deterministic single-shot teardowns (not per-iteration
+//! slopes): the handler holds one owned value live across a `sleep`, `main`
+//! lets it park, then `supervisor_stop` destroys it while parked. The correct
+//! program leaks exactly zero nodes, so an exact-zero `leaks --atExit` assertion
+//! is trustworthy (there is no per-iteration baseline noise to cancel). The
+//! moved-out wall is pinned under the poisoned-allocator triple: a double-free of
+//! the single shared buffer aborts.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    compile_to_native, leaks_supported, measure_leaks, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+/// A plain actor holds an owned `Vec<i64>` live across `sleep(10s)`; the
+/// supervisor stops it while parked, destroying the coroutine without resuming.
+/// The `Vec`'s heap buffer must be freed on the abandon edge — 0 leaks.
+const PARKED_VEC_TEARDOWN: &str = r#"
+actor Sleeper {
+    receive fn work() {
+        let xs: Vec<i64> = Vec::new();
+        xs.push(1);
+        xs.push(2);
+        xs.push(3);
+        sleep(10s);
+        println(f"{xs.len()}");
+    }
+}
+
+supervisor App {
+    strategy: one_for_one;
+    intensity: 3 within 60s;
+
+    child sleeper: Sleeper;
+}
+
+fn main() {
+    let sup = spawn App;
+    let s = sup.sleeper;
+    s.work();
+    sleep(200ms);
+    supervisor_stop(sup);
+}
+"#;
+
+/// Wall: a local MOVED OUT across the suspend must NOT be dropped on the abandon
+/// edge. `let ys = xs;` moves the `Vec` handle (xs and ys share ONE buffer); at
+/// the park xs is Consumed and ys is Live, so only ys is dropped on destroy.
+/// Dropping both would free the shared buffer twice.
+const MOVED_OUT_ACROSS_SUSPEND: &str = r#"
+actor Mover {
+    receive fn go() {
+        let xs: Vec<i64> = Vec::new();
+        xs.push(1);
+        xs.push(2);
+        xs.push(3);
+        let ys = xs;
+        sleep(10s);
+        println(f"{ys.len()}");
+    }
+}
+
+supervisor App {
+    strategy: one_for_one;
+    intensity: 3 within 60s;
+
+    child mover: Mover;
+}
+
+fn main() {
+    let sup = spawn App;
+    let m = sup.mover;
+    m.go();
+    sleep(200ms);
+    supervisor_stop(sup);
+}
+"#;
+
+/// The #2395 regression pin: an owned local live across a suspend, destroyed
+/// while parked, leaks zero nodes. Skips gracefully when `leaks(1)` is
+/// unavailable (non-macOS or `leaks` off PATH).
+#[test]
+fn parked_destroy_frees_owned_local_zero_leaks() {
+    let shape = "parked_vec_teardown";
+    if !leaks_supported(shape) {
+        return;
+    }
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("parked-destroy-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(PARKED_VEC_TEARDOWN, dir.path(), shape);
+    let Some(leaks) = measure_leaks(&bin) else {
+        return;
+    };
+    assert_eq!(
+        leaks,
+        0,
+        "destroy-while-parked leaked {leaks} node(s): the owned Vec live across \
+         the sleep was not dropped on the coroutine abandon edge (#2395). Re-run \
+         with `MallocStackLogging=1 leaks --atExit -- {}` for the leaked stack.",
+        bin.display()
+    );
+}
+
+/// The moved-out wall: a value moved across the suspend must not be double-freed
+/// on the abandon edge. Runs under the poisoned-allocator triple on any unix; a
+/// double-free of the shared buffer aborts. Also asserts zero leaks on macOS.
+#[test]
+fn moved_out_across_suspend_no_double_free() {
+    let shape = "moved_out_across_suspend";
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("moved-out-suspend-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(MOVED_OUT_ACROSS_SUSPEND, dir.path(), shape);
+
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "moved-out-across-suspend aborted under the poisoned allocator — a value \
+         moved out before the park was double-freed on the abandon edge:\n{}",
+        describe_output(&output)
+    );
+
+    if leaks_supported(shape) {
+        if let Some(leaks) = measure_leaks(&bin) {
+            assert_eq!(
+                leaks, 0,
+                "moved-out-across-suspend leaked {leaks} node(s): the surviving \
+                 owner (ys) was not freed on the abandon edge.",
+            );
+        }
+    }
+}

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -1665,6 +1665,23 @@ pub(crate) struct FnCtx<'a, 'ctx> {
     /// runtime ABI param slots), and returns `i32 0`. `None` for every
     /// other call convention.
     pub(crate) lambda_actor_shape: Option<hew_mir::LambdaActorShape>,
+    /// The elaborated drop plans for this function, keyed by exit block via
+    /// `ExitPath`. Carried on `FnCtx` so `emit_suspend_point` (the single
+    /// suspend-ramp helper shared by all 13 collapsed-suspension emitters) can
+    /// emit the abandon-edge drop plan for the parked coroutine's destroy edge
+    /// (#2395) without threading the slice through every emitter signature. The
+    /// borrow is the same per-function `elaborated_mir.drop_plans` slice the
+    /// block loop consults; `&[]` for hand-built test pipelines.
+    pub(crate) drop_plans: &'a [(ExitPath, hew_mir::DropPlan)],
+    /// The MIR block id of the suspend terminator currently being lowered.
+    /// `lower_terminator` sets this before dispatching, so `emit_suspend_point`
+    /// (reached deep inside a per-kind emitter, without the block id in scope)
+    /// can look up THIS suspend's abandon-edge drop plan (#2395). Interior
+    /// mutability mirrors the `RefCell<runtime_decls>` pattern; it is written
+    /// then read synchronously within one `lower_terminator` call, never across
+    /// a re-entrant one, so a plain `Cell` is sufficient. Initial `0` is
+    /// overwritten before any suspend emitter runs.
+    pub(crate) suspend_abandon_block: std::cell::Cell<u32>,
 }
 
 /// Module-level symbol table populated by the declaration pass. Keyed by
@@ -26376,7 +26393,7 @@ fn emit_borrow_gated_string_clone<'ctx>(
 /// Called immediately before `lower_terminator` for every block so
 /// every exit path receives its drops regardless of CFG shape.
 /// LESSONS: cleanup-all-exits (P0), lifecycle-symmetry (P0).
-fn emit_elab_drops(
+pub(crate) fn emit_elab_drops(
     fn_ctx: &FnCtx<'_, '_>,
     block_id: u32,
     drop_plans: &[(ExitPath, hew_mir::DropPlan)],
@@ -30891,6 +30908,21 @@ fn dispatch_collapsed_suspend<'ctx>(
     }
 }
 
+/// A terminator that parks the coroutine on an `llvm.coro.suspend`: its
+/// frame-owned local drops belong on the case-1 (destroy-while-parked) abandon
+/// edge, NOT in the normal block flow (they would drop values before the park).
+/// The block loop suppresses its normal-flow `emit_elab_drops` for these; the
+/// abandon-edge emission is in `emit_suspend_point` / the `Yield` arm (#2395).
+fn terminator_is_suspend_carrier(term: &Terminator) -> bool {
+    matches!(
+        term,
+        Terminator::Suspend { .. }
+            | Terminator::SuspendingScopeDeadline { .. }
+            | Terminator::SuspendingSelect { .. }
+            | Terminator::Yield { .. }
+    )
+}
+
 fn lower_terminator<'ctx>(
     fn_ctx: &FnCtx<'_, 'ctx>,
     fn_symbols: &FnSymbolMap<'ctx>,
@@ -30899,6 +30931,13 @@ fn lower_terminator<'ctx>(
     await_deadlines: &std::collections::HashMap<u32, i64>,
     suspend_kinds: &std::collections::HashMap<u32, SuspendKind>,
 ) -> CodegenResult<()> {
+    // Record the block whose suspend terminator is being lowered so the
+    // per-kind emitters' shared `emit_suspend_point` helper can look up THIS
+    // suspend's abandon-edge drop plan (#2395) without the block id threaded
+    // through all 13 emitter signatures. Harmless for non-suspend terminators
+    // (only suspend carriers reach `emit_suspend_point`); written then read
+    // synchronously within this call.
+    fn_ctx.suspend_abandon_block.set(block_id);
     match term {
         Terminator::Return => {
             // Implicit actor-drain floor: emit `hew_shutdown_initiate(0)` then
@@ -31872,32 +31911,49 @@ fn lower_terminator<'ctx>(
                 .build_store(out_ptr, yielded)
                 .llvm_ctx("gen yield value publish")?;
             // Suspend (non-final). The resume edge is the MIR `next` block; the
-            // destroy edge routes to the shared single-teardown cleanup epilogue.
+            // destroy edge routes through an interposed abandon block (#2395)
+            // that drops the frame-owned locals live across this yield BEFORE
+            // joining the single-teardown `coro.cleanup` epilogue.
             let resume_bb = *fn_ctx
                 .blocks
                 .get(next)
                 .ok_or_else(|| CodegenError::FailClosed(format!("Yield next bb{next} missing")))?;
+            let parent = fn_ctx
+                .builder
+                .get_insert_block()
+                .and_then(|bb| bb.get_parent())
+                .ok_or_else(|| CodegenError::Llvm("yield block has no parent function".into()))?;
+            // #2395 — interpose the yield abandon (destroy-while-parked-at-yield)
+            // block. A generator destroyed before exhaustion (a `for await`
+            // consumer that stops early, a supervisor tearing the producer down)
+            // parks HERE; its frame-owned locals must be dropped on this case-1
+            // edge. The just-yielded value is a MOVE into `*out` so its binding
+            // is `Consumed` and excluded from this plan — `hew_gen_coro_destroy`'s
+            // `out_drop_thunk` is its sole owner (no double-free). These fire ONLY
+            // on the abandon edge (the block loop suppressed the normal-flow
+            // emission for `Yield`); the resume edge continues the still-owned body.
+            let yield_abandon_bb = fn_ctx.ctx.append_basic_block(parent, "gen_yield_abandon");
             let cc = crate::coro::CoroContext {
                 ctx: fn_ctx.ctx,
                 llvm_mod: fn_ctx.llvm_mod,
                 builder: &fn_ctx.builder,
-                function: fn_ctx
-                    .builder
-                    .get_insert_block()
-                    .and_then(|bb| bb.get_parent())
-                    .ok_or_else(|| {
-                        CodegenError::Llvm("yield block has no parent function".into())
-                    })?,
+                function: parent,
                 handle: coro.handle,
                 id_token: coro.id_token,
             };
             cc.emit_suspend(
                 resume_bb,
-                coro.cleanup_block,
+                yield_abandon_bb,
                 coro.suspend_return_block,
                 false,
                 "gen_yield",
             )?;
+            fn_ctx.builder.position_at_end(yield_abandon_bb);
+            emit_elab_drops(fn_ctx, block_id, fn_ctx.drop_plans)?;
+            fn_ctx
+                .builder
+                .build_unconditional_branch(coro.cleanup_block)
+                .llvm_ctx("gen yield abandon -> shared cleanup br")?;
         }
         Terminator::MakeGenerator {
             dest,
@@ -38035,6 +38091,13 @@ fn lower_function<'ctx>(
         })
         .unwrap_or_default();
 
+    // Extract drop_plans from the matched elaborated function, or an empty
+    // ('static) slice when no elaborated function is available (hand-built test
+    // pipelines that inline Instr::Drop instead of using drop_plans). Threaded
+    // onto `FnCtx` so the block loop AND `emit_suspend_point` (the shared
+    // suspend-ramp helper) read the same per-function plan set.
+    let drop_plans: &[(ExitPath, hew_mir::DropPlan)] =
+        elab.map(|e| e.drop_plans.as_slice()).unwrap_or(&[]);
     let fn_ctx = FnCtx {
         ctx,
         llvm_mod,
@@ -38073,6 +38136,8 @@ fn lower_function<'ctx>(
             FunctionCallConv::LambdaActorBody(shape) => Some(shape),
             _ => None,
         },
+        drop_plans,
+        suspend_abandon_block: std::cell::Cell::new(0),
     };
 
     // Fail-closed boundary: reject composite returns whose heap-owning payload
@@ -38136,13 +38201,6 @@ fn lower_function<'ctx>(
         )));
     }
 
-    // Extract drop_plans from the matched elaborated function, or use an
-    // empty slice when no elaborated function is available (hand-built test
-    // pipelines that inline Instr::Drop instead of using drop_plans).
-    let empty_plans: Vec<(ExitPath, hew_mir::DropPlan)> = Vec::new();
-    let drop_plans: &[(ExitPath, hew_mir::DropPlan)] = elab
-        .map(|e| e.drop_plans.as_slice())
-        .unwrap_or(empty_plans.as_slice());
     let cooperate_sites: &[CooperateSite] =
         checked.map(|c| c.cooperate_sites.as_slice()).unwrap_or(&[]);
     if let Some(site) = cooperate_sites
@@ -38292,7 +38350,18 @@ fn lower_function<'ctx>(
         // Emit LIFO drops from the elaborated drop plan BEFORE the
         // terminator so the alloca null-stores precede the ret/br.
         // LESSONS: cleanup-all-exits (P0), lifecycle-symmetry (P0).
-        emit_elab_drops(&fn_ctx, block.id, drop_plans)?;
+        //
+        // EXCEPT for a suspend carrier (`Suspend`/`SuspendingScopeDeadline`/
+        // `SuspendingSelect`/`Yield`): its `ExitPath::Suspend`/`Yield` plan holds
+        // the frame-owned locals live across the park, which must fire ONLY on
+        // the case-1 (destroy-while-parked) abandon edge — NOT here in the
+        // normal flow, where they would drop the values BEFORE the suspend and
+        // leave the resumed body reading freed memory (#2395). The abandon-edge
+        // emission lives in `emit_suspend_point` (all 13 collapsed emitters) and
+        // in the `Terminator::Yield` arm's interposed abandon block.
+        if !terminator_is_suspend_carrier(&block.terminator) {
+            emit_elab_drops(&fn_ctx, block.id, drop_plans)?;
+        }
         // Stage 2 (gdb `-g`): a call / branch / return lowers to a TERMINATOR,
         // not an `Instr`, so a call-statement (`println(r)`) would otherwise
         // inherit the previous instruction's line. The terminator span is keyed
@@ -48643,6 +48712,10 @@ mod tests {
             coro: None,
             // Test harness never exercises the lambda-actor body path.
             lambda_actor_shape: None,
+            // Composite-helper unit tests inline `Instr::Drop`; no elaborated
+            // drop plans and no suspend carrier to key an abandon plan off.
+            drop_plans: &[],
+            suspend_abandon_block: std::cell::Cell::new(0),
         }
     }
 

--- a/hew-codegen-rs/src/suspend.rs
+++ b/hew-codegen-rs/src/suspend.rs
@@ -270,6 +270,22 @@ where
 
     fn_ctx.builder.position_at_end(abandon_cleanup_bb);
     emit_abandon_cleanup()?;
+    // #2395 — the abandon (destroy-while-parked) edge. After the per-kind
+    // bookkeeping cleanup (slot cancel/free, observer deregister, deadline
+    // cancel) and BEFORE joining the frame-free `coro.cleanup` epilogue, drop
+    // the frame-owned Hew heap values live across this suspend. This is the
+    // never-implemented "cleanup outline": the MIR elaborator populated this
+    // block's `ExitPath::Suspend` plan with the `drops_for_exit`
+    // `BindingState`-filtered owned locals (a moved-out local is `Consumed` and
+    // excluded — no double-free), and the block loop suppressed its normal-flow
+    // emission so these fire ONLY here on the case-1 edge, never on resume. The
+    // block id is threaded via `FnCtx::suspend_abandon_block` (set by
+    // `lower_terminator`) so this one helper covers all 13 collapsed emitters.
+    crate::llvm::emit_elab_drops(
+        fn_ctx,
+        fn_ctx.suspend_abandon_block.get(),
+        fn_ctx.drop_plans,
+    )?;
     fn_ctx
         .builder
         .build_unconditional_branch(coro.cleanup_block)

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -9295,6 +9295,17 @@ struct Builder {
     /// carrier/Terminator field) so the carriers collapse onto one
     /// `Terminator::Suspend` while the emitted IR stays byte-identical.
     suspend_kinds: HashMap<u32, SuspendKind>,
+    /// #2395 decision 2 — abandon-edge drops for a suspend's escape-poisoned
+    /// value that the generic `drops_for_exit` `BindingState` filter cannot see.
+    /// Today the sole member is the `SuspendKind::StreamSend` in-flight yield
+    /// value: it is escape-poisoned (so no scope-exit drop competes on the
+    /// resume path) and its resume-edge release is the pump's inline `after_send`
+    /// `Instr::Drop`. Keyed by the id of the block carrying the
+    /// `Terminator::Suspend` (the SAME key `suspend_kinds` uses). Appended to the
+    /// matching `ExitPath::Suspend` plan AFTER `enumerate_exits`, so the value is
+    /// freed exactly once on the destroy-while-parked edge — mutually exclusive
+    /// with the resume-edge drop (abandon XOR resume).
+    suspend_abandon_extra_drops: HashMap<u32, Vec<ElabDrop>>,
     owned_locals: Vec<OwnedLocalEntry>,
     /// Generator/`AsyncGenerator` owned bindings tagged with the HIR scope they
     /// were declared in, recorded so a per-scope-exit `hew_gen_coro_destroy`
@@ -32210,6 +32221,42 @@ impl Builder {
         (resume_bb, close_bb)
     }
 
+    /// #2395 decision 2 — record the abandon-edge drop for a `StreamSend`
+    /// in-flight yield value. The value is escape-poisoned (so the generic
+    /// `drops_for_exit` filter misses it) and its resume-edge release (the
+    /// pump's `after_send` inline `Instr::Drop`) never fires on
+    /// destroy-while-parked. Stash a congruent `CowHeap` drop keyed by
+    /// `suspend_block` (the block carrying the `Terminator::Suspend`); the
+    /// post-`enumerate_exits` pass appends it to that suspend's plan so codegen
+    /// fires it on the case-1 destroy edge only. Exactly-once holds: the abandon
+    /// and resume edges are mutually exclusive and this drop lives only on the
+    /// abandon plan. The release protocol is the SAME `generator_yield_drop_symbol`
+    /// verdict the resume drop uses, routed through the canonical
+    /// `CowHeapRelease::from_symbol` inverse (no picker drift); the resulting kind
+    /// passes `validate_drop_plan` (string/bytes via the Place-driven dispatcher,
+    /// `Vec*` via its dedicated owned/plain arms). A symbol outside the wired set
+    /// (`from_symbol` → `None`) skips the drop — leak-not-wrong-free.
+    fn record_stream_send_abandon_drop(
+        &mut self,
+        suspend_block: u32,
+        value: Place,
+        yield_ty: &ResolvedTy,
+        symbol: &'static str,
+    ) {
+        if let Some(release) = crate::ownership::CowHeapRelease::from_symbol(symbol) {
+            self.suspend_abandon_extra_drops
+                .entry(suspend_block)
+                .or_default()
+                .push(ElabDrop {
+                    place: value,
+                    ty: yield_ty.clone(),
+                    drop_fn: None,
+                    kind: DropKind::CowHeap { release },
+                    guard: None,
+                });
+        }
+    }
+
     fn build_stream_producer_pump(&mut self, gen_place: Place, pump: &StreamProducerPumpCtx) {
         use hew_types::runtime_call::RuntimeCallFamily;
 
@@ -32318,11 +32365,15 @@ impl Builder {
         if let ReleaseSymbolVerdict::Wired(symbol) =
             self.generator_yield_drop_symbol(&pump.yield_ty)
         {
+            // Resume-edge release (delivered/ready): the pump is the sole owner
+            // of its copy and frees it here before the loop overwrites the slot.
             self.push_instr(Instr::Drop {
                 place: value_local,
                 ty: pump.yield_ty.clone(),
                 drop_fn: Some(crate::model::DropFnSpec::Release(symbol)),
             });
+            // Abandon-edge release for the SAME in-flight value (#2395 dec. 2).
+            self.record_stream_send_abandon_drop(send_bb, value_local, &pump.yield_ty, symbol);
         }
         self.finish_current_block(Terminator::Goto { target: loop_head });
 
@@ -34167,7 +34218,7 @@ fn elaborate(
         &indirect_enum_drop_allowed,
         &builder.resource_drop_flags,
     );
-    let (elab_blocks, drop_plans) = enumerate_exits(
+    let (elab_blocks, mut drop_plans) = enumerate_exits(
         &checked.blocks,
         &lifo_drops,
         &dataflow_result.exit_states,
@@ -34182,6 +34233,21 @@ fn elaborate(
         &builder.loop_back_edge_blocks,
         &builder.locals,
     );
+
+    // #2395 decision 2 — append each suspend's escape-poisoned abandon-edge drops
+    // (today: the `SuspendKind::StreamSend` in-flight value) to its
+    // `ExitPath::Suspend` plan. `drops_for_exit`'s `BindingState` filter cannot
+    // see an escape-poisoned value, so it is stashed at the pump lowering site
+    // (keyed by the suspend block id) and folded in here. Appended AFTER the
+    // generic drops so it releases in the same LIFO order codegen walks; codegen
+    // fires the whole plan on the case-1 destroy edge only.
+    for (exit, plan) in &mut drop_plans {
+        if let ExitPath::Suspend { block, .. } = exit {
+            if let Some(extra) = builder.suspend_abandon_extra_drops.get(block) {
+                plan.drops.extend(extra.iter().cloned());
+            }
+        }
+    }
 
     ElaboratedMirFunction {
         name: checked.name.clone(),
@@ -44079,12 +44145,27 @@ fn enumerate_exits(
                     },
                 )
             }
+            // Generator-body `yield`. The abandon (destroy-while-parked-at-yield)
+            // edge must drop the frame-owned locals live across this yield, or a
+            // generator destroyed before exhaustion (a `for await` consumer that
+            // stops early, a supervisor tearing the producer down) leaks them.
+            // The plan is the SAME `drops_for_exit` `BindingState`-filtered set the
+            // `Return`/`Cancel` exits use, so a moved-out local is excluded (no
+            // double-free). The just-yielded `value` is published to the companion
+            // `out` slot as a MOVE, so its binding is `Consumed` at this exit and
+            // the filter drops it here — its sole owner is `hew_gen_coro_destroy`'s
+            // `out_drop_thunk`. Codegen fires this plan ONLY on the yield's case-1
+            // destroy edge (never on resume): `emit_elab_drops` interposed before
+            // the `br coro.cleanup`, with the block-loop's normal-flow emission
+            // suppressed for suspend carriers.
             Terminator::Yield { value: _, next } => (
                 ExitPath::Yield {
                     block: block_id,
                     next: *next,
                 },
-                DropPlan::default(),
+                DropPlan {
+                    drops: drops_for_exit(block_id),
+                },
             ),
             // Generator construction is a synchronous call into the runtime
             // (the coro companion alloc + the gen-body ramp call) with a single
@@ -44216,23 +44297,30 @@ fn enumerate_exits(
                 },
                 DropPlan::default(),
             ),
-            // Stackless suspend (R326/R327). The suspend point preserves all
-            // live state in the coro frame across the suspend, so it fires NO
-            // scope-exit drops here — the frame's owned values are dropped
-            // exactly once by the `cleanup` outline on `coro.destroy` (the
-            // single-teardown owner, the `cleanup` edge), never at the suspend
-            // site. Function-wide DropPlan is intentionally empty, mirroring
-            // `ExitPath::Yield`/`Goto`.
+            // Stackless suspend (R326/R327). When the parked continuation is
+            // DESTROYED without resuming (a supervisor stopping a parked actor,
+            // teardown, `hew_cont_destroy`'s abandon edge), the coro frame is
+            // freed but its frame-owned Hew heap values would leak (#2395) — the
+            // never-implemented "cleanup outline". This plan carries the exit's
+            // owned-local drops so codegen fires them on the case-1 (destroy)
+            // edge, BEFORE the frame free, and ONLY there (never on resume: the
+            // block-loop's normal-flow `emit_elab_drops` is suppressed for
+            // suspend carriers, and the resume edge continues the still-owned
+            // body). The drop set is the SAME `drops_for_exit` `BindingState`
+            // filter the `Return`/`Cancel` exits use, so a local moved out across
+            // the suspend is `Consumed` and excluded — no double-free. The
+            // StreamSend in-flight value (escape-poisoned, so the generic filter
+            // misses it) is appended kind-specifically after `enumerate_exits`
+            // returns (see the `suspend_abandon_extra_drops` post-pass).
             Terminator::Suspend {
                 resume, cleanup, ..
             }
-            // `SuspendingScopeDeadline` has the same suspend drop posture: the
-            // frame-owned values are dropped exactly once by the `cleanup`
-            // outline; the scoped children's drops are owned by the scope-join /
-            // scope-cancel codegen, not the function-wide DropPlan. The
-            // `timeout_body_block` deadline edge is a regular in-CFG successor
-            // already covered by the successors walker; the drop plan keys off the
-            // resume/cleanup coro edges exactly like the other suspend carriers.
+            // `SuspendingScopeDeadline` shares the abandon-edge drop posture: the
+            // frame-owned owned LOCALS are released by this plan; the scoped
+            // children's drops + deadline cancel stay codegen-owned in the abandon
+            // closure. The `timeout_body_block` deadline edge is a regular in-CFG
+            // successor already covered by the successors walker; the plan keys
+            // off the resume/cleanup coro edges exactly like the other carriers.
             | Terminator::SuspendingScopeDeadline {
                 resume, cleanup, ..
             }
@@ -44242,10 +44330,10 @@ fn enumerate_exits(
             // per-arm LOSER cleanup (win path) runs at the codegen resume-edge
             // dispatch site exactly as `Terminator::Select`'s does; the abandon
             // edge deregisters EVERY observer + cancels the timer + frees the
-            // arbiter (the single-teardown owner). The function-wide DropPlan is
-            // intentionally empty — both the select-loser cleanup and the
-            // suspend-frame teardown are codegen-owned, never a function-exit
-            // LIFO drop.
+            // arbiter (the single-teardown owner) in the codegen abandon closure.
+            // This plan adds ONLY the ordinary owned-local drops on top — the
+            // `drops_for_exit` set (registered owned locals) cannot include those
+            // select structures by construction.
             | Terminator::SuspendingSelect {
                 resume, cleanup, ..
             } => (
@@ -44254,7 +44342,9 @@ fn enumerate_exits(
                     resume: *resume,
                     cleanup: *cleanup,
                 },
-                DropPlan::default(),
+                DropPlan {
+                    drops: drops_for_exit(block_id),
+                },
             ),
         };
         plans.push(plan);
@@ -46108,6 +46198,140 @@ mod slice3_narrowing_proptests {
                 prop_assert!(i < n, "drop for binding {} but only {} defined", i, n);
             }
         }
+    }
+
+    // ── #2395 lane A: suspend / yield abandon-edge drop plans ────────────────
+    // enumerate_exits must populate the ExitPath::Suspend / ExitPath::Yield plan
+    // with the exit's live owned-local drops (fired by codegen on the
+    // destroy-while-parked abandon edge), and exclude a moved-out (Consumed)
+    // binding so a value moved across the suspend is never double-freed.
+
+    fn single_suspend_block(id: u32) -> BasicBlock {
+        BasicBlock {
+            id,
+            statements: vec![],
+            instructions: vec![],
+            // resume/cleanup alias to a resume target as the collapsed carriers do;
+            // the plan keys off the suspend terminator's own block id.
+            terminator: Terminator::Suspend {
+                resume: id + 1,
+                cleanup: id + 1,
+                is_final: false,
+            },
+        }
+    }
+
+    fn single_yield_block(id: u32) -> BasicBlock {
+        BasicBlock {
+            id,
+            statements: vec![],
+            instructions: vec![],
+            terminator: Terminator::Yield {
+                value: Place::Local(99),
+                next: id + 1,
+            },
+        }
+    }
+
+    #[test]
+    fn suspend_exit_plan_carries_live_owned_local_drop() {
+        let blocks = vec![single_suspend_block(0)];
+        let lifo = build_lifo(1);
+        let exit_states = build_exit_states(1, &[]);
+        let binding_locals = build_binding_locals(1);
+        let (_, plans) = enumerate_exits(
+            &blocks,
+            &lifo,
+            &exit_states,
+            &HashMap::new(),
+            &binding_locals,
+            &HashSet::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &[],
+        );
+        let (exit, plan) = &plans[0];
+        assert!(matches!(exit, ExitPath::Suspend { block: 0, .. }));
+        assert_eq!(
+            plan.drops.iter().map(|d| d.place).collect::<Vec<_>>(),
+            vec![Place::DuplexHandle(0)],
+            "the live owned local must be dropped on the suspend abandon edge",
+        );
+    }
+
+    #[test]
+    fn suspend_exit_plan_excludes_moved_out_local() {
+        let blocks = vec![single_suspend_block(0)];
+        let lifo = build_lifo(1);
+        // BindingId(0) is Consumed (moved out across the suspend).
+        let exit_states = build_exit_states(1, &[0]);
+        let binding_locals = build_binding_locals(1);
+        let (_, plans) = enumerate_exits(
+            &blocks,
+            &lifo,
+            &exit_states,
+            &HashMap::new(),
+            &binding_locals,
+            &HashSet::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &[],
+        );
+        let (_, plan) = &plans[0];
+        assert!(
+            plan.drops.is_empty(),
+            "a moved-out (Consumed) local must NOT be dropped on the abandon edge \
+             (double-free wall); got {:?}",
+            plan.drops,
+        );
+    }
+
+    #[test]
+    fn yield_exit_plan_carries_live_drop_and_excludes_consumed() {
+        // Live binding: dropped on the yield abandon (destroy-while-parked-at-yield) edge.
+        let blocks = vec![single_yield_block(0)];
+        let lifo = build_lifo(1);
+        let live = build_exit_states(1, &[]);
+        let binding_locals = build_binding_locals(1);
+        let (_, plans) = enumerate_exits(
+            &blocks,
+            &lifo,
+            &live,
+            &HashMap::new(),
+            &binding_locals,
+            &HashSet::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &[],
+        );
+        let (exit, plan) = &plans[0];
+        assert!(matches!(exit, ExitPath::Yield { block: 0, .. }));
+        assert_eq!(
+            plan.drops.iter().map(|d| d.place).collect::<Vec<_>>(),
+            vec![Place::DuplexHandle(0)],
+        );
+
+        // The just-yielded value is a MOVE into the companion out-slot, so its
+        // binding is Consumed at the yield exit and is excluded — its sole owner
+        // is hew_gen_coro_destroy's out_drop_thunk (no second dropper).
+        let consumed = build_exit_states(1, &[0]);
+        let (_, plans) = enumerate_exits(
+            &blocks,
+            &lifo,
+            &consumed,
+            &HashMap::new(),
+            &binding_locals,
+            &HashSet::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &[],
+        );
+        assert!(
+            plans[0].1.drops.is_empty(),
+            "a Consumed (moved-to-out-slot) yield value must be excluded from the \
+             yield abandon plan; got {:?}",
+            plans[0].1.drops,
+        );
     }
 }
 

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -31962,7 +31962,29 @@ impl Builder {
         // Seal the last block with `Terminator::Return`. For a gen body
         // this represents the generator completing (returns `return_ty` which
         // S5 maps to `None` on the Iterator impl side).
-        let raw_blocks = body_builder.finalize_blocks(Terminator::Return);
+        let mut blocks = body_builder.finalize_blocks(Terminator::Return);
+
+        // W5.011 P3 — release nested fresh-`string` temporaries (f-string
+        // interpolation's `to_string_*`/`string_concat` chain, `(a + b).len()`,
+        // `s.to_uppercase().len()`, discarded `a + b;`) that `derive_cow_fresh_
+        // borrowed_owner` (binding-scoped) cannot see. `lower_function`'s
+        // ordinary-fn path runs this splice unconditionally right after
+        // `finalize_blocks` (see its own call site); this gen-body ramp builds
+        // its `RawMirFunction` through its own hand-rolled pipeline below
+        // instead of going through `lower_function`, so it needs the identical
+        // call — omitting it left every fresh-string temp inside a generator
+        // body (most visibly an f-string per `yield`) leaking unconditionally,
+        // independent of the `string_concat` catalog-name contract fix, since
+        // this pass never ran on gen-body blocks at all. Must run BEFORE
+        // `check_function`/`elaborate` below so the dataflow observes each
+        // inline drop as a read of its temp and codegen emits the release.
+        apply_nested_fresh_string_temp_drops(
+            &mut blocks,
+            &body_builder.suspend_kinds,
+            &body_builder.locals,
+            &body_builder.binding_locals,
+            &mut body_builder.instr_spans,
+        );
 
         // Cross-suspend state is owned by LLVM's CoroSplit. The generator body
         // lowers to an `llvm.coro.*` switched-resume coroutine; CoroSplit
@@ -31972,7 +31994,6 @@ impl Builder {
         // state-record synthesis pass: the prior `gen_state::synthesise` machinery
         // (the spike-era stand-in for the never-landed hand-rolled state machine)
         // is subsumed by the coro frame and removed (RC14).
-        let blocks = raw_blocks;
         let body_locals_with_state = body_builder.locals.clone();
 
         // Build the THIR/raw/checked/elaborated triple for the body function.

--- a/hew-mir/src/runtime_symbols.rs
+++ b/hew-mir/src/runtime_symbols.rs
@@ -1020,6 +1020,22 @@ pub fn callee_ownership_contract(callee: &str) -> CalleeOwnershipContract {
         // string result. `hew-runtime/src/string.rs` either allocates a new
         // refcounted buffer at rc=1 or bumps an existing string's refcount; the
         // caller owns exactly one balancing `hew_string_drop`.
+        //
+        // `string_concat` (no `hew_` prefix) is the `stdlib_catalog` presentation
+        // name f-string interpolation lowering calls through (`build_catalog_call`,
+        // `hew-hir/src/lower.rs::lower_interpolated_string`) — it reaches MIR as
+        // a `Terminator::Call { callee: "string_concat", .. }`, never rewritten to
+        // the `hew_string_concat` c-symbol before this lookup (that rewrite is a
+        // codegen-time `BuiltinLinkage::RuntimeFfiShim` concern, per
+        // `hew-hir/src/stdlib_catalog.rs`). Every sibling catalog presentation
+        // name reachable as a literal MIR callee (`to_string_i64`, `println_str`,
+        // …) is already dual-listed against its c-symbol below; `string_concat`
+        // was the one missing entry, so both the concat call's own fresh-owned
+        // result AND the `to_string_*` temp feeding it as a borrowed argument
+        // fell through to `FAIL_CLOSED` (`Untracked` / `Escaping`) and leaked —
+        // `collect_nested_fresh_string_temp_drops` never admitted either. The
+        // runtime behaviour is byte-identical to `hew_string_concat` (the shim
+        // calls it directly), so the contract must be too.
         "hew_string_clone"
         | "hew_string_concat"
         | "hew_string_repeat"
@@ -1028,9 +1044,8 @@ pub fn callee_ownership_contract(callee: &str) -> CalleeOwnershipContract {
         | "hew_string_slice_codepoints"
         | "hew_string_to_lowercase"
         | "hew_string_to_uppercase"
-        | "hew_string_trim" => {
-            CalleeOwnershipContract::new(Escapes, BorrowingUse, FreshOwnedString)
-        }
+        | "hew_string_trim"
+        | "string_concat" => CalleeOwnershipContract::new(Escapes, BorrowingUse, FreshOwnedString),
 
         // String inspectors and container producers borrow their string input
         // without handing back a tracked string result. Scalar/bytes/Vec

--- a/hew-mir/tests/lowering_expr/cstring_container_domain_canary.rs
+++ b/hew-mir/tests/lowering_expr/cstring_container_domain_canary.rs
@@ -125,6 +125,12 @@ fn string_element_vec_accessors_are_allowlisted_but_guarded() {
 /// `hew_string_drop` after the body uses `word`.
 #[test]
 fn vec_string_for_in_emits_retained_getter_with_iteration_drop() {
+    // `println(count)` (a direct scalar print) rather than an f-string: the
+    // fixture's subject is the for-in retained-getter drop, and an
+    // interpolated `f"count={count}"` tail would add its OWN
+    // `hew_string_drop`s (the fresh-`string`-temp release lane, W5.011 P3 /
+    // Lane E) into `string_drops` below, conflating two unrelated things
+    // this test is not about.
     let pl = pipeline_with_tc(
         r#"fn main() {
             let words: Vec<string> = Vec::new();
@@ -135,7 +141,7 @@ fn vec_string_for_in_emits_retained_getter_with_iteration_drop() {
                 println(word);
                 count = count + 1;
             }
-            println(f"count={count}");
+            println(count);
         }"#,
     );
 

--- a/hew-mir/tests/lowering_expr/owned_string_temp_drop_canary.rs
+++ b/hew-mir/tests/lowering_expr/owned_string_temp_drop_canary.rs
@@ -412,3 +412,64 @@ fn index_bound_oob_trap_drops_nothing() {
          not be dropped on the trap edge (else a clean trap degrades to SIGSEGV)",
     );
 }
+
+// ---------------------------------------------------------------------------
+// f-string interpolation temp release (Lane E, rc1 drop-safety completion
+// program). `f"item-{i}"` over a non-string value desugars
+// (`hew-hir/src/lower.rs::lower_interpolated_string`) to a chain of
+// `stdlib_catalog` presentation-name calls: `to_string_i64(i)` (a fresh
+// conversion temp) then `string_concat(lit, temp)` (the join). Both reach MIR
+// as `Terminator::Call` to the CATALOG name, not the `hew_*` c-symbol; unlike
+// its `to_string_i64`/`println_str` siblings, `string_concat` had no
+// `callee_ownership_contract` row (only `hew_string_concat` did), so it fell
+// through to `FAIL_CLOSED` and neither the conversion temp (unrecognised
+// borrowing use) nor the concat's own result (unrecognised fresh producer)
+// was ever admitted by this file's NESTED/DISCARD substrate — both leaked.
+// ---------------------------------------------------------------------------
+
+/// NESTED statement position: `println(f"item-{i}")` — neither temp is bound
+/// to a `let`, so both are the substrate's NESTED shape. Exactly one inline
+/// drop each: the conversion temp (borrowed by the concat) and the concat
+/// result (borrowed by `println_str`, a covered print sink).
+#[test]
+fn canary6_fstring_interpolation_statement_position_releases_both_temps() {
+    let pl = pipeline_with_tc("fn f6(i: i64) {\n    println(f\"item-{i}\");\n}\n");
+    assert_no_nyi(&pl);
+    assert_eq!(
+        inline_string_drops(&pl, "f6"),
+        2,
+        "f-string interpolation of a non-string value must release both the \
+         Display::fmt conversion temp (hew_i64_to_string) and the \
+         hew_string_concat join result -- one inline drop each"
+    );
+    assert_eq!(return_exit_string_drops(&pl, "f6"), 0);
+}
+
+/// Gen-body shape: a standalone `gen fn` yields `f"item-{i}"` per iteration.
+/// The concat result is published through the yield-transport (a MOVE,
+/// correctly excluded from this substrate), so only the conversion temp is at
+/// risk here -- but `lower_gen_block` builds the coroutine ramp's
+/// `RawMirFunction` through its own hand-rolled pipeline instead of
+/// `lower_function`, so it never called `apply_nested_fresh_string_temp_drops`
+/// at all (a SEPARATE gap from the catalog-name contract row above; every
+/// ordinary function gets the splice for free via `lower_function`'s shared
+/// post-`finalize_blocks` step). The gen-body ramp is emitted as its own MIR
+/// function named `__hew_gen_body_<owner>_<id>`.
+#[test]
+fn canary7_fstring_interpolation_gen_yield_releases_conversion_temp() {
+    let pl = pipeline_with_tc(
+        "gen fn g7(n: i64) -> string {\n    var i: i64 = 0;\n    while i < n {\n        yield f\"item-{i}\";\n        i = i + 1;\n    }\n}\n",
+    );
+    assert_no_nyi(&pl);
+    assert_eq!(
+        inline_string_drops(&pl, "__hew_gen_body_g7_0"),
+        1,
+        "the hew_i64_to_string conversion temp feeding the yielded f-string \
+         must release exactly once inside the generator body ramp"
+    );
+    assert_eq!(
+        return_exit_string_drops(&pl, "__hew_gen_body_g7_0"),
+        0,
+        "the conversion temp is a NESTED (unbound) shape, not a scope-exit-drop binding"
+    );
+}

--- a/hew-runtime/src/cont.rs
+++ b/hew-runtime/src/cont.rs
@@ -280,11 +280,21 @@ pub unsafe extern "C" fn hew_cont_poll(handle: *mut c_void, out_value: *mut c_vo
 
 /// Destroy a completed (or abandoned) continuation — `llvm.coro.destroy(handle)`.
 ///
-/// Runs the single `cleanup` outline: drops any frame-owned Hew heap values
-/// still live, then frees the frame via `coro.free` → [`hew_cont_frame_free`].
+/// Resumes the coroutine at its `coro.suspend` cleanup edge (case 1), running
+/// the coroutine's OWN cleanup funclet before the frame is freed. Codegen emits
+/// that funclet, so the drops live in the compiled coroutine, not in this
+/// runtime shim. For a continuation abandoned WHILE SUSPENDED the funclet runs,
+/// in order: (a) the suspend kind's per-park bookkeeping (slot cancel/free,
+/// observer deregister, deadline cancel), then (b) the drop of every frame-owned
+/// Hew heap value live across the park — the suspend exit's elaborated drop plan
+/// (#2395, the previously-unimplemented "cleanup outline") — and finally the
+/// shared `coro.cleanup` frees the frame via `coro.free` →
+/// [`hew_cont_frame_free`]. A continuation destroyed AFTER completing already
+/// ran its return-path drops; its value-free final suspend frees the frame only.
 /// This is the SOLE teardown owner; it must be called exactly once per
 /// continuation, by the handle's owner, after observing [`ResumePoll::Ready`]
-/// (or to abandon a still-suspended continuation, e.g. scope cancellation).
+/// (or to abandon a still-suspended continuation, e.g. scope cancellation /
+/// supervisor stop).
 ///
 /// # Safety
 ///
@@ -313,9 +323,12 @@ pub unsafe extern "C" fn hew_cont_destroy(handle: *mut c_void) {
 /// This is the SOLE teardown owner of a generator value, called exactly once at
 /// the generator's scope-exit drop (or early drop while suspended). It:
 ///   1. reads the coro handle at offset 0 and [`hew_cont_destroy`]s it — the
-///      coro `cleanup` outline drops every value the body still owns in its
-///      frame (a value suspended mid-iteration, a cross-yield-live owned local),
+///      coro `cleanup` funclet (codegen's yield abandon edge, #2395) drops every
+///      value the body still owns in its frame (a cross-yield-live owned local),
 ///      then frees the coro frame. Exactly the single-owner destroy discipline.
+///      The just-yielded value in `out` is NOT among them (it is a MOVE into
+///      `out`, `Consumed` at the yield, so excluded from that plan); it is
+///      dropped by step 3 below, keeping the companion its sole owner.
 ///   2. reads the heap env at offset `ptr_width` and frees it via
 ///      [`hew_cont_frame_free`] (null for a capture-free generator → no-op). The
 ///      env holds only plain-copyable captures (`gen_env_capture_admissible`


### PR DESCRIPTION
Two long-standing drop-elaboration gaps, fixed at the MIR/codegen seam they share.

**Owned locals leaked on destroy-while-parked (#2395).** Suspend and yield exits carried empty drop plans — the design delegated cleanup to a codegen outline that was never built — and the destroy edge freed only the coroutine frame. Any owned local live across a suspend leaked when an actor or generator was destroyed without resuming (supervisor stop, scope teardown). The exit plans are now populated with the same binding-state-filtered LIFO drops that return and cancel exits have always used, emitted only on the destroy edge across all thirteen suspend emitters plus yield, with the in-flight stream-send value appended to its own suspend plan. Normal-flow emission is suppressed for suspend carriers so the plan fires exactly once: resume-and-complete drops at return, destroy-while-parked drops on the abandon edge, never both.

**F-string interpolation temporaries never released.** Two independent causes: the desugar calls the catalog name `string_concat`, which was missing from the callee ownership contract (every sibling was dual-listed), so the fail-closed default refused to release the concat result and conversion temps; and generator bodies build their ramp through a pipeline that skipped the temp-drop splice ordinary functions get. Both fixed — statement-position and gen-body f-strings now release their temporaries at statement boundaries.

The checked-MIR goldens are re-blessed accordingly: the drift is one suspend plan gaining a resource drop and 67 inserted string-release drops across eight fixtures, nothing else.

Verification: new leak oracles for both fixes (destroy-while-parked owned locals + moved-out exclusion; f-string temps in loops, gen bodies, and receive handlers, all asserting zero leaked allocations); the teardown-fault fixture keeps its exact stdout and exit 134 while dropping to zero leaks; vertical slice 419/419; full workspace test lanes; poisoned-allocator runs clean on the adversarial ownership shapes (conditional moves, reassignment across suspends, moved-out yields, bound/returned/by-value f-string results).

Known residuals tracked separately, all leak-only and pre-existing: #2411, #2412, #2413 (now narrower than filed — owned locals do drop on the select abandon edge; the residual is select-internal channel bookkeeping), #2418.

Fixes #2395