### PR TITLE
fix(codegen): widen runtime_size_ty to cover 32-bit x86, not just wasm32

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -1843,27 +1843,48 @@ fn math_builtin_intrinsic(callee: &str) -> Option<MathBuiltinIntrinsic> {
 ///
 /// `intern_runtime_decl` declares runtime FFI symbols whose parameters are
 /// `usize`/`size_t` in the Rust runtime (`hew_actor_spawn(state_size: usize)`,
-/// `hew_actor_send_by_id(size: usize)`, …). `size_t` is 64-bit on the native
-/// targets (x86_64/aarch64) but 32-bit on wasm32. The IR is rebuilt per target
-/// by `build_module_for_target`, which sets the module triple before any body
-/// fill triggers an FFI declaration, so the module triple is the authority for
-/// the pointer/`size_t` width at declaration time.
+/// `hew_actor_send_by_id(size: usize)`, …). `size_t` is 64-bit on 64-bit
+/// native targets (x86_64/aarch64) but 32-bit on any 32-bit target: wasm32
+/// and the 32-bit x86 family (`i386`/`i586`/`i686`, e.g.
+/// `i686-unknown-linux-gnu`, `i686-pc-windows-msvc`). The IR is rebuilt per
+/// target by `build_module_for_target`, which sets the module triple before
+/// any body fill triggers an FFI declaration, so the module triple is the
+/// authority for the pointer/`size_t` width at declaration time.
 ///
 /// Declaring these params at the wrong width produces a `wasm-ld` signature
 /// mismatch against the wasm32 runtime archive (codegen `i64` vs runtime
 /// `i32`), and the resulting `signature_mismatch:hew_actor_spawn` stub traps
-/// `unreachable` at runtime. This helper returns the target-correct width so
-/// the codegen declaration matches the runtime's real C ABI.
+/// `unreachable` at runtime. On i386/i686 the equivalent mismatch is a
+/// `size_t` argument-width mismatch against the real 32-bit C ABI rather than
+/// a linker-level trap, but the failure class is the same: a declared i64
+/// parameter for a runtime function whose real C signature takes a 32-bit
+/// `size_t`. This helper returns the target-correct width so the codegen
+/// declaration matches the runtime's real C ABI on every 32-bit target, not
+/// only wasm32 (PR #1939 added the `reconcile_int_width_signed` calls needed
+/// once this returns the correct width for i386/i686, but left this helper's
+/// own triple check wasm32-only, so the reconcile was a same-width no-op on
+/// 32-bit x86 and the declaration itself stayed at the wrong width there).
 pub(crate) fn runtime_size_ty<'ctx>(
     ctx: &'ctx Context,
     llvm_mod: &LlvmModule<'ctx>,
 ) -> inkwell::types::IntType<'ctx> {
     let triple = llvm_mod.get_triple();
-    if triple.as_str().to_string_lossy().starts_with("wasm32") {
+    let triple = triple.as_str().to_string_lossy();
+    if triple.starts_with("wasm32") || is_32bit_x86_triple(&triple) {
         ctx.i32_type()
     } else {
         ctx.i64_type()
     }
+}
+
+/// True for the 32-bit x86 (`i386`/`i486`/`i586`/`i686`) triple family, e.g.
+/// `i686-unknown-linux-gnu` or `i686-pc-windows-msvc`. Matches `rustc --print
+/// target-list`'s real 32-bit x86 arch components (`i386`, `i586`, `i686`;
+/// `i486` is included for completeness even though no current Rust target
+/// uses it). Does not match `x86_64`/`amd64` (64-bit) or any other arch.
+fn is_32bit_x86_triple(triple: &str) -> bool {
+    let arch = triple.split('-').next().unwrap_or(triple);
+    matches!(arch, "i386" | "i486" | "i586" | "i686")
 }
 
 /// Intern a runtime-ABI function declaration for `symbol` in `llvm_mod`.
@@ -44626,6 +44647,62 @@ fn link_wasm_module(obj: &Path, out: &Path) -> CodegenResult<()> {
 mod tests {
     use super::*;
     use hew_mir::{BasicBlock, DecisionFact, IrPipeline};
+
+    #[test]
+    fn runtime_size_ty_is_i32_on_wasm32() {
+        let ctx = Context::create();
+        let llvm_mod = ctx.create_module("runtime_size_ty_wasm32");
+        llvm_mod.set_triple(&TargetTriple::create("wasm32-unknown-unknown"));
+        assert_eq!(runtime_size_ty(&ctx, &llvm_mod), ctx.i32_type());
+    }
+
+    #[test]
+    fn runtime_size_ty_is_i32_on_32bit_x86() {
+        // PR #1939 fixed the wasm32 case (`reconcile_int_width_signed` at the
+        // join-terminator and suspending-ask call sites) but this helper's own
+        // triple check stayed wasm32-only, so on i386/i686 the reconcile was a
+        // same-width i64-vs-i64 no-op and the FFI declaration itself stayed at
+        // the wrong (i64) width against the real 32-bit C ABI. Guard every
+        // real Rust 32-bit x86 triple prefix (`rustc --print target-list`:
+        // i386-apple-ios, i586-unknown-*, i686-*) so this can't silently regress
+        // to wasm32-only again.
+        let ctx = Context::create();
+        for triple in [
+            "i686-unknown-linux-gnu",
+            "i686-pc-windows-msvc",
+            "i686-pc-windows-gnu",
+            "i686-apple-darwin",
+            "i586-unknown-linux-gnu",
+            "i386-apple-ios",
+        ] {
+            let llvm_mod = ctx.create_module("runtime_size_ty_32bit_x86");
+            llvm_mod.set_triple(&TargetTriple::create(triple));
+            assert_eq!(
+                runtime_size_ty(&ctx, &llvm_mod),
+                ctx.i32_type(),
+                "runtime_size_ty should be i32 on 32-bit x86 triple {triple}"
+            );
+        }
+    }
+
+    #[test]
+    fn runtime_size_ty_is_i64_on_64bit_native_targets() {
+        let ctx = Context::create();
+        for triple in [
+            "x86_64-unknown-linux-gnu",
+            "x86_64-pc-windows-msvc",
+            "aarch64-apple-darwin",
+            "aarch64-unknown-linux-gnu",
+        ] {
+            let llvm_mod = ctx.create_module("runtime_size_ty_64bit");
+            llvm_mod.set_triple(&TargetTriple::create(triple));
+            assert_eq!(
+                runtime_size_ty(&ctx, &llvm_mod),
+                ctx.i64_type(),
+                "runtime_size_ty should be i64 on 64-bit triple {triple}"
+            );
+        }
+    }
 
     #[test]
     fn uint_to_string_runtime_arg_width_is_u32() {


### PR DESCRIPTION
## What

Fixes #1939's remaining i386/i686 gap: `runtime_size_ty` (`hew-codegen-rs/src/llvm.rs`) still only special-cases `wasm32` for the actor-FFI `size_t` ABI width; every other target — including 32-bit x86 — falls through to the 64-bit `i64` branch.

## Why this reopens #1939

PR #1939 added `reconcile_int_width_signed` calls at the join-terminator and suspending-ask call sites so the *call argument* width matches `runtime_size_ty`'s declared width. That's correct for wasm32 (`i64` payload-size operand reconciled down to `runtime_size_ty`'s `i32`). But on i386/i686, `runtime_size_ty` itself still returns `i64` (only `wasm32` is checked), so the reconcile is a same-width `i64`-vs-`i64` no-op — it fixes call/declaration *parity* but does nothing about both sides being the wrong width for the real 32-bit C ABI. #1939's own commit message says "i32 on a 32-bit target (wasm32, i386)", describing behavior `runtime_size_ty` didn't actually implement for i386.

The existing regression test added in #1939, `emit_join_terminator_reconciles_payload_size_width`, is a source-text scan asserting `reconcile_int_width_signed` appears in `emit_join_terminator`'s body — it never compiles for an i386/i686 triple, so it can't and doesn't catch this gap.

## Fix

`runtime_size_ty` now also returns `i32` for the i386/i486/i586/i686 triple family (the real 32-bit x86 arch components in `rustc --print target-list`: `i386-apple-ios`, `i586-unknown-*`, `i686-*`), matching wasm32 and every other target the same way. wasm32 and 64-bit targets are unaffected — this only widens which triples hit the existing `i32` branch.

## Tests

Added three unit tests directly on `runtime_size_ty` (builds a real LLVM module per triple via `TargetTriple::create` + `set_triple`, asserts the returned `IntType`):

- `runtime_size_ty_is_i32_on_wasm32` — pins existing behavior.
- `runtime_size_ty_is_i32_on_32bit_x86` — 6 real i386/i586/i686 triples (`i686-unknown-linux-gnu`, `i686-pc-windows-msvc`, `i686-pc-windows-gnu`, `i686-apple-darwin`, `i586-unknown-linux-gnu`, `i386-apple-ios`).
- `runtime_size_ty_is_i64_on_64bit_native_targets` — 4 real 64-bit triples, guards against over-widening.

These test the helper directly rather than via source-text scanning, so a future regression on this exact triple check fails a fast unit test instead of only surfacing on a real i386/i686 build.

## Verification

- `cargo test -p hew-codegen-rs --lib`: 214/214 passing (211 pre-existing + 3 new), run against current `main` (`4844bf9a1`).
- `cargo fmt -p hew-codegen-rs -- --check`: clean.
- `cargo clippy -p hew-codegen-rs --lib -- -D warnings`: clean.

## Scope

Single file, `hew-codegen-rs/src/llvm.rs`. No behavior change for wasm32 or 64-bit targets. i386/i686 is already documented elsewhere as an out-of-tree/untested target family (no other file in the tree references it), so this closes a known-incomplete fix rather than introducing new target support.