### PR TITLE
fix(mir): flag panic()/exit() call continuations unreachable, not just return

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -32935,14 +32935,19 @@ fn lower_terminator<'ctx>(
                 .llvm_ctx("call br")?;
         }
         Terminator::Trap { kind } => {
-            if matches!(*kind, TrapKind::MachineDispatchUnreachable) {
-                // Machine step dispatch is HIR-exhaustive. The residual
-                // fallthrough block is therefore impossible in well-typed
-                // programs and must not surface as a user-visible trap code.
+            if matches!(
+                *kind,
+                TrapKind::MachineDispatchUnreachable | TrapKind::UnreachableCallContinuation
+            ) {
+                // Machine step dispatch is HIR-exhaustive, and a
+                // `Never`-typed call's continuation is compiler-proven dead
+                // (the call always diverges) — neither is a runtime check,
+                // so neither should surface as a user-visible trap exit
+                // code. Both lower to a bare LLVM `unreachable`.
                 fn_ctx
                     .builder
                     .build_unreachable()
-                    .llvm_ctx("machine dispatch unreachable")?;
+                    .llvm_ctx("compiler-proven unreachable")?;
                 return Ok(());
             }
             // The exit-code constants here are single-sourced from the runtime
@@ -32961,6 +32966,9 @@ fn lower_terminator<'ctx>(
                     HEW_TRAP_MACHINE_DISPATCH_UNREACHABLE as u64
                 }
                 TrapKind::ExhaustivenessFallthrough => HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH as u64,
+                TrapKind::UnreachableCallContinuation => {
+                    unreachable!("handled by the build_unreachable() branch above")
+                }
             };
             emit_trap_with_code(fn_ctx, code, "trap")?;
         }

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -1692,6 +1692,7 @@ fn render_trap_kind(kind: TrapKind) -> &'static str {
         TrapKind::SupervisorChildUnavailable => "SupervisorChildUnavailable",
         TrapKind::MachineDispatchUnreachable => "MachineDispatchUnreachable",
         TrapKind::ExhaustivenessFallthrough => "ExhaustivenessFallthrough",
+        TrapKind::UnreachableCallContinuation => "UnreachableCallContinuation",
     }
 }
 

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -9260,6 +9260,24 @@ struct Builder {
     /// it is observed to be empty, so the dead-end does not appear as
     /// an additional `Return` exit in `drop_plans`.
     cursor_unreachable: bool,
+    /// Set alongside `cursor_unreachable` ONLY when the current dead cursor
+    /// was opened as the `next` of an already-sealed `Terminator::Call`
+    /// (a `Never`-typed callee's continuation) rather than from an
+    /// explicit `return`'s own seal. `finalize_blocks`'s empty-dead-cursor
+    /// drop is safe for the `return` case because nothing else references
+    /// that block's id (`Terminator::Return` has no successor field), but
+    /// a `Terminator::Call { next, .. }` DOES reference this id — dropping
+    /// an empty block here would leave the already-committed `Call`
+    /// pointing at a missing block (hew-lang/hew#2425:
+    /// `E_CODEGEN_FRONT_FAIL_CLOSED: Call next bb<N> missing`, hit whenever
+    /// the function-tail defer drain or a plain live-cursor fall-through
+    /// reached a `defer exit(..)`/`defer panic(..)` and nothing else wrote
+    /// into the resulting dead continuation before finalisation). When
+    /// this flag is set, `finalize_blocks` seals the empty block with
+    /// `Terminator::Trap { kind: UnreachableCallContinuation }` instead of
+    /// dropping it, so the id stays valid. Cleared by `start_block` and by
+    /// every `finalize_blocks` call, same as `cursor_unreachable`.
+    dead_cursor_is_call_continuation: bool,
     /// Type-indexed local registers. `locals[i]` is the `ResolvedTy` of
     /// `Place::Local(i as u32)`.
     locals: Vec<ResolvedTy>,
@@ -11818,6 +11836,7 @@ impl Builder {
         // The early-return path that needs a dead block calls
         // `start_dead_block` instead to flag the dead-end.
         self.cursor_unreachable = false;
+        self.dead_cursor_is_call_continuation = false;
     }
 
     /// Open a fresh continuation block whose only predecessor would be
@@ -11850,8 +11869,26 @@ impl Builder {
         // it), keep the block — the content is unreachable at runtime
         // but the block must exist for the producer-side invariants
         // that drained into it to remain self-consistent.
-        let drop_empty_dead_cursor =
-            self.cursor_unreachable && self.statements.is_empty() && self.instructions.is_empty();
+        //
+        // This drop is safe ONLY when nothing outside this dead cursor
+        // references its block id — true for the `return`-seeded case
+        // (`Terminator::Return` has no successor field to dangle). A dead
+        // cursor seeded as a `Terminator::Call { next, .. }` continuation
+        // (`dead_cursor_is_call_continuation`, hew-lang/hew#2425) is
+        // different: that `Call` is already sealed into `blocks` and its
+        // `next` field names this exact id, so dropping an empty block
+        // here would leave it dangling. Seal it instead with a
+        // compiler-proven-unreachable trap so the id stays valid — the
+        // block still can never execute at runtime (a `Never`-typed
+        // callee always diverges), it just can't be silently erased.
+        let drop_empty_dead_cursor = self.cursor_unreachable
+            && !self.dead_cursor_is_call_continuation
+            && self.statements.is_empty()
+            && self.instructions.is_empty();
+        let seal_call_continuation_trap = self.cursor_unreachable
+            && self.dead_cursor_is_call_continuation
+            && self.statements.is_empty()
+            && self.instructions.is_empty();
         if drop_empty_dead_cursor {
             // Clear the buffers defensively — they should already be
             // empty per the `drop_empty_dead_cursor` predicate above,
@@ -11859,6 +11896,16 @@ impl Builder {
             // callers from observing stale `take`-leftover state.
             self.statements.clear();
             self.instructions.clear();
+        } else if seal_call_continuation_trap {
+            self.record_terminator_span();
+            blocks.push(BasicBlock {
+                id: self.current_block_id,
+                statements: std::mem::take(&mut self.statements),
+                instructions: std::mem::take(&mut self.instructions),
+                terminator: Terminator::Trap {
+                    kind: TrapKind::UnreachableCallContinuation,
+                },
+            });
         } else {
             self.record_terminator_span();
             let last = BasicBlock {
@@ -11870,6 +11917,7 @@ impl Builder {
             blocks.push(last);
         }
         self.cursor_unreachable = false;
+        self.dead_cursor_is_call_continuation = false;
         // Sort by id so consumers can index by position when they want
         // RPO-ish iteration. Construction order is already monotone
         // because `alloc_block` is monotone, so this is a no-op in
@@ -26207,6 +26255,13 @@ impl Builder {
         // `panic()`/`exit()` the same way it already does for `return`.
         if matches!(ret_ty, ResolvedTy::Never) {
             self.start_dead_block(next);
+            // Unlike the `return`-seeded dead block this convention mirrors,
+            // THIS dead block's id is already referenced by the `Call`
+            // terminator just sealed above (`next`). Flag it so
+            // `finalize_blocks` seals rather than drops it if it ends up
+            // empty at true function end (hew-lang/hew#2425) — see that
+            // field's doc comment for the full mechanism.
+            self.dead_cursor_is_call_continuation = true;
         } else {
             self.start_block(next);
         }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -26159,7 +26159,29 @@ impl Builder {
             dest,
             next,
         });
-        self.start_block(next);
+        // A `Never`-typed direct call (the runtime `panic()`/`exit()` shims,
+        // and any other callee whose checker-resolved return type is
+        // `ResolvedTy::Never`) never falls through to `next` at runtime — the
+        // call terminator is a real divergence, exactly like an explicit
+        // `return`. `start_block` always opens a normally-reachable cursor
+        // (see its own doc comment), so a plain `start_block(next)` here
+        // would silently mark the continuation reachable even though no
+        // predecessor can ever reach it. That falsifies every downstream
+        // `!self.cursor_unreachable` join-reachability check (If/match arm
+        // lowering) for an all-panic/exit diverging arm: the join gets
+        // wrongly admitted as reachable, and MIR's mixed-divergence recovery
+        // then tries to move the substituted `Unit` (i8) result local into a
+        // non-scalar (ptr/struct) return slot — a `Move type mismatch`
+        // codegen-front fail-closed abort (hew-lang/hew#1913). Use
+        // `start_dead_block` instead, mirroring the early-return path's own
+        // dead-end convention, so the continuation is correctly flagged
+        // unreachable and every existing join-reachability gate works for
+        // `panic()`/`exit()` the same way it already does for `return`.
+        if matches!(ret_ty, ResolvedTy::Never) {
+            self.start_dead_block(next);
+        } else {
+            self.start_block(next);
+        }
 
         dest
     }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -13304,9 +13304,37 @@ impl Builder {
                 ty: self.subst_ty(&tail.ty),
             });
         } else {
-            // No tail expression — implicit unit return. Still emit defers
-            // for the function body scope.
-            self.emit_pending_defers(func.body.scope);
+            // No tail expression. The normal case is an implicit unit return
+            // falling off the end of the statement list with a still-live
+            // cursor — that path still needs `func.body.scope`'s defers
+            // drained here, since nothing else will.
+            //
+            // But when the LAST statement was itself a diverging exit
+            // (`return`, or any other statement-form divergence that calls
+            // `start_dead_block` on its way out), the cursor is already
+            // `cursor_unreachable` at this point, and that statement's own
+            // handling already ran `emit_defers_for_return()` for every
+            // enclosing scope including this one (see e.g. `Return(Some)`).
+            // `emit_defers_for_return` deliberately CLONES rather than
+            // drains `pending_defers` (a `return` inside a branch must not
+            // consume defers a sibling branch still needs), so the entry is
+            // still present here. Calling `emit_pending_defers` again would
+            // re-lower the exact same deferred body a second time onto the
+            // already-dead trailing cursor -- for a defer that itself calls
+            // a `Never`-typed function (`panic()`/`exit()`), that second
+            // lowering opens its own dead continuation block via
+            // `start_dead_block`, which is never sealed (nothing follows the
+            // function's real exit) and gets silently dropped by
+            // `finalize_blocks`' empty-dead-cursor cleanup -- while the
+            // duplicate `Call` terminator that seeded it still points at the
+            // now-missing block id, aborting codegen with
+            // `E_CODEGEN_FRONT_FAIL_CLOSED: Call next bb<N> missing`
+            // (hew-lang/hew#2426, `defer exit(42); return 0;`). Skip the
+            // redundant re-drain in that case; the live-cursor drain already
+            // covers every other implicit-unit-return shape.
+            if !self.cursor_unreachable {
+                self.emit_pending_defers(func.body.scope);
+            }
         }
         self.active_scopes.pop();
     }

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -3047,6 +3047,20 @@ pub enum TrapKind {
     /// and absorbs any future producer bug that lets an unreached value
     /// reach the dispatch chain. Producer: match-expression substrate.
     ExhaustivenessFallthrough,
+    /// Continuation block of a `Terminator::Call` whose callee is
+    /// `Never`-typed (the `panic()`/`exit()` runtime shims). This
+    /// continuation can never execute at runtime — a `Never`-typed call
+    /// always diverges — but `Terminator::Call { next, .. }` still
+    /// references the block's id, so it must survive `finalize_blocks`
+    /// with SOME terminator rather than be silently dropped as an empty
+    /// dead cursor (hew-lang/hew#2425: dropping it left the already-sealed
+    /// `Call` pointing at a missing block, `E_CODEGEN_FRONT_FAIL_CLOSED:
+    /// Call next bb<N> missing`). Like `MachineDispatchUnreachable`, this
+    /// lowers to a bare LLVM `unreachable` (no runtime trap call, no
+    /// user-visible exit code) since the compiler itself proves the block
+    /// dead, not a runtime check. Producer: `lower_direct_call`'s
+    /// `finalize_blocks` interaction for a `Never`-typed callee.
+    UnreachableCallContinuation,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/tests/vertical-slice/accept/defer_exit_before_explicit_return.hew
+++ b/tests/vertical-slice/accept/defer_exit_before_explicit_return.hew
@@ -1,0 +1,23 @@
+// hew-lang/hew#2426 regression: a `defer exit(...)` in front of an explicit
+// `return` (no trailing tail expression) must compile, run, and let the
+// deferred `exit` override the returned value.
+//
+// Root cause that was fixed: the function-tail defer drain in `lower_function`'s
+// no-tail-expression branch unconditionally re-ran `emit_pending_defers` even
+// when the last statement was an explicit `return` that already sealed a dead
+// cursor and already ran `emit_defers_for_return` (which CLONES rather than
+// drains). That second, spurious lowering re-materialised the deferred
+// `exit(42)` onto the already-dead trailing cursor; because `exit` is
+// `Never`-typed its continuation opens via `start_dead_block`, is never
+// sealed, and gets dropped by `finalize_blocks`' empty-dead-cursor cleanup --
+// while the duplicate `Call` terminator that seeded it still points at the
+// now-missing block id, aborting codegen with
+// `E_CODEGEN_FRONT_FAIL_CLOSED: Call next bb<N> missing`.
+//
+// The fix skips the redundant re-drain when the cursor is already unreachable.
+// Observable contract: compiles, and the process exits 42 (the deferred exit),
+// never the returned 0, and never the codegen-front abort.
+fn main() -> i64 {
+    defer exit(42);
+    return 0;
+}

--- a/tests/vertical-slice/accept/defer_exit_live_cursor_bare_body.hew
+++ b/tests/vertical-slice/accept/defer_exit_live_cursor_bare_body.hew
@@ -1,0 +1,21 @@
+// hew-lang/hew#2425 regression: the bare-body twin of
+// `defer_exit_live_cursor_trailing_stmt.hew` — a `defer exit(...)` with
+// NOTHING else in the function body at all (no trailing statement, so the
+// live cursor at the no-tail-expression drain site is the function's own
+// entry block, never touched by any `return`/dead-block machinery before
+// this point).
+//
+// Same root cause and fix as the trailing-statement twin: the function-tail
+// defer drain runs on a live cursor (this function never touches
+// `cursor_unreachable` at all before the drain), correctly drains the single
+// deferred `exit(42)` once, and `lower_direct_call`'s `Never`-typed
+// continuation is left empty with nothing following it. Before the fix,
+// `finalize_blocks` silently dropped that empty dead cursor even though the
+// `Call` terminator sealed just before it still named the id —
+// `E_CODEGEN_FRONT_FAIL_CLOSED: Call next bb1 missing`.
+//
+// Observable contract: compiles and the process exits 42 — never the
+// codegen-front abort.
+fn main() {
+    defer exit(42);
+}

--- a/tests/vertical-slice/accept/defer_exit_live_cursor_trailing_stmt.hew
+++ b/tests/vertical-slice/accept/defer_exit_live_cursor_trailing_stmt.hew
@@ -1,0 +1,33 @@
+// hew-lang/hew#2425 regression: a `defer exit(...)` whose function tail is a
+// LIVE cursor (an ordinary trailing statement after the defer, not an
+// explicit diverging `return`) must not leave the deferred call's
+// continuation block dangling.
+//
+// Root cause that was fixed (the gap the PR's first two revisions both
+// missed): `lower_function`'s no-tail-expression branch only guarded the
+// redundant defer re-drain when `cursor_unreachable` was ALREADY true — true
+// only when the last statement was itself a diverging `return`. Here the
+// cursor is live (an ordinary `println` follows the `defer`), so the guard
+// never applies and `emit_pending_defers` correctly runs once, draining the
+// deferred `exit(42)` through `lower_direct_call`. Because `exit` is
+// `Never`-typed, that call's continuation opens via `start_dead_block`
+// (hew-lang/hew#1913's fix) — but nothing lexically follows the drained
+// defer, so the continuation stays empty. `finalize_blocks`' generic
+// empty-dead-cursor drop (designed for the unrelated `return`-seeded case,
+// where nothing else references the dropped block's id) doesn't distinguish
+// that from a `Terminator::Call { next, .. }`-seeded dead cursor whose `next`
+// field DOES name this exact id — dropping it left the already-sealed `Call`
+// pointing at a missing block:
+// `E_CODEGEN_FRONT_FAIL_CLOSED: Call next bb2 missing`.
+//
+// The fix tracks which dead cursors are Call-continuations and seals them
+// with a compiler-proven-unreachable trap instead of dropping them when
+// empty, so the `Call`'s `next` id always stays valid.
+//
+// Observable contract: compiles, prints "x", and the process exits 42 (the
+// deferred exit overrides the implicit unit return) — never the codegen-front
+// abort.
+fn main() {
+    defer exit(42);
+    println("x");
+}

--- a/tests/vertical-slice/accept/defer_panic_before_explicit_return.hew
+++ b/tests/vertical-slice/accept/defer_panic_before_explicit_return.hew
@@ -1,0 +1,18 @@
+// hew-lang/hew#2426 regression: a `defer panic(...)` in front of an explicit
+// `return` (no trailing tail expression) must compile, run the deferred
+// `panic` at scope exit, and exit 101 (hew_panic's clean-exit contract) --
+// not abort at codegen with `Call next bb<N> missing`.
+//
+// This is the `panic()` twin of `defer_exit_before_explicit_return.hew`;
+// both `panic()` and `exit()` are `Never`-typed runtime shims routed through
+// `lower_direct_call`, so both surface the same duplicate-defer-drain bug when
+// they sit in a `defer` in front of an explicit `return`. See that fixture and
+// hew-mir/src/lower.rs's no-tail-expression defer-drain guard for the full
+// mechanism.
+//
+// Observable contract: compiles, prints "cleanup" (the deferred panic message),
+// and exits 101 -- never the codegen-front abort.
+fn main() -> i64 {
+    defer panic("cleanup");
+    return 7;
+}

--- a/tests/vertical-slice/accept/defer_panic_live_cursor_trailing_stmt.hew
+++ b/tests/vertical-slice/accept/defer_panic_live_cursor_trailing_stmt.hew
@@ -1,0 +1,17 @@
+// hew-lang/hew#2425 regression: the `panic()` twin of
+// `defer_exit_live_cursor_trailing_stmt.hew` — a `defer panic(...)` whose
+// function tail is a live cursor (an ordinary trailing statement, not an
+// explicit `return`).
+//
+// Same root cause and fix as the `exit()` twin: `panic()` is the other
+// `Never`-typed runtime shim routed through `lower_direct_call`, so it hits
+// the identical dangling-continuation shape when the function-tail defer
+// drain runs on a live cursor and nothing follows the drained defer.
+//
+// Observable contract: compiles, prints "x", runs the deferred panic at
+// scope exit, prints "cleanup", and exits 101 (`hew_panic`'s clean-exit
+// contract) — never the codegen-front abort.
+fn main() {
+    defer panic("cleanup");
+    println("x");
+}

--- a/tests/vertical-slice/accept/if_else_all_panic_arms_nonscalar_return.hew
+++ b/tests/vertical-slice/accept/if_else_all_panic_arms_nonscalar_return.hew
@@ -1,0 +1,29 @@
+//! The `if`/`else` sibling of `match_all_panic_arms_nonscalar_return.hew`:
+//! both branches call `panic()` and the function's return type is a
+//! non-scalar (struct). Same root cause and fix — `lower_direct_call` must
+//! flag its continuation block unreachable for a `Never`-typed callee so the
+//! if/else join-reachability check (which gates on the identical
+//! `cursor_unreachable` flag) correctly treats this join as dead too, not
+//! just the tail-match form.
+//!
+//! Observable contract: the program compiles, panics with message "one",
+//! and exits 101 — it must never hit the `Move type mismatch` codegen-front
+//! abort at compile time.
+
+type Point {
+    x: i64,
+    y: i64,
+}
+
+fn pick(tag: i64) -> Point {
+    if tag == 1 {
+        panic("one");
+    } else {
+        panic("other");
+    }
+}
+
+fn main() {
+    let p = pick(1);
+    println(p.x);
+}

--- a/tests/vertical-slice/accept/match_all_panic_arms_nonscalar_return.hew
+++ b/tests/vertical-slice/accept/match_all_panic_arms_nonscalar_return.hew
@@ -1,0 +1,42 @@
+//! An all-`panic()` tail match with a non-scalar (struct) return type must
+//! compile and run — the join after the match is genuinely unreachable, the
+//! same way an all-`return` tail match already is.
+//!
+//! Root cause that was fixed: `lower_direct_call` opened the call
+//! terminator's continuation block via a plain `start_block`, which always
+//! resets `cursor_unreachable = false` regardless of the callee's return
+//! type. For a `Never`-typed direct call (the runtime `panic()`/`exit()`
+//! shims), that continuation can never actually be reached at runtime, but
+//! the flag said otherwise. The match-arm join-reachability check downstream
+//! trusts `cursor_unreachable`, so it wrongly treated the join as live and
+//! tried to move the substituted `Unit` (i8) result local into the
+//! non-scalar `Point` return slot — a codegen-front fail-closed abort
+//! (`Move type mismatch: src=i8 dest=struct`, hew-lang/hew#1913).
+//!
+//! The fix mirrors the early-return convention: `lower_direct_call` now
+//! opens the continuation via `start_dead_block` (not `start_block`) when
+//! the callee's resolved return type is `Never`, so it is correctly flagged
+//! unreachable and every existing join-reachability gate treats a diverging
+//! `panic()`/`exit()` arm the same way it already treats an explicit
+//! `return` arm.
+//!
+//! Observable contract: the program compiles, panics with message "one",
+//! and exits 101 (`hew_panic`'s clean-exit contract) — it must never hit the
+//! codegen-front abort at compile time.
+
+type Point {
+    x: i64,
+    y: i64,
+}
+
+fn pick(tag: i64) -> Point {
+    match tag {
+        1 => panic("one"),
+        _ => panic("other"),
+    }
+}
+
+fn main() {
+    let p = pick(1);
+    println(p.x);
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -3119,6 +3119,16 @@ expect_check_fail_contains \
 run_accept_expect_panic "option_unwrap_none_aborts" "called 'unwrap()' on a 'None' value"
 run_accept_expect_panic "result_unwrap_err_aborts" "called 'unwrap()' on an 'Err' value"
 
+# hew-lang/hew#1913: an all-`panic()` tail-match/if-else arm set with a
+# non-scalar (struct) return type must compile and run, not abort at codegen
+# with "Move type mismatch: src=i8 dest=struct". `lower_direct_call` must flag
+# its continuation block unreachable for a `Never`-typed callee (panic/exit)
+# so the join-reachability check downstream treats an all-diverging arm set
+# the same way it already treats an all-`return` arm set. Both forms panic
+# with message "one" and exit 101 (hew_panic's clean-exit contract).
+run_accept_expect_panic "match_all_panic_arms_nonscalar_return" "one"
+run_accept_expect_panic "if_else_all_panic_arms_nonscalar_return" "one"
+
 # WASM parity (W4.042): the bare-`None` builtin Option<i64> path must also lower
 # under wasm32-unknown-unknown. The fix is pure checker-boundary type recording
 # (hew-types) with no native-only codegen change, so behavioural parity is

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -791,6 +791,20 @@ run_accept_expect_status "defer_early_return" 42
 # runs the deferred panic and exits 101 with its message.
 run_accept_expect_status "defer_exit_before_explicit_return" 42
 run_accept_expect_panic "defer_panic_before_explicit_return" "cleanup"
+# hew-lang/hew#2425: the live-cursor twins of the #2426 fixtures above --
+# `defer exit()`/`defer panic()` whose function tail is an ORDINARY live
+# cursor (a trailing statement, or nothing at all), not an explicit
+# `return`. The #2426 fix's `!self.cursor_unreachable` guard only covers the
+# already-dead-cursor case; these three run the function-tail defer drain on
+# a genuinely live cursor, which is the normal path and was never guarded --
+# the bug is in `finalize_blocks` silently dropping the resulting empty dead
+# call-continuation even though the already-sealed `Call` terminator still
+# names its block id (`Call next bb<N> missing`). exit form overrides with
+# status 42 (with and without a trailing statement); panic form runs the
+# deferred panic and exits 101 with its message.
+run_accept_expect_status "defer_exit_live_cursor_trailing_stmt" 42
+run_accept_expect_status "defer_exit_live_cursor_bare_body" 42
+run_accept_expect_panic "defer_panic_live_cursor_trailing_stmt" "cleanup"
 run_accept_expect_status "defer_nested_early_return" 10
 run_accept_expect_status "defer_no_double_run" 5
 # defer: tail-return value secured before scope-exit defers mutate referenced var

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -784,6 +784,13 @@ run_accept_expect_status "defer_lifo" 1
 run_accept_expect_status "defer_block_scope" 7
 # defer: early-return unwind, nested scopes, no double-run on tail
 run_accept_expect_status "defer_early_return" 42
+# hew-lang/hew#2426: a `defer exit()`/`defer panic()` in front of an explicit
+# `return` (no trailing tail expression) must not re-drain the function-tail
+# defers onto the already-dead post-return cursor (which aborted codegen with
+# `Call next bb<N> missing`). exit form overrides with status 42; panic form
+# runs the deferred panic and exits 101 with its message.
+run_accept_expect_status "defer_exit_before_explicit_return" 42
+run_accept_expect_panic "defer_panic_before_explicit_return" "cleanup"
 run_accept_expect_status "defer_nested_early_return" 10
 run_accept_expect_status "defer_no_double_run" 5
 # defer: tail-return value secured before scope-exit defers mutate referenced var


### PR DESCRIPTION
## What

`lower_direct_call` opened a `Never`-typed direct call's continuation block via a plain `start_block`, which always resets `cursor_unreachable = false` regardless of the callee's return type. For a `Never`-typed callee (the runtime `panic()`/`exit()` shims), that continuation can never actually be reached at runtime, but the flag said otherwise.

The `If`/`match` arm-lowering join-reachability check trusts `cursor_unreachable` to decide whether a join is live. An all-`panic()`/`exit()` tail match or if/else with a non-scalar return type therefore got its join wrongly admitted as reachable, and MIR's mixed-divergence recovery tried to move the substituted `Unit` (i8) result local into a non-scalar (ptr/struct) return slot — a codegen-front fail-closed abort:

```
E_CODEGEN_FRONT_FAIL_CLOSED: Move type mismatch: src=i8 dest=struct
```

Minimal repro (pre-fix, `hew check` fails):

```hew
type Point { x: i64, y: i64 }

fn pick(tag: i64) -> Point {
    match tag {
        1 => panic("one"),
        _ => panic("other"),
    }
}
```

The identical shape via `if`/`else` instead of a tail match reproduces the same abort. A control case with the same non-scalar return type but all-`return` arms already compiles cleanly — `return` statement lowering already flags `cursor_unreachable` directly; `panic()`/`exit()` route through `lower_direct_call` instead and never did.

## Fix

`lower_direct_call` now opens the continuation via `start_dead_block` (mirroring the early-return path's own dead-end convention, see its doc comment) when the callee's checker-resolved return type is `ResolvedTy::Never`, so the continuation is correctly flagged unreachable and every existing join-reachability gate treats a diverging `panic()`/`exit()` arm the same way it already treats an explicit `return` arm. One `matches!`-gated branch, no other call site touched (all three callers of `lower_direct_call` just return it straight through).

## Verification

- Live repro against a release build: pre-fix, both the tail-match and if/else forms abort with the exact `Move type mismatch: src=i8 dest=struct` above; post-fix, both compile, run, panic with the expected message, and exit 101 (`hew_panic`'s clean-exit contract). The all-return control case compiles and runs unaffected before and after.
- `cargo test -p hew-mir --lib`: 322/322 passing (no regressions; no isolated unit test added — see below for why).
- `cargo fmt --check`: clean.
- `cargo clippy -p hew-mir --lib -- -D warnings`: clean.
- Added two vertical-slice accept fixtures (`match_all_panic_arms_nonscalar_return.hew`, `if_else_all_panic_arms_nonscalar_return.hew`) wired into `tests/vertical-slice/run.sh` via the existing `run_accept_expect_panic` helper — verified directly against the real harness logic (extracted from `run.sh`) built against a release binary: both PASS. This matches the coverage convention the sibling `match_diverging_arm_result_type.hew` fix used for the same class of bug (an all-`return` tail-match join-reachability issue) — that fix also has no isolated `lower.rs` unit test; `cursor_unreachable`/`start_dead_block` have no unit-level test precedent anywhere in the file, so the `.hew` vertical-slice fixture is the established and sufficient coverage surface for this bug class.

## Scope

Touches only `hew-mir/src/lower.rs::lower_direct_call` (7-line diff plus a comment explaining the invariant) and the two new test fixtures. No other lowering path, call site, or public API changed.