### PR TITLE
fix(hir): resolve protocol descriptors for file-imported actors

### DIFF
--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -140,6 +140,7 @@ pub(crate) fn mir_diagnostic_prefix(kind: &hew_mir::MirDiagnosticKind) -> &'stat
         | hew_mir::MirDiagnosticKind::StaticDispatchMonomorphisationMissing { .. }
         | hew_mir::MirDiagnosticKind::TraitObjectStorageUndetermined { .. }
         | hew_mir::MirDiagnosticKind::CallTraitMethodSignatureUnresolved { .. }
+        | hew_mir::MirDiagnosticKind::ActorProtocolDescriptorMissing { .. }
         | hew_mir::MirDiagnosticKind::ClosureCapturesDuplexHandle { .. } => "E_MIR",
     }
 }
@@ -564,6 +565,9 @@ fn mir_kind_name(kind: &hew_mir::MirDiagnosticKind) -> &'static str {
         hew_mir::MirDiagnosticKind::MailboxOverflowCoalesceNotYetImplemented { .. } => {
             "MailboxOverflowCoalesceNotYetImplemented"
         }
+        hew_mir::MirDiagnosticKind::ActorProtocolDescriptorMissing { .. } => {
+            "ActorProtocolDescriptorMissing"
+        }
         hew_mir::MirDiagnosticKind::UnresolvedStaticDispatchSubstitution { .. } => {
             "UnresolvedStaticDispatchSubstitution"
         }
@@ -644,6 +648,7 @@ fn mir_primary_site(kind: &hew_mir::MirDiagnosticKind) -> Option<hew_hir::SiteId
         | hew_mir::MirDiagnosticKind::ActorHandlerSymbolCollision { .. }
         | hew_mir::MirDiagnosticKind::ActorStateCloneClassificationFailed { .. }
         | hew_mir::MirDiagnosticKind::OwnedHandleAggregateExtractionUnsupported { .. }
+        | hew_mir::MirDiagnosticKind::ActorProtocolDescriptorMissing { .. }
         | hew_mir::MirDiagnosticKind::MailboxOverflowCoalesceNotYetImplemented { .. } => None,
     }
 }
@@ -740,6 +745,14 @@ fn mir_diagnostic_message(diagnostic: &hew_mir::MirDiagnostic) -> String {
             "actor `{actor}` declares `overflow coalesce({key_field})`, which is not yet \
              implemented — the coalesce key-function ABI slice does not exist in codegen; \
              use `drop_new`, `drop_old`, `block`, or `fail` instead"
+        ),
+        hew_mir::MirDiagnosticKind::ActorProtocolDescriptorMissing {
+            actor,
+            handler_count,
+        } => format!(
+            "actor `{actor}` declares {handler_count} `receive fn` handler(s) but no \
+             protocol descriptor was attached during lowering, so message-kind \
+             discriminants cannot be assigned"
         ),
         hew_mir::MirDiagnosticKind::UnresolvedStaticDispatchSubstitution {
             receiver_type_param,
@@ -889,6 +902,7 @@ fn mir_context_notes(diagnostic: &hew_mir::MirDiagnostic) -> Vec<String> {
         | hew_mir::MirDiagnosticKind::UnknownActorStateField { .. }
         | hew_mir::MirDiagnosticKind::ActorHandlerSymbolCollision { .. }
         | hew_mir::MirDiagnosticKind::TraitObjectStorageUndetermined { .. }
+        | hew_mir::MirDiagnosticKind::ActorProtocolDescriptorMissing { .. }
         | hew_mir::MirDiagnosticKind::CallTraitMethodSignatureUnresolved { .. } => {}
         hew_mir::MirDiagnosticKind::OwnedHandleAggregateExtractionUnsupported {
             handle_ty, ..

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -10682,6 +10682,39 @@ impl LowerCtx {
 
         let (methods, lifecycle_hooks) = self.partition_actor_methods(&decl.methods, &state_fields);
 
+        // Checker side-tables key a module actor under its module-short
+        // identity (`"{module_leaf}.{Actor}"`, matching the checker's
+        // `current_module_short()` fn_sigs prefix); only genuine root actors
+        // are keyed bare. A FILE-imported actor lowers through this root path
+        // — `flatten_file_import_items` (hew-compile) splices it into
+        // `program.items` AFTER type-checking, so its HIR identity stays
+        // root/bare — but the checker validated it as a module-graph item and
+        // published its protocol descriptor under the module-short key. The
+        // third pass sets `current_module_name` to the originating module's
+        // dotted path for spliced items (root items lower with it unset), so
+        // resolve the descriptor and the cycle-capability flag under the
+        // module-short key first and fall back to the bare root key. Without
+        // the module-scoped lookup every spliced multi-handler actor lost its
+        // descriptor and MIR collapsed all message-kind discriminants to the
+        // i32::MAX sentinel — LLVM rejected the dispatch switch with
+        // "Duplicate integer as switch case". Package-module actors overwrite
+        // both fields in `lower_imported_actor` with the same qualified keys,
+        // so this lookup is identity-preserving for them.
+        let module_scoped_key = self
+            .current_module_name
+            .as_deref()
+            .and_then(|module| module.rsplit('.').next())
+            .map(|leaf| format!("{leaf}.{}", decl.name));
+        let protocol_descriptor = module_scoped_key
+            .as_deref()
+            .and_then(|key| self.actor_protocol_descriptors.get(key))
+            .or_else(|| self.actor_protocol_descriptors.get(&decl.name))
+            .cloned();
+        let cycle_capable = module_scoped_key
+            .as_deref()
+            .is_some_and(|key| self.cycle_capable_actors.contains(key))
+            || self.cycle_capable_actors.contains(&decl.name);
+
         HirActorDecl {
             id: self.ids.item(),
             node: self.ids.node(),
@@ -10699,8 +10732,8 @@ impl LowerCtx {
             is_isolated: decl.is_isolated,
             mailbox_capacity: decl.mailbox_capacity,
             overflow_policy: decl.overflow_policy.clone(),
-            cycle_capable: self.cycle_capable_actors.contains(&decl.name),
-            protocol_descriptor: self.actor_protocol_descriptors.get(&decl.name).cloned(),
+            cycle_capable,
+            protocol_descriptor,
             span,
         }
     }

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -1526,6 +1526,10 @@ fn render_diag_kind(kind: &MirDiagnosticKind) -> String {
         MirDiagnosticKind::MailboxOverflowCoalesceNotYetImplemented { actor, key_field } => {
             format!("MailboxOverflowCoalesceNotYetImplemented {actor} key_field={key_field}")
         }
+        MirDiagnosticKind::ActorProtocolDescriptorMissing {
+            actor,
+            handler_count,
+        } => format!("ActorProtocolDescriptorMissing {actor} handler_count={handler_count}"),
         MirDiagnosticKind::UnresolvedStaticDispatchSubstitution {
             receiver_type_param,
             declaring_trait,

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -1795,6 +1795,30 @@ pub fn lower_hir_module_with_facts(
                 ),
             });
         }
+        // Fail closed when receive handlers exist but no protocol descriptor
+        // was attached: `lower_actor_handler_layouts` would fall back to the
+        // `i32::MAX` sentinel for EVERY handler — a duplicate-switch-case
+        // LLVM verify reject at two-plus handlers, and silent wire-protocol
+        // corruption (wrong discriminant, in-process-only dispatch) at
+        // exactly one. A known handler must never ride the sentinel; the
+        // sentinel rows below exist only to keep the MIR shape well-formed
+        // behind this hard error.
+        if !actor.receive_handlers.is_empty() && actor.protocol_descriptor.is_none() {
+            diagnostics.push(crate::model::MirDiagnostic {
+                kind: crate::model::MirDiagnosticKind::ActorProtocolDescriptorMissing {
+                    actor: actor.qualified_name(),
+                    handler_count: actor.receive_handlers.len(),
+                },
+                note: format!(
+                    "actor `{}` declares {} `receive fn` handler(s) but carries no \
+                     protocol descriptor; message-kind discriminants cannot be \
+                     assigned, so lowering refuses instead of emitting the \
+                     unknown-message sentinel for known handlers",
+                    actor.qualified_name(),
+                    actor.receive_handlers.len()
+                ),
+            });
+        }
         actor_layouts.push(crate::model::ActorLayout {
             // The registry key is the actor's qualified identity: dotted
             // `module.Name` for module actors, bare for root actors. It
@@ -5445,12 +5469,13 @@ fn lower_supervisor_bootstrap(
 ///
 /// Fail-closed: an actor that carries `receive_handlers` but no descriptor
 /// (the checker emitted an `ActorProtocolCollision` and refused to publish
-/// the protocol, or an upstream bug) falls back to `i32::MAX`. The
-/// upstream collision diagnostic is the user-facing error; the sentinel
-/// here exists only to keep the MIR shape well-formed for the few internal
-/// callers (e.g. `lower_program_smoke`) that exercise lowering on
-/// descriptor-less inputs. Production builds never observe it because the
-/// checker rejects collision-bearing programs before MIR runs.
+/// the protocol, a lowering path failed to attach the checker's descriptor,
+/// or an upstream bug) falls back to `i32::MAX` here — but the layout pass
+/// pairs that fallback with a hard `ActorProtocolDescriptorMissing`
+/// diagnostic (see the guard before the `ActorLayout` push in
+/// `lower_hir_module`), so no compiled program ever dispatches on the
+/// sentinel. The sentinel rows exist only to keep the MIR shape well-formed
+/// behind that hard error.
 fn lower_actor_handler_layouts(actor: &HirActorDecl) -> Vec<ActorHandlerLayout> {
     let descriptor = actor.protocol_descriptor.as_ref();
     let mut layouts = Vec::with_capacity(actor.receive_handlers.len());

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -6121,6 +6121,19 @@ pub enum MirDiagnosticKind {
     /// this fence closes — so lowering fails closed here with an honest NYI
     /// diagnostic instead of a silent remap to another policy.
     MailboxOverflowCoalesceNotYetImplemented { actor: String, key_field: String },
+    /// An actor reached MIR layout lowering with `receive fn` handlers but no
+    /// protocol descriptor, so no handler can be assigned its real
+    /// message-kind discriminant. Emitting the `i32::MAX` sentinel instead
+    /// collapses every handler onto one tag: with two or more handlers LLVM
+    /// rejects the dispatch switch ("Duplicate integer as switch case"), and
+    /// with exactly one the program compiles but carries a wrong wire
+    /// discriminant — silent protocol corruption. Fail closed here; the
+    /// sentinel rows exist only to keep the MIR shape well-formed behind this
+    /// hard error. Reachable when a lowering path fails to attach the
+    /// checker's descriptor (the checker's own `ActorProtocolCollision`
+    /// reject empties the descriptor too, but that path already carries its
+    /// user-facing diagnostic).
+    ActorProtocolDescriptorMissing { actor: String, handler_count: usize },
     /// W3.022 V10: A `CallTraitMethodStatic` reached MIR with no concrete
     /// substitution for its `receiver_type_param`. After Stage 3 (impl-level
     /// type params flow into `HirFn::type_params`), unspecialised generic

--- a/hew-mir/tests/actor/actor_handler_lowering.rs
+++ b/hew-mir/tests/actor/actor_handler_lowering.rs
@@ -394,6 +394,37 @@ fn root_actor_layout_carries_no_defining_module() {
     assert_eq!(pipeline.actor_layouts[0].defining_module, None);
 }
 
+/// An actor with `receive fn` handlers but no protocol descriptor must be
+/// refused at layout lowering. The alternative — emitting the `i32::MAX`
+/// unknown-message sentinel for every handler — is a duplicate-switch-case
+/// LLVM verify reject at two-plus handlers and a silent wire-discriminant
+/// corruption at exactly one, so lowering fails closed instead.
+#[test]
+fn missing_protocol_descriptor_with_handlers_fails_closed() {
+    let mut ids = IdGen::default();
+    let bump_body = block(&mut ids, vec![], None, ResolvedTy::Unit);
+    let mut counter = actor(
+        &mut ids,
+        "Counter",
+        vec![receive("bump", false, vec![], ResolvedTy::Unit, bump_body)],
+    );
+    counter.protocol_descriptor = None;
+
+    let pipeline = lower_hir_module(&empty_module(vec![HirItem::Actor(counter)]));
+
+    assert!(
+        pipeline.diagnostics.iter().any(|d| matches!(
+            &d.kind,
+            MirDiagnosticKind::ActorProtocolDescriptorMissing {
+                actor,
+                handler_count,
+            } if actor == "Counter" && *handler_count == 1
+        )),
+        "descriptor-less actor with handlers must fail closed: {:?}",
+        pipeline.diagnostics
+    );
+}
+
 #[test]
 fn supervisor_child_layout_mirrors_cycle_capable_actor_metadata() {
     let mut ids = IdGen::default();

--- a/tests/vertical-slice/accept/imported_actor_msg_discriminants.expected
+++ b/tests/vertical-slice/accept/imported_actor_msg_discriminants.expected
@@ -1,0 +1,3 @@
+add=5
+scale=20
+read=0

--- a/tests/vertical-slice/accept/imported_actor_msg_discriminants.hew
+++ b/tests/vertical-slice/accept/imported_actor_msg_discriminants.hew
@@ -1,0 +1,25 @@
+// Regression: an actor with multiple receive handlers, imported via a file
+// import, collapsed every handler's message-kind discriminant to the i32::MAX
+// unknown-message sentinel — LLVM verify rejected the module with
+// "Duplicate integer as switch case". Each handler must keep its distinct
+// discriminant AND dispatch correctly: a tag mismatch between the send side
+// and the dispatch side is silent message loss, worse than the verify failure,
+// so every handler is exercised with an exact-value round trip.
+import "imported_actor_msg_discriminants_lib.hew";
+
+fn main() {
+    let reg = spawn Register(total: 0);
+    match await reg.add(5) {
+        Ok(v) => println(f"add={v}"),
+        Err(_) => println("add failed"),
+    }
+    match await reg.scale(4) {
+        Ok(v) => println(f"scale={v}"),
+        Err(_) => println("scale failed"),
+    }
+    reg.reset();
+    match await reg.read() {
+        Ok(v) => println(f"read={v}"),
+        Err(_) => println("read failed"),
+    }
+}

--- a/tests/vertical-slice/accept/imported_actor_msg_discriminants_lib.hew
+++ b/tests/vertical-slice/accept/imported_actor_msg_discriminants_lib.hew
@@ -1,0 +1,25 @@
+// Multi-handler actor consumed via a file import. Guards imported-actor
+// message-kind discriminant assignment: every receive handler must carry its
+// own hash-derived discriminant when the actor lowers from a spliced
+// file-import module, and dispatch must route each message to its handler.
+pub actor Register {
+    var total: i64 = 0;
+
+    receive fn add(n: i64) -> i64 {
+        total = total + n;
+        total
+    }
+
+    receive fn scale(n: i64) -> i64 {
+        total = total * n;
+        total
+    }
+
+    receive fn reset() {
+        total = 0;
+    }
+
+    receive fn read() -> i64 {
+        total
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -3951,6 +3951,18 @@ grep -q 'guarded record/tuple match destructure' "${reject_output}"
 # or weak linkage!".
 run_check_run_expect_stdout file_import_trait_impl
 
+# Regression: a file-imported multi-handler actor keeps a DISTINCT message-kind
+# discriminant per receive handler. The spliced file-import lowering path
+# previously missed the checker's protocol descriptor (keyed by module-short
+# identity, looked up bare), collapsing every handler to the i32::MAX
+# unknown-message sentinel — LLVM verification failed with "Duplicate integer
+# as switch case" at two-plus handlers, and a single handler compiled with a
+# corrupt wire discriminant. The fixture round-trips every handler (two asks,
+# one fire-and-forget, one ask observing its effect) with exact values, so it
+# also guards send-side/dispatch-side tag agreement (a mismatch is silent
+# message loss, not a compile failure).
+run_check_run_expect_stdout imported_actor_msg_discriminants
+
 # `.clone()` on a Copy type (i64, bool): emits a StyleSuggestion warning but
 # compiles and runs correctly — the value is duplicated as-if by plain copy.
 run_accept_expect_stdout copy_clone_warn


### PR DESCRIPTION
## Summary

File-imported actors are spliced into the program after type-checking and lowered through the root pass, but the protocol-descriptor lookup there used the actor's bare name while the checker keys descriptors module-scoped. Every handler on such an actor therefore rode the unknown-message sentinel: with two or more handlers the dispatch switch had duplicate cases and the build failed LLVM verification ("Duplicate integer as switch case"), and with exactly one handler the program compiled but silently carried the wrong wire discriminant. HIR lowering now threads the defining module through the spliced-item pass so the lookup uses the same module-scoped key, and MIR fails closed with a new `ActorProtocolDescriptorMissing` diagnostic when a descriptor is genuinely missing instead of emitting the sentinel.

## Verification

- New compiled two-module vertical-slice fixture (`imported_actor_msg_discriminants`) exercises a message round-trip per handler with exact-value assertions; it fails LLVM verification before the fix and passes after.
- Checked the emitted IR for a file-imported actor: the send site, dispatch switch, handler registration, and both codec registrations all carry the same hash-derived tag.
- `make test-lane CRATE=hew-hir`: 500 passed
- `make test-lane CRATE=hew-mir`: 890 passed, including the new fail-closed descriptor-miss unit test
- `bash tests/vertical-slice/run.sh`: all pass, including `imported_actor_msg_discriminants`
- `make lint`: clean
- `cargo fmt --check`: clean

## Out of scope

- Two file-imported modules sharing a short name are already rejected before lowering by `check_duplicate_short_module_names`; that pre-existing guard is what keeps the module-scoped descriptor key unambiguous, and it is untouched here.
- Package-module actor lowering (`lower_imported_actor`) is unchanged; the existing actor-identity tests in hew-types cover that path.

Fixes #2417