### PR TITLE
fix(mir): gate var overwrite release on RHS alias freedom

### DIFF
--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -13896,6 +13896,23 @@ impl Builder {
                 ..
             } => {
                 if let Some(dest) = self.binding_locals.get(binding).copied() {
+                    // #2420 -- the overwrite release below is sound ONLY when
+                    // the incoming value cannot alias the outgoing value's
+                    // heap. An RHS that reads the reassigned binding (`s =
+                    // grow(s)`, `s = S { n: s.n + 1, v: s.v }`) can hand back
+                    // an UN-RETAINED alias of the old value's owned fields:
+                    // by-value heap params are BORROWS and a non-`string`
+                    // owned field load is a raw pointer copy, so releasing the
+                    // old value here frees storage the incoming value still
+                    // references -- use-after-free on the next field use and a
+                    // double-free at the next release. When the RHS may alias,
+                    // skip the release on BOTH the static and the flag-gated
+                    // paths: fail-open (leak) is this seam's documented
+                    // posture, matching the scope-exit exclusion
+                    // (`derive_owned_record_drop_allowed`) for the identical
+                    // aliasing channel. WHEN-OBSOLETE: the COW retain-on-share
+                    // spine (every share retained => release always sound).
+                    let rhs_may_alias_old = self.reassign_rhs_may_alias_binding(value, *binding);
                     // #53 / #2301: release the prior heap-owning value before
                     // the slot is overwritten.
                     if let Some(flag) = self.overwrite_guard_flags.get(binding).copied() {
@@ -13908,7 +13925,9 @@ impl Builder {
                         // `flag = 1` to hand the value to its new owner. Reset to
                         // 0 after the store so the fresh value is released on the
                         // next overwrite.
-                        self.emit_flag_gated_overwrite_release(dest, &target.ty, flag);
+                        if !rhs_may_alias_old {
+                            self.emit_flag_gated_overwrite_release(dest, &target.ty, flag);
+                        }
                         self.push_instr(Instr::Move { dest, src });
                         self.push_instr(Instr::ConstI64 {
                             dest: flag,
@@ -13921,9 +13940,12 @@ impl Builder {
                         // consumed it (dispositioned off the scope-exit set by
                         // `mark_binding_moved`, so absent from the live view),
                         // so this is skipped and never double-frees.
-                        if self.owned_locals.iter().any(|entry| {
-                            &entry.binding == binding && entry.disposition == Disposition::ScopeExit
-                        }) {
+                        if !rhs_may_alias_old
+                            && self.owned_locals.iter().any(|entry| {
+                                &entry.binding == binding
+                                    && entry.disposition == Disposition::ScopeExit
+                            })
+                        {
                             self.emit_local_overwrite_release(dest, &target.ty);
                         }
                         self.push_instr(Instr::Move { dest, src });
@@ -19451,6 +19473,172 @@ impl Builder {
                 }
             })
             .collect()
+    }
+
+    /// #2420 -- may the value of `expr`, used as the RHS of `binding = expr`,
+    /// embed an UN-RETAINED alias of `binding`'s old owned heap?
+    ///
+    /// The overwrite release (`emit_local_overwrite_release`) frees the old
+    /// value's owned fields in place before the store. That is sound only when
+    /// the incoming value cannot reference the same heap. Two shapes break it,
+    /// both rooted in the RHS reading the reassigned binding:
+    ///
+    /// - `s = grow(s)` -- a by-value heap param is a BORROW (LESSONS
+    ///   `by-value-heap-params-are-borrows`), and the callee's non-`string`
+    ///   owned field load (`S { v: s.v }`) is a raw pointer copy with no
+    ///   retain, so the returned value aliases the caller's old heap;
+    /// - `s = S { n: s.n + 1, v: s.v }` -- the caller-side literal embeds the
+    ///   projection directly.
+    ///
+    /// Fail-closed allowlist mirroring `return_value_may_alias_borrow`, with
+    /// the leaf parameterised to "a read of `binding`" instead of "any
+    /// parameter": wrappers recurse all reachable values, constructions
+    /// recurse operands, a call may alias iff its callee is not
+    /// summary-proven fresh (`funcupdate_fn_returns_fresh`) AND some argument
+    /// may alias, projections recurse their object chain, and every unmodelled
+    /// form answers `true`. Two deliberate refinements:
+    ///
+    /// - TYPE CUT: a value whose type has no un-retained owned leaf
+    ///   (`ty_has_unretained_owned_leaf`) can never alias the released
+    ///   storage -- `s.n + 1` (`BitCopy`) and string-only records (every
+    ///   `string` aggregate load is retained `+1`) keep today's exact
+    ///   release/free balance.
+    /// - A bare read of a DIFFERENT binding answers `false` (release fires,
+    ///   preserving the `s = s2` rebind free). An intra-function alias built
+    ///   through another local (`let t = S { v: s.v }; s = t`) is a
+    ///   PRE-EXISTING hole of the projection-alias machinery, not widened
+    ///   here; closing it needs binding-level alias provenance.
+    ///   WHEN-OBSOLETE: the COW retain-on-share spine retires this predicate
+    ///   entirely (every share retained => the release is always sound).
+    fn reassign_rhs_may_alias_binding(&self, expr: &HirExpr, binding: BindingId) -> bool {
+        // A value that cannot carry an un-retained owned leaf cannot alias the
+        // storage the overwrite release frees.
+        if !self.ty_has_unretained_owned_leaf(&expr.ty) {
+            return false;
+        }
+        match &expr.kind {
+            // Value-passthrough wrappers: aliasing iff ANY reachable value
+            // aliases. A missing tail/else cannot produce the owned value in
+            // the first place, but stay fail-closed to mirror the summary walk.
+            HirExprKind::Block(block) => block
+                .tail
+                .as_deref()
+                .is_none_or(|t| self.reassign_rhs_may_alias_binding(t, binding)),
+            HirExprKind::If {
+                then_expr,
+                else_expr,
+                ..
+            } => {
+                self.reassign_rhs_may_alias_binding(then_expr, binding)
+                    || else_expr
+                        .as_deref()
+                        .is_none_or(|e| self.reassign_rhs_may_alias_binding(e, binding))
+            }
+            HirExprKind::Match { arms, .. } => {
+                arms.is_empty()
+                    || arms
+                        .iter()
+                        .any(|arm| self.reassign_rhs_may_alias_binding(&arm.body, binding))
+            }
+            HirExprKind::Return { value } => value
+                .as_deref()
+                .is_none_or(|v| self.reassign_rhs_may_alias_binding(v, binding)),
+            // Fresh leaves: a `.clone()` is a deep copy; a `Vec<T>` element
+            // load / slice is an independent element (push-clone + refcount);
+            // a literal owns nothing borrowed.
+            HirExprKind::RecordCloneCall { .. }
+            | HirExprKind::Index { .. }
+            | HirExprKind::Slice { .. }
+            | HirExprKind::Literal(_) => false,
+            // Constructions alias iff an operand does.
+            HirExprKind::StructInit { fields, base, .. } => {
+                fields
+                    .iter()
+                    .any(|(_, v)| self.reassign_rhs_may_alias_binding(v, binding))
+                    || base
+                        .as_deref()
+                        .is_some_and(|b| self.reassign_rhs_may_alias_binding(b, binding))
+            }
+            HirExprKind::TupleLiteral { elements } => elements
+                .iter()
+                .any(|e| self.reassign_rhs_may_alias_binding(e, binding)),
+            HirExprKind::MachineVariantCtor { payload, .. } => {
+                payload.as_ref().is_some_and(|fields| {
+                    fields
+                        .iter()
+                        .any(|(_, v)| self.reassign_rhs_may_alias_binding(v, binding))
+                })
+            }
+            // A call's result may alias `binding` iff the callee is not
+            // statically resolvable (closure / fn-pointer -- a hidden capture
+            // can smuggle the binding), or it is not summary-proven to return
+            // a fresh owner AND some argument itself may alias (the callee can
+            // forward that argument's heap into its return).
+            HirExprKind::Call { callee, args } => {
+                !callee_is_resolved_item(callee)
+                    || (!callee_returns_fresh_owner(callee, &self.funcupdate_fn_returns_fresh)
+                        && args
+                            .iter()
+                            .any(|a| self.reassign_rhs_may_alias_binding(a, binding)))
+            }
+            // A projection aliases iff its object chain reaches the binding.
+            HirExprKind::FieldAccess { object, .. } => {
+                self.reassign_rhs_may_alias_binding(object, binding)
+            }
+            HirExprKind::TupleIndex { tuple, .. } => {
+                self.reassign_rhs_may_alias_binding(tuple, binding)
+            }
+            // THE leaf: a read of the reassigned binding itself. A different
+            // binding or an Item/Const ref is not the old value (see the doc
+            // note on the pre-existing local-launder hole).
+            HirExprKind::BindingRef { resolved, .. } => {
+                matches!(resolved, ResolvedRef::Binding(id) if *id == binding)
+            }
+            // Method calls (can return borrowed `self`), derefs, operators
+            // over owned values, and every future form: fail closed.
+            _ => true,
+        }
+    }
+
+    /// True when `ty` transitively contains an owned heap leaf that aggregate
+    /// loads share WITHOUT a retain -- the alias channel the overwrite release
+    /// must respect (#2420).
+    ///
+    /// `string` is NOT such a leaf: every `string` aggregate field/element
+    /// load is retained `+1` in codegen (`retain_string_field_load`), so a
+    /// shared string never dangles when the old owner is released. `BitCopy`
+    /// types own no heap. Everything else that owns heap -- Vec / `HashMap` /
+    /// `HashSet` / Generator / bytes, enums with owned payloads, and any
+    /// unmodelled owner -- is a raw-shared leaf; user records and tuples
+    /// recurse their fields (value-recursive records are impossible by
+    /// construction, so the recursion terminates).
+    fn ty_has_unretained_owned_leaf(&self, ty: &ResolvedTy) -> bool {
+        let ty = self.subst_ty(ty);
+        if !crate::model::ty_owns_heap_mir(&ty, &self.record_field_orders, &self.enum_layouts) {
+            return false;
+        }
+        match &ty {
+            ResolvedTy::String => false,
+            ResolvedTy::Tuple(items) => items
+                .iter()
+                .any(|item| self.ty_has_unretained_owned_leaf(item)),
+            _ => {
+                if let Some(key) = user_record_layout_key(&ty) {
+                    if let Some(field_order) = self.lookup_record_field_order(&key) {
+                        // Clone the field types out so the `&self` borrow is
+                        // released before the recursive calls.
+                        let field_tys: Vec<ResolvedTy> =
+                            field_order.iter().map(|(_, fty)| fty.clone()).collect();
+                        return field_tys
+                            .iter()
+                            .any(|fty| self.ty_has_unretained_owned_leaf(fty));
+                    }
+                }
+                // Vec / HashMap / HashSet / Generator / bytes, owned-payload
+                // enums, unregistered records, opaque owners: fail closed.
+                true
+            }
+        }
     }
 
     /// Release the heap-owning OLD value of a `var`-local slot before a

--- a/tests/hew/var_record_reassign_ownership_test.hew
+++ b/tests/hew/var_record_reassign_ownership_test.hew
@@ -1,0 +1,141 @@
+//! Regression pins for #2420: reassigning a `var` record with a Vec field
+//! from a value that aliases the old one (`var s = mk(); s = grow(s)`).
+//!
+//! A by-value heap param is a borrow, and a non-string owned field load is a
+//! raw pointer copy — so `grow`'s returned record aliases the caller's old
+//! Vec. The #53 overwrite release at the reassignment then freed that Vec
+//! under the incoming owner: use-after-free on the next push, double free at
+//! the next release, or a silently wrong len. The release is now gated on the
+//! RHS being alias-free of the reassigned binding; these pins assert exact
+//! values (not just lengths) so an allocator-interleaving corruption cannot
+//! read as green.
+
+import std::testing;
+
+type S {
+    n: i64;
+    v: Vec<i64>;
+}
+
+type Pair {
+    n: i64;
+    a: Vec<i64>;
+    b: Vec<i64>;
+}
+
+fn mk() -> S {
+    S { n: 0, v: Vec::new() }
+}
+
+fn grow(s: S) -> S {
+    s.v.push(s.n);
+    S { n: s.n + 1, v: s.v }
+}
+
+fn mk_pair() -> Pair {
+    Pair { n: 0, a: Vec::new(), b: Vec::new() }
+}
+
+fn grow_pair(p: Pair) -> Pair {
+    p.a.push(p.n);
+    p.b.push(p.n * 10);
+    Pair { n: p.n + 1, a: p.a, b: p.b }
+}
+
+fn refresh(s: S) -> S {
+    mk()
+}
+
+// The issue #2420 repro: two reassignments through an alias-carrying callee.
+#[test]
+fn test_var_reassign_through_aliasing_fn_is_exact() {
+    var s = mk();
+    s = grow(s);
+    s = grow(s);
+    testing.assert_eq(s.n, 2);
+    testing.assert_eq(s.v.len(), 2);
+    testing.assert_eq(s.v[0], 0);
+    testing.assert_eq(s.v[1], 1);
+}
+
+// The accumulator idiom under repeated reassignment: every element must be
+// present and exact after 12 round trips.
+#[test]
+fn test_loop_reassignment_accumulates_exact_elements() {
+    var s = mk();
+    for i in 0..12 {
+        s = grow(s);
+    }
+    testing.assert_eq(s.n, 12);
+    testing.assert_eq(s.v.len(), 12);
+    testing.assert_eq(s.v[0], 0);
+    testing.assert_eq(s.v[6], 6);
+    testing.assert_eq(s.v[11], 11);
+}
+
+// Two owned Vec fields moved through the same call: both must survive the
+// reassignment release independently.
+#[test]
+fn test_two_vec_record_reassignment_is_exact() {
+    var p = mk_pair();
+    p = grow_pair(p);
+    p = grow_pair(p);
+    p = grow_pair(p);
+    testing.assert_eq(p.n, 3);
+    testing.assert_eq(p.a.len(), 3);
+    testing.assert_eq(p.b.len(), 3);
+    testing.assert_eq(p.a[0], 0);
+    testing.assert_eq(p.a[2], 2);
+    testing.assert_eq(p.b[0], 0);
+    testing.assert_eq(p.b[2], 20);
+}
+
+// A callee whose return is a proven-fresh record keeps the overwrite release:
+// the old value is freed exactly once and the fresh value is independent.
+#[test]
+fn test_reassignment_from_fresh_returning_fn_resets() {
+    var s = mk();
+    s = grow(s);
+    s = refresh(s);
+    testing.assert_eq(s.n, 0);
+    testing.assert_eq(s.v.len(), 0);
+    s = grow(s);
+    testing.assert_eq(s.n, 1);
+    testing.assert_eq(s.v.len(), 1);
+    testing.assert_eq(s.v[0], 0);
+}
+
+// Conditional reassignment: the maybe-reassigned join must be exact on both
+// the taken and the not-taken path.
+#[test]
+fn test_conditional_reassignment_join_is_exact() {
+    var taken = mk();
+    var skipped = mk();
+    let hot = true;
+    let cold = false;
+    if hot {
+        taken = grow(taken);
+    }
+    if cold {
+        skipped = grow(skipped);
+    }
+    testing.assert_eq(taken.n, 1);
+    testing.assert_eq(taken.v.len(), 1);
+    testing.assert_eq(taken.v[0], 0);
+    testing.assert_eq(skipped.n, 0);
+    testing.assert_eq(skipped.v.len(), 0);
+}
+
+// The caller-side literal form of the same alias: the RHS embeds a projection
+// of the reassigned binding directly. Crashed deterministically before the
+// release gate.
+#[test]
+fn test_literal_rhs_embedding_own_projection_is_exact() {
+    var s = S { n: 0, v: Vec::new() };
+    s.v.push(7);
+    s = S { n: s.n + 1, v: s.v };
+    s = S { n: s.n + 1, v: s.v };
+    testing.assert_eq(s.n, 2);
+    testing.assert_eq(s.v.len(), 1);
+    testing.assert_eq(s.v[0], 7);
+}

--- a/tests/hew/var_record_reassign_ownership_test.hew
+++ b/tests/hew/var_record_reassign_ownership_test.hew
@@ -139,3 +139,155 @@ fn test_literal_rhs_embedding_own_projection_is_exact() {
     testing.assert_eq(s.v.len(), 1);
     testing.assert_eq(s.v[0], 7);
 }
+
+// ── Actor state channel ─────────────────────────────────────────────────
+//
+// The actor analogue of the same reassignment shape is defended at codegen
+// level, not by the MIR release gate: a record-typed state re-store runs the
+// synthesised collect-neutralise-drop helper
+// (`__hew_record_overwrite_release_<R>`) — old heap leaves that reappear
+// anywhere in the incoming value are nulled before the drop spine, so
+// aliased leaves flow through and replaced leaves free exactly once; a bare
+// collection field rides a pointer-inequality guard. These pins hold that
+// substrate in place: a regression to a blind drop (or a dropped guard)
+// corrupts the accumulator and fails the exact-element asserts below.
+
+type W {
+    a: Vec<i64>;
+    b: Vec<i64>;
+}
+
+fn swap_w(w: W) -> W {
+    W { a: w.b, b: w.a }
+}
+
+fn grow_vec(v: Vec<i64>, x: i64) -> Vec<i64> {
+    v.push(x);
+    v
+}
+
+actor RecAcc {
+    var state: S = S { n: 0, v: Vec::new() };
+
+    receive fn bump() {
+        state = grow(state);
+    }
+
+    receive fn reset() {
+        state = mk();
+    }
+
+    receive fn report() -> i64 {
+        state.n * 1000 + state.v.len()
+    }
+
+    receive fn at(i: i64) -> i64 {
+        state.v[i]
+    }
+}
+
+actor VecAcc {
+    var v: Vec<i64> = Vec::new();
+
+    receive fn bump(x: i64) {
+        v = grow_vec(v, x);
+    }
+
+    receive fn checksum() -> i64 {
+        var sum: i64 = 0;
+        for x in v {
+            sum = sum + x;
+        }
+        sum * 100 + v.len()
+    }
+}
+
+actor Swapper {
+    var w: W = W { a: Vec::new(), b: Vec::new() };
+
+    receive fn seed() {
+        w.a.push(1);
+        w.b.push(2);
+    }
+
+    receive fn flip() {
+        w = swap_w(w);
+    }
+
+    receive fn probe() -> i64 {
+        w.a[0] * 10 + w.b[0]
+    }
+}
+
+// Record state reassigned through the alias-carrying callee, 12 messages:
+// every element must survive every neutralise round-trip exactly.
+#[test]
+fn test_actor_record_state_reassign_accumulates_exact() {
+    let a = spawn RecAcc();
+    for i in 0..12 {
+        a.bump();
+    }
+    match await a.report() {
+        Ok(x) => testing.assert_eq(x, 12012),
+        Err(_) => testing.assert_true(false),
+    }
+    match await a.at(0) {
+        Ok(x) => testing.assert_eq(x, 0),
+        Err(_) => testing.assert_true(false),
+    }
+    match await a.at(11) {
+        Ok(x) => testing.assert_eq(x, 11),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+// The fresh-callee control: a re-store from a fresh value must RELEASE the
+// old state (the runtime neutralise finds no aliases) and the fresh value
+// must grow independently afterwards.
+#[test]
+fn test_actor_record_state_fresh_reset_is_exact() {
+    let a = spawn RecAcc();
+    for i in 0..5 {
+        a.bump();
+    }
+    a.reset();
+    a.bump();
+    match await a.report() {
+        Ok(x) => testing.assert_eq(x, 1001),
+        Err(_) => testing.assert_true(false),
+    }
+    match await a.at(0) {
+        Ok(x) => testing.assert_eq(x, 0),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+// Bare Vec state field reassigned through a callee handing the borrowed
+// handle back: the pointer-inequality guard must not free the flowing handle.
+#[test]
+fn test_actor_vec_state_reassign_accumulates_exact() {
+    let b = spawn VecAcc();
+    for i in 0..12 {
+        b.bump(i);
+    }
+    match await b.checksum() {
+        Ok(x) => testing.assert_eq(x, 6612),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+// In-record cross-field swap through a callee: the neutralise step compares
+// old leaves against ALL collected new slots (not same-position), so a swap
+// must flow both Vecs intact through repeated re-stores.
+#[test]
+fn test_actor_record_state_field_swap_is_exact() {
+    let s = spawn Swapper();
+    s.seed();
+    s.flip();
+    s.flip();
+    s.flip();
+    match await s.probe() {
+        Ok(x) => testing.assert_eq(x, 21),
+        Err(_) => testing.assert_true(false),
+    }
+}


### PR DESCRIPTION
## Summary

Reassigning a `var` record that carries a Vec field with the result of a function that took the old value by move was non-deterministic memory corruption. By-value heap parameters are borrows, and record-literal Vec-field loads do not retain — so the returned record aliased the caller's old field, and the unconditional overwrite release at the reassignment freed the very allocation the new value carried. At base, 30 runs of one repro binary produced 4 correct results, 14 silently wrong, and 12 crashes.

The overwrite release is now gated on a fail-closed may-alias walk of the right-hand side, backed by an interprocedural freshness summary for callee returns. When alias freedom cannot be proven, the release is skipped — a bounded leak, never a wrong free. Fresh-literal and proven-fresh-callee reassignments keep today's exact release, verified in the emitted IR.

## Verification

- Base repro, 30 runs of one binary: 4 correct / 14 silently wrong / 12 crashes; deterministic SIGSEGV under GuardMalloc. Fixed: exact output every run, GuardMalloc ×3 clean.
- Adversarial RHS shapes — conditional, nested call, method call, and cross-module callee — all skip the release (zero release calls at the reassignment site in the emitted IR) and run exact + GuardMalloc ×3 clean.
- Fresh-RHS loop probe: leak count flat across 100/1000/10000 iterations (`leaks --atExit`); the release is correctly retained in the IR when freshness is proven.
- New fixture `tests/hew/var_record_reassign_ownership_test.hew`: six reassignment-ownership pins (0/6 pass at base → 6/6, poisoned-allocator clean) plus four actor-state regression pins documenting that the actor store path's runtime full-set compare is already swap-safe and unaffected.
- `make test-lane CRATE=hew-mir`: 890 passed
- `make test-lane CRATE=hew-codegen-rs`: 538 passed
- `make test-lane CRATE=hew-runtime`: 2484 passed
- `bash tests/vertical-slice/run.sh`: all pass, exit 0
- `make checked-mir-verify`: 39 fixtures × 2 stages byte-identical
- `make lint` and `cargo fmt --check`: clean

All gates re-run after rebasing onto current main.

## Out of scope

- The flow-insensitive arg-passed scope-exit exclusion (#2428).
- The bare-collection state-swap defect on the actor store path (#2432).
- The local-launder shape (`let t = S { v: s.v }; s = t;`) — a pre-existing hole documented in the predicate's doc comment; identical behaviour at base and head.

Fixes #2420