### PR TITLE
fix(mir,codegen): release composite yield values through the in-place drop thunks

### DIFF
--- a/hew-cli/tests/composite_yield_leak_oracle.rs
+++ b/hew-cli/tests/composite_yield_leak_oracle.rs
@@ -1,0 +1,288 @@
+//! Per-yield leak / double-free oracle for owned-composite stream elements:
+//! a `receive gen fn` yielding a record/enum whose fields own heap must free
+//! BOTH per-yield copies exactly once — the pump's producer copy (released on
+//! the stream-send resume edge through the `__hew_record_drop_inplace_<R>` /
+//! `__hew_enum_drop_inplace_<E>` thunk; its abandon-edge twin rides the
+//! suspend plan) and the consumer's fresh decode copy (released at the
+//! consuming body's end through the same thunk).
+//!
+//! ## Ownership shape under test
+//!
+//! The layout-witness send (`encode_elem_envelope`, `LayoutManaged`)
+//! deep-clones the element into the queue envelope — for a `string` field the
+//! clone is a refcount retain, so producer and consumer hold two REFERENCES
+//! to one allocation. Slope 0 therefore requires BOTH releases: either one
+//! alone leaves the node reachable-from-nothing at refcount 1 (the
+//! pre-fix red measured exactly 1 leaked node / 32 B per yield with both
+//! references leaked).
+//!
+//! The failure modes this oracle catches:
+//!   * a LEAK (either side's release missing) — positive per-yield slope;
+//!   * a DOUBLE-FREE (a release reaching the OTHER side's reference, or one
+//!     side releasing twice across the break/body-end edge pair) — an abort
+//!     under the poisoned-allocator triple;
+//!   * an OVER-DROP corrupting a live value — scribbled output / non-zero
+//!     exit (each fixture self-checks its computed total).
+//!
+//! ## Consumer-shape boundary
+//!
+//! The enum SLOPE fixture drains without touching the payload, so the frame
+//! binding's body-end release is the sole consumer-side owner. A consumer
+//! that DESTRUCTURES the payload (`match n { Text(s) => ... }`) moves
+//! ownership out of the frame binding — the body-end release is correctly
+//! suppressed, and releasing the moved-out arm binding per iteration is the
+//! match-arm consume-side discipline, tracked separately from this seam. The
+//! destructuring shape is covered here by a no-double-free scribble pin (its
+//! per-iteration release is the tracked gap; over-releasing it would be the
+//! regression this oracle must catch).
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+// -- fixtures ----------------------------------------------------------------
+
+/// Owned-record yields drained by a `for await` body that reads only the
+/// `BitCopy` field, so the frame binding keeps ownership of the heap `name`
+/// field for its whole iteration and the body-end release is the sole
+/// consumer-side dropper. The heap field is deliberately NOT read in the
+/// slope body: a retained string field read leaves a per-iteration
+/// interpolation/getter temp behind — a pre-existing temp-discipline class
+/// (verified: identical leak signature on the pre-fix baseline) that would
+/// mask this seam's slope. The scribble pin below reads the field instead
+/// (an over-drop there is a poisoned read, not a leak). `main` self-checks
+/// the running total so a scribbled read cannot pass silently.
+fn record_yield_loop_source(frames: usize) -> String {
+    let expected_total = frames * (frames.saturating_sub(1)) / 2;
+    format!(
+        "record Item {{\n\
+         \x20   name: string,\n\
+         \x20   value: i64,\n\
+         }}\n\
+         actor Maker {{\n\
+         \x20   receive gen fn items() -> Item {{\n\
+         \x20       for i in 0..{frames} {{\n\
+         \x20           yield Item {{ name: f\"item-{{i}}\", value: i }};\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   let m = spawn Maker;\n\
+         \x20   for await it in m.items() {{\n\
+         \x20       total = total + it.value;\n\
+         \x20   }}\n\
+         \x20   if total != {expected_total} {{ return 91; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+/// The scribble-pin twin of [`record_yield_loop_source`]: reads the heap
+/// `name` field each iteration (a retained read BEFORE the body-end release),
+/// so an over-eager release — the producer's drop reaching the consumer's
+/// copy, or a premature body-end drop — surfaces as a poisoned read /
+/// self-check failure under the scribbled allocator.
+fn record_yield_field_read_loop_source(frames: usize) -> String {
+    let expected_total = frames * (frames.saturating_sub(1)) / 2;
+    format!(
+        "record Item {{\n\
+         \x20   name: string,\n\
+         \x20   value: i64,\n\
+         }}\n\
+         actor Maker {{\n\
+         \x20   receive gen fn items() -> Item {{\n\
+         \x20       for i in 0..{frames} {{\n\
+         \x20           yield Item {{ name: f\"item-{{i}}\", value: i }};\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   let m = spawn Maker;\n\
+         \x20   for await it in m.items() {{\n\
+         \x20       if it.name.len() < 6 {{ return 93; }}\n\
+         \x20       total = total + it.value;\n\
+         \x20   }}\n\
+         \x20   if total != {expected_total} {{ return 91; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+/// Owned-enum yields (heap `string` payload per frame) drained WITHOUT
+/// touching the payload: the frame binding stays the sole consumer-side
+/// owner, so its body-end enum in-place release must fire per iteration.
+fn enum_yield_drain_loop_source(frames: usize) -> String {
+    format!(
+        "enum Note {{\n\
+         \x20   Text(string);\n\
+         \x20   Number(i64);\n\
+         }}\n\
+         actor Maker {{\n\
+         \x20   receive gen fn notes() -> Note {{\n\
+         \x20       for i in 0..{frames} {{\n\
+         \x20           yield Note::Text(f\"note-{{i}}\");\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var count: i64 = 0;\n\
+         \x20   let m = spawn Maker;\n\
+         \x20   for await n in m.notes() {{\n\
+         \x20       count = count + 1;\n\
+         \x20   }}\n\
+         \x20   if count != {frames} {{ return 92; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+/// Owned-enum yields drained by a DESTRUCTURING consumer: each `Text(s)`
+/// payload moves out of the frame binding into the arm binding, whose length
+/// feeds the self-checked total. The frame binding's body-end release must be
+/// suppressed (ownership left the frame) — over-releasing it would free the
+/// string the arm binding still reads (caught by the poisoned allocator).
+fn enum_yield_destructure_loop_source(frames: usize) -> String {
+    // Every payload is "note-<i>"; len = 5 + digits(i).
+    let expected_total: usize = (0..frames).map(|i| 5 + i.to_string().len()).sum();
+    format!(
+        "enum Note {{\n\
+         \x20   Text(string);\n\
+         \x20   Number(i64);\n\
+         }}\n\
+         actor Maker {{\n\
+         \x20   receive gen fn notes() -> Note {{\n\
+         \x20       for i in 0..{frames} {{\n\
+         \x20           yield Note::Text(f\"note-{{i}}\");\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   let m = spawn Maker;\n\
+         \x20   for await n in m.notes() {{\n\
+         \x20       match n {{\n\
+         \x20           Note::Text(s) => {{ total = total + s.len(); }},\n\
+         \x20           Note::Number(v) => {{ total = total + v; }},\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         \x20   if total != {expected_total} {{ return 94; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+/// Mid-drain `break` on an infinite owned-record stream: the break edge must
+/// release the breaking iteration's record (the break jumps past the body-end
+/// release) and the fall-through iterations must not double-release across
+/// the mutually-exclusive edge pair.
+fn record_yield_break_loop_source(frames: usize) -> String {
+    // Sum of 0..=frames-1 plus the breaking iteration's value (== frames).
+    let expected_total = frames * (frames.saturating_sub(1)) / 2 + frames;
+    format!(
+        "record Item {{\n\
+         \x20   name: string,\n\
+         \x20   value: i64,\n\
+         }}\n\
+         actor Maker {{\n\
+         \x20   receive gen fn items() -> Item {{\n\
+         \x20       var i: i64 = 0;\n\
+         \x20       loop {{\n\
+         \x20           yield Item {{ name: f\"it-{{i}}\", value: i }};\n\
+         \x20           i = i + 1;\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   let m = spawn Maker;\n\
+         \x20   for await it in m.items() {{\n\
+         \x20       total = total + it.value;\n\
+         \x20       if it.value >= {frames} {{\n\
+         \x20           break;\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         \x20   if total != {expected_total} {{ return 95; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+// -- correctness pins --------------------------------------------------------
+
+/// Compile `source`, run under the poisoned-allocator triple, assert clean
+/// exit. A crash is a double-free (one of the per-yield copies released
+/// twice, or a release reaching the other side's reference); a non-zero exit
+/// is a scribbled-read miscompute or the fixture's own self-check failing.
+fn assert_no_double_free(shape_name: &str, source: &str) {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("composite-yield-df-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), shape_name);
+    let output = run_under_malloc_scribble(&bin);
+
+    assert!(
+        output.status.success(),
+        "{shape_name}: a composite yield value must be released exactly once per owning \
+         reference — a crash here is a double-free (the pump and consumer copies share \
+         refcounted field allocations); a non-zero exit is a scribbled-read miscompute or \
+         the fixture's own total check;\n{}",
+        describe_output(&output)
+    );
+}
+
+// -- oracles -----------------------------------------------------------------
+
+/// Slope oracle (record): pump + consumer each release their copy per yield —
+/// flat leak slope. Pre-fix this leaked exactly 1 node / 32 B per yield (the
+/// record's `name` string, both references unreleased).
+#[test]
+fn record_yield_stream_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("record_yield_stream", record_yield_loop_source);
+}
+
+/// Slope oracle (enum, drain consumer): the tag-dispatched enum in-place
+/// release fires on both sides per yield — flat leak slope.
+#[test]
+fn enum_yield_stream_drain_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("enum_yield_stream_drain", enum_yield_drain_loop_source);
+}
+
+/// No-double-free pin (record): 200 yields, retained heap-field reads in the
+/// body — a producer-side release reaching the consumer's copy (or a
+/// premature body-end drop) is a poisoned read here, not a leak.
+#[test]
+fn record_yield_stream_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free("record_yield_df", &record_yield_field_read_loop_source(200));
+}
+
+/// No-double-free pin (enum, destructuring consumer): 200 yields; the
+/// moved-out payload must never be freed by the frame binding's suppressed
+/// body-end release.
+#[test]
+fn enum_yield_destructure_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free(
+        "enum_yield_destructure_df",
+        &enum_yield_destructure_loop_source(200),
+    );
+}
+
+/// No-double-free pin (record, break edge): the break-edge release and the
+/// body-end release are mutually exclusive; 200 fall-through iterations plus
+/// the breaking one must stay exactly-once.
+#[test]
+fn record_yield_break_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free(
+        "record_yield_break_df",
+        &record_yield_break_loop_source(200),
+    );
+}

--- a/hew-cli/tests/fstring_interp_temp_leak_oracle.rs
+++ b/hew-cli/tests/fstring_interp_temp_leak_oracle.rs
@@ -169,7 +169,7 @@ fn fstring_scalar_interp_statement_position_leak_slope_below_tolerance() {
 /// Slope oracle (gen-body): a standalone `gen fn` yielding `f"item-{i}"`
 /// releases the conversion temp every iteration — flat leak slope. Pre-fix
 /// this leaked 1 node/iteration, reproducing with zero receive-gen/actor
-/// surface (string-yield plan E4 control).
+/// surface (the string-yield control shape).
 #[test]
 fn fstring_scalar_interp_gen_yield_leak_slope_below_tolerance() {
     assert_frame_slope_below_tolerance("fstring_scalar_gen", fstring_gen_yield_interp_loop_source);

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -9691,8 +9691,8 @@ fn struct_abi_size(ty: StructType<'_>, target_data: Option<&TargetData>) -> u64 
 
 /// Synthesise per-actor `__hew_state_clone_<Actor>` / `__hew_state_drop_<Actor>`
 /// AND per-record `__hew_record_{clone_inplace,drop_inplace}_<Record>`
-/// bodies for every classified actor in `actor_layouts` plus the Lane-A
-/// direct-string user-record slice. Called from
+/// bodies for every classified actor in `actor_layouts` plus the
+/// let-bound direct-string user-record set. Called from
 /// `build_module_for_target` BEFORE supervisor bootstrap emission so the
 /// `get_function`-or-declare-extern lookup at Stage 2's spawn/supervisor
 /// sites resolves to a real `define` rather than the linker-failure
@@ -12310,7 +12310,7 @@ fn collect_vec_owned_element_seeds(
                 // witness's thunk pointers dangle at llvm-verify for any
                 // heap-payload enum element reachable only through a
                 // channel (string-bearing records were masked by the
-                // Lane-A direct-string record seed). Carrier names may be
+                // direct-string record seed). Carrier names may be
                 // module-qualified (`channel.Receiver`) — compare short.
                 if name == "Vec" || matches!(short_name(name), "Sender" | "Receiver" | "Stream") {
                     if let Some(elem) = args.first() {
@@ -12371,7 +12371,7 @@ fn collect_vec_owned_element_seeds(
 }
 
 /// Compute the transitive set of user records AND user enums reachable
-/// through any classified actor's state fields, plus monomorphic Lane-A
+/// through any classified actor's state fields, plus monomorphic
 /// direct-string records (and, recursively, through nested record fields and
 /// enum payload fields for the actor-state route). Records and enums can
 /// reference one another (e.g. a record field of enum type, or an enum payload

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -1008,7 +1008,13 @@ fn wasm_excluded_drop_symbol(spec: &hew_mir::DropFnSpec) -> Option<String> {
             | D::LambdaActorHandleClose
             | D::CancellationTokenRelease => None,
         },
-        hew_mir::DropFnSpec::Release(_) | hew_mir::DropFnSpec::UserClose(_) => None,
+        // `Release` symbols come from the closed cow-heap set (none
+        // duplex-backed), `InPlace` resolves to a synthesised per-type thunk
+        // (pure generated IR), and `UserClose` bodies are pure Hew code — all
+        // three compile on wasm32.
+        hew_mir::DropFnSpec::Release(_)
+        | hew_mir::DropFnSpec::InPlace(_)
+        | hew_mir::DropFnSpec::UserClose(_) => None,
     }
 }
 
@@ -11919,6 +11925,92 @@ fn collect_closure_capture_drop_seeds(
                         &mut record_seeds,
                         &mut enum_seeds,
                     );
+                }
+            }
+        }
+    }
+    (record_seeds, enum_seeds)
+}
+
+/// Collect the record/enum layout keys of every inline composite yield-value
+/// release (`Instr::Drop { drop_fn: Some(DropFnSpec::InPlace(_)) }`) in raw
+/// MIR so the `__hew_{record,enum}_drop_inplace_<key>` body is synthesised
+/// before the drop call resolves it. Returns `(record_seeds, enum_seeds)`.
+///
+/// Belt-and-suspenders: every composite that flows through the pump /
+/// for-await seam is ALSO referenced by its stream layout witness
+/// (`owned_elem_layout_descriptor_ptr`) or generator out-slot drop thunk,
+/// whose emission seeds the same bodies — but that coupling is structural,
+/// not enforced. Seeding the drop sites directly keeps the inline release
+/// resolvable even for a shape whose witness emission is skipped or
+/// reordered, at the cost of one raw-MIR walk. Resolution mirrors
+/// `collect_record_inplace_drop_seeds` / `collect_enum_inplace_drop_seeds`
+/// (full name, short name, and mangled generic forms against the registered
+/// layouts) so seed and consumer resolve the same key.
+fn collect_inline_inplace_drop_seeds(
+    raw_mir: &[RawMirFunction],
+    record_layouts: &[RecordLayout],
+    enum_layouts: &[EnumLayout],
+) -> (Vec<String>, Vec<String>) {
+    let mut record_seeds: Vec<String> = Vec::new();
+    let mut enum_seeds: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<(bool, String)> = std::collections::HashSet::new();
+    for func in raw_mir {
+        for block in &func.blocks {
+            for instr in &block.instructions {
+                let Instr::Drop {
+                    ty,
+                    drop_fn: Some(hew_mir::DropFnSpec::InPlace(kind)),
+                    ..
+                } = instr
+                else {
+                    continue;
+                };
+                let ResolvedTy::Named { name, args, .. } = ty else {
+                    continue;
+                };
+                let short = short_name(name);
+                let (is_enum, key) = match kind {
+                    hew_mir::InPlaceReleaseKind::Record => {
+                        let key = if args.is_empty() {
+                            record_layouts
+                                .iter()
+                                .find(|rl| rl.name == *name || short_name(&rl.name) == short)
+                                .map(|rl| rl.name.clone())
+                        } else {
+                            let full_mangled = mangle_with_shortened_args(name, args);
+                            let short_mangled = mangle_with_shortened_args(short, args);
+                            record_layouts
+                                .iter()
+                                .find(|rl| rl.name == full_mangled || rl.name == short_mangled)
+                                .map(|rl| rl.name.clone())
+                        };
+                        (false, key)
+                    }
+                    hew_mir::InPlaceReleaseKind::Enum => {
+                        let key = if args.is_empty() {
+                            enum_layouts
+                                .iter()
+                                .find(|el| el.name == *name || short_name(&el.name) == short)
+                                .map(|el| el.name.clone())
+                        } else {
+                            let mangled = mangle_with_shortened_args(short, args);
+                            enum_layouts
+                                .iter()
+                                .find(|el| el.name == mangled || el.name == *name)
+                                .map(|el| el.name.clone())
+                        };
+                        (true, key)
+                    }
+                };
+                if let Some(key) = key {
+                    if seen.insert((is_enum, key.clone())) {
+                        if is_enum {
+                            enum_seeds.push(key);
+                        } else {
+                            record_seeds.push(key);
+                        }
+                    }
                 }
             }
         }
@@ -26116,6 +26208,14 @@ fn resolve_drop_fn<'ctx>(
              the MIR producer mixed the two domains. Refusing to emit \
              (LESSONS: boundary-fail-closed, lifecycle-symmetry)."
         ))),
+        hew_mir::DropFnSpec::InPlace(kind) => Err(CodegenError::FailClosed(format!(
+            "drop_fn=InPlace({kind:?}) reached the close-ritual dispatch; \
+             composite in-place releases are consumed by the inline drop \
+             dispatcher's record/enum thunk arm (`lower_inline_drop`), never \
+             by the runtime/user close split — the MIR producer mixed the two \
+             domains. Refusing to emit \
+             (LESSONS: boundary-fail-closed, lifecycle-symmetry)."
+        ))),
     }
 }
 
@@ -26242,6 +26342,32 @@ fn lower_inline_drop(
              not a known copy-on-write release symbol; refusing to route a heap-owning \
              value through the generic drop dispatcher (LESSONS: boundary-fail-closed)",
         )));
+    }
+    // Composite in-place release (the per-yield record/enum producer/consumer
+    // copy). The helper is derived from `ty` by the SAME resolution the
+    // function-scope `DropKind::RecordInPlace` / `EnumInPlace` plan arms use,
+    // so type↔helper congruence holds by construction — there is no symbol to
+    // cross-check. After the thunk call, typed-zero the slot: unlike a
+    // scope-exit plan drop (slot dead afterwards), an inline yield-value drop's
+    // slot stays live (the pump loop / consuming body reuses it), and the
+    // in-place thunk does not null its fields — the zero-store makes a
+    // structurally-reachable second drop a no-op against the null-tolerant
+    // leaf releases (`raii-null-after-move`, mirroring `lower_drop_user_fn`'s
+    // typed-zero discipline).
+    if let hew_mir::DropFnSpec::InPlace(kind) = drop_fn {
+        match kind {
+            hew_mir::InPlaceReleaseKind::Record => {
+                emit_record_inplace_drop_call(fn_ctx, place, ty)?
+            }
+            hew_mir::InPlaceReleaseKind::Enum => emit_enum_inplace_drop_call(fn_ctx, place, ty)?,
+        }
+        let slot_llvm_ty = resolve_ty(fn_ctx.ctx, ty, fn_ctx.record_layouts)?;
+        let (slot, _) = place_pointer(fn_ctx, place)?;
+        fn_ctx
+            .builder
+            .build_store(slot, slot_llvm_ty.const_zero())
+            .llvm_ctx("inline in-place drop zero-store")?;
+        return Ok(());
     }
     lower_drop(fn_ctx, place, drop_fn)
 }
@@ -27205,6 +27331,83 @@ fn record_inplace_drop_name(ty: &ResolvedTy) -> CodegenResult<String> {
     }
 }
 
+/// Emit the call to `__hew_record_drop_inplace_<R>` for the record at
+/// `place`, resolving the helper name from `ty` (`record_inplace_drop_name`).
+/// The single emission body behind BOTH composite record-drop channels: the
+/// function-scope `DropKind::RecordInPlace` plan arm and the inline
+/// `DropFnSpec::InPlace(Record)` yield-value release — one resolution, one
+/// signature contract, so the two channels cannot drift. Fails closed on a
+/// missing/bodyless helper (the synthesis seeds must cover every dropped
+/// record) and on a non-`void(ptr)` signature.
+fn emit_record_inplace_drop_call(
+    fn_ctx: &FnCtx<'_, '_>,
+    place: Place,
+    ty: &ResolvedTy,
+) -> CodegenResult<()> {
+    let record_name = record_inplace_drop_name(ty)?;
+    let sym = format!("__hew_record_drop_inplace_{record_name}");
+    let helper = fn_ctx.llvm_mod.get_function(&sym).ok_or_else(|| {
+        CodegenError::FailClosed(format!(
+            "record in-place drop @ {place:?} for `{record_name}` has no \
+             synthesized {sym} helper; the drop-synthesis seeds must cover every \
+             dropped record before body lowering"
+        ))
+    })?;
+    if helper.count_basic_blocks() == 0 {
+        return Err(CodegenError::FailClosed(format!(
+            "record in-place drop @ {place:?} for `{record_name}` resolved \
+             {sym}, but it has no body; refusing to emit a dangling helper call"
+        )));
+    }
+    let params = helper.get_type().get_param_types();
+    if params.len() != 1
+        || !matches!(params[0], BasicMetadataTypeEnum::PointerType(_))
+        || helper.get_type().get_return_type().is_some()
+    {
+        return Err(CodegenError::FailClosed(format!(
+            "record in-place drop helper {sym} has malformed signature: expected \
+             void(ptr), got {} params and return {:?}",
+            params.len(),
+            helper.get_type().get_return_type(),
+        )));
+    }
+    let (slot, _) = place_pointer(fn_ctx, place)?;
+    fn_ctx
+        .builder
+        .build_call(helper, &[slot.into()], "record_inplace_drop")
+        .llvm_ctx("record inplace drop call")?;
+    Ok(())
+}
+
+/// Emit the call to `__hew_enum_drop_inplace_<E>` for the enum composite at
+/// `place`, resolving the layout key from `ty`. The single emission body
+/// behind BOTH composite enum-drop channels (the `DropKind::EnumInPlace` plan
+/// arm and the inline `DropFnSpec::InPlace(Enum)` yield-value release). Fails
+/// closed on a bodyless helper — the synthesis seeds must cover every dropped
+/// enum before body lowering.
+fn emit_enum_inplace_drop_call(
+    fn_ctx: &FnCtx<'_, '_>,
+    place: Place,
+    ty: &ResolvedTy,
+) -> CodegenResult<()> {
+    let enum_name = crate::layout::enum_layout_key_for_ty(fn_ctx, ty)?;
+    let helper = get_or_declare_enum_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &enum_name);
+    if helper.count_basic_blocks() == 0 {
+        return Err(CodegenError::FailClosed(format!(
+            "enum in-place drop @ {place:?} for enum `{enum_name}` resolved \
+             `__hew_enum_drop_inplace_{enum_name}`, but it has no body; the \
+             drop-synthesis pass must seed every in-place-dropped enum \
+             before body lowering (LESSONS: boundary-fail-closed)."
+        )));
+    }
+    let (slot, _) = place_pointer(fn_ctx, place)?;
+    fn_ctx
+        .builder
+        .build_call(helper, &[slot.into()], "enum_inplace_drop")
+        .llvm_ctx("enum inplace drop call")?;
+    Ok(())
+}
+
 /// True when `ty` is a non-owning actor-pid leaf (`LocalPid` / `RemotePid`):
 /// an `ActorPid`-family builtin handle whose `close_method()` is `None`.
 ///
@@ -27302,41 +27505,7 @@ fn emit_one_elab_drop_unguarded(fn_ctx: &FnCtx<'_, '_>, drop: &ElabDrop) -> Code
                     df = drop.drop_fn,
                 )));
             }
-            let record_name = record_inplace_drop_name(&drop.ty)?;
-            let sym = format!("__hew_record_drop_inplace_{record_name}");
-            let helper = fn_ctx.llvm_mod.get_function(&sym).ok_or_else(|| {
-                CodegenError::FailClosed(format!(
-                    "RecordInPlace ElabDrop @ {place:?} for `{record_name}` has no \
-                     synthesized {sym} helper; owned-string-record codegen must pre-seed direct \
-                     string records before body lowering",
-                    place = drop.place,
-                ))
-            })?;
-            if helper.count_basic_blocks() == 0 {
-                return Err(CodegenError::FailClosed(format!(
-                    "RecordInPlace ElabDrop @ {place:?} for `{record_name}` resolved \
-                     {sym}, but it has no body; refusing to emit a dangling helper call",
-                    place = drop.place,
-                )));
-            }
-            let params = helper.get_type().get_param_types();
-            if params.len() != 1
-                || !matches!(params[0], BasicMetadataTypeEnum::PointerType(_))
-                || helper.get_type().get_return_type().is_some()
-            {
-                return Err(CodegenError::FailClosed(format!(
-                    "RecordInPlace helper {sym} has malformed signature: expected \
-                     void(ptr), got {} params and return {:?}",
-                    params.len(),
-                    helper.get_type().get_return_type(),
-                )));
-            }
-            let (slot, _) = place_pointer(fn_ctx, drop.place)?;
-            fn_ctx
-                .builder
-                .build_call(helper, &[slot.into()], "record_inplace_drop")
-                .llvm_ctx("record inplace drop call")?;
-            Ok(())
+            emit_record_inplace_drop_call(fn_ctx, drop.place, &drop.ty)
         }
         // W5.020 — heap-owning enum composite (`Result<T, string>` /
         // `Option<string>` / user enum with an owned-payload variant) carried
@@ -27363,26 +27532,7 @@ fn emit_one_elab_drop_unguarded(fn_ctx: &FnCtx<'_, '_>, drop: &ElabDrop) -> Code
                     df = drop.drop_fn,
                 )));
             }
-            let enum_name = crate::layout::enum_layout_key_for_ty(fn_ctx, &drop.ty)?;
-            // The helper body is synthesised by `emit_state_clone_drop_synthesis`
-            // (seeded with every `EnumInPlace`-dropped enum). A declaration with
-            // no body would link-fail; refuse to emit a dangling call.
-            let helper = get_or_declare_enum_drop_inplace(fn_ctx.ctx, fn_ctx.llvm_mod, &enum_name);
-            if helper.count_basic_blocks() == 0 {
-                return Err(CodegenError::FailClosed(format!(
-                    "EnumInPlace ElabDrop @ {place:?} for enum `{enum_name}` resolved \
-                     `__hew_enum_drop_inplace_{enum_name}`, but it has no body; the \
-                     drop-synthesis pass must seed every EnumInPlace-dropped enum \
-                     before body lowering (LESSONS: boundary-fail-closed).",
-                    place = drop.place,
-                )));
-            }
-            let (slot, _) = place_pointer(fn_ctx, drop.place)?;
-            fn_ctx
-                .builder
-                .build_call(helper, &[slot.into()], "enum_inplace_drop")
-                .llvm_ctx("enum inplace drop call")?;
-            Ok(())
+            emit_enum_inplace_drop_call(fn_ctx, drop.place, &drop.ty)
         }
         // W5.021 — heap-owning tuple by value (the tuple-of-owned-handles drop
         // spine) carried across a function/handler return boundary or held as a
@@ -39674,6 +39824,27 @@ fn build_module_for_target<'ctx>(
     // clone/drop thunk PAIR is synthesised together (the enum twin of the
     // record clone-site seed loop directly above).
     for seed in collect_enum_clone_inplace_seeds(&pipeline.raw_mir, &pipeline.enum_layouts) {
+        if !enum_inplace_drop_seeds.contains(&seed) {
+            enum_inplace_drop_seeds.push(seed);
+        }
+    }
+    // Inline composite yield-value releases (`DropFnSpec::InPlace` on a raw
+    // `Instr::Drop` — the pump's per-yield producer copy and the for-await
+    // Some-arm consumer copy): seed both channels so the
+    // `__hew_{record,enum}_drop_inplace_<key>` bodies exist before the drop
+    // calls resolve them.
+    let (inline_inplace_record_seeds, inline_inplace_enum_seeds) =
+        collect_inline_inplace_drop_seeds(
+            &pipeline.raw_mir,
+            &pipeline.record_layouts,
+            &synthesis_enum_layouts,
+        );
+    for seed in inline_inplace_record_seeds {
+        if !vec_owned_record_seeds.contains(&seed) {
+            vec_owned_record_seeds.push(seed);
+        }
+    }
+    for seed in inline_inplace_enum_seeds {
         if !enum_inplace_drop_seeds.contains(&seed) {
             enum_inplace_drop_seeds.push(seed);
         }

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -1722,6 +1722,7 @@ fn render_drop_fn_spec(spec: &DropFnSpec) -> String {
     match spec {
         DropFnSpec::Runtime(d) => format!("rt({d:?})"),
         DropFnSpec::Release(sym) => format!("release({sym})"),
+        DropFnSpec::InPlace(kind) => format!("in_place({kind:?})"),
         DropFnSpec::UserClose(sym) => format!("user_close({sym})"),
     }
 }

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -66,9 +66,9 @@ pub use model::{
     ThirFunction, TraitObjectStorage, TrapKind, WitnessOperand,
 };
 pub use ownership::{
-    AbiClass, CowHeapRelease, DropClass, FailClosedReason, HandleRole, HeapLeaf, LayoutClass,
-    OwnershipCtx, OwnershipDecision, PlaceProvenance, Projection, ProvenanceOrigin, ValueOwnership,
-    ValueProvenance,
+    AbiClass, CowHeapRelease, DropClass, FailClosedReason, HandleRole, HeapLeaf,
+    InPlaceReleaseKind, LayoutClass, OwnershipCtx, OwnershipDecision, PlaceProvenance, Projection,
+    ProvenanceOrigin, ValueOwnership, ValueProvenance,
 };
 pub use runtime_symbols::UnknownRuntimeSymbol;
 pub use state_clone::{

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -9396,11 +9396,12 @@ struct Builder {
     /// consuming body finishes lowering.
     /// Per-iteration generator-yielded heap value bindings active during a
     /// consuming body's lowering. Each entry is `(active_scopes_len, Place,
-    /// ResolvedTy, drop_symbol, start_block_id, start_instr_len)`:
+    /// ResolvedTy, drop_fn, start_block_id, start_instr_len)`:
     /// - `active_scopes_len`: depth marker used by break/continue at the
     ///   matching loop scope to know which entries lie inside the breaking
     ///   loop;
-    /// - `Place`/`ResolvedTy`/`drop_symbol`: what to drop and how;
+    /// - `Place`/`ResolvedTy`/`drop_fn`: what to drop and how (a cow-heap
+    ///   `Release` symbol, or the composite `InPlace` thunk route);
     /// - `start_block_id`/`start_instr_len`: the binding's site, used by
     ///   `generator_yield_binding_drop_safe` to scan the body for an
     ///   ownership-transferring escape (a `Move` of the binding's slot into
@@ -9414,7 +9415,14 @@ struct Builder {
     ///   loop. (`scope_generator_bindings` for the generator HANDLE has no
     ///   such case because handles do not get re-bound to another local
     ///   mid-body — only their content is consumed via `next`.)
-    active_generator_yield_values: Vec<(usize, Place, ResolvedTy, &'static str, u32, usize)>,
+    active_generator_yield_values: Vec<(
+        usize,
+        Place,
+        ResolvedTy,
+        crate::model::DropFnSpec,
+        u32,
+        usize,
+    )>,
     /// Map from each MIR-bound HIR `BindingId` to the HIR `ScopeId` it was
     /// declared in. Populated at every `MirStatement::Bind` push site (let
     /// statements, match-arm payload bindings, function parameters, for-range
@@ -11239,22 +11247,22 @@ impl Builder {
     /// reachable second free a no-op (`raii-null-after-move`; the runtime
     /// also null-guards).
     fn emit_generator_yield_value_drops_for_break_continue(&mut self, loop_scope_depth: usize) {
-        let to_drop: Vec<(Place, ResolvedTy, &'static str, u32, usize)> = self
+        let to_drop: Vec<(Place, ResolvedTy, crate::model::DropFnSpec, u32, usize)> = self
             .active_generator_yield_values
             .iter()
             .rev()
             .filter(|(depth, _, _, _, _, _)| *depth >= loop_scope_depth)
-            .map(|(_, place, ty, symbol, start_block_id, start_instr_len)| {
+            .map(|(_, place, ty, drop_fn, start_block_id, start_instr_len)| {
                 (
                     *place,
                     ty.clone(),
-                    *symbol,
+                    drop_fn.clone(),
                     *start_block_id,
                     *start_instr_len,
                 )
             })
             .collect();
-        for (place, ty, symbol, start_block_id, start_instr_len) in to_drop {
+        for (place, ty, drop_fn, start_block_id, start_instr_len) in to_drop {
             let Some(local) = base_local(place) else {
                 continue;
             };
@@ -11269,7 +11277,7 @@ impl Builder {
             self.push_instr(Instr::Drop {
                 place,
                 ty,
-                drop_fn: Some(crate::model::DropFnSpec::Release(symbol)),
+                drop_fn: Some(drop_fn),
             });
         }
     }
@@ -15303,7 +15311,13 @@ impl Builder {
                         // emittable release.
                         match self.project_field_inline_drop_symbol(&subst_fty) {
                             ReleaseSymbolVerdict::Wired(_) => {}
-                            ReleaseSymbolVerdict::NoDropPath => {
+                            // `WiredInPlace` is the yield/recv picker's composite
+                            // verdict; the FIELD picker never returns it, and this
+                            // pre-flight's override-drop below emits only
+                            // symbol-carrying releases. Keep the owned-aggregate
+                            // fail-closed posture for both.
+                            ReleaseSymbolVerdict::WiredInPlace(_)
+                            | ReleaseSymbolVerdict::NoDropPath => {
                                 // Owned-aggregate field (record / tuple / enum): in-place
                                 // drop kinds are function-scope only and cannot be emitted
                                 // as inline `Instr::Drop` here.  Fail closed.
@@ -18732,10 +18746,17 @@ impl Builder {
     /// [`ReleaseSymbolVerdict::Wired`] carries the C-ABI symbol the
     /// consumer-body drop emits, restricted to the proven leak shapes — a
     /// heap-owning `string`, `bytes`, and any builtin `Vec<T>` whose element
-    /// release is wired. [`ReleaseSymbolVerdict::NoDropPath`] covers shapes
-    /// with no validated consumer-drop path (HashMap/HashSet yields — they
-    /// leak as before rather than risk a double-free, matching the
-    /// conservative posture of the function-scope `CoW` drop allow-set).
+    /// release is wired. [`ReleaseSymbolVerdict::WiredInPlace`] covers a
+    /// registered heap-owning record/enum composite (the `LayoutManaged`
+    /// stream-element shapes): the release is the synthesised
+    /// `__hew_record_drop_inplace_<R>` / `__hew_enum_drop_inplace_<E>` thunk,
+    /// admitted by the same `elem_is_owned_abi_releasable` authority the
+    /// layout-witness (send-side deep clone) mirrors, so the drop is wired
+    /// exactly where the witness already clones. A `BitCopy` record/enum owns
+    /// no heap and never earns it. [`ReleaseSymbolVerdict::NoDropPath`]
+    /// covers shapes with no validated consumer-drop path (HashMap/HashSet
+    /// yields — they leak as before rather than risk a double-free, matching
+    /// the conservative posture of the function-scope `CoW` drop allow-set).
     /// [`ReleaseSymbolVerdict::Unwired`] is the fail-closed refusal: the
     /// value owns heap the buffer-only free cannot reach (a `Vec` of `bytes`
     /// or of an indirect-enum element), so the consulting site must reject
@@ -18800,8 +18821,57 @@ impl Builder {
                         self.vec_release_symbol_verdict(elem)
                     })
             }
+            // A registered heap-owning record/enum composite: release through
+            // the synthesised in-place drop thunk. `owned_composite_release_kind`
+            // (→ `elem_is_owned_abi_releasable`) is the SAME admission the
+            // stream layout witness mirrors for its LayoutManaged deep-clone
+            // (`owned_elem_thunk_key`), so this verdict Wires the release
+            // exactly where the witness already clones — a shape it refuses
+            // (BitCopy composite, indirect enum, closure-bearing, resource /
+            // opaque leaves) keeps its existing NoDropPath / rejected posture.
+            composite @ ResolvedTy::Named { .. } => {
+                match self.owned_composite_release_kind(composite) {
+                    Some(kind) => ReleaseSymbolVerdict::WiredInPlace(kind),
+                    None => ReleaseSymbolVerdict::NoDropPath,
+                }
+            }
             _ => ReleaseSymbolVerdict::NoDropPath,
         }
+    }
+
+    /// The in-place thunk family (record vs enum) releasing an owned composite
+    /// yield/recv payload, or `None` when the type is not an owned-ABI
+    /// releasable composite. Admission is exactly
+    /// [`Builder::elem_is_owned_abi_releasable`] — the documented MIR mirror
+    /// of codegen's `owned_elem_thunk_key` witness authority — so the picker
+    /// and the layout witness cannot drift on which composites carry live
+    /// ownership through the queue (`dedup-semantic-boundary`). The
+    /// record-vs-enum split re-reads the same registries that authority
+    /// consulted (a name resolves to exactly one of them).
+    fn owned_composite_release_kind(
+        &self,
+        ty: &ResolvedTy,
+    ) -> Option<crate::ownership::InPlaceReleaseKind> {
+        if !self.elem_is_owned_abi_releasable(ty) {
+            return None;
+        }
+        let ResolvedTy::Named { name, args, .. } = ty else {
+            return None;
+        };
+        let key = if args.is_empty() {
+            name.clone()
+        } else {
+            mangle_layout_key(name, args)
+        };
+        let is_enum = self
+            .enum_layouts
+            .iter()
+            .any(|el| el.name == key || short_name(&el.name) == short_name(name));
+        Some(if is_enum {
+            crate::ownership::InPlaceReleaseKind::Enum
+        } else {
+            crate::ownership::InPlaceReleaseKind::Record
+        })
     }
 
     /// The shared `Vec<E>` arm of both release-symbol pickers: map the
@@ -18880,12 +18950,14 @@ impl Builder {
         body_start_instr_len: usize,
         site: hew_hir::SiteId,
     ) {
-        // Only a Wired verdict reaches this emitter: the binding-registration
-        // gate schedules a body-end drop for Wired shapes alone (Unwired is a
-        // fail-closed compile diagnostic there; NoDropPath is never
-        // scheduled).
-        let ReleaseSymbolVerdict::Wired(symbol) = self.generator_yield_drop_symbol(ty) else {
-            return;
+        // Only a Wired / WiredInPlace verdict reaches this emitter: the
+        // binding-registration gate schedules a body-end drop for those shapes
+        // alone (Unwired is a fail-closed compile diagnostic there; NoDropPath
+        // is never scheduled).
+        let drop_fn = match self.generator_yield_drop_symbol(ty) {
+            ReleaseSymbolVerdict::Wired(symbol) => crate::model::DropFnSpec::Release(symbol),
+            ReleaseSymbolVerdict::WiredInPlace(kind) => crate::model::DropFnSpec::InPlace(kind),
+            ReleaseSymbolVerdict::NoDropPath | ReleaseSymbolVerdict::Unwired(_) => return,
         };
         let Some(local) = base_local(place) else {
             self.diagnostics.push(MirDiagnostic {
@@ -18895,7 +18967,8 @@ impl Builder {
                 },
                 note: format!(
                     "generator-yielded binding {binding:?} must lower to a Place::Local-backed \
-                     owner so the yielded heap value can be balanced with {symbol}; got {place:?}"
+                     owner so the yielded heap value can be balanced with {drop_fn:?}; got \
+                     {place:?}"
                 ),
             });
             return;
@@ -18905,7 +18978,7 @@ impl Builder {
             self.push_instr(Instr::Drop {
                 place,
                 ty: ty.clone(),
-                drop_fn: Some(crate::model::DropFnSpec::Release(symbol)),
+                drop_fn: Some(drop_fn),
             });
         }
         // else: the value escapes the consuming body — leak-not-double-free.
@@ -21572,10 +21645,11 @@ impl Builder {
                     // `owned_locals`, and a retracted binding is gone from it
                     // by then).
                     match self.generator_yield_drop_symbol(&binding_ty) {
-                        ReleaseSymbolVerdict::Wired(_) => {
+                        ReleaseSymbolVerdict::Wired(_) | ReleaseSymbolVerdict::WiredInPlace(_) => {
                             // The yielded/received payload owns heap (a
-                            // `string`, a `Vec`, a `Bytes`) with a wired
-                            // release. Schedule a body-end release and take it
+                            // `string`, a `Vec`, a `Bytes`, or a heap-owning
+                            // record/enum composite) with a wired release.
+                            // Schedule a body-end release and take it
                             // back out of `owned_locals` so the function-scope
                             // drop pass cannot also fire (double-free guard).
                             // The body-shape drop-safety scan in
@@ -21714,13 +21788,22 @@ impl Builder {
             // lowers (the fall-through path uses the body-end drop instead).
             let active_yield_mark = self.active_generator_yield_values.len();
             for (_binding, place, ty, _site) in &generator_yield_drop_bindings {
-                if let ReleaseSymbolVerdict::Wired(symbol) = self.generator_yield_drop_symbol(ty) {
+                let drop_fn = match self.generator_yield_drop_symbol(ty) {
+                    ReleaseSymbolVerdict::Wired(symbol) => {
+                        Some(crate::model::DropFnSpec::Release(symbol))
+                    }
+                    ReleaseSymbolVerdict::WiredInPlace(kind) => {
+                        Some(crate::model::DropFnSpec::InPlace(kind))
+                    }
+                    ReleaseSymbolVerdict::NoDropPath | ReleaseSymbolVerdict::Unwired(_) => None,
+                };
+                if let Some(drop_fn) = drop_fn {
                     let depth = self.active_scopes.len();
                     self.active_generator_yield_values.push((
                         depth,
                         *place,
                         ty.clone(),
-                        symbol,
+                        drop_fn,
                         body_start_block_id,
                         body_start_instr_len,
                     ));
@@ -21743,7 +21826,7 @@ impl Builder {
                         depth,
                         *place,
                         ty.clone(),
-                        "hew_string_drop",
+                        crate::model::DropFnSpec::Release("hew_string_drop"),
                         body_start_block_id,
                         body_start_instr_len,
                     ));
@@ -28469,7 +28552,12 @@ impl Builder {
                 });
                 None
             }
-            ReleaseSymbolVerdict::NoDropPath => Some(()),
+            // `WiredInPlace` is the yield/recv picker's composite verdict;
+            // `project_field_inline_drop_symbol` never returns it (owned
+            // aggregates stay `NoDropPath` here — the F-04 SHIM above). Kept
+            // as an explicit arm so admitting composites at THIS seam is a
+            // deliberate decision, not an accidental fall-through.
+            ReleaseSymbolVerdict::WiredInPlace(_) | ReleaseSymbolVerdict::NoDropPath => Some(()),
         }
     }
 
@@ -32282,6 +32370,100 @@ impl Builder {
         }
     }
 
+    /// Composite twin of [`Builder::record_stream_send_abandon_drop`]: stash
+    /// the in-flight record/enum yield value's abandon-edge release as the
+    /// same `DropKind::RecordInPlace` / `DropKind::EnumInPlace` plan drop the
+    /// function-scope spine uses (`drop_fn = None`; the helper resolves from
+    /// `ElabDrop::ty`). Exactly-once holds identically: the abandon and
+    /// resume edges are mutually exclusive, and this drop lives only on the
+    /// abandon plan. `validate_drop_plan` accepts the dedicated kinds on a
+    /// `Place::Local` composite, so the congruence gate is unchanged.
+    fn record_stream_send_abandon_composite_drop(
+        &mut self,
+        suspend_block: u32,
+        value: Place,
+        yield_ty: &ResolvedTy,
+        kind: crate::ownership::InPlaceReleaseKind,
+    ) {
+        let drop_kind = match kind {
+            crate::ownership::InPlaceReleaseKind::Record => DropKind::RecordInPlace,
+            crate::ownership::InPlaceReleaseKind::Enum => DropKind::EnumInPlace,
+        };
+        self.suspend_abandon_extra_drops
+            .entry(suspend_block)
+            .or_default()
+            .push(ElabDrop {
+                place: value,
+                ty: yield_ty.clone(),
+                drop_fn: None,
+                kind: drop_kind,
+                guard: None,
+            });
+    }
+
+    /// Release the pump's per-yield value copy on the stream-send RESUME edge
+    /// (and register its abandon-edge twin on the suspend plan).
+    ///
+    /// The stream send BORROWS the yielded value: `hew_stream_await_send`
+    /// and its layout sibling both copy the content out of the slot and
+    /// document the argument as borrowed, so the pump stays the sole owner
+    /// of the original and must release it exactly once per yield. Emit that
+    /// release on the resume edge, before the `Goto` loops back to
+    /// overwrite `value_local` on the next iteration. That edge is reached
+    /// ONLY when the send resumes (delivered/ready); the abandon-while-parked
+    /// path fires the suspend plan's twin drop on the destroy edge instead —
+    /// the two edges are mutually exclusive, so the value is never
+    /// double-released. `SuspendKind::StreamSend`'s value is escape-poisoned
+    /// (`terminator_escape_places`), so no scope-exit drop competes with this
+    /// one — it is the sole dropper. The release protocol comes from the same
+    /// authority the consumer-side yield-binding drop uses
+    /// (`generator_yield_drop_symbol`), so it stays congruent with the codegen
+    /// inline-drop validator. `string`/`bytes`/`Vec` release through their
+    /// wired symbol; a heap-owning record/enum composite releases through its
+    /// synthesised in-place thunk (`DropFnSpec::InPlace`) — the send deep-
+    /// cloned the envelope's copy (`encode_elem_envelope` `LayoutManaged`), so
+    /// the pump's copy is released without reaching the consumer's. `BitCopy`
+    /// scalars carry no inline release (`NoDropPath`); an `Unwired` element
+    /// is rejected upstream and never reaches the pump.
+    fn emit_pump_yield_value_release(
+        &mut self,
+        send_bb: u32,
+        value_local: Place,
+        yield_ty: &ResolvedTy,
+    ) {
+        match self.generator_yield_drop_symbol(yield_ty) {
+            ReleaseSymbolVerdict::Wired(symbol) => {
+                // Resume-edge release (delivered/ready): the pump is the sole
+                // owner of its copy and frees it here before the loop
+                // overwrites the slot.
+                self.push_instr(Instr::Drop {
+                    place: value_local,
+                    ty: yield_ty.clone(),
+                    drop_fn: Some(crate::model::DropFnSpec::Release(symbol)),
+                });
+                // Abandon-edge release for the SAME in-flight value.
+                self.record_stream_send_abandon_drop(send_bb, value_local, yield_ty, symbol);
+            }
+            ReleaseSymbolVerdict::WiredInPlace(kind) => {
+                // Composite twin of the Wired arm: same resume-edge inline
+                // release, routed through the in-place thunk instead of a
+                // C-ABI symbol.
+                self.push_instr(Instr::Drop {
+                    place: value_local,
+                    ty: yield_ty.clone(),
+                    drop_fn: Some(crate::model::DropFnSpec::InPlace(kind)),
+                });
+                self.record_stream_send_abandon_composite_drop(
+                    send_bb,
+                    value_local,
+                    yield_ty,
+                    kind,
+                );
+            }
+            ReleaseSymbolVerdict::NoDropPath | ReleaseSymbolVerdict::Unwired(_) => {}
+        }
+    }
+
     fn build_stream_producer_pump(&mut self, gen_place: Place, pump: &StreamProducerPumpCtx) {
         use hew_types::runtime_call::RuntimeCallFamily;
 
@@ -32369,37 +32551,7 @@ impl Builder {
             is_final: false,
         });
         self.start_block(after_send);
-        // The stream send BORROWS the yielded value: `hew_stream_await_send`
-        // and its layout sibling both copy the content out of the slot and
-        // document the argument as borrowed, so the pump stays the sole owner
-        // of the original and must release it exactly once per yield. Emit that
-        // release here, on the resume edge, before the `Goto` loops back to
-        // overwrite `value_local` on the next iteration. This edge is reached
-        // ONLY when the send resumes (delivered/ready); the abandon-while-parked
-        // path routes to the coro cleanup epilogue instead (it cancels + detaches
-        // the slot's borrowed copy), so the value is never double-released, and an
-        // abandoned in-flight value leaks — a tracked teardown gap, not a defect
-        // here. `SuspendKind::StreamSend`'s value is escape-poisoned
-        // (`terminator_escape_places`), so no scope-exit drop competes with this
-        // one — it is the sole dropper. The release symbol comes from the same
-        // authority the consumer-side yield-binding drop uses
-        // (`generator_yield_drop_symbol`), so it stays congruent with the codegen
-        // inline-drop validator. `string`/`bytes` release here; records/enums and
-        // BitCopy scalars carry no wired inline release (`NoDropPath`) and keep
-        // leaking their producer copy for now — tracked, never a wrong-ABI free.
-        if let ReleaseSymbolVerdict::Wired(symbol) =
-            self.generator_yield_drop_symbol(&pump.yield_ty)
-        {
-            // Resume-edge release (delivered/ready): the pump is the sole owner
-            // of its copy and frees it here before the loop overwrites the slot.
-            self.push_instr(Instr::Drop {
-                place: value_local,
-                ty: pump.yield_ty.clone(),
-                drop_fn: Some(crate::model::DropFnSpec::Release(symbol)),
-            });
-            // Abandon-edge release for the SAME in-flight value (#2395 dec. 2).
-            self.record_stream_send_abandon_drop(send_bb, value_local, &pump.yield_ty, symbol);
-        }
+        self.emit_pump_yield_value_release(send_bb, value_local, &pump.yield_ty);
         self.finish_current_block(Terminator::Goto { target: loop_head });
 
         // Shared close path: reached with the generator exhausted (`None`)

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -46377,7 +46377,7 @@ mod slice3_narrowing_proptests {
         }
     }
 
-    // ── #2395 lane A: suspend / yield abandon-edge drop plans ────────────────
+    // ── #2395: suspend / yield abandon-edge drop plans ────────────────────────
     // enumerate_exits must populate the ExitPath::Suspend / ExitPath::Yield plan
     // with the exit's live owned-local drops (fired by codegen on the
     // destroy-while-parked abandon edge), and exclude a moved-out (Consumed)

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -18847,7 +18847,10 @@ impl Builder {
     /// and the layout witness cannot drift on which composites carry live
     /// ownership through the queue (`dedup-semantic-boundary`). The
     /// record-vs-enum split re-reads the same registries that authority
-    /// consulted (a name resolves to exactly one of them).
+    /// consulted (a name resolves to exactly one of them); a generic
+    /// instantiation probes the short-name-mangled key (the registration
+    /// form), with the short-name comparison covering module-qualified
+    /// monomorphic names.
     fn owned_composite_release_kind(
         &self,
         ty: &ResolvedTy,
@@ -18861,7 +18864,7 @@ impl Builder {
         let key = if args.is_empty() {
             name.clone()
         } else {
-            mangle_layout_key(name, args)
+            mangle_layout_key(short_name(name), args)
         };
         let is_enum = self
             .enum_layouts

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -5727,8 +5727,8 @@ pub enum DropKind {
     ///
     /// This is deliberately narrower than [`DropKind::AggregateRecursive`]:
     /// named user records may also be `@resource` or otherwise unsupported on
-    /// the value-class surface, so the MIR producer emits this kind only for the
-    /// Lane-A let-bound record-construction slice.
+    /// the value-class surface, so the MIR producer emits this kind only for
+    /// the let-bound direct-string record-construction set.
     RecordInPlace,
     /// W5.011 — function-scope recursive drop of a heap-owning aggregate
     /// `CowValue` local whose payload transitively contains heap-owning

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -5535,7 +5535,7 @@ pub enum ExitPath {
 
 /// Typed drop-ritual selector carried by [`Instr::Drop`] and [`ElabDrop`].
 ///
-/// The drop world has exactly three identity domains, and each gets its
+/// The drop world has exactly four identity domains, and each gets its
 /// own arm so no consumer ever re-parses a string to recover which one
 /// it is holding (`checker-authority` / `type-info-survival`):
 ///
@@ -5552,6 +5552,16 @@ pub enum ExitPath {
 ///   `drop_kind_for`'s cow tables) and congruence-checked against the
 ///   value's type in codegen before any call is emitted — the string is
 ///   a C-ABI name consumed at the declare edge, never a dispatch key.
+/// - [`DropFnSpec::InPlace`] — a whole-value in-place composite release
+///   for a registered heap-owning record/enum, routed to the synthesised
+///   `__hew_record_drop_inplace_<R>` / `__hew_enum_drop_inplace_<E>`
+///   thunk. No symbol travels in MIR: codegen derives the helper from
+///   the drop's carried type (the same resolution the
+///   `DropKind::RecordInPlace` / `DropKind::EnumInPlace` plan arms use),
+///   so type↔helper congruence holds by construction. Emitted only by
+///   the yield/recv release seam (`generator_yield_drop_symbol`'s
+///   `WiredInPlace` verdict) for the per-yield producer/consumer copies
+///   of a composite stream element.
 /// - [`DropFnSpec::UserClose`] — a user `#[resource]` `close` method,
 ///   addressed by its generated `<Type>::<method>` symbol. Open set by
 ///   nature (the generated-object symbol IS the linker-edge name);
@@ -5566,6 +5576,9 @@ pub enum DropFnSpec {
     /// Cow-heap / fresh-value release C symbol (closed MIR-side
     /// selection; codegen validates type↔symbol congruence).
     Release(&'static str),
+    /// In-place composite release through the synthesised record/enum
+    /// drop thunk (helper derived from the drop's `ty` at codegen).
+    InPlace(crate::ownership::InPlaceReleaseKind),
     /// User `#[resource]` close method (`<Type>::<method>` generated
     /// symbol — the open-set linker-edge arm).
     UserClose(String),

--- a/hew-mir/src/ownership.rs
+++ b/hew-mir/src/ownership.rs
@@ -438,6 +438,17 @@ impl VecElementRelease {
 pub enum ReleaseSymbolVerdict {
     /// A wired, ABI-correct release symbol for the whole value at this site.
     Wired(&'static str),
+    /// A wired, ABI-correct in-place composite release: the whole value is a
+    /// registered heap-owning record/enum whose release is the synthesised
+    /// `__hew_record_drop_inplace_<R>` / `__hew_enum_drop_inplace_<E>` thunk
+    /// (resolved by codegen from the drop's carried type — no C-ABI symbol
+    /// travels in MIR). Emitting sites carry it as
+    /// [`DropFnSpec::InPlace`](crate::model::DropFnSpec::InPlace) on an inline
+    /// `Instr::Drop`, or as `DropKind::RecordInPlace` / `DropKind::EnumInPlace`
+    /// on a plan `ElabDrop`. Only the yield/recv release seam
+    /// (`generator_yield_drop_symbol`) returns this verdict; the field picker
+    /// keeps its `NoDropPath` posture for owned-aggregate fields.
+    WiredInPlace(InPlaceReleaseKind),
     /// No inline release is selected here: the shape owns no heap this picker
     /// releases, has no validated consumer-drop path (the HashMap/HashSet
     /// yield posture — leak-as-before, never a double-free risk), or is
@@ -449,6 +460,20 @@ pub enum ReleaseSymbolVerdict {
     /// wrong ABI. The consulting site must refuse the construct at compile
     /// time — never emit a symbol, never fall through silently.
     Unwired(FailClosedReason),
+}
+
+/// Which synthesised in-place drop thunk family releases a
+/// [`ReleaseSymbolVerdict::WiredInPlace`] composite. The registry identity
+/// (record layout vs tagged-union enum layout) selects the thunk getter on
+/// the codegen side (`__hew_record_drop_inplace_<R>` vs
+/// `__hew_enum_drop_inplace_<E>`); the concrete type travels on the drop
+/// itself (`Instr::Drop::ty` / `ElabDrop::ty`), never here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InPlaceReleaseKind {
+    /// A registered heap-owning user (or builtin-aggregate) record.
+    Record,
+    /// A registered heap-owning enum (tagged-union composite).
+    Enum,
 }
 
 // ──────────────────────────────── provenance ─────────────────────────────

--- a/hew-mir/tests/actor/actor_handler_lowering.rs
+++ b/hew-mir/tests/actor/actor_handler_lowering.rs
@@ -988,6 +988,208 @@ fn generator_pump_releases_string_yield_value_but_not_i64() {
     );
 }
 
+/// Run the full source pipeline (parse → check → HIR → MIR) so record/enum
+/// registration (field orders, tagged-union layouts) matches what real
+/// programs get — the composite-yield release verdict consults those
+/// registries (`elem_is_owned_abi_releasable`).
+fn source_pipeline(source: &str) -> hew_mir::IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:?}",
+        parsed.errors
+    );
+    let mut checker =
+        hew_types::Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    let output = hew_hir::lower_program(
+        &parsed.program,
+        &tc_output,
+        &hew_hir::ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    lower_hir_module(&output.module)
+}
+
+/// The first inline `Instr::Drop` in the raw handler body whose `drop_fn` is
+/// the composite `InPlace` route — the pump's (or consuming body's) per-yield
+/// composite value release.
+fn body_inline_inplace_drop(func: &hew_mir::RawMirFunction) -> Option<hew_mir::InPlaceReleaseKind> {
+    func.blocks
+        .iter()
+        .flat_map(|b| &b.instructions)
+        .find_map(|i| match i {
+            Instr::Drop {
+                drop_fn: Some(hew_mir::DropFnSpec::InPlace(kind)),
+                ..
+            } => Some(*kind),
+            _ => None,
+        })
+}
+
+/// The composite in-place drop kinds carried on the elaborated function's
+/// `ExitPath::Suspend` plans — the abandon-edge (destroy-while-parked) twin of
+/// the pump's resume-edge inline release.
+fn suspend_plan_inplace_drop_kinds(
+    pipeline: &hew_mir::IrPipeline,
+    func_name: &str,
+) -> Vec<hew_mir::DropKind> {
+    let elab = pipeline
+        .elaborated_mir
+        .iter()
+        .find(|f| f.name == func_name)
+        .unwrap_or_else(|| panic!("elaborated function `{func_name}` must exist"));
+    elab.drop_plans
+        .iter()
+        .filter(|(exit, _)| matches!(exit, hew_mir::ExitPath::Suspend { .. }))
+        .flat_map(|(_, plan)| plan.drops.iter())
+        .filter(|drop| {
+            matches!(
+                drop.kind,
+                hew_mir::DropKind::RecordInPlace | hew_mir::DropKind::EnumInPlace
+            )
+        })
+        .map(|drop| drop.kind)
+        .collect()
+}
+
+/// An owned-record yield carries the inline `InPlace(Record)` release on the
+/// pump's resume edge AND the `RecordInPlace` plan drop on the stream-send
+/// suspend's abandon edge (mutually exclusive edges — exactly-once), and the
+/// consuming `for await` body releases its own decode copy at body end
+/// through the same route.
+#[test]
+fn generator_pump_releases_record_yield_value_in_place() {
+    let record_pipeline = source_pipeline(
+        "record Item {\n\
+         \x20   name: string,\n\
+         \x20   value: i64,\n\
+         }\n\
+         actor Maker {\n\
+         \x20   receive gen fn items() -> Item {\n\
+         \x20       yield Item { name: \"named\", value: 7 };\n\
+         \x20   }\n\
+         }\n\
+         fn main() {\n\
+         \x20   let m = spawn Maker;\n\
+         \x20   for await it in m.items() {\n\
+         \x20       println(f\"{it.value}\");\n\
+         \x20   }\n\
+         }\n",
+    );
+    let record_pump = record_pipeline
+        .raw_mir
+        .iter()
+        .find(|f| f.name == "Maker__recv__items")
+        .expect("record generator handler must lower");
+    assert_eq!(
+        body_inline_inplace_drop(record_pump),
+        Some(hew_mir::InPlaceReleaseKind::Record),
+        "an owned-record yield pump must release its producer copy through the \
+         record in-place thunk on the resume edge"
+    );
+    assert_eq!(
+        suspend_plan_inplace_drop_kinds(&record_pipeline, "Maker__recv__items"),
+        vec![hew_mir::DropKind::RecordInPlace],
+        "the in-flight record yield value must carry exactly one RecordInPlace \
+         drop on the stream-send suspend's abandon plan"
+    );
+    let record_main = record_pipeline
+        .raw_mir
+        .iter()
+        .find(|f| f.name == "main")
+        .expect("main must lower");
+    assert_eq!(
+        body_inline_inplace_drop(record_main),
+        Some(hew_mir::InPlaceReleaseKind::Record),
+        "the for-await consuming body must release its fresh decode copy of the \
+         record frame at body end through the record in-place thunk"
+    );
+}
+
+/// The enum twin of the record-yield release: `InPlace(Enum)` on the resume
+/// edge, `EnumInPlace` on the abandon plan.
+#[test]
+fn generator_pump_releases_enum_yield_value_in_place() {
+    let enum_pipeline = source_pipeline(
+        "enum Note {\n\
+         \x20   Text(string);\n\
+         \x20   Number(i64);\n\
+         }\n\
+         actor Maker {\n\
+         \x20   receive gen fn notes() -> Note {\n\
+         \x20       yield Note::Text(\"alpha\");\n\
+         \x20   }\n\
+         }\n\
+         fn main() {\n\
+         \x20   let m = spawn Maker;\n\
+         \x20   for await n in m.notes() {\n\
+         \x20   }\n\
+         }\n",
+    );
+    let enum_pump = enum_pipeline
+        .raw_mir
+        .iter()
+        .find(|f| f.name == "Maker__recv__notes")
+        .expect("enum generator handler must lower");
+    assert_eq!(
+        body_inline_inplace_drop(enum_pump),
+        Some(hew_mir::InPlaceReleaseKind::Enum),
+        "an owned-enum yield pump must release its producer copy through the \
+         enum in-place thunk on the resume edge"
+    );
+    assert_eq!(
+        suspend_plan_inplace_drop_kinds(&enum_pipeline, "Maker__recv__notes"),
+        vec![hew_mir::DropKind::EnumInPlace],
+        "the in-flight enum yield value must carry exactly one EnumInPlace drop \
+         on the stream-send suspend's abandon plan"
+    );
+}
+
+/// Admission boundary (`elem_is_owned_abi_releasable`): a `BitCopy` record
+/// owns no heap — no inline release of any kind, exactly the pre-change
+/// posture.
+#[test]
+fn generator_pump_skips_bitcopy_record_yield_release() {
+    let bitcopy_pipeline = source_pipeline(
+        "record Point {\n\
+         \x20   x: i64,\n\
+         \x20   y: i64,\n\
+         }\n\
+         actor Shaper {\n\
+         \x20   receive gen fn points() -> Point {\n\
+         \x20       yield Point { x: 1, y: 2 };\n\
+         \x20   }\n\
+         }\n\
+         fn main() {\n\
+         \x20   let s = spawn Shaper;\n\
+         \x20   for await p in s.points() {\n\
+         \x20       println(f\"{p.x}\");\n\
+         \x20   }\n\
+         }\n",
+    );
+    let bitcopy_pump = bitcopy_pipeline
+        .raw_mir
+        .iter()
+        .find(|f| f.name == "Shaper__recv__points")
+        .expect("BitCopy record generator handler must lower");
+    assert_eq!(
+        body_inline_inplace_drop(bitcopy_pump),
+        None,
+        "a BitCopy record yield owns no heap — the pump must not emit a \
+         composite in-place release for it"
+    );
+    assert_eq!(
+        pump_body_inline_release_drop(bitcopy_pump),
+        None,
+        "a BitCopy record yield must not acquire a cow-heap release either"
+    );
+    assert!(
+        suspend_plan_inplace_drop_kinds(&bitcopy_pipeline, "Shaper__recv__points").is_empty(),
+        "a BitCopy record yield must not add abandon-edge plan drops"
+    );
+}
+
 /// A `receive gen fn` body that reads an actor state field (`count`, an
 /// `HirGenCaptureSource::ActorStateField` capture per `lower_actor_generator_body`)
 /// must snapshot it in the ENCLOSING shell frame — where actor state is

--- a/hew-mir/tests/lowering_expr/cstring_container_domain_canary.rs
+++ b/hew-mir/tests/lowering_expr/cstring_container_domain_canary.rs
@@ -128,8 +128,9 @@ fn vec_string_for_in_emits_retained_getter_with_iteration_drop() {
     // `println(count)` (a direct scalar print) rather than an f-string: the
     // fixture's subject is the for-in retained-getter drop, and an
     // interpolated `f"count={count}"` tail would add its OWN
-    // `hew_string_drop`s (the fresh-`string`-temp release lane, W5.011 P3 /
-    // Lane E) into `string_drops` below, conflating two unrelated things
+    // `hew_string_drop`s (the fresh-`string`-temp release seam, W5.011 P3 /
+    // the f-string interpolation temp fix) into `string_drops` below,
+    // conflating two unrelated things
     // this test is not about.
     let pl = pipeline_with_tc(
         r#"fn main() {

--- a/hew-mir/tests/lowering_expr/owned_string_temp_drop_canary.rs
+++ b/hew-mir/tests/lowering_expr/owned_string_temp_drop_canary.rs
@@ -414,8 +414,8 @@ fn index_bound_oob_trap_drops_nothing() {
 }
 
 // ---------------------------------------------------------------------------
-// f-string interpolation temp release (Lane E, rc1 drop-safety completion
-// program). `f"item-{i}"` over a non-string value desugars
+// f-string interpolation temp release (the rc1 drop-safety completion
+// pass). `f"item-{i}"` over a non-string value desugars
 // (`hew-hir/src/lower.rs::lower_interpolated_string`) to a chain of
 // `stdlib_catalog` presentation-name calls: `to_string_i64(i)` (a fresh
 // conversion temp) then `string_concat(lit, temp)` (the join). Both reach MIR

--- a/tests/vertical-slice/accept/receive_gen_fn_owned_enum_yield.expected
+++ b/tests/vertical-slice/accept/receive_gen_fn_owned_enum_yield.expected
@@ -1,0 +1,3 @@
+text alpha
+number 4
+text beta

--- a/tests/vertical-slice/accept/receive_gen_fn_owned_enum_yield.hew
+++ b/tests/vertical-slice/accept/receive_gen_fn_owned_enum_yield.hew
@@ -1,0 +1,31 @@
+// Owned-composite yield generalization, enum twin: a payload-carrying enum
+// whose active variant owns heap (`Text(string)`) crosses the pump's
+// layout-witness send path with discriminant and payload intact; the pump
+// frees its producer copy per yield through the tag-dispatched enum in-place
+// drop thunk. The consumer destructures each payload in a `match` — an
+// ownership transfer out of the frame binding, so the moved-out arm binding
+// owns the payload from there (the frame binding's body-end release is
+// correctly suppressed; releasing the destructured arm binding per iteration
+// is the match-arm consume-side discipline, tracked separately).
+enum Note {
+    Text(string);
+    Number(i64);
+}
+
+actor Maker {
+    receive gen fn notes() -> Note {
+        yield Note::Text("alpha");
+        yield Note::Number(4);
+        yield Note::Text("beta");
+    }
+}
+
+fn main() {
+    let m = spawn Maker;
+    for await n in m.notes() {
+        match n {
+            Note::Text(s) => println(f"text {s}"),
+            Note::Number(v) => println(f"number {v}"),
+        }
+    }
+}

--- a/tests/vertical-slice/accept/receive_gen_fn_owned_record_yield.expected
+++ b/tests/vertical-slice/accept/receive_gen_fn_owned_record_yield.expected
@@ -1,0 +1,2 @@
+named,7
+other,9

--- a/tests/vertical-slice/accept/receive_gen_fn_owned_record_yield.hew
+++ b/tests/vertical-slice/accept/receive_gen_fn_owned_record_yield.hew
@@ -1,0 +1,26 @@
+// Owned-composite yield generalization: a record yield whose field owns heap
+// (`name: string`) crosses the pump's layout-witness send path
+// (LayoutManaged: envelope deep-clone in, ownership move out) with every
+// field intact, and BOTH per-yield copies are released — the pump frees its
+// producer copy on the send's resume edge through the record in-place drop
+// thunk, and the consuming `for await` body frees its fresh decode copy at
+// body end through the same thunk. Exact output pins the field values; the
+// per-yield leak slope is pinned by the composite-yield leak oracle.
+record Item {
+    name: string,
+    value: i64,
+}
+
+actor Maker {
+    receive gen fn items() -> Item {
+        yield Item { name: "named", value: 7 };
+        yield Item { name: "other", value: 9 };
+    }
+}
+
+fn main() {
+    let m = spawn Maker;
+    for await it in m.items() {
+        println(f"{it.name},{it.value}");
+    }
+}

--- a/tests/vertical-slice/accept/receive_gen_fn_record_stream_break.expected
+++ b/tests/vertical-slice/accept/receive_gen_fn_record_stream_break.expected
@@ -1,0 +1,2 @@
+total=3
+ping=99

--- a/tests/vertical-slice/accept/receive_gen_fn_record_stream_break.hew
+++ b/tests/vertical-slice/accept/receive_gen_fn_record_stream_break.hew
@@ -1,0 +1,41 @@
+// Cancelling an owned-record stream mid-drain: `for await ... break` on an
+// infinite record generator must unwedge the pump via the peer-closed check
+// (the i64 cancellation proof) AND release the breaking iteration's record on
+// the break edge — the break jumps past the body-end release, so the
+// break-edge drop is the only thing standing between cancellation and a
+// per-cancel leak of the frame's owned field. The actor stays healthy and
+// answers a later ask normally.
+record Item {
+    name: string,
+    value: i64,
+}
+
+actor Maker {
+    receive gen fn items() -> Item {
+        var i: i64 = 0;
+        loop {
+            yield Item { name: f"it-{i}", value: i };
+            i = i + 1;
+        }
+    }
+    receive fn ping() -> i64 {
+        99
+    }
+}
+
+fn main() {
+    let m = spawn Maker;
+    var total: i64 = 0;
+    for await it in m.items() {
+        total = total + it.value;
+        if it.value >= 2 {
+            break;
+        }
+    }
+    println(f"total={total}");
+    let r = await m.ping();
+    match r {
+        Ok(v) => println(f"ping={v}"),
+        Err(_) => println("ping failed"),
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -2566,6 +2566,17 @@ run_accept_expect_stdout "receive_gen_fn_string_yield"
 run_accept_expect_stdout "receive_gen_fn_record_yield"
 run_accept_expect_stdout "receive_gen_fn_enum_yield"
 
+# Owned-composite yields (heap-owning record/enum): the pump releases its
+# producer copy per yield through the record/enum in-place drop thunks, the
+# `for await` consumer releases its decode copy at body end, and a mid-drain
+# `break` releases the breaking iteration's record on the break edge while
+# the peer-closed check unwedges the pump. Field values and discriminants
+# stay intact end to end; the per-yield leak slope is pinned by the
+# composite-yield leak oracle in hew-cli.
+run_accept_expect_stdout "receive_gen_fn_owned_record_yield"
+run_accept_expect_stdout "receive_gen_fn_owned_enum_yield"
+run_accept_expect_stdout "receive_gen_fn_record_stream_break"
+
 # Fault (producer crash): the gen body yields once, then traps on a
 # runtime div-by-zero. The consumer, having already received the first value,
 # must observe the fault on its next resume — never a clean, silent EOF. The


### PR DESCRIPTION
A record or enum yielded through a generator pump — or consumed through a for-await arm — leaked its producer copy on every yield: the yield-value release picker wired strings, bytes, and vectors but sent composite types to a no-drop path. The measured slope was exactly one leaked node per yield, at both small and large iteration counts.

Composites now route through the existing per-type in-place drop thunks. The release is emitted on the pump's resume edge with a matching abandon-plan entry for destroy-while-parked, the for-await consumer side releases per iteration with break and continue covered by a release ledger, and resolving an unseeded thunk fails closed instead of skipping. A raw-MIR seed walk guarantees the thunk bodies exist for every inline release site, keyed through the same layout resolution the plan-walker uses.

The consumer's copy shares the allocation by refcount retain rather than deep copy, so each holder releases its own reference and the node frees exactly once — verified by independent re-trace of the atomic refcount implementation and adversarial probes across discarded, kept-alive, multi-field, nested, and generic shapes, all clean under the poisoned-allocator battery. Leak slope is zero at both scales for record and enum yields; an all-bit-copy record yield emits no release at all.

Also reworded a handful of internal planning-shorthand comments in the touched files to plain engineering phrasing.

Two pre-existing residuals were verified identical on the base commit and remain tracked separately: retained string-field reads in for-await bodies leak a per-iteration temporary, and destructured enum payloads follow the consume-side class already on file.