### PR TITLE
fix(std): set hew_tls_connect's last_error, drain it in try_read_bytes

### DIFF
--- a/examples/v05/checked-mir/golden/stream_blocking_recv.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.elab.mir
@@ -852,10 +852,11 @@ fn fs$try_read_bytes -> Result<bytes, IoError>
     bind BindingId(52) data site=SiteId(465) ty=bytes
     bind BindingId(53) errno site=SiteId(468) ty=i32
     use BindingId(53) errno site=SiteId(472) ty=i32 intent=Read
-    use BindingId(53) errno site=SiteId(478) ty=i32 intent=Read
-    use BindingId(52) data site=SiteId(482) ty=bytes intent=Read
-    agg_alias BindingId(52) data site=SiteId(482) ty=bytes
+    use BindingId(52) data site=SiteId(484) ty=bytes intent=Read
+    agg_alias BindingId(52) data site=SiteId(484) ty=bytes
     return site=Some(SiteId(464)) ty=Result<bytes, IoError>
+    eval site=SiteId(475) ty=string
+    use BindingId(53) errno site=SiteId(480) ty=i32 intent=Read
     drop BindingId(52) data ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
@@ -866,22 +867,24 @@ fn fs$try_read_bytes -> Result<bytes, IoError>
       (none)
     branch[bb2: bb3/bb4] ->
       (none)
-    call[bb3 fs$io_error_from_errno -> bb6] ->
+    call[bb3 hew_stream_last_error -> bb6] ->
       (none)
     goto[bb4->bb5] ->
       (none)
     return[bb5] ->
       (none)
-    goto[bb6->bb5] ->
+    call[bb6 fs$io_error_from_errno -> bb7] ->
       (none)
-    cancel[bb6] ->
+    goto[bb7->bb5] ->
+      (none)
+    cancel[bb7] ->
       (none)
 
 fn fs$write_bytes -> i64
   statements:
-    use BindingId(54) path site=SiteId(486) ty=string intent=Read
-    use BindingId(55) data site=SiteId(487) ty=bytes intent=Read
-    return site=Some(SiteId(483)) ty=i64
+    use BindingId(54) path site=SiteId(488) ty=string intent=Read
+    use BindingId(55) data site=SiteId(489) ty=bytes intent=Read
+    return site=Some(SiteId(485)) ty=i64
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -892,10 +895,10 @@ fn fs$write_bytes -> i64
 
 fn fs$try_write_bytes -> Result<i64, IoError>
   statements:
-    use BindingId(56) file_path site=SiteId(492) ty=string intent=Read
-    use BindingId(57) data site=SiteId(493) ty=bytes intent=Read
-    return site=Some(SiteId(489)) ty=Result<i64, IoError>
-    use BindingId(56) file_path site=SiteId(499) ty=string intent=Read
+    use BindingId(56) file_path site=SiteId(494) ty=string intent=Read
+    use BindingId(57) data site=SiteId(495) ty=bytes intent=Read
+    return site=Some(SiteId(491)) ty=Result<i64, IoError>
+    use BindingId(56) file_path site=SiteId(501) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -922,8 +925,8 @@ fn fs$try_write_bytes -> Result<i64, IoError>
 
 fn fs$mkdir -> i64
   statements:
-    use BindingId(58) path site=SiteId(504) ty=string intent=Read
-    return site=Some(SiteId(501)) ty=i64
+    use BindingId(58) path site=SiteId(506) ty=string intent=Read
+    return site=Some(SiteId(503)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -934,9 +937,9 @@ fn fs$mkdir -> i64
 
 fn fs$try_mkdir -> Result<i64, IoError>
   statements:
-    use BindingId(59) dir_path site=SiteId(509) ty=string intent=Read
-    return site=Some(SiteId(506)) ty=Result<i64, IoError>
-    use BindingId(59) dir_path site=SiteId(515) ty=string intent=Read
+    use BindingId(59) dir_path site=SiteId(511) ty=string intent=Read
+    return site=Some(SiteId(508)) ty=Result<i64, IoError>
+    use BindingId(59) dir_path site=SiteId(517) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -963,8 +966,8 @@ fn fs$try_mkdir -> Result<i64, IoError>
 
 fn fs$mkdir_all -> i64
   statements:
-    use BindingId(60) path site=SiteId(520) ty=string intent=Read
-    return site=Some(SiteId(517)) ty=i64
+    use BindingId(60) path site=SiteId(522) ty=string intent=Read
+    return site=Some(SiteId(519)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -975,9 +978,9 @@ fn fs$mkdir_all -> i64
 
 fn fs$try_mkdir_all -> Result<i64, IoError>
   statements:
-    use BindingId(61) dir_path site=SiteId(525) ty=string intent=Read
-    return site=Some(SiteId(522)) ty=Result<i64, IoError>
-    use BindingId(61) dir_path site=SiteId(532) ty=string intent=Read
+    use BindingId(61) dir_path site=SiteId(527) ty=string intent=Read
+    return site=Some(SiteId(524)) ty=Result<i64, IoError>
+    use BindingId(61) dir_path site=SiteId(534) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -1010,8 +1013,8 @@ fn fs$try_mkdir_all -> Result<i64, IoError>
 
 fn fs$list_dir -> Vec<string>
   statements:
-    use BindingId(62) path site=SiteId(544) ty=string intent=Read
-    return site=Some(SiteId(542)) ty=Vec<string>
+    use BindingId(62) path site=SiteId(546) ty=string intent=Read
+    return site=Some(SiteId(544)) ty=Vec<string>
   drop_plans:
     call[bb0 hew_fs_list_dir -> bb1] ->
       (none)
@@ -1022,14 +1025,14 @@ fn fs$list_dir -> Vec<string>
 
 fn fs$try_list_dir -> Result<Vec<string>, IoError>
   statements:
-    use BindingId(63) dir_path site=SiteId(548) ty=string intent=Read
-    return site=Some(SiteId(550)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(554) ty=()
-    use BindingId(63) dir_path site=SiteId(557) ty=string intent=Read
-    return site=Some(SiteId(559)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(563) ty=()
-    use BindingId(63) dir_path site=SiteId(567) ty=string intent=Read
-    return site=Some(SiteId(564)) ty=Result<Vec<string>, IoError>
+    use BindingId(63) dir_path site=SiteId(550) ty=string intent=Read
+    return site=Some(SiteId(552)) ty=Result<Vec<string>, IoError>
+    eval site=SiteId(556) ty=()
+    use BindingId(63) dir_path site=SiteId(559) ty=string intent=Read
+    return site=Some(SiteId(561)) ty=Result<Vec<string>, IoError>
+    eval site=SiteId(565) ty=()
+    use BindingId(63) dir_path site=SiteId(569) ty=string intent=Read
+    return site=Some(SiteId(566)) ty=Result<Vec<string>, IoError>
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -1064,9 +1067,9 @@ fn fs$try_list_dir -> Result<Vec<string>, IoError>
 
 fn fs$rename -> i64
   statements:
-    use BindingId(64) from site=SiteId(572) ty=string intent=Read
-    use BindingId(65) to site=SiteId(573) ty=string intent=Read
-    return site=Some(SiteId(569)) ty=i64
+    use BindingId(64) from site=SiteId(574) ty=string intent=Read
+    use BindingId(65) to site=SiteId(575) ty=string intent=Read
+    return site=Some(SiteId(571)) ty=i64
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1077,11 +1080,11 @@ fn fs$rename -> i64
 
 fn fs$try_rename -> Result<i64, IoError>
   statements:
-    use BindingId(66) from site=SiteId(578) ty=string intent=Read
-    use BindingId(67) to site=SiteId(579) ty=string intent=Read
-    return site=Some(SiteId(575)) ty=Result<i64, IoError>
-    use BindingId(66) from site=SiteId(585) ty=string intent=Read
-    use BindingId(67) to site=SiteId(586) ty=string intent=Read
+    use BindingId(66) from site=SiteId(580) ty=string intent=Read
+    use BindingId(67) to site=SiteId(581) ty=string intent=Read
+    return site=Some(SiteId(577)) ty=Result<i64, IoError>
+    use BindingId(66) from site=SiteId(587) ty=string intent=Read
+    use BindingId(67) to site=SiteId(588) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1108,9 +1111,9 @@ fn fs$try_rename -> Result<i64, IoError>
 
 fn fs$copy -> i64
   statements:
-    use BindingId(68) from site=SiteId(591) ty=string intent=Read
-    use BindingId(69) to site=SiteId(592) ty=string intent=Read
-    return site=Some(SiteId(588)) ty=i64
+    use BindingId(68) from site=SiteId(593) ty=string intent=Read
+    use BindingId(69) to site=SiteId(594) ty=string intent=Read
+    return site=Some(SiteId(590)) ty=i64
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1121,11 +1124,11 @@ fn fs$copy -> i64
 
 fn fs$try_copy -> Result<i64, IoError>
   statements:
-    use BindingId(70) from site=SiteId(597) ty=string intent=Read
-    use BindingId(71) to site=SiteId(598) ty=string intent=Read
-    return site=Some(SiteId(594)) ty=Result<i64, IoError>
-    use BindingId(70) from site=SiteId(604) ty=string intent=Read
-    use BindingId(71) to site=SiteId(605) ty=string intent=Read
+    use BindingId(70) from site=SiteId(599) ty=string intent=Read
+    use BindingId(71) to site=SiteId(600) ty=string intent=Read
+    return site=Some(SiteId(596)) ty=Result<i64, IoError>
+    use BindingId(70) from site=SiteId(606) ty=string intent=Read
+    use BindingId(71) to site=SiteId(607) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1152,8 +1155,8 @@ fn fs$try_copy -> Result<i64, IoError>
 
 fn fs$is_dir -> bool
   statements:
-    use BindingId(72) path site=SiteId(609) ty=string intent=Read
-    return site=Some(SiteId(607)) ty=bool
+    use BindingId(72) path site=SiteId(611) ty=string intent=Read
+    return site=Some(SiteId(609)) ty=bool
   drop_plans:
     call[bb0 hew_fs_is_dir -> bb1] ->
       (none)
@@ -1164,19 +1167,19 @@ fn fs$is_dir -> bool
 
 fn stream$pipe -> (Sink<string>, Stream<string>)
   statements:
-    use BindingId(73) capacity site=SiteId(614) ty=i64 intent=Read
-    bind BindingId(74) pair site=SiteId(612) ty=StreamPair
-    use BindingId(74) pair site=SiteId(617) ty=StreamPair intent=Read
-    bind BindingId(75) sink site=SiteId(616) ty=Sink<string>
-    use BindingId(74) pair site=SiteId(620) ty=StreamPair intent=Read
-    bind BindingId(76) input site=SiteId(619) ty=Stream<string>
-    use BindingId(74) pair site=SiteId(623) ty=StreamPair intent=Read
-    eval site=SiteId(622) ty=()
-    use BindingId(75) sink site=SiteId(626) ty=Sink<string> intent=Read
-    use BindingId(76) input site=SiteId(627) ty=Stream<string> intent=Read
-    agg_alias BindingId(75) sink site=SiteId(626) ty=Sink<string>
-    agg_alias BindingId(76) input site=SiteId(627) ty=Stream<string>
-    return site=Some(SiteId(611)) ty=(Sink<string>, Stream<string>)
+    use BindingId(73) capacity site=SiteId(616) ty=i64 intent=Read
+    bind BindingId(74) pair site=SiteId(614) ty=StreamPair
+    use BindingId(74) pair site=SiteId(619) ty=StreamPair intent=Read
+    bind BindingId(75) sink site=SiteId(618) ty=Sink<string>
+    use BindingId(74) pair site=SiteId(622) ty=StreamPair intent=Read
+    bind BindingId(76) input site=SiteId(621) ty=Stream<string>
+    use BindingId(74) pair site=SiteId(625) ty=StreamPair intent=Read
+    eval site=SiteId(624) ty=()
+    use BindingId(75) sink site=SiteId(628) ty=Sink<string> intent=Read
+    use BindingId(76) input site=SiteId(629) ty=Stream<string> intent=Read
+    agg_alias BindingId(75) sink site=SiteId(628) ty=Sink<string>
+    agg_alias BindingId(76) input site=SiteId(629) ty=Stream<string>
+    return site=Some(SiteId(613)) ty=(Sink<string>, Stream<string>)
     drop BindingId(76) input ty=Stream<string>
     drop BindingId(75) sink ty=Sink<string>
   drop_plans:
@@ -1195,19 +1198,19 @@ fn stream$pipe -> (Sink<string>, Stream<string>)
 
 fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
   statements:
-    use BindingId(77) capacity site=SiteId(631) ty=i64 intent=Read
-    bind BindingId(78) pair site=SiteId(629) ty=StreamPair
-    use BindingId(78) pair site=SiteId(634) ty=StreamPair intent=Read
-    bind BindingId(79) sink site=SiteId(633) ty=Sink<bytes>
-    use BindingId(78) pair site=SiteId(637) ty=StreamPair intent=Read
-    bind BindingId(80) input site=SiteId(636) ty=Stream<bytes>
-    use BindingId(78) pair site=SiteId(640) ty=StreamPair intent=Read
-    eval site=SiteId(639) ty=()
-    use BindingId(79) sink site=SiteId(643) ty=Sink<bytes> intent=Read
-    use BindingId(80) input site=SiteId(644) ty=Stream<bytes> intent=Read
-    agg_alias BindingId(79) sink site=SiteId(643) ty=Sink<bytes>
-    agg_alias BindingId(80) input site=SiteId(644) ty=Stream<bytes>
-    return site=Some(SiteId(628)) ty=(Sink<bytes>, Stream<bytes>)
+    use BindingId(77) capacity site=SiteId(633) ty=i64 intent=Read
+    bind BindingId(78) pair site=SiteId(631) ty=StreamPair
+    use BindingId(78) pair site=SiteId(636) ty=StreamPair intent=Read
+    bind BindingId(79) sink site=SiteId(635) ty=Sink<bytes>
+    use BindingId(78) pair site=SiteId(639) ty=StreamPair intent=Read
+    bind BindingId(80) input site=SiteId(638) ty=Stream<bytes>
+    use BindingId(78) pair site=SiteId(642) ty=StreamPair intent=Read
+    eval site=SiteId(641) ty=()
+    use BindingId(79) sink site=SiteId(645) ty=Sink<bytes> intent=Read
+    use BindingId(80) input site=SiteId(646) ty=Stream<bytes> intent=Read
+    agg_alias BindingId(79) sink site=SiteId(645) ty=Sink<bytes>
+    agg_alias BindingId(80) input site=SiteId(646) ty=Stream<bytes>
+    return site=Some(SiteId(630)) ty=(Sink<bytes>, Stream<bytes>)
     drop BindingId(80) input ty=Stream<bytes>
     drop BindingId(79) sink ty=Sink<bytes>
   drop_plans:
@@ -1226,12 +1229,12 @@ fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
 
 fn stream$from_file -> Result<Stream<string>, string>
   statements:
-    use BindingId(81) path site=SiteId(647) ty=string intent=Read
-    bind BindingId(82) s site=SiteId(646) ty=Stream<string>
-    use BindingId(82) s site=SiteId(651) ty=Stream<string> intent=Read
-    use BindingId(82) s site=SiteId(655) ty=Stream<string> intent=Read
-    agg_alias BindingId(82) s site=SiteId(655) ty=Stream<string>
-    return site=Some(SiteId(645)) ty=Result<Stream<string>, string>
+    use BindingId(81) path site=SiteId(649) ty=string intent=Read
+    bind BindingId(82) s site=SiteId(648) ty=Stream<string>
+    use BindingId(82) s site=SiteId(653) ty=Stream<string> intent=Read
+    use BindingId(82) s site=SiteId(657) ty=Stream<string> intent=Read
+    agg_alias BindingId(82) s site=SiteId(657) ty=Stream<string>
+    return site=Some(SiteId(647)) ty=Result<Stream<string>, string>
     drop BindingId(82) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
@@ -1255,15 +1258,15 @@ fn stream$from_file -> Result<Stream<string>, string>
 
 fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
   statements:
-    use BindingId(83) path site=SiteId(662) ty=string intent=Read
-    bind BindingId(84) s site=SiteId(661) ty=Stream<string>
-    use BindingId(84) s site=SiteId(666) ty=Stream<string> intent=Read
-    use BindingId(84) s site=SiteId(670) ty=Stream<string> intent=Read
-    agg_alias BindingId(84) s site=SiteId(670) ty=Stream<string>
-    return site=Some(SiteId(660)) ty=Result<Stream<string>, fs.IoError>
-    bind BindingId(85) errno site=SiteId(672) ty=i32
-    eval site=SiteId(674) ty=string
-    use BindingId(85) errno site=SiteId(679) ty=i32 intent=Read
+    use BindingId(83) path site=SiteId(664) ty=string intent=Read
+    bind BindingId(84) s site=SiteId(663) ty=Stream<string>
+    use BindingId(84) s site=SiteId(668) ty=Stream<string> intent=Read
+    use BindingId(84) s site=SiteId(672) ty=Stream<string> intent=Read
+    agg_alias BindingId(84) s site=SiteId(672) ty=Stream<string>
+    return site=Some(SiteId(662)) ty=Result<Stream<string>, fs.IoError>
+    bind BindingId(85) errno site=SiteId(674) ty=i32
+    eval site=SiteId(676) ty=string
+    use BindingId(85) errno site=SiteId(681) ty=i32 intent=Read
     drop BindingId(84) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
@@ -1291,12 +1294,12 @@ fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
 
 fn stream$to_file -> Result<Sink<string>, string>
   statements:
-    use BindingId(86) path site=SiteId(683) ty=string intent=Read
-    bind BindingId(87) s site=SiteId(682) ty=Sink<string>
-    use BindingId(87) s site=SiteId(687) ty=Sink<string> intent=Read
-    use BindingId(87) s site=SiteId(691) ty=Sink<string> intent=Read
-    agg_alias BindingId(87) s site=SiteId(691) ty=Sink<string>
-    return site=Some(SiteId(681)) ty=Result<Sink<string>, string>
+    use BindingId(86) path site=SiteId(685) ty=string intent=Read
+    bind BindingId(87) s site=SiteId(684) ty=Sink<string>
+    use BindingId(87) s site=SiteId(689) ty=Sink<string> intent=Read
+    use BindingId(87) s site=SiteId(693) ty=Sink<string> intent=Read
+    agg_alias BindingId(87) s site=SiteId(693) ty=Sink<string>
+    return site=Some(SiteId(683)) ty=Result<Sink<string>, string>
     drop BindingId(87) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
@@ -1320,15 +1323,15 @@ fn stream$to_file -> Result<Sink<string>, string>
 
 fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
   statements:
-    use BindingId(88) path site=SiteId(698) ty=string intent=Read
-    bind BindingId(89) s site=SiteId(697) ty=Sink<string>
-    use BindingId(89) s site=SiteId(702) ty=Sink<string> intent=Read
-    use BindingId(89) s site=SiteId(706) ty=Sink<string> intent=Read
-    agg_alias BindingId(89) s site=SiteId(706) ty=Sink<string>
-    return site=Some(SiteId(696)) ty=Result<Sink<string>, fs.IoError>
-    bind BindingId(90) errno site=SiteId(708) ty=i32
-    eval site=SiteId(710) ty=string
-    use BindingId(90) errno site=SiteId(715) ty=i32 intent=Read
+    use BindingId(88) path site=SiteId(700) ty=string intent=Read
+    bind BindingId(89) s site=SiteId(699) ty=Sink<string>
+    use BindingId(89) s site=SiteId(704) ty=Sink<string> intent=Read
+    use BindingId(89) s site=SiteId(708) ty=Sink<string> intent=Read
+    agg_alias BindingId(89) s site=SiteId(708) ty=Sink<string>
+    return site=Some(SiteId(698)) ty=Result<Sink<string>, fs.IoError>
+    bind BindingId(90) errno site=SiteId(710) ty=i32
+    eval site=SiteId(712) ty=string
+    use BindingId(90) errno site=SiteId(717) ty=i32 intent=Read
     drop BindingId(89) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
@@ -1356,9 +1359,9 @@ fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
 
 fn stream$forward -> ()
   statements:
-    use BindingId(91) source site=SiteId(719) ty=Stream<string> intent=Read
-    use BindingId(92) dest site=SiteId(720) ty=Sink<string> intent=Read
-    eval site=SiteId(717) ty=()
+    use BindingId(91) source site=SiteId(721) ty=Stream<string> intent=Read
+    use BindingId(92) dest site=SiteId(722) ty=Sink<string> intent=Read
+    eval site=SiteId(719) ty=()
   drop_plans:
     call[bb0 hew_stream_pipe -> bb1] ->
       (none)
@@ -1369,8 +1372,8 @@ fn stream$forward -> ()
 
 fn i8::fmt -> string
   statements:
-    use BindingId(101) val site=SiteId(792) ty=i8 intent=Read
-    return site=Some(SiteId(790)) ty=string
+    use BindingId(101) val site=SiteId(794) ty=i8 intent=Read
+    return site=Some(SiteId(792)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1381,8 +1384,8 @@ fn i8::fmt -> string
 
 fn i16::fmt -> string
   statements:
-    use BindingId(102) val site=SiteId(796) ty=i16 intent=Read
-    return site=Some(SiteId(794)) ty=string
+    use BindingId(102) val site=SiteId(798) ty=i16 intent=Read
+    return site=Some(SiteId(796)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1393,8 +1396,8 @@ fn i16::fmt -> string
 
 fn i32::fmt -> string
   statements:
-    use BindingId(103) val site=SiteId(799) ty=i32 intent=Read
-    return site=Some(SiteId(798)) ty=string
+    use BindingId(103) val site=SiteId(801) ty=i32 intent=Read
+    return site=Some(SiteId(800)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1405,8 +1408,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(104) val site=SiteId(802) ty=i64 intent=Read
-    return site=Some(SiteId(801)) ty=string
+    use BindingId(104) val site=SiteId(804) ty=i64 intent=Read
+    return site=Some(SiteId(803)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1417,8 +1420,8 @@ fn i64::fmt -> string
 
 fn u8::fmt -> string
   statements:
-    use BindingId(105) val site=SiteId(805) ty=u8 intent=Read
-    return site=Some(SiteId(804)) ty=string
+    use BindingId(105) val site=SiteId(807) ty=u8 intent=Read
+    return site=Some(SiteId(806)) ty=string
   drop_plans:
     call[bb0 to_string_u8 -> bb1] ->
       (none)
@@ -1429,8 +1432,8 @@ fn u8::fmt -> string
 
 fn u16::fmt -> string
   statements:
-    use BindingId(106) val site=SiteId(808) ty=u16 intent=Read
-    return site=Some(SiteId(807)) ty=string
+    use BindingId(106) val site=SiteId(810) ty=u16 intent=Read
+    return site=Some(SiteId(809)) ty=string
   drop_plans:
     call[bb0 to_string_u16 -> bb1] ->
       (none)
@@ -1441,8 +1444,8 @@ fn u16::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(107) val site=SiteId(811) ty=u32 intent=Read
-    return site=Some(SiteId(810)) ty=string
+    use BindingId(107) val site=SiteId(813) ty=u32 intent=Read
+    return site=Some(SiteId(812)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -1453,8 +1456,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(108) val site=SiteId(814) ty=u64 intent=Read
-    return site=Some(SiteId(813)) ty=string
+    use BindingId(108) val site=SiteId(816) ty=u64 intent=Read
+    return site=Some(SiteId(815)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1465,8 +1468,8 @@ fn u64::fmt -> string
 
 fn isize::fmt -> string
   statements:
-    use BindingId(109) val site=SiteId(818) ty=isize intent=Read
-    return site=Some(SiteId(816)) ty=string
+    use BindingId(109) val site=SiteId(820) ty=isize intent=Read
+    return site=Some(SiteId(818)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1477,8 +1480,8 @@ fn isize::fmt -> string
 
 fn usize::fmt -> string
   statements:
-    use BindingId(110) val site=SiteId(822) ty=usize intent=Read
-    return site=Some(SiteId(820)) ty=string
+    use BindingId(110) val site=SiteId(824) ty=usize intent=Read
+    return site=Some(SiteId(822)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1489,8 +1492,8 @@ fn usize::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(111) val site=SiteId(825) ty=bool intent=Read
-    return site=Some(SiteId(824)) ty=string
+    use BindingId(111) val site=SiteId(827) ty=bool intent=Read
+    return site=Some(SiteId(826)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -1501,8 +1504,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(112) val site=SiteId(828) ty=char intent=Read
-    return site=Some(SiteId(827)) ty=string
+    use BindingId(112) val site=SiteId(830) ty=char intent=Read
+    return site=Some(SiteId(829)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -1513,8 +1516,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(113) val site=SiteId(831) ty=f64 intent=Read
-    return site=Some(SiteId(830)) ty=string
+    use BindingId(113) val site=SiteId(833) ty=f64 intent=Read
+    return site=Some(SiteId(832)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1525,8 +1528,8 @@ fn f64::fmt -> string
 
 fn f32::fmt -> string
   statements:
-    use BindingId(114) val site=SiteId(835) ty=f32 intent=Read
-    return site=Some(SiteId(833)) ty=string
+    use BindingId(114) val site=SiteId(837) ty=f32 intent=Read
+    return site=Some(SiteId(835)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1537,16 +1540,16 @@ fn f32::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(115) val site=SiteId(837) ty=string intent=Read
-    return site=Some(SiteId(837)) ty=string
+    use BindingId(115) val site=SiteId(839) ty=string intent=Read
+    return site=Some(SiteId(839)) ty=string
   drop_plans:
     return[bb0] ->
       (none)
 
 fn duration::from_nanos -> duration
   statements:
-    use BindingId(116) n site=SiteId(839) ty=i64 intent=Read
-    return site=Some(SiteId(838)) ty=duration
+    use BindingId(116) n site=SiteId(841) ty=i64 intent=Read
+    return site=Some(SiteId(840)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1557,8 +1560,8 @@ fn duration::from_nanos -> duration
 
 fn duration::from_micros -> duration
   statements:
-    use BindingId(117) n site=SiteId(842) ty=i64 intent=Read
-    return site=Some(SiteId(841)) ty=duration
+    use BindingId(117) n site=SiteId(844) ty=i64 intent=Read
+    return site=Some(SiteId(843)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1569,8 +1572,8 @@ fn duration::from_micros -> duration
 
 fn duration::from_millis -> duration
   statements:
-    use BindingId(118) n site=SiteId(845) ty=i64 intent=Read
-    return site=Some(SiteId(844)) ty=duration
+    use BindingId(118) n site=SiteId(847) ty=i64 intent=Read
+    return site=Some(SiteId(846)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1581,8 +1584,8 @@ fn duration::from_millis -> duration
 
 fn duration::from_secs -> duration
   statements:
-    use BindingId(119) n site=SiteId(848) ty=i64 intent=Read
-    return site=Some(SiteId(847)) ty=duration
+    use BindingId(119) n site=SiteId(850) ty=i64 intent=Read
+    return site=Some(SiteId(849)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1593,8 +1596,8 @@ fn duration::from_secs -> duration
 
 fn duration::fmt -> string
   statements:
-    use BindingId(120) val site=SiteId(853) ty=duration intent=Read
-    return site=Some(SiteId(850)) ty=string
+    use BindingId(120) val site=SiteId(855) ty=duration intent=Read
+    return site=Some(SiteId(852)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
@@ -1425,15 +1425,16 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _5: Result<bytes, IoError>
     _6: i32
     _7: bool
-    _8: Result<bytes, IoError>
-    _9: i64
+    _8: string
+    _9: Result<bytes, IoError>
     _10: i64
-    _11: IoError
-    _12: Result<bytes, IoError>
+    _11: i64
+    _12: IoError
     _13: Result<bytes, IoError>
-    _14: i64
-    _15: Result<bytes, IoError>
+    _14: Result<bytes, IoError>
+    _15: i64
     _16: Result<bytes, IoError>
+    _17: Result<bytes, IoError>
   bb0:
     stmt: use BindingId(51) file_path site=SiteId(466) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
@@ -1449,29 +1450,32 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _7 = icmp.ne _4 _6
     branch _7 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(53) errno site=SiteId(478) ty=i32 intent=Read
-    _9 = const.i64 1
-    mtag8 = move _9
-    _10 = cast _4 i32 -> i64
-    _11 = call fs$io_error_from_errno(_10) -> bb6
+    _8 = call hew_stream_last_error() -> bb6
   bb4:
-    stmt: use BindingId(52) data site=SiteId(482) ty=bytes intent=Read
-    stmt: agg_alias BindingId(52) data site=SiteId(482) ty=bytes
-    _14 = const.i64 0
-    mtag13 = move _14
-    mvar13.0.0 = move _2
-    _15 = move _13
-    _5 = move _15
+    stmt: use BindingId(52) data site=SiteId(484) ty=bytes intent=Read
+    stmt: agg_alias BindingId(52) data site=SiteId(484) ty=bytes
+    _15 = const.i64 0
+    mtag14 = move _15
+    mvar14.0.0 = move _2
+    _16 = move _14
+    _5 = move _16
     goto bb5
   bb5:
     stmt: return site=Some(SiteId(464)) ty=Result<bytes, IoError>
-    _16 = move _5
-    ret = move _16
+    _17 = move _5
+    ret = move _17
     return
   bb6:
-    mvar8.1.0 = move _11
-    _12 = move _8
-    _5 = move _12
+    stmt: eval site=SiteId(475) ty=string
+    stmt: use BindingId(53) errno site=SiteId(480) ty=i32 intent=Read
+    _10 = const.i64 1
+    mtag9 = move _10
+    _11 = cast _4 i32 -> i64
+    _12 = call fs$io_error_from_errno(_11) -> bb7
+  bb7:
+    mvar9.1.0 = move _12
+    _13 = move _9
+    _5 = move _13
     goto bb5
 
 fn fs$write_bytes(string, bytes) -> i64 [conv=default]
@@ -1482,11 +1486,11 @@ fn fs$write_bytes(string, bytes) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(54) path site=SiteId(486) ty=string intent=Read
-    stmt: use BindingId(55) data site=SiteId(487) ty=bytes intent=Read
+    stmt: use BindingId(54) path site=SiteId(488) ty=string intent=Read
+    stmt: use BindingId(55) data site=SiteId(489) ty=bytes intent=Read
     _2 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(483)) ty=i64
+    stmt: return site=Some(SiteId(485)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1508,14 +1512,14 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(56) file_path site=SiteId(492) ty=string intent=Read
-    stmt: use BindingId(57) data site=SiteId(493) ty=bytes intent=Read
+    stmt: use BindingId(56) file_path site=SiteId(494) ty=string intent=Read
+    stmt: use BindingId(57) data site=SiteId(495) ty=bytes intent=Read
     _3 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(489)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(491)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1523,7 +1527,7 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(56) file_path site=SiteId(499) ty=string intent=Read
+    stmt: use BindingId(56) file_path site=SiteId(501) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$write_error(_0) -> bb7
@@ -1548,10 +1552,10 @@ fn fs$mkdir(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(58) path site=SiteId(504) ty=string intent=Read
+    stmt: use BindingId(58) path site=SiteId(506) ty=string intent=Read
     _1 = call hew_fs_mkdir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(501)) ty=i64
+    stmt: return site=Some(SiteId(503)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1572,13 +1576,13 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(59) dir_path site=SiteId(509) ty=string intent=Read
+    stmt: use BindingId(59) dir_path site=SiteId(511) ty=string intent=Read
     _2 = call hew_fs_mkdir(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(506)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(508)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1586,7 +1590,7 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(59) dir_path site=SiteId(515) ty=string intent=Read
+    stmt: use BindingId(59) dir_path site=SiteId(517) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
     _11 = call fs$mkdir_error(_0) -> bb7
@@ -1611,10 +1615,10 @@ fn fs$mkdir_all(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(60) path site=SiteId(520) ty=string intent=Read
+    stmt: use BindingId(60) path site=SiteId(522) ty=string intent=Read
     _1 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(517)) ty=i64
+    stmt: return site=Some(SiteId(519)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1647,13 +1651,13 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _22: Result<i64, IoError>
     _23: Result<i64, IoError>
   bb0:
-    stmt: use BindingId(61) dir_path site=SiteId(525) ty=string intent=Read
+    stmt: use BindingId(61) dir_path site=SiteId(527) ty=string intent=Read
     _2 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(522)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(524)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1661,7 +1665,7 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(61) dir_path site=SiteId(532) ty=string intent=Read
+    stmt: use BindingId(61) dir_path site=SiteId(534) ty=string intent=Read
     _10 = call fs$exists(_0) -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
@@ -1707,10 +1711,10 @@ fn fs$list_dir(string) -> Vec<string> [conv=default]
     _1: Vec<string>
     _2: Vec<string>
   bb0:
-    stmt: use BindingId(62) path site=SiteId(544) ty=string intent=Read
+    stmt: use BindingId(62) path site=SiteId(546) ty=string intent=Read
     _1 = call hew_fs_list_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(542)) ty=Vec<string>
+    stmt: return site=Some(SiteId(544)) ty=Vec<string>
     _2 = move _1
     ret = move _2
     return
@@ -1739,13 +1743,13 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
     _19: Vec<string>
     _20: Vec<string>
   bb0:
-    stmt: use BindingId(63) dir_path site=SiteId(548) ty=string intent=Read
+    stmt: use BindingId(63) dir_path site=SiteId(550) ty=string intent=Read
     _2 = call fs$exists(_0) -> bb1
   bb1:
     _3 = not _2
     branch _3 ? bb2 : bb3
   bb2:
-    stmt: return site=Some(SiteId(550)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(552)) ty=Result<Vec<string>, IoError>
     _5 = const.i64 1
     mtag4 = move _5
     _7 = const.i64 0
@@ -1758,8 +1762,8 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   bb3:
     goto bb4
   bb4:
-    stmt: eval site=SiteId(554) ty=()
-    stmt: use BindingId(63) dir_path site=SiteId(557) ty=string intent=Read
+    stmt: eval site=SiteId(556) ty=()
+    stmt: use BindingId(63) dir_path site=SiteId(559) ty=string intent=Read
     _10 = call fs$is_dir(_0) -> bb6
   bb5:
     goto bb4
@@ -1767,7 +1771,7 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
     _11 = not _10
     branch _11 ? bb7 : bb8
   bb7:
-    stmt: return site=Some(SiteId(559)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(561)) ty=Result<Vec<string>, IoError>
     _13 = const.i64 1
     mtag12 = move _13
     _15 = const.i64 5
@@ -1780,15 +1784,15 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   bb8:
     goto bb9
   bb9:
-    stmt: eval site=SiteId(563) ty=()
-    stmt: use BindingId(63) dir_path site=SiteId(567) ty=string intent=Read
+    stmt: eval site=SiteId(565) ty=()
+    stmt: use BindingId(63) dir_path site=SiteId(569) ty=string intent=Read
     _18 = const.i64 0
     mtag17 = move _18
     _19 = call hew_fs_list_dir(_0) -> bb11
   bb10:
     goto bb9
   bb11:
-    stmt: return site=Some(SiteId(564)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(566)) ty=Result<Vec<string>, IoError>
     _20 = move _19
     mvar17.0.0 = move _20
     ret = move _17
@@ -1802,11 +1806,11 @@ fn fs$rename(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(64) from site=SiteId(572) ty=string intent=Read
-    stmt: use BindingId(65) to site=SiteId(573) ty=string intent=Read
+    stmt: use BindingId(64) from site=SiteId(574) ty=string intent=Read
+    stmt: use BindingId(65) to site=SiteId(575) ty=string intent=Read
     _2 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(569)) ty=i64
+    stmt: return site=Some(SiteId(571)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1828,14 +1832,14 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(66) from site=SiteId(578) ty=string intent=Read
-    stmt: use BindingId(67) to site=SiteId(579) ty=string intent=Read
+    stmt: use BindingId(66) from site=SiteId(580) ty=string intent=Read
+    stmt: use BindingId(67) to site=SiteId(581) ty=string intent=Read
     _3 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(575)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(577)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1843,8 +1847,8 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(66) from site=SiteId(585) ty=string intent=Read
-    stmt: use BindingId(67) to site=SiteId(586) ty=string intent=Read
+    stmt: use BindingId(66) from site=SiteId(587) ty=string intent=Read
+    stmt: use BindingId(67) to site=SiteId(588) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$move_copy_error(_0, _1) -> bb7
@@ -1870,11 +1874,11 @@ fn fs$copy(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(68) from site=SiteId(591) ty=string intent=Read
-    stmt: use BindingId(69) to site=SiteId(592) ty=string intent=Read
+    stmt: use BindingId(68) from site=SiteId(593) ty=string intent=Read
+    stmt: use BindingId(69) to site=SiteId(594) ty=string intent=Read
     _2 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(588)) ty=i64
+    stmt: return site=Some(SiteId(590)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1896,14 +1900,14 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(70) from site=SiteId(597) ty=string intent=Read
-    stmt: use BindingId(71) to site=SiteId(598) ty=string intent=Read
+    stmt: use BindingId(70) from site=SiteId(599) ty=string intent=Read
+    stmt: use BindingId(71) to site=SiteId(600) ty=string intent=Read
     _3 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(594)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(596)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1911,8 +1915,8 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(70) from site=SiteId(604) ty=string intent=Read
-    stmt: use BindingId(71) to site=SiteId(605) ty=string intent=Read
+    stmt: use BindingId(70) from site=SiteId(606) ty=string intent=Read
+    stmt: use BindingId(71) to site=SiteId(607) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$move_copy_error(_0, _1) -> bb7
@@ -1936,10 +1940,10 @@ fn fs$is_dir(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(72) path site=SiteId(609) ty=string intent=Read
+    stmt: use BindingId(72) path site=SiteId(611) ty=string intent=Read
     _1 = call hew_fs_is_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(607)) ty=bool
+    stmt: return site=Some(SiteId(609)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -1957,31 +1961,31 @@ fn stream$pipe(i64) -> (Sink<string>, Stream<string>) [conv=default]
     _8: (Sink<string>, Stream<string>)
     _9: (Sink<string>, Stream<string>)
   bb0:
-    stmt: use BindingId(73) capacity site=SiteId(614) ty=i64 intent=Read
+    stmt: use BindingId(73) capacity site=SiteId(616) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(74) pair site=SiteId(612) ty=StreamPair
-    stmt: use BindingId(74) pair site=SiteId(617) ty=StreamPair intent=Read
+    stmt: bind BindingId(74) pair site=SiteId(614) ty=StreamPair
+    stmt: use BindingId(74) pair site=SiteId(619) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink(_3) -> bb2
   bb2:
-    stmt: bind BindingId(75) sink site=SiteId(616) ty=Sink<string>
-    stmt: use BindingId(74) pair site=SiteId(620) ty=StreamPair intent=Read
+    stmt: bind BindingId(75) sink site=SiteId(618) ty=Sink<string>
+    stmt: use BindingId(74) pair site=SiteId(622) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream(_3) -> bb3
   bb3:
-    stmt: bind BindingId(76) input site=SiteId(619) ty=Stream<string>
-    stmt: use BindingId(74) pair site=SiteId(623) ty=StreamPair intent=Read
+    stmt: bind BindingId(76) input site=SiteId(621) ty=Stream<string>
+    stmt: use BindingId(74) pair site=SiteId(625) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(622) ty=()
-    stmt: use BindingId(75) sink site=SiteId(626) ty=Sink<string> intent=Read
-    stmt: use BindingId(76) input site=SiteId(627) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(75) sink site=SiteId(626) ty=Sink<string>
-    stmt: agg_alias BindingId(76) input site=SiteId(627) ty=Stream<string>
-    stmt: return site=Some(SiteId(611)) ty=(Sink<string>, Stream<string>)
+    stmt: eval site=SiteId(624) ty=()
+    stmt: use BindingId(75) sink site=SiteId(628) ty=Sink<string> intent=Read
+    stmt: use BindingId(76) input site=SiteId(629) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(75) sink site=SiteId(628) ty=Sink<string>
+    stmt: agg_alias BindingId(76) input site=SiteId(629) ty=Stream<string>
+    stmt: return site=Some(SiteId(613)) ty=(Sink<string>, Stream<string>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2000,31 +2004,31 @@ fn stream$bytes_pipe(i64) -> (Sink<bytes>, Stream<bytes>) [conv=default]
     _8: (Sink<bytes>, Stream<bytes>)
     _9: (Sink<bytes>, Stream<bytes>)
   bb0:
-    stmt: use BindingId(77) capacity site=SiteId(631) ty=i64 intent=Read
+    stmt: use BindingId(77) capacity site=SiteId(633) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(78) pair site=SiteId(629) ty=StreamPair
-    stmt: use BindingId(78) pair site=SiteId(634) ty=StreamPair intent=Read
+    stmt: bind BindingId(78) pair site=SiteId(631) ty=StreamPair
+    stmt: use BindingId(78) pair site=SiteId(636) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink_bytes(_3) -> bb2
   bb2:
-    stmt: bind BindingId(79) sink site=SiteId(633) ty=Sink<bytes>
-    stmt: use BindingId(78) pair site=SiteId(637) ty=StreamPair intent=Read
+    stmt: bind BindingId(79) sink site=SiteId(635) ty=Sink<bytes>
+    stmt: use BindingId(78) pair site=SiteId(639) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream_bytes(_3) -> bb3
   bb3:
-    stmt: bind BindingId(80) input site=SiteId(636) ty=Stream<bytes>
-    stmt: use BindingId(78) pair site=SiteId(640) ty=StreamPair intent=Read
+    stmt: bind BindingId(80) input site=SiteId(638) ty=Stream<bytes>
+    stmt: use BindingId(78) pair site=SiteId(642) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(639) ty=()
-    stmt: use BindingId(79) sink site=SiteId(643) ty=Sink<bytes> intent=Read
-    stmt: use BindingId(80) input site=SiteId(644) ty=Stream<bytes> intent=Read
-    stmt: agg_alias BindingId(79) sink site=SiteId(643) ty=Sink<bytes>
-    stmt: agg_alias BindingId(80) input site=SiteId(644) ty=Stream<bytes>
-    stmt: return site=Some(SiteId(628)) ty=(Sink<bytes>, Stream<bytes>)
+    stmt: eval site=SiteId(641) ty=()
+    stmt: use BindingId(79) sink site=SiteId(645) ty=Sink<bytes> intent=Read
+    stmt: use BindingId(80) input site=SiteId(646) ty=Stream<bytes> intent=Read
+    stmt: agg_alias BindingId(79) sink site=SiteId(645) ty=Sink<bytes>
+    stmt: agg_alias BindingId(80) input site=SiteId(646) ty=Stream<bytes>
+    stmt: return site=Some(SiteId(630)) ty=(Sink<bytes>, Stream<bytes>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2046,18 +2050,18 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     _11: Result<Stream<string>, string>
     _12: Result<Stream<string>, string>
   bb0:
-    stmt: use BindingId(81) path site=SiteId(647) ty=string intent=Read
+    stmt: use BindingId(81) path site=SiteId(649) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(82) s site=SiteId(646) ty=Stream<string>
-    stmt: use BindingId(82) s site=SiteId(651) ty=Stream<string> intent=Read
+    stmt: bind BindingId(82) s site=SiteId(648) ty=Stream<string>
+    stmt: use BindingId(82) s site=SiteId(653) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(82) s site=SiteId(655) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(82) s site=SiteId(655) ty=Stream<string>
+    stmt: use BindingId(82) s site=SiteId(657) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(82) s site=SiteId(657) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2069,7 +2073,7 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(645)) ty=Result<Stream<string>, string>
+    stmt: return site=Some(SiteId(647)) ty=Result<Stream<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2099,18 +2103,18 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _15: Result<Stream<string>, fs.IoError>
     _16: Result<Stream<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(83) path site=SiteId(662) ty=string intent=Read
+    stmt: use BindingId(83) path site=SiteId(664) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(84) s site=SiteId(661) ty=Stream<string>
-    stmt: use BindingId(84) s site=SiteId(666) ty=Stream<string> intent=Read
+    stmt: bind BindingId(84) s site=SiteId(663) ty=Stream<string>
+    stmt: use BindingId(84) s site=SiteId(668) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(84) s site=SiteId(670) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(84) s site=SiteId(670) ty=Stream<string>
+    stmt: use BindingId(84) s site=SiteId(672) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(84) s site=SiteId(672) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2120,17 +2124,17 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
   bb4:
     _8 = call hew_stream_last_errno() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(660)) ty=Result<Stream<string>, fs.IoError>
+    stmt: return site=Some(SiteId(662)) ty=Result<Stream<string>, fs.IoError>
     _16 = move _3
     ret = move _16
     return
   bb6:
-    stmt: bind BindingId(85) errno site=SiteId(672) ty=i32
+    stmt: bind BindingId(85) errno site=SiteId(674) ty=i32
     _9 = move _8
     _10 = call hew_stream_last_error() -> bb7
   bb7:
-    stmt: eval site=SiteId(674) ty=string
-    stmt: use BindingId(85) errno site=SiteId(679) ty=i32 intent=Read
+    stmt: eval site=SiteId(676) ty=string
+    stmt: use BindingId(85) errno site=SiteId(681) ty=i32 intent=Read
     _12 = const.i64 1
     mtag11 = move _12
     _13 = cast _9 i32 -> i64
@@ -2157,18 +2161,18 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     _11: Result<Sink<string>, string>
     _12: Result<Sink<string>, string>
   bb0:
-    stmt: use BindingId(86) path site=SiteId(683) ty=string intent=Read
+    stmt: use BindingId(86) path site=SiteId(685) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(87) s site=SiteId(682) ty=Sink<string>
-    stmt: use BindingId(87) s site=SiteId(687) ty=Sink<string> intent=Read
+    stmt: bind BindingId(87) s site=SiteId(684) ty=Sink<string>
+    stmt: use BindingId(87) s site=SiteId(689) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(87) s site=SiteId(691) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(87) s site=SiteId(691) ty=Sink<string>
+    stmt: use BindingId(87) s site=SiteId(693) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(87) s site=SiteId(693) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2180,7 +2184,7 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(681)) ty=Result<Sink<string>, string>
+    stmt: return site=Some(SiteId(683)) ty=Result<Sink<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2210,18 +2214,18 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _15: Result<Sink<string>, fs.IoError>
     _16: Result<Sink<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(88) path site=SiteId(698) ty=string intent=Read
+    stmt: use BindingId(88) path site=SiteId(700) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(89) s site=SiteId(697) ty=Sink<string>
-    stmt: use BindingId(89) s site=SiteId(702) ty=Sink<string> intent=Read
+    stmt: bind BindingId(89) s site=SiteId(699) ty=Sink<string>
+    stmt: use BindingId(89) s site=SiteId(704) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(89) s site=SiteId(706) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(89) s site=SiteId(706) ty=Sink<string>
+    stmt: use BindingId(89) s site=SiteId(708) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(89) s site=SiteId(708) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2231,17 +2235,17 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
   bb4:
     _8 = call hew_stream_last_errno() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(696)) ty=Result<Sink<string>, fs.IoError>
+    stmt: return site=Some(SiteId(698)) ty=Result<Sink<string>, fs.IoError>
     _16 = move _3
     ret = move _16
     return
   bb6:
-    stmt: bind BindingId(90) errno site=SiteId(708) ty=i32
+    stmt: bind BindingId(90) errno site=SiteId(710) ty=i32
     _9 = move _8
     _10 = call hew_stream_last_error() -> bb7
   bb7:
-    stmt: eval site=SiteId(710) ty=string
-    stmt: use BindingId(90) errno site=SiteId(715) ty=i32 intent=Read
+    stmt: eval site=SiteId(712) ty=string
+    stmt: use BindingId(90) errno site=SiteId(717) ty=i32 intent=Read
     _12 = const.i64 1
     mtag11 = move _12
     _13 = cast _9 i32 -> i64
@@ -2257,11 +2261,11 @@ fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
     _0: Stream<string>
     _1: Sink<string>
   bb0:
-    stmt: use BindingId(91) source site=SiteId(719) ty=Stream<string> intent=Read
-    stmt: use BindingId(92) dest site=SiteId(720) ty=Sink<string> intent=Read
+    stmt: use BindingId(91) source site=SiteId(721) ty=Stream<string> intent=Read
+    stmt: use BindingId(92) dest site=SiteId(722) ty=Sink<string> intent=Read
     call hew_stream_pipe(_0, _1) -> bb1
   bb1:
-    stmt: eval site=SiteId(717) ty=()
+    stmt: eval site=SiteId(719) ty=()
     return
 
 fn i8::fmt(i8) -> string [conv=default]
@@ -2270,11 +2274,11 @@ fn i8::fmt(i8) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(101) val site=SiteId(792) ty=i8 intent=Read
+    stmt: use BindingId(101) val site=SiteId(794) ty=i8 intent=Read
     _1 = cast _0 i8 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(790)) ty=string
+    stmt: return site=Some(SiteId(792)) ty=string
     ret = move _2
     return
 
@@ -2284,11 +2288,11 @@ fn i16::fmt(i16) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(102) val site=SiteId(796) ty=i16 intent=Read
+    stmt: use BindingId(102) val site=SiteId(798) ty=i16 intent=Read
     _1 = cast _0 i16 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(794)) ty=string
+    stmt: return site=Some(SiteId(796)) ty=string
     ret = move _2
     return
 
@@ -2297,10 +2301,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(103) val site=SiteId(799) ty=i32 intent=Read
+    stmt: use BindingId(103) val site=SiteId(801) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(798)) ty=string
+    stmt: return site=Some(SiteId(800)) ty=string
     ret = move _1
     return
 
@@ -2309,10 +2313,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(104) val site=SiteId(802) ty=i64 intent=Read
+    stmt: use BindingId(104) val site=SiteId(804) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(801)) ty=string
+    stmt: return site=Some(SiteId(803)) ty=string
     ret = move _1
     return
 
@@ -2321,10 +2325,10 @@ fn u8::fmt(u8) -> string [conv=default]
     _0: u8
     _1: string
   bb0:
-    stmt: use BindingId(105) val site=SiteId(805) ty=u8 intent=Read
+    stmt: use BindingId(105) val site=SiteId(807) ty=u8 intent=Read
     _1 = call to_string_u8(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(804)) ty=string
+    stmt: return site=Some(SiteId(806)) ty=string
     ret = move _1
     return
 
@@ -2333,10 +2337,10 @@ fn u16::fmt(u16) -> string [conv=default]
     _0: u16
     _1: string
   bb0:
-    stmt: use BindingId(106) val site=SiteId(808) ty=u16 intent=Read
+    stmt: use BindingId(106) val site=SiteId(810) ty=u16 intent=Read
     _1 = call to_string_u16(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(807)) ty=string
+    stmt: return site=Some(SiteId(809)) ty=string
     ret = move _1
     return
 
@@ -2345,10 +2349,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(107) val site=SiteId(811) ty=u32 intent=Read
+    stmt: use BindingId(107) val site=SiteId(813) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(810)) ty=string
+    stmt: return site=Some(SiteId(812)) ty=string
     ret = move _1
     return
 
@@ -2357,10 +2361,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(108) val site=SiteId(814) ty=u64 intent=Read
+    stmt: use BindingId(108) val site=SiteId(816) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(813)) ty=string
+    stmt: return site=Some(SiteId(815)) ty=string
     ret = move _1
     return
 
@@ -2370,11 +2374,11 @@ fn isize::fmt(isize) -> string [conv=default]
     _1: i64
     _2: string
   bb0:
-    stmt: use BindingId(109) val site=SiteId(818) ty=isize intent=Read
+    stmt: use BindingId(109) val site=SiteId(820) ty=isize intent=Read
     _1 = cast _0 isize -> i64
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(816)) ty=string
+    stmt: return site=Some(SiteId(818)) ty=string
     ret = move _2
     return
 
@@ -2384,11 +2388,11 @@ fn usize::fmt(usize) -> string [conv=default]
     _1: u64
     _2: string
   bb0:
-    stmt: use BindingId(110) val site=SiteId(822) ty=usize intent=Read
+    stmt: use BindingId(110) val site=SiteId(824) ty=usize intent=Read
     _1 = cast _0 usize -> u64
     _2 = call to_string_u64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(820)) ty=string
+    stmt: return site=Some(SiteId(822)) ty=string
     ret = move _2
     return
 
@@ -2397,10 +2401,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(111) val site=SiteId(825) ty=bool intent=Read
+    stmt: use BindingId(111) val site=SiteId(827) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(824)) ty=string
+    stmt: return site=Some(SiteId(826)) ty=string
     ret = move _1
     return
 
@@ -2409,10 +2413,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(112) val site=SiteId(828) ty=char intent=Read
+    stmt: use BindingId(112) val site=SiteId(830) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(827)) ty=string
+    stmt: return site=Some(SiteId(829)) ty=string
     ret = move _1
     return
 
@@ -2421,10 +2425,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(113) val site=SiteId(831) ty=f64 intent=Read
+    stmt: use BindingId(113) val site=SiteId(833) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(830)) ty=string
+    stmt: return site=Some(SiteId(832)) ty=string
     ret = move _1
     return
 
@@ -2434,11 +2438,11 @@ fn f32::fmt(f32) -> string [conv=default]
     _1: f64
     _2: string
   bb0:
-    stmt: use BindingId(114) val site=SiteId(835) ty=f32 intent=Read
+    stmt: use BindingId(114) val site=SiteId(837) ty=f32 intent=Read
     _1 = cast _0 f32 -> f64
     _2 = call to_string_f64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(833)) ty=string
+    stmt: return site=Some(SiteId(835)) ty=string
     ret = move _2
     return
 
@@ -2446,8 +2450,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(115) val site=SiteId(837) ty=string intent=Read
-    stmt: return site=Some(SiteId(837)) ty=string
+    stmt: use BindingId(115) val site=SiteId(839) ty=string intent=Read
+    stmt: return site=Some(SiteId(839)) ty=string
     ret = move _0
     return
 
@@ -2458,14 +2462,14 @@ fn duration::from_nanos(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(116) n site=SiteId(839) ty=i64 intent=Read
+    stmt: use BindingId(116) n site=SiteId(841) ty=i64 intent=Read
     _1 = const.duration 1ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(838)) ty=duration
+    stmt: return site=Some(SiteId(840)) ty=duration
     ret = move _2
     return
 
@@ -2476,14 +2480,14 @@ fn duration::from_micros(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(117) n site=SiteId(842) ty=i64 intent=Read
+    stmt: use BindingId(117) n site=SiteId(844) ty=i64 intent=Read
     _1 = const.duration 1000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(841)) ty=duration
+    stmt: return site=Some(SiteId(843)) ty=duration
     ret = move _2
     return
 
@@ -2494,14 +2498,14 @@ fn duration::from_millis(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(118) n site=SiteId(845) ty=i64 intent=Read
+    stmt: use BindingId(118) n site=SiteId(847) ty=i64 intent=Read
     _1 = const.duration 1000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(844)) ty=duration
+    stmt: return site=Some(SiteId(846)) ty=duration
     ret = move _2
     return
 
@@ -2512,14 +2516,14 @@ fn duration::from_secs(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(119) n site=SiteId(848) ty=i64 intent=Read
+    stmt: use BindingId(119) n site=SiteId(850) ty=i64 intent=Read
     _1 = const.duration 1000000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(847)) ty=duration
+    stmt: return site=Some(SiteId(849)) ty=duration
     ret = move _2
     return
 
@@ -2531,11 +2535,11 @@ fn duration::fmt(duration) -> string [conv=default]
     _3: string
     _4: string
   bb0:
-    stmt: use BindingId(120) val site=SiteId(853) ty=duration intent=Read
+    stmt: use BindingId(120) val site=SiteId(855) ty=duration intent=Read
     _1 = call_rt hew_duration_nanos(_0)
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(850)) ty=string
+    stmt: return site=Some(SiteId(852)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
     ret = move _4

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.elab.mir
@@ -884,10 +884,11 @@ fn fs$try_read_bytes -> Result<bytes, IoError>
     bind BindingId(57) data site=SiteId(484) ty=bytes
     bind BindingId(58) errno site=SiteId(487) ty=i32
     use BindingId(58) errno site=SiteId(491) ty=i32 intent=Read
-    use BindingId(58) errno site=SiteId(497) ty=i32 intent=Read
-    use BindingId(57) data site=SiteId(501) ty=bytes intent=Read
-    agg_alias BindingId(57) data site=SiteId(501) ty=bytes
+    use BindingId(57) data site=SiteId(503) ty=bytes intent=Read
+    agg_alias BindingId(57) data site=SiteId(503) ty=bytes
     return site=Some(SiteId(483)) ty=Result<bytes, IoError>
+    eval site=SiteId(494) ty=string
+    use BindingId(58) errno site=SiteId(499) ty=i32 intent=Read
     drop BindingId(57) data ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
@@ -898,22 +899,24 @@ fn fs$try_read_bytes -> Result<bytes, IoError>
       (none)
     branch[bb2: bb3/bb4] ->
       (none)
-    call[bb3 fs$io_error_from_errno -> bb6] ->
+    call[bb3 hew_stream_last_error -> bb6] ->
       (none)
     goto[bb4->bb5] ->
       (none)
     return[bb5] ->
       (none)
-    goto[bb6->bb5] ->
+    call[bb6 fs$io_error_from_errno -> bb7] ->
       (none)
-    cancel[bb6] ->
+    goto[bb7->bb5] ->
+      (none)
+    cancel[bb7] ->
       (none)
 
 fn fs$write_bytes -> i64
   statements:
-    use BindingId(59) path site=SiteId(505) ty=string intent=Read
-    use BindingId(60) data site=SiteId(506) ty=bytes intent=Read
-    return site=Some(SiteId(502)) ty=i64
+    use BindingId(59) path site=SiteId(507) ty=string intent=Read
+    use BindingId(60) data site=SiteId(508) ty=bytes intent=Read
+    return site=Some(SiteId(504)) ty=i64
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -924,10 +927,10 @@ fn fs$write_bytes -> i64
 
 fn fs$try_write_bytes -> Result<i64, IoError>
   statements:
-    use BindingId(61) file_path site=SiteId(511) ty=string intent=Read
-    use BindingId(62) data site=SiteId(512) ty=bytes intent=Read
-    return site=Some(SiteId(508)) ty=Result<i64, IoError>
-    use BindingId(61) file_path site=SiteId(518) ty=string intent=Read
+    use BindingId(61) file_path site=SiteId(513) ty=string intent=Read
+    use BindingId(62) data site=SiteId(514) ty=bytes intent=Read
+    return site=Some(SiteId(510)) ty=Result<i64, IoError>
+    use BindingId(61) file_path site=SiteId(520) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -954,8 +957,8 @@ fn fs$try_write_bytes -> Result<i64, IoError>
 
 fn fs$mkdir -> i64
   statements:
-    use BindingId(63) path site=SiteId(523) ty=string intent=Read
-    return site=Some(SiteId(520)) ty=i64
+    use BindingId(63) path site=SiteId(525) ty=string intent=Read
+    return site=Some(SiteId(522)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -966,9 +969,9 @@ fn fs$mkdir -> i64
 
 fn fs$try_mkdir -> Result<i64, IoError>
   statements:
-    use BindingId(64) dir_path site=SiteId(528) ty=string intent=Read
-    return site=Some(SiteId(525)) ty=Result<i64, IoError>
-    use BindingId(64) dir_path site=SiteId(534) ty=string intent=Read
+    use BindingId(64) dir_path site=SiteId(530) ty=string intent=Read
+    return site=Some(SiteId(527)) ty=Result<i64, IoError>
+    use BindingId(64) dir_path site=SiteId(536) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -995,8 +998,8 @@ fn fs$try_mkdir -> Result<i64, IoError>
 
 fn fs$mkdir_all -> i64
   statements:
-    use BindingId(65) path site=SiteId(539) ty=string intent=Read
-    return site=Some(SiteId(536)) ty=i64
+    use BindingId(65) path site=SiteId(541) ty=string intent=Read
+    return site=Some(SiteId(538)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -1007,9 +1010,9 @@ fn fs$mkdir_all -> i64
 
 fn fs$try_mkdir_all -> Result<i64, IoError>
   statements:
-    use BindingId(66) dir_path site=SiteId(544) ty=string intent=Read
-    return site=Some(SiteId(541)) ty=Result<i64, IoError>
-    use BindingId(66) dir_path site=SiteId(551) ty=string intent=Read
+    use BindingId(66) dir_path site=SiteId(546) ty=string intent=Read
+    return site=Some(SiteId(543)) ty=Result<i64, IoError>
+    use BindingId(66) dir_path site=SiteId(553) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -1042,8 +1045,8 @@ fn fs$try_mkdir_all -> Result<i64, IoError>
 
 fn fs$list_dir -> Vec<string>
   statements:
-    use BindingId(67) path site=SiteId(563) ty=string intent=Read
-    return site=Some(SiteId(561)) ty=Vec<string>
+    use BindingId(67) path site=SiteId(565) ty=string intent=Read
+    return site=Some(SiteId(563)) ty=Vec<string>
   drop_plans:
     call[bb0 hew_fs_list_dir -> bb1] ->
       (none)
@@ -1054,14 +1057,14 @@ fn fs$list_dir -> Vec<string>
 
 fn fs$try_list_dir -> Result<Vec<string>, IoError>
   statements:
-    use BindingId(68) dir_path site=SiteId(567) ty=string intent=Read
-    return site=Some(SiteId(569)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(573) ty=()
-    use BindingId(68) dir_path site=SiteId(576) ty=string intent=Read
-    return site=Some(SiteId(578)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(582) ty=()
-    use BindingId(68) dir_path site=SiteId(586) ty=string intent=Read
-    return site=Some(SiteId(583)) ty=Result<Vec<string>, IoError>
+    use BindingId(68) dir_path site=SiteId(569) ty=string intent=Read
+    return site=Some(SiteId(571)) ty=Result<Vec<string>, IoError>
+    eval site=SiteId(575) ty=()
+    use BindingId(68) dir_path site=SiteId(578) ty=string intent=Read
+    return site=Some(SiteId(580)) ty=Result<Vec<string>, IoError>
+    eval site=SiteId(584) ty=()
+    use BindingId(68) dir_path site=SiteId(588) ty=string intent=Read
+    return site=Some(SiteId(585)) ty=Result<Vec<string>, IoError>
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -1096,9 +1099,9 @@ fn fs$try_list_dir -> Result<Vec<string>, IoError>
 
 fn fs$rename -> i64
   statements:
-    use BindingId(69) from site=SiteId(591) ty=string intent=Read
-    use BindingId(70) to site=SiteId(592) ty=string intent=Read
-    return site=Some(SiteId(588)) ty=i64
+    use BindingId(69) from site=SiteId(593) ty=string intent=Read
+    use BindingId(70) to site=SiteId(594) ty=string intent=Read
+    return site=Some(SiteId(590)) ty=i64
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1109,11 +1112,11 @@ fn fs$rename -> i64
 
 fn fs$try_rename -> Result<i64, IoError>
   statements:
-    use BindingId(71) from site=SiteId(597) ty=string intent=Read
-    use BindingId(72) to site=SiteId(598) ty=string intent=Read
-    return site=Some(SiteId(594)) ty=Result<i64, IoError>
-    use BindingId(71) from site=SiteId(604) ty=string intent=Read
-    use BindingId(72) to site=SiteId(605) ty=string intent=Read
+    use BindingId(71) from site=SiteId(599) ty=string intent=Read
+    use BindingId(72) to site=SiteId(600) ty=string intent=Read
+    return site=Some(SiteId(596)) ty=Result<i64, IoError>
+    use BindingId(71) from site=SiteId(606) ty=string intent=Read
+    use BindingId(72) to site=SiteId(607) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1140,9 +1143,9 @@ fn fs$try_rename -> Result<i64, IoError>
 
 fn fs$copy -> i64
   statements:
-    use BindingId(73) from site=SiteId(610) ty=string intent=Read
-    use BindingId(74) to site=SiteId(611) ty=string intent=Read
-    return site=Some(SiteId(607)) ty=i64
+    use BindingId(73) from site=SiteId(612) ty=string intent=Read
+    use BindingId(74) to site=SiteId(613) ty=string intent=Read
+    return site=Some(SiteId(609)) ty=i64
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1153,11 +1156,11 @@ fn fs$copy -> i64
 
 fn fs$try_copy -> Result<i64, IoError>
   statements:
-    use BindingId(75) from site=SiteId(616) ty=string intent=Read
-    use BindingId(76) to site=SiteId(617) ty=string intent=Read
-    return site=Some(SiteId(613)) ty=Result<i64, IoError>
-    use BindingId(75) from site=SiteId(623) ty=string intent=Read
-    use BindingId(76) to site=SiteId(624) ty=string intent=Read
+    use BindingId(75) from site=SiteId(618) ty=string intent=Read
+    use BindingId(76) to site=SiteId(619) ty=string intent=Read
+    return site=Some(SiteId(615)) ty=Result<i64, IoError>
+    use BindingId(75) from site=SiteId(625) ty=string intent=Read
+    use BindingId(76) to site=SiteId(626) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1184,8 +1187,8 @@ fn fs$try_copy -> Result<i64, IoError>
 
 fn fs$is_dir -> bool
   statements:
-    use BindingId(77) path site=SiteId(628) ty=string intent=Read
-    return site=Some(SiteId(626)) ty=bool
+    use BindingId(77) path site=SiteId(630) ty=string intent=Read
+    return site=Some(SiteId(628)) ty=bool
   drop_plans:
     call[bb0 hew_fs_is_dir -> bb1] ->
       (none)
@@ -1196,19 +1199,19 @@ fn fs$is_dir -> bool
 
 fn stream$pipe -> (Sink<string>, Stream<string>)
   statements:
-    use BindingId(78) capacity site=SiteId(633) ty=i64 intent=Read
-    bind BindingId(79) pair site=SiteId(631) ty=StreamPair
-    use BindingId(79) pair site=SiteId(636) ty=StreamPair intent=Read
-    bind BindingId(80) sink site=SiteId(635) ty=Sink<string>
-    use BindingId(79) pair site=SiteId(639) ty=StreamPair intent=Read
-    bind BindingId(81) input site=SiteId(638) ty=Stream<string>
-    use BindingId(79) pair site=SiteId(642) ty=StreamPair intent=Read
-    eval site=SiteId(641) ty=()
-    use BindingId(80) sink site=SiteId(645) ty=Sink<string> intent=Read
-    use BindingId(81) input site=SiteId(646) ty=Stream<string> intent=Read
-    agg_alias BindingId(80) sink site=SiteId(645) ty=Sink<string>
-    agg_alias BindingId(81) input site=SiteId(646) ty=Stream<string>
-    return site=Some(SiteId(630)) ty=(Sink<string>, Stream<string>)
+    use BindingId(78) capacity site=SiteId(635) ty=i64 intent=Read
+    bind BindingId(79) pair site=SiteId(633) ty=StreamPair
+    use BindingId(79) pair site=SiteId(638) ty=StreamPair intent=Read
+    bind BindingId(80) sink site=SiteId(637) ty=Sink<string>
+    use BindingId(79) pair site=SiteId(641) ty=StreamPair intent=Read
+    bind BindingId(81) input site=SiteId(640) ty=Stream<string>
+    use BindingId(79) pair site=SiteId(644) ty=StreamPair intent=Read
+    eval site=SiteId(643) ty=()
+    use BindingId(80) sink site=SiteId(647) ty=Sink<string> intent=Read
+    use BindingId(81) input site=SiteId(648) ty=Stream<string> intent=Read
+    agg_alias BindingId(80) sink site=SiteId(647) ty=Sink<string>
+    agg_alias BindingId(81) input site=SiteId(648) ty=Stream<string>
+    return site=Some(SiteId(632)) ty=(Sink<string>, Stream<string>)
     drop BindingId(81) input ty=Stream<string>
     drop BindingId(80) sink ty=Sink<string>
   drop_plans:
@@ -1227,19 +1230,19 @@ fn stream$pipe -> (Sink<string>, Stream<string>)
 
 fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
   statements:
-    use BindingId(82) capacity site=SiteId(650) ty=i64 intent=Read
-    bind BindingId(83) pair site=SiteId(648) ty=StreamPair
-    use BindingId(83) pair site=SiteId(653) ty=StreamPair intent=Read
-    bind BindingId(84) sink site=SiteId(652) ty=Sink<bytes>
-    use BindingId(83) pair site=SiteId(656) ty=StreamPair intent=Read
-    bind BindingId(85) input site=SiteId(655) ty=Stream<bytes>
-    use BindingId(83) pair site=SiteId(659) ty=StreamPair intent=Read
-    eval site=SiteId(658) ty=()
-    use BindingId(84) sink site=SiteId(662) ty=Sink<bytes> intent=Read
-    use BindingId(85) input site=SiteId(663) ty=Stream<bytes> intent=Read
-    agg_alias BindingId(84) sink site=SiteId(662) ty=Sink<bytes>
-    agg_alias BindingId(85) input site=SiteId(663) ty=Stream<bytes>
-    return site=Some(SiteId(647)) ty=(Sink<bytes>, Stream<bytes>)
+    use BindingId(82) capacity site=SiteId(652) ty=i64 intent=Read
+    bind BindingId(83) pair site=SiteId(650) ty=StreamPair
+    use BindingId(83) pair site=SiteId(655) ty=StreamPair intent=Read
+    bind BindingId(84) sink site=SiteId(654) ty=Sink<bytes>
+    use BindingId(83) pair site=SiteId(658) ty=StreamPair intent=Read
+    bind BindingId(85) input site=SiteId(657) ty=Stream<bytes>
+    use BindingId(83) pair site=SiteId(661) ty=StreamPair intent=Read
+    eval site=SiteId(660) ty=()
+    use BindingId(84) sink site=SiteId(664) ty=Sink<bytes> intent=Read
+    use BindingId(85) input site=SiteId(665) ty=Stream<bytes> intent=Read
+    agg_alias BindingId(84) sink site=SiteId(664) ty=Sink<bytes>
+    agg_alias BindingId(85) input site=SiteId(665) ty=Stream<bytes>
+    return site=Some(SiteId(649)) ty=(Sink<bytes>, Stream<bytes>)
     drop BindingId(85) input ty=Stream<bytes>
     drop BindingId(84) sink ty=Sink<bytes>
   drop_plans:
@@ -1258,12 +1261,12 @@ fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
 
 fn stream$from_file -> Result<Stream<string>, string>
   statements:
-    use BindingId(86) path site=SiteId(666) ty=string intent=Read
-    bind BindingId(87) s site=SiteId(665) ty=Stream<string>
-    use BindingId(87) s site=SiteId(670) ty=Stream<string> intent=Read
-    use BindingId(87) s site=SiteId(674) ty=Stream<string> intent=Read
-    agg_alias BindingId(87) s site=SiteId(674) ty=Stream<string>
-    return site=Some(SiteId(664)) ty=Result<Stream<string>, string>
+    use BindingId(86) path site=SiteId(668) ty=string intent=Read
+    bind BindingId(87) s site=SiteId(667) ty=Stream<string>
+    use BindingId(87) s site=SiteId(672) ty=Stream<string> intent=Read
+    use BindingId(87) s site=SiteId(676) ty=Stream<string> intent=Read
+    agg_alias BindingId(87) s site=SiteId(676) ty=Stream<string>
+    return site=Some(SiteId(666)) ty=Result<Stream<string>, string>
     drop BindingId(87) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
@@ -1287,15 +1290,15 @@ fn stream$from_file -> Result<Stream<string>, string>
 
 fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
   statements:
-    use BindingId(88) path site=SiteId(681) ty=string intent=Read
-    bind BindingId(89) s site=SiteId(680) ty=Stream<string>
-    use BindingId(89) s site=SiteId(685) ty=Stream<string> intent=Read
-    use BindingId(89) s site=SiteId(689) ty=Stream<string> intent=Read
-    agg_alias BindingId(89) s site=SiteId(689) ty=Stream<string>
-    return site=Some(SiteId(679)) ty=Result<Stream<string>, fs.IoError>
-    bind BindingId(90) errno site=SiteId(691) ty=i32
-    eval site=SiteId(693) ty=string
-    use BindingId(90) errno site=SiteId(698) ty=i32 intent=Read
+    use BindingId(88) path site=SiteId(683) ty=string intent=Read
+    bind BindingId(89) s site=SiteId(682) ty=Stream<string>
+    use BindingId(89) s site=SiteId(687) ty=Stream<string> intent=Read
+    use BindingId(89) s site=SiteId(691) ty=Stream<string> intent=Read
+    agg_alias BindingId(89) s site=SiteId(691) ty=Stream<string>
+    return site=Some(SiteId(681)) ty=Result<Stream<string>, fs.IoError>
+    bind BindingId(90) errno site=SiteId(693) ty=i32
+    eval site=SiteId(695) ty=string
+    use BindingId(90) errno site=SiteId(700) ty=i32 intent=Read
     drop BindingId(89) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
@@ -1323,12 +1326,12 @@ fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
 
 fn stream$to_file -> Result<Sink<string>, string>
   statements:
-    use BindingId(91) path site=SiteId(702) ty=string intent=Read
-    bind BindingId(92) s site=SiteId(701) ty=Sink<string>
-    use BindingId(92) s site=SiteId(706) ty=Sink<string> intent=Read
-    use BindingId(92) s site=SiteId(710) ty=Sink<string> intent=Read
-    agg_alias BindingId(92) s site=SiteId(710) ty=Sink<string>
-    return site=Some(SiteId(700)) ty=Result<Sink<string>, string>
+    use BindingId(91) path site=SiteId(704) ty=string intent=Read
+    bind BindingId(92) s site=SiteId(703) ty=Sink<string>
+    use BindingId(92) s site=SiteId(708) ty=Sink<string> intent=Read
+    use BindingId(92) s site=SiteId(712) ty=Sink<string> intent=Read
+    agg_alias BindingId(92) s site=SiteId(712) ty=Sink<string>
+    return site=Some(SiteId(702)) ty=Result<Sink<string>, string>
     drop BindingId(92) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
@@ -1352,15 +1355,15 @@ fn stream$to_file -> Result<Sink<string>, string>
 
 fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
   statements:
-    use BindingId(93) path site=SiteId(717) ty=string intent=Read
-    bind BindingId(94) s site=SiteId(716) ty=Sink<string>
-    use BindingId(94) s site=SiteId(721) ty=Sink<string> intent=Read
-    use BindingId(94) s site=SiteId(725) ty=Sink<string> intent=Read
-    agg_alias BindingId(94) s site=SiteId(725) ty=Sink<string>
-    return site=Some(SiteId(715)) ty=Result<Sink<string>, fs.IoError>
-    bind BindingId(95) errno site=SiteId(727) ty=i32
-    eval site=SiteId(729) ty=string
-    use BindingId(95) errno site=SiteId(734) ty=i32 intent=Read
+    use BindingId(93) path site=SiteId(719) ty=string intent=Read
+    bind BindingId(94) s site=SiteId(718) ty=Sink<string>
+    use BindingId(94) s site=SiteId(723) ty=Sink<string> intent=Read
+    use BindingId(94) s site=SiteId(727) ty=Sink<string> intent=Read
+    agg_alias BindingId(94) s site=SiteId(727) ty=Sink<string>
+    return site=Some(SiteId(717)) ty=Result<Sink<string>, fs.IoError>
+    bind BindingId(95) errno site=SiteId(729) ty=i32
+    eval site=SiteId(731) ty=string
+    use BindingId(95) errno site=SiteId(736) ty=i32 intent=Read
     drop BindingId(94) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
@@ -1388,9 +1391,9 @@ fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
 
 fn stream$forward -> ()
   statements:
-    use BindingId(96) source site=SiteId(738) ty=Stream<string> intent=Read
-    use BindingId(97) dest site=SiteId(739) ty=Sink<string> intent=Read
-    eval site=SiteId(736) ty=()
+    use BindingId(96) source site=SiteId(740) ty=Stream<string> intent=Read
+    use BindingId(97) dest site=SiteId(741) ty=Sink<string> intent=Read
+    eval site=SiteId(738) ty=()
   drop_plans:
     call[bb0 hew_stream_pipe -> bb1] ->
       (none)
@@ -1401,8 +1404,8 @@ fn stream$forward -> ()
 
 fn i8::fmt -> string
   statements:
-    use BindingId(106) val site=SiteId(811) ty=i8 intent=Read
-    return site=Some(SiteId(809)) ty=string
+    use BindingId(106) val site=SiteId(813) ty=i8 intent=Read
+    return site=Some(SiteId(811)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1413,8 +1416,8 @@ fn i8::fmt -> string
 
 fn i16::fmt -> string
   statements:
-    use BindingId(107) val site=SiteId(815) ty=i16 intent=Read
-    return site=Some(SiteId(813)) ty=string
+    use BindingId(107) val site=SiteId(817) ty=i16 intent=Read
+    return site=Some(SiteId(815)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1425,8 +1428,8 @@ fn i16::fmt -> string
 
 fn i32::fmt -> string
   statements:
-    use BindingId(108) val site=SiteId(818) ty=i32 intent=Read
-    return site=Some(SiteId(817)) ty=string
+    use BindingId(108) val site=SiteId(820) ty=i32 intent=Read
+    return site=Some(SiteId(819)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1437,8 +1440,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(109) val site=SiteId(821) ty=i64 intent=Read
-    return site=Some(SiteId(820)) ty=string
+    use BindingId(109) val site=SiteId(823) ty=i64 intent=Read
+    return site=Some(SiteId(822)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1449,8 +1452,8 @@ fn i64::fmt -> string
 
 fn u8::fmt -> string
   statements:
-    use BindingId(110) val site=SiteId(824) ty=u8 intent=Read
-    return site=Some(SiteId(823)) ty=string
+    use BindingId(110) val site=SiteId(826) ty=u8 intent=Read
+    return site=Some(SiteId(825)) ty=string
   drop_plans:
     call[bb0 to_string_u8 -> bb1] ->
       (none)
@@ -1461,8 +1464,8 @@ fn u8::fmt -> string
 
 fn u16::fmt -> string
   statements:
-    use BindingId(111) val site=SiteId(827) ty=u16 intent=Read
-    return site=Some(SiteId(826)) ty=string
+    use BindingId(111) val site=SiteId(829) ty=u16 intent=Read
+    return site=Some(SiteId(828)) ty=string
   drop_plans:
     call[bb0 to_string_u16 -> bb1] ->
       (none)
@@ -1473,8 +1476,8 @@ fn u16::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(112) val site=SiteId(830) ty=u32 intent=Read
-    return site=Some(SiteId(829)) ty=string
+    use BindingId(112) val site=SiteId(832) ty=u32 intent=Read
+    return site=Some(SiteId(831)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -1485,8 +1488,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(113) val site=SiteId(833) ty=u64 intent=Read
-    return site=Some(SiteId(832)) ty=string
+    use BindingId(113) val site=SiteId(835) ty=u64 intent=Read
+    return site=Some(SiteId(834)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1497,8 +1500,8 @@ fn u64::fmt -> string
 
 fn isize::fmt -> string
   statements:
-    use BindingId(114) val site=SiteId(837) ty=isize intent=Read
-    return site=Some(SiteId(835)) ty=string
+    use BindingId(114) val site=SiteId(839) ty=isize intent=Read
+    return site=Some(SiteId(837)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1509,8 +1512,8 @@ fn isize::fmt -> string
 
 fn usize::fmt -> string
   statements:
-    use BindingId(115) val site=SiteId(841) ty=usize intent=Read
-    return site=Some(SiteId(839)) ty=string
+    use BindingId(115) val site=SiteId(843) ty=usize intent=Read
+    return site=Some(SiteId(841)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1521,8 +1524,8 @@ fn usize::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(116) val site=SiteId(844) ty=bool intent=Read
-    return site=Some(SiteId(843)) ty=string
+    use BindingId(116) val site=SiteId(846) ty=bool intent=Read
+    return site=Some(SiteId(845)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -1533,8 +1536,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(117) val site=SiteId(847) ty=char intent=Read
-    return site=Some(SiteId(846)) ty=string
+    use BindingId(117) val site=SiteId(849) ty=char intent=Read
+    return site=Some(SiteId(848)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -1545,8 +1548,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(118) val site=SiteId(850) ty=f64 intent=Read
-    return site=Some(SiteId(849)) ty=string
+    use BindingId(118) val site=SiteId(852) ty=f64 intent=Read
+    return site=Some(SiteId(851)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1557,8 +1560,8 @@ fn f64::fmt -> string
 
 fn f32::fmt -> string
   statements:
-    use BindingId(119) val site=SiteId(854) ty=f32 intent=Read
-    return site=Some(SiteId(852)) ty=string
+    use BindingId(119) val site=SiteId(856) ty=f32 intent=Read
+    return site=Some(SiteId(854)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1569,16 +1572,16 @@ fn f32::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(120) val site=SiteId(856) ty=string intent=Read
-    return site=Some(SiteId(856)) ty=string
+    use BindingId(120) val site=SiteId(858) ty=string intent=Read
+    return site=Some(SiteId(858)) ty=string
   drop_plans:
     return[bb0] ->
       (none)
 
 fn duration::from_nanos -> duration
   statements:
-    use BindingId(121) n site=SiteId(858) ty=i64 intent=Read
-    return site=Some(SiteId(857)) ty=duration
+    use BindingId(121) n site=SiteId(860) ty=i64 intent=Read
+    return site=Some(SiteId(859)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1589,8 +1592,8 @@ fn duration::from_nanos -> duration
 
 fn duration::from_micros -> duration
   statements:
-    use BindingId(122) n site=SiteId(861) ty=i64 intent=Read
-    return site=Some(SiteId(860)) ty=duration
+    use BindingId(122) n site=SiteId(863) ty=i64 intent=Read
+    return site=Some(SiteId(862)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1601,8 +1604,8 @@ fn duration::from_micros -> duration
 
 fn duration::from_millis -> duration
   statements:
-    use BindingId(123) n site=SiteId(864) ty=i64 intent=Read
-    return site=Some(SiteId(863)) ty=duration
+    use BindingId(123) n site=SiteId(866) ty=i64 intent=Read
+    return site=Some(SiteId(865)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1613,8 +1616,8 @@ fn duration::from_millis -> duration
 
 fn duration::from_secs -> duration
   statements:
-    use BindingId(124) n site=SiteId(867) ty=i64 intent=Read
-    return site=Some(SiteId(866)) ty=duration
+    use BindingId(124) n site=SiteId(869) ty=i64 intent=Read
+    return site=Some(SiteId(868)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1625,8 +1628,8 @@ fn duration::from_secs -> duration
 
 fn duration::fmt -> string
   statements:
-    use BindingId(125) val site=SiteId(872) ty=duration intent=Read
-    return site=Some(SiteId(869)) ty=string
+    use BindingId(125) val site=SiteId(874) ty=duration intent=Read
+    return site=Some(SiteId(871)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -1486,15 +1486,16 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _5: Result<bytes, IoError>
     _6: i32
     _7: bool
-    _8: Result<bytes, IoError>
-    _9: i64
+    _8: string
+    _9: Result<bytes, IoError>
     _10: i64
-    _11: IoError
-    _12: Result<bytes, IoError>
+    _11: i64
+    _12: IoError
     _13: Result<bytes, IoError>
-    _14: i64
-    _15: Result<bytes, IoError>
+    _14: Result<bytes, IoError>
+    _15: i64
     _16: Result<bytes, IoError>
+    _17: Result<bytes, IoError>
   bb0:
     stmt: use BindingId(56) file_path site=SiteId(485) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
@@ -1510,29 +1511,32 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _7 = icmp.ne _4 _6
     branch _7 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(58) errno site=SiteId(497) ty=i32 intent=Read
-    _9 = const.i64 1
-    mtag8 = move _9
-    _10 = cast _4 i32 -> i64
-    _11 = call fs$io_error_from_errno(_10) -> bb6
+    _8 = call hew_stream_last_error() -> bb6
   bb4:
-    stmt: use BindingId(57) data site=SiteId(501) ty=bytes intent=Read
-    stmt: agg_alias BindingId(57) data site=SiteId(501) ty=bytes
-    _14 = const.i64 0
-    mtag13 = move _14
-    mvar13.0.0 = move _2
-    _15 = move _13
-    _5 = move _15
+    stmt: use BindingId(57) data site=SiteId(503) ty=bytes intent=Read
+    stmt: agg_alias BindingId(57) data site=SiteId(503) ty=bytes
+    _15 = const.i64 0
+    mtag14 = move _15
+    mvar14.0.0 = move _2
+    _16 = move _14
+    _5 = move _16
     goto bb5
   bb5:
     stmt: return site=Some(SiteId(483)) ty=Result<bytes, IoError>
-    _16 = move _5
-    ret = move _16
+    _17 = move _5
+    ret = move _17
     return
   bb6:
-    mvar8.1.0 = move _11
-    _12 = move _8
-    _5 = move _12
+    stmt: eval site=SiteId(494) ty=string
+    stmt: use BindingId(58) errno site=SiteId(499) ty=i32 intent=Read
+    _10 = const.i64 1
+    mtag9 = move _10
+    _11 = cast _4 i32 -> i64
+    _12 = call fs$io_error_from_errno(_11) -> bb7
+  bb7:
+    mvar9.1.0 = move _12
+    _13 = move _9
+    _5 = move _13
     goto bb5
 
 fn fs$write_bytes(string, bytes) -> i64 [conv=default]
@@ -1543,11 +1547,11 @@ fn fs$write_bytes(string, bytes) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(59) path site=SiteId(505) ty=string intent=Read
-    stmt: use BindingId(60) data site=SiteId(506) ty=bytes intent=Read
+    stmt: use BindingId(59) path site=SiteId(507) ty=string intent=Read
+    stmt: use BindingId(60) data site=SiteId(508) ty=bytes intent=Read
     _2 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(502)) ty=i64
+    stmt: return site=Some(SiteId(504)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1569,14 +1573,14 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(61) file_path site=SiteId(511) ty=string intent=Read
-    stmt: use BindingId(62) data site=SiteId(512) ty=bytes intent=Read
+    stmt: use BindingId(61) file_path site=SiteId(513) ty=string intent=Read
+    stmt: use BindingId(62) data site=SiteId(514) ty=bytes intent=Read
     _3 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(508)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(510)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1584,7 +1588,7 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(61) file_path site=SiteId(518) ty=string intent=Read
+    stmt: use BindingId(61) file_path site=SiteId(520) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$write_error(_0) -> bb7
@@ -1609,10 +1613,10 @@ fn fs$mkdir(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(63) path site=SiteId(523) ty=string intent=Read
+    stmt: use BindingId(63) path site=SiteId(525) ty=string intent=Read
     _1 = call hew_fs_mkdir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(520)) ty=i64
+    stmt: return site=Some(SiteId(522)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1633,13 +1637,13 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(64) dir_path site=SiteId(528) ty=string intent=Read
+    stmt: use BindingId(64) dir_path site=SiteId(530) ty=string intent=Read
     _2 = call hew_fs_mkdir(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(525)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(527)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1647,7 +1651,7 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(64) dir_path site=SiteId(534) ty=string intent=Read
+    stmt: use BindingId(64) dir_path site=SiteId(536) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
     _11 = call fs$mkdir_error(_0) -> bb7
@@ -1672,10 +1676,10 @@ fn fs$mkdir_all(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(65) path site=SiteId(539) ty=string intent=Read
+    stmt: use BindingId(65) path site=SiteId(541) ty=string intent=Read
     _1 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(536)) ty=i64
+    stmt: return site=Some(SiteId(538)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1708,13 +1712,13 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _22: Result<i64, IoError>
     _23: Result<i64, IoError>
   bb0:
-    stmt: use BindingId(66) dir_path site=SiteId(544) ty=string intent=Read
+    stmt: use BindingId(66) dir_path site=SiteId(546) ty=string intent=Read
     _2 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(541)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(543)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1722,7 +1726,7 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(66) dir_path site=SiteId(551) ty=string intent=Read
+    stmt: use BindingId(66) dir_path site=SiteId(553) ty=string intent=Read
     _10 = call fs$exists(_0) -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
@@ -1768,10 +1772,10 @@ fn fs$list_dir(string) -> Vec<string> [conv=default]
     _1: Vec<string>
     _2: Vec<string>
   bb0:
-    stmt: use BindingId(67) path site=SiteId(563) ty=string intent=Read
+    stmt: use BindingId(67) path site=SiteId(565) ty=string intent=Read
     _1 = call hew_fs_list_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(561)) ty=Vec<string>
+    stmt: return site=Some(SiteId(563)) ty=Vec<string>
     _2 = move _1
     ret = move _2
     return
@@ -1800,13 +1804,13 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
     _19: Vec<string>
     _20: Vec<string>
   bb0:
-    stmt: use BindingId(68) dir_path site=SiteId(567) ty=string intent=Read
+    stmt: use BindingId(68) dir_path site=SiteId(569) ty=string intent=Read
     _2 = call fs$exists(_0) -> bb1
   bb1:
     _3 = not _2
     branch _3 ? bb2 : bb3
   bb2:
-    stmt: return site=Some(SiteId(569)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(571)) ty=Result<Vec<string>, IoError>
     _5 = const.i64 1
     mtag4 = move _5
     _7 = const.i64 0
@@ -1819,8 +1823,8 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   bb3:
     goto bb4
   bb4:
-    stmt: eval site=SiteId(573) ty=()
-    stmt: use BindingId(68) dir_path site=SiteId(576) ty=string intent=Read
+    stmt: eval site=SiteId(575) ty=()
+    stmt: use BindingId(68) dir_path site=SiteId(578) ty=string intent=Read
     _10 = call fs$is_dir(_0) -> bb6
   bb5:
     goto bb4
@@ -1828,7 +1832,7 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
     _11 = not _10
     branch _11 ? bb7 : bb8
   bb7:
-    stmt: return site=Some(SiteId(578)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(580)) ty=Result<Vec<string>, IoError>
     _13 = const.i64 1
     mtag12 = move _13
     _15 = const.i64 5
@@ -1841,15 +1845,15 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   bb8:
     goto bb9
   bb9:
-    stmt: eval site=SiteId(582) ty=()
-    stmt: use BindingId(68) dir_path site=SiteId(586) ty=string intent=Read
+    stmt: eval site=SiteId(584) ty=()
+    stmt: use BindingId(68) dir_path site=SiteId(588) ty=string intent=Read
     _18 = const.i64 0
     mtag17 = move _18
     _19 = call hew_fs_list_dir(_0) -> bb11
   bb10:
     goto bb9
   bb11:
-    stmt: return site=Some(SiteId(583)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(585)) ty=Result<Vec<string>, IoError>
     _20 = move _19
     mvar17.0.0 = move _20
     ret = move _17
@@ -1863,11 +1867,11 @@ fn fs$rename(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(69) from site=SiteId(591) ty=string intent=Read
-    stmt: use BindingId(70) to site=SiteId(592) ty=string intent=Read
+    stmt: use BindingId(69) from site=SiteId(593) ty=string intent=Read
+    stmt: use BindingId(70) to site=SiteId(594) ty=string intent=Read
     _2 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(588)) ty=i64
+    stmt: return site=Some(SiteId(590)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1889,14 +1893,14 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(71) from site=SiteId(597) ty=string intent=Read
-    stmt: use BindingId(72) to site=SiteId(598) ty=string intent=Read
+    stmt: use BindingId(71) from site=SiteId(599) ty=string intent=Read
+    stmt: use BindingId(72) to site=SiteId(600) ty=string intent=Read
     _3 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(594)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(596)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1904,8 +1908,8 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(71) from site=SiteId(604) ty=string intent=Read
-    stmt: use BindingId(72) to site=SiteId(605) ty=string intent=Read
+    stmt: use BindingId(71) from site=SiteId(606) ty=string intent=Read
+    stmt: use BindingId(72) to site=SiteId(607) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$move_copy_error(_0, _1) -> bb7
@@ -1931,11 +1935,11 @@ fn fs$copy(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(73) from site=SiteId(610) ty=string intent=Read
-    stmt: use BindingId(74) to site=SiteId(611) ty=string intent=Read
+    stmt: use BindingId(73) from site=SiteId(612) ty=string intent=Read
+    stmt: use BindingId(74) to site=SiteId(613) ty=string intent=Read
     _2 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(607)) ty=i64
+    stmt: return site=Some(SiteId(609)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1957,14 +1961,14 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(75) from site=SiteId(616) ty=string intent=Read
-    stmt: use BindingId(76) to site=SiteId(617) ty=string intent=Read
+    stmt: use BindingId(75) from site=SiteId(618) ty=string intent=Read
+    stmt: use BindingId(76) to site=SiteId(619) ty=string intent=Read
     _3 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(613)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(615)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1972,8 +1976,8 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(75) from site=SiteId(623) ty=string intent=Read
-    stmt: use BindingId(76) to site=SiteId(624) ty=string intent=Read
+    stmt: use BindingId(75) from site=SiteId(625) ty=string intent=Read
+    stmt: use BindingId(76) to site=SiteId(626) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$move_copy_error(_0, _1) -> bb7
@@ -1997,10 +2001,10 @@ fn fs$is_dir(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(77) path site=SiteId(628) ty=string intent=Read
+    stmt: use BindingId(77) path site=SiteId(630) ty=string intent=Read
     _1 = call hew_fs_is_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(626)) ty=bool
+    stmt: return site=Some(SiteId(628)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -2018,31 +2022,31 @@ fn stream$pipe(i64) -> (Sink<string>, Stream<string>) [conv=default]
     _8: (Sink<string>, Stream<string>)
     _9: (Sink<string>, Stream<string>)
   bb0:
-    stmt: use BindingId(78) capacity site=SiteId(633) ty=i64 intent=Read
+    stmt: use BindingId(78) capacity site=SiteId(635) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(79) pair site=SiteId(631) ty=StreamPair
-    stmt: use BindingId(79) pair site=SiteId(636) ty=StreamPair intent=Read
+    stmt: bind BindingId(79) pair site=SiteId(633) ty=StreamPair
+    stmt: use BindingId(79) pair site=SiteId(638) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink(_3) -> bb2
   bb2:
-    stmt: bind BindingId(80) sink site=SiteId(635) ty=Sink<string>
-    stmt: use BindingId(79) pair site=SiteId(639) ty=StreamPair intent=Read
+    stmt: bind BindingId(80) sink site=SiteId(637) ty=Sink<string>
+    stmt: use BindingId(79) pair site=SiteId(641) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream(_3) -> bb3
   bb3:
-    stmt: bind BindingId(81) input site=SiteId(638) ty=Stream<string>
-    stmt: use BindingId(79) pair site=SiteId(642) ty=StreamPair intent=Read
+    stmt: bind BindingId(81) input site=SiteId(640) ty=Stream<string>
+    stmt: use BindingId(79) pair site=SiteId(644) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(641) ty=()
-    stmt: use BindingId(80) sink site=SiteId(645) ty=Sink<string> intent=Read
-    stmt: use BindingId(81) input site=SiteId(646) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(80) sink site=SiteId(645) ty=Sink<string>
-    stmt: agg_alias BindingId(81) input site=SiteId(646) ty=Stream<string>
-    stmt: return site=Some(SiteId(630)) ty=(Sink<string>, Stream<string>)
+    stmt: eval site=SiteId(643) ty=()
+    stmt: use BindingId(80) sink site=SiteId(647) ty=Sink<string> intent=Read
+    stmt: use BindingId(81) input site=SiteId(648) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(80) sink site=SiteId(647) ty=Sink<string>
+    stmt: agg_alias BindingId(81) input site=SiteId(648) ty=Stream<string>
+    stmt: return site=Some(SiteId(632)) ty=(Sink<string>, Stream<string>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2061,31 +2065,31 @@ fn stream$bytes_pipe(i64) -> (Sink<bytes>, Stream<bytes>) [conv=default]
     _8: (Sink<bytes>, Stream<bytes>)
     _9: (Sink<bytes>, Stream<bytes>)
   bb0:
-    stmt: use BindingId(82) capacity site=SiteId(650) ty=i64 intent=Read
+    stmt: use BindingId(82) capacity site=SiteId(652) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(83) pair site=SiteId(648) ty=StreamPair
-    stmt: use BindingId(83) pair site=SiteId(653) ty=StreamPair intent=Read
+    stmt: bind BindingId(83) pair site=SiteId(650) ty=StreamPair
+    stmt: use BindingId(83) pair site=SiteId(655) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink_bytes(_3) -> bb2
   bb2:
-    stmt: bind BindingId(84) sink site=SiteId(652) ty=Sink<bytes>
-    stmt: use BindingId(83) pair site=SiteId(656) ty=StreamPair intent=Read
+    stmt: bind BindingId(84) sink site=SiteId(654) ty=Sink<bytes>
+    stmt: use BindingId(83) pair site=SiteId(658) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream_bytes(_3) -> bb3
   bb3:
-    stmt: bind BindingId(85) input site=SiteId(655) ty=Stream<bytes>
-    stmt: use BindingId(83) pair site=SiteId(659) ty=StreamPair intent=Read
+    stmt: bind BindingId(85) input site=SiteId(657) ty=Stream<bytes>
+    stmt: use BindingId(83) pair site=SiteId(661) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(658) ty=()
-    stmt: use BindingId(84) sink site=SiteId(662) ty=Sink<bytes> intent=Read
-    stmt: use BindingId(85) input site=SiteId(663) ty=Stream<bytes> intent=Read
-    stmt: agg_alias BindingId(84) sink site=SiteId(662) ty=Sink<bytes>
-    stmt: agg_alias BindingId(85) input site=SiteId(663) ty=Stream<bytes>
-    stmt: return site=Some(SiteId(647)) ty=(Sink<bytes>, Stream<bytes>)
+    stmt: eval site=SiteId(660) ty=()
+    stmt: use BindingId(84) sink site=SiteId(664) ty=Sink<bytes> intent=Read
+    stmt: use BindingId(85) input site=SiteId(665) ty=Stream<bytes> intent=Read
+    stmt: agg_alias BindingId(84) sink site=SiteId(664) ty=Sink<bytes>
+    stmt: agg_alias BindingId(85) input site=SiteId(665) ty=Stream<bytes>
+    stmt: return site=Some(SiteId(649)) ty=(Sink<bytes>, Stream<bytes>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2107,18 +2111,18 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     _11: Result<Stream<string>, string>
     _12: Result<Stream<string>, string>
   bb0:
-    stmt: use BindingId(86) path site=SiteId(666) ty=string intent=Read
+    stmt: use BindingId(86) path site=SiteId(668) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(87) s site=SiteId(665) ty=Stream<string>
-    stmt: use BindingId(87) s site=SiteId(670) ty=Stream<string> intent=Read
+    stmt: bind BindingId(87) s site=SiteId(667) ty=Stream<string>
+    stmt: use BindingId(87) s site=SiteId(672) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(87) s site=SiteId(674) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(87) s site=SiteId(674) ty=Stream<string>
+    stmt: use BindingId(87) s site=SiteId(676) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(87) s site=SiteId(676) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2130,7 +2134,7 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(664)) ty=Result<Stream<string>, string>
+    stmt: return site=Some(SiteId(666)) ty=Result<Stream<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2160,18 +2164,18 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _15: Result<Stream<string>, fs.IoError>
     _16: Result<Stream<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(88) path site=SiteId(681) ty=string intent=Read
+    stmt: use BindingId(88) path site=SiteId(683) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(89) s site=SiteId(680) ty=Stream<string>
-    stmt: use BindingId(89) s site=SiteId(685) ty=Stream<string> intent=Read
+    stmt: bind BindingId(89) s site=SiteId(682) ty=Stream<string>
+    stmt: use BindingId(89) s site=SiteId(687) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(89) s site=SiteId(689) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(89) s site=SiteId(689) ty=Stream<string>
+    stmt: use BindingId(89) s site=SiteId(691) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(89) s site=SiteId(691) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2181,17 +2185,17 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
   bb4:
     _8 = call hew_stream_last_errno() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(679)) ty=Result<Stream<string>, fs.IoError>
+    stmt: return site=Some(SiteId(681)) ty=Result<Stream<string>, fs.IoError>
     _16 = move _3
     ret = move _16
     return
   bb6:
-    stmt: bind BindingId(90) errno site=SiteId(691) ty=i32
+    stmt: bind BindingId(90) errno site=SiteId(693) ty=i32
     _9 = move _8
     _10 = call hew_stream_last_error() -> bb7
   bb7:
-    stmt: eval site=SiteId(693) ty=string
-    stmt: use BindingId(90) errno site=SiteId(698) ty=i32 intent=Read
+    stmt: eval site=SiteId(695) ty=string
+    stmt: use BindingId(90) errno site=SiteId(700) ty=i32 intent=Read
     _12 = const.i64 1
     mtag11 = move _12
     _13 = cast _9 i32 -> i64
@@ -2218,18 +2222,18 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     _11: Result<Sink<string>, string>
     _12: Result<Sink<string>, string>
   bb0:
-    stmt: use BindingId(91) path site=SiteId(702) ty=string intent=Read
+    stmt: use BindingId(91) path site=SiteId(704) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(92) s site=SiteId(701) ty=Sink<string>
-    stmt: use BindingId(92) s site=SiteId(706) ty=Sink<string> intent=Read
+    stmt: bind BindingId(92) s site=SiteId(703) ty=Sink<string>
+    stmt: use BindingId(92) s site=SiteId(708) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(92) s site=SiteId(710) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(92) s site=SiteId(710) ty=Sink<string>
+    stmt: use BindingId(92) s site=SiteId(712) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(92) s site=SiteId(712) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2241,7 +2245,7 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(700)) ty=Result<Sink<string>, string>
+    stmt: return site=Some(SiteId(702)) ty=Result<Sink<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2271,18 +2275,18 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _15: Result<Sink<string>, fs.IoError>
     _16: Result<Sink<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(93) path site=SiteId(717) ty=string intent=Read
+    stmt: use BindingId(93) path site=SiteId(719) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(94) s site=SiteId(716) ty=Sink<string>
-    stmt: use BindingId(94) s site=SiteId(721) ty=Sink<string> intent=Read
+    stmt: bind BindingId(94) s site=SiteId(718) ty=Sink<string>
+    stmt: use BindingId(94) s site=SiteId(723) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(94) s site=SiteId(725) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(94) s site=SiteId(725) ty=Sink<string>
+    stmt: use BindingId(94) s site=SiteId(727) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(94) s site=SiteId(727) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2292,17 +2296,17 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
   bb4:
     _8 = call hew_stream_last_errno() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(715)) ty=Result<Sink<string>, fs.IoError>
+    stmt: return site=Some(SiteId(717)) ty=Result<Sink<string>, fs.IoError>
     _16 = move _3
     ret = move _16
     return
   bb6:
-    stmt: bind BindingId(95) errno site=SiteId(727) ty=i32
+    stmt: bind BindingId(95) errno site=SiteId(729) ty=i32
     _9 = move _8
     _10 = call hew_stream_last_error() -> bb7
   bb7:
-    stmt: eval site=SiteId(729) ty=string
-    stmt: use BindingId(95) errno site=SiteId(734) ty=i32 intent=Read
+    stmt: eval site=SiteId(731) ty=string
+    stmt: use BindingId(95) errno site=SiteId(736) ty=i32 intent=Read
     _12 = const.i64 1
     mtag11 = move _12
     _13 = cast _9 i32 -> i64
@@ -2318,11 +2322,11 @@ fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
     _0: Stream<string>
     _1: Sink<string>
   bb0:
-    stmt: use BindingId(96) source site=SiteId(738) ty=Stream<string> intent=Read
-    stmt: use BindingId(97) dest site=SiteId(739) ty=Sink<string> intent=Read
+    stmt: use BindingId(96) source site=SiteId(740) ty=Stream<string> intent=Read
+    stmt: use BindingId(97) dest site=SiteId(741) ty=Sink<string> intent=Read
     call hew_stream_pipe(_0, _1) -> bb1
   bb1:
-    stmt: eval site=SiteId(736) ty=()
+    stmt: eval site=SiteId(738) ty=()
     return
 
 fn i8::fmt(i8) -> string [conv=default]
@@ -2331,11 +2335,11 @@ fn i8::fmt(i8) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(106) val site=SiteId(811) ty=i8 intent=Read
+    stmt: use BindingId(106) val site=SiteId(813) ty=i8 intent=Read
     _1 = cast _0 i8 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(809)) ty=string
+    stmt: return site=Some(SiteId(811)) ty=string
     ret = move _2
     return
 
@@ -2345,11 +2349,11 @@ fn i16::fmt(i16) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(107) val site=SiteId(815) ty=i16 intent=Read
+    stmt: use BindingId(107) val site=SiteId(817) ty=i16 intent=Read
     _1 = cast _0 i16 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(813)) ty=string
+    stmt: return site=Some(SiteId(815)) ty=string
     ret = move _2
     return
 
@@ -2358,10 +2362,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(108) val site=SiteId(818) ty=i32 intent=Read
+    stmt: use BindingId(108) val site=SiteId(820) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(817)) ty=string
+    stmt: return site=Some(SiteId(819)) ty=string
     ret = move _1
     return
 
@@ -2370,10 +2374,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(109) val site=SiteId(821) ty=i64 intent=Read
+    stmt: use BindingId(109) val site=SiteId(823) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(820)) ty=string
+    stmt: return site=Some(SiteId(822)) ty=string
     ret = move _1
     return
 
@@ -2382,10 +2386,10 @@ fn u8::fmt(u8) -> string [conv=default]
     _0: u8
     _1: string
   bb0:
-    stmt: use BindingId(110) val site=SiteId(824) ty=u8 intent=Read
+    stmt: use BindingId(110) val site=SiteId(826) ty=u8 intent=Read
     _1 = call to_string_u8(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(823)) ty=string
+    stmt: return site=Some(SiteId(825)) ty=string
     ret = move _1
     return
 
@@ -2394,10 +2398,10 @@ fn u16::fmt(u16) -> string [conv=default]
     _0: u16
     _1: string
   bb0:
-    stmt: use BindingId(111) val site=SiteId(827) ty=u16 intent=Read
+    stmt: use BindingId(111) val site=SiteId(829) ty=u16 intent=Read
     _1 = call to_string_u16(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(826)) ty=string
+    stmt: return site=Some(SiteId(828)) ty=string
     ret = move _1
     return
 
@@ -2406,10 +2410,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(112) val site=SiteId(830) ty=u32 intent=Read
+    stmt: use BindingId(112) val site=SiteId(832) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(829)) ty=string
+    stmt: return site=Some(SiteId(831)) ty=string
     ret = move _1
     return
 
@@ -2418,10 +2422,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(113) val site=SiteId(833) ty=u64 intent=Read
+    stmt: use BindingId(113) val site=SiteId(835) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(832)) ty=string
+    stmt: return site=Some(SiteId(834)) ty=string
     ret = move _1
     return
 
@@ -2431,11 +2435,11 @@ fn isize::fmt(isize) -> string [conv=default]
     _1: i64
     _2: string
   bb0:
-    stmt: use BindingId(114) val site=SiteId(837) ty=isize intent=Read
+    stmt: use BindingId(114) val site=SiteId(839) ty=isize intent=Read
     _1 = cast _0 isize -> i64
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(835)) ty=string
+    stmt: return site=Some(SiteId(837)) ty=string
     ret = move _2
     return
 
@@ -2445,11 +2449,11 @@ fn usize::fmt(usize) -> string [conv=default]
     _1: u64
     _2: string
   bb0:
-    stmt: use BindingId(115) val site=SiteId(841) ty=usize intent=Read
+    stmt: use BindingId(115) val site=SiteId(843) ty=usize intent=Read
     _1 = cast _0 usize -> u64
     _2 = call to_string_u64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(839)) ty=string
+    stmt: return site=Some(SiteId(841)) ty=string
     ret = move _2
     return
 
@@ -2458,10 +2462,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(116) val site=SiteId(844) ty=bool intent=Read
+    stmt: use BindingId(116) val site=SiteId(846) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(843)) ty=string
+    stmt: return site=Some(SiteId(845)) ty=string
     ret = move _1
     return
 
@@ -2470,10 +2474,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(117) val site=SiteId(847) ty=char intent=Read
+    stmt: use BindingId(117) val site=SiteId(849) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(846)) ty=string
+    stmt: return site=Some(SiteId(848)) ty=string
     ret = move _1
     return
 
@@ -2482,10 +2486,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(118) val site=SiteId(850) ty=f64 intent=Read
+    stmt: use BindingId(118) val site=SiteId(852) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(849)) ty=string
+    stmt: return site=Some(SiteId(851)) ty=string
     ret = move _1
     return
 
@@ -2495,11 +2499,11 @@ fn f32::fmt(f32) -> string [conv=default]
     _1: f64
     _2: string
   bb0:
-    stmt: use BindingId(119) val site=SiteId(854) ty=f32 intent=Read
+    stmt: use BindingId(119) val site=SiteId(856) ty=f32 intent=Read
     _1 = cast _0 f32 -> f64
     _2 = call to_string_f64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(852)) ty=string
+    stmt: return site=Some(SiteId(854)) ty=string
     ret = move _2
     return
 
@@ -2507,8 +2511,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(120) val site=SiteId(856) ty=string intent=Read
-    stmt: return site=Some(SiteId(856)) ty=string
+    stmt: use BindingId(120) val site=SiteId(858) ty=string intent=Read
+    stmt: return site=Some(SiteId(858)) ty=string
     ret = move _0
     return
 
@@ -2519,14 +2523,14 @@ fn duration::from_nanos(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(121) n site=SiteId(858) ty=i64 intent=Read
+    stmt: use BindingId(121) n site=SiteId(860) ty=i64 intent=Read
     _1 = const.duration 1ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(857)) ty=duration
+    stmt: return site=Some(SiteId(859)) ty=duration
     ret = move _2
     return
 
@@ -2537,14 +2541,14 @@ fn duration::from_micros(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(122) n site=SiteId(861) ty=i64 intent=Read
+    stmt: use BindingId(122) n site=SiteId(863) ty=i64 intent=Read
     _1 = const.duration 1000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(860)) ty=duration
+    stmt: return site=Some(SiteId(862)) ty=duration
     ret = move _2
     return
 
@@ -2555,14 +2559,14 @@ fn duration::from_millis(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(123) n site=SiteId(864) ty=i64 intent=Read
+    stmt: use BindingId(123) n site=SiteId(866) ty=i64 intent=Read
     _1 = const.duration 1000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(863)) ty=duration
+    stmt: return site=Some(SiteId(865)) ty=duration
     ret = move _2
     return
 
@@ -2573,14 +2577,14 @@ fn duration::from_secs(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(124) n site=SiteId(867) ty=i64 intent=Read
+    stmt: use BindingId(124) n site=SiteId(869) ty=i64 intent=Read
     _1 = const.duration 1000000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(866)) ty=duration
+    stmt: return site=Some(SiteId(868)) ty=duration
     ret = move _2
     return
 
@@ -2592,11 +2596,11 @@ fn duration::fmt(duration) -> string [conv=default]
     _3: string
     _4: string
   bb0:
-    stmt: use BindingId(125) val site=SiteId(872) ty=duration intent=Read
+    stmt: use BindingId(125) val site=SiteId(874) ty=duration intent=Read
     _1 = call_rt hew_duration_nanos(_0)
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(869)) ty=string
+    stmt: return site=Some(SiteId(871)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
     ret = move _4

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.elab.mir
@@ -819,10 +819,11 @@ fn fs$try_read_bytes -> Result<bytes, IoError>
     bind BindingId(52) data site=SiteId(452) ty=bytes
     bind BindingId(53) errno site=SiteId(455) ty=i32
     use BindingId(53) errno site=SiteId(459) ty=i32 intent=Read
-    use BindingId(53) errno site=SiteId(465) ty=i32 intent=Read
-    use BindingId(52) data site=SiteId(469) ty=bytes intent=Read
-    agg_alias BindingId(52) data site=SiteId(469) ty=bytes
+    use BindingId(52) data site=SiteId(471) ty=bytes intent=Read
+    agg_alias BindingId(52) data site=SiteId(471) ty=bytes
     return site=Some(SiteId(451)) ty=Result<bytes, IoError>
+    eval site=SiteId(462) ty=string
+    use BindingId(53) errno site=SiteId(467) ty=i32 intent=Read
     drop BindingId(52) data ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
@@ -833,22 +834,24 @@ fn fs$try_read_bytes -> Result<bytes, IoError>
       (none)
     branch[bb2: bb3/bb4] ->
       (none)
-    call[bb3 fs$io_error_from_errno -> bb6] ->
+    call[bb3 hew_stream_last_error -> bb6] ->
       (none)
     goto[bb4->bb5] ->
       (none)
     return[bb5] ->
       (none)
-    goto[bb6->bb5] ->
+    call[bb6 fs$io_error_from_errno -> bb7] ->
       (none)
-    cancel[bb6] ->
+    goto[bb7->bb5] ->
+      (none)
+    cancel[bb7] ->
       (none)
 
 fn fs$write_bytes -> i64
   statements:
-    use BindingId(54) path site=SiteId(473) ty=string intent=Read
-    use BindingId(55) data site=SiteId(474) ty=bytes intent=Read
-    return site=Some(SiteId(470)) ty=i64
+    use BindingId(54) path site=SiteId(475) ty=string intent=Read
+    use BindingId(55) data site=SiteId(476) ty=bytes intent=Read
+    return site=Some(SiteId(472)) ty=i64
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -859,10 +862,10 @@ fn fs$write_bytes -> i64
 
 fn fs$try_write_bytes -> Result<i64, IoError>
   statements:
-    use BindingId(56) file_path site=SiteId(479) ty=string intent=Read
-    use BindingId(57) data site=SiteId(480) ty=bytes intent=Read
-    return site=Some(SiteId(476)) ty=Result<i64, IoError>
-    use BindingId(56) file_path site=SiteId(486) ty=string intent=Read
+    use BindingId(56) file_path site=SiteId(481) ty=string intent=Read
+    use BindingId(57) data site=SiteId(482) ty=bytes intent=Read
+    return site=Some(SiteId(478)) ty=Result<i64, IoError>
+    use BindingId(56) file_path site=SiteId(488) ty=string intent=Read
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -889,8 +892,8 @@ fn fs$try_write_bytes -> Result<i64, IoError>
 
 fn fs$mkdir -> i64
   statements:
-    use BindingId(58) path site=SiteId(491) ty=string intent=Read
-    return site=Some(SiteId(488)) ty=i64
+    use BindingId(58) path site=SiteId(493) ty=string intent=Read
+    return site=Some(SiteId(490)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -901,9 +904,9 @@ fn fs$mkdir -> i64
 
 fn fs$try_mkdir -> Result<i64, IoError>
   statements:
-    use BindingId(59) dir_path site=SiteId(496) ty=string intent=Read
-    return site=Some(SiteId(493)) ty=Result<i64, IoError>
-    use BindingId(59) dir_path site=SiteId(502) ty=string intent=Read
+    use BindingId(59) dir_path site=SiteId(498) ty=string intent=Read
+    return site=Some(SiteId(495)) ty=Result<i64, IoError>
+    use BindingId(59) dir_path site=SiteId(504) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -930,8 +933,8 @@ fn fs$try_mkdir -> Result<i64, IoError>
 
 fn fs$mkdir_all -> i64
   statements:
-    use BindingId(60) path site=SiteId(507) ty=string intent=Read
-    return site=Some(SiteId(504)) ty=i64
+    use BindingId(60) path site=SiteId(509) ty=string intent=Read
+    return site=Some(SiteId(506)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -942,9 +945,9 @@ fn fs$mkdir_all -> i64
 
 fn fs$try_mkdir_all -> Result<i64, IoError>
   statements:
-    use BindingId(61) dir_path site=SiteId(512) ty=string intent=Read
-    return site=Some(SiteId(509)) ty=Result<i64, IoError>
-    use BindingId(61) dir_path site=SiteId(519) ty=string intent=Read
+    use BindingId(61) dir_path site=SiteId(514) ty=string intent=Read
+    return site=Some(SiteId(511)) ty=Result<i64, IoError>
+    use BindingId(61) dir_path site=SiteId(521) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -977,8 +980,8 @@ fn fs$try_mkdir_all -> Result<i64, IoError>
 
 fn fs$list_dir -> Vec<string>
   statements:
-    use BindingId(62) path site=SiteId(531) ty=string intent=Read
-    return site=Some(SiteId(529)) ty=Vec<string>
+    use BindingId(62) path site=SiteId(533) ty=string intent=Read
+    return site=Some(SiteId(531)) ty=Vec<string>
   drop_plans:
     call[bb0 hew_fs_list_dir -> bb1] ->
       (none)
@@ -989,14 +992,14 @@ fn fs$list_dir -> Vec<string>
 
 fn fs$try_list_dir -> Result<Vec<string>, IoError>
   statements:
-    use BindingId(63) dir_path site=SiteId(535) ty=string intent=Read
-    return site=Some(SiteId(537)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(541) ty=()
-    use BindingId(63) dir_path site=SiteId(544) ty=string intent=Read
-    return site=Some(SiteId(546)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(550) ty=()
-    use BindingId(63) dir_path site=SiteId(554) ty=string intent=Read
-    return site=Some(SiteId(551)) ty=Result<Vec<string>, IoError>
+    use BindingId(63) dir_path site=SiteId(537) ty=string intent=Read
+    return site=Some(SiteId(539)) ty=Result<Vec<string>, IoError>
+    eval site=SiteId(543) ty=()
+    use BindingId(63) dir_path site=SiteId(546) ty=string intent=Read
+    return site=Some(SiteId(548)) ty=Result<Vec<string>, IoError>
+    eval site=SiteId(552) ty=()
+    use BindingId(63) dir_path site=SiteId(556) ty=string intent=Read
+    return site=Some(SiteId(553)) ty=Result<Vec<string>, IoError>
   drop_plans:
     call[bb0 fs$exists -> bb1] ->
       (none)
@@ -1031,9 +1034,9 @@ fn fs$try_list_dir -> Result<Vec<string>, IoError>
 
 fn fs$rename -> i64
   statements:
-    use BindingId(64) from site=SiteId(559) ty=string intent=Read
-    use BindingId(65) to site=SiteId(560) ty=string intent=Read
-    return site=Some(SiteId(556)) ty=i64
+    use BindingId(64) from site=SiteId(561) ty=string intent=Read
+    use BindingId(65) to site=SiteId(562) ty=string intent=Read
+    return site=Some(SiteId(558)) ty=i64
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1044,11 +1047,11 @@ fn fs$rename -> i64
 
 fn fs$try_rename -> Result<i64, IoError>
   statements:
-    use BindingId(66) from site=SiteId(565) ty=string intent=Read
-    use BindingId(67) to site=SiteId(566) ty=string intent=Read
-    return site=Some(SiteId(562)) ty=Result<i64, IoError>
-    use BindingId(66) from site=SiteId(572) ty=string intent=Read
-    use BindingId(67) to site=SiteId(573) ty=string intent=Read
+    use BindingId(66) from site=SiteId(567) ty=string intent=Read
+    use BindingId(67) to site=SiteId(568) ty=string intent=Read
+    return site=Some(SiteId(564)) ty=Result<i64, IoError>
+    use BindingId(66) from site=SiteId(574) ty=string intent=Read
+    use BindingId(67) to site=SiteId(575) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1075,9 +1078,9 @@ fn fs$try_rename -> Result<i64, IoError>
 
 fn fs$copy -> i64
   statements:
-    use BindingId(68) from site=SiteId(578) ty=string intent=Read
-    use BindingId(69) to site=SiteId(579) ty=string intent=Read
-    return site=Some(SiteId(575)) ty=i64
+    use BindingId(68) from site=SiteId(580) ty=string intent=Read
+    use BindingId(69) to site=SiteId(581) ty=string intent=Read
+    return site=Some(SiteId(577)) ty=i64
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1088,11 +1091,11 @@ fn fs$copy -> i64
 
 fn fs$try_copy -> Result<i64, IoError>
   statements:
-    use BindingId(70) from site=SiteId(584) ty=string intent=Read
-    use BindingId(71) to site=SiteId(585) ty=string intent=Read
-    return site=Some(SiteId(581)) ty=Result<i64, IoError>
-    use BindingId(70) from site=SiteId(591) ty=string intent=Read
-    use BindingId(71) to site=SiteId(592) ty=string intent=Read
+    use BindingId(70) from site=SiteId(586) ty=string intent=Read
+    use BindingId(71) to site=SiteId(587) ty=string intent=Read
+    return site=Some(SiteId(583)) ty=Result<i64, IoError>
+    use BindingId(70) from site=SiteId(593) ty=string intent=Read
+    use BindingId(71) to site=SiteId(594) ty=string intent=Read
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1119,8 +1122,8 @@ fn fs$try_copy -> Result<i64, IoError>
 
 fn fs$is_dir -> bool
   statements:
-    use BindingId(72) path site=SiteId(596) ty=string intent=Read
-    return site=Some(SiteId(594)) ty=bool
+    use BindingId(72) path site=SiteId(598) ty=string intent=Read
+    return site=Some(SiteId(596)) ty=bool
   drop_plans:
     call[bb0 hew_fs_is_dir -> bb1] ->
       (none)
@@ -1131,19 +1134,19 @@ fn fs$is_dir -> bool
 
 fn stream$pipe -> (Sink<string>, Stream<string>)
   statements:
-    use BindingId(73) capacity site=SiteId(601) ty=i64 intent=Read
-    bind BindingId(74) pair site=SiteId(599) ty=StreamPair
-    use BindingId(74) pair site=SiteId(604) ty=StreamPair intent=Read
-    bind BindingId(75) sink site=SiteId(603) ty=Sink<string>
-    use BindingId(74) pair site=SiteId(607) ty=StreamPair intent=Read
-    bind BindingId(76) input site=SiteId(606) ty=Stream<string>
-    use BindingId(74) pair site=SiteId(610) ty=StreamPair intent=Read
-    eval site=SiteId(609) ty=()
-    use BindingId(75) sink site=SiteId(613) ty=Sink<string> intent=Read
-    use BindingId(76) input site=SiteId(614) ty=Stream<string> intent=Read
-    agg_alias BindingId(75) sink site=SiteId(613) ty=Sink<string>
-    agg_alias BindingId(76) input site=SiteId(614) ty=Stream<string>
-    return site=Some(SiteId(598)) ty=(Sink<string>, Stream<string>)
+    use BindingId(73) capacity site=SiteId(603) ty=i64 intent=Read
+    bind BindingId(74) pair site=SiteId(601) ty=StreamPair
+    use BindingId(74) pair site=SiteId(606) ty=StreamPair intent=Read
+    bind BindingId(75) sink site=SiteId(605) ty=Sink<string>
+    use BindingId(74) pair site=SiteId(609) ty=StreamPair intent=Read
+    bind BindingId(76) input site=SiteId(608) ty=Stream<string>
+    use BindingId(74) pair site=SiteId(612) ty=StreamPair intent=Read
+    eval site=SiteId(611) ty=()
+    use BindingId(75) sink site=SiteId(615) ty=Sink<string> intent=Read
+    use BindingId(76) input site=SiteId(616) ty=Stream<string> intent=Read
+    agg_alias BindingId(75) sink site=SiteId(615) ty=Sink<string>
+    agg_alias BindingId(76) input site=SiteId(616) ty=Stream<string>
+    return site=Some(SiteId(600)) ty=(Sink<string>, Stream<string>)
     drop BindingId(76) input ty=Stream<string>
     drop BindingId(75) sink ty=Sink<string>
   drop_plans:
@@ -1162,19 +1165,19 @@ fn stream$pipe -> (Sink<string>, Stream<string>)
 
 fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
   statements:
-    use BindingId(77) capacity site=SiteId(618) ty=i64 intent=Read
-    bind BindingId(78) pair site=SiteId(616) ty=StreamPair
-    use BindingId(78) pair site=SiteId(621) ty=StreamPair intent=Read
-    bind BindingId(79) sink site=SiteId(620) ty=Sink<bytes>
-    use BindingId(78) pair site=SiteId(624) ty=StreamPair intent=Read
-    bind BindingId(80) input site=SiteId(623) ty=Stream<bytes>
-    use BindingId(78) pair site=SiteId(627) ty=StreamPair intent=Read
-    eval site=SiteId(626) ty=()
-    use BindingId(79) sink site=SiteId(630) ty=Sink<bytes> intent=Read
-    use BindingId(80) input site=SiteId(631) ty=Stream<bytes> intent=Read
-    agg_alias BindingId(79) sink site=SiteId(630) ty=Sink<bytes>
-    agg_alias BindingId(80) input site=SiteId(631) ty=Stream<bytes>
-    return site=Some(SiteId(615)) ty=(Sink<bytes>, Stream<bytes>)
+    use BindingId(77) capacity site=SiteId(620) ty=i64 intent=Read
+    bind BindingId(78) pair site=SiteId(618) ty=StreamPair
+    use BindingId(78) pair site=SiteId(623) ty=StreamPair intent=Read
+    bind BindingId(79) sink site=SiteId(622) ty=Sink<bytes>
+    use BindingId(78) pair site=SiteId(626) ty=StreamPair intent=Read
+    bind BindingId(80) input site=SiteId(625) ty=Stream<bytes>
+    use BindingId(78) pair site=SiteId(629) ty=StreamPair intent=Read
+    eval site=SiteId(628) ty=()
+    use BindingId(79) sink site=SiteId(632) ty=Sink<bytes> intent=Read
+    use BindingId(80) input site=SiteId(633) ty=Stream<bytes> intent=Read
+    agg_alias BindingId(79) sink site=SiteId(632) ty=Sink<bytes>
+    agg_alias BindingId(80) input site=SiteId(633) ty=Stream<bytes>
+    return site=Some(SiteId(617)) ty=(Sink<bytes>, Stream<bytes>)
     drop BindingId(80) input ty=Stream<bytes>
     drop BindingId(79) sink ty=Sink<bytes>
   drop_plans:
@@ -1193,12 +1196,12 @@ fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
 
 fn stream$from_file -> Result<Stream<string>, string>
   statements:
-    use BindingId(81) path site=SiteId(634) ty=string intent=Read
-    bind BindingId(82) s site=SiteId(633) ty=Stream<string>
-    use BindingId(82) s site=SiteId(638) ty=Stream<string> intent=Read
-    use BindingId(82) s site=SiteId(642) ty=Stream<string> intent=Read
-    agg_alias BindingId(82) s site=SiteId(642) ty=Stream<string>
-    return site=Some(SiteId(632)) ty=Result<Stream<string>, string>
+    use BindingId(81) path site=SiteId(636) ty=string intent=Read
+    bind BindingId(82) s site=SiteId(635) ty=Stream<string>
+    use BindingId(82) s site=SiteId(640) ty=Stream<string> intent=Read
+    use BindingId(82) s site=SiteId(644) ty=Stream<string> intent=Read
+    agg_alias BindingId(82) s site=SiteId(644) ty=Stream<string>
+    return site=Some(SiteId(634)) ty=Result<Stream<string>, string>
     drop BindingId(82) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
@@ -1222,15 +1225,15 @@ fn stream$from_file -> Result<Stream<string>, string>
 
 fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
   statements:
-    use BindingId(83) path site=SiteId(649) ty=string intent=Read
-    bind BindingId(84) s site=SiteId(648) ty=Stream<string>
-    use BindingId(84) s site=SiteId(653) ty=Stream<string> intent=Read
-    use BindingId(84) s site=SiteId(657) ty=Stream<string> intent=Read
-    agg_alias BindingId(84) s site=SiteId(657) ty=Stream<string>
-    return site=Some(SiteId(647)) ty=Result<Stream<string>, fs.IoError>
-    bind BindingId(85) errno site=SiteId(659) ty=i32
-    eval site=SiteId(661) ty=string
-    use BindingId(85) errno site=SiteId(666) ty=i32 intent=Read
+    use BindingId(83) path site=SiteId(651) ty=string intent=Read
+    bind BindingId(84) s site=SiteId(650) ty=Stream<string>
+    use BindingId(84) s site=SiteId(655) ty=Stream<string> intent=Read
+    use BindingId(84) s site=SiteId(659) ty=Stream<string> intent=Read
+    agg_alias BindingId(84) s site=SiteId(659) ty=Stream<string>
+    return site=Some(SiteId(649)) ty=Result<Stream<string>, fs.IoError>
+    bind BindingId(85) errno site=SiteId(661) ty=i32
+    eval site=SiteId(663) ty=string
+    use BindingId(85) errno site=SiteId(668) ty=i32 intent=Read
     drop BindingId(84) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
@@ -1258,12 +1261,12 @@ fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
 
 fn stream$to_file -> Result<Sink<string>, string>
   statements:
-    use BindingId(86) path site=SiteId(670) ty=string intent=Read
-    bind BindingId(87) s site=SiteId(669) ty=Sink<string>
-    use BindingId(87) s site=SiteId(674) ty=Sink<string> intent=Read
-    use BindingId(87) s site=SiteId(678) ty=Sink<string> intent=Read
-    agg_alias BindingId(87) s site=SiteId(678) ty=Sink<string>
-    return site=Some(SiteId(668)) ty=Result<Sink<string>, string>
+    use BindingId(86) path site=SiteId(672) ty=string intent=Read
+    bind BindingId(87) s site=SiteId(671) ty=Sink<string>
+    use BindingId(87) s site=SiteId(676) ty=Sink<string> intent=Read
+    use BindingId(87) s site=SiteId(680) ty=Sink<string> intent=Read
+    agg_alias BindingId(87) s site=SiteId(680) ty=Sink<string>
+    return site=Some(SiteId(670)) ty=Result<Sink<string>, string>
     drop BindingId(87) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
@@ -1287,15 +1290,15 @@ fn stream$to_file -> Result<Sink<string>, string>
 
 fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
   statements:
-    use BindingId(88) path site=SiteId(685) ty=string intent=Read
-    bind BindingId(89) s site=SiteId(684) ty=Sink<string>
-    use BindingId(89) s site=SiteId(689) ty=Sink<string> intent=Read
-    use BindingId(89) s site=SiteId(693) ty=Sink<string> intent=Read
-    agg_alias BindingId(89) s site=SiteId(693) ty=Sink<string>
-    return site=Some(SiteId(683)) ty=Result<Sink<string>, fs.IoError>
-    bind BindingId(90) errno site=SiteId(695) ty=i32
-    eval site=SiteId(697) ty=string
-    use BindingId(90) errno site=SiteId(702) ty=i32 intent=Read
+    use BindingId(88) path site=SiteId(687) ty=string intent=Read
+    bind BindingId(89) s site=SiteId(686) ty=Sink<string>
+    use BindingId(89) s site=SiteId(691) ty=Sink<string> intent=Read
+    use BindingId(89) s site=SiteId(695) ty=Sink<string> intent=Read
+    agg_alias BindingId(89) s site=SiteId(695) ty=Sink<string>
+    return site=Some(SiteId(685)) ty=Result<Sink<string>, fs.IoError>
+    bind BindingId(90) errno site=SiteId(697) ty=i32
+    eval site=SiteId(699) ty=string
+    use BindingId(90) errno site=SiteId(704) ty=i32 intent=Read
     drop BindingId(89) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
@@ -1323,9 +1326,9 @@ fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
 
 fn stream$forward -> ()
   statements:
-    use BindingId(91) source site=SiteId(706) ty=Stream<string> intent=Read
-    use BindingId(92) dest site=SiteId(707) ty=Sink<string> intent=Read
-    eval site=SiteId(704) ty=()
+    use BindingId(91) source site=SiteId(708) ty=Stream<string> intent=Read
+    use BindingId(92) dest site=SiteId(709) ty=Sink<string> intent=Read
+    eval site=SiteId(706) ty=()
   drop_plans:
     call[bb0 hew_stream_pipe -> bb1] ->
       (none)
@@ -1336,8 +1339,8 @@ fn stream$forward -> ()
 
 fn i8::fmt -> string
   statements:
-    use BindingId(101) val site=SiteId(779) ty=i8 intent=Read
-    return site=Some(SiteId(777)) ty=string
+    use BindingId(101) val site=SiteId(781) ty=i8 intent=Read
+    return site=Some(SiteId(779)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1348,8 +1351,8 @@ fn i8::fmt -> string
 
 fn i16::fmt -> string
   statements:
-    use BindingId(102) val site=SiteId(783) ty=i16 intent=Read
-    return site=Some(SiteId(781)) ty=string
+    use BindingId(102) val site=SiteId(785) ty=i16 intent=Read
+    return site=Some(SiteId(783)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1360,8 +1363,8 @@ fn i16::fmt -> string
 
 fn i32::fmt -> string
   statements:
-    use BindingId(103) val site=SiteId(786) ty=i32 intent=Read
-    return site=Some(SiteId(785)) ty=string
+    use BindingId(103) val site=SiteId(788) ty=i32 intent=Read
+    return site=Some(SiteId(787)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1372,8 +1375,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(104) val site=SiteId(789) ty=i64 intent=Read
-    return site=Some(SiteId(788)) ty=string
+    use BindingId(104) val site=SiteId(791) ty=i64 intent=Read
+    return site=Some(SiteId(790)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1384,8 +1387,8 @@ fn i64::fmt -> string
 
 fn u8::fmt -> string
   statements:
-    use BindingId(105) val site=SiteId(792) ty=u8 intent=Read
-    return site=Some(SiteId(791)) ty=string
+    use BindingId(105) val site=SiteId(794) ty=u8 intent=Read
+    return site=Some(SiteId(793)) ty=string
   drop_plans:
     call[bb0 to_string_u8 -> bb1] ->
       (none)
@@ -1396,8 +1399,8 @@ fn u8::fmt -> string
 
 fn u16::fmt -> string
   statements:
-    use BindingId(106) val site=SiteId(795) ty=u16 intent=Read
-    return site=Some(SiteId(794)) ty=string
+    use BindingId(106) val site=SiteId(797) ty=u16 intent=Read
+    return site=Some(SiteId(796)) ty=string
   drop_plans:
     call[bb0 to_string_u16 -> bb1] ->
       (none)
@@ -1408,8 +1411,8 @@ fn u16::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(107) val site=SiteId(798) ty=u32 intent=Read
-    return site=Some(SiteId(797)) ty=string
+    use BindingId(107) val site=SiteId(800) ty=u32 intent=Read
+    return site=Some(SiteId(799)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -1420,8 +1423,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(108) val site=SiteId(801) ty=u64 intent=Read
-    return site=Some(SiteId(800)) ty=string
+    use BindingId(108) val site=SiteId(803) ty=u64 intent=Read
+    return site=Some(SiteId(802)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1432,8 +1435,8 @@ fn u64::fmt -> string
 
 fn isize::fmt -> string
   statements:
-    use BindingId(109) val site=SiteId(805) ty=isize intent=Read
-    return site=Some(SiteId(803)) ty=string
+    use BindingId(109) val site=SiteId(807) ty=isize intent=Read
+    return site=Some(SiteId(805)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1444,8 +1447,8 @@ fn isize::fmt -> string
 
 fn usize::fmt -> string
   statements:
-    use BindingId(110) val site=SiteId(809) ty=usize intent=Read
-    return site=Some(SiteId(807)) ty=string
+    use BindingId(110) val site=SiteId(811) ty=usize intent=Read
+    return site=Some(SiteId(809)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1456,8 +1459,8 @@ fn usize::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(111) val site=SiteId(812) ty=bool intent=Read
-    return site=Some(SiteId(811)) ty=string
+    use BindingId(111) val site=SiteId(814) ty=bool intent=Read
+    return site=Some(SiteId(813)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -1468,8 +1471,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(112) val site=SiteId(815) ty=char intent=Read
-    return site=Some(SiteId(814)) ty=string
+    use BindingId(112) val site=SiteId(817) ty=char intent=Read
+    return site=Some(SiteId(816)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -1480,8 +1483,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(113) val site=SiteId(818) ty=f64 intent=Read
-    return site=Some(SiteId(817)) ty=string
+    use BindingId(113) val site=SiteId(820) ty=f64 intent=Read
+    return site=Some(SiteId(819)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1492,8 +1495,8 @@ fn f64::fmt -> string
 
 fn f32::fmt -> string
   statements:
-    use BindingId(114) val site=SiteId(822) ty=f32 intent=Read
-    return site=Some(SiteId(820)) ty=string
+    use BindingId(114) val site=SiteId(824) ty=f32 intent=Read
+    return site=Some(SiteId(822)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1504,16 +1507,16 @@ fn f32::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(115) val site=SiteId(824) ty=string intent=Read
-    return site=Some(SiteId(824)) ty=string
+    use BindingId(115) val site=SiteId(826) ty=string intent=Read
+    return site=Some(SiteId(826)) ty=string
   drop_plans:
     return[bb0] ->
       (none)
 
 fn duration::from_nanos -> duration
   statements:
-    use BindingId(116) n site=SiteId(826) ty=i64 intent=Read
-    return site=Some(SiteId(825)) ty=duration
+    use BindingId(116) n site=SiteId(828) ty=i64 intent=Read
+    return site=Some(SiteId(827)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1524,8 +1527,8 @@ fn duration::from_nanos -> duration
 
 fn duration::from_micros -> duration
   statements:
-    use BindingId(117) n site=SiteId(829) ty=i64 intent=Read
-    return site=Some(SiteId(828)) ty=duration
+    use BindingId(117) n site=SiteId(831) ty=i64 intent=Read
+    return site=Some(SiteId(830)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1536,8 +1539,8 @@ fn duration::from_micros -> duration
 
 fn duration::from_millis -> duration
   statements:
-    use BindingId(118) n site=SiteId(832) ty=i64 intent=Read
-    return site=Some(SiteId(831)) ty=duration
+    use BindingId(118) n site=SiteId(834) ty=i64 intent=Read
+    return site=Some(SiteId(833)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1548,8 +1551,8 @@ fn duration::from_millis -> duration
 
 fn duration::from_secs -> duration
   statements:
-    use BindingId(119) n site=SiteId(835) ty=i64 intent=Read
-    return site=Some(SiteId(834)) ty=duration
+    use BindingId(119) n site=SiteId(837) ty=i64 intent=Read
+    return site=Some(SiteId(836)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1560,8 +1563,8 @@ fn duration::from_secs -> duration
 
 fn duration::fmt -> string
   statements:
-    use BindingId(120) val site=SiteId(840) ty=duration intent=Read
-    return site=Some(SiteId(837)) ty=string
+    use BindingId(120) val site=SiteId(842) ty=duration intent=Read
+    return site=Some(SiteId(839)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
@@ -1373,15 +1373,16 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _5: Result<bytes, IoError>
     _6: i32
     _7: bool
-    _8: Result<bytes, IoError>
-    _9: i64
+    _8: string
+    _9: Result<bytes, IoError>
     _10: i64
-    _11: IoError
-    _12: Result<bytes, IoError>
+    _11: i64
+    _12: IoError
     _13: Result<bytes, IoError>
-    _14: i64
-    _15: Result<bytes, IoError>
+    _14: Result<bytes, IoError>
+    _15: i64
     _16: Result<bytes, IoError>
+    _17: Result<bytes, IoError>
   bb0:
     stmt: use BindingId(51) file_path site=SiteId(453) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
@@ -1397,29 +1398,32 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _7 = icmp.ne _4 _6
     branch _7 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(53) errno site=SiteId(465) ty=i32 intent=Read
-    _9 = const.i64 1
-    mtag8 = move _9
-    _10 = cast _4 i32 -> i64
-    _11 = call fs$io_error_from_errno(_10) -> bb6
+    _8 = call hew_stream_last_error() -> bb6
   bb4:
-    stmt: use BindingId(52) data site=SiteId(469) ty=bytes intent=Read
-    stmt: agg_alias BindingId(52) data site=SiteId(469) ty=bytes
-    _14 = const.i64 0
-    mtag13 = move _14
-    mvar13.0.0 = move _2
-    _15 = move _13
-    _5 = move _15
+    stmt: use BindingId(52) data site=SiteId(471) ty=bytes intent=Read
+    stmt: agg_alias BindingId(52) data site=SiteId(471) ty=bytes
+    _15 = const.i64 0
+    mtag14 = move _15
+    mvar14.0.0 = move _2
+    _16 = move _14
+    _5 = move _16
     goto bb5
   bb5:
     stmt: return site=Some(SiteId(451)) ty=Result<bytes, IoError>
-    _16 = move _5
-    ret = move _16
+    _17 = move _5
+    ret = move _17
     return
   bb6:
-    mvar8.1.0 = move _11
-    _12 = move _8
-    _5 = move _12
+    stmt: eval site=SiteId(462) ty=string
+    stmt: use BindingId(53) errno site=SiteId(467) ty=i32 intent=Read
+    _10 = const.i64 1
+    mtag9 = move _10
+    _11 = cast _4 i32 -> i64
+    _12 = call fs$io_error_from_errno(_11) -> bb7
+  bb7:
+    mvar9.1.0 = move _12
+    _13 = move _9
+    _5 = move _13
     goto bb5
 
 fn fs$write_bytes(string, bytes) -> i64 [conv=default]
@@ -1430,11 +1434,11 @@ fn fs$write_bytes(string, bytes) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(54) path site=SiteId(473) ty=string intent=Read
-    stmt: use BindingId(55) data site=SiteId(474) ty=bytes intent=Read
+    stmt: use BindingId(54) path site=SiteId(475) ty=string intent=Read
+    stmt: use BindingId(55) data site=SiteId(476) ty=bytes intent=Read
     _2 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(470)) ty=i64
+    stmt: return site=Some(SiteId(472)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1456,14 +1460,14 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(56) file_path site=SiteId(479) ty=string intent=Read
-    stmt: use BindingId(57) data site=SiteId(480) ty=bytes intent=Read
+    stmt: use BindingId(56) file_path site=SiteId(481) ty=string intent=Read
+    stmt: use BindingId(57) data site=SiteId(482) ty=bytes intent=Read
     _3 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(476)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(478)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1471,7 +1475,7 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(56) file_path site=SiteId(486) ty=string intent=Read
+    stmt: use BindingId(56) file_path site=SiteId(488) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$write_error(_0) -> bb7
@@ -1496,10 +1500,10 @@ fn fs$mkdir(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(58) path site=SiteId(491) ty=string intent=Read
+    stmt: use BindingId(58) path site=SiteId(493) ty=string intent=Read
     _1 = call hew_fs_mkdir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(488)) ty=i64
+    stmt: return site=Some(SiteId(490)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1520,13 +1524,13 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(59) dir_path site=SiteId(496) ty=string intent=Read
+    stmt: use BindingId(59) dir_path site=SiteId(498) ty=string intent=Read
     _2 = call hew_fs_mkdir(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(493)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(495)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1534,7 +1538,7 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(59) dir_path site=SiteId(502) ty=string intent=Read
+    stmt: use BindingId(59) dir_path site=SiteId(504) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
     _11 = call fs$mkdir_error(_0) -> bb7
@@ -1559,10 +1563,10 @@ fn fs$mkdir_all(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(60) path site=SiteId(507) ty=string intent=Read
+    stmt: use BindingId(60) path site=SiteId(509) ty=string intent=Read
     _1 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(504)) ty=i64
+    stmt: return site=Some(SiteId(506)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1595,13 +1599,13 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _22: Result<i64, IoError>
     _23: Result<i64, IoError>
   bb0:
-    stmt: use BindingId(61) dir_path site=SiteId(512) ty=string intent=Read
+    stmt: use BindingId(61) dir_path site=SiteId(514) ty=string intent=Read
     _2 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(509)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(511)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1609,7 +1613,7 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(61) dir_path site=SiteId(519) ty=string intent=Read
+    stmt: use BindingId(61) dir_path site=SiteId(521) ty=string intent=Read
     _10 = call fs$exists(_0) -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
@@ -1655,10 +1659,10 @@ fn fs$list_dir(string) -> Vec<string> [conv=default]
     _1: Vec<string>
     _2: Vec<string>
   bb0:
-    stmt: use BindingId(62) path site=SiteId(531) ty=string intent=Read
+    stmt: use BindingId(62) path site=SiteId(533) ty=string intent=Read
     _1 = call hew_fs_list_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(529)) ty=Vec<string>
+    stmt: return site=Some(SiteId(531)) ty=Vec<string>
     _2 = move _1
     ret = move _2
     return
@@ -1687,13 +1691,13 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
     _19: Vec<string>
     _20: Vec<string>
   bb0:
-    stmt: use BindingId(63) dir_path site=SiteId(535) ty=string intent=Read
+    stmt: use BindingId(63) dir_path site=SiteId(537) ty=string intent=Read
     _2 = call fs$exists(_0) -> bb1
   bb1:
     _3 = not _2
     branch _3 ? bb2 : bb3
   bb2:
-    stmt: return site=Some(SiteId(537)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(539)) ty=Result<Vec<string>, IoError>
     _5 = const.i64 1
     mtag4 = move _5
     _7 = const.i64 0
@@ -1706,8 +1710,8 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   bb3:
     goto bb4
   bb4:
-    stmt: eval site=SiteId(541) ty=()
-    stmt: use BindingId(63) dir_path site=SiteId(544) ty=string intent=Read
+    stmt: eval site=SiteId(543) ty=()
+    stmt: use BindingId(63) dir_path site=SiteId(546) ty=string intent=Read
     _10 = call fs$is_dir(_0) -> bb6
   bb5:
     goto bb4
@@ -1715,7 +1719,7 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
     _11 = not _10
     branch _11 ? bb7 : bb8
   bb7:
-    stmt: return site=Some(SiteId(546)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(548)) ty=Result<Vec<string>, IoError>
     _13 = const.i64 1
     mtag12 = move _13
     _15 = const.i64 5
@@ -1728,15 +1732,15 @@ fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   bb8:
     goto bb9
   bb9:
-    stmt: eval site=SiteId(550) ty=()
-    stmt: use BindingId(63) dir_path site=SiteId(554) ty=string intent=Read
+    stmt: eval site=SiteId(552) ty=()
+    stmt: use BindingId(63) dir_path site=SiteId(556) ty=string intent=Read
     _18 = const.i64 0
     mtag17 = move _18
     _19 = call hew_fs_list_dir(_0) -> bb11
   bb10:
     goto bb9
   bb11:
-    stmt: return site=Some(SiteId(551)) ty=Result<Vec<string>, IoError>
+    stmt: return site=Some(SiteId(553)) ty=Result<Vec<string>, IoError>
     _20 = move _19
     mvar17.0.0 = move _20
     ret = move _17
@@ -1750,11 +1754,11 @@ fn fs$rename(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(64) from site=SiteId(559) ty=string intent=Read
-    stmt: use BindingId(65) to site=SiteId(560) ty=string intent=Read
+    stmt: use BindingId(64) from site=SiteId(561) ty=string intent=Read
+    stmt: use BindingId(65) to site=SiteId(562) ty=string intent=Read
     _2 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(556)) ty=i64
+    stmt: return site=Some(SiteId(558)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1776,14 +1780,14 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(66) from site=SiteId(565) ty=string intent=Read
-    stmt: use BindingId(67) to site=SiteId(566) ty=string intent=Read
+    stmt: use BindingId(66) from site=SiteId(567) ty=string intent=Read
+    stmt: use BindingId(67) to site=SiteId(568) ty=string intent=Read
     _3 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(562)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(564)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1791,8 +1795,8 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(66) from site=SiteId(572) ty=string intent=Read
-    stmt: use BindingId(67) to site=SiteId(573) ty=string intent=Read
+    stmt: use BindingId(66) from site=SiteId(574) ty=string intent=Read
+    stmt: use BindingId(67) to site=SiteId(575) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$move_copy_error(_0, _1) -> bb7
@@ -1818,11 +1822,11 @@ fn fs$copy(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(68) from site=SiteId(578) ty=string intent=Read
-    stmt: use BindingId(69) to site=SiteId(579) ty=string intent=Read
+    stmt: use BindingId(68) from site=SiteId(580) ty=string intent=Read
+    stmt: use BindingId(69) to site=SiteId(581) ty=string intent=Read
     _2 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(575)) ty=i64
+    stmt: return site=Some(SiteId(577)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1844,14 +1848,14 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(70) from site=SiteId(584) ty=string intent=Read
-    stmt: use BindingId(71) to site=SiteId(585) ty=string intent=Read
+    stmt: use BindingId(70) from site=SiteId(586) ty=string intent=Read
+    stmt: use BindingId(71) to site=SiteId(587) ty=string intent=Read
     _3 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(581)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(583)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1859,8 +1863,8 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(70) from site=SiteId(591) ty=string intent=Read
-    stmt: use BindingId(71) to site=SiteId(592) ty=string intent=Read
+    stmt: use BindingId(70) from site=SiteId(593) ty=string intent=Read
+    stmt: use BindingId(71) to site=SiteId(594) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
     _12 = call fs$move_copy_error(_0, _1) -> bb7
@@ -1884,10 +1888,10 @@ fn fs$is_dir(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(72) path site=SiteId(596) ty=string intent=Read
+    stmt: use BindingId(72) path site=SiteId(598) ty=string intent=Read
     _1 = call hew_fs_is_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(594)) ty=bool
+    stmt: return site=Some(SiteId(596)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -1905,31 +1909,31 @@ fn stream$pipe(i64) -> (Sink<string>, Stream<string>) [conv=default]
     _8: (Sink<string>, Stream<string>)
     _9: (Sink<string>, Stream<string>)
   bb0:
-    stmt: use BindingId(73) capacity site=SiteId(601) ty=i64 intent=Read
+    stmt: use BindingId(73) capacity site=SiteId(603) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(74) pair site=SiteId(599) ty=StreamPair
-    stmt: use BindingId(74) pair site=SiteId(604) ty=StreamPair intent=Read
+    stmt: bind BindingId(74) pair site=SiteId(601) ty=StreamPair
+    stmt: use BindingId(74) pair site=SiteId(606) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink(_3) -> bb2
   bb2:
-    stmt: bind BindingId(75) sink site=SiteId(603) ty=Sink<string>
-    stmt: use BindingId(74) pair site=SiteId(607) ty=StreamPair intent=Read
+    stmt: bind BindingId(75) sink site=SiteId(605) ty=Sink<string>
+    stmt: use BindingId(74) pair site=SiteId(609) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream(_3) -> bb3
   bb3:
-    stmt: bind BindingId(76) input site=SiteId(606) ty=Stream<string>
-    stmt: use BindingId(74) pair site=SiteId(610) ty=StreamPair intent=Read
+    stmt: bind BindingId(76) input site=SiteId(608) ty=Stream<string>
+    stmt: use BindingId(74) pair site=SiteId(612) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(609) ty=()
-    stmt: use BindingId(75) sink site=SiteId(613) ty=Sink<string> intent=Read
-    stmt: use BindingId(76) input site=SiteId(614) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(75) sink site=SiteId(613) ty=Sink<string>
-    stmt: agg_alias BindingId(76) input site=SiteId(614) ty=Stream<string>
-    stmt: return site=Some(SiteId(598)) ty=(Sink<string>, Stream<string>)
+    stmt: eval site=SiteId(611) ty=()
+    stmt: use BindingId(75) sink site=SiteId(615) ty=Sink<string> intent=Read
+    stmt: use BindingId(76) input site=SiteId(616) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(75) sink site=SiteId(615) ty=Sink<string>
+    stmt: agg_alias BindingId(76) input site=SiteId(616) ty=Stream<string>
+    stmt: return site=Some(SiteId(600)) ty=(Sink<string>, Stream<string>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -1948,31 +1952,31 @@ fn stream$bytes_pipe(i64) -> (Sink<bytes>, Stream<bytes>) [conv=default]
     _8: (Sink<bytes>, Stream<bytes>)
     _9: (Sink<bytes>, Stream<bytes>)
   bb0:
-    stmt: use BindingId(77) capacity site=SiteId(618) ty=i64 intent=Read
+    stmt: use BindingId(77) capacity site=SiteId(620) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(78) pair site=SiteId(616) ty=StreamPair
-    stmt: use BindingId(78) pair site=SiteId(621) ty=StreamPair intent=Read
+    stmt: bind BindingId(78) pair site=SiteId(618) ty=StreamPair
+    stmt: use BindingId(78) pair site=SiteId(623) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink_bytes(_3) -> bb2
   bb2:
-    stmt: bind BindingId(79) sink site=SiteId(620) ty=Sink<bytes>
-    stmt: use BindingId(78) pair site=SiteId(624) ty=StreamPair intent=Read
+    stmt: bind BindingId(79) sink site=SiteId(622) ty=Sink<bytes>
+    stmt: use BindingId(78) pair site=SiteId(626) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream_bytes(_3) -> bb3
   bb3:
-    stmt: bind BindingId(80) input site=SiteId(623) ty=Stream<bytes>
-    stmt: use BindingId(78) pair site=SiteId(627) ty=StreamPair intent=Read
+    stmt: bind BindingId(80) input site=SiteId(625) ty=Stream<bytes>
+    stmt: use BindingId(78) pair site=SiteId(629) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(626) ty=()
-    stmt: use BindingId(79) sink site=SiteId(630) ty=Sink<bytes> intent=Read
-    stmt: use BindingId(80) input site=SiteId(631) ty=Stream<bytes> intent=Read
-    stmt: agg_alias BindingId(79) sink site=SiteId(630) ty=Sink<bytes>
-    stmt: agg_alias BindingId(80) input site=SiteId(631) ty=Stream<bytes>
-    stmt: return site=Some(SiteId(615)) ty=(Sink<bytes>, Stream<bytes>)
+    stmt: eval site=SiteId(628) ty=()
+    stmt: use BindingId(79) sink site=SiteId(632) ty=Sink<bytes> intent=Read
+    stmt: use BindingId(80) input site=SiteId(633) ty=Stream<bytes> intent=Read
+    stmt: agg_alias BindingId(79) sink site=SiteId(632) ty=Sink<bytes>
+    stmt: agg_alias BindingId(80) input site=SiteId(633) ty=Stream<bytes>
+    stmt: return site=Some(SiteId(617)) ty=(Sink<bytes>, Stream<bytes>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -1994,18 +1998,18 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     _11: Result<Stream<string>, string>
     _12: Result<Stream<string>, string>
   bb0:
-    stmt: use BindingId(81) path site=SiteId(634) ty=string intent=Read
+    stmt: use BindingId(81) path site=SiteId(636) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(82) s site=SiteId(633) ty=Stream<string>
-    stmt: use BindingId(82) s site=SiteId(638) ty=Stream<string> intent=Read
+    stmt: bind BindingId(82) s site=SiteId(635) ty=Stream<string>
+    stmt: use BindingId(82) s site=SiteId(640) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(82) s site=SiteId(642) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(82) s site=SiteId(642) ty=Stream<string>
+    stmt: use BindingId(82) s site=SiteId(644) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(82) s site=SiteId(644) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2017,7 +2021,7 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(632)) ty=Result<Stream<string>, string>
+    stmt: return site=Some(SiteId(634)) ty=Result<Stream<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2047,18 +2051,18 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _15: Result<Stream<string>, fs.IoError>
     _16: Result<Stream<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(83) path site=SiteId(649) ty=string intent=Read
+    stmt: use BindingId(83) path site=SiteId(651) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(84) s site=SiteId(648) ty=Stream<string>
-    stmt: use BindingId(84) s site=SiteId(653) ty=Stream<string> intent=Read
+    stmt: bind BindingId(84) s site=SiteId(650) ty=Stream<string>
+    stmt: use BindingId(84) s site=SiteId(655) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(84) s site=SiteId(657) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(84) s site=SiteId(657) ty=Stream<string>
+    stmt: use BindingId(84) s site=SiteId(659) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(84) s site=SiteId(659) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2068,17 +2072,17 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
   bb4:
     _8 = call hew_stream_last_errno() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(647)) ty=Result<Stream<string>, fs.IoError>
+    stmt: return site=Some(SiteId(649)) ty=Result<Stream<string>, fs.IoError>
     _16 = move _3
     ret = move _16
     return
   bb6:
-    stmt: bind BindingId(85) errno site=SiteId(659) ty=i32
+    stmt: bind BindingId(85) errno site=SiteId(661) ty=i32
     _9 = move _8
     _10 = call hew_stream_last_error() -> bb7
   bb7:
-    stmt: eval site=SiteId(661) ty=string
-    stmt: use BindingId(85) errno site=SiteId(666) ty=i32 intent=Read
+    stmt: eval site=SiteId(663) ty=string
+    stmt: use BindingId(85) errno site=SiteId(668) ty=i32 intent=Read
     _12 = const.i64 1
     mtag11 = move _12
     _13 = cast _9 i32 -> i64
@@ -2105,18 +2109,18 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     _11: Result<Sink<string>, string>
     _12: Result<Sink<string>, string>
   bb0:
-    stmt: use BindingId(86) path site=SiteId(670) ty=string intent=Read
+    stmt: use BindingId(86) path site=SiteId(672) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(87) s site=SiteId(669) ty=Sink<string>
-    stmt: use BindingId(87) s site=SiteId(674) ty=Sink<string> intent=Read
+    stmt: bind BindingId(87) s site=SiteId(671) ty=Sink<string>
+    stmt: use BindingId(87) s site=SiteId(676) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(87) s site=SiteId(678) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(87) s site=SiteId(678) ty=Sink<string>
+    stmt: use BindingId(87) s site=SiteId(680) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(87) s site=SiteId(680) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2128,7 +2132,7 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(668)) ty=Result<Sink<string>, string>
+    stmt: return site=Some(SiteId(670)) ty=Result<Sink<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2158,18 +2162,18 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _15: Result<Sink<string>, fs.IoError>
     _16: Result<Sink<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(88) path site=SiteId(685) ty=string intent=Read
+    stmt: use BindingId(88) path site=SiteId(687) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(89) s site=SiteId(684) ty=Sink<string>
-    stmt: use BindingId(89) s site=SiteId(689) ty=Sink<string> intent=Read
+    stmt: bind BindingId(89) s site=SiteId(686) ty=Sink<string>
+    stmt: use BindingId(89) s site=SiteId(691) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(89) s site=SiteId(693) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(89) s site=SiteId(693) ty=Sink<string>
+    stmt: use BindingId(89) s site=SiteId(695) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(89) s site=SiteId(695) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2179,17 +2183,17 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
   bb4:
     _8 = call hew_stream_last_errno() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(683)) ty=Result<Sink<string>, fs.IoError>
+    stmt: return site=Some(SiteId(685)) ty=Result<Sink<string>, fs.IoError>
     _16 = move _3
     ret = move _16
     return
   bb6:
-    stmt: bind BindingId(90) errno site=SiteId(695) ty=i32
+    stmt: bind BindingId(90) errno site=SiteId(697) ty=i32
     _9 = move _8
     _10 = call hew_stream_last_error() -> bb7
   bb7:
-    stmt: eval site=SiteId(697) ty=string
-    stmt: use BindingId(90) errno site=SiteId(702) ty=i32 intent=Read
+    stmt: eval site=SiteId(699) ty=string
+    stmt: use BindingId(90) errno site=SiteId(704) ty=i32 intent=Read
     _12 = const.i64 1
     mtag11 = move _12
     _13 = cast _9 i32 -> i64
@@ -2205,11 +2209,11 @@ fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
     _0: Stream<string>
     _1: Sink<string>
   bb0:
-    stmt: use BindingId(91) source site=SiteId(706) ty=Stream<string> intent=Read
-    stmt: use BindingId(92) dest site=SiteId(707) ty=Sink<string> intent=Read
+    stmt: use BindingId(91) source site=SiteId(708) ty=Stream<string> intent=Read
+    stmt: use BindingId(92) dest site=SiteId(709) ty=Sink<string> intent=Read
     call hew_stream_pipe(_0, _1) -> bb1
   bb1:
-    stmt: eval site=SiteId(704) ty=()
+    stmt: eval site=SiteId(706) ty=()
     return
 
 fn i8::fmt(i8) -> string [conv=default]
@@ -2218,11 +2222,11 @@ fn i8::fmt(i8) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(101) val site=SiteId(779) ty=i8 intent=Read
+    stmt: use BindingId(101) val site=SiteId(781) ty=i8 intent=Read
     _1 = cast _0 i8 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(777)) ty=string
+    stmt: return site=Some(SiteId(779)) ty=string
     ret = move _2
     return
 
@@ -2232,11 +2236,11 @@ fn i16::fmt(i16) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(102) val site=SiteId(783) ty=i16 intent=Read
+    stmt: use BindingId(102) val site=SiteId(785) ty=i16 intent=Read
     _1 = cast _0 i16 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(781)) ty=string
+    stmt: return site=Some(SiteId(783)) ty=string
     ret = move _2
     return
 
@@ -2245,10 +2249,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(103) val site=SiteId(786) ty=i32 intent=Read
+    stmt: use BindingId(103) val site=SiteId(788) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(785)) ty=string
+    stmt: return site=Some(SiteId(787)) ty=string
     ret = move _1
     return
 
@@ -2257,10 +2261,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(104) val site=SiteId(789) ty=i64 intent=Read
+    stmt: use BindingId(104) val site=SiteId(791) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(788)) ty=string
+    stmt: return site=Some(SiteId(790)) ty=string
     ret = move _1
     return
 
@@ -2269,10 +2273,10 @@ fn u8::fmt(u8) -> string [conv=default]
     _0: u8
     _1: string
   bb0:
-    stmt: use BindingId(105) val site=SiteId(792) ty=u8 intent=Read
+    stmt: use BindingId(105) val site=SiteId(794) ty=u8 intent=Read
     _1 = call to_string_u8(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(791)) ty=string
+    stmt: return site=Some(SiteId(793)) ty=string
     ret = move _1
     return
 
@@ -2281,10 +2285,10 @@ fn u16::fmt(u16) -> string [conv=default]
     _0: u16
     _1: string
   bb0:
-    stmt: use BindingId(106) val site=SiteId(795) ty=u16 intent=Read
+    stmt: use BindingId(106) val site=SiteId(797) ty=u16 intent=Read
     _1 = call to_string_u16(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(794)) ty=string
+    stmt: return site=Some(SiteId(796)) ty=string
     ret = move _1
     return
 
@@ -2293,10 +2297,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(107) val site=SiteId(798) ty=u32 intent=Read
+    stmt: use BindingId(107) val site=SiteId(800) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(797)) ty=string
+    stmt: return site=Some(SiteId(799)) ty=string
     ret = move _1
     return
 
@@ -2305,10 +2309,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(108) val site=SiteId(801) ty=u64 intent=Read
+    stmt: use BindingId(108) val site=SiteId(803) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(800)) ty=string
+    stmt: return site=Some(SiteId(802)) ty=string
     ret = move _1
     return
 
@@ -2318,11 +2322,11 @@ fn isize::fmt(isize) -> string [conv=default]
     _1: i64
     _2: string
   bb0:
-    stmt: use BindingId(109) val site=SiteId(805) ty=isize intent=Read
+    stmt: use BindingId(109) val site=SiteId(807) ty=isize intent=Read
     _1 = cast _0 isize -> i64
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(803)) ty=string
+    stmt: return site=Some(SiteId(805)) ty=string
     ret = move _2
     return
 
@@ -2332,11 +2336,11 @@ fn usize::fmt(usize) -> string [conv=default]
     _1: u64
     _2: string
   bb0:
-    stmt: use BindingId(110) val site=SiteId(809) ty=usize intent=Read
+    stmt: use BindingId(110) val site=SiteId(811) ty=usize intent=Read
     _1 = cast _0 usize -> u64
     _2 = call to_string_u64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(807)) ty=string
+    stmt: return site=Some(SiteId(809)) ty=string
     ret = move _2
     return
 
@@ -2345,10 +2349,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(111) val site=SiteId(812) ty=bool intent=Read
+    stmt: use BindingId(111) val site=SiteId(814) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(811)) ty=string
+    stmt: return site=Some(SiteId(813)) ty=string
     ret = move _1
     return
 
@@ -2357,10 +2361,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(112) val site=SiteId(815) ty=char intent=Read
+    stmt: use BindingId(112) val site=SiteId(817) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(814)) ty=string
+    stmt: return site=Some(SiteId(816)) ty=string
     ret = move _1
     return
 
@@ -2369,10 +2373,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(113) val site=SiteId(818) ty=f64 intent=Read
+    stmt: use BindingId(113) val site=SiteId(820) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(817)) ty=string
+    stmt: return site=Some(SiteId(819)) ty=string
     ret = move _1
     return
 
@@ -2382,11 +2386,11 @@ fn f32::fmt(f32) -> string [conv=default]
     _1: f64
     _2: string
   bb0:
-    stmt: use BindingId(114) val site=SiteId(822) ty=f32 intent=Read
+    stmt: use BindingId(114) val site=SiteId(824) ty=f32 intent=Read
     _1 = cast _0 f32 -> f64
     _2 = call to_string_f64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(820)) ty=string
+    stmt: return site=Some(SiteId(822)) ty=string
     ret = move _2
     return
 
@@ -2394,8 +2398,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(115) val site=SiteId(824) ty=string intent=Read
-    stmt: return site=Some(SiteId(824)) ty=string
+    stmt: use BindingId(115) val site=SiteId(826) ty=string intent=Read
+    stmt: return site=Some(SiteId(826)) ty=string
     ret = move _0
     return
 
@@ -2406,14 +2410,14 @@ fn duration::from_nanos(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(116) n site=SiteId(826) ty=i64 intent=Read
+    stmt: use BindingId(116) n site=SiteId(828) ty=i64 intent=Read
     _1 = const.duration 1ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(825)) ty=duration
+    stmt: return site=Some(SiteId(827)) ty=duration
     ret = move _2
     return
 
@@ -2424,14 +2428,14 @@ fn duration::from_micros(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(117) n site=SiteId(829) ty=i64 intent=Read
+    stmt: use BindingId(117) n site=SiteId(831) ty=i64 intent=Read
     _1 = const.duration 1000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(828)) ty=duration
+    stmt: return site=Some(SiteId(830)) ty=duration
     ret = move _2
     return
 
@@ -2442,14 +2446,14 @@ fn duration::from_millis(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(118) n site=SiteId(832) ty=i64 intent=Read
+    stmt: use BindingId(118) n site=SiteId(834) ty=i64 intent=Read
     _1 = const.duration 1000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(831)) ty=duration
+    stmt: return site=Some(SiteId(833)) ty=duration
     ret = move _2
     return
 
@@ -2460,14 +2464,14 @@ fn duration::from_secs(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(119) n site=SiteId(835) ty=i64 intent=Read
+    stmt: use BindingId(119) n site=SiteId(837) ty=i64 intent=Read
     _1 = const.duration 1000000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(834)) ty=duration
+    stmt: return site=Some(SiteId(836)) ty=duration
     ret = move _2
     return
 
@@ -2479,11 +2483,11 @@ fn duration::fmt(duration) -> string [conv=default]
     _3: string
     _4: string
   bb0:
-    stmt: use BindingId(120) val site=SiteId(840) ty=duration intent=Read
+    stmt: use BindingId(120) val site=SiteId(842) ty=duration intent=Read
     _1 = call_rt hew_duration_nanos(_0)
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(837)) ty=string
+    stmt: return site=Some(SiteId(839)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
     ret = move _4

--- a/hew-runtime/src/file_io.rs
+++ b/hew-runtime/src/file_io.rs
@@ -1108,6 +1108,61 @@ mod tests {
     }
 
     #[test]
+    fn read_bytes_failure_message_survives_a_standalone_errno_read() {
+        // Regression (std/fs.hew try_read_bytes leak, hew-lang/hew#1728-class):
+        // hew_stream_last_errno() and hew_stream_last_error() are independent
+        // thread-local reads (see stream_error.rs's own doc comment) — reading
+        // one does not clear the other. try_read_bytes in std/fs.hew reads only
+        // hew_stream_last_errno() on its failure path; if it does not also
+        // drain hew_stream_last_error(), a stale `hew_file_read_bytes: ...`
+        // message from this failed read stays parked in the thread-local and
+        // can leak into a later, unrelated hew_last_error() /
+        // hew_stream_last_error() read (e.g. a subsequent fs.read() panic
+        // message). This test pins the FFI-layer precondition for that fix:
+        // after hew_file_read_bytes fails and only the errno is consumed, the
+        // message must still be present and draining it must yield the
+        // *current* failure's own text, not an empty/stale value.
+        use hew_cabi::sink::{hew_stream_last_errno, hew_stream_last_error};
+
+        let dir = test_dir("bytes_errno_only_read_leak");
+        let ghost_path = dir.join("does_not_exist.bin");
+        let ghost = cpath(&ghost_path);
+
+        // SAFETY: ghost is a valid NUL-terminated C string.
+        let triple = unsafe { hew_file_read_bytes(ghost.as_ptr()) };
+        assert_eq!(triple.len, 0);
+        assert!(triple.ptr.is_null());
+
+        // Mirror try_read_bytes's exact failure-path call: read errno alone
+        // first, the way the .hew wrapper does before deciding to return Err.
+        let errno = hew_stream_last_errno();
+        assert_ne!(errno, 0, "expected a non-zero errno from the missing file");
+
+        // The message must still be there for a caller that goes on to drain
+        // it (the fix), and it must be this call's own message, not empty.
+        // SAFETY: hew_stream_last_error() returns a fresh, valid C string or
+        // null; we only read it and then free it via the documented path.
+        unsafe {
+            let msg_ptr = hew_stream_last_error();
+            assert!(
+                !msg_ptr.is_null(),
+                "hew_stream_last_error() must still return the message after a \
+                 standalone hew_stream_last_errno() read — they are documented \
+                 as independent reads, so try_read_bytes's fix must explicitly \
+                 drain this instead of assuming the errno read already did"
+            );
+            let message = CStr::from_ptr(msg_ptr).to_str().unwrap_or("").to_owned();
+            crate::string::hew_string_drop(msg_ptr);
+            assert!(
+                message.contains("hew_file_read_bytes"),
+                "expected the current failed read's own message, got {message:?}"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn read_bytes_invalid_utf8_path_returns_empty_triple() {
         let bad = invalid_utf8_cstring();
         // SAFETY: bad is a valid NUL-terminated C string (non-UTF-8 is handled).

--- a/hew-std/src/tls.rs
+++ b/hew-std/src/tls.rs
@@ -317,14 +317,22 @@ fn write_tls_bytes<W: Write>(writer: &mut W, buf: &[u8]) -> HewTlsWriteResult {
 pub unsafe extern "C" fn hew_tls_connect(host: *const c_char, port: c_int) -> *mut HewTlsStream {
     // SAFETY: `host` is a valid NUL-terminated C string per caller contract.
     let Some(host_str) = (unsafe { cstr_to_str(host) }) else {
+        set_tls_last_error("hew_tls_connect: invalid host string");
         return std::ptr::null_mut();
     };
     let Ok(port_u16) = u16::try_from(port) else {
+        set_tls_last_error(format!("hew_tls_connect: invalid port {port}"));
         return std::ptr::null_mut();
     };
     match connect_tls(host_str, port_u16) {
-        Ok(stream) => Box::into_raw(Box::new(stream)),
-        Err(_) => std::ptr::null_mut(),
+        Ok(stream) => {
+            clear_tls_last_error();
+            Box::into_raw(Box::new(stream))
+        }
+        Err(err) => {
+            set_tls_last_error(format!("hew_tls_connect: {err}"));
+            std::ptr::null_mut()
+        }
     }
 }
 
@@ -859,6 +867,7 @@ mod tests {
     use std::cell::Cell;
     use std::collections::HashMap;
     use std::ffi::CStr;
+    use std::ffi::CString;
     use std::io::ErrorKind;
     use std::net::TcpListener;
     use std::os::raw::c_void;
@@ -1043,9 +1052,35 @@ mod tests {
 
     #[test]
     fn connect_null_host_returns_null() {
+        clear_tls_last_error();
         // SAFETY: passing null is the test.
         let ptr = unsafe { hew_tls_connect(std::ptr::null(), 443) };
         assert!(ptr.is_null());
+        assert_eq!(last_error_string(), "hew_tls_connect: invalid host string");
+    }
+
+    #[test]
+    fn connect_refused_sets_last_error() {
+        clear_tls_last_error();
+        // Port 0 is never listening; the OS refuses the connect() attempt
+        // (or DNS resolution itself fails for a bogus host), either way
+        // exercising the `connect_tls(...) => Err(_)` failure path without
+        // needing a live network fixture.
+        let host = CString::new("127.0.0.1").unwrap();
+        // SAFETY: `host` is a valid NUL-terminated C string.
+        let ptr = unsafe { hew_tls_connect(host.as_ptr(), 0) };
+        assert!(ptr.is_null());
+        assert!(
+            last_error_string().starts_with("hew_tls_connect: "),
+            "expected a hew_tls_connect-prefixed message, got {:?}",
+            last_error_string()
+        );
+        assert!(
+            !last_error_string().ends_with("invalid host string")
+                && !last_error_string().contains("invalid port"),
+            "expected the connect_tls Err(_) path, got {:?}",
+            last_error_string()
+        );
     }
 
     #[test]
@@ -1277,18 +1312,26 @@ mod tests {
 
     #[test]
     fn connect_empty_host_returns_null() {
+        clear_tls_last_error();
         let host = std::ffi::CString::new("").unwrap();
         // SAFETY: passing valid but empty C string.
         let ptr = unsafe { hew_tls_connect(host.as_ptr(), 443) };
         assert!(ptr.is_null());
+        // An empty host is valid UTF-8 (passes `cstr_to_str`), so this hits
+        // the `connect_tls(...) => Err(_)` path (invalid DNS name) rather
+        // than the null/invalid-C-string path exercised by
+        // `connect_null_host_returns_null`.
+        assert_eq!(last_error_string(), "hew_tls_connect: invalid dns name");
     }
 
     #[test]
     fn connect_negative_port_returns_null() {
+        clear_tls_last_error();
         let host = std::ffi::CString::new("example.com").unwrap();
         // SAFETY: passing valid host with invalid port.
         let ptr = unsafe { hew_tls_connect(host.as_ptr(), -1) };
         assert!(ptr.is_null());
+        assert_eq!(last_error_string(), "hew_tls_connect: invalid port -1");
     }
 
     #[test]

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -357,6 +357,11 @@ pub fn try_read_bytes(file_path: string) -> Result<bytes, IoError> {
         let data = hew_file_read_bytes(file_path);
         let errno = hew_stream_last_errno();
         if errno != 0 {
+            // Drain the thread-local error message on the failure path,
+            // mirroring `try_read` above, so a stale
+            // `hew_file_read_bytes: ...` message can't leak into a later,
+            // unrelated `hew_last_error()` / `hew_stream_last_error()` read.
+            let _ = hew_stream_last_error();
             Err(io_error_from_errno(errno as i64))
         } else {
             // `data` is the sole owner of the freshly-read buffer and is not

--- a/tests/hew/fs_stream_test.hew
+++ b/tests/hew/fs_stream_test.hew
@@ -8,6 +8,17 @@ import std::stream;
 
 import std::testing;
 
+// hew_stream_last_error / hew_stream_last_errno are the single shared
+// thread-local error channel declared once in hew-runtime (see
+// hew-runtime/src/stream_error.rs); std/fs.hew declares this exact same
+// extern block internally to read them. Declaring it here too lets this
+// test observe the channel directly, the same way an unrelated caller
+// elsewhere in the program would.
+extern "C" {
+    fn hew_stream_last_error() -> string;
+    fn hew_stream_last_errno() -> i32;
+}
+
 fn cleanup_file(file_path: string) {
     if fs.exists(file_path) {
         fs.delete(file_path);
@@ -38,6 +49,48 @@ fn test_try_read_bytes_missing_returns_not_found() {
             _ => panic("expected IoError::NotFound"),
         },
     }
+}
+
+#[test]
+fn test_try_read_bytes_failure_drains_stale_error_message() {
+    // Regression pin: try_read_bytes must drain hew_stream_last_error() on
+    // its failure path, not just hew_stream_last_errno(). The two are
+    // documented as independent thread-local reads (hew-runtime's
+    // stream_error.rs) — reading errno alone does not clear the message.
+    // Without the drain, a failed try_read_bytes leaves the
+    // `hew_file_read_bytes: ...` message parked in the shared thread-local,
+    // where it can leak into a later, unrelated hew_stream_last_error() read.
+    let file_path = "tests/hew/_fs_stream_drain_missing.bin";
+    cleanup_file(file_path);
+    match fs.try_read_bytes(file_path) {
+        Ok(_) => panic("expected missing file error"),
+        Err(err) => match err {
+            IoError::NotFound(_) => {},
+            _ => panic("expected IoError::NotFound"),
+        },
+    }
+    // The failure path above must have already drained the message: a
+    // direct read of the shared channel right after must come back empty.
+    // Before the fix, this returns the stale `hew_file_read_bytes: ...`
+    // text instead, because try_read_bytes only ever consumed the errno
+    // side of the channel and left the message behind.
+    // (compared by length, not `== ""`: a drained/never-set channel comes
+    // back as a null C string, which converts to a length-0 `string` that
+    // is not `==` to the `""` literal — see hew_stream_last_error's None
+    // branch in hew-runtime/src/stream_error.rs.)
+    let leaked = unsafe {
+        hew_stream_last_error()
+    };
+    testing.assert_eq(leaked.len(), 0);
+
+    // The errno side is independently drained too (already covered by the
+    // io_error_from_errno mapping above succeeding), so a second read
+    // here must also report "no error" — proving the whole channel, not
+    // just one half of it, comes back clean after the failed call.
+    let errno_after = unsafe {
+        hew_stream_last_errno()
+    };
+    testing.assert_eq(errno_after as i64, 0);
 }
 
 #[test]


### PR DESCRIPTION
Fixes two independent, previously-open diagnostic-contract bugs surfaced during source review (`reviews/hew-pr-bad-issues.md`) against PR #1476 and PR #1728. Both still reproduced against current `origin/main` before this fix.

## 1. `hew_tls_connect()` never set `last_error()` on failure (from #1476)

`hew_tls_connect()` returned null on all three failure paths — invalid host C string, invalid port, and `connect_tls(...) => Err(_)` — without ever calling `set_tls_last_error()`. `std/net/tls/tls.hew`'s own doc comment for `last_error()` says "Failed `connect()` calls update this string", but the string stayed empty on every failure. The read/write paths already follow this convention (`set_tls_last_error(message)` on each failure arm); `connect()` just never did.

Fix mirrors that convention on all three failure paths, using `connect_tls`'s own error `Display` for the network-failure case so the message is diagnostic rather than generic (e.g. `"hew_tls_connect: invalid dns name"` for an unresolvable/empty host).

## 2. `try_read_bytes` left a stale error message parked in the thread-local (from #1728)

`std/fs.hew`'s `try_read_bytes` reads `hew_stream_last_errno()` alone on its failure path but never drains `hew_stream_last_error()`. The two are documented as independent thread-local reads (see `hew-runtime/src/stream_error.rs`'s own module doc comment), so a failed `try_read_bytes` left a stale `hew_file_read_bytes: ...` message sitting in the thread-local — which could leak into a later, unrelated `hew_last_error()` / `hew_stream_last_error()` read (e.g. a subsequent `fs.read()` panic would report the *earlier* failure's text instead of its own).

The sibling `try_read` already drains this correctly (`let _ = hew_stream_last_error();`); `try_read_bytes` now mirrors it.

## Tests

- `hew-std/src/tls.rs`: strengthened 4 existing `hew_tls_connect` tests to assert `last_error()` content on each failure shape, added `connect_refused_sets_last_error` covering the `connect_tls(...) => Err(_)` arm specifically.
- `hew-runtime/src/file_io.rs`: added `read_bytes_failure_message_survives_a_standalone_errno_read`, pinning the FFI-layer precondition (`hew_stream_last_errno()` and `hew_stream_last_error()` are independent reads) that `try_read_bytes`'s fix depends on.

## Verification (fresh `origin/main`, before pushing)

- `cargo test -p hew-std --lib tls:: -- --test-threads=1`: 32/32 passing.
  - Note: the crate's pre-existing `tls::` suite aborts under the *default parallel* test runner independent of this change — reproduced identically on an unmodified `origin/main` worktree (a pre-existing environment flake in `close_reaps_a_live_blocked_reader_without_hanging`, not caused by or related to this diff). Single-threaded is clean.
- `cargo test -p hew-runtime --lib file_io::`: 69/69 passing.
- `hew test tests/hew/fs_stream_test.hew`: 15/15 passing.
- `tests/vertical-slice/run.sh`: 419/419 passing, 0 failures.
- `cargo fmt -p hew-std -p hew-runtime -- --check` and `cargo clippy -p hew-std -p hew-runtime --lib -- -D warnings`: both clean.

Scope is intentionally narrow — no other behaviour changed.