### PR TITLE
fix(check): check spawn args against init() params, not state fields

### DIFF
--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -6725,8 +6725,28 @@ impl Checker {
     fn check_spawn_constructor_args(&mut self, actor_name: &str, args: &[(String, Spanned<Expr>)]) {
         let actor_fields: Option<HashMap<String, Ty>> =
             self.lookup_type_def(actor_name).map(|td| td.fields);
+        // An actor with an explicit `init(...)` names its spawn args after
+        // the INIT PARAMETERS, not the state fields they assign into (the
+        // two names may differ, and even when they match, the init
+        // parameter's declared width is the checker-authoritative one — the
+        // init body may narrow/widen before storing into the field). Look up
+        // `actor_init_params` first so a param like `init(start: i32)` gets
+        // `check_against(..., i32)` here; only actors with no explicit init
+        // (whose spawn args map directly onto bare field names) fall back to
+        // the field-type lookup. Without this, an unmatched `field_name`
+        // silently synthesizes the arg (defaulting an untyped int literal to
+        // `i64`), which then mismatches the init thunk's declared i32
+        // parameter and trips the LLVM verifier at the spawn call site
+        // (#2402).
+        let init_params = self.actor_init_params.get(actor_name).cloned();
         for (field_name, (arg, as_)) in args {
-            let declared = actor_fields.as_ref().and_then(|f| f.get(field_name));
+            let declared_init_param = init_params
+                .as_ref()
+                .and_then(|params| params.iter().find(|p| &p.name == field_name))
+                .map(|p| p.ty.clone());
+            let declared = declared_init_param
+                .as_ref()
+                .or_else(|| actor_fields.as_ref().and_then(|f| f.get(field_name)));
             let ty_raw = match declared {
                 Some(declared_ty) => {
                     let is_bare_actor = if let Ty::Named {

--- a/tests/vertical-slice/accept/actor_init_narrow_param.hew
+++ b/tests/vertical-slice/accept/actor_init_narrow_param.hew
@@ -1,0 +1,29 @@
+// Regression for #2402: an actor `init(...)` parameter narrower than the
+// word-width `i64` used to fail LLVM verification at the spawn call site —
+// the spawn thunk packed every scalar init arg as `i64` while `init`'s own
+// declared signature kept the narrower width, so the two sides of the spawn
+// boundary disagreed and the verifier rejected the call. Covers i32, i16 and
+// u8 init params (the widths most likely to be reached for a port number, a
+// small count, or a flag) and asserts the EXACT stored value survives
+// through a receive fn read, not just that the module compiles.
+actor NarrowInit {
+    var n32: i32;
+    var n16: i16;
+    var n8: u8;
+    init(a: i32, b: i16, c: u8) {
+        n32 = a;
+        n16 = b;
+        n8 = c;
+    }
+    receive fn sum() -> i64 {
+        n32 as i64 + n16 as i64 + n8 as i64
+    }
+}
+
+fn main() -> i64 {
+    let handle = spawn NarrowInit(a: 100, b: 20, c: 3);
+    match await handle.sum() {
+        Ok(v) => v,
+        Err(_e) => -1,
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1128,6 +1128,11 @@ run_accept_expect_status "actor_counter_init" 42
 # send(10) + send(32) = 42; get() returns 42.
 run_accept_expect_status "actor_receive_fn_named_send" 42
 
+# Regression for #2402: init() params narrower than i64 (i32/i16/u8) must
+# survive the spawn thunk without an LLVM verifier width mismatch.
+# 100 + 20 + 3 = 123.
+run_accept_expect_status "actor_init_narrow_param" 123
+
 # Accept: a value-returning `receive fn send(...) -> T` invoked via
 # `await ref.send(...)` is a first-class *ask* — the awaited form consumes the
 # reply, so the HIR fire-and-forget gate must not block it. Doubler.send(21)


### PR DESCRIPTION
## Summary

Spawn arguments were type-checked against the actor's state fields, so an actor with an explicit `init(start: i32)` assigning into a differently-named field made the lookup miss and fall through to literal synthesis, which defaults integer literals to `i64` — disagreeing with the init thunk's real signature and tripping the LLVM verifier at spawn (`Call parameter type does not match function signature!`). The checker now consults the existing init-parameter table by name first, keeping the field lookup for actors without an explicit init (and for field-routed names on actors that have one). Genuinely unknown arguments stay fail-closed, and out-of-range literals for narrow init parameters are now rejected at the checker instead of silently widening.

## Verification

- New compiled fixture `tests/vertical-slice/accept/actor_init_narrow_param.hew`: spawns across `i32`/`i16`/`u8` init parameter widths with exact exit-value pinning; red on the previous compiler with the original failure signature.
- `bash tests/vertical-slice/run.sh`: green, including the new fixture
- `make test-lane CRATE=hew-types` and `CRATE=hew-codegen-rs`: green
- `make lint`: clean
- `cargo fmt --check`: clean

## Out of scope

- Spawn-site generic substitution: spawn args are still checked against registration-time declared types with spawn-site type arguments unsubstituted (pre-existing on the field path too); tracked in #2447 (spawn-site generic substitution) and #2448 (collision diagnostic).
- A checker-level diagnostic for the case where an init parameter and a state field share a name with different types (currently fails closed with a low-level error); tracked in #2447 (spawn-site generic substitution) and #2448 (collision diagnostic).

## Quality Checklist
- [x] PR title, body, and commit messages avoid internal-only orchestration/model vocabulary
- [x] No new `.ok()?` or `unwrap_or_default()` in codegen without `// JUSTIFIED` comment
- [x] New allocations have cleanup paths for sync, async, and actor shutdown contexts (none added)
- [x] Serialization changes include round-trip encode/decode tests (no serialization changes)
- [x] New runtime features have WASM implementation or `// WASM-TODO(#NNN):` marker (with issue ref, e.g. `#1451`), and new `hew_*` exports are classified in `scripts/jit-symbol-classification.toml` (none added)
- [x] No duplicated logic — checked for existing helpers before adding new ones

Fixes #2402
