### PR TITLE
fix(mir): run the #2301 overwrite-guard pre-pass on closure/gen-fn bodies

### DIFF
--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -30927,6 +30927,19 @@ impl Builder {
             builder.binding_locals.insert(param.id, place);
         }
 
+        // #2301 -- run the same owned-Vec-key / consumed-and-reassigned-binding
+        // pre-pass on the closure body that `function_body` runs for a
+        // top-level function. `lower_closure_shim` builds a brand-new child
+        // `Builder` and lowers `body` directly via `lower_value` below; without
+        // this call, `prepass_consumed_bindings`/`prepass_reassigned_bindings`
+        // stay empty for every closure-local binding, so
+        // `maybe_alloc_overwrite_guard_flag` never fires inside a closure body
+        // and a `var` consumed on one control-flow arm and overwritten on a
+        // sibling arm silently leaks its prior value (no guard flag, no
+        // release before the overwrite) instead of getting the path-sensitive
+        // release a byte-identical top-level function body would.
+        builder.collect_vec_owned_element_keys_from_expr(body);
+
         if let Some(src) = builder.lower_value(body) {
             builder.instructions.push(Instr::Move {
                 dest: Place::ReturnSlot,
@@ -31558,6 +31571,16 @@ impl Builder {
         // Lower the lambda body. The body is a single HirExpr (an arrow
         // body or block); reuse `lower_value` so all expression shapes —
         // BlockExpr, Call, BinaryOp, etc. — go through the standard path.
+        //
+        // #2301 -- same pre-pass gap as `lower_closure_shim`/`lower_gen_block`:
+        // this lambda-actor body lowers via its own fresh `body_builder`
+        // (built via `child_builder_tables`, which does not carry
+        // `prepass_consumed_bindings`/`prepass_reassigned_bindings` either), so
+        // without this call a `var` local to the lambda body that is consumed
+        // on one control-flow arm and overwritten on a sibling arm silently
+        // leaks its prior value instead of getting the path-sensitive release
+        // a byte-identical top-level function body would.
+        body_builder.collect_vec_owned_element_keys_from_expr(body);
         let tail_place = body_builder.lower_value(body);
 
         // Shape-driven return slot wiring:
@@ -32254,6 +32277,16 @@ impl Builder {
                 );
             }
         }
+
+        // #2301 -- same pre-pass gap as `lower_closure_shim`: this gen body
+        // lowers via its own fresh `body_builder` (built by field list above,
+        // not `child_builder_tables`), so without this call
+        // `prepass_consumed_bindings`/`prepass_reassigned_bindings` stay empty
+        // for every binding local to the `gen fn`/`gen {}` body and a `var`
+        // consumed on one control-flow arm and overwritten on a sibling arm
+        // silently leaks its prior value instead of getting the path-sensitive
+        // release a byte-identical top-level function body would.
+        body_builder.collect_vec_owned_element_keys_from_block(body);
 
         // Lower all statements in the gen-block body. Yields inside the body
         // call `lower_yield_expr` which emits `Terminator::Yield` and advances

--- a/tests/vertical-slice/accept/closure_consume_reassign_overwrite_release.hew
+++ b/tests/vertical-slice/accept/closure_consume_reassign_overwrite_release.hew
@@ -1,0 +1,59 @@
+// #2301 -- closure-body coverage. `function_body` runs the owned-Vec-key /
+// consumed-and-reassigned-binding pre-pass (`collect_vec_owned_element_keys_
+// from_block`) that seeds `prepass_consumed_bindings`/`prepass_reassigned_
+// bindings`, which `maybe_alloc_overwrite_guard_flag` consults to allocate a
+// runtime-gated release for a `var` consumed on one control-flow arm and
+// reassigned on a sibling arm. `lower_closure_shim` builds a brand-new child
+// `Builder` and lowers the closure body directly via `lower_value` — before
+// the #2301 fix this pre-pass never ran on a closure body, so the identical
+// consume/reassign pattern silently skipped the release when wrapped in a
+// closure (confirmed via `--dump-mir raw`: the top-level function emits an
+// `i64` guard-flag local plus a gated `drop` before the reassignment; the
+// closure invoke shim emitted neither, leaking the prior string).
+//
+// Exercises the ELSE (non-consuming, reassigning) arm so the fix's guard-flag
+// release path actually executes at runtime, not just at MIR-construction
+// time; a double-free here would abort instead of exiting 0.
+fn control(take_consume_arm: bool) -> i64 {
+    var s: string = "aaaaaaaaaa";
+    if take_consume_arm {
+        let moved: string = s;
+        return moved.len();
+    }
+    s = "bbbbbbbbbb";
+    s.len()
+}
+
+fn via_closure(take_consume_arm: bool) -> i64 {
+    let f = |flag: bool| -> i64 {
+        var s: string = "aaaaaaaaaa";
+        if flag {
+            let moved: string = s;
+            return moved.len();
+        }
+        s = "bbbbbbbbbb";
+        s.len()
+    };
+    f(take_consume_arm)
+}
+
+fn main() -> i64 {
+    // Both arms, both call shapes, so the guard-flag machinery's TRUE branch
+    // (consume, no release-on-reassign) and FALSE branch (no consume,
+    // release-then-reassign) both execute for both the top-level control
+    // function and the closure — any accidental double-free would abort
+    // before reaching the final return.
+    if control(true) != 10 {
+        return 1;
+    }
+    if control(false) != 10 {
+        return 2;
+    }
+    if via_closure(true) != 10 {
+        return 3;
+    }
+    if via_closure(false) != 10 {
+        return 4;
+    }
+    0
+}

--- a/tests/vertical-slice/accept/gen_fn_consume_reassign_overwrite_release.hew
+++ b/tests/vertical-slice/accept/gen_fn_consume_reassign_overwrite_release.hew
@@ -1,0 +1,47 @@
+// #2301 -- gen-fn-body coverage (the `lower_gen_block` sibling of
+// `lower_closure_shim`'s gap fixed alongside it). `lower_gen_block` builds its
+// own fresh `body_builder` via an explicit field list ending in
+// `..Builder::default()` and lowers `body.statements`/`body.tail` directly —
+// before the #2301 fix, this body builder's `prepass_consumed_bindings`/
+// `prepass_reassigned_bindings` stayed permanently empty (never seeded by
+// `collect_vec_owned_element_keys_from_block`), so a `var` local to a `gen fn`
+// body that is consumed on one control-flow arm and reassigned on a sibling
+// arm silently skipped the path-sensitive release, exactly like the closure
+// case in `closure_consume_reassign_overwrite_release.hew`.
+//
+// Two separate generator invocations (not two iterations of one loop) so each
+// exercises exactly one arm of the `if` — avoids the pre-existing, unrelated
+// checker limitation where a loop body's guard-flag reset does not yet
+// support a consume on one iteration followed by a second `let`-consume of
+// the same binding on a later iteration.
+gen fn emit_len(take_consume_arm: bool) -> i64 {
+    var s: string = "aaaaaaaaaa";
+    if take_consume_arm {
+        let moved: string = s;
+        yield moved.len();
+    } else {
+        s = "bbbbbbbbbb";
+        yield s.len();
+    }
+}
+
+fn main() -> i64 {
+    var got_consume: i64 = -1;
+    for v in emit_len(true) {
+        got_consume = v;
+    }
+    var got_reassign: i64 = -1;
+    for v in emit_len(false) {
+        got_reassign = v;
+    }
+    // Both arms yield a 10-byte ASCII string's length; a double-free on the
+    // reassigning arm (the arm the #2301 gap under-releases) would abort
+    // before either `for` loop completes, not just produce a wrong number.
+    if got_consume != 10 {
+        return 1;
+    }
+    if got_reassign != 10 {
+        return 2;
+    }
+    0
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -2468,6 +2468,30 @@ run_accept_expect_stdout "gen_block_capture_outer"
 # PersistentShare and poisoned sibling scalar params via all_materialisable=false.
 run_accept_expect_stdout "gen_fn_fn_typed_param"
 
+# #2301 -- child-body pre-pass coverage. `function_body` runs a pre-pass
+# (`collect_vec_owned_element_keys_from_block`) that seeds
+# `prepass_consumed_bindings`/`prepass_reassigned_bindings`, consulted by
+# `maybe_alloc_overwrite_guard_flag` to allocate a runtime-gated release for a
+# `var` consumed on one control-flow arm and reassigned on a sibling arm.
+# `lower_closure_shim` and `lower_gen_block` each build their own fresh child
+# `Builder` and lower the body directly, bypassing the pre-pass entirely
+# before the fix -- so the identical consume/reassign pattern silently
+# skipped the release inside a closure or `gen fn` body (confirmed via
+# `--dump-mir raw`: the top-level `control` function emits an `i64` guard-flag
+# local plus a gated `drop` before the reassignment; the closure invoke shim /
+# generator body emitted neither, leaking the prior string). Both fixtures
+# exit 0 either way -- the leak is silent, not a crash -- so the MIR dump grep
+# for the now-present guard-flag/drop shape is the load-bearing assertion,
+# not just the exit-code check.
+"${HEW}" compile --dump-mir raw "${ROOT}/tests/vertical-slice/accept/closure_consume_reassign_overwrite_release.hew" >"${accept_output}" 2>&1
+grep -q 'drop _2 ty=string fn=release(hew_string_drop)' "${accept_output}"
+grep -q 'drop _3 ty=string fn=release(hew_string_drop)' "${accept_output}"
+run_accept_expect_status "closure_consume_reassign_overwrite_release" 0
+
+"${HEW}" compile --dump-mir raw "${ROOT}/tests/vertical-slice/accept/gen_fn_consume_reassign_overwrite_release.hew" >"${accept_output}" 2>&1
+grep -q 'drop _3 ty=string fn=release(hew_string_drop)' "${accept_output}"
+run_accept_expect_status "gen_fn_consume_reassign_overwrite_release" 0
+
 # Reject: a generator that captures a closure-with-env must still fail closed
 # after the fn-typed-param gate was widened. A closure literal capturing an
 # outer binding carries a heap-boxed env; flat-copying it across the thread


### PR DESCRIPTION
## What

`function_body` runs `collect_vec_owned_element_keys_from_block` before lowering a top-level function's statements. That pre-pass has a second, dual-purpose job (see its own `#2301` comments in `lower.rs`): it also records every binding that is BOTH consumed via a move-out AND reassigned via `Assign` anywhere in the function, into `prepass_consumed_bindings`/`prepass_reassigned_bindings`. `maybe_alloc_overwrite_guard_flag` consults those two sets to decide whether a `var` needs a runtime-gated release before a reassignment on a sibling control-flow arm from the one that consumed it.

`lower_closure_shim`, `lower_spawn_lambda_actor` (the lambda-actor / `receive gen fn` body), and `lower_gen_block` (a `gen fn`/`gen {}` body) each build their own fresh child `Builder` and lower the body directly via `lower_value`/`stmt`, without ever running this pre-pass. Both `child_builder_tables()` and the ad hoc field-list construction used by `lower_gen_block` leave `prepass_consumed_bindings`/`prepass_reassigned_bindings` at their default empty state, so `maybe_alloc_overwrite_guard_flag` never fires for any binding local to one of these three body shapes.

A `var` consumed on one arm and reassigned on a sibling arm inside a closure, lambda-actor body, or generator therefore silently skips the release of its prior value — confirmed via `--dump-mir raw`: a byte-identical top-level function emits an `i64` guard-flag local, a runtime `icmp.eq` check, and a gated `drop` before the reassignment; the closure invoke shim / generator body emitted none of the three, leaking the prior owned value.

## Fix

Call `collect_vec_owned_element_keys_from_expr`/`_from_block` on each child `Builder` before lowering its body, exactly mirroring `function_body`'s own call for the top-level case. This also correctly extends the (already fail-open/safe) owned-Vec-element-key harvest into these three body shapes, though no fixture in this repo currently depends on that side effect since the existing recursive walk never had a `Closure`/`Gen*` arm at all — it's a `_ => {}` fallthrough by design, documented as sound because a missed harvest only causes a still-rejected program, never an unsound lowering.

## Tests

Added two vertical-slice accept fixtures exercising the identical consume/reassign shape both directly (as a control) and wrapped in a closure / `gen fn`:
- `closure_consume_reassign_overwrite_release.hew`
- `gen_fn_consume_reassign_overwrite_release.hew`

Both assert the now-present guard-flag/drop MIR shape via `--dump-mir raw` (the leak is silent — exit code alone does not catch it, confirmed identical exit-0 behavior pre- and post-fix) plus a runtime exit-code check exercising both control-flow arms so an accidental double-free would abort instead of just producing a wrong number.

Verified before pushing:
- `cargo test -p hew-mir --lib` — 322/322 passing
- `cargo fmt --check` — clean
- `cargo clippy -p hew-mir --lib -- -D warnings` — clean
- full `tests/vertical-slice/run.sh` — 428/428, 0 failures

Diagnosed against `origin/main` and documented in this account's own tracking backlog (`projects/inbox-of-unresolved/items/2026-07-06-hew-pr-2301.yaml`) before implementing.