### PR TITLE
build: make assemble build hew-observe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -430,7 +430,7 @@ wasm-dist: wasm
 
 # Create symlinks from build/ into the real output locations.
 # This gives you one stable directory to point PATH at during development.
-assemble: | hew adze runtime stdlib wasm-runtime
+assemble: | hew adze observe runtime stdlib wasm-runtime
 	@mkdir -p $(BUILD_DIR)/bin $(BUILD_DIR)/lib
 	@# assemble-release makes build/std a symlink to ../std; reset it so the
 	@# flat std stub loop below cannot rewrite tracked std/*.hew files in root.


### PR DESCRIPTION
## Summary

`make assemble` creates `build/bin/hew-observe`, but the target's order-only prerequisites omitted `observe`. On a clean tree, running `make assemble` standalone could therefore leave `build/bin/hew-observe` as a broken symlink to `target/debug/hew-observe`.

This adds `observe` to the `assemble` prerequisites, matching the top-level `all` target.

## Verification

From a tree with `target/debug/hew-observe` and `build/bin/hew-observe` removed:

```sh
make assemble
[ -x target/debug/hew-observe ]
[ -e build/bin/hew-observe ]
build/bin/hew-observe --help
```

`make assemble` now invokes `cargo build -p hew-observe`, and the symlink resolves to a runnable binary.
