### PR TITLE
fix(lsp): stop goto-definition on named imports jumping to the import line

### DIFF
--- a/hew-analysis/src/resolver.rs
+++ b/hew-analysis/src/resolver.rs
@@ -93,7 +93,18 @@ pub enum Resolution {
 }
 
 impl Resolution {
-    /// Return the definition URI + span, if the variant carries one.
+    /// Return the definition URI + span, if the variant carries a location
+    /// this resolver can vouch for as the actual definition site.
+    ///
+    /// `ImportedItem` deliberately returns `None` here even though it carries
+    /// an `import_span`: that span points at the *import statement* in the
+    /// importing file, not the imported item's real definition, which may
+    /// live in a different file this resolver never sees (it only has the
+    /// current file's source/parse result). Returning it as a `def_location`
+    /// would make callers treat the import site as the definition and skip
+    /// their own cross-file resolution fallback. Callers that want the
+    /// import span itself (e.g. to chase the import across files) should
+    /// match on `Self::ImportedItem` directly instead of using this method.
     #[must_use]
     pub fn def_location(&self) -> Option<(&str, OffsetSpan)> {
         match self {
@@ -104,12 +115,7 @@ impl Resolution {
             | Self::Field { uri, def_span, .. }
             | Self::TypeDef { uri, def_span, .. }
             | Self::Variant { uri, def_span, .. } => Some((uri.as_str(), *def_span)),
-            Self::ImportedItem {
-                importer_uri,
-                import_span,
-                ..
-            } => Some((importer_uri.as_str(), *import_span)),
-            Self::ModuleQualified { .. } | Self::Unknown { .. } => None,
+            Self::ImportedItem { .. } | Self::ModuleQualified { .. } | Self::Unknown { .. } => None,
         }
     }
 }

--- a/hew-lsp/src/server/mod.rs
+++ b/hew-lsp/src/server/mod.rs
@@ -4303,6 +4303,79 @@ machine Traffic {
     }
 
     #[test]
+    fn goto_definition_handler_named_import_usage_jumps_to_imported_file_not_import_line() {
+        // Regression test for the bug this helper-level test above cannot catch:
+        // `cross_file_goto_named_import_resolves_to_open_document` calls
+        // `find_cross_file_definition` directly, bypassing the actual
+        // `goto_definition` LSP handler entirely. The handler used to return
+        // any `Resolution::def_location()` immediately -- and
+        // `Resolution::ImportedItem::def_location()` used to point at the
+        // *import statement*, not the real definition -- so this path was
+        // never exercised end-to-end and the regression shipped silently.
+        //
+        // Cursor sits on a *usage* of `Counter` inside `main()`, not on the
+        // import line, so this only passes if `goto_definition` actually
+        // chases the import across files instead of stopping at the import
+        // span.
+        let main_source =
+            "import counter::{ Counter };\nfn main() -> Counter { Counter { value: 1 } }";
+        let counter_source = "type Counter { value: i32 }";
+
+        let main_uri = make_test_uri("/project/main.hew");
+        let counter_uri = make_test_uri("/project/counter.hew");
+
+        // Build a real `HewLanguageServer` via `tower_lsp::LspService::new`,
+        // the same construction path production code uses (`main.rs`). This
+        // is the harness-free route the original bug report noted was
+        // missing: `Client` has no public constructor of its own, but
+        // `LspService::new(init)` hands a real one to `init` and `.inner()`
+        // gives back the constructed server for direct, non-async calls into
+        // the handler.
+        let (service, _socket) = tower_lsp::LspService::new(|client| {
+            HewLanguageServer::new_with_options(client, Vec::new())
+        });
+        let server = service.inner();
+        server
+            .documents
+            .insert(main_uri.clone(), make_doc(main_source));
+        server
+            .documents
+            .insert(counter_uri.clone(), make_doc(counter_source));
+
+        // Cursor on the *usage* `Counter` in the return type, not the import.
+        let usage_offset = main_source.rfind("-> Counter").unwrap() + "-> ".len();
+        let doc = server.documents.get(&main_uri).unwrap();
+        let position =
+            offset_range_to_lsp(main_source, &doc.line_offsets, usage_offset, usage_offset).start;
+        drop(doc);
+
+        let params = GotoDefinitionParams {
+            text_document_position_params: tower_lsp::lsp_types::TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: main_uri.clone(),
+                },
+                position,
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+
+        let response = handlers::navigation::goto_definition(server, &params)
+            .expect("goto_definition should resolve the imported Counter usage");
+        let GotoDefinitionResponse::Scalar(location) = response else {
+            panic!("expected a scalar goto-definition response, got {response:?}");
+        };
+
+        assert_eq!(
+            location.uri, counter_uri,
+            "goto-definition on a named-import usage must jump to the imported \
+             file's real definition, not stay on the import statement in the \
+             importing file (got uri={}, range={:?})",
+            location.uri, location.range
+        );
+    }
+
+    #[test]
     fn cross_file_goto_aliased_import_resolves_by_alias() {
         // `import counter::{ Counter as Cnt }` — cursor on `Cnt` in usage.
         let main_source = "import counter::{ Counter as Cnt };\nfn main() {}";


### PR DESCRIPTION
Fixes #1221.

## Bug

`Resolution::ImportedItem::def_location()` returned `(importer_uri, import_span)` — the import statement's own span in the importing file, not the imported item's real definition. The `goto_definition` LSP handler ([`hew-lsp/src/server/handlers/navigation.rs`](https://github.com/hew-lang/hew/blob/main/hew-lsp/src/server/handlers/navigation.rs)) consumes any `def_location()` immediately, before it ever reaches the existing `find_cross_file_definition` fallback that actually chases an import across files.

Net effect: goto-definition on a named-import usage (e.g. cursor on `Counter` in `fn main() -> Counter`) jumped to the `import counter::{ Counter };` line instead of `Counter`'s real declaration in `counter.hew`.

## Fix

`ImportedItem` now returns `None` from `def_location()`, matching `ModuleQualified`/`Unknown`'s existing "no location I can vouch for, caller do your own cross-file work" contract. `resolve_symbol_at_raw` only ever sees the current file's source/parse result, so it has no way to compute the imported item's real URI/span itself — returning a wrong-but-present span is worse than returning none, since "present" silently short-circuits the handler's fallback. Callers that specifically want the raw import span (there are none today) can still match on `Resolution::ImportedItem` directly instead of going through `def_location()`.

## Test-coverage gap

Also closes the gap already flagged on this issue: the only existing regression test for this scenario, `cross_file_goto_named_import_resolves_to_open_document`, calls `find_cross_file_definition` directly and never goes through `goto_definition`/`resolve_symbol_at_raw` at all — it proves the cross-file helper works in isolation but can't and didn't catch this handler-level regression.

`hew-lsp` has no `Client`-free server harness (`tower_lsp::Client::new` is `pub(super)`, unreachable outside the `tower_lsp` crate itself), but `tower_lsp::LspService::new(init)` hands a real `Client` to `init` and `.inner()` returns the constructed server afterward — enough to call `goto_definition` directly without a running transport/socket. Added `goto_definition_handler_named_import_usage_jumps_to_imported_file_not_import_line` using that construction path (cursor on a *usage* of the imported name, not the import line itself, so it only passes if the handler genuinely chases the import).

Verified the new test actually catches the regression: temporarily reverted the `def_location()` change and confirmed the test fails with the exact old symptom (jumps to `main.hew` line 0, the import line, instead of `counter.hew`).

## Verification

- `cargo test -p hew-analysis --lib` — 249/249
- `cargo test -p hew-lsp --lib` — 277/277 (+1 new test; 2 pre-existing unrelated ignores)
- `cargo fmt -p hew-analysis -p hew-lsp --check` — clean
- `cargo clippy -p hew-analysis -p hew-lsp --lib --tests -- -D warnings` — clean
- `tests/vertical-slice/run.sh` — exits 0