### PR TITLE
fix(cli): suppress eval banner when stdin is piped

### DIFF
--- a/hew-cli/src/eval/repl.rs
+++ b/hew-cli/src/eval/repl.rs
@@ -1600,9 +1600,9 @@ fn run_wasm_eval_compiled(
 
 /// Run the interactive REPL with a custom execution timeout.
 ///
-/// The startup banner and help line are printed only when stdout is an
-/// interactive terminal and `quiet` is `false`; piped/redirected stdout or
-/// an explicit `quiet` suppresses them.
+/// The startup banner and help line are printed only when both stdin and stdout
+/// are interactive terminals and `quiet` is `false`; piped/redirected stdin or
+/// stdout, or an explicit `quiet`, suppresses them.
 ///
 /// # Errors
 ///
@@ -1619,7 +1619,7 @@ pub fn run_interactive(
     let mut session = ReplSession::with_timeout_and_target(timeout, target);
     session.set_jit_mode(jit);
 
-    if !quiet && std::io::stdout().is_terminal() {
+    if !quiet && std::io::stdin().is_terminal() && std::io::stdout().is_terminal() {
         println!("Hew REPL v{}", env!("CARGO_PKG_VERSION"));
         println!("Type :help for commands, :items to list definitions, :quit to exit.\n");
     }

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -6,6 +6,9 @@ use std::process::{Command, Output, Stdio};
 use std::sync::mpsc::{self, RecvTimeoutError};
 use std::time::{Duration, Instant};
 
+#[cfg(unix)]
+use std::{fs::File, io::ErrorKind, os::fd::FromRawFd, thread};
+
 use support::{hew_binary, repo_root, require_codegen, strip_ansi};
 
 fn run_eval_with_stdin_in_dir(args: &[&str], input: &str, cwd: &Path) -> Output {
@@ -28,6 +31,80 @@ fn run_eval_with_stdin_in_dir(args: &[&str], input: &str, cwd: &Path) -> Output 
 
 fn run_eval_with_stdin(args: &[&str], input: &str) -> Output {
     run_eval_with_stdin_in_dir(args, input, repo_root())
+}
+
+#[cfg(unix)]
+fn run_eval_with_piped_stdin_and_pty_stdout(args: &[&str], input: &str) -> Output {
+    let mut master = -1;
+    let mut slave = -1;
+    // SAFETY: `openpty` initializes the two out-parameters on success. The
+    // optional name/termios/winsize pointers are null because the test only
+    // needs a default pseudo-terminal pair.
+    let rc = unsafe {
+        libc::openpty(
+            &raw mut master,
+            &raw mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            std::ptr::null(),
+        )
+    };
+    assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());
+
+    // SAFETY: `openpty` returned owned file descriptors above. Each descriptor
+    // is wrapped exactly once so it is closed by the owning `File`/`Stdio`.
+    let master_file = unsafe { File::from_raw_fd(master) };
+    // SAFETY: see the `master_file` safety note; this wraps the slave fd once.
+    let slave_file = unsafe { File::from_raw_fd(slave) };
+
+    let reader = thread::spawn(move || {
+        let mut file = master_file;
+        let mut stdout = Vec::new();
+        let mut buf = [0; 4096];
+        loop {
+            match file.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => stdout.extend_from_slice(&buf[..n]),
+                // Linux returns EIO when the slave side of a pty closes; treat
+                // it as EOF so the test stays portable across pty semantics.
+                Err(error) if error.kind() == ErrorKind::UnexpectedEof => break,
+                Err(error) if error.raw_os_error() == Some(libc::EIO) => break,
+                Err(error) => panic!("failed to read pty stdout: {error}"),
+            }
+        }
+        stdout
+    });
+
+    let mut child = Command::new(hew_binary())
+        .args(args)
+        .current_dir(repo_root())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::from(slave_file))
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    {
+        let mut stdin = child.stdin.take().expect("stdin should be piped");
+        stdin.write_all(input.as_bytes()).unwrap();
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        if child.try_wait().unwrap().is_some() {
+            break;
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("hew eval did not exit after receiving piped REPL input");
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+
+    let mut output = child.wait_with_output().unwrap();
+    output.stdout = reader.join().expect("pty stdout reader should not panic");
+    output
 }
 
 fn assert_no_monomorphic_overload_error(stderr: &str) {
@@ -628,6 +705,29 @@ fn statement_replay_repl_does_not_repeat_one_shot_statement() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert_eq!(stdout.matches("once\n").count(), 1, "stdout: {stdout}");
     assert!(stdout.contains("2\n"), "stdout: {stdout}");
+}
+
+#[cfg(unix)]
+#[test]
+fn repl_suppresses_startup_banner_when_only_stdout_is_a_terminal() {
+    let output = run_eval_with_piped_stdin_and_pty_stdout(&["eval"], ":quit\n");
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Hew REPL v"),
+        "piped stdin must suppress the startup banner even when stdout is a terminal; stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Type :help for commands"),
+        "piped stdin must suppress the startup help even when stdout is a terminal; stdout: {stdout}"
+    );
 }
 
 #[test]

--- a/hew-cli/tests/eval_e2e.rs
+++ b/hew-cli/tests/eval_e2e.rs
@@ -45,8 +45,8 @@ fn run_eval_with_piped_stdin_and_pty_stdout(args: &[&str], input: &str) -> Outpu
             &raw mut master,
             &raw mut slave,
             std::ptr::null_mut(),
-            std::ptr::null(),
-            std::ptr::null(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
         )
     };
     assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());


### PR DESCRIPTION
## Summary

Fixes the remaining `hew eval` startup-chrome gap from PR #2396: when stdin is piped but stdout is a terminal, the REPL should treat the invocation as scripted/non-interactive and avoid printing the startup banner/help unless the user has a real terminal on both sides.

## Changes

- Require both `stdin().is_terminal()` and `stdout().is_terminal()` before printing the REPL banner/help.
- Add a Unix pty-backed regression test that gives `hew eval` piped stdin and terminal stdout, then asserts the banner/help stay suppressed.

## Verification

- `cargo fmt -p hew-cli --check`
- `cargo test -p hew-cli --test eval_e2e repl_suppresses_startup_banner_when_only_stdout_is_a_terminal -- --exact`
- Load-bearing check: temporarily reverted the production guard to stdout-only and confirmed the new test fails with the old banner output; restored the fix afterward.
- `cargo clippy -p hew-cli --test eval_e2e -- -D warnings`
- `cargo test -p hew-cli --test eval_e2e -- --skip eval_wasm` — 96 passed

Note: the full `cargo test -p hew-cli --test eval_e2e` run in this local environment fails only on the existing WASM eval tests because `wasmtime` is not installed (`failed to bootstrap WASI runner prerequisites: wasmtime not found`). The non-WASM eval suite, including the new regression, passes.
