### PR TITLE
fix(check): enforce record name in let-destructuring patterns

### DIFF
--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -708,6 +708,36 @@ impl Checker {
                                                 TypeDefKind::Record | TypeDefKind::Struct
                                             ) =>
                                         {
+                                            // The pattern's written constructor name must
+                                            // resolve to the SAME product type as the RHS.
+                                            // `let Other { x } = Point { .. }` must NOT be
+                                            // admitted as an irrefutable destructure just
+                                            // because `Other` and `Point` share a field
+                                            // shape — the written `Other` constructor would
+                                            // otherwise never be enforced (see PR #2003).
+                                            let pat_td = self.lookup_type_def(pat_name);
+                                            let matches_rhs = pat_td
+                                                .as_ref()
+                                                .is_some_and(|pt| pt.name == td.name);
+                                            if !matches_rhs {
+                                                // Report a mismatch and still return `None`
+                                                // (no *additional* refutable-let error): the
+                                                // reported error already fails compilation, and
+                                                // bind_pattern runs below for error recovery.
+                                                self.report_error(
+                                                    TypeErrorKind::Mismatch {
+                                                        expected: pat_name.clone(),
+                                                        actual: td.name.clone(),
+                                                    },
+                                                    &pattern.1,
+                                                    format!(
+                                                        "let-destructuring pattern names \
+                                                         type `{pat_name}`, but the value \
+                                                         has type `{}`",
+                                                        td.name
+                                                    ),
+                                                );
+                                            }
                                             None
                                         } // irrefutable product type
                                         Some(_) => Some("enum variant"),

--- a/tests/vertical-slice/reject/let_destructure_wrong_record_name.hew
+++ b/tests/vertical-slice/reject/let_destructure_wrong_record_name.hew
@@ -1,0 +1,13 @@
+// Validation (PR #2003): a record let-destructuring pattern whose written type
+// name (`Other`) differs from the RHS product type (`Point`) must be rejected,
+// even when the two records share an identical field shape. Before the fix the
+// checker admitted this as an irrefutable destructure and silently lowered the
+// projection as `Point.x`, so the written `Other` constructor was never
+// enforced. Exactly one spanned error must fire, naming both types.
+type Point { x: i64; }
+type Other { x: i64; }
+
+fn main() -> i64 {
+    let Other { x } = Point { x: 41 };
+    return x;
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -4085,6 +4085,20 @@ if grep -q 'has no binding' "${reject_output}"; then
   exit 1
 fi
 
+# Reject (PR #2003): a record let-destructuring pattern that names a different
+# product type than the RHS (`let Other { x } = Point { .. }`) must emit exactly
+# one spanned error naming both types, even when the two records share a field
+# shape. Guards against silently lowering the projection as the RHS type and
+# never enforcing the written constructor.
+expect_check_fail_error_count \
+    "${ROOT}/tests/vertical-slice/reject/let_destructure_wrong_record_name.hew" \
+    1 \
+    "let_destructure_wrong_record_name"
+expect_check_fail_contains \
+    "${ROOT}/tests/vertical-slice/reject/let_destructure_wrong_record_name.hew" \
+    "Other" \
+    "let_destructure_wrong_record_name_message"
+
 # Reject: a `let … else` whose else block does not diverge. The non-diverging
 # else (`{ 0 }`) trips the new E_LET_ELSE_DOES_NOT_DIVERGE diagnostic.
 expect_check_fail_error_count \


### PR DESCRIPTION
## Problem

The irrefutable-`let` admission gate in `hew-types/src/check/statements.rs` accepted any `Pattern::Struct` whose RHS resolved to a product type (`Record`/`Struct`) **without comparing the pattern's written constructor name to the RHS type**. So with two records sharing a field shape:

```hew
type Point { x: i64; }
type Other { x: i64; }

fn main() -> i64 {
  let Other { x } = Point { x: 41 };  // accepted; runs, returns 41
  return x;
}
```

`hew check` printed OK and HIR lowering silently projected the field as `Point.x` — the written `Other` constructor was never enforced. (Flagged against PR #2003.)

## Fix

Before treating a `Pattern::Struct` as an irrefutable product destructure, resolve the pattern's written type name to its `TypeDef` and require it to be the same product type as the RHS (compared on resolved `td.name`, so module-qualified / aliased names still match). On mismatch, report a single spanned `Mismatch` error. `bind_pattern` still runs afterward for error recovery, so no secondary cascade fires.

## Verification

- New reject fixture `let_destructure_wrong_record_name` asserts exactly one spanned error naming both types.
- Repro now fails with a single clean error; matching `Point { x } = Point { .. }`, `record`-keyword form, and nested destructures still pass.
- `cargo test -p hew-types --lib` 1631/1631; `cargo fmt -p hew-types --check` clean; `cargo clippy -p hew-types --lib --tests -- -D warnings` clean; full `tests/vertical-slice/run.sh` exits 0.