### PR TITLE
test(runtime): poll last_seen_ms, not just coarse state, in the driven-SWIM false-DEAD test

### DIFF
--- a/hew-runtime/src/cluster.rs
+++ b/hew-runtime/src/cluster.rs
@@ -2360,6 +2360,25 @@ impl HewCluster {
             .map(|m| m.incarnation)
     }
 
+    /// The raw `last_seen_ms` timestamp the membership table currently records
+    /// for `node_id`, or `None` if the node is unknown. Unlike the coarse
+    /// `MEMBER_*` state (which only flips SUSPECT->ALIVE and is otherwise
+    /// unchanged while already ALIVE), this value is refreshed on every
+    /// PING-ACK round-trip, so polling for a *new* value distinct from a
+    /// previously-observed one detects a fresh round-trip even when state
+    /// stays steady-state ALIVE across multiple observation periods. Used by
+    /// the driven-SWIM false-DEAD regression test to confirm each simulated
+    /// period actually waits for its own round-trip rather than re-observing
+    /// stale ALIVE state left over from an earlier period.
+    #[cfg(test)]
+    pub(crate) fn member_last_seen_ms(&self, node_id: u16) -> Option<u64> {
+        let members = self.members.lock_or_recover();
+        members
+            .iter()
+            .find(|m| m.node_id == node_id)
+            .map(|m| m.last_seen_ms)
+    }
+
     /// The membership state recorded for `node_id` (a `MEMBER_*` constant), or
     /// `-1` if the node is unknown. Used by the rejoin test-introspection probe.
     pub(crate) fn member_state(&self, node_id: u16) -> i32 {

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -10199,6 +10199,29 @@ mod tests {
         // SAFETY: both nodes are valid here.
         unsafe { wait_for_handshake(node_a.as_ptr(), node_b.as_ptr()) };
 
+        // Baseline last_seen_ms readings from immediately after the handshake,
+        // before any simulated period has been advanced. Each period below
+        // must observe last_seen_ms strictly *newer* than the value recorded
+        // at the end of the previous period. Polling the coarse MEMBER_ALIVE
+        // state alone is not sufficient here: update_last_seen only flips
+        // SUSPECT -> ALIVE and otherwise leaves an already-ALIVE state
+        // unchanged, so once both peers reach ALIVE on period 0, a state-only
+        // poll is trivially already satisfied at the very first check of every
+        // subsequent period -- it would break immediately without ever
+        // observing that period's own PING-ACK round-trip actually landed.
+        // last_seen_ms is refreshed on every round-trip regardless of state,
+        // so requiring a fresh value each period genuinely confirms each tick
+        // re-synchronized rather than re-observing stale state from an earlier
+        // period.
+        // SAFETY: node_a's cluster is live (node still running).
+        let mut prev_a_view_of_b = unsafe { &*(*node_a.as_ptr()).cluster }
+            .member_last_seen_ms(NODE_B)
+            .unwrap_or(0);
+        // SAFETY: node_b's cluster is live (node still running).
+        let mut prev_b_view_of_a = unsafe { &*(*node_b.as_ptr()).cluster }
+            .member_last_seen_ms(NODE_A)
+            .unwrap_or(0);
+
         // Step sim time forward one protocol period at a time. After each
         // advance the driver fires a tick (its next_period_ms has been crossed)
         // and sends a PING; the peer's ACK lets the connection-reader refresh
@@ -10216,44 +10239,59 @@ mod tests {
             // frozen during this real wait, so no new staleness accrues; a
             // landing ACK revives a transient SUSPECT straight back to ALIVE
             // (cluster::update_last_seen), and the SUSPECT -> DEAD step cannot
-            // fire without another sim advance. We proceed as soon as both views
-            // are ALIVE — waiting for the actual round-trip instead of betting a
-            // fixed sleep against loopback/VM latency, so a loaded CI host can't
-            // stale last_seen into a false DEAD. The "never DEAD" invariant is
+            // fire without another sim advance. We proceed only once both
+            // peers report a last_seen_ms strictly newer than the value
+            // recorded at the end of the previous period — confirming this
+            // period's own round-trip actually landed, not just that state is
+            // still ALIVE from an earlier one. The "never DEAD" invariant is
             // still enforced strictly on every poll.
             let alive_deadline =
                 std::time::Instant::now() + Duration::from_millis(SWIM_ALIVE_DEADLINE_MS);
-            loop {
+            let (a_view_of_b, b_view_of_a) = loop {
                 // SAFETY: A's cluster is live (node still running).
-                let a_view_of_b =
+                let a_state =
                     unsafe { hew_cluster_member_state((*node_a.as_ptr()).cluster, NODE_B) };
                 // SAFETY: B's cluster is live (node still running).
-                let b_view_of_a =
+                let b_state =
                     unsafe { hew_cluster_member_state((*node_b.as_ptr()).cluster, NODE_A) };
                 assert_ne!(
-                    a_view_of_b,
+                    a_state,
                     crate::cluster::MEMBER_DEAD,
                     "A must not declare a still-alive B as DEAD after period \
-                     (state={a_view_of_b})"
+                     (state={a_state})"
                 );
                 assert_ne!(
-                    b_view_of_a,
+                    b_state,
                     crate::cluster::MEMBER_DEAD,
                     "B must not declare a still-alive A as DEAD after period \
-                     (state={b_view_of_a})"
+                     (state={b_state})"
                 );
-                if a_view_of_b == crate::cluster::MEMBER_ALIVE
-                    && b_view_of_a == crate::cluster::MEMBER_ALIVE
+                // SAFETY: A's cluster is live (node still running).
+                let a_last_seen = unsafe { &*(*node_a.as_ptr()).cluster }
+                    .member_last_seen_ms(NODE_B)
+                    .unwrap_or(0);
+                // SAFETY: B's cluster is live (node still running).
+                let b_last_seen = unsafe { &*(*node_b.as_ptr()).cluster }
+                    .member_last_seen_ms(NODE_A)
+                    .unwrap_or(0);
+                if a_state == crate::cluster::MEMBER_ALIVE
+                    && b_state == crate::cluster::MEMBER_ALIVE
+                    && a_last_seen > prev_a_view_of_b
+                    && b_last_seen > prev_b_view_of_a
                 {
-                    break;
+                    break (a_last_seen, b_last_seen);
                 }
                 assert!(
                     std::time::Instant::now() < alive_deadline,
                     "PING-ACK round-trip did not refresh last_seen within the \
-                     deadline (a_view_of_b={a_view_of_b}, b_view_of_a={b_view_of_a})"
+                     deadline (a_state={a_state}, b_state={b_state}, \
+                     a_last_seen={a_last_seen}, prev_a_view_of_b={prev_a_view_of_b}, \
+                     b_last_seen={b_last_seen}, prev_b_view_of_a={prev_b_view_of_a})"
                 );
                 thread::sleep(Duration::from_millis(SWIM_ALIVE_POLL_MS));
-            }
+            };
+            prev_a_view_of_b = a_view_of_b;
+            prev_b_view_of_a = b_view_of_a;
         }
 
         // SAFETY: nodes were allocated in this test and remain valid.


### PR DESCRIPTION
Fixes a test-quality gap in `alive_node_is_not_falsely_killed_by_driven_swim`, introduced by #1961.

## Bug

The test's per-period wait loop breaks as soon as both peers' `MEMBER_*` state reads `ALIVE`. `update_last_seen` only flips `SUSPECT -> ALIVE` and otherwise leaves an already-`ALIVE` state unchanged, so once both peers settle `ALIVE` on the first observation period, the state-only poll is trivially satisfied at the very first check of every subsequent period — it can and does break before that period's own PING-ACK round-trip has actually landed.

Confirmed empirically with temporary instrumentation (since reverted, not part of this diff): period 0 breaks after a genuine ~2ms poll cycle, but periods 1–4 (of the 5 `OBSERVATION_PERIODS` the test's own comment says exercise the suspect-timeout window) break after 0µs every single run — the very first state check, before any real wait. So 80% of this test's claimed period-by-period coverage was re-observing stale `ALIVE` state, not confirming a fresh round trip; a real regression that stalled PING-ACK processing (lock contention, a connection-reader stall, the exact loaded-host race this test exists to catch) would only be caught if it happened to manifest during period 0 specifically.

## Fix

Add `HewCluster::member_last_seen_ms` (`#[cfg(test)]`, mirroring the existing `member_incarnation`/`member_state` test-introspection pattern) and require each period's poll to observe a `last_seen_ms` strictly newer than the value recorded at the end of the previous period, not just `MEMBER_ALIVE` state. `last_seen_ms` is refreshed on every round-trip regardless of state, so this discriminates a genuinely fresh round trip from stale state.

Since simulated time is enabled for this test, `last_seen_ms` is the sim clock (`hew_now_ms()` returns `simtime_now()` when set), so this is not a wall-clock/precision race — re-verified via the same instrumentation that `last_seen_ms` cleanly advances by exactly one `SWIM_TEST_PERIOD_MS` (40) on every one of the 5 periods:

```
DIAG period-break: a_last_seen=40  prev_a=0   b_last_seen=40  prev_b=0
DIAG period-break: a_last_seen=80  prev_a=40  b_last_seen=80  prev_b=40
DIAG period-break: a_last_seen=120 prev_a=80  b_last_seen=120 prev_b=80
DIAG period-break: a_last_seen=160 prev_a=120 b_last_seen=160 prev_b=120
DIAG period-break: a_last_seen=200 prev_a=160 b_last_seen=200 prev_b=160
```

## Verification

- `cargo test -p hew-runtime --lib` — 2019/2019 (matches existing baseline)
- `cargo fmt -p hew-runtime --check` — clean
- `cargo clippy -p hew-runtime --lib --tests -- -D warnings` — clean
- `tests/vertical-slice/run.sh` — exits 0 (427/427)

Signed commit `55e3d2d2c` confirmed GitHub-verified (`reason: valid`).