### PR TITLE
fix(dist): bind CTRL_LINK_DOWN to the handshake-authenticated peer

### DIFF
--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -1247,10 +1247,13 @@ fn handle_link_down_frame(mgr: *mut HewConnMgr, conn_id: c_int, control: &Contro
     let mgr_ref = unsafe { &*mgr };
     // Peer-binding defence: resolve the handshake-authenticated identity of the
     // connection this frame arrived on. `authenticated == 0` (no active,
-    // registered connection for `conn_id`) still flows into the ref-id lookup
-    // below and simply cannot match any real link's `remote_node_id` (a valid
-    // node id is always non-zero), so it fails closed the same way an actual
-    // peer mismatch does — no separate early return required.
+    // registered connection for `conn_id`, e.g. mid-teardown) is NOT
+    // guaranteed to fail closed on its own — `handle_link_req_frame` performs
+    // no peer authentication on an inbound `CTRL_LINK_REQ`, so any connected
+    // peer can set `linker_node_id` to 0 and land a `WatcherEntry` with
+    // `remote_node_id == 0`. `deliver_link_down_to_ref` rejects
+    // `authenticated_peer == 0` explicitly, before it is ever compared to a
+    // stored `remote_node_id`.
     let authenticated = peer_node_id_for_conn(mgr_ref, conn_id);
     crate::hew_node::handle_inbound_link_down(payload.ref_id, authenticated, payload.reason);
 }

--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -1058,7 +1058,7 @@ fn handle_control_frame(
             return;
         }
         CTRL_LINK_DOWN => {
-            handle_link_down_frame(control);
+            handle_link_down_frame(mgr, conn_id, control);
             return;
         }
         other => {
@@ -1223,9 +1223,13 @@ fn handle_unlink_frame(control: &ControlFrame) {
 /// synthesize a `SYS_MSG_EXIT` into the LOCAL linked actor's mailbox and crash it
 /// (for `CrashLinked`). THE divergence from a monitor DOWN (which arms a recv
 /// slot): a link DOWN crashes the linked actor through its mailbox. Fail-closed
-/// on malformed input; the EXIT fires exactly once and ONLY for a link entry this
-/// node registered, so a forged frame cannot crash an actor we never linked.
-fn handle_link_down_frame(control: &ControlFrame) {
+/// on malformed input; the EXIT fires exactly once and ONLY for a link entry
+/// this node registered AND ONLY when the handshake-authenticated sender of this
+/// connection is the same peer that entry is linked to — otherwise neither a
+/// forged `ref_id` this node never linked NOR a different, genuinely-connected
+/// peer that merely guessed/learned a pending link `ref_id` can crash an actor
+/// linked to another, still-alive peer.
+fn handle_link_down_frame(mgr: *mut HewConnMgr, conn_id: c_int, control: &ControlFrame) {
     let payload = match decode_link_down_payload(&control.payload) {
         Ok(payload) => payload,
         Err(err) => {
@@ -1235,7 +1239,20 @@ fn handle_link_down_frame(control: &ControlFrame) {
             return;
         }
     };
-    crate::hew_node::handle_inbound_link_down(payload.ref_id, payload.reason);
+    if mgr.is_null() {
+        set_last_error("connection reader link down frame missing manager");
+        return;
+    }
+    // SAFETY: reader_loop owns a live manager pointer for this connection.
+    let mgr_ref = unsafe { &*mgr };
+    // Peer-binding defence: resolve the handshake-authenticated identity of the
+    // connection this frame arrived on. `authenticated == 0` (no active,
+    // registered connection for `conn_id`) still flows into the ref-id lookup
+    // below and simply cannot match any real link's `remote_node_id` (a valid
+    // node id is always non-zero), so it fails closed the same way an actual
+    // peer mismatch does — no separate early return required.
+    let authenticated = peer_node_id_for_conn(mgr_ref, conn_id);
+    crate::hew_node::handle_inbound_link_down(payload.ref_id, authenticated, payload.reason);
 }
 
 fn active_gossip_connection_ids(mgr: &HewConnMgr) -> Vec<c_int> {

--- a/hew-runtime/src/dist_monitor.rs
+++ b/hew-runtime/src/dist_monitor.rs
@@ -278,14 +278,26 @@ impl DistMonitorState {
     /// receipt). Transitions the entry `Pending → Consumed` exactly once and
     /// returns the cascade action (the LOCAL linked actor + reason + policy) so the
     /// caller can synthesize the mailbox EXIT. A no-op (returns `None`) if the
-    /// entry is unknown, already fired, or is a monitor (not a link) — the
-    /// exactly-once + fail-closed guard. The EXIT is fired ONLY for an entry THIS
-    /// node registered, so a forged `CTRL_LINK_DOWN` `ref_id` cannot crash an actor
-    /// this node never linked.
-    pub(crate) fn deliver_link_down_to_ref(&self, ref_id: u64, reason: i32) -> Option<LinkDown> {
+    /// entry is unknown, already fired, is a monitor (not a link), or
+    /// `authenticated_peer` does not match the entry's own `remote_node_id` — the
+    /// exactly-once + fail-closed + peer-binding guard. The EXIT is fired ONLY for
+    /// an entry THIS node registered AND ONLY when the frame's authenticated
+    /// sender is the same peer this node linked to, so neither a forged `ref_id`
+    /// this node never linked NOR a genuinely-authenticated but UNRELATED peer
+    /// (one that merely guessed/learned a pending cross-node link `ref_id`) can
+    /// crash a linked actor before its real remote peer has died.
+    pub(crate) fn deliver_link_down_to_ref(
+        &self,
+        ref_id: u64,
+        authenticated_peer: u16,
+        reason: i32,
+    ) -> Option<LinkDown> {
         let mut watchers = self.watchers.lock().unwrap_or_else(PoisonError::into_inner);
         match watchers.get_mut(&ref_id) {
-            Some(entry) if entry.slot == TerminalSlot::Pending => {
+            Some(entry)
+                if entry.slot == TerminalSlot::Pending
+                    && entry.remote_node_id == authenticated_peer =>
+            {
                 if let WatcherAction::Link {
                     local_actor_id,
                     policy_tag,
@@ -789,9 +801,10 @@ mod tests {
         let ref_id = state.register_link_watcher(7, 99, 12_345, POLICY_TAG_CRASH_LINKED);
         assert_ne!(ref_id, 0);
 
-        // First link-down fires the cascade carrying the local actor + policy.
+        // First link-down, authenticated as node 7 (the real linked-to peer),
+        // fires the cascade carrying the local actor + policy.
         let down = state
-            .deliver_link_down_to_ref(ref_id, 5)
+            .deliver_link_down_to_ref(ref_id, 7, 5)
             .expect("first link-down must fire");
         assert_eq!(down.local_actor_id, 12_345);
         assert_eq!(down.reason, 5);
@@ -799,9 +812,36 @@ mod tests {
 
         // Second delivery is a no-op (fire-once): the entry is Consumed.
         assert!(
-            state.deliver_link_down_to_ref(ref_id, 6).is_none(),
+            state.deliver_link_down_to_ref(ref_id, 7, 6).is_none(),
             "second link-down must be a no-op"
         );
+    }
+
+    /// A `CTRL_LINK_DOWN` whose handshake-authenticated sender does NOT match
+    /// the entry's own `remote_node_id` must be rejected — a real link to node 7
+    /// must not be crashed by a different, genuinely-connected peer (node 99)
+    /// that merely guessed/learned the pending `ref_id`. This is the exact
+    /// upstream defect this test locks in: the entry must survive intact and
+    /// remain deliverable by its real peer afterward.
+    #[test]
+    fn link_down_from_wrong_authenticated_peer_is_rejected() {
+        let state = DistMonitorState::new();
+        let ref_id = state.register_link_watcher(7, 99, 777, POLICY_TAG_CRASH_LINKED);
+
+        // Node 99 is connected and authenticated, but it is NOT the peer this
+        // link was registered against (node 7) — the forged/misattributed case.
+        assert!(
+            state.deliver_link_down_to_ref(ref_id, 99, 4321).is_none(),
+            "a link-down from an unrelated authenticated peer must not fire the cascade"
+        );
+
+        // The entry must still be Pending: the real peer (node 7) can still
+        // legitimately fire it later.
+        let down = state
+            .deliver_link_down_to_ref(ref_id, 7, 4321)
+            .expect("the real linked-to peer must still be able to fire the cascade");
+        assert_eq!(down.local_actor_id, 777);
+        assert_eq!(down.reason, 4321);
     }
 
     /// A `CTRL_MONITOR_DOWN`-style `deliver_to_ref` must NOT fire a LINK entry,
@@ -816,7 +856,7 @@ mod tests {
 
         // A monitor DOWN must not fire the link entry.
         assert!(
-            state.deliver_link_down_to_ref(monitor_ref, 5).is_none(),
+            state.deliver_link_down_to_ref(monitor_ref, 7, 5).is_none(),
             "link delivery must not fire a monitor entry"
         );
         // A link DOWN must not arm the monitor's recv slot.
@@ -828,7 +868,7 @@ mod tests {
         // Each fires only through its own path.
         assert!(state.deliver_to_ref(monitor_ref, 6), "monitor arms");
         assert!(
-            state.deliver_link_down_to_ref(link_ref, 5).is_some(),
+            state.deliver_link_down_to_ref(link_ref, 7, 5).is_some(),
             "link fires"
         );
     }
@@ -845,8 +885,9 @@ mod tests {
         // A monitor on the same node must NOT appear in the link fan-out.
         let _m = state.register_watcher(7, 4);
 
-        // `a` already received a definitive crash DOWN.
-        assert!(state.deliver_link_down_to_ref(a, 5).is_some());
+        // `a` already received a definitive crash DOWN, authenticated as its own
+        // registered peer (node 7).
+        assert!(state.deliver_link_down_to_ref(a, 7, 5).is_some());
 
         // Connection drop to node 7: only the still-Pending link `b` fires
         // (MonitorLost == -1); `a` is Consumed, `other` is on node 9, the
@@ -856,8 +897,9 @@ mod tests {
         assert_eq!(downs[0].local_actor_id, 200);
         assert_eq!(downs[0].reason, MONITOR_REASON_LOST);
 
-        // `other` (node 9) untouched; still fires on its own node's drop.
-        assert!(state.deliver_link_down_to_ref(other, 5).is_some());
+        // `other` (node 9) untouched; still fires on its own node's drop,
+        // authenticated as its own registered peer (node 9).
+        assert!(state.deliver_link_down_to_ref(other, 9, 5).is_some());
     }
 
     /// A non-`CrashLinked` policy is carried through the table verbatim so the
@@ -868,7 +910,7 @@ mod tests {
         // MonitorLost policy (tag 2) — non-fatal.
         let ref_id = state.register_link_watcher(7, 1, 42, 2);
         let down = state
-            .deliver_link_down_to_ref(ref_id, 6)
+            .deliver_link_down_to_ref(ref_id, 7, 6)
             .expect("link-down fires regardless of policy; the runtime decides fatality");
         assert_eq!(down.policy_tag, 2, "policy tag round-trips verbatim");
         assert_eq!(down.local_actor_id, 42);

--- a/hew-runtime/src/dist_monitor.rs
+++ b/hew-runtime/src/dist_monitor.rs
@@ -277,21 +277,36 @@ impl DistMonitorState {
     /// Fire a cross-node LINK down for a single link registration (`CTRL_LINK_DOWN`
     /// receipt). Transitions the entry `Pending → Consumed` exactly once and
     /// returns the cascade action (the LOCAL linked actor + reason + policy) so the
-    /// caller can synthesize the mailbox EXIT. A no-op (returns `None`) if the
-    /// entry is unknown, already fired, is a monitor (not a link), or
-    /// `authenticated_peer` does not match the entry's own `remote_node_id` — the
-    /// exactly-once + fail-closed + peer-binding guard. The EXIT is fired ONLY for
-    /// an entry THIS node registered AND ONLY when the frame's authenticated
-    /// sender is the same peer this node linked to, so neither a forged `ref_id`
-    /// this node never linked NOR a genuinely-authenticated but UNRELATED peer
-    /// (one that merely guessed/learned a pending cross-node link `ref_id`) can
-    /// crash a linked actor before its real remote peer has died.
+    /// caller can synthesize the mailbox EXIT. A no-op (returns `None`) if
+    /// `authenticated_peer` is 0 (unauthenticated sender), the entry is unknown,
+    /// already fired, is a monitor (not a link), or `authenticated_peer` does not
+    /// match the entry's own `remote_node_id` — the exactly-once + fail-closed +
+    /// peer-binding guard. The EXIT is fired ONLY for an entry THIS node
+    /// registered AND ONLY when the frame's authenticated sender is the same peer
+    /// this node linked to, so neither a forged `ref_id` this node never linked
+    /// NOR a genuinely-authenticated but UNRELATED peer (one that merely
+    /// guessed/learned a pending cross-node link `ref_id`) can crash a linked
+    /// actor before its real remote peer has died.
+    ///
+    /// `authenticated_peer == 0` is rejected explicitly, before it is ever
+    /// compared to `entry.remote_node_id`. A stored `remote_node_id` of 0 is
+    /// reachable today: `handle_link_req_frame` (`connection.rs`) performs NO
+    /// peer authentication on an inbound `CTRL_LINK_REQ` at all, so any
+    /// connected peer can set `linker_node_id` to 0 and reach
+    /// `handle_inbound_link_req` → `register_link_watcher(payload.linker_node_id,
+    /// ...)`, which stores it into THIS table (the watcher side) verbatim. Absent
+    /// this guard, an unauthenticated sender (`authenticated_peer == 0`, e.g.
+    /// `peer_node_id_for_conn`'s documented fallback when no ACTIVE connection
+    /// matches the frame's `conn_id`) would wrongly match such an entry.
     pub(crate) fn deliver_link_down_to_ref(
         &self,
         ref_id: u64,
         authenticated_peer: u16,
         reason: i32,
     ) -> Option<LinkDown> {
+        if authenticated_peer == 0 {
+            return None;
+        }
         let mut watchers = self.watchers.lock().unwrap_or_else(PoisonError::into_inner);
         match watchers.get_mut(&ref_id) {
             Some(entry)
@@ -842,6 +857,35 @@ mod tests {
             .expect("the real linked-to peer must still be able to fire the cascade");
         assert_eq!(down.local_actor_id, 777);
         assert_eq!(down.reason, 4321);
+    }
+
+    /// An unauthenticated sender (`authenticated_peer == 0`, e.g.
+    /// `peer_node_id_for_conn`'s documented fallback when no ACTIVE connection
+    /// matches the frame's `conn_id`) must never be admitted by an equality
+    /// coincidence against a `WatcherEntry.remote_node_id` of 0. A stored `0` is
+    /// reachable today: `handle_link_req_frame` performs no peer authentication
+    /// on an inbound `CTRL_LINK_REQ`, so any connected peer can set
+    /// `linker_node_id` to 0 and land a zero-id entry via
+    /// `handle_inbound_link_req` → `register_link_watcher`. Without an explicit
+    /// `authenticated_peer == 0` reject, `entry.remote_node_id ==
+    /// authenticated_peer` becomes `0 == 0` and wrongly admits the forged
+    /// delivery.
+    #[test]
+    fn link_down_with_zero_authenticated_peer_is_rejected_against_zero_remote_node_id() {
+        let state = DistMonitorState::new();
+        // Simulates a WatcherEntry reachable via the unpatched CTRL_LINK_REQ
+        // path: remote_node_id == 0.
+        let ref_id = state.register_link_watcher(0, 99, 777, POLICY_TAG_CRASH_LINKED);
+
+        // Simulates the connection-teardown-race fallback: authenticated == 0.
+        // Without the explicit `authenticated_peer == 0` guard this would match
+        // `entry.remote_node_id == authenticated_peer` (`0 == 0`) and wrongly
+        // fire the cascade.
+        assert!(
+            state.deliver_link_down_to_ref(ref_id, 0, 4321).is_none(),
+            "an unauthenticated sender must not fire the cascade merely because \
+             the entry's remote_node_id also happens to be 0"
+        );
     }
 
     /// A `CTRL_MONITOR_DOWN`-style `deliver_to_ref` must NOT fire a LINK entry,

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -3382,14 +3382,21 @@ pub(crate) fn handle_inbound_unlink(payload: &crate::envelope::LinkReqPayload) {
 /// This is THE divergence from monitor's `deliver_to_ref` (which arms a recv
 /// slot). A monitor DOWN lands in a slot the program polls; a `CrashLinked` link
 /// DOWN crashes the linked actor through its mailbox. The EXIT is fired exactly
-/// once and ONLY for a link entry THIS node registered, so a forged frame cannot
-/// crash an actor we never linked.
-pub(crate) fn handle_inbound_link_down(ref_id: u64, reason: i32) {
+/// once and ONLY for a link entry THIS node registered AND ONLY when
+/// `authenticated_peer` (the handshake-verified sender of the frame, resolved by
+/// the connection layer) matches that entry's own linked-to node — so neither a
+/// forged `ref_id` this node never linked NOR a genuinely-connected but
+/// unrelated peer that merely guessed/learned a pending link `ref_id` can crash
+/// an actor we linked to a DIFFERENT, still-alive peer.
+pub(crate) fn handle_inbound_link_down(ref_id: u64, authenticated_peer: u16, reason: i32) {
     let Some(rt) = crate::runtime::rt_current_opt() else {
         set_last_error("handle_inbound_link_down: no runtime installed");
         return;
     };
-    if let Some(down) = rt.dist_monitors.deliver_link_down_to_ref(ref_id, reason) {
+    if let Some(down) =
+        rt.dist_monitors
+            .deliver_link_down_to_ref(ref_id, authenticated_peer, reason)
+    {
         let _ = crate::link::deliver_cross_node_link_exit(
             down.local_actor_id,
             down.remote_target_serial,


### PR DESCRIPTION
## Bug

`CTRL_LINK_DOWN` was delivered by `ref_id` alone: `handle_control_frame` dispatched it to `handle_link_down_frame(control)` with no connection or peer identity, unlike the `CTRL_SWIM` arm, which resolves and threads `peer_node_id_for_conn(mgr, conn_id)` before accepting attributed data. `dist_monitor::deliver_link_down_to_ref` matched solely on `watchers.get_mut(&ref_id)` + `Pending` + `WatcherAction::Link` and never compared the stored `entry.remote_node_id` to the frame's actual sender.

`WatcherEntry` already records the peer this node registered the link against, so the existing doc comment ("the EXIT fires exactly once and ONLY for a link entry this node registered") is an entry-**locality** guard, not a peer-**binding** guard: it stops a forged `ref_id` this node never linked, but does nothing to stop a *different*, genuinely handshake-authenticated peer from firing a link this node registered against a *third* node.

Cross-node link `ref_id`s are allocated from a monotonic, enumerable namespace (`DIST_REF_ID_BASE = 2^48`), not a secret, so any connected peer that guesses or learns a pending `ref_id` could send `CTRL_LINK_DOWN{ref_id, reason}` and force a `CrashLinked` `EXIT` (with an attacker-chosen reason) into a local actor whose real linked peer is still alive.

Verified live before fixing: a temporary unit probe modelling the delivery primitive (register a `CrashLinked` link against node 7, then `deliver_link_down_to_ref` as if the frame had actually arrived from node 99) fired the cascade unconditionally; reverted before committing.

## Fix

Resolve `peer_node_id_for_conn(mgr, conn_id)` in the `CTRL_LINK_DOWN` arm of `handle_control_frame` (mirroring the `CTRL_SWIM` arm exactly) and thread it through `handle_link_down_frame` → `hew_node::handle_inbound_link_down` → `dist_monitor::deliver_link_down_to_ref`, which now rejects the delivery unless the stored `entry.remote_node_id` equals the authenticated sender. `authenticated == 0` (no live/registered connection for `conn_id`) cannot match any real link, since node ids are never `0` elsewhere in this file, so it fails closed without a separate early-return.

Added `link_down_from_wrong_authenticated_peer_is_rejected`: confirmed load-bearing by reverting the peer check and watching the test fail with the exact forged-delivery symptom, then restoring the fix. Updated the three pre-existing `deliver_link_down_to_ref` call sites in `dist_monitor::tests` to pass each entry's own registered peer as the now-required `authenticated_peer` argument; behaviour of those tests is unchanged.

## Verification

- `cargo test -p hew-runtime --lib` — 2020/2020 (was 2019, +1 new)
- `cargo fmt -p hew-runtime --check` — clean
- `cargo clippy -p hew-runtime --lib --tests -- -D warnings` — clean
- `tests/vertical-slice/run.sh` — 427/427

## Scope

This PR covers only the LINK cascade (`CTRL_LINK_DOWN`). The sibling MONITOR family (`CTRL_MONITOR_REQ`/`CTRL_DEMONITOR`/`CTRL_MONITOR_DOWN`) has the identical peer-binding gap and is tracked separately (not touched here to keep this fix reviewable and scoped to one cascade).