### PR TITLE
fix(runtime): bind monitor controls to peer identity

### DIFF
--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -1038,15 +1038,15 @@ fn handle_control_frame(
             return;
         }
         CTRL_MONITOR_REQ => {
-            handle_monitor_req_frame(control);
+            handle_monitor_req_frame(mgr, conn_id, control);
             return;
         }
         CTRL_DEMONITOR => {
-            handle_demonitor_frame(control);
+            handle_demonitor_frame(mgr, conn_id, control);
             return;
         }
         CTRL_MONITOR_DOWN => {
-            handle_monitor_down_frame(control);
+            handle_monitor_down_frame(mgr, conn_id, control);
             return;
         }
         CTRL_LINK_REQ => {
@@ -1107,13 +1107,30 @@ fn handle_control_frame(
     }
 }
 
+fn authenticated_peer_node_id(mgr: *mut HewConnMgr, conn_id: c_int, context: &str) -> Option<u16> {
+    if mgr.is_null() {
+        set_last_error(format!("connection reader {context}: missing manager"));
+        return None;
+    }
+    // SAFETY: reader_loop owns a live manager pointer for this connection.
+    let mgr_ref = unsafe { &*mgr };
+    let authenticated = peer_node_id_for_conn(mgr_ref, conn_id);
+    if authenticated == 0 {
+        set_last_error(format!(
+            "connection reader {context}: missing authenticated peer for conn {conn_id}"
+        ));
+        return None;
+    }
+    Some(authenticated)
+}
+
 /// Handle an inbound `CTRL_MONITOR_REQ`: a remote node is monitoring
 /// one of our local actors. Record a target-side remote-watcher entry so the
 /// terminal sweep can fan out a `CTRL_MONITOR_DOWN` when that actor dies.
 ///
 /// Fail-closed: a malformed / oversized payload is dropped with `set_last_error`
 /// and never registers a watcher — no fabricated state from untrusted bytes.
-fn handle_monitor_req_frame(control: &ControlFrame) {
+fn handle_monitor_req_frame(mgr: *mut HewConnMgr, conn_id: c_int, control: &ControlFrame) {
     let payload = match decode_monitor_req_payload(&control.payload) {
         Ok(payload) => payload,
         Err(err) => {
@@ -1123,6 +1140,16 @@ fn handle_monitor_req_frame(control: &ControlFrame) {
             return;
         }
     };
+    let Some(authenticated) = authenticated_peer_node_id(mgr, conn_id, "monitor req") else {
+        return;
+    };
+    if payload.watcher_node_id != authenticated {
+        set_last_error(format!(
+            "connection reader monitor req watcher_node_id {} does not match authenticated peer {authenticated}",
+            payload.watcher_node_id
+        ));
+        return;
+    }
     let Some(rt) = crate::runtime::rt_current_opt() else {
         set_last_error("connection reader monitor req: no runtime installed");
         return;
@@ -1137,7 +1164,7 @@ fn handle_monitor_req_frame(control: &ControlFrame) {
 /// Handle an inbound `CTRL_DEMONITOR`: a remote node retracted its
 /// monitor of one of our local actors. Remove the target-side remote-watcher
 /// entry. Idempotent / fail-closed on malformed input.
-fn handle_demonitor_frame(control: &ControlFrame) {
+fn handle_demonitor_frame(mgr: *mut HewConnMgr, conn_id: c_int, control: &ControlFrame) {
     let payload = match decode_monitor_req_payload(&control.payload) {
         Ok(payload) => payload,
         Err(err) => {
@@ -1147,6 +1174,16 @@ fn handle_demonitor_frame(control: &ControlFrame) {
             return;
         }
     };
+    let Some(authenticated) = authenticated_peer_node_id(mgr, conn_id, "demonitor") else {
+        return;
+    };
+    if payload.watcher_node_id != authenticated {
+        set_last_error(format!(
+            "connection reader demonitor watcher_node_id {} does not match authenticated peer {authenticated}",
+            payload.watcher_node_id
+        ));
+        return;
+    }
     let Some(rt) = crate::runtime::rt_current_opt() else {
         return;
     };
@@ -1165,7 +1202,7 @@ fn handle_demonitor_frame(control: &ControlFrame) {
 /// connection-drop / SWIM-DEAD fan-out's reach (the slot is no longer
 /// `Pending`), which is the exactly-once disambiguation: a definitive DOWN beats
 /// a later partition signal for the same registration.
-fn handle_monitor_down_frame(control: &ControlFrame) {
+fn handle_monitor_down_frame(mgr: *mut HewConnMgr, conn_id: c_int, control: &ControlFrame) {
     let payload = match decode_monitor_down_payload(&control.payload) {
         Ok(payload) => payload,
         Err(err) => {
@@ -1175,12 +1212,15 @@ fn handle_monitor_down_frame(control: &ControlFrame) {
             return;
         }
     };
+    let Some(authenticated) = authenticated_peer_node_id(mgr, conn_id, "monitor down") else {
+        return;
+    };
     let Some(rt) = crate::runtime::rt_current_opt() else {
         set_last_error("connection reader monitor down: no runtime installed");
         return;
     };
     rt.dist_monitors
-        .deliver_to_ref(payload.ref_id, payload.reason);
+        .deliver_to_ref(payload.ref_id, authenticated, payload.reason);
 }
 
 /// Handle an inbound `CTRL_LINK_REQ`: a remote node is linking one of our local

--- a/hew-runtime/src/dist_monitor.rs
+++ b/hew-runtime/src/dist_monitor.rs
@@ -248,10 +248,15 @@ impl DistMonitorState {
 
     /// Arm the terminal slot for a single watcher registration with `reason`.
     ///
+    /// The `remote_node_id` must match the node this monitor registration was
+    /// originally opened against. This binds `CTRL_MONITOR_DOWN` delivery to the
+    /// handshake-authenticated peer that sent the frame instead of trusting the
+    /// ref id alone.
+    ///
     /// Only transitions `Pending → Delivered`; a no-op if the slot is already
     /// `Delivered` or `Consumed` (exactly-once). Wakes any blocked `recv_down`.
     /// Returns true if this call armed the slot.
-    pub(crate) fn deliver_to_ref(&self, ref_id: u64, reason: i32) -> bool {
+    pub(crate) fn deliver_to_ref(&self, ref_id: u64, remote_node_id: u16, reason: i32) -> bool {
         let armed = {
             let mut watchers = self.watchers.lock().unwrap_or_else(PoisonError::into_inner);
             match watchers.get_mut(&ref_id) {
@@ -260,6 +265,7 @@ impl DistMonitorState {
                 // must never arm a link entry's slot (it has no recv consumer).
                 Some(entry)
                     if entry.slot == TerminalSlot::Pending
+                        && entry.remote_node_id == remote_node_id
                         && matches!(entry.action, WatcherAction::Observe) =>
                 {
                     entry.slot = TerminalSlot::Delivered(reason);
@@ -592,10 +598,10 @@ mod tests {
         assert_ne!(ref_id, 0);
 
         // Arm with the clean-exit reason (HewActorState::Stopped == 6).
-        assert!(state.deliver_to_ref(ref_id, 6), "first arm must succeed");
+        assert!(state.deliver_to_ref(ref_id, 7, 6), "first arm must succeed");
         // A second arm is a no-op (exactly-once arming).
         assert!(
-            !state.deliver_to_ref(ref_id, 5),
+            !state.deliver_to_ref(ref_id, 7, 5),
             "second arm must be a no-op"
         );
 
@@ -609,6 +615,28 @@ mod tests {
     }
 
     #[test]
+    fn monitor_down_from_wrong_authenticated_peer_is_rejected() {
+        let state = DistMonitorState::new();
+        let ref_id = state.register_watcher(7, 99);
+
+        assert!(
+            !state.deliver_to_ref(ref_id, 9, 5),
+            "DOWN from a different authenticated peer must not arm the monitor"
+        );
+        assert_eq!(
+            state.recv_down(ref_id, Duration::from_millis(20)),
+            MONITOR_REASON_TIMEOUT,
+            "forged DOWN must leave the slot pending"
+        );
+
+        assert!(
+            state.deliver_to_ref(ref_id, 7, 6),
+            "the owning authenticated peer can still deliver"
+        );
+        assert_eq!(state.recv_down(ref_id, Duration::from_millis(50)), 6);
+    }
+
+    #[test]
     fn deliver_to_node_arms_only_pending_slots() {
         let state = DistMonitorState::new();
         let a = state.register_watcher(7, 1);
@@ -616,7 +644,7 @@ mod tests {
         let other = state.register_watcher(9, 3);
 
         // A clean-exit DOWN already armed `a` before the connection dropped.
-        assert!(state.deliver_to_ref(a, 6));
+        assert!(state.deliver_to_ref(a, 7, 6));
 
         // Connection drop to node 7 fans out MonitorLost: it must arm only `b`
         // (still pending), not `a` (already delivered) and not `other` (node 9).
@@ -642,7 +670,7 @@ mod tests {
         // drop fan-out must NOT re-arm the slot (no second DOWN).
         let state = DistMonitorState::new();
         let ref_id = state.register_watcher(7, 1);
-        assert!(state.deliver_to_ref(ref_id, 6));
+        assert!(state.deliver_to_ref(ref_id, 7, 6));
         assert_eq!(state.recv_down(ref_id, Duration::from_millis(50)), 6);
 
         // Node drops afterwards: slot is Consumed, so no re-arm.
@@ -672,7 +700,7 @@ mod tests {
             MONITOR_REASON_TIMEOUT
         );
         // Now arm and recv: the still-Pending slot delivers.
-        assert!(state.deliver_to_ref(ref_id, 5));
+        assert!(state.deliver_to_ref(ref_id, 7, 5));
         assert_eq!(state.recv_down(ref_id, Duration::from_millis(50)), 5);
     }
 
@@ -821,12 +849,12 @@ mod tests {
         );
         // A link DOWN must not arm the monitor's recv slot.
         assert!(
-            !state.deliver_to_ref(link_ref, 5),
+            !state.deliver_to_ref(link_ref, 7, 5),
             "monitor delivery must not arm a link entry"
         );
 
         // Each fires only through its own path.
-        assert!(state.deliver_to_ref(monitor_ref, 6), "monitor arms");
+        assert!(state.deliver_to_ref(monitor_ref, 7, 6), "monitor arms");
         assert!(
             state.deliver_link_down_to_ref(link_ref, 5).is_some(),
             "link fires"
@@ -888,7 +916,7 @@ mod tests {
 
         // Give the recv thread time to park on the condvar, then arm.
         std::thread::sleep(Duration::from_millis(50));
-        assert!(state.deliver_to_ref(ref_id, 6));
+        assert!(state.deliver_to_ref(ref_id, 7, 6));
 
         let reason = handle.join().expect("recv thread panicked");
         assert_eq!(reason, 6, "blocked recv must wake with the armed reason");


### PR DESCRIPTION
## Summary

Bind cross-node monitor control handling to the handshake-authenticated peer identity instead of trusting wire-carried node ids or `ref_id` alone.

This closes the remaining monitor-side variant of the peer-forgery gap noted from PR #2256:

- `CTRL_MONITOR_REQ` now rejects a `watcher_node_id` that does not match the authenticated sender.
- `CTRL_DEMONITOR` applies the same sender binding before removing target-side watcher state.
- `CTRL_MONITOR_DOWN` now passes the authenticated sender into `DistMonitorState::deliver_to_ref`, which only arms a pending monitor if the ref's stored `remote_node_id` matches that sender.

The existing exact-once behavior stays intact; the check only rejects a DOWN from a different connected peer.

## Verification

- `cargo test -p hew-runtime --lib dist_monitor::tests::monitor_down_from_wrong_authenticated_peer_is_rejected`
- Load-bearing check: temporarily removed the `entry.remote_node_id == remote_node_id` guard and confirmed the new regression fails with the forged-delivery symptom.
- `cargo test -p hew-runtime --lib` (2024/2024)
- `cargo fmt -p hew-runtime --check`
- `cargo clippy -p hew-runtime --lib --tests -- -D warnings`
- `tests/vertical-slice/run.sh`
