### PR TITLE
fix(mir): release from-call match-scrutinee enum payloads on loop back-edges

### DIFF
--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.elab.mir
@@ -69,17 +69,17 @@ fn Echo__recv__run -> ()
     branch[bb17: bb19/bb22] ->
       (none)
     goto[bb18->bb14] ->
-      (none)
+      drop _26 ty=Option<bytes> kind=enum_in_place
     cancel[bb18] ->
-      (none)
+      drop _26 ty=Option<bytes> kind=enum_in_place
     call[bb19 hew_bytes_to_string -> bb23] ->
       (none)
     goto[bb20->bb18] ->
       (none)
     cancel[bb20] ->
-      (none)
+      drop _26 ty=Option<bytes> kind=enum_in_place
     panic[bb21] ->
-      (none)
+      drop _26 ty=Option<bytes> kind=enum_in_place
     branch[bb22: bb20/bb21] ->
       (none)
     call[bb23 println_str -> bb24] ->
@@ -87,7 +87,7 @@ fn Echo__recv__run -> ()
     goto[bb24->bb18] ->
       (none)
     cancel[bb24] ->
-      (none)
+      drop _26 ty=Option<bytes> kind=enum_in_place
     return[bb25] ->
       (none)
 

--- a/hew-cli/tests/match_call_scrutinee_leak_oracle.rs
+++ b/hew-cli/tests/match_call_scrutinee_leak_oracle.rs
@@ -1,0 +1,350 @@
+//! From-call match-scrutinee enum-payload leak oracle (#2429 guard).
+//!
+//! `match f() { Ok(b) => …, Err(e) => {} }` over a `Result`/`Option` returned
+//! from a called function consumes the composite through an anonymous MIR
+//! temp. Before the fix the temp had no owner, so the arm-destructured payload
+//! was released on NO edge: each iteration of a
+//! `while … { match f() { … } }` loop leaked one payload allocation — the
+//! primary consumption shape for every read-style API (`while` over
+//! `tls.read()`, chunked HTTP bodies, line framing). A `bytes` payload leaked
+//! even when LET-bound, because the composite prover classified the borrowing
+//! `b.len()` (`hew_bytes_len` receiver read) as an owning escape.
+//!
+//! These slope guards pin the fix per shape: the scrutinee temp now carries a
+//! synthetic owned binding released through the standard machinery (back-edge
+//! per iteration, Return for the straight line, scope-close for
+//! break/continue), and the bytes receiver-borrow contract joined the
+//! `binder_read_is_borrow_safe_*` exemption.
+//!
+//! ## De-flake: slope, not single-shot exact-zero
+//!
+//! Each shape is measured at LOW and HIGH iteration counts and the leak-node
+//! delta asserted within tolerance — the delta cancels the constant runtime
+//! baseline. A regression re-opens a 1-node-per-iteration slope
+//! (LOW→HIGH delta of 40 nodes) and trips the assertion.
+//!
+//! The scribble pins are the #2384 exactly-once wall: the payload is read back
+//! verbatim before its release (a use-after-free garbles output) and the run
+//! must exit clean under the poisoned-allocator triple (a double free — the
+//! back-edge release stacking on a scope-exit release — aborts).
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+// ── slope shapes ────────────────────────────────────────────────────────────
+
+/// The #2429 zero-FFI headline repro: `Result<bytes, string>` from a call,
+/// matched directly (no `let`) inside a `while` loop, payload borrowed by
+/// `.len()`.
+fn bytes_scrutinee_loop_source(frames: usize) -> String {
+    format!(
+        "fn f() -> Result<bytes, string> {{\n\
+         \x20   Ok(\"g2429-bytes-payload\".to_bytes())\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       match f() {{\n\
+         \x20           Ok(b) => {{ total = total + b.len(); }}\n\
+         \x20           Err(e) => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// String payload through the same unbound-scrutinee seam.
+fn string_scrutinee_loop_source(frames: usize) -> String {
+    format!(
+        "fn f() -> Result<string, string> {{\n\
+         \x20   Ok(\"g2429-string-payload\".to_upper())\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       match f() {{\n\
+         \x20           Ok(b) => {{ total = total + b.len(); }}\n\
+         \x20           Err(e) => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// The Err arm is the taken path: a fresh heap error payload per iteration
+/// must be released on the back-edge exactly like an Ok payload.
+fn err_arm_loop_source(frames: usize) -> String {
+    format!(
+        "fn f(n: i64) -> Result<i64, string> {{\n\
+         \x20   if n >= 0 {{ Err(\"g2429-err-payload\".to_upper()) }} else {{ Ok(n) }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var hits = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       match f(i) {{\n\
+         \x20           Ok(v) => {{}}\n\
+         \x20           Err(e) => {{ if !e.is_empty() {{ hits = hits + 1; }} }}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if hits > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// Composite (record) payload with an owned string field: rides the in-place
+/// composite drop machinery through the same scrutinee seam.
+fn composite_payload_loop_source(frames: usize) -> String {
+    format!(
+        "type Row {{\n\
+         \x20   name: string;\n\
+         \x20   id: i64;\n\
+         }}\n\
+         \n\
+         fn f(n: i64) -> Result<Row, string> {{\n\
+         \x20   Ok(Row {{ name: \"g2429-row-payload\".to_upper(), id: n }})\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       match f(i) {{\n\
+         \x20           Ok(r) => {{ total = total + r.id; }}\n\
+         \x20           Err(e) => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total >= 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// `continue` inside the taken arm: the payload of a continued iteration is
+/// released on the continue edge / back-edge, not stranded.
+fn continue_loop_source(frames: usize) -> String {
+    format!(
+        "fn f() -> Result<bytes, string> {{\n\
+         \x20   Ok(\"g2429-continue-payload\".to_bytes())\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var seen = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       i = i + 1;\n\
+         \x20       match f() {{\n\
+         \x20           Ok(b) => {{ if b.len() > 3 {{ continue; }} }}\n\
+         \x20           Err(e) => {{}}\n\
+         \x20       }}\n\
+         \x20       seen = seen + 1;\n\
+         \x20   }}\n\
+         \x20   if seen == 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// Early `return` out of the consuming arm mid-loop, from a helper called
+/// per measurement frame: the returning iteration's payload is released on
+/// the Return plan; prior iterations released on the back-edge.
+fn early_return_loop_source(frames: usize) -> String {
+    format!(
+        "fn f() -> Result<bytes, string> {{\n\
+         \x20   Ok(\"g2429-return-payload\".to_bytes())\n\
+         }}\n\
+         \n\
+         fn run(cap: i64) -> i64 {{\n\
+         \x20   var i = 0;\n\
+         \x20   while i < cap {{\n\
+         \x20       match f() {{\n\
+         \x20           Ok(b) => {{ if b.len() == 20 && i == cap - 1 {{ return i; }} }}\n\
+         \x20           Err(e) => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   -1\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let r = run({frames});\n\
+         \x20   if r >= 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// The #2429 acceptance surface: a looped `tls.read()` (offline-deterministic
+/// per the tls fixture precedent — port 1 refuses fast, the Err arm is taken
+/// every iteration). Covers both the from-call scrutinee release and the TLS
+/// bridge no longer materialising a discarded `last_error()` string per Err.
+fn tls_read_loop_source(frames: usize) -> String {
+    format!(
+        "import std::net::tls;\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let stream = tls.connect(\"127.0.0.1\", 1);\n\
+         \x20   var errs = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       match tls.read(stream, 16) {{\n\
+         \x20           Ok(data) => {{ let n = data.len(); }}\n\
+         \x20           Err(e) => {{ errs = errs + 1; }}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if errs > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+// ── scribble exactly-once pins ──────────────────────────────────────────────
+
+/// Loop whose `break` fires on the LAST iteration — the shape where the
+/// back-edge release and the loop-exit/scope-close release are adjacent. The
+/// payload is read back verbatim each iteration; a double free (back-edge
+/// release stacking on a second release) aborts under the poisoned allocator.
+const LAST_ITERATION_BREAK_SCRIBBLE_SOURCE: &str = "\
+fn f() -> Result<string, string> {\n\
+\x20   Ok(\"g2429-scribble-payload\".to_upper())\n\
+}\n\
+\n\
+fn main() {\n\
+\x20   var i = 0;\n\
+\x20   while i < 3 {\n\
+\x20       match f() {\n\
+\x20           Ok(b) => {\n\
+\x20               print(\"o\");\n\
+\x20               if i == 2 { break; }\n\
+\x20           }\n\
+\x20           Err(e) => { print(\"e\"); }\n\
+\x20       }\n\
+\x20       i = i + 1;\n\
+\x20   }\n\
+}\n";
+
+/// Straight-line from-call scrutinee: released once on Return, payload read
+/// back before the release.
+const SINGLE_MATCH_SCRIBBLE_SOURCE: &str = "\
+fn f() -> Result<bytes, string> {\n\
+\x20   Ok(\"g2429-single\".to_bytes())\n\
+}\n\
+\n\
+fn main() {\n\
+\x20   match f() {\n\
+\x20       Ok(b) => { if b.len() == 12 { print(\"m\"); } }\n\
+\x20       Err(e) => { print(\"e\"); }\n\
+\x20   }\n\
+}\n";
+
+fn assert_exact_under_malloc_scribble(name: &str, source: &str, expected: &str) {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("match-call-scrutinee-{name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), name);
+    let output = run_under_malloc_scribble(&bin);
+
+    assert!(
+        output.status.success(),
+        "{name} must run clean under the poisoned allocator — a crash here means the \
+         from-call scrutinee's payload was double-freed (the back-edge release stacking \
+         on a second release of the same buffer);\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        expected,
+        "{name} must read the arm-bound payload back verbatim — scribbled/short output \
+         indicates a use-after-free read on a prematurely released payload;\n{}",
+        describe_output(&output)
+    );
+}
+
+// ── oracles ─────────────────────────────────────────────────────────────────
+
+/// #2429 headline: the zero-FFI bytes repro holds a flat leak slope.
+#[test]
+fn from_call_bytes_scrutinee_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_bytes_scrutinee", bytes_scrutinee_loop_source);
+}
+
+/// String payload through the unbound-scrutinee seam holds a flat slope.
+#[test]
+fn from_call_string_scrutinee_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_string_scrutinee", string_scrutinee_loop_source);
+}
+
+/// The Err-arm payload is released per iteration, not just the Ok arm.
+#[test]
+fn err_arm_payload_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_err_arm", err_arm_loop_source);
+}
+
+/// A record payload with an owned field rides the composite in-place drop
+/// through the same seam.
+#[test]
+fn composite_payload_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_composite_payload", composite_payload_loop_source);
+}
+
+/// `continue` from the consuming arm releases the continued iteration's
+/// payload.
+#[test]
+fn continue_edge_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_continue_edge", continue_loop_source);
+}
+
+/// Early `return` out of the consuming arm releases the in-flight payload on
+/// the Return plan and prior iterations on the back-edge.
+#[test]
+fn early_return_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_early_return", early_return_loop_source);
+}
+
+/// The #2429 acceptance surface: a looped `tls.read()` (offline Err path)
+/// holds a flat slope — one composite + one payload per read, each released.
+#[test]
+fn tls_read_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_tls_read_loop", tls_read_loop_source);
+}
+
+/// Exactly-once wall: back-edge release adjacent to the break/loop-exit edge
+/// on the last iteration must not double-free, and the payload reads back
+/// verbatim first.
+#[test]
+fn last_iteration_break_no_double_free_under_malloc_scribble() {
+    assert_exact_under_malloc_scribble(
+        "g2429_last_iter_break_scribble",
+        LAST_ITERATION_BREAK_SCRIBBLE_SOURCE,
+        "ooo",
+    );
+}
+
+/// Straight-line from-call scrutinee: single Return-plan release, no
+/// double-free, payload readable.
+#[test]
+fn single_from_call_match_no_double_free_under_malloc_scribble() {
+    assert_exact_under_malloc_scribble(
+        "g2429_single_match_scribble",
+        SINGLE_MATCH_SCRIBBLE_SOURCE,
+        "m",
+    );
+}

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -12650,28 +12650,38 @@ fn emit_enum_clone_inplace_body<'ctx>(
             layout.variant_struct_tys.len()
         )));
     }
-    // Fail closed: if any variant carries an OpaqueHandle field, emit a
-    // trap body rather than a shallow-copy clone. Silently treating an
-    // OpaqueHandle as BitCopy (pointer bit-copy via the outer memcpy) would
+    // Fail closed: if any variant carries an OpaqueHandle field — or an
+    // IoHandle field (Connection / Stream / Sink / Generator /
+    // CancellationToken, none of which has a dup runtime symbol) — emit a
+    // trap body rather than a shallow-copy clone. Silently treating such a
+    // handle as BitCopy (pointer bit-copy via the outer memcpy) would
     // produce two owners of the same resource — a double-free on drop.
     //
-    // The enum DROP path is safe: dropping an opaque handle is a no-op/leak
-    // (user must call `.free()` explicitly), so only the clone direction is
-    // unsafe.
+    // The enum DROP path is safe for both families: dropping an opaque
+    // handle is a no-op/leak (user must call `.free()` explicitly), and the
+    // IoHandle kinds route to their wired close symbols (`hew_stream_close`
+    // et al) — only the clone direction is unsafe.
     //
     // A trap body is emitted rather than a compile-time CodegenError because
     // the enum clone helper is synthesised for ALL enums reachable from
-    // actor state or from enum-drop seeds; an opaque-containing enum may be
-    // seeded only for its DROP helper (function-local `Result<json.Value, _>`)
-    // and the clone body would never be called in that path. Emitting a trap
-    // body keeps the symbol defined (linker satisfied) while ensuring that
-    // IF the path ever becomes reachable (upstream gates relaxed), it traps
-    // rather than silently aliasing the handle pointer. Consistent with the
+    // actor state or from enum-drop seeds; a handle-carrying enum may be
+    // seeded only for its DROP helper (function-local `Result<json.Value, _>`,
+    // or the #2429 from-call `match stream.from_file(p) { … }` scrutinee
+    // whose `Result<Stream, E>` earns a scope-exit EnumInPlace drop) and the
+    // clone body would never be called in that path. Emitting a trap body
+    // keeps the symbol defined (linker satisfied) while ensuring that IF the
+    // path ever becomes reachable (upstream gates relaxed), it traps rather
+    // than silently aliasing the handle pointer. Consistent with the
     // direct-opaque-in-actor-state guard (codegen-front `OpaqueHandle has no
-    // dup runtime helper` FailClosed diagnostic at actor spawn).
+    // dup runtime helper` FailClosed diagnostic at actor spawn) and with
+    // `clone_helper_for_kind`'s fail-closed IoHandle arms.
     let has_nested_opaque = variant_kinds.iter().any(|fks| {
-        fks.iter()
-            .any(|k| matches!(k, StateFieldCloneKind::OpaqueHandle { .. }))
+        fks.iter().any(|k| {
+            matches!(
+                k,
+                StateFieldCloneKind::OpaqueHandle { .. } | StateFieldCloneKind::IoHandle { .. }
+            )
+        })
     });
     if has_nested_opaque {
         // Emit a single trap-on-entry body so the symbol is defined but any

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -130,6 +130,29 @@ const SENTINEL_EXIT_KIND_TAG_BINDING: BindingId = BindingId(u32::MAX - 3);
 /// dedicated value keeps the pump self-contained and future-proof).
 const SENTINEL_RECV_GEN_COMPANION_BINDING: BindingId = BindingId(u32::MAX - 4);
 
+/// Base of the per-function synthetic binding-id range for FROM-CALL match
+/// scrutinee temps (#2429). `match f() { Ok(b) => …, Err(e) => {} }` consumes
+/// the callee's `Result`/`Option` return through an anonymous MIR temp; with
+/// no `BindingId` the temp is invisible to `build_lifo_drops` /
+/// `enumerate_exits`, so the arm-destructured payload was released on NO edge
+/// — one leaked payload per iteration of a `while … { match f() { … } }`
+/// read loop. Minting a synthetic owned binding over the temp routes it
+/// through the PROVEN let-bound discipline (enum-composite sole-owner prover,
+/// back-edge body-scope filter, return/cancel plans).
+///
+/// The range DESCENDS from here (`base`, `base - 1`, …), one id per from-call
+/// scrutinee in the function, so it can never collide with the fixed
+/// sentinels above (`u32::MAX ..= u32::MAX - 4`). Collision with real HIR
+/// binding ids would need a function with ~4.29 billion bindings — outside
+/// any representable source. If HIR ever exposes a per-function binding-id
+/// ceiling, mint above it instead and retire this reserved range.
+const SYNTHETIC_MATCH_SCRUTINEE_BINDING_BASE: u32 = u32::MAX - 64;
+
+/// Diagnostic name for synthetic from-call match-scrutinee bindings. Never
+/// user-visible (no `-g` variable DIE is minted for it); shows up only in MIR
+/// dumps and drop-plan diagnostics.
+const SYNTHETIC_MATCH_SCRUTINEE_NAME: &str = "__hew_match_scrutinee";
+
 /// Prefix of the synthetic for-iteration cursor binding minted by the HIR
 /// for-loop desugar (`hew-hir/src/lower.rs`, `lower_for_iter_desugar`:
 /// `format!("__hew_for_iter_{}", …)`). The scope-exit `Stream`/`Receiver` close
@@ -9240,6 +9263,12 @@ struct Builder {
     /// initialiser. Cluster 1 reads the slot directly; later clusters add
     /// drop-cleanup and rebinding semantics.
     binding_locals: HashMap<BindingId, Place>,
+    /// Count of synthetic from-call match-scrutinee bindings minted so far in
+    /// this function (#2429). The next mint is
+    /// `BindingId(SYNTHETIC_MATCH_SCRUTINEE_BINDING_BASE - count)` — a
+    /// descending per-function range that stays clear of both the fixed
+    /// `u32::MAX ..= u32::MAX - 4` sentinels and real HIR binding ids.
+    synthetic_match_scrutinee_bindings: u32,
     /// Per-function destructive-funcupdate base provenance. Maps a `BindingId`
     /// to whether `{ ..<binding>, f: new }` over it is a PROVEN unique owner of
     /// its heap fields — i.e. consuming it leaves no live alias, so the
@@ -10218,6 +10247,81 @@ impl Builder {
             provenance: Some(provenance),
             disposition: Disposition::AliasOf,
         });
+    }
+
+    /// #2429 — give a FROM-CALL enum-composite match scrutinee an owner.
+    ///
+    /// `match f() { Ok(b) => …, Err(e) => {} }` consumes the callee's
+    /// by-value `Result`/`Option` return through an anonymous MIR temp. With
+    /// no `BindingId`, the temp is invisible to `build_lifo_drops` /
+    /// `enumerate_exits`, so the arm-destructured payload was released on NO
+    /// edge — not the loop back-edge, not the return plan — and every
+    /// iteration of a `while … { match f() { … } }` read loop leaked one
+    /// payload allocation. Minting a synthetic owned binding over the temp
+    /// routes it through the PROVEN let-bound discipline end to end: the
+    /// fail-closed enum-composite sole-owner prover decides admission, the
+    /// back-edge body-scope filter releases per iteration, the return/cancel
+    /// plans cover the straight-line case, and the scope-close goto pass
+    /// covers break/continue edges.
+    ///
+    /// Registration alone never emits a drop: an escaping payload keeps
+    /// today's leak-not-double-free posture because
+    /// `derive_enum_composite_drop_allowed` still excludes the composite.
+    fn register_from_call_scrutinee_owner(&mut self, scrutinee: &HirExpr, scrutinee_local: u32) {
+        // Only the direct-call rvalue shape. A `BindingRef` scrutinee already
+        // owns its slot through its own `let`/param registration — a second
+        // owner over the same local would double-free — and every non-call
+        // rvalue keeps its pre-fix posture (fail-closed).
+        let HirExprKind::Call { callee, .. } = &scrutinee.kind else {
+            return;
+        };
+        // Recv-next / vec-string-iter-next scrutinees already carry their own
+        // per-iteration release discipline (`Disposition::BodyEndReleased` on
+        // the Some-arm payload binder); their codegen-materialised `Option`
+        // shell owns no heap beyond that payload. Registering a second owner
+        // here would double-release the payload. (A generator `.next()`
+        // scrutinee is `HirExprKind::GeneratorNext`, not `Call`, so the shape
+        // gate above already excludes it.)
+        if Self::is_recv_next_scrutinee(scrutinee)
+            || self.is_vec_string_iter_next_scrutinee(scrutinee)
+        {
+            return;
+        }
+        // Runtime-symbol / builtin producers have per-symbol ownership
+        // contracts — an interior getter may hand back a BORROW of storage
+        // the receiver still owns, and freeing that here would be the #2384
+        // double-free class. Only a Hew callee's by-value return is
+        // unconditionally caller-owned (the callee side retracts its drop of
+        // every member handed out through the return —
+        // `derive_returned_aggregate_member_bindings`), so this caller holds
+        // the single release obligation.
+        if let HirExprKind::BindingRef { name, resolved } = &callee.kind {
+            if matches!(resolved, ResolvedRef::Builtin(_))
+                || crate::runtime_symbols::is_known_runtime_symbol(name)
+            {
+                return;
+            }
+        }
+        // Exactly the value class the `EnumInPlace` scope-exit machinery
+        // owns; anything else keeps its pre-fix posture.
+        let ty = self.subst_ty(&scrutinee.ty);
+        if !ty_is_heap_owning_enum_composite(&ty, &self.record_field_orders, &self.enum_layouts) {
+            return;
+        }
+        let binding = BindingId(
+            SYNTHETIC_MATCH_SCRUTINEE_BINDING_BASE - self.synthetic_match_scrutinee_bindings,
+        );
+        self.synthetic_match_scrutinee_bindings += 1;
+        self.statements.push(MirStatement::Bind {
+            binding,
+            name: SYNTHETIC_MATCH_SCRUTINEE_NAME.to_string(),
+            site: scrutinee.site,
+            ty: ty.clone(),
+        });
+        self.binding_locals
+            .insert(binding, Place::Local(scrutinee_local));
+        self.record_binding_scope(binding);
+        self.register_owned_local(binding, SYNTHETIC_MATCH_SCRUTINEE_NAME.to_string(), ty);
     }
 
     /// Provenance of a `let`-bound field projection that is a byte-copy interior
@@ -21550,6 +21654,15 @@ impl Builder {
                 return None;
             }
         };
+
+        // A from-call enum-composite scrutinee (`match f() { … }`) gets a
+        // synthetic owned binding over its temp so the arm-destructured
+        // payload is released on every exit edge — most importantly the loop
+        // back-edge, where each iteration previously leaked one payload
+        // (#2429). No-op for binding-ref scrutinees, runtime-symbol
+        // producers, and the recv/iter-next shapes that carry their own
+        // release discipline.
+        self.register_from_call_scrutinee_owner(scrutinee, scrutinee_local);
 
         // Load the tag into a fresh i64 local. `Place::EnumTag(local)`
         // is the substrate primitive; codegen GEPs to outer-struct
@@ -39297,7 +39410,18 @@ fn derive_enum_composite_drop_allowed(
                         {
                             note_alias_escape(l, &mut excluded_roots);
                         }
-                        if payload_binders.contains_key(&l) && !place_is_tag_read(p) {
+                        // A payload binder read as the BORROWED receiver of a
+                        // collection/bytes runtime op (`b.len()` lowers
+                        // `hew_bytes_len` as `Instr::CallRuntimeAbi` with the
+                        // binder as arg[0]) is a transient interior borrow the
+                        // composite survives — the same arg[0] exemption the
+                        // record/tuple provers already apply through
+                        // `binder_read_is_borrow_safe_instr` (#2429). Every
+                        // other read stays a fail-closed owning escape.
+                        if payload_binders.contains_key(&l)
+                            && !place_is_tag_read(p)
+                            && !binder_read_is_borrow_safe_instr(instr, l)
+                        {
                             note_payload_escape(
                                 &payload_binders,
                                 l,
@@ -39331,9 +39455,16 @@ fn derive_enum_composite_drop_allowed(
                         note_alias_escape(l, &mut excluded_roots);
                     }
                 }
+                // `binder_read_is_borrow_safe_terminator` subsumes the string
+                // borrow/print exemption and extends it to the collection- and
+                // bytes-receiver-borrow contracts, so a `Result<bytes, _>`
+                // payload binder read by `hew_bytes_to_string(b)` (a
+                // `Terminator::Call` receiver borrow) no longer excludes its
+                // composite (#2429). Anything not provably borrow-safe stays a
+                // fail-closed payload escape.
                 if payload_binders.contains_key(&l)
                     && !place_is_tag_read(p)
-                    && !retained_string_terminator_drop_safe(
+                    && !binder_read_is_borrow_safe_terminator(
                         &block.terminator,
                         suspend_kinds.get(&block.id),
                         l,
@@ -44145,17 +44276,29 @@ fn binder_read_is_borrow_safe_terminator(
     if retained_string_terminator_drop_safe(term, suspend_kind, binder) {
         return true;
     }
-    // A collection-borrow call borrows arg[0] in place; only a read in the
-    // by-value tail (arg[1..]) genuinely escapes. `binder` is borrow-safe iff it
-    // never appears past arg[0].
+    // A collection-borrow or bytes-receiver-borrow call borrows arg[0] in
+    // place; only a read in the by-value tail (arg[1..]) genuinely escapes.
+    // `binder` is borrow-safe iff it never appears past arg[0]. The bytes
+    // contract is the SAME authority `derive_local_bytes_drop_allowed`
+    // applies to a bytes LOCAL — a `bytes` enum-payload / field binder read
+    // by `b.len()` / `b.is_empty()` (`hew_bytes_len` et al) is a transient
+    // receiver borrow, not an ownership escape of the owning composite
+    // (#2429: classifying it as an escape excluded every
+    // `Result<bytes, _>` composite from its `EnumInPlace` drop and leaked
+    // the payload on every loop iteration).
     if let Terminator::Call { callee, args, .. } = term {
-        if crate::runtime_symbols::callee_ownership_contract(callee)
-            .borrows_collection_binder_receiver()
-        {
+        let contract = crate::runtime_symbols::callee_ownership_contract(callee);
+        if contract.borrows_collection_binder_receiver() || contract.borrows_bytes_receiver() {
             return !args
                 .iter()
                 .skip(1)
                 .any(|arg| place_refs_local(*arg, binder));
+        }
+        // `hew_bytes_append` borrows the receiver AND the unpacked source
+        // triple — every operand is a read-only borrow, so a binder read
+        // anywhere in the argument list stays owned by its composite.
+        if contract.borrows_all_bytes_args() {
+            return true;
         }
     }
     false
@@ -44168,14 +44311,18 @@ fn binder_read_is_borrow_safe_terminator(
 /// `false` unless the only references to `binder` are the borrowed receiver.
 fn binder_read_is_borrow_safe_instr(instr: &Instr, binder: u32) -> bool {
     if let Instr::CallRuntimeAbi(call) = instr {
-        if crate::runtime_symbols::callee_ownership_contract(call.symbol())
-            .borrows_collection_binder_receiver()
-        {
+        let contract = crate::runtime_symbols::callee_ownership_contract(call.symbol());
+        if contract.borrows_collection_binder_receiver() || contract.borrows_bytes_receiver() {
             return !call
                 .args()
                 .iter()
                 .skip(1)
                 .any(|arg| place_refs_local(*arg, binder));
+        }
+        // Bytes append: receiver and unpacked source triple are all borrows
+        // (mirrors the terminator arm and the bytes-LOCAL scan's exemption).
+        if contract.borrows_all_bytes_args() {
+            return true;
         }
     }
     false

--- a/hew-mir/tests/lowering_expr.rs
+++ b/hew-mir/tests/lowering_expr.rs
@@ -28,6 +28,8 @@ mod loop_break_continue;
 mod machine_dispatch_fixtures;
 #[path = "lowering_expr/machine_mir.rs"]
 mod machine_mir;
+#[path = "lowering_expr/match_call_scrutinee_drop.rs"]
+mod match_call_scrutinee_drop;
 #[path = "lowering_expr/match_literal_string.rs"]
 mod match_literal_string;
 #[path = "lowering_expr/match_project.rs"]

--- a/hew-mir/tests/lowering_expr/match_call_scrutinee_drop.rs
+++ b/hew-mir/tests/lowering_expr/match_call_scrutinee_drop.rs
@@ -1,0 +1,278 @@
+//! From-call match-scrutinee composite drop elaboration (#2429).
+//!
+//! `match f() { Ok(b) => …, Err(e) => {} }` consumes the called function's
+//! `Result`/`Option` return through an anonymous MIR temp. Before this fix the
+//! temp had no `BindingId`, so `build_lifo_drops` / `enumerate_exits` never saw
+//! it and the arm-destructured payload was released on NO edge — not the loop
+//! back-edge, not the return plan. Each iteration of a
+//! `while … { match f() { … } }` loop leaked one payload allocation (n at O0),
+//! the primary consumption shape for every read-style API (`while` over
+//! `tls.read()`).
+//!
+//! The fix mints a synthetic owned binding over the scrutinee temp so the
+//! PROVEN let-bound discipline covers it end to end: the enum-composite
+//! sole-owner prover decides admission, the back-edge body-scope filter
+//! releases per iteration, and the return plan covers the straight-line case.
+//!
+//! The `bytes` payload rode a second gap: `hew_bytes_len` (`b.len()`) reads the
+//! payload binder as its BORROWED receiver, but the composite prover's borrow
+//! exemption only consulted the string-borrow contract, so the read classified
+//! as an owning escape and excluded the composite. The
+//! `binder_read_is_borrow_safe_*` helpers now carry the bytes receiver-borrow
+//! contract (the same authority `derive_local_bytes_drop_allowed` applies).
+//!
+//! Negative controls are load-bearing (`drop-allowset-from-value-flow`): a
+//! let-bound scrutinee must not gain a SECOND owner over the same slot, and an
+//! escaping payload must keep the composite excluded (leak, never double-free).
+
+use hew_mir::{DropKind, ElabDrop, ExitPath, IrPipeline};
+use hew_types::module_registry::ModuleRegistry;
+use hew_types::Checker;
+
+fn pipeline_with_tc(source: &str) -> IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:#?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    let output = hew_hir::lower_program(
+        &parsed.program,
+        &tc_output,
+        &hew_hir::ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    hew_mir::lower_hir_module(&output.module)
+}
+
+fn drops_matching(
+    p: &IrPipeline,
+    fn_name: &str,
+    pred: impl Fn(&ExitPath) -> bool,
+) -> Vec<ElabDrop> {
+    p.elaborated_mir
+        .iter()
+        .find(|f| f.name == fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name} must be present in elaborated_mir"))
+        .drop_plans
+        .iter()
+        .filter(|(exit, _)| pred(exit))
+        .flat_map(|(_, plan)| plan.drops.iter().cloned())
+        .collect()
+}
+
+/// Every `ElabDrop` on the named function's `Return` exits.
+fn return_drops(p: &IrPipeline, fn_name: &str) -> Vec<ElabDrop> {
+    drops_matching(p, fn_name, |exit| matches!(exit, ExitPath::Return { .. }))
+}
+
+/// Every `ElabDrop` on the named function's `Goto` exits (the loop back-edge
+/// plan lives on the body-closing `Goto`).
+fn goto_drops(p: &IrPipeline, fn_name: &str) -> Vec<ElabDrop> {
+    drops_matching(p, fn_name, |exit| matches!(exit, ExitPath::Goto { .. }))
+}
+
+/// Every `ElabDrop` across every exit of the named function.
+fn all_exit_drops(p: &IrPipeline, fn_name: &str) -> Vec<ElabDrop> {
+    drops_matching(p, fn_name, |_| true)
+}
+
+fn enum_in_place(drops: &[ElabDrop]) -> Vec<ElabDrop> {
+    drops
+        .iter()
+        .filter(|d| matches!(d.kind, DropKind::EnumInPlace))
+        .cloned()
+        .collect()
+}
+
+/// The #2429 headline shape: a `Result<bytes, string>` returned from a call and
+/// consumed directly by a `match` inside a `while` loop. The scrutinee temp
+/// must earn a per-iteration `EnumInPlace` release on the loop back-edge
+/// `Goto` — the edge that previously leaked one payload per iteration.
+#[test]
+fn from_call_bytes_scrutinee_in_loop_gets_backedge_enum_in_place_drop() {
+    let p = pipeline_with_tc(
+        r#"
+fn f() -> Result<bytes, string> {
+    Ok("payload".to_bytes())
+}
+
+fn main() {
+    var i = 0;
+    while i < 5 {
+        match f() {
+            Ok(b) => { let n = b.len(); }
+            Err(e) => {}
+        }
+        i = i + 1;
+    }
+}
+"#,
+    );
+    let backedge = enum_in_place(&goto_drops(&p, "main"));
+    assert_eq!(
+        backedge.len(),
+        1,
+        "the from-call Result<bytes, string> scrutinee must be released exactly \
+         once per iteration on the loop back-edge Goto plan; got {backedge:?}"
+    );
+}
+
+/// Straight-line variant: a single un-looped `match f() { … }` releases the
+/// scrutinee temp on the `Return` plan (the shape that leaked one payload
+/// even without a loop).
+#[test]
+fn from_call_bytes_scrutinee_single_gets_return_enum_in_place_drop() {
+    let p = pipeline_with_tc(
+        r#"
+fn f() -> Result<bytes, string> {
+    Ok("payload".to_bytes())
+}
+
+fn main() {
+    match f() {
+        Ok(b) => { let n = b.len(); }
+        Err(e) => {}
+    }
+}
+"#,
+    );
+    let ret = enum_in_place(&return_drops(&p, "main"));
+    assert_eq!(
+        ret.len(),
+        1,
+        "the straight-line from-call scrutinee must be released exactly once on \
+         the Return plan; got {ret:?}"
+    );
+}
+
+/// String payloads ride the same seam: the from-call `Result<string, string>`
+/// scrutinee (previously released only when let-bound) earns the back-edge
+/// release in the unbound shape too.
+#[test]
+fn from_call_string_scrutinee_in_loop_gets_backedge_enum_in_place_drop() {
+    let p = pipeline_with_tc(
+        r#"
+fn f() -> Result<string, string> {
+    Ok("payload".to_upper())
+}
+
+fn main() {
+    var i = 0;
+    while i < 5 {
+        match f() {
+            Ok(b) => { let n = b.len(); }
+            Err(e) => {}
+        }
+        i = i + 1;
+    }
+}
+"#,
+    );
+    let backedge = enum_in_place(&goto_drops(&p, "main"));
+    assert_eq!(
+        backedge.len(),
+        1,
+        "the from-call Result<string, string> scrutinee must be released exactly \
+         once per iteration on the loop back-edge Goto plan; got {backedge:?}"
+    );
+}
+
+/// Bytes-payload admission (the second #2429 gap): a LET-BOUND
+/// `Result<bytes, string>` whose payload binder is only read by the borrowing
+/// `b.len()` keeps the composite's `EnumInPlace` drop. Before the fix the
+/// `hew_bytes_len` receiver read classified as an owning escape and excluded
+/// the composite entirely (zero drops on every plan).
+#[test]
+fn letbound_bytes_composite_with_borrowing_len_keeps_enum_in_place_drop() {
+    let p = pipeline_with_tc(
+        r#"
+fn f() -> Result<bytes, string> {
+    Ok("payload".to_bytes())
+}
+
+fn main() {
+    let r = f();
+    match r {
+        Ok(b) => { let n = b.len(); }
+        Err(e) => {}
+    }
+}
+"#,
+    );
+    let ret = enum_in_place(&return_drops(&p, "main"));
+    assert_eq!(
+        ret.len(),
+        1,
+        "a let-bound Result<bytes, string> whose payload is only borrowed by \
+         .len() must keep its EnumInPlace Return drop; got {ret:?}"
+    );
+}
+
+/// Negative control — no second owner. A let-bound scrutinee already owns its
+/// slot; the from-call registration must not mint a second owner over the same
+/// local (two admitted owners over one slot would double-free). Exactly one
+/// `EnumInPlace` drop may appear on the Return plan.
+#[test]
+fn letbound_scrutinee_gains_no_second_enum_in_place_owner() {
+    let p = pipeline_with_tc(
+        r#"
+fn f() -> Result<string, string> {
+    Ok("payload".to_upper())
+}
+
+fn main() {
+    let r = f();
+    match r {
+        Ok(b) => { let n = b.len(); }
+        Err(e) => {}
+    }
+}
+"#,
+    );
+    let ret = enum_in_place(&return_drops(&p, "main"));
+    assert_eq!(
+        ret.len(),
+        1,
+        "a let-bound scrutinee owns its slot exactly once; a second EnumInPlace \
+         entry means the from-call registration double-registered; got {ret:?}"
+    );
+}
+
+/// Negative control — escaping payload stays fail-closed. When the arm moves
+/// the payload into an outer binding that survives the loop back-edge, the
+/// composite must stay EXCLUDED from the per-iteration release (freeing it
+/// would leave the outer binding dangling — the #2384 class). Leak, never
+/// double-free.
+#[test]
+fn escaping_payload_keeps_composite_excluded_from_backedge_drop() {
+    let p = pipeline_with_tc(
+        r#"
+fn f() -> Result<string, string> {
+    Ok("payload".to_upper())
+}
+
+fn main() {
+    var carry = "";
+    var i = 0;
+    while i < 5 {
+        match f() {
+            Ok(b) => { carry = b; }
+            Err(e) => {}
+        }
+        i = i + 1;
+    }
+    let n = carry.len();
+}
+"#,
+    );
+    let all = enum_in_place(&all_exit_drops(&p, "main"));
+    assert!(
+        all.is_empty(),
+        "a payload moved to an outer surviving binding escapes the composite; \
+         the prover must keep the scrutinee excluded on every plan \
+         (leak-not-double-free); got {all:?}"
+    );
+}

--- a/std/net/tls/tls.hew
+++ b/std/net/tls/tls.hew
@@ -52,7 +52,7 @@ const TLS_STATUS_TLS_ERROR: i32 = 2;
 
 const TLS_STATUS_IO_ERROR: i32 = 3;
 
-fn tls_error_from_status(status: i32, _message: string) -> net.NetError { // INTERNAL-ABI: TLS FFI bridge reports a small status enum plus thread-local last_error
+fn tls_error_from_status(status: i32) -> net.NetError { // INTERNAL-ABI: TLS FFI bridge reports a small status enum; detail stays in last_error()
     if status == TLS_STATUS_RETRYABLE {
         NetError::TimedOut(0)
     } else {
@@ -64,7 +64,7 @@ fn tls_write_result(raw: TlsWriteFfiResult) -> Result<i64, net.NetError> { // IN
     if raw.status == TLS_STATUS_SUCCESS {
         Ok(raw.written as i64)
     } else {
-        Err(tls_error_from_status(raw.status, last_error()))
+        Err(tls_error_from_status(raw.status))
     }
 }
 
@@ -72,7 +72,7 @@ fn tls_read_result(raw: TlsReadFfiResult) -> Result<bytes, net.NetError> { // IN
     if raw.status == TLS_STATUS_SUCCESS {
         Ok(raw.data)
     } else {
-        Err(tls_error_from_status(raw.status, last_error()))
+        Err(tls_error_from_status(raw.status))
     }
 }
 
@@ -251,7 +251,7 @@ extern "C" {
 // module-private and therefore only reachable from an inline test here.
 #[test]
 fn tls_error_from_status_retryable_maps_to_timed_out() {
-    assert(tls_error_from_status(TLS_STATUS_RETRYABLE, "") == NetError::TimedOut(0));
+    assert(tls_error_from_status(TLS_STATUS_RETRYABLE) == NetError::TimedOut(0));
 }
 
 #[test]
@@ -261,7 +261,7 @@ fn tls_error_from_status_success_never_reached_maps_like_other() {
     // function itself has no dedicated arm for it, so it falls into the
     // same `else` branch as TLS_ERROR/IO_ERROR. Pinned here so a stray
     // caller passing SUCCESS gets the current (non-crashing) behavior.
-    assert(tls_error_from_status(TLS_STATUS_SUCCESS, "") == NetError::Other(0));
+    assert(tls_error_from_status(TLS_STATUS_SUCCESS) == NetError::Other(0));
 }
 
 #[test]
@@ -272,8 +272,8 @@ fn tls_error_from_status_tls_error_and_io_error_currently_collapse() {
     // TLS-protocol failure from a plain I/O failure. This test pins that
     // collapse as current, deliberate behavior; changing the mapping is a
     // separate product decision, not something to do incidentally here.
-    let tls_error = tls_error_from_status(TLS_STATUS_TLS_ERROR, "");
-    let io_error = tls_error_from_status(TLS_STATUS_IO_ERROR, "");
+    let tls_error = tls_error_from_status(TLS_STATUS_TLS_ERROR);
+    let io_error = tls_error_from_status(TLS_STATUS_IO_ERROR);
     assert(tls_error == NetError::Other(0));
     assert(io_error == NetError::Other(0));
     assert(tls_error == io_error);

--- a/tests/vertical-slice/accept/enum_payload_call_loop_release.expected
+++ b/tests/vertical-slice/accept/enum_payload_call_loop_release.expected
@@ -1,0 +1,4 @@
+bytes=35
+mixed=36033
+composite=6
+breakcont=4

--- a/tests/vertical-slice/accept/enum_payload_call_loop_release.hew
+++ b/tests/vertical-slice/accept/enum_payload_call_loop_release.hew
@@ -1,0 +1,97 @@
+// A match-arm-destructured payload from a called function is released
+// exactly once per iteration across loop back-edges (#2429). The scrutinee
+// is the CALL RESULT itself (no `let`), the shape every read-style API loop
+// takes: `while … { match f() { Ok(b) => …, Err(e) => … } }`.
+//
+// Output teeth: every payload is read back before its release (a
+// use-after-free garbles the totals; a double-free aborts), Ok and Err arms
+// are both taken, and break/continue exercise the loop-exit edges.
+
+type Row {
+    name: string;
+    id: i64;
+}
+
+fn ok_bytes(n: i64) -> Result<bytes, string> {
+    if n >= 0 {
+        Ok("payload".to_bytes())
+    } else {
+        Err("negative".to_upper())
+    }
+}
+
+fn mixed(n: i64) -> Result<string, string> {
+    if n % 2 == 0 {
+        Ok("even-payload".to_upper())
+    } else {
+        Err("odd-payload".to_upper())
+    }
+}
+
+fn ok_row(n: i64) -> Result<Row, string> {
+    Ok(Row { name: "row-payload".to_upper(), id: n })
+}
+
+fn bytes_loop() -> i64 {
+    var total = 0;
+    var i = 0;
+    while i < 5 {
+        match ok_bytes(i) {
+            Ok(b) => { total = total + b.len(); }
+            Err(e) => { total = total - e.len(); }
+        }
+        i = i + 1;
+    }
+    total
+}
+
+fn mixed_arms_loop() -> i64 {
+    var oks = 0;
+    var errs = 0;
+    var i = 0;
+    while i < 6 {
+        match mixed(i) {
+            Ok(s) => { oks = oks + s.len(); }
+            Err(e) => { errs = errs + e.len(); }
+        }
+        i = i + 1;
+    }
+    oks * 1000 + errs
+}
+
+fn composite_loop() -> i64 {
+    var total = 0;
+    var i = 0;
+    while i < 4 {
+        match ok_row(i) {
+            Ok(r) => { total = total + r.id; }
+            Err(e) => {}
+        }
+        i = i + 1;
+    }
+    total
+}
+
+fn break_continue_loop() -> i64 {
+    var seen = 0;
+    var i = 0;
+    while i < 10 {
+        i = i + 1;
+        match ok_bytes(i) {
+            Ok(b) => {
+                if b.len() == 7 && i == 3 { continue; }
+                if i >= 6 { break; }
+                seen = seen + 1;
+            }
+            Err(e) => {}
+        }
+    }
+    seen
+}
+
+fn main() {
+    println(f"bytes={bytes_loop()}");
+    println(f"mixed={mixed_arms_loop()}");
+    println(f"composite={composite_loop()}");
+    println(f"breakcont={break_continue_loop()}");
+}

--- a/tests/vertical-slice/accept/enum_payload_call_loop_release.hew
+++ b/tests/vertical-slice/accept/enum_payload_call_loop_release.hew
@@ -6,7 +6,6 @@
 // Output teeth: every payload is read back before its release (a
 // use-after-free garbles the totals; a double-free aborts), Ok and Err arms
 // are both taken, and break/continue exercise the loop-exit edges.
-
 type Row {
     name: string;
     id: i64;
@@ -37,8 +36,12 @@ fn bytes_loop() -> i64 {
     var i = 0;
     while i < 5 {
         match ok_bytes(i) {
-            Ok(b) => { total = total + b.len(); }
-            Err(e) => { total = total - e.len(); }
+            Ok(b) => {
+                total = total + b.len();
+            },
+            Err(e) => {
+                total = total - e.len();
+            },
         }
         i = i + 1;
     }
@@ -51,8 +54,12 @@ fn mixed_arms_loop() -> i64 {
     var i = 0;
     while i < 6 {
         match mixed(i) {
-            Ok(s) => { oks = oks + s.len(); }
-            Err(e) => { errs = errs + e.len(); }
+            Ok(s) => {
+                oks = oks + s.len();
+            },
+            Err(e) => {
+                errs = errs + e.len();
+            },
         }
         i = i + 1;
     }
@@ -64,8 +71,10 @@ fn composite_loop() -> i64 {
     var i = 0;
     while i < 4 {
         match ok_row(i) {
-            Ok(r) => { total = total + r.id; }
-            Err(e) => {}
+            Ok(r) => {
+                total = total + r.id;
+            },
+            Err(e) => {},
         }
         i = i + 1;
     }
@@ -79,11 +88,15 @@ fn break_continue_loop() -> i64 {
         i = i + 1;
         match ok_bytes(i) {
             Ok(b) => {
-                if b.len() == 7 && i == 3 { continue; }
-                if i >= 6 { break; }
+                if b.len() == 7 && i == 3 {
+                    continue;
+                }
+                if i >= 6 {
+                    break;
+                }
                 seen = seen + 1;
-            }
-            Err(e) => {}
+            },
+            Err(e) => {},
         }
     }
     seen

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1548,6 +1548,7 @@ run_accept_expect_stdout "owned_nested_tuple_return_drop"
 run_accept_expect_stdout "owned_nested_tuple_clone"
 run_accept_expect_stdout "owned_nested_tuple_bytes"
 run_accept_expect_stdout "owned_nested_tuple_record"
+run_accept_expect_stdout "enum_payload_call_loop_release"
 run_accept_expect_stdout "match_float_literal_arm"
 # match result type is inferred from the non-diverging arm; a return-only arm
 # (typed Unit by lower_block) must not set the match result type.


### PR DESCRIPTION
## Summary

Matching on a function call result directly (`match f() { Ok(b) => ... }`) leaked the matched enum's payload on every loop back-edge, and also on the single-call straight-line path. The scrutinee temporary produced by the call had no owning binding, so the drop-plan builder had nothing to attach a release to — `drop_plans` for that temp were always `(none)`, and the emitted IR had zero release calls for it.

The fix mints a synthetic owned MIR binding for from-call match scrutinees so they route through the same let-bound drop discipline that already handles `let x = f(); match x { ... }`. Alongside that:

- Extends the bytes receiver-read borrow-safety classification so `hew_bytes_*` in-place mutation calls (`push`/`pop`/`set`/`clear`) are correctly recognized as not escaping the receiver, matching the existing precedent for `Vec`/`HashMap`/`HashSet`.
- Adds a codegen guard against enum-clone synthesis for `IoHandle`-payload variants (defense in depth for a path that should be unreachable — clones of such payloads are already rejected at type-check).
- Fixes the TLS FFI bridge (`std/net/tls/tls.hew`) to stop materializing `last_error()` into a parameter that was already discarded (`_message`) on every read/write error path.
- Re-blesses one golden MIR fixture (`stream_pipe_send_recv.elab.mir`) whose drop plan gained the same admitted-composite release class this fix introduces.

## Verification

- `make test-lane CRATE=hew-mir`: 899/899 pass
- `make test-lane CRATE=hew-codegen-rs`: 541/541 pass
- `make test-lane CRATE=hew-runtime`: 2484/2484 pass (6 skipped)
- `bash tests/vertical-slice/run.sh`: 427 PASS, including new `enum_payload_call_loop_release` fixture
- `make test-hew-ratchet`: 0 expected / 0 actual
- `make checked-mir-verify`: 39 fixtures × 2 stages byte-identical (one intentional re-bless, verified hunk-by-hunk)
- `make hew-check-all`, `make lint`, `cargo fmt --check`, `hew fmt --check`: all clean
- `make ci-preflight`: full comprehensive lane green (fmt, lint, playground-check, test, vertical-slice, pkg-import, fuzz-oracle, ratchet, O2 differential, stdlib-ratchet, doc-examples, sandbox-parity, checked-mir-verify, hew-check-all, stdlib-lint)
- Leak verification: repro from #2429, single-call, let-bound single/loop (bytes + string), unused binder, break/continue/early-return, composite payload, `Err`-arm heap payload, and a looped offline `tls.read()` shape all confirmed 0/0 leaks at both O0 and O2, with `MallocScribble`/`PreScribble`/`GuardMalloc` clean across repeated runs
- Adversarially probed: synthetic-binding id collision, suspend-exit/actor-park interaction, nested from-call matches (LIFO release order confirmed), and return-escaping payloads (correctly excluded from release since ownership transfers to the return value)

## Out of scope

- `while let Ok(b) = f() { ... }` uses a different lowering path (scrutinee re-evaluated in the loop header, not the body scope) and still leaks — unaffected by this fix, tracked separately.
- The `b.to_string()` / `f"x{i}".to_bytes()` rvalue-temp-consumed-as-call-arg leak class in `stream_pipe_send_recv` is a different leak signature, not addressed here.
- Record clone synthesis with unclonable `IoHandle` fields still fails closed at compile time (pre-existing behavior); this PR extends the analogous enum guard only, since no gate required the record case.

Fixes #2429