### PR TITLE
fix(mir): drop conditionally-moved collection locals exactly once at scope exit

### DIFF
--- a/hew-cli/tests/conditional_move_drop_leak_oracle.rs
+++ b/hew-cli/tests/conditional_move_drop_leak_oracle.rs
@@ -1,0 +1,358 @@
+//! Conditionally-moved collection locals — leak-slope oracles plus
+//! poisoned-allocator exactly-once pins (#2418).
+//!
+//! Empirical oracle for the conditional-move leak class: an owned collection
+//! local moved out on only SOME control-flow paths (`let xs = make(); if take
+//! { let ys = xs; }`) was retracted from the scope-exit set at its consume
+//! site path-insensitively, so the NOT-moved path leaked the value at return
+//! (2 nodes / 176 B per small `Vec`). The fix keeps the registration behind a
+//! path-sensitive runtime drop-flag (`hew-mir/src/lower.rs`,
+//! `collection_drop_flags`): the not-moved path releases at scope exit, the
+//! moved path skips — an unguarded release there would double-free, because
+//! the whole-value move does not null the source slot.
+//!
+//! ## Slope methodology
+//!
+//! Shared harness (`support::leak_slope`): compile the same shape at LOW and
+//! HIGH iteration counts, measure leak NODE counts under `leaks --atExit`
+//! with the poisoned-allocator triple, assert the delta stays within the
+//! tolerance. The pre-fix defect is PER-CALL GROWTH on the not-taken path —
+//! 2 nodes per call for `Vec<i64>`, more for `Vec<string>` — which over the
+//! 47-frame delta lands an order of magnitude above the +5 tolerance.
+//!
+//! ## Exactly-once pins
+//!
+//! The moved path must NOT double-free: the guarded scope-exit drop has to
+//! skip where the arm's owner already released. The pin binaries run every
+//! shape (taken and not-taken branches, nested joins, loop + break, the
+//! array-literal chain, `HashMap`, `Vec<string>`) to completion under
+//! `MallocScribble`/`MallocPreScribble`/`MallocGuardEdges` and must print
+//! the exact checksum — a double-free aborts (or scribbles the values)
+//! before the output completes.
+//!
+//! ## Skip behaviour
+//!
+//! Slope oracles are macOS-only (`leaks(1)`); elsewhere they log `skip:` and
+//! return. The scribble pins run on any unix host.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+// ── slope fixtures — the not-taken path leaks per call pre-fix ────────────
+
+/// `Vec<i64>` conditionally moved, branch never taken: one leaked vec per
+/// call pre-fix (the primary #2418 shape).
+fn vec_conditional_not_taken_source(frames: usize) -> String {
+    format!(
+        "fn make_vec() -> Vec<i64> {{\n\
+         \x20   let v: Vec<i64> = Vec::new();\n\
+         \x20   v.push(40);\n\
+         \x20   v.push(2);\n\
+         \x20   return v;\n\
+         }}\n\
+         \n\
+         fn probe(take: bool) -> i64 {{\n\
+         \x20   let xs = make_vec();\n\
+         \x20   var out: i64 = 1;\n\
+         \x20   if take {{\n\
+         \x20       let ys = xs;\n\
+         \x20       out = ys.len();\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + probe(false);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// `Vec<string>` variant: the guarded `hew_vec_free` must release the element
+/// copies through the runtime's `ElemKind::String` walk as well.
+fn vec_string_conditional_not_taken_source(frames: usize) -> String {
+    format!(
+        "fn make_strs() -> Vec<string> {{\n\
+         \x20   let v: Vec<string> = Vec::new();\n\
+         \x20   v.push(\"per-call-element-one\");\n\
+         \x20   v.push(\"per-call-element-two\");\n\
+         \x20   return v;\n\
+         }}\n\
+         \n\
+         fn probe(take: bool) -> i64 {{\n\
+         \x20   let xs = make_strs();\n\
+         \x20   var out: i64 = 1;\n\
+         \x20   if take {{\n\
+         \x20       let ys = xs;\n\
+         \x20       out = ys.len();\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + probe(false);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// `HashMap` handle variant — the collection-handle class rides the same
+/// drop-flag machinery.
+fn hashmap_conditional_not_taken_source(frames: usize) -> String {
+    format!(
+        "fn probe(take: bool) -> i64 {{\n\
+         \x20   let m: HashMap<string, i64> = HashMap::new();\n\
+         \x20   m.insert(\"k\", 42);\n\
+         \x20   var out: i64 = 1;\n\
+         \x20   if take {{\n\
+         \x20       let n = m;\n\
+         \x20       out = n.len();\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + probe(false);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// TAKEN path per call: the arm's owner (`ys`) releases and the guarded
+/// source drop must SKIP — a mis-gated guard shows as either a crash under
+/// the scribble pin below or, for a silently-tolerated re-free, would not
+/// leak; the slope here pins the leak direction of the taken path (the flag
+/// must not suppress the arm owner's release).
+fn vec_conditional_taken_source(frames: usize) -> String {
+    format!(
+        "fn make_vec() -> Vec<i64> {{\n\
+         \x20   let v: Vec<i64> = Vec::new();\n\
+         \x20   v.push(40);\n\
+         \x20   v.push(2);\n\
+         \x20   return v;\n\
+         }}\n\
+         \n\
+         fn probe(take: bool) -> i64 {{\n\
+         \x20   let xs = make_vec();\n\
+         \x20   var out: i64 = 1;\n\
+         \x20   if take {{\n\
+         \x20       let ys = xs;\n\
+         \x20       out = ys.len();\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + probe(true);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+// ── exactly-once pin — every shape, both branches, poisoned allocator ─────
+
+/// Every fixed shape in one binary: repro both branches, nested joins,
+/// conditional move in a loop with break (taken and never-taken), the
+/// array-literal hand-off chain, `HashMap`, and `Vec<string>`. Expected
+/// output is the concatenated per-shape checksums + `OK`.
+const EXACTLY_ONCE_PIN_SOURCE: &str = "\
+fn make_vec() -> Vec<i64> {\n\
+\x20   let v: Vec<i64> = Vec::new();\n\
+\x20   v.push(40);\n\
+\x20   v.push(2);\n\
+\x20   return v;\n\
+}\n\
+\n\
+fn make_strs() -> Vec<string> {\n\
+\x20   let v: Vec<string> = Vec::new();\n\
+\x20   v.push(\"alpha\");\n\
+\x20   v.push(\"beta\");\n\
+\x20   return v;\n\
+}\n\
+\n\
+fn cond_move(take: bool) -> i64 {\n\
+\x20   let xs = make_vec();\n\
+\x20   var out: i64 = 0;\n\
+\x20   if take {\n\
+\x20       let ys = xs;\n\
+\x20       out = ys.len();\n\
+\x20   }\n\
+\x20   out\n\
+}\n\
+\n\
+fn nested(a: bool, b: bool) -> i64 {\n\
+\x20   let xs = make_vec();\n\
+\x20   var out: i64 = 0;\n\
+\x20   if a {\n\
+\x20       if b {\n\
+\x20           let ys = xs;\n\
+\x20           out = out + ys.len();\n\
+\x20       }\n\
+\x20       out = out + 1;\n\
+\x20   }\n\
+\x20   out\n\
+}\n\
+\n\
+fn loop_move(limit: i64) -> i64 {\n\
+\x20   let xs = make_vec();\n\
+\x20   var hits: i64 = 0;\n\
+\x20   for i in 0..4 {\n\
+\x20       if i == limit {\n\
+\x20           let ys = xs;\n\
+\x20           hits = hits + ys.len();\n\
+\x20           break;\n\
+\x20       }\n\
+\x20       hits = hits + 1;\n\
+\x20   }\n\
+\x20   hits\n\
+}\n\
+\n\
+fn array_chain(take: bool) -> i64 {\n\
+\x20   let v: Vec<i64> = [7, 8, 9];\n\
+\x20   var out: i64 = 1;\n\
+\x20   if take {\n\
+\x20       let w = v;\n\
+\x20       out = w.len();\n\
+\x20   }\n\
+\x20   out\n\
+}\n\
+\n\
+fn map_move(take: bool) -> i64 {\n\
+\x20   let m: HashMap<string, i64> = HashMap::new();\n\
+\x20   m.insert(\"k\", 42);\n\
+\x20   var out: i64 = 2;\n\
+\x20   if take {\n\
+\x20       let n = m;\n\
+\x20       out = n.len();\n\
+\x20   }\n\
+\x20   out\n\
+}\n\
+\n\
+fn strs_move(take: bool) -> i64 {\n\
+\x20   let xs = make_strs();\n\
+\x20   var out: i64 = 3;\n\
+\x20   if take {\n\
+\x20       let ys = xs;\n\
+\x20       out = ys.len();\n\
+\x20   }\n\
+\x20   out\n\
+}\n\
+\n\
+fn main() {\n\
+\x20   print(cond_move(false));\n\
+\x20   print(cond_move(true));\n\
+\x20   print(nested(false, false));\n\
+\x20   print(nested(true, false));\n\
+\x20   print(nested(true, true));\n\
+\x20   print(loop_move(2));\n\
+\x20   print(loop_move(9));\n\
+\x20   print(array_chain(false));\n\
+\x20   print(array_chain(true));\n\
+\x20   print(map_move(false));\n\
+\x20   print(map_move(true));\n\
+\x20   print(strs_move(false));\n\
+\x20   print(strs_move(true));\n\
+\x20   print(\"OK\");\n\
+}\n";
+
+/// The concatenated `print` output of [`EXACTLY_ONCE_PIN_SOURCE`]:
+/// `cond_move` 0,2 · `nested` 0,1,3 · `loop_move` 4,4 · `array_chain` 1,3 ·
+/// `map_move` 2,1 · `strs_move` 3,2 · OK.
+const EXACTLY_ONCE_PIN_EXPECTED: &str = "0201344132132OK";
+
+// ── oracles ───────────────────────────────────────────────────────────────
+
+/// Not-taken conditional move of a `Vec<i64>` must not leak per call.
+/// Pre-fix slope is 2 nodes/call (handle + buffer, never registered for the
+/// scope-exit drop); post-fix the guarded drop releases each call's vec.
+#[test]
+fn vec_conditional_move_not_taken_no_per_call_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "vec_conditional_not_taken",
+        vec_conditional_not_taken_source,
+    );
+}
+
+/// `Vec<string>` variant: the guarded free must walk the string elements.
+#[test]
+fn vec_string_conditional_move_not_taken_no_per_call_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "vec_string_conditional_not_taken",
+        vec_string_conditional_not_taken_source,
+    );
+}
+
+/// `HashMap` handle variant of the not-taken conditional move.
+#[test]
+fn hashmap_conditional_move_not_taken_no_per_call_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "hashmap_conditional_not_taken",
+        hashmap_conditional_not_taken_source,
+    );
+}
+
+/// Taken path: the arm owner's release must keep firing (the guard gates
+/// only the source's scope-exit drop, never the destination's).
+#[test]
+fn vec_conditional_move_taken_no_per_call_leak_slope() {
+    assert_frame_slope_below_tolerance("vec_conditional_taken", vec_conditional_taken_source);
+}
+
+/// Exactly-once pin: every shape (both branches) runs to completion under
+/// the poisoned-allocator triple and prints the exact checksums. A
+/// double-free — the guarded source drop firing on the moved path, or the
+/// dedup admitting two owners over one handle — aborts or scribbles the
+/// output before `OK`.
+#[test]
+fn conditional_move_shapes_run_clean_under_malloc_scribble() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("conditional-move-pin-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(EXACTLY_ONCE_PIN_SOURCE, dir.path(), "exactly_once_pin");
+
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "conditional-move shapes must run clean under the poisoned allocator \
+         — a crash indicates the guarded scope-exit drop fired on the moved \
+         path (double free);\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        EXACTLY_ONCE_PIN_EXPECTED,
+        "conditional-move shapes must print the exact checksums — a \
+         scribbled value indicates a freed handle was still read;\n{}",
+        describe_output(&output)
+    );
+}

--- a/hew-cli/tests/conditional_move_drop_leak_oracle.rs
+++ b/hew-cli/tests/conditional_move_drop_leak_oracle.rs
@@ -175,6 +175,49 @@ fn vec_conditional_taken_source(frames: usize) -> String {
     )
 }
 
+/// Two destinations on mutually-exclusive branches (`if a { let y = xs; }
+/// else if b { let z = xs; }`), NEITHER taken per call: the fan-out collapse
+/// must not conflate exclusive branch destinations with a parallel fan-out
+/// and strip the guarded source's release — the shape that leaked on every
+/// path before the CFG-exclusivity rule. (A genuinely-parallel fan-out —
+/// both destinations on ONE path — cannot be written in source: the
+/// move-checker rejects the second consume with `UseAfterConsume`. Its
+/// fail-closed strip is pinned at the seam by the
+/// `dedup_fanout_exclusivity_tests` unit tests in `hew-mir`.)
+fn vec_double_destination_not_taken_source(frames: usize) -> String {
+    format!(
+        "fn make_vec() -> Vec<i64> {{\n\
+         \x20   let v: Vec<i64> = Vec::new();\n\
+         \x20   v.push(40);\n\
+         \x20   v.push(2);\n\
+         \x20   return v;\n\
+         }}\n\
+         \n\
+         fn probe(a: bool, b: bool) -> i64 {{\n\
+         \x20   let xs = make_vec();\n\
+         \x20   var out: i64 = 1;\n\
+         \x20   if a {{\n\
+         \x20       let y = xs;\n\
+         \x20       out = y.len();\n\
+         \x20   }} else if b {{\n\
+         \x20       let z = xs;\n\
+         \x20       out = z.len() + 100;\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + probe(false, false);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
 // ── exactly-once pin — every shape, both branches, poisoned allocator ─────
 
 /// Every fixed shape in one binary: repro both branches, nested joins,
@@ -264,6 +307,51 @@ fn strs_move(take: bool) -> i64 {\n\
 \x20   out\n\
 }\n\
 \n\
+record Crate {\n\
+\x20   items: Vec<i64>,\n\
+}\n\
+\n\
+fn double_dest(a: bool, b: bool) -> i64 {\n\
+\x20   let xs = make_vec();\n\
+\x20   var out: i64 = 0;\n\
+\x20   if a {\n\
+\x20       let y = xs;\n\
+\x20       out = y.len();\n\
+\x20   } else if b {\n\
+\x20       let z = xs;\n\
+\x20       out = z.len() + 100;\n\
+\x20   } else {\n\
+\x20       out = 999;\n\
+\x20   }\n\
+\x20   out\n\
+}\n\
+\n\
+fn both_arms(c: bool) -> i64 {\n\
+\x20   let xs = make_vec();\n\
+\x20   if c {\n\
+\x20       let a = xs;\n\
+\x20       return a.len();\n\
+\x20   } else {\n\
+\x20       let b = xs;\n\
+\x20       return b.len() + 10;\n\
+\x20   }\n\
+}\n\
+\n\
+fn mixed_ingress(a: bool, b: bool) -> i64 {\n\
+\x20   let xs = make_vec();\n\
+\x20   var out: i64 = 0;\n\
+\x20   if a {\n\
+\x20       let y = xs;\n\
+\x20       out = y.len();\n\
+\x20   } else if b {\n\
+\x20       let h = Crate { items: xs };\n\
+\x20       out = h.items.len() + 100;\n\
+\x20   } else {\n\
+\x20       out = 999;\n\
+\x20   }\n\
+\x20   out\n\
+}\n\
+\n\
 fn main() {\n\
 \x20   print(cond_move(false));\n\
 \x20   print(cond_move(true));\n\
@@ -278,13 +366,22 @@ fn main() {\n\
 \x20   print(map_move(true));\n\
 \x20   print(strs_move(false));\n\
 \x20   print(strs_move(true));\n\
+\x20   print(double_dest(true, false));\n\
+\x20   print(double_dest(false, true));\n\
+\x20   print(double_dest(false, false));\n\
+\x20   print(both_arms(true));\n\
+\x20   print(both_arms(false));\n\
+\x20   print(mixed_ingress(true, false));\n\
+\x20   print(mixed_ingress(false, true));\n\
+\x20   print(mixed_ingress(false, false));\n\
 \x20   print(\"OK\");\n\
 }\n";
 
 /// The concatenated `print` output of [`EXACTLY_ONCE_PIN_SOURCE`]:
 /// `cond_move` 0,2 · `nested` 0,1,3 · `loop_move` 4,4 · `array_chain` 1,3 ·
-/// `map_move` 2,1 · `strs_move` 3,2 · OK.
-const EXACTLY_ONCE_PIN_EXPECTED: &str = "0201344132132OK";
+/// `map_move` 2,1 · `strs_move` 3,2 · `double_dest` 2,102,999 ·
+/// `both_arms` 2,12 · `mixed_ingress` 2,102,999 · OK.
+const EXACTLY_ONCE_PIN_EXPECTED: &str = "020134413213221029992122102999OK";
 
 // ── oracles ───────────────────────────────────────────────────────────────
 
@@ -322,6 +419,18 @@ fn hashmap_conditional_move_not_taken_no_per_call_leak_slope() {
 #[test]
 fn vec_conditional_move_taken_no_per_call_leak_slope() {
     assert_frame_slope_below_tolerance("vec_conditional_taken", vec_conditional_taken_source);
+}
+
+/// Two exclusive destinations, neither taken per call: the guarded source's
+/// scope-exit release must survive the fan-out collapse (the CFG-exclusivity
+/// rule). The pre-rule behaviour stripped the whole component and leaked 2
+/// nodes/call on every path.
+#[test]
+fn vec_double_destination_not_taken_no_per_call_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "vec_double_destination_not_taken",
+        vec_double_destination_not_taken_source,
+    );
 }
 
 /// Exactly-once pin: every shape (both branches) runs to completion under

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -9948,6 +9948,32 @@ struct Builder {
     /// record/string locals are released through the `elaborate` allow-set
     /// prover (`CowValue` arm), not `owned_locals` / this flag.
     overwrite_guard_flags: HashMap<BindingId, Place>,
+    /// #2418: runtime drop-flags for an owned collection local (owned-element
+    /// `Vec`, plain `Vec`, `HashMap`/`HashSet` handle) that the pre-pass saw
+    /// genuinely consumed (`intent=Consume`, a move-out such as `let ys = xs`)
+    /// somewhere in the body. The legacy path-insensitive `mark_binding_moved`
+    /// retraction at the consume site removed the binding from the scope-exit
+    /// set entirely, so a binding moved out on only SOME control-flow paths
+    /// (`MaybeConsumed` at the converging join) leaked on the not-moved path —
+    /// the whole-value `Move` lowering does NOT null the source slot, so the
+    /// moved path cannot be discriminated statically at a shared exit.
+    ///
+    /// A flagged binding is KEPT in `owned_locals` at its consume sites
+    /// (mirroring the #1933 `resource_drop_flags` discipline): the flag is an
+    /// `i64` local zero-initialised at the binding's `let` (dominating every
+    /// consume, including loop back-edges) and set to 1 at each consume-use.
+    /// `build_lifo_drops` attaches it as the [`ElabDrop::guard`], so codegen
+    /// gates the release on `flag == 0` — exactly once on a `MaybeConsumed`
+    /// join: skipped where the value moved to a new owner, fired where it is
+    /// still owned. The per-exit `drops_for_exit` dataflow filter still
+    /// excludes exits where the binding is `Consumed` on every reaching path.
+    ///
+    /// Mutually exclusive with `overwrite_guard_flags` (a mutable binding both
+    /// consumed and reassigned keeps the #2301 overwrite path and today's
+    /// scope-exit retraction — fail-closed, no flag interplay). Bindings
+    /// outside the collection classes keep the legacy retraction (leak on the
+    /// not-moved path, never double-free).
+    collection_drop_flags: HashMap<BindingId, Place>,
     /// #2301 per-function pre-pass scratch: `BindingId`s used with
     /// `intent=Consume` anywhere in the body. Populated by
     /// `collect_vec_owned_element_keys_from_expr` before lowering; intersected
@@ -13466,6 +13492,11 @@ impl Builder {
                 // other binding class (see `resource_needs_drop_flag`).
                 self.maybe_alloc_resource_drop_flag(binding.id, &binding_ty);
                 self.maybe_alloc_overwrite_guard_flag(binding);
+                // #2418 — allocate the path-sensitive scope-exit drop-flag for
+                // an owned collection local the pre-pass saw consumed, so a
+                // conditional move keeps its (flag-gated) scope-exit release
+                // on the not-moved path instead of retracting it entirely.
+                self.maybe_alloc_collection_drop_flag(binding, &binding_ty);
             }
             HirStmtKind::Let(_, None) => {}
             HirStmtKind::Expr(expr) => {
@@ -14296,6 +14327,21 @@ impl Builder {
                         // other consumed owned class keeps the legacy
                         // path-insensitive `owned_locals` removal.
                         if let Some(flag) = self.resource_drop_flags.get(id).copied() {
+                            self.instructions.push(Instr::ConstI64 {
+                                dest: flag,
+                                value: 1,
+                            });
+                        } else if let Some(flag) = self.collection_drop_flags.get(id).copied() {
+                            // #2418 — an owned collection local with a
+                            // path-sensitive drop-flag is KEPT in
+                            // `owned_locals` so a conditional move drops the
+                            // value exactly once: mark the flag consumed
+                            // (set 1) so codegen's `flag == 0` gate skips the
+                            // now-moved-out release on this path, while the
+                            // not-moved path keeps `flag == 0` and releases at
+                            // scope exit. The dataflow's own `Use{Consume}`
+                            // transition still drives the move-checker and the
+                            // per-exit `BindingState` narrowing.
                             self.instructions.push(Instr::ConstI64 {
                                 dest: flag,
                                 value: 1,
@@ -33145,6 +33191,55 @@ impl Builder {
         self.overwrite_guard_flags.insert(binding.id, flag);
     }
 
+    /// #2418 -- allocate a zero-init path-sensitive scope-exit drop-flag for an
+    /// owned collection local (owned-element `Vec`, plain `Vec`,
+    /// `HashMap`/`HashSet` handle) the pre-pass saw consumed somewhere in the
+    /// body. The flag keeps the binding on the scope-exit set at its consume
+    /// sites (see `collection_drop_flags`), so a conditional move (`if take {
+    /// let ys = xs; }`) releases the value exactly once: the runtime gate
+    /// skips the moved path, the not-moved path fires the release.
+    ///
+    /// Restricted to the collection classes whose releases are null-tolerant
+    /// runtime frees and whose allow-set provers ride the
+    /// `derive_local_collection_drop_allowed` escape scan; every other owned
+    /// class keeps the legacy path-insensitive retraction (fail-closed: leak
+    /// on the not-moved path, never a double-free). A mutable binding that is
+    /// also reassigned takes the #2301 `overwrite_guard_flags` path instead —
+    /// the two flag families never share a binding, so the overwrite reset
+    /// discipline cannot re-arm a scope-exit drop this flag suppressed.
+    /// Zero-init at the `let` so the flag dominates every consume site,
+    /// including loop back-edges (a per-iteration `let` re-zeros it).
+    fn maybe_alloc_collection_drop_flag(&mut self, binding: &HirBinding, ty: &ResolvedTy) {
+        if !self.prepass_consumed_bindings.contains(&binding.id) {
+            return;
+        }
+        if binding.mutable && self.prepass_reassigned_bindings.contains(&binding.id) {
+            return;
+        }
+        if !(self.binding_ty_is_owned_element_vec(ty)
+            || self.binding_ty_is_plain_vec(ty)
+            || ty_is_local_collection_handle(ty))
+        {
+            return;
+        }
+        if !self
+            .owned_locals
+            .iter()
+            .any(|entry| entry.binding == binding.id && entry.disposition == Disposition::ScopeExit)
+        {
+            return;
+        }
+        if self.collection_drop_flags.contains_key(&binding.id) {
+            return;
+        }
+        let flag = self.alloc_local(ResolvedTy::I64);
+        self.instructions.push(Instr::ConstI64 {
+            dest: flag,
+            value: 0,
+        });
+        self.collection_drop_flags.insert(binding.id, flag);
+    }
+
     /// #2301 -- emit `if flag == 0 { <release old value of `dest`> }` as a CFG
     /// diamond, then leave the cursor at the continuation block so the caller's
     /// `Move` (store of the fresh value) and the `flag = 0` reset land there.
@@ -34291,12 +34386,19 @@ fn elaborate(
         &builder.binding_locals,
         |ty| builder.binding_ty_is_owned_element_vec(ty),
     );
+    // #2418 — a binding carrying a path-sensitive collection drop-flag is
+    // exempt from the consume-exit removal: its scope-exit release is gated on
+    // `flag == 0` at runtime (skipped on the moved path, fired on the
+    // not-moved path), and the per-exit `drops_for_exit` state filter still
+    // excludes exits reached only through the consume. Unflagged bindings keep
+    // the removal (fail-closed).
     for states in dataflow_result.exit_states.values() {
         for (binding, state) in states {
             if matches!(
                 state,
                 dataflow::BindingState::Consumed(_) | dataflow::BindingState::MaybeConsumed(_)
-            ) {
+            ) && !builder.collection_drop_flags.contains_key(binding)
+            {
                 owned_vec_drop_allowed.remove(binding);
             }
         }
@@ -34334,6 +34436,7 @@ fn elaborate(
         &checked.blocks,
         &builder.binding_locals,
         &mut owned_vec_drop_allowed,
+        &builder.collection_drop_flags,
     );
 
     // Local `HashMap` / `HashSet` handle scope-exit drop allow-set. A local
@@ -34356,12 +34459,16 @@ fn elaborate(
         &builder.binding_locals,
         ty_is_local_collection_handle,
     );
+    // #2418 — flagged bindings are exempt from the consume-exit removal (the
+    // runtime `flag == 0` gate discriminates the moved path); see the
+    // owned-Vec loop above.
     for states in dataflow_result.exit_states.values() {
         for (binding, state) in states {
             if matches!(
                 state,
                 dataflow::BindingState::Consumed(_) | dataflow::BindingState::MaybeConsumed(_)
-            ) {
+            ) && !builder.collection_drop_flags.contains_key(binding)
+            {
                 local_collection_drop_allowed.remove(binding);
             }
         }
@@ -34444,12 +34551,16 @@ fn elaborate(
         &builder.binding_locals,
         |ty| builder.binding_ty_is_plain_vec(ty),
     );
+    // #2418 — flagged bindings are exempt from the consume-exit removal (the
+    // runtime `flag == 0` gate discriminates the moved path); see the
+    // owned-Vec loop above.
     for states in dataflow_result.exit_states.values() {
         for (binding, state) in states {
             if matches!(
                 state,
                 dataflow::BindingState::Consumed(_) | dataflow::BindingState::MaybeConsumed(_)
-            ) {
+            ) && !builder.collection_drop_flags.contains_key(binding)
+            {
                 plain_vec_drop_allowed.remove(binding);
             }
         }
@@ -34462,11 +34573,13 @@ fn elaborate(
         &checked.blocks,
         &builder.binding_locals,
         &mut closure_vec_drop_allowed,
+        &builder.collection_drop_flags,
     );
     dedup_whole_value_handoff(
         &checked.blocks,
         &builder.binding_locals,
         &mut plain_vec_drop_allowed,
+        &builder.collection_drop_flags,
     );
 
     // Value-class capstone — owned-aggregate-record scope-exit drop allow-set.
@@ -34618,6 +34731,7 @@ fn elaborate(
         &plain_vec_drop_allowed,
         &indirect_enum_drop_allowed,
         &builder.resource_drop_flags,
+        &builder.collection_drop_flags,
     );
     let (elab_blocks, mut drop_plans) = enumerate_exits(
         &checked.blocks,
@@ -42996,6 +43110,7 @@ fn dedup_whole_value_handoff(
     blocks: &[BasicBlock],
     binding_locals: &HashMap<BindingId, Place>,
     allowed: &mut HashSet<BindingId>,
+    guarded: &HashMap<BindingId, Place>,
 ) {
     let admitted_locals: HashMap<u32, BindingId> = allowed
         .iter()
@@ -43039,7 +43154,15 @@ fn dedup_whole_value_handoff(
                 }
             }
         }
-        if handed_off {
+        if handed_off && !guarded.contains_key(start_binding) {
+            // #2418 — a source binding carrying a path-sensitive drop-flag is
+            // NOT stripped: its hand-off is a dataflow-visible consume (the
+            // flag is set 1 exactly where the move executes), so its
+            // scope-exit release already fires only on paths where the handle
+            // was never handed off. Stripping it would re-open the
+            // conditional-move leak the flag exists to close. Unguarded
+            // sources (the dataflow-invisible synthetic chains) keep the
+            // strip: the downstream owner fires the single release.
             allowed.remove(start_binding);
         }
     }
@@ -43088,7 +43211,20 @@ fn dedup_whole_value_handoff(
         component_admitted.entry(root).or_default().push(binding);
     }
     for bindings in component_admitted.values() {
-        if bindings.len() > 1 {
+        // #2418 — a flag-guarded binding (a conditional move's source) shares
+        // its component with the move's DESTINATION by construction, and the
+        // pair is exactly-once provable at runtime: the destination releases
+        // on the arm where the move executed (its own scope-close edge), the
+        // guarded source releases at scope exit only where the flag is still
+        // 0 (the not-moved path). So a component holding at most ONE
+        // unguarded member alongside guarded ones keeps every member.
+        // Components with two or more UNGUARDED members retain the fail-closed
+        // collapse — sole ownership across a dataflow-invisible fan-out is
+        // unprovable — and the collapse removes the guarded members with them
+        // (a guarded drop over an ambiguous share could still double-free on
+        // the not-moved path; leak instead, as before).
+        let unguarded = bindings.iter().filter(|b| !guarded.contains_key(b)).count();
+        if unguarded > 1 {
             for binding in bindings {
                 allowed.remove(binding);
             }
@@ -43352,6 +43488,7 @@ fn build_lifo_drops(
     plain_vec_drop_allowed: &HashSet<BindingId>,
     indirect_enum_drop_allowed: &HashSet<BindingId>,
     resource_drop_flags: &HashMap<BindingId, Place>,
+    collection_drop_flags: &HashMap<BindingId, Place>,
 ) -> Vec<ElabDrop> {
     let mut drops = Vec::new();
     for (binding, _name, ty) in owned_locals.iter().rev() {
@@ -43427,7 +43564,13 @@ fn build_lifo_drops(
                 kind: DropKind::CowHeap {
                     release: crate::ownership::CowHeapRelease::VecOwnedElement,
                 },
-                guard: None,
+                // #2418 — a conditionally-moved handle carries its
+                // path-sensitive drop-flag so the release fires exactly once:
+                // skipped where the flag reads 1 (moved out on this path),
+                // fired where it reads 0 (still owned). `None` for every
+                // unflagged binding (the common case) — byte-identical to the
+                // pre-#2418 drop.
+                guard: collection_drop_flags.get(binding).copied(),
             });
             continue;
         }
@@ -43464,7 +43607,9 @@ fn build_lifo_drops(
                 kind: DropKind::CowHeap {
                     release: crate::ownership::CowHeapRelease::VecPlain,
                 },
-                guard: None,
+                // #2418 — path-sensitive exactly-once gate for a
+                // conditionally-moved handle; see the owned-Vec arm above.
+                guard: collection_drop_flags.get(binding).copied(),
             });
             continue;
         }
@@ -43502,7 +43647,9 @@ fn build_lifo_drops(
                 ty: ty.clone(),
                 drop_fn: None,
                 kind: drop_kind_for(place, ty, None),
-                guard: None,
+                // #2418 — path-sensitive exactly-once gate for a
+                // conditionally-moved handle; see the owned-Vec arm above.
+                guard: collection_drop_flags.get(binding).copied(),
             });
             continue;
         }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -9980,6 +9980,19 @@ struct Builder {
     /// with `prepass_reassigned_bindings` + `owned_locals` membership to decide
     /// which bindings get an `overwrite_guard_flags` entry.
     prepass_consumed_bindings: HashSet<BindingId>,
+    /// #2418 per-function pre-pass scratch: `BindingId`s with a
+    /// `intent=Consume` use in any position OTHER than a direct `let`-rebind
+    /// initializer (`let y = xs;`) — a by-value call argument, an
+    /// aggregate-literal field (`Holder { items: xs }`), a `return xs`, an
+    /// assignment RHS, a match scrutinee, and every nested-expression read.
+    /// A binding in this set never gets a `collection_drop_flags` entry:
+    /// those consume shapes are owning-sink ESCAPES to the allow-set provers,
+    /// and keeping the source registered (flagged) would leave it a candidate
+    /// whose escape taints its whole whole-value alias group — excluding a
+    /// destination the unflagged (retract-at-consume) path admits. Fail
+    /// closed to the legacy retraction instead: behaviour byte-identical to
+    /// the pre-flag compiler for every non-rebind consume shape.
+    prepass_nonrebind_consumed: HashSet<BindingId>,
     /// #2301 per-function pre-pass scratch: `BindingId`s that are the target of an
     /// `Assign` (`r = <rhs>`) anywhere in the body.
     prepass_reassigned_bindings: HashSet<BindingId>,
@@ -12867,6 +12880,24 @@ impl Builder {
                         {
                             self.closure_pair_laundered_bindings.insert(binding.id);
                         }
+                        // #2418 — a DIRECT consume-rebind initializer
+                        // (`let y = xs;`) is the one consume shape the
+                        // collection drop-flag covers; record the consume
+                        // WITHOUT the non-rebind mark the general walk would
+                        // apply, replicating the walk's other effects on a
+                        // childless `BindingRef` (the type-key harvest).
+                        if let HirExprKind::BindingRef {
+                            resolved: ResolvedRef::Binding(id),
+                            ..
+                        } = &v.kind
+                        {
+                            if v.intent == IntentKind::Consume {
+                                self.prepass_consumed_bindings.insert(*id);
+                                let vty = self.subst_ty(&v.ty);
+                                self.harvest_vec_owned_element_key(&vty);
+                                continue;
+                            }
+                        }
                         self.collect_vec_owned_element_keys_from_expr(v);
                     }
                 }
@@ -12905,18 +12936,18 @@ impl Builder {
         }
     }
 
-    /// Harvest owned-Vec element keys from an expression's type and recurse into
-    /// the structural child expressions that may carry a `Vec<owned>` value.
-    /// Every visited expr contributes its own `.ty` (so a `Vec<Header>`
-    /// `BindingRef`/`Call`/`StructInit` receiver is caught); the recursion
-    /// reaches nested blocks (if/match/scope/loop bodies) where an owned-Vec
-    /// could be constructed or used.
-    fn collect_vec_owned_element_keys_from_expr(&mut self, expr: &HirExpr) {
-        // #2301 -- during this single pre-pass traversal, also harvest genuine
-        // move-out consumes (`intent=Consume` on a `BindingRef`). A binding that
-        // is BOTH consumed here and reassigned (see the `Assign` arm in
-        // `collect_vec_owned_element_keys_from_block`) gets a path-sensitive
-        // overwrite-release drop-flag at its `let`.
+    /// #2301 -- record a genuine move-out consume (`intent=Consume` on a
+    /// `BindingRef`) seen by the pre-pass walk. A binding that is BOTH
+    /// consumed and reassigned (see the `Assign` arm in
+    /// `collect_vec_owned_element_keys_from_block`) gets a path-sensitive
+    /// overwrite-release drop-flag at its `let`.
+    ///
+    /// #2418 -- every consume reached through the general expression walk is
+    /// a NON-REBIND shape (the direct `let y = xs;` initializer is
+    /// intercepted in the block walker and never recurses here), so it also
+    /// disqualifies the binding from the collection drop-flag (see
+    /// `prepass_nonrebind_consumed`).
+    fn prepass_note_nonrebind_consume(&mut self, expr: &HirExpr) {
         if expr.intent == IntentKind::Consume {
             if let HirExprKind::BindingRef {
                 resolved: ResolvedRef::Binding(id),
@@ -12924,8 +12955,19 @@ impl Builder {
             } = &expr.kind
             {
                 self.prepass_consumed_bindings.insert(*id);
+                self.prepass_nonrebind_consumed.insert(*id);
             }
         }
+    }
+
+    /// Harvest owned-Vec element keys from an expression's type and recurse into
+    /// the structural child expressions that may carry a `Vec<owned>` value.
+    /// Every visited expr contributes its own `.ty` (so a `Vec<Header>`
+    /// `BindingRef`/`Call`/`StructInit` receiver is caught); the recursion
+    /// reaches nested blocks (if/match/scope/loop bodies) where an owned-Vec
+    /// could be constructed or used.
+    fn collect_vec_owned_element_keys_from_expr(&mut self, expr: &HirExpr) {
+        self.prepass_note_nonrebind_consume(expr);
         let ty = self.subst_ty(&expr.ty);
         self.harvest_vec_owned_element_key(&ty);
         match &expr.kind {
@@ -33193,11 +33235,12 @@ impl Builder {
 
     /// #2418 -- allocate a zero-init path-sensitive scope-exit drop-flag for an
     /// owned collection local (owned-element `Vec`, plain `Vec`,
-    /// `HashMap`/`HashSet` handle) the pre-pass saw consumed somewhere in the
-    /// body. The flag keeps the binding on the scope-exit set at its consume
-    /// sites (see `collection_drop_flags`), so a conditional move (`if take {
-    /// let ys = xs; }`) releases the value exactly once: the runtime gate
-    /// skips the moved path, the not-moved path fires the release.
+    /// `HashMap`/`HashSet` handle) whose pre-pass consumes are ALL direct
+    /// `let`-rebind moves (`let ys = xs;`). The flag keeps the binding on the
+    /// scope-exit set at its consume sites (see `collection_drop_flags`), so
+    /// a conditional move (`if take { let ys = xs; }`) releases the value
+    /// exactly once: the runtime gate skips the moved path, the not-moved
+    /// path fires the release.
     ///
     /// Restricted to the collection classes whose releases are null-tolerant
     /// runtime frees and whose allow-set provers ride the
@@ -33211,6 +33254,16 @@ impl Builder {
     /// including loop back-edges (a per-iteration `let` re-zeros it).
     fn maybe_alloc_collection_drop_flag(&mut self, binding: &HirBinding, ty: &ResolvedTy) {
         if !self.prepass_consumed_bindings.contains(&binding.id) {
+            return;
+        }
+        // #2418 — any consume in a non-rebind position (call argument,
+        // aggregate-literal field, return, assignment RHS, nested read)
+        // disqualifies the flag: those shapes are owning-sink escapes to the
+        // allow-set provers, and a flagged (still-registered) source would
+        // taint its whole-value alias group where the legacy retraction lets
+        // the destination stand alone. Fail closed to the retraction —
+        // byte-identical to the pre-flag compiler for those shapes.
+        if self.prepass_nonrebind_consumed.contains(&binding.id) {
             return;
         }
         if binding.mutable && self.prepass_reassigned_bindings.contains(&binding.id) {
@@ -34379,12 +34432,19 @@ fn elaborate(
     // the prover did not clear is never double-freed
     // (`drop-allowset-from-value-flow`, `boundary-fail-closed`,
     // `raii-null-after-move`, `cleanup-all-exits`).
-    let mut owned_vec_drop_allowed = derive_local_collection_drop_allowed(
-        &checked.blocks,
-        &builder.suspend_kinds,
+    let mut owned_vec_drop_allowed = admit_with_flagged_fallback(
         &owned_locals_snapshot,
-        &builder.binding_locals,
+        &builder.collection_drop_flags,
         |ty| builder.binding_ty_is_owned_element_vec(ty),
+        |view| {
+            derive_local_collection_drop_allowed(
+                &checked.blocks,
+                &builder.suspend_kinds,
+                view,
+                &builder.binding_locals,
+                |ty| builder.binding_ty_is_owned_element_vec(ty),
+            )
+        },
     );
     // #2418 — a binding carrying a path-sensitive collection drop-flag is
     // exempt from the consume-exit removal: its scope-exit release is gated on
@@ -34452,12 +34512,19 @@ fn elaborate(
     // moved out by a by-value consume. Both directions only ever over-EXCLUDE
     // (leak), never re-admit — a handle the prover did not clear is never
     // double-freed (`boundary-fail-closed`, `cleanup-all-exits`).
-    let mut local_collection_drop_allowed = derive_local_collection_drop_allowed(
-        &checked.blocks,
-        &builder.suspend_kinds,
+    let mut local_collection_drop_allowed = admit_with_flagged_fallback(
         &owned_locals_snapshot,
-        &builder.binding_locals,
+        &builder.collection_drop_flags,
         ty_is_local_collection_handle,
+        |view| {
+            derive_local_collection_drop_allowed(
+                &checked.blocks,
+                &builder.suspend_kinds,
+                view,
+                &builder.binding_locals,
+                ty_is_local_collection_handle,
+            )
+        },
     );
     // #2418 — flagged bindings are exempt from the consume-exit removal (the
     // runtime `flag == 0` gate discriminates the moved path); see the
@@ -34544,12 +34611,19 @@ fn elaborate(
     // under the same no-retain-on-share invariant the collection handles
     // document above. An excluded handle leaks (as before this fix), never
     // double-frees (`boundary-fail-closed`, `cleanup-all-exits`).
-    let mut plain_vec_drop_allowed = derive_local_collection_drop_allowed(
-        &checked.blocks,
-        &builder.suspend_kinds,
+    let mut plain_vec_drop_allowed = admit_with_flagged_fallback(
         &owned_locals_snapshot,
-        &builder.binding_locals,
+        &builder.collection_drop_flags,
         |ty| builder.binding_ty_is_plain_vec(ty),
+        |view| {
+            derive_local_collection_drop_allowed(
+                &checked.blocks,
+                &builder.suspend_kinds,
+                view,
+                &builder.binding_locals,
+                |ty| builder.binding_ty_is_plain_vec(ty),
+            )
+        },
     );
     // #2418 — flagged bindings are exempt from the consume-exit removal (the
     // runtime `flag == 0` gate discriminates the moved path); see the
@@ -43212,24 +43286,172 @@ fn dedup_whole_value_handoff(
     }
     for bindings in component_admitted.values() {
         // #2418 — a flag-guarded binding (a conditional move's source) shares
-        // its component with the move's DESTINATION by construction, and the
-        // pair is exactly-once provable at runtime: the destination releases
-        // on the arm where the move executed (its own scope-close edge), the
-        // guarded source releases at scope exit only where the flag is still
-        // 0 (the not-moved path). So a component holding at most ONE
-        // unguarded member alongside guarded ones keeps every member.
-        // Components with two or more UNGUARDED members retain the fail-closed
-        // collapse — sole ownership across a dataflow-invisible fan-out is
-        // unprovable — and the collapse removes the guarded members with them
-        // (a guarded drop over an ambiguous share could still double-free on
-        // the not-moved path; leak instead, as before).
-        let unguarded = bindings.iter().filter(|b| !guarded.contains_key(b)).count();
-        if unguarded > 1 {
-            for binding in bindings {
-                allowed.remove(binding);
+        // its component with the move's DESTINATION(s) by construction, and
+        // the group is exactly-once provable at runtime when the destinations
+        // are on mutually-exclusive control-flow paths: each destination
+        // releases on the arm where its move executed (its own scope-close
+        // edge), the guarded source releases at scope exit only where the
+        // flag is still 0 (the not-moved path). The move-checker already
+        // rejects co-executable consume sites of one binding
+        // (`UseAfterConsume` — straight-line re-consume and loop re-consume
+        // without `break` both fail), so exclusive per-branch destinations
+        // (`if a { let y = xs; } else if b { let z = xs; }`) are the only
+        // accepted multi-destination shape — but the exclusivity is proven
+        // HERE, in the CFG (no path executes two of the destinations' bind
+        // sites), not assumed from the checker: a synthetic Move that never
+        // went through the checker gets no benefit of the doubt.
+        //
+        // So: a component containing a guarded member keeps every member iff
+        // every UNGUARDED member's bind sites are pairwise non-co-executable
+        // (`unguarded_bind_sites_pairwise_exclusive`). A genuinely-parallel
+        // fan-out — two unguarded destinations reachable on ONE path — still
+        // takes the fail-closed collapse, guarded members included (a guarded
+        // drop over an ambiguous share could double-free on the not-moved
+        // path; leak instead, as before). Guardless components keep the
+        // original >1-member collapse: sole ownership across a
+        // dataflow-invisible fan-out is unprovable.
+        let unguarded: Vec<BindingId> = bindings
+            .iter()
+            .filter(|b| !guarded.contains_key(b))
+            .copied()
+            .collect();
+        if unguarded.len() <= 1 {
+            continue;
+        }
+        let has_guarded = bindings.len() > unguarded.len();
+        if has_guarded
+            && unguarded_bind_sites_pairwise_exclusive(blocks, binding_locals, &unguarded)
+        {
+            continue;
+        }
+        for binding in bindings {
+            allowed.remove(binding);
+        }
+    }
+}
+
+/// #2418 — base-parity fallback for a flag-guarded binding the escape scan
+/// cannot admit. A flagged binding stays REGISTERED at its consume sites
+/// (that is the fix), which also keeps it a CANDIDATE in the collection
+/// escape scans — so an owning-sink read of it anywhere (an aggregate-literal
+/// ingress on one branch, a by-value call, a return) excludes not just the
+/// binding but its whole whole-value alias group, via the scan's
+/// root-resolution. The legacy retract-at-consume compiler never presented
+/// the binding as a candidate at all, so the move DESTINATION stood alone
+/// with its own root and kept its release. Reproduce exactly that outcome:
+/// re-derive the allow-set with every excluded flagged binding removed from
+/// the candidate view, to a fixpoint (each round strictly shrinks the view,
+/// and removing a candidate only removes escape notes, so admissions grow
+/// monotonically). The excluded binding itself ends unregistered — the same
+/// leak-not-double-free posture the legacy path had for that shape.
+fn admit_with_flagged_fallback<C, F>(
+    owned_locals_snapshot: &[(BindingId, String, ResolvedTy)],
+    collection_drop_flags: &HashMap<BindingId, Place>,
+    class_filter: C,
+    derive: F,
+) -> HashSet<BindingId>
+where
+    C: Fn(&ResolvedTy) -> bool,
+    F: Fn(&[(BindingId, String, ResolvedTy)]) -> HashSet<BindingId>,
+{
+    let mut view: Vec<(BindingId, String, ResolvedTy)> = owned_locals_snapshot.to_vec();
+    let mut allowed = derive(&view);
+    loop {
+        let excluded_flagged: HashSet<BindingId> = view
+            .iter()
+            .filter(|(binding, _, ty)| {
+                class_filter(ty)
+                    && collection_drop_flags.contains_key(binding)
+                    && !allowed.contains(binding)
+            })
+            .map(|(binding, _, _)| *binding)
+            .collect();
+        if excluded_flagged.is_empty() {
+            return allowed;
+        }
+        view.retain(|(binding, _, _)| !excluded_flagged.contains(binding));
+        allowed = derive(&view);
+    }
+}
+
+/// #2418 — CFG-grounded exclusivity test for the fan-out collapse in
+/// [`dedup_whole_value_handoff`]: true iff the whole-value `Move` bind sites
+/// of every binding in `unguarded` are pairwise non-co-executable, i.e. no
+/// runtime path can execute two of them. Two sites co-execute when they share
+/// a basic block, when one site's block reaches the other's, or when a site's
+/// block sits on a cycle (it could re-execute); each case is tested directly
+/// on the CFG via [`BasicBlock::successors`] reachability, so the answer is a
+/// structural fact about this function's blocks — not an inference from the
+/// move-checker's acceptance.
+///
+/// Fail-closed: a binding with no locatable bind site, an unresolvable Place,
+/// or any co-executable pair returns `false` (the caller strips the whole
+/// component — leak, never a double-free). Over-approximation direction: the
+/// reachability walk follows EVERY successor edge (`successors()` is an
+/// exhaustive match over `Terminator`), so exclusivity can only be
+/// under-reported, never over-reported.
+fn unguarded_bind_sites_pairwise_exclusive(
+    blocks: &[BasicBlock],
+    binding_locals: &HashMap<BindingId, Place>,
+    unguarded: &[BindingId],
+) -> bool {
+    let mut dest_locals: HashSet<u32> = HashSet::new();
+    for binding in unguarded {
+        let Some(local) = binding_locals.get(binding).and_then(|p| base_local(*p)) else {
+            return false;
+        };
+        dest_locals.insert(local);
+    }
+    // Every block holding a whole-value Move into one of the destinations.
+    // Two sites (same or different destinations) in one block are trivially
+    // co-executable, so a second site in a block fails immediately.
+    let mut site_blocks: Vec<u32> = Vec::new();
+    let mut located_dest_locals: HashSet<u32> = HashSet::new();
+    for block in blocks {
+        let mut block_has_site = false;
+        for instr in &block.instructions {
+            if let Instr::Move { dest, src } = instr {
+                if let (Some(dl), Some(sl)) = (base_local(*dest), base_local(*src)) {
+                    if dl != sl && dest_locals.contains(&dl) {
+                        if block_has_site {
+                            return false;
+                        }
+                        block_has_site = true;
+                        located_dest_locals.insert(dl);
+                    }
+                }
+            }
+        }
+        if block_has_site {
+            site_blocks.push(block.id);
+        }
+    }
+    // A destination the scan could not locate a bind site for cannot be
+    // proven exclusive of anything — fail closed.
+    if located_dest_locals.len() != dest_locals.len() {
+        return false;
+    }
+    // Forward reachability from each site block. A site reaching ANY site
+    // block — another's, or its own around a cycle — is co-executable.
+    let successors: HashMap<u32, Vec<u32>> =
+        blocks.iter().map(|b| (b.id, b.successors())).collect();
+    let site_set: HashSet<u32> = site_blocks.iter().copied().collect();
+    for &start in &site_blocks {
+        let mut frontier: Vec<u32> = successors.get(&start).cloned().unwrap_or_default();
+        let mut visited: HashSet<u32> = HashSet::new();
+        while let Some(cur) = frontier.pop() {
+            if !visited.insert(cur) {
+                continue;
+            }
+            if site_set.contains(&cur) {
+                return false;
+            }
+            if let Some(succs) = successors.get(&cur) {
+                frontier.extend(succs.iter().copied());
             }
         }
     }
+    true
 }
 
 /// True when `name` is an `indirect enum` registered in `enum_layouts` — the
@@ -46879,6 +47101,181 @@ mod slice3_narrowing_proptests {
             "a Consumed (moved-to-out-slot) yield value must be excluded from the \
              yield abandon plan; got {:?}",
             plans[0].1.drops,
+        );
+    }
+}
+
+// ============================================================================
+// #2418 fan-out exclusivity boundary — direct-CFG tests against
+// `dedup_whole_value_handoff`'s guarded-component collapse. Hand-constructed
+// blocks are required because the co-executable (parallel) fan-out shapes are
+// checker-rejected in source (`UseAfterConsume` on the second consume), so
+// only a synthetic Move stream can reach the boundary — which is exactly why
+// the exclusivity proof lives in the CFG walk and not in the checker's
+// acceptance.
+// ============================================================================
+
+#[cfg(test)]
+mod dedup_fanout_exclusivity_tests {
+    use super::*;
+
+    /// `BindingId(0) -> Local(10)` (the guarded source), `BindingId(1) ->
+    /// Local(11)` and `BindingId(2) -> Local(12)` (the move destinations).
+    fn locals() -> HashMap<BindingId, Place> {
+        [
+            (BindingId(0), Place::Local(10)),
+            (BindingId(1), Place::Local(11)),
+            (BindingId(2), Place::Local(12)),
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    fn all_allowed() -> HashSet<BindingId> {
+        [BindingId(0), BindingId(1), BindingId(2)]
+            .into_iter()
+            .collect()
+    }
+
+    fn guarded_source() -> HashMap<BindingId, Place> {
+        [(BindingId(0), Place::Local(90))].into_iter().collect()
+    }
+
+    fn mv(src: u32, dest: u32) -> Instr {
+        Instr::Move {
+            dest: Place::Local(dest),
+            src: Place::Local(src),
+        }
+    }
+
+    fn block(id: u32, instructions: Vec<Instr>, terminator: Terminator) -> BasicBlock {
+        BasicBlock {
+            id,
+            statements: vec![],
+            instructions,
+            terminator,
+        }
+    }
+
+    /// Exclusive per-branch destinations of one guarded source (`if a
+    /// { let y = xs; } else { let z = xs; }`): the destinations' bind sites
+    /// sit on mutually-exclusive branch arms, so the whole component keeps
+    /// its releases — the #2418 two-destination shape.
+    #[test]
+    fn exclusive_branch_destinations_of_guarded_source_are_kept() {
+        let blocks = vec![
+            block(
+                0,
+                vec![],
+                Terminator::Branch {
+                    cond: Place::Local(0),
+                    then_target: 1,
+                    else_target: 2,
+                },
+            ),
+            block(1, vec![mv(10, 11)], Terminator::Goto { target: 3 }),
+            block(2, vec![mv(10, 12)], Terminator::Goto { target: 3 }),
+            block(3, vec![], Terminator::Return),
+        ];
+        let mut allowed = all_allowed();
+        dedup_whole_value_handoff(&blocks, &locals(), &mut allowed, &guarded_source());
+        assert_eq!(
+            allowed,
+            all_allowed(),
+            "mutually-exclusive branch destinations of a guarded source must \
+             keep every member's release"
+        );
+    }
+
+    /// Genuinely-parallel fan-out (both destinations on ONE path): the
+    /// fail-closed collapse strips the whole component, guarded source
+    /// included — sole ownership across a co-executable fan is unprovable.
+    /// This shape is checker-rejected in source; a synthetic Move stream
+    /// gets no benefit of the doubt.
+    #[test]
+    fn parallel_fanout_from_guarded_source_still_strips_component() {
+        let blocks = vec![
+            block(0, vec![mv(10, 11)], Terminator::Goto { target: 1 }),
+            block(1, vec![mv(10, 12)], Terminator::Goto { target: 2 }),
+            block(2, vec![], Terminator::Return),
+        ];
+        let mut allowed = all_allowed();
+        dedup_whole_value_handoff(&blocks, &locals(), &mut allowed, &guarded_source());
+        assert!(
+            allowed.is_empty(),
+            "co-executable (sequential) fan-out must strip the whole \
+             component, guarded source included; kept {allowed:?}"
+        );
+    }
+
+    /// Two bind sites in one block are trivially co-executable — strip.
+    #[test]
+    fn same_block_fanout_from_guarded_source_strips_component() {
+        let blocks = vec![block(0, vec![mv(10, 11), mv(10, 12)], Terminator::Return)];
+        let mut allowed = all_allowed();
+        dedup_whole_value_handoff(&blocks, &locals(), &mut allowed, &guarded_source());
+        assert!(
+            allowed.is_empty(),
+            "same-block fan-out must strip the whole component; kept {allowed:?}"
+        );
+    }
+
+    /// A bind site on a cycle can re-execute — co-executable with itself, so
+    /// the pair (loop site, post-loop site) strips even though neither
+    /// branch dominates the other.
+    #[test]
+    fn loop_bind_site_fanout_strips_component() {
+        let blocks = vec![
+            block(0, vec![], Terminator::Goto { target: 1 }),
+            block(1, vec![mv(10, 11)], Terminator::Goto { target: 2 }),
+            block(
+                2,
+                vec![],
+                Terminator::Branch {
+                    cond: Place::Local(0),
+                    then_target: 1,
+                    else_target: 3,
+                },
+            ),
+            block(3, vec![mv(10, 12)], Terminator::Return),
+        ];
+        let mut allowed = all_allowed();
+        dedup_whole_value_handoff(&blocks, &locals(), &mut allowed, &guarded_source());
+        assert!(
+            allowed.is_empty(),
+            "a bind site inside a loop is reachable from itself and from the \
+             post-loop site; the component must strip; kept {allowed:?}"
+        );
+    }
+
+    /// Without a guarded member the original >1-member collapse holds even
+    /// for exclusive destinations — the exclusivity exemption is earned by
+    /// the guard flag, never by shape alone.
+    #[test]
+    fn guardless_component_keeps_original_collapse() {
+        let blocks = vec![
+            block(
+                0,
+                vec![],
+                Terminator::Branch {
+                    cond: Place::Local(0),
+                    then_target: 1,
+                    else_target: 2,
+                },
+            ),
+            block(1, vec![mv(10, 11)], Terminator::Goto { target: 3 }),
+            block(2, vec![mv(10, 12)], Terminator::Goto { target: 3 }),
+            block(3, vec![], Terminator::Return),
+        ];
+        let mut allowed = all_allowed();
+        dedup_whole_value_handoff(&blocks, &locals(), &mut allowed, &HashMap::new());
+        // The chain strip removes the source (its handle reaches admitted
+        // destinations); the fan-out collapse then strips the ambiguous
+        // sibling pair.
+        assert!(
+            allowed.is_empty(),
+            "a guardless multi-destination component keeps the fail-closed \
+             collapse; kept {allowed:?}"
         );
     }
 }

--- a/hew-mir/tests/lowering_expr.rs
+++ b/hew-mir/tests/lowering_expr.rs
@@ -6,6 +6,8 @@
 mod binop_bitwise_logical;
 #[path = "lowering_expr/bytes_literal_lowering.rs"]
 mod bytes_literal_lowering;
+#[path = "lowering_expr/conditional_move_drop.rs"]
+mod conditional_move_drop;
 #[path = "lowering_expr/cstring_container_domain_canary.rs"]
 mod cstring_container_domain_canary;
 #[path = "lowering_expr/elaborate.rs"]

--- a/hew-mir/tests/lowering_expr/conditional_move_drop.rs
+++ b/hew-mir/tests/lowering_expr/conditional_move_drop.rs
@@ -258,6 +258,187 @@ fn conditional_move_hashmap_gets_guarded_return_drop() {
 }
 
 // ---------------------------------------------------------------------------
+// Two exclusive destinations of one guarded source.
+// ---------------------------------------------------------------------------
+
+const DOUBLE_DESTINATION: &str = r"
+    fn make_vec() -> Vec<i64> {
+        let v: Vec<i64> = Vec::new();
+        v.push(40);
+        v.push(2);
+        return v;
+    }
+
+    fn probe(a: bool, b: bool) {
+        let xs = make_vec();
+        if a {
+            let y = xs;
+        } else if b {
+            let z = xs;
+        }
+    }
+
+    fn main() {
+        probe(false, false);
+    }
+    ";
+
+/// `if a { let y = xs; } else if b { let z = xs; }` — the source keeps
+/// exactly one GUARDED Return-exit release; the two destinations keep one
+/// unguarded release each on their own (mutually-exclusive) arm edges. The
+/// fan-out collapse must not conflate exclusive branch destinations with a
+/// parallel fan-out.
+#[test]
+fn exclusive_double_destination_keeps_all_three_releases() {
+    let pipeline = pipeline_with_tc(DOUBLE_DESTINATION);
+    let ret = return_drops(&pipeline, "probe");
+    let ret_frees = frees(&ret, "hew_vec_free");
+    assert_eq!(
+        ret_frees.len(),
+        1,
+        "the double-destination source must keep exactly one Return-exit \
+         release; got {ret:?}"
+    );
+    assert!(
+        ret_frees[0].guard.is_some(),
+        "the double-destination source's Return-exit release must be \
+         guarded; got {ret_frees:?}"
+    );
+    let gotos = goto_drops(&pipeline, "probe");
+    let goto_frees = frees(&gotos, "hew_vec_free");
+    assert_eq!(
+        goto_frees.len(),
+        2,
+        "each exclusive destination keeps one release on its own arm's \
+         scope-close edge; got {gotos:?}"
+    );
+    assert!(
+        goto_frees.iter().all(|d| d.guard.is_none()),
+        "destination releases need no guard — each edge exists only on the \
+         path where its move executed; got {goto_frees:?}"
+    );
+}
+
+/// Rebinds on BOTH arms of an if/else: every runtime path moves the source,
+/// so its guarded drop is statically excluded at each arm's Return, and each
+/// destination releases exactly once on its own path.
+#[test]
+fn both_arm_destinations_each_release_once() {
+    let pipeline = pipeline_with_tc(
+        r"
+        fn make_vec() -> Vec<i64> {
+            let v: Vec<i64> = Vec::new();
+            v.push(40);
+            v.push(2);
+            return v;
+        }
+
+        fn probe(c: bool) -> i64 {
+            let xs = make_vec();
+            if c {
+                let a = xs;
+                return a.len();
+            } else {
+                let b = xs;
+                return b.len() + 10;
+            }
+        }
+
+        fn main() {
+            let _r = probe(false);
+        }
+        ",
+    );
+    let drops = all_exit_drops(&pipeline, "probe");
+    let all_frees = frees(&drops, "hew_vec_free");
+    // One binding's release may appear on several exit PLANS (its own arm's
+    // return plus the cancel/trap cleanups) — exactly-once is per runtime
+    // path, so count distinct released PLACES.
+    let unguarded_places: std::collections::HashSet<_> = all_frees
+        .iter()
+        .filter(|d| d.guard.is_none())
+        .map(|d| d.place)
+        .collect();
+    assert_eq!(
+        unguarded_places.len(),
+        2,
+        "each arm's destination must keep its own unguarded release; got {drops:?}"
+    );
+    assert!(
+        all_frees.iter().all(|d| d.guard.is_none()),
+        "no guarded release survives — the source is consumed on every \
+         path, so its drop is statically excluded per-exit; got {drops:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Mixed rebind + aggregate-ingress arms — base-parity fallback.
+// ---------------------------------------------------------------------------
+
+/// A rebind on one arm and a record-literal ingress on the other: the
+/// aggregate ingress is an owning-sink escape, so the source falls back to
+/// the legacy posture (excluded — its flag never engages a release), while
+/// the rebind destination keeps its own release exactly as the
+/// retract-at-consume compiler admitted it. Pins the base-parity fallback:
+/// a flagged binding the escape scan cannot admit must not drag its move
+/// destination down with it.
+#[test]
+fn mixed_rebind_and_record_ingress_keeps_destination_release() {
+    let pipeline = pipeline_with_tc(
+        r"
+        fn make_vec() -> Vec<i64> {
+            let v: Vec<i64> = Vec::new();
+            v.push(40);
+            v.push(2);
+            return v;
+        }
+
+        record Holder {
+            items: Vec<i64>,
+        }
+
+        fn probe(a: bool, b: bool) -> i64 {
+            let xs = make_vec();
+            var out: i64 = 0;
+            if a {
+                let y = xs;
+                out = y.len();
+            } else if b {
+                let h = Holder { items: xs };
+                out = h.items.len() + 100;
+            } else {
+                out = 999;
+            }
+            out
+        }
+
+        fn main() {
+            let _r = probe(false, false);
+        }
+        ",
+    );
+    let drops = all_exit_drops(&pipeline, "probe");
+    let vec_frees = frees(&drops, "hew_vec_free");
+    // One binding's release may appear on several exit PLANS (arm goto plus
+    // cancel cleanups) — count distinct released PLACES. Exactly one place
+    // (the rebind destination) earns a bare-vec release; the escaped source
+    // is excluded on every exit (its handle is the record's on the ingress
+    // arm and leaks fail-closed on the others).
+    let free_places: std::collections::HashSet<_> = vec_frees.iter().map(|d| d.place).collect();
+    assert_eq!(
+        free_places.len(),
+        1,
+        "only the rebind destination keeps a bare-vec release (the escaped \
+         source is excluded, fail-closed); got {drops:?}"
+    );
+    assert!(
+        vec_frees.iter().all(|d| d.guard.is_none()),
+        "the destination's release is unguarded and the excluded source \
+         contributes no guarded release; got {vec_frees:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Escape — fail-closed exclusions unchanged (negative controls).
 // ---------------------------------------------------------------------------
 

--- a/hew-mir/tests/lowering_expr/conditional_move_drop.rs
+++ b/hew-mir/tests/lowering_expr/conditional_move_drop.rs
@@ -1,0 +1,339 @@
+//! Conditionally-moved collection locals — scope-exit drop registration and
+//! path-sensitive guard pinning (#2418).
+//!
+//! An owned collection local moved out on only SOME control-flow paths
+//! (`let xs = make(); if take { let ys = xs; }`) used to be retracted from
+//! the scope-exit set path-insensitively at its consume site: no drop was
+//! registered at all, and the not-moved path leaked the value at return.
+//! The whole-value `Move` lowering does not null the source slot, so a naked
+//! registration would double-free on the moved path instead — the fix keeps
+//! the registration and gates the release on a runtime drop-flag (set at
+//! each consume site), mirroring the non-idempotent `#[resource]` close
+//! discipline. This suite pins the structure:
+//!
+//! - Admit (positive): the conditionally-moved source earns its scope-exit
+//!   drop on the Return exit WITH `guard: Some(..)` — skipped at runtime on
+//!   the moved path, fired on the not-moved path. The move's destination
+//!   keeps its own (unguarded) release on its arm's scope-close edge.
+//! - Common case unchanged: a never-consumed local's drop carries
+//!   `guard: None` — byte-identical to the pre-fix plan.
+//! - Unconditional move: the source is `Consumed` at the Return exit, so the
+//!   per-exit state filter excludes its drop statically; only the
+//!   destination releases.
+//! - Escape (negative controls): a conditional by-value call argument and a
+//!   conditional `return xs` keep their fail-closed exclusions — no drop of
+//!   the source on any path (the callee / caller owns the release).
+//!
+//! The negative controls are load-bearing: per
+//! `drop-allowset-from-value-flow` an allow-set test without a paired
+//! exclusion would pass even if the gate admitted everything (the
+//! double-free this fix must never introduce).
+
+use hew_mir::{DropKind, ElabDrop, ExitPath, IrPipeline};
+use hew_types::module_registry::ModuleRegistry;
+use hew_types::Checker;
+
+/// Full pipeline with type-checking so the `Vec`/`HashMap` builtins resolve
+/// their element types and the builtin discriminant flows onto the MIR
+/// binding type (the class predicates dispatch on it).
+fn pipeline_with_tc(source: &str) -> IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:#?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    let output = hew_hir::lower_program(
+        &parsed.program,
+        &tc_output,
+        &hew_hir::ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    hew_mir::lower_hir_module(&output.module)
+}
+
+/// Every `ElabDrop` on the named function's `Return` exits, in plan order.
+fn return_drops(p: &IrPipeline, fn_name: &str) -> Vec<ElabDrop> {
+    drops_matching(p, fn_name, |exit| matches!(exit, ExitPath::Return { .. }))
+}
+
+/// Every `ElabDrop` on the named function's forward `Goto` (scope-close)
+/// exits, in plan order.
+fn goto_drops(p: &IrPipeline, fn_name: &str) -> Vec<ElabDrop> {
+    drops_matching(p, fn_name, |exit| matches!(exit, ExitPath::Goto { .. }))
+}
+
+/// Every `ElabDrop` across EVERY exit of the named function (used by the
+/// negative controls: an escaped handle must not be dropped on ANY path).
+fn all_exit_drops(p: &IrPipeline, fn_name: &str) -> Vec<ElabDrop> {
+    drops_matching(p, fn_name, |_| true)
+}
+
+fn drops_matching(
+    p: &IrPipeline,
+    fn_name: &str,
+    pred: impl Fn(&ExitPath) -> bool,
+) -> Vec<ElabDrop> {
+    p.elaborated_mir
+        .iter()
+        .find(|f| f.name == fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name} must be present in elaborated_mir"))
+        .drop_plans
+        .iter()
+        .filter(|(exit, _)| pred(exit))
+        .flat_map(|(_, plan)| plan.drops.iter().cloned())
+        .collect()
+}
+
+/// True when `drop` is a `CowHeap` release naming `symbol`.
+fn is_cow_heap_free(drop: &ElabDrop, symbol: &str) -> bool {
+    matches!(drop.kind, DropKind::CowHeap { release } if release.release_symbol() == symbol)
+}
+
+fn frees<'d>(drops: &'d [ElabDrop], symbol: &str) -> Vec<&'d ElabDrop> {
+    drops
+        .iter()
+        .filter(|d| is_cow_heap_free(d, symbol))
+        .collect()
+}
+
+const CONDITIONAL_MOVE: &str = r"
+    fn make_vec() -> Vec<i64> {
+        let v: Vec<i64> = Vec::new();
+        v.push(40);
+        v.push(2);
+        return v;
+    }
+
+    fn probe(take: bool) {
+        let xs = make_vec();
+        if take {
+            let ys = xs;
+        }
+    }
+
+    fn main() {
+        probe(false);
+    }
+    ";
+
+// ---------------------------------------------------------------------------
+// Admit — the conditionally-moved source earns a GUARDED Return-exit drop.
+// ---------------------------------------------------------------------------
+
+/// The issue repro: `xs` must appear on the Return exit with a runtime guard
+/// (exactly one guarded `hew_vec_free`), so the not-moved path releases it
+/// and the moved path skips. LESSONS: `cleanup-all-exits`,
+/// `drop-allowset-from-value-flow`, `boundary-fail-closed`.
+#[test]
+fn conditional_move_source_gets_guarded_return_drop() {
+    let pipeline = pipeline_with_tc(CONDITIONAL_MOVE);
+    let drops = return_drops(&pipeline, "probe");
+    let vec_frees = frees(&drops, "hew_vec_free");
+    assert_eq!(
+        vec_frees.len(),
+        1,
+        "the conditionally-moved source must earn exactly one Return-exit \
+         hew_vec_free drop; got {drops:?}"
+    );
+    assert!(
+        vec_frees[0].guard.is_some(),
+        "the Return-exit drop of a conditionally-moved binding must carry a \
+         path-sensitive guard (an unguarded drop double-frees on the moved \
+         path — the Move lowering does not null the source slot); got \
+         {vec_frees:?}"
+    );
+}
+
+/// The move's destination (`ys`, bound on one arm only) keeps its own
+/// UNGUARDED release on the arm's scope-close edge — it is the sole owner
+/// exactly where the arm executed.
+#[test]
+fn conditional_move_destination_keeps_arm_scope_close_drop() {
+    let pipeline = pipeline_with_tc(CONDITIONAL_MOVE);
+    let drops = goto_drops(&pipeline, "probe");
+    let vec_frees = frees(&drops, "hew_vec_free");
+    assert_eq!(
+        vec_frees.len(),
+        1,
+        "the move destination must keep exactly one scope-close hew_vec_free \
+         on its arm's closing goto; got {drops:?}"
+    );
+    assert!(
+        vec_frees[0].guard.is_none(),
+        "the destination's arm-edge drop needs no guard — the edge only \
+         exists on the path where the move executed; got {vec_frees:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Common case unchanged — no consume, no guard.
+// ---------------------------------------------------------------------------
+
+/// A never-consumed local keeps its unguarded drop: the guard machinery must
+/// not perturb the common case.
+#[test]
+fn unconsumed_local_drop_carries_no_guard() {
+    let pipeline = pipeline_with_tc(
+        r"
+        fn main() -> i64 {
+            let v: Vec<i64> = Vec::new();
+            v.push(1);
+            v.len()
+        }
+        ",
+    );
+    let drops = return_drops(&pipeline, "main");
+    let vec_frees = frees(&drops, "hew_vec_free");
+    assert_eq!(vec_frees.len(), 1, "plain local vec still drops: {drops:?}");
+    assert!(
+        vec_frees[0].guard.is_none(),
+        "a never-consumed local's drop must stay unguarded (byte-identical \
+         common case); got {vec_frees:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unconditional move — the source is statically excluded at the Return.
+// ---------------------------------------------------------------------------
+
+/// A straight-line rebind consumes the source on every path: the per-exit
+/// state filter excludes its drop statically, so exactly one release (the
+/// destination's) survives on the Return exit.
+#[test]
+fn unconditional_move_leaves_single_return_release() {
+    let pipeline = pipeline_with_tc(
+        r"
+        fn main() -> i64 {
+            let a: Vec<i64> = Vec::new();
+            a.push(7);
+            let b = a;
+            b.len()
+        }
+        ",
+    );
+    let drops = return_drops(&pipeline, "main");
+    let vec_frees = frees(&drops, "hew_vec_free");
+    assert_eq!(
+        vec_frees.len(),
+        1,
+        "an unconditionally-moved source must not add a second Return-exit \
+         release alongside the destination's; got {drops:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// HashMap — the collection-handle class rides the same guard.
+// ---------------------------------------------------------------------------
+
+/// A conditionally-moved `HashMap` handle earns a guarded Return-exit
+/// release through the same flag machinery.
+#[test]
+fn conditional_move_hashmap_gets_guarded_return_drop() {
+    let pipeline = pipeline_with_tc(
+        r#"
+        fn probe(take: bool) {
+            let m: HashMap<string, i64> = HashMap::new();
+            m.insert("k", 1);
+            if take {
+                let n = m;
+            }
+        }
+
+        fn main() {
+            probe(false);
+        }
+        "#,
+    );
+    let drops = return_drops(&pipeline, "probe");
+    let guarded: Vec<&ElabDrop> = drops.iter().filter(|d| d.guard.is_some()).collect();
+    assert_eq!(
+        guarded.len(),
+        1,
+        "the conditionally-moved HashMap handle must earn exactly one \
+         guarded Return-exit release; got {drops:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Escape — fail-closed exclusions unchanged (negative controls).
+// ---------------------------------------------------------------------------
+
+/// A vec conditionally consumed by a BY-VALUE CALL stays excluded (the
+/// callee-ownership question is the by-value-argument frontier, not this
+/// fix): no drop of the source on any path — leak, never a wrong free.
+#[test]
+fn conditional_by_value_call_arg_stays_excluded() {
+    let pipeline = pipeline_with_tc(
+        r"
+        fn sink(xs: Vec<i64>) -> i64 {
+            xs.len()
+        }
+
+        fn probe(take: bool) -> i64 {
+            let xs = make_vec();
+            if take {
+                return sink(xs);
+            }
+            0
+        }
+
+        fn make_vec() -> Vec<i64> {
+            let v: Vec<i64> = Vec::new();
+            v.push(1);
+            return v;
+        }
+
+        fn main() {
+            probe(false);
+        }
+        ",
+    );
+    let drops = all_exit_drops(&pipeline, "probe");
+    assert_eq!(
+        frees(&drops, "hew_vec_free").len(),
+        0,
+        "a vec handed to a by-value callee must keep its fail-closed \
+         exclusion on every exit; got {drops:?}"
+    );
+}
+
+/// A vec RETURNED on one arm stays excluded on every path — the caller owns
+/// the returned handle; the not-returned path keeps today's posture.
+#[test]
+fn conditional_return_stays_excluded() {
+    let pipeline = pipeline_with_tc(
+        r"
+        fn make_vec() -> Vec<i64> {
+            let v: Vec<i64> = Vec::new();
+            v.push(1);
+            return v;
+        }
+
+        fn probe(take: bool) -> Vec<i64> {
+            let xs = make_vec();
+            if take {
+                return xs;
+            }
+            let other: Vec<i64> = Vec::new();
+            other
+        }
+
+        fn main() {
+            let r = probe(false);
+            let _n = r.len();
+        }
+        ",
+    );
+    let drops = all_exit_drops(&pipeline, "probe");
+    // `other` (the not-taken arm's fresh vec) legitimately drops nowhere in
+    // `probe` either — it is returned. No hew_vec_free may target `xs`.
+    assert_eq!(
+        frees(&drops, "hew_vec_free").len(),
+        0,
+        "a conditionally-returned vec must keep its fail-closed exclusion \
+         on every exit; got {drops:?}"
+    );
+}

--- a/tests/hew/conditional_move_drop_test.hew
+++ b/tests/hew/conditional_move_drop_test.hew
@@ -1,0 +1,181 @@
+//! Regression tests for conditionally-moved owned collection locals (#2418).
+//!
+//! An owned collection local moved out on only some control-flow paths
+//! (`MaybeConsumed` at the converging join, no later use) must be released
+//! exactly once: on the not-moved path the scope-exit drop fires (this used
+//! to leak — the consume site retracted the binding from the scope-exit set
+//! path-insensitively); on the moved path the runtime drop-flag skips it
+//! (an unguarded drop would double-free, since the whole-value move does
+//! not null the source slot). A double-free aborts the run, so a test that
+//! reaches its assertion proves the release fired no more than once on the
+//! exercised path; the leak direction is pinned by the MIR drop-plan tests
+//! in `hew-mir/tests/lowering_expr/conditional_move_drop.rs` and by the
+//! `conditional_move_drop_leak_oracle` measurements.
+
+import std::testing;
+
+fn make_vec() -> Vec<i64> {
+    let v: Vec<i64> = Vec::new();
+    v.push(40);
+    v.push(2);
+    return v;
+}
+
+fn make_strs() -> Vec<string> {
+    let v: Vec<string> = Vec::new();
+    v.push("alpha");
+    v.push("beta");
+    return v;
+}
+
+// The issue repro, not-moved path: `xs` is still owned at return and the
+// (flag-gated) scope-exit drop is the sole release.
+#[test]
+fn test_not_moved_path_releases_at_scope_exit() {
+    let take = false;
+    let xs = make_vec();
+    var out: i64 = 0;
+    if take {
+        let ys = xs;
+        out = ys.len();
+    }
+    testing.assert_eq(out, 0);
+}
+
+// The issue repro, moved path: `ys` owns the handle and releases it on the
+// arm's scope-close edge; the guarded scope-exit drop of `xs` must skip
+// (a second free aborts).
+#[test]
+fn test_moved_path_releases_exactly_once() {
+    let take = true;
+    let xs = make_vec();
+    var out: i64 = 0;
+    if take {
+        let ys = xs;
+        out = ys.len();
+    }
+    testing.assert_eq(out, 2);
+}
+
+// Nested conditional — two joins between the consume and the scope exit.
+// Each nesting level's flag state must survive both joins.
+#[test]
+fn test_nested_conditional_move() {
+    var total: i64 = 0;
+    let a = true;
+    let b = false;
+    let xs = make_vec();
+    if a {
+        if b {
+            let ys = xs;
+            total = total + ys.len();
+        }
+        total = total + 1;
+    }
+    testing.assert_eq(total, 1);
+}
+
+// Conditional move inside a loop body with break: at most one consume
+// executes; iterations before it (and a run where the consume never
+// executes) keep the value owned by `xs`.
+#[test]
+fn test_loop_conditional_move_with_break() {
+    let xs = make_vec();
+    var hits: i64 = 0;
+    for i in 0..4 {
+        if i == 2 {
+            let ys = xs;
+            hits = hits + ys.len();
+            break;
+        }
+        hits = hits + 1;
+    }
+    testing.assert_eq(hits, 4);
+}
+
+// Loop where the consume never executes: the loop exits normally and the
+// scope-exit drop is the sole release.
+#[test]
+fn test_loop_conditional_move_never_taken() {
+    let xs = make_vec();
+    var hits: i64 = 0;
+    for i in 0..4 {
+        if i == 9 {
+            let ys = xs;
+            hits = hits + ys.len();
+            break;
+        }
+        hits = hits + 1;
+    }
+    testing.assert_eq(hits, 4);
+}
+
+// Array-literal desugar chained into a conditional move: the synthetic temp
+// hands the handle to `v`, then `v` is conditionally moved to `w`. The
+// hand-off dedup must strip the synthetic temp while keeping the guarded
+// source and its destination.
+#[test]
+fn test_array_literal_chain_conditional_move() {
+    let take = true;
+    let v: Vec<i64> = [7, 8, 9];
+    var out: i64 = 0;
+    if take {
+        let w = v;
+        out = w.len();
+    }
+    testing.assert_eq(out, 3);
+}
+
+// HashMap handle conditionally moved — the collection-handle class rides the
+// same drop-flag machinery.
+#[test]
+fn test_hashmap_conditional_move() {
+    let take = true;
+    let m: HashMap<string, i64> = HashMap::new();
+    m.insert("k", 42);
+    var out: i64 = 0;
+    if take {
+        let n = m;
+        out = n.len();
+    }
+    testing.assert_eq(out, 1);
+}
+
+#[test]
+fn test_hashmap_conditional_move_not_taken() {
+    let take = false;
+    let m: HashMap<string, i64> = HashMap::new();
+    m.insert("k", 42);
+    var out: i64 = 0;
+    if take {
+        let n = m;
+        out = n.len();
+    }
+    testing.assert_eq(out, 0);
+}
+
+// Vec<string>: the plain-vec class with per-element releases behind the
+// single guarded free.
+#[test]
+fn test_vec_string_conditional_move() {
+    let take = true;
+    let xs = make_strs();
+    var out: i64 = 0;
+    if take {
+        let ys = xs;
+        out = ys.len();
+    }
+    testing.assert_eq(out, 2);
+}
+
+#[test]
+fn test_vec_string_conditional_move_not_taken() {
+    let take = false;
+    let xs = make_strs();
+    var out: i64 = 0;
+    if take {
+        let ys = xs;
+        out = ys.len();
+    }
+    testing.assert_eq(out, 0);
+}

--- a/tests/hew/conditional_move_drop_test.hew
+++ b/tests/hew/conditional_move_drop_test.hew
@@ -179,3 +179,86 @@ fn test_vec_string_conditional_move_not_taken() {
     }
     testing.assert_eq(out, 0);
 }
+
+// Two destinations on mutually-exclusive branches, one drop-flag: each path
+// must release exactly once (a double-free aborts before the assertion; the
+// leak direction is pinned by the oracle's slope and the MIR plan tests).
+fn double_dest(a: bool, b: bool) -> i64 {
+    let xs = make_vec();
+    var out: i64 = 0;
+    if a {
+        let y = xs;
+        out = y.len();
+    } else if b {
+        let z = xs;
+        out = z.len() + 100;
+    } else {
+        out = 999;
+    }
+    out
+}
+
+#[test]
+fn test_double_destination_first_branch() {
+    testing.assert_eq(double_dest(true, false), 2);
+}
+
+#[test]
+fn test_double_destination_second_branch() {
+    testing.assert_eq(double_dest(false, true), 102);
+}
+
+#[test]
+fn test_double_destination_neither_branch() {
+    testing.assert_eq(double_dest(false, false), 999);
+}
+
+// Rebinds on both arms: every path moves the source; each arm's destination
+// releases exactly once on its own path and the guarded source drop skips.
+fn both_arms(c: bool) -> i64 {
+    let xs = make_vec();
+    if c {
+        let a = xs;
+        return a.len();
+    } else {
+        let b = xs;
+        return b.len() + 10;
+    }
+}
+
+#[test]
+fn test_both_arm_moves_release_once_each() {
+    testing.assert_eq(both_arms(true), 2);
+    testing.assert_eq(both_arms(false), 12);
+}
+
+// Mixed rebind + record-literal ingress on exclusive branches: the ingress
+// arm's record owns and releases the handle; the rebind arm's destination
+// keeps its release; the source falls back to the fail-closed legacy posture
+// on the neither path (bounded leak, never a wrong free). Values must stay
+// exact on every path.
+record Crate {
+    items: Vec<i64>,
+}
+
+fn mixed_ingress(a: bool, b: bool) -> i64 {
+    let xs = make_vec();
+    var out: i64 = 0;
+    if a {
+        let y = xs;
+        out = y.len();
+    } else if b {
+        let h = Crate { items: xs };
+        out = h.items.len() + 100;
+    } else {
+        out = 999;
+    }
+    out
+}
+
+#[test]
+fn test_mixed_ingress_all_paths_exact() {
+    testing.assert_eq(mixed_ingress(true, false), 2);
+    testing.assert_eq(mixed_ingress(false, true), 102);
+    testing.assert_eq(mixed_ingress(false, false), 999);
+}


### PR DESCRIPTION
## Why

A collection local conditionally moved out via `let ys = xs;` on one branch, and never touched on the other, leaked its allocation on the not-moved path: `owned_locals_snapshot()` filters to scope-exit locals for the drop plan, and the initial move-consume lowering retracted `xs` from that plan unconditionally at the consume site (path-insensitively), so no `drop` entry existed for it on the not-taken branch. Confirmed by `leaks --atExit`: 2 leaks / 176 bytes on the not-moved path pre-fix.

A related shape surfaced once the exactly-once fix landed: a single guarded source moved into two *different* destination bindings on mutually exclusive branches (`if a { let y = xs; } else if b { let z = xs; }`) leaked on every path — moved or not. The dedup pass that collapses a guarded source with its move destinations (`dedup_whole_value_handoff`) treated `y` and `z` as two unguarded members of the same undirected move-component as `xs`, even though their branches never co-execute at runtime; ≥2 unguarded members stripped the whole component's drop entry, guarded source included.

Fixes #2418.

## What

- `hew-mir/src/lower.rs`: a conditionally-moved, scope-exit collection local now gets a runtime guard flag (`collection_drop_flags`), set at the consume site, that gates its release at scope exit instead of unconditionally retracting the binding from the drop plan.
- Added `unguarded_bind_sites_pairwise_exclusive`, a CFG walk over `BasicBlock::successors()` that recognizes when two move-destination bind sites are structurally exclusive (same-block, forward reachability, and cycle membership are each checked) so mutually-exclusive branch destinations no longer get miscounted as an ambiguous fan-out and stripped.
- Added `admit_with_flagged_fallback`, a monotone fixpoint that falls a flagged candidate back to the legacy retract-at-consume behavior whenever escape analysis can't safely admit it — this keeps results base-identical for shapes the guard mechanism doesn't cover (e.g. a mixed rebind + record-field-ingress destination pair).
- Narrowed flag allocation to rebind-style consumes only (`prepass_nonrebind_consumed`) — by-value call arguments, aggregate fields, `return`, and nested reads keep the prior retraction behavior unchanged.

## Test

- `hew-mir/tests/lowering_expr/conditional_move_drop.rs`: MIR structural pins for the double-destination, both-arms, and mixed rebind/record-ingress shapes.
- `hew-mir/src/lower.rs` (`dedup_fanout_exclusivity_tests`): 5 direct-CFG unit tests pinning the exclusivity boundary — exclusive-keep, sequential-strip, same-block-strip, loop-site-strip, guardless-collapse.
- `hew-cli/tests/conditional_move_drop_leak_oracle.rs`: leak-oracle coverage for the double-destination and both-arms shapes, plus a per-call leak-slope regression test.
- `tests/hew/conditional_move_drop_test.hew`: runtime fixtures covering all paths of the double-destination, both-arms, and mixed-ingress shapes.

Verified before pushing: `make ci-preflight` (full comprehensive lane — smoke, lint, playground-check, `make test`, vertical-slice, pkg-import, fuzz-oracle, `test-hew-ratchet`, `test-o2-differential`, `test-stdlib-ratchet`, doc-examples, sandbox-parity, `checked-mir-verify`, `hew-check-all`) — all stages green.

## Out of scope

The guard mechanism deliberately does not cover (measured byte-identical to pre-fix behavior, no regression):
- By-value call arguments (the callee owns the parameter; not dropped in the caller regardless of branch shape).
- A conditionally-moved binding consumed via `return` on one arm.
- A `var` that's consumed on one branch and reassigned on a sibling branch (composes with the existing `#2301` overwrite-guard mechanism, tracked separately).
- Non-collection classes (`bytes`, cow-string, closure captures, indirect enums) — each is a separate exclusion boundary with its own prover.

## Quality Checklist
- [x] PR title, body, and commit messages avoid internal-only orchestration/model vocabulary
- [x] No new `.ok()?` or `unwrap_or_default()` in codegen without `// JUSTIFIED` comment
- [x] New allocations have cleanup paths for sync, async, and actor shutdown contexts
- [x] Serialization changes include round-trip encode/decode tests — N/A, no serialization change
- [x] New runtime features have WASM implementation or `// WASM-TODO(#NNN):` marker — N/A, no new runtime export
- [x] No duplicated logic — checked for existing helpers before adding new ones