### PR TITLE
fix(stdlib): avoid i64::MIN overflow in fmt base conversions

### DIFF
--- a/std/fmt/fmt.hew
+++ b/std/fmt/fmt.hew
@@ -35,7 +35,16 @@ pub fn to_hex(n: i64) -> string {
         return "0";
     }
     if n < 0 {
-        return "-" + to_hex(0 - n);
+        // Iterate on the negative value directly so `i64::MIN` (whose positive
+        // magnitude is unrepresentable) does not overflow via `0 - n`.
+        var result = "";
+        var val = n;
+        while val < 0 {
+            let digit = 0 - val % 16;
+            result = hex_digit(digit) + result;
+            val = val / 16;
+        }
+        return "-" + result;
     }
     var result = "";
     var val = n;
@@ -63,7 +72,16 @@ pub fn to_binary(n: i64) -> string {
         return "0";
     }
     if n < 0 {
-        return "-" + to_binary(0 - n);
+        // Iterate on the negative value directly so `i64::MIN` does not
+        // overflow via `0 - n`.
+        var result = "";
+        var val = n;
+        while val < 0 {
+            let digit = 0 - val % 2;
+            result = f"{digit}" + result;
+            val = val / 2;
+        }
+        return "-" + result;
     }
     var result = "";
     var val = n;
@@ -91,7 +109,16 @@ pub fn to_octal(n: i64) -> string {
         return "0";
     }
     if n < 0 {
-        return "-" + to_octal(0 - n);
+        // Iterate on the negative value directly so `i64::MIN` does not
+        // overflow via `0 - n`.
+        var result = "";
+        var val = n;
+        while val < 0 {
+            let digit = 0 - val % 8;
+            result = f"{digit}" + result;
+            val = val / 8;
+        }
+        return "-" + result;
     }
     var result = "";
     var val = n;

--- a/tests/hew/fmt_test.hew
+++ b/tests/hew/fmt_test.hew
@@ -4,10 +4,10 @@
 //! are all pure, allocation-only functions with no I/O or handles.
 
 import std::fmt;
+
 import std::testing;
 
 // ── to_hex ────────────────────────────────────────────────────────────
-
 #[test]
 fn test_to_hex_zero() {
     testing.assert_eq_str(fmt.to_hex(0), "0");
@@ -29,6 +29,8 @@ fn test_to_hex_byte_boundary() {
 fn test_to_hex_negative_value() {
     testing.assert_eq_str(fmt.to_hex(-16), "-10");
     testing.assert_eq_str(fmt.to_hex(-255), "-ff");
+    // i64::MIN: positive magnitude is unrepresentable, so `0 - n` overflows.
+    testing.assert_eq_str(fmt.to_hex(-9223372036854775807 - 1), "-8000000000000000");
 }
 
 #[test]
@@ -38,7 +40,6 @@ fn test_to_hex_larger_value() {
 }
 
 // ── to_binary ─────────────────────────────────────────────────────────
-
 #[test]
 fn test_to_binary_zero() {
     testing.assert_eq_str(fmt.to_binary(0), "0");
@@ -62,10 +63,11 @@ fn test_to_binary_arbitrary_values() {
 fn test_to_binary_negative_value() {
     testing.assert_eq_str(fmt.to_binary(-5), "-101");
     testing.assert_eq_str(fmt.to_binary(-1), "-1");
+    // i64::MIN == -2^63: "-1" followed by 63 zeros.
+    testing.assert_eq_str(fmt.to_binary(-9223372036854775807 - 1), "-1000000000000000000000000000000000000000000000000000000000000000");
 }
 
 // ── to_octal ──────────────────────────────────────────────────────────
-
 #[test]
 fn test_to_octal_zero() {
     testing.assert_eq_str(fmt.to_octal(0), "0");
@@ -86,10 +88,11 @@ fn test_to_octal_multi_digit_values() {
 #[test]
 fn test_to_octal_negative_value() {
     testing.assert_eq_str(fmt.to_octal(-8), "-10");
+    // i64::MIN == -2^63 == -(8^21): "-1" followed by 21 zeros.
+    testing.assert_eq_str(fmt.to_octal(-9223372036854775807 - 1), "-1000000000000000000000");
 }
 
 // ── round-trip: to_hex / to_binary / to_octal boundaries ─────────────
-
 #[test]
 fn test_base_conversions_at_16() {
     // 16 in hex = "10", in binary = "10000", in octal = "20"
@@ -99,7 +102,6 @@ fn test_base_conversions_at_16() {
 }
 
 // ── pad_left ──────────────────────────────────────────────────────────
-
 #[test]
 fn test_pad_left_adds_leading_zeros() {
     testing.assert_eq_str(fmt.pad_left("7", 3, "0"), "007");
@@ -127,7 +129,6 @@ fn test_pad_left_empty_string() {
 }
 
 // ── pad_right ─────────────────────────────────────────────────────────
-
 #[test]
 fn test_pad_right_adds_trailing_dots() {
     testing.assert_eq_str(fmt.pad_right("hi", 5, "."), "hi...");
@@ -149,7 +150,6 @@ fn test_pad_right_empty_string() {
 }
 
 // ── repeat ────────────────────────────────────────────────────────────
-
 #[test]
 fn test_repeat_zero_times_returns_empty() {
     testing.assert_eq_str(fmt.repeat("abc", 0), "");
@@ -167,7 +167,6 @@ fn test_repeat_multiple_times() {
 }
 
 // ── combined usage: zero-pad hex with pad_left ────────────────────────
-
 #[test]
 fn test_zero_padded_hex_byte_representation() {
     // to_hex(10) = "a"; padded to 2 digits → "0a"


### PR DESCRIPTION
## Problem

`std::fmt::to_hex`/`to_binary`/`to_octal` handle negatives by recursing on the positive magnitude: `return "-" + to_hex(0 - n);`. For `i64::MIN` (`-9223372036854775808`) the positive magnitude is unrepresentable in `i64`, so `0 - n` overflows and traps:

```
hew: trap in main context: IntegerOverflow
```

Ordinary negatives (`-16`, `-255`, …) were fine; only the min-int boundary was affected, and no test exercised it.

## Fix

Iterate on the negative value directly, extracting each digit as `0 - val % base` (a small non-negative value) and prefixing `-`. This never computes the positive magnitude, so no negation overflow is possible.

Verified outputs at `i64::MIN`:
- `to_hex`  → `-8000000000000000`
- `to_binary` → `-1` followed by 63 zeros (`-2^63`)
- `to_octal` → `-1` followed by 21 zeros (`8^21 = 2^63`)

## Tests

Added `i64::MIN` boundary assertions to the three existing negative-value tests (previously only `-16`/`-255`/`-5`/`-8` were covered). Confirmed load-bearing: reverting `to_hex` to the old recursion makes `test_to_hex_negative_value` trap with `IntegerOverflow`.

- `hew test tests/hew/fmt_test.hew`: 27/27 pass
- `hew fmt --check` clean on both files
- full `tests/vertical-slice/run.sh`: 429/429 pass

Closes a defect tracked from the review of #207.