### PR TITLE
fix(mir): release for-await loop variable across return/break/continue edges

### DIFF
--- a/hew-cli/tests/recv_loop_leak_oracle.rs
+++ b/hew-cli/tests/recv_loop_leak_oracle.rs
@@ -1140,3 +1140,112 @@ fn gen_stream_returned_loop_var_no_uaf() {
         &["before", "escaped", "after"],
     );
 }
+
+// ── Identity-callee forwarding: `wrap(v)` on the return / break edges ──────
+//
+// The generator/recv-yield exit-edge ledger's escape scan
+// (`generator_yield_terminator_escapes`) used to classify EVERY
+// `Terminator::Call` argument as a non-escaping borrow (a structural "any
+// call is a borrow" rule). That is wrong when the callee forwards its
+// argument back out as its own return value: `wrap` below is an identity
+// pass-through (a validator / `.trim()`-style wrapper / decorator shape),
+// so `v` and `wrap(v)`'s result alias the SAME underlying buffer. The
+// escape scan said "no escape", so the exit-edge ledger still fired a
+// `Drop` on `v`'s place AFTER `wrap` had already threaded that buffer into
+// its own return slot — a silent use-after-free: the caller reads the
+// freed-and-poisoned buffer as an empty string instead of the real value
+// (GitHub issue #2412). The fix makes the scan consult the SAME closed
+// ownership-contract list the body-end scan's `CallRuntimeAbi` arm uses
+// (`call_args_borrow_safe` in `hew-mir/src/lower.rs`); a
+// directly-resolved Hew function like `wrap`, which is not on that list,
+// now counts as an escape and the exit-edge drop is retracted.
+//
+// The identical corruption reproduces via `break` (`carry = wrap(v);
+// break;`) because both edges share the same ledger emitter
+// (`emit_generator_yield_value_drops_for_exit_edge`) and the same escape
+// scan — a pre-existing defect on `break`/`continue`, which wired the
+// ledger before the `return` edge existed.
+
+/// `fn wrap(v: string) -> string { return v; }` — an identity pass-through
+/// callee. `return wrap(v)` forwards the loop variable through the call;
+/// neither the body-end release nor the return-edge release may fire on
+/// `v` (the call's result IS `v`'s buffer, now owned by the caller through
+/// `wrap`'s own return). Pre-fix: the exit-edge ledger dropped `v` after
+/// `wrap` returned, freeing the buffer the caller is about to read —
+/// `println(s)` printed an empty string instead of `escaped` under the
+/// scribble triple.
+fn gen_stream_return_forwarded_via_call_source() -> String {
+    "actor Maker {\n\
+     \x20   receive gen fn items() -> string {\n\
+     \x20       yield \"escaped\";\n\
+     \x20       yield \"rest\";\n\
+     \x20   }\n\
+     }\n\
+     fn wrap(v: string) -> string {\n\
+     \x20   return v;\n\
+     }\n\
+     fn first(m: LocalPid<Maker>) -> string {\n\
+     \x20   for await v in m.items() {\n\
+     \x20       return wrap(v);\n\
+     \x20   }\n\
+     \x20   \"none\"\n\
+     }\n\
+     fn main() {\n\
+     \x20   println(\"before\");\n\
+     \x20   let m = spawn Maker;\n\
+     \x20   let s = first(m);\n\
+     \x20   println(s);\n\
+     \x20   println(\"after\");\n\
+     }\n"
+    .to_string()
+}
+
+/// `break`-analog of the identity-forwarding shape: `carry = wrap(v);
+/// break;`. Same ledger emitter, same escape scan, same identity callee —
+/// proves the fix closes both exit edges, not just `return`.
+fn gen_stream_break_forwarded_via_call_source() -> String {
+    "actor Maker {\n\
+     \x20   receive gen fn items() -> string {\n\
+     \x20       yield \"escaped\";\n\
+     \x20       yield \"rest\";\n\
+     \x20   }\n\
+     }\n\
+     fn wrap(v: string) -> string {\n\
+     \x20   return v;\n\
+     }\n\
+     fn main() {\n\
+     \x20   println(\"before\");\n\
+     \x20   let m = spawn Maker;\n\
+     \x20   var carry = \"init\";\n\
+     \x20   for await v in m.items() {\n\
+     \x20       carry = wrap(v);\n\
+     \x20       break;\n\
+     \x20   }\n\
+     \x20   println(carry);\n\
+     \x20   println(\"after\");\n\
+     }\n"
+    .to_string()
+}
+
+/// Identity-callee forwarding on the RETURN edge must not free the buffer
+/// the caller is about to read. `GuardMalloc` ×3 in the flake gate.
+#[test]
+fn gen_stream_return_forwarded_via_call_no_uaf() {
+    assert_payload_escape_prints(
+        "gen_stream_return_forwarded_via_call",
+        &gen_stream_return_forwarded_via_call_source(),
+        &["before", "escaped", "after"],
+    );
+}
+
+/// Identity-callee forwarding on the BREAK edge — same ledger emitter and
+/// escape scan as the return edge, so the fix must close both. `GuardMalloc`
+/// ×3 in the flake gate.
+#[test]
+fn gen_stream_break_forwarded_via_call_no_uaf() {
+    assert_payload_escape_prints(
+        "gen_stream_break_forwarded_via_call",
+        &gen_stream_break_forwarded_via_call_source(),
+        &["before", "escaped", "after"],
+    );
+}

--- a/hew-cli/tests/recv_loop_leak_oracle.rs
+++ b/hew-cli/tests/recv_loop_leak_oracle.rs
@@ -974,3 +974,169 @@ fn carry_fallthrough_payload_escape_no_uaf() {
         &["before", "escaped", "after"],
     );
 }
+
+// ── Actor-generator stream: loop-var release across the early-return edge ──
+//
+// `for await v in m.items()` over a `receive gen fn` stream. The consuming
+// body releases its received value on EVERY path out of the body: the
+// fall-through body-end drop, the break/continue edge drops, and the early-
+// `return` edge. Pre-fix, a `return` on any body path was treated as an
+// ownership escape of the loop variable by the body walk, which suppressed
+// the body-end release for the WHOLE binding — every received string leaked
+// one `alloc_cstring_data` node per yield (trunk measurement on the 50-frame
+// probe: 38 leaked nodes, all rooted in `hew_stream_next_layout`'s decode
+// copy), not just the returning iteration's.
+//
+// The `return v` shape (the loop variable itself moved to the caller) is the
+// exactly-once wall: the ReturnSlot move is a real escape, so BOTH the
+// body-end release and the return-edge release must stay suppressed — the
+// scribble pin below catches an over-emitted release as a poisoned read.
+
+/// Full drain of a `receive gen fn` string stream — the headline shape of
+/// the consumer-side loop-var discipline (one received string per yield,
+/// released at body end each iteration). Slope 0 pins it.
+fn gen_stream_string_drain_source(frames: usize) -> String {
+    format!(
+        "actor Maker {{\n\
+         \x20   receive gen fn items() -> string {{\n\
+         \x20       for i in 0..{frames} {{\n\
+         \x20           yield f\"item-{{i}}\";\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var seen: i64 = 0;\n\
+         \x20   let m = spawn Maker;\n\
+         \x20   for await v in m.items() {{\n\
+         \x20       if v.len() < 6 {{ return 91; }}\n\
+         \x20       seen = seen + 1;\n\
+         \x20   }}\n\
+         \x20   if seen != {frames} {{ return 92; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+/// Mid-drain early `return`: the iterations before the hit release at body
+/// end, the returning iteration releases on the return edge. Pre-fix this
+/// leaked EVERY iteration's received string (the return path poisoned the
+/// body walk), slope 1.0/frame.
+fn gen_stream_string_early_return_source(frames: usize) -> String {
+    let stop_at = frames / 2 + 1;
+    format!(
+        "actor Maker {{\n\
+         \x20   receive gen fn items() -> string {{\n\
+         \x20       for i in 0..{frames} {{\n\
+         \x20           yield f\"item-{{i}}\";\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var seen: i64 = 0;\n\
+         \x20   let m = spawn Maker;\n\
+         \x20   for await v in m.items() {{\n\
+         \x20       if v.len() < 6 {{ return 91; }}\n\
+         \x20       seen = seen + 1;\n\
+         \x20       if seen >= {stop_at} {{\n\
+         \x20           return 0;\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         \x20   92\n\
+         }}\n"
+    )
+}
+
+/// Bytes variant of the early-return shape: the received `bytes` triple
+/// releases through `hew_bytes_drop` on the same edges as the string case.
+fn gen_stream_bytes_early_return_source(frames: usize) -> String {
+    let stop_at = frames / 2 + 1;
+    format!(
+        "actor Maker {{\n\
+         \x20   receive gen fn frames() -> bytes {{\n\
+         \x20       for i in 0..{frames} {{\n\
+         \x20           yield \"frame-data\".to_bytes();\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var seen: i64 = 0;\n\
+         \x20   let m = spawn Maker;\n\
+         \x20   for await b in m.frames() {{\n\
+         \x20       if b.len() != 10 {{ return 91; }}\n\
+         \x20       seen = seen + 1;\n\
+         \x20       if seen >= {stop_at} {{\n\
+         \x20           return 0;\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         \x20   92\n\
+         }}\n"
+    )
+}
+
+/// `return v` — the loop variable moves to the caller, who reads it after
+/// the stream loop is gone. Neither the body-end release nor the return-edge
+/// release may fire (over-emitting frees the caller's string; under the
+/// scribble triple the post-return `println` reads poison or trips a guard
+/// page).
+fn gen_stream_return_carry_source() -> String {
+    "actor Maker {\n\
+     \x20   receive gen fn items() -> string {\n\
+     \x20       yield \"escaped\";\n\
+     \x20       yield \"rest\";\n\
+     \x20   }\n\
+     }\n\
+     fn first(m: LocalPid<Maker>) -> string {\n\
+     \x20   for await v in m.items() {\n\
+     \x20       return v;\n\
+     \x20   }\n\
+     \x20   \"none\"\n\
+     }\n\
+     fn main() {\n\
+     \x20   println(\"before\");\n\
+     \x20   let m = spawn Maker;\n\
+     \x20   let s = first(m);\n\
+     \x20   println(s);\n\
+     \x20   println(\"after\");\n\
+     }\n"
+    .to_string()
+}
+
+/// Full-drain slope oracle for the actor-generator string stream (the
+/// consumer decode copy is released at body end, one per yield).
+#[test]
+fn gen_stream_string_drain_no_per_frame_leak_slope() {
+    assert_per_frame_slope_below_tolerance(
+        "gen_stream_string_drain",
+        gen_stream_string_drain_source,
+    );
+}
+
+/// Early-return slope oracle: a `return`-carrying body path must not
+/// suppress the per-iteration release (pre-fix slope 1.0 leak/frame).
+#[test]
+fn gen_stream_string_early_return_no_per_frame_leak_slope() {
+    assert_per_frame_slope_below_tolerance(
+        "gen_stream_string_early_return",
+        gen_stream_string_early_return_source,
+    );
+}
+
+/// Bytes variant of the early-return slope oracle.
+#[test]
+fn gen_stream_bytes_early_return_no_per_frame_leak_slope() {
+    assert_per_frame_slope_below_tolerance(
+        "gen_stream_bytes_early_return",
+        gen_stream_bytes_early_return_source,
+    );
+}
+
+/// Exactly-once wall for the return edge: a loop variable RETURNED to the
+/// caller is caller-owned; the return-edge release must stay suppressed.
+#[test]
+fn gen_stream_returned_loop_var_no_uaf() {
+    assert_payload_escape_prints(
+        "gen_stream_return_carry",
+        &gen_stream_return_carry_source(),
+        &["before", "escaped", "after"],
+    );
+}

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -36865,6 +36865,44 @@ fn place_refs_local(place: Place, local: u32) -> bool {
     base_local(place) == Some(local)
 }
 
+/// True when every reference to `local` inside `args` is a borrow `contract`
+/// proves — a borrowing string-argument position (`hew_string_concat`,
+/// `print`/`println`, …), or the collection/Vec/bytes receiver slot
+/// (`args[0]`; a reference anywhere in the by-value tail `args[1..]` still
+/// counts as unproven). `true` when `local` does not appear in `args` at all.
+///
+/// Shared by the `Terminator::Call` arm of
+/// [`generator_yield_terminator_escapes`] and the `Instr::CallRuntimeAbi` arm
+/// of [`generator_yield_instr_escapes`] — the SAME closed, positive-
+/// membership ownership-contract table
+/// `binder_read_is_borrow_safe_{instr,terminator}` consults, never a
+/// structural "any call is a borrow" rule. A callee outside the list —
+/// including a directly-resolved user Hew function — is unproven: it may
+/// forward the argument back out as its own return value (an
+/// identity/pass-through helper: validators, `.trim()`-style wrappers,
+/// decorators), which would let the generator/recv-yield exit-edge ledger
+/// (`return`/`break`/`continue`) free the buffer the call just handed to its
+/// caller — a silent use-after-free (GitHub issue #2412: `return
+/// wrap(v)`). Fail-closed: unproven is NOT borrow-safe, never re-admitted
+/// (LESSONS `boundary-fail-closed`). WHEN OBSOLETE: the COW retain-on-share
+/// spine (A240) replaces this leak-on-uncertainty posture with an exact
+/// retain, and every `Call` argument can be admitted unconditionally.
+fn call_args_borrow_safe(
+    contract: crate::runtime_symbols::CalleeOwnershipContract,
+    args: &[Place],
+    local: u32,
+) -> bool {
+    let refs = |p: &Place| place_refs_local(*p, local);
+    if !args.iter().any(refs) {
+        return true;
+    }
+    let receiver_borrow_safe = (contract.borrows_vec_receiver()
+        || contract.borrows_collection_receiver()
+        || contract.borrows_bytes_receiver())
+        && !args.iter().skip(1).any(refs);
+    contract.borrows_string_call_args() || receiver_borrow_safe
+}
+
 /// True when an instruction transfers ownership of `local` out of its slot
 /// (so a body-end drop of the binding would be unsound). A fresh, solely-owned
 /// generator-yielded value escapes only via:
@@ -36931,12 +36969,29 @@ fn generator_yield_instr_escapes(instr: &Instr, local: u32) -> bool {
         } => state.is_some_and(&refs) || init_args.iter().any(|p| refs(*p)),
         Instr::SpawnTaskDirect { task, .. } => refs(*task),
         Instr::SpawnTaskClosure { task, env, .. } => refs(*task) || refs(*env),
-        // Borrowing reads — a getter / runtime-ABI / arithmetic operand does
-        // not retain the yielded value. These do NOT escape it.
-        Instr::CallRuntimeAbi(_)
-        | Instr::CallClosure { .. }
-        | Instr::CallTraitMethod { .. }
-        | Instr::EnterContext
+        // A `CallRuntimeAbi` argument is a borrow only when its callee symbol
+        // is on the closed ownership-contract list [`call_args_borrow_safe`]
+        // consults — see its doc comment. Any callee outside that list is
+        // unproven and counts as an escape (fail-closed).
+        Instr::CallRuntimeAbi(call) => !call_args_borrow_safe(
+            crate::runtime_symbols::callee_ownership_contract(call.symbol()),
+            call.args(),
+            local,
+        ),
+        // A closure or trait-method call is dynamic dispatch — no
+        // compile-time symbol to consult an ownership contract for. Any
+        // reference to `local` (the callee/receiver pair itself, or an
+        // argument) is unproven and counts as an escape (fail-closed; same
+        // rationale as the `CallRuntimeAbi` arm above).
+        Instr::CallClosure { callee, args, .. } => {
+            refs(*callee) || args.iter().any(|p| refs(*p))
+        }
+        Instr::CallTraitMethod {
+            fat_pointer, args, ..
+        } => refs(*fat_pointer) || args.iter().any(|p| refs(*p)),
+        // Borrowing reads — a context/cancellation query or an arithmetic
+        // operand does not retain the yielded value. These do NOT escape it.
+        Instr::EnterContext
         | Instr::ExitContext
         | Instr::CheckCancellation
         | Instr::ContextField { .. }
@@ -37008,8 +37063,8 @@ fn generator_yield_instr_escapes(instr: &Instr, local: u32) -> bool {
 /// True when a terminator transfers ownership of `local` out of the body: a
 /// return moves it to the caller, a re-yield hands it back to a consumer, an
 /// actor send/ask/select transfers it into the message. A `Call` argument is a
-/// borrow (the callee does not retain a fresh yielded value), so a `Call`
-/// terminator does not escape it.
+/// borrow ONLY when the callee is on the closed ownership-contract borrow
+/// list — see [`generator_yield_terminator_escapes`]'s `Terminator::Call` arm.
 #[allow(
     clippy::match_same_arms,
     reason = "exhaustive match over every Terminator variant; the non-escaping \
@@ -37058,9 +37113,18 @@ fn generator_yield_terminator_escapes(
     local: u32,
 ) -> bool {
     match term {
-        // A `Call`'s args are borrows (same posture as `Instr::Call*`).
-        Terminator::Call { .. }
-        | Terminator::Goto { .. }
+        // A `Call`'s args are a borrow only when the callee is on the closed
+        // ownership-contract list [`call_args_borrow_safe`] consults — see
+        // its doc comment. A callee outside that list — including a
+        // directly-resolved user Hew function — is unproven and counts as an
+        // escape (fail-closed): it may forward the argument back out as its
+        // own return value (GitHub issue #2412: `return wrap(v)`).
+        Terminator::Call { callee, args, .. } => !call_args_borrow_safe(
+            crate::runtime_symbols::callee_ownership_contract(callee),
+            args,
+            local,
+        ),
+        Terminator::Goto { .. }
         | Terminator::Branch { .. }
         | Terminator::Trap { .. }
         | Terminator::MakeGenerator { .. } => false,

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -11350,12 +11350,21 @@ impl Builder {
     /// escape scan; the inline drop's null-after-free makes a structurally-
     /// reachable second free a no-op (`raii-null-after-move`; the runtime
     /// also null-guards).
-    fn emit_generator_yield_value_drops_for_break_continue(&mut self, loop_scope_depth: usize) {
+    ///
+    /// EXIT-EDGE FAMILY (`cleanup-all-exits`): `break` and `continue` pass
+    /// their loop frame's `scope_depth` (free only the entries inside the loop
+    /// being left); an early `return` passes `min_scope_depth = 0` because a
+    /// return leaves EVERY enclosing consuming body — each active entry is the
+    /// current iteration's live value and must be freed on that edge. The same
+    /// per-entry escape scan protects all three edges: `return v` has already
+    /// moved the value into `Place::ReturnSlot`, so the scan sees the Move and
+    /// refuses the drop (the caller owns the release).
+    fn emit_generator_yield_value_drops_for_exit_edge(&mut self, min_scope_depth: usize) {
         let to_drop: Vec<(Place, ResolvedTy, crate::model::DropFnSpec, u32, usize)> = self
             .active_generator_yield_values
             .iter()
             .rev()
-            .filter(|(depth, _, _, _, _, _)| *depth >= loop_scope_depth)
+            .filter(|(depth, _, _, _, _, _)| *depth >= min_scope_depth)
             .map(|(_, place, ty, drop_fn, start_block_id, start_instr_len)| {
                 (
                     *place,
@@ -13607,6 +13616,15 @@ impl Builder {
                 // point — mutable vars have their final value; moved bindings
                 // are flagged by the move-checker.
                 self.emit_defers_for_return();
+                // Free every active consuming-body yielded value on the
+                // return edge (`cleanup-all-exits`): a `return` inside a
+                // `for await v in stream` / `for x in gen()` body exits the
+                // loop past the body-end drop, so the current iteration's
+                // received value must be released here. After defers (a defer
+                // may still read the value), before sealing. `return v` is
+                // protected by the per-entry escape scan — the ReturnSlot
+                // Move above marks the value caller-owned.
+                self.emit_generator_yield_value_drops_for_exit_edge(0);
                 // Seal the current basic block with Terminator::Return so
                 // codegen actually emits an early return at this program
                 // point. Codegen consumes the block terminator (not the
@@ -13623,6 +13641,9 @@ impl Builder {
             HirStmtKind::Return(None) => {
                 // Emit defers before the unit return.
                 self.emit_defers_for_return();
+                // Release the current iteration's yielded value(s) on this
+                // return edge — same discipline as Return(Some) above.
+                self.emit_generator_yield_value_drops_for_exit_edge(0);
                 self.statements.push(MirStatement::Return {
                     site: None,
                     ty: ResolvedTy::Unit,
@@ -17175,7 +17196,7 @@ impl Builder {
                 // edge (the body-end drop is past the break — would leak it).
                 // Value before handle: the yielded buffer is inner heap, the
                 // handle owns the coro frame + heap companion (LIFO inner-first).
-                self.emit_generator_yield_value_drops_for_break_continue(frame.scope_depth);
+                self.emit_generator_yield_value_drops_for_exit_edge(frame.scope_depth);
                 // Release in-loop generators on the break edge so the
                 // break-iteration's coro frame + heap companion are not leaked.
                 self.emit_generator_drops_for_break_continue(frame.scope_depth);
@@ -17220,6 +17241,11 @@ impl Builder {
                     });
                 }
                 self.emit_defers_for_return();
+                // Release the current iteration's yielded value(s) on this
+                // return edge — same discipline as the statement-position
+                // return (`cleanup-all-exits`; the per-entry escape scan
+                // keeps a `return v` caller-owned).
+                self.emit_generator_yield_value_drops_for_exit_edge(0);
                 self.finish_current_block(Terminator::Return);
                 let dead = self.alloc_block();
                 self.start_dead_block(dead);
@@ -17232,7 +17258,7 @@ impl Builder {
                 // Free the continued iteration's yielded heap value(s) on the
                 // continue edge (the body-end drop is past the continue — would
                 // leak it). Value before handle (LIFO inner-first).
-                self.emit_generator_yield_value_drops_for_break_continue(frame.scope_depth);
+                self.emit_generator_yield_value_drops_for_exit_edge(frame.scope_depth);
                 // Release in-loop generators on the continue edge so the
                 // skipped iteration's coro frame + heap companion are not leaked.
                 self.emit_generator_drops_for_break_continue(frame.scope_depth);
@@ -19152,6 +19178,15 @@ impl Builder {
                   ceiling without changing the function's structural \
                   responsibility (single yield-block walk)"
     )]
+    #[allow(
+        clippy::match_same_arms,
+        reason = "`Trap` (diverging abort — no continuation to leak into) and \
+                  `Return` (non-carrying function exit — the ReturnSlot Move \
+                  is the escape, caught by the instruction scan) are both \
+                  drop-safe for DIFFERENT reasons; folding them would let a \
+                  future body-exiting terminator inherit the wrong \
+                  justification"
+    )]
     fn generator_yield_block_paths_drop_safe(
         &self,
         block_id: u32,
@@ -19284,11 +19319,24 @@ impl Builder {
                         )
                     }
                     Terminator::Trap { .. } => true,
+                    // A `Return`-terminated path exits the function WITHOUT
+                    // carrying the binding: `return v` moves the value through
+                    // an `Instr::Move` into `Place::ReturnSlot`, and that Move
+                    // is already classified as an escape by the instruction
+                    // scan above. The return edge releases the current
+                    // iteration's value itself (the return lowering fires the
+                    // active yield-value ledger before sealing the block), and
+                    // that edge is CFG-mutually-exclusive with the body-end /
+                    // break-edge drops — so a non-carrying `Return` path is
+                    // drop-safe. Answering false here poisoned the WHOLE
+                    // binding: one early-return path suppressed the body-end
+                    // drop and leaked every iteration's received value
+                    // (#2412's early-return shape, one node per yield).
+                    Terminator::Return => true,
                     // `Suspend` never appears in a generator body (gen bodies
                     // use `Yield`); a body-end drop across it is conservatively
                     // unsound here, like the other body-exiting terminators.
-                    Terminator::Return
-                    | Terminator::Yield { .. }
+                    Terminator::Yield { .. }
                     | Terminator::Send { .. }
                     | Terminator::Ask { .. }
                     | Terminator::RemoteAsk { .. }

--- a/hew-mir/tests/lowering_expr.rs
+++ b/hew-mir/tests/lowering_expr.rs
@@ -10,6 +10,8 @@ mod bytes_literal_lowering;
 mod cstring_container_domain_canary;
 #[path = "lowering_expr/elaborate.rs"]
 mod elaborate;
+#[path = "lowering_expr/forawait_loopvar_release.rs"]
+mod forawait_loopvar_release;
 #[path = "lowering_expr/gen_block_mir_lowering.rs"]
 mod gen_block_mir_lowering;
 #[path = "lowering_expr/generic_record_layout_test.rs"]

--- a/hew-mir/tests/lowering_expr/forawait_loopvar_release.rs
+++ b/hew-mir/tests/lowering_expr/forawait_loopvar_release.rs
@@ -194,6 +194,128 @@ fn forawait_returned_loop_var_escapes_without_release() {
     );
 }
 
+/// `return wrap(v)`, where `wrap` is an identity pass-through
+/// (`fn wrap(v: string) -> string { return v; }`), forwards the loop
+/// variable's buffer through a `Terminator::Call` before it reaches the
+/// return slot. Neither the body-end drop nor the return-edge drop may
+/// fire: `wrap` is not a verified borrowing callee (it is not on the
+/// runtime ownership-contract table's closed borrow list), so its `v`
+/// argument must be treated as an escape — exactly like `return v`
+/// itself, just one call-hop removed. Before the fix the escape scan
+/// blanket-treated every `Terminator::Call` argument as a borrow, so the
+/// return-edge ledger fired a release AFTER `wrap` had already threaded
+/// the same buffer into its own return value: a use-after-free the
+/// caller reads as an emptied string (issue #2412 / #2463).
+#[test]
+fn forawait_return_forwarded_via_call_escapes_without_release() {
+    let pl = pipeline_with_tc(
+        r#"
+        actor Maker {
+            receive gen fn items() -> string {
+                yield "one";
+                yield "two";
+            }
+        }
+        fn wrap(v: string) -> string {
+            return v;
+        }
+        fn first(m: LocalPid<Maker>) -> string {
+            for await v in m.items() {
+                return wrap(v);
+            }
+            ""
+        }
+        fn main() {
+            let m = spawn Maker;
+            let s = first(m);
+            println(s);
+        }
+        "#,
+    );
+    assert_no_nyi(&pl);
+    let (return_edge, fall_through) = string_drops_by_edge(&pl, "first");
+    assert_eq!(
+        (return_edge, fall_through),
+        (0, 0),
+        "a loop variable forwarded through an identity callee (`wrap`) is not \
+         on the verified-borrow list; any emitted release double-frees the \
+         buffer `wrap`'s return value shares with it"
+    );
+}
+
+/// `break`-edge analogue of the identity-forwarding shape: the same ledger
+/// emitter (`emit_generator_yield_value_drops_for_exit_edge`) and the same
+/// escape scan protect `break` as `return` — this proves the fix closes
+/// both exit edges, not just the return edge.
+#[test]
+fn forawait_break_forwarded_via_call_escapes_without_release() {
+    let pl = pipeline_with_tc(
+        r#"
+        actor Maker {
+            receive gen fn items() -> string {
+                yield "one";
+                yield "two";
+            }
+        }
+        fn wrap(v: string) -> string {
+            return v;
+        }
+        fn main() -> i64 {
+            let m = spawn Maker;
+            var carry = "init";
+            for await v in m.items() {
+                carry = wrap(v);
+                break;
+            }
+            println(carry);
+            0
+        }
+        "#,
+    );
+    assert_no_nyi(&pl);
+    let f = pl
+        .raw_mir
+        .iter()
+        .find(|f| f.name == "main")
+        .expect("function must be present in raw_mir");
+    // Identify `v`'s own Place from the `wrap` call site: `args[0]` of the
+    // `Terminator::Call { callee: "wrap", .. }` IS the loop variable's place.
+    // Scoping the drop count to that exact place (rather than every
+    // `hew_string_drop` in `main`) keeps this assertion independent of the
+    // unrelated, EXPECTED drop-on-reassignment release that fires for
+    // `carry`'s own prior value ("init") when `carry = wrap(v)` overwrites it.
+    let v_place = f
+        .blocks
+        .iter()
+        .find_map(|block| match &block.terminator {
+            Terminator::Call { callee, args, .. } if callee == "wrap" => Some(args[0]),
+            _ => None,
+        })
+        .expect("a `wrap` call terminator must be present in `main`");
+    let v_place_drops: usize = f
+        .blocks
+        .iter()
+        .flat_map(|block| block.instructions.iter())
+        .filter(|i| {
+            matches!(
+                i,
+                Instr::Drop {
+                    place,
+                    ty: ResolvedTy::String,
+                    drop_fn: Some(s),
+                    ..
+                } if *place == v_place && *s == hew_mir::DropFnSpec::Release("hew_string_drop")
+            )
+        })
+        .count();
+    assert_eq!(
+        v_place_drops, 0,
+        "a loop variable forwarded through an identity callee (`wrap`) before \
+         `break` is not on the verified-borrow list; any emitted release of \
+         `v`'s own place double-frees the buffer `carry` now aliases"
+    );
+}
+
 /// The sync-generator consumer (`for x in gen()`) shares the same body walk:
 /// an early `return` must not poison its per-iteration release either.
 #[test]

--- a/hew-mir/tests/lowering_expr/forawait_loopvar_release.rs
+++ b/hew-mir/tests/lowering_expr/forawait_loopvar_release.rs
@@ -1,0 +1,274 @@
+//! For-await / generator consumer loop-variable release on early-`return`
+//! bodies.
+//!
+//! The consuming body of `for await v in stream` (and `for x in gen()`)
+//! releases its fresh, solely-owned yielded value on every path out of the
+//! body: the fall-through body-end drop, the `break`/`continue` edge drops,
+//! and — pinned here — the early-`return` edge. A `Terminator::Return` on
+//! some body path must not be treated as an ownership escape of the loop
+//! variable: doing so suppressed the body-end drop for the WHOLE binding, so
+//! every iteration leaked its received value (one `alloc_cstring_data` node
+//! per yield), not just the returning one.
+//!
+//! Exactly-once walls (the wrong fix is a double-free):
+//!   * the return edge and the body-end drop are mutually exclusive in the
+//!     CFG — each runtime path releases once;
+//!   * `return v` (the loop variable itself) moves ownership to the caller:
+//!     BOTH releases must stay suppressed (leak-not-double-free posture; the
+//!     `ReturnSlot` `Instr::Move` is the escape the body scan catches).
+//!
+//! LESSONS: cleanup-all-exits (P1), raii-null-after-move (P0),
+//! drop-allowset-from-value-flow (P0).
+
+use hew_hir::{lower_program, ResolutionCtx};
+use hew_mir::{lower_hir_module, Instr, IrPipeline, Terminator};
+use hew_types::module_registry::ModuleRegistry;
+use hew_types::{Checker, ResolvedTy};
+
+/// Full front-half pipeline with type-checking (actors, streams, and
+/// generators need checker side-tables to lower).
+fn pipeline_with_tc(source: &str) -> IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:#?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    let output = lower_program(
+        &parsed.program,
+        &tc_output,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    lower_hir_module(&output.module)
+}
+
+/// Inline `hew_string_drop` releases in `fn_name`, split by whether the
+/// carrying block ends in `Terminator::Return` (the early-return edge) or not
+/// (the body-end / fall-through release).
+fn string_drops_by_edge(pl: &IrPipeline, fn_name: &str) -> (usize, usize) {
+    let f = pl
+        .raw_mir
+        .iter()
+        .find(|f| f.name == fn_name)
+        .expect("function must be present in raw_mir");
+    let mut on_return_edge = 0;
+    let mut on_fall_through = 0;
+    for block in &f.blocks {
+        let drops = block
+            .instructions
+            .iter()
+            .filter(|i| {
+                matches!(
+                    i,
+                    Instr::Drop {
+                        ty: ResolvedTy::String,
+                        drop_fn: Some(s),
+                        ..
+                    } if *s == hew_mir::DropFnSpec::Release("hew_string_drop")
+                )
+            })
+            .count();
+        if matches!(block.terminator, Terminator::Return) {
+            on_return_edge += drops;
+        } else {
+            on_fall_through += drops;
+        }
+    }
+    (on_return_edge, on_fall_through)
+}
+
+fn assert_no_nyi(pl: &IrPipeline) {
+    let nyi: Vec<_> = pl
+        .diagnostics
+        .iter()
+        .filter(|d| matches!(d.kind, hew_mir::MirDiagnosticKind::NotYetImplemented { .. }))
+        .collect();
+    assert!(nyi.is_empty(), "unexpected NYI diagnostics: {nyi:#?}");
+}
+
+/// An early `return` on one body path must not suppress the fall-through
+/// body-end release: iterations that do NOT return still free their received
+/// string. Pre-fix this was the 1-leak-per-received-value shape — the
+/// `Terminator::Return` arm of the body walk answered "unsafe", poisoning the
+/// whole binding.
+#[test]
+fn forawait_early_return_body_keeps_body_end_release() {
+    let pl = pipeline_with_tc(
+        r#"
+        actor Maker {
+            receive gen fn items() -> string {
+                yield "one";
+                yield "two";
+            }
+        }
+        fn main() -> i64 {
+            let m = spawn Maker;
+            for await v in m.items() {
+                if v.len() > 3 {
+                    return 1;
+                }
+            }
+            0
+        }
+        "#,
+    );
+    assert_no_nyi(&pl);
+    let (_, fall_through) = string_drops_by_edge(&pl, "main");
+    assert!(
+        fall_through >= 1,
+        "the fall-through body-end release must survive an early-return path \
+         (its absence leaks every non-returning iteration's received string)"
+    );
+}
+
+/// The returning iteration's received value is freed ON the return edge —
+/// the body-end drop sits past the `return` and never runs on that path.
+#[test]
+fn forawait_early_return_edge_releases_current_iteration() {
+    let pl = pipeline_with_tc(
+        r#"
+        actor Maker {
+            receive gen fn items() -> string {
+                yield "one";
+                yield "two";
+            }
+        }
+        fn main() -> i64 {
+            let m = spawn Maker;
+            for await v in m.items() {
+                if v.len() > 3 {
+                    return 1;
+                }
+            }
+            0
+        }
+        "#,
+    );
+    assert_no_nyi(&pl);
+    let (return_edge, _) = string_drops_by_edge(&pl, "main");
+    assert_eq!(
+        return_edge, 1,
+        "the early-return edge must release exactly the current iteration's \
+         received string (0 = the returning iteration leaks; >1 = a second \
+         holder was dropped on the same edge)"
+    );
+}
+
+/// `return v` moves the loop variable to the caller: neither the body-end
+/// drop nor the return-edge drop may fire (the caller owns the release).
+/// Leak-not-double-free posture — over-emitting here frees the value the
+/// caller still reads.
+#[test]
+fn forawait_returned_loop_var_escapes_without_release() {
+    let pl = pipeline_with_tc(
+        r#"
+        actor Maker {
+            receive gen fn items() -> string {
+                yield "one";
+                yield "two";
+            }
+        }
+        fn first(m: LocalPid<Maker>) -> string {
+            for await v in m.items() {
+                return v;
+            }
+            ""
+        }
+        fn main() {
+            let m = spawn Maker;
+            let s = first(m);
+            println(s);
+        }
+        "#,
+    );
+    assert_no_nyi(&pl);
+    let (return_edge, fall_through) = string_drops_by_edge(&pl, "first");
+    assert_eq!(
+        (return_edge, fall_through),
+        (0, 0),
+        "a loop variable moved out by `return v` is owned by the caller; any \
+         emitted release double-frees the returned string"
+    );
+}
+
+/// The sync-generator consumer (`for x in gen()`) shares the same body walk:
+/// an early `return` must not poison its per-iteration release either.
+#[test]
+fn sync_generator_early_return_keeps_body_end_release() {
+    let pl = pipeline_with_tc(
+        r#"
+        gen fn names() -> string {
+            yield "alpha";
+            yield "beta";
+        }
+        fn pick() -> i64 {
+            for x in names() {
+                if x.len() > 4 {
+                    return 1;
+                }
+            }
+            0
+        }
+        fn main() {
+            let n = pick();
+            println(f"{n}");
+        }
+        "#,
+    );
+    assert_no_nyi(&pl);
+    let (return_edge, fall_through) = string_drops_by_edge(&pl, "pick");
+    assert!(
+        fall_through >= 1,
+        "the sync-generator body-end release must survive an early-return path"
+    );
+    assert_eq!(
+        return_edge, 1,
+        "the sync-generator early-return edge must release the current \
+         iteration's yielded string exactly once"
+    );
+}
+
+/// A `break` that follows a `return`-carrying path in the same body keeps its
+/// break-edge release: the break-edge emitter re-runs the same body walk, so
+/// a `Return`-poisoned walk would silently suppress this edge too.
+#[test]
+fn forawait_break_edge_release_survives_sibling_return_path() {
+    let pl = pipeline_with_tc(
+        r#"
+        actor Maker {
+            receive gen fn items() -> string {
+                yield "one";
+                yield "two";
+            }
+        }
+        fn main() -> i64 {
+            let m = spawn Maker;
+            for await v in m.items() {
+                if v.len() > 30 {
+                    return 1;
+                }
+                if v.len() > 2 {
+                    break;
+                }
+            }
+            0
+        }
+        "#,
+    );
+    assert_no_nyi(&pl);
+    let (return_edge, fall_through) = string_drops_by_edge(&pl, "main");
+    assert_eq!(
+        return_edge, 1,
+        "the return edge releases the current iteration's received string"
+    );
+    // Body-end release + break-edge release both live in non-Return blocks;
+    // they are CFG-mutually-exclusive per iteration.
+    assert!(
+        fall_through >= 2,
+        "both the body-end release and the break-edge release must survive a \
+         sibling return path (got {fall_through})"
+    );
+}

--- a/tests/vertical-slice/accept/receive_gen_fn_stream_early_return.expected
+++ b/tests/vertical-slice/accept/receive_gen_fn_stream_early_return.expected
@@ -1,0 +1,1 @@
+found at 3

--- a/tests/vertical-slice/accept/receive_gen_fn_stream_early_return.hew
+++ b/tests/vertical-slice/accept/receive_gen_fn_stream_early_return.hew
@@ -1,0 +1,32 @@
+// Early `return` out of a `for await` drain: the consuming body's
+// per-iteration release survives a return-carrying path (iterations before
+// the hit release at body end), the returning iteration's received string is
+// released on the return edge itself, and the caller-facing result is
+// computed from the received values — proving no release fires early. The
+// per-yield leak slope for this shape is pinned by the recv-loop leak oracle
+// in hew-cli.
+actor Namer {
+    receive gen fn names() -> string {
+        yield "ab";
+        yield "cdef";
+        yield "gamma";
+        yield "never-sent";
+    }
+}
+
+fn find_len(n: LocalPid<Namer>, want: i64) -> i64 {
+    var seen: i64 = 0;
+    for await v in n.names() {
+        seen = seen + 1;
+        if v.len() >= want {
+            return seen;
+        }
+    }
+    0 - 1
+}
+
+fn main() {
+    let n = spawn Namer;
+    let at = find_len(n, 5);
+    println(f"found at {at}");
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -2607,6 +2607,12 @@ run_accept_expect_stdout "receive_gen_fn_owned_record_yield"
 run_accept_expect_stdout "receive_gen_fn_owned_enum_yield"
 run_accept_expect_stdout "receive_gen_fn_record_stream_break"
 
+# Early `return` out of a `for await` drain: the body-end release survives a
+# return-carrying path, the returning iteration's received string is released
+# on the return edge, and the returned result proves the received values were
+# intact when read. Leak slope pinned by the recv-loop leak oracle in hew-cli.
+run_accept_expect_stdout "receive_gen_fn_stream_early_return"
+
 # Fault (producer crash): the gen body yields once, then traps on a
 # runtime div-by-zero. The consumer, having already received the first value,
 # must observe the fault on its next resume — never a clean, silent EOF. The


### PR DESCRIPTION
## Why

Draining an actor generator stream that yields owned values leaked the
consumer's `for await v in stream { ... }` loop variable whenever the body
exited early. A `return` anywhere in the loop body suppressed the
per-iteration release for every iteration (not just the one that returned),
and `break`/`continue` had a separate use-after-free hazard: if the loop
variable was forwarded through an identity/pass-through callee
(`carry = wrap(v); break;` where `wrap` just returns its argument), the
exit-edge ledger freed `v`'s buffer after the call had already threaded that
same buffer into its return value — corrupting the caller's copy instead of
leaking it.

## What

- **`generator_yield_block_paths_drop_safe`**: a non-carrying `Terminator::Return`
  path is now drop-safe (it never transfers the loop variable — `return v`
  is caught separately by the instruction scan's `ReturnSlot` move). Answering
  `false` here previously poisoned the whole binding's body-end drop the
  moment any path in the body contained a `return`.
- **Return edges now fire the same exit-edge release break/continue already
  had** (`emit_generator_yield_value_drops_for_exit_edge`, renamed from
  `emit_generator_yield_value_drops_for_break_continue`), at scope-depth
  floor 0 — one mechanism for all three exit edges instead of return being
  unhandled.
- **Call-argument escape scan hardened.** `generator_yield_terminator_escapes`
  and `generator_yield_instr_escapes` no longer treat every call argument as
  a non-escaping borrow. They now consult a closed, positive-membership
  runtime ownership-contract table (`callee_ownership_contract`) through a
  new `call_args_borrow_safe` helper — the same table
  `binder_read_is_borrow_safe_{instr,terminator}` already uses for the
  enum-composite drop prover. A callee outside that list, including any
  directly-resolved Hew function or a closure/trait-method call, is treated
  as an escape and the exit-edge drop is retracted. Fail-closed: an unproven
  callee stays a leak, never a double-free.

## Test

- `hew-cli/tests/recv_loop_leak_oracle.rs`: pins the return-edge release
  slope across an early-return body, plus
  `gen_stream_return_forwarded_via_call_no_uaf` and
  `gen_stream_break_forwarded_via_call_no_uaf` (full-process GuardMalloc
  stdout-content assertions for the identity-callee-forwarding shape on
  both edges).
- `hew-mir/tests/lowering_expr/forawait_loopvar_release.rs`: MIR-level
  place-scoped drop-instruction-count assertions, including
  `forawait_return_forwarded_via_call_escapes_without_release` and
  `forawait_break_forwarded_via_call_escapes_without_release`.
- `tests/vertical-slice/accept/receive_gen_fn_stream_early_return.hew`: new
  accepted fixture for the early-return drain shape.

## Out of scope

- `call_args_borrow_safe` doesn't yet recognize the bytes-all-args-borrow
  contract (`hew_bytes_append`, where the receiver and the unpacked source
  triple are all borrows) that the sibling `binder_read_is_borrow_safe_*`
  functions already handle. Bounded to an extra leak in a narrow shape (a
  loop variable threaded into `hew_bytes_append`'s source triple, then
  exiting via return/break/continue) — never a double-free. Filed as #2474.
- The for-await early-return edge still leaks a constant, non-growing
  stream cursor (the block-scope `StreamClose` only fires on the
  fall-through path) — a different holder than the loop variable this PR
  addresses. Not filed yet.
- A for-await body that suspends mid-body (an `ask` before the next
  iteration) suppresses the loop variable's body-end release on the resume
  path — noted from the escape-scan's structure, not reproduced. Not filed
  yet.

Fixes #2412
Fixes #2463
