### PR TITLE
test(runtime): serialize task_scope tests that share global test counters

### DIFF
--- a/hew-runtime/src/task_scope.rs
+++ b/hew-runtime/src/task_scope.rs
@@ -2895,6 +2895,7 @@ mod tests {
 
     #[test]
     fn suspending_unit_task_await_cancel_frees_waiter_and_slot_once() {
+        let _guard = crate::runtime_test_guard();
         crate::read_slot::reset_read_slot_final_free_count_for_test();
         reset_task_await_waiter_final_free_count_for_test();
 
@@ -2935,6 +2936,7 @@ mod tests {
 
     #[test]
     fn suspending_unit_task_await_normal_completion_frees_waiter_and_slot_once() {
+        let _guard = crate::runtime_test_guard();
         crate::read_slot::reset_read_slot_final_free_count_for_test();
         reset_task_await_waiter_final_free_count_for_test();
 
@@ -2981,6 +2983,7 @@ mod tests {
         use crate::timer_wheel::{hew_timer_wheel_free, hew_timer_wheel_new, hew_timer_wheel_tick};
         use std::time::Duration;
 
+        let _guard = crate::runtime_test_guard();
         reset_await_cancel_final_free_count_for_test();
         // SAFETY: the registration and wheel are owned by this test; cancellation
         // wins before the wheel fires, mirroring suspending sleep abandon.


### PR DESCRIPTION
PR #2336's own finding: `suspending_unit_task_await_cancel_frees_waiter_and_slot_once`, `suspending_unit_task_await_normal_completion_frees_waiter_and_slot_once`, and `suspending_sleep_cancel_and_completion_free_deadline_registration_once` (`hew-runtime/src/task_scope.rs`) reset and assert exact counts on process-global `cfg(test)` `AtomicUsize` statics (`READ_SLOT_FINAL_FREE_COUNT`, `TASK_AWAIT_WAITER_FINAL_FREE_COUNT`, `AWAIT_CANCEL_FINAL_FREE_COUNT`), but none of them call `runtime_test_guard()` (`SchedTestLock`) — unlike every other test in this crate that touches this kind of shared test-only state (e.g. `actor.rs`, `actor_group.rs`).

Under Rust's default parallel libtest harness — the fallback path taken when `cargo nextest` isn't installed, plus any ad-hoc `cargo test -p hew-runtime` invocation — two of these tests running concurrently in one process can reset/increment each other's counters mid-assertion, failing the exact `== 1` check with a stray increment from the sibling thread. `cargo nextest`'s own process-per-test model (the project's actual CI gate) isn't affected by this, so it doesn't show up there, but the plain-`cargo test` path is genuinely broken.

**Reproduced live before fixing:** running `suspending_unit_task_await_cancel_frees_waiter_and_slot_once` and `suspending_unit_task_await_normal_completion_frees_waiter_and_slot_once` together via `cargo test -p hew-runtime --lib suspending_unit_task_await` failed both, every attempt, with `left: 2, right: 1` (a stray increment from the sibling).

**Fix:** add `let _guard = crate::runtime_test_guard();` as the first statement of each of the three tests, matching the existing convention elsewhere in the crate. After the fix, 15/15 clean reruns of the same invocation.

Verified:
- `cargo test -p hew-runtime --lib`: 2025/2025 passing, 0 regressions
- `cargo fmt -p hew-runtime --check`: clean
- `cargo clippy -p hew-runtime --lib --tests -- -D warnings`: clean
- Full `tests/vertical-slice/run.sh`: exit 0 (430/430 RUN/PASS pairs)