### PR TITLE
fix(types): admit HashMap.keys() regardless of an unsupported value type

### DIFF
--- a/hew-codegen-rs/tests/exec/hashmap_keys_values_exec.rs
+++ b/hew-codegen-rs/tests/exec/hashmap_keys_values_exec.rs
@@ -276,21 +276,6 @@ fn hashmap_values_heap_bearing_record_rejected_with_one_exact_diagnostic() {
 }
 
 #[test]
-fn hashmap_keys_heap_bearing_value_rejected_with_one_exact_diagnostic() {
-    let repo = repo_root();
-    let fixture = repo.join("tests/vertical-slice/reject/hashmap_keys_managed_record.hew");
-    let (code, output) = check_hew_file(&repo, &fixture);
-    assert_eq!(
-        code, 1,
-        "keys() projection with heap-bearing map value must fail at check time; output:\n{output}"
-    );
-    assert_single_check_error_with_exact_diagnostic(
-        &output,
-        "`HashMap<i64, Vec<i64>>.keys()` is not yet supported: projecting from a map with value type `Vec<i64>` into an owned `Vec` is not lowered; supported projection value types are scalar primitives, `string`, and Copy record/enum types",
-    );
-}
-
-#[test]
 fn hashmap_keys_bytes_rejected_by_key_branch_with_one_exact_diagnostic() {
     let repo = repo_root();
     let fixture = repo.join("tests/vertical-slice/reject/hashmap_keys_bytes.hew");

--- a/hew-types/src/check/admissibility.rs
+++ b/hew-types/src/check/admissibility.rs
@@ -1308,7 +1308,14 @@ impl Checker {
             return true;
         }
 
-        if !self.is_supported_hashmap_projection_element_type(&resolved_val) {
+        // `keys()` only needs the key layout — `hew_hashmap_keys_layout`
+        // (hew-runtime/src/hashmap.rs) branches solely on `map.key_layout` and
+        // never reads the value layout at all, so a value type unsupported for
+        // projection (e.g. a managed `Vec<i64>`) must not block `.keys()`; it
+        // only actually blocks `.values()` (and the `into_iter`/`for (k, v) in m`
+        // desugars, which separately call this function again with
+        // `method == "values"` and so still gate the value type there).
+        if method != "keys" && !self.is_supported_hashmap_projection_element_type(&resolved_val) {
             self.report_error(
                 TypeErrorKind::InvalidOperation,
                 span,

--- a/tests/vertical-slice/accept/hashmap_keys_unsupported_value_type.hew
+++ b/tests/vertical-slice/accept/hashmap_keys_unsupported_value_type.hew
@@ -1,0 +1,20 @@
+// `HashMap<i64, Vec<i64>>.keys()` — the value type (`Vec<i64>`) is not a
+// supported HashMap *projection* value type (managed Vec, not a scalar/
+// string/Copy record), but `.keys()` never materializes values at all:
+// `hew_hashmap_keys_layout` (hew-runtime/src/hashmap.rs) branches solely on
+// `map.key_layout` and copies key blobs. Gating `.keys()` on the value type
+// was a checker false-positive (hew-lang/hew#2009's own finding) — fixed by
+// only gating the value-type check when `method != "keys"` in
+// `validate_hashmap_projection_element_types` (hew-types/src/check/
+// admissibility.rs). `.values()`/`into_iter()`/`for (k, v) in m` over this
+// same map must still correctly reject on the value type — see the sibling
+// `hashmap_values_managed_record.hew` reject fixture, which covers exactly
+// that (unchanged by this fix). One key inserted → keys().len() == 1. Exit 1.
+fn main() -> i64 {
+    let values: HashMap<i64, Vec<i64>> = HashMap::new();
+    let xs: Vec<i64> = Vec::new();
+    xs.push(42);
+    values.insert(1, xs);
+    let projected = values.keys();
+    projected.len()
+}

--- a/tests/vertical-slice/reject/hashmap_keys_managed_record.hew
+++ b/tests/vertical-slice/reject/hashmap_keys_managed_record.hew
@@ -1,8 +1,0 @@
-fn main() {
-    let values: HashMap<i64, Vec<i64>> = HashMap::new();
-    let xs: Vec<i64> = Vec::new();
-    xs.push(42);
-    values.insert(1, xs);
-    let projected = values.keys();
-    println(projected.len());
-}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -506,6 +506,8 @@ run_accept_expect_status "hashmap_for_in_owned" 35
 # match Vec. The map is shared (Capture), staying live after the pipeline.
 # count 3 entries → 3.
 run_accept_expect_status "hashmap_into_iter_count" 3
+
+run_accept_expect_status "hashmap_keys_unsupported_value_type" 1
 # map (k,v)->k+v then fold: keys 6 + values 60 → 66.
 run_accept_expect_status "hashmap_into_iter_map_fold" 66
 # filter values >= 20 then count: 2 of 3 pass → 2.
@@ -2851,16 +2853,6 @@ expect_check_fail_error_count \
   "${ROOT}/tests/vertical-slice/reject/hashmap_values_managed_record.hew" \
   1 \
   "hashmap_values_managed_record"
-
-# shellcheck disable=SC2016  # backtick-containing diagnostic strings; not shell expansion.
-expect_check_fail_contains \
-  "${ROOT}/tests/vertical-slice/reject/hashmap_keys_managed_record.hew" \
-  'HashMap<i64, Vec<i64>>.keys()` is not yet supported: projecting from a map with value type `Vec<i64>` into an owned `Vec` is not lowered' \
-  "hashmap_keys_managed_record"
-expect_check_fail_error_count \
-  "${ROOT}/tests/vertical-slice/reject/hashmap_keys_managed_record.hew" \
-  1 \
-  "hashmap_keys_managed_record"
 
 # shellcheck disable=SC2016  # backtick-containing diagnostic strings; not shell expansion.
 expect_check_fail_contains \


### PR DESCRIPTION
## Why

`validate_hashmap_projection_element_types` gated `.keys()` on **both** the
key and value type being supported HashMap projection element types (scalar
primitives, `string`, or Copy record/enum). But `.keys()` never materializes
values at all: `hew_hashmap_keys_layout` (`hew-runtime/src/hashmap.rs`)
branches solely on `map.key_layout` and copies key blobs — the value layout
is never read for this method.

`HashMap<i64, Vec<i64>>.keys()` failed `hew check` with a value-projection
diagnostic even though the key type (`i64`) is fully supported and the
runtime path never touches the value layout:

```
error: `HashMap<i64, Vec<i64>>.keys()` is not yet supported: projecting from
a map with value type `Vec<i64>` into an owned `Vec` is not lowered;
supported projection value types are scalar primitives, `string`, and Copy
record/enum types
```

## Fix

Only gate the value-type check when `method != "keys"` in
`validate_hashmap_projection_element_types`
(`hew-types/src/check/admissibility.rs`), mirroring the existing
method-conditional key-type check right below it.

`.values()` and the `into_iter()` / `for (k, v) in m` desugars are
unaffected — both call this same function again with `method == "values"`
(see `hew-types/src/check/methods.rs:4365-4366` and
`hew-types/src/check/statements.rs:1335-1341`), so they still correctly
reject a map whose value type can't be projected. Verified live against all
four call sites (`.keys()`, `.values()`, `.into_iter()`, `for (k, v) in m`)
before and after the fix, plus the sibling "unsupported key type" guard.

## Tests

Converted the `hashmap_keys_managed_record` reject fixture (which existed
specifically to pin the now-fixed false-positive) into an accept fixture,
`hashmap_keys_unsupported_value_type`, proving `.keys().len()` returns the
right count end-to-end via the compiled native binary. The sibling
`hashmap_values_managed_record` reject fixture is untouched and still covers
the genuinely-unsupported `.values()` case on the same shape of map.

- `cargo test -p hew-types --lib`: 1636/1636 (0 regressions)
- `cargo fmt -p hew-types --check`: clean
- `cargo clippy -p hew-types --lib --tests -- -D warnings`: clean
- Full `tests/vertical-slice/run.sh`: exit 0 (run twice independently)