### PR TITLE
fix(mir): make task-entry adapter symbols injective per callee

### DIFF
--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -48,7 +48,20 @@ use crate::ownership::ValueOwnership;
 use crate::ownership::ValueProvenance;
 use crate::ownership::VecElementRelease;
 
-type TaskEntryAdapterSymbols = Rc<RefCell<HashSet<String>>>;
+/// Maps each original (unsanitized) callee symbol to the adapter symbol
+/// generated for it. `mir_sanitize_symbol` maps every non-alphanumeric byte to
+/// `'_'`, which is lossy and non-injective (e.g. a generic monomorphization
+/// mangled as `worker$$i64` and an unrelated concrete function literally named
+/// `worker__i64` both sanitize to the same `worker__i64` name). Naively
+/// generating `__hew_task_entry_<sanitized>` per callee and deduping on either
+/// the sanitized name (wrong: two distinct callees silently share one
+/// adapter, so the second callee's task body never runs) or the plain
+/// sanitized name with dedup keyed on the original symbol instead (wrong: two
+/// distinct adapters would still collide on the same generated function
+/// name) both break. Keying this map by the original callee symbol and
+/// disambiguating with a numeric suffix on collision keeps every adapter
+/// symbol both stable-per-callee and unique-per-distinct-callee.
+type TaskEntryAdapterSymbols = Rc<RefCell<HashMap<String, String>>>;
 
 const HEW_CTX_OFFSET_ACTOR_ID: usize = 8;
 const HEW_CTX_OFFSET_PARENT_SUPERVISOR: usize = 16;
@@ -24699,15 +24712,44 @@ impl Builder {
         )
     }
 
+    /// Resolve (and, on first use, allocate) the task-entry adapter symbol
+    /// for `callee_symbol`. Stable across repeated calls with the same
+    /// `callee_symbol` (returns the previously allocated adapter symbol
+    /// without regenerating the adapter body). If the naive sanitized name
+    /// is already owned by a *different* original callee symbol, appends a
+    /// numeric disambiguation suffix so every distinct callee still gets its
+    /// own, uniquely named adapter.
     fn ensure_task_entry_adapter(&mut self, callee_symbol: &str, result_ty: &ResolvedTy) -> String {
-        let adapter_symbol = Self::task_entry_adapter_symbol(callee_symbol);
-        if !self
-            .task_entry_adapter_symbols
-            .borrow_mut()
-            .insert(adapter_symbol.clone())
-        {
-            return adapter_symbol;
+        if let Some(existing) = self.task_entry_adapter_symbols.borrow().get(callee_symbol) {
+            return existing.clone();
         }
+        let base_symbol = Self::task_entry_adapter_symbol(callee_symbol);
+        let already_used = self
+            .task_entry_adapter_symbols
+            .borrow()
+            .values()
+            .any(|used| used == &base_symbol);
+        let adapter_symbol = if already_used {
+            let mut candidate;
+            let mut suffix = 2usize;
+            loop {
+                candidate = format!("{base_symbol}__dup{suffix}");
+                let taken = self
+                    .task_entry_adapter_symbols
+                    .borrow()
+                    .values()
+                    .any(|used| used == &candidate);
+                if !taken {
+                    break candidate;
+                }
+                suffix += 1;
+            }
+        } else {
+            base_symbol
+        };
+        self.task_entry_adapter_symbols
+            .borrow_mut()
+            .insert(callee_symbol.to_string(), adapter_symbol.clone());
         let lowered = self.synthesize_task_entry_adapter(callee_symbol, &adapter_symbol, result_ty);
         self.generated_functions.push(lowered);
         adapter_symbol

--- a/tests/hew/task_entry_adapter_symbol_collision_test.hew
+++ b/tests/hew/task_entry_adapter_symbol_collision_test.hew
@@ -1,0 +1,76 @@
+//! Task-spawn adapter-symbol collision: `ensure_task_entry_adapter` must
+//! generate a distinct adapter for every distinct callee symbol, even when
+//! two unrelated callee symbols sanitize to the same lossy adapter name.
+//!
+//! `mir_sanitize_symbol` maps every non-alphanumeric byte in a callee symbol
+//! to `'_'`. That mapping is not injective: a generic monomorphization
+//! mangled as `worker$$i64` and an unrelated, literally-named concrete
+//! function `worker__i64` both sanitize to `worker__i64`, so a naive
+//! "generate `__hew_task_entry_<sanitized>` once per sanitized name" scheme
+//! would silently share one adapter between the two callees — every spawn of
+//! the *second* callee would actually run the *first* callee's body.
+//!
+//! VALUE ASSERTIONS pin the exact combined result (1 + 2 == 3) so a
+//! mis-routed spawn is caught by a wrong sum, not just a missing exit code.
+//! Both spawn orders are exercised because the adapter that gets the plain
+//! (non-suffixed) name depends on lowering order, not spawn order — the test
+//! must hold regardless of which callee is encountered first.
+
+import std::testing;
+
+// Generic free fn. Its `i64` monomorphization mangles to `worker$$i64`,
+// which `mir_sanitize_symbol` normalizes to `worker__i64` — the exact same
+// normalized form as the concrete function below.
+fn worker<T>() -> i64 {
+    return 1;
+}
+
+// Unrelated concrete function whose literal name collides with the
+// sanitized form of `worker`'s `i64` monomorphization.
+fn worker__i64() -> i64 {
+    return 2;
+}
+
+actor CollisionRunner {
+    receive fn run_original_order() -> i64 {
+        var total: i64 = 0;
+        scope {
+            fork a = worker::<i64>();
+            fork b = worker__i64();
+            let ra = await a;
+            let rb = await b;
+            total = ra + rb;
+        };
+        return total;
+    }
+
+    receive fn run_reversed_order() -> i64 {
+        var total: i64 = 0;
+        scope {
+            fork b = worker__i64();
+            fork a = worker::<i64>();
+            let rb = await b;
+            let ra = await a;
+            total = ra + rb;
+        };
+        return total;
+    }
+}
+
+#[test]
+fn test_task_entry_adapter_no_collision_original_order() {
+    let r = spawn CollisionRunner();
+    match await r.run_original_order() {
+        Ok(n) => testing.assert_eq(n, 3),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn test_task_entry_adapter_no_collision_reversed_order() {
+    let r = spawn CollisionRunner();
+    match await r.run_reversed_order() {
+        Ok(n) => testing.assert_eq(n, 3),
+        Err(_) => testing.assert_true(false),
+    }
+}


### PR DESCRIPTION
Fixes a silent wrong-function-execution bug found in PR #2160's review: `ensure_task_entry_adapter` generated `__hew_task_entry_<sanitized-callee-symbol>` and deduped purely on the *sanitized* name. `mir_sanitize_symbol` maps every non-alphanumeric byte to `'_'`, which is lossy and non-injective — a generic monomorphization mangled as `worker$$i64` and an unrelated concrete function literally named `worker__i64` both sanitize to `worker__i64`. The old code silently reused the first-generated adapter for the second callee too: every spawn of the second callee actually executed the *first* callee's body, with `hew check` passing clean and no diagnostic anywhere.

Repro (matching the review's own reported exit codes exactly): a generic `worker<T>() -> i64` (returns 1) plus an unrelated `worker__i64() -> i64` (returns 2), both `fork`-spawned and awaited inside an actor, summed and compared against the expected 3. Before the fix: both spawn orders return `2` (only the shared adapter's body ever runs). After the fix: both orders correctly return `3`.

**Fix:** key the adapter-symbol cache (`TaskEntryAdapterSymbols`) by the *original* callee symbol — unique per distinct callee upstream of this lowering — instead of the lossy sanitized name. When the naive sanitized name collides with a different original callee already using it, append a stable numeric suffix (`__dup2`, `__dup3`, ...) so the new adapter still gets its own uniquely-named generated function. Confirmed via `--dump-mir raw` that the fixed build now emits two distinct adapter functions (`__hew_task_entry_worker__i64` / `__hew_task_entry_worker__i64__dup2`), each correctly calling its own callee.

Added `tests/hew/task_entry_adapter_symbol_collision_test.hew`, covering both spawn orders since which callee gets the plain (non-suffixed) name depends on lowering order, not spawn order. Verified load-bearing: reverted the fix (kept the test), confirmed both orders fail with the exact predicted wrong sum; restored, confirmed both pass.

**Verified before pushing:**
- `cargo test -p hew-mir --lib`: 327 passed, 0 failed
- `cargo fmt -p hew-mir --check`: clean
- `cargo clippy -p hew-mir --lib --tests -- -D warnings`: clean
- `hew test tests/hew/`: 1029 passed, 0 failed (includes the new fixture)
- `tests/vertical-slice/run.sh`: exit 0, 436 PASS / 0 FAIL
