### PR TITLE
fix(types): reject surplus LambdaPid method args

### DIFF
--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -3241,21 +3241,28 @@ impl Checker {
 
         match method {
             "send" => {
-                // Check the argument against M (the message type).
+                if args.len() != 1 {
+                    self.report_error(
+                        TypeErrorKind::ArityMismatch,
+                        span,
+                        format!(
+                            "LambdaPid::send expects one argument (the message), but {} were supplied",
+                            args.len()
+                        ),
+                    );
+                }
+                // Check the argument against M (the message type) when present so
+                // the caller still gets the most specific message-type diagnostic
+                // alongside any arity error.
                 if let Some(arg) = args.first() {
                     let (expr, sp) = arg.expr();
                     let ty = self.check_against(expr, sp, &m_ty);
                     // Enforce Send bound: the message crosses the actor boundary.
                     let resolved = self.subst.resolve(&ty);
                     self.enforce_actor_boundary_send(expr, sp, span, &resolved);
-                } else {
-                    self.report_error(
-                        TypeErrorKind::ArityMismatch,
-                        span,
-                        "LambdaPid::send expects one argument (the message)".to_string(),
-                    );
                 }
-                // Synthesize extra args for recovery diagnostics.
+                // Synthesize extra args for recovery diagnostics, but do not accept
+                // them: MIR only lowers the receiver plus the first message arg.
                 for arg in args.iter().skip(1) {
                     let (expr, sp) = arg.expr();
                     self.synthesize(expr, sp);
@@ -3275,7 +3282,19 @@ impl Checker {
                 }
             }
             "close" => {
-                // No arguments expected.
+                // No arguments expected. Synthesize any supplied args for
+                // recovery diagnostics, but do not accept them: MIR lowers only
+                // the receiver for LambdaPid::close.
+                if !args.is_empty() {
+                    self.report_error(
+                        TypeErrorKind::ArityMismatch,
+                        span,
+                        format!(
+                            "LambdaPid::close expects no arguments, but {} were supplied",
+                            args.len()
+                        ),
+                    );
+                }
                 for arg in args {
                     let (expr, sp) = arg.expr();
                     self.synthesize(expr, sp);

--- a/tests/vertical-slice/reject/lambda_close_extra_arg.hew
+++ b/tests/vertical-slice/reject/lambda_close_extra_arg.hew
@@ -1,0 +1,9 @@
+// Reject: LambdaPid::close takes no arguments. Extra arguments were previously
+// type-checked for recovery and then silently dropped by MIR lowering, so this
+// must fail at check time instead.
+fn main() {
+    let printer = actor |x: i64| {
+        println(x);
+    };
+    printer.close(12345);
+}

--- a/tests/vertical-slice/reject/lambda_method_send_extra_arg.hew
+++ b/tests/vertical-slice/reject/lambda_method_send_extra_arg.hew
@@ -1,0 +1,9 @@
+// Reject: LambdaPid::send accepts exactly one message argument. Extra
+// arguments were previously type-checked for recovery and then silently
+// dropped by MIR lowering, so this must fail at check time instead.
+fn main() {
+    let printer = actor |x: i64| {
+        println(x);
+    };
+    printer.send(42, 99);
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -2082,6 +2082,23 @@ run_accept_expect_status_and_stdout "lambda_send_result_ok" 7
 # the message was delivered before the release.
 run_accept_expect_stdout "lambda_close"
 
+# Reject: LambdaPid::send accepts exactly one message argument. MIR lowers only
+# the receiver plus the first message arg, so surplus args must not be silently
+# accepted and dropped.
+if "${HEW}" check "${ROOT}/tests/vertical-slice/reject/lambda_method_send_extra_arg.hew" >"${reject_output}" 2>&1; then
+  echo "expected lambda-method-send-extra-arg fixture to fail" >&2
+  exit 1
+fi
+grep -q 'LambdaPid::send expects one argument' "${reject_output}"
+
+# Reject: LambdaPid::close accepts no arguments. MIR lowers only the receiver,
+# so surplus args must not be silently accepted and dropped.
+if "${HEW}" check "${ROOT}/tests/vertical-slice/reject/lambda_close_extra_arg.hew" >"${reject_output}" 2>&1; then
+  echo "expected lambda-close-extra-arg fixture to fail" >&2
+  exit 1
+fi
+grep -q 'LambdaPid::close expects no arguments' "${reject_output}"
+
 # Reject: ask-shaped actor body return type mismatch (E_LAMBDA_RETURN_TYPE_MISMATCH).
 if "${HEW}" check "${ROOT}/tests/vertical-slice/reject/lambda_return_mismatch.hew" >"${reject_output}" 2>&1; then
   echo "expected lambda-return-mismatch fixture to fail" >&2


### PR DESCRIPTION
## Summary
- reject surplus arguments on `LambdaPid::send` and `LambdaPid::close` instead of only synthesizing them for recovery
- keep checking the first `.send(msg)` argument against the message type when present so recovery diagnostics stay useful
- add vertical-slice rejects for the formerly-silent `.send(42, 99)` / `.close(12345)` drops

## Verification
- `cargo fmt -p hew-types --check`
- `cargo test -p hew-types --lib`
- `cargo clippy -p hew-types --lib --tests -- -D warnings`
- `tests/vertical-slice/run.sh`

Fixes inbox item for PR #2093.
