### PR TITLE
fix(hir): route typed instant Display through the i64 path

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -8414,6 +8414,21 @@ impl LowerCtx {
             ResolvedTy::Duration => {
                 self.dispatch_display_to_named_impl("duration", &method_name, value, span)
             }
+            ResolvedTy::Named {
+                builtin: Some(BuiltinType::Instant),
+                ..
+            } => {
+                // A typed `instant` (`let t: instant`, parameter-typed, etc.)
+                // reaches HIR as `Named { builtin: Some(Instant) }` because
+                // annotation-lowering preserves the named form. It canonicalises
+                // to i64 and renders as raw nanoseconds via the i64 catalog
+                // overload, mirroring the checker's own `Named{Instant}` -> i64
+                // satisfaction path. Handled before the general `Named` arm,
+                // which would otherwise route to a non-existent `instant::fmt`
+                // impl symbol and fail closed.
+                let builtin = scalar_display_builtin(&ResolvedTy::I64);
+                self.build_catalog_call(builtin, vec![value], span)
+            }
             ResolvedTy::Named { name, .. } => {
                 // An abstract type parameter `T: Display` (the checker lowers
                 // `T` to a bare `Named`) defers to per-monomorphisation static
@@ -8523,6 +8538,7 @@ impl LowerCtx {
             && args.first().is_some_and(|arg| {
                 self.abstract_type_param_name(&arg.ty).is_some()
                     || matches!(arg.ty, ResolvedTy::Duration)
+                    || is_named_instant(&arg.ty)
             });
         if !is_display_surface || !single_dispatchable || self.lang_items.display_method().is_none()
         {
@@ -28806,6 +28822,22 @@ fn scan_expr_for_vec_index_gate(
 /// Map a scalar `ResolvedTy` to its `to_string_*` catalog builtin for Display
 /// dispatch. Only the scalar arm of `lower_display_dispatch` reaches here; any
 /// non-scalar type is a caller bug (the dispatch match never routes it here).
+/// Whether `ty` is a typed `instant` (`Named { builtin: Some(Instant) }`).
+///
+/// Annotation-lowering preserves the named form for `instant` (unlike the
+/// expression-level `from_ty`, which canonicalises to i64), so any
+/// annotation/parameter-typed instant carries this shape rather than a bare
+/// `ResolvedTy::I64`.
+fn is_named_instant(ty: &ResolvedTy) -> bool {
+    matches!(
+        ty,
+        ResolvedTy::Named {
+            builtin: Some(BuiltinType::Instant),
+            ..
+        }
+    )
+}
+
 fn scalar_display_builtin(ty: &ResolvedTy) -> &'static str {
     match ty {
         ResolvedTy::I8 | ResolvedTy::I16 | ResolvedTy::I32 => "to_string_i32",

--- a/tests/hew/instant_methods_test.hew
+++ b/tests/hew/instant_methods_test.hew
@@ -67,3 +67,39 @@ fn test_instant_result_interops_with_duration_methods() {
     testing.assert_true(!span.is_zero());
     testing.assert_true(span.abs().nanos() == span.nanos());
 }
+
+// ── Display of a TYPED instant renders raw nanos (regression for #2277) ───────
+//
+// A typed `instant` binding (`let t: instant`, `fn f(t: instant)`) reaches HIR
+// as `Named{Instant}` rather than a bare `i64`, so the i64 Display catalog
+// overload never matched it directly. Before the fix, `println`/`to_string`/
+// f-string interpolation of such a value failed HIR with
+// `UnresolvedBuiltinOverload` + `UnresolvedSymbol` even though the checker
+// admitted it (the inline `println(instant::now())` shape, whose arg is already
+// i64, worked — masking the annotated/param-typed gap). The fix routes
+// `Named{Instant}` through the i64 Display path in `lower_display_dispatch`,
+// mirroring the checker's own `Named{Instant} -> i64` satisfaction.
+//
+// The clock is monotonic so the exact number is not fixed; these assert the
+// load-bearing invariant that all three Display surfaces render the SAME
+// non-empty string for one typed instant, and agree with a param-typed helper.
+
+fn render_typed_instant(t: instant) -> string {
+    return to_string(t);
+}
+
+#[test]
+fn test_typed_instant_to_string_is_consistent_across_surfaces() {
+    let a: instant = instant::now();
+    let alias: instant = a;
+    let s1: string = to_string(a);
+    // A `let`-aliased typed instant renders identically.
+    testing.assert_eq_str(to_string(alias), s1);
+    // A param-typed instant (the utility-function shape the defect broke)
+    // renders identically.
+    testing.assert_eq_str(render_typed_instant(a), s1);
+    // f-string interpolation shares the same Display dispatch spine.
+    testing.assert_eq_str(f"{a}", s1);
+    // A garbage/empty-string regression fails here.
+    testing.assert_true(!s1.is_empty());
+}


### PR DESCRIPTION
## Problem

A typed `instant` value fails to `Display` even though the checker admits it:

```hew
let t: instant = instant::now();
println(t);            // E_HIR: UnresolvedBuiltinOverload + UnresolvedSymbol
fn show(t: instant) { println(t); }   // same failure
```

The inline shape `println(instant::now())` works (its arg is already `i64` via `from_ty`), which masked the gap for any annotated or parameter-typed instant.

## Root cause

Annotation-lowering preserves the named form for `instant`, so a typed binding reaches HIR as `Named { builtin: Some(Instant) }` rather than a bare `i64`. The i64 Display catalog overload never matches it, so `try_lower_generic_display_builtin`'s `single_dispatchable` gate rejects it and it falls through to the fail-closed `UnresolvedBuiltinOverload`. The in-code comment ("instant needs no arm: it canonicalises to i64") only held for the inline shape.

The checker already admits this via `type_satisfies_trait_bound` delegating `Named{Instant}` to the i64 satisfaction path — HIR just never mirrored it.

## Fix

- Admit `Named{Instant}` in the `single_dispatchable` gate (new `is_named_instant` helper).
- Add a dedicated `Named { builtin: Some(Instant) }` arm in `lower_display_dispatch` that routes through the i64 catalog overload (raw nanoseconds), placed before the general `Named` arm which would otherwise seek a non-existent `instant::fmt` impl.

Now typed instants render raw nanos consistently across `to_string`, `println`, param-typed helpers, and f-string interpolation, matching the inline shape and the checker's own `Named{Instant} -> i64` contract.

## Testing

- New regression `test_typed_instant_to_string_is_consistent_across_surfaces` in `tests/hew/instant_methods_test.hew` asserting all three Display surfaces render the same non-empty string for one typed instant. Verified load-bearing: reverting the fix makes it fail with the exact reported `UnresolvedSymbol` (plus the f-string `instant::fmt` gap).
- `cargo test -p hew-hir --lib` 89/89, `cargo fmt -p hew-hir --check` clean, `cargo clippy -p hew-hir --lib --tests -- -D warnings` clean.
- Full `tests/vertical-slice/run.sh` exit 0 (438 PASS / 0 FAIL).