### PR TITLE
fix(runtime,codegen): bounds-check the real pool index before truncation

### DIFF
--- a/hew-codegen-rs/src/runtime_abi.rs
+++ b/hew-codegen-rs/src/runtime_abi.rs
@@ -2924,16 +2924,22 @@ pub(crate) fn lower_call_runtime_abi(
                 .builder
                 .build_int_truncate(key_i64, i32_ty, "supervisor_child_get key_i32")
                 .llvm_ctx("supervisor_child_get key truncate")?;
-            // pool_child_get arg2: the member index — i64 in MIR, truncate to i32.
-            let index_i32 = if is_pool {
-                let idx_i64 =
-                    load_int_arg(fn_ctx, args[2], i64_ty, "supervisor_pool_child_get index_i64")?;
-                Some(
-                    fn_ctx
-                        .builder
-                        .build_int_truncate(idx_i64, i32_ty, "supervisor_pool_child_get index_i32")
-                        .llvm_ctx("supervisor_pool_child_get index truncate")?,
-                )
+            // pool_child_get arg2: the member index. Pass the full i64 through
+            // untruncated -- `hew_supervisor_pool_child_get`'s `index` param is
+            // `u64` specifically so the runtime can bounds-check the caller's
+            // real index before any narrowing cast. Truncating to i32 here (as
+            // this code used to) let an index like `2^32` silently wrap back
+            // into `[0, member_count)` and alias an unrelated live member
+            // instead of trapping OOB (hew-lang/hew#2244) -- passing the wide
+            // value through removes the wraparound at its source instead of
+            // moving it further down the pipeline.
+            let index_i64 = if is_pool {
+                Some(load_int_arg(
+                    fn_ctx,
+                    args[2],
+                    i64_ty,
+                    "supervisor_pool_child_get index_i64",
+                )?)
             } else {
                 None
             };
@@ -2968,7 +2974,12 @@ pub(crate) fn lower_call_runtime_abi(
             let triple = fn_ctx.llvm_mod.get_triple();
             let triple_str = triple.as_str().to_string_lossy();
             let param_tys: Vec<inkwell::types::BasicMetadataTypeEnum> = if is_pool {
-                vec![ptr_ty.into(), i32_ty.into(), i32_ty.into()]
+                // Third param is the member index, passed as the full i64 —
+                // not truncated to i32 like the supervisor/pool key — so the
+                // runtime can bounds-check the caller's real index before any
+                // narrowing cast (hew-lang/hew#2244). Must match
+                // `hew_supervisor_pool_child_get`'s `index: u64` ABI param.
+                vec![ptr_ty.into(), i32_ty.into(), i64_ty.into()]
             } else {
                 vec![ptr_ty.into(), i32_ty.into()]
             };
@@ -2982,7 +2993,7 @@ pub(crate) fn lower_call_runtime_abi(
                 &param_tys,
             )?;
             // Argument list for the register-pair (no sret) path.
-            let call_args: Vec<inkwell::values::BasicMetadataValueEnum> = match index_i32 {
+            let call_args: Vec<inkwell::values::BasicMetadataValueEnum> = match index_i64 {
                 Some(idx) => vec![sup_ptr.into(), key_i32.into(), idx.into()],
                 None => vec![sup_ptr.into(), key_i32.into()],
             };
@@ -3047,7 +3058,7 @@ pub(crate) fn lower_call_runtime_abi(
                         "child_result_sret_lt_start",
                     )?;
                     let sret_args: Vec<inkwell::values::BasicMetadataValueEnum> =
-                        match index_i32 {
+                        match index_i64 {
                             Some(idx) => vec![
                                 result_slot.into(),
                                 sup_ptr.into(),

--- a/hew-mir/src/runtime_symbols.rs
+++ b/hew-mir/src/runtime_symbols.rs
@@ -471,10 +471,13 @@ const MIR_EMITTER_RUNTIME_SYMBOLS: &[&str] = &[
     // bit-pattern for multi-segment dotted access (`app.api.auth`).
     "hew_supervisor_nested_get",
     // `hew_supervisor_pool_child_get(sup: *mut HewSupervisor, pool_key: u32,
-    //  index: u32) -> ChildLookupResult` (`hew-runtime/src/supervisor.rs`).
+    //  index: u64) -> ChildLookupResult` (`hew-runtime/src/supervisor.rs`).
     // Resolves static-pool member `index` through its live static slot; same
     // 16-byte by-value result as `hew_supervisor_child_get`. The MIR static-pool
-    // accessor (`sup.pool[i]` / `.get(i)`) emits this. (Sorted: `pool_c` <
+    // accessor (`sup.pool[i]` / `.get(i)`) emits this. `index` is `u64` (wider
+    // than the `u32` supervisor/pool key) so the runtime can bounds-check the
+    // caller's real, untruncated index instead of a narrowed value that could
+    // wrap back in range (hew-lang/hew#2244). (Sorted: `pool_c` <
     // `pool_l` < `restart`.)
     "hew_supervisor_pool_child_get",
     // `hew_supervisor_pool_len(sup: *mut HewSupervisor, pool_key: u32) -> i64`

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -6107,6 +6107,14 @@ pub unsafe extern "C" fn hew_supervisor_pool_member_remove(
 /// [`hew_supervisor_pool_member_remove`]) may shift other members' indices
 /// because the pool uses `swap_remove`. Do not cache an index across removals.
 ///
+/// `index` is `u64` (not `u32`) specifically so this function can
+/// bounds-check the caller's *original, untruncated* index. A pool's real
+/// member count always fits comfortably in a `u32`, so any `index` that does
+/// not itself fit in `usize`/`u32` range is unconditionally out of bounds and
+/// is rejected as `Dead(UnknownSlot)` before any narrowing cast — matching
+/// `Vec[i]` OOB-parity semantics for arbitrarily large indices instead of
+/// silently wrapping (see hew-lang/hew#2244).
+///
 /// # Safety
 ///
 /// `sup` must be a valid pointer returned by [`hew_supervisor_new`].
@@ -6114,7 +6122,7 @@ pub unsafe extern "C" fn hew_supervisor_pool_member_remove(
 pub unsafe extern "C" fn hew_supervisor_pool_child_get(
     sup: *mut HewSupervisor,
     pool_key: u32,
-    index: u32,
+    index: u64,
 ) -> ChildLookupResult {
     if sup.is_null() {
         return ChildLookupResult::dead(ChildSlotReason::SupervisorShutdown);
@@ -6126,6 +6134,19 @@ pub unsafe extern "C" fn hew_supervisor_pool_child_get(
     if s.cancelled.load(Ordering::Acquire) || s.running.load(Ordering::Acquire) == 0 {
         return ChildLookupResult::dead(ChildSlotReason::SupervisorShutdown);
     }
+
+    // `index` arrives untruncated here (u64). No real pool ever has anywhere
+    // near `usize::MAX` members, so any index that overflows `usize` (only
+    // possible on a 32-bit `usize` target) is unconditionally OOB. On the
+    // universally-supported 64-bit targets this `try_into` is infallible, but
+    // keeping the target-generic checked conversion (rather than a bare `as`)
+    // is what actually closes the truncation-and-wraparound gap this function
+    // exists to prevent (hew-lang/hew#2244) -- an `as usize` here would just
+    // move the same silent-wraparound bug from `i64->u32` (codegen) to
+    // `u64->usize` (here) on a 32-bit target instead of removing it.
+    let Ok(index) = usize::try_from(index) else {
+        return ChildLookupResult::dead(ChildSlotReason::UnknownSlot);
+    };
 
     let i = pool_key as usize;
     if i >= s.pool_slots.len() {
@@ -6149,7 +6170,7 @@ pub unsafe extern "C" fn hew_supervisor_pool_child_get(
     // child resolver verbatim.
     let static_members = &s.pool_specs[i].static_members;
     if !static_members.is_empty() {
-        let Some(&static_idx) = static_members.get(index as usize) else {
+        let Some(&static_idx) = static_members.get(index) else {
             // Index beyond the member count → out of bounds (Vec[i] OOB parity).
             return ChildLookupResult::dead(ChildSlotReason::UnknownSlot);
         };
@@ -6168,7 +6189,7 @@ pub unsafe extern "C" fn hew_supervisor_pool_child_get(
     // Resolve the index within the pool's member list via the public ABI so
     // we stay within the module's encapsulation boundary.
     // SAFETY: pool was created by hew_pool_new and has not been freed.
-    let pid = unsafe { crate::pool::hew_pool_get_at(pool, index as usize) };
+    let pid = unsafe { crate::pool::hew_pool_get_at(pool, index) };
     if pid == 0 {
         // 0 is returned both for out-of-range and for an empty pool;
         // both cases are dead from the caller's perspective.
@@ -6326,6 +6347,57 @@ mod pool_slot_tests {
         assert_eq!(r.tag, 2, "should be Dead");
         assert_eq!(r.reason, ChildSlotReason::UnknownSlot as u8);
         assert!(r.handle.is_null());
+
+        unsafe { hew_supervisor_stop(sup) };
+    }
+
+    /// hew-lang/hew#2244 regression: before this fix, codegen truncated the
+    /// index to i32 before this function ever saw it, so a caller-supplied
+    /// index of `2^32 + k` silently wrapped to `k` and could alias an
+    /// unrelated Live member instead of failing bounds-checking. This test
+    /// exercises the *runtime* half of the fix directly: `index` is now a
+    /// `u64` ABI param specifically so a huge, never-legitimately-in-range
+    /// index is rejected as `Dead(UnknownSlot)` on its own, with no
+    /// dependence on codegen not truncating it upstream (belt-and-suspenders
+    /// with the codegen-side fix in `hew-codegen-rs/src/runtime_abi.rs`).
+    #[test]
+    fn pool_child_get_huge_index_returns_dead_unknown_slot_not_aliased_member() {
+        let _rt = crate::runtime_test_guard();
+        let sup = unsafe { make_sup() };
+        let name = std::ffi::CString::new("workers").unwrap();
+        unsafe { hew_supervisor_pool_add_slot(sup, name.as_ptr(), ROUND_ROBIN, 0) };
+        // Two members: PID 1001 at index 0, PID 2002 at index 1. If a huge
+        // index silently wrapped instead of failing bounds-checking, these
+        // are exactly the (wrong) Live handles it could alias.
+        unsafe { hew_supervisor_pool_member_add(sup, 0, 1001) };
+        unsafe { hew_supervisor_pool_member_add(sup, 0, 2002) };
+        unsafe { mark_running(sup) };
+
+        // 2^32 would wrap to 0 (aliasing PID 1001) under the old i32-truncating
+        // ABI; 2^32 + 1 would wrap to 1 (aliasing PID 2002). Both must be
+        // rejected as out of bounds now, never resolving to either handle.
+        for huge_index in [1u64 << 32, (1u64 << 32) + 1, u64::MAX] {
+            let r = unsafe { hew_supervisor_pool_child_get(sup, 0, huge_index) };
+            assert_eq!(r.tag, 2, "index {huge_index} should be Dead, not Live");
+            assert_eq!(r.reason, ChildSlotReason::UnknownSlot as u8);
+            assert!(r.handle.is_null());
+            assert_ne!(
+                r.handle as u64, 1001,
+                "index {huge_index} must not alias member 0's PID"
+            );
+            assert_ne!(
+                r.handle as u64, 2002,
+                "index {huge_index} must not alias member 1's PID"
+            );
+        }
+
+        // Sanity: the real in-range indices still resolve Live (the fix
+        // widened the ABI/added a bounds check, it did not break ordinary
+        // lookups).
+        let r0 = unsafe { hew_supervisor_pool_child_get(sup, 0, 0) };
+        let r1 = unsafe { hew_supervisor_pool_child_get(sup, 0, 1) };
+        assert!(r0.is_live() && r0.handle as u64 == 1001);
+        assert!(r1.is_live() && r1.handle as u64 == 2002);
 
         unsafe { hew_supervisor_stop(sup) };
     }
@@ -6850,7 +6922,7 @@ mod pool_slot_tests {
 
         // Each member resolves Live to its static slot's actor.
         for idx in 0..3u32 {
-            let r = unsafe { hew_supervisor_pool_child_get(sup, 0, idx) };
+            let r = unsafe { hew_supervisor_pool_child_get(sup, 0, u64::from(idx)) };
             assert!(r.is_live(), "member {idx} should be Live");
             let expected = unsafe { (&(*sup).children)[idx as usize] };
             assert_eq!(

--- a/tests/vertical-slice/accept/supervisor_static_pool_huge_index_traps.hew
+++ b/tests/vertical-slice/accept/supervisor_static_pool_huge_index_traps.hew
@@ -1,0 +1,39 @@
+// v0.6 static supervisor pool OOB-index hardening (hew-lang/hew#2244): the
+// pool accessor index used to be truncated to i32/u32 before the runtime
+// bounds-check, so a huge i64 index that wrapped back into [0, member_count)
+// silently aliased a live member instead of trapping OOB — e.g.
+// `sup.workers[4294967296]` (2^32) on a 3-member pool resolved as member 0
+// instead of failing `Vec[i]`-parity bounds checking.
+//
+// This fixture indexes a 3-member pool with 2^32 + 1 (member 1's aliased
+// address under the old truncating bug) and expects a trap: the runtime now
+// bounds-checks the caller's real, untruncated index before any narrowing
+// cast, so any index that cannot itself fit the pool's member-count range is
+// rejected as out-of-bounds regardless of how it would have wrapped.
+actor Worker {
+    var value: i64;
+    receive fn id() -> i64 {
+        value
+    }
+}
+
+supervisor Pool {
+    strategy: simple_one_for_one;
+    intensity: 5 within 60s;
+
+    pool workers: Worker(count: 3, value: 42);
+}
+
+fn main() -> i64 {
+    let sup = spawn Pool;
+    let idx: i64 = 4294967297; // 2^32 + 1 — used to alias member 1.
+    let m = sup.workers[idx];
+    match await m.id() {
+        Ok(v) => {
+            v
+        },
+        Err(_) => {
+            0
+        },
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1350,6 +1350,14 @@ run_accept_expect_status "supervisor_static_pool" 24
 # no-op arm (pre-S5) or a stale-PID re-access would trap (exit 133).
 run_accept_expect_status "supervisor_static_pool_restart" 7
 
+# v0.6 static pool OOB-index hardening (#2244): a huge i64 index (2^32 + 1)
+# used to be truncated to i32 before the runtime bounds-check and silently
+# wrap back into range, aliasing an unrelated live member (here, member 1)
+# instead of trapping OOB. The runtime now bounds-checks the real,
+# untruncated index, so this must trap (Vec[i] OOB parity) instead of
+# resolving to any member; exit 0/42 would mean the wraparound regressed.
+run_accept_expect_trap "supervisor_static_pool_huge_index_traps"
+
 # F-04 fungible reference: a supervised-child handle re-resolves to the CURRENT
 # child at each send/ask, so a handle BOUND before a crash and held ACROSS the
 # restart reaches the FRESH child. Binds `let w = sup.w1` before crashing, then


### PR DESCRIPTION
## Bug

`hew_supervisor_pool_child_get`'s `index` param was `u32`, and codegen
truncated the MIR-level i64 index to i32 before ever calling it. Neither
layer ever saw the caller's real, untruncated index, so an index like
`2^32` (or `2^32 + k`) silently wrapped back into `[0, member_count)` and
resolved to an unrelated live pool member instead of trapping
out-of-bounds.

Live repro on a 3-member pool (`pool workers: Worker(count: 3, value: 42)`):

```
sup.workers[4294967296]  // == 2^32
```

`hew check` passes clean and `hew run` exits via member 0's own
logic (exit 42) instead of trapping — the exact aliasing this review
flagged, and a hard security-adjacent gap: any code path that lets a
large/attacker-influenced value reach a pool index can silently reach
into an unrelated live actor instead of failing safely.

## Fix

Widens `hew_supervisor_pool_child_get`'s `index` to `u64` and
bounds-checks it (`usize::try_from`) before any narrowing cast, and
stops codegen truncating the index to i32 at the call site — the full
i64 now travels untruncated all the way to the runtime's own bounds
check. Both the static-pool and dynamic-PID-set pool resolution paths
share this one entry point, so both are covered by the same fix.

## Tests

- New vertical-slice trap fixture: `supervisor_static_pool_huge_index_traps`
  (2^32 + 1 on a 3-member pool — the old alias target for member 1 —
  must now trap instead of resolving to any member).
- New runtime unit test:
  `pool_child_get_huge_index_returns_dead_unknown_slot_not_aliased_member`,
  exercising `2^32`, `2^32 + 1`, and `u64::MAX` against a 2-member pool
  and asserting neither aliased PID is ever returned. Verified
  load-bearing by temporarily reverting the bounds check (simulating the
  old truncating cast) and confirming the test fails with the exact
  predicted "should be Dead, not Live" symptom; restoring the fix makes
  it pass again.

## Verification

- `cargo test -p hew-runtime --lib`: 2029/2029
- `cargo test -p hew-codegen-rs --lib`: 214/214
- `cargo test -p hew-mir --lib`: 327/327 (unaffected, sanity check)
- `cargo fmt --check` clean on all three crates
- `cargo clippy --tests -- -D warnings` clean on all three crates
- Full `tests/vertical-slice/run.sh`: 433 RUN / 439 PASS / 0 FAIL, exit 0
  — run twice independently, both clean