### PR TITLE
fix(scripts): preserve the numeric-const NAME when normalizing .ll pool ids

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -663,9 +663,10 @@ ll-diff: hew
 ll-golden: hew
 	bash scripts/ll-corpus.sh golden
 
-# Self-test for the ll-byte-identity normaliser: four independently-failable
-# cases that prove string-content changes are caught and pool-id reorderings
-# are transparent.  No compiler build required — exercises the oracle script
+# Self-test for the ll-byte-identity normaliser: six independently-failable
+# cases that prove string-content changes and numeric-const NAME changes are
+# caught, and pool-id reorderings (both string-pool and numeric-const) are
+# transparent.  No compiler build required — exercises the oracle script
 # against synthetic .ll snippets only.
 ll-identity-selftest:
 	bash scripts/ll-identity-selftest.sh

--- a/scripts/ll-byte-identity.sh
+++ b/scripts/ll-byte-identity.sh
@@ -141,7 +141,31 @@ norm() {
         gsub(pat, canonical, line)
       }
       # Numeric const pool: NAME discriminates identity; collapse pool-id.
-      gsub(/@__hew_const__([A-Za-z0-9_]+)__[0-9]+/, "@__hew_const__\\1__N", line)
+      #
+      # NOTE: the gsub replacement string is a LITERAL in POSIX/gawk/mawk;
+      # it does NOT expand \1 backreferences the way sed/perl do, so a naive
+      # `gsub(/.../, "@__hew_const__\\1__N", line)` here substitutes the
+      # literal text "@__hew_const__\1__N" for every match, erasing the NAME
+      # and making @__hew_const__FOO__1 and @__hew_const__BAR__99 collapse to
+      # the SAME canonical token — a false-negative that hides a numeric
+      # constant identity change. gensub() would expand the backreference,
+      # but it is a gawk-only extension, absent from the default
+      # one-true-awk-derived /usr/bin/awk shipped on macOS, so reconstruct
+      # the substitution manually with the same portable match()/substr()
+      # idiom already used above in this file, preserving the captured
+      # NAME segment verbatim.
+      out = ""
+      rest = line
+      while (match(rest, /@__hew_const__[A-Za-z0-9_]+__[0-9]+/)) {
+        pre  = substr(rest, 1, RSTART - 1)
+        m    = substr(rest, RSTART, RLENGTH)
+        name = m
+        sub(/^@__hew_const__/, "", name)
+        sub(/__[0-9]+$/, "", name)
+        out  = out pre "@__hew_const__" name "__N"
+        rest = substr(rest, RSTART + RLENGTH)
+      }
+      line = out rest
       print line
     }
   ' "$file" "$file"

--- a/scripts/ll-identity-selftest.sh
+++ b/scripts/ll-identity-selftest.sh
@@ -25,6 +25,26 @@
 #     The old normaliser would have passed this accidentally; the new one
 #     proves it via content-based canonicalisation.
 #
+#   Case 5 (numeric-const-name-change-caught):
+#     A function referencing @__hew_const__FOO__1 vs the same shape referencing
+#     @__hew_const__BAR__99 MUST be reported as DIFFERS. gsub replacement
+#     strings are literal in POSIX/gawk/mawk (they do not expand \1
+#     backreferences), so the original
+#     `gsub(/.../, "@__hew_const__\1__N", line)` collapsed both FOO and BAR
+#     references to the literal text "@__hew_const__\1__N", erasing the NAME
+#     and silently hiding a numeric constant identity change. The fix
+#     reconstructs the substitution manually with match()/substr(), the same
+#     portable idiom already used elsewhere in the normaliser, preserving the
+#     captured NAME segment verbatim (gensub() would also expand the
+#     backreference, but it is a gawk-only extension unavailable on the
+#     default macOS /usr/bin/awk).
+#
+#   Case 6 (numeric-const-pool-id-reordering-transparent):
+#     Same numeric constant NAME (FOO) but a different pool-id suffix
+#     (@__hew_const__FOO__1 vs @__hew_const__FOO__7) MUST still be IDENTICAL
+#     — only the NAME discriminates identity, not the run-to-run pool-id
+#     number. Proves Case 5's fix does not over-correct into false positives.
+#
 # Exit codes:
 #   0  all cases pass
 #   1  one or more cases fail (details on stderr)
@@ -122,6 +142,46 @@ define void @test_reg() {
 EOF
 }
 
+# Numeric-const fixture: references @__hew_const__FOO__1.
+write_numeric_const_foo() {
+  cat > "$1" << 'EOF'
+@__hew_const__FOO__1 = private unnamed_addr constant i64 42, align 8
+
+define i64 @test_numeric_const() {
+  %v = load i64, ptr @__hew_const__FOO__1, align 8
+  ret i64 %v
+}
+EOF
+}
+
+# Numeric-const fixture: SAME shape, but references @__hew_const__BAR__99 --
+# a genuinely different named constant (not just a different pool-id
+# suffix on the same name).
+write_numeric_const_bar() {
+  cat > "$1" << 'EOF'
+@__hew_const__BAR__99 = private unnamed_addr constant i64 42, align 8
+
+define i64 @test_numeric_const() {
+  %v = load i64, ptr @__hew_const__BAR__99, align 8
+  ret i64 %v
+}
+EOF
+}
+
+# Numeric-const fixture: SAME name (FOO) as write_numeric_const_foo, but a
+# different pool-id suffix (__7 instead of __1) -- run-to-run
+# HashMap-iteration-order non-determinism for the SAME semantic constant.
+write_numeric_const_foo_reordered() {
+  cat > "$1" << 'EOF'
+@__hew_const__FOO__7 = private unnamed_addr constant i64 42, align 8
+
+define i64 @test_numeric_const() {
+  %v = load i64, ptr @__hew_const__FOO__7, align 8
+  ret i64 %v
+}
+EOF
+}
+
 # ---------------------------------------------------------------------------
 # Each case uses a dedicated pair of directories so failures are independent.
 # ---------------------------------------------------------------------------
@@ -213,5 +273,51 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Case 5: numeric-const-name-change-caught
+# @__hew_const__FOO__1 vs @__hew_const__BAR__99 in the SAME structural
+# position MUST be reported as DIFFERS -- a different named numeric constant
+# is a real semantic change, not pool-id churn.
+# ---------------------------------------------------------------------------
+echo "--- Case 5: numeric-const-name-change-caught ---"
+C5_BASE="$TMPDIR_BASE/c5_base"
+C5_HEAD="$TMPDIR_BASE/c5_head"
+mkdir -p "$C5_BASE" "$C5_HEAD"
+write_numeric_const_foo "$C5_BASE/fixture.ll"
+write_numeric_const_bar "$C5_HEAD/fixture.ll"
+
+rc=0
+bash "$ORACLE" "$C5_BASE" "$C5_HEAD" > /dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 1 ]]; then
+  pass "numeric-const-name-change-caught"
+elif [[ "$rc" -eq 0 ]]; then
+  fail "numeric-const-name-change-caught" \
+    "oracle exited 0 (IDENTICAL) but the referenced numeric constant's NAME changed (FOO -> BAR) — false negative"
+else
+  fail "numeric-const-name-change-caught" "oracle exited $rc (expected 1)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 6: numeric-const-pool-id-reordering-transparent
+# @__hew_const__FOO__1 vs @__hew_const__FOO__7 -- SAME name, only the
+# run-to-run pool-id suffix shifted.  MUST be IDENTICAL.
+# ---------------------------------------------------------------------------
+echo "--- Case 6: numeric-const-pool-id-reordering-transparent ---"
+C6_BASE="$TMPDIR_BASE/c6_base"
+C6_HEAD="$TMPDIR_BASE/c6_head"
+mkdir -p "$C6_BASE" "$C6_HEAD"
+write_numeric_const_foo "$C6_BASE/fixture.ll"
+write_numeric_const_foo_reordered "$C6_HEAD/fixture.ll"
+
+rc=0
+bash "$ORACLE" "$C6_BASE" "$C6_HEAD" > /dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  pass "numeric-const-pool-id-reordering-transparent"
+else
+  bash "$ORACLE" "$C6_BASE" "$C6_HEAD" 2>&1 || true
+  fail "numeric-const-pool-id-reordering-transparent" \
+    "oracle exited $rc (expected 0) — false positive on numeric-const pool-id reordering"
+fi
+
+# ---------------------------------------------------------------------------
 echo ""
-echo "ll-identity-selftest: all 4 cases PASS"
+echo "ll-identity-selftest: all 6 cases PASS"


### PR DESCRIPTION
## Bug

`scripts/ll-byte-identity.sh`'s `norm()` function canonicalizes
`@__hew_const__NAME__N` numeric-constant pool-id suffixes (which are
HashMap-iteration-driven and non-deterministic run-to-run) so the same
binary compiled twice produces byte-identical normalized function bodies.
It did this with:

```awk
gsub(/@__hew_const__([A-Za-z0-9_]+)__[0-9]+/, "@__hew_const__\\1__N", line)
```

`gsub`'s replacement string is a **literal** in POSIX awk, gawk, and
mawk -- it does not expand `\1` backreferences the way `sed`/`perl` do.
Every match was replaced with the literal text `@__hew_const__\1__N`,
erasing the captured NAME entirely. So `@__hew_const__FOO__1` and
`@__hew_const__BAR__99` both normalized to the identical string, and a
function whose numeric-constant *reference* changed from `FOO` to `BAR`
could be reported as byte-identical -- a false negative in a gate whose
entire purpose (per #2075) is proving codegen refactors emit unchanged
IR.

Confirmed live with a synthetic two-fixture repro before touching code:
one function loading from `@__hew_const__FOO__1`, a structurally
identical function loading from `@__hew_const__BAR__99` -- the oracle
reported `OK (1 fixture(s) byte-identical)`, exit 0.

## Fix

Reconstructs the substitution manually with the `match()`/`substr()`
idiom already used elsewhere in this same file (see the existing
`@str_lit`/`@__hew_const_str__` pool-symbol handling a few lines above),
extracting the NAME segment and re-emitting `@__hew_const__<NAME>__N`
directly instead of relying on `gsub`'s literal replacement.

`gensub()` would also expand the backreference and was the initial fix
attempt, but it's a **gawk-only extension**, absent from the default
one-true-awk-derived `/usr/bin/awk` shipped on macOS -- this script has
no other GNU-only dependencies (its existing `match()`/`RSTART`/`RLENGTH`
usage is POSIX-portable), and this repo's CI matrix includes macOS, so
the portable form was used instead to avoid introducing the first
GNU-awk requirement into an otherwise-portable script.

Re-verified the fix against the same repro: now correctly reports
`DIFFERS` with a diff showing `@__hew_const__FOO__N` vs
`@__hew_const__BAR__N`. Also verified the *intended* transparency case
still holds -- `@__hew_const__FOO__1` vs `@__hew_const__FOO__7` (same
NAME, only the pool-id number reordered) still reports `IDENTICAL`.

## Tests

Adds two cases to `scripts/ll-identity-selftest.sh`, mirroring the
existing four (`content-change-caught`, `register-perturbation-caught`,
`baseline-identical`, `pool-id-reordering-transparent`) so the oracle's
numeric-const path now has the same self-proof discipline the
string-pool path already had:

- **Case 5** `numeric-const-name-change-caught`: `@__hew_const__FOO__1`
  vs `@__hew_const__BAR__99` MUST be `DIFFERS`.
- **Case 6** `numeric-const-pool-id-reordering-transparent`:
  `@__hew_const__FOO__1` vs `@__hew_const__FOO__7` (same NAME) MUST
  still be `IDENTICAL`.

Updates the `Makefile`'s `ll-identity-selftest` target comment and the
selftest script's own header from "four" to "six" cases.

## Verification

- `bash scripts/ll-identity-selftest.sh` -- all 6/6 cases PASS, exit 0.
- `make ll-identity-selftest` -- same result via the Makefile entry
  point.
- **Load-bearing check**: reverted the fix (kept the new tests) and
  reran -- Case 5 failed with the exact predicted message (`oracle
  exited 0 (IDENTICAL) but the referenced numeric constant's NAME
  changed (FOO -> BAR) -- false negative`); restored the fix, all 6/6
  passed again.
- **Portability check**: shadowed `awk` in `PATH` with `mawk` (a
  non-GNU awk implementation, used here as a stand-in for macOS's
  default `awk` since `gensub` is unavailable on both) and reran the
  full selftest end-to-end against the production script -- all 6/6
  still PASS, confirming the fix does not depend on any GNU-only awk
  extension.
- Confirmed no other part of the repo (Rust code, CI workflows) depends
  on this normalizer's specific behavior -- `ll-byte-identity.sh` is a
  standalone opt-in developer tool invoked via `make ll-diff`/`make
  ll-golden`/`make ll-identity-selftest`, not part of `make test`/
  `test-rust`.
