### PR TITLE
fix(pkg): verify locked project-local package materializations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@
 #   make test-cli          — CLI crate tests (narrow)
 #   make test-compiler-pipeline — compiler ladder + CLI pipeline tests (narrow)
 #   make test-vertical-slice — end-to-end Hew compiler oracle
+#   make test-package-install — Adze install -> Hew import consumer proof
 #   make test-runtime-net  — runtime / analysis / lsp / std-net crate tests (narrow)
 #   make test-runtime-unit — hew-runtime tests without heavy QUIC/TLS/profiler stack (~3× faster)
 #   make test-real-timing  — serialized real wall-clock / OS-timing quarantine tests (narrow)
@@ -70,7 +71,7 @@
 # ============================================================================
 
 .PHONY: all build bootstrap install-hooks hew hew-native adze observe observe-functional-test runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh licenses licenses-check
-.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all lane-gates test-fast test-stdlib test-hew test-hew-ratchet test-o2-differential o2-differential-selftest test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar
+.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-package-install test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all lane-gates test-fast test-stdlib test-hew test-hew-ratchet test-o2-differential o2-differential-selftest test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
 .PHONY: coverage coverage-summary coverage-lcov coverage-runtime coverage-combined coverage-branch
@@ -572,7 +573,7 @@ test: test-rust
 # by CI (which uses cargo nextest directly). Use `make test-all` when you
 # want the previous behaviour.
 # TODO: Add test-stdlib to `test-all` unconditionally once stdlib files are type-check clean
-test-all: test test-stdlib test-hew test-ux-examples test-surface-examples
+test-all: test test-stdlib test-hew test-ux-examples test-surface-examples test-package-install
 
 # Build the combined runtime+stdlib static lib, the native runtime staticlib,
 # and the WASM runtime before running the full workspace test suite.  Several
@@ -640,6 +641,12 @@ test-vertical-slice: hew runtime stdlib check-libhew-fresh
 # asks, imported-type trait methods, and the [native] auto-link path.
 test-pkg-import: hew runtime stdlib check-libhew-fresh
 	bash tests/pkg-import/run.sh
+
+# Package-manager consumer oracle: publish-like local setup, `hew package
+# install`, lock/materialization assertions, `hew check`, and exact `hew run`
+# stdout under an isolated HOME.
+test-package-install: hew adze runtime stdlib check-libhew-fresh
+	bash tests/package-install/run.sh
 
 # Golden MIR corpus (examples/v05/checked-mir): byte-identical --dump-mir
 # oracle for internal retyping work. `checked-mir-verify` re-dumps every

--- a/adze-cli/src/cli.rs
+++ b/adze-cli/src/cli.rs
@@ -657,17 +657,12 @@ fn cmd_install(locked: bool, registry: &registry::Registry, registry_name: Optio
                 std::process::exit(1);
             }
         }
-        #[cfg(unix)]
-        {
-            if let Err(e) = replace_local_package_link(&link, &target) {
-                eprintln!("adze install: cannot create symlink for {name}: {e}");
+        match replace_local_package_materialization(&link, &target) {
+            Ok(materialization) => println!("  {} {name}@{version}", materialization.verb()),
+            Err(e) => {
+                eprintln!("adze install: cannot materialize project package for {name}: {e}");
                 std::process::exit(1);
             }
-            println!("  linked {name}@{version}");
-        }
-        #[cfg(not(unix))]
-        {
-            eprintln!("adze install: symlinks not supported on this platform; skipping {name}");
         }
     }
 
@@ -1360,10 +1355,12 @@ fn cmd_remove(package: &str) {
 
     match manifest::remove_dependency(&manifest_path, package) {
         Ok(true) => {
-            // Remove local symlink if it exists.
+            // Remove local project package materialization if it exists.
             let link = local_link_path(&project_packages_path(&cwd), package);
-            if link.is_symlink() || link.exists() {
-                let _ = std::fs::remove_file(&link);
+            if std::fs::symlink_metadata(&link).is_ok() {
+                if let Err(e) = remove_path_for_replacement(&link) {
+                    eprintln!("warning: could not remove {}: {e}", link.display());
+                }
             }
             println!("Removed {package} from hew.toml");
         }
@@ -1953,6 +1950,41 @@ fn local_link_path(base: &Path, package_name: &str) -> PathBuf {
         .fold(base.to_path_buf(), |path, segment| path.join(segment))
 }
 
+#[derive(Debug, Clone, Copy)]
+enum LocalPackageMaterialization {
+    #[cfg(unix)]
+    Linked,
+    #[cfg(not(unix))]
+    Copied,
+}
+
+impl LocalPackageMaterialization {
+    fn verb(self) -> &'static str {
+        match self {
+            #[cfg(unix)]
+            Self::Linked => "linked",
+            #[cfg(not(unix))]
+            Self::Copied => "copied",
+        }
+    }
+}
+
+fn replace_local_package_materialization(
+    link: &Path,
+    target: &Path,
+) -> std::io::Result<LocalPackageMaterialization> {
+    #[cfg(unix)]
+    {
+        replace_local_package_link(link, target)?;
+        Ok(LocalPackageMaterialization::Linked)
+    }
+    #[cfg(not(unix))]
+    {
+        replace_local_package_copy(link, target)?;
+        Ok(LocalPackageMaterialization::Copied)
+    }
+}
+
 #[cfg(unix)]
 fn replace_local_package_link(link: &Path, target: &Path) -> std::io::Result<()> {
     if let Ok(existing) = std::fs::read_link(link) {
@@ -1967,6 +1999,74 @@ fn replace_local_package_link(link: &Path, target: &Path) -> std::io::Result<()>
     }
 
     crate::atomic_fs::replace_symlink_atomic(link, target)
+}
+
+#[cfg_attr(
+    unix,
+    allow(
+        dead_code,
+        reason = "portable install fallback is selected on non-Unix and unit-tested on Unix"
+    )
+)]
+fn replace_local_package_copy(link: &Path, target: &Path) -> std::io::Result<()> {
+    if !target.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("{} is not an installed package directory", target.display()),
+        ));
+    }
+    let parent = link.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{} has no parent directory", link.display()),
+        )
+    })?;
+    std::fs::create_dir_all(parent)?;
+
+    let file_name = link.file_name().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{} has no final path component", link.display()),
+        )
+    })?;
+    let temp = link.with_file_name(format!(
+        ".{}.tmp-{}",
+        file_name.to_string_lossy(),
+        std::process::id()
+    ));
+    if std::fs::symlink_metadata(&temp).is_ok() {
+        remove_path_for_replacement(&temp)?;
+    }
+
+    if let Err(err) = copy_dir(target, &temp) {
+        let _ = remove_path_for_replacement(&temp);
+        return Err(err);
+    }
+    if std::fs::symlink_metadata(link).is_ok() {
+        remove_path_for_replacement(link)?;
+    }
+    std::fs::rename(temp, link)
+}
+
+#[cfg_attr(
+    unix,
+    allow(
+        dead_code,
+        reason = "portable install fallback is selected on non-Unix and unit-tested on Unix"
+    )
+)]
+fn remove_path_for_replacement(path: &Path) -> std::io::Result<()> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || metadata.is_file() {
+        std::fs::remove_file(path)
+    } else if metadata.is_dir() {
+        std::fs::remove_dir_all(path)
+    } else {
+        Err(std::io::Error::other(format!(
+            "{} is neither a file nor a directory",
+            path.display()
+        )))
+    }
 }
 
 /// Find the latest (highest semver) version of `package_name` in the registry.
@@ -2115,6 +2215,30 @@ mod tests {
         assert!(!dst.path().join(".git").exists());
         assert!(!dst.path().join("target").exists());
         assert!(dst.path().join("hew.toml").exists());
+    }
+
+    #[test]
+    fn replace_local_package_copy_replaces_existing_tree() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(
+            src.path().join("hew.toml"),
+            "[package]\nname=\"x\"\nversion=\"0.2.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(src.path().join("x.hew"), "pub fn answer() -> i64 { 2 }").unwrap();
+
+        let project = tempfile::tempdir().unwrap();
+        let link = project.path().join(".adze").join("packages").join("x");
+        std::fs::create_dir_all(&link).unwrap();
+        std::fs::write(link.join("stale.hew"), "old").unwrap();
+
+        replace_local_package_copy(&link, src.path()).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(link.join("x.hew")).unwrap(),
+            "pub fn answer() -> i64 { 2 }"
+        );
+        assert!(!link.join("stale.hew").exists());
     }
 
     #[test]

--- a/adze-cli/src/cli.rs
+++ b/adze-cli/src/cli.rs
@@ -5,6 +5,9 @@ use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand, ValueEnum};
 
+use crate::package_name::{
+    invalid_message as invalid_package_name_message, is_valid as is_valid_package_name,
+};
 use crate::{
     checksum, client, config, credentials, index, lockfile, manifest, native, package_fs, registry,
     resolver, signing, tarball,
@@ -491,6 +494,11 @@ fn ensure_gitignore_entry(dir: &Path, entry: &str) {
 }
 
 fn cmd_add(pkg: &str, version: &str, registry_name: Option<&str>) {
+    if !is_valid_package_name(pkg) {
+        eprintln!("adze add: {}", invalid_package_name_message(pkg));
+        std::process::exit(1);
+    }
+
     // Validate the named registry exists (if specified) early.
     if registry_name.is_some() {
         let _ = make_client(registry_name);
@@ -553,6 +561,13 @@ fn cmd_install(locked: bool, registry: &registry::Registry, registry_name: Optio
         }
         // Verify checksums of locked packages.
         for entry in &lf.packages {
+            if !is_valid_package_name(&entry.name) {
+                eprintln!(
+                    "adze install: {}",
+                    invalid_package_name_message(&entry.name)
+                );
+                std::process::exit(1);
+            }
             if let Some(expected) = &entry.checksum {
                 let pkg_dir = registry.package_dir(&entry.name, &entry.version);
                 if pkg_dir.is_dir() {
@@ -621,6 +636,10 @@ fn cmd_install(locked: bool, registry: &registry::Registry, registry_name: Optio
     let mut lock_packages: Vec<lockfile::LockedPackage> = Vec::new();
 
     for (name, package) in &resolved {
+        if !is_valid_package_name(name) {
+            eprintln!("adze install: {}", invalid_package_name_message(name));
+            std::process::exit(1);
+        }
         let version = &package.version;
         let target = registry.package_dir(name, version);
         if !registry.is_installed(name, version) {
@@ -650,7 +669,13 @@ fn cmd_install(locked: bool, registry: &registry::Registry, registry_name: Optio
         });
 
         // Build the local symlink path: replace :: with / separators.
-        let link = local_link_path(&local_packages, name);
+        let link = match local_link_path(&local_packages, name) {
+            Ok(link) => link,
+            Err(e) => {
+                eprintln!("adze install: {e}");
+                std::process::exit(1);
+            }
+        };
         if let Some(parent) = link.parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
                 eprintln!("adze install: cannot create {}: {e}", parent.display());
@@ -1263,8 +1288,14 @@ fn cmd_tree(registry: &registry::Registry) {
         let child_prefix = if is_last { "    " } else { "│   " };
 
         let ver_req = spec.version_req();
-        let resolved = resolver::resolve_version(name, ver_req, registry)
-            .unwrap_or_else(|_| ver_req.to_string());
+        let resolved = match resolver::resolve_version(name, ver_req, registry) {
+            Ok(resolved) => resolved,
+            Err(resolver::ResolveError::NoMatchingVersion { .. }) => ver_req.to_string(),
+            Err(e) => {
+                eprintln!("adze tree: dependency {name}@{ver_req}: {e}");
+                std::process::exit(1);
+            }
+        };
         println!("{prefix}{name}@{resolved}");
 
         // Check if this dep itself has dependencies.
@@ -1356,7 +1387,14 @@ fn cmd_remove(package: &str) {
     match manifest::remove_dependency(&manifest_path, package) {
         Ok(true) => {
             // Remove local project package materialization if it exists.
-            let link = local_link_path(&project_packages_path(&cwd), package);
+            let link = match local_link_path(&project_packages_path(&cwd), package) {
+                Ok(link) => link,
+                Err(e) => {
+                    eprintln!("warning: could not remove local materialization for {package}: {e}");
+                    println!("Removed {package} from hew.toml");
+                    return;
+                }
+            };
             if std::fs::symlink_metadata(&link).is_ok() {
                 if let Err(e) = remove_path_for_replacement(&link) {
                     eprintln!("warning: could not remove {}: {e}", link.display());
@@ -1944,10 +1982,14 @@ fn project_packages_path(cwd: &Path) -> PathBuf {
     cwd.join(".adze").join("packages")
 }
 
-fn local_link_path(base: &Path, package_name: &str) -> PathBuf {
-    package_name
+fn local_link_path(base: &Path, package_name: &str) -> Result<PathBuf, String> {
+    if !is_valid_package_name(package_name) {
+        return Err(invalid_package_name_message(package_name));
+    }
+
+    Ok(package_name
         .split("::")
-        .fold(base.to_path_buf(), |path, segment| path.join(segment))
+        .fold(base.to_path_buf(), |path, segment| path.join(segment)))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -2080,35 +2122,6 @@ fn find_latest_version(
         .filter_map(|p| semver::Version::parse(&p.version).ok())
         .max()
         .map(|v| v.to_string())
-}
-
-/// Validate that a package name contains only lowercase alphanumeric, `_`, and `::` or `/` separators.
-/// Rejects empty names, empty segments, and names longer than 128 characters.
-fn is_valid_package_name(name: &str) -> bool {
-    if name.is_empty() || name.len() > 128 {
-        return false;
-    }
-    // Normalize :: to / then validate segments
-    let normalized = name.replace("::", "/");
-    // After normalizing ::→/, any remaining colons mean a bare single colon
-    if normalized.contains(':') {
-        return false;
-    }
-    if normalized.starts_with('/') || normalized.ends_with('/') {
-        return false;
-    }
-    for segment in normalized.split('/') {
-        if segment.is_empty() {
-            return false;
-        }
-        if !segment
-            .chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
-        {
-            return false;
-        }
-    }
-    true
 }
 
 /// Recursively copy `src` to `dst`, skipping `.git`, `target`, and `.adze`.
@@ -2310,6 +2323,9 @@ mod tests {
         assert!(!is_valid_package_name("my package"));
         assert!(!is_valid_package_name("my@package"));
         assert!(!is_valid_package_name("my:package")); // single colon
+        assert!(!is_valid_package_name("my/package"));
+        assert!(!is_valid_package_name("evil::../../../tmp/pwned"));
+        assert!(!is_valid_package_name("evil::/tmp/pwned"));
     }
 
     #[test]

--- a/adze-cli/src/lib.rs
+++ b/adze-cli/src/lib.rs
@@ -22,4 +22,5 @@ mod atomic_fs;
 mod checksum;
 mod lockfile;
 mod package_fs;
+mod package_name;
 mod paths;

--- a/adze-cli/src/package_name.rs
+++ b/adze-cli/src/package_name.rs
@@ -1,0 +1,71 @@
+//! Package-name validation shared by registry-facing code paths.
+
+const PACKAGE_NAME_RULES: &str = "only lowercase alphanumeric, `_`, and `::` allowed";
+
+/// Validate a package name in canonical `::` notation.
+///
+/// Names must be non-empty, at most 128 bytes, and composed of non-empty
+/// lowercase ASCII alphanumeric/underscore segments separated by `::`.
+#[must_use]
+pub(crate) fn is_valid(name: &str) -> bool {
+    if name.is_empty() || name.len() > 128 {
+        return false;
+    }
+    if name.starts_with("::") || name.ends_with("::") {
+        return false;
+    }
+    if name.contains('/') || name.contains('\\') {
+        return false;
+    }
+
+    for segment in name.split("::") {
+        if segment.is_empty() {
+            return false;
+        }
+        if !segment
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+        {
+            return false;
+        }
+    }
+    true
+}
+
+#[must_use]
+pub(crate) fn invalid_message(name: &str) -> String {
+    format!("invalid package name `{name}`: {PACKAGE_NAME_RULES}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_canonical_names() {
+        assert!(is_valid("mypackage"));
+        assert!(is_valid("my_package"));
+        assert!(is_valid("std::net::http"));
+        assert!(is_valid("pkg123::v2"));
+    }
+
+    #[test]
+    fn rejects_invalid_names() {
+        for name in [
+            "",
+            "my package",
+            "my@package",
+            "my:package",
+            "std::::http",
+            "::std",
+            "std::",
+            "std/net/http",
+            "std\\net",
+            "evil::..::etc",
+            "evil::../../../tmp/pwned",
+            "evil::/tmp/pwned",
+        ] {
+            assert!(!is_valid(name), "{name} should be invalid");
+        }
+    }
+}

--- a/adze-cli/src/resolver.rs
+++ b/adze-cli/src/resolver.rs
@@ -16,6 +16,7 @@ use std::fmt;
 
 use crate::index::IndexEntry;
 use crate::manifest::{self, DepSpec, HewManifest};
+use crate::package_name;
 use crate::registry::Registry;
 
 /// A dependency that could not be resolved locally.
@@ -50,6 +51,11 @@ pub enum ResolveError {
         /// The underlying parse error.
         source: semver::Error,
     },
+    /// The package name is not safe to resolve as a registry package.
+    InvalidPackageName {
+        /// The invalid package name.
+        package: String,
+    },
     /// No installed version matches the requirement.
     NoMatchingVersion {
         /// The package that was requested.
@@ -83,6 +89,9 @@ impl fmt::Display for ResolveError {
         match self {
             Self::InvalidVersionReq { input, source } => {
                 write!(f, "invalid version requirement `{input}`: {source}")
+            }
+            Self::InvalidPackageName { package } => {
+                f.write_str(&package_name::invalid_message(package))
             }
             Self::NoMatchingVersion {
                 package,
@@ -128,6 +137,7 @@ impl std::error::Error for ResolveError {
             Self::InvalidVersionReq { source, .. } => Some(source),
             Self::ManifestRead { source, .. } => Some(source),
             Self::NoMatchingVersion { .. }
+            | Self::InvalidPackageName { .. }
             | Self::CircularDependency { .. }
             | Self::UnresolvableDeps { .. } => None,
         }
@@ -311,6 +321,8 @@ impl<'a> ResolverPass<'a> {
         request: DepRequest,
         path: &[String],
     ) -> Result<VisitControl, ResolveError> {
+        validate_package_name(&request.name)?;
+
         if let Some(index) = path.iter().position(|node| node == &request.name) {
             let mut cycle = path[index..].to_vec();
             cycle.push(request.name.clone());
@@ -612,12 +624,24 @@ pub fn resolve_version(
     requirement: &str,
     registry: &Registry,
 ) -> Result<String, ResolveError> {
+    validate_package_name(package_name)?;
+
     let requirements = vec![requirement.to_string()];
     select_highest_matching_version(package_name, &requirements, &available_versions(registry))?
         .ok_or_else(|| ResolveError::NoMatchingVersion {
             package: package_name.to_string(),
             requirement: requirement.to_string(),
         })
+}
+
+fn validate_package_name(package: &str) -> Result<(), ResolveError> {
+    if package_name::is_valid(package) {
+        Ok(())
+    } else {
+        Err(ResolveError::InvalidPackageName {
+            package: package.to_string(),
+        })
+    }
 }
 
 /// Resolved version from a remote index query.
@@ -1011,6 +1035,17 @@ mod tests {
     }
 
     #[test]
+    fn resolve_version_rejects_traversal_package_name() {
+        let (_dir, reg) = test_registry();
+
+        let err = resolve_version("evil::../../../tmp/pwned", "1.0.0", &reg).unwrap_err();
+        assert!(matches!(err, ResolveError::InvalidPackageName { .. }));
+        assert!(err
+            .to_string()
+            .contains("invalid package name `evil::../../../tmp/pwned`"));
+    }
+
+    #[test]
     fn resolve_two_part_exact() {
         let (_dir, reg) = test_registry();
         install_fake(&reg, "mypkg", "1.0.0");
@@ -1170,6 +1205,37 @@ mod tests {
         assert_eq!(resolved["app::beta"].version, "1.0.0");
         assert_eq!(resolved["shared::leaf"].version, "1.4.0");
         assert!(resolved["shared::leaf"].direct_requirement.is_none());
+    }
+
+    #[test]
+    fn resolve_all_rejects_traversal_transitive_dependency_name() {
+        let (_dir, reg) = test_registry();
+        install_fake_package(
+            &reg,
+            "acme::innocent",
+            "1.0.0",
+            &[FakeDep {
+                name: "evil::../../../tmp/pwned",
+                version: "1.0.0",
+                optional: false,
+                features: &[],
+                default_features: true,
+            }],
+            &[],
+        );
+
+        let manifest = test_manifest(BTreeMap::from([(
+            "acme::innocent".to_string(),
+            manifest::DepSpec::Version("1.0.0".to_string()),
+        )]));
+
+        let err = resolve_all(&manifest, &reg).unwrap_err();
+        match err {
+            ResolveError::InvalidPackageName { package } => {
+                assert_eq!(package, "evil::../../../tmp/pwned");
+            }
+            other => panic!("expected InvalidPackageName, got: {other}"),
+        }
     }
 
     #[test]

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -200,6 +200,13 @@ pub struct ImportResolutionContext<'a> {
 }
 
 #[derive(Debug)]
+struct LockedPackageCheck {
+    package_dir: PathBuf,
+    name: String,
+    version: String,
+}
+
+#[derive(Debug)]
 pub struct TypeCheckResult {
     pub tco: Option<hew_types::check::TypeCheckOutput>,
     pub module_registry: hew_types::module_registry::ModuleRegistry,
@@ -1088,6 +1095,11 @@ fn resolve_file_imports_internal(
                     .collect::<PathBuf>()
                     .join(format!("{last}.hew"));
                 let mut candidates = Vec::new();
+                let mut locked_project_candidates = Vec::new();
+                let locked_version = ctx
+                    .locked_versions
+                    .and_then(|locked| locked.iter().find(|(name, _)| name == &module_str))
+                    .map(|(_, version)| version.as_str());
 
                 if is_local && !rest_path.is_empty() {
                     let local_last = *rest_path.last().expect("non-empty local path");
@@ -1107,12 +1119,8 @@ fn resolve_file_imports_internal(
                     candidates.push(cwd.join(&rel_path));
                 }
 
-                if let Some(version) = ctx
-                    .locked_versions
-                    .and_then(|locked| locked.iter().find(|(name, _)| name == &module_str))
-                    .map(|(_, version)| version.as_str())
-                {
-                    let module_dir = decl.path.iter().collect::<PathBuf>();
+                let module_dir = decl.path.iter().collect::<PathBuf>();
+                if let Some(version) = locked_version {
                     let entry_file =
                         format!("{}.hew", decl.path.last().expect("path is non-empty"));
                     let versioned_rel = module_dir.join(version).join(entry_file);
@@ -1123,7 +1131,19 @@ fn resolve_file_imports_internal(
                 }
 
                 candidates.push(ctx.project_dir.join(".adze/packages").join(&rel_path));
-                candidates.push(ctx.project_dir.join(".adze/packages").join(&dir_path));
+                let project_package_dir = ctx.project_dir.join(".adze/packages").join(&module_dir);
+                let project_package_entry = ctx.project_dir.join(".adze/packages").join(&dir_path);
+                if let Some(version) = locked_version {
+                    locked_project_candidates.push((
+                        project_package_entry.clone(),
+                        LockedPackageCheck {
+                            package_dir: project_package_dir,
+                            name: module_str.clone(),
+                            version: version.to_string(),
+                        },
+                    ));
+                }
+                candidates.push(project_package_entry);
 
                 if let Some(pkg) = ctx.extra_pkg_path {
                     candidates.push(pkg.join(&dir_path));
@@ -1166,10 +1186,18 @@ fn resolve_file_imports_internal(
                 // Collect ALL candidates that resolve, then deduplicate by canonical path.
                 // If two or more distinct canonical paths resolve, the import is ambiguous —
                 // fail-closed rather than silently picking the first match.
-                let mut resolved: Vec<std::path::PathBuf> = candidates
-                    .iter()
-                    .filter_map(|candidate| candidate.canonicalize().ok())
-                    .collect();
+                let mut resolved = Vec::new();
+                for candidate in &candidates {
+                    if let Ok(canonical) = candidate.canonicalize() {
+                        if let Some((_, check)) = locked_project_candidates
+                            .iter()
+                            .find(|(locked_candidate, _)| locked_candidate == candidate)
+                        {
+                            verify_locked_project_package(check)?;
+                        }
+                        resolved.push(canonical);
+                    }
+                }
                 resolved.sort();
                 resolved.dedup();
 
@@ -1608,6 +1636,8 @@ fn default_edition() -> String {
 #[derive(Debug, Deserialize)]
 struct PackageSection {
     name: String,
+    #[serde(default)]
+    version: Option<String>,
     #[serde(default = "default_edition")]
     edition: String,
 }
@@ -1701,6 +1731,37 @@ fn load_manifest(dir: &Path) -> Result<Option<TomlManifest>, FrontendFailure> {
         }
     }
     Ok(manifest)
+}
+
+fn verify_locked_project_package(check: &LockedPackageCheck) -> Result<(), FrontendFailure> {
+    let Some(manifest) = load_manifest(&check.package_dir)? else {
+        return Err(FrontendFailure::message_only(format!(
+            "Error: locked package `{}` resolved through `{}` is missing hew.toml\n  hint: run `adze install` to refresh .adze/packages",
+            check.name,
+            check.package_dir.display()
+        )));
+    };
+    let Some(package) = manifest.package else {
+        return Err(FrontendFailure::message_only(format!(
+            "Error: locked package `{}` resolved through `{}` has no [package] section\n  hint: run `adze install` to refresh .adze/packages",
+            check.name,
+            check.package_dir.display()
+        )));
+    };
+    if package.name != check.name || package.version.as_deref() != Some(check.version.as_str()) {
+        let found = package.version.as_deref().map_or_else(
+            || format!("{}@<missing-version>", package.name),
+            |version| format!("{}@{version}", package.name),
+        );
+        return Err(FrontendFailure::message_only(format!(
+            "Error: locked package `{}` resolved through `{}` does not match adze.lock (expected {}@{}, found {found})\n  hint: run `adze install` to refresh .adze/packages",
+            check.name,
+            check.package_dir.display(),
+            check.name,
+            check.version
+        )));
+    }
+    Ok(())
 }
 
 fn load_manifest_metadata(

--- a/tests/package-install/run.sh
+++ b/tests/package-install/run.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# End-to-end package-manager consumer proof: local publish setup -> user-facing
+# `hew package install` -> lock/materialization -> compiler check/run.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HEW="${ROOT}/target/debug/hew"
+ADZE="${ROOT}/target/debug/adze"
+
+fail() {
+  echo "FAIL package-install: $*" >&2
+  exit 1
+}
+
+require_binary() {
+  local bin="$1"
+  if [[ ! -x "${bin}" ]]; then
+    fail "missing executable ${bin}; run the Makefile target so build prerequisites are present"
+  fi
+}
+
+run_in() {
+  local dir="$1"
+  local name="$2"
+  shift 2
+  local log="${TMP}/logs/${name}.log"
+  if ! (cd "${dir}" && "$@") >"${log}" 2>&1; then
+    cat "${log}" >&2
+    fail "${name} exited non-zero"
+  fi
+}
+
+assert_contains() {
+  local path="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" "${path}"; then
+    echo "Expected ${path} to contain: ${needle}" >&2
+    echo "--- ${path} ---" >&2
+    cat "${path}" >&2
+    fail "missing expected file content"
+  fi
+}
+
+assert_output() {
+  local consumer="$1"
+  local expected="$2"
+  local name="$3"
+  local actual="${TMP}/logs/${name}.out"
+  local stderr="${TMP}/logs/${name}.err"
+  if ! (cd "${consumer}" && "${HEW}" run main.hew) >"${actual}" 2>"${stderr}"; then
+    cat "${stderr}" >&2
+    fail "${name}: hew run exited non-zero"
+  fi
+  printf '%s\n' "${expected}" >"${TMP}/logs/${name}.expected"
+  if ! diff -u "${TMP}/logs/${name}.expected" "${actual}"; then
+    fail "${name}: stdout mismatch"
+  fi
+}
+
+last_segment() {
+  local package="$1"
+  printf '%s\n' "${package##*::}"
+}
+
+write_package() {
+  local dir="$1"
+  local package="$2"
+  local version="$3"
+  local value="$4"
+  local entry
+  entry="$(last_segment "${package}")"
+  mkdir -p "${dir}"
+  cat >"${dir}/hew.toml" <<EOF_MANIFEST
+[package]
+name = "${package}"
+version = "${version}"
+edition = "2026"
+description = "package-install e2e fixture"
+authors = ["Hew Contributors"]
+license = "MIT OR Apache-2.0"
+EOF_MANIFEST
+  cat >"${dir}/${entry}.hew" <<EOF_SOURCE
+pub fn answer() -> i64 {
+    ${value}
+}
+EOF_SOURCE
+}
+
+write_consumer() {
+  local dir="$1"
+  local package="$2"
+  local version="$3"
+  local module
+  module="$(last_segment "${package}")"
+  mkdir -p "${dir}"
+  cat >"${dir}/hew.toml" <<EOF_MANIFEST
+[package]
+name = "consumer"
+version = "0.1.0"
+edition = "2026"
+
+[dependencies]
+"${package}" = "${version}"
+EOF_MANIFEST
+  cat >"${dir}/main.hew" <<EOF_SOURCE
+import ${package};
+
+fn main() {
+    println(f"{${module}.answer()}");
+}
+EOF_SOURCE
+}
+
+expect_check_failure() {
+  local dir="$1"
+  local name="$2"
+  local needle="$3"
+  local output
+  if output="$(cd "${dir}" && "${HEW}" check main.hew 2>&1)"; then
+    echo "${output}" >&2
+    fail "${name}: hew check unexpectedly succeeded"
+  fi
+  if ! grep -Fq "${needle}" <<<"${output}"; then
+    echo "${output}" >&2
+    fail "${name}: missing expected diagnostic: ${needle}"
+  fi
+}
+
+expect_install_failure() {
+  local dir="$1"
+  local name="$2"
+  local needle="$3"
+  local output
+  if output="$(cd "${dir}" && "${HEW}" package install 2>&1)"; then
+    echo "${output}" >&2
+    fail "${name}: hew package install unexpectedly succeeded"
+  fi
+  if ! grep -Fq "${needle}" <<<"${output}"; then
+    echo "${output}" >&2
+    fail "${name}: missing expected install diagnostic: ${needle}"
+  fi
+}
+
+require_binary "${HEW}"
+require_binary "${ADZE}"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/hew-package-install.XXXXXX")"
+trap 'rm -rf "${TMP}"' EXIT
+mkdir -p "${TMP}/logs"
+
+export HOME="${TMP}/home"
+mkdir -p "${HOME}"
+
+run_in "${TMP}" keygen "${ADZE}" key generate
+
+adder_pkg="${TMP}/pkgs/adder-0.1.0"
+write_package "${adder_pkg}" "acme::adder" "0.1.0" "42"
+run_in "${adder_pkg}" publish-adder "${ADZE}" publish
+
+consumer="${TMP}/consumer"
+write_consumer "${consumer}" "acme::adder" "0.1.0"
+run_in "${consumer}" install-adder "${HEW}" package install
+test -f "${consumer}/adze.lock" || fail "adze.lock was not written"
+assert_contains "${consumer}/adze.lock" 'name = "acme::adder"'
+assert_contains "${consumer}/adze.lock" 'version = "0.1.0"'
+test -f "${consumer}/.adze/packages/acme/adder/hew.toml" \
+  || fail "project-local package manifest was not materialized"
+test -f "${consumer}/.adze/packages/acme/adder/adder.hew" \
+  || fail "project-local package entry source was not materialized"
+run_in "${consumer}" check-adder "${HEW}" check main.hew
+assert_output "${consumer}" "42" "run-adder"
+echo "PASS package-install minimal consumer"
+
+missing_consumer="${TMP}/missing-consumer"
+write_consumer "${missing_consumer}" "acme::missing" "0.1.0"
+expect_check_failure "${missing_consumer}" "missing package" "run \`adze install\`"
+echo "PASS package-install missing rejection"
+
+broken_registry="${HOME}/.adze/packages/acme/broken/0.1.0"
+mkdir -p "${broken_registry}"
+printf 'not valid {{{\n' >"${broken_registry}/hew.toml"
+broken_consumer="${TMP}/broken-consumer"
+write_consumer "${broken_consumer}" "acme::broken" "0.1.0"
+expect_install_failure \
+  "${broken_consumer}" \
+  "malformed package" \
+  "cannot read installed manifest for \`acme::broken@0.1.0\`"
+echo "PASS package-install malformed rejection"
+
+versioned_v1="${TMP}/pkgs/versioned-0.1.0"
+versioned_v2="${TMP}/pkgs/versioned-0.2.0"
+write_package "${versioned_v1}" "acme::versioned" "0.1.0" "101"
+write_package "${versioned_v2}" "acme::versioned" "0.2.0" "202"
+run_in "${versioned_v1}" publish-versioned-v1 "${ADZE}" publish
+run_in "${versioned_v2}" publish-versioned-v2 "${ADZE}" publish
+
+versioned_consumer="${TMP}/versioned-consumer"
+write_consumer "${versioned_consumer}" "acme::versioned" "0.1.0"
+run_in "${versioned_consumer}" install-versioned-v1 "${HEW}" package install
+assert_contains "${versioned_consumer}/adze.lock" 'name = "acme::versioned"'
+assert_contains "${versioned_consumer}/adze.lock" 'version = "0.1.0"'
+run_in "${versioned_consumer}" check-versioned-v1 "${HEW}" check main.hew
+assert_output "${versioned_consumer}" "101" "run-versioned-v1"
+
+write_consumer "${versioned_consumer}" "acme::versioned" "0.2.0"
+run_in "${versioned_consumer}" install-versioned-v2 "${HEW}" package install
+assert_contains "${versioned_consumer}/adze.lock" 'name = "acme::versioned"'
+assert_contains "${versioned_consumer}/adze.lock" 'version = "0.2.0"'
+run_in "${versioned_consumer}" check-versioned-v2 "${HEW}" check main.hew
+assert_output "${versioned_consumer}" "202" "run-versioned-v2"
+
+stale_target="${HOME}/.adze/packages/acme/versioned/0.1.0"
+stale_link="${versioned_consumer}/.adze/packages/acme/versioned"
+rm -rf "${stale_link}"
+mkdir -p "$(dirname "${stale_link}")"
+if ! ln -s "${stale_target}" "${stale_link}" 2>/dev/null; then
+  cp -R "${stale_target}" "${stale_link}"
+fi
+expect_check_failure \
+  "${versioned_consumer}" \
+  "stale package materialization" \
+  'does not match adze.lock (expected acme::versioned@0.2.0'
+echo "PASS package-install version matrix"

--- a/tests/package-install/run.sh
+++ b/tests/package-install/run.sh
@@ -176,6 +176,23 @@ write_consumer "${missing_consumer}" "acme::missing" "0.1.0"
 expect_check_failure "${missing_consumer}" "missing package" "run \`adze install\`"
 echo "PASS package-install missing rejection"
 
+traversal_consumer="${TMP}/traversal-consumer"
+mkdir -p "${traversal_consumer}"
+cat >"${traversal_consumer}/hew.toml" <<EOF_MANIFEST
+[package]
+name = "traversal_consumer"
+version = "0.1.0"
+edition = "2026"
+
+[dependencies]
+"evil::../../../tmp/pwned" = "1.0.0"
+EOF_MANIFEST
+expect_install_failure \
+  "${traversal_consumer}" \
+  "traversal package name" \
+  "invalid package name \`evil::../../../tmp/pwned\`"
+echo "PASS package-install traversal dependency rejection"
+
 broken_registry="${HOME}/.adze/packages/acme/broken/0.1.0"
 mkdir -p "${broken_registry}"
 printf 'not valid {{{\n' >"${broken_registry}/hew.toml"


### PR DESCRIPTION
## Why

A project-local `.adze/packages/{pkg}` materialization left over from an earlier `adze install` run could go stale relative to `adze.lock`. If the package directory's version bumped (or `adze.lock` was updated) but the on-disk `.adze/packages/{pkg}` symlink still pointed at the old install, `hew check`/`hew run` accepted it silently — the compiler resolved the import through the stale materialization and compiled against the wrong version with no error.

`adze install`'s project-local package linking was also Unix-only: on non-Unix platforms it printed a warning and skipped materializing the package entirely, so a `hew.toml` dependency with a project-local package never actually became importable.

## What

- **hew-compile**: track the unversioned project-local `.adze/packages/{module}/{entry}.hew` import candidate alongside its `adze.lock` entry when one exists. Before accepting a resolution through that candidate, `verify_locked_project_package` loads the candidate's `hew.toml` and requires `[package].name`/`.version` to match the lock entry exactly — a missing manifest, missing `[package]` section, or version mismatch fails closed with a diagnostic pointing at `adze install`.
- **adze-cli**: `adze install`'s project-local materialization now goes through a shared `replace_local_package_materialization` entry point. Unix keeps the existing symlink swap unchanged; non-Unix gets a real copy fallback (`replace_local_package_copy`) — stage into a temp sibling, remove any existing target, then rename into place — instead of silently skipping the link. `cmd_remove`'s local package removal now branches on `symlink_metadata` instead of assuming the target is always a symlink, which is correct on both platforms.
- Added `tests/package-install/run.sh` (`make test-package-install`), an isolated e2e harness: publish a fixture package, `hew package install` it, assert `adze.lock` and the project-local materialization, `hew check`, and assert exact `hew run` output — plus missing-dependency rejection, malformed-manifest rejection, and a two-version pin-then-upgrade case that includes the stale-materialization rejection.

## Test

- `tests/package-install/run.sh` reproduces the original gap directly: with `verify_locked_project_package` disabled, `hew check` against a consumer whose `.adze/packages` symlink still pointed at an older package version printed `OK` and exited 0. With the check restored, the same scenario fails closed with the expected diagnostic.
- New `adze-cli` unit test `replace_local_package_copy_replaces_existing_tree` covers the copy fallback replacing stale content.
- No dedicated fast in-process test exists yet for `verify_locked_project_package` itself — only the e2e harness in `tests/package-install/run.sh` exercises it. That harness proved the actual bug and its fix end to end; a faster unit test would still be a useful follow-up (see Out of scope).
- Existing suites pass with no regressions: `hew-compile` (47 tests), `adze-cli` (257 tests, including the new one), `tests/pkg-import/run.sh` import-resolution oracle, `cargo fmt --check`, `make lint` (including `cargo clippy --workspace --tests -- -D warnings`).

## Quality Checklist
- [x] PR title, body, and commit messages avoid internal-only orchestration/model vocabulary
- [ ] No new `.ok()?` or `unwrap_or_default()` in codegen without `// JUSTIFIED` comment — N/A, no codegen touched
- [x] New allocations have cleanup paths for sync, async, and actor shutdown contexts — the copy fallback removes its temp staging directory on failure and never leaves a partial swap in place
- [ ] Serialization changes include round-trip encode/decode tests — N/A, no wire/serialization format changed
- [ ] New runtime features have WASM implementation or `// WASM-TODO(#NNN):` marker — N/A, no runtime feature added
- [x] No duplicated logic — checked for existing helpers before adding new ones — the copy fallback reuses the existing `copy_dir` helper

## Out of scope

- A dedicated fast Rust unit/integration test for `verify_locked_project_package` beyond the e2e harness — tracked as a follow-up, not a blocker.
- This diff touches TOML manifest deserialization of installed package metadata and filesystem symlink/copy staging with a temp-then-rename swap. Flagging as a follow-up security-focused pass over package installation, not a blocker — nothing found here looks exploitable by inspection.
- A pre-existing flat `.adze/packages/{module}.hew` unversioned candidate is not covered by the new lock check. Verified this is dead surface today: `adze install`'s local link path always produces the directory-style layout, never a flat file. Worth a comment or follow-up if a single-file package layout is added later.
