### PR TITLE
feat(std-url): add query form decoder

### DIFF
--- a/std/net/url/url.hew
+++ b/std/net/url/url.hew
@@ -214,6 +214,72 @@ fn decode_impl(s: string) -> string {
     out.to_string()
 }
 
+/// Decode an `application/x-www-form-urlencoded` query string into
+/// `(key, value)` pairs.
+///
+/// Entries are separated by `&`; each entry must contain `=` and entries
+/// without one are skipped, matching `encode_query`'s invalid-line convention.
+/// Percent-escapes are decoded like [`decode`], and `+` decodes to a space.
+///
+/// # Examples
+///
+/// ```
+/// import std::net::url;
+///
+/// let pairs = url.decode_query("name=hello+world&x=a%2Bb");
+/// // [("name", "hello world"), ("x", "a+b")]
+/// ```
+pub fn decode_query(params: string) -> Vec<(string, string)> {
+    decode_query_impl(params)
+}
+
+fn decode_query_impl(params: string) -> Vec<(string, string)> {
+    let decoded: Vec<(string, string)> = Vec::new();
+    if string.is_empty(params) {
+        return decoded;
+    }
+    let entries = string.split(params, "&");
+    for i in 0 .. entries.len() {
+        let entry = entries[i];
+        let eq = entry.find("=");
+        if eq >= 0 {
+            let key = entry.slice(0, eq);
+            let value = entry.slice(eq + 1, entry.len());
+            decoded.push((decode_form_component(key), decode_form_component(value)));
+        }
+    }
+    decoded
+}
+
+fn decode_form_component(s: string) -> string {
+    let data = s.to_bytes();
+    if !valid_percent_utf8(data) {
+        return "";
+    }
+    let out: bytes = bytes::new();
+    var i = 0;
+    while i < data.len() {
+        let b = data[i];
+        if b == 43 {
+            out.push(32 as u8);
+            i = i + 1;
+            continue;
+        }
+        if b == 37 && i + 2 < data.len() {
+            let hi = hex_nibble(data[i + 1]);
+            let lo = hex_nibble(data[i + 2]);
+            if hi >= 0 && lo >= 0 {
+                out.push((hi * 16 + lo) as u8);
+                i = i + 3;
+                continue;
+            }
+        }
+        out.push(b);
+        i = i + 1;
+    }
+    out.to_string()
+}
+
 /// Validate that the percent-encoded bytes in `data` decode to complete,
 /// well-formed UTF-8 sequences. Literal bytes may not interrupt a multi-byte
 /// sequence. Returns `false` on any malformed sequence (decode returns `""`).

--- a/std/net/url/url.hew
+++ b/std/net/url/url.hew
@@ -241,11 +241,13 @@ fn decode_query_impl(params: string) -> Vec<(string, string)> {
     let entries = string.split(params, "&");
     for i in 0 .. entries.len() {
         let entry = entries[i];
-        let eq = entry.find("=");
-        if eq >= 0 {
-            let key = entry.slice(0, eq);
-            let value = entry.slice(eq + 1, entry.len());
-            decoded.push((decode_form_component(key), decode_form_component(value)));
+        match entry.find("=") {
+            Some(eq) => {
+                let key = entry.slice(0, eq);
+                let value = entry.slice(eq + 1, entry.len());
+                decoded.push((decode_form_component(key), decode_form_component(value)));
+            },
+            None => {},
         }
     }
     decoded

--- a/tests/hew/url_test.hew
+++ b/tests/hew/url_test.hew
@@ -35,6 +35,36 @@ fn test_decode_truncates_at_decoded_nul() {
 }
 
 #[test]
+fn test_decode_query_empty_returns_empty_vec() {
+    let pairs = url.decode_query("");
+    testing.assert_eq(pairs.len(), 0);
+}
+
+#[test]
+fn test_decode_query_decodes_form_pairs_in_order() {
+    let pairs = url.decode_query("name=hello+world&x=a%2Bb&empty=&a=b=c");
+    testing.assert_eq(pairs.len(), 4);
+    testing.assert_eq_str(pairs[0].0, "name");
+    testing.assert_eq_str(pairs[0].1, "hello world");
+    testing.assert_eq_str(pairs[1].0, "x");
+    testing.assert_eq_str(pairs[1].1, "a+b");
+    testing.assert_eq_str(pairs[2].0, "empty");
+    testing.assert_eq_str(pairs[2].1, "");
+    testing.assert_eq_str(pairs[3].0, "a");
+    testing.assert_eq_str(pairs[3].1, "b=c");
+}
+
+#[test]
+fn test_decode_query_skips_entries_without_equals() {
+    let pairs = url.decode_query("skip-me&ok=yes&&also=no");
+    testing.assert_eq(pairs.len(), 2);
+    testing.assert_eq_str(pairs[0].0, "ok");
+    testing.assert_eq_str(pairs[0].1, "yes");
+    testing.assert_eq_str(pairs[1].0, "also");
+    testing.assert_eq_str(pairs[1].1, "no");
+}
+
+#[test]
 fn test_port_returns_none_when_absent() {
     let parsed = url.parse("http://localhost/path");
     let port = parsed.port();


### PR DESCRIPTION
## Summary

`std::net::url` gets a `decode_query(params: string) -> Vec<(string, string)>` function that parses an `application/x-www-form-urlencoded` query string into ordered `(key, value)` pairs. Entries are split on `&`; each entry needs a `=` or it's skipped (mirrors `encode_query`'s own invalid-line convention). Values are decoded the same way `decode` handles percent-escapes, plus `+` decodes to a space per the form-encoding spec. This is the read-side counterpart to the existing `encode_query`.

## Verification

- `hew test tests/hew/url_test.hew`: 12 passed, 0 failed, 0 ignored
- `make test-lane CRATE=hew-cli`: 381 tests run, 381 passed, 2 skipped
- `make test-lane CRATE=hew-types`: 2483 tests run, 2483 passed, 3 skipped
- `make hew-check-all`: 1510 files checked, 139 expected failures, 139 actual — matches
- `make lint`: clean (fmt, clippy `--workspace --tests -D warnings`, FFI symbol verify, orchestration-leak scan)
- Manual: hand-traced and confirmed `decode_query("name=hello+world&x=a%2Bb&empty=&a=b=c")` against the built binary, round-tripped `decode_query(encode_query(...))`, and spot-checked edge cases (empty input, lone `=`, entries without `=`, consecutive `&&`, truncated/malformed percent-escapes)

## Out of scope

- `decode_form_component`'s buffer-build pattern (`bytes::new()` ... `.to_string()`) inherits a pre-existing, already-tracked memory leak shared by every stdlib function using that idiom (`decode`, `base64`, `hex`, `binary`, ...). Root cause is a compiler-level ownership-tracking gap, tracked separately in #2332 — not introduced by this change and not fixable within a stdlib feature PR.
