### PR TITLE
fix(mir,types): re-resolve Vec<T>::iter()'s clone symbol per element type

### DIFF
--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -12864,6 +12864,7 @@ impl Builder {
                 | hew_types::VecMethod::Pop
                 | hew_types::VecMethod::Remove
                 | hew_types::VecMethod::Contains
+                | hew_types::VecMethod::Clone
         ) {
             return None;
         }
@@ -12876,6 +12877,33 @@ impl Builder {
             return None;
         };
         let elem = args.first()?;
+        // `Clone` has its own arm: unlike push/get/set/pop/remove/contains it
+        // has no entry at all in `vec_element_op_symbol`'s shared
+        // `(method, token)` table (that table only covers the ops whose
+        // owned/non-owned symbol pair the concrete path resolves through it;
+        // `resolve_vec_method`'s own `"clone"` arm never consults it either —
+        // see `hew-types/src/stdlib.rs`). Route it directly: an owned element
+        // clones deep via `hew_vec_clone_owned` (arity matches the call site's
+        // receiver-only `arg_places`, same as `push`/`get`/etc.); a BitCopy
+        // scalar/string/pointer element clones via the legacy element-agnostic
+        // `hew_vec_clone` (also receiver-only arity) — this is the concrete
+        // path's own `_ => Some("hew_vec_clone")` default for every non-Copy,
+        // non-owned, non-layout element. A concrete (non-abstract) BitCopy
+        // *value-record*/tuple element under a type param resolves to the
+        // `Layout` token here, but its clone needs `hew_vec_clone_layout`,
+        // which is NOT receiver-only (it also takes a layout-descriptor
+        // pointer the `_FAMILY` call site never lowers as an operand) — fail
+        // closed on that token rather than emit an arity-mismatched call.
+        if vec_method == hew_types::VecMethod::Clone {
+            if self.is_owned_vec_element(elem) {
+                return Some("hew_vec_clone_owned".to_string());
+            }
+            let elem_ty = elem.to_ty();
+            return match self.vec_generic_element_abi.get(&elem_ty).copied() {
+                Some(hew_types::stdlib::VecElementToken::Layout) => None,
+                _ => Some("hew_vec_clone".to_string()),
+            };
+        }
         // #1929 Stage 2: an owned (non-`Copy`) element resolves to the owned
         // descriptor family — the same symbol the concrete owned path picks
         // (`Builder` get-symbol routing `_ if owned_elem => "hew_vec_get_owned"`
@@ -12896,7 +12924,8 @@ impl Builder {
                 other => unreachable!(
                     "resolve_polymorphic_vec_element_symbol reached the owned arm \
                      for non-element Vec method {other:?}; the `matches!` guard \
-                     above admits only push/get/set/pop/remove/contains"
+                     above admits only push/get/set/pop/remove/contains (Clone \
+                     returns earlier above)"
                 ),
             };
             Some(owned_symbol.to_string())

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -3862,6 +3862,37 @@ impl Checker {
             return;
         }
 
+        // `clone` (unlike `push`/`get`/`set`/`pop`/`remove`/`contains`) has no
+        // dedicated per-element-token entry in `resolve_vec_method` — its
+        // match arm falls back to the plain scalar/BitCopy symbol
+        // (`hew_vec_clone`) whenever `vec_element_runtime_suffix` returns
+        // anything other than `Some("layout")`, INCLUDING `None` (a bare
+        // declared type parameter, e.g. `T` in `fn f<T>(v: Vec<T>)` —
+        // `type_defs.get(name)` has no entry for a type param). So
+        // `resolve_vec_runtime_symbol("clone", abstract_T, ..)` below always
+        // returns `Some("hew_vec_clone")` for an abstract element: the
+        // `let Some(..) = .. else` placeholder-preserving branch never even
+        // fires for `clone`, unlike the element-typed ops it mirrors.
+        //
+        // The `Vec<T>::iter()` desugar hits exactly this gap: it pre-records
+        // a synthetic `recv.clone()` snapshot while `T` is still abstract
+        // (see the `"iter"` arm above), so `hew check` silently bakes in the
+        // legacy `hew_vec_clone` symbol. `hew_vec_clone` aborts at runtime on
+        // a layout-aware/owned Vec (its own doc comment: "Legacy
+        // `hew_vec_clone` aborts on a layout-backed Vec"), so instantiating
+        // the generic at an owned element type (e.g. a managed record) passes
+        // `hew check` clean and then panics at runtime — a real, live,
+        // checker-approved-code-crashes defect, not just a diagnostic gap.
+        //
+        // Fail this resolution closed here (treat it exactly like `push`/
+        // `get`/etc.'s abstract case) so the `_FAMILY` placeholder survives
+        // to MIR, which now re-resolves `clone` per-monomorphisation through
+        // the same `is_owned_vec_element` / `vec_generic_element_abi`
+        // authority the other element-typed ops already use.
+        if method == "clone" && self.is_vec_element_abstract_type_param(&elem_ty) {
+            return;
+        }
+
         let Some(symbol_name) = self.resolve_vec_runtime_symbol(method, &elem_ty, span) else {
             // Polymorphic element re-resolution (#1929 Stage 1). When the
             // element is a declared type parameter the concrete `hew_vec_*`

--- a/tests/hew/generic_vec_iter_surface_test.hew
+++ b/tests/hew/generic_vec_iter_surface_test.hew
@@ -18,3 +18,25 @@ fn test_generic_vec_iter_i64() {
     values.push(2);
     testing.assert_eq(generic_iter_count(values), 2);
 }
+
+// Regression: `Vec<T>::iter()` pre-records its internal place-receiver
+// snapshot clone while `T` is still abstract. For an OWNED (non-Copy)
+// element like a managed record, the abstract-time resolution used to fall
+// through to the legacy `hew_vec_clone` symbol (the concrete path's default
+// for anything that isn't a known layout), which aborts at runtime on an
+// owned-constructed Vec ("Vec owned operation requires an element layout
+// descriptor") -- `hew check` passed clean, and the panic only surfaced when
+// the generic was instantiated at an owned element type. The fix
+// re-resolves `clone` per-monomorphisation through the same
+// `is_owned_vec_element` authority `push`/`get`/etc. already use, routing an
+// owned element to `hew_vec_clone_owned` instead.
+type IterOwnedItem { name: string; n: i64; }
+
+#[test]
+fn test_generic_vec_iter_owned_record() {
+    let xs: Vec<IterOwnedItem> = Vec::new();
+    xs.push(IterOwnedItem { name: "alpha", n: 10 });
+    xs.push(IterOwnedItem { name: "beta", n: 20 });
+    xs.push(IterOwnedItem { name: "gamma", n: 30 });
+    testing.assert_eq(generic_iter_count(xs), 3);
+}


### PR DESCRIPTION
## What

`Vec<T>::iter()` desugars to a place-receiver clone snapshot
(`recv.clone()`) recorded while the element type `T` is still abstract.
That snapshot's symbol resolution was never actually wired into the
per-monomorphisation re-resolution path (#1929 Stage 1) that
`push`/`get`/`set`/`pop`/`remove`/`contains` already use — `clone` fell
through to the legacy `hew_vec_clone` symbol at check time regardless
of what the element resolves to at monomorphisation.

## Bug

For a generic function that iterates a `Vec<T>` and gets instantiated
at an **owned** (non-`Copy`) element type — a managed record, for
example — `hew check` passes clean, but `hew run`/`hew test` panics at
runtime:

```
PANIC: Vec owned operation requires an element layout descriptor
```

`hew_vec_clone` (the symbol the checker picked at abstract-check-time)
aborts by design on an owned-constructed Vec; the checker just never
told MIR it needed to re-resolve `clone` per-instantiation the way it
already does for the other element-typed ops.

### Root cause, precisely

- **Checker** (`record_resolved_vec_call` in
  `hew-types/src/check/methods.rs`): `resolve_vec_method`'s `"clone"`
  arm has no per-element-token entry in the shared `(method, token)`
  table the other ops use — it falls back to plain `hew_vec_clone`
  whenever `vec_element_runtime_suffix` returns anything other than
  `Some("layout")`, **including `None`** (an abstract type parameter
  has no entry in `type_defs`). So `resolve_vec_runtime_symbol("clone",
  abstract_T, ..)` always succeeds with the wrong symbol, and the
  `_FAMILY`-placeholder-preserving branch that gates `push`/`get`/etc.
  never triggers for `clone`.
- **MIR** (`resolve_polymorphic_vec_element_symbol` in
  `hew-mir/src/lower.rs`): the re-resolution gate's `matches!` never
  included `VecMethod::Clone` in the first place, and `clone` has no
  entries in `vec_element_op_symbol` either.

Verified live in an isolated worktree before touching any code: a
generic `fn f<T>(v: Vec<T>) { for x in v.iter() {...} }` instantiated
at a `type Item { name: string; n: i64; }` record passed `hew check`
(RC=0) and then panicked exactly as above on `hew test`/`hew run`.

## Fix

Treat `clone` like the other element-typed Vec ops it was supposed to
mirror:

- Checker: keep the `hew_vec_clone_FAMILY` placeholder (instead of
  eagerly resolving to the legacy symbol) whenever the element is a
  bare declared type parameter.
- MIR: add a dedicated `Clone` arm to
  `resolve_polymorphic_vec_element_symbol` that consults the same
  `is_owned_vec_element` authority the other ops use:
  - an **owned** element routes to `hew_vec_clone_owned` (same
    receiver-only argument arity the `_FAMILY` call site already
    lowers, so no operand-shape change needed);
  - a **BitCopy scalar/string/pointer** element keeps the legacy
    `hew_vec_clone` (also receiver-only arity — this matches the
    concrete path's own default for the same element classes);
  - a **concrete BitCopy value-record/tuple** element under a type
    param (the `Layout` token) now **fails closed at check time**
    instead of silently panicking at runtime. `hew_vec_clone_layout`
    needs an extra layout-descriptor pointer operand that the
    `_FAMILY` call site never lowers, so routing to it would trade one
    silent-runtime-panic shape for an ABI-mismatched call — worse, not
    better. This case was *also* silently panicking before this PR
    (verified live: `"Vec layout-aware operation is not implemented"`),
    so converting it to an accurate compile-time diagnostic is a net
    improvement, and it's consistent with this function's existing
    fail-closed policy for every other element class it can't yet
    route ("An element neither authority resolves fails closed here
    rather than calling an undeclared symbol").

## Tests

Added `test_generic_vec_iter_owned_record` alongside the existing
`test_generic_vec_iter_i64` in `tests/hew/generic_vec_iter_surface_test.hew`,
giving the owned-element path the same coverage the scalar path already
had. Verified load-bearing: reverting the fix (keeping only the new
test) reproduces the exact predicted panic; restoring the fix passes.

## Verification

- `cargo test -p hew-mir --lib` — 327/327 passed, 0 failed
- `cargo test -p hew-types --lib` — 1636/1636 passed, 2 ignored (pre-existing), 0 failed
- `cargo fmt -p hew-types -p hew-mir --check` — clean
- `cargo clippy -p hew-types -p hew-mir --lib --tests -- -D warnings` — clean
- `tests/vertical-slice/run.sh` — 433/439 passed, 0 failed
- `scripts/hew-suite-ratchet.sh` — **PASSED** (0 expected failures, 0 actual failures)
