### PR TITLE
fix(compile,types): close std:: shadowing gap, fix unit-binding warning

### DIFF
--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -1128,7 +1128,7 @@ fn resolve_file_imports_internal(
                 if let Some(pkg) = ctx.extra_pkg_path {
                     candidates.push(pkg.join(&dir_path));
                     candidates.push(pkg.join(&rel_path));
-                    if decl.path.len() > 1 {
+                    if decl.path.len() > 1 && !is_builtin_module(&module_str) {
                         let rest_dir = decl.path[1..]
                             .iter()
                             .collect::<PathBuf>()
@@ -2163,6 +2163,180 @@ mod tests {
 
         check_file(&input, &FrontendOptions::default())
             .expect("explicit file import should keep _test.hew semantics");
+    }
+
+    #[test]
+    fn std_import_does_not_fall_back_to_pkg_path_tail() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let pkg_root = dir.path().join("packages");
+        fs::create_dir_all(&pkg_root).expect("create package root");
+        write_source(&pkg_root, "bogus.hew", "pub fn marker() -> i64 { 1 }\n");
+        let input = write_source(
+            dir.path(),
+            "main.hew",
+            "import std::bogus;\n\nfn main() {}\n",
+        );
+
+        let failure = check_file(
+            &input,
+            &FrontendOptions {
+                no_typecheck: true,
+                pkg_path: Some(pkg_root.clone()),
+                ..Default::default()
+            },
+        )
+        .expect_err("std::bogus must not resolve from --pkg-path/bogus.hew");
+
+        assert!(
+            failure.message.contains("module `std::bogus` not found"),
+            "expected std::bogus to fail closed, got: {}",
+            failure.message
+        );
+        let stripped_pkg_candidate = pkg_root.join("bogus.hew").display().to_string();
+        assert!(
+            !failure.message.contains(&stripped_pkg_candidate),
+            "std:: imports must not try stripped --pkg-path tail candidate `{stripped_pkg_candidate}`: {}",
+            failure.message
+        );
+    }
+
+    #[test]
+    fn std_import_prefers_compiler_std_over_pkg_path_tail_collision() {
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("hew-compile lives under repo root");
+
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let pkg_root = dir.path().join("packages");
+        fs::create_dir_all(&pkg_root).expect("create package root");
+        write_source(&pkg_root, "fs.hew", "pub fn marker() -> i64 { 1 }\n");
+        let input = write_source(dir.path(), "main.hew", "import std::fs;\n\nfn main() {}\n");
+
+        let (_output, state) = check_file_with_state(
+            &input,
+            &FrontendOptions {
+                no_typecheck: true,
+                pkg_path: Some(pkg_root.clone()),
+                project_dir: Some(repo_root.to_path_buf()),
+                ..Default::default()
+            },
+        )
+        .expect("std::fs must resolve from compiler std without package-tail ambiguity");
+
+        let import = state
+            .program
+            .items
+            .iter()
+            .find_map(|item| match &item.0 {
+                Item::Import(import) if import.path == ["std", "fs"] => Some(import),
+                _ => None,
+            })
+            .expect("std::fs import should remain in the program");
+        assert_eq!(
+            import.resolved_source_paths.len(),
+            1,
+            "std::fs should resolve to exactly one source path"
+        );
+        let resolved = &import.resolved_source_paths[0];
+        assert!(
+            resolved.ends_with("std/fs.hew"),
+            "std::fs should resolve to compiler std/fs.hew, got {}",
+            resolved.display()
+        );
+        assert!(
+            !resolved.starts_with(&pkg_root),
+            "std::fs must not resolve from colliding --pkg-path file {}",
+            resolved.display()
+        );
+    }
+
+    #[test]
+    fn non_builtin_import_still_uses_pkg_path_tail_fallback() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let pkg_root = dir.path().join("packages");
+        fs::create_dir_all(&pkg_root).expect("create package root");
+        let package_file = Path::new(&write_source(
+            &pkg_root,
+            "fs.hew",
+            "pub fn marker() -> i64 { 1 }\n",
+        ))
+        .canonicalize()
+        .expect("canonical package file");
+        let input = write_source(
+            dir.path(),
+            "main.hew",
+            "import mypkg::fs;\n\nfn main() {}\n",
+        );
+
+        let (_output, state) = check_file_with_state(
+            &input,
+            &FrontendOptions {
+                no_typecheck: true,
+                pkg_path: Some(pkg_root),
+                ..Default::default()
+            },
+        )
+        .expect("non-builtin package imports should still use stripped tail fallback");
+
+        let import = state
+            .program
+            .items
+            .iter()
+            .find_map(|item| match &item.0 {
+                Item::Import(import) if import.path == ["mypkg", "fs"] => Some(import),
+                _ => None,
+            })
+            .expect("mypkg::fs import should remain in the program");
+        assert_eq!(
+            import.resolved_source_paths,
+            vec![package_file],
+            "mypkg::fs should resolve through --pkg-path/fs.hew"
+        );
+    }
+
+    #[test]
+    fn hew_package_layout_still_uses_explicit_pkg_path_tail_fallback() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let pkg_root = dir.path().join("packages");
+        let sqlite_dir = pkg_root.join("db/sqlite");
+        fs::create_dir_all(&sqlite_dir).expect("create package directory");
+        let package_file = Path::new(&write_source(
+            &sqlite_dir,
+            "sqlite.hew",
+            "pub fn marker() -> i64 { 1 }\n",
+        ))
+        .canonicalize()
+        .expect("canonical package file");
+        let input = write_source(
+            dir.path(),
+            "main.hew",
+            "import hew::db::sqlite;\n\nfn main() {}\n",
+        );
+
+        let (_output, state) = check_file_with_state(
+            &input,
+            &FrontendOptions {
+                no_typecheck: true,
+                pkg_path: Some(pkg_root),
+                ..Default::default()
+            },
+        )
+        .expect("hew:: package-layout import should keep using its explicit fallback");
+
+        let import = state
+            .program
+            .items
+            .iter()
+            .find_map(|item| match &item.0 {
+                Item::Import(import) if import.path == ["hew", "db", "sqlite"] => Some(import),
+                _ => None,
+            })
+            .expect("hew::db::sqlite import should remain in the program");
+        assert_eq!(
+            import.resolved_source_paths,
+            vec![package_file],
+            "hew::db::sqlite should resolve through the explicit hew:: package-layout fallback"
+        );
     }
 
     #[test]

--- a/hew-compile/src/lib.rs
+++ b/hew-compile/src/lib.rs
@@ -1153,6 +1153,17 @@ fn resolve_file_imports_internal(
                     }
                 }
 
+                if module_str.starts_with("ecosystem::") && decl.path.len() > 1 {
+                    let tail = decl.path[1..].iter().collect::<PathBuf>();
+                    let tail_last = decl.path.last().expect("path is non-empty");
+                    let tail_dir = tail.join(format!("{tail_last}.hew"));
+                    let tail_rel = tail.with_extension("hew");
+                    if let Some(pkg) = ctx.extra_pkg_path {
+                        candidates.push(pkg.join(&tail_dir));
+                        candidates.push(pkg.join(&tail_rel));
+                    }
+                }
+
                 // Stdlib / global search roots — apply exclusive precedence tiers so that
                 // a file in worktree-A always resolves std from A only, never from the
                 // build binary's worktree or a sibling checkout.
@@ -2336,6 +2347,53 @@ mod tests {
             import.resolved_source_paths,
             vec![package_file],
             "hew::db::sqlite should resolve through the explicit hew:: package-layout fallback"
+        );
+    }
+
+    #[test]
+    fn ecosystem_package_layout_still_uses_explicit_pkg_path_tail_fallback() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let pkg_root = dir.path().join("packages");
+        let postgres_dir = pkg_root.join("db/postgres");
+        fs::create_dir_all(&postgres_dir).expect("create package directory");
+        let package_file = Path::new(&write_source(
+            &postgres_dir,
+            "postgres.hew",
+            "pub fn marker() -> i64 { 1 }\n",
+        ))
+        .canonicalize()
+        .expect("canonical package file");
+        let input = write_source(
+            dir.path(),
+            "main.hew",
+            "import ecosystem::db::postgres;\n\nfn main() {}\n",
+        );
+
+        let (_output, state) = check_file_with_state(
+            &input,
+            &FrontendOptions {
+                no_typecheck: true,
+                pkg_path: Some(pkg_root),
+                ..Default::default()
+            },
+        )
+        .expect("ecosystem:: package-layout import should keep using its explicit fallback");
+
+        let import = state
+            .program
+            .items
+            .iter()
+            .find_map(|item| match &item.0 {
+                Item::Import(import) if import.path == ["ecosystem", "db", "postgres"] => {
+                    Some(import)
+                }
+                _ => None,
+            })
+            .expect("ecosystem::db::postgres import should remain in the program");
+        assert_eq!(
+            import.resolved_source_paths,
+            vec![package_file],
+            "ecosystem::db::postgres should resolve through the explicit ecosystem:: package-layout fallback"
         );
     }
 

--- a/hew-types/src/check/statements.rs
+++ b/hew-types/src/check/statements.rs
@@ -639,7 +639,7 @@ impl Checker {
                     _ => None,
                 };
                 if let Some(name) = plain_identifier {
-                    if val_ty == Ty::Unit && value.is_some() {
+                    if val_ty == Ty::Unit && value.is_some() && !name.starts_with('_') {
                         self.warnings.push(TypeError {
                             severity: crate::error::Severity::Warning,
                             kind: TypeErrorKind::StyleSuggestion,

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -930,6 +930,15 @@ fn warn_unit_binding() {
 }
 
 #[test]
+fn no_warn_underscore_prefixed_unit_binding() {
+    let (_, warnings) = parse_and_check("fn main() { let _already_ignored = println(42); }");
+    assert!(
+        !warnings.iter().any(|w| w.message.contains("unit type")),
+        "underscore-prefixed unit binding should not warn, got: {warnings:?}"
+    );
+}
+
+#[test]
 fn no_warn_non_unit_binding() {
     let (_, warnings) =
         parse_and_check("fn compute() -> i32 { 42 }\nfn main() { let x = compute(); println(x); }");


### PR DESCRIPTION
## Summary

Compiling with `--pkg-path` against a package tree that happens to contain a matching subpath (e.g. `net/http/`) could silently shadow `std::` imports: the resolver's stripped-tail candidate builder stripped an import's first path segment unconditionally, so `import std::net::http` could resolve against a package's `net/http.hew` instead of the real standard library module, and a nonexistent module like `std::bogus` could be silently satisfied by unrelated package content instead of failing. I fixed this by excluding builtin roots (`std::`, `hew::`, `ecosystem::`) from the generic stripped-tail fallback, then added explicit rescue blocks for `hew::` and `ecosystem::` that restore the pre-existing stripped-tail resolution convention those two namespaces relied on (mirroring the `hew::` rescue block that predates this change) — only `std::` actually needed to lose the fallback.

Separately, binding a unit-typed expression to a name already prefixed with an underscore (e.g. `let _server_task = spawn(...);`) still triggered the "binding has unit type and carries no value" lint with a suggestion to prefix the name with an underscore — telling you to do what you'd already done. The check now skips names that already start with `_`, matching how every other unused-binding lint treats underscore-prefixed names.

## Verification

- `make test-lane CRATE=hew-compile`: 52 passed
- `make test-lane CRATE=hew-types`: 2484 passed, 3 skipped
- `bash tests/vertical-slice/run.sh`: all PASS
- `make hew-check-all`: 1516 files checked, 138/138 expected failures matched
- `make lint` (includes `cargo clippy --workspace --tests -- -D warnings`): clean
- `cargo fmt --check`: clean
- Manual checks: built pre-fix and post-fix binaries and reproduced both defects directly against real `--pkg-path` trees (not just the added unit tests) — confirmed `std::bogus` now fails closed instead of silently resolving, confirmed the `ecosystem::` stripped-tail route (e.g. `import ecosystem::db::postgres;` resolving via `--pkg-path`) still resolves post-fix, and confirmed `hew::` package imports and genuine non-builtin package imports are unaffected

## Out of scope

The `hew::` and `ecosystem::` rescue blocks in `hew-compile/src/lib.rs` are now identical except for the string literal they match on — mirroring the existing `hew::` block was the direct fix for the `ecosystem::` gap. They're a clean candidate to collapse into a single guard later, but I'm leaving them as separate blocks here since that's exactly the shape of the fix this PR set out to make.

Fixes #2444
Fixes #2445
