### PR TITLE
fix(ci): match preflight↔CI parity by exact command, not substring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@
 # ============================================================================
 
 .PHONY: all build bootstrap install-hooks hew hew-native adze observe observe-functional-test runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh licenses licenses-check
-.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-package-install test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all lane-gates test-fast test-stdlib test-hew test-hew-ratchet test-o2-differential o2-differential-selftest test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar
+.PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-package-install test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all lane-gates test-fast test-stdlib test-hew test-hew-ratchet test-o2-differential o2-differential-selftest preflight-parity-selftest test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar
 .PHONY: clean install install-check uninstall verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
 .PHONY: coverage coverage-summary coverage-lcov coverage-runtime coverage-combined coverage-branch
@@ -811,6 +811,9 @@ test-o2-differential: hew runtime stdlib
 
 o2-differential-selftest:
 	bash scripts/o2-differential-selftest.sh
+
+preflight-parity-selftest:
+	bash scripts/preflight-parity-selftest.sh
 
 test-stdlib-ratchet: hew
 	@echo "==> Type-checking stdlib (ratcheted)"

--- a/Makefile
+++ b/Makefile
@@ -1049,7 +1049,7 @@ miri:
 
 # ── Lint ────────────────────────────────────────────────────────────────────
 
-lint: runtime-poison-safe-lint lint-wasm-todo leak-scan verify-ffi hew-fmt-check
+lint: runtime-poison-safe-lint lint-wasm-todo leak-scan verify-ffi hew-fmt-check preflight-parity-selftest
 	cargo clippy --workspace --tests -- -D warnings
 
 # Scan tracked source for orchestration-token leaks (lane IDs, Q-tags, .tmp/ paths)

--- a/scripts/check-preflight-ci-parity.sh
+++ b/scripts/check-preflight-ci-parity.sh
@@ -32,8 +32,11 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-DISPATCHER="$REPO_ROOT/scripts/ci-preflight-dispatcher.sh"
-CI_YML="$REPO_ROOT/.github/workflows/ci.yml"
+# DISPATCHER / CI_YML default to the in-repo paths but may be overridden via the
+# environment so the self-test (scripts/preflight-parity-selftest.sh) can point
+# this checker at controlled stub fixtures.
+DISPATCHER="${PREFLIGHT_PARITY_DISPATCHER:-$REPO_ROOT/scripts/ci-preflight-dispatcher.sh}"
+CI_YML="${PREFLIGHT_PARITY_CI_YML:-$REPO_ROOT/.github/workflows/ci.yml}"
 VERBOSE=0
 [[ "${1:-}" == "--verbose" ]] && VERBOSE=1
 
@@ -144,7 +147,7 @@ fail=0
 for (( j=0; j<CI_CHECKS_COUNT; j++ )); do
     label="${CI_CHECKS_LABEL[$j]}"
     pattern="${CI_CHECKS_PATTERN[$j]}"
-    if printf '%s\n' "$FALLBACK_CMDS" | grep -qF "$pattern"; then
+    if printf "%s\n" "$FALLBACK_CMDS" | grep -qF "$pattern"; then
         if (( VERBOSE == 1 )); then
             echo "  ok  [$label]: '$pattern' found"
         fi

--- a/scripts/check-preflight-ci-parity.sh
+++ b/scripts/check-preflight-ci-parity.sh
@@ -147,7 +147,7 @@ fail=0
 for (( j=0; j<CI_CHECKS_COUNT; j++ )); do
     label="${CI_CHECKS_LABEL[$j]}"
     pattern="${CI_CHECKS_PATTERN[$j]}"
-    if printf "%s\n" "$FALLBACK_CMDS" | grep -qF "$pattern"; then
+    if printf "%s\n" "$FALLBACK_CMDS" | grep -qxF "$pattern"; then
         if (( VERBOSE == 1 )); then
             echo "  ok  [$label]: '$pattern' found"
         fi
@@ -184,7 +184,7 @@ subset_fail=0
 for step_cmd in "${CI_BUILD_AND_TEST_STEPS[@]}"; do
     matched=0
     for (( k=0; k<CI_CHECKS_COUNT; k++ )); do
-        if [[ "${CI_CHECKS_PATTERN[$k]}" == *"$step_cmd"* ]] || [[ "$step_cmd" == *"${CI_CHECKS_PATTERN[$k]}"* ]]; then
+        if [[ "${CI_CHECKS_PATTERN[$k]}" == "$step_cmd" ]]; then
             matched=1
             break
         fi
@@ -238,7 +238,7 @@ _assert_lane_includes() {
     local cmds
     cmds=$(printf '%s\n' "$dry_out" | awk '/^Commands:/{found=1; next} found && /^  - /{cmd=substr($0,5); sub(/  \(budget:[^)]*\)$/, "", cmd); print cmd} found && /^(Dry run:|Commands: none)/{found=0}')
 
-    if printf '%s\n' "$cmds" | grep -qF "$required_gate"; then
+    if printf '%s\n' "$cmds" | grep -qxF "$required_gate"; then
         if (( VERBOSE == 1 )); then
             echo "  ok  [$description]: '$required_gate' present"
         fi

--- a/scripts/preflight-parity-selftest.sh
+++ b/scripts/preflight-parity-selftest.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# preflight-parity-selftest.sh - Self-proof for scripts/check-preflight-ci-parity.sh.
+#
+# Four independently-failable cases prove the parity checker distinguishes a
+# genuinely-mirrored dispatcher from one that has silently dropped a CI-required
+# check, using EXACT command matching rather than substring containment.
+#
+# Regression guard for the bug fixed in #2028: the checker previously matched CI
+# steps to CI_REQUIRED_CHECKS (and required checks to the fallback lane) with
+# bidirectional substring containment, so the bare `make test` (nextest workspace
+# suite) was falsely treated as covered by `make test-vertical-slice` /
+# `make test-hew-ratchet` / etc. A lane could drop `make test` entirely and the
+# gate would still report parity. Cases (b)/(c) fail if that absorption returns.
+#
+# Exit codes:
+#   0  all cases pass
+#   1  one or more cases fail (details on stderr)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="$SCRIPT_DIR/check-preflight-ci-parity.sh"
+
+TMPDIR_BASE="$(mktemp -d /tmp/hew-preflight-parity-selftest.XXXXXX)"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+pass() { echo "PASS $1"; }
+fail() { echo "FAIL $1: $2" >&2; exit 1; }
+
+# A stub ci.yml carrying the CI-PARITY-STEPS block the checker parses.  Two of
+# the steps (`make test` and `make test-vertical-slice`) are substring-related on
+# purpose: exact matching must keep them distinct.
+CI_YML="$TMPDIR_BASE/ci.yml"
+cat > "$CI_YML" <<'EOF'
+jobs:
+  build-and-test:
+    steps:
+      # >>> CI-PARITY-STEPS
+      - name: nextest workspace
+        run: >-  # parity-cmd: make test
+          cargo nextest run --workspace --profile ci
+      - name: vertical slice
+        run: make test-vertical-slice
+      # <<< CI-PARITY-STEPS
+EOF
+
+# Build a stub dispatcher.  MODE selects which required check / fallback command
+# is (or is not) emitted, so each case exercises a distinct code path.
+#   full       : both checks present in required list AND fallback lane  (PASS)
+#   drop-fb    : `make test` in required list, MISSING from fallback lane (FAIL presence)
+#   drop-both  : `make test` MISSING from required list AND fallback lane (FAIL subset)
+#   substring  : fallback lane has ONLY `make test-vertical-slice` (a superstring of
+#                `make test`) — proves exact matching does NOT absorb it   (FAIL presence)
+make_dispatcher() {
+    local mode="$1"
+    local path="$TMPDIR_BASE/dispatcher-$mode.sh"
+    cat > "$path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+MODE="$mode"
+EOF
+    cat >> "$path" <<'EOF'
+if [[ "${1:-}" == "--ci-required" ]]; then
+    if [[ "$MODE" != "drop-both" ]]; then
+        printf 'nextest workspace ci\tmake test\n'
+    fi
+    printf 'vertical slice\tmake test-vertical-slice\n'
+    exit 0
+fi
+# --dry-run -- <file>  → emit the fallback "Commands:" block.  `make fuzz-oracle`
+# is always present so the checker's GAP-2 lane→gate assertions are satisfied;
+# these cases exercise only the `make test` / `make test-vertical-slice` parity.
+echo "Commands:"
+echo "  - make fuzz-oracle  (budget: 120s)"
+case "$MODE" in
+    full)
+        echo "  - make test  (budget: 360s)"
+        echo "  - make test-vertical-slice  (budget: 240s)"
+        ;;
+    drop-fb|drop-both)
+        echo "  - make test-vertical-slice  (budget: 240s)"
+        ;;
+    substring)
+        # Only the superstring is present; exact matching must NOT count it as
+        # covering the bare `make test` required check.
+        echo "  - make test-vertical-slice  (budget: 240s)"
+        ;;
+esac
+echo "Dry run: fallback lane"
+exit 0
+EOF
+    chmod +x "$path"
+    echo "$path"
+}
+
+run_case() {
+    local name="$1" mode="$2" expected_rc="$3"
+    local disp log rc=0
+    disp="$(make_dispatcher "$mode")"
+    log="$TMPDIR_BASE/$name.log"
+    echo "--- Case: $name ---"
+    PREFLIGHT_PARITY_DISPATCHER="$disp" PREFLIGHT_PARITY_CI_YML="$CI_YML" \
+        bash "$CHECKER" > "$log" 2>&1 || rc=$?
+    if [[ "$rc" -eq "$expected_rc" ]]; then
+        pass "$name"
+    else
+        sed 's/^/  /' "$log" >&2
+        fail "$name" "checker exited $rc (expected $expected_rc)"
+    fi
+}
+
+run_case "mirrored-parity-passes"          full      0
+run_case "dropped-fallback-command-caught" drop-fb   1
+run_case "dropped-required-and-lane-caught" drop-both 1
+run_case "substring-superstring-not-absorbed" substring 1
+
+echo ""
+echo "preflight-parity-selftest: all 4 cases PASS"


### PR DESCRIPTION
## Problem

`scripts/check-preflight-ci-parity.sh` matched CI build-and-test steps to `CI_REQUIRED_CHECKS` (and required checks to the dispatcher fallback lane) with **bidirectional substring containment**:

```bash
# subset assertion
[[ "${CI_CHECKS_PATTERN[$k]}" == *"$step_cmd"* ]] || [[ "$step_cmd" == *"${CI_CHECKS_PATTERN[$k]}"* ]]
# fallback presence
printf '%s\n' "$FALLBACK_CMDS" | grep -qF "$pattern"
```

Because `make test` is a substring of `make test-vertical-slice`, `make test-hew-ratchet`, `make test-stdlib-ratchet`, `make test-pkg-import`, and `make test-doc-examples`, the bare `make test` (the nextest workspace suite) was treated as covered whenever any of those longer commands was present.

**Reproduced live on current `main`:** removing the fallback `add_command "make test"` (keeping its `CI_REQUIRED_CHECKS` row) — the fallback lane no longer runs the nextest workspace suite at all — the checker still reports `16/16 checks present`, RC=0. Removing both the row and the fallback command likewise still reports `11/11 steps mapped`, RC=0. A lane could silently drop the entire workspace test run and the parity gate would not catch it — the exact failure class this gate exists to prevent.

## Fix

Switch both matches to **exact command equality**:
- fallback presence check → `grep -qxF` (whole-line match)
- subset assertion → `==` equality

Every existing legitimate mapping is already an exact whole-line match (verified: all `CI_REQUIRED_CHECKS` patterns appear verbatim as fallback-lane lines, and every CI step equals a pattern exactly), so the clean tree still passes unchanged (`16/16`, `11/11`, `5` GAP-2 assertions).

## Regression coverage

New `scripts/preflight-parity-selftest.sh` (`make preflight-parity-selftest`), modeled on the existing `o2-differential-selftest.sh` — a stub-driven self-proof with four independently-failable cases:
1. `mirrored-parity-passes` — genuine parity → RC=0
2. `dropped-fallback-command-caught` — `make test` dropped from fallback lane → RC=1
3. `dropped-required-and-lane-caught` — `make test` dropped from both → RC=1
4. `substring-superstring-not-absorbed` — only `make test-vertical-slice` present, must **not** cover `make test` → RC=1

The checker gains `PREFLIGHT_PARITY_DISPATCHER` / `PREFLIGHT_PARITY_CI_YML` env overrides so the self-test can point it at controlled fixtures (default behavior unchanged).

**Load-bearing verified:** reverted the fix (kept the selftest) → case 2 fails (`checker exited 0, expected 1`); restored the fix → all 4 pass.

## Verification
- `bash scripts/check-preflight-ci-parity.sh` against real repo: RC=0, `16/16` / `11/11` / GAP-2 `5` (no regression)
- `make preflight-parity-selftest`: all 4 cases PASS
- `bash -n` clean on both scripts

Addresses the finding tracked for #2028.