### PR TITLE
fix(mir): drop nested string concat temps

### DIFF
--- a/examples/v05/checked-mir/golden/string_ops.raw.mir
+++ b/examples/v05/checked-mir/golden/string_ops.raw.mir
@@ -43,6 +43,7 @@ fn main() -> i64 [conv=default]
     _10 = call_rt hew_string_concat(_1, _9)
     _11 = string_lit "world"
     _12 = call_rt hew_string_concat(_10, _11)
+    drop _10 ty=string fn=release(hew_string_drop)
     _13 = move _12
     call println_str(_13) -> bb2
   bb2:

--- a/hew-cli/tests/nested_string_concat_temp_leak_oracle.rs
+++ b/hew-cli/tests/nested_string_concat_temp_leak_oracle.rs
@@ -1,0 +1,124 @@
+//! Leak / double-free oracle for the #2434 root-cause split.
+//!
+//! The generic-record path is pinned with a single fresh `string.repeat` field,
+//! while the real leak shape is record-free nested concat:
+//! `first + " " + last`. The first concat result is a fresh
+//! `hew_string_concat` temp immediately borrowed by the second concat; the MIR
+//! nested-temp collector must release that intermediate exactly once without
+//! broadening to ownership-transfer sinks.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance_with, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+const LOW_FRAMES: usize = 1;
+const HIGH_FRAMES: usize = 50;
+const SLOPE_TOLERANCE: usize = 3;
+
+fn generic_record_repeat_source(frames: usize) -> String {
+    format!(
+        "import std::string;\n\
+         type Pair<A, B> {{ first: A; second: B; }}\n\
+         fn emit_pair(print_it: bool) -> i64 {{\n\
+         \x20   let full = string.repeat(\"field\", 1);\n\
+         \x20   let pair = Pair {{ first: 1, second: full }};\n\
+         \x20   if print_it {{ println(pair.second); }}\n\
+         \x20   pair.first\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + emit_pair(i == 0);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total != {frames} {{ return 91; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+fn nested_concat_no_record_source(frames: usize) -> String {
+    let expected = frames * 12;
+    format!(
+        "fn emit_full(print_it: bool) -> i64 {{\n\
+         \x20   let first = \"Ada\";\n\
+         \x20   let last = \"Lovelace\";\n\
+         \x20   let full = first + \" \" + last;\n\
+         \x20   if print_it {{ println(full); }}\n\
+         \x20   full.len()\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + emit_full(i == 0);\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total != {expected} {{ return 92; }}\n\
+         \x20   0\n\
+         }}\n"
+    )
+}
+
+fn assert_no_double_free(shape_name: &str, source: &str) {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("nested-concat-temp-df-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), shape_name);
+    let output = run_under_malloc_scribble(&bin);
+
+    assert!(
+        output.status.success(),
+        "{shape_name}: string temps must be released exactly once; a crash \
+         indicates a double-free and a non-zero status indicates a scribbled-read \
+         miscompute:\n{}",
+        describe_output(&output)
+    );
+}
+
+#[test]
+fn generic_record_repeat_field_has_no_per_iteration_leak_slope() {
+    assert_frame_slope_below_tolerance_with(
+        "generic_record_repeat_clean",
+        generic_record_repeat_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+        SLOPE_TOLERANCE,
+    );
+}
+
+#[test]
+fn nested_concat_without_record_has_no_per_iteration_leak_slope() {
+    assert_frame_slope_below_tolerance_with(
+        "nested_concat_no_record",
+        nested_concat_no_record_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+        SLOPE_TOLERANCE,
+    );
+}
+
+#[test]
+fn generic_record_repeat_field_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free(
+        "generic_record_repeat_df",
+        &generic_record_repeat_source(200),
+    );
+}
+
+#[test]
+fn nested_concat_without_record_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free(
+        "nested_concat_no_record_df",
+        &nested_concat_no_record_source(200),
+    );
+}

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -1697,10 +1697,11 @@ fn run_user_record_string_field_is_dropped_once() {
 }
 
 /// Generic-instantiation twin of `run_user_record_string_field_is_dropped_once`:
-/// a `Pair<i64, string>` carrying a computed (heap) string is constructed and
-/// dropped on every one of 100k iterations. The generic owned-record drop spine
-/// must free the string field exactly once per iteration — a double-free aborts
-/// (the loop is the exactly-once witness), a missed drop leaks.
+/// a `Pair<i64, string>` carrying a single fresh `string.repeat` result is
+/// constructed and dropped on every one of 100k iterations. The generic
+/// owned-record drop spine must free the string field exactly once per iteration
+/// without depending on nested-concat temp cleanup — a double-free aborts (the
+/// loop is the exactly-once witness), a missed drop leaks.
 #[test]
 fn run_generic_record_string_field_is_dropped_once() {
     require_codegen();
@@ -1716,6 +1717,33 @@ fn run_generic_record_string_field_is_dropped_once() {
     assert!(
         output.status.success(),
         "generic_record_string_field should run cleanly (a double-free would \
+         abort); stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let actual = strip_ansi(&String::from_utf8_lossy(&output.stdout));
+    assert_eq!(actual, expected, "stdout mismatch for {}", source.display());
+}
+
+/// The #2434 root cause split from the generic-record fixture: `first + " " +
+/// last` creates a fresh concat temp that is immediately borrowed by another
+/// concat, with no record wrapper involved. The nested-temp drop splice must
+/// release that intermediate exactly once.
+#[test]
+fn run_nested_string_concat_temp_is_dropped_once() {
+    require_codegen();
+
+    let source = repo_root().join("tests/vertical-slice/accept/nested_string_concat_temp.hew");
+    let expected = std::fs::read_to_string(
+        repo_root().join("tests/vertical-slice/accept/nested_string_concat_temp.expected"),
+    )
+    .expect("read nested_string_concat_temp.expected");
+
+    let output = run_bounded_hew_run(&source, repo_root());
+
+    assert!(
+        output.status.success(),
+        "nested_string_concat_temp should run cleanly (a double-free would \
          abort); stdout: {}\nstderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -38269,6 +38269,35 @@ fn is_borrowing_string_cmp_instr(instr: &Instr, t: u32) -> bool {
     )
 }
 
+fn is_hew_string_concat_runtime_call(call: &crate::model::RuntimeCall) -> bool {
+    call.symbol() == "hew_string_concat"
+}
+
+fn is_fresh_string_concat_instr_def(def: NestedDefSite, blocks: &[BasicBlock], t: u32) -> bool {
+    let NestedDefSite::Instr { block, idx } = def else {
+        return false;
+    };
+    let Some(Instr::CallRuntimeAbi(call)) =
+        block_by_id(blocks, block).and_then(|b| b.instructions.get(idx))
+    else {
+        return false;
+    };
+    is_hew_string_concat_runtime_call(call)
+        && call.dest().and_then(base_local) == Some(t)
+        && crate::runtime_symbols::callee_ownership_contract(call.symbol())
+            .produces_fresh_owned_string()
+}
+
+fn is_borrowing_string_concat_instr_use(instr: &Instr, t: u32) -> bool {
+    let Instr::CallRuntimeAbi(call) = instr else {
+        return false;
+    };
+    is_hew_string_concat_runtime_call(call)
+        && call.args().iter().any(|p| place_refs_local(*p, t))
+        && crate::runtime_symbols::callee_ownership_contract(call.symbol())
+            .borrows_string_call_args()
+}
+
 /// W5.011 P3 — `true` when an instruction transfers ownership of a fresh-owned
 /// `string` `local` out of its slot, so a scope-exit drop of `local` would be a
 /// double-free (over-decrement of the shared refcount).
@@ -38536,9 +38565,11 @@ fn block_by_id(blocks: &[BasicBlock], id: u32) -> Option<&BasicBlock> {
 ///    construction, so a buffer is never claimed by both);
 /// 3. it has exactly ONE def, a known fresh producer (no instruction
 ///    re-definition; a producer-terminator temp has no instruction writer);
-/// 4. it has AT MOST ONE source-use, and (if present) that use is a verified
-///    borrowing `Terminator::Call` — any other use (`Move`/store/return/send/
-///    user-call) excludes it (leak, never double-free);
+/// 4. it has AT MOST ONE source-use, and (if present) that use is verified
+///    borrowing-only: a borrowing `Terminator::Call`, a string compare
+///    instruction, or the narrowly-proven nested `hew_string_concat` →
+///    `hew_string_concat` instruction chain. Any other use (`Move`/store/
+///    return/send/user-call) excludes it (leak, never double-free);
 /// 5. the drop site is provably dominated by the def and entered exactly once
 ///    (single-predecessor continuation), in one of these structural shapes:
 ///      * discard, instr def → drop right after the producer instruction (same
@@ -38786,20 +38817,21 @@ fn nested_fresh_string_temp_drop(
             };
             def_dominates.then_some((*next, 0, drop_place, drop_ty))
         }
-        // Single instruction use: admit ONLY a borrowing string compare
-        // (`xs[i] == "hello"`, `xs[i] != s`, and the ordering family) where the
-        // def dominates the use, and drop right after the compare consumed
-        // (read) the temp. String compares lower to `Instr::IntCmp` whose
-        // string operands codegen routes through `hew_string_equals` /
-        // `hew_string_compare` — pure `strcmp` borrows that never free the
-        // operand (see `is_borrowing_string_cmp_instr`). Any other instruction
-        // use stays fail-closed (leak, never double-free): a `Move`/store/
-        // user-call/closure-call may take ownership, and the conservative leak
-        // is the safe side.
+        // Single instruction use: admit ONLY known borrowing instruction uses:
+        // a borrowing string compare (`xs[i] == "hello"`, `xs[i] != s`, and
+        // the ordering family) or the reproduced nested-concat chain where a
+        // fresh `hew_string_concat` instruction result is immediately borrowed
+        // by another `hew_string_concat` instruction (`first + " " + last`).
+        // Any other instruction use stays fail-closed (leak, never
+        // double-free): a `Move`/store/user-call/closure-call/unknown runtime
+        // call may take ownership, and the conservative leak is the safe side.
         (_, Some(NestedUseSite::Instr { block: ub, idx: ui })) => {
             let ub = *ub;
             let use_instr = block_by_id(blocks, ub)?.instructions.get(*ui)?;
-            if !is_borrowing_string_cmp_instr(use_instr, t) {
+            let borrowing_use = is_borrowing_string_cmp_instr(use_instr, t)
+                || (is_fresh_string_concat_instr_def(def, blocks, t)
+                    && is_borrowing_string_concat_instr_use(use_instr, t));
+            if !borrowing_use {
                 return None;
             }
             let def_dominates = match def {
@@ -38872,6 +38904,249 @@ fn apply_nested_fresh_string_temp_drops(
                 u32::try_from(at).unwrap_or(u32::MAX),
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod nested_fresh_string_temp_drop_admission {
+    use super::*;
+
+    fn block(id: u32, instructions: Vec<Instr>, terminator: Terminator) -> BasicBlock {
+        BasicBlock {
+            id,
+            statements: vec![],
+            instructions,
+            terminator,
+        }
+    }
+
+    fn ret_block(id: u32) -> BasicBlock {
+        block(id, vec![], Terminator::Return)
+    }
+
+    fn runtime_call(symbol: &str, args: Vec<Place>, dest: Option<Place>) -> Instr {
+        Instr::CallRuntimeAbi(
+            crate::model::RuntimeCall::new(symbol, args, dest)
+                .unwrap_or_else(|_| panic!("{symbol} must be an allowlisted RuntimeCall")),
+        )
+    }
+
+    fn concat(lhs: u32, rhs: u32, dest: u32) -> Instr {
+        runtime_call(
+            "hew_string_concat",
+            vec![Place::Local(lhs), Place::Local(rhs)],
+            Some(Place::Local(dest)),
+        )
+    }
+
+    fn user_record_ty() -> ResolvedTy {
+        ResolvedTy::named_user("Holder", vec![])
+    }
+
+    fn vec_string_ty() -> ResolvedTy {
+        ResolvedTy::named_builtin("Vec", BuiltinType::Vec, vec![ResolvedTy::String])
+    }
+
+    fn locals_with(overrides: &[(usize, ResolvedTy)]) -> Vec<ResolvedTy> {
+        let mut locals = vec![ResolvedTy::String; 10];
+        for (idx, ty) in overrides {
+            locals[*idx] = ty.clone();
+        }
+        locals
+    }
+
+    fn collect(
+        blocks: &[BasicBlock],
+        locals: &[ResolvedTy],
+        binding_locals: &HashMap<BindingId, Place>,
+    ) -> Vec<(u32, usize, Place, ResolvedTy)> {
+        collect_nested_fresh_string_temp_drops(blocks, &HashMap::new(), locals, binding_locals)
+    }
+
+    fn nested_concat_blocks() -> Vec<BasicBlock> {
+        vec![block(
+            0,
+            vec![concat(0, 1, 2), concat(2, 3, 4)],
+            Terminator::Return,
+        )]
+    }
+
+    fn second_concat_binding() -> HashMap<BindingId, Place> {
+        [(BindingId(44), Place::Local(4))].into_iter().collect()
+    }
+
+    #[test]
+    fn nested_concat_instr_temp_gets_one_inline_drop_after_borrowing_concat_use() {
+        let blocks = nested_concat_blocks();
+        let drops = collect(&blocks, &locals_with(&[]), &second_concat_binding());
+
+        assert_eq!(
+            drops,
+            vec![(0, 2, Place::Local(2), ResolvedTy::String)],
+            "the first concat temp is a fresh owner used exactly once by the \
+             second borrowing concat; it must be dropped immediately after that \
+             use and only once"
+        );
+    }
+
+    #[test]
+    fn binding_local_concat_result_stays_out_of_nested_temp_collector() {
+        let blocks = nested_concat_blocks();
+        let binding_locals: HashMap<BindingId, Place> = [
+            (BindingId(22), Place::Local(2)),
+            (BindingId(44), Place::Local(4)),
+        ]
+        .into_iter()
+        .collect();
+        let drops = collect(&blocks, &locals_with(&[]), &binding_locals);
+
+        assert!(
+            drops.is_empty(),
+            "a local owned by a let/parameter binding belongs to scope-exit drop \
+             derivation, not the bare-temp collector; got {drops:?}"
+        );
+    }
+
+    #[test]
+    fn concat_temp_moved_into_record_is_not_dropped_by_collector() {
+        let blocks = vec![block(
+            0,
+            vec![
+                concat(0, 1, 2),
+                Instr::RecordInit {
+                    ty: user_record_ty(),
+                    fields: vec![(FieldOffset(0), Place::Local(2))],
+                    dest: Place::Local(5),
+                },
+            ],
+            Terminator::Return,
+        )];
+        let locals = locals_with(&[(5, user_record_ty())]);
+
+        assert!(
+            collect(&blocks, &locals, &HashMap::new()).is_empty(),
+            "record ingress transfers ownership to the aggregate; an inline temp \
+             drop would double-free the field"
+        );
+    }
+
+    #[test]
+    fn concat_temp_moved_into_vec_owned_store_is_not_dropped_by_collector() {
+        let blocks = vec![
+            block(
+                0,
+                vec![concat(0, 1, 2)],
+                Terminator::Call {
+                    callee: "hew_vec_push_owned".to_string(),
+                    builtin: None,
+                    args: vec![Place::Local(5), Place::Local(2)],
+                    dest: None,
+                    next: 1,
+                },
+            ),
+            ret_block(1),
+        ];
+        let locals = locals_with(&[(5, vec_string_ty())]);
+
+        assert!(
+            collect(&blocks, &locals, &HashMap::new()).is_empty(),
+            "Vec owned-element ingress is not the proven borrowing concat chain; \
+             the collector must leave ownership with the container path"
+        );
+    }
+
+    #[test]
+    fn concat_temp_return_move_is_not_dropped_by_collector() {
+        let blocks = vec![block(
+            0,
+            vec![
+                concat(0, 1, 2),
+                Instr::Move {
+                    dest: Place::ReturnSlot,
+                    src: Place::Local(2),
+                },
+            ],
+            Terminator::Return,
+        )];
+
+        assert!(
+            collect(&blocks, &locals_with(&[]), &HashMap::new()).is_empty(),
+            "moving the temp into the return slot transfers ownership to the \
+             caller; no producer-side temp drop is admissible"
+        );
+    }
+
+    #[test]
+    fn concat_temp_sent_to_actor_is_not_dropped_by_collector() {
+        let blocks = vec![
+            block(
+                0,
+                vec![concat(0, 1, 2)],
+                Terminator::Send {
+                    actor: Place::Local(8),
+                    msg_type: 0,
+                    value: Place::Local(2),
+                    next: 1,
+                    alias_mode: crate::model::SendAliasMode::Copy,
+                },
+            ),
+            ret_block(1),
+        ];
+
+        assert!(
+            collect(&blocks, &locals_with(&[]), &HashMap::new()).is_empty(),
+            "actor send is an ownership-transfer edge, not a borrowing concat \
+             instruction use"
+        );
+    }
+
+    #[test]
+    fn concat_temp_passed_to_unknown_user_call_is_not_dropped_by_collector() {
+        let blocks = vec![
+            block(
+                0,
+                vec![concat(0, 1, 2)],
+                Terminator::Call {
+                    callee: "user_takes_string".to_string(),
+                    builtin: None,
+                    args: vec![Place::Local(2)],
+                    dest: None,
+                    next: 1,
+                },
+            ),
+            ret_block(1),
+        ];
+
+        assert!(
+            collect(&blocks, &locals_with(&[]), &HashMap::new()).is_empty(),
+            "unknown/user calls have no borrowing contract, so the collector must \
+             fail closed"
+        );
+    }
+
+    #[test]
+    fn branch_around_concat_producer_does_not_insert_uninitialized_drop() {
+        let blocks = vec![
+            block(
+                0,
+                vec![],
+                Terminator::Branch {
+                    cond: Place::Local(9),
+                    then_target: 1,
+                    else_target: 2,
+                },
+            ),
+            block(1, vec![concat(0, 1, 2)], Terminator::Goto { target: 2 }),
+            block(2, vec![concat(2, 3, 4)], Terminator::Return),
+        ];
+        let mut locals = locals_with(&[(9, ResolvedTy::Bool)]);
+        locals[4] = ResolvedTy::String;
+
+        assert!(
+            collect(&blocks, &locals, &second_concat_binding()).is_empty(),
+            "the use block is reachable from a path that skipped the producer; \
+             inserting a drop there would free an uninitialized temp"
+        );
     }
 }
 

--- a/hew-mir/tests/lowering_expr/cstring_container_domain_canary.rs
+++ b/hew-mir/tests/lowering_expr/cstring_container_domain_canary.rs
@@ -241,11 +241,11 @@ fn emits_vec_get_str(pl: &IrPipeline) -> bool {
 }
 
 /// A BRANCHED body (`if/else`, both arms reading the binding by-value via string
-/// concat) lowers without an NYI and places exactly ONE `hew_string_drop` — at
-/// the post-body branch-join block reached once per iteration regardless of which
-/// arm ran. Concat is a borrowing read, so the retained element is still owned by
-/// the loop and released at the join. This is the demo `transform_body` shape the
-/// over-conservative single-post-body-drop analysis used to reject.
+/// concat) lowers without an NYI and places the post-body retained-element drop
+/// at the branch-join block reached once per iteration regardless of which arm
+/// ran. The then arm also has the #2434 nested-concat shape
+/// `out + "P:" + line`: the intermediate concat temp is borrowed by the second
+/// concat and now earns its own inline `hew_string_drop`.
 #[test]
 fn vec_string_for_in_branched_body_drops_once_at_join() {
     let pl = pipeline_with_tc(
@@ -269,10 +269,11 @@ fn vec_string_for_in_branched_body_drops_once_at_join() {
     );
     assert_eq!(
         string_drop_count(&pl),
-        3,
+        4,
         "branched body drops the retained `line` once at the branch-join PLUS \
          the prior `out` value on each arm's `out = out + ...` reassignment \
-         (#53 var-overwrite-release): two arms = two overwrite releases + the \
+         (#53 var-overwrite-release) PLUS the then-arm nested-concat \
+         intermediate: two overwrite releases + one nested-temp release + the \
          single post-body element drop",
     );
 }

--- a/tests/vertical-slice/accept/generic_record_string_field.expected
+++ b/tests/vertical-slice/accept/generic_record_string_field.expected
@@ -1,1 +1,1 @@
-Ada Lovelace
+field

--- a/tests/vertical-slice/accept/generic_record_string_field.hew
+++ b/tests/vertical-slice/accept/generic_record_string_field.hew
@@ -1,17 +1,17 @@
-// Generic record INSTANTIATION carrying an owned (computed-heap) string field,
-// dropped at scope exit on every loop iteration. The generic-instantiation twin
-// of `user_record_string_field`: each iteration constructs a `Pair<i64, string>`
-// whose `second` field owns a freshly-allocated string, then drops it. A
-// double-free SIGSEGVs and a missed drop leaks; 100k iterations surface either.
+// Generic record INSTANTIATION carrying an owned string field from a single fresh
+// producer (`string.repeat`), dropped at scope exit on every loop iteration. This
+// pins the generic-record drop spine independently from nested string-concat
+// temps: a double-free SIGSEGVs and a missed field drop leaks; 100k iterations
+// surface either without relying on `first + " " + last`.
+import std::string;
+
 type Pair<A, B> {
     first: A;
     second: B;
 }
 
 fn emit_pair(print_it: bool) -> i64 {
-    let first = "Ada";
-    let last = "Lovelace";
-    let full = first + " " + last;
+    let full = string.repeat("field", 1);
     let pair = Pair { first: 1, second: full };
     if print_it {
         println(pair.second);

--- a/tests/vertical-slice/accept/nested_string_concat_temp.expected
+++ b/tests/vertical-slice/accept/nested_string_concat_temp.expected
@@ -1,0 +1,1 @@
+Ada Lovelace

--- a/tests/vertical-slice/accept/nested_string_concat_temp.hew
+++ b/tests/vertical-slice/accept/nested_string_concat_temp.hew
@@ -1,0 +1,26 @@
+// Nested fresh string-concat temp: `first + " "` produces a fresh
+// `hew_string_concat` result that is immediately borrowed by the second
+// `hew_string_concat` in `... + last`. This has no record wrapper; it pins the
+// real #2434 leak independently of generic-record drop machinery.
+fn emit_full(print_it: bool) -> i64 {
+    let first = "Ada";
+    let last = "Lovelace";
+    let full = first + " " + last;
+    if print_it {
+        println(full);
+    }
+    full.len()
+}
+
+fn main() -> i64 {
+    var total: i64 = 0;
+    var i: i64 = 0;
+    while i < 100000 {
+        total = total + emit_full(i == 0);
+        i = i + 1;
+    }
+    if total != 1200000 {
+        return 7;
+    }
+    0
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -390,6 +390,12 @@ compile_accept "machine_fork_args_spawn"
 # type is normalised before the enum-layout probe so the bare-name view is found.
 run_accept_expect_status "machine_generic_record_field" 0
 
+# #2434 split coverage: the generic-record owned-field path is clean on its own
+# (`string.repeat` single fresh producer), while the real leak root is the
+# record-free nested concat temp in `first + " " + last`.
+run_accept_expect_stdout "generic_record_string_field"
+run_accept_expect_stdout "nested_string_concat_temp"
+
 # Regression guard: a plain record with an Option<i64> field must compile and
 # run.  The MIR field classifier must NOT strip args from generic enum types
 # (Option, Result) even though their origin names appear in machine_layout_names.


### PR DESCRIPTION
Fixes #2434

## Summary
- I tightened MIR drop planning so fresh `hew_string_concat` temporaries that are consumed exactly once by another borrowing `hew_string_concat` are dropped immediately after that borrowing use.
- The admission remains fail-closed for binding locals, record/Vec ingress, return-slot moves, actor sends, unknown/user calls, and branch-around-producer paths.
- I added regression coverage for the positive nested-concat case and the escape cases, plus updated the checked-MIR golden for the new inline drop.

## Verification
- Full post-rebase gate passed locally: formatting, linting, MIR lane tests, codegen lane tests, checked-MIR verification, vertical-slice coverage, HEW ratchet, and corpus checks.
- Reproduced the original nested string-concat leak before the fix and confirmed the fixed build is clean under Linux valgrind at scale, with balanced alloc/free counts and no memcheck errors.
- Confirmed the generated MIR inserts exactly one dominated inline `hew_string_drop` for each admitted intermediate and leaves escaping values outside this narrow admission rule.

## Out of scope
- macOS oracle followup remains owed: the leak-oracle `*_freed_exactly_once_under_malloc_scribble` pins are macOS-only and degraded to skips on this Linux gate. I substituted valgrind for this pass, and it came back clean, but the macOS-specific oracle still needs to run separately.
