### PR TITLE
fix(mir): poison the whole abandoned capture set in lower_gen_block

### DIFF
--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -32572,6 +32572,29 @@ impl Builder {
                     }
                 }
             }
+            // Env-record synthesis is all-or-nothing (see `all_materialisable`
+            // below): if ANY capture is inadmissible, the whole generator
+            // construction fails closed with a root `NotYetImplemented`, and
+            // NO env record is built at all — not even for the otherwise-
+            // admissible captures collected into `init_fields`/`field_tys`
+            // above. Their would-be `capture_env_sources` entries are
+            // therefore never registered either (that registration loop below
+            // only runs when `env_ty.is_some()`).
+            //
+            // Without this poison-everything step, an admissible capture in
+            // that same abandoned set would be neither in
+            // `poisoned_captures` (only the explicitly-rejected binding was
+            // added above) nor in `capture_env_sources` (no env exists to
+            // source it from) — so its body-side `BindingRef` falls through
+            // to the ordinary unresolved-binding path and cascades a spurious
+            // `InitialisedBeforeUse` + `UnresolvedPlace` on top of the one
+            // actionable root diagnostic. Poison every capture in the
+            // abandoned set so the body stays silent for all of them: the
+            // root rejection above is already the single actionable
+            // diagnostic for the whole construction.
+            if !all_materialisable {
+                poisoned_captures.extend(captures.iter().map(|capture| capture.binding));
+            }
             if all_materialisable {
                 let env_name = format!("__hew_gen_env_{owner}_{gen_id}");
                 let env_resolved_ty = ResolvedTy::Named {

--- a/tests/vertical-slice/reject/gen_fn_mixed_capture_cascade.hew
+++ b/tests/vertical-slice/reject/gen_fn_mixed_capture_cascade.hew
@@ -1,0 +1,42 @@
+// Reject fixture: gen_fn_mixed_capture_cascade — a generator that reads BOTH
+// an inadmissible (`#[opaque]`) parameter AND an otherwise-admissible scalar
+// parameter as free variables of its body.
+//
+// Env-record synthesis for a generator's captures is all-or-nothing: if ANY
+// capture is inadmissible, `lower_gen_block` abandons the whole env record —
+// not only for the rejected capture, but for every other capture that would
+// otherwise have materialised cleanly. Before this fixture's fix, only the
+// explicitly-rejected binding was poisoned; the admissible scalar sibling had
+// neither a poison entry (silencing its body-side read) nor a
+// `capture_env_sources` entry (since no env exists to source it from), so it
+// fell through to the ordinary unresolved-binding path and cascaded a spurious
+// InitialisedBeforeUse + UnresolvedPlace on top of the one actionable root
+// diagnostic for the opaque capture.
+//
+// Harness verb: hew check
+// Error count: exactly 1 — the root NotYetImplemented naming the opaque
+// capture `handle`. The scalar capture `n` must NOT cascade
+// InitialisedBeforeUse/UnresolvedPlace: the whole abandoned capture set
+// (every binding in `captures`, not just the explicitly-rejected one) is
+// poisoned so the body stays silent for all of them.
+
+#[opaque]
+type Dq {}
+
+extern "C" {
+    fn hew_deque_new() -> Dq;
+    fn hew_deque_len(dq: Dq) -> i64;
+    fn hew_deque_free(dq: Dq);
+}
+
+gen fn drain(handle: Dq, n: i64) -> i64 {
+    yield unsafe { hew_deque_len(handle) } + n;
+}
+
+fn main() {
+    let dq = unsafe { hew_deque_new() };
+    for n in drain(dq, 5) {
+        println(n);
+    }
+    unsafe { hew_deque_free(dq) };
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -2580,6 +2580,23 @@ expect_check_fail_error_count_no_cascade \
   "gen_fn_capture_owned_value" \
   "InitialisedBeforeUse" "UnresolvedPlace"
 
+# Reject: a generator that reads BOTH an inadmissible (`#[opaque]`) parameter
+# AND an otherwise-admissible scalar parameter as free variables of its body.
+# Env-record synthesis is all-or-nothing: if any capture is inadmissible, the
+# whole env record is abandoned, including for captures that would otherwise
+# have materialised cleanly. Every capture in that abandoned set must be
+# poisoned, not only the explicitly-rejected one, or the admissible sibling
+# cascades a spurious InitialisedBeforeUse + UnresolvedPlace on top of the one
+# actionable root diagnostic.
+#
+# Error count: exactly 1 — the root NotYetImplemented naming the opaque
+# capture `handle`; the scalar capture `n` must not cascade.
+expect_check_fail_error_count_no_cascade \
+  "${ROOT}/tests/vertical-slice/reject/gen_fn_mixed_capture_cascade.hew" \
+  1 \
+  "gen_fn_mixed_capture_cascade" \
+  "InitialisedBeforeUse" "UnresolvedPlace"
+
 # Generator proving-gate (compile + run + stdout-order): the behavioural oracle
 # the generator->coro substrate unification must preserve byte-for-byte.
 # gen_lazy_interleave proves LAZY per-resume side-effect interleaving (effects


### PR DESCRIPTION
Fixes the remaining gap in PR #2302's own review finding.

## Bug

A generator's capture-env synthesis in `lower_gen_block` is
all-or-nothing: if any capture in a `gen fn`'s free-variable set is
inadmissible (an `#[opaque]` handle, an owned/non-`BitCopy` value, or
a closure with a captured environment), the whole env record is
abandoned rather than partially materialised. That is correct — the
whole generator construction fails closed with a root
`NotYetImplemented` regardless of how many other captures would have
been fine.

But only the explicitly-rejected binding was added to
`poisoned_captures`. An otherwise-admissible sibling capture in the
same abandoned set had neither a poison entry (which silences its
body-side `BindingRef` resolution) nor a `capture_env_sources` entry
(since no env record exists to source it from — that registration
loop only runs when `env_ty.is_some()`). So the sibling fell through
to the ordinary unresolved-binding path and cascaded a spurious
`InitialisedBeforeUse` + `UnresolvedPlace` on top of the one
actionable root diagnostic.

## Live repro (before the fix)

```
#[opaque]
type Dq {}

extern "C" {
    fn hew_deque_len(dq: Dq) -> i64;
}

gen fn drain(handle: Dq, n: i64) -> i64 {
    yield unsafe { hew_deque_len(handle) } + n;
}
```

`hew check` on this emitted **3 errors**: the root `NotYetImplemented`
for `handle`, plus `InitialisedBeforeUse` and `UnresolvedPlace` for
the otherwise-fine scalar `n`.

## Fix

When the capture loop concludes `!all_materialisable`, poison every
capture binding in the abandoned set, not only the one that triggered
the explicit rejection arm. The root diagnostic is already the single
actionable message for the whole construction.

After the fix, the same repro emits **exactly 1 error** (the root
NYI). Confirmed load-bearing by reverting the fix and reproducing the
3-error cascade, then restoring it.

The two pre-existing single-inadmissible-capture reject fixtures
(`gen_fn_capture_opaque_handle`, `gen_fn_capture_owned_value`) are
unaffected — still exactly one root diagnostic each.

## Test

Adds `tests/vertical-slice/reject/gen_fn_mixed_capture_cascade.hew`
and wires it into `run.sh` via the existing
`expect_check_fail_error_count_no_cascade` helper, matching the
convention of the two sibling fixtures it sits beside.

## Verification

- `cargo test -p hew-mir --lib`: 327/327 (0 regressions)
- `cargo fmt -p hew-mir --check`: clean
- `cargo clippy -p hew-mir --lib --tests -- -D warnings`: clean
- Full `tests/vertical-slice/run.sh`: 435 RUN / 441 PASS / 0 FAIL, exit 0
