### PR TITLE
fix(types): give parameters a shadow span so nested locals warn, not error

### DIFF
--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -131,7 +131,12 @@ impl Checker {
                     param.name, sd.name
                 ),
             );
-            self.env.define(param.name.clone(), ty, param.is_mutable);
+            self.env.define_param_with_span(
+                param.name.clone(),
+                ty,
+                param.is_mutable,
+                param.ty.1.clone(),
+            );
         }
 
         // Synthesise the type of every child's init-arg expressions so the
@@ -866,7 +871,8 @@ impl Checker {
             if in_actor {
                 self.check_shadowing(&p.name, &p.ty.1);
             }
-            self.env.define(p.name.clone(), ty, p.is_mutable);
+            self.env
+                .define_param_with_span(p.name.clone(), ty, p.is_mutable, p.ty.1.clone());
         }
 
         // Use the return type from the already-registered fn signature so that
@@ -1327,7 +1333,8 @@ impl Checker {
                 &p.ty,
                 format!("init parameter `{}` of actor `{actor_name}`", p.name),
             );
-            self.env.define(p.name.clone(), ty, p.is_mutable);
+            self.env
+                .define_param_with_span(p.name.clone(), ty, p.is_mutable, p.ty.1.clone());
         }
 
         // Init returns unit — no meaningful return type
@@ -1610,7 +1617,8 @@ impl Checker {
         self.bind_actor_fields(fields);
         if let Some(p) = hook.params.first() {
             let pty = self.resolve_type_expr(&p.ty);
-            self.env.define(p.name.clone(), pty, p.is_mutable);
+            self.env
+                .define_param_with_span(p.name.clone(), pty, p.is_mutable, p.ty.1.clone());
         }
 
         self.current_return_type = Some(return_ty);
@@ -1711,7 +1719,8 @@ impl Checker {
         self.bind_actor_fields(fields);
         if let Some(p) = hook.params.first() {
             let pty = self.resolve_type_expr(&p.ty);
-            self.env.define(p.name.clone(), pty, p.is_mutable);
+            self.env
+                .define_param_with_span(p.name.clone(), pty, p.is_mutable, p.ty.1.clone());
         }
 
         self.current_return_type = Some(Ty::Unit);
@@ -1898,7 +1907,8 @@ impl Checker {
         for p in &rf.params {
             self.check_shadowing(&p.name, &p.ty.1);
             let ty = self.resolve_type_expr(&p.ty);
-            self.env.define(p.name.clone(), ty, p.is_mutable);
+            self.env
+                .define_param_with_span(p.name.clone(), ty, p.is_mutable, p.ty.1.clone());
         }
 
         let declared_ret = if let Some(sig) = self.fn_sigs.get(&qualified_name) {

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -2285,6 +2285,74 @@ fn test_actor_fn_method_field_shadowing_is_error() {
 }
 
 #[test]
+fn warn_nested_scope_shadowing_of_free_fn_param() {
+    // Regression for PR #240 review finding: a nested local shadowing a
+    // *user-visible parameter* must be downgraded to a warning, the same
+    // treatment given to shadowing a `let`-declared local (see
+    // `warn_nested_scope_shadowing`). Before the fix, function/receive-fn/
+    // init/hook parameters were bound via `env.define` (no source span),
+    // which is indistinguishable from the actor-field synthetic-binding case
+    // that intentionally stays a hard error, so this shadowing was wrongly
+    // rejected.
+    let source = "fn f(x: i64) -> i64 { if true { let x = 2; return x; } return x; }";
+    let (errors, warnings) = parse_and_check(source);
+    assert!(
+        !errors.iter().any(|e| e.kind == TypeErrorKind::Shadowing),
+        "shadowing a free-fn parameter should not be a hard error, got errors: {errors:?}",
+    );
+    assert!(
+        warnings.iter().any(|w| w.kind == TypeErrorKind::Shadowing
+            && w.message.contains("shadows a binding in an outer scope")),
+        "expected outer-scope shadowing warning for parameter `x`, got warnings: {warnings:?}",
+    );
+}
+
+#[test]
+fn warn_nested_scope_shadowing_of_receive_fn_param() {
+    // Same regression as `warn_nested_scope_shadowing_of_free_fn_param`, for
+    // the actor `receive fn` parameter surface the review finding also named
+    // explicitly (hew-types/src/check/items.rs, receive-fn param binding).
+    let source = r#"
+        actor Greeter {
+            receive fn greet(name: string) {
+                if true {
+                    let name = "nested";
+                    println(name);
+                }
+                println(name);
+            }
+        }
+    "#;
+    let (errors, warnings) = parse_and_check(source);
+    assert!(
+        !errors.iter().any(|e| e.kind == TypeErrorKind::Shadowing),
+        "shadowing a receive-fn parameter should not be a hard error, got errors: {errors:?}",
+    );
+    assert!(
+        warnings.iter().any(|w| w.kind == TypeErrorKind::Shadowing
+            && w.message.contains("shadows a binding in an outer scope")),
+        "expected outer-scope shadowing warning for parameter `name`, got warnings: {warnings:?}",
+    );
+}
+
+#[test]
+fn unused_free_fn_param_is_not_warned() {
+    // Parameters keep `def_span: None` (see `define_param_with_span`) even
+    // though they now carry a `shadow_span` for the shadowing fix above, so
+    // they must stay exempt from the `UnusedVariable` scope-exit lint exactly
+    // as before this change — only the shadowing *classification* changed.
+    let source = "fn f(unused: i64) -> i64 { return 5; }";
+    let (errors, warnings) = parse_and_check(source);
+    assert!(
+        !warnings
+            .iter()
+            .any(|w| w.kind == TypeErrorKind::UnusedVariable),
+        "unused parameters must not trigger UnusedVariable, got warnings: {warnings:?}",
+    );
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+}
+
+#[test]
 fn actor_this_field_points_to_bare_state_field() {
     let source = r"
         actor Counter {

--- a/hew-types/src/env.rs
+++ b/hew-types/src/env.rs
@@ -30,6 +30,18 @@ pub struct Binding {
     pub is_written: bool,
     /// Source span of the definition, for diagnostics. None for synthetic bindings.
     pub def_span: Option<Span>,
+    /// Source span used **only** for outer-scope shadowing classification
+    /// (see `check_shadowing`), independent of `def_span`.
+    ///
+    /// Almost always mirrors `def_span`. The one deliberate exception is
+    /// user-visible function/method/init/hook parameters: they keep
+    /// `def_span: None` (so they stay exempt from the `UnusedVariable` /
+    /// `NeverMutated` scope-exit lints in `pop_scope_with_warnings`, which
+    /// only consider bindings with a `def_span`), while still needing a real
+    /// span here so a nested local that shadows a parameter is classified as
+    /// "shadows a user-visible outer binding" (warning) rather than
+    /// "shadows a synthetic binding" (hard error) — see `define_param_with_span`.
+    pub shadow_span: Option<Span>,
 }
 
 /// A diagnostic about a binding discovered at scope exit.
@@ -112,6 +124,7 @@ impl TypeEnv {
                     read_count: 1, // synthetic bindings are always "used"
                     is_written: false,
                     def_span: None,
+                    shadow_span: None,
                 },
             );
         }
@@ -131,7 +144,38 @@ impl TypeEnv {
                     moved_at: None,
                     read_count: 0,
                     is_written: false,
-                    def_span: Some(span),
+                    def_span: Some(span.clone()),
+                    shadow_span: Some(span),
+                },
+            );
+        }
+    }
+
+    /// Define a user-visible function/method/init/hook **parameter** with a
+    /// source span for outer-scope shadowing classification only.
+    ///
+    /// Deliberately keeps `def_span: None` (like the fully-synthetic
+    /// `define`): parameters are exempt from the `UnusedVariable` /
+    /// `NeverMutated` scope-exit lints, which key off `def_span`, matching
+    /// existing behaviour before and after this constructor's introduction.
+    /// Unlike `define`, `shadow_span` is populated so a nested local that
+    /// shadows the parameter name is downgraded from hard error to warning,
+    /// the same treatment given to shadowing a user-declared local variable.
+    pub fn define_param_with_span(&mut self, name: String, ty: Ty, is_mutable: bool, span: Span) {
+        let id = self.next_binding_id();
+        if let Some(scope) = self.scopes.last_mut() {
+            scope.insert(
+                name,
+                Binding {
+                    id,
+                    ty,
+                    is_mutable,
+                    is_moved: false,
+                    moved_at: None,
+                    read_count: 1, // exempt from unused-variable lint, like `define`
+                    is_written: false,
+                    def_span: None,
+                    shadow_span: Some(span),
                 },
             );
         }
@@ -244,28 +288,28 @@ impl TypeEnv {
 
     /// Check if `name` already exists in the current (innermost) scope.
     ///
-    /// Returns `Some(Some(span))` when the binding has a source span,
-    /// `Some(None)` when found but synthetic, or `None` when the name
+    /// Returns `Some(Some(span))` when the binding has a shadow-classification
+    /// span, `Some(None)` when found but synthetic, or `None` when the name
     /// is not bound in the current scope.
     #[must_use]
     pub fn find_in_current_scope(&self, name: &str) -> Option<Option<Span>> {
         self.scopes
             .last()
             .and_then(|scope| scope.get(name))
-            .map(|b| b.def_span.clone())
+            .map(|b| b.shadow_span.clone())
     }
 
     /// Check if a variable name exists in any outer scope (not the current one).
     ///
-    /// Returns `Some(Some(span))` when the binding has a source span,
-    /// `Some(None)` when found but synthetic (e.g. actor fields), or
+    /// Returns `Some(Some(span))` when the binding has a shadow-classification
+    /// span, `Some(None)` when found but synthetic (e.g. actor fields), or
     /// `None` when the name is not bound in any outer scope.
     #[must_use]
     pub fn find_in_outer_scope(&self, name: &str) -> Option<Option<Span>> {
         // Skip the last (current) scope and check all outer scopes
         for scope in self.scopes.iter().rev().skip(1) {
             if let Some(binding) = scope.get(name) {
-                return Some(binding.def_span.clone());
+                return Some(binding.shadow_span.clone());
             }
         }
         None


### PR DESCRIPTION
## Problem

Nested-scope shadowing severity is decided entirely by whether the outer binding being shadowed carries a source span:

```rust
// check_shadowing
if let Some(prev_span) = self.env.find_in_outer_scope(name) {
    match prev_span {
        None => /* synthetic binding (actor field) -> hard error */,
        Some(prev_span) => /* user-visible local -> warning */,
    }
}
```

Function, receive-fn, actor-`init`, and actor-hook parameters are bound via `env.define(...)`, which always sets `def_span: None`. A nested `let` shadowing a parameter is therefore indistinguishable from shadowing a synthetic actor field, so it's rejected as a hard error instead of the intended warning:

```hew
fn f(x: i64) -> i64 {
    if true {
        let x = 2;   // error: variable `x` shadows a binding in an outer scope
        return x;
    }
    return x;
}
```

The same shape with a `let`-declared outer local instead of a parameter correctly warns instead of erroring.

## Why not just give parameters a `def_span`?

`def_span` is also what gates the `UnusedVariable`/`NeverMutated` scope-exit lints in `pop_scope_with_warnings`. Parameters are intentionally exempt from both (an unused parameter is normal; an unused local generally isn't). Naively switching parameters to `define_with_span` would fix the shadowing bug but introduce spurious "unused parameter" warnings for the first time.

## Fix

Split the two concerns. `Binding` gains a `shadow_span: Option<Span>` field used **only** for shadowing classification, independent of `def_span`:

- `define` (synthetic bindings): `def_span: None`, `shadow_span: None` — unchanged behavior.
- `define_with_span` (user locals): both spans set — unchanged behavior.
- **New** `define_param_with_span` (parameters): `def_span: None` (preserves the unused-lint exemption) but `shadow_span: Some(span)` (lets `check_shadowing` correctly classify a nested shadow as "user-visible outer binding" → warning).

`find_in_current_scope`/`find_in_outer_scope` now read `shadow_span` instead of `def_span`, since that's the field that should drive shadowing classification.

All 6 parameter-binding call sites in `hew-types/src/check/items.rs` (free-fn, supervisor-config, actor-`init`, both actor-hook forms, receive-fn) now use `define_param_with_span`. The 2 genuinely-synthetic `env.define` call sites in the same file (actor-field defaults in `bind_actor_fields_for_init`, const declarations) are untouched.

## Tests

Three new regression tests in `hew-types/src/check/tests/lints.rs`:

- `warn_nested_scope_shadowing_of_free_fn_param` — free-fn parameter shadowed by a nested local now warns, not errors (the repro above).
- `warn_nested_scope_shadowing_of_receive_fn_param` — same for an actor `receive fn` parameter.
- `unused_free_fn_param_is_not_warned` — guards the lint-exemption side: an unused parameter still doesn't trigger `UnusedVariable`.

Verified load-bearing: reverted `env.rs`/`items.rs` (kept the new tests) and confirmed both shadowing tests fail with the original hard error; restored, all pass. Existing actor-field-shadowing hard-error tests (`test_actor_field_shadowing_is_error`, `test_actor_fn_method_field_shadowing_is_error`) continue to pass unchanged, confirming shadowing a genuine synthetic binding is still a hard error.

## Verification

Ran the exact lane `scripts/ci-preflight-dispatcher.sh --dry-run -- <changed files>` selects for this diff (profile `types`, reason "type-checker surface changed"):

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --tests -- -D warnings`
- `make test-compiler-pipeline` — 7161/7161 passed (32 skipped, unrelated feature gates), via `cargo-nextest`
- `make fuzz-oracle` — `ORACLE gate: PASS` (26 raw `FAIL` lines are all pre-registered intentional-trap fixtures in `tests/fuzz-oracle/expected-failures.txt`, not regressions)
- `make leak-scan`

All green.
