### PR TITLE
fix(cli): keep Linux musl cross targets off GNU toolchain path

### DIFF
--- a/hew-cli/src/link.rs
+++ b/hew-cli/src/link.rs
@@ -527,16 +527,17 @@ where
     }
 }
 
-/// Probe for the Debian/Ubuntu multiarch tuple for Linux cross-arch linking.
+/// Probe for the Debian/Ubuntu GNU multiarch tuple for Linux cross-arch linking.
 ///
 /// Returns `None` when:
 /// - the target arch is the same as the host arch (no cross paths needed), or
+/// - the target ABI environment is not GNU, or
 /// - the arch has no known Debian multiarch tuple, or
 /// - the multiarch directory does not exist on this host.
 ///
-/// Paths follow the Debian/Ubuntu multiarch convention:
-/// - `/usr/aarch64-linux-gnu` — aarch64 cross-libs on an `x86_64` host
-/// - `/usr/x86_64-linux-gnu` — `x86_64` cross-libs on an aarch64 host
+/// Paths follow the Debian/Ubuntu GNU multiarch convention:
+/// - `/usr/aarch64-linux-gnu` — aarch64 GNU cross-libs on an `x86_64` host
+/// - `/usr/x86_64-linux-gnu` — `x86_64` GNU cross-libs on an aarch64 host
 #[cfg(target_os = "linux")]
 fn linux_cross_multiarch_tuple(target: &TargetSpec) -> Option<&'static str> {
     let arch_tuple = linux_cross_arch_tuple(target)?;
@@ -566,7 +567,7 @@ fn find_linux_cross_gcc_toolchain(target: &TargetSpec) -> Option<&'static str> {
 fn linux_cross_arch_tuple(target: &TargetSpec) -> Option<&'static str> {
     use crate::target::{TargetArch, TargetOs};
 
-    if target.os() != TargetOs::Linux {
+    if target.os() != TargetOs::Linux || target.env() != Some("gnu") {
         return None;
     }
 
@@ -1798,6 +1799,40 @@ mod tests {
         assert!(error.contains("llvm-project/releases/download/llvmorg-22.1.6"));
         assert!(error.contains("PATH"));
         assert!(error.contains("vcvars64.bat"));
+    }
+
+    #[cfg(all(
+        target_os = "linux",
+        any(target_arch = "aarch64", target_arch = "x86_64")
+    ))]
+    #[test]
+    fn linux_cross_arch_tuple_only_advertises_gnu_multiarch() {
+        let gnu_triple = if cfg!(target_arch = "aarch64") {
+            "x86_64-unknown-linux-gnu"
+        } else {
+            "aarch64-unknown-linux-gnu"
+        };
+        let musl_triple = if cfg!(target_arch = "aarch64") {
+            "x86_64-unknown-linux-musl"
+        } else {
+            "aarch64-unknown-linux-musl"
+        };
+        let gnu_target = TargetSpec::from_requested(Some(gnu_triple)).expect("gnu target");
+        let musl_target = TargetSpec::from_requested(Some(musl_triple)).expect("musl target");
+
+        assert_eq!(
+            linux_cross_arch_tuple(&gnu_target),
+            Some(if cfg!(target_arch = "aarch64") {
+                "x86_64-linux-gnu"
+            } else {
+                "aarch64-linux-gnu"
+            })
+        );
+        assert_eq!(
+            linux_cross_arch_tuple(&musl_target),
+            None,
+            "musl targets must not be mapped onto GNU Debian multiarch tuples"
+        );
     }
 
     #[cfg(all(

--- a/hew-cli/src/target.rs
+++ b/hew-cli/src/target.rs
@@ -325,6 +325,20 @@ impl TargetSpec {
         self.object_format
     }
 
+    /// Returns the target ABI environment component (`gnu`, `musl`, `msvc`, ...)
+    /// when the triple carries one.
+    ///
+    /// Used by Linux cross-link probing in `link.rs` so the production linker
+    /// helper does not silently map a musl target onto GNU Debian multiarch
+    /// directories.
+    #[allow(
+        dead_code,
+        reason = "only called from #[cfg(target_os=\"linux\")] code in link.rs; unused on non-Linux hosts"
+    )]
+    pub fn env(&self) -> Option<&str> {
+        self.env.as_deref()
+    }
+
     pub fn can_link_with_host_tools(&self) -> bool {
         self.is_wasm()
             || self.matches_host_environment()
@@ -365,15 +379,18 @@ impl TargetSpec {
             && self.arch != host.arch
     }
 
-    /// Linux same-OS cross-arch linking is supported by clang/LLD with a
-    /// Debian/Ubuntu multiarch sysroot.  Both arches must share the same
-    /// runtime ABI environment (e.g. both `gnu` or both `musl`) so that the
-    /// pre-built `libhew.a` and runtime ABI contract are compatible.
+    /// Linux same-OS cross-arch linking is supported by clang/LLD with the
+    /// Debian/Ubuntu GNU multiarch toolchain that `link.rs` probes.  Both
+    /// arches must share the GNU runtime ABI environment so that the pre-built
+    /// `libhew.a`, the runtime ABI contract, and the discovered startup objects
+    /// all agree.  Do not advertise musl cross-arch native linking until the
+    /// production linker grows a real musl cross-toolchain probe.
     fn can_cross_link_on_linux_host(&self) -> bool {
         let host = host_platform();
         host.os == TargetOs::Linux
             && self.os == TargetOs::Linux
             && self.env == host.env
+            && self.env.as_deref() == Some("gnu")
             && self.arch != host.arch
     }
 }
@@ -771,10 +788,17 @@ mod tests {
             "x86_64-unknown-linux-gnu"
         };
         let spec = TargetSpec::from_requested(Some(triple)).expect("target");
-        assert!(
-            spec.can_link_with_host_tools(),
-            "{triple} must be linkable from aarch64 Linux host"
-        );
+        if cfg!(target_env = "musl") {
+            assert!(
+                !spec.can_link_with_host_tools(),
+                "{triple} must not be advertised as linkable until musl cross-toolchain probing exists"
+            );
+        } else {
+            assert!(
+                spec.can_link_with_host_tools(),
+                "{triple} must be linkable from aarch64 GNU/Linux host"
+            );
+        }
         assert!(
             !spec.can_run_on_host(),
             "cross-arch binary must not be runnable on host"
@@ -791,10 +815,17 @@ mod tests {
             "aarch64-unknown-linux-gnu"
         };
         let spec = TargetSpec::from_requested(Some(triple)).expect("target");
-        assert!(
-            spec.can_link_with_host_tools(),
-            "{triple} must be linkable from x86_64 Linux host"
-        );
+        if cfg!(target_env = "musl") {
+            assert!(
+                !spec.can_link_with_host_tools(),
+                "{triple} must not be advertised as linkable until musl cross-toolchain probing exists"
+            );
+        } else {
+            assert!(
+                spec.can_link_with_host_tools(),
+                "{triple} must be linkable from x86_64 GNU/Linux host"
+            );
+        }
         assert!(
             !spec.can_run_on_host(),
             "cross-arch binary must not be runnable on host"


### PR DESCRIPTION
## Summary

- stop advertising Linux cross-arch native linking for musl targets until the linker has a real musl cross-toolchain probe
- keep the production Linux multiarch helper GNU-only instead of mapping `*-linux-musl` targets onto Debian GNU tuples
- add regression coverage proving musl targets do not reuse `aarch64-linux-gnu` / `x86_64-linux-gnu` tuple discovery

## Verification

- `cargo fmt -p hew-cli --check`
- `cargo test -p hew-cli linux_cross_arch -- --nocapture`
- load-bearing check: reverted the tuple env guard and confirmed `linux_cross_arch_tuple_only_advertises_gnu_multiarch` fails with `left: Some("aarch64-linux-gnu")`; restored and reran it green
- `cargo clippy -p hew-cli --tests -- -D warnings`
