### PR TITLE
fix(mir): release moved fork spawn environments

### DIFF
--- a/hew-cli/tests/generic_spawn_owned_arg_leak_oracle.rs
+++ b/hew-cli/tests/generic_spawn_owned_arg_leak_oracle.rs
@@ -7,32 +7,20 @@
 //! The caller retains ownership; a callee-side drop of a borrowed buffer
 //! double-frees the caller's live allocation → UAF.
 //!
-//! Under the current M-COW move-only spine the fork-env rc-box passes a
-//! `null_drop` destructor, so the by-value string arg inside the env is
-//! released by no one — exactly as the direct-call baseline behaves:
-//!
-//! > "the fork form leaks exactly where the direct call already leaks —
-//! > never a double-free."
-//! > (lower.rs `lower_spawned_args_call_task`, WHEN-OBSOLETE: M-COW
-//! > retain-on-share; the env transfer then needs a real retain/release
-//! > pair in lockstep with call args.)
+//! The fork environment receives the source's owner, so its Rc payload callback
+//! releases the string after the task completes. The callee remains a borrow and
+//! must not participate in teardown.
 //!
 //! ## What this oracle pins
 //!
-//! 1. **No double-free** — both the generic-fork shape and the direct-call
-//!    baseline complete under `MallocScribble`/`MallocPreScribble`/
-//!    `MallocGuardEdges`. Any callee-side drop of the borrowed string buffer
-//!    (the known-catastrophic "fix" that caused 59 UAF/double-free failures
-//!    in v056) aborts here before any result is read.
+//! 1. **No double-free** — the generic-fork shape completes under
+//!    `MallocScribble`/`MallocPreScribble`/`MallocGuardEdges`. A callee-side
+//!    drop of the borrowed string buffer would abort here before any result is
+//!    read.
 //!
-//! 2. **Conservative-leak parity** — the per-iteration leak delta of the
-//!    generic-fork path equals the direct-call baseline delta within
-//!    `SLOPE_TOLERANCE` nodes. This proves the generic symbol resolution
-//!    added by generic symbol resolution introduces no *additional* heap retention per fork.
-//!
-//! The conservative leak itself (one string node per iteration, both paths)
-//! is the documented design, not a bug. It will be eliminated when M-COW
-//! grows retain-on-share (WHEN-OBSOLETE comment above).
+//! 2. **Flat leak slope** — the low/high standalone fork binaries differ by at
+//!    most `SLOPE_TOLERANCE` nodes, proving the environment releases its moved
+//!    string once per invocation.
 //!
 //! macOS-only (`leaks(1)` is Darwin's allocator inspector); skips elsewhere.
 
@@ -51,20 +39,11 @@ use support::{describe_output, hew_binary, repo_root, require_codegen};
 /// while staying near the constant-overhead floor.
 const LOW_ITERS: usize = 20;
 
-/// High count for the slope check. A slope of 1.0 node/iter (one string
-/// buffer leaked per iteration, both paths) produces a delta of
-/// `HIGH - LOW = 80` vs the tolerance of 16 (5× SNR) — both paths must sit
-/// at exactly the same node-count delta for the parity assertion to hold.
-/// Kept at 100 (down from 500) so the four compile+leaks measurements finish
-/// well inside the 300 s nextest slow-timeout on the slowest CI runner.
+/// High count keeps a one-node-per-iteration regression well above the shared
+/// tolerance while remaining fast enough for the standalone `leaks` runs.
 const HIGH_ITERS: usize = 100;
 
-/// Maximum permitted leak-node delta *between the fork and direct paths* at
-/// the same iteration count. A single runtime/scheduler allocation difference
-/// between the two binaries (e.g. different actor-spawn overhead) means the
-/// absolute counts may differ by a small constant; but the PER-ITERATION
-/// DELTA must be equal (both paths leak 1 node/iter). This tolerance absorbs
-/// small constant offsets while still catching any extra per-iteration node.
+/// Maximum permitted low/high leak-node delta for the same fork program.
 const SLOPE_TOLERANCE: usize = 16;
 
 // ── source generators ─────────────────────────────────────────────────────
@@ -75,9 +54,7 @@ const SLOPE_TOLERANCE: usize = 16;
 /// heap-allocated (not a static literal), then moved into the fork env.
 ///
 /// Under `by-value-heap-params-are-borrows`, the callee does not drop `s`;
-/// the env rc-box uses a `null_drop` destructor so the string bytes are also
-/// not freed via the env. The string leaks conservatively — exactly 1 node
-/// per iteration, matching the direct-call baseline.
+/// the fork environment's Rc callback is the sole release site.
 fn generic_fork_source(iters: usize) -> String {
     format!(
         "import std::string;\n\
@@ -100,38 +77,6 @@ fn generic_fork_source(iters: usize) -> String {
          \n\
          fn main() -> i64 {{\n\
          \x20   let d = spawn ForkDriver;\n\
-         \x20   match await d.run_n({iters}) {{\n\
-         \x20       Ok(v) => v,\n\
-         \x20       Err(_) => -1,\n\
-         \x20   }}\n\
-         }}\n"
-    )
-}
-
-/// Direct-call baseline: the same owned heap string passed to a non-generic,
-/// non-fork callee. Same conservative-leak shape (1 node/iter); serves as
-/// the denominator for the parity assertion. If the two deltas diverge the
-/// fork path is retaining something the direct call does not.
-fn direct_call_source(iters: usize) -> String {
-    format!(
-        "import std::string;\n\
-         \n\
-         fn direct_str_sink(s: string) {{}}\n\
-         \n\
-         actor DirectDriver {{\n\
-         \x20   receive fn run_n(n: i64) -> i64 {{\n\
-         \x20       var i: i64 = 0;\n\
-         \x20       while i < n {{\n\
-         \x20           let s = string.repeat(\"owned-heap-string-payload\", 20);\n\
-         \x20           direct_str_sink(s);\n\
-         \x20           i = i + 1;\n\
-         \x20       }}\n\
-         \x20       0\n\
-         \x20   }}\n\
-         }}\n\
-         \n\
-         fn main() -> i64 {{\n\
-         \x20   let d = spawn DirectDriver;\n\
          \x20   match await d.run_n({iters}) {{\n\
          \x20       Ok(v) => v,\n\
          \x20       Err(_) => -1,\n\
@@ -247,14 +192,8 @@ fn leaks_available() -> bool {
 
 // ── oracles ───────────────────────────────────────────────────────────────
 
-/// Both the generic-fork shape and the direct-call baseline must run to
-/// completion under the poisoned-allocator triple. Any callee-side drop of
-/// the borrowed string buffer (the revert-triggering "fix" from v056) crashes
-/// here: `MallocScribble` poisons freed bytes; the caller's subsequent reads
-/// of the scribbled buffer abort or produce a wrong exit code.
-///
-/// This is the headline safety property: the conservative leak is the correct
-/// design; the absence of a double-free is the proof.
+/// The generic-fork shape must complete under the poisoned-allocator triple.
+/// A callee-side drop of the borrowed string buffer would crash here.
 #[test]
 fn generic_fork_owned_str_no_double_free() {
     if !leaks_available() {
@@ -273,26 +212,13 @@ fn generic_fork_owned_str_no_double_free() {
         dir.path(),
         "generic_fork_str_high",
     );
-    let direct_bin = compile_to_native(
-        &direct_call_source(HIGH_ITERS),
-        dir.path(),
-        "direct_call_str_high",
-    );
-
     assert_no_poisoned_allocator_abort(&fork_bin, "generic-fork owned-string arg");
-    assert_no_poisoned_allocator_abort(&direct_bin, "direct-call owned-string arg (baseline)");
 }
 
-/// Per-iteration leak delta for the generic-fork path must equal the
-/// direct-call baseline delta within `SLOPE_TOLERANCE`. Both paths
-/// conservatively leak exactly one string node per iteration under the
-/// current M-COW move-only spine (WHEN-OBSOLETE: retain-on-share).
-///
-/// A diverging delta would mean the generic symbol resolution or fork-env
-/// construction is retaining an *additional* heap node per invocation — an
-/// extra leak the direct-call path does not have.
+/// The generic-fork environment must release its moved string once per
+/// invocation, keeping the low/high standalone leak slope flat.
 #[test]
-fn generic_fork_owned_str_leak_matches_direct_call_baseline() {
+fn generic_fork_owned_str_leak_slope_is_flat() {
     if !leaks_available() {
         eprintln!("skip: generic_spawn_owned_arg oracle: leaks(1) is macOS-only / not on PATH");
         return;
@@ -300,7 +226,7 @@ fn generic_fork_owned_str_leak_matches_direct_call_baseline() {
     require_codegen();
 
     let dir = tempfile::Builder::new()
-        .prefix("generic-spawn-str-parity-")
+        .prefix("generic-spawn-str-slope-")
         .tempdir()
         .expect("tempdir");
 
@@ -314,47 +240,25 @@ fn generic_fork_owned_str_leak_matches_direct_call_baseline() {
         dir.path(),
         "generic_fork_str_high",
     );
-    let direct_low = compile_to_native(
-        &direct_call_source(LOW_ITERS),
-        dir.path(),
-        "direct_call_str_low",
-    );
-    let direct_high = compile_to_native(
-        &direct_call_source(HIGH_ITERS),
-        dir.path(),
-        "direct_call_str_high",
-    );
-
     let Some(fork_low_leaks) = measure_leaks(&fork_low) else {
         return;
     };
     let Some(fork_high_leaks) = measure_leaks(&fork_high) else {
         return;
     };
-    let Some(direct_low_leaks) = measure_leaks(&direct_low) else {
-        return;
-    };
-    let Some(direct_high_leaks) = measure_leaks(&direct_high) else {
-        return;
-    };
-
     let fork_delta = fork_high_leaks.saturating_sub(fork_low_leaks);
-    let direct_delta = direct_high_leaks.saturating_sub(direct_low_leaks);
 
     eprintln!(
-        "generic_fork_owned_str_leak_parity: \
-         fork_low={fork_low_leaks} fork_high={fork_high_leaks} fork_delta={fork_delta} \
-         direct_low={direct_low_leaks} direct_high={direct_high_leaks} \
-         direct_delta={direct_delta} tolerance={SLOPE_TOLERANCE}"
+        "generic_fork_owned_str_leak_slope: \
+         fork_low={fork_low_leaks} fork_high={fork_high_leaks} \
+         fork_delta={fork_delta} tolerance={SLOPE_TOLERANCE}"
     );
 
-    let delta_diff = fork_delta.abs_diff(direct_delta);
     assert!(
-        delta_diff <= SLOPE_TOLERANCE,
-        "generic-fork owned-string arg leaks MORE per iteration than the \
-         direct-call baseline — the generic symbol resolution or fork-env \
-         construction is retaining an extra heap node per invocation. \
-         fork_delta={fork_delta} direct_delta={direct_delta} diff={delta_diff} \
+        fork_delta <= SLOPE_TOLERANCE,
+        "generic-fork owned-string argument leaks per iteration — the Rc \
+         environment callback did not release the moved argument. \
+         fork_delta={fork_delta} \
          tolerance={SLOPE_TOLERANCE}. \
          Re-run with `MallocStackLogging=1 leaks --atExit -- {}` to identify \
          the extra allocation site.",

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -18662,8 +18662,16 @@ fn lower_instruction(
             fn_symbol,
             env,
             env_ty,
+            env_ownership,
         } => {
-            crate::thunks::emit_spawn_task_closure(fn_ctx, *task, fn_symbol, *env, env_ty)?;
+            crate::thunks::emit_spawn_task_closure(
+                fn_ctx,
+                *task,
+                fn_symbol,
+                *env,
+                env_ty,
+                env_ownership,
+            )?;
             let _ = ctx;
         }
         Instr::SpawnActor {
@@ -20984,23 +20992,24 @@ fn lower_make_closure(
 /// is a `CodegenError::FailClosed` (the owned capture would otherwise leak by
 /// omission), and an env whose record type is missing from the registry is a
 /// hard error rather than a silent empty (which would reinstate the leak).
-fn closure_env_capture_drop_kinds(
+pub(crate) fn env_field_drop_kinds(
     fn_ctx: &FnCtx<'_, '_>,
     fn_symbol: &str,
     env: Place,
+    env_role: &str,
 ) -> CodegenResult<Vec<StateFieldCloneKind>> {
     let env_ty = place_resolved_ty(fn_ctx, env)?;
     let ResolvedTy::Named { name: env_name, .. } = env_ty else {
         return Err(CodegenError::FailClosed(format!(
-            "closure env for `{fn_symbol}` has non-Named place type {env_ty:?}; \
-             expected the `__hew_closure_env_*` record"
+            "{env_role} environment for `{fn_symbol}` has non-Named place type {env_ty:?}; \
+             expected a generated record"
         )));
     };
     let Some(field_tys) = fn_ctx.record_field_resolved_tys.get(env_name.as_str()) else {
         return Err(CodegenError::FailClosed(format!(
-            "closure env `{env_name}` for `{fn_symbol}` is not in the codegen record \
-             registry; its captured-field drop manifest cannot be derived and owned \
-             captures would leak (boundary-fail-closed)"
+            "{env_role} environment `{env_name}` for `{fn_symbol}` is not in the codegen \
+             record registry; its owned-field drop manifest cannot be derived and values \
+             would leak (boundary-fail-closed)"
         )));
     };
     // Reconstruct the RecordLayout slice the classifier consumes from the same
@@ -21025,9 +21034,9 @@ fn closure_env_capture_drop_kinds(
         )
         .map_err(|e| {
             CodegenError::FailClosed(format!(
-                "closure env `{env_name}` capture field {idx} (type {field_ty:?}) is not \
-                 drop-classifiable: {e}; an owned capture would leak when the escaping \
-                 closure is dropped (borrow-classifier-completeness-or-leak)"
+                "{env_role} environment `{env_name}` field {idx} (type {field_ty:?}) is not \
+                 drop-classifiable: {e}; an owned field would leak on teardown \
+                 (borrow-classifier-completeness-or-leak)"
             ))
         })?;
         kinds.push(kind);
@@ -21107,7 +21116,7 @@ fn emit_closure_env_heap_box<'ctx>(
             )));
         }
     };
-    let field_kinds = closure_env_capture_drop_kinds(fn_ctx, fn_symbol, env)?;
+    let field_kinds = env_field_drop_kinds(fn_ctx, fn_symbol, env, "closure")?;
     let free_thunk = crate::thunks::get_or_emit_closure_env_free_thunk(
         fn_ctx,
         fn_symbol,

--- a/hew-codegen-rs/src/thunks.rs
+++ b/hew-codegen-rs/src/thunks.rs
@@ -22,7 +22,10 @@ use inkwell::values::{BasicMetadataValueEnum, FunctionValue, IntValue, PointerVa
 use inkwell::{AddressSpace, IntPredicate};
 
 use hew_hir::mangle_dotted_name;
-use hew_mir::{ActorLayout, IoHandleKind, LambdaEnvFieldDrop, Place, StateFieldCloneKind};
+use hew_mir::{
+    ActorLayout, IoHandleKind, LambdaEnvFieldDrop, Place, SpawnEnvFieldOwnership,
+    StateFieldCloneKind,
+};
 use hew_runtime::internal::types::HEW_TRAP_EXHAUSTIVENESS_FALLTHROUGH;
 use hew_types::{BuiltinType, ResolvedTy};
 
@@ -499,6 +502,7 @@ pub(crate) fn emit_spawn_task_closure(
     fn_symbol: &str,
     env: Place,
     env_ty: &ResolvedTy,
+    env_ownership: &[SpawnEnvFieldOwnership],
 ) -> CodegenResult<()> {
     let spilled_ctx = fn_ctx.execution_context.ok_or_else(|| {
         CodegenError::FailClosed("SpawnTaskClosure spawn site requires an execution context".into())
@@ -515,6 +519,14 @@ pub(crate) fn emit_spawn_task_closure(
         return Err(CodegenError::FailClosed(format!(
             "SpawnTaskClosure env place type {env_slot_ty:?} does not match registered env \
              struct {env_struct:?}"
+        )));
+    }
+    let field_count = env_struct.count_fields() as usize;
+    if env_ownership.len() != field_count {
+        return Err(CodegenError::FailClosed(format!(
+            "SpawnTaskClosure environment for `{fn_symbol}` has {field_count} fields but \
+             ownership manifest has {} entries",
+            env_ownership.len()
         )));
     }
     let Some(env_size) = env_struct.size_of() else {
@@ -537,6 +549,28 @@ pub(crate) fn emit_spawn_task_closure(
         "hew_rc_new",
     )?;
     let null_drop = fn_ctx.ctx.ptr_type(AddressSpace::default()).const_null();
+    let owned_field_kinds: Vec<(u32, StateFieldCloneKind)> =
+        if env_ownership.contains(&SpawnEnvFieldOwnership::OwnsMoved) {
+            crate::llvm::env_field_drop_kinds(fn_ctx, fn_symbol, env, "spawn task")?
+                .into_iter()
+                .enumerate()
+                .filter_map(|(idx, kind)| {
+                    (env_ownership[idx] == SpawnEnvFieldOwnership::OwnsMoved).then_some((
+                        u32::try_from(idx).expect("spawn env field count exceeds u32::MAX"),
+                        kind,
+                    ))
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+    let drop_fn = if owned_field_kinds.is_empty() {
+        null_drop
+    } else {
+        get_or_emit_spawn_env_rc_drop_thunk(fn_ctx, fn_symbol, env_struct, &owned_field_kinds)?
+            .as_global_value()
+            .as_pointer_value()
+    };
     let rc_env = fn_ctx
         .builder
         .build_call(
@@ -545,7 +579,7 @@ pub(crate) fn emit_spawn_task_closure(
                 env_ptr.into(),
                 env_size.into(),
                 env_align.into(),
-                null_drop.into(),
+                drop_fn.into(),
             ],
             "hew_closure_env_rc_new",
         )
@@ -581,6 +615,55 @@ pub(crate) fn emit_spawn_task_closure(
         )
         .llvm_ctx("hew_task_spawn_thread_with_inherited_context call")?;
     Ok(())
+}
+
+/// Synthesise a payload-only callback for an Rc task environment.
+///
+/// `hew_rc_new` owns and reclaims the allocation itself, so this callback drops
+/// only the manifest-owned fields and must never call `hew_dyn_box_free`.
+fn get_or_emit_spawn_env_rc_drop_thunk<'ctx>(
+    fn_ctx: &FnCtx<'_, 'ctx>,
+    fn_symbol: &str,
+    env_struct: StructType<'ctx>,
+    owned_field_kinds: &[(u32, StateFieldCloneKind)],
+) -> CodegenResult<FunctionValue<'ctx>> {
+    let symbol = format!("__hew_spawn_env_rc_drop_{fn_symbol}");
+    if let Some(existing) = fn_ctx.llvm_mod.get_function(&symbol) {
+        return Ok(existing);
+    }
+    let ctx = fn_ctx.ctx;
+    let ptr_ty = ctx.ptr_type(AddressSpace::default());
+    let thunk = fn_ctx.llvm_mod.add_function(
+        &symbol,
+        ctx.void_type().fn_type(&[ptr_ty.into()], false),
+        Some(Linkage::Private),
+    );
+    let entry = ctx.append_basic_block(thunk, "entry");
+    let builder = ctx.create_builder();
+    builder.position_at_end(entry);
+    let env = thunk
+        .get_nth_param(0)
+        .ok_or_else(|| {
+            CodegenError::FailClosed(format!(
+                "spawn env Rc drop thunk `{symbol}`: synthesised function missing env parameter"
+            ))
+        })?
+        .into_pointer_value();
+    for (field_idx, kind) in owned_field_kinds.iter().rev() {
+        crate::llvm::emit_field_drop_step(
+            ctx,
+            fn_ctx.llvm_mod,
+            &builder,
+            Some(env_struct),
+            env,
+            *field_idx,
+            kind,
+        )?;
+    }
+    builder
+        .build_return(None)
+        .llvm_ctx_with(|| format!("spawn env Rc drop thunk `{symbol}`: return"))?;
+    Ok(thunk)
 }
 
 /// Synthesise (once per closure shim) the `void(ptr env)` free thunk the

--- a/hew-codegen-rs/tests/emission/task_abi_emission.rs
+++ b/hew-codegen-rs/tests/emission/task_abi_emission.rs
@@ -16,7 +16,7 @@ use hew_codegen_rs::{emit_module, EmitOptions};
 use hew_mir::{
     BasicBlock, BlockKind, CheckedMirFunction, DropPlan, ElabBlock, ElaboratedMirFunction,
     ExitPath, FunctionCallConv, Instr, IrPipeline, Place, RawMirFunction, RecordLayout,
-    RuntimeCall, Terminator,
+    RuntimeCall, SpawnEnvFieldOwnership, Terminator,
 };
 use hew_types::ResolvedTy;
 
@@ -367,7 +367,7 @@ fn pipeline_with_spawn_task_closure() -> IrPipeline {
             Instr::EnterContext,
             Instr::RecordInit {
                 ty: env_ty.clone(),
-                fields: vec![],
+                fields: vec![(hew_mir::FieldOffset(0), Place::Local(2))],
                 dest: Place::Local(1),
             },
             Instr::SpawnTaskClosure {
@@ -375,6 +375,7 @@ fn pipeline_with_spawn_task_closure() -> IrPipeline {
                 fn_symbol: "__hew_closure_invoke_main_0".to_string(),
                 env: Place::Local(1),
                 env_ty: env_ty.clone(),
+                env_ownership: vec![SpawnEnvFieldOwnership::BorrowsOnly],
             },
             Instr::ExitContext,
         ],
@@ -400,7 +401,11 @@ fn pipeline_with_spawn_task_closure() -> IrPipeline {
                 return_ty: ResolvedTy::Unit,
                 call_conv: FunctionCallConv::ActorHandler,
                 params: vec![],
-                locals: vec![ResolvedTy::Task(Box::new(ResolvedTy::Unit)), env_ty.clone()],
+                locals: vec![
+                    ResolvedTy::Task(Box::new(ResolvedTy::Unit)),
+                    env_ty.clone(),
+                    ResolvedTy::String,
+                ],
                 local_names: Vec::new(),
                 local_scopes: Vec::new(),
                 local_decl_bytes: Vec::new(),
@@ -461,7 +466,7 @@ fn pipeline_with_spawn_task_closure() -> IrPipeline {
         opaque_handle_names: vec![],
         record_layouts: vec![RecordLayout {
             name: "__hew_closure_env_main_0".to_string(),
-            field_tys: vec![],
+            field_tys: vec![ResolvedTy::String],
             field_names: vec![],
         }],
         actor_layouts: vec![],
@@ -829,6 +834,15 @@ fn task_abi_emission_spawn_task_closure_threads_execution_context() {
     assert!(
         ir.contains("@hew_task_spawn_thread_with_inherited_context"),
         "spawned closures must use inherited-context spawn helper; got:\n{ir}",
+    );
+    assert!(
+        !ir.contains("__hew_spawn_env_rc_drop_"),
+        "a scope-owned closure env borrows its string capture and must not get an \
+         Rc payload destructor; got:\n{ir}",
+    );
+    assert!(
+        ir.contains("call ptr @hew_rc_new") && ir.contains("ptr null)"),
+        "a borrowed scope-owned closure env must retain the null Rc callback; got:\n{ir}",
     );
     assert!(
         ir.contains("call i8 @__hew_closure_invoke_main_0(ptr %0, ptr %hew_task_get_env_call)"),

--- a/hew-codegen-rs/tests/structural.rs
+++ b/hew-codegen-rs/tests/structural.rs
@@ -14,6 +14,8 @@ mod composite_return;
 mod emit_duplex_pair;
 #[path = "structural/error_enum_cross_crate_parity.rs"]
 mod error_enum_cross_crate_parity;
+#[path = "structural/fork_spawn_env_drop.rs"]
+mod fork_spawn_env_drop;
 #[path = "structural/hashmap_layout_ops.rs"]
 mod hashmap_layout_ops;
 #[path = "structural/machine_layout.rs"]

--- a/hew-codegen-rs/tests/structural/fork_spawn_env_drop.rs
+++ b/hew-codegen-rs/tests/structural/fork_spawn_env_drop.rs
@@ -1,0 +1,125 @@
+//! Fork-call task environments own moved arguments, unlike scope-owned closure
+//! environments whose captures are borrowed. The RC callback must drop only the
+//! owned payload fields; `hew_rc_new` reclaims its allocation itself.
+
+use std::path::Path;
+
+use hew_codegen_rs::{emit_module, EmitOptions};
+use hew_types::module_registry::ModuleRegistry;
+use hew_types::Checker;
+
+fn emit_ll(source: &str) -> String {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    let output = hew_hir::lower_program(
+        &parsed.program,
+        &tc_output,
+        &hew_hir::ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    assert!(
+        output.diagnostics.is_empty(),
+        "hir diagnostics: {:?}",
+        output.diagnostics
+    );
+    let pipeline = hew_mir::lower_hir_module(&output.module);
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "mir diagnostics: {:?}",
+        pipeline.diagnostics
+    );
+    let tmp = tempfile::Builder::new()
+        .prefix("hew-fork-spawn-env-drop-")
+        .tempdir()
+        .expect("tempdir");
+    let options = EmitOptions {
+        module_name: "fork_spawn_env_drop",
+        out_dir: tmp.path(),
+        native: false,
+        wasm: false,
+        target_triple: None,
+        debug: false,
+        opt_level: hew_codegen_rs::OptLevel::O0,
+        source_path: None,
+    };
+    let artefacts = emit_module(&pipeline, &options).expect("fork pipeline must emit");
+    let ll_path: &Path = artefacts
+        .ll_path
+        .as_deref()
+        .expect("emit_module must populate ll_path");
+    std::fs::read_to_string(ll_path).expect("read emitted .ll")
+}
+
+fn function_body(ll: &str, fn_name: &str) -> String {
+    let needle = format!("@{fn_name}(");
+    let mut body = String::new();
+    let mut in_fn = false;
+    for line in ll.lines() {
+        if !in_fn && line.starts_with("define") && line.contains(&needle) {
+            in_fn = true;
+        }
+        if in_fn {
+            body.push_str(line);
+            body.push('\n');
+            if line.trim() == "}" {
+                break;
+            }
+        }
+    }
+    body
+}
+
+#[test]
+fn fork_env_rc_callback_drops_only_moved_string_argument() {
+    let ll = emit_ll(
+        r#"
+        fn shout(n: i64, message: string) {}
+
+        actor Driver {
+            receive fn drive() {
+                let greeting = "hello".to_upper();
+                scope {
+                    fork { shout(7, greeting); }
+                };
+            }
+        }
+
+        fn main() -> i64 {
+            let d = spawn Driver;
+            d.drive();
+            0
+        }
+        "#,
+    );
+    let prefix = "__hew_spawn_env_rc_drop_";
+    let thunk_name = ll
+        .lines()
+        .find_map(|line| {
+            if !line.starts_with("define") {
+                return None;
+            }
+            let start = line.find(&format!("@{prefix}"))? + 1;
+            line[start..].split('(').next().map(str::to_owned)
+        })
+        .expect("moved string fork argument must emit an Rc payload callback");
+    let thunk = function_body(&ll, &thunk_name);
+    assert_eq!(
+        thunk.matches("hew_string_drop").count(),
+        1,
+        "the moved string must be released exactly once by its task env callback: {thunk}"
+    );
+    assert!(
+        !thunk.contains("hew_dyn_box_free"),
+        "Rc payload callback must not free Rc-managed storage: {thunk}"
+    );
+    assert!(
+        ll.contains(&format!("ptr @{thunk_name}")),
+        "hew_rc_new must receive the generated payload callback: {ll}"
+    );
+}

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -34,7 +34,8 @@ use crate::model::{
     CmpPred, Direction, DropFnSpec, DropKind, DropPlan, ElabDrop, ElaboratedMirFunction, ExitPath,
     FloatWidth, FunctionCallConv, Instr, IntArithOp, IntSignedness, IrPipeline, JoinBranch,
     LambdaEnvFieldDrop, MirCheck, MirDiagnostic, MirDiagnosticKind, MirStatement, Place,
-    RawMirFunction, SelectArm, SelectArmKind, SuspendKind, Terminator, TrapKind,
+    RawMirFunction, SelectArm, SelectArmKind, SpawnEnvFieldOwnership, SuspendKind, Terminator,
+    TrapKind,
 };
 
 /// Which stage of the pipeline to render.
@@ -931,11 +932,20 @@ fn render_instr(instr: &Instr) -> String {
             fn_symbol,
             env,
             env_ty,
+            env_ownership,
         } => format!(
-            "{} = spawn_task_closure {fn_symbol} env={} env_ty={}",
+            "{} = spawn_task_closure {fn_symbol} env={} env_ty={} ownership=[{}]",
             render_place(task),
             render_place(env),
-            env_ty.user_facing()
+            env_ty.user_facing(),
+            env_ownership
+                .iter()
+                .map(|ownership| match ownership {
+                    SpawnEnvFieldOwnership::BorrowsOnly => "borrow",
+                    SpawnEnvFieldOwnership::OwnsMoved => "own_moved",
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
         ),
 
         // Drop

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -62,9 +62,9 @@ pub use model::{
     MachineLayout, MachineVariantLayout, MirCheck, MirConst, MirConstValue, MirDiagnostic,
     MirDiagnosticKind, MirHeapLayouts, MirLint, MirScope, MirStatement, Place, PointerWidth,
     PolymorphicMirFunction, PoolCount, RawMirFunction, RecordLayout, RegexLiteral, RuntimeCall,
-    SelectArm, SelectArmKind, SendAliasMode, SourceOrigin, Strategy, SupervisorChildLayout,
-    SupervisorConfigParam, SupervisorLayout, SuspendKind, Terminator, ThirFunction,
-    TraitObjectStorage, TrapKind, WitnessOperand,
+    SelectArm, SelectArmKind, SendAliasMode, SourceOrigin, SpawnEnvFieldOwnership, Strategy,
+    SupervisorChildLayout, SupervisorConfigParam, SupervisorLayout, SuspendKind, Terminator,
+    ThirFunction, TraitObjectStorage, TrapKind, WitnessOperand,
 };
 pub use ownership::{
     AbiClass, CowHeapRelease, DropClass, FailClosedReason, HandleRole, HeapLeaf,

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -35,8 +35,8 @@ use crate::model::{
     DropKind, DropPlan, ElabBlock, ElabDrop, ElaboratedMirFunction, ExitPath, FieldOffset,
     FloatWidth, Instr, IntArithOp, IntSignedness, IrPipeline, JoinBranch, LambdaCapture, MirCheck,
     MirConst, MirConstValue, MirDiagnostic, MirDiagnosticKind, MirStatement, Place, PointerWidth,
-    RawMirFunction, SelectArm, SelectArmKind, SourceOrigin, Strategy, SuspendKind, Terminator,
-    ThirFunction, TraitObjectStorage, TrapKind,
+    RawMirFunction, SelectArm, SelectArmKind, SourceOrigin, SpawnEnvFieldOwnership, Strategy,
+    SuspendKind, Terminator, ThirFunction, TraitObjectStorage, TrapKind,
 };
 use crate::ownership::FailClosedReason;
 use crate::ownership::LayoutClass;
@@ -25615,6 +25615,16 @@ impl Builder {
             fn_symbol: shim_name,
             env: env_place,
             env_ty,
+            env_ownership: arg_tys
+                .iter()
+                .map(|ty| {
+                    if ValueClass::of_ty(ty, &self.type_classes) == ValueClass::BitCopy {
+                        SpawnEnvFieldOwnership::BorrowsOnly
+                    } else {
+                        SpawnEnvFieldOwnership::OwnsMoved
+                    }
+                })
+                .collect(),
         });
         Some(task_place)
     }
@@ -25623,11 +25633,9 @@ impl Builder {
     /// `ClosureInvoke`-ABI function `(ctx, env_ptr)` that loads each arg
     /// back out of the env record and calls the target function with them.
     ///
-    /// The env field loads forward the arg bits to the callee with the same
-    /// ownership posture as a direct call: the shim emits no drops for the
-    /// loaded temps, and the callee treats owned params exactly as it would
-    /// for a direct call (verified by drop-plan parity with the no-fork
-    /// baseline).
+    /// Loading an owned string capture retains it so the environment remains
+    /// valid while the call runs. The shim balances that temporary retain after
+    /// the callee returns; this does not release the moved environment owner.
     #[expect(
         clippy::too_many_lines,
         reason = "shim construction keeps raw/checked/elaborated MIR snapshots aligned, \
@@ -25683,11 +25691,20 @@ impl Builder {
         builder.finish_current_block(Terminator::Call {
             callee: callee_symbol.to_string(),
             builtin: None,
-            args: arg_places,
+            args: arg_places.clone(),
             dest: None,
             next: ret_block_id,
         });
         builder.start_block(ret_block_id);
+        for (place, ty) in arg_places.iter().zip(arg_tys) {
+            if matches!(ty, ResolvedTy::String) {
+                builder.instructions.push(Instr::Drop {
+                    place: *place,
+                    ty: ty.clone(),
+                    drop_fn: Some(crate::model::DropFnSpec::Release("hew_string_drop")),
+                });
+            }
+        }
         let blocks = builder.finalize_blocks(Terminator::Return);
 
         let thir_statements: Vec<MirStatement> = blocks
@@ -25839,6 +25856,7 @@ impl Builder {
             fn_symbol,
             env: env_place,
             env_ty,
+            env_ownership: vec![SpawnEnvFieldOwnership::BorrowsOnly; captures.len()],
         });
         Some(task_place)
     }

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -4331,6 +4331,10 @@ pub enum Instr {
         fn_symbol: String,
         env: Place,
         env_ty: ResolvedTy,
+        /// Per-field ownership contract for the Rc task environment. Fork
+        /// argument fields transferred from the parent are owned by this
+        /// environment; scope-owned closure captures remain borrowed.
+        env_ownership: Vec<SpawnEnvFieldOwnership>,
     },
     /// Run the drop ritual for `place`. Cluster 3 makes this first-class:
     /// `drop_fn = Some(spec)` selects the release ritual through the typed
@@ -5950,6 +5954,19 @@ pub enum ClosureEnvFieldOwnership {
     OwnsMoved,
     /// Reserved for the future retain/deep-clone capture path.
     OwnsClonedOrRetained,
+}
+
+/// Ownership verdict for one [`Instr::SpawnTaskClosure`] environment field.
+///
+/// `SpawnTaskClosure` carries both moved fork-call arguments and borrowed
+/// scope-owned closure captures. The runtime Rc payload destructor must release
+/// only the former.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SpawnEnvFieldOwnership {
+    /// The environment aliases a value that remains owned elsewhere.
+    BorrowsOnly,
+    /// The environment received the source value's existing owner.
+    OwnsMoved,
 }
 
 /// One field of a [`Instr::ClosureEnvInit`] ownership manifest.

--- a/hew-mir/tests/actor/cancellation_scope.rs
+++ b/hew-mir/tests/actor/cancellation_scope.rs
@@ -1,5 +1,7 @@
 use hew_hir::{lower_program, ResolutionCtx};
-use hew_mir::{lower_hir_module, Instr, IrPipeline, MirCheck, MirDiagnosticKind};
+use hew_mir::{
+    lower_hir_module, Instr, IrPipeline, MirCheck, MirDiagnosticKind, SpawnEnvFieldOwnership,
+};
 use hew_types::module_registry::ModuleRegistry;
 use hew_types::Checker;
 
@@ -213,9 +215,9 @@ fn fork_string_arg_parent_and_shim_emit_no_drops_for_moved_arg() {
     // Drop-plan oracle (the truth standard): the moved-in string rides the
     // env bytes into the child. The parent's emitted drop plans carry NO
     // release for it (the consume fact removed it) and the shim's plans are
-    // empty — byte-for-byte the posture of the direct-call baseline, which
-    // also emits no drops for a by-value string arg under the move-only
-    // M-COW spine. Leak-as-before; never a double free.
+    // empty. The shim does emit an explicit inline release for its temporary
+    // retained env load; the Rc environment callback remains the sole release
+    // site for the moved source owner.
     let mir = lower_clean_to_mir(FORK_ARGS_DRIVER);
     for func in &mir.elaborated_mir {
         if func.name.contains("drive") || func.name.starts_with("__hew_fork_entry_") {
@@ -229,6 +231,91 @@ fn fork_string_arg_parent_and_shim_emit_no_drops_for_moved_arg() {
             }
         }
     }
+    let shim = mir
+        .raw_mir
+        .iter()
+        .find(|func| func.name.starts_with("__hew_fork_entry_"))
+        .expect("arg-bearing fork entry shim");
+    let inline_string_drops = shim
+        .blocks
+        .iter()
+        .flat_map(|block| block.instructions.iter())
+        .filter(|instr| {
+            matches!(
+                instr,
+                Instr::Drop {
+                    ty: hew_types::ResolvedTy::String,
+                    drop_fn: Some(hew_mir::DropFnSpec::Release("hew_string_drop")),
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(
+        inline_string_drops, 1,
+        "the shim must balance exactly one retain from its string env load"
+    );
+}
+
+#[test]
+fn fork_string_arg_spawn_env_owns_the_moved_field() {
+    let mir = lower_clean_to_mir(FORK_ARGS_DRIVER);
+    let ownership = mir
+        .raw_mir
+        .iter()
+        .flat_map(|func| &func.blocks)
+        .flat_map(|block| block.instructions.iter())
+        .find_map(|instr| match instr {
+            Instr::SpawnTaskClosure { env_ownership, .. } => Some(env_ownership),
+            _ => None,
+        })
+        .expect("arg-bearing fork must emit a spawn env ownership manifest");
+    assert_eq!(
+        ownership,
+        &[SpawnEnvFieldOwnership::OwnsMoved],
+        "the fork environment is the sole owner after the parent consumes its string"
+    );
+}
+
+#[test]
+fn spawned_closure_env_borrows_its_scope_owned_capture() {
+    let mir = lower_clean_to_mir(
+        r#"
+        actor _Driver {
+            receive fn drive() {
+                let greeting = "hello" + " world";
+                scope {
+                    (|| println(greeting))();
+                };
+            }
+        }
+
+        fn main() -> i64 {
+            let d = spawn _Driver;
+            d.drive();
+            0
+        }
+        "#,
+    );
+    let ownership = mir
+        .raw_mir
+        .iter()
+        .flat_map(|func| &func.blocks)
+        .flat_map(|block| block.instructions.iter())
+        .find_map(|instr| match instr {
+            Instr::SpawnTaskClosure { env_ownership, .. } if !env_ownership.is_empty() => {
+                Some(env_ownership)
+            }
+            _ => None,
+        })
+        .expect("spawned closure must emit a non-empty scope-owned environment manifest");
+    assert!(
+        ownership
+            .iter()
+            .all(|ownership| *ownership == SpawnEnvFieldOwnership::BorrowsOnly),
+        "scope-owned closure captures remain borrowed and must not receive an Rc payload drop: \
+         {ownership:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

A `fork { ... }` block capturing a heap-owned argument (e.g. a `string`) leaked it on every invocation: the scope-owned spawn environment carrying the moved argument was given a null drop function, so nothing ever released the capture. This gives the spawn environment a drop function, but only for its moved-owned captured arguments — borrowed closure environments carried through the same code path are left untouched, since giving those a drop would double-free memory the parent scope still owns. That borrowed-vs-moved distinction is what makes the fix safe: fork-call environments classify each field as `BitCopy` (borrowed) or owned (moved, currently only `string`), while closure environments are always all-borrowed and never receive a drop, exactly as before this change.

## Verification

- `cargo clippy -p hew-mir -p hew-codegen-rs`: clean
- `cargo test -p hew-mir`: full suite green (positive case — moved string field owns the drop; negative case — a scope-spawned closure capturing an owned string still emits an all-borrowed, drop-free manifest; shim balance — exactly one inline string drop, no double free)
- Native leak oracle (`leaks --atExit` + MallocScribble/PreScribble/GuardEdges, 100 iterations): leak count closes to zero, no double-free under the poisoned allocator
- `tests/vertical-slice/run.sh`: green, including the exact block-capture shape from this issue
- Borrowed closure-environment codegen path is byte-identical to before this change (still emits a null drop callback)

## Out of scope

- A dedicated runtime poisoned-allocator fixture for the scope-owned closure-capture (borrowed) case is left for a follow-up; the borrowed path is unchanged by this fix and is already covered by MIR- and structural-level negative tests.

Fixes #2494