### PR TITLE
fix(runtime): Deque.pop_front/pop_back trap on empty instead of returning 0

### DIFF
--- a/hew-runtime/src/vecdeque.rs
+++ b/hew-runtime/src/vecdeque.rs
@@ -4,12 +4,42 @@
 //! `#[no_mangle] extern "C"` functions so compiled Hew code can create
 //! and manipulate deques through the `std::deque` module.
 
+use crate::internal::types::HEW_TRAP_INDEX_OUT_OF_BOUNDS;
+use crate::trap_code::runtime_bounds_trap;
 use std::collections::VecDeque;
 
 /// Opaque handle to a `VecDeque<i64>`.
 #[derive(Debug)]
 pub struct HewDeque {
     inner: VecDeque<i64>,
+}
+
+/// Write a message to stderr.
+///
+/// # Safety
+///
+/// `msg` must be valid for reads for its full length.
+unsafe fn write_stderr(msg: &[u8]) {
+    // SAFETY: msg.as_ptr() is valid for msg.len() bytes, and fd 2 is stderr.
+    unsafe {
+        #[cfg(not(target_os = "windows"))]
+        libc::write(2, msg.as_ptr().cast(), msg.len());
+        #[cfg(target_os = "windows")]
+        libc::write(2, msg.as_ptr().cast(), msg.len() as core::ffi::c_uint);
+    }
+}
+
+/// Emit a deque empty-pop diagnostic and route through the trap seam.
+///
+/// # Safety
+///
+/// Call only from a fail-closed deque empty-pop path.
+unsafe fn deque_bounds_trap(message: &str) -> ! {
+    // SAFETY: writing the diagnostic and trapping is the terminal failure path.
+    unsafe {
+        write_stderr(message.as_bytes());
+        runtime_bounds_trap(HEW_TRAP_INDEX_OUT_OF_BOUNDS);
+    }
 }
 
 // ── Constructor ─────────────────────────────────────────────────────────
@@ -58,7 +88,11 @@ pub unsafe extern "C" fn hew_deque_push_back(dq: *mut HewDeque, value: i64) {
 
 // ── Pop ─────────────────────────────────────────────────────────────────
 
-/// Remove and return the front element.  Returns 0 if the deque is empty.
+/// Remove and return the front element.
+///
+/// Traps via [`deque_bounds_trap`] when the deque is empty (spec
+/// `pop_front() -> i64`: no `Option`, so the empty case fails closed like
+/// `Vec.pop()`/`bytes.pop()`).
 ///
 /// # Safety
 ///
@@ -69,10 +103,18 @@ pub unsafe extern "C" fn hew_deque_pop_front(dq: *mut HewDeque) -> i64 {
         return 0;
     }
     // SAFETY: Caller guarantees `dq` is valid.
-    unsafe { &mut *dq }.inner.pop_front().unwrap_or(0)
+    match unsafe { &mut *dq }.inner.pop_front() {
+        Some(value) => value,
+        // SAFETY: this is the terminal empty-pop path.
+        None => unsafe { deque_bounds_trap("PANIC: Deque.pop_front() on an empty deque\n") },
+    }
 }
 
-/// Remove and return the back element.  Returns 0 if the deque is empty.
+/// Remove and return the back element.
+///
+/// Traps via [`deque_bounds_trap`] when the deque is empty (spec
+/// `pop_back() -> i64`: no `Option`, so the empty case fails closed like
+/// `Vec.pop()`/`bytes.pop()`).
 ///
 /// # Safety
 ///
@@ -83,7 +125,11 @@ pub unsafe extern "C" fn hew_deque_pop_back(dq: *mut HewDeque) -> i64 {
         return 0;
     }
     // SAFETY: Caller guarantees `dq` is valid.
-    unsafe { &mut *dq }.inner.pop_back().unwrap_or(0)
+    match unsafe { &mut *dq }.inner.pop_back() {
+        Some(value) => value,
+        // SAFETY: this is the terminal empty-pop path.
+        None => unsafe { deque_bounds_trap("PANIC: Deque.pop_back() on an empty deque\n") },
+    }
 }
 
 // ── Query ───────────────────────────────────────────────────────────────
@@ -202,14 +248,89 @@ mod tests {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+    fn run_deque_death_helper(helper: &str) -> std::process::Output {
+        std::process::Command::new(std::env::current_exe().unwrap())
+            .args(["--exact", "--nocapture", helper])
+            .env("RUST_TEST_THREADS", "1")
+            .env("HEW_DEATH_TEST", helper)
+            .output()
+            .unwrap()
+    }
+
     #[test]
-    fn pop_empty_returns_zero() {
-        let dq = hew_deque_new();
-        // SAFETY: `dq` was just created above.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
+    fn test_deque_pop_front_empty_traps_main_context() {
+        let output = run_deque_death_helper("vecdeque::tests::_helper_deque_pop_front_empty");
+        assert!(
+            !output.status.success(),
+            "empty Deque.pop_front() must terminate without actor context"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("PANIC: Deque.pop_front() on an empty deque"),
+            "empty Deque.pop_front() must report the operation; got: {stderr}"
+        );
+        assert!(
+            stderr.contains("hew: trap in main context: IndexOutOfBounds"),
+            "empty Deque.pop_front() must route through the trap code; got: {stderr}"
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn _helper_deque_pop_front_empty() {
+        if std::env::var("HEW_DEATH_TEST").map_or(true, |value| {
+            value != "vecdeque::tests::_helper_deque_pop_front_empty"
+        }) {
+            return;
+        }
+        // SAFETY: FFI calls use a valid deque; the pop is intentionally empty.
         unsafe {
-            assert_eq!(hew_deque_pop_front(dq), 0);
-            assert_eq!(hew_deque_pop_back(dq), 0);
-            hew_deque_free(dq);
+            let dq = hew_deque_new();
+            let _ = hew_deque_pop_front(dq);
+        }
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg_attr(
+        miri,
+        ignore = "spawns a subprocess to observe abort(); Miri cannot posix_spawn"
+    )]
+    fn test_deque_pop_back_empty_traps_main_context() {
+        let output = run_deque_death_helper("vecdeque::tests::_helper_deque_pop_back_empty");
+        assert!(
+            !output.status.success(),
+            "empty Deque.pop_back() must terminate without actor context"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("PANIC: Deque.pop_back() on an empty deque"),
+            "empty Deque.pop_back() must report the operation; got: {stderr}"
+        );
+        assert!(
+            stderr.contains("hew: trap in main context: IndexOutOfBounds"),
+            "empty Deque.pop_back() must route through the trap code; got: {stderr}"
+        );
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn _helper_deque_pop_back_empty() {
+        if std::env::var("HEW_DEATH_TEST").map_or(true, |value| {
+            value != "vecdeque::tests::_helper_deque_pop_back_empty"
+        }) {
+            return;
+        }
+        // SAFETY: FFI calls use a valid deque; the pop is intentionally empty.
+        unsafe {
+            let dq = hew_deque_new();
+            let _ = hew_deque_pop_back(dq);
         }
     }
 

--- a/tests/fuzz-oracle/expected-failures.txt
+++ b/tests/fuzz-oracle/expected-failures.txt
@@ -21,7 +21,7 @@
 # map_literal_empty_annotated.hew, array_repeat_int_sum.hew, and
 # array_repeat_runtime_count.hew are intentionally absent: they must pass.
 #
-# Total: 26 known-failing entries (26 intentional-trap/abort fixtures).
+# Total: 28 known-failing entries (28 intentional-trap/abort fixtures).
 #
 # Intentional aborts/traps: fixtures in tests/vertical-slice/accept/ that are
 # designed to trap or abort at runtime as their correctness proof.  Listed here
@@ -39,6 +39,8 @@ string_index_oob_traps.hew   # intentional abort: out-of-bounds string index s[i
 vec_set_oob_traps.hew        # intentional abort: out-of-bounds Vec.set() calls libc::abort() → SIGABRT (signal 6)
 vec_pop_empty_traps.hew      # intentional abort: empty Vec.pop() calls libc::abort() → SIGABRT (signal 6)
 vec_remove_oob_traps.hew     # intentional abort: out-of-bounds Vec.remove() calls libc::abort() → SIGABRT (signal 6)
+deque_pop_front_empty_traps.hew  # intentional abort: empty Deque.pop_front() routes through runtime_bounds_trap → std::process::abort() (no main-context actor recovery frame) → SIGABRT (signal 6)
+deque_pop_back_empty_traps.hew   # intentional abort: empty Deque.pop_back() routes through runtime_bounds_trap → std::process::abort() (no main-context actor recovery frame) → SIGABRT (signal 6)
 # Arch-dependent trap signals: SIGILL (132) on x86_64 Linux, SIGTRAP (133) on aarch64/macOS.
 isize_div_by_zero_traps.hew  # intentional trap: isize / 0 → DivideByZero signal (SIGILL x86_64 / SIGTRAP aarch64)
 isize_shift_oob_traps.hew    # intentional trap: isize << 64 → ShiftOutOfRange signal (SIGILL x86_64 / SIGTRAP aarch64)

--- a/tests/vertical-slice/accept/deque_pop_back_empty_actor_isolated.hew
+++ b/tests/vertical-slice/accept/deque_pop_back_empty_actor_isolated.hew
@@ -1,0 +1,25 @@
+import std::deque;
+
+actor DequePopBackCrasher {
+    receive fn boom() {
+        let dq = deque.new();
+        let _ = dq.pop_back();
+    }
+}
+
+actor DequePopBackProbe {
+    receive fn ping() -> i64 {
+        0
+    }
+}
+
+fn main() -> i64 {
+    let crasher = spawn DequePopBackCrasher;
+    let probe = spawn DequePopBackProbe;
+    crasher.boom();
+    sleep(300ms);
+    match await probe.ping() {
+        Ok(v) => v,
+        Err(_) => 1,
+    }
+}

--- a/tests/vertical-slice/accept/deque_pop_back_empty_traps.hew
+++ b/tests/vertical-slice/accept/deque_pop_back_empty_traps.hew
@@ -1,0 +1,10 @@
+// `Deque.pop_back()` on an empty deque fails closed through the runtime
+// bounds trap. In main context there is no actor recovery frame, so the
+// runtime trap helper aborts the process and run.sh pins exit 134.
+import std::deque;
+
+fn main() -> i64 {
+    let dq = deque.new();
+    let x = dq.pop_back();
+    x
+}

--- a/tests/vertical-slice/accept/deque_pop_front_empty_actor_isolated.hew
+++ b/tests/vertical-slice/accept/deque_pop_front_empty_actor_isolated.hew
@@ -1,0 +1,25 @@
+import std::deque;
+
+actor DequePopFrontCrasher {
+    receive fn boom() {
+        let dq = deque.new();
+        let _ = dq.pop_front();
+    }
+}
+
+actor DequePopFrontProbe {
+    receive fn ping() -> i64 {
+        0
+    }
+}
+
+fn main() -> i64 {
+    let crasher = spawn DequePopFrontCrasher;
+    let probe = spawn DequePopFrontProbe;
+    crasher.boom();
+    sleep(300ms);
+    match await probe.ping() {
+        Ok(v) => v,
+        Err(_) => 1,
+    }
+}

--- a/tests/vertical-slice/accept/deque_pop_front_empty_traps.hew
+++ b/tests/vertical-slice/accept/deque_pop_front_empty_traps.hew
@@ -1,0 +1,10 @@
+// `Deque.pop_front()` on an empty deque fails closed through the runtime
+// bounds trap. In main context there is no actor recovery frame, so the
+// runtime trap helper aborts the process and run.sh pins exit 134.
+import std::deque;
+
+fn main() -> i64 {
+    let dq = deque.new();
+    let x = dq.pop_front();
+    x
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1812,6 +1812,14 @@ run_actor_bounds_trap_fixture \
   "string_slice_oob_actor_isolated" \
   "PANIC: string slice range 1..99 out of bounds (len 5)" \
   "StringSliceCrasher"
+run_actor_bounds_trap_fixture \
+  "deque_pop_front_empty_actor_isolated" \
+  "PANIC: Deque.pop_front() on an empty deque" \
+  "DequePopFrontCrasher"
+run_actor_bounds_trap_fixture \
+  "deque_pop_back_empty_actor_isolated" \
+  "PANIC: Deque.pop_back() on an empty deque" \
+  "DequePopBackCrasher"
 
 run_accept_expect_status "directory_module_call" 7
 

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1707,6 +1707,11 @@ run_accept_expect_status "vec_set_oob_traps" 134
 run_accept_expect_status "vec_pop_empty_traps" 134
 run_accept_expect_status "vec_remove_oob_traps" 134
 
+# Main-context Deque method bounds ratchets: same fail-closed contract as the
+# Vec pops above — no actor recovery frame, so the trap helper aborts.
+run_accept_expect_status "deque_pop_front_empty_traps" 134
+run_accept_expect_status "deque_pop_back_empty_traps" 134
+
 run_accept_expect_stdout "regex_captures_find_all"
 run_check_run_expect_stdout "stdlib_io_scanner_file_oracle"
 run_accept_expect_stdout "tls_ffi_result_lowering"


### PR DESCRIPTION
## Summary

`hew_deque_pop_front`/`hew_deque_pop_back` fabricated a `0` return value when the deque was empty, which is indistinguishable from a genuinely popped zero — a silent fail-open. Both now route the empty case through the shared runtime bounds-trap seam (`HEW_TRAP_INDEX_OUT_OF_BOUNDS`), matching the fail-closed pattern already shipped for `Vec.pop()`/`bytes.pop()`.

## Verification

- Rust subprocess death tests (`hew-runtime/src/vecdeque.rs`): assert the operation-specific panic diagnostic and the `IndexOutOfBounds` trap code.
- Compiled `.hew` vertical-slice fixtures: main-context empty pop pins exit 134 (SIGABRT via the bounds trap, no recovery frame); actor-isolation empty pop pins exit 0 with the panic diagnostic and crasher actor name on stderr, no main-context leak.
- Full vertical-slice harness: green, including all four new deque fixtures.

## Out of scope

- No changes to `Vec`/`bytes` pop semantics — those already trap correctly and are used here as the reference pattern.

Fixes #2342