### PR TITLE
fix(mir): release drop-elaboration leak tail (Option payload, while-let scrutinee, concat operand)

### DIFF
--- a/examples/v05/checked-mir/golden/actor_ask_race.raw.mir
+++ b/examples/v05/checked-mir/golden/actor_ask_race.raw.mir
@@ -348,6 +348,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(145)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/actor_counter_ask.raw.mir
+++ b/examples/v05/checked-mir/golden/actor_counter_ask.raw.mir
@@ -372,6 +372,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(153)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/actor_link_monitor.raw.mir
+++ b/examples/v05/checked-mir/golden/actor_link_monitor.raw.mir
@@ -326,6 +326,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(143)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/await_ask_deadline.raw.mir
+++ b/examples/v05/checked-mir/golden/await_ask_deadline.raw.mir
@@ -384,6 +384,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(144)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/bytes_ops.raw.mir
+++ b/examples/v05/checked-mir/golden/bytes_ops.raw.mir
@@ -415,6 +415,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(207)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/channel_auto_close_scope.raw.mir
+++ b/examples/v05/checked-mir/golden/channel_auto_close_scope.raw.mir
@@ -456,6 +456,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(191)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/channel_recv_select.raw.mir
+++ b/examples/v05/checked-mir/golden/channel_recv_select.raw.mir
@@ -577,6 +577,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(230)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/duplex_split_half_ops.raw.mir
+++ b/examples/v05/checked-mir/golden/duplex_split_half_ops.raw.mir
@@ -455,6 +455,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(179)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/duplex_unified_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/duplex_unified_recv.raw.mir
@@ -372,6 +372,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(157)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/escaped_sibling_field_drop.raw.mir
+++ b/examples/v05/checked-mir/golden/escaped_sibling_field_drop.raw.mir
@@ -327,6 +327,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(145)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/hashmap_keys_values.raw.mir
+++ b/examples/v05/checked-mir/golden/hashmap_keys_values.raw.mir
@@ -327,6 +327,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(150)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/hashmap_ops.raw.mir
+++ b/examples/v05/checked-mir/golden/hashmap_ops.raw.mir
@@ -522,6 +522,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(219)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/hashset_insert_managed_string_move.raw.mir
+++ b/examples/v05/checked-mir/golden/hashset_insert_managed_string_move.raw.mir
@@ -302,6 +302,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(138)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/hashset_ops.raw.mir
+++ b/examples/v05/checked-mir/golden/hashset_ops.raw.mir
@@ -442,6 +442,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(206)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/lambda_actor_lifecycle.raw.mir
+++ b/examples/v05/checked-mir/golden/lambda_actor_lifecycle.raw.mir
@@ -394,6 +394,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(156)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/match_skip_aggregate_field_drops.raw.mir
+++ b/examples/v05/checked-mir/golden/match_skip_aggregate_field_drops.raw.mir
@@ -453,6 +453,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(178)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/match_skip_drop_control_flow.raw.mir
+++ b/examples/v05/checked-mir/golden/match_skip_drop_control_flow.raw.mir
@@ -600,6 +600,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(215)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/match_skip_leaf_field_drops.raw.mir
+++ b/examples/v05/checked-mir/golden/match_skip_leaf_field_drops.raw.mir
@@ -512,6 +512,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(193)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/math_intrinsics.raw.mir
+++ b/examples/v05/checked-mir/golden/math_intrinsics.raw.mir
@@ -561,6 +561,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(241)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/metric_register_record.raw.mir
+++ b/examples/v05/checked-mir/golden/metric_register_record.raw.mir
@@ -734,6 +734,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(318)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/node_lookup_send.raw.mir
+++ b/examples/v05/checked-mir/golden/node_lookup_send.raw.mir
@@ -581,6 +581,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(204)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/option_result_predicates.raw.mir
+++ b/examples/v05/checked-mir/golden/option_result_predicates.raw.mir
@@ -638,6 +638,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(198)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/option_result_unwrap.raw.mir
+++ b/examples/v05/checked-mir/golden/option_result_unwrap.raw.mir
@@ -894,6 +894,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(259)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/regex_match_literal.raw.mir
+++ b/examples/v05/checked-mir/golden/regex_match_literal.raw.mir
@@ -919,6 +919,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(322)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/scope_fork_spawn.raw.mir
+++ b/examples/v05/checked-mir/golden/scope_fork_spawn.raw.mir
@@ -324,6 +324,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(136)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/scope_fork_spawn_generic.raw.mir
+++ b/examples/v05/checked-mir/golden/scope_fork_spawn_generic.raw.mir
@@ -385,6 +385,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(151)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/slice_annotation_alias.raw.mir
+++ b/examples/v05/checked-mir/golden/slice_annotation_alias.raw.mir
@@ -314,6 +314,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(143)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
@@ -2568,6 +2568,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(848)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -2629,6 +2629,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(867)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
@@ -2516,6 +2516,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(835)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/string_ops.raw.mir
+++ b/examples/v05/checked-mir/golden/string_ops.raw.mir
@@ -338,6 +338,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(156)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/string_sentinel_ops.raw.mir
+++ b/examples/v05/checked-mir/golden/string_sentinel_ops.raw.mir
@@ -515,6 +515,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(197)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/supervisor_await_restart.raw.mir
+++ b/examples/v05/checked-mir/golden/supervisor_await_restart.raw.mir
@@ -360,6 +360,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(139)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/supervisor_config_init.raw.mir
+++ b/examples/v05/checked-mir/golden/supervisor_config_init.raw.mir
@@ -334,6 +334,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(147)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/supervisor_stop.raw.mir
+++ b/examples/v05/checked-mir/golden/supervisor_stop.raw.mir
@@ -341,6 +341,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(139)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/user_fn_shadows_builtin_name.raw.mir
+++ b/examples/v05/checked-mir/golden/user_fn_shadows_builtin_name.raw.mir
@@ -323,6 +323,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(141)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/vec_descriptor_slice.raw.mir
+++ b/examples/v05/checked-mir/golden/vec_descriptor_slice.raw.mir
@@ -461,6 +461,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(177)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/vec_element_widths.raw.mir
+++ b/examples/v05/checked-mir/golden/vec_element_widths.raw.mir
@@ -640,6 +640,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(237)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/vec_owned_elems.raw.mir
+++ b/examples/v05/checked-mir/golden/vec_owned_elems.raw.mir
@@ -620,6 +620,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(242)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/examples/v05/checked-mir/golden/vec_scalar_ops.raw.mir
+++ b/examples/v05/checked-mir/golden/vec_scalar_ops.raw.mir
@@ -664,6 +664,7 @@ fn duration::fmt(duration) -> string [conv=default]
     stmt: return site=Some(SiteId(258)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
+    drop _2 ty=string fn=release(hew_string_drop)
     ret = move _4
     return
 

--- a/hew-cli/tests/discarded_owned_option_leak_oracle.rs
+++ b/hew-cli/tests/discarded_owned_option_leak_oracle.rs
@@ -1,0 +1,110 @@
+//! Leak and exactly-once guards for discarded caller-owned `Option<T>` results.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+fn discarded_remove_source(frames: usize) -> String {
+    format!(
+        "fn one() {{\n\
+         \x20   let m: HashMap<i64, string> = HashMap::new();\n\
+         \x20   m.insert(1, \"discard-remove\".to_upper());\n\
+         \x20   m.remove(1);\n\
+         }}\n\
+         fn main() {{\n\
+         \x20   for i in 0..{frames} {{ one(); }}\n\
+         }}\n"
+    )
+}
+
+fn wildcard_remove_source(frames: usize) -> String {
+    format!(
+        "fn one() {{\n\
+         \x20   let m: HashMap<i64, string> = HashMap::new();\n\
+         \x20   m.insert(1, \"wildcard-remove\".to_upper());\n\
+         \x20   let _ = m.remove(1);\n\
+         }}\n\
+         fn main() {{\n\
+         \x20   for i in 0..{frames} {{ one(); }}\n\
+         }}\n"
+    )
+}
+
+fn discarded_get_source(frames: usize) -> String {
+    format!(
+        "fn one() {{\n\
+         \x20   let m: HashMap<i64, string> = HashMap::new();\n\
+         \x20   m.insert(1, \"discard-get\".to_upper());\n\
+         \x20   m.get(1);\n\
+         }}\n\
+         fn main() {{\n\
+         \x20   for i in 0..{frames} {{ one(); }}\n\
+         }}\n"
+    )
+}
+
+fn none_control_source(frames: usize) -> String {
+    format!(
+        "fn one() {{\n\
+         \x20   let m: HashMap<i64, string> = HashMap::new();\n\
+         \x20   m.remove(1);\n\
+         }}\n\
+         fn main() {{\n\
+         \x20   for i in 0..{frames} {{ one(); }}\n\
+         }}\n"
+    )
+}
+
+const SCRIBBLE_SOURCE: &str = "\
+fn main() {\n\
+\x20   let m: HashMap<string, string> = HashMap::new();\n\
+\x20   m.insert(\"k\", \"still-owned\".to_upper());\n\
+\x20   m.get(\"k\");\n\
+\x20   print(m[\"k\"]);\n\
+}\n";
+
+#[test]
+fn discarded_hashmap_remove_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance("discarded_hashmap_remove", discarded_remove_source);
+}
+
+#[test]
+fn wildcard_hashmap_remove_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance("wildcard_hashmap_remove", wildcard_remove_source);
+}
+
+#[test]
+fn discarded_hashmap_get_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance("discarded_hashmap_get", discarded_get_source);
+}
+
+#[test]
+fn discarded_none_control_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance("discarded_none_control", none_control_source);
+}
+
+#[test]
+fn discarded_get_does_not_release_the_maps_copy() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("discarded-owned-option-scribble-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(SCRIBBLE_SOURCE, dir.path(), "discarded_get_scribble");
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "discarded get must release only its clone, not the map's live value:\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "STILL-OWNED",
+        "the map's copy must remain readable after the discarded clone is released"
+    );
+}

--- a/hew-cli/tests/nested_string_concat_temp_leak_oracle.rs
+++ b/hew-cli/tests/nested_string_concat_temp_leak_oracle.rs
@@ -66,6 +66,40 @@ fn nested_concat_no_record_source(frames: usize) -> String {
     )
 }
 
+fn terminator_produced_operand_source(frames: usize) -> String {
+    let expected = frames * 17;
+    format!(
+        "fn emit_full() -> i64 {{\n\
+         \x20   let full = \"left-\" + \"middle\".to_upper() + \"-right\";\n\
+         \x20   full.len()\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total = 0;\n\
+         \x20   for i in 0..{frames} {{ total = total + emit_full(); }}\n\
+         \x20   if total == {expected} {{ 0 }} else {{ 93 }}\n\
+         }}\n"
+    )
+}
+
+fn closure_returned_operand_source(frames: usize) -> String {
+    let expected = frames * 17;
+    format!(
+        "fn emit_full() -> i64 {{\n\
+         \x20   let middle = \"middle\";\n\
+         \x20   let compose = || {{\n\
+         \x20       let full = \"left-\" + middle.to_upper() + \"-right\";\n\
+         \x20       full.len()\n\
+         \x20   }};\n\
+         \x20   compose()\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total = 0;\n\
+         \x20   for i in 0..{frames} {{ total = total + emit_full(); }}\n\
+         \x20   if total == {expected} {{ 0 }} else {{ 94 }}\n\
+         }}\n"
+    )
+}
+
 fn assert_no_double_free(shape_name: &str, source: &str) {
     require_codegen();
 
@@ -108,6 +142,28 @@ fn nested_concat_without_record_has_no_per_iteration_leak_slope() {
 }
 
 #[test]
+fn terminator_produced_concat_operand_has_no_per_iteration_leak_slope() {
+    assert_frame_slope_below_tolerance_with(
+        "nested_concat_terminator_operand",
+        terminator_produced_operand_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+        SLOPE_TOLERANCE,
+    );
+}
+
+#[test]
+fn closure_returned_concat_operand_has_no_per_iteration_leak_slope() {
+    assert_frame_slope_below_tolerance_with(
+        "nested_concat_closure_operand",
+        closure_returned_operand_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+        SLOPE_TOLERANCE,
+    );
+}
+
+#[test]
 fn generic_record_repeat_field_freed_exactly_once_under_malloc_scribble() {
     assert_no_double_free(
         "generic_record_repeat_df",
@@ -120,5 +176,21 @@ fn nested_concat_without_record_freed_exactly_once_under_malloc_scribble() {
     assert_no_double_free(
         "nested_concat_no_record_df",
         &nested_concat_no_record_source(200),
+    );
+}
+
+#[test]
+fn terminator_produced_concat_operand_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free(
+        "nested_concat_terminator_operand_df",
+        &terminator_produced_operand_source(200),
+    );
+}
+
+#[test]
+fn closure_returned_concat_operand_freed_exactly_once_under_malloc_scribble() {
+    assert_no_double_free(
+        "nested_concat_closure_operand_df",
+        &closure_returned_operand_source(200),
     );
 }

--- a/hew-cli/tests/while_let_scrutinee_leak_oracle.rs
+++ b/hew-cli/tests/while_let_scrutinee_leak_oracle.rs
@@ -1,0 +1,103 @@
+//! Leak and exactly-once guards for from-call `while let` scrutinee owners.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+fn successful_iterations_source(frames: usize) -> String {
+    format!(
+        "fn next(i: i64, cap: i64) -> Result<string, string> {{\n\
+         \x20   if i < cap {{ Ok(\"while-let-ok\".to_upper()) }} else {{ Err(\"done\".to_upper()) }}\n\
+         }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var i = 0;\n\
+         \x20   var total = 0;\n\
+         \x20   while let Ok(value) = next(i, {frames}) {{\n\
+         \x20       total = total + value.len();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+fn final_false_source(frames: usize) -> String {
+    format!(
+        "fn next() -> Result<string, string> {{ Err(\"while-let-false\".to_upper()) }}\n\
+         fn one() {{\n\
+         \x20   while let Ok(value) = next() {{ print(value); }}\n\
+         }}\n\
+         fn main() {{\n\
+         \x20   for i in 0..{frames} {{ one(); }}\n\
+         }}\n"
+    )
+}
+
+const EXIT_EDGES_SCRIBBLE_SOURCE: &str = "\
+fn next(i: i64) -> Result<string, string> {\n\
+\x20   if i < 4 { Ok(\"edge-payload\".to_upper()) } else { Err(\"done\".to_upper()) }\n\
+}\n\
+\n\
+fn run_continue() {\n\
+\x20   var i = 0;\n\
+\x20   while let Ok(value) = next(i) {\n\
+\x20       i = i + 1;\n\
+\x20       if value.len() > 0 { continue; }\n\
+\x20   }\n\
+}\n\
+\n\
+fn run_break() {\n\
+\x20   var i = 0;\n\
+\x20   while let Ok(value) = next(i) {\n\
+\x20       if value.len() > 0 { break; }\n\
+\x20   }\n\
+}\n\
+\n\
+fn run_return() -> i64 {\n\
+\x20   while let Ok(value) = next(0) {\n\
+\x20       if value.len() > 0 { return 1; }\n\
+\x20   }\n\
+\x20   0\n\
+}\n\
+\n\
+fn main() {\n\
+\x20   run_continue();\n\
+\x20   run_break();\n\
+\x20   if run_return() == 1 { print(\"ok\"); }\n\
+}\n";
+
+#[test]
+fn while_let_successful_scrutinees_have_flat_leak_slope() {
+    assert_frame_slope_below_tolerance("while_let_success", successful_iterations_source);
+}
+
+#[test]
+fn while_let_final_false_scrutinee_has_flat_leak_slope() {
+    assert_frame_slope_below_tolerance("while_let_false", final_false_source);
+}
+
+#[test]
+fn while_let_break_continue_and_return_release_exactly_once() {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix("while-let-scrutinee-scribble-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(
+        EXIT_EDGES_SCRIBBLE_SOURCE,
+        dir.path(),
+        "while_let_exit_edges",
+    );
+    let output = run_under_malloc_scribble(&bin);
+    assert!(
+        output.status.success(),
+        "while-let edge cleanup must not double-free or read freed payloads:\n{}",
+        describe_output(&output)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "ok");
+}

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -38847,19 +38847,24 @@ fn is_hew_string_concat_runtime_call(call: &crate::model::RuntimeCall) -> bool {
     call.symbol() == "hew_string_concat"
 }
 
-fn is_fresh_string_concat_instr_def(def: NestedDefSite, blocks: &[BasicBlock], t: u32) -> bool {
-    let NestedDefSite::Instr { block, idx } = def else {
-        return false;
+fn is_fresh_string_producer_def(
+    def: NestedDefSite,
+    blocks: &[BasicBlock],
+    locals: &[ResolvedTy],
+    t: u32,
+) -> bool {
+    let dest = match def {
+        NestedDefSite::Instr { block, idx } => block_by_id(blocks, block)
+            .and_then(|b| b.instructions.get(idx))
+            .and_then(|instr| {
+                fresh_string_producer_dest(instr)
+                    .or_else(|| string_field_load_producer_dest(instr, locals))
+            }),
+        NestedDefSite::Term { block } => {
+            block_by_id(blocks, block).and_then(|b| fresh_string_producer_term_dest(&b.terminator))
+        }
     };
-    let Some(Instr::CallRuntimeAbi(call)) =
-        block_by_id(blocks, block).and_then(|b| b.instructions.get(idx))
-    else {
-        return false;
-    };
-    is_hew_string_concat_runtime_call(call)
-        && call.dest().and_then(base_local) == Some(t)
-        && crate::runtime_symbols::callee_ownership_contract(call.symbol())
-            .produces_fresh_owned_string()
+    dest.and_then(base_local) == Some(t)
 }
 
 fn is_borrowing_string_concat_instr_use(instr: &Instr, t: u32) -> bool {
@@ -39403,7 +39408,7 @@ fn nested_fresh_string_temp_drop(
             let ub = *ub;
             let use_instr = block_by_id(blocks, ub)?.instructions.get(*ui)?;
             let borrowing_use = is_borrowing_string_cmp_instr(use_instr, t)
-                || (is_fresh_string_concat_instr_def(def, blocks, t)
+                || (is_fresh_string_producer_def(def, blocks, locals, t)
                     && is_borrowing_string_concat_instr_use(use_instr, t));
             if !borrowing_use {
                 return None;
@@ -39513,6 +39518,16 @@ mod nested_fresh_string_temp_drop_admission {
         )
     }
 
+    fn fresh_string_call(callee: &str, dest: u32, next: u32) -> Terminator {
+        Terminator::Call {
+            callee: callee.to_string(),
+            builtin: None,
+            args: vec![Place::Local(0)],
+            dest: Some(Place::Local(dest)),
+            next,
+        }
+    }
+
     fn user_record_ty() -> ResolvedTy {
         ResolvedTy::named_user("Holder", vec![])
     }
@@ -39560,6 +39575,26 @@ mod nested_fresh_string_temp_drop_admission {
             "the first concat temp is a fresh owner used exactly once by the \
              second borrowing concat; it must be dropped immediately after that \
              use and only once"
+        );
+    }
+
+    #[test]
+    fn terminator_fresh_temp_gets_one_inline_drop_after_borrowing_concat_use() {
+        let blocks = vec![
+            block(
+                0,
+                vec![],
+                fresh_string_call("hew_string_to_uppercase", 2, 1),
+            ),
+            block(1, vec![concat(3, 2, 4)], Terminator::Return),
+        ];
+        let drops = collect(&blocks, &locals_with(&[]), &second_concat_binding());
+
+        assert_eq!(
+            drops,
+            vec![(1, 1, Place::Local(2), ResolvedTy::String)],
+            "a proven fresh terminator-produced operand used once by borrowing concat \
+             must be dropped immediately after that concat"
         );
     }
 

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -144,28 +144,22 @@ const SENTINEL_EXIT_KIND_TAG_BINDING: BindingId = BindingId(u32::MAX - 3);
 /// dedicated value keeps the pump self-contained and future-proof).
 const SENTINEL_RECV_GEN_COMPANION_BINDING: BindingId = BindingId(u32::MAX - 4);
 
-/// Base of the per-function synthetic binding-id range for FROM-CALL match
-/// scrutinee temps (#2429). `match f() { Ok(b) => …, Err(e) => {} }` consumes
-/// the callee's `Result`/`Option` return through an anonymous MIR temp; with
-/// no `BindingId` the temp is invisible to `build_lifo_drops` /
-/// `enumerate_exits`, so the arm-destructured payload was released on NO edge
-/// — one leaked payload per iteration of a `while … { match f() { … } }`
-/// read loop. Minting a synthetic owned binding over the temp routes it
-/// through the PROVEN let-bound discipline (enum-composite sole-owner prover,
-/// back-edge body-scope filter, return/cancel plans).
+/// Base of the per-function synthetic binding-id range for anonymous
+/// caller-owned temps. From-call match/while-let scrutinees and discarded
+/// caller-owned `Option<T>` results all materialise into MIR locals without a
+/// user binding; without a `BindingId` they are invisible to the ordinary
+/// sole-owner/drop-plan machinery.
 ///
-/// The range DESCENDS from here (`base`, `base - 1`, …), one id per from-call
-/// scrutinee in the function, so it can never collide with the fixed
+/// The range DESCENDS from here (`base`, `base - 1`, …), one id per anonymous
+/// owner in the function, so it can never collide with the fixed
 /// sentinels above (`u32::MAX ..= u32::MAX - 4`). Collision with real HIR
 /// binding ids would need a function with ~4.29 billion bindings — outside
 /// any representable source. If HIR ever exposes a per-function binding-id
 /// ceiling, mint above it instead and retire this reserved range.
-const SYNTHETIC_MATCH_SCRUTINEE_BINDING_BASE: u32 = u32::MAX - 64;
+const SYNTHETIC_OWNED_TEMP_BINDING_BASE: u32 = u32::MAX - 64;
 
-/// Diagnostic name for synthetic from-call match-scrutinee bindings. Never
-/// user-visible (no `-g` variable DIE is minted for it); shows up only in MIR
-/// dumps and drop-plan diagnostics.
-const SYNTHETIC_MATCH_SCRUTINEE_NAME: &str = "__hew_match_scrutinee";
+const SYNTHETIC_CALL_SCRUTINEE_NAME: &str = "__hew_call_scrutinee";
+const SYNTHETIC_DISCARDED_CALL_RESULT_NAME: &str = "__hew_discarded_call_result";
 
 /// Prefix of the synthetic for-iteration cursor binding minted by the HIR
 /// for-loop desugar (`hew-hir/src/lower.rs`, `lower_for_iter_desugar`:
@@ -9051,6 +9045,15 @@ struct LoopFrame {
     body_scope: ScopeId,
 }
 
+#[derive(Debug, Clone)]
+struct ActiveIterationOwner {
+    scope_depth: usize,
+    binding: BindingId,
+    name: String,
+    site: SiteId,
+    ty: ResolvedTy,
+}
+
 /// Accumulated lexical-scope facts for one HIR `ScopeId`, built incrementally
 /// while lowering a function body (see `Builder::scope_info`). `parent` is the
 /// enclosing scope (the frame below this one on `active_scopes` at first
@@ -9308,12 +9311,12 @@ struct Builder {
     /// initialiser. Cluster 1 reads the slot directly; later clusters add
     /// drop-cleanup and rebinding semantics.
     binding_locals: HashMap<BindingId, Place>,
-    /// Count of synthetic from-call match-scrutinee bindings minted so far in
-    /// this function (#2429). The next mint is
-    /// `BindingId(SYNTHETIC_MATCH_SCRUTINEE_BINDING_BASE - count)` — a
+    /// Count of anonymous caller-owned temp bindings minted so far in this
+    /// function. The next mint is
+    /// `BindingId(SYNTHETIC_OWNED_TEMP_BINDING_BASE - count)` — a
     /// descending per-function range that stays clear of both the fixed
     /// `u32::MAX ..= u32::MAX - 4` sentinels and real HIR binding ids.
-    synthetic_match_scrutinee_bindings: u32,
+    synthetic_owned_temp_bindings: u32,
     /// Per-function destructive-funcupdate base provenance. Maps a `BindingId`
     /// to whether `{ ..<binding>, f: new }` over it is a PROVEN unique owner of
     /// its heap fields — i.e. consuming it leaves no live alias, so the
@@ -9497,6 +9500,11 @@ struct Builder {
         u32,
         usize,
     )>,
+    /// Header-defined while-let scrutinee owners active while their body is
+    /// lowered. Break/continue edges consume these owners and record an
+    /// explicit edge drop; returns/panic/cancellation leave them Live so the
+    /// ordinary exit planner releases them.
+    active_iteration_owners: Vec<ActiveIterationOwner>,
     /// Map from each MIR-bound HIR `BindingId` to the HIR `ScopeId` it was
     /// declared in. Populated at every `MirStatement::Bind` push site (let
     /// statements, match-arm payload bindings, function parameters, for-range
@@ -9516,6 +9524,11 @@ struct Builder {
     /// drop set per-iteration and CFG-correct: outer-scope bindings keep their
     /// function-exit drop, inner-scope bindings get one drop per iteration.
     binding_scope: HashMap<BindingId, ScopeId>,
+    /// Scope facts for transient payload-binding locals whose `binding_locals`
+    /// entry is restored after a match-like body lowers. The enum sole-owner
+    /// prover still needs their real body lifetime to distinguish an in-body
+    /// handoff from an escape into a surviving outer binding.
+    transient_local_scopes: HashMap<u32, ScopeId>,
     /// gdb `-g` lexical-block scoping. Accumulates, per HIR `ScopeId` ever active
     /// while lowering this function's body, the scope's parent `ScopeId` (the
     /// scope directly below it on `active_scopes` when first observed) and the
@@ -9553,6 +9566,10 @@ struct Builder {
     /// / pass-by-value / first-iteration-uninit double-free corner cases are
     /// handled by the existing dataflow without bespoke logic.
     loop_back_edge_blocks: HashMap<u32, ScopeId>,
+    /// Goto-edge blocks that must release header-defined iteration owners.
+    /// Each binding is also marked consumed in the source block's statement
+    /// stream, so the target's later function exit cannot release it again.
+    iteration_owner_drop_blocks: HashMap<u32, Vec<BindingId>>,
     /// Diagnostics collected during MIR building (e.g., Unsupported HIR nodes).
     diagnostics: Vec<MirDiagnostic>,
     /// Per-function de-duplication for W3.029 user-aggregate value-class
@@ -10298,6 +10315,28 @@ impl Builder {
         });
     }
 
+    fn register_synthetic_owned_local(
+        &mut self,
+        name: &'static str,
+        site: SiteId,
+        local: u32,
+        ty: ResolvedTy,
+    ) -> BindingId {
+        let binding =
+            BindingId(SYNTHETIC_OWNED_TEMP_BINDING_BASE - self.synthetic_owned_temp_bindings);
+        self.synthetic_owned_temp_bindings += 1;
+        self.statements.push(MirStatement::Bind {
+            binding,
+            name: name.to_string(),
+            site,
+            ty: ty.clone(),
+        });
+        self.binding_locals.insert(binding, Place::Local(local));
+        self.record_binding_scope(binding);
+        self.register_owned_local(binding, name.to_string(), ty);
+        binding
+    }
+
     /// Register a `let`-bound field projection whose result is a byte-copy
     /// interior ALIAS of the still-live owner named by `provenance` — the
     /// [`ByteCopyAlias`](FieldLoadClass::ByteCopyAlias) class of the field-load
@@ -10351,13 +10390,13 @@ impl Builder {
     /// Registration alone never emits a drop: an escaping payload keeps
     /// today's leak-not-double-free posture because
     /// `derive_enum_composite_drop_allowed` still excludes the composite.
-    fn register_from_call_scrutinee_owner(&mut self, scrutinee: &HirExpr, scrutinee_local: u32) {
+    fn call_scrutinee_owned_ty(&self, scrutinee: &HirExpr) -> Option<ResolvedTy> {
         // Only the direct-call rvalue shape. A `BindingRef` scrutinee already
         // owns its slot through its own `let`/param registration — a second
         // owner over the same local would double-free — and every non-call
         // rvalue keeps its pre-fix posture (fail-closed).
         let HirExprKind::Call { callee, .. } = &scrutinee.kind else {
-            return;
+            return None;
         };
         // Recv-next / vec-string-iter-next scrutinees already carry their own
         // per-iteration release discipline (`Disposition::BodyEndReleased` on
@@ -10369,7 +10408,7 @@ impl Builder {
         if Self::is_recv_next_scrutinee(scrutinee)
             || self.is_vec_string_iter_next_scrutinee(scrutinee)
         {
-            return;
+            return None;
         }
         // Runtime-symbol / builtin producers have per-symbol ownership
         // contracts — an interior getter may hand back a BORROW of storage
@@ -10383,29 +10422,123 @@ impl Builder {
             if matches!(resolved, ResolvedRef::Builtin(_))
                 || crate::runtime_symbols::is_known_runtime_symbol(name)
             {
-                return;
+                return None;
             }
         }
         // Exactly the value class the `EnumInPlace` scope-exit machinery
         // owns; anything else keeps its pre-fix posture.
         let ty = self.subst_ty(&scrutinee.ty);
         if !ty_is_heap_owning_enum_composite(&ty, &self.record_field_orders, &self.enum_layouts) {
+            return None;
+        }
+        Some(ty)
+    }
+
+    fn register_from_call_scrutinee_owner(
+        &mut self,
+        scrutinee: &HirExpr,
+        scrutinee_local: u32,
+    ) -> Option<(BindingId, ResolvedTy)> {
+        let ty = self.call_scrutinee_owned_ty(scrutinee)?;
+        let binding = self.register_synthetic_owned_local(
+            SYNTHETIC_CALL_SCRUTINEE_NAME,
+            scrutinee.site,
+            scrutinee_local,
+            ty.clone(),
+        );
+        Some((binding, ty))
+    }
+
+    fn discarded_call_result_owned_ty(&self, expr: &HirExpr) -> Option<ResolvedTy> {
+        if let Some(ty) = self.call_scrutinee_owned_ty(expr) {
+            return Some(ty);
+        }
+        let HirExprKind::ResolvedImplCall {
+            target_symbol,
+            target_family,
+            ..
+        } = &expr.kind
+        else {
+            return None;
+        };
+        let caller_owned = matches!(
+            (target_family, target_symbol.as_str()),
+            (
+                hew_types::MethodTargetFamily::HashMap(hew_types::HashMapMethod::Get),
+                "hew_hashmap_get_layout"
+            ) | (
+                hew_types::MethodTargetFamily::HashMap(hew_types::HashMapMethod::Remove),
+                "hew_hashmap_remove_take_layout"
+            )
+        );
+        if !caller_owned {
+            return None;
+        }
+        let ty = self.subst_ty(&expr.ty);
+        ty_is_heap_owning_enum_composite(&ty, &self.record_field_orders, &self.enum_layouts)
+            .then_some(ty)
+    }
+
+    fn register_discarded_call_result_owner(&mut self, expr: &HirExpr, place: Place) {
+        let Some(ty) = self.discarded_call_result_owned_ty(expr) else {
+            return;
+        };
+        let Place::Local(local) = place else {
+            self.diagnostics.push(MirDiagnostic {
+                kind: MirDiagnosticKind::NotYetImplemented {
+                    construct: "discarded caller-owned result place shape".to_string(),
+                    site: expr.site,
+                },
+                note: format!(
+                    "a proven caller-owned discarded result must lower to Place::Local; got \
+                     {place:?}"
+                ),
+            });
+            return;
+        };
+        self.register_synthetic_owned_local(
+            SYNTHETIC_DISCARDED_CALL_RESULT_NAME,
+            expr.site,
+            local,
+            ty,
+        );
+    }
+
+    fn record_iteration_owner_drop(
+        &mut self,
+        binding: BindingId,
+        name: &str,
+        site: SiteId,
+        ty: &ResolvedTy,
+    ) {
+        let drops = self
+            .iteration_owner_drop_blocks
+            .entry(self.current_block_id)
+            .or_default();
+        if drops.contains(&binding) {
             return;
         }
-        let binding = BindingId(
-            SYNTHETIC_MATCH_SCRUTINEE_BINDING_BASE - self.synthetic_match_scrutinee_bindings,
-        );
-        self.synthetic_match_scrutinee_bindings += 1;
-        self.statements.push(MirStatement::Bind {
+        self.statements.push(MirStatement::Use {
             binding,
-            name: SYNTHETIC_MATCH_SCRUTINEE_NAME.to_string(),
-            site: scrutinee.site,
+            name: name.to_string(),
+            site,
             ty: ty.clone(),
+            intent: IntentKind::Consume,
         });
-        self.binding_locals
-            .insert(binding, Place::Local(scrutinee_local));
-        self.record_binding_scope(binding);
-        self.register_owned_local(binding, SYNTHETIC_MATCH_SCRUTINEE_NAME.to_string(), ty);
+        drops.push(binding);
+    }
+
+    fn record_active_iteration_owner_drops_for_exit_edge(&mut self, min_scope_depth: usize) {
+        let owners: Vec<ActiveIterationOwner> = self
+            .active_iteration_owners
+            .iter()
+            .rev()
+            .filter(|owner| owner.scope_depth >= min_scope_depth)
+            .cloned()
+            .collect();
+        for owner in owners {
+            self.record_iteration_owner_drop(owner.binding, &owner.name, owner.site, &owner.ty);
+        }
     }
 
     /// Provenance of a `let`-bound field projection that is a byte-copy interior
@@ -14100,7 +14233,9 @@ impl Builder {
             // (`apply_nested_fresh_string_temp_drops`), which splices one inline
             // `hew_string_drop` after the unused producer. No Vec-specific
             // handling is owed here.
-            self.lower_value(expr);
+            if let Some(place) = self.lower_value(expr) {
+                self.register_discarded_call_result_owner(expr, place);
+            }
         }
     }
 
@@ -17419,6 +17554,7 @@ impl Builder {
                 // Value before handle: the yielded buffer is inner heap, the
                 // handle owns the coro frame + heap companion (LIFO inner-first).
                 self.emit_generator_yield_value_drops_for_exit_edge(frame.scope_depth);
+                self.record_active_iteration_owner_drops_for_exit_edge(frame.scope_depth);
                 // Release in-loop generators on the break edge so the
                 // break-iteration's coro frame + heap companion are not leaked.
                 self.emit_generator_drops_for_break_continue(frame.scope_depth);
@@ -17481,6 +17617,7 @@ impl Builder {
                 // continue edge (the body-end drop is past the continue — would
                 // leak it). Value before handle (LIFO inner-first).
                 self.emit_generator_yield_value_drops_for_exit_edge(frame.scope_depth);
+                self.record_active_iteration_owner_drops_for_exit_edge(frame.scope_depth);
                 // Release in-loop generators on the continue edge so the
                 // skipped iteration's coro frame + heap companion are not leaked.
                 self.emit_generator_drops_for_break_continue(frame.scope_depth);
@@ -23033,6 +23170,8 @@ impl Builder {
                 return None;
             }
         };
+        let scrutinee_owner = self.register_from_call_scrutinee_owner(scrutinee, scrutinee_local);
+        let false_cleanup_bb = scrutinee_owner.as_ref().map(|_| self.alloc_block());
 
         // Load the variant tag into a fresh i64 local, mirroring
         // `lower_match_enum_tag`. `Place::EnumTag(local)` is the substrate
@@ -23060,7 +23199,7 @@ impl Builder {
         self.finish_current_block(Terminator::Branch {
             cond: cond_local,
             then_target: body_bb,
-            else_target: exit_bb,
+            else_target: false_cleanup_bb.unwrap_or(exit_bb),
         });
 
         // Body: bind payload fields, lower body, loop back to header.
@@ -23078,7 +23217,7 @@ impl Builder {
                 pvp,
                 scrutinee_local,
                 variant_idx,
-                exit_bb,
+                false_cleanup_bb.unwrap_or(exit_bb),
                 scrutinee.site,
                 &mut nested_binding_jobs,
             )?;
@@ -23112,6 +23251,9 @@ impl Builder {
                 },
             });
             let previous = self.binding_locals.insert(binding.binding, dest);
+            if let Some(local) = base_local(dest) {
+                self.transient_local_scopes.insert(local, body.scope);
+            }
             overwritten_bindings.push((binding.binding, previous));
         }
         for (src_local, src_variant_idx, binding) in nested_binding_jobs {
@@ -23140,6 +23282,9 @@ impl Builder {
                 },
             });
             let previous = self.binding_locals.insert(binding.binding, dest);
+            if let Some(local) = base_local(dest) {
+                self.transient_local_scopes.insert(local, body.scope);
+            }
             overwritten_bindings.push((binding.binding, previous));
         }
 
@@ -23153,6 +23298,16 @@ impl Builder {
             scope_depth: loop_scope_depth,
             body_scope: body.scope,
         });
+        let active_iteration_owner_mark = self.active_iteration_owners.len();
+        if let Some((binding, ty)) = &scrutinee_owner {
+            self.active_iteration_owners.push(ActiveIterationOwner {
+                scope_depth: self.active_scopes.len(),
+                binding: *binding,
+                name: SYNTHETIC_CALL_SCRUTINEE_NAME.to_string(),
+                site: scrutinee.site,
+                ty: ty.clone(),
+            });
+        }
         for stmt in &body.statements {
             self.stmt(stmt);
         }
@@ -23168,12 +23323,22 @@ impl Builder {
         // the generator release above (see `emit_scope_vec_iter_drops`).
         self.emit_scope_vec_iter_drops(body.scope);
         self.emit_scope_stream_drops(body.scope);
+        if let Some((binding, ty)) = &scrutinee_owner {
+            self.record_iteration_owner_drop(
+                *binding,
+                SYNTHETIC_CALL_SCRUTINEE_NAME,
+                scrutinee.site,
+                ty,
+            );
+        }
         // Record this block as a loop-body back-edge so `enumerate_exits`
         // populates its `Goto` `DropPlan` with per-iteration releases for
         // heap-owning bindings declared in `body.scope` (including the
         // match-arm payload bindings the `while let` itself introduces).
         self.loop_back_edge_blocks
             .insert(self.current_block_id, body.scope);
+        self.active_iteration_owners
+            .truncate(active_iteration_owner_mark);
         self.active_scopes.pop();
         self.loop_stack.pop();
         // Restore the prior `binding_locals` entries so the binding scope
@@ -23187,6 +23352,18 @@ impl Builder {
         }
 
         self.finish_current_block(Terminator::Goto { target: header_bb });
+
+        if let (Some(false_cleanup_bb), Some((binding, ty))) = (false_cleanup_bb, &scrutinee_owner)
+        {
+            self.start_block(false_cleanup_bb);
+            self.record_iteration_owner_drop(
+                *binding,
+                SYNTHETIC_CALL_SCRUTINEE_NAME,
+                scrutinee.site,
+                ty,
+            );
+            self.finish_current_block(Terminator::Goto { target: exit_bb });
+        }
 
         // Exit: subsequent lowering continues here.
         self.start_block(exit_bb);
@@ -35240,6 +35417,7 @@ fn elaborate(
         &owned_locals_snapshot,
         &builder.binding_locals,
         &builder.binding_scope,
+        &builder.transient_local_scopes,
         &builder.locals,
         &builder.record_field_orders,
         &builder.enum_layouts,
@@ -35659,6 +35837,26 @@ fn elaborate(
         &builder.loop_back_edge_blocks,
         &builder.locals,
     );
+
+    for (exit, plan) in &mut drop_plans {
+        let ExitPath::Goto { block, .. } = exit else {
+            continue;
+        };
+        let Some(bindings) = builder.iteration_owner_drop_blocks.get(block) else {
+            continue;
+        };
+        for binding in bindings {
+            let Some(place) = builder.binding_locals.get(binding) else {
+                continue;
+            };
+            if plan.drops.iter().any(|drop| drop.place == *place) {
+                continue;
+            }
+            if let Some(drop) = lifo_drops.iter().find(|drop| drop.place == *place) {
+                plan.drops.push(drop.clone());
+            }
+        }
+    }
 
     // #2395 decision 2 — append each suspend's escape-poisoned abandon-edge drops
     // (today: the `SuspendKind::StreamSend` in-flight value) to its
@@ -40489,6 +40687,7 @@ fn derive_enum_composite_drop_allowed(
     owned_locals: &[(BindingId, String, ResolvedTy)],
     binding_locals: &HashMap<BindingId, Place>,
     binding_scope: &HashMap<BindingId, ScopeId>,
+    transient_local_scopes: &HashMap<u32, ScopeId>,
     local_tys: &[ResolvedTy],
     record_field_orders: &HashMap<String, Vec<(String, ResolvedTy)>>,
     enum_layouts: &[crate::model::EnumLayout],
@@ -40541,7 +40740,7 @@ fn derive_enum_composite_drop_allowed(
     // outlive its surrounding statement and so can safely participate
     // in payload-binder chains without inflating the surviving-binding
     // set.
-    let local_scope: HashMap<u32, ScopeId> = binding_locals
+    let mut local_scope: HashMap<u32, ScopeId> = binding_locals
         .iter()
         .filter_map(|(binding, place)| {
             let local = base_local(*place)?;
@@ -40549,6 +40748,11 @@ fn derive_enum_composite_drop_allowed(
             Some((local, scope))
         })
         .collect();
+    local_scope.extend(
+        transient_local_scopes
+            .iter()
+            .map(|(local, scope)| (*local, *scope)),
+    );
 
     // Payload-binder set: destinations of `Move { dest, src: interior
     // projection of an alias-set local }` — the match/while-let destructure
@@ -51563,6 +51767,7 @@ mod enum_composite_field_drop_exemption {
             &HashMap::new(),
             &owned,
             &binding_locals,
+            &HashMap::new(),
             &HashMap::new(),
             &local_tys,
             &record_field_orders,

--- a/hew-mir/tests/lowering_expr.rs
+++ b/hew-mir/tests/lowering_expr.rs
@@ -2,6 +2,8 @@
 // Add new lowering_expr-behaviour tests under `tests/lowering_expr/`, wire them into this
 // file via #[path] — do not create a new top-level tests/*.rs file.
 
+#[path = "lowering_expr/anonymous_owned_temp_drop.rs"]
+mod anonymous_owned_temp_drop;
 #[path = "lowering_expr/binop_bitwise_logical.rs"]
 mod binop_bitwise_logical;
 #[path = "lowering_expr/bytes_literal_lowering.rs"]

--- a/hew-mir/tests/lowering_expr/anonymous_owned_temp_drop.rs
+++ b/hew-mir/tests/lowering_expr/anonymous_owned_temp_drop.rs
@@ -1,0 +1,196 @@
+//! Anonymous caller-owned result and while-let scrutinee drop regressions.
+
+use hew_mir::{DropKind, ElabDrop, ExitPath, IrPipeline, MirStatement};
+use hew_types::module_registry::ModuleRegistry;
+use hew_types::Checker;
+
+fn pipeline_with_tc(source: &str) -> IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:#?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    let output = hew_hir::lower_program(
+        &parsed.program,
+        &tc_output,
+        &hew_hir::ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    hew_mir::lower_hir_module(&output.module)
+}
+
+fn synthetic_binds(p: &IrPipeline, fn_name: &str, name: &str) -> usize {
+    p.raw_mir
+        .iter()
+        .find(|f| f.name == fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name} must be present"))
+        .blocks
+        .iter()
+        .flat_map(|b| b.statements.iter())
+        .filter(|stmt| matches!(stmt, MirStatement::Bind { name: n, .. } if n == name))
+        .count()
+}
+
+fn enum_drops(p: &IrPipeline, fn_name: &str, pred: impl Fn(&ExitPath) -> bool) -> Vec<ElabDrop> {
+    p.elaborated_mir
+        .iter()
+        .find(|f| f.name == fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name} must be present"))
+        .drop_plans
+        .iter()
+        .filter(|(exit, _)| pred(exit))
+        .flat_map(|(_, plan)| plan.drops.iter())
+        .filter(|drop| matches!(drop.kind, DropKind::EnumInPlace))
+        .cloned()
+        .collect()
+}
+
+#[test]
+fn discarded_owned_hashmap_results_get_one_synthetic_owner() {
+    let p = pipeline_with_tc(
+        r#"
+fn bare_remove() {
+    let m: HashMap<i64, string> = HashMap::new();
+    m.insert(1, "payload".to_upper());
+    m.remove(1);
+}
+
+fn wildcard_remove() {
+    let m: HashMap<i64, string> = HashMap::new();
+    m.insert(1, "payload".to_upper());
+    let _ = m.remove(1);
+}
+
+fn bare_get() {
+    let m: HashMap<i64, string> = HashMap::new();
+    m.insert(1, "payload".to_upper());
+    m.get(1);
+}
+
+fn scalar_control() {
+    let m: HashMap<i64, i64> = HashMap::new();
+    m.insert(1, 7);
+    m.remove(1);
+}
+"#,
+    );
+
+    for fn_name in ["bare_remove", "wildcard_remove", "bare_get"] {
+        assert_eq!(
+            synthetic_binds(&p, fn_name, "__hew_discarded_call_result"),
+            1,
+            "{fn_name} must expose exactly one synthetic owner in raw MIR"
+        );
+        assert_eq!(
+            enum_drops(&p, fn_name, |exit| matches!(exit, ExitPath::Return { .. })).len(),
+            1,
+            "{fn_name} must release the discarded owned Option exactly once"
+        );
+    }
+
+    assert_eq!(
+        synthetic_binds(&p, "scalar_control", "__hew_discarded_call_result"),
+        0,
+        "Option<i64> owns no heap and must not gain a synthetic drop owner"
+    );
+    assert!(
+        enum_drops(&p, "scalar_control", |_| true).is_empty(),
+        "the scalar control must not emit a bogus enum payload drop"
+    );
+}
+
+#[test]
+fn from_call_while_let_releases_each_iteration_and_final_false_scrutinee() {
+    let p = pipeline_with_tc(
+        r#"
+fn next(i: i64, cap: i64) -> Result<string, string> {
+    if i < cap {
+        Ok("payload".to_upper())
+    } else {
+        Err("done".to_upper())
+    }
+}
+
+fn run(cap: i64) -> i64 {
+    var i = 0;
+    var total = 0;
+    while let Ok(value) = next(i, cap) {
+        total = total + value.len();
+        i = i + 1;
+    }
+    total
+}
+"#,
+    );
+
+    assert_eq!(
+        synthetic_binds(&p, "run", "__hew_call_scrutinee"),
+        1,
+        "while-let must reuse the from-call synthetic scrutinee owner"
+    );
+    assert_eq!(
+        enum_drops(&p, "run", |exit| matches!(exit, ExitPath::Goto { .. })).len(),
+        2,
+        "while-let needs one drop on the body back-edge and one on the final false edge"
+    );
+    assert!(
+        enum_drops(&p, "run", |exit| matches!(exit, ExitPath::Return { .. })).is_empty(),
+        "the final false edge consumes the owner, so the later function return must not drop it again"
+    );
+}
+
+#[test]
+fn from_call_while_let_early_return_drops_in_flight_scrutinee() {
+    let p = pipeline_with_tc(
+        r#"
+fn next() -> Result<string, string> {
+    Ok("payload".to_upper())
+}
+
+fn run() -> i64 {
+    while let Ok(value) = next() {
+        if value.len() > 0 {
+            return 7;
+        }
+    }
+    0
+}
+"#,
+    );
+
+    assert_eq!(
+        enum_drops(&p, "run", |exit| matches!(exit, ExitPath::Return { .. })).len(),
+        1,
+        "an early return from the while-let body must release the current scrutinee exactly once"
+    );
+}
+
+#[test]
+fn escaping_while_let_payload_keeps_composite_fail_closed() {
+    let p = pipeline_with_tc(
+        r#"
+fn next() -> Result<string, string> {
+    Ok("payload".to_upper())
+}
+
+fn run() -> i64 {
+    var carry = "";
+    while let Ok(value) = next() {
+        carry = value;
+        break;
+    }
+    carry.len()
+}
+"#,
+    );
+
+    let drops = enum_drops(&p, "run", |_| true);
+    assert!(
+        drops.is_empty(),
+        "a payload moved into a surviving outer binding must keep the composite excluded; \
+         got {drops:?}"
+    );
+}

--- a/hew-mir/tests/lowering_expr/cstring_container_domain_canary.rs
+++ b/hew-mir/tests/lowering_expr/cstring_container_domain_canary.rs
@@ -160,6 +160,9 @@ fn vec_string_for_in_emits_retained_getter_with_iteration_drop() {
 
     let mut string_drops = Vec::new();
     for f in &pl.raw_mir {
+        if !matches!(f.source_origin, hew_mir::SourceOrigin::RootUnit) {
+            continue;
+        }
         for b in &f.blocks {
             for instr in &b.instructions {
                 if let Instr::Drop {
@@ -195,17 +198,19 @@ fn vec_string_for_in_emits_retained_getter_with_iteration_drop() {
 fn string_drop_count(pl: &IrPipeline) -> usize {
     let mut n = 0;
     for f in &pl.raw_mir {
-        // Each canary measures the drop balance of the construct under test,
-        // which always lives in a named helper fn (`transform`, `keep`, `pick`,
-        // `count`, …). `main` is pure test scaffolding that calls the helper and
-        // prints the result. A harness that wraps an `i64`-returning helper in a
+        // Each canary measures the drop balance of the root-unit construct under
+        // test, which always lives in a named helper fn (`transform`, `keep`,
+        // `pick`, `count`, …). Imported stdlib functions may independently gain
+        // legitimate drops as their own leak fixes land; they are not part of
+        // this container-domain count. `main` is pure test scaffolding that calls
+        // the helper and prints the result. A harness that wraps an `i64`-returning helper in a
         // bare single-interpolation f-string — `println(f"{count(v)}")` — now
         // earns its own legitimate inline `hew_string_drop` for the
         // `to_string_i64` result (the f-string interpolation leak fix). That
         // harness-side drop is correct but unrelated to the construct under test,
         // so counting it pipeline-wide would conflate two independent ownership
         // balances. Scope the count to the helper functions by skipping `main`.
-        if f.name == "main" {
+        if f.name == "main" || !matches!(f.source_origin, hew_mir::SourceOrigin::RootUnit) {
             continue;
         }
         for b in &f.blocks {

--- a/hew-mir/tests/lowering_expr/owned_string_temp_drop_canary.rs
+++ b/hew-mir/tests/lowering_expr/owned_string_temp_drop_canary.rs
@@ -473,3 +473,26 @@ fn canary7_fstring_interpolation_gen_yield_releases_conversion_temp() {
         "the conversion temp is a NESTED (unbound) shape, not a scope-exit-drop binding"
     );
 }
+
+#[test]
+fn terminator_produced_nested_concat_operand_releases_after_borrowing_concat() {
+    let pl = pipeline_with_tc(
+        r#"
+fn compose() -> i64 {
+    let full = "left-" + "middle".to_upper() + "-right";
+    full.len()
+}
+"#,
+    );
+    assert_no_nyi(&pl);
+    assert_eq!(
+        inline_string_drops(&pl, "compose"),
+        2,
+        "the function-returned operand and the first concat intermediate each need one inline drop"
+    );
+    assert_eq!(
+        return_exit_string_drops(&pl, "compose"),
+        1,
+        "the final bound concat result remains owned by the ordinary scope-exit path"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes three related drop-elaboration leaks in `hew-mir`'s ownership pass, all in the discarded-owner / anonymous-temp tail:

- A discarded `Option`-returning call's `Some` payload was never released — `let _ = map.remove(k)` (or a plain discard) leaked the extracted heap-owning enum composite instead of dropping it (#2443).
- A `while let` loop's header-scope scrutinee payload was not released on every iteration — only the final iteration's payload was cleaned up, leaking one allocation per successful loop pass (#2453).
- An owned string operand feeding a nested `hew_string_concat` chain was not released once consumed by the concat — each intermediate concatenation step leaked its operand (#2507).

The fix registers these anonymous/discarded owners in the correct scope (loop header vs. body) and threads them through the existing drop-elaboration machinery (`lifo_drops`, back-edge drops, `false_cleanup_bb`) so each is dropped exactly once — on every code path, including early return, `break`, and `continue`.

## Verification

- `cargo test -p hew-mir`: 331 passed / 0 failed.
- Three targeted leak oracles (discarded Option, while-let scrutinee, nested string-concat temp) under `MallocScribble`/`MallocPreScribble`/`MallocGuardEdges` plus `leaks --atExit`: all leak counts close to zero across low/high fixture variants.
- Anti-double-free checks under the poisoned allocator (`MallocScribble` abort/poison pins): discarded `HashMap` get does not corrupt the map's live copy, nested-concat operands are freed exactly once, and `while let` break/continue/return paths each release exactly once — no double-free introduced by any of the three fixes.
- `make test-hew-ratchet`: expected failures 0 / actual failures 0 — no fixture status change.
- `make ci-preflight` (compiler-pipeline profile: fmt, clippy, test-compiler-pipeline, test-vertical-slice, test-pkg-import, fuzz-oracle, await_e2e, leak-scan): all green.

## Out of scope

Nothing deliberately deferred — no follow-up issues filed. This closes out the known leak tail in this area.

Fixes #2443
Fixes #2453
Fixes #2507