### PR TITLE
fix(hir,types): make generic type-fragment mangling injective

### DIFF
--- a/hew-hir/src/mono/mangle.rs
+++ b/hew-hir/src/mono/mangle.rs
@@ -7,11 +7,10 @@
 //! name plus concrete type and const arguments, prefixed by a
 //! class-tag derived from [`SymbolClass`]:
 //!
-//! - [`SymbolClass::Function`] (empty class prefix): `<name>$$<args>`
-//!   — byte-identical to the legacy [`crate::monomorph::mangle`]
-//!   output for the same `(name, type_args)` input, and with empty
-//!   `const_args` produces no additional suffix. The legacy helper is
-//!   now a thin wrapper over this entry point.
+//! - [`SymbolClass::Function`] (empty class prefix): `<name>$$<args>`.
+//!   With empty `const_args` it produces no additional suffix. The
+//!   legacy helper is a thin wrapper over this entry point, so both
+//!   paths always use the same current type-fragment encoding.
 //! - All other [`SymbolClass`] variants prefix the symbol with
 //!   `<tag>$$` where `<tag>` is a short ASCII discriminator
 //!   (`mc` for machine, `ac` for actor, etc.). The prefix ensures two
@@ -31,8 +30,8 @@
 //! Per-`ResolvedTy` segment rendering is delegated to
 //! [`crate::monomorph::mangle_resolved_ty`], which the legacy
 //! [`crate::monomorph::mangle`] also uses — so individual type-arg
-//! fragments are byte-identical between the legacy and new paths by
-//! construction. Only the surrounding prefix/separator scheme is new.
+//! fragments are identical between the two paths by construction. Only
+//! the surrounding prefix/separator scheme differs by symbol class.
 
 use std::fmt::Write;
 

--- a/hew-hir/src/monomorph.rs
+++ b/hew-hir/src/monomorph.rs
@@ -92,10 +92,10 @@ pub struct MonomorphizedFn {
 /// `[a-zA-Z0-9_]`, so `$` cannot collide with any user-written Hew
 /// identifier. LLVM IR permits `$` in global symbol names.
 ///
-/// Type args are rendered via [`mangle_resolved_ty`], which uses `_`
-/// internally for nested args (e.g. `Vec_i64`) — the major/minor
-/// separator distinction (`$$` vs `$`) keeps top-level args
-/// unambiguously parseable.
+/// Type args are rendered via [`mangle_resolved_ty`]. Compound fragments use
+/// `$`-letter tokens (for example, `Vec$li64$g`) so their structure remains
+/// unambiguous while the top-level `$$` and `$` separators keep their existing
+/// meanings.
 #[must_use]
 pub fn mangle(origin_name: &str, type_args: &[ResolvedTy]) -> String {
     // Thin wrapper over the parametric `mangle_instantiation` helper.
@@ -226,12 +226,14 @@ pub fn shorten_named_arg_qualifiers(ty: ResolvedTy) -> ResolvedTy {
 
 /// Render a single `ResolvedTy` as a mangled fragment.
 ///
-/// Uses `_` as the nested separator so a top-level `$`-separated mangle
-/// can recover individual args by splitting on `$` alone. Returns names
-/// that are stable across runs (no hash, no monotonic counter). The
-/// rendering is structural and injective over the `ResolvedTy` variants
-/// (distinct types render to distinct fragments), so it is also the
-/// canonical key source for codegen-synthesised per-type thunks.
+/// Compound structure is encoded with `$`-letter tokens: `$l`/`$g` delimit
+/// named type arguments, `$x`/`$g` delimit structural compounds, `$c`
+/// separates list items, `$r` marks function returns, `$a` marks trait-object
+/// associated bindings, and `$m` replaces name qualifiers. Every token starts
+/// with `$`, which Hew identifiers cannot contain, so the rendering is
+/// structural and injective over the supported `ResolvedTy` identity
+/// dimensions. It is stable across runs (no hash or monotonic counter) and is
+/// the canonical key source for codegen-synthesised per-type thunks.
 #[must_use]
 pub fn mangle_resolved_ty(ty: &ResolvedTy) -> String {
     match ty {
@@ -255,82 +257,91 @@ pub fn mangle_resolved_ty(ty: &ResolvedTy) -> String {
         ResolvedTy::Duration => "duration".to_string(),
         ResolvedTy::Unit => "unit".to_string(),
         ResolvedTy::Never => "never".to_string(),
-        ResolvedTy::Tuple(items) => {
-            let mut out = String::from("tuple_");
-            for (i, item) in items.iter().enumerate() {
-                if i > 0 {
-                    out.push('_');
-                }
-                out.push_str(&mangle_resolved_ty(item));
-            }
-            out
-        }
-        ResolvedTy::Array(elem, n) => format!("array_{}_{}", mangle_resolved_ty(elem), n),
-        ResolvedTy::Slice(elem) => format!("slice_{}", mangle_resolved_ty(elem)),
-        ResolvedTy::Named { name, args, .. } => {
-            // Replace any `::` from module-qualified names with `_` to keep
-            // the symbol LLVM-clean.
-            let mut out = name.replace("::", "_");
-            for arg in args {
-                out.push('_');
-                out.push_str(&mangle_resolved_ty(arg));
-            }
-            out
-        }
-        ResolvedTy::Function { params, ret } => {
-            let mut out = String::from("fn_");
-            for p in params {
-                out.push_str(&mangle_resolved_ty(p));
-                out.push('_');
-            }
-            out.push_str("ret_");
-            out.push_str(&mangle_resolved_ty(ret));
-            out
-        }
-        ResolvedTy::Closure { params, ret, .. } => {
-            // Captures are not part of the call-type identity.
-            let mut out = String::from("closure_");
-            for p in params {
-                out.push_str(&mangle_resolved_ty(p));
-                out.push('_');
-            }
-            out.push_str("ret_");
-            out.push_str(&mangle_resolved_ty(ret));
-            out
-        }
+        ResolvedTy::Tuple(items) => mangle_compound("tuple", items),
+        ResolvedTy::Array(elem, n) => format!("array$x{}$c{n}$g", mangle_resolved_ty(elem)),
+        ResolvedTy::Slice(elem) => format!("slice$x{}$g", mangle_resolved_ty(elem)),
+        ResolvedTy::Named { name, args, .. } => mangle_named(name, args),
+        ResolvedTy::Function { params, ret } => mangle_function_like("fn", params, ret),
+        // Captures are not part of the call-type identity.
+        ResolvedTy::Closure { params, ret, .. } => mangle_function_like("closure", params, ret),
         ResolvedTy::Pointer {
             is_mutable,
             pointee,
         } => {
             if *is_mutable {
-                format!("ptrmut_{}", mangle_resolved_ty(pointee))
+                format!("ptrmut$x{}$g", mangle_resolved_ty(pointee))
             } else {
-                format!("ptr_{}", mangle_resolved_ty(pointee))
+                format!("ptr$x{}$g", mangle_resolved_ty(pointee))
             }
         }
-        ResolvedTy::Borrow { pointee } => {
-            format!("borrow_{}", mangle_resolved_ty(pointee))
-        }
-        ResolvedTy::TraitObject { traits } => {
-            let mut out = String::from("dyn_");
-            for (i, b) in traits.iter().enumerate() {
-                if i > 0 {
-                    out.push('_');
-                }
-                out.push_str(&b.trait_name.replace("::", "_"));
-                for a in &b.args {
-                    out.push('_');
-                    out.push_str(&mangle_resolved_ty(a));
-                }
-            }
-            out
-        }
-        ResolvedTy::Task(inner) => format!("task_{}", mangle_resolved_ty(inner)),
+        ResolvedTy::Borrow { pointee } => format!("borrow$x{}$g", mangle_resolved_ty(pointee)),
+        ResolvedTy::TraitObject { traits } => mangle_trait_object(traits),
+        ResolvedTy::Task(inner) => format!("task$x{}$g", mangle_resolved_ty(inner)),
         // A concrete monomorphisation never carries an abstract parameter in
         // its type-arg list, so this is not reached for a real instantiation.
         // It is mangled deterministically (and LLVM-clean) for totality.
-        ResolvedTy::TypeParam { name } => format!("typeparam_{}", name.replace("::", "_")),
+        ResolvedTy::TypeParam { name } => format!("typeparam$x{name}$g"),
     }
+}
+
+fn mangle_compound(head: &str, items: &[ResolvedTy]) -> String {
+    let mut out = format!("{head}$x");
+    append_type_list(&mut out, items);
+    out.push_str("$g");
+    out
+}
+
+fn mangle_named(name: &str, args: &[ResolvedTy]) -> String {
+    let mut out = mangle_qualified_name(name);
+    if !args.is_empty() {
+        out.push_str("$l");
+        append_type_list(&mut out, args);
+        out.push_str("$g");
+    }
+    out
+}
+
+fn mangle_function_like(head: &str, params: &[ResolvedTy], ret: &ResolvedTy) -> String {
+    let mut out = format!("{head}$x");
+    append_type_list(&mut out, params);
+    out.push_str("$r");
+    out.push_str(&mangle_resolved_ty(ret));
+    out.push_str("$g");
+    out
+}
+
+fn mangle_trait_object(traits: &[hew_types::ResolvedTraitBound]) -> String {
+    let mut out = String::from("dyn$x");
+    for (i, bound) in traits.iter().enumerate() {
+        if i > 0 {
+            out.push_str("$c");
+        }
+        out.push_str(&mangle_named(&bound.trait_name, &bound.args));
+        let mut assoc_bindings = bound.assoc_bindings.iter().collect::<Vec<_>>();
+        assoc_bindings.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+        for (name, ty) in assoc_bindings {
+            out.push_str("$a");
+            out.push_str(name);
+            out.push_str("$l");
+            out.push_str(&mangle_resolved_ty(ty));
+            out.push_str("$g");
+        }
+    }
+    out.push_str("$g");
+    out
+}
+
+fn append_type_list(out: &mut String, types: &[ResolvedTy]) {
+    for (i, ty) in types.iter().enumerate() {
+        if i > 0 {
+            out.push_str("$c");
+        }
+        out.push_str(&mangle_resolved_ty(ty));
+    }
+}
+
+fn mangle_qualified_name(name: &str) -> String {
+    name.replace("::", "$m").replace('.', "$m")
 }
 
 /// Insertion-ordered registry used during HIR lowering.
@@ -935,9 +946,9 @@ mod tests {
     }
 
     #[test]
-    fn mangle_module_qualified_strips_colons() {
+    fn mangle_module_qualified_encodes_colons() {
         let ty = ResolvedTy::named_user("widgets::Label", vec![]);
-        assert_eq!(mangle("describe", &[ty]), "describe$$widgets_Label");
+        assert_eq!(mangle("describe", &[ty]), "describe$$widgets$mLabel");
     }
 
     #[test]
@@ -1295,7 +1306,7 @@ mod tests {
         // byte form every codegen lookup probes.
         assert_eq!(
             mangle("Result", &[shortened]),
-            "Result$$Result_Vec_Foo_tuple_slice_Conn_array_Buf_4",
+            "Result$$Result$lVec$lFoo$g$ctuple$xslice$xConn$g$carray$xBuf$c4$g$g$g",
         );
     }
 
@@ -1332,7 +1343,7 @@ mod tests {
         );
         let entries = reg.into_vec();
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].mangled_name, "Option$$Vec_Foo");
+        assert_eq!(entries[0].mangled_name, "Option$$Vec$lFoo$g");
     }
 
     #[test]

--- a/hew-hir/tests/monomorphization.rs
+++ b/hew-hir/tests/monomorphization.rs
@@ -6,6 +6,8 @@
 mod layout_mono_pass;
 #[path = "monomorphization/machine_mono_pass.rs"]
 mod machine_mono_pass;
+#[path = "monomorphization/mangle_resolved_ty_segment_parity.rs"]
+mod mangle_resolved_ty_segment_parity;
 #[path = "monomorphization/mangle_resolved_ty_test.rs"]
 mod mangle_resolved_ty_test;
 #[path = "monomorphization/mono_foundation_byte_compat.rs"]

--- a/hew-hir/tests/monomorphization.rs
+++ b/hew-hir/tests/monomorphization.rs
@@ -6,6 +6,8 @@
 mod layout_mono_pass;
 #[path = "monomorphization/machine_mono_pass.rs"]
 mod machine_mono_pass;
+#[path = "monomorphization/mangle_resolved_ty_test.rs"]
+mod mangle_resolved_ty_test;
 #[path = "monomorphization/mono_foundation_byte_compat.rs"]
 mod mono_foundation_byte_compat;
 #[path = "monomorphization/monomorph_call_type_args_boundary.rs"]

--- a/hew-hir/tests/monomorphization/mangle_resolved_ty_segment_parity.rs
+++ b/hew-hir/tests/monomorphization/mangle_resolved_ty_segment_parity.rs
@@ -1,0 +1,149 @@
+//! Cross-crate parity pin: `hew_types::resolved_ty::mangle_resolved_ty_segment`
+//! MUST render byte-identical output to
+//! `hew_hir::monomorph::mangle_resolved_ty` for every concrete `ResolvedTy`.
+//!
+//! The two encoders can't share code — `hew-types` cannot depend on
+//! `hew-hir` (that would be circular) — so their doc comments are the only
+//! thing declaring the sync invariant. This test is what actually enforces
+//! it: a change to one scheme without a matching change to the other fails
+//! here.
+//!
+//! Regression this guards: the `$`-token mangling scheme
+//! (`hew-hir/src/monomorph.rs::mangle_resolved_ty`) updated the HIR-side
+//! encoder but left `mangle_resolved_ty_segment` on the old `_`-join scheme.
+//! Leaf args (`Wrapper<i64>`) and literal names happened to agree under both
+//! schemes, so the desync was invisible until a COMPOUND-NESTED type arg
+//! (`Wrapper<Boxx<i64>>`) diverged — see
+//! `tests/hew/generic_mangling_compound_nested_impl_test.hew` for the
+//! compiled-and-run reproduction of the resulting dispatch failure.
+
+use std::collections::HashSet;
+
+use hew_hir::mangle_resolved_ty;
+use hew_types::resolved_ty::mangle_resolved_ty_segment;
+use hew_types::{ResolvedTraitBound, ResolvedTy};
+
+fn named(name: &str, args: Vec<ResolvedTy>) -> ResolvedTy {
+    ResolvedTy::named_user(name, args)
+}
+
+/// Assert the two encoders agree for a concrete (`TypeParam`-free) type.
+fn assert_parity(ty: &ResolvedTy) {
+    let hir_mangled = mangle_resolved_ty(ty);
+    let types_mangled = mangle_resolved_ty_segment(ty);
+    assert_eq!(
+        types_mangled.as_deref(),
+        Some(hir_mangled.as_str()),
+        "mangle_resolved_ty_segment desynced from mangle_resolved_ty for {ty:?}: \
+         hew-types produced {types_mangled:?}, hew-hir produced {hir_mangled:?}"
+    );
+}
+
+#[test]
+fn leaf_scalar_matches() {
+    assert_parity(&ResolvedTy::I64);
+    assert_parity(&ResolvedTy::String);
+    assert_parity(&ResolvedTy::Bool);
+}
+
+#[test]
+fn single_generic_named_matches() {
+    // Foo<i64>
+    assert_parity(&named("Foo", vec![ResolvedTy::I64]));
+}
+
+#[test]
+fn literal_named_matches() {
+    // Foo_i64 (a type literally named this way, distinct from Foo<i64>)
+    assert_parity(&named("Foo_i64", vec![]));
+}
+
+#[test]
+fn compound_nested_named_matches() {
+    // impl Describe for Wrapper<Boxx<i64>> / Wrapper<Boxx<string>> — the
+    // exact shape that regressed (BLOCK verdict, issue #2485).
+    let boxx_i64 = named("Boxx", vec![ResolvedTy::I64]);
+    assert_parity(&named("Wrapper", vec![boxx_i64]));
+
+    let boxx_string = named("Boxx", vec![ResolvedTy::String]);
+    assert_parity(&named("Wrapper", vec![boxx_string]));
+}
+
+#[test]
+fn named_with_tuple_arg_matches() {
+    // Vec<(string, i64)>
+    let tuple = ResolvedTy::Tuple(vec![ResolvedTy::String, ResolvedTy::I64]);
+    assert_parity(&named("Vec", vec![tuple]));
+}
+
+#[test]
+fn qualified_name_separator_matches() {
+    assert_parity(&named("a::b", vec![]));
+    assert_parity(&named("a.b", vec![]));
+}
+
+#[test]
+fn family_of_concrete_nested_types_stays_in_lockstep() {
+    for ty in concrete_type_family(2) {
+        assert_parity(&ty);
+    }
+}
+
+/// Same shape as `mangle_resolved_ty_test.rs::type_family`, but seeded
+/// without `TypeParam`: `mangle_resolved_ty_segment` intentionally diverges
+/// (returns `None`) for abstract type parameters — see its doc comment — so
+/// `TypeParam`-bearing shapes are out of scope for this parity pin, which
+/// covers only the concrete-type contract the two encoders must share.
+fn concrete_type_family(depth: usize) -> Vec<ResolvedTy> {
+    let mut types = vec![
+        ResolvedTy::I64,
+        ResolvedTy::Bool,
+        ResolvedTy::String,
+        named("Leaf", vec![]),
+    ];
+
+    for _ in 0..depth {
+        let previous = types.clone();
+        for ty in previous {
+            types.extend([
+                named("Box", vec![ty.clone()]),
+                named("Pair", vec![ty.clone(), ResolvedTy::Bool]),
+                ResolvedTy::Tuple(vec![ty.clone(), ResolvedTy::String]),
+                ResolvedTy::Array(Box::new(ty.clone()), 3),
+                ResolvedTy::Slice(Box::new(ty.clone())),
+                ResolvedTy::Function {
+                    params: vec![ty.clone(), ResolvedTy::Bool],
+                    ret: Box::new(ResolvedTy::String),
+                },
+                ResolvedTy::Closure {
+                    params: vec![ty.clone()],
+                    ret: Box::new(ResolvedTy::Bool),
+                    captures: vec![],
+                },
+                ResolvedTy::Pointer {
+                    is_mutable: false,
+                    pointee: Box::new(ty.clone()),
+                },
+                ResolvedTy::Pointer {
+                    is_mutable: true,
+                    pointee: Box::new(ty.clone()),
+                },
+                ResolvedTy::Borrow {
+                    pointee: Box::new(ty.clone()),
+                },
+                ResolvedTy::TraitObject {
+                    traits: vec![ResolvedTraitBound {
+                        trait_name: "Iterator".to_string(),
+                        args: vec![ty.clone()],
+                        assoc_bindings: vec![("Item".to_string(), ty.clone())],
+                    }],
+                },
+                ResolvedTy::Task(Box::new(ty)),
+            ]);
+        }
+    }
+
+    let mut unique = HashSet::with_capacity(types.len());
+    types.retain(|ty| unique.insert(ty.clone()));
+    types
+}

--- a/hew-hir/tests/monomorphization/mangle_resolved_ty_test.rs
+++ b/hew-hir/tests/monomorphization/mangle_resolved_ty_test.rs
@@ -1,0 +1,143 @@
+use std::collections::HashSet;
+
+use hew_hir::{mangle_dotted_name, mangle_resolved_ty};
+use hew_types::{ResolvedTraitBound, ResolvedTy};
+
+fn named(name: &str, args: Vec<ResolvedTy>) -> ResolvedTy {
+    ResolvedTy::named_user(name, args)
+}
+
+#[test]
+fn nested_type_fragments_distinguish_former_collision_pairs() {
+    let foo_i64 = named("Foo", vec![ResolvedTy::I64]);
+    let literal_foo_i64 = named("Foo_i64", vec![]);
+    assert_eq!(mangle_resolved_ty(&foo_i64), "Foo$li64$g");
+    assert_eq!(mangle_resolved_ty(&literal_foo_i64), "Foo_i64");
+    assert_ne!(
+        mangle_resolved_ty(&foo_i64),
+        mangle_resolved_ty(&literal_foo_i64)
+    );
+
+    let pair = named("Pair", vec![named("A", vec![]), named("B", vec![])]);
+    let nested = named("Foo", vec![named("A", vec![named("B", vec![])])]);
+    assert_ne!(mangle_resolved_ty(&pair), mangle_resolved_ty(&nested));
+
+    let option_foo_i64 = named("Option", vec![foo_i64]);
+    let option_literal_foo_i64 = named("Option", vec![literal_foo_i64]);
+    assert_ne!(
+        mangle_resolved_ty(&option_foo_i64),
+        mangle_resolved_ty(&option_literal_foo_i64)
+    );
+
+    let tuple = ResolvedTy::Tuple(vec![named("a", vec![]), named("b", vec![])]);
+    let literal_tuple = named("tuple_a_b", vec![]);
+    assert_ne!(
+        mangle_resolved_ty(&tuple),
+        mangle_resolved_ty(&literal_tuple)
+    );
+
+    assert_ne!(
+        mangle_resolved_ty(&named("a::b", vec![])),
+        mangle_resolved_ty(&named("a_b", vec![]))
+    );
+
+    let iterator_i64 = ResolvedTy::TraitObject {
+        traits: vec![ResolvedTraitBound {
+            trait_name: "Iterator".to_string(),
+            args: vec![],
+            assoc_bindings: vec![("Item".to_string(), ResolvedTy::I64)],
+        }],
+    };
+    let iterator_string = ResolvedTy::TraitObject {
+        traits: vec![ResolvedTraitBound {
+            trait_name: "Iterator".to_string(),
+            args: vec![],
+            assoc_bindings: vec![("Item".to_string(), ResolvedTy::String)],
+        }],
+    };
+    assert_ne!(
+        mangle_resolved_ty(&iterator_i64),
+        mangle_resolved_ty(&iterator_string)
+    );
+}
+
+#[test]
+fn type_fragments_are_injective_and_safe_through_depth_three() {
+    let types = type_family(3);
+    let mut fragments = HashSet::with_capacity(types.len());
+
+    for ty in types {
+        let fragment = mangle_resolved_ty(&ty);
+        assert!(
+            fragments.insert(fragment.clone()),
+            "fragment collision for {ty:?}: {fragment}"
+        );
+        assert!(!fragment.contains("$$"), "fragment has $$: {fragment}");
+        assert!(
+            !fragment.starts_with('$') && !fragment.ends_with('$'),
+            "fragment has unsafe boundary: {fragment}"
+        );
+        assert_eq!(
+            mangle_dotted_name(&fragment),
+            fragment,
+            "fragment contains a literal dot"
+        );
+    }
+}
+
+fn type_family(depth: usize) -> Vec<ResolvedTy> {
+    let mut types = vec![
+        ResolvedTy::I64,
+        ResolvedTy::Bool,
+        ResolvedTy::String,
+        named("Leaf", vec![]),
+        ResolvedTy::TypeParam {
+            name: "T".to_string(),
+        },
+    ];
+
+    for _ in 0..depth {
+        let previous = types.clone();
+        for ty in previous {
+            types.extend([
+                named("Box", vec![ty.clone()]),
+                named("Pair", vec![ty.clone(), ResolvedTy::Bool]),
+                ResolvedTy::Tuple(vec![ty.clone(), ResolvedTy::String]),
+                ResolvedTy::Array(Box::new(ty.clone()), 3),
+                ResolvedTy::Slice(Box::new(ty.clone())),
+                ResolvedTy::Function {
+                    params: vec![ty.clone(), ResolvedTy::Bool],
+                    ret: Box::new(ResolvedTy::String),
+                },
+                ResolvedTy::Closure {
+                    params: vec![ty.clone()],
+                    ret: Box::new(ResolvedTy::Bool),
+                    captures: vec![],
+                },
+                ResolvedTy::Pointer {
+                    is_mutable: false,
+                    pointee: Box::new(ty.clone()),
+                },
+                ResolvedTy::Pointer {
+                    is_mutable: true,
+                    pointee: Box::new(ty.clone()),
+                },
+                ResolvedTy::Borrow {
+                    pointee: Box::new(ty.clone()),
+                },
+                ResolvedTy::TraitObject {
+                    traits: vec![ResolvedTraitBound {
+                        trait_name: "Iterator".to_string(),
+                        args: vec![ty.clone()],
+                        assoc_bindings: vec![("Item".to_string(), ty.clone())],
+                    }],
+                },
+                ResolvedTy::Task(Box::new(ty)),
+            ]);
+        }
+    }
+
+    let mut unique = HashSet::with_capacity(types.len());
+    types.retain(|ty| unique.insert(ty.clone()));
+    types
+}

--- a/hew-hir/tests/monomorphization/type_mono_registry_test.rs
+++ b/hew-hir/tests/monomorphization/type_mono_registry_test.rs
@@ -299,8 +299,8 @@ fn generic_in_generic_box_vec_int_produces_one_entry_for_box_only() {
     // replaced by `Vec<i64>`.
     assert_eq!(layouts[0].fields, vec![("value".to_string(), expected_arg)]);
 
-    // Mangling round-trips the nested arg: `Box$$Vec_i64`.
-    assert_eq!(layouts[0].mangled_name, "Box$$Vec_i64");
+    // Mangling round-trips the nested arg: `Box$$Vec$li64$g`.
+    assert_eq!(layouts[0].mangled_name, "Box$$Vec$li64$g");
 }
 
 /// (e) Plan test E: diverging polymorphic instantiation fires

--- a/hew-types/src/resolved_ty.rs
+++ b/hew-types/src/resolved_ty.rs
@@ -745,14 +745,19 @@ impl fmt::Display for UserFacingResolvedTy<'_> {
 //
 // The mangle format matches `hew-hir::monomorph::mangle` for
 // `SymbolClass::Function`: `"{origin}$$" + args joined by "$"`, where each
-// arg is its canonical string segment (primitives → their keyword, named
-// types → their bare name, compounds → recursively rendered).
+// arg is rendered via the `$`-token scheme documented on
+// `mangle_resolved_ty_segment` below — the same scheme
+// `hew-hir::monomorph::mangle_resolved_ty` uses.
 //
 // These helpers live in `hew-types` (not `hew-hir`) because `hew-types` does
 // not depend on `hew-hir` and the checker must compute mangled keys without
 // introducing a circular dependency. `hew-hir` calls its own `mangle()` entry
 // point over `ResolvedTy` values; both produce byte-identical output for the
-// inputs that a concrete specialised impl target can carry.
+// inputs that a concrete specialised impl target can carry. The two encoders
+// are kept in lockstep ONLY by doc comments plus the cross-crate parity test
+// in `hew-hir/tests/monomorphization/mangle_resolved_ty_segment_parity.rs` —
+// there is no shared code path, so any change to one MUST be mirrored in the
+// other.
 //
 // Scope: only concrete specialised impls ever produce mangled keys here.
 // Generic impls (`impl<T> Trait for Wrapper<T>`) and impls with no target type
@@ -763,13 +768,20 @@ impl fmt::Display for UserFacingResolvedTy<'_> {
 
 /// Render a single `ResolvedTy` as the canonical mangle segment used by
 /// `hew-hir::monomorph::mangle_resolved_ty`. Returns `None` for shapes that
-/// cannot be embedded (inference variables, error placeholders, abstract
-/// type-parameter references).
+/// cannot be embedded (inference variables, abstract type-parameter
+/// references) — those never appear in a concrete specialised impl's target
+/// type args, so `None` signals the caller to fall back to the bare
+/// (unmangled) key. Every other shape is concrete and always renders `Some`.
 ///
-/// The output for every concrete type matches `hew-hir`'s rendering
-/// byte-for-byte: scalar keywords (`i64`, `string`, …), named types by their
-/// bare name (compound args separated by `_`), and compound shapes recursively.
-/// This function must be kept in sync with `hew-hir/src/monomorph.rs::mangle_resolved_ty`.
+/// For every concrete shape this matches `hew-hir`'s rendering byte-for-byte:
+/// scalar keywords (`i64`, `string`, …); `Named` as `name$l a1 $c a2 $g`
+/// (`::`/`.` name qualifiers → `$m`, argument list omitted entirely when
+/// empty); structural compounds (`Tuple`/`Array`/`Slice`/`Function`/
+/// `Closure`/`Pointer`/`Borrow`/`TraitObject`/`Task`) as `head$x...$g` with
+/// `$c` list separators and `$r` marking a function/closure return. This
+/// function MUST be kept in lockstep with
+/// `hew-hir/src/monomorph.rs::mangle_resolved_ty` — see the module comment
+/// above for why the two can't share code.
 #[must_use]
 pub fn mangle_resolved_ty_segment(ty: &ResolvedTy) -> Option<String> {
     match ty {
@@ -793,29 +805,107 @@ pub fn mangle_resolved_ty_segment(ty: &ResolvedTy) -> Option<String> {
         ResolvedTy::Duration => Some("duration".to_string()),
         ResolvedTy::Unit => Some("unit".to_string()),
         ResolvedTy::Never => Some("never".to_string()),
-        ResolvedTy::Named { name, args, .. } => {
-            // Bare name, args joined by `_` — mirrors the HIR rendering.
-            let mut out = name.replace("::", "_");
-            for arg in args {
-                out.push('_');
-                out.push_str(&mangle_resolved_ty_segment(arg)?);
-            }
-            Some(out)
+        ResolvedTy::Tuple(items) => Some(format!("tuple$x{}$g", mangle_type_list_segment(items)?)),
+        ResolvedTy::Array(elem, n) => {
+            let elem_seg = mangle_resolved_ty_segment(elem)?;
+            Some(format!("array$x{elem_seg}$c{n}$g"))
         }
-        // Abstract type parameters, inference leftovers, and complex shapes
-        // (closures, tuples, pointers, …) produce None — callers fall back to
-        // the bare key, preserving existing behaviour.
-        ResolvedTy::TypeParam { .. }
-        | ResolvedTy::Tuple(_)
-        | ResolvedTy::Array(_, _)
-        | ResolvedTy::Slice(_)
-        | ResolvedTy::Function { .. }
-        | ResolvedTy::Closure { .. }
-        | ResolvedTy::Pointer { .. }
-        | ResolvedTy::Borrow { .. }
-        | ResolvedTy::TraitObject { .. }
-        | ResolvedTy::Task(_) => None,
+        ResolvedTy::Slice(elem) => {
+            let elem_seg = mangle_resolved_ty_segment(elem)?;
+            Some(format!("slice$x{elem_seg}$g"))
+        }
+        ResolvedTy::Named { name, args, .. } => mangle_named_segment(name, args),
+        ResolvedTy::Function { params, ret } => mangle_function_like_segment("fn", params, ret),
+        // Captures are not part of the call-type identity — mirrors
+        // `hew-hir::monomorph::mangle_resolved_ty`.
+        ResolvedTy::Closure { params, ret, .. } => {
+            mangle_function_like_segment("closure", params, ret)
+        }
+        ResolvedTy::Pointer {
+            is_mutable,
+            pointee,
+        } => {
+            let seg = mangle_resolved_ty_segment(pointee)?;
+            Some(if *is_mutable {
+                format!("ptrmut$x{seg}$g")
+            } else {
+                format!("ptr$x{seg}$g")
+            })
+        }
+        ResolvedTy::Borrow { pointee } => {
+            let seg = mangle_resolved_ty_segment(pointee)?;
+            Some(format!("borrow$x{seg}$g"))
+        }
+        ResolvedTy::TraitObject { traits } => mangle_trait_object_segment(traits),
+        ResolvedTy::Task(inner) => {
+            let seg = mangle_resolved_ty_segment(inner)?;
+            Some(format!("task$x{seg}$g"))
+        }
+        // Abstract type parameters never appear in a concrete specialised
+        // impl's target type args (a generic impl target carries `TypeParam`
+        // only before instantiation) — `None` signals the caller to fall
+        // back to the bare key, preserving existing behaviour.
+        ResolvedTy::TypeParam { .. } => None,
     }
+}
+
+/// Render a `$c`-separated list of segments — mirrors
+/// `hew-hir::monomorph::append_type_list`.
+fn mangle_type_list_segment(types: &[ResolvedTy]) -> Option<String> {
+    let mut out = String::new();
+    for (i, ty) in types.iter().enumerate() {
+        if i > 0 {
+            out.push_str("$c");
+        }
+        out.push_str(&mangle_resolved_ty_segment(ty)?);
+    }
+    Some(out)
+}
+
+/// Render a `Named` segment — mirrors `hew-hir::monomorph::mangle_named`.
+fn mangle_named_segment(name: &str, args: &[ResolvedTy]) -> Option<String> {
+    let mut out = name.replace("::", "$m").replace('.', "$m");
+    if !args.is_empty() {
+        out.push_str("$l");
+        out.push_str(&mangle_type_list_segment(args)?);
+        out.push_str("$g");
+    }
+    Some(out)
+}
+
+/// Render a `Function`/`Closure` segment — mirrors
+/// `hew-hir::monomorph::mangle_function_like`.
+fn mangle_function_like_segment(
+    head: &str,
+    params: &[ResolvedTy],
+    ret: &ResolvedTy,
+) -> Option<String> {
+    let params_seg = mangle_type_list_segment(params)?;
+    let ret_seg = mangle_resolved_ty_segment(ret)?;
+    Some(format!("{head}$x{params_seg}$r{ret_seg}$g"))
+}
+
+/// Render a `TraitObject` segment — mirrors
+/// `hew-hir::monomorph::mangle_trait_object`.
+fn mangle_trait_object_segment(traits: &[ResolvedTraitBound]) -> Option<String> {
+    let mut out = String::from("dyn$x");
+    for (i, bound) in traits.iter().enumerate() {
+        if i > 0 {
+            out.push_str("$c");
+        }
+        out.push_str(&mangle_named_segment(&bound.trait_name, &bound.args)?);
+        let mut assoc_bindings = bound.assoc_bindings.iter().collect::<Vec<_>>();
+        assoc_bindings.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+        for (name, ty) in assoc_bindings {
+            out.push_str("$a");
+            out.push_str(name);
+            out.push_str("$l");
+            out.push_str(&mangle_resolved_ty_segment(ty)?);
+            out.push_str("$g");
+        }
+    }
+    out.push_str("$g");
+    Some(out)
 }
 
 /// Produce the mangled self-type name for a concrete specialised impl.
@@ -827,8 +917,9 @@ pub fn mangle_resolved_ty_segment(ty: &ResolvedTy) -> Option<String> {
 /// bare `name`.
 ///
 /// The produced name matches `hew-hir::monomorph::mangle(name, type_args)` for
-/// `SymbolClass::Function` — both omit a class prefix and join args with `$$`
-/// + `$` separators.
+/// `SymbolClass::Function` — both omit a class prefix and join args with a
+/// `$$` then `$` separator, with each arg itself rendered via
+/// [`mangle_resolved_ty_segment`].
 #[must_use]
 pub fn mangle_impl_self_name(name: &str, type_args: &[ResolvedTy]) -> Option<String> {
     if type_args.is_empty() {

--- a/tests/hew/generic_mangling_compound_nested_impl_test.hew
+++ b/tests/hew/generic_mangling_compound_nested_impl_test.hew
@@ -1,0 +1,36 @@
+//! Concrete specialised impls over a COMPOUND-NESTED type arg
+//! (`Wrapper<Boxx<i64>>` vs `Wrapper<Boxx<string>>`). The checker registers
+//! the impl method under `hew_types::mangle_impl_self_name`; HIR emits the
+//! call symbol under `hew_hir::monomorph::mangle`. The two manglers must
+//! agree byte-for-byte or method dispatch resolves to the wrong symbol (or
+//! no symbol at all). A LEAF type arg (`Wrapper<i64>`) already exercises
+//! this seam, but the two schemes agreed for leaf args even when desynced —
+//! only a nested compound arg (`Boxx<i64>` inside `Wrapper<...>`) exposes a
+//! divergence between the two encoders.
+
+import std::testing;
+
+trait Describe {
+    fn describe(val: Self) -> i64;
+}
+
+type Boxx<T> { inner: T; }
+type Wrapper<T> { payload: T; }
+
+impl Describe for Wrapper<Boxx<i64>> {
+    fn describe(w: Wrapper<Boxx<i64>>) -> i64 { 111 }
+}
+
+impl Describe for Wrapper<Boxx<string>> {
+    fn describe(w: Wrapper<Boxx<string>>) -> i64 { 222 }
+}
+
+#[test]
+fn test_compound_nested_specialised_impl_dispatches_to_matching_arm() {
+    let a = Wrapper<Boxx<i64>> { payload: Boxx { inner: 1 } };
+    let b = Wrapper<Boxx<string>> { payload: Boxx { inner: "x" } };
+
+    testing.assert_eq(a.describe(), 111);
+    testing.assert_eq(b.describe(), 222);
+    println("VALUES-OK generic-mangling-compound-nested");
+}

--- a/tests/hew/generic_mangling_enum_collision_test.hew
+++ b/tests/hew/generic_mangling_enum_collision_test.hew
@@ -1,0 +1,24 @@
+//! `Option<Foo<i64>>` and `Option<Foo_i64>` used to collapse to one enum
+//! layout key. Matching both payloads proves their independent layouts and
+//! payload fields survive lowering.
+
+import std::testing;
+
+type Foo<T> { value: T; }
+type Foo_i64 { value: i64; }
+
+#[test]
+fn test_generic_mangle_keeps_option_payload_layouts_distinct() {
+    let generic: Option<Foo<i64>> = Some(Foo { value: 41 });
+    let literal: Option<Foo_i64> = Some(Foo_i64 { value: 73 });
+
+    match generic {
+        Some(value) => testing.assert_eq(value.value, 41),
+        None => testing.assert_true(false),
+    }
+    match literal {
+        Some(value) => testing.assert_eq(value.value, 73),
+        None => testing.assert_true(false),
+    }
+    println("VALUES-OK generic-mangling-enum");
+}

--- a/tests/hew/generic_mangling_fn_collision_test.hew
+++ b/tests/hew/generic_mangling_fn_collision_test.hew
@@ -1,0 +1,21 @@
+//! The generic instantiation `Foo<i64>` and literal type `Foo_i64` used to
+//! share the `Foo_i64` type fragment, causing `through<T>` specializations to
+//! collide. Both values must retain their independent fields after distinct
+//! monomorphizations are emitted.
+
+import std::testing;
+
+type Foo<T> { value: T; }
+type Foo_i64 { value: i64; }
+
+fn through<T>(value: T) -> T { value }
+
+#[test]
+fn test_generic_mangle_keeps_literal_and_generic_specializations_distinct() {
+    let generic = through(Foo { value: 17 });
+    let literal = through(Foo_i64 { value: 29 });
+
+    testing.assert_eq(generic.value, 17);
+    testing.assert_eq(literal.value, 29);
+    println("VALUES-OK generic-mangling-fn");
+}


### PR DESCRIPTION
## Summary

Generic type-fragment mangling was not injective. `mangle_resolved_ty` joined nested type-argument names with a bare `_` and no shape marker, so a type literally named `Foo_i64` and the generic instantiation `Foo<i64>` both mangled to the same symbol (`worker$$Foo_i64`) and were treated as one function before any dedup ran — silently dispatching the wrong monomorphisation with no crash or diagnostic. Nested type arguments now use an unambiguous `$`-token scheme (`Foo<i64>` → `Foo$li64$g`) that encodes shape, so structurally distinct instantiations can never alias.

The checker keys concrete specialised-impl methods with a second, independent encoder (`hew-types`'s `mangle_resolved_ty_segment`, consumed by `mangle_impl_self_name`) that must render byte-for-byte identically to the HIR mangler — the two crates cannot depend on each other, so they are kept in sync only by contract. That segment mangler was left on the old `_`-join scheme when the HIR side moved to the token scheme. Leaf args mangled identically so it went unnoticed, but a compound-nested arg like `Wrapper<Boxx<i64>>` diverged (`Wrapper$$Boxx_i64` vs `Wrapper$$Boxx$li64$g`) and made specialised-impl method dispatch miss with `IndirectCallUnsupported`/`UnresolvedSymbol`. I rewrote the segment mangler to mirror every `ResolvedTy` arm byte-for-byte and added a cross-crate parity test so the two encoders can never silently desync again.

## Verification

- Cross-crate parity test (`mangle_resolved_ty_segment_parity`, 7/7): passes, and bites — reverting a single arm to the old `_`-join fails it with a clear desync assertion.
- Injectivity property test (`mangle_resolved_ty_test`, depth-3 HashSet distinctness): passes.
- Compound-nested regression (`generic_mangling_compound_nested_impl_test.hew`): concrete specialised impls over `Wrapper<Boxx<i64>>` and `Wrapper<Boxx<string>>` now dispatch to the correct method, asserting exact 111/222.
- Collision regressions (`generic_mangling_enum_collision_test.hew`, `generic_mangling_fn_collision_test.hew`): `Option<Foo<i64>>` vs `Option<Foo_i64>` payload layouts and `through<T>` specialisations stay distinct.
- `make test-hew-ratchet`: full compiled `.hew` suite green, 0 failures.

## Out of scope

- Reserving primitive/structural type names (a user `type i64` still renders the primitive fragment `i64`): pre-existing, tracked in #2520.
- No golden `.ll` regeneration: leaf-arg mangling is byte-identical under the new scheme, so the oracle corpus does not re-mangle.

Fixes #2485