### PR TITLE
fix(runtime): resolve parked network awaits to Cancelled on shutdown

### DIFF
--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -3068,6 +3068,11 @@ operations, converting a plain suspend into a timed suspend that returns
 | `await ln.accept()` | `net.Connection` |
 | `await ln.accept() \| after d` | `Result<net.Connection, IoError>` |
 
+If explicit runtime shutdown begins while a deadline-form read or accept is
+already parked, it resumes as `Err(NetError::Cancelled(0))`. Its own deadline
+still reports `Err(NetError::TimedOut(_))`. Plain forms have no `Result` error
+surface and retain their existing fail-closed empty/invalid value behaviour.
+
 Use inside a `scope` body to bound how long a handler waits for a peer:
 
 <!-- doctest: skip -->

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -1466,7 +1466,7 @@ pub(crate) struct CoroState<'ctx> {
 pub(crate) struct FnCtx<'a, 'ctx> {
     pub(crate) ctx: &'ctx Context,
     pub(crate) llvm_mod: &'a LlvmModule<'ctx>,
-    /// Emit `hew_shutdown_initiate(0)` + `hew_shutdown_wait()` before the
+    /// Emit `hew_shutdown_initiate_implicit(0)` + `hew_shutdown_wait()` before the
     /// `Terminator::Return` in the native program entry point of an
     /// actor-using program — the implicit actor-drain floor.
     ///
@@ -1494,7 +1494,8 @@ pub(crate) struct FnCtx<'a, 'ctx> {
     /// `true` ONLY when ALL of: `func.name == "main"`, the module has at least
     /// one actor layout, the target is wasm32 (`emit_wasm_entry_alias`), and
     /// there are no supervisors. The native epilogue uses a thread-backed
-    /// `hew_shutdown_initiate`/`_wait`; on the wasm32 cooperative scheduler
+    /// `hew_shutdown_initiate_implicit`/`hew_shutdown_wait`; on the wasm32
+    /// cooperative scheduler
     /// that has no driver, the standalone-WASM runtime-exit helper runs all
     /// runnable actors to completion synchronously and then performs scheduler
     /// shutdown plus actor cleanup. Without it the mailbox never drains and
@@ -2578,7 +2579,7 @@ pub(crate) fn intern_runtime_decl<'ctx>(
         // down scheduler state, and runs the runtime cleanup chain before WASI
         // process return. WASI has no runtime-owned atexit hook to fill this gap.
         "hew_wasm_runtime_exit" => ctx.void_type().fn_type(&[], false),
-        // hew_shutdown_initiate(drain_timeout_ms: i64) -> void
+        // hew_shutdown_initiate{,_implicit}(drain_timeout_ms: i64) -> void
         // (`hew-runtime/src/shutdown.rs:183`). Non-blocking — sets the
         // shutdown phase to QUIESCE and spawns an orchestrator thread that
         // drains remaining actor messages then calls `hew_sched_shutdown`.
@@ -2587,14 +2588,15 @@ pub(crate) fn intern_runtime_decl<'ctx>(
         // Safe to call on an uninitialized scheduler: `drain_is_idle()`
         // returns `true` immediately when no scheduler is present, so the
         // orchestrator completes in ~20 ms (two idle polls at 10 ms each).
-        // Used by the implicit main-exit drain epilogue (codegen-emitted).
-        "hew_shutdown_initiate" => ctx.void_type().fn_type(&[i64_ty.into()], false),
+        "hew_shutdown_initiate" | "hew_shutdown_initiate_implicit" => {
+            ctx.void_type().fn_type(&[i64_ty.into()], false)
+        }
         // hew_shutdown_wait() -> i32
         // (`hew-runtime/src/shutdown.rs:231`). Blocks until `PHASE_DONE`
         // (returns 0). Returns -1 if shutdown was never initiated and -2
         // if the shutdown worker panicked. Paired with
-        // `hew_shutdown_initiate`; emitted by the implicit main-exit drain
-        // epilogue immediately after the initiate call (codegen-emitted).
+        // either initiate entry point; emitted by the implicit main-exit drain
+        // epilogue immediately after its implicit initiate call.
         "hew_shutdown_wait" => i32_ty.fn_type(&[], false),
         // hew_duplex_pair(s_cap: usize, r_cap: usize,
         //                 out_a: *mut *mut HewDuplexHandle,
@@ -32067,7 +32069,7 @@ fn lower_terminator<'ctx>(
     fn_ctx.suspend_abandon_block.set(block_id);
     match term {
         Terminator::Return => {
-            // Implicit actor-drain floor: emit `hew_shutdown_initiate(0)` then
+            // Implicit actor-drain floor: emit `hew_shutdown_initiate_implicit(0)` then
             // `hew_shutdown_wait()` before `main` returns. This ensures
             // fire-and-forget actor messages (spawned actors, pending handler
             // calls) are fully processed before the process exits. Without this,
@@ -32086,7 +32088,7 @@ fn lower_terminator<'ctx>(
                     fn_ctx.ctx,
                     fn_ctx.llvm_mod,
                     &mut fn_ctx.runtime_decls.borrow_mut(),
-                    "hew_shutdown_initiate",
+                    "hew_shutdown_initiate_implicit",
                 )?;
                 let shutdown_wait = intern_runtime_decl(
                     fn_ctx.ctx,
@@ -32104,9 +32106,9 @@ fn lower_terminator<'ctx>(
                     .build_call(
                         shutdown_initiate,
                         &[i64_ty.const_int(0, false).into()],
-                        "hew_shutdown_initiate_call",
+                        "hew_shutdown_initiate_implicit_call",
                     )
-                    .llvm_ctx("hew_shutdown_initiate call")?;
+                    .llvm_ctx("hew_shutdown_initiate_implicit call")?;
                 fn_ctx
                     .builder
                     .build_call(shutdown_wait, &[], "hew_shutdown_wait_call")
@@ -53588,7 +53590,7 @@ mod tests {
 
     // ── Actor-drain epilogue gate tests ──────────────────────────────────────
     //
-    // These tests verify that `hew_shutdown_initiate` / `hew_shutdown_wait`
+    // These tests verify that `hew_shutdown_initiate_implicit` / `hew_shutdown_wait`
     // appear in `main`'s LLVM IR exactly when expected: native actor-using
     // programs (gate = on), non-actor programs (gate = off), and non-`main`
     // functions even in actor programs (gate = off).
@@ -53688,7 +53690,7 @@ mod tests {
     }
 
     /// For a native actor-using program, the `main` function's IR must contain
-    /// `hew_shutdown_initiate` and `hew_shutdown_wait` calls immediately before
+    /// `hew_shutdown_initiate_implicit` and `hew_shutdown_wait` calls immediately before
     /// the return.  These are the implicit actor-drain floor that prevents
     /// fire-and-forget messages from being silently dropped when `main` returns
     /// before scheduler workers finish draining.
@@ -53704,8 +53706,8 @@ mod tests {
         );
         let ir = m.print_to_string().to_string();
         assert!(
-            ir.contains("hew_shutdown_initiate"),
-            "actor-using main must emit hew_shutdown_initiate call before return:\n{ir}"
+            ir.contains("hew_shutdown_initiate_implicit"),
+            "actor-using main must emit hew_shutdown_initiate_implicit call before return:\n{ir}"
         );
         assert!(
             ir.contains("hew_shutdown_wait"),
@@ -53763,8 +53765,8 @@ mod tests {
         );
         let ir = m.print_to_string().to_string();
         assert!(
-            !ir.contains("hew_shutdown_initiate"),
-            "non-actor main must NOT emit hew_shutdown_initiate:\n{ir}"
+            !ir.contains("hew_shutdown_initiate_implicit"),
+            "non-actor main must NOT emit hew_shutdown_initiate_implicit:\n{ir}"
         );
         assert!(
             !ir.contains("hew_shutdown_wait"),

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -31031,8 +31031,45 @@ pub(crate) fn emit_read_deadline_timeout_err(
     emit_result_err(fn_ctx, result_dest, error_dest)
 }
 
-/// Emit `Err(TimeoutError::Timeout)` into `result_dest` for the
-/// `await rx.recv() | after d` / `await stream.recv() | after d` timeout arm
+/// Emit `Err(NetError::Cancelled(0))` into `result_dest` for the shutdown-cancel
+/// arm of a suspending `await … | after d` accept/read arbiter. The typed
+/// counterpart of [`emit_read_deadline_timeout_err`]: a runtime shutdown sweep
+/// deposits `AwaitCancelStatus::Cancelled` on a parked wait, and the arbiter
+/// routes that to `NetError::Cancelled` rather than the deadline's `TimedOut`.
+///
+/// `NetError::Cancelled` is variant index 4 in `std/net/net.hew`
+/// (ConnectionRefused=0, AddressInUse=1, AddressNotAvailable=2, TimedOut=3,
+/// Cancelled=4, Other=5). Payload int 0, mirroring the `TimedOut` template.
+pub(crate) fn emit_read_deadline_cancelled_err(
+    fn_ctx: &FnCtx<'_, '_>,
+    result_dest: Place,
+    error_dest: Place,
+) -> CodegenResult<()> {
+    let error_local = composite_dest_local(error_dest, "SuspendingRead NetError")?;
+    store_composite_tag(fn_ctx, error_local, 4, "SuspendingRead NetError::Cancelled")?;
+    let (payload_ptr, payload_ty) = place_pointer(
+        fn_ctx,
+        Place::MachineVariant {
+            local: error_local,
+            variant_idx: 4,
+            field_idx: 0,
+        },
+    )?;
+    let payload_int_ty = match payload_ty {
+        BasicTypeEnum::IntType(t) => t,
+        other => {
+            return Err(CodegenError::FailClosed(format!(
+                "SuspendingRead NetError::Cancelled payload must be integer, got {other:?}"
+            )));
+        }
+    };
+    fn_ctx
+        .builder
+        .build_store(payload_ptr, payload_int_ty.const_zero())
+        .llvm_ctx("store SuspendingRead NetError::Cancelled payload")?;
+    emit_result_err(fn_ctx, result_dest, error_dest)
+}
+
 /// (L4 phase 2). `TimeoutError::Timeout` is variant 0 with no payload.
 pub(crate) fn emit_recv_deadline_timeout_err(
     fn_ctx: &FnCtx<'_, '_>,

--- a/hew-codegen-rs/src/suspend.rs
+++ b/hew-codegen-rs/src/suspend.rs
@@ -832,6 +832,66 @@ fn emit_suspending_read_bind<'ctx>(
                 CodegenError::FailClosed("hew_await_cancel_status returned void".into())
             })?
             .into_int_value();
+        // Three-way resume arbiter (was two-way TimedOut-vs-proceed). A runtime
+        // shutdown sweep can deposit `AwaitCancelStatus::Cancelled (2)` on a
+        // parked wait; route that to a typed `Err(NetError::Cancelled)` instead
+        // of falling through to the proceed arm (which would wrap an invalid
+        // read as `Ok(_)`). Order: Cancelled (2) → TimedOut (3) → proceed.
+        let cancelled = fn_ctx
+            .builder
+            .build_int_compare(
+                IntPredicate::EQ,
+                status,
+                i32_ty.const_int(2, false),
+                "suspending_read_cancelled",
+            )
+            .llvm_ctx("suspending read cancelled compare")?;
+        let cancelled_bb = fn_ctx
+            .ctx
+            .append_basic_block(parent, "suspending_read_cancelled");
+        let timeout_check_bb = fn_ctx
+            .ctx
+            .append_basic_block(parent, "suspending_read_timeout_check");
+        fn_ctx
+            .builder
+            .build_conditional_branch(cancelled, cancelled_bb, timeout_check_bb)
+            .llvm_ctx("suspending read cancelled branch")?;
+
+        // Cancelled arm — structurally identical to the timeout arm but emits
+        // `NetError::Cancelled`: free the deadline reg, free the slot, store the
+        // typed error, and resume.
+        fn_ctx.builder.position_at_end(cancelled_bb);
+        let reg_free_cancel = intern_runtime_decl(
+            fn_ctx.ctx,
+            fn_ctx.llvm_mod,
+            &mut fn_ctx.runtime_decls.borrow_mut(),
+            "hew_await_cancel_free",
+        )?;
+        fn_ctx
+            .builder
+            .build_call(
+                reg_free_cancel,
+                &[reg.into()],
+                "suspending_read_cancelled_reg_free",
+            )
+            .llvm_ctx("hew_await_cancel_free (read cancelled) call")?;
+        fn_ctx
+            .builder
+            .build_call(slot_free, &[slot.into()], "suspending_read_cancelled_free")
+            .llvm_ctx("hew_read_slot_free (cancelled) call")?;
+        let cancel_result_dest = term.deadline_result_dest.ok_or_else(|| {
+            CodegenError::FailClosed("SuspendingRead cancelled missing Result dest".into())
+        })?;
+        let cancel_error_dest = term.error_dest.ok_or_else(|| {
+            CodegenError::FailClosed("SuspendingRead cancelled missing NetError dest".into())
+        })?;
+        emit_read_deadline_cancelled_err(fn_ctx, cancel_result_dest, cancel_error_dest)?;
+        fn_ctx
+            .builder
+            .build_unconditional_branch(resume_bb)
+            .llvm_ctx("suspending read cancelled br")?;
+
+        fn_ctx.builder.position_at_end(timeout_check_bb);
         let timed_out = fn_ctx
             .builder
             .build_int_compare(
@@ -1507,6 +1567,65 @@ fn emit_suspending_accept_bind<'ctx>(
                 CodegenError::FailClosed("hew_await_cancel_status returned void".into())
             })?
             .into_int_value();
+        // A shutdown sweep resolves the common arbiter as Cancelled before
+        // waking the parked actor. Route that status to the typed NetError arm
+        // instead of treating the invalid accept handle as a successful value.
+        let cancelled = fn_ctx
+            .builder
+            .build_int_compare(
+                IntPredicate::EQ,
+                status,
+                i32_ty.const_int(2, false),
+                "suspending_accept_cancelled",
+            )
+            .llvm_ctx("suspending accept cancelled compare")?;
+        let cancelled_bb = fn_ctx
+            .ctx
+            .append_basic_block(parent, "suspending_accept_cancelled");
+        let timeout_check_bb = fn_ctx
+            .ctx
+            .append_basic_block(parent, "suspending_accept_timeout_check");
+        fn_ctx
+            .builder
+            .build_conditional_branch(cancelled, cancelled_bb, timeout_check_bb)
+            .llvm_ctx("suspending accept cancelled branch")?;
+
+        fn_ctx.builder.position_at_end(cancelled_bb);
+        let reg_free_cancel = intern_runtime_decl(
+            fn_ctx.ctx,
+            fn_ctx.llvm_mod,
+            &mut fn_ctx.runtime_decls.borrow_mut(),
+            "hew_await_cancel_free",
+        )?;
+        fn_ctx
+            .builder
+            .build_call(
+                reg_free_cancel,
+                &[reg.into()],
+                "suspending_accept_cancelled_reg_free",
+            )
+            .llvm_ctx("hew_await_cancel_free (accept cancelled) call")?;
+        fn_ctx
+            .builder
+            .build_call(
+                slot_free,
+                &[slot.into()],
+                "suspending_accept_cancelled_free",
+            )
+            .llvm_ctx("hew_read_slot_free (cancelled) call")?;
+        let cancel_result_dest = term.deadline_result_dest.ok_or_else(|| {
+            CodegenError::FailClosed("SuspendingAccept cancelled missing Result dest".into())
+        })?;
+        let cancel_error_dest = term.error_dest.ok_or_else(|| {
+            CodegenError::FailClosed("SuspendingAccept cancelled missing NetError dest".into())
+        })?;
+        emit_read_deadline_cancelled_err(fn_ctx, cancel_result_dest, cancel_error_dest)?;
+        fn_ctx
+            .builder
+            .build_unconditional_branch(resume_bb)
+            .llvm_ctx("suspending accept cancelled br")?;
+
+        fn_ctx.builder.position_at_end(timeout_check_bb);
         let timed_out = fn_ctx
             .builder
             .build_int_compare(

--- a/hew-codegen-rs/src/suspend.rs
+++ b/hew-codegen-rs/src/suspend.rs
@@ -539,22 +539,71 @@ pub(crate) fn emit_suspending_read_terminator<'ctx>(
         .build_call(slot_free, &[slot.into()], "suspending_read_err_free")
         .llvm_ctx("hew_read_slot_free (register err) call")?;
     if let Some(reg) = reg {
+        let status = fn_ctx.call_runtime_int(
+            "hew_await_cancel_status",
+            &[reg.into()],
+            "suspending_read_register_status",
+            "hew_await_cancel_status (read register err) call",
+        )?;
+        let cancelled = fn_ctx
+            .builder
+            .build_int_compare(
+                IntPredicate::EQ,
+                status,
+                i32_ty.const_int(2, false),
+                "suspending_read_register_cancelled",
+            )
+            .llvm_ctx("suspending read register-cancelled compare")?;
+        let cancelled_bb = fn_ctx
+            .ctx
+            .append_basic_block(parent, "suspending_read_register_cancelled");
+        let timeout_bb = fn_ctx
+            .ctx
+            .append_basic_block(parent, "suspending_read_register_timeout");
+        fn_ctx
+            .builder
+            .build_conditional_branch(cancelled, cancelled_bb, timeout_bb)
+            .llvm_ctx("suspending read register-error status branch")?;
+
+        let result_dest = term.deadline_result_dest.ok_or_else(|| {
+            CodegenError::FailClosed("SuspendingRead register error missing Result dest".into())
+        })?;
+        let error_dest = term.error_dest.ok_or_else(|| {
+            CodegenError::FailClosed("SuspendingRead register error missing NetError dest".into())
+        })?;
+
+        fn_ctx.builder.position_at_end(cancelled_bb);
         fn_ctx.call_runtime_void(
             "hew_await_cancel_free",
             &[reg.into()],
-            "suspending_read_err_reg_free",
-            "hew_await_cancel_free (register err) call",
+            "suspending_read_err_cancelled_reg_free",
+            "hew_await_cancel_free (read register cancelled) call",
         )?;
-    }
-    if let (Some(result_dest), Some(error_dest)) = (term.deadline_result_dest, term.error_dest) {
+        emit_read_deadline_cancelled_err(fn_ctx, result_dest, error_dest)?;
+        fn_ctx
+            .builder
+            .build_unconditional_branch(resume_bb)
+            .llvm_ctx("suspending read register-cancelled br")?;
+
+        fn_ctx.builder.position_at_end(timeout_bb);
+        fn_ctx.call_runtime_void(
+            "hew_await_cancel_free",
+            &[reg.into()],
+            "suspending_read_err_timeout_reg_free",
+            "hew_await_cancel_free (read register timeout) call",
+        )?;
         emit_read_deadline_timeout_err(fn_ctx, result_dest, error_dest)?;
+        fn_ctx
+            .builder
+            .build_unconditional_branch(resume_bb)
+            .llvm_ctx("suspending read register-timeout br")?;
     } else {
         store_empty_bytes(fn_ctx, term.result_dest)?;
+        fn_ctx
+            .builder
+            .build_unconditional_branch(resume_bb)
+            .llvm_ctx("suspending read register-err br")?;
     }
-    fn_ctx
-        .builder
-        .build_unconditional_branch(resume_bb)
-        .llvm_ctx("suspending read register-err br")?;
 
     // ── do_suspend: park the continuation (non-final suspend). The default edge
     // returns the coro handle to the trampoline (which parks it on this actor);
@@ -1253,26 +1302,71 @@ pub(crate) fn emit_suspending_accept_terminator<'ctx>(
         .build_call(slot_free, &[slot.into()], "suspending_accept_err_free")
         .llvm_ctx("hew_read_slot_free (register err) call")?;
     if let Some(reg) = reg {
-        let reg_free = intern_runtime_decl(
-            fn_ctx.ctx,
-            fn_ctx.llvm_mod,
-            &mut fn_ctx.runtime_decls.borrow_mut(),
-            "hew_await_cancel_free",
+        let status = fn_ctx.call_runtime_int(
+            "hew_await_cancel_status",
+            &[reg.into()],
+            "suspending_accept_register_status",
+            "hew_await_cancel_status (accept register err) call",
         )?;
+        let cancelled = fn_ctx
+            .builder
+            .build_int_compare(
+                IntPredicate::EQ,
+                status,
+                i32_ty.const_int(2, false),
+                "suspending_accept_register_cancelled",
+            )
+            .llvm_ctx("suspending accept register-cancelled compare")?;
+        let cancelled_bb = fn_ctx
+            .ctx
+            .append_basic_block(parent, "suspending_accept_register_cancelled");
+        let timeout_bb = fn_ctx
+            .ctx
+            .append_basic_block(parent, "suspending_accept_register_timeout");
         fn_ctx
             .builder
-            .build_call(reg_free, &[reg.into()], "suspending_accept_err_reg_free")
-            .llvm_ctx("hew_await_cancel_free (register err) call")?;
-    }
-    if let (Some(result_dest), Some(error_dest)) = (term.deadline_result_dest, term.error_dest) {
+            .build_conditional_branch(cancelled, cancelled_bb, timeout_bb)
+            .llvm_ctx("suspending accept register-error status branch")?;
+
+        let result_dest = term.deadline_result_dest.ok_or_else(|| {
+            CodegenError::FailClosed("SuspendingAccept register error missing Result dest".into())
+        })?;
+        let error_dest = term.error_dest.ok_or_else(|| {
+            CodegenError::FailClosed("SuspendingAccept register error missing NetError dest".into())
+        })?;
+
+        fn_ctx.builder.position_at_end(cancelled_bb);
+        fn_ctx.call_runtime_void(
+            "hew_await_cancel_free",
+            &[reg.into()],
+            "suspending_accept_err_cancelled_reg_free",
+            "hew_await_cancel_free (accept register cancelled) call",
+        )?;
+        emit_read_deadline_cancelled_err(fn_ctx, result_dest, error_dest)?;
+        fn_ctx
+            .builder
+            .build_unconditional_branch(resume_bb)
+            .llvm_ctx("suspending accept register-cancelled br")?;
+
+        fn_ctx.builder.position_at_end(timeout_bb);
+        fn_ctx.call_runtime_void(
+            "hew_await_cancel_free",
+            &[reg.into()],
+            "suspending_accept_err_timeout_reg_free",
+            "hew_await_cancel_free (accept register timeout) call",
+        )?;
         emit_read_deadline_timeout_err(fn_ctx, result_dest, error_dest)?;
+        fn_ctx
+            .builder
+            .build_unconditional_branch(resume_bb)
+            .llvm_ctx("suspending accept register-timeout br")?;
     } else {
         store_invalid_connection(fn_ctx, term.result_dest)?;
+        fn_ctx
+            .builder
+            .build_unconditional_branch(resume_bb)
+            .llvm_ctx("suspending accept register-err br")?;
     }
-    fn_ctx
-        .builder
-        .build_unconditional_branch(resume_bb)
-        .llvm_ctx("suspending accept register-err br")?;
 
     // ── do_suspend: park the continuation (non-final suspend). ─────────────────
     fn_ctx.builder.position_at_end(do_suspend_bb);

--- a/hew-codegen-rs/tests/e2e/actor_e2e.rs
+++ b/hew-codegen-rs/tests/e2e/actor_e2e.rs
@@ -53,6 +53,17 @@ fn network_deadline_arbiters_emit_typed_cancelled_branch() {
             block.contains("store i8 4"),
             "{fixture}: Cancelled block must store NetError::Cancelled tag 4:\n{block}"
         );
+
+        let register_compare = ll
+            .lines()
+            .find(|line| line.contains(&format!("%{prefix}_register_cancelled = icmp eq i32")))
+            .unwrap_or_else(|| {
+                panic!("{fixture}: missing synchronous register-cancelled compare in IR")
+            });
+        assert!(
+            register_compare.ends_with(", 2"),
+            "{fixture}: register-error path must preserve Cancelled status 2: {register_compare}"
+        );
     }
 }
 

--- a/hew-codegen-rs/tests/e2e/actor_e2e.rs
+++ b/hew-codegen-rs/tests/e2e/actor_e2e.rs
@@ -28,6 +28,34 @@ fn closure_pid_send_compile_and_exit_code() {
     compile_and_run_actor_fixture("actor_closure_pid_send", 42);
 }
 
+#[test]
+fn network_deadline_arbiters_emit_typed_cancelled_branch() {
+    for (fixture, prefix) in [
+        ("await_accept_deadline_timeout", "suspending_accept"),
+        ("await_read_string_deadline_timeout", "suspending_read"),
+    ] {
+        let ll = compile_vertical_slice_ll(fixture);
+        let compare = ll
+            .lines()
+            .find(|line| line.contains(&format!("%{prefix}_cancelled = icmp eq i32")))
+            .unwrap_or_else(|| panic!("{fixture}: missing Cancelled status compare in IR"));
+        assert!(
+            compare.ends_with(", 2"),
+            "{fixture}: Cancelled compare must test AwaitCancelStatus::Cancelled (2): {compare}"
+        );
+
+        let block_start = ll
+            .find(&format!("\n{prefix}_cancelled"))
+            .map(|index| index + 1)
+            .unwrap_or_else(|| panic!("{fixture}: missing Cancelled basic block in IR"));
+        let block = ll[block_start..].split("\n\n").next().unwrap_or_default();
+        assert!(
+            block.contains("store i8 4"),
+            "{fixture}: Cancelled block must store NetError::Cancelled tag 4:\n{block}"
+        );
+    }
+}
+
 /// Drop-plan oracle (the truth standard): capturing a pid into a closure
 /// must add ZERO drops to the parent's emitted drop plan. The pid has no
 /// drop glue, so the closure fixture's `main` plan must be
@@ -287,6 +315,37 @@ fn ensure_codegen_artifacts(repo: &Path) {
             lib.display()
         );
     });
+}
+
+fn compile_vertical_slice_ll(fixture_name: &str) -> String {
+    let repo = repo_root();
+    ensure_codegen_artifacts(&repo);
+    let emit_dir = tempfile::Builder::new()
+        .prefix(&format!("hew-cancelled-arbiter-{fixture_name}-"))
+        .tempdir()
+        .expect("create cancelled-arbiter emit dir");
+    let source = format!("tests/vertical-slice/accept/{fixture_name}.hew");
+    let compile = Command::new(hew_bin(&repo))
+        .current_dir(&repo)
+        .args([
+            "compile",
+            "--emit-dir",
+            emit_dir
+                .path()
+                .to_str()
+                .expect("emit dir path is valid UTF-8"),
+            &source,
+        ])
+        .output()
+        .expect("run built hew compile");
+    assert!(
+        compile.status.success(),
+        "hew compile {source} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    std::fs::read_to_string(emit_dir.path().join(format!("{fixture_name}.ll")))
+        .expect("read emitted cancelled-arbiter LLVM IR")
 }
 
 /// Run a compiled fixture, killing it if it does not exit within `secs`.

--- a/hew-runtime/src/reactor.rs
+++ b/hew-runtime/src/reactor.rs
@@ -48,7 +48,7 @@
     reason = "FFI-adjacent module; SAFETY documented at each unsafe site."
 )]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::{c_int, c_void};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
@@ -206,6 +206,11 @@ struct ReactorState {
     conn_to_fd: HashMap<c_int, c_int>,
     /// Queued mutations from worker/teardown threads.
     pending: Vec<Pending>,
+    /// Actors whose already-parked wait was swept during shutdown. The paired
+    /// await entry check rejects only these actors if they loop and try to park
+    /// again; actors that had not reached their await when shutdown began retain
+    /// the existing fast-shutdown abandonment behaviour.
+    shutdown_cancelled_actors: HashSet<usize>,
 }
 
 impl ReactorState {
@@ -214,6 +219,7 @@ impl ReactorState {
             registry: HashMap::new(),
             conn_to_fd: HashMap::new(),
             pending: Vec::new(),
+            shutdown_cancelled_actors: HashSet::new(),
         }
     }
 }
@@ -509,6 +515,60 @@ impl Drop for InflightSlotRef {
         // here drops exactly that one in-flight ref; the slot box is reclaimed
         // only when its last ref (creator/registration/in-flight) drops.
         unsafe { crate::read_slot::hew_read_slot_free(self.0) };
+    }
+}
+
+/// A parked read/accept registration removed by the shutdown sweep.
+///
+/// `registration` keeps the reactor-owned slot ref until the cancellation has
+/// been deposited. `_slot_ref` is the sweep's independent in-flight ref, taken
+/// under the registry lock in the same snapshot that removes the registration.
+/// It remains live after `registration` drops, preserving the same cross-thread
+/// delivery invariant as [`ReadySnapshot`].
+struct ShutdownWait {
+    registration: Registration,
+    _slot_ref: InflightSlotRef,
+}
+
+impl ShutdownWait {
+    fn new(registration: Registration) -> Self {
+        let read_slot = match registration.mode {
+            RegMode::Resume { read_slot } | RegMode::Accept { read_slot } => read_slot,
+            RegMode::AutoSend { .. } => {
+                unreachable!("shutdown sweep only snapshots parked waits")
+            }
+        };
+        // SAFETY: this constructor runs under the reactor-state lock immediately
+        // after removing a Registration that still owns a live slot ref.
+        unsafe { crate::read_slot::read_slot_retain(read_slot) };
+        Self {
+            registration,
+            _slot_ref: InflightSlotRef(read_slot),
+        }
+    }
+
+    fn actor_key(&self) -> usize {
+        self.registration.actor_key
+    }
+
+    fn read_slot(&self) -> *mut crate::read_slot::HewReadSlot {
+        match self.registration.mode {
+            RegMode::Resume { read_slot } | RegMode::Accept { read_slot } => read_slot,
+            RegMode::AutoSend { .. } => unreachable!("shutdown wait must carry a read slot"),
+        }
+    }
+
+    fn cancel(&self) {
+        // Deadline forms resolve through the common one-shot arbiter. Plain forms
+        // have no typed error carrier, so reuse the existing fail-closed
+        // deposit+wake path (empty/error bytes or INVALID_CONNECTION_HANDLE).
+        // SAFETY: the sweep's independent `_slot_ref` keeps this slot live.
+        let deadline = unsafe {
+            crate::read_slot::read_slot_cancel_await_for_shutdown(self.read_slot(), true)
+        };
+        if deadline.is_none() {
+            deliver_orphan_close(&self.registration);
+        }
     }
 }
 
@@ -1101,6 +1161,151 @@ fn resume_with_status(
     }
 }
 
+fn is_parked_wait(reg: &Registration) -> bool {
+    matches!(reg.mode, RegMode::Resume { .. } | RegMode::Accept { .. })
+}
+
+/// Remove every currently parked read/accept registration under the reactor
+/// lock, taking an independent slot ref for each before releasing the lock.
+///
+/// Registry entries also queue their poller-side unregister. Pending adds never
+/// reached the poller and are simply removed. Actor keys are recorded before any
+/// wake so a resumed loop cannot publish another parked wait during shutdown.
+fn take_shutdown_waits() -> Vec<ShutdownWait> {
+    REACTOR_STATE.access(|state| {
+        let registry_fds: Vec<c_int> = state
+            .registry
+            .iter()
+            .filter_map(|(fd, reg)| is_parked_wait(reg).then_some(*fd))
+            .collect();
+        let mut waits = Vec::with_capacity(registry_fds.len());
+        for fd in &registry_fds {
+            let reg = state
+                .registry
+                .remove(fd)
+                .expect("shutdown sweep fd came from the registry");
+            state.conn_to_fd.retain(|_, mapped| mapped != fd);
+            let wait = ShutdownWait::new(reg);
+            state.shutdown_cancelled_actors.insert(wait.actor_key());
+            waits.push(wait);
+        }
+        if !registry_fds.is_empty() {
+            crate::observe::record_reactor_unregistration(registry_fds.len() as u64);
+        }
+
+        let pending = std::mem::take(&mut state.pending);
+        let mut retained = Vec::with_capacity(pending.len() + registry_fds.len());
+        for req in pending {
+            match req {
+                Pending::Add { reg, .. } if is_parked_wait(&reg) => {
+                    let wait = ShutdownWait::new(reg);
+                    state.shutdown_cancelled_actors.insert(wait.actor_key());
+                    waits.push(wait);
+                }
+                other => retained.push(other),
+            }
+        }
+        retained.extend(
+            registry_fds
+                .into_iter()
+                .map(|fd| Pending::UnregisterFd { fd }),
+        );
+        state.pending = retained;
+        waits
+    })
+}
+
+fn shutdown_waits_quiescent(cancelled_actors: &HashSet<usize>) -> bool {
+    let no_parked_state = REACTOR_STATE.access(|state| {
+        !state.registry.values().any(is_parked_wait)
+            && !state.pending.iter().any(|req| match req {
+                Pending::Add { reg, .. } => is_parked_wait(reg),
+                _ => false,
+            })
+    });
+    let delivering = DELIVERING_ACTOR.load(Ordering::SeqCst);
+    no_parked_state
+        && PROMOTING_ACTOR.load(Ordering::SeqCst) == 0
+        && !cancelled_actors.contains(&delivering)
+}
+
+/// Resolve all reactor waits that were already parked when shutdown entered its
+/// drain phase.
+///
+/// The sweep is scrub-then-wait looped against the same promotion/delivery
+/// guards as actor teardown. Each batch is cancelled outside the registry lock;
+/// the one-shot await arbiter decides cancellation-vs-readiness exactly once.
+/// The returned count lets immediate shutdown run a bounded re-drain only when
+/// the sweep actually made actors runnable.
+pub(crate) fn reactor_cancel_parked_waits_for_shutdown() -> usize {
+    let mut swept = 0;
+    let mut cancelled_actors = HashSet::new();
+    loop {
+        let waits = take_shutdown_waits();
+        swept += waits.len();
+        cancelled_actors.extend(waits.iter().map(ShutdownWait::actor_key));
+        for wait in &waits {
+            wait.cancel();
+        }
+        drop(waits);
+
+        while PROMOTING_ACTOR.load(Ordering::SeqCst) != 0
+            || cancelled_actors.contains(&DELIVERING_ACTOR.load(Ordering::SeqCst))
+        {
+            std::hint::spin_loop();
+        }
+        if shutdown_waits_quiescent(&cancelled_actors) {
+            return swept;
+        }
+    }
+}
+
+fn shutdown_rejects_actor_wait(state: &ReactorState, actor_key: usize) -> bool {
+    crate::shutdown::hew_is_shutting_down() != 0
+        && state.shutdown_cancelled_actors.contains(&actor_key)
+}
+
+unsafe fn reject_read_wait_during_shutdown(read_slot: *mut crate::read_slot::HewReadSlot) -> c_int {
+    // Deadline form: resolve the arbiter without waking because the actor is
+    // still running on this synchronous register-error edge.
+    // SAFETY: the codegen caller still owns the slot's creator ref.
+    let deadline =
+        unsafe { crate::read_slot::read_slot_cancel_await_for_shutdown(read_slot, false) };
+    if deadline.is_none() {
+        // Plain form: preserve its existing empty/error fail-closed outcome.
+        // SAFETY: the caller owns the creator ref and the slot is live.
+        let _ = unsafe {
+            crate::read_slot::read_slot_deposit_status(
+                read_slot,
+                crate::read_slot::ReadStatus::Error,
+            )
+        };
+    }
+    crate::set_last_error("hew_conn_await_read: runtime is shutting down");
+    -1
+}
+
+unsafe fn reject_accept_wait_during_shutdown(
+    read_slot: *mut crate::read_slot::HewReadSlot,
+) -> c_int {
+    // SAFETY: the codegen caller still owns the slot's creator ref.
+    let deadline =
+        unsafe { crate::read_slot::read_slot_cancel_await_for_shutdown(read_slot, false) };
+    if deadline.is_none() {
+        // Plain form: preserve its existing invalid-Connection fail-closed
+        // outcome. No wake is needed because codegen follows register_err.
+        // SAFETY: the caller owns the creator ref and the slot is live.
+        let _ = unsafe {
+            crate::read_slot::read_slot_deposit_handle(
+                read_slot,
+                crate::read_slot::INVALID_CONNECTION_HANDLE,
+            )
+        };
+    }
+    crate::set_last_error("hew_listener_await_accept: runtime is shutting down");
+    -1
+}
+
 // ---------------------------------------------------------------------------
 // Public registration API (called from FFI in 4c)
 // ---------------------------------------------------------------------------
@@ -1245,24 +1450,34 @@ pub(crate) unsafe fn reactor_await_read(
     let actor_local = actor_ref_local_ptr(&snapshot).cast::<HewActor>();
     let actor_key = actor_local as usize;
 
-    // Take the REACTOR ref on the slot BEFORE queueing the registration, so the
-    // slot cannot be freed out from under the reactor between the queue and the
-    // promotion. The ref is owned by the `Registration` and released by its
-    // `Drop` (the single authority) on removal.
-    // SAFETY: caller holds a ref, so the slot is live for this retain.
-    unsafe { crate::read_slot::read_slot_retain(read_slot) };
-
-    let reg = Registration {
-        conn,
-        actor_ref: snapshot,
-        actor_key,
-        mode: RegMode::Resume { read_slot },
-        closed: false,
-    };
-    REACTOR_STATE.access(|state| {
-        state.pending.push(Pending::Add { fd, reg });
+    // Publish atomically with the shutdown pairing. If this actor was swept from
+    // an already-parked wait, reject its attempt to re-park; otherwise retain the
+    // reactor ref and queue the registration under the same lock the sweep uses.
+    let queued = REACTOR_STATE.access(|state| {
+        if shutdown_rejects_actor_wait(state, actor_key) {
+            return false;
+        }
+        // SAFETY: caller holds a ref, so the slot is live for this retain. The
+        // resulting ref is owned by Registration and released by its Drop.
+        unsafe { crate::read_slot::read_slot_retain(read_slot) };
+        state.pending.push(Pending::Add {
+            fd,
+            reg: Registration {
+                conn,
+                actor_ref: snapshot,
+                actor_key,
+                mode: RegMode::Resume { read_slot },
+                closed: false,
+            },
+        });
+        true
     });
-    0
+    if queued {
+        0
+    } else {
+        // SAFETY: the caller still owns the untouched creator ref.
+        unsafe { reject_read_wait_during_shutdown(read_slot) }
+    }
 }
 
 /// Register a TCP listener for a SUSPENDING `await listener.accept()` (NEW-2,
@@ -1320,26 +1535,32 @@ pub(crate) unsafe fn reactor_await_accept(
     let actor_local = actor_ref_local_ptr(&snapshot).cast::<HewActor>();
     let actor_key = actor_local as usize;
 
-    // Take the REACTOR ref on the slot BEFORE queueing the registration (the same
-    // single-authority discipline as `reactor_await_read`); the `Registration`'s
-    // `Drop` releases it on removal.
-    // SAFETY: caller holds a ref, so the slot is live for this retain.
-    unsafe { crate::read_slot::read_slot_retain(read_slot) };
-
-    let reg = Registration {
-        // The accept registration's `conn` field carries the LISTENER handle the
-        // fd belongs to (the reactor `accept()`s on it; it is not read as a
-        // stream).
-        conn: listener,
-        actor_ref: snapshot,
-        actor_key,
-        mode: RegMode::Accept { read_slot },
-        closed: false,
-    };
-    REACTOR_STATE.access(|state| {
-        state.pending.push(Pending::Add { fd, reg });
+    let queued = REACTOR_STATE.access(|state| {
+        if shutdown_rejects_actor_wait(state, actor_key) {
+            return false;
+        }
+        // SAFETY: caller holds a ref, so the slot is live for this retain.
+        unsafe { crate::read_slot::read_slot_retain(read_slot) };
+        state.pending.push(Pending::Add {
+            fd,
+            reg: Registration {
+                // The accept registration's `conn` field carries the LISTENER
+                // handle the fd belongs to.
+                conn: listener,
+                actor_ref: snapshot,
+                actor_key,
+                mode: RegMode::Accept { read_slot },
+                closed: false,
+            },
+        });
+        true
     });
-    0
+    if queued {
+        0
+    } else {
+        // SAFETY: the caller still owns the untouched creator ref.
+        unsafe { reject_accept_wait_during_shutdown(read_slot) }
+    }
 }
 
 /// Detach a connection handle from the reactor (queue an unregister).
@@ -1578,6 +1799,7 @@ pub(crate) fn reactor_shutdown() {
         state.registry.clear();
         state.conn_to_fd.clear();
         state.pending.clear();
+        state.shutdown_cancelled_actors.clear();
     });
 }
 
@@ -2650,6 +2872,183 @@ mod tests {
             hew_io_poller_stop(poller);
         }
         free_parked_actor(actor);
+        reset_reactor();
+    }
+
+    /// Forced-ordering shutdown race: readiness has snapshotted its independent
+    /// slot ref and is paused immediately before deposit. The shutdown sweep then
+    /// removes the registration, takes its own independent ref under the lock,
+    /// and resolves the deadline arbiter as Cancelled. The resumed reactor deposit
+    /// must lose the one-shot race without touching freed memory or replacing the
+    /// terminal status.
+    #[test]
+    #[allow(
+        clippy::undocumented_unsafe_blocks,
+        reason = "test-only FFI: every pointer is a fresh local registration, slot, \
+                  actor, poller, or socket with lifecycle asserted in the body"
+    )]
+    fn shutdown_sweep_cancel_wins_inflight_deposit_exactly_once() {
+        use std::io::Write;
+        const KEY: usize = 0x00C4_11ED;
+
+        let _rt = crate::runtime_test_guard();
+        let _guard = REACTOR_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        reset_reactor();
+        crate::await_cancel::reset_await_cancel_final_free_count_for_test();
+        crate::read_slot::reset_read_slot_final_free_count_for_test();
+
+        let poller = unsafe { hew_io_poller_new() };
+        assert!(!poller.is_null());
+        let (conn, mut client) = crate::transport::tcp_socketpair_conn_for_test();
+        let fd = crate::transport::tcp_conn_raw_fd(conn).expect("conn fd");
+        assert!(crate::transport::tcp_conn_set_nonblocking(conn, true));
+        assert_eq!(
+            unsafe { hew_io_poller_register(poller, fd, std::ptr::null_mut(), 0, HEW_IO_READ) },
+            0
+        );
+
+        let actor = spawn_full_reject_actor();
+        let actor_ref = unsafe { crate::transport::hew_actor_ref_local(actor) };
+        let slot = crate::read_slot::hew_read_slot_new();
+        let await_cancel = unsafe {
+            crate::await_cancel::hew_await_cancel_new(
+                std::ptr::null_mut(),
+                Some(crate::read_slot::hew_read_slot_cancel_cleanup),
+                slot.cast(),
+            )
+        };
+        unsafe { crate::read_slot::hew_read_slot_set_await_cancel(slot, await_cancel) };
+        unsafe { crate::read_slot::read_slot_retain(slot) }; // registration ref
+        inject_resume_registration_for_test(fd, conn, actor_ref, KEY, slot);
+
+        client.write_all(b"shutdown-race").expect("client write");
+        client.flush().ok();
+        std::thread::sleep(Duration::from_millis(20));
+
+        let slot_addr = slot as usize;
+        let refs_observed = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let refs_observed_h = std::sync::Arc::clone(&refs_observed);
+        set_resume_pre_deposit_hook(Some(Box::new(move || {
+            let slot = slot_addr as *mut crate::read_slot::HewReadSlot;
+            assert_eq!(
+                unsafe { crate::read_slot::read_slot_refs_for_test(slot) },
+                3,
+                "creator + registration + readiness in-flight refs must be live"
+            );
+            let waits = take_shutdown_waits();
+            assert_eq!(waits.len(), 1, "sweep must snapshot the parked read");
+            let refs_during_sweep = unsafe { crate::read_slot::read_slot_refs_for_test(slot) };
+            for wait in &waits {
+                wait.cancel();
+            }
+            drop(waits);
+            let refs_after_sweep = unsafe { crate::read_slot::read_slot_refs_for_test(slot) };
+            refs_observed_h.store(
+                (refs_during_sweep << 8) | refs_after_sweep,
+                Ordering::SeqCst,
+            );
+        })));
+
+        handle_ready_fd_for_test(poller, fd, HEW_IO_READ);
+        set_resume_pre_deposit_hook(None);
+
+        let observed = refs_observed.load(Ordering::SeqCst);
+        assert_eq!(
+            observed >> 8,
+            4,
+            "the sweep must hold its own ref in addition to creator, registration, \
+             and readiness refs"
+        );
+        assert_eq!(
+            observed & 0xff,
+            2,
+            "after the sweep batch drops, creator + readiness refs must remain"
+        );
+        assert_eq!(
+            unsafe { crate::read_slot::hew_read_slot_status(slot) },
+            crate::read_slot::ReadStatus::Cancelled as i32,
+            "the readiness deposit must not overwrite shutdown cancellation"
+        );
+        assert_eq!(
+            unsafe { crate::await_cancel::hew_await_cancel_status(await_cancel) },
+            crate::await_cancel::AwaitCancelStatus::Cancelled as i32
+        );
+        assert_eq!(registration_count_for_test(), 0);
+
+        unsafe { crate::read_slot::hew_read_slot_free(slot) };
+        unsafe { crate::await_cancel::hew_await_cancel_free(await_cancel) };
+        assert_eq!(
+            crate::read_slot::read_slot_final_free_count_for_test(),
+            1,
+            "slot must be reclaimed exactly once"
+        );
+        assert_eq!(
+            crate::await_cancel::await_cancel_final_free_count_for_test(),
+            1,
+            "deadline arbiter must be reclaimed exactly once"
+        );
+
+        drop(client);
+        unsafe {
+            crate::transport::tcp_close_raw_for_test(conn);
+            hew_io_poller_stop(poller);
+        }
+        free_parked_actor(actor);
+        reset_reactor();
+    }
+
+    #[test]
+    #[allow(
+        clippy::undocumented_unsafe_blocks,
+        reason = "test-only FFI: the pending registration owns the retained slot \
+                  reference and the test releases every creator reference"
+    )]
+    fn shutdown_sweep_scrubs_pending_wait_before_promotion() {
+        const KEY: usize = 0x00C4_11EE;
+
+        let _guard = REACTOR_TEST_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        reset_reactor();
+
+        let slot = crate::read_slot::hew_read_slot_new();
+        let await_cancel = unsafe {
+            crate::await_cancel::hew_await_cancel_new(
+                std::ptr::null_mut(),
+                Some(crate::read_slot::hew_read_slot_cancel_cleanup),
+                slot.cast(),
+            )
+        };
+        unsafe { crate::read_slot::hew_read_slot_set_await_cancel(slot, await_cancel) };
+        unsafe { crate::read_slot::read_slot_retain(slot) }; // registration ref
+        REACTOR_STATE.access(|state| {
+            state.pending.push(Pending::Add {
+                fd: 73,
+                reg: Registration {
+                    conn: 74,
+                    actor_ref: dead_actor_ref(),
+                    actor_key: KEY,
+                    mode: RegMode::Resume { read_slot: slot },
+                    closed: false,
+                },
+            });
+        });
+
+        assert_eq!(reactor_cancel_parked_waits_for_shutdown(), 1);
+        assert_eq!(
+            pending_count_for_test(),
+            0,
+            "a swept pending add must never reach poller promotion"
+        );
+        assert_eq!(
+            unsafe { crate::await_cancel::hew_await_cancel_status(await_cancel) },
+            crate::await_cancel::AwaitCancelStatus::Cancelled as i32
+        );
+
+        unsafe { crate::read_slot::hew_read_slot_free(slot) };
+        unsafe { crate::await_cancel::hew_await_cancel_free(await_cancel) };
         reset_reactor();
     }
 

--- a/hew-runtime/src/read_slot.rs
+++ b/hew-runtime/src/read_slot.rs
@@ -27,7 +27,8 @@
 use std::sync::atomic::{AtomicI32, AtomicI64, AtomicPtr, AtomicUsize, Ordering};
 
 use crate::await_cancel::{
-    hew_await_cancel_complete, hew_await_cancel_free, hew_await_cancel_retain,
+    hew_await_cancel_cancel, hew_await_cancel_complete, hew_await_cancel_free,
+    hew_await_cancel_retain,
 };
 use crate::await_cancel::{AwaitCancelStatus, HewAwaitCancel};
 use crate::bytes::BytesTriple;
@@ -304,6 +305,44 @@ pub unsafe extern "C" fn hew_read_slot_set_await_cancel(
         // SAFETY: releases the slot's previous retained registration.
         unsafe { hew_await_cancel_free(old) };
     }
+}
+
+/// Resolve this slot's attached deadline arbiter as shutdown cancellation.
+///
+/// Returns `None` for the plain, non-deadline await form. For a deadline form,
+/// returns whether this call won the one-shot transition. The caller must hold a
+/// live slot ref across this call; the shutdown sweep takes that independent ref
+/// while the reactor registry lock still guarantees the slot is live.
+///
+/// # Safety
+///
+/// `slot` must be null or a live read slot the caller holds a ref to.
+pub(crate) unsafe fn read_slot_cancel_await_for_shutdown(
+    slot: *mut HewReadSlot,
+    wake_actor: bool,
+) -> Option<bool> {
+    if slot.is_null() {
+        return None;
+    }
+    // SAFETY: caller holds a live slot ref, so its retained registration pointer
+    // cannot be released by the slot's final drop while we retain it here.
+    let reg = unsafe { (*slot).await_cancel.load(Ordering::Acquire) };
+    if reg.is_null() {
+        return None;
+    }
+    // SAFETY: the live slot owns a retained reference.
+    unsafe { hew_await_cancel_retain(reg) };
+    // SAFETY: the retain above keeps the registration live for the cancellation.
+    let won = unsafe {
+        hew_await_cancel_cancel(
+            reg,
+            AwaitCancelStatus::Cancelled as i32,
+            i32::from(wake_actor),
+        ) != 0
+    };
+    // SAFETY: release exactly the temporary reference retained above.
+    unsafe { hew_await_cancel_free(reg) };
+    Some(won)
 }
 
 /// Cleanup callback for [`crate::await_cancel::HewAwaitCancel`] read waits.

--- a/hew-runtime/src/shutdown.rs
+++ b/hew-runtime/src/shutdown.rs
@@ -21,6 +21,7 @@ use std::ffi::c_int;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
+use crate::reactor;
 use crate::runtime::{rt_current, rt_default};
 use crate::scheduler;
 
@@ -69,6 +70,10 @@ fn shutdown_phase_store(value: i32, ordering: Ordering) {
 const DEFAULT_DRAIN_TIMEOUT_MS: u64 = 5_000;
 /// Poll interval while waiting for the scheduler to drain existing work.
 const DRAIN_POLL_INTERVAL: Duration = Duration::from_millis(10);
+/// Immediate shutdown normally skips the drain. If the reactor sweep wakes an
+/// already-parked actor, give that typed cancellation a short bounded window to
+/// run before workers are joined.
+const SHUTDOWN_CANCEL_REDRAIN_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// Wrapper for `*mut HewSupervisor` to impl `Send`.
 ///
@@ -209,15 +214,24 @@ pub(crate) fn registered_supervisors_snapshot() -> Vec<*mut crate::supervisor::H
 /// Must only be called once. Subsequent calls are no-ops.
 #[no_mangle]
 pub extern "C" fn hew_shutdown_initiate(drain_timeout_ms: i64) {
+    shutdown_initiate(drain_timeout_ms, true);
+}
+
+/// Initiate the compiler-generated main-exit drain.
+///
+/// This preserves the pre-existing implicit drain contract: queued actor work may
+/// finish, but already-parked reactor waits remain abandoned rather than being
+/// surfaced as user-visible shutdown errors. Explicit [`hew_shutdown_initiate`]
+/// is the typed-cancellation boundary.
+#[no_mangle]
+pub extern "C" fn hew_shutdown_initiate_implicit(drain_timeout_ms: i64) {
+    shutdown_initiate(drain_timeout_ms, false);
+}
+
+fn shutdown_initiate(drain_timeout_ms: i64, cancel_parked_waits: bool) {
     // No runtime installed → nothing to shut down. The implicit actor-drain
-    // epilogue (codegen) emits `hew_shutdown_initiate`/`hew_shutdown_wait` for
-    // every program that declares an actor type, but `hew_sched_init` only runs
-    // at an actual spawn site. A program that declares an actor type yet never
-    // spawns one therefore reaches this call with no `RuntimeInner` installed;
-    // there is no scheduler and no in-flight work to drain, so this is a no-op —
-    // matching `hew_sched_shutdown`/`hew_runtime_cleanup`, which are likewise
-    // safe to call on a never-initialized runtime. Guarding here (before
-    // `rt_current()`) keeps that resolver fail-closed for genuine authority use.
+    // epilogue emits the implicit entry point for every program that declares an
+    // actor type, but `hew_sched_init` only runs at an actual spawn site.
     if rt_default().is_none() {
         return;
     }
@@ -248,9 +262,9 @@ pub extern "C" fn hew_shutdown_initiate(drain_timeout_ms: i64) {
     match std::thread::Builder::new()
         .name("hew-shutdown".into())
         .spawn(move || {
-            if let Err(panic_payload) =
-                run_shutdown_with_panic_handling(|| shutdown_orchestrate(timeout))
-            {
+            if let Err(panic_payload) = run_shutdown_with_panic_handling(|| {
+                shutdown_orchestrate_mode(timeout, cancel_parked_waits);
+            }) {
                 std::panic::resume_unwind(panic_payload);
             }
         }) {
@@ -260,7 +274,9 @@ pub extern "C" fn hew_shutdown_initiate(drain_timeout_ms: i64) {
         Err(_) => {
             // Spawn failed — run shutdown synchronously on current thread.
             // This ensures shutdown completes even if thread spawning fails.
-            let _ = run_shutdown_with_panic_handling(|| shutdown_orchestrate(timeout));
+            let _ = run_shutdown_with_panic_handling(|| {
+                shutdown_orchestrate_mode(timeout, cancel_parked_waits);
+            });
         }
     }
 }
@@ -404,8 +420,40 @@ fn report_shutdown_panic(panic_payload: &(dyn std::any::Any + Send)) {
     eprintln!("hew-runtime: shutdown orchestration panicked: {reason}");
 }
 
+fn drain_until_idle(timeout: Duration) -> bool {
+    if timeout.is_zero() {
+        return true;
+    }
+    let deadline = Instant::now() + timeout;
+    let mut idle_polls = 0;
+    while Instant::now() < deadline {
+        if scheduler::drain_is_idle() {
+            idle_polls += 1;
+            if idle_polls >= 2 {
+                return true;
+            }
+        } else {
+            idle_polls = 0;
+        }
+
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        std::thread::sleep(DRAIN_POLL_INTERVAL.min(remaining));
+    }
+    // Covers the case where the deadline expired while sleeping but the runtime
+    // became idle before the final observation.
+    scheduler::drain_is_idle()
+}
+
 /// Orchestrate the 3-phase shutdown.
+#[cfg(test)]
 fn shutdown_orchestrate(drain_timeout: Duration) {
+    shutdown_orchestrate_mode(drain_timeout, true);
+}
+
+fn shutdown_orchestrate_mode(drain_timeout: Duration, cancel_parked_waits: bool) {
     // Phase 1: Quiesce (already set by caller).
     // Nothing else to do — hew_is_shutting_down() now returns 1, which
     // callers can check before spawning new actors.
@@ -413,40 +461,27 @@ fn shutdown_orchestrate(drain_timeout: Duration) {
     // Phase 2: Drain — let workers process remaining messages.
     shutdown_phase_store(PHASE_DRAIN, Ordering::Release);
 
+    // Resolve waits that were already parked when shutdown began. The sweep
+    // deposits a terminal outcome and wakes outside the reactor lock; running it
+    // before the drain lets those resumptions settle before the worker join.
+    let swept_waits = if cancel_parked_waits {
+        reactor::reactor_cancel_parked_waits_for_shutdown()
+    } else {
+        0
+    };
+    let drain_window = if drain_timeout.is_zero() && swept_waits != 0 {
+        SHUTDOWN_CANCEL_REDRAIN_TIMEOUT
+    } else {
+        drain_timeout
+    };
+
     // Track whether the drain loop reached idle before the deadline.
     // WHY: Phase 3 join safety depends on this.  If the drain converged
     // (all workers parked), joining is instant and safe.  If it timed out,
     // a worker thread is still executing a handler; joining would block
     // forever.  The timed-out path skips join and all post-join cleanup,
     // letting process exit reap the stuck thread.
-    let mut drain_converged = drain_timeout.is_zero(); // zero-timeout ⇒ skip drain ⇒ treat as converged
-
-    if !drain_timeout.is_zero() {
-        let deadline = Instant::now() + drain_timeout;
-        let mut idle_polls = 0;
-        while Instant::now() < deadline {
-            if scheduler::drain_is_idle() {
-                idle_polls += 1;
-                if idle_polls >= 2 {
-                    drain_converged = true;
-                    break;
-                }
-            } else {
-                idle_polls = 0;
-            }
-
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                break;
-            }
-            std::thread::sleep(DRAIN_POLL_INTERVAL.min(remaining));
-        }
-        // Final idle check after the loop: covers the case where the deadline
-        // expired while sleeping but the runtime is actually idle now.
-        if !drain_converged && scheduler::drain_is_idle() {
-            drain_converged = true;
-        }
-    }
+    let drain_converged = drain_until_idle(drain_window);
 
     // Phase 3: Terminate.
     shutdown_phase_store(PHASE_TERMINATE, Ordering::Release);

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -1098,6 +1098,7 @@ internal = [
   "hew_sched_metrics_worker_count",
   "hew_sched_shutdown",
   "hew_shutdown_initiate",
+  "hew_shutdown_initiate_implicit",
   "hew_shutdown_phase",
   "hew_shutdown_register_supervisor",
   "hew_shutdown_unregister_supervisor",

--- a/tests/vertical-slice/accept/await_accept_shutdown_repark_loop.hew
+++ b/tests/vertical-slice/accept/await_accept_shutdown_repark_loop.hew
@@ -1,0 +1,53 @@
+// A handler woken from a parked accept during explicit shutdown immediately
+// loops and attempts to park again. The paired reactor entry check must reject
+// that second registration synchronously as Cancelled, so the loop terminates
+// instead of re-parking forever.
+//
+// Exit-code contract: two Cancelled outcomes (sweep + entry check) -> 44;
+// unexpected Ok -> 2; TimedOut -> 41; another error -> 3; hang/fallback -> 99.
+import std::net;
+import std::observe;
+
+extern "C" {
+    fn hew_sched_metrics_active_workers() -> i64;
+    fn hew_shutdown_initiate(drain_timeout_ms: i64);
+    fn hew_shutdown_wait() -> i32;
+}
+
+actor Server {
+    receive fn go() {
+        let ln = net.listen("127.0.0.1:0");
+        var cancellations: i64 = 0;
+        loop {
+            match await ln.accept() | after 10s {
+                Ok(_conn) => exit(2),
+                Err(e) => match e {
+                    NetError::Cancelled(_c) => {
+                        cancellations = cancellations + 1;
+                        if cancellations == 2 {
+                            exit(44);
+                        }
+                    },
+                    NetError::TimedOut(_c) => exit(41),
+                    _ => exit(3),
+                },
+            }
+        }
+    }
+}
+
+fn main() {
+    let server = spawn Server;
+    server.go();
+    while observe.read("reactor.registrations_live") == 0 {}
+    while unsafe {
+        hew_sched_metrics_active_workers()
+    } != 0 {}
+    unsafe {
+        hew_shutdown_initiate(0);
+    };
+    unsafe {
+        hew_shutdown_wait();
+    };
+    exit(99);
+}

--- a/tests/vertical-slice/accept/await_read_shutdown_cancelled.hew
+++ b/tests/vertical-slice/accept/await_read_shutdown_cancelled.hew
@@ -1,0 +1,54 @@
+// A read that is already parked when explicit shutdown begins must resume with
+// the exact typed shutdown outcome, not Ok(empty bytes) or its own deadline.
+//
+// The reactor registration gauge plus the active-worker idle check form the
+// parking barrier: the read registration is live and its handler has suspended.
+//
+// Exit-code contract: Cancelled -> 43; TimedOut -> 41; Ok -> 2; another error
+// -> 3; no reader outcome -> main fallback 99.
+import std::net::{Listener};
+import std::observe;
+
+extern "C" {
+    fn hew_tcp_listener_local_port(listener: Listener) -> i32;
+    fn hew_sched_metrics_active_workers() -> i64;
+    fn hew_shutdown_initiate(drain_timeout_ms: i64);
+    fn hew_shutdown_wait() -> i32;
+}
+
+actor Reader {
+    let port: i32;
+    receive fn go() {
+        let conn = net.connect(f"127.0.0.1:{port}");
+        let code = match await conn.read() | after 10s {
+            Ok(_body) => 2,
+            Err(e) => match e {
+                NetError::Cancelled(_c) => 43,
+                NetError::TimedOut(_c) => 41,
+                _ => 3,
+            },
+        };
+        exit(code);
+    }
+}
+
+fn main() {
+    let listener = net.listen("127.0.0.1:0");
+    let port = unsafe {
+        hew_tcp_listener_local_port(listener)
+    };
+    let reader = spawn Reader(port: port);
+    reader.go();
+    let _peer = listener.accept();
+    while observe.read("reactor.registrations_live") == 0 {}
+    while unsafe {
+        hew_sched_metrics_active_workers()
+    } != 0 {}
+    unsafe {
+        hew_shutdown_initiate(0);
+    };
+    unsafe {
+        hew_shutdown_wait();
+    };
+    exit(99);
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -3641,6 +3641,24 @@ if [[ "${read_ok_status}" -ne 42 ]]; then
   exit 1
 fi
 
+# Accept (#2446 read-half shutdown outcome): a read registration is confirmed
+# live and its actor parked before explicit shutdown. The sweep must resume it
+# with the exact Err(NetError::Cancelled) branch -> exit 43.
+compile_accept "await_read_shutdown_cancelled"
+read_shutdown_bin="${ROOT}/.tmp/compile-out/await_read_shutdown_cancelled"
+read_shutdown_status=0
+if "${TIMEOUT}" --kill-after=5s 30s env HEW_WORKERS=1 "${read_shutdown_bin}" \
+    >"${stdout_output}" 2>"${stderr_output}"; then
+  read_shutdown_status=0
+else
+  read_shutdown_status=$?
+fi
+if [[ "${read_shutdown_status}" -ne 43 ]]; then
+  echo "expected await_read_shutdown_cancelled (HEW_WORKERS=1) to exit 43, got ${read_shutdown_status}" >&2
+  cat "${accept_output}" "${stdout_output}" "${stderr_output}" >&2
+  exit 1
+fi
+
 # Accept (TCP write-side backpressure): a producer with a short write timeout
 # writes a 16 MiB payload to a peer that never reads. The send buffer fills, the
 # write cannot complete within the deadline, and conn.write() returns
@@ -3829,6 +3847,43 @@ else
 fi
 if [[ "${accept_ok_status}" -ne 42 ]]; then
   echo "expected await_accept_deadline_ok (HEW_WORKERS=1) to exit 42, got ${accept_ok_status}" >&2
+  cat "${accept_output}" "${stdout_output}" "${stderr_output}" >&2
+  exit 1
+fi
+
+# Accept (#2446 accept-half shutdown outcome): the accept is confirmed parked
+# before explicit shutdown. It must resume with Err(NetError::Cancelled) -> 42,
+# never Ok(INVALID_CONNECTION_HANDLE), its own deadline, or abandonment.
+compile_accept "await_accept_shutdown_abandoned"
+accept_shutdown_bin="${ROOT}/.tmp/compile-out/await_accept_shutdown_abandoned"
+accept_shutdown_status=0
+if "${TIMEOUT}" --kill-after=5s 30s env HEW_WORKERS=1 "${accept_shutdown_bin}" \
+    >"${stdout_output}" 2>"${stderr_output}"; then
+  accept_shutdown_status=0
+else
+  accept_shutdown_status=$?
+fi
+if [[ "${accept_shutdown_status}" -ne 42 ]]; then
+  echo "expected await_accept_shutdown_abandoned (HEW_WORKERS=1) to exit 42, got ${accept_shutdown_status}" >&2
+  cat "${accept_output}" "${stdout_output}" "${stderr_output}" >&2
+  exit 1
+fi
+
+# Accept (#2446 shutdown re-park guard): the first Cancelled comes from the
+# sweep; the handler immediately loops, and the paired entry check must reject
+# the second accept synchronously as Cancelled -> exit 44. A tight timeout makes
+# any re-park/livelock fail as 124/137 instead of hanging the suite.
+compile_accept "await_accept_shutdown_repark_loop"
+accept_repark_bin="${ROOT}/.tmp/compile-out/await_accept_shutdown_repark_loop"
+accept_repark_status=0
+if "${TIMEOUT}" --kill-after=1s 2s env HEW_WORKERS=1 "${accept_repark_bin}" \
+    >"${stdout_output}" 2>"${stderr_output}"; then
+  accept_repark_status=0
+else
+  accept_repark_status=$?
+fi
+if [[ "${accept_repark_status}" -ne 44 ]]; then
+  echo "expected await_accept_shutdown_repark_loop (HEW_WORKERS=1) to exit 44 promptly, got ${accept_repark_status}" >&2
   cat "${accept_output}" "${stdout_output}" "${stderr_output}" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

On shutdown, an actor parked in `await listener.accept()` or `await conn.read()` was silently abandoned: the await never resolved, and on the read path the resume could hand back an invalid connection handle. It now resolves to a typed `Err(NetError::Cancelled(_))` and the actor is woken to run its cancellation path. The accept and read arbiters gained a real three-way branch (Cancelled / TimedOut / proceed), so a cancelled await no longer falls through to `Ok(<invalid handle>)`. The fast-exit floor and teardown-safety guards are preserved — a server with no parked waits still exits promptly, and the shutdown sweep acts only as a scrubber, holding an independent in-flight slot reference so it opens no use-after-free window.

## Verification

- Full `hew-runtime` lib suite: 2037/2037 (reactor 25/25 including two new forced-ordering race tests, shutdown 22/22, plus read_slot and await_cancel coverage).
- `hew-codegen-rs` lib suite: 214/214.
- Compiled-`.hew` shutdown fixtures (built with the tree's `hew`): `await_accept_shutdown_abandoned` (previously abandoned, exit 99) now resolves to Cancelled; `await_read_shutdown_cancelled` resolves the read to Cancelled; `await_accept_shutdown_repark_loop` proves the re-park loop terminates under a 2s kill. All green with zero flakiness across repeated single- and four-worker runs.
- `await_accept_shutdown_fast_exit`: exit 0 in ~30ms — the fast-exit floor holds, no drain regression.
- The two new race tests pass under `MallocScribble=1 MallocPreScribble=1` (use-after-free detection), reproducing the teardown-vs-in-flight-deposit race and asserting Cancelled wins with the slot freed exactly once.
- Full `tests/vertical-slice/run.sh`: exit 0.
- `clippy` (hew-runtime + hew-codegen-rs) clean; `cargo fmt --check` clean.

## Out of scope

- `Receiver::recv` and the stream-next suspend-resume ramp keep their existing behaviour; this change covers the network accept and read awaits only.
- #2509 (the `Listener`-name / LLVM named-struct collision) is unchanged.

Fixes #2446