### PR TITLE
fix(hir): make impl Display sufficient for direct println/print/to_string

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -28916,12 +28916,6 @@ fn scan_expr_for_vec_index_gate(
 /// Map a scalar `ResolvedTy` to its `to_string_*` catalog builtin for Display
 /// dispatch. Only the scalar arm of `lower_display_dispatch` reaches here; any
 /// non-scalar type is a caller bug (the dispatch match never routes it here).
-/// Whether `ty` is a typed `instant` (`Named { builtin: Some(Instant) }`).
-///
-/// Annotation-lowering preserves the named form for `instant` (unlike the
-/// expression-level `from_ty`, which canonicalises to i64), so any
-/// annotation/parameter-typed instant carries this shape rather than a bare
-/// `ResolvedTy::I64`.
 fn scalar_display_builtin(ty: &ResolvedTy) -> &'static str {
     match ty {
         ResolvedTy::I8 | ResolvedTy::I16 | ResolvedTy::I32 => "to_string_i32",

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -8606,20 +8606,25 @@ impl LowerCtx {
         // whenever no concrete-ABI overload matched. Reaching this fallback
         // means `stdlib_catalog::resolve_overload` found no monomorphic entry
         // (`println_i32`, `to_string_str`, …) for the argument type, yet the
-        // checker's `require_display_impl` gate has already verified the
-        // argument implements `Display` — a non-`Display` argument is rejected
-        // before HIR lowering runs (`println(blob)` on a type with no
-        // `impl Display` fails the checker's trait-bound gate, never reaching
-        // here). So the argument count is the only condition worth testing:
-        // `lower_display_dispatch` already has a working arm for every shape a
-        // `Display` value can take — `string`, every scalar (incl. `char` and
-        // the narrow ints via `scalar_display_builtin`), `duration`,
-        // named-`instant`, concrete named `impl Display` types, and abstract
-        // type parameters `T: Display` — and fails closed on anything else.
-        // Enumerating a subset of those shapes here only re-hid the rest behind
-        // `UnresolvedBuiltinOverload` (#2351: `char`/`i8`/`f32`; #2492: named
-        // types with a real `impl Display`), even though f-string interpolation
-        // of the identical value already renders it fine through this shell.
+        // argument is already known to implement `Display`: `println` / `print`
+        // / `to_string` are generic `T: Display` builtins, so the checker's
+        // type-parameter bound enforcement (`Checker::enforce_type_param_bounds`
+        // / `type_satisfies_trait_bound` in `check/generics.rs`) rejects a
+        // non-`Display` argument before HIR lowering runs — `println(blob)` on a
+        // type with no `impl Display` fails that bound gate with "does not
+        // implement trait `Display` required by `T`" and never reaches here.
+        // (That is a distinct gate from the f-string-only `require_display_impl`,
+        // which validates each interpolation part.) So the argument count is the
+        // only condition worth testing: `lower_display_dispatch` already has a
+        // working arm for every shape a `Display` value can take — `string`,
+        // every scalar (incl. `char` and the narrow ints via
+        // `scalar_display_builtin`), `duration`, named-`instant`, concrete named
+        // `impl Display` types, and abstract type parameters `T: Display` — and
+        // fails closed on anything else. Enumerating a subset of those shapes
+        // here only re-hid the rest behind `UnresolvedBuiltinOverload` (#2351:
+        // `char`/`i8`/`f32`; #2492: named types with a real `impl Display`),
+        // even though f-string interpolation of the identical value already
+        // renders it fine through this shell.
         let single_dispatchable = args.len() == 1;
         if !is_display_surface || !single_dispatchable || self.lang_items.display_method().is_none()
         {

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -8340,24 +8340,6 @@ impl LowerCtx {
         }
     }
 
-    /// If `ty` is a bare reference to a type parameter of the function
-    /// currently being lowered, return its name. The checker lowers an
-    /// abstract `T` to `ResolvedTy::Named { args: [] }` (a structural
-    /// `ResolvedTy::TypeParam` also appears after substitution), so both
-    /// shapes are recognised. Used to route generic `Display` surfaces to
-    /// per-monomorphisation static dispatch instead of a concrete overload.
-    fn abstract_type_param_name<'a>(&self, ty: &'a ResolvedTy) -> Option<&'a str> {
-        match ty {
-            ResolvedTy::TypeParam { name } => Some(name),
-            ResolvedTy::Named { name, args, .. }
-                if args.is_empty() && self.current_fn_type_params.contains(name) =>
-            {
-                Some(name)
-            }
-            _ => None,
-        }
-    }
-
     /// Emit a `Display::fmt` static trait-dispatch over an abstract type
     /// parameter `type_param_name` (#1565). `bound_trait` and
     /// `declaring_trait` are both the `Display` lang-item trait; the concrete
@@ -8595,21 +8577,25 @@ impl LowerCtx {
         span: &Span,
     ) -> Result<(HirExprKind, ResolvedTy), Vec<HirExpr>> {
         let is_display_surface = matches!(name, "println" | "print" | "to_string");
-        // Route a single `dyn Display` argument through the Display dispatch
-        // spine when no concrete-ABI overload matched. This covers two shapes:
-        //   * an abstract type parameter `T: Display` (per-monomorphisation
-        //     static dispatch), and
-        //   * `duration`, whose `impl Display for duration` fmt has no
-        //     `to_string_*` catalog overload — without this it would fail closed
-        //     with `UnresolvedBuiltinOverload` even though the checker admitted
-        //     the call (`instant` needs no arm: it canonicalises to i64 and the
-        //     i64 overload renders it as raw nanos).
-        let single_dispatchable = args.len() == 1
-            && args.first().is_some_and(|arg| {
-                self.abstract_type_param_name(&arg.ty).is_some()
-                    || matches!(arg.ty, ResolvedTy::Duration)
-                    || is_named_instant(&arg.ty)
-            });
+        // Route a single `Display` argument through the Display dispatch spine
+        // whenever no concrete-ABI overload matched. Reaching this fallback
+        // means `stdlib_catalog::resolve_overload` found no monomorphic entry
+        // (`println_i32`, `to_string_str`, …) for the argument type, yet the
+        // checker's `require_display_impl` gate has already verified the
+        // argument implements `Display` — a non-`Display` argument is rejected
+        // before HIR lowering runs (`println(blob)` on a type with no
+        // `impl Display` fails the checker's trait-bound gate, never reaching
+        // here). So the argument count is the only condition worth testing:
+        // `lower_display_dispatch` already has a working arm for every shape a
+        // `Display` value can take — `string`, every scalar (incl. `char` and
+        // the narrow ints via `scalar_display_builtin`), `duration`,
+        // named-`instant`, concrete named `impl Display` types, and abstract
+        // type parameters `T: Display` — and fails closed on anything else.
+        // Enumerating a subset of those shapes here only re-hid the rest behind
+        // `UnresolvedBuiltinOverload` (#2351: `char`/`i8`/`f32`; #2492: named
+        // types with a real `impl Display`), even though f-string interpolation
+        // of the identical value already renders it fine through this shell.
+        let single_dispatchable = args.len() == 1;
         if !is_display_surface || !single_dispatchable || self.lang_items.display_method().is_none()
         {
             return Err(args);
@@ -28911,16 +28897,6 @@ fn scan_expr_for_vec_index_gate(
 /// expression-level `from_ty`, which canonicalises to i64), so any
 /// annotation/parameter-typed instant carries this shape rather than a bare
 /// `ResolvedTy::I64`.
-fn is_named_instant(ty: &ResolvedTy) -> bool {
-    matches!(
-        ty,
-        ResolvedTy::Named {
-            builtin: Some(BuiltinType::Instant),
-            ..
-        }
-    )
-}
-
 fn scalar_display_builtin(ty: &ResolvedTy) -> &'static str {
     match ty {
         ResolvedTy::I8 | ResolvedTy::I16 | ResolvedTy::I32 => "to_string_i32",

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -8451,12 +8451,37 @@ impl LowerCtx {
             | ResolvedTy::U64
             | ResolvedTy::Isize
             | ResolvedTy::Usize
-            | ResolvedTy::F32
             | ResolvedTy::F64
             | ResolvedTy::Bool
             | ResolvedTy::Char => {
                 let builtin = scalar_display_builtin(&ty);
                 self.build_catalog_call(builtin, vec![value], span)
+            }
+            ResolvedTy::F32 => {
+                // `to_string_f64` (`hew_float_to_string`) is the only float
+                // formatter symbol and takes an `f64`; the value here is a raw
+                // `f32`. The builtin `impl Display for f32` renders through
+                // `to_string(val as f64)`, so this shared shell must apply the
+                // same widening. Without the explicit `f32 -> f64` cast, codegen
+                // emits `hew_float_to_string(float)` against a `double`
+                // signature and the module fails LLVM verification — the exact
+                // failure a direct `to_string(f32)` / `println(f32)` and a
+                // concrete-`f32` f-string (`f"{x}"`) both hit before this arm
+                // was split out.
+                let widened = HirExpr {
+                    node: self.ids.node(),
+                    site: self.ids.site(),
+                    value_class: ValueClass::of_ty(&ResolvedTy::F64, &self.type_classes),
+                    ty: ResolvedTy::F64,
+                    intent: IntentKind::Read,
+                    kind: HirExprKind::NumericCast {
+                        value: Box::new(value),
+                        from_ty: ResolvedTy::F32,
+                        to_ty: ResolvedTy::F64,
+                    },
+                    span: span.clone(),
+                };
+                self.build_catalog_call("to_string_f64", vec![widened], span)
             }
             // `duration` has a pure-Hew `impl Display for duration` (rendered
             // through `is_builtin_display_impl`), so dispatch to its fmt symbol

--- a/hew-hir/tests/lowering_calls/display_dispatch_lower.rs
+++ b/hew-hir/tests/lowering_calls/display_dispatch_lower.rs
@@ -383,3 +383,87 @@ fn fstring_string_routes_through_user_display_impl() {
          user `impl Display for string` (`string::fmt`); observed calls: {calls:?}"
     );
 }
+
+/// Assert a lowered program raised no `UnresolvedBuiltinOverload` — i.e. the
+/// direct `println`/`print`/`to_string` call routed through the shared
+/// `lower_display_dispatch` shell instead of failing closed at the widened
+/// `single_dispatchable` gate.
+fn assert_no_unresolved_overload(source: &str) {
+    let output = lower_checked(source);
+    let unresolved: Vec<_> = output
+        .diagnostics
+        .iter()
+        .filter(|d| matches!(&d.kind, HirDiagnosticKind::UnresolvedBuiltinOverload { .. }))
+        .collect();
+    assert!(
+        unresolved.is_empty(),
+        "direct display-surface call must not fail closed with \
+         UnresolvedBuiltinOverload once `single_dispatchable` is widened to \
+         trust the checker's Display gate; got: {unresolved:#?}\nsource:\n{source}"
+    );
+}
+
+/// #2351: a direct (non-generic-wrapped) `println`/`print`/`to_string` of
+/// `char` and every narrow primitive the catalog has no concrete
+/// `println_*`/`print_*`/`to_string_*` overload for must route through the
+/// Display dispatch shell rather than hitting `UnresolvedBuiltinOverload` —
+/// the exact same values already render fine through f-string interpolation.
+#[test]
+fn direct_display_surface_narrow_primitives_lower() {
+    // (type, literal) pairs whose direct display-surface calls reached the
+    // `single_dispatchable` fallback on the pre-fix admit-list. `char`, `i8`,
+    // `f32` are the shapes named in #2351; `i16`/`u16`/`isize`/`usize` share
+    // the identical seam.
+    let matrix = [
+        ("char", "'x'"),
+        ("i8", "-3"),
+        ("i16", "300"),
+        ("u16", "7"),
+        ("isize", "9"),
+        ("usize", "4"),
+        ("f32", "1.5"),
+    ];
+    for (ty, lit) in matrix {
+        assert_no_unresolved_overload(&format!("fn main() {{ let v: {ty} = {lit}; println(v); }}"));
+        assert_no_unresolved_overload(&format!("fn main() {{ let v: {ty} = {lit}; print(v); }}"));
+        assert_no_unresolved_overload(&format!(
+            "fn main() {{ let v: {ty} = {lit}; let s: string = to_string(v); }}"
+        ));
+    }
+}
+
+/// #2492: a direct `println`/`print`/`to_string` of a concrete named type
+/// carrying a real `impl Display` must route through the type's `fmt` symbol
+/// via the shared shell — the same dispatch f-string interpolation already
+/// performs — instead of failing closed with `UnresolvedBuiltinOverload`.
+#[test]
+fn direct_display_surface_named_type_routes_to_impl() {
+    let prelude = "type Point { x: i64 } \
+                   impl Display for Point { fn fmt(p: Point) -> string { \"P\" } }";
+    let surfaces = [
+        ("println(p);", "println_str"),
+        ("print(p);", "print_str"),
+        ("let s: string = to_string(p);", "Point::fmt"),
+    ];
+    for (call, _wrapper) in surfaces {
+        let source = format!("{prelude} fn main() {{ let p = Point {{ x: 7 }}; {call} }}");
+        let output = lower_checked(&source);
+        let unresolved: Vec<_> = output
+            .diagnostics
+            .iter()
+            .filter(|d| matches!(&d.kind, HirDiagnosticKind::UnresolvedBuiltinOverload { .. }))
+            .collect();
+        assert!(
+            unresolved.is_empty(),
+            "direct display-surface call of a named `impl Display` type must not \
+             fail closed; got: {unresolved:#?}\nsource:\n{source}"
+        );
+        let calls = collect_calls(&output);
+        assert!(
+            calls.iter().any(|c| c == "Point::fmt"),
+            "direct display-surface call of `Point` must dispatch through its \
+             `impl Display` fmt symbol (`Point::fmt`); observed calls: {calls:?}\n\
+             source:\n{source}"
+        );
+    }
+}

--- a/tests/hew/display_direct_call_coverage_test.hew
+++ b/tests/hew/display_direct_call_coverage_test.hew
@@ -1,0 +1,81 @@
+//! Ratchets DIRECT (non-generic) Display coverage: `println`, `print`, and
+//! `to_string` invoked on a concrete value at the call site.
+//!
+//! The generic `T: Display` wrappers in display_primitive_coverage_test.hew
+//! never exercise this path — they dispatch through the type-parameter spine.
+//! These calls hit the builtin-overload fallback directly and must route
+//! through the shared Display dispatch shell: `char` and the narrow primitives
+//! the catalog has no concrete `println_*`/`print_*`/`to_string_*` overload for
+//! (#2351), plus a named type carrying a real `impl Display` (#2492).
+
+import std::testing;
+
+type Point {
+    x: i64,
+    y: i64,
+}
+
+impl Display for Point {
+    fn fmt(p: Point) -> string {
+        f"Point({p.x}, {p.y})"
+    }
+}
+
+#[test]
+fn test_direct_to_string_char_and_narrow_primitives() {
+    let cv: char = 'h';
+    let i8v: i8 = -7;
+    let i16v: i16 = -1234;
+    let u16v: u16 = 65000;
+    let isizev: isize = -4096;
+    let usizev: usize = 4000000000;
+    let f32v: f32 = 1.5;
+
+    testing.assert_eq_str(to_string(cv), "h");
+    testing.assert_eq_str(to_string(i8v), "-7");
+    testing.assert_eq_str(to_string(i16v), "-1234");
+    testing.assert_eq_str(to_string(u16v), "65000");
+    testing.assert_eq_str(to_string(isizev), "-4096");
+    testing.assert_eq_str(to_string(usizev), "4000000000");
+    testing.assert_eq_str(to_string(f32v), "1.5");
+}
+
+#[test]
+fn test_direct_to_string_named_display_type() {
+    let p = Point { x: 3, y: 4 };
+    testing.assert_eq_str(to_string(p), "Point(3, 4)");
+}
+
+#[test]
+fn test_direct_println_and_print_run_without_trap() {
+    // Direct println/print of char, a narrow primitive, and a named
+    // `impl Display` type in statement position — the same widened dispatch the
+    // to_string assertions verify by value. Must compile and run without a trap.
+    let cv: char = 'x';
+    let i8v: i8 = -7;
+    let f32v: f32 = 1.5;
+    let p = Point { x: 1, y: 2 };
+
+    println(cv);
+    print(i8v);
+    println(f32v);
+    println(p);
+    print(p);
+    println("");
+}
+
+#[test]
+fn test_concrete_fstring_renders_through_same_shell() {
+    // The shared Display shell serves both syntactic positions: the direct
+    // builtin call and f-string interpolation. Concrete (non-generic)
+    // interpolation of a raw `f32`, a `char`, and a named `impl Display` type
+    // must render identically to the direct-call path above — in particular
+    // the `f32 -> f64` widening the shell applies for `to_string_f64`.
+    let cv: char = 'h';
+    let f32v: f32 = 1.5;
+    let p = Point { x: 3, y: 4 };
+
+    testing.assert_eq_str(f"{cv}", "h");
+    testing.assert_eq_str(f"{f32v}", "1.5");
+    testing.assert_eq_str(f"{p}", "Point(3, 4)");
+}


### PR DESCRIPTION
## Summary

Any single-argument `println`, `print`, or `to_string` of a `Display`-able value now dispatches through the same shared display shell that f-string interpolation already used. The builtin-overload fallback was previously narrower, so `char`, the narrow primitives (`i8`/`i16`/`u16`/`isize`/`usize`/`f32`), and concrete named `impl Display` types did not render through direct calls the way they already did inside f-strings. The widened fallback trusts the checker's generic `dyn Display` bound validation, so these values now render via direct calls exactly as interpolation does.

This also repairs an `f32` defect in the shared shell: its scalar arm passed a raw `f32` into a to-string that takes `f64`, which failed LLVM verification. The value is now widened with an `f32`->`f64` cast, matching `impl Display for f32` (which itself calls `to_string(val as f64)`). That correction also fixes concrete-`f32` f-string interpolation, which previously reached the same broken arm.

## Verification

- `cargo test -p hew-hir --test lowering_calls display_dispatch_lower`: 6 passed, 0 failed.
- `make test-hew-ratchet`: 0 expected failures, 0 actual failures.
- Compiled `tests/hew/display_direct_call_coverage_test.hew`: direct `char`, `i8`, `i16`, `u16`, `isize`, `usize`, `f32`, a concrete named `Display` impl, and concrete `f"{f32}"` all render correctly.
- Fail-closed backstop verified: `println` of a non-`Display` value is still rejected at type-check with `type 'T' does not implement trait 'Display'`.
- Preflight: clean.

## Out of scope

- The `.to_string()` dot-call syntax gap is a separate, wider fix and is not addressed here.

Fixes #2351
Fixes #2492