### PR TITLE
fix(net): map Windows WSA errors to NetError

### DIFF
--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -87,20 +87,20 @@ pub enum NetError {
 ///
 /// Covers TCP, QUIC, TLS, HTTP, WebSocket, and DNS failure codes.
 pub fn net_error_from_errno(errno: i64) -> NetError {
-    // ECONNREFUSED: Linux=111, macOS=61
-    if errno == 111 || errno == 61 {
+    // ECONNREFUSED: Linux=111, macOS=61, Windows=10061
+    if errno == 111 || errno == 61 || errno == 10061 {
         NetError::ConnectionRefused(errno)
-    // EADDRINUSE: Linux=98, macOS=48
-    } else if errno == 98 || errno == 48 {
+    // EADDRINUSE: Linux=98, macOS=48, Windows=10048
+    } else if errno == 98 || errno == 48 || errno == 10048 {
         NetError::AddressInUse(errno)
-    // ETIMEDOUT: Linux=110, macOS=60
-    } else if errno == 110 || errno == 60 {
+    // ETIMEDOUT: Linux=110, macOS=60, Windows=10060
+    } else if errno == 110 || errno == 60 || errno == 10060 {
         NetError::TimedOut(errno)
     // ECANCELED: Linux=125, macOS=89
     } else if errno == 125 || errno == 89 {
         NetError::Cancelled(errno)
-    // EADDRNOTAVAIL: Linux=99, macOS=49
-    } else if errno == 99 || errno == 49 {
+    // EADDRNOTAVAIL: Linux=99, macOS=49, Windows=10049
+    } else if errno == 99 || errno == 49 || errno == 10049 {
         NetError::AddressNotAvailable(errno)
     } else {
         NetError::Other(errno)

--- a/tests/hew/net_try_api_test.hew
+++ b/tests/hew/net_try_api_test.hew
@@ -87,3 +87,23 @@ fn test_net_error_tcp_variants_are_distinct() {
         _ => panic("unexpected variant"),
     }
 }
+
+#[test]
+fn test_net_error_windows_wsa_variants() {
+    match net.net_error_from_errno(10061) {
+        NetError::ConnectionRefused(_) => {},
+        _ => panic("expected NetError::ConnectionRefused"),
+    }
+    match net.net_error_from_errno(10048) {
+        NetError::AddressInUse(_) => {},
+        _ => panic("expected NetError::AddressInUse"),
+    }
+    match net.net_error_from_errno(10060) {
+        NetError::TimedOut(_) => {},
+        _ => panic("expected NetError::TimedOut"),
+    }
+    match net.net_error_from_errno(10049) {
+        NetError::AddressNotAvailable(_) => {},
+        _ => panic("expected NetError::AddressNotAvailable"),
+    }
+}


### PR DESCRIPTION
## Summary

On Windows the `net` try-API surfaced connection failures as `NetError::Other(raw)`, because `net_error_from_errno` only recognized the Linux and macOS errno values. I map the four Winsock2 codes that have direct BSD equivalents — `WSAECONNREFUSED` (10061), `WSAEADDRINUSE` (10048), `WSAETIMEDOUT` (10060), and `WSAEADDRNOTAVAIL` (10049), each `WSABASEERR` (10000) plus its BSD offset — onto the existing `ConnectionRefused` / `AddressInUse` / `TimedOut` / `AddressNotAvailable` variants. A refused connect, an in-use bind address, a timeout, and an unavailable address now return their precise `NetError` variant on Windows instead of an opaque `Other(raw)`.

The change is purely additive: every errno that matched before still matches the same branch, and the added WSA codes (all > 10000) cannot collide with any POSIX code (all < 200), so there is no regression risk for the `http` / `quic` / `websocket` / `dns` / `net` callers that route through this function.

## Verification

- `hew test tests/hew/net_try_api_test.hew`: 7 passed, 0 failed (including the new `test_net_error_windows_wsa_variants`, which asserts the exact variant for each of the four codes).
- Ran the same fixture against the pre-fix mapping: 1 failed — the WSA test fell through to `Other` and tripped its panic arm, confirming the test discriminates the exact variant rather than mere `is_err()`.
- The mapping is native-verifiable: `net_error_from_errno` is a pure function fed literal integers, so the table validates in the compiled `.hew` suite on macOS with no Windows host required.
- Rust std sockets on Windows use Winsock, and `io::Error::raw_os_error()` returns the raw `WSAGetLastError()` code verbatim, so these codes flow unchanged into the mapping; a Windows-host run of the integration net tests would be confirmatory only.
- Preflight: ready-to-push

## Out of scope

- The Windows `Cancelled` case. Windows cancellation has no clean `10000 + BSD` offset — it surfaces as `ERROR_OPERATION_ABORTED` (995) — so a cancelled net op on Windows still lands as `NetError::Other(995)`, which is a real `Err`, just a less precise variant. Mapping it to `NetError::Cancelled` needs the runtime to surface the code first; tracked as a follow-up.
- The `run_argv` half of #2506, tracked separately.

Part of #2506