### PR TITLE
fix(sandbox-wasm): admit .clone() on core types the emitter already handles

### DIFF
--- a/examples/playground/manifest.json
+++ b/examples/playground/manifest.json
@@ -557,5 +557,18 @@
       "sandbox": "runnable",
       "wasi": "runnable"
     }
+  },
+  {
+    "id": "types/method_clone",
+    "category": "types",
+    "name": "Method Clone",
+    "description": "`.clone()` method-call syntax on Vec/String/Array/Slice/Regex \u2014 each produces an independent deep copy, matching the `clone expr` prefix form.",
+    "source_path": "types/method_clone.hew",
+    "expected_path": "types/method_clone.expected",
+    "capabilities": {
+      "browser": "analysis-only",
+      "sandbox": "runnable",
+      "wasi": "unsupported"
+    }
   }
 ]

--- a/examples/playground/manifest.json
+++ b/examples/playground/manifest.json
@@ -562,7 +562,7 @@
     "id": "types/method_clone",
     "category": "types",
     "name": "Method Clone",
-    "description": "`.clone()` method-call syntax on Vec/String/Array/Slice/Regex \u2014 each produces an independent deep copy, matching the `clone expr` prefix form.",
+    "description": "`.clone()` method-call syntax on Vec/String/Array/Slice \u2014 each produces an independent deep copy, matching the `clone expr` prefix form.",
     "source_path": "types/method_clone.hew",
     "expected_path": "types/method_clone.expected",
     "capabilities": {

--- a/examples/playground/types/method_clone.expected
+++ b/examples/playground/types/method_clone.expected
@@ -3,4 +3,3 @@ nums_copy.len(): 2
 s == s_copy: true
 xs_copy[1]: 20
 takes_slice(nums_copy): 2
-re2.is_match: true

--- a/examples/playground/types/method_clone.expected
+++ b/examples/playground/types/method_clone.expected
@@ -1,0 +1,6 @@
+nums.len(): 3
+nums_copy.len(): 2
+s == s_copy: true
+xs_copy[1]: 20
+takes_slice(nums_copy): 2
+re2.is_match: true

--- a/examples/playground/types/method_clone.hew
+++ b/examples/playground/types/method_clone.hew
@@ -1,7 +1,5 @@
 //! @name Method Clone
-//! @description `.clone()` method-call syntax on Vec/String/Array/Slice/Regex — each produces an independent deep copy, matching the `clone expr` prefix form.
-
-import std::text::regex;
+//! @description `.clone()` method-call syntax on Vec/String/Array/Slice — each produces an independent deep copy, matching the `clone expr` prefix form.
 
 fn takes_slice(xs: [i64]) -> i64 {
     let ys = xs.clone();
@@ -30,12 +28,4 @@ fn main() {
 
     // Slice-typed parameter .clone() ([i64] receiver, distinct from Vec/Array).
     println(f"takes_slice(nums_copy): {takes_slice(nums_copy)}");
-
-    // regex.Pattern::clone() — each clone released independently.
-    let re = regex.new("a+");
-    let re2 = re.clone();
-    let matched = re2.is_match("aaa");
-    println(f"re2.is_match: {matched}");
-    re.free();
-    re2.free();
 }

--- a/examples/playground/types/method_clone.hew
+++ b/examples/playground/types/method_clone.hew
@@ -1,0 +1,41 @@
+//! @name Method Clone
+//! @description `.clone()` method-call syntax on Vec/String/Array/Slice/Regex — each produces an independent deep copy, matching the `clone expr` prefix form.
+
+import std::text::regex;
+
+fn takes_slice(xs: [i64]) -> i64 {
+    let ys = xs.clone();
+    ys.len()
+}
+
+fn main() {
+    // Vec<T>::clone() — mutating the original after clone does not affect the copy.
+    let nums = Vec::new();
+    nums.push(1);
+    nums.push(2);
+    let nums_copy = nums.clone();
+    nums.push(3);
+    println(f"nums.len(): {nums.len()}");
+    println(f"nums_copy.len(): {nums_copy.len()}");
+
+    // string.clone()
+    let s = "sandbox";
+    let s_copy = s.clone();
+    println(f"s == s_copy: {s == s_copy}");
+
+    // Fixed-size array .clone()
+    let xs = [10, 20, 30];
+    let xs_copy = xs.clone();
+    println(f"xs_copy[1]: {xs_copy[1]}");
+
+    // Slice-typed parameter .clone() ([i64] receiver, distinct from Vec/Array).
+    println(f"takes_slice(nums_copy): {takes_slice(nums_copy)}");
+
+    // regex.Pattern::clone() — each clone released independently.
+    let re = regex.new("a+");
+    let re2 = re.clone();
+    let matched = re2.is_match("aaa");
+    println(f"re2.is_match: {matched}");
+    re.free();
+    re2.free();
+}

--- a/examples/sandbox-graduation/regex_clone.hew
+++ b/examples/sandbox-graduation/regex_clone.hew
@@ -1,0 +1,10 @@
+import std::text::regex;
+
+fn main() {
+    let re = regex.new("a+");
+    let re2 = re.clone();
+    let matched = re2.is_match("aaa");
+    println(f"re2.is_match: {matched}");
+    re.close();
+    re2.close();
+}

--- a/hew-cli/tests/wasi_run_e2e.rs
+++ b/hew-cli/tests/wasi_run_e2e.rs
@@ -49,6 +49,7 @@ const EXPECTED_WASI_UNSUPPORTED: &[&str] = &[
     "concurrency/supervisor",
     "language/string_slicing",
     "machines/traffic_light",
+    "types/method_clone",
 ];
 
 // WINDOWS-TODO: requires wasmtime runtime which is not configured on Windows.
@@ -58,10 +59,17 @@ fn curated_playground_examples_run_under_wasi() {
     require_wasi_runner();
 
     let manifest = load_playground_manifest();
+    // Tracks the curated playground manifest's entry count as a deliberate
+    // tripwire: it forces a human to review EXPECTED_WASI_UNSUPPORTED (and the
+    // runnable loop below) whenever a fixture is added, rather than letting a
+    // new entry silently fall into the wrong bucket. A dynamic count derived
+    // from the manifest itself would be tautological against `manifest.len()`
+    // and lose that review trigger, so the literal is intentional; bump it
+    // alongside manifest.json (currently 44, +1 for types/method_clone).
     assert_eq!(
         manifest.len(),
-        43,
-        "expected the curated 43-snippet manifest"
+        44,
+        "expected the curated 44-snippet manifest"
     );
 
     let mut actual_unsupported: Vec<&str> = manifest

--- a/hew-sandbox-wasm/src/lib.rs
+++ b/hew-sandbox-wasm/src/lib.rs
@@ -131,6 +131,12 @@ pub const REQUIRED_PARITY_TEST_NAMES: &[&str] = &[
     "record_shorthand_destructure_let",
     "nested_tuple_destructure_let",
     "wrapping_binary_operators",
+    // `.clone()` method-call syntax on Vec/String/Array/Slice/Regex — an
+    // allowlist gap: the emitter's generic `local.set` → `cloneValue` clone
+    // arm already handled these receiver types, but the profile only admitted
+    // `clone` on user-defined records. Verifies independence (mutating the
+    // original after clone does not affect the copy) across all five types.
+    "method_clone",
 ];
 
 const SANDBOX_STDIN_HELPER: &str = "__hew_sandbox_stdin_read_line";

--- a/hew-sandbox-wasm/src/lib.rs
+++ b/hew-sandbox-wasm/src/lib.rs
@@ -131,12 +131,16 @@ pub const REQUIRED_PARITY_TEST_NAMES: &[&str] = &[
     "record_shorthand_destructure_let",
     "nested_tuple_destructure_let",
     "wrapping_binary_operators",
-    // `.clone()` method-call syntax on Vec/String/Array/Slice/Regex — an
-    // allowlist gap: the emitter's generic `local.set` → `cloneValue` clone
-    // arm already handled these receiver types, but the profile only admitted
-    // `clone` on user-defined records. Verifies independence (mutating the
-    // original after clone does not affect the copy) across all five types.
+    // `.clone()` method-call syntax on Vec/String/Array/Slice — an allowlist
+    // gap: the emitter's generic `local.set` → `cloneValue` clone arm already
+    // handled these receiver types, but the profile only admitted `clone` on
+    // user-defined records. Verifies independence (mutating the original
+    // after clone does not affect the copy) across all four types.
     "method_clone",
+    // `regex.Pattern::clone()` — same allowlist gap, pinned separately since
+    // its source lives outside the curated playground manifest scope (see
+    // `regex_clone` in tests/parity.rs).
+    "regex_clone",
 ];
 
 const SANDBOX_STDIN_HELPER: &str = "__hew_sandbox_stdin_read_line";

--- a/hew-sandbox-wasm/src/profile.rs
+++ b/hew-sandbox-wasm/src/profile.rs
@@ -975,10 +975,25 @@ impl<'a> ProfileChecker<'a> {
             }
         }
         match receiver_ty.materialize_literal_defaults() {
-            Ty::String => matches!(method, "len" | "slice" | "to_string"),
-            Ty::Array(_, _) | Ty::Slice(_) => matches!(method, "len" | "get" | "to_string"),
+            // `clone` on String/Array/Slice/Vec/Regex lowers through the same
+            // generic `local.set` → `cloneValue` path as the user-defined-record
+            // arm below (`emit.rs`'s `"clone"` arm dispatches on method name
+            // alone, not receiver type) — the VM's `cloneValue` has a case for
+            // every `VmValue` kind these types resolve to (string, vector,
+            // regex). `Option`/`Result` are deliberately excluded: native Hew
+            // has no `Option::clone`/`Result::clone` (`hew check` reports
+            // `UndefinedMethod`), so no valid program can reach this arm with
+            // one — admitting it here would be dead, unreachable surface, not a
+            // real capability.
+            Ty::String => matches!(method, "len" | "slice" | "to_string" | "clone"),
+            Ty::Array(_, _) | Ty::Slice(_) => {
+                matches!(method, "len" | "get" | "to_string" | "clone")
+            }
             Ty::Named { name, .. } if name == "Vec" => {
-                matches!(method, "len" | "push" | "get" | "contains" | "to_string")
+                matches!(
+                    method,
+                    "len" | "push" | "get" | "contains" | "to_string" | "clone"
+                )
             }
             Ty::Named { name, .. }
                 if name.eq_ignore_ascii_case("Regex")
@@ -988,8 +1003,9 @@ impl<'a> ProfileChecker<'a> {
                 // `Pattern` is a `#[resource]`; `close()` is its canonical
                 // release method (renamed from `free()` in the resource
                 // migration). Mirror the stdlib surface here so the sandbox
-                // admits the release call.
-                matches!(method, "find" | "is_match" | "replace" | "close")
+                // admits the release call, plus `clone` which the emitter
+                // already handles via the generic `local.set` deep-copy path.
+                matches!(method, "find" | "is_match" | "replace" | "close" | "clone")
             }
             Ty::Named {
                 builtin: Some(BuiltinType::Option),

--- a/hew-sandbox-wasm/tests/parity.rs
+++ b/hew-sandbox-wasm/tests/parity.rs
@@ -395,6 +395,16 @@ const PARITY_CASES: &[ParityCase] = &[
         source_rel: "examples/sandbox-graduation/wrapping_binary_operators.hew",
         accepted_divergences: &[],
     },
+    ParityCase {
+        // `.clone()` method-call syntax on Vec/String/Array/Slice/Regex. The
+        // emitter's generic clone arm (`local.set` → `cloneValue`) already
+        // handled these receiver types; the profile allowlist was the gap.
+        // Proves independence: mutating the original after clone leaves the
+        // copy unaffected, for every newly-admitted receiver type.
+        test_name: "method_clone",
+        source_rel: "examples/playground/types/method_clone.hew",
+        accepted_divergences: &[],
+    },
 ];
 
 #[derive(Debug, Clone, Copy)]

--- a/hew-sandbox-wasm/tests/parity.rs
+++ b/hew-sandbox-wasm/tests/parity.rs
@@ -396,13 +396,24 @@ const PARITY_CASES: &[ParityCase] = &[
         accepted_divergences: &[],
     },
     ParityCase {
-        // `.clone()` method-call syntax on Vec/String/Array/Slice/Regex. The
+        // `.clone()` method-call syntax on Vec/String/Array/Slice. The
         // emitter's generic clone arm (`local.set` → `cloneValue`) already
         // handled these receiver types; the profile allowlist was the gap.
         // Proves independence: mutating the original after clone leaves the
         // copy unaffected, for every newly-admitted receiver type.
         test_name: "method_clone",
         source_rel: "examples/playground/types/method_clone.hew",
+        accepted_divergences: &[],
+    },
+    ParityCase {
+        // `regex.Pattern::clone()` — same profile-allowlist gap as
+        // `method_clone`, covered by a source file outside the curated
+        // playground manifest scope: `std::text::regex` FFI is unresolvable
+        // by the hew-wasm browser analyzer (dev-tooling world, distinct from
+        // this sandbox VM), so a regex-importing fixture cannot live under
+        // `examples/playground/` without failing the analyzer smoke test.
+        test_name: "regex_clone",
+        source_rel: "examples/sandbox-graduation/regex_clone.hew",
         accepted_divergences: &[],
     },
 ];

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -829,16 +829,25 @@ const CONSTRUCTS: &[Construct] = &[
         coverage: Coverage::Parity("vec_f64_nonfinite_contains"),
     },
     Construct {
-        // `.clone()` method-call syntax on Vec/String/Array/Slice/Regex (B-7
+        // `.clone()` method-call syntax on Vec/String/Array/Slice (B-7
         // allowlist gap). The emitter's generic `local.set` → `cloneValue`
         // clone arm already handled every one of these receiver types; the
         // profile allowlist only admitted `clone` on user-defined records.
         // `Option`/`Result` are deliberately excluded: native Hew has no
         // `Option::clone`/`Result::clone` (checker reports `UndefinedMethod`),
         // so no valid program can reach the emitter with one.
-        id: "Vec/String/Array/Slice/Regex method `clone()`",
-        probe: "import std::text::regex;\nfn takes(xs: [i64]) -> i64 {\n    let ys = xs.clone();\n    ys.len()\n}\nfn main() {\n    let v: Vec<i64> = Vec::new();\n    v.push(1);\n    let vc = v.clone();\n    println(vc.len());\n    let s = \"hi\";\n    let sc = s.clone();\n    println(sc);\n    let xs = [1, 2, 3];\n    let xc = xs.clone();\n    println(xc[0]);\n    println(takes(v));\n    let re = regex.new(\"a+\");\n    let re2 = re.clone();\n    println(re2.is_match(\"aaa\"));\n    re.free();\n    re2.free();\n}\n",
+        id: "Vec/String/Array/Slice method `clone()`",
+        probe: "fn takes(xs: [i64]) -> i64 {\n    let ys = xs.clone();\n    ys.len()\n}\nfn main() {\n    let v: Vec<i64> = Vec::new();\n    v.push(1);\n    let vc = v.clone();\n    println(vc.len());\n    let s = \"hi\";\n    let sc = s.clone();\n    println(sc);\n    let xs = [1, 2, 3];\n    let xc = xs.clone();\n    println(xc[0]);\n    println(takes(v));\n}\n",
         coverage: Coverage::Parity("method_clone"),
+    },
+    Construct {
+        // `regex.Pattern::clone()` — same B-7 allowlist gap, same generic
+        // emitter arm, pinned as its own construct since its probe imports
+        // `std::text::regex` and its fixture (`regex_clone`) lives outside
+        // the curated playground manifest scope (see tests/parity.rs).
+        id: "regex method `clone()`",
+        probe: "import std::text::regex;\nfn main() {\n    let re = regex.new(\"a+\");\n    let re2 = re.clone();\n    println(re2.is_match(\"aaa\"));\n    re.close();\n    re2.close();\n}\n",
+        coverage: Coverage::Parity("regex_clone"),
     },
 ];
 
@@ -890,7 +899,7 @@ fn every_required_parity_case_backs_a_construct() {
 /// justifying a removed admission in the same commit.
 #[test]
 fn runnable_coverage_does_not_shrink() {
-    const RUNNABLE_BASELINE: usize = 51; // +1: record shorthand let destructure
+    const RUNNABLE_BASELINE: usize = 52; // +1: regex method `clone()` split into its own construct
     let runnable = CONSTRUCTS
         .iter()
         .filter(|c| matches!(c.coverage, Coverage::Parity(_) | Coverage::ParityTrap(_)))

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -828,6 +828,18 @@ const CONSTRUCTS: &[Construct] = &[
         probe: "fn main() {\n    let zero: f64 = 0.0;\n    let nan: f64 = zero / zero;\n    let inf: f64 = 1.0 / zero;\n    let nans: Vec<f64> = Vec::new();\n    nans.push(nan);\n    println(nans.contains(nan));\n    println(nans.contains(inf));\n    let nums: Vec<f64> = Vec::new();\n    nums.push(2.5);\n    println(nums.contains(2.5));\n}\n",
         coverage: Coverage::Parity("vec_f64_nonfinite_contains"),
     },
+    Construct {
+        // `.clone()` method-call syntax on Vec/String/Array/Slice/Regex (B-7
+        // allowlist gap). The emitter's generic `local.set` → `cloneValue`
+        // clone arm already handled every one of these receiver types; the
+        // profile allowlist only admitted `clone` on user-defined records.
+        // `Option`/`Result` are deliberately excluded: native Hew has no
+        // `Option::clone`/`Result::clone` (checker reports `UndefinedMethod`),
+        // so no valid program can reach the emitter with one.
+        id: "Vec/String/Array/Slice/Regex method `clone()`",
+        probe: "import std::text::regex;\nfn takes(xs: [i64]) -> i64 {\n    let ys = xs.clone();\n    ys.len()\n}\nfn main() {\n    let v: Vec<i64> = Vec::new();\n    v.push(1);\n    let vc = v.clone();\n    println(vc.len());\n    let s = \"hi\";\n    let sc = s.clone();\n    println(sc);\n    let xs = [1, 2, 3];\n    let xc = xs.clone();\n    println(xc[0]);\n    println(takes(v));\n    let re = regex.new(\"a+\");\n    let re2 = re.clone();\n    println(re2.is_match(\"aaa\"));\n    re.free();\n    re2.free();\n}\n",
+        coverage: Coverage::Parity("method_clone"),
+    },
 ];
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/scripts/gen-playground-manifest.py
+++ b/scripts/gen-playground-manifest.py
@@ -88,6 +88,7 @@ EXAMPLE_ORDER = {
         "vec_inclusive_slice",
         "record_clone",
         "fn_field_call",
+        "method_clone",
     ),
 }
 
@@ -207,6 +208,10 @@ SANDBOX_CAPABILITY: dict[str, str] = {
     # types/fn_field_call: `(rec.f)(args)` fn-field call via call.indirect.
     # Functions are materialised as function-kind values via const.function.
     "types/fn_field_call": "runnable",
+    # types/method_clone: `.clone()` method-call syntax on Vec/String/Array/
+    # Slice/Regex now lowers via the same local.set → cloneValue path as the
+    # `clone expr` prefix form and user-defined record `.clone()`.
+    "types/method_clone": "runnable",
 }
 
 # Entries omitted from WASI_CAPABILITY default to "runnable".
@@ -224,6 +229,11 @@ WASI_CAPABILITY: dict[str, str] = {
     # wasm-ld function-signature mismatch ((i32,i64,i64)->i32); the example runs
     # at native↔sandbox parity but is not WASI-runnable until that ABI gap closes.
     "language/string_slicing": "unsupported",
+    # types/method_clone: the wasm32-wasip1 runtime has no regex FFI symbols at
+    # all (hew_regex_new/is_match/clone/close are undefined at link time) — a
+    # pre-existing wasm32-wasi gap, not a clone-specific one. Runs at
+    # native↔sandbox parity; not WASI-runnable until regex ships for wasm32-wasi.
+    "types/method_clone": "unsupported",
 }
 
 


### PR DESCRIPTION
## Summary

The WASM sandbox rejected valid `.clone()` calls on `String`, `Array`/`Slice`, `Vec`, and `Regex` receivers with `unknown_method_symbol`, even though the emitter already lowers `.clone()` generically for any receiver type that reaches it (`local.set` -> `cloneValue`). This admits `clone` in the sandbox method allowlist for those four receiver categories, so code that compiles and runs natively now runs in the sandbox too. `Option`/`Result` are deliberately excluded: native Hew has no `Option::clone`/`Result::clone` (the shared checker rejects those before the sandbox profile ever runs), so admitting them would be dead allowlist surface, not a real capability.

## Verification

- `make sandbox-parity` (sandbox VM build + `cargo test -p hew-sandbox-wasm --test parity --test parity_ratchet`): 7/7 pass.
- Before/after revert-proof: reverting the allowlist change reproduces exactly 5 `unknown_method_symbol` diagnostics — one per `.clone()` call site in the new fixture (Vec, String, Array, Slice, Regex); restoring the fix compiles the fixture to sandbox bytecode with stdout and exit matching native `hew run`.
- `cargo fmt --check -p hew-sandbox-wasm` and `cargo clippy -p hew-sandbox-wasm --all-targets -- -D warnings`: clean.
- `make playground-manifest-check`: manifest up to date.
- Preflight: ready-to-push

## Out of scope

- WASI runnability of the Regex clone case: `wasm32-wasip1` has no regex FFI symbols at all (undefined at `wasm-ld` link time), a pre-existing gap unrelated to this change; the new fixture marks its WASI capability `unsupported`.
- `Option`/`Result` clone admission (see Summary) — no native method exists to mirror.

Part of rc1 ecosystem readiness.