### PR TITLE
test(runtime): free restart-await slots I create

### DIFF
--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -3585,7 +3585,13 @@ mod tests {
                 (*sup).restart_await_waiters.lock_or_recover().is_empty(),
                 "notify_restart must drain every parked waiter"
             );
-            // notify drained + freed the observer's retained ref; the slot is gone.
+            assert_eq!(
+                crate::read_slot::read_slot_refs_for_test(slot),
+                1,
+                "notify must release only the observer ref"
+            );
+            // Match the codegen bind edge: the caller releases the creator ref.
+            crate::read_slot::hew_read_slot_free(slot);
 
             hew_supervisor_stop(sup);
         }
@@ -3612,6 +3618,13 @@ mod tests {
                 (*sup).restart_await_waiters.lock_or_recover().is_empty(),
                 "detach must remove the waiter"
             );
+            assert_eq!(
+                crate::read_slot::read_slot_refs_for_test(slot),
+                1,
+                "detach must release only the observer ref"
+            );
+            // The direct caller still releases the creator ref after detach.
+            crate::read_slot::hew_read_slot_free(slot);
 
             // A later notify has nothing to wake (the waiter is gone).
             store_child_slot(&mut *sup, 0, child);


### PR DESCRIPTION
## Summary

The two direct-runtime `restart_await` tests created a `HewReadSlot` (creator reference, refs=1) but only released the observer reference that notify/detach drops, leaking the creator allocation on every run. Real programs never hit this: the generated bind path always frees the creator reference. I updated both tests to assert the observer release (refs 2 -> 1) and then free the creator reference (refs 1 -> 0), mirroring the neighbouring test that already gets this right.

## Verification

- `cargo test -p hew-runtime --lib`: 2043 passed, 0 failed.
- Targeted `restart_await`/`read_slot` tests: 20 passed, 0 failed.
- Host ASan run over the targeted tests: clean, no leak or use-after-free findings.
- `cargo clippy -p hew-runtime --all-targets -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.

## Out of scope

- Production notify/detach reference ownership is unchanged. Making notify or detach consume the creator reference (instead of just the observer reference) would double-free against the generated bind path's cleanup.

Fixes #2548