### PR TITLE
fix(mir,codegen): free nested-collection actor state and borrow indexed cursors

### DIFF
--- a/hew-cli/tests/nested_collection_ownership_oracle.rs
+++ b/hew-cli/tests/nested_collection_ownership_oracle.rs
@@ -32,6 +32,58 @@ fn main() -> i64 {
 }
 ";
 
+// Shape 1: local `Vec<Vec<T>>` iterated over the OUTER vec. The loop variable
+// `row` is an inner Vec still owned by `rows`, so it must BORROW — the recursive
+// `hew_vec_free_owned` drop of `rows` is the sole freer. A per-iteration free of
+// `row` would double-free against that recursion; the scribble allocator turns a
+// double-free into an abort, so a clean exit proves the loop variable borrows.
+const LOCAL_OUTER_ITER_SOURCE: &str = "\
+fn main() -> i64 {
+    let rows: Vec<Vec<i64>> = Vec::new();
+    let a: Vec<i64> = Vec::new();
+    a.push(1);
+    a.push(2);
+    rows.push(a);
+    let b: Vec<i64> = Vec::new();
+    b.push(3);
+    b.push(4);
+    rows.push(b);
+    var sum: i64 = 0;
+    for row in rows {
+        sum = sum + row[0];
+    }
+    sum
+}
+";
+
+// Shape 6: single-element actor-state `Vec<Vec<T>>`. Pre-fix this read 0 leaks
+// only by coincidence (the one inner vec happened to be freed by a for-loop
+// cursor); with the recursive owned teardown it is genuinely freed once by the
+// state drop. Runs under the scribble allocator so any double-free aborts.
+const ACTOR_SINGLE_INNER_SOURCE: &str = "\
+actor Holder {
+    var rows: Vec<Vec<i64>>;
+
+    receive fn count() -> i64 {
+        rows.len()
+    }
+}
+
+fn main() -> i64 {
+    let rows: Vec<Vec<i64>> = Vec::new();
+    let inner: Vec<i64> = Vec::new();
+    inner.push(7);
+    inner.push(8);
+    rows.push(inner);
+    let holder = spawn Holder(rows: rows);
+    sleep(500ms);
+    match await holder.count() {
+        Ok(v) => v,
+        Err(_) => -1,
+    }
+}
+";
+
 fn actor_nested_vec_source(rows: usize) -> String {
     format!(
         "actor Buckets {{\n\
@@ -53,6 +105,74 @@ fn actor_nested_vec_source(rows: usize) -> String {
          \x20   let buckets = spawn Buckets(rows: rows);\n\
          \x20   sleep(500ms);\n\
          \x20   match await buckets.count() {{\n\
+         \x20       Ok(v) => v,\n\
+         \x20       Err(_) => -1,\n\
+         \x20   }}\n\
+         }}\n"
+    )
+}
+
+// Shape 4: actor-state `Vec<Vec<T>>` iterated over the OUTER vec INSIDE a receive
+// handler, then torn down. Exercises the loop variable over a state-owned inner
+// vec (must borrow) followed by the recursive state teardown (must free each
+// inner once). A per-iteration free would double-free against the teardown; an
+// under-free at teardown would show as a per-row leak slope.
+fn actor_nested_vec_iterate_source(rows: usize) -> String {
+    format!(
+        "actor Buckets {{\n\
+         \x20   var rows: Vec<Vec<i64>>;\n\
+         \n\
+         \x20   receive fn sum_firsts() -> i64 {{\n\
+         \x20       var s: i64 = 0;\n\
+         \x20       for row in rows {{\n\
+         \x20           s = s + row[0];\n\
+         \x20       }}\n\
+         \x20       s\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let rows: Vec<Vec<i64>> = Vec::new();\n\
+         \x20   for i in 0..{rows} {{\n\
+         \x20       let row: Vec<i64> = Vec::new();\n\
+         \x20       row.push(i);\n\
+         \x20       row.push(i + 1);\n\
+         \x20       rows.push(row);\n\
+         \x20   }}\n\
+         \x20   let buckets = spawn Buckets(rows: rows);\n\
+         \x20   sleep(500ms);\n\
+         \x20   match await buckets.sum_firsts() {{\n\
+         \x20       Ok(_) => 0,\n\
+         \x20       Err(_) => -1,\n\
+         \x20   }}\n\
+         }}\n"
+    )
+}
+
+// `Vec<HashMap<K, V>>` actor state: the same owned-descriptor routing must free
+// each inner HashMap via `hew_hashmap_free_layout` at teardown. Pins the
+// HashMap-element branch of the witness routing (not just the `Vec<Vec<T>>` one).
+fn actor_nested_hashmap_source(rows: usize) -> String {
+    format!(
+        "actor Registry {{\n\
+         \x20   var buckets: Vec<HashMap<string, i64>>;\n\
+         \n\
+         \x20   receive fn total() -> i64 {{\n\
+         \x20       buckets.len()\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let buckets: Vec<HashMap<string, i64>> = Vec::new();\n\
+         \x20   for i in 0..{rows} {{\n\
+         \x20       let m: HashMap<string, i64> = HashMap::new();\n\
+         \x20       m.insert(\"a\", i);\n\
+         \x20       m.insert(\"b\", i + 1);\n\
+         \x20       buckets.push(m);\n\
+         \x20   }}\n\
+         \x20   let reg = spawn Registry(buckets: buckets);\n\
+         \x20   sleep(500ms);\n\
+         \x20   match await reg.total() {{\n\
          \x20       Ok(v) => v,\n\
          \x20       Err(_) => -1,\n\
          \x20   }}\n\
@@ -87,4 +207,60 @@ fn local_indexed_inner_iteration_frees_each_vec_once() {
 #[test]
 fn actor_nested_vec_teardown_has_no_per_row_leak_slope() {
     assert_frame_slope_below_tolerance("actor_nested_vec_teardown", actor_nested_vec_source);
+}
+
+#[test]
+fn local_outer_iteration_borrows_each_inner_vec() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("nested-collection-local-outer-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(LOCAL_OUTER_ITER_SOURCE, dir.path(), "local_outer_iter");
+    let output = run_under_malloc_scribble(&bin);
+
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "iterating the outer Vec must borrow each inner-Vec loop variable and leave the \
+         recursive outer drop as the sole freer;\n{}",
+        describe_output(&output)
+    );
+}
+
+#[test]
+fn actor_single_inner_vec_teardown_runs_clean() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("nested-collection-single-inner-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(ACTOR_SINGLE_INNER_SOURCE, dir.path(), "actor_single_inner");
+    let output = run_under_malloc_scribble(&bin);
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "a single-element actor-state Vec<Vec<T>> must tear down cleanly (freed once by the \
+         recursive state drop, not by loop coincidence);\n{}",
+        describe_output(&output)
+    );
+}
+
+#[test]
+fn actor_state_outer_iteration_has_no_per_row_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "actor_state_outer_iteration",
+        actor_nested_vec_iterate_source,
+    );
+}
+
+#[test]
+fn actor_nested_hashmap_teardown_has_no_per_row_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "actor_nested_hashmap_teardown",
+        actor_nested_hashmap_source,
+    );
 }

--- a/hew-cli/tests/nested_collection_ownership_oracle.rs
+++ b/hew-cli/tests/nested_collection_ownership_oracle.rs
@@ -1,0 +1,90 @@
+//! Nested-collection exactly-once ownership oracles for #2545 and #2546.
+//!
+//! The two regressions are duals: local `Vec<Vec<T>>` already drops recursively,
+//! so a cursor over `rows[i]` must borrow the indexed inner Vec; actor-state
+//! `Vec<Vec<T>>` must use the same recursive clone/free protocol at teardown.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+const LOCAL_INDEXED_INNER_SOURCE: &str = "\
+fn main() -> i64 {
+    let rows: Vec<Vec<i64>> = Vec::new();
+    let a: Vec<i64> = Vec::new();
+    a.push(1);
+    a.push(2);
+    rows.push(a);
+    let b: Vec<i64> = Vec::new();
+    b.push(3);
+    b.push(4);
+    rows.push(b);
+    var sum: i64 = 0;
+    for v in rows[0] {
+        sum = sum + v;
+    }
+    sum
+}
+";
+
+fn actor_nested_vec_source(rows: usize) -> String {
+    format!(
+        "actor Buckets {{\n\
+         \x20   var rows: Vec<Vec<i64>>;\n\
+         \n\
+         \x20   receive fn count() -> i64 {{\n\
+         \x20       rows.len()\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let rows: Vec<Vec<i64>> = Vec::new();\n\
+         \x20   for i in 0..{rows} {{\n\
+         \x20       let row: Vec<i64> = Vec::new();\n\
+         \x20       row.push(i);\n\
+         \x20       row.push(i + 1);\n\
+         \x20       rows.push(row);\n\
+         \x20   }}\n\
+         \x20   let buckets = spawn Buckets(rows: rows);\n\
+         \x20   sleep(500ms);\n\
+         \x20   match await buckets.count() {{\n\
+         \x20       Ok(v) => v,\n\
+         \x20       Err(_) => -1,\n\
+         \x20   }}\n\
+         }}\n"
+    )
+}
+
+#[test]
+fn local_indexed_inner_iteration_frees_each_vec_once() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("nested-collection-local-index-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(
+        LOCAL_INDEXED_INNER_SOURCE,
+        dir.path(),
+        "local_indexed_inner",
+    );
+    let output = run_under_malloc_scribble(&bin);
+
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "indexed inner-Vec iteration must borrow the handle and leave the recursive outer \
+         Vec drop as its sole freer;\n{}",
+        describe_output(&output)
+    );
+}
+
+#[test]
+fn actor_nested_vec_teardown_has_no_per_row_leak_slope() {
+    assert_frame_slope_below_tolerance("actor_nested_vec_teardown", actor_nested_vec_source);
+}

--- a/hew-codegen-rs/src/layout.rs
+++ b/hew-codegen-rs/src/layout.rs
@@ -888,6 +888,21 @@ pub(crate) fn collection_layout_witness(
         )));
     }
     Ok(match kind {
+        StateFieldCloneKind::Vec { elem } if elem.is_heap_collection_handle() => {
+            // #2546 — a nested/heap-element Vec (`Vec<Vec<T>>` / `Vec<HashMap>` /
+            // `Vec<HashSet>`). The outer handle was constructed through the OWNED
+            // descriptor ABI (`hew_vec_new_with_elem_layout` with the per-element
+            // clone/drop thunk `collection_elem_clone_drop_syms` stamped), so its
+            // clone/free MUST run those thunks via the `_owned` pair. The managed
+            // pair below frees only the outer buffer + handle and leaks every
+            // inner handle. Symmetric with the local `Vec<Vec<T>>` release, so the
+            // state clone/drop, the overwrite-release store, and the field-load
+            // retain never select mismatched symbols (`lifecycle-symmetry`).
+            Some(CollectionLayoutWitness {
+                clone_sym: VEC_CLONE_OWNED_SYMBOL,
+                drop_sym: VEC_FREE_OWNED_SYMBOL,
+            })
+        }
         StateFieldCloneKind::Vec { .. } => Some(CollectionLayoutWitness {
             // Constructor lowering stamps every layout-backed Vec<T> handle with
             // its `HewTypeLayout` descriptor; the managed pair reads it from the

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -9305,6 +9305,18 @@ pub(crate) const HASHSET_FREE_LAYOUT_SYMBOL: &str = "hew_hashset_free_layout";
 pub(crate) const VEC_CLONE_MANAGED_SYMBOL: &str = "hew_vec_clone_managed";
 pub(crate) const VEC_FREE_MANAGED_SYMBOL: &str = "hew_vec_free_managed";
 
+/// The owned-descriptor clone/free pair, for a state `Vec<E>` whose element `E`
+/// is itself a heap collection handle (`Vec` / `HashMap` / `HashSet`). Such an
+/// outer handle is constructed through the owned descriptor ABI
+/// (`hew_vec_new_with_elem_layout`), so its clone/free MUST run the per-element
+/// descriptor thunks — the managed pair frees only the outer buffer and leaks
+/// every element (#2546). Symmetric with the local `Vec<Vec<T>>` release and
+/// with the element thunks `collection_elem_clone_drop_syms` selects, so the
+/// state clone/drop, the overwrite-release store, and the field-load retain all
+/// agree per element-class (`lifecycle-symmetry`, W4.045 UAF class).
+pub(crate) const VEC_CLONE_OWNED_SYMBOL: &str = "hew_vec_clone_owned";
+pub(crate) const VEC_FREE_OWNED_SYMBOL: &str = "hew_vec_free_owned";
+
 fn clone_helper_for_kind(kind: &StateFieldCloneKind) -> CodegenResult<Option<CloneHelper>> {
     match kind {
         StateFieldCloneKind::BitCopy { .. } => Ok(None),

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -11421,6 +11421,48 @@ impl Builder {
         }
     }
 
+    /// True when the `for x in …` cursor `value` iterates an INDEX projection
+    /// `container[i]` whose `container` is an owned-element `Vec` — a
+    /// `Vec<Vec<T>>` / `Vec<HashMap>` / `Vec<HashSet>` / `Vec<heap-owning
+    /// record/tuple>` whose scope-exit (or actor-state) release is
+    /// `hew_vec_free_owned`, which RECURSES and frees every element handle,
+    /// including `container[i]`, via the per-element descriptor drop thunk.
+    ///
+    /// #2545 — the sibling of [`Self::vec_iter_source_projects_actor_state_field`]
+    /// for the LOCAL Vec-element case. `for v in rows[i]` lowers to
+    /// `VecIter { vec: rows[i], idx }`; the `vec` source is an `Index` expression,
+    /// not a bare `BindingRef` + `Capture`, so
+    /// [`vec_iter_let_cursor_owns_handle`] classifies the cursor as the SOLE
+    /// owner and registers it for a scope-exit `RecordFieldDrop` of `rows[i]`.
+    /// But the container `rows` (`Vec<Vec<T>>`) is itself released by
+    /// `hew_vec_free_owned`, whose recursion ALSO frees `rows[i]` — the exact
+    /// double-free the poisoned allocator turns into an abort. Unlike a local
+    /// RECORD field escaping into a cursor (`for v in localBox.v`), where the
+    /// record's drop of the escaped field is elided (#2212) so the cursor is the
+    /// lone freer, a Vec ELEMENT projection has NO such elision: the container's
+    /// recursive drop is the exactly-once freer, so the cursor must BORROW.
+    ///
+    /// Keyed on the container's resolved type being an owned-element Vec —
+    /// [`Self::binding_ty_is_owned_element_vec`], the SAME authority the
+    /// constructor and the container's own `hew_vec_free_owned` release consult —
+    /// so the borrow fires for exactly the containers whose recursion frees the
+    /// indexed element (`dedup-semantic-boundary`). Covers a local binding, an
+    /// actor-state field (whose recursive teardown lands in the same lane), and
+    /// an rvalue container equally: whichever owner recurses is the sole freer.
+    /// A plain `Vec<i64>` container is NOT owned-element, so `for v in flat[i]`
+    /// (element `i64`, no per-element drop) is untouched and keeps its existing
+    /// disposition. Fail-closed direction is a leak (borrow when the container
+    /// does not in fact recurse), never the double-free.
+    fn vec_iter_source_indexes_owned_element_vec(&self, value: &HirExpr) -> bool {
+        let Some(src) = vec_iter_init_vec_source_expr(value) else {
+            return false;
+        };
+        let HirExprKind::Index { container, .. } = &src.kind else {
+            return false;
+        };
+        self.binding_ty_is_owned_element_vec(&self.subst_ty(&container.ty))
+    }
+
     /// Close every `Stream<T>` / `Receiver<T>` for-await cursor declared in
     /// `scope_id` when that scope closes — the `Generator`/`VecIter` analogue of
     /// #1949 for the general `for await` consumption path. A `for await v in
@@ -13928,9 +13970,17 @@ impl Builder {
                     // that state-owned buffer against the state drop (the UAF the
                     // supervisor normal-return cleanup epilogue exposes). See
                     // `vec_iter_source_projects_actor_state_field`.
+                    //
+                    // #2545 — an INDEX projection of an owned-element Vec
+                    // (`for v in rows[i]`, `rows: Vec<Vec<T>>`) is excluded for the
+                    // same reason: the container's `hew_vec_free_owned` recursion
+                    // frees `rows[i]` exactly once, so the cursor must BORROW or
+                    // the inner handle is freed twice. See
+                    // `vec_iter_source_indexes_owned_element_vec`.
                     if vec_iter_ty_drop_safe(&binding_ty)
                         && vec_iter_let_cursor_owns_handle(value)
                         && !self.vec_iter_source_projects_actor_state_field(value)
+                        && !self.vec_iter_source_indexes_owned_element_vec(value)
                     {
                         if let Some(scope) = self.active_scopes.last().copied() {
                             self.scope_vec_iter_bindings.push((

--- a/hew-mir/src/state_clone.rs
+++ b/hew-mir/src/state_clone.rs
@@ -387,6 +387,38 @@ impl StateFieldCloneKind {
         }
     }
 
+    /// True when this kind is a heap COLLECTION HANDLE — a `Vec`, `HashMap`, or
+    /// `HashSet`. Such a value is a single owned heap handle whose own release
+    /// (`hew_vec_free_owned` / `hew_hashmap_free_layout` / `hew_hashset_free_
+    /// layout`) recurses into its buffer.
+    ///
+    /// #2546 — the routing discriminator for a state `Vec<E>` field's clone/free
+    /// symbols. When `E` is one of these handles, the OUTER `Vec<E>` was
+    /// constructed through the owned descriptor ABI (`hew_vec_new_with_elem_
+    /// layout`, a per-element clone/drop thunk stamped by
+    /// `collection_elem_clone_drop_syms`), so the outer handle MUST clone/free
+    /// through the `_owned` pair, which runs those per-element thunks. The shallow
+    /// managed pair frees only the outer buffer + handle and leaks every element.
+    /// This is the exact structural subset of the constructor's
+    /// `is_owned_vec_element` / `resolved_ty_element_owns_heap_for_owned_vec`
+    /// authority that is decidable from the classified kind alone (a nested
+    /// collection element is UNAMBIGUOUSLY owned-descriptor), so the free symbol
+    /// can never disagree with the alloc ABI (`dedup-semantic-boundary`,
+    /// `vec-element-width-symmetric-abi`). A `Vec<record/tuple>` whose element
+    /// owns heap only through a nested user record/enum is NOT matched here — the
+    /// kind carries only a registry key for those, so it stays on the managed
+    /// pair (fail-closed: a leak, never a wrong-ABI free/abort); those shapes are
+    /// deferred to a sibling issue.
+    #[must_use]
+    pub fn is_heap_collection_handle(&self) -> bool {
+        matches!(
+            self,
+            StateFieldCloneKind::Vec { .. }
+                | StateFieldCloneKind::HashMap { .. }
+                | StateFieldCloneKind::HashSet { .. }
+        )
+    }
+
     /// True when a field of this kind is admissible to the owned-aggregate
     /// record value-class (the `__hew_record_{clone,drop}_inplace_<R>` in-place
     /// record spine).


### PR DESCRIPTION
## Summary

Actor-state `Vec` fields whose elements are themselves heap collections (`Vec<Vec<T>>`, `Vec<HashMap<K,V>>`) now route through the recursive owned free path at teardown, so the inner collections are freed instead of leaked. A for-loop cursor over an index projection `container[i]` of such a container now borrows rather than owns, since the container's own recursive drop is the sole freer — this closes a double-free when iterating a locally-owned `Vec<Vec<T>>` by index (`for v in rows[i]`). Flat `Vec<i64>` state fields are unchanged; the managed free path still handles them.

## Verification

- `make test-hew-ratchet`: 0 expected failures / 0 actual failures — PASSED
- `make checked-mir-verify`: OK (40 fixtures x 2 stages, byte-identical)
- Nested-collection ownership oracle (6 shapes, local + actor-state, index + outer iteration): 6/6, exact-exit and scribble-abort and leak-slope assertions
- State-overwrite leak guard (existing regression pin): 12/12, unchanged
- `cargo test -p hew-mir -p hew-codegen-rs`: green
- Independently re-run and verified by a second reviewer pass, including a fail-direction analysis confirming the predicate cannot miss (no double-free path) for the reachable `Vec<Vec<T>>` set

## Out of scope

- `Vec<record/enum-owning-heap>` and `Vec<tuple-with-blind-record>` actor-state fields stay on the managed free path — element heap-ownership isn't visible at that layer yet, so these remain a pre-existing leak (fail-closed, never a wrong-ABI free or abort). Same bug class as this fix; candidate for a follow-up.
- `HashMap<K, Vec>` value recursion is unchanged — per the same deferral.

Fixes #2545
Fixes #2546