### PR TITLE
fix(mir): drop unnamed fresh bytes/string call-result temporaries without freeing borrowed reads

### DIFF
--- a/hew-cli/tests/bytes_drop_leak_oracle.rs
+++ b/hew-cli/tests/bytes_drop_leak_oracle.rs
@@ -265,6 +265,105 @@ fn owned_partner_escape_source(frames: usize) -> String {
     )
 }
 
+/// Fixture I — #2542: an UNNAMED user-call `bytes` result used as a transient
+/// method receiver. `mk()` returns a fresh owned bytes; `.len()` borrows it
+/// (`hew_vec_len`); with no `let` binding the result flows straight into that
+/// borrow and then dies. Pre-fix the temp had no drop on ANY edge (slope 1.0
+/// leak/frame — the leak this issue reports); post-fix the
+/// nested-fresh-bytes-temp splice releases it exactly once right after the
+/// borrow. The sibling `let b = mk(); b.len()` already held flat (it routes
+/// through the binding-scoped `derive_local_bytes_drop_allowed`), so this
+/// fixture pins the transient gap specifically.
+fn usercall_transient_len_source(frames: usize) -> String {
+    format!(
+        "fn mk() -> bytes {{ \"unnamed-usercall-transient-payload\".to_bytes() }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       total = total + mk().len();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Fixture I2 — #2542 terminator-use path: an unnamed user-call `bytes` result
+/// borrowed by a method that lowers to a `Terminator::Call` (`.get(i)` →
+/// `hew_bytes_get`). Every `Terminator::Call` bytes arg is a borrow (Hew's
+/// by-value heap params), so the transient is released at the call's
+/// continuation. Pre-fix slope 1.0 leak/frame; post-fix flat.
+fn usercall_transient_get_source(frames: usize) -> String {
+    format!(
+        "fn mk() -> bytes {{ \"usercall-get-transient-payload\".to_bytes() }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       match mk().get(0) {{\n\
+         \x20           Some(_b) => {{ total = total + 1; }}\n\
+         \x20           None => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n"
+    )
+}
+
+/// Fixture J — #2542 discard: a user-call `bytes` result in statement position
+/// (`mk();`). Zero uses; pre-fix the discarded temp leaked every frame, post-fix
+/// the splice drops it at the front of the producer's single-predecessor
+/// continuation. The slope doubles as the over-retain gate: an inline drop that
+/// mis-fired more than once would still fail the balance.
+fn usercall_discarded_source(frames: usize) -> String {
+    format!(
+        "fn mk() -> bytes {{ \"usercall-discarded-transient-payload\".to_bytes() }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       mk();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   i\n\
+         }}\n"
+    )
+}
+
+/// No-double-free pin (#2542): the shapes the nested-fresh-bytes-temp pass must
+/// NOT drop. `let b = mk()` is released by the binding-scoped derivation; a
+/// user-call result RETURNED by `forward()` is owned by the caller; a user-call
+/// result moved into a record FIELD is owned by the aggregate. If the pass
+/// mis-admitted any (a `Move`/return/record-ingress is NOT a borrowing use, so
+/// each must stay excluded), the producer-side drop would free a buffer the real
+/// owner also frees — a crash under the poisoned-allocator triple before the
+/// `42 OK` checksum prints. Each payload is 14 bytes, so the three `.len()`
+/// reads sum to 42.
+const BYTES_USERCALL_NO_DOUBLE_FREE_SOURCE: &str = "\
+fn mk() -> bytes {\n\
+\x20   \"escape-payload\".to_bytes()\n\
+}\n\
+\n\
+fn forward() -> bytes {\n\
+\x20   mk()\n\
+}\n\
+\n\
+type Boxed {\n\
+\x20   payload: bytes,\n\
+}\n\
+\n\
+fn main() {\n\
+\x20   let b = mk();\n\
+\x20   let named_len = b.len();\n\
+\x20   let fwd = forward();\n\
+\x20   let fwd_len = fwd.len();\n\
+\x20   let boxed = Boxed { payload: mk() };\n\
+\x20   let box_len = boxed.payload.len();\n\
+\x20   print(named_len + fwd_len + box_len);\n\
+\x20   print(\"OK\");\n\
+}\n";
+
 // ── leak measurement plumbing (same shape as recv_loop_leak_oracle) ──────
 
 /// Compile `source` to a native binary via `hew compile --emit-dir` and
@@ -539,5 +638,91 @@ fn bytes_owned_partner_escape_no_per_frame_leak_slope() {
         owned_partner_escape_source,
         LOW_FRAMES,
         HIGH_FRAMES,
+    );
+}
+
+/// Fixture I: an unnamed user-call `bytes` result used as a transient method
+/// receiver (`mk().len()`) — the #2542 leak. Pre-fix slope 1.0 leak/frame (the
+/// temp had no drop on any edge); post-fix the nested-fresh-bytes-temp splice
+/// releases it once after the borrow. Reverting either the collector's
+/// admission or the apply splice fails this by ~47 nodes.
+#[test]
+fn bytes_usercall_transient_receiver_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "bytes_usercall_transient_len",
+        usercall_transient_len_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// Fixture I2: an unnamed user-call `bytes` result borrowed by a
+/// `Terminator::Call` method (`mk().get(0)`). Pre-fix slope 1.0 leak/frame;
+/// post-fix the terminator-use splice releases it at the continuation.
+#[test]
+fn bytes_usercall_transient_terminator_use_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "bytes_usercall_transient_get",
+        usercall_transient_get_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// Fixture J: a discarded user-call `bytes` result (`mk();`). Pre-fix slope 1.0
+/// leak/frame; post-fix the discard splice drops it at the producer's
+/// continuation. Holds flat.
+#[test]
+fn bytes_usercall_discarded_no_per_frame_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "bytes_usercall_discarded",
+        usercall_discarded_source,
+        LOW_FRAMES,
+        HIGH_FRAMES,
+    );
+}
+
+/// No-double-free pin (#2542): the named-binding / returned / record-ingress
+/// shapes the nested-fresh-bytes-temp pass must leave alone run to completion
+/// under the poisoned-allocator triple and print the `42 OK` checksum. A
+/// producer-side drop of any of those (mis-admitting a `Move`/return/record
+/// ingress as a borrowing use) would free a buffer the real owner also frees —
+/// a crash or scribbled value before the checksum prints.
+#[test]
+fn bytes_usercall_escape_shapes_run_clean_under_malloc_scribble() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("bytes-leak-usercall-escape-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(
+        BYTES_USERCALL_NO_DOUBLE_FREE_SOURCE,
+        dir.path(),
+        "usercall_escape_shapes",
+    );
+
+    let output = Command::new(&bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .expect("run usercall-escape-shapes binary");
+
+    assert!(
+        output.status.success(),
+        "usercall escape shapes must run clean under the poisoned allocator — a \
+         crash here indicates the nested-fresh-bytes-temp pass mis-dropped a \
+         named-binding / returned / record-ingress bytes value (double free);\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        "42OK",
+        "usercall escape shapes must print the 3x14 checksum untouched — a \
+         scribbled value indicates the producer freed a buffer the real owner \
+         still reads;\n{}",
+        describe_output(&output)
     );
 }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -40520,11 +40520,17 @@ mod nested_fresh_string_temp_drop_admission {
 ///    `derive_local_bytes_drop_allowed` drops — disjoint by construction, so a
 ///    buffer is never claimed by both);
 /// 3. it has NO instruction writer (its sole def is the producer terminator);
-/// 4. it has AT MOST ONE source-use, and (if present) that use is a
-///    receiver-/all-args-borrowing `bytes` runtime op — an
-///    `Instr::CallRuntimeAbi` or a `Terminator::Call` on a listed bytes symbol.
-///    Any other use (`Move`/store/return/send/aggregate ingress/user call)
-///    excludes it (leak, never double-free);
+/// 4. it has AT MOST ONE use-site in the FULL dataflow reads
+///    (`dataflow::instr_reads_writes(..).0` for instructions — which, unlike
+///    `instr_source_places`, also sees the borrow-excluded readers
+///    `Instr::WireCodec` / `Instr::BytesRetain` / `Instr::GeneratorNext` — plus
+///    `terminator_source_places` for terminators), and (if present) that use is
+///    a borrowing bytes op — an `Instr::CallRuntimeAbi` with a
+///    receiver-/all-args-borrowing contract, or a `Terminator::Call`. Any other
+///    use (`Move`/store/return/send/aggregate ingress/`WireCodec`/`BytesRetain`)
+///    excludes it (leak, never double-free) — the reads-based table is what
+///    keeps a `Packet.decode(mk())` operand ALIVE past the decode instead of
+///    routing it down the discard branch;
 /// 5. the drop site is provably dominated by the def and entered exactly once
 ///    (single-predecessor continuation), in one of these shapes:
 ///      * discard (zero uses) → drop at the front of the producer's
@@ -40580,13 +40586,31 @@ fn collect_nested_fresh_bytes_temp_drops(
         }
     }
 
-    // Source-use sites per local (rule 4), deduplicated within each
+    // Use sites per local (rule 4), deduplicated within each
     // instruction/terminator so a temp referenced twice by one call counts once.
+    //
+    // Instruction uses come from the full dataflow READS
+    // (`dataflow::instr_reads_writes(..).0`), NOT from `instr_source_places`.
+    // The two tables encode different facts: `instr_source_places` deliberately
+    // EXCLUDES borrow-only readers (`Instr::WireCodec`'s decode operand,
+    // `Instr::BytesRetain`'s value, `Instr::GeneratorNext`'s ctx) so a NAMED
+    // binding keeps its scope-exit drop past those reads — but this collector
+    // needs "is the temp actually read at all / where". A hidden reader the
+    // source table hides would register ZERO uses, route the temp down the
+    // discard branch, and splice `hew_bytes_drop` at the front of the
+    // continuation BEFORE the reader runs — a use-after-free
+    // (`Packet.decode(mk())` trapped exactly this way). With the reads table, a
+    // hidden reader is a real use-site that the borrow-only classification
+    // rejects (not an admissible borrowing bytes runtime op), so the temp fails
+    // CLOSED to the leak direction. Terminator uses keep
+    // `terminator_source_places`, which has no borrow-exclusions (every reading
+    // variant lists its operands).
     let mut source_uses: HashMap<u32, Vec<NestedUseSite>> = HashMap::new();
     for block in blocks {
         for (idx, instr) in block.instructions.iter().enumerate() {
             let mut here: HashSet<u32> = HashSet::new();
-            for p in instr_source_places(instr) {
+            let (reads, _) = crate::dataflow::instr_reads_writes(instr);
+            for p in reads {
                 if let Some(l) = base_local(p) {
                     here.insert(l);
                 }
@@ -41141,6 +41165,63 @@ mod nested_fresh_bytes_temp_drop_admission {
             collect(&blocks, &locals, &HashMap::new()).is_empty(),
             "a bytes temp consumed by an actor send must not be dropped by the \
              sender (the mailbox copy / state_drop owns the release)"
+        );
+    }
+
+    #[test]
+    fn usercall_result_read_only_by_wire_decode_is_not_discard_dropped() {
+        // `Packet.decode(mk())`: the fresh bytes temp's ONLY reader is
+        // `Instr::WireCodec` (decode operand). `instr_source_places` deliberately
+        // excludes that read (a borrow-exclusion so NAMED bindings keep their
+        // scope-exit drop) — a source-places-based use table would register ZERO
+        // uses, take the discard branch, and splice `hew_bytes_drop` at the
+        // front of the continuation BEFORE the decode reads the buffer (the
+        // reproduced use-after-free). The reads-based table sees the WireCodec
+        // use-site; it is not an admissible borrowing bytes runtime op, so the
+        // temp fails CLOSED to the leak direction: NO drop is spliced.
+        let blocks = vec![
+            block(0, vec![], user_call("mk", 2, 1)),
+            block(
+                1,
+                vec![Instr::WireCodec {
+                    dest: Place::Local(5),
+                    operand: Place::Local(2),
+                    direction: hew_types::WireCodecDirection::Decode,
+                    value_ty: ResolvedTy::named_user("Packet", vec![]),
+                }],
+                Terminator::Return,
+            ),
+        ];
+        let locals = bytes_locals_with(&[(5, ResolvedTy::named_user("Packet", vec![]))]);
+        assert!(
+            collect(&blocks, &locals, &HashMap::new()).is_empty(),
+            "a bytes temp whose only reader is a WireCodec decode must not take \
+             the discard drop — a front-of-continuation hew_bytes_drop would free \
+             the buffer before the decode reads it (use-after-free)"
+        );
+    }
+
+    #[test]
+    fn usercall_result_read_only_by_bytes_retain_is_not_discard_dropped() {
+        // Same hidden-reader class: `Instr::BytesRetain` reads its value but is
+        // excluded from `instr_source_places`. The reads-based use table must
+        // see it and fail closed (no discard drop), never splice a drop the
+        // retain's co-owner accounting did not budget for.
+        let blocks = vec![
+            block(0, vec![], user_call("mk", 2, 1)),
+            block(
+                1,
+                vec![Instr::BytesRetain {
+                    value: Place::Local(2),
+                }],
+                Terminator::Return,
+            ),
+        ];
+        let locals = bytes_locals_with(&[]);
+        assert!(
+            collect(&blocks, &locals, &HashMap::new()).is_empty(),
+            "a bytes temp read by a BytesRetain must not take the discard drop; \
+             the retain implies a co-owner mint this collector cannot balance"
         );
     }
 

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -38350,7 +38350,18 @@ pub fn terminator_source_places(
         Terminator::Call { args, .. } => args.clone(),
         Terminator::Yield { value, .. } => vec![*value],
         // `dest` is the handle slot the generator is written into (a write);
-        // `body_fn` is a static symbol, not a Place — no source operands.
+        // `body_fn` is a static symbol, not a Place. `env` (when present) IS
+        // read — the ramp flat-copies the capture env into the coro frame —
+        // but is deliberately NOT listed as a source: the env place is always
+        // the dedicated closure-env aggregate local `ClosureEnvInit` just
+        // built (never a user binding or a leaf string/bytes temp), and
+        // listing it would make the escape scans treat the env local itself
+        // as escaping. Every USER value enters the env through
+        // `ClosureEnvInit`, whose reads the dataflow table
+        // (`dataflow::instr_reads_writes`) already reports — consumers that
+        // need every read (the nested fresh-temp collectors) use that table,
+        // not this one. Note the asymmetry with `MakeLambdaActor` below,
+        // which does list its env.
         Terminator::MakeGenerator { .. } => Vec::new(),
         // Lambda-actor construction: `dest` is written; `body_fn` and
         // `state_drop_fn` are static symbols. The capture env (when
@@ -39845,11 +39856,17 @@ fn block_by_id(blocks: &[BasicBlock], id: u32) -> Option<&BasicBlock> {
 ///    construction, so a buffer is never claimed by both);
 /// 3. it has exactly ONE def, a known fresh producer (no instruction
 ///    re-definition; a producer-terminator temp has no instruction writer);
-/// 4. it has AT MOST ONE source-use, and (if present) that use is verified
-///    borrowing-only: a borrowing `Terminator::Call`, a string compare
-///    instruction, or the narrowly-proven nested `hew_string_concat` →
-///    `hew_string_concat` instruction chain. Any other use (`Move`/store/
-///    return/send/user-call) excludes it (leak, never double-free);
+/// 4. it has AT MOST ONE use-site in the FULL dataflow reads
+///    (`dataflow::instr_reads_writes(..).0` for instructions — which, unlike
+///    `instr_source_places`, also sees borrow-excluded readers such as
+///    `Instr::WireCodec`'s operand — plus `terminator_source_places` for
+///    terminators), and (if present) that use is verified borrowing-only: a
+///    borrowing `Terminator::Call`, a string compare instruction, or the
+///    narrowly-proven nested `hew_string_concat` → `hew_string_concat`
+///    instruction chain. Any other use (`Move`/store/return/send/user-call/
+///    `WireCodec`) excludes it (leak, never double-free) — the reads-based
+///    table is what keeps a `Packet.from_json(a + b)` operand ALIVE past the
+///    parse instead of routing it down the discard branch;
 /// 5. the drop site is provably dominated by the def and entered exactly once
 ///    (single-predecessor continuation), in one of these structural shapes:
 ///      * discard, instr def → drop right after the producer instruction (same
@@ -39906,13 +39923,32 @@ fn collect_nested_fresh_string_temp_drops(
         }
     }
 
-    // Source-use sites per local (rule 4), deduplicated within each
+    // Use sites per local (rule 4), deduplicated within each
     // instruction/terminator so a temp referenced twice by one call counts once.
+    //
+    // Instruction uses come from the full dataflow READS
+    // (`dataflow::instr_reads_writes(..).0`), NOT from `instr_source_places` —
+    // the same hidden-borrow-reader correction as the bytes collector
+    // (`collect_nested_fresh_bytes_temp_drops`). `instr_source_places`
+    // deliberately excludes borrow-only readers (`Instr::WireCodec`'s operand,
+    // borrow-only `ClosureEnvInit` fields) so a NAMED binding keeps its
+    // scope-exit drop past those reads; for a bare temp that exclusion
+    // registered ZERO uses, took the discard branch, and spliced
+    // `hew_string_drop` immediately after the producer — freeing the buffer
+    // BEFORE the hidden reader ran. `Packet.from_json(a + b)` parsed a freed
+    // buffer this way: a silent wrong-result (`Err`), while the named
+    // `let joined = a + b` sibling was correct. With the reads table a hidden
+    // reader is a real use-site the borrowing-use classification rejects, so
+    // the temp fails CLOSED to the leak direction. Terminator uses keep
+    // `terminator_source_places` (no borrow-exclusions for any reading
+    // variant; `MakeGenerator`'s env — see its arm's note — never carries a
+    // leaf string/bytes temp directly).
     let mut source_uses: HashMap<u32, Vec<NestedUseSite>> = HashMap::new();
     for block in blocks {
         for (idx, instr) in block.instructions.iter().enumerate() {
             let mut here: HashSet<u32> = HashSet::new();
-            for p in instr_source_places(instr) {
+            let (reads, _) = crate::dataflow::instr_reads_writes(instr);
+            for p in reads {
                 if let Some(l) = base_local(p) {
                     here.insert(l);
                 }
@@ -40362,6 +40398,39 @@ mod nested_fresh_string_temp_drop_admission {
             collect(&blocks, &locals, &HashMap::new()).is_empty(),
             "Vec owned-element ingress is not the proven borrowing concat chain; \
              the collector must leave ownership with the container path"
+        );
+    }
+
+    #[test]
+    fn concat_temp_read_only_by_wire_from_json_is_not_discard_dropped() {
+        // `Packet.from_json(a + b)`: the fresh concat temp's ONLY reader is
+        // `Instr::WireCodec` (FromJson operand) — a borrow-excluded read that
+        // `instr_source_places` hides. A source-places-based use table
+        // registered ZERO uses, took the discard branch, and spliced
+        // `hew_string_drop` immediately after the concat — the parse then read
+        // a freed buffer (silent wrong-result `Err`, while the named
+        // `let joined = a + b` sibling was correct). The reads-based table
+        // sees the WireCodec use-site; it is not an admissible borrowing use,
+        // so the temp fails CLOSED to the leak direction: NO drop is spliced.
+        let blocks = vec![block(
+            0,
+            vec![
+                concat(0, 1, 2),
+                Instr::WireCodec {
+                    dest: Place::Local(5),
+                    operand: Place::Local(2),
+                    direction: hew_types::WireCodecDirection::FromJson,
+                    value_ty: user_record_ty(),
+                },
+            ],
+            Terminator::Return,
+        )];
+        let locals = locals_with(&[(5, user_record_ty())]);
+        assert!(
+            collect(&blocks, &locals, &HashMap::new()).is_empty(),
+            "a string temp whose only reader is a WireCodec parse must not take \
+             the discard drop — an immediate post-producer hew_string_drop \
+             would free the buffer before the parse reads it"
         );
     }
 

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -8338,6 +8338,17 @@ fn lower_function(
         &builder.binding_locals,
         &mut builder.instr_spans,
     );
+    // #2542 — release nested fresh-owned `bytes` user-call-result temporaries
+    // (`mk().len()`, `mk().to_string()`, discarded `mk();`) that
+    // `derive_local_bytes_drop_allowed` (binding-scoped) cannot see. Same
+    // pre-`check_function` ordering rationale as the string splice above.
+    apply_nested_fresh_bytes_temp_drops(
+        &mut blocks,
+        &builder.suspend_kinds,
+        &builder.locals,
+        &builder.binding_locals,
+        &mut builder.instr_spans,
+    );
     // The scope-exit-live owned-locals view, materialised once for the
     // escaped-sibling emitter and the double-free gate below — the same
     // `(binding, name, ty)` tuples they read before the ledger carried richer
@@ -32365,6 +32376,15 @@ impl Builder {
             &builder.binding_locals,
             &mut builder.instr_spans,
         );
+        // #2542 — mirror the closure-shim ramp's string splice for the bytes
+        // user-call-result temp class (see `lower_function`'s call site).
+        apply_nested_fresh_bytes_temp_drops(
+            &mut blocks,
+            &builder.suspend_kinds,
+            &builder.locals,
+            &builder.binding_locals,
+            &mut builder.instr_spans,
+        );
         let thir_statements: Vec<MirStatement> = blocks
             .iter()
             .flat_map(|b| b.statements.iter().cloned())
@@ -33792,6 +33812,17 @@ impl Builder {
         // `check_function`/`elaborate` below so the dataflow observes each
         // inline drop as a read of its temp and codegen emits the release.
         apply_nested_fresh_string_temp_drops(
+            &mut blocks,
+            &body_builder.suspend_kinds,
+            &body_builder.locals,
+            &body_builder.binding_locals,
+            &mut body_builder.instr_spans,
+        );
+        // #2542 — the gen-body ramp needs the identical bytes user-call-result
+        // temp splice as `lower_function` (a `mk().len()` inside a `yield`
+        // expression would otherwise leak per iteration). Must run BEFORE
+        // `check_function`/elaborate below, same as the string splice.
+        apply_nested_fresh_bytes_temp_drops(
             &mut blocks,
             &body_builder.suspend_kinds,
             &body_builder.locals,
@@ -40425,6 +40456,711 @@ mod nested_fresh_string_temp_drop_admission {
             collect(&blocks, &locals, &second_concat_binding()).is_empty(),
             "the use block is reachable from a path that skipped the producer; \
              inserting a drop there would free an uninitialized temp"
+        );
+    }
+}
+
+/// #2542 — release a nested fresh-owned `bytes` CALL-RESULT temporary. The
+/// bytes analogue of [`collect_nested_fresh_string_temp_drops`], scoped to the
+/// one producer the string pass cannot see: a USER Hew function returning an
+/// owned `bytes` value whose result flows straight into a borrowing use (or is
+/// discarded) WITHOUT a `let` binding, so the binding-scoped
+/// [`derive_local_bytes_drop_allowed`] never sees it.
+///
+/// Shapes this releases exactly once (each leaked before this fix):
+///
+/// ```text
+///   mk().len()               // user-call bytes temp, borrowed by hew_vec_len
+///   mk().get(i)              // borrowed by hew_bytes_get
+///   mk();                    // discarded user-call bytes temp (zero uses)
+///   "x".to_bytes().len()     // hew_string_to_bytes fresh temp, borrowed
+/// ```
+///
+/// A `let b = mk(); b.len()` is UNCHANGED: `mk`'s dest is a separate temp
+/// `move`d into `b`'s binding local, and a `Move` is not a borrowing use, so the
+/// temp is excluded here (rule 4) and `b`'s scope-exit
+/// `derive_local_bytes_drop_allowed` release remains the sole drop. No double
+/// free.
+///
+/// ## Ownership model (the same refcount keystone as the binding path)
+///
+/// A user Hew function returning `bytes` hands the caller the SOLE drop
+/// obligation: the callee retracts its own return-slot release
+/// (`derive_returned_aggregate_member_bindings` / the `ReturnSlot` move), so the
+/// caller owns exactly one `hew_bytes_drop`. A receiver-/all-args-borrowing
+/// `bytes` runtime op (`hew_vec_len`, `hew_bytes_get`, `hew_bytes_contains`,
+/// `hew_bytes_to_string`, `hew_bytes_slice`, … — every `borrows_bytes_receiver`
+/// / `borrows_all_bytes_args` contract) reads the triple WITHOUT consuming its
+/// refcount, so a fresh temp used once by such a borrow (or never used) still
+/// owns its single obligation afterwards; releasing it once balances the callee.
+///
+/// ## Producer scope (fail-closed, safe direction)
+///
+/// A `builtin: None` `Terminator::Call` returning a `bytes`-typed dest whose
+/// callee is NOT a known runtime symbol AND whose contract does not classify its
+/// result as an interior alias of the receiver. Two producers satisfy this:
+///
+///   * a USER Hew function returning `bytes` — its ABI hands the caller the sole
+///     release (`FAIL_CLOSED` contract), and a Hew function can never return a
+///     borrow (no lifetimes);
+///   * `hew_string_to_bytes` (`"x".to_bytes()`), the one non-allowlisted fresh
+///     `bytes` runtime helper — it allocates a fresh rc==1 buffer.
+///
+/// ALLOWLISTED runtime callees (`hew_bytes_slice`, `hew_vec_get_owned`, …) are
+/// EXCLUDED: some borrow their receiver / return an interior alias, and the
+/// `FreshOwnedBytes` result contract that would let us tell fresh from borrow
+/// per-symbol does not exist yet, so admitting one risks dropping a value that is
+/// actually a borrow (double free). A `b.slice(..).len()` transient therefore
+/// still leaks — a separate, tracked follow-up. The leak is the safe side.
+///
+/// ## Fail-closed admission — a temp earns a drop iff ALL hold
+///
+/// 1. its local is a `bytes` local;
+/// 2. it is NOT a `let`/parameter binding local (those belong to the scope-exit
+///    `derive_local_bytes_drop_allowed` drops — disjoint by construction, so a
+///    buffer is never claimed by both);
+/// 3. it has NO instruction writer (its sole def is the producer terminator);
+/// 4. it has AT MOST ONE source-use, and (if present) that use is a
+///    receiver-/all-args-borrowing `bytes` runtime op — an
+///    `Instr::CallRuntimeAbi` or a `Terminator::Call` on a listed bytes symbol.
+///    Any other use (`Move`/store/return/send/aggregate ingress/user call)
+///    excludes it (leak, never double-free);
+/// 5. the drop site is provably dominated by the def and entered exactly once
+///    (single-predecessor continuation), in one of these shapes:
+///      * discard (zero uses) → drop at the front of the producer's
+///        single-predecessor continuation;
+///      * single borrowing instruction use in the producer's single-predecessor
+///        continuation → drop immediately after the use instruction;
+///      * single borrowing terminator use whose block is the producer's
+///        single-predecessor continuation → drop at the front of that use's
+///        single-predecessor continuation.
+///
+/// Any other CFG shape fails closed (the temp leaks, as before this fix). The
+/// return is a list of `(block_id, insert_index, place, ty)` inline-drop
+/// insertions for the caller to splice in. Pure over `blocks` (no mutation) so
+/// it is unit-testable.
+///
+/// LESSONS: boundary-fail-closed (P0), cleanup-all-exits, raii-null-after-move.
+#[must_use]
+fn collect_nested_fresh_bytes_temp_drops(
+    blocks: &[BasicBlock],
+    suspend_kinds: &HashMap<u32, SuspendKind>,
+    locals: &[ResolvedTy],
+    binding_locals: &HashMap<BindingId, Place>,
+) -> Vec<(u32, usize, Place, ResolvedTy)> {
+    // A drop spliced at the FRONT of a block is sound only if that block is
+    // entered from exactly one place — otherwise it could fire on a path where
+    // the temp was never produced (free of an uninitialised slot / double-free).
+    let mut pred_count: HashMap<u32, usize> = HashMap::new();
+    for block in blocks {
+        for succ in block.successors() {
+            *pred_count.entry(succ).or_insert(0) += 1;
+        }
+    }
+
+    // Binding/parameter locals are released by the scope-exit
+    // `derive_local_bytes_drop_allowed` drops; never double-claim one here.
+    let binding_local_ids: HashSet<u32> = binding_locals
+        .values()
+        .filter_map(|p| base_local(*p))
+        .collect();
+
+    // Any local an instruction writes to. A user-call bytes temp is produced by
+    // its terminator (rule 3): an admissible temp has NO instruction writer, so
+    // a slot reused/re-defined by a later instruction is excluded fail-closed.
+    let mut instr_written: HashSet<u32> = HashSet::new();
+    for block in blocks {
+        for instr in &block.instructions {
+            let (_, writes) = crate::dataflow::instr_reads_writes(instr);
+            for w in writes {
+                if let Some(l) = base_local(w) {
+                    instr_written.insert(l);
+                }
+            }
+        }
+    }
+
+    // Source-use sites per local (rule 4), deduplicated within each
+    // instruction/terminator so a temp referenced twice by one call counts once.
+    let mut source_uses: HashMap<u32, Vec<NestedUseSite>> = HashMap::new();
+    for block in blocks {
+        for (idx, instr) in block.instructions.iter().enumerate() {
+            let mut here: HashSet<u32> = HashSet::new();
+            for p in instr_source_places(instr) {
+                if let Some(l) = base_local(p) {
+                    here.insert(l);
+                }
+            }
+            for l in here {
+                source_uses
+                    .entry(l)
+                    .or_default()
+                    .push(NestedUseSite::Instr {
+                        block: block.id,
+                        idx,
+                    });
+            }
+        }
+        let mut here: HashSet<u32> = HashSet::new();
+        for p in terminator_source_places(&block.terminator, suspend_kinds.get(&block.id)) {
+            if let Some(l) = base_local(p) {
+                here.insert(l);
+            }
+        }
+        for l in here {
+            source_uses
+                .entry(l)
+                .or_default()
+                .push(NestedUseSite::Term { block: block.id });
+        }
+    }
+
+    let mut result: Vec<(u32, usize, Place, ResolvedTy)> = Vec::new();
+    let mut seen: HashSet<u32> = HashSet::new();
+    for block in blocks {
+        // Producer: a `builtin: None` `Terminator::Call` returning an owned
+        // `bytes` dest whose callee is NOT a known runtime symbol. This is a
+        // user Hew function (its ABI hands the caller the sole release —
+        // `FAIL_CLOSED`), OR a non-allowlisted fresh-`bytes` helper such as
+        // `hew_string_to_bytes` (`"x".to_bytes()`), which likewise allocates a
+        // fresh rc==1 buffer. Allowlisted runtime callees (`hew_bytes_slice`,
+        // `hew_bytes_get`, …) are excluded here: some borrow their receiver, and
+        // the FreshOwnedBytes result contract that would let us tell fresh from
+        // borrow does not exist yet, so admitting one risks a double-free.
+        // Defense-in-depth: a callee whose contract classifies its result as an
+        // interior alias of arg[0] is ALSO excluded, so a borrow-returner can
+        // never be dropped even if a future one lands without the allowlist
+        // entry (a Hew user fn can never return a borrow — no lifetimes).
+        let Terminator::Call {
+            callee,
+            builtin: None,
+            dest: Some(dest),
+            next,
+            ..
+        } = &block.terminator
+        else {
+            continue;
+        };
+        if crate::runtime_symbols::is_known_runtime_symbol(callee)
+            || crate::runtime_symbols::callee_ownership_contract(callee)
+                .returns_receiver_interior_alias()
+        {
+            continue;
+        }
+        if !bytes_place_is_typed(*dest, locals) {
+            continue;
+        }
+        let Some(t) = base_local(*dest) else {
+            continue;
+        };
+        if !seen.insert(t) {
+            continue;
+        }
+        if let Some(ins) = nested_fresh_bytes_temp_drop(
+            t,
+            *next,
+            blocks,
+            &pred_count,
+            &binding_local_ids,
+            &instr_written,
+            &source_uses,
+        ) {
+            result.push(ins);
+        }
+    }
+    result
+}
+
+/// Per-candidate admission for [`collect_nested_fresh_bytes_temp_drops`].
+/// Returns the inline-drop insertion `(block_id, insert_index, place, ty)` if
+/// the fresh-owned `bytes` temp `t` (produced by a `Terminator::Call` whose
+/// continuation is `def_next`) satisfies every fail-closed rule, else `None`.
+#[must_use]
+#[allow(
+    clippy::too_many_arguments,
+    reason = "admission threads the precomputed CFG/dataflow tables (pred counts, \
+              binding locals, instruction-written set, source uses) needed to prove \
+              the temp is a no-instr-writer, borrow-only, dominated fresh-owned bytes"
+)]
+fn nested_fresh_bytes_temp_drop(
+    t: u32,
+    def_next: u32,
+    blocks: &[BasicBlock],
+    pred_count: &HashMap<u32, usize>,
+    binding_local_ids: &HashSet<u32>,
+    instr_written: &HashSet<u32>,
+    source_uses: &HashMap<u32, Vec<NestedUseSite>>,
+) -> Option<(u32, usize, Place, ResolvedTy)> {
+    // 2. not a binding/parameter local.
+    if binding_local_ids.contains(&t) {
+        return None;
+    }
+    // 3. the producer terminator is the sole def — no instruction rewrites `t`.
+    if instr_written.contains(&t) {
+        return None;
+    }
+    // 4. at most one source-use.
+    let uses: &[NestedUseSite] = source_uses.get(&t).map_or(&[][..], Vec::as_slice);
+    if uses.len() > 1 {
+        return None;
+    }
+    let drop_place = Place::Local(t);
+    let drop_ty = ResolvedTy::Bytes;
+
+    match uses.first() {
+        // Discard (zero uses): drop at the front of the producer's continuation,
+        // which must be single-predecessor so the temp was provably produced.
+        None => (pred_count.get(&def_next).copied().unwrap_or(0) == 1)
+            .then_some((def_next, 0, drop_place, drop_ty)),
+        // Single instruction use: it must be a borrowing `bytes` runtime op, and
+        // the def must dominate it. The producer's continuation `def_next` is the
+        // ONLY block the def dominates by structural single-entry; requiring the
+        // use to live there (single-predecessor) proves the def ran before it.
+        Some(NestedUseSite::Instr { block: ub, idx: ui }) => {
+            let ub = *ub;
+            let use_instr = block_by_id(blocks, ub)?.instructions.get(*ui)?;
+            if !bytes_temp_instr_use_is_borrow_only(use_instr, t) {
+                return None;
+            }
+            let def_dominates = ub == def_next && pred_count.get(&ub).copied().unwrap_or(0) == 1;
+            // Drop immediately after the borrowing use (straight-line in `ub`),
+            // so the release runs exactly once on the path that produced and
+            // borrowed the temp.
+            def_dominates.then_some((ub, ui + 1, drop_place, drop_ty))
+        }
+        // Single terminator use: a `Terminator::Call` reading `t`. Hew's
+        // by-value heap parameters are BORROWS — a plain function/method call
+        // never consumes the caller's `bytes` reference (a callee that shares it
+        // mints its own retain), so EVERY `Terminator::Call` bytes arg is a
+        // borrow. This mirrors `derive_local_bytes_drop_allowed`'s uniform
+        // `Terminator::Call { .. } => {}` (no-escape) posture, which is why a
+        // named `let b = mk(); b.get(0)` keeps its scope-exit drop; the bare temp
+        // needs the identical release. Actor `Send`/`Ask` (which DO consume the
+        // triple via the mailbox hand-off) are distinct terminators, so the
+        // pattern below excludes them fail-closed. Drop at the front of the use's
+        // single-predecessor continuation.
+        Some(NestedUseSite::Term { block: ub }) => {
+            let ub = *ub;
+            let Terminator::Call { args, next, .. } = &block_by_id(blocks, ub)?.terminator else {
+                return None;
+            };
+            if !args.iter().any(|p| place_refs_local(*p, t)) {
+                return None;
+            }
+            if pred_count.get(next).copied().unwrap_or(0) != 1 {
+                return None;
+            }
+            let def_dominates = ub == def_next && pred_count.get(&ub).copied().unwrap_or(0) == 1;
+            def_dominates.then_some((*next, 0, drop_place, drop_ty))
+        }
+    }
+}
+
+/// A `bytes` runtime-op argument position is a BORROW (reads the triple without
+/// consuming its refcount) iff the callee's ownership contract borrows all bytes
+/// args, or borrows the receiver and `t` sits at arg[0]. The
+/// `VecCopyInElementStore` receiver class is deliberately NOT admitted here:
+/// that is container-ingress ownership, out of scope for this fix.
+#[must_use]
+fn bytes_call_arg_is_borrow(callee: &str, arg_index: usize) -> bool {
+    let contract = crate::runtime_symbols::callee_ownership_contract(callee);
+    contract.borrows_all_bytes_args() || (arg_index == 0 && contract.borrows_bytes_receiver())
+}
+
+/// True iff every position at which `t` appears in `args` is a borrowing `bytes`
+/// position for `callee`, and `t` appears at least once. A single non-borrow
+/// position (an escaping tail operand) fails the whole use closed.
+#[must_use]
+fn bytes_temp_call_use_is_borrow_only(callee: &str, args: &[Place], t: u32) -> bool {
+    let mut appears = false;
+    for (arg_index, place) in args.iter().enumerate() {
+        if place_refs_local(*place, t) {
+            appears = true;
+            if !bytes_call_arg_is_borrow(callee, arg_index) {
+                return false;
+            }
+        }
+    }
+    appears
+}
+
+/// True iff `instr` is an `Instr::CallRuntimeAbi` whose every use of `t` is a
+/// borrowing `bytes` position. Every non-runtime-call instruction use
+/// (`Move`/store/aggregate ingress/…) is an ownership transfer or escape and
+/// fails closed — the temp keeps its leak (never a double-free).
+#[must_use]
+fn bytes_temp_instr_use_is_borrow_only(instr: &Instr, t: u32) -> bool {
+    match instr {
+        Instr::CallRuntimeAbi(call) => {
+            bytes_temp_call_use_is_borrow_only(call.symbol(), call.args(), t)
+        }
+        _ => false,
+    }
+}
+
+/// #2542 — splice the inline `hew_bytes_drop`s computed by
+/// [`collect_nested_fresh_bytes_temp_drops`] into `blocks`. Applied during
+/// lowering BEFORE `check_function` / drop elaboration so the dataflow observes
+/// each drop as a read of its temp (no use-after-free flag) and so codegen emits
+/// the release. Per-block insertions are applied in descending index order so an
+/// earlier splice does not shift a later (lower-index) one. Codegen routes a
+/// `bytes`-typed inline `Instr::Drop` carrying `Release("hew_bytes_drop")`
+/// through `emit_bytes_inplace_drop` (the `BytesTriple` field-0 release).
+fn apply_nested_fresh_bytes_temp_drops(
+    blocks: &mut [BasicBlock],
+    suspend_kinds: &HashMap<u32, SuspendKind>,
+    locals: &[ResolvedTy],
+    binding_locals: &HashMap<BindingId, Place>,
+    instr_spans: &mut BTreeMap<(u32, u32), (u32, u32)>,
+) {
+    let insertions =
+        collect_nested_fresh_bytes_temp_drops(blocks, suspend_kinds, locals, binding_locals);
+    if insertions.is_empty() {
+        return;
+    }
+    let mut by_block: HashMap<u32, Vec<(usize, Place, ResolvedTy)>> = HashMap::new();
+    for (bid, idx, place, ty) in insertions {
+        by_block.entry(bid).or_default().push((idx, place, ty));
+    }
+    for block in blocks.iter_mut() {
+        let Some(mut ins) = by_block.remove(&block.id) else {
+            continue;
+        };
+        // Apply in descending index order so an earlier splice does not shift
+        // the insertion point of a later (lower-index) one.
+        ins.sort_by_key(|entry| std::cmp::Reverse(entry.0));
+        for (idx, place, ty) in ins {
+            let at = idx.min(block.instructions.len());
+            block.instructions.insert(
+                at,
+                Instr::Drop {
+                    place,
+                    ty,
+                    drop_fn: Some(crate::model::DropFnSpec::Release("hew_bytes_drop")),
+                },
+            );
+            shift_instr_spans_on_insert(
+                instr_spans,
+                block.id,
+                u32::try_from(at).unwrap_or(u32::MAX),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod nested_fresh_bytes_temp_drop_admission {
+    use super::*;
+
+    fn block(id: u32, instructions: Vec<Instr>, terminator: Terminator) -> BasicBlock {
+        BasicBlock {
+            id,
+            statements: vec![],
+            instructions,
+            terminator,
+        }
+    }
+
+    fn ret_block(id: u32) -> BasicBlock {
+        block(id, vec![], Terminator::Return)
+    }
+
+    /// A user Hew callee producing a `bytes` dest — the #2542 shape.
+    fn user_call(callee: &str, dest: u32, next: u32) -> Terminator {
+        Terminator::Call {
+            callee: callee.to_string(),
+            builtin: None,
+            args: vec![],
+            dest: Some(Place::Local(dest)),
+            next,
+        }
+    }
+
+    fn runtime_call(symbol: &str, args: Vec<Place>, dest: Option<Place>) -> Instr {
+        Instr::CallRuntimeAbi(
+            crate::model::RuntimeCall::new(symbol, args, dest)
+                .unwrap_or_else(|_| panic!("{symbol} must be an allowlisted RuntimeCall")),
+        )
+    }
+
+    /// `hew_vec_len` is the polymorphic bytes/vec length borrow (`.len()`).
+    fn bytes_len(recv: u32, dest: u32) -> Instr {
+        runtime_call(
+            "hew_vec_len",
+            vec![Place::Local(recv)],
+            Some(Place::Local(dest)),
+        )
+    }
+
+    fn boxed_ty() -> ResolvedTy {
+        ResolvedTy::named_user("Boxed", vec![])
+    }
+
+    /// All locals `bytes` except the listed overrides (e.g. an `i64` length).
+    fn bytes_locals_with(overrides: &[(usize, ResolvedTy)]) -> Vec<ResolvedTy> {
+        let mut locals = vec![ResolvedTy::Bytes; 10];
+        for (idx, ty) in overrides {
+            locals[*idx] = ty.clone();
+        }
+        locals
+    }
+
+    fn collect(
+        blocks: &[BasicBlock],
+        locals: &[ResolvedTy],
+        binding_locals: &HashMap<BindingId, Place>,
+    ) -> Vec<(u32, usize, Place, ResolvedTy)> {
+        collect_nested_fresh_bytes_temp_drops(blocks, &HashMap::new(), locals, binding_locals)
+    }
+
+    #[test]
+    fn usercall_transient_receiver_gets_one_inline_drop_after_borrowing_use() {
+        // bb0: _2 = call mk() -> bb1
+        // bb1: _3 = hew_vec_len(_2)  (borrow)  -> Return
+        let blocks = vec![
+            block(0, vec![], user_call("mk", 2, 1)),
+            block(1, vec![bytes_len(2, 3)], Terminator::Return),
+        ];
+        let locals = bytes_locals_with(&[(3, ResolvedTy::I64)]);
+        assert_eq!(
+            collect(&blocks, &locals, &HashMap::new()),
+            vec![(1, 1, Place::Local(2), ResolvedTy::Bytes)],
+            "the user-call bytes temp is used once by a borrowing hew_vec_len; it \
+             must be dropped immediately after that use, exactly once"
+        );
+    }
+
+    #[test]
+    fn usercall_result_moved_into_local_is_not_dropped_by_collector() {
+        // The `let b = mk(); b.len()` shape: mk's dest _2 is `move`d into b's
+        // local _4, then _4 is borrowed. _2's only use is the Move (ownership
+        // transfer), so dropping _2 would double-free b's buffer.
+        let blocks = vec![
+            block(0, vec![], user_call("mk", 2, 1)),
+            block(
+                1,
+                vec![
+                    Instr::Move {
+                        dest: Place::Local(4),
+                        src: Place::Local(2),
+                    },
+                    bytes_len(4, 3),
+                ],
+                Terminator::Return,
+            ),
+        ];
+        let locals = bytes_locals_with(&[(3, ResolvedTy::I64)]);
+        let binding_locals: HashMap<BindingId, Place> =
+            [(BindingId(7), Place::Local(4))].into_iter().collect();
+        assert!(
+            collect(&blocks, &locals, &binding_locals).is_empty(),
+            "the mk() temp's only use is a Move (ownership transfer to b); dropping \
+             it would double-free the buffer b's scope-exit release owns"
+        );
+    }
+
+    #[test]
+    fn binding_local_usercall_result_stays_out_of_collector() {
+        // mk()'s dest IS a binding local directly — owned by the scope-exit
+        // derive_local_bytes_drop_allowed release, not the bare-temp collector.
+        let blocks = vec![
+            block(0, vec![], user_call("mk", 2, 1)),
+            block(1, vec![bytes_len(2, 3)], Terminator::Return),
+        ];
+        let locals = bytes_locals_with(&[(3, ResolvedTy::I64)]);
+        let binding_locals: HashMap<BindingId, Place> =
+            [(BindingId(9), Place::Local(2))].into_iter().collect();
+        assert!(
+            collect(&blocks, &locals, &binding_locals).is_empty(),
+            "a bytes local owned by a let/parameter binding belongs to \
+             derive_local_bytes_drop_allowed, not the bare-temp collector"
+        );
+    }
+
+    #[test]
+    fn fresh_bytes_helper_transient_is_admitted() {
+        // `"x".to_bytes().len()`: hew_string_to_bytes is a non-allowlisted fresh
+        // bytes helper (builtin: None, result not an interior alias), so its
+        // transient result is admitted like a user call.
+        let blocks = vec![
+            block(
+                0,
+                vec![],
+                Terminator::Call {
+                    callee: "hew_string_to_bytes".to_string(),
+                    builtin: None,
+                    args: vec![Place::Local(5)],
+                    dest: Some(Place::Local(2)),
+                    next: 1,
+                },
+            ),
+            block(1, vec![bytes_len(2, 3)], Terminator::Return),
+        ];
+        let locals = bytes_locals_with(&[(3, ResolvedTy::I64)]);
+        assert_eq!(
+            collect(&blocks, &locals, &HashMap::new()),
+            vec![(1, 1, Place::Local(2), ResolvedTy::Bytes)],
+            "hew_string_to_bytes hands the caller a fresh rc==1 buffer; its \
+             transient result borrowed once must be dropped exactly once"
+        );
+    }
+
+    #[test]
+    fn allowlisted_runtime_bytes_terminator_is_not_admitted() {
+        // hew_bytes_slice returns fresh bytes but is an ALLOWLISTED runtime
+        // symbol; excluded fail-closed pending a FreshOwnedBytes contract (some
+        // allowlisted bytes callees borrow / alias their receiver).
+        let blocks = vec![
+            block(
+                0,
+                vec![],
+                Terminator::Call {
+                    callee: "hew_bytes_slice".to_string(),
+                    builtin: None,
+                    args: vec![Place::Local(5)],
+                    dest: Some(Place::Local(2)),
+                    next: 1,
+                },
+            ),
+            block(1, vec![bytes_len(2, 3)], Terminator::Return),
+        ];
+        let locals = bytes_locals_with(&[(3, ResolvedTy::I64)]);
+        assert!(
+            collect(&blocks, &locals, &HashMap::new()).is_empty(),
+            "an allowlisted runtime bytes callee is excluded (leak-safe) until a \
+             per-symbol FreshOwnedBytes contract can tell fresh from borrow"
+        );
+    }
+
+    #[test]
+    fn discarded_usercall_result_dropped_at_single_pred_continuation() {
+        // bb0: _2 = call mk() -> bb1 ; bb1 never reads _2 (discard).
+        let blocks = vec![block(0, vec![], user_call("mk", 2, 1)), ret_block(1)];
+        let locals = bytes_locals_with(&[]);
+        assert_eq!(
+            collect(&blocks, &locals, &HashMap::new()),
+            vec![(1, 0, Place::Local(2), ResolvedTy::Bytes)],
+            "a discarded user-call bytes temp is dropped at the front of its \
+             single-predecessor continuation"
+        );
+    }
+
+    #[test]
+    fn discarded_usercall_result_at_multipred_continuation_not_dropped() {
+        // bb1 (the continuation) has two predecessors: bb0 (producer) and bb2. A
+        // front-of-block drop could fire on the bb2 path that never produced _2.
+        let blocks = vec![
+            block(0, vec![], user_call("mk", 2, 1)),
+            ret_block(1),
+            block(2, vec![], Terminator::Goto { target: 1 }),
+        ];
+        let locals = bytes_locals_with(&[]);
+        assert!(
+            collect(&blocks, &locals, &HashMap::new()).is_empty(),
+            "a front-of-block drop on a multi-predecessor continuation could free \
+             an uninitialised temp — fail closed"
+        );
+    }
+
+    #[test]
+    fn usercall_result_moved_into_record_not_dropped() {
+        // mk()'s result is stored into a record field (aggregate ingress); the
+        // aggregate owns the release. RecordInit is not a borrowing runtime call.
+        let blocks = vec![
+            block(0, vec![], user_call("mk", 2, 1)),
+            block(
+                1,
+                vec![Instr::RecordInit {
+                    ty: boxed_ty(),
+                    fields: vec![(FieldOffset(0), Place::Local(2))],
+                    dest: Place::Local(5),
+                }],
+                Terminator::Return,
+            ),
+        ];
+        let locals = bytes_locals_with(&[(5, boxed_ty())]);
+        assert!(
+            collect(&blocks, &locals, &HashMap::new()).is_empty(),
+            "record ingress transfers ownership to the aggregate; an inline temp \
+             drop would double-free the field"
+        );
+    }
+
+    #[test]
+    fn usercall_result_borrowed_by_terminator_call_gets_dropped_at_continuation() {
+        // `mk().get(0)`: mk's dest _2 is borrowed by a `Terminator::Call`
+        // (`hew_bytes_get`, a COLLECTION-scan receiver borrow). Every
+        // Terminator::Call bytes arg is a borrow (Hew by-value heap params), so
+        // the temp is dropped at the front of the call's continuation.
+        let blocks = vec![
+            block(0, vec![], user_call("mk", 2, 1)),
+            block(
+                1,
+                vec![],
+                Terminator::Call {
+                    callee: "hew_bytes_get".to_string(),
+                    builtin: None,
+                    args: vec![Place::Local(2), Place::Local(6)],
+                    dest: Some(Place::Local(7)),
+                    next: 2,
+                },
+            ),
+            ret_block(2),
+        ];
+        let locals = bytes_locals_with(&[(6, ResolvedTy::I64)]);
+        assert_eq!(
+            collect(&blocks, &locals, &HashMap::new()),
+            vec![(2, 0, Place::Local(2), ResolvedTy::Bytes)],
+            "a bytes temp borrowed by a Terminator::Call is released at the front \
+             of the call's single-predecessor continuation"
+        );
+    }
+
+    #[test]
+    fn usercall_result_sent_to_actor_is_not_dropped() {
+        // A `Terminator::Send` CONSUMES the bytes (mailbox hand-off); the sender
+        // must NOT drop it. Only `Terminator::Call` is a borrow — `Send` is
+        // excluded fail-closed.
+        let blocks = vec![
+            block(0, vec![], user_call("mk", 2, 1)),
+            block(
+                1,
+                vec![],
+                Terminator::Send {
+                    actor: Place::Local(6),
+                    msg_type: 0,
+                    value: Place::Local(2),
+                    next: 2,
+                    alias_mode: crate::model::SendAliasMode::Copy,
+                },
+            ),
+            ret_block(2),
+        ];
+        let locals = bytes_locals_with(&[]);
+        assert!(
+            collect(&blocks, &locals, &HashMap::new()).is_empty(),
+            "a bytes temp consumed by an actor send must not be dropped by the \
+             sender (the mailbox copy / state_drop owns the release)"
+        );
+    }
+
+    #[test]
+    fn usercall_result_used_twice_not_dropped() {
+        // Two source-uses (rule 4: at most one). Fail closed rather than guess
+        // which use is the last.
+        let blocks = vec![
+            block(0, vec![], user_call("mk", 2, 1)),
+            block(
+                1,
+                vec![bytes_len(2, 3), bytes_len(2, 6)],
+                Terminator::Return,
+            ),
+        ];
+        let locals = bytes_locals_with(&[(3, ResolvedTy::I64), (6, ResolvedTy::I64)]);
+        assert!(
+            collect(&blocks, &locals, &HashMap::new()).is_empty(),
+            "a temp with more than one source-use is not the single-borrow shape; \
+             fail closed (leak, never double-free)"
         );
     }
 }

--- a/tests/vertical-slice/accept/wire_cbor_fresh_call_result.hew
+++ b/tests/vertical-slice/accept/wire_cbor_fresh_call_result.hew
@@ -1,0 +1,21 @@
+// Validation: an unnamed fresh `bytes` call-result flowing straight into a
+// wire decode (`Packet.decode(mk())`) round-trips and returns the decoded
+// value. The decode reads its operand through the borrow-excluded `WireCodec`
+// instruction, so the transient-bytes drop pass must keep the buffer alive
+// past the decode: a mis-scheduled front-of-continuation drop freed it before
+// the read — a use-after-free trap — while the named `let raw = mk();
+// Packet.decode(raw)` sibling worked. Exit 42 proves the full round-trip.
+#[wire]
+type Packet {
+    id: i64 @1,
+}
+
+fn mk() -> bytes {
+    let p = Packet { id: 42 };
+    p.encode()
+}
+
+fn main() -> i64 {
+    let back = Packet.decode(mk());
+    back.id
+}

--- a/tests/vertical-slice/accept/wire_json_fresh_concat_operand.hew
+++ b/tests/vertical-slice/accept/wire_json_fresh_concat_operand.hew
@@ -1,0 +1,22 @@
+// Validation: an unnamed fresh `string` concat result flowing straight into a
+// JSON parse (`Packet.from_json(a + b)`) round-trips and returns the decoded
+// value. The parse reads its operand through the borrow-excluded `WireCodec`
+// instruction, so the transient-string drop pass must keep the buffer alive
+// past the parse: a mis-scheduled post-producer drop freed it before the read
+// — the parse then consumed a freed buffer and returned `Err` (a silent wrong
+// result, exit 7) — while the named `let joined = a + b` sibling worked.
+// Exit 42 proves the full round-trip.
+#[wire]
+type Packet {
+    id: i64 @1,
+}
+
+fn main() -> i64 {
+    let p = Packet { id: 42 };
+    let a = p.to_json();
+    let b = "";
+    match Packet.from_json(a + b) {
+        Ok(back) => back.id,
+        Err(_) => 7,
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -4434,6 +4434,9 @@ run_accept_expect_status "wire_json_nested_roundtrip" 42
 run_accept_expect_status "wire_json_enum_unit_roundtrip" 42
 run_accept_expect_status "wire_json_enum_payload_roundtrip" 42
 run_accept_expect_status "wire_json_vec_option_roundtrip" 42
+# An unnamed fresh string concat result into from_json: the transient-string
+# drop pass must not free the operand before the WireCodec parse reads it.
+run_accept_expect_status "wire_json_fresh_concat_operand" 42
 run_accept_expect_status "wire_yaml_roundtrip" 42
 run_accept_expect_status "wire_json_malformed_is_err" 42
 run_accept_expect_status "wire_json_wrong_shape_is_err" 42

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -4404,6 +4404,9 @@ run_check_run_expect_stdout wrapping_saturating_as_cast
 # fixture proves the codec fails closed (traps) on garbage rather than
 # fabricating a partial value.
 run_accept_expect_status "wire_cbor_roundtrip_packet" 42
+# An unnamed fresh bytes call-result into decode: the transient-bytes drop
+# pass must not free the operand before the WireCodec decode reads it.
+run_accept_expect_status "wire_cbor_fresh_call_result" 42
 run_accept_expect_trap "wire_cbor_decode_malformed_traps"
 run_accept_expect_trap "wire_cbor_enum_oob_tag_traps"
 run_accept_expect_trap "wire_cbor_narrow_int_over_range_traps"


### PR DESCRIPTION
## Why

`mk().len()` where `mk() -> bytes` — an unnamed, fresh call-result `bytes` temporary used only as a borrow-only method receiver — leaked on every call. A named `let b = mk(); b.len()` didn't leak, because the existing scope-exit drop machinery keys on bindings, and this temp has none.

My first fix added a collector for these unnamed temps, but its use-count came from the source-places table, which deliberately excludes borrow-only readers (a `WireCodec` decode operand, `BytesRetain`, borrow-only `ClosureEnvInit` fields) so that named bindings still get their scope-exit drop after those reads run. Reusing that table for the new collector's use-count meant a fresh temp whose only reader was one of those borrow-only ops registered zero uses, fell into the discard branch, and got freed at the front of its continuation — before the read that used it. `Packet.decode(mk())` trapped with a use-after-free.

The string side had the identical defect, predating this branch: `Packet.from_json(a + b)` on a fresh concatenated string operand silently returned the wrong result (parsed a freed buffer) instead of trapping.

## What

- **hew-mir**: `collect_nested_fresh_bytes_temp_drops` — the bytes analogue of the existing nested-fresh-string-temp collector. Splices an inline drop for an unnamed, fresh `bytes` temp iff it has no instruction writer, exactly one source-use, and that use is a borrowing bytes op or call argument, dominated by the producer through a single-predecessor continuation. A temp moved into a binding, aggregate, return slot, or actor send keeps its existing (safe) handling.
- **hew-mir**: fixed the use-detection in both the bytes and string collectors to build their instruction-side use table from the full dataflow reads (`instr_reads_writes`) instead of the source-places table. A hidden borrow-only reader is now a real use-site — the temp fails closed to the leak side, never gets a premature drop.
- Codegen needed no changes — a bytes-typed inline drop already routes through the existing generator-yield drop path.

## Test

- `hew-cli/tests/bytes_drop_leak_oracle.rs`: new fixtures pinning the unnamed bytes call-result shapes (method-receiver, terminator-use, discarded) at 0 leaks under `leaks --atExit` with MallocScribble/PreScribble/GuardEdges, alongside the pre-existing named-binding controls.
- `hew-mir` unit tests (`nested_fresh_bytes_temp_drop_admission` / `nested_fresh_string_temp_drop_admission`): admission pins for the hidden-reader classes (`WireCodec` decode operand, `BytesRetain`) asserting no drop is spliced ahead of the read.
- `tests/vertical-slice/accept/wire_cbor_fresh_call_result.hew` and `wire_json_fresh_concat_operand.hew`: compiled roundtrip regressions — `Packet.decode(mk())` and `Packet.from_json(a + b)` on fresh operands now return the correct decoded value instead of trapping or silently corrupting.
- Full workspace (`cargo nextest run --workspace --no-fail-fast`), `make test-hew-ratchet`, and `make checked-mir-verify` all green.

## Quality Checklist
- [x] PR title, body, and commit messages avoid internal-only orchestration/model vocabulary
- [x] No new `.ok()?` or `unwrap_or_default()` in codegen without `// JUSTIFIED` comment
- [x] New allocations have cleanup paths for sync, async, and actor shutdown contexts
- [x] Serialization changes include round-trip encode/decode tests
- [ ] New runtime features have WASM implementation or `// WASM-TODO(#NNN):` marker — n/a, no new runtime symbols
- [x] No duplicated logic — checked for existing helpers before adding new ones (mirrors the existing string collector)

Fixes #2542