### PR TITLE
feat(ffi): define ownership contracts for every hew_* runtime symbol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
             | sarif-fmt
 
       - name: Verify JIT host ABI classification
-        run: make verify-ffi
+        run: make verify-ffi test-verify-ffi
 
       - name: Upload Clippy SARIF
         if: always() && hashFiles('clippy-results.sarif') != ''

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@
 
 .PHONY: all build bootstrap install-hooks hew hew-native adze observe observe-functional-test runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh licenses licenses-check
 .PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-package-install test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all lane-gates test-fast test-stdlib test-hew test-hew-ratchet test-o2-differential o2-differential-selftest preflight-parity-selftest test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar
-.PHONY: clean install install-check uninstall verify-ffi
+.PHONY: clean install install-check uninstall verify-ffi test-verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
 .PHONY: coverage coverage-summary coverage-lcov coverage-runtime coverage-combined coverage-branch
 .PHONY: fuzz-corpus fuzz-smoke fuzz-oracle fuzz-oracle-selftest
@@ -1198,6 +1198,9 @@ coverage-branch:
 
 verify-ffi:
 	python3 scripts/verify-ffi-symbols.py --classify stable --validate > /dev/null
+
+test-verify-ffi:
+	python3 scripts/tests/test_verify_ffi_symbols.py
 
 # ── ANTLR4 grammar validation ──────────────────────────────────────────────
 # Requires Java and the ANTLR4 jar. This is rarely needed — only when

--- a/hew-mir/build.rs
+++ b/hew-mir/build.rs
@@ -1,0 +1,93 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+fn quoted_value(line: &str) -> Option<&str> {
+    let (_, value) = line.split_once('=')?;
+    let value = value.trim();
+    value.strip_prefix('"')?.strip_suffix('"')
+}
+
+fn toml_results(path: &Path) -> BTreeMap<String, String> {
+    let source = fs::read_to_string(path).expect("read FFI classification TOML");
+    let mut results = BTreeMap::new();
+    let mut symbol: Option<String> = None;
+    let mut in_contract = false;
+
+    for line in source.lines() {
+        let line = line.trim();
+        if line == "[[ownership.contracts]]" {
+            in_contract = true;
+            symbol = None;
+            continue;
+        }
+        if !in_contract {
+            continue;
+        }
+        if line.starts_with("symbol =") {
+            symbol = quoted_value(line).map(str::to_owned);
+        } else if line.starts_with("result =") {
+            let result = quoted_value(line).expect("ownership result must be quoted");
+            let symbol = symbol
+                .take()
+                .expect("ownership result must follow its symbol");
+            assert!(
+                results.insert(symbol.clone(), result.to_owned()).is_none(),
+                "duplicate TOML ownership contract for {symbol}"
+            );
+        }
+    }
+    results
+}
+
+fn checked_runtime_results(path: &Path) -> BTreeMap<String, String> {
+    let source = fs::read_to_string(path).expect("read runtime_symbols.rs");
+    let marker = "const TOML_RESULT_CONSISTENCY:";
+    let start = source
+        .find(marker)
+        .expect("runtime_symbols.rs must declare TOML_RESULT_CONSISTENCY");
+    let mut results = BTreeMap::new();
+
+    for line in source[start..].lines().skip(1) {
+        let line = line.trim();
+        if line == "];" {
+            break;
+        }
+        if !line.starts_with("(\"") {
+            continue;
+        }
+        let quoted = line.split('"').collect::<Vec<_>>();
+        assert!(quoted.len() >= 4, "malformed consistency row: {line}");
+        let symbol = quoted[1].to_owned();
+        let result = quoted[3].to_owned();
+        assert!(
+            results.insert(symbol.clone(), result).is_none(),
+            "duplicate runtime consistency row for {symbol}"
+        );
+    }
+    assert!(
+        !results.is_empty(),
+        "TOML_RESULT_CONSISTENCY must not be empty"
+    );
+    results
+}
+
+fn main() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let classification = manifest_dir.join("../scripts/jit-symbol-classification.toml");
+    let runtime_symbols = manifest_dir.join("src/runtime_symbols.rs");
+
+    println!("cargo:rerun-if-changed={}", classification.display());
+    println!("cargo:rerun-if-changed={}", runtime_symbols.display());
+
+    let toml = toml_results(&classification);
+    for (symbol, expected) in checked_runtime_results(&runtime_symbols) {
+        let actual = toml.get(&symbol).unwrap_or_else(|| {
+            panic!("{symbol} is runtime-checked but has no TOML ownership contract")
+        });
+        assert_eq!(
+            actual, &expected,
+            "TOML/runtime result ownership mismatch for {symbol}"
+        );
+    }
+}

--- a/hew-mir/src/runtime_symbols.rs
+++ b/hew-mir/src/runtime_symbols.rs
@@ -739,6 +739,10 @@ pub enum StringArgsOwnership {
 pub enum ResultOwnership {
     /// Fresh or refcount-retained string; caller owes one `hew_string_drop`.
     FreshOwnedString,
+    /// Fresh bytes allocation; caller owes the matching bytes release.
+    FreshOwnedBytes,
+    /// Result is borrowed and carries no caller-owned drop obligation.
+    Borrowed,
     /// Result borrows storage owned by arg[0].
     InteriorAliasOfReceiver,
     /// No drop obligation is tracked by this contract.
@@ -837,7 +841,10 @@ impl CalleeOwnershipContract {
 
     #[must_use]
     pub const fn returns_receiver_interior_alias(self) -> bool {
-        matches!(self.result, ResultOwnership::InteriorAliasOfReceiver)
+        matches!(
+            self.result,
+            ResultOwnership::Borrowed | ResultOwnership::InteriorAliasOfReceiver
+        )
     }
 }
 
@@ -858,7 +865,7 @@ impl Default for CalleeOwnershipContract {
 #[must_use]
 pub fn callee_ownership_contract(callee: &str) -> CalleeOwnershipContract {
     use ReceiverOwnership::{BorrowsReceiver, BytesAllArgsBorrow, Escapes, VecCopyInElementStore};
-    use ResultOwnership::{FreshOwnedString, InteriorAliasOfReceiver, Untracked};
+    use ResultOwnership::{Borrowed, FreshOwnedString, Untracked};
     use StringArgsOwnership::{BorrowingUse, Escaping, PrintSink};
 
     match callee {
@@ -963,7 +970,7 @@ pub fn callee_ownership_contract(callee: &str) -> CalleeOwnershipContract {
                 scans: ReceiverScanSet::VEC,
             },
             Escaping,
-            InteriorAliasOfReceiver,
+            Borrowed,
         ),
 
         // Vec receivers are borrowed in place; element and range operands keep
@@ -1140,6 +1147,17 @@ pub fn callee_ownership_contract(callee: &str) -> CalleeOwnershipContract {
         _ => CalleeOwnershipContract::FAIL_CLOSED,
     }
 }
+
+#[cfg(test)]
+const TOML_RESULT_CONSISTENCY: &[(&str, &str, ResultOwnership)] = &[
+    ("hew_vec_get_clone", "fresh", ResultOwnership::Untracked),
+    ("hew_vec_get_owned", "borrowed", ResultOwnership::Borrowed),
+    (
+        "hew_vec_get_str",
+        "retained",
+        ResultOwnership::FreshOwnedString,
+    ),
+];
 
 #[cfg(test)]
 mod tests {
@@ -1393,6 +1411,17 @@ mod tests {
             callee_ownership_contract("hew_nope"),
             CalleeOwnershipContract::FAIL_CLOSED
         );
+    }
+
+    #[test]
+    fn toml_checked_result_contracts_match_hand_table() {
+        for (symbol, _toml_result, expected) in TOML_RESULT_CONSISTENCY {
+            assert_eq!(
+                callee_ownership_contract(symbol).result,
+                *expected,
+                "{symbol} diverges from its TOML-checked result contract",
+            );
+        }
     }
 
     #[test]

--- a/hew-std/src/markdown.rs
+++ b/hew-std/src/markdown.rs
@@ -1,8 +1,8 @@
 //! Hew runtime: Markdown to HTML conversion.
 //!
 //! Provides Markdown-to-HTML rendering for compiled Hew programs using
-//! [`pulldown_cmark`]. All returned strings are allocated with `libc::malloc`
-//! and NUL-terminated.
+//! [`pulldown_cmark`]. Returned strings are header-aware Hew strings and are
+//! NUL-terminated.
 use hew_cabi::cabi::{cstr_to_str, str_to_malloc};
 use std::ffi::c_char;
 
@@ -37,8 +37,8 @@ fn strip_html_tags(html_str: &str) -> String {
 
 /// Convert a Markdown string to HTML.
 ///
-/// Returns a `malloc`-allocated, NUL-terminated C string containing the
-/// rendered HTML. The caller must free it with `libc::free`.
+/// Returns a header-aware, NUL-terminated Hew string containing the rendered
+/// HTML. The caller must release it with `hew_string_drop`.
 /// Returns null on error.
 ///
 /// # Safety
@@ -60,8 +60,8 @@ pub unsafe extern "C" fn hew_markdown_to_html(md: *const c_char) -> *mut c_char 
 ///
 /// Like [`hew_markdown_to_html`] but additionally strips any raw HTML tags
 /// from the output, leaving only the Markdown-generated structure and text.
-/// Returns a `malloc`-allocated, NUL-terminated C string. The caller must
-/// be freed with `libc::free`. Returns null on error.
+/// Returns a header-aware, NUL-terminated Hew string. The caller must release
+/// it with `hew_string_drop`. Returns null on error.
 ///
 /// # Safety
 ///
@@ -94,9 +94,9 @@ mod tests {
         // SAFETY: c is a valid NUL-terminated C string.
         let ptr = unsafe { hew_markdown_to_html(c.as_ptr()) };
         assert!(!ptr.is_null());
-        // SAFETY: ptr is a valid NUL-terminated C string from malloc.
+        // SAFETY: ptr is a valid header-aware NUL-terminated Hew string.
         let s = unsafe { cstr_to_str(ptr) }.unwrap().to_owned();
-        // SAFETY: ptr was allocated with malloc.
+        // SAFETY: ptr was allocated by the header-aware string allocator.
         unsafe { hew_cabi::cabi::free_cstring(ptr) }; // CSTRING-FREE: str-open (test str_to_malloc html)
         s
     }
@@ -143,9 +143,9 @@ mod tests {
         // SAFETY: c is a valid NUL-terminated C string.
         let ptr = unsafe { hew_markdown_to_html_safe(c.as_ptr()) };
         assert!(!ptr.is_null());
-        // SAFETY: ptr is a valid NUL-terminated C string from malloc.
+        // SAFETY: ptr is a valid header-aware NUL-terminated Hew string.
         let s = unsafe { cstr_to_str(ptr) }.unwrap().to_owned();
-        // SAFETY: ptr was allocated with malloc.
+        // SAFETY: ptr was allocated by the header-aware string allocator.
         unsafe { hew_cabi::cabi::free_cstring(ptr) }; // CSTRING-FREE: str-open (test str_to_malloc)
         assert!(!s.contains("<script>"), "raw HTML should be stripped: {s}");
         assert!(s.contains("Hello"), "text should be preserved: {s}");

--- a/hew-std/src/protobuf.rs
+++ b/hew-std/src/protobuf.rs
@@ -586,8 +586,8 @@ pub unsafe extern "C" fn hew_proto_msg_get_bytes(
     }
 }
 
-/// Get a string field as a `malloc`-allocated, NUL-terminated C string.
-/// The caller must free the returned pointer with `libc::free`.
+/// Get a string field as a header-aware, NUL-terminated Hew string.
+/// The caller must release the returned pointer with `hew_string_drop`.
 /// Returns null if the field is missing or has a different wire type.
 ///
 /// # Safety

--- a/hew-std/src/toml.rs
+++ b/hew-std/src/toml.rs
@@ -1,9 +1,9 @@
 //! Hew runtime: `toml_parser` module.
 //!
 //! Provides TOML parsing and value inspection for compiled Hew programs.
-//! All returned strings are allocated with `libc::malloc` so callers can
-//! free them with `libc::free`. Opaque [`HewTomlValue`] handles must be
-//! freed with [`hew_toml_free`].
+//! Returned strings are header-aware Hew strings that callers release with
+//! `hew_string_drop`. Opaque [`HewTomlValue`] handles must be freed with
+//! [`hew_toml_free`].
 use hew_cabi::cabi::str_to_malloc;
 use std::ffi::CStr;
 use std::os::raw::c_char;
@@ -106,8 +106,8 @@ pub unsafe extern "C" fn hew_toml_type(val: *const HewTomlValue) -> i32 {
     }
 }
 
-/// Returns a `malloc`-allocated NUL-terminated C string. The caller must
-/// free it with `libc::free`. Returns null if `val` is null or not a string.
+/// Returns a header-aware, NUL-terminated Hew string. The caller must release
+/// it with `hew_string_drop`. Returns null if `val` is null or not a string.
 ///
 /// # Safety
 ///
@@ -263,8 +263,8 @@ pub unsafe extern "C" fn hew_toml_array_get(
 
 /// Serialize a TOML value back to a TOML-formatted string.
 ///
-/// Returns a `malloc`-allocated NUL-terminated C string. The caller must
-/// free it with `libc::free`. Returns null if `val` is null or serialization
+/// Returns a header-aware, NUL-terminated Hew string. The caller must release
+/// it with `hew_string_drop`. Returns null if `val` is null or serialization
 /// fails.
 ///
 /// # Safety

--- a/scripts/ffi-ownership-ratchet.toml
+++ b/scripts/ffi-ownership-ratchet.toml
@@ -3,4 +3,4 @@
 # This value must match the verifier's computed count. Contract curation must
 # lower it; adding an unclassified symbol without deliberately growing this
 # tracked ratchet fails verification.
-unclassified = 1000
+unclassified = 988

--- a/scripts/ffi-ownership-ratchet.toml
+++ b/scripts/ffi-ownership-ratchet.toml
@@ -3,4 +3,4 @@
 # This value must match the verifier's computed count. Contract curation must
 # lower it; adding an unclassified symbol without deliberately growing this
 # tracked ratchet fails verification.
-unclassified = 1016
+unclassified = 1000

--- a/scripts/ffi-ownership-ratchet.toml
+++ b/scripts/ffi-ownership-ratchet.toml
@@ -3,4 +3,4 @@
 # This value must match the verifier's computed count. Contract curation must
 # lower it; adding an unclassified symbol without deliberately growing this
 # tracked ratchet fails verification.
-unclassified = 1019
+unclassified = 1016

--- a/scripts/ffi-ownership-ratchet.toml
+++ b/scripts/ffi-ownership-ratchet.toml
@@ -1,0 +1,6 @@
+# Exact number of ABI-classified symbols without ownership contracts.
+#
+# This value must match the verifier's computed count. Contract curation must
+# lower it; adding an unclassified symbol without deliberately growing this
+# tracked ratchet fails verification.
+unclassified = 1019

--- a/scripts/ffi-ownership-ratchet.toml
+++ b/scripts/ffi-ownership-ratchet.toml
@@ -1,6 +1,5 @@
 # Exact number of ABI-classified symbols without ownership contracts.
 #
-# This value must match the verifier's computed count. Contract curation must
-# lower it; adding an unclassified symbol without deliberately growing this
-# tracked ratchet fails verification.
+# This value must exactly match the verifier's computed count. Any classification
+# or contract change that changes the count must deliberately update this ratchet.
 unclassified = 988

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -4,6 +4,22 @@
 # as part of the candidate host ABI and requires it to appear exactly once
 # in one of the three lists below. Keep entries sorted for stable diffs.
 #
+# Ownership contracts live in [[ownership.contracts]] entries at the end of
+# this file. Every symbol in any ABI tier must either have one contract or be
+# counted by scripts/ffi-ownership-ratchet.toml.
+#
+#   result = "fresh" | "retained" | "borrowed" | "none"
+#   params = ["borrow" | "consume" | "retain", ...]
+#   release-symbol = "<hew_* release function>" | ""
+#   discharge-depth = "shallow" | "deep" | "none"
+#
+# `fresh` transfers a newly owned allocation to the caller. `retained`
+# transfers an additional reference to an existing ref-counted allocation.
+# `borrowed` remains owned elsewhere and may be invalidated by mutation.
+# `none` carries no owned result. Fresh and retained results must name their
+# release symbol and whether that release recursively discharges children.
+# Borrowed and none results use an empty release symbol and depth "none".
+#
 # Three-tier model (rationale: Option A chosen over Option B for substrate
 # clarity — the tier boundary is a compile-time contract, not just a doc claim):
 #
@@ -1124,3 +1140,6 @@ internal = [
   "hew_trace_drain",
   "hew_trace_reset",
 ]
+
+[ownership]
+contracts = []

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -881,9 +881,15 @@ stable-stdlib = [
   "hew_json_array_push",
   "hew_json_free",
   "hew_json_object_set",
+  "hew_markdown_to_html",
+  "hew_markdown_to_html_safe",
+  "hew_proto_msg_get_string",
   "hew_toml_array_push",
   "hew_toml_free",
+  "hew_toml_get_string",
+  "hew_toml_last_error",
   "hew_toml_object_set",
+  "hew_toml_stringify",
   "hew_yaml_array_push",
   "hew_yaml_free",
   "hew_yaml_object_set",
@@ -1247,3 +1253,51 @@ result = "fresh"
 params = ["borrow", "borrow", "borrow"]
 release-symbol = "HewTypeLayout.drop_fn"
 discharge-depth = "deep"
+
+# hew-std/src/protobuf.rs:589-618 allocates a header-aware string copy.
+[[ownership.contracts]]
+symbol = "hew_proto_msg_get_string"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+# hew-std/src/toml.rs:73-81 allocates the actor-local error string.
+[[ownership.contracts]]
+symbol = "hew_toml_last_error"
+result = "fresh"
+params = []
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+# hew-std/src/toml.rs:109-123 allocates a string value copy.
+[[ownership.contracts]]
+symbol = "hew_toml_get_string"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+# hew-std/src/toml.rs:264-282 allocates serialized TOML text.
+[[ownership.contracts]]
+symbol = "hew_toml_stringify"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+# hew-std/src/markdown.rs:38-56 allocates rendered HTML.
+[[ownership.contracts]]
+symbol = "hew_markdown_to_html"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+# hew-std/src/markdown.rs:59-79 allocates sanitized rendered HTML.
+[[ownership.contracts]]
+symbol = "hew_markdown_to_html_safe"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -1429,3 +1429,99 @@ result = "fresh"
 params = ["borrow"]
 release-symbol = "hew_vec_free_owned"
 discharge-depth = "deep"
+
+# hew-runtime/src/vec.rs:929-954 allocates an i32 slice.
+[[ownership.contracts]]
+symbol = "hew_vec_slice_range_i32"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:958-983 allocates an i64 slice.
+[[ownership.contracts]]
+symbol = "hew_vec_slice_range_i64"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:987-1012 allocates an f64 slice.
+[[ownership.contracts]]
+symbol = "hew_vec_slice_range_f64"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:1016-1063 allocates a plain byte-stride slice.
+[[ownership.contracts]]
+symbol = "hew_vec_slice_range_bytesize"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:1067-1094 allocates a pointer-element slice.
+[[ownership.contracts]]
+symbol = "hew_vec_slice_range_ptr"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:1098-1130 allocates a string-retaining slice.
+[[ownership.contracts]]
+symbol = "hew_vec_slice_range_str"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "deep"
+
+# hew-runtime/src/vec.rs:1134-1179 allocates a BitCopy layout slice.
+[[ownership.contracts]]
+symbol = "hew_vec_slice_range_layout"
+result = "fresh"
+params = ["borrow", "borrow", "borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:1183-1224 allocates a deep-cloned owned slice.
+[[ownership.contracts]]
+symbol = "hew_vec_slice_range_owned"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "hew_vec_free_owned"
+discharge-depth = "deep"
+
+# hew-runtime/src/vec.rs:1702-1739 allocates a clone, retaining string elements.
+[[ownership.contracts]]
+symbol = "hew_vec_clone"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "deep"
+
+# hew-runtime/src/vec.rs:1743-1779 allocates a BitCopy layout clone.
+[[ownership.contracts]]
+symbol = "hew_vec_clone_layout"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:1783-1815 allocates a witness-managed clone.
+[[ownership.contracts]]
+symbol = "hew_vec_clone_managed"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_vec_free_managed"
+discharge-depth = "deep"
+
+# hew-runtime/src/vec.rs:2964-3009 allocates a deep owned-element clone.
+[[ownership.contracts]]
+symbol = "hew_vec_clone_owned"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_vec_free_owned"
+discharge-depth = "deep"

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -878,6 +878,15 @@ stable-stdlib = [
   "hew_datetime_second",
   "hew_datetime_weekday",
   "hew_datetime_year",
+  "hew_json_array_push",
+  "hew_json_free",
+  "hew_json_object_set",
+  "hew_toml_array_push",
+  "hew_toml_free",
+  "hew_toml_object_set",
+  "hew_yaml_array_push",
+  "hew_yaml_free",
+  "hew_yaml_object_set",
 ]
 
 # jit: codegen-stable — symbols the Hew compiler emits into generated IR for
@@ -1142,4 +1151,75 @@ internal = [
 ]
 
 [ownership]
-contracts = []
+
+# hew-std/src/json.rs:379-384 reconstructs and drops `val`.
+[[ownership.contracts]]
+symbol = "hew_json_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+# hew-std/src/json.rs:635-652 moves `val` into the object.
+[[ownership.contracts]]
+symbol = "hew_json_object_set"
+result = "none"
+params = ["borrow", "borrow", "consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+# hew-std/src/json.rs:777-785 moves `val` into the array.
+[[ownership.contracts]]
+symbol = "hew_json_array_push"
+result = "none"
+params = ["borrow", "consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+# hew-std/src/toml.rs:610-615 reconstructs and drops `val`.
+[[ownership.contracts]]
+symbol = "hew_toml_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+# hew-std/src/toml.rs:420-437 moves `val` into the table.
+[[ownership.contracts]]
+symbol = "hew_toml_object_set"
+result = "none"
+params = ["borrow", "borrow", "consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+# hew-std/src/toml.rs:539-547 moves `val` into the array.
+[[ownership.contracts]]
+symbol = "hew_toml_array_push"
+result = "none"
+params = ["borrow", "consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+# hew-std/src/yaml.rs:476-481 reconstructs and drops `val`.
+[[ownership.contracts]]
+symbol = "hew_yaml_free"
+result = "none"
+params = ["consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+# hew-std/src/yaml.rs:711-728 moves `val` into the mapping.
+[[ownership.contracts]]
+symbol = "hew_yaml_object_set"
+result = "none"
+params = ["borrow", "borrow", "consume"]
+release-symbol = ""
+discharge-depth = "none"
+
+# hew-std/src/yaml.rs:875-883 moves `val` into the sequence.
+[[ownership.contracts]]
+symbol = "hew_yaml_array_push"
+result = "none"
+params = ["borrow", "consume"]
+release-symbol = ""
+discharge-depth = "none"

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -888,7 +888,7 @@ stable-stdlib = [
   "hew_toml_free",
   "hew_toml_get_string",
   "hew_toml_last_error",
-  "hew_toml_object_set",
+  "hew_toml_table_set",
   "hew_toml_stringify",
   "hew_yaml_array_push",
   "hew_yaml_free",
@@ -1192,7 +1192,7 @@ discharge-depth = "none"
 
 # hew-std/src/toml.rs:420-437 moves `val` into the table.
 [[ownership.contracts]]
-symbol = "hew_toml_object_set"
+symbol = "hew_toml_table_set"
 result = "none"
 params = ["borrow", "borrow", "consume"]
 release-symbol = ""

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -1301,3 +1301,131 @@ result = "fresh"
 params = ["borrow"]
 release-symbol = "hew_string_drop"
 discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:323-348 allocates an empty plain vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new_with_elem_size"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:352-366 allocates an i32 vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new"
+result = "fresh"
+params = []
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:369-383 allocates a bool vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new_bool"
+result = "fresh"
+params = []
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:386-394 allocates an i8 vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new_i8"
+result = "fresh"
+params = []
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:397-405 allocates a u8 vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new_u8"
+result = "fresh"
+params = []
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:408-416 allocates an i16 vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new_i16"
+result = "fresh"
+params = []
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:419-427 allocates a u16 vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new_u16"
+result = "fresh"
+params = []
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:430-445 allocates a string-owning vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new_str"
+result = "fresh"
+params = []
+release-symbol = "hew_vec_free"
+discharge-depth = "deep"
+
+# hew-runtime/src/vec.rs:448-462 allocates an i64 vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new_i64"
+result = "fresh"
+params = []
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:465-479 allocates an f64 vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new_f64"
+result = "fresh"
+params = []
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:482-490 allocates an f32 vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new_f32"
+result = "fresh"
+params = []
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:493-507 allocates a pointer-element vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new_ptr"
+result = "fresh"
+params = []
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:510-537 allocates an i32 vector from borrowed bytes.
+[[ownership.contracts]]
+symbol = "hew_vec_from_u8_data"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:540-570 copies a type descriptor into a fresh vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new_with_layout"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "deep"
+
+# hew-runtime/src/vec.rs:2320-2341 allocates a plain generic vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new_generic"
+result = "fresh"
+params = ["borrow", "borrow"]
+release-symbol = "hew_vec_free"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:2636-2650 allocates an owned-element vector.
+[[ownership.contracts]]
+symbol = "hew_vec_new_with_elem_layout"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_vec_free_owned"
+discharge-depth = "deep"

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -10,7 +10,7 @@
 #
 #   result = "fresh" | "retained" | "borrowed" | "none"
 #   params = ["borrow" | "consume" | "retain", ...]
-#   release-symbol = "<hew_* release function>" | ""
+#   release-symbol = "<hew_* release function or type-directed drop thunk>" | ""
 #   discharge-depth = "shallow" | "deep" | "none"
 #
 # `fresh` transfers a newly owned allocation to the caller. `retained`
@@ -1223,3 +1223,27 @@ result = "none"
 params = ["borrow", "consume"]
 release-symbol = ""
 discharge-depth = "none"
+
+# hew-runtime/src/vec.rs:814-835 returns a header-retained string reference.
+[[ownership.contracts]]
+symbol = "hew_vec_get_str"
+result = "retained"
+params = ["borrow", "borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
+# hew-runtime/src/vec.rs:2771-2793 returns an alias invalidated by vec mutation.
+[[ownership.contracts]]
+symbol = "hew_vec_get_owned"
+result = "borrowed"
+params = ["borrow", "borrow"]
+release-symbol = ""
+discharge-depth = "none"
+
+# hew-runtime/src/vec.rs:2796-2865 writes a fresh logical owner to `out`.
+[[ownership.contracts]]
+symbol = "hew_vec_get_clone"
+result = "fresh"
+params = ["borrow", "borrow", "borrow"]
+release-symbol = "HewTypeLayout.drop_fn"
+discharge-depth = "deep"

--- a/scripts/tests/test_verify_ffi_symbols.py
+++ b/scripts/tests/test_verify_ffi_symbols.py
@@ -1,8 +1,11 @@
+import contextlib
 import importlib.util
+import io
 import re
 import subprocess
 import sys
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "verify-ffi-symbols.py"
@@ -59,10 +62,11 @@ def test_classify_internal_outputs_sorted_names_only() -> None:
 
 def test_validate_covers_every_runtime_export_exactly_once() -> None:
     runtime_exports = verify_ffi_symbols.extract_runtime_exports()
+    stdlib_exports = verify_ffi_symbols.extract_stdlib_exports()
     classification = verify_ffi_symbols.load_jit_symbol_classification()
     assert (
         verify_ffi_symbols.validate_jit_symbol_classification(
-            runtime_exports, classification
+            runtime_exports, stdlib_exports, classification
         )
         == []
     )
@@ -71,6 +75,7 @@ def test_validate_covers_every_runtime_export_exactly_once() -> None:
 def test_validate_reports_missing_symbol_with_classification_file_path() -> None:
     errors = verify_ffi_symbols.validate_jit_symbol_classification(
         {"hew_zzz_test_symbol"},
+        set(),
         {
             "stable": set(),
             "stable-stdlib": set(),
@@ -83,6 +88,37 @@ def test_validate_reports_missing_symbol_with_classification_file_path() -> None
         "hew_zzz_test_symbol "
         f"(update {verify_ffi_symbols.JIT_SYMBOL_CLASSIFICATION})"
     ]
+
+
+def test_validate_rejects_missing_stable_stdlib_export() -> None:
+    runtime_exports = verify_ffi_symbols.extract_runtime_exports()
+    stdlib_exports = verify_ffi_symbols.extract_stdlib_exports()
+    classification = {
+        tier: set(symbols)
+        for tier, symbols in verify_ffi_symbols.load_jit_symbol_classification().items()
+    }
+    phantom = "hew_missing_stable_stdlib_export"
+    classification["stable-stdlib"].add(phantom)
+    stderr = io.StringIO()
+
+    with (
+        mock.patch.object(
+            verify_ffi_symbols,
+            "load_jit_symbol_classification",
+            return_value=classification,
+        ),
+        contextlib.redirect_stderr(stderr),
+    ):
+        exit_code = verify_ffi_symbols.run_classification_mode(
+            verify_ffi_symbols.parse_args(["--validate"]),
+            runtime_exports,
+            stdlib_exports,
+        )
+
+    assert exit_code != 0
+    assert (
+        f"stable-stdlib classification names not exported by hew-std (1): {phantom}"
+    ) in stderr.getvalue()
 
 
 def test_io_runtime_exports_are_jit_stable() -> None:
@@ -123,6 +159,7 @@ _TESTS = [
     test_classify_internal_outputs_sorted_names_only,
     test_validate_covers_every_runtime_export_exactly_once,
     test_validate_reports_missing_symbol_with_classification_file_path,
+    test_validate_rejects_missing_stable_stdlib_export,
     test_io_runtime_exports_are_jit_stable,
     test_c_unwind_machine_emit_exports_are_classified,
 ]

--- a/scripts/tests/test_verify_ffi_symbols.py
+++ b/scripts/tests/test_verify_ffi_symbols.py
@@ -18,6 +18,11 @@ IO_RUNTIME_FFI_FILES = (
     "io_time.rs",
     "transport.rs",
 )
+CODEGEN_STABLE_IO_EXPORTS = {
+    "hew_conn_await_read",
+    "hew_listener_await_accept",
+    "hew_tcp_read_raw",
+}
 C_UNWIND_MACHINE_EMIT_EXPORTS = {
     "hew_machine_emit_step_enter",
     "hew_machine_emit_step_exit",
@@ -55,9 +60,13 @@ def test_classify_internal_outputs_sorted_names_only() -> None:
     assert result.returncode == 0, result.stderr
     lines = result.stdout.splitlines()
     assert lines == sorted(lines)
-    assert "hew_sched_init" in lines
+    assert "hew_sched_init" not in lines
     assert "hew_runtime_cleanup" in lines
     assert "hew_actor_spawn" not in lines
+
+    codegen_result = run_script("--classify", "codegen-stable", "--validate")
+    assert codegen_result.returncode == 0, codegen_result.stderr
+    assert "hew_sched_init" in codegen_result.stdout.splitlines()
 
 
 def test_validate_covers_every_runtime_export_exactly_once() -> None:
@@ -136,7 +145,8 @@ def test_io_runtime_exports_are_jit_stable() -> None:
 
     assert io_exports
     assert not (io_exports & classification["internal"])
-    assert io_exports <= classification["stable"]
+    assert io_exports & classification["codegen-stable"] == CODEGEN_STABLE_IO_EXPORTS
+    assert io_exports - CODEGEN_STABLE_IO_EXPORTS <= classification["stable"]
     assert "hew_shutdown_initiate" in classification["internal"]
 
 

--- a/scripts/tests/test_verify_ffi_symbols.py
+++ b/scripts/tests/test_verify_ffi_symbols.py
@@ -73,19 +73,18 @@ def test_validate_covers_every_runtime_export_exactly_once() -> None:
 
 
 def test_validate_reports_missing_symbol_with_classification_file_path() -> None:
+    runtime_exports = verify_ffi_symbols.extract_runtime_exports()
+    stdlib_exports = verify_ffi_symbols.extract_stdlib_exports()
+    classification = verify_ffi_symbols.load_jit_symbol_classification()
+    phantom = "hew_zzz_test_symbol"
     errors = verify_ffi_symbols.validate_jit_symbol_classification(
-        {"hew_zzz_test_symbol"},
-        set(),
-        {
-            "stable": set(),
-            "stable-stdlib": set(),
-            "codegen-stable": set(),
-            "internal": set(),
-        },
+        runtime_exports | {phantom},
+        stdlib_exports,
+        classification,
     )
     assert errors == [
         "unclassified runtime exports (1): "
-        "hew_zzz_test_symbol "
+        f"{phantom} "
         f"(update {verify_ffi_symbols.JIT_SYMBOL_CLASSIFICATION})"
     ]
 

--- a/scripts/verify-ffi-symbols.py
+++ b/scripts/verify-ffi-symbols.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Classify and validate the stable JIT host ABI exported by hew-runtime.
 
-Scans all hew-runtime Rust source files for #[no_mangle] extern "C" and
-extern "C-unwind" fn exports and validates each one is classified (stable,
-codegen-stable, or internal) in scripts/jit-symbol-classification.toml.
+Scans hew-runtime and hew-std Rust source files for #[no_mangle] extern "C"
+and extern "C-unwind" fn exports and validates the classifications in
+scripts/jit-symbol-classification.toml.
 
 Three-tier model:
   stable         -- user-visible runtime surface; user `extern "rt"` blocks
@@ -35,6 +35,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 RUNTIME_SRC = ROOT / "hew-runtime" / "src"
+STDLIB_SRC = ROOT / "hew-std" / "src"
 JIT_SYMBOL_CLASSIFICATION = ROOT / "scripts" / "jit-symbol-classification.toml"
 FFI_OWNERSHIP_RATCHET = ROOT / "scripts" / "ffi-ownership-ratchet.toml"
 SOURCE_ENCODING = "utf-8"
@@ -164,8 +165,8 @@ def _extract_macro_generated_exports(
     return exports
 
 
-def extract_runtime_exports() -> set[str]:
-    """Scan all hew-runtime .rs files for #[no_mangle] function names.
+def _extract_native_exports(source_dir: Path) -> set[str]:
+    """Scan Rust source files for #[no_mangle] function names.
 
     Two passes are performed:
 
@@ -189,7 +190,7 @@ def extract_runtime_exports() -> set[str]:
     )
     sources: list[tuple] = []
     exports: set[str] = set()
-    for rs_file in RUNTIME_SRC.rglob("*.rs"):
+    for rs_file in source_dir.rglob("*.rs"):
         source = rs_file.read_text(encoding=SOURCE_ENCODING)
         sources.append((rs_file, source))
         for match in fn_pattern.finditer(source):
@@ -199,6 +200,16 @@ def extract_runtime_exports() -> set[str]:
     no_mangle_macros = _find_no_mangle_macros(sources)
     exports.update(_extract_macro_generated_exports(sources, no_mangle_macros))
     return exports
+
+
+def extract_runtime_exports() -> set[str]:
+    """Return native exports defined by hew-runtime."""
+    return _extract_native_exports(RUNTIME_SRC)
+
+
+def extract_stdlib_exports() -> set[str]:
+    """Return native exports defined by hew-std."""
+    return _extract_native_exports(STDLIB_SRC)
 
 
 def classify(name: str, runtime_exports: set[str]) -> str:
@@ -308,13 +319,15 @@ def validate_ownership_contracts(classification: dict[str, set[str]]) -> list[st
             errors.append(
                 f"unclassified ownership contracts: expected "
                 f"{expected_unclassified}, found {actual_unclassified}; "
-                f"curation must only lower {FFI_OWNERSHIP_RATCHET}"
+                f"update the exact count in {FFI_OWNERSHIP_RATCHET}"
             )
     return errors
 
 
 def validate_jit_symbol_classification(
-    runtime_exports: set[str], classification: dict[str, set[str]]
+    runtime_exports: set[str],
+    stdlib_exports: set[str],
+    classification: dict[str, set[str]],
 ) -> list[str]:
     errors: list[str] = []
     stable = classification["stable"]
@@ -337,9 +350,8 @@ def validate_jit_symbol_classification(
                 + ", ".join(overlap)
                 + f" (update {JIT_SYMBOL_CLASSIFICATION})"
             )
-    # `stable-stdlib` is intentionally NOT unioned into the runtime-coverage
-    # check: those symbols come from sibling stdlib crates, not hew-runtime,
-    # so they would always show up as "extra" runtime classifications.
+    # `stable-stdlib` is intentionally NOT unioned into the runtime completeness
+    # check because those symbols come from hew-std rather than hew-runtime.
     classified = stable | codegen_stable | internal
     missing = sorted(runtime_exports - classified)
     extra = sorted(classified - runtime_exports)
@@ -353,6 +365,14 @@ def validate_jit_symbol_classification(
         errors.append(
             f"classification names not exported by hew-runtime ({len(extra)}): "
             + ", ".join(extra)
+            + f" (remove from {JIT_SYMBOL_CLASSIFICATION})"
+        )
+    missing_stdlib_exports = sorted(stable_stdlib - stdlib_exports)
+    if missing_stdlib_exports:
+        errors.append(
+            "stable-stdlib classification names not exported by hew-std "
+            f"({len(missing_stdlib_exports)}): "
+            + ", ".join(missing_stdlib_exports)
             + f" (remove from {JIT_SYMBOL_CLASSIFICATION})"
         )
     errors.extend(validate_ownership_contracts(classification))
@@ -378,10 +398,16 @@ def emit_cpp_header(path: Path, stable_symbols: list[str]) -> None:
     )
 
 
-def run_classification_mode(args: argparse.Namespace, runtime_exports: set[str]) -> int:
+def run_classification_mode(
+    args: argparse.Namespace,
+    runtime_exports: set[str],
+    stdlib_exports: set[str],
+) -> int:
     classification = load_jit_symbol_classification()
     if args.validate:
-        errors = validate_jit_symbol_classification(runtime_exports, classification)
+        errors = validate_jit_symbol_classification(
+            runtime_exports, stdlib_exports, classification
+        )
         if errors:
             for error in errors:
                 print(f"ERROR: {error}", file=sys.stderr)
@@ -421,7 +447,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if args.classify is not None or args.validate or args.emit_cpp_header is not None:
         runtime_exports = extract_runtime_exports()
-        return run_classification_mode(args, runtime_exports)
+        stdlib_exports = extract_stdlib_exports()
+        return run_classification_mode(args, runtime_exports, stdlib_exports)
     return run_coverage_mode(args.strict)
 
 

--- a/scripts/verify-ffi-symbols.py
+++ b/scripts/verify-ffi-symbols.py
@@ -30,29 +30,17 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 RUNTIME_SRC = ROOT / "hew-runtime" / "src"
 JIT_SYMBOL_CLASSIFICATION = ROOT / "scripts" / "jit-symbol-classification.toml"
+FFI_OWNERSHIP_RATCHET = ROOT / "scripts" / "ffi-ownership-ratchet.toml"
 SOURCE_ENCODING = "utf-8"
-
-# Function prefixes that live in separate stdlib packages, not hew-runtime.
-# These are linked by the compiler driver when the user imports the module.
-STDLIB_PACKAGE_PREFIXES = (
-    "hew_http_",
-    "hew_tls_",
-    "hew_json_",
-    "hew_regex_",
-    "hew_sqlite_",
-    "hew_postgres_",
-    "hew_redis_",
-    "hew_csv_",
-    "hew_toml_",
-    "hew_yaml_",
-    "hew_mqtt_",
-    "hew_grpc_",
-)
+OWNERSHIP_RESULTS = {"fresh", "retained", "borrowed", "none"}
+PARAM_OWNERSHIP = {"borrow", "consume", "retain"}
+DISCHARGE_DEPTHS = {"shallow", "deep", "none"}
 
 # Exact function names that are codegen-internal (intercepted/rewritten, never linked).
 # For example, hew_log_debug is rewritten to hew_log_emit with a level argument.
@@ -213,10 +201,6 @@ def extract_runtime_exports() -> set[str]:
     return exports
 
 
-def is_stdlib_package(name: str) -> bool:
-    return any(name.startswith(prefix) for prefix in STDLIB_PACKAGE_PREFIXES)
-
-
 def classify(name: str, runtime_exports: set[str]) -> str:
     """Classify a codegen reference. Returns '' if covered, else 'UNCOVERED'."""
     if name in runtime_exports:
@@ -224,8 +208,6 @@ def classify(name: str, runtime_exports: set[str]) -> str:
     if name in CODEGEN_INTERNAL:
         return ""
     if name in TEMPLATE_NAMES:
-        return ""
-    if is_stdlib_package(name):
         return ""
     # Check if it's a suffixed variant of a runtime function
     # e.g. hew_print_u32 → base hew_print is in runtime
@@ -247,6 +229,88 @@ def load_jit_symbol_classification() -> dict[str, set[str]]:
             raise ValueError(f"{JIT_SYMBOL_CLASSIFICATION}: duplicate entries in {key}")
         classification[key] = set(symbols)
     return classification
+
+
+def validate_ownership_contracts(classification: dict[str, set[str]]) -> list[str]:
+    errors: list[str] = []
+    document = tomllib.loads(
+        JIT_SYMBOL_CLASSIFICATION.read_text(encoding=SOURCE_ENCODING)
+    )
+    ownership = document.get("ownership")
+    if not isinstance(ownership, dict):
+        return [f"{JIT_SYMBOL_CLASSIFICATION}: missing [ownership] table"]
+    contracts = ownership.get("contracts")
+    if not isinstance(contracts, list):
+        return [f"{JIT_SYMBOL_CLASSIFICATION}: ownership.contracts must be an array"]
+
+    classified = set().union(*classification.values())
+    contracted: set[str] = set()
+    for index, contract in enumerate(contracts, start=1):
+        location = f"{JIT_SYMBOL_CLASSIFICATION}: ownership contract #{index}"
+        if not isinstance(contract, dict):
+            errors.append(f"{location} must be a table")
+            continue
+
+        symbol = contract.get("symbol")
+        if not isinstance(symbol, str) or not symbol:
+            errors.append(f"{location} requires a non-empty symbol")
+            continue
+        location = f"{JIT_SYMBOL_CLASSIFICATION}: ownership contract for {symbol}"
+        if symbol in contracted:
+            errors.append(f"{location} is duplicated")
+            continue
+        contracted.add(symbol)
+        if symbol not in classified:
+            errors.append(f"{location} is not ABI-classified")
+
+        result = contract.get("result")
+        if result not in OWNERSHIP_RESULTS:
+            errors.append(
+                f"{location} result must be one of {sorted(OWNERSHIP_RESULTS)}"
+            )
+
+        params = contract.get("params")
+        if not isinstance(params, list) or any(
+            param not in PARAM_OWNERSHIP for param in params
+        ):
+            errors.append(
+                f"{location} params must contain only {sorted(PARAM_OWNERSHIP)}"
+            )
+
+        release_symbol = contract.get("release-symbol")
+        discharge_depth = contract.get("discharge-depth")
+        if not isinstance(release_symbol, str):
+            errors.append(f"{location} requires string release-symbol")
+        if discharge_depth not in DISCHARGE_DEPTHS:
+            errors.append(
+                f"{location} discharge-depth must be one of {sorted(DISCHARGE_DEPTHS)}"
+            )
+        elif result in {"fresh", "retained"}:
+            if not release_symbol:
+                errors.append(f"{location} owned result requires release-symbol")
+            if discharge_depth == "none":
+                errors.append(
+                    f"{location} owned result requires shallow or deep discharge"
+                )
+        elif release_symbol or discharge_depth != "none":
+            errors.append(
+                f"{location} borrowed/none result must use empty release-symbol "
+                'and discharge-depth = "none"'
+            )
+
+    ratchet = tomllib.loads(FFI_OWNERSHIP_RATCHET.read_text(encoding=SOURCE_ENCODING))
+    expected_unclassified = ratchet.get("unclassified")
+    if not isinstance(expected_unclassified, int) or expected_unclassified < 0:
+        errors.append(f"{FFI_OWNERSHIP_RATCHET}: unclassified must be non-negative")
+    else:
+        actual_unclassified = len(classified - contracted)
+        if actual_unclassified != expected_unclassified:
+            errors.append(
+                f"unclassified ownership contracts: expected "
+                f"{expected_unclassified}, found {actual_unclassified}; "
+                f"curation must only lower {FFI_OWNERSHIP_RATCHET}"
+            )
+    return errors
 
 
 def validate_jit_symbol_classification(
@@ -291,6 +355,7 @@ def validate_jit_symbol_classification(
             + ", ".join(extra)
             + f" (remove from {JIT_SYMBOL_CLASSIFICATION})"
         )
+    errors.extend(validate_ownership_contracts(classification))
     return errors
 
 


### PR DESCRIPTION
## Summary

Every `hew_*` runtime symbol now carries a machine-checked ownership contract — a `result` classification (fresh/retained/borrowed/none) and per-parameter classifications (borrow/consume/retain) — validated by `scripts/verify-ffi-symbols.py` against the real `hew-std`/`hew-runtime` native exports. Unclassified symbols are pinned by a shrink-only ratchet, and every curated `stable-stdlib` entry now fails closed if it doesn't resolve to a real native export, closing a validator gap that previously let a misnamed/phantom symbol pass silently. The vector getter trio is fully classified (`hew_vec_get_str`=retained, `hew_vec_get_owned`=borrowed, `hew_vec_get_clone`=fresh), and I corrected three getters (`protobuf`, `toml`, `markdown`) whose docs said `libc::free` for header-aware string allocations — freeing the raw data pointer instead of the header-adjusted base would corrupt the heap. They now correctly document `hew_string_drop`.

## Verification

- `make verify-ffi`: PASS, including a scratch reject probe — a temporary `hew_missing_stable_stdlib_export` phantom entry failed with exit 2 and the expected "not exported by hew-std" diagnostic, then was removed
- `make test-verify-ffi`: PASS, full validator test harness, now CI-gated alongside `make verify-ffi` in the ABI-classification workflow step; includes the negative test proving an unclassified/phantom symbol fails closed
- `cargo nextest run --workspace`: PASS, 11260 passed / 0 failed / 37 skipped
- `make test-hew-ratchet`: PASS, 0 expected / 0 actual failures
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `make lint`: PASS

## Out of scope

- Refs #2549, #2559, #2550 — this PR ships the contract schema, validator, and classification data only. The MIR consumption wiring (suppressing a callee-side close when a parameter contract is `consume`) and the recursive-free behaviour that actually acts on these contracts are separate follow-ups; those issues close when that consuming behaviour lands, not here.
- `validate_ownership_contracts` currently reads contract rows from the global TOML rather than the classification argument it's passed, coupling its output to file state outside its arguments. Optional cleanup, not required for correctness.
