### PR TITLE
fix(types): reject reserved type names in declarations

### DIFF
--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -2347,6 +2347,11 @@ impl Checker {
         name: &str,
         span: &Span,
     ) -> bool {
+        if crate::ty::is_reserved_type_name(name) {
+            self.errors
+                .push(TypeError::reserved_type_name(span.clone(), name));
+            return false;
+        }
         let owner_key = (module_short.map(str::to_string), name.to_string());
         if let Some(prev_span) = self.type_namespace_owners.get(&owner_key).cloned() {
             self.report_duplicate_type_namespace_name(name, span, prev_span);
@@ -2379,6 +2384,11 @@ impl Checker {
         machine_name: &str,
         span: &Span,
     ) -> bool {
+        if crate::ty::is_reserved_type_name(machine_name) {
+            self.errors
+                .push(TypeError::reserved_type_name(span.clone(), machine_name));
+            return false;
+        }
         let machine_key = (module_short.map(str::to_string), machine_name.to_string());
         if let Some(prev_span) = self.type_namespace_owners.get(&machine_key).cloned() {
             self.report_duplicate_type_namespace_name(machine_name, span, prev_span);

--- a/hew-types/src/check/tests/basic.rs
+++ b/hew-types/src/check/tests/basic.rs
@@ -1426,3 +1426,84 @@ fn typecheck_local_result_enum_not_qualified_to_sqlite() {
         }
     );
 }
+
+// --- #2520: reserved type names (primitives + structural encoder heads) ---
+
+#[test]
+fn reserved_primitive_type_name_i64_rejected() {
+    // `type i64 { ... }` collides with the primitive spelling. The
+    // type-fragment encoder leaves primitive fragments unchanged, so the
+    // checker must reject the declaration rather than treat it as a mangling
+    // concern.
+    let output = check_source("type i64 { value: i64; }\nfn main() -> i64 { return 0; }");
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::ReservedTypeName && e.message.contains("i64")),
+        "expected ReservedTypeName citing `i64`; got: {:?}",
+        output.errors
+    );
+}
+
+#[test]
+fn reserved_structural_head_tuple_rejected() {
+    // `type tuple<T> { ... }` collides with the structural encoder head
+    // `tuple$x...$g`.
+    let output = check_source("type tuple<T> { value: T; }\nfn main() -> i64 { return 0; }");
+    assert!(
+        output
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::ReservedTypeName && e.message.contains("tuple")),
+        "expected ReservedTypeName citing `tuple`; got: {:?}",
+        output.errors
+    );
+}
+
+#[test]
+fn reserved_type_name_rejected_across_declaration_kinds() {
+    // The gate lives in the shared namespace-registration chokepoint, so
+    // `record`/`actor` declarations are rejected the same way `type` is.
+    for (src, needle) in [
+        (
+            "record string { a: i64 }\nfn main() -> i64 { return 0; }",
+            "string",
+        ),
+        (
+            "actor bytes {\n  receive fn ping() {}\n}\nfn main() -> i64 { return 0; }",
+            "bytes",
+        ),
+    ] {
+        let output = check_source(src);
+        assert!(
+            output
+                .errors
+                .iter()
+                .any(|e| e.kind == TypeErrorKind::ReservedTypeName && e.message.contains(needle)),
+            "expected ReservedTypeName citing `{needle}` for source `{src}`; got: {:?}",
+            output.errors
+        );
+    }
+}
+
+#[test]
+fn non_reserved_type_names_still_accepted() {
+    // Names that merely resemble but do not equal a reserved spelling must
+    // still be accepted (no over-fire).
+    let output = check_source(
+        "type Point { x: i64; y: i64; }\n\
+         type Tuple { a: i64; }\n\
+         type MyString { s: i64; }\n\
+         enum Colour { Red; Green; Blue; }\n\
+         fn main() -> i64 { return 0; }",
+    );
+    assert!(
+        output
+            .errors
+            .iter()
+            .all(|e| e.kind != TypeErrorKind::ReservedTypeName),
+        "no ReservedTypeName expected for non-reserved names; got: {:?}",
+        output.errors
+    );
+}

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -223,6 +223,17 @@ impl TypeError {
         .with_note(prev_span, "previous definition here".to_string())
     }
 
+    /// Create a reserved-type-name error for a user declaration that reuses a
+    /// primitive spelling or a structural type-encoder head.
+    #[must_use]
+    pub fn reserved_type_name(span: Span, name: &str) -> Self {
+        Self::new(
+            TypeErrorKind::ReservedTypeName,
+            span,
+            format!("`{name}` is a reserved type name and cannot be used for a declaration"),
+        )
+    }
+
     /// Create a mutability error.
     #[must_use]
     pub fn mutability_error(span: Span, name: &str) -> Self {
@@ -551,6 +562,11 @@ pub enum TypeErrorKind {
     NonExhaustiveMatch,
     /// Name defined multiple times
     DuplicateDefinition,
+    /// A user type declaration uses a reserved name: either a primitive type
+    /// spelling (`i64`, `bool`, `string`, …) or a structural type-encoder head
+    /// (`tuple`, `array`, `fn`, …). These names collide with the compiler's
+    /// own type vocabulary and cannot be redeclared.
+    ReservedTypeName,
     /// Assigning to immutable variable
     MutabilityError,
     /// Return statement type doesn't match function signature
@@ -1180,6 +1196,7 @@ impl TypeErrorKind {
             Self::InferenceFailed => "InferenceFailed",
             Self::NonExhaustiveMatch => "NonExhaustiveMatch",
             Self::DuplicateDefinition => "DuplicateDefinition",
+            Self::ReservedTypeName => "ReservedTypeName",
             Self::MutabilityError => "MutabilityError",
             Self::ReturnTypeMismatch => "ReturnTypeMismatch",
             Self::UseAfterMove => "UseAfterMove",

--- a/hew-types/src/ty.rs
+++ b/hew-types/src/ty.rs
@@ -392,6 +392,53 @@ pub const PRIMITIVE_ALIASES: &[(&str, &[&str])] = &[
     ("!", &["!"]),
 ];
 
+/// Structural type-encoder "heads" — the leading tokens the monomorph and
+/// resolved-type manglers emit for non-primitive structural shapes
+/// (`tuple$x...$g`, `array$x...$g`, `fn$x...$r...$g`, etc.). A user type
+/// declaration whose bare name collides with one of these heads would be
+/// indistinguishable from a mangled structural fragment at the symbol layer,
+/// so the checker reserves them alongside the primitive spellings.
+///
+/// Kept in lockstep with `hew-hir/src/monomorph.rs::mangle_resolved_ty` and
+/// `hew-types/src/resolved_ty.rs::mangle_resolved_ty_segment`.
+pub const STRUCTURAL_ENCODER_HEADS: &[&str] = &[
+    "tuple",
+    "array",
+    "slice",
+    "fn",
+    "closure",
+    "ptr",
+    "ptrmut",
+    "borrow",
+    "dyn",
+    "task",
+    "unit",
+    "never",
+    "typeparam",
+];
+
+/// Return `true` if `name` is a reserved type-declaration name: either a
+/// primitive type spelling (`i64`, `bool`, `string`, …) or a structural
+/// encoder head (`tuple`, `array`, …). User `type`/`record`/`actor`/`machine`
+/// declarations may not use these names because the type-fragment encoder
+/// leaves such fragments unchanged, so a declaration named `i64` or `tuple`
+/// would collide with the compiler's own type vocabulary.
+///
+/// Structural spellings like `()` and `!` are excluded here because they are
+/// not valid identifiers and can never appear as a declared type name.
+#[must_use]
+pub fn is_reserved_type_name(name: &str) -> bool {
+    if STRUCTURAL_ENCODER_HEADS.contains(&name) {
+        return true;
+    }
+    for (_canonical, aliases) in PRIMITIVE_ALIASES {
+        if aliases.contains(&name) && name != "()" && name != "!" {
+            return true;
+        }
+    }
+    false
+}
+
 /// Return the alias slice for the given canonical primitive name.
 ///
 /// Intended for use in `const` initializers in downstream crates that need
@@ -1756,6 +1803,49 @@ impl fmt::Display for UserFacingTy<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reserved_type_name_covers_primitives_and_structural_heads() {
+        // Primitive spellings are reserved.
+        for name in [
+            "i64", "i32", "u64", "bool", "char", "string", "bytes", "duration",
+        ] {
+            assert!(
+                is_reserved_type_name(name),
+                "`{name}` should be a reserved type name"
+            );
+        }
+        // Structural encoder heads are reserved.
+        for name in [
+            "tuple",
+            "array",
+            "slice",
+            "fn",
+            "closure",
+            "ptr",
+            "ptrmut",
+            "borrow",
+            "dyn",
+            "task",
+            "unit",
+            "never",
+            "typeparam",
+        ] {
+            assert!(
+                is_reserved_type_name(name),
+                "`{name}` should be a reserved type name"
+            );
+        }
+        // Ordinary user names (including near-misses) are not reserved.
+        for name in [
+            "Point", "Tuple", "MyString", "I64", "String", "Array", "foo", "bar",
+        ] {
+            assert!(
+                !is_reserved_type_name(name),
+                "`{name}` should NOT be a reserved type name"
+            );
+        }
+    }
 
     #[test]
     fn test_type_var_fresh() {


### PR DESCRIPTION
Fixes #2520.

## Problem

The checker accepted type declarations that reuse the compiler's own type vocabulary:

```hew
type tuple<T> { value: T; }
type i64 { value: i64; }
```

`hew check` reported both as OK. The type-fragment encoder intentionally leaves primitive fragments unchanged, and structural fragments are emitted under fixed heads (`tuple$x...$g`, `array$x...$g`, `fn$x...$r...$g`, ...). A declaration named after a primitive spelling or a structural head is therefore indistinguishable from a mangled structural fragment at the symbol layer, so these names must be rejected at declaration time.

## Fix

- New `ty::is_reserved_type_name(name)`: the primitive aliases (minus the non-identifier `()`/`!` spellings, which can never be declared) plus the structural encoder heads (`tuple`, `array`, `slice`, `fn`, `closure`, `ptr`, `ptrmut`, `borrow`, `dyn`, `task`, `unit`, `never`, `typeparam`). The head list is kept in lockstep with `monomorph::mangle_resolved_ty` and `resolved_ty::mangle_resolved_ty_segment`.
- New `ReservedTypeName` diagnostic + `TypeError::reserved_type_name` constructor, with a stable `as_kind_str` key for the LSP/WASM protocol.
- The gate lives in the two shared namespace-registration chokepoints, `register_type_namespace_name` and `register_machine_type_namespace_names`, so `type` / `record` / `actor` / `machine` declarations are all rejected uniformly and **fail closed** (return `false`) before any registration side effects.

Behaviour:

```
error: `tuple` is a reserved type name and cannot be used for a declaration
error: `i64` is a reserved type name and cannot be used for a declaration
```

## No over-fire

Only exact-match bare names are reserved. Look-alikes (`Tuple`, `MyString`, `I64`, `String`, `Array`) still declare cleanly. Module-qualified names are unaffected (the gate keys on the bare declared name).

## Tests

- `ty` predicate unit test over primitives, structural heads, and near-miss user names.
- Checker rejection tests for `type i64`, `type tuple<T>`, and `record`/`actor` kinds.
- A no-over-fire test asserting look-alike names produce no `ReservedTypeName`.

## Verification

- `cargo test -p hew-types --lib`: 1654 passed, 0 failed.
- `cargo fmt --all -- --check` clean; `cargo clippy -p hew-types` clean.
- Full stdlib `.hew` corpus re-checked with the built compiler: zero reserved-name regressions (no std type is named after a reserved word).