### PR TITLE
fix(types): give lambda parameters a shadow span so nested locals warn, not error

### DIFF
--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -708,6 +708,15 @@ pub struct TimeoutClause {
 pub struct LambdaParam {
     pub name: String,
     pub ty: Option<Spanned<TypeExpr>>,
+    /// Source span of the parameter *name* token, used only for outer-scope
+    /// shadowing classification (see `Checker::check_lambda` /
+    /// `Env::define_param_with_span`). Free/receive-fn/init/hook parameters
+    /// already carry this via `Param.ty.1`; lambda parameters had no name
+    /// span at all prior to this field, so a nested `let` shadowing a
+    /// lambda parameter was indistinguishable from shadowing a fully
+    /// synthetic binding and hard-errored instead of warning.
+    #[serde(default)]
+    pub name_span: Span,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/hew-parser/src/parser/expressions.rs
+++ b/hew-parser/src/parser/expressions.rs
@@ -1469,6 +1469,7 @@ impl Parser<'_> {
         let mut params = Vec::new();
 
         while !self.at_end() && self.peek() != Some(&Token::Pipe) {
+            let name_span = self.peek_span();
             let name = self.expect_ident()?;
 
             let ty = if self.eat(&Token::Colon) {
@@ -1477,7 +1478,11 @@ impl Parser<'_> {
                 None
             };
 
-            params.push(LambdaParam { name, ty });
+            params.push(LambdaParam {
+                name,
+                ty,
+                name_span,
+            });
 
             if !self.eat(&Token::Comma) {
                 break;
@@ -1491,6 +1496,7 @@ impl Parser<'_> {
         let mut params = Vec::new();
 
         while !self.at_end() && self.peek() != Some(&Token::RightParen) {
+            let name_span = self.peek_span();
             let name = self.expect_ident()?;
 
             let ty = if self.eat(&Token::Colon) {
@@ -1499,7 +1505,11 @@ impl Parser<'_> {
                 None
             };
 
-            params.push(LambdaParam { name, ty });
+            params.push(LambdaParam {
+                name,
+                ty,
+                name_span,
+            });
 
             if !self.eat(&Token::Comma) {
                 break;

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -5942,7 +5942,9 @@ impl Checker {
             } else {
                 Ty::Var(TypeVar::fresh())
             };
-            self.env.define(p.name.clone(), ty.clone(), false);
+            self.check_shadowing(&p.name, &p.name_span);
+            self.env
+                .define_param_with_span(p.name.clone(), ty.clone(), false, p.name_span.clone());
             param_tys.push(ty);
         }
 

--- a/hew-types/src/check/tests/infer.rs
+++ b/hew-types/src/check/tests/infer.rs
@@ -816,6 +816,7 @@ mod non_root_module_inference_scope {
             params: vec![LambdaParam {
                 name: "x".to_string(),
                 ty: Some((TypeExpr::Infer, 15..16)),
+                name_span: 14..15,
             }],
             return_type: None,
             body: Box::new((Expr::Identifier("x".to_string()), 19..20)),

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -2345,6 +2345,56 @@ fn warn_nested_scope_shadowing_of_receive_fn_param() {
 }
 
 #[test]
+fn warn_nested_scope_shadowing_of_lambda_param() {
+    // #2503: PR #2499 fixed function/receive-fn/actor-init/actor-hook
+    // parameters (bound via `define_param_with_span`) but explicitly did not
+    // cover lambda parameters, a 5th surface with the same bug class —
+    // lambda params were bound via plain `env.define` (no span at all), so a
+    // nested `let` shadowing a lambda's own parameter was indistinguishable
+    // from shadowing a synthetic binding and hard-errored instead of warning.
+    let source = r#"
+        fn main() {
+            let f = |x: i64| -> i64 {
+                let x = 2;
+                return x;
+            };
+            println(f(5));
+        }
+    "#;
+    let (errors, warnings) = parse_and_check(source);
+    assert!(
+        !errors.iter().any(|e| e.kind == TypeErrorKind::Shadowing),
+        "shadowing a lambda parameter should not be a hard error, got errors: {errors:?}",
+    );
+    assert!(
+        warnings.iter().any(|w| w.kind == TypeErrorKind::Shadowing
+            && w.message.contains("shadows a binding in an outer scope")),
+        "expected outer-scope shadowing warning for parameter `x`, got warnings: {warnings:?}",
+    );
+}
+
+#[test]
+fn unused_lambda_param_is_not_warned() {
+    // Lambda parameters must stay exempt from the `UnusedVariable` lint —
+    // same contract as free-fn params (see `unused_free_fn_param_is_not_warned`
+    // below) — the shadowing-severity fix must not regress this.
+    let source = r#"
+        fn main() {
+            let f = |unused: i64| -> i64 { return 5; };
+            println(f(1));
+        }
+    "#;
+    let (errors, warnings) = parse_and_check(source);
+    assert!(
+        !warnings
+            .iter()
+            .any(|w| w.kind == TypeErrorKind::UnusedVariable),
+        "unused lambda parameters must not trigger UnusedVariable, got warnings: {warnings:?}",
+    );
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+}
+
+#[test]
 fn unused_free_fn_param_is_not_warned() {
     // Parameters keep `def_span: None` (see `define_param_with_span`) even
     // though they now carry a `shadow_span` for the shadowing fix above, so


### PR DESCRIPTION
Fixes #2503.

PR #2499 fixed the parameter-shadowing severity bug for function, receive-fn, actor-init, and actor-hook parameters by switching their binding from `env.define` (fully synthetic, no span) to `env.define_param_with_span` (keeps `def_span: None` so `UnusedVariable` stays exempt, but adds `shadow_span` so a nested local shadowing the parameter is classified as outer-scope-shadows-a-user-binding — a warning — instead of outer-scope-shadows-a-synthetic-binding — a hard error). That PR explicitly scoped the fix to those four surfaces and named lambda parameters as a known 5th surface with the same bug class, still bound via plain `env.define` in `hew-types/src/check/expressions.rs` (`check_lambda`).

`LambdaParam` had no name span at all (only the type annotation carries one, and it's optional), so closing this required a real AST field: `LambdaParam::name_span`, populated by both lambda-parameter parsers (`try_parse_lambda_params` and the pipe-lambda variant `try_parse_pipe_lambda_params`) by capturing `peek_span()` right before consuming the identifier token. `check_lambda` now calls `check_shadowing` (previously never invoked for lambda params at all) and binds through `define_param_with_span` using that span, matching the #2499 pattern exactly.

## Verification

- Reproduced the described defect directly against a from-source pre-fix build: `fn main() { let f = |x: i64| -> i64 { let x = 2; return x; }; ... }` hard-errors (`variable `x` shadows a binding in an outer scope`).
- Post-fix build downgrades it to the same outer-scope-shadowing *warning* the other four surfaces get, with the correct originating span pointing at the lambda parameter's name token.
- Same-scope duplicate lambda params (`|x: i64, x: i64| ...`) still correctly hard-error — `check_shadowing`'s same-scope branch is unaffected.
- Added 2 regression tests mirroring #2499's free-fn/receive-fn pair (warn on nested-scope lambda-param shadow; unused lambda param still exempt from `UnusedVariable`), plus updated the one hand-constructed `LambdaParam` test fixture for the new field.
- `cargo test -p hew-types --lib`: 1651/1651 passing.
- `cargo test -p hew-parser -p hew-hir -p hew-analysis --lib`: 357 + 249 + 89 all passing.
- `cargo fmt` clean, `cargo clippy -p hew-parser -p hew-types --lib -- -D warnings` clean.