### PR TITLE
fix(types): reject reserved declaration names

### DIFF
--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -23,11 +23,23 @@ impl Checker {
     pub(super) fn check_item(&mut self, item: &Item, span: &Span) {
         match item {
             Item::Function(fd) => self.check_function(fd),
-            Item::Actor(ad) => self.check_actor(ad),
+            Item::Actor(ad) => {
+                if !crate::ty::is_reserved_type_name(&ad.name) {
+                    self.check_actor(ad);
+                }
+            }
             Item::Const(cd) => self.check_const(cd, span),
             Item::Impl(id) => self.check_impl(id, span),
-            Item::Machine(md) => self.check_machine_exhaustiveness(md, span),
-            Item::Trait(td) => self.check_trait_defaults(td),
+            Item::Machine(md) => {
+                if !crate::ty::is_reserved_type_name(&md.name) {
+                    self.check_machine_exhaustiveness(md, span);
+                }
+            }
+            Item::Trait(td) => {
+                if !crate::ty::is_reserved_type_name(&td.name) {
+                    self.check_trait_defaults(td);
+                }
+            }
             // All of these are fully handled during earlier registration passes
             // and require no second-pass body checking.  Record declarations
             // specifically are registered by `register_record_decl`; they have

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -2347,6 +2347,11 @@ impl Checker {
         name: &str,
         span: &Span,
     ) -> bool {
+        if crate::ty::is_reserved_type_name(name) {
+            self.errors
+                .push(TypeError::reserved_type_name(span.clone(), name));
+            return false;
+        }
         let owner_key = (module_short.map(str::to_string), name.to_string());
         if let Some(prev_span) = self.type_namespace_owners.get(&owner_key).cloned() {
             self.report_duplicate_type_namespace_name(name, span, prev_span);
@@ -2379,6 +2384,11 @@ impl Checker {
         machine_name: &str,
         span: &Span,
     ) -> bool {
+        if crate::ty::is_reserved_type_name(machine_name) {
+            self.errors
+                .push(TypeError::reserved_type_name(span.clone(), machine_name));
+            return false;
+        }
         let machine_key = (module_short.map(str::to_string), machine_name.to_string());
         if let Some(prev_span) = self.type_namespace_owners.get(&machine_key).cloned() {
             self.report_duplicate_type_namespace_name(machine_name, span, prev_span);

--- a/hew-types/src/check/tests/basic.rs
+++ b/hew-types/src/check/tests/basic.rs
@@ -1426,3 +1426,86 @@ fn typecheck_local_result_enum_not_qualified_to_sqlite() {
         }
     );
 }
+
+// --- Reserved compiler type fragments ---
+
+#[test]
+fn reserved_type_names_fail_closed_across_declaration_kinds() {
+    for (source, name) in [
+        (
+            "type i64 { value: i64; }\nfn main() -> i64 { return 0; }",
+            "i64",
+        ),
+        (
+            "type CancellationToken { value: i64; }\nfn main() -> i64 { return 0; }",
+            "CancellationToken",
+        ),
+        (
+            "type tuple<T> { value: T; }\nfn main() -> i64 { return 0; }",
+            "tuple",
+        ),
+        (
+            "type typeparam<T> { value: T; }\nfn main() -> i64 { return 0; }",
+            "typeparam",
+        ),
+        (
+            "record string { value: i64, }\nfn main() -> i64 { return 0; }",
+            "string",
+        ),
+        (
+            "actor bytes { receive fn ping() {} }\nfn main() -> i64 { return 0; }",
+            "bytes",
+        ),
+        ("type char = i64;", "char"),
+        ("trait f32 {}", "f32"),
+        (
+            r"
+            machine tuple {
+                events { Toggle; }
+                state Closed;
+                state Open;
+                on Toggle: Closed => Open { Open }
+                on Toggle: Open => Closed { Closed }
+            }
+            fn main() {}
+            ",
+            "tuple",
+        ),
+    ] {
+        let output = check_source(source);
+        assert_eq!(
+            output.errors.len(),
+            1,
+            "expected exactly one error for `{name}`; got: {:?}",
+            output.errors
+        );
+        assert_eq!(
+            output.errors[0].kind,
+            TypeErrorKind::ReservedTypeName,
+            "expected ReservedTypeName for `{name}`"
+        );
+        assert_eq!(
+            output.errors[0].message,
+            format!(
+                "E_RESERVED_TYPE_NAME: `{name}` is reserved and cannot be used for a type declaration"
+            )
+        );
+    }
+}
+
+#[test]
+fn non_reserved_type_names_remain_accepted() {
+    let output = check_source(
+        "type Point { x: i64; y: i64; }\n\
+         type Tuple { a: i64; }\n\
+         type MyString { s: i64; }\n\
+         type CancellationTokens { count: i64; }\n\
+         enum Colour { Red; Green; Blue; }\n\
+         fn main() -> i64 { return 0; }",
+    );
+    assert!(
+        output.errors.is_empty(),
+        "non-reserved type names should be accepted; got: {:?}",
+        output.errors
+    );
+}

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -223,6 +223,19 @@ impl TypeError {
         .with_note(prev_span, "previous definition here".to_string())
     }
 
+    /// Create an `E_RESERVED_TYPE_NAME` error for a declaration that collides
+    /// with a compiler-emitted type fragment.
+    #[must_use]
+    pub fn reserved_type_name(span: Span, name: &str) -> Self {
+        Self::new(
+            TypeErrorKind::ReservedTypeName,
+            span,
+            format!(
+                "E_RESERVED_TYPE_NAME: `{name}` is reserved and cannot be used for a type declaration"
+            ),
+        )
+    }
+
     /// Create a mutability error.
     #[must_use]
     pub fn mutability_error(span: Span, name: &str) -> Self {
@@ -551,6 +564,8 @@ pub enum TypeErrorKind {
     NonExhaustiveMatch,
     /// Name defined multiple times
     DuplicateDefinition,
+    /// A declaration reuses a compiler-emitted primitive or structural type name.
+    ReservedTypeName,
     /// Assigning to immutable variable
     MutabilityError,
     /// Return statement type doesn't match function signature
@@ -1180,6 +1195,7 @@ impl TypeErrorKind {
             Self::InferenceFailed => "InferenceFailed",
             Self::NonExhaustiveMatch => "NonExhaustiveMatch",
             Self::DuplicateDefinition => "DuplicateDefinition",
+            Self::ReservedTypeName => "ReservedTypeName",
             Self::MutabilityError => "MutabilityError",
             Self::ReturnTypeMismatch => "ReturnTypeMismatch",
             Self::UseAfterMove => "UseAfterMove",

--- a/hew-types/src/ty.rs
+++ b/hew-types/src/ty.rs
@@ -392,6 +392,50 @@ pub const PRIMITIVE_ALIASES: &[(&str, &[&str])] = &[
     ("!", &["!"]),
 ];
 
+/// Structural type-encoder heads emitted for non-primitive `ResolvedTy`
+/// shapes (`tuple$x...$g`, `array$x...$g`, `fn$x...$r...$g`, etc.).
+///
+/// Kept in lockstep with `hew-hir/src/monomorph.rs::mangle_resolved_ty` and
+/// `hew-types/src/resolved_ty.rs::mangle_resolved_ty_segment`.
+pub const STRUCTURAL_ENCODER_HEADS: &[&str] = &[
+    "tuple",
+    "array",
+    "slice",
+    "fn",
+    "closure",
+    "ptr",
+    "ptrmut",
+    "borrow",
+    "dyn",
+    "task",
+    "unit",
+    "never",
+    "typeparam",
+];
+
+/// Return `true` if `name` is reserved for a compiler-emitted type fragment.
+///
+/// These spellings appear unescaped in the type manglers, so declarations
+/// using them would collide with the compiler's own type vocabulary. The
+/// primitive table is the canonical source for primitive names;
+/// `CancellationToken` is a separately encoded compiler leaf.
+///
+/// `()` and `!` are excluded because neither is a valid declaration identifier.
+#[must_use]
+pub fn is_reserved_type_name(name: &str) -> bool {
+    if name == BuiltinType::CancellationToken.canonical_name()
+        || STRUCTURAL_ENCODER_HEADS.contains(&name)
+    {
+        return true;
+    }
+    for (_canonical, aliases) in PRIMITIVE_ALIASES {
+        if aliases.contains(&name) && name != "()" && name != "!" {
+            return true;
+        }
+    }
+    false
+}
+
 /// Return the alias slice for the given canonical primitive name.
 ///
 /// Intended for use in `const` initializers in downstream crates that need
@@ -1756,6 +1800,48 @@ impl fmt::Display for UserFacingTy<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reserved_type_names_cover_every_bare_compiler_type_fragment() {
+        for (_canonical, aliases) in PRIMITIVE_ALIASES {
+            for &name in *aliases {
+                if matches!(name, "()" | "!") {
+                    continue;
+                }
+                assert!(
+                    is_reserved_type_name(name),
+                    "`{name}` should be a reserved primitive type name"
+                );
+            }
+        }
+        assert!(is_reserved_type_name(
+            BuiltinType::CancellationToken.canonical_name()
+        ));
+        for &name in STRUCTURAL_ENCODER_HEADS {
+            assert!(
+                is_reserved_type_name(name),
+                "`{name}` should be a reserved structural type head"
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_type_names_require_an_exact_match() {
+        for name in [
+            "Point",
+            "Tuple",
+            "MyString",
+            "I64",
+            "String",
+            "Array",
+            "CancellationTokens",
+        ] {
+            assert!(
+                !is_reserved_type_name(name),
+                "`{name}` should not be a reserved type name"
+            );
+        }
+    }
 
     #[test]
     fn test_type_var_fresh() {


### PR DESCRIPTION
hew check accepted declarations that shadowed reserved/primitive/builtin type names -- type i64 { ... } and type CancellationToken { ... } both checked successfully. A type/record/actor/alias/trait/machine declaration using a reserved name is now rejected with E_RESERVED_TYPE_NAME.

The primitive set derives from the canonical alias table rather than a hand-duplicated list, and the non-primitive structural heads (fn, closure, pointer, tuple, array, slice, dyn, task, ...) are guarded by an exhaustive match over every resolved-type variant with no wildcard arm, so a newly added type variant fails to compile until it is explicitly classified as reserved or user-namable -- a doc comment can't silently drift out of sync with the mangler.

Builds on the defect report and initial fix in #2563 by @gertybotbot -- thank you for catching this. That fix covered primitive names but missed the separately-emitted CancellationToken leaf, lacked a diagnostic code, and had test gaps that let a rejected declaration cascade into unrelated secondary errors. This closes those gaps and adds a compile-time guard against future drift.