### PR TITLE
fix(std): canonicalize regex no-match string

### DIFF
--- a/hew-std/src/regex.rs
+++ b/hew-std/src/regex.rs
@@ -68,8 +68,8 @@ pub unsafe extern "C" fn hew_regex_is_match(re: *const HewRegex, text: *const c_
 /// Find the first match of the compiled regex in `text`.
 ///
 /// Returns a `malloc`-allocated, NUL-terminated C string containing the
-/// matched substring, or null if no match is found. The caller must free
-/// the returned string with `libc::free`.
+/// matched substring, or a non-null empty string if no match is found. The
+/// caller must free the returned string with `libc::free`.
 ///
 /// # Safety
 ///
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn hew_regex_find(re: *const HewRegex, text: *const c_char
     };
     match regex.inner.find(text_str) {
         Some(m) => str_to_malloc(m.as_str()),
-        None => std::ptr::null_mut(),
+        None => str_to_malloc(""),
     }
 }
 
@@ -606,11 +606,16 @@ mod tests {
         // SAFETY: matched was allocated with libc::malloc.
         unsafe { hew_cabi::cabi::free_cstring(matched) }; // CSTRING-FREE: str-open (test str_to_malloc match)
 
-        // Test no match
+        // Test no match.
         let text_no = CString::new("123456").unwrap();
         // SAFETY: re and text pointers are valid.
         let no_match = unsafe { hew_regex_find(re, text_no.as_ptr()) };
-        assert!(no_match.is_null());
+        assert!(!no_match.is_null());
+        // SAFETY: no_match was allocated by hew_regex_find.
+        let no_match_str = unsafe { CStr::from_ptr(no_match) }.to_str().unwrap();
+        assert_eq!(no_match_str, "");
+        // SAFETY: no_match was allocated with libc::malloc.
+        unsafe { hew_cabi::cabi::free_cstring(no_match) }; // CSTRING-FREE: str-open (test str_to_malloc match)
 
         // SAFETY: re was returned by hew_regex_new.
         unsafe { hew_regex_free(re) };
@@ -784,6 +789,9 @@ mod tests {
         // SAFETY: Testing null pointer handling.
         assert!(unsafe { hew_regex_new(std::ptr::null()) }.is_null());
         assert!(!hew_regex_is_valid(std::ptr::null()));
+        let text = CString::new("text").unwrap();
+        // SAFETY: Testing a null handle with a valid input string.
+        assert!(unsafe { hew_regex_find(std::ptr::null(), text.as_ptr()) }.is_null());
         assert!(
             // SAFETY: Testing null pointer handling.
             !unsafe { hew_regex_is_match(std::ptr::null(), std::ptr::null()) },

--- a/tests/vertical-slice/accept/regex_find_no_match_empty_string.expected
+++ b/tests/vertical-slice/accept/regex_find_no_match_empty_string.expected
@@ -1,0 +1,4 @@
+hit_eq=true
+miss_len=0
+miss_eq_empty=true
+miss_neq_hit=true

--- a/tests/vertical-slice/accept/regex_find_no_match_empty_string.hew
+++ b/tests/vertical-slice/accept/regex_find_no_match_empty_string.hew
@@ -1,0 +1,16 @@
+// Regression for the regex no-match-vs-empty-string equality boundary.
+import std::text::regex;
+
+fn main() {
+    let pat = regex.new("[0-9]+");
+
+    let hit = pat.find("abc123def");
+    println(f"hit_eq={hit == "123"}");
+
+    let miss = pat.find("abcdef");
+    println(f"miss_len={miss.len()}");
+    println(f"miss_eq_empty={miss == ""}");
+    println(f"miss_neq_hit={miss != "123"}");
+
+    pat.close();
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -1712,6 +1712,7 @@ run_accept_expect_status "deque_pop_front_empty_traps" 134
 run_accept_expect_status "deque_pop_back_empty_traps" 134
 
 run_accept_expect_stdout "regex_captures_find_all"
+run_accept_expect_stdout "regex_find_no_match_empty_string"
 run_check_run_expect_stdout "stdlib_io_scanner_file_oracle"
 run_accept_expect_stdout "tls_ffi_result_lowering"
 


### PR DESCRIPTION
Pattern.find is documented -> string, returning an empty string on no match. The FFI returned a null pointer on no-match instead, and since Hew's string equality treats null and a real empty string as distinct, pattern.find(x) == "" incorrectly evaluated false even though .len() reported zero.

Only the no-match path changes to allocate a real empty string; the invalid-handle and invalid-UTF-8-input error paths continue to return null unchanged.

Builds on the defect report and initial fix in #2562 by @gertybotbot -- thank you for catching this. That fix normalized the no-match path correctly but also silently converted the FFI's error paths (invalid handle, invalid UTF-8) into the same empty-string sentinel, which masks real caller errors as valid results. This narrows the fix to the no-match path only, preserving null as the error signal.