### PR TITLE
fix(types): classify lambda parameter shadowing

### DIFF
--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -708,6 +708,8 @@ pub struct TimeoutClause {
 pub struct LambdaParam {
     pub name: String,
     pub ty: Option<Spanned<TypeExpr>>,
+    /// Span of the parameter name.
+    pub name_span: Span,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/hew-parser/src/parser/expressions.rs
+++ b/hew-parser/src/parser/expressions.rs
@@ -1469,6 +1469,7 @@ impl Parser<'_> {
         let mut params = Vec::new();
 
         while !self.at_end() && self.peek() != Some(&Token::Pipe) {
+            let name_span = self.peek_span();
             let name = self.expect_ident()?;
 
             let ty = if self.eat(&Token::Colon) {
@@ -1477,7 +1478,11 @@ impl Parser<'_> {
                 None
             };
 
-            params.push(LambdaParam { name, ty });
+            params.push(LambdaParam {
+                name,
+                ty,
+                name_span,
+            });
 
             if !self.eat(&Token::Comma) {
                 break;
@@ -1491,6 +1496,7 @@ impl Parser<'_> {
         let mut params = Vec::new();
 
         while !self.at_end() && self.peek() != Some(&Token::RightParen) {
+            let name_span = self.peek_span();
             let name = self.expect_ident()?;
 
             let ty = if self.eat(&Token::Colon) {
@@ -1499,7 +1505,11 @@ impl Parser<'_> {
                 None
             };
 
-            params.push(LambdaParam { name, ty });
+            params.push(LambdaParam {
+                name,
+                ty,
+                name_span,
+            });
 
             if !self.eat(&Token::Comma) {
                 break;

--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -5942,7 +5942,9 @@ impl Checker {
             } else {
                 Ty::Var(TypeVar::fresh())
             };
-            self.env.define(p.name.clone(), ty.clone(), false);
+            self.check_shadowing(&p.name, &p.name_span);
+            self.env
+                .define_param_with_span(p.name.clone(), ty.clone(), false, p.name_span.clone());
             param_tys.push(ty);
         }
 

--- a/hew-types/src/check/tests/infer.rs
+++ b/hew-types/src/check/tests/infer.rs
@@ -816,6 +816,7 @@ mod non_root_module_inference_scope {
             params: vec![LambdaParam {
                 name: "x".to_string(),
                 ty: Some((TypeExpr::Infer, 15..16)),
+                name_span: 14..15,
             }],
             return_type: None,
             body: Box::new((Expr::Identifier("x".to_string()), 19..20)),

--- a/hew-types/src/check/tests/lints.rs
+++ b/hew-types/src/check/tests/lints.rs
@@ -4,6 +4,8 @@
 )]
 pub(super) use super::*;
 
+use crate::error::Severity;
+
 #[test]
 fn warn_unused_variable() {
     let source = "fn main() { let unused_var = 42; }";
@@ -2341,6 +2343,92 @@ fn warn_nested_scope_shadowing_of_receive_fn_param() {
         warnings.iter().any(|w| w.kind == TypeErrorKind::Shadowing
             && w.message.contains("shadows a binding in an outer scope")),
         "expected outer-scope shadowing warning for parameter `name`, got warnings: {warnings:?}",
+    );
+}
+
+#[test]
+fn lambda_param_shadowing_in_nested_scope_is_a_warning() {
+    let source = r"
+        fn main() {
+            let captured = 1;
+            let f = |x: i64| -> i64 {
+                let x = 2;
+                return captured + x;
+            };
+            println(f(5));
+        }
+    ";
+    let lambda_param_start = source.find("|x: i64|").unwrap() + 1;
+    let local_start = source.find("let x = 2").unwrap() + 4;
+    let (errors, warnings) = parse_and_check(source);
+
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    assert_eq!(warnings.len(), 1, "unexpected warnings: {warnings:?}");
+    let shadowing = &warnings[0];
+    assert_eq!(shadowing.kind.as_kind_str(), "Shadowing");
+    assert_eq!(shadowing.severity, Severity::Warning);
+    assert_eq!(
+        shadowing.span.start, local_start,
+        "the diagnostic must point at the shadowing local"
+    );
+    assert_eq!(
+        shadowing.notes[0].0,
+        lambda_param_start..lambda_param_start + 1,
+        "the note must point at the lambda parameter"
+    );
+}
+
+#[test]
+fn nested_lambda_param_shadowing_is_a_warning() {
+    let source = r"
+        fn main() {
+            let f = |x: i64| -> i64 {
+                let g = |x: i64| -> i64 { return x; };
+                return g(x);
+            };
+            println(f(1));
+        }
+    ";
+    let (errors, warnings) = parse_and_check(source);
+
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    assert_eq!(warnings.len(), 1, "unexpected warnings: {warnings:?}");
+    assert_eq!(warnings[0].kind.as_kind_str(), "Shadowing");
+    assert_eq!(warnings[0].severity, Severity::Warning);
+}
+
+#[test]
+fn duplicate_lambda_param_is_a_shadowing_error() {
+    let source = r"
+        fn main() {
+            let f = |x: i64, x: i64| -> i64 { return x; };
+            println(f(1, 2));
+        }
+    ";
+    let (errors, warnings) = parse_and_check(source);
+
+    assert!(warnings.is_empty(), "unexpected warnings: {warnings:?}");
+    assert_eq!(errors.len(), 1, "unexpected errors: {errors:?}");
+    assert_eq!(errors[0].kind.as_kind_str(), "Shadowing");
+    assert_eq!(errors[0].severity, Severity::Error);
+}
+
+#[test]
+fn unused_lambda_param_is_not_warned() {
+    let source = r"
+        fn main() {
+            let f = |unused: i64| -> i64 { return 5; };
+            println(f(1));
+        }
+    ";
+    let (errors, warnings) = parse_and_check(source);
+
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    assert!(
+        warnings
+            .iter()
+            .all(|warning| warning.kind.as_kind_str() != "UnusedVariable"),
+        "unused lambda parameters must remain exempt: {warnings:?}",
     );
 }
 


### PR DESCRIPTION
Lambda parameters lacked a source span distinct from their enclosing scope, so a nested local shadowing a captured lambda parameter incorrectly hard-errored instead of emitting the normal shadow warning every other binding form gets. Lambda parameter names now carry a real parsed span threaded through the existing shadowing-check path.

Duplicate parameters in the same lambda are still correctly classified as a same-scope error, distinct from the nested-shadow warning case, and the unused-parameter lint exemption for lambda parameters is preserved.

Builds on the defect report and initial fix in #2564 by @gertybotbot -- thank you for catching this. That fix used a serde default fallback on the new span field, which would silently manufacture a fake location for old serialized AST data. This drops the fallback -- every lambda parameter carries a real parsed span, no exceptions.