### PR TITLE
fix(mir): reject unproven generator closure environments

### DIFF
--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -65,6 +65,9 @@ use crate::ownership::VecElementRelease;
 /// symbol both stable-per-callee and unique-per-distinct-callee.
 type TaskEntryAdapterSymbols = Rc<RefCell<HashMap<String, String>>>;
 
+#[derive(Debug, Clone, Copy)]
+struct GeneratorShellCallGate;
+
 const HEW_CTX_OFFSET_ACTOR_ID: usize = 8;
 const HEW_CTX_OFFSET_PARENT_SUPERVISOR: usize = 16;
 const HEW_CTX_OFFSET_TRACE: usize = 56;
@@ -8256,6 +8259,7 @@ fn lower_function(
         pointer_width,
         current_function_symbol: emit_name.clone(),
         current_function_call_conv: call_conv,
+        generator_shell_call_gate: func.is_generator.then_some(GeneratorShellCallGate),
         task_entry_adapter_symbols,
         ..Builder::default()
     };
@@ -9938,6 +9942,14 @@ struct Builder {
     current_task_scope: Option<Place>,
     current_function_symbol: String,
     current_function_call_conv: crate::model::FunctionCallConv,
+    /// True only on a source generator shell builder. Its fn-typed formal
+    /// parameters are admitted into the shell's generator env because every
+    /// standalone `gen fn` call crosses `lower_direct_call`'s provenance gate
+    /// and every `receive gen fn` call crosses `lower_actor_gen_stream`'s
+    /// equivalent gate. Anonymous `gen {}` blocks in ordinary functions have
+    /// no such call boundary and reject unproven fn-valued captures at env
+    /// materialisation.
+    generator_shell_call_gate: Option<GeneratorShellCallGate>,
     task_entry_adapter_symbols: TaskEntryAdapterSymbols,
     next_closure_id: u32,
     generated_functions: Vec<LoweredFunction>,
@@ -10042,22 +10054,25 @@ struct Builder {
     /// for an `Item`-resolved fn reference RHS and propagated through
     /// rebinds of an already-exempt binding.
     closure_pair_null_env: HashSet<BindingId>,
-    /// Fn-typed (`ty_is_closure_pair`) bindings whose introducing `let` or ANY
-    /// reassignment RHS produces a capturing-closure literal in a
-    /// produced-value position (directly, through block/if/match tails, or
-    /// copied from another binding already in this set). Such a binding's pair
-    /// may carry a NON-NULL heap env word even when its static type is a plain
-    /// `fn(..)` — the closure structurally unified with `fn(..)` and the env
-    /// word rode along ("laundering"). Collected flow-INSENSITIVELY by the
-    /// `collect_vec_owned_element_keys_from_block` pre-pass so a reassignment
-    /// on a loop back-edge taints the binding before any call site lowers.
+    /// Fn-typed (`ty_is_closure_pair`) bindings whose pair may carry a NON-NULL
+    /// heap closure-env word even when its static type is a plain `fn(..)`.
+    /// Sources are:
+    ///   * fn-typed parameters (the caller may pass a capturing closure);
+    ///   * fn-typed call results (the callee may return one);
+    ///   * capturing-closure literals structurally unified with `fn(..)`;
+    ///   * copies/merges/reassignments of any binding already in this set.
     ///
-    /// Consulted ONLY by `generator_arg_laundered_closure` (the
-    /// generator-constructor argument gate). Deliberately NOT a drop ledger
-    /// and NOT consulted by the closure-pair ingress/drop machinery: taint
-    /// answers "may this `fn(..)`-typed value hide a heap env?", never "who
-    /// frees the env box".
-    closure_pair_laundered_bindings: HashSet<BindingId>,
+    /// Let/reassignment provenance is collected flow-INSENSITIVELY by the
+    /// `collect_vec_owned_element_keys_from_block` pre-pass so a loop back-edge
+    /// assignment taints the binding before any call site lowers. Parameters
+    /// are seeded by `lower_params` before that pre-pass runs.
+    ///
+    /// Consulted by generator call-argument gates, anonymous-generator env
+    /// materialisation, and child-builder provenance inheritance. Deliberately
+    /// NOT a drop ledger and NOT consulted by closure-pair ingress/drop
+    /// machinery: taint answers "may this `fn(..)` value hide a heap env?",
+    /// never "who frees the env box".
+    closure_pair_env_may_be_nonnull: HashSet<BindingId>,
     /// Closure-pair bindings whose ownership has already left them via a
     /// rebind (`ClosurePairRhs::TransferFrom`). The dataflow checker flags
     /// any later use of these on its own: the rebind's RHS read carries
@@ -11079,12 +11094,9 @@ impl Builder {
     ///      produced by the compiler has a null env word; and (d) a capturing
     ///      closure that structurally unifies with `fn(..)` (via `unify.rs`)
     ///      is REFUSED at the generator-constructor call boundary
-    ///      (`generator_arg_laundered_closure` in `lower_direct_call`), so a
-    ///      `fn(..)`-typed value reaching this admission is null-env wherever
-    ///      that gate can prove provenance. The gate's documented residual
-    ///      (fn-typed parameters / call results forwarded interprocedurally)
-    ///      can still smuggle a heap env word; that residual leaks the env
-    ///      box — it never double-frees, per (a)-(b).
+    ///      (`generator_arg_laundered_closure` in `lower_direct_call`). That
+    ///      gate tracks local producer provenance and fails closed for fn-typed
+    ///      parameters and call results whose env word is not provably null.
     ///   3. `ResolvedTy::Closure { captures, .. }` where `captures.is_empty()` —
     ///      an empty-capture closure. No heap env box exists to alias. Closures
     ///      with non-empty captures carry a heap-boxed env; flat-copying them would
@@ -11111,9 +11123,8 @@ impl Builder {
         // pointers), PersistentShare no-drop on the body side, and the
         // generator-constructor argument gate (`generator_arg_laundered_closure`)
         // refusing a capturing closure laundered through `fn(..)` at the call
-        // boundary — so the value here is null-env wherever provenance is
-        // provable; the gate's interprocedural residual leaks at worst, never
-        // double-frees.
+        // boundary. Its provenance ledger rejects fn-typed parameters and call
+        // results whose env word is not provably null.
         if matches!(ty, ResolvedTy::Function { .. }) {
             return true;
         }
@@ -11930,15 +11941,13 @@ impl Builder {
             // Record the parameter name for `-g` `DW_TAG_formal_parameter`
             // DIEs (codegen's `create_parameter_variable`).
             self.record_local_name(slot, &param.name);
-            // A fn-typed parameter's closure env is provably heap (the checker
+            // A fn-typed parameter's closure env is provably heap-or-null (the checker
             // `Escapes`-classifies any closure crossing a call boundary as an
             // argument), so it may transfer env ownership into an owning
             // container on store — see `closure_pair_param_owned`. Check the
             // substituted type so a monomorphised type parameter that resolves
             // to a fn type is also admitted.
-            if ty_is_closure_pair(&self.subst_ty(&param.ty)) {
-                self.closure_pair_param_owned.insert(param.id);
-            }
+            self.seed_fn_param_provenance(param);
             // RAII-2 (#1295) callee-side drop: a CONSUME affine `#[resource]`
             // parameter is OWNED by the callee (the caller moved it in and does
             // not drop it), so register it for the scope-exit drop — closing the
@@ -11985,6 +11994,17 @@ impl Builder {
                 // close is idempotent/refcounted (`resource_needs_drop_flag`).
                 self.maybe_alloc_resource_drop_flag(param.id, &owned_ty);
             }
+        }
+    }
+
+    fn seed_fn_param_provenance(&mut self, param: &hew_hir::HirBinding) {
+        if ty_is_closure_pair(&self.subst_ty(&param.ty)) {
+            self.closure_pair_param_owned.insert(param.id);
+            // CAP-11 provenance: the parameter's env word is not provably
+            // null. If it is forwarded into a generator constructor, the
+            // flat-copied env cannot release it, so the call-site gate must
+            // reject that crossing.
+            self.closure_pair_env_may_be_nonnull.insert(param.id);
         }
     }
 
@@ -13446,112 +13466,167 @@ impl Builder {
     /// Recursively walk a block's statements + tail, harvesting owned-Vec
     /// element keys from every expression's type (the `Vec<T>` receiver of an
     /// owned-Vec op carries the type) and every let binding's declared type.
-    /// True when `expr`, read as a produced VALUE, is a capturing-closure
-    /// literal — directly, behind transparent block/scope tails, on either
-    /// branch of an `if`, in any `match` arm body, or copied from a binding
-    /// already tainted as laundered. Feeds `closure_pair_laundered_bindings`
-    /// during the pre-pass (statements are visited in source order, so a
-    /// binding-to-binding copy chain resolves top-down). A capture-FREE
-    /// closure literal answers `false`: its pair's env word is null by
-    /// construction, so nothing can leak or dangle through a flat copy.
-    ///
-    /// Deliberately conservative in the ADMIT direction for producer shapes
-    /// this walk cannot see through (fn-typed call results, fn-typed
-    /// parameters): those stay untainted here and are the documented residual
-    /// of the generator-argument gate (`generator_arg_laundered_closure`).
-    fn rhs_produces_capturing_closure(&self, expr: &HirExpr) -> bool {
+    /// True when `expr`, read as a produced fn VALUE, may carry a non-null heap
+    /// closure environment. A capture-free literal or named-function reference
+    /// answers `false`; parameters, fn-valued call results, capturing literals,
+    /// aggregate/container reads, and merges/copies of those answer `true`.
+    /// Feeds `closure_pair_env_may_be_nonnull` during the pre-pass.
+    fn closure_rhs_may_carry_env(&self, expr: &HirExpr) -> bool {
         match &expr.kind {
             HirExprKind::Closure { captures, .. } => !captures.is_empty(),
             HirExprKind::BindingRef {
                 resolved: ResolvedRef::Binding(id),
                 ..
-            } => self.closure_pair_laundered_bindings.contains(id),
+            } => {
+                ty_is_closure_pair(&self.subst_ty(&expr.ty))
+                    && self.closure_pair_env_may_be_nonnull.contains(id)
+            }
+            HirExprKind::BindingRef {
+                resolved: ResolvedRef::Item(_),
+                ..
+            } => false,
+            HirExprKind::Call { .. }
+            | HirExprKind::ResolvedImplCall { .. }
+            | HirExprKind::CallTraitMethodStatic { .. }
+            | HirExprKind::CallDynMethod { .. } => ty_is_closure_pair(&self.subst_ty(&expr.ty)),
             HirExprKind::Block(body) | HirExprKind::Scope { body } => body
                 .tail
                 .as_deref()
-                .is_some_and(|tail| self.rhs_produces_capturing_closure(tail)),
+                .is_some_and(|tail| self.closure_rhs_may_carry_env(tail)),
             HirExprKind::If {
                 then_expr,
                 else_expr,
                 ..
             } => {
-                self.rhs_produces_capturing_closure(then_expr)
+                self.closure_rhs_may_carry_env(then_expr)
                     || else_expr
                         .as_deref()
-                        .is_some_and(|eb| self.rhs_produces_capturing_closure(eb))
+                        .is_some_and(|eb| self.closure_rhs_may_carry_env(eb))
             }
             HirExprKind::Match { arms, .. } => arms
                 .iter()
-                .any(|arm| self.rhs_produces_capturing_closure(&arm.body)),
-            _ => false,
+                .any(|arm| self.closure_rhs_may_carry_env(&arm.body)),
+            // Any other fn-valued producer (record/tuple/Vec field read,
+            // projection, indirect value source) is unproven. Owning
+            // containers can legitimately hold a capturing closure, so
+            // admitting an unknown projection would reopen the same env-box
+            // leak behind a different laundering shape.
+            _ => matches!(self.subst_ty(&expr.ty), ResolvedTy::Function { .. }),
+        }
+    }
+
+    fn mark_pattern_bindings_unproven(&mut self, bindings: &[hew_hir::HirMatchArmBinding]) {
+        for binding in bindings {
+            if ty_is_closure_pair(&self.subst_ty(&binding.ty)) {
+                self.closure_pair_env_may_be_nonnull.insert(binding.binding);
+            }
+        }
+    }
+
+    fn mark_nested_pattern_bindings_unproven(
+        &mut self,
+        predicates: &[hew_hir::HirPayloadVariantPredicate],
+    ) {
+        for predicate in predicates {
+            self.mark_pattern_bindings_unproven(&predicate.bindings);
+            self.mark_nested_pattern_bindings_unproven(&predicate.nested);
+        }
+    }
+
+    fn mark_match_predicate_binding_unproven(&mut self, predicate: &hew_hir::HirMatchArmPredicate) {
+        if let hew_hir::HirMatchArmPredicate::Binding { binding_id, ty, .. } = predicate {
+            if ty_is_closure_pair(&self.subst_ty(ty)) {
+                self.closure_pair_env_may_be_nonnull.insert(*binding_id);
+            }
+        }
+    }
+
+    fn collect_vec_owned_element_keys_from_stmt(&mut self, stmt: &hew_hir::HirStmt) {
+        match &stmt.kind {
+            HirStmtKind::Let(binding, value) => {
+                let binding_ty = self.subst_ty(&binding.ty);
+                self.harvest_vec_owned_element_key(&binding_ty);
+                if let Some(v) = value {
+                    // Closure-env provenance: a fn/closure-typed binding
+                    // whose RHS may carry a heap env word must remain
+                    // fail-closed at any later generator crossing.
+                    if ty_is_closure_pair(&binding_ty) && self.closure_rhs_may_carry_env(v) {
+                        self.closure_pair_env_may_be_nonnull.insert(binding.id);
+                    }
+                    // #2418 — a DIRECT consume-rebind initializer
+                    // (`let y = xs;`) is the one consume shape the
+                    // collection drop-flag covers; record the consume
+                    // WITHOUT the non-rebind mark the general walk would
+                    // apply, replicating the walk's other effects on a
+                    // childless `BindingRef` (the type-key harvest).
+                    if let HirExprKind::BindingRef {
+                        resolved: ResolvedRef::Binding(id),
+                        ..
+                    } = &v.kind
+                    {
+                        if v.intent == IntentKind::Consume {
+                            self.prepass_consumed_bindings.insert(*id);
+                            let vty = self.subst_ty(&v.ty);
+                            self.harvest_vec_owned_element_key(&vty);
+                            return;
+                        }
+                    }
+                    self.collect_vec_owned_element_keys_from_expr(v);
+                }
+            }
+            HirStmtKind::LetElse {
+                scrutinee,
+                bindings,
+                success_prelude,
+                payload_variant_predicates,
+                else_body,
+                ..
+            } => {
+                self.collect_vec_owned_element_keys_from_expr(scrutinee);
+                self.mark_pattern_bindings_unproven(bindings);
+                self.mark_nested_pattern_bindings_unproven(payload_variant_predicates);
+                for prelude_stmt in success_prelude {
+                    self.collect_vec_owned_element_keys_from_stmt(prelude_stmt);
+                }
+                self.collect_vec_owned_element_keys_from_block(else_body);
+            }
+            HirStmtKind::Assign { target, value } => {
+                // #2301 -- record a reassigned `var` target so a consumed
+                // binding that is also overwritten gets an overwrite-release
+                // drop-flag (the intersection keeps the common no-consume
+                // overwrite on the zero-churn static gate).
+                if let HirExprKind::BindingRef {
+                    resolved: ResolvedRef::Binding(id),
+                    ..
+                } = &target.kind
+                {
+                    self.prepass_reassigned_bindings.insert(*id);
+                    // Closure-env provenance for reassignments (`var g =
+                    // triple; g = producer();`). The pre-pass runs before
+                    // any call site lowers, so a back-edge reassignment
+                    // taints the binding for the whole function.
+                    if ty_is_closure_pair(&self.subst_ty(&target.ty))
+                        && self.closure_rhs_may_carry_env(value)
+                    {
+                        self.closure_pair_env_may_be_nonnull.insert(*id);
+                    }
+                }
+                self.collect_vec_owned_element_keys_from_expr(target);
+                self.collect_vec_owned_element_keys_from_expr(value);
+            }
+            HirStmtKind::Expr(e) | HirStmtKind::Return(Some(e)) => {
+                self.collect_vec_owned_element_keys_from_expr(e);
+            }
+            HirStmtKind::Defer { body, .. } => {
+                self.collect_vec_owned_element_keys_from_expr(body);
+            }
+            HirStmtKind::Return(None) => {}
         }
     }
 
     fn collect_vec_owned_element_keys_from_block(&mut self, block: &HirBlock) {
         for stmt in &block.statements {
-            match &stmt.kind {
-                HirStmtKind::Let(binding, value) => {
-                    let binding_ty = self.subst_ty(&binding.ty);
-                    self.harvest_vec_owned_element_key(&binding_ty);
-                    if let Some(v) = value {
-                        // Launder taint: a fn/closure-typed binding whose RHS
-                        // produces a capturing-closure literal may hide a heap
-                        // env word behind a `fn(..)` static type — see
-                        // `closure_pair_laundered_bindings`.
-                        if ty_is_closure_pair(&binding_ty) && self.rhs_produces_capturing_closure(v)
-                        {
-                            self.closure_pair_laundered_bindings.insert(binding.id);
-                        }
-                        // #2418 — a DIRECT consume-rebind initializer
-                        // (`let y = xs;`) is the one consume shape the
-                        // collection drop-flag covers; record the consume
-                        // WITHOUT the non-rebind mark the general walk would
-                        // apply, replicating the walk's other effects on a
-                        // childless `BindingRef` (the type-key harvest).
-                        if let HirExprKind::BindingRef {
-                            resolved: ResolvedRef::Binding(id),
-                            ..
-                        } = &v.kind
-                        {
-                            if v.intent == IntentKind::Consume {
-                                self.prepass_consumed_bindings.insert(*id);
-                                let vty = self.subst_ty(&v.ty);
-                                self.harvest_vec_owned_element_key(&vty);
-                                continue;
-                            }
-                        }
-                        self.collect_vec_owned_element_keys_from_expr(v);
-                    }
-                }
-                HirStmtKind::Assign { target, value } => {
-                    // #2301 -- record a reassigned `var` target so a consumed
-                    // binding that is also overwritten gets an overwrite-release
-                    // drop-flag (the intersection keeps the common no-consume
-                    // overwrite on the zero-churn static gate).
-                    if let HirExprKind::BindingRef {
-                        resolved: ResolvedRef::Binding(id),
-                        ..
-                    } = &target.kind
-                    {
-                        self.prepass_reassigned_bindings.insert(*id);
-                        // Launder taint for reassignments (`var g = triple;
-                        // g = |x| x * k;`). The pre-pass runs before any call
-                        // site lowers, so a back-edge reassignment taints the
-                        // binding for the whole function.
-                        if ty_is_closure_pair(&self.subst_ty(&target.ty))
-                            && self.rhs_produces_capturing_closure(value)
-                        {
-                            self.closure_pair_laundered_bindings.insert(*id);
-                        }
-                    }
-                    self.collect_vec_owned_element_keys_from_expr(target);
-                    self.collect_vec_owned_element_keys_from_expr(value);
-                }
-                HirStmtKind::Expr(e) | HirStmtKind::Return(Some(e)) => {
-                    self.collect_vec_owned_element_keys_from_expr(e);
-                }
-                _ => {}
-            }
+            self.collect_vec_owned_element_keys_from_stmt(stmt);
         }
         if let Some(tail) = &block.tail {
             self.collect_vec_owned_element_keys_from_expr(tail);
@@ -13588,12 +13663,18 @@ impl Builder {
     /// `BindingRef`/`Call`/`StructInit` receiver is caught); the recursion
     /// reaches nested blocks (if/match/scope/loop bodies) where an owned-Vec
     /// could be constructed or used.
+    #[allow(
+        clippy::too_many_lines,
+        reason = "one structural HIR walk must keep every same-builder child expression \
+                  visible to both ownership-key harvesting and closure-env provenance"
+    )]
     fn collect_vec_owned_element_keys_from_expr(&mut self, expr: &HirExpr) {
         self.prepass_note_nonrebind_consume(expr);
         let ty = self.subst_ty(&expr.ty);
         self.harvest_vec_owned_element_key(&ty);
         match &expr.kind {
-            HirExprKind::Binary { left, right, .. } => {
+            HirExprKind::Binary { left, right, .. }
+            | HirExprKind::IdentityCompare { left, right } => {
                 self.collect_vec_owned_element_keys_from_expr(left);
                 self.collect_vec_owned_element_keys_from_expr(right);
             }
@@ -13602,7 +13683,26 @@ impl Builder {
             }
             HirExprKind::NumericCast { value, .. }
             | HirExprKind::SaturatingWidthCast { value, .. }
-            | HirExprKind::TryWidthCast { value, .. } => {
+            | HirExprKind::TryWidthCast { value, .. }
+            | HirExprKind::CoerceToDynTrait { value, .. }
+            | HirExprKind::WireCodec { operand: value, .. }
+            | HirExprKind::RecordCloneCall { src: value, .. }
+            | HirExprKind::CancellationTokenIsCancelled { receiver: value }
+            | HirExprKind::GeneratorNext {
+                receiver: value, ..
+            }
+            | HirExprKind::MachineStateName {
+                receiver: value, ..
+            }
+            | HirExprKind::AwaitRestart { child: value }
+            | HirExprKind::ConnAwaitRead { conn: value, .. }
+            | HirExprKind::ListenerAwaitAccept {
+                listener: value, ..
+            }
+            | HirExprKind::ChannelRecvAwait {
+                receiver: value, ..
+            }
+            | HirExprKind::StreamRecvAwait { stream: value, .. } => {
                 self.collect_vec_owned_element_keys_from_expr(value);
             }
             HirExprKind::TupleLiteral { elements } => {
@@ -13616,12 +13716,37 @@ impl Builder {
                     self.collect_vec_owned_element_keys_from_expr(a);
                 }
             }
-            HirExprKind::ResolvedImplCall { receiver, args, .. }
-            | HirExprKind::VarSelfMethodCall { receiver, args, .. } => {
+            HirExprKind::Spawn { args, .. } => {
+                for (_, arg) in args {
+                    self.collect_vec_owned_element_keys_from_expr(arg);
+                }
+            }
+            HirExprKind::ActorSend { receiver, args, .. }
+            | HirExprKind::ActorAsk { receiver, args, .. }
+            | HirExprKind::ActorGenStream { receiver, args, .. }
+            | HirExprKind::SpawnedCall {
+                callee: receiver,
+                args,
+                ..
+            }
+            | HirExprKind::ResolvedImplCall { receiver, args, .. }
+            | HirExprKind::VarSelfMethodCall { receiver, args, .. }
+            | HirExprKind::CallDynMethod { receiver, args, .. }
+            | HirExprKind::CallTraitMethodStatic { receiver, args, .. } => {
                 self.collect_vec_owned_element_keys_from_expr(receiver);
                 for a in args {
                     self.collect_vec_owned_element_keys_from_expr(a);
                 }
+            }
+            HirExprKind::RemoteActorAsk {
+                receiver,
+                msg,
+                timeout_ms,
+                ..
+            } => {
+                self.collect_vec_owned_element_keys_from_expr(receiver);
+                self.collect_vec_owned_element_keys_from_expr(msg);
+                self.collect_vec_owned_element_keys_from_expr(timeout_ms);
             }
             HirExprKind::StructInit { fields, base, .. } => {
                 for (_, f) in fields {
@@ -13655,10 +13780,87 @@ impl Builder {
             | HirExprKind::Loop { body, .. } => {
                 self.collect_vec_owned_element_keys_from_block(body);
             }
+            HirExprKind::ScopeDeadline { duration, body } => {
+                self.collect_vec_owned_element_keys_from_expr(duration);
+                self.collect_vec_owned_element_keys_from_block(body);
+            }
             HirExprKind::Match { scrutinee, arms } => {
                 self.collect_vec_owned_element_keys_from_expr(scrutinee);
                 for arm in arms {
+                    self.mark_match_predicate_binding_unproven(&arm.predicate);
+                    self.mark_pattern_bindings_unproven(&arm.bindings);
+                    self.mark_nested_pattern_bindings_unproven(&arm.payload_variant_predicates);
+                    if let Some(guard) = &arm.guard {
+                        self.collect_vec_owned_element_keys_from_expr(guard);
+                    }
                     self.collect_vec_owned_element_keys_from_expr(&arm.body);
+                }
+            }
+            HirExprKind::WhileLet {
+                scrutinee,
+                bindings,
+                payload_variant_predicates,
+                body,
+                ..
+            } => {
+                self.collect_vec_owned_element_keys_from_expr(scrutinee);
+                self.mark_pattern_bindings_unproven(bindings);
+                self.mark_nested_pattern_bindings_unproven(payload_variant_predicates);
+                self.collect_vec_owned_element_keys_from_block(body);
+            }
+            HirExprKind::IfLet {
+                scrutinee,
+                bindings,
+                payload_variant_predicates,
+                body,
+                else_body,
+                ..
+            } => {
+                self.collect_vec_owned_element_keys_from_expr(scrutinee);
+                self.mark_pattern_bindings_unproven(bindings);
+                self.mark_nested_pattern_bindings_unproven(payload_variant_predicates);
+                self.collect_vec_owned_element_keys_from_block(body);
+                if let Some(else_body) = else_body {
+                    self.collect_vec_owned_element_keys_from_block(else_body);
+                }
+            }
+            HirExprKind::Select(select) => {
+                for arm in &select.arms {
+                    if let Some(binding) = arm.binding_id {
+                        // The select result type is encoded by the arm source,
+                        // not repeated on the binding. Mark it unproven; later
+                        // consumers consult this set only for fn-typed values.
+                        self.closure_pair_env_may_be_nonnull.insert(binding);
+                    }
+                    match &arm.kind {
+                        hew_hir::HirSelectArmKind::StreamNext { stream } => {
+                            self.collect_vec_owned_element_keys_from_expr(stream);
+                        }
+                        hew_hir::HirSelectArmKind::ActorAsk { actor, args, .. } => {
+                            self.collect_vec_owned_element_keys_from_expr(actor);
+                            for arg in args {
+                                self.collect_vec_owned_element_keys_from_expr(arg);
+                            }
+                        }
+                        hew_hir::HirSelectArmKind::TaskAwait { task } => {
+                            self.collect_vec_owned_element_keys_from_expr(task);
+                        }
+                        hew_hir::HirSelectArmKind::ChannelRecv { receiver } => {
+                            self.collect_vec_owned_element_keys_from_expr(receiver);
+                        }
+                        hew_hir::HirSelectArmKind::AfterTimer { duration } => {
+                            self.collect_vec_owned_element_keys_from_expr(duration);
+                        }
+                    }
+                    self.collect_vec_owned_element_keys_from_expr(&arm.body);
+                }
+            }
+            HirExprKind::Join(join) => {
+                for branch in &join.branches {
+                    self.collect_vec_owned_element_keys_from_expr(&branch.actor);
+                    for arg in &branch.args {
+                        self.collect_vec_owned_element_keys_from_expr(arg);
+                    }
                 }
             }
             HirExprKind::While {
@@ -13679,13 +13881,82 @@ impl Builder {
                 self.collect_vec_owned_element_keys_from_expr(step);
                 self.collect_vec_owned_element_keys_from_block(body);
             }
+            HirExprKind::Yield { value, .. }
+            | HirExprKind::Break { value, .. }
+            | HirExprKind::Return { value } => {
+                if let Some(value) = value {
+                    self.collect_vec_owned_element_keys_from_expr(value);
+                }
+            }
+            HirExprKind::Slice {
+                container,
+                start,
+                end,
+                ..
+            } => {
+                self.collect_vec_owned_element_keys_from_expr(container);
+                if let Some(start) = start {
+                    self.collect_vec_owned_element_keys_from_expr(start);
+                }
+                if let Some(end) = end {
+                    self.collect_vec_owned_element_keys_from_expr(end);
+                }
+            }
+            HirExprKind::NumericMethod { receiver, arg, .. }
+            | HirExprKind::MachineStep {
+                receiver,
+                event: arg,
+                ..
+            }
+            | HirExprKind::MachineTakeEmits {
+                receiver,
+                event: arg,
+                ..
+            } => {
+                self.collect_vec_owned_element_keys_from_expr(receiver);
+                self.collect_vec_owned_element_keys_from_expr(arg);
+            }
+            HirExprKind::MachineEmit { fields, .. }
+            | HirExprKind::MachineVariantCtor {
+                payload: Some(fields),
+                ..
+            } => {
+                for (_, value) in fields {
+                    self.collect_vec_owned_element_keys_from_expr(value);
+                }
+            }
             // Remaining variants either carry no owned-Vec sub-expression in
             // this slice's surface or are leaves; their own `.ty` was already
             // harvested above. Fail-open here is sound: a missed harvest only
             // leaves a value at the W3.029 fail-closed reject (never an
             // over-admit), so the worst case is a still-rejected program, not
-            // an unsound lowering.
+            // an unsound lowering. Closure, lambda-actor, and generator bodies
+            // lower through fresh child builders with dedicated fixed-point
+            // pre-passes.
             _ => {}
+        }
+    }
+
+    /// Run the shared function/body pre-pass until closure-env provenance
+    /// reaches a fixed point. The walk's other outputs are set-valued and
+    /// idempotent, so repeating it is semantically harmless.
+    fn collect_prepass_facts(&mut self, block: &HirBlock) {
+        loop {
+            let provenance_count = self.closure_pair_env_may_be_nonnull.len();
+            self.collect_vec_owned_element_keys_from_block(block);
+            if self.closure_pair_env_may_be_nonnull.len() == provenance_count {
+                break;
+            }
+        }
+    }
+
+    fn collect_expr_prepass_facts(&mut self, expr: &HirExpr) {
+        loop {
+            let provenance_count = self.closure_pair_env_may_be_nonnull.len();
+            self.collect_vec_owned_element_keys_from_expr(expr);
+            if self.closure_pair_env_may_be_nonnull.len() == provenance_count {
+                break;
+            }
         }
     }
 
@@ -13697,7 +13968,12 @@ impl Builder {
         // order-independent. Only owned-Vec element types (which carry
         // synthesizable clone/drop thunks) enter the set, so the W3.029 reject
         // stays fail-closed for every non-owned-Vec record.
-        self.collect_vec_owned_element_keys_from_block(&func.body);
+        // Closure-env provenance is a transitive, flow-insensitive may-fact.
+        // Repeat the shared pre-pass to a fixed point so reverse-order
+        // assignments and nested-block producer chains cannot evade the
+        // generator gate. Every other fact this walk records is set-valued and
+        // idempotent, so repeating it adds no duplicate semantic effects.
+        self.collect_prepass_facts(&func.body);
 
         self.active_scopes.push(func.body.scope);
         for stmt in &func.body.statements {
@@ -15611,6 +15887,10 @@ impl Builder {
                     callee.ty,
                     ResolvedTy::Function { .. } | ResolvedTy::Closure { .. }
                 ) {
+                    let ret_ty = self.subst_ty(&expr.ty);
+                    if ty_is_generator_handle(&ret_ty) {
+                        self.reject_unproven_generator_fn_args(args);
+                    }
                     // Suspendable-callee discriminator: a call to a binding that
                     // holds a closure whose body `await`s across the coroutine
                     // boundary drives the callee coroutine and PROPAGATES its
@@ -15635,7 +15915,6 @@ impl Builder {
                     for arg in args {
                         arg_places.push(self.lower_value(arg)?);
                     }
-                    let ret_ty = self.subst_ty(&expr.ty);
                     let dest = if matches!(ret_ty, ResolvedTy::Unit) {
                         None
                     } else {
@@ -26439,6 +26718,11 @@ impl Builder {
             });
             return None;
         };
+        // Deadline bodies lower later on this same Builder, after the outer
+        // function pre-pass has already completed. Refresh the fixed-point
+        // facts here so body-local fn producers cannot bypass the generator
+        // provenance gate.
+        self.collect_prepass_facts(body);
         let has_body = !body.statements.is_empty() || body.tail.is_some();
 
         // Empty `after(d) {}` keeps the legacy per-deadline-thread cancel on BOTH
@@ -26924,43 +27208,15 @@ impl Builder {
             builtin,
             builtin.map_or("", |f| f.c_symbol()),
         );
-        // CAP-11 fail-closed gate: a generator-constructor call (`gen fn` —
-        // the only direct calls typed `Generator<..>`) flat-copies every
-        // argument its body captures into the generator env
+        // CAP-11 fail-closed gate: a call producing `Generator<..>` may
+        // ultimately flat-copy a fn-valued argument into the generator env
         // (`Terminator::MakeGenerator`'s heap-copy), and the body side never
-        // drops a fn-typed capture. A capturing closure laundered through a
-        // `fn(..)`-typed parameter therefore carries a heap env box NOTHING
-        // can ever release — refuse it here, at the launder crossing, where the
-        // argument's real shape is still visible (the callee's own frame
-        // sees only the null-env-presumptive `fn(..)` type). Named-fn
-        // references and capture-free closures stay admitted: their env
-        // word is null by construction.
+        // drops a fn-typed capture. Refuse a capturing closure or any fn value
+        // whose env provenance is unproven (parameter/call result) at the
+        // crossing. Named-fn references and capture-free closures stay
+        // admitted: their env word is null by construction.
         if ty_is_generator_handle(ret_ty) {
-            for arg in hir_args {
-                if let Some(what) = self.generator_arg_laundered_closure(arg) {
-                    // The diagnostic is fatal on its own; lowering CONTINUES so
-                    // the surrounding statement stream stays coherent (a bare
-                    // `return None` here cascades spurious follow-on errors
-                    // onto bindings the enclosing loop/let still references).
-                    // No binary is ever produced past a fatal diagnostic.
-                    self.diagnostics.push(MirDiagnostic {
-                        kind: MirDiagnosticKind::NotYetImplemented {
-                            construct: "a capturing closure as a generator's `fn(..)` \
-                                        argument"
-                                .to_string(),
-                            site: arg.site,
-                        },
-                        note: format!(
-                            "{what} would cross into the generator's flat-copied env: \
-                             the generator can never release a capturing closure's \
-                             environment box, so every generator constructed from it \
-                             would leak that box. Pass a named function or a \
-                             capture-free closure instead; owned captures need the \
-                             clone-into-env protocol (`genfn-owned-captures`)."
-                        ),
-                    });
-                }
-            }
+            self.reject_unproven_generator_fn_args(hir_args);
         }
         // Lower each argument left-to-right.  If any fails to produce a
         // Place, fail the whole call — argument diagnostics already capture
@@ -30277,6 +30533,11 @@ impl Builder {
             return None;
         }
 
+        // `receive gen fn` calls do not route through `lower_direct_call`, so
+        // enforce the same closure-env provenance boundary here before packing
+        // the start message.
+        self.reject_unproven_generator_fn_args(args);
+
         let actor = self.lower_value(receiver)?;
         let mut lowered: Vec<(Place, ResolvedTy)> = Vec::with_capacity(args.len() + 1);
         for arg in args {
@@ -32338,10 +32599,22 @@ impl Builder {
                     ty: self.subst_ty(&capture.ty),
                 },
             );
+            if self
+                .closure_pair_env_may_be_nonnull
+                .contains(&capture.binding)
+            {
+                builder
+                    .closure_pair_env_may_be_nonnull
+                    .insert(capture.binding);
+            }
+            if self.closure_pair_null_env.contains(&capture.binding) {
+                builder.closure_pair_null_env.insert(capture.binding);
+            }
         }
         for param in params {
             let place = builder.alloc_local(param.ty.clone());
             builder.binding_locals.insert(param.id, place);
+            builder.seed_fn_param_provenance(param);
         }
 
         // #2301 -- run the same owned-Vec-key / consumed-and-reassigned-binding
@@ -32355,7 +32628,7 @@ impl Builder {
         // sibling arm silently leaks its prior value (no guard flag, no
         // release before the overwrite) instead of getting the path-sensitive
         // release a byte-identical top-level function body would.
-        builder.collect_vec_owned_element_keys_from_expr(body);
+        builder.collect_expr_prepass_facts(body);
 
         if let Some(src) = builder.lower_value(body) {
             builder.instructions.push(Instr::Move {
@@ -32988,6 +33261,7 @@ impl Builder {
                 unreachable!("alloc_local returns Place::Local");
             };
             body_builder.binding_locals.insert(param.id, slot);
+            body_builder.seed_fn_param_provenance(param);
             user_param_local_ids.push(slot_id);
         }
 
@@ -33011,6 +33285,17 @@ impl Builder {
                         ty: env_capture_field_tys[idx].clone(),
                     },
                 );
+                if self
+                    .closure_pair_env_may_be_nonnull
+                    .contains(&capture.binding)
+                {
+                    body_builder
+                        .closure_pair_env_may_be_nonnull
+                        .insert(capture.binding);
+                }
+                if self.closure_pair_null_env.contains(&capture.binding) {
+                    body_builder.closure_pair_null_env.insert(capture.binding);
+                }
             }
             body_builder.weak_lambda_capture_bindings = weak_capture_bindings;
         }
@@ -33027,7 +33312,7 @@ impl Builder {
         // on one control-flow arm and overwritten on a sibling arm silently
         // leaks its prior value instead of getting the path-sensitive release
         // a byte-identical top-level function body would.
-        body_builder.collect_vec_owned_element_keys_from_expr(body);
+        body_builder.collect_expr_prepass_facts(body);
         let tail_place = body_builder.lower_value(body);
 
         // Shape-driven return slot wiring:
@@ -33549,15 +33834,30 @@ impl Builder {
                         }
                     }
                 };
+                let fn_env_provenance_unproven = matches!(capture_ty, Some(ResolvedTy::Function { .. }))
+                    && self
+                        .closure_pair_env_may_be_nonnull
+                        .contains(&capture.binding)
+                    // A source `gen fn` shell's own formal parameters are
+                    // checked at every generator-constructor call. No other
+                    // anonymous-gen capture has that external provenance gate.
+                    && !(self.generator_shell_call_gate.is_some()
+                        && self.closure_pair_param_owned.contains(&capture.binding));
                 match (slot, capture_ty) {
-                    (Some(src), Some(ty)) if self.gen_env_capture_admissible(&ty) => {
+                    (Some(src), Some(ty))
+                        if self.gen_env_capture_admissible(&ty) && !fn_env_provenance_unproven =>
+                    {
                         init_fields.push((offset, src));
                         field_tys.push(ty);
                     }
                     (Some(_), Some(ty)) => {
                         // Not admissible to the flat-`memcpy`'d generator env.
-                        // Three fail-closed shapes reach this arm; name the reason
+                        // Four fail-closed shapes reach this arm; name the reason
                         // precisely so the diagnostic is actionable:
+                        //   * `Function` with unproven env provenance — an
+                        //     anonymous gen block captured a parameter/call
+                        //     result/aggregate read without a direct gen-fn call
+                        //     boundary proving the pair's env word null; OR
                         //   * `Closure` with non-empty `captures` — a heap-boxed
                         //     env; flat-copying it shallow-aliases the caller's env
                         //     → double-free / UAF at generator teardown (admitting
@@ -33572,34 +33872,49 @@ impl Builder {
                         // bytes once, at construction, so shallow-copying any of
                         // these would alias the caller's resource → double-free /
                         // UAF at generator teardown.
-                        let reason = match &ty {
-                            ResolvedTy::Closure { captures, .. } if !captures.is_empty() => {
-                                "a closure with a captured environment cannot yet be admitted \
+                        let reason = if fn_env_provenance_unproven {
+                            "its fn value may carry a heap closure environment, and this \
+                             anonymous generator construction has no call-boundary proof \
+                             that the env word is null"
+                        } else {
+                            match &ty {
+                                ResolvedTy::Closure { captures, .. } if !captures.is_empty() => {
+                                    "a closure with a captured environment cannot yet be admitted \
                                  into the generator's flat-copied env; its heap env would be \
                                  shallow-aliased (double-free / UAF at teardown). \
                                  Owned/closure-env captures need the clone-into-env + \
                                  env-field-drop-on-destroy protocol"
-                            }
-                            _ if ValueClass::of_ty(&ty, &self.type_classes)
-                                == ValueClass::BitCopy =>
-                            {
-                                "it transitively contains an `#[opaque]` runtime handle; an \
+                                }
+                                _ if ValueClass::of_ty(&ty, &self.type_classes)
+                                    == ValueClass::BitCopy =>
+                                {
+                                    "it transitively contains an `#[opaque]` runtime handle; an \
                                  opaque handle is a pointer-width value with no clone helper, \
                                  so flat-copying it into the generator's env would alias the \
                                  caller's handle and double-free / use-after-free at teardown"
-                            }
-                            _ => {
-                                "it is an owned / non-BitCopy value; the generator's env is a \
+                                }
+                                _ => {
+                                    "it is an owned / non-BitCopy value; the generator's env is a \
                                  flat heap copy taken once at construction and can carry only \
                                  plain copyable values"
+                                }
                             }
+                        };
+                        let construct = if fn_env_provenance_unproven {
+                            format!(
+                                "the capture of fn value `{}` with unproven env provenance \
+                                 into a generator",
+                                capture.name
+                            )
+                        } else {
+                            format!(
+                                "the capture of opaque/owned value `{}` into a generator",
+                                capture.name
+                            )
                         };
                         self.diagnostics.push(MirDiagnostic {
                             kind: MirDiagnosticKind::NotYetImplemented {
-                                construct: format!(
-                                    "the capture of opaque/owned value `{}` into a generator",
-                                    capture.name
-                                ),
+                                construct,
                                 site: expr.site,
                             },
                             note: format!(
@@ -33771,7 +34086,7 @@ impl Builder {
         // consumed on one control-flow arm and overwritten on a sibling arm
         // silently leaks its prior value instead of getting the path-sensitive
         // release a byte-identical top-level function body would.
-        body_builder.collect_vec_owned_element_keys_from_block(body);
+        body_builder.collect_prepass_facts(body);
 
         // Lower all statements in the gen-block body. Yields inside the body
         // call `lower_yield_expr` which emits `Terminator::Yield` and advances
@@ -35310,36 +35625,56 @@ impl Builder {
         }
     }
 
-    /// `Some(description)` when a generator-constructor call argument is a
-    /// capturing closure (or a binding that may hold one) laundered behind a
-    /// `fn(..)` view — the CAP-11 fail-closed gate. The generator env is a
+    /// Emit the shared fail-closed diagnostic for fn-valued arguments crossing
+    /// into either a standalone or actor `gen fn` constructor. Lowering
+    /// continues after the fatal diagnostic so surrounding bindings remain
+    /// structurally coherent; no binary is emitted while diagnostics exist.
+    fn reject_unproven_generator_fn_args(&mut self, args: &[HirExpr]) {
+        for arg in args {
+            if let Some(what) = self.generator_arg_laundered_closure(arg) {
+                self.diagnostics.push(MirDiagnostic {
+                    kind: MirDiagnosticKind::NotYetImplemented {
+                        construct: "a capturing closure as a generator's `fn(..)` argument"
+                            .to_string(),
+                        site: arg.site,
+                    },
+                    note: format!(
+                        "{what} would cross into the generator's flat-copied env: \
+                         the generator can never release a capturing closure's \
+                         environment box, so every generator constructed from it \
+                         would leak that box. Pass a named function or a \
+                         capture-free closure directly to the generator; forwarding \
+                         through a parameter, call result, pattern payload, or aggregate \
+                         remains unavailable until the clone-into-env protocol \
+                         (`genfn-owned-captures`) exists."
+                    ),
+                });
+            }
+        }
+    }
+
+    /// `Some(description)` when a generator-constructor call argument may carry
+    /// a capturing closure behind a `fn(..)` view — the CAP-11 fail-closed
+    /// gate. The generator env is a
     /// flat `memcpy` (`Terminator::MakeGenerator`'s heap-copy) that never
     /// recurses into inner pointers and the body side never drops a fn-typed
     /// capture, so a non-null env word crossing this boundary is an
     /// unreleasable heap box: every constructed generator would leak it.
     /// `None` admits the argument.
     ///
-    /// Admitted (provably or presumptively null-env):
+    /// Admitted (provably null-env):
     ///   * named-fn references (`Item`-resolved — env word null by
     ///     construction);
     ///   * capture-free closure literals (no env box exists);
-    ///   * fn-typed values whose producer this gate cannot see through —
-    ///     fn-typed parameters of the ENCLOSING function and fn-typed call
-    ///     results. TODO(genfn-owned-captures): these two shapes can still
-    ///     smuggle a heap env interprocedurally (`fn wrap(f: fn(i64) -> i64)`
-    ///     forwarding `f` into a generator, called with a capturing closure)
-    ///     and keep the env-box leak. Closing them needs either closure-pair
-    ///     provenance carried on the value/type or the clone-into-env
-    ///     protocol that makes the generator own its captures; until then
-    ///     they stay admitted-and-documented, matching the pre-existing
-    ///     call-argument alias posture (leak, never a double-free).
+    ///   * bindings whose producer chain contains only those null-env shapes.
     ///
     /// Rejected (fail closed):
     ///   * a closure literal with captures;
     ///   * any expression whose resolved type is a capturing `Closure`;
-    ///   * a binding tainted by `closure_pair_laundered_bindings` (its `let`
-    ///     or any reassignment RHS was a capturing closure, so its `fn(..)`
-    ///     static type proves nothing about the env word).
+    ///   * fn-typed parameters and fn-valued call results, whose env provenance
+    ///     is not provably null;
+    ///   * fn-valued aggregate/container reads and other unproven producers;
+    ///   * bindings/merges/reassignments derived from any rejected shape.
     fn generator_arg_laundered_closure(&self, arg: &HirExpr) -> Option<String> {
         if let HirExprKind::Block(body) = &arg.kind {
             return body
@@ -35364,11 +35699,17 @@ impl Builder {
             name,
         } = &arg.kind
         {
-            if self.closure_pair_laundered_bindings.contains(id) {
-                return Some(format!("`{name}` (which holds a capturing closure)"));
+            if ty_is_closure_pair(&self.subst_ty(&arg.ty))
+                && self.closure_pair_env_may_be_nonnull.contains(id)
+            {
+                return Some(format!(
+                    "`{name}` (whose fn value may carry a heap closure environment)"
+                ));
             }
         }
-        None
+        self.closure_rhs_may_carry_env(arg).then(|| {
+            "a fn-valued producer whose closure environment is not provably null".to_string()
+        })
     }
 
     /// Ownership classification for a closure-pair operand entering an

--- a/hew-mir/tests/lowering_expr/gen_block_mir_lowering.rs
+++ b/hew-mir/tests/lowering_expr/gen_block_mir_lowering.rs
@@ -513,6 +513,608 @@ fn gen_block_capturing_fn_typed_param_is_admitted() {
     let _body = find_gen_body(&pipeline, "mapped");
 }
 
+/// CAP-11 P0: a plain function may not forward an unproven fn-typed parameter
+/// into a generator constructor. The caller can supply a capturing closure, so
+/// the parameter's env word is not provably null at the crossing.
+#[test]
+fn gen_fn_forwarded_fn_parameter_fails_closed() {
+    let pipeline = lower_checked(
+        r"
+        gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        fn forward(f: fn(i64) -> i64) -> Generator<i64, ()> { mapped(f) }
+        fn dbl(x: i64) -> i64 { x * 2 }
+        fn main() { for v in forward(dbl) { println(v); } }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        rejected,
+        "a forwarded fn parameter must fail closed because its env provenance is \
+         not provably null; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// CAP-11 P0: a fn-valued call result is also unproven. This is the direct
+/// laundering shape: the capturing closure is hidden behind `identity(...)`
+/// before it reaches the generator constructor.
+#[test]
+fn gen_fn_fn_valued_call_result_fails_closed() {
+    let pipeline = lower_checked(
+        r#"
+        gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        fn identity(f: fn(i64) -> i64) -> fn(i64) -> i64 { f }
+        fn main() {
+            let suffix = "owned";
+            for v in mapped(identity(|x: i64| x + suffix.len())) { println(v); }
+        }
+        "#,
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        rejected,
+        "a fn-valued call result must fail closed because it may hide a capturing \
+         closure env; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// The call-result provenance must survive a local binding. Otherwise
+/// `let f = producer(); mapped(f)` would erase the producer shape before the
+/// generator gate examines the argument.
+#[test]
+fn gen_fn_bound_fn_valued_call_result_fails_closed() {
+    let pipeline = lower_checked(
+        r#"
+        gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        fn identity(f: fn(i64) -> i64) -> fn(i64) -> i64 { f }
+        fn main() {
+            let suffix = "owned";
+            let f = identity(|x: i64| x + suffix.len());
+            for v in mapped(f) { println(v); }
+        }
+        "#,
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        rejected,
+        "a bound fn-valued call result must retain its unproven env provenance; \
+         got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// Owning aggregates can safely hold capturing closures because their own drop
+/// machinery releases the env. Reading that fn value into a generator is not
+/// safe: the generator flat-copies the pair but cannot release the inner env.
+#[test]
+fn gen_fn_fn_valued_aggregate_read_fails_closed() {
+    let pipeline = lower_checked(
+        r"
+        type Handler { action: fn(i64) -> i64; }
+        gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        fn make_adder(n: i64) -> fn(i64) -> i64 { |x: i64| x + n }
+        fn main() {
+            let h = Handler { action: make_adder(2) };
+            for v in mapped(h.action) { println(v); }
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        rejected,
+        "a fn-valued aggregate read must fail closed because the field may own a \
+         capturing closure env; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// Anonymous `gen {}` construction bypasses `lower_direct_call`, so its env
+/// materialiser must independently reject a local fn-valued call result whose
+/// closure env is not provably null.
+#[test]
+fn gen_block_fn_valued_call_result_capture_fails_closed() {
+    let pipeline = lower_checked(
+        r"
+        fn make_adder(n: i64) -> fn(i64) -> i64 { |x: i64| x + n }
+        fn main() {
+            let f = make_adder(2);
+            let g = gen { yield f(1); };
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("unproven env provenance")
+        )
+    });
+    assert!(
+        rejected,
+        "an anonymous gen block must reject an unproven fn-valued capture; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// Negative control for the anonymous-gen capture-site gate: a local binding
+/// sourced from a named function has a provably-null env word.
+#[test]
+fn gen_block_named_fn_capture_is_admitted() {
+    let pipeline = lower_checked(
+        r"
+        fn dbl(x: i64) -> i64 { x * 2 }
+        fn main() {
+            let f = dbl;
+            let g = gen { yield f(1); };
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("into a generator")
+        )
+    });
+    assert!(
+        !rejected,
+        "an anonymous gen block must admit a named-function capture; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// Provenance collection must reach a fixed point. The outer binding is
+/// examined before the nested block's `g = make_adder(...)` producer is
+/// discovered on the first pass; a second pass must propagate the taint to
+/// `f` before `mapped(f)` lowers.
+#[test]
+fn gen_fn_nested_binding_provenance_reaches_fixed_point() {
+    let pipeline = lower_checked(
+        r"
+        gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        fn make_adder(n: i64) -> fn(i64) -> i64 { |x: i64| x + n }
+        fn main() {
+            let f = {
+                let g = make_adder(2);
+                g
+            };
+            for v in mapped(f) { println(v); }
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        rejected,
+        "nested producer provenance must propagate before generator calls lower; \
+         got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// The same fixed point must cover a loop back-edge: on the second iteration
+/// `f = g` receives the capturing closure produced at the end of the first.
+#[test]
+fn gen_fn_loop_backedge_provenance_reaches_fixed_point() {
+    let pipeline = lower_checked(
+        r"
+        gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        fn dbl(x: i64) -> i64 { x * 2 }
+        fn make_adder(n: i64) -> fn(i64) -> i64 { |x: i64| x + n }
+        fn main() {
+            var f = dbl;
+            var g = dbl;
+            var i = 0;
+            while i < 2 {
+                f = g;
+                g = make_adder(i);
+                i = i + 1;
+            }
+            for v in mapped(f) { println(v); }
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        rejected,
+        "loop back-edge provenance must propagate before generator calls lower; \
+         got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// Generator bodies use a fresh child builder, so they need the same fixed-point
+/// pre-pass as top-level functions before lowering nested generator calls.
+#[test]
+fn nested_generator_body_provenance_reaches_fixed_point() {
+    let pipeline = lower_checked(
+        r"
+        gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        fn make_adder(n: i64) -> fn(i64) -> i64 { |x: i64| x + n }
+        fn main() {
+            let outer = gen {
+                let f = {
+                    let g = make_adder(2);
+                    g
+                };
+                for v in mapped(f) { yield v; }
+            };
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        rejected,
+        "generator body provenance must reach a fixed point before nested generator \
+         calls lower; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// Pattern payloads come from owning enum storage and may contain capturing
+/// closures. The payload binder must be marked unproven before an anonymous
+/// generator captures it.
+#[test]
+fn gen_block_fn_valued_pattern_payload_fails_closed() {
+    let pipeline = lower_checked(
+        r"
+        fn make_opt(n: i64) -> Option<fn(i64) -> i64> {
+            Some(|x: i64| x + n)
+        }
+        fn main() {
+            if let Some(f) = make_opt(2) {
+                let g = gen { yield f(1); };
+            }
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("unproven env provenance")
+        )
+    });
+    assert!(
+        rejected,
+        "a fn-valued pattern payload must not enter an anonymous generator env; \
+         got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// `receive gen fn` calls use the actor-stream lowering path rather than
+/// `lower_direct_call`; that boundary must reject the same fn-valued call
+/// results before the handler shell copies its parameter into the generator env.
+#[test]
+fn actor_gen_stream_fn_valued_call_result_fails_closed() {
+    let pipeline = lower_checked(
+        r"
+        actor Mapper {
+            init() {}
+            receive gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        }
+        fn make_adder(n: i64) -> fn(i64) -> i64 { |x: i64| x + n }
+        fn main() {
+            let mapper = spawn Mapper();
+            let stream = mapper.mapped(make_adder(2));
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        rejected,
+        "an actor generator stream call must reject an unproven fn-valued argument; \
+         got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// Negative control for the actor-stream gate: a named function has a null env
+/// word and remains a supported direct argument.
+#[test]
+fn actor_gen_stream_named_fn_is_admitted() {
+    let pipeline = lower_checked(
+        r"
+        actor Mapper {
+            init() {}
+            receive gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        }
+        fn dbl(x: i64) -> i64 { x * 2 }
+        fn main() {
+            let mapper = spawn Mapper();
+            let stream = mapper.mapped(dbl);
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        !rejected,
+        "an actor generator stream must admit a direct named function; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// Closure invoke shims use a child builder. Their fn-typed parameters must be
+/// seeded as unproven before a closure body can forward one into a generator.
+#[test]
+fn closure_body_forwarded_fn_parameter_fails_closed() {
+    let pipeline = lower_checked(
+        r"
+        gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        fn main() {
+            let forward = |f: fn(i64) -> i64| mapped(f);
+            let base = 2;
+            let g = forward(|x: i64| x + base);
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        rejected,
+        "a closure body must reject a forwarded fn parameter with unproven env \
+         provenance; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// The child closure builder must also inherit provenance for fn-valued
+/// captures from its enclosing function.
+#[test]
+fn closure_body_captured_fn_call_result_fails_closed() {
+    let pipeline = lower_checked(
+        r"
+        gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        fn make_adder(n: i64) -> fn(i64) -> i64 { |x: i64| x + n }
+        fn main() {
+            let f = make_adder(2);
+            let forward = || mapped(f);
+            let g = forward();
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        rejected,
+        "a closure body must retain an enclosing fn capture's unproven env \
+         provenance; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// Lambda-actor bodies are another child-builder path with user parameters.
+/// A fn-typed message parameter may carry a capturing closure and cannot be
+/// forwarded into a generator env.
+#[test]
+fn lambda_actor_body_forwarded_fn_parameter_fails_closed() {
+    let pipeline = lower_checked(
+        r"
+        gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        fn main() {
+            let worker = actor |f: fn(i64) -> i64| {
+                let g = mapped(f);
+            };
+            let base = 2;
+            let _sent = worker.send(|x: i64| x + base);
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        rejected,
+        "a lambda-actor body must reject a forwarded fn message parameter; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// A named generator function can itself be used as a first-class fn value.
+/// Calls through that binding lower via `CallClosure`, so the indirect path must
+/// enforce the same fn-argument provenance gate as `lower_direct_call`.
+#[test]
+fn indirect_gen_fn_call_result_fails_closed() {
+    let pipeline = lower_checked(
+        r"
+        gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        fn main() {
+            let make = mapped;
+            let base = 2;
+            let g = make(|x: i64| x + base);
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        rejected,
+        "an indirect generator call must reject a capturing closure argument; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// Negative control for the indirect-call gate: named functions and
+/// capture-free closures still carry null env words.
+#[test]
+fn indirect_gen_fn_null_env_args_are_admitted() {
+    let pipeline = lower_checked(
+        r"
+        gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        fn dbl(x: i64) -> i64 { x * 2 }
+        fn main() {
+            let make = mapped;
+            let g1 = make(dbl);
+            let g2 = make(|x: i64| x + 1);
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        !rejected,
+        "an indirect generator call must admit null-env function arguments; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// A whole-scrutinee match binding (`f => ...`) is another pattern-introduced
+/// fn value and must be treated as unproven.
+#[test]
+fn match_binding_fn_provenance_fails_closed() {
+    let pipeline = lower_checked(
+        r"
+        gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        fn make_adder(n: i64) -> fn(i64) -> i64 { |x: i64| x + n }
+        fn main() {
+            match make_adder(2) {
+                f => { let g = mapped(f); },
+            }
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        rejected,
+        "a fn-valued match binding must carry unproven env provenance; got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// Negative control for the widened gate: direct generator calls with a named
+/// function or capture-free closure have provably-null env words and remain
+/// supported.
+#[test]
+fn gen_fn_direct_null_env_function_values_are_admitted() {
+    let pipeline = lower_checked(
+        r"
+        gen fn mapped(f: fn(i64) -> i64) -> i64 { yield f(1); }
+        fn dbl(x: i64) -> i64 { x * 2 }
+        fn main() {
+            for v in mapped(dbl) { println(v); }
+            for v in mapped(|x: i64| x + 1) { println(v); }
+        }
+        ",
+    );
+
+    let rejected = pipeline.diagnostics.iter().any(|d| {
+        matches!(
+            &d.kind,
+            MirDiagnosticKind::NotYetImplemented { construct, .. }
+                if construct.contains("capturing closure as a generator")
+        )
+    });
+    assert!(
+        !rejected,
+        "direct named functions and capture-free closures must remain admitted; \
+         got: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
 /// A generator that captures a closure-with-env must STILL fail closed after the
 /// fn-typed-param admission gate is widened.
 ///

--- a/tests/vertical-slice/reject/gen_fn_forwarded_fn_call_result.hew
+++ b/tests/vertical-slice/reject/gen_fn_forwarded_fn_call_result.hew
@@ -1,0 +1,20 @@
+// Reject (CAP-11): a fn-valued call result can hide a capturing closure
+// environment before the value reaches a generator constructor.
+gen fn mapped(n: i64, f: fn(i64) -> i64) -> i64 {
+    var i = 0;
+    while i < n {
+        yield f(i);
+        i = i + 1;
+    }
+}
+
+fn identity(f: fn(i64) -> i64) -> fn(i64) -> i64 {
+    f
+}
+
+fn main() {
+    let suffix = "owned-" + "heap";
+    for v in mapped(1, identity(|x: i64| x + suffix.len())) {
+        println(v);
+    }
+}

--- a/tests/vertical-slice/reject/gen_fn_forwarded_fn_param.hew
+++ b/tests/vertical-slice/reject/gen_fn_forwarded_fn_param.hew
@@ -1,0 +1,20 @@
+// Reject (CAP-11): forwarding a fn-typed parameter into a generator
+// constructor cannot prove that the function value has a null environment.
+gen fn mapped(n: i64, f: fn(i64) -> i64) -> i64 {
+    var i = 0;
+    while i < n {
+        yield f(i);
+        i = i + 1;
+    }
+}
+
+fn forward(f: fn(i64) -> i64) -> Generator<i64, ()> {
+    mapped(1, f)
+}
+
+fn main() {
+    let suffix = "owned-" + "heap";
+    for v in forward(|x: i64| x + suffix.len()) {
+        println(v);
+    }
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -4145,6 +4145,29 @@ if "${HEW}" check \
 fi
 grep -q 'can never release a capturing closure' "${reject_output}"
 
+# Reject (CAP-11, forwarded-param leg): an intermediate function cannot
+# launder a capturing closure into a generator through its `fn(..)` parameter.
+# The parameter's env word is unproven at the generator-constructor crossing.
+if "${HEW}" check \
+    "${ROOT}/tests/vertical-slice/reject/gen_fn_forwarded_fn_param.hew" \
+    >"${reject_output}" 2>&1; then
+  echo "expected gen_fn_forwarded_fn_param fixture to fail" >&2
+  exit 1
+fi
+grep -q 'E_NOT_YET_IMPLEMENTED' "${reject_output}"
+grep -q 'can never release a capturing closure' "${reject_output}"
+
+# Reject (CAP-11, call-result leg): a fn-valued call result can hide a
+# capturing closure env before it reaches the generator constructor.
+if "${HEW}" check \
+    "${ROOT}/tests/vertical-slice/reject/gen_fn_forwarded_fn_call_result.hew" \
+    >"${reject_output}" 2>&1; then
+  echo "expected gen_fn_forwarded_fn_call_result fixture to fail" >&2
+  exit 1
+fi
+grep -q 'E_NOT_YET_IMPLEMENTED' "${reject_output}"
+grep -q 'can never release a capturing closure' "${reject_output}"
+
 # Reject (CAP-11, rebind leg): a `fn(..)`-typed var REASSIGNED a capturing
 # closure is tainted by a whole-body pre-pass — including back-edge
 # assignments that textually follow the generator call — so the launder


### PR DESCRIPTION
## Why

A generator constructor receiving a capturing closure **indirectly** — through a function that returns the closure as an `fn` value, or through a call result — silently leaked the closure's owned captures on every construction. Measured before the fix: 200 leaked allocations / 8,000 bytes over 100 iterations (80 bytes/iteration), via `leaks --atExit` on a compiled repro.

The direct form (`gen_fn(capturing_closure)`) was already rejected at compile time. The indirect "laundered" form slipped through because the existing gate only checked the immediate argument expression, not the provenance of an `fn` value that had passed through a parameter or a call result first.

## What

- **hew-mir**: widened the generator closure-environment gate to trace `fn`-value provenance rather than checking only the immediate call argument. It now rejects any generator constructor whose closure environment word is not provably null, across direct calls, actor-stream constructors, and indirect fn-binding calls — covering fn-typed parameters, call results, assignments, loop back-edges, aggregate/pattern reads, and closure/lambda-actor/nested-generator child builders.
- Preserves direct named functions, capture-free closures, and a gen-fn shell forwarding its own already-gated fn parameter into its own environment (the exemption that keeps the widened gate from over-rejecting the legitimate `gen fn foo(f: fn(..))` shape).
- Does not implement a clone-into-generator-environment protocol that would make these patterns compile correctly instead of being rejected. The generator ABI has no typed capture manifest or per-field drop thunk anywhere today — it's a flat `memcpy` at construction and a flat free at destruction. Building a partial version of that protocol here would trade a leak for a double-free/use-after-free risk; an honest reject is the safer failure mode until that protocol exists.

## Test

- `hew-mir/tests/lowering_expr/gen_block_mir_lowering.rs`: 19 new tests pinning both fail-closed rejection and correct admission across actor-gen-stream construction, closure/lambda-actor child builders, pattern payloads, aggregate reads, and indirect fn-binding calls.
- `tests/vertical-slice/reject/gen_fn_forwarded_fn_param.hew` and `gen_fn_forwarded_fn_call_result.hew`: compiled regression fixtures pinning the two previously-leaking laundering shapes (fn-typed-parameter crossing and fn-valued-call-result crossing), registered in `tests/vertical-slice/run.sh`. These reject during MIR lowering with no runnable artifact, so they're vertical-slice-only, not in the expected-failures trap corpus.
- Verified the leak before the fix and the reject after: `leaks --atExit` on the compiled repro reported exactly 200 leaks / 8,000 bytes; after the fix the same source is rejected at MIR lowering with zero emitted artifacts.
- Confirmed no over-rejection: existing legitimate generator/closure patterns (direct named fn, capture-free closures, a gen-fn shell's own fn param) still compile and run correctly.
- Full workspace (`cargo nextest run --workspace --no-fail-fast`), `make test-hew-ratchet`, and `make checked-mir-verify` all pass.

## Quality Checklist
- [x] PR title, body, and commit messages avoid internal-only orchestration/model vocabulary
- [x] No new `.ok()?` or `unwrap_or_default()` in codegen without `// JUSTIFIED` comment — n/a, no such additions
- [x] New allocations have cleanup paths for sync, async, and actor shutdown contexts — n/a, this change rejects a pattern rather than adding allocation
- [ ] Serialization changes include round-trip encode/decode tests — n/a, no serialization changes
- [ ] New runtime features have WASM implementation or `// WASM-TODO(#NNN):` marker — n/a, no new runtime symbols
- [x] No duplicated logic — checked for existing helpers before adding new ones (widens the existing gate rather than adding a parallel one)