### PR TITLE
docs(mir): finalize the coalesce key_field scope as settled spec

### DIFF
--- a/hew-codegen-rs/src/thunks.rs
+++ b/hew-codegen-rs/src/thunks.rs
@@ -2439,9 +2439,9 @@ pub(crate) fn emit_coalesce_key_fn<'ctx>(
     }
 
     builder.position_at_end(default_bb);
-    // D3/Q244 shim: handlers omitted from the MIR plan must not accidentally
-    // coalesce by msg_type alone. Legacy copied payloads have distinct queue and
-    // sender addresses, so pointer identity disables matching for those types.
+    // Only coalescing message types require `key_field`; mixed handlers are valid.
+    // This least-surprise rule intentionally avoids a blanket annotation burden on
+    // unrelated handlers. Pointer identity prevents unkeyed handlers from matching.
     let default_key = builder
         .build_ptr_to_int(payload, i64_ty, "unkeyed_payload_identity")
         .llvm_ctx("coalesce unkeyed payload identity")?;

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -1224,7 +1224,9 @@ pub fn lower_hir_module_with_facts(
                 .enumerate()
                 .find(|(_, param)| param.name == *key_field)
             else {
-                // SHIM(Q244): strict all-handlers key_field rejection pending user decision; WHEN=Q244 answered; WHAT=reject-at-check if any handler message lacks key_field
+                // Only coalescing message types require `key_field`; mixed handlers are valid.
+                // This least-surprise rule intentionally avoids a blanket annotation burden on
+                // unrelated handlers.
                 continue;
             };
             let Some(kind) = coalesce_key_kind(&param.ty) else {

--- a/hew-mir/tests/coalesce_key_plan.rs
+++ b/hew-mir/tests/coalesce_key_plan.rs
@@ -89,7 +89,7 @@ fn rejects_missing_or_unsupported_key_fields() {
 }
 
 #[test]
-fn q244_shim_allows_handlers_without_the_key_field() {
+fn allows_mixed_handlers_without_the_key_field() {
     let pipeline = lower_source(
         r"
         actor Mixed {


### PR DESCRIPTION
## Summary

This documents that only a coalescing actor's key-bearing message type needs `key_field` — mixed handlers on the same actor, some with the field and some without, are valid by design, not a gap. `resolve_coalesce_key_plan` already skips (not rejects) handlers whose message type lacks the field; this comment/test update reflects that as settled behaviour instead of a provisional marker. Comment-only change, no behaviour modified.

## Verification

- Read `resolve_coalesce_key_plan` (hew-mir/src/lower.rs) end to end and confirmed the comment matches: a handler without `key_field` is skipped from the coalesce entries plan, not an error; the function only bails if no handler carries the field or the field type is unsupported.
- `cargo nextest run -p hew-mir -p hew-types`: 3701 tests run, 3701 passed, 3 skipped — exact match against the pre-change baseline, confirming zero behaviour change.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.

## Out of scope

None — this is a self-contained comment and test-name clarification.