### PR TITLE
fix(codegen): fail closed on unmodelled 32-bit size_t targets

### DIFF
--- a/hew-codegen-rs/src/abi_class.rs
+++ b/hew-codegen-rs/src/abi_class.rs
@@ -106,12 +106,19 @@ pub(crate) enum AbiClass {
 /// The byte size above which SysV / AAPCS pass an aggregate indirectly.
 const SMALL_AGGREGATE_MAX: u64 = 16;
 
-/// Returns `true` when `triple` names the Windows x64 MSVC environment, whose
-/// aggregate ABI differs from SysV/AAPCS (every non-{1,2,4,8}-byte aggregate is
-/// indirect). Matches on the `-msvc` environment suffix, not the arch, because
-/// only the MSVC environment carries this rule.
+/// Returns `true` when `triple` names the Windows **x64** MSVC environment,
+/// whose aggregate ABI differs from SysV/AAPCS (every non-{1,2,4,8}-byte
+/// aggregate is indirect). Matches the `-msvc` environment AND a 64-bit arch:
+/// the Win64 aggregate rule this admits is the x86_64/aarch64 one, not the
+/// 32-bit x86 (`i686-pc-windows-msvc`) cdecl/stdcall rule, which differs and is
+/// not modelled here. Gating on the arch keeps a 32-bit x86 MSVC triple OUT of
+/// this arm so it falls through to the fail-closed default rather than
+/// borrowing the x64 indirect rule. Hew targets Windows via 64-bit MSVC.
 fn is_windows_msvc(triple: &str) -> bool {
-    triple.contains("windows-msvc") || triple.ends_with("-msvc")
+    let is_msvc = triple.contains("windows-msvc") || triple.ends_with("-msvc");
+    let arch = triple.split('-').next().unwrap_or(triple);
+    let is_64bit_x86_or_arm = matches!(arch, "x86_64" | "amd64" | "aarch64" | "arm64");
+    is_msvc && is_64bit_x86_or_arm
 }
 
 /// Returns `true` for any Windows triple. Used to keep `*-windows-gnu`
@@ -434,6 +441,7 @@ mod tests {
     const SYSV: &str = "x86_64-unknown-linux-gnu";
     const AARCH64_DARWIN: &str = "aarch64-apple-darwin";
     const WIN_MSVC: &str = "x86_64-pc-windows-msvc";
+    const WIN_MSVC_X86: &str = "i686-pc-windows-msvc";
     const WASM32: &str = "wasm32-unknown-unknown";
 
     #[test]
@@ -493,6 +501,46 @@ mod tests {
             classify_aggregate(child_lookup(&ctx), &td, WIN_MSVC).unwrap(),
             AbiClass::Indirect
         );
+    }
+
+    #[test]
+    fn windows_msvc_rule_is_gated_to_64bit_arch() {
+        // `is_windows_msvc` matches the `-msvc` ENVIRONMENT; before the arch
+        // gate, `i686-pc-windows-msvc` (32-bit x86) borrowed the Win64
+        // aggregate rule. 32-bit x86 MSVC uses a different cdecl/stdcall
+        // aggregate ABI that is not modelled here, so it must now fall THROUGH
+        // the msvc arm to the fail-closed default rather than be classified
+        // under the x64 indirect rule.
+        assert!(is_windows_msvc("x86_64-pc-windows-msvc"));
+        assert!(is_windows_msvc("aarch64-pc-windows-msvc"));
+        assert!(
+            !is_windows_msvc("i686-pc-windows-msvc"),
+            "32-bit x86 MSVC must not borrow the Win64 aggregate rule"
+        );
+        assert!(
+            !is_windows_msvc("i586-pc-windows-msvc"),
+            "32-bit x86 MSVC must not borrow the Win64 aggregate rule"
+        );
+    }
+
+    #[test]
+    fn bytes_triple_fails_closed_on_32bit_x86_msvc() {
+        // Deletion proof for the arch gate: a 16-byte aggregate on
+        // i686-pc-windows-msvc must NOT be silently classified Indirect via the
+        // Win64 rule. With the gate it falls through to the fail-closed arm
+        // (32-bit x86 MSVC aggregate ABI is unmodelled), the honest outcome
+        // until that ABI is proven against the corpus.
+        let ctx = Context::create();
+        let td = target_data_for(WIN_MSVC); // 64-bit TargetData; the triple STRING drives the rule
+        let err = classify_aggregate(bytes_triple(&ctx), &td, WIN_MSVC_X86).expect_err(
+            "32-bit x86 MSVC aggregate ABI must fail closed, not borrow the Win64 rule",
+        );
+        match err {
+            CodegenError::FailClosed(msg) => {
+                assert!(msg.contains("i686-pc-windows-msvc"), "msg: {msg}");
+            }
+            other => panic!("expected FailClosed, got {other:?}"),
+        }
     }
 
     #[test]

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -1915,6 +1915,44 @@ fn is_32bit_x86_triple(triple: &str) -> bool {
     matches!(arch, "i386" | "i486" | "i586" | "i686")
 }
 
+/// Fail closed when the runtime-FFI `size_t`/`usize` width derived from the
+/// module triple diverges from the target's authoritative pointer width.
+///
+/// [`runtime_size_ty`] picks the width from a hard-coded triple allowlist
+/// (wasm32 + the 32-bit x86 family → `i32`, everything else → `i64`). That
+/// allowlist silently returns `i64` for every *other* 32-bit target — arm32,
+/// riscv32, mips32, ppc32, and the ILP32 variants — which is the exact
+/// wrong-width FFI-declaration class #2423 fixed for i386/i686, just on
+/// targets nobody compiles for yet. `TargetData::get_pointer_byte_size` is the
+/// authoritative `size_t` width for the module's data layout; when it
+/// disagrees with the allowlist-derived width, the runtime declarations this
+/// module emits (`hew_actor_spawn`, `malloc`, the CBOR reader, …) would
+/// mismatch the runtime's real C ABI. Refuse to emit rather than ship a
+/// silently wrong-width module. 64-bit natives and the modelled 32-bit targets
+/// (wasm32, i386/i686) agree and pass; only an unmodelled 32-bit triple trips
+/// this. (LESSONS: boundary-fail-closed)
+fn verify_runtime_size_width<'ctx>(
+    ctx: &'ctx Context,
+    llvm_mod: &LlvmModule<'ctx>,
+    target_data: &TargetData,
+    triple: &str,
+) -> CodegenResult<()> {
+    let declared_bits = runtime_size_ty(ctx, llvm_mod).get_bit_width();
+    let pointer_bits = target_data.get_pointer_byte_size(None) * 8;
+    if declared_bits != pointer_bits {
+        return Err(CodegenError::FailClosed(format!(
+            "runtime `size_t` width for target `{triple}` is not modelled: the FFI \
+             declaration width would be {declared_bits}-bit but the target's \
+             pointer/`size_t` width is {pointer_bits}-bit. This is the wrong-width \
+             runtime-declaration class fixed for 32-bit x86 in #2423, on an \
+             unmodelled 32-bit target. Add this target's arch to `runtime_size_ty`'s \
+             32-bit allowlist before emitting a module for it — codegen never emits a \
+             silently wrong-width runtime declaration. (LESSONS: boundary-fail-closed)"
+        )));
+    }
+    Ok(())
+}
+
 /// Intern a runtime-ABI function declaration for `symbol` in `llvm_mod`.
 ///
 /// Returns the cached `FunctionValue` on repeat lookups so multiple
@@ -8683,7 +8721,7 @@ fn emit_static_pool_members<'ctx>(
 ) -> CodegenResult<usize> {
     let i32_ty = ctx.i32_type();
     let i64_ty = ctx.i64_type();
-    let size_ty = ctx.i64_type(); // supervisors are HIR-gated off wasm32 → usize == i64.
+    let size_ty = runtime_size_ty(ctx, llvm_mod); // `size_t`/`usize` width; supervisors are HIR-gated off wasm32, so i64 on native and correct on 32-bit x86.
 
     let pool_count = child.pool_count.as_ref().ok_or_else(|| {
         CodegenError::FailClosed(format!(
@@ -40325,6 +40363,12 @@ fn build_module_for_target<'ctx>(
         (host_target_data(), native)
     };
 
+    // Fail closed before any body fill emits a runtime declaration: refuse an
+    // unmodelled 32-bit target whose `size_t` width `runtime_size_ty` would get
+    // wrong (silently falling through to i64). The module triple + target data
+    // are both set above, so this is the earliest point the check is valid.
+    verify_runtime_size_width(ctx, &llvm_mod, &target_data, &module_triple)?;
+
     // DWARF compile unit + file for `hew build -g` (W0.060). Created once per
     // module; the `DebugInfoBuilder` is finalized just before `verify()` below
     // (inkwell requires `finalize()` before any code generation, verification
@@ -46023,6 +46067,76 @@ mod tests {
                 ctx.i64_type(),
                 "runtime_size_ty should be i64 on 64-bit triple {triple}"
             );
+        }
+    }
+
+    #[test]
+    fn verify_runtime_size_width_accepts_modelled_targets() {
+        // wasm32 + 32-bit x86 (i32 size_t) and the 64-bit natives (i64 size_t)
+        // all AGREE between `runtime_size_ty`'s allowlist and the target's real
+        // pointer width, so the gate passes.
+        let ctx = Context::create();
+        for triple in [
+            "wasm32-unknown-unknown",
+            "i686-unknown-linux-gnu",
+            "i686-pc-windows-msvc",
+            "x86_64-unknown-linux-gnu",
+            "x86_64-pc-windows-msvc",
+            "aarch64-apple-darwin",
+            "aarch64-unknown-linux-gnu",
+        ] {
+            let llvm_mod = ctx.create_module("verify_size_ok");
+            llvm_mod.set_triple(&TargetTriple::create(triple));
+            let td = record_ret_target_data(triple);
+            verify_runtime_size_width(&ctx, &llvm_mod, &td, triple).unwrap_or_else(|e| {
+                panic!("modelled target {triple} must pass the width gate: {e:?}")
+            });
+        }
+    }
+
+    #[test]
+    fn verify_runtime_size_width_fails_closed_on_unmodelled_32bit_targets() {
+        // The bug: `runtime_size_ty` allowlists only wasm32 + 32-bit x86, so
+        // every OTHER 32-bit target (arm32, riscv32, mips32, ppc32) silently
+        // falls through to i64 while its real `size_t` is 32-bit. The gate must
+        // reject these before any wrong-width runtime declaration is emitted —
+        // this is the generalization of the #2423 i386/i686 fix to the rest of
+        // the 32-bit target space, expressed as a fail-closed check rather than
+        // an ever-growing arch allowlist.
+        let ctx = Context::create();
+        for triple in [
+            "arm-unknown-linux-gnueabi",
+            "armv7-unknown-linux-gnueabihf",
+            "riscv32imac-unknown-none-elf",
+            "mipsel-unknown-linux-gnu",
+            "powerpc-unknown-linux-gnu",
+        ] {
+            let llvm_mod = ctx.create_module("verify_size_bad");
+            llvm_mod.set_triple(&TargetTriple::create(triple));
+            // Build a 32-bit-pointer `TargetData` directly from a data-layout
+            // string so the test does not depend on the LLVM build shipping
+            // every 32-bit backend (riscv32/mips/ppc are not in the default
+            // `initialize_all` set on all hosts). `e-p:32:32` = little-endian,
+            // 32-bit pointer — the only datum the gate reads besides the triple.
+            let td = TargetData::create("e-p:32:32-i64:64");
+            let pointer_bits = td.get_pointer_byte_size(None) * 8;
+            assert_eq!(pointer_bits, 32, "expected a 32-bit pointer for {triple}");
+            let err = verify_runtime_size_width(&ctx, &llvm_mod, &td, triple).expect_err(
+                "unmodelled 32-bit target must fail closed, not emit a silently wrong-width module",
+            );
+            match err {
+                CodegenError::FailClosed(msg) => {
+                    assert!(
+                        msg.contains(triple),
+                        "diagnostic must name the target: {msg}"
+                    );
+                    assert!(
+                        msg.contains("32-bit"),
+                        "diagnostic must cite the width: {msg}"
+                    );
+                }
+                other => panic!("expected FailClosed for {triple}, got {other:?}"),
+            }
         }
     }
 


### PR DESCRIPTION
Closes #2430.

## Problem

`runtime_size_ty` derives the runtime-FFI `size_t`/`usize` width from a hard-coded triple allowlist: wasm32 + the 32-bit x86 family (`i386`/`i586`/`i686`) return `i32`, everything else returns `i64`. After #2423 modelled 32-bit x86, every **other** 32-bit target (arm32, riscv32, mips32, ppc32, ILP32 variants) still silently falls through to the `i64` branch — the exact wrong-width runtime-declaration class #2423 fixed for i386/i686, just on targets nobody compiles for yet. A declared-i64 `size_t` against a real 32-bit C ABI is a silent miscompile.

Issue #2430 also flagged two adjacent i686-specific gaps, folded into the same pass.

## Fix (three coupled fail-closed tightenings)

1. **Root**: new `verify_runtime_size_width`, called once per module in `build_module_for_target` right after the triple + target data are set (before any body fill emits a runtime declaration). It cross-checks the allowlist-derived width against `TargetData::get_pointer_byte_size` — the authoritative `size_t` width for the module's data layout — and fails closed with a diagnostic naming the target and both widths when they diverge. This generalizes the fix to the whole 32-bit space via a real pointer-width check rather than an ever-growing arch allowlist: the modelled targets (wasm32, i386/i686, all 64-bit natives) agree and pass; only an unmodelled 32-bit triple trips it.

2. **`is_windows_msvc` arch gate** (`abi_class.rs`): the helper matched the `-msvc` *environment*, not the arch, so `i686-pc-windows-msvc` (32-bit x86) borrowed the Win64 aggregate rule (indirect for size ∉ {1,2,4,8}). 32-bit x86 MSVC uses a different cdecl/stdcall aggregate ABI that is not modelled here. Gating on a 64-bit x86/arm arch makes 32-bit x86 MSVC fall through to the fail-closed default arm instead of silently classifying a 16-byte aggregate Indirect under the wrong rule.

3. **Supervisor size_ty** (`emit_static_pool_members`): the static-pool bootstrap hardcoded `size_ty = i64` for the `hew_supervisor_pool_add_slot` `max_members: usize` argument. Correct on native (i64) since supervisors are HIR-gated off wasm32, but it would desync the declared-vs-passed width on a future 32-bit x86 supervisor build. Now routed through `runtime_size_ty` so the argument width tracks the target like every other `size_t` site.

## Tests / verification

- New: width-gate **accept** over the 7 modelled targets; **fail-closed** over 5 unmodelled 32-bit triples (arm/riscv32/mips/ppc — `TargetData` built from a 32-bit data-layout string so the test needs no cross backend in the default `initialize_all` set).
- New: MSVC arch gate proves `i686`/`i586-pc-windows-msvc` are excluded, and a 16-byte aggregate on i686 MSVC now fails closed.
- Full `hew-codegen-rs` lib suite **218/218**, `abi_class` **16/16**, `cargo fmt --check` + `cargo clippy` clean.
- Native x86_64 unaffected: the static-pool vertical slice (`supervisor_static_pool_restart.hew`) still builds and runs to **exit 7**; 29/30 sampled examples `check` clean (the one failure is a pre-existing `Suite::add` HIR feature gap, not a width error).