### PR TITLE
fix(hew-runtime): make runtime-drop oracles isolation-safe under parallel tests

### DIFF
--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -97,6 +97,19 @@ pub(crate) struct RuntimeInner {
     /// (the `hew_node_monitor_recv` observation slots) and target-side remote
     /// watchers (the terminal-sweep fan-out list).
     pub(crate) dist_monitors: crate::dist_monitor::DistMonitorState,
+    /// Per-instance drop observer for the "exactly once" teardown oracles.
+    ///
+    /// Replaces the former process-global `RUNTIME_INNER_DROPS` counter, whose
+    /// delta-based (`before` → `before + 1`) assertions were corrupted under
+    /// parallel test execution: any `RuntimeInner` built and dropped by a test
+    /// in another module (which does not hold `SCHED_TEST_MUTEX`) bumped the
+    /// shared counter between an oracle's `before` read and its final assert,
+    /// producing an intermittent off-by-one (issue #2572). A probe is bound to a
+    /// single runtime instance, so it counts *only that instance's* drop and is
+    /// immune to concurrent drops elsewhere. Left `None` for every runtime a
+    /// test does not explicitly observe.
+    #[cfg(test)]
+    pub(crate) drop_probe: std::sync::Mutex<Option<std::sync::Arc<std::sync::atomic::AtomicUsize>>>,
 }
 
 impl RuntimeInner {
@@ -113,6 +126,8 @@ impl RuntimeInner {
             metrics: crate::metrics::MetricsState::new(),
             monitors: crate::monitor::MonitorState::new(),
             dist_monitors: crate::dist_monitor::DistMonitorState::new(),
+            #[cfg(test)]
+            drop_probe: std::sync::Mutex::new(None),
         }
     }
 
@@ -151,21 +166,42 @@ impl RuntimeInner {
     }
 }
 
-/// Number of [`RuntimeInner`] instances dropped, for drop-order/release-count
-/// oracles. A leak detector running green is *non-evidence* for ownership
-/// correctness (a thread-backed handle leak is invisible to it); the honest
-/// oracle is an exact drop-count assertion under a known teardown sequence.
+/// Test-only per-instance drop observer: bind a fresh counter to a single
+/// installed `RuntimeInner` so an "exactly once" teardown oracle counts only
+/// *that instance's* drop.
+///
+/// This replaces the former process-global `RUNTIME_INNER_DROPS` counter, whose
+/// delta assertions were corrupted under parallel test execution by unrelated
+/// `RuntimeInner`s built and dropped in other modules (issue #2572). The caller
+/// must hold `SCHED_TEST_MUTEX` and pass a pointer to a live runtime it owns.
 #[cfg(test)]
-pub(crate) static RUNTIME_INNER_DROPS: std::sync::atomic::AtomicUsize =
-    std::sync::atomic::AtomicUsize::new(0);
+pub(crate) fn install_drop_probe_for_test(
+    ptr: *const RuntimeInner,
+) -> std::sync::Arc<std::sync::atomic::AtomicUsize> {
+    let probe = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    // SAFETY: `ptr` refers to a live `RuntimeInner` the caller owns and keeps
+    // installed for the duration of the test; `drop_probe` uses interior
+    // mutability (a `Mutex`) so a shared reference may set it.
+    let inner = unsafe { &*ptr };
+    *inner
+        .drop_probe
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(std::sync::Arc::clone(&probe));
+    probe
+}
 
 /// Test-only drop observer. Production builds compile no `Drop` impl, so the
 /// inner frees by field-drop; the `#[cfg(test)]` impl only records that the
-/// field-drop happened, then lets the fields drop normally as it returns.
+/// field-drop happened (into an optional per-instance probe), then lets the
+/// fields drop normally as it returns.
 #[cfg(test)]
 impl Drop for RuntimeInner {
     fn drop(&mut self) {
-        RUNTIME_INNER_DROPS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if let Ok(mut guard) = self.drop_probe.lock() {
+            if let Some(probe) = guard.take() {
+                probe.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
     }
 }
 

--- a/hew-runtime/src/runtime_handle.rs
+++ b/hew-runtime/src/runtime_handle.rs
@@ -121,7 +121,7 @@
 //!
 //! A leak detector running green is non-evidence that the runtime was released
 //! (a thread-backed handle leak is invisible to it); the honest oracle is the
-//! `RUNTIME_INNER_DROPS` drop-count under a known release sequence (see
+//! per-instance `RuntimeInner` drop probe under a known release sequence (see
 //! `runtime.rs`).
 
 #![cfg(not(target_arch = "wasm32"))]

--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -4787,20 +4787,24 @@ mod tests {
     /// default runtime is detached from its slot *before* it is freed, and it
     /// is freed exactly once on cleanup. A leak detector running green is
     /// non-evidence for this (thread-backed handle leaks are invisible to it);
-    /// the honest oracle is the exact `RUNTIME_INNER_DROPS` count below.
+    /// the honest oracle is the exact per-instance drop probe below (bound via
+    /// [`runtime::install_drop_probe_for_test`]).
     #[test]
     fn default_runtime_detaches_before_free_and_drops_exactly_once() {
         let _g = SCHED_TEST_MUTEX
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-        let before = runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst);
-        let _rt_ptr = install_scheduler_for_test(worker_less_scheduler_for_test());
+        let rt_ptr = install_scheduler_for_test(worker_less_scheduler_for_test());
+
+        // Bind a per-instance drop probe to *this* runtime so the oracle counts
+        // only its own drop, never a concurrent drop from a parallel test.
+        let probe = runtime::install_drop_probe_for_test(rt_ptr);
 
         // While installed, nothing has been freed.
         assert_eq!(
-            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
-            before,
+            probe.load(Ordering::SeqCst),
+            0,
             "installing the runtime must not free anything"
         );
 
@@ -4812,16 +4816,16 @@ mod tests {
             "take_default must clear the slot before the runtime is freed"
         );
         assert_eq!(
-            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
-            before,
+            probe.load(Ordering::SeqCst),
+            0,
             "detaching the runtime from its slot must not free it"
         );
 
         // Explicit drop is the single free site — exactly once, never twice.
         drop(taken);
         assert_eq!(
-            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
-            before + 1,
+            probe.load(Ordering::SeqCst),
+            1,
             "the detached runtime must be freed exactly once on explicit drop"
         );
 
@@ -4829,8 +4833,8 @@ mod tests {
         // free): take_default returns None and the drop count is unchanged.
         assert!(runtime::take_default().is_none());
         assert_eq!(
-            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
-            before + 1,
+            probe.load(Ordering::SeqCst),
+            1,
             "a second teardown of an empty slot must not free anything"
         );
     }
@@ -4845,17 +4849,18 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let first = install_scheduler_for_test(worker_less_scheduler_for_test());
-        let before = runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst);
 
-        // Attempt to install a second runtime: rejected (slot occupied).
-        let installed = runtime::install_default(Box::new(RuntimeInner::new(
-            worker_less_scheduler_for_test(),
-        )));
+        // Attempt to install a second runtime: rejected (slot occupied). Bind a
+        // drop probe to the rejected runtime so the oracle counts only *its*
+        // free, immune to concurrent drops from parallel tests.
+        let rejected = Box::new(RuntimeInner::new(worker_less_scheduler_for_test()));
+        let probe = runtime::install_drop_probe_for_test(&raw const *rejected);
+        let installed = runtime::install_default(rejected);
         assert!(!installed, "second install must be rejected");
         // The rejected runtime is freed immediately, exactly once.
         assert_eq!(
-            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
-            before + 1,
+            probe.load(Ordering::SeqCst),
+            1,
             "install_default must free the rejected runtime exactly once"
         );
         // The originally-installed runtime is still the one in the slot.
@@ -5146,7 +5151,7 @@ mod tests {
     /// `drain_deferred_teardown_threads` → `rt_current()` would trap on a
     /// missing runtime mid-cleanup. A registered-but-not-yet-joined reaper that
     /// the cleanup joins is the proof the sweep saw an installed runtime; the
-    /// exact `RUNTIME_INNER_DROPS` delta proves the drop is the single final
+    /// exact per-instance drop-probe delta proves the drop is the single final
     /// step, never doubled and never driven by detaching the slot.
     #[test]
     fn runtime_cleanup_sweeps_before_detach_and_drops_runtime_once() {
@@ -5171,7 +5176,10 @@ mod tests {
             joined2.store(true, Ordering::Release);
         }));
 
-        let before = runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst);
+        // Bind a per-instance drop probe to the installed runtime so the oracle
+        // counts only its own drop, immune to concurrent parallel-test drops.
+        let probe =
+            runtime::install_drop_probe_for_test(runtime::default_runtime_ptr(Ordering::SeqCst));
 
         let cleanup_done = std::sync::Arc::new(AtomicBool::new(false));
         let cleanup_done2 = std::sync::Arc::clone(&cleanup_done);
@@ -5193,8 +5201,8 @@ mod tests {
             "runtime must stay installed through the sweep — detach is the FINAL step"
         );
         assert_eq!(
-            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
-            before,
+            probe.load(Ordering::SeqCst),
+            0,
             "runtime must not be dropped before the sweep completes"
         );
 
@@ -5211,8 +5219,8 @@ mod tests {
             "cleanup must detach the runtime as its final step"
         );
         assert_eq!(
-            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
-            before + 1,
+            probe.load(Ordering::SeqCst),
+            1,
             "cleanup must drop the runtime exactly once as the final teardown step"
         );
     }
@@ -5256,7 +5264,10 @@ mod tests {
             }
         }));
 
-        let before = runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst);
+        // Bind a per-instance drop probe to the installed runtime so the oracle
+        // counts only its own drop, immune to concurrent parallel-test drops.
+        let probe =
+            runtime::install_drop_probe_for_test(runtime::default_runtime_ptr(Ordering::SeqCst));
 
         let cleanup = thread::spawn(|| hew_runtime_cleanup());
 
@@ -5268,8 +5279,8 @@ mod tests {
             "runtime must stay installed through the supervisor-roots sweep"
         );
         assert_eq!(
-            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
-            before,
+            probe.load(Ordering::SeqCst),
+            0,
             "runtime must not be dropped before the supervisor-roots sweep completes"
         );
         assert!(
@@ -5287,8 +5298,8 @@ mod tests {
             "cleanup must detach the runtime as its final step"
         );
         assert_eq!(
-            runtime::RUNTIME_INNER_DROPS.load(Ordering::SeqCst),
-            before + 1,
+            probe.load(Ordering::SeqCst),
+            1,
             "cleanup must drop the runtime exactly once after sweeping supervisor roots"
         );
     }


### PR DESCRIPTION
## Problem

The four "runtime dropped exactly once" teardown oracles in `scheduler::tests` — `default_runtime_detaches_before_free_and_drops_exactly_once`, `second_install_is_noop_and_frees_the_rejected_runtime_once`, `runtime_cleanup_sweeps_before_detach_and_drops_runtime_once`, and `runtime_cleanup_frees_supervisor_root_before_detach` — asserted on a **delta of a single process-global counter** (`RUNTIME_INNER_DROPS`): read `before`, then require `before + 1` after the teardown under test.

Those oracles serialize among themselves via `SCHED_TEST_MUTEX`, but the counter was bumped by **every** `RuntimeInner` drop process-wide — including the many runtimes that tests in `monitor`, `pid`, `metrics`, `lambda_actor`, `actor`, and `runtime` build and drop *without* holding that mutex. Under parallel test execution, one such unrelated drop lands between an oracle's `before` read and its final assert, inflating the delta by one and failing the assertion (issue #2572: observed `16389` vs expected `16388`).

The scheduler drop path itself was never at fault — this is a **test-isolation defect in the oracle instrumentation**, exactly as the issue diagnoses.

## Fix

Replace the process-global counter with a **per-instance drop probe** carried inside `RuntimeInner` (`#[cfg(test)]` only):

- Each oracle binds a fresh `Arc<AtomicUsize>` to the specific runtime it is about to tear down, via a new `install_drop_probe_for_test(ptr)` helper (caller holds `SCHED_TEST_MUTEX`).
- The `#[cfg(test)]` `Drop` impl bumps only *that instance's* probe (taking it out of an interior-mutable `Option`), so an oracle counts exclusively its own runtime's drop and is immune to concurrent drops elsewhere. Assertions become `0`-before / `1`-after regardless of parallel load.
- The second-install oracle probes the rejected runtime *before* handing it to `install_default`, preserving the "rejected runtime freed exactly once" check.

**Production is unaffected:** the probe field, drop observer, and helper are all `#[cfg(test)]`; production still frees the inner by field-drop with no `Drop` impl.

## Verification

- Full `hew-runtime` lib suite (**2040 tests**) green across **four consecutive** default-parallelism runs — the scenario that previously flaked.
- `scheduler::tests` (39 tests incl. all four oracles) pass.
- `cargo fmt --check` and `cargo clippy --lib --tests` clean.

Closes #2572