### PR TITLE
fix(types): give each E_SUPERVISOR_* diagnostic a distinct kind

### DIFF
--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -209,7 +209,9 @@ impl Checker {
                 // A pool declares a fixed-size fleet; without `count:` the size
                 // is undefined. Fail closed rather than defaulting to a silent 1.
                 self.errors.push(TypeError::new(
-                    TypeErrorKind::InvalidOperation,
+                    TypeErrorKind::SupervisorError {
+                        subkind: SupervisorErrorKind::PoolCountMissing,
+                    },
                     span.clone(),
                     format!(
                         "E_SUPERVISOR_POOL_COUNT_MISSING: supervisor `{}` pool child `{}` is \
@@ -228,7 +230,9 @@ impl Checker {
             let resolved = self.subst.resolve(&count_ty);
             if !resolved.is_integer() && !matches!(resolved, Ty::IntLiteral | Ty::Error) {
                 self.errors.push(TypeError::new(
-                    TypeErrorKind::InvalidOperation,
+                    TypeErrorKind::SupervisorError {
+                        subkind: SupervisorErrorKind::PoolCountType,
+                    },
                     count_expr.1.clone(),
                     format!(
                         "E_SUPERVISOR_POOL_COUNT_TYPE: supervisor `{}` pool child `{}` `count:` \
@@ -252,7 +256,9 @@ impl Checker {
             match super::const_eval::eval_const_expr(count_expr, &const_env) {
                 Ok(0) => {
                     self.errors.push(TypeError::new(
-                        TypeErrorKind::InvalidOperation,
+                        TypeErrorKind::SupervisorError {
+                            subkind: SupervisorErrorKind::PoolCountNonPositive,
+                        },
                         count_expr.1.clone(),
                         format!(
                             "E_SUPERVISOR_POOL_COUNT_NON_POSITIVE: supervisor `{}` pool child \
@@ -263,7 +269,9 @@ impl Checker {
                 }
                 Err(super::const_eval::ConstEvalError::Overflow) => {
                     self.errors.push(TypeError::new(
-                        TypeErrorKind::InvalidOperation,
+                        TypeErrorKind::SupervisorError {
+                            subkind: SupervisorErrorKind::PoolCountNonPositive,
+                        },
                         count_expr.1.clone(),
                         format!(
                             "E_SUPERVISOR_POOL_COUNT_NON_POSITIVE: supervisor `{}` pool child \
@@ -300,7 +308,9 @@ impl Checker {
         for child in &sd.children {
             if let Some(handler) = self.actors_with_periodic_handlers.get(&child.actor_type) {
                 self.errors.push(TypeError::new(
-                    TypeErrorKind::InvalidOperation,
+                    TypeErrorKind::SupervisorError {
+                        subkind: SupervisorErrorKind::PeriodicChild,
+                    },
                     span.clone(),
                     format!(
                         "E_SUPERVISOR_PERIODIC_CHILD: supervisor `{}` child `{}` (actor `{}`) \
@@ -364,7 +374,9 @@ impl Checker {
                 // synthesis pass; this is the param-type gate.
                 if !ty_is_supervisor_init_reproducible(&param.ty) {
                     self.errors.push(TypeError::new(
-                        TypeErrorKind::InvalidOperation,
+                        TypeErrorKind::SupervisorError {
+                            subkind: SupervisorErrorKind::InitArgNonBitcopy,
+                        },
                         param.span.clone(),
                         format!(
                             "E_SUPERVISOR_INIT_ARG_NON_BITCOPY: supervisor `{}` child `{}` \
@@ -399,7 +411,9 @@ impl Checker {
         };
         if intensity.restarts < 0 {
             self.errors.push(TypeError::new(
-                TypeErrorKind::InvalidOperation,
+                TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::IntensityRestarts,
+                },
                 span.clone(),
                 format!(
                     "E_SUPERVISOR_INTENSITY_RESTARTS: supervisor `{}` has a negative restart \
@@ -411,7 +425,9 @@ impl Checker {
         match hew_parser::parse_duration_ns(&intensity.window) {
             Some(ns) if ns > 0 => {}
             Some(_) => self.errors.push(TypeError::new(
-                TypeErrorKind::InvalidOperation,
+                TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::IntensityWindow,
+                },
                 span.clone(),
                 format!(
                     "E_SUPERVISOR_INTENSITY_WINDOW: supervisor `{}` has a zero-length restart \
@@ -420,7 +436,9 @@ impl Checker {
                 ),
             )),
             None => self.errors.push(TypeError::new(
-                TypeErrorKind::InvalidOperation,
+                TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::IntensityWindow,
+                },
                 span.clone(),
                 format!(
                     "E_SUPERVISOR_INTENSITY_WINDOW: supervisor `{}` window `{}` is not a valid \
@@ -505,7 +523,9 @@ impl Checker {
                     continue;
                 }
                 self.errors.push(TypeError::new(
-                    TypeErrorKind::InvalidOperation,
+                    TypeErrorKind::SupervisorError {
+                        subkind: SupervisorErrorKind::PermanentOwnedHeap,
+                    },
                     span.clone(),
                     format!(
                         "E_SUPERVISOR_PERMANENT_OWNED_HEAP: supervisor `{}` child `{}` \
@@ -532,7 +552,9 @@ impl Checker {
                 }
                 std::collections::hash_map::Entry::Occupied(_) => {
                     self.errors.push(TypeError::new(
-                        TypeErrorKind::DuplicateDefinition,
+                        TypeErrorKind::SupervisorError {
+                            subkind: SupervisorErrorKind::DuplicateChild,
+                        },
                         span.clone(),
                         format!(
                             "E_SUPERVISOR_DUPLICATE_CHILD: supervisor `{}` declares child `{}` \
@@ -555,7 +577,9 @@ impl Checker {
             // simple_one_for_one: exactly one pool child, no static children.
             if pool_children.len() != 1 {
                 self.errors.push(TypeError::new(
-                    TypeErrorKind::InvalidOperation,
+                    TypeErrorKind::SupervisorError {
+                        subkind: SupervisorErrorKind::StrategyPoolMismatch,
+                    },
                     span.clone(),
                     format!(
                         "E_SUPERVISOR_STRATEGY_POOL_MISMATCH: supervisor `{}` uses \
@@ -569,7 +593,9 @@ impl Checker {
             if !static_children.is_empty() {
                 let names: Vec<&str> = static_children.iter().map(|c| c.name.as_str()).collect();
                 self.errors.push(TypeError::new(
-                    TypeErrorKind::InvalidOperation,
+                    TypeErrorKind::SupervisorError {
+                        subkind: SupervisorErrorKind::StrategyPoolMismatch,
+                    },
                     span.clone(),
                     format!(
                         "E_SUPERVISOR_STRATEGY_POOL_MISMATCH: supervisor `{}` uses \
@@ -590,7 +616,9 @@ impl Checker {
                 SupervisorStrategy::SimpleOneForOne => unreachable!(),
             });
             self.errors.push(TypeError::new(
-                TypeErrorKind::InvalidOperation,
+                TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::StrategyPoolMismatch,
+                },
                 span.clone(),
                 format!(
                     "E_SUPERVISOR_STRATEGY_POOL_MISMATCH: supervisor `{}` uses `{}` strategy \
@@ -621,7 +649,9 @@ impl Checker {
                 // ── Key resolution: sibling must exist ──────────────────────
                 let Some(&sibling_type) = sibling_types.get(sibling_name.as_str()) else {
                     self.errors.push(TypeError::new(
-                        TypeErrorKind::InvalidOperation,
+                        TypeErrorKind::SupervisorError {
+                            subkind: SupervisorErrorKind::WiredToUnknownSibling,
+                        },
                         span.clone(),
                         format!(
                             "E_SUPERVISOR_WIRED_TO_UNKNOWN_SIBLING: in supervisor `{}`, \
@@ -681,7 +711,9 @@ impl Checker {
 
         let Some(param) = params.iter().find(|param| param.name == param_key) else {
             self.errors.push(TypeError::new(
-                TypeErrorKind::InvalidOperation,
+                TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::WiredToTypeMismatch,
+                },
                 span.clone(),
                 format!(
                     "E_SUPERVISOR_WIRED_TO_TYPE_MISMATCH: in supervisor `{supervisor_name}`, \
@@ -701,7 +733,9 @@ impl Checker {
 
         if !type_ok {
             self.errors.push(TypeError::new(
-                TypeErrorKind::InvalidOperation,
+                TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::WiredToTypeMismatch,
+                },
                 span.clone(),
                 format!(
                     "E_SUPERVISOR_WIRED_TO_TYPE_MISMATCH: in supervisor `{supervisor_name}`, \
@@ -796,7 +830,9 @@ impl Checker {
             let mut sorted_cycle = cycle_nodes.clone();
             sorted_cycle.sort_unstable();
             self.errors.push(TypeError::new(
-                TypeErrorKind::InvalidOperation,
+                TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::WiredCycle,
+                },
                 span.clone(),
                 format!(
                     "E_SUPERVISOR_WIRED_CYCLE: supervisor `{}` has a `wired_to` dependency \

--- a/hew-types/src/check/mod.rs
+++ b/hew-types/src/check/mod.rs
@@ -1,7 +1,7 @@
 //! Bidirectional type checker for Hew programs.
 
 use crate::builtin_names::{builtin_named_type, builtin_named_types, BuiltinMethodRuntime};
-use crate::error::{TypeError, TypeErrorKind};
+use crate::error::{SupervisorErrorKind, TypeError, TypeErrorKind};
 use crate::module_registry::ModuleError;
 use crate::resolved_ty::{BoundaryError, ResolvedTy};
 use crate::traits::MarkerTrait;

--- a/hew-types/src/check/tests/actor_fields.rs
+++ b/hew-types/src/check/tests/actor_fields.rs
@@ -353,10 +353,20 @@ mod every_attribute {
     use super::*;
 
     fn invalid_op_contains(output: &TypeCheckOutput, fragment: &str) -> bool {
-        output
-            .errors
-            .iter()
-            .any(|e| e.kind == TypeErrorKind::InvalidOperation && e.message.contains(fragment))
+        output.errors.iter().any(|e| {
+            // Most `#[every]` diagnostics use the generic `InvalidOperation`
+            // kind; the two supervisor-periodic-child cases now carry the
+            // distinct `SupervisorError { PeriodicChild }` kind (#2377). Accept
+            // either so this fragment helper keeps checking the diagnostic body
+            // regardless of which of the two related kinds emitted it.
+            matches!(
+                e.kind,
+                TypeErrorKind::InvalidOperation
+                    | TypeErrorKind::SupervisorError {
+                        subkind: SupervisorErrorKind::PeriodicChild,
+                    }
+            ) && e.message.contains(fragment)
+        })
     }
 
     #[test]

--- a/hew-types/src/check/tests/collections.rs
+++ b/hew-types/src/check/tests/collections.rs
@@ -1234,7 +1234,10 @@ fn supervisor_wired_to_rejects_remote_pid_by_role() {
 
     assert!(
         output.errors.iter().any(|error| {
-            error.kind == TypeErrorKind::InvalidOperation
+            error.kind
+                == TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::WiredToTypeMismatch,
+                }
                 && error
                     .message
                     .contains("E_SUPERVISOR_WIRED_TO_TYPE_MISMATCH")

--- a/hew-types/src/check/tests/supervisor.rs
+++ b/hew-types/src/check/tests/supervisor.rs
@@ -21,7 +21,10 @@ fn supervisor_permanent_owned_heap_rejects_vec_field() {
 
     assert!(
         output.errors.iter().any(|e| {
-            e.kind == TypeErrorKind::InvalidOperation
+            e.kind
+                == TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::PermanentOwnedHeap,
+                }
                 && e.message.contains("E_SUPERVISOR_PERMANENT_OWNED_HEAP")
                 && e.message.contains("worker")
                 && e.message.contains("Counter")
@@ -49,7 +52,10 @@ fn supervisor_permanent_owned_heap_rejects_string_field() {
 
     assert!(
         output.errors.iter().any(|e| {
-            e.kind == TypeErrorKind::InvalidOperation
+            e.kind
+                == TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::PermanentOwnedHeap,
+                }
                 && e.message.contains("E_SUPERVISOR_PERMANENT_OWNED_HEAP")
                 && e.message.contains("label")
         }),
@@ -75,7 +81,10 @@ fn supervisor_permanent_owned_heap_rejects_hashmap_field() {
 
     assert!(
         output.errors.iter().any(|e| {
-            e.kind == TypeErrorKind::InvalidOperation
+            e.kind
+                == TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::PermanentOwnedHeap,
+                }
                 && e.message.contains("E_SUPERVISOR_PERMANENT_OWNED_HEAP")
                 && e.message.contains("entries")
         }),
@@ -101,7 +110,10 @@ fn supervisor_permanent_owned_heap_rejects_hashset_field() {
 
     assert!(
         output.errors.iter().any(|e| {
-            e.kind == TypeErrorKind::InvalidOperation
+            e.kind
+                == TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::PermanentOwnedHeap,
+                }
                 && e.message.contains("E_SUPERVISOR_PERMANENT_OWNED_HEAP")
                 && e.message.contains("seen")
         }),
@@ -127,7 +139,10 @@ fn supervisor_permanent_owned_heap_rejects_bytes_field() {
 
     assert!(
         output.errors.iter().any(|e| {
-            e.kind == TypeErrorKind::InvalidOperation
+            e.kind
+                == TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::PermanentOwnedHeap,
+                }
                 && e.message.contains("E_SUPERVISOR_PERMANENT_OWNED_HEAP")
                 && e.message.contains("data")
         }),
@@ -154,7 +169,10 @@ fn supervisor_implicit_permanent_owned_heap_rejects() {
 
     assert!(
         output.errors.iter().any(|e| {
-            e.kind == TypeErrorKind::InvalidOperation
+            e.kind
+                == TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::PermanentOwnedHeap,
+                }
                 && e.message.contains("E_SUPERVISOR_PERMANENT_OWNED_HEAP")
                 && e.message.contains("items")
         }),
@@ -182,7 +200,10 @@ fn supervisor_permanent_owned_heap_rejects_nested_vec() {
 
     assert!(
         output.errors.iter().any(|e| {
-            e.kind == TypeErrorKind::InvalidOperation
+            e.kind
+                == TypeErrorKind::SupervisorError {
+                    subkind: SupervisorErrorKind::PermanentOwnedHeap,
+                }
                 && e.message.contains("E_SUPERVISOR_PERMANENT_OWNED_HEAP")
                 && e.message.contains("matrix")
         }),
@@ -959,4 +980,81 @@ fn supervisor_child_no_init_args_string_field_not_flagged_by_bitcopy_wall() {
         "child with no init args must not trigger the bitcopy wall; errors: {:#?}",
         output.errors
     );
+}
+
+// ── Machine-readable kind wiring (issue #2377) ─────────────────────────────
+// The supervisor diagnostics must expose distinct `as_kind_str()` values
+// (JSON `code` / LSP `data.kind`), not the generic `InvalidOperation`. These
+// assert the end-to-end wiring for a real emitted diagnostic, not just the
+// enum table in error.rs.
+
+#[test]
+fn supervisor_permanent_owned_heap_reports_distinct_kind() {
+    let output = check_source(
+        r"
+        actor Counter {
+            let count: Vec<i64>;
+            receive fn inc() {}
+        }
+
+        supervisor App {
+            child worker: Counter restart: permanent;
+        }
+        ",
+    );
+
+    let err = output
+        .errors
+        .iter()
+        .find(|e| e.message.contains("E_SUPERVISOR_PERMANENT_OWNED_HEAP"))
+        .expect("permanent-owned-heap diagnostic must be emitted");
+
+    assert_eq!(
+        err.kind,
+        TypeErrorKind::SupervisorError {
+            subkind: SupervisorErrorKind::PermanentOwnedHeap,
+        }
+    );
+    assert_eq!(err.kind.as_kind_str(), "SupervisorPermanentOwnedHeap");
+    // Regression guard for #2377: must no longer collapse to the generic kind.
+    assert_ne!(err.kind.as_kind_str(), "InvalidOperation");
+}
+
+#[test]
+fn supervisor_wired_cycle_reports_distinct_kind() {
+    let output = check_source(
+        r"
+        actor ActorA {
+            init(dep: LocalPid<ActorB>) {}
+            receive fn ping() {}
+        }
+        actor ActorB {
+            init(dep: LocalPid<ActorA>) {}
+            receive fn ping() {}
+        }
+
+        supervisor CycleApp {
+            strategy: one_for_one
+
+            child a: ActorA wired_to: { dep: b };
+            child b: ActorB wired_to: { dep: a };
+        }
+        ",
+    );
+
+    let err = output
+        .errors
+        .iter()
+        .find(|e| e.message.contains("E_SUPERVISOR_WIRED_CYCLE"))
+        .expect("wired_to cycle a->b->a must emit E_SUPERVISOR_WIRED_CYCLE");
+    assert_eq!(
+        err.kind,
+        TypeErrorKind::SupervisorError {
+            subkind: SupervisorErrorKind::WiredCycle,
+        }
+    );
+    assert_eq!(err.kind.as_kind_str(), "SupervisorWiredCycle");
+    // A different supervisor diagnostic yields a different kind string,
+    // proving the family no longer shares one indistinguishable kind.
+    assert_ne!(err.kind.as_kind_str(), "SupervisorPermanentOwnedHeap");
 }

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -515,6 +515,77 @@ impl fmt::Display for TypeError {
 
 impl std::error::Error for TypeError {}
 
+/// The specific supervisor-declaration check that failed.
+///
+/// Every arm corresponds to exactly one `E_SUPERVISOR_*` diagnostic code and
+/// maps to a distinct `TypeErrorKind::as_kind_str()` value, so JSON `code` and
+/// LSP `data.kind` consumers can differentiate the supervisor diagnostics
+/// without parsing the inline message prefix. Adding a new supervisor
+/// diagnostic means adding an arm here; the exhaustive (catch-all-free) match
+/// in `as_kind_str` then forces a matching kind string, so a new diagnostic
+/// cannot silently collapse into an existing one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SupervisorErrorKind {
+    /// `E_SUPERVISOR_POOL_COUNT_MISSING`: a `pool` child omits the required
+    /// `count:` argument.
+    PoolCountMissing,
+    /// `E_SUPERVISOR_POOL_COUNT_TYPE`: a pool child's `count:` is not an integer.
+    PoolCountType,
+    /// `E_SUPERVISOR_POOL_COUNT_NON_POSITIVE`: a pool child's compile-time
+    /// `count:` is zero or negative.
+    PoolCountNonPositive,
+    /// `E_SUPERVISOR_PERIODIC_CHILD`: a supervised child's actor declares an
+    /// `#[every]` periodic handler, which is not armed for supervised children.
+    PeriodicChild,
+    /// `E_SUPERVISOR_INIT_ARG_NON_BITCOPY`: a supervised child init arg has a
+    /// type the init-closure restart thunk cannot reproduce per incarnation.
+    InitArgNonBitcopy,
+    /// `E_SUPERVISOR_INTENSITY_RESTARTS`: a negative `intensity:` restart budget.
+    IntensityRestarts,
+    /// `E_SUPERVISOR_INTENSITY_WINDOW`: the `intensity:` window is zero-length or
+    /// not a valid duration literal.
+    IntensityWindow,
+    /// `E_SUPERVISOR_PERMANENT_OWNED_HEAP`: a permanent child's state carries an
+    /// owned-heap field that byte-copy restart would alias.
+    PermanentOwnedHeap,
+    /// `E_SUPERVISOR_DUPLICATE_CHILD`: two children share a name.
+    DuplicateChild,
+    /// `E_SUPERVISOR_STRATEGY_POOL_MISMATCH`: `pool` children and the chosen
+    /// strategy are incompatible.
+    StrategyPoolMismatch,
+    /// `E_SUPERVISOR_WIRED_TO_UNKNOWN_SIBLING`: a `wired_to` value names a child
+    /// that is not declared in this supervisor.
+    WiredToUnknownSibling,
+    /// `E_SUPERVISOR_WIRED_TO_TYPE_MISMATCH`: a `wired_to` key has no matching
+    /// init parameter, or the parameter type is not `LocalPid<sibling>`.
+    WiredToTypeMismatch,
+    /// `E_SUPERVISOR_WIRED_CYCLE`: the `wired_to` dependency graph has a cycle.
+    WiredCycle,
+}
+
+impl SupervisorErrorKind {
+    /// The distinct machine-readable kind string for this supervisor
+    /// diagnostic, surfaced through `TypeErrorKind::as_kind_str()`.
+    #[must_use]
+    pub fn as_kind_str(self) -> &'static str {
+        match self {
+            Self::PoolCountMissing => "SupervisorPoolCountMissing",
+            Self::PoolCountType => "SupervisorPoolCountType",
+            Self::PoolCountNonPositive => "SupervisorPoolCountNonPositive",
+            Self::PeriodicChild => "SupervisorPeriodicChild",
+            Self::InitArgNonBitcopy => "SupervisorInitArgNonBitcopy",
+            Self::IntensityRestarts => "SupervisorIntensityRestarts",
+            Self::IntensityWindow => "SupervisorIntensityWindow",
+            Self::PermanentOwnedHeap => "SupervisorPermanentOwnedHeap",
+            Self::DuplicateChild => "SupervisorDuplicateChild",
+            Self::StrategyPoolMismatch => "SupervisorStrategyPoolMismatch",
+            Self::WiredToUnknownSibling => "SupervisorWiredToUnknownSibling",
+            Self::WiredToTypeMismatch => "SupervisorWiredToTypeMismatch",
+            Self::WiredCycle => "SupervisorWiredCycle",
+        }
+    }
+}
+
 /// The specific kind of type error.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeErrorKind {
@@ -552,6 +623,14 @@ pub enum TypeErrorKind {
     InvalidSend,
     /// Operation not supported for this type
     InvalidOperation,
+    /// A supervisor-declaration check failed. `subkind` names the specific
+    /// `E_SUPERVISOR_*` diagnostic so JSON `code` / LSP `data.kind` consumers
+    /// can differentiate the supervisor family instead of collapsing every
+    /// supervisor error onto one generic kind.
+    SupervisorError {
+        /// The specific supervisor check that failed.
+        subkind: SupervisorErrorKind,
+    },
     /// Execution-context reader used outside an actor handler context
     ContextReaderOutsideHandler,
     /// Wrong number of arguments
@@ -1189,6 +1268,7 @@ impl TypeErrorKind {
             Self::AmbiguousType => "AmbiguousType",
             Self::InvalidSend => "InvalidSend",
             Self::InvalidOperation => "InvalidOperation",
+            Self::SupervisorError { subkind } => subkind.as_kind_str(),
             Self::ContextReaderOutsideHandler => "ContextReaderOutsideHandler",
             Self::ArityMismatch => "ArityMismatch",
             Self::BoundsNotSatisfied => "BoundsNotSatisfied",
@@ -1801,5 +1881,62 @@ mod tests {
             err.to_string(),
             "no field `colour` on type `HashMap<string, i32>`"
         );
+    }
+
+    /// Every supervisor subkind must produce a distinct, stable `as_kind_str`
+    /// value distinct from the generic `InvalidOperation` and from each other,
+    /// so JSON `code` / LSP `data.kind` consumers can tell the supervisor
+    /// diagnostics apart. The `ALL` slice below is the exhaustiveness guard:
+    /// adding a `SupervisorErrorKind` arm without adding it here fails this
+    /// test's uniqueness/count assertions, and the catch-all-free `match` in
+    /// `SupervisorErrorKind::as_kind_str` fails to compile if the arm has no
+    /// string — so a new supervisor diagnostic cannot silently collapse onto an
+    /// existing kind.
+    #[test]
+    fn test_supervisor_subkind_kind_strings_are_distinct() {
+        use std::collections::HashSet;
+
+        const ALL: &[SupervisorErrorKind] = &[
+            SupervisorErrorKind::PoolCountMissing,
+            SupervisorErrorKind::PoolCountType,
+            SupervisorErrorKind::PoolCountNonPositive,
+            SupervisorErrorKind::PeriodicChild,
+            SupervisorErrorKind::InitArgNonBitcopy,
+            SupervisorErrorKind::IntensityRestarts,
+            SupervisorErrorKind::IntensityWindow,
+            SupervisorErrorKind::PermanentOwnedHeap,
+            SupervisorErrorKind::DuplicateChild,
+            SupervisorErrorKind::StrategyPoolMismatch,
+            SupervisorErrorKind::WiredToUnknownSibling,
+            SupervisorErrorKind::WiredToTypeMismatch,
+            SupervisorErrorKind::WiredCycle,
+        ];
+
+        // 13 distinct E_SUPERVISOR_* codes → 13 subkinds.
+        assert_eq!(ALL.len(), 13, "expected 13 supervisor subkinds");
+
+        let via_subkind: HashSet<&'static str> = ALL.iter().map(|s| s.as_kind_str()).collect();
+        assert_eq!(
+            via_subkind.len(),
+            ALL.len(),
+            "supervisor subkind kind strings must be pairwise distinct"
+        );
+
+        // The wrapped-in-TypeErrorKind path must agree with the subkind path
+        // and must never collapse to the generic InvalidOperation string.
+        for &subkind in ALL {
+            let wrapped = TypeErrorKind::SupervisorError { subkind };
+            assert_eq!(wrapped.as_kind_str(), subkind.as_kind_str());
+            assert_ne!(
+                wrapped.as_kind_str(),
+                TypeErrorKind::InvalidOperation.as_kind_str(),
+                "supervisor kind must not collapse to InvalidOperation"
+            );
+            assert!(
+                wrapped.as_kind_str().starts_with("Supervisor"),
+                "supervisor kind string should be Supervisor-prefixed: {}",
+                wrapped.as_kind_str()
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #2377.

## Problem

All supervisor-declaration checks in `hew-types` reported through the single generic `TypeErrorKind::InvalidOperation` (and `DuplicateDefinition` for the duplicate-child case). Both the JSON `code` field (`TypeErrorKind::as_kind_str()`) and the LSP `data.kind` field therefore collapsed every supervisor diagnostic onto one indistinguishable value — the inline `E_SUPERVISOR_*: ` message prefix was the *only* machine-readable differentiator, forcing JSON/LSP consumers to string-parse the message body.

## Fix

- New `SupervisorErrorKind` enum: one arm per distinct `E_SUPERVISOR_*` code (13 total).
- New `TypeErrorKind::SupervisorError { subkind }` variant; `as_kind_str()` delegates to the subkind, so each supervisor diagnostic now surfaces a distinct, stable `Supervisor*` kind string through both the JSON and LSP paths.
- All 18 emission sites in `check/items.rs` rerouted onto the matching subkind (strategy-pool-mismatch has 3 sites; wired-to-type-mismatch and pool-count-non-positive 2 each).

## Scope discipline

- **Severity unchanged** — set independently of kind (still `Error`).
- **Inline `E_SUPERVISOR_*` message prefixes retained verbatim**, so every existing message-text assertion stays green. Dropping those prefixes (the way the 10 other single-kind diagnostics already had theirs dropped) is the follow-up this issue explicitly unblocks; it is intentionally **not** done here.
- **Future-regression guard**: `SupervisorErrorKind::as_kind_str` is a catch-all-free `match`, and the `error.rs` uniqueness test enumerates all 13 subkinds — a new supervisor diagnostic cannot compile without its own kind string and cannot silently collapse onto an existing one.

## Tests

- `error.rs`: `test_supervisor_subkind_kind_strings_are_distinct` — pairwise-distinct kind strings, agreement between the subkind and wrapped paths, never `InvalidOperation`, and the 13-count exhaustiveness pin.
- `check/tests/supervisor.rs`: two end-to-end checker tests assert a real emitted permanent-owned-heap and wired-cycle diagnostic carry their distinct kind strings (not `InvalidOperation`).
- Updated the test call sites that keyed on the old kind: the seven permanent-owned-heap assertions, the wired-to-type-mismatch RemotePid-role rejection, and the `#[every]` `invalid_op_contains` helper (now also accepts the periodic-child supervisor kind). All message-text-only assertions were untouched.

`cargo test -p hew-types` — 1660 lib tests + all integration suites (incl. `registry_core/supervisor_check`) pass; `cargo fmt`/`clippy` clean. Load-bearing check: reverting one emission site back to `InvalidOperation` fails the new distinct-kind test with `left: InvalidOperation, right: SupervisorError { subkind: PermanentOwnedHeap }`.