### PR TITLE
fix(std): release digit slices in try_to_int

### DIFF
--- a/hew-cli/tests/string_try_to_int_leak_oracle.rs
+++ b/hew-cli/tests/string_try_to_int_leak_oracle.rs
@@ -1,0 +1,57 @@
+//! Leak oracle for `std::string::try_to_int`.
+//!
+//! Each parsed character is obtained with `string.slice`, which allocates a
+//! fresh heap string. The parser must release that temporary after
+//! `digit_value` borrows it, both on the loop back-edge and on early returns.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::assert_frame_slope_below_tolerance;
+
+fn valid_multi_digit_source(frames: usize) -> String {
+    let expected = frames * 1_234_567;
+    format!(
+        "import std::string;\n\
+         fn main() -> i64 {{\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   for i in 0..{frames} {{\n\
+         \x20       match string.try_to_int(\"1234567\") {{\n\
+         \x20           Ok(value) => {{ total = total + value; }},\n\
+         \x20           Err(_) => {{ return 91; }},\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         \x20   if total == {expected} {{ 0 }} else {{ 92 }}\n\
+         }}\n"
+    )
+}
+
+fn invalid_trailing_digit_source(frames: usize) -> String {
+    format!(
+        "import std::string;\n\
+         fn main() -> i64 {{\n\
+         \x20   var failures: i64 = 0;\n\
+         \x20   for i in 0..{frames} {{\n\
+         \x20       match string.try_to_int(\"123456x\") {{\n\
+         \x20           Ok(_) => {{ return 93; }},\n\
+         \x20           Err(_) => {{ failures = failures + 1; }},\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         \x20   if failures == {frames} {{ 0 }} else {{ 94 }}\n\
+         }}\n"
+    )
+}
+
+#[test]
+fn valid_multi_digit_parse_has_no_per_digit_leak_slope() {
+    assert_frame_slope_below_tolerance("try_to_int_valid_multi_digit", valid_multi_digit_source);
+}
+
+#[test]
+fn invalid_digit_early_return_has_no_per_digit_leak_slope() {
+    assert_frame_slope_below_tolerance(
+        "try_to_int_invalid_trailing_digit",
+        invalid_trailing_digit_source,
+    );
+}

--- a/std/string.hew
+++ b/std/string.hew
@@ -112,7 +112,11 @@ pub fn try_to_int(s: string) -> Result<i64, string> {
     };
     var result = 0;
     for i in start .. slen {
-        let d = digit_value(s.slice(i, i + 1));
+        let digit = s.slice(i, i + 1);
+        let d = digit_value(digit);
+        unsafe {
+            hew_string_drop(digit)
+        };
         if d < 0 {
             return Err("string.try_to_int: invalid integer literal");
         }
@@ -780,7 +784,8 @@ pub trait ToString {
     fn to_str(val: Self) -> string;
 }
 
-// ── FFI binding (char-code-to-string has no builtin equivalent) ─────
+// ── FFI bindings ─────────────────────────────────────────────────────
 extern "C" {
     fn hew_char_to_string(code: i32) -> string;
+    fn hew_string_drop(consume s: string);
 }


### PR DESCRIPTION
## Summary

`try_to_int`'s digit-scanning loop allocated a fresh heap string per character via `slice(i, i+1)`, passed it to `digit_value` (which only borrows it), and never released it. Every digit scanned during int parsing leaked one small string allocation. I now explicitly release each digit slice after `digit_value` consumes it, on every exit path (loop continuation, invalid-digit return, overflow return).

## Verification

- Leak oracle (`hew-cli/tests/string_try_to_int_leak_oracle.rs`): leaked-node count scaled 21→350 with input length before the fix, flat 0→0 after
- 33 `string.hew` tests: pass (multi-digit, signed, invalid input, i64 bounds, overflow)
- 72 stdlib checks: pass
- Full `tests/hew/` suite: 1081 passed, 0 failed
- `cargo fmt`, `make hew-fmt`: clean

## Out of scope

- The `try_to_float` family (`find_exponent_index`, `is_valid_float_significand`, `parse_float_significand`, `float_parse_start`) has the same per-character slice leak, confirmed separately (66→1100 nodes). Pre-existing, not introduced by this change, tracked as a follow-up fix.
