### PR TITLE
fix(hir): reject missing spawned closure capture facts

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -24521,7 +24521,7 @@ impl LowerCtx {
                 // The closure body type will be checked after lowering via checker expr_types
                 // For now, we rely on the inline checks at lowering time
 
-                // (3) Check captures are Send (or conservatively reject if facts missing)
+                // (3) Check captures are Send.
                 let closure_span_key = self.mk_key(&function.1);
                 if let Some(captures) = self.closure_capture_facts.get(&closure_span_key) {
                     for capture in captures {
@@ -24540,12 +24540,15 @@ impl LowerCtx {
                         }
                     }
                 } else {
-                    // FC-P1-A1 Blocker 3: Conservative reject when capture facts missing
-                    // (Treat empty/missing as unknown — fail closed)
-                    // Note: Zero-param closures with no captures are OK (empty vec is different from missing entry)
-                    // We only warn here if there's actually a capture syntax present
-                    // A production implementation would track whether the closure has capture syntax
-                    // For now, we accept missing facts (assume no captures if not provided by checker)
+                    self.diagnostics.push(HirDiagnostic::new(
+                        HirDiagnosticKind::CheckerBoundaryViolation {
+                            name: "closure literal".to_string(),
+                            reason: "closure_capture_facts has no record for closure literal span"
+                                .to_string(),
+                        },
+                        span.clone(),
+                        "closure literal reached HIR without checker capture metadata",
+                    ));
                 }
             }
             _ => {
@@ -27091,9 +27094,17 @@ fn check_fork_child_shape(
                         ));
                     }
                 }
+            } else {
+                ctx.diagnostics.push(HirDiagnostic::new(
+                    HirDiagnosticKind::CheckerBoundaryViolation {
+                        name: "closure literal".to_string(),
+                        reason: "closure_capture_facts has no record for closure literal span"
+                            .to_string(),
+                    },
+                    span.clone(),
+                    "closure literal reached HIR without checker capture metadata",
+                ));
             }
-            // Note: Missing closure_capture_facts is treated as "no captures" (acceptable)
-            // since checker only populates this for closures with actual captures.
         }
         _ => {
             ctx.diagnostics.push(HirDiagnostic::new(

--- a/hew-hir/tests/concurrency/task_gates_type_dependent.rs
+++ b/hew-hir/tests/concurrency/task_gates_type_dependent.rs
@@ -135,3 +135,51 @@ fn checker_pipeline_rc_capture_emits_non_send_diagnostic() {
         "non-Send spawned closure capture must make lowering fatal"
     );
 }
+
+#[test]
+fn missing_capture_facts_for_forked_closure_emit_boundary_diagnostics() {
+    let source = r"
+        fn main() {
+            let k: i64 = 1;
+            scope {
+                fork child = (move || { let _ = k; })();
+            }
+        }
+    ";
+    let (parsed, mut tco) = support::checker_pipeline::typecheck_source(source);
+    assert!(
+        tco.errors.is_empty(),
+        "forked closure fixture must typecheck cleanly: {:#?}",
+        tco.errors
+    );
+    assert_eq!(
+        tco.closure_capture_facts.len(),
+        1,
+        "test setup requires one checker-produced closure capture entry: {:#?}",
+        tco.closure_capture_facts
+    );
+    tco.closure_capture_facts.clear();
+
+    let output = lower_program_host_target(&parsed.program, &tco, &ResolutionCtx);
+    let boundary_count = output
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            matches!(
+                &diagnostic.kind,
+                HirDiagnosticKind::CheckerBoundaryViolation { name, reason }
+                    if name == "closure literal"
+                        && reason == "closure_capture_facts has no record for closure literal span"
+            )
+        })
+        .count();
+    assert_eq!(
+        boundary_count, 3,
+        "ordinary lowering and both spawned-closure validators must reject missing capture facts; got {:#?}",
+        output.diagnostics
+    );
+    assert!(
+        output.into_result().is_err(),
+        "missing spawned-closure capture facts must make lowering fatal"
+    );
+}


### PR DESCRIPTION
## Summary

The spawn-time Send-safety check for closure captures silently accepted a missing `closure_capture_facts` entry as "no captures," when a missing entry actually means the checker never visited that closure literal — a real checker/lowering boundary violation. The comment above this code claimed fail-closed behavior; the code did the opposite. Both spawn-time sites now emit `CheckerBoundaryViolation` on a missing entry, matching the sibling ordinary-closure path that already handled this correctly.

## Verification

- New regression test: fails pre-fix (only 1 of 3 validator sites emitted the diagnostic), passes post-fix (all 3)
- Existing non-Send-capture diagnostic path unchanged and still passing
- `make test-lane CRATE=hew-hir`: 512 passed
- `cargo check --workspace`: clean

## Out of scope

None.
