### PR TITLE
fix(runtime): report closed non-blocking sends

### DIFF
--- a/hew-cabi/src/sink.rs
+++ b/hew-cabi/src/sink.rs
@@ -136,14 +136,34 @@ pub fn take_last_errno() -> i32 {
 
 // ── Sink handle ───────────────────────────────────────────────────────────────
 
+/// Result of a non-blocking sink write attempt.
+#[must_use]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(i32)]
+pub enum TrySendResult {
+    /// The item was accepted by the sink.
+    Accepted = 0,
+    /// The sink or its receiving peer is closed.
+    Closed = 1,
+    /// The sink is open, but its bounded buffer has no capacity.
+    Full = 2,
+}
+
+impl TrySendResult {
+    /// Return the stable C ABI status code for this result.
+    #[must_use]
+    pub const fn into_abi_code(self) -> i32 {
+        self as i32
+    }
+}
+
 trait SinkOps: Send {
     fn write_item(&mut self, data: &[u8]);
-    /// Non-blocking write attempt. Returns `true` if the item was accepted,
-    /// `false` if the backing buffer is full. The default delegates to
-    /// `write_item` (always blocks, always returns `true`).
-    fn try_write_item(&mut self, data: &[u8]) -> bool {
+    /// Non-blocking write attempt. The default delegates to `write_item`, which
+    /// blocks until the item is accepted.
+    fn try_write_item(&mut self, data: &[u8]) -> TrySendResult {
         self.write_item(data);
-        true
+        TrySendResult::Accepted
     }
     fn flush(&mut self);
     fn close(&mut self);
@@ -212,14 +232,14 @@ impl HewSink {
 
     /// Attempt to write one item without blocking.
     ///
-    /// Returns `true` if the item was accepted; `false` if the backing buffer
-    /// was full and the write would have blocked. For non-channel sinks the
-    /// default behaviour is to block (delegating to `write_item`) and return
-    /// `true` — callers that need genuine non-blocking semantics should create
-    /// the sink with [`into_channel_sink_ptr`].
-    pub fn try_write_item(&mut self, data: &[u8]) -> bool {
+    /// Returns whether the item was accepted, the buffer was full, or the sink
+    /// was closed. For non-channel sinks the default behaviour is to block
+    /// (delegating to `write_item`) until the item is accepted — callers that
+    /// need genuine non-blocking semantics should create the sink with
+    /// [`into_channel_sink_ptr`].
+    pub fn try_write_item(&mut self, data: &[u8]) -> TrySendResult {
         let Some(inner) = self.inner.as_mut() else {
-            return true; // closed sink: item silently discarded, not "full"
+            return TrySendResult::Closed;
         };
         inner.try_write_item(data)
     }
@@ -312,7 +332,7 @@ pub fn into_write_sink_ptr(backing: impl Write + Send + 'static) -> *mut HewSink
 // ── Channel-backed sink ───────────────────────────────────────────────────────
 
 /// Channel sink: wraps an `mpsc::SyncSender` and provides genuine non-blocking
-/// `try_write_item` semantics (returns `false` when the queue is at capacity).
+/// `try_write_item` semantics.
 struct ChannelSinkBacking {
     tx: std::sync::mpsc::SyncSender<Vec<u8>>,
 }
@@ -328,14 +348,13 @@ impl SinkOps for ChannelSinkBacking {
         let _ = self.tx.send(data.to_vec());
     }
 
-    /// Non-blocking send. Returns `false` when the channel queue is full.
-    fn try_write_item(&mut self, data: &[u8]) -> bool {
+    /// Non-blocking send that distinguishes acceptance, backpressure, and closure.
+    fn try_write_item(&mut self, data: &[u8]) -> TrySendResult {
         use std::sync::mpsc::TrySendError;
         match self.tx.try_send(data.to_vec()) {
-            // Disconnected: receiver is gone; item silently discarded.
-            // Report success so callers don't mistake a closed channel for a full one.
-            Ok(()) | Err(TrySendError::Disconnected(_)) => true,
-            Err(TrySendError::Full(_)) => false,
+            Ok(()) => TrySendResult::Accepted,
+            Err(TrySendError::Disconnected(_)) => TrySendResult::Closed,
+            Err(TrySendError::Full(_)) => TrySendResult::Full,
         }
     }
 
@@ -351,8 +370,8 @@ impl SinkOps for ChannelSinkBacking {
 /// Create a heap-allocated [`HewSink`] backed by a bounded `mpsc` channel sender.
 ///
 /// Unlike [`into_write_sink_ptr`], the returned sink supports genuine non-blocking
-/// writes via [`HewSink::try_write_item`]: the call returns `false` immediately if
-/// the channel queue is at capacity rather than blocking until space is available.
+/// writes via [`HewSink::try_write_item`], distinguishing an accepted item from a
+/// full queue or a disconnected receiver.
 ///
 /// # Ownership
 ///
@@ -714,5 +733,30 @@ mod tests {
         let items = written.lock().unwrap();
         assert_eq!(items.as_slice(), &[b"abc".to_vec()]);
         assert_eq!(close_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn channel_sink_try_write_distinguishes_accepted_full_and_closed() {
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        let ptr = into_channel_sink_ptr(tx);
+        // SAFETY: ptr was created by into_channel_sink_ptr and is reclaimed once.
+        let mut sink = unsafe { Box::from_raw(ptr) }; // ALLOCATOR-PAIRING: GlobalAlloc
+
+        assert_eq!(sink.try_write_item(b"accepted"), TrySendResult::Accepted);
+        assert_eq!(sink.try_write_item(b"full"), TrySendResult::Full);
+
+        drop(rx);
+        assert_eq!(sink.try_write_item(b"closed"), TrySendResult::Closed);
+    }
+
+    #[test]
+    fn closed_sink_try_write_reports_closed() {
+        let (mock, written, _flush_count, _close_count) = MockSink::new();
+        // SAFETY: into_write_sink_ptr returns a Box::into_raw allocation owned by this test.
+        let mut sink = unsafe { Box::from_raw(into_write_sink_ptr(mock)) }; // ALLOCATOR-PAIRING: GlobalAlloc
+        sink.close();
+
+        assert_eq!(sink.try_write_item(b"discarded"), TrySendResult::Closed);
+        assert!(written.lock().unwrap().is_empty());
     }
 }

--- a/hew-runtime/src/channel_core.rs
+++ b/hew-runtime/src/channel_core.rs
@@ -34,6 +34,7 @@
 use std::collections::VecDeque;
 use std::sync::{Condvar, Mutex};
 
+use hew_cabi::sink::TrySendResult;
 use hew_cabi::vec::{HewTypeOwnershipKind, HewVecElemLayout};
 
 use crate::actor::HewActor;
@@ -504,23 +505,21 @@ impl ChannelCore {
         self.cv.notify_all();
     }
 
-    /// Non-blocking producer send (`try_send`). Returns `true` if accepted,
-    /// `false` if the ring is full.
-    #[must_use]
-    pub fn try_send(&self, item: Vec<u8>) -> bool {
+    /// Non-blocking producer send (`try_send`).
+    pub fn try_send(&self, item: Vec<u8>) -> TrySendResult {
         let consumer_wake;
         {
             let mut inner = self.locked();
-            if inner.stream_closed {
-                // Discard, not "full": release an owned envelope via the
-                // stamped witness, outside the lock.
+            if inner.stream_closed || inner.sink_closed {
+                // Release an owned envelope via the stamped witness outside the
+                // lock, and report that no consumer can accept the item.
                 let layout = inner.elem_layout;
                 drop(inner);
                 Self::drop_envelope(layout.as_ref(), item);
-                return true;
+                return TrySendResult::Closed;
             }
             if inner.queue.len() >= inner.capacity {
-                return false;
+                return TrySendResult::Full;
             }
             inner.queue.push_back(item);
             consumer_wake = inner.consumer.take();
@@ -530,7 +529,7 @@ impl ChannelCore {
             unsafe { Self::wake(w) };
         }
         self.cv.notify_all();
-        true
+        TrySendResult::Accepted
     }
 
     /// Detach an abandoned producer registration (the codegen abandon edge).
@@ -707,8 +706,8 @@ mod tests {
     #[test]
     fn fifo_push_pop_without_parking() {
         let core = ChannelCore::new(4);
-        assert!(core.try_send(b"a".to_vec()));
-        assert!(core.try_send(b"b".to_vec()));
+        assert_eq!(core.try_send(b"a".to_vec()), TrySendResult::Accepted);
+        assert_eq!(core.try_send(b"b".to_vec()), TrySendResult::Accepted);
         assert_eq!(core.pop(), Some(b"a".to_vec()));
         assert_eq!(core.pop(), Some(b"b".to_vec()));
         assert_eq!(core.pop(), None);
@@ -717,16 +716,32 @@ mod tests {
     #[test]
     fn full_ring_rejects_try_send() {
         let core = ChannelCore::new(1);
-        assert!(core.try_send(b"x".to_vec()));
-        assert!(!core.try_send(b"y".to_vec()), "ring is full");
+        assert_eq!(core.try_send(b"x".to_vec()), TrySendResult::Accepted);
+        assert_eq!(
+            core.try_send(b"y".to_vec()),
+            TrySendResult::Full,
+            "ring is full"
+        );
         assert_eq!(core.pop(), Some(b"x".to_vec()));
-        assert!(core.try_send(b"y".to_vec()), "space freed by pop");
+        assert_eq!(
+            core.try_send(b"y".to_vec()),
+            TrySendResult::Accepted,
+            "space freed by pop"
+        );
+    }
+
+    #[test]
+    fn closed_stream_rejects_try_send() {
+        let core = ChannelCore::new(1);
+        core.close_stream();
+        assert_eq!(core.try_send(b"discarded".to_vec()), TrySendResult::Closed);
+        assert_eq!(core.pop(), None);
     }
 
     #[test]
     fn await_next_ready_when_item_queued() {
         let core = ChannelCore::new(2);
-        assert!(core.try_send(b"hi".to_vec()));
+        assert_eq!(core.try_send(b"hi".to_vec()), TrySendResult::Accepted);
         let slot = hew_read_slot_new();
         let rc = unsafe { core.await_next(std::ptr::null_mut(), slot) };
         assert_eq!(rc, STREAM_AWAIT_READY);
@@ -745,7 +760,7 @@ mod tests {
         assert_eq!(rc, STREAM_AWAIT_SUSPEND);
         // A producer write deposits a Data signal + (null-actor) wake is dropped,
         // and releases the core's in-flight ref.
-        assert!(core.try_send(b"z".to_vec()));
+        assert_eq!(core.try_send(b"z".to_vec()), TrySendResult::Accepted);
         assert_eq!(
             unsafe { hew_read_slot_status(slot) },
             ReadStatus::Data as i32
@@ -781,14 +796,14 @@ mod tests {
         unsafe { hew_read_slot_free(slot) };
         // The item the producer writes after abandon stays queued (exactly-once:
         // never lost), available to the next consumer.
-        assert!(core.try_send(b"late".to_vec()));
+        assert_eq!(core.try_send(b"late".to_vec()), TrySendResult::Accepted);
         assert_eq!(core.pop(), Some(b"late".to_vec()));
     }
 
     #[test]
     fn parked_producer_drained_on_pop() {
         let core = ChannelCore::new(1);
-        assert!(core.try_send(b"first".to_vec()));
+        assert_eq!(core.try_send(b"first".to_vec()), TrySendResult::Accepted);
         let slot = hew_read_slot_new();
         // Ring full → producer parks, owning its item.
         let rc = unsafe { core.await_send(std::ptr::null_mut(), slot, b"second".to_vec()) };
@@ -807,7 +822,7 @@ mod tests {
     #[test]
     fn abandoned_producer_detach_drops_item_and_releases_ref() {
         let core = ChannelCore::new(1);
-        assert!(core.try_send(b"first".to_vec()));
+        assert_eq!(core.try_send(b"first".to_vec()), TrySendResult::Accepted);
         let slot = hew_read_slot_new();
         // Ring full → producer parks, owning "second".
         let rc = unsafe { core.await_send(std::ptr::null_mut(), slot, b"second".to_vec()) };
@@ -925,9 +940,9 @@ mod tests {
         let drops_before = OWNED_DROPS.load(Ordering::SeqCst);
         let core = ChannelCore::new(4);
         core.stamp_elem_layout(&owned_elem_layout());
-        assert!(core.try_send(owned_envelope(1)));
-        assert!(core.try_send(owned_envelope(2)));
-        assert!(core.try_send(owned_envelope(3)));
+        assert_eq!(core.try_send(owned_envelope(1)), TrySendResult::Accepted);
+        assert_eq!(core.try_send(owned_envelope(2)), TrySendResult::Accepted);
+        assert_eq!(core.try_send(owned_envelope(3)), TrySendResult::Accepted);
         drop(core);
         assert_eq!(
             OWNED_DROPS.load(Ordering::SeqCst) - drops_before,
@@ -944,7 +959,7 @@ mod tests {
         let drops_before = OWNED_DROPS.load(Ordering::SeqCst);
         let core = ChannelCore::new(1);
         core.stamp_elem_layout(&owned_elem_layout());
-        assert!(core.try_send(owned_envelope(1)));
+        assert_eq!(core.try_send(owned_envelope(1)), TrySendResult::Accepted);
         let slot = hew_read_slot_new();
         // Ring full → producer parks, owning its envelope.
         let rc = unsafe { core.await_send(std::ptr::null_mut(), slot, owned_envelope(2)) };
@@ -972,7 +987,11 @@ mod tests {
         core.stamp_elem_layout(&owned_elem_layout());
         core.close_stream();
         // Discards (consumer gone) must still release the owned envelope.
-        assert!(core.try_send(owned_envelope(7)), "discard, not full");
+        assert_eq!(
+            core.try_send(owned_envelope(7)),
+            TrySendResult::Closed,
+            "consumer closure must be reported"
+        );
         core.blocking_send(owned_envelope(8));
         assert_eq!(
             OWNED_DROPS.load(Ordering::SeqCst) - drops_before,
@@ -995,7 +1014,7 @@ mod tests {
         let drops_before = OWNED_DROPS.load(Ordering::SeqCst);
         let core = ChannelCore::new(2);
         core.stamp_elem_layout(&owned_elem_layout());
-        assert!(core.try_send(owned_envelope(9)));
+        assert_eq!(core.try_send(owned_envelope(9)), TrySendResult::Accepted);
         let mut env = core.pop().expect("queued envelope");
         assert_eq!(
             OWNED_DROPS.load(Ordering::SeqCst) - drops_before,
@@ -1011,7 +1030,7 @@ mod tests {
     #[test]
     fn close_stream_wakes_parked_producers_and_drops_items() {
         let core = ChannelCore::new(1);
-        assert!(core.try_send(b"x".to_vec()));
+        assert_eq!(core.try_send(b"x".to_vec()), TrySendResult::Accepted);
         let slot = hew_read_slot_new();
         let rc = unsafe { core.await_send(std::ptr::null_mut(), slot, b"y".to_vec()) };
         assert_eq!(rc, STREAM_AWAIT_SUSPEND);

--- a/hew-runtime/src/stream.rs
+++ b/hew-runtime/src/stream.rs
@@ -2600,10 +2600,11 @@ pub unsafe extern "C" fn hew_sink_detach_await(
 /// Non-blocking variant of [`hew_sink_write_string`].
 ///
 /// Writes a null-terminated C string to the sink if the backing buffer has
-/// capacity. Returns `0` (`SendError::Ok`) on success or `2`
+/// capacity. Returns `0` (`SendError::Ok`) on success, `1`
+/// (`SendError::Closed`) if the sink or its receiving peer is closed, or `2`
 /// (`SendError::Full`) if the buffer is at capacity and the write would have
-/// blocked. For non-channel sinks the backing falls back to a blocking write
-/// and always returns `0`.
+/// blocked. For open non-channel sinks the backing falls back to a blocking
+/// write and returns `0`.
 ///
 /// Returns `1` (`SendError::Closed`) if `sink` or `data` is null.
 ///
@@ -2622,7 +2623,7 @@ pub unsafe extern "C" fn hew_sink_detach_await(
 /// copies the bytes before returning.
 ///
 /// ## Return value
-/// `0` = item accepted; `1` = null argument (closed); `2` = channel full.
+/// `0` = item accepted; `1` = closed/null argument; `2` = channel full.
 ///
 /// ## Caller responsibility
 /// The caller retains ownership of `data`; the runtime copies the bytes.
@@ -2644,7 +2645,7 @@ pub unsafe extern "C" fn hew_sink_try_write_string(sink: *mut HewSink, data: *co
     // Channel-backed sinks use the core's genuine non-blocking `try_send`.
     // SAFETY: sink is valid per the guard above.
     if let Some(core) = unsafe { sink_channel_core(sink) } {
-        return if core.try_send(bytes.to_vec()) { 0 } else { 2 };
+        return core.try_send(bytes.to_vec()).into_abi_code();
     }
     // SAFETY:
     //   Provenance: `sink` came from a `hew_*_sink_*` constructor; non-null by guard above.
@@ -2653,12 +2654,7 @@ pub unsafe extern "C" fn hew_sink_try_write_string(sink: *mut HewSink, data: *co
     //   Aliasing/concurrency: caller contract bans concurrent writes; backing's try_write is internally synchronised.
     //   Bounds: not a slice access — method dispatch with the bytes slice we just borrowed.
     //   Failure mode: violations are UAF / data race; documented at fn level. Non-channel sinks fall back to blocking write per `SinkOps::try_write_item` default.
-    let accepted = unsafe { (*sink).try_write_item(bytes) };
-    if accepted {
-        0
-    } else {
-        2
-    } // 0 = Ok, 2 = Full
+    unsafe { (*sink).try_write_item(bytes) }.into_abi_code()
 }
 
 /// If `sink` is a channel-backed (NEW-7) sink, return a borrow of its core.
@@ -2686,9 +2682,10 @@ unsafe fn sink_channel_core<'a>(
 /// Non-blocking variant of [`hew_sink_write_bytes`].
 ///
 /// Writes a `bytes` value to the sink if the backing buffer has capacity.
-/// Returns `0` (`SendError::Ok`) on success or `2` (`SendError::Full`) if
-/// the buffer is at capacity. For non-channel sinks the backing falls back
-/// to a blocking write and always returns `0`.
+/// Returns `0` (`SendError::Ok`) on success, `1` (`SendError::Closed`) if the
+/// sink or its receiving peer is closed, or `2` (`SendError::Full`) if the
+/// buffer is at capacity. For open non-channel sinks the backing falls back
+/// to a blocking write and returns `0`.
 ///
 /// Returns `1` (`SendError::Closed`) if `sink` or `data` is null.
 ///
@@ -2714,7 +2711,7 @@ unsafe fn sink_channel_core<'a>(
 /// runtime copies the bytes before returning.
 ///
 /// ## Return value
-/// `0` = item accepted; `1` = null sink/data (closed); `2` = channel full.
+/// `0` = item accepted; `1` = closed/null sink or data; `2` = channel full.
 #[no_mangle]
 pub unsafe extern "C" fn hew_sink_try_write_bytes(
     sink: *mut HewSink,
@@ -2738,7 +2735,7 @@ pub unsafe extern "C" fn hew_sink_try_write_bytes(
     // (the CallbackSink default would block).
     // SAFETY: sink is valid per caller contract.
     if let Some(core) = unsafe { sink_channel_core(sink) } {
-        return if core.try_send(bytes.to_vec()) { 0 } else { 2 };
+        return core.try_send(bytes.to_vec()).into_abi_code();
     }
     // SAFETY:
     //   Provenance: `sink` came from a `hew_*_sink_*` constructor; non-null by guard above.
@@ -2747,12 +2744,7 @@ pub unsafe extern "C" fn hew_sink_try_write_bytes(
     //   Aliasing/concurrency: caller contract bans concurrent writes; backing's try_write is internally synchronised.
     //   Bounds: method dispatch with the bytes slice borrowed above.
     //   Failure mode: violations are UAF / data race. Non-channel sinks fall back to blocking write.
-    let accepted = unsafe { (*sink).try_write_item(bytes) };
-    if accepted {
-        0
-    } else {
-        2
-    } // 0 = Ok, 2 = Full
+    unsafe { (*sink).try_write_item(bytes) }.into_abi_code()
 }
 
 #[cfg(test)]
@@ -3351,6 +3343,53 @@ mod tests {
             hew_sink_flush(sink);
             hew_sink_close(sink);
             hew_stream_pair_free(pair);
+        }
+    }
+
+    #[test]
+    fn sink_try_write_string_reports_accepted_full_and_closed() {
+        let data = CString::new("message").unwrap();
+        // SAFETY: all handles and data pointers come from their matching constructors.
+        unsafe {
+            let pair = hew_stream_channel(1);
+            let sink = hew_stream_pair_sink(pair);
+            let stream = hew_stream_pair_stream(pair);
+            hew_stream_pair_free(pair);
+
+            assert_eq!(hew_sink_try_write_string(sink, data.as_ptr()), 0);
+            assert_eq!(hew_sink_try_write_string(sink, data.as_ptr()), 2);
+            hew_stream_close(stream);
+            assert_eq!(hew_sink_try_write_string(sink, data.as_ptr()), 1);
+
+            hew_sink_close(sink);
+        }
+    }
+
+    #[test]
+    fn sink_try_write_bytes_reports_accepted_full_and_closed() {
+        let payload = b"message";
+        // SAFETY: payload is valid for its length and the returned bytes allocation
+        // remains live until the matching hew_bytes_drop below.
+        let data = unsafe {
+            crate::bytes::hew_bytes_from_static(
+                payload.as_ptr(),
+                u32::try_from(payload.len()).unwrap(),
+            )
+        };
+        // SAFETY: all handles and data pointers come from their matching constructors.
+        unsafe {
+            let pair = hew_stream_channel(1);
+            let sink = hew_stream_pair_sink_bytes(pair);
+            let stream = hew_stream_pair_stream_bytes(pair);
+            hew_stream_pair_free(pair);
+
+            assert_eq!(hew_sink_try_write_bytes(sink, &raw const data), 0);
+            assert_eq!(hew_sink_try_write_bytes(sink, &raw const data), 2);
+            hew_stream_close(stream);
+            assert_eq!(hew_sink_try_write_bytes(sink, &raw const data), 1);
+
+            hew_sink_close(sink);
+            crate::bytes::hew_bytes_drop(data.ptr);
         }
     }
 


### PR DESCRIPTION
## Summary

`ChannelCore::try_send` and the sink/stream non-blocking send paths returned a bare `bool` meaning accepted-vs-full, and silently reported `true` (accepted) after discarding an item sent to a closed channel or a disconnected sender — a real data-loss bug with no diagnostic. I replaced the bool with a typed `TrySendResult` (`Accepted`/`Closed`/`Full`) threaded through the core channel, sinks, and streams, mapped consistently to the C ABI's documented return codes.

## Verification

- New native and C ABI (string/bytes) regression coverage for all three states
- `make test-runtime-unit`-equivalent runtime suite: 2,533 passed
- `cargo nextest run -p hew-cabi`: 79 passed
- FFI ownership-contract validator: 7/7
- `cargo fmt`, `cargo clippy -p hew-runtime -p hew-cabi --all-targets -- -D warnings`: clean
- `cargo check --workspace`: clean

## Out of scope

None.
