### PR TITLE
fix(runtime): three diagnostic-honesty fixes in channel/vec/task-scope paths

### DIFF
--- a/hew-cabi/src/vec.rs
+++ b/hew-cabi/src/vec.rs
@@ -531,8 +531,9 @@ pub unsafe fn hwvec_to_u8(v: *mut HewVec) -> Vec<u8> {
 /// Copies the payload bytes into a fresh `Vec<u8>` and returns `Some(Vec<u8>)`
 /// on success.  Returns `None` if `v` is null, has the wrong element shape
 /// (`elem_kind` != `Plain` or `elem_size` != `size_of::<i32>()`), or contains
-/// a value outside the byte range `0..=255`.  Does not consume or free the
-/// `HewVec` header — ownership stays with the caller.
+/// a value outside the byte range `0..=255`, or reports a negative length.
+/// Does not consume or free the `HewVec` header — ownership stays with the
+/// caller.
 ///
 /// This is the correct choice for any call site that must be fail-closed rather
 /// than abort-on-bad-input (e.g. FFI wrappers that return a sentinel on error).
@@ -556,8 +557,10 @@ pub unsafe fn try_hwvec_to_u8(v: *mut HewVec) -> Option<Vec<u8>> {
     #[cfg(not(test))]
     // SAFETY: caller guarantees `v` points to a valid HewVec.
     let len = unsafe { hew_vec_len(v) };
-    // A negative len is malformed; treat as empty rather than aborting.
-    let len_usize = usize::try_from(len).unwrap_or(0);
+    if len < 0 {
+        return None;
+    }
+    let len_usize = usize::try_from(len).ok()?;
     let mut out = Vec::with_capacity(len_usize);
     for i in 0..len {
         #[cfg(test)]
@@ -852,5 +855,30 @@ mod tests {
             Some(vec![]),
             "empty plain HewVec must return Some([])"
         );
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn try_hwvec_to_u8_returns_none_for_negative_length() {
+        // The test-only length export converts the platform-sized `len` to
+        // i64, making this malformed header report -1. Rejection happens before
+        // the null data pointer can be inspected.
+        // SAFETY: layout is null so layout_storage is never read.
+        let mut vec = unsafe {
+            HewVec {
+                data: std::ptr::null_mut(),
+                len: usize::MAX,
+                cap: usize::MAX,
+                elem_size: mem::size_of::<i32>(),
+                elem_kind: ElemKind::Plain,
+                layout: std::ptr::null(),
+                layout_storage: core::mem::zeroed(),
+            }
+        };
+        let vec_ptr = &raw mut vec;
+        // SAFETY: the test passes a live header and asserts the malformed
+        // signed length is rejected before any element access.
+        let result = unsafe { try_hwvec_to_u8(vec_ptr) };
+        assert!(result.is_none(), "negative length must return None");
     }
 }

--- a/hew-runtime/src/channel_wasm.rs
+++ b/hew-runtime/src/channel_wasm.rs
@@ -264,12 +264,15 @@ impl Clone for WasmChannelSender {
 
 fn send_bytes(sender: &HewWasmChannelSender, bytes: Vec<u8>, api_name: &str) {
     match sender.inner.try_send(bytes) {
-        Ok(()) | Err(TrySendError::Closed) => {}
+        Ok(()) => {}
         Err(TrySendError::Full) => {
             panic!(
                 "{api_name}: channel is full; blocking send is not available on wasm32 \
                  (cooperative scheduler does not yet support yield/resume for send parks)"
             );
+        }
+        Err(TrySendError::Closed) => {
+            panic!("{api_name}: channel receiver is closed; message was not sent");
         }
     }
 }
@@ -277,8 +280,9 @@ fn send_bytes(sender: &HewWasmChannelSender, bytes: Vec<u8>, api_name: &str) {
 /// Send one element of any witness-describable type through the channel
 /// (the wasm32 counterpart of the native `hew_channel_send_layout`). The
 /// element is deep-copied into the envelope; the caller keeps its value.
-/// Non-blocking: a full queue traps because blocking send needs cooperative
-/// yield/resume parity.
+/// Non-blocking: a full queue or closed receiver traps because this void ABI
+/// cannot report a failed send. Blocking send needs cooperative yield/resume
+/// parity.
 ///
 /// # Safety
 ///
@@ -779,5 +783,18 @@ mod tests {
 
         // Send to a full channel — must trap rather than silently dropping.
         send_bytes(&tx, vec![2], "hew_channel_send_layout");
+    }
+
+    #[test]
+    #[should_panic(expected = "channel receiver is closed; message was not sent")]
+    fn send_bytes_closed_traps() {
+        crate::hew_clear_error();
+        let _guard = crate::runtime_test_guard();
+        let (tx, rx) = channel(1);
+        let tx = HewWasmChannelSender::new(tx);
+        drop(rx);
+
+        // A closed receiver must trap rather than silently dropping the envelope.
+        send_bytes(&tx, vec![1], "hew_channel_send_layout");
     }
 }

--- a/hew-runtime/src/task_scope.rs
+++ b/hew-runtime/src/task_scope.rs
@@ -480,6 +480,16 @@ impl std::fmt::Debug for HewTask {
 // the enclosing task scope. No cross-thread sharing occurs.
 unsafe impl Send for HewTask {}
 
+fn panic_payload_message(panic_payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = panic_payload.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic_payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "non-string panic payload".to_string()
+    }
+}
+
 impl HewTask {
     /// Atomically load the current state with `Acquire` ordering.
     ///
@@ -548,13 +558,7 @@ impl HewTask {
                     unsafe { f(env_ptr) };
                 }));
                 if let Err(panic_payload) = result {
-                    let msg: String = if let Some(s) = panic_payload.downcast_ref::<&str>() {
-                        (*s).to_string()
-                    } else if let Some(s) = panic_payload.downcast_ref::<String>() {
-                        s.clone()
-                    } else {
-                        "non-string panic payload".to_string()
-                    };
+                    let msg = panic_payload_message(panic_payload.as_ref());
                     let error_msg = format!("task_scope cancel_cleanup_fn panicked: {msg}");
                     crate::set_last_error(error_msg.clone());
                     #[cfg(test)]
@@ -590,7 +594,16 @@ fn reap_detached_scope_tasks(
     detached_handles: Vec<std::thread::JoinHandle<()>>,
 ) {
     for handle in detached_handles {
-        let _ = handle.join();
+        if let Err(panic_payload) = handle.join() {
+            let error_msg = format!(
+                "task_scope detached worker panicked during teardown: {}",
+                panic_payload_message(panic_payload.as_ref())
+            );
+            crate::set_last_error(error_msg.clone());
+            // Background reapers have a separate thread-local error slot, so
+            // make this teardown failure visible to the process as well.
+            eprintln!("hew: {error_msg}");
+        }
     }
     // SAFETY: every detached worker has exited, so no task pointer can be
     // observed again after this point.
@@ -3554,6 +3567,36 @@ mod tests {
         assert!(
             msg.contains("cancel_cleanup intentional panic"),
             "error message must contain the original panic payload; got: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn detached_task_reaper_reports_worker_panic() {
+        crate::hew_clear_error();
+        // SAFETY: this takes ownership of a newly allocated, otherwise-empty scope.
+        let scope = unsafe { Box::from_raw(hew_task_scope_new()) };
+        let worker = std::thread::spawn(|| panic!("detached worker intentional panic"));
+
+        reap_detached_scope_tasks(scope, vec![worker]);
+
+        let error_ptr = crate::hew_last_error();
+        assert!(
+            !error_ptr.is_null(),
+            "reaping a panicked worker must record a diagnostic"
+        );
+        // SAFETY: the reaper just populated the current thread's last-error slot.
+        let error = unsafe {
+            CStr::from_ptr(error_ptr)
+                .to_str()
+                .expect("last error should be utf-8")
+        };
+        assert!(
+            error.contains("task_scope detached worker panicked during teardown"),
+            "unexpected last error: {error}"
+        );
+        assert!(
+            error.contains("detached worker intentional panic"),
+            "panic payload must be included in the diagnostic: {error}"
         );
     }
 


### PR DESCRIPTION
## Summary

Three independent, small diagnostic-honesty bugs, each its own commit:

- `8cf0f63b9`: the WASM channel's `send_bytes` silently dropped a deep-copied envelope when the receiver had torn down, instead of failing the way capacity exhaustion already did. It now traps on a closed channel the same way it traps on full.
- `69ae2d613`: `try_hwvec_to_u8` (documented as the fail-closed FFI vector conversion) silently aliased a malformed *negative* vector length with a legitimate empty vector. It now rejects negative lengths explicitly.
- `75621edf2`: the detached-task reaper discarded every worker's `join()` result, so an escaped thread panic left no `last_error`, no failed-task state, and no diagnostic. Panics are now recorded and reported.

## Verification

- New regression test per bug proving the fixed behavior
- `make test-runtime-unit`: 2,532 passed
- `cargo nextest run -p hew-cabi`: 78 passed
- `cargo check --workspace`: clean

## Out of scope

None.
