### PR TITLE
fix(mir): classify direct actor resources correctly

### DIFF
--- a/hew-cli/tests/actor_resource_opaque_state.rs
+++ b/hew-cli/tests/actor_resource_opaque_state.rs
@@ -1,0 +1,221 @@
+#![cfg(unix)]
+
+mod support;
+
+use std::path::Path;
+use std::process::Command;
+
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+fn hew_string_literal(path: &Path) -> String {
+    path.to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+}
+
+fn run_teardown_close_oracle(name: &str, actor_decl: &str, spawn_expr: &str) {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("actor-resource-state-{name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let marker = dir.path().join("closed.txt");
+    let source_path = dir.path().join(format!("{name}.hew"));
+    let marker_literal = hew_string_literal(&marker);
+    let source = format!(
+        r#"import std::fs;
+import std::testing;
+
+#[resource]
+#[opaque]
+type Dq {{}}
+
+impl Dq {{
+    fn close(self) {{
+        unsafe {{ hew_deque_free(self) }};
+        match fs.try_append("{marker_literal}", "closed\n") {{
+            Ok(_) => {{}},
+            Err(_) => panic("append close marker"),
+        }}
+    }}
+}}
+
+extern "C" {{
+    fn hew_deque_new() -> Dq;
+    fn hew_deque_free(consume dq: Dq);
+}}
+
+type Holder {{
+    dq: Dq
+}}
+
+{actor_decl}
+
+#[test]
+fn actor_resource_state_closes_once() {{
+    let keeper = {spawn_expr};
+    match await keeper.ping() {{
+        Ok(n) => testing.assert_eq(n, 1),
+        Err(_) => testing.assert_true(false),
+    }}
+}}
+"#
+    );
+    std::fs::write(&source_path, source).expect("write Hew source");
+
+    let output = Command::new(hew_binary())
+        .args([
+            "test",
+            "--no-color",
+            source_path.to_str().expect("source path utf-8"),
+        ])
+        .current_dir(repo_root())
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .expect("run Hew test");
+    assert!(
+        output.status.success(),
+        "{name}: actor resource-state Hew test must compile and run cleanly;\n{}",
+        describe_output(&output)
+    );
+
+    let closes = std::fs::read_to_string(&marker)
+        .unwrap_or_else(|error| panic!("{name}: close marker was not written: {error}"));
+    assert_eq!(
+        closes, "closed\n",
+        "{name}: actor teardown must call the resource close exactly once",
+    );
+}
+
+fn fn_body<'a>(ll: &'a str, symbol: &str) -> &'a str {
+    let start = ll
+        .match_indices("define ")
+        .find_map(|(start, _)| {
+            ll[start..]
+                .lines()
+                .next()?
+                .contains(symbol)
+                .then_some(start)
+        })
+        .unwrap_or_else(|| panic!("missing function definition containing `{symbol}`"));
+    let body = &ll[start..];
+    let end = body.find("\n}").expect("function body terminator");
+    &body[..=end + 1]
+}
+
+#[test]
+fn direct_resource_actor_state_closes_once_on_teardown() {
+    run_teardown_close_oracle(
+        "direct",
+        r"actor Keeper {
+    let dq: Dq;
+    receive fn ping() -> i64 { 1 }
+}",
+        "spawn Keeper(dq: unsafe { hew_deque_new() })",
+    );
+}
+
+#[test]
+fn wrapped_resource_actor_state_still_closes_once_on_teardown() {
+    run_teardown_close_oracle(
+        "wrapped",
+        r"actor Keeper {
+    let holder: Holder;
+    receive fn ping() -> i64 { 1 }
+}",
+        "spawn Keeper(holder: Holder { dq: unsafe { hew_deque_new() } })",
+    );
+}
+
+#[test]
+fn direct_resource_actor_state_uses_restart_clone_refusal_and_single_close_drop() {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("actor-resource-state-ir-")
+        .tempdir()
+        .expect("tempdir");
+    let source_path = dir.path().join("resource_actor.hew");
+    let source = r#"#[resource]
+#[opaque]
+type Dq {}
+
+impl Dq {
+    fn close(self) {
+        unsafe { hew_deque_free(self) };
+    }
+}
+
+extern "C" {
+    fn hew_deque_free(consume dq: Dq);
+}
+
+type Holder {
+    dq: Dq
+}
+
+actor Direct {
+    let dq: Dq;
+}
+
+actor Wrapped {
+    let holder: Holder;
+}
+
+fn main() {}
+"#;
+    std::fs::write(&source_path, source).expect("write Hew source");
+
+    let output = Command::new(hew_binary())
+        .args([
+            "compile",
+            "--emit-dir",
+            dir.path().to_str().expect("emit dir utf-8"),
+            source_path.to_str().expect("source path utf-8"),
+        ])
+        .current_dir(repo_root())
+        .output()
+        .expect("compile actor resource-state fixture");
+    assert!(
+        output.status.success(),
+        "direct `#[resource] #[opaque]` actor state must compile instead of \
+         failing as OpaqueHandle;\n{}",
+        describe_output(&output)
+    );
+
+    let ll = std::fs::read_to_string(dir.path().join("resource_actor.ll"))
+        .expect("read emitted LLVM IR");
+    let clone = fn_body(&ll, "@__hew_state_clone_Direct(");
+    assert!(
+        clone.contains("field_step_0_clone")
+            && clone.contains("rollback_before_step_0")
+            && clone.contains("ret ptr null"),
+        "direct resource actor restart clone must use the affine clone-refusal \
+         protocol, not an opaque-handle codegen error or a shallow copy:\n{clone}",
+    );
+    assert!(
+        !clone.contains("@\"Dq::close\""),
+        "clone refusal must not close the live source resource:\n{clone}",
+    );
+
+    let direct_drop = fn_body(&ll, "@__hew_state_drop_Direct(");
+    assert_eq!(
+        direct_drop.matches("@\"Dq::close\"").count(),
+        1,
+        "direct actor state drop must contain exactly one close call:\n{direct_drop}",
+    );
+    assert!(
+        direct_drop.contains("store ptr null"),
+        "direct actor state drop must null the field after close:\n{direct_drop}",
+    );
+
+    let wrapped_drop = fn_body(&ll, "@__hew_record_drop_inplace_Holder(");
+    assert_eq!(
+        wrapped_drop.matches("@\"Dq::close\"").count(),
+        1,
+        "the existing record-wrapped resource drop must remain exactly-once:\n{wrapped_drop}",
+    );
+}

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -1727,11 +1727,11 @@ pub fn lower_hir_module_with_facts(
     // substrate records needed by synthetic MIR construction.
     register_builtin_record_layouts(&mut record_layouts, &mut record_field_orders);
 
-    // Pre-compute the opaque handle names before the state-field classification
-    // pass so the opaque-aware classifier can recognise `#[opaque]` types (e.g.
-    // `json.Value`, `cron.Expr`) that appear in actor state (directly or inside
-    // `Result`/`Option`). Mirrors the IrPipeline construction below; both draws
-    // are from the same `module.items` so they are guaranteed to agree.
+    // Pre-compute the opaque handle names and resource-close registry before the
+    // state-field classification pass so the classifier can distinguish plain
+    // `#[opaque]` handles from `#[resource] #[opaque]` handles. The same registry
+    // is moved into the `IrPipeline` below, keeping MIR admission and codegen
+    // drop synthesis on one classification authority.
     let opaque_handle_names: Vec<String> = module
         .items
         .iter()
@@ -1740,6 +1740,8 @@ pub fn lower_hir_module_with_facts(
             _ => None,
         })
         .collect();
+    let resource_opaque_close =
+        resource_opaque_close_registry(&opaque_handle_names, &module.type_classes);
 
     // Machines are enums at the value-classification layer: build every
     // machine's layout descriptor BEFORE the actor classification pass
@@ -1845,11 +1847,12 @@ pub fn lower_hir_module_with_facts(
         let closure_field = actor.state_fields.iter().enumerate().find(|(_, field)| {
             crate::model::ty_contains_closure_value(&field.ty, &record_layouts, &enum_layouts)
         });
-        let classification = crate::state_clone::classify_actor_state_fields_with_opaque_handles(
+        let classification = crate::state_clone::classify_actor_state_fields_with_resource_handles(
             &state_field_tys,
             &record_layouts,
             &classification_enum_layouts,
             &opaque_handle_names,
+            &resource_opaque_close,
         );
         let (clone_sym, drop_sym, clone_kinds) = if let Some((field_index, field)) = closure_field {
             let reason = format!(
@@ -3154,15 +3157,6 @@ pub fn lower_hir_module_with_facts(
             Some((layout.name.clone(), symbol))
         })
         .collect();
-
-    // RAII-1 complement of `resource_record_close`: the close registry for
-    // single-slot `#[resource] #[opaque]` HANDLES (no record layout, hence
-    // excluded above). Built from the SAME `opaque_handle_names` +
-    // `module.type_classes` the lowering `Builder` ctor used for the admission
-    // gate (`resource_opaque_close_registry`), so codegen's drop-body synthesis
-    // classifies a resource-bearing record identically to MIR admission.
-    let resource_opaque_close =
-        resource_opaque_close_registry(&opaque_handle_names, &module.type_classes);
 
     IrPipeline {
         thir,
@@ -11159,8 +11153,9 @@ impl Builder {
     ///
     /// Returns `Some(kinds)` iff the record named by `key`:
     ///   1. has a registered layout (`record_field_orders`),
-    ///   2. classifies cleanly under the SAME field classifier actor-state
-    ///      records use (`classify_actor_state_fields_with_opaque_handles`), AND
+    ///   2. classifies cleanly under the SAME resource-aware field classifier
+    ///      actor state uses (`classify_actor_state_fields_with_resource_handles`),
+    ///      AND
     ///   3. every field's kind is admissible to the in-place record value-class
     ///      (`StateFieldCloneKind::supports_value_class_drop_spine`) — so codegen
     ///      can synthesize BOTH the clone and drop side of the

--- a/hew-mir/tests/lowering_expr/state_clone_classification.rs
+++ b/hew-mir/tests/lowering_expr/state_clone_classification.rs
@@ -103,6 +103,64 @@ fn trivial_state_actor_gets_paired_clone_and_drop_symbols() {
 }
 
 #[test]
+fn opaque_resource_actor_field_classifies_as_resource_directly_and_when_wrapped() {
+    let src = r"
+        #[resource]
+        #[opaque]
+        type Dq {}
+
+        impl Dq {
+            fn close(self) {}
+        }
+
+        type Holder {
+            dq: Dq
+        }
+
+        actor Direct {
+            let dq: Dq;
+        }
+
+        actor Wrapped {
+            let holder: Holder;
+        }
+    ";
+    let pipeline = lower_source(src);
+    assert!(
+        pipeline.diagnostics.is_empty(),
+        "unexpected MIR diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+
+    let resource_kind = StateFieldCloneKind::Resource {
+        name: "Dq".to_string(),
+        close_symbol: "Dq::close".to_string(),
+    };
+    let direct = find_actor(&pipeline, "Direct");
+    assert_eq!(
+        direct.state_field_clone_kinds.as_deref(),
+        Some(std::slice::from_ref(&resource_kind)),
+        "a direct `#[resource] #[opaque]` actor field must not fall through to OpaqueHandle",
+    );
+
+    let wrapped = find_actor(&pipeline, "Wrapped");
+    assert_eq!(
+        wrapped.state_field_clone_kinds.as_deref(),
+        Some(
+            &[StateFieldCloneKind::UserRecord {
+                name: "Holder".to_string(),
+            }][..]
+        ),
+        "the already-supported record-wrapped resource path must remain unchanged",
+    );
+    assert_eq!(
+        pipeline.resource_opaque_close,
+        vec![("Dq".to_string(), "Dq::close".to_string())],
+        "the shared resource registry must remain available to nested-record codegen",
+    );
+}
+
+#[test]
 fn zero_state_actor_also_gets_paired_symbols() {
     // Plan §4.2: "Emit both `state_clone_fn` and `state_drop_fn`
     // registration unconditionally for every actor." Zero-state actors

--- a/tests/hew/actor_resource_opaque_state_test.hew
+++ b/tests/hew/actor_resource_opaque_state_test.hew
@@ -1,0 +1,57 @@
+import std::testing;
+
+#[resource]
+#[opaque]
+type Dq {}
+
+impl Dq {
+    fn close(self) {
+        unsafe { hew_deque_free(self) };
+        println("resource-state-closed");
+    }
+}
+
+extern "C" {
+    fn hew_deque_new() -> Dq;
+    fn hew_deque_free(consume dq: Dq);
+}
+
+type Holder {
+    dq: Dq
+}
+
+actor DirectKeeper {
+    let dq: Dq;
+
+    receive fn ping() -> i64 {
+        1
+    }
+}
+
+actor WrappedKeeper {
+    let holder: Holder;
+
+    receive fn ping() -> i64 {
+        2
+    }
+}
+
+#[test]
+fn direct_resource_actor_field_compiles_and_runs() {
+    let keeper = spawn DirectKeeper(dq: unsafe { hew_deque_new() });
+    match await keeper.ping() {
+        Ok(n) => testing.assert_eq(n, 1),
+        Err(_) => testing.assert_true(false),
+    }
+}
+
+#[test]
+fn wrapped_resource_actor_field_still_compiles_and_runs() {
+    let keeper = spawn WrappedKeeper(
+        holder: Holder { dq: unsafe { hew_deque_new() } }
+    );
+    match await keeper.ping() {
+        Ok(n) => testing.assert_eq(n, 2),
+        Err(_) => testing.assert_true(false),
+    }
+}


### PR DESCRIPTION
## Summary

A `#[resource] #[opaque]` type used directly as a supervised actor's state field was misclassified as a plain opaque handle, because the direct actor-state lowering path called into a wrapper that silently substituted an empty resource-close registry. Module emission then rejected the program with `E_NOT_YET_IMPLEMENTED`, misdescribing a real registered resource as an unsupported opaque handle. The direct actor-state path now receives the real resource-close registry, matching the already-correct owned-record path, so the correct `Resource` classification (close-on-drop, clone-refusal protocol) is reached.

## Verification

- New MIR classification regression
- New runtime/codegen regressions: close-exactly-once, restart clone-refusal, wrapped-control unaffected
- New `.hew` integration test
- MIR/codegen proving gates: 1,679 passed, 22 skipped
- `make test-hew-ratchet`: 0 failures
- `cargo check --workspace`: clean

## Out of scope

None.
