### PR TITLE
fix(codegen): drop pending yielded closure environments

### DIFF
--- a/hew-cli/tests/generator_closure_yield_leak_oracle.rs
+++ b/hew-cli/tests/generator_closure_yield_leak_oracle.rs
@@ -2,9 +2,9 @@
 //!
 //! A generator constructor runs to its first `yield`, so each loop iteration
 //! leaves a closure pair pending in the generator companion's output slot. The
-//! closure captures a heap-owning string and therefore owns both its env box
-//! and the captured string allocation. Dropping the generator without consuming
-//! that output must invoke the per-yield drop thunk and release both allocations.
+//! closure has a heap environment box. Dropping the generator without consuming
+//! that output must invoke the per-yield drop thunk and release the environment
+//! and any captured allocation.
 //!
 //! Before the fix, `ty_owns_heap` classified `ResolvedTy::Closure` as non-owning,
 //! `MakeGenerator` stored a null output-drop thunk, and this exact eight-iteration
@@ -17,7 +17,7 @@ mod support;
 use support::leak_slope::{compile_to_native, leaks_supported, measure_leaks};
 use support::require_codegen;
 
-const PENDING_CAPTURED_CLOSURE: &str = r#"
+const PENDING_HEAP_CAPTURED_CLOSURE: &str = r#"
 fn main() {
     var i = 0;
     while i < 8 {
@@ -30,9 +30,20 @@ fn main() {
 }
 "#;
 
-#[test]
-fn pending_generator_drops_yielded_heap_capturing_closure() {
-    let shape = "generator_yielded_heap_capturing_closure";
+const PENDING_COPY_CAPTURED_CLOSURE: &str = r"
+fn main() {
+    var i = 0;
+    while i < 8 {
+        let _g = gen {
+            let captured = i * 2;
+            yield || captured + 1;
+        };
+        i = i + 1;
+    }
+}
+";
+
+fn assert_pending_generator_closure_has_no_leaks(source: &str, shape: &str, description: &str) {
     if !leaks_supported(shape) {
         return;
     }
@@ -42,15 +53,33 @@ fn pending_generator_drops_yielded_heap_capturing_closure() {
         .prefix("generator-closure-yield-")
         .tempdir()
         .expect("tempdir");
-    let bin = compile_to_native(PENDING_CAPTURED_CLOSURE, dir.path(), shape);
+    let bin = compile_to_native(source, dir.path(), shape);
     let Some(leaks) = measure_leaks(&bin) else {
         return;
     };
 
     assert_eq!(
         leaks, 0,
-        "dropping a generator with a yielded heap-capturing closure pending leaked \
+        "dropping a generator with a yielded {description} pending leaked \
          {leaks} allocation(s): the generator companion's output-drop thunk must \
-         release the closure env box and its captured string"
+         release the closure env box"
+    );
+}
+
+#[test]
+fn pending_generator_drops_yielded_heap_capturing_closure() {
+    assert_pending_generator_closure_has_no_leaks(
+        PENDING_HEAP_CAPTURED_CLOSURE,
+        "generator_yielded_heap_capturing_closure",
+        "heap-capturing closure",
+    );
+}
+
+#[test]
+fn pending_generator_drops_yielded_copy_capturing_closure() {
+    assert_pending_generator_closure_has_no_leaks(
+        PENDING_COPY_CAPTURED_CLOSURE,
+        "generator_yielded_copy_capturing_closure",
+        "Copy-capturing closure",
     );
 }

--- a/hew-cli/tests/generator_closure_yield_leak_oracle.rs
+++ b/hew-cli/tests/generator_closure_yield_leak_oracle.rs
@@ -1,0 +1,56 @@
+//! Pending generator output leak oracle for a yielded capturing closure.
+//!
+//! A generator constructor runs to its first `yield`, so each loop iteration
+//! leaves a closure pair pending in the generator companion's output slot. The
+//! closure captures a heap-owning string and therefore owns both its env box
+//! and the captured string allocation. Dropping the generator without consuming
+//! that output must invoke the per-yield drop thunk and release both allocations.
+//!
+//! Before the fix, `ty_owns_heap` classified `ResolvedTy::Closure` as non-owning,
+//! `MakeGenerator` stored a null output-drop thunk, and this exact eight-iteration
+//! fixture leaked 16 nodes / 896 bytes under `leaks --atExit`.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{compile_to_native, leaks_supported, measure_leaks};
+use support::require_codegen;
+
+const PENDING_CAPTURED_CLOSURE: &str = r#"
+fn main() {
+    var i = 0;
+    while i < 8 {
+        let _g = gen {
+            let captured = f"generator-yielded-closure-owned-capture-{i}";
+            yield || captured.len();
+        };
+        i = i + 1;
+    }
+}
+"#;
+
+#[test]
+fn pending_generator_drops_yielded_heap_capturing_closure() {
+    let shape = "generator_yielded_heap_capturing_closure";
+    if !leaks_supported(shape) {
+        return;
+    }
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix("generator-closure-yield-")
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(PENDING_CAPTURED_CLOSURE, dir.path(), shape);
+    let Some(leaks) = measure_leaks(&bin) else {
+        return;
+    };
+
+    assert_eq!(
+        leaks, 0,
+        "dropping a generator with a yielded heap-capturing closure pending leaked \
+         {leaks} allocation(s): the generator companion's output-drop thunk must \
+         release the closure env box and its captured string"
+    );
+}

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -28298,6 +28298,102 @@ fn ty_is_nonowning_pid_leaf(ty: &ResolvedTy) -> bool {
     )
 }
 
+/// Drop a two-pointer closure pair held at `pair_ptr`.
+///
+/// The env word is null for bare functions and capture-free closures. Otherwise
+/// it points at a heap env whose preceding header word carries the typed free
+/// thunk. Calling that thunk releases every owned capture and the env box, then
+/// the env slot is nulled so any structurally reachable second drop is a no-op.
+fn emit_closure_pair_drop_at_slot<'ctx>(
+    fn_ctx: &FnCtx<'_, 'ctx>,
+    pair_ptr: PointerValue<'ctx>,
+    pair_ty: BasicTypeEnum<'ctx>,
+    label: &str,
+) -> CodegenResult<()> {
+    let struct_ty = match pair_ty {
+        BasicTypeEnum::StructType(st)
+            if st.count_fields() == 2
+                && st
+                    .get_field_types()
+                    .iter()
+                    .all(|field| matches!(field, BasicTypeEnum::PointerType(_))) =>
+        {
+            st
+        }
+        other => {
+            return Err(CodegenError::FailClosed(format!(
+                "{label}: closure pair slot is not the two-pointer closure pair \
+                 (got {other:?}); refusing to derive an env slot"
+            )));
+        }
+    };
+    let ctx = fn_ctx.ctx;
+    let ptr_ty = ctx.ptr_type(AddressSpace::default());
+    let env_slot = fn_ctx
+        .builder
+        .build_struct_gep(struct_ty, pair_ptr, 1, &format!("{label}_env_slot"))
+        .llvm_ctx_with(|| format!("{label} closure env gep"))?;
+    let env = fn_ctx
+        .builder
+        .build_load(ptr_ty, env_slot, &format!("{label}_env"))
+        .llvm_ctx_with(|| format!("{label} closure env load"))?
+        .into_pointer_value();
+    let parent = fn_ctx
+        .builder
+        .get_insert_block()
+        .and_then(|bb| bb.get_parent())
+        .ok_or_else(|| CodegenError::Llvm(format!("{label}: closure pair drop has no parent")))?;
+    let free_bb = ctx.append_basic_block(parent, &format!("{label}_closure_env_free"));
+    let cont_bb = ctx.append_basic_block(parent, &format!("{label}_closure_env_drop_cont"));
+    let is_null = fn_ctx
+        .builder
+        .build_is_null(env, &format!("{label}_env_is_null"))
+        .llvm_ctx_with(|| format!("{label} closure env null check"))?;
+    fn_ctx
+        .builder
+        .build_conditional_branch(is_null, cont_bb, free_bb)
+        .llvm_ctx_with(|| format!("{label} closure env branch"))?;
+
+    fn_ctx.builder.position_at_end(free_bb);
+    let neg_header = ctx
+        .i64_type()
+        .const_int(CLOSURE_ENV_BOX_HEADER.wrapping_neg(), true);
+    let thunk_slot = unsafe {
+        fn_ctx.builder.build_in_bounds_gep(
+            ctx.i8_type(),
+            env,
+            &[neg_header],
+            &format!("{label}_env_thunk_slot"),
+        )
+    }
+    .llvm_ctx_with(|| format!("{label} closure env thunk gep"))?;
+    let thunk = fn_ctx
+        .builder
+        .build_load(ptr_ty, thunk_slot, &format!("{label}_env_free_thunk"))
+        .llvm_ctx_with(|| format!("{label} closure env thunk load"))?
+        .into_pointer_value();
+    let thunk_ty = ctx.void_type().fn_type(&[ptr_ty.into()], false);
+    fn_ctx
+        .builder
+        .build_indirect_call(
+            thunk_ty,
+            thunk,
+            &[env.into()],
+            &format!("{label}_closure_env_free_call"),
+        )
+        .llvm_ctx_with(|| format!("{label} closure env thunk call"))?;
+    fn_ctx
+        .builder
+        .build_store(env_slot, ptr_ty.const_null())
+        .llvm_ctx_with(|| format!("{label} closure env null store"))?;
+    fn_ctx
+        .builder
+        .build_unconditional_branch(cont_bb)
+        .llvm_ctx_with(|| format!("{label} closure env continuation"))?;
+    fn_ctx.builder.position_at_end(cont_bb);
+    Ok(())
+}
+
 fn emit_one_elab_drop_unguarded(fn_ctx: &FnCtx<'_, '_>, drop: &ElabDrop) -> CodegenResult<()> {
     // catch-all: a future drop-kind variant must force a compile error
     // here so a new heap-owning class can never be silently folded into
@@ -28509,78 +28605,7 @@ fn emit_one_elab_drop_unguarded(fn_ctx: &FnCtx<'_, '_>, drop: &ElabDrop) -> Code
                 )));
             }
             let (pair_ptr, pair_ty) = place_pointer(fn_ctx, drop.place)?;
-            let struct_ty = match pair_ty {
-                BasicTypeEnum::StructType(st) if st.count_fields() == 2 => st,
-                other => {
-                    return Err(CodegenError::FailClosed(format!(
-                        "ClosurePair ElabDrop @ {place:?}: place is not the \
-                         two-pointer closure pair (got {other:?}); the MIR \
-                         producer must only emit ClosurePair for fn-typed \
-                         locals (LESSONS: boundary-fail-closed).",
-                        place = drop.place,
-                    )));
-                }
-            };
-            let ctx = fn_ctx.ctx;
-            let ptr_ty = ctx.ptr_type(AddressSpace::default());
-            let i64_ty = ctx.i64_type();
-            let env_field = fn_ctx
-                .builder
-                .build_struct_gep(struct_ty, pair_ptr, 1, "closure_drop_env_slot")
-                .llvm_ctx("ClosurePair drop env gep")?;
-            let env = fn_ctx
-                .builder
-                .build_load(ptr_ty, env_field, "closure_drop_env")
-                .llvm_ctx("ClosurePair drop env load")?
-                .into_pointer_value();
-            let parent = fn_ctx
-                .builder
-                .get_insert_block()
-                .and_then(|bb| bb.get_parent())
-                .ok_or_else(|| {
-                    CodegenError::Llvm("ClosurePair drop has no parent function".into())
-                })?;
-            let free_bb = ctx.append_basic_block(parent, "closure_env_free");
-            let cont_bb = ctx.append_basic_block(parent, "closure_env_drop_cont");
-            let is_null = fn_ctx
-                .builder
-                .build_is_null(env, "closure_env_is_null")
-                .llvm_ctx("ClosurePair drop null check")?;
-            fn_ctx
-                .builder
-                .build_conditional_branch(is_null, cont_bb, free_bb)
-                .llvm_ctx("ClosurePair drop branch")?;
-            fn_ctx.builder.position_at_end(free_bb);
-            let neg_header = i64_ty.const_int(CLOSURE_ENV_BOX_HEADER.wrapping_neg(), true);
-            let thunk_slot = unsafe {
-                fn_ctx.builder.build_in_bounds_gep(
-                    ctx.i8_type(),
-                    env,
-                    &[neg_header],
-                    "closure_env_thunk_slot",
-                )
-            }
-            .llvm_ctx("ClosurePair drop thunk gep")?;
-            let thunk = fn_ctx
-                .builder
-                .build_load(ptr_ty, thunk_slot, "closure_env_free_thunk")
-                .llvm_ctx("ClosurePair drop thunk load")?
-                .into_pointer_value();
-            let thunk_ty = ctx.void_type().fn_type(&[ptr_ty.into()], false);
-            fn_ctx
-                .builder
-                .build_indirect_call(thunk_ty, thunk, &[env.into()], "closure_env_free_call")
-                .llvm_ctx("ClosurePair drop thunk call")?;
-            fn_ctx
-                .builder
-                .build_store(env_field, ptr_ty.const_null())
-                .llvm_ctx("ClosurePair drop env null store")?;
-            fn_ctx
-                .builder
-                .build_unconditional_branch(cont_bb)
-                .llvm_ctx("ClosurePair drop cont branch")?;
-            fn_ctx.builder.position_at_end(cont_bb);
-            Ok(())
+            emit_closure_pair_drop_at_slot(fn_ctx, pair_ptr, pair_ty, "closure_drop")
         }
         // `@resource` scope-exit drop. `Some(drop_fn)` dispatches the type's
         // close ritual — a runtime-substrate C-ABI symbol or a user
@@ -29208,12 +29233,12 @@ fn emit_aggregate_recursive_drop<'ctx>(
 }
 
 /// W5.011: drop the value held at slot address `slot_ptr` whose type is
-/// `ty`. Heap-owning leaves (`String` / `Vec` / `HashMap` / `HashSet`)
-/// load the handle pointer from the slot and call the release symbol;
-/// nested aggregates recurse; BitCopy leaves are no-ops. Used by the
-/// `AggregateRecursive` walk — `slot_ptr` is a field/element address, not
-/// a top-level `Place`, so this is the address-based dual of
-/// `emit_cow_heap_drop`.
+/// `ty`. Heap-owning leaves (`String` / `Vec` / `HashMap` / `HashSet`) load
+/// their handle and call the release symbol; heap-owning closures invoke the
+/// env box's in-band free thunk; nested aggregates recurse; BitCopy leaves are
+/// no-ops. Used by the `AggregateRecursive` walk — `slot_ptr` is a
+/// field/element address, not a top-level `Place`, so this is the address-based
+/// dual of `emit_cow_heap_drop`.
 fn emit_heap_slot_drop<'ctx>(
     fn_ctx: &FnCtx<'_, 'ctx>,
     slot_ptr: PointerValue<'ctx>,
@@ -29244,6 +29269,10 @@ fn emit_heap_slot_drop<'ctx>(
             .build_store(slot_ptr, null_ptr)
             .llvm_ctx_with(|| format!("{label} post-{symbol} null-store"))?;
         return Ok(());
+    }
+    if matches!(ty, ResolvedTy::Closure { .. }) {
+        let pair_ty = resolve_ty(fn_ctx.ctx, ty, fn_ctx.record_layouts)?;
+        return emit_closure_pair_drop_at_slot(fn_ctx, slot_ptr, pair_ty, label);
     }
     if matches!(ty, ResolvedTy::Tuple(_) | ResolvedTy::Array(_, _)) {
         return emit_aggregate_recursive_drop(fn_ctx, slot_ptr, ty, depth, label);
@@ -29327,8 +29356,8 @@ fn emit_heap_slot_drop<'ctx>(
     // Fix #2.1 — classify the remaining leaf fail-CLOSED instead of a blanket
     // `Ok(())`. Only PROVEN non-heap (bitcopy / zero-sized) leaves are a true
     // no-op. Any other leaf reaching here is either a heap-owning type this
-    // structural walk does not yet release (`Bytes`, `CancellationToken`, a
-    // user `Named` record/enum, a `Slice`/`Task`/closure) or an unexpected
+    // structural walk does not yet release (`CancellationToken`, a user
+    // `Named` record/enum, a `Slice`/`Task`) or an unexpected
     // shape — refuse rather than silently skip its release, which would leak
     // or (for a still-aliased buffer) risk a later double-free
     // (LESSONS: boundary-fail-closed, exhaustive-traversal-and-lowering).
@@ -32280,8 +32309,7 @@ fn gen_companion_out_drop_thunk<'ctx>(
         }
         return Err(e);
     }
-    // Terminate the thunk (the builder is still positioned at `entry`, after the
-    // drop's straight-line emission).
+    // Terminate the thunk at the drop path's continuation block.
     fn_ctx
         .builder
         .build_return(None)
@@ -49044,6 +49072,80 @@ mod tests {
         assert!(
             m.verify().is_ok(),
             "module with MakeGenerator must pass LLVM verify:\n{ir}"
+        );
+    }
+
+    #[test]
+    fn generator_out_drop_thunk_tracks_closure_capture_ownership() {
+        let ctx = Context::create();
+        let m = ctx.create_module("generator_closure_out_drop_test");
+        let harness = build_harness(&ctx, &[], &[]);
+        let mut fn_ctx = make_test_fn_ctx(&ctx, &m, &harness, "driver");
+        let generator_of = |yield_ty| {
+            ResolvedTy::named_builtin(
+                "Generator",
+                hew_types::BuiltinType::Generator,
+                vec![yield_ty, ResolvedTy::Unit],
+            )
+        };
+
+        let owned_closure = ResolvedTy::Closure {
+            params: vec![],
+            ret: Box::new(ResolvedTy::I64),
+            captures: vec![ResolvedTy::String],
+        };
+        alloc_local(&mut fn_ctx, 0, generator_of(owned_closure));
+        let (_, owned_companion) =
+            generator_coro_companion_ty(&fn_ctx, Place::Local(0)).expect("owned companion type");
+        assert!(
+            gen_companion_out_drop_thunk(
+                &fn_ctx,
+                Place::Local(0),
+                "owned_closure_yield",
+                owned_companion,
+            )
+            .expect("owned closure out-drop thunk")
+            .is_some(),
+            "a closure capturing heap-owning state must install an output-drop thunk"
+        );
+
+        let copy_closure = ResolvedTy::Closure {
+            params: vec![],
+            ret: Box::new(ResolvedTy::I64),
+            captures: vec![ResolvedTy::I64],
+        };
+        alloc_local(&mut fn_ctx, 1, generator_of(copy_closure));
+        let (_, copy_companion) =
+            generator_coro_companion_ty(&fn_ctx, Place::Local(1)).expect("copy companion type");
+        assert!(
+            gen_companion_out_drop_thunk(
+                &fn_ctx,
+                Place::Local(1),
+                "copy_closure_yield",
+                copy_companion,
+            )
+            .expect("copy closure out-drop decision")
+            .is_none(),
+            "a closure capturing only Copy scalars must keep the null-thunk fast path"
+        );
+
+        finish_test_fn(&fn_ctx);
+        let ir = m.print_to_string().to_string();
+        assert!(
+            ir.contains("define internal void @__hew_gen_out_drop_owned_closure_yield"),
+            "heap-capturing closure yields must synthesize a typed output-drop thunk:\n{ir}"
+        );
+        assert!(
+            ir.contains("call void %gen_out_drop_env_free_thunk"),
+            "the output-drop thunk must invoke the closure env's in-band free thunk:\n{ir}"
+        );
+        assert!(
+            !ir.contains("__hew_gen_out_drop_copy_closure_yield"),
+            "Copy-only closure yields must not synthesize an output-drop thunk:\n{ir}"
+        );
+        assert!(
+            m.verify().is_ok(),
+            "generator closure output-drop module must pass LLVM verify:\n{ir}"
         );
     }
 

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -28869,6 +28869,20 @@ fn resolved_ty_contains_heap_leaf(
     hew_mir::ty_owns_heap(ty, &CgHeapLayouts { fn_ctx })
 }
 
+/// True when the address-based slot-drop path can reach a captured closure's
+/// environment box. This is deliberately distinct from [`ty_owns_heap`]:
+/// that type-level predicate tracks whether captures own heap payloads, while
+/// an escaped closure with any capture owns an environment box even when every
+/// capture is `Copy`.
+fn slot_drop_may_release_closure_env(ty: &ResolvedTy) -> bool {
+    match ty {
+        ResolvedTy::Closure { captures, .. } => !captures.is_empty(),
+        ResolvedTy::Tuple(elems) => elems.iter().any(slot_drop_may_release_closure_env),
+        ResolvedTy::Array(elem, _) => slot_drop_may_release_closure_env(elem),
+        _ => false,
+    }
+}
+
 /// Resolve a `ResolvedTy` to its typed [`hew_mir::CowHeapRelease`] protocol, or
 /// `None` when the type is not a single copy-on-write heap leaf. This is the
 /// address-based aggregate walk's per-field picker (`emit_heap_slot_drop`), the
@@ -32200,7 +32214,7 @@ fn generator_coro_companion_ty<'ctx>(
 }
 
 /// Synthesise (or fetch) the per-`Y` typed out-drop thunk for a generator
-/// companion, or `None` when `Y` is `BitCopy` (nothing to drop).
+/// companion, or `None` when the slot-drop path has nothing to release.
 ///
 /// A `yield` is lowered as a MOVE — the body publishes its value into the
 /// companion `out_value` slot and never drops it — so a generator dropped while
@@ -32213,8 +32227,10 @@ fn generator_coro_companion_ty<'ctx>(
 /// scope-exit drop path uses for the same value type).
 ///
 /// Returns:
-/// - `None` when `Y` owns no heap (`BitCopy`: scalars, bitcopy records/enums) —
-///   the companion stores a null thunk and the runtime skips the drop.
+/// - `None` when `Y` neither owns heap nor contains a captured closure whose
+///   environment box needs release (`BitCopy`: scalars, bitcopy records/enums,
+///   and capture-free closures) — the companion stores a null thunk and the
+///   runtime skips the drop.
 /// - `Some(thunk)` for an owned `Y` whose typed drop `emit_heap_slot_drop`
 ///   expresses (`String`, `Vec<_>`, `HashMap`, `HashSet`, owned tuples/arrays).
 /// - Fails closed for an owned `Y` whose typed drop is not yet expressible as a
@@ -32258,8 +32274,13 @@ fn gen_companion_out_drop_thunk<'ctx>(
     if matches!(yield_ty, ResolvedTy::Never) {
         return Ok(None);
     }
-    // BitCopy `Y` owns no heap → no thunk; the runtime skips the drop on null.
-    if !resolved_ty_contains_heap_leaf(fn_ctx, &yield_ty, &mut HashSet::new()) {
+    // A captured closure yielded from a generator has escaped and owns an env
+    // box even when its captures are all Copy. `ty_owns_heap` intentionally
+    // tracks capture payload ownership, so supplement it with the slot-drop
+    // shape that can release such an env box.
+    if !resolved_ty_contains_heap_leaf(fn_ctx, &yield_ty, &mut HashSet::new())
+        && !slot_drop_may_release_closure_env(&yield_ty)
+    {
         return Ok(None);
     }
 
@@ -33748,8 +33769,9 @@ fn lower_terminator<'ctx>(
                 .build_store(started_ptr, fn_ctx.ctx.i8_type().const_zero())
                 .llvm_ctx("gen companion started init")?;
 
-            // ── 2b. Plant the per-`Y` typed out-drop thunk (field 2). Null when
-            // `Y` is `BitCopy` (nothing to drop). The runtime destroy calls it
+            // ── 2b. Plant the per-`Y` typed out-drop thunk (field 2). Null only
+            // when `Y` has neither heap ownership nor a captured closure env box
+            // for the slot-drop path to release. The runtime destroy calls it
             // (passing this companion) IFF `pending != 0`, so a generator dropped
             // while an owned yielded value is still un-consumed releases it
             // exactly once instead of leaking. Fails closed for an owned `Y`
@@ -49076,7 +49098,7 @@ mod tests {
     }
 
     #[test]
-    fn generator_out_drop_thunk_tracks_closure_capture_ownership() {
+    fn generator_out_drop_thunk_tracks_closure_env_box_ownership() {
         let ctx = Context::create();
         let m = ctx.create_module("generator_closure_out_drop_test");
         let harness = build_harness(&ctx, &[], &[]);
@@ -49114,7 +49136,7 @@ mod tests {
             ret: Box::new(ResolvedTy::I64),
             captures: vec![ResolvedTy::I64],
         };
-        alloc_local(&mut fn_ctx, 1, generator_of(copy_closure));
+        alloc_local(&mut fn_ctx, 1, generator_of(copy_closure.clone()));
         let (_, copy_companion) =
             generator_coro_companion_ty(&fn_ctx, Place::Local(1)).expect("copy companion type");
         assert!(
@@ -49125,8 +49147,44 @@ mod tests {
                 copy_companion,
             )
             .expect("copy closure out-drop decision")
+            .is_some(),
+            "a closure capturing only Copy scalars must release its escaped env box"
+        );
+
+        let aggregate_copy_closure = ResolvedTy::Tuple(vec![copy_closure]);
+        alloc_local(&mut fn_ctx, 2, generator_of(aggregate_copy_closure));
+        let (_, aggregate_companion) =
+            generator_coro_companion_ty(&fn_ctx, Place::Local(2)).expect("aggregate companion");
+        assert!(
+            gen_companion_out_drop_thunk(
+                &fn_ctx,
+                Place::Local(2),
+                "aggregate_copy_closure_yield",
+                aggregate_companion,
+            )
+            .expect("aggregate copy closure out-drop decision")
+            .is_some(),
+            "aggregate slot drops must release captured Copy-only closure env boxes"
+        );
+
+        let bare_closure = ResolvedTy::Closure {
+            params: vec![],
+            ret: Box::new(ResolvedTy::I64),
+            captures: vec![],
+        };
+        alloc_local(&mut fn_ctx, 3, generator_of(bare_closure));
+        let (_, bare_companion) =
+            generator_coro_companion_ty(&fn_ctx, Place::Local(3)).expect("bare companion type");
+        assert!(
+            gen_companion_out_drop_thunk(
+                &fn_ctx,
+                Place::Local(3),
+                "bare_closure_yield",
+                bare_companion,
+            )
+            .expect("bare closure out-drop decision")
             .is_none(),
-            "a closure capturing only Copy scalars must keep the null-thunk fast path"
+            "capture-free closures must keep the null-thunk fast path"
         );
 
         finish_test_fn(&fn_ctx);
@@ -49140,8 +49198,16 @@ mod tests {
             "the output-drop thunk must invoke the closure env's in-band free thunk:\n{ir}"
         );
         assert!(
-            !ir.contains("__hew_gen_out_drop_copy_closure_yield"),
-            "Copy-only closure yields must not synthesize an output-drop thunk:\n{ir}"
+            ir.contains("define internal void @__hew_gen_out_drop_copy_closure_yield"),
+            "Copy-only closure yields must synthesize an output-drop thunk:\n{ir}"
+        );
+        assert!(
+            ir.contains("define internal void @__hew_gen_out_drop_aggregate_copy_closure_yield"),
+            "aggregate Copy-only closure yields must synthesize an output-drop thunk:\n{ir}"
+        );
+        assert!(
+            !ir.contains("__hew_gen_out_drop_bare_closure_yield"),
+            "capture-free closure yields must keep the null-thunk fast path:\n{ir}"
         );
         assert!(
             m.verify().is_ok(),

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -1556,14 +1556,16 @@ pub trait HeapOwnershipLayouts {
 ///
 /// Answers "does `ty` transitively own heap memory?" — `true` when `ty` is, or
 /// any type reachable through its record fields, enum/machine variant payloads,
-/// tuple/array/slice elements, or generic type arguments is, a heap-owning
-/// leaf. The leaf set is the `ValueClass::of_ty` heap classification made
-/// structural: `string`, `Bytes`, `CancellationToken`, `Generator<Y, R>`,
-/// `AsyncGenerator<Y>`, and the `Vec` / `HashMap` / `HashSet` collection
-/// handles (each owns a heap buffer / runtime handle regardless of its element
-/// type — even `Vec<i64>` owns its backing buffer, even `Generator<i64, ()>`
-/// owns its coro frame + heap companion). A record/enum/tuple FIELD of one of
-/// these makes the whole composite heap-owning.
+/// tuple/array/slice elements, closure captures, or generic type arguments is,
+/// a heap-owning leaf. The leaf set is the `ValueClass::of_ty` heap
+/// classification made structural: `string`, `Bytes`, `CancellationToken`,
+/// `Generator<Y, R>`, `AsyncGenerator<Y>`, and the `Vec` / `HashMap` /
+/// `HashSet` collection handles (each owns a heap buffer / runtime handle
+/// regardless of its element type — even `Vec<i64>` owns its backing buffer,
+/// even `Generator<i64, ()>` owns its coro frame + heap companion). A
+/// record/enum/tuple field or closure capture of one of these makes the whole
+/// value heap-owning. Bare `Function` values and closures whose captures are
+/// all non-owning remain heap-free.
 ///
 /// Every "does this own heap" decision — the MIR drop elaborator's composite
 /// drop-allow derivation, the move/double-free analyses, the owned-Vec element
@@ -1666,6 +1668,12 @@ fn ty_owns_heap_inner(
                 ),
             ..
         } => true,
+        // A bare function pair has no owned environment. A closure pair needs
+        // cleanup only when its captured state transitively owns heap; the env
+        // box's in-band free thunk releases both those captures and the box.
+        ResolvedTy::Closure { captures, .. } => captures
+            .iter()
+            .any(|capture| ty_owns_heap_inner(capture, layouts, visited)),
         ResolvedTy::Named { name, args, .. } => {
             // 1. Type arguments first (fast path: `Option<string>`, etc.).
             if args
@@ -1719,7 +1727,29 @@ fn ty_owns_heap_inner(
         ResolvedTy::Array(inner, _) | ResolvedTy::Slice(inner) => {
             ty_owns_heap_inner(inner, layouts, visited)
         }
-        _ => false,
+        ResolvedTy::I8
+        | ResolvedTy::I16
+        | ResolvedTy::I32
+        | ResolvedTy::I64
+        | ResolvedTy::U8
+        | ResolvedTy::U16
+        | ResolvedTy::U32
+        | ResolvedTy::U64
+        | ResolvedTy::Isize
+        | ResolvedTy::Usize
+        | ResolvedTy::F32
+        | ResolvedTy::F64
+        | ResolvedTy::Bool
+        | ResolvedTy::Char
+        | ResolvedTy::Duration
+        | ResolvedTy::Unit
+        | ResolvedTy::Never
+        | ResolvedTy::Function { .. }
+        | ResolvedTy::Pointer { .. }
+        | ResolvedTy::Borrow { .. }
+        | ResolvedTy::TraitObject { .. }
+        | ResolvedTy::Task(_)
+        | ResolvedTy::TypeParam { .. } => false,
     }
 }
 
@@ -6476,6 +6506,14 @@ mod heap_owning_tests {
         )
     }
 
+    fn closure_with_captures(captures: Vec<ResolvedTy>) -> ResolvedTy {
+        ResolvedTy::Closure {
+            params: vec![],
+            ret: Box::new(ResolvedTy::I64),
+            captures,
+        }
+    }
+
     #[test]
     fn generator_handle_is_heap_owning_despite_bitcopy_args() {
         // Regression: before this arm a `Generator<i64, ()>` was classified
@@ -6492,6 +6530,27 @@ mod heap_owning_tests {
     #[test]
     fn cancellation_token_is_heap_owning() {
         assert!(ty_contains_heap_owning(&ResolvedTy::CancellationToken, &[]));
+    }
+
+    #[test]
+    fn closure_with_heap_owning_capture_is_heap_owning() {
+        assert!(ty_contains_heap_owning(
+            &closure_with_captures(vec![ResolvedTy::String]),
+            &[],
+        ));
+    }
+
+    #[test]
+    fn function_and_copy_only_closure_are_not_heap_owning() {
+        let function = ResolvedTy::Function {
+            params: vec![],
+            ret: Box::new(ResolvedTy::I64),
+        };
+        assert!(!ty_contains_heap_owning(&function, &[]));
+        assert!(!ty_contains_heap_owning(
+            &closure_with_captures(vec![ResolvedTy::I64, ResolvedTy::Bool]),
+            &[],
+        ));
     }
 
     #[test]

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -1668,9 +1668,10 @@ fn ty_owns_heap_inner(
                 ),
             ..
         } => true,
-        // A bare function pair has no owned environment. A closure pair needs
-        // cleanup only when its captured state transitively owns heap; the env
-        // box's in-band free thunk releases both those captures and the box.
+        // A bare function pair has no owned environment. This type-level
+        // predicate tracks a closure's captured payload ownership; whether a
+        // particular escaping closure has an env box is a construction-site fact
+        // handled by the closure slot-drop path.
         ResolvedTy::Closure { captures, .. } => captures
             .iter()
             .any(|capture| ty_owns_heap_inner(capture, layouts, visited)),

--- a/hew-mir/src/ownership.rs
+++ b/hew-mir/src/ownership.rs
@@ -788,7 +788,9 @@ impl OwnershipDecision {
                 }
             }
 
-            // A closure owns a heap env box iff it captures a heap-owning value.
+            // This type-level decision tracks captured payload ownership. The
+            // env-box ownership of an escaping closure with Copy-only captures is
+            // a construction-site fact handled by closure slot-drop codegen.
             ResolvedTy::Closure { captures, .. } => {
                 if captures.iter().any(|c| ty_owns_heap(c, &layouts)) {
                     OwnershipDecision::OwnsHeap {

--- a/hew-mir/src/ownership.rs
+++ b/hew-mir/src/ownership.rs
@@ -24,10 +24,10 @@
 //! is the point: the decision *kind* alone cannot reproduce the seeds
 //! faithfully. A heap-free tuple is [`NoHeap`] yet `CowValue`; a `&[string]` is
 //! a non-owning [`Borrowed`] view yet `ty_owns_heap` recurses its element to
-//! `true`; a closure env is [`OwnsHeap`] yet `ty_owns_heap` answers `false`. So
-//! the seed must travel with the value, making [`ValueOwnership::owns_heap`] `≡`
-//! `ty_owns_heap` and [`ValueOwnership::to_value_class`] `≡` `ValueClass::of_ty`
-//! **exactly**, for every shape — the contract the consolidation relies on when it swaps a
+//! `true`. So the seed must travel with the value, making
+//! [`ValueOwnership::owns_heap`] `≡` `ty_owns_heap` and
+//! [`ValueOwnership::to_value_class`] `≡` `ValueClass::of_ty` **exactly**, for
+//! every shape — the contract the consolidation relies on when it swaps a
 //! seam's direct authority call for the projection.
 //!
 //! This carrier is now **read**, not merely defined. The per-function
@@ -1289,13 +1289,12 @@ impl OwnershipDecision {
 /// structural [`OwnershipDecision`] kind alone cannot reproduce the seeds
 /// faithfully (a heap-free tuple is [`NoHeap`](OwnershipDecision::NoHeap) yet
 /// `CowValue`; a `&[string]` is a [`Borrowed`](OwnershipDecision::Borrowed) view
-/// yet `ty_owns_heap` recurses its element to `true`; a closure env is
-/// [`OwnsHeap`](OwnershipDecision::OwnsHeap) yet `ty_owns_heap` answers `false`;
-/// a `Generator` is `OwnsHeap { CowHeapLeaf }` yet `AffineResource`). Because the
-/// facts are carried, [`owns_heap`](Self::owns_heap) `≡` `ty_owns_heap` and
+/// yet `ty_owns_heap` recurses its element to `true`; a `Generator` is
+/// `OwnsHeap { CowHeapLeaf }` yet `AffineResource`). Because the facts are
+/// carried, [`owns_heap`](Self::owns_heap) `≡` `ty_owns_heap` and
 /// [`to_value_class`](Self::to_value_class) `≡` `ValueClass::of_ty` **exactly**,
-/// so a future consolidation seam can swap its direct authority call for the projection with
-/// byte-identical behaviour.
+/// so a future consolidation seam can swap its direct authority call for the
+/// projection with byte-identical behaviour.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ValueOwnership {
     /// The rich typed decision (drop / ABI / layout).
@@ -2000,8 +1999,8 @@ mod tests {
             assert_carries_live_seeds(label, ty, Place::Local(0), &none, &[], &classes);
         }
 
-        // The shapes the structural projection got WRONG (the gate's four named
-        // cases and their siblings) — each must still equal the live authority.
+        // Shapes where at least one coarse projection differs from the rich
+        // decision kind — each must still equal its live authority.
         let slice_string = ResolvedTy::Slice(Box::new(ResolvedTy::String));
         let drifted = [
             ("slice<string>", slice_string.clone()),
@@ -2044,6 +2043,10 @@ mod tests {
         assert!(
             ValueOwnership::classify(&slice_string, Place::Local(0), &c).owns_heap(),
             "&[string] transitively owns heap: owns_heap() is true (the kind projected false)",
+        );
+        assert!(
+            ValueOwnership::classify(&closure_capturing_string(), Place::Local(0), &c).owns_heap(),
+            "a closure capturing a string transitively owns heap",
         );
         assert_eq!(
             ValueOwnership::classify(


### PR DESCRIPTION
## Summary

A generator yielding a capturing closure leaked the closure's environment if the generator was dropped or cancelled while that yield was pending and unconsumed. The root cause was `ty_owns_heap` (the compiler-wide authority for "does this type transitively own heap memory") answering `false` for `Function`/`Closure` types via a fail-open wildcard arm, even though the ownership module's own `OwnsHeap` decision for the same types said otherwise. Codegen trusted the `false` answer and skipped installing an output-drop thunk for the pending yield. I replaced the fail-open wildcard with an exhaustive classification of closures by their transitive capture ownership, and wired pending yielded closures into the existing environment-free path.

## Verification

- New leak oracle: 16 allocations / 896 bytes leaked before the fix, 0/0 after
- `cargo clippy --workspace --tests -- -D warnings`: clean (the removed wildcard surfaced a real exhaustiveness requirement)
- MIR/codegen lane: 1,550 passed
- `make test-hew-ratchet`: 0 failures
- `cargo check --workspace`: clean

## Out of scope

None.
