### PR TITLE
fix(std): release float parser character slices

### DIFF
--- a/hew-cli/tests/string_try_to_float_leak_oracle.rs
+++ b/hew-cli/tests/string_try_to_float_leak_oracle.rs
@@ -1,0 +1,90 @@
+//! Leak oracle for `std::string::try_to_float`.
+//!
+//! Float validation and parsing obtain each character with `string.slice`,
+//! which allocates a fresh heap string. The parser must release each temporary
+//! immediately after the comparison or `digit_value` call borrows it.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::assert_frame_slope_below_tolerance;
+
+fn valid_decimal_source(frames: usize) -> String {
+    format!(
+        "import std::string;\n\
+         fn main() -> i64 {{\n\
+         \x20   var checks: i64 = 0;\n\
+         \x20   for i in 0..{frames} {{\n\
+         \x20       match string.try_to_float(\"1.25\") {{\n\
+         \x20           Ok(value) => {{ if value != 1.25 {{ return 91; }} checks = checks + 1; }},\n\
+         \x20           Err(_) => {{ return 91; }},\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         \x20   if checks == {frames} {{ 0 }} else {{ 92 }}\n\
+         }}\n"
+    )
+}
+
+fn varied_float_source(frames: usize) -> String {
+    let expected_checks = frames * 10;
+    format!(
+        "import std::string;\n\
+         fn main() -> i64 {{\n\
+         \x20   var checks: i64 = 0;\n\
+         \x20   for i in 0..{frames} {{\n\
+         \x20       match string.try_to_float(\"1234567\") {{\n\
+         \x20           Ok(value) => {{ if value != 1234567.0 {{ return 101; }} checks = checks + 1; }},\n\
+         \x20           Err(_) => {{ return 102; }},\n\
+         \x20       }}\n\
+         \x20       match string.try_to_float(\"12.5\") {{\n\
+         \x20           Ok(value) => {{ if value != 12.5 {{ return 103; }} checks = checks + 1; }},\n\
+         \x20           Err(_) => {{ return 104; }},\n\
+         \x20       }}\n\
+         \x20       match string.try_to_float(\"6e2\") {{\n\
+         \x20           Ok(value) => {{ if value != 600.0 {{ return 105; }} checks = checks + 1; }},\n\
+         \x20           Err(_) => {{ return 106; }},\n\
+         \x20       }}\n\
+         \x20       match string.try_to_float(\"-2.5E-1\") {{\n\
+         \x20           Ok(value) => {{ if value != -0.25 {{ return 107; }} checks = checks + 1; }},\n\
+         \x20           Err(_) => {{ return 108; }},\n\
+         \x20       }}\n\
+         \x20       match string.try_to_float(\"+.75\") {{\n\
+         \x20           Ok(value) => {{ if value != 0.75 {{ return 109; }} checks = checks + 1; }},\n\
+         \x20           Err(_) => {{ return 110; }},\n\
+         \x20       }}\n\
+         \x20       match string.try_to_float(\"4.\") {{\n\
+         \x20           Ok(value) => {{ if value != 4.0 {{ return 111; }} checks = checks + 1; }},\n\
+         \x20           Err(_) => {{ return 112; }},\n\
+         \x20       }}\n\
+         \x20       match string.try_to_float(\"1.2.3\") {{\n\
+         \x20           Ok(_) => {{ return 113; }},\n\
+         \x20           Err(_) => {{ checks = checks + 1; }},\n\
+         \x20       }}\n\
+         \x20       match string.try_to_float(\"9e2ms\") {{\n\
+         \x20           Ok(_) => {{ return 114; }},\n\
+         \x20           Err(_) => {{ checks = checks + 1; }},\n\
+         \x20       }}\n\
+         \x20       match string.try_to_float(\"1e2e3\") {{\n\
+         \x20           Ok(_) => {{ return 115; }},\n\
+         \x20           Err(_) => {{ checks = checks + 1; }},\n\
+         \x20       }}\n\
+         \x20       match string.try_to_float(\"-\") {{\n\
+         \x20           Ok(_) => {{ return 116; }},\n\
+         \x20           Err(_) => {{ checks = checks + 1; }},\n\
+         \x20       }}\n\
+         \x20   }}\n\
+         \x20   if checks == {expected_checks} {{ 0 }} else {{ 117 }}\n\
+         }}\n"
+    )
+}
+
+#[test]
+fn valid_decimal_parse_has_no_per_character_leak_slope() {
+    assert_frame_slope_below_tolerance("try_to_float_valid_decimal", valid_decimal_source);
+}
+
+#[test]
+fn varied_valid_and_invalid_parses_have_no_per_character_leak_slope() {
+    assert_frame_slope_below_tolerance("try_to_float_varied", varied_float_source);
+}

--- a/std/string.hew
+++ b/std/string.hew
@@ -193,7 +193,12 @@ fn is_valid_float_literal(s: string) -> bool {
 
 fn float_parse_start(s: string, slen: i64) -> i64 {
     var start = 0;
-    if s.slice(0, 1) == "-" || s.slice(0, 1) == "+" {
+    let first = s.slice(0, 1);
+    let has_sign = first == "-" || first == "+";
+    unsafe {
+        hew_string_drop(first)
+    };
+    if has_sign {
         start = 1;
     }
     if start >= slen {
@@ -205,7 +210,11 @@ fn float_parse_start(s: string, slen: i64) -> i64 {
 fn parse_valid_float_literal(s: string) -> f64 {
     let slen = s.len();
     let start = float_parse_start(s, slen);
-    let negative = s.slice(0, 1) == "-";
+    let first = s.slice(0, 1);
+    let negative = first == "-";
+    unsafe {
+        hew_string_drop(first)
+    };
     let exponent_index = find_exponent_index(s, start, slen);
     let significand_end = if exponent_index < 0 {
         slen
@@ -245,7 +254,11 @@ fn find_exponent_index(s: string, start: i64, end: i64) -> i64 {
     var exponent_index = -1;
     for i in start .. end {
         let ch = s.slice(i, i + 1);
-        if ch == "e" || ch == "E" {
+        let is_exponent = ch == "e" || ch == "E";
+        unsafe {
+            hew_string_drop(ch)
+        };
+        if is_exponent {
             if exponent_index >= 0 {
                 return -2;
             }
@@ -263,13 +276,21 @@ fn is_valid_float_significand(s: string, start: i64, end: i64) -> bool {
     var saw_decimal = false;
     for i in start .. end {
         let ch = s.slice(i, i + 1);
-        if ch == "." {
+        let is_decimal = ch == ".";
+        if is_decimal {
+            unsafe {
+                hew_string_drop(ch)
+            };
             if saw_decimal {
                 return false;
             }
             saw_decimal = true;
         } else {
-            if digit_value(ch) < 0 {
+            let digit = digit_value(ch);
+            unsafe {
+                hew_string_drop(ch)
+            };
+            if digit < 0 {
                 return false;
             }
             saw_digit = true;
@@ -284,14 +305,23 @@ fn is_valid_float_exponent(s: string, start: i64, end: i64) -> bool {
     }
     var index = start;
     let first = s.slice(start, start + 1);
-    if first == "-" || first == "+" {
+    let has_sign = first == "-" || first == "+";
+    unsafe {
+        hew_string_drop(first)
+    };
+    if has_sign {
         index = start + 1;
     }
     if index >= end {
         return false;
     }
     for i in index .. end {
-        if digit_value(s.slice(i, i + 1)) < 0 {
+        let digit = s.slice(i, i + 1);
+        let value = digit_value(digit);
+        unsafe {
+            hew_string_drop(digit)
+        };
+        if value < 0 {
             return false;
         }
     }
@@ -305,11 +335,19 @@ fn parse_float_significand(s: string, start: i64, end: i64) -> f64 {
     var saw_decimal = false;
     for i in start .. end {
         let ch = s.slice(i, i + 1);
-        if ch == "." {
+        let is_decimal = ch == ".";
+        if is_decimal {
+            unsafe {
+                hew_string_drop(ch)
+            };
             saw_decimal = true;
             continue;
         }
-        let digit = digit_to_float(digit_value(ch));
+        let value = digit_value(ch);
+        unsafe {
+            hew_string_drop(ch)
+        };
+        let digit = digit_to_float(value);
         if saw_decimal {
             fraction = fraction * 10.0 + digit;
             fraction_scale = fraction_scale * 10.0;
@@ -323,15 +361,26 @@ fn parse_float_significand(s: string, start: i64, end: i64) -> f64 {
 fn parse_float_exponent(s: string, start: i64, end: i64) -> i64 {
     var index = start;
     var negative = false;
-    if s.slice(start, start + 1) == "-" {
+    let first = s.slice(start, start + 1);
+    let has_negative_sign = first == "-";
+    let has_positive_sign = first == "+";
+    unsafe {
+        hew_string_drop(first)
+    };
+    if has_negative_sign {
         negative = true;
         index = start + 1;
-    } else if s.slice(start, start + 1) == "+" {
+    } else if has_positive_sign {
         index = start + 1;
     }
     var exponent = 0;
     for i in index .. end {
-        exponent = exponent * 10 + digit_value(s.slice(i, i + 1));
+        let digit = s.slice(i, i + 1);
+        let value = digit_value(digit);
+        unsafe {
+            hew_string_drop(digit)
+        };
+        exponent = exponent * 10 + value;
     }
     if negative {
         0 - exponent


### PR DESCRIPTION
## Summary

Fixes the same leak class as #2579 (integer parser digit slices) for the float parser: \`try_to_float\`'s per-character slicing left transient slice allocations unreleased, scaling with input length.

## Verification

- New leak-oracle test \`hew-cli/tests/string_try_to_float_leak_oracle.rs\` proves the pre-fix leak scales with input length and is flat post-fix.
- \`cargo check -p hew-std\` clean.

## Out of scope

None -- narrowly scoped sibling of #2579's already-merged fix.