### PR TITLE
fix(hir): destructure tuple-typed struct-variant fields in match arms (#2354)

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -239,6 +239,34 @@ fn constructor_payload_aggregate_subpatterns(pattern: &Pattern) -> bool {
     })
 }
 
+/// True when a struct-variant match arm (`V { field: <aggregate> }`) carries a
+/// field-position sub-pattern that itself destructures — a nested tuple or
+/// record. Mirrors [`constructor_payload_aggregate_subpatterns`] for the
+/// struct-variant field path.
+///
+/// The checker binds the inner leaves into the arm-body environment so the body
+/// type-checks, but `record_arm_resolution` only records a `PayloadBinding` for
+/// a bare field binder (`binding_name_for_pattern` returns `None` for an
+/// aggregate sub-pattern). Without this signal the HIR arm would materialise no
+/// bindings for those leaves and every inner identifier would fail closed with
+/// `E_HIR: identifier has no binding` (#2354). Detecting the shape here routes
+/// the arm through `lower_struct_variant_payload_aggregates`, which rebuilds the
+/// destructure directly from the AST pattern.
+fn struct_variant_payload_aggregate_subpatterns(pattern: &Pattern) -> bool {
+    let Pattern::Struct { fields, .. } = pattern else {
+        return false;
+    };
+    fields.iter().any(|field| {
+        matches!(
+            field.pattern.as_ref().map(|(sub_pat, _)| sub_pat),
+            Some(Pattern::Struct { .. })
+        ) || matches!(
+            field.pattern.as_ref().map(|(sub_pat, _)| sub_pat),
+            Some(Pattern::Tuple(items)) if !items.is_empty()
+        )
+    })
+}
+
 /// Resolve the type of an `if`/`else` expression from its two branch types,
 /// mirroring the checker's `unify_branches` Never-handling.
 ///
@@ -12999,6 +13027,115 @@ impl LowerCtx {
         (prelude, had_error)
     }
 
+    /// Struct-variant analogue of [`Self::lower_constructor_payload_aggregates`].
+    ///
+    /// A struct-variant match arm `V { field: (a, b) }` / `V { field: Inner { .. } }`
+    /// binds a temp to the aggregate field (by declaration-order `field_idx`,
+    /// the same positional index MIR's `EnumLayout` flattening uses — see
+    /// `HirVariant::field_tys`), pushes it as an `HirMatchArmBinding`, then
+    /// recursively lowers the field's own tuple/record sub-pattern against that
+    /// temp via `lower_pattern_value_into_stmts`. This closes #2354: the checker
+    /// accepts the pattern and binds the inner leaves, but `record_arm_resolution`
+    /// records no `PayloadBinding` for an aggregate field, so without this the
+    /// inner identifiers fail closed with `E_HIR: identifier has no binding`.
+    ///
+    /// Bare field binders (`V { field: x }` / `V { field }`) already flow through
+    /// the checker's `payload_bindings`, so this helper only processes fields
+    /// whose sub-pattern is a non-empty tuple or a record destructure; every
+    /// other field shape is skipped and left to the existing binding path.
+    fn lower_struct_variant_payload_aggregates(
+        &mut self,
+        variant_name: &str,
+        fields: &[hew_parser::ast::PatternField],
+        scrutinee_ty: &ResolvedTy,
+        bindings: &mut Vec<HirMatchArmBinding>,
+        owning_pass: &'static str,
+    ) -> (Vec<HirStmt>, bool) {
+        let mut prelude = Vec::new();
+        let mut had_error = false;
+        // Resolve the variant's declared struct fields (name + type), applying
+        // the scrutinee's concrete type args to any enum type params so a
+        // generic enum instantiation binds the inner leaves at their concrete
+        // types (mirrors the tuple-variant aggregate path).
+        let field_decls: Vec<(String, ResolvedTy)> = self
+            .lookup_variant_ctor(variant_name)
+            .map(|(type_name, _, kind)| match kind {
+                HirVariantKind::Struct(decls) => {
+                    let scrutinee_args = match scrutinee_ty {
+                        ResolvedTy::Named { args, .. } => args.as_slice(),
+                        _ => &[],
+                    };
+                    let type_params = self
+                        .enum_type_params
+                        .get(&type_name)
+                        .cloned()
+                        .unwrap_or_default();
+                    if type_params.len() == scrutinee_args.len() {
+                        decls
+                            .iter()
+                            .map(|(n, ty)| {
+                                (
+                                    n.clone(),
+                                    substitute_type_params(ty, &type_params, scrutinee_args),
+                                )
+                            })
+                            .collect()
+                    } else {
+                        decls.clone()
+                    }
+                }
+                HirVariantKind::Unit | HirVariantKind::Tuple(_) => Vec::new(),
+            })
+            .unwrap_or_default();
+        for field in fields {
+            let Some((sub_pat, sub_span)) = field.pattern.as_ref() else {
+                continue;
+            };
+            if !matches!(sub_pat, Pattern::Struct { .. })
+                && !matches!(sub_pat, Pattern::Tuple(items) if !items.is_empty())
+            {
+                continue;
+            }
+            // Locate the field's declaration-order index and resolved type.
+            let Some((field_idx, (_, field_ty))) = field_decls
+                .iter()
+                .enumerate()
+                .find(|(_, (n, _))| n == &field.name)
+                .map(|(i, decl)| (i, decl.clone()))
+            else {
+                continue;
+            };
+            let Ok(field_idx_u32) = u32::try_from(field_idx) else {
+                self.unsupported(
+                    sub_span.clone(),
+                    "struct-variant payload aggregate field index exceeds u32::MAX",
+                    owning_pass,
+                );
+                had_error = true;
+                continue;
+            };
+            let temp_name = format!("__payload_{}_{}", field_idx, self.ids.binding().0);
+            let bound = self.bind(temp_name.clone(), field_ty.clone(), false, sub_span.clone());
+            let temp_id = bound.id;
+            bindings.push(HirMatchArmBinding {
+                binding: temp_id,
+                field_idx: field_idx_u32,
+                name: temp_name.clone(),
+                ty: field_ty.clone(),
+            });
+            let temp_ref =
+                self.binding_ref_expr(temp_name, temp_id, field_ty.clone(), sub_span.clone());
+            self.lower_pattern_value_into_stmts(
+                &(sub_pat.clone(), sub_span.clone()),
+                temp_ref,
+                field_ty,
+                &mut prelude,
+                sub_span.clone(),
+            );
+        }
+        (prelude, had_error)
+    }
+
     /// Lower `let PAT = scrutinee else { <divergent block> };` to the dedicated
     /// `HirStmtKind::LetElse` node.
     ///
@@ -23742,7 +23879,8 @@ impl LowerCtx {
                     }
                 };
             let has_payload_aggregate_subpatterns =
-                constructor_payload_aggregate_subpatterns(&arm.pattern.0);
+                constructor_payload_aggregate_subpatterns(&arm.pattern.0)
+                    || struct_variant_payload_aggregate_subpatterns(&arm.pattern.0);
 
             // Nested constructor subpatterns only make sense on an
             // EnumVariant arm; anything else is a checker contract violation
@@ -23808,6 +23946,16 @@ impl LowerCtx {
                 let (prelude, had_error) = self.lower_constructor_payload_aggregates(
                     name,
                     patterns,
+                    &scrutinee_hir.ty,
+                    &mut bindings,
+                    "match-expression-substrate",
+                );
+                body_prelude = prelude;
+                binding_error |= had_error;
+            } else if let Pattern::Struct { name, fields } = &arm.pattern.0 {
+                let (prelude, had_error) = self.lower_struct_variant_payload_aggregates(
+                    name,
+                    fields,
                     &scrutinee_hir.ty,
                     &mut bindings,
                     "match-expression-substrate",

--- a/tests/vertical-slice/accept/struct_variant_field_tuple_destructure.hew
+++ b/tests/vertical-slice/accept/struct_variant_field_tuple_destructure.hew
@@ -1,0 +1,24 @@
+// Accept (#2354): a struct-variant field typed as a tuple can be destructured
+// inside a match arm. The checker already accepted `Data { value: (a, b) }` and
+// bound `a`/`b`, but HIR lowering never materialised the nested tuple bindings
+// for a struct-variant field (only the tuple-VARIANT path `Data((a, b))` did),
+// so every inner identifier failed closed with
+// `E_HIR: identifier has no binding in resolved HIR`.
+//
+// Exit 7 (3 + 4) proves the field temp was bound by declaration-order index and
+// the inner tuple sub-pattern recursively bound `a`/`b` against it.
+enum Packet {
+    Data { value: (i64, i64) };
+    Empty;
+}
+
+fn sum(p: Packet) -> i64 {
+    match p {
+        Data { value: (a, b) } => a + b,
+        Empty => 0,
+    }
+}
+
+fn main() -> i64 {
+    sum(Data { value: (3, 4) })
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -3232,6 +3232,12 @@ test -s "${ROOT}/.tmp/compile-out/stdlib_option_none.wasm"
 # Exit 42 proves named-field variant payloads lower through the generic path.
 run_accept_expect_status "generic_enum_maybe_just" 42
 
+# Accept (#2354): a struct-variant field typed as a tuple destructures inside a
+# match arm (`Data { value: (a, b) }`). Regression for the E_HIR unbound-inner-
+# identifier failure where only the tuple-VARIANT path handled nested aggregate
+# payload sub-patterns. Exit 7 (3 + 4) proves the inner tuple leaves bound.
+run_accept_expect_status "struct_variant_field_tuple_destructure" 7
+
 # Accept: Result<i64, bool>::Ok(7) — two-type-parameter generic enum.
 # Exit 7 proves the Ok arm matched and the i64 payload was read correctly.
 run_accept_expect_status "generic_enum_result_ok" 7


### PR DESCRIPTION
## Summary

Fixes #2354. A struct-variant match arm whose field carries an aggregate sub-pattern — e.g. `Data { value: (a, b) }` — passed the type checker (bindings resolve, exhaustiveness credits the arm) but HIR lowering rejected the inner identifiers `a`/`b` with `E_HIR: identifier has no binding in resolved HIR`.

## Root cause

The checker's `record_arm_resolution` only records a `PayloadBinding` for a **bare** field binder (`binding_name_for_pattern` returns `None` for a tuple/record sub-pattern), delegating the nested destructure to lowering. The tuple-**variant** path (`Data((a, b))`) already handled this via `lower_constructor_payload_aggregates` — bind a temp to the payload slot, recursively lower the sub-pattern against it. But that helper is only invoked for `Pattern::Constructor` arms, and its field-type lookup returns empty for `HirVariantKind::Struct`. A struct-variant field with a tuple sub-pattern therefore materialised no binding for the inner leaves, so each inner identifier failed closed at HIR verification.

Before #2340 this shape was unreachable (the match was wrongly rejected non-exhaustive first), so the lowering gap was latent; now it fails closed with a confusing internal-flavoured diagnostic for a shape the checker accepts.

## Fix

Struct-variant analogue of the existing tuple-variant machinery, HIR-only:

- **`struct_variant_payload_aggregate_subpatterns`** — detects a `Pattern::Struct` arm carrying a non-empty tuple / record field sub-pattern; extends the `has_payload_aggregate_subpatterns` gate that opens the arm scope.
- **`lower_struct_variant_payload_aggregates`** — resolves the variant's declared struct fields (applying the scrutinee's concrete type args to enum type params for generic instantiations), binds a temp to the aggregate field by its declaration-order index (the same positional index MIR's `EnumLayout` flattening uses — see `HirVariant::field_tys`), and recursively lowers the field's tuple/record sub-pattern against that temp via `lower_pattern_value_into_stmts`.
- The Match-arm site invokes it for `Pattern::Struct` arms, mirroring the existing `Pattern::Constructor` call.

## Scope

- Only tuple and record field sub-patterns are newly lowered; bare field binders already flow through the checker's `payload_bindings` and are untouched.
- Record-**in**-field (`Move { to: Pt { x, y } }`) remains rejected at the checker's pre-existing v0.5 payload-subpattern gate — a separate limitation outside this issue (verified identical rejection on `main`).
- Guarded aggregate arms continue to hit the shared "guarded match arm with nested aggregate payload destructure" fail-closed path, unchanged.

## Verification

- New vertical-slice fixture `struct_variant_field_tuple_destructure` exits **7** (3 + 4). Load-bearing A/B: reverting only the arm wiring reproduces the exact pre-fix `E_HIR` unbound-identifier failure, confirming the fixture pins the defect.
- Also verified end-to-end: generic-enum struct-variant tuple field, wildcard-in-tuple (`(a, _)`), and mixed aggregate+bare fields (`{ pair: (a, b), tag: t }`) all bind and run.
- `cargo test -p hew-hir --lib` 89/89, `-p hew-mir --lib` 367/367, `-p hew-types --lib` 1660/1660; `cargo fmt`/`clippy` clean on `hew-hir`.