### PR TITLE
fix(mir): classify hew_bytes_to_string as a fresh-owned-string producer (#2332)

### DIFF
--- a/examples/v05/checked-mir/golden/bytes_ops.raw.mir
+++ b/examples/v05/checked-mir/golden/bytes_ops.raw.mir
@@ -81,6 +81,7 @@ fn main() -> i64 [conv=default]
     stmt: use BindingId(0) b site=SiteId(35) ty=bytes intent=Read
     stmt: bind BindingId(4) popped site=SiteId(34) ty=u8
     stmt: use BindingId(4) popped site=SiteId(39) ty=u8 intent=Read
+    drop _15 ty=string fn=release(hew_string_drop)
     _16 = call_rt hew_bytes_pop(_2)
     _17 = move _16
     _18 = cast _17 u8 -> i64

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
@@ -73,6 +73,7 @@ fn main() -> () [conv=default]
   bb9:
     call println_str(_15) -> bb10
   bb10:
+    drop _15 ty=string fn=release(hew_string_drop)
     drop _14 ty=bytes fn=release(hew_bytes_drop)
     goto bb4
   bb11:
@@ -103,6 +104,7 @@ fn main() -> () [conv=default]
   bb18:
     call println_str(_25) -> bb19
   bb19:
+    drop _25 ty=string fn=release(hew_string_drop)
     drop _24 ty=bytes fn=release(hew_bytes_drop)
     goto bb13
   bb20:

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -143,6 +143,7 @@ fn Echo__recv__run(i64) -> () [conv=actor_handler]
   bb23:
     call println_str(_34) -> bb24
   bb24:
+    drop _34 ty=string fn=release(hew_string_drop)
     goto bb18
   bb25:
     stmt: eval site=SiteId(45) ty=()

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -49730,6 +49730,7 @@ mod runtime_callee_ownership_contract_parity {
 
     const FRESH_STRING_SYMBOLS: &[&str] = &[
         "hew_bool_to_string",
+        "hew_bytes_to_string",
         "hew_char_to_string",
         "hew_float_to_string",
         "hew_i64_to_string",
@@ -49791,7 +49792,7 @@ mod runtime_callee_ownership_contract_parity {
         assert_eq!(collection_receiver.len(), 19);
         assert_eq!(bytes_receiver.len(), 11);
         assert_eq!(string_use.len(), 27);
-        assert_eq!(fresh_string.len(), 29);
+        assert_eq!(fresh_string.len(), 30);
 
         for symbol in parity_symbols() {
             let contract = callee_ownership_contract(symbol);

--- a/hew-mir/src/runtime_symbols.rs
+++ b/hew-mir/src/runtime_symbols.rs
@@ -873,22 +873,34 @@ pub fn callee_ownership_contract(callee: &str) -> CalleeOwnershipContract {
         "hew_bytes_append" => CalleeOwnershipContract::new(BytesAllArgsBorrow, Escaping, Untracked),
 
         // Bytes receiver reads and in-place mutations leave arg[0] owned by the
-        // caller. `hew_bytes_to_string` is not a fresh-string producer here.
-        "hew_bytes_clear"
-        | "hew_bytes_contains"
-        | "hew_bytes_index"
-        | "hew_bytes_is_empty"
-        | "hew_bytes_len"
-        | "hew_bytes_pop"
-        | "hew_bytes_push"
-        | "hew_bytes_set"
-        | "hew_bytes_slice"
-        | "hew_bytes_to_string" => CalleeOwnershipContract::new(
+        // caller and hand back no tracked result.
+        "hew_bytes_clear" | "hew_bytes_contains" | "hew_bytes_index" | "hew_bytes_is_empty"
+        | "hew_bytes_len" | "hew_bytes_pop" | "hew_bytes_push" | "hew_bytes_set"
+        | "hew_bytes_slice" => CalleeOwnershipContract::new(
             BorrowsReceiver {
                 scans: ReceiverScanSet::BYTES,
             },
             Escaping,
             Untracked,
+        ),
+
+        // `hew_bytes_to_string` borrows its bytes-triple arg[0] (the source
+        // buffer stays owned by the caller) but its RESULT is a fresh, header-
+        // aware `+1` string: `alloc_cstring_from_str` allocates on BOTH the
+        // empty and non-empty paths (hew-runtime/src/bytes.rs), and the result
+        // reaches `hew_string_drop`/`free_cstring`. So it is a fresh-owned-string
+        // producer, identical in ownership shape to the `Vec<string>` getter
+        // `hew_vec_get_str`: the caller owes exactly one balancing drop. The MIR
+        // `read_string` lowering (`await conn.read_string()`, non-deadline path)
+        // emits this call with a string destination; the deadline path converts
+        // codegen-side and SKIPS this call, so the MIR result is always a genuine
+        // sole owner with no other drop site (no double-free risk).
+        "hew_bytes_to_string" => CalleeOwnershipContract::new(
+            BorrowsReceiver {
+                scans: ReceiverScanSet::BYTES,
+            },
+            Escaping,
+            FreshOwnedString,
         ),
 
         // The polymorphic Vec length symbol is a receiver borrow for both the
@@ -1150,6 +1162,11 @@ pub fn callee_ownership_contract(callee: &str) -> CalleeOwnershipContract {
 
 #[cfg(test)]
 const TOML_RESULT_CONSISTENCY: &[(&str, &str, ResultOwnership)] = &[
+    (
+        "hew_bytes_to_string",
+        "fresh",
+        ResultOwnership::FreshOwnedString,
+    ),
     ("hew_vec_get_clone", "fresh", ResultOwnership::Untracked),
     ("hew_vec_get_owned", "borrowed", ResultOwnership::Borrowed),
     (
@@ -1422,6 +1439,31 @@ mod tests {
                 "{symbol} diverges from its TOML-checked result contract",
             );
         }
+    }
+
+    #[test]
+    fn hew_bytes_to_string_is_a_fresh_owned_string_producer_that_borrows_its_source() {
+        // Issue #2354/#2332: `hew_bytes_to_string` allocates a fresh header-aware
+        // string on BOTH the empty and non-empty paths
+        // (hew-runtime/src/bytes.rs `alloc_cstring_from_str`), so its RESULT is a
+        // `+1` owner the caller must release exactly once — never zero (leak),
+        // never twice (double-free). The MIR `read_string` lowering
+        // (`await conn.read_string()`, non-deadline path) emits this call with a
+        // string destination and no other drop site, so the widened admission is
+        // sound in both directions.
+        let contract = callee_ownership_contract("hew_bytes_to_string");
+        assert!(
+            contract.produces_fresh_owned_string(),
+            "hew_bytes_to_string must be classified as a fresh-owned-string producer",
+        );
+        // The SOURCE bytes-triple arg[0] is only borrowed (the caller keeps the
+        // buffer's drop obligation): the fresh RESULT and the borrowed SOURCE are
+        // independent, so admitting the result never double-accounts the input.
+        assert!(
+            contract.borrows_bytes_receiver(),
+            "hew_bytes_to_string must still borrow its bytes-triple source arg",
+        );
+        assert_eq!(contract.result, ResultOwnership::FreshOwnedString);
     }
 
     #[test]

--- a/scripts/ffi-ownership-ratchet.toml
+++ b/scripts/ffi-ownership-ratchet.toml
@@ -2,4 +2,4 @@
 #
 # This value must exactly match the verifier's computed count. Any classification
 # or contract change that changes the count must deliberately update this ratchet.
-unclassified = 987
+unclassified = 986

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -1228,6 +1228,16 @@ params = ["borrow", "consume"]
 release-symbol = ""
 discharge-depth = "none"
 
+# hew-runtime/src/bytes.rs:818-852 allocates a fresh header-aware string on both
+# the empty and non-empty paths (`alloc_cstring_from_str`); result reaches
+# `hew_string_drop`. The caller owes exactly one balancing drop.
+[[ownership.contracts]]
+symbol = "hew_bytes_to_string"
+result = "fresh"
+params = ["borrow"]
+release-symbol = "hew_string_drop"
+discharge-depth = "shallow"
+
 # hew-runtime/src/vec.rs:814-835 returns a header-retained string reference.
 [[ownership.contracts]]
 symbol = "hew_vec_get_str"


### PR DESCRIPTION
## What

`hew_bytes_to_string` allocates a fresh, header-aware string on **both** its empty and non-empty paths (`alloc_cstring_from_str`, `hew-runtime/src/bytes.rs:818-852`), and the result reaches `hew_string_drop`/`free_cstring`. But the callee ownership table folded it into the bytes-receiver group with an `Untracked` result. That absence was load-bearing: `fresh_string_producer_term_dest` only seeds listed producers, and `derive_cow_fresh_borrowed_owner` excludes any string binding whose local is not in the fresh set — so a `read_string()` result used in a borrowing context leaked its `+1` refcount.

Closes #2332.

## Change

- Split `hew_bytes_to_string` out of the `Untracked` bytes-receiver arm into its own contract: it still borrows its bytes-triple source arg[0] (`BorrowsReceiver BYTES` — the caller keeps the source buffer's drop obligation) but now returns `FreshOwnedString`. The fresh result and the borrowed source are independent, so admitting the result never double-accounts the input.
- The MIR `read_string` lowering (`await conn.read_string()`, non-deadline path) emits this call with a string destination and no other drop site; the deadline path converts codegen-side and **skips** the MIR call, so the MIR result is always a genuine sole owner — no double-free risk.
- Mirror into the JIT symbol-classification TOML (ownership source of truth): add a `result = "fresh"` contract row, decrement the ffi-ownership ratchet `987 → 986`, pin the result in `TOML_RESULT_CONSISTENCY`, and add the symbol to the FRESH_STRING parity set (`29 → 30`).

## Leak oracle (revert-reproducing)

A new unit test pins the **dual** contract — fresh-owned-string result AND retained bytes-receiver borrow (fresh in the leak direction; borrowed source so the input is never double-accounted). Reverting the classification back into the `Untracked` group genuinely fails **both**:
- the new oracle — *"hew_bytes_to_string must be classified as a fresh-owned-string producer"*
- the projection parity test — *"fresh-string projection mismatch for hew_bytes_to_string"*

## Verification

- `cargo test -p hew-mir`: 368 lib + all integration tests pass
- `python3 scripts/verify-ffi-symbols.py --validate`: clean (ratchet 986 matches)
- `cargo fmt --check` + `cargo clippy -p hew-mir --all-targets`: clean