### PR TITLE
fix(mir): recognize the bytes-all-args-borrow contract in call_args_borrow_safe (#2474)

### DIFF
--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -38813,9 +38813,11 @@ fn place_refs_local(place: Place, local: u32) -> bool {
 
 /// True when every reference to `local` inside `args` is a borrow `contract`
 /// proves — a borrowing string-argument position (`hew_string_concat`,
-/// `print`/`println`, …), or the collection/Vec/bytes receiver slot
+/// `print`/`println`, …), the collection/Vec/bytes receiver slot
 /// (`args[0]`; a reference anywhere in the by-value tail `args[1..]` still
-/// counts as unproven). `true` when `local` does not appear in `args` at all.
+/// counts as unproven), or the all-args-borrow bytes contract
+/// (`hew_bytes_append`: receiver + unpacked source triple are every-position
+/// read-only borrows). `true` when `local` does not appear in `args` at all.
 ///
 /// Shared by the `Terminator::Call` arm of
 /// [`generator_yield_terminator_escapes`] and the `Instr::CallRuntimeAbi` arm
@@ -38840,6 +38842,17 @@ fn call_args_borrow_safe(
 ) -> bool {
     let refs = |p: &Place| place_refs_local(*p, local);
     if !args.iter().any(refs) {
+        return true;
+    }
+    // `hew_bytes_append` borrows the receiver AND the unpacked source triple —
+    // every argument position is a read-only borrow, none consumed — so a
+    // reference to `local` anywhere in the argument list is borrow-safe (it
+    // does not escape via the call). Mirrors the exemption the composite-drop
+    // provers `binder_read_is_borrow_safe_terminator`/`_instr` already carry;
+    // without it, threading a for-await/generator loop variable into the
+    // `hew_bytes_append` source triple made the exit-edge release retract and
+    // leaked that value on a `return`/`break`/`continue` exit (#2474).
+    if contract.borrows_all_bytes_args() {
         return true;
     }
     let receiver_borrow_safe = (contract.borrows_vec_receiver()
@@ -58693,6 +58706,84 @@ mod drop_admission_type_shape_pins {
              seed decisions route through `binding_seeds_drop_elaboration`, \
              never an inline class test — classify any change to this \
              population in the allowlist above deliberately"
+        );
+    }
+}
+
+#[cfg(test)]
+mod call_args_borrow_safe_bytes_append_pins {
+    //! #2474: `call_args_borrow_safe` (the escape scan the
+    //! for-await/generator loop-variable exit-edge release consults on
+    //! `return`/`break`/`continue`) must recognise the all-args-borrow bytes
+    //! contract. `hew_bytes_append` borrows its receiver AND the unpacked
+    //! source triple — no argument position is consumed — so a loop variable
+    //! threaded into the source triple (args[1..], NOT the receiver) stays
+    //! owned by its binding and its exit-edge drop must fire. The sibling
+    //! composite-drop provers
+    //! (`binder_read_is_borrow_safe_terminator`/`_instr`) already carry this
+    //! exemption; before the fix this function did not, so that shape leaked.
+    use super::*;
+
+    fn contract(sym: &str) -> crate::runtime_symbols::CalleeOwnershipContract {
+        crate::runtime_symbols::callee_ownership_contract(sym)
+    }
+
+    #[test]
+    fn bytes_append_receiver_reference_is_borrow_safe() {
+        // args[0] is the receiver triple's base local.
+        let args = [Place::Local(7)];
+        assert!(
+            call_args_borrow_safe(contract("hew_bytes_append"), &args, 7),
+            "the hew_bytes_append receiver is a read-only borrow"
+        );
+    }
+
+    #[test]
+    fn bytes_append_source_triple_reference_is_borrow_safe() {
+        // A for-await/generator loop variable (local 9) threaded into the
+        // source-triple positions (args[1..]) — the exact #2474 leak shape.
+        // hew_bytes_append(&mut dst_triple, src_ptr, src_offset, src_len):
+        // model the loop var appearing in the by-value source tail.
+        let args = [
+            Place::Local(3), // receiver dst triple
+            Place::Local(9), // src ptr (from loop var)
+            Place::Local(9), // src offset
+            Place::Local(9), // src len
+        ];
+        assert!(
+            call_args_borrow_safe(contract("hew_bytes_append"), &args, 9),
+            "every hew_bytes_append argument position is a read-only borrow; \
+             a source-triple reference does not escape (was leaking pre-#2474)"
+        );
+    }
+
+    #[test]
+    fn local_absent_is_borrow_safe_regardless_of_contract() {
+        // Baseline: a local that never appears in args is trivially safe.
+        let args = [Place::Local(1), Place::Local(2)];
+        assert!(call_args_borrow_safe(
+            contract("hew_bytes_append"),
+            &args,
+            42
+        ));
+    }
+
+    #[test]
+    fn non_borrowing_callee_reference_still_escapes() {
+        // Fail-closed anchor: a callee WITHOUT a proven borrow contract, with
+        // the tracked local in an argument, is still unproven (escape). This
+        // pins that the fix widened ONLY the bytes-all-args-borrow case and
+        // did not relax the fail-closed default for arbitrary callees.
+        let args = [Place::Local(5), Place::Local(9)];
+        let c = contract("hew_vec_push");
+        assert!(
+            !c.borrows_all_bytes_args(),
+            "guard: hew_vec_push must not be an all-args-borrow contract"
+        );
+        assert!(
+            !call_args_borrow_safe(c, &args, 9),
+            "a non-borrowing callee with the tracked local as a by-value arg \
+             must stay unproven (fail-closed leak, never re-admitted)"
         );
     }
 }


### PR DESCRIPTION
Fixes #2474.

## Problem

`call_args_borrow_safe` in `hew-mir/src/lower.rs` — the escape scan the for-await/generator loop-variable exit-edge release consults on `return`/`break`/`continue` — checks `borrows_vec_receiver()`, `borrows_collection_receiver()`, `borrows_bytes_receiver()`, and `borrows_string_call_args()`, but **not** `borrows_all_bytes_args()`.

`hew_bytes_append`'s contract (`BytesAllArgsBorrow`) is that the receiver **and** the unpacked source triple are all read-only borrows — no argument position is consumed. Because `borrows_all_bytes_args` returns `false` from `borrows_bytes_receiver()`, an `hew_bytes_append` call fell through to the fail-closed default (`false` → escape).

The sibling composite-drop provers `binder_read_is_borrow_safe_terminator` / `binder_read_is_borrow_safe_instr` already carry the `if contract.borrows_all_bytes_args() { return true; }` exemption; `call_args_borrow_safe` did not.

## Impact

Bounded to a **leak, not a correctness issue** (leak-not-double-free; no UAF/corruption): when a for-await/generator loop variable is threaded into `hew_bytes_append` as part of the source triple (args[1..], not the receiver) and the loop exits via `return`/`break`/`continue`, `call_args_borrow_safe` treated the call as an escape and retracted the exit-edge release for that value.

## Fix

Adds the same `if contract.borrows_all_bytes_args() { return true; }` branch the sibling provers already have, placed before the receiver-slot check so a reference **anywhere** in the argument list (including the by-value source tail) is admitted as borrow-safe for this contract only. The fail-closed default for every other callee is unchanged. Doc comment updated to list the all-args-borrow bytes case alongside the string/receiver cases.

## Tests

New `call_args_borrow_safe_bytes_append_pins` module (4 tests):
- `bytes_append_receiver_reference_is_borrow_safe` — args[0] receiver borrow.
- `bytes_append_source_triple_reference_is_borrow_safe` — the exact #2474 leak shape (loop var in args[1..]).
- `local_absent_is_borrow_safe_regardless_of_contract` — baseline.
- `non_borrowing_callee_reference_still_escapes` — **fail-closed anchor**: `hew_vec_push` (guarded as not all-args-borrow) with the tracked local as a by-value arg stays unproven (escape), proving the fix widened only the bytes-all-args-borrow case and did not relax the default.

Verification: `cargo test -p hew-mir --lib` 371/371, `cargo fmt -p hew-mir --check` clean, `cargo clippy -p hew-mir --lib` clean.