### PR TITLE
fix(types): validate array-repeat count against fixed-array length (#2330)

### DIFF
--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -862,6 +862,34 @@ impl Checker {
         target
     }
 
+    /// Fold an array-repeat count expression to a compile-time `i64`, or
+    /// `None` when it is not a checker-visible constant.
+    ///
+    /// Only the shapes that can legitimately name a fixed-array length are
+    /// recognized: a bare integer literal, a negated integer literal, and an
+    /// identifier bound to an integer `const`/`let` (tracked in
+    /// `const_values`). Anything else — a runtime variable, a call, an
+    /// arithmetic expression — returns `None` so the caller can reject a
+    /// non-constant length in a `[T; N]` position (issue #2330). This is a
+    /// pure classification of `count`; it emits no diagnostics of its own.
+    pub(super) fn const_array_repeat_count(&self, count: &Expr) -> Option<i64> {
+        match count {
+            Expr::Literal(Literal::Integer { value, .. }) => Some(*value),
+            Expr::Unary {
+                op: UnaryOp::Negate,
+                operand,
+            } => match &operand.0 {
+                Expr::Literal(Literal::Integer { value, .. }) => value.checked_neg(),
+                _ => None,
+            },
+            Expr::Identifier(name) => match self.const_values.get(name) {
+                Some(ConstValue::Integer(v)) => Some(*v),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     pub(super) fn synthesize_array_repeat(
         &mut self,
         value: &Spanned<Expr>,
@@ -2768,10 +2796,59 @@ impl Checker {
                 expected.clone()
             }
 
-            // Array repeat coercion to Array<T, N> type
-            (Expr::ArrayRepeat { value, count }, Ty::Array(elem_ty, _)) => {
+            // Array repeat coercion to Array<T, N> type.
+            //
+            // The declared length `N` is part of the fixed-array type, so the
+            // repeat count must agree with it — the same line the plain array
+            // literal arm above holds. A constant count that differs from `N`
+            // is an arity mismatch; a non-constant count is rejected outright
+            // because the length in a `[T; N]` position must be known at check
+            // time (issue #2330).
+            (Expr::ArrayRepeat { value, count }, Ty::Array(elem_ty, size)) => {
                 self.check_against(&value.0, &value.1, elem_ty);
                 self.check_against(&count.0, &count.1, &Ty::I64);
+
+                match self.const_array_repeat_count(&count.0) {
+                    Some(actual) if actual < 0 => {
+                        self.report_error(
+                            TypeErrorKind::ArityMismatch,
+                            &count.1,
+                            format!(
+                                "array repeat count cannot be negative: `{}` requires {size} elements, found {actual}",
+                                expected.user_facing()
+                            ),
+                        );
+                        return Ty::Error;
+                    }
+                    #[allow(
+                        clippy::cast_sign_loss,
+                        reason = "the negative branch above returns first, so `actual` is non-negative here"
+                    )]
+                    Some(actual) if (actual as u64) != *size => {
+                        self.report_error(
+                            TypeErrorKind::ArityMismatch,
+                            span,
+                            format!(
+                                "array repeat length mismatch: expected {size} elements for `{}`, found {actual}",
+                                expected.user_facing()
+                            ),
+                        );
+                        return Ty::Error;
+                    }
+                    Some(_) => {}
+                    None => {
+                        self.report_error(
+                            TypeErrorKind::ArityMismatch,
+                            &count.1,
+                            format!(
+                                "array repeat count must be a constant to coerce to fixed-array type `{}` (length {size} is part of the type); use a compile-time-constant count",
+                                expected.user_facing()
+                            ),
+                        );
+                        return Ty::Error;
+                    }
+                }
+
                 self.record_type(span, expected);
                 expected.clone()
             }

--- a/hew-types/src/check/tests/collections.rs
+++ b/hew-types/src/check/tests/collections.rs
@@ -90,6 +90,90 @@ fn literal_coercion_array_literal_element_mismatch() {
 }
 
 #[test]
+fn literal_coercion_array_repeat_length_mismatch() {
+    // `let a: [i64; 4] = [0; 2]` — the repeat count disagrees with the
+    // declared fixed-array length and must be rejected the same way a plain
+    // array literal of the wrong arity is (issue #2330).
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let span = 0..8;
+    let expected = Ty::Array(Box::new(Ty::I64), 4);
+    let expr = Expr::ArrayRepeat {
+        value: Box::new(make_int_literal(0, 1..2)),
+        count: Box::new(make_int_literal(2, 4..5)),
+    };
+
+    let result = checker.check_against(&expr, &span, &expected);
+
+    assert_eq!(result, Ty::Error);
+    assert_eq!(
+        checker.errors.len(),
+        1,
+        "repeat length mismatch should emit one targeted diagnostic: {:#?}",
+        checker.errors
+    );
+    let error = &checker.errors[0];
+    assert_eq!(error.kind, TypeErrorKind::ArityMismatch);
+    assert_eq!(error.span, span);
+    assert!(
+        error.message.contains("expected 4") && error.message.contains("found 2"),
+        "diagnostic should name expected and actual arity: {error:#?}"
+    );
+}
+
+#[test]
+fn literal_coercion_array_repeat_length_match() {
+    // A matching constant count coerces cleanly with no diagnostic.
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let span = 0..8;
+    let expected = Ty::Array(Box::new(Ty::I64), 3);
+    let expr = Expr::ArrayRepeat {
+        value: Box::new(make_int_literal(7, 1..2)),
+        count: Box::new(make_int_literal(3, 4..5)),
+    };
+
+    let result = checker.check_against(&expr, &span, &expected);
+
+    assert_eq!(result, expected);
+    assert!(
+        checker.errors.is_empty(),
+        "matching repeat count should coerce cleanly: {:#?}",
+        checker.errors
+    );
+    assert_eq!(
+        checker.expr_types.get(&SpanKey::from(&span)),
+        Some(&expected)
+    );
+}
+
+#[test]
+fn literal_coercion_array_repeat_non_constant_count_rejected() {
+    // A runtime (non-constant) count cannot name a fixed-array length, so
+    // it is rejected in `[T; N]` position rather than silently accepted.
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let span = 0..8;
+    let count_span = 4..5;
+    let expected = Ty::Array(Box::new(Ty::I64), 4);
+    let expr = Expr::ArrayRepeat {
+        value: Box::new(make_int_literal(0, 1..2)),
+        count: Box::new((Expr::Identifier("n".to_string()), count_span.clone())),
+    };
+
+    let result = checker.check_against(&expr, &span, &expected);
+
+    assert_eq!(result, Ty::Error);
+    assert!(
+        checker
+            .errors
+            .iter()
+            .any(|e| e.kind == TypeErrorKind::ArityMismatch
+                && e.span == count_span
+                && e.message.contains("must be a constant")),
+        "non-constant count should be rejected in fixed-array position: {:#?}",
+        checker.errors
+    );
+}
+
+#[test]
 fn vec_copy_record_new_constructor_typechecks() {
     let output = check_source(
         r"


### PR DESCRIPTION
Closes #2330.

## Problem

The `[x; count]` repeat-literal coercion arm in `hew-types` matched `Ty::Array(elem_ty, _)` and **discarded the declared length `N`**. The count was type-checked as `i64` but never value-checked against `N`, so:

```hew
let a: [i64; 4] = [0; 2]   // type-checked despite 4 != 2
```

The plain array-literal arm directly above already emits a dedicated `ArityMismatch` diagnostic on the same length disagreement, so the two literal forms disagreed on identical inputs.

## Fix

- Bind the length in the coercion pattern (`Ty::Array(elem_ty, size)`).
- Fold the count to a compile-time constant via a new pure helper `const_array_repeat_count` (integer literal, negated integer literal, or an identifier bound to an integer `const`/`let` in `const_values`).
- A constant count `!= N` reports the same `ArityMismatch` (expected/found) the array literal does.
- A negative constant length is rejected.
- A **non-constant** count is rejected in `[T; N]` position — the length is part of the fixed-array type and must be known at check time (the policy the issue calls for).

The synthesized, **unannotated** `[x; n]` → `Vec<T>` path (`synthesize_array_repeat`) is untouched, so runtime-count repeats still work where no fixed length is declared (e.g. the `array_repeat_runtime_count` vertical-slice fixture).

## Tests

`hew-types --lib`:
- `literal_coercion_array_repeat_length_mismatch` — one `ArityMismatch` naming `expected 4` / `found 2`.
- `literal_coercion_array_repeat_length_match` — matching constant count coerces cleanly and records the fixed-array type.
- `literal_coercion_array_repeat_non_constant_count_rejected` — a runtime identifier count is rejected in fixed-array position.

**Load-bearing A/B:** reverting the arm to the permissive `(.., Ty::Array(elem_ty, _))` form genuinely fails the mismatch and non-constant tests while the match test still passes.

Full `hew-types` lib 1663/1663; `cargo fmt` + `clippy` clean. Pure checker change (no MIR/codegen reach), so not built end-to-end.