### PR TITLE
fix(types): fail closed on Stream lazy adapters with one honest diagnostic (#2530)

### DIFF
--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -1724,10 +1724,6 @@ impl Checker {
         );
     }
 
-    fn record_deferred_method_call_rewrite(&mut self, span: &Span) {
-        self.record_method_call_rewrite(span, MethodCallRewrite::DeferToLowering);
-    }
-
     /// Record a channel method rewrite to be resolved after inference settles.
     ///
     /// Called instead of `record_runtime_method_call_rewrite` when the inner
@@ -1960,14 +1956,6 @@ impl Checker {
             Ty::String => Some("string"),
             Ty::Bytes => Some("bytes"),
             _ => None,
-        }
-    }
-
-    fn stream_receiver_element_kind(ty: &Ty) -> &'static str {
-        match ty {
-            Ty::String => "string",
-            Ty::Bytes => "bytes",
-            _ => "",
         }
     }
 
@@ -3015,21 +3003,39 @@ impl Checker {
                 sig.return_type
             }
             "take" | "map" | "filter" => {
+                // These lazy adapters have builtin signatures (so they
+                // type-check) but no MIR lowering: they routed to the legacy
+                // `DeferToLowering` codegen path the Rust MIR pipeline does not
+                // consume, dead-ending in HIR lowering with two misleading,
+                // internal-shaped `E_NOT_YET_IMPLEMENTED` notes. Fail closed here
+                // at the checker with one honest capability-boundary diagnostic
+                // so the user sees a single clear message pointing at the
+                // supported alternative, and lowering never reaches the stub.
+                // Still check the argument so an ill-typed adapter arg is not
+                // masked by this boundary error.
                 if let Some(arg) = args.first() {
                     let (expr, sp) = arg.expr();
                     if let Some(param_ty) = sig.params.first() {
                         self.check_against(expr, sp, param_ty);
                     }
                 }
-                self.record_deferred_method_call_rewrite(span);
-                self.record_method_call_receiver_kind(
-                    span,
-                    MethodCallReceiverKind::StreamInstance {
-                        element_kind: Self::stream_receiver_element_kind(&resolved_inner)
-                            .to_string(),
+                self.report_error(
+                    TypeErrorKind::StreamAdapterNotSupported {
+                        method: method.to_string(),
+                        element_ty: inner.user_facing().to_string(),
                     },
+                    span,
+                    format!(
+                        "`Stream<{}>.{method}` is not yet supported: the lazy \
+                         stream adapters (`take`/`map`/`filter`) have no lowering \
+                         yet; consume the stream directly with `for await x in \
+                         s {{ ... }}` (applying the `take`/`map`/`filter` logic in \
+                         the loop body), or `.recv()` in a loop \
+                         [E_STREAM_ADAPTER_UNSUPPORTED]",
+                        inner.user_facing()
+                    ),
                 );
-                sig.return_type
+                Ty::Error
             }
             _ => {
                 for arg in args {
@@ -8939,24 +8945,6 @@ mod tests {
                 args: vec![],
             }),
             None
-        );
-    }
-
-    #[test]
-    fn stream_receiver_element_kind_stays_canonical() {
-        assert_eq!(Checker::stream_receiver_element_kind(&Ty::String), "string");
-        assert_eq!(Checker::stream_receiver_element_kind(&Ty::Bytes), "bytes");
-        assert_eq!(
-            Checker::stream_receiver_element_kind(&Ty::Named {
-                builtin: None,
-                name: "String".into(),
-                args: vec![],
-            }),
-            ""
-        );
-        assert_eq!(
-            Checker::stream_receiver_element_kind(&Ty::Var(TypeVar::fresh())),
-            ""
         );
     }
 

--- a/hew-types/src/check/tests/builtins.rs
+++ b/hew-types/src/check/tests/builtins.rs
@@ -284,6 +284,61 @@ fn typecheck_generator_yield_mismatch_reports_element_type() {
 }
 
 #[test]
+fn stream_lazy_adapters_fail_closed_with_one_honest_diagnostic() {
+    // `Stream<T>.take/map/filter` type-check (they carry builtin signatures)
+    // but have no MIR lowering: they previously routed to the legacy
+    // `DeferToLowering` codegen path the Rust MIR pipeline does not consume, so
+    // they dead-ended in HIR lowering with TWO misleading, internal-shaped
+    // `E_NOT_YET_IMPLEMENTED` notes ("method-call rewrite variant" +
+    // "Unsupported HIR node reached verification"). They must now fail closed at
+    // the checker with exactly ONE honest, user-facing capability-boundary
+    // diagnostic (issue #2530).
+    for method in ["take", "map", "filter"] {
+        let arg = if method == "take" { "3" } else { "|x| x" };
+        let source =
+            format!("fn use_stream(s: Stream<string>) {{\n    let _t = s.{method}({arg});\n}}\n");
+        let (errors, _warnings) = parse_and_check(&source);
+        let adapter_errors: Vec<_> = errors
+            .iter()
+            .filter(|e| e.kind.as_kind_str() == "StreamAdapterNotSupported")
+            .collect();
+        assert_eq!(
+            adapter_errors.len(),
+            1,
+            "`Stream<string>.{method}` must emit exactly one StreamAdapterNotSupported \
+             diagnostic; got errors: {errors:?}"
+        );
+        // No leftover internal-shaped NYI noise from the old DeferToLowering path.
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.kind.as_kind_str() == "NotYetImplemented"),
+            "`Stream<string>.{method}` must not leak the internal NotYetImplemented \
+             note; got errors: {errors:?}"
+        );
+        // The single diagnostic points at the supported alternative.
+        assert!(
+            adapter_errors[0].message.contains("for await"),
+            "the diagnostic must point at the supported `for await` consumption \
+             pattern; got: {}",
+            adapter_errors[0].message
+        );
+    }
+}
+
+#[test]
+fn stream_recv_still_type_checks_after_adapter_fail_closed() {
+    // Guard: fail-closing the lazy adapters must not regress the supported
+    // fundamental recv surface, which continues to type-check cleanly.
+    let source = "fn use_stream(s: Stream<string>) {\n    let _m = s.recv();\n}\n";
+    let (errors, _warnings) = parse_and_check(source);
+    assert!(
+        errors.is_empty(),
+        "`Stream<string>.recv()` must still type-check cleanly; got: {errors:?}"
+    );
+}
+
+#[test]
 fn test_stream_annotation_resolves_to_stream_type() {
     use hew_parser::ast::{FnDecl, Item, TypeExpr};
 

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -1208,6 +1208,24 @@ pub enum TypeErrorKind {
         /// `"net.Listener"`).
         type_name: String,
     },
+    /// A `Stream<T>` lazy adapter (`.take`/`.map`/`.filter`) was invoked.
+    ///
+    /// These adapters type-check (they have builtin signatures) but have no
+    /// lowering: they routed to the legacy `DeferToLowering` codegen path that
+    /// the Rust MIR pipeline does not consume, so they dead-ended in HIR
+    /// lowering with a pair of misleading, internal-shaped
+    /// `E_NOT_YET_IMPLEMENTED` notes ("method-call rewrite variant", "Unsupported
+    /// HIR node reached verification"). This error is emitted at the checker
+    /// layer to replace that downstream noise with a single clean, actionable
+    /// capability-boundary diagnostic that points at the supported alternative.
+    ///
+    /// Envelope code: `E_STREAM_ADAPTER_UNSUPPORTED`.
+    StreamAdapterNotSupported {
+        /// The adapter method that was invoked (`"take"`, `"map"`, `"filter"`).
+        method: String,
+        /// The user-facing element type of the receiver `Stream<T>`.
+        element_ty: String,
+    },
     /// A cross-module or cross-package reference to a `private` symbol.
     ///
     /// `private` symbols are accessible only within the module that declares
@@ -1337,6 +1355,7 @@ impl TypeErrorKind {
             Self::RefutableLetPattern { .. } => "RefutableLetPattern",
             Self::LetElseDoesNotDiverge => "LetElseDoesNotDiverge",
             Self::OpaqueDirectConstruct { .. } => "OpaqueDirectConstruct",
+            Self::StreamAdapterNotSupported { .. } => "StreamAdapterNotSupported",
             Self::VisibilityViolationPrivate { .. } => "VisibilityViolationPrivate",
             Self::VisibilityViolationPackage { .. } => "VisibilityViolationPackage",
             Self::Lint(id) => id.as_str(),

--- a/hew-types/tests/e2e_typecheck.rs
+++ b/hew-types/tests/e2e_typecheck.rs
@@ -363,7 +363,11 @@ fn consume(s: Stream<string>) {
 }
 
 #[test]
-fn method_call_rewrites_record_deferred_stream_lowering() {
+fn method_call_stream_take_fails_closed_with_honest_diagnostic() {
+    // `take` shares the lazy-adapter capability boundary with `map`/`filter`:
+    // it previously recorded a `DeferToLowering` rewrite that dead-ended in HIR
+    // lowering with an internal-shaped `NotYetImplemented` note. Per issue #2530
+    // it now fails closed at the checker with one honest diagnostic.
     let output = typecheck_inline(
         r"
 fn consume(s: Stream<bytes>) {
@@ -371,23 +375,44 @@ fn consume(s: Stream<bytes>) {
 }
 ",
     );
-    assert!(
-        output.errors.is_empty(),
-        "expected clean typecheck, got: {:#?}",
+    let adapter_errors: Vec<_> = output
+        .errors
+        .iter()
+        .filter(|e| matches!(&e.kind, TypeErrorKind::StreamAdapterNotSupported { .. }))
+        .collect();
+    assert_eq!(
+        adapter_errors.len(),
+        1,
+        "expected exactly one StreamAdapterNotSupported diagnostic, got: {:#?}",
         output.errors
     );
     assert!(
-        output
+        matches!(
+            &adapter_errors[0].kind,
+            TypeErrorKind::StreamAdapterNotSupported { method, element_ty }
+                if method == "take" && element_ty == "bytes"
+        ),
+        "expected `take`/`bytes` in the diagnostic, got: {:?}",
+        adapter_errors[0].kind
+    );
+    assert!(
+        !output
             .method_call_rewrites
             .values()
             .any(|rewrite| matches!(rewrite, hew_types::MethodCallRewrite::DeferToLowering)),
-        "expected checker-owned deferred rewrite metadata, got: {:?}",
+        "fail-closed adapters must record no DeferToLowering rewrite, got: {:?}",
         output.method_call_rewrites
     );
 }
 
 #[test]
-fn method_call_receiver_kinds_record_string_stream_dispatch() {
+fn method_call_stream_map_fails_closed_with_honest_diagnostic() {
+    // The lazy stream adapters (`take`/`map`/`filter`) have no MIR lowering.
+    // They previously type-checked clean and recorded `StreamInstance` receiver
+    // metadata before dead-ending in HIR lowering with internal-shaped
+    // `E_NOT_YET_IMPLEMENTED` noise. Per issue #2530 they now fail closed at the
+    // checker with exactly one honest `StreamAdapterNotSupported` diagnostic and
+    // record no receiver-kind metadata.
     let output = typecheck_inline(
         r"
 fn consume(s: Stream<string>) {
@@ -395,27 +420,41 @@ fn consume(s: Stream<string>) {
 }
 ",
     );
-    assert!(
-        output.errors.is_empty(),
-        "expected clean typecheck, got: {:#?}",
+    let adapter_errors: Vec<_> = output
+        .errors
+        .iter()
+        .filter(|e| matches!(&e.kind, TypeErrorKind::StreamAdapterNotSupported { .. }))
+        .collect();
+    assert_eq!(
+        adapter_errors.len(),
+        1,
+        "expected exactly one StreamAdapterNotSupported diagnostic, got: {:#?}",
         output.errors
     );
     assert!(
-        output
+        matches!(
+            &adapter_errors[0].kind,
+            TypeErrorKind::StreamAdapterNotSupported { method, element_ty }
+                if method == "map" && element_ty == "string"
+        ),
+        "expected `map`/`string` in the diagnostic, got: {:?}",
+        adapter_errors[0].kind
+    );
+    assert!(
+        !output
             .method_call_receiver_kinds
             .values()
             .any(|kind| matches!(
                 kind,
-                hew_types::MethodCallReceiverKind::StreamInstance { element_kind }
-                    if element_kind == "string"
+                hew_types::MethodCallReceiverKind::StreamInstance { .. }
             )),
-        "expected string stream receiver metadata, got: {:?}",
+        "fail-closed adapters must record no StreamInstance metadata, got: {:?}",
         output.method_call_receiver_kinds
     );
 }
 
 #[test]
-fn method_call_receiver_kinds_record_bytes_stream_dispatch() {
+fn method_call_stream_filter_fails_closed_with_honest_diagnostic() {
     let output = typecheck_inline(
         r"
 fn consume(s: Stream<bytes>) {
@@ -423,21 +462,35 @@ fn consume(s: Stream<bytes>) {
 }
 ",
     );
-    assert!(
-        output.errors.is_empty(),
-        "expected clean typecheck, got: {:#?}",
+    let adapter_errors: Vec<_> = output
+        .errors
+        .iter()
+        .filter(|e| matches!(&e.kind, TypeErrorKind::StreamAdapterNotSupported { .. }))
+        .collect();
+    assert_eq!(
+        adapter_errors.len(),
+        1,
+        "expected exactly one StreamAdapterNotSupported diagnostic, got: {:#?}",
         output.errors
     );
     assert!(
-        output
+        matches!(
+            &adapter_errors[0].kind,
+            TypeErrorKind::StreamAdapterNotSupported { method, element_ty }
+                if method == "filter" && element_ty == "bytes"
+        ),
+        "expected `filter`/`bytes` in the diagnostic, got: {:?}",
+        adapter_errors[0].kind
+    );
+    assert!(
+        !output
             .method_call_receiver_kinds
             .values()
             .any(|kind| matches!(
                 kind,
-                hew_types::MethodCallReceiverKind::StreamInstance { element_kind }
-                    if element_kind == "bytes"
+                hew_types::MethodCallReceiverKind::StreamInstance { .. }
             )),
-        "expected bytes stream receiver metadata, got: {:?}",
+        "fail-closed adapters must record no StreamInstance metadata, got: {:?}",
         output.method_call_receiver_kinds
     );
 }

--- a/tests/vertical-slice/reject/stream_lazy_adapter_unsupported.hew
+++ b/tests/vertical-slice/reject/stream_lazy_adapter_unsupported.hew
@@ -1,0 +1,17 @@
+// Reject fixture: the lazy stream adapters (#2530 diagnostic-honesty gate).
+// `Stream<T>.take/map/filter` type-check (they carry builtin signatures) but
+// have no MIR lowering. They previously routed to the legacy `DeferToLowering`
+// codegen path the Rust MIR pipeline does not consume, so they dead-ended in
+// HIR lowering with TWO misleading, internal-shaped `E_NOT_YET_IMPLEMENTED`
+// notes ("method-call rewrite variant" + "Unsupported HIR node reached
+// verification"). The checker must now reject the call with exactly ONE honest
+// capability-boundary diagnostic that points at the supported alternative, so a
+// regression back to the dead-ending stub (or a diagnostic cascade) fails this
+// gate.
+// Expected: exactly one error carrying `E_STREAM_ADAPTER_UNSUPPORTED`, and NO
+// leftover `E_NOT_YET_IMPLEMENTED` / "reached verification" internal noise.
+fn use_stream(s: Stream<string>) {
+    let _t = s.take(3);
+}
+
+fn main() {}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -2116,6 +2116,24 @@ fi
 # the diagnostic's pretty-printed `lines` / `Stream<bytes>` names.
 grep -qF 'no method `lines` on `Stream<bytes>`' "${reject_output}"
 
+# Reject: the lazy stream adapters (#2530 diagnostic-honesty gate).
+# `Stream<T>.take/map/filter` type-check but have no MIR lowering; they must
+# fail closed at the checker with exactly ONE honest capability-boundary
+# diagnostic (E_STREAM_ADAPTER_UNSUPPORTED) rather than dead-ending in HIR
+# lowering with the pair of internal-shaped NotYetImplemented notes the old
+# DeferToLowering stub emitted.
+expect_check_fail_error_count_no_cascade \
+  "${ROOT}/tests/vertical-slice/reject/stream_lazy_adapter_unsupported.hew" \
+  1 \
+  "stream-lazy-adapter-unsupported" \
+  "E_NOT_YET_IMPLEMENTED" \
+  "reached verification"
+if "${HEW}" check "${ROOT}/tests/vertical-slice/reject/stream_lazy_adapter_unsupported.hew" >"${reject_output}" 2>&1; then
+  echo "expected stream-lazy-adapter-unsupported fixture to fail" >&2
+  exit 1
+fi
+grep -qF 'E_STREAM_ADAPTER_UNSUPPORTED' "${reject_output}"
+
 # Accept + run: the §6.5 first-class stream pipe round-trips bytes end-to-end.
 # Two writes then a close drain through `for await`; the summed chunk lengths
 # (2 + 3) leave exit code 5. Regression-guards the shipped stream surface so a


### PR DESCRIPTION
Fixes #2530 (part 1: the Stream adapter dead-end).

## Problem

`Stream<T>.take` / `.map` / `.filter` carry builtin method signatures, so they type-check, but they have no MIR lowering. The checker routed them to the legacy `DeferToLowering` codegen rewrite that the Rust MIR pipeline never consumes, so they dead-ended in HIR lowering and surfaced **two** misleading, internal-shaped diagnostics for one call:

```
error: E_NOT_YET_IMPLEMENTED: `method-call rewrite variant for `.take`` ...
  this method-call rewrite variant is not supported in the Rust MIR pipeline
error: E_NOT_YET_IMPLEMENTED: `unsupported rewrite variant for method `take`` ...
  verifier: Unsupported HIR node reached verification without a prior diagnostic
```

Neither points at the real capability boundary — a diagnostic-honesty / no-NYI ship-gate violation.

## Fix

Emit a single honest capability-boundary error at the checker (mirroring the `OpaqueDirectConstruct` precedent), then return `Ty::Error` so lowering never reaches the stub:

```
error: `Stream<string>.take` is not yet supported: the lazy stream adapters
(`take`/`map`/`filter`) have no lowering yet; consume the stream directly with
`for await x in s { ... }` (applying the `take`/`map`/`filter` logic in the loop
body), or `.recv()` in a loop [E_STREAM_ADAPTER_UNSUPPORTED]
```

New `TypeErrorKind::StreamAdapterNotSupported` (envelope `E_STREAM_ADAPTER_UNSUPPORTED`) names the method + element type and points at the supported alternative. The adapter argument is still checked first so an ill-typed closure arg is not masked by the boundary error.

Supported surfaces are unchanged: `.recv()` / `.try_recv()` / `.collect()` / `.chunks()` still type-check and lower; unknown methods still route to the similar-method suggestion path. The now-unused `DeferToLowering` producer helper and `stream_receiver_element_kind` (its only remaining caller) plus that helper's unit test are removed; the `DeferToLowering` rewrite variant and the `StreamInstance` receiver-kind stay for defensive match coverage.

Scope: this addresses part 1 of #2530 (the Stream adapter dead-end). Part 2 (the `fixed-array.iter()` cascade) is not touched here.

## Tests

- Two new `hew-types` unit tests: all three adapters emit exactly one `StreamAdapterNotSupported` error with no `NotYetImplemented` leak and a `for await` suggestion; `.recv()` still type-checks cleanly.
- New `stream_lazy_adapter_unsupported` vertical-slice reject fixture asserting exactly one error carrying the new envelope and zero `E_NOT_YET_IMPLEMENTED` / "reached verification" noise.
- `cargo test -p hew-types --lib` 1661/1661; `cargo fmt -p hew-types -- --check` + `cargo clippy -p hew-types --lib -D warnings` clean; full vertical-slice suite 466/0.