### PR TITLE
fix(sandbox-vm): truncate wrapping i64 add/sub/mul to 64 bits (#2341)

### DIFF
--- a/examples/sandbox-graduation/wrapping_binary_operators.hew
+++ b/examples/sandbox-graduation/wrapping_binary_operators.hew
@@ -1,8 +1,30 @@
-// IS: parity covers non-overflow values; the wraparound boundary is tracked in #2341.
+// Wrapping binary operators (`&+`/`&-`/`&*`) must produce two's-complement
+// 64-bit results in both the native backend and the sandbox VM, including when
+// an operation overflows. This pins the parity fixed in #2341: before the VM
+// applied `asIntN(64)` truncation, an overflowing wrapping op produced a
+// mathematically-unbounded value (e.g. it kept 2^63 instead of wrapping to
+// `i64::MIN`).
+//
+// The overflowing values below are *computed* from safe-range literals via
+// wrapping multiplication, so every literal stays inside the JS safe-integer
+// range while the wrapping ops themselves cross the 64-bit boundary — native
+// (i64) and the VM (BigInt + asIntN(64)) must agree on the wrapped result.
 fn main() {
     let a = 10;
     let b = 3;
     println(f"wadd: {a &+ b}");
     println(f"wsub: {a &- b}");
     println(f"wmul: {a &* b}");
+
+    // 3037000500^2 = 9223372037000250000 > i64::MAX, so the wrapping multiply
+    // overflows and wraps to a two's-complement negative. Non-truncating math
+    // would instead keep the unbounded positive product.
+    let base = 3037000500;
+    let sq = base &* base;
+    println(f"wmul_of: {sq}");
+
+    // Feed the wrapped (large-magnitude) value back through wrapping add/sub so
+    // those opcodes' truncation is exercised on a genuinely 64-bit operand.
+    println(f"wadd_of: {sq &+ sq}");
+    println(f"wsub_of: {sq &- base}");
 }

--- a/hew-sandbox-vm/src/interpreter/interpreter.ts
+++ b/hew-sandbox-vm/src/interpreter/interpreter.ts
@@ -330,14 +330,19 @@ class Interpreter {
         frame.locals.set(target, cloneValue(this.resolve(frame, instruction.args[1], instruction.span)));
         return;
       }
+      // Wrapping arithmetic (`&+`/`&-`/`&*`): truncate to two's-complement 64 bits
+      // to match native LLVM `i64.add/sub/mul`, which wrap silently on overflow.
+      // Without `asIntN(64)` an overflowing operation yields a mathematically
+      // unbounded BigInt (e.g. `i64::MAX &+ 1` -> 2^63 instead of `i64::MIN`).
+      // The shift opcode already applies the same truncation; see #2341.
       case "i64.add":
-        this.writeDst(frame, instruction, this.i64(this.i64Arg(frame, instruction.args[0], instruction.span) + this.i64Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(frame, instruction, this.i64(BigInt.asIntN(64, this.i64Arg(frame, instruction.args[0], instruction.span) + this.i64Arg(frame, instruction.args[1], instruction.span))));
         return;
       case "i64.sub":
-        this.writeDst(frame, instruction, this.i64(this.i64Arg(frame, instruction.args[0], instruction.span) - this.i64Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(frame, instruction, this.i64(BigInt.asIntN(64, this.i64Arg(frame, instruction.args[0], instruction.span) - this.i64Arg(frame, instruction.args[1], instruction.span))));
         return;
       case "i64.mul":
-        this.writeDst(frame, instruction, this.i64(this.i64Arg(frame, instruction.args[0], instruction.span) * this.i64Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(frame, instruction, this.i64(BigInt.asIntN(64, this.i64Arg(frame, instruction.args[0], instruction.span) * this.i64Arg(frame, instruction.args[1], instruction.span))));
         return;
       case "i64.and":
         this.writeDst(frame, instruction, this.i64(this.i64Arg(frame, instruction.args[0], instruction.span) & this.i64Arg(frame, instruction.args[1], instruction.span)));

--- a/hew-sandbox-vm/test/wrapping-arith-parity.test.mjs
+++ b/hew-sandbox-vm/test/wrapping-arith-parity.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runBytecode } from "../dist/interpreter/index.js";
+
+// Regression coverage for #2341: the sandbox VM's wrapping arithmetic opcodes
+// (`&+`/`&-`/`&*` -> i64.add/sub/mul) must truncate their result to
+// two's-complement 64 bits, matching native LLVM which wraps silently on
+// overflow. Before the fix these opcodes fed the raw (unbounded) BigInt to
+// `this.i64()`, so an overflowing operation produced a mathematically
+// unbounded value (e.g. `i64::MAX &+ 1` yielded 2^63 instead of `i64::MIN`).
+//
+// These fixtures are handcrafted inline bytecode (same approach as
+// unsupported-gates.test.mjs) rather than compiler output, so they run without
+// the wasm bridge. Each pins one boundary case where wrapping and native
+// arithmetic diverge; ordinary non-overflow wrapping is already covered by the
+// arithmetic parity fixtures.
+
+const I64_MIN = "-9223372036854775808";
+const I64_MAX = "9223372036854775807";
+
+// Build a minimal single-function package: two i64 constants, one wrapping
+// op, then println(result). `lhs`/`rhs` are decimal string literals so the
+// full 64-bit range is expressible (const.i64 accepts string literals for
+// values outside the JS safe-integer range, as in fixture 26-i64-bigint).
+function wrappingOpPackage(op, lhs, rhs) {
+  return {
+    schema_version: "hew.sandbox.bytecode.v0",
+    package_id: "pkg:wrapping-arith",
+    hew_version: "0.6.0-pre",
+    compiler_version: "test",
+    profile: "sandbox.educational.v0",
+    source_map: { sources: [], spans: [] },
+    module_graph: {
+      entry: "mod:main",
+      modules: [{ id: "mod:main", path: "main.hew", source_id: "src:main", imports: [], functions: ["fn:main"] }]
+    },
+    layouts: {
+      types: [
+        { id: "type:unit", kind: "unit", name: "()" },
+        { id: "type:i64", kind: "integer", name: "i64" },
+        { id: "type:string", kind: "string", name: "String" }
+      ],
+      records: [],
+      enums: [],
+      actors: [],
+      supervisors: [],
+      machines: []
+    },
+    stdlib_symbols: [
+      {
+        id: "sym:core.stdout.println",
+        module: "core.stdout",
+        name: "println",
+        params: ["type:i64"],
+        result: "type:unit",
+        capability: "core.stdout",
+        admission: "allowed"
+      }
+    ],
+    capabilities: [
+      {
+        id: "core.stdout",
+        disposition: "allowed",
+        reason: "wrapping-arith parity test stdout",
+        required_by: ["sym:core.stdout.println"]
+      }
+    ],
+    functions: [
+      {
+        id: "fn:main",
+        module: "mod:main",
+        name: "main",
+        params: [],
+        result: "type:unit",
+        locals: [
+          { id: "local:main.lhs", name: null, type: "type:i64", mutable: false, span: null },
+          { id: "local:main.rhs", name: null, type: "type:i64", mutable: false, span: null },
+          { id: "local:main.res", name: null, type: "type:i64", mutable: false, span: null },
+          { id: "local:main.unit", name: null, type: "type:unit", mutable: false, span: null }
+        ],
+        blocks: [
+          {
+            id: "block:main.entry",
+            params: [],
+            instructions: [
+              { op: "const.i64", dst: "local:main.lhs", args: [{ kind: "literal", value: lhs }], span: null },
+              { op: "const.i64", dst: "local:main.rhs", args: [{ kind: "literal", value: rhs }], span: null },
+              {
+                op,
+                dst: "local:main.res",
+                args: [
+                  { kind: "local", value: "local:main.lhs" },
+                  { kind: "local", value: "local:main.rhs" }
+                ],
+                span: null
+              },
+              {
+                op: "call.stdlib",
+                dst: null,
+                args: [
+                  { kind: "symbol", value: "sym:core.stdout.println" },
+                  { kind: "local", value: "local:main.res" }
+                ],
+                span: null
+              },
+              { op: "const.unit", dst: "local:main.unit", args: [], span: null }
+            ],
+            terminator: { op: "return", args: [{ kind: "local", value: "local:main.unit" }], span: null },
+            span: null
+          }
+        ],
+        span: null
+      }
+    ]
+  };
+}
+
+function runWrapping(op, lhs, rhs) {
+  const trace = runBytecode(wrappingOpPackage(op, lhs, rhs), {
+    fixtureId: "wrapping-arith",
+    traceId: "trace:wrapping-arith",
+    replay: { seed: 42, step_budget: 1000, virtual_clock: { epoch_ms: 0, tick_ms: 1, current_ms: 0 }, inputs: [] }
+  });
+  assert.equal(
+    trace.result,
+    "ok",
+    `expected ok but got ${trace.result}: ${JSON.stringify(trace.final_state.runtime_failures)}`
+  );
+  assert.deepEqual(trace.final_state.runtime_failures, []);
+  return trace.final_state.stdout.join("").trim();
+}
+
+test("i64.add wraps i64::MAX &+ 1 to i64::MIN (two's-complement)", () => {
+  assert.equal(runWrapping("i64.add", I64_MAX, "1"), I64_MIN);
+});
+
+test("i64.sub wraps i64::MIN &- 1 to i64::MAX (two's-complement)", () => {
+  assert.equal(runWrapping("i64.sub", I64_MIN, "1"), I64_MAX);
+});
+
+test("i64.mul wraps i64::MAX &* 2 to -2 (two's-complement)", () => {
+  // i64::MAX * 2 = 2^64 - 2; asIntN(64) -> -2.
+  assert.equal(runWrapping("i64.mul", I64_MAX, "2"), "-2");
+});
+
+test("i64.mul wraps i64::MIN &* -1 back to i64::MIN (magnitude unrepresentable)", () => {
+  // -(i64::MIN) = 2^63 is unrepresentable; two's-complement leaves i64::MIN.
+  assert.equal(runWrapping("i64.mul", I64_MIN, "-1"), I64_MIN);
+});
+
+test("non-overflow wrapping arithmetic still matches native", () => {
+  // Negative control: ordinary in-range wrapping ops are unchanged by the
+  // truncation (asIntN(64) is the identity on values already in range).
+  assert.equal(runWrapping("i64.add", "2", "3"), "5");
+  assert.equal(runWrapping("i64.sub", "10", "4"), "6");
+  assert.equal(runWrapping("i64.mul", "-6", "7"), "-42");
+});

--- a/hew-sandbox-wasm/tests/parity.rs
+++ b/hew-sandbox-wasm/tests/parity.rs
@@ -390,7 +390,8 @@ const PARITY_CASES: &[ParityCase] = &[
         accepted_divergences: &[],
     },
     ParityCase {
-        // IS: parity covers non-overflow values; the wraparound boundary is tracked in #2341.
+        // Wrapping ops at the overflow boundary: the VM truncates `&+`/`&-`/`&*`
+        // to two's-complement 64 bits to match native (#2341).
         test_name: "wrapping_binary_operators",
         source_rel: "examples/sandbox-graduation/wrapping_binary_operators.hew",
         accepted_divergences: &[],

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -207,7 +207,8 @@ const CONSTRUCTS: &[Construct] = &[
     },
     Construct {
         id: "wrapping binary operators",
-        // IS: parity covers non-overflow values; the wraparound boundary is tracked in #2341.
+        // Boundary wraparound parity (`i64::MAX &+ 1` -> `i64::MIN`) is pinned by
+        // the wrapping_binary_operators parity case; this probe covers admission.
         probe: "fn main() {\n    let a = 10;\n    let b = 3;\n    println(a &+ b);\n    println(a &- b);\n    println(a &* b);\n}\n",
         coverage: Coverage::Parity("wrapping_binary_operators"),
     },


### PR DESCRIPTION
Fixes #2341.

## Problem

The sandbox VM's wrapping arithmetic opcodes (`&+`/`&-`/`&*` → `i64.add`/`i64.sub`/`i64.mul`) fed their raw BigInt result straight to `this.i64()` without applying `BigInt.asIntN(64, ...)` truncation. A genuinely overflowing wrapping operation therefore produced a mathematically-unbounded BigInt instead of the two's-complement wraparound native LLVM produces:

- `i64::MAX &+ 1` → observed `2^63` (`9223372036854775808`) in the VM, but `i64::MIN` natively.

Non-overflow wrapping arithmetic already agreed with native (covered by the arithmetic parity fixtures), so the divergence was confined to the overflow boundary.

## Fix

Apply `BigInt.asIntN(64, ...)` to each wrapping opcode's result in `hew-sandbox-vm/src/interpreter/interpreter.ts`, matching the truncation the shift opcode already performs and the native `i64.add/sub/mul` two's-complement semantics.

## Coverage

- **`hew-sandbox-vm/test/wrapping-arith-parity.test.mjs`** (new): handcrafted-bytecode unit tests pinning `MAX &+ 1 → MIN`, `MIN &- 1 → MAX`, `MAX &* 2 → -2`, `MIN &* -1 → MIN`, plus a non-overflow negative control. Runs without the wasm bridge (same inline-bytecode approach as `unsupported-gates.test.mjs`).
- **`examples/sandbox-graduation/wrapping_binary_operators.hew`**: the existing parity fixture now *computes* overflowing operands from safe-range literals (`base &* base`, then feeds the wrapped value back through `&+`/`&-`) so the native-vs-VM parity gate exercises the 64-bit wraparound end to end. Keeping operands computed avoids the separate near-boundary integer-literal JSON-precision concern (large i64 literals lose precision through `JSON.parse`) — every literal here stays inside the JS safe-integer range while the wrapping ops themselves cross the boundary.
- The `#2341`-deferral comments in `parity.rs` / `parity_ratchet.rs` are updated to note the boundary is now covered.

## Verification

- `node --test test/wrapping-arith-parity.test.mjs`: 5/5 pass.
- `cargo test -p hew-sandbox-wasm --test parity --test parity_ratchet`: 2/2 + 5/5 pass (native ↔ VM stdout parity across the new overflow rows).
- `cargo fmt -p hew-sandbox-wasm -- --check`: clean.
- `hew check examples/sandbox-graduation/wrapping_binary_operators.hew`: OK.
- **Load-bearing A/B (both layers):** reverting the `asIntN` truncation fails the VM unit test (`9223372036854775808` vs `-9223372036854775808`) and the parity gate (untruncated `9223372037000250000`/`18446744074000500000` vs the wrapped native results); restoring re-passes both.