### PR TITLE
fix(sandbox): string-encode out-of-safe-range i64 literals in emitter

### DIFF
--- a/hew-sandbox-vm/src/interpreter/values.ts
+++ b/hew-sandbox-vm/src/interpreter/values.ts
@@ -26,6 +26,8 @@ export type VmValue =
 
 export const UNIT: VmValue = { kind: "unit" };
 
+const I64_LITERAL_DECIMAL = /^(?:0|-?[1-9]\d*)$/;
+
 export function cloneValue(value: VmValue): VmValue {
   switch (value.kind) {
     case "unit":
@@ -57,6 +59,10 @@ export function cloneValue(value: VmValue): VmValue {
 }
 
 export function valueFromLiteral(value: JsonValue): VmValue {
+  const taggedI64 = taggedI64Literal(value);
+  if (taggedI64 !== null) {
+    return { kind: "i64", value: taggedI64 };
+  }
   if (value === null) {
     return UNIT;
   }
@@ -70,6 +76,22 @@ export function valueFromLiteral(value: JsonValue): VmValue {
     default:
       return { kind: "string", value: canonicalJson(value) };
   }
+}
+
+function taggedI64Literal(value: JsonValue): bigint | null {
+  if (value === null || Array.isArray(value) || typeof value !== "object") {
+    return null;
+  }
+  if (
+    Object.keys(value).length !== 2 ||
+    value.kind !== "i64" ||
+    typeof value.value !== "string" ||
+    !I64_LITERAL_DECIMAL.test(value.value)
+  ) {
+    return null;
+  }
+  const parsed = BigInt(value.value);
+  return BigInt.asIntN(64, parsed) === parsed ? parsed : null;
 }
 
 /// Render an f64 value to a string matching native Hew output.

--- a/hew-sandbox-vm/test/run-program.test.mjs
+++ b/hew-sandbox-vm/test/run-program.test.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { pathToFileURL, fileURLToPath } from "node:url";
+import { runBytecode } from "../dist/interpreter/index.js";
 import { runProgram } from "../dist/interpreter/run-program.js";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -30,6 +31,42 @@ test("runProgram hello_world returns stdout and zero exit code", () => {
   assert.equal(result.stdout, "Hello, sandbox!\n");
   assert.equal(result.exit_code, 0);
   assert.deepEqual(result.diagnostics, []);
+});
+
+test("serialized bytecode preserves supervisor child i64 bounds", () => {
+  const compileOutput = globalThis.__hewSandboxCompileToSandboxBytecode(
+    `
+actor Bounds {
+    let max: i64;
+    let min: i64;
+}
+
+supervisor BoundsTree {
+    strategy: one_for_one;
+    intensity: 1 within 60s;
+    child bounds: Bounds(max: 9223372036854775807, min: -9223372036854775808);
+}
+
+fn main() {
+    let tree = spawn BoundsTree;
+}
+`,
+    "sandbox-vm-export"
+  );
+  const compiled = typeof compileOutput === "string" ? JSON.parse(compileOutput) : compileOutput;
+
+  assert.ok(compiled.diagnostics.every((diagnostic) => diagnostic.severity !== "error"), JSON.stringify(compiled.diagnostics));
+  assert.ok(compiled.bytecode, "compiler should emit bytecode");
+  const bytecode = JSON.parse(JSON.stringify(compiled.bytecode));
+  assert.deepEqual(bytecode.layouts.supervisors[0].children[0].start_spec.args, [
+    { kind: "i64", value: "9223372036854775807" },
+    { kind: "i64", value: "-9223372036854775808" }
+  ]);
+
+  const trace = runBytecode(bytecode);
+  const childSpawn = trace.events.find((event) => event.message === "actor.spawn");
+  assert.ok(childSpawn?.text, "supervisor child should spawn");
+  assert.deepEqual(JSON.parse(childSpawn.text).state, ["9223372036854775807", "-9223372036854775808"]);
 });
 
 test("runProgram reads two stdin lines from the page input buffer byte-cleanly", () => {

--- a/hew-sandbox-wasm/src/emit.rs
+++ b/hew-sandbox-wasm/src/emit.rs
@@ -4773,12 +4773,29 @@ fn parse_duration_ms(raw: &str) -> u64 {
 /// exact 64-bit magnitude. In-range values stay numeric to keep the common-case
 /// bytecode compact and diff-friendly.
 fn i64_literal_operand(value: i64) -> Operand {
-    const SAFE_INT_MAX: i64 = 9_007_199_254_740_991; // 2^53 - 1
-    if value.unsigned_abs() > SAFE_INT_MAX as u64 {
+    if i64_requires_string_encoding(value) {
         Operand::literal(value.to_string())
     } else {
         Operand::literal(value)
     }
+}
+
+/// Build a supervisor child initial-state literal that preserves its i64 type.
+///
+/// Unlike a `const.i64` operand, supervisor initial-state values have no opcode
+/// to provide their type. A bare string therefore denotes a Hew `String`, so an
+/// out-of-safe-range i64 is encoded as the VM's tagged i64 JSON form.
+fn supervisor_i64_literal(value: i64) -> Value {
+    if i64_requires_string_encoding(value) {
+        json!({ "kind": "i64", "value": value.to_string() })
+    } else {
+        Value::from(value)
+    }
+}
+
+fn i64_requires_string_encoding(value: i64) -> bool {
+    const SAFE_INT_MAX: i64 = 9_007_199_254_740_991; // 2^53 - 1
+    value.unsigned_abs() > SAFE_INT_MAX as u64
 }
 
 /// Evaluate a constant literal expression into a JSON value for baking a
@@ -4786,7 +4803,7 @@ fn i64_literal_operand(value: i64) -> Operand {
 /// (which the educational profile does not yet admit in child specs).
 fn literal_json(expr: &Expr) -> Option<Value> {
     match expr {
-        Expr::Literal(Literal::Integer { value, .. }) => Some(Value::from(*value)),
+        Expr::Literal(Literal::Integer { value, .. }) => Some(supervisor_i64_literal(*value)),
         Expr::Literal(Literal::Float(value)) => Some(Value::from(*value)),
         Expr::Literal(Literal::String(value)) => Some(Value::from(value.clone())),
         Expr::Literal(Literal::Bool(value)) => Some(Value::from(*value)),

--- a/hew-sandbox-wasm/src/emit.rs
+++ b/hew-sandbox-wasm/src/emit.rs
@@ -2272,7 +2272,7 @@ impl<'pkg, 'src> FunctionEmitter<'pkg, 'src> {
                 self.emit_instruction(
                     "const.i64",
                     Some(dst.clone()),
-                    vec![Operand::literal(*value)],
+                    vec![i64_literal_operand(*value)],
                     Some(span),
                     None,
                 );
@@ -2327,7 +2327,7 @@ impl<'pkg, 'src> FunctionEmitter<'pkg, 'src> {
                 self.emit_instruction(
                     "const.i64",
                     Some(dst.clone()),
-                    vec![Operand::literal(*value)],
+                    vec![i64_literal_operand(*value)],
                     Some(span),
                     Some(json!({ "literal_kind": "duration_ns" })),
                 );
@@ -4759,6 +4759,25 @@ fn parse_duration_ms(raw: &str) -> u64 {
         "h" => value.saturating_mul(3_600_000),
         // Seconds is both the explicit `"s"` unit and the fallback default.
         _ => value.saturating_mul(1_000),
+    }
+}
+
+/// Build a `const.i64` literal operand that survives the VM's JSON transport.
+///
+/// The bytecode is serialized to JSON and re-parsed by the JS VM via
+/// `JSON.parse`, whose numbers are IEEE-754 doubles. Any i64 outside the
+/// safe-integer range (`|n| > 2^53 - 1`) would silently lose precision as a
+/// JSON number (e.g. `i64::MAX` → `9223372036854775808`). The VM's `bigintArg`
+/// reader already accepts a decimal *string* operand and parses it with
+/// `BigInt(..)`, so we string-encode out-of-safe-range values to preserve the
+/// exact 64-bit magnitude. In-range values stay numeric to keep the common-case
+/// bytecode compact and diff-friendly.
+fn i64_literal_operand(value: i64) -> Operand {
+    const SAFE_INT_MAX: i64 = 9_007_199_254_740_991; // 2^53 - 1
+    if value.unsigned_abs() > SAFE_INT_MAX as u64 {
+        Operand::literal(value.to_string())
+    } else {
+        Operand::literal(value)
     }
 }
 

--- a/hew-sandbox-wasm/src/lib.rs
+++ b/hew-sandbox-wasm/src/lib.rs
@@ -1458,6 +1458,100 @@ fn main() {
             .collect()
     }
 
+    /// Collect the first-argument `Value` of every `const.i64` instruction.
+    fn const_i64_operand_values(bytecode: &SandboxBytecodePackage) -> Vec<serde_json::Value> {
+        bytecode
+            .functions
+            .iter()
+            .flat_map(|function| &function.blocks)
+            .flat_map(|block| &block.instructions)
+            .filter(|instruction| instruction.op == "const.i64")
+            .filter_map(|instruction| instruction.args.first())
+            .map(|operand| operand.value.clone())
+            .collect()
+    }
+
+    #[test]
+    fn large_i64_literal_is_string_encoded_to_survive_json_transport() {
+        // Any i64 outside the JS safe-integer range (|n| > 2^53 - 1) must be
+        // emitted as a decimal *string* operand, otherwise it loses precision
+        // when the JS VM re-parses the bytecode via JSON.parse (doubles).
+        set_test_hewpath();
+        let source = r#"
+fn main() {
+    let big = 9223372036854775807;
+    let neg = -9223372036854775808;
+    println("large literals");
+}
+"#;
+        let output = compile_to_sandbox_bytecode(source, Some("sandbox-vm-export"))
+            .expect("compile should not throw");
+        assert!(
+            output.diagnostics.iter().all(|d| d.severity != "error"),
+            "unexpected diagnostics: {:#?}",
+            output.diagnostics
+        );
+        let bytecode = output.bytecode.expect("bytecode should be emitted");
+        let values = const_i64_operand_values(&bytecode);
+        assert!(
+            values
+                .iter()
+                .any(|v| v == &serde_json::json!("9223372036854775807")),
+            "i64::MAX must be string-encoded, got: {values:#?}"
+        );
+        assert!(
+            values
+                .iter()
+                .any(|v| v == &serde_json::json!("-9223372036854775808")),
+            "i64::MIN must be string-encoded, got: {values:#?}"
+        );
+        // Regression guard: the raw JSON must not contain the imprecise
+        // number-encoded form of i64::MAX.
+        let serialized = serde_json::to_string(&bytecode).expect("serialize");
+        assert!(
+            !serialized.contains(":9223372036854775807,")
+                && !serialized.contains(":9223372036854775807}"),
+            "i64::MAX must not appear as a bare JSON number operand"
+        );
+    }
+
+    #[test]
+    fn small_i64_literal_stays_numeric() {
+        // In-safe-range values stay compact JSON numbers so common-case
+        // bytecode remains small and diff-friendly.
+        set_test_hewpath();
+        let source = r#"
+fn main() {
+    let small = 42;
+    let boundary = 9007199254740991;
+    println("small literals");
+}
+"#;
+        let output = compile_to_sandbox_bytecode(source, Some("sandbox-vm-export"))
+            .expect("compile should not throw");
+        assert!(
+            output.diagnostics.iter().all(|d| d.severity != "error"),
+            "unexpected diagnostics: {:#?}",
+            output.diagnostics
+        );
+        let bytecode = output.bytecode.expect("bytecode should be emitted");
+        let values = const_i64_operand_values(&bytecode);
+        assert!(
+            values.iter().any(|v| v == &serde_json::json!(42)),
+            "small literal must stay numeric, got: {values:#?}"
+        );
+        assert!(
+            values
+                .iter()
+                .any(|v| v == &serde_json::json!(9_007_199_254_740_991_i64)),
+            "safe-int boundary must stay numeric, got: {values:#?}"
+        );
+        assert!(
+            !values.iter().any(|v| v == &serde_json::json!("42")),
+            "small literal must not be string-encoded, got: {values:#?}"
+        );
+    }
+
     #[test]
     fn simple_for_range_lowers_to_bytecode() {
         set_test_hewpath();

--- a/hew-sandbox-wasm/src/lib.rs
+++ b/hew-sandbox-wasm/src/lib.rs
@@ -1553,6 +1553,52 @@ fn main() {
     }
 
     #[test]
+    fn supervisor_i64_bounds_are_tagged_in_serialized_bytecode() {
+        set_test_hewpath();
+        let source = r"
+actor Bounds {
+    let max: i64;
+    let min: i64;
+}
+
+supervisor BoundsTree {
+    strategy: one_for_one;
+    intensity: 1 within 60s;
+    child bounds: Bounds(max: 9223372036854775807, min: -9223372036854775808);
+}
+
+fn main() {
+    let tree = spawn BoundsTree;
+}
+";
+        let output = compile_to_sandbox_bytecode(source, Some("sandbox-vm-export"))
+            .expect("compile should not throw");
+        assert!(
+            output.diagnostics.iter().all(|d| d.severity != "error"),
+            "unexpected diagnostics: {:#?}",
+            output.diagnostics
+        );
+        let bytecode = output.bytecode.expect("bytecode should be emitted");
+        let serialized = serde_json::to_string(&bytecode).expect("bytecode should serialize");
+        let decoded: SandboxBytecodePackage =
+            serde_json::from_str(&serialized).expect("serialized bytecode should deserialize");
+        let args = &decoded.layouts.supervisors[0].children[0].start_spec.args;
+        assert_eq!(
+            args,
+            &[
+                serde_json::json!({ "kind": "i64", "value": "9223372036854775807" }),
+                serde_json::json!({ "kind": "i64", "value": "-9223372036854775808" }),
+            ],
+            "supervisor child i64 bounds must retain their tagged decimal form"
+        );
+        assert!(
+            !serialized.contains(":9223372036854775807")
+                && !serialized.contains(":-9223372036854775808"),
+            "supervisor i64 bounds must not be serialized as bare JSON numbers"
+        );
+    }
+
+    #[test]
     fn simple_for_range_lowers_to_bytecode() {
         set_test_hewpath();
         let output = compile_to_sandbox_bytecode(


### PR DESCRIPTION
## Problem

The sandbox emitter lowered every integer/duration literal via `Operand::literal(*value)`, serializing i64 constants as JSON **numbers**. The JS VM re-parses bytecode with `JSON.parse`, whose numbers are IEEE-754 doubles, so any literal outside the safe-integer range (`|n| > 2^53 - 1`) silently lost precision *before execution*:

```
i64::MAX  9223372036854775807  →  JSON.parse  →  9223372036854776000
```

Demonstrated directly:

```
$ node -e 'console.log(JSON.parse(JSON.stringify({v:9223372036854775807})).v.toString())'
9223372036854776000        # wrong: != i64::MAX
```

This was noted (out of scope) while fixing #2341: the parity fixture there deliberately computes large operands from safe-range literals to sidestep exactly this emitter bug.

## Fix

The VM's `const.i64` reader (`bigintArg`) *already* accepts a decimal **string** operand and parses it with `BigInt(..)` — the handcrafted `26-i64-bigint` fixture string-encodes big literals for this reason — but the emitter never produced that form. This routes `const.i64` literals (both `Integer` and `Duration`) through a new `i64_literal_operand` helper that string-encodes values with `|n| > 2^53 - 1` and leaves in-range values as compact JSON numbers (keeping common-case bytecode small and diff-friendly).

```
$ node -e 'console.log(BigInt(JSON.parse(JSON.stringify({v:"9223372036854775807"})).v).toString())'
9223372036854775807        # exact
```

## Tests

- Two new `hew-sandbox-wasm` lib tests: assert `i64::MAX`/`i64::MIN` are string-encoded (and never appear as bare JSON-number operands), while `42` and the `2^53 - 1` boundary stay numeric.
- **Load-bearing A/B:** reverting the helper call to `Operand::literal(*value)` fails the large-literal test; restored, re-passes.

## Verification

- `hew-sandbox-wasm` lib: **49/49**
- native↔VM parity gate (`--test parity`, npm deps installed): **2/2**
- `cargo fmt --check` clean; `cargo clippy -p hew-sandbox-wasm --tests -- -D warnings` clean

Scope is emitter-only; no VM or fixture bytecode changes. (The 11 pre-existing `hew-sandbox-vm` M3-conformance golden-trace failures are present on clean `main` and unrelated to this change.)