### PR TITLE
fix(types): name spawn-arg init/field type collision at the checker (#2448)

### DIFF
--- a/hew-types/src/check/expressions.rs
+++ b/hew-types/src/check/expressions.rs
@@ -6739,19 +6739,60 @@ impl Checker {
         // parameter's declared width is the checker-authoritative one — the
         // init body may narrow/widen before storing into the field). Look up
         // `actor_init_params` first so a param like `init(start: i32)` gets
-        // `check_against(..., i32)` here; only actors with no explicit init
-        // (whose spawn args map directly onto bare field names) fall back to
-        // the field-type lookup. Without this, an unmatched `field_name`
-        // silently synthesizes the arg (defaulting an untyped int literal to
-        // `i64`), which then mismatches the init thunk's declared i32
-        // parameter and trips the LLVM verifier at the spawn call site
-        // (#2402).
+        // `check_against(..., i32)` here. The field-type lookup is the
+        // fallback for two shapes: an actor with no explicit `init` (whose
+        // spawn args map directly onto bare field names), and an init-bearing
+        // actor whose spawn arg name does not match any init parameter and so
+        // routes straight into a same-named state field. Without this, an
+        // unmatched `field_name` silently synthesizes the arg (defaulting an
+        // untyped int literal to `i64`), which then mismatches the init
+        // thunk's declared i32 parameter and trips the LLVM verifier at the
+        // spawn call site (#2402).
         let init_params = self.actor_init_params.get(actor_name).cloned();
         for (field_name, (arg, as_)) in args {
             let declared_init_param = init_params
                 .as_ref()
                 .and_then(|params| params.iter().find(|p| &p.name == field_name))
                 .map(|p| p.ty.clone());
+            // A spawn arg name that matches BOTH an init parameter and a state
+            // field with a DIFFERENT declared type is unsatisfiable: the one
+            // provided value cannot simultaneously be the init parameter's type
+            // (which the init thunk expects) and the field's type (which the
+            // constructor stores it into). Checking the arg against the init
+            // parameter alone lets it pass here, but codegen then stores the
+            // value into the mismatched field slot and fails closed with a raw
+            // RecordInit verifier dump (#2448). Name the collision at the
+            // checker level -- the parameter, the field, and the two disagreeing
+            // types -- and skip the per-arg check so no confusing secondary
+            // diagnostic piles on.
+            let field_ty = actor_fields.as_ref().and_then(|f| f.get(field_name));
+            if let (Some(param_ty), Some(field_ty)) = (declared_init_param.as_ref(), field_ty) {
+                if param_ty != field_ty {
+                    let param_display = param_ty.user_facing().to_string();
+                    let field_display = field_ty.user_facing().to_string();
+                    self.report_error(
+                        TypeErrorKind::Mismatch {
+                            expected: field_display.clone(),
+                            actual: param_display.clone(),
+                        },
+                        as_,
+                        format!(
+                            "spawn argument `{field_name}` matches both the `init` \
+                             parameter `{field_name}: {param_display}` and the state \
+                             field `{field_name}: {field_display}` of actor \
+                             `{actor_name}`, whose types disagree; one value cannot \
+                             fill both. Rename the `init` parameter or the field so the \
+                             spawn argument targets exactly one of them."
+                        ),
+                    );
+                    // Still synthesize the arg so downstream expression typing
+                    // sees a type for this span, but do not run `check_against`
+                    // (it would emit a second, less-informative mismatch).
+                    let ty_raw = self.synthesize(arg, as_);
+                    self.enforce_actor_boundary_send(arg, as_, as_, &ty_raw);
+                    continue;
+                }
+            }
             let declared = declared_init_param
                 .as_ref()
                 .or_else(|| actor_fields.as_ref().and_then(|f| f.get(field_name)));

--- a/hew-types/tests/actor/actor_init_typecheck.rs
+++ b/hew-types/tests/actor/actor_init_typecheck.rs
@@ -271,3 +271,80 @@ fn ask_method_form_rejected_by_typechecker() {
          called directly by their `receive fn` name, not via an `.ask()` method"
     );
 }
+
+// #2448 — a spawn arg name that matches BOTH an `init` parameter and a state
+// field with a DIFFERENT type is unsatisfiable. Before the checker guard this
+// slipped through arg checking (the arg was validated against the init param
+// only) and failed closed in codegen with a raw `E_CODEGEN_FRONT_FAIL_CLOSED`
+// RecordInit verifier dump. It must now be a clean checker diagnostic that
+// names the parameter, the field, and the two disagreeing types.
+#[test]
+fn spawn_arg_name_collision_differing_types_reports_checker_diagnostic() {
+    let output = typecheck(
+        r"
+        actor Widget {
+            var n: string;
+            init(n: i32) {
+                let _ = n;
+            }
+            receive fn peek() -> string { n }
+        }
+        fn main() {
+            let _w = spawn Widget(n: 7);
+        }
+    ",
+    );
+    let hit = output.errors.iter().find(|e| {
+        e.message.contains("matches both the `init` parameter") && e.message.contains("state field")
+    });
+    assert!(
+        hit.is_some(),
+        "differing-type spawn-arg name collision should be a named checker \
+         diagnostic, not a codegen fail-closed: {:?}",
+        output.errors
+    );
+    let msg = &hit.unwrap().message;
+    assert!(
+        msg.contains("i32") && msg.contains("string"),
+        "diagnostic should name both disagreeing types (i32 / string): {msg}"
+    );
+    // No raw codegen-front verifier dump should leak through.
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("RecordInit")
+                || e.message.contains("E_CODEGEN_FRONT_FAIL_CLOSED")),
+        "the checker diagnostic must pre-empt the raw codegen dump: {:?}",
+        output.errors
+    );
+}
+
+// #2448 companion — a same-name collision whose types AGREE is a legitimate
+// COEXIST spawn (state field passed at spawn time alongside a same-named init
+// param); it must NOT trip the differing-type guard.
+#[test]
+fn spawn_arg_name_collision_matching_types_is_accepted() {
+    let output = typecheck(
+        r"
+        actor Widget2 {
+            var n: i64;
+            init(n: i64) {
+                let _ = n;
+            }
+            receive fn peek() -> i64 { n }
+        }
+        fn main() {
+            let _w = spawn Widget2(n: 7);
+        }
+    ",
+    );
+    assert!(
+        !output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("matches both the `init` parameter")),
+        "a same-type same-name spawn arg is a valid COEXIST, not a collision: {:?}",
+        output.errors
+    );
+}


### PR DESCRIPTION
## Problem (#2448)

When a spawn argument name matches **both** an `init` parameter and a state field of the target actor, and their declared types **differ**, the checker validated the arg against the init parameter only. That check passed, so the collision slipped through to codegen, where the constructor stored the value into the mismatched field slot and the codegen front failed closed with a raw `E_CODEGEN_FRONT_FAIL_CLOSED` RecordInit verifier dump.

Fail-closed (nothing miscompiles), but the diagnostic pointed at LLVM-shaped internals instead of the source collision.

### Before

```
error: E_CODEGEN_FRONT_FAIL_CLOSED: codegen-front validation failed: fail-closed:
RecordInit field 0 source slot type does not match struct field type:
src=IntType(...i32), field=PointerType(...ptr)
 17 |     let w = spawn Widget(n: 7);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

### After

```
error: spawn argument `n` matches both the `init` parameter `n: i32` and the
state field `n: string` of actor `Widget`, whose types disagree; one value
cannot fill both. Rename the `init` parameter or the field so the spawn
argument targets exactly one of them.
 17 |     let w = spawn Widget(n: 7);
    |                             ^
```

## Fix

`check_spawn_constructor_args` now detects the differing-type name collision **before** the per-arg check and emits a checker-level `Mismatch` diagnostic naming the parameter, the field, and the two disagreeing types. It then synthesizes the arg (so downstream span typing stays populated) without running `check_against` — which would otherwise pile on a second, less-informative mismatch. Same-name collisions whose types **agree** remain a valid COEXIST spawn (state field passed at spawn time alongside a same-named init param) and are untouched.

Also corrects the stale field-lookup-fallback comment: the fallback serves both no-init actors **and** same-name field-routed args on init-bearing actors, per the issue's request.

## Tests

Two checker regressions in `hew-types` `actor_init_typecheck`:
- `spawn_arg_name_collision_differing_types_reports_checker_diagnostic` — the differing-type collision yields the named diagnostic with both types and **no** raw RecordInit dump.
- `spawn_arg_name_collision_matching_types_is_accepted` — the same-type same-name COEXIST is accepted.

Full `hew-types` suite green; `cargo fmt` + `cargo clippy --tests -D warnings` clean.

Closes #2448.