### PR TITLE
fix(parser): honest diagnostic for unsupported record rest-patterns (#2339)

### DIFF
--- a/hew-parser/src/parser/patterns.rs
+++ b/hew-parser/src/parser/patterns.rs
@@ -8,6 +8,27 @@ use super::*;
 
 impl Parser<'_> {
     // ── Patterns ──
+
+    /// If the next token is a record rest-pattern `..`, emit an honest
+    /// "not yet supported" diagnostic (matching the checker's deferred-feature
+    /// message) instead of letting the generic `expected identifier` error fire,
+    /// then return `true` so the caller can stop the field loop. See #2339.
+    fn reject_record_rest_pattern(&mut self) -> bool {
+        if self.peek() == Some(&Token::DotDot) {
+            let span = self.peek_span();
+            self.error_at_with_hint(
+                "record rest-patterns (`..`) are not yet supported".to_string(),
+                span,
+                "list every field explicitly, or bind the whole value; \
+                 subset destructuring with `..` is not implemented yet",
+            );
+            self.advance(); // consume `..` so recovery does not re-report it
+            true
+        } else {
+            false
+        }
+    }
+
     pub(crate) fn parse_pattern(&mut self) -> Option<Spanned<Pattern>> {
         let _guard = self.enter_recursion()?;
         let mut result = self.parse_base_pattern()?;
@@ -92,6 +113,9 @@ impl Parser<'_> {
                 } else if self.eat(&Token::LeftBrace) {
                     let mut fields = Vec::new();
                     while !self.at_end() && self.peek() != Some(&Token::RightBrace) {
+                        if self.reject_record_rest_pattern() {
+                            break;
+                        }
                         let field_name = self.expect_ident()?;
                         let pattern = if self.eat(&Token::Colon) {
                             Some(self.parse_pattern()?)
@@ -143,6 +167,9 @@ impl Parser<'_> {
                         // Struct pattern
                         let mut fields = Vec::new();
                         while !self.at_end() && self.peek() != Some(&Token::RightBrace) {
+                            if self.reject_record_rest_pattern() {
+                                break;
+                            }
                             let field_name = self.expect_ident()?;
                             let pattern = if self.eat(&Token::Colon) {
                                 Some(self.parse_pattern()?)
@@ -194,6 +221,9 @@ impl Parser<'_> {
                 self.advance(); // consume '{'
                 let mut fields = Vec::new();
                 while !self.at_end() && self.peek() != Some(&Token::RightBrace) {
+                    if self.reject_record_rest_pattern() {
+                        break;
+                    }
                     let field_name = self.expect_ident()?;
                     let pattern = if self.eat(&Token::Colon) {
                         Some(self.parse_pattern()?)

--- a/hew-parser/src/parser/tests.rs
+++ b/hew-parser/src/parser/tests.rs
@@ -4312,3 +4312,57 @@ fn wire_enum_keyword_form_rejected() {
         "hint should point at #[wire] type, got: {first_hint}"
     );
 }
+
+/// Record rest-patterns (`Point { x, .. }`) are not yet implemented. The parser
+/// must surface an honest "not yet supported" diagnostic pointing at the `..`
+/// rather than the generic `expected identifier, found `..`` error that gives
+/// no hint the construct is simply unimplemented. Covers the typed struct
+/// pattern, the enum-variant-qualified struct pattern, and the shorthand form.
+/// Regression for issue #2339.
+#[allow(clippy::doc_markdown, reason = "doc mentions code-like pattern syntax")]
+#[test]
+fn record_rest_pattern_reports_honest_unsupported_diagnostic() {
+    for source in [
+        // Typed struct pattern in a match arm.
+        "fn f(p: Point) -> i64 { match p { Point { x, .. } => x } }",
+        // Enum-variant-qualified struct pattern.
+        "fn f(e: E) -> i64 { match e { E::A { x, .. } => x } }",
+        // Shorthand record destructure.
+        "fn f(p: Point) -> i64 { match p { { x, .. } => x } }",
+    ] {
+        let result = parse(source);
+        assert!(
+            !result.errors.is_empty(),
+            "expected a parse error for rest pattern in: {source}"
+        );
+        let msg = &result.errors[0].message;
+        assert!(
+            msg.contains("rest-patterns") && msg.contains("not yet supported"),
+            "first error should be the honest unsupported-rest-pattern diagnostic, \
+             got: {msg} (source: {source})"
+        );
+        // The generic parser fallthrough must not fire ahead of the honest message.
+        assert!(
+            !msg.contains("expected identifier"),
+            "generic `expected identifier` should not precede the honest diagnostic, \
+             got: {msg} (source: {source})"
+        );
+        let hint = result.errors[0].hint.as_deref().unwrap_or_default();
+        assert!(
+            hint.contains("list every field explicitly"),
+            "diagnostic should hint at listing fields explicitly, got: {hint}"
+        );
+    }
+}
+
+/// A full field enumeration (no `..`) in a typed record pattern must still parse
+/// cleanly — the rest-pattern guard must not disturb valid destructures.
+#[test]
+fn typed_record_pattern_full_destructure_still_parses() {
+    let result = parse("fn f(p: Point) -> i64 { match p { Point { x, y } => x + y } }");
+    assert!(
+        result.errors.is_empty(),
+        "full typed destructure should parse cleanly, got: {:?}",
+        result.errors
+    );
+}


### PR DESCRIPTION
Closes #2339.

## Problem

`match p { Point { x, .. } => ... }` — binding a subset of record fields and ignoring the rest — failed at the **parser** with a generic `expected identifier, found `..`` plus a cascade of misleading recovery errors (`expected expression, found `=>``, `unexpected `=>` in block`, …). Nothing hinted that the construct is simply **unimplemented**.

The checker already carried partial awareness (`record pattern omits field(s) …; rest patterns (`..`) are not yet supported` at `hew-types/src/check/patterns.rs`), but the record-pattern grammar never accepted `..` at all, so that honest message was unreachable from the obvious spelling.

## Fix

All three record-pattern field loops in `hew-parser` — the typed struct pattern, the enum-variant-qualified struct pattern (`E::A { … }`), and the shorthand form (`{ … }`) — now detect a leading `..` at the start of a field and emit a single honest diagnostic:

```
error: record rest-patterns (`..`) are not yet supported
 6 |         Point { x, .. } => x,
   |                    ^^
  = help: list every field explicitly, or bind the whole value; subset destructuring with `..` is not implemented yet
```

The `..` token is consumed so error recovery doesn't re-report it, eliminating the downstream cascade. Valid full destructures (`Point { x, y }`) are untouched.

## Tests

Two new `hew-parser` regressions:
- `record_rest_pattern_reports_honest_unsupported_diagnostic` — the honest message fires (and the generic `expected identifier` does **not** precede it) for all three spellings, with the list-fields hint present.
- `typed_record_pattern_full_destructure_still_parses` — a `..`-free typed destructure still parses cleanly.

`cargo test -p hew-parser` green (359 + suites, 0 failed); `cargo fmt` clean; `cargo clippy -p hew-parser --tests -- -D warnings` clean.

## Scope note

This addresses the primary diagnostic-honesty complaint in #2339 (parser rejects `..` with a useless message). The wider feature work — actually *implementing* rest-patterns, plus the adjacent enum-variant-payload-subpattern misrouting (`Wrapper::W(Pair { a, b })` → misleading `non-exhaustive` message) — remains open follow-up; this PR makes the unimplemented surface honest rather than confusing.