### PR TITLE
fix(parser): honest diagnostic for record rest patterns (`..`)

### DIFF
--- a/hew-parser/src/parser/patterns.rs
+++ b/hew-parser/src/parser/patterns.rs
@@ -8,6 +8,60 @@ use super::*;
 
 impl Parser<'_> {
     // ── Patterns ──
+
+    /// Parse the field list inside a struct/record pattern's braces
+    /// (`{ field, field: sub, .. }`), assuming the opening `{` has already
+    /// been consumed and consuming the closing `}`.
+    ///
+    /// The rest pattern (`..`) is not yet implemented anywhere in the pipeline
+    /// (the checker at `hew-types/src/check/patterns.rs` already carries a
+    /// rest-patterns-not-yet-supported message for the omitted-field case, but
+    /// the grammar never accepted `..`, so that message was unreachable from
+    /// the obvious spelling). Rather than let the bare `expect_ident` fail on
+    /// `..` and cascade a chain of misleading generic errors (expected
+    /// identifier, then expected `=>`, ...), this recognises `..` explicitly,
+    /// emits ONE honest "not yet supported" diagnostic, and recovers by
+    /// consuming the `..` (and any trailing comma/fields) so the rest of the
+    /// arm still parses cleanly.
+    fn parse_pattern_fields(&mut self) -> Option<Vec<PatternField>> {
+        let mut fields = Vec::new();
+        let mut rest_reported = false;
+        while !self.at_end() && self.peek() != Some(&Token::RightBrace) {
+            if self.peek() == Some(&Token::DotDot) {
+                // Rest pattern: `..`. Report once, then swallow it so the
+                // closing brace / match arm still parses without a cascade.
+                if !rest_reported {
+                    self.error_with_hint(
+                        "rest patterns (`..`) in record patterns are not yet supported".to_string(),
+                        "bind or wildcard each field explicitly (e.g. `{ x, y: _ }`); \
+                             omitting fields with `..` is not implemented yet",
+                    );
+                    rest_reported = true;
+                }
+                self.advance(); // consume `..`
+                if !self.eat(&Token::Comma) {
+                    break;
+                }
+                continue;
+            }
+            let field_name = self.expect_ident()?;
+            let pattern = if self.eat(&Token::Colon) {
+                Some(self.parse_pattern()?)
+            } else {
+                None
+            };
+            fields.push(PatternField {
+                name: field_name,
+                pattern,
+            });
+            if !self.eat(&Token::Comma) {
+                break;
+            }
+        }
+        self.expect(&Token::RightBrace)?;
+        Some(fields)
+    }
+
     pub(crate) fn parse_pattern(&mut self) -> Option<Spanned<Pattern>> {
         let _guard = self.enter_recursion()?;
         let mut result = self.parse_base_pattern()?;
@@ -90,23 +144,7 @@ impl Parser<'_> {
                     self.expect(&Token::RightParen)?;
                     Pattern::Constructor { name, patterns }
                 } else if self.eat(&Token::LeftBrace) {
-                    let mut fields = Vec::new();
-                    while !self.at_end() && self.peek() != Some(&Token::RightBrace) {
-                        let field_name = self.expect_ident()?;
-                        let pattern = if self.eat(&Token::Colon) {
-                            Some(self.parse_pattern()?)
-                        } else {
-                            None
-                        };
-                        fields.push(PatternField {
-                            name: field_name,
-                            pattern,
-                        });
-                        if !self.eat(&Token::Comma) {
-                            break;
-                        }
-                    }
-                    self.expect(&Token::RightBrace)?;
+                    let fields = self.parse_pattern_fields()?;
                     Pattern::Struct { name, fields }
                 } else {
                     Pattern::Identifier(name)
@@ -141,24 +179,7 @@ impl Parser<'_> {
                         Pattern::Constructor { name, patterns }
                     } else if self.eat(&Token::LeftBrace) {
                         // Struct pattern
-                        let mut fields = Vec::new();
-                        while !self.at_end() && self.peek() != Some(&Token::RightBrace) {
-                            let field_name = self.expect_ident()?;
-                            let pattern = if self.eat(&Token::Colon) {
-                                Some(self.parse_pattern()?)
-                            } else {
-                                None
-                            };
-                            fields.push(PatternField {
-                                name: field_name,
-                                pattern,
-                            });
-
-                            if !self.eat(&Token::Comma) {
-                                break;
-                            }
-                        }
-                        self.expect(&Token::RightBrace)?;
+                        let fields = self.parse_pattern_fields()?;
                         Pattern::Struct { name, fields }
                     } else {
                         Pattern::Identifier(name)
@@ -192,23 +213,7 @@ impl Parser<'_> {
             // delegates to the same field-binding path as `Pattern::Struct`.
             Some(Token::LeftBrace) => {
                 self.advance(); // consume '{'
-                let mut fields = Vec::new();
-                while !self.at_end() && self.peek() != Some(&Token::RightBrace) {
-                    let field_name = self.expect_ident()?;
-                    let pattern = if self.eat(&Token::Colon) {
-                        Some(self.parse_pattern()?)
-                    } else {
-                        None
-                    };
-                    fields.push(PatternField {
-                        name: field_name,
-                        pattern,
-                    });
-                    if !self.eat(&Token::Comma) {
-                        break;
-                    }
-                }
-                self.expect(&Token::RightBrace)?;
+                let fields = self.parse_pattern_fields()?;
                 Pattern::RecordShorthand { fields }
             }
             Some(Token::Integer(s)) => {

--- a/hew-parser/src/parser/tests.rs
+++ b/hew-parser/src/parser/tests.rs
@@ -4183,6 +4183,80 @@ fn format_let_record_shorthand_round_trips_without_type_name() {
     );
 }
 
+// ── Rest patterns (`..`) in record/struct patterns (issue #2339) ──
+
+/// A named struct pattern with a `..` rest element in a match arm emits ONE
+/// honest "not yet supported" diagnostic (not the pre-fix cascade of five
+/// generic expected-identifier / expected-arrow errors), and recovers so
+/// nothing after the arm produces extra parse noise.
+#[test]
+fn record_rest_pattern_in_match_arm_reports_single_honest_error() {
+    let source = "fn main() { match p { Point { x, .. } => print(x) } }";
+    let result = parse(source);
+    let rest_errs: Vec<_> = result
+        .errors
+        .iter()
+        .filter(|e| e.message.contains("rest patterns (`..`)"))
+        .collect();
+    assert_eq!(
+        rest_errs.len(),
+        1,
+        "expected exactly one rest-pattern diagnostic, got: {:?}",
+        result.errors
+    );
+    assert!(
+        rest_errs[0].hint.is_some(),
+        "rest-pattern diagnostic should carry a recovery hint"
+    );
+    // Recovery: no misleading `found \`..\`` / `found \`=>\`` cascade survives.
+    assert!(
+        !result
+            .errors
+            .iter()
+            .any(|e| e.message.contains("found `..`") || e.message.contains("found `=>`")),
+        "rest-pattern recovery must not cascade generic token errors, got: {:?}",
+        result.errors
+    );
+}
+
+/// The shorthand record spelling (`let { x, .. } = p`, no type name) reaches
+/// the same single honest rest-pattern diagnostic.
+#[test]
+fn record_shorthand_rest_pattern_reports_single_honest_error() {
+    let source = "fn main() { let { x, .. } = p; }";
+    let result = parse(source);
+    let rest_errs: Vec<_> = result
+        .errors
+        .iter()
+        .filter(|e| e.message.contains("rest patterns (`..`)"))
+        .collect();
+    assert_eq!(
+        rest_errs.len(),
+        1,
+        "expected exactly one rest-pattern diagnostic, got: {:?}",
+        result.errors
+    );
+}
+
+/// A `..` in leading or interior position (`Point { .., x }`) is recognised as
+/// a rest pattern too, and the trailing field still parses without cascade.
+#[test]
+fn record_rest_pattern_leading_position_recovers() {
+    let source = "fn main() { match p { Point { .., x } => print(x) } }";
+    let result = parse(source);
+    let rest_errs: Vec<_> = result
+        .errors
+        .iter()
+        .filter(|e| e.message.contains("rest patterns (`..`)"))
+        .collect();
+    assert_eq!(
+        rest_errs.len(),
+        1,
+        "expected exactly one rest-pattern diagnostic, got: {:?}",
+        result.errors
+    );
+}
+
 // Proving gate: bare `wire` keyword is rejected as a declaration form.
 // Item::Wire no longer exists; the identifier "wire" produces a helpful error.
 #[test]


### PR DESCRIPTION
Fixes #2339.

## Problem

Record/struct patterns with a rest element failed at the **parser** with a cascade of misleading generic errors that never hinted the construct is simply unimplemented:

```
match p { Point { x, .. } => print(x) }
```

produced five diagnostics — `expected identifier, found `..``, `expected `=>``, `unexpected `=>` in block`, `expected item …` — instead of one honest message.

The checker (`hew-types/src/check/patterns.rs`) already carries a `rest patterns (`..`) are not yet supported` message for the omitted-field case, but the grammar never accepted `..` at all, so that intent was unreachable from the obvious spelling.

## Fix

The three duplicated struct-pattern field loops (bare-name `Foo { … }`, leading-dot variant `.Variant { … }`, and shorthand `{ … }`) are factored into a single `parse_pattern_fields` helper that:

- recognizes `..` explicitly and emits **one** honest diagnostic with a recovery hint (`rest patterns (`..`) in record patterns are not yet supported` / *bind or wildcard each field explicitly*), and
- recovers by consuming the `..` (plus any trailing fields) so the rest of the arm parses cleanly with no cascade.

No new AST variant is introduced (the `..` is consumed in the parser), so HIR lowering and the checker are untouched. This keeps the change purely at the diagnostic/grammar surface and leaves the door open for a future real rest-pattern implementation to swap the diagnostic for actual binding semantics.

## Behaviour

Before: 5 cascading generic errors. After:

```
error: rest patterns (`..`) in record patterns are not yet supported
  |         Point { x, .. } => print(x),
  |                    ^^
  = help: bind or wildcard each field explicitly (e.g. `{ x, y: _ }`); omitting fields with `..` is not implemented yet
```

Same single honest diagnostic for the shorthand (`let { x, .. } = p`) and leading-`..` (`Point { .., x }`) spellings.

## Verification

- Three parser regression tests pin the single-diagnostic contract for the named-struct, shorthand, and leading-`..` spellings and assert the generic-token cascade does not survive recovery.
- **Load-bearing A/B**: neutralizing the `..` branch reproduces the exact pre-fix 4–5 error cascade (`left: 0/… right: 1`); restored, 3/3 pass.
- `cargo test -p hew-parser --lib` **360/360**; `hew-hir`/`hew-types` build clean (no AST surface change); `cargo fmt` + `cargo clippy -p hew-parser --tests` clean.

Note: the adjacent enum-payload-nesting diagnostic mentioned in the issue (`Wrapper::W(Pair { a, b })` misroute) is a separate checker-side concern and is intentionally left for a follow-up; this PR addresses the record rest-pattern parser surface.
