### PR TITLE
fix(sandbox): reject range values in bare value position at the profile gate (#2344)

### DIFF
--- a/hew-sandbox-wasm/src/lib.rs
+++ b/hew-sandbox-wasm/src/lib.rs
@@ -1380,6 +1380,24 @@ fn main() {
     }
 
     #[test]
+    fn open_ended_slice_ranges_are_profile_rejected() {
+        // The emitter only lowers a slice when both endpoints are present. These
+        // forms must fail at the profile gate, not emit an unsupported opcode.
+        assert_profile_rejection(
+            r"
+fn main() {
+    let v: Vec<i64> = Vec::new();
+    let all = v[..];
+    let tail = v[1..];
+    let prefix = v[..2];
+    println(all.len() + tail.len() + prefix.len());
+}
+",
+            "reserved_runtime_feature",
+        );
+    }
+
+    #[test]
     fn bytecode_output_is_stable_for_same_source() {
         let source = fixture("01-hello-world");
         let first = compile_to_sandbox_bytecode(&source, Some("sandbox-vm-export"))

--- a/hew-sandbox-wasm/src/profile.rs
+++ b/hew-sandbox-wasm/src/profile.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeSet;
 
-use hew_parser::ast::{CallArg, Expr, ImportDecl, Item, Pattern, Program, Spanned, Stmt, TypeExpr};
+use hew_parser::ast::{
+    BinaryOp, CallArg, Expr, ImportDecl, Item, Pattern, Program, Spanned, Stmt, TypeExpr,
+};
 use hew_types::{check::SpanKey, BuiltinType, Ty};
 
 use crate::Diagnostic;
@@ -452,7 +454,7 @@ impl<'a> ProfileChecker<'a> {
                         "labeled for loops are not yet admitted in the sandbox profile",
                     );
                 }
-                self.check_expr(iterable);
+                self.check_range_operand(iterable);
                 self.check_block(body);
             }
             Stmt::While { condition, body, label } => {
@@ -556,7 +558,21 @@ impl<'a> ProfileChecker<'a> {
         let (expr, span) = expr;
         match expr {
             Expr::Literal(_) | Expr::Identifier(_) | Expr::This | Expr::RegexLiteral(_) => {}
-            Expr::Binary { left, op: _, right } => {
+            Expr::Binary { left, op, right } => {
+                // `a..b` / `a..=b` parse as `Expr::Binary` with a range operator.
+                // In bare value position these have no sandbox lowering (the
+                // emitter's `lower_binary` catch-all traps at runtime), so reject
+                // them at the gate. The admitted structural positions (for-loop
+                // iterables and slice subscripts) route through
+                // `check_range_operand` and never reach this arm.
+                if matches!(op, BinaryOp::Range | BinaryOp::RangeInclusive) {
+                    self.reject(
+                        span.clone(),
+                        "reserved_runtime_feature",
+                        "range values are not admitted in the browser sandbox except as \
+                         `for` loop iterables and slice subscripts (`v[a..b]`)",
+                    );
+                }
                 // Structural equality (`==`/`!=`) on records, payload enums,
                 // Option, and Result is now admitted: `lower_binary` emits
                 // `cmp.eq`/`cmp.ne` for all types, and the VM's `compare` handler
@@ -818,14 +834,32 @@ impl<'a> ProfileChecker<'a> {
             }
             Expr::Index { object, index } => {
                 self.check_expr(object);
-                self.check_expr(index);
+                // A range subscript (`v[a..b]`, `v[a..=b]`) is an admitted
+                // slice form that the emitter lowers via `vector.range_slice`.
+                // Descend into its bounds without rejecting the range itself.
+                self.check_range_operand(index);
             }
-            Expr::Range { start, end, .. } => {
-                if let Some(start) = start {
-                    self.check_expr(start);
-                }
-                if let Some(end) = end {
-                    self.check_expr(end);
+            Expr::Range { .. } => {
+                // A range in bare value position (e.g. `let r = a..b;`) has no
+                // sandbox lowering — `lower_expr` falls to `emit_unsupported`
+                // and traps at runtime. Reject it at the profile gate so the
+                // gap fails closed at compile time, matching native's rejection
+                // of first-class range values. The two admitted structural
+                // positions (for-loop iterables and slice subscripts) route
+                // through `check_range_operand` and never reach this arm.
+                self.reject(
+                    span.clone(),
+                    "reserved_runtime_feature",
+                    "range values are not admitted in the browser sandbox except as \
+                     `for` loop iterables and slice subscripts (`v[a..b]`)",
+                );
+                if let Expr::Range { start, end, .. } = expr {
+                    if let Some(start) = start {
+                        self.check_expr(start);
+                    }
+                    if let Some(end) = end {
+                        self.check_expr(end);
+                    }
                 }
             }
             Expr::UnsafeBlock(block) => {
@@ -841,6 +875,34 @@ impl<'a> ProfileChecker<'a> {
                 "reserved_runtime_feature",
                 "this value form is not admitted to sandbox bytecode export yet",
             ),
+        }
+    }
+
+    /// Check an expression that appears in an *admitted range position* (a
+    /// `for` loop iterable or an index-slice subscript). If it is a range
+    /// (`a..b`, `a..=b`, or an open-ended `..b` / `a..`), descend into its
+    /// bounds without rejecting the range itself — those positions are lowered
+    /// by the emitter (`emit_for_range` / `vector.range_slice`). Any other
+    /// expression is checked normally.
+    fn check_range_operand(&mut self, expr: &Spanned<Expr>) {
+        match &expr.0 {
+            Expr::Binary {
+                left,
+                op: BinaryOp::Range | BinaryOp::RangeInclusive,
+                right,
+            } => {
+                self.check_expr(left);
+                self.check_expr(right);
+            }
+            Expr::Range { start, end, .. } => {
+                if let Some(start) = start {
+                    self.check_expr(start);
+                }
+                if let Some(end) = end {
+                    self.check_expr(end);
+                }
+            }
+            _ => self.check_expr(expr),
         }
     }
 

--- a/hew-sandbox-wasm/src/profile.rs
+++ b/hew-sandbox-wasm/src/profile.rs
@@ -836,8 +836,9 @@ impl<'a> ProfileChecker<'a> {
                 self.check_expr(object);
                 // A range subscript (`v[a..b]`, `v[a..=b]`) is an admitted
                 // slice form that the emitter lowers via `vector.range_slice`.
-                // Descend into its bounds without rejecting the range itself.
-                self.check_range_operand(index);
+                // Open-ended forms are not lowered, so route them through the
+                // ordinary value-position gate and reject them before emission.
+                self.check_slice_range_operand(index);
             }
             Expr::Range { .. } => {
                 // A range in bare value position (e.g. `let r = a..b;`) has no
@@ -878,12 +879,9 @@ impl<'a> ProfileChecker<'a> {
         }
     }
 
-    /// Check an expression that appears in an *admitted range position* (a
-    /// `for` loop iterable or an index-slice subscript). If it is a range
-    /// (`a..b`, `a..=b`, or an open-ended `..b` / `a..`), descend into its
-    /// bounds without rejecting the range itself — those positions are lowered
-    /// by the emitter (`emit_for_range` / `vector.range_slice`). Any other
-    /// expression is checked normally.
+    /// Check an expression that appears as a `for` loop iterable. Range bounds
+    /// are structural here, including an omitted start (`for i in ..end`), so
+    /// descend into the present bounds without treating the range as a value.
     fn check_range_operand(&mut self, expr: &Spanned<Expr>) {
         match &expr.0 {
             Expr::Binary {
@@ -901,6 +899,31 @@ impl<'a> ProfileChecker<'a> {
                 if let Some(end) = end {
                     self.check_expr(end);
                 }
+            }
+            _ => self.check_expr(expr),
+        }
+    }
+
+    /// Check an index expression. The emitter only lowers slice ranges with
+    /// both endpoints, so all open-ended forms must remain fail-closed at the
+    /// profile gate instead of reaching `emit_unsupported`.
+    fn check_slice_range_operand(&mut self, expr: &Spanned<Expr>) {
+        match &expr.0 {
+            Expr::Binary {
+                left,
+                op: BinaryOp::Range | BinaryOp::RangeInclusive,
+                right,
+            } => {
+                self.check_expr(left);
+                self.check_expr(right);
+            }
+            Expr::Range {
+                start: Some(start),
+                end: Some(end),
+                ..
+            } => {
+                self.check_expr(start);
+                self.check_expr(end);
             }
             _ => self.check_expr(expr),
         }

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -849,6 +849,23 @@ const CONSTRUCTS: &[Construct] = &[
         probe: "import std::text::regex;\nfn main() {\n    let re = regex.new(\"a+\");\n    let re2 = re.clone();\n    println(re2.is_match(\"aaa\"));\n    re.close();\n    re2.close();\n}\n",
         coverage: Coverage::Parity("regex_clone"),
     },
+    Construct {
+        // A range in bare value position (`let r = a..b;`) is fail-closed
+        // rejected. `lower_binary` / `lower_expr` have no arm for a first-class
+        // range value — they fall to `emit_unsupported`, which traps at runtime
+        // (`unsupported_instruction`). Before this gate the profile admitted the
+        // program and emitted bytecode that trapped only when the VM reached the
+        // instruction (a compile-time surprise for playground users). The two
+        // admitted range positions — `for` loop iterables (`for i in 0..n`) and
+        // slice subscripts (`v[a..b]`) — are pinned as Parity constructs above,
+        // so this rejection cannot regress those. Matches native's rejection of
+        // range-in-value position.
+        id: "range value in bare position (`let r = a..b`)",
+        probe: "fn main() {\n    let r = 0..3;\n    println(\"x\");\n}\n",
+        coverage: Coverage::RejectedByProfile {
+            diagnostic_kind: "reserved_runtime_feature",
+        },
+    },
 ];
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -866,6 +866,16 @@ const CONSTRUCTS: &[Construct] = &[
             diagnostic_kind: "reserved_runtime_feature",
         },
     },
+    Construct {
+        // The emitter only lowers slices with both endpoints. Keep `[..]`,
+        // `[start..]`, and `[..end]` fail-closed at the profile gate rather
+        // than admitting bytecode that later traps as unsupported.
+        id: "open-ended Vec range slices",
+        probe: "fn main() {\n    let v: Vec<i64> = Vec::new();\n    let all = v[..];\n    let tail = v[1..];\n    let prefix = v[..2];\n    println(all.len() + tail.len() + prefix.len());\n}\n",
+        coverage: Coverage::RejectedByProfile {
+            diagnostic_kind: "reserved_runtime_feature",
+        },
+    },
 ];
 
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #2344.

## Problem

`let r = n..=10;` compiled clean for the browser-sandbox profile and trapped at runtime with `unsupported_instruction`. The emitter's `lower_binary` / `lower_expr` have no arm for a first-class range value (both fall to the catch-all `emit_unsupported`), and the profile checker added no restriction on range operators — so the shared checker admitted the program and emitted bytecode that only failed when the VM reached the instruction. Reproduced on `main`: `admitted=true, trap=true`.

This is the same admit-then-trap class as the sandbox operator gaps recently closed on this surface, but it surfaces as a compile-time surprise for playground users instead of a clean diagnostic.

## Fix

Reject `BinaryOp::Range` / `BinaryOp::RangeInclusive` (`a..b`, `a..=b`) and the standalone `Expr::Range` (open-ended `..b` / `a..`) **in value position** at the profile gate with a `reserved_runtime_feature` diagnostic, matching native's rejection of range-in-value position.

The two positions where the sandbox genuinely lowers ranges are preserved:
- **`for` loop iterables** (`for i in 0..n`) — lowered by `emit_for_range`
- **index-slice subscripts** (`v[a..b]`, `v[a..=b]`) — lowered via `vector.range_slice`

Both route their range operand through a new `check_range_operand` helper that descends into the range bounds without rejecting the range node itself, so those admitted forms are unaffected.

## Tests

- New `parity_ratchet` construct pins `let r = 0..3;` as `RejectedByProfile { reserved_runtime_feature }`.
- The pre-existing for-loop (`0..3`) and slice (`v[0..2]` / `v[0..=1]`) constructs remain `Parity`, so the live gate confirms the rejection does **not** regress either admitted range position.
- Full `hew-sandbox-wasm` suite green (lib 47/47 + parity / parity_ratchet / playground); `cargo fmt` clean; `cargo clippy --tests -D warnings` clean.