### PR TITLE
fix(hir): destructure tuple sub-patterns in enum struct-variant match fields (#2354)

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -239,6 +239,31 @@ fn constructor_payload_aggregate_subpatterns(pattern: &Pattern) -> bool {
     })
 }
 
+/// True when an enum struct-variant arm pattern (`Variant { field: (a, b) }`)
+/// has at least one field whose sub-pattern is an aggregate (a non-empty tuple
+/// or a nested struct/record) that needs recursive destructure lowering.
+///
+/// The checker accepts these field sub-patterns (see
+/// `unsupported_payload_subpattern_label`, which returns `None` for
+/// `Pattern::Tuple`), but the payload-binding side-table only records a
+/// `PayloadBinding` for plain-identifier field binders. Aggregate field
+/// sub-patterns therefore produce no arm binding on their own and must be
+/// materialised the same way the tuple-variant path is
+/// (`lower_struct_variant_payload_aggregates`). Mirrors
+/// `constructor_payload_aggregate_subpatterns` for the struct-variant shape.
+fn struct_variant_payload_aggregate_subpatterns(pattern: &Pattern) -> bool {
+    let Pattern::Struct { fields, .. } = pattern else {
+        return false;
+    };
+    fields.iter().any(|pf| match &pf.pattern {
+        Some((sub_pat, _)) => {
+            matches!(sub_pat, Pattern::Struct { .. })
+                || matches!(sub_pat, Pattern::Tuple(items) if !items.is_empty())
+        }
+        None => false,
+    })
+}
+
 /// Resolve the type of an `if`/`else` expression from its two branch types,
 /// mirroring the checker's `unify_branches` Never-handling.
 ///
@@ -12999,6 +13024,113 @@ impl LowerCtx {
         (prelude, had_error)
     }
 
+    /// Materialise aggregate field sub-patterns of an enum struct-variant match
+    /// arm (`Variant { field: (a, b) }`, `Variant { field: Inner { x } }`).
+    ///
+    /// The struct-variant sibling of `lower_constructor_payload_aggregates`.
+    /// The checker accepts a tuple/struct sub-pattern in struct-variant field
+    /// position but records no `PayloadBinding` for it (only plain-identifier
+    /// field binders get one), so the inner binders (`a`, `b`) are never
+    /// materialised and later fail closed with `E_HIR: identifier has no
+    /// binding`. This mirrors the tuple-variant path: for each aggregate field
+    /// it binds a synthetic `__payload_*` temp to the field slot (so MIR
+    /// projects the field into it) and then reuses the `let`-binding destructure
+    /// (`lower_pattern_value_into_stmts`) to bind the inner names off that temp.
+    ///
+    /// Fields are matched to their declared type by NAME (struct-variant field
+    /// order in the pattern need not match declaration order), and generic
+    /// enum type params are substituted from the scrutinee's type args, exactly
+    /// as the constructor path does positionally.
+    fn lower_struct_variant_payload_aggregates(
+        &mut self,
+        variant_name: &str,
+        fields: &[hew_parser::ast::PatternField],
+        scrutinee_ty: &ResolvedTy,
+        bindings: &mut Vec<HirMatchArmBinding>,
+        owning_pass: &'static str,
+    ) -> (Vec<HirStmt>, bool) {
+        let mut prelude = Vec::new();
+        let mut had_error = false;
+        // Declared struct-variant fields in declaration order, with generic
+        // type params substituted from the scrutinee's type args.
+        let field_decls: Vec<(String, ResolvedTy)> = self
+            .lookup_variant_ctor(variant_name)
+            .map(|(type_name, _, kind)| match kind {
+                HirVariantKind::Struct(field_decls) => {
+                    let scrutinee_args = match scrutinee_ty {
+                        ResolvedTy::Named { args, .. } => args.as_slice(),
+                        _ => &[],
+                    };
+                    let type_params = self
+                        .enum_type_params
+                        .get(&type_name)
+                        .cloned()
+                        .unwrap_or_default();
+                    if type_params.len() == scrutinee_args.len() {
+                        field_decls
+                            .iter()
+                            .map(|(name, ty)| {
+                                (
+                                    name.clone(),
+                                    substitute_type_params(ty, &type_params, scrutinee_args),
+                                )
+                            })
+                            .collect()
+                    } else {
+                        field_decls.clone()
+                    }
+                }
+                HirVariantKind::Unit | HirVariantKind::Tuple(_) => Vec::new(),
+            })
+            .unwrap_or_default();
+        for pf in fields {
+            let Some((sub_pat, sub_span)) = &pf.pattern else {
+                continue;
+            };
+            if !matches!(sub_pat, Pattern::Struct { .. })
+                && !matches!(sub_pat, Pattern::Tuple(items) if !items.is_empty())
+            {
+                continue;
+            }
+            let Some((field_idx, field_ty)) = field_decls
+                .iter()
+                .enumerate()
+                .find(|(_, (name, _))| name == &pf.name)
+                .map(|(idx, (_, ty))| (idx, ty.clone()))
+            else {
+                continue;
+            };
+            let Ok(field_idx_u32) = u32::try_from(field_idx) else {
+                self.unsupported(
+                    sub_span.clone(),
+                    "payload aggregate field index exceeds u32::MAX",
+                    owning_pass,
+                );
+                had_error = true;
+                continue;
+            };
+            let temp_name = format!("__payload_{}_{}", field_idx, self.ids.binding().0);
+            let bound = self.bind(temp_name.clone(), field_ty.clone(), false, sub_span.clone());
+            let temp_id = bound.id;
+            bindings.push(HirMatchArmBinding {
+                binding: temp_id,
+                field_idx: field_idx_u32,
+                name: temp_name.clone(),
+                ty: field_ty.clone(),
+            });
+            let temp_ref =
+                self.binding_ref_expr(temp_name, temp_id, field_ty.clone(), sub_span.clone());
+            self.lower_pattern_value_into_stmts(
+                &(sub_pat.clone(), sub_span.clone()),
+                temp_ref,
+                field_ty,
+                &mut prelude,
+                sub_span.clone(),
+            );
+        }
+        (prelude, had_error)
+    }
+
     /// Lower `let PAT = scrutinee else { <divergent block> };` to the dedicated
     /// `HirStmtKind::LetElse` node.
     ///
@@ -23742,7 +23874,8 @@ impl LowerCtx {
                     }
                 };
             let has_payload_aggregate_subpatterns =
-                constructor_payload_aggregate_subpatterns(&arm.pattern.0);
+                constructor_payload_aggregate_subpatterns(&arm.pattern.0)
+                    || struct_variant_payload_aggregate_subpatterns(&arm.pattern.0);
 
             // Nested constructor subpatterns only make sense on an
             // EnumVariant arm; anything else is a checker contract violation
@@ -23808,6 +23941,21 @@ impl LowerCtx {
                 let (prelude, had_error) = self.lower_constructor_payload_aggregates(
                     name,
                     patterns,
+                    &scrutinee_hir.ty,
+                    &mut bindings,
+                    "match-expression-substrate",
+                );
+                body_prelude = prelude;
+                binding_error |= had_error;
+            } else if let Pattern::Struct { name, fields } = &arm.pattern.0 {
+                // Enum struct-variant arm with aggregate field sub-patterns
+                // (`Variant { field: (a, b) }`). Plain record-project arms
+                // (`Point { x, y }`) and plain field binders route through the
+                // payload-binding side-table above and produce no aggregate
+                // fields, so this is a no-op for them.
+                let (prelude, had_error) = self.lower_struct_variant_payload_aggregates(
+                    name,
+                    fields,
                     &scrutinee_hir.ty,
                     &mut bindings,
                     "match-expression-substrate",

--- a/hew-hir/tests/lowering_core/nested_match_payload_lower.rs
+++ b/hew-hir/tests/lowering_core/nested_match_payload_lower.rs
@@ -248,3 +248,162 @@ fn sum(t: (i64, i64, i64)) -> i64 {
     assert_eq!(arms[0].bindings[2].name, "c");
     assert_eq!(arms[0].bindings[2].field_idx, 2);
 }
+
+// ── Struct-variant field aggregate destructure (issue #2354) ──────────────────
+
+// Collect every `let`-binding name introduced in an arm body's prelude block.
+// Aggregate field destructures (`Variant { field: (a, b) }`) lower the inner
+// binders as prelude `let` statements off a synthetic per-field temp — the same
+// shape the tuple-variant path uses — so the arm's own `bindings` list carries
+// only that synthetic `__payload_*` temp, and the user-visible binders live in
+// the body block's statements.
+fn arm_body_prelude_binding_names(arm: &hew_hir::HirMatchArm) -> Vec<String> {
+    let HirExprKind::Block(block) = &arm.body.kind else {
+        return Vec::new();
+    };
+    block
+        .statements
+        .iter()
+        .filter_map(|stmt| match &stmt.kind {
+            hew_hir::HirStmtKind::Let(binding, _) => Some(binding.name.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+// Regression for hew-lang/hew#2354: a tuple sub-pattern in enum struct-variant
+// field position (`Data { value: (a, b) }`) passed the checker but failed HIR
+// lowering with `E_HIR: identifier has no binding` because the aggregate
+// destructure lowering ran only for tuple-variant (`Pattern::Constructor`)
+// arms, never for struct-variant (`Pattern::Struct`) arms. The inner binders
+// must now materialise: a synthetic per-field temp in the arm bindings plus the
+// user-visible binders as prelude lets in the arm body.
+#[test]
+fn struct_variant_tuple_field_destructure_binds_inner_names() {
+    let output = lower_checked(
+        r"
+enum Packet {
+    Data { value: (i64, i64) };
+    Empty;
+}
+
+fn sum(p: Packet) -> i64 {
+    match p {
+        Data { value: (a, b) } => a + b,
+        Empty => 0,
+    }
+}",
+    );
+    assert!(
+        output.diagnostics.is_empty(),
+        "unexpected HIR diagnostics: {:?}",
+        output.diagnostics
+    );
+
+    let HirExprKind::Match { arms, .. } = find_match_in_fn(&output, "sum") else {
+        panic!("expected match expression")
+    };
+    let data_arm = &arms[0];
+    // The synthetic per-field temp is the only arm binding; it drives the
+    // field projection MIR consumes.
+    let temp_names: Vec<&str> = data_arm.bindings.iter().map(|b| b.name.as_str()).collect();
+    assert!(
+        temp_names.iter().any(|n| n.starts_with("__payload_")),
+        "expected a synthetic payload temp in arm bindings: {temp_names:?}"
+    );
+    // The user-visible inner binders `a`/`b` must appear as prelude lets; before
+    // the fix they were never materialised and the body references dangled.
+    let inner = arm_body_prelude_binding_names(data_arm);
+    assert!(
+        inner.iter().any(|n| n == "a"),
+        "inner binder `a` missing from arm body prelude: {inner:?}"
+    );
+    assert!(
+        inner.iter().any(|n| n == "b"),
+        "inner binder `b` missing from arm body prelude: {inner:?}"
+    );
+}
+
+// A plain field binder alongside an aggregate field must both resolve, and the
+// field-to-declared-type mapping is by NAME, so a pattern whose field order
+// differs from declaration order still lowers cleanly (no dangling binders).
+#[test]
+fn struct_variant_mixed_and_reordered_fields_all_bind() {
+    let output = lower_checked(
+        r"
+enum P {
+    D { p: (i64, i64), q: (i64, i64) };
+    E;
+}
+
+fn sum(v: P) -> i64 {
+    match v {
+        D { q: (c, d), p: (a, b) } => a + b + c + d,
+        E => 0,
+    }
+}",
+    );
+    assert!(
+        output.diagnostics.is_empty(),
+        "unexpected HIR diagnostics: {:?}",
+        output.diagnostics
+    );
+
+    let HirExprKind::Match { arms, .. } = find_match_in_fn(&output, "sum") else {
+        panic!("expected match expression")
+    };
+    let inner = arm_body_prelude_binding_names(&arms[0]);
+    for name in ["a", "b", "c", "d"] {
+        assert!(
+            inner.iter().any(|n| n == name),
+            "inner binder `{name}` missing from arm body prelude: {inner:?}"
+        );
+    }
+}
+
+// Generic enum struct-variant: the field's declared type mentions a type param
+// that must be substituted from the scrutinee's type args before the tuple
+// sub-pattern's inner binders are typed and materialised. The synthetic field
+// temp carries the substituted concrete field type (`(i64, i64)`).
+#[test]
+fn generic_struct_variant_tuple_field_destructure_binds_inner_names() {
+    let output = lower_checked(
+        r"
+enum Box<T> {
+    Pair { both: (T, T) };
+    Empty;
+}
+
+fn sum(b: Box<i64>) -> i64 {
+    match b {
+        Pair { both: (a, c) } => a + c,
+        Empty => 0,
+    }
+}",
+    );
+    assert!(
+        output.diagnostics.is_empty(),
+        "unexpected HIR diagnostics: {:?}",
+        output.diagnostics
+    );
+
+    let HirExprKind::Match { arms, .. } = find_match_in_fn(&output, "sum") else {
+        panic!("expected match expression")
+    };
+    let inner = arm_body_prelude_binding_names(&arms[0]);
+    assert!(
+        inner.iter().any(|n| n == "a") && inner.iter().any(|n| n == "c"),
+        "inner binders `a`/`c` missing from arm body prelude: {inner:?}"
+    );
+    // The synthetic field temp carries the substituted concrete field type,
+    // not `(T, T)`.
+    let temp = arms[0]
+        .bindings
+        .iter()
+        .find(|b| b.name.starts_with("__payload_"))
+        .expect("synthetic payload temp present");
+    assert_eq!(
+        temp.ty,
+        ResolvedTy::Tuple(vec![ResolvedTy::I64, ResolvedTy::I64])
+    );
+}


### PR DESCRIPTION
Fixes #2354.

## Problem

A tuple sub-pattern in enum struct-variant field position passed the type checker but failed HIR lowering with `E_HIR: identifier has no binding in resolved HIR` for the inner binders:

```hew
enum Packet { Data { value: (i64, i64) }; Empty; }

fn main() {
    let p = Packet::Data { value: (3, 4) };
    let r = match p {
        Data { value: (a, b) } => a + b,   // a, b: E_HIR: identifier has no binding
        Empty => 0,
    };
    println(f"{r}");
}
```

The checker accepts the shape (`unsupported_payload_subpattern_label` returns `None` for `Pattern::Tuple`) and records no `PayloadBinding` for it (only plain-identifier field binders get one), so the aggregate has to be materialised by the recursive-destructure path the tuple-variant arm uses. That path (`lower_constructor_payload_aggregates`) ran only for `Pattern::Constructor` arms, never for `Pattern::Struct` (struct-variant) arms, so the inner binders were never lowered and dangled. Before #2340 the shape was unreachable (the arm was wrongly rejected as non-exhaustive first), so the gap was latent.

## Fix

Add `lower_struct_variant_payload_aggregates`, the struct-variant sibling of the tuple-variant aggregate lowering: for each aggregate field sub-pattern (non-empty tuple or nested struct) it binds a synthetic `__payload_*` temp to the field slot (so MIR projects the field into it) and reuses `lower_pattern_value_into_stmts` to bind the inner names off that temp. Fields are matched to their declared type by **name** (struct-variant pattern field order need not follow declaration order) and generic enum type params are substituted from the scrutinee's type args, mirroring the constructor path. It is wired into the match-arm loop alongside the constructor branch, and `needs_scope` / the aggregate-detection predicate (`struct_variant_payload_aggregate_subpatterns`) are extended so the arm opens a scope for the new bindings.

## Scope

Tuple sub-patterns in struct-variant field position — exactly what #2354 reports. Nested record-in-field (`Node { inner: Inner { x, y } }`) stays checker-gated behind the separate `record destructure` payload-subpattern label and is out of scope here. Plain record-project arms (`Point { x, y }`) and plain field binders route through the payload-binding side-table unchanged.

## Testing

- 3 new lowering tests: single tuple field, mixed + reordered aggregate fields, generic enum with type-param substitution.
- Full `hew-hir` suite green (198 lowering-core + rest); full `hew-types` suite green (1660+…).
- fmt + clippy (`--tests`) clean.
- Verified end-to-end via the compiled `hew run`: the report's repro prints `7`, plus mixed (`16`), reordered multi-aggregate (`10`), wildcard-in-tuple (`4`), and generic (`7`) variants all correct.