### PR TITLE
fix(types): clean diagnostic for opaque-handle receive-fn parameter (#2511)

### DIFF
--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -1955,6 +1955,7 @@ impl Checker {
         for p in &rf.params {
             self.check_shadowing(&p.name, &p.ty.1);
             let ty = self.resolve_type_expr(&p.ty);
+            self.reject_opaque_receive_fn_param(&p.name, &ty, &p.ty.1);
             self.env
                 .define_param_with_span(p.name.clone(), ty, p.is_mutable, p.ty.1.clone());
         }
@@ -2027,6 +2028,36 @@ impl Checker {
         }
         self.env.pop_scope(); // params scope
         self.env.pop_scope(); // fields scope
+    }
+
+    /// Fail closed on an opaque-handle receive-fn parameter.
+    ///
+    /// Actor message payloads are CBOR-serialized for mailbox dispatch, but
+    /// `#[opaque]` runtime handles (e.g. `net.Listener`, `net.Connection`) are
+    /// pointer-shaped resources with no record layout, so they cannot cross the
+    /// actor message boundary. If a parameter type is (or transitively contains)
+    /// an opaque handle, emit a clean checker diagnostic that points at the
+    /// parameter instead of letting it reach codegen and surface as a raw
+    /// `E_CODEGEN_FRONT_FAIL_CLOSED: wire CBOR serialize …` message (#2511).
+    fn reject_opaque_receive_fn_param(&mut self, param_name: &str, ty: &Ty, span: &Span) {
+        let mut visiting = std::collections::HashSet::new();
+        let Some(opaque_name) = self.ty_field_contains_opaque(ty, &mut visiting) else {
+            return;
+        };
+        self.report_error(
+            TypeErrorKind::OpaqueMessagePayload {
+                param_name: param_name.to_string(),
+                opaque_name: opaque_name.clone(),
+            },
+            span,
+            format!(
+                "opaque type `{opaque_name}` cannot be used as receive-fn \
+                 parameter `{param_name}`; actor message payloads must be \
+                 serializable, but opaque handles carry no record layout — open \
+                 or construct it locally in the handler instead \
+                 [E_OPAQUE_MESSAGE_PAYLOAD]"
+            ),
+        );
     }
 
     pub(super) fn check_const(&mut self, cd: &ConstDecl, _span: &Span) {

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -2041,7 +2041,7 @@ impl Checker {
     /// `E_CODEGEN_FRONT_FAIL_CLOSED: wire CBOR serialize …` message (#2511).
     fn reject_opaque_receive_fn_param(&mut self, param_name: &str, ty: &Ty, span: &Span) {
         let mut visiting = std::collections::HashSet::new();
-        let Some(opaque_name) = self.ty_field_contains_opaque(ty, &mut visiting) else {
+        let Some(opaque_name) = self.ty_field_contains_opaque_inner(ty, &mut visiting, true) else {
             return;
         };
         self.report_error(

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -2780,6 +2780,16 @@ impl Checker {
         type_args: &[Ty],
         visiting: &mut std::collections::HashSet<String>,
     ) -> Option<String> {
+        self.record_field_contains_opaque_inner(name, type_args, visiting, false)
+    }
+
+    fn record_field_contains_opaque_inner(
+        &self,
+        name: &str,
+        type_args: &[Ty],
+        visiting: &mut std::collections::HashSet<String>,
+        allow_channel_handles: bool,
+    ) -> Option<String> {
         if !visiting.insert(name.to_string()) {
             return None; // cycle protection
         }
@@ -2788,7 +2798,9 @@ impl Checker {
             for field_ty in type_def.fields.values() {
                 let field_ty =
                     Self::instantiate_type_def_member(field_ty, &type_def.type_params, type_args);
-                if let Some(opaque) = self.ty_field_contains_opaque(&field_ty, visiting) {
+                if let Some(opaque) =
+                    self.ty_field_contains_opaque_inner(&field_ty, visiting, allow_channel_handles)
+                {
                     found = Some(opaque);
                     break;
                 }
@@ -2814,6 +2826,16 @@ impl Checker {
         type_args: &[Ty],
         visiting: &mut std::collections::HashSet<String>,
     ) -> Option<String> {
+        self.enum_variant_contains_opaque_inner(name, type_args, visiting, false)
+    }
+
+    fn enum_variant_contains_opaque_inner(
+        &self,
+        name: &str,
+        type_args: &[Ty],
+        visiting: &mut std::collections::HashSet<String>,
+        allow_channel_handles: bool,
+    ) -> Option<String> {
         if !visiting.insert(name.to_string()) {
             return None; // cycle protection
         }
@@ -2831,7 +2853,11 @@ impl Checker {
                         &type_def.type_params,
                         type_args,
                     );
-                    if let Some(opaque) = self.ty_field_contains_opaque(&payload_ty, visiting) {
+                    if let Some(opaque) = self.ty_field_contains_opaque_inner(
+                        &payload_ty,
+                        visiting,
+                        allow_channel_handles,
+                    ) {
                         found = Some(opaque);
                         break 'variants;
                     }
@@ -2842,32 +2868,51 @@ impl Checker {
         found
     }
 
-    pub(super) fn ty_field_contains_opaque(
+    /// Transitive opaque-leaf walk. The receive-fn boundary opts into the
+    /// channel-handle carve-out because `Sender`/`Receiver` are transferable
+    /// mailbox capabilities; clone-site callers retain the strict default.
+    pub(super) fn ty_field_contains_opaque_inner(
         &self,
         ty: &Ty,
         visiting: &mut std::collections::HashSet<String>,
+        allow_channel_handles: bool,
     ) -> Option<String> {
         // Resolve inference vars so a field whose type is still a `Ty::Var`
         // bound in the substitution environment is walked at its concrete type
         // (mirrors `vec_element_contains_structural_array`).
         let resolved = self.subst.resolve(ty);
         match &resolved {
-            Ty::Named { name, args, .. } => {
+            Ty::Named {
+                name,
+                args,
+                builtin,
+                ..
+            } => {
+                let is_channel_handle = builtin.is_some_and(BuiltinType::is_channel_handle);
                 // Direct opaque handle (imported via module registry OR user-declared #[opaque])?
-                if self.canonical_owned_handle_type_name(name).is_some()
-                    || self.user_opaque_type_names.contains(name.as_str())
+                if !(allow_channel_handles && is_channel_handle)
+                    && (self.canonical_owned_handle_type_name(name).is_some()
+                        || self.user_opaque_type_names.contains(name.as_str()))
                 {
                     return Some(name.clone());
                 }
-                // Recurse into type args (e.g. `Vec<Handle>`, `Option<Handle>`).
+                // Recurse into type args (e.g. `Vec<Handle>`, `Option<Handle>`,
+                // `Sender<T>`/`Receiver<T>`'s own element type `T`).
                 for arg in args {
-                    if let Some(n) = self.ty_field_contains_opaque(arg, visiting) {
+                    if let Some(n) =
+                        self.ty_field_contains_opaque_inner(arg, visiting, allow_channel_handles)
+                    {
                         return Some(n);
                     }
                 }
                 // Recurse into the type def's fields, substituting the def's
                 // params with the concrete `args` at this use site.
-                if let Some(n) = self.record_field_contains_opaque(name, args, visiting) {
+                if let Some(n) = self.record_field_contains_opaque_inner(
+                    name,
+                    args,
+                    visiting,
+                    allow_channel_handles,
+                ) {
                     return Some(n);
                 }
                 // Recurse into enum variant payloads too — a nested enum with a
@@ -2876,14 +2921,21 @@ impl Checker {
                 // walk, so without this an outer clone would admit an
                 // unclonable leaf. (`record_field_contains_opaque` is a no-op
                 // for an enum, and vice-versa, so both calls are kind-safe.)
-                if let Some(n) = self.enum_variant_contains_opaque(name, args, visiting) {
+                if let Some(n) = self.enum_variant_contains_opaque_inner(
+                    name,
+                    args,
+                    visiting,
+                    allow_channel_handles,
+                ) {
                     return Some(n);
                 }
                 None
             }
             Ty::Tuple(items) => {
                 for item in items {
-                    if let Some(n) = self.ty_field_contains_opaque(item, visiting) {
+                    if let Some(n) =
+                        self.ty_field_contains_opaque_inner(item, visiting, allow_channel_handles)
+                    {
                         return Some(n);
                     }
                 }

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -2842,7 +2842,7 @@ impl Checker {
         found
     }
 
-    fn ty_field_contains_opaque(
+    pub(super) fn ty_field_contains_opaque(
         &self,
         ty: &Ty,
         visiting: &mut std::collections::HashSet<String>,

--- a/hew-types/src/check/tests/actor_fields.rs
+++ b/hew-types/src/check/tests/actor_fields.rs
@@ -1095,6 +1095,115 @@ mod every_attribute {
         );
     }
 
+    // ── Opaque handle as a receive-fn message parameter (#2511) ──────────────
+    //
+    // Actor message payloads are CBOR-serialized for mailbox dispatch. An
+    // `#[opaque]` handle has no record layout, so it cannot cross the actor
+    // message boundary. The checker must reject an opaque-typed receive-fn
+    // parameter with a clean `OpaqueMessagePayload` diagnostic rather than
+    // letting it reach codegen and surface as a raw wire-serialize failure.
+
+    #[test]
+    fn opaque_receive_fn_param_emits_opaque_message_payload_error() {
+        let output = check_source(
+            r"
+            #[opaque]
+            type Handle {}
+
+            actor Server {
+                receive fn handle(h: Handle) {}
+            }
+
+            fn main() {}
+            ",
+        );
+        let payload_errors: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(&e.kind, TypeErrorKind::OpaqueMessagePayload { .. }))
+            .collect();
+        assert_eq!(
+            payload_errors.len(),
+            1,
+            "an opaque-typed receive-fn parameter must emit exactly one \
+             OpaqueMessagePayload error; got: {:#?}",
+            output.errors
+        );
+        match &payload_errors[0].kind {
+            TypeErrorKind::OpaqueMessagePayload {
+                param_name,
+                opaque_name,
+            } => {
+                assert_eq!(param_name, "h");
+                assert_eq!(opaque_name, "Handle");
+            }
+            other => panic!("unexpected error kind: {other:?}"),
+        }
+        assert!(
+            payload_errors[0]
+                .message
+                .contains("E_OPAQUE_MESSAGE_PAYLOAD"),
+            "OpaqueMessagePayload message must carry the envelope code; got: {:?}",
+            payload_errors[0].message
+        );
+    }
+
+    #[test]
+    fn opaque_receive_fn_param_nested_in_vec_is_rejected() {
+        // The restriction is transitive: a `Vec<Handle>` payload also can't be
+        // serialized, so the opaque leaf must still be detected.
+        let output = check_source(
+            r"
+            #[opaque]
+            type Handle {}
+
+            actor Server {
+                receive fn handle(hs: Vec<Handle>) {}
+            }
+
+            fn main() {}
+            ",
+        );
+        let payload_errors: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(&e.kind, TypeErrorKind::OpaqueMessagePayload { .. }))
+            .collect();
+        assert_eq!(
+            payload_errors.len(),
+            1,
+            "an opaque handle nested in a Vec receive-fn parameter must be \
+             rejected; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn non_opaque_receive_fn_params_are_not_affected() {
+        // Plain serializable payloads (primitives, records) must still pass.
+        let output = check_source(
+            r"
+            type Point { x: i64; y: i64; }
+
+            actor Server {
+                receive fn handle(n: i64, s: string, p: Point) {}
+            }
+
+            fn main() {}
+            ",
+        );
+        let payload_errors: Vec<_> = output
+            .errors
+            .iter()
+            .filter(|e| matches!(&e.kind, TypeErrorKind::OpaqueMessagePayload { .. }))
+            .collect();
+        assert!(
+            payload_errors.is_empty(),
+            "serializable receive-fn parameters must not produce \
+             OpaqueMessagePayload; got: {payload_errors:#?}",
+        );
+    }
+
     #[test]
     fn cross_actor_msg_id_collision_is_rejected() {
         // `Alpha::h69862` and `Beta::h103299` are a real SipHash-1-3 low-32-bit

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -1226,6 +1226,26 @@ pub enum TypeErrorKind {
         /// The user-facing element type of the receiver `Stream<T>`.
         element_ty: String,
     },
+    /// An actor receive-fn declared a parameter whose type is (or transitively
+    /// contains) an `#[opaque]` runtime handle.
+    ///
+    /// Actor message payloads are CBOR-serialized for mailbox dispatch, but
+    /// opaque handles (e.g. `net.Listener`, `net.Connection`) are pointer-shaped
+    /// runtime resources with no record layout, so they cannot cross the actor
+    /// message boundary. Without this check the restriction surfaced only at
+    /// codegen as a raw `E_CODEGEN_FRONT_FAIL_CLOSED: wire CBOR serialize …`
+    /// message naming an internal wire-serialization detail. This error replaces
+    /// that downstream noise with a clean, actionable checker diagnostic that
+    /// points at the parameter.
+    ///
+    /// Envelope code: `E_OPAQUE_MESSAGE_PAYLOAD`.
+    OpaqueMessagePayload {
+        /// The receive-fn parameter name.
+        param_name: String,
+        /// The resolved opaque handle type name reached from the parameter type
+        /// (e.g. `"Listener"`, `"net.Connection"`).
+        opaque_name: String,
+    },
     /// A cross-module or cross-package reference to a `private` symbol.
     ///
     /// `private` symbols are accessible only within the module that declares
@@ -1356,6 +1376,7 @@ impl TypeErrorKind {
             Self::LetElseDoesNotDiverge => "LetElseDoesNotDiverge",
             Self::OpaqueDirectConstruct { .. } => "OpaqueDirectConstruct",
             Self::StreamAdapterNotSupported { .. } => "StreamAdapterNotSupported",
+            Self::OpaqueMessagePayload { .. } => "OpaqueMessagePayload",
             Self::VisibilityViolationPrivate { .. } => "VisibilityViolationPrivate",
             Self::VisibilityViolationPackage { .. } => "VisibilityViolationPackage",
             Self::Lint(id) => id.as_str(),


### PR DESCRIPTION
Fixes #2511.

## Problem

Passing an opaque FFI handle type (e.g. `net.Listener`, `net.Connection`) as an actor receive-fn message parameter failed at **codegen**, not type-check, surfacing as a raw internal message:

```
E_CODEGEN_FRONT_FAIL_CLOSED: wire CBOR serialize: named type `Listener` (key `Listener`) is not a registered record layout
```

Actor message payloads are CBOR-serialized for mailbox dispatch, but opaque handles are pointer-shaped runtime resources with no record layout, so they can't cross the actor message boundary. The compiler correctly fails closed — this isn't a memory-safety bug — but the error named an internal wire-serialization detail instead of pointing at the offending parameter.

## Fix

Reject opaque-typed receive-fn parameters at the checker with a new `E_OPAQUE_MESSAGE_PAYLOAD` diagnostic pointing at the parameter type span:

```
error: opaque type `net.Listener` cannot be used as receive-fn parameter `l`;
actor message payloads must be serializable, but opaque handles carry no record
layout — open or construct it locally in the handler instead [E_OPAQUE_MESSAGE_PAYLOAD]
 6 |     receive fn handle(l: Listener) {
   |                          ^^^^^^^^
```

- New `TypeErrorKind::OpaqueMessagePayload { param_name, opaque_name }` variant.
- The check reuses `ty_field_contains_opaque` (promoted to `pub(super)`), so it is **transitive**: a `Vec<Listener>` / `Option<Handle>` payload is caught at the opaque leaf, mirroring the existing actor-state clone-gate story referenced in the issue.
- Lives in a small `reject_opaque_receive_fn_param` helper to keep `check_receive_fn` under the `too_many_lines` clippy gate.
- Serializable payloads (primitives, records) are unaffected.

## Testing

- 3 new checker tests: user-`#[opaque]` param rejected (exactly one error, correct param/type names, envelope code), transitive `Vec<Handle>` rejected, non-opaque `i64`/`string`/record params clean.
- Full `hew-types` suite green (1663 lib + integration), `cargo fmt` + `cargo clippy --tests` clean.
- Repro verified from-source on `main`: opaque param now errors at the parameter span; normal params `OK`.