### PR TITLE
fix(hir): self-guard record_registry bare-key resolution against cross-module collisions (#2534)

### DIFF
--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -895,6 +895,48 @@ struct RecordEntry {
     fields: Vec<(String, ResolvedTy)>,
 }
 
+/// Resolve a record declaration by source name against `record_registry`,
+/// self-guarding the bare fallback against cross-module bare-name collisions.
+///
+/// #2534: `record_registry` is keyed by BARE `decl.name` at every insert
+/// site (see the type-decl pre-pass), so two same-bare-name records from
+/// different modules collapse to last-writer in the map. An exact
+/// (possibly module-qualified) key hits directly and is unambiguous. Only
+/// the bare fallback is at risk: if the bare name is a known cross-module
+/// collision (`colliding`), returning the last-writer entry would silently
+/// resolve the wrong module's record layout. Fail closed there instead of
+/// relying solely on the upstream checker's ambiguity guard to have fired
+/// first, so a future checker gap cannot leak a wrong-record layout through
+/// the HIR bare fallback.
+fn lookup_record_entry_guarded<'a>(
+    record_registry: &'a HashMap<String, RecordEntry>,
+    colliding: &HashSet<String>,
+    type_name: &str,
+) -> Option<&'a RecordEntry> {
+    // A bare (unqualified) name that is a known cross-module collision is
+    // ambiguous no matter how it reaches us: the `record_registry` bare key
+    // holds only the last-writer entry. Fail closed before the direct hit
+    // so we never resolve the wrong module's layout through the bare key.
+    let bare_stem = type_name
+        .rsplit_once('.')
+        .map_or(type_name, |(_, bare)| bare);
+    let is_bare_input = !type_name.contains('.');
+    if is_bare_input && colliding.contains(bare_stem) {
+        return None;
+    }
+    if let Some(entry) = record_registry.get(type_name) {
+        return Some(entry);
+    }
+    if type_name == bare_stem {
+        // No qualifier to strip; the direct lookup above was the only route.
+        return None;
+    }
+    if colliding.contains(bare_stem) {
+        return None;
+    }
+    record_registry.get(bare_stem)
+}
+
 /// Pre-collected inherent-impl `close` method signature for a `#[resource]`
 /// type. Populated before the type-decl pre-pass by walking `program.items`
 /// for inherent `impl T { fn close(...) {...} }` blocks (no trait bound,
@@ -11257,12 +11299,22 @@ impl LowerCtx {
 
     /// Finds a record declaration by its source name, accepting the
     /// module-qualified spelling assigned by the type checker for imports.
+    ///
+    /// #2534: the `record_registry` is keyed by BARE `decl.name` at every
+    /// insert site, so two same-bare-name records from different modules
+    /// collapse to last-writer in the map. When the qualified spelling is
+    /// present we resolve it exactly; only the bare fallback is ambiguous.
+    /// Rather than trust the checker's upstream ambiguity guard to have
+    /// fired first, self-guard here: if the bare name is a known
+    /// cross-module collision (`colliding_imported_record_names`), fail
+    /// closed on the bare fallback instead of silently returning the
+    /// last-writer entry, which may be the wrong module's record.
     fn lookup_record_entry(&self, type_name: &str) -> Option<&RecordEntry> {
-        if let Some(entry) = self.record_registry.get(type_name) {
-            return Some(entry);
-        }
-        let bare = type_name.rsplit_once('.').map(|(_, bare)| bare)?;
-        self.record_registry.get(bare)
+        lookup_record_entry_guarded(
+            &self.record_registry,
+            &self.colliding_imported_record_names,
+            type_name,
+        )
     }
 
     /// Lower a statement, returning zero or more `HirStmt`s.
@@ -31197,6 +31249,81 @@ mod tests {
                  or an unresolved bare name"
             );
         }
+    }
+
+    // ---- #2534: record_registry bare-key collision self-guard ----
+
+    fn record_entry(id: u32) -> RecordEntry {
+        RecordEntry {
+            id: ItemId(id),
+            type_params: Vec::new(),
+            fields: Vec::new(),
+        }
+    }
+
+    /// An exact (module-qualified) key resolves directly regardless of
+    /// whether the bare stem is a known collision — the qualified spelling
+    /// is unambiguous, so the guard must never suppress it.
+    #[test]
+    fn lookup_record_entry_resolves_qualified_key_even_when_bare_collides() {
+        let mut registry: HashMap<String, RecordEntry> = HashMap::new();
+        registry.insert("a.Thing".to_string(), record_entry(1));
+        registry.insert("b.Thing".to_string(), record_entry(2));
+        // Bare last-writer (whichever module lowered last).
+        registry.insert("Thing".to_string(), record_entry(2));
+        let mut colliding: HashSet<String> = HashSet::new();
+        colliding.insert("Thing".to_string());
+
+        assert_eq!(
+            lookup_record_entry_guarded(&registry, &colliding, "a.Thing").map(|e| e.id),
+            Some(ItemId(1)),
+            "qualified key must resolve to its own module's entry"
+        );
+        assert_eq!(
+            lookup_record_entry_guarded(&registry, &colliding, "b.Thing").map(|e| e.id),
+            Some(ItemId(2)),
+        );
+    }
+
+    /// A bare lookup of a known cross-module collision fails closed rather
+    /// than returning the last-writer entry, which may be the wrong
+    /// module's record layout.
+    #[test]
+    fn lookup_record_entry_bare_collision_fails_closed() {
+        let mut registry: HashMap<String, RecordEntry> = HashMap::new();
+        registry.insert("a.Thing".to_string(), record_entry(1));
+        registry.insert("b.Thing".to_string(), record_entry(2));
+        registry.insert("Thing".to_string(), record_entry(2));
+        let mut colliding: HashSet<String> = HashSet::new();
+        colliding.insert("Thing".to_string());
+
+        assert!(
+            lookup_record_entry_guarded(&registry, &colliding, "Thing").is_none(),
+            "bare fallback on a known cross-module collision must fail \
+             closed, not silently resolve the last-writer entry"
+        );
+    }
+
+    /// A bare lookup of a NON-colliding name still resolves through the
+    /// bare fallback — the common single-definition case is unaffected.
+    #[test]
+    fn lookup_record_entry_bare_non_collision_resolves() {
+        let mut registry: HashMap<String, RecordEntry> = HashMap::new();
+        registry.insert("Solo".to_string(), record_entry(7));
+        let colliding: HashSet<String> = HashSet::new();
+
+        assert_eq!(
+            lookup_record_entry_guarded(&registry, &colliding, "Solo").map(|e| e.id),
+            Some(ItemId(7)),
+        );
+        // A qualified spelling whose bare stem is not registered as a
+        // collision still falls back to the bare entry.
+        assert_eq!(
+            lookup_record_entry_guarded(&registry, &colliding, "m.Solo").map(|e| e.id),
+            Some(ItemId(7)),
+            "qualified spelling of a non-colliding name resolves via the \
+             bare fallback"
+        );
     }
 }
 

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -885,6 +885,7 @@ struct ConstEntry {
 #[derive(Debug)]
 struct RecordEntry {
     id: ItemId,
+    owner: RecordRegistryOwner,
     /// Source-declared generic type-parameter names, in order. Empty for
     /// monomorphic record/type declarations.
     type_params: Vec<String>,
@@ -893,6 +894,16 @@ struct RecordEntry {
     /// record-layout registry walks these and substitutes per
     /// instantiation.
     fields: Vec<(String, ResolvedTy)>,
+}
+
+/// Which pre-pass populated a `RecordEntry`.
+///
+/// A root-local entry intentionally overwrites an imported bare entry with the
+/// same name, matching the checker's local-over-import precedence rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecordRegistryOwner {
+    Imported,
+    RootLocal,
 }
 
 /// Resolve a record declaration by source name against `record_registry`,
@@ -907,7 +918,9 @@ struct RecordEntry {
 /// resolve the wrong module's record layout. Fail closed there instead of
 /// relying solely on the upstream checker's ambiguity guard to have fired
 /// first, so a future checker gap cannot leak a wrong-record layout through
-/// the HIR bare fallback.
+/// the HIR bare fallback. A root-local entry is the exception: root registration
+/// intentionally overwrites imported bare entries and must retain the checker's
+/// local-over-import precedence.
 fn lookup_record_entry_guarded<'a>(
     record_registry: &'a HashMap<String, RecordEntry>,
     colliding: &HashSet<String>,
@@ -921,11 +934,14 @@ fn lookup_record_entry_guarded<'a>(
         .rsplit_once('.')
         .map_or(type_name, |(_, bare)| bare);
     let is_bare_input = !type_name.contains('.');
-    if is_bare_input && colliding.contains(bare_stem) {
-        return None;
-    }
     if let Some(entry) = record_registry.get(type_name) {
-        return Some(entry);
+        if !is_bare_input
+            || !colliding.contains(bare_stem)
+            || entry.owner == RecordRegistryOwner::RootLocal
+        {
+            return Some(entry);
+        }
+        return None;
     }
     if type_name == bare_stem {
         // No qualifier to strip; the direct lookup above was the only route.
@@ -2110,6 +2126,7 @@ pub fn lower_program_with_mono_cap(
                                 format!("{module_short}.{}", decl.name),
                                 RecordEntry {
                                     id,
+                                    owner: RecordRegistryOwner::Imported,
                                     type_params: type_params.clone(),
                                     fields: fields.clone(),
                                 },
@@ -2118,6 +2135,7 @@ pub fn lower_program_with_mono_cap(
                                 decl.name.clone(),
                                 RecordEntry {
                                     id,
+                                    owner: RecordRegistryOwner::Imported,
                                     type_params,
                                     fields,
                                 },
@@ -2140,6 +2158,7 @@ pub fn lower_program_with_mono_cap(
                                 format!("{module_short}.{}", decl.name),
                                 RecordEntry {
                                     id,
+                                    owner: RecordRegistryOwner::Imported,
                                     type_params: type_params.clone(),
                                     fields: fields.clone(),
                                 },
@@ -2148,6 +2167,7 @@ pub fn lower_program_with_mono_cap(
                                 decl.name.clone(),
                                 RecordEntry {
                                     id,
+                                    owner: RecordRegistryOwner::Imported,
                                     type_params,
                                     fields,
                                 },
@@ -2268,6 +2288,7 @@ pub fn lower_program_with_mono_cap(
                     decl.name.clone(),
                     RecordEntry {
                         id,
+                        owner: RecordRegistryOwner::RootLocal,
                         type_params,
                         fields,
                     },
@@ -2296,6 +2317,7 @@ pub fn lower_program_with_mono_cap(
                     decl.name.clone(),
                     RecordEntry {
                         id,
+                        owner: RecordRegistryOwner::RootLocal,
                         type_params,
                         fields,
                     },
@@ -11307,8 +11329,9 @@ impl LowerCtx {
     /// Rather than trust the checker's upstream ambiguity guard to have
     /// fired first, self-guard here: if the bare name is a known
     /// cross-module collision (`colliding_imported_record_names`), fail
-    /// closed on the bare fallback instead of silently returning the
-    /// last-writer entry, which may be the wrong module's record.
+    /// closed on an imported bare entry instead of silently returning the
+    /// last-writer entry, which may be the wrong module's record. A root-local
+    /// entry intentionally wins over imported collisions.
     fn lookup_record_entry(&self, type_name: &str) -> Option<&RecordEntry> {
         lookup_record_entry_guarded(
             &self.record_registry,
@@ -31256,6 +31279,7 @@ mod tests {
     fn record_entry(id: u32) -> RecordEntry {
         RecordEntry {
             id: ItemId(id),
+            owner: RecordRegistryOwner::Imported,
             type_params: Vec::new(),
             fields: Vec::new(),
         }

--- a/hew-hir/tests/lowering_core.rs
+++ b/hew-hir/tests/lowering_core.rs
@@ -39,6 +39,8 @@ mod nested_match_payload_lower;
 mod numeric_cast_lowering;
 #[path = "lowering_core/raw_pointer_no_lowering.rs"]
 mod raw_pointer_no_lowering;
+#[path = "lowering_core/record_registry_collision_guard.rs"]
+mod record_registry_collision_guard;
 #[path = "lowering_core/regex_match_arm_lower.rs"]
 mod regex_match_arm_lower;
 #[path = "lowering_core/stdlib_catalog_layout_descriptor_coverage.rs"]

--- a/hew-hir/tests/lowering_core/record_registry_collision_guard.rs
+++ b/hew-hir/tests/lowering_core/record_registry_collision_guard.rs
@@ -1,0 +1,100 @@
+use hew_hir::{lower_program_host_target, HirDiagnosticKind, ResolutionCtx};
+use hew_parser::ast::{Item, Program};
+use hew_parser::module::{Module, ModuleGraph, ModuleId};
+use hew_types::{module_registry::ModuleRegistry, Checker};
+
+fn parsed_module(id: ModuleId, source: &str) -> Module {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors for {}: {:?}",
+        id.path.join("."),
+        parsed.errors
+    );
+
+    Module {
+        id,
+        items: parsed
+            .program
+            .items
+            .into_iter()
+            .filter(|(item, _)| !matches!(item, Item::Import(_)))
+            .collect(),
+        imports: Vec::new(),
+        source_paths: Vec::new(),
+        doc: None,
+    }
+}
+
+fn program_with_colliding_imports_and_local_record() -> Program {
+    let root_source = r"
+type Thing { x: i64 }
+
+fn main() -> i64 {
+    let Thing { x } = Thing { x: 1 };
+    x
+}
+";
+    let root = hew_parser::parse(root_source);
+    assert!(
+        root.errors.is_empty(),
+        "root parse errors: {:?}",
+        root.errors
+    );
+
+    let a_id = ModuleId::new(vec!["a".to_string()]);
+    let b_id = ModuleId::new(vec!["b".to_string()]);
+    let root_id = ModuleId::root();
+    let root_module = Module {
+        id: root_id.clone(),
+        items: root.program.items.clone(),
+        imports: Vec::new(),
+        source_paths: Vec::new(),
+        doc: None,
+    };
+
+    let mut graph = ModuleGraph::new(root_id.clone());
+    graph
+        .add_module(parsed_module(a_id.clone(), "pub type Thing { a: i64 }"))
+        .expect("add module a");
+    graph
+        .add_module(parsed_module(b_id.clone(), "pub type Thing { b: i64 }"))
+        .expect("add module b");
+    graph.add_module(root_module).expect("add root module");
+    graph.topo_order = vec![a_id, b_id, root_id];
+
+    Program {
+        items: root.program.items,
+        module_graph: Some(graph),
+        ..root.program
+    }
+}
+
+#[test]
+fn root_local_record_shadows_colliding_imported_record_names() {
+    let program = program_with_colliding_imports_and_local_record();
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let typecheck = checker.check_program(&program);
+    assert!(
+        typecheck.errors.is_empty(),
+        "local `Thing` must shadow imported collisions: {:#?}",
+        typecheck.errors
+    );
+
+    let lowered = lower_program_host_target(&program, &typecheck, &ResolutionCtx);
+    let boundary_violations: Vec<_> = lowered
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            matches!(
+                diagnostic.kind,
+                HirDiagnosticKind::CheckerBoundaryViolation { .. }
+            )
+        })
+        .collect();
+    assert!(
+        boundary_violations.is_empty(),
+        "root-local `Thing` destructuring must lower without a registry boundary violation: \
+         {boundary_violations:#?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2534. Hardens the HIR `record_registry` bare-key resolution so it fails closed on cross-module bare-name collisions instead of trusting the upstream checker's ambiguity guard to have fired first.

## Problem

`record_registry` is keyed by **bare** `decl.name` at every insert site (type-decl pre-pass, imported-module pre-pass), so two same-bare-name records from different modules collapse to **last-writer** in the `HashMap`. `lookup_record_entry` resolved the bare fallback unconditionally, relying entirely on the upstream checker's ambiguity check (`ambiguous type Thing: published bare by 2 imported modules`) to fire before HIR desugar. That leaves the registry able to silently resolve the *wrong* module's record layout if a future checker gap ever let a bare-collision reach lowering.

## Fix

The colliding bare names are **already computed** in the pre-pass as `colliding_imported_record_names`. The registry now self-guards: a bare name in that set fails closed rather than returning the last-writer entry. Behaviour by input shape:

- **Qualified spelling** (`a.Thing`) — resolves directly and exactly; never suppressed (the qualified key is unambiguous).
- **Bare name that is a known collision** (`Thing`) — fails closed (`None`).
- **Bare/qualified name with no collision** — unchanged; falls back normally.

Resolution logic is extracted into a pure `lookup_record_entry_guarded` free function so the collision behaviour is unit-testable without constructing a full `LowerCtx`.

Scope note: this is the defense-in-depth hardening requested in the issue ("detect a same-bare-key collision at registration + fail-closed on ambiguous fallback"). It does not change any behaviour that the checker already rejects; it removes the registry's dependence on checker authority for correctness.

## Tests

- 3 new unit tests: qualified-key-resolves-through-collision, bare-collision-fails-closed, non-collision-still-resolves.
- Full `hew-hir` suite green (lib + integration).
- `cargo fmt -p hew-hir --check` and `cargo clippy -p hew-hir --tests` clean.