### PR TITLE
fix(sandbox-vm): truncate wrapping i64 add/sub/mul to 64 bits (#2341)

### DIFF
--- a/examples/sandbox-graduation/wrapping_binary_operators.hew
+++ b/examples/sandbox-graduation/wrapping_binary_operators.hew
@@ -8,9 +8,9 @@ fn main() {
     println(f"wsub: {a &- b}");
     println(f"wmul: {a &* b}");
     // Overflow boundary: results must wrap, not grow past i64.
-    let max = 9223372036854775807;  // i64::MAX
+    let max = 9223372036854775807; // i64::MAX
     let min = -9223372036854775808; // i64::MIN
-    println(f"max_add_one: {max &+ 1}");   // -> i64::MIN
-    println(f"min_sub_one: {min &- 1}");   // -> i64::MAX
-    println(f"max_mul_two: {max &* 2}");   // -> -2
+    println(f"max_add_one: {max &+ 1}"); // -> i64::MIN
+    println(f"min_sub_one: {min &- 1}"); // -> i64::MAX
+    println(f"max_mul_two: {max &* 2}"); // -> -2
 }

--- a/examples/sandbox-graduation/wrapping_binary_operators.hew
+++ b/examples/sandbox-graduation/wrapping_binary_operators.hew
@@ -1,8 +1,16 @@
-// IS: parity covers non-overflow values; the wraparound boundary is tracked in #2341.
+// Wrapping arithmetic (`&+`/`&-`/`&*`): two's-complement wraparound.
+// Covers both non-overflow values and the overflow boundary, so the sandbox
+// VM's asIntN(64) truncation is pinned against native LLVM wraparound (#2341).
 fn main() {
     let a = 10;
     let b = 3;
     println(f"wadd: {a &+ b}");
     println(f"wsub: {a &- b}");
     println(f"wmul: {a &* b}");
+    // Overflow boundary: results must wrap, not grow past i64.
+    let max = 9223372036854775807;  // i64::MAX
+    let min = -9223372036854775808; // i64::MIN
+    println(f"max_add_one: {max &+ 1}");   // -> i64::MIN
+    println(f"min_sub_one: {min &- 1}");   // -> i64::MAX
+    println(f"max_mul_two: {max &* 2}");   // -> -2
 }

--- a/hew-sandbox-vm/src/interpreter/interpreter.ts
+++ b/hew-sandbox-vm/src/interpreter/interpreter.ts
@@ -330,14 +330,18 @@ class Interpreter {
         frame.locals.set(target, cloneValue(this.resolve(frame, instruction.args[1], instruction.span)));
         return;
       }
+      // Wrapping arithmetic (`&+`/`&-`/`&*`): two's-complement wraparound.
+      // Truncate to 64 bits with asIntN(64) (same as i64.shl) so an
+      // overflowing operation observes native LLVM's wraparound (e.g.
+      // i64::MAX &+ 1 == i64::MIN) instead of an unbounded BigInt. See #2341.
       case "i64.add":
-        this.writeDst(frame, instruction, this.i64(this.i64Arg(frame, instruction.args[0], instruction.span) + this.i64Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(frame, instruction, this.i64(BigInt.asIntN(64, this.i64Arg(frame, instruction.args[0], instruction.span) + this.i64Arg(frame, instruction.args[1], instruction.span))));
         return;
       case "i64.sub":
-        this.writeDst(frame, instruction, this.i64(this.i64Arg(frame, instruction.args[0], instruction.span) - this.i64Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(frame, instruction, this.i64(BigInt.asIntN(64, this.i64Arg(frame, instruction.args[0], instruction.span) - this.i64Arg(frame, instruction.args[1], instruction.span))));
         return;
       case "i64.mul":
-        this.writeDst(frame, instruction, this.i64(this.i64Arg(frame, instruction.args[0], instruction.span) * this.i64Arg(frame, instruction.args[1], instruction.span)));
+        this.writeDst(frame, instruction, this.i64(BigInt.asIntN(64, this.i64Arg(frame, instruction.args[0], instruction.span) * this.i64Arg(frame, instruction.args[1], instruction.span))));
         return;
       case "i64.and":
         this.writeDst(frame, instruction, this.i64(this.i64Arg(frame, instruction.args[0], instruction.span) & this.i64Arg(frame, instruction.args[1], instruction.span)));

--- a/hew-sandbox-wasm/tests/parity.rs
+++ b/hew-sandbox-wasm/tests/parity.rs
@@ -390,7 +390,9 @@ const PARITY_CASES: &[ParityCase] = &[
         accepted_divergences: &[],
     },
     ParityCase {
-        // IS: parity covers non-overflow values; the wraparound boundary is tracked in #2341.
+        // Wrapping `&+`/`&-`/`&*` at non-overflow values and the overflow
+        // boundary; the VM truncates with asIntN(64) to match native LLVM
+        // wraparound (#2341).
         test_name: "wrapping_binary_operators",
         source_rel: "examples/sandbox-graduation/wrapping_binary_operators.hew",
         accepted_divergences: &[],

--- a/hew-sandbox-wasm/tests/parity_ratchet.rs
+++ b/hew-sandbox-wasm/tests/parity_ratchet.rs
@@ -207,8 +207,9 @@ const CONSTRUCTS: &[Construct] = &[
     },
     Construct {
         id: "wrapping binary operators",
-        // IS: parity covers non-overflow values; the wraparound boundary is tracked in #2341.
-        probe: "fn main() {\n    let a = 10;\n    let b = 3;\n    println(a &+ b);\n    println(a &- b);\n    println(a &* b);\n}\n",
+        // Parity covers non-overflow values AND the overflow boundary; the VM
+        // truncates with asIntN(64) to match native wraparound (#2341).
+        probe: "fn main() {\n    let a = 10;\n    let b = 3;\n    println(a &+ b);\n    println(a &- b);\n    println(a &* b);\n    let max = 9223372036854775807;\n    println(max &+ 1);\n}\n",
         coverage: Coverage::Parity("wrapping_binary_operators"),
     },
     Construct {


### PR DESCRIPTION
Fixes #2341.

## Problem

The sandbox VM's BigInt implementations of the wrapping arithmetic opcodes (`i64.add`/`i64.sub`/`i64.mul`, backing `&+`/`&-`/`&*`) stored the raw BigInt result without 64-bit truncation. A genuinely overflowing wrapping operation therefore produced a mathematically-unbounded BigInt instead of the two's-complement wraparound native LLVM produces — e.g. `i64::MAX &+ 1` observed `2^63` in the VM instead of `i64::MIN`.

Non-overflow wrapping arithmetic already agreed with native (covered by the existing `wrapping_binary_operators` parity fixture), so this only diverged at the wraparound boundary.

## Fix

Apply `BigInt.asIntN(64)` to the result of each wrapping opcode — the same pattern `i64.shl` already uses. Operands are always stored in-range i64 values (`i64Arg`), so this is a no-op for non-overflow arithmetic (existing parity preserved) and only corrects the wraparound boundary.

## Coverage

Extended the `wrapping_binary_operators` parity fixture (and its `parity_ratchet` construct probe) with the overflow-boundary cases so wraparound fidelity is pinned by the native↔VM parity gate rather than assumed:

- `i64::MAX &+ 1` → `i64::MIN`
- `i64::MIN &- 1` → `i64::MAX`
- `i64::MAX &* 2` → `-2`

Removed the "#2341 tracked separately" caveats now that the boundary is covered.

## Verification

- Native `hew run` of the updated example prints the wraparound values above.
- At the VM interpreter level (direct bytecode), all three opcodes now match native line-for-line: `MAX &+ 1 => -9223372036854775808`, `MIN &- 1 => 9223372036854775807`, `MAX &* 2 => -2`.
- `cargo test -p hew-sandbox-wasm --test parity_ratchet` — 5/5 green.
- `cargo fmt` + `cargo clippy -p hew-sandbox-wasm --tests` clean; sandbox-vm `tsc` build + validation pass.

(The full native↔VM `parity.rs` leg requires `wasm-pack`, which isn't provisioned on this machine; it runs in CI.)