### PR TITLE
fix(codegen): actionable diagnostic for user type colliding with opaque handle name (#2509)

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -29835,6 +29835,32 @@ pub(crate) fn load_duplex_handle<'ctx>(
     let (slot, ty) = place_pointer(fn_ctx, place)?;
     match ty {
         BasicTypeEnum::PointerType(_) => {}
+        BasicTypeEnum::StructType(st)
+            if st
+                .get_name()
+                .and_then(|n| n.to_str().ok())
+                .is_some_and(|n| fn_ctx.record_layouts.opaque.contains(n)) =>
+        {
+            // Name-collision seam (#2509): the slot resolved to a user
+            // record/actor-state/enum/machine LLVM named struct whose bare name
+            // is ALSO a loaded `#[opaque]` runtime-handle name (e.g. a user
+            // `actor Listener` alongside stdlib `net.Listener`). The opaque
+            // handle should resolve to a bare `ptr`, but the user aggregate
+            // predeclared the named struct first, so `resolve_ty` returned the
+            // struct. Codegen fails closed here rather than miscompiling — but
+            // the raw LLVM-dump form of this message names an internal wire
+            // detail. Surface the actionable cause instead.
+            let collided = st
+                .get_name()
+                .and_then(|n| n.to_str().ok())
+                .unwrap_or("<unknown>");
+            return Err(CodegenError::FailClosed(format!(
+                "{label}: user type `{collided}` collides with the built-in opaque \
+                 handle type of the same name, so a handle operation here resolves to \
+                 your type's layout instead of the runtime handle pointer. Rename the \
+                 user `{collided}` (record/actor/enum/machine) to a distinct name."
+            )));
+        }
         other => {
             return Err(CodegenError::FailClosed(format!(
                 "{label}: Place {place:?} resolves to non-pointer type {other:?}; \

--- a/tests/vertical-slice/reject/opaque_handle_name_collision.hew
+++ b/tests/vertical-slice/reject/opaque_handle_name_collision.hew
@@ -1,0 +1,43 @@
+// #2509: a user actor/record/enum/machine whose bare name collides with a
+// loaded stdlib `#[opaque]` runtime-handle type name (here `net.Listener`)
+// makes a handle operation resolve to the user type's LLVM named struct
+// instead of the runtime handle `ptr`. Codegen must fail closed with an
+// actionable rename diagnostic rather than a raw LLVM-dump wire detail.
+import std::net::{Connection};
+
+actor Router {
+    receive fn register_client(cid: string) {
+        println(cid);
+    }
+}
+
+actor ClientHandler {
+    let conn: Connection;
+
+    receive fn start() {
+        conn.close();
+    }
+}
+
+actor Listener {
+    let router: LocalPid<Router>;
+
+    receive fn start() {
+        let lst = net.listen(":0");
+        var next_id: i32 = 1;
+        loop {
+            let conn = await lst.accept();
+            let cid = f"client-{next_id}";
+            let handler = spawn ClientHandler(conn: conn);
+            router.register_client(cid);
+            handler.start();
+            next_id = next_id + 1;
+        }
+    }
+}
+
+fn main() {
+    let router = spawn Router();
+    let listener = spawn Listener(router: router);
+    listener.start();
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -656,6 +656,18 @@ expect_check_fail_contains \
   "${ROOT}/tests/vertical-slice/reject/managed_record_or_enum_eq.hew" \
   "owned or heap-backed" \
   "managed_record_or_enum_eq"
+# #2509: user type name colliding with a loaded stdlib opaque handle name must
+# fail closed at codegen with an actionable rename diagnostic, not a raw LLVM
+# non-pointer-type dump.
+expect_check_fail_contains \
+  "${ROOT}/tests/vertical-slice/reject/opaque_handle_name_collision.hew" \
+  "collides with the built-in opaque handle type of the same name" \
+  "opaque_handle_name_collision"
+if grep -qF 'resolves to non-pointer type' "${reject_output}"; then
+  echo "opaque_handle_name_collision leaked the raw LLVM non-pointer dump" >&2
+  cat "${reject_output}" >&2
+  exit 1
+fi
 # Declaration-level generic bounds are authority at nominal instantiation sites:
 # valid arguments compile, invalid arguments fail closed at the reference site.
 compile_accept "generic_decl_bound_satisfied"


### PR DESCRIPTION
## Summary

Fixes #2509. A user `actor`/`record`/`enum`/`machine` whose bare name matches a loaded stdlib `#[opaque]` runtime-handle type name (e.g. `actor Listener` alongside `net.Listener`) predeclares its LLVM named struct first, so a later handle operation \u2014 the reporter's suspending `await lst.accept()` \u2014 resolves the local to that struct instead of the runtime handle `ptr`.

`load_duplex_handle` **already failed closed** (no miscompilation), but the message was a raw LLVM-dump:

```
E_CODEGEN_FRONT_FAIL_CLOSED: ... suspending_accept listener: Place Local(2) resolves to non-pointer type StructType(... "%Listener = type { ptr }"); expected `ptr` (the Duplex handle alloca)
```

## Fix

At that seam, when the non-pointer slot is a **named struct whose name is in the loaded opaque-handle set** (`FnCtx.record_layouts.opaque`), emit an actionable rename diagnostic instead:

```
... user type `Listener` collides with the built-in opaque handle type of the same name, so a handle operation here resolves to your type's layout instead of the runtime handle pointer. Rename the user `Listener` (record/actor/enum/machine) to a distinct name.
```

## Scope / safety

- **Diagnostic-quality only.** Still fails closed; changes no accepted program. The struct-first name-resolution invariant (which keeps user `Value` vs `json.Value` memory-safe, documented in `layout.rs`) is untouched \u2014 this only reclassifies the *error message* on the path that was already rejected.
- Non-colliding names and the rename workaround (`Listener` \u2192 `Acceptor`) compile unchanged.

## Tests

- New vertical-slice reject fixture `opaque_handle_name_collision.hew` (the reporter's exact repro) pins the actionable substring **and** asserts the raw `resolves to non-pointer type` dump no longer leaks.
- `hew-codegen-rs` lib suite green (219/219), `cargo fmt` + `clippy --tests` clean.

Reproduced on `main` `94b68a4`; verified fix + rename-workaround with both release and debug binaries.