### PR TITLE
fix(mir): preserve owned Vec get ownership

### DIFF
--- a/examples/v05/checked-mir/golden/slice_annotation_alias.elab.mir
+++ b/examples/v05/checked-mir/golden/slice_annotation_alias.elab.mir
@@ -34,7 +34,7 @@ fn main -> ()
     call[bb4 println_i64 -> bb5] ->
       (none)
     return[bb5] ->
-      (none)
+      drop _1 ty=Vec<i32> kind=cow_heap(hew_vec_free)
 
 fn i8::fmt -> string
   statements:

--- a/examples/v05/checked-mir/golden/vec_owned_elems.elab.mir
+++ b/examples/v05/checked-mir/golden/vec_owned_elems.elab.mir
@@ -176,9 +176,9 @@ fn main -> ()
       (none)
     call[bb38 Vec::new -> bb39] ->
       (none)
-    call[bb39 hew_vec_push_owned -> bb40] ->
+    call[bb39 hew_vec_push_owned_move -> bb40] ->
       (none)
-    call[bb40 hew_vec_push_owned -> bb41] ->
+    call[bb40 hew_vec_push_owned_move -> bb41] ->
       (none)
     branch[bb41: bb42/bb43] ->
       (none)
@@ -188,31 +188,38 @@ fn main -> ()
       drop _20 ty=Vec<string> kind=cow_heap(hew_vec_free)
       drop _9 ty=string kind=cow_heap(hew_string_drop)
       drop _1 ty=Vec<string> kind=cow_heap(hew_vec_free)
-    call[bb43 println_i64 -> bb44] ->
+    call[bb43 hew_vec_get_clone -> bb44] ->
       (none)
-    branch[bb44: bb45/bb46] ->
+    call[bb44 println_i64 -> bb45] ->
       (none)
-    panic[bb45] ->
+    branch[bb45: bb46/bb47] ->
+      (none)
+    panic[bb46] ->
+      drop _80 ty=Tag kind=record_in_place
       drop _69 ty=Vec<Tag> kind=cow_heap(hew_vec_free_owned)
       drop _55 ty=Vec<Point> kind=cow_heap(hew_vec_free)
       drop _20 ty=Vec<string> kind=cow_heap(hew_vec_free)
       drop _9 ty=string kind=cow_heap(hew_string_drop)
       drop _1 ty=Vec<string> kind=cow_heap(hew_vec_free)
-    branch[bb46: bb45/bb47] ->
+    branch[bb47: bb46/bb48] ->
       (none)
-    branch[bb47: bb48/bb49] ->
+    branch[bb48: bb49/bb50] ->
       (none)
-    panic[bb48] ->
+    panic[bb49] ->
       drop _88 ty=Vec<Tag> kind=cow_heap(hew_vec_free_owned)
+      drop _80 ty=Tag kind=record_in_place
       drop _69 ty=Vec<Tag> kind=cow_heap(hew_vec_free_owned)
       drop _55 ty=Vec<Point> kind=cow_heap(hew_vec_free)
       drop _20 ty=Vec<string> kind=cow_heap(hew_vec_free)
       drop _9 ty=string kind=cow_heap(hew_string_drop)
       drop _1 ty=Vec<string> kind=cow_heap(hew_vec_free)
-    call[bb49 println_i64 -> bb50] ->
+    call[bb50 hew_vec_get_clone -> bb51] ->
       (none)
-    return[bb50] ->
+    call[bb51 println_i64 -> bb52] ->
+      (none)
+    return[bb52] ->
       drop _88 ty=Vec<Tag> kind=cow_heap(hew_vec_free_owned)
+      drop _80 ty=Tag kind=record_in_place
       drop _69 ty=Vec<Tag> kind=cow_heap(hew_vec_free_owned)
       drop _55 ty=Vec<Point> kind=cow_heap(hew_vec_free)
       drop _20 ty=Vec<string> kind=cow_heap(hew_vec_free)

--- a/examples/v05/checked-mir/golden/vec_owned_elems.raw.mir
+++ b/examples/v05/checked-mir/golden/vec_owned_elems.raw.mir
@@ -290,14 +290,14 @@ fn main() -> () [conv=default]
     _70 = string_lit "a"
     _71 = const.i64 1
     _72 = record_init Tag { .0=_70, .1=_71 }
-    call hew_vec_push_owned(_69, _72) -> bb40
+    call hew_vec_push_owned_move(_69, _72) -> bb40
   bb40:
     stmt: eval site=SiteId(87) ty=()
     stmt: use BindingId(10) tags site=SiteId(93) ty=Vec<Tag> intent=Read
     _73 = string_lit "b"
     _74 = const.i64 2
     _75 = record_init Tag { .0=_73, .1=_74 }
-    call hew_vec_push_owned(_69, _75) -> bb41
+    call hew_vec_push_owned_move(_69, _75) -> bb41
   bb41:
     stmt: eval site=SiteId(92) ty=()
     stmt: use BindingId(10) tags site=SiteId(98) ty=Vec<Tag> intent=Read
@@ -308,26 +308,27 @@ fn main() -> () [conv=default]
   bb42:
     trap(IndexOutOfBounds)
   bb43:
+    _79 = call hew_vec_get_clone(_69, _76) -> bb44
+  bb44:
     stmt: bind BindingId(11) t site=SiteId(97) ty=Tag
     stmt: use BindingId(11) t site=SiteId(102) ty=Tag intent=Read
-    _79 = call_rt hew_vec_get_owned(_69, _76)
     _80 = move _79
     _81 = _80.field[1]
-    call println_i64(_81) -> bb44
-  bb44:
+    call println_i64(_81) -> bb45
+  bb45:
     stmt: eval site=SiteId(100) ty=()
     stmt: use BindingId(10) tags site=SiteId(105) ty=Vec<Tag> intent=Read
     _82 = const.i64 1
     _83 = const.i64 2
     _84 = icmp.sgt _82 _83
-    branch _84 ? bb45 : bb46
-  bb45:
-    trap(IndexOutOfBounds)
+    branch _84 ? bb46 : bb47
   bb46:
+    trap(IndexOutOfBounds)
+  bb47:
     _85 = call_rt hew_vec_len(_69)
     _86 = icmp.sgt _83 _85
-    branch _86 ? bb45 : bb47
-  bb47:
+    branch _86 ? bb46 : bb48
+  bb48:
     stmt: bind BindingId(12) tail_tags site=SiteId(104) ty=Vec<Tag>
     stmt: use BindingId(12) tail_tags site=SiteId(111) ty=Vec<Tag> intent=Read
     _87 = call_rt hew_vec_slice_range_owned(_69, _82, _83)
@@ -335,14 +336,15 @@ fn main() -> () [conv=default]
     _89 = const.i64 0
     _90 = call_rt hew_vec_len(_88)
     _91 = icmp.uge _89 _90
-    branch _91 ? bb48 : bb49
-  bb48:
-    trap(IndexOutOfBounds)
+    branch _91 ? bb49 : bb50
   bb49:
-    _92 = call_rt hew_vec_get_owned(_88, _89)
-    _93 = _92.field[1]
-    call println_i64(_93) -> bb50
+    trap(IndexOutOfBounds)
   bb50:
+    _92 = call hew_vec_get_clone(_88, _89) -> bb51
+  bb51:
+    _93 = _92.field[1]
+    call println_i64(_93) -> bb52
+  bb52:
     stmt: eval site=SiteId(108) ty=()
     return
 

--- a/hew-cli/tests/vec_generic_get_owned_leak_oracle.rs
+++ b/hew-cli/tests/vec_generic_get_owned_leak_oracle.rs
@@ -1,14 +1,16 @@
 //! Generic `Vec<T>.get` owned-element leak oracle (hew-lang/hew#1929 Stage 2).
 //!
-//! `Vec<T>.get` where `T` is a type parameter bound to a non-Copy record type
-//! routes through the owned-element ABI: the getter calls `hew_vec_get_owned`
-//! (borrows the live slot and transfers ownership to the caller), while the
-//! Vec's scope-exit drop calls `hew_vec_free_owned` (runs the per-element
-//! record drop thunk over every live slot). Pre-fix these two paths aliased
-//! the same heap string — the getter transferred ownership while `free_owned`
-//! also released the slot — producing a double-free on the first element's
-//! `label` field within a few iterations. A missed drop on the other side
-//! grows the leak-node count linearly with iteration count.
+//! `Vec<T>.get` where `T` is a type parameter bound to a non-Copy record routes
+//! through `hew_vec_get_clone`, which writes a fresh owner into `Option<T>`.
+//! The caller still owns the source Vec and must run `hew_vec_free_owned` at
+//! scope exit. Two ownership holes combined in the tracked leak:
+//! 1. the collection escape scan treated `first(vn)` as a handoff even though
+//!    `first` only borrowed its parameter, suppressing the caller's Vec drop;
+//! 2. `vn.push(Name { ... })` used copy-in for an anonymous fresh record, leaving
+//!    the source temporary's retained `label` owner with no balancing drop.
+//!
+//! The fix proves borrow-only direct-call parameters and moves fresh
+//! materialised owned push rvalues into the Vec.
 //!
 //! ## What each oracle pins
 //!
@@ -24,21 +26,11 @@
 //!   (`"owned-ok".to_upper()` — a static literal needs no free and would mask the
 //!   leak), looped at a LOW and a HIGH iteration count. The leak-node delta must
 //!   stay within tolerance. A getter that moves the owned element out of its
-//!   `Option<T>` while the element's `label` heap buffer never runs its drop
-//!   leaks ~3 nodes per iteration (the Vec handle + buffer the by-value generic
-//!   param leaves unreleased, plus the moved element's `label`).
-//!
-//!   ### TRACKED-RED (Stage A pin)
-//!
-//!   This slope oracle currently FAILS: the owned-element move-out path
-//!   (`let got = match first(vn) { Some(g) => g }; got.label.len()`) leaks the
-//!   element's heap `label` — the `hew_vec_get_owned` transfer plus the by-value
-//!   generic param `first<T>(v: Vec<T>)` drop the Vec but not the moved element's
-//!   string field. The original fixture masked this with a static `"owned-ok"`
-//!   label (nothing to free). The slope assertion below states the CORRECT
-//!   (no-leak) bar; it is `#[ignore]`d so the deterministic gate stays green
-//!   while the leak is tracked. The Stage C owned-element-drop fix removes the
-//!   `#[ignore]`.
+//!   `Option<T>` while the caller's source Vec drop is suppressed and the fresh
+//!   push source is stranded leaks ~3 nodes per iteration: the Vec handle,
+//!   backing buffer, and element label. The parameter-body proof must keep the
+//!   caller Vec admitted while still excluding helpers that return/store the
+//!   parameter, and fresh owned push rvalues must transfer rather than clone.
 //!
 //! ## Skip behaviour
 //!
@@ -166,17 +158,9 @@ fn vec_generic_get_owned_element_exact_contents_under_malloc_scribble() {
     );
 }
 
-/// Slope oracle (TRACKED-RED — see module header): the non-vacuous
-/// push-get(move-out)-drop cycle must hold the leak-node count flat. It does NOT
-/// today — the owned-element move-out leaks the element's heap `label` — so the
-/// assertion (which states the correct no-leak bar) is `#[ignore]`d to keep the
-/// deterministic gate green. The Stage C owned-element-drop fix removes the
-/// `#[ignore]`.
+/// Slope oracle: the non-vacuous push-get(move-out)-drop cycle must hold the
+/// leak-node count flat.
 #[test]
-#[ignore = "tracked-RED (no-leak-bar Stage A): owned-element Vec<T>.get move-out leaks the \
-            moved element's heap `label` — measured low=9 nodes/672 B at 3 frames vs \
-            high=150 nodes/11200 B at 50 frames (~3 nodes/iter). The assertion states the \
-            correct no-leak bar; the Stage C owned-element-drop fix removes this ignore."]
 fn vec_generic_get_owned_element_leak_slope_below_tolerance() {
     assert_frame_slope_below_tolerance("vec_generic_get_owned", generic_get_loop_source);
 }

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -26206,8 +26206,8 @@ fn lower_hashmap_index_trap_call(
     Ok(())
 }
 
-/// Lower the trait-routed `Vec::get` → `Option<T>` call (the Vec twin of
-/// `lower_hashmap_get_layout_call`). Calls the fresh-owner runtime choke point
+/// Lower the fresh-owner Vec getter used by trait-routed `Vec::get -> Option<T>`
+/// and trapping owned-value `v[i] -> T`. Calls the runtime choke point
 /// `hew_vec_get_clone(vec, index, out) -> bool`: the runtime bounds-checks and,
 /// on a hit, writes a freshly retained/cloned owner into the `Some` payload
 /// slot, so the `Option` payload is never a borrow into the live buffer
@@ -26227,7 +26227,7 @@ fn lower_vec_get_clone_call(
     }
     let dest_place = dest.ok_or_else(|| {
         CodegenError::FailClosed(
-            "hew_vec_get_clone returns Option<T>; call must supply a dest".into(),
+            "hew_vec_get_clone returns a value; call must supply a dest".into(),
         )
     })?;
 
@@ -26245,18 +26245,20 @@ fn lower_vec_get_clone_call(
         }
     };
     let dest_ty = place_resolved_ty(fn_ctx, *dest_place)?.clone();
-    match &dest_ty {
+    let dest_is_option = match &dest_ty {
         ResolvedTy::Named {
             name,
             args: ty_args,
             ..
-        } if name == "Option" && ty_args.len() == 1 && ty_args[0] == elem_resolved => {}
+        } if name == "Option" && ty_args.len() == 1 && ty_args[0] == elem_resolved => true,
+        ty if ty == &elem_resolved => false,
         other => {
             return Err(CodegenError::FailClosed(format!(
-                "hew_vec_get_clone dest must be Option<{elem_resolved:?}>, got {other:?}"
+                "hew_vec_get_clone dest must be Option<{elem_resolved:?}> or bare \
+                 {elem_resolved:?}, got {other:?}"
             )));
         }
-    }
+    };
 
     let elem_llvm_ty = resolve_ty(
         fn_ctx.ctx,
@@ -26273,28 +26275,30 @@ fn lower_vec_get_clone_call(
         .get_insert_block()
         .and_then(|bb| bb.get_parent())
         .ok_or_else(|| CodegenError::FailClosed("hew_vec_get_clone has no parent fn".into()))?;
-    let none_bb = fn_ctx.ctx.append_basic_block(parent, "vec_get_none");
-    let some_bb = fn_ctx.ctx.append_basic_block(parent, "vec_get_some");
     let next_bb = *fn_ctx
         .blocks
         .get(&next)
         .ok_or_else(|| CodegenError::FailClosed(format!("Call next bb{next} missing")))?;
 
-    // Compute the Some payload address up front; the runtime clones the stored
-    // slot value into it through the element descriptor's semantic clone path.
-    let dest_local = composite_dest_local(*dest_place, "hew_vec_get_clone")?;
-    let (payload_ptr, payload_ty) = place_pointer(
-        fn_ctx,
-        Place::MachineVariant {
-            local: dest_local,
-            variant_idx: 0,
-            field_idx: 0,
-        },
-    )?;
-    if payload_ty != elem_llvm_ty {
+    // `Vec::get` writes into the `Some` payload. Trapping scalar index over an
+    // owned element writes the same fresh owner directly into its bare `T` dest.
+    let (out_ptr, out_ty) = if dest_is_option {
+        let dest_local = composite_dest_local(*dest_place, "hew_vec_get_clone")?;
+        place_pointer(
+            fn_ctx,
+            Place::MachineVariant {
+                local: dest_local,
+                variant_idx: 0,
+                field_idx: 0,
+            },
+        )?
+    } else {
+        place_pointer(fn_ctx, *dest_place)?
+    };
+    if out_ty != elem_llvm_ty {
         return Err(CodegenError::FailClosed(format!(
-            "hew_vec_get_clone Option::Some payload type {payload_ty:?} \
-             does not match Vec element type {elem_llvm_ty:?}"
+            "hew_vec_get_clone output slot type {out_ty:?} does not match Vec \
+             element type {elem_llvm_ty:?}"
         )));
     }
     let fv = get_or_declare_vec_get_clone_runtime(fn_ctx.ctx, fn_ctx.llvm_mod);
@@ -26302,7 +26306,7 @@ fn lower_vec_get_clone_call(
         .builder
         .build_call(
             fv,
-            &[vec_ptr.into(), index.into(), payload_ptr.into()],
+            &[vec_ptr.into(), index.into(), out_ptr.into()],
             "hew_vec_get_clone_call",
         )
         .llvm_ctx("hew_vec_get_clone call")?
@@ -26310,6 +26314,26 @@ fn lower_vec_get_clone_call(
         .basic()
         .ok_or_else(|| CodegenError::FailClosed("hew_vec_get_clone returned void".into()))?
         .into_int_value();
+
+    if !dest_is_option {
+        let trap_bb = fn_ctx
+            .ctx
+            .append_basic_block(parent, "vec_index_clone_absent_trap");
+        fn_ctx
+            .builder
+            .build_conditional_branch(is_some, next_bb, trap_bb)
+            .llvm_ctx("hew_vec_get_clone bare condbr")?;
+        fn_ctx.builder.position_at_end(trap_bb);
+        emit_trap_with_code(
+            fn_ctx,
+            HEW_TRAP_INDEX_OUT_OF_BOUNDS as u64,
+            "vec_index_clone_absent",
+        )?;
+        return Ok(());
+    }
+
+    let none_bb = fn_ctx.ctx.append_basic_block(parent, "vec_get_none");
+    let some_bb = fn_ctx.ctx.append_basic_block(parent, "vec_get_some");
     fn_ctx
         .builder
         .build_conditional_branch(is_some, some_bb, none_bb)

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -6536,6 +6536,13 @@ struct ParamOwnershipFacts {
     /// caller keeps ownership and the resource is dropped exactly once (at the
     /// caller's scope exit) instead of being moved into a borrowing callee.
     borrow_arg_sites: HashSet<hew_hir::SiteId>,
+    /// `SiteId`s of direct free-function arguments whose target parameter is
+    /// proven borrow-only by the same body scan used for resource parameters.
+    ///
+    /// This broader set does not change MIR move intent or callee-side drops. It
+    /// lets owned collection drop elaboration distinguish a genuine handoff from
+    /// a call-boundary borrow such as `first<T>(v: Vec<T>) { v.get(0) }`.
+    proven_borrow_arg_sites: HashSet<hew_hir::SiteId>,
 }
 
 /// True when `ty` is a user-declared affine `#[resource]` type — a
@@ -6694,6 +6701,107 @@ fn force_consume_method_nonreceiver_resource_params(
     }
 }
 
+/// Prove borrow-only direct-call parameters across every free function. This
+/// broader summary is consumed only by collection escape analysis; it does not
+/// change call-site move intent or register non-resource parameters for
+/// callee-side drops.
+fn compute_call_param_consumption(
+    fns: &HashMap<hew_hir::ItemId, &HirFn>,
+    methods: &HashSet<hew_hir::ItemId>,
+    resource_param_consume: &HashMap<(hew_hir::ItemId, usize), bool>,
+) -> HashMap<(hew_hir::ItemId, usize), bool> {
+    // Seed every parameter as BORROW, except explicit `consume` parameters and
+    // resource parameters the RAII table already classified CONSUME. The
+    // fail-closed body scan flips a parameter when it is returned, stored, sent,
+    // captured, or forwarded to an unproven/consuming parameter.
+    let mut consume: HashMap<(hew_hir::ItemId, usize), bool> = HashMap::new();
+    for (&id, &f) in fns {
+        for (i, param) in f.params.iter().enumerate() {
+            let resource_consume = resource_param_consume
+                .get(&(id, i))
+                .copied()
+                .unwrap_or(false);
+            consume.insert((id, i), param.is_consume || resource_consume);
+        }
+    }
+    loop {
+        let mut changed = false;
+        for (&id, &f) in fns {
+            for (i, param) in f.params.iter().enumerate() {
+                let key = (id, i);
+                if consume.get(&key) != Some(&false) {
+                    continue;
+                }
+                let consumed = {
+                    let cx = ScanCtx {
+                        consume: &consume,
+                        methods,
+                    };
+                    param_consumed_in_body(&f.body, param.id, &cx)
+                };
+                if consumed {
+                    consume.insert(key, true);
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    consume
+}
+
+/// Collect direct free-call argument sites whose target parameter is BORROW,
+/// across every user body in the module.
+fn collect_module_borrow_arg_sites(
+    items: &[HirItem],
+    cx: &ScanCtx<'_>,
+) -> HashSet<hew_hir::SiteId> {
+    let mut sites = HashSet::new();
+    for item in items {
+        match item {
+            HirItem::Function(f) => {
+                collect_borrow_arg_sites_in_block(&f.body, cx, &mut sites);
+            }
+            HirItem::Actor(actor) => {
+                if let Some(init) = &actor.init {
+                    collect_borrow_arg_sites_in_block(&init.body, cx, &mut sites);
+                }
+                for handler in &actor.receive_handlers {
+                    collect_borrow_arg_sites_in_block(&handler.body, cx, &mut sites);
+                }
+                for method in &actor.methods {
+                    collect_borrow_arg_sites_in_block(&method.body, cx, &mut sites);
+                }
+                for hook in &actor.lifecycle_hooks {
+                    collect_borrow_arg_sites_in_block(&hook.body, cx, &mut sites);
+                }
+            }
+            HirItem::Machine(machine) => {
+                for state in &machine.states {
+                    if let Some(entry) = &state.entry {
+                        collect_borrow_arg_sites_in_block(entry, cx, &mut sites);
+                    }
+                    if let Some(exit) = &state.exit {
+                        collect_borrow_arg_sites_in_block(exit, cx, &mut sites);
+                    }
+                }
+                for transition in &machine.transitions {
+                    if let Some(guard) = &transition.guard {
+                        collect_borrow_arg_sites_in_expr(guard, cx, &mut sites);
+                    }
+                    collect_borrow_arg_sites_in_expr(&transition.body, cx, &mut sites);
+                }
+            }
+            // No call-bearing user bodies: extern fns have none; impl methods
+            // are mirrored as `Function` items; other item kinds carry no calls.
+            _ => {}
+        }
+    }
+    sites
+}
+
 fn compute_param_ownership(
     fns: &HashMap<hew_hir::ItemId, &HirFn>,
     items: &[HirItem],
@@ -6756,6 +6864,7 @@ fn compute_param_ownership(
             break;
         }
     }
+    let call_param_consume = compute_call_param_consumption(fns, &methods, &param_consume);
     // With the verdict final, collect every free-call argument `SiteId` whose
     // target parameter is a resource BORROW. The arg's `Use` is then emitted
     // `Read` instead of the HIR-over-stamped `Consume`, so the caller keeps the
@@ -6773,55 +6882,24 @@ fn compute_param_ownership(
     // in that body. Scanning all bodies removes that false rejection. Impl
     // methods are reached via their mirror `HirItem::Function` entries, so the
     // `Impl` block itself is skipped to avoid a redundant re-scan.
-    let mut borrow_arg_sites: HashSet<hew_hir::SiteId> = HashSet::new();
-    let cx = ScanCtx {
-        consume: &param_consume,
-        methods: &methods,
-    };
-    for item in items {
-        match item {
-            HirItem::Function(f) => {
-                collect_borrow_arg_sites_in_block(&f.body, &cx, &mut borrow_arg_sites);
-            }
-            HirItem::Actor(actor) => {
-                if let Some(init) = &actor.init {
-                    collect_borrow_arg_sites_in_block(&init.body, &cx, &mut borrow_arg_sites);
-                }
-                for handler in &actor.receive_handlers {
-                    collect_borrow_arg_sites_in_block(&handler.body, &cx, &mut borrow_arg_sites);
-                }
-                for method in &actor.methods {
-                    collect_borrow_arg_sites_in_block(&method.body, &cx, &mut borrow_arg_sites);
-                }
-                for hook in &actor.lifecycle_hooks {
-                    collect_borrow_arg_sites_in_block(&hook.body, &cx, &mut borrow_arg_sites);
-                }
-            }
-            HirItem::Machine(machine) => {
-                for state in &machine.states {
-                    if let Some(entry) = &state.entry {
-                        collect_borrow_arg_sites_in_block(entry, &cx, &mut borrow_arg_sites);
-                    }
-                    if let Some(exit) = &state.exit {
-                        collect_borrow_arg_sites_in_block(exit, &cx, &mut borrow_arg_sites);
-                    }
-                }
-                for transition in &machine.transitions {
-                    if let Some(guard) = &transition.guard {
-                        collect_borrow_arg_sites_in_expr(guard, &cx, &mut borrow_arg_sites);
-                    }
-                    collect_borrow_arg_sites_in_expr(&transition.body, &cx, &mut borrow_arg_sites);
-                }
-            }
-            // No call-bearing user bodies: extern fns have none; impl methods
-            // are mirrored as `Function` items (scanned above); records, type
-            // decls, supervisors, and consts carry no free-call argument sites.
-            _ => {}
-        }
-    }
+    let borrow_arg_sites = collect_module_borrow_arg_sites(
+        items,
+        &ScanCtx {
+            consume: &param_consume,
+            methods: &methods,
+        },
+    );
+    let proven_borrow_arg_sites = collect_module_borrow_arg_sites(
+        items,
+        &ScanCtx {
+            consume: &call_param_consume,
+            methods: &methods,
+        },
+    );
     ParamOwnershipFacts {
         param_consume,
         borrow_arg_sites,
+        proven_borrow_arg_sites,
     }
 }
 
@@ -9500,6 +9578,11 @@ struct Builder {
     /// `Rc` so child builders share it cheaply; empty default leaves every
     /// arg `Consume` and drops no param (sound: pre-RAII-2 behaviour).
     param_ownership: Rc<ParamOwnershipFacts>,
+    /// Per-call direct-function argument positions proven borrow-only by the
+    /// module parameter-body summary. Keyed by the block containing the
+    /// `Terminator::Call`; consumed by collection drop escape analysis so a
+    /// caller-owned Vec survives a helper that only reads it.
+    proven_borrow_call_args: HashMap<u32, HashSet<usize>>,
     /// Binding ids of the CURRENT function's by-value parameters, captured in
     /// `lower_params`. A funcupdate base that is (or embeds in a construction) a
     /// WHOLE by-value parameter is NOT a unique owner — the parameter is a
@@ -17400,6 +17483,25 @@ impl Builder {
                 } else {
                     target_symbol.clone()
                 };
+                // A user-authored owned-element push of a fresh materialised
+                // rvalue (`v.push(Name { ... })`, `v.push(make_name())`,
+                // `v.push(existing.clone())`) has no source binding whose
+                // scope-exit drop can balance `hew_vec_push_owned`'s copy-in
+                // clone. Move that one-shot owner into the Vec instead. A bare
+                // binding is not a materialised rvalue, so
+                // `v.push(existing_owned)` keeps the clone-in contract and the
+                // caller keeps its own independent drop.
+                let callee = if callee == "hew_vec_push_owned"
+                    && args.len() == 1
+                    && Self::expr_is_materialized_owner(
+                        &args[0],
+                        &self.funcupdate_fn_returns_fresh,
+                        &self.funcupdate_param_ids,
+                    ) {
+                    "hew_vec_push_owned_move".to_string()
+                } else {
+                    callee
+                };
 
                 // Array literals are HIR-desugared to pushes into a synthetic
                 // Vec temp. Treat each pushed element as aggregate ingress so
@@ -24888,6 +24990,8 @@ impl Builder {
     /// cont_bb:
     ///   CallRuntimeAbi { symbol: "hew_vec_get_T",
     ///                    args: [vec_place, index_place], dest: result_place }
+    ///   -- owned elements instead use Terminator::Call("hew_vec_get_clone")
+    ///      so the bare `T` result owns an independent clone
     /// ```
     ///
     /// The `UnsignedGreaterEq` predicate catches both negative indices
@@ -24907,6 +25011,8 @@ impl Builder {
     /// - `BitCopy` `Named` value records and `Tuple` → `hew_vec_get_layout`
     ///   (layout-descriptor path; codegen loads the element via the dest-place
     ///   type so the full record stride is honoured)
+    /// - owned record/enum/tuple value elements → `hew_vec_get_clone` into a bare `T`
+    /// - nested collection handles → `hew_vec_get_owned` borrow
     /// - ptr-shaped (`Duplex`, `LambdaActorHandle`, non-`BitCopy` Named heap
     ///   types) → `hew_vec_get_ptr`
     ///
@@ -24999,14 +25105,16 @@ impl Builder {
         //     applies the correct per-element stride via the layout descriptor.
         //   - Heap-handle nominals (Resource / Linear): stored as pointer-sized
         //     opaque handles; `hew_vec_get_ptr` is correct for these.
-        // W5.016: an owned (non-Copy) record/enum/tuple element was constructed
-        // through the owned descriptor (`hew_vec_new_with_elem_layout`), so its
-        // element load must route to the owned borrow getter. `hew_vec_get_ptr`
-        // (8-byte stride) would mis-stride a value-shaped element (the E3
-        // panic); `hew_vec_get_layout` aborts on an owned descriptor. The
-        // owned getter borrows the live buffer slot (no clone/drop) — a for-in
-        // / index read is a BORROW, not an independent owner.
+        // W5.016: an owned (non-Copy) record/enum/tuple VALUE element was
+        // constructed through the owned descriptor. A scalar index result is an
+        // independently-droppable value, so route it through the same fresh-owner
+        // clone choke as `Vec::get`, with a bare `T` dest. Nested collection
+        // HANDLES keep the established borrow contract: for-in and chained reads
+        // rely on the outer Vec remaining the sole owner, and cloning each cursor
+        // read would create an untracked temporary collection.
         let owned_elem = self.is_owned_vec_element(elem_ty);
+        let clone_owned_value =
+            owned_elem && !ty_is_vec(elem_ty) && !ty_is_local_collection_handle(elem_ty);
         let get_symbol = match elem_ty {
             ResolvedTy::Bool => "hew_vec_get_bool",
             ResolvedTy::I8 => "hew_vec_get_i8",
@@ -25024,6 +25132,7 @@ impl Builder {
             ResolvedTy::F32 => "hew_vec_get_f32",
             ResolvedTy::F64 => "hew_vec_get_f64",
             ResolvedTy::String => "hew_vec_get_str",
+            _ if clone_owned_value => "hew_vec_get_clone",
             _ if owned_elem => "hew_vec_get_owned",
             // BitCopy Named value records: use layout-descriptor getter so the
             // runtime applies the correct element stride.
@@ -25086,14 +25195,26 @@ impl Builder {
         };
 
         let result_place = self.alloc_local(elem_ty.clone());
-        self.push_instr(Instr::CallRuntimeAbi(
-            crate::model::RuntimeCall::new(
-                get_symbol,
-                vec![vec_place, index_place],
-                Some(result_place),
-            )
-            .expect("hew_vec_get_T is an allowlisted runtime symbol"),
-        ));
+        if clone_owned_value {
+            let next = self.alloc_block();
+            self.finish_current_block(Terminator::Call {
+                callee: get_symbol.to_string(),
+                builtin: None,
+                args: vec![vec_place, index_place],
+                dest: Some(result_place),
+                next,
+            });
+            self.start_block(next);
+        } else {
+            self.push_instr(Instr::CallRuntimeAbi(
+                crate::model::RuntimeCall::new(
+                    get_symbol,
+                    vec![vec_place, index_place],
+                    Some(result_place),
+                )
+                .expect("hew_vec_get_T is an allowlisted runtime symbol"),
+            ));
+        }
 
         Some(result_place)
     }
@@ -27242,6 +27363,20 @@ impl Builder {
         }
 
         let next = self.alloc_block();
+        let proven_borrow_args: HashSet<usize> = hir_args
+            .iter()
+            .enumerate()
+            .filter_map(|(index, arg)| {
+                self.param_ownership
+                    .proven_borrow_arg_sites
+                    .contains(&arg.site)
+                    .then_some(index)
+            })
+            .collect();
+        if !proven_borrow_args.is_empty() {
+            self.proven_borrow_call_args
+                .insert(self.current_block_id, proven_borrow_args);
+        }
         self.finish_current_block(Terminator::Call {
             callee: callee_symbol.to_string(),
             builtin,
@@ -35495,6 +35630,16 @@ impl Builder {
                         .as_deref()
                         .is_none_or(|b| !Self::expr_embeds_whole_param(b, params))
             }
+            HirExprKind::TupleLiteral { elements } => !elements
+                .iter()
+                .any(|value| Self::expr_embeds_whole_param(value, params)),
+            HirExprKind::MachineVariantCtor { payload, .. } => {
+                payload.as_ref().is_none_or(|fields| {
+                    !fields
+                        .iter()
+                        .any(|(_, value)| Self::expr_embeds_whole_param(value, params))
+                })
+            }
             // A projection is materialised iff its object chain is.
             HirExprKind::FieldAccess { object, .. } => {
                 Self::expr_is_materialized_owner(object, fresh, params)
@@ -36194,6 +36339,7 @@ fn elaborate(
                 &builder.suspend_kinds,
                 view,
                 &builder.binding_locals,
+                &builder.proven_borrow_call_args,
                 |ty| builder.binding_ty_is_owned_element_vec(ty),
             )
         },
@@ -36299,6 +36445,7 @@ fn elaborate(
                 &builder.suspend_kinds,
                 view,
                 &builder.binding_locals,
+                &builder.proven_borrow_call_args,
                 ty_is_local_collection_handle,
             )
         },
@@ -36367,6 +36514,7 @@ fn elaborate(
         &builder.suspend_kinds,
         &owned_locals_snapshot,
         &builder.binding_locals,
+        &builder.proven_borrow_call_args,
         ty_is_closure_pair_vec,
     );
     for states in dataflow_result.exit_states.values() {
@@ -36406,6 +36554,7 @@ fn elaborate(
                 &builder.suspend_kinds,
                 view,
                 &builder.binding_locals,
+                &builder.proven_borrow_call_args,
                 |ty| builder.binding_ty_is_plain_vec(ty),
             )
         },
@@ -44060,6 +44209,7 @@ fn derive_local_collection_drop_allowed(
     suspend_kinds: &HashMap<u32, SuspendKind>,
     owned_locals: &[(BindingId, String, ResolvedTy)],
     binding_locals: &HashMap<BindingId, Place>,
+    proven_borrow_call_args: &HashMap<u32, HashSet<usize>>,
     ty_filter: impl Fn(&ResolvedTy) -> bool,
 ) -> HashSet<BindingId> {
     // Candidate collection locals: base locals of owned handle bindings of
@@ -44205,6 +44355,25 @@ fn derive_local_collection_drop_allowed(
             Terminator::Call { callee, .. }
                 if crate::runtime_symbols::callee_ownership_contract(callee)
                     .is_vec_copy_in_element_store() => {}
+            // A direct user-function call borrows only the argument positions
+            // proven by the module parameter-body summary. Scan every other
+            // position as an escape, preserving the fail-closed behavior for a
+            // helper that returns, stores, sends, or otherwise forwards the Vec.
+            Terminator::Call { args, .. } if proven_borrow_call_args.contains_key(&block.id) => {
+                let borrowed = &proven_borrow_call_args[&block.id];
+                for (index, p) in args.iter().enumerate() {
+                    if borrowed.contains(&index) {
+                        continue;
+                    }
+                    if let Some(l) = base_local(*p) {
+                        if alias_of.contains_key(&l)
+                            && matches!(p, Place::Local(_) | Place::ReturnSlot)
+                        {
+                            note_escape(l, &mut excluded_roots);
+                        }
+                    }
+                }
+            }
             Terminator::Call { callee, args, .. }
                 if {
                     let contract = crate::runtime_symbols::callee_ownership_contract(callee);
@@ -53607,6 +53776,7 @@ mod owned_record_drop_derivation {
             &HashMap::new(),
             &collection_owned,
             &collection_binding_locals,
+            &HashMap::new(),
             is_vec_handle,
         );
         assert!(
@@ -56163,6 +56333,7 @@ mod f1_suspending_escape_poison {
             &std::collections::HashMap::new(),
             &owned_locals,
             &binding_locals,
+            &HashMap::new(),
             ty_is_local_collection_handle,
         );
 
@@ -56227,6 +56398,7 @@ mod f1_suspending_escape_poison {
             &std::collections::HashMap::new(),
             &owned_locals,
             &binding_locals,
+            &HashMap::new(),
             ty_is_local_collection_handle,
         );
 
@@ -56862,6 +57034,7 @@ mod plain_vec_drop_interior_alias_and_escape {
             &std::collections::HashMap::new(),
             &owned_locals,
             &binding_locals,
+            &HashMap::new(),
             ty_is_vec_handle,
         );
         assert!(
@@ -56925,6 +57098,7 @@ mod plain_vec_drop_interior_alias_and_escape {
             &std::collections::HashMap::new(),
             &owned_locals,
             &binding_locals,
+            &HashMap::new(),
             ty_is_vec_handle,
         );
         assert!(
@@ -56993,6 +57167,7 @@ mod plain_vec_drop_interior_alias_and_escape {
             &std::collections::HashMap::new(),
             &owned_locals,
             &binding_locals,
+            &HashMap::new(),
             ty_is_vec_handle,
         );
         assert!(
@@ -57067,6 +57242,7 @@ mod plain_vec_drop_interior_alias_and_escape {
             &std::collections::HashMap::new(),
             &owned_locals,
             &binding_locals,
+            &HashMap::new(),
             ty_is_vec_handle,
         );
         assert!(
@@ -57111,6 +57287,7 @@ mod plain_vec_drop_interior_alias_and_escape {
             &std::collections::HashMap::new(),
             &owned_locals,
             &binding_locals,
+            &HashMap::new(),
             ty_is_vec_handle,
         );
         assert!(
@@ -57165,6 +57342,7 @@ mod plain_vec_drop_interior_alias_and_escape {
             &std::collections::HashMap::new(),
             &owned_locals,
             &binding_locals,
+            &HashMap::new(),
             ty_is_vec_handle,
         );
         assert!(

--- a/hew-mir/tests/lowering_expr/conditional_move_drop.rs
+++ b/hew-mir/tests/lowering_expr/conditional_move_drop.rs
@@ -439,14 +439,14 @@ fn mixed_rebind_and_record_ingress_keeps_destination_release() {
 }
 
 // ---------------------------------------------------------------------------
-// Escape — fail-closed exclusions unchanged (negative controls).
+// Escape and borrow-call controls.
 // ---------------------------------------------------------------------------
 
-/// A vec conditionally consumed by a BY-VALUE CALL stays excluded (the
-/// callee-ownership question is the by-value-argument frontier, not this
-/// fix): no drop of the source on any path — leak, never a wrong free.
+/// A Vec passed to a helper whose parameter body is proven borrow-only remains
+/// caller-owned. Both the early-return call path and the ordinary fallthrough
+/// path must release it.
 #[test]
-fn conditional_by_value_call_arg_stays_excluded() {
+fn conditional_borrowing_value_call_drops_on_both_exits() {
     let pipeline = pipeline_with_tc(
         r"
         fn sink(xs: Vec<i64>) -> i64 {
@@ -475,9 +475,9 @@ fn conditional_by_value_call_arg_stays_excluded() {
     let drops = all_exit_drops(&pipeline, "probe");
     assert_eq!(
         frees(&drops, "hew_vec_free").len(),
-        0,
-        "a vec handed to a by-value callee must keep its fail-closed \
-         exclusion on every exit; got {drops:?}"
+        2,
+        "a Vec handed to a proven borrow-only callee must be released on both \
+         return exits; got {drops:?}"
     );
 }
 

--- a/hew-mir/tests/lowering_expr/plain_vec_local_drop.rs
+++ b/hew-mir/tests/lowering_expr/plain_vec_local_drop.rs
@@ -33,7 +33,7 @@
 //! an allow-set test without a paired exclusion would pass even if the gate
 //! admitted everything (the double-free this fix must never introduce).
 
-use hew_mir::{DropKind, ElabDrop, ExitPath, IrPipeline};
+use hew_mir::{DropKind, ElabDrop, ExitPath, IrPipeline, Terminator};
 use hew_types::module_registry::ModuleRegistry;
 use hew_types::Checker;
 
@@ -98,6 +98,19 @@ fn is_cow_heap_free(drop: &ElabDrop, symbol: &str) -> bool {
 
 fn count_free(drops: &[ElabDrop], symbol: &str) -> usize {
     drops.iter().filter(|d| is_cow_heap_free(d, symbol)).count()
+}
+
+fn count_calls(p: &IrPipeline, fn_name: &str, symbol: &str) -> usize {
+    p.raw_mir
+        .iter()
+        .find(|f| f.name == fn_name)
+        .unwrap_or_else(|| panic!("function {fn_name} must be present in raw_mir"))
+        .blocks
+        .iter()
+        .filter(|block| {
+            matches!(&block.terminator, Terminator::Call { callee, .. } if callee == symbol)
+        })
+        .count()
 }
 
 // ---------------------------------------------------------------------------
@@ -244,6 +257,35 @@ fn plain_vec_local_drop_bitcopy_record_array_repeat_frees_exactly_once() {
     );
 }
 
+/// A bound owned value remains caller-owned after `push`, so it must keep the
+/// copy-in clone route rather than transferring its heap into the Vec.
+#[test]
+fn owned_vec_push_of_bound_value_keeps_copy_in_route() {
+    let pipeline = pipeline_with_tc(
+        r#"
+        type Header {
+            name: string;
+        }
+        fn main() -> i64 {
+            let hs: Vec<Header> = Vec::new();
+            let header = Header { name: "content-type".to_upper() };
+            hs.push(header);
+            header.name.len() + hs.len()
+        }
+        "#,
+    );
+    assert_eq!(
+        count_calls(&pipeline, "main", "hew_vec_push_owned"),
+        1,
+        "a bound source must be cloned into the Vec"
+    );
+    assert_eq!(
+        count_calls(&pipeline, "main", "hew_vec_push_owned_move"),
+        0,
+        "a bound source must retain its independent owner"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Cancel parity — cancellation frees what normal return frees.
 // ---------------------------------------------------------------------------
@@ -314,6 +356,71 @@ fn plain_vec_local_drop_does_not_displace_owned_element_vec() {
         0,
         "the plain hew_vec_free must never fire on an owned-element Vec \
          (it would skip the per-element descriptor drops); got {drops:?}"
+    );
+}
+
+/// A direct generic helper that only borrows its `Vec<T>` parameter through
+/// `Vec::get` must not suppress the caller's owned-element Vec release. The
+/// returned `Option<Header>` owns a fresh clone; the caller still owns and drops
+/// the original Vec.
+#[test]
+fn owned_vec_get_through_borrowing_helper_keeps_caller_drop() {
+    let pipeline = pipeline_with_tc(
+        r#"
+        type Header {
+            name: string;
+        }
+        fn first<T>(xs: Vec<T>) -> Option<T> {
+            xs.get(0)
+        }
+        fn main() -> i64 {
+            let hs: Vec<Header> = Vec::new();
+            hs.push(Header { name: "content-type" });
+            match first(hs) {
+                Some(header) => header.name.len(),
+                None => 0,
+            }
+        }
+        "#,
+    );
+    assert_eq!(
+        count_calls(&pipeline, "main", "hew_vec_push_owned_move"),
+        1,
+        "the fresh Header literal must move into the Vec instead of leaking the \
+         anonymous source through clone-in"
+    );
+    let drops = return_drops(&pipeline, "main");
+    assert_eq!(
+        count_free(&drops, "hew_vec_free_owned"),
+        1,
+        "a borrow-only generic helper must leave the caller's owned Vec admitted \
+         for exactly one hew_vec_free_owned; got {drops:?}"
+    );
+}
+
+/// Trapping `v[i]` over an owned element must use the same fresh-owner clone
+/// choke as `Vec::get`; borrowing the live slot would let the indexed result
+/// release heap still owned by the Vec.
+#[test]
+fn owned_vec_index_uses_fresh_clone_choke() {
+    let pipeline = pipeline_with_tc(
+        r#"
+        type Header {
+            name: string;
+        }
+        fn main() -> i64 {
+            let hs: Vec<Header> = Vec::new();
+            hs.push(Header { name: "content-type".to_upper() });
+            let first = hs[0];
+            first.name.len() + hs[0].name.len()
+        }
+        "#,
+    );
+    assert_eq!(
+        count_calls(&pipeline, "main", "hew_vec_get_clone"),
+        2,
+        "each owned-element scalar index must materialise a fresh owner through \
+         hew_vec_get_clone"
     );
 }
 
@@ -560,10 +667,10 @@ fn plain_vec_local_drop_single_arm_match_frees_result_exactly_once() {
     );
 }
 
-/// A vec consumed by a by-value call is owned by the callee now; the calling
-/// function must NOT also free it. LESSONS: `raii-null-after-move`.
+/// A direct helper whose parameter body only borrows the Vec leaves ownership
+/// with the caller, which must keep its scope-exit release.
 #[test]
-fn plain_vec_local_drop_excludes_by_value_consumed_vec() {
+fn plain_vec_local_drop_keeps_vec_across_borrowing_value_call() {
     let pipeline = pipeline_with_tc(
         r"
         fn total(xs: Vec<i64>) -> i64 {
@@ -579,8 +686,33 @@ fn plain_vec_local_drop_excludes_by_value_consumed_vec() {
     let drops = all_exit_drops(&pipeline, "main");
     assert_eq!(
         count_free(&drops, "hew_vec_free"),
-        0,
-        "a vec passed by value is consumed by the callee; the caller must \
-         NOT also free it; got {drops:?}"
+        1,
+        "a borrow-only by-value helper leaves the Vec caller-owned; the caller \
+         must free it exactly once; got {drops:?}"
+    );
+}
+
+/// Negative control: a helper that returns its Vec parameter hands the handle
+/// to the result owner, so the caller's source binding must remain excluded.
+#[test]
+fn plain_vec_local_drop_excludes_value_call_that_returns_vec() {
+    let pipeline = pipeline_with_tc(
+        r"
+        fn identity(xs: Vec<i64>) -> Vec<i64> {
+            xs
+        }
+        fn main() -> i64 {
+            let v: Vec<i64> = Vec::new();
+            let out = identity(v);
+            out.len()
+        }
+        ",
+    );
+    let drops = all_exit_drops(&pipeline, "main");
+    assert_eq!(
+        count_free(&drops, "hew_vec_free"),
+        1,
+        "the returned Vec owner must free once while the caller's source stays \
+         excluded; got {drops:?}"
     );
 }

--- a/hew-types/tests/coverage/checked_mir_corpus_coverage.rs
+++ b/hew-types/tests/coverage/checked_mir_corpus_coverage.rs
@@ -204,6 +204,10 @@ const EXPECTED_UNCOVERED: &[&str] = &[
     "hew_node_link_remote",
     // -- Ptr element-type variants with no source-reachable producer
     //    (no user surface yields a ptr-element Vec).
+    // -- Owned Vec.get is lowered through the clone-returning ABI for
+    //    ownership-safe extraction; the legacy move-out symbol is no longer
+    //    emitted by checked MIR.
+    "hew_vec_get_owned",
     "hew_vec_get_ptr",
     "hew_vec_slice_range_ptr",
     // -- Per-type slice-range symbols replaced by the unified bytesize path.


### PR DESCRIPTION
I fixed an active ownership leak in Vec<T>.get() when the element is owned and moved out through a generic helper. macOS leaks(1) measured 9 leaks / 576 B at 3 frames and 150 leaks / 9600 B at 50 frames before the fix, approximately 3 nodes / 192 B per iteration.

The root cause was two ownership gaps: borrow-only direct-call parameters were treated as collection handoffs, suppressing the caller's Vec drop, and fresh owned push rvalues were copied instead of transferred. I corrected both MIR/codegen paths and un-ignored the regression oracle.

The oracle now passes with 0 leaks at both 3 and 50 frames, including the poisoned-allocator exact-contents check.

Validation:
- cargo test -p hew-cli --test vec_generic_get_owned_leak_oracle -- --nocapture --include-ignored
- cargo check --workspace
- cargo test -p hew-mir -p hew-codegen-rs