### PR TITLE
test(tls): serialize global runtime ownership

### DIFF
--- a/hew-std/src/tls.rs
+++ b/hew-std/src/tls.rs
@@ -1569,12 +1569,22 @@ mod tests {
         std::ptr::null_mut()
     }
 
-    struct TlsRuntimeGuard;
+    static TLS_RUNTIME_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct TlsRuntimeGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
 
     impl TlsRuntimeGuard {
         fn new() -> Self {
+            // The scheduler is process-global: repeated init is a no-op, but
+            // cleanup frees every tracked actor. Hold exclusive ownership for
+            // the full test so one TLS test cannot reclaim another's live actor.
+            let lock = TLS_RUNTIME_TEST_LOCK
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
             assert_eq!(scheduler::hew_sched_init(), 0);
-            Self
+            Self { _lock: lock }
         }
     }
 


### PR DESCRIPTION
## Summary

I traced the Windows abort to the two runtime-backed TLS tests sharing one process-global scheduler. Each guard treated idempotent `hew_sched_init` as exclusive ownership, so the first test to finish called global cleanup and freed the sibling test's live actor. The sibling then used its stale actor pointer during teardown; Windows allocator reuse turned the freed mailbox field into the reported misaligned address.

I added a test mutex to `TlsRuntimeGuard` and hold it across scheduler init, the full test body, shutdown, and cleanup. This keeps each test's actor and mailbox alive until its reader is joined and its explicit teardown completes.

Fixes #2615

## Verification

- `cargo test -p hew-std -p hew-runtime`
- Repeated the concurrent `reaps` filter 25 times with `--test-threads=2`
- Reproduced the pre-fix race locally before applying the guard

## Out of scope

I did not change production TLS reader shutdown or mailbox code because the reader join ordering is sound; the dangling pointer was created by overlapping test-runtime cleanup.

## Quality Checklist

- [x] PR title, body, and commit messages avoid internal-only orchestration/model vocabulary
- [x] No new `.ok()?` or `unwrap_or_default()` in codegen without `// JUSTIFIED` comment
- [x] New allocations have cleanup paths for sync, async, and actor shutdown contexts
- [x] Serialization changes include round-trip encode/decode tests
- [x] New runtime features have WASM implementation or `// WASM-TODO(#NNN):` marker
- [x] No duplicated logic — checked for existing helpers before adding new ones