### PR TITLE
fix(types): reject opaque handles as receive-fn parameters, with a clean diagnostic

### DIFF
--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -1903,6 +1903,38 @@ impl Checker {
         }
     }
 
+    /// Reject an opaque handle type used as a receive-fn (actor message)
+    /// parameter, directly or nested inside a record/enum/tuple payload.
+    ///
+    /// Actor message payloads are CBOR-serialized to cross the mailbox
+    /// dispatch boundary. Opaque handle types (e.g. `net.Listener`,
+    /// `net.Connection`, user `#[opaque]` types) are pointer-shaped runtime
+    /// resources with no serializable record layout, so they can never be a
+    /// message payload. Without this checker-layer diagnostic the failure
+    /// surfaces late as a raw codegen-front `wire CBOR serialize: named type
+    /// ... is not a registered record layout` message that names an internal
+    /// wire detail instead of the offending parameter. See #2511.
+    fn reject_opaque_message_payload(&mut self, ty: &Ty, param_span: &Span, handler: &str) {
+        let mut visiting = std::collections::HashSet::new();
+        let Some(opaque_name) = self.ty_field_contains_opaque(ty, &mut visiting) else {
+            return;
+        };
+        self.report_error(
+            TypeErrorKind::OpaqueMessagePayload {
+                type_name: opaque_name.clone(),
+                handler: handler.to_string(),
+            },
+            param_span,
+            format!(
+                "opaque type `{opaque_name}` cannot be used as a receive-fn \
+                 parameter; actor message payloads must be CBOR-serializable, \
+                 and opaque handles have no serializable layout. Open or \
+                 construct the handle locally inside the handler instead \
+                 [E_OPAQUE_MESSAGE_PAYLOAD]"
+            ),
+        );
+    }
+
     pub(super) fn check_receive_fn(
         &mut self,
         actor_name: &str,
@@ -1955,6 +1987,7 @@ impl Checker {
         for p in &rf.params {
             self.check_shadowing(&p.name, &p.ty.1);
             let ty = self.resolve_type_expr(&p.ty);
+            self.reject_opaque_message_payload(&ty, &p.ty.1, &qualified_name);
             self.env
                 .define_param_with_span(p.name.clone(), ty, p.is_mutable, p.ty.1.clone());
         }

--- a/hew-types/src/check/items.rs
+++ b/hew-types/src/check/items.rs
@@ -1916,7 +1916,7 @@ impl Checker {
     /// wire detail instead of the offending parameter. See #2511.
     fn reject_opaque_message_payload(&mut self, ty: &Ty, param_span: &Span, handler: &str) {
         let mut visiting = std::collections::HashSet::new();
-        let Some(opaque_name) = self.ty_field_contains_opaque(ty, &mut visiting) else {
+        let Some(opaque_name) = self.ty_message_payload_contains_opaque(ty, &mut visiting) else {
             return;
         };
         self.report_error(

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -2861,9 +2861,9 @@ impl Checker {
         found
     }
 
-    /// Return the first opaque message-payload type, exempting only the
-    /// compiler-built-in channel endpoints that local actor delivery transfers
-    /// by ownership.
+    /// Return the first opaque message-payload type, exempting compiler-built-in
+    /// channel endpoints and actor references that local actor delivery
+    /// transfers as handle values.
     pub(super) fn ty_message_payload_contains_opaque(
         &self,
         ty: &Ty,
@@ -2892,7 +2892,12 @@ impl Checker {
                 if skip_channel_handles
                     && matches!(
                         builtin,
-                        Some(crate::BuiltinType::Sender | crate::BuiltinType::Receiver)
+                        Some(
+                            crate::BuiltinType::Sender
+                                | crate::BuiltinType::Receiver
+                                | crate::BuiltinType::LocalPid
+                                | crate::BuiltinType::RemotePid
+                        )
                     )
                 {
                     return None;

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -2853,7 +2853,7 @@ impl Checker {
         found
     }
 
-    fn ty_field_contains_opaque(
+    pub(super) fn ty_field_contains_opaque(
         &self,
         ty: &Ty,
         visiting: &mut std::collections::HashSet<String>,

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -2742,6 +2742,7 @@ impl Checker {
                 name,
                 type_args,
                 &mut std::collections::HashSet::new(),
+                false,
             ) {
                 return RecordCloneAdmissibility::OpaqueField { opaque_name };
             }
@@ -2768,6 +2769,7 @@ impl Checker {
             name,
             type_args,
             &mut std::collections::HashSet::new(),
+            false,
         ) {
             return RecordCloneAdmissibility::OpaqueField { opaque_name };
         }
@@ -2790,6 +2792,7 @@ impl Checker {
         name: &str,
         type_args: &[Ty],
         visiting: &mut std::collections::HashSet<String>,
+        skip_channel_handles: bool,
     ) -> Option<String> {
         if !visiting.insert(name.to_string()) {
             return None; // cycle protection
@@ -2799,7 +2802,9 @@ impl Checker {
             for field_ty in type_def.fields.values() {
                 let field_ty =
                     Self::instantiate_type_def_member(field_ty, &type_def.type_params, type_args);
-                if let Some(opaque) = self.ty_field_contains_opaque(&field_ty, visiting) {
+                if let Some(opaque) =
+                    self.ty_field_contains_opaque(&field_ty, visiting, skip_channel_handles)
+                {
                     found = Some(opaque);
                     break;
                 }
@@ -2824,6 +2829,7 @@ impl Checker {
         name: &str,
         type_args: &[Ty],
         visiting: &mut std::collections::HashSet<String>,
+        skip_channel_handles: bool,
     ) -> Option<String> {
         if !visiting.insert(name.to_string()) {
             return None; // cycle protection
@@ -2842,7 +2848,9 @@ impl Checker {
                         &type_def.type_params,
                         type_args,
                     );
-                    if let Some(opaque) = self.ty_field_contains_opaque(&payload_ty, visiting) {
+                    if let Some(opaque) =
+                        self.ty_field_contains_opaque(&payload_ty, visiting, skip_channel_handles)
+                    {
                         found = Some(opaque);
                         break 'variants;
                     }
@@ -2853,17 +2861,42 @@ impl Checker {
         found
     }
 
-    pub(super) fn ty_field_contains_opaque(
+    /// Return the first opaque message-payload type, exempting only the
+    /// compiler-built-in channel endpoints that local actor delivery transfers
+    /// by ownership.
+    pub(super) fn ty_message_payload_contains_opaque(
         &self,
         ty: &Ty,
         visiting: &mut std::collections::HashSet<String>,
+    ) -> Option<String> {
+        self.ty_field_contains_opaque(ty, visiting, true)
+    }
+
+    fn ty_field_contains_opaque(
+        &self,
+        ty: &Ty,
+        visiting: &mut std::collections::HashSet<String>,
+        skip_channel_handles: bool,
     ) -> Option<String> {
         // Resolve inference vars so a field whose type is still a `Ty::Var`
         // bound in the substitution environment is walked at its concrete type
         // (mirrors `vec_element_contains_structural_array`).
         let resolved = self.subst.resolve(ty);
         match &resolved {
-            Ty::Named { name, args, .. } => {
+            Ty::Named {
+                name,
+                args,
+                builtin,
+                ..
+            } => {
+                if skip_channel_handles
+                    && matches!(
+                        builtin,
+                        Some(crate::BuiltinType::Sender | crate::BuiltinType::Receiver)
+                    )
+                {
+                    return None;
+                }
                 // Direct opaque handle (imported via module registry OR user-declared #[opaque])?
                 if self.canonical_owned_handle_type_name(name).is_some()
                     || self.user_opaque_type_names.contains(name.as_str())
@@ -2872,13 +2905,17 @@ impl Checker {
                 }
                 // Recurse into type args (e.g. `Vec<Handle>`, `Option<Handle>`).
                 for arg in args {
-                    if let Some(n) = self.ty_field_contains_opaque(arg, visiting) {
+                    if let Some(n) =
+                        self.ty_field_contains_opaque(arg, visiting, skip_channel_handles)
+                    {
                         return Some(n);
                     }
                 }
                 // Recurse into the type def's fields, substituting the def's
                 // params with the concrete `args` at this use site.
-                if let Some(n) = self.record_field_contains_opaque(name, args, visiting) {
+                if let Some(n) =
+                    self.record_field_contains_opaque(name, args, visiting, skip_channel_handles)
+                {
                     return Some(n);
                 }
                 // Recurse into enum variant payloads too — a nested enum with a
@@ -2887,14 +2924,18 @@ impl Checker {
                 // walk, so without this an outer clone would admit an
                 // unclonable leaf. (`record_field_contains_opaque` is a no-op
                 // for an enum, and vice-versa, so both calls are kind-safe.)
-                if let Some(n) = self.enum_variant_contains_opaque(name, args, visiting) {
+                if let Some(n) =
+                    self.enum_variant_contains_opaque(name, args, visiting, skip_channel_handles)
+                {
                     return Some(n);
                 }
                 None
             }
             Ty::Tuple(items) => {
                 for item in items {
-                    if let Some(n) = self.ty_field_contains_opaque(item, visiting) {
+                    if let Some(n) =
+                        self.ty_field_contains_opaque(item, visiting, skip_channel_handles)
+                    {
                         return Some(n);
                     }
                 }

--- a/hew-types/src/check/tests/handles.rs
+++ b/hew-types/src/check/tests/handles.rs
@@ -1076,3 +1076,156 @@ mod task_type_surface_rules {
         );
     }
 }
+
+// ── #2511: opaque handles rejected as receive-fn (message) parameters ───────
+//
+// Actor message payloads are CBOR-serialized to cross the mailbox dispatch
+// boundary. Opaque handle types (`net.Listener`, user `#[opaque]` types, etc.)
+// are pointer-shaped runtime resources with no serializable record layout, so
+// they cannot be message payloads. Before #2511 this fell through to a raw
+// codegen-front `wire CBOR serialize: named type ... is not a registered
+// record layout` failure surfaced even at `hew check`; the checker now emits a
+// clean `OpaqueMessagePayload` diagnostic pointing at the parameter.
+mod opaque_receive_fn_param_rules {
+    use super::*;
+
+    fn opaque_payload_errors(output: &TypeCheckOutput) -> Vec<&TypeError> {
+        output
+            .errors
+            .iter()
+            .filter(|e| matches!(&e.kind, TypeErrorKind::OpaqueMessagePayload { .. }))
+            .collect()
+    }
+
+    #[test]
+    fn user_opaque_direct_receive_fn_param_is_rejected() {
+        // A same-module `#[opaque]` type (producer-side, so constructing it is
+        // allowed) used directly as a receive-fn parameter must still be
+        // rejected: it can never cross the message boundary.
+        let output = check_source(
+            r"
+            #[opaque]
+            type Handle {}
+
+            actor Server {
+                var count: i64 = 0;
+                receive fn handle(h: Handle) {
+                    count = count + 1;
+                }
+            }
+            ",
+        );
+        let errs = opaque_payload_errors(&output);
+        assert_eq!(
+            errs.len(),
+            1,
+            "opaque handle as a receive-fn parameter must emit exactly one \
+             OpaqueMessagePayload error; got: {:#?}",
+            output.errors
+        );
+        assert!(
+            errs[0].message.contains("E_OPAQUE_MESSAGE_PAYLOAD"),
+            "diagnostic must carry the envelope code; got: {:?}",
+            errs[0].message
+        );
+        assert!(
+            matches!(&errs[0].kind, TypeErrorKind::OpaqueMessagePayload { type_name, .. } if type_name == "Handle"),
+            "diagnostic must name the opaque type `Handle`; got: {:?}",
+            errs[0].kind
+        );
+    }
+
+    #[test]
+    fn stdlib_handle_direct_receive_fn_param_is_rejected() {
+        // A registered stdlib-style owned handle used directly as a receive-fn
+        // parameter is rejected the same way.
+        let output = check_source_with_handle(
+            r"
+            actor Server {
+                var count: i64 = 0;
+                receive fn handle(p: regex.Pattern) {
+                    count = count + 1;
+                }
+            }
+            ",
+            "regex.Pattern",
+        );
+        let errs = opaque_payload_errors(&output);
+        assert_eq!(
+            errs.len(),
+            1,
+            "registered handle as a receive-fn parameter must emit exactly one \
+             OpaqueMessagePayload error; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn opaque_nested_in_record_receive_fn_param_is_rejected() {
+        // The opaque leaf is reached transitively through a record field, so a
+        // record-wrapped handle payload is rejected too (single clean error at
+        // the parameter, not a late codegen clone-gate message).
+        let output = check_source_with_handle(
+            r"
+            type Wrapper { conn: regex.Pattern }
+
+            actor Server {
+                var count: i64 = 0;
+                receive fn handle(w: Wrapper) {
+                    count = count + 1;
+                }
+            }
+            ",
+            "regex.Pattern",
+        );
+        let errs = opaque_payload_errors(&output);
+        assert_eq!(
+            errs.len(),
+            1,
+            "record field carrying an opaque handle must emit exactly one \
+             OpaqueMessagePayload error at the receive-fn parameter; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn serializable_receive_fn_params_are_accepted() {
+        // Negative control: ordinary CBOR-serializable payloads must NOT trip
+        // the new diagnostic.
+        let output = check_source(
+            r"
+            actor Server {
+                var count: i64 = 0;
+                receive fn handle(n: i64, label: string) {
+                    count = count + n;
+                }
+            }
+            ",
+        );
+        assert!(
+            opaque_payload_errors(&output).is_empty(),
+            "serializable receive-fn params must not raise OpaqueMessagePayload; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn opaque_handle_as_non_receive_fn_param_is_accepted() {
+        // Negative control: the restriction is specific to receive-fn (message)
+        // parameters. A plain free function taking an opaque handle is fine.
+        let output = check_source_with_handle(
+            r"
+            fn use_pattern(p: regex.Pattern) -> i64 {
+                0
+            }
+            ",
+            "regex.Pattern",
+        );
+        assert!(
+            opaque_payload_errors(&output).is_empty(),
+            "opaque handle as a non-receive fn param must not raise \
+             OpaqueMessagePayload; got: {:#?}",
+            output.errors
+        );
+    }
+}

--- a/hew-types/src/check/tests/handles.rs
+++ b/hew-types/src/check/tests/handles.rs
@@ -1210,6 +1210,33 @@ mod opaque_receive_fn_param_rules {
     }
 
     #[test]
+    fn actor_pid_param_does_not_walk_referenced_actor_state() {
+        let output = check_source(
+            r"
+            #[opaque]
+            type Handle {}
+
+            actor Worker {
+                let handle: Handle;
+                receive fn run() {}
+            }
+
+            actor Server {
+                receive fn register(worker: LocalPid<Worker>) {}
+                receive fn register_remote(worker: RemotePid<Worker>) {}
+            }
+            ",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "actor PID parameters are transferable references; the referenced \
+             actor's opaque state must not be treated as structurally embedded \
+             in the message payload; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
     fn serializable_receive_fn_params_are_accepted() {
         // Negative control: ordinary CBOR-serializable payloads must NOT trip
         // the new diagnostic.

--- a/hew-types/src/check/tests/handles.rs
+++ b/hew-types/src/check/tests/handles.rs
@@ -1189,6 +1189,27 @@ mod opaque_receive_fn_param_rules {
     }
 
     #[test]
+    fn channel_handle_receive_fn_params_are_accepted() {
+        let output = check_source(
+            r"
+            actor Server {
+                receive fn sender(tx: channel.Sender<string>) {}
+                receive fn receiver(rx: channel.Receiver<string>) {}
+                receive fn nested(
+                    handles: (channel.Sender<i64>, channel.Receiver<i64>)
+                ) {}
+            }
+            ",
+        );
+        assert!(
+            output.errors.is_empty(),
+            "built-in channel handles must remain valid local receive-fn \
+             parameters, including in aggregate payloads; got: {:#?}",
+            output.errors
+        );
+    }
+
+    #[test]
     fn serializable_receive_fn_params_are_accepted() {
         // Negative control: ordinary CBOR-serializable payloads must NOT trip
         // the new diagnostic.

--- a/hew-types/src/error.rs
+++ b/hew-types/src/error.rs
@@ -1208,6 +1208,27 @@ pub enum TypeErrorKind {
         /// `"net.Listener"`).
         type_name: String,
     },
+    /// An `#[opaque]` handle type was used as a receive-fn (actor message)
+    /// parameter, directly or nested inside a record/enum/tuple payload.
+    ///
+    /// Actor message payloads are CBOR-serialized to cross the mailbox
+    /// dispatch boundary, but opaque handles are pointer-shaped runtime
+    /// resources (e.g. `net.Listener`, `net.Connection`) with no record
+    /// layout, so they cannot be serialized. Without this checker-layer
+    /// diagnostic the failure surfaces late as a raw codegen-front
+    /// `wire CBOR serialize: named type ... is not a registered record
+    /// layout` message that names an internal wire detail instead of the
+    /// offending parameter. The handle should be opened/constructed locally
+    /// inside the handler instead of being sent as a message.
+    ///
+    /// Envelope code: `E_OPAQUE_MESSAGE_PAYLOAD`.
+    OpaqueMessagePayload {
+        /// The resolved name of the opaque handle type reached at or within
+        /// the parameter (e.g. `"Listener"`, `"net.Connection"`).
+        type_name: String,
+        /// The `actor::handler` key the offending parameter belongs to.
+        handler: String,
+    },
     /// A `Stream<T>` lazy adapter (`.take`/`.map`/`.filter`) was invoked.
     ///
     /// These adapters type-check (they have builtin signatures) but have no
@@ -1355,6 +1376,7 @@ impl TypeErrorKind {
             Self::RefutableLetPattern { .. } => "RefutableLetPattern",
             Self::LetElseDoesNotDiverge => "LetElseDoesNotDiverge",
             Self::OpaqueDirectConstruct { .. } => "OpaqueDirectConstruct",
+            Self::OpaqueMessagePayload { .. } => "OpaqueMessagePayload",
             Self::StreamAdapterNotSupported { .. } => "StreamAdapterNotSupported",
             Self::VisibilityViolationPrivate { .. } => "VisibilityViolationPrivate",
             Self::VisibilityViolationPackage { .. } => "VisibilityViolationPackage",


### PR DESCRIPTION
Fixes #2511.

## Problem

Passing an opaque FFI handle type (e.g. `net.Listener`, `net.Connection`) as an actor receive-fn message parameter failed at codegen, not type-check, surfacing as a raw internal message:

```
E_CODEGEN_FRONT_FAIL_CLOSED: wire CBOR serialize: named type `Listener` (key `Listener`) is not a registered record layout
```

Actor message payloads are CBOR-serialized to cross the mailbox dispatch boundary. Opaque handle types are pointer-shaped runtime resources with no serializable layout, so they can never be a message payload — the checker should reject this at `hew check` time with a diagnostic that names the offending parameter, not let it fall through to a codegen-internal error.

## Fix

Added `reject_opaque_message_payload` in the checker, walking a receive-fn parameter's type (including nested record/enum/tuple payloads) for an opaque handle and reporting `E_OPAQUE_MESSAGE_PAYLOAD` with the parameter's span.

The walk exempts three classes of builtin handle that are legitimately transferable as message payloads despite being opaque-shaped:
- `channel.Sender<T>`/`channel.Receiver<T>` — the deliberate process-local actor-message transfer mechanism; the channel endpoint itself is the serializable unit, not its type argument's structure.
- `LocalPid<T>`/`RemotePid<T>` — actor process references. Passing a PID as a message payload is a routine, fundamental part of the actor model (addressing/replying). The PID is what gets serialized as a lightweight identifier; its type argument denotes which actor type it addresses, not data structurally embedded in the handle.

`LambdaPid` (an owning, closeable resource, unlike the two reference-only PID types above) is deliberately NOT exempted — it's excluded from the generic-payload traversal on the same basis as any other owned opaque handle.

## Verification

- `cargo test -p hew-types opaque_receive_fn_param_rules`: 7/7 pass, including both new-pass cases (`LocalPid<T>`/`RemotePid<T>` no longer rejected) and the still-reject controls (a record directly embedding an opaque field stays rejected).
- `cargo test -p hew-cli --test machine_transition_watch_e2e`: 13/13 pass.
- `cargo check --workspace`: clean.
- `make hew-check-all` (full 1,575-file `.hew` corpus ratchet, including `examples/chat_server.hew` which uses `LocalPid<ClientHandler>` as a receive-fn parameter): clean, no unexpected failures.

Credit to gertybotbot (#2583) for the original diagnostic and channel-handle exemption; this PR carries that work forward with the additional `LocalPid`/`RemotePid` exemption needed to pass the full example corpus.