### PR TITLE
fix(examples): refresh ecosystem-facing APIs and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -823,29 +823,13 @@ test-stdlib-ratchet: hew
 # .expected file.  Any tutorial whose .expected output diverges from `hew run`
 # output fails the gate, catching dialect regressions before they reach users.
 #
-# Tutorials that depend on unimplemented substrate are explicitly listed in
-# UX_SKIP and PROG_SKIP with a one-line reason; they are reported as SKIP, not
-# failures.  Remove a file from the skip list once the substrate gap is closed.
-#
-#   hew_duplex_close NYI — lambda-actor close() not yet lowered to MIR
-#     tracked: deferred-v05-followups.md (hew_duplex_close)
-UX_SKIP   := examples/ux/10_lambda_actor.hew
-PROG_SKIP  := examples/progressive/10_lambda_actor.hew
-
 test-ux-examples: hew runtime stdlib
 	@echo "==> Running ux + progressive tutorials against .expected"
-	@fail=0; pass=0; skip=0; \
+	@fail=0; pass=0; \
 	for corpus in examples/ux examples/progressive; do \
 	  for src in $$(find $$corpus -maxdepth 1 -name '*.hew' | sort); do \
 	    exp="$${src%.hew}.expected"; \
 	    test -f "$$exp" || continue; \
-	    for s in $(UX_SKIP) $(PROG_SKIP); do \
-	      if [ "$$src" = "$$s" ]; then \
-	        echo "  SKIP: $$src  (substrate-gated: hew_duplex_close NYI)"; \
-	        skip=$$((skip + 1)); \
-	        continue 2; \
-	      fi; \
-	    done; \
 	    actual=$$($(DEBUG_DIR)/hew run "$$src" 2>&1); \
 	    expected=$$(cat "$$exp"); \
 	    if [ "$$actual" = "$$expected" ]; then \
@@ -858,7 +842,7 @@ test-ux-examples: hew runtime stdlib
 	    fi; \
 	  done; \
 	done; \
-	echo "  $$pass passed, $$skip skipped (substrate-gated), $$fail failed"; \
+	echo "  $$pass passed, $$fail failed"; \
 	if [ $$fail -gt 0 ]; then \
 	  echo "ERROR: $$fail tutorial(s) failed — run \`hew run <file>\` to reproduce"; \
 	  exit 1; \

--- a/docs/hew-language-guide.md
+++ b/docs/hew-language-guide.md
@@ -23,7 +23,12 @@ hew check hello.hew
 
 The `--` separator is mandatory when passing program arguments — everything before `--` is parsed as `hew run` options, and everything after is forwarded to your program as `os.args()`. Without `--`, unrecognised flags produce a usage error.
 
-**Working inside the Hew source checkout?** The stdlib resolver will find both the checkout's `std/` and the compiler's own stdlib and reject the ambiguity. Move your project to a directory outside the checkout, or use a standalone `hew init` directory.
+**Working inside the Hew source checkout?** An in-checkout compiler can resolve
+the repository's `std/` through the development fallback. Set `HEWPATH` or
+`HEW_STD` when selecting an alternate installation or when another directory
+layout would otherwise be ambiguous. See
+[Module search paths & stdlib discovery](../README.md#module-search-paths--stdlib-discovery)
+for the documented resolver precedence.
 
 ## Core idioms
 

--- a/docs/specs/HEW-SPEC-2026.md
+++ b/docs/specs/HEW-SPEC-2026.md
@@ -1735,8 +1735,15 @@ max(3.14, 2.71);       // max$f64
 
 #### 3.8.2 Type-Erased Dispatch with `dyn Trait`
 
-> See HEW-FUTURE.md §2.2 for `dyn Trait`, vtable layout, and object-safety
-> rules — targeted for v0.6.
+Single-trait `dyn Trait` dispatch is implemented. A concrete value whose type
+implements the trait can be passed to a `dyn Trait` parameter, where calls to
+the trait's instance methods dispatch through the runtime vtable. See
+[`examples/types_and_traits.hew`](../../examples/types_and_traits.hew) for a
+runnable example.
+
+The current subset does not yet fully enforce object-safety rules or support
+associated-type bounds and higher-ranked trait bounds in `dyn` position. See
+[HEW-FUTURE.md §2.2](HEW-FUTURE.md) for those remaining object-type details.
 
 #### 3.8.3 Trait Bounds
 
@@ -2482,10 +2489,12 @@ a `main()`-body call outside any receive handler.
 
 #### 3.10.8 Regular Expressions
 
-> See HEW-FUTURE.md §3 for `std::text::regex` — targeted for v0.6+
-> alongside the stdlib port-forward. `regex.Pattern` is a
-> `#[resource]`-annotated type with RAII handles (§3.7.8): `close()`
-> releases early, and the implicit scope-exit drop covers the rest.
+`std::text::regex` is shipped. It compiles patterns and supports matching,
+replacement, indexed and named captures, and multi-match capture tables.
+`regex.Pattern` is a `#[resource]`-annotated type with RAII handles (§3.7.8):
+`close()` releases early, and the implicit scope-exit drop covers the rest.
+Pattern construction is currently fail-fast: `regex.new()` panics for invalid
+syntax rather than returning a structured compile error.
 
 ---
 
@@ -4224,10 +4233,13 @@ enum Status { PendingReview; ActiveNow; Completed; }
 
 #### 7.3.2a YAML Encoding
 
-> See HEW-FUTURE.md §3 for `std::encoding::yaml` — targeted for v0.6+
-> alongside the stdlib port-forward. Wire types may serialize as YAML
-> via the same mapping rules JSON uses (§7.3.2); the normative YAML
-> mapping waits for the next edition.
+`std::encoding::yaml` is shipped for parsing, constructing, inspecting, and
+stringifying YAML values. Wire types can also serialize to and from YAML using
+the helper surface below.
+
+The exact normative YAML mapping for wire fields and variants remains deferred
+to the next edition. The current implementation follows the JSON mapping rules
+in §7.3.2 where those rules apply.
 
 #### 7.3.4 Encoding Selection
 

--- a/examples/progressive/10_lambda_actor.hew
+++ b/examples/progressive/10_lambda_actor.hew
@@ -5,8 +5,17 @@ fn main() {
     let counter = actor |msg: i64| {
         println(msg * 2);
     };
-    counter.send(5);
-    counter.send(10);
-    counter.send(15);
+    match counter.send(5) {
+        Ok(_) => {},
+        Err(_) => panic("failed to send 5"),
+    }
+    match counter.send(10) {
+        Ok(_) => {},
+        Err(_) => panic("failed to send 10"),
+    }
+    match counter.send(15) {
+        Ok(_) => {},
+        Err(_) => panic("failed to send 15"),
+    }
     await counter.close();
 }

--- a/examples/quic_mesh/client.hew
+++ b/examples/quic_mesh/client.hew
@@ -7,14 +7,44 @@
 //
 // Run after server.hew is already listening:
 //   hew run examples/quic_mesh/client.hew
+#[wire]
+enum CounterMsg {
+    Increment(i64);
+}
+
 actor Counter {
     var count: i64;
-    receive fn increment(n: i64) {
-        count = count + n;
+    receive fn handle(msg: CounterMsg) {
+        match msg {
+            CounterMsg::Increment(n) => {
+                count = count + n;
+            },
+        }
     }
     receive fn get_count() -> i64 {
         count
     }
+}
+
+impl ActorMsg for Counter {
+    type Msg = CounterMsg;
+    type Reply = ();
+}
+
+fn lookup_counter() -> Result<RemotePid<Counter>, LookupError> {
+    for attempt in 0 .. 40 {
+        let found: Result<RemotePid<Counter>, LookupError> = Node::lookup("counter");
+        match found {
+            Ok(counter) => return Ok(counter),
+            Err(error) => {
+                if attempt == 39 {
+                    return Err(error);
+                }
+                sleep(100ms);
+            },
+        }
+    }
+    Err(LookupError::NotFound)
 }
 
 fn main() {
@@ -29,15 +59,26 @@ fn main() {
     println("[client] connected (QUIC/TLS 1.3 encrypted)");
 
     // Look up the remote Counter actor via cross-node registry gossip.
-    let counter: Counter = Node::lookup("counter");
-    println("[client] found remote 'counter' actor via registry gossip");
-
-    // Send messages to the remote actor — same syntax as local.
-    counter.increment(10);
-    counter.increment(20);
-    counter.increment(30);
-    println("[client] sent 3 increments to remote counter");
-
+    let found = lookup_counter();
+    match found {
+        Err(_) => println("[client] remote 'counter' actor was not found"),
+        Ok(counter) => {
+            println("[client] found remote 'counter' actor via registry gossip");
+            match counter.send(CounterMsg::Increment(10)) {
+                Ok(_) => {},
+                Err(_) => println("[client] failed to send increment 10"),
+            }
+            match counter.send(CounterMsg::Increment(20)) {
+                Ok(_) => {},
+                Err(_) => println("[client] failed to send increment 20"),
+            }
+            match counter.send(CounterMsg::Increment(30)) {
+                Ok(_) => {},
+                Err(_) => println("[client] failed to send increment 30"),
+            }
+            println("[client] sent 3 increments to remote counter");
+        },
+    }
     // Allow messages to be delivered.
     sleep(500ms);
     Node::shutdown();

--- a/examples/quic_mesh/server.hew
+++ b/examples/quic_mesh/server.hew
@@ -7,15 +7,29 @@
 //
 // Run:  hew run examples/quic_mesh/server.hew
 // Then: hew run examples/quic_mesh/client.hew
+#[wire]
+enum CounterMsg {
+    Increment(i64);
+}
+
 actor Counter {
     var count: i64;
-    receive fn increment(n: i64) {
-        count = count + n;
-        println(f"[server] counter incremented by {n} → {count}");
+    receive fn handle(msg: CounterMsg) {
+        match msg {
+            CounterMsg::Increment(n) => {
+                count = count + n;
+                println(f"[server] counter incremented by {n} → {count}");
+            },
+        }
     }
     receive fn get_count() -> i64 {
         count
     }
+}
+
+impl ActorMsg for Counter {
+    type Msg = CounterMsg;
+    type Reply = ();
 }
 
 fn main() {

--- a/examples/services/circuit_breaker.hew
+++ b/examples/services/circuit_breaker.hew
@@ -60,7 +60,10 @@ actor CircuitBreaker {
             println(f"[breaker] OPEN — rejecting request {id}");
             -1
         } else {
-            let result = await backend.call(id);
+            let result = match await backend.call(id) {
+                Ok(value) => value,
+                Err(_) => -1,
+            };
             if result < 0 {
                 // Backend returned an error — count as failure
                 failure_count = failure_count + 1;
@@ -120,9 +123,15 @@ fn main() {
     // Breaker is now open — requests rejected immediately
     println("");
     println("--- Breaker is open (fast-fail) ---");
-    let rejected = await breaker.request(7);
+    let rejected = match await breaker.request(7) {
+        Ok(value) => value,
+        Err(_) => -3,
+    };
     println(f"Result while open: {rejected}");
-    let rejected2 = await breaker.request(8);
+    let rejected2 = match await breaker.request(8) {
+        Ok(value) => value,
+        Err(_) => -3,
+    };
     println(f"Result while open: {rejected2}");
 
     // ── Backend recovers ──
@@ -134,7 +143,10 @@ fn main() {
     // Trigger half-open probe, then send a request
     breaker.probe();
     sleep(20ms);
-    let probe_result = await breaker.request(9);
+    let probe_result = match await breaker.request(9) {
+        Ok(value) => value,
+        Err(_) => -3,
+    };
     println(f"Probe request result: {probe_result}");
 
     // Breaker should be closed again — normal operation resumes
@@ -142,7 +154,10 @@ fn main() {
     println("--- Back to normal ---");
     let _ = await breaker.request(10);
     let _ = await breaker.request(11);
-    let final_state = await breaker.get_state();
+    let final_state = match await breaker.get_state() {
+        Ok(value) => value,
+        Err(_) => -1,
+    };
     println(f"Final breaker state: {final_state} (0=Closed)");
     println("");
     println("Circuit breaker complete.");

--- a/examples/services/distributed_counter.hew
+++ b/examples/services/distributed_counter.hew
@@ -15,11 +15,9 @@
 // is an actor that merges state via message passing. No shared memory,
 // no locks, no data races — the actor model guarantees it.
 //
-// NOTE: The Node API (Node::start, Node::connect, Node::lookup) exists
-// in the runtime but codegen lowering is not yet wired. This example
-// runs all replicas in a single process. When the Node API lands, the
-// only change is adding Node::start/register/lookup calls — the actor
-// code stays identical.
+// This example runs all replicas in one process to focus on the replication
+// pattern. A multi-node version would add a #[wire] message envelope and an
+// ActorMsg implementation before using Node::start/register/lookup.
 
 // Coordinator — merges replica counts into a global total.
 actor Coordinator {
@@ -122,7 +120,10 @@ fn main() {
     sleep(30ms);
 
     // ── Read global total ──
-    let global = await coord.get_global();
+    let global = match await coord.get_global() {
+        Ok(value) => value,
+        Err(_) => -1,
+    };
     println(f"Global counter: {global}");
     // Expected: 5+3 + 10 + 7+2 = 27
 
@@ -138,7 +139,10 @@ fn main() {
     sleep(10ms);
     r3.sync_to_coordinator();
     sleep(30ms);
-    let global2 = await coord.get_global();
+    let global2 = match await coord.get_global() {
+        Ok(value) => value,
+        Err(_) => -1,
+    };
     println(f"Global counter after update: {global2}");
     // Expected: 108 + 210 + 9 = 327
 
@@ -153,6 +157,5 @@ fn main() {
     println(f"  node-1: {l1}, node-2: {l2}, node-3: {l3}");
     println("");
     println("Distributed counter complete.");
-    println("When Node API lands, add Node::start/connect/lookup —");
-    println("the actor code stays exactly the same.");
+    println("A multi-node version would expose this protocol through ActorMsg.");
 }

--- a/examples/services/health_monitor.hew
+++ b/examples/services/health_monitor.hew
@@ -20,10 +20,11 @@ actor Service {
     var requests: i64;
     receive fn health_check() -> i64 {
         if healthy == 0 {
-            panic("service unhealthy");
+            0
+        } else {
+            requests = requests + 1;
+            1
         }
-        requests = requests + 1;
-        1
     }
     receive fn handle(id: i64) -> i64 {
         requests = requests + 1;
@@ -54,14 +55,20 @@ actor HealthMonitor {
         check_count = check_count + 1;
         println(f"[monitor] --- health check #{check_count} ---");
         for i in 0 .. svc_refs.len() {
-            let svc = svc_refs.get(i);
+            let svc = match svc_refs.get(i) {
+                Some(value) => value,
+                None => panic("service registry is inconsistent"),
+            };
             // Use select with timeout — if the service doesn't respond
             // within 500ms, mark it unhealthy.
             let result = select {
                 r from svc.health_check() => r,
                 after 500ms => -1,
             };
-            let svc_name = svc_names.get(i);
+            let svc_name = match svc_names.get(i) {
+                Some(value) => value,
+                None => panic("service registry is inconsistent"),
+            };
             if result == 1 {
                 svc_status.set(i, 1);
                 println(f"  {svc_name}: HEALTHY");
@@ -77,8 +84,14 @@ actor HealthMonitor {
         var healthy_count = 0;
         let total = svc_names.len();
         for i in 0 .. total {
-            let name = svc_names.get(i);
-            let status = svc_status.get(i);
+            let name = match svc_names.get(i) {
+                Some(value) => value,
+                None => panic("service registry is inconsistent"),
+            };
+            let status = match svc_status.get(i) {
+                Some(value) => value,
+                None => panic("service registry is inconsistent"),
+            };
             if status == 1 {
                 println(f"  {name}: UP");
                 healthy_count = healthy_count + 1;
@@ -112,7 +125,7 @@ fn main() {
 
     // ── All healthy ──
     println("--- All services healthy ---");
-    await monitor.check_all();
+    monitor.check_all();
     sleep(30ms);
     let _ = await monitor.report();
     // ── Normal traffic ──
@@ -126,7 +139,7 @@ fn main() {
     println("--- Cache goes down ---");
     cache.set_unhealthy();
     sleep(30ms);
-    await monitor.check_all();
+    monitor.check_all();
     sleep(600ms);
     let _ = await monitor.report();
     // ── Remaining services still serve traffic ──

--- a/examples/ux/10_lambda_actor.hew
+++ b/examples/ux/10_lambda_actor.hew
@@ -3,8 +3,17 @@ fn main() {
     let worker = actor |msg: i64| {
         println(msg * 2);
     };
-    worker.send(5);
-    worker.send(10);
-    worker.send(15);
+    match worker.send(5) {
+        Ok(_) => {},
+        Err(_) => panic("failed to send 5"),
+    }
+    match worker.send(10) {
+        Ok(_) => {},
+        Err(_) => panic("failed to send 10"),
+    }
+    match worker.send(15) {
+        Ok(_) => {},
+        Err(_) => panic("failed to send 15"),
+    }
     await worker.close();
 }

--- a/scripts/hew-corpus-expected-failures.txt
+++ b/scripts/hew-corpus-expected-failures.txt
@@ -62,13 +62,9 @@ examples/net/probe_opaque_actor_state.hew
 # deferred-nyi: profiler NYI
 
 # deferred-nyi: QUIC / advanced net NYI
-examples/quic_mesh/client.hew
 examples/quic_mesh/selector_smoke.hew
 
 # deferred-nyi: advanced actor patterns NYI
-examples/services/circuit_breaker.hew
-examples/services/distributed_counter.hew
-examples/services/health_monitor.hew
 examples/test_actors_messaging.hew
 
 # deferred-nyi: v05 examples using NYI features

--- a/std/README.md
+++ b/std/README.md
@@ -52,12 +52,16 @@ Every shipped module under `std/` should appear here.
 | [`option`](option.hew) | `std::option` | Helper functions for common `Option<T>` patterns |
 | [`result`](result.hew) | `std::result` | Helper functions for common `Result<T, E>` patterns |
 | [`math`](math/math.hew) | `std::math` | Integer helpers, float ops, and common constants |
+| [`failure`](failure.hew) | `std::failure` | Crash-hook payloads and lifecycle failure actions |
+| [`mem`](mem/mem.hew) | `std::mem` | Compiler-internal allocation and typed-pointer intrinsics |
 
 ### Files, OS, and processes
 
 | Module | Import | Use for |
 | --- | --- | --- |
 | [`io`](io.hew) | `std::io` | stdin, stdout, and stderr helpers |
+| [`closable`](io/closable.hew) | `std::io::closable` | Explicit early release for IO and protocol handles |
+| [`scanner`](io/scanner.hew) | `std::io::scanner` | Line and word scanning over strings, stdin, and files |
 | [`fs`](fs.hew) | `std::fs` | File system operations |
 | [`path`](path.hew) | `std::path` | File path and glob utilities |
 | [`os`](os.hew) | `std::os` | Operating system interfaces |
@@ -75,12 +79,17 @@ Every shipped module under `std/` should appear here.
 | [`channel`](channel/channel.hew) | `std::channel::channel` | Bounded MPSC channels |
 | [`semaphore`](semaphore.hew) | `std::semaphore` | Counting semaphore for concurrency control |
 | [`concurrency`](concurrency/concurrency.hew) | `std::concurrency` | Structured concurrency support types such as `ScopeError<E>` |
+| [`lambda_actor`](concurrency/lambda_actor.hew) | `std::concurrency::lambda_actor` | Native lambda-actor handle declarations |
+| [`lifecycle`](concurrency/lifecycle.hew) | `std::concurrency::lifecycle` | Generic resource-service lifecycle state machine |
+| [`link_monitor`](link_monitor.hew) | `std::link_monitor` | Actor monitor handles and partition policies |
+| [`toggle`](machines/toggle.hew) | `std::machines::toggle` | Minimal reusable two-state machine |
 
 ### Encoding and wire formats
 
 | Module | Import | Use for |
 | --- | --- | --- |
 | [`base64`](encoding/base64/base64.hew) | `std::encoding::base64` | Base64 encoding and decoding |
+| [`binary`](encoding/binary/binary.hew) | `std::encoding::binary` | Fixed-width integer encoding in either byte order |
 | [`compress`](encoding/compress/compress.hew) | `std::encoding::compress` | Compression and decompression |
 | [`csv`](encoding/csv/csv.hew) | `std::encoding::csv` | CSV parsing |
 | [`hex`](encoding/hex/hex.hew) | `std::encoding::hex` | Hexadecimal encoding and decoding |
@@ -90,6 +99,7 @@ Every shipped module under `std/` should appear here.
 | [`protobuf`](encoding/protobuf/protobuf.hew) | `std::encoding::protobuf` | Protocol Buffers message construction |
 | [`toml`](encoding/toml/toml.hew) | `std::encoding::toml` | TOML parsing and generation |
 | [`wire`](encoding/wire/wire.hew) | `std::encoding::wire` | Hew wire format encoding and decoding |
+| [`value_trait`](encoding/wire/value_trait.hew) | `std::encoding::wire::value_trait` | Shared opaque-value contract for encoding modules |
 | [`xml`](encoding/xml/xml.hew) | `std::encoding::xml` | XML parsing and manipulation |
 | [`yaml`](encoding/yaml/yaml.hew) | `std::encoding::yaml` | YAML parsing and generation |
 
@@ -101,6 +111,7 @@ Every shipped module under `std/` should appear here.
 | [`encrypt`](crypto/encrypt/encrypt.hew) | `std::crypto::encrypt` | Symmetric encryption and decryption |
 | [`jwt`](crypto/jwt/jwt.hew) | `std::crypto::jwt` | JSON Web Token encoding and validation |
 | [`password`](crypto/password/password.hew) | `std::crypto::password` | Password hashing and verification |
+| [`sign`](crypto/sign/sign.hew) | `std::crypto::sign` | Ed25519 key generation, signing, and verification |
 
 ### Networking
 
@@ -109,6 +120,8 @@ Every shipped module under `std/` should appear here.
 | [`net`](net/net.hew) | `std::net` | TCP listeners and connections |
 | [`dns`](net/dns/dns.hew) | `std::net::dns` | DNS hostname resolution |
 | [`http`](net/http/http.hew) | `std::net::http` | HTTP server and request/response handling |
+| [`http_async_client`](net/http/http_async_client.hew) | `std::net::http::http_async_client` | Suspending HTTP/1.1 client codec for actor handlers |
+| [`http_async_server`](net/http/http_async_server.hew) | `std::net::http::http_async_server` | Suspending HTTP/1.1 server codec for actor handlers |
 | [`http_client`](net/http/http_client.hew) | `std::net::http::http_client` | Outbound HTTP request helpers (`request`, `request_string`, `get`, `post`) |
 | [`ipnet`](net/ipnet/ipnet.hew) | `std::net::ipnet` | IP address and CIDR utilities |
 | [`mime`](net/mime/mime.hew) | `std::net::mime` | MIME type detection |
@@ -124,10 +137,13 @@ Every shipped module under `std/` should appear here.
 | --- | --- | --- |
 | [`regex`](text/regex/regex.hew) | `std::text::regex` | Regular expression matching |
 | [`semver`](text/semver/semver.hew) | `std::text::semver` | Semantic version parsing and comparison |
+| [`template`](text/template/template.hew) | `std::text::template` | Go-style text template parsing and rendering |
+| [`unicode`](text/unicode/unicode.hew) | `std::text::unicode` | Unicode classification and UTF-8 codepoint helpers |
 | [`datetime`](time/datetime/datetime.hew) | `std::time::datetime` | Date and time operations |
 | [`cron`](time/cron/cron.hew) | `std::time::cron` | Cron expression parsing and scheduling |
 | [`log`](misc/log/log.hew) | `std::misc::log` | Structured logging |
 | [`uuid`](misc/uuid/uuid.hew) | `std::misc::uuid` | UUID generation and validation |
+| [`random`](random/random.hew) | `std::random` | Seedable random numbers, shuffling, and sampling |
 
 ### Testing and benchmarking
 
@@ -136,6 +152,7 @@ Every shipped module under `std/` should appear here.
 | [`testing`](testing/testing.hew) | `std::testing` | Assertion helpers for Hew tests |
 | [`bench`](bench/bench.hew) | `std::bench` | Benchmark harness for measuring function performance |
 | [`observe`](observe.hew) | `std::observe` | Runtime-owned observability reads, series discovery, and scrape text |
+| [`metrics`](metrics/metrics.hew) | `std::metrics` | Application counters, gauges, and histograms |
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- I updated the circuit-breaker, distributed-counter, health-monitor, and QUIC examples for current actor ask, collection, lookup, and remote-send APIs.
- I enabled the lambda-actor tutorials in the output gate and made their sends fail closed without changing expected output.
- I completed the canonical stdlib index and corrected the specification and language-guide text for shipped features and stdlib discovery.

## Verification

- `hew check` on all affected service and QUIC examples
- `hew run` on the circuit-breaker, distributed-counter, and health-monitor examples
- `make test-stdlib-ratchet`
- `make test-doc-examples`
- `make test-ux-examples`
- `make hew-check-all` (1,575 checked; 129 expected failures; 129 actual failures)
- stdlib index comparison (72 surfaces; 72 links; 0 missing; 0 extra)

## Out-of-scope

I did not change QUIC transport authentication or registry-gossip runtime behavior. The client and server now pass the supported compile-check path; a local two-process legacy-QUIC smoke did not discover the remote registry entry, so I am not claiming runtime end-to-end coverage here.