### PR TITLE
fix(types): bind package-local bare type refs to their own module identity (#2208)

### DIFF
--- a/hew-types/src/check/resolution.rs
+++ b/hew-types/src/check/resolution.rs
@@ -1638,7 +1638,32 @@ impl Checker {
                     return Ty::Error;
                 }
                 let resolved_name = if is_local && self.type_defs.contains_key(name) {
-                    name.clone()
+                    // A bare reference to a locally-defined type normally binds
+                    // to the bare `type_defs` key. But when checking a non-root
+                    // module, the bare key is last-write-wins across modules that
+                    // declare the same bare name (`pre_register_type_decl`
+                    // documents this: the qualified alias is the authority). If a
+                    // sibling module later overwrites the bare `Wrap` entry, a
+                    // bare local `Wrap` here would resolve to the WRONG module's
+                    // fields downstream (observable as `no field ... help: <other
+                    // module's field>` — #2208). Bind to this module's OWN
+                    // qualified identity (`{short}.{name}`) when it exists so the
+                    // local reference is immune to the cross-module bare-key
+                    // race, mirroring the `published_bare_type_qualified` branch
+                    // below. `pre_register_type_decl` always seeds the qualified
+                    // key alongside the bare one, so non-colliding locals resolve
+                    // identically to their own def.
+                    match self.current_module_short() {
+                        Some(short) => {
+                            let qualified = format!("{short}.{name}");
+                            if self.type_defs.contains_key(&qualified) {
+                                qualified
+                            } else {
+                                name.clone()
+                            }
+                        }
+                        None => name.clone(),
+                    }
                 } else if let Some(qualified) = self.published_bare_type_qualified(name) {
                     // Exactly one module published this bare name. Bind to that
                     // owner's QUALIFIED identity (`owner.Name`) so a sibling

--- a/hew-types/tests/registry_core/module_system_test.rs
+++ b/hew-types/tests/registry_core/module_system_test.rs
@@ -750,6 +750,116 @@ fn pub_struct_with_scalar_field(name: &str, field: &str, scalar: &str) -> TypeDe
     }
 }
 
+/// A `pub type Holder { <field>: <member> }` whose single field references the
+/// bare (unqualified) name `member`. Used to exercise member-position
+/// resolution of a bare name that collides across modules.
+fn pub_holder_with_named_field(name: &str, field: &str, member: &str) -> TypeDecl {
+    TypeDecl {
+        visibility: Visibility::Pub,
+        kind: TypeDeclKind::Struct,
+        name: name.to_string(),
+        type_params: None,
+        where_clause: None,
+        body: vec![TypeBodyItem::Field {
+            name: field.to_string(),
+            ty: (
+                TypeExpr::Named {
+                    name: member.to_string(),
+                    type_args: None,
+                },
+                0..0,
+            ),
+            attributes: vec![],
+            doc_comment: None,
+            span: 0..0,
+        }],
+        doc_comment: None,
+        wire: None,
+        is_indirect: false,
+        resource_marker: hew_parser::ast::ResourceMarker::None,
+        is_opaque: false,
+        consuming_methods: Vec::new(),
+    }
+}
+
+#[test]
+fn same_bare_name_member_field_binds_to_own_module_identity() {
+    // #2208: two package-local (non-root module-graph) modules each declare a
+    // bare `Wrap` with a DIVERGENT layout and a `Holder { w: Wrap }` whose field
+    // references the bare local name. The bare `type_defs["Wrap"]` key is
+    // last-write-wins across modules (documented in `pre_register_type_decl`),
+    // so a `Holder.w` field resolved to the BARE name `Wrap` silently binds to
+    // whichever module's `Wrap` was registered last (observable downstream as
+    // `no field ... help: <other module's field>` in a correctly-disambiguated
+    // program — the bug report's "unobservable" claim is false). The field type
+    // must instead carry each holder's OWN module-qualified `Wrap` identity.
+    //
+    // Load-bearing: on revert (member field resolves to bare `Wrap`) both
+    // holders' field types collapse to the same last-writer identity and the
+    // exact-string assertions below fail.
+    let root_id = ModuleId::new(vec!["myapp".to_string()]);
+
+    let mut graph = ModuleGraph::new(root_id.clone());
+    let root_mod = module_node("myapp", &[]);
+    let mut alpha_mod = module_node("alpha", &[]);
+    alpha_mod.items = vec![
+        (
+            Item::TypeDecl(pub_struct_with_scalar_field("Wrap", "a_field", "i64")),
+            0..0,
+        ),
+        (
+            Item::TypeDecl(pub_holder_with_named_field("Holder", "w", "Wrap")),
+            0..0,
+        ),
+    ];
+    let mut beta_mod = module_node("beta", &[]);
+    beta_mod.items = vec![
+        (
+            Item::TypeDecl(pub_struct_with_scalar_field("Wrap", "b_field", "i8")),
+            0..0,
+        ),
+        (
+            Item::TypeDecl(pub_holder_with_named_field("Holder", "w", "Wrap")),
+            0..0,
+        ),
+    ];
+
+    graph.add_module(root_mod).unwrap();
+    graph.add_module(alpha_mod).unwrap();
+    graph.add_module(beta_mod).unwrap();
+    graph.compute_topo_order().expect("no cycles");
+
+    let program = Program {
+        items: vec![],
+        module_doc: None,
+        module_graph: Some(graph),
+    };
+    let mut checker = isolated_checker();
+    let output = checker.check_program(&program);
+
+    let field_member = |holder_key: &str| -> String {
+        let holder = output
+            .type_defs
+            .get(holder_key)
+            .unwrap_or_else(|| panic!("{holder_key} must register its own qualified def"));
+        match holder.fields.get("w") {
+            Some(Ty::Named { name, .. }) => name.clone(),
+            other => panic!("{holder_key}.w must be a Ty::Named, got {other:?}"),
+        }
+    };
+
+    assert_eq!(
+        field_member("alpha.Holder"),
+        "alpha.Wrap",
+        "alpha.Holder.w must bind to alpha's own Wrap, not the last-writer bare key"
+    );
+    assert_eq!(
+        field_member("beta.Holder"),
+        "beta.Wrap",
+        "beta.Holder.w must bind to beta's own Wrap, not the last-writer bare key"
+    );
+}
+
 #[test]
 fn same_bare_name_types_register_independent_divergent_field_layouts() {
     // C1 authority: two co-imported modules each export a `Widget` with a


### PR DESCRIPTION
## Summary

Fixes #2208. A bare type reference inside a **non-root module** — e.g. a `Holder { w: Wrap }` field whose `Wrap` is declared in the same package-local module — resolved through the `is_local` arm of `resolve_type_expr` to the **bare** `type_defs` key. That key is last-write-wins across modules that declare the same bare name (`pre_register_type_decl` documents the qualified alias as the authority), so when a sibling module declares its own `Wrap`, the field silently binds to whichever module registered `Wrap` last.

## Observability (correcting the issue note)

The issue notes this as "unobservable in correctly-disambiguated programs." It is in fact observable. Two package-local modules, each with a divergent `Wrap` and a `Holder { w: Wrap }`, mis-resolve one holder's field to the *other* module's layout:

```
error: no field `a_field` on type `Wrap`
  = help: b_field
```

…and the winner flips with import order (a program that reads `a.w.a_field` / `b.w.b_field` compiles or fails purely by which module's `Wrap` was registered last).

## Fix

In the `is_local` arm, bind to the current module's **own** qualified identity (`{short}.{name}`) when that key exists — mirroring the sibling `published_bare_type_qualified` branch that already qualifies specifically to dodge this bare-key collapse. `pre_register_type_decl` always seeds the qualified key alongside the bare one, so:

- non-colliding locals resolve identically to before,
- root-module references (`current_module_short() == None`) are untouched,
- only the cross-module collision case changes — from wrong-module to own-module.

## Boundary / neighbours checked

- Root program (`current_module == None`): unchanged, still binds bare.
- Single-module local reference: unchanged (qualified key == own def).
- The `published_bare_type_qualified` and `handle_matches` arms below are untouched.

## Tests

New load-bearing regression `same_bare_name_member_field_binds_to_own_module_identity` asserts each holder's `w` field carries its **own** module's `Wrap` identity (`alpha.Wrap` / `beta.Wrap`). It **fails on revert** (both collapse to the single last-writer identity), verified locally.

- hew-types: 1665 lib + all integration suites green (registry_core 281→282).
- hew-hir: full suite green (field identity flows into HIR/MIR).
- `cargo fmt` + `cargo clippy --tests`: clean.
- e2e: the two-module repro (both import orders) now prints `42` / `hello` and exits 0.