### PR TITLE
fix(std/net): make transport APIs fail closed

### DIFF
--- a/examples/v05/checked-mir/golden/channel_auto_close_scope.elab.mir
+++ b/examples/v05/checked-mir/golden/channel_auto_close_scope.elab.mir
@@ -117,35 +117,125 @@ fn Receiver::close -> ()
 
 fn channel$new -> (Sender, Receiver)
   statements:
-    use BindingId(12) capacity site=SiteId(49) ty=i64 intent=Read
-    bind BindingId(13) pair site=SiteId(47) ty=ChannelPair
-    use BindingId(13) pair site=SiteId(52) ty=ChannelPair intent=Read
-    bind BindingId(14) tx site=SiteId(51) ty=Sender
-    use BindingId(13) pair site=SiteId(55) ty=ChannelPair intent=Read
-    bind BindingId(15) rx site=SiteId(54) ty=Receiver
-    use BindingId(13) pair site=SiteId(58) ty=ChannelPair intent=Read
-    eval site=SiteId(57) ty=()
-    use BindingId(14) tx site=SiteId(61) ty=Sender intent=Read
-    use BindingId(15) rx site=SiteId(62) ty=Receiver intent=Read
+    use BindingId(12) capacity site=SiteId(48) ty=i64 intent=Read
+    bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(47) ty=Result<(Sender, Receiver), string>
     return site=Some(SiteId(46)) ty=(Sender, Receiver)
+    bind BindingId(13) pair site=SiteId(50) ty=(Sender, Receiver)
+    use BindingId(13) pair site=SiteId(50) ty=(Sender, Receiver) intent=Read
+    bind BindingId(14) err site=SiteId(51) ty=string
+    use BindingId(14) err site=SiteId(52) ty=string intent=Read
+    drop BindingId(14) err ty=string
+    drop BindingId(13) pair ty=(Sender, Receiver)
+    drop BindingId(4294967231) __hew_call_scrutinee ty=Result<(Sender, Receiver), string>
   drop_plans:
-    call[bb0 hew_channel_new -> bb1] ->
+    call[bb0 channel$try_new -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    call[bb1 hew_channel_pair_sender -> bb2] ->
+    branch[bb1: bb3/bb6] ->
       (none)
-    call[bb2 hew_channel_pair_receiver -> bb3] ->
+    return[bb2] ->
       (none)
-    call[bb3 hew_channel_pair_free -> bb4] ->
+    goto[bb3->bb2] ->
       (none)
-    return[bb4] ->
+    cancel[bb3] ->
+      (none)
+    call[bb4 panic -> bb7] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    branch[bb6: bb4/bb5] ->
+      (none)
+    goto[bb7->bb2] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+
+fn channel$try_new -> Result<(Sender, Receiver), string>
+  statements:
+    use BindingId(15) capacity site=SiteId(55) ty=i64 intent=Read
+    use BindingId(15) capacity site=SiteId(60) ty=i64 intent=Read
+    eval site=SiteId(69) ty=()
+    use BindingId(15) capacity site=SiteId(73) ty=i64 intent=Read
+    return site=Some(SiteId(57)) ty=Result<(Sender, Receiver), string>
+    bind BindingId(16) pair site=SiteId(71) ty=ChannelPair
+    use BindingId(16) pair site=SiteId(77) ty=ChannelPair intent=Read
+    eval site=SiteId(91) ty=()
+    use BindingId(16) pair site=SiteId(93) ty=ChannelPair intent=Read
+    bind BindingId(17) detail site=SiteId(79) ty=string
+    use BindingId(17) detail site=SiteId(82) ty=string intent=Read
+    return site=Some(SiteId(84)) ty=Result<(Sender, Receiver), string>
+    eval site=SiteId(87) ty=()
+    use BindingId(17) detail site=SiteId(89) ty=string intent=Read
+    agg_alias BindingId(17) detail site=SiteId(89) ty=string
+    return site=Some(SiteId(88)) ty=Result<(Sender, Receiver), string>
+    bind BindingId(18) tx site=SiteId(92) ty=Sender
+    use BindingId(16) pair site=SiteId(96) ty=ChannelPair intent=Read
+    bind BindingId(19) rx site=SiteId(95) ty=Receiver
+    use BindingId(16) pair site=SiteId(99) ty=ChannelPair intent=Read
+    eval site=SiteId(98) ty=()
+    use BindingId(18) tx site=SiteId(103) ty=Sender intent=Read
+    use BindingId(19) rx site=SiteId(104) ty=Receiver intent=Read
+    return site=Some(SiteId(70)) ty=Result<(Sender, Receiver), string>
+    drop BindingId(17) detail ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    call[bb3 hew_channel_new -> bb8] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    return[bb6] ->
+      (none)
+    goto[bb7->bb3] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+    call[bb8 hew_channel_pair_is_valid -> bb9] ->
+      (none)
+    branch[bb9: bb10/bb11] ->
+      (none)
+    call[bb10 hew_stream_last_error -> bb13] ->
+      (none)
+    goto[bb11->bb12] ->
+      (none)
+    call[bb12 hew_channel_pair_sender -> bb19] ->
+      (none)
+    branch[bb13: bb14/bb15] ->
+      (none)
+    return[bb14] ->
+      (none)
+    goto[bb15->bb16] ->
+      (none)
+    return[bb16] ->
+      (none)
+    goto[bb17->bb16] ->
+      (none)
+    cancel[bb17] ->
+      (none)
+    goto[bb18->bb12] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    call[bb19 hew_channel_pair_receiver -> bb20] ->
+      (none)
+    call[bb20 hew_channel_pair_free -> bb21] ->
+      (none)
+    return[bb21] ->
       (none)
 
 fn i8::fmt -> string
   statements:
-    use BindingId(24) val site=SiteId(133) ty=i8 intent=Read
-    return site=Some(SiteId(131)) ty=string
+    use BindingId(28) val site=SiteId(175) ty=i8 intent=Read
+    return site=Some(SiteId(173)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -156,8 +246,8 @@ fn i8::fmt -> string
 
 fn i16::fmt -> string
   statements:
-    use BindingId(25) val site=SiteId(137) ty=i16 intent=Read
-    return site=Some(SiteId(135)) ty=string
+    use BindingId(29) val site=SiteId(179) ty=i16 intent=Read
+    return site=Some(SiteId(177)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -168,8 +258,8 @@ fn i16::fmt -> string
 
 fn i32::fmt -> string
   statements:
-    use BindingId(26) val site=SiteId(140) ty=i32 intent=Read
-    return site=Some(SiteId(139)) ty=string
+    use BindingId(30) val site=SiteId(182) ty=i32 intent=Read
+    return site=Some(SiteId(181)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -180,8 +270,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(27) val site=SiteId(143) ty=i64 intent=Read
-    return site=Some(SiteId(142)) ty=string
+    use BindingId(31) val site=SiteId(185) ty=i64 intent=Read
+    return site=Some(SiteId(184)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -192,8 +282,8 @@ fn i64::fmt -> string
 
 fn u8::fmt -> string
   statements:
-    use BindingId(28) val site=SiteId(146) ty=u8 intent=Read
-    return site=Some(SiteId(145)) ty=string
+    use BindingId(32) val site=SiteId(188) ty=u8 intent=Read
+    return site=Some(SiteId(187)) ty=string
   drop_plans:
     call[bb0 to_string_u8 -> bb1] ->
       (none)
@@ -204,8 +294,8 @@ fn u8::fmt -> string
 
 fn u16::fmt -> string
   statements:
-    use BindingId(29) val site=SiteId(149) ty=u16 intent=Read
-    return site=Some(SiteId(148)) ty=string
+    use BindingId(33) val site=SiteId(191) ty=u16 intent=Read
+    return site=Some(SiteId(190)) ty=string
   drop_plans:
     call[bb0 to_string_u16 -> bb1] ->
       (none)
@@ -216,8 +306,8 @@ fn u16::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(30) val site=SiteId(152) ty=u32 intent=Read
-    return site=Some(SiteId(151)) ty=string
+    use BindingId(34) val site=SiteId(194) ty=u32 intent=Read
+    return site=Some(SiteId(193)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -228,8 +318,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(31) val site=SiteId(155) ty=u64 intent=Read
-    return site=Some(SiteId(154)) ty=string
+    use BindingId(35) val site=SiteId(197) ty=u64 intent=Read
+    return site=Some(SiteId(196)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -240,8 +330,8 @@ fn u64::fmt -> string
 
 fn isize::fmt -> string
   statements:
-    use BindingId(32) val site=SiteId(159) ty=isize intent=Read
-    return site=Some(SiteId(157)) ty=string
+    use BindingId(36) val site=SiteId(201) ty=isize intent=Read
+    return site=Some(SiteId(199)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -252,8 +342,8 @@ fn isize::fmt -> string
 
 fn usize::fmt -> string
   statements:
-    use BindingId(33) val site=SiteId(163) ty=usize intent=Read
-    return site=Some(SiteId(161)) ty=string
+    use BindingId(37) val site=SiteId(205) ty=usize intent=Read
+    return site=Some(SiteId(203)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -264,8 +354,8 @@ fn usize::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(34) val site=SiteId(166) ty=bool intent=Read
-    return site=Some(SiteId(165)) ty=string
+    use BindingId(38) val site=SiteId(208) ty=bool intent=Read
+    return site=Some(SiteId(207)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -276,8 +366,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(35) val site=SiteId(169) ty=char intent=Read
-    return site=Some(SiteId(168)) ty=string
+    use BindingId(39) val site=SiteId(211) ty=char intent=Read
+    return site=Some(SiteId(210)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -288,8 +378,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(36) val site=SiteId(172) ty=f64 intent=Read
-    return site=Some(SiteId(171)) ty=string
+    use BindingId(40) val site=SiteId(214) ty=f64 intent=Read
+    return site=Some(SiteId(213)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -300,8 +390,8 @@ fn f64::fmt -> string
 
 fn f32::fmt -> string
   statements:
-    use BindingId(37) val site=SiteId(176) ty=f32 intent=Read
-    return site=Some(SiteId(174)) ty=string
+    use BindingId(41) val site=SiteId(218) ty=f32 intent=Read
+    return site=Some(SiteId(216)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -312,16 +402,16 @@ fn f32::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(38) val site=SiteId(178) ty=string intent=Read
-    return site=Some(SiteId(178)) ty=string
+    use BindingId(42) val site=SiteId(220) ty=string intent=Read
+    return site=Some(SiteId(220)) ty=string
   drop_plans:
     return[bb0] ->
       (none)
 
 fn duration::from_nanos -> duration
   statements:
-    use BindingId(39) n site=SiteId(180) ty=i64 intent=Read
-    return site=Some(SiteId(179)) ty=duration
+    use BindingId(43) n site=SiteId(222) ty=i64 intent=Read
+    return site=Some(SiteId(221)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -332,8 +422,8 @@ fn duration::from_nanos -> duration
 
 fn duration::from_micros -> duration
   statements:
-    use BindingId(40) n site=SiteId(183) ty=i64 intent=Read
-    return site=Some(SiteId(182)) ty=duration
+    use BindingId(44) n site=SiteId(225) ty=i64 intent=Read
+    return site=Some(SiteId(224)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -344,8 +434,8 @@ fn duration::from_micros -> duration
 
 fn duration::from_millis -> duration
   statements:
-    use BindingId(41) n site=SiteId(186) ty=i64 intent=Read
-    return site=Some(SiteId(185)) ty=duration
+    use BindingId(45) n site=SiteId(228) ty=i64 intent=Read
+    return site=Some(SiteId(227)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -356,8 +446,8 @@ fn duration::from_millis -> duration
 
 fn duration::from_secs -> duration
   statements:
-    use BindingId(42) n site=SiteId(189) ty=i64 intent=Read
-    return site=Some(SiteId(188)) ty=duration
+    use BindingId(46) n site=SiteId(231) ty=i64 intent=Read
+    return site=Some(SiteId(230)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -368,8 +458,8 @@ fn duration::from_secs -> duration
 
 fn duration::fmt -> string
   statements:
-    use BindingId(43) val site=SiteId(194) ty=duration intent=Read
-    return site=Some(SiteId(191)) ty=string
+    use BindingId(47) val site=SiteId(236) ty=duration intent=Read
+    return site=Some(SiteId(233)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)

--- a/examples/v05/checked-mir/golden/channel_auto_close_scope.raw.mir
+++ b/examples/v05/checked-mir/golden/channel_auto_close_scope.raw.mir
@@ -144,42 +144,185 @@ fn Receiver::close(Receiver) -> () [conv=default]
 fn channel$new(i64) -> (Sender, Receiver) [conv=default]
   locals:
     _0: i64
-    _1: i64
-    _2: ChannelPair
-    _3: ChannelPair
-    _4: Sender
-    _5: Sender
-    _6: Receiver
-    _7: Receiver
+    _1: (Sender, Receiver)
+    _2: Result<(Sender, Receiver), string>
+    _3: i64
+    _4: i64
+    _5: bool
+    _6: i64
+    _7: bool
     _8: (Sender, Receiver)
-    _9: (Sender, Receiver)
+    _9: string
   bb0:
-    stmt: use BindingId(12) capacity site=SiteId(49) ty=i64 intent=Read
-    _1 = cast _0 i64 -> i64
-    _2 = call hew_channel_new(_1) -> bb1
+    stmt: use BindingId(12) capacity site=SiteId(48) ty=i64 intent=Read
+    _2 = call channel$try_new(_0) -> bb1
   bb1:
-    stmt: bind BindingId(13) pair site=SiteId(47) ty=ChannelPair
-    stmt: use BindingId(13) pair site=SiteId(52) ty=ChannelPair intent=Read
-    _3 = move _2
-    _4 = call hew_channel_pair_sender(_3) -> bb2
+    stmt: bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(47) ty=Result<(Sender, Receiver), string>
+    _3 = move etag2
+    _4 = const.i64 0
+    _5 = icmp.eq _3 _4
+    branch _5 ? bb3 : bb6
   bb2:
-    stmt: bind BindingId(14) tx site=SiteId(51) ty=Sender
-    stmt: use BindingId(13) pair site=SiteId(55) ty=ChannelPair intent=Read
-    _5 = move _4
-    _6 = call hew_channel_pair_receiver(_3) -> bb3
-  bb3:
-    stmt: bind BindingId(15) rx site=SiteId(54) ty=Receiver
-    stmt: use BindingId(13) pair site=SiteId(58) ty=ChannelPair intent=Read
-    _7 = move _6
-    call hew_channel_pair_free(_3) -> bb4
-  bb4:
-    stmt: eval site=SiteId(57) ty=()
-    stmt: use BindingId(14) tx site=SiteId(61) ty=Sender intent=Read
-    stmt: use BindingId(15) rx site=SiteId(62) ty=Receiver intent=Read
     stmt: return site=Some(SiteId(46)) ty=(Sender, Receiver)
-    _8 = tuple (_5, _7)
-    _9 = move _8
-    ret = move _9
+    ret = move _1
+    return
+  bb3:
+    stmt: bind BindingId(13) pair site=SiteId(50) ty=(Sender, Receiver)
+    stmt: use BindingId(13) pair site=SiteId(50) ty=(Sender, Receiver) intent=Read
+    _8 = move mvar2.0.0
+    _1 = move _8
+    goto bb2
+  bb4:
+    stmt: bind BindingId(14) err site=SiteId(51) ty=string
+    stmt: use BindingId(14) err site=SiteId(52) ty=string intent=Read
+    _9 = move mvar2.1.0
+    call panic(_9) -> bb7
+  bb5:
+    trap(ExhaustivenessFallthrough)
+  bb6:
+    _6 = const.i64 1
+    _7 = icmp.eq _3 _6
+    branch _7 ? bb4 : bb5
+  bb7:
+    goto bb2
+
+fn channel$try_new(i64) -> Result<(Sender, Receiver), string> [conv=default]
+  locals:
+    _0: i64
+    _1: ()
+    _2: i64
+    _3: bool
+    _4: Result<(Sender, Receiver), string>
+    _5: i64
+    _6: string
+    _7: string
+    _8: string
+    _9: string
+    _10: string
+    _11: i64
+    _12: ChannelPair
+    _13: ChannelPair
+    _14: ()
+    _15: bool
+    _16: bool
+    _17: string
+    _18: string
+    _19: ()
+    _20: string
+    _21: bool
+    _22: Result<(Sender, Receiver), string>
+    _23: i64
+    _24: string
+    _25: Result<(Sender, Receiver), string>
+    _26: i64
+    _27: Sender
+    _28: Sender
+    _29: Receiver
+    _30: Receiver
+    _31: Result<(Sender, Receiver), string>
+    _32: i64
+    _33: (Sender, Receiver)
+    _34: Result<(Sender, Receiver), string>
+  bb0:
+    stmt: use BindingId(15) capacity site=SiteId(55) ty=i64 intent=Read
+    _2 = const.i64 0
+    _3 = icmp.slt _0 _2
+    branch _3 ? bb1 : bb2
+  bb1:
+    stmt: use BindingId(15) capacity site=SiteId(60) ty=i64 intent=Read
+    _5 = const.i64 1
+    mtag4 = move _5
+    _6 = string_lit "channel.new: invalid capacity "
+    _7 = call to_string_i64(_0) -> bb4
+  bb2:
+    goto bb3
+  bb3:
+    stmt: eval site=SiteId(69) ty=()
+    stmt: use BindingId(15) capacity site=SiteId(73) ty=i64 intent=Read
+    _11 = cast _0 i64 -> i64
+    _12 = call hew_channel_new(_11) -> bb8
+  bb4:
+    _8 = call string_concat(_6, _7) -> bb5
+  bb5:
+    drop _7 ty=string fn=release(hew_string_drop)
+    _9 = string_lit " (must be >= 0)"
+    _10 = call string_concat(_8, _9) -> bb6
+  bb6:
+    stmt: return site=Some(SiteId(57)) ty=Result<(Sender, Receiver), string>
+    drop _8 ty=string fn=release(hew_string_drop)
+    mvar4.1.0 = move _10
+    ret = move _4
+    return
+  bb7:
+    goto bb3
+  bb8:
+    stmt: bind BindingId(16) pair site=SiteId(71) ty=ChannelPair
+    stmt: use BindingId(16) pair site=SiteId(77) ty=ChannelPair intent=Read
+    _13 = move _12
+    _15 = call hew_channel_pair_is_valid(_13) -> bb9
+  bb9:
+    _16 = not _15
+    branch _16 ? bb10 : bb11
+  bb10:
+    _17 = call hew_stream_last_error() -> bb13
+  bb11:
+    goto bb12
+  bb12:
+    stmt: eval site=SiteId(91) ty=()
+    stmt: use BindingId(16) pair site=SiteId(93) ty=ChannelPair intent=Read
+    _27 = call hew_channel_pair_sender(_13) -> bb19
+  bb13:
+    stmt: bind BindingId(17) detail site=SiteId(79) ty=string
+    stmt: use BindingId(17) detail site=SiteId(82) ty=string intent=Read
+    _18 = move _17
+    _20 = string_lit ""
+    _21 = icmp.eq _18 _20
+    branch _21 ? bb14 : bb15
+  bb14:
+    stmt: return site=Some(SiteId(84)) ty=Result<(Sender, Receiver), string>
+    _23 = const.i64 1
+    mtag22 = move _23
+    _24 = string_lit "channel.new: channel allocation failed"
+    mvar22.1.0 = move _24
+    ret = move _22
+    return
+  bb15:
+    goto bb16
+  bb16:
+    stmt: eval site=SiteId(87) ty=()
+    stmt: use BindingId(17) detail site=SiteId(89) ty=string intent=Read
+    stmt: agg_alias BindingId(17) detail site=SiteId(89) ty=string
+    stmt: return site=Some(SiteId(88)) ty=Result<(Sender, Receiver), string>
+    _26 = const.i64 1
+    mtag25 = move _26
+    mvar25.1.0 = move _18
+    ret = move _25
+    return
+  bb17:
+    goto bb16
+  bb18:
+    goto bb12
+  bb19:
+    stmt: bind BindingId(18) tx site=SiteId(92) ty=Sender
+    stmt: use BindingId(16) pair site=SiteId(96) ty=ChannelPair intent=Read
+    _28 = move _27
+    _29 = call hew_channel_pair_receiver(_13) -> bb20
+  bb20:
+    stmt: bind BindingId(19) rx site=SiteId(95) ty=Receiver
+    stmt: use BindingId(16) pair site=SiteId(99) ty=ChannelPair intent=Read
+    _30 = move _29
+    call hew_channel_pair_free(_13) -> bb21
+  bb21:
+    stmt: eval site=SiteId(98) ty=()
+    stmt: use BindingId(18) tx site=SiteId(103) ty=Sender intent=Read
+    stmt: use BindingId(19) rx site=SiteId(104) ty=Receiver intent=Read
+    stmt: return site=Some(SiteId(70)) ty=Result<(Sender, Receiver), string>
+    _32 = const.i64 0
+    mtag31 = move _32
+    _33 = tuple (_28, _30)
+    mvar31.0.0 = move _33
+    _34 = move _31
+    ret = move _34
     return
 
 fn i8::fmt(i8) -> string [conv=default]
@@ -188,11 +331,11 @@ fn i8::fmt(i8) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(24) val site=SiteId(133) ty=i8 intent=Read
+    stmt: use BindingId(28) val site=SiteId(175) ty=i8 intent=Read
     _1 = cast _0 i8 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(131)) ty=string
+    stmt: return site=Some(SiteId(173)) ty=string
     ret = move _2
     return
 
@@ -202,11 +345,11 @@ fn i16::fmt(i16) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(25) val site=SiteId(137) ty=i16 intent=Read
+    stmt: use BindingId(29) val site=SiteId(179) ty=i16 intent=Read
     _1 = cast _0 i16 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(135)) ty=string
+    stmt: return site=Some(SiteId(177)) ty=string
     ret = move _2
     return
 
@@ -215,10 +358,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(26) val site=SiteId(140) ty=i32 intent=Read
+    stmt: use BindingId(30) val site=SiteId(182) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(139)) ty=string
+    stmt: return site=Some(SiteId(181)) ty=string
     ret = move _1
     return
 
@@ -227,10 +370,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(27) val site=SiteId(143) ty=i64 intent=Read
+    stmt: use BindingId(31) val site=SiteId(185) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(142)) ty=string
+    stmt: return site=Some(SiteId(184)) ty=string
     ret = move _1
     return
 
@@ -239,10 +382,10 @@ fn u8::fmt(u8) -> string [conv=default]
     _0: u8
     _1: string
   bb0:
-    stmt: use BindingId(28) val site=SiteId(146) ty=u8 intent=Read
+    stmt: use BindingId(32) val site=SiteId(188) ty=u8 intent=Read
     _1 = call to_string_u8(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(145)) ty=string
+    stmt: return site=Some(SiteId(187)) ty=string
     ret = move _1
     return
 
@@ -251,10 +394,10 @@ fn u16::fmt(u16) -> string [conv=default]
     _0: u16
     _1: string
   bb0:
-    stmt: use BindingId(29) val site=SiteId(149) ty=u16 intent=Read
+    stmt: use BindingId(33) val site=SiteId(191) ty=u16 intent=Read
     _1 = call to_string_u16(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(148)) ty=string
+    stmt: return site=Some(SiteId(190)) ty=string
     ret = move _1
     return
 
@@ -263,10 +406,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(30) val site=SiteId(152) ty=u32 intent=Read
+    stmt: use BindingId(34) val site=SiteId(194) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(151)) ty=string
+    stmt: return site=Some(SiteId(193)) ty=string
     ret = move _1
     return
 
@@ -275,10 +418,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(31) val site=SiteId(155) ty=u64 intent=Read
+    stmt: use BindingId(35) val site=SiteId(197) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(154)) ty=string
+    stmt: return site=Some(SiteId(196)) ty=string
     ret = move _1
     return
 
@@ -288,11 +431,11 @@ fn isize::fmt(isize) -> string [conv=default]
     _1: i64
     _2: string
   bb0:
-    stmt: use BindingId(32) val site=SiteId(159) ty=isize intent=Read
+    stmt: use BindingId(36) val site=SiteId(201) ty=isize intent=Read
     _1 = cast _0 isize -> i64
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(157)) ty=string
+    stmt: return site=Some(SiteId(199)) ty=string
     ret = move _2
     return
 
@@ -302,11 +445,11 @@ fn usize::fmt(usize) -> string [conv=default]
     _1: u64
     _2: string
   bb0:
-    stmt: use BindingId(33) val site=SiteId(163) ty=usize intent=Read
+    stmt: use BindingId(37) val site=SiteId(205) ty=usize intent=Read
     _1 = cast _0 usize -> u64
     _2 = call to_string_u64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(161)) ty=string
+    stmt: return site=Some(SiteId(203)) ty=string
     ret = move _2
     return
 
@@ -315,10 +458,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(34) val site=SiteId(166) ty=bool intent=Read
+    stmt: use BindingId(38) val site=SiteId(208) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(165)) ty=string
+    stmt: return site=Some(SiteId(207)) ty=string
     ret = move _1
     return
 
@@ -327,10 +470,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(35) val site=SiteId(169) ty=char intent=Read
+    stmt: use BindingId(39) val site=SiteId(211) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(168)) ty=string
+    stmt: return site=Some(SiteId(210)) ty=string
     ret = move _1
     return
 
@@ -339,10 +482,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(36) val site=SiteId(172) ty=f64 intent=Read
+    stmt: use BindingId(40) val site=SiteId(214) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(171)) ty=string
+    stmt: return site=Some(SiteId(213)) ty=string
     ret = move _1
     return
 
@@ -352,11 +495,11 @@ fn f32::fmt(f32) -> string [conv=default]
     _1: f64
     _2: string
   bb0:
-    stmt: use BindingId(37) val site=SiteId(176) ty=f32 intent=Read
+    stmt: use BindingId(41) val site=SiteId(218) ty=f32 intent=Read
     _1 = cast _0 f32 -> f64
     _2 = call to_string_f64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(174)) ty=string
+    stmt: return site=Some(SiteId(216)) ty=string
     ret = move _2
     return
 
@@ -364,8 +507,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(38) val site=SiteId(178) ty=string intent=Read
-    stmt: return site=Some(SiteId(178)) ty=string
+    stmt: use BindingId(42) val site=SiteId(220) ty=string intent=Read
+    stmt: return site=Some(SiteId(220)) ty=string
     ret = move _0
     return
 
@@ -376,14 +519,14 @@ fn duration::from_nanos(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(39) n site=SiteId(180) ty=i64 intent=Read
+    stmt: use BindingId(43) n site=SiteId(222) ty=i64 intent=Read
     _1 = const.duration 1ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(179)) ty=duration
+    stmt: return site=Some(SiteId(221)) ty=duration
     ret = move _2
     return
 
@@ -394,14 +537,14 @@ fn duration::from_micros(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(40) n site=SiteId(183) ty=i64 intent=Read
+    stmt: use BindingId(44) n site=SiteId(225) ty=i64 intent=Read
     _1 = const.duration 1000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(182)) ty=duration
+    stmt: return site=Some(SiteId(224)) ty=duration
     ret = move _2
     return
 
@@ -412,14 +555,14 @@ fn duration::from_millis(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(41) n site=SiteId(186) ty=i64 intent=Read
+    stmt: use BindingId(45) n site=SiteId(228) ty=i64 intent=Read
     _1 = const.duration 1000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(185)) ty=duration
+    stmt: return site=Some(SiteId(227)) ty=duration
     ret = move _2
     return
 
@@ -430,14 +573,14 @@ fn duration::from_secs(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(42) n site=SiteId(189) ty=i64 intent=Read
+    stmt: use BindingId(46) n site=SiteId(231) ty=i64 intent=Read
     _1 = const.duration 1000000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(188)) ty=duration
+    stmt: return site=Some(SiteId(230)) ty=duration
     ret = move _2
     return
 
@@ -449,11 +592,11 @@ fn duration::fmt(duration) -> string [conv=default]
     _3: string
     _4: string
   bb0:
-    stmt: use BindingId(43) val site=SiteId(194) ty=duration intent=Read
+    stmt: use BindingId(47) val site=SiteId(236) ty=duration intent=Read
     _1 = call_rt hew_duration_nanos(_0)
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(191)) ty=string
+    stmt: return site=Some(SiteId(233)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
     drop _2 ty=string fn=release(hew_string_drop)

--- a/examples/v05/checked-mir/golden/channel_recv_select.elab.mir
+++ b/examples/v05/checked-mir/golden/channel_recv_select.elab.mir
@@ -201,35 +201,125 @@ fn Receiver::close -> ()
 
 fn channel$new -> (Sender, Receiver)
   statements:
-    use BindingId(17) capacity site=SiteId(88) ty=i64 intent=Read
-    bind BindingId(18) pair site=SiteId(86) ty=ChannelPair
-    use BindingId(18) pair site=SiteId(91) ty=ChannelPair intent=Read
-    bind BindingId(19) tx site=SiteId(90) ty=Sender
-    use BindingId(18) pair site=SiteId(94) ty=ChannelPair intent=Read
-    bind BindingId(20) rx site=SiteId(93) ty=Receiver
-    use BindingId(18) pair site=SiteId(97) ty=ChannelPair intent=Read
-    eval site=SiteId(96) ty=()
-    use BindingId(19) tx site=SiteId(100) ty=Sender intent=Read
-    use BindingId(20) rx site=SiteId(101) ty=Receiver intent=Read
+    use BindingId(17) capacity site=SiteId(87) ty=i64 intent=Read
+    bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(86) ty=Result<(Sender, Receiver), string>
     return site=Some(SiteId(85)) ty=(Sender, Receiver)
+    bind BindingId(18) pair site=SiteId(89) ty=(Sender, Receiver)
+    use BindingId(18) pair site=SiteId(89) ty=(Sender, Receiver) intent=Read
+    bind BindingId(19) err site=SiteId(90) ty=string
+    use BindingId(19) err site=SiteId(91) ty=string intent=Read
+    drop BindingId(19) err ty=string
+    drop BindingId(18) pair ty=(Sender, Receiver)
+    drop BindingId(4294967231) __hew_call_scrutinee ty=Result<(Sender, Receiver), string>
   drop_plans:
-    call[bb0 hew_channel_new -> bb1] ->
+    call[bb0 channel$try_new -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    call[bb1 hew_channel_pair_sender -> bb2] ->
+    branch[bb1: bb3/bb6] ->
       (none)
-    call[bb2 hew_channel_pair_receiver -> bb3] ->
+    return[bb2] ->
       (none)
-    call[bb3 hew_channel_pair_free -> bb4] ->
+    goto[bb3->bb2] ->
       (none)
-    return[bb4] ->
+    cancel[bb3] ->
+      (none)
+    call[bb4 panic -> bb7] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    branch[bb6: bb4/bb5] ->
+      (none)
+    goto[bb7->bb2] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+
+fn channel$try_new -> Result<(Sender, Receiver), string>
+  statements:
+    use BindingId(20) capacity site=SiteId(94) ty=i64 intent=Read
+    use BindingId(20) capacity site=SiteId(99) ty=i64 intent=Read
+    eval site=SiteId(108) ty=()
+    use BindingId(20) capacity site=SiteId(112) ty=i64 intent=Read
+    return site=Some(SiteId(96)) ty=Result<(Sender, Receiver), string>
+    bind BindingId(21) pair site=SiteId(110) ty=ChannelPair
+    use BindingId(21) pair site=SiteId(116) ty=ChannelPair intent=Read
+    eval site=SiteId(130) ty=()
+    use BindingId(21) pair site=SiteId(132) ty=ChannelPair intent=Read
+    bind BindingId(22) detail site=SiteId(118) ty=string
+    use BindingId(22) detail site=SiteId(121) ty=string intent=Read
+    return site=Some(SiteId(123)) ty=Result<(Sender, Receiver), string>
+    eval site=SiteId(126) ty=()
+    use BindingId(22) detail site=SiteId(128) ty=string intent=Read
+    agg_alias BindingId(22) detail site=SiteId(128) ty=string
+    return site=Some(SiteId(127)) ty=Result<(Sender, Receiver), string>
+    bind BindingId(23) tx site=SiteId(131) ty=Sender
+    use BindingId(21) pair site=SiteId(135) ty=ChannelPair intent=Read
+    bind BindingId(24) rx site=SiteId(134) ty=Receiver
+    use BindingId(21) pair site=SiteId(138) ty=ChannelPair intent=Read
+    eval site=SiteId(137) ty=()
+    use BindingId(23) tx site=SiteId(142) ty=Sender intent=Read
+    use BindingId(24) rx site=SiteId(143) ty=Receiver intent=Read
+    return site=Some(SiteId(109)) ty=Result<(Sender, Receiver), string>
+    drop BindingId(22) detail ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    call[bb3 hew_channel_new -> bb8] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    return[bb6] ->
+      (none)
+    goto[bb7->bb3] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+    call[bb8 hew_channel_pair_is_valid -> bb9] ->
+      (none)
+    branch[bb9: bb10/bb11] ->
+      (none)
+    call[bb10 hew_stream_last_error -> bb13] ->
+      (none)
+    goto[bb11->bb12] ->
+      (none)
+    call[bb12 hew_channel_pair_sender -> bb19] ->
+      (none)
+    branch[bb13: bb14/bb15] ->
+      (none)
+    return[bb14] ->
+      (none)
+    goto[bb15->bb16] ->
+      (none)
+    return[bb16] ->
+      (none)
+    goto[bb17->bb16] ->
+      (none)
+    cancel[bb17] ->
+      (none)
+    goto[bb18->bb12] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    call[bb19 hew_channel_pair_receiver -> bb20] ->
+      (none)
+    call[bb20 hew_channel_pair_free -> bb21] ->
+      (none)
+    return[bb21] ->
       (none)
 
 fn i8::fmt -> string
   statements:
-    use BindingId(29) val site=SiteId(172) ty=i8 intent=Read
-    return site=Some(SiteId(170)) ty=string
+    use BindingId(33) val site=SiteId(214) ty=i8 intent=Read
+    return site=Some(SiteId(212)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -240,8 +330,8 @@ fn i8::fmt -> string
 
 fn i16::fmt -> string
   statements:
-    use BindingId(30) val site=SiteId(176) ty=i16 intent=Read
-    return site=Some(SiteId(174)) ty=string
+    use BindingId(34) val site=SiteId(218) ty=i16 intent=Read
+    return site=Some(SiteId(216)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -252,8 +342,8 @@ fn i16::fmt -> string
 
 fn i32::fmt -> string
   statements:
-    use BindingId(31) val site=SiteId(179) ty=i32 intent=Read
-    return site=Some(SiteId(178)) ty=string
+    use BindingId(35) val site=SiteId(221) ty=i32 intent=Read
+    return site=Some(SiteId(220)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -264,8 +354,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(32) val site=SiteId(182) ty=i64 intent=Read
-    return site=Some(SiteId(181)) ty=string
+    use BindingId(36) val site=SiteId(224) ty=i64 intent=Read
+    return site=Some(SiteId(223)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -276,8 +366,8 @@ fn i64::fmt -> string
 
 fn u8::fmt -> string
   statements:
-    use BindingId(33) val site=SiteId(185) ty=u8 intent=Read
-    return site=Some(SiteId(184)) ty=string
+    use BindingId(37) val site=SiteId(227) ty=u8 intent=Read
+    return site=Some(SiteId(226)) ty=string
   drop_plans:
     call[bb0 to_string_u8 -> bb1] ->
       (none)
@@ -288,8 +378,8 @@ fn u8::fmt -> string
 
 fn u16::fmt -> string
   statements:
-    use BindingId(34) val site=SiteId(188) ty=u16 intent=Read
-    return site=Some(SiteId(187)) ty=string
+    use BindingId(38) val site=SiteId(230) ty=u16 intent=Read
+    return site=Some(SiteId(229)) ty=string
   drop_plans:
     call[bb0 to_string_u16 -> bb1] ->
       (none)
@@ -300,8 +390,8 @@ fn u16::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(35) val site=SiteId(191) ty=u32 intent=Read
-    return site=Some(SiteId(190)) ty=string
+    use BindingId(39) val site=SiteId(233) ty=u32 intent=Read
+    return site=Some(SiteId(232)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -312,8 +402,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(36) val site=SiteId(194) ty=u64 intent=Read
-    return site=Some(SiteId(193)) ty=string
+    use BindingId(40) val site=SiteId(236) ty=u64 intent=Read
+    return site=Some(SiteId(235)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -324,8 +414,8 @@ fn u64::fmt -> string
 
 fn isize::fmt -> string
   statements:
-    use BindingId(37) val site=SiteId(198) ty=isize intent=Read
-    return site=Some(SiteId(196)) ty=string
+    use BindingId(41) val site=SiteId(240) ty=isize intent=Read
+    return site=Some(SiteId(238)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -336,8 +426,8 @@ fn isize::fmt -> string
 
 fn usize::fmt -> string
   statements:
-    use BindingId(38) val site=SiteId(202) ty=usize intent=Read
-    return site=Some(SiteId(200)) ty=string
+    use BindingId(42) val site=SiteId(244) ty=usize intent=Read
+    return site=Some(SiteId(242)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -348,8 +438,8 @@ fn usize::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(39) val site=SiteId(205) ty=bool intent=Read
-    return site=Some(SiteId(204)) ty=string
+    use BindingId(43) val site=SiteId(247) ty=bool intent=Read
+    return site=Some(SiteId(246)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -360,8 +450,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(40) val site=SiteId(208) ty=char intent=Read
-    return site=Some(SiteId(207)) ty=string
+    use BindingId(44) val site=SiteId(250) ty=char intent=Read
+    return site=Some(SiteId(249)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -372,8 +462,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(41) val site=SiteId(211) ty=f64 intent=Read
-    return site=Some(SiteId(210)) ty=string
+    use BindingId(45) val site=SiteId(253) ty=f64 intent=Read
+    return site=Some(SiteId(252)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -384,8 +474,8 @@ fn f64::fmt -> string
 
 fn f32::fmt -> string
   statements:
-    use BindingId(42) val site=SiteId(215) ty=f32 intent=Read
-    return site=Some(SiteId(213)) ty=string
+    use BindingId(46) val site=SiteId(257) ty=f32 intent=Read
+    return site=Some(SiteId(255)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -396,16 +486,16 @@ fn f32::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(43) val site=SiteId(217) ty=string intent=Read
-    return site=Some(SiteId(217)) ty=string
+    use BindingId(47) val site=SiteId(259) ty=string intent=Read
+    return site=Some(SiteId(259)) ty=string
   drop_plans:
     return[bb0] ->
       (none)
 
 fn duration::from_nanos -> duration
   statements:
-    use BindingId(44) n site=SiteId(219) ty=i64 intent=Read
-    return site=Some(SiteId(218)) ty=duration
+    use BindingId(48) n site=SiteId(261) ty=i64 intent=Read
+    return site=Some(SiteId(260)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -416,8 +506,8 @@ fn duration::from_nanos -> duration
 
 fn duration::from_micros -> duration
   statements:
-    use BindingId(45) n site=SiteId(222) ty=i64 intent=Read
-    return site=Some(SiteId(221)) ty=duration
+    use BindingId(49) n site=SiteId(264) ty=i64 intent=Read
+    return site=Some(SiteId(263)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -428,8 +518,8 @@ fn duration::from_micros -> duration
 
 fn duration::from_millis -> duration
   statements:
-    use BindingId(46) n site=SiteId(225) ty=i64 intent=Read
-    return site=Some(SiteId(224)) ty=duration
+    use BindingId(50) n site=SiteId(267) ty=i64 intent=Read
+    return site=Some(SiteId(266)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -440,8 +530,8 @@ fn duration::from_millis -> duration
 
 fn duration::from_secs -> duration
   statements:
-    use BindingId(47) n site=SiteId(228) ty=i64 intent=Read
-    return site=Some(SiteId(227)) ty=duration
+    use BindingId(51) n site=SiteId(270) ty=i64 intent=Read
+    return site=Some(SiteId(269)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -452,8 +542,8 @@ fn duration::from_secs -> duration
 
 fn duration::fmt -> string
   statements:
-    use BindingId(48) val site=SiteId(233) ty=duration intent=Read
-    return site=Some(SiteId(230)) ty=string
+    use BindingId(52) val site=SiteId(275) ty=duration intent=Read
+    return site=Some(SiteId(272)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)

--- a/examples/v05/checked-mir/golden/channel_recv_select.raw.mir
+++ b/examples/v05/checked-mir/golden/channel_recv_select.raw.mir
@@ -265,42 +265,185 @@ fn Receiver::close(Receiver) -> () [conv=default]
 fn channel$new(i64) -> (Sender, Receiver) [conv=default]
   locals:
     _0: i64
-    _1: i64
-    _2: ChannelPair
-    _3: ChannelPair
-    _4: Sender
-    _5: Sender
-    _6: Receiver
-    _7: Receiver
+    _1: (Sender, Receiver)
+    _2: Result<(Sender, Receiver), string>
+    _3: i64
+    _4: i64
+    _5: bool
+    _6: i64
+    _7: bool
     _8: (Sender, Receiver)
-    _9: (Sender, Receiver)
+    _9: string
   bb0:
-    stmt: use BindingId(17) capacity site=SiteId(88) ty=i64 intent=Read
-    _1 = cast _0 i64 -> i64
-    _2 = call hew_channel_new(_1) -> bb1
+    stmt: use BindingId(17) capacity site=SiteId(87) ty=i64 intent=Read
+    _2 = call channel$try_new(_0) -> bb1
   bb1:
-    stmt: bind BindingId(18) pair site=SiteId(86) ty=ChannelPair
-    stmt: use BindingId(18) pair site=SiteId(91) ty=ChannelPair intent=Read
-    _3 = move _2
-    _4 = call hew_channel_pair_sender(_3) -> bb2
+    stmt: bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(86) ty=Result<(Sender, Receiver), string>
+    _3 = move etag2
+    _4 = const.i64 0
+    _5 = icmp.eq _3 _4
+    branch _5 ? bb3 : bb6
   bb2:
-    stmt: bind BindingId(19) tx site=SiteId(90) ty=Sender
-    stmt: use BindingId(18) pair site=SiteId(94) ty=ChannelPair intent=Read
-    _5 = move _4
-    _6 = call hew_channel_pair_receiver(_3) -> bb3
-  bb3:
-    stmt: bind BindingId(20) rx site=SiteId(93) ty=Receiver
-    stmt: use BindingId(18) pair site=SiteId(97) ty=ChannelPair intent=Read
-    _7 = move _6
-    call hew_channel_pair_free(_3) -> bb4
-  bb4:
-    stmt: eval site=SiteId(96) ty=()
-    stmt: use BindingId(19) tx site=SiteId(100) ty=Sender intent=Read
-    stmt: use BindingId(20) rx site=SiteId(101) ty=Receiver intent=Read
     stmt: return site=Some(SiteId(85)) ty=(Sender, Receiver)
-    _8 = tuple (_5, _7)
-    _9 = move _8
-    ret = move _9
+    ret = move _1
+    return
+  bb3:
+    stmt: bind BindingId(18) pair site=SiteId(89) ty=(Sender, Receiver)
+    stmt: use BindingId(18) pair site=SiteId(89) ty=(Sender, Receiver) intent=Read
+    _8 = move mvar2.0.0
+    _1 = move _8
+    goto bb2
+  bb4:
+    stmt: bind BindingId(19) err site=SiteId(90) ty=string
+    stmt: use BindingId(19) err site=SiteId(91) ty=string intent=Read
+    _9 = move mvar2.1.0
+    call panic(_9) -> bb7
+  bb5:
+    trap(ExhaustivenessFallthrough)
+  bb6:
+    _6 = const.i64 1
+    _7 = icmp.eq _3 _6
+    branch _7 ? bb4 : bb5
+  bb7:
+    goto bb2
+
+fn channel$try_new(i64) -> Result<(Sender, Receiver), string> [conv=default]
+  locals:
+    _0: i64
+    _1: ()
+    _2: i64
+    _3: bool
+    _4: Result<(Sender, Receiver), string>
+    _5: i64
+    _6: string
+    _7: string
+    _8: string
+    _9: string
+    _10: string
+    _11: i64
+    _12: ChannelPair
+    _13: ChannelPair
+    _14: ()
+    _15: bool
+    _16: bool
+    _17: string
+    _18: string
+    _19: ()
+    _20: string
+    _21: bool
+    _22: Result<(Sender, Receiver), string>
+    _23: i64
+    _24: string
+    _25: Result<(Sender, Receiver), string>
+    _26: i64
+    _27: Sender
+    _28: Sender
+    _29: Receiver
+    _30: Receiver
+    _31: Result<(Sender, Receiver), string>
+    _32: i64
+    _33: (Sender, Receiver)
+    _34: Result<(Sender, Receiver), string>
+  bb0:
+    stmt: use BindingId(20) capacity site=SiteId(94) ty=i64 intent=Read
+    _2 = const.i64 0
+    _3 = icmp.slt _0 _2
+    branch _3 ? bb1 : bb2
+  bb1:
+    stmt: use BindingId(20) capacity site=SiteId(99) ty=i64 intent=Read
+    _5 = const.i64 1
+    mtag4 = move _5
+    _6 = string_lit "channel.new: invalid capacity "
+    _7 = call to_string_i64(_0) -> bb4
+  bb2:
+    goto bb3
+  bb3:
+    stmt: eval site=SiteId(108) ty=()
+    stmt: use BindingId(20) capacity site=SiteId(112) ty=i64 intent=Read
+    _11 = cast _0 i64 -> i64
+    _12 = call hew_channel_new(_11) -> bb8
+  bb4:
+    _8 = call string_concat(_6, _7) -> bb5
+  bb5:
+    drop _7 ty=string fn=release(hew_string_drop)
+    _9 = string_lit " (must be >= 0)"
+    _10 = call string_concat(_8, _9) -> bb6
+  bb6:
+    stmt: return site=Some(SiteId(96)) ty=Result<(Sender, Receiver), string>
+    drop _8 ty=string fn=release(hew_string_drop)
+    mvar4.1.0 = move _10
+    ret = move _4
+    return
+  bb7:
+    goto bb3
+  bb8:
+    stmt: bind BindingId(21) pair site=SiteId(110) ty=ChannelPair
+    stmt: use BindingId(21) pair site=SiteId(116) ty=ChannelPair intent=Read
+    _13 = move _12
+    _15 = call hew_channel_pair_is_valid(_13) -> bb9
+  bb9:
+    _16 = not _15
+    branch _16 ? bb10 : bb11
+  bb10:
+    _17 = call hew_stream_last_error() -> bb13
+  bb11:
+    goto bb12
+  bb12:
+    stmt: eval site=SiteId(130) ty=()
+    stmt: use BindingId(21) pair site=SiteId(132) ty=ChannelPair intent=Read
+    _27 = call hew_channel_pair_sender(_13) -> bb19
+  bb13:
+    stmt: bind BindingId(22) detail site=SiteId(118) ty=string
+    stmt: use BindingId(22) detail site=SiteId(121) ty=string intent=Read
+    _18 = move _17
+    _20 = string_lit ""
+    _21 = icmp.eq _18 _20
+    branch _21 ? bb14 : bb15
+  bb14:
+    stmt: return site=Some(SiteId(123)) ty=Result<(Sender, Receiver), string>
+    _23 = const.i64 1
+    mtag22 = move _23
+    _24 = string_lit "channel.new: channel allocation failed"
+    mvar22.1.0 = move _24
+    ret = move _22
+    return
+  bb15:
+    goto bb16
+  bb16:
+    stmt: eval site=SiteId(126) ty=()
+    stmt: use BindingId(22) detail site=SiteId(128) ty=string intent=Read
+    stmt: agg_alias BindingId(22) detail site=SiteId(128) ty=string
+    stmt: return site=Some(SiteId(127)) ty=Result<(Sender, Receiver), string>
+    _26 = const.i64 1
+    mtag25 = move _26
+    mvar25.1.0 = move _18
+    ret = move _25
+    return
+  bb17:
+    goto bb16
+  bb18:
+    goto bb12
+  bb19:
+    stmt: bind BindingId(23) tx site=SiteId(131) ty=Sender
+    stmt: use BindingId(21) pair site=SiteId(135) ty=ChannelPair intent=Read
+    _28 = move _27
+    _29 = call hew_channel_pair_receiver(_13) -> bb20
+  bb20:
+    stmt: bind BindingId(24) rx site=SiteId(134) ty=Receiver
+    stmt: use BindingId(21) pair site=SiteId(138) ty=ChannelPair intent=Read
+    _30 = move _29
+    call hew_channel_pair_free(_13) -> bb21
+  bb21:
+    stmt: eval site=SiteId(137) ty=()
+    stmt: use BindingId(23) tx site=SiteId(142) ty=Sender intent=Read
+    stmt: use BindingId(24) rx site=SiteId(143) ty=Receiver intent=Read
+    stmt: return site=Some(SiteId(109)) ty=Result<(Sender, Receiver), string>
+    _32 = const.i64 0
+    mtag31 = move _32
+    _33 = tuple (_28, _30)
+    mvar31.0.0 = move _33
+    _34 = move _31
+    ret = move _34
     return
 
 fn i8::fmt(i8) -> string [conv=default]
@@ -309,11 +452,11 @@ fn i8::fmt(i8) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(29) val site=SiteId(172) ty=i8 intent=Read
+    stmt: use BindingId(33) val site=SiteId(214) ty=i8 intent=Read
     _1 = cast _0 i8 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(170)) ty=string
+    stmt: return site=Some(SiteId(212)) ty=string
     ret = move _2
     return
 
@@ -323,11 +466,11 @@ fn i16::fmt(i16) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(30) val site=SiteId(176) ty=i16 intent=Read
+    stmt: use BindingId(34) val site=SiteId(218) ty=i16 intent=Read
     _1 = cast _0 i16 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(174)) ty=string
+    stmt: return site=Some(SiteId(216)) ty=string
     ret = move _2
     return
 
@@ -336,10 +479,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(31) val site=SiteId(179) ty=i32 intent=Read
+    stmt: use BindingId(35) val site=SiteId(221) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(178)) ty=string
+    stmt: return site=Some(SiteId(220)) ty=string
     ret = move _1
     return
 
@@ -348,10 +491,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(32) val site=SiteId(182) ty=i64 intent=Read
+    stmt: use BindingId(36) val site=SiteId(224) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(181)) ty=string
+    stmt: return site=Some(SiteId(223)) ty=string
     ret = move _1
     return
 
@@ -360,10 +503,10 @@ fn u8::fmt(u8) -> string [conv=default]
     _0: u8
     _1: string
   bb0:
-    stmt: use BindingId(33) val site=SiteId(185) ty=u8 intent=Read
+    stmt: use BindingId(37) val site=SiteId(227) ty=u8 intent=Read
     _1 = call to_string_u8(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(184)) ty=string
+    stmt: return site=Some(SiteId(226)) ty=string
     ret = move _1
     return
 
@@ -372,10 +515,10 @@ fn u16::fmt(u16) -> string [conv=default]
     _0: u16
     _1: string
   bb0:
-    stmt: use BindingId(34) val site=SiteId(188) ty=u16 intent=Read
+    stmt: use BindingId(38) val site=SiteId(230) ty=u16 intent=Read
     _1 = call to_string_u16(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(187)) ty=string
+    stmt: return site=Some(SiteId(229)) ty=string
     ret = move _1
     return
 
@@ -384,10 +527,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(35) val site=SiteId(191) ty=u32 intent=Read
+    stmt: use BindingId(39) val site=SiteId(233) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(190)) ty=string
+    stmt: return site=Some(SiteId(232)) ty=string
     ret = move _1
     return
 
@@ -396,10 +539,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(36) val site=SiteId(194) ty=u64 intent=Read
+    stmt: use BindingId(40) val site=SiteId(236) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(193)) ty=string
+    stmt: return site=Some(SiteId(235)) ty=string
     ret = move _1
     return
 
@@ -409,11 +552,11 @@ fn isize::fmt(isize) -> string [conv=default]
     _1: i64
     _2: string
   bb0:
-    stmt: use BindingId(37) val site=SiteId(198) ty=isize intent=Read
+    stmt: use BindingId(41) val site=SiteId(240) ty=isize intent=Read
     _1 = cast _0 isize -> i64
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(196)) ty=string
+    stmt: return site=Some(SiteId(238)) ty=string
     ret = move _2
     return
 
@@ -423,11 +566,11 @@ fn usize::fmt(usize) -> string [conv=default]
     _1: u64
     _2: string
   bb0:
-    stmt: use BindingId(38) val site=SiteId(202) ty=usize intent=Read
+    stmt: use BindingId(42) val site=SiteId(244) ty=usize intent=Read
     _1 = cast _0 usize -> u64
     _2 = call to_string_u64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(200)) ty=string
+    stmt: return site=Some(SiteId(242)) ty=string
     ret = move _2
     return
 
@@ -436,10 +579,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(39) val site=SiteId(205) ty=bool intent=Read
+    stmt: use BindingId(43) val site=SiteId(247) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(204)) ty=string
+    stmt: return site=Some(SiteId(246)) ty=string
     ret = move _1
     return
 
@@ -448,10 +591,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(40) val site=SiteId(208) ty=char intent=Read
+    stmt: use BindingId(44) val site=SiteId(250) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(207)) ty=string
+    stmt: return site=Some(SiteId(249)) ty=string
     ret = move _1
     return
 
@@ -460,10 +603,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(41) val site=SiteId(211) ty=f64 intent=Read
+    stmt: use BindingId(45) val site=SiteId(253) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(210)) ty=string
+    stmt: return site=Some(SiteId(252)) ty=string
     ret = move _1
     return
 
@@ -473,11 +616,11 @@ fn f32::fmt(f32) -> string [conv=default]
     _1: f64
     _2: string
   bb0:
-    stmt: use BindingId(42) val site=SiteId(215) ty=f32 intent=Read
+    stmt: use BindingId(46) val site=SiteId(257) ty=f32 intent=Read
     _1 = cast _0 f32 -> f64
     _2 = call to_string_f64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(213)) ty=string
+    stmt: return site=Some(SiteId(255)) ty=string
     ret = move _2
     return
 
@@ -485,8 +628,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(43) val site=SiteId(217) ty=string intent=Read
-    stmt: return site=Some(SiteId(217)) ty=string
+    stmt: use BindingId(47) val site=SiteId(259) ty=string intent=Read
+    stmt: return site=Some(SiteId(259)) ty=string
     ret = move _0
     return
 
@@ -497,14 +640,14 @@ fn duration::from_nanos(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(44) n site=SiteId(219) ty=i64 intent=Read
+    stmt: use BindingId(48) n site=SiteId(261) ty=i64 intent=Read
     _1 = const.duration 1ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(218)) ty=duration
+    stmt: return site=Some(SiteId(260)) ty=duration
     ret = move _2
     return
 
@@ -515,14 +658,14 @@ fn duration::from_micros(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(45) n site=SiteId(222) ty=i64 intent=Read
+    stmt: use BindingId(49) n site=SiteId(264) ty=i64 intent=Read
     _1 = const.duration 1000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(221)) ty=duration
+    stmt: return site=Some(SiteId(263)) ty=duration
     ret = move _2
     return
 
@@ -533,14 +676,14 @@ fn duration::from_millis(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(46) n site=SiteId(225) ty=i64 intent=Read
+    stmt: use BindingId(50) n site=SiteId(267) ty=i64 intent=Read
     _1 = const.duration 1000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(224)) ty=duration
+    stmt: return site=Some(SiteId(266)) ty=duration
     ret = move _2
     return
 
@@ -551,14 +694,14 @@ fn duration::from_secs(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(47) n site=SiteId(228) ty=i64 intent=Read
+    stmt: use BindingId(51) n site=SiteId(270) ty=i64 intent=Read
     _1 = const.duration 1000000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(227)) ty=duration
+    stmt: return site=Some(SiteId(269)) ty=duration
     ret = move _2
     return
 
@@ -570,11 +713,11 @@ fn duration::fmt(duration) -> string [conv=default]
     _3: string
     _4: string
   bb0:
-    stmt: use BindingId(48) val site=SiteId(233) ty=duration intent=Read
+    stmt: use BindingId(52) val site=SiteId(275) ty=duration intent=Read
     _1 = call_rt hew_duration_nanos(_0)
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(230)) ty=string
+    stmt: return site=Some(SiteId(272)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
     drop _2 ty=string fn=release(hew_string_drop)

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.elab.mir
@@ -948,75 +948,255 @@ fn fs$is_dir -> bool
 
 fn stream$pipe -> (Sink<string>, Stream<string>)
   statements:
-    use BindingId(66) capacity site=SiteId(511) ty=i64 intent=Read
-    bind BindingId(67) pair site=SiteId(509) ty=StreamPair
-    use BindingId(67) pair site=SiteId(514) ty=StreamPair intent=Read
-    bind BindingId(68) sink site=SiteId(513) ty=Sink<string>
-    use BindingId(67) pair site=SiteId(517) ty=StreamPair intent=Read
-    bind BindingId(69) input site=SiteId(516) ty=Stream<string>
-    use BindingId(67) pair site=SiteId(520) ty=StreamPair intent=Read
-    eval site=SiteId(519) ty=()
-    use BindingId(68) sink site=SiteId(523) ty=Sink<string> intent=Read
-    use BindingId(69) input site=SiteId(524) ty=Stream<string> intent=Read
-    agg_alias BindingId(68) sink site=SiteId(523) ty=Sink<string>
-    agg_alias BindingId(69) input site=SiteId(524) ty=Stream<string>
+    use BindingId(66) capacity site=SiteId(510) ty=i64 intent=Read
+    bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(509) ty=Result<(Sink<string>, Stream<string>), string>
     return site=Some(SiteId(508)) ty=(Sink<string>, Stream<string>)
-    drop BindingId(69) input ty=Stream<string>
-    drop BindingId(68) sink ty=Sink<string>
+    bind BindingId(67) pair site=SiteId(512) ty=(Sink<string>, Stream<string>)
+    use BindingId(67) pair site=SiteId(512) ty=(Sink<string>, Stream<string>) intent=Read
+    bind BindingId(68) err site=SiteId(513) ty=string
+    use BindingId(68) err site=SiteId(514) ty=string intent=Read
+    drop BindingId(68) err ty=string
+    drop BindingId(67) pair ty=(Sink<string>, Stream<string>)
+    drop BindingId(4294967231) __hew_call_scrutinee ty=Result<(Sink<string>, Stream<string>), string>
   drop_plans:
-    call[bb0 hew_stream_channel -> bb1] ->
+    call[bb0 stream$try_pipe -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    call[bb1 hew_stream_pair_sink -> bb2] ->
+    branch[bb1: bb3/bb6] ->
       (none)
-    call[bb2 hew_stream_pair_stream -> bb3] ->
+    return[bb2] ->
       (none)
-    call[bb3 hew_stream_pair_free -> bb4] ->
+    goto[bb3->bb2] ->
       (none)
-    return[bb4] ->
+    cancel[bb3] ->
+      (none)
+    call[bb4 panic -> bb7] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    branch[bb6: bb4/bb5] ->
+      (none)
+    goto[bb7->bb2] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+
+fn stream$try_pipe -> Result<(Sink<string>, Stream<string>), string>
+  statements:
+    use BindingId(69) capacity site=SiteId(517) ty=i64 intent=Read
+    use BindingId(69) capacity site=SiteId(522) ty=i64 intent=Read
+    eval site=SiteId(531) ty=()
+    use BindingId(69) capacity site=SiteId(535) ty=i64 intent=Read
+    return site=Some(SiteId(519)) ty=Result<(Sink<string>, Stream<string>), string>
+    bind BindingId(70) pair site=SiteId(533) ty=StreamPair
+    use BindingId(70) pair site=SiteId(539) ty=StreamPair intent=Read
+    eval site=SiteId(553) ty=()
+    use BindingId(70) pair site=SiteId(555) ty=StreamPair intent=Read
+    bind BindingId(71) detail site=SiteId(541) ty=string
+    use BindingId(71) detail site=SiteId(544) ty=string intent=Read
+    return site=Some(SiteId(546)) ty=Result<(Sink<string>, Stream<string>), string>
+    eval site=SiteId(549) ty=()
+    use BindingId(71) detail site=SiteId(551) ty=string intent=Read
+    agg_alias BindingId(71) detail site=SiteId(551) ty=string
+    return site=Some(SiteId(550)) ty=Result<(Sink<string>, Stream<string>), string>
+    bind BindingId(72) sink site=SiteId(554) ty=Sink<string>
+    use BindingId(70) pair site=SiteId(558) ty=StreamPair intent=Read
+    bind BindingId(73) input site=SiteId(557) ty=Stream<string>
+    use BindingId(70) pair site=SiteId(561) ty=StreamPair intent=Read
+    eval site=SiteId(560) ty=()
+    use BindingId(72) sink site=SiteId(565) ty=Sink<string> intent=Read
+    use BindingId(73) input site=SiteId(566) ty=Stream<string> intent=Read
+    agg_alias BindingId(72) sink site=SiteId(565) ty=Sink<string>
+    agg_alias BindingId(73) input site=SiteId(566) ty=Stream<string>
+    return site=Some(SiteId(532)) ty=Result<(Sink<string>, Stream<string>), string>
+    drop BindingId(73) input ty=Stream<string>
+    drop BindingId(72) sink ty=Sink<string>
+    drop BindingId(71) detail ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    call[bb3 hew_stream_channel -> bb8] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    return[bb6] ->
+      (none)
+    goto[bb7->bb3] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+    call[bb8 hew_stream_pair_is_valid -> bb9] ->
+      (none)
+    branch[bb9: bb10/bb11] ->
+      (none)
+    call[bb10 hew_stream_last_error -> bb13] ->
+      (none)
+    goto[bb11->bb12] ->
+      (none)
+    call[bb12 hew_stream_pair_sink -> bb19] ->
+      (none)
+    branch[bb13: bb14/bb15] ->
+      (none)
+    return[bb14] ->
+      (none)
+    goto[bb15->bb16] ->
+      (none)
+    return[bb16] ->
+      (none)
+    goto[bb17->bb16] ->
+      (none)
+    cancel[bb17] ->
+      (none)
+    goto[bb18->bb12] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    call[bb19 hew_stream_pair_stream -> bb20] ->
+      (none)
+    call[bb20 hew_stream_pair_free -> bb21] ->
+      (none)
+    return[bb21] ->
       (none)
 
 fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
   statements:
-    use BindingId(70) capacity site=SiteId(528) ty=i64 intent=Read
-    bind BindingId(71) pair site=SiteId(526) ty=StreamPair
-    use BindingId(71) pair site=SiteId(531) ty=StreamPair intent=Read
-    bind BindingId(72) sink site=SiteId(530) ty=Sink<bytes>
-    use BindingId(71) pair site=SiteId(534) ty=StreamPair intent=Read
-    bind BindingId(73) input site=SiteId(533) ty=Stream<bytes>
-    use BindingId(71) pair site=SiteId(537) ty=StreamPair intent=Read
-    eval site=SiteId(536) ty=()
-    use BindingId(72) sink site=SiteId(540) ty=Sink<bytes> intent=Read
-    use BindingId(73) input site=SiteId(541) ty=Stream<bytes> intent=Read
-    agg_alias BindingId(72) sink site=SiteId(540) ty=Sink<bytes>
-    agg_alias BindingId(73) input site=SiteId(541) ty=Stream<bytes>
-    return site=Some(SiteId(525)) ty=(Sink<bytes>, Stream<bytes>)
-    drop BindingId(73) input ty=Stream<bytes>
-    drop BindingId(72) sink ty=Sink<bytes>
+    use BindingId(74) capacity site=SiteId(569) ty=i64 intent=Read
+    bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(568) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    return site=Some(SiteId(567)) ty=(Sink<bytes>, Stream<bytes>)
+    bind BindingId(75) pair site=SiteId(571) ty=(Sink<bytes>, Stream<bytes>)
+    use BindingId(75) pair site=SiteId(571) ty=(Sink<bytes>, Stream<bytes>) intent=Read
+    bind BindingId(76) err site=SiteId(572) ty=string
+    use BindingId(76) err site=SiteId(573) ty=string intent=Read
+    drop BindingId(76) err ty=string
+    drop BindingId(75) pair ty=(Sink<bytes>, Stream<bytes>)
+    drop BindingId(4294967231) __hew_call_scrutinee ty=Result<(Sink<bytes>, Stream<bytes>), string>
   drop_plans:
-    call[bb0 hew_stream_channel -> bb1] ->
+    call[bb0 stream$try_bytes_pipe -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    call[bb1 hew_stream_pair_sink_bytes -> bb2] ->
+    branch[bb1: bb3/bb6] ->
       (none)
-    call[bb2 hew_stream_pair_stream_bytes -> bb3] ->
+    return[bb2] ->
       (none)
-    call[bb3 hew_stream_pair_free -> bb4] ->
+    goto[bb3->bb2] ->
       (none)
-    return[bb4] ->
+    cancel[bb3] ->
+      (none)
+    call[bb4 panic -> bb7] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    branch[bb6: bb4/bb5] ->
+      (none)
+    goto[bb7->bb2] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+
+fn stream$try_bytes_pipe -> Result<(Sink<bytes>, Stream<bytes>), string>
+  statements:
+    use BindingId(77) capacity site=SiteId(576) ty=i64 intent=Read
+    use BindingId(77) capacity site=SiteId(581) ty=i64 intent=Read
+    eval site=SiteId(590) ty=()
+    use BindingId(77) capacity site=SiteId(594) ty=i64 intent=Read
+    return site=Some(SiteId(578)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    bind BindingId(78) pair site=SiteId(592) ty=StreamPair
+    use BindingId(78) pair site=SiteId(598) ty=StreamPair intent=Read
+    eval site=SiteId(612) ty=()
+    use BindingId(78) pair site=SiteId(614) ty=StreamPair intent=Read
+    bind BindingId(79) detail site=SiteId(600) ty=string
+    use BindingId(79) detail site=SiteId(603) ty=string intent=Read
+    return site=Some(SiteId(605)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    eval site=SiteId(608) ty=()
+    use BindingId(79) detail site=SiteId(610) ty=string intent=Read
+    agg_alias BindingId(79) detail site=SiteId(610) ty=string
+    return site=Some(SiteId(609)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    bind BindingId(80) sink site=SiteId(613) ty=Sink<bytes>
+    use BindingId(78) pair site=SiteId(617) ty=StreamPair intent=Read
+    bind BindingId(81) input site=SiteId(616) ty=Stream<bytes>
+    use BindingId(78) pair site=SiteId(620) ty=StreamPair intent=Read
+    eval site=SiteId(619) ty=()
+    use BindingId(80) sink site=SiteId(624) ty=Sink<bytes> intent=Read
+    use BindingId(81) input site=SiteId(625) ty=Stream<bytes> intent=Read
+    agg_alias BindingId(80) sink site=SiteId(624) ty=Sink<bytes>
+    agg_alias BindingId(81) input site=SiteId(625) ty=Stream<bytes>
+    return site=Some(SiteId(591)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    drop BindingId(81) input ty=Stream<bytes>
+    drop BindingId(80) sink ty=Sink<bytes>
+    drop BindingId(79) detail ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    call[bb3 hew_stream_channel -> bb8] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    return[bb6] ->
+      (none)
+    goto[bb7->bb3] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+    call[bb8 hew_stream_pair_is_valid -> bb9] ->
+      (none)
+    branch[bb9: bb10/bb11] ->
+      (none)
+    call[bb10 hew_stream_last_error -> bb13] ->
+      (none)
+    goto[bb11->bb12] ->
+      (none)
+    call[bb12 hew_stream_pair_sink_bytes -> bb19] ->
+      (none)
+    branch[bb13: bb14/bb15] ->
+      (none)
+    return[bb14] ->
+      (none)
+    goto[bb15->bb16] ->
+      (none)
+    return[bb16] ->
+      (none)
+    goto[bb17->bb16] ->
+      (none)
+    cancel[bb17] ->
+      (none)
+    goto[bb18->bb12] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    call[bb19 hew_stream_pair_stream_bytes -> bb20] ->
+      (none)
+    call[bb20 hew_stream_pair_free -> bb21] ->
+      (none)
+    return[bb21] ->
       (none)
 
 fn stream$from_file -> Result<Stream<string>, string>
   statements:
-    use BindingId(74) path site=SiteId(544) ty=string intent=Read
-    bind BindingId(75) s site=SiteId(543) ty=Stream<string>
-    use BindingId(75) s site=SiteId(548) ty=Stream<string> intent=Read
-    use BindingId(75) s site=SiteId(552) ty=Stream<string> intent=Read
-    agg_alias BindingId(75) s site=SiteId(552) ty=Stream<string>
-    return site=Some(SiteId(542)) ty=Result<Stream<string>, string>
-    drop BindingId(75) s ty=Stream<string>
+    use BindingId(82) path site=SiteId(628) ty=string intent=Read
+    bind BindingId(83) s site=SiteId(627) ty=Stream<string>
+    use BindingId(83) s site=SiteId(632) ty=Stream<string> intent=Read
+    use BindingId(83) s site=SiteId(636) ty=Stream<string> intent=Read
+    agg_alias BindingId(83) s site=SiteId(636) ty=Stream<string>
+    return site=Some(SiteId(626)) ty=Result<Stream<string>, string>
+    drop BindingId(83) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1039,18 +1219,18 @@ fn stream$from_file -> Result<Stream<string>, string>
 
 fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
   statements:
-    use BindingId(76) path site=SiteId(559) ty=string intent=Read
-    bind BindingId(77) s site=SiteId(558) ty=Stream<string>
-    use BindingId(77) s site=SiteId(563) ty=Stream<string> intent=Read
-    use BindingId(77) s site=SiteId(567) ty=Stream<string> intent=Read
-    agg_alias BindingId(77) s site=SiteId(567) ty=Stream<string>
-    return site=Some(SiteId(557)) ty=Result<Stream<string>, fs.IoError>
-    bind BindingId(78) kind site=SiteId(569) ty=i64
-    bind BindingId(79) errno site=SiteId(572) ty=i32
-    eval site=SiteId(574) ty=string
-    use BindingId(78) kind site=SiteId(578) ty=i64 intent=Read
-    use BindingId(79) errno site=SiteId(580) ty=i32 intent=Read
-    drop BindingId(77) s ty=Stream<string>
+    use BindingId(84) path site=SiteId(643) ty=string intent=Read
+    bind BindingId(85) s site=SiteId(642) ty=Stream<string>
+    use BindingId(85) s site=SiteId(647) ty=Stream<string> intent=Read
+    use BindingId(85) s site=SiteId(651) ty=Stream<string> intent=Read
+    agg_alias BindingId(85) s site=SiteId(651) ty=Stream<string>
+    return site=Some(SiteId(641)) ty=Result<Stream<string>, fs.IoError>
+    bind BindingId(86) kind site=SiteId(653) ty=i64
+    bind BindingId(87) errno site=SiteId(656) ty=i32
+    eval site=SiteId(658) ty=string
+    use BindingId(86) kind site=SiteId(662) ty=i64 intent=Read
+    use BindingId(87) errno site=SiteId(664) ty=i32 intent=Read
+    drop BindingId(85) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1079,13 +1259,13 @@ fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
 
 fn stream$to_file -> Result<Sink<string>, string>
   statements:
-    use BindingId(80) path site=SiteId(584) ty=string intent=Read
-    bind BindingId(81) s site=SiteId(583) ty=Sink<string>
-    use BindingId(81) s site=SiteId(588) ty=Sink<string> intent=Read
-    use BindingId(81) s site=SiteId(592) ty=Sink<string> intent=Read
-    agg_alias BindingId(81) s site=SiteId(592) ty=Sink<string>
-    return site=Some(SiteId(582)) ty=Result<Sink<string>, string>
-    drop BindingId(81) s ty=Sink<string>
+    use BindingId(88) path site=SiteId(668) ty=string intent=Read
+    bind BindingId(89) s site=SiteId(667) ty=Sink<string>
+    use BindingId(89) s site=SiteId(672) ty=Sink<string> intent=Read
+    use BindingId(89) s site=SiteId(676) ty=Sink<string> intent=Read
+    agg_alias BindingId(89) s site=SiteId(676) ty=Sink<string>
+    return site=Some(SiteId(666)) ty=Result<Sink<string>, string>
+    drop BindingId(89) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1108,18 +1288,18 @@ fn stream$to_file -> Result<Sink<string>, string>
 
 fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
   statements:
-    use BindingId(82) path site=SiteId(599) ty=string intent=Read
-    bind BindingId(83) s site=SiteId(598) ty=Sink<string>
-    use BindingId(83) s site=SiteId(603) ty=Sink<string> intent=Read
-    use BindingId(83) s site=SiteId(607) ty=Sink<string> intent=Read
-    agg_alias BindingId(83) s site=SiteId(607) ty=Sink<string>
-    return site=Some(SiteId(597)) ty=Result<Sink<string>, fs.IoError>
-    bind BindingId(84) kind site=SiteId(609) ty=i64
-    bind BindingId(85) errno site=SiteId(612) ty=i32
-    eval site=SiteId(614) ty=string
-    use BindingId(84) kind site=SiteId(618) ty=i64 intent=Read
-    use BindingId(85) errno site=SiteId(620) ty=i32 intent=Read
-    drop BindingId(83) s ty=Sink<string>
+    use BindingId(90) path site=SiteId(683) ty=string intent=Read
+    bind BindingId(91) s site=SiteId(682) ty=Sink<string>
+    use BindingId(91) s site=SiteId(687) ty=Sink<string> intent=Read
+    use BindingId(91) s site=SiteId(691) ty=Sink<string> intent=Read
+    agg_alias BindingId(91) s site=SiteId(691) ty=Sink<string>
+    return site=Some(SiteId(681)) ty=Result<Sink<string>, fs.IoError>
+    bind BindingId(92) kind site=SiteId(693) ty=i64
+    bind BindingId(93) errno site=SiteId(696) ty=i32
+    eval site=SiteId(698) ty=string
+    use BindingId(92) kind site=SiteId(702) ty=i64 intent=Read
+    use BindingId(93) errno site=SiteId(704) ty=i32 intent=Read
+    drop BindingId(91) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1148,9 +1328,9 @@ fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
 
 fn stream$forward -> ()
   statements:
-    use BindingId(86) source site=SiteId(624) ty=Stream<string> intent=Read
-    use BindingId(87) dest site=SiteId(625) ty=Sink<string> intent=Read
-    eval site=SiteId(622) ty=()
+    use BindingId(94) source site=SiteId(708) ty=Stream<string> intent=Read
+    use BindingId(95) dest site=SiteId(709) ty=Sink<string> intent=Read
+    eval site=SiteId(706) ty=()
   drop_plans:
     call[bb0 hew_stream_pipe -> bb1] ->
       (none)
@@ -1161,8 +1341,8 @@ fn stream$forward -> ()
 
 fn i8::fmt -> string
   statements:
-    use BindingId(96) val site=SiteId(697) ty=i8 intent=Read
-    return site=Some(SiteId(695)) ty=string
+    use BindingId(104) val site=SiteId(781) ty=i8 intent=Read
+    return site=Some(SiteId(779)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1173,8 +1353,8 @@ fn i8::fmt -> string
 
 fn i16::fmt -> string
   statements:
-    use BindingId(97) val site=SiteId(701) ty=i16 intent=Read
-    return site=Some(SiteId(699)) ty=string
+    use BindingId(105) val site=SiteId(785) ty=i16 intent=Read
+    return site=Some(SiteId(783)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1185,8 +1365,8 @@ fn i16::fmt -> string
 
 fn i32::fmt -> string
   statements:
-    use BindingId(98) val site=SiteId(704) ty=i32 intent=Read
-    return site=Some(SiteId(703)) ty=string
+    use BindingId(106) val site=SiteId(788) ty=i32 intent=Read
+    return site=Some(SiteId(787)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1197,8 +1377,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(99) val site=SiteId(707) ty=i64 intent=Read
-    return site=Some(SiteId(706)) ty=string
+    use BindingId(107) val site=SiteId(791) ty=i64 intent=Read
+    return site=Some(SiteId(790)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1209,8 +1389,8 @@ fn i64::fmt -> string
 
 fn u8::fmt -> string
   statements:
-    use BindingId(100) val site=SiteId(710) ty=u8 intent=Read
-    return site=Some(SiteId(709)) ty=string
+    use BindingId(108) val site=SiteId(794) ty=u8 intent=Read
+    return site=Some(SiteId(793)) ty=string
   drop_plans:
     call[bb0 to_string_u8 -> bb1] ->
       (none)
@@ -1221,8 +1401,8 @@ fn u8::fmt -> string
 
 fn u16::fmt -> string
   statements:
-    use BindingId(101) val site=SiteId(713) ty=u16 intent=Read
-    return site=Some(SiteId(712)) ty=string
+    use BindingId(109) val site=SiteId(797) ty=u16 intent=Read
+    return site=Some(SiteId(796)) ty=string
   drop_plans:
     call[bb0 to_string_u16 -> bb1] ->
       (none)
@@ -1233,8 +1413,8 @@ fn u16::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(102) val site=SiteId(716) ty=u32 intent=Read
-    return site=Some(SiteId(715)) ty=string
+    use BindingId(110) val site=SiteId(800) ty=u32 intent=Read
+    return site=Some(SiteId(799)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -1245,8 +1425,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(103) val site=SiteId(719) ty=u64 intent=Read
-    return site=Some(SiteId(718)) ty=string
+    use BindingId(111) val site=SiteId(803) ty=u64 intent=Read
+    return site=Some(SiteId(802)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1257,8 +1437,8 @@ fn u64::fmt -> string
 
 fn isize::fmt -> string
   statements:
-    use BindingId(104) val site=SiteId(723) ty=isize intent=Read
-    return site=Some(SiteId(721)) ty=string
+    use BindingId(112) val site=SiteId(807) ty=isize intent=Read
+    return site=Some(SiteId(805)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1269,8 +1449,8 @@ fn isize::fmt -> string
 
 fn usize::fmt -> string
   statements:
-    use BindingId(105) val site=SiteId(727) ty=usize intent=Read
-    return site=Some(SiteId(725)) ty=string
+    use BindingId(113) val site=SiteId(811) ty=usize intent=Read
+    return site=Some(SiteId(809)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1281,8 +1461,8 @@ fn usize::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(106) val site=SiteId(730) ty=bool intent=Read
-    return site=Some(SiteId(729)) ty=string
+    use BindingId(114) val site=SiteId(814) ty=bool intent=Read
+    return site=Some(SiteId(813)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -1293,8 +1473,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(107) val site=SiteId(733) ty=char intent=Read
-    return site=Some(SiteId(732)) ty=string
+    use BindingId(115) val site=SiteId(817) ty=char intent=Read
+    return site=Some(SiteId(816)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -1305,8 +1485,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(108) val site=SiteId(736) ty=f64 intent=Read
-    return site=Some(SiteId(735)) ty=string
+    use BindingId(116) val site=SiteId(820) ty=f64 intent=Read
+    return site=Some(SiteId(819)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1317,8 +1497,8 @@ fn f64::fmt -> string
 
 fn f32::fmt -> string
   statements:
-    use BindingId(109) val site=SiteId(740) ty=f32 intent=Read
-    return site=Some(SiteId(738)) ty=string
+    use BindingId(117) val site=SiteId(824) ty=f32 intent=Read
+    return site=Some(SiteId(822)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1329,16 +1509,16 @@ fn f32::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(110) val site=SiteId(742) ty=string intent=Read
-    return site=Some(SiteId(742)) ty=string
+    use BindingId(118) val site=SiteId(826) ty=string intent=Read
+    return site=Some(SiteId(826)) ty=string
   drop_plans:
     return[bb0] ->
       (none)
 
 fn duration::from_nanos -> duration
   statements:
-    use BindingId(111) n site=SiteId(744) ty=i64 intent=Read
-    return site=Some(SiteId(743)) ty=duration
+    use BindingId(119) n site=SiteId(828) ty=i64 intent=Read
+    return site=Some(SiteId(827)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1349,8 +1529,8 @@ fn duration::from_nanos -> duration
 
 fn duration::from_micros -> duration
   statements:
-    use BindingId(112) n site=SiteId(747) ty=i64 intent=Read
-    return site=Some(SiteId(746)) ty=duration
+    use BindingId(120) n site=SiteId(831) ty=i64 intent=Read
+    return site=Some(SiteId(830)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1361,8 +1541,8 @@ fn duration::from_micros -> duration
 
 fn duration::from_millis -> duration
   statements:
-    use BindingId(113) n site=SiteId(750) ty=i64 intent=Read
-    return site=Some(SiteId(749)) ty=duration
+    use BindingId(121) n site=SiteId(834) ty=i64 intent=Read
+    return site=Some(SiteId(833)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1373,8 +1553,8 @@ fn duration::from_millis -> duration
 
 fn duration::from_secs -> duration
   statements:
-    use BindingId(114) n site=SiteId(753) ty=i64 intent=Read
-    return site=Some(SiteId(752)) ty=duration
+    use BindingId(122) n site=SiteId(837) ty=i64 intent=Read
+    return site=Some(SiteId(836)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1385,8 +1565,8 @@ fn duration::from_secs -> duration
 
 fn duration::fmt -> string
   statements:
-    use BindingId(115) val site=SiteId(758) ty=duration intent=Read
-    return site=Some(SiteId(755)) ty=string
+    use BindingId(123) val site=SiteId(842) ty=duration intent=Read
+    return site=Some(SiteId(839)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
@@ -1614,87 +1614,373 @@ fn fs$is_dir(string) -> bool [conv=default]
 fn stream$pipe(i64) -> (Sink<string>, Stream<string>) [conv=default]
   locals:
     _0: i64
-    _1: i64
-    _2: StreamPair
-    _3: StreamPair
-    _4: Sink<string>
-    _5: Sink<string>
-    _6: Stream<string>
-    _7: Stream<string>
+    _1: (Sink<string>, Stream<string>)
+    _2: Result<(Sink<string>, Stream<string>), string>
+    _3: i64
+    _4: i64
+    _5: bool
+    _6: i64
+    _7: bool
     _8: (Sink<string>, Stream<string>)
-    _9: (Sink<string>, Stream<string>)
+    _9: string
   bb0:
-    stmt: use BindingId(66) capacity site=SiteId(511) ty=i64 intent=Read
-    _1 = cast _0 i64 -> i64
-    _2 = call hew_stream_channel(_1) -> bb1
+    stmt: use BindingId(66) capacity site=SiteId(510) ty=i64 intent=Read
+    _2 = call stream$try_pipe(_0) -> bb1
   bb1:
-    stmt: bind BindingId(67) pair site=SiteId(509) ty=StreamPair
-    stmt: use BindingId(67) pair site=SiteId(514) ty=StreamPair intent=Read
-    _3 = move _2
-    _4 = call hew_stream_pair_sink(_3) -> bb2
+    stmt: bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(509) ty=Result<(Sink<string>, Stream<string>), string>
+    _3 = move etag2
+    _4 = const.i64 0
+    _5 = icmp.eq _3 _4
+    branch _5 ? bb3 : bb6
   bb2:
-    stmt: bind BindingId(68) sink site=SiteId(513) ty=Sink<string>
-    stmt: use BindingId(67) pair site=SiteId(517) ty=StreamPair intent=Read
-    _5 = move _4
-    _6 = call hew_stream_pair_stream(_3) -> bb3
-  bb3:
-    stmt: bind BindingId(69) input site=SiteId(516) ty=Stream<string>
-    stmt: use BindingId(67) pair site=SiteId(520) ty=StreamPair intent=Read
-    _7 = move _6
-    call hew_stream_pair_free(_3) -> bb4
-  bb4:
-    stmt: eval site=SiteId(519) ty=()
-    stmt: use BindingId(68) sink site=SiteId(523) ty=Sink<string> intent=Read
-    stmt: use BindingId(69) input site=SiteId(524) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(68) sink site=SiteId(523) ty=Sink<string>
-    stmt: agg_alias BindingId(69) input site=SiteId(524) ty=Stream<string>
     stmt: return site=Some(SiteId(508)) ty=(Sink<string>, Stream<string>)
-    _8 = tuple (_5, _7)
-    _9 = move _8
-    ret = move _9
+    ret = move _1
+    return
+  bb3:
+    stmt: bind BindingId(67) pair site=SiteId(512) ty=(Sink<string>, Stream<string>)
+    stmt: use BindingId(67) pair site=SiteId(512) ty=(Sink<string>, Stream<string>) intent=Read
+    _8 = move mvar2.0.0
+    _1 = move _8
+    goto bb2
+  bb4:
+    stmt: bind BindingId(68) err site=SiteId(513) ty=string
+    stmt: use BindingId(68) err site=SiteId(514) ty=string intent=Read
+    _9 = move mvar2.1.0
+    call panic(_9) -> bb7
+  bb5:
+    trap(ExhaustivenessFallthrough)
+  bb6:
+    _6 = const.i64 1
+    _7 = icmp.eq _3 _6
+    branch _7 ? bb4 : bb5
+  bb7:
+    goto bb2
+
+fn stream$try_pipe(i64) -> Result<(Sink<string>, Stream<string>), string> [conv=default]
+  locals:
+    _0: i64
+    _1: ()
+    _2: i64
+    _3: bool
+    _4: Result<(Sink<string>, Stream<string>), string>
+    _5: i64
+    _6: string
+    _7: string
+    _8: string
+    _9: string
+    _10: string
+    _11: i64
+    _12: StreamPair
+    _13: StreamPair
+    _14: ()
+    _15: bool
+    _16: bool
+    _17: string
+    _18: string
+    _19: ()
+    _20: string
+    _21: bool
+    _22: Result<(Sink<string>, Stream<string>), string>
+    _23: i64
+    _24: string
+    _25: Result<(Sink<string>, Stream<string>), string>
+    _26: i64
+    _27: Sink<string>
+    _28: Sink<string>
+    _29: Stream<string>
+    _30: Stream<string>
+    _31: Result<(Sink<string>, Stream<string>), string>
+    _32: i64
+    _33: (Sink<string>, Stream<string>)
+    _34: Result<(Sink<string>, Stream<string>), string>
+  bb0:
+    stmt: use BindingId(69) capacity site=SiteId(517) ty=i64 intent=Read
+    _2 = const.i64 0
+    _3 = icmp.slt _0 _2
+    branch _3 ? bb1 : bb2
+  bb1:
+    stmt: use BindingId(69) capacity site=SiteId(522) ty=i64 intent=Read
+    _5 = const.i64 1
+    mtag4 = move _5
+    _6 = string_lit "stream.pipe: invalid capacity "
+    _7 = call to_string_i64(_0) -> bb4
+  bb2:
+    goto bb3
+  bb3:
+    stmt: eval site=SiteId(531) ty=()
+    stmt: use BindingId(69) capacity site=SiteId(535) ty=i64 intent=Read
+    _11 = cast _0 i64 -> i64
+    _12 = call hew_stream_channel(_11) -> bb8
+  bb4:
+    _8 = call string_concat(_6, _7) -> bb5
+  bb5:
+    drop _7 ty=string fn=release(hew_string_drop)
+    _9 = string_lit " (must be >= 0)"
+    _10 = call string_concat(_8, _9) -> bb6
+  bb6:
+    stmt: return site=Some(SiteId(519)) ty=Result<(Sink<string>, Stream<string>), string>
+    drop _8 ty=string fn=release(hew_string_drop)
+    mvar4.1.0 = move _10
+    ret = move _4
+    return
+  bb7:
+    goto bb3
+  bb8:
+    stmt: bind BindingId(70) pair site=SiteId(533) ty=StreamPair
+    stmt: use BindingId(70) pair site=SiteId(539) ty=StreamPair intent=Read
+    _13 = move _12
+    _15 = call hew_stream_pair_is_valid(_13) -> bb9
+  bb9:
+    _16 = not _15
+    branch _16 ? bb10 : bb11
+  bb10:
+    _17 = call hew_stream_last_error() -> bb13
+  bb11:
+    goto bb12
+  bb12:
+    stmt: eval site=SiteId(553) ty=()
+    stmt: use BindingId(70) pair site=SiteId(555) ty=StreamPair intent=Read
+    _27 = call hew_stream_pair_sink(_13) -> bb19
+  bb13:
+    stmt: bind BindingId(71) detail site=SiteId(541) ty=string
+    stmt: use BindingId(71) detail site=SiteId(544) ty=string intent=Read
+    _18 = move _17
+    _20 = string_lit ""
+    _21 = icmp.eq _18 _20
+    branch _21 ? bb14 : bb15
+  bb14:
+    stmt: return site=Some(SiteId(546)) ty=Result<(Sink<string>, Stream<string>), string>
+    _23 = const.i64 1
+    mtag22 = move _23
+    _24 = string_lit "stream.pipe: stream allocation failed"
+    mvar22.1.0 = move _24
+    ret = move _22
+    return
+  bb15:
+    goto bb16
+  bb16:
+    stmt: eval site=SiteId(549) ty=()
+    stmt: use BindingId(71) detail site=SiteId(551) ty=string intent=Read
+    stmt: agg_alias BindingId(71) detail site=SiteId(551) ty=string
+    stmt: return site=Some(SiteId(550)) ty=Result<(Sink<string>, Stream<string>), string>
+    _26 = const.i64 1
+    mtag25 = move _26
+    mvar25.1.0 = move _18
+    ret = move _25
+    return
+  bb17:
+    goto bb16
+  bb18:
+    goto bb12
+  bb19:
+    stmt: bind BindingId(72) sink site=SiteId(554) ty=Sink<string>
+    stmt: use BindingId(70) pair site=SiteId(558) ty=StreamPair intent=Read
+    _28 = move _27
+    _29 = call hew_stream_pair_stream(_13) -> bb20
+  bb20:
+    stmt: bind BindingId(73) input site=SiteId(557) ty=Stream<string>
+    stmt: use BindingId(70) pair site=SiteId(561) ty=StreamPair intent=Read
+    _30 = move _29
+    call hew_stream_pair_free(_13) -> bb21
+  bb21:
+    stmt: eval site=SiteId(560) ty=()
+    stmt: use BindingId(72) sink site=SiteId(565) ty=Sink<string> intent=Read
+    stmt: use BindingId(73) input site=SiteId(566) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(72) sink site=SiteId(565) ty=Sink<string>
+    stmt: agg_alias BindingId(73) input site=SiteId(566) ty=Stream<string>
+    stmt: return site=Some(SiteId(532)) ty=Result<(Sink<string>, Stream<string>), string>
+    _32 = const.i64 0
+    mtag31 = move _32
+    _33 = tuple (_28, _30)
+    mvar31.0.0 = move _33
+    _34 = move _31
+    ret = move _34
     return
 
 fn stream$bytes_pipe(i64) -> (Sink<bytes>, Stream<bytes>) [conv=default]
   locals:
     _0: i64
-    _1: i64
-    _2: StreamPair
-    _3: StreamPair
-    _4: Sink<bytes>
-    _5: Sink<bytes>
-    _6: Stream<bytes>
-    _7: Stream<bytes>
+    _1: (Sink<bytes>, Stream<bytes>)
+    _2: Result<(Sink<bytes>, Stream<bytes>), string>
+    _3: i64
+    _4: i64
+    _5: bool
+    _6: i64
+    _7: bool
     _8: (Sink<bytes>, Stream<bytes>)
-    _9: (Sink<bytes>, Stream<bytes>)
+    _9: string
   bb0:
-    stmt: use BindingId(70) capacity site=SiteId(528) ty=i64 intent=Read
-    _1 = cast _0 i64 -> i64
-    _2 = call hew_stream_channel(_1) -> bb1
+    stmt: use BindingId(74) capacity site=SiteId(569) ty=i64 intent=Read
+    _2 = call stream$try_bytes_pipe(_0) -> bb1
   bb1:
-    stmt: bind BindingId(71) pair site=SiteId(526) ty=StreamPair
-    stmt: use BindingId(71) pair site=SiteId(531) ty=StreamPair intent=Read
-    _3 = move _2
-    _4 = call hew_stream_pair_sink_bytes(_3) -> bb2
+    stmt: bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(568) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    _3 = move etag2
+    _4 = const.i64 0
+    _5 = icmp.eq _3 _4
+    branch _5 ? bb3 : bb6
   bb2:
-    stmt: bind BindingId(72) sink site=SiteId(530) ty=Sink<bytes>
-    stmt: use BindingId(71) pair site=SiteId(534) ty=StreamPair intent=Read
-    _5 = move _4
-    _6 = call hew_stream_pair_stream_bytes(_3) -> bb3
+    stmt: return site=Some(SiteId(567)) ty=(Sink<bytes>, Stream<bytes>)
+    ret = move _1
+    return
   bb3:
-    stmt: bind BindingId(73) input site=SiteId(533) ty=Stream<bytes>
-    stmt: use BindingId(71) pair site=SiteId(537) ty=StreamPair intent=Read
-    _7 = move _6
-    call hew_stream_pair_free(_3) -> bb4
+    stmt: bind BindingId(75) pair site=SiteId(571) ty=(Sink<bytes>, Stream<bytes>)
+    stmt: use BindingId(75) pair site=SiteId(571) ty=(Sink<bytes>, Stream<bytes>) intent=Read
+    _8 = move mvar2.0.0
+    _1 = move _8
+    goto bb2
   bb4:
-    stmt: eval site=SiteId(536) ty=()
-    stmt: use BindingId(72) sink site=SiteId(540) ty=Sink<bytes> intent=Read
-    stmt: use BindingId(73) input site=SiteId(541) ty=Stream<bytes> intent=Read
-    stmt: agg_alias BindingId(72) sink site=SiteId(540) ty=Sink<bytes>
-    stmt: agg_alias BindingId(73) input site=SiteId(541) ty=Stream<bytes>
-    stmt: return site=Some(SiteId(525)) ty=(Sink<bytes>, Stream<bytes>)
-    _8 = tuple (_5, _7)
-    _9 = move _8
-    ret = move _9
+    stmt: bind BindingId(76) err site=SiteId(572) ty=string
+    stmt: use BindingId(76) err site=SiteId(573) ty=string intent=Read
+    _9 = move mvar2.1.0
+    call panic(_9) -> bb7
+  bb5:
+    trap(ExhaustivenessFallthrough)
+  bb6:
+    _6 = const.i64 1
+    _7 = icmp.eq _3 _6
+    branch _7 ? bb4 : bb5
+  bb7:
+    goto bb2
+
+fn stream$try_bytes_pipe(i64) -> Result<(Sink<bytes>, Stream<bytes>), string> [conv=default]
+  locals:
+    _0: i64
+    _1: ()
+    _2: i64
+    _3: bool
+    _4: Result<(Sink<bytes>, Stream<bytes>), string>
+    _5: i64
+    _6: string
+    _7: string
+    _8: string
+    _9: string
+    _10: string
+    _11: i64
+    _12: StreamPair
+    _13: StreamPair
+    _14: ()
+    _15: bool
+    _16: bool
+    _17: string
+    _18: string
+    _19: ()
+    _20: string
+    _21: bool
+    _22: Result<(Sink<bytes>, Stream<bytes>), string>
+    _23: i64
+    _24: string
+    _25: Result<(Sink<bytes>, Stream<bytes>), string>
+    _26: i64
+    _27: Sink<bytes>
+    _28: Sink<bytes>
+    _29: Stream<bytes>
+    _30: Stream<bytes>
+    _31: Result<(Sink<bytes>, Stream<bytes>), string>
+    _32: i64
+    _33: (Sink<bytes>, Stream<bytes>)
+    _34: Result<(Sink<bytes>, Stream<bytes>), string>
+  bb0:
+    stmt: use BindingId(77) capacity site=SiteId(576) ty=i64 intent=Read
+    _2 = const.i64 0
+    _3 = icmp.slt _0 _2
+    branch _3 ? bb1 : bb2
+  bb1:
+    stmt: use BindingId(77) capacity site=SiteId(581) ty=i64 intent=Read
+    _5 = const.i64 1
+    mtag4 = move _5
+    _6 = string_lit "stream.bytes_pipe: invalid capacity "
+    _7 = call to_string_i64(_0) -> bb4
+  bb2:
+    goto bb3
+  bb3:
+    stmt: eval site=SiteId(590) ty=()
+    stmt: use BindingId(77) capacity site=SiteId(594) ty=i64 intent=Read
+    _11 = cast _0 i64 -> i64
+    _12 = call hew_stream_channel(_11) -> bb8
+  bb4:
+    _8 = call string_concat(_6, _7) -> bb5
+  bb5:
+    drop _7 ty=string fn=release(hew_string_drop)
+    _9 = string_lit " (must be >= 0)"
+    _10 = call string_concat(_8, _9) -> bb6
+  bb6:
+    stmt: return site=Some(SiteId(578)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    drop _8 ty=string fn=release(hew_string_drop)
+    mvar4.1.0 = move _10
+    ret = move _4
+    return
+  bb7:
+    goto bb3
+  bb8:
+    stmt: bind BindingId(78) pair site=SiteId(592) ty=StreamPair
+    stmt: use BindingId(78) pair site=SiteId(598) ty=StreamPair intent=Read
+    _13 = move _12
+    _15 = call hew_stream_pair_is_valid(_13) -> bb9
+  bb9:
+    _16 = not _15
+    branch _16 ? bb10 : bb11
+  bb10:
+    _17 = call hew_stream_last_error() -> bb13
+  bb11:
+    goto bb12
+  bb12:
+    stmt: eval site=SiteId(612) ty=()
+    stmt: use BindingId(78) pair site=SiteId(614) ty=StreamPair intent=Read
+    _27 = call hew_stream_pair_sink_bytes(_13) -> bb19
+  bb13:
+    stmt: bind BindingId(79) detail site=SiteId(600) ty=string
+    stmt: use BindingId(79) detail site=SiteId(603) ty=string intent=Read
+    _18 = move _17
+    _20 = string_lit ""
+    _21 = icmp.eq _18 _20
+    branch _21 ? bb14 : bb15
+  bb14:
+    stmt: return site=Some(SiteId(605)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    _23 = const.i64 1
+    mtag22 = move _23
+    _24 = string_lit "stream.bytes_pipe: stream allocation failed"
+    mvar22.1.0 = move _24
+    ret = move _22
+    return
+  bb15:
+    goto bb16
+  bb16:
+    stmt: eval site=SiteId(608) ty=()
+    stmt: use BindingId(79) detail site=SiteId(610) ty=string intent=Read
+    stmt: agg_alias BindingId(79) detail site=SiteId(610) ty=string
+    stmt: return site=Some(SiteId(609)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    _26 = const.i64 1
+    mtag25 = move _26
+    mvar25.1.0 = move _18
+    ret = move _25
+    return
+  bb17:
+    goto bb16
+  bb18:
+    goto bb12
+  bb19:
+    stmt: bind BindingId(80) sink site=SiteId(613) ty=Sink<bytes>
+    stmt: use BindingId(78) pair site=SiteId(617) ty=StreamPair intent=Read
+    _28 = move _27
+    _29 = call hew_stream_pair_stream_bytes(_13) -> bb20
+  bb20:
+    stmt: bind BindingId(81) input site=SiteId(616) ty=Stream<bytes>
+    stmt: use BindingId(78) pair site=SiteId(620) ty=StreamPair intent=Read
+    _30 = move _29
+    call hew_stream_pair_free(_13) -> bb21
+  bb21:
+    stmt: eval site=SiteId(619) ty=()
+    stmt: use BindingId(80) sink site=SiteId(624) ty=Sink<bytes> intent=Read
+    stmt: use BindingId(81) input site=SiteId(625) ty=Stream<bytes> intent=Read
+    stmt: agg_alias BindingId(80) sink site=SiteId(624) ty=Sink<bytes>
+    stmt: agg_alias BindingId(81) input site=SiteId(625) ty=Stream<bytes>
+    stmt: return site=Some(SiteId(591)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    _32 = const.i64 0
+    mtag31 = move _32
+    _33 = tuple (_28, _30)
+    mvar31.0.0 = move _33
+    _34 = move _31
+    ret = move _34
     return
 
 fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
@@ -1713,18 +1999,18 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     _11: Result<Stream<string>, string>
     _12: Result<Stream<string>, string>
   bb0:
-    stmt: use BindingId(74) path site=SiteId(544) ty=string intent=Read
+    stmt: use BindingId(82) path site=SiteId(628) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(75) s site=SiteId(543) ty=Stream<string>
-    stmt: use BindingId(75) s site=SiteId(548) ty=Stream<string> intent=Read
+    stmt: bind BindingId(83) s site=SiteId(627) ty=Stream<string>
+    stmt: use BindingId(83) s site=SiteId(632) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(75) s site=SiteId(552) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(75) s site=SiteId(552) ty=Stream<string>
+    stmt: use BindingId(83) s site=SiteId(636) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(83) s site=SiteId(636) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -1736,7 +2022,7 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(542)) ty=Result<Stream<string>, string>
+    stmt: return site=Some(SiteId(626)) ty=Result<Stream<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -1769,18 +2055,18 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _18: Result<Stream<string>, fs.IoError>
     _19: Result<Stream<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(76) path site=SiteId(559) ty=string intent=Read
+    stmt: use BindingId(84) path site=SiteId(643) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(77) s site=SiteId(558) ty=Stream<string>
-    stmt: use BindingId(77) s site=SiteId(563) ty=Stream<string> intent=Read
+    stmt: bind BindingId(85) s site=SiteId(642) ty=Stream<string>
+    stmt: use BindingId(85) s site=SiteId(647) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(77) s site=SiteId(567) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(77) s site=SiteId(567) ty=Stream<string>
+    stmt: use BindingId(85) s site=SiteId(651) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(85) s site=SiteId(651) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -1790,23 +2076,23 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
   bb4:
     _8 = call hew_stream_last_error_kind() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(557)) ty=Result<Stream<string>, fs.IoError>
+    stmt: return site=Some(SiteId(641)) ty=Result<Stream<string>, fs.IoError>
     _19 = move _3
     ret = move _19
     return
   bb6:
-    stmt: bind BindingId(78) kind site=SiteId(569) ty=i64
+    stmt: bind BindingId(86) kind site=SiteId(653) ty=i64
     _9 = cast _8 i32 -> i64
     _10 = move _9
     _11 = call hew_stream_last_errno() -> bb7
   bb7:
-    stmt: bind BindingId(79) errno site=SiteId(572) ty=i32
+    stmt: bind BindingId(87) errno site=SiteId(656) ty=i32
     _12 = move _11
     _13 = call hew_stream_last_error() -> bb8
   bb8:
-    stmt: eval site=SiteId(574) ty=string
-    stmt: use BindingId(78) kind site=SiteId(578) ty=i64 intent=Read
-    stmt: use BindingId(79) errno site=SiteId(580) ty=i32 intent=Read
+    stmt: eval site=SiteId(658) ty=string
+    stmt: use BindingId(86) kind site=SiteId(662) ty=i64 intent=Read
+    stmt: use BindingId(87) errno site=SiteId(664) ty=i32 intent=Read
     _15 = const.i64 1
     mtag14 = move _15
     _16 = cast _12 i32 -> i64
@@ -1833,18 +2119,18 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     _11: Result<Sink<string>, string>
     _12: Result<Sink<string>, string>
   bb0:
-    stmt: use BindingId(80) path site=SiteId(584) ty=string intent=Read
+    stmt: use BindingId(88) path site=SiteId(668) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(81) s site=SiteId(583) ty=Sink<string>
-    stmt: use BindingId(81) s site=SiteId(588) ty=Sink<string> intent=Read
+    stmt: bind BindingId(89) s site=SiteId(667) ty=Sink<string>
+    stmt: use BindingId(89) s site=SiteId(672) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(81) s site=SiteId(592) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(81) s site=SiteId(592) ty=Sink<string>
+    stmt: use BindingId(89) s site=SiteId(676) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(89) s site=SiteId(676) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -1856,7 +2142,7 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(582)) ty=Result<Sink<string>, string>
+    stmt: return site=Some(SiteId(666)) ty=Result<Sink<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -1889,18 +2175,18 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _18: Result<Sink<string>, fs.IoError>
     _19: Result<Sink<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(82) path site=SiteId(599) ty=string intent=Read
+    stmt: use BindingId(90) path site=SiteId(683) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(83) s site=SiteId(598) ty=Sink<string>
-    stmt: use BindingId(83) s site=SiteId(603) ty=Sink<string> intent=Read
+    stmt: bind BindingId(91) s site=SiteId(682) ty=Sink<string>
+    stmt: use BindingId(91) s site=SiteId(687) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(83) s site=SiteId(607) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(83) s site=SiteId(607) ty=Sink<string>
+    stmt: use BindingId(91) s site=SiteId(691) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(91) s site=SiteId(691) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -1910,23 +2196,23 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
   bb4:
     _8 = call hew_stream_last_error_kind() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(597)) ty=Result<Sink<string>, fs.IoError>
+    stmt: return site=Some(SiteId(681)) ty=Result<Sink<string>, fs.IoError>
     _19 = move _3
     ret = move _19
     return
   bb6:
-    stmt: bind BindingId(84) kind site=SiteId(609) ty=i64
+    stmt: bind BindingId(92) kind site=SiteId(693) ty=i64
     _9 = cast _8 i32 -> i64
     _10 = move _9
     _11 = call hew_stream_last_errno() -> bb7
   bb7:
-    stmt: bind BindingId(85) errno site=SiteId(612) ty=i32
+    stmt: bind BindingId(93) errno site=SiteId(696) ty=i32
     _12 = move _11
     _13 = call hew_stream_last_error() -> bb8
   bb8:
-    stmt: eval site=SiteId(614) ty=string
-    stmt: use BindingId(84) kind site=SiteId(618) ty=i64 intent=Read
-    stmt: use BindingId(85) errno site=SiteId(620) ty=i32 intent=Read
+    stmt: eval site=SiteId(698) ty=string
+    stmt: use BindingId(92) kind site=SiteId(702) ty=i64 intent=Read
+    stmt: use BindingId(93) errno site=SiteId(704) ty=i32 intent=Read
     _15 = const.i64 1
     mtag14 = move _15
     _16 = cast _12 i32 -> i64
@@ -1942,11 +2228,11 @@ fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
     _0: Stream<string>
     _1: Sink<string>
   bb0:
-    stmt: use BindingId(86) source site=SiteId(624) ty=Stream<string> intent=Read
-    stmt: use BindingId(87) dest site=SiteId(625) ty=Sink<string> intent=Read
+    stmt: use BindingId(94) source site=SiteId(708) ty=Stream<string> intent=Read
+    stmt: use BindingId(95) dest site=SiteId(709) ty=Sink<string> intent=Read
     call hew_stream_pipe(_0, _1) -> bb1
   bb1:
-    stmt: eval site=SiteId(622) ty=()
+    stmt: eval site=SiteId(706) ty=()
     return
 
 fn i8::fmt(i8) -> string [conv=default]
@@ -1955,11 +2241,11 @@ fn i8::fmt(i8) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(96) val site=SiteId(697) ty=i8 intent=Read
+    stmt: use BindingId(104) val site=SiteId(781) ty=i8 intent=Read
     _1 = cast _0 i8 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(695)) ty=string
+    stmt: return site=Some(SiteId(779)) ty=string
     ret = move _2
     return
 
@@ -1969,11 +2255,11 @@ fn i16::fmt(i16) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(97) val site=SiteId(701) ty=i16 intent=Read
+    stmt: use BindingId(105) val site=SiteId(785) ty=i16 intent=Read
     _1 = cast _0 i16 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(699)) ty=string
+    stmt: return site=Some(SiteId(783)) ty=string
     ret = move _2
     return
 
@@ -1982,10 +2268,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(98) val site=SiteId(704) ty=i32 intent=Read
+    stmt: use BindingId(106) val site=SiteId(788) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(703)) ty=string
+    stmt: return site=Some(SiteId(787)) ty=string
     ret = move _1
     return
 
@@ -1994,10 +2280,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(99) val site=SiteId(707) ty=i64 intent=Read
+    stmt: use BindingId(107) val site=SiteId(791) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(706)) ty=string
+    stmt: return site=Some(SiteId(790)) ty=string
     ret = move _1
     return
 
@@ -2006,10 +2292,10 @@ fn u8::fmt(u8) -> string [conv=default]
     _0: u8
     _1: string
   bb0:
-    stmt: use BindingId(100) val site=SiteId(710) ty=u8 intent=Read
+    stmt: use BindingId(108) val site=SiteId(794) ty=u8 intent=Read
     _1 = call to_string_u8(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(709)) ty=string
+    stmt: return site=Some(SiteId(793)) ty=string
     ret = move _1
     return
 
@@ -2018,10 +2304,10 @@ fn u16::fmt(u16) -> string [conv=default]
     _0: u16
     _1: string
   bb0:
-    stmt: use BindingId(101) val site=SiteId(713) ty=u16 intent=Read
+    stmt: use BindingId(109) val site=SiteId(797) ty=u16 intent=Read
     _1 = call to_string_u16(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(712)) ty=string
+    stmt: return site=Some(SiteId(796)) ty=string
     ret = move _1
     return
 
@@ -2030,10 +2316,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(102) val site=SiteId(716) ty=u32 intent=Read
+    stmt: use BindingId(110) val site=SiteId(800) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(715)) ty=string
+    stmt: return site=Some(SiteId(799)) ty=string
     ret = move _1
     return
 
@@ -2042,10 +2328,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(103) val site=SiteId(719) ty=u64 intent=Read
+    stmt: use BindingId(111) val site=SiteId(803) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(718)) ty=string
+    stmt: return site=Some(SiteId(802)) ty=string
     ret = move _1
     return
 
@@ -2055,11 +2341,11 @@ fn isize::fmt(isize) -> string [conv=default]
     _1: i64
     _2: string
   bb0:
-    stmt: use BindingId(104) val site=SiteId(723) ty=isize intent=Read
+    stmt: use BindingId(112) val site=SiteId(807) ty=isize intent=Read
     _1 = cast _0 isize -> i64
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(721)) ty=string
+    stmt: return site=Some(SiteId(805)) ty=string
     ret = move _2
     return
 
@@ -2069,11 +2355,11 @@ fn usize::fmt(usize) -> string [conv=default]
     _1: u64
     _2: string
   bb0:
-    stmt: use BindingId(105) val site=SiteId(727) ty=usize intent=Read
+    stmt: use BindingId(113) val site=SiteId(811) ty=usize intent=Read
     _1 = cast _0 usize -> u64
     _2 = call to_string_u64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(725)) ty=string
+    stmt: return site=Some(SiteId(809)) ty=string
     ret = move _2
     return
 
@@ -2082,10 +2368,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(106) val site=SiteId(730) ty=bool intent=Read
+    stmt: use BindingId(114) val site=SiteId(814) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(729)) ty=string
+    stmt: return site=Some(SiteId(813)) ty=string
     ret = move _1
     return
 
@@ -2094,10 +2380,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(107) val site=SiteId(733) ty=char intent=Read
+    stmt: use BindingId(115) val site=SiteId(817) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(732)) ty=string
+    stmt: return site=Some(SiteId(816)) ty=string
     ret = move _1
     return
 
@@ -2106,10 +2392,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(108) val site=SiteId(736) ty=f64 intent=Read
+    stmt: use BindingId(116) val site=SiteId(820) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(735)) ty=string
+    stmt: return site=Some(SiteId(819)) ty=string
     ret = move _1
     return
 
@@ -2119,11 +2405,11 @@ fn f32::fmt(f32) -> string [conv=default]
     _1: f64
     _2: string
   bb0:
-    stmt: use BindingId(109) val site=SiteId(740) ty=f32 intent=Read
+    stmt: use BindingId(117) val site=SiteId(824) ty=f32 intent=Read
     _1 = cast _0 f32 -> f64
     _2 = call to_string_f64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(738)) ty=string
+    stmt: return site=Some(SiteId(822)) ty=string
     ret = move _2
     return
 
@@ -2131,8 +2417,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(110) val site=SiteId(742) ty=string intent=Read
-    stmt: return site=Some(SiteId(742)) ty=string
+    stmt: use BindingId(118) val site=SiteId(826) ty=string intent=Read
+    stmt: return site=Some(SiteId(826)) ty=string
     ret = move _0
     return
 
@@ -2143,14 +2429,14 @@ fn duration::from_nanos(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(111) n site=SiteId(744) ty=i64 intent=Read
+    stmt: use BindingId(119) n site=SiteId(828) ty=i64 intent=Read
     _1 = const.duration 1ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(743)) ty=duration
+    stmt: return site=Some(SiteId(827)) ty=duration
     ret = move _2
     return
 
@@ -2161,14 +2447,14 @@ fn duration::from_micros(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(112) n site=SiteId(747) ty=i64 intent=Read
+    stmt: use BindingId(120) n site=SiteId(831) ty=i64 intent=Read
     _1 = const.duration 1000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(746)) ty=duration
+    stmt: return site=Some(SiteId(830)) ty=duration
     ret = move _2
     return
 
@@ -2179,14 +2465,14 @@ fn duration::from_millis(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(113) n site=SiteId(750) ty=i64 intent=Read
+    stmt: use BindingId(121) n site=SiteId(834) ty=i64 intent=Read
     _1 = const.duration 1000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(749)) ty=duration
+    stmt: return site=Some(SiteId(833)) ty=duration
     ret = move _2
     return
 
@@ -2197,14 +2483,14 @@ fn duration::from_secs(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(114) n site=SiteId(753) ty=i64 intent=Read
+    stmt: use BindingId(122) n site=SiteId(837) ty=i64 intent=Read
     _1 = const.duration 1000000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(752)) ty=duration
+    stmt: return site=Some(SiteId(836)) ty=duration
     ret = move _2
     return
 
@@ -2216,11 +2502,11 @@ fn duration::fmt(duration) -> string [conv=default]
     _3: string
     _4: string
   bb0:
-    stmt: use BindingId(115) val site=SiteId(758) ty=duration intent=Read
+    stmt: use BindingId(123) val site=SiteId(842) ty=duration intent=Read
     _1 = call_rt hew_duration_nanos(_0)
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(755)) ty=string
+    stmt: return site=Some(SiteId(839)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
     drop _2 ty=string fn=release(hew_string_drop)

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.elab.mir
@@ -982,75 +982,255 @@ fn fs$is_dir -> bool
 
 fn stream$pipe -> (Sink<string>, Stream<string>)
   statements:
-    use BindingId(71) capacity site=SiteId(530) ty=i64 intent=Read
-    bind BindingId(72) pair site=SiteId(528) ty=StreamPair
-    use BindingId(72) pair site=SiteId(533) ty=StreamPair intent=Read
-    bind BindingId(73) sink site=SiteId(532) ty=Sink<string>
-    use BindingId(72) pair site=SiteId(536) ty=StreamPair intent=Read
-    bind BindingId(74) input site=SiteId(535) ty=Stream<string>
-    use BindingId(72) pair site=SiteId(539) ty=StreamPair intent=Read
-    eval site=SiteId(538) ty=()
-    use BindingId(73) sink site=SiteId(542) ty=Sink<string> intent=Read
-    use BindingId(74) input site=SiteId(543) ty=Stream<string> intent=Read
-    agg_alias BindingId(73) sink site=SiteId(542) ty=Sink<string>
-    agg_alias BindingId(74) input site=SiteId(543) ty=Stream<string>
+    use BindingId(71) capacity site=SiteId(529) ty=i64 intent=Read
+    bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(528) ty=Result<(Sink<string>, Stream<string>), string>
     return site=Some(SiteId(527)) ty=(Sink<string>, Stream<string>)
-    drop BindingId(74) input ty=Stream<string>
-    drop BindingId(73) sink ty=Sink<string>
+    bind BindingId(72) pair site=SiteId(531) ty=(Sink<string>, Stream<string>)
+    use BindingId(72) pair site=SiteId(531) ty=(Sink<string>, Stream<string>) intent=Read
+    bind BindingId(73) err site=SiteId(532) ty=string
+    use BindingId(73) err site=SiteId(533) ty=string intent=Read
+    drop BindingId(73) err ty=string
+    drop BindingId(72) pair ty=(Sink<string>, Stream<string>)
+    drop BindingId(4294967231) __hew_call_scrutinee ty=Result<(Sink<string>, Stream<string>), string>
   drop_plans:
-    call[bb0 hew_stream_channel -> bb1] ->
+    call[bb0 stream$try_pipe -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    call[bb1 hew_stream_pair_sink -> bb2] ->
+    branch[bb1: bb3/bb6] ->
       (none)
-    call[bb2 hew_stream_pair_stream -> bb3] ->
+    return[bb2] ->
       (none)
-    call[bb3 hew_stream_pair_free -> bb4] ->
+    goto[bb3->bb2] ->
       (none)
-    return[bb4] ->
+    cancel[bb3] ->
+      (none)
+    call[bb4 panic -> bb7] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    branch[bb6: bb4/bb5] ->
+      (none)
+    goto[bb7->bb2] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+
+fn stream$try_pipe -> Result<(Sink<string>, Stream<string>), string>
+  statements:
+    use BindingId(74) capacity site=SiteId(536) ty=i64 intent=Read
+    use BindingId(74) capacity site=SiteId(541) ty=i64 intent=Read
+    eval site=SiteId(550) ty=()
+    use BindingId(74) capacity site=SiteId(554) ty=i64 intent=Read
+    return site=Some(SiteId(538)) ty=Result<(Sink<string>, Stream<string>), string>
+    bind BindingId(75) pair site=SiteId(552) ty=StreamPair
+    use BindingId(75) pair site=SiteId(558) ty=StreamPair intent=Read
+    eval site=SiteId(572) ty=()
+    use BindingId(75) pair site=SiteId(574) ty=StreamPair intent=Read
+    bind BindingId(76) detail site=SiteId(560) ty=string
+    use BindingId(76) detail site=SiteId(563) ty=string intent=Read
+    return site=Some(SiteId(565)) ty=Result<(Sink<string>, Stream<string>), string>
+    eval site=SiteId(568) ty=()
+    use BindingId(76) detail site=SiteId(570) ty=string intent=Read
+    agg_alias BindingId(76) detail site=SiteId(570) ty=string
+    return site=Some(SiteId(569)) ty=Result<(Sink<string>, Stream<string>), string>
+    bind BindingId(77) sink site=SiteId(573) ty=Sink<string>
+    use BindingId(75) pair site=SiteId(577) ty=StreamPair intent=Read
+    bind BindingId(78) input site=SiteId(576) ty=Stream<string>
+    use BindingId(75) pair site=SiteId(580) ty=StreamPair intent=Read
+    eval site=SiteId(579) ty=()
+    use BindingId(77) sink site=SiteId(584) ty=Sink<string> intent=Read
+    use BindingId(78) input site=SiteId(585) ty=Stream<string> intent=Read
+    agg_alias BindingId(77) sink site=SiteId(584) ty=Sink<string>
+    agg_alias BindingId(78) input site=SiteId(585) ty=Stream<string>
+    return site=Some(SiteId(551)) ty=Result<(Sink<string>, Stream<string>), string>
+    drop BindingId(78) input ty=Stream<string>
+    drop BindingId(77) sink ty=Sink<string>
+    drop BindingId(76) detail ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    call[bb3 hew_stream_channel -> bb8] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    return[bb6] ->
+      (none)
+    goto[bb7->bb3] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+    call[bb8 hew_stream_pair_is_valid -> bb9] ->
+      (none)
+    branch[bb9: bb10/bb11] ->
+      (none)
+    call[bb10 hew_stream_last_error -> bb13] ->
+      (none)
+    goto[bb11->bb12] ->
+      (none)
+    call[bb12 hew_stream_pair_sink -> bb19] ->
+      (none)
+    branch[bb13: bb14/bb15] ->
+      (none)
+    return[bb14] ->
+      (none)
+    goto[bb15->bb16] ->
+      (none)
+    return[bb16] ->
+      (none)
+    goto[bb17->bb16] ->
+      (none)
+    cancel[bb17] ->
+      (none)
+    goto[bb18->bb12] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    call[bb19 hew_stream_pair_stream -> bb20] ->
+      (none)
+    call[bb20 hew_stream_pair_free -> bb21] ->
+      (none)
+    return[bb21] ->
       (none)
 
 fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
   statements:
-    use BindingId(75) capacity site=SiteId(547) ty=i64 intent=Read
-    bind BindingId(76) pair site=SiteId(545) ty=StreamPair
-    use BindingId(76) pair site=SiteId(550) ty=StreamPair intent=Read
-    bind BindingId(77) sink site=SiteId(549) ty=Sink<bytes>
-    use BindingId(76) pair site=SiteId(553) ty=StreamPair intent=Read
-    bind BindingId(78) input site=SiteId(552) ty=Stream<bytes>
-    use BindingId(76) pair site=SiteId(556) ty=StreamPair intent=Read
-    eval site=SiteId(555) ty=()
-    use BindingId(77) sink site=SiteId(559) ty=Sink<bytes> intent=Read
-    use BindingId(78) input site=SiteId(560) ty=Stream<bytes> intent=Read
-    agg_alias BindingId(77) sink site=SiteId(559) ty=Sink<bytes>
-    agg_alias BindingId(78) input site=SiteId(560) ty=Stream<bytes>
-    return site=Some(SiteId(544)) ty=(Sink<bytes>, Stream<bytes>)
-    drop BindingId(78) input ty=Stream<bytes>
-    drop BindingId(77) sink ty=Sink<bytes>
+    use BindingId(79) capacity site=SiteId(588) ty=i64 intent=Read
+    bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(587) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    return site=Some(SiteId(586)) ty=(Sink<bytes>, Stream<bytes>)
+    bind BindingId(80) pair site=SiteId(590) ty=(Sink<bytes>, Stream<bytes>)
+    use BindingId(80) pair site=SiteId(590) ty=(Sink<bytes>, Stream<bytes>) intent=Read
+    bind BindingId(81) err site=SiteId(591) ty=string
+    use BindingId(81) err site=SiteId(592) ty=string intent=Read
+    drop BindingId(81) err ty=string
+    drop BindingId(80) pair ty=(Sink<bytes>, Stream<bytes>)
+    drop BindingId(4294967231) __hew_call_scrutinee ty=Result<(Sink<bytes>, Stream<bytes>), string>
   drop_plans:
-    call[bb0 hew_stream_channel -> bb1] ->
+    call[bb0 stream$try_bytes_pipe -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    call[bb1 hew_stream_pair_sink_bytes -> bb2] ->
+    branch[bb1: bb3/bb6] ->
       (none)
-    call[bb2 hew_stream_pair_stream_bytes -> bb3] ->
+    return[bb2] ->
       (none)
-    call[bb3 hew_stream_pair_free -> bb4] ->
+    goto[bb3->bb2] ->
       (none)
-    return[bb4] ->
+    cancel[bb3] ->
+      (none)
+    call[bb4 panic -> bb7] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    branch[bb6: bb4/bb5] ->
+      (none)
+    goto[bb7->bb2] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+
+fn stream$try_bytes_pipe -> Result<(Sink<bytes>, Stream<bytes>), string>
+  statements:
+    use BindingId(82) capacity site=SiteId(595) ty=i64 intent=Read
+    use BindingId(82) capacity site=SiteId(600) ty=i64 intent=Read
+    eval site=SiteId(609) ty=()
+    use BindingId(82) capacity site=SiteId(613) ty=i64 intent=Read
+    return site=Some(SiteId(597)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    bind BindingId(83) pair site=SiteId(611) ty=StreamPair
+    use BindingId(83) pair site=SiteId(617) ty=StreamPair intent=Read
+    eval site=SiteId(631) ty=()
+    use BindingId(83) pair site=SiteId(633) ty=StreamPair intent=Read
+    bind BindingId(84) detail site=SiteId(619) ty=string
+    use BindingId(84) detail site=SiteId(622) ty=string intent=Read
+    return site=Some(SiteId(624)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    eval site=SiteId(627) ty=()
+    use BindingId(84) detail site=SiteId(629) ty=string intent=Read
+    agg_alias BindingId(84) detail site=SiteId(629) ty=string
+    return site=Some(SiteId(628)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    bind BindingId(85) sink site=SiteId(632) ty=Sink<bytes>
+    use BindingId(83) pair site=SiteId(636) ty=StreamPair intent=Read
+    bind BindingId(86) input site=SiteId(635) ty=Stream<bytes>
+    use BindingId(83) pair site=SiteId(639) ty=StreamPair intent=Read
+    eval site=SiteId(638) ty=()
+    use BindingId(85) sink site=SiteId(643) ty=Sink<bytes> intent=Read
+    use BindingId(86) input site=SiteId(644) ty=Stream<bytes> intent=Read
+    agg_alias BindingId(85) sink site=SiteId(643) ty=Sink<bytes>
+    agg_alias BindingId(86) input site=SiteId(644) ty=Stream<bytes>
+    return site=Some(SiteId(610)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    drop BindingId(86) input ty=Stream<bytes>
+    drop BindingId(85) sink ty=Sink<bytes>
+    drop BindingId(84) detail ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    call[bb3 hew_stream_channel -> bb8] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    return[bb6] ->
+      (none)
+    goto[bb7->bb3] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+    call[bb8 hew_stream_pair_is_valid -> bb9] ->
+      (none)
+    branch[bb9: bb10/bb11] ->
+      (none)
+    call[bb10 hew_stream_last_error -> bb13] ->
+      (none)
+    goto[bb11->bb12] ->
+      (none)
+    call[bb12 hew_stream_pair_sink_bytes -> bb19] ->
+      (none)
+    branch[bb13: bb14/bb15] ->
+      (none)
+    return[bb14] ->
+      (none)
+    goto[bb15->bb16] ->
+      (none)
+    return[bb16] ->
+      (none)
+    goto[bb17->bb16] ->
+      (none)
+    cancel[bb17] ->
+      (none)
+    goto[bb18->bb12] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    call[bb19 hew_stream_pair_stream_bytes -> bb20] ->
+      (none)
+    call[bb20 hew_stream_pair_free -> bb21] ->
+      (none)
+    return[bb21] ->
       (none)
 
 fn stream$from_file -> Result<Stream<string>, string>
   statements:
-    use BindingId(79) path site=SiteId(563) ty=string intent=Read
-    bind BindingId(80) s site=SiteId(562) ty=Stream<string>
-    use BindingId(80) s site=SiteId(567) ty=Stream<string> intent=Read
-    use BindingId(80) s site=SiteId(571) ty=Stream<string> intent=Read
-    agg_alias BindingId(80) s site=SiteId(571) ty=Stream<string>
-    return site=Some(SiteId(561)) ty=Result<Stream<string>, string>
-    drop BindingId(80) s ty=Stream<string>
+    use BindingId(87) path site=SiteId(647) ty=string intent=Read
+    bind BindingId(88) s site=SiteId(646) ty=Stream<string>
+    use BindingId(88) s site=SiteId(651) ty=Stream<string> intent=Read
+    use BindingId(88) s site=SiteId(655) ty=Stream<string> intent=Read
+    agg_alias BindingId(88) s site=SiteId(655) ty=Stream<string>
+    return site=Some(SiteId(645)) ty=Result<Stream<string>, string>
+    drop BindingId(88) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1073,18 +1253,18 @@ fn stream$from_file -> Result<Stream<string>, string>
 
 fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
   statements:
-    use BindingId(81) path site=SiteId(578) ty=string intent=Read
-    bind BindingId(82) s site=SiteId(577) ty=Stream<string>
-    use BindingId(82) s site=SiteId(582) ty=Stream<string> intent=Read
-    use BindingId(82) s site=SiteId(586) ty=Stream<string> intent=Read
-    agg_alias BindingId(82) s site=SiteId(586) ty=Stream<string>
-    return site=Some(SiteId(576)) ty=Result<Stream<string>, fs.IoError>
-    bind BindingId(83) kind site=SiteId(588) ty=i64
-    bind BindingId(84) errno site=SiteId(591) ty=i32
-    eval site=SiteId(593) ty=string
-    use BindingId(83) kind site=SiteId(597) ty=i64 intent=Read
-    use BindingId(84) errno site=SiteId(599) ty=i32 intent=Read
-    drop BindingId(82) s ty=Stream<string>
+    use BindingId(89) path site=SiteId(662) ty=string intent=Read
+    bind BindingId(90) s site=SiteId(661) ty=Stream<string>
+    use BindingId(90) s site=SiteId(666) ty=Stream<string> intent=Read
+    use BindingId(90) s site=SiteId(670) ty=Stream<string> intent=Read
+    agg_alias BindingId(90) s site=SiteId(670) ty=Stream<string>
+    return site=Some(SiteId(660)) ty=Result<Stream<string>, fs.IoError>
+    bind BindingId(91) kind site=SiteId(672) ty=i64
+    bind BindingId(92) errno site=SiteId(675) ty=i32
+    eval site=SiteId(677) ty=string
+    use BindingId(91) kind site=SiteId(681) ty=i64 intent=Read
+    use BindingId(92) errno site=SiteId(683) ty=i32 intent=Read
+    drop BindingId(90) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1113,13 +1293,13 @@ fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
 
 fn stream$to_file -> Result<Sink<string>, string>
   statements:
-    use BindingId(85) path site=SiteId(603) ty=string intent=Read
-    bind BindingId(86) s site=SiteId(602) ty=Sink<string>
-    use BindingId(86) s site=SiteId(607) ty=Sink<string> intent=Read
-    use BindingId(86) s site=SiteId(611) ty=Sink<string> intent=Read
-    agg_alias BindingId(86) s site=SiteId(611) ty=Sink<string>
-    return site=Some(SiteId(601)) ty=Result<Sink<string>, string>
-    drop BindingId(86) s ty=Sink<string>
+    use BindingId(93) path site=SiteId(687) ty=string intent=Read
+    bind BindingId(94) s site=SiteId(686) ty=Sink<string>
+    use BindingId(94) s site=SiteId(691) ty=Sink<string> intent=Read
+    use BindingId(94) s site=SiteId(695) ty=Sink<string> intent=Read
+    agg_alias BindingId(94) s site=SiteId(695) ty=Sink<string>
+    return site=Some(SiteId(685)) ty=Result<Sink<string>, string>
+    drop BindingId(94) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1142,18 +1322,18 @@ fn stream$to_file -> Result<Sink<string>, string>
 
 fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
   statements:
-    use BindingId(87) path site=SiteId(618) ty=string intent=Read
-    bind BindingId(88) s site=SiteId(617) ty=Sink<string>
-    use BindingId(88) s site=SiteId(622) ty=Sink<string> intent=Read
-    use BindingId(88) s site=SiteId(626) ty=Sink<string> intent=Read
-    agg_alias BindingId(88) s site=SiteId(626) ty=Sink<string>
-    return site=Some(SiteId(616)) ty=Result<Sink<string>, fs.IoError>
-    bind BindingId(89) kind site=SiteId(628) ty=i64
-    bind BindingId(90) errno site=SiteId(631) ty=i32
-    eval site=SiteId(633) ty=string
-    use BindingId(89) kind site=SiteId(637) ty=i64 intent=Read
-    use BindingId(90) errno site=SiteId(639) ty=i32 intent=Read
-    drop BindingId(88) s ty=Sink<string>
+    use BindingId(95) path site=SiteId(702) ty=string intent=Read
+    bind BindingId(96) s site=SiteId(701) ty=Sink<string>
+    use BindingId(96) s site=SiteId(706) ty=Sink<string> intent=Read
+    use BindingId(96) s site=SiteId(710) ty=Sink<string> intent=Read
+    agg_alias BindingId(96) s site=SiteId(710) ty=Sink<string>
+    return site=Some(SiteId(700)) ty=Result<Sink<string>, fs.IoError>
+    bind BindingId(97) kind site=SiteId(712) ty=i64
+    bind BindingId(98) errno site=SiteId(715) ty=i32
+    eval site=SiteId(717) ty=string
+    use BindingId(97) kind site=SiteId(721) ty=i64 intent=Read
+    use BindingId(98) errno site=SiteId(723) ty=i32 intent=Read
+    drop BindingId(96) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1182,9 +1362,9 @@ fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
 
 fn stream$forward -> ()
   statements:
-    use BindingId(91) source site=SiteId(643) ty=Stream<string> intent=Read
-    use BindingId(92) dest site=SiteId(644) ty=Sink<string> intent=Read
-    eval site=SiteId(641) ty=()
+    use BindingId(99) source site=SiteId(727) ty=Stream<string> intent=Read
+    use BindingId(100) dest site=SiteId(728) ty=Sink<string> intent=Read
+    eval site=SiteId(725) ty=()
   drop_plans:
     call[bb0 hew_stream_pipe -> bb1] ->
       (none)
@@ -1195,8 +1375,8 @@ fn stream$forward -> ()
 
 fn i8::fmt -> string
   statements:
-    use BindingId(101) val site=SiteId(716) ty=i8 intent=Read
-    return site=Some(SiteId(714)) ty=string
+    use BindingId(109) val site=SiteId(800) ty=i8 intent=Read
+    return site=Some(SiteId(798)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1207,8 +1387,8 @@ fn i8::fmt -> string
 
 fn i16::fmt -> string
   statements:
-    use BindingId(102) val site=SiteId(720) ty=i16 intent=Read
-    return site=Some(SiteId(718)) ty=string
+    use BindingId(110) val site=SiteId(804) ty=i16 intent=Read
+    return site=Some(SiteId(802)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1219,8 +1399,8 @@ fn i16::fmt -> string
 
 fn i32::fmt -> string
   statements:
-    use BindingId(103) val site=SiteId(723) ty=i32 intent=Read
-    return site=Some(SiteId(722)) ty=string
+    use BindingId(111) val site=SiteId(807) ty=i32 intent=Read
+    return site=Some(SiteId(806)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1231,8 +1411,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(104) val site=SiteId(726) ty=i64 intent=Read
-    return site=Some(SiteId(725)) ty=string
+    use BindingId(112) val site=SiteId(810) ty=i64 intent=Read
+    return site=Some(SiteId(809)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1243,8 +1423,8 @@ fn i64::fmt -> string
 
 fn u8::fmt -> string
   statements:
-    use BindingId(105) val site=SiteId(729) ty=u8 intent=Read
-    return site=Some(SiteId(728)) ty=string
+    use BindingId(113) val site=SiteId(813) ty=u8 intent=Read
+    return site=Some(SiteId(812)) ty=string
   drop_plans:
     call[bb0 to_string_u8 -> bb1] ->
       (none)
@@ -1255,8 +1435,8 @@ fn u8::fmt -> string
 
 fn u16::fmt -> string
   statements:
-    use BindingId(106) val site=SiteId(732) ty=u16 intent=Read
-    return site=Some(SiteId(731)) ty=string
+    use BindingId(114) val site=SiteId(816) ty=u16 intent=Read
+    return site=Some(SiteId(815)) ty=string
   drop_plans:
     call[bb0 to_string_u16 -> bb1] ->
       (none)
@@ -1267,8 +1447,8 @@ fn u16::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(107) val site=SiteId(735) ty=u32 intent=Read
-    return site=Some(SiteId(734)) ty=string
+    use BindingId(115) val site=SiteId(819) ty=u32 intent=Read
+    return site=Some(SiteId(818)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -1279,8 +1459,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(108) val site=SiteId(738) ty=u64 intent=Read
-    return site=Some(SiteId(737)) ty=string
+    use BindingId(116) val site=SiteId(822) ty=u64 intent=Read
+    return site=Some(SiteId(821)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1291,8 +1471,8 @@ fn u64::fmt -> string
 
 fn isize::fmt -> string
   statements:
-    use BindingId(109) val site=SiteId(742) ty=isize intent=Read
-    return site=Some(SiteId(740)) ty=string
+    use BindingId(117) val site=SiteId(826) ty=isize intent=Read
+    return site=Some(SiteId(824)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1303,8 +1483,8 @@ fn isize::fmt -> string
 
 fn usize::fmt -> string
   statements:
-    use BindingId(110) val site=SiteId(746) ty=usize intent=Read
-    return site=Some(SiteId(744)) ty=string
+    use BindingId(118) val site=SiteId(830) ty=usize intent=Read
+    return site=Some(SiteId(828)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1315,8 +1495,8 @@ fn usize::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(111) val site=SiteId(749) ty=bool intent=Read
-    return site=Some(SiteId(748)) ty=string
+    use BindingId(119) val site=SiteId(833) ty=bool intent=Read
+    return site=Some(SiteId(832)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -1327,8 +1507,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(112) val site=SiteId(752) ty=char intent=Read
-    return site=Some(SiteId(751)) ty=string
+    use BindingId(120) val site=SiteId(836) ty=char intent=Read
+    return site=Some(SiteId(835)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -1339,8 +1519,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(113) val site=SiteId(755) ty=f64 intent=Read
-    return site=Some(SiteId(754)) ty=string
+    use BindingId(121) val site=SiteId(839) ty=f64 intent=Read
+    return site=Some(SiteId(838)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1351,8 +1531,8 @@ fn f64::fmt -> string
 
 fn f32::fmt -> string
   statements:
-    use BindingId(114) val site=SiteId(759) ty=f32 intent=Read
-    return site=Some(SiteId(757)) ty=string
+    use BindingId(122) val site=SiteId(843) ty=f32 intent=Read
+    return site=Some(SiteId(841)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1363,16 +1543,16 @@ fn f32::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(115) val site=SiteId(761) ty=string intent=Read
-    return site=Some(SiteId(761)) ty=string
+    use BindingId(123) val site=SiteId(845) ty=string intent=Read
+    return site=Some(SiteId(845)) ty=string
   drop_plans:
     return[bb0] ->
       (none)
 
 fn duration::from_nanos -> duration
   statements:
-    use BindingId(116) n site=SiteId(763) ty=i64 intent=Read
-    return site=Some(SiteId(762)) ty=duration
+    use BindingId(124) n site=SiteId(847) ty=i64 intent=Read
+    return site=Some(SiteId(846)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1383,8 +1563,8 @@ fn duration::from_nanos -> duration
 
 fn duration::from_micros -> duration
   statements:
-    use BindingId(117) n site=SiteId(766) ty=i64 intent=Read
-    return site=Some(SiteId(765)) ty=duration
+    use BindingId(125) n site=SiteId(850) ty=i64 intent=Read
+    return site=Some(SiteId(849)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1395,8 +1575,8 @@ fn duration::from_micros -> duration
 
 fn duration::from_millis -> duration
   statements:
-    use BindingId(118) n site=SiteId(769) ty=i64 intent=Read
-    return site=Some(SiteId(768)) ty=duration
+    use BindingId(126) n site=SiteId(853) ty=i64 intent=Read
+    return site=Some(SiteId(852)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1407,8 +1587,8 @@ fn duration::from_millis -> duration
 
 fn duration::from_secs -> duration
   statements:
-    use BindingId(119) n site=SiteId(772) ty=i64 intent=Read
-    return site=Some(SiteId(771)) ty=duration
+    use BindingId(127) n site=SiteId(856) ty=i64 intent=Read
+    return site=Some(SiteId(855)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1419,8 +1599,8 @@ fn duration::from_secs -> duration
 
 fn duration::fmt -> string
   statements:
-    use BindingId(120) val site=SiteId(777) ty=duration intent=Read
-    return site=Some(SiteId(774)) ty=string
+    use BindingId(128) val site=SiteId(861) ty=duration intent=Read
+    return site=Some(SiteId(858)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -1674,87 +1674,373 @@ fn fs$is_dir(string) -> bool [conv=default]
 fn stream$pipe(i64) -> (Sink<string>, Stream<string>) [conv=default]
   locals:
     _0: i64
-    _1: i64
-    _2: StreamPair
-    _3: StreamPair
-    _4: Sink<string>
-    _5: Sink<string>
-    _6: Stream<string>
-    _7: Stream<string>
+    _1: (Sink<string>, Stream<string>)
+    _2: Result<(Sink<string>, Stream<string>), string>
+    _3: i64
+    _4: i64
+    _5: bool
+    _6: i64
+    _7: bool
     _8: (Sink<string>, Stream<string>)
-    _9: (Sink<string>, Stream<string>)
+    _9: string
   bb0:
-    stmt: use BindingId(71) capacity site=SiteId(530) ty=i64 intent=Read
-    _1 = cast _0 i64 -> i64
-    _2 = call hew_stream_channel(_1) -> bb1
+    stmt: use BindingId(71) capacity site=SiteId(529) ty=i64 intent=Read
+    _2 = call stream$try_pipe(_0) -> bb1
   bb1:
-    stmt: bind BindingId(72) pair site=SiteId(528) ty=StreamPair
-    stmt: use BindingId(72) pair site=SiteId(533) ty=StreamPair intent=Read
-    _3 = move _2
-    _4 = call hew_stream_pair_sink(_3) -> bb2
+    stmt: bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(528) ty=Result<(Sink<string>, Stream<string>), string>
+    _3 = move etag2
+    _4 = const.i64 0
+    _5 = icmp.eq _3 _4
+    branch _5 ? bb3 : bb6
   bb2:
-    stmt: bind BindingId(73) sink site=SiteId(532) ty=Sink<string>
-    stmt: use BindingId(72) pair site=SiteId(536) ty=StreamPair intent=Read
-    _5 = move _4
-    _6 = call hew_stream_pair_stream(_3) -> bb3
-  bb3:
-    stmt: bind BindingId(74) input site=SiteId(535) ty=Stream<string>
-    stmt: use BindingId(72) pair site=SiteId(539) ty=StreamPair intent=Read
-    _7 = move _6
-    call hew_stream_pair_free(_3) -> bb4
-  bb4:
-    stmt: eval site=SiteId(538) ty=()
-    stmt: use BindingId(73) sink site=SiteId(542) ty=Sink<string> intent=Read
-    stmt: use BindingId(74) input site=SiteId(543) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(73) sink site=SiteId(542) ty=Sink<string>
-    stmt: agg_alias BindingId(74) input site=SiteId(543) ty=Stream<string>
     stmt: return site=Some(SiteId(527)) ty=(Sink<string>, Stream<string>)
-    _8 = tuple (_5, _7)
-    _9 = move _8
-    ret = move _9
+    ret = move _1
+    return
+  bb3:
+    stmt: bind BindingId(72) pair site=SiteId(531) ty=(Sink<string>, Stream<string>)
+    stmt: use BindingId(72) pair site=SiteId(531) ty=(Sink<string>, Stream<string>) intent=Read
+    _8 = move mvar2.0.0
+    _1 = move _8
+    goto bb2
+  bb4:
+    stmt: bind BindingId(73) err site=SiteId(532) ty=string
+    stmt: use BindingId(73) err site=SiteId(533) ty=string intent=Read
+    _9 = move mvar2.1.0
+    call panic(_9) -> bb7
+  bb5:
+    trap(ExhaustivenessFallthrough)
+  bb6:
+    _6 = const.i64 1
+    _7 = icmp.eq _3 _6
+    branch _7 ? bb4 : bb5
+  bb7:
+    goto bb2
+
+fn stream$try_pipe(i64) -> Result<(Sink<string>, Stream<string>), string> [conv=default]
+  locals:
+    _0: i64
+    _1: ()
+    _2: i64
+    _3: bool
+    _4: Result<(Sink<string>, Stream<string>), string>
+    _5: i64
+    _6: string
+    _7: string
+    _8: string
+    _9: string
+    _10: string
+    _11: i64
+    _12: StreamPair
+    _13: StreamPair
+    _14: ()
+    _15: bool
+    _16: bool
+    _17: string
+    _18: string
+    _19: ()
+    _20: string
+    _21: bool
+    _22: Result<(Sink<string>, Stream<string>), string>
+    _23: i64
+    _24: string
+    _25: Result<(Sink<string>, Stream<string>), string>
+    _26: i64
+    _27: Sink<string>
+    _28: Sink<string>
+    _29: Stream<string>
+    _30: Stream<string>
+    _31: Result<(Sink<string>, Stream<string>), string>
+    _32: i64
+    _33: (Sink<string>, Stream<string>)
+    _34: Result<(Sink<string>, Stream<string>), string>
+  bb0:
+    stmt: use BindingId(74) capacity site=SiteId(536) ty=i64 intent=Read
+    _2 = const.i64 0
+    _3 = icmp.slt _0 _2
+    branch _3 ? bb1 : bb2
+  bb1:
+    stmt: use BindingId(74) capacity site=SiteId(541) ty=i64 intent=Read
+    _5 = const.i64 1
+    mtag4 = move _5
+    _6 = string_lit "stream.pipe: invalid capacity "
+    _7 = call to_string_i64(_0) -> bb4
+  bb2:
+    goto bb3
+  bb3:
+    stmt: eval site=SiteId(550) ty=()
+    stmt: use BindingId(74) capacity site=SiteId(554) ty=i64 intent=Read
+    _11 = cast _0 i64 -> i64
+    _12 = call hew_stream_channel(_11) -> bb8
+  bb4:
+    _8 = call string_concat(_6, _7) -> bb5
+  bb5:
+    drop _7 ty=string fn=release(hew_string_drop)
+    _9 = string_lit " (must be >= 0)"
+    _10 = call string_concat(_8, _9) -> bb6
+  bb6:
+    stmt: return site=Some(SiteId(538)) ty=Result<(Sink<string>, Stream<string>), string>
+    drop _8 ty=string fn=release(hew_string_drop)
+    mvar4.1.0 = move _10
+    ret = move _4
+    return
+  bb7:
+    goto bb3
+  bb8:
+    stmt: bind BindingId(75) pair site=SiteId(552) ty=StreamPair
+    stmt: use BindingId(75) pair site=SiteId(558) ty=StreamPair intent=Read
+    _13 = move _12
+    _15 = call hew_stream_pair_is_valid(_13) -> bb9
+  bb9:
+    _16 = not _15
+    branch _16 ? bb10 : bb11
+  bb10:
+    _17 = call hew_stream_last_error() -> bb13
+  bb11:
+    goto bb12
+  bb12:
+    stmt: eval site=SiteId(572) ty=()
+    stmt: use BindingId(75) pair site=SiteId(574) ty=StreamPair intent=Read
+    _27 = call hew_stream_pair_sink(_13) -> bb19
+  bb13:
+    stmt: bind BindingId(76) detail site=SiteId(560) ty=string
+    stmt: use BindingId(76) detail site=SiteId(563) ty=string intent=Read
+    _18 = move _17
+    _20 = string_lit ""
+    _21 = icmp.eq _18 _20
+    branch _21 ? bb14 : bb15
+  bb14:
+    stmt: return site=Some(SiteId(565)) ty=Result<(Sink<string>, Stream<string>), string>
+    _23 = const.i64 1
+    mtag22 = move _23
+    _24 = string_lit "stream.pipe: stream allocation failed"
+    mvar22.1.0 = move _24
+    ret = move _22
+    return
+  bb15:
+    goto bb16
+  bb16:
+    stmt: eval site=SiteId(568) ty=()
+    stmt: use BindingId(76) detail site=SiteId(570) ty=string intent=Read
+    stmt: agg_alias BindingId(76) detail site=SiteId(570) ty=string
+    stmt: return site=Some(SiteId(569)) ty=Result<(Sink<string>, Stream<string>), string>
+    _26 = const.i64 1
+    mtag25 = move _26
+    mvar25.1.0 = move _18
+    ret = move _25
+    return
+  bb17:
+    goto bb16
+  bb18:
+    goto bb12
+  bb19:
+    stmt: bind BindingId(77) sink site=SiteId(573) ty=Sink<string>
+    stmt: use BindingId(75) pair site=SiteId(577) ty=StreamPair intent=Read
+    _28 = move _27
+    _29 = call hew_stream_pair_stream(_13) -> bb20
+  bb20:
+    stmt: bind BindingId(78) input site=SiteId(576) ty=Stream<string>
+    stmt: use BindingId(75) pair site=SiteId(580) ty=StreamPair intent=Read
+    _30 = move _29
+    call hew_stream_pair_free(_13) -> bb21
+  bb21:
+    stmt: eval site=SiteId(579) ty=()
+    stmt: use BindingId(77) sink site=SiteId(584) ty=Sink<string> intent=Read
+    stmt: use BindingId(78) input site=SiteId(585) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(77) sink site=SiteId(584) ty=Sink<string>
+    stmt: agg_alias BindingId(78) input site=SiteId(585) ty=Stream<string>
+    stmt: return site=Some(SiteId(551)) ty=Result<(Sink<string>, Stream<string>), string>
+    _32 = const.i64 0
+    mtag31 = move _32
+    _33 = tuple (_28, _30)
+    mvar31.0.0 = move _33
+    _34 = move _31
+    ret = move _34
     return
 
 fn stream$bytes_pipe(i64) -> (Sink<bytes>, Stream<bytes>) [conv=default]
   locals:
     _0: i64
-    _1: i64
-    _2: StreamPair
-    _3: StreamPair
-    _4: Sink<bytes>
-    _5: Sink<bytes>
-    _6: Stream<bytes>
-    _7: Stream<bytes>
+    _1: (Sink<bytes>, Stream<bytes>)
+    _2: Result<(Sink<bytes>, Stream<bytes>), string>
+    _3: i64
+    _4: i64
+    _5: bool
+    _6: i64
+    _7: bool
     _8: (Sink<bytes>, Stream<bytes>)
-    _9: (Sink<bytes>, Stream<bytes>)
+    _9: string
   bb0:
-    stmt: use BindingId(75) capacity site=SiteId(547) ty=i64 intent=Read
-    _1 = cast _0 i64 -> i64
-    _2 = call hew_stream_channel(_1) -> bb1
+    stmt: use BindingId(79) capacity site=SiteId(588) ty=i64 intent=Read
+    _2 = call stream$try_bytes_pipe(_0) -> bb1
   bb1:
-    stmt: bind BindingId(76) pair site=SiteId(545) ty=StreamPair
-    stmt: use BindingId(76) pair site=SiteId(550) ty=StreamPair intent=Read
-    _3 = move _2
-    _4 = call hew_stream_pair_sink_bytes(_3) -> bb2
+    stmt: bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(587) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    _3 = move etag2
+    _4 = const.i64 0
+    _5 = icmp.eq _3 _4
+    branch _5 ? bb3 : bb6
   bb2:
-    stmt: bind BindingId(77) sink site=SiteId(549) ty=Sink<bytes>
-    stmt: use BindingId(76) pair site=SiteId(553) ty=StreamPair intent=Read
-    _5 = move _4
-    _6 = call hew_stream_pair_stream_bytes(_3) -> bb3
+    stmt: return site=Some(SiteId(586)) ty=(Sink<bytes>, Stream<bytes>)
+    ret = move _1
+    return
   bb3:
-    stmt: bind BindingId(78) input site=SiteId(552) ty=Stream<bytes>
-    stmt: use BindingId(76) pair site=SiteId(556) ty=StreamPair intent=Read
-    _7 = move _6
-    call hew_stream_pair_free(_3) -> bb4
+    stmt: bind BindingId(80) pair site=SiteId(590) ty=(Sink<bytes>, Stream<bytes>)
+    stmt: use BindingId(80) pair site=SiteId(590) ty=(Sink<bytes>, Stream<bytes>) intent=Read
+    _8 = move mvar2.0.0
+    _1 = move _8
+    goto bb2
   bb4:
-    stmt: eval site=SiteId(555) ty=()
-    stmt: use BindingId(77) sink site=SiteId(559) ty=Sink<bytes> intent=Read
-    stmt: use BindingId(78) input site=SiteId(560) ty=Stream<bytes> intent=Read
-    stmt: agg_alias BindingId(77) sink site=SiteId(559) ty=Sink<bytes>
-    stmt: agg_alias BindingId(78) input site=SiteId(560) ty=Stream<bytes>
-    stmt: return site=Some(SiteId(544)) ty=(Sink<bytes>, Stream<bytes>)
-    _8 = tuple (_5, _7)
-    _9 = move _8
-    ret = move _9
+    stmt: bind BindingId(81) err site=SiteId(591) ty=string
+    stmt: use BindingId(81) err site=SiteId(592) ty=string intent=Read
+    _9 = move mvar2.1.0
+    call panic(_9) -> bb7
+  bb5:
+    trap(ExhaustivenessFallthrough)
+  bb6:
+    _6 = const.i64 1
+    _7 = icmp.eq _3 _6
+    branch _7 ? bb4 : bb5
+  bb7:
+    goto bb2
+
+fn stream$try_bytes_pipe(i64) -> Result<(Sink<bytes>, Stream<bytes>), string> [conv=default]
+  locals:
+    _0: i64
+    _1: ()
+    _2: i64
+    _3: bool
+    _4: Result<(Sink<bytes>, Stream<bytes>), string>
+    _5: i64
+    _6: string
+    _7: string
+    _8: string
+    _9: string
+    _10: string
+    _11: i64
+    _12: StreamPair
+    _13: StreamPair
+    _14: ()
+    _15: bool
+    _16: bool
+    _17: string
+    _18: string
+    _19: ()
+    _20: string
+    _21: bool
+    _22: Result<(Sink<bytes>, Stream<bytes>), string>
+    _23: i64
+    _24: string
+    _25: Result<(Sink<bytes>, Stream<bytes>), string>
+    _26: i64
+    _27: Sink<bytes>
+    _28: Sink<bytes>
+    _29: Stream<bytes>
+    _30: Stream<bytes>
+    _31: Result<(Sink<bytes>, Stream<bytes>), string>
+    _32: i64
+    _33: (Sink<bytes>, Stream<bytes>)
+    _34: Result<(Sink<bytes>, Stream<bytes>), string>
+  bb0:
+    stmt: use BindingId(82) capacity site=SiteId(595) ty=i64 intent=Read
+    _2 = const.i64 0
+    _3 = icmp.slt _0 _2
+    branch _3 ? bb1 : bb2
+  bb1:
+    stmt: use BindingId(82) capacity site=SiteId(600) ty=i64 intent=Read
+    _5 = const.i64 1
+    mtag4 = move _5
+    _6 = string_lit "stream.bytes_pipe: invalid capacity "
+    _7 = call to_string_i64(_0) -> bb4
+  bb2:
+    goto bb3
+  bb3:
+    stmt: eval site=SiteId(609) ty=()
+    stmt: use BindingId(82) capacity site=SiteId(613) ty=i64 intent=Read
+    _11 = cast _0 i64 -> i64
+    _12 = call hew_stream_channel(_11) -> bb8
+  bb4:
+    _8 = call string_concat(_6, _7) -> bb5
+  bb5:
+    drop _7 ty=string fn=release(hew_string_drop)
+    _9 = string_lit " (must be >= 0)"
+    _10 = call string_concat(_8, _9) -> bb6
+  bb6:
+    stmt: return site=Some(SiteId(597)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    drop _8 ty=string fn=release(hew_string_drop)
+    mvar4.1.0 = move _10
+    ret = move _4
+    return
+  bb7:
+    goto bb3
+  bb8:
+    stmt: bind BindingId(83) pair site=SiteId(611) ty=StreamPair
+    stmt: use BindingId(83) pair site=SiteId(617) ty=StreamPair intent=Read
+    _13 = move _12
+    _15 = call hew_stream_pair_is_valid(_13) -> bb9
+  bb9:
+    _16 = not _15
+    branch _16 ? bb10 : bb11
+  bb10:
+    _17 = call hew_stream_last_error() -> bb13
+  bb11:
+    goto bb12
+  bb12:
+    stmt: eval site=SiteId(631) ty=()
+    stmt: use BindingId(83) pair site=SiteId(633) ty=StreamPair intent=Read
+    _27 = call hew_stream_pair_sink_bytes(_13) -> bb19
+  bb13:
+    stmt: bind BindingId(84) detail site=SiteId(619) ty=string
+    stmt: use BindingId(84) detail site=SiteId(622) ty=string intent=Read
+    _18 = move _17
+    _20 = string_lit ""
+    _21 = icmp.eq _18 _20
+    branch _21 ? bb14 : bb15
+  bb14:
+    stmt: return site=Some(SiteId(624)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    _23 = const.i64 1
+    mtag22 = move _23
+    _24 = string_lit "stream.bytes_pipe: stream allocation failed"
+    mvar22.1.0 = move _24
+    ret = move _22
+    return
+  bb15:
+    goto bb16
+  bb16:
+    stmt: eval site=SiteId(627) ty=()
+    stmt: use BindingId(84) detail site=SiteId(629) ty=string intent=Read
+    stmt: agg_alias BindingId(84) detail site=SiteId(629) ty=string
+    stmt: return site=Some(SiteId(628)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    _26 = const.i64 1
+    mtag25 = move _26
+    mvar25.1.0 = move _18
+    ret = move _25
+    return
+  bb17:
+    goto bb16
+  bb18:
+    goto bb12
+  bb19:
+    stmt: bind BindingId(85) sink site=SiteId(632) ty=Sink<bytes>
+    stmt: use BindingId(83) pair site=SiteId(636) ty=StreamPair intent=Read
+    _28 = move _27
+    _29 = call hew_stream_pair_stream_bytes(_13) -> bb20
+  bb20:
+    stmt: bind BindingId(86) input site=SiteId(635) ty=Stream<bytes>
+    stmt: use BindingId(83) pair site=SiteId(639) ty=StreamPair intent=Read
+    _30 = move _29
+    call hew_stream_pair_free(_13) -> bb21
+  bb21:
+    stmt: eval site=SiteId(638) ty=()
+    stmt: use BindingId(85) sink site=SiteId(643) ty=Sink<bytes> intent=Read
+    stmt: use BindingId(86) input site=SiteId(644) ty=Stream<bytes> intent=Read
+    stmt: agg_alias BindingId(85) sink site=SiteId(643) ty=Sink<bytes>
+    stmt: agg_alias BindingId(86) input site=SiteId(644) ty=Stream<bytes>
+    stmt: return site=Some(SiteId(610)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    _32 = const.i64 0
+    mtag31 = move _32
+    _33 = tuple (_28, _30)
+    mvar31.0.0 = move _33
+    _34 = move _31
+    ret = move _34
     return
 
 fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
@@ -1773,18 +2059,18 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     _11: Result<Stream<string>, string>
     _12: Result<Stream<string>, string>
   bb0:
-    stmt: use BindingId(79) path site=SiteId(563) ty=string intent=Read
+    stmt: use BindingId(87) path site=SiteId(647) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(80) s site=SiteId(562) ty=Stream<string>
-    stmt: use BindingId(80) s site=SiteId(567) ty=Stream<string> intent=Read
+    stmt: bind BindingId(88) s site=SiteId(646) ty=Stream<string>
+    stmt: use BindingId(88) s site=SiteId(651) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(80) s site=SiteId(571) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(80) s site=SiteId(571) ty=Stream<string>
+    stmt: use BindingId(88) s site=SiteId(655) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(88) s site=SiteId(655) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -1796,7 +2082,7 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(561)) ty=Result<Stream<string>, string>
+    stmt: return site=Some(SiteId(645)) ty=Result<Stream<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -1829,18 +2115,18 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _18: Result<Stream<string>, fs.IoError>
     _19: Result<Stream<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(81) path site=SiteId(578) ty=string intent=Read
+    stmt: use BindingId(89) path site=SiteId(662) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(82) s site=SiteId(577) ty=Stream<string>
-    stmt: use BindingId(82) s site=SiteId(582) ty=Stream<string> intent=Read
+    stmt: bind BindingId(90) s site=SiteId(661) ty=Stream<string>
+    stmt: use BindingId(90) s site=SiteId(666) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(82) s site=SiteId(586) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(82) s site=SiteId(586) ty=Stream<string>
+    stmt: use BindingId(90) s site=SiteId(670) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(90) s site=SiteId(670) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -1850,23 +2136,23 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
   bb4:
     _8 = call hew_stream_last_error_kind() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(576)) ty=Result<Stream<string>, fs.IoError>
+    stmt: return site=Some(SiteId(660)) ty=Result<Stream<string>, fs.IoError>
     _19 = move _3
     ret = move _19
     return
   bb6:
-    stmt: bind BindingId(83) kind site=SiteId(588) ty=i64
+    stmt: bind BindingId(91) kind site=SiteId(672) ty=i64
     _9 = cast _8 i32 -> i64
     _10 = move _9
     _11 = call hew_stream_last_errno() -> bb7
   bb7:
-    stmt: bind BindingId(84) errno site=SiteId(591) ty=i32
+    stmt: bind BindingId(92) errno site=SiteId(675) ty=i32
     _12 = move _11
     _13 = call hew_stream_last_error() -> bb8
   bb8:
-    stmt: eval site=SiteId(593) ty=string
-    stmt: use BindingId(83) kind site=SiteId(597) ty=i64 intent=Read
-    stmt: use BindingId(84) errno site=SiteId(599) ty=i32 intent=Read
+    stmt: eval site=SiteId(677) ty=string
+    stmt: use BindingId(91) kind site=SiteId(681) ty=i64 intent=Read
+    stmt: use BindingId(92) errno site=SiteId(683) ty=i32 intent=Read
     _15 = const.i64 1
     mtag14 = move _15
     _16 = cast _12 i32 -> i64
@@ -1893,18 +2179,18 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     _11: Result<Sink<string>, string>
     _12: Result<Sink<string>, string>
   bb0:
-    stmt: use BindingId(85) path site=SiteId(603) ty=string intent=Read
+    stmt: use BindingId(93) path site=SiteId(687) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(86) s site=SiteId(602) ty=Sink<string>
-    stmt: use BindingId(86) s site=SiteId(607) ty=Sink<string> intent=Read
+    stmt: bind BindingId(94) s site=SiteId(686) ty=Sink<string>
+    stmt: use BindingId(94) s site=SiteId(691) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(86) s site=SiteId(611) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(86) s site=SiteId(611) ty=Sink<string>
+    stmt: use BindingId(94) s site=SiteId(695) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(94) s site=SiteId(695) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -1916,7 +2202,7 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(601)) ty=Result<Sink<string>, string>
+    stmt: return site=Some(SiteId(685)) ty=Result<Sink<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -1949,18 +2235,18 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _18: Result<Sink<string>, fs.IoError>
     _19: Result<Sink<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(87) path site=SiteId(618) ty=string intent=Read
+    stmt: use BindingId(95) path site=SiteId(702) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(88) s site=SiteId(617) ty=Sink<string>
-    stmt: use BindingId(88) s site=SiteId(622) ty=Sink<string> intent=Read
+    stmt: bind BindingId(96) s site=SiteId(701) ty=Sink<string>
+    stmt: use BindingId(96) s site=SiteId(706) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(88) s site=SiteId(626) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(88) s site=SiteId(626) ty=Sink<string>
+    stmt: use BindingId(96) s site=SiteId(710) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(96) s site=SiteId(710) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -1970,23 +2256,23 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
   bb4:
     _8 = call hew_stream_last_error_kind() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(616)) ty=Result<Sink<string>, fs.IoError>
+    stmt: return site=Some(SiteId(700)) ty=Result<Sink<string>, fs.IoError>
     _19 = move _3
     ret = move _19
     return
   bb6:
-    stmt: bind BindingId(89) kind site=SiteId(628) ty=i64
+    stmt: bind BindingId(97) kind site=SiteId(712) ty=i64
     _9 = cast _8 i32 -> i64
     _10 = move _9
     _11 = call hew_stream_last_errno() -> bb7
   bb7:
-    stmt: bind BindingId(90) errno site=SiteId(631) ty=i32
+    stmt: bind BindingId(98) errno site=SiteId(715) ty=i32
     _12 = move _11
     _13 = call hew_stream_last_error() -> bb8
   bb8:
-    stmt: eval site=SiteId(633) ty=string
-    stmt: use BindingId(89) kind site=SiteId(637) ty=i64 intent=Read
-    stmt: use BindingId(90) errno site=SiteId(639) ty=i32 intent=Read
+    stmt: eval site=SiteId(717) ty=string
+    stmt: use BindingId(97) kind site=SiteId(721) ty=i64 intent=Read
+    stmt: use BindingId(98) errno site=SiteId(723) ty=i32 intent=Read
     _15 = const.i64 1
     mtag14 = move _15
     _16 = cast _12 i32 -> i64
@@ -2002,11 +2288,11 @@ fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
     _0: Stream<string>
     _1: Sink<string>
   bb0:
-    stmt: use BindingId(91) source site=SiteId(643) ty=Stream<string> intent=Read
-    stmt: use BindingId(92) dest site=SiteId(644) ty=Sink<string> intent=Read
+    stmt: use BindingId(99) source site=SiteId(727) ty=Stream<string> intent=Read
+    stmt: use BindingId(100) dest site=SiteId(728) ty=Sink<string> intent=Read
     call hew_stream_pipe(_0, _1) -> bb1
   bb1:
-    stmt: eval site=SiteId(641) ty=()
+    stmt: eval site=SiteId(725) ty=()
     return
 
 fn i8::fmt(i8) -> string [conv=default]
@@ -2015,11 +2301,11 @@ fn i8::fmt(i8) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(101) val site=SiteId(716) ty=i8 intent=Read
+    stmt: use BindingId(109) val site=SiteId(800) ty=i8 intent=Read
     _1 = cast _0 i8 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(714)) ty=string
+    stmt: return site=Some(SiteId(798)) ty=string
     ret = move _2
     return
 
@@ -2029,11 +2315,11 @@ fn i16::fmt(i16) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(102) val site=SiteId(720) ty=i16 intent=Read
+    stmt: use BindingId(110) val site=SiteId(804) ty=i16 intent=Read
     _1 = cast _0 i16 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(718)) ty=string
+    stmt: return site=Some(SiteId(802)) ty=string
     ret = move _2
     return
 
@@ -2042,10 +2328,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(103) val site=SiteId(723) ty=i32 intent=Read
+    stmt: use BindingId(111) val site=SiteId(807) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(722)) ty=string
+    stmt: return site=Some(SiteId(806)) ty=string
     ret = move _1
     return
 
@@ -2054,10 +2340,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(104) val site=SiteId(726) ty=i64 intent=Read
+    stmt: use BindingId(112) val site=SiteId(810) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(725)) ty=string
+    stmt: return site=Some(SiteId(809)) ty=string
     ret = move _1
     return
 
@@ -2066,10 +2352,10 @@ fn u8::fmt(u8) -> string [conv=default]
     _0: u8
     _1: string
   bb0:
-    stmt: use BindingId(105) val site=SiteId(729) ty=u8 intent=Read
+    stmt: use BindingId(113) val site=SiteId(813) ty=u8 intent=Read
     _1 = call to_string_u8(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(728)) ty=string
+    stmt: return site=Some(SiteId(812)) ty=string
     ret = move _1
     return
 
@@ -2078,10 +2364,10 @@ fn u16::fmt(u16) -> string [conv=default]
     _0: u16
     _1: string
   bb0:
-    stmt: use BindingId(106) val site=SiteId(732) ty=u16 intent=Read
+    stmt: use BindingId(114) val site=SiteId(816) ty=u16 intent=Read
     _1 = call to_string_u16(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(731)) ty=string
+    stmt: return site=Some(SiteId(815)) ty=string
     ret = move _1
     return
 
@@ -2090,10 +2376,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(107) val site=SiteId(735) ty=u32 intent=Read
+    stmt: use BindingId(115) val site=SiteId(819) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(734)) ty=string
+    stmt: return site=Some(SiteId(818)) ty=string
     ret = move _1
     return
 
@@ -2102,10 +2388,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(108) val site=SiteId(738) ty=u64 intent=Read
+    stmt: use BindingId(116) val site=SiteId(822) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(737)) ty=string
+    stmt: return site=Some(SiteId(821)) ty=string
     ret = move _1
     return
 
@@ -2115,11 +2401,11 @@ fn isize::fmt(isize) -> string [conv=default]
     _1: i64
     _2: string
   bb0:
-    stmt: use BindingId(109) val site=SiteId(742) ty=isize intent=Read
+    stmt: use BindingId(117) val site=SiteId(826) ty=isize intent=Read
     _1 = cast _0 isize -> i64
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(740)) ty=string
+    stmt: return site=Some(SiteId(824)) ty=string
     ret = move _2
     return
 
@@ -2129,11 +2415,11 @@ fn usize::fmt(usize) -> string [conv=default]
     _1: u64
     _2: string
   bb0:
-    stmt: use BindingId(110) val site=SiteId(746) ty=usize intent=Read
+    stmt: use BindingId(118) val site=SiteId(830) ty=usize intent=Read
     _1 = cast _0 usize -> u64
     _2 = call to_string_u64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(744)) ty=string
+    stmt: return site=Some(SiteId(828)) ty=string
     ret = move _2
     return
 
@@ -2142,10 +2428,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(111) val site=SiteId(749) ty=bool intent=Read
+    stmt: use BindingId(119) val site=SiteId(833) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(748)) ty=string
+    stmt: return site=Some(SiteId(832)) ty=string
     ret = move _1
     return
 
@@ -2154,10 +2440,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(112) val site=SiteId(752) ty=char intent=Read
+    stmt: use BindingId(120) val site=SiteId(836) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(751)) ty=string
+    stmt: return site=Some(SiteId(835)) ty=string
     ret = move _1
     return
 
@@ -2166,10 +2452,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(113) val site=SiteId(755) ty=f64 intent=Read
+    stmt: use BindingId(121) val site=SiteId(839) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(754)) ty=string
+    stmt: return site=Some(SiteId(838)) ty=string
     ret = move _1
     return
 
@@ -2179,11 +2465,11 @@ fn f32::fmt(f32) -> string [conv=default]
     _1: f64
     _2: string
   bb0:
-    stmt: use BindingId(114) val site=SiteId(759) ty=f32 intent=Read
+    stmt: use BindingId(122) val site=SiteId(843) ty=f32 intent=Read
     _1 = cast _0 f32 -> f64
     _2 = call to_string_f64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(757)) ty=string
+    stmt: return site=Some(SiteId(841)) ty=string
     ret = move _2
     return
 
@@ -2191,8 +2477,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(115) val site=SiteId(761) ty=string intent=Read
-    stmt: return site=Some(SiteId(761)) ty=string
+    stmt: use BindingId(123) val site=SiteId(845) ty=string intent=Read
+    stmt: return site=Some(SiteId(845)) ty=string
     ret = move _0
     return
 
@@ -2203,14 +2489,14 @@ fn duration::from_nanos(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(116) n site=SiteId(763) ty=i64 intent=Read
+    stmt: use BindingId(124) n site=SiteId(847) ty=i64 intent=Read
     _1 = const.duration 1ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(762)) ty=duration
+    stmt: return site=Some(SiteId(846)) ty=duration
     ret = move _2
     return
 
@@ -2221,14 +2507,14 @@ fn duration::from_micros(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(117) n site=SiteId(766) ty=i64 intent=Read
+    stmt: use BindingId(125) n site=SiteId(850) ty=i64 intent=Read
     _1 = const.duration 1000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(765)) ty=duration
+    stmt: return site=Some(SiteId(849)) ty=duration
     ret = move _2
     return
 
@@ -2239,14 +2525,14 @@ fn duration::from_millis(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(118) n site=SiteId(769) ty=i64 intent=Read
+    stmt: use BindingId(126) n site=SiteId(853) ty=i64 intent=Read
     _1 = const.duration 1000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(768)) ty=duration
+    stmt: return site=Some(SiteId(852)) ty=duration
     ret = move _2
     return
 
@@ -2257,14 +2543,14 @@ fn duration::from_secs(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(119) n site=SiteId(772) ty=i64 intent=Read
+    stmt: use BindingId(127) n site=SiteId(856) ty=i64 intent=Read
     _1 = const.duration 1000000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(771)) ty=duration
+    stmt: return site=Some(SiteId(855)) ty=duration
     ret = move _2
     return
 
@@ -2276,11 +2562,11 @@ fn duration::fmt(duration) -> string [conv=default]
     _3: string
     _4: string
   bb0:
-    stmt: use BindingId(120) val site=SiteId(777) ty=duration intent=Read
+    stmt: use BindingId(128) val site=SiteId(861) ty=duration intent=Read
     _1 = call_rt hew_duration_nanos(_0)
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(774)) ty=string
+    stmt: return site=Some(SiteId(858)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
     drop _2 ty=string fn=release(hew_string_drop)

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.elab.mir
@@ -915,75 +915,255 @@ fn fs$is_dir -> bool
 
 fn stream$pipe -> (Sink<string>, Stream<string>)
   statements:
-    use BindingId(66) capacity site=SiteId(498) ty=i64 intent=Read
-    bind BindingId(67) pair site=SiteId(496) ty=StreamPair
-    use BindingId(67) pair site=SiteId(501) ty=StreamPair intent=Read
-    bind BindingId(68) sink site=SiteId(500) ty=Sink<string>
-    use BindingId(67) pair site=SiteId(504) ty=StreamPair intent=Read
-    bind BindingId(69) input site=SiteId(503) ty=Stream<string>
-    use BindingId(67) pair site=SiteId(507) ty=StreamPair intent=Read
-    eval site=SiteId(506) ty=()
-    use BindingId(68) sink site=SiteId(510) ty=Sink<string> intent=Read
-    use BindingId(69) input site=SiteId(511) ty=Stream<string> intent=Read
-    agg_alias BindingId(68) sink site=SiteId(510) ty=Sink<string>
-    agg_alias BindingId(69) input site=SiteId(511) ty=Stream<string>
+    use BindingId(66) capacity site=SiteId(497) ty=i64 intent=Read
+    bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(496) ty=Result<(Sink<string>, Stream<string>), string>
     return site=Some(SiteId(495)) ty=(Sink<string>, Stream<string>)
-    drop BindingId(69) input ty=Stream<string>
-    drop BindingId(68) sink ty=Sink<string>
+    bind BindingId(67) pair site=SiteId(499) ty=(Sink<string>, Stream<string>)
+    use BindingId(67) pair site=SiteId(499) ty=(Sink<string>, Stream<string>) intent=Read
+    bind BindingId(68) err site=SiteId(500) ty=string
+    use BindingId(68) err site=SiteId(501) ty=string intent=Read
+    drop BindingId(68) err ty=string
+    drop BindingId(67) pair ty=(Sink<string>, Stream<string>)
+    drop BindingId(4294967231) __hew_call_scrutinee ty=Result<(Sink<string>, Stream<string>), string>
   drop_plans:
-    call[bb0 hew_stream_channel -> bb1] ->
+    call[bb0 stream$try_pipe -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    call[bb1 hew_stream_pair_sink -> bb2] ->
+    branch[bb1: bb3/bb6] ->
       (none)
-    call[bb2 hew_stream_pair_stream -> bb3] ->
+    return[bb2] ->
       (none)
-    call[bb3 hew_stream_pair_free -> bb4] ->
+    goto[bb3->bb2] ->
       (none)
-    return[bb4] ->
+    cancel[bb3] ->
+      (none)
+    call[bb4 panic -> bb7] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    branch[bb6: bb4/bb5] ->
+      (none)
+    goto[bb7->bb2] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+
+fn stream$try_pipe -> Result<(Sink<string>, Stream<string>), string>
+  statements:
+    use BindingId(69) capacity site=SiteId(504) ty=i64 intent=Read
+    use BindingId(69) capacity site=SiteId(509) ty=i64 intent=Read
+    eval site=SiteId(518) ty=()
+    use BindingId(69) capacity site=SiteId(522) ty=i64 intent=Read
+    return site=Some(SiteId(506)) ty=Result<(Sink<string>, Stream<string>), string>
+    bind BindingId(70) pair site=SiteId(520) ty=StreamPair
+    use BindingId(70) pair site=SiteId(526) ty=StreamPair intent=Read
+    eval site=SiteId(540) ty=()
+    use BindingId(70) pair site=SiteId(542) ty=StreamPair intent=Read
+    bind BindingId(71) detail site=SiteId(528) ty=string
+    use BindingId(71) detail site=SiteId(531) ty=string intent=Read
+    return site=Some(SiteId(533)) ty=Result<(Sink<string>, Stream<string>), string>
+    eval site=SiteId(536) ty=()
+    use BindingId(71) detail site=SiteId(538) ty=string intent=Read
+    agg_alias BindingId(71) detail site=SiteId(538) ty=string
+    return site=Some(SiteId(537)) ty=Result<(Sink<string>, Stream<string>), string>
+    bind BindingId(72) sink site=SiteId(541) ty=Sink<string>
+    use BindingId(70) pair site=SiteId(545) ty=StreamPair intent=Read
+    bind BindingId(73) input site=SiteId(544) ty=Stream<string>
+    use BindingId(70) pair site=SiteId(548) ty=StreamPair intent=Read
+    eval site=SiteId(547) ty=()
+    use BindingId(72) sink site=SiteId(552) ty=Sink<string> intent=Read
+    use BindingId(73) input site=SiteId(553) ty=Stream<string> intent=Read
+    agg_alias BindingId(72) sink site=SiteId(552) ty=Sink<string>
+    agg_alias BindingId(73) input site=SiteId(553) ty=Stream<string>
+    return site=Some(SiteId(519)) ty=Result<(Sink<string>, Stream<string>), string>
+    drop BindingId(73) input ty=Stream<string>
+    drop BindingId(72) sink ty=Sink<string>
+    drop BindingId(71) detail ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    call[bb3 hew_stream_channel -> bb8] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    return[bb6] ->
+      (none)
+    goto[bb7->bb3] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+    call[bb8 hew_stream_pair_is_valid -> bb9] ->
+      (none)
+    branch[bb9: bb10/bb11] ->
+      (none)
+    call[bb10 hew_stream_last_error -> bb13] ->
+      (none)
+    goto[bb11->bb12] ->
+      (none)
+    call[bb12 hew_stream_pair_sink -> bb19] ->
+      (none)
+    branch[bb13: bb14/bb15] ->
+      (none)
+    return[bb14] ->
+      (none)
+    goto[bb15->bb16] ->
+      (none)
+    return[bb16] ->
+      (none)
+    goto[bb17->bb16] ->
+      (none)
+    cancel[bb17] ->
+      (none)
+    goto[bb18->bb12] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    call[bb19 hew_stream_pair_stream -> bb20] ->
+      (none)
+    call[bb20 hew_stream_pair_free -> bb21] ->
+      (none)
+    return[bb21] ->
       (none)
 
 fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
   statements:
-    use BindingId(70) capacity site=SiteId(515) ty=i64 intent=Read
-    bind BindingId(71) pair site=SiteId(513) ty=StreamPair
-    use BindingId(71) pair site=SiteId(518) ty=StreamPair intent=Read
-    bind BindingId(72) sink site=SiteId(517) ty=Sink<bytes>
-    use BindingId(71) pair site=SiteId(521) ty=StreamPair intent=Read
-    bind BindingId(73) input site=SiteId(520) ty=Stream<bytes>
-    use BindingId(71) pair site=SiteId(524) ty=StreamPair intent=Read
-    eval site=SiteId(523) ty=()
-    use BindingId(72) sink site=SiteId(527) ty=Sink<bytes> intent=Read
-    use BindingId(73) input site=SiteId(528) ty=Stream<bytes> intent=Read
-    agg_alias BindingId(72) sink site=SiteId(527) ty=Sink<bytes>
-    agg_alias BindingId(73) input site=SiteId(528) ty=Stream<bytes>
-    return site=Some(SiteId(512)) ty=(Sink<bytes>, Stream<bytes>)
-    drop BindingId(73) input ty=Stream<bytes>
-    drop BindingId(72) sink ty=Sink<bytes>
+    use BindingId(74) capacity site=SiteId(556) ty=i64 intent=Read
+    bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(555) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    return site=Some(SiteId(554)) ty=(Sink<bytes>, Stream<bytes>)
+    bind BindingId(75) pair site=SiteId(558) ty=(Sink<bytes>, Stream<bytes>)
+    use BindingId(75) pair site=SiteId(558) ty=(Sink<bytes>, Stream<bytes>) intent=Read
+    bind BindingId(76) err site=SiteId(559) ty=string
+    use BindingId(76) err site=SiteId(560) ty=string intent=Read
+    drop BindingId(76) err ty=string
+    drop BindingId(75) pair ty=(Sink<bytes>, Stream<bytes>)
+    drop BindingId(4294967231) __hew_call_scrutinee ty=Result<(Sink<bytes>, Stream<bytes>), string>
   drop_plans:
-    call[bb0 hew_stream_channel -> bb1] ->
+    call[bb0 stream$try_bytes_pipe -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    call[bb1 hew_stream_pair_sink_bytes -> bb2] ->
+    branch[bb1: bb3/bb6] ->
       (none)
-    call[bb2 hew_stream_pair_stream_bytes -> bb3] ->
+    return[bb2] ->
       (none)
-    call[bb3 hew_stream_pair_free -> bb4] ->
+    goto[bb3->bb2] ->
       (none)
-    return[bb4] ->
+    cancel[bb3] ->
+      (none)
+    call[bb4 panic -> bb7] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    branch[bb6: bb4/bb5] ->
+      (none)
+    goto[bb7->bb2] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+
+fn stream$try_bytes_pipe -> Result<(Sink<bytes>, Stream<bytes>), string>
+  statements:
+    use BindingId(77) capacity site=SiteId(563) ty=i64 intent=Read
+    use BindingId(77) capacity site=SiteId(568) ty=i64 intent=Read
+    eval site=SiteId(577) ty=()
+    use BindingId(77) capacity site=SiteId(581) ty=i64 intent=Read
+    return site=Some(SiteId(565)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    bind BindingId(78) pair site=SiteId(579) ty=StreamPair
+    use BindingId(78) pair site=SiteId(585) ty=StreamPair intent=Read
+    eval site=SiteId(599) ty=()
+    use BindingId(78) pair site=SiteId(601) ty=StreamPair intent=Read
+    bind BindingId(79) detail site=SiteId(587) ty=string
+    use BindingId(79) detail site=SiteId(590) ty=string intent=Read
+    return site=Some(SiteId(592)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    eval site=SiteId(595) ty=()
+    use BindingId(79) detail site=SiteId(597) ty=string intent=Read
+    agg_alias BindingId(79) detail site=SiteId(597) ty=string
+    return site=Some(SiteId(596)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    bind BindingId(80) sink site=SiteId(600) ty=Sink<bytes>
+    use BindingId(78) pair site=SiteId(604) ty=StreamPair intent=Read
+    bind BindingId(81) input site=SiteId(603) ty=Stream<bytes>
+    use BindingId(78) pair site=SiteId(607) ty=StreamPair intent=Read
+    eval site=SiteId(606) ty=()
+    use BindingId(80) sink site=SiteId(611) ty=Sink<bytes> intent=Read
+    use BindingId(81) input site=SiteId(612) ty=Stream<bytes> intent=Read
+    agg_alias BindingId(80) sink site=SiteId(611) ty=Sink<bytes>
+    agg_alias BindingId(81) input site=SiteId(612) ty=Stream<bytes>
+    return site=Some(SiteId(578)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    drop BindingId(81) input ty=Stream<bytes>
+    drop BindingId(80) sink ty=Sink<bytes>
+    drop BindingId(79) detail ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    call[bb3 hew_stream_channel -> bb8] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    return[bb6] ->
+      (none)
+    goto[bb7->bb3] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+    call[bb8 hew_stream_pair_is_valid -> bb9] ->
+      (none)
+    branch[bb9: bb10/bb11] ->
+      (none)
+    call[bb10 hew_stream_last_error -> bb13] ->
+      (none)
+    goto[bb11->bb12] ->
+      (none)
+    call[bb12 hew_stream_pair_sink_bytes -> bb19] ->
+      (none)
+    branch[bb13: bb14/bb15] ->
+      (none)
+    return[bb14] ->
+      (none)
+    goto[bb15->bb16] ->
+      (none)
+    return[bb16] ->
+      (none)
+    goto[bb17->bb16] ->
+      (none)
+    cancel[bb17] ->
+      (none)
+    goto[bb18->bb12] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    call[bb19 hew_stream_pair_stream_bytes -> bb20] ->
+      (none)
+    call[bb20 hew_stream_pair_free -> bb21] ->
+      (none)
+    return[bb21] ->
       (none)
 
 fn stream$from_file -> Result<Stream<string>, string>
   statements:
-    use BindingId(74) path site=SiteId(531) ty=string intent=Read
-    bind BindingId(75) s site=SiteId(530) ty=Stream<string>
-    use BindingId(75) s site=SiteId(535) ty=Stream<string> intent=Read
-    use BindingId(75) s site=SiteId(539) ty=Stream<string> intent=Read
-    agg_alias BindingId(75) s site=SiteId(539) ty=Stream<string>
-    return site=Some(SiteId(529)) ty=Result<Stream<string>, string>
-    drop BindingId(75) s ty=Stream<string>
+    use BindingId(82) path site=SiteId(615) ty=string intent=Read
+    bind BindingId(83) s site=SiteId(614) ty=Stream<string>
+    use BindingId(83) s site=SiteId(619) ty=Stream<string> intent=Read
+    use BindingId(83) s site=SiteId(623) ty=Stream<string> intent=Read
+    agg_alias BindingId(83) s site=SiteId(623) ty=Stream<string>
+    return site=Some(SiteId(613)) ty=Result<Stream<string>, string>
+    drop BindingId(83) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1006,18 +1186,18 @@ fn stream$from_file -> Result<Stream<string>, string>
 
 fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
   statements:
-    use BindingId(76) path site=SiteId(546) ty=string intent=Read
-    bind BindingId(77) s site=SiteId(545) ty=Stream<string>
-    use BindingId(77) s site=SiteId(550) ty=Stream<string> intent=Read
-    use BindingId(77) s site=SiteId(554) ty=Stream<string> intent=Read
-    agg_alias BindingId(77) s site=SiteId(554) ty=Stream<string>
-    return site=Some(SiteId(544)) ty=Result<Stream<string>, fs.IoError>
-    bind BindingId(78) kind site=SiteId(556) ty=i64
-    bind BindingId(79) errno site=SiteId(559) ty=i32
-    eval site=SiteId(561) ty=string
-    use BindingId(78) kind site=SiteId(565) ty=i64 intent=Read
-    use BindingId(79) errno site=SiteId(567) ty=i32 intent=Read
-    drop BindingId(77) s ty=Stream<string>
+    use BindingId(84) path site=SiteId(630) ty=string intent=Read
+    bind BindingId(85) s site=SiteId(629) ty=Stream<string>
+    use BindingId(85) s site=SiteId(634) ty=Stream<string> intent=Read
+    use BindingId(85) s site=SiteId(638) ty=Stream<string> intent=Read
+    agg_alias BindingId(85) s site=SiteId(638) ty=Stream<string>
+    return site=Some(SiteId(628)) ty=Result<Stream<string>, fs.IoError>
+    bind BindingId(86) kind site=SiteId(640) ty=i64
+    bind BindingId(87) errno site=SiteId(643) ty=i32
+    eval site=SiteId(645) ty=string
+    use BindingId(86) kind site=SiteId(649) ty=i64 intent=Read
+    use BindingId(87) errno site=SiteId(651) ty=i32 intent=Read
+    drop BindingId(85) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1046,13 +1226,13 @@ fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
 
 fn stream$to_file -> Result<Sink<string>, string>
   statements:
-    use BindingId(80) path site=SiteId(571) ty=string intent=Read
-    bind BindingId(81) s site=SiteId(570) ty=Sink<string>
-    use BindingId(81) s site=SiteId(575) ty=Sink<string> intent=Read
-    use BindingId(81) s site=SiteId(579) ty=Sink<string> intent=Read
-    agg_alias BindingId(81) s site=SiteId(579) ty=Sink<string>
-    return site=Some(SiteId(569)) ty=Result<Sink<string>, string>
-    drop BindingId(81) s ty=Sink<string>
+    use BindingId(88) path site=SiteId(655) ty=string intent=Read
+    bind BindingId(89) s site=SiteId(654) ty=Sink<string>
+    use BindingId(89) s site=SiteId(659) ty=Sink<string> intent=Read
+    use BindingId(89) s site=SiteId(663) ty=Sink<string> intent=Read
+    agg_alias BindingId(89) s site=SiteId(663) ty=Sink<string>
+    return site=Some(SiteId(653)) ty=Result<Sink<string>, string>
+    drop BindingId(89) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1075,18 +1255,18 @@ fn stream$to_file -> Result<Sink<string>, string>
 
 fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
   statements:
-    use BindingId(82) path site=SiteId(586) ty=string intent=Read
-    bind BindingId(83) s site=SiteId(585) ty=Sink<string>
-    use BindingId(83) s site=SiteId(590) ty=Sink<string> intent=Read
-    use BindingId(83) s site=SiteId(594) ty=Sink<string> intent=Read
-    agg_alias BindingId(83) s site=SiteId(594) ty=Sink<string>
-    return site=Some(SiteId(584)) ty=Result<Sink<string>, fs.IoError>
-    bind BindingId(84) kind site=SiteId(596) ty=i64
-    bind BindingId(85) errno site=SiteId(599) ty=i32
-    eval site=SiteId(601) ty=string
-    use BindingId(84) kind site=SiteId(605) ty=i64 intent=Read
-    use BindingId(85) errno site=SiteId(607) ty=i32 intent=Read
-    drop BindingId(83) s ty=Sink<string>
+    use BindingId(90) path site=SiteId(670) ty=string intent=Read
+    bind BindingId(91) s site=SiteId(669) ty=Sink<string>
+    use BindingId(91) s site=SiteId(674) ty=Sink<string> intent=Read
+    use BindingId(91) s site=SiteId(678) ty=Sink<string> intent=Read
+    agg_alias BindingId(91) s site=SiteId(678) ty=Sink<string>
+    return site=Some(SiteId(668)) ty=Result<Sink<string>, fs.IoError>
+    bind BindingId(92) kind site=SiteId(680) ty=i64
+    bind BindingId(93) errno site=SiteId(683) ty=i32
+    eval site=SiteId(685) ty=string
+    use BindingId(92) kind site=SiteId(689) ty=i64 intent=Read
+    use BindingId(93) errno site=SiteId(691) ty=i32 intent=Read
+    drop BindingId(91) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1115,9 +1295,9 @@ fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
 
 fn stream$forward -> ()
   statements:
-    use BindingId(86) source site=SiteId(611) ty=Stream<string> intent=Read
-    use BindingId(87) dest site=SiteId(612) ty=Sink<string> intent=Read
-    eval site=SiteId(609) ty=()
+    use BindingId(94) source site=SiteId(695) ty=Stream<string> intent=Read
+    use BindingId(95) dest site=SiteId(696) ty=Sink<string> intent=Read
+    eval site=SiteId(693) ty=()
   drop_plans:
     call[bb0 hew_stream_pipe -> bb1] ->
       (none)
@@ -1128,8 +1308,8 @@ fn stream$forward -> ()
 
 fn i8::fmt -> string
   statements:
-    use BindingId(96) val site=SiteId(684) ty=i8 intent=Read
-    return site=Some(SiteId(682)) ty=string
+    use BindingId(104) val site=SiteId(768) ty=i8 intent=Read
+    return site=Some(SiteId(766)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1140,8 +1320,8 @@ fn i8::fmt -> string
 
 fn i16::fmt -> string
   statements:
-    use BindingId(97) val site=SiteId(688) ty=i16 intent=Read
-    return site=Some(SiteId(686)) ty=string
+    use BindingId(105) val site=SiteId(772) ty=i16 intent=Read
+    return site=Some(SiteId(770)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1152,8 +1332,8 @@ fn i16::fmt -> string
 
 fn i32::fmt -> string
   statements:
-    use BindingId(98) val site=SiteId(691) ty=i32 intent=Read
-    return site=Some(SiteId(690)) ty=string
+    use BindingId(106) val site=SiteId(775) ty=i32 intent=Read
+    return site=Some(SiteId(774)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1164,8 +1344,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(99) val site=SiteId(694) ty=i64 intent=Read
-    return site=Some(SiteId(693)) ty=string
+    use BindingId(107) val site=SiteId(778) ty=i64 intent=Read
+    return site=Some(SiteId(777)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1176,8 +1356,8 @@ fn i64::fmt -> string
 
 fn u8::fmt -> string
   statements:
-    use BindingId(100) val site=SiteId(697) ty=u8 intent=Read
-    return site=Some(SiteId(696)) ty=string
+    use BindingId(108) val site=SiteId(781) ty=u8 intent=Read
+    return site=Some(SiteId(780)) ty=string
   drop_plans:
     call[bb0 to_string_u8 -> bb1] ->
       (none)
@@ -1188,8 +1368,8 @@ fn u8::fmt -> string
 
 fn u16::fmt -> string
   statements:
-    use BindingId(101) val site=SiteId(700) ty=u16 intent=Read
-    return site=Some(SiteId(699)) ty=string
+    use BindingId(109) val site=SiteId(784) ty=u16 intent=Read
+    return site=Some(SiteId(783)) ty=string
   drop_plans:
     call[bb0 to_string_u16 -> bb1] ->
       (none)
@@ -1200,8 +1380,8 @@ fn u16::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(102) val site=SiteId(703) ty=u32 intent=Read
-    return site=Some(SiteId(702)) ty=string
+    use BindingId(110) val site=SiteId(787) ty=u32 intent=Read
+    return site=Some(SiteId(786)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -1212,8 +1392,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(103) val site=SiteId(706) ty=u64 intent=Read
-    return site=Some(SiteId(705)) ty=string
+    use BindingId(111) val site=SiteId(790) ty=u64 intent=Read
+    return site=Some(SiteId(789)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1224,8 +1404,8 @@ fn u64::fmt -> string
 
 fn isize::fmt -> string
   statements:
-    use BindingId(104) val site=SiteId(710) ty=isize intent=Read
-    return site=Some(SiteId(708)) ty=string
+    use BindingId(112) val site=SiteId(794) ty=isize intent=Read
+    return site=Some(SiteId(792)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1236,8 +1416,8 @@ fn isize::fmt -> string
 
 fn usize::fmt -> string
   statements:
-    use BindingId(105) val site=SiteId(714) ty=usize intent=Read
-    return site=Some(SiteId(712)) ty=string
+    use BindingId(113) val site=SiteId(798) ty=usize intent=Read
+    return site=Some(SiteId(796)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1248,8 +1428,8 @@ fn usize::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(106) val site=SiteId(717) ty=bool intent=Read
-    return site=Some(SiteId(716)) ty=string
+    use BindingId(114) val site=SiteId(801) ty=bool intent=Read
+    return site=Some(SiteId(800)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -1260,8 +1440,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(107) val site=SiteId(720) ty=char intent=Read
-    return site=Some(SiteId(719)) ty=string
+    use BindingId(115) val site=SiteId(804) ty=char intent=Read
+    return site=Some(SiteId(803)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -1272,8 +1452,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(108) val site=SiteId(723) ty=f64 intent=Read
-    return site=Some(SiteId(722)) ty=string
+    use BindingId(116) val site=SiteId(807) ty=f64 intent=Read
+    return site=Some(SiteId(806)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1284,8 +1464,8 @@ fn f64::fmt -> string
 
 fn f32::fmt -> string
   statements:
-    use BindingId(109) val site=SiteId(727) ty=f32 intent=Read
-    return site=Some(SiteId(725)) ty=string
+    use BindingId(117) val site=SiteId(811) ty=f32 intent=Read
+    return site=Some(SiteId(809)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1296,16 +1476,16 @@ fn f32::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(110) val site=SiteId(729) ty=string intent=Read
-    return site=Some(SiteId(729)) ty=string
+    use BindingId(118) val site=SiteId(813) ty=string intent=Read
+    return site=Some(SiteId(813)) ty=string
   drop_plans:
     return[bb0] ->
       (none)
 
 fn duration::from_nanos -> duration
   statements:
-    use BindingId(111) n site=SiteId(731) ty=i64 intent=Read
-    return site=Some(SiteId(730)) ty=duration
+    use BindingId(119) n site=SiteId(815) ty=i64 intent=Read
+    return site=Some(SiteId(814)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1316,8 +1496,8 @@ fn duration::from_nanos -> duration
 
 fn duration::from_micros -> duration
   statements:
-    use BindingId(112) n site=SiteId(734) ty=i64 intent=Read
-    return site=Some(SiteId(733)) ty=duration
+    use BindingId(120) n site=SiteId(818) ty=i64 intent=Read
+    return site=Some(SiteId(817)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1328,8 +1508,8 @@ fn duration::from_micros -> duration
 
 fn duration::from_millis -> duration
   statements:
-    use BindingId(113) n site=SiteId(737) ty=i64 intent=Read
-    return site=Some(SiteId(736)) ty=duration
+    use BindingId(121) n site=SiteId(821) ty=i64 intent=Read
+    return site=Some(SiteId(820)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1340,8 +1520,8 @@ fn duration::from_millis -> duration
 
 fn duration::from_secs -> duration
   statements:
-    use BindingId(114) n site=SiteId(740) ty=i64 intent=Read
-    return site=Some(SiteId(739)) ty=duration
+    use BindingId(122) n site=SiteId(824) ty=i64 intent=Read
+    return site=Some(SiteId(823)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1352,8 +1532,8 @@ fn duration::from_secs -> duration
 
 fn duration::fmt -> string
   statements:
-    use BindingId(115) val site=SiteId(745) ty=duration intent=Read
-    return site=Some(SiteId(742)) ty=string
+    use BindingId(123) val site=SiteId(829) ty=duration intent=Read
+    return site=Some(SiteId(826)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
@@ -1560,87 +1560,373 @@ fn fs$is_dir(string) -> bool [conv=default]
 fn stream$pipe(i64) -> (Sink<string>, Stream<string>) [conv=default]
   locals:
     _0: i64
-    _1: i64
-    _2: StreamPair
-    _3: StreamPair
-    _4: Sink<string>
-    _5: Sink<string>
-    _6: Stream<string>
-    _7: Stream<string>
+    _1: (Sink<string>, Stream<string>)
+    _2: Result<(Sink<string>, Stream<string>), string>
+    _3: i64
+    _4: i64
+    _5: bool
+    _6: i64
+    _7: bool
     _8: (Sink<string>, Stream<string>)
-    _9: (Sink<string>, Stream<string>)
+    _9: string
   bb0:
-    stmt: use BindingId(66) capacity site=SiteId(498) ty=i64 intent=Read
-    _1 = cast _0 i64 -> i64
-    _2 = call hew_stream_channel(_1) -> bb1
+    stmt: use BindingId(66) capacity site=SiteId(497) ty=i64 intent=Read
+    _2 = call stream$try_pipe(_0) -> bb1
   bb1:
-    stmt: bind BindingId(67) pair site=SiteId(496) ty=StreamPair
-    stmt: use BindingId(67) pair site=SiteId(501) ty=StreamPair intent=Read
-    _3 = move _2
-    _4 = call hew_stream_pair_sink(_3) -> bb2
+    stmt: bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(496) ty=Result<(Sink<string>, Stream<string>), string>
+    _3 = move etag2
+    _4 = const.i64 0
+    _5 = icmp.eq _3 _4
+    branch _5 ? bb3 : bb6
   bb2:
-    stmt: bind BindingId(68) sink site=SiteId(500) ty=Sink<string>
-    stmt: use BindingId(67) pair site=SiteId(504) ty=StreamPair intent=Read
-    _5 = move _4
-    _6 = call hew_stream_pair_stream(_3) -> bb3
-  bb3:
-    stmt: bind BindingId(69) input site=SiteId(503) ty=Stream<string>
-    stmt: use BindingId(67) pair site=SiteId(507) ty=StreamPair intent=Read
-    _7 = move _6
-    call hew_stream_pair_free(_3) -> bb4
-  bb4:
-    stmt: eval site=SiteId(506) ty=()
-    stmt: use BindingId(68) sink site=SiteId(510) ty=Sink<string> intent=Read
-    stmt: use BindingId(69) input site=SiteId(511) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(68) sink site=SiteId(510) ty=Sink<string>
-    stmt: agg_alias BindingId(69) input site=SiteId(511) ty=Stream<string>
     stmt: return site=Some(SiteId(495)) ty=(Sink<string>, Stream<string>)
-    _8 = tuple (_5, _7)
-    _9 = move _8
-    ret = move _9
+    ret = move _1
+    return
+  bb3:
+    stmt: bind BindingId(67) pair site=SiteId(499) ty=(Sink<string>, Stream<string>)
+    stmt: use BindingId(67) pair site=SiteId(499) ty=(Sink<string>, Stream<string>) intent=Read
+    _8 = move mvar2.0.0
+    _1 = move _8
+    goto bb2
+  bb4:
+    stmt: bind BindingId(68) err site=SiteId(500) ty=string
+    stmt: use BindingId(68) err site=SiteId(501) ty=string intent=Read
+    _9 = move mvar2.1.0
+    call panic(_9) -> bb7
+  bb5:
+    trap(ExhaustivenessFallthrough)
+  bb6:
+    _6 = const.i64 1
+    _7 = icmp.eq _3 _6
+    branch _7 ? bb4 : bb5
+  bb7:
+    goto bb2
+
+fn stream$try_pipe(i64) -> Result<(Sink<string>, Stream<string>), string> [conv=default]
+  locals:
+    _0: i64
+    _1: ()
+    _2: i64
+    _3: bool
+    _4: Result<(Sink<string>, Stream<string>), string>
+    _5: i64
+    _6: string
+    _7: string
+    _8: string
+    _9: string
+    _10: string
+    _11: i64
+    _12: StreamPair
+    _13: StreamPair
+    _14: ()
+    _15: bool
+    _16: bool
+    _17: string
+    _18: string
+    _19: ()
+    _20: string
+    _21: bool
+    _22: Result<(Sink<string>, Stream<string>), string>
+    _23: i64
+    _24: string
+    _25: Result<(Sink<string>, Stream<string>), string>
+    _26: i64
+    _27: Sink<string>
+    _28: Sink<string>
+    _29: Stream<string>
+    _30: Stream<string>
+    _31: Result<(Sink<string>, Stream<string>), string>
+    _32: i64
+    _33: (Sink<string>, Stream<string>)
+    _34: Result<(Sink<string>, Stream<string>), string>
+  bb0:
+    stmt: use BindingId(69) capacity site=SiteId(504) ty=i64 intent=Read
+    _2 = const.i64 0
+    _3 = icmp.slt _0 _2
+    branch _3 ? bb1 : bb2
+  bb1:
+    stmt: use BindingId(69) capacity site=SiteId(509) ty=i64 intent=Read
+    _5 = const.i64 1
+    mtag4 = move _5
+    _6 = string_lit "stream.pipe: invalid capacity "
+    _7 = call to_string_i64(_0) -> bb4
+  bb2:
+    goto bb3
+  bb3:
+    stmt: eval site=SiteId(518) ty=()
+    stmt: use BindingId(69) capacity site=SiteId(522) ty=i64 intent=Read
+    _11 = cast _0 i64 -> i64
+    _12 = call hew_stream_channel(_11) -> bb8
+  bb4:
+    _8 = call string_concat(_6, _7) -> bb5
+  bb5:
+    drop _7 ty=string fn=release(hew_string_drop)
+    _9 = string_lit " (must be >= 0)"
+    _10 = call string_concat(_8, _9) -> bb6
+  bb6:
+    stmt: return site=Some(SiteId(506)) ty=Result<(Sink<string>, Stream<string>), string>
+    drop _8 ty=string fn=release(hew_string_drop)
+    mvar4.1.0 = move _10
+    ret = move _4
+    return
+  bb7:
+    goto bb3
+  bb8:
+    stmt: bind BindingId(70) pair site=SiteId(520) ty=StreamPair
+    stmt: use BindingId(70) pair site=SiteId(526) ty=StreamPair intent=Read
+    _13 = move _12
+    _15 = call hew_stream_pair_is_valid(_13) -> bb9
+  bb9:
+    _16 = not _15
+    branch _16 ? bb10 : bb11
+  bb10:
+    _17 = call hew_stream_last_error() -> bb13
+  bb11:
+    goto bb12
+  bb12:
+    stmt: eval site=SiteId(540) ty=()
+    stmt: use BindingId(70) pair site=SiteId(542) ty=StreamPair intent=Read
+    _27 = call hew_stream_pair_sink(_13) -> bb19
+  bb13:
+    stmt: bind BindingId(71) detail site=SiteId(528) ty=string
+    stmt: use BindingId(71) detail site=SiteId(531) ty=string intent=Read
+    _18 = move _17
+    _20 = string_lit ""
+    _21 = icmp.eq _18 _20
+    branch _21 ? bb14 : bb15
+  bb14:
+    stmt: return site=Some(SiteId(533)) ty=Result<(Sink<string>, Stream<string>), string>
+    _23 = const.i64 1
+    mtag22 = move _23
+    _24 = string_lit "stream.pipe: stream allocation failed"
+    mvar22.1.0 = move _24
+    ret = move _22
+    return
+  bb15:
+    goto bb16
+  bb16:
+    stmt: eval site=SiteId(536) ty=()
+    stmt: use BindingId(71) detail site=SiteId(538) ty=string intent=Read
+    stmt: agg_alias BindingId(71) detail site=SiteId(538) ty=string
+    stmt: return site=Some(SiteId(537)) ty=Result<(Sink<string>, Stream<string>), string>
+    _26 = const.i64 1
+    mtag25 = move _26
+    mvar25.1.0 = move _18
+    ret = move _25
+    return
+  bb17:
+    goto bb16
+  bb18:
+    goto bb12
+  bb19:
+    stmt: bind BindingId(72) sink site=SiteId(541) ty=Sink<string>
+    stmt: use BindingId(70) pair site=SiteId(545) ty=StreamPair intent=Read
+    _28 = move _27
+    _29 = call hew_stream_pair_stream(_13) -> bb20
+  bb20:
+    stmt: bind BindingId(73) input site=SiteId(544) ty=Stream<string>
+    stmt: use BindingId(70) pair site=SiteId(548) ty=StreamPair intent=Read
+    _30 = move _29
+    call hew_stream_pair_free(_13) -> bb21
+  bb21:
+    stmt: eval site=SiteId(547) ty=()
+    stmt: use BindingId(72) sink site=SiteId(552) ty=Sink<string> intent=Read
+    stmt: use BindingId(73) input site=SiteId(553) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(72) sink site=SiteId(552) ty=Sink<string>
+    stmt: agg_alias BindingId(73) input site=SiteId(553) ty=Stream<string>
+    stmt: return site=Some(SiteId(519)) ty=Result<(Sink<string>, Stream<string>), string>
+    _32 = const.i64 0
+    mtag31 = move _32
+    _33 = tuple (_28, _30)
+    mvar31.0.0 = move _33
+    _34 = move _31
+    ret = move _34
     return
 
 fn stream$bytes_pipe(i64) -> (Sink<bytes>, Stream<bytes>) [conv=default]
   locals:
     _0: i64
-    _1: i64
-    _2: StreamPair
-    _3: StreamPair
-    _4: Sink<bytes>
-    _5: Sink<bytes>
-    _6: Stream<bytes>
-    _7: Stream<bytes>
+    _1: (Sink<bytes>, Stream<bytes>)
+    _2: Result<(Sink<bytes>, Stream<bytes>), string>
+    _3: i64
+    _4: i64
+    _5: bool
+    _6: i64
+    _7: bool
     _8: (Sink<bytes>, Stream<bytes>)
-    _9: (Sink<bytes>, Stream<bytes>)
+    _9: string
   bb0:
-    stmt: use BindingId(70) capacity site=SiteId(515) ty=i64 intent=Read
-    _1 = cast _0 i64 -> i64
-    _2 = call hew_stream_channel(_1) -> bb1
+    stmt: use BindingId(74) capacity site=SiteId(556) ty=i64 intent=Read
+    _2 = call stream$try_bytes_pipe(_0) -> bb1
   bb1:
-    stmt: bind BindingId(71) pair site=SiteId(513) ty=StreamPair
-    stmt: use BindingId(71) pair site=SiteId(518) ty=StreamPair intent=Read
-    _3 = move _2
-    _4 = call hew_stream_pair_sink_bytes(_3) -> bb2
+    stmt: bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(555) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    _3 = move etag2
+    _4 = const.i64 0
+    _5 = icmp.eq _3 _4
+    branch _5 ? bb3 : bb6
   bb2:
-    stmt: bind BindingId(72) sink site=SiteId(517) ty=Sink<bytes>
-    stmt: use BindingId(71) pair site=SiteId(521) ty=StreamPair intent=Read
-    _5 = move _4
-    _6 = call hew_stream_pair_stream_bytes(_3) -> bb3
+    stmt: return site=Some(SiteId(554)) ty=(Sink<bytes>, Stream<bytes>)
+    ret = move _1
+    return
   bb3:
-    stmt: bind BindingId(73) input site=SiteId(520) ty=Stream<bytes>
-    stmt: use BindingId(71) pair site=SiteId(524) ty=StreamPair intent=Read
-    _7 = move _6
-    call hew_stream_pair_free(_3) -> bb4
+    stmt: bind BindingId(75) pair site=SiteId(558) ty=(Sink<bytes>, Stream<bytes>)
+    stmt: use BindingId(75) pair site=SiteId(558) ty=(Sink<bytes>, Stream<bytes>) intent=Read
+    _8 = move mvar2.0.0
+    _1 = move _8
+    goto bb2
   bb4:
-    stmt: eval site=SiteId(523) ty=()
-    stmt: use BindingId(72) sink site=SiteId(527) ty=Sink<bytes> intent=Read
-    stmt: use BindingId(73) input site=SiteId(528) ty=Stream<bytes> intent=Read
-    stmt: agg_alias BindingId(72) sink site=SiteId(527) ty=Sink<bytes>
-    stmt: agg_alias BindingId(73) input site=SiteId(528) ty=Stream<bytes>
-    stmt: return site=Some(SiteId(512)) ty=(Sink<bytes>, Stream<bytes>)
-    _8 = tuple (_5, _7)
-    _9 = move _8
-    ret = move _9
+    stmt: bind BindingId(76) err site=SiteId(559) ty=string
+    stmt: use BindingId(76) err site=SiteId(560) ty=string intent=Read
+    _9 = move mvar2.1.0
+    call panic(_9) -> bb7
+  bb5:
+    trap(ExhaustivenessFallthrough)
+  bb6:
+    _6 = const.i64 1
+    _7 = icmp.eq _3 _6
+    branch _7 ? bb4 : bb5
+  bb7:
+    goto bb2
+
+fn stream$try_bytes_pipe(i64) -> Result<(Sink<bytes>, Stream<bytes>), string> [conv=default]
+  locals:
+    _0: i64
+    _1: ()
+    _2: i64
+    _3: bool
+    _4: Result<(Sink<bytes>, Stream<bytes>), string>
+    _5: i64
+    _6: string
+    _7: string
+    _8: string
+    _9: string
+    _10: string
+    _11: i64
+    _12: StreamPair
+    _13: StreamPair
+    _14: ()
+    _15: bool
+    _16: bool
+    _17: string
+    _18: string
+    _19: ()
+    _20: string
+    _21: bool
+    _22: Result<(Sink<bytes>, Stream<bytes>), string>
+    _23: i64
+    _24: string
+    _25: Result<(Sink<bytes>, Stream<bytes>), string>
+    _26: i64
+    _27: Sink<bytes>
+    _28: Sink<bytes>
+    _29: Stream<bytes>
+    _30: Stream<bytes>
+    _31: Result<(Sink<bytes>, Stream<bytes>), string>
+    _32: i64
+    _33: (Sink<bytes>, Stream<bytes>)
+    _34: Result<(Sink<bytes>, Stream<bytes>), string>
+  bb0:
+    stmt: use BindingId(77) capacity site=SiteId(563) ty=i64 intent=Read
+    _2 = const.i64 0
+    _3 = icmp.slt _0 _2
+    branch _3 ? bb1 : bb2
+  bb1:
+    stmt: use BindingId(77) capacity site=SiteId(568) ty=i64 intent=Read
+    _5 = const.i64 1
+    mtag4 = move _5
+    _6 = string_lit "stream.bytes_pipe: invalid capacity "
+    _7 = call to_string_i64(_0) -> bb4
+  bb2:
+    goto bb3
+  bb3:
+    stmt: eval site=SiteId(577) ty=()
+    stmt: use BindingId(77) capacity site=SiteId(581) ty=i64 intent=Read
+    _11 = cast _0 i64 -> i64
+    _12 = call hew_stream_channel(_11) -> bb8
+  bb4:
+    _8 = call string_concat(_6, _7) -> bb5
+  bb5:
+    drop _7 ty=string fn=release(hew_string_drop)
+    _9 = string_lit " (must be >= 0)"
+    _10 = call string_concat(_8, _9) -> bb6
+  bb6:
+    stmt: return site=Some(SiteId(565)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    drop _8 ty=string fn=release(hew_string_drop)
+    mvar4.1.0 = move _10
+    ret = move _4
+    return
+  bb7:
+    goto bb3
+  bb8:
+    stmt: bind BindingId(78) pair site=SiteId(579) ty=StreamPair
+    stmt: use BindingId(78) pair site=SiteId(585) ty=StreamPair intent=Read
+    _13 = move _12
+    _15 = call hew_stream_pair_is_valid(_13) -> bb9
+  bb9:
+    _16 = not _15
+    branch _16 ? bb10 : bb11
+  bb10:
+    _17 = call hew_stream_last_error() -> bb13
+  bb11:
+    goto bb12
+  bb12:
+    stmt: eval site=SiteId(599) ty=()
+    stmt: use BindingId(78) pair site=SiteId(601) ty=StreamPair intent=Read
+    _27 = call hew_stream_pair_sink_bytes(_13) -> bb19
+  bb13:
+    stmt: bind BindingId(79) detail site=SiteId(587) ty=string
+    stmt: use BindingId(79) detail site=SiteId(590) ty=string intent=Read
+    _18 = move _17
+    _20 = string_lit ""
+    _21 = icmp.eq _18 _20
+    branch _21 ? bb14 : bb15
+  bb14:
+    stmt: return site=Some(SiteId(592)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    _23 = const.i64 1
+    mtag22 = move _23
+    _24 = string_lit "stream.bytes_pipe: stream allocation failed"
+    mvar22.1.0 = move _24
+    ret = move _22
+    return
+  bb15:
+    goto bb16
+  bb16:
+    stmt: eval site=SiteId(595) ty=()
+    stmt: use BindingId(79) detail site=SiteId(597) ty=string intent=Read
+    stmt: agg_alias BindingId(79) detail site=SiteId(597) ty=string
+    stmt: return site=Some(SiteId(596)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    _26 = const.i64 1
+    mtag25 = move _26
+    mvar25.1.0 = move _18
+    ret = move _25
+    return
+  bb17:
+    goto bb16
+  bb18:
+    goto bb12
+  bb19:
+    stmt: bind BindingId(80) sink site=SiteId(600) ty=Sink<bytes>
+    stmt: use BindingId(78) pair site=SiteId(604) ty=StreamPair intent=Read
+    _28 = move _27
+    _29 = call hew_stream_pair_stream_bytes(_13) -> bb20
+  bb20:
+    stmt: bind BindingId(81) input site=SiteId(603) ty=Stream<bytes>
+    stmt: use BindingId(78) pair site=SiteId(607) ty=StreamPair intent=Read
+    _30 = move _29
+    call hew_stream_pair_free(_13) -> bb21
+  bb21:
+    stmt: eval site=SiteId(606) ty=()
+    stmt: use BindingId(80) sink site=SiteId(611) ty=Sink<bytes> intent=Read
+    stmt: use BindingId(81) input site=SiteId(612) ty=Stream<bytes> intent=Read
+    stmt: agg_alias BindingId(80) sink site=SiteId(611) ty=Sink<bytes>
+    stmt: agg_alias BindingId(81) input site=SiteId(612) ty=Stream<bytes>
+    stmt: return site=Some(SiteId(578)) ty=Result<(Sink<bytes>, Stream<bytes>), string>
+    _32 = const.i64 0
+    mtag31 = move _32
+    _33 = tuple (_28, _30)
+    mvar31.0.0 = move _33
+    _34 = move _31
+    ret = move _34
     return
 
 fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
@@ -1659,18 +1945,18 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     _11: Result<Stream<string>, string>
     _12: Result<Stream<string>, string>
   bb0:
-    stmt: use BindingId(74) path site=SiteId(531) ty=string intent=Read
+    stmt: use BindingId(82) path site=SiteId(615) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(75) s site=SiteId(530) ty=Stream<string>
-    stmt: use BindingId(75) s site=SiteId(535) ty=Stream<string> intent=Read
+    stmt: bind BindingId(83) s site=SiteId(614) ty=Stream<string>
+    stmt: use BindingId(83) s site=SiteId(619) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(75) s site=SiteId(539) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(75) s site=SiteId(539) ty=Stream<string>
+    stmt: use BindingId(83) s site=SiteId(623) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(83) s site=SiteId(623) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -1682,7 +1968,7 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(529)) ty=Result<Stream<string>, string>
+    stmt: return site=Some(SiteId(613)) ty=Result<Stream<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -1715,18 +2001,18 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _18: Result<Stream<string>, fs.IoError>
     _19: Result<Stream<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(76) path site=SiteId(546) ty=string intent=Read
+    stmt: use BindingId(84) path site=SiteId(630) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(77) s site=SiteId(545) ty=Stream<string>
-    stmt: use BindingId(77) s site=SiteId(550) ty=Stream<string> intent=Read
+    stmt: bind BindingId(85) s site=SiteId(629) ty=Stream<string>
+    stmt: use BindingId(85) s site=SiteId(634) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(77) s site=SiteId(554) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(77) s site=SiteId(554) ty=Stream<string>
+    stmt: use BindingId(85) s site=SiteId(638) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(85) s site=SiteId(638) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -1736,23 +2022,23 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
   bb4:
     _8 = call hew_stream_last_error_kind() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(544)) ty=Result<Stream<string>, fs.IoError>
+    stmt: return site=Some(SiteId(628)) ty=Result<Stream<string>, fs.IoError>
     _19 = move _3
     ret = move _19
     return
   bb6:
-    stmt: bind BindingId(78) kind site=SiteId(556) ty=i64
+    stmt: bind BindingId(86) kind site=SiteId(640) ty=i64
     _9 = cast _8 i32 -> i64
     _10 = move _9
     _11 = call hew_stream_last_errno() -> bb7
   bb7:
-    stmt: bind BindingId(79) errno site=SiteId(559) ty=i32
+    stmt: bind BindingId(87) errno site=SiteId(643) ty=i32
     _12 = move _11
     _13 = call hew_stream_last_error() -> bb8
   bb8:
-    stmt: eval site=SiteId(561) ty=string
-    stmt: use BindingId(78) kind site=SiteId(565) ty=i64 intent=Read
-    stmt: use BindingId(79) errno site=SiteId(567) ty=i32 intent=Read
+    stmt: eval site=SiteId(645) ty=string
+    stmt: use BindingId(86) kind site=SiteId(649) ty=i64 intent=Read
+    stmt: use BindingId(87) errno site=SiteId(651) ty=i32 intent=Read
     _15 = const.i64 1
     mtag14 = move _15
     _16 = cast _12 i32 -> i64
@@ -1779,18 +2065,18 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     _11: Result<Sink<string>, string>
     _12: Result<Sink<string>, string>
   bb0:
-    stmt: use BindingId(80) path site=SiteId(571) ty=string intent=Read
+    stmt: use BindingId(88) path site=SiteId(655) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(81) s site=SiteId(570) ty=Sink<string>
-    stmt: use BindingId(81) s site=SiteId(575) ty=Sink<string> intent=Read
+    stmt: bind BindingId(89) s site=SiteId(654) ty=Sink<string>
+    stmt: use BindingId(89) s site=SiteId(659) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(81) s site=SiteId(579) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(81) s site=SiteId(579) ty=Sink<string>
+    stmt: use BindingId(89) s site=SiteId(663) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(89) s site=SiteId(663) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -1802,7 +2088,7 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(569)) ty=Result<Sink<string>, string>
+    stmt: return site=Some(SiteId(653)) ty=Result<Sink<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -1835,18 +2121,18 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _18: Result<Sink<string>, fs.IoError>
     _19: Result<Sink<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(82) path site=SiteId(586) ty=string intent=Read
+    stmt: use BindingId(90) path site=SiteId(670) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(83) s site=SiteId(585) ty=Sink<string>
-    stmt: use BindingId(83) s site=SiteId(590) ty=Sink<string> intent=Read
+    stmt: bind BindingId(91) s site=SiteId(669) ty=Sink<string>
+    stmt: use BindingId(91) s site=SiteId(674) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(83) s site=SiteId(594) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(83) s site=SiteId(594) ty=Sink<string>
+    stmt: use BindingId(91) s site=SiteId(678) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(91) s site=SiteId(678) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -1856,23 +2142,23 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
   bb4:
     _8 = call hew_stream_last_error_kind() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(584)) ty=Result<Sink<string>, fs.IoError>
+    stmt: return site=Some(SiteId(668)) ty=Result<Sink<string>, fs.IoError>
     _19 = move _3
     ret = move _19
     return
   bb6:
-    stmt: bind BindingId(84) kind site=SiteId(596) ty=i64
+    stmt: bind BindingId(92) kind site=SiteId(680) ty=i64
     _9 = cast _8 i32 -> i64
     _10 = move _9
     _11 = call hew_stream_last_errno() -> bb7
   bb7:
-    stmt: bind BindingId(85) errno site=SiteId(599) ty=i32
+    stmt: bind BindingId(93) errno site=SiteId(683) ty=i32
     _12 = move _11
     _13 = call hew_stream_last_error() -> bb8
   bb8:
-    stmt: eval site=SiteId(601) ty=string
-    stmt: use BindingId(84) kind site=SiteId(605) ty=i64 intent=Read
-    stmt: use BindingId(85) errno site=SiteId(607) ty=i32 intent=Read
+    stmt: eval site=SiteId(685) ty=string
+    stmt: use BindingId(92) kind site=SiteId(689) ty=i64 intent=Read
+    stmt: use BindingId(93) errno site=SiteId(691) ty=i32 intent=Read
     _15 = const.i64 1
     mtag14 = move _15
     _16 = cast _12 i32 -> i64
@@ -1888,11 +2174,11 @@ fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
     _0: Stream<string>
     _1: Sink<string>
   bb0:
-    stmt: use BindingId(86) source site=SiteId(611) ty=Stream<string> intent=Read
-    stmt: use BindingId(87) dest site=SiteId(612) ty=Sink<string> intent=Read
+    stmt: use BindingId(94) source site=SiteId(695) ty=Stream<string> intent=Read
+    stmt: use BindingId(95) dest site=SiteId(696) ty=Sink<string> intent=Read
     call hew_stream_pipe(_0, _1) -> bb1
   bb1:
-    stmt: eval site=SiteId(609) ty=()
+    stmt: eval site=SiteId(693) ty=()
     return
 
 fn i8::fmt(i8) -> string [conv=default]
@@ -1901,11 +2187,11 @@ fn i8::fmt(i8) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(96) val site=SiteId(684) ty=i8 intent=Read
+    stmt: use BindingId(104) val site=SiteId(768) ty=i8 intent=Read
     _1 = cast _0 i8 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(682)) ty=string
+    stmt: return site=Some(SiteId(766)) ty=string
     ret = move _2
     return
 
@@ -1915,11 +2201,11 @@ fn i16::fmt(i16) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(97) val site=SiteId(688) ty=i16 intent=Read
+    stmt: use BindingId(105) val site=SiteId(772) ty=i16 intent=Read
     _1 = cast _0 i16 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(686)) ty=string
+    stmt: return site=Some(SiteId(770)) ty=string
     ret = move _2
     return
 
@@ -1928,10 +2214,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(98) val site=SiteId(691) ty=i32 intent=Read
+    stmt: use BindingId(106) val site=SiteId(775) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(690)) ty=string
+    stmt: return site=Some(SiteId(774)) ty=string
     ret = move _1
     return
 
@@ -1940,10 +2226,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(99) val site=SiteId(694) ty=i64 intent=Read
+    stmt: use BindingId(107) val site=SiteId(778) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(693)) ty=string
+    stmt: return site=Some(SiteId(777)) ty=string
     ret = move _1
     return
 
@@ -1952,10 +2238,10 @@ fn u8::fmt(u8) -> string [conv=default]
     _0: u8
     _1: string
   bb0:
-    stmt: use BindingId(100) val site=SiteId(697) ty=u8 intent=Read
+    stmt: use BindingId(108) val site=SiteId(781) ty=u8 intent=Read
     _1 = call to_string_u8(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(696)) ty=string
+    stmt: return site=Some(SiteId(780)) ty=string
     ret = move _1
     return
 
@@ -1964,10 +2250,10 @@ fn u16::fmt(u16) -> string [conv=default]
     _0: u16
     _1: string
   bb0:
-    stmt: use BindingId(101) val site=SiteId(700) ty=u16 intent=Read
+    stmt: use BindingId(109) val site=SiteId(784) ty=u16 intent=Read
     _1 = call to_string_u16(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(699)) ty=string
+    stmt: return site=Some(SiteId(783)) ty=string
     ret = move _1
     return
 
@@ -1976,10 +2262,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(102) val site=SiteId(703) ty=u32 intent=Read
+    stmt: use BindingId(110) val site=SiteId(787) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(702)) ty=string
+    stmt: return site=Some(SiteId(786)) ty=string
     ret = move _1
     return
 
@@ -1988,10 +2274,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(103) val site=SiteId(706) ty=u64 intent=Read
+    stmt: use BindingId(111) val site=SiteId(790) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(705)) ty=string
+    stmt: return site=Some(SiteId(789)) ty=string
     ret = move _1
     return
 
@@ -2001,11 +2287,11 @@ fn isize::fmt(isize) -> string [conv=default]
     _1: i64
     _2: string
   bb0:
-    stmt: use BindingId(104) val site=SiteId(710) ty=isize intent=Read
+    stmt: use BindingId(112) val site=SiteId(794) ty=isize intent=Read
     _1 = cast _0 isize -> i64
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(708)) ty=string
+    stmt: return site=Some(SiteId(792)) ty=string
     ret = move _2
     return
 
@@ -2015,11 +2301,11 @@ fn usize::fmt(usize) -> string [conv=default]
     _1: u64
     _2: string
   bb0:
-    stmt: use BindingId(105) val site=SiteId(714) ty=usize intent=Read
+    stmt: use BindingId(113) val site=SiteId(798) ty=usize intent=Read
     _1 = cast _0 usize -> u64
     _2 = call to_string_u64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(712)) ty=string
+    stmt: return site=Some(SiteId(796)) ty=string
     ret = move _2
     return
 
@@ -2028,10 +2314,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(106) val site=SiteId(717) ty=bool intent=Read
+    stmt: use BindingId(114) val site=SiteId(801) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(716)) ty=string
+    stmt: return site=Some(SiteId(800)) ty=string
     ret = move _1
     return
 
@@ -2040,10 +2326,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(107) val site=SiteId(720) ty=char intent=Read
+    stmt: use BindingId(115) val site=SiteId(804) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(719)) ty=string
+    stmt: return site=Some(SiteId(803)) ty=string
     ret = move _1
     return
 
@@ -2052,10 +2338,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(108) val site=SiteId(723) ty=f64 intent=Read
+    stmt: use BindingId(116) val site=SiteId(807) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(722)) ty=string
+    stmt: return site=Some(SiteId(806)) ty=string
     ret = move _1
     return
 
@@ -2065,11 +2351,11 @@ fn f32::fmt(f32) -> string [conv=default]
     _1: f64
     _2: string
   bb0:
-    stmt: use BindingId(109) val site=SiteId(727) ty=f32 intent=Read
+    stmt: use BindingId(117) val site=SiteId(811) ty=f32 intent=Read
     _1 = cast _0 f32 -> f64
     _2 = call to_string_f64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(725)) ty=string
+    stmt: return site=Some(SiteId(809)) ty=string
     ret = move _2
     return
 
@@ -2077,8 +2363,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(110) val site=SiteId(729) ty=string intent=Read
-    stmt: return site=Some(SiteId(729)) ty=string
+    stmt: use BindingId(118) val site=SiteId(813) ty=string intent=Read
+    stmt: return site=Some(SiteId(813)) ty=string
     ret = move _0
     return
 
@@ -2089,14 +2375,14 @@ fn duration::from_nanos(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(111) n site=SiteId(731) ty=i64 intent=Read
+    stmt: use BindingId(119) n site=SiteId(815) ty=i64 intent=Read
     _1 = const.duration 1ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(730)) ty=duration
+    stmt: return site=Some(SiteId(814)) ty=duration
     ret = move _2
     return
 
@@ -2107,14 +2393,14 @@ fn duration::from_micros(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(112) n site=SiteId(734) ty=i64 intent=Read
+    stmt: use BindingId(120) n site=SiteId(818) ty=i64 intent=Read
     _1 = const.duration 1000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(733)) ty=duration
+    stmt: return site=Some(SiteId(817)) ty=duration
     ret = move _2
     return
 
@@ -2125,14 +2411,14 @@ fn duration::from_millis(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(113) n site=SiteId(737) ty=i64 intent=Read
+    stmt: use BindingId(121) n site=SiteId(821) ty=i64 intent=Read
     _1 = const.duration 1000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(736)) ty=duration
+    stmt: return site=Some(SiteId(820)) ty=duration
     ret = move _2
     return
 
@@ -2143,14 +2429,14 @@ fn duration::from_secs(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(114) n site=SiteId(740) ty=i64 intent=Read
+    stmt: use BindingId(122) n site=SiteId(824) ty=i64 intent=Read
     _1 = const.duration 1000000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(739)) ty=duration
+    stmt: return site=Some(SiteId(823)) ty=duration
     ret = move _2
     return
 
@@ -2162,11 +2448,11 @@ fn duration::fmt(duration) -> string [conv=default]
     _3: string
     _4: string
   bb0:
-    stmt: use BindingId(115) val site=SiteId(745) ty=duration intent=Read
+    stmt: use BindingId(123) val site=SiteId(829) ty=duration intent=Read
     _1 = call_rt hew_duration_nanos(_0)
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(742)) ty=string
+    stmt: return site=Some(SiteId(826)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
     drop _2 ty=string fn=release(hew_string_drop)

--- a/hew-codegen-rs/tests/structural/bytes_extern_fail_closed.rs
+++ b/hew-codegen-rs/tests/structural/bytes_extern_fail_closed.rs
@@ -259,12 +259,13 @@ fn unknown_bytes_param_extern_fails_closed_naming_symbol() {
 /// We test the param side: `hew_sha256_hew(data: bytes) -> bytes`. Because
 /// `hew_sha256_hew` is in `is_bytes_triple_return_producer` (return side) AND
 /// `is_bytes_struct_expansion_consumer` (param side), both guards pass.
-#[test]
-fn known_bytes_extern_does_not_fail_closed() {
-    // hew_sha256_hew takes bytes and returns bytes — both sides are registered.
-    let pipeline =
-        pipeline_with_extern("hew_sha256_hew", ResolvedTy::Bytes, vec![ResolvedTy::Bytes]);
-    let result = emit_module(&pipeline, &emit_options("sha256_known"));
+fn assert_known_bytes_extern_does_not_fail_closed(
+    symbol: &str,
+    return_ty: ResolvedTy,
+    param_tys: Vec<ResolvedTy>,
+) {
+    let pipeline = pipeline_with_extern(symbol, return_ty, param_tys);
+    let result = emit_module(&pipeline, &emit_options(symbol));
     // We do not assert Ok(_) because downstream codegen may still fail on
     // unrelated shape/lowering details; we only assert the gate did NOT fire.
     match result {
@@ -274,11 +275,47 @@ fn known_bytes_extern_does_not_fail_closed() {
                 || msg.contains("is_bytes_struct_expansion_consumer") =>
         {
             panic!(
-                "hew_sha256_hew is a known registered extern; the bytes ABI \
-                 gate must not fire for it. Got FailClosed: {msg}"
+                "{symbol} is a known registered extern; the bytes ABI gate \
+                 must not fire for it. Got FailClosed: {msg}"
             );
         }
         // Any other outcome (Ok or a different error) is acceptable here.
         _ => {}
     }
+}
+
+#[test]
+fn known_bytes_extern_does_not_fail_closed() {
+    // hew_sha256_hew takes bytes and returns bytes — both sides are registered.
+    assert_known_bytes_extern_does_not_fail_closed(
+        "hew_sha256_hew",
+        ResolvedTy::Bytes,
+        vec![ResolvedTy::Bytes],
+    );
+}
+
+#[test]
+fn quic_bytes_externs_do_not_fail_closed() {
+    // QUIC receive wrappers produce BytesTriple, and send wrappers consume a
+    // pointer to the caller's BytesTriple. Every direction must stay registered.
+    assert_known_bytes_extern_does_not_fail_closed(
+        "hew_quic_stream_recv",
+        ResolvedTy::Bytes,
+        vec![ResolvedTy::I64],
+    );
+    assert_known_bytes_extern_does_not_fail_closed(
+        "hew_quic_stream_recv_timeout_hew",
+        ResolvedTy::Bytes,
+        vec![ResolvedTy::I64, ResolvedTy::I32],
+    );
+    assert_known_bytes_extern_does_not_fail_closed(
+        "hew_quic_stream_send",
+        ResolvedTy::I32,
+        vec![ResolvedTy::I64, ResolvedTy::Bytes],
+    );
+    assert_known_bytes_extern_does_not_fail_closed(
+        "hew_quic_stream_send_timeout_hew",
+        ResolvedTy::I32,
+        vec![ResolvedTy::I64, ResolvedTy::Bytes, ResolvedTy::I32],
+    );
 }

--- a/hew-codegen-rs/tests/structural/bytes_extern_fail_closed.rs
+++ b/hew-codegen-rs/tests/structural/bytes_extern_fail_closed.rs
@@ -265,23 +265,8 @@ fn assert_known_bytes_extern_does_not_fail_closed(
     param_tys: Vec<ResolvedTy>,
 ) {
     let pipeline = pipeline_with_extern(symbol, return_ty, param_tys);
-    let result = emit_module(&pipeline, &emit_options(symbol));
-    // We do not assert Ok(_) because downstream codegen may still fail on
-    // unrelated shape/lowering details; we only assert the gate did NOT fire.
-    match result {
-        Err(CodegenError::FailClosed(msg))
-            if msg.contains("is_bytes_triple_return_producer")
-                || msg.contains("is_bytes_by_pointer_consumer")
-                || msg.contains("is_bytes_struct_expansion_consumer") =>
-        {
-            panic!(
-                "{symbol} is a known registered extern; the bytes ABI gate \
-                 must not fire for it. Got FailClosed: {msg}"
-            );
-        }
-        // Any other outcome (Ok or a different error) is acceptable here.
-        _ => {}
-    }
+    emit_module(&pipeline, &emit_options(symbol))
+        .unwrap_or_else(|error| panic!("{symbol} must emit successfully: {error:?}"));
 }
 
 #[test]

--- a/hew-runtime/src/channel.rs
+++ b/hew-runtime/src/channel.rs
@@ -133,15 +133,15 @@ impl std::fmt::Debug for HewChannelPair {
 #[no_mangle]
 pub extern "C" fn hew_channel_new(capacity: i64) -> *mut HewChannelPair {
     if capacity < 0 {
-        crate::set_last_error(format!(
-            "hew_channel_new: invalid capacity {capacity} (must be >= 0)"
-        ));
+        let message = format!("hew_channel_new: invalid capacity {capacity} (must be >= 0)");
+        crate::set_last_error(message.clone());
+        crate::stream_error::set_last_error(message);
         return ptr::null_mut();
     }
     let Ok(cap) = usize::try_from(capacity.max(1)) else {
-        crate::set_last_error(format!(
-            "hew_channel_new: capacity {capacity} exceeds platform maximum"
-        ));
+        let message = format!("hew_channel_new: capacity {capacity} exceeds platform maximum");
+        crate::set_last_error(message.clone());
+        crate::stream_error::set_last_error(message);
         return ptr::null_mut();
     };
     let core = Arc::new(ChannelCore::new(cap));
@@ -158,6 +158,12 @@ pub extern "C" fn hew_channel_new(capacity: i64) -> *mut HewChannelPair {
     })); // ALLOCATOR-PAIRING: GlobalAlloc
 
     Box::into_raw(Box::new(HewChannelPair { sender, receiver })) // ALLOCATOR-PAIRING: GlobalAlloc
+}
+
+/// Return whether `pair` is a valid channel-pair handle.
+#[no_mangle]
+pub const extern "C" fn hew_channel_pair_is_valid(pair: *const HewChannelPair) -> bool {
+    !pair.is_null()
 }
 
 /// Extract the sender from a channel pair.
@@ -703,6 +709,22 @@ pub unsafe extern "C" fn hew_channel_recv_cancel_cleanup(source: *mut c_void, _s
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn negative_capacity_returns_invalid_pair_with_exact_error() {
+        crate::hew_clear_error();
+        let pair = hew_channel_new(-1);
+        assert!(!hew_channel_pair_is_valid(pair));
+        // SAFETY: hew_last_error returns a runtime-owned NUL-terminated string.
+        let err = unsafe { CStr::from_ptr(crate::hew_last_error()) }
+            .to_str()
+            .unwrap();
+        assert_eq!(err, "hew_channel_new: invalid capacity -1 (must be >= 0)");
+        assert_eq!(
+            crate::stream_error::take_last_error().as_deref(),
+            Some("hew_channel_new: invalid capacity -1 (must be >= 0)")
+        );
+    }
     use std::ffi::{c_char, CStr};
     use std::thread;
 

--- a/hew-runtime/src/channel_wasm.rs
+++ b/hew-runtime/src/channel_wasm.rs
@@ -154,15 +154,15 @@ pub fn channel(capacity: usize) -> (WasmChannelSender, WasmChannelReceiver) {
 #[cfg_attr(target_arch = "wasm32", no_mangle)]
 pub extern "C" fn hew_channel_new(capacity: i64) -> *mut HewWasmChannelPair {
     if capacity < 0 {
-        crate::set_last_error(format!(
-            "hew_channel_new: invalid capacity {capacity} (must be >= 0)"
-        ));
+        let message = format!("hew_channel_new: invalid capacity {capacity} (must be >= 0)");
+        crate::set_last_error(message.clone());
+        crate::stream_error::set_last_error(message);
         return ptr::null_mut();
     }
     let Some(cap) = usize::try_from(capacity.max(1)).ok() else {
-        crate::set_last_error(format!(
-            "hew_channel_new: capacity {capacity} exceeds platform maximum"
-        ));
+        let message = format!("hew_channel_new: capacity {capacity} exceeds platform maximum");
+        crate::set_last_error(message.clone());
+        crate::stream_error::set_last_error(message);
         return ptr::null_mut();
     };
 
@@ -171,6 +171,16 @@ pub extern "C" fn hew_channel_new(capacity: i64) -> *mut HewWasmChannelPair {
     let receiver = Box::into_raw(Box::new(HewWasmChannelReceiver::new(receiver))); // ALLOCATOR-PAIRING: GlobalAlloc
 
     Box::into_raw(Box::new(HewWasmChannelPair { sender, receiver })) // ALLOCATOR-PAIRING: GlobalAlloc
+}
+
+/// Return whether `pair` is a valid channel-pair handle.
+#[cfg_attr(target_arch = "wasm32", no_mangle)]
+#[cfg_attr(
+    not(target_arch = "wasm32"),
+    allow(dead_code, reason = "exported only for the wasm32 channel ABI")
+)]
+pub const extern "C" fn hew_channel_pair_is_valid(pair: *const HewWasmChannelPair) -> bool {
+    !pair.is_null()
 }
 
 /// Extract the sender from a channel pair.

--- a/hew-runtime/src/stream.rs
+++ b/hew-runtime/src/stream.rs
@@ -870,7 +870,18 @@ unsafe fn rc_drop_env(env_ptr: *const c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn hew_stream_channel(capacity: i64) -> *mut HewStreamPair {
     use crate::channel_core::ChannelCore;
-    let cap = usize::try_from(capacity.max(1)).unwrap_or(1);
+    if capacity < 0 {
+        set_last_error(format!(
+            "hew_stream_channel: invalid capacity {capacity} (must be >= 0)"
+        ));
+        return ptr::null_mut();
+    }
+    let Ok(cap) = usize::try_from(capacity.max(1)) else {
+        set_last_error(format!(
+            "hew_stream_channel: capacity {capacity} exceeds platform maximum"
+        ));
+        return ptr::null_mut();
+    };
     let core = Arc::new(ChannelCore::new(cap));
     // Borrow the allocation address before the Arc clones move; the address is
     // stable and stays valid while either handle (each holding an Arc clone)
@@ -905,6 +916,12 @@ pub unsafe extern "C" fn hew_stream_channel(capacity: i64) -> *mut HewStreamPair
         sink: sink_ptr,
         stream: stream_ptr,
     }))
+}
+
+/// Return whether `pair` is a valid stream-pair handle.
+#[no_mangle]
+pub const extern "C" fn hew_stream_pair_is_valid(pair: *const HewStreamPair) -> bool {
+    !pair.is_null()
 }
 
 /// Channel-sink callback: blocking write (default callers). Suspending callers
@@ -2857,6 +2874,18 @@ mod tests {
         assert!(!pair.is_null());
         // SAFETY: pair was just created.
         unsafe { hew_stream_pair_free(pair) };
+    }
+
+    #[test]
+    fn channel_negative_capacity_returns_invalid_pair_with_exact_error() {
+        let _ = hew_cabi::sink::take_last_error();
+        // SAFETY: negative capacity is explicitly validated.
+        let pair = unsafe { hew_stream_channel(-1) };
+        assert!(!hew_stream_pair_is_valid(pair));
+        assert_eq!(
+            hew_cabi::sink::take_last_error().as_deref(),
+            Some("hew_stream_channel: invalid capacity -1 (must be >= 0)")
+        );
     }
 
     #[test]

--- a/hew-std/src/http/client.rs
+++ b/hew-std/src/http/client.rs
@@ -118,18 +118,18 @@ pub struct HewHttpResponse {
     pub body_allocation_failed: bool,
 }
 
-/// Collect all response headers into a heap-allocated `Vec<(String, String)>`.
-fn capture_headers(map: &ureq::http::HeaderMap) -> *mut Vec<(String, String)> {
-    let pairs: Vec<(String, String)> = map
-        .iter()
-        .filter_map(|(name, value)| {
-            value
-                .to_str()
-                .ok()
-                .map(|v| (name.to_string(), v.to_string()))
-        })
-        .collect();
-    Box::into_raw(Box::new(pairs))
+/// Collect all response headers without silently dropping non-UTF-8 values.
+fn capture_headers(map: &ureq::http::HeaderMap) -> Result<*mut Vec<(String, String)>, String> {
+    let mut pairs = Vec::with_capacity(map.len());
+    for (name, value) in map {
+        let value = value.to_str().map_err(|_| {
+            format!(
+                "response header `{name}` contains bytes that cannot be represented as a Hew string"
+            )
+        })?;
+        pairs.push((name.to_string(), value.to_string()));
+    }
+    Ok(Box::into_raw(Box::new(pairs)))
 }
 
 /// Build a [`HewHttpResponse`] from a Rust string body and captured headers.
@@ -272,7 +272,10 @@ fn make_agent() -> ureq::Agent {
 /// error response.
 fn finish_response(mut resp: ureq::http::Response<ureq::Body>) -> *mut HewHttpResponse {
     let status = resp.status().as_u16();
-    let headers = capture_headers(resp.headers());
+    let headers = match capture_headers(resp.headers()) {
+        Ok(headers) => headers,
+        Err(message) => return error_response(&message),
+    };
     match resp.body_mut().read_to_string() {
         Ok(body) => build_response(i32::from(status), &body, headers),
         Err(e) => {
@@ -869,6 +872,33 @@ mod tests {
     use super::*;
     use std::ffi::CString;
     use std::ptr;
+
+    #[test]
+    fn capture_headers_rejects_non_utf8_value_instead_of_dropping_it() {
+        let mut headers = ureq::http::HeaderMap::new();
+        headers.insert(
+            ureq::http::HeaderName::from_static("x-opaque"),
+            ureq::http::HeaderValue::from_bytes(&[0x80]).unwrap(),
+        );
+        let err = capture_headers(&headers).unwrap_err();
+        assert_eq!(
+            err,
+            "response header `x-opaque` contains bytes that cannot be represented as a Hew string"
+        );
+    }
+
+    #[test]
+    fn capture_headers_preserves_valid_values() {
+        let mut headers = ureq::http::HeaderMap::new();
+        headers.insert(
+            ureq::http::HeaderName::from_static("x-test"),
+            ureq::http::HeaderValue::from_static("present"),
+        );
+        let pairs = capture_headers(&headers).unwrap();
+        // SAFETY: capture_headers allocated this Vec with Box::into_raw.
+        let pairs = unsafe { Box::from_raw(pairs) };
+        assert_eq!(pairs.as_slice(), &[("x-test".into(), "present".into())]);
+    }
 
     /// Read a response and free it; returns `(status_code, body_string)`.
     ///

--- a/hew-std/src/http/server.rs
+++ b/hew-std/src/http/server.rs
@@ -82,7 +82,7 @@ impl ResponseThreadTracker {
         &self,
         request: tiny_http::Request,
         status: u16,
-        content_type: Option<String>,
+        content_type: Option<tiny_http::Header>,
         reader: ChannelReader,
     ) {
         self.reap_completed();
@@ -106,15 +106,8 @@ impl ResponseThreadTracker {
                 None, // No Content-Length — tiny_http uses chunked encoding
                 None,
             );
-            if let Some(ct) = content_type {
-                match tiny_http::Header::from_bytes("Content-Type", ct) {
-                    Ok(header) => {
-                        response = response.with_header(header);
-                    }
-                    Err(err) => {
-                        eprintln!("hew_http: ignoring invalid Content-Type header: {err:?}");
-                    }
-                }
+            if let Some(header) = content_type {
+                response = response.with_header(header);
             }
             if let Err(err) = request.respond(response) {
                 eprintln!("hew_http: streaming response thread failed to respond: {err}");
@@ -623,6 +616,19 @@ pub unsafe extern "C" fn hew_http_respond(
     if req.is_null() {
         return -1;
     }
+    let Ok(status_code) = validate_http_status(status) else {
+        set_last_error(format!(
+            "invalid HTTP response status {status}: expected 100..=599"
+        ));
+        return -1;
+    };
+    let content_type = match response_content_type_header(content_type) {
+        Ok(header) => header,
+        Err(message) => {
+            set_last_error(message);
+            return -1;
+        }
+    };
     // SAFETY: req was allocated by hew_http_server_recv and is valid.
     let request = unsafe { &mut *req };
     let Some(inner) = request.inner.take() else {
@@ -636,24 +642,10 @@ pub unsafe extern "C" fn hew_http_respond(
         unsafe { std::slice::from_raw_parts(body, body_len) }.to_vec()
     };
 
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "HTTP status codes fit in u16"
-    )]
-    #[expect(
-        clippy::cast_sign_loss,
-        reason = "status codes are always non-negative in practice"
-    )]
-    let status_code = tiny_http::StatusCode(status.max(0) as u16);
-    let mut response = tiny_http::Response::from_data(body_vec).with_status_code(status_code);
-
-    if !content_type.is_null() {
-        // SAFETY: content_type is a valid NUL-terminated C string per caller contract.
-        if let Ok(ct) = unsafe { CStr::from_ptr(content_type) }.to_str() {
-            if let Ok(header) = tiny_http::Header::from_bytes("Content-Type", ct) {
-                response = response.with_header(header);
-            }
-        }
+    let mut response = tiny_http::Response::from_data(body_vec)
+        .with_status_code(tiny_http::StatusCode(status_code));
+    if let Some(header) = content_type {
+        response = response.with_header(header);
     }
 
     if inner.respond(response).is_ok() {
@@ -851,22 +843,24 @@ pub unsafe extern "C" fn hew_http_respond_stream(
         set_last_error("invalid request pointer".into());
         return std::ptr::null_mut();
     }
+    let Ok(status_u16) = validate_http_status(status) else {
+        set_last_error(format!(
+            "invalid HTTP response status {status}: expected 100..=599"
+        ));
+        return std::ptr::null_mut();
+    };
+    let ct_header = match response_content_type_header(content_type) {
+        Ok(header) => header,
+        Err(message) => {
+            set_last_error(message);
+            return std::ptr::null_mut();
+        }
+    };
     // SAFETY: req was allocated by hew_http_server_recv and is valid.
     let request = unsafe { &mut *req };
     let Some(inner) = request.inner.take() else {
         set_last_error("request already responded to".into());
         return std::ptr::null_mut();
-    };
-
-    // Parse content type before spawning the thread.
-    let ct_string = if content_type.is_null() {
-        None
-    } else {
-        // SAFETY: content_type is a valid NUL-terminated C string per contract.
-        unsafe { CStr::from_ptr(content_type) }
-            .to_str()
-            .ok()
-            .map(String::from)
     };
 
     let Some(response_threads) = request.response_threads.clone() else {
@@ -885,21 +879,38 @@ pub unsafe extern "C" fn hew_http_respond_stream(
         offset: 0,
     };
 
-    #[expect(
-        clippy::cast_possible_truncation,
-        reason = "HTTP status codes fit in u16"
-    )]
-    #[expect(
-        clippy::cast_sign_loss,
-        reason = "status codes are always non-negative in practice"
-    )]
-    let status_u16 = status.max(0) as u16;
-
-    response_threads.spawn_response(inner, status_u16, ct_string, reader);
+    response_threads.spawn_response(inner, status_u16, ct_header, reader);
     into_write_sink_ptr(HttpResponseSink {
         cancel,
         tx: Some(tx),
     })
+}
+
+fn validate_http_status(status: i32) -> Result<u16, ()> {
+    let status = u16::try_from(status).map_err(|_| ())?;
+    if (100..=599).contains(&status) {
+        Ok(status)
+    } else {
+        Err(())
+    }
+}
+
+fn response_content_type_header(
+    content_type: *const c_char,
+) -> Result<Option<tiny_http::Header>, String> {
+    if content_type.is_null() {
+        return Ok(None);
+    }
+    // SAFETY: caller guarantees a valid NUL-terminated C string.
+    let value = unsafe { CStr::from_ptr(content_type) }
+        .to_str()
+        .map_err(|_| "invalid Content-Type: value is not UTF-8".to_string())?;
+    if value.bytes().any(|byte| byte < b' ' || byte == 0x7f) {
+        return Err("invalid Content-Type: value contains forbidden bytes".to_string());
+    }
+    tiny_http::Header::from_bytes("Content-Type", value)
+        .map(Some)
+        .map_err(|()| "invalid Content-Type: value contains forbidden bytes".to_string())
 }
 
 /// Close and free the HTTP server.
@@ -1010,6 +1021,37 @@ pub unsafe extern "C" fn hew_http_request_headers(req: *const HewHttpRequest) ->
 mod tests {
     use super::*;
     use std::net::{Shutdown, SocketAddr, TcpStream};
+
+    #[test]
+    fn invalid_response_status_is_rejected_exactly() {
+        assert_eq!(validate_http_status(99), Err(()));
+        assert_eq!(validate_http_status(600), Err(()));
+        assert_eq!(validate_http_status(200), Ok(200));
+    }
+
+    #[test]
+    fn invalid_content_type_is_rejected_exactly() {
+        let invalid = c"text/plain\r\nX-Injected: yes";
+        assert_eq!(
+            response_content_type_header(invalid.as_ptr()).unwrap_err(),
+            "invalid Content-Type: value contains forbidden bytes"
+        );
+
+        let mut req = HewHttpRequest {
+            inner: None,
+            max_body_size: MAX_BODY_SIZE,
+            request_body_timeout: DEFAULT_REQUEST_BODY_TIMEOUT,
+            response_threads: None,
+        };
+        // SAFETY: req is a valid local handle and invalid is a valid C string.
+        let result =
+            unsafe { hew_http_respond(&raw mut req, 200, std::ptr::null(), 0, invalid.as_ptr()) };
+        assert_eq!(result, -1);
+        assert_eq!(
+            hew_cabi::sink::take_last_error().as_deref(),
+            Some("invalid Content-Type: value contains forbidden bytes")
+        );
+    }
 
     fn wait_for_condition(
         description: &str,

--- a/hew-std/src/quic.rs
+++ b/hew-std/src/quic.rs
@@ -1477,17 +1477,17 @@ pub unsafe extern "C" fn hew_quic_stream_recv_timeout(
 // per function. Cleared at the start of every `_hew` call so stale state
 // from another stream cannot leak across calls.
 std::thread_local! {
-    static LAST_RECV_TIMED_OUT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static LAST_RECV_STATUS: std::cell::Cell<c_int> = const { std::cell::Cell::new(0) };
 }
 
-fn set_last_recv_timed_out(v: bool) {
-    LAST_RECV_TIMED_OUT.with(|c| c.set(v));
+fn set_last_recv_status(status: c_int) {
+    LAST_RECV_STATUS.with(|cell| cell.set(status));
 }
 
 #[no_mangle]
 /// Hew-friendly `recv_timeout`: returns a `BytesTriple` (empty on timeout or
-/// error). Hew callers query [`hew_quic_stream_last_recv_timed_out`] to
-/// distinguish a timeout from an EOF/error outcome.
+/// error). Hew callers query [`hew_quic_stream_last_recv_status`] to
+/// distinguish success/EOF (`0`), transport error (`-1`), and timeout (`-2`).
 ///
 /// # Safety
 ///
@@ -1496,17 +1496,20 @@ pub unsafe extern "C" fn hew_quic_stream_recv_timeout_hew(
     stream: *mut HewQuicStream,
     deadline_ms: i32,
 ) -> BytesTriple {
-    set_last_recv_timed_out(false);
+    set_last_recv_status(0);
     let mut out = empty_bytes_triple();
     // SAFETY: forwarded contract. `&raw mut out` is a valid writable slot.
     let status = unsafe { hew_quic_stream_recv_timeout(stream, deadline_ms, &raw mut out) };
     match status {
         0 => out,
         -2 => {
-            set_last_recv_timed_out(true);
+            set_last_recv_status(-2);
             empty_bytes_triple()
         }
-        _ => empty_bytes_triple(),
+        _ => {
+            set_last_recv_status(-1);
+            empty_bytes_triple()
+        }
     }
 }
 
@@ -1534,7 +1537,15 @@ pub unsafe extern "C" fn hew_quic_stream_recv_timeout_hew_raw(
 /// `hew_quic_stream_send_timeout_hew` call on this thread observed a
 /// deadline expiry. The value is reset at the start of every `_hew` call.
 pub extern "C" fn hew_quic_stream_last_recv_timed_out() -> i32 {
-    LAST_RECV_TIMED_OUT.with(|c| i32::from(c.get()))
+    i32::from(LAST_RECV_STATUS.with(std::cell::Cell::get) == -2)
+}
+
+/// Return the status from the last Hew-friendly timed receive on this thread.
+///
+/// `0` means data or EOF, `-1` means transport failure, and `-2` means timeout.
+#[no_mangle]
+pub extern "C" fn hew_quic_stream_last_recv_status() -> c_int {
+    LAST_RECV_STATUS.with(std::cell::Cell::get)
 }
 
 #[no_mangle]
@@ -1615,7 +1626,14 @@ pub unsafe extern "C" fn hew_quic_stream_stop(
         let _ = stream.events.push(EVENT_ERROR);
         return -1;
     };
-    let code = quinn::VarInt::try_from(error_code.unsigned_abs()).unwrap_or(quinn::VarInt::MAX);
+    let code = match quic_application_error_code(error_code) {
+        Ok(code) => code,
+        Err(message) => {
+            update_stream(stream, |state| state.last_error = message);
+            let _ = stream.events.push(EVENT_ERROR);
+            return -1;
+        }
+    };
     match send.reset(code) {
         Ok(()) => {
             update_stream(stream, |state| {
@@ -1631,6 +1649,15 @@ pub unsafe extern "C" fn hew_quic_stream_stop(
             -1
         }
     }
+}
+
+fn quic_application_error_code(error_code: i64) -> Result<quinn::VarInt, String> {
+    let code = u64::try_from(error_code).map_err(|_| {
+        format!("invalid QUIC application error code {error_code}: expected 0..=2^62-1")
+    })?;
+    quinn::VarInt::try_from(code).map_err(|_| {
+        format!("invalid QUIC application error code {error_code}: expected 0..=2^62-1")
+    })
 }
 
 #[no_mangle]
@@ -1794,6 +1821,30 @@ mod tests {
     use std::thread;
 
     use hew_runtime::bytes::hew_bytes_drop;
+
+    #[test]
+    fn timed_receive_transport_failure_has_distinct_status() {
+        // SAFETY: null streams are explicitly rejected by the ABI.
+        let payload = unsafe { hew_quic_stream_recv_timeout_hew(std::ptr::null_mut(), 10) };
+        assert_eq!(payload.len, 0);
+        assert_eq!(hew_quic_stream_last_recv_status(), -1);
+        assert_eq!(hew_quic_stream_last_recv_timed_out(), 0);
+    }
+
+    #[test]
+    fn invalid_application_error_codes_are_rejected_exactly() {
+        assert_eq!(
+            quic_application_error_code(-7).unwrap_err(),
+            "invalid QUIC application error code -7: expected 0..=2^62-1"
+        );
+        assert_eq!(
+            quic_application_error_code(i64::MAX).unwrap_err(),
+            format!(
+                "invalid QUIC application error code {}: expected 0..=2^62-1",
+                i64::MAX
+            )
+        );
+    }
 
     unsafe fn take_event_kind(event: *mut HewQuicEvent) -> i32 {
         assert!(!event.is_null(), "event pointer must not be null");

--- a/hew-types/src/stdlib_loader.rs
+++ b/hew-types/src/stdlib_loader.rs
@@ -873,6 +873,53 @@ fn extract_handle_forwarding_target(body: &Block, ctx: &WrapperForward) -> Optio
     None
 }
 
+/// Recognise a fielded resource-wrapper forward guarded by one early return.
+///
+/// A validation guard makes the method non-trivial, so it must not be collapsed
+/// into a direct handle-method rewrite: the real impl body has to run the guard.
+/// This accepts only `if condition { return ...; }` or
+/// `if condition { panic(...); }` followed by the same validated
+/// `self.<field>` extern forward that
+/// [`extract_handle_forwarding_target`] accepts. Any additional guard statement,
+/// else branch, or non-forwarding tail remains unregistered.
+fn extract_guarded_handle_forwarding_target(
+    body: &Block,
+    ctx: &WrapperForward,
+) -> Option<(String, usize)> {
+    let [(
+        Stmt::If {
+            then_block,
+            else_block: None,
+            ..
+        },
+        _,
+    )] = body.stmts.as_slice()
+    else {
+        return None;
+    };
+    if !is_immediate_terminating_guard(then_block) {
+        return None;
+    }
+    let trailing = body.trailing_expr.as_ref()?;
+    handle_forwarding_call_from_expr(&trailing.0, ctx)
+}
+
+/// True when a guard block has one terminating statement and cannot fall through
+/// to the extern forward. `panic` is the only non-returning call accepted here;
+/// broadening this to arbitrary calls would hide non-trivial wrapper bodies.
+fn is_immediate_terminating_guard(block: &Block) -> bool {
+    if block.trailing_expr.is_some() {
+        return false;
+    }
+    match block.stmts.as_slice() {
+        [(Stmt::Return(_), _)] => true,
+        [(Stmt::Expression((Expr::Call { function, .. }, _)), _)] => {
+            matches!(&function.0, Expr::Identifier(name) if name == "panic")
+        }
+        _ => false,
+    }
+}
+
 /// Find a handle-forwarding extern call in a wrapper method's tail expression,
 /// peeling `unsafe`/block/cast wrappers and the wrapper-constructing clone
 /// literal. A call qualifies when the callee is one of the module's extern
@@ -1091,6 +1138,18 @@ fn extract_handle_methods(
                     field_names,
                     extern_fn_names,
                 };
+                extract_guarded_handle_forwarding_target(&method.body, &ctx)
+                    .map(|target| (target, true))
+            })
+            .or_else(|| {
+                let field_names = wrapper_field_names?;
+                let receiver = method.params.first()?.name.as_str();
+                let ctx = WrapperForward {
+                    receiver,
+                    wrapper_simple_name,
+                    field_names,
+                    extern_fn_names,
+                };
                 extract_handle_forwarding_target(&method.body, &ctx).map(|target| (target, true))
             })
             // Authoritative extern gate for BOTH extraction paths: a handle
@@ -1286,21 +1345,28 @@ mod tests {
 
     #[test]
     fn load_http_module_registers_handle_methods_through_abi_width_casts() {
-        // `impl RequestMethods for Request` wraps `status: int` in `status as i32`
-        // before calling the C shim. Those casts are pure ABI-width narrowing and
-        // must not prevent the method from registering as a handle pass-through —
-        // otherwise the type checker reports `no method respond on http.Request`.
+        // `impl RequestMethods for Request` validates the status before forwarding
+        // it through an i32 ABI cast. The loader must retain the imported method
+        // signatures, but the guard means each call must dispatch through the
+        // real impl body rather than bypassing validation with a direct extern
+        // rewrite.
         let info =
             load_module("std::net::http", &test_root()).expect("should load std::net::http module");
 
         for method in ["respond", "respond_text", "respond_json", "respond_stream"] {
-            let found = info
+            let handle_method = info
                 .handle_methods
                 .iter()
-                .any(|m| m.type_name == "http.Request" && m.method_name == method);
+                .find(|m| m.type_name == "http.Request" && m.method_name == method);
             assert!(
-                found,
-                "http.Request.{method} should register as a handle method even when its C shim uses `status as i32`"
+                handle_method.is_some(),
+                "http.Request.{method} should retain its imported method signature \
+                 after adding a status-validation guard"
+            );
+            assert!(
+                handle_method.is_some_and(|m| m.dispatch_through_impl),
+                "http.Request.{method} must dispatch through its impl body so its \
+                 status-validation guard cannot be bypassed"
             );
         }
     }
@@ -1986,6 +2052,50 @@ mod tests {
         assert!(
             !handle_method_registered(&info, "m.Wrap", "bad"),
             "forwarding to a non-extern Hew helper must not register, got: {:?}",
+            info.handle_methods
+        );
+    }
+
+    #[test]
+    fn guarded_wrapper_forward_requires_single_early_return_guard() {
+        let result = parse(
+            "#[resource]\n\
+             pub type Wrap { handle: i64; }\n\
+             impl Wrap {\n\
+             \x20   fn good(w: Wrap, status: i64) -> i64 {\n\
+             \x20       if status < 0 { return -1; }\n\
+             \x20       unsafe { c_use(w.handle, status) }\n\
+             \x20   }\n\
+             \x20   fn bad(w: Wrap, status: i64) -> i64 {\n\
+             \x20       if status < 0 { c_touch(w.handle); return -1; }\n\
+             \x20       unsafe { c_use(w.handle, status) }\n\
+             \x20   }\n\
+             }\n\
+             extern \"C\" {\n\
+             \x20   fn c_use(h: i64, status: i64) -> i64;\n\
+             \x20   fn c_touch(h: i64);\n\
+             }\n",
+        );
+        assert!(
+            result.errors.is_empty(),
+            "parse errors: {:?}",
+            result.errors
+        );
+        let info = extract_module_info(&result.program, "m");
+
+        let good = info
+            .handle_methods
+            .iter()
+            .find(|m| m.type_name == "m.Wrap" && m.method_name == "good");
+        assert!(
+            good.is_some_and(|m| m.dispatch_through_impl),
+            "a single early-return guard plus a field forward should register for \
+             impl-body dispatch, got: {:?}",
+            info.handle_methods
+        );
+        assert!(
+            !handle_method_registered(&info, "m.Wrap", "bad"),
+            "a guard with extra work must not register as a thin forwarding method, got: {:?}",
             info.handle_methods
         );
     }

--- a/std/channel/channel.hew
+++ b/std/channel/channel.hew
@@ -165,12 +165,33 @@ impl ReceiverMethods for Receiver {
 /// println(rx.recv());     // infers Receiver<string>
 /// ```
 pub fn new(capacity: i64) -> (Sender, Receiver) {
+    match try_new(capacity) {
+        Ok(pair) => pair,
+        Err(err) => panic(err),
+    }
+}
+
+/// Try to create a bounded MPSC channel with the given capacity.
+///
+/// Returns `Err` when the capacity is invalid instead of returning null-backed
+/// sender and receiver handles.
+pub fn try_new(capacity: i64) -> Result<(Sender, Receiver), string> {
+    if capacity < 0 {
+        return Err(f"channel.new: invalid capacity {capacity} (must be >= 0)");
+    }
     unsafe {
         let pair = hew_channel_new(capacity as i64); // INTERNAL-ABI: runtime ABI takes i64 capacity
+        if !hew_channel_pair_is_valid(pair) {
+            let detail = hew_stream_last_error();
+            if detail == "" {
+                return Err("channel.new: channel allocation failed");
+            }
+            return Err(detail);
+        }
         let tx = hew_channel_pair_sender(pair);
         let rx = hew_channel_pair_receiver(pair);
         hew_channel_pair_free(pair);
-        (tx, rx)
+        Ok((tx, rx))
     }
 }
 
@@ -182,9 +203,11 @@ pub type ChannelPair {
 
 extern "C" {
     fn hew_channel_new(capacity: i64) -> ChannelPair;
+    fn hew_channel_pair_is_valid(pair: ChannelPair) -> bool;
     fn hew_channel_pair_sender(pair: ChannelPair) -> Sender;
     fn hew_channel_pair_receiver(pair: ChannelPair) -> Receiver;
     fn hew_channel_pair_free(pair: ChannelPair);
+    fn hew_stream_last_error() -> string;
     // hew_channel_send_layout, hew_channel_recv_layout, and
     // hew_channel_try_recv_layout use an out-parameter + element-layout
     // witness ABI and are declared by codegen with the correct calling

--- a/std/crypto/password/password.hew
+++ b/std/crypto/password/password.hew
@@ -43,9 +43,24 @@ pub fn hash(password: string) -> string {
 /// }
 /// ```
 pub fn verify(password: string, hash: string) -> bool {
-    unsafe {
+    match try_verify(password, hash) {
+        Ok(matches) => matches,
+        Err(err) => panic(err),
+    }
+}
+
+/// Verify a password while distinguishing malformed hashes from mismatches.
+pub fn try_verify(password: string, hash: string) -> Result<bool, string> {
+    let status = unsafe {
         hew_password_verify(password, hash)
-    } == 1
+    };
+    if status == 1 {
+        Ok(true)
+    } else if status == 0 {
+        Ok(false)
+    } else {
+        Err("password.verify: malformed password hash")
+    }
 }
 
 /// Hash a password using Argon2id with a custom cost (iteration count).
@@ -58,8 +73,24 @@ pub fn verify(password: string, hash: string) -> bool {
 /// let hash = password.hash_custom("hunter2", 6);
 /// ```
 pub fn hash_custom(password: string, cost: i64) -> string {
-    unsafe {
+    match try_hash_custom(password, cost) {
+        Ok(hash) => hash,
+        Err(err) => panic(err),
+    }
+}
+
+/// Hash with a custom cost while rejecting values that cannot cross the ABI.
+pub fn try_hash_custom(password: string, cost: i64) -> Result<string, string> {
+    if cost < 1 || cost > 2147483647 {
+        return Err(f"password.hash_custom: invalid cost {cost} (must be 1..=2147483647)");
+    }
+    let hash = unsafe {
         hew_password_hash_custom(password, cost as i32)
+    };
+    if hash == "" {
+        Err("password.hash_custom: hashing failed")
+    } else {
+        Ok(hash)
     }
 }
 

--- a/std/net/http/http.hew
+++ b/std/net/http/http.hew
@@ -188,24 +188,36 @@ impl RequestMethods for Request {
     }
     /// Send a full HTTP response with status, content-type, and body.
     fn respond(req: Request, status: i64, content_type: string, body: string) -> i64 {
+        if !valid_response_status(status) {
+            return -1;
+        }
         unsafe {
             hew_http_respond_bridge(req.handle, status as i32, content_type, body) as i64
         } // INTERNAL-ABI: C ABI status is i32
     }
     /// Send a plain-text HTTP response.
     fn respond_text(req: Request, status: i64, body: string) -> i64 {
+        if !valid_response_status(status) {
+            return -1;
+        }
         unsafe {
             hew_http_respond_text(req.handle, status as i32, body) as i64
         } // INTERNAL-ABI: C ABI status is i32
     }
     /// Send a JSON HTTP response with `Content-Type: application/json`.
     fn respond_json(req: Request, status: i64, json: string) -> i64 {
+        if !valid_response_status(status) {
+            return -1;
+        }
         unsafe {
             hew_http_respond_json(req.handle, status as i32, json) as i64
         } // INTERNAL-ABI: C ABI status is i32
     }
     /// Begin a streaming response and return a `Sink` for chunked output.
     fn respond_stream(req: Request, status: i64, content_type: string) -> Sink<string> {
+        if !valid_response_status(status) {
+            panic(f"http.respond_stream: invalid status {status} (must be 100..=599)");
+        }
         unsafe {
             hew_http_respond_stream(req.handle, status as i32, content_type)
         } // INTERNAL-ABI: C ABI status is i32
@@ -216,9 +228,13 @@ impl RequestMethods for Request {
         //   directly to preserve the i32 truncation the FFI signature requires.
         // WHEN — remove when codegen correctly propagates explicit casts through method-call inlining.
         // WHAT — restore to: let n = req.respond(status, content_type, body);
-        let n = unsafe {
-            hew_http_respond_bridge(req.handle, status as i32, content_type, body)
-        } as i64;
+        let n = if valid_response_status(status) {
+            unsafe {
+                hew_http_respond_bridge(req.handle, status as i32, content_type, body)
+            } as i64
+        } else {
+            -1
+        };
         if n < 0 {
             Err(net.net_error_from_errno(0))
         } else {
@@ -231,9 +247,13 @@ impl RequestMethods for Request {
         //   directly to preserve the i32 truncation the FFI signature requires.
         // WHEN — remove when codegen correctly propagates explicit casts through method-call inlining.
         // WHAT — restore to: let n = req.respond_text(status, body);
-        let n = unsafe {
-            hew_http_respond_text(req.handle, status as i32, body)
-        } as i64;
+        let n = if valid_response_status(status) {
+            unsafe {
+                hew_http_respond_text(req.handle, status as i32, body)
+            } as i64
+        } else {
+            -1
+        };
         if n < 0 {
             Err(net.net_error_from_errno(0))
         } else {
@@ -246,9 +266,13 @@ impl RequestMethods for Request {
         //   directly to preserve the i32 truncation the FFI signature requires.
         // WHEN — remove when codegen correctly propagates explicit casts through method-call inlining.
         // WHAT — restore to: let n = req.respond_json(status, json);
-        let n = unsafe {
-            hew_http_respond_json(req.handle, status as i32, json)
-        } as i64;
+        let n = if valid_response_status(status) {
+            unsafe {
+                hew_http_respond_json(req.handle, status as i32, json)
+            } as i64
+        } else {
+            -1
+        };
         if n < 0 {
             Err(net.net_error_from_errno(0))
         } else {
@@ -257,23 +281,31 @@ impl RequestMethods for Request {
     }
     /// Begin a streaming response; returns Err(NetError::Other(0)) on failure.
     fn try_respond_stream(req: Request, status: i64, content_type: string) -> Result<Sink<string>, net.NetError> {
-        let sink = unsafe {
-            hew_http_respond_stream(req.handle, status as i32, content_type)
-        };
-        // HTTP has no errno channel; the runtime sets a message via set_last_error
-        // on the two failure paths (null req, already-responded).  The errno side-
-        // channel is always 0 here, so Other(0) is the correct classification.
-        if unsafe {
-            hew_sink_is_valid(sink)
-        } {
-            Ok(sink)
+        if valid_response_status(status) {
+            let sink = unsafe {
+                hew_http_respond_stream(req.handle, status as i32, content_type)
+            };
+            // HTTP has no errno channel; the runtime sets a message via set_last_error
+            // on the two failure paths (null req, already-responded).  The errno side-
+            // channel is always 0 here, so Other(0) is the correct classification.
+            if unsafe {
+                hew_sink_is_valid(sink)
+            } {
+                Ok(sink)
+            } else {
+                let _ = unsafe {
+                    hew_stream_last_error()
+                }; // consume the error message
+                Err(net.net_error_from_errno(0))
+            }
         } else {
-            let _ = unsafe {
-                hew_stream_last_error()
-            }; // consume the error message
             Err(net.net_error_from_errno(0))
         }
     }
+}
+
+fn valid_response_status(status: i64) -> bool {
+    status >= 100 && status <= 599
 }
 
 impl Request {

--- a/std/net/http/http_async_client.hew
+++ b/std/net/http/http_async_client.hew
@@ -183,10 +183,7 @@ pub fn split_address(url_str: string) -> (string, string) {
     let scheme = scheme_of(url_str);
     let after_scheme = strip_scheme(url_str);
     // The authority runs up to the first '/' (the path), '?' (query), or end.
-    let (authority, path) = match after_scheme.find("/") {
-        Some(slash) => (after_scheme.slice(0, slash), after_scheme.slice(slash, after_scheme.len())),
-        None => (after_scheme, "/"),
-    };
+    let (authority, path) = split_authority_path(after_scheme);
     let addr = authority_with_port(authority, scheme);
     (addr, path)
 }
@@ -194,13 +191,45 @@ pub fn split_address(url_str: string) -> (string, string) {
 /// Return the host component of `url_str` for the `Host:` header (no port).
 pub fn host_of(url_str: string) -> string {
     let after_scheme = strip_scheme(url_str);
-    let authority = match after_scheme.find("/") {
-        Some(slash) => after_scheme.slice(0, slash),
-        None => after_scheme,
+    let (authority, _) = split_authority_path(after_scheme);
+    if authority.starts_with("[") {
+        match authority.find("]") {
+            Some(end) => authority.slice(0, end + 1),
+            None => authority,
+        }
+    } else {
+        match authority.find(":") {
+            Some(colon) => authority.slice(0, colon),
+            None => authority,
+        }
+    }
+}
+
+fn split_authority_path(after_scheme: string) -> (string, string) {
+    let slash = after_scheme.find("/");
+    let query = after_scheme.find("?");
+    let end = match slash {
+        Some(s) => match query {
+            Some(q) => if s < q {
+                Some(s)
+            } else {
+                Some(q)
+            },
+            None => Some(s),
+        },
+        None => query,
     };
-    match authority.find(":") {
-        Some(colon) => authority.slice(0, colon),
-        None => authority,
+    match end {
+        Some(i) => {
+            let authority = after_scheme.slice(0, i);
+            let suffix = after_scheme.slice(i, after_scheme.len());
+            if suffix.starts_with("?") {
+                (authority, "/" + suffix)
+            } else {
+                (authority, suffix)
+            }
+        },
+        None => (after_scheme, "/"),
     }
 }
 
@@ -232,9 +261,22 @@ fn strip_scheme(url_str: string) -> string {
 /// Ensure an authority carries an explicit port, appending the scheme default
 /// when absent (so `net.connect` always receives `host:port`).
 fn authority_with_port(authority: string, scheme: string) -> string {
-    match authority.find(":") {
-        Some(_) => authority,
-        None => f"{authority}:{default_port(scheme)}",
+    if authority.starts_with("[") {
+        match authority.find("]") {
+            Some(end) => {
+                if end + 1 < authority.len() && authority.slice(end + 1, end + 2) == ":" {
+                    authority
+                } else {
+                    f"{authority}:{default_port(scheme)}"
+                }
+            },
+            None => f"{authority}:{default_port(scheme)}",
+        }
+    } else {
+        match authority.find(":") {
+            Some(_) => authority,
+            None => f"{authority}:{default_port(scheme)}",
+        }
     }
 }
 

--- a/std/net/http/http_async_server.hew
+++ b/std/net/http/http_async_server.hew
@@ -282,6 +282,9 @@ pub fn response_json(status: i64, json: string) -> string {
 /// such a value is rejected and an empty string is returned (the acceptor writes
 /// nothing and closes) rather than emitting an attacker-controlled header.
 pub fn build_response(status: i64, content_type: string, body: string) -> string {
+    if status < 100 || status > 599 {
+        return "";
+    }
     if has_control_char(content_type) {
         return "";
     }

--- a/std/net/quic/quic.hew
+++ b/std/net/quic/quic.hew
@@ -709,7 +709,7 @@ extern "C" {
     fn hew_quic_stream_send_timeout_hew(stream: QUICStream, data: bytes, deadline_ms: i32) -> i32; // INTERNAL-ABI: 0=ok, -1=error, -2=timeout
     fn hew_quic_stream_recv_timeout_hew(stream: QUICStream, deadline_ms: i32) -> bytes;
     fn hew_quic_stream_last_recv_timed_out() -> i32; // INTERNAL-ABI: thread-local timeout sentinel; 1=timeout, 0=ok-or-error
-    fn hew_quic_stream_last_recv_status() -> i32; // INTERNAL-ABI: thread-local timeout sentinel; 1=timeout, 0=ok-or-error
+    fn hew_quic_stream_last_recv_status() -> i32; // INTERNAL-ABI: thread-local status; 0=ok-or-EOF, -1=transport error, -2=timeout
     fn hew_quic_stream_finish(stream: QUICStream) -> i32;
     fn hew_quic_stream_stop(stream: QUICStream, error_code: i64) -> i32;
     fn hew_quic_stream_close(stream: QUICStream) -> i32;

--- a/std/net/quic/quic.hew
+++ b/std/net/quic/quic.hew
@@ -596,11 +596,13 @@ pub fn stream_recv_timeout(strm: QUICStream, deadline_ms: i64) -> Result<bytes, 
     let payload: bytes = unsafe {
         hew_quic_stream_recv_timeout_hew(strm, deadline_ms as i32)
     };
-    let timed_out: i32 = unsafe { // INTERNAL-ABI: 1=timeout, 0=ok-or-error; thread-local sentinel
-        hew_quic_stream_last_recv_timed_out()
+    let status: i32 = unsafe { // INTERNAL-ABI: 0=ok-or-EOF, -1=transport error, -2=timeout
+        hew_quic_stream_last_recv_status()
     };
-    if timed_out == 1 {
+    if status == -2 {
         Err(net.net_error_timed_out())
+    } else if status < 0 {
+        Err(net.net_error_from_errno(0))
     } else {
         Ok(payload)
     }
@@ -707,6 +709,7 @@ extern "C" {
     fn hew_quic_stream_send_timeout_hew(stream: QUICStream, data: bytes, deadline_ms: i32) -> i32; // INTERNAL-ABI: 0=ok, -1=error, -2=timeout
     fn hew_quic_stream_recv_timeout_hew(stream: QUICStream, deadline_ms: i32) -> bytes;
     fn hew_quic_stream_last_recv_timed_out() -> i32; // INTERNAL-ABI: thread-local timeout sentinel; 1=timeout, 0=ok-or-error
+    fn hew_quic_stream_last_recv_status() -> i32; // INTERNAL-ABI: thread-local timeout sentinel; 1=timeout, 0=ok-or-error
     fn hew_quic_stream_finish(stream: QUICStream) -> i32;
     fn hew_quic_stream_stop(stream: QUICStream, error_code: i64) -> i32;
     fn hew_quic_stream_close(stream: QUICStream) -> i32;

--- a/std/stream.hew
+++ b/std/stream.hew
@@ -68,12 +68,30 @@ pub type Sink<T> {
 /// backpressured contract as `bytes_pipe()`.
 /// Returns a `(Sink<string>, Stream<string>)` pair for writing and reading.
 pub fn pipe(capacity: i64) -> (Sink<string>, Stream<string>) {
+    match try_pipe(capacity) {
+        Ok(pair) => pair,
+        Err(err) => panic(err),
+    }
+}
+
+/// Try to create a bounded in-memory string pipe.
+pub fn try_pipe(capacity: i64) -> Result<(Sink<string>, Stream<string>), string> {
+    if capacity < 0 {
+        return Err(f"stream.pipe: invalid capacity {capacity} (must be >= 0)");
+    }
     unsafe {
         let pair = hew_stream_channel(capacity as i64);
+        if !hew_stream_pair_is_valid(pair) {
+            let detail = hew_stream_last_error();
+            if detail == "" {
+                return Err("stream.pipe: stream allocation failed");
+            }
+            return Err(detail);
+        }
         let sink = hew_stream_pair_sink(pair);
         let input = hew_stream_pair_stream(pair);
         hew_stream_pair_free(pair);
-        (sink, input)
+        Ok((sink, input))
     }
 }
 
@@ -82,12 +100,30 @@ pub fn pipe(capacity: i64) -> (Sink<string>, Stream<string>) {
 /// This is the canonical first-class Stream/Sink foundation for binary items.
 /// Returns a `(Sink<bytes>, Stream<bytes>)` pair for writing and reading.
 pub fn bytes_pipe(capacity: i64) -> (Sink<bytes>, Stream<bytes>) {
+    match try_bytes_pipe(capacity) {
+        Ok(pair) => pair,
+        Err(err) => panic(err),
+    }
+}
+
+/// Try to create a bounded in-memory bytes pipe.
+pub fn try_bytes_pipe(capacity: i64) -> Result<(Sink<bytes>, Stream<bytes>), string> {
+    if capacity < 0 {
+        return Err(f"stream.bytes_pipe: invalid capacity {capacity} (must be >= 0)");
+    }
     unsafe {
         let pair = hew_stream_channel(capacity as i64);
+        if !hew_stream_pair_is_valid(pair) {
+            let detail = hew_stream_last_error();
+            if detail == "" {
+                return Err("stream.bytes_pipe: stream allocation failed");
+            }
+            return Err(detail);
+        }
         let sink = hew_stream_pair_sink_bytes(pair);
         let input = hew_stream_pair_stream_bytes(pair);
         hew_stream_pair_free(pair);
-        (sink, input)
+        Ok((sink, input))
     }
 }
 
@@ -214,6 +250,7 @@ pub type StreamPair {
 
 extern "C" {
     fn hew_stream_channel(capacity: i64) -> StreamPair;
+    fn hew_stream_pair_is_valid(pair: StreamPair) -> bool;
     fn hew_stream_pair_sink(pair: StreamPair) -> Sink<string>;
     fn hew_stream_pair_stream(pair: StreamPair) -> Stream<string>;
     fn hew_stream_pair_free(pair: StreamPair);

--- a/tests/hew/net_transport_failclosed_test.hew
+++ b/tests/hew/net_transport_failclosed_test.hew
@@ -1,0 +1,90 @@
+import std::channel;
+
+import std::crypto::password;
+
+import std::net::http::http_async_client;
+
+import std::net::http::http_async_server;
+
+import std::stream;
+
+import std::testing;
+
+#[test]
+fn test_negative_channel_capacity_is_rejected() {
+    match channel.try_new(-1) {
+        Ok(_) => panic("expected negative channel capacity to fail"),
+        Err(err) => testing.assert_eq_str(err, "channel.new: invalid capacity -1 (must be >= 0)"),
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_negative_channel_capacity_panics_at_legacy_boundary() {
+    let (tx, rx) = channel.new(-1);
+    tx.send("unreachable");
+    rx.close();
+}
+
+#[test]
+fn test_negative_stream_capacities_are_rejected() {
+    match stream.try_pipe(-1) {
+        Ok(_) => panic("expected negative string-pipe capacity to fail"),
+        Err(err) => testing.assert_eq_str(err, "stream.pipe: invalid capacity -1 (must be >= 0)"),
+    }
+    match stream.try_bytes_pipe(-1) {
+        Ok(_) => panic("expected negative bytes-pipe capacity to fail"),
+        Err(err) => testing.assert_eq_str(err, "stream.bytes_pipe: invalid capacity -1 (must be >= 0)"),
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_negative_stream_capacity_panics_at_legacy_boundary() {
+    let _ = stream.pipe(-1);
+}
+
+#[test]
+fn test_password_cost_overflow_is_rejected() {
+    match password.try_hash_custom("secret", 4294967299) {
+        Ok(_) => panic("expected oversized password cost to fail"),
+        Err(err) => testing.assert_eq_str(err, "password.hash_custom: invalid cost 4294967299 (must be 1..=2147483647)"),
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_password_cost_overflow_panics_at_legacy_boundary() {
+    let _ = password.hash_custom("secret", 4294967299);
+}
+
+#[test]
+fn test_malformed_password_hash_is_not_a_mismatch() {
+    match password.try_verify("secret", "not-a-phc-hash") {
+        Ok(_) => panic("expected malformed password hash to fail"),
+        Err(err) => testing.assert_eq_str(err, "password.verify: malformed password hash"),
+    }
+}
+
+#[test]
+#[should_panic]
+fn test_malformed_password_hash_panics_at_legacy_boundary() {
+    let _ = password.verify("secret", "not-a-phc-hash");
+}
+
+#[test]
+fn test_async_http_query_and_ipv6_authority_split() {
+    let (query_addr, query_path) = http_async_client.split_address("http://example.com?x=1");
+    testing.assert_eq_str(query_addr, "example.com:80");
+    testing.assert_eq_str(query_path, "/?x=1");
+    let (ipv6_addr, ipv6_path) = http_async_client.split_address("http://[::1]:8080/status");
+    testing.assert_eq_str(ipv6_addr, "[::1]:8080");
+    testing.assert_eq_str(ipv6_path, "/status");
+    testing.assert_eq_str(http_async_client.host_of("http://[::1]:8080/status"), "[::1]");
+}
+
+#[test]
+fn test_async_http_invalid_status_is_rejected() {
+    testing.assert_eq_str(http_async_server.response_text(-1, "body"), "");
+    testing.assert_eq_str(http_async_server.response_text(600, "body"), "");
+}


### PR DESCRIPTION
## Summary

I made network and transport surfaces reject invalid inputs or return honest errors instead of silently normalizing or discarding failures.

- I added fallible channel/stream constructors and made legacy constructors panic on invalid capacities.
- I preserved QUIC timed-receive transport errors separately from EOF/timeouts and reject invalid reset codes.
- I reject invalid HTTP statuses and Content-Type values before consuming requests, fail the client response when headers cannot be represented, and fixed query/bracketed-IPv6 authority splitting.
- I added fallible password verification/custom-cost helpers so malformed hashes and overflowing costs are distinct from ordinary mismatches.

## Verification

- `cargo test -p hew-std --quiet -- --test-threads=1`
- `cargo test -p hew-runtime --quiet -- --test-threads=1`
- `cargo check --workspace --quiet`
- `target/debug/hew test tests/hew/net_transport_failclosed_test.hew`
- `make hew-check-all`

## Out of scope

I left API-wide changes that require coordinated caller migrations for separate work: distinguishing TCP read errors from EOF, normalizing all network `i64` parameters before ABI narrowing, fallible HTTP/WebSocket constructors, strict `connect_timeout` endpoint parsing, and fully typed pure-Hew HTTP response framing.