### PR TITLE
test(sandbox): prove playground and iOS corpus coverage

### DIFF
--- a/hew-sandbox-wasm/tests/fixtures/ios/examples.json
+++ b/hew-sandbox-wasm/tests/fixtures/ios/examples.json
@@ -1,0 +1,54 @@
+[
+  {
+    "id": "hello-world",
+    "source": "fn main() {\n    println(\"Hello, World!\");\n}\n"
+  },
+  {
+    "id": "fibonacci",
+    "source": "fn fib(n: i64) -> i64 {\n    if n <= 1 {\n        n\n    } else {\n        fib(n - 1) + fib(n - 2)\n    }\n}\n\nfn main() {\n    for i in 0..10 {\n        print(f\"fib({i}) = \");\n        println(fib(i));\n    }\n}\n"
+  },
+  {
+    "id": "while-let",
+    "source": "// Test while-let pattern matching loops with Option types\n\nfn countdown(n: i64) -> Option<i64> {\n    if n > 0 {\n        Some(n - 1)\n    } else {\n        let none: Option<i64> = None;\n        none\n    }\n}\n\nfn main() -> i64 {\n    // Basic while-let: iterate until None\n    var opt: Option<i64> = Some(3);\n    while let Some(x) = opt {\n        println(x);\n        opt = countdown(x);\n    }\n\n    // Early exit with break\n    var opt2: Option<i64> = Some(10);\n    while let Some(x) = opt2 {\n        if x < 8 {\n            break;\n        }\n        println(x);\n        opt2 = countdown(x);\n    }\n    println(\"done\");\n\n    return 0;\n}\n"
+  },
+  {
+    "id": "pattern-matching",
+    "source": "enum Shape {\n    Circle(i64);\n    Rectangle(i64, i64);\n    Triangle(i64, i64);\n}\n\nfn area(shape: Shape) -> i64 {\n    match shape {\n        Circle(r) => r * r * 3,\n        Rectangle(w, h) => w * h,\n        Triangle(b, h) => b * h / 2,\n    }\n}\n\nfn main() {\n    let c = Circle(5);\n    let r = Rectangle(4, 6);\n    let t = Triangle(3, 8);\n\n    print(\"Circle area: \");\n    println(area(c));\n    print(\"Rectangle area: \");\n    println(area(r));\n    // Or using inline interpolation\n    println(f\"Triangle area: {area(t)}\");\n}\n"
+  },
+  {
+    "id": "actor-counter",
+    "source": "actor Counter {\n    var count: i64;\n\n    receive fn increment(n: i64) -> i64 {\n        count = count + n;\n        print(\"Count is now: \");\n        println(count);\n        count\n    }\n}\n\nfn main() {\n    let c = spawn Counter(count: 0);\n    await c.increment(5);\n    await c.increment(3);\n    match await c.increment(12) {\n        Ok(total) => println(f\"Final total: {total}\"),\n        Err(_) => println(\"send failed\"),\n    }\n}\n"
+  },
+  {
+    "id": "multiple-actors",
+    "source": "// Spawn several actors and send each a message with `await`.\n// Each actor runs on its own task and replies independently.\n\nactor Worker {\n    let id: i64;\n\n    receive fn handle(task: i64) -> i64 {\n        println(f\"Worker {id} handling task {task}\");\n        task * 2\n    }\n}\n\nfn main() {\n    let w1 = spawn Worker(id: 1);\n    let w2 = spawn Worker(id: 2);\n    await w1.handle(10);\n    await w2.handle(20);\n    await w1.handle(30);\n}\n"
+  },
+  {
+    "id": "async-await",
+    "source": "// Hew handles concurrency with actors and `await`.\n// `await` sends a message to an actor and waits for its reply.\n\nactor Calculator {\n    var total: i64;\n\n    receive fn add(n: i64) -> i64 {\n        total = total + n;\n        println(f\"running total: {total}\");\n        total\n    }\n}\n\nfn main() {\n    let calc = spawn Calculator(total: 0);\n    await calc.add(10);\n    await calc.add(20);\n    await calc.add(12);\n    println(\"done\");\n}\n"
+  },
+  {
+    "id": "state-machine",
+    "source": "machine Light {\n    events { Toggle; }\n    state Off;\n    state On;\n    on Toggle: Off => On;\n    on Toggle: On => Off;\n}\n\nfn main() -> i64 {\n    var light = Light::Off;\n    println(light.state_name());\n    light.step(Toggle);\n    println(light.state_name());\n    light.step(Toggle);\n    println(light.state_name());\n    0\n}\n"
+  },
+  {
+    "id": "for-loops",
+    "source": "fn main() {\n    // Range-based for loop\n    for i in 0..5 {\n        println(f\"count: {i}\");\n    }\n}\n"
+  },
+  {
+    "id": "enums",
+    "source": "enum Direction {\n    North;\n    South;\n    East;\n    West;\n}\n\nfn describe(dir: Direction) -> string {\n    match dir {\n        North => \"heading north\",\n        South => \"heading south\",\n        East => \"heading east\",\n        West => \"heading west\",\n    }\n}\n\nfn main() {\n    let dir = North;\n    println(describe(dir));\n    println(describe(South));\n}\n"
+  },
+  {
+    "id": "error-handling",
+    "source": "fn divide(a: i64, b: i64) -> Option<i64> {\n    if b == 0 {\n        None\n    } else {\n        Some(a / b)\n    }\n}\n\nfn main() {\n    match divide(10, 3) {\n        Some(result) => println(f\"10 / 3 = {result}\"),\n        None => println(\"cannot divide by zero\"),\n    }\n\n    match divide(10, 0) {\n        Some(result) => println(f\"10 / 0 = {result}\"),\n        None => println(\"cannot divide by zero\"),\n    }\n}\n"
+  },
+  {
+    "id": "higher-order-functions",
+    "source": "fn double(x: i64) -> i64 { x * 2 }\nfn square(x: i64) -> i64 { x * x }\n\nfn apply(f: fn(i64) -> i64, x: i64) -> i64 {\n    f(x)\n}\n\nfn main() {\n    println(f\"double(5) = {apply(double, 5)}\");\n    println(f\"square(4) = {apply(square, 4)}\");\n}\n"
+  },
+  {
+    "id": "supervisor",
+    "source": "actor Worker {\n    let id: i64;\n\n    receive fn work(x: i64) -> i64 {\n        println(f\"Worker {id} processing {x}\");\n        x * 2\n    }\n}\n\n// A supervisor starts and restarts a tree of child actors.\nsupervisor WorkerPool {\n    strategy: one_for_one;\n    intensity: 5 within 60s;\n    child w1: Worker(id: 1);\n    child w2: Worker(id: 2);\n}\n\nfn main() {\n    let workers = spawn WorkerPool;\n    let w1 = workers.w1;\n    await w1.work(10);\n    let w2 = workers.w2;\n    await w2.work(20);\n}\n"
+  }
+]

--- a/hew-sandbox-wasm/tests/fixtures/ios/quick_ref.json
+++ b/hew-sandbox-wasm/tests/fixtures/ios/quick_ref.json
@@ -1,0 +1,78 @@
+[
+  {
+    "id": "actor",
+    "snippet": "actor Counter {\n    var count: i64;\n    receive fn increment(by: i64) -> i64 {\n        count = count + by;\n        count\n    }\n}\n\nfn main() {\n    let c = spawn Counter(count: 0);\n    await c.increment(5);\n}\n"
+  },
+  {
+    "id": "spawn",
+    "snippet": "let counter = spawn Counter(count: 0);\n"
+  },
+  {
+    "id": "send-message",
+    "snippet": "// `await` sends a message and waits for the reply (a Result).\nmatch await counter.increment(5) {\n    Ok(total) => println(total),\n    Err(_) => {}\n}\n"
+  },
+  {
+    "id": "receive",
+    "snippet": "actor Greeter {\n    let name: string;\n    receive fn greet() -> i64 {\n        println(f\"Hello from {name}\");\n        0\n    }\n}\n\nfn main() {\n    let g = spawn Greeter(name: \"Hew\");\n    await g.greet();\n}\n"
+  },
+  {
+    "id": "supervisor",
+    "snippet": "actor Worker {\n    let id: i64;\n\n    receive fn work(x: i64) -> i64 {\n        println(f\"Worker {id} processing {x}\");\n        x * 2\n    }\n}\n\nsupervisor WorkerPool {\n    strategy: one_for_one;\n    intensity: 5 within 60s;\n    child w1: Worker(id: 1);\n    child w2: Worker(id: 2);\n}\n\nfn main() {\n    let workers = spawn WorkerPool;\n    let w1 = workers.w1;\n    await w1.work(10);\n}\n"
+  },
+  {
+    "id": "machine",
+    "snippet": "machine Light {\n    events { Toggle; }\n    state Off;\n    state On;\n    on Toggle: Off => On;\n    on Toggle: On => Off;\n}\n\nfn main() -> i64 {\n    var light = Light::Off;\n    println(light.state_name());\n    light.step(Toggle);\n    println(light.state_name());\n    light.step(Toggle);\n    println(light.state_name());\n    0\n}\n"
+  },
+  {
+    "id": "match",
+    "snippet": "match value {\n    Some(x) => println(x),\n    None => println(\"empty\"),\n}\n"
+  },
+  {
+    "id": "functions",
+    "snippet": "fn add(a: i64, b: i64) -> i64 {\n    a + b\n}\n\nfn main() {\n    println(add(2, 3));\n}\n"
+  },
+  {
+    "id": "variables",
+    "snippet": "let name: string = \"Hew\";\nvar total: i64 = 0;\ntotal = total + 1;\nprintln(f\"{name} {total}\");\n"
+  },
+  {
+    "id": "while-let",
+    "snippet": "fn countdown(n: i64) -> Option<i64> {\n    if n > 0 { Some(n - 1) } else { None }\n}\n\nfn main() {\n    var opt: Option<i64> = Some(3);\n    while let Some(value) = opt {\n        println(value);\n        opt = countdown(value);\n    }\n}\n"
+  },
+  {
+    "id": "enum",
+    "snippet": "enum Shape {\n    Circle(i64);\n    Rectangle(i64, i64);\n}\n\nfn main() {\n    let shape = Circle(5);\n    match shape {\n        Circle(r) => println(r * r * 3),\n        Rectangle(w, h) => println(w * h),\n    }\n}\n"
+  },
+  {
+    "id": "for-loop",
+    "snippet": "for i in 0..10 {\n    println(i);\n}\n"
+  },
+  {
+    "id": "async-functions",
+    "snippet": "// Hew has no `async fn` — actors are the unit of concurrency.\nactor Fetcher {\n    receive fn get(url: string) -> string {\n        \"response body\"\n    }\n}\n\nfn main() {\n    let fetcher = spawn Fetcher;\n    match await fetcher.get(\"https://example.com\") {\n        Ok(body) => println(body),\n        Err(_) => println(\"request failed\"),\n    }\n}\n"
+  },
+  {
+    "id": "await-future",
+    "snippet": "// `await` returns a Result with the actor's reply.\nmatch await fetcher.get(\"https://example.com\") {\n    Ok(body) => println(body),\n    Err(_) => println(\"request failed\"),\n}\n"
+  },
+  {
+    "id": "machine-step",
+    "snippet": "var light = Light::Off;\nlight.step(Toggle);\n"
+  },
+  {
+    "id": "state-name",
+    "snippet": "println(light.state_name());\n"
+  },
+  {
+    "id": "higher-order-functions",
+    "snippet": "fn double(x: i64) -> i64 { x * 2 }\n\nfn apply(f: fn(i64) -> i64, x: i64) -> i64 {\n    f(x)\n}\n\nfn main() {\n    println(apply(double, 5));\n}\n"
+  },
+  {
+    "id": "option-result",
+    "snippet": "let val: Option<i64> = Some(42);\nmatch val {\n    Some(x) => println(x),\n    None => println(\"nothing\"),\n}\n"
+  },
+  {
+    "id": "import",
+    "snippet": "import std::io;\nimport std::math;\n\nfn main() {\n    println(\"imports are file-level\");\n}\n"
+  }
+]

--- a/hew-sandbox-wasm/tests/fixtures/ios/tutorials.json
+++ b/hew-sandbox-wasm/tests/fixtures/ios/tutorials.json
@@ -1,0 +1,54 @@
+[
+  {
+    "id": "hello-world",
+    "starterCode": "// Lesson 1: Hello World\n// TODO: Replace the placeholder below with a greeting.\n\nfn main() {\n    println(\"...\");\n}\n"
+  },
+  {
+    "id": "variables",
+    "starterCode": "// Lesson 2: Variables & Constants\n// TODO: Declare a mutable variable `count` starting at 1,\n//       then increment it by 1 and print the result.\n\nfn main() {\n    let name = \"Hew\";\n    var count = 1;\n    count = count + 1;\n    println(name);\n    println(count);\n}\n"
+  },
+  {
+    "id": "functions",
+    "starterCode": "// Lesson 3: Functions\n// TODO: Write a function `add` that takes two i64 parameters\n//       and returns their sum.\n\nfn add(a: i64, b: i64) -> i64 {\n    a + b\n}\n\nfn main() {\n    let result = add(3, 4);\n    println(result);\n}\n"
+  },
+  {
+    "id": "control-flow",
+    "starterCode": "// Lesson 4: While Let\n// `while let` keeps looping while the pattern matches.\n\nfn countdown(n: i64) -> Option<i64> {\n    if n > 0 {\n        Some(n - 1)\n    } else {\n        None\n    }\n}\n\nfn main() {\n    var opt: Option<i64> = Some(3);\n    while let Some(value) = opt {\n        println(value);\n        opt = countdown(value);\n    }\n    println(\"done\");\n}\n"
+  },
+  {
+    "id": "actors-intro",
+    "starterCode": "// Lesson 5: Actors Intro\n// A simple counter actor that tracks a value.\n// Send it a message with `await`.\n\nactor Counter {\n    var count: i64;\n\n    receive fn increment() -> i64 {\n        count = count + 1;\n        println(count);\n        count\n    }\n}\n\nfn main() {\n    let counter = spawn Counter(count: 0);\n    await counter.increment();\n    await counter.increment();\n    await counter.increment();\n}\n"
+  },
+  {
+    "id": "actor-messaging",
+    "starterCode": "// Lesson 6: Actor Messaging\n// Spawn several actors and send each its own message.\n// Each actor runs concurrently on its own task.\n\nactor Worker {\n    let id: i64;\n\n    receive fn task(name: string) -> i64 {\n        println(f\"Worker {id} got task: {name}\");\n        id\n    }\n}\n\nfn main() {\n    let w1 = spawn Worker(id: 1);\n    let w2 = spawn Worker(id: 2);\n    await w1.task(\"build widgets\");\n    await w2.task(\"paint widgets\");\n}\n"
+  },
+  {
+    "id": "for-loops",
+    "starterCode": "// Lesson 7: For Loops\n// TODO: Print the numbers 1 through 5 using a for loop.\n\nfn main() {\n    for i in 1..6 {\n        println(\"...\");\n    }\n}\n"
+  },
+  {
+    "id": "enums",
+    "starterCode": "// Lesson 8: Enums & Match\n// TODO: Add a Triangle variant and handle it in the match.\n\nenum Shape {\n    Circle(i64);\n    Rectangle(i64, i64);\n}\n\nfn describe(s: Shape) {\n    match s {\n        Circle(r) => println(f\"circle with radius {r}\"),\n        Rectangle(w, h) => println(f\"rectangle {w}x{h}\"),\n    }\n}\n\nfn main() {\n    describe(Circle(5));\n    describe(Rectangle(3, 4));\n}\n"
+  },
+  {
+    "id": "option-type",
+    "starterCode": "// Lesson 9: Option Type\n// TODO: Handle the None case so the program prints \"not found\".\n\nfn find(items: i64, target: i64) -> Option<i64> {\n    if target <= items {\n        Some(target)\n    } else {\n        None\n    }\n}\n\nfn main() {\n    match find(10, 5) {\n        Some(x) => println(f\"found: {x}\"),\n        None => println(\"not found\"),\n    }\n    match find(3, 7) {\n        Some(x) => println(f\"found: {x}\"),\n        None => println(\"not found\"),\n    }\n}\n"
+  },
+  {
+    "id": "closures",
+    "starterCode": "// Lesson 10: Higher-Order Functions\n// TODO: Write a function that triples its input.\n\nfn triple(x: i64) -> i64 { x * 3 }\n\nfn apply(f: fn(i64) -> i64, x: i64) -> i64 {\n    f(x)\n}\n\nfn main() {\n    println(apply(triple, 7));\n}\n"
+  },
+  {
+    "id": "closure-captures",
+    "starterCode": "// Lesson 11: Closures\n// TODO: Capture `factor` so the closure multiplies its argument by it.\n\nfn main() {\n    let factor: i64 = 4;\n    let scale = |x: i64| x;\n    println(scale(10));\n}\n"
+  },
+  {
+    "id": "async-await",
+    "starterCode": "// Lesson 12: Async / Await\n// Hew has no `async fn` — actors are the unit of concurrency.\n// `await` sends a message to an actor and waits for its reply.\n\nfn fib(n: i64) -> i64 {\n    if n <= 1 { n }\n    else { fib(n - 1) + fib(n - 2) }\n}\n\nactor Calculator {\n    receive fn compute(n: i64) -> i64 {\n        fib(n)\n    }\n}\n\nfn main() {\n    let calc = spawn Calculator;\n    match await calc.compute(10) {\n        Ok(result) => println(f\"fib(10) = {result}\"),\n        Err(_) => println(\"failed\"),\n    }\n}\n"
+  },
+  {
+    "id": "state-machines",
+    "starterCode": "// Lesson 13: State Machines\n// TODO: Toggle the light twice and print each state.\n\nmachine Light {\n    events { Toggle; }\n    state Off;\n    state On;\n    on Toggle: Off => On;\n    on Toggle: On => Off;\n}\n\nfn main() -> i64 {\n    var light = Light::Off;\n    println(light.state_name());\n    light.step(Toggle);\n    println(light.state_name());\n    light.step(Toggle);\n    println(light.state_name());\n    0\n}\n"
+  }
+]

--- a/hew-sandbox-wasm/tests/ios_subset.rs
+++ b/hew-sandbox-wasm/tests/ios_subset.rs
@@ -9,6 +9,23 @@ use serde::Deserialize;
 
 const SANDBOX_PROFILE: &str = "sandbox-vm-export";
 const HEW_SEED: &str = "42";
+const CONTEXT_DEPENDENT_QUICK_REFERENCES: &[&str] = &[
+    "await-future",
+    "machine-step",
+    "match",
+    "send-message",
+    "spawn",
+    "state-name",
+];
+const QUICK_REFERENCE_TOP_LEVEL_KEYWORDS: &[&str] = &[
+    "fn ",
+    "actor ",
+    "enum ",
+    "machine ",
+    "supervisor ",
+    "async fn",
+    "import ",
+];
 const DEFAULT_TEMPLATE: &str = r#"// Hew: safe concurrency with actors
 // Try the examples or tutorials to learn more!
 
@@ -45,6 +62,12 @@ struct TutorialFixture {
     starter_code: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct QuickReferenceFixture {
+    id: String,
+    snippet: String,
+}
+
 #[derive(Debug, Clone, Copy)]
 enum Expectation {
     Parity,
@@ -61,14 +84,14 @@ struct IosCase {
 
 #[cfg_attr(windows, ignore)]
 #[test]
-fn ios_default_examples_and_tutorials_are_sandbox_safe() {
+fn ios_runnable_corpus_is_sandbox_safe() {
     set_test_hewpath();
     ensure_native_toolchain();
     ensure_parity_runner_built();
     let cases = load_cases();
     let unique_ids: BTreeSet<_> = cases.iter().map(|case| case.id.as_str()).collect();
 
-    assert_eq!(cases.len(), 27, "the pinned iOS core corpus changed");
+    assert_eq!(cases.len(), 40, "the pinned iOS runnable corpus changed");
     assert_eq!(
         unique_ids.len(),
         cases.len(),
@@ -92,6 +115,14 @@ fn load_cases() -> Vec<IosCase> {
     let tutorials: Vec<TutorialFixture> =
         serde_json::from_str(include_str!("fixtures/ios/tutorials.json"))
             .expect("iOS tutorial fixtures should parse");
+    let quick_references: Vec<QuickReferenceFixture> =
+        serde_json::from_str(include_str!("fixtures/ios/quick_ref.json"))
+            .expect("iOS quick-reference fixtures should parse");
+    assert_eq!(
+        quick_references.len(),
+        19,
+        "the pinned iOS quick-reference corpus changed"
+    );
 
     cases.extend(examples.into_iter().map(|fixture| {
         let expectation = match fixture.id.as_str() {
@@ -116,7 +147,46 @@ fn load_cases() -> Vec<IosCase> {
             expectation,
         }
     }));
+    let context_dependent: BTreeSet<_> =
+        CONTEXT_DEPENDENT_QUICK_REFERENCES.iter().copied().collect();
+    let actual_context_dependent: BTreeSet<_> = quick_references
+        .iter()
+        .filter(|fixture| CONTEXT_DEPENDENT_QUICK_REFERENCES.contains(&fixture.id.as_str()))
+        .map(|fixture| fixture.id.as_str())
+        .collect();
+    assert_eq!(
+        actual_context_dependent, context_dependent,
+        "the context-dependent iOS quick-reference boundary changed"
+    );
+    cases.extend(
+        quick_references
+            .into_iter()
+            .filter(|fixture| !CONTEXT_DEPENDENT_QUICK_REFERENCES.contains(&fixture.id.as_str()))
+            .map(|fixture| {
+                let expectation = match fixture.id.as_str() {
+                    "higher-order-functions" => Expectation::FailClosedProfile("unknown_symbol"),
+                    "import" => Expectation::FailClosedProfile("Unsupported::NATIVE_ONLY"),
+                    _ => Expectation::Parity,
+                };
+                IosCase {
+                    id: format!("quick-reference/{}", fixture.id),
+                    source: wrap_quick_reference(&fixture.snippet),
+                    expectation,
+                }
+            }),
+    );
     cases
+}
+
+fn wrap_quick_reference(snippet: &str) -> String {
+    if QUICK_REFERENCE_TOP_LEVEL_KEYWORDS
+        .iter()
+        .any(|keyword| snippet.contains(keyword))
+    {
+        snippet.to_owned()
+    } else {
+        format!("fn main() {{\n{snippet}\n}}")
+    }
 }
 
 fn assert_case(case: &IosCase) {

--- a/hew-sandbox-wasm/tests/ios_subset.rs
+++ b/hew-sandbox-wasm/tests/ios_subset.rs
@@ -1,0 +1,355 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::Output;
+use std::sync::OnceLock;
+
+use assert_cmd::Command;
+use hew_sandbox_wasm::{compile_to_sandbox_bytecode, Diagnostic, SandboxBytecodePackage};
+use serde::Deserialize;
+
+const SANDBOX_PROFILE: &str = "sandbox-vm-export";
+const HEW_SEED: &str = "42";
+const DEFAULT_TEMPLATE: &str = r#"// Hew: safe concurrency with actors
+// Try the examples or tutorials to learn more!
+
+actor Counter {
+    let count: i64;
+
+    receive fn increment(n: i64) -> i64 {
+        count = count + n;
+        count
+    }
+}
+
+fn main() {
+    let c = spawn Counter(count: 0);
+    await c.increment(5);
+    await c.increment(3);
+    match await c.increment(12) {
+        Ok(total) => println(f"Total: {total}"),
+        Err(_) => println("send failed"),
+    }
+}
+"#;
+
+#[derive(Debug, Deserialize)]
+struct ExampleFixture {
+    id: String,
+    source: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TutorialFixture {
+    id: String,
+    #[serde(rename = "starterCode")]
+    starter_code: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Expectation {
+    Parity,
+    FailClosedProfile(&'static str),
+    FailClosedTypecheck,
+}
+
+#[derive(Debug)]
+struct IosCase {
+    id: String,
+    source: String,
+    expectation: Expectation,
+}
+
+#[cfg_attr(windows, ignore)]
+#[test]
+fn ios_default_examples_and_tutorials_are_sandbox_safe() {
+    set_test_hewpath();
+    ensure_native_toolchain();
+    ensure_parity_runner_built();
+    let cases = load_cases();
+    let unique_ids: BTreeSet<_> = cases.iter().map(|case| case.id.as_str()).collect();
+
+    assert_eq!(cases.len(), 27, "the pinned iOS core corpus changed");
+    assert_eq!(
+        unique_ids.len(),
+        cases.len(),
+        "the pinned iOS core corpus contains duplicate ids"
+    );
+
+    for case in &cases {
+        assert_case(case);
+    }
+}
+
+fn load_cases() -> Vec<IosCase> {
+    let mut cases = vec![IosCase {
+        id: "default-template".to_owned(),
+        source: DEFAULT_TEMPLATE.to_owned(),
+        expectation: Expectation::FailClosedTypecheck,
+    }];
+    let examples: Vec<ExampleFixture> =
+        serde_json::from_str(include_str!("fixtures/ios/examples.json"))
+            .expect("iOS example fixtures should parse");
+    let tutorials: Vec<TutorialFixture> =
+        serde_json::from_str(include_str!("fixtures/ios/tutorials.json"))
+            .expect("iOS tutorial fixtures should parse");
+
+    cases.extend(examples.into_iter().map(|fixture| {
+        let expectation = match fixture.id.as_str() {
+            "higher-order-functions" => Expectation::FailClosedProfile("unknown_symbol"),
+            _ => Expectation::Parity,
+        };
+        IosCase {
+            id: format!("example/{}", fixture.id),
+            source: fixture.source,
+            expectation,
+        }
+    }));
+    cases.extend(tutorials.into_iter().map(|fixture| {
+        let expectation = match fixture.id.as_str() {
+            "closures" => Expectation::FailClosedProfile("unknown_symbol"),
+            "closure-captures" => Expectation::FailClosedProfile("reserved_runtime_feature"),
+            _ => Expectation::Parity,
+        };
+        IosCase {
+            id: format!("tutorial/{}", fixture.id),
+            source: fixture.starter_code,
+            expectation,
+        }
+    }));
+    cases
+}
+
+fn assert_case(case: &IosCase) {
+    let native = run_native(&case.source, &case.id);
+    let compiled = compile_to_sandbox_bytecode(&case.source, Some(SANDBOX_PROFILE))
+        .unwrap_or_else(|err| panic!("sandbox compile threw for {}: {err}", case.id));
+
+    match case.expectation {
+        Expectation::Parity => {
+            assert!(
+                native.status.success(),
+                "{} is shipped as runnable iOS Hew but failed natively:\n{}",
+                case.id,
+                describe_output(&native)
+            );
+            assert_no_error_diagnostics(case, &compiled.diagnostics);
+            let bytecode = compiled.bytecode.unwrap_or_else(|| {
+                panic!(
+                    "sandbox compile emitted no bytecode for {}; diagnostics:\n{}",
+                    case.id,
+                    diagnostics_dump(&compiled.diagnostics)
+                )
+            });
+            let sandbox = run_sandbox(&bytecode, &case.id);
+            assert_eq!(
+                sandbox.status.code(),
+                native.status.code(),
+                "{} exit-code mismatch\nnative:\n{}\nsandbox:\n{}",
+                case.id,
+                describe_output(&native),
+                describe_output(&sandbox)
+            );
+            assert_eq!(
+                String::from_utf8_lossy(&sandbox.stdout),
+                String::from_utf8_lossy(&native.stdout),
+                "{} stdout mismatch\nnative:\n{}\nsandbox:\n{}",
+                case.id,
+                describe_output(&native),
+                describe_output(&sandbox)
+            );
+        }
+        Expectation::FailClosedProfile(diagnostic_kind) => {
+            assert!(
+                native.status.success(),
+                "{} should be valid native Hew before the sandbox profile rejects it:\n{}",
+                case.id,
+                describe_output(&native)
+            );
+            assert!(
+                compiled.bytecode.is_none(),
+                "{} must fail closed but emitted sandbox bytecode",
+                case.id
+            );
+            assert!(
+                compiled
+                    .diagnostics
+                    .iter()
+                    .any(|diagnostic| diagnostic.severity == "error"
+                        && diagnostic.phase == "profile"
+                        && diagnostic.kind == diagnostic_kind),
+                "{} must fail closed with profile diagnostic {diagnostic_kind:?}; got:\n{}",
+                case.id,
+                diagnostics_dump(&compiled.diagnostics)
+            );
+        }
+        Expectation::FailClosedTypecheck => {
+            assert!(
+                !native.status.success(),
+                "{} is expected to be invalid in current native Hew",
+                case.id
+            );
+            assert!(
+                compiled.bytecode.is_none(),
+                "{} must not emit sandbox bytecode after typecheck failure",
+                case.id
+            );
+            assert!(
+                compiled
+                    .diagnostics
+                    .iter()
+                    .any(|diagnostic| diagnostic.severity == "error"
+                        && diagnostic.phase == "typecheck"),
+                "{} must fail closed with a typecheck diagnostic; got:\n{}",
+                case.id,
+                diagnostics_dump(&compiled.diagnostics)
+            );
+        }
+    }
+}
+
+fn assert_no_error_diagnostics(case: &IosCase, diagnostics: &[Diagnostic]) {
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.severity != "error"),
+        "{} produced sandbox compile errors:\n{}",
+        case.id,
+        diagnostics_dump(diagnostics)
+    );
+}
+
+fn run_native(source: &str, id: &str) -> Output {
+    let tempdir = tempfile::tempdir()
+        .unwrap_or_else(|err| panic!("failed to create tempdir for {id}: {err}"));
+    let source_path = tempdir.path().join("main.hew");
+    std::fs::write(&source_path, source)
+        .unwrap_or_else(|err| panic!("failed to write native source for {id}: {err}"));
+
+    Command::new(hew_binary())
+        .arg("run")
+        .arg(source_path)
+        .current_dir(repo_root())
+        .env("HEWPATH", repo_root())
+        .env("HEW_SEED", HEW_SEED)
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap_or_else(|err| panic!("failed to spawn native `hew run` for {id}: {err}"))
+}
+
+fn run_sandbox(bytecode: &SandboxBytecodePackage, id: &str) -> Output {
+    let bytecode_json = serde_json::to_string_pretty(bytecode)
+        .unwrap_or_else(|err| panic!("failed to serialize bytecode for {id}: {err}"));
+    let tempdir = tempfile::tempdir()
+        .unwrap_or_else(|err| panic!("failed to create tempdir for {id}: {err}"));
+    let bytecode_path = tempdir.path().join("bytecode.json");
+    std::fs::write(&bytecode_path, bytecode_json)
+        .unwrap_or_else(|err| panic!("failed to write bytecode for {id}: {err}"));
+
+    Command::new("npm")
+        .arg("--prefix")
+        .arg(repo_root().join("hew-sandbox-vm"))
+        .arg("run")
+        .arg("-s")
+        .arg("parity:run")
+        .arg("--")
+        .arg(bytecode_path)
+        .arg("--seed")
+        .arg(HEW_SEED)
+        .current_dir(repo_root())
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap_or_else(|err| panic!("failed to spawn sandbox parity runner for {id}: {err}"))
+}
+
+fn ensure_native_toolchain() {
+    static NATIVE_TOOLCHAIN: OnceLock<()> = OnceLock::new();
+    NATIVE_TOOLCHAIN.get_or_init(|| {
+        run_bootstrap_command(
+            "cargo build -q -p hew-cli",
+            std::process::Command::new("cargo")
+                .args(["build", "-q", "-p", "hew-cli"])
+                .current_dir(repo_root()),
+        );
+        run_bootstrap_command(
+            "cargo build -q -p hew-lib",
+            std::process::Command::new("cargo")
+                .args(["build", "-q", "-p", "hew-lib"])
+                .current_dir(repo_root()),
+        );
+    });
+}
+
+fn ensure_parity_runner_built() {
+    static PARITY_RUNNER: OnceLock<()> = OnceLock::new();
+    PARITY_RUNNER.get_or_init(|| {
+        let vm_dir = repo_root().join("hew-sandbox-vm");
+        assert!(
+            vm_dir.join("node_modules").is_dir(),
+            "hew-sandbox-vm dependencies are not installed; run `npm --prefix hew-sandbox-vm ci` or `make sandbox-parity`"
+        );
+        run_bootstrap_command(
+            "npm --prefix hew-sandbox-vm run -s build",
+            std::process::Command::new("npm")
+                .arg("--prefix")
+                .arg(&vm_dir)
+                .arg("run")
+                .arg("-s")
+                .arg("build")
+                .current_dir(repo_root()),
+        );
+    });
+}
+
+fn run_bootstrap_command(label: &str, command: &mut std::process::Command) {
+    let output = command
+        .output()
+        .unwrap_or_else(|err| panic!("failed to invoke `{label}`: {err}"));
+    assert!(
+        output.status.success(),
+        "`{label}` failed\n{}",
+        describe_output(&output)
+    );
+}
+
+fn hew_binary() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_hew") {
+        return PathBuf::from(path);
+    }
+    target_debug_dir().join(format!("hew{}", std::env::consts::EXE_SUFFIX))
+}
+
+fn target_debug_dir() -> PathBuf {
+    if let Ok(target_dir) = std::env::var("CARGO_TARGET_DIR") {
+        return PathBuf::from(target_dir).join("debug");
+    }
+    repo_root().join("target").join("debug")
+}
+
+fn repo_root() -> &'static Path {
+    static REPO_ROOT: OnceLock<PathBuf> = OnceLock::new();
+    REPO_ROOT
+        .get_or_init(|| {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .expect("hew-sandbox-wasm crate should have a workspace parent")
+                .to_path_buf()
+        })
+        .as_path()
+}
+
+fn set_test_hewpath() {
+    std::env::set_var("HEWPATH", repo_root());
+}
+
+fn diagnostics_dump(diagnostics: &[Diagnostic]) -> String {
+    serde_json::to_string_pretty(diagnostics).expect("diagnostics should serialize")
+}
+
+fn describe_output(output: &Output) -> String {
+    format!(
+        "status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}

--- a/hew-sandbox-wasm/tests/parity.rs
+++ b/hew-sandbox-wasm/tests/parity.rs
@@ -464,6 +464,38 @@ fn minimum_parity_set_is_enforced_by_test_name() {
     );
 }
 
+#[test]
+fn sandbox_graduation_corpus_is_fully_covered() {
+    let graduation_dir = repo_root().join("examples").join("sandbox-graduation");
+    let expected: BTreeSet<PathBuf> = std::fs::read_dir(&graduation_dir)
+        .unwrap_or_else(|err| {
+            panic!(
+                "failed to read sandbox graduation directory {}: {err}",
+                graduation_dir.display()
+            )
+        })
+        .map(|entry| {
+            entry
+                .unwrap_or_else(|err| panic!("failed to read sandbox graduation entry: {err}"))
+                .path()
+        })
+        .filter(|path| path.extension().is_some_and(|extension| extension == "hew"))
+        .collect();
+    let actual: BTreeSet<PathBuf> = PARITY_CASES
+        .iter()
+        .filter_map(|case| {
+            case.source_rel
+                .strip_prefix("examples/sandbox-graduation/")
+                .map(|source_rel| graduation_dir.join(source_rel))
+        })
+        .collect();
+
+    assert_eq!(
+        actual, expected,
+        "every sandbox-graduation Hew source must have a native↔sandbox parity case"
+    );
+}
+
 // Windows parity enforcement is tracked in #1823; Windows runners do not yet
 // provision the hew-sandbox-vm npm toolchain for this harness.
 #[cfg_attr(windows, ignore)]

--- a/hew-sandbox-wasm/tests/playground.rs
+++ b/hew-sandbox-wasm/tests/playground.rs
@@ -1,12 +1,16 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
+use std::process::Output;
+use std::sync::OnceLock;
 
+use assert_cmd::Command;
 use hew_sandbox_wasm::{compile_to_sandbox_bytecode, Diagnostic};
 use serde::Deserialize;
 
 const RUNNABLE: &str = "runnable";
 const UNSUPPORTED_NATIVE_ONLY: &str = "unsupported_native_only";
 const SANDBOX_PROFILE: &str = "sandbox-vm-export";
+const HEW_SEED: &str = "42";
 
 const REQUIRED_SANDBOX_EXAMPLES: &[&str] = &[
     "basics/hello_world",
@@ -21,6 +25,7 @@ const REQUIRED_SANDBOX_EXAMPLES: &[&str] = &[
 struct ManifestEntry {
     id: String,
     source_path: PathBuf,
+    expected_path: PathBuf,
     capabilities: Capabilities,
 }
 
@@ -30,8 +35,10 @@ struct Capabilities {
 }
 
 #[test]
-fn playground_manifest_sources_compile_to_sandbox_bytecode() {
+fn playground_manifest_sources_run_at_native_sandbox_parity() {
     set_test_hewpath();
+    ensure_native_toolchain();
+    ensure_parity_runner_built();
     let playground_dir = playground_dir();
     let entries = load_manifest(&playground_dir);
     let mut seen_ids = BTreeSet::new();
@@ -42,64 +49,7 @@ fn playground_manifest_sources_compile_to_sandbox_bytecode() {
             "duplicate playground manifest id {}",
             entry.id
         );
-
-        let source_path = playground_dir.join(&entry.source_path);
-        let source = std::fs::read_to_string(&source_path).unwrap_or_else(|err| {
-            panic!(
-                "failed to read playground source {} for {}: {err}",
-                source_path.display(),
-                entry.id
-            )
-        });
-        let output =
-            compile_to_sandbox_bytecode(&source, Some(SANDBOX_PROFILE)).unwrap_or_else(|err| {
-                panic!("compile_to_sandbox_bytecode threw for {}: {err}", entry.id)
-            });
-
-        match entry.capabilities.sandbox.as_str() {
-            RUNNABLE => {
-                assert!(
-                    output.diagnostics.iter().all(|diagnostic| diagnostic.severity != "error"),
-                    "runnable playground entry {} produced error diagnostics:\n{}",
-                    entry.id,
-                    diagnostics_dump(&output.diagnostics)
-                );
-                let bytecode = output.bytecode.unwrap_or_else(|| {
-                    panic!(
-                        "runnable playground entry {} did not emit bytecode; diagnostics:\n{}",
-                        entry.id,
-                        diagnostics_dump(&output.diagnostics)
-                    )
-                });
-                assert!(
-                    !serde_json::to_vec(&bytecode)
-                        .expect("sandbox bytecode should serialize")
-                        .is_empty(),
-                    "runnable playground entry {} emitted empty bytecode",
-                    entry.id
-                );
-            }
-            UNSUPPORTED_NATIVE_ONLY => {
-                assert!(
-                    output.bytecode.is_none(),
-                    "unsupported_native_only playground entry {} unexpectedly emitted bytecode",
-                    entry.id
-                );
-                assert!(
-                    output
-                        .diagnostics
-                        .iter()
-                        .any(is_typed_profile_rejection),
-                    "unsupported_native_only playground entry {} must fail closed with a typed profile diagnostic; got:\n{}",
-                    entry.id,
-                    diagnostics_dump(&output.diagnostics)
-                );
-            }
-            other => panic!(
-                "manifest entry {} has unsupported capabilities.sandbox {other:?}; expected {RUNNABLE:?} or {UNSUPPORTED_NATIVE_ONLY:?}",
-                entry.id
-            ),
-        }
+        assert_manifest_entry(entry, &playground_dir);
     }
 
     for required_id in REQUIRED_SANDBOX_EXAMPLES {
@@ -107,6 +57,91 @@ fn playground_manifest_sources_compile_to_sandbox_bytecode() {
             seen_ids.contains(required_id),
             "playground manifest missing required sandbox parity entry {required_id}"
         );
+    }
+}
+
+fn assert_manifest_entry(entry: &ManifestEntry, playground_dir: &Path) {
+    let source_path = playground_dir.join(&entry.source_path);
+    let source = std::fs::read_to_string(&source_path).unwrap_or_else(|err| {
+        panic!(
+            "failed to read playground source {} for {}: {err}",
+            source_path.display(),
+            entry.id
+        )
+    });
+    let output = compile_to_sandbox_bytecode(&source, Some(SANDBOX_PROFILE))
+        .unwrap_or_else(|err| panic!("compile_to_sandbox_bytecode threw for {}: {err}", entry.id));
+
+    match entry.capabilities.sandbox.as_str() {
+        RUNNABLE => {
+            assert!(
+                output
+                    .diagnostics
+                    .iter()
+                    .all(|diagnostic| diagnostic.severity != "error"),
+                "runnable playground entry {} produced error diagnostics:\n{}",
+                entry.id,
+                diagnostics_dump(&output.diagnostics)
+            );
+            let bytecode = output.bytecode.unwrap_or_else(|| {
+                panic!(
+                    "runnable playground entry {} did not emit bytecode; diagnostics:\n{}",
+                    entry.id,
+                    diagnostics_dump(&output.diagnostics)
+                )
+            });
+            let native = run_native(&source_path);
+            let sandbox = run_sandbox(&bytecode, &entry.id);
+            let expected_path = playground_dir.join(&entry.expected_path);
+            let expected = std::fs::read_to_string(&expected_path).unwrap_or_else(|err| {
+                panic!(
+                    "failed to read expected output {} for {}: {err}",
+                    expected_path.display(),
+                    entry.id
+                )
+            });
+
+            assert_eq!(
+                sandbox.status.code(),
+                native.status.code(),
+                "{} exit-code mismatch\nnative:\n{}\nsandbox:\n{}",
+                entry.id,
+                describe_output(&native),
+                describe_output(&sandbox)
+            );
+            assert_eq!(
+                String::from_utf8_lossy(&sandbox.stdout),
+                String::from_utf8_lossy(&native.stdout),
+                "{} stdout mismatch\nnative:\n{}\nsandbox:\n{}",
+                entry.id,
+                describe_output(&native),
+                describe_output(&sandbox)
+            );
+            assert_eq!(
+                String::from_utf8_lossy(&sandbox.stdout),
+                expected,
+                "{} sandbox stdout did not match {}",
+                entry.id,
+                expected_path.display()
+            );
+        }
+        UNSUPPORTED_NATIVE_ONLY => {
+            assert!(
+                output.bytecode.is_none(),
+                "unsupported_native_only playground entry {} unexpectedly emitted bytecode",
+                entry.id
+            );
+            assert!(
+                output.diagnostics.iter().any(is_typed_profile_rejection),
+                "unsupported_native_only playground entry {} must fail closed with a typed profile diagnostic; got:\n{}",
+                entry.id,
+                diagnostics_dump(&output.diagnostics)
+            );
+        }
+        other => panic!(
+            "manifest entry {} has unsupported capabilities.sandbox {other:?}; expected {RUNNABLE:?} or {UNSUPPORTED_NATIVE_ONLY:?}",
+            entry.id
+        ),
     }
 }
 
@@ -127,18 +162,11 @@ fn load_manifest(playground_dir: &Path) -> Vec<ManifestEntry> {
 }
 
 fn playground_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("crate should have a workspace parent")
-        .join("examples")
-        .join("playground")
+    repo_root().join("examples").join("playground")
 }
 
 fn set_test_hewpath() {
-    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("crate should have a workspace parent");
-    std::env::set_var("HEWPATH", repo_root);
+    std::env::set_var("HEWPATH", repo_root());
 }
 
 fn is_typed_profile_rejection(diagnostic: &Diagnostic) -> bool {
@@ -153,4 +181,126 @@ fn is_typed_profile_rejection(diagnostic: &Diagnostic) -> bool {
 
 fn diagnostics_dump(diagnostics: &[Diagnostic]) -> String {
     serde_json::to_string_pretty(diagnostics).expect("diagnostics should serialize")
+}
+
+fn run_native(source_path: &Path) -> Output {
+    Command::new(hew_binary())
+        .arg("run")
+        .arg(source_path)
+        .current_dir(repo_root())
+        .env("HEWPATH", repo_root())
+        .env("HEW_SEED", HEW_SEED)
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap_or_else(|err| panic!("failed to spawn native `hew run`: {err}"))
+}
+
+fn run_sandbox(bytecode: &hew_sandbox_wasm::SandboxBytecodePackage, id: &str) -> Output {
+    let bytecode_json = serde_json::to_string_pretty(bytecode)
+        .unwrap_or_else(|err| panic!("failed to serialize bytecode for {id}: {err}"));
+    let tempdir = tempfile::tempdir()
+        .unwrap_or_else(|err| panic!("failed to create tempdir for {id}: {err}"));
+    let bytecode_path = tempdir.path().join("bytecode.json");
+    std::fs::write(&bytecode_path, bytecode_json)
+        .unwrap_or_else(|err| panic!("failed to write bytecode for {id}: {err}"));
+
+    Command::new("npm")
+        .arg("--prefix")
+        .arg(repo_root().join("hew-sandbox-vm"))
+        .arg("run")
+        .arg("-s")
+        .arg("parity:run")
+        .arg("--")
+        .arg(bytecode_path)
+        .arg("--seed")
+        .arg(HEW_SEED)
+        .current_dir(repo_root())
+        .env("NO_COLOR", "1")
+        .output()
+        .unwrap_or_else(|err| panic!("failed to spawn sandbox parity runner for {id}: {err}"))
+}
+
+fn ensure_native_toolchain() {
+    static NATIVE_TOOLCHAIN: OnceLock<()> = OnceLock::new();
+    NATIVE_TOOLCHAIN.get_or_init(|| {
+        run_bootstrap_command(
+            "cargo build -q -p hew-cli",
+            std::process::Command::new("cargo")
+                .args(["build", "-q", "-p", "hew-cli"])
+                .current_dir(repo_root()),
+        );
+        run_bootstrap_command(
+            "cargo build -q -p hew-lib",
+            std::process::Command::new("cargo")
+                .args(["build", "-q", "-p", "hew-lib"])
+                .current_dir(repo_root()),
+        );
+    });
+}
+
+fn ensure_parity_runner_built() {
+    static PARITY_RUNNER: OnceLock<()> = OnceLock::new();
+    PARITY_RUNNER.get_or_init(|| {
+        let vm_dir = repo_root().join("hew-sandbox-vm");
+        assert!(
+            vm_dir.join("node_modules").is_dir(),
+            "hew-sandbox-vm dependencies are not installed; run `npm --prefix hew-sandbox-vm ci` or `make sandbox-parity`"
+        );
+        run_bootstrap_command(
+            "npm --prefix hew-sandbox-vm run -s build",
+            std::process::Command::new("npm")
+                .arg("--prefix")
+                .arg(&vm_dir)
+                .arg("run")
+                .arg("-s")
+                .arg("build")
+                .current_dir(repo_root()),
+        );
+    });
+}
+
+fn run_bootstrap_command(label: &str, command: &mut std::process::Command) {
+    let output = command
+        .output()
+        .unwrap_or_else(|err| panic!("failed to invoke `{label}`: {err}"));
+    assert!(
+        output.status.success(),
+        "`{label}` failed\n{}",
+        describe_output(&output)
+    );
+}
+
+fn hew_binary() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_hew") {
+        return PathBuf::from(path);
+    }
+    target_debug_dir().join(format!("hew{}", std::env::consts::EXE_SUFFIX))
+}
+
+fn target_debug_dir() -> PathBuf {
+    if let Ok(target_dir) = std::env::var("CARGO_TARGET_DIR") {
+        return PathBuf::from(target_dir).join("debug");
+    }
+    repo_root().join("target").join("debug")
+}
+
+fn repo_root() -> &'static Path {
+    static REPO_ROOT: OnceLock<PathBuf> = OnceLock::new();
+    REPO_ROOT
+        .get_or_init(|| {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .expect("hew-sandbox-wasm crate should have a workspace parent")
+                .to_path_buf()
+        })
+        .as_path()
+}
+
+fn describe_output(output: &Output) -> String {
+    format!(
+        "status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
 }


### PR DESCRIPTION
## Summary

I added consumer-driven sandbox coverage for the real web playground and iOS app sources. The tests execute supported programs through native Hew and the TypeScript sandbox VM, compare exit status and stdout, and require unsupported sources to fail closed with typed diagnostics.

## Covered subsets

- All 44 entries in `examples/playground/manifest.json`, with sandbox output also pinned to each checked-in `.expected` file.
- All 17 `examples/sandbox-graduation/*.hew` files, plus an exact corpus ratchet so new fixtures cannot land uncovered.
- 40 standalone iOS sources: the default template, 13 bundled examples, 13 tutorial starters, and 13 standalone quick-reference snippets using the app's wrapping rule.
- Six iOS quick-reference fragments are explicitly enumerated as context-dependent rather than treated as standalone programs.

## Fail-closed boundaries

- The shipped iOS default template currently mutates an immutable actor field and is pinned to a typecheck failure with no bytecode.
- Function-parameter indirect calls in the higher-order examples are pinned to profile rejection.
- Closure syntax is pinned to profile rejection.
- The quick-reference import sample is pinned to native-only/unallowlisted module rejection.

## Verification

- `cargo test -p hew-sandbox-wasm`
- `make hew-check-all` (1,575 files; expected failure set matched)
- `npm --prefix hew-sandbox-vm test --silent`: 62/72 pass; the 10 existing M3 golden failures differ only in `hew_version` metadata (`0.5.0-pre` expected versus `0.6.0-rc1` actual).
