### PR TITLE
fix(std): fail-closed error handling for fs, env, and stream I/O

### DIFF
--- a/examples/v05/checked-mir/golden/stream_blocking_recv.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.elab.mir
@@ -81,15 +81,84 @@ fn fs$io_error_from_errno -> IoError
     use BindingId(6) errno site=SiteId(46) ty=i64 intent=Read
     return site=Some(SiteId(37)) ty=IoError
     use BindingId(6) errno site=SiteId(50) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(53) ty=i64 intent=Read
+    use BindingId(6) errno site=SiteId(54) ty=i64 intent=Read
     use BindingId(6) errno site=SiteId(57) ty=i64 intent=Read
     use BindingId(6) errno site=SiteId(61) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(64) ty=i64 intent=Read
+    use BindingId(6) errno site=SiteId(65) ty=i64 intent=Read
     use BindingId(6) errno site=SiteId(68) ty=i64 intent=Read
     use BindingId(6) errno site=SiteId(72) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(75) ty=i64 intent=Read
+    use BindingId(6) errno site=SiteId(76) ty=i64 intent=Read
     use BindingId(6) errno site=SiteId(79) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(82) ty=i64 intent=Read
+    use BindingId(6) errno site=SiteId(83) ty=i64 intent=Read
+    use BindingId(6) errno site=SiteId(86) ty=i64 intent=Read
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    goto[bb1->bb3] ->
+      (none)
+    branch[bb2: bb4/bb5] ->
+      (none)
+    return[bb3] ->
+      (none)
+    goto[bb4->bb6] ->
+      (none)
+    branch[bb5: bb8/bb7] ->
+      (none)
+    goto[bb6->bb3] ->
+      (none)
+    cancel[bb6] ->
+      (none)
+    goto[bb7->bb8] ->
+      (none)
+    branch[bb8: bb9/bb10] ->
+      (none)
+    goto[bb9->bb11] ->
+      (none)
+    branch[bb10: bb13/bb12] ->
+      (none)
+    goto[bb11->bb6] ->
+      (none)
+    cancel[bb11] ->
+      (none)
+    goto[bb12->bb13] ->
+      (none)
+    branch[bb13: bb14/bb15] ->
+      (none)
+    goto[bb14->bb16] ->
+      (none)
+    branch[bb15: bb18/bb17] ->
+      (none)
+    goto[bb16->bb11] ->
+      (none)
+    cancel[bb16] ->
+      (none)
+    goto[bb17->bb18] ->
+      (none)
+    branch[bb18: bb19/bb20] ->
+      (none)
+    goto[bb19->bb21] ->
+      (none)
+    goto[bb20->bb21] ->
+      (none)
+    goto[bb21->bb16] ->
+      (none)
+    cancel[bb21] ->
+      (none)
+
+fn fs$io_error_from_kind -> IoError
+  statements:
+    use BindingId(7) kind site=SiteId(89) ty=i64 intent=Read
+    use BindingId(8) errno site=SiteId(93) ty=i64 intent=Read
+    use BindingId(7) kind site=SiteId(96) ty=i64 intent=Read
+    return site=Some(SiteId(87)) ty=IoError
+    use BindingId(8) errno site=SiteId(100) ty=i64 intent=Read
+    use BindingId(7) kind site=SiteId(103) ty=i64 intent=Read
+    use BindingId(8) errno site=SiteId(107) ty=i64 intent=Read
+    use BindingId(7) kind site=SiteId(110) ty=i64 intent=Read
+    use BindingId(8) errno site=SiteId(114) ty=i64 intent=Read
+    use BindingId(8) errno site=SiteId(117) ty=i64 intent=Read
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -111,53 +180,41 @@ fn fs$io_error_from_errno -> IoError
       (none)
     goto[bb7->bb9] ->
       (none)
-    branch[bb8: bb11/bb10] ->
+    branch[bb8: bb10/bb11] ->
       (none)
     goto[bb9->bb6] ->
       (none)
     cancel[bb9] ->
       (none)
-    goto[bb10->bb11] ->
+    goto[bb10->bb12] ->
       (none)
-    branch[bb11: bb12/bb13] ->
+    call[bb11 fs$io_error_from_errno -> bb13] ->
       (none)
-    goto[bb12->bb14] ->
+    goto[bb12->bb9] ->
       (none)
-    branch[bb13: bb16/bb15] ->
+    cancel[bb12] ->
       (none)
-    goto[bb14->bb9] ->
+    goto[bb13->bb12] ->
       (none)
-    cancel[bb14] ->
-      (none)
-    goto[bb15->bb16] ->
-      (none)
-    branch[bb16: bb17/bb18] ->
-      (none)
-    goto[bb17->bb19] ->
-      (none)
-    goto[bb18->bb19] ->
-      (none)
-    goto[bb19->bb14] ->
-      (none)
-    cancel[bb19] ->
+    cancel[bb13] ->
       (none)
 
 fn fs$io_error_message -> string
   statements:
-    use BindingId(7) e site=SiteId(84) ty=IoError intent=Read
-    return site=Some(SiteId(83)) ty=string
-    bind BindingId(8) code site=SiteId(85) ty=i64
-    use BindingId(8) code site=SiteId(87) ty=i64 intent=Read
-    bind BindingId(9) code site=SiteId(95) ty=i64
-    use BindingId(9) code site=SiteId(97) ty=i64 intent=Read
-    bind BindingId(10) code site=SiteId(105) ty=i64
-    use BindingId(10) code site=SiteId(107) ty=i64 intent=Read
-    bind BindingId(11) code site=SiteId(115) ty=i64
-    use BindingId(11) code site=SiteId(117) ty=i64 intent=Read
-    bind BindingId(12) code site=SiteId(125) ty=i64
-    use BindingId(12) code site=SiteId(127) ty=i64 intent=Read
-    bind BindingId(13) code site=SiteId(135) ty=i64
-    use BindingId(13) code site=SiteId(137) ty=i64 intent=Read
+    use BindingId(9) e site=SiteId(120) ty=IoError intent=Read
+    return site=Some(SiteId(119)) ty=string
+    bind BindingId(10) code site=SiteId(121) ty=i64
+    use BindingId(10) code site=SiteId(123) ty=i64 intent=Read
+    bind BindingId(11) code site=SiteId(131) ty=i64
+    use BindingId(11) code site=SiteId(133) ty=i64 intent=Read
+    bind BindingId(12) code site=SiteId(141) ty=i64
+    use BindingId(12) code site=SiteId(143) ty=i64 intent=Read
+    bind BindingId(13) code site=SiteId(151) ty=i64
+    use BindingId(13) code site=SiteId(153) ty=i64 intent=Read
+    bind BindingId(14) code site=SiteId(161) ty=i64
+    use BindingId(14) code site=SiteId(163) ty=i64 intent=Read
+    bind BindingId(15) code site=SiteId(171) ty=i64
+    use BindingId(15) code site=SiteId(173) ty=i64 intent=Read
   drop_plans:
     branch[bb0: bb2/bb9] ->
       (none)
@@ -240,363 +297,73 @@ fn fs$io_error_message -> string
 
 fn fs$io_error_timed_out -> IoError
   statements:
-    return site=Some(SiteId(145)) ty=IoError
+    return site=Some(SiteId(181)) ty=IoError
   drop_plans:
     return[bb0] ->
       (none)
 
 fn fs$io_error_cancelled -> IoError
   statements:
-    return site=Some(SiteId(147)) ty=IoError
+    return site=Some(SiteId(183)) ty=IoError
   drop_plans:
     return[bb0] ->
       (none)
 
-fn fs$missing_parent -> bool
+fn fs$last_io_error -> IoError
   statements:
-    use BindingId(14) target site=SiteId(150) ty=string intent=Read
-    bind BindingId(15) parent site=SiteId(149) ty=string
-    use BindingId(15) parent site=SiteId(154) ty=string intent=Read
-    use BindingId(15) parent site=SiteId(158) ty=string intent=Read
-    return site=Some(SiteId(152)) ty=bool
-    drop BindingId(15) parent ty=string
+    bind BindingId(16) kind site=SiteId(186) ty=i64
+    bind BindingId(17) errno site=SiteId(189) ty=i64
+    eval site=SiteId(192) ty=string
+    use BindingId(17) errno site=SiteId(197) ty=i64 intent=Read
+    use BindingId(16) kind site=SiteId(200) ty=i64 intent=Read
+    use BindingId(16) kind site=SiteId(207) ty=i64 intent=Read
+    use BindingId(17) errno site=SiteId(208) ty=i64 intent=Read
+    return site=Some(SiteId(185)) ty=IoError
   drop_plans:
-    call[bb0 fs$dirname -> bb1] ->
+    call[bb0 hew_stream_last_error_kind -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    branch[bb1: bb2/bb3] ->
+    call[bb1 hew_stream_last_errno -> bb2] ->
       (none)
-    call[bb2 fs$exists -> bb4] ->
+    call[bb2 hew_stream_last_error -> bb3] ->
       (none)
-    return[bb3] ->
-      (none)
-    goto[bb4->bb3] ->
-      (none)
-    cancel[bb4] ->
-      (none)
-
-fn fs$dirname -> string
-  statements:
-    use BindingId(16) p site=SiteId(161) ty=string intent=Read
-    bind BindingId(17) s site=SiteId(160) ty=string
-    use BindingId(17) s site=SiteId(164) ty=string intent=Read
-    bind BindingId(18) pos site=SiteId(163) ty=i64
-    use BindingId(18) pos site=SiteId(167) ty=i64 intent=Read
-    return site=Some(SiteId(169)) ty=string
-    eval site=SiteId(171) ty=()
-    use BindingId(18) pos site=SiteId(173) ty=i64 intent=Read
-    return site=Some(SiteId(175)) ty=string
-    eval site=SiteId(177) ty=()
-    use BindingId(17) s site=SiteId(179) ty=string intent=Read
-    use BindingId(18) pos site=SiteId(181) ty=i64 intent=Read
-    return site=Some(SiteId(178)) ty=string
-    drop BindingId(17) s ty=string
-  drop_plans:
-    call[bb0 fs$strip_trailing_slash -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    call[bb1 fs$last_slash_pos -> bb2] ->
-      (none)
-    branch[bb2: bb3/bb4] ->
-      (none)
-    return[bb3] ->
+    branch[bb3: bb4/bb5] ->
       (none)
     goto[bb4->bb5] ->
       (none)
-    branch[bb5: bb7/bb8] ->
-      (none)
-    goto[bb6->bb5] ->
-      (none)
-    cancel[bb6] ->
-      (none)
-    return[bb7] ->
-      (none)
-    goto[bb8->bb9] ->
-      (none)
-    call[bb9 hew_string_slice -> bb11] ->
-      (none)
-    goto[bb10->bb9] ->
-      (none)
-    cancel[bb10] ->
-      (none)
-    return[bb11] ->
-      (none)
-
-fn fs$strip_trailing_slash -> string
-  statements:
-    use BindingId(19) p site=SiteId(184) ty=string intent=Read
-    use BindingId(19) p site=SiteId(188) ty=string intent=Read
-    return site=Some(SiteId(186)) ty=string
-    eval site=SiteId(190) ty=()
-    use BindingId(19) p site=SiteId(194) ty=string intent=Read
-    use BindingId(19) p site=SiteId(198) ty=string intent=Read
-    use BindingId(19) p site=SiteId(202) ty=string intent=Read
-    use BindingId(19) p site=SiteId(206) ty=string intent=Read
-    eval site=SiteId(211) ty=()
-    use BindingId(19) p site=SiteId(214) ty=string intent=Read
-    return site=Some(SiteId(212)) ty=string
-    return site=Some(SiteId(201)) ty=string
-  drop_plans:
-    branch[bb0: bb1/bb2] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    return[bb1] ->
-      (none)
-    goto[bb2->bb3] ->
-      (none)
-    call[bb3 hew_string_length -> bb5] ->
-      (none)
-    goto[bb4->bb3] ->
-      (none)
-    cancel[bb4] ->
-      (none)
-    branch[bb5: bb6/bb7] ->
-      (none)
-    call[bb6 hew_string_ends_with -> bb8] ->
-      (none)
-    branch[bb7: bb9/bb10] ->
-      (none)
-    goto[bb8->bb7] ->
-      (none)
-    cancel[bb8] ->
-      (none)
-    call[bb9 hew_string_length -> bb12] ->
-      (none)
-    goto[bb10->bb11] ->
-      (none)
-    return[bb11] ->
-      (none)
-    branch[bb12: bb13/bb14] ->
-      (none)
-    panic[bb13] ->
-      (none)
-    call[bb14 hew_string_slice -> bb15] ->
-      (none)
-    return[bb15] ->
-      (none)
-    goto[bb16->bb11] ->
-      (none)
-    cancel[bb16] ->
-      (none)
-
-fn fs$last_slash_pos -> i64
-  statements:
-    use BindingId(20) s site=SiteId(217) ty=string intent=Read
-    bind BindingId(22) first site=SiteId(215) ty=i64
-    use BindingId(22) first site=SiteId(223) ty=i64 intent=Consume
-    bind BindingId(23) last site=SiteId(223) ty=i64
-    use BindingId(22) first site=SiteId(225) ty=i64 intent=Read
-    bind BindingId(21) i site=SiteId(220) ty=i64
-    use BindingId(21) i site=SiteId(220) ty=i64 intent=Read
-    return site=Some(SiteId(222)) ty=i64
-    bind BindingId(24) search_from site=SiteId(224) ty=i64
-    use BindingId(24) search_from site=SiteId(228) ty=i64 intent=Read
-    use BindingId(20) s site=SiteId(230) ty=string intent=Read
-    use BindingId(20) s site=SiteId(233) ty=string intent=Read
-    use BindingId(24) search_from site=SiteId(234) ty=i64 intent=Read
-    use BindingId(20) s site=SiteId(236) ty=string intent=Read
-    eval site=SiteId(255) ty=()
-    use BindingId(23) last site=SiteId(256) ty=i64 intent=Read
-    return site=Some(SiteId(256)) ty=i64
-    bind BindingId(25) rest site=SiteId(232) ty=string
-    use BindingId(25) rest site=SiteId(241) ty=string intent=Read
-    bind BindingId(27) next site=SiteId(239) ty=i64
-    use BindingId(24) search_from site=SiteId(249) ty=i64 intent=Read
-    use BindingId(27) next site=SiteId(250) ty=i64 intent=Read
-    bind BindingId(26) i site=SiteId(244) ty=i64
-    use BindingId(26) i site=SiteId(244) ty=i64 intent=Read
-    use BindingId(23) last site=SiteId(246) ty=i64 intent=Consume
-    return site=Some(SiteId(246)) ty=i64
-    bind BindingId(23) last site=SiteId(247) ty=i64
-    eval site=SiteId(248) ty=()
-    use BindingId(23) last site=SiteId(253) ty=i64 intent=Read
-    bind BindingId(24) search_from site=SiteId(251) ty=i64
-    eval site=SiteId(252) ty=()
-    drop BindingId(25) rest ty=string
-  drop_plans:
-    call[bb0 hew_string_find -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb3/bb6] ->
-      (none)
-    branch[bb2: bb8/bb9] ->
-      (none)
-    goto[bb3->bb2] ->
-      (none)
-    cancel[bb3] ->
-      (none)
-    return[bb4] ->
-      (none)
-    panic[bb5] ->
-      (none)
-    branch[bb6: bb4/bb5] ->
-      (none)
-    goto[bb7->bb2] ->
-      (none)
-    cancel[bb7] ->
-      (none)
-    panic[bb8] ->
-      (none)
-    goto[bb9->bb10] ->
-      (none)
-    call[bb10 hew_string_length -> bb13] ->
-      (none)
-    call[bb11 hew_string_length -> bb14] ->
-      (none)
-    return[bb12] ->
-      (none)
-    branch[bb13: bb11/bb12] ->
-      (none)
-    call[bb14 hew_string_slice -> bb15] ->
-      (none)
-    call[bb15 hew_string_find -> bb16] ->
-      (none)
-    branch[bb16: bb18/bb21] ->
-      (none)
-    branch[bb17: bb23/bb24] ->
-      (none)
-    goto[bb18->bb17] ->
-      (none)
-    cancel[bb18] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    return[bb19] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    panic[bb20] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    branch[bb21: bb19/bb20] ->
-      (none)
-    goto[bb22->bb17] ->
-      (none)
-    cancel[bb22] ->
-      (none)
-    panic[bb23] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    branch[bb24: bb25/bb26] ->
-      (none)
-    panic[bb25] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    goto[bb26->bb10] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    cancel[bb26] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-
-fn fs$write_error -> IoError
-  statements:
-    use BindingId(28) target site=SiteId(259) ty=string intent=Read
-    return site=Some(SiteId(257)) ty=IoError
-  drop_plans:
-    call[bb0 fs$missing_parent -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb2/bb3] ->
-      (none)
-    goto[bb2->bb4] ->
-      (none)
-    goto[bb3->bb4] ->
-      (none)
-    return[bb4] ->
-      (none)
-
-fn fs$missing_path_error -> IoError
-  statements:
-    use BindingId(29) target site=SiteId(269) ty=string intent=Read
-    return site=Some(SiteId(267)) ty=IoError
-  drop_plans:
-    call[bb0 fs$exists -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb2/bb3] ->
-      (none)
-    goto[bb2->bb4] ->
-      (none)
-    goto[bb3->bb4] ->
-      (none)
-    return[bb4] ->
-      (none)
-
-fn fs$mkdir_error -> IoError
-  statements:
-    use BindingId(30) target site=SiteId(279) ty=string intent=Read
-    use BindingId(30) target site=SiteId(286) ty=string intent=Read
-    return site=Some(SiteId(277)) ty=IoError
-  drop_plans:
-    call[bb0 fs$exists -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb2/bb3] ->
-      (none)
-    goto[bb2->bb4] ->
-      (none)
-    call[bb3 fs$missing_parent -> bb5] ->
-      (none)
-    return[bb4] ->
-      (none)
     branch[bb5: bb6/bb7] ->
       (none)
     goto[bb6->bb8] ->
       (none)
-    goto[bb7->bb8] ->
+    call[bb7 fs$io_error_from_kind -> bb9] ->
       (none)
-    goto[bb8->bb4] ->
+    return[bb8] ->
       (none)
-    cancel[bb8] ->
+    goto[bb9->bb8] ->
       (none)
-
-fn fs$move_copy_error -> IoError
-  statements:
-    use BindingId(31) source site=SiteId(297) ty=string intent=Read
-    use BindingId(32) target site=SiteId(304) ty=string intent=Read
-    return site=Some(SiteId(294)) ty=IoError
-  drop_plans:
-    call[bb0 fs$exists -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb2/bb3] ->
-      (none)
-    goto[bb2->bb4] ->
-      (none)
-    call[bb3 fs$missing_parent -> bb5] ->
-      (none)
-    return[bb4] ->
-      (none)
-    branch[bb5: bb6/bb7] ->
-      (none)
-    goto[bb6->bb8] ->
-      (none)
-    goto[bb7->bb8] ->
-      (none)
-    goto[bb8->bb4] ->
-      (none)
-    cancel[bb8] ->
+    cancel[bb9] ->
       (none)
 
 fn fs$read -> string
   statements:
-    use BindingId(33) path site=SiteId(314) ty=string intent=Read
-    bind BindingId(34) contents site=SiteId(313) ty=string
-    bind BindingId(35) errno site=SiteId(316) ty=i32
-    use BindingId(35) errno site=SiteId(319) ty=i32 intent=Read
-    eval site=SiteId(371) ty=()
-    use BindingId(34) contents site=SiteId(372) ty=string intent=Read
-    return site=Some(SiteId(312)) ty=string
-    bind BindingId(36) detail site=SiteId(321) ty=string
-    use BindingId(36) detail site=SiteId(326) ty=string intent=Read
-    use BindingId(33) path site=SiteId(333) ty=string intent=Read
-    use BindingId(33) path site=SiteId(356) ty=string intent=Read
-    use BindingId(35) errno site=SiteId(340) ty=i32 intent=Read
-    eval site=SiteId(330) ty=!
-    use BindingId(36) detail site=SiteId(360) ty=string intent=Read
-    eval site=SiteId(353) ty=!
-    drop BindingId(36) detail ty=string
-    drop BindingId(34) contents ty=string
+    use BindingId(18) path site=SiteId(212) ty=string intent=Read
+    bind BindingId(19) contents site=SiteId(211) ty=string
+    bind BindingId(20) errno site=SiteId(214) ty=i32
+    use BindingId(20) errno site=SiteId(217) ty=i32 intent=Read
+    eval site=SiteId(269) ty=()
+    use BindingId(19) contents site=SiteId(270) ty=string intent=Read
+    return site=Some(SiteId(210)) ty=string
+    bind BindingId(21) detail site=SiteId(219) ty=string
+    use BindingId(21) detail site=SiteId(224) ty=string intent=Read
+    use BindingId(18) path site=SiteId(231) ty=string intent=Read
+    use BindingId(18) path site=SiteId(254) ty=string intent=Read
+    use BindingId(20) errno site=SiteId(238) ty=i32 intent=Read
+    eval site=SiteId(228) ty=!
+    use BindingId(21) detail site=SiteId(258) ty=string intent=Read
+    eval site=SiteId(251) ty=!
+    drop BindingId(21) detail ty=string
+    drop BindingId(19) contents ty=string
   drop_plans:
     call[bb0 hew_file_read -> bb1] ->
       (none)
@@ -659,14 +426,21 @@ fn fs$read -> string
 
 fn fs$try_read -> Result<string, IoError>
   statements:
-    use BindingId(37) file_path site=SiteId(375) ty=string intent=Read
-    bind BindingId(38) file site=SiteId(374) ty=FileReadStream
-    use BindingId(38) file site=SiteId(379) ty=FileReadStream intent=Read
-    use BindingId(38) file site=SiteId(384) ty=FileReadStream intent=Read
-    return site=Some(SiteId(373)) ty=Result<string, IoError>
-    bind BindingId(39) errno site=SiteId(387) ty=i32
-    eval site=SiteId(389) ty=string
-    use BindingId(39) errno site=SiteId(394) ty=i32 intent=Read
+    use BindingId(22) file_path site=SiteId(273) ty=string intent=Read
+    bind BindingId(23) file site=SiteId(272) ty=FileReadStream
+    use BindingId(23) file site=SiteId(277) ty=FileReadStream intent=Read
+    use BindingId(23) file site=SiteId(281) ty=FileReadStream intent=Read
+    return site=Some(SiteId(271)) ty=Result<string, IoError>
+    bind BindingId(24) contents site=SiteId(280) ty=string
+    bind BindingId(25) kind site=SiteId(283) ty=i64
+    bind BindingId(26) errno site=SiteId(286) ty=i32
+    eval site=SiteId(288) ty=string
+    use BindingId(26) errno site=SiteId(292) ty=i32 intent=Read
+    use BindingId(24) contents site=SiteId(296) ty=string intent=Read
+    agg_alias BindingId(24) contents site=SiteId(296) ty=string
+    use BindingId(25) kind site=SiteId(300) ty=i64 intent=Read
+    use BindingId(26) errno site=SiteId(302) ty=i32 intent=Read
+    drop BindingId(24) contents ty=string
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -678,28 +452,40 @@ fn fs$try_read -> Result<string, IoError>
       (none)
     call[bb3 hew_stream_collect_string -> bb6] ->
       (none)
-    call[bb4 hew_stream_last_errno -> bb7] ->
+    call[bb4 fs$last_io_error -> bb14] ->
       (none)
     return[bb5] ->
       (none)
-    goto[bb6->bb5] ->
+    call[bb6 hew_stream_last_error_kind -> bb7] ->
       (none)
-    cancel[bb6] ->
+    call[bb7 hew_stream_last_errno -> bb8] ->
       (none)
-    call[bb7 hew_stream_last_error -> bb8] ->
+    call[bb8 hew_stream_last_error -> bb9] ->
       (none)
-    call[bb8 fs$io_error_from_errno -> bb9] ->
+    branch[bb9: bb10/bb11] ->
       (none)
-    goto[bb9->bb5] ->
+    goto[bb10->bb12] ->
       (none)
-    cancel[bb9] ->
+    call[bb11 fs$io_error_from_kind -> bb13] ->
+      (none)
+    goto[bb12->bb5] ->
+      (none)
+    cancel[bb12] ->
+      (none)
+    goto[bb13->bb12] ->
+      (none)
+    cancel[bb13] ->
+      (none)
+    goto[bb14->bb5] ->
+      (none)
+    cancel[bb14] ->
       (none)
 
 fn fs$write -> i64
   statements:
-    use BindingId(40) path site=SiteId(399) ty=string intent=Read
-    use BindingId(41) content site=SiteId(400) ty=string intent=Read
-    return site=Some(SiteId(396)) ty=i64
+    use BindingId(27) path site=SiteId(311) ty=string intent=Read
+    use BindingId(28) content site=SiteId(312) ty=string intent=Read
+    return site=Some(SiteId(308)) ty=i64
   drop_plans:
     call[bb0 hew_file_write -> bb1] ->
       (none)
@@ -710,10 +496,9 @@ fn fs$write -> i64
 
 fn fs$try_write -> Result<i64, IoError>
   statements:
-    use BindingId(42) file_path site=SiteId(405) ty=string intent=Read
-    use BindingId(43) content site=SiteId(406) ty=string intent=Read
-    return site=Some(SiteId(402)) ty=Result<i64, IoError>
-    use BindingId(42) file_path site=SiteId(412) ty=string intent=Read
+    use BindingId(29) file_path site=SiteId(317) ty=string intent=Read
+    use BindingId(30) content site=SiteId(318) ty=string intent=Read
+    return site=Some(SiteId(314)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_file_write -> bb1] ->
       (none)
@@ -725,7 +510,7 @@ fn fs$try_write -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$write_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -740,9 +525,9 @@ fn fs$try_write -> Result<i64, IoError>
 
 fn fs$append -> i64
   statements:
-    use BindingId(44) path site=SiteId(417) ty=string intent=Read
-    use BindingId(45) content site=SiteId(418) ty=string intent=Read
-    return site=Some(SiteId(414)) ty=i64
+    use BindingId(31) path site=SiteId(328) ty=string intent=Read
+    use BindingId(32) content site=SiteId(329) ty=string intent=Read
+    return site=Some(SiteId(325)) ty=i64
   drop_plans:
     call[bb0 hew_file_append -> bb1] ->
       (none)
@@ -753,10 +538,9 @@ fn fs$append -> i64
 
 fn fs$try_append -> Result<i64, IoError>
   statements:
-    use BindingId(46) file_path site=SiteId(423) ty=string intent=Read
-    use BindingId(47) content site=SiteId(424) ty=string intent=Read
-    return site=Some(SiteId(420)) ty=Result<i64, IoError>
-    use BindingId(46) file_path site=SiteId(430) ty=string intent=Read
+    use BindingId(33) file_path site=SiteId(334) ty=string intent=Read
+    use BindingId(34) content site=SiteId(335) ty=string intent=Read
+    return site=Some(SiteId(331)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_file_append -> bb1] ->
       (none)
@@ -768,7 +552,7 @@ fn fs$try_append -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$write_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -783,8 +567,8 @@ fn fs$try_append -> Result<i64, IoError>
 
 fn fs$exists -> bool
   statements:
-    use BindingId(48) path site=SiteId(434) ty=string intent=Read
-    return site=Some(SiteId(432)) ty=bool
+    use BindingId(35) path site=SiteId(344) ty=string intent=Read
+    return site=Some(SiteId(342)) ty=bool
   drop_plans:
     call[bb0 hew_file_exists -> bb1] ->
       (none)
@@ -795,8 +579,8 @@ fn fs$exists -> bool
 
 fn fs$delete -> i64
   statements:
-    use BindingId(49) path site=SiteId(439) ty=string intent=Read
-    return site=Some(SiteId(436)) ty=i64
+    use BindingId(36) path site=SiteId(349) ty=string intent=Read
+    return site=Some(SiteId(346)) ty=i64
   drop_plans:
     call[bb0 hew_file_delete -> bb1] ->
       (none)
@@ -807,9 +591,8 @@ fn fs$delete -> i64
 
 fn fs$try_delete -> Result<i64, IoError>
   statements:
-    use BindingId(50) file_path site=SiteId(444) ty=string intent=Read
-    return site=Some(SiteId(441)) ty=Result<i64, IoError>
-    use BindingId(50) file_path site=SiteId(450) ty=string intent=Read
+    use BindingId(37) file_path site=SiteId(354) ty=string intent=Read
+    return site=Some(SiteId(351)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_file_delete -> bb1] ->
       (none)
@@ -821,7 +604,7 @@ fn fs$try_delete -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$missing_path_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -836,8 +619,8 @@ fn fs$try_delete -> Result<i64, IoError>
 
 fn fs$size -> i64
   statements:
-    use BindingId(51) path site=SiteId(454) ty=string intent=Read
-    return site=Some(SiteId(452)) ty=i64
+    use BindingId(38) path site=SiteId(363) ty=string intent=Read
+    return site=Some(SiteId(361)) ty=i64
   drop_plans:
     call[bb0 hew_file_size -> bb1] ->
       (none)
@@ -848,8 +631,8 @@ fn fs$size -> i64
 
 fn fs$read_bytes -> bytes
   statements:
-    use BindingId(52) path site=SiteId(458) ty=string intent=Read
-    return site=Some(SiteId(456)) ty=bytes
+    use BindingId(39) path site=SiteId(367) ty=string intent=Read
+    return site=Some(SiteId(365)) ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
       (none)
@@ -860,42 +643,46 @@ fn fs$read_bytes -> bytes
 
 fn fs$try_read_bytes -> Result<bytes, IoError>
   statements:
-    use BindingId(53) file_path site=SiteId(462) ty=string intent=Read
-    bind BindingId(54) data site=SiteId(461) ty=bytes
-    bind BindingId(55) errno site=SiteId(464) ty=i32
-    use BindingId(55) errno site=SiteId(468) ty=i32 intent=Read
-    use BindingId(54) data site=SiteId(480) ty=bytes intent=Read
-    return site=Some(SiteId(460)) ty=Result<bytes, IoError>
-    eval site=SiteId(471) ty=string
-    use BindingId(55) errno site=SiteId(476) ty=i32 intent=Read
-    drop BindingId(54) data ty=bytes
+    use BindingId(40) file_path site=SiteId(371) ty=string intent=Read
+    bind BindingId(41) data site=SiteId(370) ty=bytes
+    bind BindingId(42) kind site=SiteId(373) ty=i64
+    bind BindingId(43) errno site=SiteId(376) ty=i32
+    use BindingId(43) errno site=SiteId(380) ty=i32 intent=Read
+    use BindingId(41) data site=SiteId(393) ty=bytes intent=Read
+    return site=Some(SiteId(369)) ty=Result<bytes, IoError>
+    eval site=SiteId(383) ty=string
+    use BindingId(42) kind site=SiteId(387) ty=i64 intent=Read
+    use BindingId(43) errno site=SiteId(389) ty=i32 intent=Read
+    drop BindingId(41) data ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    call[bb1 hew_stream_last_errno -> bb2] ->
+    call[bb1 hew_stream_last_error_kind -> bb2] ->
       (none)
-    branch[bb2: bb3/bb4] ->
+    call[bb2 hew_stream_last_errno -> bb3] ->
       (none)
-    call[bb3 hew_stream_last_error -> bb6] ->
+    branch[bb3: bb4/bb5] ->
       (none)
-    goto[bb4->bb5] ->
+    call[bb4 hew_stream_last_error -> bb7] ->
       (none)
-    return[bb5] ->
+    goto[bb5->bb6] ->
       (none)
-    call[bb6 fs$io_error_from_errno -> bb7] ->
+    return[bb6] ->
       (none)
-    goto[bb7->bb5] ->
+    call[bb7 fs$io_error_from_kind -> bb8] ->
       (none)
-    cancel[bb7] ->
+    goto[bb8->bb6] ->
+      (none)
+    cancel[bb8] ->
       (none)
 
 fn fs$write_bytes -> i64
   statements:
-    use BindingId(56) path site=SiteId(484) ty=string intent=Read
-    use BindingId(57) data site=SiteId(485) ty=bytes intent=Read
-    return site=Some(SiteId(481)) ty=i64
+    use BindingId(44) path site=SiteId(397) ty=string intent=Read
+    use BindingId(45) data site=SiteId(398) ty=bytes intent=Read
+    return site=Some(SiteId(394)) ty=i64
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -906,10 +693,9 @@ fn fs$write_bytes -> i64
 
 fn fs$try_write_bytes -> Result<i64, IoError>
   statements:
-    use BindingId(58) file_path site=SiteId(490) ty=string intent=Read
-    use BindingId(59) data site=SiteId(491) ty=bytes intent=Read
-    return site=Some(SiteId(487)) ty=Result<i64, IoError>
-    use BindingId(58) file_path site=SiteId(497) ty=string intent=Read
+    use BindingId(46) file_path site=SiteId(403) ty=string intent=Read
+    use BindingId(47) data site=SiteId(404) ty=bytes intent=Read
+    return site=Some(SiteId(400)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -921,7 +707,7 @@ fn fs$try_write_bytes -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$write_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -936,8 +722,8 @@ fn fs$try_write_bytes -> Result<i64, IoError>
 
 fn fs$mkdir -> i64
   statements:
-    use BindingId(60) path site=SiteId(502) ty=string intent=Read
-    return site=Some(SiteId(499)) ty=i64
+    use BindingId(48) path site=SiteId(414) ty=string intent=Read
+    return site=Some(SiteId(411)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -948,9 +734,8 @@ fn fs$mkdir -> i64
 
 fn fs$try_mkdir -> Result<i64, IoError>
   statements:
-    use BindingId(61) dir_path site=SiteId(507) ty=string intent=Read
-    return site=Some(SiteId(504)) ty=Result<i64, IoError>
-    use BindingId(61) dir_path site=SiteId(513) ty=string intent=Read
+    use BindingId(49) dir_path site=SiteId(419) ty=string intent=Read
+    return site=Some(SiteId(416)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -962,7 +747,7 @@ fn fs$try_mkdir -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$mkdir_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -977,8 +762,8 @@ fn fs$try_mkdir -> Result<i64, IoError>
 
 fn fs$mkdir_all -> i64
   statements:
-    use BindingId(62) path site=SiteId(518) ty=string intent=Read
-    return site=Some(SiteId(515)) ty=i64
+    use BindingId(50) path site=SiteId(429) ty=string intent=Read
+    return site=Some(SiteId(426)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -989,9 +774,8 @@ fn fs$mkdir_all -> i64
 
 fn fs$try_mkdir_all -> Result<i64, IoError>
   statements:
-    use BindingId(63) dir_path site=SiteId(523) ty=string intent=Read
-    return site=Some(SiteId(520)) ty=Result<i64, IoError>
-    use BindingId(63) dir_path site=SiteId(530) ty=string intent=Read
+    use BindingId(51) dir_path site=SiteId(434) ty=string intent=Read
+    return site=Some(SiteId(431)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -1003,7 +787,7 @@ fn fs$try_mkdir_all -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$exists -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -1011,21 +795,15 @@ fn fs$try_mkdir_all -> Result<i64, IoError>
       (none)
     cancel[bb6] ->
       (none)
-    branch[bb7: bb8/bb9] ->
+    goto[bb7->bb2] ->
       (none)
-    goto[bb8->bb10] ->
-      (none)
-    goto[bb9->bb10] ->
-      (none)
-    goto[bb10->bb2] ->
-      (none)
-    cancel[bb10] ->
+    cancel[bb7] ->
       (none)
 
 fn fs$list_dir -> Vec<string>
   statements:
-    use BindingId(64) path site=SiteId(542) ty=string intent=Read
-    return site=Some(SiteId(540)) ty=Vec<string>
+    use BindingId(52) path site=SiteId(443) ty=string intent=Read
+    return site=Some(SiteId(441)) ty=Vec<string>
   drop_plans:
     call[bb0 hew_fs_list_dir -> bb1] ->
       (none)
@@ -1036,51 +814,47 @@ fn fs$list_dir -> Vec<string>
 
 fn fs$try_list_dir -> Result<Vec<string>, IoError>
   statements:
-    use BindingId(65) dir_path site=SiteId(546) ty=string intent=Read
-    return site=Some(SiteId(548)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(552) ty=()
-    use BindingId(65) dir_path site=SiteId(555) ty=string intent=Read
-    return site=Some(SiteId(557)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(561) ty=()
-    use BindingId(65) dir_path site=SiteId(565) ty=string intent=Read
-    return site=Some(SiteId(562)) ty=Result<Vec<string>, IoError>
+    use BindingId(53) dir_path site=SiteId(447) ty=string intent=Read
+    bind BindingId(54) entries site=SiteId(446) ty=Vec<string>
+    bind BindingId(55) kind site=SiteId(449) ty=i64
+    bind BindingId(56) errno site=SiteId(452) ty=i32
+    eval site=SiteId(454) ty=string
+    use BindingId(56) errno site=SiteId(458) ty=i32 intent=Read
+    use BindingId(54) entries site=SiteId(462) ty=Vec<string> intent=Read
+    agg_alias BindingId(54) entries site=SiteId(462) ty=Vec<string>
+    use BindingId(55) kind site=SiteId(466) ty=i64 intent=Read
+    use BindingId(56) errno site=SiteId(468) ty=i32 intent=Read
+    return site=Some(SiteId(445)) ty=Result<Vec<string>, IoError>
+    drop BindingId(54) entries ty=Vec<string>
   drop_plans:
-    call[bb0 fs$exists -> bb1] ->
+    call[bb0 hew_fs_list_dir -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    branch[bb1: bb2/bb3] ->
+    call[bb1 hew_stream_last_error_kind -> bb2] ->
       (none)
-    return[bb2] ->
+    call[bb2 hew_stream_last_errno -> bb3] ->
       (none)
-    goto[bb3->bb4] ->
+    call[bb3 hew_stream_last_error -> bb4] ->
       (none)
-    call[bb4 fs$is_dir -> bb6] ->
+    branch[bb4: bb5/bb6] ->
       (none)
-    goto[bb5->bb4] ->
+    goto[bb5->bb7] ->
       (none)
-    cancel[bb5] ->
-      (none)
-    branch[bb6: bb7/bb8] ->
+    call[bb6 fs$io_error_from_kind -> bb8] ->
       (none)
     return[bb7] ->
       (none)
-    goto[bb8->bb9] ->
+    goto[bb8->bb7] ->
       (none)
-    call[bb9 hew_fs_list_dir -> bb11] ->
-      (none)
-    goto[bb10->bb9] ->
-      (none)
-    cancel[bb10] ->
-      (none)
-    return[bb11] ->
+    cancel[bb8] ->
       (none)
 
 fn fs$rename -> i64
   statements:
-    use BindingId(66) from site=SiteId(570) ty=string intent=Read
-    use BindingId(67) to site=SiteId(571) ty=string intent=Read
-    return site=Some(SiteId(567)) ty=i64
+    use BindingId(57) from site=SiteId(473) ty=string intent=Read
+    use BindingId(58) to site=SiteId(474) ty=string intent=Read
+    return site=Some(SiteId(470)) ty=i64
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1091,11 +865,9 @@ fn fs$rename -> i64
 
 fn fs$try_rename -> Result<i64, IoError>
   statements:
-    use BindingId(68) from site=SiteId(576) ty=string intent=Read
-    use BindingId(69) to site=SiteId(577) ty=string intent=Read
-    return site=Some(SiteId(573)) ty=Result<i64, IoError>
-    use BindingId(68) from site=SiteId(583) ty=string intent=Read
-    use BindingId(69) to site=SiteId(584) ty=string intent=Read
+    use BindingId(59) from site=SiteId(479) ty=string intent=Read
+    use BindingId(60) to site=SiteId(480) ty=string intent=Read
+    return site=Some(SiteId(476)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1107,7 +879,7 @@ fn fs$try_rename -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$move_copy_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -1122,9 +894,9 @@ fn fs$try_rename -> Result<i64, IoError>
 
 fn fs$copy -> i64
   statements:
-    use BindingId(70) from site=SiteId(589) ty=string intent=Read
-    use BindingId(71) to site=SiteId(590) ty=string intent=Read
-    return site=Some(SiteId(586)) ty=i64
+    use BindingId(61) from site=SiteId(490) ty=string intent=Read
+    use BindingId(62) to site=SiteId(491) ty=string intent=Read
+    return site=Some(SiteId(487)) ty=i64
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1135,11 +907,9 @@ fn fs$copy -> i64
 
 fn fs$try_copy -> Result<i64, IoError>
   statements:
-    use BindingId(72) from site=SiteId(595) ty=string intent=Read
-    use BindingId(73) to site=SiteId(596) ty=string intent=Read
-    return site=Some(SiteId(592)) ty=Result<i64, IoError>
-    use BindingId(72) from site=SiteId(602) ty=string intent=Read
-    use BindingId(73) to site=SiteId(603) ty=string intent=Read
+    use BindingId(63) from site=SiteId(496) ty=string intent=Read
+    use BindingId(64) to site=SiteId(497) ty=string intent=Read
+    return site=Some(SiteId(493)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1151,7 +921,7 @@ fn fs$try_copy -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$move_copy_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -1166,8 +936,8 @@ fn fs$try_copy -> Result<i64, IoError>
 
 fn fs$is_dir -> bool
   statements:
-    use BindingId(74) path site=SiteId(607) ty=string intent=Read
-    return site=Some(SiteId(605)) ty=bool
+    use BindingId(65) path site=SiteId(506) ty=string intent=Read
+    return site=Some(SiteId(504)) ty=bool
   drop_plans:
     call[bb0 hew_fs_is_dir -> bb1] ->
       (none)
@@ -1178,21 +948,21 @@ fn fs$is_dir -> bool
 
 fn stream$pipe -> (Sink<string>, Stream<string>)
   statements:
-    use BindingId(75) capacity site=SiteId(612) ty=i64 intent=Read
-    bind BindingId(76) pair site=SiteId(610) ty=StreamPair
-    use BindingId(76) pair site=SiteId(615) ty=StreamPair intent=Read
-    bind BindingId(77) sink site=SiteId(614) ty=Sink<string>
-    use BindingId(76) pair site=SiteId(618) ty=StreamPair intent=Read
-    bind BindingId(78) input site=SiteId(617) ty=Stream<string>
-    use BindingId(76) pair site=SiteId(621) ty=StreamPair intent=Read
-    eval site=SiteId(620) ty=()
-    use BindingId(77) sink site=SiteId(624) ty=Sink<string> intent=Read
-    use BindingId(78) input site=SiteId(625) ty=Stream<string> intent=Read
-    agg_alias BindingId(77) sink site=SiteId(624) ty=Sink<string>
-    agg_alias BindingId(78) input site=SiteId(625) ty=Stream<string>
-    return site=Some(SiteId(609)) ty=(Sink<string>, Stream<string>)
-    drop BindingId(78) input ty=Stream<string>
-    drop BindingId(77) sink ty=Sink<string>
+    use BindingId(66) capacity site=SiteId(511) ty=i64 intent=Read
+    bind BindingId(67) pair site=SiteId(509) ty=StreamPair
+    use BindingId(67) pair site=SiteId(514) ty=StreamPair intent=Read
+    bind BindingId(68) sink site=SiteId(513) ty=Sink<string>
+    use BindingId(67) pair site=SiteId(517) ty=StreamPair intent=Read
+    bind BindingId(69) input site=SiteId(516) ty=Stream<string>
+    use BindingId(67) pair site=SiteId(520) ty=StreamPair intent=Read
+    eval site=SiteId(519) ty=()
+    use BindingId(68) sink site=SiteId(523) ty=Sink<string> intent=Read
+    use BindingId(69) input site=SiteId(524) ty=Stream<string> intent=Read
+    agg_alias BindingId(68) sink site=SiteId(523) ty=Sink<string>
+    agg_alias BindingId(69) input site=SiteId(524) ty=Stream<string>
+    return site=Some(SiteId(508)) ty=(Sink<string>, Stream<string>)
+    drop BindingId(69) input ty=Stream<string>
+    drop BindingId(68) sink ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_channel -> bb1] ->
       (none)
@@ -1209,21 +979,21 @@ fn stream$pipe -> (Sink<string>, Stream<string>)
 
 fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
   statements:
-    use BindingId(79) capacity site=SiteId(629) ty=i64 intent=Read
-    bind BindingId(80) pair site=SiteId(627) ty=StreamPair
-    use BindingId(80) pair site=SiteId(632) ty=StreamPair intent=Read
-    bind BindingId(81) sink site=SiteId(631) ty=Sink<bytes>
-    use BindingId(80) pair site=SiteId(635) ty=StreamPair intent=Read
-    bind BindingId(82) input site=SiteId(634) ty=Stream<bytes>
-    use BindingId(80) pair site=SiteId(638) ty=StreamPair intent=Read
-    eval site=SiteId(637) ty=()
-    use BindingId(81) sink site=SiteId(641) ty=Sink<bytes> intent=Read
-    use BindingId(82) input site=SiteId(642) ty=Stream<bytes> intent=Read
-    agg_alias BindingId(81) sink site=SiteId(641) ty=Sink<bytes>
-    agg_alias BindingId(82) input site=SiteId(642) ty=Stream<bytes>
-    return site=Some(SiteId(626)) ty=(Sink<bytes>, Stream<bytes>)
-    drop BindingId(82) input ty=Stream<bytes>
-    drop BindingId(81) sink ty=Sink<bytes>
+    use BindingId(70) capacity site=SiteId(528) ty=i64 intent=Read
+    bind BindingId(71) pair site=SiteId(526) ty=StreamPair
+    use BindingId(71) pair site=SiteId(531) ty=StreamPair intent=Read
+    bind BindingId(72) sink site=SiteId(530) ty=Sink<bytes>
+    use BindingId(71) pair site=SiteId(534) ty=StreamPair intent=Read
+    bind BindingId(73) input site=SiteId(533) ty=Stream<bytes>
+    use BindingId(71) pair site=SiteId(537) ty=StreamPair intent=Read
+    eval site=SiteId(536) ty=()
+    use BindingId(72) sink site=SiteId(540) ty=Sink<bytes> intent=Read
+    use BindingId(73) input site=SiteId(541) ty=Stream<bytes> intent=Read
+    agg_alias BindingId(72) sink site=SiteId(540) ty=Sink<bytes>
+    agg_alias BindingId(73) input site=SiteId(541) ty=Stream<bytes>
+    return site=Some(SiteId(525)) ty=(Sink<bytes>, Stream<bytes>)
+    drop BindingId(73) input ty=Stream<bytes>
+    drop BindingId(72) sink ty=Sink<bytes>
   drop_plans:
     call[bb0 hew_stream_channel -> bb1] ->
       (none)
@@ -1240,13 +1010,13 @@ fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
 
 fn stream$from_file -> Result<Stream<string>, string>
   statements:
-    use BindingId(83) path site=SiteId(645) ty=string intent=Read
-    bind BindingId(84) s site=SiteId(644) ty=Stream<string>
-    use BindingId(84) s site=SiteId(649) ty=Stream<string> intent=Read
-    use BindingId(84) s site=SiteId(653) ty=Stream<string> intent=Read
-    agg_alias BindingId(84) s site=SiteId(653) ty=Stream<string>
-    return site=Some(SiteId(643)) ty=Result<Stream<string>, string>
-    drop BindingId(84) s ty=Stream<string>
+    use BindingId(74) path site=SiteId(544) ty=string intent=Read
+    bind BindingId(75) s site=SiteId(543) ty=Stream<string>
+    use BindingId(75) s site=SiteId(548) ty=Stream<string> intent=Read
+    use BindingId(75) s site=SiteId(552) ty=Stream<string> intent=Read
+    agg_alias BindingId(75) s site=SiteId(552) ty=Stream<string>
+    return site=Some(SiteId(542)) ty=Result<Stream<string>, string>
+    drop BindingId(75) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1269,16 +1039,18 @@ fn stream$from_file -> Result<Stream<string>, string>
 
 fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
   statements:
-    use BindingId(85) path site=SiteId(660) ty=string intent=Read
-    bind BindingId(86) s site=SiteId(659) ty=Stream<string>
-    use BindingId(86) s site=SiteId(664) ty=Stream<string> intent=Read
-    use BindingId(86) s site=SiteId(668) ty=Stream<string> intent=Read
-    agg_alias BindingId(86) s site=SiteId(668) ty=Stream<string>
-    return site=Some(SiteId(658)) ty=Result<Stream<string>, fs.IoError>
-    bind BindingId(87) errno site=SiteId(670) ty=i32
-    eval site=SiteId(672) ty=string
-    use BindingId(87) errno site=SiteId(677) ty=i32 intent=Read
-    drop BindingId(86) s ty=Stream<string>
+    use BindingId(76) path site=SiteId(559) ty=string intent=Read
+    bind BindingId(77) s site=SiteId(558) ty=Stream<string>
+    use BindingId(77) s site=SiteId(563) ty=Stream<string> intent=Read
+    use BindingId(77) s site=SiteId(567) ty=Stream<string> intent=Read
+    agg_alias BindingId(77) s site=SiteId(567) ty=Stream<string>
+    return site=Some(SiteId(557)) ty=Result<Stream<string>, fs.IoError>
+    bind BindingId(78) kind site=SiteId(569) ty=i64
+    bind BindingId(79) errno site=SiteId(572) ty=i32
+    eval site=SiteId(574) ty=string
+    use BindingId(78) kind site=SiteId(578) ty=i64 intent=Read
+    use BindingId(79) errno site=SiteId(580) ty=i32 intent=Read
+    drop BindingId(77) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1290,28 +1062,30 @@ fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
       (none)
     goto[bb3->bb5] ->
       (none)
-    call[bb4 hew_stream_last_errno -> bb6] ->
+    call[bb4 hew_stream_last_error_kind -> bb6] ->
       (none)
     return[bb5] ->
       (none)
-    call[bb6 hew_stream_last_error -> bb7] ->
+    call[bb6 hew_stream_last_errno -> bb7] ->
       (none)
-    call[bb7 fs$io_error_from_errno -> bb8] ->
+    call[bb7 hew_stream_last_error -> bb8] ->
       (none)
-    goto[bb8->bb5] ->
+    call[bb8 fs$io_error_from_kind -> bb9] ->
       (none)
-    cancel[bb8] ->
+    goto[bb9->bb5] ->
+      (none)
+    cancel[bb9] ->
       (none)
 
 fn stream$to_file -> Result<Sink<string>, string>
   statements:
-    use BindingId(88) path site=SiteId(681) ty=string intent=Read
-    bind BindingId(89) s site=SiteId(680) ty=Sink<string>
-    use BindingId(89) s site=SiteId(685) ty=Sink<string> intent=Read
-    use BindingId(89) s site=SiteId(689) ty=Sink<string> intent=Read
-    agg_alias BindingId(89) s site=SiteId(689) ty=Sink<string>
-    return site=Some(SiteId(679)) ty=Result<Sink<string>, string>
-    drop BindingId(89) s ty=Sink<string>
+    use BindingId(80) path site=SiteId(584) ty=string intent=Read
+    bind BindingId(81) s site=SiteId(583) ty=Sink<string>
+    use BindingId(81) s site=SiteId(588) ty=Sink<string> intent=Read
+    use BindingId(81) s site=SiteId(592) ty=Sink<string> intent=Read
+    agg_alias BindingId(81) s site=SiteId(592) ty=Sink<string>
+    return site=Some(SiteId(582)) ty=Result<Sink<string>, string>
+    drop BindingId(81) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1334,16 +1108,18 @@ fn stream$to_file -> Result<Sink<string>, string>
 
 fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
   statements:
-    use BindingId(90) path site=SiteId(696) ty=string intent=Read
-    bind BindingId(91) s site=SiteId(695) ty=Sink<string>
-    use BindingId(91) s site=SiteId(700) ty=Sink<string> intent=Read
-    use BindingId(91) s site=SiteId(704) ty=Sink<string> intent=Read
-    agg_alias BindingId(91) s site=SiteId(704) ty=Sink<string>
-    return site=Some(SiteId(694)) ty=Result<Sink<string>, fs.IoError>
-    bind BindingId(92) errno site=SiteId(706) ty=i32
-    eval site=SiteId(708) ty=string
-    use BindingId(92) errno site=SiteId(713) ty=i32 intent=Read
-    drop BindingId(91) s ty=Sink<string>
+    use BindingId(82) path site=SiteId(599) ty=string intent=Read
+    bind BindingId(83) s site=SiteId(598) ty=Sink<string>
+    use BindingId(83) s site=SiteId(603) ty=Sink<string> intent=Read
+    use BindingId(83) s site=SiteId(607) ty=Sink<string> intent=Read
+    agg_alias BindingId(83) s site=SiteId(607) ty=Sink<string>
+    return site=Some(SiteId(597)) ty=Result<Sink<string>, fs.IoError>
+    bind BindingId(84) kind site=SiteId(609) ty=i64
+    bind BindingId(85) errno site=SiteId(612) ty=i32
+    eval site=SiteId(614) ty=string
+    use BindingId(84) kind site=SiteId(618) ty=i64 intent=Read
+    use BindingId(85) errno site=SiteId(620) ty=i32 intent=Read
+    drop BindingId(83) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1355,24 +1131,26 @@ fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
       (none)
     goto[bb3->bb5] ->
       (none)
-    call[bb4 hew_stream_last_errno -> bb6] ->
+    call[bb4 hew_stream_last_error_kind -> bb6] ->
       (none)
     return[bb5] ->
       (none)
-    call[bb6 hew_stream_last_error -> bb7] ->
+    call[bb6 hew_stream_last_errno -> bb7] ->
       (none)
-    call[bb7 fs$io_error_from_errno -> bb8] ->
+    call[bb7 hew_stream_last_error -> bb8] ->
       (none)
-    goto[bb8->bb5] ->
+    call[bb8 fs$io_error_from_kind -> bb9] ->
       (none)
-    cancel[bb8] ->
+    goto[bb9->bb5] ->
+      (none)
+    cancel[bb9] ->
       (none)
 
 fn stream$forward -> ()
   statements:
-    use BindingId(93) source site=SiteId(717) ty=Stream<string> intent=Read
-    use BindingId(94) dest site=SiteId(718) ty=Sink<string> intent=Read
-    eval site=SiteId(715) ty=()
+    use BindingId(86) source site=SiteId(624) ty=Stream<string> intent=Read
+    use BindingId(87) dest site=SiteId(625) ty=Sink<string> intent=Read
+    eval site=SiteId(622) ty=()
   drop_plans:
     call[bb0 hew_stream_pipe -> bb1] ->
       (none)
@@ -1383,8 +1161,8 @@ fn stream$forward -> ()
 
 fn i8::fmt -> string
   statements:
-    use BindingId(103) val site=SiteId(790) ty=i8 intent=Read
-    return site=Some(SiteId(788)) ty=string
+    use BindingId(96) val site=SiteId(697) ty=i8 intent=Read
+    return site=Some(SiteId(695)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1395,8 +1173,8 @@ fn i8::fmt -> string
 
 fn i16::fmt -> string
   statements:
-    use BindingId(104) val site=SiteId(794) ty=i16 intent=Read
-    return site=Some(SiteId(792)) ty=string
+    use BindingId(97) val site=SiteId(701) ty=i16 intent=Read
+    return site=Some(SiteId(699)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1407,8 +1185,8 @@ fn i16::fmt -> string
 
 fn i32::fmt -> string
   statements:
-    use BindingId(105) val site=SiteId(797) ty=i32 intent=Read
-    return site=Some(SiteId(796)) ty=string
+    use BindingId(98) val site=SiteId(704) ty=i32 intent=Read
+    return site=Some(SiteId(703)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1419,8 +1197,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(106) val site=SiteId(800) ty=i64 intent=Read
-    return site=Some(SiteId(799)) ty=string
+    use BindingId(99) val site=SiteId(707) ty=i64 intent=Read
+    return site=Some(SiteId(706)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1431,8 +1209,8 @@ fn i64::fmt -> string
 
 fn u8::fmt -> string
   statements:
-    use BindingId(107) val site=SiteId(803) ty=u8 intent=Read
-    return site=Some(SiteId(802)) ty=string
+    use BindingId(100) val site=SiteId(710) ty=u8 intent=Read
+    return site=Some(SiteId(709)) ty=string
   drop_plans:
     call[bb0 to_string_u8 -> bb1] ->
       (none)
@@ -1443,8 +1221,8 @@ fn u8::fmt -> string
 
 fn u16::fmt -> string
   statements:
-    use BindingId(108) val site=SiteId(806) ty=u16 intent=Read
-    return site=Some(SiteId(805)) ty=string
+    use BindingId(101) val site=SiteId(713) ty=u16 intent=Read
+    return site=Some(SiteId(712)) ty=string
   drop_plans:
     call[bb0 to_string_u16 -> bb1] ->
       (none)
@@ -1455,8 +1233,8 @@ fn u16::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(109) val site=SiteId(809) ty=u32 intent=Read
-    return site=Some(SiteId(808)) ty=string
+    use BindingId(102) val site=SiteId(716) ty=u32 intent=Read
+    return site=Some(SiteId(715)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -1467,8 +1245,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(110) val site=SiteId(812) ty=u64 intent=Read
-    return site=Some(SiteId(811)) ty=string
+    use BindingId(103) val site=SiteId(719) ty=u64 intent=Read
+    return site=Some(SiteId(718)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1479,8 +1257,8 @@ fn u64::fmt -> string
 
 fn isize::fmt -> string
   statements:
-    use BindingId(111) val site=SiteId(816) ty=isize intent=Read
-    return site=Some(SiteId(814)) ty=string
+    use BindingId(104) val site=SiteId(723) ty=isize intent=Read
+    return site=Some(SiteId(721)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1491,8 +1269,8 @@ fn isize::fmt -> string
 
 fn usize::fmt -> string
   statements:
-    use BindingId(112) val site=SiteId(820) ty=usize intent=Read
-    return site=Some(SiteId(818)) ty=string
+    use BindingId(105) val site=SiteId(727) ty=usize intent=Read
+    return site=Some(SiteId(725)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1503,8 +1281,8 @@ fn usize::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(113) val site=SiteId(823) ty=bool intent=Read
-    return site=Some(SiteId(822)) ty=string
+    use BindingId(106) val site=SiteId(730) ty=bool intent=Read
+    return site=Some(SiteId(729)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -1515,8 +1293,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(114) val site=SiteId(826) ty=char intent=Read
-    return site=Some(SiteId(825)) ty=string
+    use BindingId(107) val site=SiteId(733) ty=char intent=Read
+    return site=Some(SiteId(732)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -1527,8 +1305,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(115) val site=SiteId(829) ty=f64 intent=Read
-    return site=Some(SiteId(828)) ty=string
+    use BindingId(108) val site=SiteId(736) ty=f64 intent=Read
+    return site=Some(SiteId(735)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1539,8 +1317,8 @@ fn f64::fmt -> string
 
 fn f32::fmt -> string
   statements:
-    use BindingId(116) val site=SiteId(833) ty=f32 intent=Read
-    return site=Some(SiteId(831)) ty=string
+    use BindingId(109) val site=SiteId(740) ty=f32 intent=Read
+    return site=Some(SiteId(738)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1551,16 +1329,16 @@ fn f32::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(117) val site=SiteId(835) ty=string intent=Read
-    return site=Some(SiteId(835)) ty=string
+    use BindingId(110) val site=SiteId(742) ty=string intent=Read
+    return site=Some(SiteId(742)) ty=string
   drop_plans:
     return[bb0] ->
       (none)
 
 fn duration::from_nanos -> duration
   statements:
-    use BindingId(118) n site=SiteId(837) ty=i64 intent=Read
-    return site=Some(SiteId(836)) ty=duration
+    use BindingId(111) n site=SiteId(744) ty=i64 intent=Read
+    return site=Some(SiteId(743)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1571,8 +1349,8 @@ fn duration::from_nanos -> duration
 
 fn duration::from_micros -> duration
   statements:
-    use BindingId(119) n site=SiteId(840) ty=i64 intent=Read
-    return site=Some(SiteId(839)) ty=duration
+    use BindingId(112) n site=SiteId(747) ty=i64 intent=Read
+    return site=Some(SiteId(746)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1583,8 +1361,8 @@ fn duration::from_micros -> duration
 
 fn duration::from_millis -> duration
   statements:
-    use BindingId(120) n site=SiteId(843) ty=i64 intent=Read
-    return site=Some(SiteId(842)) ty=duration
+    use BindingId(113) n site=SiteId(750) ty=i64 intent=Read
+    return site=Some(SiteId(749)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1595,8 +1373,8 @@ fn duration::from_millis -> duration
 
 fn duration::from_secs -> duration
   statements:
-    use BindingId(121) n site=SiteId(846) ty=i64 intent=Read
-    return site=Some(SiteId(845)) ty=duration
+    use BindingId(114) n site=SiteId(753) ty=i64 intent=Read
+    return site=Some(SiteId(752)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1607,8 +1385,8 @@ fn duration::from_secs -> duration
 
 fn duration::fmt -> string
   statements:
-    use BindingId(122) val site=SiteId(851) ty=duration intent=Read
-    return site=Some(SiteId(848)) ty=string
+    use BindingId(115) val site=SiteId(758) ty=duration intent=Read
+    return site=Some(SiteId(755)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)

--- a/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_blocking_recv.raw.mir
@@ -129,32 +129,35 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     _11: i64
     _12: IoError
     _13: IoError
-    _14: i64
-    _15: bool
-    _16: IoError
+    _14: bool
+    _15: i64
+    _16: bool
     _17: i64
-    _18: IoError
+    _18: bool
     _19: IoError
-    _20: bool
-    _21: i64
-    _22: bool
-    _23: i64
-    _24: bool
-    _25: IoError
+    _20: i64
+    _21: IoError
+    _22: IoError
+    _23: bool
+    _24: i64
+    _25: bool
     _26: i64
-    _27: IoError
+    _27: bool
     _28: IoError
-    _29: bool
-    _30: i64
-    _31: bool
-    _32: i64
-    _33: bool
-    _34: IoError
+    _29: i64
+    _30: IoError
+    _31: IoError
+    _32: bool
+    _33: i64
+    _34: bool
     _35: i64
-    _36: IoError
+    _36: bool
     _37: IoError
     _38: i64
     _39: IoError
+    _40: IoError
+    _41: i64
+    _42: IoError
   bb0:
     stmt: use BindingId(6) errno site=SiteId(39) ty=i64 intent=Read
     _2 = const.i64 2
@@ -186,82 +189,194 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     _7 = move _12
     goto bb6
   bb5:
-    stmt: use BindingId(6) errno site=SiteId(53) ty=i64 intent=Read
-    _14 = const.i64 17
-    _15 = icmp.eq _0 _14
-    branch _15 ? bb7 : bb8
+    stmt: use BindingId(6) errno site=SiteId(54) ty=i64 intent=Read
+    _14 = const.i64 1
+    _15 = const.i64 17
+    _16 = icmp.eq _0 _15
+    branch _16 ? bb8 : bb7
   bb6:
     _1 = move _7
     goto bb3
   bb7:
     stmt: use BindingId(6) errno site=SiteId(57) ty=i64 intent=Read
-    _17 = const.i64 2
-    mtag16 = move _17
-    mvar16.2.0 = move _0
-    _18 = move _16
-    _13 = move _18
-    goto bb9
+    _17 = const.i64 183
+    _18 = icmp.eq _0 _17
+    _14 = move _18
+    goto bb8
   bb8:
-    stmt: use BindingId(6) errno site=SiteId(61) ty=i64 intent=Read
-    _20 = const.i64 1
-    _21 = const.i64 110
-    _22 = icmp.eq _0 _21
-    branch _22 ? bb11 : bb10
+    branch _14 ? bb9 : bb10
   bb9:
+    stmt: use BindingId(6) errno site=SiteId(61) ty=i64 intent=Read
+    _20 = const.i64 2
+    mtag19 = move _20
+    mvar19.2.0 = move _0
+    _21 = move _19
+    _13 = move _21
+    goto bb11
+  bb10:
+    stmt: use BindingId(6) errno site=SiteId(65) ty=i64 intent=Read
+    _23 = const.i64 1
+    _24 = const.i64 110
+    _25 = icmp.eq _0 _24
+    branch _25 ? bb13 : bb12
+  bb11:
     _7 = move _13
     goto bb6
-  bb10:
-    stmt: use BindingId(6) errno site=SiteId(64) ty=i64 intent=Read
-    _23 = const.i64 60
-    _24 = icmp.eq _0 _23
-    _20 = move _24
-    goto bb11
-  bb11:
-    branch _20 ? bb12 : bb13
   bb12:
     stmt: use BindingId(6) errno site=SiteId(68) ty=i64 intent=Read
-    _26 = const.i64 3
-    mtag25 = move _26
-    mvar25.3.0 = move _0
-    _27 = move _25
-    _19 = move _27
-    goto bb14
+    _26 = const.i64 60
+    _27 = icmp.eq _0 _26
+    _23 = move _27
+    goto bb13
   bb13:
-    stmt: use BindingId(6) errno site=SiteId(72) ty=i64 intent=Read
-    _29 = const.i64 1
-    _30 = const.i64 125
-    _31 = icmp.eq _0 _30
-    branch _31 ? bb16 : bb15
+    branch _23 ? bb14 : bb15
   bb14:
-    _13 = move _19
-    goto bb9
-  bb15:
-    stmt: use BindingId(6) errno site=SiteId(75) ty=i64 intent=Read
-    _32 = const.i64 89
-    _33 = icmp.eq _0 _32
-    _29 = move _33
+    stmt: use BindingId(6) errno site=SiteId(72) ty=i64 intent=Read
+    _29 = const.i64 3
+    mtag28 = move _29
+    mvar28.3.0 = move _0
+    _30 = move _28
+    _22 = move _30
     goto bb16
+  bb15:
+    stmt: use BindingId(6) errno site=SiteId(76) ty=i64 intent=Read
+    _32 = const.i64 1
+    _33 = const.i64 125
+    _34 = icmp.eq _0 _33
+    branch _34 ? bb18 : bb17
   bb16:
-    branch _29 ? bb17 : bb18
+    _13 = move _22
+    goto bb11
   bb17:
     stmt: use BindingId(6) errno site=SiteId(79) ty=i64 intent=Read
-    _35 = const.i64 4
-    mtag34 = move _35
-    mvar34.4.0 = move _0
-    _36 = move _34
-    _28 = move _36
-    goto bb19
+    _35 = const.i64 89
+    _36 = icmp.eq _0 _35
+    _32 = move _36
+    goto bb18
   bb18:
-    stmt: use BindingId(6) errno site=SiteId(82) ty=i64 intent=Read
-    _38 = const.i64 5
-    mtag37 = move _38
-    mvar37.5.0 = move _0
-    _39 = move _37
-    _28 = move _39
-    goto bb19
+    branch _32 ? bb19 : bb20
   bb19:
-    _19 = move _28
-    goto bb14
+    stmt: use BindingId(6) errno site=SiteId(83) ty=i64 intent=Read
+    _38 = const.i64 4
+    mtag37 = move _38
+    mvar37.4.0 = move _0
+    _39 = move _37
+    _31 = move _39
+    goto bb21
+  bb20:
+    stmt: use BindingId(6) errno site=SiteId(86) ty=i64 intent=Read
+    _41 = const.i64 5
+    mtag40 = move _41
+    mvar40.5.0 = move _0
+    _42 = move _40
+    _31 = move _42
+    goto bb21
+  bb21:
+    _22 = move _31
+    goto bb16
+
+fn fs$io_error_from_kind(i64, i64) -> IoError [conv=default]
+  locals:
+    _0: i64
+    _1: i64
+    _2: IoError
+    _3: i64
+    _4: bool
+    _5: IoError
+    _6: i64
+    _7: IoError
+    _8: IoError
+    _9: i64
+    _10: bool
+    _11: IoError
+    _12: i64
+    _13: IoError
+    _14: IoError
+    _15: i64
+    _16: bool
+    _17: IoError
+    _18: i64
+    _19: IoError
+    _20: IoError
+    _21: i64
+    _22: bool
+    _23: IoError
+    _24: i64
+    _25: IoError
+    _26: IoError
+    _27: IoError
+  bb0:
+    stmt: use BindingId(7) kind site=SiteId(89) ty=i64 intent=Read
+    _3 = const.i64 1
+    _4 = icmp.eq _0 _3
+    branch _4 ? bb1 : bb2
+  bb1:
+    stmt: use BindingId(8) errno site=SiteId(93) ty=i64 intent=Read
+    _6 = const.i64 0
+    mtag5 = move _6
+    mvar5.0.0 = move _1
+    _7 = move _5
+    _2 = move _7
+    goto bb3
+  bb2:
+    stmt: use BindingId(7) kind site=SiteId(96) ty=i64 intent=Read
+    _9 = const.i64 2
+    _10 = icmp.eq _0 _9
+    branch _10 ? bb4 : bb5
+  bb3:
+    stmt: return site=Some(SiteId(87)) ty=IoError
+    ret = move _2
+    return
+  bb4:
+    stmt: use BindingId(8) errno site=SiteId(100) ty=i64 intent=Read
+    _12 = const.i64 1
+    mtag11 = move _12
+    mvar11.1.0 = move _1
+    _13 = move _11
+    _8 = move _13
+    goto bb6
+  bb5:
+    stmt: use BindingId(7) kind site=SiteId(103) ty=i64 intent=Read
+    _15 = const.i64 3
+    _16 = icmp.eq _0 _15
+    branch _16 ? bb7 : bb8
+  bb6:
+    _2 = move _8
+    goto bb3
+  bb7:
+    stmt: use BindingId(8) errno site=SiteId(107) ty=i64 intent=Read
+    _18 = const.i64 2
+    mtag17 = move _18
+    mvar17.2.0 = move _1
+    _19 = move _17
+    _14 = move _19
+    goto bb9
+  bb8:
+    stmt: use BindingId(7) kind site=SiteId(110) ty=i64 intent=Read
+    _21 = const.i64 4
+    _22 = icmp.eq _0 _21
+    branch _22 ? bb10 : bb11
+  bb9:
+    _8 = move _14
+    goto bb6
+  bb10:
+    stmt: use BindingId(8) errno site=SiteId(114) ty=i64 intent=Read
+    _24 = const.i64 3
+    mtag23 = move _24
+    mvar23.3.0 = move _1
+    _25 = move _23
+    _20 = move _25
+    goto bb12
+  bb11:
+    stmt: use BindingId(8) errno site=SiteId(117) ty=i64 intent=Read
+    _26 = call fs$io_error_from_errno(_1) -> bb13
+  bb12:
+    _14 = move _20
+    goto bb9
+  bb13:
+    _27 = move _26
+    _20 = move _27
+    goto bb12
 
 fn fs$io_error_message(IoError) -> string [conv=default]
   locals:
@@ -317,48 +432,48 @@ fn fs$io_error_message(IoError) -> string [conv=default]
     _49: string
     _50: string
   bb0:
-    stmt: use BindingId(7) e site=SiteId(84) ty=IoError intent=Read
+    stmt: use BindingId(9) e site=SiteId(120) ty=IoError intent=Read
     _2 = move etag0
     _3 = const.i64 0
     _4 = icmp.eq _2 _3
     branch _4 ? bb2 : bb9
   bb1:
-    stmt: return site=Some(SiteId(83)) ty=string
+    stmt: return site=Some(SiteId(119)) ty=string
     ret = move _1
     return
   bb2:
-    stmt: bind BindingId(8) code site=SiteId(85) ty=i64
-    stmt: use BindingId(8) code site=SiteId(87) ty=i64 intent=Read
+    stmt: bind BindingId(10) code site=SiteId(121) ty=i64
+    stmt: use BindingId(10) code site=SiteId(123) ty=i64 intent=Read
     _15 = move mvar0.0.0
     _16 = string_lit "NotFound("
     _17 = call to_string_i64(_15) -> bb14
   bb3:
-    stmt: bind BindingId(9) code site=SiteId(95) ty=i64
-    stmt: use BindingId(9) code site=SiteId(97) ty=i64 intent=Read
+    stmt: bind BindingId(11) code site=SiteId(131) ty=i64
+    stmt: use BindingId(11) code site=SiteId(133) ty=i64 intent=Read
     _21 = move mvar0.1.0
     _22 = string_lit "PermissionDenied("
     _23 = call to_string_i64(_21) -> bb17
   bb4:
-    stmt: bind BindingId(10) code site=SiteId(105) ty=i64
-    stmt: use BindingId(10) code site=SiteId(107) ty=i64 intent=Read
+    stmt: bind BindingId(12) code site=SiteId(141) ty=i64
+    stmt: use BindingId(12) code site=SiteId(143) ty=i64 intent=Read
     _27 = move mvar0.2.0
     _28 = string_lit "AlreadyExists("
     _29 = call to_string_i64(_27) -> bb20
   bb5:
-    stmt: bind BindingId(11) code site=SiteId(115) ty=i64
-    stmt: use BindingId(11) code site=SiteId(117) ty=i64 intent=Read
+    stmt: bind BindingId(13) code site=SiteId(151) ty=i64
+    stmt: use BindingId(13) code site=SiteId(153) ty=i64 intent=Read
     _33 = move mvar0.3.0
     _34 = string_lit "TimedOut("
     _35 = call to_string_i64(_33) -> bb23
   bb6:
-    stmt: bind BindingId(12) code site=SiteId(125) ty=i64
-    stmt: use BindingId(12) code site=SiteId(127) ty=i64 intent=Read
+    stmt: bind BindingId(14) code site=SiteId(161) ty=i64
+    stmt: use BindingId(14) code site=SiteId(163) ty=i64 intent=Read
     _39 = move mvar0.4.0
     _40 = string_lit "Cancelled("
     _41 = call to_string_i64(_39) -> bb26
   bb7:
-    stmt: bind BindingId(13) code site=SiteId(135) ty=i64
-    stmt: use BindingId(13) code site=SiteId(137) ty=i64 intent=Read
+    stmt: bind BindingId(15) code site=SiteId(171) ty=i64
+    stmt: use BindingId(15) code site=SiteId(173) ty=i64 intent=Read
     _45 = move mvar0.5.0
     _46 = string_lit "Other("
     _47 = call to_string_i64(_45) -> bb29
@@ -451,7 +566,7 @@ fn fs$io_error_timed_out() -> IoError [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: return site=Some(SiteId(145)) ty=IoError
+    stmt: return site=Some(SiteId(181)) ty=IoError
     _1 = const.i64 3
     mtag0 = move _1
     _2 = const.i64 0
@@ -465,7 +580,7 @@ fn fs$io_error_cancelled() -> IoError [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: return site=Some(SiteId(147)) ty=IoError
+    stmt: return site=Some(SiteId(183)) ty=IoError
     _1 = const.i64 4
     mtag0 = move _1
     _2 = const.i64 0
@@ -473,553 +588,76 @@ fn fs$io_error_cancelled() -> IoError [conv=default]
     ret = move _0
     return
 
-fn fs$missing_parent(string) -> bool [conv=default]
+fn fs$last_io_error() -> IoError [conv=default]
   locals:
-    _0: string
-    _1: string
-    _2: string
-    _3: bool
-    _4: string
-    _5: bool
-    _6: bool
-    _7: bool
-  bb0:
-    stmt: use BindingId(14) target site=SiteId(150) ty=string intent=Read
-    _1 = call fs$dirname(_0) -> bb1
-  bb1:
-    stmt: bind BindingId(15) parent site=SiteId(149) ty=string
-    stmt: use BindingId(15) parent site=SiteId(154) ty=string intent=Read
-    _2 = move _1
-    _3 = const.i64 0
-    _4 = string_lit ""
-    _5 = icmp.ne _2 _4
-    branch _5 ? bb2 : bb3
-  bb2:
-    stmt: use BindingId(15) parent site=SiteId(158) ty=string intent=Read
-    _6 = call fs$exists(_2) -> bb4
-  bb3:
-    stmt: return site=Some(SiteId(152)) ty=bool
-    ret = move _3
-    return
-  bb4:
-    _7 = not _6
-    _3 = move _7
-    goto bb3
-
-fn fs$dirname(string) -> string [conv=default]
-  locals:
-    _0: string
-    _1: string
-    _2: string
-    _3: i64
+    _0: i32
+    _1: i64
+    _2: i64
+    _3: i32
     _4: i64
-    _5: ()
-    _6: i64
-    _7: bool
-    _8: string
-    _9: ()
-    _10: i64
-    _11: bool
-    _12: string
-    _13: i64
-    _14: string
-  bb0:
-    stmt: use BindingId(16) p site=SiteId(161) ty=string intent=Read
-    _1 = call fs$strip_trailing_slash(_0) -> bb1
-  bb1:
-    stmt: bind BindingId(17) s site=SiteId(160) ty=string
-    stmt: use BindingId(17) s site=SiteId(164) ty=string intent=Read
-    _2 = move _1
-    _3 = call fs$last_slash_pos(_2) -> bb2
-  bb2:
-    stmt: bind BindingId(18) pos site=SiteId(163) ty=i64
-    stmt: use BindingId(18) pos site=SiteId(167) ty=i64 intent=Read
-    _4 = move _3
-    _6 = const.i64 0
-    _7 = icmp.slt _4 _6
-    branch _7 ? bb3 : bb4
-  bb3:
-    stmt: return site=Some(SiteId(169)) ty=string
-    _8 = string_lit ""
-    ret = move _8
-    return
-  bb4:
-    goto bb5
-  bb5:
-    stmt: eval site=SiteId(171) ty=()
-    stmt: use BindingId(18) pos site=SiteId(173) ty=i64 intent=Read
-    _10 = const.i64 0
-    _11 = icmp.eq _4 _10
-    branch _11 ? bb7 : bb8
-  bb6:
-    goto bb5
-  bb7:
-    stmt: return site=Some(SiteId(175)) ty=string
-    _12 = string_lit "/"
-    ret = move _12
-    return
-  bb8:
-    goto bb9
-  bb9:
-    stmt: eval site=SiteId(177) ty=()
-    stmt: use BindingId(17) s site=SiteId(179) ty=string intent=Read
-    stmt: use BindingId(18) pos site=SiteId(181) ty=i64 intent=Read
-    _13 = const.i64 0
-    _14 = call hew_string_slice(_2, _13, _4) -> bb11
-  bb10:
-    goto bb9
-  bb11:
-    stmt: return site=Some(SiteId(178)) ty=string
-    ret = move _14
-    return
-
-fn fs$strip_trailing_slash(string) -> string [conv=default]
-  locals:
-    _0: string
-    _1: ()
-    _2: string
-    _3: bool
-    _4: string
-    _5: string
-    _6: ()
-    _7: bool
-    _8: i64
+    _5: i64
+    _6: string
+    _7: IoError
+    _8: bool
     _9: i64
     _10: bool
-    _11: string
+    _11: i64
     _12: bool
-    _13: i64
-    _14: i64
-    _15: i64
-    _16: i64
-    _17: bool
-    _18: string
-    _19: string
-    _20: string
-  bb0:
-    stmt: use BindingId(19) p site=SiteId(184) ty=string intent=Read
-    _2 = string_lit "/"
-    _3 = icmp.eq _0 _2
-    branch _3 ? bb1 : bb2
-  bb1:
-    stmt: use BindingId(19) p site=SiteId(188) ty=string intent=Read
-    stmt: return site=Some(SiteId(186)) ty=string
-    _4 = string_lit ""
-    _5 = call_rt hew_string_concat(_4, _0)
-    ret = move _5
-    return
-  bb2:
-    goto bb3
-  bb3:
-    stmt: eval site=SiteId(190) ty=()
-    stmt: use BindingId(19) p site=SiteId(194) ty=string intent=Read
-    _7 = const.i64 0
-    _8 = call hew_string_length(_0) -> bb5
-  bb4:
-    goto bb3
-  bb5:
-    _9 = const.i64 1
-    _10 = icmp.sgt _8 _9
-    branch _10 ? bb6 : bb7
-  bb6:
-    stmt: use BindingId(19) p site=SiteId(198) ty=string intent=Read
-    _11 = string_lit "/"
-    _12 = call hew_string_ends_with(_0, _11) -> bb8
-  bb7:
-    branch _7 ? bb9 : bb10
-  bb8:
-    _7 = move _12
-    goto bb7
-  bb9:
-    stmt: use BindingId(19) p site=SiteId(202) ty=string intent=Read
-    stmt: use BindingId(19) p site=SiteId(206) ty=string intent=Read
-    _13 = const.i64 0
-    _14 = call hew_string_length(_0) -> bb12
-  bb10:
-    goto bb11
-  bb11:
-    stmt: eval site=SiteId(211) ty=()
-    stmt: use BindingId(19) p site=SiteId(214) ty=string intent=Read
-    stmt: return site=Some(SiteId(212)) ty=string
-    _19 = string_lit ""
-    _20 = call_rt hew_string_concat(_19, _0)
-    ret = move _20
-    return
-  bb12:
-    _15 = const.i64 1
-    _16 ovf=_17 = sub.checked.s _14 _15
-    branch _17 ? bb13 : bb14
-  bb13:
-    trap(IntegerOverflow)
-  bb14:
-    _18 = call hew_string_slice(_0, _13, _16) -> bb15
-  bb15:
-    stmt: return site=Some(SiteId(201)) ty=string
-    ret = move _18
-    return
-  bb16:
-    goto bb11
-
-fn fs$last_slash_pos(string) -> i64 [conv=default]
-  locals:
-    _0: string
-    _1: i64
-    _2: string
-    _3: Option<i64>
-    _4: i64
-    _5: i64
-    _6: bool
-    _7: i64
-    _8: bool
-    _9: i64
-    _10: i64
-    _11: i64
-    _12: i64
-    _13: i64
-    _14: i64
-    _15: bool
-    _16: i64
-    _17: i64
-    _18: bool
-    _19: i64
-    _20: string
-    _21: string
-    _22: i64
-    _23: string
-    _24: Option<i64>
-    _25: i64
-    _26: i64
-    _27: bool
-    _28: i64
-    _29: bool
-    _30: i64
-    _31: i64
-    _32: i64
-    _33: bool
-    _34: i64
-    _35: i64
-    _36: bool
-  bb0:
-    stmt: use BindingId(20) s site=SiteId(217) ty=string intent=Read
-    _2 = string_lit "/"
-    _3 = call hew_string_find(_0, _2) -> bb1
-  bb1:
-    _4 = move etag3
-    _5 = const.i64 0
-    _6 = icmp.eq _4 _5
-    branch _6 ? bb3 : bb6
-  bb2:
-    stmt: bind BindingId(22) first site=SiteId(215) ty=i64
-    stmt: use BindingId(22) first site=SiteId(223) ty=i64 intent=Consume
-    stmt: bind BindingId(23) last site=SiteId(223) ty=i64
-    stmt: use BindingId(22) first site=SiteId(225) ty=i64 intent=Read
-    _11 = move _1
-    _12 = move _11
-    _13 = const.i64 1
-    _14 ovf=_15 = add.checked.s _11 _13
-    branch _15 ? bb8 : bb9
-  bb3:
-    stmt: bind BindingId(21) i site=SiteId(220) ty=i64
-    stmt: use BindingId(21) i site=SiteId(220) ty=i64 intent=Read
-    _9 = move mvar3.0.0
-    _1 = move _9
-    goto bb2
-  bb4:
-    stmt: return site=Some(SiteId(222)) ty=i64
-    _10 = const.i64 -1
-    ret = move _10
-    return
-  bb5:
-    trap(ExhaustivenessFallthrough)
-  bb6:
-    _7 = const.i64 1
-    _8 = icmp.eq _4 _7
-    branch _8 ? bb4 : bb5
-  bb7:
-    goto bb2
-  bb8:
-    trap(IntegerOverflow)
-  bb9:
-    stmt: bind BindingId(24) search_from site=SiteId(224) ty=i64
-    _16 = move _14
-    goto bb10
-  bb10:
-    stmt: use BindingId(24) search_from site=SiteId(228) ty=i64 intent=Read
-    stmt: use BindingId(20) s site=SiteId(230) ty=string intent=Read
-    _17 = call hew_string_length(_0) -> bb13
-  bb11:
-    stmt: use BindingId(20) s site=SiteId(233) ty=string intent=Read
-    stmt: use BindingId(24) search_from site=SiteId(234) ty=i64 intent=Read
-    stmt: use BindingId(20) s site=SiteId(236) ty=string intent=Read
-    _19 = call hew_string_length(_0) -> bb14
-  bb12:
-    stmt: eval site=SiteId(255) ty=()
-    stmt: use BindingId(23) last site=SiteId(256) ty=i64 intent=Read
-    stmt: return site=Some(SiteId(256)) ty=i64
-    ret = move _12
-    return
-  bb13:
-    _18 = icmp.slt _16 _17
-    branch _18 ? bb11 : bb12
-  bb14:
-    _20 = call hew_string_slice(_0, _16, _19) -> bb15
-  bb15:
-    stmt: bind BindingId(25) rest site=SiteId(232) ty=string
-    stmt: use BindingId(25) rest site=SiteId(241) ty=string intent=Read
-    _21 = move _20
-    _23 = string_lit "/"
-    _24 = call hew_string_find(_21, _23) -> bb16
-  bb16:
-    _25 = move etag24
-    _26 = const.i64 0
-    _27 = icmp.eq _25 _26
-    branch _27 ? bb18 : bb21
-  bb17:
-    stmt: bind BindingId(27) next site=SiteId(239) ty=i64
-    stmt: use BindingId(24) search_from site=SiteId(249) ty=i64 intent=Read
-    stmt: use BindingId(27) next site=SiteId(250) ty=i64 intent=Read
-    _31 = move _22
-    _32 ovf=_33 = add.checked.s _16 _31
-    branch _33 ? bb23 : bb24
-  bb18:
-    stmt: bind BindingId(26) i site=SiteId(244) ty=i64
-    stmt: use BindingId(26) i site=SiteId(244) ty=i64 intent=Read
-    _30 = move mvar24.0.0
-    _22 = move _30
-    goto bb17
-  bb19:
-    stmt: use BindingId(23) last site=SiteId(246) ty=i64 intent=Consume
-    stmt: return site=Some(SiteId(246)) ty=i64
-    ret = move _12
-    return
-  bb20:
-    trap(ExhaustivenessFallthrough)
-  bb21:
-    _28 = const.i64 1
-    _29 = icmp.eq _25 _28
-    branch _29 ? bb19 : bb20
-  bb22:
-    goto bb17
-  bb23:
-    trap(IntegerOverflow)
-  bb24:
-    stmt: bind BindingId(23) last site=SiteId(247) ty=i64
-    stmt: eval site=SiteId(248) ty=()
-    stmt: use BindingId(23) last site=SiteId(253) ty=i64 intent=Read
-    _12 = move _32
-    _34 = const.i64 1
-    _35 ovf=_36 = add.checked.s _12 _34
-    branch _36 ? bb25 : bb26
-  bb25:
-    trap(IntegerOverflow)
-  bb26:
-    stmt: bind BindingId(24) search_from site=SiteId(251) ty=i64
-    stmt: eval site=SiteId(252) ty=()
-    _16 = move _35
-    goto bb10
-
-fn fs$write_error(string) -> IoError [conv=default]
-  locals:
-    _0: string
-    _1: IoError
-    _2: bool
-    _3: IoError
-    _4: i64
-    _5: i64
-    _6: IoError
-    _7: IoError
-    _8: i64
-    _9: i64
-    _10: IoError
-  bb0:
-    stmt: use BindingId(28) target site=SiteId(259) ty=string intent=Read
-    _2 = call fs$missing_parent(_0) -> bb1
-  bb1:
-    branch _2 ? bb2 : bb3
-  bb2:
-    _4 = const.i64 0
-    mtag3 = move _4
-    _5 = const.i64 0
-    mvar3.0.0 = move _5
-    _6 = move _3
-    _1 = move _6
-    goto bb4
-  bb3:
-    _8 = const.i64 5
-    mtag7 = move _8
-    _9 = const.i64 0
-    mvar7.5.0 = move _9
-    _10 = move _7
-    _1 = move _10
-    goto bb4
-  bb4:
-    stmt: return site=Some(SiteId(257)) ty=IoError
-    ret = move _1
-    return
-
-fn fs$missing_path_error(string) -> IoError [conv=default]
-  locals:
-    _0: string
-    _1: IoError
-    _2: bool
-    _3: IoError
-    _4: i64
-    _5: i64
-    _6: IoError
-    _7: IoError
-    _8: i64
-    _9: i64
-    _10: IoError
-  bb0:
-    stmt: use BindingId(29) target site=SiteId(269) ty=string intent=Read
-    _2 = call fs$exists(_0) -> bb1
-  bb1:
-    branch _2 ? bb2 : bb3
-  bb2:
-    _4 = const.i64 5
-    mtag3 = move _4
-    _5 = const.i64 0
-    mvar3.5.0 = move _5
-    _6 = move _3
-    _1 = move _6
-    goto bb4
-  bb3:
-    _8 = const.i64 0
-    mtag7 = move _8
-    _9 = const.i64 0
-    mvar7.0.0 = move _9
-    _10 = move _7
-    _1 = move _10
-    goto bb4
-  bb4:
-    stmt: return site=Some(SiteId(267)) ty=IoError
-    ret = move _1
-    return
-
-fn fs$mkdir_error(string) -> IoError [conv=default]
-  locals:
-    _0: string
-    _1: IoError
-    _2: bool
-    _3: IoError
-    _4: i64
-    _5: i64
-    _6: IoError
-    _7: IoError
-    _8: bool
-    _9: IoError
-    _10: i64
-    _11: i64
-    _12: IoError
     _13: IoError
     _14: i64
     _15: i64
     _16: IoError
+    _17: IoError
+    _18: IoError
+    _19: IoError
   bb0:
-    stmt: use BindingId(30) target site=SiteId(279) ty=string intent=Read
-    _2 = call fs$exists(_0) -> bb1
+    _0 = call hew_stream_last_error_kind() -> bb1
   bb1:
-    branch _2 ? bb2 : bb3
+    stmt: bind BindingId(16) kind site=SiteId(186) ty=i64
+    _1 = cast _0 i32 -> i64
+    _2 = move _1
+    _3 = call hew_stream_last_errno() -> bb2
   bb2:
-    _4 = const.i64 2
-    mtag3 = move _4
-    _5 = const.i64 0
-    mvar3.2.0 = move _5
-    _6 = move _3
-    _1 = move _6
-    goto bb4
+    stmt: bind BindingId(17) errno site=SiteId(189) ty=i64
+    _4 = cast _3 i32 -> i64
+    _5 = move _4
+    _6 = call hew_stream_last_error() -> bb3
   bb3:
-    stmt: use BindingId(30) target site=SiteId(286) ty=string intent=Read
-    _8 = call fs$missing_parent(_0) -> bb5
+    stmt: eval site=SiteId(192) ty=string
+    stmt: use BindingId(17) errno site=SiteId(197) ty=i64 intent=Read
+    _8 = const.i64 0
+    _9 = const.i64 0
+    _10 = icmp.eq _5 _9
+    branch _10 ? bb4 : bb5
   bb4:
-    stmt: return site=Some(SiteId(277)) ty=IoError
-    ret = move _1
-    return
+    stmt: use BindingId(16) kind site=SiteId(200) ty=i64 intent=Read
+    _11 = const.i64 0
+    _12 = icmp.eq _2 _11
+    _8 = move _12
+    goto bb5
   bb5:
     branch _8 ? bb6 : bb7
   bb6:
-    _10 = const.i64 0
-    mtag9 = move _10
-    _11 = const.i64 0
-    mvar9.0.0 = move _11
-    _12 = move _9
-    _7 = move _12
-    goto bb8
-  bb7:
     _14 = const.i64 5
     mtag13 = move _14
-    _15 = const.i64 0
+    _15 = const.i64 5
     mvar13.5.0 = move _15
     _16 = move _13
     _7 = move _16
     goto bb8
-  bb8:
-    _1 = move _7
-    goto bb4
-
-fn fs$move_copy_error(string, string) -> IoError [conv=default]
-  locals:
-    _0: string
-    _1: string
-    _2: IoError
-    _3: bool
-    _4: bool
-    _5: IoError
-    _6: i64
-    _7: i64
-    _8: IoError
-    _9: IoError
-    _10: bool
-    _11: IoError
-    _12: i64
-    _13: i64
-    _14: IoError
-    _15: IoError
-    _16: i64
-    _17: i64
-    _18: IoError
-  bb0:
-    stmt: use BindingId(31) source site=SiteId(297) ty=string intent=Read
-    _3 = call fs$exists(_0) -> bb1
-  bb1:
-    _4 = not _3
-    branch _4 ? bb2 : bb3
-  bb2:
-    _6 = const.i64 0
-    mtag5 = move _6
-    _7 = const.i64 0
-    mvar5.0.0 = move _7
-    _8 = move _5
-    _2 = move _8
-    goto bb4
-  bb3:
-    stmt: use BindingId(32) target site=SiteId(304) ty=string intent=Read
-    _10 = call fs$missing_parent(_1) -> bb5
-  bb4:
-    stmt: return site=Some(SiteId(294)) ty=IoError
-    ret = move _2
-    return
-  bb5:
-    branch _10 ? bb6 : bb7
-  bb6:
-    _12 = const.i64 0
-    mtag11 = move _12
-    _13 = const.i64 0
-    mvar11.0.0 = move _13
-    _14 = move _11
-    _9 = move _14
-    goto bb8
   bb7:
-    _16 = const.i64 5
-    mtag15 = move _16
-    _17 = const.i64 0
-    mvar15.5.0 = move _17
-    _18 = move _15
-    _9 = move _18
-    goto bb8
+    stmt: use BindingId(16) kind site=SiteId(207) ty=i64 intent=Read
+    stmt: use BindingId(17) errno site=SiteId(208) ty=i64 intent=Read
+    _17 = call fs$io_error_from_kind(_2, _5) -> bb9
   bb8:
-    _2 = move _9
-    goto bb4
+    stmt: return site=Some(SiteId(185)) ty=IoError
+    _19 = move _7
+    ret = move _19
+    return
+  bb9:
+    _18 = move _17
+    _7 = move _18
+    goto bb8
 
 fn fs$read(string) -> string [conv=default]
   locals:
@@ -1057,15 +695,15 @@ fn fs$read(string) -> string [conv=default]
     _31: !
     _32: string
   bb0:
-    stmt: use BindingId(33) path site=SiteId(314) ty=string intent=Read
+    stmt: use BindingId(18) path site=SiteId(212) ty=string intent=Read
     _1 = call hew_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(34) contents site=SiteId(313) ty=string
+    stmt: bind BindingId(19) contents site=SiteId(211) ty=string
     _2 = move _1
     _3 = call hew_stream_last_errno() -> bb2
   bb2:
-    stmt: bind BindingId(35) errno site=SiteId(316) ty=i32
-    stmt: use BindingId(35) errno site=SiteId(319) ty=i32 intent=Read
+    stmt: bind BindingId(20) errno site=SiteId(214) ty=i32
+    stmt: use BindingId(20) errno site=SiteId(217) ty=i32 intent=Read
     _4 = move _3
     _6 = const.i64 0
     _7 = icmp.ne _4 _6
@@ -1075,15 +713,15 @@ fn fs$read(string) -> string [conv=default]
   bb4:
     goto bb5
   bb5:
-    stmt: eval site=SiteId(371) ty=()
-    stmt: use BindingId(34) contents site=SiteId(372) ty=string intent=Read
-    stmt: return site=Some(SiteId(312)) ty=string
+    stmt: eval site=SiteId(269) ty=()
+    stmt: use BindingId(19) contents site=SiteId(270) ty=string intent=Read
+    stmt: return site=Some(SiteId(210)) ty=string
     _32 = move _2
     ret = move _32
     return
   bb6:
-    stmt: bind BindingId(36) detail site=SiteId(321) ty=string
-    stmt: use BindingId(36) detail site=SiteId(326) ty=string intent=Read
+    stmt: bind BindingId(21) detail site=SiteId(219) ty=string
+    stmt: use BindingId(21) detail site=SiteId(224) ty=string intent=Read
     _9 = move _8
     _11 = call hew_string_length(_9) -> bb7
   bb7:
@@ -1091,11 +729,11 @@ fn fs$read(string) -> string [conv=default]
     _13 = icmp.eq _11 _12
     branch _13 ? bb8 : bb9
   bb8:
-    stmt: use BindingId(33) path site=SiteId(333) ty=string intent=Read
+    stmt: use BindingId(18) path site=SiteId(231) ty=string intent=Read
     _14 = string_lit "fs.read failed for `"
     _15 = call string::fmt(_0) -> bb11
   bb9:
-    stmt: use BindingId(33) path site=SiteId(356) ty=string intent=Read
+    stmt: use BindingId(18) path site=SiteId(254) ty=string intent=Read
     _24 = string_lit "fs.read failed for `"
     _25 = call string::fmt(_0) -> bb19
   bb10:
@@ -1108,7 +746,7 @@ fn fs$read(string) -> string [conv=default]
     _17 = string_lit "`: "
     _18 = call string_concat(_16, _17) -> bb13
   bb13:
-    stmt: use BindingId(35) errno site=SiteId(340) ty=i32 intent=Read
+    stmt: use BindingId(20) errno site=SiteId(238) ty=i32 intent=Read
     drop _16 ty=string fn=release(hew_string_drop)
     _19 = cast _4 i32 -> i64
     _20 = call fs$io_error_from_errno(_19) -> bb14
@@ -1121,7 +759,7 @@ fn fs$read(string) -> string [conv=default]
   bb17:
     call panic(_23) -> bb18
   bb18:
-    stmt: eval site=SiteId(330) ty=!
+    stmt: eval site=SiteId(228) ty=!
     goto bb10
   bb19:
     _26 = call string_concat(_24, _25) -> bb20
@@ -1129,7 +767,7 @@ fn fs$read(string) -> string [conv=default]
     _27 = string_lit "`: "
     _28 = call string_concat(_26, _27) -> bb21
   bb21:
-    stmt: use BindingId(36) detail site=SiteId(360) ty=string intent=Read
+    stmt: use BindingId(21) detail site=SiteId(258) ty=string intent=Read
     drop _26 ty=string fn=release(hew_string_drop)
     _29 = call string::fmt(_9) -> bb22
   bb22:
@@ -1137,7 +775,7 @@ fn fs$read(string) -> string [conv=default]
   bb23:
     call panic(_30) -> bb24
   bb24:
-    stmt: eval site=SiteId(353) ty=!
+    stmt: eval site=SiteId(251) ty=!
     goto bb10
 
 fn fs$try_read(string) -> Result<string, IoError> [conv=default]
@@ -1147,61 +785,101 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
     _2: FileReadStream
     _3: Result<string, IoError>
     _4: bool
-    _5: Result<string, IoError>
-    _6: i64
-    _7: string
-    _8: Result<string, IoError>
-    _9: i32
+    _5: string
+    _6: string
+    _7: i32
+    _8: i64
+    _9: i64
     _10: i32
-    _11: string
-    _12: Result<string, IoError>
-    _13: i64
-    _14: i64
-    _15: IoError
+    _11: i32
+    _12: string
+    _13: Result<string, IoError>
+    _14: i32
+    _15: bool
     _16: Result<string, IoError>
-    _17: Result<string, IoError>
+    _17: i64
+    _18: Result<string, IoError>
+    _19: Result<string, IoError>
+    _20: i64
+    _21: i64
+    _22: IoError
+    _23: Result<string, IoError>
+    _24: Result<string, IoError>
+    _25: Result<string, IoError>
+    _26: i64
+    _27: IoError
+    _28: Result<string, IoError>
+    _29: Result<string, IoError>
   bb0:
-    stmt: use BindingId(37) file_path site=SiteId(375) ty=string intent=Read
+    stmt: use BindingId(22) file_path site=SiteId(273) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(38) file site=SiteId(374) ty=FileReadStream
-    stmt: use BindingId(38) file site=SiteId(379) ty=FileReadStream intent=Read
+    stmt: bind BindingId(23) file site=SiteId(272) ty=FileReadStream
+    stmt: use BindingId(23) file site=SiteId(277) ty=FileReadStream intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(38) file site=SiteId(384) ty=FileReadStream intent=Read
-    _6 = const.i64 0
-    mtag5 = move _6
-    _7 = call hew_stream_collect_string(_2) -> bb6
+    stmt: use BindingId(23) file site=SiteId(281) ty=FileReadStream intent=Read
+    _5 = call hew_stream_collect_string(_2) -> bb6
   bb4:
-    _9 = call hew_stream_last_errno() -> bb7
+    _26 = const.i64 1
+    mtag25 = move _26
+    _27 = call fs$last_io_error() -> bb14
   bb5:
-    stmt: return site=Some(SiteId(373)) ty=Result<string, IoError>
-    _17 = move _3
-    ret = move _17
+    stmt: return site=Some(SiteId(271)) ty=Result<string, IoError>
+    _29 = move _3
+    ret = move _29
     return
   bb6:
-    mvar5.0.0 = move _7
-    _8 = move _5
-    _3 = move _8
-    goto bb5
+    stmt: bind BindingId(24) contents site=SiteId(280) ty=string
+    _6 = move _5
+    _7 = call hew_stream_last_error_kind() -> bb7
   bb7:
-    stmt: bind BindingId(39) errno site=SiteId(387) ty=i32
-    _10 = move _9
-    _11 = call hew_stream_last_error() -> bb8
+    stmt: bind BindingId(25) kind site=SiteId(283) ty=i64
+    _8 = cast _7 i32 -> i64
+    _9 = move _8
+    _10 = call hew_stream_last_errno() -> bb8
   bb8:
-    stmt: eval site=SiteId(389) ty=string
-    stmt: use BindingId(39) errno site=SiteId(394) ty=i32 intent=Read
-    _13 = const.i64 1
-    mtag12 = move _13
-    _14 = cast _10 i32 -> i64
-    _15 = call fs$io_error_from_errno(_14) -> bb9
+    stmt: bind BindingId(26) errno site=SiteId(286) ty=i32
+    _11 = move _10
+    _12 = call hew_stream_last_error() -> bb9
   bb9:
-    mvar12.1.0 = move _15
-    _16 = move _12
-    _3 = move _16
+    stmt: eval site=SiteId(288) ty=string
+    stmt: use BindingId(26) errno site=SiteId(292) ty=i32 intent=Read
+    _14 = const.i64 0
+    _15 = icmp.eq _11 _14
+    branch _15 ? bb10 : bb11
+  bb10:
+    stmt: use BindingId(24) contents site=SiteId(296) ty=string intent=Read
+    stmt: agg_alias BindingId(24) contents site=SiteId(296) ty=string
+    _17 = const.i64 0
+    mtag16 = move _17
+    mvar16.0.0 = move _6
+    _18 = move _16
+    _13 = move _18
+    goto bb12
+  bb11:
+    stmt: use BindingId(25) kind site=SiteId(300) ty=i64 intent=Read
+    stmt: use BindingId(26) errno site=SiteId(302) ty=i32 intent=Read
+    _20 = const.i64 1
+    mtag19 = move _20
+    _21 = cast _11 i32 -> i64
+    _22 = call fs$io_error_from_kind(_9, _21) -> bb13
+  bb12:
+    _24 = move _13
+    _3 = move _24
+    goto bb5
+  bb13:
+    mvar19.1.0 = move _22
+    _23 = move _19
+    _13 = move _23
+    goto bb12
+  bb14:
+    mvar25.1.0 = move _27
+    _28 = move _25
+    _3 = move _28
     goto bb5
 
 fn fs$write(string, string) -> i64 [conv=default]
@@ -1212,11 +890,11 @@ fn fs$write(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(40) path site=SiteId(399) ty=string intent=Read
-    stmt: use BindingId(41) content site=SiteId(400) ty=string intent=Read
+    stmt: use BindingId(27) path site=SiteId(311) ty=string intent=Read
+    stmt: use BindingId(28) content site=SiteId(312) ty=string intent=Read
     _2 = call hew_file_write(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(396)) ty=i64
+    stmt: return site=Some(SiteId(308)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1238,14 +916,14 @@ fn fs$try_write(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(42) file_path site=SiteId(405) ty=string intent=Read
-    stmt: use BindingId(43) content site=SiteId(406) ty=string intent=Read
+    stmt: use BindingId(29) file_path site=SiteId(317) ty=string intent=Read
+    stmt: use BindingId(30) content site=SiteId(318) ty=string intent=Read
     _3 = call hew_file_write(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(402)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(314)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1253,10 +931,9 @@ fn fs$try_write(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(42) file_path site=SiteId(412) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$write_error(_0) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1279,11 +956,11 @@ fn fs$append(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(44) path site=SiteId(417) ty=string intent=Read
-    stmt: use BindingId(45) content site=SiteId(418) ty=string intent=Read
+    stmt: use BindingId(31) path site=SiteId(328) ty=string intent=Read
+    stmt: use BindingId(32) content site=SiteId(329) ty=string intent=Read
     _2 = call hew_file_append(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(414)) ty=i64
+    stmt: return site=Some(SiteId(325)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1305,14 +982,14 @@ fn fs$try_append(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(46) file_path site=SiteId(423) ty=string intent=Read
-    stmt: use BindingId(47) content site=SiteId(424) ty=string intent=Read
+    stmt: use BindingId(33) file_path site=SiteId(334) ty=string intent=Read
+    stmt: use BindingId(34) content site=SiteId(335) ty=string intent=Read
     _3 = call hew_file_append(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(420)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(331)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1320,10 +997,9 @@ fn fs$try_append(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(46) file_path site=SiteId(430) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$write_error(_0) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1344,10 +1020,10 @@ fn fs$exists(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(48) path site=SiteId(434) ty=string intent=Read
+    stmt: use BindingId(35) path site=SiteId(344) ty=string intent=Read
     _1 = call hew_file_exists(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(432)) ty=bool
+    stmt: return site=Some(SiteId(342)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -1359,10 +1035,10 @@ fn fs$delete(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(49) path site=SiteId(439) ty=string intent=Read
+    stmt: use BindingId(36) path site=SiteId(349) ty=string intent=Read
     _1 = call hew_file_delete(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(436)) ty=i64
+    stmt: return site=Some(SiteId(346)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1383,13 +1059,13 @@ fn fs$try_delete(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(50) file_path site=SiteId(444) ty=string intent=Read
+    stmt: use BindingId(37) file_path site=SiteId(354) ty=string intent=Read
     _2 = call hew_file_delete(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(441)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(351)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1397,10 +1073,9 @@ fn fs$try_delete(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(50) file_path site=SiteId(450) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
-    _11 = call fs$missing_path_error(_0) -> bb7
+    _11 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1421,10 +1096,10 @@ fn fs$size(string) -> i64 [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: use BindingId(51) path site=SiteId(454) ty=string intent=Read
+    stmt: use BindingId(38) path site=SiteId(363) ty=string intent=Read
     _1 = call hew_file_size(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(452)) ty=i64
+    stmt: return site=Some(SiteId(361)) ty=i64
     _2 = move _1
     ret = move _2
     return
@@ -1435,10 +1110,10 @@ fn fs$read_bytes(string) -> bytes [conv=default]
     _1: bytes
     _2: bytes
   bb0:
-    stmt: use BindingId(52) path site=SiteId(458) ty=string intent=Read
+    stmt: use BindingId(39) path site=SiteId(367) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(456)) ty=bytes
+    stmt: return site=Some(SiteId(365)) ty=bytes
     _2 = move _1
     ret = move _2
     return
@@ -1449,61 +1124,70 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _1: bytes
     _2: bytes
     _3: i32
-    _4: i32
-    _5: Result<bytes, IoError>
+    _4: i64
+    _5: i64
     _6: i32
-    _7: bool
-    _8: string
-    _9: Result<bytes, IoError>
-    _10: i64
-    _11: i64
-    _12: IoError
-    _13: Result<bytes, IoError>
-    _14: Result<bytes, IoError>
-    _15: i64
+    _7: i32
+    _8: Result<bytes, IoError>
+    _9: i32
+    _10: bool
+    _11: string
+    _12: Result<bytes, IoError>
+    _13: i64
+    _14: i64
+    _15: IoError
     _16: Result<bytes, IoError>
     _17: Result<bytes, IoError>
+    _18: i64
+    _19: Result<bytes, IoError>
+    _20: Result<bytes, IoError>
   bb0:
-    stmt: use BindingId(53) file_path site=SiteId(462) ty=string intent=Read
+    stmt: use BindingId(40) file_path site=SiteId(371) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
   bb1:
-    stmt: bind BindingId(54) data site=SiteId(461) ty=bytes
+    stmt: bind BindingId(41) data site=SiteId(370) ty=bytes
     _2 = move _1
-    _3 = call hew_stream_last_errno() -> bb2
+    _3 = call hew_stream_last_error_kind() -> bb2
   bb2:
-    stmt: bind BindingId(55) errno site=SiteId(464) ty=i32
-    stmt: use BindingId(55) errno site=SiteId(468) ty=i32 intent=Read
-    _4 = move _3
-    _6 = const.i64 0
-    _7 = icmp.ne _4 _6
-    branch _7 ? bb3 : bb4
+    stmt: bind BindingId(42) kind site=SiteId(373) ty=i64
+    _4 = cast _3 i32 -> i64
+    _5 = move _4
+    _6 = call hew_stream_last_errno() -> bb3
   bb3:
-    _8 = call hew_stream_last_error() -> bb6
+    stmt: bind BindingId(43) errno site=SiteId(376) ty=i32
+    stmt: use BindingId(43) errno site=SiteId(380) ty=i32 intent=Read
+    _7 = move _6
+    _9 = const.i64 0
+    _10 = icmp.ne _7 _9
+    branch _10 ? bb4 : bb5
   bb4:
-    stmt: use BindingId(54) data site=SiteId(480) ty=bytes intent=Read
-    _15 = const.i64 0
-    mtag14 = move _15
-    mvar14.0.0 = move _2
-    _16 = move _14
-    _5 = move _16
-    goto bb5
+    _11 = call hew_stream_last_error() -> bb7
   bb5:
-    stmt: return site=Some(SiteId(460)) ty=Result<bytes, IoError>
-    _17 = move _5
-    ret = move _17
-    return
+    stmt: use BindingId(41) data site=SiteId(393) ty=bytes intent=Read
+    _18 = const.i64 0
+    mtag17 = move _18
+    mvar17.0.0 = move _2
+    _19 = move _17
+    _8 = move _19
+    goto bb6
   bb6:
-    stmt: eval site=SiteId(471) ty=string
-    stmt: use BindingId(55) errno site=SiteId(476) ty=i32 intent=Read
-    _10 = const.i64 1
-    mtag9 = move _10
-    _11 = cast _4 i32 -> i64
-    _12 = call fs$io_error_from_errno(_11) -> bb7
+    stmt: return site=Some(SiteId(369)) ty=Result<bytes, IoError>
+    _20 = move _8
+    ret = move _20
+    return
   bb7:
-    mvar9.1.0 = move _12
-    _13 = move _9
-    _5 = move _13
-    goto bb5
+    stmt: eval site=SiteId(383) ty=string
+    stmt: use BindingId(42) kind site=SiteId(387) ty=i64 intent=Read
+    stmt: use BindingId(43) errno site=SiteId(389) ty=i32 intent=Read
+    _13 = const.i64 1
+    mtag12 = move _13
+    _14 = cast _7 i32 -> i64
+    _15 = call fs$io_error_from_kind(_5, _14) -> bb8
+  bb8:
+    mvar12.1.0 = move _15
+    _16 = move _12
+    _8 = move _16
+    goto bb6
 
 fn fs$write_bytes(string, bytes) -> i64 [conv=default]
   locals:
@@ -1513,11 +1197,11 @@ fn fs$write_bytes(string, bytes) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(56) path site=SiteId(484) ty=string intent=Read
-    stmt: use BindingId(57) data site=SiteId(485) ty=bytes intent=Read
+    stmt: use BindingId(44) path site=SiteId(397) ty=string intent=Read
+    stmt: use BindingId(45) data site=SiteId(398) ty=bytes intent=Read
     _2 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(481)) ty=i64
+    stmt: return site=Some(SiteId(394)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1539,14 +1223,14 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(58) file_path site=SiteId(490) ty=string intent=Read
-    stmt: use BindingId(59) data site=SiteId(491) ty=bytes intent=Read
+    stmt: use BindingId(46) file_path site=SiteId(403) ty=string intent=Read
+    stmt: use BindingId(47) data site=SiteId(404) ty=bytes intent=Read
     _3 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(487)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(400)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1554,10 +1238,9 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(58) file_path site=SiteId(497) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$write_error(_0) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1579,10 +1262,10 @@ fn fs$mkdir(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(60) path site=SiteId(502) ty=string intent=Read
+    stmt: use BindingId(48) path site=SiteId(414) ty=string intent=Read
     _1 = call hew_fs_mkdir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(499)) ty=i64
+    stmt: return site=Some(SiteId(411)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1603,13 +1286,13 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(61) dir_path site=SiteId(507) ty=string intent=Read
+    stmt: use BindingId(49) dir_path site=SiteId(419) ty=string intent=Read
     _2 = call hew_fs_mkdir(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(504)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(416)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1617,10 +1300,9 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(61) dir_path site=SiteId(513) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
-    _11 = call fs$mkdir_error(_0) -> bb7
+    _11 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1642,10 +1324,10 @@ fn fs$mkdir_all(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(62) path site=SiteId(518) ty=string intent=Read
+    stmt: use BindingId(50) path site=SiteId(429) ty=string intent=Read
     _1 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(515)) ty=i64
+    stmt: return site=Some(SiteId(426)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1663,28 +1345,16 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _7: i64
     _8: i64
     _9: Result<i64, IoError>
-    _10: bool
-    _11: Result<i64, IoError>
-    _12: i64
-    _13: IoError
-    _14: i64
-    _15: i64
-    _16: Result<i64, IoError>
-    _17: Result<i64, IoError>
-    _18: i64
-    _19: IoError
-    _20: i64
-    _21: i64
-    _22: Result<i64, IoError>
-    _23: Result<i64, IoError>
+    _10: i64
+    _11: IoError
   bb0:
-    stmt: use BindingId(63) dir_path site=SiteId(523) ty=string intent=Read
+    stmt: use BindingId(51) dir_path site=SiteId(434) ty=string intent=Read
     _2 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(520)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(431)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1692,8 +1362,9 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(63) dir_path site=SiteId(530) ty=string intent=Read
-    _10 = call fs$exists(_0) -> bb7
+    _10 = const.i64 1
+    mtag9 = move _10
+    _11 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1704,32 +1375,8 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _1 = move _6
     goto bb2
   bb7:
-    branch _10 ? bb8 : bb9
-  bb8:
-    _12 = const.i64 1
-    mtag11 = move _12
-    _14 = const.i64 2
-    mtag13 = move _14
-    _15 = const.i64 0
-    mvar13.2.0 = move _15
-    mvar11.1.0 = move _13
-    _16 = move _11
-    _9 = move _16
-    goto bb10
-  bb9:
-    _18 = const.i64 1
-    mtag17 = move _18
-    _20 = const.i64 5
-    mtag19 = move _20
-    _21 = const.i64 0
-    mvar19.5.0 = move _21
-    mvar17.1.0 = move _19
-    _22 = move _17
-    _9 = move _22
-    goto bb10
-  bb10:
-    _23 = move _9
-    _1 = move _23
+    mvar9.1.0 = move _11
+    _1 = move _9
     goto bb2
 
 fn fs$list_dir(string) -> Vec<string> [conv=default]
@@ -1738,10 +1385,10 @@ fn fs$list_dir(string) -> Vec<string> [conv=default]
     _1: Vec<string>
     _2: Vec<string>
   bb0:
-    stmt: use BindingId(64) path site=SiteId(542) ty=string intent=Read
+    stmt: use BindingId(52) path site=SiteId(443) ty=string intent=Read
     _1 = call hew_fs_list_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(540)) ty=Vec<string>
+    stmt: return site=Some(SiteId(441)) ty=Vec<string>
     _2 = move _1
     ret = move _2
     return
@@ -1749,81 +1396,74 @@ fn fs$list_dir(string) -> Vec<string> [conv=default]
 fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   locals:
     _0: string
-    _1: ()
-    _2: bool
-    _3: bool
-    _4: Result<Vec<string>, IoError>
+    _1: Vec<string>
+    _2: Vec<string>
+    _3: i32
+    _4: i64
     _5: i64
-    _6: IoError
-    _7: i64
-    _8: i64
-    _9: ()
-    _10: bool
+    _6: i32
+    _7: i32
+    _8: string
+    _9: Result<Vec<string>, IoError>
+    _10: i32
     _11: bool
     _12: Result<Vec<string>, IoError>
     _13: i64
-    _14: IoError
-    _15: i64
+    _14: Result<Vec<string>, IoError>
+    _15: Result<Vec<string>, IoError>
     _16: i64
-    _17: Result<Vec<string>, IoError>
-    _18: i64
-    _19: Vec<string>
-    _20: Vec<string>
+    _17: i64
+    _18: IoError
+    _19: Result<Vec<string>, IoError>
+    _20: Result<Vec<string>, IoError>
   bb0:
-    stmt: use BindingId(65) dir_path site=SiteId(546) ty=string intent=Read
-    _2 = call fs$exists(_0) -> bb1
+    stmt: use BindingId(53) dir_path site=SiteId(447) ty=string intent=Read
+    _1 = call hew_fs_list_dir(_0) -> bb1
   bb1:
-    _3 = not _2
-    branch _3 ? bb2 : bb3
+    stmt: bind BindingId(54) entries site=SiteId(446) ty=Vec<string>
+    _2 = move _1
+    _3 = call hew_stream_last_error_kind() -> bb2
   bb2:
-    stmt: return site=Some(SiteId(548)) ty=Result<Vec<string>, IoError>
-    _5 = const.i64 1
-    mtag4 = move _5
-    _7 = const.i64 0
-    mtag6 = move _7
-    _8 = const.i64 0
-    mvar6.0.0 = move _8
-    mvar4.1.0 = move _6
-    ret = move _4
-    return
+    stmt: bind BindingId(55) kind site=SiteId(449) ty=i64
+    _4 = cast _3 i32 -> i64
+    _5 = move _4
+    _6 = call hew_stream_last_errno() -> bb3
   bb3:
-    goto bb4
+    stmt: bind BindingId(56) errno site=SiteId(452) ty=i32
+    _7 = move _6
+    _8 = call hew_stream_last_error() -> bb4
   bb4:
-    stmt: eval site=SiteId(552) ty=()
-    stmt: use BindingId(65) dir_path site=SiteId(555) ty=string intent=Read
-    _10 = call fs$is_dir(_0) -> bb6
+    stmt: eval site=SiteId(454) ty=string
+    stmt: use BindingId(56) errno site=SiteId(458) ty=i32 intent=Read
+    _10 = const.i64 0
+    _11 = icmp.eq _7 _10
+    branch _11 ? bb5 : bb6
   bb5:
-    goto bb4
-  bb6:
-    _11 = not _10
-    branch _11 ? bb7 : bb8
-  bb7:
-    stmt: return site=Some(SiteId(557)) ty=Result<Vec<string>, IoError>
-    _13 = const.i64 1
+    stmt: use BindingId(54) entries site=SiteId(462) ty=Vec<string> intent=Read
+    stmt: agg_alias BindingId(54) entries site=SiteId(462) ty=Vec<string>
+    _13 = const.i64 0
     mtag12 = move _13
-    _15 = const.i64 5
-    mtag14 = move _15
-    _16 = const.i64 0
-    mvar14.5.0 = move _16
-    mvar12.1.0 = move _14
-    ret = move _12
+    mvar12.0.0 = move _2
+    _14 = move _12
+    _9 = move _14
+    goto bb7
+  bb6:
+    stmt: use BindingId(55) kind site=SiteId(466) ty=i64 intent=Read
+    stmt: use BindingId(56) errno site=SiteId(468) ty=i32 intent=Read
+    _16 = const.i64 1
+    mtag15 = move _16
+    _17 = cast _7 i32 -> i64
+    _18 = call fs$io_error_from_kind(_5, _17) -> bb8
+  bb7:
+    stmt: return site=Some(SiteId(445)) ty=Result<Vec<string>, IoError>
+    _20 = move _9
+    ret = move _20
     return
   bb8:
-    goto bb9
-  bb9:
-    stmt: eval site=SiteId(561) ty=()
-    stmt: use BindingId(65) dir_path site=SiteId(565) ty=string intent=Read
-    _18 = const.i64 0
-    mtag17 = move _18
-    _19 = call hew_fs_list_dir(_0) -> bb11
-  bb10:
-    goto bb9
-  bb11:
-    stmt: return site=Some(SiteId(562)) ty=Result<Vec<string>, IoError>
-    _20 = move _19
-    mvar17.0.0 = move _20
-    ret = move _17
-    return
+    mvar15.1.0 = move _18
+    _19 = move _15
+    _9 = move _19
+    goto bb7
 
 fn fs$rename(string, string) -> i64 [conv=default]
   locals:
@@ -1833,11 +1473,11 @@ fn fs$rename(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(66) from site=SiteId(570) ty=string intent=Read
-    stmt: use BindingId(67) to site=SiteId(571) ty=string intent=Read
+    stmt: use BindingId(57) from site=SiteId(473) ty=string intent=Read
+    stmt: use BindingId(58) to site=SiteId(474) ty=string intent=Read
     _2 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(567)) ty=i64
+    stmt: return site=Some(SiteId(470)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1859,14 +1499,14 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(68) from site=SiteId(576) ty=string intent=Read
-    stmt: use BindingId(69) to site=SiteId(577) ty=string intent=Read
+    stmt: use BindingId(59) from site=SiteId(479) ty=string intent=Read
+    stmt: use BindingId(60) to site=SiteId(480) ty=string intent=Read
     _3 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(573)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(476)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1874,11 +1514,9 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(68) from site=SiteId(583) ty=string intent=Read
-    stmt: use BindingId(69) to site=SiteId(584) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$move_copy_error(_0, _1) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1901,11 +1539,11 @@ fn fs$copy(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(70) from site=SiteId(589) ty=string intent=Read
-    stmt: use BindingId(71) to site=SiteId(590) ty=string intent=Read
+    stmt: use BindingId(61) from site=SiteId(490) ty=string intent=Read
+    stmt: use BindingId(62) to site=SiteId(491) ty=string intent=Read
     _2 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(586)) ty=i64
+    stmt: return site=Some(SiteId(487)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1927,14 +1565,14 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(72) from site=SiteId(595) ty=string intent=Read
-    stmt: use BindingId(73) to site=SiteId(596) ty=string intent=Read
+    stmt: use BindingId(63) from site=SiteId(496) ty=string intent=Read
+    stmt: use BindingId(64) to site=SiteId(497) ty=string intent=Read
     _3 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(592)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(493)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1942,11 +1580,9 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(72) from site=SiteId(602) ty=string intent=Read
-    stmt: use BindingId(73) to site=SiteId(603) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$move_copy_error(_0, _1) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1967,10 +1603,10 @@ fn fs$is_dir(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(74) path site=SiteId(607) ty=string intent=Read
+    stmt: use BindingId(65) path site=SiteId(506) ty=string intent=Read
     _1 = call hew_fs_is_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(605)) ty=bool
+    stmt: return site=Some(SiteId(504)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -1988,31 +1624,31 @@ fn stream$pipe(i64) -> (Sink<string>, Stream<string>) [conv=default]
     _8: (Sink<string>, Stream<string>)
     _9: (Sink<string>, Stream<string>)
   bb0:
-    stmt: use BindingId(75) capacity site=SiteId(612) ty=i64 intent=Read
+    stmt: use BindingId(66) capacity site=SiteId(511) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(76) pair site=SiteId(610) ty=StreamPair
-    stmt: use BindingId(76) pair site=SiteId(615) ty=StreamPair intent=Read
+    stmt: bind BindingId(67) pair site=SiteId(509) ty=StreamPair
+    stmt: use BindingId(67) pair site=SiteId(514) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink(_3) -> bb2
   bb2:
-    stmt: bind BindingId(77) sink site=SiteId(614) ty=Sink<string>
-    stmt: use BindingId(76) pair site=SiteId(618) ty=StreamPair intent=Read
+    stmt: bind BindingId(68) sink site=SiteId(513) ty=Sink<string>
+    stmt: use BindingId(67) pair site=SiteId(517) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream(_3) -> bb3
   bb3:
-    stmt: bind BindingId(78) input site=SiteId(617) ty=Stream<string>
-    stmt: use BindingId(76) pair site=SiteId(621) ty=StreamPair intent=Read
+    stmt: bind BindingId(69) input site=SiteId(516) ty=Stream<string>
+    stmt: use BindingId(67) pair site=SiteId(520) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(620) ty=()
-    stmt: use BindingId(77) sink site=SiteId(624) ty=Sink<string> intent=Read
-    stmt: use BindingId(78) input site=SiteId(625) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(77) sink site=SiteId(624) ty=Sink<string>
-    stmt: agg_alias BindingId(78) input site=SiteId(625) ty=Stream<string>
-    stmt: return site=Some(SiteId(609)) ty=(Sink<string>, Stream<string>)
+    stmt: eval site=SiteId(519) ty=()
+    stmt: use BindingId(68) sink site=SiteId(523) ty=Sink<string> intent=Read
+    stmt: use BindingId(69) input site=SiteId(524) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(68) sink site=SiteId(523) ty=Sink<string>
+    stmt: agg_alias BindingId(69) input site=SiteId(524) ty=Stream<string>
+    stmt: return site=Some(SiteId(508)) ty=(Sink<string>, Stream<string>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2031,31 +1667,31 @@ fn stream$bytes_pipe(i64) -> (Sink<bytes>, Stream<bytes>) [conv=default]
     _8: (Sink<bytes>, Stream<bytes>)
     _9: (Sink<bytes>, Stream<bytes>)
   bb0:
-    stmt: use BindingId(79) capacity site=SiteId(629) ty=i64 intent=Read
+    stmt: use BindingId(70) capacity site=SiteId(528) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(80) pair site=SiteId(627) ty=StreamPair
-    stmt: use BindingId(80) pair site=SiteId(632) ty=StreamPair intent=Read
+    stmt: bind BindingId(71) pair site=SiteId(526) ty=StreamPair
+    stmt: use BindingId(71) pair site=SiteId(531) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink_bytes(_3) -> bb2
   bb2:
-    stmt: bind BindingId(81) sink site=SiteId(631) ty=Sink<bytes>
-    stmt: use BindingId(80) pair site=SiteId(635) ty=StreamPair intent=Read
+    stmt: bind BindingId(72) sink site=SiteId(530) ty=Sink<bytes>
+    stmt: use BindingId(71) pair site=SiteId(534) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream_bytes(_3) -> bb3
   bb3:
-    stmt: bind BindingId(82) input site=SiteId(634) ty=Stream<bytes>
-    stmt: use BindingId(80) pair site=SiteId(638) ty=StreamPair intent=Read
+    stmt: bind BindingId(73) input site=SiteId(533) ty=Stream<bytes>
+    stmt: use BindingId(71) pair site=SiteId(537) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(637) ty=()
-    stmt: use BindingId(81) sink site=SiteId(641) ty=Sink<bytes> intent=Read
-    stmt: use BindingId(82) input site=SiteId(642) ty=Stream<bytes> intent=Read
-    stmt: agg_alias BindingId(81) sink site=SiteId(641) ty=Sink<bytes>
-    stmt: agg_alias BindingId(82) input site=SiteId(642) ty=Stream<bytes>
-    stmt: return site=Some(SiteId(626)) ty=(Sink<bytes>, Stream<bytes>)
+    stmt: eval site=SiteId(536) ty=()
+    stmt: use BindingId(72) sink site=SiteId(540) ty=Sink<bytes> intent=Read
+    stmt: use BindingId(73) input site=SiteId(541) ty=Stream<bytes> intent=Read
+    stmt: agg_alias BindingId(72) sink site=SiteId(540) ty=Sink<bytes>
+    stmt: agg_alias BindingId(73) input site=SiteId(541) ty=Stream<bytes>
+    stmt: return site=Some(SiteId(525)) ty=(Sink<bytes>, Stream<bytes>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2077,18 +1713,18 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     _11: Result<Stream<string>, string>
     _12: Result<Stream<string>, string>
   bb0:
-    stmt: use BindingId(83) path site=SiteId(645) ty=string intent=Read
+    stmt: use BindingId(74) path site=SiteId(544) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(84) s site=SiteId(644) ty=Stream<string>
-    stmt: use BindingId(84) s site=SiteId(649) ty=Stream<string> intent=Read
+    stmt: bind BindingId(75) s site=SiteId(543) ty=Stream<string>
+    stmt: use BindingId(75) s site=SiteId(548) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(84) s site=SiteId(653) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(84) s site=SiteId(653) ty=Stream<string>
+    stmt: use BindingId(75) s site=SiteId(552) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(75) s site=SiteId(552) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2100,7 +1736,7 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(643)) ty=Result<Stream<string>, string>
+    stmt: return site=Some(SiteId(542)) ty=Result<Stream<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2121,27 +1757,30 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _6: i64
     _7: Result<Stream<string>, fs.IoError>
     _8: i32
-    _9: i32
-    _10: string
-    _11: Result<Stream<string>, fs.IoError>
-    _12: i64
-    _13: i64
-    _14: fs.IoError
-    _15: Result<Stream<string>, fs.IoError>
-    _16: Result<Stream<string>, fs.IoError>
+    _9: i64
+    _10: i64
+    _11: i32
+    _12: i32
+    _13: string
+    _14: Result<Stream<string>, fs.IoError>
+    _15: i64
+    _16: i64
+    _17: fs.IoError
+    _18: Result<Stream<string>, fs.IoError>
+    _19: Result<Stream<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(85) path site=SiteId(660) ty=string intent=Read
+    stmt: use BindingId(76) path site=SiteId(559) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(86) s site=SiteId(659) ty=Stream<string>
-    stmt: use BindingId(86) s site=SiteId(664) ty=Stream<string> intent=Read
+    stmt: bind BindingId(77) s site=SiteId(558) ty=Stream<string>
+    stmt: use BindingId(77) s site=SiteId(563) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(86) s site=SiteId(668) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(86) s site=SiteId(668) ty=Stream<string>
+    stmt: use BindingId(77) s site=SiteId(567) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(77) s site=SiteId(567) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2149,27 +1788,33 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _3 = move _7
     goto bb5
   bb4:
-    _8 = call hew_stream_last_errno() -> bb6
+    _8 = call hew_stream_last_error_kind() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(658)) ty=Result<Stream<string>, fs.IoError>
-    _16 = move _3
-    ret = move _16
+    stmt: return site=Some(SiteId(557)) ty=Result<Stream<string>, fs.IoError>
+    _19 = move _3
+    ret = move _19
     return
   bb6:
-    stmt: bind BindingId(87) errno site=SiteId(670) ty=i32
-    _9 = move _8
-    _10 = call hew_stream_last_error() -> bb7
+    stmt: bind BindingId(78) kind site=SiteId(569) ty=i64
+    _9 = cast _8 i32 -> i64
+    _10 = move _9
+    _11 = call hew_stream_last_errno() -> bb7
   bb7:
-    stmt: eval site=SiteId(672) ty=string
-    stmt: use BindingId(87) errno site=SiteId(677) ty=i32 intent=Read
-    _12 = const.i64 1
-    mtag11 = move _12
-    _13 = cast _9 i32 -> i64
-    _14 = call fs$io_error_from_errno(_13) -> bb8
+    stmt: bind BindingId(79) errno site=SiteId(572) ty=i32
+    _12 = move _11
+    _13 = call hew_stream_last_error() -> bb8
   bb8:
-    mvar11.1.0 = move _14
-    _15 = move _11
-    _3 = move _15
+    stmt: eval site=SiteId(574) ty=string
+    stmt: use BindingId(78) kind site=SiteId(578) ty=i64 intent=Read
+    stmt: use BindingId(79) errno site=SiteId(580) ty=i32 intent=Read
+    _15 = const.i64 1
+    mtag14 = move _15
+    _16 = cast _12 i32 -> i64
+    _17 = call fs$io_error_from_kind(_10, _16) -> bb9
+  bb9:
+    mvar14.1.0 = move _17
+    _18 = move _14
+    _3 = move _18
     goto bb5
 
 fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
@@ -2188,18 +1833,18 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     _11: Result<Sink<string>, string>
     _12: Result<Sink<string>, string>
   bb0:
-    stmt: use BindingId(88) path site=SiteId(681) ty=string intent=Read
+    stmt: use BindingId(80) path site=SiteId(584) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(89) s site=SiteId(680) ty=Sink<string>
-    stmt: use BindingId(89) s site=SiteId(685) ty=Sink<string> intent=Read
+    stmt: bind BindingId(81) s site=SiteId(583) ty=Sink<string>
+    stmt: use BindingId(81) s site=SiteId(588) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(89) s site=SiteId(689) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(89) s site=SiteId(689) ty=Sink<string>
+    stmt: use BindingId(81) s site=SiteId(592) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(81) s site=SiteId(592) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2211,7 +1856,7 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(679)) ty=Result<Sink<string>, string>
+    stmt: return site=Some(SiteId(582)) ty=Result<Sink<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2232,27 +1877,30 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _6: i64
     _7: Result<Sink<string>, fs.IoError>
     _8: i32
-    _9: i32
-    _10: string
-    _11: Result<Sink<string>, fs.IoError>
-    _12: i64
-    _13: i64
-    _14: fs.IoError
-    _15: Result<Sink<string>, fs.IoError>
-    _16: Result<Sink<string>, fs.IoError>
+    _9: i64
+    _10: i64
+    _11: i32
+    _12: i32
+    _13: string
+    _14: Result<Sink<string>, fs.IoError>
+    _15: i64
+    _16: i64
+    _17: fs.IoError
+    _18: Result<Sink<string>, fs.IoError>
+    _19: Result<Sink<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(90) path site=SiteId(696) ty=string intent=Read
+    stmt: use BindingId(82) path site=SiteId(599) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(91) s site=SiteId(695) ty=Sink<string>
-    stmt: use BindingId(91) s site=SiteId(700) ty=Sink<string> intent=Read
+    stmt: bind BindingId(83) s site=SiteId(598) ty=Sink<string>
+    stmt: use BindingId(83) s site=SiteId(603) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(91) s site=SiteId(704) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(91) s site=SiteId(704) ty=Sink<string>
+    stmt: use BindingId(83) s site=SiteId(607) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(83) s site=SiteId(607) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2260,27 +1908,33 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _3 = move _7
     goto bb5
   bb4:
-    _8 = call hew_stream_last_errno() -> bb6
+    _8 = call hew_stream_last_error_kind() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(694)) ty=Result<Sink<string>, fs.IoError>
-    _16 = move _3
-    ret = move _16
+    stmt: return site=Some(SiteId(597)) ty=Result<Sink<string>, fs.IoError>
+    _19 = move _3
+    ret = move _19
     return
   bb6:
-    stmt: bind BindingId(92) errno site=SiteId(706) ty=i32
-    _9 = move _8
-    _10 = call hew_stream_last_error() -> bb7
+    stmt: bind BindingId(84) kind site=SiteId(609) ty=i64
+    _9 = cast _8 i32 -> i64
+    _10 = move _9
+    _11 = call hew_stream_last_errno() -> bb7
   bb7:
-    stmt: eval site=SiteId(708) ty=string
-    stmt: use BindingId(92) errno site=SiteId(713) ty=i32 intent=Read
-    _12 = const.i64 1
-    mtag11 = move _12
-    _13 = cast _9 i32 -> i64
-    _14 = call fs$io_error_from_errno(_13) -> bb8
+    stmt: bind BindingId(85) errno site=SiteId(612) ty=i32
+    _12 = move _11
+    _13 = call hew_stream_last_error() -> bb8
   bb8:
-    mvar11.1.0 = move _14
-    _15 = move _11
-    _3 = move _15
+    stmt: eval site=SiteId(614) ty=string
+    stmt: use BindingId(84) kind site=SiteId(618) ty=i64 intent=Read
+    stmt: use BindingId(85) errno site=SiteId(620) ty=i32 intent=Read
+    _15 = const.i64 1
+    mtag14 = move _15
+    _16 = cast _12 i32 -> i64
+    _17 = call fs$io_error_from_kind(_10, _16) -> bb9
+  bb9:
+    mvar14.1.0 = move _17
+    _18 = move _14
+    _3 = move _18
     goto bb5
 
 fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
@@ -2288,11 +1942,11 @@ fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
     _0: Stream<string>
     _1: Sink<string>
   bb0:
-    stmt: use BindingId(93) source site=SiteId(717) ty=Stream<string> intent=Read
-    stmt: use BindingId(94) dest site=SiteId(718) ty=Sink<string> intent=Read
+    stmt: use BindingId(86) source site=SiteId(624) ty=Stream<string> intent=Read
+    stmt: use BindingId(87) dest site=SiteId(625) ty=Sink<string> intent=Read
     call hew_stream_pipe(_0, _1) -> bb1
   bb1:
-    stmt: eval site=SiteId(715) ty=()
+    stmt: eval site=SiteId(622) ty=()
     return
 
 fn i8::fmt(i8) -> string [conv=default]
@@ -2301,11 +1955,11 @@ fn i8::fmt(i8) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(103) val site=SiteId(790) ty=i8 intent=Read
+    stmt: use BindingId(96) val site=SiteId(697) ty=i8 intent=Read
     _1 = cast _0 i8 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(788)) ty=string
+    stmt: return site=Some(SiteId(695)) ty=string
     ret = move _2
     return
 
@@ -2315,11 +1969,11 @@ fn i16::fmt(i16) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(104) val site=SiteId(794) ty=i16 intent=Read
+    stmt: use BindingId(97) val site=SiteId(701) ty=i16 intent=Read
     _1 = cast _0 i16 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(792)) ty=string
+    stmt: return site=Some(SiteId(699)) ty=string
     ret = move _2
     return
 
@@ -2328,10 +1982,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(105) val site=SiteId(797) ty=i32 intent=Read
+    stmt: use BindingId(98) val site=SiteId(704) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(796)) ty=string
+    stmt: return site=Some(SiteId(703)) ty=string
     ret = move _1
     return
 
@@ -2340,10 +1994,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(106) val site=SiteId(800) ty=i64 intent=Read
+    stmt: use BindingId(99) val site=SiteId(707) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(799)) ty=string
+    stmt: return site=Some(SiteId(706)) ty=string
     ret = move _1
     return
 
@@ -2352,10 +2006,10 @@ fn u8::fmt(u8) -> string [conv=default]
     _0: u8
     _1: string
   bb0:
-    stmt: use BindingId(107) val site=SiteId(803) ty=u8 intent=Read
+    stmt: use BindingId(100) val site=SiteId(710) ty=u8 intent=Read
     _1 = call to_string_u8(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(802)) ty=string
+    stmt: return site=Some(SiteId(709)) ty=string
     ret = move _1
     return
 
@@ -2364,10 +2018,10 @@ fn u16::fmt(u16) -> string [conv=default]
     _0: u16
     _1: string
   bb0:
-    stmt: use BindingId(108) val site=SiteId(806) ty=u16 intent=Read
+    stmt: use BindingId(101) val site=SiteId(713) ty=u16 intent=Read
     _1 = call to_string_u16(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(805)) ty=string
+    stmt: return site=Some(SiteId(712)) ty=string
     ret = move _1
     return
 
@@ -2376,10 +2030,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(109) val site=SiteId(809) ty=u32 intent=Read
+    stmt: use BindingId(102) val site=SiteId(716) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(808)) ty=string
+    stmt: return site=Some(SiteId(715)) ty=string
     ret = move _1
     return
 
@@ -2388,10 +2042,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(110) val site=SiteId(812) ty=u64 intent=Read
+    stmt: use BindingId(103) val site=SiteId(719) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(811)) ty=string
+    stmt: return site=Some(SiteId(718)) ty=string
     ret = move _1
     return
 
@@ -2401,11 +2055,11 @@ fn isize::fmt(isize) -> string [conv=default]
     _1: i64
     _2: string
   bb0:
-    stmt: use BindingId(111) val site=SiteId(816) ty=isize intent=Read
+    stmt: use BindingId(104) val site=SiteId(723) ty=isize intent=Read
     _1 = cast _0 isize -> i64
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(814)) ty=string
+    stmt: return site=Some(SiteId(721)) ty=string
     ret = move _2
     return
 
@@ -2415,11 +2069,11 @@ fn usize::fmt(usize) -> string [conv=default]
     _1: u64
     _2: string
   bb0:
-    stmt: use BindingId(112) val site=SiteId(820) ty=usize intent=Read
+    stmt: use BindingId(105) val site=SiteId(727) ty=usize intent=Read
     _1 = cast _0 usize -> u64
     _2 = call to_string_u64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(818)) ty=string
+    stmt: return site=Some(SiteId(725)) ty=string
     ret = move _2
     return
 
@@ -2428,10 +2082,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(113) val site=SiteId(823) ty=bool intent=Read
+    stmt: use BindingId(106) val site=SiteId(730) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(822)) ty=string
+    stmt: return site=Some(SiteId(729)) ty=string
     ret = move _1
     return
 
@@ -2440,10 +2094,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(114) val site=SiteId(826) ty=char intent=Read
+    stmt: use BindingId(107) val site=SiteId(733) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(825)) ty=string
+    stmt: return site=Some(SiteId(732)) ty=string
     ret = move _1
     return
 
@@ -2452,10 +2106,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(115) val site=SiteId(829) ty=f64 intent=Read
+    stmt: use BindingId(108) val site=SiteId(736) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(828)) ty=string
+    stmt: return site=Some(SiteId(735)) ty=string
     ret = move _1
     return
 
@@ -2465,11 +2119,11 @@ fn f32::fmt(f32) -> string [conv=default]
     _1: f64
     _2: string
   bb0:
-    stmt: use BindingId(116) val site=SiteId(833) ty=f32 intent=Read
+    stmt: use BindingId(109) val site=SiteId(740) ty=f32 intent=Read
     _1 = cast _0 f32 -> f64
     _2 = call to_string_f64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(831)) ty=string
+    stmt: return site=Some(SiteId(738)) ty=string
     ret = move _2
     return
 
@@ -2477,8 +2131,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(117) val site=SiteId(835) ty=string intent=Read
-    stmt: return site=Some(SiteId(835)) ty=string
+    stmt: use BindingId(110) val site=SiteId(742) ty=string intent=Read
+    stmt: return site=Some(SiteId(742)) ty=string
     ret = move _0
     return
 
@@ -2489,14 +2143,14 @@ fn duration::from_nanos(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(118) n site=SiteId(837) ty=i64 intent=Read
+    stmt: use BindingId(111) n site=SiteId(744) ty=i64 intent=Read
     _1 = const.duration 1ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(836)) ty=duration
+    stmt: return site=Some(SiteId(743)) ty=duration
     ret = move _2
     return
 
@@ -2507,14 +2161,14 @@ fn duration::from_micros(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(119) n site=SiteId(840) ty=i64 intent=Read
+    stmt: use BindingId(112) n site=SiteId(747) ty=i64 intent=Read
     _1 = const.duration 1000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(839)) ty=duration
+    stmt: return site=Some(SiteId(746)) ty=duration
     ret = move _2
     return
 
@@ -2525,14 +2179,14 @@ fn duration::from_millis(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(120) n site=SiteId(843) ty=i64 intent=Read
+    stmt: use BindingId(113) n site=SiteId(750) ty=i64 intent=Read
     _1 = const.duration 1000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(842)) ty=duration
+    stmt: return site=Some(SiteId(749)) ty=duration
     ret = move _2
     return
 
@@ -2543,14 +2197,14 @@ fn duration::from_secs(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(121) n site=SiteId(846) ty=i64 intent=Read
+    stmt: use BindingId(114) n site=SiteId(753) ty=i64 intent=Read
     _1 = const.duration 1000000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(845)) ty=duration
+    stmt: return site=Some(SiteId(752)) ty=duration
     ret = move _2
     return
 
@@ -2562,11 +2216,11 @@ fn duration::fmt(duration) -> string [conv=default]
     _3: string
     _4: string
   bb0:
-    stmt: use BindingId(122) val site=SiteId(851) ty=duration intent=Read
+    stmt: use BindingId(115) val site=SiteId(758) ty=duration intent=Read
     _1 = call_rt hew_duration_nanos(_0)
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(848)) ty=string
+    stmt: return site=Some(SiteId(755)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
     drop _2 ty=string fn=release(hew_string_drop)

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.elab.mir
@@ -115,15 +115,84 @@ fn fs$io_error_from_errno -> IoError
     use BindingId(11) errno site=SiteId(65) ty=i64 intent=Read
     return site=Some(SiteId(56)) ty=IoError
     use BindingId(11) errno site=SiteId(69) ty=i64 intent=Read
-    use BindingId(11) errno site=SiteId(72) ty=i64 intent=Read
+    use BindingId(11) errno site=SiteId(73) ty=i64 intent=Read
     use BindingId(11) errno site=SiteId(76) ty=i64 intent=Read
     use BindingId(11) errno site=SiteId(80) ty=i64 intent=Read
-    use BindingId(11) errno site=SiteId(83) ty=i64 intent=Read
+    use BindingId(11) errno site=SiteId(84) ty=i64 intent=Read
     use BindingId(11) errno site=SiteId(87) ty=i64 intent=Read
     use BindingId(11) errno site=SiteId(91) ty=i64 intent=Read
-    use BindingId(11) errno site=SiteId(94) ty=i64 intent=Read
+    use BindingId(11) errno site=SiteId(95) ty=i64 intent=Read
     use BindingId(11) errno site=SiteId(98) ty=i64 intent=Read
-    use BindingId(11) errno site=SiteId(101) ty=i64 intent=Read
+    use BindingId(11) errno site=SiteId(102) ty=i64 intent=Read
+    use BindingId(11) errno site=SiteId(105) ty=i64 intent=Read
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    goto[bb1->bb3] ->
+      (none)
+    branch[bb2: bb4/bb5] ->
+      (none)
+    return[bb3] ->
+      (none)
+    goto[bb4->bb6] ->
+      (none)
+    branch[bb5: bb8/bb7] ->
+      (none)
+    goto[bb6->bb3] ->
+      (none)
+    cancel[bb6] ->
+      (none)
+    goto[bb7->bb8] ->
+      (none)
+    branch[bb8: bb9/bb10] ->
+      (none)
+    goto[bb9->bb11] ->
+      (none)
+    branch[bb10: bb13/bb12] ->
+      (none)
+    goto[bb11->bb6] ->
+      (none)
+    cancel[bb11] ->
+      (none)
+    goto[bb12->bb13] ->
+      (none)
+    branch[bb13: bb14/bb15] ->
+      (none)
+    goto[bb14->bb16] ->
+      (none)
+    branch[bb15: bb18/bb17] ->
+      (none)
+    goto[bb16->bb11] ->
+      (none)
+    cancel[bb16] ->
+      (none)
+    goto[bb17->bb18] ->
+      (none)
+    branch[bb18: bb19/bb20] ->
+      (none)
+    goto[bb19->bb21] ->
+      (none)
+    goto[bb20->bb21] ->
+      (none)
+    goto[bb21->bb16] ->
+      (none)
+    cancel[bb21] ->
+      (none)
+
+fn fs$io_error_from_kind -> IoError
+  statements:
+    use BindingId(12) kind site=SiteId(108) ty=i64 intent=Read
+    use BindingId(13) errno site=SiteId(112) ty=i64 intent=Read
+    use BindingId(12) kind site=SiteId(115) ty=i64 intent=Read
+    return site=Some(SiteId(106)) ty=IoError
+    use BindingId(13) errno site=SiteId(119) ty=i64 intent=Read
+    use BindingId(12) kind site=SiteId(122) ty=i64 intent=Read
+    use BindingId(13) errno site=SiteId(126) ty=i64 intent=Read
+    use BindingId(12) kind site=SiteId(129) ty=i64 intent=Read
+    use BindingId(13) errno site=SiteId(133) ty=i64 intent=Read
+    use BindingId(13) errno site=SiteId(136) ty=i64 intent=Read
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -145,53 +214,41 @@ fn fs$io_error_from_errno -> IoError
       (none)
     goto[bb7->bb9] ->
       (none)
-    branch[bb8: bb11/bb10] ->
+    branch[bb8: bb10/bb11] ->
       (none)
     goto[bb9->bb6] ->
       (none)
     cancel[bb9] ->
       (none)
-    goto[bb10->bb11] ->
+    goto[bb10->bb12] ->
       (none)
-    branch[bb11: bb12/bb13] ->
+    call[bb11 fs$io_error_from_errno -> bb13] ->
       (none)
-    goto[bb12->bb14] ->
+    goto[bb12->bb9] ->
       (none)
-    branch[bb13: bb16/bb15] ->
+    cancel[bb12] ->
       (none)
-    goto[bb14->bb9] ->
+    goto[bb13->bb12] ->
       (none)
-    cancel[bb14] ->
-      (none)
-    goto[bb15->bb16] ->
-      (none)
-    branch[bb16: bb17/bb18] ->
-      (none)
-    goto[bb17->bb19] ->
-      (none)
-    goto[bb18->bb19] ->
-      (none)
-    goto[bb19->bb14] ->
-      (none)
-    cancel[bb19] ->
+    cancel[bb13] ->
       (none)
 
 fn fs$io_error_message -> string
   statements:
-    use BindingId(12) e site=SiteId(103) ty=IoError intent=Read
-    return site=Some(SiteId(102)) ty=string
-    bind BindingId(13) code site=SiteId(104) ty=i64
-    use BindingId(13) code site=SiteId(106) ty=i64 intent=Read
-    bind BindingId(14) code site=SiteId(114) ty=i64
-    use BindingId(14) code site=SiteId(116) ty=i64 intent=Read
-    bind BindingId(15) code site=SiteId(124) ty=i64
-    use BindingId(15) code site=SiteId(126) ty=i64 intent=Read
-    bind BindingId(16) code site=SiteId(134) ty=i64
-    use BindingId(16) code site=SiteId(136) ty=i64 intent=Read
-    bind BindingId(17) code site=SiteId(144) ty=i64
-    use BindingId(17) code site=SiteId(146) ty=i64 intent=Read
-    bind BindingId(18) code site=SiteId(154) ty=i64
-    use BindingId(18) code site=SiteId(156) ty=i64 intent=Read
+    use BindingId(14) e site=SiteId(139) ty=IoError intent=Read
+    return site=Some(SiteId(138)) ty=string
+    bind BindingId(15) code site=SiteId(140) ty=i64
+    use BindingId(15) code site=SiteId(142) ty=i64 intent=Read
+    bind BindingId(16) code site=SiteId(150) ty=i64
+    use BindingId(16) code site=SiteId(152) ty=i64 intent=Read
+    bind BindingId(17) code site=SiteId(160) ty=i64
+    use BindingId(17) code site=SiteId(162) ty=i64 intent=Read
+    bind BindingId(18) code site=SiteId(170) ty=i64
+    use BindingId(18) code site=SiteId(172) ty=i64 intent=Read
+    bind BindingId(19) code site=SiteId(180) ty=i64
+    use BindingId(19) code site=SiteId(182) ty=i64 intent=Read
+    bind BindingId(20) code site=SiteId(190) ty=i64
+    use BindingId(20) code site=SiteId(192) ty=i64 intent=Read
   drop_plans:
     branch[bb0: bb2/bb9] ->
       (none)
@@ -274,363 +331,73 @@ fn fs$io_error_message -> string
 
 fn fs$io_error_timed_out -> IoError
   statements:
-    return site=Some(SiteId(164)) ty=IoError
+    return site=Some(SiteId(200)) ty=IoError
   drop_plans:
     return[bb0] ->
       (none)
 
 fn fs$io_error_cancelled -> IoError
   statements:
-    return site=Some(SiteId(166)) ty=IoError
+    return site=Some(SiteId(202)) ty=IoError
   drop_plans:
     return[bb0] ->
       (none)
 
-fn fs$missing_parent -> bool
+fn fs$last_io_error -> IoError
   statements:
-    use BindingId(19) target site=SiteId(169) ty=string intent=Read
-    bind BindingId(20) parent site=SiteId(168) ty=string
-    use BindingId(20) parent site=SiteId(173) ty=string intent=Read
-    use BindingId(20) parent site=SiteId(177) ty=string intent=Read
-    return site=Some(SiteId(171)) ty=bool
-    drop BindingId(20) parent ty=string
+    bind BindingId(21) kind site=SiteId(205) ty=i64
+    bind BindingId(22) errno site=SiteId(208) ty=i64
+    eval site=SiteId(211) ty=string
+    use BindingId(22) errno site=SiteId(216) ty=i64 intent=Read
+    use BindingId(21) kind site=SiteId(219) ty=i64 intent=Read
+    use BindingId(21) kind site=SiteId(226) ty=i64 intent=Read
+    use BindingId(22) errno site=SiteId(227) ty=i64 intent=Read
+    return site=Some(SiteId(204)) ty=IoError
   drop_plans:
-    call[bb0 fs$dirname -> bb1] ->
+    call[bb0 hew_stream_last_error_kind -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    branch[bb1: bb2/bb3] ->
+    call[bb1 hew_stream_last_errno -> bb2] ->
       (none)
-    call[bb2 fs$exists -> bb4] ->
+    call[bb2 hew_stream_last_error -> bb3] ->
       (none)
-    return[bb3] ->
-      (none)
-    goto[bb4->bb3] ->
-      (none)
-    cancel[bb4] ->
-      (none)
-
-fn fs$dirname -> string
-  statements:
-    use BindingId(21) p site=SiteId(180) ty=string intent=Read
-    bind BindingId(22) s site=SiteId(179) ty=string
-    use BindingId(22) s site=SiteId(183) ty=string intent=Read
-    bind BindingId(23) pos site=SiteId(182) ty=i64
-    use BindingId(23) pos site=SiteId(186) ty=i64 intent=Read
-    return site=Some(SiteId(188)) ty=string
-    eval site=SiteId(190) ty=()
-    use BindingId(23) pos site=SiteId(192) ty=i64 intent=Read
-    return site=Some(SiteId(194)) ty=string
-    eval site=SiteId(196) ty=()
-    use BindingId(22) s site=SiteId(198) ty=string intent=Read
-    use BindingId(23) pos site=SiteId(200) ty=i64 intent=Read
-    return site=Some(SiteId(197)) ty=string
-    drop BindingId(22) s ty=string
-  drop_plans:
-    call[bb0 fs$strip_trailing_slash -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    call[bb1 fs$last_slash_pos -> bb2] ->
-      (none)
-    branch[bb2: bb3/bb4] ->
-      (none)
-    return[bb3] ->
+    branch[bb3: bb4/bb5] ->
       (none)
     goto[bb4->bb5] ->
       (none)
-    branch[bb5: bb7/bb8] ->
-      (none)
-    goto[bb6->bb5] ->
-      (none)
-    cancel[bb6] ->
-      (none)
-    return[bb7] ->
-      (none)
-    goto[bb8->bb9] ->
-      (none)
-    call[bb9 hew_string_slice -> bb11] ->
-      (none)
-    goto[bb10->bb9] ->
-      (none)
-    cancel[bb10] ->
-      (none)
-    return[bb11] ->
-      (none)
-
-fn fs$strip_trailing_slash -> string
-  statements:
-    use BindingId(24) p site=SiteId(203) ty=string intent=Read
-    use BindingId(24) p site=SiteId(207) ty=string intent=Read
-    return site=Some(SiteId(205)) ty=string
-    eval site=SiteId(209) ty=()
-    use BindingId(24) p site=SiteId(213) ty=string intent=Read
-    use BindingId(24) p site=SiteId(217) ty=string intent=Read
-    use BindingId(24) p site=SiteId(221) ty=string intent=Read
-    use BindingId(24) p site=SiteId(225) ty=string intent=Read
-    eval site=SiteId(230) ty=()
-    use BindingId(24) p site=SiteId(233) ty=string intent=Read
-    return site=Some(SiteId(231)) ty=string
-    return site=Some(SiteId(220)) ty=string
-  drop_plans:
-    branch[bb0: bb1/bb2] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    return[bb1] ->
-      (none)
-    goto[bb2->bb3] ->
-      (none)
-    call[bb3 hew_string_length -> bb5] ->
-      (none)
-    goto[bb4->bb3] ->
-      (none)
-    cancel[bb4] ->
-      (none)
-    branch[bb5: bb6/bb7] ->
-      (none)
-    call[bb6 hew_string_ends_with -> bb8] ->
-      (none)
-    branch[bb7: bb9/bb10] ->
-      (none)
-    goto[bb8->bb7] ->
-      (none)
-    cancel[bb8] ->
-      (none)
-    call[bb9 hew_string_length -> bb12] ->
-      (none)
-    goto[bb10->bb11] ->
-      (none)
-    return[bb11] ->
-      (none)
-    branch[bb12: bb13/bb14] ->
-      (none)
-    panic[bb13] ->
-      (none)
-    call[bb14 hew_string_slice -> bb15] ->
-      (none)
-    return[bb15] ->
-      (none)
-    goto[bb16->bb11] ->
-      (none)
-    cancel[bb16] ->
-      (none)
-
-fn fs$last_slash_pos -> i64
-  statements:
-    use BindingId(25) s site=SiteId(236) ty=string intent=Read
-    bind BindingId(27) first site=SiteId(234) ty=i64
-    use BindingId(27) first site=SiteId(242) ty=i64 intent=Consume
-    bind BindingId(28) last site=SiteId(242) ty=i64
-    use BindingId(27) first site=SiteId(244) ty=i64 intent=Read
-    bind BindingId(26) i site=SiteId(239) ty=i64
-    use BindingId(26) i site=SiteId(239) ty=i64 intent=Read
-    return site=Some(SiteId(241)) ty=i64
-    bind BindingId(29) search_from site=SiteId(243) ty=i64
-    use BindingId(29) search_from site=SiteId(247) ty=i64 intent=Read
-    use BindingId(25) s site=SiteId(249) ty=string intent=Read
-    use BindingId(25) s site=SiteId(252) ty=string intent=Read
-    use BindingId(29) search_from site=SiteId(253) ty=i64 intent=Read
-    use BindingId(25) s site=SiteId(255) ty=string intent=Read
-    eval site=SiteId(274) ty=()
-    use BindingId(28) last site=SiteId(275) ty=i64 intent=Read
-    return site=Some(SiteId(275)) ty=i64
-    bind BindingId(30) rest site=SiteId(251) ty=string
-    use BindingId(30) rest site=SiteId(260) ty=string intent=Read
-    bind BindingId(32) next site=SiteId(258) ty=i64
-    use BindingId(29) search_from site=SiteId(268) ty=i64 intent=Read
-    use BindingId(32) next site=SiteId(269) ty=i64 intent=Read
-    bind BindingId(31) i site=SiteId(263) ty=i64
-    use BindingId(31) i site=SiteId(263) ty=i64 intent=Read
-    use BindingId(28) last site=SiteId(265) ty=i64 intent=Consume
-    return site=Some(SiteId(265)) ty=i64
-    bind BindingId(28) last site=SiteId(266) ty=i64
-    eval site=SiteId(267) ty=()
-    use BindingId(28) last site=SiteId(272) ty=i64 intent=Read
-    bind BindingId(29) search_from site=SiteId(270) ty=i64
-    eval site=SiteId(271) ty=()
-    drop BindingId(30) rest ty=string
-  drop_plans:
-    call[bb0 hew_string_find -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb3/bb6] ->
-      (none)
-    branch[bb2: bb8/bb9] ->
-      (none)
-    goto[bb3->bb2] ->
-      (none)
-    cancel[bb3] ->
-      (none)
-    return[bb4] ->
-      (none)
-    panic[bb5] ->
-      (none)
-    branch[bb6: bb4/bb5] ->
-      (none)
-    goto[bb7->bb2] ->
-      (none)
-    cancel[bb7] ->
-      (none)
-    panic[bb8] ->
-      (none)
-    goto[bb9->bb10] ->
-      (none)
-    call[bb10 hew_string_length -> bb13] ->
-      (none)
-    call[bb11 hew_string_length -> bb14] ->
-      (none)
-    return[bb12] ->
-      (none)
-    branch[bb13: bb11/bb12] ->
-      (none)
-    call[bb14 hew_string_slice -> bb15] ->
-      (none)
-    call[bb15 hew_string_find -> bb16] ->
-      (none)
-    branch[bb16: bb18/bb21] ->
-      (none)
-    branch[bb17: bb23/bb24] ->
-      (none)
-    goto[bb18->bb17] ->
-      (none)
-    cancel[bb18] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    return[bb19] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    panic[bb20] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    branch[bb21: bb19/bb20] ->
-      (none)
-    goto[bb22->bb17] ->
-      (none)
-    cancel[bb22] ->
-      (none)
-    panic[bb23] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    branch[bb24: bb25/bb26] ->
-      (none)
-    panic[bb25] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    goto[bb26->bb10] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    cancel[bb26] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-
-fn fs$write_error -> IoError
-  statements:
-    use BindingId(33) target site=SiteId(278) ty=string intent=Read
-    return site=Some(SiteId(276)) ty=IoError
-  drop_plans:
-    call[bb0 fs$missing_parent -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb2/bb3] ->
-      (none)
-    goto[bb2->bb4] ->
-      (none)
-    goto[bb3->bb4] ->
-      (none)
-    return[bb4] ->
-      (none)
-
-fn fs$missing_path_error -> IoError
-  statements:
-    use BindingId(34) target site=SiteId(288) ty=string intent=Read
-    return site=Some(SiteId(286)) ty=IoError
-  drop_plans:
-    call[bb0 fs$exists -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb2/bb3] ->
-      (none)
-    goto[bb2->bb4] ->
-      (none)
-    goto[bb3->bb4] ->
-      (none)
-    return[bb4] ->
-      (none)
-
-fn fs$mkdir_error -> IoError
-  statements:
-    use BindingId(35) target site=SiteId(298) ty=string intent=Read
-    use BindingId(35) target site=SiteId(305) ty=string intent=Read
-    return site=Some(SiteId(296)) ty=IoError
-  drop_plans:
-    call[bb0 fs$exists -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb2/bb3] ->
-      (none)
-    goto[bb2->bb4] ->
-      (none)
-    call[bb3 fs$missing_parent -> bb5] ->
-      (none)
-    return[bb4] ->
-      (none)
     branch[bb5: bb6/bb7] ->
       (none)
     goto[bb6->bb8] ->
       (none)
-    goto[bb7->bb8] ->
+    call[bb7 fs$io_error_from_kind -> bb9] ->
       (none)
-    goto[bb8->bb4] ->
+    return[bb8] ->
       (none)
-    cancel[bb8] ->
+    goto[bb9->bb8] ->
       (none)
-
-fn fs$move_copy_error -> IoError
-  statements:
-    use BindingId(36) source site=SiteId(316) ty=string intent=Read
-    use BindingId(37) target site=SiteId(323) ty=string intent=Read
-    return site=Some(SiteId(313)) ty=IoError
-  drop_plans:
-    call[bb0 fs$exists -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb2/bb3] ->
-      (none)
-    goto[bb2->bb4] ->
-      (none)
-    call[bb3 fs$missing_parent -> bb5] ->
-      (none)
-    return[bb4] ->
-      (none)
-    branch[bb5: bb6/bb7] ->
-      (none)
-    goto[bb6->bb8] ->
-      (none)
-    goto[bb7->bb8] ->
-      (none)
-    goto[bb8->bb4] ->
-      (none)
-    cancel[bb8] ->
+    cancel[bb9] ->
       (none)
 
 fn fs$read -> string
   statements:
-    use BindingId(38) path site=SiteId(333) ty=string intent=Read
-    bind BindingId(39) contents site=SiteId(332) ty=string
-    bind BindingId(40) errno site=SiteId(335) ty=i32
-    use BindingId(40) errno site=SiteId(338) ty=i32 intent=Read
-    eval site=SiteId(390) ty=()
-    use BindingId(39) contents site=SiteId(391) ty=string intent=Read
-    return site=Some(SiteId(331)) ty=string
-    bind BindingId(41) detail site=SiteId(340) ty=string
-    use BindingId(41) detail site=SiteId(345) ty=string intent=Read
-    use BindingId(38) path site=SiteId(352) ty=string intent=Read
-    use BindingId(38) path site=SiteId(375) ty=string intent=Read
-    use BindingId(40) errno site=SiteId(359) ty=i32 intent=Read
-    eval site=SiteId(349) ty=!
-    use BindingId(41) detail site=SiteId(379) ty=string intent=Read
-    eval site=SiteId(372) ty=!
-    drop BindingId(41) detail ty=string
-    drop BindingId(39) contents ty=string
+    use BindingId(23) path site=SiteId(231) ty=string intent=Read
+    bind BindingId(24) contents site=SiteId(230) ty=string
+    bind BindingId(25) errno site=SiteId(233) ty=i32
+    use BindingId(25) errno site=SiteId(236) ty=i32 intent=Read
+    eval site=SiteId(288) ty=()
+    use BindingId(24) contents site=SiteId(289) ty=string intent=Read
+    return site=Some(SiteId(229)) ty=string
+    bind BindingId(26) detail site=SiteId(238) ty=string
+    use BindingId(26) detail site=SiteId(243) ty=string intent=Read
+    use BindingId(23) path site=SiteId(250) ty=string intent=Read
+    use BindingId(23) path site=SiteId(273) ty=string intent=Read
+    use BindingId(25) errno site=SiteId(257) ty=i32 intent=Read
+    eval site=SiteId(247) ty=!
+    use BindingId(26) detail site=SiteId(277) ty=string intent=Read
+    eval site=SiteId(270) ty=!
+    drop BindingId(26) detail ty=string
+    drop BindingId(24) contents ty=string
   drop_plans:
     call[bb0 hew_file_read -> bb1] ->
       (none)
@@ -693,14 +460,21 @@ fn fs$read -> string
 
 fn fs$try_read -> Result<string, IoError>
   statements:
-    use BindingId(42) file_path site=SiteId(394) ty=string intent=Read
-    bind BindingId(43) file site=SiteId(393) ty=FileReadStream
-    use BindingId(43) file site=SiteId(398) ty=FileReadStream intent=Read
-    use BindingId(43) file site=SiteId(403) ty=FileReadStream intent=Read
-    return site=Some(SiteId(392)) ty=Result<string, IoError>
-    bind BindingId(44) errno site=SiteId(406) ty=i32
-    eval site=SiteId(408) ty=string
-    use BindingId(44) errno site=SiteId(413) ty=i32 intent=Read
+    use BindingId(27) file_path site=SiteId(292) ty=string intent=Read
+    bind BindingId(28) file site=SiteId(291) ty=FileReadStream
+    use BindingId(28) file site=SiteId(296) ty=FileReadStream intent=Read
+    use BindingId(28) file site=SiteId(300) ty=FileReadStream intent=Read
+    return site=Some(SiteId(290)) ty=Result<string, IoError>
+    bind BindingId(29) contents site=SiteId(299) ty=string
+    bind BindingId(30) kind site=SiteId(302) ty=i64
+    bind BindingId(31) errno site=SiteId(305) ty=i32
+    eval site=SiteId(307) ty=string
+    use BindingId(31) errno site=SiteId(311) ty=i32 intent=Read
+    use BindingId(29) contents site=SiteId(315) ty=string intent=Read
+    agg_alias BindingId(29) contents site=SiteId(315) ty=string
+    use BindingId(30) kind site=SiteId(319) ty=i64 intent=Read
+    use BindingId(31) errno site=SiteId(321) ty=i32 intent=Read
+    drop BindingId(29) contents ty=string
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -712,28 +486,40 @@ fn fs$try_read -> Result<string, IoError>
       (none)
     call[bb3 hew_stream_collect_string -> bb6] ->
       (none)
-    call[bb4 hew_stream_last_errno -> bb7] ->
+    call[bb4 fs$last_io_error -> bb14] ->
       (none)
     return[bb5] ->
       (none)
-    goto[bb6->bb5] ->
+    call[bb6 hew_stream_last_error_kind -> bb7] ->
       (none)
-    cancel[bb6] ->
+    call[bb7 hew_stream_last_errno -> bb8] ->
       (none)
-    call[bb7 hew_stream_last_error -> bb8] ->
+    call[bb8 hew_stream_last_error -> bb9] ->
       (none)
-    call[bb8 fs$io_error_from_errno -> bb9] ->
+    branch[bb9: bb10/bb11] ->
       (none)
-    goto[bb9->bb5] ->
+    goto[bb10->bb12] ->
       (none)
-    cancel[bb9] ->
+    call[bb11 fs$io_error_from_kind -> bb13] ->
+      (none)
+    goto[bb12->bb5] ->
+      (none)
+    cancel[bb12] ->
+      (none)
+    goto[bb13->bb12] ->
+      (none)
+    cancel[bb13] ->
+      (none)
+    goto[bb14->bb5] ->
+      (none)
+    cancel[bb14] ->
       (none)
 
 fn fs$write -> i64
   statements:
-    use BindingId(45) path site=SiteId(418) ty=string intent=Read
-    use BindingId(46) content site=SiteId(419) ty=string intent=Read
-    return site=Some(SiteId(415)) ty=i64
+    use BindingId(32) path site=SiteId(330) ty=string intent=Read
+    use BindingId(33) content site=SiteId(331) ty=string intent=Read
+    return site=Some(SiteId(327)) ty=i64
   drop_plans:
     call[bb0 hew_file_write -> bb1] ->
       (none)
@@ -744,10 +530,9 @@ fn fs$write -> i64
 
 fn fs$try_write -> Result<i64, IoError>
   statements:
-    use BindingId(47) file_path site=SiteId(424) ty=string intent=Read
-    use BindingId(48) content site=SiteId(425) ty=string intent=Read
-    return site=Some(SiteId(421)) ty=Result<i64, IoError>
-    use BindingId(47) file_path site=SiteId(431) ty=string intent=Read
+    use BindingId(34) file_path site=SiteId(336) ty=string intent=Read
+    use BindingId(35) content site=SiteId(337) ty=string intent=Read
+    return site=Some(SiteId(333)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_file_write -> bb1] ->
       (none)
@@ -759,7 +544,7 @@ fn fs$try_write -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$write_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -774,9 +559,9 @@ fn fs$try_write -> Result<i64, IoError>
 
 fn fs$append -> i64
   statements:
-    use BindingId(49) path site=SiteId(436) ty=string intent=Read
-    use BindingId(50) content site=SiteId(437) ty=string intent=Read
-    return site=Some(SiteId(433)) ty=i64
+    use BindingId(36) path site=SiteId(347) ty=string intent=Read
+    use BindingId(37) content site=SiteId(348) ty=string intent=Read
+    return site=Some(SiteId(344)) ty=i64
   drop_plans:
     call[bb0 hew_file_append -> bb1] ->
       (none)
@@ -787,10 +572,9 @@ fn fs$append -> i64
 
 fn fs$try_append -> Result<i64, IoError>
   statements:
-    use BindingId(51) file_path site=SiteId(442) ty=string intent=Read
-    use BindingId(52) content site=SiteId(443) ty=string intent=Read
-    return site=Some(SiteId(439)) ty=Result<i64, IoError>
-    use BindingId(51) file_path site=SiteId(449) ty=string intent=Read
+    use BindingId(38) file_path site=SiteId(353) ty=string intent=Read
+    use BindingId(39) content site=SiteId(354) ty=string intent=Read
+    return site=Some(SiteId(350)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_file_append -> bb1] ->
       (none)
@@ -802,7 +586,7 @@ fn fs$try_append -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$write_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -817,8 +601,8 @@ fn fs$try_append -> Result<i64, IoError>
 
 fn fs$exists -> bool
   statements:
-    use BindingId(53) path site=SiteId(453) ty=string intent=Read
-    return site=Some(SiteId(451)) ty=bool
+    use BindingId(40) path site=SiteId(363) ty=string intent=Read
+    return site=Some(SiteId(361)) ty=bool
   drop_plans:
     call[bb0 hew_file_exists -> bb1] ->
       (none)
@@ -829,8 +613,8 @@ fn fs$exists -> bool
 
 fn fs$delete -> i64
   statements:
-    use BindingId(54) path site=SiteId(458) ty=string intent=Read
-    return site=Some(SiteId(455)) ty=i64
+    use BindingId(41) path site=SiteId(368) ty=string intent=Read
+    return site=Some(SiteId(365)) ty=i64
   drop_plans:
     call[bb0 hew_file_delete -> bb1] ->
       (none)
@@ -841,9 +625,8 @@ fn fs$delete -> i64
 
 fn fs$try_delete -> Result<i64, IoError>
   statements:
-    use BindingId(55) file_path site=SiteId(463) ty=string intent=Read
-    return site=Some(SiteId(460)) ty=Result<i64, IoError>
-    use BindingId(55) file_path site=SiteId(469) ty=string intent=Read
+    use BindingId(42) file_path site=SiteId(373) ty=string intent=Read
+    return site=Some(SiteId(370)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_file_delete -> bb1] ->
       (none)
@@ -855,7 +638,7 @@ fn fs$try_delete -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$missing_path_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -870,8 +653,8 @@ fn fs$try_delete -> Result<i64, IoError>
 
 fn fs$size -> i64
   statements:
-    use BindingId(56) path site=SiteId(473) ty=string intent=Read
-    return site=Some(SiteId(471)) ty=i64
+    use BindingId(43) path site=SiteId(382) ty=string intent=Read
+    return site=Some(SiteId(380)) ty=i64
   drop_plans:
     call[bb0 hew_file_size -> bb1] ->
       (none)
@@ -882,8 +665,8 @@ fn fs$size -> i64
 
 fn fs$read_bytes -> bytes
   statements:
-    use BindingId(57) path site=SiteId(477) ty=string intent=Read
-    return site=Some(SiteId(475)) ty=bytes
+    use BindingId(44) path site=SiteId(386) ty=string intent=Read
+    return site=Some(SiteId(384)) ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
       (none)
@@ -894,42 +677,46 @@ fn fs$read_bytes -> bytes
 
 fn fs$try_read_bytes -> Result<bytes, IoError>
   statements:
-    use BindingId(58) file_path site=SiteId(481) ty=string intent=Read
-    bind BindingId(59) data site=SiteId(480) ty=bytes
-    bind BindingId(60) errno site=SiteId(483) ty=i32
-    use BindingId(60) errno site=SiteId(487) ty=i32 intent=Read
-    use BindingId(59) data site=SiteId(499) ty=bytes intent=Read
-    return site=Some(SiteId(479)) ty=Result<bytes, IoError>
-    eval site=SiteId(490) ty=string
-    use BindingId(60) errno site=SiteId(495) ty=i32 intent=Read
-    drop BindingId(59) data ty=bytes
+    use BindingId(45) file_path site=SiteId(390) ty=string intent=Read
+    bind BindingId(46) data site=SiteId(389) ty=bytes
+    bind BindingId(47) kind site=SiteId(392) ty=i64
+    bind BindingId(48) errno site=SiteId(395) ty=i32
+    use BindingId(48) errno site=SiteId(399) ty=i32 intent=Read
+    use BindingId(46) data site=SiteId(412) ty=bytes intent=Read
+    return site=Some(SiteId(388)) ty=Result<bytes, IoError>
+    eval site=SiteId(402) ty=string
+    use BindingId(47) kind site=SiteId(406) ty=i64 intent=Read
+    use BindingId(48) errno site=SiteId(408) ty=i32 intent=Read
+    drop BindingId(46) data ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    call[bb1 hew_stream_last_errno -> bb2] ->
+    call[bb1 hew_stream_last_error_kind -> bb2] ->
       (none)
-    branch[bb2: bb3/bb4] ->
+    call[bb2 hew_stream_last_errno -> bb3] ->
       (none)
-    call[bb3 hew_stream_last_error -> bb6] ->
+    branch[bb3: bb4/bb5] ->
       (none)
-    goto[bb4->bb5] ->
+    call[bb4 hew_stream_last_error -> bb7] ->
       (none)
-    return[bb5] ->
+    goto[bb5->bb6] ->
       (none)
-    call[bb6 fs$io_error_from_errno -> bb7] ->
+    return[bb6] ->
       (none)
-    goto[bb7->bb5] ->
+    call[bb7 fs$io_error_from_kind -> bb8] ->
       (none)
-    cancel[bb7] ->
+    goto[bb8->bb6] ->
+      (none)
+    cancel[bb8] ->
       (none)
 
 fn fs$write_bytes -> i64
   statements:
-    use BindingId(61) path site=SiteId(503) ty=string intent=Read
-    use BindingId(62) data site=SiteId(504) ty=bytes intent=Read
-    return site=Some(SiteId(500)) ty=i64
+    use BindingId(49) path site=SiteId(416) ty=string intent=Read
+    use BindingId(50) data site=SiteId(417) ty=bytes intent=Read
+    return site=Some(SiteId(413)) ty=i64
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -940,10 +727,9 @@ fn fs$write_bytes -> i64
 
 fn fs$try_write_bytes -> Result<i64, IoError>
   statements:
-    use BindingId(63) file_path site=SiteId(509) ty=string intent=Read
-    use BindingId(64) data site=SiteId(510) ty=bytes intent=Read
-    return site=Some(SiteId(506)) ty=Result<i64, IoError>
-    use BindingId(63) file_path site=SiteId(516) ty=string intent=Read
+    use BindingId(51) file_path site=SiteId(422) ty=string intent=Read
+    use BindingId(52) data site=SiteId(423) ty=bytes intent=Read
+    return site=Some(SiteId(419)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -955,7 +741,7 @@ fn fs$try_write_bytes -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$write_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -970,8 +756,8 @@ fn fs$try_write_bytes -> Result<i64, IoError>
 
 fn fs$mkdir -> i64
   statements:
-    use BindingId(65) path site=SiteId(521) ty=string intent=Read
-    return site=Some(SiteId(518)) ty=i64
+    use BindingId(53) path site=SiteId(433) ty=string intent=Read
+    return site=Some(SiteId(430)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -982,9 +768,8 @@ fn fs$mkdir -> i64
 
 fn fs$try_mkdir -> Result<i64, IoError>
   statements:
-    use BindingId(66) dir_path site=SiteId(526) ty=string intent=Read
-    return site=Some(SiteId(523)) ty=Result<i64, IoError>
-    use BindingId(66) dir_path site=SiteId(532) ty=string intent=Read
+    use BindingId(54) dir_path site=SiteId(438) ty=string intent=Read
+    return site=Some(SiteId(435)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -996,7 +781,7 @@ fn fs$try_mkdir -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$mkdir_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -1011,8 +796,8 @@ fn fs$try_mkdir -> Result<i64, IoError>
 
 fn fs$mkdir_all -> i64
   statements:
-    use BindingId(67) path site=SiteId(537) ty=string intent=Read
-    return site=Some(SiteId(534)) ty=i64
+    use BindingId(55) path site=SiteId(448) ty=string intent=Read
+    return site=Some(SiteId(445)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -1023,9 +808,8 @@ fn fs$mkdir_all -> i64
 
 fn fs$try_mkdir_all -> Result<i64, IoError>
   statements:
-    use BindingId(68) dir_path site=SiteId(542) ty=string intent=Read
-    return site=Some(SiteId(539)) ty=Result<i64, IoError>
-    use BindingId(68) dir_path site=SiteId(549) ty=string intent=Read
+    use BindingId(56) dir_path site=SiteId(453) ty=string intent=Read
+    return site=Some(SiteId(450)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -1037,7 +821,7 @@ fn fs$try_mkdir_all -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$exists -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -1045,21 +829,15 @@ fn fs$try_mkdir_all -> Result<i64, IoError>
       (none)
     cancel[bb6] ->
       (none)
-    branch[bb7: bb8/bb9] ->
+    goto[bb7->bb2] ->
       (none)
-    goto[bb8->bb10] ->
-      (none)
-    goto[bb9->bb10] ->
-      (none)
-    goto[bb10->bb2] ->
-      (none)
-    cancel[bb10] ->
+    cancel[bb7] ->
       (none)
 
 fn fs$list_dir -> Vec<string>
   statements:
-    use BindingId(69) path site=SiteId(561) ty=string intent=Read
-    return site=Some(SiteId(559)) ty=Vec<string>
+    use BindingId(57) path site=SiteId(462) ty=string intent=Read
+    return site=Some(SiteId(460)) ty=Vec<string>
   drop_plans:
     call[bb0 hew_fs_list_dir -> bb1] ->
       (none)
@@ -1070,51 +848,47 @@ fn fs$list_dir -> Vec<string>
 
 fn fs$try_list_dir -> Result<Vec<string>, IoError>
   statements:
-    use BindingId(70) dir_path site=SiteId(565) ty=string intent=Read
-    return site=Some(SiteId(567)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(571) ty=()
-    use BindingId(70) dir_path site=SiteId(574) ty=string intent=Read
-    return site=Some(SiteId(576)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(580) ty=()
-    use BindingId(70) dir_path site=SiteId(584) ty=string intent=Read
-    return site=Some(SiteId(581)) ty=Result<Vec<string>, IoError>
+    use BindingId(58) dir_path site=SiteId(466) ty=string intent=Read
+    bind BindingId(59) entries site=SiteId(465) ty=Vec<string>
+    bind BindingId(60) kind site=SiteId(468) ty=i64
+    bind BindingId(61) errno site=SiteId(471) ty=i32
+    eval site=SiteId(473) ty=string
+    use BindingId(61) errno site=SiteId(477) ty=i32 intent=Read
+    use BindingId(59) entries site=SiteId(481) ty=Vec<string> intent=Read
+    agg_alias BindingId(59) entries site=SiteId(481) ty=Vec<string>
+    use BindingId(60) kind site=SiteId(485) ty=i64 intent=Read
+    use BindingId(61) errno site=SiteId(487) ty=i32 intent=Read
+    return site=Some(SiteId(464)) ty=Result<Vec<string>, IoError>
+    drop BindingId(59) entries ty=Vec<string>
   drop_plans:
-    call[bb0 fs$exists -> bb1] ->
+    call[bb0 hew_fs_list_dir -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    branch[bb1: bb2/bb3] ->
+    call[bb1 hew_stream_last_error_kind -> bb2] ->
       (none)
-    return[bb2] ->
+    call[bb2 hew_stream_last_errno -> bb3] ->
       (none)
-    goto[bb3->bb4] ->
+    call[bb3 hew_stream_last_error -> bb4] ->
       (none)
-    call[bb4 fs$is_dir -> bb6] ->
+    branch[bb4: bb5/bb6] ->
       (none)
-    goto[bb5->bb4] ->
+    goto[bb5->bb7] ->
       (none)
-    cancel[bb5] ->
-      (none)
-    branch[bb6: bb7/bb8] ->
+    call[bb6 fs$io_error_from_kind -> bb8] ->
       (none)
     return[bb7] ->
       (none)
-    goto[bb8->bb9] ->
+    goto[bb8->bb7] ->
       (none)
-    call[bb9 hew_fs_list_dir -> bb11] ->
-      (none)
-    goto[bb10->bb9] ->
-      (none)
-    cancel[bb10] ->
-      (none)
-    return[bb11] ->
+    cancel[bb8] ->
       (none)
 
 fn fs$rename -> i64
   statements:
-    use BindingId(71) from site=SiteId(589) ty=string intent=Read
-    use BindingId(72) to site=SiteId(590) ty=string intent=Read
-    return site=Some(SiteId(586)) ty=i64
+    use BindingId(62) from site=SiteId(492) ty=string intent=Read
+    use BindingId(63) to site=SiteId(493) ty=string intent=Read
+    return site=Some(SiteId(489)) ty=i64
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1125,11 +899,9 @@ fn fs$rename -> i64
 
 fn fs$try_rename -> Result<i64, IoError>
   statements:
-    use BindingId(73) from site=SiteId(595) ty=string intent=Read
-    use BindingId(74) to site=SiteId(596) ty=string intent=Read
-    return site=Some(SiteId(592)) ty=Result<i64, IoError>
-    use BindingId(73) from site=SiteId(602) ty=string intent=Read
-    use BindingId(74) to site=SiteId(603) ty=string intent=Read
+    use BindingId(64) from site=SiteId(498) ty=string intent=Read
+    use BindingId(65) to site=SiteId(499) ty=string intent=Read
+    return site=Some(SiteId(495)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1141,7 +913,7 @@ fn fs$try_rename -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$move_copy_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -1156,9 +928,9 @@ fn fs$try_rename -> Result<i64, IoError>
 
 fn fs$copy -> i64
   statements:
-    use BindingId(75) from site=SiteId(608) ty=string intent=Read
-    use BindingId(76) to site=SiteId(609) ty=string intent=Read
-    return site=Some(SiteId(605)) ty=i64
+    use BindingId(66) from site=SiteId(509) ty=string intent=Read
+    use BindingId(67) to site=SiteId(510) ty=string intent=Read
+    return site=Some(SiteId(506)) ty=i64
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1169,11 +941,9 @@ fn fs$copy -> i64
 
 fn fs$try_copy -> Result<i64, IoError>
   statements:
-    use BindingId(77) from site=SiteId(614) ty=string intent=Read
-    use BindingId(78) to site=SiteId(615) ty=string intent=Read
-    return site=Some(SiteId(611)) ty=Result<i64, IoError>
-    use BindingId(77) from site=SiteId(621) ty=string intent=Read
-    use BindingId(78) to site=SiteId(622) ty=string intent=Read
+    use BindingId(68) from site=SiteId(515) ty=string intent=Read
+    use BindingId(69) to site=SiteId(516) ty=string intent=Read
+    return site=Some(SiteId(512)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1185,7 +955,7 @@ fn fs$try_copy -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$move_copy_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -1200,8 +970,8 @@ fn fs$try_copy -> Result<i64, IoError>
 
 fn fs$is_dir -> bool
   statements:
-    use BindingId(79) path site=SiteId(626) ty=string intent=Read
-    return site=Some(SiteId(624)) ty=bool
+    use BindingId(70) path site=SiteId(525) ty=string intent=Read
+    return site=Some(SiteId(523)) ty=bool
   drop_plans:
     call[bb0 hew_fs_is_dir -> bb1] ->
       (none)
@@ -1212,21 +982,21 @@ fn fs$is_dir -> bool
 
 fn stream$pipe -> (Sink<string>, Stream<string>)
   statements:
-    use BindingId(80) capacity site=SiteId(631) ty=i64 intent=Read
-    bind BindingId(81) pair site=SiteId(629) ty=StreamPair
-    use BindingId(81) pair site=SiteId(634) ty=StreamPair intent=Read
-    bind BindingId(82) sink site=SiteId(633) ty=Sink<string>
-    use BindingId(81) pair site=SiteId(637) ty=StreamPair intent=Read
-    bind BindingId(83) input site=SiteId(636) ty=Stream<string>
-    use BindingId(81) pair site=SiteId(640) ty=StreamPair intent=Read
-    eval site=SiteId(639) ty=()
-    use BindingId(82) sink site=SiteId(643) ty=Sink<string> intent=Read
-    use BindingId(83) input site=SiteId(644) ty=Stream<string> intent=Read
-    agg_alias BindingId(82) sink site=SiteId(643) ty=Sink<string>
-    agg_alias BindingId(83) input site=SiteId(644) ty=Stream<string>
-    return site=Some(SiteId(628)) ty=(Sink<string>, Stream<string>)
-    drop BindingId(83) input ty=Stream<string>
-    drop BindingId(82) sink ty=Sink<string>
+    use BindingId(71) capacity site=SiteId(530) ty=i64 intent=Read
+    bind BindingId(72) pair site=SiteId(528) ty=StreamPair
+    use BindingId(72) pair site=SiteId(533) ty=StreamPair intent=Read
+    bind BindingId(73) sink site=SiteId(532) ty=Sink<string>
+    use BindingId(72) pair site=SiteId(536) ty=StreamPair intent=Read
+    bind BindingId(74) input site=SiteId(535) ty=Stream<string>
+    use BindingId(72) pair site=SiteId(539) ty=StreamPair intent=Read
+    eval site=SiteId(538) ty=()
+    use BindingId(73) sink site=SiteId(542) ty=Sink<string> intent=Read
+    use BindingId(74) input site=SiteId(543) ty=Stream<string> intent=Read
+    agg_alias BindingId(73) sink site=SiteId(542) ty=Sink<string>
+    agg_alias BindingId(74) input site=SiteId(543) ty=Stream<string>
+    return site=Some(SiteId(527)) ty=(Sink<string>, Stream<string>)
+    drop BindingId(74) input ty=Stream<string>
+    drop BindingId(73) sink ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_channel -> bb1] ->
       (none)
@@ -1243,21 +1013,21 @@ fn stream$pipe -> (Sink<string>, Stream<string>)
 
 fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
   statements:
-    use BindingId(84) capacity site=SiteId(648) ty=i64 intent=Read
-    bind BindingId(85) pair site=SiteId(646) ty=StreamPair
-    use BindingId(85) pair site=SiteId(651) ty=StreamPair intent=Read
-    bind BindingId(86) sink site=SiteId(650) ty=Sink<bytes>
-    use BindingId(85) pair site=SiteId(654) ty=StreamPair intent=Read
-    bind BindingId(87) input site=SiteId(653) ty=Stream<bytes>
-    use BindingId(85) pair site=SiteId(657) ty=StreamPair intent=Read
-    eval site=SiteId(656) ty=()
-    use BindingId(86) sink site=SiteId(660) ty=Sink<bytes> intent=Read
-    use BindingId(87) input site=SiteId(661) ty=Stream<bytes> intent=Read
-    agg_alias BindingId(86) sink site=SiteId(660) ty=Sink<bytes>
-    agg_alias BindingId(87) input site=SiteId(661) ty=Stream<bytes>
-    return site=Some(SiteId(645)) ty=(Sink<bytes>, Stream<bytes>)
-    drop BindingId(87) input ty=Stream<bytes>
-    drop BindingId(86) sink ty=Sink<bytes>
+    use BindingId(75) capacity site=SiteId(547) ty=i64 intent=Read
+    bind BindingId(76) pair site=SiteId(545) ty=StreamPair
+    use BindingId(76) pair site=SiteId(550) ty=StreamPair intent=Read
+    bind BindingId(77) sink site=SiteId(549) ty=Sink<bytes>
+    use BindingId(76) pair site=SiteId(553) ty=StreamPair intent=Read
+    bind BindingId(78) input site=SiteId(552) ty=Stream<bytes>
+    use BindingId(76) pair site=SiteId(556) ty=StreamPair intent=Read
+    eval site=SiteId(555) ty=()
+    use BindingId(77) sink site=SiteId(559) ty=Sink<bytes> intent=Read
+    use BindingId(78) input site=SiteId(560) ty=Stream<bytes> intent=Read
+    agg_alias BindingId(77) sink site=SiteId(559) ty=Sink<bytes>
+    agg_alias BindingId(78) input site=SiteId(560) ty=Stream<bytes>
+    return site=Some(SiteId(544)) ty=(Sink<bytes>, Stream<bytes>)
+    drop BindingId(78) input ty=Stream<bytes>
+    drop BindingId(77) sink ty=Sink<bytes>
   drop_plans:
     call[bb0 hew_stream_channel -> bb1] ->
       (none)
@@ -1274,13 +1044,13 @@ fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
 
 fn stream$from_file -> Result<Stream<string>, string>
   statements:
-    use BindingId(88) path site=SiteId(664) ty=string intent=Read
-    bind BindingId(89) s site=SiteId(663) ty=Stream<string>
-    use BindingId(89) s site=SiteId(668) ty=Stream<string> intent=Read
-    use BindingId(89) s site=SiteId(672) ty=Stream<string> intent=Read
-    agg_alias BindingId(89) s site=SiteId(672) ty=Stream<string>
-    return site=Some(SiteId(662)) ty=Result<Stream<string>, string>
-    drop BindingId(89) s ty=Stream<string>
+    use BindingId(79) path site=SiteId(563) ty=string intent=Read
+    bind BindingId(80) s site=SiteId(562) ty=Stream<string>
+    use BindingId(80) s site=SiteId(567) ty=Stream<string> intent=Read
+    use BindingId(80) s site=SiteId(571) ty=Stream<string> intent=Read
+    agg_alias BindingId(80) s site=SiteId(571) ty=Stream<string>
+    return site=Some(SiteId(561)) ty=Result<Stream<string>, string>
+    drop BindingId(80) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1303,16 +1073,18 @@ fn stream$from_file -> Result<Stream<string>, string>
 
 fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
   statements:
-    use BindingId(90) path site=SiteId(679) ty=string intent=Read
-    bind BindingId(91) s site=SiteId(678) ty=Stream<string>
-    use BindingId(91) s site=SiteId(683) ty=Stream<string> intent=Read
-    use BindingId(91) s site=SiteId(687) ty=Stream<string> intent=Read
-    agg_alias BindingId(91) s site=SiteId(687) ty=Stream<string>
-    return site=Some(SiteId(677)) ty=Result<Stream<string>, fs.IoError>
-    bind BindingId(92) errno site=SiteId(689) ty=i32
-    eval site=SiteId(691) ty=string
-    use BindingId(92) errno site=SiteId(696) ty=i32 intent=Read
-    drop BindingId(91) s ty=Stream<string>
+    use BindingId(81) path site=SiteId(578) ty=string intent=Read
+    bind BindingId(82) s site=SiteId(577) ty=Stream<string>
+    use BindingId(82) s site=SiteId(582) ty=Stream<string> intent=Read
+    use BindingId(82) s site=SiteId(586) ty=Stream<string> intent=Read
+    agg_alias BindingId(82) s site=SiteId(586) ty=Stream<string>
+    return site=Some(SiteId(576)) ty=Result<Stream<string>, fs.IoError>
+    bind BindingId(83) kind site=SiteId(588) ty=i64
+    bind BindingId(84) errno site=SiteId(591) ty=i32
+    eval site=SiteId(593) ty=string
+    use BindingId(83) kind site=SiteId(597) ty=i64 intent=Read
+    use BindingId(84) errno site=SiteId(599) ty=i32 intent=Read
+    drop BindingId(82) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1324,28 +1096,30 @@ fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
       (none)
     goto[bb3->bb5] ->
       (none)
-    call[bb4 hew_stream_last_errno -> bb6] ->
+    call[bb4 hew_stream_last_error_kind -> bb6] ->
       (none)
     return[bb5] ->
       (none)
-    call[bb6 hew_stream_last_error -> bb7] ->
+    call[bb6 hew_stream_last_errno -> bb7] ->
       (none)
-    call[bb7 fs$io_error_from_errno -> bb8] ->
+    call[bb7 hew_stream_last_error -> bb8] ->
       (none)
-    goto[bb8->bb5] ->
+    call[bb8 fs$io_error_from_kind -> bb9] ->
       (none)
-    cancel[bb8] ->
+    goto[bb9->bb5] ->
+      (none)
+    cancel[bb9] ->
       (none)
 
 fn stream$to_file -> Result<Sink<string>, string>
   statements:
-    use BindingId(93) path site=SiteId(700) ty=string intent=Read
-    bind BindingId(94) s site=SiteId(699) ty=Sink<string>
-    use BindingId(94) s site=SiteId(704) ty=Sink<string> intent=Read
-    use BindingId(94) s site=SiteId(708) ty=Sink<string> intent=Read
-    agg_alias BindingId(94) s site=SiteId(708) ty=Sink<string>
-    return site=Some(SiteId(698)) ty=Result<Sink<string>, string>
-    drop BindingId(94) s ty=Sink<string>
+    use BindingId(85) path site=SiteId(603) ty=string intent=Read
+    bind BindingId(86) s site=SiteId(602) ty=Sink<string>
+    use BindingId(86) s site=SiteId(607) ty=Sink<string> intent=Read
+    use BindingId(86) s site=SiteId(611) ty=Sink<string> intent=Read
+    agg_alias BindingId(86) s site=SiteId(611) ty=Sink<string>
+    return site=Some(SiteId(601)) ty=Result<Sink<string>, string>
+    drop BindingId(86) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1368,16 +1142,18 @@ fn stream$to_file -> Result<Sink<string>, string>
 
 fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
   statements:
-    use BindingId(95) path site=SiteId(715) ty=string intent=Read
-    bind BindingId(96) s site=SiteId(714) ty=Sink<string>
-    use BindingId(96) s site=SiteId(719) ty=Sink<string> intent=Read
-    use BindingId(96) s site=SiteId(723) ty=Sink<string> intent=Read
-    agg_alias BindingId(96) s site=SiteId(723) ty=Sink<string>
-    return site=Some(SiteId(713)) ty=Result<Sink<string>, fs.IoError>
-    bind BindingId(97) errno site=SiteId(725) ty=i32
-    eval site=SiteId(727) ty=string
-    use BindingId(97) errno site=SiteId(732) ty=i32 intent=Read
-    drop BindingId(96) s ty=Sink<string>
+    use BindingId(87) path site=SiteId(618) ty=string intent=Read
+    bind BindingId(88) s site=SiteId(617) ty=Sink<string>
+    use BindingId(88) s site=SiteId(622) ty=Sink<string> intent=Read
+    use BindingId(88) s site=SiteId(626) ty=Sink<string> intent=Read
+    agg_alias BindingId(88) s site=SiteId(626) ty=Sink<string>
+    return site=Some(SiteId(616)) ty=Result<Sink<string>, fs.IoError>
+    bind BindingId(89) kind site=SiteId(628) ty=i64
+    bind BindingId(90) errno site=SiteId(631) ty=i32
+    eval site=SiteId(633) ty=string
+    use BindingId(89) kind site=SiteId(637) ty=i64 intent=Read
+    use BindingId(90) errno site=SiteId(639) ty=i32 intent=Read
+    drop BindingId(88) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1389,24 +1165,26 @@ fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
       (none)
     goto[bb3->bb5] ->
       (none)
-    call[bb4 hew_stream_last_errno -> bb6] ->
+    call[bb4 hew_stream_last_error_kind -> bb6] ->
       (none)
     return[bb5] ->
       (none)
-    call[bb6 hew_stream_last_error -> bb7] ->
+    call[bb6 hew_stream_last_errno -> bb7] ->
       (none)
-    call[bb7 fs$io_error_from_errno -> bb8] ->
+    call[bb7 hew_stream_last_error -> bb8] ->
       (none)
-    goto[bb8->bb5] ->
+    call[bb8 fs$io_error_from_kind -> bb9] ->
       (none)
-    cancel[bb8] ->
+    goto[bb9->bb5] ->
+      (none)
+    cancel[bb9] ->
       (none)
 
 fn stream$forward -> ()
   statements:
-    use BindingId(98) source site=SiteId(736) ty=Stream<string> intent=Read
-    use BindingId(99) dest site=SiteId(737) ty=Sink<string> intent=Read
-    eval site=SiteId(734) ty=()
+    use BindingId(91) source site=SiteId(643) ty=Stream<string> intent=Read
+    use BindingId(92) dest site=SiteId(644) ty=Sink<string> intent=Read
+    eval site=SiteId(641) ty=()
   drop_plans:
     call[bb0 hew_stream_pipe -> bb1] ->
       (none)
@@ -1417,8 +1195,8 @@ fn stream$forward -> ()
 
 fn i8::fmt -> string
   statements:
-    use BindingId(108) val site=SiteId(809) ty=i8 intent=Read
-    return site=Some(SiteId(807)) ty=string
+    use BindingId(101) val site=SiteId(716) ty=i8 intent=Read
+    return site=Some(SiteId(714)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1429,8 +1207,8 @@ fn i8::fmt -> string
 
 fn i16::fmt -> string
   statements:
-    use BindingId(109) val site=SiteId(813) ty=i16 intent=Read
-    return site=Some(SiteId(811)) ty=string
+    use BindingId(102) val site=SiteId(720) ty=i16 intent=Read
+    return site=Some(SiteId(718)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1441,8 +1219,8 @@ fn i16::fmt -> string
 
 fn i32::fmt -> string
   statements:
-    use BindingId(110) val site=SiteId(816) ty=i32 intent=Read
-    return site=Some(SiteId(815)) ty=string
+    use BindingId(103) val site=SiteId(723) ty=i32 intent=Read
+    return site=Some(SiteId(722)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1453,8 +1231,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(111) val site=SiteId(819) ty=i64 intent=Read
-    return site=Some(SiteId(818)) ty=string
+    use BindingId(104) val site=SiteId(726) ty=i64 intent=Read
+    return site=Some(SiteId(725)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1465,8 +1243,8 @@ fn i64::fmt -> string
 
 fn u8::fmt -> string
   statements:
-    use BindingId(112) val site=SiteId(822) ty=u8 intent=Read
-    return site=Some(SiteId(821)) ty=string
+    use BindingId(105) val site=SiteId(729) ty=u8 intent=Read
+    return site=Some(SiteId(728)) ty=string
   drop_plans:
     call[bb0 to_string_u8 -> bb1] ->
       (none)
@@ -1477,8 +1255,8 @@ fn u8::fmt -> string
 
 fn u16::fmt -> string
   statements:
-    use BindingId(113) val site=SiteId(825) ty=u16 intent=Read
-    return site=Some(SiteId(824)) ty=string
+    use BindingId(106) val site=SiteId(732) ty=u16 intent=Read
+    return site=Some(SiteId(731)) ty=string
   drop_plans:
     call[bb0 to_string_u16 -> bb1] ->
       (none)
@@ -1489,8 +1267,8 @@ fn u16::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(114) val site=SiteId(828) ty=u32 intent=Read
-    return site=Some(SiteId(827)) ty=string
+    use BindingId(107) val site=SiteId(735) ty=u32 intent=Read
+    return site=Some(SiteId(734)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -1501,8 +1279,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(115) val site=SiteId(831) ty=u64 intent=Read
-    return site=Some(SiteId(830)) ty=string
+    use BindingId(108) val site=SiteId(738) ty=u64 intent=Read
+    return site=Some(SiteId(737)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1513,8 +1291,8 @@ fn u64::fmt -> string
 
 fn isize::fmt -> string
   statements:
-    use BindingId(116) val site=SiteId(835) ty=isize intent=Read
-    return site=Some(SiteId(833)) ty=string
+    use BindingId(109) val site=SiteId(742) ty=isize intent=Read
+    return site=Some(SiteId(740)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1525,8 +1303,8 @@ fn isize::fmt -> string
 
 fn usize::fmt -> string
   statements:
-    use BindingId(117) val site=SiteId(839) ty=usize intent=Read
-    return site=Some(SiteId(837)) ty=string
+    use BindingId(110) val site=SiteId(746) ty=usize intent=Read
+    return site=Some(SiteId(744)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1537,8 +1315,8 @@ fn usize::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(118) val site=SiteId(842) ty=bool intent=Read
-    return site=Some(SiteId(841)) ty=string
+    use BindingId(111) val site=SiteId(749) ty=bool intent=Read
+    return site=Some(SiteId(748)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -1549,8 +1327,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(119) val site=SiteId(845) ty=char intent=Read
-    return site=Some(SiteId(844)) ty=string
+    use BindingId(112) val site=SiteId(752) ty=char intent=Read
+    return site=Some(SiteId(751)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -1561,8 +1339,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(120) val site=SiteId(848) ty=f64 intent=Read
-    return site=Some(SiteId(847)) ty=string
+    use BindingId(113) val site=SiteId(755) ty=f64 intent=Read
+    return site=Some(SiteId(754)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1573,8 +1351,8 @@ fn f64::fmt -> string
 
 fn f32::fmt -> string
   statements:
-    use BindingId(121) val site=SiteId(852) ty=f32 intent=Read
-    return site=Some(SiteId(850)) ty=string
+    use BindingId(114) val site=SiteId(759) ty=f32 intent=Read
+    return site=Some(SiteId(757)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1585,16 +1363,16 @@ fn f32::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(122) val site=SiteId(854) ty=string intent=Read
-    return site=Some(SiteId(854)) ty=string
+    use BindingId(115) val site=SiteId(761) ty=string intent=Read
+    return site=Some(SiteId(761)) ty=string
   drop_plans:
     return[bb0] ->
       (none)
 
 fn duration::from_nanos -> duration
   statements:
-    use BindingId(123) n site=SiteId(856) ty=i64 intent=Read
-    return site=Some(SiteId(855)) ty=duration
+    use BindingId(116) n site=SiteId(763) ty=i64 intent=Read
+    return site=Some(SiteId(762)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1605,8 +1383,8 @@ fn duration::from_nanos -> duration
 
 fn duration::from_micros -> duration
   statements:
-    use BindingId(124) n site=SiteId(859) ty=i64 intent=Read
-    return site=Some(SiteId(858)) ty=duration
+    use BindingId(117) n site=SiteId(766) ty=i64 intent=Read
+    return site=Some(SiteId(765)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1617,8 +1395,8 @@ fn duration::from_micros -> duration
 
 fn duration::from_millis -> duration
   statements:
-    use BindingId(125) n site=SiteId(862) ty=i64 intent=Read
-    return site=Some(SiteId(861)) ty=duration
+    use BindingId(118) n site=SiteId(769) ty=i64 intent=Read
+    return site=Some(SiteId(768)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1629,8 +1407,8 @@ fn duration::from_millis -> duration
 
 fn duration::from_secs -> duration
   statements:
-    use BindingId(126) n site=SiteId(865) ty=i64 intent=Read
-    return site=Some(SiteId(864)) ty=duration
+    use BindingId(119) n site=SiteId(772) ty=i64 intent=Read
+    return site=Some(SiteId(771)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1641,8 +1419,8 @@ fn duration::from_secs -> duration
 
 fn duration::fmt -> string
   statements:
-    use BindingId(127) val site=SiteId(870) ty=duration intent=Read
-    return site=Some(SiteId(867)) ty=string
+    use BindingId(120) val site=SiteId(777) ty=duration intent=Read
+    return site=Some(SiteId(774)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)

--- a/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_pipe_send_recv.raw.mir
@@ -189,32 +189,35 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     _11: i64
     _12: IoError
     _13: IoError
-    _14: i64
-    _15: bool
-    _16: IoError
+    _14: bool
+    _15: i64
+    _16: bool
     _17: i64
-    _18: IoError
+    _18: bool
     _19: IoError
-    _20: bool
-    _21: i64
-    _22: bool
-    _23: i64
-    _24: bool
-    _25: IoError
+    _20: i64
+    _21: IoError
+    _22: IoError
+    _23: bool
+    _24: i64
+    _25: bool
     _26: i64
-    _27: IoError
+    _27: bool
     _28: IoError
-    _29: bool
-    _30: i64
-    _31: bool
-    _32: i64
-    _33: bool
-    _34: IoError
+    _29: i64
+    _30: IoError
+    _31: IoError
+    _32: bool
+    _33: i64
+    _34: bool
     _35: i64
-    _36: IoError
+    _36: bool
     _37: IoError
     _38: i64
     _39: IoError
+    _40: IoError
+    _41: i64
+    _42: IoError
   bb0:
     stmt: use BindingId(11) errno site=SiteId(58) ty=i64 intent=Read
     _2 = const.i64 2
@@ -246,82 +249,194 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     _7 = move _12
     goto bb6
   bb5:
-    stmt: use BindingId(11) errno site=SiteId(72) ty=i64 intent=Read
-    _14 = const.i64 17
-    _15 = icmp.eq _0 _14
-    branch _15 ? bb7 : bb8
+    stmt: use BindingId(11) errno site=SiteId(73) ty=i64 intent=Read
+    _14 = const.i64 1
+    _15 = const.i64 17
+    _16 = icmp.eq _0 _15
+    branch _16 ? bb8 : bb7
   bb6:
     _1 = move _7
     goto bb3
   bb7:
     stmt: use BindingId(11) errno site=SiteId(76) ty=i64 intent=Read
-    _17 = const.i64 2
-    mtag16 = move _17
-    mvar16.2.0 = move _0
-    _18 = move _16
-    _13 = move _18
-    goto bb9
+    _17 = const.i64 183
+    _18 = icmp.eq _0 _17
+    _14 = move _18
+    goto bb8
   bb8:
-    stmt: use BindingId(11) errno site=SiteId(80) ty=i64 intent=Read
-    _20 = const.i64 1
-    _21 = const.i64 110
-    _22 = icmp.eq _0 _21
-    branch _22 ? bb11 : bb10
+    branch _14 ? bb9 : bb10
   bb9:
+    stmt: use BindingId(11) errno site=SiteId(80) ty=i64 intent=Read
+    _20 = const.i64 2
+    mtag19 = move _20
+    mvar19.2.0 = move _0
+    _21 = move _19
+    _13 = move _21
+    goto bb11
+  bb10:
+    stmt: use BindingId(11) errno site=SiteId(84) ty=i64 intent=Read
+    _23 = const.i64 1
+    _24 = const.i64 110
+    _25 = icmp.eq _0 _24
+    branch _25 ? bb13 : bb12
+  bb11:
     _7 = move _13
     goto bb6
-  bb10:
-    stmt: use BindingId(11) errno site=SiteId(83) ty=i64 intent=Read
-    _23 = const.i64 60
-    _24 = icmp.eq _0 _23
-    _20 = move _24
-    goto bb11
-  bb11:
-    branch _20 ? bb12 : bb13
   bb12:
     stmt: use BindingId(11) errno site=SiteId(87) ty=i64 intent=Read
-    _26 = const.i64 3
-    mtag25 = move _26
-    mvar25.3.0 = move _0
-    _27 = move _25
-    _19 = move _27
-    goto bb14
+    _26 = const.i64 60
+    _27 = icmp.eq _0 _26
+    _23 = move _27
+    goto bb13
   bb13:
-    stmt: use BindingId(11) errno site=SiteId(91) ty=i64 intent=Read
-    _29 = const.i64 1
-    _30 = const.i64 125
-    _31 = icmp.eq _0 _30
-    branch _31 ? bb16 : bb15
+    branch _23 ? bb14 : bb15
   bb14:
-    _13 = move _19
-    goto bb9
-  bb15:
-    stmt: use BindingId(11) errno site=SiteId(94) ty=i64 intent=Read
-    _32 = const.i64 89
-    _33 = icmp.eq _0 _32
-    _29 = move _33
+    stmt: use BindingId(11) errno site=SiteId(91) ty=i64 intent=Read
+    _29 = const.i64 3
+    mtag28 = move _29
+    mvar28.3.0 = move _0
+    _30 = move _28
+    _22 = move _30
     goto bb16
+  bb15:
+    stmt: use BindingId(11) errno site=SiteId(95) ty=i64 intent=Read
+    _32 = const.i64 1
+    _33 = const.i64 125
+    _34 = icmp.eq _0 _33
+    branch _34 ? bb18 : bb17
   bb16:
-    branch _29 ? bb17 : bb18
+    _13 = move _22
+    goto bb11
   bb17:
     stmt: use BindingId(11) errno site=SiteId(98) ty=i64 intent=Read
-    _35 = const.i64 4
-    mtag34 = move _35
-    mvar34.4.0 = move _0
-    _36 = move _34
-    _28 = move _36
-    goto bb19
+    _35 = const.i64 89
+    _36 = icmp.eq _0 _35
+    _32 = move _36
+    goto bb18
   bb18:
-    stmt: use BindingId(11) errno site=SiteId(101) ty=i64 intent=Read
-    _38 = const.i64 5
-    mtag37 = move _38
-    mvar37.5.0 = move _0
-    _39 = move _37
-    _28 = move _39
-    goto bb19
+    branch _32 ? bb19 : bb20
   bb19:
-    _19 = move _28
-    goto bb14
+    stmt: use BindingId(11) errno site=SiteId(102) ty=i64 intent=Read
+    _38 = const.i64 4
+    mtag37 = move _38
+    mvar37.4.0 = move _0
+    _39 = move _37
+    _31 = move _39
+    goto bb21
+  bb20:
+    stmt: use BindingId(11) errno site=SiteId(105) ty=i64 intent=Read
+    _41 = const.i64 5
+    mtag40 = move _41
+    mvar40.5.0 = move _0
+    _42 = move _40
+    _31 = move _42
+    goto bb21
+  bb21:
+    _22 = move _31
+    goto bb16
+
+fn fs$io_error_from_kind(i64, i64) -> IoError [conv=default]
+  locals:
+    _0: i64
+    _1: i64
+    _2: IoError
+    _3: i64
+    _4: bool
+    _5: IoError
+    _6: i64
+    _7: IoError
+    _8: IoError
+    _9: i64
+    _10: bool
+    _11: IoError
+    _12: i64
+    _13: IoError
+    _14: IoError
+    _15: i64
+    _16: bool
+    _17: IoError
+    _18: i64
+    _19: IoError
+    _20: IoError
+    _21: i64
+    _22: bool
+    _23: IoError
+    _24: i64
+    _25: IoError
+    _26: IoError
+    _27: IoError
+  bb0:
+    stmt: use BindingId(12) kind site=SiteId(108) ty=i64 intent=Read
+    _3 = const.i64 1
+    _4 = icmp.eq _0 _3
+    branch _4 ? bb1 : bb2
+  bb1:
+    stmt: use BindingId(13) errno site=SiteId(112) ty=i64 intent=Read
+    _6 = const.i64 0
+    mtag5 = move _6
+    mvar5.0.0 = move _1
+    _7 = move _5
+    _2 = move _7
+    goto bb3
+  bb2:
+    stmt: use BindingId(12) kind site=SiteId(115) ty=i64 intent=Read
+    _9 = const.i64 2
+    _10 = icmp.eq _0 _9
+    branch _10 ? bb4 : bb5
+  bb3:
+    stmt: return site=Some(SiteId(106)) ty=IoError
+    ret = move _2
+    return
+  bb4:
+    stmt: use BindingId(13) errno site=SiteId(119) ty=i64 intent=Read
+    _12 = const.i64 1
+    mtag11 = move _12
+    mvar11.1.0 = move _1
+    _13 = move _11
+    _8 = move _13
+    goto bb6
+  bb5:
+    stmt: use BindingId(12) kind site=SiteId(122) ty=i64 intent=Read
+    _15 = const.i64 3
+    _16 = icmp.eq _0 _15
+    branch _16 ? bb7 : bb8
+  bb6:
+    _2 = move _8
+    goto bb3
+  bb7:
+    stmt: use BindingId(13) errno site=SiteId(126) ty=i64 intent=Read
+    _18 = const.i64 2
+    mtag17 = move _18
+    mvar17.2.0 = move _1
+    _19 = move _17
+    _14 = move _19
+    goto bb9
+  bb8:
+    stmt: use BindingId(12) kind site=SiteId(129) ty=i64 intent=Read
+    _21 = const.i64 4
+    _22 = icmp.eq _0 _21
+    branch _22 ? bb10 : bb11
+  bb9:
+    _8 = move _14
+    goto bb6
+  bb10:
+    stmt: use BindingId(13) errno site=SiteId(133) ty=i64 intent=Read
+    _24 = const.i64 3
+    mtag23 = move _24
+    mvar23.3.0 = move _1
+    _25 = move _23
+    _20 = move _25
+    goto bb12
+  bb11:
+    stmt: use BindingId(13) errno site=SiteId(136) ty=i64 intent=Read
+    _26 = call fs$io_error_from_errno(_1) -> bb13
+  bb12:
+    _14 = move _20
+    goto bb9
+  bb13:
+    _27 = move _26
+    _20 = move _27
+    goto bb12
 
 fn fs$io_error_message(IoError) -> string [conv=default]
   locals:
@@ -377,48 +492,48 @@ fn fs$io_error_message(IoError) -> string [conv=default]
     _49: string
     _50: string
   bb0:
-    stmt: use BindingId(12) e site=SiteId(103) ty=IoError intent=Read
+    stmt: use BindingId(14) e site=SiteId(139) ty=IoError intent=Read
     _2 = move etag0
     _3 = const.i64 0
     _4 = icmp.eq _2 _3
     branch _4 ? bb2 : bb9
   bb1:
-    stmt: return site=Some(SiteId(102)) ty=string
+    stmt: return site=Some(SiteId(138)) ty=string
     ret = move _1
     return
   bb2:
-    stmt: bind BindingId(13) code site=SiteId(104) ty=i64
-    stmt: use BindingId(13) code site=SiteId(106) ty=i64 intent=Read
+    stmt: bind BindingId(15) code site=SiteId(140) ty=i64
+    stmt: use BindingId(15) code site=SiteId(142) ty=i64 intent=Read
     _15 = move mvar0.0.0
     _16 = string_lit "NotFound("
     _17 = call to_string_i64(_15) -> bb14
   bb3:
-    stmt: bind BindingId(14) code site=SiteId(114) ty=i64
-    stmt: use BindingId(14) code site=SiteId(116) ty=i64 intent=Read
+    stmt: bind BindingId(16) code site=SiteId(150) ty=i64
+    stmt: use BindingId(16) code site=SiteId(152) ty=i64 intent=Read
     _21 = move mvar0.1.0
     _22 = string_lit "PermissionDenied("
     _23 = call to_string_i64(_21) -> bb17
   bb4:
-    stmt: bind BindingId(15) code site=SiteId(124) ty=i64
-    stmt: use BindingId(15) code site=SiteId(126) ty=i64 intent=Read
+    stmt: bind BindingId(17) code site=SiteId(160) ty=i64
+    stmt: use BindingId(17) code site=SiteId(162) ty=i64 intent=Read
     _27 = move mvar0.2.0
     _28 = string_lit "AlreadyExists("
     _29 = call to_string_i64(_27) -> bb20
   bb5:
-    stmt: bind BindingId(16) code site=SiteId(134) ty=i64
-    stmt: use BindingId(16) code site=SiteId(136) ty=i64 intent=Read
+    stmt: bind BindingId(18) code site=SiteId(170) ty=i64
+    stmt: use BindingId(18) code site=SiteId(172) ty=i64 intent=Read
     _33 = move mvar0.3.0
     _34 = string_lit "TimedOut("
     _35 = call to_string_i64(_33) -> bb23
   bb6:
-    stmt: bind BindingId(17) code site=SiteId(144) ty=i64
-    stmt: use BindingId(17) code site=SiteId(146) ty=i64 intent=Read
+    stmt: bind BindingId(19) code site=SiteId(180) ty=i64
+    stmt: use BindingId(19) code site=SiteId(182) ty=i64 intent=Read
     _39 = move mvar0.4.0
     _40 = string_lit "Cancelled("
     _41 = call to_string_i64(_39) -> bb26
   bb7:
-    stmt: bind BindingId(18) code site=SiteId(154) ty=i64
-    stmt: use BindingId(18) code site=SiteId(156) ty=i64 intent=Read
+    stmt: bind BindingId(20) code site=SiteId(190) ty=i64
+    stmt: use BindingId(20) code site=SiteId(192) ty=i64 intent=Read
     _45 = move mvar0.5.0
     _46 = string_lit "Other("
     _47 = call to_string_i64(_45) -> bb29
@@ -511,7 +626,7 @@ fn fs$io_error_timed_out() -> IoError [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: return site=Some(SiteId(164)) ty=IoError
+    stmt: return site=Some(SiteId(200)) ty=IoError
     _1 = const.i64 3
     mtag0 = move _1
     _2 = const.i64 0
@@ -525,7 +640,7 @@ fn fs$io_error_cancelled() -> IoError [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: return site=Some(SiteId(166)) ty=IoError
+    stmt: return site=Some(SiteId(202)) ty=IoError
     _1 = const.i64 4
     mtag0 = move _1
     _2 = const.i64 0
@@ -533,553 +648,76 @@ fn fs$io_error_cancelled() -> IoError [conv=default]
     ret = move _0
     return
 
-fn fs$missing_parent(string) -> bool [conv=default]
+fn fs$last_io_error() -> IoError [conv=default]
   locals:
-    _0: string
-    _1: string
-    _2: string
-    _3: bool
-    _4: string
-    _5: bool
-    _6: bool
-    _7: bool
-  bb0:
-    stmt: use BindingId(19) target site=SiteId(169) ty=string intent=Read
-    _1 = call fs$dirname(_0) -> bb1
-  bb1:
-    stmt: bind BindingId(20) parent site=SiteId(168) ty=string
-    stmt: use BindingId(20) parent site=SiteId(173) ty=string intent=Read
-    _2 = move _1
-    _3 = const.i64 0
-    _4 = string_lit ""
-    _5 = icmp.ne _2 _4
-    branch _5 ? bb2 : bb3
-  bb2:
-    stmt: use BindingId(20) parent site=SiteId(177) ty=string intent=Read
-    _6 = call fs$exists(_2) -> bb4
-  bb3:
-    stmt: return site=Some(SiteId(171)) ty=bool
-    ret = move _3
-    return
-  bb4:
-    _7 = not _6
-    _3 = move _7
-    goto bb3
-
-fn fs$dirname(string) -> string [conv=default]
-  locals:
-    _0: string
-    _1: string
-    _2: string
-    _3: i64
+    _0: i32
+    _1: i64
+    _2: i64
+    _3: i32
     _4: i64
-    _5: ()
-    _6: i64
-    _7: bool
-    _8: string
-    _9: ()
-    _10: i64
-    _11: bool
-    _12: string
-    _13: i64
-    _14: string
-  bb0:
-    stmt: use BindingId(21) p site=SiteId(180) ty=string intent=Read
-    _1 = call fs$strip_trailing_slash(_0) -> bb1
-  bb1:
-    stmt: bind BindingId(22) s site=SiteId(179) ty=string
-    stmt: use BindingId(22) s site=SiteId(183) ty=string intent=Read
-    _2 = move _1
-    _3 = call fs$last_slash_pos(_2) -> bb2
-  bb2:
-    stmt: bind BindingId(23) pos site=SiteId(182) ty=i64
-    stmt: use BindingId(23) pos site=SiteId(186) ty=i64 intent=Read
-    _4 = move _3
-    _6 = const.i64 0
-    _7 = icmp.slt _4 _6
-    branch _7 ? bb3 : bb4
-  bb3:
-    stmt: return site=Some(SiteId(188)) ty=string
-    _8 = string_lit ""
-    ret = move _8
-    return
-  bb4:
-    goto bb5
-  bb5:
-    stmt: eval site=SiteId(190) ty=()
-    stmt: use BindingId(23) pos site=SiteId(192) ty=i64 intent=Read
-    _10 = const.i64 0
-    _11 = icmp.eq _4 _10
-    branch _11 ? bb7 : bb8
-  bb6:
-    goto bb5
-  bb7:
-    stmt: return site=Some(SiteId(194)) ty=string
-    _12 = string_lit "/"
-    ret = move _12
-    return
-  bb8:
-    goto bb9
-  bb9:
-    stmt: eval site=SiteId(196) ty=()
-    stmt: use BindingId(22) s site=SiteId(198) ty=string intent=Read
-    stmt: use BindingId(23) pos site=SiteId(200) ty=i64 intent=Read
-    _13 = const.i64 0
-    _14 = call hew_string_slice(_2, _13, _4) -> bb11
-  bb10:
-    goto bb9
-  bb11:
-    stmt: return site=Some(SiteId(197)) ty=string
-    ret = move _14
-    return
-
-fn fs$strip_trailing_slash(string) -> string [conv=default]
-  locals:
-    _0: string
-    _1: ()
-    _2: string
-    _3: bool
-    _4: string
-    _5: string
-    _6: ()
-    _7: bool
-    _8: i64
+    _5: i64
+    _6: string
+    _7: IoError
+    _8: bool
     _9: i64
     _10: bool
-    _11: string
+    _11: i64
     _12: bool
-    _13: i64
-    _14: i64
-    _15: i64
-    _16: i64
-    _17: bool
-    _18: string
-    _19: string
-    _20: string
-  bb0:
-    stmt: use BindingId(24) p site=SiteId(203) ty=string intent=Read
-    _2 = string_lit "/"
-    _3 = icmp.eq _0 _2
-    branch _3 ? bb1 : bb2
-  bb1:
-    stmt: use BindingId(24) p site=SiteId(207) ty=string intent=Read
-    stmt: return site=Some(SiteId(205)) ty=string
-    _4 = string_lit ""
-    _5 = call_rt hew_string_concat(_4, _0)
-    ret = move _5
-    return
-  bb2:
-    goto bb3
-  bb3:
-    stmt: eval site=SiteId(209) ty=()
-    stmt: use BindingId(24) p site=SiteId(213) ty=string intent=Read
-    _7 = const.i64 0
-    _8 = call hew_string_length(_0) -> bb5
-  bb4:
-    goto bb3
-  bb5:
-    _9 = const.i64 1
-    _10 = icmp.sgt _8 _9
-    branch _10 ? bb6 : bb7
-  bb6:
-    stmt: use BindingId(24) p site=SiteId(217) ty=string intent=Read
-    _11 = string_lit "/"
-    _12 = call hew_string_ends_with(_0, _11) -> bb8
-  bb7:
-    branch _7 ? bb9 : bb10
-  bb8:
-    _7 = move _12
-    goto bb7
-  bb9:
-    stmt: use BindingId(24) p site=SiteId(221) ty=string intent=Read
-    stmt: use BindingId(24) p site=SiteId(225) ty=string intent=Read
-    _13 = const.i64 0
-    _14 = call hew_string_length(_0) -> bb12
-  bb10:
-    goto bb11
-  bb11:
-    stmt: eval site=SiteId(230) ty=()
-    stmt: use BindingId(24) p site=SiteId(233) ty=string intent=Read
-    stmt: return site=Some(SiteId(231)) ty=string
-    _19 = string_lit ""
-    _20 = call_rt hew_string_concat(_19, _0)
-    ret = move _20
-    return
-  bb12:
-    _15 = const.i64 1
-    _16 ovf=_17 = sub.checked.s _14 _15
-    branch _17 ? bb13 : bb14
-  bb13:
-    trap(IntegerOverflow)
-  bb14:
-    _18 = call hew_string_slice(_0, _13, _16) -> bb15
-  bb15:
-    stmt: return site=Some(SiteId(220)) ty=string
-    ret = move _18
-    return
-  bb16:
-    goto bb11
-
-fn fs$last_slash_pos(string) -> i64 [conv=default]
-  locals:
-    _0: string
-    _1: i64
-    _2: string
-    _3: Option<i64>
-    _4: i64
-    _5: i64
-    _6: bool
-    _7: i64
-    _8: bool
-    _9: i64
-    _10: i64
-    _11: i64
-    _12: i64
-    _13: i64
-    _14: i64
-    _15: bool
-    _16: i64
-    _17: i64
-    _18: bool
-    _19: i64
-    _20: string
-    _21: string
-    _22: i64
-    _23: string
-    _24: Option<i64>
-    _25: i64
-    _26: i64
-    _27: bool
-    _28: i64
-    _29: bool
-    _30: i64
-    _31: i64
-    _32: i64
-    _33: bool
-    _34: i64
-    _35: i64
-    _36: bool
-  bb0:
-    stmt: use BindingId(25) s site=SiteId(236) ty=string intent=Read
-    _2 = string_lit "/"
-    _3 = call hew_string_find(_0, _2) -> bb1
-  bb1:
-    _4 = move etag3
-    _5 = const.i64 0
-    _6 = icmp.eq _4 _5
-    branch _6 ? bb3 : bb6
-  bb2:
-    stmt: bind BindingId(27) first site=SiteId(234) ty=i64
-    stmt: use BindingId(27) first site=SiteId(242) ty=i64 intent=Consume
-    stmt: bind BindingId(28) last site=SiteId(242) ty=i64
-    stmt: use BindingId(27) first site=SiteId(244) ty=i64 intent=Read
-    _11 = move _1
-    _12 = move _11
-    _13 = const.i64 1
-    _14 ovf=_15 = add.checked.s _11 _13
-    branch _15 ? bb8 : bb9
-  bb3:
-    stmt: bind BindingId(26) i site=SiteId(239) ty=i64
-    stmt: use BindingId(26) i site=SiteId(239) ty=i64 intent=Read
-    _9 = move mvar3.0.0
-    _1 = move _9
-    goto bb2
-  bb4:
-    stmt: return site=Some(SiteId(241)) ty=i64
-    _10 = const.i64 -1
-    ret = move _10
-    return
-  bb5:
-    trap(ExhaustivenessFallthrough)
-  bb6:
-    _7 = const.i64 1
-    _8 = icmp.eq _4 _7
-    branch _8 ? bb4 : bb5
-  bb7:
-    goto bb2
-  bb8:
-    trap(IntegerOverflow)
-  bb9:
-    stmt: bind BindingId(29) search_from site=SiteId(243) ty=i64
-    _16 = move _14
-    goto bb10
-  bb10:
-    stmt: use BindingId(29) search_from site=SiteId(247) ty=i64 intent=Read
-    stmt: use BindingId(25) s site=SiteId(249) ty=string intent=Read
-    _17 = call hew_string_length(_0) -> bb13
-  bb11:
-    stmt: use BindingId(25) s site=SiteId(252) ty=string intent=Read
-    stmt: use BindingId(29) search_from site=SiteId(253) ty=i64 intent=Read
-    stmt: use BindingId(25) s site=SiteId(255) ty=string intent=Read
-    _19 = call hew_string_length(_0) -> bb14
-  bb12:
-    stmt: eval site=SiteId(274) ty=()
-    stmt: use BindingId(28) last site=SiteId(275) ty=i64 intent=Read
-    stmt: return site=Some(SiteId(275)) ty=i64
-    ret = move _12
-    return
-  bb13:
-    _18 = icmp.slt _16 _17
-    branch _18 ? bb11 : bb12
-  bb14:
-    _20 = call hew_string_slice(_0, _16, _19) -> bb15
-  bb15:
-    stmt: bind BindingId(30) rest site=SiteId(251) ty=string
-    stmt: use BindingId(30) rest site=SiteId(260) ty=string intent=Read
-    _21 = move _20
-    _23 = string_lit "/"
-    _24 = call hew_string_find(_21, _23) -> bb16
-  bb16:
-    _25 = move etag24
-    _26 = const.i64 0
-    _27 = icmp.eq _25 _26
-    branch _27 ? bb18 : bb21
-  bb17:
-    stmt: bind BindingId(32) next site=SiteId(258) ty=i64
-    stmt: use BindingId(29) search_from site=SiteId(268) ty=i64 intent=Read
-    stmt: use BindingId(32) next site=SiteId(269) ty=i64 intent=Read
-    _31 = move _22
-    _32 ovf=_33 = add.checked.s _16 _31
-    branch _33 ? bb23 : bb24
-  bb18:
-    stmt: bind BindingId(31) i site=SiteId(263) ty=i64
-    stmt: use BindingId(31) i site=SiteId(263) ty=i64 intent=Read
-    _30 = move mvar24.0.0
-    _22 = move _30
-    goto bb17
-  bb19:
-    stmt: use BindingId(28) last site=SiteId(265) ty=i64 intent=Consume
-    stmt: return site=Some(SiteId(265)) ty=i64
-    ret = move _12
-    return
-  bb20:
-    trap(ExhaustivenessFallthrough)
-  bb21:
-    _28 = const.i64 1
-    _29 = icmp.eq _25 _28
-    branch _29 ? bb19 : bb20
-  bb22:
-    goto bb17
-  bb23:
-    trap(IntegerOverflow)
-  bb24:
-    stmt: bind BindingId(28) last site=SiteId(266) ty=i64
-    stmt: eval site=SiteId(267) ty=()
-    stmt: use BindingId(28) last site=SiteId(272) ty=i64 intent=Read
-    _12 = move _32
-    _34 = const.i64 1
-    _35 ovf=_36 = add.checked.s _12 _34
-    branch _36 ? bb25 : bb26
-  bb25:
-    trap(IntegerOverflow)
-  bb26:
-    stmt: bind BindingId(29) search_from site=SiteId(270) ty=i64
-    stmt: eval site=SiteId(271) ty=()
-    _16 = move _35
-    goto bb10
-
-fn fs$write_error(string) -> IoError [conv=default]
-  locals:
-    _0: string
-    _1: IoError
-    _2: bool
-    _3: IoError
-    _4: i64
-    _5: i64
-    _6: IoError
-    _7: IoError
-    _8: i64
-    _9: i64
-    _10: IoError
-  bb0:
-    stmt: use BindingId(33) target site=SiteId(278) ty=string intent=Read
-    _2 = call fs$missing_parent(_0) -> bb1
-  bb1:
-    branch _2 ? bb2 : bb3
-  bb2:
-    _4 = const.i64 0
-    mtag3 = move _4
-    _5 = const.i64 0
-    mvar3.0.0 = move _5
-    _6 = move _3
-    _1 = move _6
-    goto bb4
-  bb3:
-    _8 = const.i64 5
-    mtag7 = move _8
-    _9 = const.i64 0
-    mvar7.5.0 = move _9
-    _10 = move _7
-    _1 = move _10
-    goto bb4
-  bb4:
-    stmt: return site=Some(SiteId(276)) ty=IoError
-    ret = move _1
-    return
-
-fn fs$missing_path_error(string) -> IoError [conv=default]
-  locals:
-    _0: string
-    _1: IoError
-    _2: bool
-    _3: IoError
-    _4: i64
-    _5: i64
-    _6: IoError
-    _7: IoError
-    _8: i64
-    _9: i64
-    _10: IoError
-  bb0:
-    stmt: use BindingId(34) target site=SiteId(288) ty=string intent=Read
-    _2 = call fs$exists(_0) -> bb1
-  bb1:
-    branch _2 ? bb2 : bb3
-  bb2:
-    _4 = const.i64 5
-    mtag3 = move _4
-    _5 = const.i64 0
-    mvar3.5.0 = move _5
-    _6 = move _3
-    _1 = move _6
-    goto bb4
-  bb3:
-    _8 = const.i64 0
-    mtag7 = move _8
-    _9 = const.i64 0
-    mvar7.0.0 = move _9
-    _10 = move _7
-    _1 = move _10
-    goto bb4
-  bb4:
-    stmt: return site=Some(SiteId(286)) ty=IoError
-    ret = move _1
-    return
-
-fn fs$mkdir_error(string) -> IoError [conv=default]
-  locals:
-    _0: string
-    _1: IoError
-    _2: bool
-    _3: IoError
-    _4: i64
-    _5: i64
-    _6: IoError
-    _7: IoError
-    _8: bool
-    _9: IoError
-    _10: i64
-    _11: i64
-    _12: IoError
     _13: IoError
     _14: i64
     _15: i64
     _16: IoError
+    _17: IoError
+    _18: IoError
+    _19: IoError
   bb0:
-    stmt: use BindingId(35) target site=SiteId(298) ty=string intent=Read
-    _2 = call fs$exists(_0) -> bb1
+    _0 = call hew_stream_last_error_kind() -> bb1
   bb1:
-    branch _2 ? bb2 : bb3
+    stmt: bind BindingId(21) kind site=SiteId(205) ty=i64
+    _1 = cast _0 i32 -> i64
+    _2 = move _1
+    _3 = call hew_stream_last_errno() -> bb2
   bb2:
-    _4 = const.i64 2
-    mtag3 = move _4
-    _5 = const.i64 0
-    mvar3.2.0 = move _5
-    _6 = move _3
-    _1 = move _6
-    goto bb4
+    stmt: bind BindingId(22) errno site=SiteId(208) ty=i64
+    _4 = cast _3 i32 -> i64
+    _5 = move _4
+    _6 = call hew_stream_last_error() -> bb3
   bb3:
-    stmt: use BindingId(35) target site=SiteId(305) ty=string intent=Read
-    _8 = call fs$missing_parent(_0) -> bb5
+    stmt: eval site=SiteId(211) ty=string
+    stmt: use BindingId(22) errno site=SiteId(216) ty=i64 intent=Read
+    _8 = const.i64 0
+    _9 = const.i64 0
+    _10 = icmp.eq _5 _9
+    branch _10 ? bb4 : bb5
   bb4:
-    stmt: return site=Some(SiteId(296)) ty=IoError
-    ret = move _1
-    return
+    stmt: use BindingId(21) kind site=SiteId(219) ty=i64 intent=Read
+    _11 = const.i64 0
+    _12 = icmp.eq _2 _11
+    _8 = move _12
+    goto bb5
   bb5:
     branch _8 ? bb6 : bb7
   bb6:
-    _10 = const.i64 0
-    mtag9 = move _10
-    _11 = const.i64 0
-    mvar9.0.0 = move _11
-    _12 = move _9
-    _7 = move _12
-    goto bb8
-  bb7:
     _14 = const.i64 5
     mtag13 = move _14
-    _15 = const.i64 0
+    _15 = const.i64 5
     mvar13.5.0 = move _15
     _16 = move _13
     _7 = move _16
     goto bb8
-  bb8:
-    _1 = move _7
-    goto bb4
-
-fn fs$move_copy_error(string, string) -> IoError [conv=default]
-  locals:
-    _0: string
-    _1: string
-    _2: IoError
-    _3: bool
-    _4: bool
-    _5: IoError
-    _6: i64
-    _7: i64
-    _8: IoError
-    _9: IoError
-    _10: bool
-    _11: IoError
-    _12: i64
-    _13: i64
-    _14: IoError
-    _15: IoError
-    _16: i64
-    _17: i64
-    _18: IoError
-  bb0:
-    stmt: use BindingId(36) source site=SiteId(316) ty=string intent=Read
-    _3 = call fs$exists(_0) -> bb1
-  bb1:
-    _4 = not _3
-    branch _4 ? bb2 : bb3
-  bb2:
-    _6 = const.i64 0
-    mtag5 = move _6
-    _7 = const.i64 0
-    mvar5.0.0 = move _7
-    _8 = move _5
-    _2 = move _8
-    goto bb4
-  bb3:
-    stmt: use BindingId(37) target site=SiteId(323) ty=string intent=Read
-    _10 = call fs$missing_parent(_1) -> bb5
-  bb4:
-    stmt: return site=Some(SiteId(313)) ty=IoError
-    ret = move _2
-    return
-  bb5:
-    branch _10 ? bb6 : bb7
-  bb6:
-    _12 = const.i64 0
-    mtag11 = move _12
-    _13 = const.i64 0
-    mvar11.0.0 = move _13
-    _14 = move _11
-    _9 = move _14
-    goto bb8
   bb7:
-    _16 = const.i64 5
-    mtag15 = move _16
-    _17 = const.i64 0
-    mvar15.5.0 = move _17
-    _18 = move _15
-    _9 = move _18
-    goto bb8
+    stmt: use BindingId(21) kind site=SiteId(226) ty=i64 intent=Read
+    stmt: use BindingId(22) errno site=SiteId(227) ty=i64 intent=Read
+    _17 = call fs$io_error_from_kind(_2, _5) -> bb9
   bb8:
-    _2 = move _9
-    goto bb4
+    stmt: return site=Some(SiteId(204)) ty=IoError
+    _19 = move _7
+    ret = move _19
+    return
+  bb9:
+    _18 = move _17
+    _7 = move _18
+    goto bb8
 
 fn fs$read(string) -> string [conv=default]
   locals:
@@ -1117,15 +755,15 @@ fn fs$read(string) -> string [conv=default]
     _31: !
     _32: string
   bb0:
-    stmt: use BindingId(38) path site=SiteId(333) ty=string intent=Read
+    stmt: use BindingId(23) path site=SiteId(231) ty=string intent=Read
     _1 = call hew_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(39) contents site=SiteId(332) ty=string
+    stmt: bind BindingId(24) contents site=SiteId(230) ty=string
     _2 = move _1
     _3 = call hew_stream_last_errno() -> bb2
   bb2:
-    stmt: bind BindingId(40) errno site=SiteId(335) ty=i32
-    stmt: use BindingId(40) errno site=SiteId(338) ty=i32 intent=Read
+    stmt: bind BindingId(25) errno site=SiteId(233) ty=i32
+    stmt: use BindingId(25) errno site=SiteId(236) ty=i32 intent=Read
     _4 = move _3
     _6 = const.i64 0
     _7 = icmp.ne _4 _6
@@ -1135,15 +773,15 @@ fn fs$read(string) -> string [conv=default]
   bb4:
     goto bb5
   bb5:
-    stmt: eval site=SiteId(390) ty=()
-    stmt: use BindingId(39) contents site=SiteId(391) ty=string intent=Read
-    stmt: return site=Some(SiteId(331)) ty=string
+    stmt: eval site=SiteId(288) ty=()
+    stmt: use BindingId(24) contents site=SiteId(289) ty=string intent=Read
+    stmt: return site=Some(SiteId(229)) ty=string
     _32 = move _2
     ret = move _32
     return
   bb6:
-    stmt: bind BindingId(41) detail site=SiteId(340) ty=string
-    stmt: use BindingId(41) detail site=SiteId(345) ty=string intent=Read
+    stmt: bind BindingId(26) detail site=SiteId(238) ty=string
+    stmt: use BindingId(26) detail site=SiteId(243) ty=string intent=Read
     _9 = move _8
     _11 = call hew_string_length(_9) -> bb7
   bb7:
@@ -1151,11 +789,11 @@ fn fs$read(string) -> string [conv=default]
     _13 = icmp.eq _11 _12
     branch _13 ? bb8 : bb9
   bb8:
-    stmt: use BindingId(38) path site=SiteId(352) ty=string intent=Read
+    stmt: use BindingId(23) path site=SiteId(250) ty=string intent=Read
     _14 = string_lit "fs.read failed for `"
     _15 = call string::fmt(_0) -> bb11
   bb9:
-    stmt: use BindingId(38) path site=SiteId(375) ty=string intent=Read
+    stmt: use BindingId(23) path site=SiteId(273) ty=string intent=Read
     _24 = string_lit "fs.read failed for `"
     _25 = call string::fmt(_0) -> bb19
   bb10:
@@ -1168,7 +806,7 @@ fn fs$read(string) -> string [conv=default]
     _17 = string_lit "`: "
     _18 = call string_concat(_16, _17) -> bb13
   bb13:
-    stmt: use BindingId(40) errno site=SiteId(359) ty=i32 intent=Read
+    stmt: use BindingId(25) errno site=SiteId(257) ty=i32 intent=Read
     drop _16 ty=string fn=release(hew_string_drop)
     _19 = cast _4 i32 -> i64
     _20 = call fs$io_error_from_errno(_19) -> bb14
@@ -1181,7 +819,7 @@ fn fs$read(string) -> string [conv=default]
   bb17:
     call panic(_23) -> bb18
   bb18:
-    stmt: eval site=SiteId(349) ty=!
+    stmt: eval site=SiteId(247) ty=!
     goto bb10
   bb19:
     _26 = call string_concat(_24, _25) -> bb20
@@ -1189,7 +827,7 @@ fn fs$read(string) -> string [conv=default]
     _27 = string_lit "`: "
     _28 = call string_concat(_26, _27) -> bb21
   bb21:
-    stmt: use BindingId(41) detail site=SiteId(379) ty=string intent=Read
+    stmt: use BindingId(26) detail site=SiteId(277) ty=string intent=Read
     drop _26 ty=string fn=release(hew_string_drop)
     _29 = call string::fmt(_9) -> bb22
   bb22:
@@ -1197,7 +835,7 @@ fn fs$read(string) -> string [conv=default]
   bb23:
     call panic(_30) -> bb24
   bb24:
-    stmt: eval site=SiteId(372) ty=!
+    stmt: eval site=SiteId(270) ty=!
     goto bb10
 
 fn fs$try_read(string) -> Result<string, IoError> [conv=default]
@@ -1207,61 +845,101 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
     _2: FileReadStream
     _3: Result<string, IoError>
     _4: bool
-    _5: Result<string, IoError>
-    _6: i64
-    _7: string
-    _8: Result<string, IoError>
-    _9: i32
+    _5: string
+    _6: string
+    _7: i32
+    _8: i64
+    _9: i64
     _10: i32
-    _11: string
-    _12: Result<string, IoError>
-    _13: i64
-    _14: i64
-    _15: IoError
+    _11: i32
+    _12: string
+    _13: Result<string, IoError>
+    _14: i32
+    _15: bool
     _16: Result<string, IoError>
-    _17: Result<string, IoError>
+    _17: i64
+    _18: Result<string, IoError>
+    _19: Result<string, IoError>
+    _20: i64
+    _21: i64
+    _22: IoError
+    _23: Result<string, IoError>
+    _24: Result<string, IoError>
+    _25: Result<string, IoError>
+    _26: i64
+    _27: IoError
+    _28: Result<string, IoError>
+    _29: Result<string, IoError>
   bb0:
-    stmt: use BindingId(42) file_path site=SiteId(394) ty=string intent=Read
+    stmt: use BindingId(27) file_path site=SiteId(292) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(43) file site=SiteId(393) ty=FileReadStream
-    stmt: use BindingId(43) file site=SiteId(398) ty=FileReadStream intent=Read
+    stmt: bind BindingId(28) file site=SiteId(291) ty=FileReadStream
+    stmt: use BindingId(28) file site=SiteId(296) ty=FileReadStream intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(43) file site=SiteId(403) ty=FileReadStream intent=Read
-    _6 = const.i64 0
-    mtag5 = move _6
-    _7 = call hew_stream_collect_string(_2) -> bb6
+    stmt: use BindingId(28) file site=SiteId(300) ty=FileReadStream intent=Read
+    _5 = call hew_stream_collect_string(_2) -> bb6
   bb4:
-    _9 = call hew_stream_last_errno() -> bb7
+    _26 = const.i64 1
+    mtag25 = move _26
+    _27 = call fs$last_io_error() -> bb14
   bb5:
-    stmt: return site=Some(SiteId(392)) ty=Result<string, IoError>
-    _17 = move _3
-    ret = move _17
+    stmt: return site=Some(SiteId(290)) ty=Result<string, IoError>
+    _29 = move _3
+    ret = move _29
     return
   bb6:
-    mvar5.0.0 = move _7
-    _8 = move _5
-    _3 = move _8
-    goto bb5
+    stmt: bind BindingId(29) contents site=SiteId(299) ty=string
+    _6 = move _5
+    _7 = call hew_stream_last_error_kind() -> bb7
   bb7:
-    stmt: bind BindingId(44) errno site=SiteId(406) ty=i32
-    _10 = move _9
-    _11 = call hew_stream_last_error() -> bb8
+    stmt: bind BindingId(30) kind site=SiteId(302) ty=i64
+    _8 = cast _7 i32 -> i64
+    _9 = move _8
+    _10 = call hew_stream_last_errno() -> bb8
   bb8:
-    stmt: eval site=SiteId(408) ty=string
-    stmt: use BindingId(44) errno site=SiteId(413) ty=i32 intent=Read
-    _13 = const.i64 1
-    mtag12 = move _13
-    _14 = cast _10 i32 -> i64
-    _15 = call fs$io_error_from_errno(_14) -> bb9
+    stmt: bind BindingId(31) errno site=SiteId(305) ty=i32
+    _11 = move _10
+    _12 = call hew_stream_last_error() -> bb9
   bb9:
-    mvar12.1.0 = move _15
-    _16 = move _12
-    _3 = move _16
+    stmt: eval site=SiteId(307) ty=string
+    stmt: use BindingId(31) errno site=SiteId(311) ty=i32 intent=Read
+    _14 = const.i64 0
+    _15 = icmp.eq _11 _14
+    branch _15 ? bb10 : bb11
+  bb10:
+    stmt: use BindingId(29) contents site=SiteId(315) ty=string intent=Read
+    stmt: agg_alias BindingId(29) contents site=SiteId(315) ty=string
+    _17 = const.i64 0
+    mtag16 = move _17
+    mvar16.0.0 = move _6
+    _18 = move _16
+    _13 = move _18
+    goto bb12
+  bb11:
+    stmt: use BindingId(30) kind site=SiteId(319) ty=i64 intent=Read
+    stmt: use BindingId(31) errno site=SiteId(321) ty=i32 intent=Read
+    _20 = const.i64 1
+    mtag19 = move _20
+    _21 = cast _11 i32 -> i64
+    _22 = call fs$io_error_from_kind(_9, _21) -> bb13
+  bb12:
+    _24 = move _13
+    _3 = move _24
+    goto bb5
+  bb13:
+    mvar19.1.0 = move _22
+    _23 = move _19
+    _13 = move _23
+    goto bb12
+  bb14:
+    mvar25.1.0 = move _27
+    _28 = move _25
+    _3 = move _28
     goto bb5
 
 fn fs$write(string, string) -> i64 [conv=default]
@@ -1272,11 +950,11 @@ fn fs$write(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(45) path site=SiteId(418) ty=string intent=Read
-    stmt: use BindingId(46) content site=SiteId(419) ty=string intent=Read
+    stmt: use BindingId(32) path site=SiteId(330) ty=string intent=Read
+    stmt: use BindingId(33) content site=SiteId(331) ty=string intent=Read
     _2 = call hew_file_write(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(415)) ty=i64
+    stmt: return site=Some(SiteId(327)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1298,14 +976,14 @@ fn fs$try_write(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(47) file_path site=SiteId(424) ty=string intent=Read
-    stmt: use BindingId(48) content site=SiteId(425) ty=string intent=Read
+    stmt: use BindingId(34) file_path site=SiteId(336) ty=string intent=Read
+    stmt: use BindingId(35) content site=SiteId(337) ty=string intent=Read
     _3 = call hew_file_write(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(421)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(333)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1313,10 +991,9 @@ fn fs$try_write(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(47) file_path site=SiteId(431) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$write_error(_0) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1339,11 +1016,11 @@ fn fs$append(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(49) path site=SiteId(436) ty=string intent=Read
-    stmt: use BindingId(50) content site=SiteId(437) ty=string intent=Read
+    stmt: use BindingId(36) path site=SiteId(347) ty=string intent=Read
+    stmt: use BindingId(37) content site=SiteId(348) ty=string intent=Read
     _2 = call hew_file_append(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(433)) ty=i64
+    stmt: return site=Some(SiteId(344)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1365,14 +1042,14 @@ fn fs$try_append(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(51) file_path site=SiteId(442) ty=string intent=Read
-    stmt: use BindingId(52) content site=SiteId(443) ty=string intent=Read
+    stmt: use BindingId(38) file_path site=SiteId(353) ty=string intent=Read
+    stmt: use BindingId(39) content site=SiteId(354) ty=string intent=Read
     _3 = call hew_file_append(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(439)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(350)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1380,10 +1057,9 @@ fn fs$try_append(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(51) file_path site=SiteId(449) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$write_error(_0) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1404,10 +1080,10 @@ fn fs$exists(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(53) path site=SiteId(453) ty=string intent=Read
+    stmt: use BindingId(40) path site=SiteId(363) ty=string intent=Read
     _1 = call hew_file_exists(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(451)) ty=bool
+    stmt: return site=Some(SiteId(361)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -1419,10 +1095,10 @@ fn fs$delete(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(54) path site=SiteId(458) ty=string intent=Read
+    stmt: use BindingId(41) path site=SiteId(368) ty=string intent=Read
     _1 = call hew_file_delete(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(455)) ty=i64
+    stmt: return site=Some(SiteId(365)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1443,13 +1119,13 @@ fn fs$try_delete(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(55) file_path site=SiteId(463) ty=string intent=Read
+    stmt: use BindingId(42) file_path site=SiteId(373) ty=string intent=Read
     _2 = call hew_file_delete(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(460)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(370)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1457,10 +1133,9 @@ fn fs$try_delete(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(55) file_path site=SiteId(469) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
-    _11 = call fs$missing_path_error(_0) -> bb7
+    _11 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1481,10 +1156,10 @@ fn fs$size(string) -> i64 [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: use BindingId(56) path site=SiteId(473) ty=string intent=Read
+    stmt: use BindingId(43) path site=SiteId(382) ty=string intent=Read
     _1 = call hew_file_size(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(471)) ty=i64
+    stmt: return site=Some(SiteId(380)) ty=i64
     _2 = move _1
     ret = move _2
     return
@@ -1495,10 +1170,10 @@ fn fs$read_bytes(string) -> bytes [conv=default]
     _1: bytes
     _2: bytes
   bb0:
-    stmt: use BindingId(57) path site=SiteId(477) ty=string intent=Read
+    stmt: use BindingId(44) path site=SiteId(386) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(475)) ty=bytes
+    stmt: return site=Some(SiteId(384)) ty=bytes
     _2 = move _1
     ret = move _2
     return
@@ -1509,61 +1184,70 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _1: bytes
     _2: bytes
     _3: i32
-    _4: i32
-    _5: Result<bytes, IoError>
+    _4: i64
+    _5: i64
     _6: i32
-    _7: bool
-    _8: string
-    _9: Result<bytes, IoError>
-    _10: i64
-    _11: i64
-    _12: IoError
-    _13: Result<bytes, IoError>
-    _14: Result<bytes, IoError>
-    _15: i64
+    _7: i32
+    _8: Result<bytes, IoError>
+    _9: i32
+    _10: bool
+    _11: string
+    _12: Result<bytes, IoError>
+    _13: i64
+    _14: i64
+    _15: IoError
     _16: Result<bytes, IoError>
     _17: Result<bytes, IoError>
+    _18: i64
+    _19: Result<bytes, IoError>
+    _20: Result<bytes, IoError>
   bb0:
-    stmt: use BindingId(58) file_path site=SiteId(481) ty=string intent=Read
+    stmt: use BindingId(45) file_path site=SiteId(390) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
   bb1:
-    stmt: bind BindingId(59) data site=SiteId(480) ty=bytes
+    stmt: bind BindingId(46) data site=SiteId(389) ty=bytes
     _2 = move _1
-    _3 = call hew_stream_last_errno() -> bb2
+    _3 = call hew_stream_last_error_kind() -> bb2
   bb2:
-    stmt: bind BindingId(60) errno site=SiteId(483) ty=i32
-    stmt: use BindingId(60) errno site=SiteId(487) ty=i32 intent=Read
-    _4 = move _3
-    _6 = const.i64 0
-    _7 = icmp.ne _4 _6
-    branch _7 ? bb3 : bb4
+    stmt: bind BindingId(47) kind site=SiteId(392) ty=i64
+    _4 = cast _3 i32 -> i64
+    _5 = move _4
+    _6 = call hew_stream_last_errno() -> bb3
   bb3:
-    _8 = call hew_stream_last_error() -> bb6
+    stmt: bind BindingId(48) errno site=SiteId(395) ty=i32
+    stmt: use BindingId(48) errno site=SiteId(399) ty=i32 intent=Read
+    _7 = move _6
+    _9 = const.i64 0
+    _10 = icmp.ne _7 _9
+    branch _10 ? bb4 : bb5
   bb4:
-    stmt: use BindingId(59) data site=SiteId(499) ty=bytes intent=Read
-    _15 = const.i64 0
-    mtag14 = move _15
-    mvar14.0.0 = move _2
-    _16 = move _14
-    _5 = move _16
-    goto bb5
+    _11 = call hew_stream_last_error() -> bb7
   bb5:
-    stmt: return site=Some(SiteId(479)) ty=Result<bytes, IoError>
-    _17 = move _5
-    ret = move _17
-    return
+    stmt: use BindingId(46) data site=SiteId(412) ty=bytes intent=Read
+    _18 = const.i64 0
+    mtag17 = move _18
+    mvar17.0.0 = move _2
+    _19 = move _17
+    _8 = move _19
+    goto bb6
   bb6:
-    stmt: eval site=SiteId(490) ty=string
-    stmt: use BindingId(60) errno site=SiteId(495) ty=i32 intent=Read
-    _10 = const.i64 1
-    mtag9 = move _10
-    _11 = cast _4 i32 -> i64
-    _12 = call fs$io_error_from_errno(_11) -> bb7
+    stmt: return site=Some(SiteId(388)) ty=Result<bytes, IoError>
+    _20 = move _8
+    ret = move _20
+    return
   bb7:
-    mvar9.1.0 = move _12
-    _13 = move _9
-    _5 = move _13
-    goto bb5
+    stmt: eval site=SiteId(402) ty=string
+    stmt: use BindingId(47) kind site=SiteId(406) ty=i64 intent=Read
+    stmt: use BindingId(48) errno site=SiteId(408) ty=i32 intent=Read
+    _13 = const.i64 1
+    mtag12 = move _13
+    _14 = cast _7 i32 -> i64
+    _15 = call fs$io_error_from_kind(_5, _14) -> bb8
+  bb8:
+    mvar12.1.0 = move _15
+    _16 = move _12
+    _8 = move _16
+    goto bb6
 
 fn fs$write_bytes(string, bytes) -> i64 [conv=default]
   locals:
@@ -1573,11 +1257,11 @@ fn fs$write_bytes(string, bytes) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(61) path site=SiteId(503) ty=string intent=Read
-    stmt: use BindingId(62) data site=SiteId(504) ty=bytes intent=Read
+    stmt: use BindingId(49) path site=SiteId(416) ty=string intent=Read
+    stmt: use BindingId(50) data site=SiteId(417) ty=bytes intent=Read
     _2 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(500)) ty=i64
+    stmt: return site=Some(SiteId(413)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1599,14 +1283,14 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(63) file_path site=SiteId(509) ty=string intent=Read
-    stmt: use BindingId(64) data site=SiteId(510) ty=bytes intent=Read
+    stmt: use BindingId(51) file_path site=SiteId(422) ty=string intent=Read
+    stmt: use BindingId(52) data site=SiteId(423) ty=bytes intent=Read
     _3 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(506)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(419)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1614,10 +1298,9 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(63) file_path site=SiteId(516) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$write_error(_0) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1639,10 +1322,10 @@ fn fs$mkdir(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(65) path site=SiteId(521) ty=string intent=Read
+    stmt: use BindingId(53) path site=SiteId(433) ty=string intent=Read
     _1 = call hew_fs_mkdir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(518)) ty=i64
+    stmt: return site=Some(SiteId(430)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1663,13 +1346,13 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(66) dir_path site=SiteId(526) ty=string intent=Read
+    stmt: use BindingId(54) dir_path site=SiteId(438) ty=string intent=Read
     _2 = call hew_fs_mkdir(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(523)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(435)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1677,10 +1360,9 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(66) dir_path site=SiteId(532) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
-    _11 = call fs$mkdir_error(_0) -> bb7
+    _11 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1702,10 +1384,10 @@ fn fs$mkdir_all(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(67) path site=SiteId(537) ty=string intent=Read
+    stmt: use BindingId(55) path site=SiteId(448) ty=string intent=Read
     _1 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(534)) ty=i64
+    stmt: return site=Some(SiteId(445)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1723,28 +1405,16 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _7: i64
     _8: i64
     _9: Result<i64, IoError>
-    _10: bool
-    _11: Result<i64, IoError>
-    _12: i64
-    _13: IoError
-    _14: i64
-    _15: i64
-    _16: Result<i64, IoError>
-    _17: Result<i64, IoError>
-    _18: i64
-    _19: IoError
-    _20: i64
-    _21: i64
-    _22: Result<i64, IoError>
-    _23: Result<i64, IoError>
+    _10: i64
+    _11: IoError
   bb0:
-    stmt: use BindingId(68) dir_path site=SiteId(542) ty=string intent=Read
+    stmt: use BindingId(56) dir_path site=SiteId(453) ty=string intent=Read
     _2 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(539)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(450)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1752,8 +1422,9 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(68) dir_path site=SiteId(549) ty=string intent=Read
-    _10 = call fs$exists(_0) -> bb7
+    _10 = const.i64 1
+    mtag9 = move _10
+    _11 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1764,32 +1435,8 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _1 = move _6
     goto bb2
   bb7:
-    branch _10 ? bb8 : bb9
-  bb8:
-    _12 = const.i64 1
-    mtag11 = move _12
-    _14 = const.i64 2
-    mtag13 = move _14
-    _15 = const.i64 0
-    mvar13.2.0 = move _15
-    mvar11.1.0 = move _13
-    _16 = move _11
-    _9 = move _16
-    goto bb10
-  bb9:
-    _18 = const.i64 1
-    mtag17 = move _18
-    _20 = const.i64 5
-    mtag19 = move _20
-    _21 = const.i64 0
-    mvar19.5.0 = move _21
-    mvar17.1.0 = move _19
-    _22 = move _17
-    _9 = move _22
-    goto bb10
-  bb10:
-    _23 = move _9
-    _1 = move _23
+    mvar9.1.0 = move _11
+    _1 = move _9
     goto bb2
 
 fn fs$list_dir(string) -> Vec<string> [conv=default]
@@ -1798,10 +1445,10 @@ fn fs$list_dir(string) -> Vec<string> [conv=default]
     _1: Vec<string>
     _2: Vec<string>
   bb0:
-    stmt: use BindingId(69) path site=SiteId(561) ty=string intent=Read
+    stmt: use BindingId(57) path site=SiteId(462) ty=string intent=Read
     _1 = call hew_fs_list_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(559)) ty=Vec<string>
+    stmt: return site=Some(SiteId(460)) ty=Vec<string>
     _2 = move _1
     ret = move _2
     return
@@ -1809,81 +1456,74 @@ fn fs$list_dir(string) -> Vec<string> [conv=default]
 fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   locals:
     _0: string
-    _1: ()
-    _2: bool
-    _3: bool
-    _4: Result<Vec<string>, IoError>
+    _1: Vec<string>
+    _2: Vec<string>
+    _3: i32
+    _4: i64
     _5: i64
-    _6: IoError
-    _7: i64
-    _8: i64
-    _9: ()
-    _10: bool
+    _6: i32
+    _7: i32
+    _8: string
+    _9: Result<Vec<string>, IoError>
+    _10: i32
     _11: bool
     _12: Result<Vec<string>, IoError>
     _13: i64
-    _14: IoError
-    _15: i64
+    _14: Result<Vec<string>, IoError>
+    _15: Result<Vec<string>, IoError>
     _16: i64
-    _17: Result<Vec<string>, IoError>
-    _18: i64
-    _19: Vec<string>
-    _20: Vec<string>
+    _17: i64
+    _18: IoError
+    _19: Result<Vec<string>, IoError>
+    _20: Result<Vec<string>, IoError>
   bb0:
-    stmt: use BindingId(70) dir_path site=SiteId(565) ty=string intent=Read
-    _2 = call fs$exists(_0) -> bb1
+    stmt: use BindingId(58) dir_path site=SiteId(466) ty=string intent=Read
+    _1 = call hew_fs_list_dir(_0) -> bb1
   bb1:
-    _3 = not _2
-    branch _3 ? bb2 : bb3
+    stmt: bind BindingId(59) entries site=SiteId(465) ty=Vec<string>
+    _2 = move _1
+    _3 = call hew_stream_last_error_kind() -> bb2
   bb2:
-    stmt: return site=Some(SiteId(567)) ty=Result<Vec<string>, IoError>
-    _5 = const.i64 1
-    mtag4 = move _5
-    _7 = const.i64 0
-    mtag6 = move _7
-    _8 = const.i64 0
-    mvar6.0.0 = move _8
-    mvar4.1.0 = move _6
-    ret = move _4
-    return
+    stmt: bind BindingId(60) kind site=SiteId(468) ty=i64
+    _4 = cast _3 i32 -> i64
+    _5 = move _4
+    _6 = call hew_stream_last_errno() -> bb3
   bb3:
-    goto bb4
+    stmt: bind BindingId(61) errno site=SiteId(471) ty=i32
+    _7 = move _6
+    _8 = call hew_stream_last_error() -> bb4
   bb4:
-    stmt: eval site=SiteId(571) ty=()
-    stmt: use BindingId(70) dir_path site=SiteId(574) ty=string intent=Read
-    _10 = call fs$is_dir(_0) -> bb6
+    stmt: eval site=SiteId(473) ty=string
+    stmt: use BindingId(61) errno site=SiteId(477) ty=i32 intent=Read
+    _10 = const.i64 0
+    _11 = icmp.eq _7 _10
+    branch _11 ? bb5 : bb6
   bb5:
-    goto bb4
-  bb6:
-    _11 = not _10
-    branch _11 ? bb7 : bb8
-  bb7:
-    stmt: return site=Some(SiteId(576)) ty=Result<Vec<string>, IoError>
-    _13 = const.i64 1
+    stmt: use BindingId(59) entries site=SiteId(481) ty=Vec<string> intent=Read
+    stmt: agg_alias BindingId(59) entries site=SiteId(481) ty=Vec<string>
+    _13 = const.i64 0
     mtag12 = move _13
-    _15 = const.i64 5
-    mtag14 = move _15
-    _16 = const.i64 0
-    mvar14.5.0 = move _16
-    mvar12.1.0 = move _14
-    ret = move _12
+    mvar12.0.0 = move _2
+    _14 = move _12
+    _9 = move _14
+    goto bb7
+  bb6:
+    stmt: use BindingId(60) kind site=SiteId(485) ty=i64 intent=Read
+    stmt: use BindingId(61) errno site=SiteId(487) ty=i32 intent=Read
+    _16 = const.i64 1
+    mtag15 = move _16
+    _17 = cast _7 i32 -> i64
+    _18 = call fs$io_error_from_kind(_5, _17) -> bb8
+  bb7:
+    stmt: return site=Some(SiteId(464)) ty=Result<Vec<string>, IoError>
+    _20 = move _9
+    ret = move _20
     return
   bb8:
-    goto bb9
-  bb9:
-    stmt: eval site=SiteId(580) ty=()
-    stmt: use BindingId(70) dir_path site=SiteId(584) ty=string intent=Read
-    _18 = const.i64 0
-    mtag17 = move _18
-    _19 = call hew_fs_list_dir(_0) -> bb11
-  bb10:
-    goto bb9
-  bb11:
-    stmt: return site=Some(SiteId(581)) ty=Result<Vec<string>, IoError>
-    _20 = move _19
-    mvar17.0.0 = move _20
-    ret = move _17
-    return
+    mvar15.1.0 = move _18
+    _19 = move _15
+    _9 = move _19
+    goto bb7
 
 fn fs$rename(string, string) -> i64 [conv=default]
   locals:
@@ -1893,11 +1533,11 @@ fn fs$rename(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(71) from site=SiteId(589) ty=string intent=Read
-    stmt: use BindingId(72) to site=SiteId(590) ty=string intent=Read
+    stmt: use BindingId(62) from site=SiteId(492) ty=string intent=Read
+    stmt: use BindingId(63) to site=SiteId(493) ty=string intent=Read
     _2 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(586)) ty=i64
+    stmt: return site=Some(SiteId(489)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1919,14 +1559,14 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(73) from site=SiteId(595) ty=string intent=Read
-    stmt: use BindingId(74) to site=SiteId(596) ty=string intent=Read
+    stmt: use BindingId(64) from site=SiteId(498) ty=string intent=Read
+    stmt: use BindingId(65) to site=SiteId(499) ty=string intent=Read
     _3 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(592)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(495)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1934,11 +1574,9 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(73) from site=SiteId(602) ty=string intent=Read
-    stmt: use BindingId(74) to site=SiteId(603) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$move_copy_error(_0, _1) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1961,11 +1599,11 @@ fn fs$copy(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(75) from site=SiteId(608) ty=string intent=Read
-    stmt: use BindingId(76) to site=SiteId(609) ty=string intent=Read
+    stmt: use BindingId(66) from site=SiteId(509) ty=string intent=Read
+    stmt: use BindingId(67) to site=SiteId(510) ty=string intent=Read
     _2 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(605)) ty=i64
+    stmt: return site=Some(SiteId(506)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1987,14 +1625,14 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(77) from site=SiteId(614) ty=string intent=Read
-    stmt: use BindingId(78) to site=SiteId(615) ty=string intent=Read
+    stmt: use BindingId(68) from site=SiteId(515) ty=string intent=Read
+    stmt: use BindingId(69) to site=SiteId(516) ty=string intent=Read
     _3 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(611)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(512)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -2002,11 +1640,9 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(77) from site=SiteId(621) ty=string intent=Read
-    stmt: use BindingId(78) to site=SiteId(622) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$move_copy_error(_0, _1) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -2027,10 +1663,10 @@ fn fs$is_dir(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(79) path site=SiteId(626) ty=string intent=Read
+    stmt: use BindingId(70) path site=SiteId(525) ty=string intent=Read
     _1 = call hew_fs_is_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(624)) ty=bool
+    stmt: return site=Some(SiteId(523)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -2048,31 +1684,31 @@ fn stream$pipe(i64) -> (Sink<string>, Stream<string>) [conv=default]
     _8: (Sink<string>, Stream<string>)
     _9: (Sink<string>, Stream<string>)
   bb0:
-    stmt: use BindingId(80) capacity site=SiteId(631) ty=i64 intent=Read
+    stmt: use BindingId(71) capacity site=SiteId(530) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(81) pair site=SiteId(629) ty=StreamPair
-    stmt: use BindingId(81) pair site=SiteId(634) ty=StreamPair intent=Read
+    stmt: bind BindingId(72) pair site=SiteId(528) ty=StreamPair
+    stmt: use BindingId(72) pair site=SiteId(533) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink(_3) -> bb2
   bb2:
-    stmt: bind BindingId(82) sink site=SiteId(633) ty=Sink<string>
-    stmt: use BindingId(81) pair site=SiteId(637) ty=StreamPair intent=Read
+    stmt: bind BindingId(73) sink site=SiteId(532) ty=Sink<string>
+    stmt: use BindingId(72) pair site=SiteId(536) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream(_3) -> bb3
   bb3:
-    stmt: bind BindingId(83) input site=SiteId(636) ty=Stream<string>
-    stmt: use BindingId(81) pair site=SiteId(640) ty=StreamPair intent=Read
+    stmt: bind BindingId(74) input site=SiteId(535) ty=Stream<string>
+    stmt: use BindingId(72) pair site=SiteId(539) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(639) ty=()
-    stmt: use BindingId(82) sink site=SiteId(643) ty=Sink<string> intent=Read
-    stmt: use BindingId(83) input site=SiteId(644) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(82) sink site=SiteId(643) ty=Sink<string>
-    stmt: agg_alias BindingId(83) input site=SiteId(644) ty=Stream<string>
-    stmt: return site=Some(SiteId(628)) ty=(Sink<string>, Stream<string>)
+    stmt: eval site=SiteId(538) ty=()
+    stmt: use BindingId(73) sink site=SiteId(542) ty=Sink<string> intent=Read
+    stmt: use BindingId(74) input site=SiteId(543) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(73) sink site=SiteId(542) ty=Sink<string>
+    stmt: agg_alias BindingId(74) input site=SiteId(543) ty=Stream<string>
+    stmt: return site=Some(SiteId(527)) ty=(Sink<string>, Stream<string>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2091,31 +1727,31 @@ fn stream$bytes_pipe(i64) -> (Sink<bytes>, Stream<bytes>) [conv=default]
     _8: (Sink<bytes>, Stream<bytes>)
     _9: (Sink<bytes>, Stream<bytes>)
   bb0:
-    stmt: use BindingId(84) capacity site=SiteId(648) ty=i64 intent=Read
+    stmt: use BindingId(75) capacity site=SiteId(547) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(85) pair site=SiteId(646) ty=StreamPair
-    stmt: use BindingId(85) pair site=SiteId(651) ty=StreamPair intent=Read
+    stmt: bind BindingId(76) pair site=SiteId(545) ty=StreamPair
+    stmt: use BindingId(76) pair site=SiteId(550) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink_bytes(_3) -> bb2
   bb2:
-    stmt: bind BindingId(86) sink site=SiteId(650) ty=Sink<bytes>
-    stmt: use BindingId(85) pair site=SiteId(654) ty=StreamPair intent=Read
+    stmt: bind BindingId(77) sink site=SiteId(549) ty=Sink<bytes>
+    stmt: use BindingId(76) pair site=SiteId(553) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream_bytes(_3) -> bb3
   bb3:
-    stmt: bind BindingId(87) input site=SiteId(653) ty=Stream<bytes>
-    stmt: use BindingId(85) pair site=SiteId(657) ty=StreamPair intent=Read
+    stmt: bind BindingId(78) input site=SiteId(552) ty=Stream<bytes>
+    stmt: use BindingId(76) pair site=SiteId(556) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(656) ty=()
-    stmt: use BindingId(86) sink site=SiteId(660) ty=Sink<bytes> intent=Read
-    stmt: use BindingId(87) input site=SiteId(661) ty=Stream<bytes> intent=Read
-    stmt: agg_alias BindingId(86) sink site=SiteId(660) ty=Sink<bytes>
-    stmt: agg_alias BindingId(87) input site=SiteId(661) ty=Stream<bytes>
-    stmt: return site=Some(SiteId(645)) ty=(Sink<bytes>, Stream<bytes>)
+    stmt: eval site=SiteId(555) ty=()
+    stmt: use BindingId(77) sink site=SiteId(559) ty=Sink<bytes> intent=Read
+    stmt: use BindingId(78) input site=SiteId(560) ty=Stream<bytes> intent=Read
+    stmt: agg_alias BindingId(77) sink site=SiteId(559) ty=Sink<bytes>
+    stmt: agg_alias BindingId(78) input site=SiteId(560) ty=Stream<bytes>
+    stmt: return site=Some(SiteId(544)) ty=(Sink<bytes>, Stream<bytes>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2137,18 +1773,18 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     _11: Result<Stream<string>, string>
     _12: Result<Stream<string>, string>
   bb0:
-    stmt: use BindingId(88) path site=SiteId(664) ty=string intent=Read
+    stmt: use BindingId(79) path site=SiteId(563) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(89) s site=SiteId(663) ty=Stream<string>
-    stmt: use BindingId(89) s site=SiteId(668) ty=Stream<string> intent=Read
+    stmt: bind BindingId(80) s site=SiteId(562) ty=Stream<string>
+    stmt: use BindingId(80) s site=SiteId(567) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(89) s site=SiteId(672) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(89) s site=SiteId(672) ty=Stream<string>
+    stmt: use BindingId(80) s site=SiteId(571) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(80) s site=SiteId(571) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2160,7 +1796,7 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(662)) ty=Result<Stream<string>, string>
+    stmt: return site=Some(SiteId(561)) ty=Result<Stream<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2181,27 +1817,30 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _6: i64
     _7: Result<Stream<string>, fs.IoError>
     _8: i32
-    _9: i32
-    _10: string
-    _11: Result<Stream<string>, fs.IoError>
-    _12: i64
-    _13: i64
-    _14: fs.IoError
-    _15: Result<Stream<string>, fs.IoError>
-    _16: Result<Stream<string>, fs.IoError>
+    _9: i64
+    _10: i64
+    _11: i32
+    _12: i32
+    _13: string
+    _14: Result<Stream<string>, fs.IoError>
+    _15: i64
+    _16: i64
+    _17: fs.IoError
+    _18: Result<Stream<string>, fs.IoError>
+    _19: Result<Stream<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(90) path site=SiteId(679) ty=string intent=Read
+    stmt: use BindingId(81) path site=SiteId(578) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(91) s site=SiteId(678) ty=Stream<string>
-    stmt: use BindingId(91) s site=SiteId(683) ty=Stream<string> intent=Read
+    stmt: bind BindingId(82) s site=SiteId(577) ty=Stream<string>
+    stmt: use BindingId(82) s site=SiteId(582) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(91) s site=SiteId(687) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(91) s site=SiteId(687) ty=Stream<string>
+    stmt: use BindingId(82) s site=SiteId(586) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(82) s site=SiteId(586) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2209,27 +1848,33 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _3 = move _7
     goto bb5
   bb4:
-    _8 = call hew_stream_last_errno() -> bb6
+    _8 = call hew_stream_last_error_kind() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(677)) ty=Result<Stream<string>, fs.IoError>
-    _16 = move _3
-    ret = move _16
+    stmt: return site=Some(SiteId(576)) ty=Result<Stream<string>, fs.IoError>
+    _19 = move _3
+    ret = move _19
     return
   bb6:
-    stmt: bind BindingId(92) errno site=SiteId(689) ty=i32
-    _9 = move _8
-    _10 = call hew_stream_last_error() -> bb7
+    stmt: bind BindingId(83) kind site=SiteId(588) ty=i64
+    _9 = cast _8 i32 -> i64
+    _10 = move _9
+    _11 = call hew_stream_last_errno() -> bb7
   bb7:
-    stmt: eval site=SiteId(691) ty=string
-    stmt: use BindingId(92) errno site=SiteId(696) ty=i32 intent=Read
-    _12 = const.i64 1
-    mtag11 = move _12
-    _13 = cast _9 i32 -> i64
-    _14 = call fs$io_error_from_errno(_13) -> bb8
+    stmt: bind BindingId(84) errno site=SiteId(591) ty=i32
+    _12 = move _11
+    _13 = call hew_stream_last_error() -> bb8
   bb8:
-    mvar11.1.0 = move _14
-    _15 = move _11
-    _3 = move _15
+    stmt: eval site=SiteId(593) ty=string
+    stmt: use BindingId(83) kind site=SiteId(597) ty=i64 intent=Read
+    stmt: use BindingId(84) errno site=SiteId(599) ty=i32 intent=Read
+    _15 = const.i64 1
+    mtag14 = move _15
+    _16 = cast _12 i32 -> i64
+    _17 = call fs$io_error_from_kind(_10, _16) -> bb9
+  bb9:
+    mvar14.1.0 = move _17
+    _18 = move _14
+    _3 = move _18
     goto bb5
 
 fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
@@ -2248,18 +1893,18 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     _11: Result<Sink<string>, string>
     _12: Result<Sink<string>, string>
   bb0:
-    stmt: use BindingId(93) path site=SiteId(700) ty=string intent=Read
+    stmt: use BindingId(85) path site=SiteId(603) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(94) s site=SiteId(699) ty=Sink<string>
-    stmt: use BindingId(94) s site=SiteId(704) ty=Sink<string> intent=Read
+    stmt: bind BindingId(86) s site=SiteId(602) ty=Sink<string>
+    stmt: use BindingId(86) s site=SiteId(607) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(94) s site=SiteId(708) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(94) s site=SiteId(708) ty=Sink<string>
+    stmt: use BindingId(86) s site=SiteId(611) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(86) s site=SiteId(611) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2271,7 +1916,7 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(698)) ty=Result<Sink<string>, string>
+    stmt: return site=Some(SiteId(601)) ty=Result<Sink<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2292,27 +1937,30 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _6: i64
     _7: Result<Sink<string>, fs.IoError>
     _8: i32
-    _9: i32
-    _10: string
-    _11: Result<Sink<string>, fs.IoError>
-    _12: i64
-    _13: i64
-    _14: fs.IoError
-    _15: Result<Sink<string>, fs.IoError>
-    _16: Result<Sink<string>, fs.IoError>
+    _9: i64
+    _10: i64
+    _11: i32
+    _12: i32
+    _13: string
+    _14: Result<Sink<string>, fs.IoError>
+    _15: i64
+    _16: i64
+    _17: fs.IoError
+    _18: Result<Sink<string>, fs.IoError>
+    _19: Result<Sink<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(95) path site=SiteId(715) ty=string intent=Read
+    stmt: use BindingId(87) path site=SiteId(618) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(96) s site=SiteId(714) ty=Sink<string>
-    stmt: use BindingId(96) s site=SiteId(719) ty=Sink<string> intent=Read
+    stmt: bind BindingId(88) s site=SiteId(617) ty=Sink<string>
+    stmt: use BindingId(88) s site=SiteId(622) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(96) s site=SiteId(723) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(96) s site=SiteId(723) ty=Sink<string>
+    stmt: use BindingId(88) s site=SiteId(626) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(88) s site=SiteId(626) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2320,27 +1968,33 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _3 = move _7
     goto bb5
   bb4:
-    _8 = call hew_stream_last_errno() -> bb6
+    _8 = call hew_stream_last_error_kind() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(713)) ty=Result<Sink<string>, fs.IoError>
-    _16 = move _3
-    ret = move _16
+    stmt: return site=Some(SiteId(616)) ty=Result<Sink<string>, fs.IoError>
+    _19 = move _3
+    ret = move _19
     return
   bb6:
-    stmt: bind BindingId(97) errno site=SiteId(725) ty=i32
-    _9 = move _8
-    _10 = call hew_stream_last_error() -> bb7
+    stmt: bind BindingId(89) kind site=SiteId(628) ty=i64
+    _9 = cast _8 i32 -> i64
+    _10 = move _9
+    _11 = call hew_stream_last_errno() -> bb7
   bb7:
-    stmt: eval site=SiteId(727) ty=string
-    stmt: use BindingId(97) errno site=SiteId(732) ty=i32 intent=Read
-    _12 = const.i64 1
-    mtag11 = move _12
-    _13 = cast _9 i32 -> i64
-    _14 = call fs$io_error_from_errno(_13) -> bb8
+    stmt: bind BindingId(90) errno site=SiteId(631) ty=i32
+    _12 = move _11
+    _13 = call hew_stream_last_error() -> bb8
   bb8:
-    mvar11.1.0 = move _14
-    _15 = move _11
-    _3 = move _15
+    stmt: eval site=SiteId(633) ty=string
+    stmt: use BindingId(89) kind site=SiteId(637) ty=i64 intent=Read
+    stmt: use BindingId(90) errno site=SiteId(639) ty=i32 intent=Read
+    _15 = const.i64 1
+    mtag14 = move _15
+    _16 = cast _12 i32 -> i64
+    _17 = call fs$io_error_from_kind(_10, _16) -> bb9
+  bb9:
+    mvar14.1.0 = move _17
+    _18 = move _14
+    _3 = move _18
     goto bb5
 
 fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
@@ -2348,11 +2002,11 @@ fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
     _0: Stream<string>
     _1: Sink<string>
   bb0:
-    stmt: use BindingId(98) source site=SiteId(736) ty=Stream<string> intent=Read
-    stmt: use BindingId(99) dest site=SiteId(737) ty=Sink<string> intent=Read
+    stmt: use BindingId(91) source site=SiteId(643) ty=Stream<string> intent=Read
+    stmt: use BindingId(92) dest site=SiteId(644) ty=Sink<string> intent=Read
     call hew_stream_pipe(_0, _1) -> bb1
   bb1:
-    stmt: eval site=SiteId(734) ty=()
+    stmt: eval site=SiteId(641) ty=()
     return
 
 fn i8::fmt(i8) -> string [conv=default]
@@ -2361,11 +2015,11 @@ fn i8::fmt(i8) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(108) val site=SiteId(809) ty=i8 intent=Read
+    stmt: use BindingId(101) val site=SiteId(716) ty=i8 intent=Read
     _1 = cast _0 i8 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(807)) ty=string
+    stmt: return site=Some(SiteId(714)) ty=string
     ret = move _2
     return
 
@@ -2375,11 +2029,11 @@ fn i16::fmt(i16) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(109) val site=SiteId(813) ty=i16 intent=Read
+    stmt: use BindingId(102) val site=SiteId(720) ty=i16 intent=Read
     _1 = cast _0 i16 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(811)) ty=string
+    stmt: return site=Some(SiteId(718)) ty=string
     ret = move _2
     return
 
@@ -2388,10 +2042,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(110) val site=SiteId(816) ty=i32 intent=Read
+    stmt: use BindingId(103) val site=SiteId(723) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(815)) ty=string
+    stmt: return site=Some(SiteId(722)) ty=string
     ret = move _1
     return
 
@@ -2400,10 +2054,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(111) val site=SiteId(819) ty=i64 intent=Read
+    stmt: use BindingId(104) val site=SiteId(726) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(818)) ty=string
+    stmt: return site=Some(SiteId(725)) ty=string
     ret = move _1
     return
 
@@ -2412,10 +2066,10 @@ fn u8::fmt(u8) -> string [conv=default]
     _0: u8
     _1: string
   bb0:
-    stmt: use BindingId(112) val site=SiteId(822) ty=u8 intent=Read
+    stmt: use BindingId(105) val site=SiteId(729) ty=u8 intent=Read
     _1 = call to_string_u8(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(821)) ty=string
+    stmt: return site=Some(SiteId(728)) ty=string
     ret = move _1
     return
 
@@ -2424,10 +2078,10 @@ fn u16::fmt(u16) -> string [conv=default]
     _0: u16
     _1: string
   bb0:
-    stmt: use BindingId(113) val site=SiteId(825) ty=u16 intent=Read
+    stmt: use BindingId(106) val site=SiteId(732) ty=u16 intent=Read
     _1 = call to_string_u16(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(824)) ty=string
+    stmt: return site=Some(SiteId(731)) ty=string
     ret = move _1
     return
 
@@ -2436,10 +2090,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(114) val site=SiteId(828) ty=u32 intent=Read
+    stmt: use BindingId(107) val site=SiteId(735) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(827)) ty=string
+    stmt: return site=Some(SiteId(734)) ty=string
     ret = move _1
     return
 
@@ -2448,10 +2102,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(115) val site=SiteId(831) ty=u64 intent=Read
+    stmt: use BindingId(108) val site=SiteId(738) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(830)) ty=string
+    stmt: return site=Some(SiteId(737)) ty=string
     ret = move _1
     return
 
@@ -2461,11 +2115,11 @@ fn isize::fmt(isize) -> string [conv=default]
     _1: i64
     _2: string
   bb0:
-    stmt: use BindingId(116) val site=SiteId(835) ty=isize intent=Read
+    stmt: use BindingId(109) val site=SiteId(742) ty=isize intent=Read
     _1 = cast _0 isize -> i64
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(833)) ty=string
+    stmt: return site=Some(SiteId(740)) ty=string
     ret = move _2
     return
 
@@ -2475,11 +2129,11 @@ fn usize::fmt(usize) -> string [conv=default]
     _1: u64
     _2: string
   bb0:
-    stmt: use BindingId(117) val site=SiteId(839) ty=usize intent=Read
+    stmt: use BindingId(110) val site=SiteId(746) ty=usize intent=Read
     _1 = cast _0 usize -> u64
     _2 = call to_string_u64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(837)) ty=string
+    stmt: return site=Some(SiteId(744)) ty=string
     ret = move _2
     return
 
@@ -2488,10 +2142,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(118) val site=SiteId(842) ty=bool intent=Read
+    stmt: use BindingId(111) val site=SiteId(749) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(841)) ty=string
+    stmt: return site=Some(SiteId(748)) ty=string
     ret = move _1
     return
 
@@ -2500,10 +2154,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(119) val site=SiteId(845) ty=char intent=Read
+    stmt: use BindingId(112) val site=SiteId(752) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(844)) ty=string
+    stmt: return site=Some(SiteId(751)) ty=string
     ret = move _1
     return
 
@@ -2512,10 +2166,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(120) val site=SiteId(848) ty=f64 intent=Read
+    stmt: use BindingId(113) val site=SiteId(755) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(847)) ty=string
+    stmt: return site=Some(SiteId(754)) ty=string
     ret = move _1
     return
 
@@ -2525,11 +2179,11 @@ fn f32::fmt(f32) -> string [conv=default]
     _1: f64
     _2: string
   bb0:
-    stmt: use BindingId(121) val site=SiteId(852) ty=f32 intent=Read
+    stmt: use BindingId(114) val site=SiteId(759) ty=f32 intent=Read
     _1 = cast _0 f32 -> f64
     _2 = call to_string_f64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(850)) ty=string
+    stmt: return site=Some(SiteId(757)) ty=string
     ret = move _2
     return
 
@@ -2537,8 +2191,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(122) val site=SiteId(854) ty=string intent=Read
-    stmt: return site=Some(SiteId(854)) ty=string
+    stmt: use BindingId(115) val site=SiteId(761) ty=string intent=Read
+    stmt: return site=Some(SiteId(761)) ty=string
     ret = move _0
     return
 
@@ -2549,14 +2203,14 @@ fn duration::from_nanos(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(123) n site=SiteId(856) ty=i64 intent=Read
+    stmt: use BindingId(116) n site=SiteId(763) ty=i64 intent=Read
     _1 = const.duration 1ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(855)) ty=duration
+    stmt: return site=Some(SiteId(762)) ty=duration
     ret = move _2
     return
 
@@ -2567,14 +2221,14 @@ fn duration::from_micros(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(124) n site=SiteId(859) ty=i64 intent=Read
+    stmt: use BindingId(117) n site=SiteId(766) ty=i64 intent=Read
     _1 = const.duration 1000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(858)) ty=duration
+    stmt: return site=Some(SiteId(765)) ty=duration
     ret = move _2
     return
 
@@ -2585,14 +2239,14 @@ fn duration::from_millis(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(125) n site=SiteId(862) ty=i64 intent=Read
+    stmt: use BindingId(118) n site=SiteId(769) ty=i64 intent=Read
     _1 = const.duration 1000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(861)) ty=duration
+    stmt: return site=Some(SiteId(768)) ty=duration
     ret = move _2
     return
 
@@ -2603,14 +2257,14 @@ fn duration::from_secs(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(126) n site=SiteId(865) ty=i64 intent=Read
+    stmt: use BindingId(119) n site=SiteId(772) ty=i64 intent=Read
     _1 = const.duration 1000000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(864)) ty=duration
+    stmt: return site=Some(SiteId(771)) ty=duration
     ret = move _2
     return
 
@@ -2622,11 +2276,11 @@ fn duration::fmt(duration) -> string [conv=default]
     _3: string
     _4: string
   bb0:
-    stmt: use BindingId(127) val site=SiteId(870) ty=duration intent=Read
+    stmt: use BindingId(120) val site=SiteId(777) ty=duration intent=Read
     _1 = call_rt hew_duration_nanos(_0)
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(867)) ty=string
+    stmt: return site=Some(SiteId(774)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
     drop _2 ty=string fn=release(hew_string_drop)

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.elab.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.elab.mir
@@ -48,15 +48,84 @@ fn fs$io_error_from_errno -> IoError
     use BindingId(6) errno site=SiteId(33) ty=i64 intent=Read
     return site=Some(SiteId(24)) ty=IoError
     use BindingId(6) errno site=SiteId(37) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(40) ty=i64 intent=Read
+    use BindingId(6) errno site=SiteId(41) ty=i64 intent=Read
     use BindingId(6) errno site=SiteId(44) ty=i64 intent=Read
     use BindingId(6) errno site=SiteId(48) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(51) ty=i64 intent=Read
+    use BindingId(6) errno site=SiteId(52) ty=i64 intent=Read
     use BindingId(6) errno site=SiteId(55) ty=i64 intent=Read
     use BindingId(6) errno site=SiteId(59) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(62) ty=i64 intent=Read
+    use BindingId(6) errno site=SiteId(63) ty=i64 intent=Read
     use BindingId(6) errno site=SiteId(66) ty=i64 intent=Read
-    use BindingId(6) errno site=SiteId(69) ty=i64 intent=Read
+    use BindingId(6) errno site=SiteId(70) ty=i64 intent=Read
+    use BindingId(6) errno site=SiteId(73) ty=i64 intent=Read
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    goto[bb1->bb3] ->
+      (none)
+    branch[bb2: bb4/bb5] ->
+      (none)
+    return[bb3] ->
+      (none)
+    goto[bb4->bb6] ->
+      (none)
+    branch[bb5: bb8/bb7] ->
+      (none)
+    goto[bb6->bb3] ->
+      (none)
+    cancel[bb6] ->
+      (none)
+    goto[bb7->bb8] ->
+      (none)
+    branch[bb8: bb9/bb10] ->
+      (none)
+    goto[bb9->bb11] ->
+      (none)
+    branch[bb10: bb13/bb12] ->
+      (none)
+    goto[bb11->bb6] ->
+      (none)
+    cancel[bb11] ->
+      (none)
+    goto[bb12->bb13] ->
+      (none)
+    branch[bb13: bb14/bb15] ->
+      (none)
+    goto[bb14->bb16] ->
+      (none)
+    branch[bb15: bb18/bb17] ->
+      (none)
+    goto[bb16->bb11] ->
+      (none)
+    cancel[bb16] ->
+      (none)
+    goto[bb17->bb18] ->
+      (none)
+    branch[bb18: bb19/bb20] ->
+      (none)
+    goto[bb19->bb21] ->
+      (none)
+    goto[bb20->bb21] ->
+      (none)
+    goto[bb21->bb16] ->
+      (none)
+    cancel[bb21] ->
+      (none)
+
+fn fs$io_error_from_kind -> IoError
+  statements:
+    use BindingId(7) kind site=SiteId(76) ty=i64 intent=Read
+    use BindingId(8) errno site=SiteId(80) ty=i64 intent=Read
+    use BindingId(7) kind site=SiteId(83) ty=i64 intent=Read
+    return site=Some(SiteId(74)) ty=IoError
+    use BindingId(8) errno site=SiteId(87) ty=i64 intent=Read
+    use BindingId(7) kind site=SiteId(90) ty=i64 intent=Read
+    use BindingId(8) errno site=SiteId(94) ty=i64 intent=Read
+    use BindingId(7) kind site=SiteId(97) ty=i64 intent=Read
+    use BindingId(8) errno site=SiteId(101) ty=i64 intent=Read
+    use BindingId(8) errno site=SiteId(104) ty=i64 intent=Read
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -78,53 +147,41 @@ fn fs$io_error_from_errno -> IoError
       (none)
     goto[bb7->bb9] ->
       (none)
-    branch[bb8: bb11/bb10] ->
+    branch[bb8: bb10/bb11] ->
       (none)
     goto[bb9->bb6] ->
       (none)
     cancel[bb9] ->
       (none)
-    goto[bb10->bb11] ->
+    goto[bb10->bb12] ->
       (none)
-    branch[bb11: bb12/bb13] ->
+    call[bb11 fs$io_error_from_errno -> bb13] ->
       (none)
-    goto[bb12->bb14] ->
+    goto[bb12->bb9] ->
       (none)
-    branch[bb13: bb16/bb15] ->
+    cancel[bb12] ->
       (none)
-    goto[bb14->bb9] ->
+    goto[bb13->bb12] ->
       (none)
-    cancel[bb14] ->
-      (none)
-    goto[bb15->bb16] ->
-      (none)
-    branch[bb16: bb17/bb18] ->
-      (none)
-    goto[bb17->bb19] ->
-      (none)
-    goto[bb18->bb19] ->
-      (none)
-    goto[bb19->bb14] ->
-      (none)
-    cancel[bb19] ->
+    cancel[bb13] ->
       (none)
 
 fn fs$io_error_message -> string
   statements:
-    use BindingId(7) e site=SiteId(71) ty=IoError intent=Read
-    return site=Some(SiteId(70)) ty=string
-    bind BindingId(8) code site=SiteId(72) ty=i64
-    use BindingId(8) code site=SiteId(74) ty=i64 intent=Read
-    bind BindingId(9) code site=SiteId(82) ty=i64
-    use BindingId(9) code site=SiteId(84) ty=i64 intent=Read
-    bind BindingId(10) code site=SiteId(92) ty=i64
-    use BindingId(10) code site=SiteId(94) ty=i64 intent=Read
-    bind BindingId(11) code site=SiteId(102) ty=i64
-    use BindingId(11) code site=SiteId(104) ty=i64 intent=Read
-    bind BindingId(12) code site=SiteId(112) ty=i64
-    use BindingId(12) code site=SiteId(114) ty=i64 intent=Read
-    bind BindingId(13) code site=SiteId(122) ty=i64
-    use BindingId(13) code site=SiteId(124) ty=i64 intent=Read
+    use BindingId(9) e site=SiteId(107) ty=IoError intent=Read
+    return site=Some(SiteId(106)) ty=string
+    bind BindingId(10) code site=SiteId(108) ty=i64
+    use BindingId(10) code site=SiteId(110) ty=i64 intent=Read
+    bind BindingId(11) code site=SiteId(118) ty=i64
+    use BindingId(11) code site=SiteId(120) ty=i64 intent=Read
+    bind BindingId(12) code site=SiteId(128) ty=i64
+    use BindingId(12) code site=SiteId(130) ty=i64 intent=Read
+    bind BindingId(13) code site=SiteId(138) ty=i64
+    use BindingId(13) code site=SiteId(140) ty=i64 intent=Read
+    bind BindingId(14) code site=SiteId(148) ty=i64
+    use BindingId(14) code site=SiteId(150) ty=i64 intent=Read
+    bind BindingId(15) code site=SiteId(158) ty=i64
+    use BindingId(15) code site=SiteId(160) ty=i64 intent=Read
   drop_plans:
     branch[bb0: bb2/bb9] ->
       (none)
@@ -207,363 +264,73 @@ fn fs$io_error_message -> string
 
 fn fs$io_error_timed_out -> IoError
   statements:
-    return site=Some(SiteId(132)) ty=IoError
+    return site=Some(SiteId(168)) ty=IoError
   drop_plans:
     return[bb0] ->
       (none)
 
 fn fs$io_error_cancelled -> IoError
   statements:
-    return site=Some(SiteId(134)) ty=IoError
+    return site=Some(SiteId(170)) ty=IoError
   drop_plans:
     return[bb0] ->
       (none)
 
-fn fs$missing_parent -> bool
+fn fs$last_io_error -> IoError
   statements:
-    use BindingId(14) target site=SiteId(137) ty=string intent=Read
-    bind BindingId(15) parent site=SiteId(136) ty=string
-    use BindingId(15) parent site=SiteId(141) ty=string intent=Read
-    use BindingId(15) parent site=SiteId(145) ty=string intent=Read
-    return site=Some(SiteId(139)) ty=bool
-    drop BindingId(15) parent ty=string
+    bind BindingId(16) kind site=SiteId(173) ty=i64
+    bind BindingId(17) errno site=SiteId(176) ty=i64
+    eval site=SiteId(179) ty=string
+    use BindingId(17) errno site=SiteId(184) ty=i64 intent=Read
+    use BindingId(16) kind site=SiteId(187) ty=i64 intent=Read
+    use BindingId(16) kind site=SiteId(194) ty=i64 intent=Read
+    use BindingId(17) errno site=SiteId(195) ty=i64 intent=Read
+    return site=Some(SiteId(172)) ty=IoError
   drop_plans:
-    call[bb0 fs$dirname -> bb1] ->
+    call[bb0 hew_stream_last_error_kind -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    branch[bb1: bb2/bb3] ->
+    call[bb1 hew_stream_last_errno -> bb2] ->
       (none)
-    call[bb2 fs$exists -> bb4] ->
+    call[bb2 hew_stream_last_error -> bb3] ->
       (none)
-    return[bb3] ->
-      (none)
-    goto[bb4->bb3] ->
-      (none)
-    cancel[bb4] ->
-      (none)
-
-fn fs$dirname -> string
-  statements:
-    use BindingId(16) p site=SiteId(148) ty=string intent=Read
-    bind BindingId(17) s site=SiteId(147) ty=string
-    use BindingId(17) s site=SiteId(151) ty=string intent=Read
-    bind BindingId(18) pos site=SiteId(150) ty=i64
-    use BindingId(18) pos site=SiteId(154) ty=i64 intent=Read
-    return site=Some(SiteId(156)) ty=string
-    eval site=SiteId(158) ty=()
-    use BindingId(18) pos site=SiteId(160) ty=i64 intent=Read
-    return site=Some(SiteId(162)) ty=string
-    eval site=SiteId(164) ty=()
-    use BindingId(17) s site=SiteId(166) ty=string intent=Read
-    use BindingId(18) pos site=SiteId(168) ty=i64 intent=Read
-    return site=Some(SiteId(165)) ty=string
-    drop BindingId(17) s ty=string
-  drop_plans:
-    call[bb0 fs$strip_trailing_slash -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    call[bb1 fs$last_slash_pos -> bb2] ->
-      (none)
-    branch[bb2: bb3/bb4] ->
-      (none)
-    return[bb3] ->
+    branch[bb3: bb4/bb5] ->
       (none)
     goto[bb4->bb5] ->
       (none)
-    branch[bb5: bb7/bb8] ->
-      (none)
-    goto[bb6->bb5] ->
-      (none)
-    cancel[bb6] ->
-      (none)
-    return[bb7] ->
-      (none)
-    goto[bb8->bb9] ->
-      (none)
-    call[bb9 hew_string_slice -> bb11] ->
-      (none)
-    goto[bb10->bb9] ->
-      (none)
-    cancel[bb10] ->
-      (none)
-    return[bb11] ->
-      (none)
-
-fn fs$strip_trailing_slash -> string
-  statements:
-    use BindingId(19) p site=SiteId(171) ty=string intent=Read
-    use BindingId(19) p site=SiteId(175) ty=string intent=Read
-    return site=Some(SiteId(173)) ty=string
-    eval site=SiteId(177) ty=()
-    use BindingId(19) p site=SiteId(181) ty=string intent=Read
-    use BindingId(19) p site=SiteId(185) ty=string intent=Read
-    use BindingId(19) p site=SiteId(189) ty=string intent=Read
-    use BindingId(19) p site=SiteId(193) ty=string intent=Read
-    eval site=SiteId(198) ty=()
-    use BindingId(19) p site=SiteId(201) ty=string intent=Read
-    return site=Some(SiteId(199)) ty=string
-    return site=Some(SiteId(188)) ty=string
-  drop_plans:
-    branch[bb0: bb1/bb2] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    return[bb1] ->
-      (none)
-    goto[bb2->bb3] ->
-      (none)
-    call[bb3 hew_string_length -> bb5] ->
-      (none)
-    goto[bb4->bb3] ->
-      (none)
-    cancel[bb4] ->
-      (none)
-    branch[bb5: bb6/bb7] ->
-      (none)
-    call[bb6 hew_string_ends_with -> bb8] ->
-      (none)
-    branch[bb7: bb9/bb10] ->
-      (none)
-    goto[bb8->bb7] ->
-      (none)
-    cancel[bb8] ->
-      (none)
-    call[bb9 hew_string_length -> bb12] ->
-      (none)
-    goto[bb10->bb11] ->
-      (none)
-    return[bb11] ->
-      (none)
-    branch[bb12: bb13/bb14] ->
-      (none)
-    panic[bb13] ->
-      (none)
-    call[bb14 hew_string_slice -> bb15] ->
-      (none)
-    return[bb15] ->
-      (none)
-    goto[bb16->bb11] ->
-      (none)
-    cancel[bb16] ->
-      (none)
-
-fn fs$last_slash_pos -> i64
-  statements:
-    use BindingId(20) s site=SiteId(204) ty=string intent=Read
-    bind BindingId(22) first site=SiteId(202) ty=i64
-    use BindingId(22) first site=SiteId(210) ty=i64 intent=Consume
-    bind BindingId(23) last site=SiteId(210) ty=i64
-    use BindingId(22) first site=SiteId(212) ty=i64 intent=Read
-    bind BindingId(21) i site=SiteId(207) ty=i64
-    use BindingId(21) i site=SiteId(207) ty=i64 intent=Read
-    return site=Some(SiteId(209)) ty=i64
-    bind BindingId(24) search_from site=SiteId(211) ty=i64
-    use BindingId(24) search_from site=SiteId(215) ty=i64 intent=Read
-    use BindingId(20) s site=SiteId(217) ty=string intent=Read
-    use BindingId(20) s site=SiteId(220) ty=string intent=Read
-    use BindingId(24) search_from site=SiteId(221) ty=i64 intent=Read
-    use BindingId(20) s site=SiteId(223) ty=string intent=Read
-    eval site=SiteId(242) ty=()
-    use BindingId(23) last site=SiteId(243) ty=i64 intent=Read
-    return site=Some(SiteId(243)) ty=i64
-    bind BindingId(25) rest site=SiteId(219) ty=string
-    use BindingId(25) rest site=SiteId(228) ty=string intent=Read
-    bind BindingId(27) next site=SiteId(226) ty=i64
-    use BindingId(24) search_from site=SiteId(236) ty=i64 intent=Read
-    use BindingId(27) next site=SiteId(237) ty=i64 intent=Read
-    bind BindingId(26) i site=SiteId(231) ty=i64
-    use BindingId(26) i site=SiteId(231) ty=i64 intent=Read
-    use BindingId(23) last site=SiteId(233) ty=i64 intent=Consume
-    return site=Some(SiteId(233)) ty=i64
-    bind BindingId(23) last site=SiteId(234) ty=i64
-    eval site=SiteId(235) ty=()
-    use BindingId(23) last site=SiteId(240) ty=i64 intent=Read
-    bind BindingId(24) search_from site=SiteId(238) ty=i64
-    eval site=SiteId(239) ty=()
-    drop BindingId(25) rest ty=string
-  drop_plans:
-    call[bb0 hew_string_find -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb3/bb6] ->
-      (none)
-    branch[bb2: bb8/bb9] ->
-      (none)
-    goto[bb3->bb2] ->
-      (none)
-    cancel[bb3] ->
-      (none)
-    return[bb4] ->
-      (none)
-    panic[bb5] ->
-      (none)
-    branch[bb6: bb4/bb5] ->
-      (none)
-    goto[bb7->bb2] ->
-      (none)
-    cancel[bb7] ->
-      (none)
-    panic[bb8] ->
-      (none)
-    goto[bb9->bb10] ->
-      (none)
-    call[bb10 hew_string_length -> bb13] ->
-      (none)
-    call[bb11 hew_string_length -> bb14] ->
-      (none)
-    return[bb12] ->
-      (none)
-    branch[bb13: bb11/bb12] ->
-      (none)
-    call[bb14 hew_string_slice -> bb15] ->
-      (none)
-    call[bb15 hew_string_find -> bb16] ->
-      (none)
-    branch[bb16: bb18/bb21] ->
-      (none)
-    branch[bb17: bb23/bb24] ->
-      (none)
-    goto[bb18->bb17] ->
-      (none)
-    cancel[bb18] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    return[bb19] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    panic[bb20] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    branch[bb21: bb19/bb20] ->
-      (none)
-    goto[bb22->bb17] ->
-      (none)
-    cancel[bb22] ->
-      (none)
-    panic[bb23] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    branch[bb24: bb25/bb26] ->
-      (none)
-    panic[bb25] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    goto[bb26->bb10] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-    cancel[bb26] ->
-      drop _21 ty=string kind=cow_heap(hew_string_drop)
-
-fn fs$write_error -> IoError
-  statements:
-    use BindingId(28) target site=SiteId(246) ty=string intent=Read
-    return site=Some(SiteId(244)) ty=IoError
-  drop_plans:
-    call[bb0 fs$missing_parent -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb2/bb3] ->
-      (none)
-    goto[bb2->bb4] ->
-      (none)
-    goto[bb3->bb4] ->
-      (none)
-    return[bb4] ->
-      (none)
-
-fn fs$missing_path_error -> IoError
-  statements:
-    use BindingId(29) target site=SiteId(256) ty=string intent=Read
-    return site=Some(SiteId(254)) ty=IoError
-  drop_plans:
-    call[bb0 fs$exists -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb2/bb3] ->
-      (none)
-    goto[bb2->bb4] ->
-      (none)
-    goto[bb3->bb4] ->
-      (none)
-    return[bb4] ->
-      (none)
-
-fn fs$mkdir_error -> IoError
-  statements:
-    use BindingId(30) target site=SiteId(266) ty=string intent=Read
-    use BindingId(30) target site=SiteId(273) ty=string intent=Read
-    return site=Some(SiteId(264)) ty=IoError
-  drop_plans:
-    call[bb0 fs$exists -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb2/bb3] ->
-      (none)
-    goto[bb2->bb4] ->
-      (none)
-    call[bb3 fs$missing_parent -> bb5] ->
-      (none)
-    return[bb4] ->
-      (none)
     branch[bb5: bb6/bb7] ->
       (none)
     goto[bb6->bb8] ->
       (none)
-    goto[bb7->bb8] ->
+    call[bb7 fs$io_error_from_kind -> bb9] ->
       (none)
-    goto[bb8->bb4] ->
+    return[bb8] ->
       (none)
-    cancel[bb8] ->
+    goto[bb9->bb8] ->
       (none)
-
-fn fs$move_copy_error -> IoError
-  statements:
-    use BindingId(31) source site=SiteId(284) ty=string intent=Read
-    use BindingId(32) target site=SiteId(291) ty=string intent=Read
-    return site=Some(SiteId(281)) ty=IoError
-  drop_plans:
-    call[bb0 fs$exists -> bb1] ->
-      (none)
-    cancel[bb0] ->
-      (none)
-    branch[bb1: bb2/bb3] ->
-      (none)
-    goto[bb2->bb4] ->
-      (none)
-    call[bb3 fs$missing_parent -> bb5] ->
-      (none)
-    return[bb4] ->
-      (none)
-    branch[bb5: bb6/bb7] ->
-      (none)
-    goto[bb6->bb8] ->
-      (none)
-    goto[bb7->bb8] ->
-      (none)
-    goto[bb8->bb4] ->
-      (none)
-    cancel[bb8] ->
+    cancel[bb9] ->
       (none)
 
 fn fs$read -> string
   statements:
-    use BindingId(33) path site=SiteId(301) ty=string intent=Read
-    bind BindingId(34) contents site=SiteId(300) ty=string
-    bind BindingId(35) errno site=SiteId(303) ty=i32
-    use BindingId(35) errno site=SiteId(306) ty=i32 intent=Read
-    eval site=SiteId(358) ty=()
-    use BindingId(34) contents site=SiteId(359) ty=string intent=Read
-    return site=Some(SiteId(299)) ty=string
-    bind BindingId(36) detail site=SiteId(308) ty=string
-    use BindingId(36) detail site=SiteId(313) ty=string intent=Read
-    use BindingId(33) path site=SiteId(320) ty=string intent=Read
-    use BindingId(33) path site=SiteId(343) ty=string intent=Read
-    use BindingId(35) errno site=SiteId(327) ty=i32 intent=Read
-    eval site=SiteId(317) ty=!
-    use BindingId(36) detail site=SiteId(347) ty=string intent=Read
-    eval site=SiteId(340) ty=!
-    drop BindingId(36) detail ty=string
-    drop BindingId(34) contents ty=string
+    use BindingId(18) path site=SiteId(199) ty=string intent=Read
+    bind BindingId(19) contents site=SiteId(198) ty=string
+    bind BindingId(20) errno site=SiteId(201) ty=i32
+    use BindingId(20) errno site=SiteId(204) ty=i32 intent=Read
+    eval site=SiteId(256) ty=()
+    use BindingId(19) contents site=SiteId(257) ty=string intent=Read
+    return site=Some(SiteId(197)) ty=string
+    bind BindingId(21) detail site=SiteId(206) ty=string
+    use BindingId(21) detail site=SiteId(211) ty=string intent=Read
+    use BindingId(18) path site=SiteId(218) ty=string intent=Read
+    use BindingId(18) path site=SiteId(241) ty=string intent=Read
+    use BindingId(20) errno site=SiteId(225) ty=i32 intent=Read
+    eval site=SiteId(215) ty=!
+    use BindingId(21) detail site=SiteId(245) ty=string intent=Read
+    eval site=SiteId(238) ty=!
+    drop BindingId(21) detail ty=string
+    drop BindingId(19) contents ty=string
   drop_plans:
     call[bb0 hew_file_read -> bb1] ->
       (none)
@@ -626,14 +393,21 @@ fn fs$read -> string
 
 fn fs$try_read -> Result<string, IoError>
   statements:
-    use BindingId(37) file_path site=SiteId(362) ty=string intent=Read
-    bind BindingId(38) file site=SiteId(361) ty=FileReadStream
-    use BindingId(38) file site=SiteId(366) ty=FileReadStream intent=Read
-    use BindingId(38) file site=SiteId(371) ty=FileReadStream intent=Read
-    return site=Some(SiteId(360)) ty=Result<string, IoError>
-    bind BindingId(39) errno site=SiteId(374) ty=i32
-    eval site=SiteId(376) ty=string
-    use BindingId(39) errno site=SiteId(381) ty=i32 intent=Read
+    use BindingId(22) file_path site=SiteId(260) ty=string intent=Read
+    bind BindingId(23) file site=SiteId(259) ty=FileReadStream
+    use BindingId(23) file site=SiteId(264) ty=FileReadStream intent=Read
+    use BindingId(23) file site=SiteId(268) ty=FileReadStream intent=Read
+    return site=Some(SiteId(258)) ty=Result<string, IoError>
+    bind BindingId(24) contents site=SiteId(267) ty=string
+    bind BindingId(25) kind site=SiteId(270) ty=i64
+    bind BindingId(26) errno site=SiteId(273) ty=i32
+    eval site=SiteId(275) ty=string
+    use BindingId(26) errno site=SiteId(279) ty=i32 intent=Read
+    use BindingId(24) contents site=SiteId(283) ty=string intent=Read
+    agg_alias BindingId(24) contents site=SiteId(283) ty=string
+    use BindingId(25) kind site=SiteId(287) ty=i64 intent=Read
+    use BindingId(26) errno site=SiteId(289) ty=i32 intent=Read
+    drop BindingId(24) contents ty=string
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -645,28 +419,40 @@ fn fs$try_read -> Result<string, IoError>
       (none)
     call[bb3 hew_stream_collect_string -> bb6] ->
       (none)
-    call[bb4 hew_stream_last_errno -> bb7] ->
+    call[bb4 fs$last_io_error -> bb14] ->
       (none)
     return[bb5] ->
       (none)
-    goto[bb6->bb5] ->
+    call[bb6 hew_stream_last_error_kind -> bb7] ->
       (none)
-    cancel[bb6] ->
+    call[bb7 hew_stream_last_errno -> bb8] ->
       (none)
-    call[bb7 hew_stream_last_error -> bb8] ->
+    call[bb8 hew_stream_last_error -> bb9] ->
       (none)
-    call[bb8 fs$io_error_from_errno -> bb9] ->
+    branch[bb9: bb10/bb11] ->
       (none)
-    goto[bb9->bb5] ->
+    goto[bb10->bb12] ->
       (none)
-    cancel[bb9] ->
+    call[bb11 fs$io_error_from_kind -> bb13] ->
+      (none)
+    goto[bb12->bb5] ->
+      (none)
+    cancel[bb12] ->
+      (none)
+    goto[bb13->bb12] ->
+      (none)
+    cancel[bb13] ->
+      (none)
+    goto[bb14->bb5] ->
+      (none)
+    cancel[bb14] ->
       (none)
 
 fn fs$write -> i64
   statements:
-    use BindingId(40) path site=SiteId(386) ty=string intent=Read
-    use BindingId(41) content site=SiteId(387) ty=string intent=Read
-    return site=Some(SiteId(383)) ty=i64
+    use BindingId(27) path site=SiteId(298) ty=string intent=Read
+    use BindingId(28) content site=SiteId(299) ty=string intent=Read
+    return site=Some(SiteId(295)) ty=i64
   drop_plans:
     call[bb0 hew_file_write -> bb1] ->
       (none)
@@ -677,10 +463,9 @@ fn fs$write -> i64
 
 fn fs$try_write -> Result<i64, IoError>
   statements:
-    use BindingId(42) file_path site=SiteId(392) ty=string intent=Read
-    use BindingId(43) content site=SiteId(393) ty=string intent=Read
-    return site=Some(SiteId(389)) ty=Result<i64, IoError>
-    use BindingId(42) file_path site=SiteId(399) ty=string intent=Read
+    use BindingId(29) file_path site=SiteId(304) ty=string intent=Read
+    use BindingId(30) content site=SiteId(305) ty=string intent=Read
+    return site=Some(SiteId(301)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_file_write -> bb1] ->
       (none)
@@ -692,7 +477,7 @@ fn fs$try_write -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$write_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -707,9 +492,9 @@ fn fs$try_write -> Result<i64, IoError>
 
 fn fs$append -> i64
   statements:
-    use BindingId(44) path site=SiteId(404) ty=string intent=Read
-    use BindingId(45) content site=SiteId(405) ty=string intent=Read
-    return site=Some(SiteId(401)) ty=i64
+    use BindingId(31) path site=SiteId(315) ty=string intent=Read
+    use BindingId(32) content site=SiteId(316) ty=string intent=Read
+    return site=Some(SiteId(312)) ty=i64
   drop_plans:
     call[bb0 hew_file_append -> bb1] ->
       (none)
@@ -720,10 +505,9 @@ fn fs$append -> i64
 
 fn fs$try_append -> Result<i64, IoError>
   statements:
-    use BindingId(46) file_path site=SiteId(410) ty=string intent=Read
-    use BindingId(47) content site=SiteId(411) ty=string intent=Read
-    return site=Some(SiteId(407)) ty=Result<i64, IoError>
-    use BindingId(46) file_path site=SiteId(417) ty=string intent=Read
+    use BindingId(33) file_path site=SiteId(321) ty=string intent=Read
+    use BindingId(34) content site=SiteId(322) ty=string intent=Read
+    return site=Some(SiteId(318)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_file_append -> bb1] ->
       (none)
@@ -735,7 +519,7 @@ fn fs$try_append -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$write_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -750,8 +534,8 @@ fn fs$try_append -> Result<i64, IoError>
 
 fn fs$exists -> bool
   statements:
-    use BindingId(48) path site=SiteId(421) ty=string intent=Read
-    return site=Some(SiteId(419)) ty=bool
+    use BindingId(35) path site=SiteId(331) ty=string intent=Read
+    return site=Some(SiteId(329)) ty=bool
   drop_plans:
     call[bb0 hew_file_exists -> bb1] ->
       (none)
@@ -762,8 +546,8 @@ fn fs$exists -> bool
 
 fn fs$delete -> i64
   statements:
-    use BindingId(49) path site=SiteId(426) ty=string intent=Read
-    return site=Some(SiteId(423)) ty=i64
+    use BindingId(36) path site=SiteId(336) ty=string intent=Read
+    return site=Some(SiteId(333)) ty=i64
   drop_plans:
     call[bb0 hew_file_delete -> bb1] ->
       (none)
@@ -774,9 +558,8 @@ fn fs$delete -> i64
 
 fn fs$try_delete -> Result<i64, IoError>
   statements:
-    use BindingId(50) file_path site=SiteId(431) ty=string intent=Read
-    return site=Some(SiteId(428)) ty=Result<i64, IoError>
-    use BindingId(50) file_path site=SiteId(437) ty=string intent=Read
+    use BindingId(37) file_path site=SiteId(341) ty=string intent=Read
+    return site=Some(SiteId(338)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_file_delete -> bb1] ->
       (none)
@@ -788,7 +571,7 @@ fn fs$try_delete -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$missing_path_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -803,8 +586,8 @@ fn fs$try_delete -> Result<i64, IoError>
 
 fn fs$size -> i64
   statements:
-    use BindingId(51) path site=SiteId(441) ty=string intent=Read
-    return site=Some(SiteId(439)) ty=i64
+    use BindingId(38) path site=SiteId(350) ty=string intent=Read
+    return site=Some(SiteId(348)) ty=i64
   drop_plans:
     call[bb0 hew_file_size -> bb1] ->
       (none)
@@ -815,8 +598,8 @@ fn fs$size -> i64
 
 fn fs$read_bytes -> bytes
   statements:
-    use BindingId(52) path site=SiteId(445) ty=string intent=Read
-    return site=Some(SiteId(443)) ty=bytes
+    use BindingId(39) path site=SiteId(354) ty=string intent=Read
+    return site=Some(SiteId(352)) ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
       (none)
@@ -827,42 +610,46 @@ fn fs$read_bytes -> bytes
 
 fn fs$try_read_bytes -> Result<bytes, IoError>
   statements:
-    use BindingId(53) file_path site=SiteId(449) ty=string intent=Read
-    bind BindingId(54) data site=SiteId(448) ty=bytes
-    bind BindingId(55) errno site=SiteId(451) ty=i32
-    use BindingId(55) errno site=SiteId(455) ty=i32 intent=Read
-    use BindingId(54) data site=SiteId(467) ty=bytes intent=Read
-    return site=Some(SiteId(447)) ty=Result<bytes, IoError>
-    eval site=SiteId(458) ty=string
-    use BindingId(55) errno site=SiteId(463) ty=i32 intent=Read
-    drop BindingId(54) data ty=bytes
+    use BindingId(40) file_path site=SiteId(358) ty=string intent=Read
+    bind BindingId(41) data site=SiteId(357) ty=bytes
+    bind BindingId(42) kind site=SiteId(360) ty=i64
+    bind BindingId(43) errno site=SiteId(363) ty=i32
+    use BindingId(43) errno site=SiteId(367) ty=i32 intent=Read
+    use BindingId(41) data site=SiteId(380) ty=bytes intent=Read
+    return site=Some(SiteId(356)) ty=Result<bytes, IoError>
+    eval site=SiteId(370) ty=string
+    use BindingId(42) kind site=SiteId(374) ty=i64 intent=Read
+    use BindingId(43) errno site=SiteId(376) ty=i32 intent=Read
+    drop BindingId(41) data ty=bytes
   drop_plans:
     call[bb0 hew_file_read_bytes -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    call[bb1 hew_stream_last_errno -> bb2] ->
+    call[bb1 hew_stream_last_error_kind -> bb2] ->
       (none)
-    branch[bb2: bb3/bb4] ->
+    call[bb2 hew_stream_last_errno -> bb3] ->
       (none)
-    call[bb3 hew_stream_last_error -> bb6] ->
+    branch[bb3: bb4/bb5] ->
       (none)
-    goto[bb4->bb5] ->
+    call[bb4 hew_stream_last_error -> bb7] ->
       (none)
-    return[bb5] ->
+    goto[bb5->bb6] ->
       (none)
-    call[bb6 fs$io_error_from_errno -> bb7] ->
+    return[bb6] ->
       (none)
-    goto[bb7->bb5] ->
+    call[bb7 fs$io_error_from_kind -> bb8] ->
       (none)
-    cancel[bb7] ->
+    goto[bb8->bb6] ->
+      (none)
+    cancel[bb8] ->
       (none)
 
 fn fs$write_bytes -> i64
   statements:
-    use BindingId(56) path site=SiteId(471) ty=string intent=Read
-    use BindingId(57) data site=SiteId(472) ty=bytes intent=Read
-    return site=Some(SiteId(468)) ty=i64
+    use BindingId(44) path site=SiteId(384) ty=string intent=Read
+    use BindingId(45) data site=SiteId(385) ty=bytes intent=Read
+    return site=Some(SiteId(381)) ty=i64
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -873,10 +660,9 @@ fn fs$write_bytes -> i64
 
 fn fs$try_write_bytes -> Result<i64, IoError>
   statements:
-    use BindingId(58) file_path site=SiteId(477) ty=string intent=Read
-    use BindingId(59) data site=SiteId(478) ty=bytes intent=Read
-    return site=Some(SiteId(474)) ty=Result<i64, IoError>
-    use BindingId(58) file_path site=SiteId(484) ty=string intent=Read
+    use BindingId(46) file_path site=SiteId(390) ty=string intent=Read
+    use BindingId(47) data site=SiteId(391) ty=bytes intent=Read
+    return site=Some(SiteId(387)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_file_write_bytes -> bb1] ->
       (none)
@@ -888,7 +674,7 @@ fn fs$try_write_bytes -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$write_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -903,8 +689,8 @@ fn fs$try_write_bytes -> Result<i64, IoError>
 
 fn fs$mkdir -> i64
   statements:
-    use BindingId(60) path site=SiteId(489) ty=string intent=Read
-    return site=Some(SiteId(486)) ty=i64
+    use BindingId(48) path site=SiteId(401) ty=string intent=Read
+    return site=Some(SiteId(398)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -915,9 +701,8 @@ fn fs$mkdir -> i64
 
 fn fs$try_mkdir -> Result<i64, IoError>
   statements:
-    use BindingId(61) dir_path site=SiteId(494) ty=string intent=Read
-    return site=Some(SiteId(491)) ty=Result<i64, IoError>
-    use BindingId(61) dir_path site=SiteId(500) ty=string intent=Read
+    use BindingId(49) dir_path site=SiteId(406) ty=string intent=Read
+    return site=Some(SiteId(403)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_fs_mkdir -> bb1] ->
       (none)
@@ -929,7 +714,7 @@ fn fs$try_mkdir -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$mkdir_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -944,8 +729,8 @@ fn fs$try_mkdir -> Result<i64, IoError>
 
 fn fs$mkdir_all -> i64
   statements:
-    use BindingId(62) path site=SiteId(505) ty=string intent=Read
-    return site=Some(SiteId(502)) ty=i64
+    use BindingId(50) path site=SiteId(416) ty=string intent=Read
+    return site=Some(SiteId(413)) ty=i64
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -956,9 +741,8 @@ fn fs$mkdir_all -> i64
 
 fn fs$try_mkdir_all -> Result<i64, IoError>
   statements:
-    use BindingId(63) dir_path site=SiteId(510) ty=string intent=Read
-    return site=Some(SiteId(507)) ty=Result<i64, IoError>
-    use BindingId(63) dir_path site=SiteId(517) ty=string intent=Read
+    use BindingId(51) dir_path site=SiteId(421) ty=string intent=Read
+    return site=Some(SiteId(418)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_fs_mkdir_all -> bb1] ->
       (none)
@@ -970,7 +754,7 @@ fn fs$try_mkdir_all -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$exists -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -978,21 +762,15 @@ fn fs$try_mkdir_all -> Result<i64, IoError>
       (none)
     cancel[bb6] ->
       (none)
-    branch[bb7: bb8/bb9] ->
+    goto[bb7->bb2] ->
       (none)
-    goto[bb8->bb10] ->
-      (none)
-    goto[bb9->bb10] ->
-      (none)
-    goto[bb10->bb2] ->
-      (none)
-    cancel[bb10] ->
+    cancel[bb7] ->
       (none)
 
 fn fs$list_dir -> Vec<string>
   statements:
-    use BindingId(64) path site=SiteId(529) ty=string intent=Read
-    return site=Some(SiteId(527)) ty=Vec<string>
+    use BindingId(52) path site=SiteId(430) ty=string intent=Read
+    return site=Some(SiteId(428)) ty=Vec<string>
   drop_plans:
     call[bb0 hew_fs_list_dir -> bb1] ->
       (none)
@@ -1003,51 +781,47 @@ fn fs$list_dir -> Vec<string>
 
 fn fs$try_list_dir -> Result<Vec<string>, IoError>
   statements:
-    use BindingId(65) dir_path site=SiteId(533) ty=string intent=Read
-    return site=Some(SiteId(535)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(539) ty=()
-    use BindingId(65) dir_path site=SiteId(542) ty=string intent=Read
-    return site=Some(SiteId(544)) ty=Result<Vec<string>, IoError>
-    eval site=SiteId(548) ty=()
-    use BindingId(65) dir_path site=SiteId(552) ty=string intent=Read
-    return site=Some(SiteId(549)) ty=Result<Vec<string>, IoError>
+    use BindingId(53) dir_path site=SiteId(434) ty=string intent=Read
+    bind BindingId(54) entries site=SiteId(433) ty=Vec<string>
+    bind BindingId(55) kind site=SiteId(436) ty=i64
+    bind BindingId(56) errno site=SiteId(439) ty=i32
+    eval site=SiteId(441) ty=string
+    use BindingId(56) errno site=SiteId(445) ty=i32 intent=Read
+    use BindingId(54) entries site=SiteId(449) ty=Vec<string> intent=Read
+    agg_alias BindingId(54) entries site=SiteId(449) ty=Vec<string>
+    use BindingId(55) kind site=SiteId(453) ty=i64 intent=Read
+    use BindingId(56) errno site=SiteId(455) ty=i32 intent=Read
+    return site=Some(SiteId(432)) ty=Result<Vec<string>, IoError>
+    drop BindingId(54) entries ty=Vec<string>
   drop_plans:
-    call[bb0 fs$exists -> bb1] ->
+    call[bb0 hew_fs_list_dir -> bb1] ->
       (none)
     cancel[bb0] ->
       (none)
-    branch[bb1: bb2/bb3] ->
+    call[bb1 hew_stream_last_error_kind -> bb2] ->
       (none)
-    return[bb2] ->
+    call[bb2 hew_stream_last_errno -> bb3] ->
       (none)
-    goto[bb3->bb4] ->
+    call[bb3 hew_stream_last_error -> bb4] ->
       (none)
-    call[bb4 fs$is_dir -> bb6] ->
+    branch[bb4: bb5/bb6] ->
       (none)
-    goto[bb5->bb4] ->
+    goto[bb5->bb7] ->
       (none)
-    cancel[bb5] ->
-      (none)
-    branch[bb6: bb7/bb8] ->
+    call[bb6 fs$io_error_from_kind -> bb8] ->
       (none)
     return[bb7] ->
       (none)
-    goto[bb8->bb9] ->
+    goto[bb8->bb7] ->
       (none)
-    call[bb9 hew_fs_list_dir -> bb11] ->
-      (none)
-    goto[bb10->bb9] ->
-      (none)
-    cancel[bb10] ->
-      (none)
-    return[bb11] ->
+    cancel[bb8] ->
       (none)
 
 fn fs$rename -> i64
   statements:
-    use BindingId(66) from site=SiteId(557) ty=string intent=Read
-    use BindingId(67) to site=SiteId(558) ty=string intent=Read
-    return site=Some(SiteId(554)) ty=i64
+    use BindingId(57) from site=SiteId(460) ty=string intent=Read
+    use BindingId(58) to site=SiteId(461) ty=string intent=Read
+    return site=Some(SiteId(457)) ty=i64
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1058,11 +832,9 @@ fn fs$rename -> i64
 
 fn fs$try_rename -> Result<i64, IoError>
   statements:
-    use BindingId(68) from site=SiteId(563) ty=string intent=Read
-    use BindingId(69) to site=SiteId(564) ty=string intent=Read
-    return site=Some(SiteId(560)) ty=Result<i64, IoError>
-    use BindingId(68) from site=SiteId(570) ty=string intent=Read
-    use BindingId(69) to site=SiteId(571) ty=string intent=Read
+    use BindingId(59) from site=SiteId(466) ty=string intent=Read
+    use BindingId(60) to site=SiteId(467) ty=string intent=Read
+    return site=Some(SiteId(463)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_fs_rename -> bb1] ->
       (none)
@@ -1074,7 +846,7 @@ fn fs$try_rename -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$move_copy_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -1089,9 +861,9 @@ fn fs$try_rename -> Result<i64, IoError>
 
 fn fs$copy -> i64
   statements:
-    use BindingId(70) from site=SiteId(576) ty=string intent=Read
-    use BindingId(71) to site=SiteId(577) ty=string intent=Read
-    return site=Some(SiteId(573)) ty=i64
+    use BindingId(61) from site=SiteId(477) ty=string intent=Read
+    use BindingId(62) to site=SiteId(478) ty=string intent=Read
+    return site=Some(SiteId(474)) ty=i64
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1102,11 +874,9 @@ fn fs$copy -> i64
 
 fn fs$try_copy -> Result<i64, IoError>
   statements:
-    use BindingId(72) from site=SiteId(582) ty=string intent=Read
-    use BindingId(73) to site=SiteId(583) ty=string intent=Read
-    return site=Some(SiteId(579)) ty=Result<i64, IoError>
-    use BindingId(72) from site=SiteId(589) ty=string intent=Read
-    use BindingId(73) to site=SiteId(590) ty=string intent=Read
+    use BindingId(63) from site=SiteId(483) ty=string intent=Read
+    use BindingId(64) to site=SiteId(484) ty=string intent=Read
+    return site=Some(SiteId(480)) ty=Result<i64, IoError>
   drop_plans:
     call[bb0 hew_fs_copy -> bb1] ->
       (none)
@@ -1118,7 +888,7 @@ fn fs$try_copy -> Result<i64, IoError>
       (none)
     branch[bb3: bb6/bb4] ->
       (none)
-    call[bb4 fs$move_copy_error -> bb7] ->
+    call[bb4 fs$last_io_error -> bb7] ->
       (none)
     panic[bb5] ->
       (none)
@@ -1133,8 +903,8 @@ fn fs$try_copy -> Result<i64, IoError>
 
 fn fs$is_dir -> bool
   statements:
-    use BindingId(74) path site=SiteId(594) ty=string intent=Read
-    return site=Some(SiteId(592)) ty=bool
+    use BindingId(65) path site=SiteId(493) ty=string intent=Read
+    return site=Some(SiteId(491)) ty=bool
   drop_plans:
     call[bb0 hew_fs_is_dir -> bb1] ->
       (none)
@@ -1145,21 +915,21 @@ fn fs$is_dir -> bool
 
 fn stream$pipe -> (Sink<string>, Stream<string>)
   statements:
-    use BindingId(75) capacity site=SiteId(599) ty=i64 intent=Read
-    bind BindingId(76) pair site=SiteId(597) ty=StreamPair
-    use BindingId(76) pair site=SiteId(602) ty=StreamPair intent=Read
-    bind BindingId(77) sink site=SiteId(601) ty=Sink<string>
-    use BindingId(76) pair site=SiteId(605) ty=StreamPair intent=Read
-    bind BindingId(78) input site=SiteId(604) ty=Stream<string>
-    use BindingId(76) pair site=SiteId(608) ty=StreamPair intent=Read
-    eval site=SiteId(607) ty=()
-    use BindingId(77) sink site=SiteId(611) ty=Sink<string> intent=Read
-    use BindingId(78) input site=SiteId(612) ty=Stream<string> intent=Read
-    agg_alias BindingId(77) sink site=SiteId(611) ty=Sink<string>
-    agg_alias BindingId(78) input site=SiteId(612) ty=Stream<string>
-    return site=Some(SiteId(596)) ty=(Sink<string>, Stream<string>)
-    drop BindingId(78) input ty=Stream<string>
-    drop BindingId(77) sink ty=Sink<string>
+    use BindingId(66) capacity site=SiteId(498) ty=i64 intent=Read
+    bind BindingId(67) pair site=SiteId(496) ty=StreamPair
+    use BindingId(67) pair site=SiteId(501) ty=StreamPair intent=Read
+    bind BindingId(68) sink site=SiteId(500) ty=Sink<string>
+    use BindingId(67) pair site=SiteId(504) ty=StreamPair intent=Read
+    bind BindingId(69) input site=SiteId(503) ty=Stream<string>
+    use BindingId(67) pair site=SiteId(507) ty=StreamPair intent=Read
+    eval site=SiteId(506) ty=()
+    use BindingId(68) sink site=SiteId(510) ty=Sink<string> intent=Read
+    use BindingId(69) input site=SiteId(511) ty=Stream<string> intent=Read
+    agg_alias BindingId(68) sink site=SiteId(510) ty=Sink<string>
+    agg_alias BindingId(69) input site=SiteId(511) ty=Stream<string>
+    return site=Some(SiteId(495)) ty=(Sink<string>, Stream<string>)
+    drop BindingId(69) input ty=Stream<string>
+    drop BindingId(68) sink ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_channel -> bb1] ->
       (none)
@@ -1176,21 +946,21 @@ fn stream$pipe -> (Sink<string>, Stream<string>)
 
 fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
   statements:
-    use BindingId(79) capacity site=SiteId(616) ty=i64 intent=Read
-    bind BindingId(80) pair site=SiteId(614) ty=StreamPair
-    use BindingId(80) pair site=SiteId(619) ty=StreamPair intent=Read
-    bind BindingId(81) sink site=SiteId(618) ty=Sink<bytes>
-    use BindingId(80) pair site=SiteId(622) ty=StreamPair intent=Read
-    bind BindingId(82) input site=SiteId(621) ty=Stream<bytes>
-    use BindingId(80) pair site=SiteId(625) ty=StreamPair intent=Read
-    eval site=SiteId(624) ty=()
-    use BindingId(81) sink site=SiteId(628) ty=Sink<bytes> intent=Read
-    use BindingId(82) input site=SiteId(629) ty=Stream<bytes> intent=Read
-    agg_alias BindingId(81) sink site=SiteId(628) ty=Sink<bytes>
-    agg_alias BindingId(82) input site=SiteId(629) ty=Stream<bytes>
-    return site=Some(SiteId(613)) ty=(Sink<bytes>, Stream<bytes>)
-    drop BindingId(82) input ty=Stream<bytes>
-    drop BindingId(81) sink ty=Sink<bytes>
+    use BindingId(70) capacity site=SiteId(515) ty=i64 intent=Read
+    bind BindingId(71) pair site=SiteId(513) ty=StreamPair
+    use BindingId(71) pair site=SiteId(518) ty=StreamPair intent=Read
+    bind BindingId(72) sink site=SiteId(517) ty=Sink<bytes>
+    use BindingId(71) pair site=SiteId(521) ty=StreamPair intent=Read
+    bind BindingId(73) input site=SiteId(520) ty=Stream<bytes>
+    use BindingId(71) pair site=SiteId(524) ty=StreamPair intent=Read
+    eval site=SiteId(523) ty=()
+    use BindingId(72) sink site=SiteId(527) ty=Sink<bytes> intent=Read
+    use BindingId(73) input site=SiteId(528) ty=Stream<bytes> intent=Read
+    agg_alias BindingId(72) sink site=SiteId(527) ty=Sink<bytes>
+    agg_alias BindingId(73) input site=SiteId(528) ty=Stream<bytes>
+    return site=Some(SiteId(512)) ty=(Sink<bytes>, Stream<bytes>)
+    drop BindingId(73) input ty=Stream<bytes>
+    drop BindingId(72) sink ty=Sink<bytes>
   drop_plans:
     call[bb0 hew_stream_channel -> bb1] ->
       (none)
@@ -1207,13 +977,13 @@ fn stream$bytes_pipe -> (Sink<bytes>, Stream<bytes>)
 
 fn stream$from_file -> Result<Stream<string>, string>
   statements:
-    use BindingId(83) path site=SiteId(632) ty=string intent=Read
-    bind BindingId(84) s site=SiteId(631) ty=Stream<string>
-    use BindingId(84) s site=SiteId(636) ty=Stream<string> intent=Read
-    use BindingId(84) s site=SiteId(640) ty=Stream<string> intent=Read
-    agg_alias BindingId(84) s site=SiteId(640) ty=Stream<string>
-    return site=Some(SiteId(630)) ty=Result<Stream<string>, string>
-    drop BindingId(84) s ty=Stream<string>
+    use BindingId(74) path site=SiteId(531) ty=string intent=Read
+    bind BindingId(75) s site=SiteId(530) ty=Stream<string>
+    use BindingId(75) s site=SiteId(535) ty=Stream<string> intent=Read
+    use BindingId(75) s site=SiteId(539) ty=Stream<string> intent=Read
+    agg_alias BindingId(75) s site=SiteId(539) ty=Stream<string>
+    return site=Some(SiteId(529)) ty=Result<Stream<string>, string>
+    drop BindingId(75) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1236,16 +1006,18 @@ fn stream$from_file -> Result<Stream<string>, string>
 
 fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
   statements:
-    use BindingId(85) path site=SiteId(647) ty=string intent=Read
-    bind BindingId(86) s site=SiteId(646) ty=Stream<string>
-    use BindingId(86) s site=SiteId(651) ty=Stream<string> intent=Read
-    use BindingId(86) s site=SiteId(655) ty=Stream<string> intent=Read
-    agg_alias BindingId(86) s site=SiteId(655) ty=Stream<string>
-    return site=Some(SiteId(645)) ty=Result<Stream<string>, fs.IoError>
-    bind BindingId(87) errno site=SiteId(657) ty=i32
-    eval site=SiteId(659) ty=string
-    use BindingId(87) errno site=SiteId(664) ty=i32 intent=Read
-    drop BindingId(86) s ty=Stream<string>
+    use BindingId(76) path site=SiteId(546) ty=string intent=Read
+    bind BindingId(77) s site=SiteId(545) ty=Stream<string>
+    use BindingId(77) s site=SiteId(550) ty=Stream<string> intent=Read
+    use BindingId(77) s site=SiteId(554) ty=Stream<string> intent=Read
+    agg_alias BindingId(77) s site=SiteId(554) ty=Stream<string>
+    return site=Some(SiteId(544)) ty=Result<Stream<string>, fs.IoError>
+    bind BindingId(78) kind site=SiteId(556) ty=i64
+    bind BindingId(79) errno site=SiteId(559) ty=i32
+    eval site=SiteId(561) ty=string
+    use BindingId(78) kind site=SiteId(565) ty=i64 intent=Read
+    use BindingId(79) errno site=SiteId(567) ty=i32 intent=Read
+    drop BindingId(77) s ty=Stream<string>
   drop_plans:
     call[bb0 hew_stream_from_file_read -> bb1] ->
       (none)
@@ -1257,28 +1029,30 @@ fn stream$try_from_file -> Result<Stream<string>, fs.IoError>
       (none)
     goto[bb3->bb5] ->
       (none)
-    call[bb4 hew_stream_last_errno -> bb6] ->
+    call[bb4 hew_stream_last_error_kind -> bb6] ->
       (none)
     return[bb5] ->
       (none)
-    call[bb6 hew_stream_last_error -> bb7] ->
+    call[bb6 hew_stream_last_errno -> bb7] ->
       (none)
-    call[bb7 fs$io_error_from_errno -> bb8] ->
+    call[bb7 hew_stream_last_error -> bb8] ->
       (none)
-    goto[bb8->bb5] ->
+    call[bb8 fs$io_error_from_kind -> bb9] ->
       (none)
-    cancel[bb8] ->
+    goto[bb9->bb5] ->
+      (none)
+    cancel[bb9] ->
       (none)
 
 fn stream$to_file -> Result<Sink<string>, string>
   statements:
-    use BindingId(88) path site=SiteId(668) ty=string intent=Read
-    bind BindingId(89) s site=SiteId(667) ty=Sink<string>
-    use BindingId(89) s site=SiteId(672) ty=Sink<string> intent=Read
-    use BindingId(89) s site=SiteId(676) ty=Sink<string> intent=Read
-    agg_alias BindingId(89) s site=SiteId(676) ty=Sink<string>
-    return site=Some(SiteId(666)) ty=Result<Sink<string>, string>
-    drop BindingId(89) s ty=Sink<string>
+    use BindingId(80) path site=SiteId(571) ty=string intent=Read
+    bind BindingId(81) s site=SiteId(570) ty=Sink<string>
+    use BindingId(81) s site=SiteId(575) ty=Sink<string> intent=Read
+    use BindingId(81) s site=SiteId(579) ty=Sink<string> intent=Read
+    agg_alias BindingId(81) s site=SiteId(579) ty=Sink<string>
+    return site=Some(SiteId(569)) ty=Result<Sink<string>, string>
+    drop BindingId(81) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1301,16 +1075,18 @@ fn stream$to_file -> Result<Sink<string>, string>
 
 fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
   statements:
-    use BindingId(90) path site=SiteId(683) ty=string intent=Read
-    bind BindingId(91) s site=SiteId(682) ty=Sink<string>
-    use BindingId(91) s site=SiteId(687) ty=Sink<string> intent=Read
-    use BindingId(91) s site=SiteId(691) ty=Sink<string> intent=Read
-    agg_alias BindingId(91) s site=SiteId(691) ty=Sink<string>
-    return site=Some(SiteId(681)) ty=Result<Sink<string>, fs.IoError>
-    bind BindingId(92) errno site=SiteId(693) ty=i32
-    eval site=SiteId(695) ty=string
-    use BindingId(92) errno site=SiteId(700) ty=i32 intent=Read
-    drop BindingId(91) s ty=Sink<string>
+    use BindingId(82) path site=SiteId(586) ty=string intent=Read
+    bind BindingId(83) s site=SiteId(585) ty=Sink<string>
+    use BindingId(83) s site=SiteId(590) ty=Sink<string> intent=Read
+    use BindingId(83) s site=SiteId(594) ty=Sink<string> intent=Read
+    agg_alias BindingId(83) s site=SiteId(594) ty=Sink<string>
+    return site=Some(SiteId(584)) ty=Result<Sink<string>, fs.IoError>
+    bind BindingId(84) kind site=SiteId(596) ty=i64
+    bind BindingId(85) errno site=SiteId(599) ty=i32
+    eval site=SiteId(601) ty=string
+    use BindingId(84) kind site=SiteId(605) ty=i64 intent=Read
+    use BindingId(85) errno site=SiteId(607) ty=i32 intent=Read
+    drop BindingId(83) s ty=Sink<string>
   drop_plans:
     call[bb0 hew_stream_from_file_write -> bb1] ->
       (none)
@@ -1322,24 +1098,26 @@ fn stream$try_to_file -> Result<Sink<string>, fs.IoError>
       (none)
     goto[bb3->bb5] ->
       (none)
-    call[bb4 hew_stream_last_errno -> bb6] ->
+    call[bb4 hew_stream_last_error_kind -> bb6] ->
       (none)
     return[bb5] ->
       (none)
-    call[bb6 hew_stream_last_error -> bb7] ->
+    call[bb6 hew_stream_last_errno -> bb7] ->
       (none)
-    call[bb7 fs$io_error_from_errno -> bb8] ->
+    call[bb7 hew_stream_last_error -> bb8] ->
       (none)
-    goto[bb8->bb5] ->
+    call[bb8 fs$io_error_from_kind -> bb9] ->
       (none)
-    cancel[bb8] ->
+    goto[bb9->bb5] ->
+      (none)
+    cancel[bb9] ->
       (none)
 
 fn stream$forward -> ()
   statements:
-    use BindingId(93) source site=SiteId(704) ty=Stream<string> intent=Read
-    use BindingId(94) dest site=SiteId(705) ty=Sink<string> intent=Read
-    eval site=SiteId(702) ty=()
+    use BindingId(86) source site=SiteId(611) ty=Stream<string> intent=Read
+    use BindingId(87) dest site=SiteId(612) ty=Sink<string> intent=Read
+    eval site=SiteId(609) ty=()
   drop_plans:
     call[bb0 hew_stream_pipe -> bb1] ->
       (none)
@@ -1350,8 +1128,8 @@ fn stream$forward -> ()
 
 fn i8::fmt -> string
   statements:
-    use BindingId(103) val site=SiteId(777) ty=i8 intent=Read
-    return site=Some(SiteId(775)) ty=string
+    use BindingId(96) val site=SiteId(684) ty=i8 intent=Read
+    return site=Some(SiteId(682)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1362,8 +1140,8 @@ fn i8::fmt -> string
 
 fn i16::fmt -> string
   statements:
-    use BindingId(104) val site=SiteId(781) ty=i16 intent=Read
-    return site=Some(SiteId(779)) ty=string
+    use BindingId(97) val site=SiteId(688) ty=i16 intent=Read
+    return site=Some(SiteId(686)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1374,8 +1152,8 @@ fn i16::fmt -> string
 
 fn i32::fmt -> string
   statements:
-    use BindingId(105) val site=SiteId(784) ty=i32 intent=Read
-    return site=Some(SiteId(783)) ty=string
+    use BindingId(98) val site=SiteId(691) ty=i32 intent=Read
+    return site=Some(SiteId(690)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -1386,8 +1164,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(106) val site=SiteId(787) ty=i64 intent=Read
-    return site=Some(SiteId(786)) ty=string
+    use BindingId(99) val site=SiteId(694) ty=i64 intent=Read
+    return site=Some(SiteId(693)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1398,8 +1176,8 @@ fn i64::fmt -> string
 
 fn u8::fmt -> string
   statements:
-    use BindingId(107) val site=SiteId(790) ty=u8 intent=Read
-    return site=Some(SiteId(789)) ty=string
+    use BindingId(100) val site=SiteId(697) ty=u8 intent=Read
+    return site=Some(SiteId(696)) ty=string
   drop_plans:
     call[bb0 to_string_u8 -> bb1] ->
       (none)
@@ -1410,8 +1188,8 @@ fn u8::fmt -> string
 
 fn u16::fmt -> string
   statements:
-    use BindingId(108) val site=SiteId(793) ty=u16 intent=Read
-    return site=Some(SiteId(792)) ty=string
+    use BindingId(101) val site=SiteId(700) ty=u16 intent=Read
+    return site=Some(SiteId(699)) ty=string
   drop_plans:
     call[bb0 to_string_u16 -> bb1] ->
       (none)
@@ -1422,8 +1200,8 @@ fn u16::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(109) val site=SiteId(796) ty=u32 intent=Read
-    return site=Some(SiteId(795)) ty=string
+    use BindingId(102) val site=SiteId(703) ty=u32 intent=Read
+    return site=Some(SiteId(702)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -1434,8 +1212,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(110) val site=SiteId(799) ty=u64 intent=Read
-    return site=Some(SiteId(798)) ty=string
+    use BindingId(103) val site=SiteId(706) ty=u64 intent=Read
+    return site=Some(SiteId(705)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1446,8 +1224,8 @@ fn u64::fmt -> string
 
 fn isize::fmt -> string
   statements:
-    use BindingId(111) val site=SiteId(803) ty=isize intent=Read
-    return site=Some(SiteId(801)) ty=string
+    use BindingId(104) val site=SiteId(710) ty=isize intent=Read
+    return site=Some(SiteId(708)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -1458,8 +1236,8 @@ fn isize::fmt -> string
 
 fn usize::fmt -> string
   statements:
-    use BindingId(112) val site=SiteId(807) ty=usize intent=Read
-    return site=Some(SiteId(805)) ty=string
+    use BindingId(105) val site=SiteId(714) ty=usize intent=Read
+    return site=Some(SiteId(712)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -1470,8 +1248,8 @@ fn usize::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(113) val site=SiteId(810) ty=bool intent=Read
-    return site=Some(SiteId(809)) ty=string
+    use BindingId(106) val site=SiteId(717) ty=bool intent=Read
+    return site=Some(SiteId(716)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -1482,8 +1260,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(114) val site=SiteId(813) ty=char intent=Read
-    return site=Some(SiteId(812)) ty=string
+    use BindingId(107) val site=SiteId(720) ty=char intent=Read
+    return site=Some(SiteId(719)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -1494,8 +1272,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(115) val site=SiteId(816) ty=f64 intent=Read
-    return site=Some(SiteId(815)) ty=string
+    use BindingId(108) val site=SiteId(723) ty=f64 intent=Read
+    return site=Some(SiteId(722)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1506,8 +1284,8 @@ fn f64::fmt -> string
 
 fn f32::fmt -> string
   statements:
-    use BindingId(116) val site=SiteId(820) ty=f32 intent=Read
-    return site=Some(SiteId(818)) ty=string
+    use BindingId(109) val site=SiteId(727) ty=f32 intent=Read
+    return site=Some(SiteId(725)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -1518,16 +1296,16 @@ fn f32::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(117) val site=SiteId(822) ty=string intent=Read
-    return site=Some(SiteId(822)) ty=string
+    use BindingId(110) val site=SiteId(729) ty=string intent=Read
+    return site=Some(SiteId(729)) ty=string
   drop_plans:
     return[bb0] ->
       (none)
 
 fn duration::from_nanos -> duration
   statements:
-    use BindingId(118) n site=SiteId(824) ty=i64 intent=Read
-    return site=Some(SiteId(823)) ty=duration
+    use BindingId(111) n site=SiteId(731) ty=i64 intent=Read
+    return site=Some(SiteId(730)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1538,8 +1316,8 @@ fn duration::from_nanos -> duration
 
 fn duration::from_micros -> duration
   statements:
-    use BindingId(119) n site=SiteId(827) ty=i64 intent=Read
-    return site=Some(SiteId(826)) ty=duration
+    use BindingId(112) n site=SiteId(734) ty=i64 intent=Read
+    return site=Some(SiteId(733)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1550,8 +1328,8 @@ fn duration::from_micros -> duration
 
 fn duration::from_millis -> duration
   statements:
-    use BindingId(120) n site=SiteId(830) ty=i64 intent=Read
-    return site=Some(SiteId(829)) ty=duration
+    use BindingId(113) n site=SiteId(737) ty=i64 intent=Read
+    return site=Some(SiteId(736)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1562,8 +1340,8 @@ fn duration::from_millis -> duration
 
 fn duration::from_secs -> duration
   statements:
-    use BindingId(121) n site=SiteId(833) ty=i64 intent=Read
-    return site=Some(SiteId(832)) ty=duration
+    use BindingId(114) n site=SiteId(740) ty=i64 intent=Read
+    return site=Some(SiteId(739)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -1574,8 +1352,8 @@ fn duration::from_secs -> duration
 
 fn duration::fmt -> string
   statements:
-    use BindingId(122) val site=SiteId(838) ty=duration intent=Read
-    return site=Some(SiteId(835)) ty=string
+    use BindingId(115) val site=SiteId(745) ty=duration intent=Read
+    return site=Some(SiteId(742)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)

--- a/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
+++ b/examples/v05/checked-mir/golden/stream_string_pipe_send.raw.mir
@@ -75,32 +75,35 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     _11: i64
     _12: IoError
     _13: IoError
-    _14: i64
-    _15: bool
-    _16: IoError
+    _14: bool
+    _15: i64
+    _16: bool
     _17: i64
-    _18: IoError
+    _18: bool
     _19: IoError
-    _20: bool
-    _21: i64
-    _22: bool
-    _23: i64
-    _24: bool
-    _25: IoError
+    _20: i64
+    _21: IoError
+    _22: IoError
+    _23: bool
+    _24: i64
+    _25: bool
     _26: i64
-    _27: IoError
+    _27: bool
     _28: IoError
-    _29: bool
-    _30: i64
-    _31: bool
-    _32: i64
-    _33: bool
-    _34: IoError
+    _29: i64
+    _30: IoError
+    _31: IoError
+    _32: bool
+    _33: i64
+    _34: bool
     _35: i64
-    _36: IoError
+    _36: bool
     _37: IoError
     _38: i64
     _39: IoError
+    _40: IoError
+    _41: i64
+    _42: IoError
   bb0:
     stmt: use BindingId(6) errno site=SiteId(26) ty=i64 intent=Read
     _2 = const.i64 2
@@ -132,82 +135,194 @@ fn fs$io_error_from_errno(i64) -> IoError [conv=default]
     _7 = move _12
     goto bb6
   bb5:
-    stmt: use BindingId(6) errno site=SiteId(40) ty=i64 intent=Read
-    _14 = const.i64 17
-    _15 = icmp.eq _0 _14
-    branch _15 ? bb7 : bb8
+    stmt: use BindingId(6) errno site=SiteId(41) ty=i64 intent=Read
+    _14 = const.i64 1
+    _15 = const.i64 17
+    _16 = icmp.eq _0 _15
+    branch _16 ? bb8 : bb7
   bb6:
     _1 = move _7
     goto bb3
   bb7:
     stmt: use BindingId(6) errno site=SiteId(44) ty=i64 intent=Read
-    _17 = const.i64 2
-    mtag16 = move _17
-    mvar16.2.0 = move _0
-    _18 = move _16
-    _13 = move _18
-    goto bb9
+    _17 = const.i64 183
+    _18 = icmp.eq _0 _17
+    _14 = move _18
+    goto bb8
   bb8:
-    stmt: use BindingId(6) errno site=SiteId(48) ty=i64 intent=Read
-    _20 = const.i64 1
-    _21 = const.i64 110
-    _22 = icmp.eq _0 _21
-    branch _22 ? bb11 : bb10
+    branch _14 ? bb9 : bb10
   bb9:
+    stmt: use BindingId(6) errno site=SiteId(48) ty=i64 intent=Read
+    _20 = const.i64 2
+    mtag19 = move _20
+    mvar19.2.0 = move _0
+    _21 = move _19
+    _13 = move _21
+    goto bb11
+  bb10:
+    stmt: use BindingId(6) errno site=SiteId(52) ty=i64 intent=Read
+    _23 = const.i64 1
+    _24 = const.i64 110
+    _25 = icmp.eq _0 _24
+    branch _25 ? bb13 : bb12
+  bb11:
     _7 = move _13
     goto bb6
-  bb10:
-    stmt: use BindingId(6) errno site=SiteId(51) ty=i64 intent=Read
-    _23 = const.i64 60
-    _24 = icmp.eq _0 _23
-    _20 = move _24
-    goto bb11
-  bb11:
-    branch _20 ? bb12 : bb13
   bb12:
     stmt: use BindingId(6) errno site=SiteId(55) ty=i64 intent=Read
-    _26 = const.i64 3
-    mtag25 = move _26
-    mvar25.3.0 = move _0
-    _27 = move _25
-    _19 = move _27
-    goto bb14
+    _26 = const.i64 60
+    _27 = icmp.eq _0 _26
+    _23 = move _27
+    goto bb13
   bb13:
-    stmt: use BindingId(6) errno site=SiteId(59) ty=i64 intent=Read
-    _29 = const.i64 1
-    _30 = const.i64 125
-    _31 = icmp.eq _0 _30
-    branch _31 ? bb16 : bb15
+    branch _23 ? bb14 : bb15
   bb14:
-    _13 = move _19
-    goto bb9
-  bb15:
-    stmt: use BindingId(6) errno site=SiteId(62) ty=i64 intent=Read
-    _32 = const.i64 89
-    _33 = icmp.eq _0 _32
-    _29 = move _33
+    stmt: use BindingId(6) errno site=SiteId(59) ty=i64 intent=Read
+    _29 = const.i64 3
+    mtag28 = move _29
+    mvar28.3.0 = move _0
+    _30 = move _28
+    _22 = move _30
     goto bb16
+  bb15:
+    stmt: use BindingId(6) errno site=SiteId(63) ty=i64 intent=Read
+    _32 = const.i64 1
+    _33 = const.i64 125
+    _34 = icmp.eq _0 _33
+    branch _34 ? bb18 : bb17
   bb16:
-    branch _29 ? bb17 : bb18
+    _13 = move _22
+    goto bb11
   bb17:
     stmt: use BindingId(6) errno site=SiteId(66) ty=i64 intent=Read
-    _35 = const.i64 4
-    mtag34 = move _35
-    mvar34.4.0 = move _0
-    _36 = move _34
-    _28 = move _36
-    goto bb19
+    _35 = const.i64 89
+    _36 = icmp.eq _0 _35
+    _32 = move _36
+    goto bb18
   bb18:
-    stmt: use BindingId(6) errno site=SiteId(69) ty=i64 intent=Read
-    _38 = const.i64 5
-    mtag37 = move _38
-    mvar37.5.0 = move _0
-    _39 = move _37
-    _28 = move _39
-    goto bb19
+    branch _32 ? bb19 : bb20
   bb19:
-    _19 = move _28
-    goto bb14
+    stmt: use BindingId(6) errno site=SiteId(70) ty=i64 intent=Read
+    _38 = const.i64 4
+    mtag37 = move _38
+    mvar37.4.0 = move _0
+    _39 = move _37
+    _31 = move _39
+    goto bb21
+  bb20:
+    stmt: use BindingId(6) errno site=SiteId(73) ty=i64 intent=Read
+    _41 = const.i64 5
+    mtag40 = move _41
+    mvar40.5.0 = move _0
+    _42 = move _40
+    _31 = move _42
+    goto bb21
+  bb21:
+    _22 = move _31
+    goto bb16
+
+fn fs$io_error_from_kind(i64, i64) -> IoError [conv=default]
+  locals:
+    _0: i64
+    _1: i64
+    _2: IoError
+    _3: i64
+    _4: bool
+    _5: IoError
+    _6: i64
+    _7: IoError
+    _8: IoError
+    _9: i64
+    _10: bool
+    _11: IoError
+    _12: i64
+    _13: IoError
+    _14: IoError
+    _15: i64
+    _16: bool
+    _17: IoError
+    _18: i64
+    _19: IoError
+    _20: IoError
+    _21: i64
+    _22: bool
+    _23: IoError
+    _24: i64
+    _25: IoError
+    _26: IoError
+    _27: IoError
+  bb0:
+    stmt: use BindingId(7) kind site=SiteId(76) ty=i64 intent=Read
+    _3 = const.i64 1
+    _4 = icmp.eq _0 _3
+    branch _4 ? bb1 : bb2
+  bb1:
+    stmt: use BindingId(8) errno site=SiteId(80) ty=i64 intent=Read
+    _6 = const.i64 0
+    mtag5 = move _6
+    mvar5.0.0 = move _1
+    _7 = move _5
+    _2 = move _7
+    goto bb3
+  bb2:
+    stmt: use BindingId(7) kind site=SiteId(83) ty=i64 intent=Read
+    _9 = const.i64 2
+    _10 = icmp.eq _0 _9
+    branch _10 ? bb4 : bb5
+  bb3:
+    stmt: return site=Some(SiteId(74)) ty=IoError
+    ret = move _2
+    return
+  bb4:
+    stmt: use BindingId(8) errno site=SiteId(87) ty=i64 intent=Read
+    _12 = const.i64 1
+    mtag11 = move _12
+    mvar11.1.0 = move _1
+    _13 = move _11
+    _8 = move _13
+    goto bb6
+  bb5:
+    stmt: use BindingId(7) kind site=SiteId(90) ty=i64 intent=Read
+    _15 = const.i64 3
+    _16 = icmp.eq _0 _15
+    branch _16 ? bb7 : bb8
+  bb6:
+    _2 = move _8
+    goto bb3
+  bb7:
+    stmt: use BindingId(8) errno site=SiteId(94) ty=i64 intent=Read
+    _18 = const.i64 2
+    mtag17 = move _18
+    mvar17.2.0 = move _1
+    _19 = move _17
+    _14 = move _19
+    goto bb9
+  bb8:
+    stmt: use BindingId(7) kind site=SiteId(97) ty=i64 intent=Read
+    _21 = const.i64 4
+    _22 = icmp.eq _0 _21
+    branch _22 ? bb10 : bb11
+  bb9:
+    _8 = move _14
+    goto bb6
+  bb10:
+    stmt: use BindingId(8) errno site=SiteId(101) ty=i64 intent=Read
+    _24 = const.i64 3
+    mtag23 = move _24
+    mvar23.3.0 = move _1
+    _25 = move _23
+    _20 = move _25
+    goto bb12
+  bb11:
+    stmt: use BindingId(8) errno site=SiteId(104) ty=i64 intent=Read
+    _26 = call fs$io_error_from_errno(_1) -> bb13
+  bb12:
+    _14 = move _20
+    goto bb9
+  bb13:
+    _27 = move _26
+    _20 = move _27
+    goto bb12
 
 fn fs$io_error_message(IoError) -> string [conv=default]
   locals:
@@ -263,48 +378,48 @@ fn fs$io_error_message(IoError) -> string [conv=default]
     _49: string
     _50: string
   bb0:
-    stmt: use BindingId(7) e site=SiteId(71) ty=IoError intent=Read
+    stmt: use BindingId(9) e site=SiteId(107) ty=IoError intent=Read
     _2 = move etag0
     _3 = const.i64 0
     _4 = icmp.eq _2 _3
     branch _4 ? bb2 : bb9
   bb1:
-    stmt: return site=Some(SiteId(70)) ty=string
+    stmt: return site=Some(SiteId(106)) ty=string
     ret = move _1
     return
   bb2:
-    stmt: bind BindingId(8) code site=SiteId(72) ty=i64
-    stmt: use BindingId(8) code site=SiteId(74) ty=i64 intent=Read
+    stmt: bind BindingId(10) code site=SiteId(108) ty=i64
+    stmt: use BindingId(10) code site=SiteId(110) ty=i64 intent=Read
     _15 = move mvar0.0.0
     _16 = string_lit "NotFound("
     _17 = call to_string_i64(_15) -> bb14
   bb3:
-    stmt: bind BindingId(9) code site=SiteId(82) ty=i64
-    stmt: use BindingId(9) code site=SiteId(84) ty=i64 intent=Read
+    stmt: bind BindingId(11) code site=SiteId(118) ty=i64
+    stmt: use BindingId(11) code site=SiteId(120) ty=i64 intent=Read
     _21 = move mvar0.1.0
     _22 = string_lit "PermissionDenied("
     _23 = call to_string_i64(_21) -> bb17
   bb4:
-    stmt: bind BindingId(10) code site=SiteId(92) ty=i64
-    stmt: use BindingId(10) code site=SiteId(94) ty=i64 intent=Read
+    stmt: bind BindingId(12) code site=SiteId(128) ty=i64
+    stmt: use BindingId(12) code site=SiteId(130) ty=i64 intent=Read
     _27 = move mvar0.2.0
     _28 = string_lit "AlreadyExists("
     _29 = call to_string_i64(_27) -> bb20
   bb5:
-    stmt: bind BindingId(11) code site=SiteId(102) ty=i64
-    stmt: use BindingId(11) code site=SiteId(104) ty=i64 intent=Read
+    stmt: bind BindingId(13) code site=SiteId(138) ty=i64
+    stmt: use BindingId(13) code site=SiteId(140) ty=i64 intent=Read
     _33 = move mvar0.3.0
     _34 = string_lit "TimedOut("
     _35 = call to_string_i64(_33) -> bb23
   bb6:
-    stmt: bind BindingId(12) code site=SiteId(112) ty=i64
-    stmt: use BindingId(12) code site=SiteId(114) ty=i64 intent=Read
+    stmt: bind BindingId(14) code site=SiteId(148) ty=i64
+    stmt: use BindingId(14) code site=SiteId(150) ty=i64 intent=Read
     _39 = move mvar0.4.0
     _40 = string_lit "Cancelled("
     _41 = call to_string_i64(_39) -> bb26
   bb7:
-    stmt: bind BindingId(13) code site=SiteId(122) ty=i64
-    stmt: use BindingId(13) code site=SiteId(124) ty=i64 intent=Read
+    stmt: bind BindingId(15) code site=SiteId(158) ty=i64
+    stmt: use BindingId(15) code site=SiteId(160) ty=i64 intent=Read
     _45 = move mvar0.5.0
     _46 = string_lit "Other("
     _47 = call to_string_i64(_45) -> bb29
@@ -397,7 +512,7 @@ fn fs$io_error_timed_out() -> IoError [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: return site=Some(SiteId(132)) ty=IoError
+    stmt: return site=Some(SiteId(168)) ty=IoError
     _1 = const.i64 3
     mtag0 = move _1
     _2 = const.i64 0
@@ -411,7 +526,7 @@ fn fs$io_error_cancelled() -> IoError [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: return site=Some(SiteId(134)) ty=IoError
+    stmt: return site=Some(SiteId(170)) ty=IoError
     _1 = const.i64 4
     mtag0 = move _1
     _2 = const.i64 0
@@ -419,553 +534,76 @@ fn fs$io_error_cancelled() -> IoError [conv=default]
     ret = move _0
     return
 
-fn fs$missing_parent(string) -> bool [conv=default]
+fn fs$last_io_error() -> IoError [conv=default]
   locals:
-    _0: string
-    _1: string
-    _2: string
-    _3: bool
-    _4: string
-    _5: bool
-    _6: bool
-    _7: bool
-  bb0:
-    stmt: use BindingId(14) target site=SiteId(137) ty=string intent=Read
-    _1 = call fs$dirname(_0) -> bb1
-  bb1:
-    stmt: bind BindingId(15) parent site=SiteId(136) ty=string
-    stmt: use BindingId(15) parent site=SiteId(141) ty=string intent=Read
-    _2 = move _1
-    _3 = const.i64 0
-    _4 = string_lit ""
-    _5 = icmp.ne _2 _4
-    branch _5 ? bb2 : bb3
-  bb2:
-    stmt: use BindingId(15) parent site=SiteId(145) ty=string intent=Read
-    _6 = call fs$exists(_2) -> bb4
-  bb3:
-    stmt: return site=Some(SiteId(139)) ty=bool
-    ret = move _3
-    return
-  bb4:
-    _7 = not _6
-    _3 = move _7
-    goto bb3
-
-fn fs$dirname(string) -> string [conv=default]
-  locals:
-    _0: string
-    _1: string
-    _2: string
-    _3: i64
+    _0: i32
+    _1: i64
+    _2: i64
+    _3: i32
     _4: i64
-    _5: ()
-    _6: i64
-    _7: bool
-    _8: string
-    _9: ()
-    _10: i64
-    _11: bool
-    _12: string
-    _13: i64
-    _14: string
-  bb0:
-    stmt: use BindingId(16) p site=SiteId(148) ty=string intent=Read
-    _1 = call fs$strip_trailing_slash(_0) -> bb1
-  bb1:
-    stmt: bind BindingId(17) s site=SiteId(147) ty=string
-    stmt: use BindingId(17) s site=SiteId(151) ty=string intent=Read
-    _2 = move _1
-    _3 = call fs$last_slash_pos(_2) -> bb2
-  bb2:
-    stmt: bind BindingId(18) pos site=SiteId(150) ty=i64
-    stmt: use BindingId(18) pos site=SiteId(154) ty=i64 intent=Read
-    _4 = move _3
-    _6 = const.i64 0
-    _7 = icmp.slt _4 _6
-    branch _7 ? bb3 : bb4
-  bb3:
-    stmt: return site=Some(SiteId(156)) ty=string
-    _8 = string_lit ""
-    ret = move _8
-    return
-  bb4:
-    goto bb5
-  bb5:
-    stmt: eval site=SiteId(158) ty=()
-    stmt: use BindingId(18) pos site=SiteId(160) ty=i64 intent=Read
-    _10 = const.i64 0
-    _11 = icmp.eq _4 _10
-    branch _11 ? bb7 : bb8
-  bb6:
-    goto bb5
-  bb7:
-    stmt: return site=Some(SiteId(162)) ty=string
-    _12 = string_lit "/"
-    ret = move _12
-    return
-  bb8:
-    goto bb9
-  bb9:
-    stmt: eval site=SiteId(164) ty=()
-    stmt: use BindingId(17) s site=SiteId(166) ty=string intent=Read
-    stmt: use BindingId(18) pos site=SiteId(168) ty=i64 intent=Read
-    _13 = const.i64 0
-    _14 = call hew_string_slice(_2, _13, _4) -> bb11
-  bb10:
-    goto bb9
-  bb11:
-    stmt: return site=Some(SiteId(165)) ty=string
-    ret = move _14
-    return
-
-fn fs$strip_trailing_slash(string) -> string [conv=default]
-  locals:
-    _0: string
-    _1: ()
-    _2: string
-    _3: bool
-    _4: string
-    _5: string
-    _6: ()
-    _7: bool
-    _8: i64
+    _5: i64
+    _6: string
+    _7: IoError
+    _8: bool
     _9: i64
     _10: bool
-    _11: string
+    _11: i64
     _12: bool
-    _13: i64
-    _14: i64
-    _15: i64
-    _16: i64
-    _17: bool
-    _18: string
-    _19: string
-    _20: string
-  bb0:
-    stmt: use BindingId(19) p site=SiteId(171) ty=string intent=Read
-    _2 = string_lit "/"
-    _3 = icmp.eq _0 _2
-    branch _3 ? bb1 : bb2
-  bb1:
-    stmt: use BindingId(19) p site=SiteId(175) ty=string intent=Read
-    stmt: return site=Some(SiteId(173)) ty=string
-    _4 = string_lit ""
-    _5 = call_rt hew_string_concat(_4, _0)
-    ret = move _5
-    return
-  bb2:
-    goto bb3
-  bb3:
-    stmt: eval site=SiteId(177) ty=()
-    stmt: use BindingId(19) p site=SiteId(181) ty=string intent=Read
-    _7 = const.i64 0
-    _8 = call hew_string_length(_0) -> bb5
-  bb4:
-    goto bb3
-  bb5:
-    _9 = const.i64 1
-    _10 = icmp.sgt _8 _9
-    branch _10 ? bb6 : bb7
-  bb6:
-    stmt: use BindingId(19) p site=SiteId(185) ty=string intent=Read
-    _11 = string_lit "/"
-    _12 = call hew_string_ends_with(_0, _11) -> bb8
-  bb7:
-    branch _7 ? bb9 : bb10
-  bb8:
-    _7 = move _12
-    goto bb7
-  bb9:
-    stmt: use BindingId(19) p site=SiteId(189) ty=string intent=Read
-    stmt: use BindingId(19) p site=SiteId(193) ty=string intent=Read
-    _13 = const.i64 0
-    _14 = call hew_string_length(_0) -> bb12
-  bb10:
-    goto bb11
-  bb11:
-    stmt: eval site=SiteId(198) ty=()
-    stmt: use BindingId(19) p site=SiteId(201) ty=string intent=Read
-    stmt: return site=Some(SiteId(199)) ty=string
-    _19 = string_lit ""
-    _20 = call_rt hew_string_concat(_19, _0)
-    ret = move _20
-    return
-  bb12:
-    _15 = const.i64 1
-    _16 ovf=_17 = sub.checked.s _14 _15
-    branch _17 ? bb13 : bb14
-  bb13:
-    trap(IntegerOverflow)
-  bb14:
-    _18 = call hew_string_slice(_0, _13, _16) -> bb15
-  bb15:
-    stmt: return site=Some(SiteId(188)) ty=string
-    ret = move _18
-    return
-  bb16:
-    goto bb11
-
-fn fs$last_slash_pos(string) -> i64 [conv=default]
-  locals:
-    _0: string
-    _1: i64
-    _2: string
-    _3: Option<i64>
-    _4: i64
-    _5: i64
-    _6: bool
-    _7: i64
-    _8: bool
-    _9: i64
-    _10: i64
-    _11: i64
-    _12: i64
-    _13: i64
-    _14: i64
-    _15: bool
-    _16: i64
-    _17: i64
-    _18: bool
-    _19: i64
-    _20: string
-    _21: string
-    _22: i64
-    _23: string
-    _24: Option<i64>
-    _25: i64
-    _26: i64
-    _27: bool
-    _28: i64
-    _29: bool
-    _30: i64
-    _31: i64
-    _32: i64
-    _33: bool
-    _34: i64
-    _35: i64
-    _36: bool
-  bb0:
-    stmt: use BindingId(20) s site=SiteId(204) ty=string intent=Read
-    _2 = string_lit "/"
-    _3 = call hew_string_find(_0, _2) -> bb1
-  bb1:
-    _4 = move etag3
-    _5 = const.i64 0
-    _6 = icmp.eq _4 _5
-    branch _6 ? bb3 : bb6
-  bb2:
-    stmt: bind BindingId(22) first site=SiteId(202) ty=i64
-    stmt: use BindingId(22) first site=SiteId(210) ty=i64 intent=Consume
-    stmt: bind BindingId(23) last site=SiteId(210) ty=i64
-    stmt: use BindingId(22) first site=SiteId(212) ty=i64 intent=Read
-    _11 = move _1
-    _12 = move _11
-    _13 = const.i64 1
-    _14 ovf=_15 = add.checked.s _11 _13
-    branch _15 ? bb8 : bb9
-  bb3:
-    stmt: bind BindingId(21) i site=SiteId(207) ty=i64
-    stmt: use BindingId(21) i site=SiteId(207) ty=i64 intent=Read
-    _9 = move mvar3.0.0
-    _1 = move _9
-    goto bb2
-  bb4:
-    stmt: return site=Some(SiteId(209)) ty=i64
-    _10 = const.i64 -1
-    ret = move _10
-    return
-  bb5:
-    trap(ExhaustivenessFallthrough)
-  bb6:
-    _7 = const.i64 1
-    _8 = icmp.eq _4 _7
-    branch _8 ? bb4 : bb5
-  bb7:
-    goto bb2
-  bb8:
-    trap(IntegerOverflow)
-  bb9:
-    stmt: bind BindingId(24) search_from site=SiteId(211) ty=i64
-    _16 = move _14
-    goto bb10
-  bb10:
-    stmt: use BindingId(24) search_from site=SiteId(215) ty=i64 intent=Read
-    stmt: use BindingId(20) s site=SiteId(217) ty=string intent=Read
-    _17 = call hew_string_length(_0) -> bb13
-  bb11:
-    stmt: use BindingId(20) s site=SiteId(220) ty=string intent=Read
-    stmt: use BindingId(24) search_from site=SiteId(221) ty=i64 intent=Read
-    stmt: use BindingId(20) s site=SiteId(223) ty=string intent=Read
-    _19 = call hew_string_length(_0) -> bb14
-  bb12:
-    stmt: eval site=SiteId(242) ty=()
-    stmt: use BindingId(23) last site=SiteId(243) ty=i64 intent=Read
-    stmt: return site=Some(SiteId(243)) ty=i64
-    ret = move _12
-    return
-  bb13:
-    _18 = icmp.slt _16 _17
-    branch _18 ? bb11 : bb12
-  bb14:
-    _20 = call hew_string_slice(_0, _16, _19) -> bb15
-  bb15:
-    stmt: bind BindingId(25) rest site=SiteId(219) ty=string
-    stmt: use BindingId(25) rest site=SiteId(228) ty=string intent=Read
-    _21 = move _20
-    _23 = string_lit "/"
-    _24 = call hew_string_find(_21, _23) -> bb16
-  bb16:
-    _25 = move etag24
-    _26 = const.i64 0
-    _27 = icmp.eq _25 _26
-    branch _27 ? bb18 : bb21
-  bb17:
-    stmt: bind BindingId(27) next site=SiteId(226) ty=i64
-    stmt: use BindingId(24) search_from site=SiteId(236) ty=i64 intent=Read
-    stmt: use BindingId(27) next site=SiteId(237) ty=i64 intent=Read
-    _31 = move _22
-    _32 ovf=_33 = add.checked.s _16 _31
-    branch _33 ? bb23 : bb24
-  bb18:
-    stmt: bind BindingId(26) i site=SiteId(231) ty=i64
-    stmt: use BindingId(26) i site=SiteId(231) ty=i64 intent=Read
-    _30 = move mvar24.0.0
-    _22 = move _30
-    goto bb17
-  bb19:
-    stmt: use BindingId(23) last site=SiteId(233) ty=i64 intent=Consume
-    stmt: return site=Some(SiteId(233)) ty=i64
-    ret = move _12
-    return
-  bb20:
-    trap(ExhaustivenessFallthrough)
-  bb21:
-    _28 = const.i64 1
-    _29 = icmp.eq _25 _28
-    branch _29 ? bb19 : bb20
-  bb22:
-    goto bb17
-  bb23:
-    trap(IntegerOverflow)
-  bb24:
-    stmt: bind BindingId(23) last site=SiteId(234) ty=i64
-    stmt: eval site=SiteId(235) ty=()
-    stmt: use BindingId(23) last site=SiteId(240) ty=i64 intent=Read
-    _12 = move _32
-    _34 = const.i64 1
-    _35 ovf=_36 = add.checked.s _12 _34
-    branch _36 ? bb25 : bb26
-  bb25:
-    trap(IntegerOverflow)
-  bb26:
-    stmt: bind BindingId(24) search_from site=SiteId(238) ty=i64
-    stmt: eval site=SiteId(239) ty=()
-    _16 = move _35
-    goto bb10
-
-fn fs$write_error(string) -> IoError [conv=default]
-  locals:
-    _0: string
-    _1: IoError
-    _2: bool
-    _3: IoError
-    _4: i64
-    _5: i64
-    _6: IoError
-    _7: IoError
-    _8: i64
-    _9: i64
-    _10: IoError
-  bb0:
-    stmt: use BindingId(28) target site=SiteId(246) ty=string intent=Read
-    _2 = call fs$missing_parent(_0) -> bb1
-  bb1:
-    branch _2 ? bb2 : bb3
-  bb2:
-    _4 = const.i64 0
-    mtag3 = move _4
-    _5 = const.i64 0
-    mvar3.0.0 = move _5
-    _6 = move _3
-    _1 = move _6
-    goto bb4
-  bb3:
-    _8 = const.i64 5
-    mtag7 = move _8
-    _9 = const.i64 0
-    mvar7.5.0 = move _9
-    _10 = move _7
-    _1 = move _10
-    goto bb4
-  bb4:
-    stmt: return site=Some(SiteId(244)) ty=IoError
-    ret = move _1
-    return
-
-fn fs$missing_path_error(string) -> IoError [conv=default]
-  locals:
-    _0: string
-    _1: IoError
-    _2: bool
-    _3: IoError
-    _4: i64
-    _5: i64
-    _6: IoError
-    _7: IoError
-    _8: i64
-    _9: i64
-    _10: IoError
-  bb0:
-    stmt: use BindingId(29) target site=SiteId(256) ty=string intent=Read
-    _2 = call fs$exists(_0) -> bb1
-  bb1:
-    branch _2 ? bb2 : bb3
-  bb2:
-    _4 = const.i64 5
-    mtag3 = move _4
-    _5 = const.i64 0
-    mvar3.5.0 = move _5
-    _6 = move _3
-    _1 = move _6
-    goto bb4
-  bb3:
-    _8 = const.i64 0
-    mtag7 = move _8
-    _9 = const.i64 0
-    mvar7.0.0 = move _9
-    _10 = move _7
-    _1 = move _10
-    goto bb4
-  bb4:
-    stmt: return site=Some(SiteId(254)) ty=IoError
-    ret = move _1
-    return
-
-fn fs$mkdir_error(string) -> IoError [conv=default]
-  locals:
-    _0: string
-    _1: IoError
-    _2: bool
-    _3: IoError
-    _4: i64
-    _5: i64
-    _6: IoError
-    _7: IoError
-    _8: bool
-    _9: IoError
-    _10: i64
-    _11: i64
-    _12: IoError
     _13: IoError
     _14: i64
     _15: i64
     _16: IoError
+    _17: IoError
+    _18: IoError
+    _19: IoError
   bb0:
-    stmt: use BindingId(30) target site=SiteId(266) ty=string intent=Read
-    _2 = call fs$exists(_0) -> bb1
+    _0 = call hew_stream_last_error_kind() -> bb1
   bb1:
-    branch _2 ? bb2 : bb3
+    stmt: bind BindingId(16) kind site=SiteId(173) ty=i64
+    _1 = cast _0 i32 -> i64
+    _2 = move _1
+    _3 = call hew_stream_last_errno() -> bb2
   bb2:
-    _4 = const.i64 2
-    mtag3 = move _4
-    _5 = const.i64 0
-    mvar3.2.0 = move _5
-    _6 = move _3
-    _1 = move _6
-    goto bb4
+    stmt: bind BindingId(17) errno site=SiteId(176) ty=i64
+    _4 = cast _3 i32 -> i64
+    _5 = move _4
+    _6 = call hew_stream_last_error() -> bb3
   bb3:
-    stmt: use BindingId(30) target site=SiteId(273) ty=string intent=Read
-    _8 = call fs$missing_parent(_0) -> bb5
+    stmt: eval site=SiteId(179) ty=string
+    stmt: use BindingId(17) errno site=SiteId(184) ty=i64 intent=Read
+    _8 = const.i64 0
+    _9 = const.i64 0
+    _10 = icmp.eq _5 _9
+    branch _10 ? bb4 : bb5
   bb4:
-    stmt: return site=Some(SiteId(264)) ty=IoError
-    ret = move _1
-    return
+    stmt: use BindingId(16) kind site=SiteId(187) ty=i64 intent=Read
+    _11 = const.i64 0
+    _12 = icmp.eq _2 _11
+    _8 = move _12
+    goto bb5
   bb5:
     branch _8 ? bb6 : bb7
   bb6:
-    _10 = const.i64 0
-    mtag9 = move _10
-    _11 = const.i64 0
-    mvar9.0.0 = move _11
-    _12 = move _9
-    _7 = move _12
-    goto bb8
-  bb7:
     _14 = const.i64 5
     mtag13 = move _14
-    _15 = const.i64 0
+    _15 = const.i64 5
     mvar13.5.0 = move _15
     _16 = move _13
     _7 = move _16
     goto bb8
-  bb8:
-    _1 = move _7
-    goto bb4
-
-fn fs$move_copy_error(string, string) -> IoError [conv=default]
-  locals:
-    _0: string
-    _1: string
-    _2: IoError
-    _3: bool
-    _4: bool
-    _5: IoError
-    _6: i64
-    _7: i64
-    _8: IoError
-    _9: IoError
-    _10: bool
-    _11: IoError
-    _12: i64
-    _13: i64
-    _14: IoError
-    _15: IoError
-    _16: i64
-    _17: i64
-    _18: IoError
-  bb0:
-    stmt: use BindingId(31) source site=SiteId(284) ty=string intent=Read
-    _3 = call fs$exists(_0) -> bb1
-  bb1:
-    _4 = not _3
-    branch _4 ? bb2 : bb3
-  bb2:
-    _6 = const.i64 0
-    mtag5 = move _6
-    _7 = const.i64 0
-    mvar5.0.0 = move _7
-    _8 = move _5
-    _2 = move _8
-    goto bb4
-  bb3:
-    stmt: use BindingId(32) target site=SiteId(291) ty=string intent=Read
-    _10 = call fs$missing_parent(_1) -> bb5
-  bb4:
-    stmt: return site=Some(SiteId(281)) ty=IoError
-    ret = move _2
-    return
-  bb5:
-    branch _10 ? bb6 : bb7
-  bb6:
-    _12 = const.i64 0
-    mtag11 = move _12
-    _13 = const.i64 0
-    mvar11.0.0 = move _13
-    _14 = move _11
-    _9 = move _14
-    goto bb8
   bb7:
-    _16 = const.i64 5
-    mtag15 = move _16
-    _17 = const.i64 0
-    mvar15.5.0 = move _17
-    _18 = move _15
-    _9 = move _18
-    goto bb8
+    stmt: use BindingId(16) kind site=SiteId(194) ty=i64 intent=Read
+    stmt: use BindingId(17) errno site=SiteId(195) ty=i64 intent=Read
+    _17 = call fs$io_error_from_kind(_2, _5) -> bb9
   bb8:
-    _2 = move _9
-    goto bb4
+    stmt: return site=Some(SiteId(172)) ty=IoError
+    _19 = move _7
+    ret = move _19
+    return
+  bb9:
+    _18 = move _17
+    _7 = move _18
+    goto bb8
 
 fn fs$read(string) -> string [conv=default]
   locals:
@@ -1003,15 +641,15 @@ fn fs$read(string) -> string [conv=default]
     _31: !
     _32: string
   bb0:
-    stmt: use BindingId(33) path site=SiteId(301) ty=string intent=Read
+    stmt: use BindingId(18) path site=SiteId(199) ty=string intent=Read
     _1 = call hew_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(34) contents site=SiteId(300) ty=string
+    stmt: bind BindingId(19) contents site=SiteId(198) ty=string
     _2 = move _1
     _3 = call hew_stream_last_errno() -> bb2
   bb2:
-    stmt: bind BindingId(35) errno site=SiteId(303) ty=i32
-    stmt: use BindingId(35) errno site=SiteId(306) ty=i32 intent=Read
+    stmt: bind BindingId(20) errno site=SiteId(201) ty=i32
+    stmt: use BindingId(20) errno site=SiteId(204) ty=i32 intent=Read
     _4 = move _3
     _6 = const.i64 0
     _7 = icmp.ne _4 _6
@@ -1021,15 +659,15 @@ fn fs$read(string) -> string [conv=default]
   bb4:
     goto bb5
   bb5:
-    stmt: eval site=SiteId(358) ty=()
-    stmt: use BindingId(34) contents site=SiteId(359) ty=string intent=Read
-    stmt: return site=Some(SiteId(299)) ty=string
+    stmt: eval site=SiteId(256) ty=()
+    stmt: use BindingId(19) contents site=SiteId(257) ty=string intent=Read
+    stmt: return site=Some(SiteId(197)) ty=string
     _32 = move _2
     ret = move _32
     return
   bb6:
-    stmt: bind BindingId(36) detail site=SiteId(308) ty=string
-    stmt: use BindingId(36) detail site=SiteId(313) ty=string intent=Read
+    stmt: bind BindingId(21) detail site=SiteId(206) ty=string
+    stmt: use BindingId(21) detail site=SiteId(211) ty=string intent=Read
     _9 = move _8
     _11 = call hew_string_length(_9) -> bb7
   bb7:
@@ -1037,11 +675,11 @@ fn fs$read(string) -> string [conv=default]
     _13 = icmp.eq _11 _12
     branch _13 ? bb8 : bb9
   bb8:
-    stmt: use BindingId(33) path site=SiteId(320) ty=string intent=Read
+    stmt: use BindingId(18) path site=SiteId(218) ty=string intent=Read
     _14 = string_lit "fs.read failed for `"
     _15 = call string::fmt(_0) -> bb11
   bb9:
-    stmt: use BindingId(33) path site=SiteId(343) ty=string intent=Read
+    stmt: use BindingId(18) path site=SiteId(241) ty=string intent=Read
     _24 = string_lit "fs.read failed for `"
     _25 = call string::fmt(_0) -> bb19
   bb10:
@@ -1054,7 +692,7 @@ fn fs$read(string) -> string [conv=default]
     _17 = string_lit "`: "
     _18 = call string_concat(_16, _17) -> bb13
   bb13:
-    stmt: use BindingId(35) errno site=SiteId(327) ty=i32 intent=Read
+    stmt: use BindingId(20) errno site=SiteId(225) ty=i32 intent=Read
     drop _16 ty=string fn=release(hew_string_drop)
     _19 = cast _4 i32 -> i64
     _20 = call fs$io_error_from_errno(_19) -> bb14
@@ -1067,7 +705,7 @@ fn fs$read(string) -> string [conv=default]
   bb17:
     call panic(_23) -> bb18
   bb18:
-    stmt: eval site=SiteId(317) ty=!
+    stmt: eval site=SiteId(215) ty=!
     goto bb10
   bb19:
     _26 = call string_concat(_24, _25) -> bb20
@@ -1075,7 +713,7 @@ fn fs$read(string) -> string [conv=default]
     _27 = string_lit "`: "
     _28 = call string_concat(_26, _27) -> bb21
   bb21:
-    stmt: use BindingId(36) detail site=SiteId(347) ty=string intent=Read
+    stmt: use BindingId(21) detail site=SiteId(245) ty=string intent=Read
     drop _26 ty=string fn=release(hew_string_drop)
     _29 = call string::fmt(_9) -> bb22
   bb22:
@@ -1083,7 +721,7 @@ fn fs$read(string) -> string [conv=default]
   bb23:
     call panic(_30) -> bb24
   bb24:
-    stmt: eval site=SiteId(340) ty=!
+    stmt: eval site=SiteId(238) ty=!
     goto bb10
 
 fn fs$try_read(string) -> Result<string, IoError> [conv=default]
@@ -1093,61 +731,101 @@ fn fs$try_read(string) -> Result<string, IoError> [conv=default]
     _2: FileReadStream
     _3: Result<string, IoError>
     _4: bool
-    _5: Result<string, IoError>
-    _6: i64
-    _7: string
-    _8: Result<string, IoError>
-    _9: i32
+    _5: string
+    _6: string
+    _7: i32
+    _8: i64
+    _9: i64
     _10: i32
-    _11: string
-    _12: Result<string, IoError>
-    _13: i64
-    _14: i64
-    _15: IoError
+    _11: i32
+    _12: string
+    _13: Result<string, IoError>
+    _14: i32
+    _15: bool
     _16: Result<string, IoError>
-    _17: Result<string, IoError>
+    _17: i64
+    _18: Result<string, IoError>
+    _19: Result<string, IoError>
+    _20: i64
+    _21: i64
+    _22: IoError
+    _23: Result<string, IoError>
+    _24: Result<string, IoError>
+    _25: Result<string, IoError>
+    _26: i64
+    _27: IoError
+    _28: Result<string, IoError>
+    _29: Result<string, IoError>
   bb0:
-    stmt: use BindingId(37) file_path site=SiteId(362) ty=string intent=Read
+    stmt: use BindingId(22) file_path site=SiteId(260) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(38) file site=SiteId(361) ty=FileReadStream
-    stmt: use BindingId(38) file site=SiteId(366) ty=FileReadStream intent=Read
+    stmt: bind BindingId(23) file site=SiteId(259) ty=FileReadStream
+    stmt: use BindingId(23) file site=SiteId(264) ty=FileReadStream intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(38) file site=SiteId(371) ty=FileReadStream intent=Read
-    _6 = const.i64 0
-    mtag5 = move _6
-    _7 = call hew_stream_collect_string(_2) -> bb6
+    stmt: use BindingId(23) file site=SiteId(268) ty=FileReadStream intent=Read
+    _5 = call hew_stream_collect_string(_2) -> bb6
   bb4:
-    _9 = call hew_stream_last_errno() -> bb7
+    _26 = const.i64 1
+    mtag25 = move _26
+    _27 = call fs$last_io_error() -> bb14
   bb5:
-    stmt: return site=Some(SiteId(360)) ty=Result<string, IoError>
-    _17 = move _3
-    ret = move _17
+    stmt: return site=Some(SiteId(258)) ty=Result<string, IoError>
+    _29 = move _3
+    ret = move _29
     return
   bb6:
-    mvar5.0.0 = move _7
-    _8 = move _5
-    _3 = move _8
-    goto bb5
+    stmt: bind BindingId(24) contents site=SiteId(267) ty=string
+    _6 = move _5
+    _7 = call hew_stream_last_error_kind() -> bb7
   bb7:
-    stmt: bind BindingId(39) errno site=SiteId(374) ty=i32
-    _10 = move _9
-    _11 = call hew_stream_last_error() -> bb8
+    stmt: bind BindingId(25) kind site=SiteId(270) ty=i64
+    _8 = cast _7 i32 -> i64
+    _9 = move _8
+    _10 = call hew_stream_last_errno() -> bb8
   bb8:
-    stmt: eval site=SiteId(376) ty=string
-    stmt: use BindingId(39) errno site=SiteId(381) ty=i32 intent=Read
-    _13 = const.i64 1
-    mtag12 = move _13
-    _14 = cast _10 i32 -> i64
-    _15 = call fs$io_error_from_errno(_14) -> bb9
+    stmt: bind BindingId(26) errno site=SiteId(273) ty=i32
+    _11 = move _10
+    _12 = call hew_stream_last_error() -> bb9
   bb9:
-    mvar12.1.0 = move _15
-    _16 = move _12
-    _3 = move _16
+    stmt: eval site=SiteId(275) ty=string
+    stmt: use BindingId(26) errno site=SiteId(279) ty=i32 intent=Read
+    _14 = const.i64 0
+    _15 = icmp.eq _11 _14
+    branch _15 ? bb10 : bb11
+  bb10:
+    stmt: use BindingId(24) contents site=SiteId(283) ty=string intent=Read
+    stmt: agg_alias BindingId(24) contents site=SiteId(283) ty=string
+    _17 = const.i64 0
+    mtag16 = move _17
+    mvar16.0.0 = move _6
+    _18 = move _16
+    _13 = move _18
+    goto bb12
+  bb11:
+    stmt: use BindingId(25) kind site=SiteId(287) ty=i64 intent=Read
+    stmt: use BindingId(26) errno site=SiteId(289) ty=i32 intent=Read
+    _20 = const.i64 1
+    mtag19 = move _20
+    _21 = cast _11 i32 -> i64
+    _22 = call fs$io_error_from_kind(_9, _21) -> bb13
+  bb12:
+    _24 = move _13
+    _3 = move _24
+    goto bb5
+  bb13:
+    mvar19.1.0 = move _22
+    _23 = move _19
+    _13 = move _23
+    goto bb12
+  bb14:
+    mvar25.1.0 = move _27
+    _28 = move _25
+    _3 = move _28
     goto bb5
 
 fn fs$write(string, string) -> i64 [conv=default]
@@ -1158,11 +836,11 @@ fn fs$write(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(40) path site=SiteId(386) ty=string intent=Read
-    stmt: use BindingId(41) content site=SiteId(387) ty=string intent=Read
+    stmt: use BindingId(27) path site=SiteId(298) ty=string intent=Read
+    stmt: use BindingId(28) content site=SiteId(299) ty=string intent=Read
     _2 = call hew_file_write(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(383)) ty=i64
+    stmt: return site=Some(SiteId(295)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1184,14 +862,14 @@ fn fs$try_write(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(42) file_path site=SiteId(392) ty=string intent=Read
-    stmt: use BindingId(43) content site=SiteId(393) ty=string intent=Read
+    stmt: use BindingId(29) file_path site=SiteId(304) ty=string intent=Read
+    stmt: use BindingId(30) content site=SiteId(305) ty=string intent=Read
     _3 = call hew_file_write(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(389)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(301)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1199,10 +877,9 @@ fn fs$try_write(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(42) file_path site=SiteId(399) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$write_error(_0) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1225,11 +902,11 @@ fn fs$append(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(44) path site=SiteId(404) ty=string intent=Read
-    stmt: use BindingId(45) content site=SiteId(405) ty=string intent=Read
+    stmt: use BindingId(31) path site=SiteId(315) ty=string intent=Read
+    stmt: use BindingId(32) content site=SiteId(316) ty=string intent=Read
     _2 = call hew_file_append(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(401)) ty=i64
+    stmt: return site=Some(SiteId(312)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1251,14 +928,14 @@ fn fs$try_append(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(46) file_path site=SiteId(410) ty=string intent=Read
-    stmt: use BindingId(47) content site=SiteId(411) ty=string intent=Read
+    stmt: use BindingId(33) file_path site=SiteId(321) ty=string intent=Read
+    stmt: use BindingId(34) content site=SiteId(322) ty=string intent=Read
     _3 = call hew_file_append(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(407)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(318)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1266,10 +943,9 @@ fn fs$try_append(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(46) file_path site=SiteId(417) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$write_error(_0) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1290,10 +966,10 @@ fn fs$exists(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(48) path site=SiteId(421) ty=string intent=Read
+    stmt: use BindingId(35) path site=SiteId(331) ty=string intent=Read
     _1 = call hew_file_exists(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(419)) ty=bool
+    stmt: return site=Some(SiteId(329)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -1305,10 +981,10 @@ fn fs$delete(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(49) path site=SiteId(426) ty=string intent=Read
+    stmt: use BindingId(36) path site=SiteId(336) ty=string intent=Read
     _1 = call hew_file_delete(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(423)) ty=i64
+    stmt: return site=Some(SiteId(333)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1329,13 +1005,13 @@ fn fs$try_delete(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(50) file_path site=SiteId(431) ty=string intent=Read
+    stmt: use BindingId(37) file_path site=SiteId(341) ty=string intent=Read
     _2 = call hew_file_delete(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(428)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(338)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1343,10 +1019,9 @@ fn fs$try_delete(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(50) file_path site=SiteId(437) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
-    _11 = call fs$missing_path_error(_0) -> bb7
+    _11 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1367,10 +1042,10 @@ fn fs$size(string) -> i64 [conv=default]
     _1: i64
     _2: i64
   bb0:
-    stmt: use BindingId(51) path site=SiteId(441) ty=string intent=Read
+    stmt: use BindingId(38) path site=SiteId(350) ty=string intent=Read
     _1 = call hew_file_size(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(439)) ty=i64
+    stmt: return site=Some(SiteId(348)) ty=i64
     _2 = move _1
     ret = move _2
     return
@@ -1381,10 +1056,10 @@ fn fs$read_bytes(string) -> bytes [conv=default]
     _1: bytes
     _2: bytes
   bb0:
-    stmt: use BindingId(52) path site=SiteId(445) ty=string intent=Read
+    stmt: use BindingId(39) path site=SiteId(354) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(443)) ty=bytes
+    stmt: return site=Some(SiteId(352)) ty=bytes
     _2 = move _1
     ret = move _2
     return
@@ -1395,61 +1070,70 @@ fn fs$try_read_bytes(string) -> Result<bytes, IoError> [conv=default]
     _1: bytes
     _2: bytes
     _3: i32
-    _4: i32
-    _5: Result<bytes, IoError>
+    _4: i64
+    _5: i64
     _6: i32
-    _7: bool
-    _8: string
-    _9: Result<bytes, IoError>
-    _10: i64
-    _11: i64
-    _12: IoError
-    _13: Result<bytes, IoError>
-    _14: Result<bytes, IoError>
-    _15: i64
+    _7: i32
+    _8: Result<bytes, IoError>
+    _9: i32
+    _10: bool
+    _11: string
+    _12: Result<bytes, IoError>
+    _13: i64
+    _14: i64
+    _15: IoError
     _16: Result<bytes, IoError>
     _17: Result<bytes, IoError>
+    _18: i64
+    _19: Result<bytes, IoError>
+    _20: Result<bytes, IoError>
   bb0:
-    stmt: use BindingId(53) file_path site=SiteId(449) ty=string intent=Read
+    stmt: use BindingId(40) file_path site=SiteId(358) ty=string intent=Read
     _1 = call hew_file_read_bytes(_0) -> bb1
   bb1:
-    stmt: bind BindingId(54) data site=SiteId(448) ty=bytes
+    stmt: bind BindingId(41) data site=SiteId(357) ty=bytes
     _2 = move _1
-    _3 = call hew_stream_last_errno() -> bb2
+    _3 = call hew_stream_last_error_kind() -> bb2
   bb2:
-    stmt: bind BindingId(55) errno site=SiteId(451) ty=i32
-    stmt: use BindingId(55) errno site=SiteId(455) ty=i32 intent=Read
-    _4 = move _3
-    _6 = const.i64 0
-    _7 = icmp.ne _4 _6
-    branch _7 ? bb3 : bb4
+    stmt: bind BindingId(42) kind site=SiteId(360) ty=i64
+    _4 = cast _3 i32 -> i64
+    _5 = move _4
+    _6 = call hew_stream_last_errno() -> bb3
   bb3:
-    _8 = call hew_stream_last_error() -> bb6
+    stmt: bind BindingId(43) errno site=SiteId(363) ty=i32
+    stmt: use BindingId(43) errno site=SiteId(367) ty=i32 intent=Read
+    _7 = move _6
+    _9 = const.i64 0
+    _10 = icmp.ne _7 _9
+    branch _10 ? bb4 : bb5
   bb4:
-    stmt: use BindingId(54) data site=SiteId(467) ty=bytes intent=Read
-    _15 = const.i64 0
-    mtag14 = move _15
-    mvar14.0.0 = move _2
-    _16 = move _14
-    _5 = move _16
-    goto bb5
+    _11 = call hew_stream_last_error() -> bb7
   bb5:
-    stmt: return site=Some(SiteId(447)) ty=Result<bytes, IoError>
-    _17 = move _5
-    ret = move _17
-    return
+    stmt: use BindingId(41) data site=SiteId(380) ty=bytes intent=Read
+    _18 = const.i64 0
+    mtag17 = move _18
+    mvar17.0.0 = move _2
+    _19 = move _17
+    _8 = move _19
+    goto bb6
   bb6:
-    stmt: eval site=SiteId(458) ty=string
-    stmt: use BindingId(55) errno site=SiteId(463) ty=i32 intent=Read
-    _10 = const.i64 1
-    mtag9 = move _10
-    _11 = cast _4 i32 -> i64
-    _12 = call fs$io_error_from_errno(_11) -> bb7
+    stmt: return site=Some(SiteId(356)) ty=Result<bytes, IoError>
+    _20 = move _8
+    ret = move _20
+    return
   bb7:
-    mvar9.1.0 = move _12
-    _13 = move _9
-    _5 = move _13
-    goto bb5
+    stmt: eval site=SiteId(370) ty=string
+    stmt: use BindingId(42) kind site=SiteId(374) ty=i64 intent=Read
+    stmt: use BindingId(43) errno site=SiteId(376) ty=i32 intent=Read
+    _13 = const.i64 1
+    mtag12 = move _13
+    _14 = cast _7 i32 -> i64
+    _15 = call fs$io_error_from_kind(_5, _14) -> bb8
+  bb8:
+    mvar12.1.0 = move _15
+    _16 = move _12
+    _8 = move _16
+    goto bb6
 
 fn fs$write_bytes(string, bytes) -> i64 [conv=default]
   locals:
@@ -1459,11 +1143,11 @@ fn fs$write_bytes(string, bytes) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(56) path site=SiteId(471) ty=string intent=Read
-    stmt: use BindingId(57) data site=SiteId(472) ty=bytes intent=Read
+    stmt: use BindingId(44) path site=SiteId(384) ty=string intent=Read
+    stmt: use BindingId(45) data site=SiteId(385) ty=bytes intent=Read
     _2 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(468)) ty=i64
+    stmt: return site=Some(SiteId(381)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1485,14 +1169,14 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(58) file_path site=SiteId(477) ty=string intent=Read
-    stmt: use BindingId(59) data site=SiteId(478) ty=bytes intent=Read
+    stmt: use BindingId(46) file_path site=SiteId(390) ty=string intent=Read
+    stmt: use BindingId(47) data site=SiteId(391) ty=bytes intent=Read
     _3 = call hew_file_write_bytes(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(474)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(387)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1500,10 +1184,9 @@ fn fs$try_write_bytes(string, bytes) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(58) file_path site=SiteId(484) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$write_error(_0) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1525,10 +1208,10 @@ fn fs$mkdir(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(60) path site=SiteId(489) ty=string intent=Read
+    stmt: use BindingId(48) path site=SiteId(401) ty=string intent=Read
     _1 = call hew_fs_mkdir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(486)) ty=i64
+    stmt: return site=Some(SiteId(398)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1549,13 +1232,13 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _10: i64
     _11: IoError
   bb0:
-    stmt: use BindingId(61) dir_path site=SiteId(494) ty=string intent=Read
+    stmt: use BindingId(49) dir_path site=SiteId(406) ty=string intent=Read
     _2 = call hew_fs_mkdir(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(491)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(403)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1563,10 +1246,9 @@ fn fs$try_mkdir(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(61) dir_path site=SiteId(500) ty=string intent=Read
     _10 = const.i64 1
     mtag9 = move _10
-    _11 = call fs$mkdir_error(_0) -> bb7
+    _11 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1588,10 +1270,10 @@ fn fs$mkdir_all(string) -> i64 [conv=default]
     _2: i64
     _3: i64
   bb0:
-    stmt: use BindingId(62) path site=SiteId(505) ty=string intent=Read
+    stmt: use BindingId(50) path site=SiteId(416) ty=string intent=Read
     _1 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(502)) ty=i64
+    stmt: return site=Some(SiteId(413)) ty=i64
     _2 = cast _1 i32 -> i64
     _3 = move _2
     ret = move _3
@@ -1609,28 +1291,16 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _7: i64
     _8: i64
     _9: Result<i64, IoError>
-    _10: bool
-    _11: Result<i64, IoError>
-    _12: i64
-    _13: IoError
-    _14: i64
-    _15: i64
-    _16: Result<i64, IoError>
-    _17: Result<i64, IoError>
-    _18: i64
-    _19: IoError
-    _20: i64
-    _21: i64
-    _22: Result<i64, IoError>
-    _23: Result<i64, IoError>
+    _10: i64
+    _11: IoError
   bb0:
-    stmt: use BindingId(63) dir_path site=SiteId(510) ty=string intent=Read
+    stmt: use BindingId(51) dir_path site=SiteId(421) ty=string intent=Read
     _2 = call hew_fs_mkdir_all(_0) -> bb1
   bb1:
     _3 = move _2
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(507)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(418)) ty=Result<i64, IoError>
     ret = move _1
     return
   bb3:
@@ -1638,8 +1308,9 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _5 = icmp.eq _3 _4
     branch _5 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(63) dir_path site=SiteId(517) ty=string intent=Read
-    _10 = call fs$exists(_0) -> bb7
+    _10 = const.i64 1
+    mtag9 = move _10
+    _11 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1650,32 +1321,8 @@ fn fs$try_mkdir_all(string) -> Result<i64, IoError> [conv=default]
     _1 = move _6
     goto bb2
   bb7:
-    branch _10 ? bb8 : bb9
-  bb8:
-    _12 = const.i64 1
-    mtag11 = move _12
-    _14 = const.i64 2
-    mtag13 = move _14
-    _15 = const.i64 0
-    mvar13.2.0 = move _15
-    mvar11.1.0 = move _13
-    _16 = move _11
-    _9 = move _16
-    goto bb10
-  bb9:
-    _18 = const.i64 1
-    mtag17 = move _18
-    _20 = const.i64 5
-    mtag19 = move _20
-    _21 = const.i64 0
-    mvar19.5.0 = move _21
-    mvar17.1.0 = move _19
-    _22 = move _17
-    _9 = move _22
-    goto bb10
-  bb10:
-    _23 = move _9
-    _1 = move _23
+    mvar9.1.0 = move _11
+    _1 = move _9
     goto bb2
 
 fn fs$list_dir(string) -> Vec<string> [conv=default]
@@ -1684,10 +1331,10 @@ fn fs$list_dir(string) -> Vec<string> [conv=default]
     _1: Vec<string>
     _2: Vec<string>
   bb0:
-    stmt: use BindingId(64) path site=SiteId(529) ty=string intent=Read
+    stmt: use BindingId(52) path site=SiteId(430) ty=string intent=Read
     _1 = call hew_fs_list_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(527)) ty=Vec<string>
+    stmt: return site=Some(SiteId(428)) ty=Vec<string>
     _2 = move _1
     ret = move _2
     return
@@ -1695,81 +1342,74 @@ fn fs$list_dir(string) -> Vec<string> [conv=default]
 fn fs$try_list_dir(string) -> Result<Vec<string>, IoError> [conv=default]
   locals:
     _0: string
-    _1: ()
-    _2: bool
-    _3: bool
-    _4: Result<Vec<string>, IoError>
+    _1: Vec<string>
+    _2: Vec<string>
+    _3: i32
+    _4: i64
     _5: i64
-    _6: IoError
-    _7: i64
-    _8: i64
-    _9: ()
-    _10: bool
+    _6: i32
+    _7: i32
+    _8: string
+    _9: Result<Vec<string>, IoError>
+    _10: i32
     _11: bool
     _12: Result<Vec<string>, IoError>
     _13: i64
-    _14: IoError
-    _15: i64
+    _14: Result<Vec<string>, IoError>
+    _15: Result<Vec<string>, IoError>
     _16: i64
-    _17: Result<Vec<string>, IoError>
-    _18: i64
-    _19: Vec<string>
-    _20: Vec<string>
+    _17: i64
+    _18: IoError
+    _19: Result<Vec<string>, IoError>
+    _20: Result<Vec<string>, IoError>
   bb0:
-    stmt: use BindingId(65) dir_path site=SiteId(533) ty=string intent=Read
-    _2 = call fs$exists(_0) -> bb1
+    stmt: use BindingId(53) dir_path site=SiteId(434) ty=string intent=Read
+    _1 = call hew_fs_list_dir(_0) -> bb1
   bb1:
-    _3 = not _2
-    branch _3 ? bb2 : bb3
+    stmt: bind BindingId(54) entries site=SiteId(433) ty=Vec<string>
+    _2 = move _1
+    _3 = call hew_stream_last_error_kind() -> bb2
   bb2:
-    stmt: return site=Some(SiteId(535)) ty=Result<Vec<string>, IoError>
-    _5 = const.i64 1
-    mtag4 = move _5
-    _7 = const.i64 0
-    mtag6 = move _7
-    _8 = const.i64 0
-    mvar6.0.0 = move _8
-    mvar4.1.0 = move _6
-    ret = move _4
-    return
+    stmt: bind BindingId(55) kind site=SiteId(436) ty=i64
+    _4 = cast _3 i32 -> i64
+    _5 = move _4
+    _6 = call hew_stream_last_errno() -> bb3
   bb3:
-    goto bb4
+    stmt: bind BindingId(56) errno site=SiteId(439) ty=i32
+    _7 = move _6
+    _8 = call hew_stream_last_error() -> bb4
   bb4:
-    stmt: eval site=SiteId(539) ty=()
-    stmt: use BindingId(65) dir_path site=SiteId(542) ty=string intent=Read
-    _10 = call fs$is_dir(_0) -> bb6
+    stmt: eval site=SiteId(441) ty=string
+    stmt: use BindingId(56) errno site=SiteId(445) ty=i32 intent=Read
+    _10 = const.i64 0
+    _11 = icmp.eq _7 _10
+    branch _11 ? bb5 : bb6
   bb5:
-    goto bb4
-  bb6:
-    _11 = not _10
-    branch _11 ? bb7 : bb8
-  bb7:
-    stmt: return site=Some(SiteId(544)) ty=Result<Vec<string>, IoError>
-    _13 = const.i64 1
+    stmt: use BindingId(54) entries site=SiteId(449) ty=Vec<string> intent=Read
+    stmt: agg_alias BindingId(54) entries site=SiteId(449) ty=Vec<string>
+    _13 = const.i64 0
     mtag12 = move _13
-    _15 = const.i64 5
-    mtag14 = move _15
-    _16 = const.i64 0
-    mvar14.5.0 = move _16
-    mvar12.1.0 = move _14
-    ret = move _12
+    mvar12.0.0 = move _2
+    _14 = move _12
+    _9 = move _14
+    goto bb7
+  bb6:
+    stmt: use BindingId(55) kind site=SiteId(453) ty=i64 intent=Read
+    stmt: use BindingId(56) errno site=SiteId(455) ty=i32 intent=Read
+    _16 = const.i64 1
+    mtag15 = move _16
+    _17 = cast _7 i32 -> i64
+    _18 = call fs$io_error_from_kind(_5, _17) -> bb8
+  bb7:
+    stmt: return site=Some(SiteId(432)) ty=Result<Vec<string>, IoError>
+    _20 = move _9
+    ret = move _20
     return
   bb8:
-    goto bb9
-  bb9:
-    stmt: eval site=SiteId(548) ty=()
-    stmt: use BindingId(65) dir_path site=SiteId(552) ty=string intent=Read
-    _18 = const.i64 0
-    mtag17 = move _18
-    _19 = call hew_fs_list_dir(_0) -> bb11
-  bb10:
-    goto bb9
-  bb11:
-    stmt: return site=Some(SiteId(549)) ty=Result<Vec<string>, IoError>
-    _20 = move _19
-    mvar17.0.0 = move _20
-    ret = move _17
-    return
+    mvar15.1.0 = move _18
+    _19 = move _15
+    _9 = move _19
+    goto bb7
 
 fn fs$rename(string, string) -> i64 [conv=default]
   locals:
@@ -1779,11 +1419,11 @@ fn fs$rename(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(66) from site=SiteId(557) ty=string intent=Read
-    stmt: use BindingId(67) to site=SiteId(558) ty=string intent=Read
+    stmt: use BindingId(57) from site=SiteId(460) ty=string intent=Read
+    stmt: use BindingId(58) to site=SiteId(461) ty=string intent=Read
     _2 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(554)) ty=i64
+    stmt: return site=Some(SiteId(457)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1805,14 +1445,14 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(68) from site=SiteId(563) ty=string intent=Read
-    stmt: use BindingId(69) to site=SiteId(564) ty=string intent=Read
+    stmt: use BindingId(59) from site=SiteId(466) ty=string intent=Read
+    stmt: use BindingId(60) to site=SiteId(467) ty=string intent=Read
     _3 = call hew_fs_rename(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(560)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(463)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1820,11 +1460,9 @@ fn fs$try_rename(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(68) from site=SiteId(570) ty=string intent=Read
-    stmt: use BindingId(69) to site=SiteId(571) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$move_copy_error(_0, _1) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1847,11 +1485,11 @@ fn fs$copy(string, string) -> i64 [conv=default]
     _3: i64
     _4: i64
   bb0:
-    stmt: use BindingId(70) from site=SiteId(576) ty=string intent=Read
-    stmt: use BindingId(71) to site=SiteId(577) ty=string intent=Read
+    stmt: use BindingId(61) from site=SiteId(477) ty=string intent=Read
+    stmt: use BindingId(62) to site=SiteId(478) ty=string intent=Read
     _2 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(573)) ty=i64
+    stmt: return site=Some(SiteId(474)) ty=i64
     _3 = cast _2 i32 -> i64
     _4 = move _3
     ret = move _4
@@ -1873,14 +1511,14 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _11: i64
     _12: IoError
   bb0:
-    stmt: use BindingId(72) from site=SiteId(582) ty=string intent=Read
-    stmt: use BindingId(73) to site=SiteId(583) ty=string intent=Read
+    stmt: use BindingId(63) from site=SiteId(483) ty=string intent=Read
+    stmt: use BindingId(64) to site=SiteId(484) ty=string intent=Read
     _3 = call hew_fs_copy(_0, _1) -> bb1
   bb1:
     _4 = move _3
     goto bb3
   bb2:
-    stmt: return site=Some(SiteId(579)) ty=Result<i64, IoError>
+    stmt: return site=Some(SiteId(480)) ty=Result<i64, IoError>
     ret = move _2
     return
   bb3:
@@ -1888,11 +1526,9 @@ fn fs$try_copy(string, string) -> Result<i64, IoError> [conv=default]
     _6 = icmp.eq _4 _5
     branch _6 ? bb6 : bb4
   bb4:
-    stmt: use BindingId(72) from site=SiteId(589) ty=string intent=Read
-    stmt: use BindingId(73) to site=SiteId(590) ty=string intent=Read
     _11 = const.i64 1
     mtag10 = move _11
-    _12 = call fs$move_copy_error(_0, _1) -> bb7
+    _12 = call fs$last_io_error() -> bb7
   bb5:
     trap(ExhaustivenessFallthrough)
   bb6:
@@ -1913,10 +1549,10 @@ fn fs$is_dir(string) -> bool [conv=default]
     _1: bool
     _2: bool
   bb0:
-    stmt: use BindingId(74) path site=SiteId(594) ty=string intent=Read
+    stmt: use BindingId(65) path site=SiteId(493) ty=string intent=Read
     _1 = call hew_fs_is_dir(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(592)) ty=bool
+    stmt: return site=Some(SiteId(491)) ty=bool
     _2 = move _1
     ret = move _2
     return
@@ -1934,31 +1570,31 @@ fn stream$pipe(i64) -> (Sink<string>, Stream<string>) [conv=default]
     _8: (Sink<string>, Stream<string>)
     _9: (Sink<string>, Stream<string>)
   bb0:
-    stmt: use BindingId(75) capacity site=SiteId(599) ty=i64 intent=Read
+    stmt: use BindingId(66) capacity site=SiteId(498) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(76) pair site=SiteId(597) ty=StreamPair
-    stmt: use BindingId(76) pair site=SiteId(602) ty=StreamPair intent=Read
+    stmt: bind BindingId(67) pair site=SiteId(496) ty=StreamPair
+    stmt: use BindingId(67) pair site=SiteId(501) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink(_3) -> bb2
   bb2:
-    stmt: bind BindingId(77) sink site=SiteId(601) ty=Sink<string>
-    stmt: use BindingId(76) pair site=SiteId(605) ty=StreamPair intent=Read
+    stmt: bind BindingId(68) sink site=SiteId(500) ty=Sink<string>
+    stmt: use BindingId(67) pair site=SiteId(504) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream(_3) -> bb3
   bb3:
-    stmt: bind BindingId(78) input site=SiteId(604) ty=Stream<string>
-    stmt: use BindingId(76) pair site=SiteId(608) ty=StreamPair intent=Read
+    stmt: bind BindingId(69) input site=SiteId(503) ty=Stream<string>
+    stmt: use BindingId(67) pair site=SiteId(507) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(607) ty=()
-    stmt: use BindingId(77) sink site=SiteId(611) ty=Sink<string> intent=Read
-    stmt: use BindingId(78) input site=SiteId(612) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(77) sink site=SiteId(611) ty=Sink<string>
-    stmt: agg_alias BindingId(78) input site=SiteId(612) ty=Stream<string>
-    stmt: return site=Some(SiteId(596)) ty=(Sink<string>, Stream<string>)
+    stmt: eval site=SiteId(506) ty=()
+    stmt: use BindingId(68) sink site=SiteId(510) ty=Sink<string> intent=Read
+    stmt: use BindingId(69) input site=SiteId(511) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(68) sink site=SiteId(510) ty=Sink<string>
+    stmt: agg_alias BindingId(69) input site=SiteId(511) ty=Stream<string>
+    stmt: return site=Some(SiteId(495)) ty=(Sink<string>, Stream<string>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -1977,31 +1613,31 @@ fn stream$bytes_pipe(i64) -> (Sink<bytes>, Stream<bytes>) [conv=default]
     _8: (Sink<bytes>, Stream<bytes>)
     _9: (Sink<bytes>, Stream<bytes>)
   bb0:
-    stmt: use BindingId(79) capacity site=SiteId(616) ty=i64 intent=Read
+    stmt: use BindingId(70) capacity site=SiteId(515) ty=i64 intent=Read
     _1 = cast _0 i64 -> i64
     _2 = call hew_stream_channel(_1) -> bb1
   bb1:
-    stmt: bind BindingId(80) pair site=SiteId(614) ty=StreamPair
-    stmt: use BindingId(80) pair site=SiteId(619) ty=StreamPair intent=Read
+    stmt: bind BindingId(71) pair site=SiteId(513) ty=StreamPair
+    stmt: use BindingId(71) pair site=SiteId(518) ty=StreamPair intent=Read
     _3 = move _2
     _4 = call hew_stream_pair_sink_bytes(_3) -> bb2
   bb2:
-    stmt: bind BindingId(81) sink site=SiteId(618) ty=Sink<bytes>
-    stmt: use BindingId(80) pair site=SiteId(622) ty=StreamPair intent=Read
+    stmt: bind BindingId(72) sink site=SiteId(517) ty=Sink<bytes>
+    stmt: use BindingId(71) pair site=SiteId(521) ty=StreamPair intent=Read
     _5 = move _4
     _6 = call hew_stream_pair_stream_bytes(_3) -> bb3
   bb3:
-    stmt: bind BindingId(82) input site=SiteId(621) ty=Stream<bytes>
-    stmt: use BindingId(80) pair site=SiteId(625) ty=StreamPair intent=Read
+    stmt: bind BindingId(73) input site=SiteId(520) ty=Stream<bytes>
+    stmt: use BindingId(71) pair site=SiteId(524) ty=StreamPair intent=Read
     _7 = move _6
     call hew_stream_pair_free(_3) -> bb4
   bb4:
-    stmt: eval site=SiteId(624) ty=()
-    stmt: use BindingId(81) sink site=SiteId(628) ty=Sink<bytes> intent=Read
-    stmt: use BindingId(82) input site=SiteId(629) ty=Stream<bytes> intent=Read
-    stmt: agg_alias BindingId(81) sink site=SiteId(628) ty=Sink<bytes>
-    stmt: agg_alias BindingId(82) input site=SiteId(629) ty=Stream<bytes>
-    stmt: return site=Some(SiteId(613)) ty=(Sink<bytes>, Stream<bytes>)
+    stmt: eval site=SiteId(523) ty=()
+    stmt: use BindingId(72) sink site=SiteId(527) ty=Sink<bytes> intent=Read
+    stmt: use BindingId(73) input site=SiteId(528) ty=Stream<bytes> intent=Read
+    stmt: agg_alias BindingId(72) sink site=SiteId(527) ty=Sink<bytes>
+    stmt: agg_alias BindingId(73) input site=SiteId(528) ty=Stream<bytes>
+    stmt: return site=Some(SiteId(512)) ty=(Sink<bytes>, Stream<bytes>)
     _8 = tuple (_5, _7)
     _9 = move _8
     ret = move _9
@@ -2023,18 +1659,18 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     _11: Result<Stream<string>, string>
     _12: Result<Stream<string>, string>
   bb0:
-    stmt: use BindingId(83) path site=SiteId(632) ty=string intent=Read
+    stmt: use BindingId(74) path site=SiteId(531) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(84) s site=SiteId(631) ty=Stream<string>
-    stmt: use BindingId(84) s site=SiteId(636) ty=Stream<string> intent=Read
+    stmt: bind BindingId(75) s site=SiteId(530) ty=Stream<string>
+    stmt: use BindingId(75) s site=SiteId(535) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(84) s site=SiteId(640) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(84) s site=SiteId(640) ty=Stream<string>
+    stmt: use BindingId(75) s site=SiteId(539) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(75) s site=SiteId(539) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2046,7 +1682,7 @@ fn stream$from_file(string) -> Result<Stream<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(630)) ty=Result<Stream<string>, string>
+    stmt: return site=Some(SiteId(529)) ty=Result<Stream<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2067,27 +1703,30 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _6: i64
     _7: Result<Stream<string>, fs.IoError>
     _8: i32
-    _9: i32
-    _10: string
-    _11: Result<Stream<string>, fs.IoError>
-    _12: i64
-    _13: i64
-    _14: fs.IoError
-    _15: Result<Stream<string>, fs.IoError>
-    _16: Result<Stream<string>, fs.IoError>
+    _9: i64
+    _10: i64
+    _11: i32
+    _12: i32
+    _13: string
+    _14: Result<Stream<string>, fs.IoError>
+    _15: i64
+    _16: i64
+    _17: fs.IoError
+    _18: Result<Stream<string>, fs.IoError>
+    _19: Result<Stream<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(85) path site=SiteId(647) ty=string intent=Read
+    stmt: use BindingId(76) path site=SiteId(546) ty=string intent=Read
     _1 = call hew_stream_from_file_read(_0) -> bb1
   bb1:
-    stmt: bind BindingId(86) s site=SiteId(646) ty=Stream<string>
-    stmt: use BindingId(86) s site=SiteId(651) ty=Stream<string> intent=Read
+    stmt: bind BindingId(77) s site=SiteId(545) ty=Stream<string>
+    stmt: use BindingId(77) s site=SiteId(550) ty=Stream<string> intent=Read
     _2 = move _1
     _4 = call hew_stream_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(86) s site=SiteId(655) ty=Stream<string> intent=Read
-    stmt: agg_alias BindingId(86) s site=SiteId(655) ty=Stream<string>
+    stmt: use BindingId(77) s site=SiteId(554) ty=Stream<string> intent=Read
+    stmt: agg_alias BindingId(77) s site=SiteId(554) ty=Stream<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2095,27 +1734,33 @@ fn stream$try_from_file(string) -> Result<Stream<string>, fs.IoError> [conv=defa
     _3 = move _7
     goto bb5
   bb4:
-    _8 = call hew_stream_last_errno() -> bb6
+    _8 = call hew_stream_last_error_kind() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(645)) ty=Result<Stream<string>, fs.IoError>
-    _16 = move _3
-    ret = move _16
+    stmt: return site=Some(SiteId(544)) ty=Result<Stream<string>, fs.IoError>
+    _19 = move _3
+    ret = move _19
     return
   bb6:
-    stmt: bind BindingId(87) errno site=SiteId(657) ty=i32
-    _9 = move _8
-    _10 = call hew_stream_last_error() -> bb7
+    stmt: bind BindingId(78) kind site=SiteId(556) ty=i64
+    _9 = cast _8 i32 -> i64
+    _10 = move _9
+    _11 = call hew_stream_last_errno() -> bb7
   bb7:
-    stmt: eval site=SiteId(659) ty=string
-    stmt: use BindingId(87) errno site=SiteId(664) ty=i32 intent=Read
-    _12 = const.i64 1
-    mtag11 = move _12
-    _13 = cast _9 i32 -> i64
-    _14 = call fs$io_error_from_errno(_13) -> bb8
+    stmt: bind BindingId(79) errno site=SiteId(559) ty=i32
+    _12 = move _11
+    _13 = call hew_stream_last_error() -> bb8
   bb8:
-    mvar11.1.0 = move _14
-    _15 = move _11
-    _3 = move _15
+    stmt: eval site=SiteId(561) ty=string
+    stmt: use BindingId(78) kind site=SiteId(565) ty=i64 intent=Read
+    stmt: use BindingId(79) errno site=SiteId(567) ty=i32 intent=Read
+    _15 = const.i64 1
+    mtag14 = move _15
+    _16 = cast _12 i32 -> i64
+    _17 = call fs$io_error_from_kind(_10, _16) -> bb9
+  bb9:
+    mvar14.1.0 = move _17
+    _18 = move _14
+    _3 = move _18
     goto bb5
 
 fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
@@ -2134,18 +1779,18 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     _11: Result<Sink<string>, string>
     _12: Result<Sink<string>, string>
   bb0:
-    stmt: use BindingId(88) path site=SiteId(668) ty=string intent=Read
+    stmt: use BindingId(80) path site=SiteId(571) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(89) s site=SiteId(667) ty=Sink<string>
-    stmt: use BindingId(89) s site=SiteId(672) ty=Sink<string> intent=Read
+    stmt: bind BindingId(81) s site=SiteId(570) ty=Sink<string>
+    stmt: use BindingId(81) s site=SiteId(575) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(89) s site=SiteId(676) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(89) s site=SiteId(676) ty=Sink<string>
+    stmt: use BindingId(81) s site=SiteId(579) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(81) s site=SiteId(579) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2157,7 +1802,7 @@ fn stream$to_file(string) -> Result<Sink<string>, string> [conv=default]
     mtag8 = move _9
     _10 = call hew_stream_last_error() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(666)) ty=Result<Sink<string>, string>
+    stmt: return site=Some(SiteId(569)) ty=Result<Sink<string>, string>
     _12 = move _3
     ret = move _12
     return
@@ -2178,27 +1823,30 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _6: i64
     _7: Result<Sink<string>, fs.IoError>
     _8: i32
-    _9: i32
-    _10: string
-    _11: Result<Sink<string>, fs.IoError>
-    _12: i64
-    _13: i64
-    _14: fs.IoError
-    _15: Result<Sink<string>, fs.IoError>
-    _16: Result<Sink<string>, fs.IoError>
+    _9: i64
+    _10: i64
+    _11: i32
+    _12: i32
+    _13: string
+    _14: Result<Sink<string>, fs.IoError>
+    _15: i64
+    _16: i64
+    _17: fs.IoError
+    _18: Result<Sink<string>, fs.IoError>
+    _19: Result<Sink<string>, fs.IoError>
   bb0:
-    stmt: use BindingId(90) path site=SiteId(683) ty=string intent=Read
+    stmt: use BindingId(82) path site=SiteId(586) ty=string intent=Read
     _1 = call hew_stream_from_file_write(_0) -> bb1
   bb1:
-    stmt: bind BindingId(91) s site=SiteId(682) ty=Sink<string>
-    stmt: use BindingId(91) s site=SiteId(687) ty=Sink<string> intent=Read
+    stmt: bind BindingId(83) s site=SiteId(585) ty=Sink<string>
+    stmt: use BindingId(83) s site=SiteId(590) ty=Sink<string> intent=Read
     _2 = move _1
     _4 = call hew_sink_is_valid(_2) -> bb2
   bb2:
     branch _4 ? bb3 : bb4
   bb3:
-    stmt: use BindingId(91) s site=SiteId(691) ty=Sink<string> intent=Read
-    stmt: agg_alias BindingId(91) s site=SiteId(691) ty=Sink<string>
+    stmt: use BindingId(83) s site=SiteId(594) ty=Sink<string> intent=Read
+    stmt: agg_alias BindingId(83) s site=SiteId(594) ty=Sink<string>
     _6 = const.i64 0
     mtag5 = move _6
     mvar5.0.0 = move _2
@@ -2206,27 +1854,33 @@ fn stream$try_to_file(string) -> Result<Sink<string>, fs.IoError> [conv=default]
     _3 = move _7
     goto bb5
   bb4:
-    _8 = call hew_stream_last_errno() -> bb6
+    _8 = call hew_stream_last_error_kind() -> bb6
   bb5:
-    stmt: return site=Some(SiteId(681)) ty=Result<Sink<string>, fs.IoError>
-    _16 = move _3
-    ret = move _16
+    stmt: return site=Some(SiteId(584)) ty=Result<Sink<string>, fs.IoError>
+    _19 = move _3
+    ret = move _19
     return
   bb6:
-    stmt: bind BindingId(92) errno site=SiteId(693) ty=i32
-    _9 = move _8
-    _10 = call hew_stream_last_error() -> bb7
+    stmt: bind BindingId(84) kind site=SiteId(596) ty=i64
+    _9 = cast _8 i32 -> i64
+    _10 = move _9
+    _11 = call hew_stream_last_errno() -> bb7
   bb7:
-    stmt: eval site=SiteId(695) ty=string
-    stmt: use BindingId(92) errno site=SiteId(700) ty=i32 intent=Read
-    _12 = const.i64 1
-    mtag11 = move _12
-    _13 = cast _9 i32 -> i64
-    _14 = call fs$io_error_from_errno(_13) -> bb8
+    stmt: bind BindingId(85) errno site=SiteId(599) ty=i32
+    _12 = move _11
+    _13 = call hew_stream_last_error() -> bb8
   bb8:
-    mvar11.1.0 = move _14
-    _15 = move _11
-    _3 = move _15
+    stmt: eval site=SiteId(601) ty=string
+    stmt: use BindingId(84) kind site=SiteId(605) ty=i64 intent=Read
+    stmt: use BindingId(85) errno site=SiteId(607) ty=i32 intent=Read
+    _15 = const.i64 1
+    mtag14 = move _15
+    _16 = cast _12 i32 -> i64
+    _17 = call fs$io_error_from_kind(_10, _16) -> bb9
+  bb9:
+    mvar14.1.0 = move _17
+    _18 = move _14
+    _3 = move _18
     goto bb5
 
 fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
@@ -2234,11 +1888,11 @@ fn stream$forward(Stream<string>, Sink<string>) -> () [conv=default]
     _0: Stream<string>
     _1: Sink<string>
   bb0:
-    stmt: use BindingId(93) source site=SiteId(704) ty=Stream<string> intent=Read
-    stmt: use BindingId(94) dest site=SiteId(705) ty=Sink<string> intent=Read
+    stmt: use BindingId(86) source site=SiteId(611) ty=Stream<string> intent=Read
+    stmt: use BindingId(87) dest site=SiteId(612) ty=Sink<string> intent=Read
     call hew_stream_pipe(_0, _1) -> bb1
   bb1:
-    stmt: eval site=SiteId(702) ty=()
+    stmt: eval site=SiteId(609) ty=()
     return
 
 fn i8::fmt(i8) -> string [conv=default]
@@ -2247,11 +1901,11 @@ fn i8::fmt(i8) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(103) val site=SiteId(777) ty=i8 intent=Read
+    stmt: use BindingId(96) val site=SiteId(684) ty=i8 intent=Read
     _1 = cast _0 i8 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(775)) ty=string
+    stmt: return site=Some(SiteId(682)) ty=string
     ret = move _2
     return
 
@@ -2261,11 +1915,11 @@ fn i16::fmt(i16) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(104) val site=SiteId(781) ty=i16 intent=Read
+    stmt: use BindingId(97) val site=SiteId(688) ty=i16 intent=Read
     _1 = cast _0 i16 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(779)) ty=string
+    stmt: return site=Some(SiteId(686)) ty=string
     ret = move _2
     return
 
@@ -2274,10 +1928,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(105) val site=SiteId(784) ty=i32 intent=Read
+    stmt: use BindingId(98) val site=SiteId(691) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(783)) ty=string
+    stmt: return site=Some(SiteId(690)) ty=string
     ret = move _1
     return
 
@@ -2286,10 +1940,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(106) val site=SiteId(787) ty=i64 intent=Read
+    stmt: use BindingId(99) val site=SiteId(694) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(786)) ty=string
+    stmt: return site=Some(SiteId(693)) ty=string
     ret = move _1
     return
 
@@ -2298,10 +1952,10 @@ fn u8::fmt(u8) -> string [conv=default]
     _0: u8
     _1: string
   bb0:
-    stmt: use BindingId(107) val site=SiteId(790) ty=u8 intent=Read
+    stmt: use BindingId(100) val site=SiteId(697) ty=u8 intent=Read
     _1 = call to_string_u8(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(789)) ty=string
+    stmt: return site=Some(SiteId(696)) ty=string
     ret = move _1
     return
 
@@ -2310,10 +1964,10 @@ fn u16::fmt(u16) -> string [conv=default]
     _0: u16
     _1: string
   bb0:
-    stmt: use BindingId(108) val site=SiteId(793) ty=u16 intent=Read
+    stmt: use BindingId(101) val site=SiteId(700) ty=u16 intent=Read
     _1 = call to_string_u16(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(792)) ty=string
+    stmt: return site=Some(SiteId(699)) ty=string
     ret = move _1
     return
 
@@ -2322,10 +1976,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(109) val site=SiteId(796) ty=u32 intent=Read
+    stmt: use BindingId(102) val site=SiteId(703) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(795)) ty=string
+    stmt: return site=Some(SiteId(702)) ty=string
     ret = move _1
     return
 
@@ -2334,10 +1988,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(110) val site=SiteId(799) ty=u64 intent=Read
+    stmt: use BindingId(103) val site=SiteId(706) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(798)) ty=string
+    stmt: return site=Some(SiteId(705)) ty=string
     ret = move _1
     return
 
@@ -2347,11 +2001,11 @@ fn isize::fmt(isize) -> string [conv=default]
     _1: i64
     _2: string
   bb0:
-    stmt: use BindingId(111) val site=SiteId(803) ty=isize intent=Read
+    stmt: use BindingId(104) val site=SiteId(710) ty=isize intent=Read
     _1 = cast _0 isize -> i64
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(801)) ty=string
+    stmt: return site=Some(SiteId(708)) ty=string
     ret = move _2
     return
 
@@ -2361,11 +2015,11 @@ fn usize::fmt(usize) -> string [conv=default]
     _1: u64
     _2: string
   bb0:
-    stmt: use BindingId(112) val site=SiteId(807) ty=usize intent=Read
+    stmt: use BindingId(105) val site=SiteId(714) ty=usize intent=Read
     _1 = cast _0 usize -> u64
     _2 = call to_string_u64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(805)) ty=string
+    stmt: return site=Some(SiteId(712)) ty=string
     ret = move _2
     return
 
@@ -2374,10 +2028,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(113) val site=SiteId(810) ty=bool intent=Read
+    stmt: use BindingId(106) val site=SiteId(717) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(809)) ty=string
+    stmt: return site=Some(SiteId(716)) ty=string
     ret = move _1
     return
 
@@ -2386,10 +2040,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(114) val site=SiteId(813) ty=char intent=Read
+    stmt: use BindingId(107) val site=SiteId(720) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(812)) ty=string
+    stmt: return site=Some(SiteId(719)) ty=string
     ret = move _1
     return
 
@@ -2398,10 +2052,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(115) val site=SiteId(816) ty=f64 intent=Read
+    stmt: use BindingId(108) val site=SiteId(723) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(815)) ty=string
+    stmt: return site=Some(SiteId(722)) ty=string
     ret = move _1
     return
 
@@ -2411,11 +2065,11 @@ fn f32::fmt(f32) -> string [conv=default]
     _1: f64
     _2: string
   bb0:
-    stmt: use BindingId(116) val site=SiteId(820) ty=f32 intent=Read
+    stmt: use BindingId(109) val site=SiteId(727) ty=f32 intent=Read
     _1 = cast _0 f32 -> f64
     _2 = call to_string_f64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(818)) ty=string
+    stmt: return site=Some(SiteId(725)) ty=string
     ret = move _2
     return
 
@@ -2423,8 +2077,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(117) val site=SiteId(822) ty=string intent=Read
-    stmt: return site=Some(SiteId(822)) ty=string
+    stmt: use BindingId(110) val site=SiteId(729) ty=string intent=Read
+    stmt: return site=Some(SiteId(729)) ty=string
     ret = move _0
     return
 
@@ -2435,14 +2089,14 @@ fn duration::from_nanos(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(118) n site=SiteId(824) ty=i64 intent=Read
+    stmt: use BindingId(111) n site=SiteId(731) ty=i64 intent=Read
     _1 = const.duration 1ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(823)) ty=duration
+    stmt: return site=Some(SiteId(730)) ty=duration
     ret = move _2
     return
 
@@ -2453,14 +2107,14 @@ fn duration::from_micros(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(119) n site=SiteId(827) ty=i64 intent=Read
+    stmt: use BindingId(112) n site=SiteId(734) ty=i64 intent=Read
     _1 = const.duration 1000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(826)) ty=duration
+    stmt: return site=Some(SiteId(733)) ty=duration
     ret = move _2
     return
 
@@ -2471,14 +2125,14 @@ fn duration::from_millis(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(120) n site=SiteId(830) ty=i64 intent=Read
+    stmt: use BindingId(113) n site=SiteId(737) ty=i64 intent=Read
     _1 = const.duration 1000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(829)) ty=duration
+    stmt: return site=Some(SiteId(736)) ty=duration
     ret = move _2
     return
 
@@ -2489,14 +2143,14 @@ fn duration::from_secs(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(121) n site=SiteId(833) ty=i64 intent=Read
+    stmt: use BindingId(114) n site=SiteId(740) ty=i64 intent=Read
     _1 = const.duration 1000000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(832)) ty=duration
+    stmt: return site=Some(SiteId(739)) ty=duration
     ret = move _2
     return
 
@@ -2508,11 +2162,11 @@ fn duration::fmt(duration) -> string [conv=default]
     _3: string
     _4: string
   bb0:
-    stmt: use BindingId(122) val site=SiteId(838) ty=duration intent=Read
+    stmt: use BindingId(115) val site=SiteId(745) ty=duration intent=Read
     _1 = call_rt hew_duration_nanos(_0)
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(835)) ty=string
+    stmt: return site=Some(SiteId(742)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
     drop _2 ty=string fn=release(hew_string_drop)

--- a/hew-runtime/src/env.rs
+++ b/hew-runtime/src/env.rs
@@ -33,6 +33,10 @@ fn string_to_malloc(s: &str) -> *mut c_char {
     unsafe { malloc_cstring(s.as_ptr(), s.len()) }
 }
 
+fn is_valid_env_key(key: &str) -> bool {
+    !key.is_empty() && !key.contains('=')
+}
+
 // ---------------------------------------------------------------------------
 // Environment variables
 // ---------------------------------------------------------------------------
@@ -63,44 +67,56 @@ pub unsafe extern "C" fn hew_env_get(key: *const c_char) -> *mut c_char {
 
 /// Set an environment variable.
 ///
+/// Returns 0 on success and -1 when the key is invalid.
+///
 /// # Safety
 ///
 /// Both `key` and `val` must be valid NUL-terminated C strings.
 #[no_mangle]
-pub unsafe extern "C" fn hew_env_set(key: *const c_char, val: *const c_char) {
+pub unsafe extern "C" fn hew_env_set(key: *const c_char, val: *const c_char) -> i32 {
     if key.is_null() || val.is_null() {
-        return;
+        return -1;
     }
     // SAFETY: caller guarantees both pointers are valid NUL-terminated C strings.
     let Ok(key_str) = (unsafe { CStr::from_ptr(key) }).to_str() else {
-        return;
+        return -1;
     };
     // SAFETY: caller guarantees val is a valid NUL-terminated C string.
     let Ok(val_str) = (unsafe { CStr::from_ptr(val) }).to_str() else {
-        return;
+        return -1;
     };
+    if !is_valid_env_key(key_str) {
+        return -1;
+    }
     // SAFETY: ENV_LOCK synchronizes access to the process-global environ array;
     // set_var is safe when protected by exclusive write access.
     ENV_LOCK.access(|()| unsafe { std::env::set_var(key_str, val_str) });
+    0
 }
 
 /// Remove an environment variable.
+///
+/// Returns 0 on success and -1 when the key is invalid.
 ///
 /// # Safety
 ///
 /// `key` must be a valid NUL-terminated C string.
 #[no_mangle]
-pub unsafe extern "C" fn hew_env_remove(key: *const c_char) {
+pub unsafe extern "C" fn hew_env_remove(key: *const c_char) -> i32 {
     if key.is_null() {
-        return;
+        return -1;
     }
     // SAFETY: caller guarantees `key` is a valid NUL-terminated C string.
     let Ok(key_str) = (unsafe { CStr::from_ptr(key) }).to_str() else {
-        return;
+        return -1;
     };
+    if !is_valid_env_key(key_str) {
+        return -1;
+    }
     // SAFETY: ENV_LOCK synchronizes access to the process-global environ array;
     // remove_var is safe when protected by exclusive write access.
     ENV_LOCK.access(|()| unsafe { std::env::remove_var(key_str) });
+    0
 }
 
 /// Check if an environment variable exists. Returns 1 if set, 0 otherwise.
@@ -645,7 +661,7 @@ mod tests {
             assert!(hew_env_get(key.as_ptr()).is_null());
 
             // Set and verify.
-            hew_env_set(key.as_ptr(), val.as_ptr());
+            assert_eq!(hew_env_set(key.as_ptr(), val.as_ptr()), 0);
             assert_eq!(hew_env_has(key.as_ptr()), 1);
 
             let got = hew_env_get(key.as_ptr());
@@ -653,8 +669,23 @@ mod tests {
             assert_eq!(text, "hello_hew");
 
             // Remove and verify.
-            hew_env_remove(key.as_ptr());
+            assert_eq!(hew_env_remove(key.as_ptr()), 0);
             assert_eq!(hew_env_has(key.as_ptr()), 0);
+        }
+    }
+
+    #[test]
+    fn test_env_set_and_remove_reject_invalid_keys() {
+        let empty = CString::new("").unwrap();
+        let equals = CString::new("HEW=INVALID").unwrap();
+        let value = CString::new("value").unwrap();
+
+        // SAFETY: all strings are valid NUL-terminated C strings.
+        unsafe {
+            assert_eq!(hew_env_set(empty.as_ptr(), value.as_ptr()), -1);
+            assert_eq!(hew_env_set(equals.as_ptr(), value.as_ptr()), -1);
+            assert_eq!(hew_env_remove(empty.as_ptr()), -1);
+            assert_eq!(hew_env_remove(equals.as_ptr()), -1);
         }
     }
 
@@ -943,9 +974,13 @@ mod tests {
         // Restore original TMPDIR.
         match orig_value {
             // SAFETY: both key and val are valid NUL-terminated C strings.
-            Some(val) => unsafe { hew_env_set(key.as_ptr(), val.as_ptr()) },
+            Some(val) => unsafe {
+                hew_env_set(key.as_ptr(), val.as_ptr());
+            },
             // SAFETY: key is a valid NUL-terminated C string.
-            None => unsafe { hew_env_remove(key.as_ptr()) },
+            None => unsafe {
+                hew_env_remove(key.as_ptr());
+            },
         }
     }
 }

--- a/hew-runtime/src/file_io.rs
+++ b/hew-runtime/src/file_io.rs
@@ -10,7 +10,10 @@
 )]
 
 use crate::cabi::str_to_malloc;
-use crate::stream_error::{set_last_error_with_errno, take_last_error};
+use crate::stream_error::{
+    io_error_kind_tag, set_last_error_with_errno, set_last_error_with_errno_and_kind,
+    take_last_error,
+};
 use std::ffi::{c_char, CStr, CString};
 
 fn clear_file_io_error() {
@@ -21,7 +24,15 @@ fn clear_file_io_error() {
 fn set_file_io_error(operation: &str, error: &std::io::Error) {
     let message = format!("{operation}: {error}");
     crate::set_last_error(&message);
-    set_last_error_with_errno(message, error.raw_os_error().unwrap_or(libc::EIO));
+    // Carry both the raw OS errno (for the payload) and the portable, canonical
+    // error-kind tag (for classification). The raw errno alone is ambiguous
+    // across platforms — Win32 and POSIX codes diverge and collide — so the
+    // consumer classifies on the kind and keeps the raw code for inspection.
+    set_last_error_with_errno_and_kind(
+        message,
+        error.raw_os_error().unwrap_or(libc::EIO),
+        io_error_kind_tag(error.kind()),
+    );
 }
 
 fn set_file_io_errno(operation: &str, message: impl std::fmt::Display, errno: i32) {
@@ -1315,6 +1326,40 @@ mod tests {
         // SAFETY: p is a valid NUL-terminated C string (dir already exists via test_dir).
         let rc = unsafe { hew_fs_mkdir(p.as_ptr()) };
         assert_eq!(rc, -1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn mkdir_already_exists_classifies_as_already_exists_kind() {
+        // Cross-platform regression (host-independent by construction):
+        // creating a directory that already exists yields
+        // std::io::ErrorKind::AlreadyExists on every OS, even though the raw OS
+        // code differs (POSIX EEXIST=17 vs Windows ERROR_ALREADY_EXISTS=183).
+        // set_file_io_error must therefore record the canonical AlreadyExists
+        // tag so std/fs.hew classifies try_mkdir identically everywhere — the
+        // previous Unix-only errno mapping turned Windows 183 into Other(183).
+        use crate::stream_error::{
+            take_last_errno, take_last_error_kind, IO_ERROR_KIND_ALREADY_EXISTS,
+        };
+        let dir = test_dir("mkdir_kind_dup");
+        let p = cpath(&dir);
+        // SAFETY: p is a valid NUL-terminated C string (dir already exists via test_dir).
+        let rc = unsafe { hew_fs_mkdir(p.as_ptr()) };
+        assert_eq!(rc, -1, "mkdir on an existing directory must fail");
+        // Read the kind BEFORE the errno (take_last_errno clears the tag).
+        let kind = take_last_error_kind();
+        let errno = take_last_errno();
+        assert_eq!(
+            kind, IO_ERROR_KIND_ALREADY_EXISTS,
+            "existing-dir mkdir must classify as AlreadyExists on every platform"
+        );
+        // On unix the raw payload is EEXIST; on Windows it would be 183. Either
+        // way it is non-zero and preserved for inspection — we do not pin the
+        // platform-specific value here.
+        assert_ne!(
+            errno, 0,
+            "the raw OS errno must be preserved in the payload"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/hew-runtime/src/file_io.rs
+++ b/hew-runtime/src/file_io.rs
@@ -10,8 +10,25 @@
 )]
 
 use crate::cabi::str_to_malloc;
-use crate::stream_error::set_last_error_with_errno;
+use crate::stream_error::{set_last_error_with_errno, take_last_error};
 use std::ffi::{c_char, CStr, CString};
+
+fn clear_file_io_error() {
+    crate::hew_clear_error();
+    let _ = take_last_error();
+}
+
+fn set_file_io_error(operation: &str, error: &std::io::Error) {
+    let message = format!("{operation}: {error}");
+    crate::set_last_error(&message);
+    set_last_error_with_errno(message, error.raw_os_error().unwrap_or(libc::EIO));
+}
+
+fn set_file_io_errno(operation: &str, message: impl std::fmt::Display, errno: i32) {
+    let message = format!("{operation}: {message}");
+    crate::set_last_error(&message);
+    set_last_error_with_errno(message, errno);
+}
 
 /// Read an entire file and return a `malloc`-allocated, NUL-terminated C string.
 ///
@@ -44,8 +61,7 @@ pub unsafe extern "C" fn hew_file_read(path: *const c_char) -> *mut c_char {
     let contents = match std::fs::read_to_string(rust_path) {
         Ok(contents) => contents,
         Err(error) => {
-            let msg = format!("hew_file_read: {error}");
-            set_last_error_with_errno(msg, error.raw_os_error().unwrap_or(22));
+            set_file_io_error("hew_file_read", &error);
             return std::ptr::null_mut();
         }
     };
@@ -56,8 +72,7 @@ pub unsafe extern "C" fn hew_file_read(path: *const c_char) -> *mut c_char {
         set_last_error_with_errno(msg.into(), 22);
         return std::ptr::null_mut();
     }
-    crate::hew_clear_error();
-    let _ = crate::stream_error::take_last_error();
+    clear_file_io_error();
     str_to_malloc(&contents)
 }
 
@@ -78,10 +93,15 @@ pub unsafe extern "C" fn hew_file_write(path: *const c_char, content: *const c_c
     let (Ok(rust_path), Ok(rust_content)) = (c_path.to_str(), c_content.to_str()) else {
         return -1;
     };
-    if std::fs::write(rust_path, rust_content).is_ok() {
-        0
-    } else {
-        -1
+    match std::fs::write(rust_path, rust_content) {
+        Ok(()) => {
+            clear_file_io_error();
+            0
+        }
+        Err(error) => {
+            set_file_io_error("hew_file_write", &error);
+            -1
+        }
     }
 }
 
@@ -104,17 +124,26 @@ pub unsafe extern "C" fn hew_file_append(path: *const c_char, content: *const c_
     let (Ok(rust_path), Ok(rust_content)) = (c_path.to_str(), c_content.to_str()) else {
         return -1;
     };
-    let Ok(mut file) = std::fs::OpenOptions::new()
+    let mut file = match std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(rust_path)
-    else {
-        return -1;
+    {
+        Ok(file) => file,
+        Err(error) => {
+            set_file_io_error("hew_file_append", &error);
+            return -1;
+        }
     };
-    if file.write_all(rust_content.as_bytes()).is_ok() {
-        0
-    } else {
-        -1
+    match file.write_all(rust_content.as_bytes()) {
+        Ok(()) => {
+            clear_file_io_error();
+            0
+        }
+        Err(error) => {
+            set_file_io_error("hew_file_append", &error);
+            -1
+        }
     }
 }
 
@@ -168,10 +197,15 @@ pub unsafe extern "C" fn hew_file_delete(path: *const c_char) -> i32 {
     let Ok(rust_path) = c_path.to_str() else {
         return -1;
     };
-    if std::fs::remove_file(rust_path).is_ok() {
-        0
-    } else {
-        -1
+    match std::fs::remove_file(rust_path) {
+        Ok(()) => {
+            clear_file_io_error();
+            0
+        }
+        Err(error) => {
+            set_file_io_error("hew_file_delete", &error);
+            -1
+        }
     }
 }
 
@@ -275,16 +309,13 @@ pub unsafe extern "C" fn hew_file_read_bytes(path: *const c_char) -> crate::byte
             // so that stale messages and errno from a prior failed call are not
             // visible to callers that inspect hew_last_error() or
             // hew_stream_last_error() after a successful read.
-            crate::hew_clear_error();
-            let _ = crate::stream_error::take_last_error();
+            clear_file_io_error();
             let len = u32::try_from(data.len()).unwrap_or(u32::MAX);
             // SAFETY: data is a valid Vec<u8>; len <= data.len().
             unsafe { crate::bytes::hew_bytes_from_static(data.as_ptr(), len) }
         }
         Err(error) => {
-            let msg = format!("hew_file_read_bytes: {error}");
-            crate::set_last_error(&msg);
-            set_last_error_with_errno(msg, error.raw_os_error().unwrap_or(0));
+            set_file_io_error("hew_file_read_bytes", &error);
             crate::bytes::BytesTriple {
                 ptr: std::ptr::null_mut(),
                 offset: 0,
@@ -349,10 +380,15 @@ pub unsafe extern "C" fn hew_file_write_bytes(
             std::slice::from_raw_parts(triple.ptr.add(triple.offset as usize), triple.len as usize)
         }
     };
-    if std::fs::write(rust_path, slice).is_ok() {
-        0
-    } else {
-        -1
+    match std::fs::write(rust_path, slice) {
+        Ok(()) => {
+            clear_file_io_error();
+            0
+        }
+        Err(error) => {
+            set_file_io_error("hew_file_write_bytes", &error);
+            -1
+        }
     }
 }
 
@@ -377,10 +413,15 @@ pub unsafe extern "C" fn hew_fs_mkdir(path: *const c_char) -> i32 {
     let Ok(rust_path) = c_path.to_str() else {
         return -1;
     };
-    if std::fs::create_dir(rust_path).is_ok() {
-        0
-    } else {
-        -1
+    match std::fs::create_dir(rust_path) {
+        Ok(()) => {
+            clear_file_io_error();
+            0
+        }
+        Err(error) => {
+            set_file_io_error("hew_fs_mkdir", &error);
+            -1
+        }
     }
 }
 
@@ -401,47 +442,78 @@ pub unsafe extern "C" fn hew_fs_mkdir_all(path: *const c_char) -> i32 {
     let Ok(rust_path) = c_path.to_str() else {
         return -1;
     };
-    if std::fs::create_dir_all(rust_path).is_ok() {
-        0
-    } else {
-        -1
+    match std::fs::create_dir_all(rust_path) {
+        Ok(()) => {
+            clear_file_io_error();
+            0
+        }
+        Err(error) => {
+            set_file_io_error("hew_fs_mkdir_all", &error);
+            -1
+        }
     }
 }
 
 /// List entries in a directory.
 ///
 /// Returns a `HewVec` of entry names (not full paths). Caller must free with
-/// `hew_vec_free`. Returns an empty vec on error.
+/// `hew_vec_free`. Returns an empty vec and records the failure on error.
 ///
 /// # Safety
 ///
 /// `path` must be a valid, NUL-terminated C string.
+///
+/// # Panics
+///
+/// Panics if an entry name contains a NUL byte, which cannot occur for
+/// real filesystem entry names on supported platforms.
 #[no_mangle]
 pub unsafe extern "C" fn hew_fs_list_dir(path: *const c_char) -> *mut crate::vec::HewVec {
     // SAFETY: hew_vec_new_str allocates a valid empty HewVec<String>.
     let v = unsafe { crate::vec::hew_vec_new_str() };
     if path.is_null() {
+        set_file_io_errno("hew_fs_list_dir", "invalid path string", libc::EINVAL);
         return v;
     }
     // SAFETY: caller guarantees `path` is a valid NUL-terminated C string.
     let c_path = unsafe { CStr::from_ptr(path) };
     let Ok(rust_path) = c_path.to_str() else {
+        set_file_io_errno("hew_fs_list_dir", "invalid path string", libc::EINVAL);
         return v;
     };
-    let Ok(entries) = std::fs::read_dir(rust_path) else {
-        return v;
+    let entries = match std::fs::read_dir(rust_path) {
+        Ok(entries) => entries,
+        Err(error) => {
+            set_file_io_error("hew_fs_list_dir", &error);
+            return v;
+        }
     };
-    for entry in entries.flatten() {
+    let mut names = Vec::new();
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                set_file_io_error("hew_fs_list_dir", &error);
+                return v;
+            }
+        };
         let name = entry.file_name();
         let Ok(name_str) = name.into_string() else {
-            continue;
+            set_file_io_errno(
+                "hew_fs_list_dir",
+                "entry name is not valid UTF-8",
+                libc::EILSEQ,
+            );
+            return v;
         };
-        let Ok(c_name) = CString::new(name_str) else {
-            continue;
-        };
+        names.push(name_str);
+    }
+    for name in names {
+        let c_name = CString::new(name).expect("file names cannot contain NUL");
         // SAFETY: v is a valid HewVec; c_name is a valid NUL-terminated C string.
         unsafe { crate::vec::hew_vec_push_str(v, c_name.as_ptr()) };
     }
+    clear_file_io_error();
     v
 }
 
@@ -465,10 +537,15 @@ pub unsafe extern "C" fn hew_fs_rename(from: *const c_char, to: *const c_char) -
     let Ok(to_str) = (unsafe { CStr::from_ptr(to) }).to_str() else {
         return -1;
     };
-    if std::fs::rename(from_str, to_str).is_ok() {
-        0
-    } else {
-        -1
+    match std::fs::rename(from_str, to_str) {
+        Ok(()) => {
+            clear_file_io_error();
+            0
+        }
+        Err(error) => {
+            set_file_io_error("hew_fs_rename", &error);
+            -1
+        }
     }
 }
 
@@ -492,10 +569,15 @@ pub unsafe extern "C" fn hew_fs_copy(from: *const c_char, to: *const c_char) -> 
     let Ok(to_str) = (unsafe { CStr::from_ptr(to) }).to_str() else {
         return -1;
     };
-    if std::fs::copy(from_str, to_str).is_ok() {
-        0
-    } else {
-        -1
+    match std::fs::copy(from_str, to_str) {
+        Ok(_) => {
+            clear_file_io_error();
+            0
+        }
+        Err(error) => {
+            set_file_io_error("hew_fs_copy", &error);
+            -1
+        }
     }
 }
 

--- a/hew-runtime/src/stream.rs
+++ b/hew-runtime/src/stream.rs
@@ -268,7 +268,14 @@ impl StreamBacking for FileReadStream {
                 buf.truncate(n);
                 Some(buf)
             }
-            _ => None,
+            Ok(_) => None,
+            Err(error) => {
+                set_last_error_with_errno(
+                    format!("file stream read failed: {error}"),
+                    error.raw_os_error().unwrap_or(libc::EIO),
+                );
+                None
+            }
         }
     }
 
@@ -1098,12 +1105,15 @@ pub unsafe extern "C" fn hew_stream_from_file_read(path: *const c_char) -> *mut 
         return ptr::null_mut();
     };
     match fs::File::open(path_str) {
-        Ok(f) => into_stream_ptr(FileReadStream {
-            reader: BufReader::new(f),
-            chunk_size: 4096,
-        }),
+        Ok(f) => {
+            let _ = take_last_error();
+            into_stream_ptr(FileReadStream {
+                reader: BufReader::new(f),
+                chunk_size: 4096,
+            })
+        }
         Err(e) => {
-            set_last_error_with_errno(format!("{e}"), e.raw_os_error().unwrap_or(0));
+            set_last_error_with_errno(format!("{e}"), e.raw_os_error().unwrap_or(libc::EIO));
             ptr::null_mut()
         }
     }

--- a/hew-runtime/src/stream.rs
+++ b/hew-runtime/src/stream.rs
@@ -4163,6 +4163,61 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    // ── File-open error classification (canonical kind channel) ──────────
+
+    #[test]
+    fn from_file_read_missing_sets_not_found_kind() {
+        // Cross-platform regression (host-independent by construction): opening
+        // a missing file for read yields std::io::ErrorKind::NotFound on every
+        // OS, so hew_stream_from_file_read must record the canonical NotFound
+        // tag. std::stream's try_from_file reads that tag before the raw errno,
+        // so on Windows an access-denied open (raw 5) classifies as
+        // PermissionDenied instead of the old Other(5). Here we pin the NotFound
+        // wiring, which is reproducible without a Windows host.
+        use crate::stream_error::{take_last_errno, take_last_error_kind, IO_ERROR_KIND_NOT_FOUND};
+        let c_path = CString::new("/tmp/hew_stream_missing_open_read.txt").unwrap();
+        // SAFETY: c_path is a valid NUL-terminated C string.
+        let s = unsafe { hew_stream_from_file_read(c_path.as_ptr()) };
+        assert!(s.is_null(), "opening a missing file for read must fail");
+        // Read the kind BEFORE the errno (take_last_errno clears the tag).
+        let kind = take_last_error_kind();
+        let errno = take_last_errno();
+        assert_eq!(
+            kind, IO_ERROR_KIND_NOT_FOUND,
+            "a missing-file open must classify as NotFound on every platform"
+        );
+        assert_ne!(
+            errno, 0,
+            "the raw OS errno must be preserved in the payload"
+        );
+    }
+
+    #[test]
+    fn from_file_write_into_missing_dir_sets_not_found_kind() {
+        // Symmetric proof for the write/sink open path used by try_to_file:
+        // creating a file under a directory that does not exist is NotFound on
+        // every OS, and the sink-open path must tag it so try_to_file classifies
+        // through the canonical kind rather than the raw errno.
+        use crate::stream_error::{take_last_errno, take_last_error_kind, IO_ERROR_KIND_NOT_FOUND};
+        let c_path = CString::new("/tmp/hew_stream_missing_dir_open/child.txt").unwrap();
+        // SAFETY: c_path is a valid NUL-terminated C string.
+        let s = unsafe { hew_stream_from_file_write(c_path.as_ptr()) };
+        assert!(
+            s.is_null(),
+            "opening a file under a missing directory for write must fail"
+        );
+        let kind = take_last_error_kind();
+        let errno = take_last_errno();
+        assert_eq!(
+            kind, IO_ERROR_KIND_NOT_FOUND,
+            "a missing-parent open must classify as NotFound on every platform"
+        );
+        assert_ne!(
+            errno, 0,
+            "the raw OS errno must be preserved in the payload"
+        );
+    }
+
     // ── Threaded channel ────────────────────────────────────────────────
 
     #[test]

--- a/hew-runtime/src/stream.rs
+++ b/hew-runtime/src/stream.rs
@@ -59,7 +59,8 @@ use std::sync::{Arc, Mutex};
 // Defining them in hew-cabi avoids pulling the full runtime into stdlib packages.
 
 pub use crate::stream_error::{
-    hew_stream_last_error, set_last_error, set_last_error_with_errno, take_last_error,
+    hew_stream_last_error, io_error_kind_tag, set_last_error, set_last_error_with_errno,
+    set_last_error_with_errno_and_kind, take_last_error,
 };
 pub use hew_cabi::sink::{into_sink_ptr, into_write_sink_ptr, HewSink};
 
@@ -1113,7 +1114,11 @@ pub unsafe extern "C" fn hew_stream_from_file_read(path: *const c_char) -> *mut 
             })
         }
         Err(e) => {
-            set_last_error_with_errno(format!("{e}"), e.raw_os_error().unwrap_or(libc::EIO));
+            set_last_error_with_errno_and_kind(
+                format!("{e}"),
+                e.raw_os_error().unwrap_or(libc::EIO),
+                io_error_kind_tag(e.kind()),
+            );
             ptr::null_mut()
         }
     }
@@ -1139,7 +1144,11 @@ pub unsafe extern "C" fn hew_stream_from_file_write(path: *const c_char) -> *mut
     match fs::File::create(path_str) {
         Ok(f) => into_write_sink_ptr(f),
         Err(e) => {
-            set_last_error_with_errno(format!("{e}"), e.raw_os_error().unwrap_or(0));
+            set_last_error_with_errno_and_kind(
+                format!("{e}"),
+                e.raw_os_error().unwrap_or(0),
+                io_error_kind_tag(e.kind()),
+            );
             ptr::null_mut()
         }
     }

--- a/hew-runtime/src/stream_error.rs
+++ b/hew-runtime/src/stream_error.rs
@@ -30,6 +30,57 @@ thread_local! {
     static LAST_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
     /// OS errno associated with the last error, or 0 when not set.
     static LAST_ERRNO: RefCell<i32> = const { RefCell::new(0) };
+    /// Canonical, platform-independent error-kind tag for the last error, or
+    /// 0 (`IO_ERROR_KIND_UNCLASSIFIED`) when not set. See [`io_error_kind_tag`].
+    static LAST_ERROR_KIND: RefCell<i32> = const { RefCell::new(0) };
+}
+
+// ── Canonical error-kind tags ─────────────────────────────────────────────────
+//
+// POSIX errno and Windows Win32 error codes diverge — "already exists" is
+// `EEXIST` = 17 on unix but `ERROR_ALREADY_EXISTS` = 183 on Windows, and
+// "access denied" is `EACCES` = 13 vs `ERROR_ACCESS_DENIED` = 5 — and worse,
+// some codes *collide* with different meanings across the two spaces (Win32 5 =
+// access-denied, POSIX 5 = `EIO`). A classifier that sees only the raw integer
+// therefore cannot be correct on both platforms at once.
+//
+// `std::io::ErrorKind` is the portable authority, but it only exists runtime
+// side where the `io::Error` is in scope. These tags carry that classification
+// across the C ABI so `std/fs.hew` picks the right `IoError` variant identically
+// on every platform, while the variant payload still surfaces the raw OS errno
+// for platform-specific inspection.
+//
+// Tag 0 means "unclassified": the consumer falls back to mapping the raw errno,
+// which preserves platform detail for kinds without a canonical tag (for
+// example `EISDIR`/`ENOTDIR` -> `IoError::Other(raw)`). Keep the tag values in
+// sync with `io_error_from_kind` in `std/fs.hew`.
+
+/// No canonical classification; the consumer falls back to raw-errno mapping.
+pub const IO_ERROR_KIND_UNCLASSIFIED: i32 = 0;
+/// Portable `std::io::ErrorKind::NotFound`.
+pub const IO_ERROR_KIND_NOT_FOUND: i32 = 1;
+/// Portable `std::io::ErrorKind::PermissionDenied`.
+pub const IO_ERROR_KIND_PERMISSION_DENIED: i32 = 2;
+/// Portable `std::io::ErrorKind::AlreadyExists`.
+pub const IO_ERROR_KIND_ALREADY_EXISTS: i32 = 3;
+/// Portable `std::io::ErrorKind::TimedOut`.
+pub const IO_ERROR_KIND_TIMED_OUT: i32 = 4;
+
+/// Map a portable [`std::io::ErrorKind`] to its canonical cross-platform tag.
+///
+/// Returns [`IO_ERROR_KIND_UNCLASSIFIED`] for kinds without a stable
+/// user-facing `IoError` variant, so the consumer keeps the raw errno detail
+/// rather than flattening it to a wrong classification.
+#[must_use]
+pub fn io_error_kind_tag(kind: std::io::ErrorKind) -> i32 {
+    use std::io::ErrorKind;
+    match kind {
+        ErrorKind::NotFound => IO_ERROR_KIND_NOT_FOUND,
+        ErrorKind::PermissionDenied => IO_ERROR_KIND_PERMISSION_DENIED,
+        ErrorKind::AlreadyExists => IO_ERROR_KIND_ALREADY_EXISTS,
+        ErrorKind::TimedOut => IO_ERROR_KIND_TIMED_OUT,
+        _ => IO_ERROR_KIND_UNCLASSIFIED,
+    }
 }
 
 // ── In-crate Rust helpers ─────────────────────────────────────────────────────
@@ -39,32 +90,73 @@ thread_local! {
 // `hew_cabi::sink` wrappers.
 
 /// Store an error message for the current thread. Retrievable via
-/// [`hew_stream_last_error`]. The associated errno is cleared to 0.
+/// [`hew_stream_last_error`]. The associated errno and error-kind are cleared.
 pub fn set_last_error(msg: String) {
     LAST_ERROR.with(|e| *e.borrow_mut() = Some(msg));
     LAST_ERRNO.with(|e| *e.borrow_mut() = 0);
+    LAST_ERROR_KIND.with(|k| *k.borrow_mut() = 0);
 }
 
 /// Store an error message together with its OS errno for the current thread.
 /// Both are retrievable via [`hew_stream_last_error`] and [`hew_stream_last_errno`].
+///
+/// The canonical error-kind is reset to unclassified: callers on this path do
+/// not have a Rust `io::Error` in scope, so the consumer maps the raw errno.
 pub fn set_last_error_with_errno(msg: String, errno: i32) {
     LAST_ERROR.with(|e| *e.borrow_mut() = Some(msg));
     LAST_ERRNO.with(|e| *e.borrow_mut() = errno);
+    LAST_ERROR_KIND.with(|k| *k.borrow_mut() = 0);
 }
 
-/// Take and clear the last error, if any. Also clears the associated errno.
+/// Store an error message together with its OS errno *and* its canonical,
+/// platform-independent error-kind tag for the current thread. Retrievable via
+/// [`hew_stream_last_error`], [`hew_stream_last_errno`], and
+/// [`hew_stream_last_error_kind`].
+///
+/// Use this at call sites where a Rust [`std::io::Error`] is in scope, passing
+/// `errno = error.raw_os_error()` and `kind = io_error_kind_tag(error.kind())`,
+/// so the raw platform code is preserved while classification stays correct
+/// across platforms whose errno spaces diverge.
+pub fn set_last_error_with_errno_and_kind(msg: String, errno: i32, kind: i32) {
+    LAST_ERROR.with(|e| *e.borrow_mut() = Some(msg));
+    LAST_ERRNO.with(|e| *e.borrow_mut() = errno);
+    LAST_ERROR_KIND.with(|k| *k.borrow_mut() = kind);
+}
+
+/// Take and clear the last error, if any. Also clears the associated errno and
+/// error-kind.
 #[must_use]
 pub fn take_last_error() -> Option<String> {
     LAST_ERRNO.with(|e| *e.borrow_mut() = 0);
+    LAST_ERROR_KIND.with(|k| *k.borrow_mut() = 0);
     LAST_ERROR.with(|e| e.borrow_mut().take())
 }
 
 /// Take and clear the last errno, if any. Returns 0 when none was set.
+///
+/// The canonical error-kind is metadata of the errno, so it is cleared here
+/// too: a caller that reads only the errno cannot leave a stale classification
+/// parked for an unrelated later read.
 #[must_use]
 pub fn take_last_errno() -> i32 {
+    LAST_ERROR_KIND.with(|k| *k.borrow_mut() = 0);
     LAST_ERRNO.with(|e| {
         let v = *e.borrow();
         *e.borrow_mut() = 0;
+        v
+    })
+}
+
+/// Take and clear the canonical error-kind tag, if any. Returns
+/// [`IO_ERROR_KIND_UNCLASSIFIED`] when none was set.
+///
+/// Consumers MUST read this before [`take_last_errno`] / [`hew_stream_last_errno`],
+/// which clear the tag as errno metadata.
+#[must_use]
+pub fn take_last_error_kind() -> i32 {
+    LAST_ERROR_KIND.with(|k| {
+        let v = *k.borrow();
+        *k.borrow_mut() = 0;
         v
     })
 }
@@ -162,6 +254,25 @@ pub extern "C" fn hew_stream_last_error() -> *mut c_char {
 #[no_mangle]
 pub extern "C" fn hew_stream_last_errno() -> i32 {
     take_last_errno()
+}
+
+/// Return the canonical, platform-independent error-kind tag associated with
+/// the last stream/sink error, or 0 (`IO_ERROR_KIND_UNCLASSIFIED`) if none.
+///
+/// Clears the tag after reading. Consumers MUST read this *before*
+/// [`hew_stream_last_errno`], which also clears the tag as errno metadata. See
+/// the `IO_ERROR_KIND_*` constants and [`io_error_kind_tag`] for the mapping;
+/// `std/fs.hew` uses this to classify I/O failures identically across platforms
+/// whose raw errno spaces diverge (POSIX `EEXIST` = 17 vs Win32
+/// `ERROR_ALREADY_EXISTS` = 183, etc.) while still surfacing the raw errno in
+/// the `IoError` payload.
+///
+/// INTERNAL-ABI: populated by `set_last_error_with_errno_and_kind` at runtime
+/// call sites where a Rust `io::Error` is in scope. Error paths without a Rust
+/// error kind leave this as 0.
+#[no_mangle]
+pub extern "C" fn hew_stream_last_error_kind() -> i32 {
+    take_last_error_kind()
 }
 
 #[cfg(test)]
@@ -336,6 +447,96 @@ mod tests {
         let msg = take_last_error();
         assert_eq!(msg.as_deref(), Some("disk full"));
         // After take_last_error the errno path is also cleared.
+        assert_eq!(take_last_errno(), 0);
+    }
+
+    // ── canonical error-kind tag (cross-platform classification) ─────────
+
+    #[test]
+    fn io_error_kind_tag_maps_portable_kinds() {
+        use std::io::ErrorKind;
+        // These portable kinds are what Rust's std maps the divergent raw OS
+        // codes to (e.g. Windows ERROR_ALREADY_EXISTS=183 and POSIX EEXIST=17
+        // both become ErrorKind::AlreadyExists), so tagging on the kind is
+        // correct on every platform without seeing the raw integer.
+        assert_eq!(
+            io_error_kind_tag(ErrorKind::NotFound),
+            IO_ERROR_KIND_NOT_FOUND
+        );
+        assert_eq!(
+            io_error_kind_tag(ErrorKind::PermissionDenied),
+            IO_ERROR_KIND_PERMISSION_DENIED
+        );
+        assert_eq!(
+            io_error_kind_tag(ErrorKind::AlreadyExists),
+            IO_ERROR_KIND_ALREADY_EXISTS
+        );
+        assert_eq!(
+            io_error_kind_tag(ErrorKind::TimedOut),
+            IO_ERROR_KIND_TIMED_OUT
+        );
+        // Kinds without a canonical IoError variant stay unclassified so the
+        // consumer keeps the raw errno (e.g. EISDIR/ENOTDIR -> Other(raw)).
+        assert_eq!(
+            io_error_kind_tag(ErrorKind::WouldBlock),
+            IO_ERROR_KIND_UNCLASSIFIED
+        );
+        assert_eq!(
+            io_error_kind_tag(ErrorKind::Other),
+            IO_ERROR_KIND_UNCLASSIFIED
+        );
+    }
+
+    #[test]
+    fn set_last_error_with_errno_and_kind_roundtrip() {
+        let _ = take_last_error();
+        set_last_error_with_errno_and_kind(
+            "hew_fs_mkdir: File exists".to_string(),
+            17,
+            IO_ERROR_KIND_ALREADY_EXISTS,
+        );
+        // Read kind before errno (documented ordering).
+        assert_eq!(hew_stream_last_error_kind(), IO_ERROR_KIND_ALREADY_EXISTS);
+        assert_eq!(hew_stream_last_errno(), 17);
+        // Kind is consumed after reading.
+        assert_eq!(hew_stream_last_error_kind(), IO_ERROR_KIND_UNCLASSIFIED);
+        let _ = take_last_error();
+    }
+
+    #[test]
+    fn take_last_errno_clears_kind_metadata() {
+        set_last_error_with_errno_and_kind("boom".to_string(), 13, IO_ERROR_KIND_PERMISSION_DENIED);
+        // A consumer that reads only the errno must not leave a stale kind
+        // parked for an unrelated later read.
+        assert_eq!(take_last_errno(), 13);
+        assert_eq!(take_last_error_kind(), IO_ERROR_KIND_UNCLASSIFIED);
+        let _ = take_last_error();
+    }
+
+    #[test]
+    fn plain_and_errno_setters_reset_kind() {
+        // A stale AlreadyExists kind must not survive into a later error set
+        // through a path that has no Rust error kind in scope.
+        set_last_error_with_errno_and_kind("old".to_string(), 17, IO_ERROR_KIND_ALREADY_EXISTS);
+        set_last_error_with_errno("new-errno-only".to_string(), 2);
+        assert_eq!(take_last_error_kind(), IO_ERROR_KIND_UNCLASSIFIED);
+
+        set_last_error_with_errno_and_kind("old2".to_string(), 17, IO_ERROR_KIND_ALREADY_EXISTS);
+        set_last_error("new-message-only".to_string());
+        assert_eq!(take_last_error_kind(), IO_ERROR_KIND_UNCLASSIFIED);
+        let _ = take_last_error();
+    }
+
+    #[test]
+    fn take_last_error_message_clears_kind() {
+        set_last_error_with_errno_and_kind(
+            "drain me".to_string(),
+            17,
+            IO_ERROR_KIND_ALREADY_EXISTS,
+        );
+        // Draining the message also drops the classification.
+        let _ = take_last_error();
+        assert_eq!(take_last_error_kind(), IO_ERROR_KIND_UNCLASSIFIED);
         assert_eq!(take_last_errno(), 0);
     }
 

--- a/scripts/ffi-ownership-ratchet.toml
+++ b/scripts/ffi-ownership-ratchet.toml
@@ -2,4 +2,4 @@
 #
 # This value must exactly match the verifier's computed count. Any classification
 # or contract change that changes the count must deliberately update this ratchet.
-unclassified = 986
+unclassified = 987

--- a/scripts/jit-symbol-classification.toml
+++ b/scripts/jit-symbol-classification.toml
@@ -538,6 +538,7 @@ stable = [
   "hew_stream_is_valid",
   "hew_stream_last_errno",
   "hew_stream_last_error",
+  "hew_stream_last_error_kind",
   "hew_stream_lines",
   "hew_stream_map_bytes",
   "hew_stream_map_string",

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -63,6 +63,15 @@ pub enum IoError {
 /// The i64 payload carried in each variant is the raw OS errno so callers
 /// can inspect the platform value. errno=0 (no OS error) maps to `Other(0)`.
 ///
+/// This is a raw-integer helper: it recognises POSIX errno values plus the few
+/// Windows Win32 codes that do not collide with a POSIX errno (only
+/// `ERROR_ALREADY_EXISTS` = 183 today). Codes that mean *different* things on
+/// each platform — for example 5 (`EIO` on POSIX, `ERROR_ACCESS_DENIED` on
+/// Windows) — cannot be disambiguated from the integer alone; the `try_*`
+/// wrappers classify those correctly through the runtime's canonical error-kind
+/// channel (`hew_stream_last_error_kind`) and only fall back to this function
+/// for kinds without a canonical tag.
+///
 /// Covers file-system errno values. For network errno values use
 /// `net.net_error_from_errno` in `std::net`.
 pub fn io_error_from_errno(errno: i64) -> IoError {
@@ -72,8 +81,9 @@ pub fn io_error_from_errno(errno: i64) -> IoError {
     // EACCES: Linux=13, macOS=13
     } else if errno == 13 {
         IoError::PermissionDenied(errno)
-    // EEXIST: Linux=17, macOS=17
-    } else if errno == 17 {
+    // EEXIST: Linux=17, macOS=17; ERROR_ALREADY_EXISTS: Windows=183.
+    // 183 is not a POSIX errno, so mapping it here is unambiguous.
+    } else if errno == 17 || errno == 183 {
         IoError::AlreadyExists(errno)
     // ETIMEDOUT: Linux=110, macOS=60
     } else if errno == 110 || errno == 60 {
@@ -83,6 +93,30 @@ pub fn io_error_from_errno(errno: i64) -> IoError {
         IoError::Cancelled(errno)
     } else {
         IoError::Other(errno)
+    }
+}
+
+/// Map the runtime's canonical, platform-independent error-kind tag (from
+/// `hew_stream_last_error_kind`) plus the raw OS errno to an `IoError`.
+///
+/// The tag classifies the failure identically on every platform — POSIX and
+/// Windows raw codes diverge and collide, so classification cannot be done from
+/// the errno alone — while the raw errno is preserved as the variant payload.
+/// Tag 0 (`IO_ERROR_KIND_UNCLASSIFIED`) means "no canonical kind": fall back to
+/// `io_error_from_errno`, which keeps platform detail for kinds without a tag
+/// (e.g. `EISDIR`/`ENOTDIR` -> `Other(raw)`). Keep the tag values in sync with
+/// the `IO_ERROR_KIND_*` constants in `hew-runtime/src/stream_error.rs`.
+fn io_error_from_kind(kind: i64, errno: i64) -> IoError {
+    if kind == 1 {
+        IoError::NotFound(errno)
+    } else if kind == 2 {
+        IoError::PermissionDenied(errno)
+    } else if kind == 3 {
+        IoError::AlreadyExists(errno)
+    } else if kind == 4 {
+        IoError::TimedOut(errno)
+    } else {
+        io_error_from_errno(errno)
     }
 }
 
@@ -126,12 +160,15 @@ pub fn io_error_cancelled() -> IoError {
 
 fn last_io_error() -> IoError {
     unsafe {
+        // Read the canonical kind BEFORE the errno: hew_stream_last_errno
+        // clears the kind tag as errno metadata, so the order matters.
+        let kind = hew_stream_last_error_kind() as i64;
         let errno = hew_stream_last_errno() as i64;
         let _ = hew_stream_last_error();
-        if errno == 0 {
+        if errno == 0 && kind == 0 {
             IoError::Other(5)
         } else {
-            io_error_from_errno(errno)
+            io_error_from_kind(kind, errno)
         }
     }
 }
@@ -170,12 +207,13 @@ pub fn try_read(file_path: string) -> Result<string, IoError> {
         let file = hew_stream_from_file_read(file_path);
         if hew_stream_is_valid(file) {
             let contents = hew_stream_collect_string(file);
+            let kind = hew_stream_last_error_kind() as i64;
             let errno = hew_stream_last_errno();
             let _ = hew_stream_last_error();
             if errno == 0 {
                 Ok(contents)
             } else {
-                Err(io_error_from_errno(errno as i64))
+                Err(io_error_from_kind(kind, errno as i64))
             }
         } else {
             Err(last_io_error())
@@ -290,6 +328,7 @@ pub fn read_bytes(path: string) -> bytes {
 pub fn try_read_bytes(file_path: string) -> Result<bytes, IoError> {
     unsafe {
         let data = hew_file_read_bytes(file_path);
+        let kind = hew_stream_last_error_kind() as i64;
         let errno = hew_stream_last_errno();
         if errno != 0 {
             // Drain the thread-local error message on the failure path,
@@ -297,7 +336,7 @@ pub fn try_read_bytes(file_path: string) -> Result<bytes, IoError> {
             // `hew_file_read_bytes: ...` message can't leak into a later,
             // unrelated `hew_last_error()` / `hew_stream_last_error()` read.
             let _ = hew_stream_last_error();
-            Err(io_error_from_errno(errno as i64))
+            Err(io_error_from_kind(kind, errno as i64))
         } else {
             // `data` is the sole owner of the freshly-read buffer and is not
             // used after this point, so move it straight into the result. A
@@ -396,12 +435,13 @@ pub fn list_dir(path: string) -> Vec<string> {
 pub fn try_list_dir(dir_path: string) -> Result<Vec<string>, IoError> {
     unsafe {
         let entries = hew_fs_list_dir(dir_path);
+        let kind = hew_stream_last_error_kind() as i64;
         let errno = hew_stream_last_errno();
         let _ = hew_stream_last_error();
         if errno == 0 {
             Ok(entries)
         } else {
-            Err(io_error_from_errno(errno as i64))
+            Err(io_error_from_kind(kind, errno as i64))
         }
     }
 }
@@ -479,5 +519,6 @@ extern "C" {
     fn hew_stream_is_valid(stream: FileReadStream) -> bool;
     fn hew_stream_last_error() -> string;
     fn hew_stream_last_errno() -> i32; // INTERNAL-ABI: OS errno from thread-local; 0 when none recorded
+    fn hew_stream_last_error_kind() -> i32; // INTERNAL-ABI: canonical cross-platform error-kind tag; 0 when none
     fn hew_stream_collect_string(stream: FileReadStream) -> string;
 }

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -124,85 +124,15 @@ pub fn io_error_cancelled() -> IoError {
     IoError::Cancelled(0)
 }
 
-fn missing_parent(target: string) -> bool {
-    let parent = dirname(target);
-    parent != "" && !exists(parent)
-}
-
-fn dirname(p: string) -> string {
-    let s = strip_trailing_slash(p);
-    let pos = last_slash_pos(s);
-    if pos < 0 {
-        return "";
-    }
-    if pos == 0 {
-        return "/";
-    }
-    s.slice(0, pos)
-}
-
-fn strip_trailing_slash(p: string) -> string {
-    if p == "/" {
-        return "" + p;
-    }
-    if p.len() > 1 && p.ends_with("/") {
-        return p.slice(0, p.len() - 1);
-    }
-    "" + p
-}
-
-fn last_slash_pos(s: string) -> i64 {
-    let first = match s.find("/") {
-        Some(i) => i,
-        None => return -1,
-    };
-    var last = first;
-    var search_from = first + 1;
-    while search_from < s.len() {
-        let rest = s.slice(search_from, s.len());
-        let next = match rest.find("/") {
-            Some(i) => i,
-            None => return last,
-        };
-        last = search_from + next;
-        search_from = last + 1;
-    }
-    last
-}
-
-fn write_error(target: string) -> IoError {
-    if missing_parent(target) {
-        IoError::NotFound(0)
-    } else {
-        IoError::Other(0)
-    }
-}
-
-fn missing_path_error(target: string) -> IoError {
-    if exists(target) {
-        IoError::Other(0)
-    } else {
-        IoError::NotFound(0)
-    }
-}
-
-fn mkdir_error(target: string) -> IoError {
-    if exists(target) {
-        IoError::AlreadyExists(0)
-    } else if missing_parent(target) {
-        IoError::NotFound(0)
-    } else {
-        IoError::Other(0)
-    }
-}
-
-fn move_copy_error(source: string, target: string) -> IoError {
-    if !exists(source) {
-        IoError::NotFound(0)
-    } else if missing_parent(target) {
-        IoError::NotFound(0)
-    } else {
-        IoError::Other(0)
+fn last_io_error() -> IoError {
+    unsafe {
+        let errno = hew_stream_last_errno() as i64;
+        let _ = hew_stream_last_error();
+        if errno == 0 {
+            IoError::Other(5)
+        } else {
+            io_error_from_errno(errno)
+        }
     }
 }
 
@@ -239,11 +169,16 @@ pub fn try_read(file_path: string) -> Result<string, IoError> {
     unsafe {
         let file = hew_stream_from_file_read(file_path);
         if hew_stream_is_valid(file) {
-            Ok(hew_stream_collect_string(file))
-        } else {
+            let contents = hew_stream_collect_string(file);
             let errno = hew_stream_last_errno();
             let _ = hew_stream_last_error();
-            Err(io_error_from_errno(errno as i64))
+            if errno == 0 {
+                Ok(contents)
+            } else {
+                Err(io_error_from_errno(errno as i64))
+            }
+        } else {
+            Err(last_io_error())
         }
     }
 }
@@ -266,7 +201,7 @@ pub fn try_write(file_path: string, content: string) -> Result<i64, IoError> {
         hew_file_write(file_path, content)
     } {
         0 => Ok(0),
-        _ => Err(write_error(file_path)),
+        _ => Err(last_io_error()),
     }
 }
 
@@ -288,7 +223,7 @@ pub fn try_append(file_path: string, content: string) -> Result<i64, IoError> {
         hew_file_append(file_path, content)
     } {
         0 => Ok(0),
-        _ => Err(write_error(file_path)),
+        _ => Err(last_io_error()),
     }
 }
 
@@ -321,7 +256,7 @@ pub fn try_delete(file_path: string) -> Result<i64, IoError> {
         hew_file_delete(file_path)
     } {
         0 => Ok(0),
-        _ => Err(missing_path_error(file_path)),
+        _ => Err(last_io_error()),
     }
 }
 
@@ -390,7 +325,7 @@ pub fn try_write_bytes(file_path: string, data: bytes) -> Result<i64, IoError> {
         hew_file_write_bytes(file_path, data)
     } {
         0 => Ok(0),
-        _ => Err(write_error(file_path)),
+        _ => Err(last_io_error()),
     }
 }
 
@@ -411,7 +346,7 @@ pub fn try_mkdir(dir_path: string) -> Result<i64, IoError> {
         hew_fs_mkdir(dir_path)
     } {
         0 => Ok(0),
-        _ => Err(mkdir_error(dir_path)),
+        _ => Err(last_io_error()),
     }
 }
 
@@ -432,13 +367,7 @@ pub fn try_mkdir_all(dir_path: string) -> Result<i64, IoError> {
         hew_fs_mkdir_all(dir_path)
     } {
         0 => Ok(0),
-        _ => {
-            if exists(dir_path) {
-                Err(IoError::AlreadyExists(0))
-            } else {
-                Err(IoError::Other(0))
-            }
-        },
+        _ => Err(last_io_error()),
     }
 }
 
@@ -463,17 +392,18 @@ pub fn list_dir(path: string) -> Vec<string> {
 
 /// List the entries in a directory.
 ///
-/// Distinguishes missing and non-directory paths from a successful listing.
+/// Returns an error for every directory-read failure.
 pub fn try_list_dir(dir_path: string) -> Result<Vec<string>, IoError> {
-    if !exists(dir_path) {
-        return Err(IoError::NotFound(0));
+    unsafe {
+        let entries = hew_fs_list_dir(dir_path);
+        let errno = hew_stream_last_errno();
+        let _ = hew_stream_last_error();
+        if errno == 0 {
+            Ok(entries)
+        } else {
+            Err(io_error_from_errno(errno as i64))
+        }
     }
-    if !is_dir(dir_path) {
-        return Err(IoError::Other(0));
-    }
-    Ok(unsafe {
-        hew_fs_list_dir(dir_path)
-    })
 }
 
 /// Rename or move a file or directory.
@@ -493,7 +423,7 @@ pub fn try_rename(from: string, to: string) -> Result<i64, IoError> {
         hew_fs_rename(from, to)
     } {
         0 => Ok(0),
-        _ => Err(move_copy_error(from, to)),
+        _ => Err(last_io_error()),
     }
 }
 
@@ -514,7 +444,7 @@ pub fn try_copy(from: string, to: string) -> Result<i64, IoError> {
         hew_fs_copy(from, to)
     } {
         0 => Ok(0),
-        _ => Err(move_copy_error(from, to)),
+        _ => Err(last_io_error()),
     }
 }
 

--- a/std/fs.hew
+++ b/std/fs.hew
@@ -106,7 +106,11 @@ pub fn io_error_from_errno(errno: i64) -> IoError {
 /// `io_error_from_errno`, which keeps platform detail for kinds without a tag
 /// (e.g. `EISDIR`/`ENOTDIR` -> `Other(raw)`). Keep the tag values in sync with
 /// the `IO_ERROR_KIND_*` constants in `hew-runtime/src/stream_error.rs`.
-fn io_error_from_kind(kind: i64, errno: i64) -> IoError {
+///
+/// Public so sibling wrappers that read the same runtime error channel — e.g.
+/// `std::stream`'s `try_from_file` / `try_to_file` — classify failures through
+/// this one authority rather than re-deriving it from the raw errno.
+pub fn io_error_from_kind(kind: i64, errno: i64) -> IoError {
     if kind == 1 {
         IoError::NotFound(errno)
     } else if kind == 2 {

--- a/std/os.hew
+++ b/std/os.hew
@@ -58,18 +58,41 @@ pub fn env(name: string) -> string {
     }
 }
 
+/// Invalid environment-variable name.
+pub enum EnvError {
+    InvalidName(string);
+}
+
 /// Set an environment variable for the current process.
-pub fn set_env(name: string, value: string) {
+///
+/// Environment names must be non-empty and cannot contain `=`.
+pub fn set_env(name: string, value: string) -> Result<i64, EnvError> {
+    if name == "" || name.contains("=") {
+        return Err(EnvError::InvalidName(name));
+    }
     unsafe {
-        hew_env_set(name, value)
-    };
+        if hew_env_set(name, value) == 0 {
+            Ok(0)
+        } else {
+            Err(EnvError::InvalidName(name))
+        }
+    }
 }
 
 /// Remove an environment variable.
-pub fn remove_env(name: string) {
+///
+/// Environment names must be non-empty and cannot contain `=`.
+pub fn remove_env(name: string) -> Result<i64, EnvError> {
+    if name == "" || name.contains("=") {
+        return Err(EnvError::InvalidName(name));
+    }
     unsafe {
-        hew_env_remove(name)
-    };
+        if hew_env_remove(name) == 0 {
+            Ok(0)
+        } else {
+            Err(EnvError::InvalidName(name))
+        }
+    }
 }
 
 /// Check whether an environment variable is set.
@@ -129,8 +152,8 @@ extern "C" {
     fn hew_args_count() -> i32;
     fn hew_args_get(index: i32) -> string;
     fn hew_env_get(name: string) -> string;
-    fn hew_env_set(name: string, value: string);
-    fn hew_env_remove(name: string);
+    fn hew_env_set(name: string, value: string) -> i32;
+    fn hew_env_remove(name: string) -> i32;
     fn hew_env_has(name: string) -> bool;
     fn hew_cwd() -> string;
     fn hew_home_dir() -> string;

--- a/std/stream.hew
+++ b/std/stream.hew
@@ -129,9 +129,12 @@ pub fn try_from_file(path: string) -> Result<Stream<string>, fs.IoError> {
         if hew_stream_is_valid(s) {
             Ok(s)
         } else {
+            // Read the canonical kind BEFORE the errno: hew_stream_last_errno
+            // clears the kind tag as errno metadata, so the order matters.
+            let kind = hew_stream_last_error_kind() as i64;
             let errno = hew_stream_last_errno();
             let _ = hew_stream_last_error();
-            Err(fs.io_error_from_errno(errno as i64))
+            Err(fs.io_error_from_kind(kind, errno as i64))
         }
     }
 }
@@ -175,9 +178,12 @@ pub fn try_to_file(path: string) -> Result<Sink<string>, fs.IoError> {
         if hew_sink_is_valid(s) {
             Ok(s)
         } else {
+            // Read the canonical kind BEFORE the errno: hew_stream_last_errno
+            // clears the kind tag as errno metadata, so the order matters.
+            let kind = hew_stream_last_error_kind() as i64;
             let errno = hew_stream_last_errno();
             let _ = hew_stream_last_error();
-            Err(fs.io_error_from_errno(errno as i64))
+            Err(fs.io_error_from_kind(kind, errno as i64))
         }
     }
 }
@@ -217,6 +223,7 @@ extern "C" {
     fn hew_sink_is_valid(sink: Sink<string>) -> bool;
     fn hew_stream_last_error() -> string;
     fn hew_stream_last_errno() -> i32; // INTERNAL-ABI: OS errno from thread-local; 0 when none recorded
+    fn hew_stream_last_error_kind() -> i32; // INTERNAL-ABI: canonical cross-platform error-kind tag; 0 when none
     fn hew_stream_close(stream: Stream<string>);
     fn hew_stream_lines(stream: Stream<string>) -> Stream<string>;
     fn hew_stream_chunks(stream: Stream<string>, size: i64) -> Stream<string>;

--- a/tests/hew/fs_stream_test.hew
+++ b/tests/hew/fs_stream_test.hew
@@ -391,6 +391,47 @@ fn test_io_error_message_formats_fs_variants() {
 }
 
 #[test]
+fn test_io_error_from_errno_maps_windows_already_exists() {
+    // Cross-platform regression (host-independent): Windows create_dir on an
+    // existing directory returns ERROR_ALREADY_EXISTS = 183, which is not a
+    // POSIX errno, so io_error_from_errno must classify it as AlreadyExists on
+    // every host — including this macOS/Linux CI runner, which never sees 183
+    // from a real syscall. Before the fix the errno mapping was POSIX-only and
+    // 183 fell through to IoError::Other(183). The raw code is preserved as the
+    // payload.
+    let mapped = fs.io_error_from_errno(183);
+    match mapped {
+        IoError::AlreadyExists(code) => testing.assert_eq(code, 183),
+        _ => panic("expected IoError::AlreadyExists(183) for Windows ERROR_ALREADY_EXISTS"),
+    }
+    // POSIX EEXIST=17 still classifies identically, sharing the variant.
+    let posix = fs.io_error_from_errno(17);
+    match posix {
+        IoError::AlreadyExists(code) => testing.assert_eq(code, 17),
+        _ => panic("expected IoError::AlreadyExists(17) for POSIX EEXIST"),
+    }
+}
+
+#[test]
+fn test_try_mkdir_existing_returns_already_exists() {
+    // End-to-end wiring proof for the canonical error-kind channel: creating a
+    // directory that already exists yields std::io::ErrorKind::AlreadyExists on
+    // every platform, so try_mkdir must surface IoError::AlreadyExists whether
+    // the raw OS code is POSIX EEXIST=17 or Windows ERROR_ALREADY_EXISTS=183.
+    // "tests/hew" always exists (it holds this test), so no fixture/cleanup is
+    // needed and the test cannot leak state. The payload is the platform errno,
+    // which we do not pin here.
+    let result = fs.try_mkdir("tests/hew");
+    match result {
+        Ok(_) => panic("expected mkdir on an existing directory to fail"),
+        Err(err) => match err {
+            IoError::AlreadyExists(_) => {},
+            _ => panic("expected IoError::AlreadyExists for an existing directory"),
+        },
+    }
+}
+
+#[test]
 fn test_net_error_message_formats_net_variants() {
     // Let-bind each call: direct `f(Enum::Variant(...))` on multiple string-
     // returning calls in one function body triggers a codegen hang at 2e6fac15

--- a/tests/hew/fs_stream_test.hew
+++ b/tests/hew/fs_stream_test.hew
@@ -335,6 +335,52 @@ fn test_stream_try_to_file_send_close_and_try_from_file() {
     cleanup_file(file_path);
 }
 
+#[test]
+fn test_stream_try_to_file_missing_dir_returns_not_found() {
+    // Regression: try_to_file must classify open failures through the runtime's
+    // canonical error-kind channel (like std/fs), not the raw errno alone.
+    // Creating a file under a directory that does not exist is NotFound on every
+    // platform; before the consumer-side fix this path read only the errno and
+    // would misclassify a Windows access-denied open (raw 5) as Other(5).
+    let missing_target = "tests/hew/_stream_no_such_dir/child.txt";
+    match stream.try_to_file(missing_target) {
+        Ok(_) => panic("expected try_to_file into a missing directory to fail"),
+        Err(err) => match err {
+            IoError::NotFound(_) => {},
+            _ => panic("expected IoError::NotFound"),
+        },
+    }
+}
+
+#[test]
+fn test_io_error_from_kind_is_tag_driven_not_errno_driven() {
+    // Cross-platform proof for the shared classifier that std::stream now routes
+    // through: the canonical kind tag — not the raw errno — selects the variant,
+    // while the raw errno is preserved as the payload. This is exactly the
+    // Windows access-denied case the reviewer cited: raw code 5 with a
+    // PermissionDenied tag must become PermissionDenied(5), not Other(5) (POSIX
+    // errno 5 is EIO). The same raw 5 under different tags proves classification
+    // is tag-driven and host-independent.
+    // Let-bind each call: multiple enum-returning calls matched inline in one
+    // body triggers a codegen hang at 2e6fac15 (see net_error test above).
+    let denied = fs.io_error_from_kind(2, 5);
+    match denied {
+        IoError::PermissionDenied(code) => testing.assert_eq(code, 5),
+        _ => panic("expected PermissionDenied(5) for kind=PermissionDenied, raw 5"),
+    }
+    let missing = fs.io_error_from_kind(1, 5);
+    match missing {
+        IoError::NotFound(code) => testing.assert_eq(code, 5),
+        _ => panic("expected NotFound(5) for kind=NotFound, raw 5"),
+    }
+    // Tag 0 (unclassified) falls back to raw-errno mapping: POSIX 5 = EIO -> Other.
+    let unclassified = fs.io_error_from_kind(0, 5);
+    match unclassified {
+        IoError::Other(code) => testing.assert_eq(code, 5),
+        _ => panic("expected Other(5) for an unclassified kind"),
+    }
+}
+
 // ── NetError variants ─────────────────────────────────────────────────
 #[test]
 fn test_net_error_from_errno_network_variants() {

--- a/tests/hew/fs_stream_test.hew
+++ b/tests/hew/fs_stream_test.hew
@@ -39,6 +39,17 @@ fn test_try_read_missing_returns_not_found() {
 }
 
 #[test]
+fn test_try_read_directory_returns_eisdir() {
+    match fs.try_read("/") {
+        Ok(_) => panic("expected directory read error"),
+        Err(err) => match err {
+            IoError::Other(errno) => testing.assert_eq(errno, 21),
+            _ => panic("expected IoError::Other(EISDIR)"),
+        },
+    }
+}
+
+#[test]
 fn test_try_read_bytes_missing_returns_not_found() {
     let file_path = "tests/hew/_fs_stream_bytes_missing.bin";
     cleanup_file(file_path);
@@ -254,6 +265,36 @@ fn test_try_list_dir_handles_success_and_missing_paths() {
             _ => panic("expected IoError::NotFound"),
         },
     }
+}
+
+#[test]
+fn test_try_list_dir_regular_file_returns_enotdir() {
+    let file_path = "tests/hew/_fs_stream_not_directory.txt";
+    cleanup_file(file_path);
+    let _ = fs.write(file_path, "not a directory");
+    match fs.try_list_dir(file_path) {
+        Ok(_) => panic("expected regular-file listing error"),
+        Err(err) => match err {
+            IoError::Other(errno) => testing.assert_eq(errno, 20),
+            _ => panic("expected IoError::Other(ENOTDIR)"),
+        },
+    }
+    cleanup_file(file_path);
+}
+
+#[test]
+fn test_try_write_reports_enotdir_errno() {
+    let file_path = "tests/hew/_fs_stream_write_parent.txt";
+    cleanup_file(file_path);
+    let _ = fs.write(file_path, "not a directory");
+    match fs.try_write(file_path + "/child", "content") {
+        Ok(_) => panic("expected write through regular file to fail"),
+        Err(err) => match err {
+            IoError::Other(errno) => testing.assert_eq(errno, 20),
+            _ => panic("expected IoError::Other(ENOTDIR)"),
+        },
+    }
+    cleanup_file(file_path);
 }
 
 #[test]

--- a/tests/hew/os_test.hew
+++ b/tests/hew/os_test.hew
@@ -1,0 +1,25 @@
+//! Tests for std::os environment-variable validation.
+
+import std::os;
+
+import std::testing;
+
+#[test]
+fn test_set_env_rejects_empty_name() {
+    match os.set_env("", "value") {
+        Ok(_) => panic("expected empty environment name rejection"),
+        Err(err) => match err {
+            EnvError::InvalidName(name) => testing.assert_eq_str(name, ""),
+        },
+    }
+}
+
+#[test]
+fn test_remove_env_rejects_equals_in_name() {
+    match os.remove_env("HEW=INVALID") {
+        Ok(_) => panic("expected invalid environment name rejection"),
+        Err(err) => match err {
+            EnvError::InvalidName(name) => testing.assert_eq_str(name, "HEW=INVALID"),
+        },
+    }
+}


### PR DESCRIPTION
## Summary

I replaced heuristic/silent-failure error paths at the fs, env, and stream I/O boundary with real fail-closed handling:

- `std/fs.hew`: file and directory operations (`write`, `mkdir`, `rename`, `copy`, `delete`, `list_dir`) now classify errors from the actual OS errno via `hew_stream_last_errno()` instead of guessing the failure reason with separate `exists()`/path-heuristic probes after the fact.
- `hew-runtime/src/file_io.rs`: the C ABI functions backing those operations now record the real `std::io::Error` (message + errno) on failure via `set_last_error_with_errno`, and `hew_fs_list_dir` reports read-dir and per-entry errors instead of silently skipping bad entries.
- `std/os.hew`: `set_env`/`remove_env` reject empty names and names containing `=`, and now return `Result<i64, EnvError>` instead of silently discarding the underlying FFI call's outcome.
- `hew-runtime/src/env.rs`: `hew_env_set`/`hew_env_remove` return a real status code instead of `()`.
- `hew-runtime/src/path.rs`, `hew-runtime/src/stream.rs`: matching fail-closed error propagation at the C ABI boundary.
- Added `tests/hew/fs_stream_test.hew` and `tests/hew/os_test.hew` covering the new error paths.

## Deferred

- `path.glob`'s Result-based error API (`PathError`, non-panicking `GlobResult.get`) is reverted for this PR — it needs more work to land cleanly and isn't required for the fs/env/stream fixes above. I'll pick it up in a follow-up.
- No changes to process-spawning fail-closed behaviour in this PR.

## Test plan

- `make hew-check-all` — full `.hew` corpus compile sweep: 1576 files checked, 133 expected failures matched, no unexpected regressions.
- `cargo check --workspace` — clean.