### PR TITLE
fix(distributed): validate node identity and setup failures

### DIFF
--- a/hew-cli/tests/distributed_two_process_e2e.rs
+++ b/hew-cli/tests/distributed_two_process_e2e.rs
@@ -629,6 +629,21 @@ fn remote_monitor_down_on_connection_drop() {
     );
 }
 
+/// Cross-node monitor setup fails honestly after route teardown. The runtime
+/// must return `Err(MonitorError::Partition)`, never an inert `MonitorRef`.
+#[test]
+fn remote_monitor_setup_after_drop_returns_typed_partition() {
+    let stdout = run_conn_drop_scenario("remote_monitor_setup_after_drop");
+    assert!(
+        stdout.contains("PASS remote_monitor_setup_after_drop error=Partition"),
+        "expected typed MonitorError::Partition after route teardown; client stdout:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("FAIL "),
+        "client reported a FAIL on monitor setup after drop; client stdout:\n{stdout}"
+    );
+}
+
 /// Partition gate: a remote ask whose target peer is gone must resolve
 /// fail-closed with a typed cause WITHOUT hanging, rather than blocking to the
 /// client ceiling or fabricating a value. The harness kills the server after the
@@ -712,6 +727,50 @@ fn remote_ask_round_trip_returns_exact_values() {
     assert!(
         !stdout.contains("FAIL "),
         "client reported a FAIL on the remote-ask round-trip; client stdout:\n{stdout}"
+    );
+}
+
+/// Node identity/location proof across two OS processes. The remote actor's
+/// packed `(node_id, serial)` identity must match the registry lookup exactly,
+/// carry fresh registration incarnation 0, and name an ALIVE SWIM member that is
+/// distinct from the client's non-zero node id.
+#[test]
+fn node_identity_location_and_incarnation_cross_process() {
+    let stdout = run_two_process_scenario("identity_location");
+    let line = stdout
+        .lines()
+        .find(|line| line.starts_with("PASS identity_location "))
+        .unwrap_or_else(|| panic!("missing identity PASS line; client stdout:\n{stdout}"));
+    let field = |name: &str| -> u64 {
+        line.split_whitespace()
+            .find_map(|part| part.strip_prefix(&format!("{name}=")))
+            .unwrap_or_else(|| panic!("missing {name}= field in {line}"))
+            .parse()
+            .unwrap_or_else(|error| panic!("invalid {name}= field in {line}: {error}"))
+    };
+    let local = field("local");
+    let remote = field("remote");
+    let serial = field("serial");
+    assert_ne!(local, 0, "local node id must be non-zero: {line}");
+    assert_ne!(remote, 0, "remote node id must be non-zero: {line}");
+    assert_ne!(
+        local, remote,
+        "two processes must have distinct node ids: {line}"
+    );
+    assert_ne!(serial, 0, "actor serial must be non-zero: {line}");
+    assert_eq!(
+        field("incarnation"),
+        0,
+        "fresh registration incarnation: {line}"
+    );
+    assert_eq!(
+        field("state"),
+        0,
+        "remote SWIM member must be ALIVE: {line}"
+    );
+    assert!(
+        !stdout.contains("FAIL "),
+        "client reported a FAIL on identity/location proof; client stdout:\n{stdout}"
     );
 }
 

--- a/hew-cli/tests/fixtures/distributed/dist_node.hew
+++ b/hew-cli/tests/fixtures/distributed/dist_node.hew
@@ -26,7 +26,7 @@
 //   - "FAIL <scenario> <detail>"  on any mismatch; main returns non-zero
 import std::os;
 
-import std::link_monitor;
+import std::link_monitor::{ MonitorError };
 
 // Self-stop FFI: the cross-node clean-exit scenario drives the remote actor to
 // the Stopped terminal state from within its own handler. `stop(self)` is not a
@@ -38,7 +38,13 @@ import std::link_monitor;
 // Hew surface, so the server calls the runtime api directly.
 extern "C" {
     fn hew_actor_self_stop();
+    fn hew_actor_self_id() -> i64;
     fn hew_node_api_unregister(name: string) -> i32;
+    fn hew_node_api_lookup(name: string) -> i64;
+    fn hew_pid_local_node() -> u16;
+    fn hew_pid_node(pid: i64) -> u16;
+    fn hew_pid_serial(pid: i64) -> u64;
+    fn hew_pid_incarnation(pid: i64) -> u32;
 }
 
 // `record` is Serializable — required for RemotePid messaging across the wire.
@@ -153,6 +159,49 @@ impl ActorMsg for WireProbe {
     type Reply = WireResult;
 }
 
+record DistIdentity {
+    packed: i64,
+    node_id: u16,
+    serial: u64,
+    incarnation: u32,
+}
+
+enum IdentityReq {
+    Inspect;
+}
+
+enum IdentityResp {
+    Value(DistIdentity);
+}
+
+actor IdentityProbe {
+    receive fn handle(_req: IdentityReq) -> IdentityResp {
+        let packed = unsafe {
+            hew_actor_self_id()
+        };
+        let node_id = unsafe {
+            hew_pid_local_node()
+        };
+        let serial = unsafe {
+            hew_pid_serial(packed)
+        };
+        let incarnation = unsafe {
+            hew_pid_incarnation(packed)
+        };
+        IdentityResp::Value(DistIdentity {
+            packed: packed,
+            node_id: node_id,
+            serial: serial,
+            incarnation: incarnation,
+        })
+    }
+}
+
+impl ActorMsg for IdentityProbe {
+    type Msg = IdentityReq;
+    type Reply = IdentityResp;
+}
+
 // ── Cross-node link ───────────────────────────────────────────────────────────
 //
 // The link scenarios prove the OTP "linked processes die together" semantic
@@ -180,7 +229,6 @@ impl ActorMsg for WireProbe {
 // HEW_LINK_PROBE), so the death survives the actor's free. A `CrashLinked`
 // cascade records Crashed (5); a survivor never reaches terminal (sentinel).
 extern "C" {
-    fn hew_actor_self_id() -> i64;
     fn hew_link_probe_terminal_state(actor_id: i64) -> i64;
 }
 
@@ -317,6 +365,25 @@ fn lookup_wire_with_retry(name: string) -> Result<RemotePid<WireProbe>, LookupEr
     }
 }
 
+fn lookup_identity_with_retry(name: string) -> Result<RemotePid<IdentityProbe>, LookupError> {
+    var attempts: i64 = 0;
+    loop {
+        let found: Result<RemotePid<IdentityProbe>, LookupError> = Node::lookup(name);
+        match found {
+            Result::Ok(pid) => {
+                return Ok(pid);
+            },
+            Result::Err(e) => {
+                attempts = attempts + 1;
+                if attempts >= 50 {
+                    return Err(e);
+                }
+                sleep(100ms);
+            },
+        }
+    }
+}
+
 fn run_server(port: string, scenario: string) {
     let addr = f"127.0.0.1:{port}";
     Node::set_transport("tcp");
@@ -328,6 +395,8 @@ fn run_server(port: string, scenario: string) {
     // remote target. Registering both keeps run_server scenario-independent.
     let wp = spawn WireProbe(calls: 0);
     Node::register("wire", wp);
+    let identity = spawn IdentityProbe;
+    Node::register("identity", identity);
 
     // Readiness signal: emitted ONLY after the actors are registered, so the
     // harness never launches the client against a half-started node.
@@ -500,37 +569,123 @@ fn scenario_wire_cbor(wp: RemotePid<WireProbe>) -> i64 {
     0
 }
 
+// Scenario: identity_location
+//
+// Proves the runtime identity tuple across two OS processes. Registry gossip
+// yields a packed remote pid whose `(node_id, serial)` location exactly matches
+// the actor's self-reported identity, whose registration incarnation is the
+// fresh value 0, and whose node is a live SWIM member distinct from this client.
+fn scenario_identity_location(identity: RemotePid<IdentityProbe>) -> i64 {
+    let raw = unsafe {
+        hew_node_api_lookup("identity")
+    };
+    if raw == 0 {
+        println("FAIL identity_location raw-lookup-zero");
+        return 2;
+    }
+    let local_node = unsafe {
+        hew_pid_local_node()
+    };
+    let remote_node = unsafe {
+        hew_pid_node(raw)
+    };
+    let remote_serial = unsafe {
+        hew_pid_serial(raw)
+    };
+    let remote_incarnation = unsafe {
+        hew_pid_incarnation(raw)
+    };
+    let member_state = unsafe {
+        hew_dist_member_state(remote_node)
+    };
+    if local_node == 0 || remote_node == 0 || local_node == remote_node {
+        println("FAIL identity_location node-ids-not-distinct");
+        return 3;
+    }
+    if remote_serial == 0 {
+        println("FAIL identity_location serial-zero");
+        return 4;
+    }
+    if remote_incarnation != 0 {
+        println(f"FAIL identity_location client-incarnation={remote_incarnation}");
+        return 5;
+    }
+    if member_state != 0 {
+        println(f"FAIL identity_location member-state={member_state}");
+        return 6;
+    }
+    let inspected = identity.ask(IdentityReq::Inspect, 5000);
+    match inspected {
+        Result::Err(_) => {
+            println("FAIL identity_location inspect-ask-error");
+            return 7;
+        },
+        Result::Ok(resp) => {
+            match resp {
+                IdentityResp::Value(actual) => {
+                    if actual.packed != raw {
+                        println("FAIL identity_location packed-mismatch");
+                        return 8;
+                    }
+                    if actual.node_id != remote_node {
+                        println("FAIL identity_location node-mismatch");
+                        return 9;
+                    }
+                    if actual.serial != remote_serial {
+                        println("FAIL identity_location serial-mismatch");
+                        return 10;
+                    }
+                    if actual.incarnation != remote_incarnation {
+                        println("FAIL identity_location incarnation-mismatch");
+                        return 11;
+                    }
+                },
+            }
+        },
+    }
+    println(f"PASS identity_location local={local_node} remote={remote_node} serial={remote_serial} incarnation={remote_incarnation} state={member_state}");
+    0
+}
+
 // Scenario: remote_monitor_clean_exit
 //
 // The client monitors the remote KeyValue actor, then tells it to stop. The
 // monitor must deliver exactly one DOWN carrying the clean-exit reason (6).
 fn scenario_remote_monitor_clean_exit(kv: RemotePid<KeyValue>) -> i64 {
-    let m: MonitorRef = monitor(kv);
-    let send_stop = kv.send(KvReq::StopSelf);
-    match send_stop {
+    let setup: Result<MonitorRef, MonitorError> = monitor(kv);
+    match setup {
         Result::Err(_) => {
-            println("FAIL remote_monitor_clean_exit stop-send-error");
-            return 2;
+            println("FAIL remote_monitor_clean_exit setup-error");
+            1
         },
-        Result::Ok(_) => {},
+        Result::Ok(m) => {
+            let send_stop = kv.send(KvReq::StopSelf);
+            match send_stop {
+                Result::Err(_) => {
+                    println("FAIL remote_monitor_clean_exit stop-send-error");
+                    return 2;
+                },
+                Result::Ok(_) => {},
+            }
+            let reason = m.recv_down(10000);
+            if reason == 6 {
+                println(f"PASS remote_monitor_clean_exit reason={reason}");
+            } else {
+                println(f"FAIL remote_monitor_clean_exit reason={reason}");
+                return 3;
+            }
+            // Negative guard for exactly-once: a second recv must time out (-2),
+            // proving no duplicate DOWN was delivered for the same registration.
+            let dup = m.recv_down(1000);
+            if dup == -2 {
+                println("PASS remote_monitor_clean_exit no-dup");
+            } else {
+                println(f"FAIL remote_monitor_clean_exit dup-reason={dup}");
+                return 4;
+            }
+            0
+        },
     }
-    let reason = m.recv_down(10000);
-    if reason == 6 {
-        println(f"PASS remote_monitor_clean_exit reason={reason}");
-    } else {
-        println(f"FAIL remote_monitor_clean_exit reason={reason}");
-        return 3;
-    }
-    // Negative guard for exactly-once: a second recv must time out (-2), proving
-    // no duplicate DOWN was delivered for the same registration.
-    let dup = m.recv_down(1000);
-    if dup == -2 {
-        println("PASS remote_monitor_clean_exit no-dup");
-    } else {
-        println(f"FAIL remote_monitor_clean_exit dup-reason={dup}");
-        return 4;
-    }
-    0
 }
 
 // Scenario: remote_monitor_crash
@@ -538,30 +693,38 @@ fn scenario_remote_monitor_clean_exit(kv: RemotePid<KeyValue>) -> i64 {
 // The client monitors the remote KeyValue actor, then tells it to crash. The
 // monitor must deliver exactly one DOWN carrying the crash reason (5).
 fn scenario_remote_monitor_crash(kv: RemotePid<KeyValue>) -> i64 {
-    let m: MonitorRef = monitor(kv);
-    let send_crash = kv.send(KvReq::CrashSelf);
-    match send_crash {
+    let setup: Result<MonitorRef, MonitorError> = monitor(kv);
+    match setup {
         Result::Err(_) => {
-            println("FAIL remote_monitor_crash crash-send-error");
-            return 2;
+            println("FAIL remote_monitor_crash setup-error");
+            1
         },
-        Result::Ok(_) => {},
+        Result::Ok(m) => {
+            let send_crash = kv.send(KvReq::CrashSelf);
+            match send_crash {
+                Result::Err(_) => {
+                    println("FAIL remote_monitor_crash crash-send-error");
+                    return 2;
+                },
+                Result::Ok(_) => {},
+            }
+            let reason = m.recv_down(10000);
+            if reason == 5 {
+                println(f"PASS remote_monitor_crash reason={reason}");
+            } else {
+                println(f"FAIL remote_monitor_crash reason={reason}");
+                return 3;
+            }
+            let dup = m.recv_down(1000);
+            if dup == -2 {
+                println("PASS remote_monitor_crash no-dup");
+            } else {
+                println(f"FAIL remote_monitor_crash dup-reason={dup}");
+                return 4;
+            }
+            0
+        },
     }
-    let reason = m.recv_down(10000);
-    if reason == 5 {
-        println(f"PASS remote_monitor_crash reason={reason}");
-    } else {
-        println(f"FAIL remote_monitor_crash reason={reason}");
-        return 3;
-    }
-    let dup = m.recv_down(1000);
-    if dup == -2 {
-        println("PASS remote_monitor_crash no-dup");
-    } else {
-        println(f"FAIL remote_monitor_crash dup-reason={dup}");
-        return 4;
-    }
-    0
 }
 
 // Scenario: remote_monitor_conn_drop
@@ -571,25 +734,66 @@ fn scenario_remote_monitor_crash(kv: RemotePid<KeyValue>) -> i64 {
 // sentinel (-1) for the connection-drop / partition cause — distinct from the
 // clean-exit and crash reasons.
 fn scenario_remote_monitor_conn_drop(kv: RemotePid<KeyValue>) -> i64 {
-    let m: MonitorRef = monitor(kv);
-    // Signal readiness so the harness knows the monitor is registered before it
-    // kills the server. The actor stays alive; only the connection drops.
-    println("READY_DROP remote_monitor_conn_drop");
-    let reason = m.recv_down(30000);
-    if reason == -1 {
-        println(f"PASS remote_monitor_conn_drop reason={reason}");
-    } else {
-        println(f"FAIL remote_monitor_conn_drop reason={reason}");
-        return 3;
+    let setup: Result<MonitorRef, MonitorError> = monitor(kv);
+    match setup {
+        Result::Err(_) => {
+            println("FAIL remote_monitor_conn_drop setup-error");
+            1
+        },
+        Result::Ok(m) => {
+            // Signal readiness so the harness knows the monitor is registered
+            // before it kills the server. The actor stays alive; only the
+            // connection drops.
+            println("READY_DROP remote_monitor_conn_drop");
+            let reason = m.recv_down(30000);
+            if reason == -1 {
+                println(f"PASS remote_monitor_conn_drop reason={reason}");
+            } else {
+                println(f"FAIL remote_monitor_conn_drop reason={reason}");
+                return 3;
+            }
+            let dup = m.recv_down(1000);
+            if dup == -2 {
+                println("PASS remote_monitor_conn_drop no-dup");
+            } else {
+                println(f"FAIL remote_monitor_conn_drop dup-reason={dup}");
+                return 4;
+            }
+            0
+        },
     }
-    let dup = m.recv_down(1000);
-    if dup == -2 {
-        println("PASS remote_monitor_conn_drop no-dup");
-    } else {
-        println(f"FAIL remote_monitor_conn_drop dup-reason={dup}");
-        return 4;
+}
+
+// Scenario: remote_monitor_setup_after_drop
+//
+// The harness kills the server after READY_DROP. Once route teardown reaches the
+// client, monitor(RemotePid) must return Err(MonitorError::Partition) rather than
+// a zero-valued or inert MonitorRef.
+fn scenario_remote_monitor_setup_after_drop(kv: RemotePid<KeyValue>) -> i64 {
+    println("READY_DROP remote_monitor_setup_after_drop");
+    var attempts: i64 = 0;
+    loop {
+        let setup: Result<MonitorRef, MonitorError> = monitor(kv);
+        match setup {
+            Result::Err(MonitorError::Partition) => {
+                println("PASS remote_monitor_setup_after_drop error=Partition");
+                return 0;
+            },
+            Result::Err(_) => {
+                println("FAIL remote_monitor_setup_after_drop wrong-error");
+                return 2;
+            },
+            Result::Ok(monitor_ref) => {
+                monitor_ref.close();
+                attempts = attempts + 1;
+                if attempts >= 100 {
+                    println("FAIL remote_monitor_setup_after_drop never-failed");
+                    return 3;
+                }
+                sleep(100ms);
+            },
+        }
     }
-    0
 }
 
 // Scenario: partition_ask
@@ -839,18 +1043,23 @@ fn scenario_server_watcher_node_death(_kv_serial: i64) {
 
 fn scenario_client_watcher_node_death(kv: RemotePid<KeyValue>) -> i64 {
     // Register a monitor on the server's long-lived actor.
-    let m: MonitorRef = monitor(kv);
-    // Signal readiness so the harness knows CTRL_MONITOR_REQ has been sent.
-    // The server then confirms receipt (READY_SERVER_WATCHER_REGISTERED) before
-    // the harness kills this process, closing the registration race.
-    println("READY_CLIENT_WATCHER monitor_watcher_node_death");
-    // Block until this process is killed (SIGKILL from harness). The generous
-    // timeout keeps `m` alive and in scope so MonitorRef's Drop does not send
-    // CTRL_DEMONITOR before the harness kill arrives.
-    let down_reason = m.recv_down(120000);
-    // On a real kill this line is never reached. Return the down reason to
-    // keep `m` alive until here and suppress the unused-value warning.
-    down_reason
+    let setup: Result<MonitorRef, MonitorError> = monitor(kv);
+    match setup {
+        Result::Err(_) => {
+            println("FAIL monitor_watcher_node_death setup-error");
+            1
+        },
+        Result::Ok(m) => {
+            // Signal readiness so the harness knows CTRL_MONITOR_REQ has been sent.
+            // The server then confirms receipt (READY_SERVER_WATCHER_REGISTERED)
+            // before the harness kills this process, closing the registration race.
+            println("READY_CLIENT_WATCHER monitor_watcher_node_death");
+            // Block until this process is killed (SIGKILL from harness). The
+            // generous timeout keeps the Result owner alive and in scope so its
+            // MonitorRef payload does not demonitor before the harness kill arrives.
+            m.recv_down(120000)
+        },
+    }
 }
 
 // ── Cross-node link scenarios ────────────────────────────────────────────────
@@ -1038,19 +1247,24 @@ fn scenario_server_monitor_close_reclaim() {
 }
 
 fn scenario_client_monitor_close_reclaim(kv: RemotePid<KeyValue>) -> i64 {
-    let m: MonitorRef = monitor(kv);
-    // Signal the watch is live so the server records the target-side entry and
-    // confirms (READY_SERVER_WATCHER_REGISTERED) before we close, closing the
-    // registration race.
-    println("READY_CLIENT_WATCHER cross_node_monitor_close_reclaim");
-    // Give the server time to record the target-side entry before we demonitor.
-    sleep(800ms);
-    // Close the monitor: must route cross-node (send CTRL_DEMONITOR to the peer
-    // + reclaim the local watcher entry), not hit the local table and no-op.
-    m.close();
-    // Stay alive briefly so the CTRL_DEMONITOR is delivered before shutdown.
-    sleep(800ms);
-    0
+    let setup: Result<MonitorRef, MonitorError> = monitor(kv);
+    match setup {
+        Result::Err(_) => {
+            println("FAIL cross_node_monitor_close_reclaim setup-error");
+            1
+        },
+        Result::Ok(m) => {
+            // Signal the watch is live so the server records the target-side
+            // entry and confirms before the explicit close sends CTRL_DEMONITOR.
+            println("READY_CLIENT_WATCHER cross_node_monitor_close_reclaim");
+            sleep(800ms);
+            m.close();
+            // Keep the node alive after the close so the control frame is
+            // delivered before Node::shutdown tears down the connection.
+            sleep(800ms);
+            0
+        },
+    }
 }
 
 // Scenario: quarantine_rejoin
@@ -1150,6 +1364,17 @@ fn run_client(port: string, scenario: string) -> i64 {
         // Membership-gate scenario: driven entirely through injected gossip on the
         // local cluster, so it needs no remote actor lookup.
         scenario_quarantine_rejoin()
+    } else if scenario == "identity_location" {
+        let found_identity = lookup_identity_with_retry("identity");
+        match found_identity {
+            Result::Err(_) => {
+                println(f"FAIL {scenario} lookup-unresolved");
+                1
+            },
+            Result::Ok(identity) => {
+                scenario_identity_location(identity)
+            },
+        }
     } else if scenario == "wire_cbor" {
         let found_wire = lookup_wire_with_retry("wire");
         match found_wire {
@@ -1181,32 +1406,36 @@ fn run_client(port: string, scenario: string) -> i64 {
                             if scenario == "remote_monitor_conn_drop" {
                                 scenario_remote_monitor_conn_drop(kv)
                             } else {
-                                if scenario == "partition_ask" {
-                                    scenario_partition_ask(kv)
+                                if scenario == "remote_monitor_setup_after_drop" {
+                                    scenario_remote_monitor_setup_after_drop(kv)
                                 } else {
-                                    if scenario == "stale_ref" {
-                                        scenario_stale_ref(kv)
+                                    if scenario == "partition_ask" {
+                                        scenario_partition_ask(kv)
                                     } else {
-                                        if scenario == "monitor_watcher_node_death" {
-                                            scenario_client_watcher_node_death(kv)
+                                        if scenario == "stale_ref" {
+                                            scenario_stale_ref(kv)
                                         } else {
-                                            if scenario == "link_remote_clean_exit" {
-                                                scenario_link_remote_clean_exit(kv)
+                                            if scenario == "monitor_watcher_node_death" {
+                                                scenario_client_watcher_node_death(kv)
                                             } else {
-                                                if scenario == "link_remote_crash" {
-                                                    scenario_link_remote_crash(kv)
+                                                if scenario == "link_remote_clean_exit" {
+                                                    scenario_link_remote_clean_exit(kv)
                                                 } else {
-                                                    if scenario == "link_remote_partition" {
-                                                        scenario_link_remote_partition(kv)
+                                                    if scenario == "link_remote_crash" {
+                                                        scenario_link_remote_crash(kv)
                                                     } else {
-                                                        if scenario == "link_remote_non_crashlinked" {
-                                                            scenario_link_remote_non_crashlinked(kv)
+                                                        if scenario == "link_remote_partition" {
+                                                            scenario_link_remote_partition(kv)
                                                         } else {
-                                                            if scenario == "cross_node_monitor_close_reclaim" {
-                                                                scenario_client_monitor_close_reclaim(kv)
+                                                            if scenario == "link_remote_non_crashlinked" {
+                                                                scenario_link_remote_non_crashlinked(kv)
                                                             } else {
-                                                                println(f"FAIL {scenario} unknown-scenario");
-                                                                90
+                                                                if scenario == "cross_node_monitor_close_reclaim" {
+                                                                    scenario_client_monitor_close_reclaim(kv)
+                                                                } else {
+                                                                    println(f"FAIL {scenario} unknown-scenario");
+                                                                    90
+                                                                }
                                                             }
                                                         }
                                                     }

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -2466,10 +2466,9 @@ pub(crate) fn intern_runtime_decl<'ctx>(
         // supported on wasm32 (basic actors — spawn/send/receive/ask — are).
         "hew_actor_demonitor" => ctx.void_type().fn_type(&[i64_ty.into()], false),
         // hew_node_monitor(target_pid: i64) -> i64
-        // (`hew-runtime/src/dist_monitor.rs`). Registers a distributed monitor
-        // for a remote actor (resolving the current node internally) and returns
-        // the ref_id. codegen-offset-mirror-drift: must match the runtime
-        // `#[no_mangle]` signature.
+        // (`hew-runtime/src/hew_node.rs`). Positive returns are ref ids; negative
+        // returns encode MonitorError as `-(variant + 1)`.
+        // codegen-offset-mirror-drift: must match the runtime signature.
         "hew_node_monitor" => i64_ty.fn_type(&[i64_ty.into()], false),
         // hew_node_monitor_recv(ref_id: i64, timeout_ms: i64) -> i64
         // (`hew-runtime/src/dist_monitor.rs`). Blocks until the monitor's terminal
@@ -2480,9 +2479,9 @@ pub(crate) fn intern_runtime_decl<'ctx>(
         // hew_node_link_remote(target_pid: i64, policy_tag: i64) -> i64
         // (`hew-runtime/src/hew_node.rs`). Establishes a cross-node link: the
         // calling actor links the remote actor `target_pid` with the
-        // `PartitionPolicy` discriminant `policy_tag`. Returns the link ref_id
-        // (non-zero) on a successful registration, 0 on failure (no runtime,
-        // local target, no route). The local actor is resolved internally (like
+        // `PartitionPolicy` discriminant `policy_tag`. Positive returns are
+        // internal link ref ids; negative returns encode LinkError as
+        // `-(variant + 1)`. The local actor is resolved internally (like
         // hew_node_monitor / hew_actor_self), so no node/self argument.
         // codegen-offset-mirror-drift: must match the runtime `#[no_mangle]`
         // signature.

--- a/hew-codegen-rs/src/runtime_abi.rs
+++ b/hew-codegen-rs/src/runtime_abi.rs
@@ -14,7 +14,7 @@
 //! verbatim here — no behaviour change; every emitted `.ll` is byte-identical.
 
 use inkwell::types::BasicTypeEnum;
-use inkwell::values::BasicMetadataValueEnum;
+use inkwell::values::{BasicMetadataValueEnum, IntValue};
 use inkwell::{AddressSpace, IntPredicate};
 
 use hew_mir::Place;
@@ -106,6 +106,195 @@ pub(crate) fn is_bytes_struct_expansion_consumer(symbol: &str) -> bool {
             | "hew_encrypt_try_open_hew"
             | "hew_encrypt_must_open_hew"
     )
+}
+
+/// Decode a setup ABI whose positive return is an internal ref id and whose
+/// negative return encodes an error enum as `-(variant + 1)`.
+///
+/// When `ok_ref_payload` is true, the Ok payload is `MonitorRef { ref_id }`;
+/// otherwise the Ok payload is unit. A defensive zero return maps to
+/// `zero_error_tag` rather than producing an uninitialised success value.
+fn emit_signed_setup_result(
+    fn_ctx: &FnCtx<'_, '_>,
+    raw_result: IntValue<'_>,
+    dest: Place,
+    ok_ref_payload: bool,
+    zero_error_tag: u64,
+    helper: &str,
+) -> CodegenResult<()> {
+    let dest_local = composite_dest_local(dest, helper)?;
+    let i64_ty = fn_ctx.ctx.i64_type();
+    let zero = i64_ty.const_zero();
+    let is_ok = fn_ctx
+        .builder
+        .build_int_compare(
+            IntPredicate::SGT,
+            raw_result,
+            zero,
+            &format!("{helper}_is_ok"),
+        )
+        .llvm_ctx_with(|| format!("{helper}: compare setup result"))?;
+    let current_fn = fn_ctx
+        .builder
+        .get_insert_block()
+        .and_then(|block| block.get_parent())
+        .ok_or_else(|| CodegenError::FailClosed(format!("{helper}: no parent function")))?;
+    let ok_bb = fn_ctx
+        .ctx
+        .append_basic_block(current_fn, &format!("{helper}_ok"));
+    let err_bb = fn_ctx
+        .ctx
+        .append_basic_block(current_fn, &format!("{helper}_err"));
+    let merge_bb = fn_ctx
+        .ctx
+        .append_basic_block(current_fn, &format!("{helper}_merge"));
+    fn_ctx
+        .builder
+        .build_conditional_branch(is_ok, ok_bb, err_bb)
+        .llvm_ctx_with(|| format!("{helper}: branch on setup result"))?;
+
+    fn_ctx.builder.position_at_end(ok_bb);
+    store_composite_tag(fn_ctx, dest_local, 0, helper)?;
+    if ok_ref_payload {
+        let (monitor_ptr, monitor_ty) = place_pointer(
+            fn_ctx,
+            Place::MachineVariant {
+                local: dest_local,
+                variant_idx: 0,
+                field_idx: 0,
+            },
+        )?;
+        let BasicTypeEnum::StructType(monitor_struct) = monitor_ty else {
+            return Err(CodegenError::FailClosed(format!(
+                "{helper}: Ok payload must be MonitorRef struct, got {monitor_ty:?}"
+            )));
+        };
+        let Some(BasicTypeEnum::IntType(ref_id_ty)) = monitor_struct.get_field_type_at_index(0)
+        else {
+            return Err(CodegenError::FailClosed(format!(
+                "{helper}: MonitorRef.ref_id must be an integer field"
+            )));
+        };
+        if ref_id_ty.get_bit_width() != raw_result.get_type().get_bit_width() {
+            return Err(CodegenError::FailClosed(format!(
+                "{helper}: MonitorRef.ref_id width {} does not match setup ABI width {}",
+                ref_id_ty.get_bit_width(),
+                raw_result.get_type().get_bit_width()
+            )));
+        }
+        let ref_id_ptr = fn_ctx
+            .builder
+            .build_struct_gep(
+                monitor_struct,
+                monitor_ptr,
+                0,
+                &format!("{helper}_ref_id_ptr"),
+            )
+            .llvm_ctx_with(|| format!("{helper}: GEP MonitorRef.ref_id"))?;
+        fn_ctx
+            .builder
+            .build_store(ref_id_ptr, raw_result)
+            .llvm_ctx_with(|| format!("{helper}: store MonitorRef.ref_id"))?;
+    }
+    fn_ctx
+        .builder
+        .build_unconditional_branch(merge_bb)
+        .llvm_ctx_with(|| format!("{helper}: Ok branch to merge"))?;
+
+    fn_ctx.builder.position_at_end(err_bb);
+    store_composite_tag(fn_ctx, dest_local, 1, helper)?;
+    let (error_ptr, error_ty) = place_pointer(
+        fn_ctx,
+        Place::MachineVariant {
+            local: dest_local,
+            variant_idx: 1,
+            field_idx: 0,
+        },
+    )?;
+    let BasicTypeEnum::StructType(error_struct) = error_ty else {
+        return Err(CodegenError::FailClosed(format!(
+            "{helper}: Err payload must be a unit-variant enum struct, got {error_ty:?}"
+        )));
+    };
+    let Some(BasicTypeEnum::IntType(error_tag_ty)) = error_struct.get_field_type_at_index(0) else {
+        return Err(CodegenError::FailClosed(format!(
+            "{helper}: error enum tag must be an integer field"
+        )));
+    };
+    let negated = fn_ctx
+        .builder
+        .build_int_sub(zero, raw_result, &format!("{helper}_negated"))
+        .llvm_ctx_with(|| format!("{helper}: negate setup error"))?;
+    let ordinal = fn_ctx
+        .builder
+        .build_int_sub(
+            negated,
+            i64_ty.const_int(1, false),
+            &format!("{helper}_error_ordinal"),
+        )
+        .llvm_ctx_with(|| format!("{helper}: decode setup error ordinal"))?;
+    let is_zero = fn_ctx
+        .builder
+        .build_int_compare(
+            IntPredicate::EQ,
+            raw_result,
+            zero,
+            &format!("{helper}_is_zero"),
+        )
+        .llvm_ctx_with(|| format!("{helper}: detect invalid zero setup result"))?;
+    let selected_tag = fn_ctx
+        .builder
+        .build_select(
+            is_zero,
+            i64_ty.const_int(zero_error_tag, false),
+            ordinal,
+            &format!("{helper}_selected_error_tag"),
+        )
+        .llvm_ctx_with(|| format!("{helper}: select setup error tag"))?
+        .into_int_value();
+    let stored_tag = match selected_tag
+        .get_type()
+        .get_bit_width()
+        .cmp(&error_tag_ty.get_bit_width())
+    {
+        std::cmp::Ordering::Equal => selected_tag,
+        std::cmp::Ordering::Less => fn_ctx
+            .builder
+            .build_int_z_extend(
+                selected_tag,
+                error_tag_ty,
+                &format!("{helper}_error_tag_zext"),
+            )
+            .llvm_ctx_with(|| format!("{helper}: widen error tag"))?,
+        std::cmp::Ordering::Greater => fn_ctx
+            .builder
+            .build_int_truncate(
+                selected_tag,
+                error_tag_ty,
+                &format!("{helper}_error_tag_trunc"),
+            )
+            .llvm_ctx_with(|| format!("{helper}: truncate error tag"))?,
+    };
+    let error_tag_ptr = fn_ctx
+        .builder
+        .build_struct_gep(
+            error_struct,
+            error_ptr,
+            0,
+            &format!("{helper}_error_tag_ptr"),
+        )
+        .llvm_ctx_with(|| format!("{helper}: GEP error enum tag"))?;
+    fn_ctx
+        .builder
+        .build_store(error_tag_ptr, stored_tag)
+        .llvm_ctx_with(|| format!("{helper}: store setup error tag"))?;
+    fn_ctx
+        .builder
+        .build_unconditional_branch(merge_bb)
+        .llvm_ctx_with(|| format!("{helper}: Err branch to merge"))?;
+
+    fn_ctx.builder.position_at_end(merge_bb);
+    Ok(())
 }
 
 /// The LLVM struct type matching the runtime `#[repr(C)] BytesTriple`
@@ -1693,12 +1882,10 @@ pub(crate) fn lower_call_runtime_abi(
             // void return; dest is always None (the close body is a void call).
             let _ = (i32_ty, ptr_ty, dest);
         }
-        // hew_node_monitor(target_pid: i64) -> i64. Registers a
-        // distributed monitor for a remote actor (the remote pid is a bare i64;
-        // the current node is resolved internally) and returns the ref_id. In
-        // value position the i64 ref_id is stored into the i64 dest; a subsequent
-        // MIR RecordInit assembles MonitorRef{ref_id}. In statement position the
-        // return is discarded. boundary-fail-closed (P0): BitCopy i64 args only.
+        // hew_node_monitor(target_pid: i64) -> i64. Positive returns are ref ids;
+        // negative returns encode MonitorError as `-(variant + 1)`. Value
+        // position constructs Result<MonitorRef, MonitorError>; statement
+        // position discards the setup result.
         F::NodeMonitor => {
             if args.len() != 1 {
                 return Err(CodegenError::FailClosed(format!(
@@ -1709,18 +1896,23 @@ pub(crate) fn lower_call_runtime_abi(
             }
             let target_pid = load_int_arg(fn_ctx, args[0], i64_ty, "node_monitor_target")?;
             let llvm_args: [BasicMetadataValueEnum; 1] = [target_pid.into()];
-            let ref_id = fn_ctx.call_runtime_int(
+            let setup_result = fn_ctx.call_runtime_int(
                 symbol,
                 &llvm_args,
                 "hew_node_monitor_call",
                 "hew_node_monitor call",
             )?;
             if let Some(d) = dest {
-                let (dest_ptr, _dest_ty) = place_pointer(fn_ctx, d)?;
-                fn_ctx
-                    .builder
-                    .build_store(dest_ptr, ref_id)
-                    .llvm_ctx("hew_node_monitor store ref_id")?;
+                // MonitorError::NodeNotRunning is variant 0 and is the defensive
+                // mapping for an impossible zero return.
+                emit_signed_setup_result(
+                    fn_ctx,
+                    setup_result,
+                    d,
+                    true,
+                    0,
+                    "hew_node_monitor_result",
+                )?;
             }
             let _ = (i32_ty, ptr_ty);
         }
@@ -1755,13 +1947,9 @@ pub(crate) fn lower_call_runtime_abi(
             let _ = (i32_ty, ptr_ty);
         }
         // hew_node_link_remote(target_pid: i64, policy_tag: i64) -> i64.
-        // Establishes a cross-node link: the calling actor (resolved internally)
-        // links the remote actor `target_pid` with the `PartitionPolicy`
-        // discriminant `policy_tag`. Both args are BitCopy i64. The i64 return is
-        // the link ref_id; the immediate Hew-visible result is registration
-        // success — Ok(()) — because the EXIT arrives asynchronously when the
-        // remote dies (mirrors hew_actor_link's infallible immediate return).
-        // boundary-fail-closed (P0): i64 args only, no heap-owning composite.
+        // Positive returns are internal link ref ids; negative returns encode
+        // LinkError as `-(variant + 1)`. The immediate Hew-visible result is
+        // Result<(), LinkError>; EXIT arrives asynchronously when the remote dies.
         F::LinkRemote => {
             if args.len() != 2 {
                 return Err(CodegenError::FailClosed(format!(
@@ -1773,19 +1961,23 @@ pub(crate) fn lower_call_runtime_abi(
             let target_pid = load_int_arg(fn_ctx, args[0], i64_ty, "node_link_target")?;
             let policy_tag = load_int_arg(fn_ctx, args[1], i64_ty, "node_link_policy")?;
             let llvm_args: [BasicMetadataValueEnum; 2] = [target_pid.into(), policy_tag.into()];
-            // Call hew_node_link_remote → i64 ref_id. The ref_id is discarded at
-            // codegen: registration is the immediate result and the Result<(),
-            // LinkError> dest is written Ok(()). A failed registration is recorded
-            // via set_last_error in the runtime and the link simply never fires
-            // (it cannot crash an actor it never registered) — fail-closed.
-            let _ref_id = fn_ctx.call_runtime_int(
+            let setup_result = fn_ctx.call_runtime_int(
                 symbol,
                 &llvm_args,
                 "hew_node_link_remote_call",
                 "hew_node_link_remote call",
             )?;
             if let Some(d) = dest {
-                emit_result_ok(fn_ctx, d, None)?;
+                // LinkError::NodeNotRunning is variant 2 and is the defensive
+                // mapping for an impossible zero return.
+                emit_signed_setup_result(
+                    fn_ctx,
+                    setup_result,
+                    d,
+                    false,
+                    2,
+                    "hew_node_link_remote_result",
+                )?;
             }
             let _ = (i32_ty, ptr_ty);
         }

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -411,7 +411,8 @@ const SYNTHETIC_TIMEOUT_ERROR_ITEM: ItemId = ItemId(u32::MAX - 1005);
 /// Surface it through the same builtin-enum path so
 /// `Err(LinkError::AlreadyLinked)` / `Err(LinkError::TargetDead)` match arms
 /// resolve via `machine_ctor_registry`. Variant order matches
-/// `hew_types::builtin_enums::LINK_ERROR_VARIANTS`: AlreadyLinked=0, TargetDead=1.
+/// `hew_types::builtin_enums::LINK_ERROR_VARIANTS`: AlreadyLinked=0,
+/// TargetDead=1, followed by the cross-node setup failures.
 const SYNTHETIC_LINK_ERROR_ITEM: ItemId = ItemId(u32::MAX - 1004);
 pub(crate) const SYNTHETIC_VEC_ITER_ITEM: ItemId = ItemId(u32::MAX - 1002);
 /// Sentinel `ItemId` for the synthetic `HashMapIter<K, V>` record — the
@@ -657,8 +658,18 @@ const ASK_ERROR_VARIANTS: &[&str] = &[
 const ASK_ERROR_PAYLOADS: &[&[&str]] = &[UNIT_VARIANT_PAYLOAD; 22];
 const TIMEOUT_ERROR_VARIANTS: &[&str] = &["Timeout"];
 const TIMEOUT_ERROR_PAYLOADS: &[&[&str]] = &[UNIT_VARIANT_PAYLOAD; 1];
-const LINK_ERROR_VARIANTS: &[&str] = &["AlreadyLinked", "TargetDead"];
-const LINK_ERROR_PAYLOADS: &[&[&str]] = &[UNIT_VARIANT_PAYLOAD; 2];
+const LINK_ERROR_VARIANTS: &[&str] = &[
+    "AlreadyLinked",
+    "TargetDead",
+    "NodeNotRunning",
+    "NoCurrentActor",
+    "InvalidTarget",
+    "Partition",
+    "StaleRef",
+    "EncodeFailure",
+    "LocalShutdown",
+];
+const LINK_ERROR_PAYLOADS: &[&[&str]] = &[UNIT_VARIANT_PAYLOAD; 9];
 const CRASH_ACTION_VARIANTS: &[&str] = &["Restart", "Escalate", "Kill"];
 const CRASH_ACTION_PAYLOADS: &[&[&str]] = &[UNIT_VARIANT_PAYLOAD; 3];
 const CRASH_KIND_VARIANTS: &[&str] = &["Crashed", "HeapExceeded", "PartitionDetected"];

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -28566,12 +28566,12 @@ impl Builder {
     ///
     /// Unlike the local `hew_actor_monitor(watcher_ptr, target_ptr)` (which keys
     /// on `HewActor*` pointers), the remote target has no pointer in this
-    /// address space. `hew_node_monitor(target_remote_pid: i64) -> u64` takes the
+    /// address space. `hew_node_monitor(target_remote_pid: i64) -> i64` takes the
     /// packed remote pid and registers a distributed-table entry keyed by
-    /// `(node_id, serial)`, sending a `CTRL_MONITOR_REQ` to the owning peer. The
-    /// `u64` return is the `ref_id` keying the registration; it is assembled into
-    /// the same `MonitorRef { ref_id }` value the local path returns, reusing the
-    /// the composite-return construction used for monitor results.
+    /// `(node_id, serial)`, sending a `CTRL_MONITOR_REQ` to the owning peer.
+    /// Positive returns are the `ref_id` keying the registration; negative
+    /// returns encode `MonitorError` as `-(variant + 1)`. Codegen assembles the
+    /// checker-authoritative `Result<MonitorRef, MonitorError>` directly.
     fn lower_node_monitor(
         &mut self,
         hir_args: &[hew_hir::HirExpr],
@@ -28584,12 +28584,13 @@ impl Builder {
 
         if context != RuntimeCallContext::ValueNeeded {
             // Statement-position monitor: register but discard the ref. The
-            // codegen handler calls the ABI and ignores the u64 return.
+            // codegen handler calls the ABI and ignores the signed setup return.
             self.push_runtime_call("hew_node_monitor", vec![target], None);
             return None;
         }
 
-        // Value-needed: the checker records `MonitorRef` as the result type.
+        // Value-needed: the checker records
+        // `Result<MonitorRef, MonitorError>` as the result type.
         // Fail closed if it did not — a HIR→MIR boundary violation.
         let composite_ty = if let Some(ty) = result_ty {
             ty.clone()
@@ -28608,18 +28609,11 @@ impl Builder {
             return None;
         };
 
-        // hew_node_monitor returns a u64 ref_id; store it into a raw i64 temp,
-        // then assemble MonitorRef { ref_id } via RecordInit, exactly as the
-        // local hew_actor_monitor value path does.
-        let ref_id_local = self.alloc_local(ResolvedTy::I64);
-        self.push_runtime_call("hew_node_monitor", vec![target], Some(ref_id_local));
-        let monitor_ref_local = self.alloc_local(composite_ty.clone());
-        self.push_instr(Instr::RecordInit {
-            ty: composite_ty,
-            fields: vec![(FieldOffset(0), ref_id_local)],
-            dest: monitor_ref_local,
-        });
-        Some(monitor_ref_local)
+        // Codegen decodes the signed setup return and writes either
+        // Ok(MonitorRef { ref_id }) or Err(MonitorError::<variant>) in place.
+        let result_local = self.alloc_local(composite_ty);
+        self.push_runtime_call("hew_node_monitor", vec![target], Some(result_local));
+        Some(result_local)
     }
 
     /// Lower a cross-node `link_remote(RemotePid<T>, PartitionPolicy)` to the
@@ -28633,9 +28627,10 @@ impl Builder {
     /// (node<<48|serial); the policy is a fieldless enum whose discriminant tag is
     /// extracted via `Place::EnumTag` and passed as the `policy_tag` i64.
     ///
-    /// The return is `Result<(), LinkError>` (matching the local `link`); the
-    /// immediate result signals registration success — the EXIT arrives async when
-    /// the remote dies. Codegen writes Ok(()) and discards the ABI's `ref_id`.
+    /// The return is `Result<(), LinkError>` (matching the local `link`). Positive
+    /// ABI returns signal registration success; negative returns encode
+    /// `LinkError` as `-(variant + 1)`. The EXIT arrives asynchronously when the
+    /// remote dies.
     fn lower_node_link_remote(
         &mut self,
         hir_args: &[hew_hir::HirExpr],
@@ -28705,9 +28700,8 @@ impl Builder {
             });
             return None;
         };
-        // Allocate the Result<(), LinkError> dest and pass it to the ABI call. The
-        // codegen LinkRemote handler sees the dest and emits emit_result_ok (tag=0,
-        // no payload) — registration success; the EXIT arrives async on death.
+        // Allocate the Result<(), LinkError> dest and pass it to the ABI call.
+        // Codegen decodes the signed setup return into Ok(()) or the precise Err.
         let result_local = self.alloc_local(composite_ty);
         self.push_runtime_call(
             "hew_node_link_remote",
@@ -47033,11 +47027,32 @@ fn terminator_escape_places(
                 || is_handle_borrowing_call_abi(builtin)
         };
     match term {
-        Terminator::Call { builtin, args, .. } => args
-            .iter()
-            .copied()
-            .filter(|place| !arg_is_borrowed(*builtin, place))
-            .collect(),
+        Terminator::Call {
+            callee,
+            builtin,
+            args,
+            ..
+        } => {
+            // `MonitorRef::recv_down` is an ordinary stdlib method (not a
+            // BuiltinNamedType rewrite), but its ABI is a proven borrow: the
+            // body reads `ref_id`, calls `hew_node_monitor_recv`, and has no
+            // parameter drop plan. Treating the Result-pattern payload binder
+            // as escaping here would reject the safe
+            // `match monitor(remote) { Ok(m) => m.recv_down(..), .. }` shape.
+            let borrows_owned_handle = callee == "MonitorRef::recv_down";
+            args.iter()
+                .copied()
+                .filter(|place| {
+                    let borrowed_handle = borrows_owned_handle
+                        && base_local(*place).is_some_and(|local| {
+                            local_tys
+                                .get(local as usize)
+                                .is_some_and(ty_is_owned_handle_leaf)
+                        });
+                    !(borrowed_handle || arg_is_borrowed(*builtin, place))
+                })
+                .collect()
+        }
         Terminator::Yield { value, .. } => vec![*value],
         Terminator::Send { value, .. }
         | Terminator::Ask { value, .. }

--- a/hew-mir/src/runtime_symbols.rs
+++ b/hew-mir/src/runtime_symbols.rs
@@ -307,9 +307,10 @@ const MIR_EMITTER_RUNTIME_SYMBOLS: &[&str] = &[
     // link ref_id. The current node + calling actor are resolved internally.
     "hew_node_link_remote",
     // `hew_node_monitor(target_pid: i64) -> i64` registers a distributed
-    // monitor for a remote actor and returns the ref_id. `hew_node_monitor_recv
-    // (ref_id: i64, timeout_ms: i64) -> i64` blocks for that monitor's terminal
-    // signal and returns the carried down-reason. The current node is resolved
+    // monitor for a remote actor. Positive returns are ref_ids; negative returns
+    // encode MonitorError as `-(variant + 1)`. `hew_node_monitor_recv(ref_id:
+    // i64, timeout_ms: i64) -> i64` blocks for that monitor's terminal signal
+    // and returns the carried down-reason. The current node is resolved
     // internally (like `hew_actor_self`), so neither carries a node argument.
     "hew_node_monitor",
     "hew_node_monitor_recv",

--- a/hew-runtime/src/cluster.rs
+++ b/hew-runtime/src/cluster.rs
@@ -1062,6 +1062,28 @@ impl HewCluster {
         }
     }
 
+    /// Admit a previously unknown peer whose `NodeId` was learned from the
+    /// connection protocol handshake.
+    ///
+    /// Existing members are left untouched so a bare reconnect cannot resurrect
+    /// a DEAD/LEFT peer without the strictly-higher incarnation required by the
+    /// gossip admission gate.
+    pub(crate) fn admit_handshake_peer(&self, node_id: u16) {
+        if node_id == 0 || node_id == self.config.local_node_id {
+            return;
+        }
+        let unknown = {
+            let members = self.members.lock_or_recover();
+            !members.iter().any(|member| member.node_id == node_id)
+        };
+        if unknown {
+            // A concurrent connection may admit the same peer between this
+            // check and `upsert_member`; equal-incarnation ALIVE upserts are
+            // idempotent under the member-table lock.
+            self.upsert_member(node_id, MEMBER_ALIVE, 1, &[]);
+        }
+    }
+
     /// Seed a member directly into the table without running the transition
     /// dispatch fan-outs. Used by cross-module tests that need the membership
     /// table to resolve a live incarnation for a node without also triggering the
@@ -2461,6 +2483,19 @@ mod tests {
             local_node_id: node_id,
             ..ClusterConfig::default()
         }
+    }
+
+    #[test]
+    fn handshake_admission_adds_unknown_peer_without_resurrecting_known_dead_peer() {
+        let cluster = HewCluster::new(make_config(1));
+        cluster.admit_handshake_peer(2);
+        assert_eq!(cluster.member_state(2), MEMBER_ALIVE);
+        assert_eq!(cluster.member_incarnation(2), Some(1));
+
+        cluster.upsert_member(3, MEMBER_DEAD, 7, &[]);
+        cluster.admit_handshake_peer(3);
+        assert_eq!(cluster.member_state(3), MEMBER_DEAD);
+        assert_eq!(cluster.member_incarnation(3), Some(7));
     }
 
     #[cfg(feature = "profiler")]

--- a/hew-runtime/src/connection.rs
+++ b/hew-runtime/src/connection.rs
@@ -36,6 +36,7 @@
     reason = "FFI entry-point module; SAFETY documented at fn signature."
 )]
 
+use std::collections::HashMap;
 use std::ffi::{c_char, c_int, CStr};
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
@@ -204,6 +205,9 @@ pub struct HewConnMgr {
     // native-only: ConnectionActor reader threads do not exist on WASM
     /// Active connections (protected by [`PoisonSafe`] for concurrent add/remove).
     connections: PoisonSafe<Vec<ConnectionActor>>,
+    /// Optional caller-supplied peer identity expectations, consumed exactly
+    /// once by `hew_connmgr_add` after the protocol handshake.
+    expected_peer_ids: PoisonSafe<HashMap<c_int, u16>>,
     /// Transport used for I/O operations.
     pub(crate) transport: *mut HewTransport,
     /// Callback for routing inbound messages to local actors.
@@ -513,6 +517,12 @@ fn publish_connection_established(
     let published = if mgr.cluster.is_null() {
         true
     } else {
+        // The handshake is the first point where a bare-address dial learns the
+        // peer's real node identity. Admit that authenticated identity before
+        // publishing the connection so SWIM, routing, and registry gossip all
+        // use the same NodeId instead of a caller-side placeholder.
+        // SAFETY: cluster is owned by the live manager.
+        unsafe { (&*mgr.cluster).admit_handshake_peer(peer_node_id) };
         // SAFETY: pointer validity is checked by the callee.
         unsafe {
             crate::cluster::hew_cluster_notify_connection_established_for_token_if_not_removed(
@@ -790,6 +800,12 @@ fn version_compatible(local: &HewHandshake, peer: &HewHandshake) -> bool {
 
 fn schema_compatible(local: &HewHandshake, peer: &HewHandshake) -> bool {
     local.schema_hash == peer.schema_hash
+}
+
+fn peer_identity_compatible(local_node_id: u16, peer_node_id: u16, expected: Option<u16>) -> bool {
+    peer_node_id != 0
+        && peer_node_id != local_node_id
+        && expected.is_none_or(|expected| expected == peer_node_id)
 }
 
 unsafe fn send_frame(transport: *mut HewTransport, conn_id: c_int, payload: &[u8]) -> bool {
@@ -1352,7 +1368,7 @@ fn flush_registry_gossip_to_connection(mgr: &HewConnMgr, conn_id: c_int, peer_fe
 /// Returns `0` if the connection is not active or is not registered. SWIM
 /// uses this to cross-check a frame's claimed `from_node` against the identity
 /// established during the handshake.
-fn peer_node_id_for_conn(mgr: &HewConnMgr, conn_id: c_int) -> u16 {
+pub(crate) fn peer_node_id_for_conn(mgr: &HewConnMgr, conn_id: c_int) -> u16 {
     mgr.connections.access(|conns| {
         conns
             .iter()
@@ -1926,6 +1942,7 @@ pub unsafe extern "C" fn hew_connmgr_new(
     cabi_guard!(transport.is_null(), std::ptr::null_mut());
     let mgr = Box::new(HewConnMgr {
         connections: PoisonSafe::new(Vec::with_capacity(16)),
+        expected_peer_ids: PoisonSafe::new(HashMap::new()),
         transport,
         inbound_router: router,
         routing_table,
@@ -1941,6 +1958,27 @@ pub unsafe extern "C" fn hew_connmgr_new(
         local_node_id,
     });
     Box::into_raw(mgr)
+}
+
+/// Bind an outbound transport connection to an expected peer `NodeId`.
+///
+/// The expectation is consumed by the next [`hew_connmgr_add`] for `conn_id`.
+/// A handshake claiming a different `NodeId` is rejected before the connection is
+/// installed or published.
+pub(crate) unsafe fn hew_connmgr_expect_peer(
+    mgr: *mut HewConnMgr,
+    conn_id: c_int,
+    expected_node_id: u16,
+) -> c_int {
+    if mgr.is_null() || conn_id == HEW_CONN_INVALID || expected_node_id == 0 {
+        set_last_error("hew_connmgr_expect_peer: invalid manager, connection, or node id");
+        return -1;
+    }
+    // SAFETY: caller guarantees mgr is valid.
+    unsafe { &*mgr }
+        .expected_peer_ids
+        .access(|expected| expected.insert(conn_id, expected_node_id));
+    0
 }
 
 /// Destroy a connection manager, closing all connections.
@@ -2195,6 +2233,9 @@ pub unsafe extern "C" fn hew_connmgr_add(mgr: *mut HewConnMgr, conn_id: c_int) -
     let mgr_ptr = mgr;
     // SAFETY: caller guarantees `mgr` is valid.
     let mgr = unsafe { &*mgr };
+    let expected_peer_node_id = mgr
+        .expected_peer_ids
+        .access(|expected| expected.remove(&conn_id));
 
     if mgr.reconnect_shutdown.load(Ordering::Acquire) {
         // SAFETY: conn_id came from the transport and is not yet tracked by the manager.
@@ -2252,6 +2293,27 @@ pub unsafe extern "C" fn hew_connmgr_add(mgr: *mut HewConnMgr, conn_id: c_int) -
         unsafe { close_transport_conn(mgr.transport, conn_id) };
         return -1;
     };
+    if !peer_identity_compatible(mgr.local_node_id, peer_hs.node_id, expected_peer_node_id) {
+        // SAFETY: mgr.transport and conn_id are valid per caller contract.
+        unsafe { close_transport_conn(mgr.transport, conn_id) };
+        if peer_hs.node_id == 0 {
+            set_last_error(format!(
+                "hew_connmgr_add: peer handshake used reserved node id 0 for conn {conn_id}"
+            ));
+        } else if peer_hs.node_id == mgr.local_node_id {
+            set_last_error(format!(
+                "hew_connmgr_add: peer node id {} collides with local node id for conn {conn_id}",
+                peer_hs.node_id
+            ));
+        } else {
+            set_last_error(format!(
+                "hew_connmgr_add: peer node id {} does not match expected node id {} for conn {conn_id}",
+                peer_hs.node_id,
+                expected_peer_node_id.unwrap_or(0)
+            ));
+        }
+        return -1;
+    }
 
     #[cfg(feature = "encryption")]
     let skip_noise = {
@@ -3042,6 +3104,7 @@ mod tests {
 
         let mgr = HewConnMgr {
             connections: PoisonSafe::new(vec![active, draining]),
+            expected_peer_ids: PoisonSafe::new(HashMap::new()),
             transport: std::ptr::null_mut(),
             inbound_router: None,
             routing_table: std::ptr::null_mut(),
@@ -3085,6 +3148,15 @@ mod tests {
     }
 
     #[test]
+    fn peer_identity_validation_rejects_reserved_colliding_and_unexpected_ids() {
+        assert!(peer_identity_compatible(10, 20, None));
+        assert!(peer_identity_compatible(10, 20, Some(20)));
+        assert!(!peer_identity_compatible(10, 0, None));
+        assert!(!peer_identity_compatible(10, 10, None));
+        assert!(!peer_identity_compatible(10, 20, Some(21)));
+    }
+
+    #[test]
     fn link_controls_from_wrong_authenticated_peer_are_rejected() {
         let _guard = crate::runtime_test_guard();
         let mut peer = ConnectionActor::new(10);
@@ -3092,6 +3164,7 @@ mod tests {
         peer.state.store(CONN_STATE_ACTIVE, Ordering::Release);
         let mgr = HewConnMgr {
             connections: PoisonSafe::new(vec![peer]),
+            expected_peer_ids: PoisonSafe::new(HashMap::new()),
             transport: std::ptr::null_mut(),
             inbound_router: None,
             routing_table: std::ptr::null_mut(),

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -1208,7 +1208,6 @@ pub struct HewNode {
     bind_addr_owned: *mut c_char,
     accept_stop: Arc<AtomicBool>,
     accept_thread: Mutex<Option<JoinHandle<()>>>,
-    next_peer_node: AtomicU16,
 }
 
 impl std::fmt::Debug for HewNode {
@@ -1970,33 +1969,19 @@ extern "C" fn node_registry_gossip_callback(
     }
 }
 
-fn next_peer_node_id(node: &HewNode) -> u16 {
-    let mut id = node.next_peer_node.fetch_add(1, Ordering::Relaxed);
-    if id == 0 || id == node.node_id {
-        id = node.next_peer_node.fetch_add(1, Ordering::Relaxed);
-        if id == 0 || id == node.node_id {
-            id = 1;
-        }
-    }
-    id
-}
-
-unsafe fn parse_connect_target(
-    addr: *const c_char,
-    fallback_node_id: u16,
-) -> Option<(u16, CString)> {
+unsafe fn parse_connect_target(addr: *const c_char) -> Option<(Option<u16>, CString)> {
     // SAFETY: caller validates non-null and C-string.
     let c_addr = unsafe { CStr::from_ptr(addr) };
     let addr_text = c_addr.to_string_lossy();
     if let Some((prefix, target)) = addr_text.split_once('@') {
         if let Ok(node_id) = prefix.parse::<u16>() {
-            if !target.is_empty() {
+            if node_id != 0 && !target.is_empty() {
                 let c_target = CString::new(target.as_bytes()).ok()?;
-                return Some((node_id, c_target));
+                return Some((Some(node_id), c_target));
             }
         }
     }
-    Some((fallback_node_id, CString::new(c_addr.to_bytes()).ok()?))
+    Some((None, CString::new(c_addr.to_bytes()).ok()?))
 }
 
 fn accept_loop(transport: SendTransport, conn_mgr: SendConnMgr, stop: &AtomicBool) {
@@ -2130,7 +2115,6 @@ pub unsafe extern "C" fn hew_node_new(node_id: u16, bind_addr: *const c_char) ->
         bind_addr_owned: bind_copy,
         accept_stop: Arc::new(AtomicBool::new(false)),
         accept_thread: Mutex::new(None),
-        next_peer_node: AtomicU16::new(1),
     });
     let raw = Box::into_raw(node);
     remember_node(raw);
@@ -2880,6 +2864,32 @@ pub unsafe extern "C" fn hew_node_send(
 
 // ── Cross-node monitor ───────────────────────────────────────────────────────
 
+const fn setup_error(variant: i64) -> i64 {
+    -(variant + 1)
+}
+
+// MonitorError declaration order in std/link_monitor.hew.
+const MONITOR_ERR_NODE_NOT_RUNNING: i64 = setup_error(0);
+const MONITOR_ERR_INVALID_TARGET: i64 = setup_error(1);
+const MONITOR_ERR_PARTITION: i64 = setup_error(2);
+const MONITOR_ERR_STALE_REF: i64 = setup_error(3);
+const MONITOR_ERR_ENCODE_FAILURE: i64 = setup_error(4);
+const MONITOR_ERR_LOCAL_SHUTDOWN: i64 = setup_error(5);
+
+// LinkError declaration order in std/builtins.hew. The local-only variants
+// AlreadyLinked=0 and TargetDead=1 remain first for compatibility.
+const LINK_ERR_NODE_NOT_RUNNING: i64 = setup_error(2);
+const LINK_ERR_NO_CURRENT_ACTOR: i64 = setup_error(3);
+const LINK_ERR_INVALID_TARGET: i64 = setup_error(4);
+const LINK_ERR_PARTITION: i64 = setup_error(5);
+const LINK_ERR_STALE_REF: i64 = setup_error(6);
+const LINK_ERR_ENCODE_FAILURE: i64 = setup_error(7);
+const LINK_ERR_LOCAL_SHUTDOWN: i64 = setup_error(8);
+
+fn setup_ref_id(ref_id: u64) -> i64 {
+    i64::try_from(ref_id).expect("distributed ref ids stay below i64::MAX")
+}
+
 /// Encode a `CTRL_MONITOR_*` control frame and send it on the connection routing
 /// to `target_pid`'s node. Returns 0 on a successful send, -1 otherwise (no
 /// route, no manager, encode failure). Never panics; logs via `set_last_error`.
@@ -2932,16 +2942,15 @@ unsafe fn send_monitor_control_frame(
 /// terminal state. The returned `ref_id` is assembled into the `MonitorRef`
 /// value and is the key `hew_node_monitor_recv` blocks on.
 ///
-/// Fail-closed: returns 0 (an invalid `ref_id`) when there is no current node,
-/// the target is local (cross-node monitor requires a remote target), or no
-/// route exists. The watcher entry is still recorded on a send failure so a
-/// later connection-drop fan-out can still deliver `MonitorLost` (the route may
-/// recover, or the drop itself is the terminal signal).
+/// Returns a positive `ref_id` on success. Setup failures are returned as
+/// negative `MonitorError` codes encoded as `-(variant + 1)`, so the Hew surface
+/// constructs `Result<MonitorRef, MonitorError>` and never manufactures an
+/// invalid zero-valued handle.
 #[no_mangle]
-pub extern "C" fn hew_node_monitor(target_pid: u64) -> u64 {
+pub extern "C" fn hew_node_monitor(target_pid: u64) -> i64 {
     let Some(rt) = crate::runtime::rt_current_opt() else {
         set_last_error("hew_node_monitor: no runtime installed");
-        return 0;
+        return MONITOR_ERR_NODE_NOT_RUNNING;
     };
     let remote_node_id = crate::pid::hew_pid_node(target_pid);
     let target_serial = crate::pid::hew_pid_serial(target_pid);
@@ -2949,15 +2958,14 @@ pub extern "C" fn hew_node_monitor(target_pid: u64) -> u64 {
         // Not a remote target — the cross-node route does not apply. The checker
         // routes only RemotePid receivers here, but guard fail-closed anyway.
         set_last_error("hew_node_monitor: target is not on a remote node");
-        return 0;
+        return MONITOR_ERR_INVALID_TARGET;
     }
 
     // StaleRef gate (shared with the send + ask paths): a captured
     // `RemotePid<T>` whose registration has been superseded fails CLOSED here —
-    // no watcher is registered against the stale capture, and the invalid `0`
-    // ref_id signals the failure (DI-012 / LESSONS `boundary-fail-closed`). The
-    // diagnostic names StaleRef so the cause is not collapsed into the generic
-    // no-route case.
+    // no watcher is registered against the stale capture, and the typed
+    // StaleRef setup error is returned. The diagnostic names StaleRef so the
+    // cause is not collapsed into the generic no-route case.
     let stale = with_current_node_read(|guard| {
         let node = *guard as *const HewNode;
         // SAFETY: read lock pins the current node pointer for this check.
@@ -2968,7 +2976,7 @@ pub extern "C" fn hew_node_monitor(target_pid: u64) -> u64 {
             "hew_node_monitor: target pid serial {target_serial} names a superseded \
              actor registration; the captured RemotePid is stale (StaleRef)"
         ));
-        return 0;
+        return MONITOR_ERR_STALE_REF;
     }
 
     // Record the watcher entry first so the connection-drop / SWIM-DEAD fan-out
@@ -2988,29 +2996,40 @@ pub extern "C" fn hew_node_monitor(target_pid: u64) -> u64 {
                 set_last_error(format!(
                     "hew_node_monitor: req payload encode failure: {err}"
                 ));
-                return ref_id;
+                rt.dist_monitors.remove_watcher(ref_id);
+                return MONITOR_ERR_ENCODE_FAILURE;
             }
         };
 
-    with_current_node_read(|guard| {
+    let send_result = with_current_node_read(|guard| {
         if *guard == 0 {
             set_last_error("hew_node_monitor: no current node");
-            return;
+            return None;
         }
         let node = *guard as *const HewNode;
         // SAFETY: read lock pins the current node pointer for this call.
         let node_ref = unsafe { &*node };
         // SAFETY: node_ref is valid for this call.
-        let _ = unsafe {
+        Some(unsafe {
             send_monitor_control_frame(
                 node_ref,
                 target_pid,
                 crate::envelope::CTRL_MONITOR_REQ,
                 payload,
             )
-        };
+        })
     });
-    ref_id
+    match send_result {
+        Some(0) => setup_ref_id(ref_id),
+        Some(_) => {
+            rt.dist_monitors.remove_watcher(ref_id);
+            MONITOR_ERR_PARTITION
+        }
+        None => {
+            rt.dist_monitors.remove_watcher(ref_id);
+            MONITOR_ERR_LOCAL_SHUTDOWN
+        }
+    }
 }
 
 /// `link_remote(RemotePid<T>, PartitionPolicy)` → establish a cross-node link
@@ -3024,17 +3043,14 @@ pub extern "C" fn hew_node_monitor(target_pid: u64) -> u64 {
 /// `CTRL_LINK_DOWN` back when the target dies AND (b) registers the reverse link
 /// so the LOCAL actor's death crashes the remote peer too (bidirectional OTP).
 ///
-/// Fail-closed: returns 0 (an invalid `ref_id`) when there is no runtime, no
-/// current actor (a link's subject is the calling actor — a link from `main` has
-/// nothing to crash), the target is local, or no route exists. The watcher entry
-/// is still recorded on a send failure so a later connection-drop fan-out can
-/// still deliver the cascade (the route may recover, or the drop is itself the
-/// terminal signal).
+/// Returns a positive internal `ref_id` on success. Setup failures are returned
+/// as negative `LinkError` codes encoded as `-(variant + 1)`, so
+/// `link_remote` cannot report `Ok(())` for a link that was never established.
 #[no_mangle]
 pub extern "C" fn hew_node_link_remote(target_pid: i64, policy_tag: i64) -> i64 {
     let Some(rt) = crate::runtime::rt_current_opt() else {
         set_last_error("hew_node_link_remote: no runtime installed");
-        return 0;
+        return LINK_ERR_NODE_NOT_RUNNING;
     };
     #[expect(
         clippy::cast_sign_loss,
@@ -3046,7 +3062,7 @@ pub extern "C" fn hew_node_link_remote(target_pid: i64, policy_tag: i64) -> i64 
     let self_actor = crate::actor::hew_actor_self();
     if self_actor.is_null() {
         set_last_error("hew_node_link_remote: no current actor (link subject)");
-        return 0;
+        return LINK_ERR_NO_CURRENT_ACTOR;
     }
     // SAFETY: hew_actor_self returned a non-null live actor pointer.
     // The actor `id` is already a packed pid (node<<48 | serial); the cascade
@@ -3059,7 +3075,19 @@ pub extern "C" fn hew_node_link_remote(target_pid: i64, policy_tag: i64) -> i64 
     let target_serial = crate::pid::hew_pid_serial(target_pid);
     if remote_node_id == 0 || remote_node_id == rt.node.local_node_id() {
         set_last_error("hew_node_link_remote: target is not on a remote node");
-        return 0;
+        return LINK_ERR_INVALID_TARGET;
+    }
+    let stale = with_current_node_read(|guard| {
+        let node = *guard as *const HewNode;
+        // SAFETY: read lock pins the current node pointer for this check.
+        !node.is_null() && dispatch_is_stale(unsafe { &*node }, target_pid)
+    });
+    if stale {
+        set_last_error(format!(
+            "hew_node_link_remote: target pid serial {target_serial} names a superseded \
+             actor registration; the captured RemotePid is stale (StaleRef)"
+        ));
+        return LINK_ERR_STALE_REF;
     }
     #[expect(
         clippy::cast_possible_truncation,
@@ -3092,38 +3120,39 @@ pub extern "C" fn hew_node_link_remote(target_pid: i64, policy_tag: i64) -> i64 
             set_last_error(format!(
                 "hew_node_link_remote: req payload encode failure: {err}"
             ));
-            #[expect(
-                clippy::cast_possible_wrap,
-                reason = "ref_id is a monotonic counter far below i64::MAX"
-            )]
-            return ref_id as i64;
+            rt.dist_monitors.remove_watcher(ref_id);
+            return LINK_ERR_ENCODE_FAILURE;
         }
     };
 
-    with_current_node_read(|guard| {
+    let send_result = with_current_node_read(|guard| {
         if *guard == 0 {
             set_last_error("hew_node_link_remote: no current node");
-            return;
+            return None;
         }
         let node = *guard as *const HewNode;
         // SAFETY: read lock pins the current node pointer for this call.
         let node_ref = unsafe { &*node };
         // SAFETY: node_ref is valid for this call.
-        let _ = unsafe {
+        Some(unsafe {
             send_monitor_control_frame(
                 node_ref,
                 target_pid,
                 crate::envelope::CTRL_LINK_REQ,
                 payload,
             )
-        };
+        })
     });
-    #[expect(
-        clippy::cast_possible_wrap,
-        reason = "ref_id is a monotonic counter far below i64::MAX"
-    )]
-    {
-        ref_id as i64
+    match send_result {
+        Some(0) => setup_ref_id(ref_id),
+        Some(_) => {
+            rt.dist_monitors.remove_watcher(ref_id);
+            LINK_ERR_PARTITION
+        }
+        None => {
+            rt.dist_monitors.remove_watcher(ref_id);
+            LINK_ERR_LOCAL_SHUTDOWN
+        }
     }
 }
 
@@ -3739,8 +3768,8 @@ pub extern "C" fn hew_dist_partition_pending_remote_asks() -> i64 {
 
 /// Connect to a remote node and register routing for its node ID.
 ///
-/// Supports `"<node_id>@<addr>"` format for explicit peer node IDs. If no
-/// prefix is supplied, an internal node-id allocator is used.
+/// Supports `"<node_id>@<addr>"` to require an exact peer `NodeId`. Without a
+/// prefix, the authenticated handshake `NodeId` is authoritative.
 ///
 /// # Safety
 ///
@@ -3759,11 +3788,8 @@ pub unsafe extern "C" fn hew_node_connect(node: *mut HewNode, addr: *const c_cha
         return -1;
     }
 
-    let fallback_node_id = next_peer_node_id(node);
     // SAFETY: addr pointer is non-null and valid by caller contract.
-    let Some((peer_node_id, target_addr)) =
-        (unsafe { parse_connect_target(addr, fallback_node_id) })
-    else {
+    let Some((expected_peer_node_id, target_addr)) = (unsafe { parse_connect_target(addr) }) else {
         set_last_error("hew_node_connect: invalid connect target");
         return -1;
     };
@@ -3786,6 +3812,20 @@ pub unsafe extern "C" fn hew_node_connect(node: *mut HewNode, addr: *const c_cha
         set_last_error("hew_node_connect: transport connect failed");
         return -1;
     }
+    if let Some(expected) = expected_peer_node_id {
+        // SAFETY: conn_mgr is live and conn_id was just returned by this node's
+        // transport. The expectation is consumed by hew_connmgr_add.
+        if unsafe { connection::hew_connmgr_expect_peer(node.conn_mgr, conn_id, expected) } != 0 {
+            // hew_connmgr_expect_peer does not take ownership on failure.
+            // SAFETY: transport and conn_id are still owned by this function.
+            if let Some(close_fn) = ops.close_conn {
+                // SAFETY: conn_id was just created by this transport and has not
+                // been transferred to the connection manager.
+                unsafe { close_fn(t.r#impl, conn_id) };
+            }
+            return -1;
+        }
+    }
 
     // SAFETY: conn_mgr pointer is valid and owned by this node.
     if unsafe { connection::hew_connmgr_add(node.conn_mgr, conn_id) } != 0 {
@@ -3803,12 +3843,6 @@ pub unsafe extern "C" fn hew_node_connect(node: *mut HewNode, addr: *const c_cha
             0,
         )
     };
-
-    if !node.cluster.is_null() {
-        // SAFETY: cluster pointer is valid if non-null.
-        let _ =
-            unsafe { cluster::hew_cluster_join(node.cluster, peer_node_id, target_addr.as_ptr()) };
-    }
 
     0
 }

--- a/hew-types/src/builtin_enums.rs
+++ b/hew-types/src/builtin_enums.rs
@@ -184,6 +184,23 @@ const LINK_ERROR_VARIANTS: &[BuiltinMonomorphicEnumVariant] = &[
         name: "AlreadyLinked",
     },
     BuiltinMonomorphicEnumVariant { name: "TargetDead" },
+    BuiltinMonomorphicEnumVariant {
+        name: "NodeNotRunning",
+    },
+    BuiltinMonomorphicEnumVariant {
+        name: "NoCurrentActor",
+    },
+    BuiltinMonomorphicEnumVariant {
+        name: "InvalidTarget",
+    },
+    BuiltinMonomorphicEnumVariant { name: "Partition" },
+    BuiltinMonomorphicEnumVariant { name: "StaleRef" },
+    BuiltinMonomorphicEnumVariant {
+        name: "EncodeFailure",
+    },
+    BuiltinMonomorphicEnumVariant {
+        name: "LocalShutdown",
+    },
 ];
 
 /// `CrashAction` variants in declaration order (`std/failure.hew`). The tag

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -1166,8 +1166,10 @@ impl Checker {
             // `monitor(LocalPid<T>)` form stays on the generic `fn_sigs` path
             // below (registered with a `LocalPid` receiver). When the argument
             // resolves to a `RemotePid<T>`, accept it here and return
-            // `MonitorRef` — the MIR lowering branches on the argument's
-            // resolved type to route a remote receiver to the node monitor ABI
+            // `Result<MonitorRef, MonitorError>` — remote setup can fail before
+            // a registration exists, so it must not manufacture a zero-valued
+            // handle. The MIR lowering branches on the argument's resolved type
+            // to route a remote receiver to the node monitor ABI
             // (`hew_node_monitor`) instead of the in-process `hew_actor_monitor`.
             // The cross-node LINK form is `link_remote(RemotePid<T>,
             // PartitionPolicy)` — its own builtin, routed via the generic
@@ -1178,7 +1180,7 @@ impl Checker {
                 let arg_ty = self.synthesize(expr, sp);
                 let resolved = self.subst.resolve(&arg_ty);
                 if resolved.as_remote_pid().is_some() {
-                    let result_ty = Ty::monitor_ref();
+                    let result_ty = Ty::result(Ty::monitor_ref(), Ty::monitor_error());
                     self.record_type(span, &result_ty);
                     return result_ty;
                 }

--- a/hew-types/src/check/registration.rs
+++ b/hew-types/src/check/registration.rs
@@ -138,11 +138,21 @@ pub type MonitorRef {
 pub enum LinkError {
     AlreadyLinked;
     TargetDead;
+    NodeNotRunning;
+    NoCurrentActor;
+    InvalidTarget;
+    Partition;
+    StaleRef;
+    EncodeFailure;
+    LocalShutdown;
 }
 
 pub enum MonitorError {
+    NodeNotRunning;
+    InvalidTarget;
     Partition;
     StaleRef;
+    EncodeFailure;
     LocalShutdown;
     VersionMismatch;
     Unauthorized;

--- a/hew-types/src/check/tests/wasm.rs
+++ b/hew-types/src/check/tests/wasm.rs
@@ -1124,6 +1124,25 @@ fn main() {
         "
     }
 
+    fn remote_monitor_returns_typed_result_source() -> &'static str {
+        r"
+            actor Worker {
+                receive fn ping() {}
+            }
+
+            fn main() {
+                let remote: RemotePid<Worker> = RemotePid::from_raw(2, 1);
+                let result: Result<MonitorRef, MonitorError> = monitor(remote);
+                match result {
+                    Ok(m) => {
+                        m.close();
+                    },
+                    Err(_) => {},
+                }
+            }
+        "
+    }
+
     fn structured_concurrency_scope_source() -> &'static str {
         "fn main() { let result = scope { 1 + 2 }; println(result); }"
     }
@@ -1341,6 +1360,16 @@ fn main() {
                 .iter()
                 .any(|e| matches!(e.kind, TypeErrorKind::Mismatch { .. })),
             "monitor() should no longer typecheck as i64; got errors: {:?}",
+            output.errors
+        );
+    }
+
+    #[test]
+    fn remote_monitor_returns_typed_result() {
+        let output = check_native(remote_monitor_returns_typed_result_source());
+        assert!(
+            output.errors.is_empty(),
+            "monitor(RemotePid) should return Result<MonitorRef, MonitorError>; got: {:?}",
             output.errors
         );
     }

--- a/hew-types/src/runtime_call.rs
+++ b/hew-types/src/runtime_call.rs
@@ -338,10 +338,11 @@ pub enum RuntimeCallFamily {
     // here as a runtime-call family.
     NodeLookup,
     /// `monitor(RemotePid<T>)` → `hew_node_monitor(target_pid: i64) -> i64`.
-    /// Registers a distributed-monitor entry keyed by the packed remote pid's
-    /// `(node_id, serial)` and returns the `ref_id` assembled into `MonitorRef`.
-    /// The current node is resolved internally (like `hew_actor_self`), so the
-    /// single arg is the remote target pid (`BitCopy` `i64`); non-consuming.
+    /// Positive returns are distributed-monitor ref ids; negative returns encode
+    /// `MonitorError` as `-(variant + 1)`. Codegen assembles
+    /// `Result<MonitorRef, MonitorError>`. The current node is resolved
+    /// internally (like `hew_actor_self`), so the single runtime arg is the
+    /// remote target pid (`BitCopy` `i64`); non-consuming.
     NodeMonitor,
     /// `MonitorRef::recv_down` → `hew_node_monitor_recv(ref_id: i64,
     /// timeout_ms: i64) -> i64`. Blocks until the distributed monitor's terminal

--- a/hew-types/src/ty.rs
+++ b/hew-types/src/ty.rs
@@ -966,6 +966,16 @@ impl Ty {
         Self::builtin_named(BuiltinType::LinkError, vec![])
     }
 
+    /// Construct `MonitorError` — setup error for `monitor(RemotePid<T>)`.
+    #[must_use]
+    pub fn monitor_error() -> Ty {
+        Ty::Named {
+            name: "MonitorError".to_string(),
+            args: vec![],
+            builtin: None,
+        }
+    }
+
     /// Construct `MonitorRef` — handle returned by `monitor(handle)`.
     ///
     /// The struct is declared in `std/link_monitor.hew` and registered via

--- a/std/builtins.hew
+++ b/std/builtins.hew
@@ -169,6 +169,13 @@ pub enum TimeoutError {
 pub enum LinkError {
     AlreadyLinked;
     TargetDead;
+    NodeNotRunning;
+    NoCurrentActor;
+    InvalidTarget;
+    Partition;
+    StaleRef;
+    EncodeFailure;
+    LocalShutdown;
 }
 
 /// Message contract for actor types used behind `LocalPid<A>` / `RemotePid<A>`.

--- a/std/link_monitor.hew
+++ b/std/link_monitor.hew
@@ -1,14 +1,16 @@
 //! Actor monitor / link handle helpers.
 //!
 //! Import `std::link_monitor` when you want to name `MonitorRef`,
-//! `MonitorError`, or `PartitionPolicy` explicitly. The `monitor(actor)`
-//! builtin returns `MonitorRef`; the `link(actor)` builtin returns
+//! `MonitorError`, or `PartitionPolicy` explicitly. `monitor(LocalPid)` returns
+//! `MonitorRef`; `monitor(RemotePid)` returns
+//! `Result<MonitorRef, MonitorError>`; and `link(actor)` returns
 //! `Result<(), LinkError>` — `LinkError` is prelude-published from
 //! `std/builtins.hew` (like `SendError`), so it needs no import.
 //!
-//! link/monitor builtins return through the value-position composite-return
-//! spine: `link()` builds `Result<(), LinkError>` and `monitor()` builds
-//! `MonitorRef` in place from the runtime ref_id.
+//! Link/monitor builtins return through the value-position composite-return
+//! spine: `link()` builds `Result<(), LinkError>`, local `monitor()` builds
+//! `MonitorRef`, and remote `monitor()` builds
+//! `Result<MonitorRef, MonitorError>` from the runtime setup result.
 
 // WASM-TODO(#1451): `MonitorRef` and `LinkError` depend on the native actor
 // monitor / link runtime. The checker rejects `monitor()` and `link()` on
@@ -20,10 +22,16 @@
 // name `LinkError::AlreadyLinked` / `TargetDead` without importing this module.
 /// Error returned when a monitor delivery cannot be completed.
 pub enum MonitorError {
+    /// No distributed node runtime is active.
+    NodeNotRunning;
+    /// The supplied pid is local or otherwise not a valid remote target.
+    InvalidTarget;
     /// The route to the monitored peer is unavailable or the peer is suspect.
     Partition;
     /// The monitor refers to an old session or actor incarnation.
     StaleRef;
+    /// The monitor control frame could not be encoded.
+    EncodeFailure;
     /// The local node is shutting down before monitor delivery can complete.
     LocalShutdown;
     /// The peer rejected the monitor because protocol or schema versions differ.

--- a/tests/hew/distributed_error_taxonomy_test.hew
+++ b/tests/hew/distributed_error_taxonomy_test.hew
@@ -60,13 +60,16 @@ fn ask_error_id(err: AskError) -> i64 {
 
 fn monitor_error_id(err: MonitorError) -> i64 {
     match err {
-        MonitorError::Partition => 1,
-        MonitorError::StaleRef => 2,
-        MonitorError::LocalShutdown => 3,
-        MonitorError::VersionMismatch => 4,
-        MonitorError::Unauthorized => 5,
-        MonitorError::DecodeFailure => 6,
-        MonitorError::MonitorLost => 7,
+        MonitorError::NodeNotRunning => 1,
+        MonitorError::InvalidTarget => 2,
+        MonitorError::Partition => 3,
+        MonitorError::StaleRef => 4,
+        MonitorError::EncodeFailure => 5,
+        MonitorError::LocalShutdown => 6,
+        MonitorError::VersionMismatch => 7,
+        MonitorError::Unauthorized => 8,
+        MonitorError::DecodeFailure => 9,
+        MonitorError::MonitorLost => 10,
     }
 }
 
@@ -134,13 +137,16 @@ fn test_ask_error_taxonomy_variants() {
 
 #[test]
 fn test_monitor_error_taxonomy_variants() {
-    testing.assert_eq(monitor_error_id(MonitorError::Partition), 1);
-    testing.assert_eq(monitor_error_id(MonitorError::StaleRef), 2);
-    testing.assert_eq(monitor_error_id(MonitorError::LocalShutdown), 3);
-    testing.assert_eq(monitor_error_id(MonitorError::VersionMismatch), 4);
-    testing.assert_eq(monitor_error_id(MonitorError::Unauthorized), 5);
-    testing.assert_eq(monitor_error_id(MonitorError::DecodeFailure), 6);
-    testing.assert_eq(monitor_error_id(MonitorError::MonitorLost), 7);
+    testing.assert_eq(monitor_error_id(MonitorError::NodeNotRunning), 1);
+    testing.assert_eq(monitor_error_id(MonitorError::InvalidTarget), 2);
+    testing.assert_eq(monitor_error_id(MonitorError::Partition), 3);
+    testing.assert_eq(monitor_error_id(MonitorError::StaleRef), 4);
+    testing.assert_eq(monitor_error_id(MonitorError::EncodeFailure), 5);
+    testing.assert_eq(monitor_error_id(MonitorError::LocalShutdown), 6);
+    testing.assert_eq(monitor_error_id(MonitorError::VersionMismatch), 7);
+    testing.assert_eq(monitor_error_id(MonitorError::Unauthorized), 8);
+    testing.assert_eq(monitor_error_id(MonitorError::DecodeFailure), 9);
+    testing.assert_eq(monitor_error_id(MonitorError::MonitorLost), 10);
 }
 
 #[test]

--- a/tests/vertical-slice/accept/link_monitor_value_result.hew
+++ b/tests/vertical-slice/accept/link_monitor_value_result.hew
@@ -39,6 +39,9 @@ fn main() -> i64 {
         Err(LinkError::TargetDead) => {
             exit(3);
         },
+        Err(_) => {
+            exit(4);
+        },
     }
     // monitor() in value position: constructs MonitorRef { ref_id: i64 }.
     // The value is move-only (#[resource]); constructing it without NYI and


### PR DESCRIPTION
## Summary

I made the connection handshake NodeId authoritative across routing and SWIM membership, reject reserved, colliding, and explicitly mismatched peer identities, and removed placeholder membership for bare-address dials.

I also made cross-node monitor and link setup fail closed with typed errors. `monitor(RemotePid)` now returns `Result<MonitorRef, MonitorError>`, failed registrations are reclaimed immediately, and codegen preserves the exact runtime error variant instead of manufacturing a handle or reporting `Ok(())`.

I extended the compiled two-process fixture to prove exact node/location/incarnation identity, ALIVE membership, typed monitor setup failure after route loss, and the existing cross-node monitor, link, partition, gossip, stale-reference, and wire behavior.

## Validation

- `cargo test -p hew-runtime -- --test-threads=1`
- `cargo test -p hew-cli --test distributed_two_process_e2e -- --test-threads=1`
- `cargo check --workspace`
- `make hew-check-all`