### PR TITLE
test(runtime): de-flake destroy_wakes_blocked_recv (accept both wake outcomes)

### DIFF
--- a/hew-runtime/src/sim_transport.rs
+++ b/hew-runtime/src/sim_transport.rs
@@ -1744,12 +1744,22 @@ mod tests {
                 thread::sleep(Duration::from_millis(5));
             }
             let outcome = recv_handle.join().expect("recv thread panicked");
-            // After destroy the partition flag is set and the conn
-            // table is cleared; whichever the recv loop sees first
-            // surfaces as Partitioned.
+            // `shutdown()` sets the partition flag AND clears the conn
+            // table (then `notify_all`s) — a woken recv loop can legally
+            // observe either first: the partition check at the top of the
+            // loop surfaces `Partitioned`, while re-taking the table lock
+            // after the cleared conns surfaces `InvalidConn`. Both prove
+            // the recv woke from `sim_transport_free` rather than its own
+            // watchdog timeout; the race over which wins is benign, so
+            // accept both instead of asserting a fixed winner (this is
+            // the de-flake per #1945 — the old `Partitioned`-only assert
+            // was timing-flaky on slower/contended runners).
             assert!(
-                matches!(outcome, SimRecvOutcome::Partitioned),
-                "expected Partitioned wake from destroy, got {outcome:?}"
+                matches!(
+                    outcome,
+                    SimRecvOutcome::Partitioned | SimRecvOutcome::InvalidConn
+                ),
+                "expected a destroy wake (Partitioned or InvalidConn), got {outcome:?}"
             );
         }
     }


### PR DESCRIPTION
Fixes #1945.

## Problem
`sim_transport::tests::destroy_wakes_blocked_recv` asserted the parked recv observed exactly `SimRecvOutcome::Partitioned` after `sim_transport_free`. But `shutdown()` sets the partition flag **and** clears the conn table before its `notify_all`, so a woken recv loop legitimately races between two views:

- the top-of-loop `st.partition` check surfaces `Partitioned`;
- re-taking the table lock over the now-empty `conns` surfaces `InvalidConn`.

Both prove the recv woke from the destroy rather than its own 5 ms watchdog timeout, so which wins is benign. On slower/contended runners the conn-table-cleared view wins first and the old assert flaked (observed on macOS arm64: `expected Partitioned, got InvalidConn`).

## Fix
Widen the assert to `Partitioned | InvalidConn` (maintainer's option 1). Any non-wake outcome (`PeerClosed`/`Frame`/`BufferTooSmall`) still fails, so the test keeps proving the destroy-wake it was written to guard — it is not blanket-retried or made unconditional.

## Verification
- 300 runs (200 serial + 100 under full-core `yes` saturation), zero failures.
- Full `hew-runtime` `sim_transport` suite green (16/16).
- fmt + clippy(--tests) clean.