### PR TITLE
fix(net): map Windows cancel codes to NetError::Cancelled

### DIFF
--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -96,8 +96,10 @@ pub fn net_error_from_errno(errno: i64) -> NetError {
     // ETIMEDOUT: Linux=110, macOS=60, Windows=10060
     } else if errno == 110 || errno == 60 || errno == 10060 {
         NetError::TimedOut(errno)
-    // ECANCELED: Linux=125, macOS=89
-    } else if errno == 125 || errno == 89 {
+    // ECANCELED: Linux=125, macOS=89. Windows has no WSABASEERR-offset
+    // ECANCELED; a cancelled/aborted overlapped net op surfaces as
+    // ERROR_OPERATION_ABORTED (995) or WSAECANCELLED (10103) instead.
+    } else if errno == 125 || errno == 89 || errno == 995 || errno == 10103 {
         NetError::Cancelled(errno)
     // EADDRNOTAVAIL: Linux=99, macOS=49, Windows=10049
     } else if errno == 99 || errno == 49 || errno == 10049 {

--- a/tests/hew/net_try_api_test.hew
+++ b/tests/hew/net_try_api_test.hew
@@ -107,3 +107,25 @@ fn test_net_error_windows_wsa_variants() {
         _ => panic("expected NetError::AddressNotAvailable"),
     }
 }
+
+#[test]
+fn test_net_error_windows_cancelled_variants() {
+    // ERROR_OPERATION_ABORTED (995): a cancelled overlapped net op on Windows.
+    match net.net_error_from_errno(995) {
+        NetError::Cancelled(code) => {
+            if code != 995 {
+                panic("expected Cancelled payload 995");
+            }
+        },
+        _ => panic("expected NetError::Cancelled for 995"),
+    }
+    // WSAECANCELLED (10103).
+    match net.net_error_from_errno(10103) {
+        NetError::Cancelled(code) => {
+            if code != 10103 {
+                panic("expected Cancelled payload 10103");
+            }
+        },
+        _ => panic("expected NetError::Cancelled for 10103"),
+    }
+}


### PR DESCRIPTION
Closes #2532.

## What

On Windows a cancelled/aborted overlapped net op surfaces as `ERROR_OPERATION_ABORTED` (995) or `WSAECANCELLED` (10103). Neither is a `WSABASEERR`-offset `ECANCELED`, so both fell through `net_error_from_errno` to `NetError::Other(raw)` instead of the existing `NetError::Cancelled` variant (which already carries Linux `ECANCELED`=125 / macOS=89).

This adds both Windows codes as additional clauses on the `ECANCELED` branch, mirroring the additive WSA mapping slepp landed for the four direct-equivalent codes in #2506 (`9061423cf`).

## Reconciling the 5th net-errno case (#2532 point 2)

The #2506 net-errno gap was described as 5 failing cases; the direct-equivalent fix covered 4. The 5th is exactly this Cancelled case — there is no clean WSABASEERR-offset for it, which is why it needed the decision this PR resolves. With 995/10103 mapped, the net-errno table is complete across POSIX and Winsock2.

## Payload precision (#2532 point 3)

The new test asserts both codes route to `Cancelled` **and** that the exact errno payload is preserved (`code == 995` / `code == 10103`), rather than discarding the payload with `Variant(_)`.

## Safety

Purely additive: POSIX errno (< 200) cannot collide with WSA/Win32 codes (> 900), so no regression to the http/quic/websocket/dns callers; the else arm still returns a real `Err`.

## Verification (Linux)

- `hew test tests/hew/net_try_api_test.hew` — **8 passed; 0 failed** (incl. new `test_net_error_windows_cancelled_variants`)
- `hew fmt --check` clean on both changed files
- `make stdlib-errno-gate` passed (no banned string-match error patterns)

The mapping itself is platform-agnostic integer matching, so the Linux test exercises the exact code path Windows will hit.