### PR TITLE
fix(runtime): portable cstr_strdup replaces libc::strdup (Windows-MSVC link)

### DIFF
--- a/hew-cabi/src/cabi.rs
+++ b/hew-cabi/src/cabi.rs
@@ -64,6 +64,43 @@ pub fn malloc_bytes(src: &[u8]) -> *mut u8 {
     ptr
 }
 
+/// Duplicate a NUL-terminated C string into a fresh `libc::malloc` buffer,
+/// portably. This is a drop-in replacement for `libc::strdup` that links on
+/// every target: Windows UCRT only exports `_strdup` (not `strdup`) for the
+/// MSVC toolchain, so a bare `libc::strdup` reference fails to link any binary
+/// that actually reaches the call site (see hew-lang/hew#2505). The returned
+/// pointer owns a bare-`malloc` allocation with a trailing NUL and MUST be
+/// released with `libc::free` (NOT `free_cstring`, which is header-aware).
+///
+/// Returns null if `src` is null or on allocation failure, matching the
+/// `strdup` contract (null in → null out). Null handling is the caller's
+/// responsibility.
+///
+/// # Safety
+///
+/// If non-null, `src` must point to a valid NUL-terminated C string.
+#[must_use]
+pub unsafe fn cstr_strdup(src: *const c_char) -> *mut c_char {
+    if src.is_null() {
+        return std::ptr::null_mut();
+    }
+    // SAFETY: caller guarantees src is a valid NUL-terminated C string.
+    let len = unsafe { CStr::from_ptr(src) }.to_bytes().len();
+    // Allocate len + 1 for the trailing NUL. len can be 0 (empty string), and
+    // len + 1 >= 1, so malloc(0) implementation-defined behaviour is avoided
+    // and the pointer is always freeable by libc::free.
+    // SAFETY: We request len + 1 bytes from malloc; it returns a valid pointer
+    // or null.
+    let dst = unsafe { libc::malloc(len + 1) }.cast::<c_char>(); // ALLOCATOR-PAIRING: libc
+    if dst.is_null() {
+        return dst;
+    }
+    // SAFETY: src points to len + 1 bytes (payload + NUL); dst is freshly
+    // allocated with len + 1 bytes; the regions are non-overlapping.
+    unsafe { std::ptr::copy_nonoverlapping(src, dst, len + 1) };
+    dst
+}
+
 /// Allocate a 1-byte sentinel via `libc::malloc`. Use this when a zero-length
 /// allocation is needed but a non-null, freeable pointer is required (e.g. an
 /// empty body buffer). Returns null on allocation failure.
@@ -1198,5 +1235,45 @@ mod tests {
             String::from_utf8_lossy(&status.stdout),
             String::from_utf8_lossy(&status.stderr),
         );
+    }
+
+    #[test]
+    fn cstr_strdup_copies_and_is_free_independent() {
+        use std::ffi::CString;
+        let src = CString::new("bind-addr:9000").unwrap();
+        // SAFETY: src is a valid NUL-terminated C string.
+        let dup = unsafe { cstr_strdup(src.as_ptr()) };
+        assert!(!dup.is_null(), "strdup of a non-empty string must succeed");
+        // SAFETY: dup is a valid NUL-terminated C string returned by cstr_strdup.
+        let round = unsafe { CStr::from_ptr(dup) };
+        assert_eq!(round.to_bytes(), src.as_bytes(), "payload copied verbatim");
+        assert_ne!(
+            dup.cast_const(),
+            src.as_ptr(),
+            "the duplicate must be a distinct allocation"
+        );
+        // SAFETY: dup was allocated via libc::malloc, so libc::free owns it.
+        unsafe { libc::free(dup.cast::<std::os::raw::c_void>()) };
+    }
+
+    #[test]
+    fn cstr_strdup_handles_empty_and_null() {
+        use std::ffi::CString;
+        let empty = CString::new("").unwrap();
+        // SAFETY: empty is a valid NUL-terminated C string.
+        let dup = unsafe { cstr_strdup(empty.as_ptr()) };
+        assert!(
+            !dup.is_null(),
+            "strdup of an empty string is still freeable"
+        );
+        // SAFETY: dup is a valid NUL-terminated C string.
+        assert_eq!(unsafe { CStr::from_ptr(dup) }.to_bytes().len(), 0);
+        // SAFETY: dup was allocated via libc::malloc.
+        unsafe { libc::free(dup.cast::<std::os::raw::c_void>()) };
+
+        // Null in -> null out, matching the strdup contract.
+        // SAFETY: null is an accepted input.
+        let null_dup = unsafe { cstr_strdup(std::ptr::null()) };
+        assert!(null_dup.is_null(), "null input must propagate as null");
     }
 }

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -2111,7 +2111,8 @@ pub unsafe extern "C" fn hew_node_new(node_id: u16, bind_addr: *const c_char) ->
     cabi_guard!(bind_addr.is_null(), ptr::null_mut());
 
     // SAFETY: caller guarantees bind_addr points to a valid C string.
-    let bind_copy = unsafe { libc::strdup(bind_addr) };
+    // Portable strdup: libc::strdup does not link on Windows-MSVC (#2505).
+    let bind_copy = unsafe { crate::cabi::cstr_strdup(bind_addr) };
     if bind_copy.is_null() {
         return ptr::null_mut();
     }
@@ -2555,7 +2556,7 @@ pub unsafe extern "C" fn hew_node_free(node: *mut HewNode) {
     }
 
     if !node.bind_addr_owned.is_null() {
-        // SAFETY: bind_addr_owned was allocated via libc::strdup.
+        // SAFETY: bind_addr_owned was allocated via cstr_strdup (libc::malloc).
         unsafe { libc::free(node.bind_addr_owned.cast::<c_void>()) };
         node.bind_addr_owned = ptr::null_mut();
         node.bind_addr = ptr::null();

--- a/hew-runtime/src/reply_channel.rs
+++ b/hew-runtime/src/reply_channel.rs
@@ -1786,7 +1786,7 @@ mod tests {
         // either pass to hew_reply (success → waiter frees) or free on the
         // `delivered=false` cancel path.
         unsafe {
-            let cloned: *mut libc::c_char = libc::strdup(original.as_ptr());
+            let cloned: *mut libc::c_char = crate::cabi::cstr_strdup(original.as_ptr());
             assert!(!cloned.is_null(), "strdup must succeed");
 
             hew_reply_channel_retain(ch); // sender's reference
@@ -1831,7 +1831,7 @@ mod tests {
         // SAFETY: cloned is libc-allocated; we either hand it off via
         // hew_reply (success path) or free it on the alloc-fail path.
         unsafe {
-            let cloned: *mut libc::c_char = libc::strdup(original.as_ptr());
+            let cloned: *mut libc::c_char = crate::cabi::cstr_strdup(original.as_ptr());
             assert!(!cloned.is_null(), "strdup must succeed");
 
             hew_reply_channel_retain(ch);
@@ -1897,7 +1897,7 @@ mod tests {
         // SAFETY: `ch` is a live, retained sender-side channel reference.
         unsafe {
             let original = std::ffi::CString::new(payload).unwrap();
-            let embedded: *mut libc::c_char = libc::strdup(original.as_ptr());
+            let embedded: *mut libc::c_char = crate::cabi::cstr_strdup(original.as_ptr());
             assert!(!embedded.is_null(), "strdup must succeed");
             let mut reply_value: *mut libc::c_char = embedded;
             let delivered = hew_reply(
@@ -2044,7 +2044,7 @@ mod tests {
             hew_reply_channel_retain(ch); // sender's reference
 
             let original = std::ffi::CString::new("cancel-before-delivery").unwrap();
-            let embedded: *mut libc::c_char = libc::strdup(original.as_ptr());
+            let embedded: *mut libc::c_char = crate::cabi::cstr_strdup(original.as_ptr());
             assert!(!embedded.is_null(), "strdup must succeed");
 
             hew_reply_channel_cancel(ch); // waiter abandons BEFORE the reply
@@ -2101,7 +2101,7 @@ mod tests {
             hew_reply_channel_retain(ch); // sender's reference
 
             let original = std::ffi::CString::new("oom-before-delivery").unwrap();
-            let embedded: *mut libc::c_char = libc::strdup(original.as_ptr());
+            let embedded: *mut libc::c_char = crate::cabi::cstr_strdup(original.as_ptr());
             assert!(!embedded.is_null(), "strdup must succeed");
 
             FORCE_REPLY_ALLOC_FAILURE.store(true, Ordering::Release);

--- a/hew-runtime/src/reply_channel_wasm.rs
+++ b/hew-runtime/src/reply_channel_wasm.rs
@@ -1105,7 +1105,7 @@ mod tests {
         // SAFETY: `ch` is a live, retained sender-side channel reference.
         unsafe {
             let original = std::ffi::CString::new(payload).unwrap();
-            let embedded: *mut libc::c_char = libc::strdup(original.as_ptr());
+            let embedded: *mut libc::c_char = crate::cabi::cstr_strdup(original.as_ptr());
             assert!(!embedded.is_null(), "strdup must succeed");
             let mut reply_value: *mut libc::c_char = embedded;
             let delivered = hew_reply(
@@ -1224,7 +1224,7 @@ mod tests {
             hew_reply_channel_retain(ch); // sender's reference
 
             let original = std::ffi::CString::new("cancel-before-delivery").unwrap();
-            let embedded: *mut libc::c_char = libc::strdup(original.as_ptr());
+            let embedded: *mut libc::c_char = crate::cabi::cstr_strdup(original.as_ptr());
             assert!(!embedded.is_null(), "strdup must succeed");
 
             hew_reply_channel_cancel(ch); // waiter abandons BEFORE the reply
@@ -1274,7 +1274,7 @@ mod tests {
             hew_reply_channel_retain(ch); // sender's reference
 
             let original = std::ffi::CString::new("oom-before-delivery").unwrap();
-            let embedded: *mut libc::c_char = libc::strdup(original.as_ptr());
+            let embedded: *mut libc::c_char = crate::cabi::cstr_strdup(original.as_ptr());
             assert!(!embedded.is_null(), "strdup must succeed");
 
             FORCE_REPLY_ALLOC_FAILURE.store(1, Ordering::Release);

--- a/hew-runtime/src/supervisor.rs
+++ b/hew-runtime/src/supervisor.rs
@@ -274,7 +274,7 @@ unsafe impl Send for ChildLookupResult {}
 /// Parallel to `InternalChildSpec` for static children, but tracks
 /// pool-specific attributes: routing strategy, capacity, and name.
 struct InternalPoolSpec {
-    /// Human-readable pool name (C string, heap-allocated via `libc::strdup`).
+    /// Human-readable pool name (C string, heap-allocated via `cstr_strdup`).
     name: *mut c_char,
     /// Routing strategy recorded for diagnostics; the live strategy is owned
     /// by the parallel `HewActorPool` in `pool_slots`.
@@ -2681,7 +2681,8 @@ pub unsafe extern "C" fn hew_supervisor_add_child_spec(
         ptr::null_mut()
     } else {
         // SAFETY: caller guarantees name is a valid C string.
-        unsafe { libc::strdup(sp.name) }
+        // Portable strdup (libc::strdup unavailable on Windows-MSVC, #2505).
+        unsafe { crate::cabi::cstr_strdup(sp.name) }
     };
 
     s.child_specs.push(InternalChildSpec {
@@ -5200,7 +5201,8 @@ pub unsafe extern "C" fn hew_supervisor_add_child_dynamic(
         ptr::null_mut()
     } else {
         // SAFETY: caller guarantees name is a valid C string.
-        unsafe { libc::strdup(sp.name) }
+        // Portable strdup (libc::strdup unavailable on Windows-MSVC, #2505).
+        unsafe { crate::cabi::cstr_strdup(sp.name) }
     };
 
     let i = s.child_count;
@@ -6053,7 +6055,8 @@ pub unsafe extern "C" fn hew_supervisor_pool_add_slot(
         ptr::null_mut()
     } else {
         // SAFETY: caller guarantees name is a valid C string.
-        unsafe { libc::strdup(name) }
+        // Portable strdup (libc::strdup unavailable on Windows-MSVC, #2505).
+        unsafe { crate::cabi::cstr_strdup(name) }
     };
 
     // Allocate the pool. hew_pool_new takes a *const c_char that must stay


### PR DESCRIPTION
## Problem

`hew_node.rs` calls `libc::strdup(bind_addr)` inside `hew_node_new` (a `#[no_mangle] extern "C"` export), and the supervisor pool machinery does the same for pool names. The Windows-MSVC toolchain / UCRT exports only `_strdup`, **not** a symbol literally named `strdup`, so any binary that actually links these exports fails at link time with `undefined symbol: strdup` (#2505).

This is masked on `hew.exe` release builds because `/OPT:REF` drops the unreferenced object, but `cargo test --release --workspace` links the no-mangle exports in and fails immediately — blocking 16 of 24 core crates on Windows, and latent in any real product build path that reaches distributed-node / supervisor functionality.

## Fix

Add `hew_cabi::cabi::cstr_strdup`: a portable drop-in for `libc::strdup` —
`libc::malloc(len + 1)` + `copy_nonoverlapping` (payload + trailing NUL),
null-in/null-out, freeable by `libc::free`. It deliberately preserves the
existing **bare-malloc / `libc::free`** ownership contract (it is *not* the
header-aware `malloc_cstring`/`free_cstring` path, so every paired
`libc::free(bind_addr_owned)` / pool-name free stays correct byte-for-byte).

Every `libc::strdup(...)` call site now routes through it:
- `hew_node_new` bind-addr copy-in (production)
- supervisor pool-name copy-in ×3 (production)
- `reply_channel` / `reply_channel_wasm` destructor-leak test fixtures

## Verification (Linux)

- New `hew-cabi` unit tests: `cstr_strdup_copies_and_is_free_independent`, `cstr_strdup_handles_empty_and_null` (2/2)
- `hew-runtime` lib: `reply_channel` 64/64, `node` 113/113, `supervisor` 61/61 green
- `cargo fmt --check` + `cargo clippy --tests` clean
- Zero `libc::strdup` call sites remain in-tree

Fixes #2505