### PR TITLE
test(runtime): de-globalize read_slot/await_cancel free-count oracles

### DIFF
--- a/hew-runtime/src/await_cancel.rs
+++ b/hew-runtime/src/await_cancel.rs
@@ -18,17 +18,47 @@ use crate::task_scope::{hew_cancel_token_release, hew_cancel_token_retain, HewCa
 use crate::timer_wheel::{hew_timer_wheel_cancel, hew_timer_wheel_schedule_handle};
 use crate::timer_wheel::{HewTimerEntry, HewTimerWheel};
 
+/// Test-only per-instance final-free probe. Replaces the former process-global
+/// `AWAIT_CANCEL_FINAL_FREE_COUNT` counter, whose delta assertions were
+/// corrupted under parallel test execution by unrelated registrations freed in
+/// other modules' tests (same contamination class as the runtime-drop counter
+/// de-globalized in #2574). Each "reclaimed exactly once" oracle binds a fresh
+/// counter to the single registration it owns via
+/// [`install_await_cancel_free_probe_for_test`], so it counts only *that
+/// registration's* final free.
 #[cfg(test)]
-static AWAIT_CANCEL_FINAL_FREE_COUNT: AtomicUsize = AtomicUsize::new(0);
+pub(crate) type AwaitCancelFreeProbe = std::sync::Arc<AtomicUsize>;
 
 #[cfg(test)]
-pub(crate) fn reset_await_cancel_final_free_count_for_test() {
-    AWAIT_CANCEL_FINAL_FREE_COUNT.store(0, Ordering::Release);
+pub(crate) fn new_await_cancel_free_probe_for_test() -> AwaitCancelFreeProbe {
+    std::sync::Arc::new(AtomicUsize::new(0))
+}
+
+/// Bind a per-instance final-free probe to a single live registration the test
+/// owns. The registration's final [`hew_await_cancel_free`] bumps this probe, so
+/// the count is immune to concurrent frees of other registrations in parallel
+/// tests.
+///
+/// # Safety
+///
+/// `reg` must be a valid live `HewAwaitCancel` the caller holds a ref to.
+#[cfg(test)]
+pub(crate) unsafe fn install_await_cancel_free_probe_for_test(
+    reg: *mut HewAwaitCancel,
+    probe: &AwaitCancelFreeProbe,
+) {
+    // SAFETY: caller holds a ref, so the box is live; `final_free_probe` uses
+    // interior mutability (a `Mutex`) so a shared reference may set it.
+    let inner = unsafe { &*reg };
+    *inner
+        .final_free_probe
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(std::sync::Arc::clone(probe));
 }
 
 #[cfg(test)]
-pub(crate) fn await_cancel_final_free_count_for_test() -> usize {
-    AWAIT_CANCEL_FINAL_FREE_COUNT.load(Ordering::Acquire)
+pub(crate) fn await_cancel_free_probe_count(probe: &AwaitCancelFreeProbe) -> usize {
+    probe.load(Ordering::Acquire)
 }
 
 /// Terminal state for an internal suspended await registration.
@@ -70,6 +100,13 @@ pub struct HewAwaitCancel {
     actor: AtomicPtr<HewActor>,
     cleanup: HewAwaitCleanup,
     source: *mut c_void,
+    /// Test-only per-instance final-free probe. When a test binds one via
+    /// [`install_await_cancel_free_probe_for_test`], the registration's final
+    /// [`hew_await_cancel_free`] bumps it, so an "exactly once" oracle observes
+    /// only this registration's free rather than a process-global count
+    /// contaminated by concurrent parallel-test frees.
+    #[cfg(test)]
+    final_free_probe: std::sync::Mutex<Option<AwaitCancelFreeProbe>>,
 }
 
 // SAFETY: shared mutable state is atomic; raw pointers are retained or source-
@@ -235,6 +272,8 @@ pub unsafe extern "C" fn hew_await_cancel_new(
         actor: AtomicPtr::new(actor),
         cleanup,
         source,
+        #[cfg(test)]
+        final_free_probe: std::sync::Mutex::new(None),
     }))
 }
 
@@ -267,7 +306,15 @@ pub unsafe extern "C" fn hew_await_cancel_free(reg: *mut HewAwaitCancel) {
         return;
     }
     #[cfg(test)]
-    AWAIT_CANCEL_FINAL_FREE_COUNT.fetch_add(1, Ordering::AcqRel);
+    // SAFETY: refs reached 0, so we own the box exclusively; read the optional
+    // per-instance probe before the box is consumed below and bump it.
+    unsafe {
+        if let Ok(mut guard) = (*reg).final_free_probe.lock() {
+            if let Some(probe) = guard.take() {
+                probe.fetch_add(1, Ordering::AcqRel);
+            }
+        }
+    }
     // SAFETY: last ref; no timer ref can still be held or refs would exceed 1.
     let boxed = unsafe { Box::from_raw(reg) };
     // SAFETY: this registration retained the token at creation.

--- a/hew-runtime/src/reactor.rs
+++ b/hew-runtime/src/reactor.rs
@@ -2896,8 +2896,8 @@ mod tests {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         reset_reactor();
-        crate::await_cancel::reset_await_cancel_final_free_count_for_test();
-        crate::read_slot::reset_read_slot_final_free_count_for_test();
+        let await_cancel_free_probe = crate::await_cancel::new_await_cancel_free_probe_for_test();
+        let slot_free_probe = crate::read_slot::new_read_slot_free_probe_for_test();
 
         let poller = unsafe { hew_io_poller_new() };
         assert!(!poller.is_null());
@@ -2912,6 +2912,10 @@ mod tests {
         let actor = spawn_full_reject_actor();
         let actor_ref = unsafe { crate::transport::hew_actor_ref_local(actor) };
         let slot = crate::read_slot::hew_read_slot_new();
+        // SAFETY: fresh slot with a live creator ref; bind a per-instance
+        // final-free probe so the "reclaimed exactly once" oracle counts only
+        // this slot's free, immune to concurrent parallel-test slot frees.
+        unsafe { crate::read_slot::install_read_slot_free_probe_for_test(slot, &slot_free_probe) };
         let await_cancel = unsafe {
             crate::await_cancel::hew_await_cancel_new(
                 std::ptr::null_mut(),
@@ -2920,6 +2924,15 @@ mod tests {
             )
         };
         unsafe { crate::read_slot::hew_read_slot_set_await_cancel(slot, await_cancel) };
+        // SAFETY: fresh registration with a live creator ref; bind a per-instance
+        // final-free probe so the "reclaimed exactly once" oracle counts only
+        // this registration's free, immune to concurrent parallel-test frees.
+        unsafe {
+            crate::await_cancel::install_await_cancel_free_probe_for_test(
+                await_cancel,
+                &await_cancel_free_probe,
+            )
+        };
         unsafe { crate::read_slot::read_slot_retain(slot) }; // registration ref
         inject_resume_registration_for_test(fd, conn, actor_ref, KEY, slot);
 
@@ -2980,12 +2993,12 @@ mod tests {
         unsafe { crate::read_slot::hew_read_slot_free(slot) };
         unsafe { crate::await_cancel::hew_await_cancel_free(await_cancel) };
         assert_eq!(
-            crate::read_slot::read_slot_final_free_count_for_test(),
+            crate::read_slot::read_slot_free_probe_count(&slot_free_probe),
             1,
             "slot must be reclaimed exactly once"
         );
         assert_eq!(
-            crate::await_cancel::await_cancel_final_free_count_for_test(),
+            crate::await_cancel::await_cancel_free_probe_count(&await_cancel_free_probe),
             1,
             "deadline arbiter must be reclaimed exactly once"
         );

--- a/hew-runtime/src/reactor.rs
+++ b/hew-runtime/src/reactor.rs
@@ -2887,6 +2887,11 @@ mod tests {
         reason = "test-only FFI: every pointer is a fresh local registration, slot, \
                   actor, poller, or socket with lifecycle asserted in the body"
     )]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "single linear shutdown-race oracle: per-instance free probes plus \
+                  the ref-count sweep assertions must stay in one body to share state"
+    )]
     fn shutdown_sweep_cancel_wins_inflight_deposit_exactly_once() {
         use std::io::Write;
         const KEY: usize = 0x00C4_11ED;
@@ -2931,7 +2936,7 @@ mod tests {
             crate::await_cancel::install_await_cancel_free_probe_for_test(
                 await_cancel,
                 &await_cancel_free_probe,
-            )
+            );
         };
         unsafe { crate::read_slot::read_slot_retain(slot) }; // registration ref
         inject_resume_registration_for_test(fd, conn, actor_ref, KEY, slot);

--- a/hew-runtime/src/read_slot.rs
+++ b/hew-runtime/src/read_slot.rs
@@ -33,17 +33,46 @@ use crate::await_cancel::{
 use crate::await_cancel::{AwaitCancelStatus, HewAwaitCancel};
 use crate::bytes::BytesTriple;
 
+/// Test-only per-instance final-free probe. Replaces the former process-global
+/// `READ_SLOT_FINAL_FREE_COUNT` counter, whose delta assertions were corrupted
+/// under parallel test execution by unrelated slots freed in other modules'
+/// tests (same contamination class as the runtime-drop counter de-globalized in
+/// #2574). Each "freed exactly once" oracle binds a fresh counter to the single
+/// slot it owns via [`install_read_slot_free_probe_for_test`], so it counts only
+/// *that slot's* final free.
 #[cfg(test)]
-static READ_SLOT_FINAL_FREE_COUNT: AtomicUsize = AtomicUsize::new(0);
+pub(crate) type ReadSlotFreeProbe = std::sync::Arc<AtomicUsize>;
 
 #[cfg(test)]
-pub(crate) fn reset_read_slot_final_free_count_for_test() {
-    READ_SLOT_FINAL_FREE_COUNT.store(0, Ordering::Release);
+pub(crate) fn new_read_slot_free_probe_for_test() -> ReadSlotFreeProbe {
+    std::sync::Arc::new(AtomicUsize::new(0))
+}
+
+/// Bind a per-instance final-free probe to a single live slot the test owns. The
+/// slot's final [`hew_read_slot_free`] bumps this probe (in addition to no
+/// process-global state), so the count is immune to concurrent frees of other
+/// slots in parallel tests.
+///
+/// # Safety
+///
+/// `slot` must be a valid live `HewReadSlot` the caller holds a ref to.
+#[cfg(test)]
+pub(crate) unsafe fn install_read_slot_free_probe_for_test(
+    slot: *mut HewReadSlot,
+    probe: &ReadSlotFreeProbe,
+) {
+    // SAFETY: caller holds a ref, so the box is live; `final_free_probe` uses
+    // interior mutability (a `Mutex`) so a shared reference may set it.
+    let inner = unsafe { &*slot };
+    *inner
+        .final_free_probe
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(std::sync::Arc::clone(probe));
 }
 
 #[cfg(test)]
-pub(crate) fn read_slot_final_free_count_for_test() -> usize {
-    READ_SLOT_FINAL_FREE_COUNT.load(Ordering::Acquire)
+pub(crate) fn read_slot_free_probe_count(probe: &ReadSlotFreeProbe) -> usize {
+    probe.load(Ordering::Acquire)
 }
 
 /// The sentinel an accept slot carries until a handle is deposited, and the
@@ -141,6 +170,13 @@ pub struct HewReadSlot {
     handle: AtomicI64,
     /// Optional common cancellation/deadline record attached to this wait.
     await_cancel: AtomicPtr<HewAwaitCancel>,
+    /// Test-only per-instance final-free probe. When a test binds one via
+    /// [`install_read_slot_free_probe_for_test`], the slot's final
+    /// [`hew_read_slot_free`] bumps it, so an "exactly once" oracle observes only
+    /// this slot's free rather than a process-global count contaminated by
+    /// concurrent parallel-test frees.
+    #[cfg(test)]
+    final_free_probe: std::sync::Mutex<Option<ReadSlotFreeProbe>>,
 }
 
 // SAFETY: `HewReadSlot` is designed for cross-thread use. `status` is the
@@ -169,6 +205,8 @@ pub extern "C" fn hew_read_slot_new() -> *mut HewReadSlot {
         },
         handle: AtomicI64::new(INVALID_CONNECTION_HANDLE),
         await_cancel: AtomicPtr::new(std::ptr::null_mut()),
+        #[cfg(test)]
+        final_free_probe: std::sync::Mutex::new(None),
     }))
 }
 
@@ -220,7 +258,15 @@ pub unsafe extern "C" fn hew_read_slot_free(slot: *mut HewReadSlot) {
         return;
     }
     #[cfg(test)]
-    READ_SLOT_FINAL_FREE_COUNT.fetch_add(1, Ordering::AcqRel);
+    // SAFETY: refs reached 0, so we own the box exclusively; read the optional
+    // per-instance probe before the box is consumed below and bump it.
+    unsafe {
+        if let Ok(mut guard) = (*slot).final_free_probe.lock() {
+            if let Some(probe) = guard.take() {
+                probe.fetch_add(1, Ordering::AcqRel);
+            }
+        }
+    }
     // Last ref — reclaim the box. SAFETY: refs reached 0, so no other thread
     // holds a live reference; we own the box exclusively.
     let boxed = unsafe { Box::from_raw(slot) };

--- a/hew-runtime/src/task_scope.rs
+++ b/hew-runtime/src/task_scope.rs
@@ -3153,7 +3153,7 @@ mod tests {
     #[test]
     fn suspending_unit_task_await_cancel_frees_waiter_and_slot_once() {
         let _guard = crate::runtime_test_guard();
-        crate::read_slot::reset_read_slot_final_free_count_for_test();
+        let slot_free_probe = crate::read_slot::new_read_slot_free_probe_for_test();
         reset_task_await_waiter_final_free_count_for_test();
 
         // SAFETY: the test owns scope/task/slot pointers and drives the exact
@@ -3163,6 +3163,10 @@ mod tests {
             let task = hew_task_new();
             hew_task_scope_spawn(scope, task);
             let slot = crate::read_slot::hew_read_slot_new();
+            // Bind a per-instance final-free probe so the "exactly once" oracle
+            // counts only this slot's free, immune to concurrent parallel-test
+            // slot frees.
+            crate::read_slot::install_read_slot_free_probe_for_test(slot, &slot_free_probe);
 
             assert_eq!(
                 hew_task_await_suspend(scope, task, ptr::null_mut(), slot),
@@ -3172,7 +3176,7 @@ mod tests {
 
             hew_task_detach_await(scope, task, slot);
             assert_eq!(
-                crate::read_slot::read_slot_final_free_count_for_test(),
+                crate::read_slot::read_slot_free_probe_count(&slot_free_probe),
                 0,
                 "detach must release only the creator ref while the observer still owns its ref"
             );
@@ -3182,7 +3186,7 @@ mod tests {
             assert_eq!((*task).error, HewTaskError::Cancelled);
             assert_eq!(task_await_waiter_final_free_count_for_test(), 1);
             assert_eq!(
-                crate::read_slot::read_slot_final_free_count_for_test(),
+                crate::read_slot::read_slot_free_probe_count(&slot_free_probe),
                 1,
                 "cancelled task completion must release the observer ref and free the read slot exactly once"
             );
@@ -3194,7 +3198,7 @@ mod tests {
     #[test]
     fn suspending_unit_task_await_normal_completion_frees_waiter_and_slot_once() {
         let _guard = crate::runtime_test_guard();
-        crate::read_slot::reset_read_slot_final_free_count_for_test();
+        let slot_free_probe = crate::read_slot::new_read_slot_free_probe_for_test();
         reset_task_await_waiter_final_free_count_for_test();
 
         // SAFETY: the test owns scope/task/slot pointers and simulates the codegen
@@ -3204,6 +3208,10 @@ mod tests {
             let task = hew_task_new();
             hew_task_scope_spawn(scope, task);
             let slot = crate::read_slot::hew_read_slot_new();
+            // Bind a per-instance final-free probe so the "exactly once" oracle
+            // counts only this slot's free, immune to concurrent parallel-test
+            // slot frees.
+            crate::read_slot::install_read_slot_free_probe_for_test(slot, &slot_free_probe);
 
             assert_eq!(
                 hew_task_await_suspend(scope, task, ptr::null_mut(), slot),
@@ -3213,14 +3221,14 @@ mod tests {
 
             assert_eq!(task_await_waiter_final_free_count_for_test(), 1);
             assert_eq!(
-                crate::read_slot::read_slot_final_free_count_for_test(),
+                crate::read_slot::read_slot_free_probe_count(&slot_free_probe),
                 0,
                 "observer completion must leave the creator ref for the bind edge"
             );
 
             crate::read_slot::hew_read_slot_free(slot);
             assert_eq!(
-                crate::read_slot::read_slot_final_free_count_for_test(),
+                crate::read_slot::read_slot_free_probe_count(&slot_free_probe),
                 1,
                 "bind edge must free the read slot exactly once"
             );
@@ -3232,21 +3240,24 @@ mod tests {
     #[test]
     fn suspending_sleep_cancel_and_completion_free_deadline_registration_once() {
         use crate::await_cancel::{
-            await_cancel_final_free_count_for_test, hew_await_cancel_cancel,
-            hew_await_cancel_complete, hew_await_cancel_free, hew_await_cancel_new,
-            hew_await_cancel_schedule_deadline_ms, reset_await_cancel_final_free_count_for_test,
+            await_cancel_free_probe_count, hew_await_cancel_cancel, hew_await_cancel_complete,
+            hew_await_cancel_free, hew_await_cancel_new, hew_await_cancel_schedule_deadline_ms,
+            install_await_cancel_free_probe_for_test, new_await_cancel_free_probe_for_test,
             AwaitCancelStatus,
         };
         use crate::timer_wheel::{hew_timer_wheel_free, hew_timer_wheel_new, hew_timer_wheel_tick};
         use std::time::Duration;
 
         let _guard = crate::runtime_test_guard();
-        reset_await_cancel_final_free_count_for_test();
+        let cancel_free_probe = new_await_cancel_free_probe_for_test();
         // SAFETY: the registration and wheel are owned by this test; cancellation
         // wins before the wheel fires, mirroring suspending sleep abandon.
         unsafe {
             let tw = hew_timer_wheel_new();
             let reg = hew_await_cancel_new(ptr::null_mut(), None, ptr::null_mut());
+            // Bind a per-instance final-free probe so the "exactly once" oracle
+            // counts only this registration's free.
+            install_await_cancel_free_probe_for_test(reg, &cancel_free_probe);
             assert_eq!(hew_await_cancel_schedule_deadline_ms(reg, tw, 1_000), 0);
             assert_eq!(
                 hew_await_cancel_cancel(reg, AwaitCancelStatus::Cancelled as i32, 0),
@@ -3254,26 +3265,27 @@ mod tests {
             );
             hew_await_cancel_free(reg);
             assert_eq!(
-                await_cancel_final_free_count_for_test(),
+                await_cancel_free_probe_count(&cancel_free_probe),
                 1,
                 "sleep cancel must free the deadline registration exactly once"
             );
             hew_timer_wheel_free(tw);
         }
 
-        reset_await_cancel_final_free_count_for_test();
+        let cancel_free_probe = new_await_cancel_free_probe_for_test();
         // SAFETY: the test manually ticks the wheel so the timer callback wins,
         // then releases the creator ref as the sleep bind edge does.
         unsafe {
             let tw = hew_timer_wheel_new();
             let reg = hew_await_cancel_new(ptr::null_mut(), None, ptr::null_mut());
+            install_await_cancel_free_probe_for_test(reg, &cancel_free_probe);
             assert_eq!(hew_await_cancel_schedule_deadline_ms(reg, tw, 1), 0);
             std::thread::sleep(Duration::from_millis(2));
             assert_eq!(hew_timer_wheel_tick(tw), 1);
             assert_eq!(hew_await_cancel_complete(reg), 0);
             hew_await_cancel_free(reg);
             assert_eq!(
-                await_cancel_final_free_count_for_test(),
+                await_cancel_free_probe_count(&cancel_free_probe),
                 1,
                 "sleep completion must free the deadline registration exactly once"
             );


### PR DESCRIPTION
## What

De-globalize the `#[cfg(test)]` "freed exactly once" oracles for `HewReadSlot` and `HewAwaitCancel`, which asserted deltas on process-global counters and therefore flaked under parallel test execution.

Fixes #2632.

## Why

`reactor::tests::shutdown_sweep_cancel_wins_inflight_deposit_exactly_once` (and the two `task_scope` suspending-await tests) assert `*_final_free_count_for_test() == 1` on process-global statics:

- `READ_SLOT_FINAL_FREE_COUNT` — bumped by every `hew_read_slot_free`
- `AWAIT_CANCEL_FINAL_FREE_COUNT` — bumped by every `hew_await_cancel_free`

Other tests in the same process (e.g. the `read_slot` module's own free-tests) hold no shared lock with these oracles, so their frees corrupt the count. Observed failure: `left: 3, right: 1` ("deadline arbiter must be reclaimed exactly once"). This is the same contamination class the maintainer de-globalized for the runtime-drop counter in #2574.

## How

Mirror #2574's per-instance drop-probe pattern for both types:

- Add a `#[cfg(test)] final_free_probe: Mutex<Option<Arc<AtomicUsize>>>` field.
- Owning test binds a fresh probe via `install_{read_slot,await_cancel}_free_probe_for_test(ptr, &probe)`.
- The final free bumps only that instance's probe, so the oracle counts only its own instance.

Production is unaffected — the field, helpers, and probe are all `#[cfg(test)]`; no ABI or `Drop` change. The remaining `TASK_AWAIT_WAITER_FINAL_FREE_COUNT` global is left in place: its waiter box is constructed and consumed entirely inside production `hew_task_await_suspend`/`task_await_wake`, so a test can't hold the pointer to bind a per-instance probe, and it did not flake in 30 saturated runs; a thread-local isolation for it can be a follow-up if it ever surfaces.

## Verification (Linux x86-64, rebased on `main` @ `adb91b7`)

- Repro before fix: reactor test **alone** 50/50; reactor test **+ `read_slot` tests** 2/30 (flake).
- After fix: contaminating combo **50/50**; **60/60** under 4× `yes` core saturation.
- Module suites green: `reactor` 25/25, `read_slot` 12/12, `await_cancel` 2/2, `task_scope` 60/60.
- `cargo fmt -p hew-runtime --check` clean; `cargo clippy -p hew-runtime --tests` clean.

The regression is load-bearing: each oracle asserts exact `== 1` on a fresh per-instance probe, so a double-free (`2`) or leak (`0`) still fails.
