### PR TITLE
test: serialize libhew test builds across processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,7 +2047,9 @@ version = "0.6.0-rc1"
 name = "hew-testutil"
 version = "0.6.0-rc1"
 dependencies = [
+ "fd-lock",
  "libc",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,6 +1919,7 @@ dependencies = [
  "clap",
  "crossterm",
  "hew-runtime",
+ "hew-testutil",
  "libc",
  "ratatui",
  "reqwest",
@@ -1990,6 +1991,7 @@ version = "0.6.0-rc1"
 dependencies = [
  "assert_cmd",
  "hew-parser",
+ "hew-testutil",
  "hew-types",
  "serde",
  "serde_json",

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@
 #   make adze         — just the package manager
 #   make observe      — just the TUI observer (hew-observe)
 #   make observe-functional-test — HTTP-backed functional observe harness
+#   make libhew-link-race-test   — real multi-process libhew.a bootstrap-race proof
 #   make runtime      — just libhew_runtime.a
 #   make stdlib       — all stdlib packages + combine into libhew.a
 #   make wasm-runtime — WASM runtime + wire JSON/YAML/TOML archives
@@ -70,7 +71,7 @@
 #   make clean        — remove build/, target/
 # ============================================================================
 
-.PHONY: all build bootstrap install-hooks hew hew-native adze observe observe-functional-test runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh licenses licenses-check
+.PHONY: all build bootstrap install-hooks hew hew-native adze observe observe-functional-test libhew-link-race-test runtime stdlib wasm-runtime wasm playground-manifest playground-manifest-check sandbox-fixtures sandbox-fixtures-check sandbox-parity playground-check playground-wasi-check ci-preflight ci-preflight-smoke ci-preflight-strict ci-local-linux wasm-dist release check-libhew-fresh licenses licenses-check
 .PHONY: test test-all test-rust test-parser test-types test-cli test-compiler-pipeline test-vertical-slice test-pkg-import test-package-install test-runtime-net test-runtime-unit test-real-timing test-lane test-lane-all lane-gates test-fast test-stdlib test-hew test-hew-ratchet test-o2-differential o2-differential-selftest preflight-parity-selftest test-stdlib-ratchet test-ux-examples test-surface-examples test-release-binary check-sanitizer-gate asan asan-fixtures tsan miri lint runtime-poison-safe-lint stdlib-lint stdlib-errno-gate lint-wasm-todo leak-scan hew-fmt-check grammar
 .PHONY: clean install install-check uninstall verify-ffi test-verify-ffi
 .PHONY: assemble assemble-release pre-release publish-docs
@@ -159,6 +160,16 @@ observe:
 
 observe-functional-test: hew-native observe
 	cargo test -p hew-observe --test functional -- --ignored --nocapture
+
+# Real multi-process proof that `hew_testutil::ensure_hew_lib_built` closes
+# the `libhew.a` uplift race: real `cargo build -p hew-lib` writers, a real
+# `hew compile` link, and a real shared NEXTEST_RUN_ID across OS processes.
+# Excluded from routine `cargo nextest run` (see the #[ignore] reasons in
+# hew-testutil/tests/libhew_link_race.rs) because it repeatedly shells real
+# cargo/hew subprocesses; run explicitly here instead, same convention as
+# observe-functional-test above.
+libhew-link-race-test: hew-native
+	cargo test -p hew-testutil --test libhew_link_race -- --ignored --nocapture --test-threads=1
 
 # Build the runtime static library (debug)
 runtime:

--- a/hew-cli/tests/support/mod.rs
+++ b/hew-cli/tests/support/mod.rs
@@ -57,75 +57,7 @@ pub fn try_require_wasi_runner() -> bool {
 }
 
 fn bootstrap_codegen() -> Result<(), String> {
-    let target_dir = target_dir()?;
-    fs::create_dir_all(&target_dir).map_err(|error| {
-        format!(
-            "failed to create target dir {}: {error}",
-            target_dir.display()
-        )
-    })?;
-
-    let build_profile = build_profile();
-    let lock_path = target_dir.join("hew-cli-codegen-bootstrap.lock");
-    let stamp_path = target_dir.join(format!("hew-cli-codegen-bootstrap-{build_profile}.stamp"));
-    let run_id =
-        std::env::var("NEXTEST_RUN_ID").unwrap_or_else(|_| format!("pid:{}", std::process::id()));
-
-    let lock_file = OpenOptions::new()
-        .create(true)
-        .read(true)
-        .write(true)
-        .truncate(false)
-        .open(&lock_path)
-        .map_err(|error| {
-            format!(
-                "failed to open codegen bootstrap lock {}: {error}",
-                lock_path.display()
-            )
-        })?;
-    let mut lock = RwLock::new(lock_file);
-    let _guard = lock.write().map_err(|error| {
-        format!(
-            "failed to lock codegen bootstrap {}: {error}",
-            lock_path.display()
-        )
-    })?;
-
-    if fs::read_to_string(&stamp_path).is_ok_and(|stamp| stamp == run_id)
-        && hew_library_path().is_file()
-    {
-        return Ok(());
-    }
-
-    let output = build_codegen_artifacts(&target_dir, build_profile)?;
-    if !output.status.success() {
-        return Err(format!(
-            "failed to bootstrap hew-cli codegen artifacts with `cargo build -p hew-lib{}`\n{}",
-            if build_profile == "release" {
-                " --release"
-            } else {
-                ""
-            },
-            describe_output(&output)
-        ));
-    }
-
-    let hew_library = hew_library_path();
-    if !hew_library.is_file() {
-        return Err(format!(
-            "codegen bootstrap succeeded but {} was not created",
-            hew_library.display()
-        ));
-    }
-
-    fs::write(&stamp_path, run_id).map_err(|error| {
-        format!(
-            "failed to write codegen bootstrap stamp {}: {error}",
-            stamp_path.display()
-        )
-    })?;
-
-    Ok(())
+    hew_testutil::ensure_hew_lib_built().map(|_lib_path| ())
 }
 
 fn bootstrap_wasi_runner() -> Result<(), String> {
@@ -411,44 +343,6 @@ fn wasi_runtime_clean_and_retry(
     Ok(())
 }
 
-fn build_codegen_artifacts(target_dir: &Path, build_profile: &str) -> Result<Output, String> {
-    let mut command = Command::new("cargo");
-    command
-        .args(["build", "-q", "-p", "hew-lib"])
-        .env("CARGO_TARGET_DIR", target_dir)
-        .current_dir(repo_root());
-    if build_profile == "release" {
-        command.arg("--release");
-    }
-
-    // On macOS, pin the deployment target so the Rust-compiled objects inside
-    // libhew.a are tagged with the same minimum-OS version as the link step
-    // (which uses MACOSX_DEPLOYMENT_TARGET or defaults to "13.0" via
-    // `TargetSpec::linker_triple`).  Without this, objects compiled against a
-    // newer Xcode SDK are tagged with a higher OS version, causing ld64.lld to
-    // emit "has version X, which is newer than target minimum of 13.0.0"
-    // warnings for every archive member.
-    #[cfg(target_os = "macos")]
-    {
-        let deployment = std::env::var("MACOSX_DEPLOYMENT_TARGET")
-            .ok()
-            .filter(|v| !v.is_empty())
-            .unwrap_or_else(|| "13.0".to_string());
-        command.env("MACOSX_DEPLOYMENT_TARGET", deployment);
-    }
-
-    command.output().map_err(|error| {
-        format!(
-            "failed to invoke `cargo build -p hew-lib{}`: {error}",
-            if build_profile == "release" {
-                " --release"
-            } else {
-                ""
-            }
-        )
-    })
-}
-
 fn target_dir() -> Result<PathBuf, String> {
     hew_binary()
         .parent()
@@ -462,13 +356,6 @@ fn target_dir() -> Result<PathBuf, String> {
         })
 }
 
-fn hew_library_path() -> PathBuf {
-    hew_binary()
-        .parent()
-        .expect("hew binary should have a parent directory")
-        .join(hew_lib_name())
-}
-
 fn build_profile() -> &'static str {
     match hew_binary()
         .parent()
@@ -477,14 +364,6 @@ fn build_profile() -> &'static str {
     {
         Some("release") => "release",
         _ => "debug",
-    }
-}
-
-fn hew_lib_name() -> &'static str {
-    if cfg!(windows) {
-        "hew.lib"
-    } else {
-        "libhew.a"
     }
 }
 

--- a/hew-codegen-rs/tests/e2e/actor_e2e.rs
+++ b/hew-codegen-rs/tests/e2e/actor_e2e.rs
@@ -289,42 +289,30 @@ fn hew_bin(repo: &Path) -> PathBuf {
         .join(format!("hew{}", std::env::consts::EXE_SUFFIX))
 }
 
-fn hew_lib(repo: &Path) -> PathBuf {
-    let lib_name = if cfg!(windows) { "hew.lib" } else { "libhew.a" };
-    target_dir(repo).join("debug").join(lib_name)
-}
-
 fn ensure_codegen_artifacts(repo: &Path) {
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
         let hew = hew_bin(repo);
-        let lib = hew_lib(repo);
-        if hew.is_file() && lib.is_file() {
-            return;
+        if !hew.is_file() {
+            let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+            let output = Command::new(cargo)
+                .current_dir(repo)
+                .args(["build", "--quiet", "-p", "hew-cli"])
+                .output()
+                .expect("spawn cargo build -p hew-cli");
+            assert!(
+                output.status.success(),
+                "cargo build -p hew-cli failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                hew.is_file(),
+                "codegen bootstrap succeeded but hew binary was not created at {}",
+                hew.display()
+            );
         }
-
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let output = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-cli", "-p", "hew-lib"])
-            .output()
-            .expect("spawn cargo build -p hew-cli -p hew-lib");
-        assert!(
-            output.status.success(),
-            "cargo build -p hew-cli -p hew-lib failed\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-        assert!(
-            hew.is_file(),
-            "codegen bootstrap succeeded but hew binary was not created at {}",
-            hew.display()
-        );
-        assert!(
-            lib.is_file(),
-            "codegen bootstrap succeeded but Hew library was not created at {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/bytes_index_exec.rs
+++ b/hew-codegen-rs/tests/exec/bytes_index_exec.rs
@@ -57,31 +57,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/ffi_int_width_exec.rs
+++ b/hew-codegen-rs/tests/exec/ffi_int_width_exec.rs
@@ -26,20 +26,6 @@ fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
-fn target_dir(repo: &Path) -> PathBuf {
-    std::env::var_os("CARGO_TARGET_DIR").map_or_else(
-        || repo.join("target"),
-        |dir| {
-            let path = PathBuf::from(dir);
-            if path.is_absolute() {
-                path
-            } else {
-                repo.join(path)
-            }
-        },
-    )
-}
-
 fn hew_command(repo: &Path) -> Command {
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
     let mut command = Command::new(cargo);
@@ -50,31 +36,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/float_return_exec.rs
+++ b/hew-codegen-rs/tests/exec/float_return_exec.rs
@@ -12,20 +12,6 @@ fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
-fn target_dir(repo: &Path) -> PathBuf {
-    std::env::var_os("CARGO_TARGET_DIR").map_or_else(
-        || repo.join("target"),
-        |dir| {
-            let path = PathBuf::from(dir);
-            if path.is_absolute() {
-                path
-            } else {
-                repo.join(path)
-            }
-        },
-    )
-}
-
 fn hew_command(repo: &Path) -> Command {
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
     let mut command = Command::new(cargo);
@@ -36,31 +22,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/for_in_vec_string_exec.rs
+++ b/hew-codegen-rs/tests/exec/for_in_vec_string_exec.rs
@@ -65,31 +65,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/generator_exec.rs
+++ b/hew-codegen-rs/tests/exec/generator_exec.rs
@@ -58,31 +58,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/hashmap_index_exec.rs
+++ b/hew-codegen-rs/tests/exec/hashmap_index_exec.rs
@@ -61,31 +61,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/hashmap_keys_values_exec.rs
+++ b/hew-codegen-rs/tests/exec/hashmap_keys_values_exec.rs
@@ -64,31 +64,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/if_let_exec.rs
+++ b/hew-codegen-rs/tests/exec/if_let_exec.rs
@@ -56,31 +56,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/machine_exec.rs
+++ b/hew-codegen-rs/tests/exec/machine_exec.rs
@@ -157,33 +157,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        // On Windows MSVC the static library is hew.lib; on Unix it is libhew.a.
-        let lib_name = if cfg!(windows) { "hew.lib" } else { "libhew.a" };
-        let lib = target_dir(repo).join("debug").join(lib_name);
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "{lib_name} missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/match_literal_guard_default_exec.rs
+++ b/hew-codegen-rs/tests/exec/match_literal_guard_default_exec.rs
@@ -60,31 +60,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/primitive_trait_bound_exec.rs
+++ b/hew-codegen-rs/tests/exec/primitive_trait_bound_exec.rs
@@ -45,31 +45,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/structural_eq_exec.rs
+++ b/hew-codegen-rs/tests/exec/structural_eq_exec.rs
@@ -42,18 +42,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/vec_enum_index_exec.rs
+++ b/hew-codegen-rs/tests/exec/vec_enum_index_exec.rs
@@ -57,31 +57,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/vec_i32_index_exec.rs
+++ b/hew-codegen-rs/tests/exec/vec_i32_index_exec.rs
@@ -45,31 +45,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/vec_owned_element_routing_exec.rs
+++ b/hew-codegen-rs/tests/exec/vec_owned_element_routing_exec.rs
@@ -63,31 +63,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/vec_record_contains_exec.rs
+++ b/hew-codegen-rs/tests/exec/vec_record_contains_exec.rs
@@ -42,18 +42,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/exec/vec_record_index_exec.rs
+++ b/hew-codegen-rs/tests/exec/vec_record_index_exec.rs
@@ -54,31 +54,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/machine_lifecycle.rs
+++ b/hew-codegen-rs/tests/machine_lifecycle.rs
@@ -42,33 +42,10 @@ fn hew_command(repo: &Path) -> Command {
 }
 
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        // On Windows MSVC the static library is hew.lib; on Unix it is libhew.a.
-        let lib_name = if cfg!(windows) { "hew.lib" } else { "libhew.a" };
-        let lib = target_dir(repo).join("debug").join(lib_name);
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "{lib_name} missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
+++ b/hew-codegen-rs/tests/zeroarg_module_enum_emission.rs
@@ -26,46 +26,11 @@ fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
-fn target_dir(repo: &Path) -> PathBuf {
-    std::env::var_os("CARGO_TARGET_DIR").map_or_else(
-        || repo.join("target"),
-        |dir| {
-            let path = PathBuf::from(dir);
-            if path.is_absolute() {
-                path
-            } else {
-                repo.join(path)
-            }
-        },
-    )
-}
-
 fn ensure_hew_runtime_lib(repo: &Path) {
+    let _ = repo;
     static BUILT: OnceLock<()> = OnceLock::new();
     BUILT.get_or_init(|| {
-        let lib = target_dir(repo).join("debug").join("libhew.a");
-        // Always ask cargo to (re)build libhew.a rather than short-circuiting on
-        // its mere presence. Cargo's own fingerprint makes this a fast no-op when
-        // the archive is current and regenerates it when the toolchain (rustc /
-        // bundled LLVM) or the runtime/stdlib sources changed. A bare
-        // `lib.exists()` early-return reused a stale archive after a toolchain
-        // upgrade, linking a freshly-rebuilt `hew` against old object code and
-        // failing the link.
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let status = Command::new(cargo)
-            .current_dir(repo)
-            .args(["build", "--quiet", "-p", "hew-lib"])
-            .status()
-            .expect("spawn cargo build -p hew-lib");
-        assert!(
-            status.success(),
-            "cargo build -p hew-lib failed: {status:?}"
-        );
-        assert!(
-            lib.exists(),
-            "libhew.a missing after build: {}",
-            lib.display()
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-observe/Cargo.toml
+++ b/hew-observe/Cargo.toml
@@ -27,6 +27,7 @@ serde_json.workspace = true
 hew-runtime = { path = "../hew-runtime", default-features = false, features = [
   "profiler",
 ] }
+hew-testutil = { path = "../hew-testutil" }
 tempfile.workspace = true
 
 [lints]

--- a/hew-observe/tests/functional.rs
+++ b/hew-observe/tests/functional.rs
@@ -182,31 +182,30 @@ fn build_fixture_binary() -> BuiltFixture {
 
 fn ensure_compiler_artifacts() {
     let hew = hew_binary_path();
-    if hew.is_file() {
-        return;
+    if !hew.is_file() {
+        let mut command = Command::new("cargo");
+        command
+            .args(["build", "-p", "hew-cli"])
+            .current_dir(repo_root());
+        if !cfg!(debug_assertions) {
+            command.arg("--release");
+        }
+        let output = command
+            .output()
+            .expect("failed to run cargo build for hew compiler artifacts");
+        assert!(
+            output.status.success(),
+            "failed to bootstrap hew compiler artifacts\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            hew.is_file(),
+            "cargo build succeeded but {} was not created",
+            hew.display()
+        );
     }
-
-    let mut command = Command::new("cargo");
-    command
-        .args(["build", "-p", "hew-cli", "-p", "hew-lib"])
-        .current_dir(repo_root());
-    if !cfg!(debug_assertions) {
-        command.arg("--release");
-    }
-    let output = command
-        .output()
-        .expect("failed to run cargo build for hew compiler artifacts");
-    assert!(
-        output.status.success(),
-        "failed to bootstrap hew compiler artifacts\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    assert!(
-        hew.is_file(),
-        "cargo build succeeded but {} was not created",
-        hew.display()
-    );
+    hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
 }
 
 fn repo_root() -> &'static Path {

--- a/hew-sandbox-wasm/Cargo.toml
+++ b/hew-sandbox-wasm/Cargo.toml
@@ -33,5 +33,6 @@ wasm-bindgen = "0.2.125"
 
 [dev-dependencies]
 assert_cmd = "2"
+hew-testutil = { path = "../hew-testutil" }
 tempfile.workspace = true
 walkdir = "2"

--- a/hew-sandbox-wasm/tests/parity.rs
+++ b/hew-sandbox-wasm/tests/parity.rs
@@ -628,12 +628,7 @@ fn ensure_native_toolchain() {
                 .args(["build", "-q", "-p", "hew-cli"])
                 .current_dir(repo_root()),
         );
-        run_bootstrap_command(
-            "cargo build -q -p hew-lib",
-            std::process::Command::new("cargo")
-                .args(["build", "-q", "-p", "hew-lib"])
-                .current_dir(repo_root()),
-        );
+        hew_testutil::ensure_hew_lib_built().expect("build libhew.a");
     });
 }
 

--- a/hew-testutil/Cargo.toml
+++ b/hew-testutil/Cargo.toml
@@ -7,8 +7,14 @@ authors.workspace = true
 description = "Shared integration-test utilities for Hew"
 publish = false
 
+[dependencies]
+fd-lock = "4"
+
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/hew-testutil/src/lib.rs
+++ b/hew-testutil/src/lib.rs
@@ -1,7 +1,10 @@
 //! Shared integration-test helpers.
 
+use fd_lock::RwLock;
 use std::fmt;
+use std::fs::{self, OpenOptions};
 use std::io::{ErrorKind, Read, Write};
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Output, Stdio};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::time::{Duration, Instant};
@@ -573,6 +576,209 @@ fn truncation_marker() -> String {
 
 fn abandoned_capture_marker(name: &str) -> Vec<u8> {
     format!("\n[{name} capture abandoned after timeout]\n").into_bytes()
+}
+
+/// Serialize `cargo build -p hew-lib` across all parallel nextest processes and
+/// return the resolved static-library path (`libhew.a` / `hew.lib`).
+///
+/// One `fd_lock` write-lock plus a `NEXTEST_RUN_ID`-keyed stamp means the first
+/// caller in a nextest run performs the (fast, Cargo-fingerprinted) build and
+/// every later caller — in any crate — takes the stamped fast path. With no
+/// second writer left, Cargo's non-atomic uplift window can no longer race the
+/// linker's `open()` of `libhew.a`.
+///
+/// # Errors
+///
+/// Returns `Err` if the lock file cannot be opened/locked, if
+/// `cargo build -p hew-lib` fails or cannot be spawned, or if the expected
+/// static-library artifact is missing after a successful build.
+pub fn ensure_hew_lib_built() -> Result<PathBuf, String> {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")) // = <repo>/hew-testutil
+        .parent()
+        .ok_or("hew-testutil must live under the workspace root")?
+        .to_path_buf();
+    let (target_dir, profile) = target_dir_and_profile();
+    let lib_path = target_dir.join(&profile).join(hew_lib_name());
+    ensure_built_serialized(&target_dir, &profile, &lib_path, |td, prof| {
+        run_cargo_build_hew_lib(&repo_root, td, prof)
+    })?;
+    Ok(lib_path)
+}
+
+fn hew_lib_name() -> &'static str {
+    if cfg!(windows) {
+        "hew.lib"
+    } else {
+        "libhew.a"
+    }
+}
+
+/// Testable core: `build_fn` is injected so the unit test can stub `cargo`.
+///
+/// The stamp read, the build, the artifact presence check, and the stamp
+/// write all happen inside the `fd_lock` write guard — no TOCTOU window
+/// between "stamp matches" and "build" and "artifact present". The lock is
+/// intentionally held across `build_fn` (that IS the serialization); the
+/// only hazard would be re-entrancy, which is absent here because `build_fn`
+/// either shells `cargo` as a subprocess or (in tests) only touches files.
+fn ensure_built_serialized(
+    target_dir: &Path,
+    profile: &str,
+    artifact: &Path,
+    build_fn: impl FnOnce(&Path, &str) -> Result<(), String>,
+) -> Result<(), String> {
+    fs::create_dir_all(target_dir).map_err(|e| format!("mkdir {}: {e}", target_dir.display()))?;
+    let run_id =
+        std::env::var("NEXTEST_RUN_ID").unwrap_or_else(|_| format!("pid:{}", std::process::id()));
+    let lock_path = target_dir.join("hew-lib-bootstrap.lock");
+    let stamp_path = target_dir.join(format!("hew-lib-bootstrap-{profile}.stamp"));
+    let fresh = || fs::read_to_string(&stamp_path).is_ok_and(|s| s == run_id) && artifact.is_file();
+    if fresh() {
+        return Ok(()); // pre-lock fast path
+    }
+    let lock_file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|e| format!("open lock {}: {e}", lock_path.display()))?;
+    let mut lock = RwLock::new(lock_file);
+    let _guard = lock
+        .write()
+        .map_err(|e| format!("lock {}: {e}", lock_path.display()))?;
+    if fresh() {
+        return Ok(()); // re-check under lock
+    }
+    build_fn(target_dir, profile)?; // build UNDER the lock (by design)
+    if !artifact.is_file() {
+        return Err(format!(
+            "build succeeded but {} was not created",
+            artifact.display()
+        ));
+    }
+    fs::write(&stamp_path, &run_id)
+        .map_err(|e| format!("write stamp {}: {e}", stamp_path.display()))
+}
+
+fn target_dir_and_profile() -> (PathBuf, String) {
+    if let Ok(exe) = std::env::current_exe() {
+        // <target>/<profile>/deps/<bin>
+        if let Some(profile_dir) = exe.parent().and_then(Path::parent) {
+            if let (Some(p), Some(t)) = (
+                profile_dir.file_name().and_then(|s| s.to_str()),
+                profile_dir.parent(),
+            ) {
+                return (t.to_path_buf(), p.to_string());
+            }
+        }
+    }
+    let target = std::env::var_os("CARGO_TARGET_DIR").map_or_else(
+        || {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .unwrap()
+                .join("target")
+        },
+        PathBuf::from,
+    );
+    (
+        target,
+        if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "release"
+        }
+        .to_string(),
+    )
+}
+
+fn run_cargo_build_hew_lib(
+    repo_root: &Path,
+    target_dir: &Path,
+    profile: &str,
+) -> Result<(), String> {
+    let mut cmd = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()));
+    cmd.args(["build", "-q", "-p", "hew-lib"])
+        .env("CARGO_TARGET_DIR", target_dir)
+        .current_dir(repo_root);
+    match profile {
+        // dev/test both land in target/debug
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
+        }
+        other => {
+            cmd.args(["--profile", other]); // e.g. CI release-lib
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // port verbatim from build_codegen_artifacts
+        let dep = std::env::var("MACOSX_DEPLOYMENT_TARGET")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| "13.0".to_string());
+        cmd.env("MACOSX_DEPLOYMENT_TARGET", dep);
+    }
+    let out = cmd
+        .output()
+        .map_err(|e| format!("spawn cargo build -p hew-lib: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "cargo build -p hew-lib failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod hew_lib_bootstrap_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// N threads race `ensure_built_serialized` on one tempdir; the injected
+    /// build stub must run exactly once (`fd_lock` serializes the writers, the
+    /// stamp fast-path short-circuits everyone after the first winner).
+    #[test]
+    fn concurrent_callers_build_exactly_once() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let target_dir = dir.path().to_path_buf();
+        let artifact = target_dir.join("libhew-stub.a");
+        let build_count = AtomicUsize::new(0);
+
+        std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..8)
+                .map(|_| {
+                    let target_dir = &target_dir;
+                    let artifact = &artifact;
+                    let build_count = &build_count;
+                    scope.spawn(move || {
+                        ensure_built_serialized(target_dir, "debug", artifact, |_td, _prof| {
+                            build_count.fetch_add(1, Ordering::SeqCst);
+                            fs::write(artifact, b"stub archive")
+                                .map_err(|e| format!("write stub artifact: {e}"))
+                        })
+                    })
+                })
+                .collect();
+            for handle in handles {
+                handle
+                    .join()
+                    .expect("bootstrap thread should not panic")
+                    .expect("bootstrap thread should succeed");
+            }
+        });
+
+        assert_eq!(
+            build_count.load(Ordering::SeqCst),
+            1,
+            "build stub should run exactly once across concurrent callers"
+        );
+        assert!(artifact.is_file(), "stub artifact should be present");
+    }
 }
 
 #[cfg(test)]

--- a/hew-testutil/src/lib.rs
+++ b/hew-testutil/src/lib.rs
@@ -230,6 +230,77 @@ fn format_duration(duration: Duration) -> String {
     }
 }
 
+/// Registers a `pre_exec` hook that moves the spawned child into a fresh,
+/// independent process group (`setpgid(0, 0)`) before it execs.
+///
+/// [`run_command_bounded`] applies this internally. Exists as its own public
+/// step for callers that must spawn now and reap later -- e.g. a
+/// barrier-synchronized test harness that spawns several long-lived
+/// children, releases them together, and only then waits -- rather than
+/// `run_command_bounded`'s single spawn-poll-capture-return call. Without
+/// this, killing only the direct child on a later timeout leaves any
+/// grandchild it forked (a `cargo`/linker invocation, say) running and free
+/// to keep mutating a shared artifact after the caller believes the
+/// process is gone.
+///
+/// Must be called before [`Command::spawn`].
+#[cfg(unix)]
+pub fn own_process_group(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+
+    // SAFETY: this runs in the child after fork and before exec. It only
+    // moves the child into a fresh process group so a later group-wide kill
+    // also reaches any grandchild the child itself forks.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setpgid(0, 0) == 0 {
+                Ok(())
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        });
+    }
+}
+
+/// Kills and reaps every process in `child`'s process group (established
+/// via [`own_process_group`]), not just `child` itself, so a grandchild
+/// process cannot outlive the group leader's termination. Returns
+/// `Ok(true)` if the whole group was killed via `killpg`, `Ok(false)` if
+/// `killpg` failed for a reason other than "already gone" (`ESRCH`) and a
+/// direct child-only kill was used as a fallback.
+///
+/// # Errors
+///
+/// Returns `Err` if neither the group kill nor the child-only fallback
+/// succeeds, or if reaping `child` afterward fails.
+#[cfg(unix)]
+pub fn terminate_process_group(child: &mut Child, label: &str) -> Result<bool, String> {
+    let process_group = child.id().cast_signed();
+    // SAFETY: `own_process_group` put the child in a process group whose
+    // PGID is the child's own PID (the group leader). ESRCH means the group
+    // is already gone.
+    let result = unsafe { libc::killpg(process_group, libc::SIGKILL) };
+    let group_killed = if result != 0 {
+        let group_error = std::io::Error::last_os_error();
+        if group_error.raw_os_error() == Some(libc::ESRCH) {
+            true
+        } else {
+            kill_child_only(child, label).map_err(|kill_error| {
+                format!(
+                    "cannot kill process group {process_group}: {group_error}; fallback child kill failed: {kill_error}"
+                )
+            })?;
+            false
+        }
+    } else {
+        true
+    };
+    child
+        .wait()
+        .map_err(|error| format!("cannot reap child after kill: {error}"))?;
+    Ok(group_killed)
+}
+
 #[derive(Debug)]
 struct BoundedChild {
     child: Child,
@@ -240,20 +311,7 @@ struct BoundedChild {
 impl BoundedChild {
     #[cfg(unix)]
     fn spawn(command: &mut Command, label: &str) -> Result<Self, BoundedExecError> {
-        use std::os::unix::process::CommandExt;
-
-        // SAFETY: this runs in the child after fork and before exec. It only
-        // moves the child into a fresh process group so timeout kills also
-        // close pipe handles inherited by grandchildren.
-        unsafe {
-            command.pre_exec(|| {
-                if libc::setpgid(0, 0) == 0 {
-                    Ok(())
-                } else {
-                    Err(std::io::Error::last_os_error())
-                }
-            });
-        }
+        own_process_group(command);
 
         let child = command.spawn().map_err(|error| {
             BoundedExecError::failed(label, format!("cannot spawn child: {error}"))
@@ -306,34 +364,8 @@ impl BoundedChild {
 
     #[cfg(unix)]
     fn terminate_process_group(&mut self, label: &str) -> Result<bool, BoundedExecError> {
-        let process_group = self.child.id().cast_signed();
-        // SAFETY: the helper put the child in a process group whose PGID is the
-        // root PID. ESRCH means the group is already gone.
-        let result = unsafe { libc::killpg(process_group, libc::SIGKILL) };
-        if result != 0 {
-            let group_error = std::io::Error::last_os_error();
-            if group_error.raw_os_error() != Some(libc::ESRCH) {
-                kill_child_only(&mut self.child, label).map_err(|kill_error| {
-                    BoundedExecError::failed(
-                        label,
-                        format!(
-                            "cannot kill process group {process_group}: {group_error}; fallback child kill failed: {kill_error}"
-                        ),
-                    )
-                })?;
-                self.child.wait().map_err(|error| {
-                    BoundedExecError::failed(
-                        label,
-                        format!("cannot reap child after timeout: {error}"),
-                    )
-                })?;
-                return Ok(false);
-            }
-        }
-        self.child.wait().map_err(|error| {
-            BoundedExecError::failed(label, format!("cannot reap child after timeout: {error}"))
-        })?;
-        Ok(true)
+        terminate_process_group(&mut self.child, label)
+            .map_err(|message| BoundedExecError::failed(label, message))
     }
 
     #[cfg(windows)]
@@ -830,6 +862,80 @@ mod tests {
             MAX_CAPTURED_BYTES + marker.len(),
             "stdout should be capped plus the marker"
         );
+    }
+
+    /// Proves the process-group guarantee `libhew_link_race.rs`'s round-3
+    /// hardening depends on: `own_process_group` must put a grandchild the
+    /// direct child forks into the *same* group, and
+    /// `terminate_process_group` must kill that grandchild too, not just
+    /// the direct child -- otherwise a self-fork race child's own
+    /// `cargo`/`hew`/linker invocation could outlive a timeout kill and
+    /// keep mutating `libhew.a` after the caller believes the process is
+    /// gone.
+    #[test]
+    fn terminate_process_group_kills_grandchild_too() {
+        let scratch = tempfile::tempdir().expect("create scratch dir");
+        let pid_file = scratch.path().join("grandchild.pid");
+
+        // The direct child is a non-interactive shell (no job-control
+        // pgid-per-job behavior) that backgrounds a grandchild shell,
+        // which records its own pid and execs into a long sleep, then the
+        // direct child blocks on `wait` -- mirroring a race child that
+        // spawns its own `cargo build -p hew-lib` and waits on it.
+        let mut command = Command::new("sh");
+        command.arg("-c").arg(format!(
+            "sh -c 'echo $$ > \"{path}\"; exec sleep 100' & wait",
+            path = pid_file.display()
+        ));
+        own_process_group(&mut command);
+        let mut child = command.spawn().expect("spawn probe child");
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let grandchild_pid: i32 = loop {
+            if let Ok(text) = fs::read_to_string(&pid_file) {
+                if let Ok(pid) = text.trim().parse() {
+                    break pid;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "grandchild never recorded its pid before the bounded wait expired"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        };
+
+        // SAFETY: signal 0 only probes liveness, it sends nothing.
+        let alive_before_kill = unsafe { libc::kill(grandchild_pid, 0) } == 0;
+        assert!(
+            alive_before_kill,
+            "grandchild should still be alive right before termination"
+        );
+
+        terminate_process_group(&mut child, "probe")
+            .expect("terminate_process_group should succeed");
+
+        // SIGKILL is uncatchable and immediate, but a just-killed process
+        // can briefly remain a reapable zombie (still a valid `kill(pid, 0)`
+        // target) until its new parent -- launchd, once the direct child's
+        // death orphans it -- reaps it. That reap happens promptly but
+        // asynchronously, so the absence proof is a short bounded poll for
+        // ESRCH, not a single immediate check: a real leak (the grandchild
+        // never signalled at all) stays permanently "alive" and fails this
+        // bound for a structural reason, not a timing coincidence.
+        let esrch_deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            // SAFETY: signal 0 only probes liveness, it sends nothing.
+            let alive = unsafe { libc::kill(grandchild_pid, 0) } == 0;
+            if !alive {
+                break;
+            }
+            assert!(
+                Instant::now() < esrch_deadline,
+                "grandchild (pid {grandchild_pid}) outlived terminate_process_group -- \
+                 it was not in the killed process group"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
     }
 }
 

--- a/hew-testutil/src/lib.rs
+++ b/hew-testutil/src/lib.rs
@@ -895,21 +895,61 @@ mod tests {
     /// deadline and fails for a structural reason, not timing luck.
     const POST_KILL_GROWTH_DEADLINE: Duration = Duration::from_secs(5);
 
-    /// Owns the heartbeat probe's direct child and process group from the
-    /// moment it is spawned, so the whole group -- direct child and the
-    /// grandchild it backgrounds -- is always killed and reaped on `Drop`,
-    /// including when a startup wait (`await_min_heartbeats`) or an
-    /// assertion panics before either test method below runs its own
-    /// explicit teardown. `terminate_group`/`kill_direct_child_only` mark
-    /// the direct child as already reaped so `Drop` does not attempt to
-    /// wait on it twice; `Drop` always retries the group-wide `killpg`
-    /// regardless, which is a harmless no-op (`ESRCH`) once the group is
-    /// already gone and is exactly what reclaims the negative control's
-    /// deliberately-orphaned grandchild afterward.
+    /// Lifecycle state for [`HeartbeatProbe`]'s direct child and process
+    /// group, tracked explicitly so `Drop` never signals a pgid number
+    /// after it could plausibly have been recycled by the kernel for an
+    /// unrelated process group.
+    ///
+    /// A process group's numeric pgid cannot be reassigned to a new
+    /// process while *any* process still references it as its own
+    /// group -- so signaling `pgid` is always safe in `Running` (nothing
+    /// has died) and in `LeaderKilledUnreaped` (the leader is a
+    /// still-unreaped zombie, and/or the grandchild is still alive, both
+    /// of which hold the reservation). It stops being safe the instant
+    /// the group is fully empty: leader reaped *and* grandchild reaped,
+    /// which is exactly the state `GroupTerminated` records -- from that
+    /// point on the kernel is free to recycle the number for a completely
+    /// unrelated process group, so `Drop` must not signal it again.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum ProbeState {
+        /// Nothing has been signaled yet.
+        Running,
+        /// `terminate_group` completed successfully: `killpg` (or its
+        /// child-only fallback) succeeded *and* the leader was reaped.
+        /// The group is fully gone; its pgid number is no longer this
+        /// probe's to signal.
+        GroupTerminated,
+        /// The negative control's setup: the leader was killed directly
+        /// but deliberately left unreaped so its PID slot -- and thus the
+        /// group's pgid, which the grandchild also still references --
+        /// stays reserved while the test observes the grandchild's
+        /// heartbeat.
+        LeaderKilledUnreaped,
+    }
+
+    /// Whether `Drop` still needs to signal the group and reap the
+    /// leader for a given lifecycle state. Pulled out as a pure function
+    /// of the state alone so the invariant -- "signal in every state
+    /// except a confirmed complete termination" -- is directly testable
+    /// without spawning any process.
+    fn probe_drop_needs_cleanup(state: ProbeState) -> bool {
+        !matches!(state, ProbeState::GroupTerminated)
+    }
+
+    /// Owns the heartbeat probe's direct child (the process group leader)
+    /// and process group from the moment it is spawned, so the whole
+    /// group -- leader and the grandchild it backgrounds -- is always
+    /// killed and reaped on `Drop`, including when a startup wait
+    /// (`await_min_heartbeats`) or an assertion panics before either test
+    /// method below runs its own explicit teardown. `Drop` consults
+    /// [`ProbeState`] rather than unconditionally re-signaling, because
+    /// once the group has been confirmed fully torn down its pgid number
+    /// may already have been recycled by the kernel for an unrelated
+    /// process.
     struct HeartbeatProbe {
         child: Child,
         pgid: i32,
-        reaped: bool,
+        state: ProbeState,
     }
 
     impl HeartbeatProbe {
@@ -934,44 +974,52 @@ mod tests {
             HeartbeatProbe {
                 child,
                 pgid,
-                reaped: false,
+                state: ProbeState::Running,
             }
         }
 
-        /// Kills the whole process group (direct child and grandchild)
-        /// and reaps the direct child -- the action the positive test
-        /// proves.
+        /// Kills the whole process group (leader and grandchild) and
+        /// reaps the leader -- the action the positive test proves. Only
+        /// transitions to `GroupTerminated` -- and so only tells `Drop`
+        /// to stand down -- when `terminate_process_group` reports full
+        /// success (group cleaned up *and* leader reaped); on failure the
+        /// state is left at `Running` so `Drop` still attempts its own
+        /// best-effort cleanup rather than trusting an unconfirmed
+        /// teardown.
         fn terminate_group(&mut self) -> Result<bool, String> {
             let result = terminate_process_group(&mut self.child, "heartbeat probe");
-            self.reaped = true;
+            if result.is_ok() {
+                self.state = ProbeState::GroupTerminated;
+            }
             result
         }
 
-        /// Kills only the direct child, deliberately leaving the
-        /// grandchild (and thus the process group) running -- the
-        /// negative control's setup step. `Drop` still reclaims the
-        /// orphaned grandchild's group afterward via `killpg`.
-        fn kill_direct_child_only(&mut self) {
-            let _ = self.child.kill();
-            let _ = self.child.wait();
-            self.reaped = true;
+        /// Kills only the leader, deliberately *not* reaping it --
+        /// the negative control's setup step. Leaving the leader a
+        /// zombie (in addition to the grandchild remaining alive) keeps
+        /// this pgid number reserved for the rest of the test; `Drop`
+        /// signals the group and reaps the leader afterward.
+        fn kill_leader_unreaped(&mut self) {
+            self.child.kill().expect("kill leader only");
+            self.state = ProbeState::LeaderKilledUnreaped;
         }
     }
 
     impl Drop for HeartbeatProbe {
         fn drop(&mut self) {
-            // Unconditional, best-effort group cleanup: the panic-safety
-            // backstop for a startup/assertion panic (nothing terminated
-            // yet), the reclaim step for the negative control's
-            // deliberately-orphaned grandchild, and a harmless no-op
-            // (ESRCH) after an already-successful `terminate_group`.
+            if !probe_drop_needs_cleanup(self.state) {
+                return;
+            }
+            // Safe to signal here: in `Running`, nothing has died yet, so
+            // this pgid is still exclusively this probe's; in
+            // `LeaderKilledUnreaped`, the unreaped leader zombie and/or
+            // the still-alive grandchild keep the pgid number reserved,
+            // so it cannot yet have been recycled for an unrelated group.
             // SAFETY: signal-only, no memory access.
             unsafe {
                 libc::killpg(self.pgid, libc::SIGKILL);
             }
-            if !self.reaped {
-                let _ = self.child.wait();
-            }
+            let _ = self.child.wait();
         }
     }
 
@@ -1048,14 +1096,16 @@ mod tests {
         );
     }
 
-    /// Negative control for the test above: killing only the direct child
-    /// (the pre-hardening pattern) must leave the grandchild's process
-    /// group untouched, so its heartbeat keeps growing past the pre-kill
-    /// count -- proving `terminate_process_group_stops_grandchild_heartbeat`
+    /// Negative control for the test above: killing only the leader (the
+    /// pre-hardening pattern) must leave the grandchild's process group
+    /// untouched, so its heartbeat keeps growing past the pre-kill count
+    /// -- proving `terminate_process_group_stops_grandchild_heartbeat`
     /// actually discriminates rather than passing regardless of what the
     /// kill call does. Growth is proven with a bounded poll for that
     /// specific event, not a fixed sleep-then-single-check window, so it
-    /// cannot false-fail under scheduler contention.
+    /// cannot false-fail under scheduler contention. The leader is left
+    /// unreaped (see `ProbeState::LeaderKilledUnreaped`) for the whole
+    /// growth check, then reclaimed by `Drop`.
     #[test]
     fn direct_child_only_kill_leaves_grandchild_heartbeating() {
         let scratch = tempfile::tempdir().expect("create scratch dir");
@@ -1069,7 +1119,7 @@ mod tests {
             HEARTBEAT_STARTUP_DEADLINE,
         );
 
-        probe.kill_direct_child_only();
+        probe.kill_leader_unreaped();
         let count_at_kill = heartbeat_count(&heartbeat_path);
 
         let count_after_growth = await_min_heartbeats(
@@ -1085,8 +1135,37 @@ mod tests {
              the grandchild surviving, or the positive test above proves nothing"
         );
 
-        // `probe`'s Drop reclaims the deliberately-orphaned grandchild's
-        // process group via killpg.
+        // `probe`'s Drop signals the group (still safe: the unreaped
+        // leader zombie and the live grandchild both hold the pgid
+        // reservation) and reaps the leader.
+    }
+
+    /// Lifecycle/PID-state invariant: `Drop` must re-signal the group in
+    /// every state where the pgid could still plausibly be this probe's
+    /// (nothing killed yet, or the leader/grandchild still hold the
+    /// reservation as a zombie/live process), and must NOT re-signal once
+    /// a `terminate_group` call has confirmed the group fully torn down
+    /// -- past that point the pgid number may already belong to an
+    /// unrelated process group recycled by the kernel, and signaling it
+    /// would be a real, high-severity foot-gun. This is a pure function
+    /// of the state alone, so the invariant is checked directly without
+    /// spawning any process or depending on any timing.
+    #[test]
+    fn probe_drop_cleanup_gated_by_confirmed_full_termination() {
+        assert!(
+            probe_drop_needs_cleanup(ProbeState::Running),
+            "nothing has been signaled yet -- Drop must still clean up"
+        );
+        assert!(
+            probe_drop_needs_cleanup(ProbeState::LeaderKilledUnreaped),
+            "the unreaped leader zombie and/or live grandchild still hold this pgid \
+             reserved -- Drop must still signal and reap"
+        );
+        assert!(
+            !probe_drop_needs_cleanup(ProbeState::GroupTerminated),
+            "the group was already fully killed and reaped -- Drop must NOT re-signal \
+             a pgid the kernel may have already recycled for an unrelated process group"
+        );
     }
 }
 

--- a/hew-testutil/src/lib.rs
+++ b/hew-testutil/src/lib.rs
@@ -875,29 +875,104 @@ mod tests {
     /// Bounds waiting for the grandchild to start heart-beating at all --
     /// a hang backstop, not the proof itself.
     const HEARTBEAT_STARTUP_DEADLINE: Duration = Duration::from_secs(5);
-    /// Fixed, single observation window used after a kill: fifteen
-    /// heartbeat intervals is generous enough that any straggler write
-    /// would clearly show up. The proof is one comparison taken after this
-    /// fixed wait, never a retry loop that treats eventual convergence as
-    /// evidence.
-    const POST_KILL_OBSERVATION_WINDOW: Duration = Duration::from_millis(300);
+    /// Post-kill settling window for the positive test: `killpg` is
+    /// immediate, but a write the grandchild had already entered before
+    /// the signal landed can still complete afterward. Waiting this long
+    /// before taking the "final" baseline absorbs that race so a
+    /// straggling in-flight write is never mistaken for survival.
+    const POST_KILL_SETTLE_WINDOW: Duration = Duration::from_millis(200);
+    /// Fixed stability window checked *after* settling: the positive
+    /// test's proof is that the count taken after this wait matches the
+    /// settled baseline exactly, not that it merely stayed below some
+    /// threshold -- so any genuine straggler write still fails it.
+    const POST_KILL_STABILITY_WINDOW: Duration = Duration::from_millis(300);
+    /// Bounds the negative control's wait for the *specific event* of
+    /// further heartbeat growth -- a hang backstop for a deterministic
+    /// bounded poll, not a fixed sleep-then-single-check window: a
+    /// genuinely surviving grandchild grows past the pre-kill count well
+    /// within this bound regardless of scheduler jitter, while a broken
+    /// negative control (grandchild actually died too) hangs until the
+    /// deadline and fails for a structural reason, not timing luck.
+    const POST_KILL_GROWTH_DEADLINE: Duration = Duration::from_secs(5);
 
-    /// Spawns a direct child that backgrounds a grandchild shell
-    /// heart-beating (appending one byte to `heartbeat_path` every
-    /// `HEARTBEAT_INTERVAL`) and blocks on `wait` -- mirroring a race
-    /// child that spawns its own long-running `cargo`/`hew` subprocess and
-    /// waits on it. `own_process_group` repositions the direct child into
-    /// a fresh process group before it execs, so the grandchild it forks
-    /// afterward inherits that same group.
-    fn spawn_heartbeat_probe(heartbeat_path: &Path) -> Child {
-        let mut command = Command::new("sh");
-        command.arg("-c").arg(format!(
-            "sh -c 'while :; do printf x >> \"{path}\"; sleep {interval}; done' & wait",
-            path = heartbeat_path.display(),
-            interval = HEARTBEAT_INTERVAL.as_secs_f64(),
-        ));
-        own_process_group(&mut command);
-        command.spawn().expect("spawn heartbeat probe child")
+    /// Owns the heartbeat probe's direct child and process group from the
+    /// moment it is spawned, so the whole group -- direct child and the
+    /// grandchild it backgrounds -- is always killed and reaped on `Drop`,
+    /// including when a startup wait (`await_min_heartbeats`) or an
+    /// assertion panics before either test method below runs its own
+    /// explicit teardown. `terminate_group`/`kill_direct_child_only` mark
+    /// the direct child as already reaped so `Drop` does not attempt to
+    /// wait on it twice; `Drop` always retries the group-wide `killpg`
+    /// regardless, which is a harmless no-op (`ESRCH`) once the group is
+    /// already gone and is exactly what reclaims the negative control's
+    /// deliberately-orphaned grandchild afterward.
+    struct HeartbeatProbe {
+        child: Child,
+        pgid: i32,
+        reaped: bool,
+    }
+
+    impl HeartbeatProbe {
+        /// Spawns a direct child that backgrounds a grandchild shell
+        /// heart-beating (appending one byte to `heartbeat_path` every
+        /// `HEARTBEAT_INTERVAL`) and blocks on `wait` -- mirroring a race
+        /// child that spawns its own long-running `cargo`/`hew`
+        /// subprocess and waits on it. `own_process_group` repositions
+        /// the direct child into a fresh process group before it execs,
+        /// so the grandchild it forks afterward inherits that same
+        /// group.
+        fn spawn(heartbeat_path: &Path) -> Self {
+            let mut command = Command::new("sh");
+            command.arg("-c").arg(format!(
+                "sh -c 'while :; do printf x >> \"{path}\"; sleep {interval}; done' & wait",
+                path = heartbeat_path.display(),
+                interval = HEARTBEAT_INTERVAL.as_secs_f64(),
+            ));
+            own_process_group(&mut command);
+            let child = command.spawn().expect("spawn heartbeat probe child");
+            let pgid = child.id().cast_signed();
+            HeartbeatProbe {
+                child,
+                pgid,
+                reaped: false,
+            }
+        }
+
+        /// Kills the whole process group (direct child and grandchild)
+        /// and reaps the direct child -- the action the positive test
+        /// proves.
+        fn terminate_group(&mut self) -> Result<bool, String> {
+            let result = terminate_process_group(&mut self.child, "heartbeat probe");
+            self.reaped = true;
+            result
+        }
+
+        /// Kills only the direct child, deliberately leaving the
+        /// grandchild (and thus the process group) running -- the
+        /// negative control's setup step. `Drop` still reclaims the
+        /// orphaned grandchild's group afterward via `killpg`.
+        fn kill_direct_child_only(&mut self) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+            self.reaped = true;
+        }
+    }
+
+    impl Drop for HeartbeatProbe {
+        fn drop(&mut self) {
+            // Unconditional, best-effort group cleanup: the panic-safety
+            // backstop for a startup/assertion panic (nothing terminated
+            // yet), the reclaim step for the negative control's
+            // deliberately-orphaned grandchild, and a harmless no-op
+            // (ESRCH) after an already-successful `terminate_group`.
+            // SAFETY: signal-only, no memory access.
+            unsafe {
+                libc::killpg(self.pgid, libc::SIGKILL);
+            }
+            if !self.reaped {
+                let _ = self.child.wait();
+            }
+        }
     }
 
     /// Heartbeat count so far: each beat appends exactly one byte, so the
@@ -947,73 +1022,71 @@ mod tests {
         let heartbeat_path = scratch.path().join("heartbeat");
         fs::write(&heartbeat_path, b"").expect("create heartbeat file");
 
-        let mut child = spawn_heartbeat_probe(&heartbeat_path);
+        let mut probe = HeartbeatProbe::spawn(&heartbeat_path);
         await_min_heartbeats(
             &heartbeat_path,
             MIN_HEARTBEATS_BEFORE_ACTION,
             HEARTBEAT_STARTUP_DEADLINE,
         );
 
-        terminate_process_group(&mut child, "heartbeat probe")
+        probe
+            .terminate_group()
             .expect("terminate_process_group should succeed");
-        let count_at_kill = heartbeat_count(&heartbeat_path);
 
-        std::thread::sleep(POST_KILL_OBSERVATION_WINDOW);
-        let count_after_window = heartbeat_count(&heartbeat_path);
+        // Let any write already in flight when the signal landed finish
+        // before treating a reading as the settled baseline.
+        std::thread::sleep(POST_KILL_SETTLE_WINDOW);
+        let settled_baseline = heartbeat_count(&heartbeat_path);
+
+        std::thread::sleep(POST_KILL_STABILITY_WINDOW);
+        let after_stability_window = heartbeat_count(&heartbeat_path);
 
         assert_eq!(
-            count_after_window, count_at_kill,
-            "heartbeat grew from {count_at_kill} to {count_after_window} bytes after \
-             terminate_process_group -- the grandchild survived the group kill"
+            after_stability_window, settled_baseline,
+            "heartbeat grew from {settled_baseline} to {after_stability_window} bytes \
+             after settling -- the grandchild survived terminate_process_group"
         );
     }
 
     /// Negative control for the test above: killing only the direct child
     /// (the pre-hardening pattern) must leave the grandchild's process
-    /// group untouched, so its heartbeat keeps growing across the same
-    /// observation window -- proving
-    /// `terminate_process_group_stops_grandchild_heartbeat` actually
-    /// discriminates rather than passing regardless of what the kill call
-    /// does.
+    /// group untouched, so its heartbeat keeps growing past the pre-kill
+    /// count -- proving `terminate_process_group_stops_grandchild_heartbeat`
+    /// actually discriminates rather than passing regardless of what the
+    /// kill call does. Growth is proven with a bounded poll for that
+    /// specific event, not a fixed sleep-then-single-check window, so it
+    /// cannot false-fail under scheduler contention.
     #[test]
     fn direct_child_only_kill_leaves_grandchild_heartbeating() {
         let scratch = tempfile::tempdir().expect("create scratch dir");
         let heartbeat_path = scratch.path().join("heartbeat");
         fs::write(&heartbeat_path, b"").expect("create heartbeat file");
 
-        let mut child = spawn_heartbeat_probe(&heartbeat_path);
+        let mut probe = HeartbeatProbe::spawn(&heartbeat_path);
         await_min_heartbeats(
             &heartbeat_path,
             MIN_HEARTBEATS_BEFORE_ACTION,
             HEARTBEAT_STARTUP_DEADLINE,
         );
 
-        // Recorded only for best-effort cleanup below, never for the
-        // proof itself: `own_process_group` made this the whole group's
-        // pgid too, but a direct-child-only kill deliberately never uses
-        // it as a group here.
-        let cleanup_pgid = child.id().cast_signed();
-
-        child.kill().expect("kill direct child only");
-        child.wait().expect("reap direct child");
+        probe.kill_direct_child_only();
         let count_at_kill = heartbeat_count(&heartbeat_path);
 
-        std::thread::sleep(POST_KILL_OBSERVATION_WINDOW);
-        let count_after_window = heartbeat_count(&heartbeat_path);
-
-        assert!(
-            count_after_window > count_at_kill,
-            "heartbeat did not grow ({count_at_kill} -> {count_after_window}) after a \
-             direct-child-only kill; this negative control should show the grandchild \
-             surviving, or the positive test above proves nothing"
+        let count_after_growth = await_min_heartbeats(
+            &heartbeat_path,
+            count_at_kill + 1,
+            POST_KILL_GROWTH_DEADLINE,
         );
 
-        // Best-effort cleanup of the grandchild this negative control
-        // deliberately leaves running; ESRCH means it is already gone.
-        // SAFETY: signal-only, no memory access.
-        unsafe {
-            libc::killpg(cleanup_pgid, libc::SIGKILL);
-        }
+        assert!(
+            count_after_growth > count_at_kill,
+            "heartbeat did not grow past {count_at_kill} bytes within the bounded \
+             deadline after a direct-child-only kill; this negative control should show \
+             the grandchild surviving, or the positive test above proves nothing"
+        );
+
+        // `probe`'s Drop reclaims the deliberately-orphaned grandchild's
+        // process group via killpg.
     }
 }
 

--- a/hew-testutil/src/lib.rs
+++ b/hew-testutil/src/lib.rs
@@ -864,77 +864,155 @@ mod tests {
         );
     }
 
-    /// Proves the process-group guarantee `libhew_link_race.rs`'s round-3
-    /// hardening depends on: `own_process_group` must put a grandchild the
-    /// direct child forks into the *same* group, and
-    /// `terminate_process_group` must kill that grandchild too, not just
+    /// Heartbeat interval used by the process-group probe tests below --
+    /// fast enough to observe several beats quickly, slow enough to keep
+    /// the probe's own I/O negligible.
+    const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(20);
+    /// How many heartbeats must be observed before either probe acts,
+    /// proving the grandchild is genuinely alive and pumping repeatedly --
+    /// not a single write that could race the read.
+    const MIN_HEARTBEATS_BEFORE_ACTION: u64 = 3;
+    /// Bounds waiting for the grandchild to start heart-beating at all --
+    /// a hang backstop, not the proof itself.
+    const HEARTBEAT_STARTUP_DEADLINE: Duration = Duration::from_secs(5);
+    /// Fixed, single observation window used after a kill: fifteen
+    /// heartbeat intervals is generous enough that any straggler write
+    /// would clearly show up. The proof is one comparison taken after this
+    /// fixed wait, never a retry loop that treats eventual convergence as
+    /// evidence.
+    const POST_KILL_OBSERVATION_WINDOW: Duration = Duration::from_millis(300);
+
+    /// Spawns a direct child that backgrounds a grandchild shell
+    /// heart-beating (appending one byte to `heartbeat_path` every
+    /// `HEARTBEAT_INTERVAL`) and blocks on `wait` -- mirroring a race
+    /// child that spawns its own long-running `cargo`/`hew` subprocess and
+    /// waits on it. `own_process_group` repositions the direct child into
+    /// a fresh process group before it execs, so the grandchild it forks
+    /// afterward inherits that same group.
+    fn spawn_heartbeat_probe(heartbeat_path: &Path) -> Child {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg(format!(
+            "sh -c 'while :; do printf x >> \"{path}\"; sleep {interval}; done' & wait",
+            path = heartbeat_path.display(),
+            interval = HEARTBEAT_INTERVAL.as_secs_f64(),
+        ));
+        own_process_group(&mut command);
+        command.spawn().expect("spawn heartbeat probe child")
+    }
+
+    /// Heartbeat count so far: each beat appends exactly one byte, so the
+    /// file's length is the count directly -- no parsing, and no races
+    /// beyond ordinary single-writer append semantics.
+    fn heartbeat_count(path: &Path) -> u64 {
+        fs::metadata(path).map_or(0, |metadata| metadata.len())
+    }
+
+    /// Bounded wait (a hang backstop, not the proof) for at least `min`
+    /// heartbeats to accumulate.
+    fn await_min_heartbeats(path: &Path, min: u64, deadline: Duration) -> u64 {
+        let start = Instant::now();
+        loop {
+            let count = heartbeat_count(path);
+            if count >= min {
+                return count;
+            }
+            assert!(
+                start.elapsed() < deadline,
+                "heartbeat probe never reached {min} beats before the startup deadline"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    /// Proves the process-group guarantee `libhew_link_race.rs`'s
+    /// hardening depends on with a portable, observable side effect
+    /// instead of PID liveness probing (which is prone to a just-killed
+    /// process briefly remaining a valid `kill(pid, 0)` target as a
+    /// zombie pending reap by its new parent): `own_process_group` must
+    /// put a grandchild the direct child forks into the *same* group, and
+    /// `terminate_process_group` must stop that grandchild too, not just
     /// the direct child -- otherwise a self-fork race child's own
     /// `cargo`/`hew`/linker invocation could outlive a timeout kill and
     /// keep mutating `libhew.a` after the caller believes the process is
     /// gone.
+    ///
+    /// `direct_child_only_kill_leaves_grandchild_heartbeating` below is
+    /// this test's negative control: the identical setup, killed the old
+    /// (direct-child-only) way, keeps heart-beating -- proving this test
+    /// actually discriminates rather than passing regardless of what the
+    /// kill call does.
     #[test]
-    fn terminate_process_group_kills_grandchild_too() {
+    fn terminate_process_group_stops_grandchild_heartbeat() {
         let scratch = tempfile::tempdir().expect("create scratch dir");
-        let pid_file = scratch.path().join("grandchild.pid");
+        let heartbeat_path = scratch.path().join("heartbeat");
+        fs::write(&heartbeat_path, b"").expect("create heartbeat file");
 
-        // The direct child is a non-interactive shell (no job-control
-        // pgid-per-job behavior) that backgrounds a grandchild shell,
-        // which records its own pid and execs into a long sleep, then the
-        // direct child blocks on `wait` -- mirroring a race child that
-        // spawns its own `cargo build -p hew-lib` and waits on it.
-        let mut command = Command::new("sh");
-        command.arg("-c").arg(format!(
-            "sh -c 'echo $$ > \"{path}\"; exec sleep 100' & wait",
-            path = pid_file.display()
-        ));
-        own_process_group(&mut command);
-        let mut child = command.spawn().expect("spawn probe child");
-
-        let deadline = Instant::now() + Duration::from_secs(10);
-        let grandchild_pid: i32 = loop {
-            if let Ok(text) = fs::read_to_string(&pid_file) {
-                if let Ok(pid) = text.trim().parse() {
-                    break pid;
-                }
-            }
-            assert!(
-                Instant::now() < deadline,
-                "grandchild never recorded its pid before the bounded wait expired"
-            );
-            std::thread::sleep(Duration::from_millis(5));
-        };
-
-        // SAFETY: signal 0 only probes liveness, it sends nothing.
-        let alive_before_kill = unsafe { libc::kill(grandchild_pid, 0) } == 0;
-        assert!(
-            alive_before_kill,
-            "grandchild should still be alive right before termination"
+        let mut child = spawn_heartbeat_probe(&heartbeat_path);
+        await_min_heartbeats(
+            &heartbeat_path,
+            MIN_HEARTBEATS_BEFORE_ACTION,
+            HEARTBEAT_STARTUP_DEADLINE,
         );
 
-        terminate_process_group(&mut child, "probe")
+        terminate_process_group(&mut child, "heartbeat probe")
             .expect("terminate_process_group should succeed");
+        let count_at_kill = heartbeat_count(&heartbeat_path);
 
-        // SIGKILL is uncatchable and immediate, but a just-killed process
-        // can briefly remain a reapable zombie (still a valid `kill(pid, 0)`
-        // target) until its new parent -- launchd, once the direct child's
-        // death orphans it -- reaps it. That reap happens promptly but
-        // asynchronously, so the absence proof is a short bounded poll for
-        // ESRCH, not a single immediate check: a real leak (the grandchild
-        // never signalled at all) stays permanently "alive" and fails this
-        // bound for a structural reason, not a timing coincidence.
-        let esrch_deadline = Instant::now() + Duration::from_secs(2);
-        loop {
-            // SAFETY: signal 0 only probes liveness, it sends nothing.
-            let alive = unsafe { libc::kill(grandchild_pid, 0) } == 0;
-            if !alive {
-                break;
-            }
-            assert!(
-                Instant::now() < esrch_deadline,
-                "grandchild (pid {grandchild_pid}) outlived terminate_process_group -- \
-                 it was not in the killed process group"
-            );
-            std::thread::sleep(Duration::from_millis(5));
+        std::thread::sleep(POST_KILL_OBSERVATION_WINDOW);
+        let count_after_window = heartbeat_count(&heartbeat_path);
+
+        assert_eq!(
+            count_after_window, count_at_kill,
+            "heartbeat grew from {count_at_kill} to {count_after_window} bytes after \
+             terminate_process_group -- the grandchild survived the group kill"
+        );
+    }
+
+    /// Negative control for the test above: killing only the direct child
+    /// (the pre-hardening pattern) must leave the grandchild's process
+    /// group untouched, so its heartbeat keeps growing across the same
+    /// observation window -- proving
+    /// `terminate_process_group_stops_grandchild_heartbeat` actually
+    /// discriminates rather than passing regardless of what the kill call
+    /// does.
+    #[test]
+    fn direct_child_only_kill_leaves_grandchild_heartbeating() {
+        let scratch = tempfile::tempdir().expect("create scratch dir");
+        let heartbeat_path = scratch.path().join("heartbeat");
+        fs::write(&heartbeat_path, b"").expect("create heartbeat file");
+
+        let mut child = spawn_heartbeat_probe(&heartbeat_path);
+        await_min_heartbeats(
+            &heartbeat_path,
+            MIN_HEARTBEATS_BEFORE_ACTION,
+            HEARTBEAT_STARTUP_DEADLINE,
+        );
+
+        // Recorded only for best-effort cleanup below, never for the
+        // proof itself: `own_process_group` made this the whole group's
+        // pgid too, but a direct-child-only kill deliberately never uses
+        // it as a group here.
+        let cleanup_pgid = child.id().cast_signed();
+
+        child.kill().expect("kill direct child only");
+        child.wait().expect("reap direct child");
+        let count_at_kill = heartbeat_count(&heartbeat_path);
+
+        std::thread::sleep(POST_KILL_OBSERVATION_WINDOW);
+        let count_after_window = heartbeat_count(&heartbeat_path);
+
+        assert!(
+            count_after_window > count_at_kill,
+            "heartbeat did not grow ({count_at_kill} -> {count_after_window}) after a \
+             direct-child-only kill; this negative control should show the grandchild \
+             surviving, or the positive test above proves nothing"
+        );
+
+        // Best-effort cleanup of the grandchild this negative control
+        // deliberately leaves running; ESRCH means it is already gone.
+        // SAFETY: signal-only, no memory access.
+        unsafe {
+            libc::killpg(cleanup_pgid, libc::SIGKILL);
         }
     }
 }

--- a/hew-testutil/src/lib.rs
+++ b/hew-testutil/src/lib.rs
@@ -914,10 +914,17 @@ mod tests {
     enum ProbeState {
         /// Nothing has been signaled yet.
         Running,
-        /// `terminate_group` completed successfully: `killpg` (or its
-        /// child-only fallback) succeeded *and* the leader was reaped.
-        /// The group is fully gone; its pgid number is no longer this
-        /// probe's to signal.
+        /// `terminate_group` confirmed the whole group gone (`killpg`
+        /// itself succeeded, or failed with `ESRCH` -- already empty)
+        /// *and* reaped the leader. The group is fully gone; its pgid
+        /// number is no longer this probe's to signal.
+        ///
+        /// This is deliberately never reached by a partial ("leader-only")
+        /// kill: unlike the general-purpose [`terminate_process_group`]
+        /// helper, this probe has no child-only fallback, because a
+        /// fallback kill leaves the grandchild's fate unconfirmed and
+        /// `GroupTerminated` must mean the grandchild is provably gone
+        /// too, not just "we gave up trying to kill the whole group".
         GroupTerminated,
         /// The negative control's setup: the leader was killed directly
         /// but deliberately left unreaped so its PID slot -- and thus the
@@ -934,6 +941,32 @@ mod tests {
     /// without spawning any process.
     fn probe_drop_needs_cleanup(state: ProbeState) -> bool {
         !matches!(state, ProbeState::GroupTerminated)
+    }
+
+    /// Classifies a raw `killpg` result against the one distinction that
+    /// matters for [`HeartbeatProbe::terminate_group`]: did this call
+    /// confirm the group is gone, or might it still be alive? Takes the
+    /// syscall's return value and captured `errno` as plain parameters
+    /// (rather than reading `io::Error::last_os_error()` itself) so the
+    /// decision is a pure function directly testable against an injected
+    /// failure, without depending on global errno state at the moment the
+    /// test runs.
+    ///
+    /// `Ok(())` means confirmed gone (the call succeeded, or failed with
+    /// `ESRCH` because the group was already empty). Any other failure is
+    /// `Err` -- the group, and thus a still-heart-beating grandchild, may
+    /// well be alive, so the caller must not treat this as termination.
+    fn classify_killpg_result(result: i32, pgid: i32, os_error: Option<i32>) -> Result<(), String> {
+        if result == 0 {
+            return Ok(());
+        }
+        if os_error == Some(libc::ESRCH) {
+            Ok(())
+        } else {
+            Err(format!(
+                "cannot kill process group {pgid}: os error {os_error:?}"
+            ))
+        }
     }
 
     /// Owns the heartbeat probe's direct child (the process group leader)
@@ -979,19 +1012,35 @@ mod tests {
         }
 
         /// Kills the whole process group (leader and grandchild) and
-        /// reaps the leader -- the action the positive test proves. Only
-        /// transitions to `GroupTerminated` -- and so only tells `Drop`
-        /// to stand down -- when `terminate_process_group` reports full
-        /// success (group cleaned up *and* leader reaped); on failure the
-        /// state is left at `Running` so `Drop` still attempts its own
-        /// best-effort cleanup rather than trusting an unconfirmed
-        /// teardown.
-        fn terminate_group(&mut self) -> Result<bool, String> {
-            let result = terminate_process_group(&mut self.child, "heartbeat probe");
-            if result.is_ok() {
-                self.state = ProbeState::GroupTerminated;
-            }
-            result
+        /// reaps the leader -- the action the positive test proves.
+        /// Deliberately does not call the crate's general-purpose
+        /// [`terminate_process_group`] helper: that helper falls back to
+        /// a leader-only kill (and still reaps the leader) when `killpg`
+        /// fails for a real reason, which would let this probe declare
+        /// `GroupTerminated` -- and so tell `Drop` to stand down -- while
+        /// the grandchild might still be heart-beating. This probe only
+        /// ever transitions to `GroupTerminated` after
+        /// [`classify_killpg_result`] confirms the group itself is gone
+        /// *and* the leader has been reaped; on any other outcome the
+        /// leader is left unreaped and the state stays `Running`, so
+        /// `Drop` still safely retries -- the group's pgid is still
+        /// this probe's own until that confirmation happens.
+        fn terminate_group(&mut self) -> Result<(), String> {
+            // SAFETY: signal-only, no memory access. `own_process_group`
+            // put the leader in a process group whose pgid is the
+            // leader's own pid.
+            let result = unsafe { libc::killpg(self.pgid, libc::SIGKILL) };
+            let os_error = if result == 0 {
+                None
+            } else {
+                std::io::Error::last_os_error().raw_os_error()
+            };
+            classify_killpg_result(result, self.pgid, os_error)?;
+            self.child.wait().map_err(|error| {
+                format!("cannot reap heartbeat probe leader after kill: {error}")
+            })?;
+            self.state = ProbeState::GroupTerminated;
+            Ok(())
         }
 
         /// Kills only the leader, deliberately *not* reaping it --
@@ -1165,6 +1214,54 @@ mod tests {
             !probe_drop_needs_cleanup(ProbeState::GroupTerminated),
             "the group was already fully killed and reaped -- Drop must NOT re-signal \
              a pgid the kernel may have already recycled for an unrelated process group"
+        );
+    }
+
+    /// `classify_killpg_result` on synthetic inputs: success and `ESRCH`
+    /// both confirm the group gone, and no other `errno` value may be
+    /// mistaken for that -- the exact decision `terminate_group` relies
+    /// on to gate the `GroupTerminated` transition.
+    #[test]
+    fn classify_killpg_result_only_confirms_gone_on_success_or_esrch() {
+        assert!(classify_killpg_result(0, 4242, None).is_ok());
+        assert!(classify_killpg_result(-1, 4242, Some(libc::ESRCH)).is_ok());
+        assert!(classify_killpg_result(-1, 4242, Some(libc::EPERM)).is_err());
+        assert!(classify_killpg_result(-1, 4242, Some(libc::EINVAL)).is_err());
+        assert!(classify_killpg_result(-1, 4242, None).is_err());
+    }
+
+    /// `classify_killpg_result` against a real, injected `killpg` failure
+    /// rather than a synthetic `errno` value: signal `0` delivers nothing
+    /// (a pure permission/existence probe), and process group `1`
+    /// (init/launchd) is a group an unprivileged test process is never
+    /// permitted to signal, so this deterministically produces a genuine
+    /// `EPERM` without ever touching any real process. Proves the
+    /// classifier treats a real "denied" failure as "group might still be
+    /// alive", never as "confirmed gone" -- the distinction that keeps
+    /// `terminate_group` from ever declaring a heart-beating grandchild
+    /// terminated just because the kill attempt was refused.
+    #[test]
+    fn classify_killpg_result_rejects_a_real_injected_permission_failure() {
+        // SAFETY: signal 0 delivers no signal; this only probes whether
+        // the calling process is permitted to signal process group 1.
+        let result = unsafe { libc::killpg(1, 0) };
+        if result == 0 {
+            // Running with a privilege level that can signal init (e.g.
+            // root) -- this environment cannot exercise a real denial, so
+            // there is nothing further to assert here; the synthetic-input
+            // test above already covers the EPERM branch directly.
+            return;
+        }
+        let os_error = std::io::Error::last_os_error().raw_os_error();
+        assert_eq!(
+            os_error,
+            Some(libc::EPERM),
+            "expected a permission-denied failure signaling process group 1, got {os_error:?}"
+        );
+        assert!(
+            classify_killpg_result(result, 1, os_error).is_err(),
+            "a real signal-denied failure must never be classified as the group already \
+             being gone"
         );
     }
 }

--- a/hew-testutil/tests/libhew_link_race.rs
+++ b/hew-testutil/tests/libhew_link_race.rs
@@ -29,16 +29,25 @@
 //!    zero of either failure kind.
 //! 3. **A real, acknowledged, bounded barrier -- and a diagnostic, not
 //!    mandatory, negative control.** Every spawned writer/reader/poller
-//!    signals readiness (about to block on the shared barrier) before the
-//!    orchestrator releases it, bounded by a deadline so a child that fails
-//!    to start fails the test loudly instead of hanging forever. Real link
-//!    operations and child reaps are themselves deadline-bounded, and
-//!    cleanup (killing stragglers, signalling any stop file) always runs on
-//!    the way out, including through a panic. The unlocked arm's poll-based
-//!    absence observation is scheduler-timing-dependent, not a structural
-//!    guarantee, so it is reported as a diagnostic rather than asserted;
-//!    the deterministic proof lives entirely in the gated arm's structural
-//!    (lock-exclusion) guarantees.
+//!    proves it is genuinely contending for the shared barrier lock (a
+//!    non-blocking probe observing the orchestrator's held write-lock)
+//!    before signalling readiness, and the orchestrator releases the
+//!    barrier only after every such acknowledgement, bounded by a deadline
+//!    so a child that fails to start fails the test loudly instead of
+//!    hanging forever. Real link operations and child reaps are themselves
+//!    deadline-bounded, and cleanup (killing stragglers, signalling any stop
+//!    file) always runs on the way out, including through a panic. The
+//!    unlocked arm's poll-based absence observation is scheduler-timing-
+//!    dependent, not a structural guarantee, so it is reported as a
+//!    diagnostic rather than asserted; the deterministic proof lives
+//!    entirely in the gated arm's structural (lock-exclusion) guarantees.
+//! 4. **No descendant outlives its process group.** Every self-fork race
+//!    child and every bounded real `cargo`/`hew` invocation runs in its own
+//!    fresh Unix process group (`hew_testutil::own_process_group`); timeout
+//!    or drop-time cleanup kills the whole group
+//!    (`hew_testutil::terminate_process_group`), not just the direct child,
+//!    so a `cargo`/linker grandchild can never keep mutating `libhew.a`
+//!    after the parent or its lock guard is gone.
 //!
 //! None of the above uses a sleep, or a retry-until-pass loop, as proof.
 //! Bounded polling for readiness/deadlines exists only as a hang backstop.
@@ -49,20 +58,21 @@
 //! proving gates that should not gate routine `cargo nextest run`.
 //!
 //! Unix-only: the fixed writer/reader roles shell real `cargo`/`hew`
-//! subprocesses, chmod a spy wrapper, and use `fd_lock`-based barriers
-//! exactly like `ensure_hew_lib_built` itself; Windows uses a different
-//! static-lib name (`hew.lib`) and MSVC link semantics the plan's grounded
-//! evidence (clang's `no such file or directory` signature) does not cover.
-//! This mirrors the existing `#[cfg(unix)]` gate elsewhere in this crate for
-//! the same class of heavy real-process repro.
+//! subprocesses, chmod a spy wrapper, use `fd_lock`-based barriers exactly
+//! like `ensure_hew_lib_built` itself, and rely on `setpgid`/`killpg`
+//! process-group semantics; Windows uses a different static-lib name
+//! (`hew.lib`) and MSVC link semantics the plan's grounded evidence (clang's
+//! `no such file or directory` signature) does not cover. This mirrors the
+//! existing `#[cfg(unix)]` gate elsewhere in this crate for the same class
+//! of heavy real-process repro.
 #![cfg(unix)]
 
 use std::env;
 use std::fs::{self, OpenOptions};
-use std::io::Read;
+use std::io::ErrorKind;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, ExitStatus, Stdio};
+use std::process::{Child, Command, ExitStatus};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
@@ -237,63 +247,29 @@ enum Classification {
     Unexpected(String),
 }
 
-/// Runs `cmd` to completion, piping stdout/stderr and returning them
-/// alongside the exit status, but never blocking past `deadline`: a child
-/// that overruns is killed (not left to finish on its own clock) and
-/// reported as an error. This is a hang backstop, not the race's proof --
-/// `LINK_DEADLINE`/`CHILD_WAIT_DEADLINE` are generous multiples of observed
-/// real link/build time.
-fn wait_piped_with_deadline(
-    mut child: Child,
-    deadline: Duration,
-) -> Result<(ExitStatus, String, String), String> {
-    let mut stdout = child.stdout.take().expect("stdout piped");
-    let mut stderr = child.stderr.take().expect("stderr piped");
-    let stdout_thread = thread::spawn(move || {
-        let mut buf = String::new();
-        let _ = stdout.read_to_string(&mut buf);
-        buf
-    });
-    let stderr_thread = thread::spawn(move || {
-        let mut buf = String::new();
-        let _ = stderr.read_to_string(&mut buf);
-        buf
-    });
-    let status = wait_with_deadline(&mut child, deadline)?;
-    let out = stdout_thread
-        .join()
-        .unwrap_or_else(|_| "[stdout reader thread panicked]".to_string());
-    let err = stderr_thread
-        .join()
-        .unwrap_or_else(|_| "[stderr reader thread panicked]".to_string());
-    Ok((status, out, err))
-}
-
 /// A real consumer link: `hew compile` on a trivial fixture. Exercises the
 /// production path (`find_hew_lib` + `link_executable`, clang/cc) that the
 /// plan's grounded evidence's `clang: error: no such file or directory:
-/// '.../libhew.a'` signature comes from. Deadline-bound: a hung linker
-/// fails the attempt instead of hanging the whole test.
+/// '.../libhew.a'` signature comes from. Runs through
+/// `hew_testutil::run_command_bounded` -- the same deadline-bounded,
+/// process-group-killing primitive `ensure_hew_lib_built`'s own callers
+/// rely on -- so a hung or runaway linker (clang/cc, forked by `hew`
+/// itself) is killed as a whole group, not left as an orphaned descendant
+/// of a process this test only thinks it killed.
 fn real_compile_attempt(hew_bin: &Path, src: &Path, emit_dir: &Path) -> Classification {
     let mut cmd = Command::new(hew_bin);
-    cmd.arg("compile")
-        .arg(src)
-        .arg("--emit-dir")
-        .arg(emit_dir)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let child = match cmd.spawn() {
-        Ok(c) => c,
-        Err(e) => return Classification::Unexpected(format!("spawn hew compile: {e}")),
-    };
-    match wait_piped_with_deadline(child, LINK_DEADLINE) {
-        Ok((status, _stdout, stderr)) => {
-            if status.success() {
+    cmd.arg("compile").arg(src).arg("--emit-dir").arg(emit_dir);
+    match hew_testutil::run_command_bounded(&mut cmd, "hew compile", LINK_DEADLINE) {
+        Ok(output) => {
+            if output.status.success() {
                 Classification::Success
-            } else if is_libhew_absence_signature(&stderr) {
-                Classification::Absence(stderr)
             } else {
-                Classification::Unexpected(stderr)
+                let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+                if is_libhew_absence_signature(&stderr) {
+                    Classification::Absence(stderr)
+                } else {
+                    Classification::Unexpected(stderr)
+                }
             }
         }
         Err(e) => Classification::Unexpected(format!("hew compile did not complete: {e}")),
@@ -301,9 +277,12 @@ fn real_compile_attempt(hew_bin: &Path, src: &Path, emit_dir: &Path) -> Classifi
 }
 
 /// Waits (bounded, polling, no sleep-as-proof) for a spawned child to exit.
-/// A child that outlives `deadline` is killed and reaped, never left
-/// running past its test -- this is the hang backstop underlying every
-/// child reap and real link attempt in this file.
+/// A child that outlives `deadline` is killed via its whole process group
+/// (`hew_testutil::terminate_process_group`), not just itself, and reaped --
+/// never left running past its test. Every self-fork race child is put in
+/// its own process group by `own_process_group` at spawn time (see
+/// `spawn_role`), so a `cargo`/`hew`/linker grandchild it forked cannot
+/// outlive this kill.
 fn wait_with_deadline(child: &mut Child, deadline: Duration) -> Result<ExitStatus, String> {
     let start = Instant::now();
     loop {
@@ -311,9 +290,11 @@ fn wait_with_deadline(child: &mut Child, deadline: Duration) -> Result<ExitStatu
             return Ok(status);
         }
         if start.elapsed() > deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(format!("child did not exit within {deadline:?}; killed"));
+            hew_testutil::terminate_process_group(child, "race child")
+                .map_err(|e| format!("child did not exit within {deadline:?}: {e}"))?;
+            return Err(format!(
+                "child did not exit within {deadline:?}; process group killed"
+            ));
         }
         thread::sleep(POLL_SLEEP);
     }
@@ -321,19 +302,35 @@ fn wait_with_deadline(child: &mut Child, deadline: Duration) -> Result<ExitStatu
 
 /// Blocks until the orchestrator drops its write guard on `barrier_path` --
 /// every barrier-waiting participant unblocks together. No sleep, no retry
-/// loop: the wait is a single blocking `fd_lock` acquisition. Writes a
-/// readiness marker immediately beforehand so the orchestrator can confirm
-/// (bounded, before releasing) that every participant is at or past this
-/// point -- otherwise a slow-to-spawn child could still be mid-exec when a
-/// fast one races off alone, undermining the "synchronized start" the race
-/// proof depends on.
+/// loop: the wait is a single blocking `fd_lock` acquisition.
+///
+/// Before declaring readiness, a participant must prove it has actually
+/// engaged the barrier: a non-blocking `try_read` is expected to observe
+/// the orchestrator's held write-lock (`ErrorKind::WouldBlock`). Writing
+/// the ready marker any earlier would be a lie the orchestrator could act
+/// on -- it could release the barrier before this participant ever
+/// contends for it, letting a descheduled child start arbitrarily late
+/// while every other participant believes the release was synchronized.
+/// Only after that observation does this function write the marker and
+/// perform the real blocking acquire, so the marker-to-block gap is a
+/// couple of instructions, not an open-ended scheduling window.
 fn wait_at_barrier(barrier_path: &Path, ready_path: &Path) {
-    fs::write(ready_path, b"ready").expect("write ready marker");
     let file = OpenOptions::new()
         .read(true)
         .open(barrier_path)
         .expect("open barrier file");
     let lock = RwLock::new(file);
+    match lock.try_read() {
+        Err(e) if e.kind() == ErrorKind::WouldBlock => {}
+        // The orchestrator's guard was already gone by the time this
+        // participant reached the barrier (legitimate under heavy
+        // scheduling load, though it means there was nothing left to prove
+        // contention against) -- drop the probe's guard and proceed; the
+        // ready marker and the read below still hold correctly.
+        Ok(guard) => drop(guard),
+        Err(e) => panic!("try_read on barrier failed unexpectedly: {e}"),
+    }
+    fs::write(ready_path, b"ready").expect("write ready marker");
     let _guard = lock.read().expect("await barrier release");
 }
 
@@ -491,14 +488,16 @@ struct RaceChild {
 
 /// Owns a batch of already-spawned race children (writers, readers, or
 /// timed builders) for one barrier-synchronized round. Guarantees no child
-/// outlives this batch and that `stop_path` (if any) is always signalled --
-/// even if an assertion earlier in the test panics, a `while
-/// !stop_path.exists()` reader must never spin as an orphan, and a
-/// still-running writer must never survive past its test. `reap_all` is the
-/// expected path (deadline-bounded, records outcomes without panicking so
-/// every child is always fully reaped first); `Drop` is the backstop for
-/// any panic that happens before `reap_all` runs (e.g. a readiness-ack
-/// timeout while other children are still live).
+/// -- or any grandchild it forked (a `cargo`/`hew`/linker invocation running
+/// inside `own_process_group`'s process group) -- outlives this batch, and
+/// that `stop_path` (if any) is always signalled -- even if an assertion
+/// earlier in the test panics, a `while !stop_path.exists()` reader must
+/// never spin as an orphan, and a still-running writer (or its own
+/// in-flight `cargo build -p hew-lib`) must never survive past its test.
+/// `reap_all` is the expected path (deadline-bounded, records outcomes
+/// without panicking so every child is always fully reaped first); `Drop`
+/// is the backstop for any panic that happens before `reap_all` runs (e.g.
+/// a readiness-ack timeout while other children are still live).
 struct ChildBatch {
     children: Vec<RaceChild>,
     stop_path: Option<PathBuf>,
@@ -516,10 +515,11 @@ impl ChildBatch {
         self.children.push(child);
     }
 
-    /// Reaps every child (deadline-bounded, kills stragglers), returning
-    /// each one's outcome. Never panics mid-loop -- every child is fully
-    /// reaped before the caller inspects outcomes and decides whether to
-    /// fail, so a single bad child can never orphan its siblings.
+    /// Reaps every child (deadline-bounded, kills stragglers -- and their
+    /// process groups -- on timeout), returning each one's outcome. Never
+    /// panics mid-loop -- every child is fully reaped before the caller
+    /// inspects outcomes and decides whether to fail, so a single bad
+    /// child can never orphan its siblings.
     fn reap_all(&mut self, label: &str) -> Vec<(PathBuf, Result<String, String>)> {
         let mut outcomes = Vec::new();
         for mut child in self.children.drain(..) {
@@ -542,8 +542,14 @@ impl Drop for ChildBatch {
             let _ = fs::write(stop, b"");
         }
         for mut child in self.children.drain(..) {
-            let _ = child.child.kill();
-            let _ = child.child.wait();
+            // Kills the child's whole process group (see `own_process_group`
+            // in `spawn_role`), not just the direct child, so a
+            // `cargo`/`hew`/linker grandchild it forked cannot survive this
+            // batch.
+            let _ = hew_testutil::terminate_process_group(
+                &mut child.child,
+                "race child (drop cleanup)",
+            );
         }
     }
 }
@@ -595,6 +601,11 @@ fn spawn_role(
     if let Some(cargo) = cargo_override {
         cmd.env("CARGO", cargo);
     }
+    // Every self-fork race child becomes its own process-group leader, so
+    // any grandchild it forks (its own `cargo build -p hew-lib`, or a
+    // `hew`/linker invocation) inherits that same group and cannot outlive
+    // a later `terminate_process_group` kill of this child.
+    hew_testutil::own_process_group(&mut cmd);
     let child = cmd.spawn().expect("spawn race child process");
     RaceChild { child, result_path }
 }
@@ -608,20 +619,28 @@ fn open_write_lock(barrier_path: &Path) -> RwLock<fs::File> {
     RwLock::new(file)
 }
 
+/// Bounded (via `hew_testutil::run_command_bounded`) one-time prebuild of the
+/// `hew` binary itself, run from the orchestrator process directly (not
+/// nested inside any self-fork child), so it needs its own process-group
+/// treatment: a hung `cargo build` (and any `rustc`/linker grandchild it
+/// forks) is killed as a whole group on timeout, not just the immediate
+/// `cargo` process.
 fn ensure_hew_binary_built() {
     let (target_dir, _profile) = target_dir_and_profile();
     let mut cmd = Command::new(env::var_os("CARGO").unwrap_or_else(|| "cargo".into()));
     cmd.args(["build", "-q", "-p", "hew-cli", "--bin", "hew"])
         .env("CARGO_TARGET_DIR", &target_dir)
-        .current_dir(repo_root())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let child = cmd.spawn().expect("spawn cargo build -p hew-cli --bin hew");
-    let (status, _stdout, stderr) = wait_piped_with_deadline(child, PREBUILD_DEADLINE)
-        .expect("prebuild of `hew` binary did not complete");
+        .current_dir(repo_root());
+    let output = hew_testutil::run_command_bounded(
+        &mut cmd,
+        "cargo build -p hew-cli --bin hew",
+        PREBUILD_DEADLINE,
+    )
+    .expect("prebuild of `hew` binary did not complete");
     assert!(
-        status.success(),
-        "prebuild of `hew` binary failed: {stderr}"
+        output.status.success(),
+        "prebuild of `hew` binary failed: {}",
+        String::from_utf8_lossy(&output.stderr)
     );
 }
 

--- a/hew-testutil/tests/libhew_link_race.rs
+++ b/hew-testutil/tests/libhew_link_race.rs
@@ -1,6 +1,7 @@
 //! Multi-process proof that `ensure_hew_lib_built` closes the `libhew.a`
 //! uplift race for real concurrent participants, and that a shared
-//! `NEXTEST_RUN_ID` collapses concurrent bootstraps to a single real build.
+//! `NEXTEST_RUN_ID` collapses concurrent bootstraps to a single real
+//! `cargo build -p hew-lib` invocation.
 //!
 //! `hew_lib_bootstrap_tests::concurrent_callers_build_exactly_once` (in
 //! `src/lib.rs`) proves the lock serializes in-process *threads* against a
@@ -10,36 +11,88 @@
 //! consumer link. This file closes that gap with real child processes, a
 //! real `cargo build -p hew-lib`, and a real `hew compile` link.
 //!
+//! Design invariants (each closes a specific cross-review finding):
+//!
+//! 1. **Exactly-once cargo invocation, not latency inference.** A shared,
+//!    fresh `NEXTEST_RUN_ID` must produce exactly one real `cargo build -p
+//!    hew-lib` invocation no matter how many real processes race it. This is
+//!    proved by a "cargo spy" wrapper (`CARGO` overridden to a small `sh`
+//!    script that atomically records its own invocation via `mktemp`, then
+//!    `exec`s the real cargo) and counting records after the fact -- not by
+//!    comparing wall-clock elapsed time, which a fast-but-still-real
+//!    invocation could pass by accident.
+//! 2. **Every real link outcome is classified, none discarded.** Real `hew
+//!    compile` attempts are bucketed into `Success` / `Absence` (the
+//!    `libhew.a`-missing signature) / `Unexpected` (anything else -- a
+//!    genuine bug should never be silently swallowed alongside the race
+//!    being studied). The gated arm requires at least one real success and
+//!    zero of either failure kind.
+//! 3. **A real, acknowledged, bounded barrier -- and a diagnostic, not
+//!    mandatory, negative control.** Every spawned writer/reader/poller
+//!    signals readiness (about to block on the shared barrier) before the
+//!    orchestrator releases it, bounded by a deadline so a child that fails
+//!    to start fails the test loudly instead of hanging forever. Real link
+//!    operations and child reaps are themselves deadline-bounded, and
+//!    cleanup (killing stragglers, signalling any stop file) always runs on
+//!    the way out, including through a panic. The unlocked arm's poll-based
+//!    absence observation is scheduler-timing-dependent, not a structural
+//!    guarantee, so it is reported as a diagnostic rather than asserted;
+//!    the deterministic proof lives entirely in the gated arm's structural
+//!    (lock-exclusion) guarantees.
+//!
+//! None of the above uses a sleep, or a retry-until-pass loop, as proof.
+//! Bounded polling for readiness/deadlines exists only as a hang backstop.
+//!
 //! Both tests below are `#[ignore]`d (see each attribute for why) and run
 //! via `make libhew-link-race-test`, matching the existing
 //! `make observe-functional-test` convention for heavy, artifact-dependent
 //! proving gates that should not gate routine `cargo nextest run`.
 //!
 //! Unix-only: the fixed writer/reader roles shell real `cargo`/`hew`
-//! subprocesses and use `fd_lock`-based barriers exactly like
-//! `ensure_hew_lib_built` itself; Windows uses a different static-lib name
-//! (`hew.lib`) and MSVC link semantics the plan's grounded evidence (clang's
-//! `no such file or directory` signature) does not cover. This mirrors the
-//! existing `#[cfg(unix)]` gate elsewhere in this crate for the same class
-//! of heavy real-process repro.
+//! subprocesses, chmod a spy wrapper, and use `fd_lock`-based barriers
+//! exactly like `ensure_hew_lib_built` itself; Windows uses a different
+//! static-lib name (`hew.lib`) and MSVC link semantics the plan's grounded
+//! evidence (clang's `no such file or directory` signature) does not cover.
+//! This mirrors the existing `#[cfg(unix)]` gate elsewhere in this crate for
+//! the same class of heavy real-process repro.
 #![cfg(unix)]
 
 use std::env;
 use std::fs::{self, OpenOptions};
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command};
+use std::process::{Child, Command, ExitStatus, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use fd_lock::RwLock;
 
 const ROLE_ENV: &str = "HEW_RACE_ROLE";
 const RESULT_ENV: &str = "HEW_RACE_RESULT";
 const BARRIER_ENV: &str = "HEW_RACE_BARRIER";
+const READY_ENV: &str = "HEW_RACE_READY";
 const STOP_ENV: &str = "HEW_RACE_STOP";
 const ITERS_ENV: &str = "HEW_RACE_ITERS";
+
+/// Bounds how long the orchestrator waits for every spawned participant to
+/// signal it has reached the shared barrier. A hang backstop, not a proof
+/// mechanism: exceeding it always fails the test loudly rather than wedging
+/// CI, and never retries.
+const READY_ACK_DEADLINE: Duration = Duration::from_secs(30);
+/// Bounds how long the orchestrator waits for any single spawned child
+/// process to exit once released. Generous enough for several real,
+/// cold-cache `cargo build -p hew-lib` invocations in sequence.
+const CHILD_WAIT_DEADLINE: Duration = Duration::from_mins(3);
+/// Bounds a single real `hew compile` link attempt.
+const LINK_DEADLINE: Duration = Duration::from_secs(30);
+/// Bounds the one-time prebuild of the `hew` binary itself.
+const PREBUILD_DEADLINE: Duration = Duration::from_mins(5);
+/// Poll interval used only for bounded-wait backstops (readiness, deadline
+/// reaping) -- never as the race's evidentiary basis.
+const POLL_SLEEP: Duration = Duration::from_millis(5);
 
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -95,7 +148,11 @@ fn unique_suffix() -> u128 {
         .as_nanos()
 }
 
-/// Real, unlocked `cargo build -p hew-lib` — byte-for-byte the pre-fix
+fn real_cargo_path() -> PathBuf {
+    env::var_os("CARGO").map_or_else(|| PathBuf::from("cargo"), PathBuf::from)
+}
+
+/// Real, unlocked `cargo build -p hew-lib` -- byte-for-byte the pre-fix
 /// pattern every migrated call site used to run with no cross-process
 /// coordination (ported from `run_cargo_build_hew_lib`, minus the lock).
 fn raw_unlocked_cargo_build_hew_lib() {
@@ -125,6 +182,39 @@ fn raw_unlocked_cargo_build_hew_lib() {
     assert!(status.success(), "raw cargo build -p hew-lib failed");
 }
 
+/// Writes a POSIX-sh "cargo spy" wrapper: atomically records this
+/// invocation (one file per call, created via `mktemp`'s `O_CREAT|O_EXCL`
+/// guarantee so concurrent invocations can never collide or clobber each
+/// other's record), then `exec`s the real cargo. Overriding `CARGO` to
+/// point here lets a test count real cargo invocations directly instead of
+/// inferring them from wall-clock timing -- a fast-but-still-real
+/// invocation would pass a latency check, so latency alone never proves
+/// the shared-stamp fast path was taken.
+fn write_cargo_spy(wrapper_path: &Path, record_dir: &Path, real_cargo: &Path) {
+    fs::create_dir_all(record_dir).expect("create cargo-spy record dir");
+    let script = format!(
+        "#!/bin/sh\n\
+         set -e\n\
+         mktemp \"{rd}/invoke-XXXXXXXX\" >/dev/null\n\
+         exec \"{real}\" \"$@\"\n",
+        rd = record_dir.display(),
+        real = real_cargo.display(),
+    );
+    fs::write(wrapper_path, script).expect("write cargo-spy wrapper");
+    let mut perms = fs::metadata(wrapper_path)
+        .expect("stat cargo-spy wrapper")
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(wrapper_path, perms).expect("chmod cargo-spy wrapper");
+}
+
+fn count_cargo_spy_invocations(record_dir: &Path) -> usize {
+    fs::read_dir(record_dir)
+        .expect("read cargo-spy record dir")
+        .filter_map(Result::ok)
+        .count()
+}
+
 /// Matches the plan's grounded failure signatures: clang/cc's own
 /// `no such file or directory` / `cannot find` on `libhew.a` (or the
 /// linker's `linking failed`), not a `find_hew_lib`-level `exists()` miss.
@@ -137,28 +227,108 @@ fn is_libhew_absence_signature(text: &str) -> bool {
     mentions_lib && mentions_absence
 }
 
+/// A classified outcome of one real `hew compile` link attempt. Every
+/// attempt lands in exactly one bucket -- no outcome is silently discarded,
+/// so a genuine (non-race) bug can never hide behind the race being
+/// studied.
+enum Classification {
+    Success,
+    Absence(String),
+    Unexpected(String),
+}
+
+/// Runs `cmd` to completion, piping stdout/stderr and returning them
+/// alongside the exit status, but never blocking past `deadline`: a child
+/// that overruns is killed (not left to finish on its own clock) and
+/// reported as an error. This is a hang backstop, not the race's proof --
+/// `LINK_DEADLINE`/`CHILD_WAIT_DEADLINE` are generous multiples of observed
+/// real link/build time.
+fn wait_piped_with_deadline(
+    mut child: Child,
+    deadline: Duration,
+) -> Result<(ExitStatus, String, String), String> {
+    let mut stdout = child.stdout.take().expect("stdout piped");
+    let mut stderr = child.stderr.take().expect("stderr piped");
+    let stdout_thread = thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stdout.read_to_string(&mut buf);
+        buf
+    });
+    let stderr_thread = thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stderr.read_to_string(&mut buf);
+        buf
+    });
+    let status = wait_with_deadline(&mut child, deadline)?;
+    let out = stdout_thread
+        .join()
+        .unwrap_or_else(|_| "[stdout reader thread panicked]".to_string());
+    let err = stderr_thread
+        .join()
+        .unwrap_or_else(|_| "[stderr reader thread panicked]".to_string());
+    Ok((status, out, err))
+}
+
 /// A real consumer link: `hew compile` on a trivial fixture. Exercises the
 /// production path (`find_hew_lib` + `link_executable`, clang/cc) that the
 /// plan's grounded evidence's `clang: error: no such file or directory:
-/// '.../libhew.a'` signature comes from.
-fn real_compile_attempt(hew_bin: &Path, src: &Path, emit_dir: &Path) -> Result<(), String> {
-    let output = Command::new(hew_bin)
-        .arg("compile")
+/// '.../libhew.a'` signature comes from. Deadline-bound: a hung linker
+/// fails the attempt instead of hanging the whole test.
+fn real_compile_attempt(hew_bin: &Path, src: &Path, emit_dir: &Path) -> Classification {
+    let mut cmd = Command::new(hew_bin);
+    cmd.arg("compile")
         .arg(src)
         .arg("--emit-dir")
         .arg(emit_dir)
-        .output()
-        .map_err(|e| format!("spawn hew compile: {e}"))?;
-    if output.status.success() {
-        return Ok(());
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => return Classification::Unexpected(format!("spawn hew compile: {e}")),
+    };
+    match wait_piped_with_deadline(child, LINK_DEADLINE) {
+        Ok((status, _stdout, stderr)) => {
+            if status.success() {
+                Classification::Success
+            } else if is_libhew_absence_signature(&stderr) {
+                Classification::Absence(stderr)
+            } else {
+                Classification::Unexpected(stderr)
+            }
+        }
+        Err(e) => Classification::Unexpected(format!("hew compile did not complete: {e}")),
     }
-    Err(String::from_utf8_lossy(&output.stderr).into_owned())
 }
 
-/// Blocks until the orchestrator drops its write guard on `barrier_path` —
-/// every barrier-waiting child unblocks together. No sleep, no retry loop:
-/// the wait is a single blocking `fd_lock` acquisition.
-fn wait_at_barrier(barrier_path: &Path) {
+/// Waits (bounded, polling, no sleep-as-proof) for a spawned child to exit.
+/// A child that outlives `deadline` is killed and reaped, never left
+/// running past its test -- this is the hang backstop underlying every
+/// child reap and real link attempt in this file.
+fn wait_with_deadline(child: &mut Child, deadline: Duration) -> Result<ExitStatus, String> {
+    let start = Instant::now();
+    loop {
+        if let Some(status) = child.try_wait().map_err(|e| format!("try_wait: {e}"))? {
+            return Ok(status);
+        }
+        if start.elapsed() > deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(format!("child did not exit within {deadline:?}; killed"));
+        }
+        thread::sleep(POLL_SLEEP);
+    }
+}
+
+/// Blocks until the orchestrator drops its write guard on `barrier_path` --
+/// every barrier-waiting participant unblocks together. No sleep, no retry
+/// loop: the wait is a single blocking `fd_lock` acquisition. Writes a
+/// readiness marker immediately beforehand so the orchestrator can confirm
+/// (bounded, before releasing) that every participant is at or past this
+/// point -- otherwise a slow-to-spawn child could still be mid-exec when a
+/// fast one races off alone, undermining the "synchronized start" the race
+/// proof depends on.
+fn wait_at_barrier(barrier_path: &Path, ready_path: &Path) {
+    fs::write(ready_path, b"ready").expect("write ready marker");
     let file = OpenOptions::new()
         .read(true)
         .open(barrier_path)
@@ -172,6 +342,54 @@ fn write_result(text: &str) {
     fs::write(path, text).expect("write child result");
 }
 
+fn write_reader_result(attempts: u32, successes: u32, absence: &[String], unexpected: &[String]) {
+    let mut out = format!(
+        "attempts={attempts} successes={successes} absence={} unexpected={}\n",
+        absence.len(),
+        unexpected.len()
+    );
+    out.push_str("##ABSENCE##\n");
+    out.push_str(&absence.join("\n---\n"));
+    out.push_str("\n##UNEXPECTED##\n");
+    out.push_str(&unexpected.join("\n---\n"));
+    write_result(&out);
+}
+
+struct ReaderResult {
+    successes: u32,
+    absence: u32,
+    unexpected: u32,
+    unexpected_log: String,
+}
+
+fn parse_reader_result(text: &str) -> ReaderResult {
+    let mut successes = 0u32;
+    let mut absence = 0u32;
+    let mut unexpected = 0u32;
+    let header = text.lines().next().unwrap_or_default();
+    for part in header.split_whitespace() {
+        if let Some(v) = part.strip_prefix("successes=") {
+            successes = v.parse().unwrap_or(0);
+        } else if let Some(v) = part.strip_prefix("absence=") {
+            absence = v.parse().unwrap_or(0);
+        } else if let Some(v) = part.strip_prefix("unexpected=") {
+            unexpected = v.parse().unwrap_or(0);
+        }
+    }
+    let unexpected_log = text
+        .split("##UNEXPECTED##\n")
+        .nth(1)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    ReaderResult {
+        successes,
+        absence,
+        unexpected,
+        unexpected_log,
+    }
+}
+
 // ---------------------------------------------------------------------
 // Child role bodies. Each is invoked by re-executing this same compiled
 // test binary (`std::env::current_exe()`), so `target_dir_and_profile()`
@@ -179,88 +397,63 @@ fn write_result(text: &str) {
 // identical real `target/<profile>` directory as the parent.
 // ---------------------------------------------------------------------
 
-fn child_writer_gated(barrier_path: &Path) {
+fn child_writer_gated(barrier_path: &Path, ready_path: &Path) {
     let iters: u32 = env::var(ITERS_ENV)
         .expect("iters env set")
         .parse()
         .expect("iters env is a number");
-    wait_at_barrier(barrier_path);
+    wait_at_barrier(barrier_path, ready_path);
     for _ in 0..iters {
         hew_testutil::ensure_hew_lib_built().expect("gated build");
     }
     write_result("done");
 }
 
-fn child_writer_unlocked(barrier_path: &Path) {
+fn child_writer_unlocked(barrier_path: &Path, ready_path: &Path) {
     let iters: u32 = env::var(ITERS_ENV)
         .expect("iters env set")
         .parse()
         .expect("iters env is a number");
-    wait_at_barrier(barrier_path);
+    wait_at_barrier(barrier_path, ready_path);
     for _ in 0..iters {
         raw_unlocked_cargo_build_hew_lib();
     }
     write_result("done");
 }
 
-/// Post-fix consumer: gate immediately before every real link, exactly like
-/// every migrated call site (`ensure_hew_runtime_lib(repo)` then
-/// `hew_command(repo).arg("run"/"compile")`).
-fn child_reader_gated(barrier_path: &Path) {
+/// Shared reader loop for both consumer roles: `gated` mirrors every
+/// migrated call site (gate immediately before every real link); `!gated`
+/// mirrors the pre-fix pattern (a naked link against whatever happens to
+/// be on disk). Every attempt is classified (`Classification`), never
+/// discarded.
+fn child_reader(barrier_path: &Path, ready_path: &Path, gated: bool) {
     let stop_path = PathBuf::from(env::var(STOP_ENV).expect("stop path env set"));
     let hew_bin = hew_bin_path();
     let scratch = tempfile::tempdir().expect("reader scratch dir");
     let src = scratch.path().join("probe.hew");
     fs::write(&src, "fn main() {}\n").expect("write probe fixture");
-    wait_at_barrier(barrier_path);
+    wait_at_barrier(barrier_path, ready_path);
     let mut attempts = 0u32;
-    let mut failures = Vec::new();
+    let mut successes = 0u32;
+    let mut absence_log: Vec<String> = Vec::new();
+    let mut unexpected_log: Vec<String> = Vec::new();
     while !stop_path.exists() {
         attempts += 1;
-        hew_testutil::ensure_hew_lib_built().expect("gated build before consume");
+        if gated {
+            hew_testutil::ensure_hew_lib_built().expect("gated build before consume");
+        }
         let emit_dir = scratch.path().join(format!("out-{attempts}"));
-        if let Err(stderr) = real_compile_attempt(&hew_bin, &src, &emit_dir) {
-            if is_libhew_absence_signature(&stderr) {
-                failures.push(stderr);
-            }
+        match real_compile_attempt(&hew_bin, &src, &emit_dir) {
+            Classification::Success => successes += 1,
+            Classification::Absence(text) => absence_log.push(text),
+            Classification::Unexpected(text) => unexpected_log.push(text),
         }
     }
-    write_result(&format!(
-        "attempts={attempts} failures={}\n{}",
-        failures.len(),
-        failures.join("\n---\n")
-    ));
+    write_reader_result(attempts, successes, &absence_log, &unexpected_log);
 }
 
-/// Pre-fix consumer: no gate call at all — a naked link against whatever
-/// happens to be on disk, matching the pre-fix call-site pattern exactly.
-fn child_reader_unguarded(barrier_path: &Path) {
-    let stop_path = PathBuf::from(env::var(STOP_ENV).expect("stop path env set"));
-    let hew_bin = hew_bin_path();
-    let scratch = tempfile::tempdir().expect("reader scratch dir");
-    let src = scratch.path().join("probe.hew");
-    fs::write(&src, "fn main() {}\n").expect("write probe fixture");
-    wait_at_barrier(barrier_path);
-    let mut attempts = 0u32;
-    let mut failures = Vec::new();
-    while !stop_path.exists() {
-        attempts += 1;
-        let emit_dir = scratch.path().join(format!("out-{attempts}"));
-        if let Err(stderr) = real_compile_attempt(&hew_bin, &src, &emit_dir) {
-            if is_libhew_absence_signature(&stderr) {
-                failures.push(stderr);
-            }
-        }
-    }
-    write_result(&format!(
-        "attempts={attempts} failures={}\n{}",
-        failures.len(),
-        failures.join("\n---\n")
-    ));
-}
-
-fn child_timed_writer_gated(barrier_path: &Path) {
-    wait_at_barrier(barrier_path);
+fn child_timed_writer_gated(barrier_path: &Path, ready_path: &Path) {
+    wait_at_barrier(barrier_path, ready_path);
     let started = Instant::now();
     hew_testutil::ensure_hew_lib_built().expect("gated build");
     let elapsed = started.elapsed();
@@ -275,12 +468,13 @@ fn maybe_run_child_role() -> bool {
         return false;
     };
     let barrier_path = PathBuf::from(env::var(BARRIER_ENV).expect("barrier path env set"));
+    let ready_path = PathBuf::from(env::var(READY_ENV).expect("ready path env set"));
     match role.as_str() {
-        "writer-gated" => child_writer_gated(&barrier_path),
-        "writer-unlocked" => child_writer_unlocked(&barrier_path),
-        "reader-gated" => child_reader_gated(&barrier_path),
-        "reader-unguarded" => child_reader_unguarded(&barrier_path),
-        "timed-writer-gated" => child_timed_writer_gated(&barrier_path),
+        "writer-gated" => child_writer_gated(&barrier_path, &ready_path),
+        "writer-unlocked" => child_writer_unlocked(&barrier_path, &ready_path),
+        "reader-gated" => child_reader(&barrier_path, &ready_path, true),
+        "reader-unguarded" => child_reader(&barrier_path, &ready_path, false),
+        "timed-writer-gated" => child_timed_writer_gated(&barrier_path, &ready_path),
         other => panic!("unknown race role `{other}`"),
     }
     true
@@ -295,32 +489,79 @@ struct RaceChild {
     result_path: PathBuf,
 }
 
-impl RaceChild {
-    fn wait_ok(&mut self, label: &str) {
-        let status = self
-            .child
-            .wait()
-            .unwrap_or_else(|e| panic!("await {label}: {e}"));
-        assert!(status.success(), "{label} exited non-zero: {status:?}");
+/// Owns a batch of already-spawned race children (writers, readers, or
+/// timed builders) for one barrier-synchronized round. Guarantees no child
+/// outlives this batch and that `stop_path` (if any) is always signalled --
+/// even if an assertion earlier in the test panics, a `while
+/// !stop_path.exists()` reader must never spin as an orphan, and a
+/// still-running writer must never survive past its test. `reap_all` is the
+/// expected path (deadline-bounded, records outcomes without panicking so
+/// every child is always fully reaped first); `Drop` is the backstop for
+/// any panic that happens before `reap_all` runs (e.g. a readiness-ack
+/// timeout while other children are still live).
+struct ChildBatch {
+    children: Vec<RaceChild>,
+    stop_path: Option<PathBuf>,
+}
+
+impl ChildBatch {
+    fn new(stop_path: Option<PathBuf>) -> Self {
+        Self {
+            children: Vec::new(),
+            stop_path,
+        }
     }
 
-    fn result(&self) -> String {
-        fs::read_to_string(&self.result_path).unwrap_or_default()
+    fn push(&mut self, child: RaceChild) {
+        self.children.push(child);
+    }
+
+    /// Reaps every child (deadline-bounded, kills stragglers), returning
+    /// each one's outcome. Never panics mid-loop -- every child is fully
+    /// reaped before the caller inspects outcomes and decides whether to
+    /// fail, so a single bad child can never orphan its siblings.
+    fn reap_all(&mut self, label: &str) -> Vec<(PathBuf, Result<String, String>)> {
+        let mut outcomes = Vec::new();
+        for mut child in self.children.drain(..) {
+            let outcome = match wait_with_deadline(&mut child.child, CHILD_WAIT_DEADLINE) {
+                Ok(status) if status.success() => {
+                    Ok(fs::read_to_string(&child.result_path).unwrap_or_default())
+                }
+                Ok(status) => Err(format!("{label} exited non-zero: {status:?}")),
+                Err(e) => Err(format!("{label}: {e}")),
+            };
+            outcomes.push((child.result_path.clone(), outcome));
+        }
+        outcomes
+    }
+}
+
+impl Drop for ChildBatch {
+    fn drop(&mut self) {
+        if let Some(stop) = &self.stop_path {
+            let _ = fs::write(stop, b"");
+        }
+        for mut child in self.children.drain(..) {
+            let _ = child.child.kill();
+            let _ = child.child.wait();
+        }
     }
 }
 
 #[allow(
     clippy::too_many_arguments,
-    reason = "each param is a distinct piece of one child's spawn contract; splitting into a struct would obscure the barrier/stop/iters/run_id role-dependent shape at call sites"
+    reason = "each param is a distinct piece of one child's spawn contract; splitting into a struct would obscure the barrier/ready/stop/iters/run_id/cargo role-dependent shape at call sites"
 )]
 fn spawn_role(
     exe: &Path,
     test_name: &str,
     role: &str,
     barrier_path: &Path,
+    ready_path: &Path,
     stop_path: Option<&Path>,
     iters: Option<u32>,
     run_id: Option<&str>,
+    cargo_override: Option<&Path>,
     result_dir: &Path,
     tag: &str,
 ) -> RaceChild {
@@ -335,6 +576,7 @@ fn spawn_role(
     ]);
     cmd.env(ROLE_ENV, role);
     cmd.env(BARRIER_ENV, barrier_path);
+    cmd.env(READY_ENV, ready_path);
     cmd.env(RESULT_ENV, &result_path);
     if let Some(stop) = stop_path {
         cmd.env(STOP_ENV, stop);
@@ -350,24 +592,11 @@ fn spawn_role(
             cmd.env_remove("NEXTEST_RUN_ID");
         }
     }
+    if let Some(cargo) = cargo_override {
+        cmd.env("CARGO", cargo);
+    }
     let child = cmd.spawn().expect("spawn race child process");
     RaceChild { child, result_path }
-}
-
-fn parse_reader_result(text: &str) -> (u32, u32, String) {
-    let mut lines = text.lines();
-    let header = lines.next().unwrap_or("attempts=0 failures=0");
-    let mut attempts = 0u32;
-    let mut failures = 0u32;
-    for part in header.split_whitespace() {
-        if let Some(v) = part.strip_prefix("attempts=") {
-            attempts = v.parse().unwrap_or(0);
-        } else if let Some(v) = part.strip_prefix("failures=") {
-            failures = v.parse().unwrap_or(0);
-        }
-    }
-    let log: String = lines.collect::<Vec<_>>().join("\n");
-    (attempts, failures, log)
 }
 
 fn open_write_lock(barrier_path: &Path) -> RwLock<fs::File> {
@@ -381,26 +610,202 @@ fn open_write_lock(barrier_path: &Path) -> RwLock<fs::File> {
 
 fn ensure_hew_binary_built() {
     let (target_dir, _profile) = target_dir_and_profile();
-    let status = Command::new(env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
-        .args(["build", "-q", "-p", "hew-cli", "--bin", "hew"])
+    let mut cmd = Command::new(env::var_os("CARGO").unwrap_or_else(|| "cargo".into()));
+    cmd.args(["build", "-q", "-p", "hew-cli", "--bin", "hew"])
         .env("CARGO_TARGET_DIR", &target_dir)
         .current_dir(repo_root())
-        .status()
-        .expect("spawn cargo build -p hew-cli --bin hew");
-    assert!(status.success(), "prebuild of `hew` binary failed");
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = cmd.spawn().expect("spawn cargo build -p hew-cli --bin hew");
+    let (status, _stdout, stderr) = wait_piped_with_deadline(child, PREBUILD_DEADLINE)
+        .expect("prebuild of `hew` binary did not complete");
+    assert!(
+        status.success(),
+        "prebuild of `hew` binary failed: {stderr}"
+    );
 }
 
-/// Deterministic negative control: `writer_count` real, unlocked
-/// `cargo build -p hew-lib` processes rebuild the real artifact while a
-/// background thread busy-polls its existence (`std::hint::spin_loop`, no
-/// sleep) for as long as the writers are alive. Termination is bounded by
-/// the writers' fixed-iteration real lifetime, not by a retry-until-pass
-/// condition. Returns (`poll_hits`, `real_link_failures`) — the poll hits are
-/// the load-bearing signal (matches the grounded 136/136 methodology and
-/// does not depend on a real linker's process-spawn timing landing inside a
-/// multi-microsecond window); the real-link failures are best-effort
-/// corroboration from real `hew compile` readers racing concurrently.
-fn run_unlocked_arm(exe: &Path, test_name: &str, scratch: &Path) -> (u32, u32) {
+/// Waits (bounded, polling, no sleep-as-proof) for every path in
+/// `ready_paths` to exist and for `poller_ready` to report true, i.e. for
+/// every spawned participant -- process or in-process thread -- to reach
+/// the shared barrier. A child that fails to start (spawn/exec error, crash
+/// before reaching the barrier) fails the test loudly here instead of the
+/// orchestrator racing ahead with a false "everyone is ready" assumption.
+fn await_ready(ready_paths: &[PathBuf], poller_ready: impl Fn() -> bool, deadline: Duration) {
+    let start = Instant::now();
+    loop {
+        if ready_paths.iter().all(|p| p.exists()) && poller_ready() {
+            return;
+        }
+        if start.elapsed() > deadline {
+            let missing: Vec<_> = ready_paths
+                .iter()
+                .filter(|p| !p.exists())
+                .map(|p| p.display().to_string())
+                .collect();
+            panic!(
+                "timed out after {deadline:?} waiting for participants to reach \
+                 the barrier (missing ready markers: {missing:?}, poller_ready={}) \
+                 -- a child likely failed to start rather than the race itself \
+                 being at fault",
+                poller_ready()
+            );
+        }
+        thread::sleep(POLL_SLEEP);
+    }
+}
+
+/// Spawns `count` writer children sharing one `role`/`iters`/`run_id`/cargo
+/// override, recording each one's readiness-marker path into `ready_paths`.
+/// Shared by both arms to keep their spawn contracts identical apart from
+/// the role/lock behaviour under test.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "each param is a distinct piece of the shared writer spawn contract"
+)]
+fn spawn_batch_writers(
+    exe: &Path,
+    test_name: &str,
+    role: &str,
+    barrier_path: &Path,
+    iters: u32,
+    run_id: Option<&str>,
+    cargo_override: Option<&Path>,
+    result_dir: &Path,
+    count: u32,
+    ready_paths: &mut Vec<PathBuf>,
+) -> ChildBatch {
+    let mut batch = ChildBatch::new(None);
+    for i in 0..count {
+        let tag = format!("writer-{i}");
+        let ready_path = result_dir.join(format!("{tag}.ready"));
+        batch.push(spawn_role(
+            exe,
+            test_name,
+            role,
+            barrier_path,
+            &ready_path,
+            None,
+            Some(iters),
+            run_id,
+            cargo_override,
+            result_dir,
+            &tag,
+        ));
+        ready_paths.push(ready_path);
+    }
+    batch
+}
+
+/// Spawns `count` reader children sharing one `role`/`run_id`/cargo override
+/// and one `stop_path`, recording each one's readiness-marker path into
+/// `ready_paths`. Shared by both arms; see `spawn_batch_writers`.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "each param is a distinct piece of the shared reader spawn contract"
+)]
+fn spawn_batch_readers(
+    exe: &Path,
+    test_name: &str,
+    role: &str,
+    barrier_path: &Path,
+    stop_path: &Path,
+    run_id: Option<&str>,
+    cargo_override: Option<&Path>,
+    result_dir: &Path,
+    count: u32,
+    ready_paths: &mut Vec<PathBuf>,
+) -> ChildBatch {
+    let mut batch = ChildBatch::new(Some(stop_path.to_path_buf()));
+    for i in 0..count {
+        let tag = format!("reader-{i}");
+        let ready_path = result_dir.join(format!("{tag}.ready"));
+        batch.push(spawn_role(
+            exe,
+            test_name,
+            role,
+            barrier_path,
+            &ready_path,
+            Some(stop_path),
+            None,
+            run_id,
+            cargo_override,
+            result_dir,
+            &tag,
+        ));
+        ready_paths.push(ready_path);
+    }
+    batch
+}
+
+/// Panics on the first `Err` outcome, naming which child and path it came
+/// from. Called only after every child has already been reaped (never
+/// mid-reap), so a bad outcome here can never orphan a sibling.
+fn panic_on_any_err(label: &str, outcomes: &[(PathBuf, Result<String, String>)]) {
+    for (path, outcome) in outcomes {
+        if let Err(e) = outcome {
+            panic!("{label} at {}: {e}", path.display());
+        }
+    }
+}
+
+/// Aggregated, classified reader outcomes across a whole batch.
+struct ReaderTotals {
+    successes: u32,
+    absence: u32,
+    unexpected: u32,
+    unexpected_log: String,
+}
+
+fn aggregate_reader_outcomes(
+    label: &str,
+    outcomes: &[(PathBuf, Result<String, String>)],
+) -> ReaderTotals {
+    let mut totals = ReaderTotals {
+        successes: 0,
+        absence: 0,
+        unexpected: 0,
+        unexpected_log: String::new(),
+    };
+    for (path, outcome) in outcomes {
+        match outcome {
+            Ok(text) => {
+                let r = parse_reader_result(text);
+                totals.successes += r.successes;
+                totals.absence += r.absence;
+                totals.unexpected += r.unexpected;
+                if !r.unexpected_log.is_empty() {
+                    totals.unexpected_log.push_str(&r.unexpected_log);
+                    totals.unexpected_log.push('\n');
+                }
+            }
+            Err(e) => panic!("{label} at {}: {e}", path.display()),
+        }
+    }
+    totals
+}
+
+/// Diagnostic result of the unlocked (pre-fix) arm. `poll_hits` is a
+/// scheduler-timing observation, not a structural guarantee -- reported,
+/// never asserted. The real-link classification counts are best-effort
+/// corroboration from real unguarded `hew compile` readers racing
+/// concurrently, also non-load-bearing.
+struct UnlockedArmResult {
+    poll_hits: u64,
+    successes: u32,
+    absence: u32,
+    unexpected: u32,
+}
+
+/// Pre-fix arm: `writer_count` real, unlocked `cargo build -p hew-lib`
+/// processes rebuild the real artifact while a background thread
+/// busy-polls its existence (`std::hint::spin_loop`, no sleep) for as long
+/// as the writers are alive, and real unguarded `hew compile` readers race
+/// concurrently. Every participant (writers, readers, poller) acknowledges
+/// readiness before the shared barrier releases, bounded by
+/// `READY_ACK_DEADLINE`. Nothing here is asserted upon by the caller --
+/// see `UnlockedArmResult`'s doc comment for why.
+fn run_unlocked_arm(exe: &Path, test_name: &str, scratch: &Path) -> UnlockedArmResult {
     let artifact = libhew_path();
     let barrier_path = scratch.join("unlocked-barrier.lock");
     fs::write(&barrier_path, b"").expect("create barrier file");
@@ -411,45 +816,40 @@ fn run_unlocked_arm(exe: &Path, test_name: &str, scratch: &Path) -> (u32, u32) {
     let mut barrier_lock = open_write_lock(&barrier_path);
     let guard = barrier_lock.write().expect("acquire barrier write-lock");
 
-    let writer_count = 3u32;
-    let iters = 8u32;
-    let mut writers: Vec<RaceChild> = (0..writer_count)
-        .map(|i| {
-            spawn_role(
-                exe,
-                test_name,
-                "writer-unlocked",
-                &barrier_path,
-                None,
-                Some(iters),
-                None,
-                &result_dir,
-                &format!("writer-{i}"),
-            )
-        })
-        .collect();
-    let reader_count = 6u32;
-    let mut readers: Vec<RaceChild> = (0..reader_count)
-        .map(|i| {
-            spawn_role(
-                exe,
-                test_name,
-                "reader-unguarded",
-                &barrier_path,
-                Some(&stop_path),
-                None,
-                None,
-                &result_dir,
-                &format!("reader-{i}"),
-            )
-        })
-        .collect();
+    let mut ready_paths = Vec::new();
+    let mut writer_batch = spawn_batch_writers(
+        exe,
+        test_name,
+        "writer-unlocked",
+        &barrier_path,
+        8,
+        None,
+        None,
+        &result_dir,
+        3,
+        &mut ready_paths,
+    );
+    let mut reader_batch = spawn_batch_readers(
+        exe,
+        test_name,
+        "reader-unguarded",
+        &barrier_path,
+        &stop_path,
+        None,
+        None,
+        &result_dir,
+        6,
+        &mut ready_paths,
+    );
 
     let poll_stop = Arc::new(AtomicBool::new(false));
+    let poll_ready = Arc::new(AtomicBool::new(false));
     let thread_stop = Arc::clone(&poll_stop);
+    let thread_ready = Arc::clone(&poll_ready);
     let poll_artifact = artifact.clone();
     let poller = thread::spawn(move || {
-        let mut hits = 0u32;
+        thread_ready.store(true, Ordering::Release);
+        let mut hits = 0u64;
         while !thread_stop.load(Ordering::Relaxed) {
             if !poll_artifact.exists() {
                 hits += 1;
@@ -459,31 +859,56 @@ fn run_unlocked_arm(exe: &Path, test_name: &str, scratch: &Path) -> (u32, u32) {
         hits
     });
 
-    drop(guard); // release the barrier -- writers start rebuilding now
+    await_ready(
+        &ready_paths,
+        || poll_ready.load(Ordering::Acquire),
+        READY_ACK_DEADLINE,
+    );
 
-    for w in &mut writers {
-        w.wait_ok("writer-unlocked child");
-    }
+    drop(guard); // release the barrier -- every participant starts together
+
+    panic_on_any_err(
+        "writer-unlocked child",
+        &writer_batch.reap_all("writer-unlocked child"),
+    );
+
     poll_stop.store(true, Ordering::Relaxed);
     let poll_hits = poller.join().expect("poll thread should not panic");
 
     fs::write(&stop_path, b"").expect("signal readers to stop");
-    let mut real_link_failures = 0u32;
-    for r in &mut readers {
-        r.wait_ok("reader-unguarded child");
-        let (_attempts, failures, _log) = parse_reader_result(&r.result());
-        real_link_failures += failures;
-    }
 
-    (poll_hits, real_link_failures)
+    let totals = aggregate_reader_outcomes(
+        "reader-unguarded child",
+        &reader_batch.reap_all("reader-unguarded child"),
+    );
+
+    UnlockedArmResult {
+        poll_hits,
+        successes: totals.successes,
+        absence: totals.absence,
+        unexpected: totals.unexpected,
+    }
 }
 
-/// Positive control: every participant (writers AND readers) calls the real
+/// Deterministic result of the gated (post-fix) arm. Every field here is a
+/// structural (lock-exclusion) guarantee, not a timing bet, so the caller
+/// asserts on all of them.
+struct GatedArmResult {
+    successes: u32,
+    absence: u32,
+    unexpected: u32,
+    unexpected_log: String,
+    cargo_invocations: usize,
+}
+
+/// Post-fix arm: every participant (writers AND readers) calls the real
 /// `ensure_hew_lib_built()` before touching `libhew.a`, sharing one fresh
-/// `NEXTEST_RUN_ID` — exactly the migrated call-site pattern. The lock makes
-/// "zero absence failures" a structural guarantee here, not a timing bet, so
-/// asserting on it deterministically is safe.
-fn run_gated_arm(exe: &Path, test_name: &str, scratch: &Path) -> (u32, u32, String) {
+/// `NEXTEST_RUN_ID` -- exactly the migrated call-site pattern. `CARGO` is
+/// overridden to a spy wrapper shared by every participant so the real
+/// number of `cargo build -p hew-lib` invocations can be counted directly:
+/// with the stamp fast path working, 3 writers + 6 readers all racing one
+/// fresh run id must still produce exactly one.
+fn run_gated_arm(exe: &Path, test_name: &str, scratch: &Path) -> GatedArmResult {
     let run_id = format!("race-link-{}-{}", std::process::id(), unique_suffix());
     let barrier_path = scratch.join("gated-barrier.lock");
     fs::write(&barrier_path, b"").expect("create barrier file");
@@ -491,77 +916,80 @@ fn run_gated_arm(exe: &Path, test_name: &str, scratch: &Path) -> (u32, u32, Stri
     let result_dir = scratch.join("gated-results");
     fs::create_dir_all(&result_dir).expect("create result dir");
 
+    let cargo_record_dir = scratch.join("gated-cargo-invocations");
+    let cargo_spy = scratch.join("gated-cargo-spy.sh");
+    write_cargo_spy(&cargo_spy, &cargo_record_dir, &real_cargo_path());
+
     let mut barrier_lock = open_write_lock(&barrier_path);
     let guard = barrier_lock.write().expect("acquire barrier write-lock");
 
-    let writer_count = 3u32;
-    let iters = 6u32;
-    let mut writers: Vec<RaceChild> = (0..writer_count)
-        .map(|i| {
-            spawn_role(
-                exe,
-                test_name,
-                "writer-gated",
-                &barrier_path,
-                None,
-                Some(iters),
-                Some(&run_id),
-                &result_dir,
-                &format!("writer-{i}"),
-            )
-        })
-        .collect();
-    let reader_count = 6u32;
-    let mut readers: Vec<RaceChild> = (0..reader_count)
-        .map(|i| {
-            spawn_role(
-                exe,
-                test_name,
-                "reader-gated",
-                &barrier_path,
-                Some(&stop_path),
-                None,
-                Some(&run_id),
-                &result_dir,
-                &format!("reader-{i}"),
-            )
-        })
-        .collect();
+    let mut ready_paths = Vec::new();
+    let mut writer_batch = spawn_batch_writers(
+        exe,
+        test_name,
+        "writer-gated",
+        &barrier_path,
+        6,
+        Some(&run_id),
+        Some(&cargo_spy),
+        &result_dir,
+        3,
+        &mut ready_paths,
+    );
+    let mut reader_batch = spawn_batch_readers(
+        exe,
+        test_name,
+        "reader-gated",
+        &barrier_path,
+        &stop_path,
+        Some(&run_id),
+        Some(&cargo_spy),
+        &result_dir,
+        6,
+        &mut ready_paths,
+    );
 
-    drop(guard); // release the barrier -- everyone starts together
+    await_ready(&ready_paths, || true, READY_ACK_DEADLINE);
 
-    for w in &mut writers {
-        w.wait_ok("writer-gated child");
-    }
+    drop(guard); // release the barrier -- every participant starts together
+
+    panic_on_any_err(
+        "writer-gated child",
+        &writer_batch.reap_all("writer-gated child"),
+    );
+
     fs::write(&stop_path, b"").expect("signal readers to stop");
 
-    let mut total_attempts = 0u32;
-    let mut total_failures = 0u32;
-    let mut failure_log = String::new();
-    for r in &mut readers {
-        r.wait_ok("reader-gated child");
-        let (attempts, failures, log) = parse_reader_result(&r.result());
-        total_attempts += attempts;
-        total_failures += failures;
-        if !log.is_empty() {
-            failure_log.push_str(&log);
-            failure_log.push('\n');
-        }
+    let totals = aggregate_reader_outcomes(
+        "reader-gated child",
+        &reader_batch.reap_all("reader-gated child"),
+    );
+
+    let cargo_invocations = count_cargo_spy_invocations(&cargo_record_dir);
+
+    GatedArmResult {
+        successes: totals.successes,
+        absence: totals.absence,
+        unexpected: totals.unexpected,
+        unexpected_log: totals.unexpected_log,
+        cargo_invocations,
     }
-    (total_attempts, total_failures, failure_log)
 }
 
 /// The core proving gate: real OS processes, real `cargo build -p hew-lib`,
 /// a real `hew compile` link, and a real shared `NEXTEST_RUN_ID`.
 ///
-/// Arm A (pre-fix): unlocked writers really race `libhew.a` — a background
-/// poll thread deterministically observes the absence window (matching the
-/// plan's grounded 136/136 evidence), corroborated best-effort by real
-/// unguarded `hew compile` readers running concurrently.
+/// Arm A (pre-fix, diagnostic): unlocked writers really race `libhew.a` --
+/// a background poll thread observes the absence window and real unguarded
+/// `hew compile` readers race concurrently. Reported, not asserted: the
+/// observation is scheduler-timing-dependent, not a structural guarantee.
 ///
-/// Arm B (post-fix): every participant gates through `ensure_hew_lib_built`
-/// before touching `libhew.a`; real `hew compile` readers must see zero
-/// absence failures — a lock-exclusion guarantee, not a timing bet.
+/// Arm B (post-fix, deterministic): every participant gates through
+/// `ensure_hew_lib_built` before touching `libhew.a`; real `hew compile`
+/// readers must see at least one success and zero of either failure kind,
+/// and exactly one real `cargo build -p hew-lib` invocation must have
+/// happened across all 9 participants sharing one run id -- lock-exclusion
+/// guarantees, not timing bets.
 #[test]
 #[ignore = "run by `make libhew-link-race-test` with the `hew` binary and libhew.a built"]
 fn concurrent_link_survives_libhew_bootstrap_race() {
@@ -575,102 +1003,58 @@ fn concurrent_link_survives_libhew_bootstrap_race() {
 
     let scratch = tempfile::tempdir().expect("scratch dir");
 
-    let (poll_hits, unguarded_real_failures) = run_unlocked_arm(&exe, test_name, scratch.path());
-    assert!(
-        poll_hits >= 1,
-        "expected the unlocked writer pattern to expose at least one real \
-         libhew.a absence window (deterministic per the plan's grounded \
-         136/136 evidence); observed zero — the race harness itself may be \
-         broken, investigate before trusting the gated-arm proof below"
-    );
+    let unlocked = run_unlocked_arm(&exe, test_name, scratch.path());
     eprintln!(
-        "unlocked arm: poll_hits={poll_hits} real_hew_compile_link_failures={unguarded_real_failures} \
-         (best-effort corroboration; not load-bearing given real-linker process-spawn timing variance)"
+        "unlocked arm (diagnostic, scheduler-timing-dependent -- not asserted): \
+         poll_hits={} real_successes={} real_absence_failures={} \
+         real_unexpected_failures={}",
+        unlocked.poll_hits, unlocked.successes, unlocked.absence, unlocked.unexpected
     );
+    if unlocked.poll_hits == 0 {
+        eprintln!(
+            "note: the unlocked writer pattern did not expose a libhew.a absence \
+             window this run; this reflects scheduler timing, not a structural \
+             guarantee, so it is not asserted -- the deterministic proof is the \
+             gated arm below"
+        );
+    }
 
-    let (gated_attempts, gated_failures, gated_log) =
-        run_gated_arm(&exe, test_name, scratch.path());
+    let gated = run_gated_arm(&exe, test_name, scratch.path());
     assert!(
-        gated_attempts > 0,
-        "gated readers should have attempted at least one real hew compile link"
+        gated.successes >= 1,
+        "gated readers should have completed at least one successful real hew \
+         compile link across their shared NEXTEST_RUN_ID; observed {} successes",
+        gated.successes
     );
     assert_eq!(
-        gated_failures, 0,
-        "gated readers observed a libhew.a absence failure across {gated_attempts} \
-         real hew-compile attempts sharing one NEXTEST_RUN_ID: {gated_log}"
+        gated.absence, 0,
+        "gated readers observed {} libhew.a absence failure(s) despite every \
+         participant gating through ensure_hew_lib_built",
+        gated.absence
+    );
+    assert_eq!(
+        gated.unexpected, 0,
+        "gated readers hit {} unexpected (non-absence) compile/link failure(s): {}",
+        gated.unexpected, gated.unexpected_log
+    );
+    assert_eq!(
+        gated.cargo_invocations, 1,
+        "expected exactly one real `cargo build -p hew-lib` invocation across 3 \
+         writers + 6 readers sharing one NEXTEST_RUN_ID; observed {} -- the \
+         shared stamp should short-circuit every caller but the first",
+        gated.cargo_invocations
     );
 }
 
-/// Focused proof that a shared `NEXTEST_RUN_ID` across real OS processes
-/// collapses concurrent bootstraps to exactly one real `cargo build -p
-/// hew-lib`. A real build costs whole seconds even as a no-op rebuild
-/// (grounded probe: ~4.2s); the stamp fast-path is a couple of filesystem
-/// reads (sub-100ms). Exactly one of N real processes sharing one run id
-/// should pay the real-build cost.
-/// Spawns `count` real processes behind one barrier, all sharing `run_id`,
-/// and returns each one's self-measured `ensure_hew_lib_built` elapsed ms.
-fn spawn_timed_batch(
-    exe: &Path,
-    test_name: &str,
-    run_id: &str,
-    result_dir: &Path,
-    tag_prefix: &str,
-    count: u32,
-) -> Vec<u64> {
-    let barrier_path = result_dir.join(format!("{tag_prefix}-barrier.lock"));
-    fs::write(&barrier_path, b"").expect("create barrier file");
-
-    let mut barrier_lock = open_write_lock(&barrier_path);
-    let guard = barrier_lock.write().expect("acquire barrier write-lock");
-
-    let mut children: Vec<RaceChild> = (0..count)
-        .map(|i| {
-            spawn_role(
-                exe,
-                test_name,
-                "timed-writer-gated",
-                &barrier_path,
-                None,
-                None,
-                Some(run_id),
-                result_dir,
-                &format!("{tag_prefix}-{i}"),
-            )
-        })
-        .collect();
-
-    drop(guard); // release -- every process in this batch starts together
-
-    children
-        .iter_mut()
-        .map(|c| {
-            c.wait_ok("timed-writer-gated child");
-            let text = c.result();
-            text.trim()
-                .parse()
-                .unwrap_or_else(|e| panic!("child reported non-numeric elapsed ms `{text}`: {e}"))
-        })
-        .collect()
-}
-
-/// Proves real `NEXTEST_RUN_ID` stamp sharing across process boundaries in
-/// two parts:
-///
-/// 1. A batch of real concurrent processes, all sharing one fresh run id,
-///    all call the real `ensure_hew_lib_built()` at once — every one must
-///    return `Ok` (the lock correctly serializes real cross-process
-///    contention; already proven for stubbed in-process threads by
-///    `hew_lib_bootstrap_tests::concurrent_callers_build_exactly_once`, now
-///    proven for real processes doing a real build).
-///
-/// 2. A lone leader process builds (with a second, different fresh run id)
-///    and only *after* it completes do the followers start, sharing the
-///    leader's run id. A real `cargo build -p hew-lib` costs a
-///    hardware-dependent but always-nontrivial amount of wall time (a
-///    single solo run here calibrates the "real build" baseline instead of
-///    hardcoding a duration); the stamp fast-path is a couple of file
-///    reads. Every follower must be a small fraction of the leader's time —
-///    the leader actually built, the followers free-rode on its stamp.
+/// Proves real `NEXTEST_RUN_ID` stamp sharing across process boundaries by
+/// counting real `cargo build -p hew-lib` invocations directly (via the
+/// cargo-spy wrapper), not by inferring it from wall-clock latency: a
+/// shared, fresh run id raced by several real processes calling the real
+/// `ensure_hew_lib_built()` must produce exactly one real cargo invocation,
+/// no matter how many processes race it -- the fd_lock-serialized winner
+/// performs the real build and writes the stamp; every other racer's
+/// re-check under the same lock finds the stamp already fresh and never
+/// reaches `build_fn` at all.
 #[test]
 #[ignore = "run by `make libhew-link-race-test` with the `hew` binary and libhew.a built"]
 fn stamp_sharing_across_real_processes_builds_exactly_once() {
@@ -682,61 +1066,74 @@ fn stamp_sharing_across_real_processes_builds_exactly_once() {
     let test_name = "stamp_sharing_across_real_processes_builds_exactly_once";
     let scratch = tempfile::tempdir().expect("scratch dir");
 
-    // Part 1: real concurrent contention, all racing a fresh run id.
-    let contend_run_id = format!(
-        "race-stamp-contend-{}-{}",
-        std::process::id(),
-        unique_suffix()
-    );
-    let contend_dir = scratch.path().join("contend");
-    fs::create_dir_all(&contend_dir).expect("create contend result dir");
-    let contend_elapsed =
-        spawn_timed_batch(&exe, test_name, &contend_run_id, &contend_dir, "contend", 4);
-    assert_eq!(
-        contend_elapsed.len(),
-        4,
-        "all four concurrent contenders should report a result"
-    );
+    let run_id = format!("race-stamp-{}-{}", std::process::id(), unique_suffix());
+    let record_dir = scratch.path().join("cargo-invocations");
+    let spy = scratch.path().join("cargo-spy.sh");
+    write_cargo_spy(&spy, &record_dir, &real_cargo_path());
 
-    // Part 2: a lone leader builds; only then do followers share its stamp.
-    let leader_run_id = format!(
-        "race-stamp-leader-{}-{}",
-        std::process::id(),
-        unique_suffix()
-    );
-    let leader_dir = scratch.path().join("leader");
-    fs::create_dir_all(&leader_dir).expect("create leader result dir");
-    let leader_elapsed =
-        spawn_timed_batch(&exe, test_name, &leader_run_id, &leader_dir, "leader", 1);
-    let leader_ms = leader_elapsed[0];
-    assert!(
-        leader_ms > 0,
-        "the lone leader's real cargo build should take measurable wall time"
-    );
+    let barrier_path = scratch.path().join("stamp-barrier.lock");
+    fs::write(&barrier_path, b"").expect("create barrier file");
+    let result_dir = scratch.path().join("stamp-results");
+    fs::create_dir_all(&result_dir).expect("create result dir");
 
-    let follower_dir = scratch.path().join("followers");
-    fs::create_dir_all(&follower_dir).expect("create follower result dir");
-    let follower_elapsed = spawn_timed_batch(
-        &exe,
-        test_name,
-        &leader_run_id, // same run id as the leader -- must hit its stamp
-        &follower_dir,
-        "follower",
-        5,
-    );
+    let mut barrier_lock = open_write_lock(&barrier_path);
+    let guard = barrier_lock.write().expect("acquire barrier write-lock");
 
-    // Each follower must be a small fraction of the leader's real-build
-    // time -- self-calibrated against this run's own leader measurement
-    // rather than a hardcoded duration, so it holds regardless of hardware
-    // speed or build-cache warmth.
-    let threshold_ms = (leader_ms / 3).max(1);
-    for (i, &ms) in follower_elapsed.iter().enumerate() {
-        assert!(
-            ms <= threshold_ms,
-            "follower {i} took {ms}ms sharing the leader's NEXTEST_RUN_ID \
-             (leader real build took {leader_ms}ms, threshold {threshold_ms}ms) \
-             -- expected it to fast-path off the leader's stamp instead of \
-             rebuilding; all follower elapsed times: {follower_elapsed:?}"
-        );
+    let mut batch = ChildBatch::new(None);
+    let mut ready_paths = Vec::new();
+    let count = 6u32;
+    for i in 0..count {
+        let tag = format!("contender-{i}");
+        let ready_path = result_dir.join(format!("{tag}.ready"));
+        batch.push(spawn_role(
+            &exe,
+            test_name,
+            "timed-writer-gated",
+            &barrier_path,
+            &ready_path,
+            None,
+            None,
+            Some(&run_id),
+            Some(&spy),
+            &result_dir,
+            &tag,
+        ));
+        ready_paths.push(ready_path);
     }
+
+    await_ready(&ready_paths, || true, READY_ACK_DEADLINE);
+
+    drop(guard); // release the barrier -- every contender starts together
+
+    let outcomes = batch.reap_all("timed-writer-gated child");
+    let mut elapsed_ms = Vec::new();
+    for (path, outcome) in &outcomes {
+        match outcome {
+            Ok(text) => {
+                let ms: u64 = text.trim().parse().unwrap_or_else(|e| {
+                    panic!(
+                        "child at {} reported non-numeric elapsed ms `{text}`: {e}",
+                        path.display()
+                    )
+                });
+                elapsed_ms.push(ms);
+            }
+            Err(e) => panic!("timed-writer-gated child at {}: {e}", path.display()),
+        }
+    }
+    eprintln!(
+        "stamp sharing: {count} real processes shared one fresh NEXTEST_RUN_ID, \
+         elapsed_ms={elapsed_ms:?} (diagnostic only -- the load-bearing proof is \
+         the cargo-invocation count below)"
+    );
+
+    let invocations = count_cargo_spy_invocations(&record_dir);
+    assert_eq!(
+        invocations, 1,
+        "expected exactly one real `cargo build -p hew-lib` invocation across \
+         {count} real processes racing one fresh NEXTEST_RUN_ID through \
+         ensure_hew_lib_built; observed {invocations} -- the shared stamp should \
+         collapse every caller but the winner onto the fast path with no further \
+         cargo invocation"
+    );
 }

--- a/hew-testutil/tests/libhew_link_race.rs
+++ b/hew-testutil/tests/libhew_link_race.rs
@@ -1,0 +1,742 @@
+//! Multi-process proof that `ensure_hew_lib_built` closes the `libhew.a`
+//! uplift race for real concurrent participants, and that a shared
+//! `NEXTEST_RUN_ID` collapses concurrent bootstraps to a single real build.
+//!
+//! `hew_lib_bootstrap_tests::concurrent_callers_build_exactly_once` (in
+//! `src/lib.rs`) proves the lock serializes in-process *threads* against a
+//! *stubbed* `build_fn`. That is necessary but not sufficient: it never
+//! exercises real OS processes, real `NEXTEST_RUN_ID` stamp sharing across
+//! process boundaries, Cargo's real non-atomic `libhew.a` uplift, or a real
+//! consumer link. This file closes that gap with real child processes, a
+//! real `cargo build -p hew-lib`, and a real `hew compile` link.
+//!
+//! Both tests below are `#[ignore]`d (see each attribute for why) and run
+//! via `make libhew-link-race-test`, matching the existing
+//! `make observe-functional-test` convention for heavy, artifact-dependent
+//! proving gates that should not gate routine `cargo nextest run`.
+//!
+//! Unix-only: the fixed writer/reader roles shell real `cargo`/`hew`
+//! subprocesses and use `fd_lock`-based barriers exactly like
+//! `ensure_hew_lib_built` itself; Windows uses a different static-lib name
+//! (`hew.lib`) and MSVC link semantics the plan's grounded evidence (clang's
+//! `no such file or directory` signature) does not cover. This mirrors the
+//! existing `#[cfg(unix)]` gate elsewhere in this crate for the same class
+//! of heavy real-process repro.
+#![cfg(unix)]
+
+use std::env;
+use std::fs::{self, OpenOptions};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::Instant;
+
+use fd_lock::RwLock;
+
+const ROLE_ENV: &str = "HEW_RACE_ROLE";
+const RESULT_ENV: &str = "HEW_RACE_RESULT";
+const BARRIER_ENV: &str = "HEW_RACE_BARRIER";
+const STOP_ENV: &str = "HEW_RACE_STOP";
+const ITERS_ENV: &str = "HEW_RACE_ITERS";
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("hew-testutil lives under the workspace root")
+        .to_path_buf()
+}
+
+/// Mirrors `hew_testutil`'s private `target_dir_and_profile` exactly: this
+/// test binary is itself compiled under `target/<profile>/deps/`, the same
+/// layout every migrated call site (and `ensure_hew_lib_built` itself) runs
+/// under, so this resolves to the identical real directory.
+fn target_dir_and_profile() -> (PathBuf, String) {
+    let exe = env::current_exe().expect("resolve current_exe");
+    let profile_dir = exe
+        .parent()
+        .and_then(Path::parent)
+        .expect("test binary path has target/<profile>/deps ancestry");
+    let profile = profile_dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .expect("profile dir has a name")
+        .to_string();
+    let target_dir = profile_dir
+        .parent()
+        .expect("profile dir has a target/ parent")
+        .to_path_buf();
+    (target_dir, profile)
+}
+
+fn hew_lib_name() -> &'static str {
+    if cfg!(windows) {
+        "hew.lib"
+    } else {
+        "libhew.a"
+    }
+}
+
+fn libhew_path() -> PathBuf {
+    let (target_dir, profile) = target_dir_and_profile();
+    target_dir.join(profile).join(hew_lib_name())
+}
+
+fn hew_bin_path() -> PathBuf {
+    let (target_dir, profile) = target_dir_and_profile();
+    target_dir.join(profile).join("hew")
+}
+
+fn unique_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock after epoch")
+        .as_nanos()
+}
+
+/// Real, unlocked `cargo build -p hew-lib` — byte-for-byte the pre-fix
+/// pattern every migrated call site used to run with no cross-process
+/// coordination (ported from `run_cargo_build_hew_lib`, minus the lock).
+fn raw_unlocked_cargo_build_hew_lib() {
+    let (target_dir, profile) = target_dir_and_profile();
+    let mut cmd = Command::new(env::var_os("CARGO").unwrap_or_else(|| "cargo".into()));
+    cmd.args(["build", "-q", "-p", "hew-lib"])
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .current_dir(repo_root());
+    match profile.as_str() {
+        "debug" => {}
+        "release" => {
+            cmd.arg("--release");
+        }
+        other => {
+            cmd.args(["--profile", other]);
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let dep = env::var("MACOSX_DEPLOYMENT_TARGET")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| "13.0".to_string());
+        cmd.env("MACOSX_DEPLOYMENT_TARGET", dep);
+    }
+    let status = cmd.status().expect("spawn raw cargo build -p hew-lib");
+    assert!(status.success(), "raw cargo build -p hew-lib failed");
+}
+
+/// Matches the plan's grounded failure signatures: clang/cc's own
+/// `no such file or directory` / `cannot find` on `libhew.a` (or the
+/// linker's `linking failed`), not a `find_hew_lib`-level `exists()` miss.
+fn is_libhew_absence_signature(text: &str) -> bool {
+    let lower = text.to_lowercase();
+    let mentions_lib = lower.contains("libhew.a") || lower.contains("hew.lib");
+    let mentions_absence = lower.contains("no such file or directory")
+        || lower.contains("cannot find")
+        || lower.contains("linking failed");
+    mentions_lib && mentions_absence
+}
+
+/// A real consumer link: `hew compile` on a trivial fixture. Exercises the
+/// production path (`find_hew_lib` + `link_executable`, clang/cc) that the
+/// plan's grounded evidence's `clang: error: no such file or directory:
+/// '.../libhew.a'` signature comes from.
+fn real_compile_attempt(hew_bin: &Path, src: &Path, emit_dir: &Path) -> Result<(), String> {
+    let output = Command::new(hew_bin)
+        .arg("compile")
+        .arg(src)
+        .arg("--emit-dir")
+        .arg(emit_dir)
+        .output()
+        .map_err(|e| format!("spawn hew compile: {e}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(String::from_utf8_lossy(&output.stderr).into_owned())
+}
+
+/// Blocks until the orchestrator drops its write guard on `barrier_path` —
+/// every barrier-waiting child unblocks together. No sleep, no retry loop:
+/// the wait is a single blocking `fd_lock` acquisition.
+fn wait_at_barrier(barrier_path: &Path) {
+    let file = OpenOptions::new()
+        .read(true)
+        .open(barrier_path)
+        .expect("open barrier file");
+    let lock = RwLock::new(file);
+    let _guard = lock.read().expect("await barrier release");
+}
+
+fn write_result(text: &str) {
+    let path = PathBuf::from(env::var(RESULT_ENV).expect("result path env set"));
+    fs::write(path, text).expect("write child result");
+}
+
+// ---------------------------------------------------------------------
+// Child role bodies. Each is invoked by re-executing this same compiled
+// test binary (`std::env::current_exe()`), so `target_dir_and_profile()`
+// and `ensure_hew_lib_built()`'s own internal detection resolve to the
+// identical real `target/<profile>` directory as the parent.
+// ---------------------------------------------------------------------
+
+fn child_writer_gated(barrier_path: &Path) {
+    let iters: u32 = env::var(ITERS_ENV)
+        .expect("iters env set")
+        .parse()
+        .expect("iters env is a number");
+    wait_at_barrier(barrier_path);
+    for _ in 0..iters {
+        hew_testutil::ensure_hew_lib_built().expect("gated build");
+    }
+    write_result("done");
+}
+
+fn child_writer_unlocked(barrier_path: &Path) {
+    let iters: u32 = env::var(ITERS_ENV)
+        .expect("iters env set")
+        .parse()
+        .expect("iters env is a number");
+    wait_at_barrier(barrier_path);
+    for _ in 0..iters {
+        raw_unlocked_cargo_build_hew_lib();
+    }
+    write_result("done");
+}
+
+/// Post-fix consumer: gate immediately before every real link, exactly like
+/// every migrated call site (`ensure_hew_runtime_lib(repo)` then
+/// `hew_command(repo).arg("run"/"compile")`).
+fn child_reader_gated(barrier_path: &Path) {
+    let stop_path = PathBuf::from(env::var(STOP_ENV).expect("stop path env set"));
+    let hew_bin = hew_bin_path();
+    let scratch = tempfile::tempdir().expect("reader scratch dir");
+    let src = scratch.path().join("probe.hew");
+    fs::write(&src, "fn main() {}\n").expect("write probe fixture");
+    wait_at_barrier(barrier_path);
+    let mut attempts = 0u32;
+    let mut failures = Vec::new();
+    while !stop_path.exists() {
+        attempts += 1;
+        hew_testutil::ensure_hew_lib_built().expect("gated build before consume");
+        let emit_dir = scratch.path().join(format!("out-{attempts}"));
+        if let Err(stderr) = real_compile_attempt(&hew_bin, &src, &emit_dir) {
+            if is_libhew_absence_signature(&stderr) {
+                failures.push(stderr);
+            }
+        }
+    }
+    write_result(&format!(
+        "attempts={attempts} failures={}\n{}",
+        failures.len(),
+        failures.join("\n---\n")
+    ));
+}
+
+/// Pre-fix consumer: no gate call at all — a naked link against whatever
+/// happens to be on disk, matching the pre-fix call-site pattern exactly.
+fn child_reader_unguarded(barrier_path: &Path) {
+    let stop_path = PathBuf::from(env::var(STOP_ENV).expect("stop path env set"));
+    let hew_bin = hew_bin_path();
+    let scratch = tempfile::tempdir().expect("reader scratch dir");
+    let src = scratch.path().join("probe.hew");
+    fs::write(&src, "fn main() {}\n").expect("write probe fixture");
+    wait_at_barrier(barrier_path);
+    let mut attempts = 0u32;
+    let mut failures = Vec::new();
+    while !stop_path.exists() {
+        attempts += 1;
+        let emit_dir = scratch.path().join(format!("out-{attempts}"));
+        if let Err(stderr) = real_compile_attempt(&hew_bin, &src, &emit_dir) {
+            if is_libhew_absence_signature(&stderr) {
+                failures.push(stderr);
+            }
+        }
+    }
+    write_result(&format!(
+        "attempts={attempts} failures={}\n{}",
+        failures.len(),
+        failures.join("\n---\n")
+    ));
+}
+
+fn child_timed_writer_gated(barrier_path: &Path) {
+    wait_at_barrier(barrier_path);
+    let started = Instant::now();
+    hew_testutil::ensure_hew_lib_built().expect("gated build");
+    let elapsed = started.elapsed();
+    write_result(&elapsed.as_millis().to_string());
+}
+
+/// Dispatches to a child role when `ROLE_ENV` is set (this process is a
+/// spawned worker, not the orchestrator); returns `true` in that case so the
+/// calling `#[test]` fn returns immediately without also orchestrating.
+fn maybe_run_child_role() -> bool {
+    let Ok(role) = env::var(ROLE_ENV) else {
+        return false;
+    };
+    let barrier_path = PathBuf::from(env::var(BARRIER_ENV).expect("barrier path env set"));
+    match role.as_str() {
+        "writer-gated" => child_writer_gated(&barrier_path),
+        "writer-unlocked" => child_writer_unlocked(&barrier_path),
+        "reader-gated" => child_reader_gated(&barrier_path),
+        "reader-unguarded" => child_reader_unguarded(&barrier_path),
+        "timed-writer-gated" => child_timed_writer_gated(&barrier_path),
+        other => panic!("unknown race role `{other}`"),
+    }
+    true
+}
+
+// ---------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------
+
+struct RaceChild {
+    child: Child,
+    result_path: PathBuf,
+}
+
+impl RaceChild {
+    fn wait_ok(&mut self, label: &str) {
+        let status = self
+            .child
+            .wait()
+            .unwrap_or_else(|e| panic!("await {label}: {e}"));
+        assert!(status.success(), "{label} exited non-zero: {status:?}");
+    }
+
+    fn result(&self) -> String {
+        fs::read_to_string(&self.result_path).unwrap_or_default()
+    }
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "each param is a distinct piece of one child's spawn contract; splitting into a struct would obscure the barrier/stop/iters/run_id role-dependent shape at call sites"
+)]
+fn spawn_role(
+    exe: &Path,
+    test_name: &str,
+    role: &str,
+    barrier_path: &Path,
+    stop_path: Option<&Path>,
+    iters: Option<u32>,
+    run_id: Option<&str>,
+    result_dir: &Path,
+    tag: &str,
+) -> RaceChild {
+    let result_path = result_dir.join(format!("{tag}.result"));
+    let mut cmd = Command::new(exe);
+    cmd.args([
+        "--exact",
+        test_name,
+        "--ignored",
+        "--nocapture",
+        "--test-threads=1",
+    ]);
+    cmd.env(ROLE_ENV, role);
+    cmd.env(BARRIER_ENV, barrier_path);
+    cmd.env(RESULT_ENV, &result_path);
+    if let Some(stop) = stop_path {
+        cmd.env(STOP_ENV, stop);
+    }
+    if let Some(iters) = iters {
+        cmd.env(ITERS_ENV, iters.to_string());
+    }
+    match run_id {
+        Some(run_id) => {
+            cmd.env("NEXTEST_RUN_ID", run_id);
+        }
+        None => {
+            cmd.env_remove("NEXTEST_RUN_ID");
+        }
+    }
+    let child = cmd.spawn().expect("spawn race child process");
+    RaceChild { child, result_path }
+}
+
+fn parse_reader_result(text: &str) -> (u32, u32, String) {
+    let mut lines = text.lines();
+    let header = lines.next().unwrap_or("attempts=0 failures=0");
+    let mut attempts = 0u32;
+    let mut failures = 0u32;
+    for part in header.split_whitespace() {
+        if let Some(v) = part.strip_prefix("attempts=") {
+            attempts = v.parse().unwrap_or(0);
+        } else if let Some(v) = part.strip_prefix("failures=") {
+            failures = v.parse().unwrap_or(0);
+        }
+    }
+    let log: String = lines.collect::<Vec<_>>().join("\n");
+    (attempts, failures, log)
+}
+
+fn open_write_lock(barrier_path: &Path) -> RwLock<fs::File> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(barrier_path)
+        .expect("open barrier for write-lock");
+    RwLock::new(file)
+}
+
+fn ensure_hew_binary_built() {
+    let (target_dir, _profile) = target_dir_and_profile();
+    let status = Command::new(env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
+        .args(["build", "-q", "-p", "hew-cli", "--bin", "hew"])
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .current_dir(repo_root())
+        .status()
+        .expect("spawn cargo build -p hew-cli --bin hew");
+    assert!(status.success(), "prebuild of `hew` binary failed");
+}
+
+/// Deterministic negative control: `writer_count` real, unlocked
+/// `cargo build -p hew-lib` processes rebuild the real artifact while a
+/// background thread busy-polls its existence (`std::hint::spin_loop`, no
+/// sleep) for as long as the writers are alive. Termination is bounded by
+/// the writers' fixed-iteration real lifetime, not by a retry-until-pass
+/// condition. Returns (`poll_hits`, `real_link_failures`) — the poll hits are
+/// the load-bearing signal (matches the grounded 136/136 methodology and
+/// does not depend on a real linker's process-spawn timing landing inside a
+/// multi-microsecond window); the real-link failures are best-effort
+/// corroboration from real `hew compile` readers racing concurrently.
+fn run_unlocked_arm(exe: &Path, test_name: &str, scratch: &Path) -> (u32, u32) {
+    let artifact = libhew_path();
+    let barrier_path = scratch.join("unlocked-barrier.lock");
+    fs::write(&barrier_path, b"").expect("create barrier file");
+    let stop_path = scratch.join("unlocked-stop");
+    let result_dir = scratch.join("unlocked-results");
+    fs::create_dir_all(&result_dir).expect("create result dir");
+
+    let mut barrier_lock = open_write_lock(&barrier_path);
+    let guard = barrier_lock.write().expect("acquire barrier write-lock");
+
+    let writer_count = 3u32;
+    let iters = 8u32;
+    let mut writers: Vec<RaceChild> = (0..writer_count)
+        .map(|i| {
+            spawn_role(
+                exe,
+                test_name,
+                "writer-unlocked",
+                &barrier_path,
+                None,
+                Some(iters),
+                None,
+                &result_dir,
+                &format!("writer-{i}"),
+            )
+        })
+        .collect();
+    let reader_count = 6u32;
+    let mut readers: Vec<RaceChild> = (0..reader_count)
+        .map(|i| {
+            spawn_role(
+                exe,
+                test_name,
+                "reader-unguarded",
+                &barrier_path,
+                Some(&stop_path),
+                None,
+                None,
+                &result_dir,
+                &format!("reader-{i}"),
+            )
+        })
+        .collect();
+
+    let poll_stop = Arc::new(AtomicBool::new(false));
+    let thread_stop = Arc::clone(&poll_stop);
+    let poll_artifact = artifact.clone();
+    let poller = thread::spawn(move || {
+        let mut hits = 0u32;
+        while !thread_stop.load(Ordering::Relaxed) {
+            if !poll_artifact.exists() {
+                hits += 1;
+            }
+            std::hint::spin_loop();
+        }
+        hits
+    });
+
+    drop(guard); // release the barrier -- writers start rebuilding now
+
+    for w in &mut writers {
+        w.wait_ok("writer-unlocked child");
+    }
+    poll_stop.store(true, Ordering::Relaxed);
+    let poll_hits = poller.join().expect("poll thread should not panic");
+
+    fs::write(&stop_path, b"").expect("signal readers to stop");
+    let mut real_link_failures = 0u32;
+    for r in &mut readers {
+        r.wait_ok("reader-unguarded child");
+        let (_attempts, failures, _log) = parse_reader_result(&r.result());
+        real_link_failures += failures;
+    }
+
+    (poll_hits, real_link_failures)
+}
+
+/// Positive control: every participant (writers AND readers) calls the real
+/// `ensure_hew_lib_built()` before touching `libhew.a`, sharing one fresh
+/// `NEXTEST_RUN_ID` — exactly the migrated call-site pattern. The lock makes
+/// "zero absence failures" a structural guarantee here, not a timing bet, so
+/// asserting on it deterministically is safe.
+fn run_gated_arm(exe: &Path, test_name: &str, scratch: &Path) -> (u32, u32, String) {
+    let run_id = format!("race-link-{}-{}", std::process::id(), unique_suffix());
+    let barrier_path = scratch.join("gated-barrier.lock");
+    fs::write(&barrier_path, b"").expect("create barrier file");
+    let stop_path = scratch.join("gated-stop");
+    let result_dir = scratch.join("gated-results");
+    fs::create_dir_all(&result_dir).expect("create result dir");
+
+    let mut barrier_lock = open_write_lock(&barrier_path);
+    let guard = barrier_lock.write().expect("acquire barrier write-lock");
+
+    let writer_count = 3u32;
+    let iters = 6u32;
+    let mut writers: Vec<RaceChild> = (0..writer_count)
+        .map(|i| {
+            spawn_role(
+                exe,
+                test_name,
+                "writer-gated",
+                &barrier_path,
+                None,
+                Some(iters),
+                Some(&run_id),
+                &result_dir,
+                &format!("writer-{i}"),
+            )
+        })
+        .collect();
+    let reader_count = 6u32;
+    let mut readers: Vec<RaceChild> = (0..reader_count)
+        .map(|i| {
+            spawn_role(
+                exe,
+                test_name,
+                "reader-gated",
+                &barrier_path,
+                Some(&stop_path),
+                None,
+                Some(&run_id),
+                &result_dir,
+                &format!("reader-{i}"),
+            )
+        })
+        .collect();
+
+    drop(guard); // release the barrier -- everyone starts together
+
+    for w in &mut writers {
+        w.wait_ok("writer-gated child");
+    }
+    fs::write(&stop_path, b"").expect("signal readers to stop");
+
+    let mut total_attempts = 0u32;
+    let mut total_failures = 0u32;
+    let mut failure_log = String::new();
+    for r in &mut readers {
+        r.wait_ok("reader-gated child");
+        let (attempts, failures, log) = parse_reader_result(&r.result());
+        total_attempts += attempts;
+        total_failures += failures;
+        if !log.is_empty() {
+            failure_log.push_str(&log);
+            failure_log.push('\n');
+        }
+    }
+    (total_attempts, total_failures, failure_log)
+}
+
+/// The core proving gate: real OS processes, real `cargo build -p hew-lib`,
+/// a real `hew compile` link, and a real shared `NEXTEST_RUN_ID`.
+///
+/// Arm A (pre-fix): unlocked writers really race `libhew.a` — a background
+/// poll thread deterministically observes the absence window (matching the
+/// plan's grounded 136/136 evidence), corroborated best-effort by real
+/// unguarded `hew compile` readers running concurrently.
+///
+/// Arm B (post-fix): every participant gates through `ensure_hew_lib_built`
+/// before touching `libhew.a`; real `hew compile` readers must see zero
+/// absence failures — a lock-exclusion guarantee, not a timing bet.
+#[test]
+#[ignore = "run by `make libhew-link-race-test` with the `hew` binary and libhew.a built"]
+fn concurrent_link_survives_libhew_bootstrap_race() {
+    if maybe_run_child_role() {
+        return;
+    }
+
+    let exe = env::current_exe().expect("resolve current_exe");
+    let test_name = "concurrent_link_survives_libhew_bootstrap_race";
+    ensure_hew_binary_built();
+
+    let scratch = tempfile::tempdir().expect("scratch dir");
+
+    let (poll_hits, unguarded_real_failures) = run_unlocked_arm(&exe, test_name, scratch.path());
+    assert!(
+        poll_hits >= 1,
+        "expected the unlocked writer pattern to expose at least one real \
+         libhew.a absence window (deterministic per the plan's grounded \
+         136/136 evidence); observed zero — the race harness itself may be \
+         broken, investigate before trusting the gated-arm proof below"
+    );
+    eprintln!(
+        "unlocked arm: poll_hits={poll_hits} real_hew_compile_link_failures={unguarded_real_failures} \
+         (best-effort corroboration; not load-bearing given real-linker process-spawn timing variance)"
+    );
+
+    let (gated_attempts, gated_failures, gated_log) =
+        run_gated_arm(&exe, test_name, scratch.path());
+    assert!(
+        gated_attempts > 0,
+        "gated readers should have attempted at least one real hew compile link"
+    );
+    assert_eq!(
+        gated_failures, 0,
+        "gated readers observed a libhew.a absence failure across {gated_attempts} \
+         real hew-compile attempts sharing one NEXTEST_RUN_ID: {gated_log}"
+    );
+}
+
+/// Focused proof that a shared `NEXTEST_RUN_ID` across real OS processes
+/// collapses concurrent bootstraps to exactly one real `cargo build -p
+/// hew-lib`. A real build costs whole seconds even as a no-op rebuild
+/// (grounded probe: ~4.2s); the stamp fast-path is a couple of filesystem
+/// reads (sub-100ms). Exactly one of N real processes sharing one run id
+/// should pay the real-build cost.
+/// Spawns `count` real processes behind one barrier, all sharing `run_id`,
+/// and returns each one's self-measured `ensure_hew_lib_built` elapsed ms.
+fn spawn_timed_batch(
+    exe: &Path,
+    test_name: &str,
+    run_id: &str,
+    result_dir: &Path,
+    tag_prefix: &str,
+    count: u32,
+) -> Vec<u64> {
+    let barrier_path = result_dir.join(format!("{tag_prefix}-barrier.lock"));
+    fs::write(&barrier_path, b"").expect("create barrier file");
+
+    let mut barrier_lock = open_write_lock(&barrier_path);
+    let guard = barrier_lock.write().expect("acquire barrier write-lock");
+
+    let mut children: Vec<RaceChild> = (0..count)
+        .map(|i| {
+            spawn_role(
+                exe,
+                test_name,
+                "timed-writer-gated",
+                &barrier_path,
+                None,
+                None,
+                Some(run_id),
+                result_dir,
+                &format!("{tag_prefix}-{i}"),
+            )
+        })
+        .collect();
+
+    drop(guard); // release -- every process in this batch starts together
+
+    children
+        .iter_mut()
+        .map(|c| {
+            c.wait_ok("timed-writer-gated child");
+            let text = c.result();
+            text.trim()
+                .parse()
+                .unwrap_or_else(|e| panic!("child reported non-numeric elapsed ms `{text}`: {e}"))
+        })
+        .collect()
+}
+
+/// Proves real `NEXTEST_RUN_ID` stamp sharing across process boundaries in
+/// two parts:
+///
+/// 1. A batch of real concurrent processes, all sharing one fresh run id,
+///    all call the real `ensure_hew_lib_built()` at once — every one must
+///    return `Ok` (the lock correctly serializes real cross-process
+///    contention; already proven for stubbed in-process threads by
+///    `hew_lib_bootstrap_tests::concurrent_callers_build_exactly_once`, now
+///    proven for real processes doing a real build).
+///
+/// 2. A lone leader process builds (with a second, different fresh run id)
+///    and only *after* it completes do the followers start, sharing the
+///    leader's run id. A real `cargo build -p hew-lib` costs a
+///    hardware-dependent but always-nontrivial amount of wall time (a
+///    single solo run here calibrates the "real build" baseline instead of
+///    hardcoding a duration); the stamp fast-path is a couple of file
+///    reads. Every follower must be a small fraction of the leader's time —
+///    the leader actually built, the followers free-rode on its stamp.
+#[test]
+#[ignore = "run by `make libhew-link-race-test` with the `hew` binary and libhew.a built"]
+fn stamp_sharing_across_real_processes_builds_exactly_once() {
+    if maybe_run_child_role() {
+        return;
+    }
+
+    let exe = env::current_exe().expect("resolve current_exe");
+    let test_name = "stamp_sharing_across_real_processes_builds_exactly_once";
+    let scratch = tempfile::tempdir().expect("scratch dir");
+
+    // Part 1: real concurrent contention, all racing a fresh run id.
+    let contend_run_id = format!(
+        "race-stamp-contend-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    );
+    let contend_dir = scratch.path().join("contend");
+    fs::create_dir_all(&contend_dir).expect("create contend result dir");
+    let contend_elapsed =
+        spawn_timed_batch(&exe, test_name, &contend_run_id, &contend_dir, "contend", 4);
+    assert_eq!(
+        contend_elapsed.len(),
+        4,
+        "all four concurrent contenders should report a result"
+    );
+
+    // Part 2: a lone leader builds; only then do followers share its stamp.
+    let leader_run_id = format!(
+        "race-stamp-leader-{}-{}",
+        std::process::id(),
+        unique_suffix()
+    );
+    let leader_dir = scratch.path().join("leader");
+    fs::create_dir_all(&leader_dir).expect("create leader result dir");
+    let leader_elapsed =
+        spawn_timed_batch(&exe, test_name, &leader_run_id, &leader_dir, "leader", 1);
+    let leader_ms = leader_elapsed[0];
+    assert!(
+        leader_ms > 0,
+        "the lone leader's real cargo build should take measurable wall time"
+    );
+
+    let follower_dir = scratch.path().join("followers");
+    fs::create_dir_all(&follower_dir).expect("create follower result dir");
+    let follower_elapsed = spawn_timed_batch(
+        &exe,
+        test_name,
+        &leader_run_id, // same run id as the leader -- must hit its stamp
+        &follower_dir,
+        "follower",
+        5,
+    );
+
+    // Each follower must be a small fraction of the leader's real-build
+    // time -- self-calibrated against this run's own leader measurement
+    // rather than a hardcoded duration, so it holds regardless of hardware
+    // speed or build-cache warmth.
+    let threshold_ms = (leader_ms / 3).max(1);
+    for (i, &ms) in follower_elapsed.iter().enumerate() {
+        assert!(
+            ms <= threshold_ms,
+            "follower {i} took {ms}ms sharing the leader's NEXTEST_RUN_ID \
+             (leader real build took {leader_ms}ms, threshold {threshold_ms}ms) \
+             -- expected it to fast-path off the leader's stamp instead of \
+             rebuilding; all follower elapsed times: {follower_elapsed:?}"
+        );
+    }
+}

--- a/hew-testutil/tests/libhew_link_race.rs
+++ b/hew-testutil/tests/libhew_link_race.rs
@@ -305,7 +305,7 @@ fn wait_with_deadline(child: &mut Child, deadline: Duration) -> Result<ExitStatu
 /// loop: the wait is a single blocking `fd_lock` acquisition.
 ///
 /// Before declaring readiness, a participant must prove it has actually
-/// engaged the barrier: a non-blocking `try_read` is expected to observe
+/// engaged the barrier: a non-blocking `try_read` is required to observe
 /// the orchestrator's held write-lock (`ErrorKind::WouldBlock`). Writing
 /// the ready marker any earlier would be a lie the orchestrator could act
 /// on -- it could release the barrier before this participant ever
@@ -314,6 +314,14 @@ fn wait_with_deadline(child: &mut Child, deadline: Duration) -> Result<ExitStatu
 /// Only after that observation does this function write the marker and
 /// perform the real blocking acquire, so the marker-to-block gap is a
 /// couple of instructions, not an open-ended scheduling window.
+///
+/// A `try_read` that *succeeds* is a hard test failure, not a tolerated
+/// fallback: the orchestrator always acquires the barrier's write-lock
+/// before spawning any participant and only releases it after every ready
+/// marker is observed, so a successful non-blocking read here means either
+/// this function ran outside that invariant or the barrier itself is
+/// broken -- either way there was nothing to prove contention against, so
+/// silently proceeding would let a false "ready" slip through undetected.
 fn wait_at_barrier(barrier_path: &Path, ready_path: &Path) {
     let file = OpenOptions::new()
         .read(true)
@@ -322,12 +330,11 @@ fn wait_at_barrier(barrier_path: &Path, ready_path: &Path) {
     let lock = RwLock::new(file);
     match lock.try_read() {
         Err(e) if e.kind() == ErrorKind::WouldBlock => {}
-        // The orchestrator's guard was already gone by the time this
-        // participant reached the barrier (legitimate under heavy
-        // scheduling load, though it means there was nothing left to prove
-        // contention against) -- drop the probe's guard and proceed; the
-        // ready marker and the read below still hold correctly.
-        Ok(guard) => drop(guard),
+        Ok(_guard) => panic!(
+            "try_read on barrier unexpectedly succeeded -- the barrier's write-lock was \
+             not held when this participant reached it, so readiness cannot be proven \
+             genuine; the orchestrator must hold the write-lock for the whole spawn window"
+        ),
         Err(e) => panic!("try_read on barrier failed unexpectedly: {e}"),
     }
     fs::write(ready_path, b"ready").expect("write ready marker");
@@ -816,6 +823,71 @@ struct UnlockedArmResult {
     unexpected: u32,
 }
 
+/// RAII-owned background poll thread for the unlocked (pre-fix) arm's
+/// absence-window diagnostic. Spawned before `await_ready` so it can
+/// acknowledge readiness like every other participant; guarantees the
+/// busy-spin loop is always stopped and joined -- even if `await_ready`
+/// panics on a readiness-ack timeout, or a later reap panics, before the
+/// caller's own `stop_and_join` runs -- so this thread can never keep
+/// spinning as an orphan just because an earlier participant failed.
+struct PollerGuard {
+    stop: Arc<AtomicBool>,
+    ready: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<u64>>,
+}
+
+impl PollerGuard {
+    fn spawn(artifact: PathBuf) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let ready = Arc::new(AtomicBool::new(false));
+        let thread_stop = Arc::clone(&stop);
+        let thread_ready = Arc::clone(&ready);
+        let handle = thread::spawn(move || {
+            thread_ready.store(true, Ordering::Release);
+            let mut hits = 0u64;
+            while !thread_stop.load(Ordering::Relaxed) {
+                if !artifact.exists() {
+                    hits += 1;
+                }
+                std::hint::spin_loop();
+            }
+            hits
+        });
+        Self {
+            stop,
+            ready,
+            handle: Some(handle),
+        }
+    }
+
+    /// Whether the poll thread has started and acknowledged readiness --
+    /// used as `await_ready`'s poller-readiness predicate.
+    fn is_ready(&self) -> bool {
+        self.ready.load(Ordering::Acquire)
+    }
+
+    /// Signals the poll thread to stop and joins it, returning the
+    /// observed hit count. The expected path; `Drop` is the backstop for
+    /// any panic that happens before this runs.
+    fn stop_and_join(mut self) -> u64 {
+        self.stop.store(true, Ordering::Relaxed);
+        self.handle
+            .take()
+            .expect("poll thread not yet joined")
+            .join()
+            .expect("poll thread should not panic")
+    }
+}
+
+impl Drop for PollerGuard {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
 /// Pre-fix arm: `writer_count` real, unlocked `cargo build -p hew-lib`
 /// processes rebuild the real artifact while a background thread
 /// busy-polls its existence (`std::hint::spin_loop`, no sleep) for as long
@@ -861,28 +933,9 @@ fn run_unlocked_arm(exe: &Path, test_name: &str, scratch: &Path) -> UnlockedArmR
         &mut ready_paths,
     );
 
-    let poll_stop = Arc::new(AtomicBool::new(false));
-    let poll_ready = Arc::new(AtomicBool::new(false));
-    let thread_stop = Arc::clone(&poll_stop);
-    let thread_ready = Arc::clone(&poll_ready);
-    let poll_artifact = artifact.clone();
-    let poller = thread::spawn(move || {
-        thread_ready.store(true, Ordering::Release);
-        let mut hits = 0u64;
-        while !thread_stop.load(Ordering::Relaxed) {
-            if !poll_artifact.exists() {
-                hits += 1;
-            }
-            std::hint::spin_loop();
-        }
-        hits
-    });
+    let poller = PollerGuard::spawn(artifact.clone());
 
-    await_ready(
-        &ready_paths,
-        || poll_ready.load(Ordering::Acquire),
-        READY_ACK_DEADLINE,
-    );
+    await_ready(&ready_paths, || poller.is_ready(), READY_ACK_DEADLINE);
 
     drop(guard); // release the barrier -- every participant starts together
 
@@ -891,8 +944,7 @@ fn run_unlocked_arm(exe: &Path, test_name: &str, scratch: &Path) -> UnlockedArmR
         &writer_batch.reap_all("writer-unlocked child"),
     );
 
-    poll_stop.store(true, Ordering::Relaxed);
-    let poll_hits = poller.join().expect("poll thread should not panic");
+    let poll_hits = poller.stop_and_join();
 
     fs::write(&stop_path, b"").expect("signal readers to stop");
 


### PR DESCRIPTION
## Summary
I centralized `libhew.a` test-build serialization in `hew-testutil` and migrated every test-side archive bootstrap to that shared lock. The new multi-process regression exercises real Cargo builds and executable links without archive replacement races.

## Verification
- `make ci-preflight`
- `make libhew-link-race-test`