### PR TITLE
fix(std): surface SMTP, MsgPack, and XML failures honestly

### DIFF
--- a/hew-std/src/msgpack.rs
+++ b/hew-std/src/msgpack.rs
@@ -176,6 +176,8 @@ fn check_depth(slice: &[u8]) -> Result<(), String> {
 /// `malloc`-allocated buffer. The length is written to `out_len`. Returns null
 /// on parse error or serialization failure.
 ///
+/// Call [`hew_msgpack_last_error`] to retrieve this actor's failure reason.
+///
 /// # Safety
 ///
 /// `json_str` must be a valid NUL-terminated C string.
@@ -186,20 +188,28 @@ pub unsafe extern "C" fn hew_msgpack_from_json(
     out_len: *mut usize,
 ) -> *mut u8 {
     if json_str.is_null() || out_len.is_null() {
+        set_msgpack_last_error("msgpack: null JSON input");
         return std::ptr::null_mut();
     }
     // SAFETY: json_str is a valid NUL-terminated C string per caller contract.
     let Some(s) = (unsafe { cstr_to_str(json_str) }) else {
+        set_msgpack_last_error("msgpack: JSON input was not valid UTF-8");
         return std::ptr::null_mut();
     };
-    let Ok(value) = serde_json::from_str::<serde_json::Value>(s) else {
-        return std::ptr::null_mut();
+    let value = match serde_json::from_str::<serde_json::Value>(s) {
+        Ok(value) => value,
+        Err(err) => {
+            set_msgpack_last_error(format!("msgpack: failed to parse JSON input: {err}"));
+            return std::ptr::null_mut();
+        }
     };
     let Ok(bytes) = rmp_serde::to_vec(&value) else {
+        set_msgpack_last_error("msgpack: failed to serialize to MessagePack");
         return std::ptr::null_mut();
     };
     // SAFETY: out_len is a valid pointer per caller contract.
     unsafe { *out_len = bytes.len() };
+    clear_msgpack_last_error();
     malloc_bytes(&bytes)
 }
 
@@ -471,6 +481,7 @@ pub unsafe extern "C" fn hew_msgpack_to_json_hew(v: *const BytesTriple) -> *mut 
     let bytes = unsafe { bytes_slice_from_triple(v) };
     if bytes.is_empty() {
         // Null/empty input → empty string (the C layer rejects len == 0).
+        set_msgpack_last_error("msgpack: invalid input buffer");
         return str_to_malloc("");
     }
     // SAFETY: bytes slice is valid for its length.

--- a/hew-std/src/smtp.rs
+++ b/hew-std/src/smtp.rs
@@ -131,10 +131,14 @@ pub unsafe extern "C" fn hew_smtp_connect(
     pass: *const c_char,
 ) -> *mut HewSmtpConn {
     let Some(port) = normalize_port(port) else {
+        set_smtp_last_error(format!(
+            "SMTP connect failed: port {port} out of range (must be 0..=65535)"
+        ));
         return std::ptr::null_mut();
     };
     // SAFETY: host is a valid NUL-terminated C string per caller contract.
     let Some(host_str) = (unsafe { cstr_to_str(host) }) else {
+        set_smtp_last_error("SMTP connect failed: host is null or invalid UTF-8");
         return std::ptr::null_mut();
     };
     // SAFETY: user is a valid NUL-terminated C string (or null) per caller contract.
@@ -143,6 +147,9 @@ pub unsafe extern "C" fn hew_smtp_connect(
     let pass_str = unsafe { cstr_to_str(pass) };
 
     let Ok(builder) = SmtpTransport::starttls_relay(host_str) else {
+        set_smtp_last_error(format!(
+            "SMTP connect failed: could not initialize relay for host `{host_str}`"
+        ));
         return std::ptr::null_mut();
     };
 
@@ -168,10 +175,14 @@ pub unsafe extern "C" fn hew_smtp_connect_tls(
     pass: *const c_char,
 ) -> *mut HewSmtpConn {
     let Some(port) = normalize_port(port) else {
+        set_smtp_last_error(format!(
+            "SMTP connect failed: port {port} out of range (must be 0..=65535)"
+        ));
         return std::ptr::null_mut();
     };
     // SAFETY: host is a valid NUL-terminated C string per caller contract.
     let Some(host_str) = (unsafe { cstr_to_str(host) }) else {
+        set_smtp_last_error("SMTP connect failed: host is null or invalid UTF-8");
         return std::ptr::null_mut();
     };
     // SAFETY: user is a valid NUL-terminated C string (or null) per caller contract.
@@ -180,6 +191,9 @@ pub unsafe extern "C" fn hew_smtp_connect_tls(
     let pass_str = unsafe { cstr_to_str(pass) };
 
     let Ok(builder) = SmtpTransport::relay(host_str) else {
+        set_smtp_last_error(format!(
+            "SMTP connect failed: could not initialize relay for host `{host_str}`"
+        ));
         return std::ptr::null_mut();
     };
 

--- a/hew-std/src/smtp.rs
+++ b/hew-std/src/smtp.rs
@@ -109,14 +109,16 @@ fn configure_builder(
     builder.build()
 }
 
-fn normalize_port(port: i32) -> Option<u16> {
+fn normalize_port(port: i64) -> Option<u16> {
     u16::try_from(port).ok()
 }
 
 /// Connect to an SMTP server using STARTTLS.
 ///
 /// Returns a heap-allocated [`HewSmtpConn`] on success, or null on error.
-/// `user` and `pass` may be null for unauthenticated connections.
+/// `user` and `pass` may be null for unauthenticated connections. `port` is
+/// `i64` (not `i32`) so a caller-supplied out-of-range value is rejected by
+/// `normalize_port` directly instead of being narrowed by a lossy cast first.
 /// The caller must close the connection with [`hew_smtp_close`].
 ///
 /// # Safety
@@ -126,7 +128,7 @@ fn normalize_port(port: i32) -> Option<u16> {
 #[no_mangle]
 pub unsafe extern "C" fn hew_smtp_connect(
     host: *const c_char,
-    port: i32,
+    port: i64,
     user: *const c_char,
     pass: *const c_char,
 ) -> *mut HewSmtpConn {
@@ -160,7 +162,8 @@ pub unsafe extern "C" fn hew_smtp_connect(
 /// Connect to an SMTP server using implicit TLS (typically port 465).
 ///
 /// Returns a heap-allocated [`HewSmtpConn`] on success, or null on error.
-/// `user` and `pass` may be null for unauthenticated connections.
+/// `user` and `pass` may be null for unauthenticated connections. `port` is
+/// `i64` for the same lossless-validation reason as [`hew_smtp_connect`].
 /// The caller must close the connection with [`hew_smtp_close`].
 ///
 /// # Safety
@@ -170,7 +173,7 @@ pub unsafe extern "C" fn hew_smtp_connect(
 #[no_mangle]
 pub unsafe extern "C" fn hew_smtp_connect_tls(
     host: *const c_char,
-    port: i32,
+    port: i64,
     user: *const c_char,
     pass: *const c_char,
 ) -> *mut HewSmtpConn {
@@ -350,7 +353,7 @@ pub unsafe extern "C" fn hew_smtp_send_html(
 
 unsafe fn connect_send_close(
     host: *const c_char,
-    port: i32,
+    port: i64,
     user: *const c_char,
     pass: *const c_char,
     send: impl FnOnce(*mut HewSmtpConn) -> i32,
@@ -371,7 +374,8 @@ unsafe fn connect_send_close(
 
 /// Connect using STARTTLS, send one plain-text email, and close the connection.
 ///
-/// Returns 0 on success, -1 on connection or send error.
+/// Returns 0 on success, -1 on connection or send error. `port` is `i64` for
+/// the same lossless-validation reason as [`hew_smtp_connect`].
 ///
 /// # Safety
 ///
@@ -381,7 +385,7 @@ unsafe fn connect_send_close(
 #[no_mangle]
 pub unsafe extern "C" fn hew_smtp_send_once(
     host: *const c_char,
-    port: i32,
+    port: i64,
     user: *const c_char,
     pass: *const c_char,
     from: *const c_char,
@@ -399,7 +403,8 @@ pub unsafe extern "C" fn hew_smtp_send_once(
 
 /// Connect using STARTTLS, send one HTML email, and close the connection.
 ///
-/// Returns 0 on success, -1 on connection or send error.
+/// Returns 0 on success, -1 on connection or send error. `port` is `i64` for
+/// the same lossless-validation reason as [`hew_smtp_connect`].
 ///
 /// # Safety
 ///
@@ -409,7 +414,7 @@ pub unsafe extern "C" fn hew_smtp_send_once(
 #[no_mangle]
 pub unsafe extern "C" fn hew_smtp_send_html_once(
     host: *const c_char,
-    port: i32,
+    port: i64,
     user: *const c_char,
     pass: *const c_char,
     from: *const c_char,
@@ -471,6 +476,16 @@ mod tests {
         assert_eq!(normalize_port(65_535), Some(65_535));
         assert_eq!(normalize_port(-1), None);
         assert_eq!(normalize_port(65_536), None);
+    }
+
+    #[test]
+    fn normalize_port_rejects_oversized_i64_without_wrapping_into_a_valid_port() {
+        // 4_294_967_883 == 587 + 2^32. A lossy i64->i32 truncation before this
+        // check would wrap it down to the "valid" port 587; normalize_port
+        // takes the full i64 directly, so it must reject the value outright.
+        assert_eq!(normalize_port(4_294_967_883), None);
+        assert_eq!(normalize_port(i64::MAX), None);
+        assert_eq!(normalize_port(i64::MIN), None);
     }
 
     #[test]

--- a/std/encoding/msgpack/msgpack.hew
+++ b/std/encoding/msgpack/msgpack.hew
@@ -27,12 +27,47 @@ pub fn from_json(json: string) -> bytes {
     }
 }
 
+/// Encode a JSON string to MessagePack binary.
+///
+/// Returns `Err(reason)` on invalid JSON or serialization failure.
+pub fn try_from_json(json: string) -> Result<bytes, string> {
+    let data = unsafe { hew_msgpack_from_json_hew(json) };
+    if data.len() == 0 {
+        Err(msgpack_err("msgpack: from_json failed"))
+    } else {
+        Ok(data)
+    }
+}
+
 /// Decode a MessagePack `bytes` buffer to a JSON string.
 ///
 /// Returns an empty string on error.
 pub fn to_json(data: bytes) -> string {
     unsafe {
         hew_msgpack_to_json_hew(data)
+    }
+}
+
+/// Decode a MessagePack `bytes` buffer to a JSON string.
+///
+/// Returns `Err(reason)` on invalid input or deserialization failure.
+pub fn try_to_json(data: bytes) -> Result<string, string> {
+    let json = unsafe { hew_msgpack_to_json_hew(data) };
+    if json.len() == 0 {
+        Err(msgpack_err("msgpack: to_json failed"))
+    } else {
+        Ok(json)
+    }
+}
+
+/// Read `last_error()` and fall back to `fallback` when the FFI reports
+/// nothing specific.
+fn msgpack_err(fallback: string) -> string {
+    let detail = unsafe { hew_msgpack_last_error() };
+    if detail.len() > 0 {
+        detail
+    } else {
+        fallback
     }
 }
 
@@ -61,6 +96,7 @@ pub fn encode_bytes(data: bytes) -> bytes {
 extern "C" {
     fn hew_msgpack_from_json_hew(json: string) -> bytes;
     fn hew_msgpack_to_json_hew(data: bytes) -> string;
+    fn hew_msgpack_last_error() -> string;
     fn hew_msgpack_encode_int_hew(val: i64) -> bytes;
     fn hew_msgpack_encode_string_hew(s: string) -> bytes;
     fn hew_msgpack_encode_bytes_hew(data: bytes) -> bytes;

--- a/std/encoding/msgpack/msgpack.hew
+++ b/std/encoding/msgpack/msgpack.hew
@@ -31,7 +31,9 @@ pub fn from_json(json: string) -> bytes {
 ///
 /// Returns `Err(reason)` on invalid JSON or serialization failure.
 pub fn try_from_json(json: string) -> Result<bytes, string> {
-    let data = unsafe { hew_msgpack_from_json_hew(json) };
+    let data = unsafe {
+        hew_msgpack_from_json_hew(json)
+    };
     if data.len() == 0 {
         Err(msgpack_err("msgpack: from_json failed"))
     } else {
@@ -52,7 +54,9 @@ pub fn to_json(data: bytes) -> string {
 ///
 /// Returns `Err(reason)` on invalid input or deserialization failure.
 pub fn try_to_json(data: bytes) -> Result<string, string> {
-    let json = unsafe { hew_msgpack_to_json_hew(data) };
+    let json = unsafe {
+        hew_msgpack_to_json_hew(data)
+    };
     if json.len() == 0 {
         Err(msgpack_err("msgpack: to_json failed"))
     } else {
@@ -63,7 +67,9 @@ pub fn try_to_json(data: bytes) -> Result<string, string> {
 /// Read `last_error()` and fall back to `fallback` when the FFI reports
 /// nothing specific.
 fn msgpack_err(fallback: string) -> string {
-    let detail = unsafe { hew_msgpack_last_error() };
+    let detail = unsafe {
+        hew_msgpack_last_error()
+    };
     if detail.len() > 0 {
         detail
     } else {

--- a/std/encoding/xml/xml.hew
+++ b/std/encoding/xml/xml.hew
@@ -107,9 +107,39 @@ impl Node {
 
 // ── Module-level functions ────────────────────────────────────────────
 /// Parse an XML string into a `Node` tree.
+///
+/// Panics with the parser's reason if `s` is not well-formed XML.
+///
+/// A non-panicking `try_parse` counterpart returning `Result<Node, string>`
+/// is not offered: `Node` is `#[resource]`-wrapped around an `#[opaque]`
+/// handle, and constructing any enum (`Result` or user-defined) that pairs
+/// that payload with a second, heap-owning variant (e.g. `string`) hits an
+/// unrelated codegen limitation (`OpaqueHandle` has no dup/clone helper,
+/// which today's enum-construction path requires unconditionally for every
+/// variant, not just the active one). Confirmed with minimal repros: a
+/// plain scalar second variant (`i64`) compiles, but any heap-owning
+/// second variant (`string`, or a record wrapping `string`) does not.
+/// Callers that must not panic can guard with `xml.is_wellformed(s)` first.
 pub fn parse(s: string) -> Node {
     unsafe {
-        Node { handle: hew_xml_parse(s) }
+        let handle = hew_xml_parse(s);
+        if hew_xml_is_element(handle) < 0 { // -1 ⟺ null ⟺ parse failed
+            panic(f"xml.parse: {hew_xml_last_error()}");
+        }
+        Node { handle: handle }
+    }
+}
+
+/// Report whether `s` is well-formed XML, without constructing a `Node`.
+///
+/// Use this to guard a call to `parse(s)` when the input's well-formedness
+/// is not already known, avoiding the panic.
+pub fn is_wellformed(s: string) -> bool {
+    unsafe {
+        let handle = hew_xml_parse(s);
+        let ok = hew_xml_is_element(handle) >= 0;
+        hew_xml_free(handle);
+        ok
     }
 }
 
@@ -137,6 +167,7 @@ pub fn get_text(node: Node) -> string {
 // ── FFI bindings (implementation detail) ──────────────────────────────
 extern "C" {
     fn hew_xml_parse(xml_str: string) -> NodeHandle;
+    fn hew_xml_last_error() -> string;
     fn hew_xml_to_string(node: NodeHandle) -> string;
     fn hew_xml_get_tag(node: NodeHandle) -> string;
     fn hew_xml_get_attribute(node: NodeHandle, name: string) -> string;

--- a/std/net/smtp/smtp.hew
+++ b/std/net/smtp/smtp.hew
@@ -63,7 +63,7 @@ impl ConnMethods for Conn {
             hew_smtp_send(conn, from, to, subject, body)
         };
         if n < 0 {
-            Err("smtp send failed")
+            Err(smtp_err("smtp send failed"))
         } else {
             Ok(())
         }
@@ -80,7 +80,7 @@ impl ConnMethods for Conn {
             hew_smtp_send_html(conn, from, to, subject, html)
         };
         if n < 0 {
-            Err("smtp send_html failed")
+            Err(smtp_err("smtp send_html failed"))
         } else {
             Ok(())
         }
@@ -94,6 +94,29 @@ impl ConnMethods for Conn {
 }
 
 // ── Module-level functions ────────────────────────────────────────────
+/// Return the last SMTP client error observed on this thread.
+///
+/// Failed `connect()`/`connect_tls()`/`send()` calls update this string.
+/// Successful sends clear it. Call immediately after a failed
+/// `connect`/`send` for the precise reason.
+pub fn last_error() -> string {
+    unsafe {
+        hew_smtp_last_error()
+    }
+}
+
+/// Read `last_error()` and fall back to `fallback` when the FFI reports
+/// nothing specific (should not happen once every failure path is wired,
+/// but keeps the contract fail-safe).
+fn smtp_err(fallback: string) -> string {
+    let detail = unsafe { hew_smtp_last_error() };
+    if detail.len() > 0 {
+        detail
+    } else {
+        fallback
+    }
+}
+
 /// Connect to an SMTP server using STARTTLS.
 ///
 /// # Examples
@@ -138,7 +161,7 @@ pub fn try_send(host: string, port: i64, username: string, password: string, fro
         hew_smtp_send_once(host, port as i32, username, password, from, to, subject, body)
     };
     if n < 0 {
-        Err("smtp send failed")
+        Err(smtp_err("smtp send failed"))
     } else {
         Ok(())
     }
@@ -162,7 +185,7 @@ pub fn try_send_html(host: string, port: i64, username: string, password: string
         hew_smtp_send_html_once(host, port as i32, username, password, from, to, subject, html)
     };
     if n < 0 {
-        Err("smtp send_html failed")
+        Err(smtp_err("smtp send_html failed"))
     } else {
         Ok(())
     }
@@ -172,6 +195,7 @@ pub fn try_send_html(host: string, port: i64, username: string, password: string
 extern "C" {
     fn hew_smtp_connect(host: string, port: i32, username: string, password: string) -> Conn;
     fn hew_smtp_connect_tls(host: string, port: i32, username: string, password: string) -> Conn;
+    fn hew_smtp_last_error() -> string;
     fn hew_smtp_send(conn: Conn, from: string, to: string, subject: string, body: string) -> i32;
     fn hew_smtp_send_html(conn: Conn, from: string, to: string, subject: string, html: string) -> i32;
     fn hew_smtp_send_once(host: string, port: i32, username: string, password: string, from: string, to: string, subject: string, body: string) -> i32;

--- a/std/net/smtp/smtp.hew
+++ b/std/net/smtp/smtp.hew
@@ -109,7 +109,9 @@ pub fn last_error() -> string {
 /// nothing specific (should not happen once every failure path is wired,
 /// but keeps the contract fail-safe).
 fn smtp_err(fallback: string) -> string {
-    let detail = unsafe { hew_smtp_last_error() };
+    let detail = unsafe {
+        hew_smtp_last_error()
+    };
     if detail.len() > 0 {
         detail
     } else {

--- a/std/net/smtp/smtp.hew
+++ b/std/net/smtp/smtp.hew
@@ -126,7 +126,7 @@ fn smtp_err(fallback: string) -> string {
 /// ```
 pub fn connect(host: string, port: i64, username: string, password: string) -> Conn {
     unsafe {
-        hew_smtp_connect(host, port as i32, username, password)
+        hew_smtp_connect(host, port, username, password)
     }
 }
 
@@ -139,7 +139,7 @@ pub fn connect(host: string, port: i64, username: string, password: string) -> C
 /// ```
 pub fn connect_tls(host: string, port: i64, username: string, password: string) -> Conn {
     unsafe {
-        hew_smtp_connect_tls(host, port as i32, username, password)
+        hew_smtp_connect_tls(host, port, username, password)
     }
 }
 
@@ -150,15 +150,15 @@ pub fn connect_tls(host: string, port: i64, username: string, password: string) 
 /// to reuse a connection for multiple messages.
 pub fn send(host: string, port: i64, username: string, password: string, from: string, to: string, subject: string, body: string) -> i64 {
     unsafe {
-        hew_smtp_send_once(host, port as i32, username, password, from, to, subject, body)
-    } as i64 // INTERNAL-ABI: FFI returns i32; C ABI takes i32 port
+        hew_smtp_send_once(host, port, username, password, from, to, subject, body)
+    } as i64 // INTERNAL-ABI: FFI returns i32
 }
 
 /// Connect with the same STARTTLS path as `connect(...)`, send one plain-text
 /// email, and close the connection.
 pub fn try_send(host: string, port: i64, username: string, password: string, from: string, to: string, subject: string, body: string) -> Result<(), string> {
     let n: i32 = unsafe {
-        hew_smtp_send_once(host, port as i32, username, password, from, to, subject, body)
+        hew_smtp_send_once(host, port, username, password, from, to, subject, body)
     };
     if n < 0 {
         Err(smtp_err("smtp send failed"))
@@ -174,15 +174,15 @@ pub fn try_send(host: string, port: i64, username: string, password: string, fro
 /// want to reuse a connection for multiple messages.
 pub fn send_html(host: string, port: i64, username: string, password: string, from: string, to: string, subject: string, html: string) -> i64 {
     unsafe {
-        hew_smtp_send_html_once(host, port as i32, username, password, from, to, subject, html)
-    } as i64 // INTERNAL-ABI: FFI returns i32; C ABI takes i32 port
+        hew_smtp_send_html_once(host, port, username, password, from, to, subject, html)
+    } as i64 // INTERNAL-ABI: FFI returns i32
 }
 
 /// Connect with the same STARTTLS path as `connect(...)`, send one HTML email,
 /// and close the connection.
 pub fn try_send_html(host: string, port: i64, username: string, password: string, from: string, to: string, subject: string, html: string) -> Result<(), string> {
     let n: i32 = unsafe {
-        hew_smtp_send_html_once(host, port as i32, username, password, from, to, subject, html)
+        hew_smtp_send_html_once(host, port, username, password, from, to, subject, html)
     };
     if n < 0 {
         Err(smtp_err("smtp send_html failed"))
@@ -193,12 +193,12 @@ pub fn try_send_html(host: string, port: i64, username: string, password: string
 
 // ── FFI bindings (implementation detail) ──────────────────────────────
 extern "C" {
-    fn hew_smtp_connect(host: string, port: i32, username: string, password: string) -> Conn;
-    fn hew_smtp_connect_tls(host: string, port: i32, username: string, password: string) -> Conn;
+    fn hew_smtp_connect(host: string, port: i64, username: string, password: string) -> Conn;
+    fn hew_smtp_connect_tls(host: string, port: i64, username: string, password: string) -> Conn;
     fn hew_smtp_last_error() -> string;
     fn hew_smtp_send(conn: Conn, from: string, to: string, subject: string, body: string) -> i32;
     fn hew_smtp_send_html(conn: Conn, from: string, to: string, subject: string, html: string) -> i32;
-    fn hew_smtp_send_once(host: string, port: i32, username: string, password: string, from: string, to: string, subject: string, body: string) -> i32;
-    fn hew_smtp_send_html_once(host: string, port: i32, username: string, password: string, from: string, to: string, subject: string, html: string) -> i32;
+    fn hew_smtp_send_once(host: string, port: i64, username: string, password: string, from: string, to: string, subject: string, body: string) -> i32;
+    fn hew_smtp_send_html_once(host: string, port: i64, username: string, password: string, from: string, to: string, subject: string, html: string) -> i32;
     fn hew_smtp_close(conn: Conn);
 }

--- a/tests/hew/msgpack_test.hew
+++ b/tests/hew/msgpack_test.hew
@@ -48,6 +48,60 @@ fn test_from_json_invalid_returns_empty() {
     testing.assert_eq(packed.len(), 0);
 }
 
+#[test]
+fn test_try_from_json_invalid_surfaces_reason() {
+    let result = msgpack.try_from_json("{not valid json!!!");
+    match result {
+        Ok(_) => panic("expected invalid JSON to fail"),
+        Err(msg) => {
+            testing.assert_true(msg.contains("msgpack:"));
+            testing.assert_true(msg.contains("parse JSON"));
+        },
+    }
+}
+
+#[test]
+fn test_try_to_json_empty_surfaces_reason() {
+    // from_json("{not json}") yields empty bytes (the documented sentinel);
+    // try_to_json of that empty buffer must surface the specific reason.
+    let empty = msgpack.from_json("{not json}");
+    let result = msgpack.try_to_json(empty);
+    match result {
+        Ok(_) => panic("expected empty input to fail"),
+        Err(msg) => testing.assert_true(msg.contains("invalid input buffer")),
+    }
+}
+
+#[test]
+fn test_try_from_json_valid_ok() {
+    let result = msgpack.try_from_json("{\"n\": 42}");
+    match result {
+        Ok(data) => testing.assert_true(data.len() > 0),
+        Err(_) => panic("expected valid JSON to succeed"),
+    }
+}
+
+#[test]
+fn test_try_to_json_valid_ok() {
+    let packed = msgpack.from_json("{\"n\": 42}");
+    let result = msgpack.try_to_json(packed);
+    match result {
+        Ok(recovered) => {
+            let r = json.try_parse(recovered);
+            match r {
+                Ok(val) => {
+                    let field = val.get_field("n");
+                    testing.assert_eq(field.get_int(), 42);
+                    field.free();
+                    val.free();
+                },
+                Err(_) => panic("try_to_json round-trip produced unparseable JSON"),
+            }
+        },
+        Err(_) => panic("expected valid msgpack bytes to succeed"),
+    }
+}
+
 // ── string root round-trip ────────────────────────────────────────────
 
 #[test]

--- a/tests/hew/msgpack_test.hew
+++ b/tests/hew/msgpack_test.hew
@@ -1,11 +1,12 @@
 //! Behavioural tests for std::encoding::msgpack.
 
 import std::encoding::msgpack;
+
 import std::encoding::json;
+
 import std::testing;
 
 // ── from_json / to_json round-trip ────────────────────────────────────
-
 #[test]
 fn test_from_json_to_json_round_trip_int_field() {
     // Encode JSON with an integer field → MessagePack bytes → JSON string
@@ -27,7 +28,6 @@ fn test_from_json_to_json_round_trip_int_field() {
 }
 
 // ── encode_int / encode_string ────────────────────────────────────────
-
 #[test]
 fn test_encode_int_produces_nonempty_bytes() {
     let encoded = msgpack.encode_int(7);
@@ -41,7 +41,6 @@ fn test_encode_string_produces_nonempty_bytes() {
 }
 
 // ── Error boundary ────────────────────────────────────────────────────
-
 #[test]
 fn test_from_json_invalid_returns_empty() {
     let packed = msgpack.from_json("{not json}");
@@ -103,7 +102,6 @@ fn test_try_to_json_valid_ok() {
 }
 
 // ── string root round-trip ────────────────────────────────────────────
-
 #[test]
 fn test_string_root_round_trip() {
     // from_json of a JSON string (not an object) → to_json → try_parse →
@@ -122,7 +120,6 @@ fn test_string_root_round_trip() {
 }
 
 // ── Array round-trip ──────────────────────────────────────────────────
-
 #[test]
 fn test_array_round_trip_length() {
     // from_json("[1, 2, 3]") → to_json → try_parse → array_len() == 3
@@ -160,7 +157,6 @@ fn test_array_round_trip_elements() {
 }
 
 // ── Nested object round-trip ──────────────────────────────────────────
-
 #[test]
 fn test_nested_object_round_trip() {
     // from_json("{\"a\": {\"b\": 7}}") → to_json → try_parse → walk a → b.
@@ -183,7 +179,6 @@ fn test_nested_object_round_trip() {
 }
 
 // ── Unicode string round-trip ─────────────────────────────────────────
-
 #[test]
 fn test_unicode_string_field_round_trip() {
     // Multi-byte UTF-8 value survives msgpack encode → decode → JSON parse.
@@ -220,7 +215,6 @@ fn test_unicode_string_field_round_trip() {
 }
 
 // ── encode_int boundary cases ─────────────────────────────────────────
-
 #[test]
 fn test_encode_int_zero_produces_nonempty_bytes() {
     // msgpack positive fixint for 0 is the single byte 0x00.
@@ -259,7 +253,6 @@ fn test_encode_int_zero_round_trip() {
 }
 
 // ── encode_string boundary ────────────────────────────────────────────
-
 #[test]
 fn test_encode_string_empty_produces_nonempty_bytes() {
     // msgpack empty-string marker is the single byte 0xa0, so encode_string("")
@@ -269,7 +262,6 @@ fn test_encode_string_empty_produces_nonempty_bytes() {
 }
 
 // ── to_json error boundary ────────────────────────────────────────────
-
 #[test]
 fn test_to_json_empty_bytes_returns_empty_string() {
     // The C implementation rejects len==0 and returns null, which the Hew

--- a/tests/hew/smtp_test.hew
+++ b/tests/hew/smtp_test.hew
@@ -7,6 +7,7 @@
 //! hew-std/src/smtp.rs's `#[cfg(test)]` unit tests.
 
 import std::net::smtp;
+
 import std::testing;
 
 #[test]
@@ -48,7 +49,6 @@ fn test_conn_try_send_bad_from_surfaces_reason() {
 // port instead of rejecting the out-of-range value. Every case here must
 // fail fast with an explicit out-of-range message, never a real send/connect
 // attempt on port 587 (or any other wrapped value).
-
 #[test]
 fn test_module_try_send_oversized_i64_port_does_not_wrap() {
     let result = smtp.try_send("localhost", 4294967883, "u", "p", "a@example.com", "b@example.com", "s", "b");

--- a/tests/hew/smtp_test.hew
+++ b/tests/hew/smtp_test.hew
@@ -1,0 +1,41 @@
+//! Tests for std::net::smtp error surfacing.
+//!
+//! All cases here fail before any socket work happens (bad port, empty
+//! message body, unparsable address), so they run offline and
+//! deterministically. A live SMTP round-trip cannot be exercised without a
+//! real server; the success clear-path is covered by
+//! hew-std/src/smtp.rs's `#[cfg(test)]` unit tests.
+
+import std::net::smtp;
+import std::testing;
+
+#[test]
+fn test_module_try_send_bad_port_surfaces_reason() {
+    let result = smtp.try_send("localhost", 999999, "u", "p", "a@example.com", "b@example.com", "s", "b");
+    match result {
+        Ok(_) => panic("expected an out-of-range port to fail"),
+        Err(msg) => testing.assert_true(msg.contains("out of range")),
+    }
+}
+
+#[test]
+fn test_conn_try_send_empty_subject_body_surfaces_reason() {
+    let conn = smtp.connect("localhost", 25, "u", "p");
+    let result = conn.try_send("a@example.com", "b@example.com", "", "");
+    match result {
+        Ok(_) => panic("expected empty subject and body to fail"),
+        Err(msg) => testing.assert_true(msg.contains("subject and body cannot both be empty")),
+    }
+    conn.close();
+}
+
+#[test]
+fn test_conn_try_send_bad_from_surfaces_reason() {
+    let conn = smtp.connect("localhost", 25, "u", "p");
+    let result = conn.try_send("not-an-email", "b@example.com", "s", "b");
+    match result {
+        Ok(_) => panic("expected an unparsable from address to fail"),
+        Err(msg) => testing.assert_true(msg.contains("could not parse from address")),
+    }
+    conn.close();
+}

--- a/tests/hew/smtp_test.hew
+++ b/tests/hew/smtp_test.hew
@@ -39,3 +39,64 @@ fn test_conn_try_send_bad_from_surfaces_reason() {
     }
     conn.close();
 }
+
+// The following cases prove that an oversized i64 port does not silently
+// wrap into an unintended valid port before Rust validates it. Before the
+// FFI port parameter was widened from i32 to i64, `4294967883_i64 as i32`
+// truncated (two's-complement) down to 587 -- a "valid-looking" port -- and
+// the connection would proceed to attempt an SMTP handshake on the wrapped
+// port instead of rejecting the out-of-range value. Every case here must
+// fail fast with an explicit out-of-range message, never a real send/connect
+// attempt on port 587 (or any other wrapped value).
+
+#[test]
+fn test_module_try_send_oversized_i64_port_does_not_wrap() {
+    let result = smtp.try_send("localhost", 4294967883, "u", "p", "a@example.com", "b@example.com", "s", "b");
+    match result {
+        Ok(_) => panic("expected an oversized i64 port to fail, not wrap into a valid port"),
+        Err(msg) => testing.assert_true(msg.contains("out of range")),
+    }
+}
+
+#[test]
+fn test_module_try_send_html_oversized_i64_port_does_not_wrap() {
+    let result = smtp.try_send_html("localhost", 4294967883, "u", "p", "a@example.com", "b@example.com", "s", "<b>b</b>");
+    match result {
+        Ok(_) => panic("expected an oversized i64 port to fail, not wrap into a valid port"),
+        Err(msg) => testing.assert_true(msg.contains("out of range")),
+    }
+}
+
+#[test]
+fn test_module_send_oversized_i64_port_returns_nonzero() {
+    let rc = smtp.send("localhost", 4294967883, "u", "p", "a@example.com", "b@example.com", "s", "b");
+    testing.assert_true(rc != 0);
+    testing.assert_true(smtp.last_error().contains("out of range"));
+}
+
+#[test]
+fn test_conn_connect_oversized_i64_port_rejects_before_relay_init() {
+    // connect() has no Result contract, so an oversized port yields an
+    // unusable Conn; the failure is still visible via last_error() and via
+    // any subsequent send attempt refusing to proceed.
+    let conn = smtp.connect("localhost", 4294967883, "u", "p");
+    testing.assert_true(smtp.last_error().contains("out of range"));
+    let result = conn.try_send("a@example.com", "b@example.com", "s", "b");
+    match result {
+        Ok(_) => panic("expected connect() with an oversized port to leave an unusable conn"),
+        Err(_) => {},
+    }
+    conn.close();
+}
+
+#[test]
+fn test_conn_connect_tls_oversized_i64_port_rejects_before_relay_init() {
+    let conn = smtp.connect_tls("localhost", 4294967883, "u", "p");
+    testing.assert_true(smtp.last_error().contains("out of range"));
+    let result = conn.try_send("a@example.com", "b@example.com", "s", "b");
+    match result {
+        Ok(_) => panic("expected connect_tls() with an oversized port to leave an unusable conn"),
+        Err(_) => {},
+    }
+    conn.close();
+}

--- a/tests/hew/xml_test.hew
+++ b/tests/hew/xml_test.hew
@@ -72,7 +72,6 @@ fn test_get_child_rejects_index_that_would_wrap_to_zero() {
 }
 
 // ── Malformed input ───────────────────────────────────────────────────
-
 #[test]
 #[should_panic]
 fn test_parse_panics_on_malformed() {

--- a/tests/hew/xml_test.hew
+++ b/tests/hew/xml_test.hew
@@ -70,3 +70,21 @@ fn test_get_child_rejects_index_that_would_wrap_to_zero() {
     let root = xml.parse("<root><child/></root>");
     root.get_child(4294967296);
 }
+
+// ── Malformed input ───────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn test_parse_panics_on_malformed() {
+    xml.parse("<unclosed>no closing tag here");
+}
+
+#[test]
+fn test_is_wellformed_true_for_valid_xml() {
+    testing.assert_true(xml.is_wellformed("<a>text</a>"));
+}
+
+#[test]
+fn test_is_wellformed_false_for_malformed_xml() {
+    testing.assert_false(xml.is_wellformed("<unclosed"));
+}


### PR DESCRIPTION
## Summary
I surface existing SMTP and MsgPack failure details instead of discarding them, validate SMTP ports before they can narrow, and make malformed XML fail closed.

## Verification
- `make ci-preflight`
- `make test-hew`
- SMTP FFI boundary tests