### PR TITLE
fix(mir): report missing actor spawn fields as user errors

### DIFF
--- a/examples/v05/checked-mir/golden/supervisor_await_restart.elab.mir
+++ b/examples/v05/checked-mir/golden/supervisor_await_restart.elab.mir
@@ -15,13 +15,13 @@ fn App__bootstrap -> LocalPid<App>
 
 fn main -> i64
   statements:
-    bind BindingId(0) sup site=SiteId(1) ty=LocalPid<App>
-    use BindingId(0) sup site=SiteId(4) ty=LocalPid<App> intent=Read
-    bind BindingId(1) w2 site=SiteId(2) ty=LocalPid<Worker>
-    use BindingId(1) w2 site=SiteId(8) ty=LocalPid<Worker> intent=Read
-    return site=Some(SiteId(5)) ty=i64
-    bind BindingId(2) v site=SiteId(9) ty=i64
-    use BindingId(2) v site=SiteId(9) ty=i64 intent=Read
+    bind BindingId(0) sup site=SiteId(2) ty=LocalPid<App>
+    use BindingId(0) sup site=SiteId(5) ty=LocalPid<App> intent=Read
+    bind BindingId(1) w2 site=SiteId(3) ty=LocalPid<Worker>
+    use BindingId(1) w2 site=SiteId(9) ty=LocalPid<Worker> intent=Read
+    return site=Some(SiteId(6)) ty=i64
+    bind BindingId(2) v site=SiteId(10) ty=i64
+    use BindingId(2) v site=SiteId(10) ty=i64 intent=Read
     drop BindingId(1) w2 ty=LocalPid<Worker>
     drop BindingId(0) sup ty=LocalPid<App>
   drop_plans:
@@ -54,8 +54,8 @@ fn main -> i64
 
 fn i8::fmt -> string
   statements:
-    use BindingId(11) val site=SiteId(81) ty=i8 intent=Read
-    return site=Some(SiteId(79)) ty=string
+    use BindingId(11) val site=SiteId(82) ty=i8 intent=Read
+    return site=Some(SiteId(80)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -66,8 +66,8 @@ fn i8::fmt -> string
 
 fn i16::fmt -> string
   statements:
-    use BindingId(12) val site=SiteId(85) ty=i16 intent=Read
-    return site=Some(SiteId(83)) ty=string
+    use BindingId(12) val site=SiteId(86) ty=i16 intent=Read
+    return site=Some(SiteId(84)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -78,8 +78,8 @@ fn i16::fmt -> string
 
 fn i32::fmt -> string
   statements:
-    use BindingId(13) val site=SiteId(88) ty=i32 intent=Read
-    return site=Some(SiteId(87)) ty=string
+    use BindingId(13) val site=SiteId(89) ty=i32 intent=Read
+    return site=Some(SiteId(88)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -90,8 +90,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(14) val site=SiteId(91) ty=i64 intent=Read
-    return site=Some(SiteId(90)) ty=string
+    use BindingId(14) val site=SiteId(92) ty=i64 intent=Read
+    return site=Some(SiteId(91)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -102,8 +102,8 @@ fn i64::fmt -> string
 
 fn u8::fmt -> string
   statements:
-    use BindingId(15) val site=SiteId(94) ty=u8 intent=Read
-    return site=Some(SiteId(93)) ty=string
+    use BindingId(15) val site=SiteId(95) ty=u8 intent=Read
+    return site=Some(SiteId(94)) ty=string
   drop_plans:
     call[bb0 to_string_u8 -> bb1] ->
       (none)
@@ -114,8 +114,8 @@ fn u8::fmt -> string
 
 fn u16::fmt -> string
   statements:
-    use BindingId(16) val site=SiteId(97) ty=u16 intent=Read
-    return site=Some(SiteId(96)) ty=string
+    use BindingId(16) val site=SiteId(98) ty=u16 intent=Read
+    return site=Some(SiteId(97)) ty=string
   drop_plans:
     call[bb0 to_string_u16 -> bb1] ->
       (none)
@@ -126,8 +126,8 @@ fn u16::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(17) val site=SiteId(100) ty=u32 intent=Read
-    return site=Some(SiteId(99)) ty=string
+    use BindingId(17) val site=SiteId(101) ty=u32 intent=Read
+    return site=Some(SiteId(100)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -138,8 +138,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(18) val site=SiteId(103) ty=u64 intent=Read
-    return site=Some(SiteId(102)) ty=string
+    use BindingId(18) val site=SiteId(104) ty=u64 intent=Read
+    return site=Some(SiteId(103)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -150,8 +150,8 @@ fn u64::fmt -> string
 
 fn isize::fmt -> string
   statements:
-    use BindingId(19) val site=SiteId(107) ty=isize intent=Read
-    return site=Some(SiteId(105)) ty=string
+    use BindingId(19) val site=SiteId(108) ty=isize intent=Read
+    return site=Some(SiteId(106)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -162,8 +162,8 @@ fn isize::fmt -> string
 
 fn usize::fmt -> string
   statements:
-    use BindingId(20) val site=SiteId(111) ty=usize intent=Read
-    return site=Some(SiteId(109)) ty=string
+    use BindingId(20) val site=SiteId(112) ty=usize intent=Read
+    return site=Some(SiteId(110)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -174,8 +174,8 @@ fn usize::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(21) val site=SiteId(114) ty=bool intent=Read
-    return site=Some(SiteId(113)) ty=string
+    use BindingId(21) val site=SiteId(115) ty=bool intent=Read
+    return site=Some(SiteId(114)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -186,8 +186,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(22) val site=SiteId(117) ty=char intent=Read
-    return site=Some(SiteId(116)) ty=string
+    use BindingId(22) val site=SiteId(118) ty=char intent=Read
+    return site=Some(SiteId(117)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -198,8 +198,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(23) val site=SiteId(120) ty=f64 intent=Read
-    return site=Some(SiteId(119)) ty=string
+    use BindingId(23) val site=SiteId(121) ty=f64 intent=Read
+    return site=Some(SiteId(120)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -210,8 +210,8 @@ fn f64::fmt -> string
 
 fn f32::fmt -> string
   statements:
-    use BindingId(24) val site=SiteId(124) ty=f32 intent=Read
-    return site=Some(SiteId(122)) ty=string
+    use BindingId(24) val site=SiteId(125) ty=f32 intent=Read
+    return site=Some(SiteId(123)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -222,16 +222,16 @@ fn f32::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(25) val site=SiteId(126) ty=string intent=Read
-    return site=Some(SiteId(126)) ty=string
+    use BindingId(25) val site=SiteId(127) ty=string intent=Read
+    return site=Some(SiteId(127)) ty=string
   drop_plans:
     return[bb0] ->
       (none)
 
 fn duration::from_nanos -> duration
   statements:
-    use BindingId(26) n site=SiteId(128) ty=i64 intent=Read
-    return site=Some(SiteId(127)) ty=duration
+    use BindingId(26) n site=SiteId(129) ty=i64 intent=Read
+    return site=Some(SiteId(128)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -242,8 +242,8 @@ fn duration::from_nanos -> duration
 
 fn duration::from_micros -> duration
   statements:
-    use BindingId(27) n site=SiteId(131) ty=i64 intent=Read
-    return site=Some(SiteId(130)) ty=duration
+    use BindingId(27) n site=SiteId(132) ty=i64 intent=Read
+    return site=Some(SiteId(131)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -254,8 +254,8 @@ fn duration::from_micros -> duration
 
 fn duration::from_millis -> duration
   statements:
-    use BindingId(28) n site=SiteId(134) ty=i64 intent=Read
-    return site=Some(SiteId(133)) ty=duration
+    use BindingId(28) n site=SiteId(135) ty=i64 intent=Read
+    return site=Some(SiteId(134)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -266,8 +266,8 @@ fn duration::from_millis -> duration
 
 fn duration::from_secs -> duration
   statements:
-    use BindingId(29) n site=SiteId(137) ty=i64 intent=Read
-    return site=Some(SiteId(136)) ty=duration
+    use BindingId(29) n site=SiteId(138) ty=i64 intent=Read
+    return site=Some(SiteId(137)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -278,8 +278,8 @@ fn duration::from_secs -> duration
 
 fn duration::fmt -> string
   statements:
-    use BindingId(30) val site=SiteId(142) ty=duration intent=Read
-    return site=Some(SiteId(139)) ty=string
+    use BindingId(30) val site=SiteId(143) ty=duration intent=Read
+    return site=Some(SiteId(140)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)

--- a/examples/v05/checked-mir/golden/supervisor_await_restart.raw.mir
+++ b/examples/v05/checked-mir/golden/supervisor_await_restart.raw.mir
@@ -44,10 +44,10 @@ fn main() -> i64 [conv=default]
   bb0:
     _0 = call App__bootstrap() -> bb1
   bb1:
-    stmt: bind BindingId(0) sup site=SiteId(1) ty=LocalPid<App>
-    stmt: use BindingId(0) sup site=SiteId(4) ty=LocalPid<App> intent=Read
-    stmt: bind BindingId(1) w2 site=SiteId(2) ty=LocalPid<Worker>
-    stmt: use BindingId(1) w2 site=SiteId(8) ty=LocalPid<Worker> intent=Read
+    stmt: bind BindingId(0) sup site=SiteId(2) ty=LocalPid<App>
+    stmt: use BindingId(0) sup site=SiteId(5) ty=LocalPid<App> intent=Read
+    stmt: bind BindingId(1) w2 site=SiteId(3) ty=LocalPid<Worker>
+    stmt: use BindingId(1) w2 site=SiteId(9) ty=LocalPid<Worker> intent=Read
     _1 = move _0
     _3 = const.i64 0
     call_rt hew_supervisor_restart_await_blocking(_1, _3)
@@ -66,12 +66,12 @@ fn main() -> i64 [conv=default]
     _17 = icmp.eq _15 _16
     branch _17 ? bb4 : bb7
   bb3:
-    stmt: return site=Some(SiteId(5)) ty=i64
+    stmt: return site=Some(SiteId(6)) ty=i64
     ret = move _7
     return
   bb4:
-    stmt: bind BindingId(2) v site=SiteId(9) ty=i64
-    stmt: use BindingId(2) v site=SiteId(9) ty=i64 intent=Read
+    stmt: bind BindingId(2) v site=SiteId(10) ty=i64
+    stmt: use BindingId(2) v site=SiteId(10) ty=i64 intent=Read
     _20 = move mvar12.0.0
     _7 = move _20
     goto bb3
@@ -92,11 +92,11 @@ fn i8::fmt(i8) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(11) val site=SiteId(81) ty=i8 intent=Read
+    stmt: use BindingId(11) val site=SiteId(82) ty=i8 intent=Read
     _1 = cast _0 i8 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(79)) ty=string
+    stmt: return site=Some(SiteId(80)) ty=string
     ret = move _2
     return
 
@@ -106,11 +106,11 @@ fn i16::fmt(i16) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(12) val site=SiteId(85) ty=i16 intent=Read
+    stmt: use BindingId(12) val site=SiteId(86) ty=i16 intent=Read
     _1 = cast _0 i16 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(83)) ty=string
+    stmt: return site=Some(SiteId(84)) ty=string
     ret = move _2
     return
 
@@ -119,10 +119,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(13) val site=SiteId(88) ty=i32 intent=Read
+    stmt: use BindingId(13) val site=SiteId(89) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(87)) ty=string
+    stmt: return site=Some(SiteId(88)) ty=string
     ret = move _1
     return
 
@@ -131,10 +131,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(14) val site=SiteId(91) ty=i64 intent=Read
+    stmt: use BindingId(14) val site=SiteId(92) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(90)) ty=string
+    stmt: return site=Some(SiteId(91)) ty=string
     ret = move _1
     return
 
@@ -143,10 +143,10 @@ fn u8::fmt(u8) -> string [conv=default]
     _0: u8
     _1: string
   bb0:
-    stmt: use BindingId(15) val site=SiteId(94) ty=u8 intent=Read
+    stmt: use BindingId(15) val site=SiteId(95) ty=u8 intent=Read
     _1 = call to_string_u8(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(93)) ty=string
+    stmt: return site=Some(SiteId(94)) ty=string
     ret = move _1
     return
 
@@ -155,10 +155,10 @@ fn u16::fmt(u16) -> string [conv=default]
     _0: u16
     _1: string
   bb0:
-    stmt: use BindingId(16) val site=SiteId(97) ty=u16 intent=Read
+    stmt: use BindingId(16) val site=SiteId(98) ty=u16 intent=Read
     _1 = call to_string_u16(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(96)) ty=string
+    stmt: return site=Some(SiteId(97)) ty=string
     ret = move _1
     return
 
@@ -167,10 +167,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(17) val site=SiteId(100) ty=u32 intent=Read
+    stmt: use BindingId(17) val site=SiteId(101) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(99)) ty=string
+    stmt: return site=Some(SiteId(100)) ty=string
     ret = move _1
     return
 
@@ -179,10 +179,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(18) val site=SiteId(103) ty=u64 intent=Read
+    stmt: use BindingId(18) val site=SiteId(104) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(102)) ty=string
+    stmt: return site=Some(SiteId(103)) ty=string
     ret = move _1
     return
 
@@ -192,11 +192,11 @@ fn isize::fmt(isize) -> string [conv=default]
     _1: i64
     _2: string
   bb0:
-    stmt: use BindingId(19) val site=SiteId(107) ty=isize intent=Read
+    stmt: use BindingId(19) val site=SiteId(108) ty=isize intent=Read
     _1 = cast _0 isize -> i64
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(105)) ty=string
+    stmt: return site=Some(SiteId(106)) ty=string
     ret = move _2
     return
 
@@ -206,11 +206,11 @@ fn usize::fmt(usize) -> string [conv=default]
     _1: u64
     _2: string
   bb0:
-    stmt: use BindingId(20) val site=SiteId(111) ty=usize intent=Read
+    stmt: use BindingId(20) val site=SiteId(112) ty=usize intent=Read
     _1 = cast _0 usize -> u64
     _2 = call to_string_u64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(109)) ty=string
+    stmt: return site=Some(SiteId(110)) ty=string
     ret = move _2
     return
 
@@ -219,10 +219,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(21) val site=SiteId(114) ty=bool intent=Read
+    stmt: use BindingId(21) val site=SiteId(115) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(113)) ty=string
+    stmt: return site=Some(SiteId(114)) ty=string
     ret = move _1
     return
 
@@ -231,10 +231,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(22) val site=SiteId(117) ty=char intent=Read
+    stmt: use BindingId(22) val site=SiteId(118) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(116)) ty=string
+    stmt: return site=Some(SiteId(117)) ty=string
     ret = move _1
     return
 
@@ -243,10 +243,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(23) val site=SiteId(120) ty=f64 intent=Read
+    stmt: use BindingId(23) val site=SiteId(121) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(119)) ty=string
+    stmt: return site=Some(SiteId(120)) ty=string
     ret = move _1
     return
 
@@ -256,11 +256,11 @@ fn f32::fmt(f32) -> string [conv=default]
     _1: f64
     _2: string
   bb0:
-    stmt: use BindingId(24) val site=SiteId(124) ty=f32 intent=Read
+    stmt: use BindingId(24) val site=SiteId(125) ty=f32 intent=Read
     _1 = cast _0 f32 -> f64
     _2 = call to_string_f64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(122)) ty=string
+    stmt: return site=Some(SiteId(123)) ty=string
     ret = move _2
     return
 
@@ -268,8 +268,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(25) val site=SiteId(126) ty=string intent=Read
-    stmt: return site=Some(SiteId(126)) ty=string
+    stmt: use BindingId(25) val site=SiteId(127) ty=string intent=Read
+    stmt: return site=Some(SiteId(127)) ty=string
     ret = move _0
     return
 
@@ -280,14 +280,14 @@ fn duration::from_nanos(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(26) n site=SiteId(128) ty=i64 intent=Read
+    stmt: use BindingId(26) n site=SiteId(129) ty=i64 intent=Read
     _1 = const.duration 1ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(127)) ty=duration
+    stmt: return site=Some(SiteId(128)) ty=duration
     ret = move _2
     return
 
@@ -298,14 +298,14 @@ fn duration::from_micros(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(27) n site=SiteId(131) ty=i64 intent=Read
+    stmt: use BindingId(27) n site=SiteId(132) ty=i64 intent=Read
     _1 = const.duration 1000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(130)) ty=duration
+    stmt: return site=Some(SiteId(131)) ty=duration
     ret = move _2
     return
 
@@ -316,14 +316,14 @@ fn duration::from_millis(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(28) n site=SiteId(134) ty=i64 intent=Read
+    stmt: use BindingId(28) n site=SiteId(135) ty=i64 intent=Read
     _1 = const.duration 1000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(133)) ty=duration
+    stmt: return site=Some(SiteId(134)) ty=duration
     ret = move _2
     return
 
@@ -334,14 +334,14 @@ fn duration::from_secs(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(29) n site=SiteId(137) ty=i64 intent=Read
+    stmt: use BindingId(29) n site=SiteId(138) ty=i64 intent=Read
     _1 = const.duration 1000000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(136)) ty=duration
+    stmt: return site=Some(SiteId(137)) ty=duration
     ret = move _2
     return
 
@@ -353,11 +353,11 @@ fn duration::fmt(duration) -> string [conv=default]
     _3: string
     _4: string
   bb0:
-    stmt: use BindingId(30) val site=SiteId(142) ty=duration intent=Read
+    stmt: use BindingId(30) val site=SiteId(143) ty=duration intent=Read
     _1 = call_rt hew_duration_nanos(_0)
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(139)) ty=string
+    stmt: return site=Some(SiteId(140)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
     drop _2 ty=string fn=release(hew_string_drop)

--- a/examples/v05/checked-mir/golden/supervisor_config_init.elab.mir
+++ b/examples/v05/checked-mir/golden/supervisor_config_init.elab.mir
@@ -17,14 +17,14 @@ fn App__bootstrap -> LocalPid<App>
 
 fn main -> i64
   statements:
-    bind BindingId(4) cfg site=SiteId(8) ty=AppConfig
-    use BindingId(4) cfg site=SiteId(12) ty=AppConfig intent=Read
-    bind BindingId(5) sup site=SiteId(11) ty=LocalPid<App>
-    use BindingId(5) sup site=SiteId(14) ty=LocalPid<App> intent=Read
-    bind BindingId(6) _c site=SiteId(13) ty=LocalPid<Cache>
-    use BindingId(5) sup site=SiteId(16) ty=LocalPid<App> intent=Read
-    eval site=SiteId(15) ty=()
-    return site=Some(SiteId(18)) ty=i64
+    bind BindingId(4) cfg site=SiteId(9) ty=AppConfig
+    use BindingId(4) cfg site=SiteId(13) ty=AppConfig intent=Read
+    bind BindingId(5) sup site=SiteId(12) ty=LocalPid<App>
+    use BindingId(5) sup site=SiteId(15) ty=LocalPid<App> intent=Read
+    bind BindingId(6) _c site=SiteId(14) ty=LocalPid<Cache>
+    use BindingId(5) sup site=SiteId(17) ty=LocalPid<App> intent=Read
+    eval site=SiteId(16) ty=()
+    return site=Some(SiteId(19)) ty=i64
     drop BindingId(6) _c ty=LocalPid<Cache>
     drop BindingId(5) sup ty=LocalPid<App>
     drop BindingId(4) cfg ty=AppConfig
@@ -39,8 +39,8 @@ fn main -> i64
 
 fn i8::fmt -> string
   statements:
-    use BindingId(15) val site=SiteId(89) ty=i8 intent=Read
-    return site=Some(SiteId(87)) ty=string
+    use BindingId(15) val site=SiteId(90) ty=i8 intent=Read
+    return site=Some(SiteId(88)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -51,8 +51,8 @@ fn i8::fmt -> string
 
 fn i16::fmt -> string
   statements:
-    use BindingId(16) val site=SiteId(93) ty=i16 intent=Read
-    return site=Some(SiteId(91)) ty=string
+    use BindingId(16) val site=SiteId(94) ty=i16 intent=Read
+    return site=Some(SiteId(92)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -63,8 +63,8 @@ fn i16::fmt -> string
 
 fn i32::fmt -> string
   statements:
-    use BindingId(17) val site=SiteId(96) ty=i32 intent=Read
-    return site=Some(SiteId(95)) ty=string
+    use BindingId(17) val site=SiteId(97) ty=i32 intent=Read
+    return site=Some(SiteId(96)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -75,8 +75,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(18) val site=SiteId(99) ty=i64 intent=Read
-    return site=Some(SiteId(98)) ty=string
+    use BindingId(18) val site=SiteId(100) ty=i64 intent=Read
+    return site=Some(SiteId(99)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -87,8 +87,8 @@ fn i64::fmt -> string
 
 fn u8::fmt -> string
   statements:
-    use BindingId(19) val site=SiteId(102) ty=u8 intent=Read
-    return site=Some(SiteId(101)) ty=string
+    use BindingId(19) val site=SiteId(103) ty=u8 intent=Read
+    return site=Some(SiteId(102)) ty=string
   drop_plans:
     call[bb0 to_string_u8 -> bb1] ->
       (none)
@@ -99,8 +99,8 @@ fn u8::fmt -> string
 
 fn u16::fmt -> string
   statements:
-    use BindingId(20) val site=SiteId(105) ty=u16 intent=Read
-    return site=Some(SiteId(104)) ty=string
+    use BindingId(20) val site=SiteId(106) ty=u16 intent=Read
+    return site=Some(SiteId(105)) ty=string
   drop_plans:
     call[bb0 to_string_u16 -> bb1] ->
       (none)
@@ -111,8 +111,8 @@ fn u16::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(21) val site=SiteId(108) ty=u32 intent=Read
-    return site=Some(SiteId(107)) ty=string
+    use BindingId(21) val site=SiteId(109) ty=u32 intent=Read
+    return site=Some(SiteId(108)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -123,8 +123,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(22) val site=SiteId(111) ty=u64 intent=Read
-    return site=Some(SiteId(110)) ty=string
+    use BindingId(22) val site=SiteId(112) ty=u64 intent=Read
+    return site=Some(SiteId(111)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -135,8 +135,8 @@ fn u64::fmt -> string
 
 fn isize::fmt -> string
   statements:
-    use BindingId(23) val site=SiteId(115) ty=isize intent=Read
-    return site=Some(SiteId(113)) ty=string
+    use BindingId(23) val site=SiteId(116) ty=isize intent=Read
+    return site=Some(SiteId(114)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -147,8 +147,8 @@ fn isize::fmt -> string
 
 fn usize::fmt -> string
   statements:
-    use BindingId(24) val site=SiteId(119) ty=usize intent=Read
-    return site=Some(SiteId(117)) ty=string
+    use BindingId(24) val site=SiteId(120) ty=usize intent=Read
+    return site=Some(SiteId(118)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -159,8 +159,8 @@ fn usize::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(25) val site=SiteId(122) ty=bool intent=Read
-    return site=Some(SiteId(121)) ty=string
+    use BindingId(25) val site=SiteId(123) ty=bool intent=Read
+    return site=Some(SiteId(122)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -171,8 +171,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(26) val site=SiteId(125) ty=char intent=Read
-    return site=Some(SiteId(124)) ty=string
+    use BindingId(26) val site=SiteId(126) ty=char intent=Read
+    return site=Some(SiteId(125)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -183,8 +183,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(27) val site=SiteId(128) ty=f64 intent=Read
-    return site=Some(SiteId(127)) ty=string
+    use BindingId(27) val site=SiteId(129) ty=f64 intent=Read
+    return site=Some(SiteId(128)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -195,8 +195,8 @@ fn f64::fmt -> string
 
 fn f32::fmt -> string
   statements:
-    use BindingId(28) val site=SiteId(132) ty=f32 intent=Read
-    return site=Some(SiteId(130)) ty=string
+    use BindingId(28) val site=SiteId(133) ty=f32 intent=Read
+    return site=Some(SiteId(131)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -207,16 +207,16 @@ fn f32::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(29) val site=SiteId(134) ty=string intent=Read
-    return site=Some(SiteId(134)) ty=string
+    use BindingId(29) val site=SiteId(135) ty=string intent=Read
+    return site=Some(SiteId(135)) ty=string
   drop_plans:
     return[bb0] ->
       (none)
 
 fn duration::from_nanos -> duration
   statements:
-    use BindingId(30) n site=SiteId(136) ty=i64 intent=Read
-    return site=Some(SiteId(135)) ty=duration
+    use BindingId(30) n site=SiteId(137) ty=i64 intent=Read
+    return site=Some(SiteId(136)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -227,8 +227,8 @@ fn duration::from_nanos -> duration
 
 fn duration::from_micros -> duration
   statements:
-    use BindingId(31) n site=SiteId(139) ty=i64 intent=Read
-    return site=Some(SiteId(138)) ty=duration
+    use BindingId(31) n site=SiteId(140) ty=i64 intent=Read
+    return site=Some(SiteId(139)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -239,8 +239,8 @@ fn duration::from_micros -> duration
 
 fn duration::from_millis -> duration
   statements:
-    use BindingId(32) n site=SiteId(142) ty=i64 intent=Read
-    return site=Some(SiteId(141)) ty=duration
+    use BindingId(32) n site=SiteId(143) ty=i64 intent=Read
+    return site=Some(SiteId(142)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -251,8 +251,8 @@ fn duration::from_millis -> duration
 
 fn duration::from_secs -> duration
   statements:
-    use BindingId(33) n site=SiteId(145) ty=i64 intent=Read
-    return site=Some(SiteId(144)) ty=duration
+    use BindingId(33) n site=SiteId(146) ty=i64 intent=Read
+    return site=Some(SiteId(145)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -263,8 +263,8 @@ fn duration::from_secs -> duration
 
 fn duration::fmt -> string
   statements:
-    use BindingId(34) val site=SiteId(150) ty=duration intent=Read
-    return site=Some(SiteId(147)) ty=string
+    use BindingId(34) val site=SiteId(151) ty=duration intent=Read
+    return site=Some(SiteId(148)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)

--- a/examples/v05/checked-mir/golden/supervisor_config_init.raw.mir
+++ b/examples/v05/checked-mir/golden/supervisor_config_init.raw.mir
@@ -36,20 +36,20 @@ fn main() -> i64 [conv=default]
     _9: i64
     _10: i64
   bb0:
-    stmt: bind BindingId(4) cfg site=SiteId(8) ty=AppConfig
-    stmt: use BindingId(4) cfg site=SiteId(12) ty=AppConfig intent=Read
+    stmt: bind BindingId(4) cfg site=SiteId(9) ty=AppConfig
+    stmt: use BindingId(4) cfg site=SiteId(13) ty=AppConfig intent=Read
     _0 = const.i64 5
     _1 = string_lit "hi"
     _2 = record_init AppConfig { .0=_0, .1=_1 }
     _3 = move _2
     _4 = call App__bootstrap(_3) -> bb1
   bb1:
-    stmt: bind BindingId(5) sup site=SiteId(11) ty=LocalPid<App>
-    stmt: use BindingId(5) sup site=SiteId(14) ty=LocalPid<App> intent=Read
-    stmt: bind BindingId(6) _c site=SiteId(13) ty=LocalPid<Cache>
-    stmt: use BindingId(5) sup site=SiteId(16) ty=LocalPid<App> intent=Read
-    stmt: eval site=SiteId(15) ty=()
-    stmt: return site=Some(SiteId(18)) ty=i64
+    stmt: bind BindingId(5) sup site=SiteId(12) ty=LocalPid<App>
+    stmt: use BindingId(5) sup site=SiteId(15) ty=LocalPid<App> intent=Read
+    stmt: bind BindingId(6) _c site=SiteId(14) ty=LocalPid<Cache>
+    stmt: use BindingId(5) sup site=SiteId(17) ty=LocalPid<App> intent=Read
+    stmt: eval site=SiteId(16) ty=()
+    stmt: return site=Some(SiteId(19)) ty=i64
     _5 = move _4
     _7 = const.i64 0
     _8 = call_rt hew_supervisor_child_get(_5, _7)
@@ -66,11 +66,11 @@ fn i8::fmt(i8) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(15) val site=SiteId(89) ty=i8 intent=Read
+    stmt: use BindingId(15) val site=SiteId(90) ty=i8 intent=Read
     _1 = cast _0 i8 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(87)) ty=string
+    stmt: return site=Some(SiteId(88)) ty=string
     ret = move _2
     return
 
@@ -80,11 +80,11 @@ fn i16::fmt(i16) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(16) val site=SiteId(93) ty=i16 intent=Read
+    stmt: use BindingId(16) val site=SiteId(94) ty=i16 intent=Read
     _1 = cast _0 i16 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(91)) ty=string
+    stmt: return site=Some(SiteId(92)) ty=string
     ret = move _2
     return
 
@@ -93,10 +93,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(17) val site=SiteId(96) ty=i32 intent=Read
+    stmt: use BindingId(17) val site=SiteId(97) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(95)) ty=string
+    stmt: return site=Some(SiteId(96)) ty=string
     ret = move _1
     return
 
@@ -105,10 +105,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(18) val site=SiteId(99) ty=i64 intent=Read
+    stmt: use BindingId(18) val site=SiteId(100) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(98)) ty=string
+    stmt: return site=Some(SiteId(99)) ty=string
     ret = move _1
     return
 
@@ -117,10 +117,10 @@ fn u8::fmt(u8) -> string [conv=default]
     _0: u8
     _1: string
   bb0:
-    stmt: use BindingId(19) val site=SiteId(102) ty=u8 intent=Read
+    stmt: use BindingId(19) val site=SiteId(103) ty=u8 intent=Read
     _1 = call to_string_u8(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(101)) ty=string
+    stmt: return site=Some(SiteId(102)) ty=string
     ret = move _1
     return
 
@@ -129,10 +129,10 @@ fn u16::fmt(u16) -> string [conv=default]
     _0: u16
     _1: string
   bb0:
-    stmt: use BindingId(20) val site=SiteId(105) ty=u16 intent=Read
+    stmt: use BindingId(20) val site=SiteId(106) ty=u16 intent=Read
     _1 = call to_string_u16(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(104)) ty=string
+    stmt: return site=Some(SiteId(105)) ty=string
     ret = move _1
     return
 
@@ -141,10 +141,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(21) val site=SiteId(108) ty=u32 intent=Read
+    stmt: use BindingId(21) val site=SiteId(109) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(107)) ty=string
+    stmt: return site=Some(SiteId(108)) ty=string
     ret = move _1
     return
 
@@ -153,10 +153,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(22) val site=SiteId(111) ty=u64 intent=Read
+    stmt: use BindingId(22) val site=SiteId(112) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(110)) ty=string
+    stmt: return site=Some(SiteId(111)) ty=string
     ret = move _1
     return
 
@@ -166,11 +166,11 @@ fn isize::fmt(isize) -> string [conv=default]
     _1: i64
     _2: string
   bb0:
-    stmt: use BindingId(23) val site=SiteId(115) ty=isize intent=Read
+    stmt: use BindingId(23) val site=SiteId(116) ty=isize intent=Read
     _1 = cast _0 isize -> i64
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(113)) ty=string
+    stmt: return site=Some(SiteId(114)) ty=string
     ret = move _2
     return
 
@@ -180,11 +180,11 @@ fn usize::fmt(usize) -> string [conv=default]
     _1: u64
     _2: string
   bb0:
-    stmt: use BindingId(24) val site=SiteId(119) ty=usize intent=Read
+    stmt: use BindingId(24) val site=SiteId(120) ty=usize intent=Read
     _1 = cast _0 usize -> u64
     _2 = call to_string_u64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(117)) ty=string
+    stmt: return site=Some(SiteId(118)) ty=string
     ret = move _2
     return
 
@@ -193,10 +193,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(25) val site=SiteId(122) ty=bool intent=Read
+    stmt: use BindingId(25) val site=SiteId(123) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(121)) ty=string
+    stmt: return site=Some(SiteId(122)) ty=string
     ret = move _1
     return
 
@@ -205,10 +205,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(26) val site=SiteId(125) ty=char intent=Read
+    stmt: use BindingId(26) val site=SiteId(126) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(124)) ty=string
+    stmt: return site=Some(SiteId(125)) ty=string
     ret = move _1
     return
 
@@ -217,10 +217,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(27) val site=SiteId(128) ty=f64 intent=Read
+    stmt: use BindingId(27) val site=SiteId(129) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(127)) ty=string
+    stmt: return site=Some(SiteId(128)) ty=string
     ret = move _1
     return
 
@@ -230,11 +230,11 @@ fn f32::fmt(f32) -> string [conv=default]
     _1: f64
     _2: string
   bb0:
-    stmt: use BindingId(28) val site=SiteId(132) ty=f32 intent=Read
+    stmt: use BindingId(28) val site=SiteId(133) ty=f32 intent=Read
     _1 = cast _0 f32 -> f64
     _2 = call to_string_f64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(130)) ty=string
+    stmt: return site=Some(SiteId(131)) ty=string
     ret = move _2
     return
 
@@ -242,8 +242,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(29) val site=SiteId(134) ty=string intent=Read
-    stmt: return site=Some(SiteId(134)) ty=string
+    stmt: use BindingId(29) val site=SiteId(135) ty=string intent=Read
+    stmt: return site=Some(SiteId(135)) ty=string
     ret = move _0
     return
 
@@ -254,14 +254,14 @@ fn duration::from_nanos(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(30) n site=SiteId(136) ty=i64 intent=Read
+    stmt: use BindingId(30) n site=SiteId(137) ty=i64 intent=Read
     _1 = const.duration 1ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(135)) ty=duration
+    stmt: return site=Some(SiteId(136)) ty=duration
     ret = move _2
     return
 
@@ -272,14 +272,14 @@ fn duration::from_micros(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(31) n site=SiteId(139) ty=i64 intent=Read
+    stmt: use BindingId(31) n site=SiteId(140) ty=i64 intent=Read
     _1 = const.duration 1000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(138)) ty=duration
+    stmt: return site=Some(SiteId(139)) ty=duration
     ret = move _2
     return
 
@@ -290,14 +290,14 @@ fn duration::from_millis(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(32) n site=SiteId(142) ty=i64 intent=Read
+    stmt: use BindingId(32) n site=SiteId(143) ty=i64 intent=Read
     _1 = const.duration 1000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(141)) ty=duration
+    stmt: return site=Some(SiteId(142)) ty=duration
     ret = move _2
     return
 
@@ -308,14 +308,14 @@ fn duration::from_secs(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(33) n site=SiteId(145) ty=i64 intent=Read
+    stmt: use BindingId(33) n site=SiteId(146) ty=i64 intent=Read
     _1 = const.duration 1000000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(144)) ty=duration
+    stmt: return site=Some(SiteId(145)) ty=duration
     ret = move _2
     return
 
@@ -327,11 +327,11 @@ fn duration::fmt(duration) -> string [conv=default]
     _3: string
     _4: string
   bb0:
-    stmt: use BindingId(34) val site=SiteId(150) ty=duration intent=Read
+    stmt: use BindingId(34) val site=SiteId(151) ty=duration intent=Read
     _1 = call_rt hew_duration_nanos(_0)
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(147)) ty=string
+    stmt: return site=Some(SiteId(148)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
     drop _2 ty=string fn=release(hew_string_drop)

--- a/examples/v05/checked-mir/golden/supervisor_stop.elab.mir
+++ b/examples/v05/checked-mir/golden/supervisor_stop.elab.mir
@@ -16,14 +16,14 @@ fn AppSupervisor__bootstrap -> LocalPid<AppSupervisor>
 
 fn main -> i64
   statements:
-    bind BindingId(1) sup site=SiteId(1) ty=LocalPid<AppSupervisor>
-    use BindingId(1) sup site=SiteId(3) ty=LocalPid<AppSupervisor> intent=Read
-    bind BindingId(2) w site=SiteId(2) ty=LocalPid<Worker>
-    use BindingId(2) w site=SiteId(5) ty=LocalPid<Worker> intent=Read
-    eval site=SiteId(4) ty=()
-    use BindingId(1) sup site=SiteId(8) ty=LocalPid<AppSupervisor> intent=Read
-    eval site=SiteId(7) ty=()
-    return site=Some(SiteId(10)) ty=i64
+    bind BindingId(1) sup site=SiteId(2) ty=LocalPid<AppSupervisor>
+    use BindingId(1) sup site=SiteId(4) ty=LocalPid<AppSupervisor> intent=Read
+    bind BindingId(2) w site=SiteId(3) ty=LocalPid<Worker>
+    use BindingId(2) w site=SiteId(6) ty=LocalPid<Worker> intent=Read
+    eval site=SiteId(5) ty=()
+    use BindingId(1) sup site=SiteId(9) ty=LocalPid<AppSupervisor> intent=Read
+    eval site=SiteId(8) ty=()
+    return site=Some(SiteId(11)) ty=i64
     drop BindingId(2) w ty=LocalPid<Worker>
     drop BindingId(1) sup ty=LocalPid<AppSupervisor>
   drop_plans:
@@ -46,8 +46,8 @@ fn main -> i64
 
 fn i8::fmt -> string
   statements:
-    use BindingId(11) val site=SiteId(81) ty=i8 intent=Read
-    return site=Some(SiteId(79)) ty=string
+    use BindingId(11) val site=SiteId(82) ty=i8 intent=Read
+    return site=Some(SiteId(80)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -58,8 +58,8 @@ fn i8::fmt -> string
 
 fn i16::fmt -> string
   statements:
-    use BindingId(12) val site=SiteId(85) ty=i16 intent=Read
-    return site=Some(SiteId(83)) ty=string
+    use BindingId(12) val site=SiteId(86) ty=i16 intent=Read
+    return site=Some(SiteId(84)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -70,8 +70,8 @@ fn i16::fmt -> string
 
 fn i32::fmt -> string
   statements:
-    use BindingId(13) val site=SiteId(88) ty=i32 intent=Read
-    return site=Some(SiteId(87)) ty=string
+    use BindingId(13) val site=SiteId(89) ty=i32 intent=Read
+    return site=Some(SiteId(88)) ty=string
   drop_plans:
     call[bb0 to_string_i32 -> bb1] ->
       (none)
@@ -82,8 +82,8 @@ fn i32::fmt -> string
 
 fn i64::fmt -> string
   statements:
-    use BindingId(14) val site=SiteId(91) ty=i64 intent=Read
-    return site=Some(SiteId(90)) ty=string
+    use BindingId(14) val site=SiteId(92) ty=i64 intent=Read
+    return site=Some(SiteId(91)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -94,8 +94,8 @@ fn i64::fmt -> string
 
 fn u8::fmt -> string
   statements:
-    use BindingId(15) val site=SiteId(94) ty=u8 intent=Read
-    return site=Some(SiteId(93)) ty=string
+    use BindingId(15) val site=SiteId(95) ty=u8 intent=Read
+    return site=Some(SiteId(94)) ty=string
   drop_plans:
     call[bb0 to_string_u8 -> bb1] ->
       (none)
@@ -106,8 +106,8 @@ fn u8::fmt -> string
 
 fn u16::fmt -> string
   statements:
-    use BindingId(16) val site=SiteId(97) ty=u16 intent=Read
-    return site=Some(SiteId(96)) ty=string
+    use BindingId(16) val site=SiteId(98) ty=u16 intent=Read
+    return site=Some(SiteId(97)) ty=string
   drop_plans:
     call[bb0 to_string_u16 -> bb1] ->
       (none)
@@ -118,8 +118,8 @@ fn u16::fmt -> string
 
 fn u32::fmt -> string
   statements:
-    use BindingId(17) val site=SiteId(100) ty=u32 intent=Read
-    return site=Some(SiteId(99)) ty=string
+    use BindingId(17) val site=SiteId(101) ty=u32 intent=Read
+    return site=Some(SiteId(100)) ty=string
   drop_plans:
     call[bb0 to_string_u32 -> bb1] ->
       (none)
@@ -130,8 +130,8 @@ fn u32::fmt -> string
 
 fn u64::fmt -> string
   statements:
-    use BindingId(18) val site=SiteId(103) ty=u64 intent=Read
-    return site=Some(SiteId(102)) ty=string
+    use BindingId(18) val site=SiteId(104) ty=u64 intent=Read
+    return site=Some(SiteId(103)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -142,8 +142,8 @@ fn u64::fmt -> string
 
 fn isize::fmt -> string
   statements:
-    use BindingId(19) val site=SiteId(107) ty=isize intent=Read
-    return site=Some(SiteId(105)) ty=string
+    use BindingId(19) val site=SiteId(108) ty=isize intent=Read
+    return site=Some(SiteId(106)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)
@@ -154,8 +154,8 @@ fn isize::fmt -> string
 
 fn usize::fmt -> string
   statements:
-    use BindingId(20) val site=SiteId(111) ty=usize intent=Read
-    return site=Some(SiteId(109)) ty=string
+    use BindingId(20) val site=SiteId(112) ty=usize intent=Read
+    return site=Some(SiteId(110)) ty=string
   drop_plans:
     call[bb0 to_string_u64 -> bb1] ->
       (none)
@@ -166,8 +166,8 @@ fn usize::fmt -> string
 
 fn bool::fmt -> string
   statements:
-    use BindingId(21) val site=SiteId(114) ty=bool intent=Read
-    return site=Some(SiteId(113)) ty=string
+    use BindingId(21) val site=SiteId(115) ty=bool intent=Read
+    return site=Some(SiteId(114)) ty=string
   drop_plans:
     call[bb0 to_string_bool -> bb1] ->
       (none)
@@ -178,8 +178,8 @@ fn bool::fmt -> string
 
 fn char::fmt -> string
   statements:
-    use BindingId(22) val site=SiteId(117) ty=char intent=Read
-    return site=Some(SiteId(116)) ty=string
+    use BindingId(22) val site=SiteId(118) ty=char intent=Read
+    return site=Some(SiteId(117)) ty=string
   drop_plans:
     call[bb0 to_string_char -> bb1] ->
       (none)
@@ -190,8 +190,8 @@ fn char::fmt -> string
 
 fn f64::fmt -> string
   statements:
-    use BindingId(23) val site=SiteId(120) ty=f64 intent=Read
-    return site=Some(SiteId(119)) ty=string
+    use BindingId(23) val site=SiteId(121) ty=f64 intent=Read
+    return site=Some(SiteId(120)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -202,8 +202,8 @@ fn f64::fmt -> string
 
 fn f32::fmt -> string
   statements:
-    use BindingId(24) val site=SiteId(124) ty=f32 intent=Read
-    return site=Some(SiteId(122)) ty=string
+    use BindingId(24) val site=SiteId(125) ty=f32 intent=Read
+    return site=Some(SiteId(123)) ty=string
   drop_plans:
     call[bb0 to_string_f64 -> bb1] ->
       (none)
@@ -214,16 +214,16 @@ fn f32::fmt -> string
 
 fn string::fmt -> string
   statements:
-    use BindingId(25) val site=SiteId(126) ty=string intent=Read
-    return site=Some(SiteId(126)) ty=string
+    use BindingId(25) val site=SiteId(127) ty=string intent=Read
+    return site=Some(SiteId(127)) ty=string
   drop_plans:
     return[bb0] ->
       (none)
 
 fn duration::from_nanos -> duration
   statements:
-    use BindingId(26) n site=SiteId(128) ty=i64 intent=Read
-    return site=Some(SiteId(127)) ty=duration
+    use BindingId(26) n site=SiteId(129) ty=i64 intent=Read
+    return site=Some(SiteId(128)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -234,8 +234,8 @@ fn duration::from_nanos -> duration
 
 fn duration::from_micros -> duration
   statements:
-    use BindingId(27) n site=SiteId(131) ty=i64 intent=Read
-    return site=Some(SiteId(130)) ty=duration
+    use BindingId(27) n site=SiteId(132) ty=i64 intent=Read
+    return site=Some(SiteId(131)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -246,8 +246,8 @@ fn duration::from_micros -> duration
 
 fn duration::from_millis -> duration
   statements:
-    use BindingId(28) n site=SiteId(134) ty=i64 intent=Read
-    return site=Some(SiteId(133)) ty=duration
+    use BindingId(28) n site=SiteId(135) ty=i64 intent=Read
+    return site=Some(SiteId(134)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -258,8 +258,8 @@ fn duration::from_millis -> duration
 
 fn duration::from_secs -> duration
   statements:
-    use BindingId(29) n site=SiteId(137) ty=i64 intent=Read
-    return site=Some(SiteId(136)) ty=duration
+    use BindingId(29) n site=SiteId(138) ty=i64 intent=Read
+    return site=Some(SiteId(137)) ty=duration
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -270,8 +270,8 @@ fn duration::from_secs -> duration
 
 fn duration::fmt -> string
   statements:
-    use BindingId(30) val site=SiteId(142) ty=duration intent=Read
-    return site=Some(SiteId(139)) ty=string
+    use BindingId(30) val site=SiteId(143) ty=duration intent=Read
+    return site=Some(SiteId(140)) ty=string
   drop_plans:
     call[bb0 to_string_i64 -> bb1] ->
       (none)

--- a/examples/v05/checked-mir/golden/supervisor_stop.raw.mir
+++ b/examples/v05/checked-mir/golden/supervisor_stop.raw.mir
@@ -35,10 +35,10 @@ fn main() -> i64 [conv=default]
   bb0:
     _0 = call AppSupervisor__bootstrap() -> bb1
   bb1:
-    stmt: bind BindingId(1) sup site=SiteId(1) ty=LocalPid<AppSupervisor>
-    stmt: use BindingId(1) sup site=SiteId(3) ty=LocalPid<AppSupervisor> intent=Read
-    stmt: bind BindingId(2) w site=SiteId(2) ty=LocalPid<Worker>
-    stmt: use BindingId(2) w site=SiteId(5) ty=LocalPid<Worker> intent=Read
+    stmt: bind BindingId(1) sup site=SiteId(2) ty=LocalPid<AppSupervisor>
+    stmt: use BindingId(1) sup site=SiteId(4) ty=LocalPid<AppSupervisor> intent=Read
+    stmt: bind BindingId(2) w site=SiteId(3) ty=LocalPid<Worker>
+    stmt: use BindingId(2) w site=SiteId(6) ty=LocalPid<Worker> intent=Read
     _1 = move _0
     _3 = const.i64 0
     _4 = call_rt hew_supervisor_child_get(_1, _3)
@@ -54,10 +54,10 @@ fn main() -> i64 [conv=default]
     _12 = icmp.eq _10 _11
     branch _12 ? bb3 : bb4
   bb2:
-    stmt: eval site=SiteId(4) ty=()
-    stmt: use BindingId(1) sup site=SiteId(8) ty=LocalPid<AppSupervisor> intent=Read
-    stmt: eval site=SiteId(7) ty=()
-    stmt: return site=Some(SiteId(10)) ty=i64
+    stmt: eval site=SiteId(5) ty=()
+    stmt: use BindingId(1) sup site=SiteId(9) ty=LocalPid<AppSupervisor> intent=Read
+    stmt: eval site=SiteId(8) ty=()
+    stmt: return site=Some(SiteId(11)) ty=i64
     call_rt hew_supervisor_stop(_1)
     _13 = const.i64 0
     ret = move _13
@@ -73,11 +73,11 @@ fn i8::fmt(i8) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(11) val site=SiteId(81) ty=i8 intent=Read
+    stmt: use BindingId(11) val site=SiteId(82) ty=i8 intent=Read
     _1 = cast _0 i8 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(79)) ty=string
+    stmt: return site=Some(SiteId(80)) ty=string
     ret = move _2
     return
 
@@ -87,11 +87,11 @@ fn i16::fmt(i16) -> string [conv=default]
     _1: i32
     _2: string
   bb0:
-    stmt: use BindingId(12) val site=SiteId(85) ty=i16 intent=Read
+    stmt: use BindingId(12) val site=SiteId(86) ty=i16 intent=Read
     _1 = cast _0 i16 -> i32
     _2 = call to_string_i32(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(83)) ty=string
+    stmt: return site=Some(SiteId(84)) ty=string
     ret = move _2
     return
 
@@ -100,10 +100,10 @@ fn i32::fmt(i32) -> string [conv=default]
     _0: i32
     _1: string
   bb0:
-    stmt: use BindingId(13) val site=SiteId(88) ty=i32 intent=Read
+    stmt: use BindingId(13) val site=SiteId(89) ty=i32 intent=Read
     _1 = call to_string_i32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(87)) ty=string
+    stmt: return site=Some(SiteId(88)) ty=string
     ret = move _1
     return
 
@@ -112,10 +112,10 @@ fn i64::fmt(i64) -> string [conv=default]
     _0: i64
     _1: string
   bb0:
-    stmt: use BindingId(14) val site=SiteId(91) ty=i64 intent=Read
+    stmt: use BindingId(14) val site=SiteId(92) ty=i64 intent=Read
     _1 = call to_string_i64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(90)) ty=string
+    stmt: return site=Some(SiteId(91)) ty=string
     ret = move _1
     return
 
@@ -124,10 +124,10 @@ fn u8::fmt(u8) -> string [conv=default]
     _0: u8
     _1: string
   bb0:
-    stmt: use BindingId(15) val site=SiteId(94) ty=u8 intent=Read
+    stmt: use BindingId(15) val site=SiteId(95) ty=u8 intent=Read
     _1 = call to_string_u8(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(93)) ty=string
+    stmt: return site=Some(SiteId(94)) ty=string
     ret = move _1
     return
 
@@ -136,10 +136,10 @@ fn u16::fmt(u16) -> string [conv=default]
     _0: u16
     _1: string
   bb0:
-    stmt: use BindingId(16) val site=SiteId(97) ty=u16 intent=Read
+    stmt: use BindingId(16) val site=SiteId(98) ty=u16 intent=Read
     _1 = call to_string_u16(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(96)) ty=string
+    stmt: return site=Some(SiteId(97)) ty=string
     ret = move _1
     return
 
@@ -148,10 +148,10 @@ fn u32::fmt(u32) -> string [conv=default]
     _0: u32
     _1: string
   bb0:
-    stmt: use BindingId(17) val site=SiteId(100) ty=u32 intent=Read
+    stmt: use BindingId(17) val site=SiteId(101) ty=u32 intent=Read
     _1 = call to_string_u32(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(99)) ty=string
+    stmt: return site=Some(SiteId(100)) ty=string
     ret = move _1
     return
 
@@ -160,10 +160,10 @@ fn u64::fmt(u64) -> string [conv=default]
     _0: u64
     _1: string
   bb0:
-    stmt: use BindingId(18) val site=SiteId(103) ty=u64 intent=Read
+    stmt: use BindingId(18) val site=SiteId(104) ty=u64 intent=Read
     _1 = call to_string_u64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(102)) ty=string
+    stmt: return site=Some(SiteId(103)) ty=string
     ret = move _1
     return
 
@@ -173,11 +173,11 @@ fn isize::fmt(isize) -> string [conv=default]
     _1: i64
     _2: string
   bb0:
-    stmt: use BindingId(19) val site=SiteId(107) ty=isize intent=Read
+    stmt: use BindingId(19) val site=SiteId(108) ty=isize intent=Read
     _1 = cast _0 isize -> i64
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(105)) ty=string
+    stmt: return site=Some(SiteId(106)) ty=string
     ret = move _2
     return
 
@@ -187,11 +187,11 @@ fn usize::fmt(usize) -> string [conv=default]
     _1: u64
     _2: string
   bb0:
-    stmt: use BindingId(20) val site=SiteId(111) ty=usize intent=Read
+    stmt: use BindingId(20) val site=SiteId(112) ty=usize intent=Read
     _1 = cast _0 usize -> u64
     _2 = call to_string_u64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(109)) ty=string
+    stmt: return site=Some(SiteId(110)) ty=string
     ret = move _2
     return
 
@@ -200,10 +200,10 @@ fn bool::fmt(bool) -> string [conv=default]
     _0: bool
     _1: string
   bb0:
-    stmt: use BindingId(21) val site=SiteId(114) ty=bool intent=Read
+    stmt: use BindingId(21) val site=SiteId(115) ty=bool intent=Read
     _1 = call to_string_bool(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(113)) ty=string
+    stmt: return site=Some(SiteId(114)) ty=string
     ret = move _1
     return
 
@@ -212,10 +212,10 @@ fn char::fmt(char) -> string [conv=default]
     _0: char
     _1: string
   bb0:
-    stmt: use BindingId(22) val site=SiteId(117) ty=char intent=Read
+    stmt: use BindingId(22) val site=SiteId(118) ty=char intent=Read
     _1 = call to_string_char(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(116)) ty=string
+    stmt: return site=Some(SiteId(117)) ty=string
     ret = move _1
     return
 
@@ -224,10 +224,10 @@ fn f64::fmt(f64) -> string [conv=default]
     _0: f64
     _1: string
   bb0:
-    stmt: use BindingId(23) val site=SiteId(120) ty=f64 intent=Read
+    stmt: use BindingId(23) val site=SiteId(121) ty=f64 intent=Read
     _1 = call to_string_f64(_0) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(119)) ty=string
+    stmt: return site=Some(SiteId(120)) ty=string
     ret = move _1
     return
 
@@ -237,11 +237,11 @@ fn f32::fmt(f32) -> string [conv=default]
     _1: f64
     _2: string
   bb0:
-    stmt: use BindingId(24) val site=SiteId(124) ty=f32 intent=Read
+    stmt: use BindingId(24) val site=SiteId(125) ty=f32 intent=Read
     _1 = cast _0 f32 -> f64
     _2 = call to_string_f64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(122)) ty=string
+    stmt: return site=Some(SiteId(123)) ty=string
     ret = move _2
     return
 
@@ -249,8 +249,8 @@ fn string::fmt(string) -> string [conv=default]
   locals:
     _0: string
   bb0:
-    stmt: use BindingId(25) val site=SiteId(126) ty=string intent=Read
-    stmt: return site=Some(SiteId(126)) ty=string
+    stmt: use BindingId(25) val site=SiteId(127) ty=string intent=Read
+    stmt: return site=Some(SiteId(127)) ty=string
     ret = move _0
     return
 
@@ -261,14 +261,14 @@ fn duration::from_nanos(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(26) n site=SiteId(128) ty=i64 intent=Read
+    stmt: use BindingId(26) n site=SiteId(129) ty=i64 intent=Read
     _1 = const.duration 1ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(127)) ty=duration
+    stmt: return site=Some(SiteId(128)) ty=duration
     ret = move _2
     return
 
@@ -279,14 +279,14 @@ fn duration::from_micros(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(27) n site=SiteId(131) ty=i64 intent=Read
+    stmt: use BindingId(27) n site=SiteId(132) ty=i64 intent=Read
     _1 = const.duration 1000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(130)) ty=duration
+    stmt: return site=Some(SiteId(131)) ty=duration
     ret = move _2
     return
 
@@ -297,14 +297,14 @@ fn duration::from_millis(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(28) n site=SiteId(134) ty=i64 intent=Read
+    stmt: use BindingId(28) n site=SiteId(135) ty=i64 intent=Read
     _1 = const.duration 1000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(133)) ty=duration
+    stmt: return site=Some(SiteId(134)) ty=duration
     ret = move _2
     return
 
@@ -315,14 +315,14 @@ fn duration::from_secs(i64) -> duration [conv=default]
     _2: duration
     _3: bool
   bb0:
-    stmt: use BindingId(29) n site=SiteId(137) ty=i64 intent=Read
+    stmt: use BindingId(29) n site=SiteId(138) ty=i64 intent=Read
     _1 = const.duration 1000000000ns
     _2 ovf=_3 = mul.checked.s _0 _1
     branch _3 ? bb1 : bb2
   bb1:
     trap(IntegerOverflow)
   bb2:
-    stmt: return site=Some(SiteId(136)) ty=duration
+    stmt: return site=Some(SiteId(137)) ty=duration
     ret = move _2
     return
 
@@ -334,11 +334,11 @@ fn duration::fmt(duration) -> string [conv=default]
     _3: string
     _4: string
   bb0:
-    stmt: use BindingId(30) val site=SiteId(142) ty=duration intent=Read
+    stmt: use BindingId(30) val site=SiteId(143) ty=duration intent=Read
     _1 = call_rt hew_duration_nanos(_0)
     _2 = call to_string_i64(_1) -> bb1
   bb1:
-    stmt: return site=Some(SiteId(139)) ty=string
+    stmt: return site=Some(SiteId(140)) ty=string
     _3 = string_lit "ns"
     _4 = call_rt hew_string_concat(_2, _3)
     drop _2 ty=string fn=release(hew_string_drop)

--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -133,6 +133,7 @@ pub(crate) fn mir_diagnostic_prefix(kind: &hew_mir::MirDiagnosticKind) -> &'stat
             "E_REMOTE_PAYLOAD_UNSUPPORTED"
         }
         hew_mir::MirDiagnosticKind::InvalidActorSpawnArgument { .. } => "E_INVALID_SPAWN_ARGUMENT",
+        hew_mir::MirDiagnosticKind::MissingActorSpawnArgument { .. } => "E_MISSING_SPAWN_ARGUMENT",
         hew_mir::MirDiagnosticKind::UnknownType { .. }
         | hew_mir::MirDiagnosticKind::UnsupportedUserRecordValueClass { .. }
         | hew_mir::MirDiagnosticKind::UnsupportedNode { .. }
@@ -564,6 +565,7 @@ fn mir_kind_name(kind: &hew_mir::MirDiagnosticKind) -> &'static str {
         hew_mir::MirDiagnosticKind::ContextBindingEscapes { .. } => "ContextBindingEscapes",
         hew_mir::MirDiagnosticKind::UnknownActorStateField { .. } => "UnknownActorStateField",
         hew_mir::MirDiagnosticKind::InvalidActorSpawnArgument { .. } => "InvalidActorSpawnArgument",
+        hew_mir::MirDiagnosticKind::MissingActorSpawnArgument { .. } => "MissingActorSpawnArgument",
         hew_mir::MirDiagnosticKind::ActorHandlerSymbolCollision { .. } => {
             "ActorHandlerSymbolCollision"
         }
@@ -636,6 +638,7 @@ fn mir_primary_site(kind: &hew_mir::MirDiagnosticKind) -> Option<hew_hir::SiteId
         hew_mir::MirDiagnosticKind::SelectArmNotImplemented { site, .. }
         | hew_mir::MirDiagnosticKind::NotYetImplemented { site, .. }
         | hew_mir::MirDiagnosticKind::InvalidActorSpawnArgument { site, .. }
+        | hew_mir::MirDiagnosticKind::MissingActorSpawnArgument { site, .. }
         | hew_mir::MirDiagnosticKind::UnresolvedPlace { site, .. }
         | hew_mir::MirDiagnosticKind::CannotMaterializeClosureCapture { site, .. }
         | hew_mir::MirDiagnosticKind::RemotePayloadUnsupported { site, .. }
@@ -731,6 +734,9 @@ fn mir_diagnostic_message(diagnostic: &hew_mir::MirDiagnostic) -> String {
         } => {
             format!("invalid spawn argument `{argument}` for actor `{actor}`")
         }
+        hew_mir::MirDiagnosticKind::MissingActorSpawnArgument { actor, field, .. } => format!(
+            "actor `{actor}` spawn is missing required field `{field}`; supply `{field}: <value>`"
+        ),
         hew_mir::MirDiagnosticKind::ActorHandlerSymbolCollision {
             symbol,
             existing,
@@ -881,6 +887,7 @@ fn mir_context_notes(diagnostic: &hew_mir::MirDiagnostic) -> Vec<String> {
         hew_mir::MirDiagnosticKind::SelectArmNotImplemented { site, .. }
         | hew_mir::MirDiagnosticKind::NotYetImplemented { site, .. }
         | hew_mir::MirDiagnosticKind::InvalidActorSpawnArgument { site, .. }
+        | hew_mir::MirDiagnosticKind::MissingActorSpawnArgument { site, .. }
         | hew_mir::MirDiagnosticKind::UnresolvedPlace { site, .. }
         | hew_mir::MirDiagnosticKind::CannotMaterializeClosureCapture { site, .. }
         | hew_mir::MirDiagnosticKind::RemotePayloadUnsupported { site, .. }

--- a/hew-cli/tests/supervisor_init_args_e2e.rs
+++ b/hew-cli/tests/supervisor_init_args_e2e.rs
@@ -683,3 +683,71 @@ fn main() {
          got stdout: {stdout}"
     );
 }
+
+/// A supervisor child's `MissingActorSpawnArgument` diagnostic must carry the
+/// real source location of the *child declaration* — never a sentinel
+/// `SiteId(0)` and never a numeric collision with an unrelated site. Before
+/// this fix, supervisor children were never registered in the verifier's
+/// site-span table, so the diagnostic either rendered with no location or
+/// (worse) aliased whatever site happened to claim the same numeric ID —
+/// observed live pointing at an unrelated `receive fn`'s parameter.
+///
+/// The fixture places the child declaration on a distinct line from the
+/// unrelated actor receive handler's parameter (`x`) so a collision would be
+/// unambiguous: `--format=json`'s `span.start_line` must match the child
+/// declaration's line, not the receive handler's.
+#[test]
+fn supervisor_missing_field_diagnostic_points_at_child_declaration() {
+    require_codegen();
+
+    let source = r"actor Worker {
+    let id: i64;
+    receive fn work(x: i64) -> i64 { x }
+}
+
+supervisor Pool {
+    strategy: one_for_one;
+    intensity: 3 within 60s;
+    child w1: Worker;
+}
+";
+
+    let (_dir, path) = write_fixture(source);
+
+    let output = Command::new(hew_binary())
+        .args(["check", "--format=json", path.to_str().unwrap()])
+        .output()
+        .expect("hew binary must run");
+
+    assert!(
+        !output.status.success(),
+        "a stateful child with no init args must be a compile error"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let diagnostics: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("stdout must be a parseable JSON array; parse error: {error}\nstdout:\n{stdout}")
+    });
+    let diagnostics = diagnostics
+        .as_array()
+        .unwrap_or_else(|| panic!("top-level JSON must be an array; got:\n{stdout}"));
+
+    let missing = diagnostics
+        .iter()
+        .find(|d| d["code"] == "MissingActorSpawnArgument")
+        .unwrap_or_else(|| {
+            panic!("expected a MissingActorSpawnArgument diagnostic; got: {diagnostics:#?}")
+        });
+
+    // `child w1: Worker;` is on source line 9 (1-based). The unrelated
+    // `receive fn work(x: i64)` parameter that a SiteId collision previously
+    // rendered a caret on lives on line 3 — asserting an exact match (not
+    // merely "not line 3") pins the fix to the real declaration rather than
+    // any other incidentally-different line.
+    assert_eq!(
+        missing["span"]["start_line"], 9,
+        "MissingActorSpawnArgument must carry the child declaration's real \
+         source line, not a sentinel or an unrelated colliding site; \
+         diagnostic: {missing:#?}"
+    );
+}

--- a/hew-codegen-rs/tests/emission/supervisor_emission.rs
+++ b/hew-codegen-rs/tests/emission/supervisor_emission.rs
@@ -19,7 +19,7 @@
 //! LESSONS: boundary-fail-closed (P0) — the bootstrap is a fail-closed
 //! seam against the runtime supervisor ABI.
 
-use hew_hir::HirSupervisorStrategy;
+use hew_hir::{HirSupervisorStrategy, SiteId};
 use hew_mir::{
     ActorLayout, BasicBlock, ChildInitArg, FunctionCallConv, IrPipeline, RawMirFunction,
     RecordLayout, SupervisorChildLayout, SupervisorLayout, Terminator,
@@ -174,6 +174,7 @@ fn supervisor_pipeline() -> IrPipeline {
             init_state_fields: vec![("value".to_string(), ChildInitArg::I64(42))],
             nested_bootstrap_symbol: None,
             pool_count: None,
+            site: SiteId(0),
         }],
     };
 
@@ -494,6 +495,7 @@ fn on_crash_pipeline() -> IrPipeline {
             init_state_fields: vec![],
             nested_bootstrap_symbol: None,
             pool_count: None,
+            site: SiteId(0),
         }],
     };
 
@@ -785,6 +787,7 @@ fn nested_supervisor_pipeline() -> IrPipeline {
             init_state_fields: vec![],
             nested_bootstrap_symbol: None,
             pool_count: None,
+            site: SiteId(0),
         }],
     };
 
@@ -813,6 +816,7 @@ fn nested_supervisor_pipeline() -> IrPipeline {
                 init_state_fields: vec![],
                 nested_bootstrap_symbol: None,
                 pool_count: None,
+                site: SiteId(0),
             },
             SupervisorChildLayout {
                 name: "sub".to_string(),
@@ -831,6 +835,7 @@ fn nested_supervisor_pipeline() -> IrPipeline {
                 init_state_fields: vec![],
                 nested_bootstrap_symbol: Some(inner_bootstrap.clone()),
                 pool_count: None,
+                site: SiteId(0),
             },
         ],
     };
@@ -1014,6 +1019,7 @@ fn pool_then_static_pipeline() -> IrPipeline {
                 init_state_fields: vec![],
                 nested_bootstrap_symbol: None,
                 pool_count: Some(hew_mir::PoolCount::Literal(2)),
+                site: SiteId(0),
             },
             // Static actor child AFTER the pool. The pool's 2 members occupy
             // static slots 0 and 1 (they ARE static children), so this `monitor`
@@ -1036,6 +1042,7 @@ fn pool_then_static_pipeline() -> IrPipeline {
                 init_state_fields: vec![],
                 nested_bootstrap_symbol: None,
                 pool_count: None,
+                site: SiteId(0),
             },
         ],
     };

--- a/hew-hir/src/lower.rs
+++ b/hew-hir/src/lower.rs
@@ -10270,6 +10270,12 @@ impl LowerCtx {
                         ShutdownDirective::BrutalKill => HirShutdownDirective::BrutalKill,
                         ShutdownDirective::Infinity => HirShutdownDirective::Infinity,
                     }),
+                    // Real site for this child declaration, registered below
+                    // by `verify.rs` so MIR diagnostics with no specific
+                    // argument to blame (a missing required field) carry a
+                    // caret at the declaration instead of a sentinel.
+                    site: self.ids.site(),
+                    span: child.span.clone(),
                 }
             })
             .collect();

--- a/hew-hir/src/node.rs
+++ b/hew-hir/src/node.rs
@@ -818,6 +818,17 @@ pub struct HirSupervisorChild {
     /// Per-child graceful-stop directive from the `shutdown:` clause.
     /// `None` means the supervisor default applies.
     pub shutdown: Option<HirShutdownDirective>,
+    /// Real, verifier-registered site for this child declaration, minted from
+    /// the same monotonic allocator as every other HIR site
+    /// (`self.ids.site()`). MIR diagnostics that have no specific
+    /// argument expression to blame (a missing required field) use this
+    /// site rather than a sentinel, so the rendered caret always lands on
+    /// the child declaration and never collides with an unrelated site.
+    pub site: SiteId,
+    /// Byte span of the child declaration (`child`/`pool` keyword through the
+    /// clause's terminator), registered against `site` by
+    /// `hew_hir::verify::collect_site_spans` so CLI rendering can resolve it.
+    pub span: Span,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/hew-hir/src/verify.rs
+++ b/hew-hir/src/verify.rs
@@ -115,6 +115,23 @@ impl Verifier {
                     // uniqueness in S-A; children-list resolution and
                     // wired_to validation are S-B's job.
                     self.node(sup.node, sup.span.clone());
+                    // Register each child's declaration site and every
+                    // init-arg/pool-count expression's real site. Without
+                    // this, MIR diagnostics that carry a supervisor child's
+                    // site (a missing required field, an unknown field name)
+                    // key into `collect_site_spans` with an ID the table
+                    // never claims — silently rendering with no location, or
+                    // worse, numerically colliding with an unrelated site
+                    // that IS registered and rendering a wrong caret.
+                    for child in &sup.children {
+                        self.site(child.site, child.span.clone());
+                        for (_, arg) in &child.init_args {
+                            self.expr(arg);
+                        }
+                        if let Some(pool_count) = &child.pool_count {
+                            self.expr(pool_count);
+                        }
+                    }
                 }
                 HirItem::Impl(block) => {
                     // V0b: impl-block metadata only contributes its own

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -1550,6 +1550,9 @@ fn render_diag_kind(kind: &MirDiagnosticKind) -> String {
             argument,
             site,
         } => format!("InvalidActorSpawnArgument {actor}.{argument} site={site:?}"),
+        MirDiagnosticKind::MissingActorSpawnArgument { actor, field, site } => {
+            format!("MissingActorSpawnArgument {actor}.{field} site={site:?}")
+        }
         MirDiagnosticKind::ActorHandlerSymbolCollision {
             symbol,
             existing,

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -2172,12 +2172,16 @@ pub fn lower_hir_module_with_facts(
                                 default_expr
                             } else {
                                 // Required field not supplied and no declared default →
-                                // fail-closed diagnostic.
+                                // fail-closed diagnostic. `child.site` is the real
+                                // per-child-declaration site registered in
+                                // `hew_hir::verify::collect_site_spans` — never a
+                                // sentinel — so the rendered caret lands on the
+                                // child declaration.
                                 diagnostics.push(MirDiagnostic {
                                     kind: MirDiagnosticKind::MissingActorSpawnArgument {
                                         actor: child.actor_name.clone(),
                                         field: field_name.clone(),
-                                        site: SiteId(0),
+                                        site: child.site,
                                     },
                                     note: format!(
                                         "supply a value: `child {}: {}({field_name}: <value>)`",
@@ -2901,7 +2905,22 @@ pub fn lower_hir_module_with_facts(
                         &mut record_layouts,
                         &mut emitted_named_fn_shims,
                     );
-                    diagnostics.extend(lowered.diagnostics);
+                    // `lowered.diagnostics` carries the synthetic body's own
+                    // Builder-accumulated diagnostics (from lowering the
+                    // per-child `spawn ChildActor(...)` statements). A
+                    // missing required field on a NON-config child is
+                    // authoritatively diagnosed once already, above, by the
+                    // post-loop pass that builds `init_state_fields` (it
+                    // walks every state field unconditionally, so it always
+                    // fires first for the identical (actor, field) pair the
+                    // synthetic spawn would also flag). Strip the redundant
+                    // copy here rather than teaching the shared
+                    // `lower_spawn_actor_state_arg` helper about a
+                    // supervisor-synthetic-body special case that would also
+                    // suppress the diagnostic real direct-spawn users need.
+                    diagnostics.extend(lowered.diagnostics.into_iter().filter(|d| {
+                        !matches!(d.kind, MirDiagnosticKind::MissingActorSpawnArgument { .. })
+                    }));
                 }
             }
             HirItem::Record(_)
@@ -5199,6 +5218,7 @@ fn build_supervisor_layout(
             // Threading it here would require a HewChildSpec ABI field the
             // runtime would ignore, which would fake enforcement. When the
             // deadline wheel lands, read child.shutdown here and emit it.
+            site: child.site,
         })
         .collect();
 
@@ -5419,6 +5439,54 @@ fn lower_supervisor_bootstrap(
             continue;
         }
 
+        // Validate every explicit init-arg NAME against the actor's accepted
+        // field/init surface, for EVERY child — including a config-backed one
+        // that is about to be skipped below. Without this, an unknown field
+        // name on a config-backed child's args got zero validation: the
+        // config-skip `continue` below runs before the synthesized spawn
+        // (further down, the only other place a name was checked) ever sees
+        // it. This is the single authoritative name-validation path for
+        // supervisor children; a bad name here means the diagnostic already
+        // fired, so the child is skipped rather than also flowing into the
+        // synthesized spawn's own (now-redundant) name check.
+        if let Some(actor_layout) = actor_layouts.get(&child.ty) {
+            let explicit_init = actor_layout.init_symbol.is_some();
+            let mut has_invalid_arg = false;
+            for (arg_name, arg_expr) in &child.init_args {
+                let is_valid = if explicit_init {
+                    actor_layout.init_param_names.iter().any(|n| n == arg_name)
+                        || actor_layout.state_field_names.iter().any(|n| n == arg_name)
+                } else {
+                    actor_layout.state_field_names.iter().any(|n| n == arg_name)
+                };
+                if !is_valid {
+                    let note = Builder::invalid_spawn_arg_note(
+                        &child.ty,
+                        arg_name,
+                        explicit_init,
+                        &actor_layout.init_param_names,
+                        &actor_layout.state_field_names,
+                    );
+                    diagnostics.push(MirDiagnostic {
+                        kind: MirDiagnosticKind::InvalidActorSpawnArgument {
+                            actor: child.ty.clone(),
+                            argument: arg_name.clone(),
+                            // Real per-arg site from the child's own
+                            // declaration — never a sentinel, never a
+                            // fresh_site() counter local to this function.
+                            site: arg_expr.site,
+                        },
+                        note,
+                    });
+                    has_invalid_arg = true;
+                    break;
+                }
+            }
+            if has_invalid_arg {
+                continue;
+            }
+        }
+
         // A config-init child (any init arg reads `config.field`) is produced
         // entirely by the codegen init thunk, which emits the whole bootstrap
         // body from `SupervisorChildLayout` and DISCARDS this synthetic body.
@@ -5427,7 +5495,8 @@ fn lower_supervisor_bootstrap(
         // BindingRef the synthetic body's dataflow can't resolve — tripping a
         // spurious "read before initialised" on an owned config field. Skip the
         // spawn statement for such a child entirely (like a nested supervisor),
-        // leaving the synthetic body a valid signature carrier.
+        // leaving the synthetic body a valid signature carrier. Name validity
+        // was already checked above, so nothing is lost by skipping.
         if child
             .init_args
             .iter()

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -2140,27 +2140,6 @@ pub fn lower_hir_module_with_facts(
                 .get(&key)
                 .map_or(&[], Vec::as_slice);
 
-            // Validate that every explicitly-supplied field name exists on the actor.
-            for (field_name, hir_expr) in explicit_hir_args {
-                let field_known =
-                    al.is_some_and(|al| al.state_field_names.iter().any(|n| n == field_name));
-                if !field_known {
-                    diagnostics.push(MirDiagnostic {
-                        kind: MirDiagnosticKind::NotYetImplemented {
-                            construct: format!(
-                                "supervisor `{}` child `{}` init arg `{field_name}` is \
-                                 not a declared state field on actor `{}`",
-                                sup_layout.name, child.name, child.actor_name
-                            ),
-                            site: hir_expr.site,
-                        },
-                        note: "child init arg field names must match actor state field \
-                               declarations"
-                            .to_string(),
-                    });
-                }
-            }
-
             // Only build the complete field plan when the actor layout is known
             // and has state fields.  Missing actor layout → silently empty (codegen
             // will fail-closed for stateful actors via its existing gate).

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -2140,11 +2140,55 @@ pub fn lower_hir_module_with_facts(
                 .get(&key)
                 .map_or(&[], Vec::as_slice);
 
-            // Only build the complete field plan when the actor layout is known
-            // and has state fields.  Missing actor layout → silently empty (codegen
-            // will fail-closed for stateful actors via its existing gate).
+            // Validate every explicit init-arg NAME against the actor's
+            // accepted field/init surface BEFORE any missing-field planning.
+            // This must run first: the field-plan loop below walks every
+            // state field unconditionally and reports a field as "missing"
+            // whenever no explicit arg matches its name, which is exactly
+            // what happens when the arg that WAS meant to supply it has a
+            // typo'd name. Running name validation first and skipping the
+            // field plan entirely on an invalid name keeps a bad name to
+            // exactly one diagnostic (InvalidActorSpawnArgument) instead of
+            // that plus a misleading MissingActorSpawnArgument for the field
+            // the bad name was presumably meant to supply.
+            let mut has_invalid_arg_name = false;
             if let Some(actor_layout) = al {
-                if !actor_layout.state_field_names.is_empty() {
+                let explicit_init = actor_layout.init_symbol.is_some();
+                for (arg_name, arg_expr) in explicit_hir_args {
+                    let is_valid = if explicit_init {
+                        actor_layout.init_param_names.iter().any(|n| n == arg_name)
+                            || actor_layout.state_field_names.iter().any(|n| n == arg_name)
+                    } else {
+                        actor_layout.state_field_names.iter().any(|n| n == arg_name)
+                    };
+                    if !is_valid {
+                        let note = Builder::invalid_spawn_arg_note(
+                            &child.actor_name,
+                            arg_name,
+                            explicit_init,
+                            &actor_layout.init_param_names,
+                            &actor_layout.state_field_names,
+                        );
+                        diagnostics.push(MirDiagnostic {
+                            kind: MirDiagnosticKind::InvalidActorSpawnArgument {
+                                actor: child.actor_name.clone(),
+                                argument: arg_name.clone(),
+                                site: arg_expr.site,
+                            },
+                            note,
+                        });
+                        has_invalid_arg_name = true;
+                        break;
+                    }
+                }
+            }
+
+            // Only build the complete field plan when the actor layout is known,
+            // has state fields, and every explicit arg name was valid.  Missing
+            // actor layout → silently empty (codegen will fail-closed for
+            // stateful actors via its existing gate).
+            if let Some(actor_layout) = al {
+                if !has_invalid_arg_name && !actor_layout.state_field_names.is_empty() {
                     // Index explicit args by field name for O(1) lookup.
                     let explicit_by_name: HashMap<&str, &HirExpr> = explicit_hir_args
                         .iter()
@@ -5439,49 +5483,28 @@ fn lower_supervisor_bootstrap(
             continue;
         }
 
-        // Validate every explicit init-arg NAME against the actor's accepted
-        // field/init surface, for EVERY child — including a config-backed one
-        // that is about to be skipped below. Without this, an unknown field
-        // name on a config-backed child's args got zero validation: the
-        // config-skip `continue` below runs before the synthesized spawn
-        // (further down, the only other place a name was checked) ever sees
-        // it. This is the single authoritative name-validation path for
-        // supervisor children; a bad name here means the diagnostic already
-        // fired, so the child is skipped rather than also flowing into the
-        // synthesized spawn's own (now-redundant) name check.
+        // Determine whether any explicit init-arg NAME is invalid against the
+        // actor's accepted field/init surface — WITHOUT emitting a
+        // diagnostic here. The authoritative InvalidActorSpawnArgument for a
+        // bad name is emitted earlier in the pipeline, in the post-loop
+        // supervisor-layout pass in `lower_hir_module_with_facts` (S3), which
+        // runs before this synthetic-body lowering and also skips its own
+        // missing-field planning for the same child once a bad name is
+        // found. Re-emitting here would duplicate that diagnostic; this
+        // check exists solely so the spawn statement for an invalid child is
+        // still skipped (never routed through the synthesized-body lowering
+        // that assumes every arg name resolved).
         if let Some(actor_layout) = actor_layouts.get(&child.ty) {
             let explicit_init = actor_layout.init_symbol.is_some();
-            let mut has_invalid_arg = false;
-            for (arg_name, arg_expr) in &child.init_args {
+            let has_invalid_arg = child.init_args.iter().any(|(arg_name, _)| {
                 let is_valid = if explicit_init {
                     actor_layout.init_param_names.iter().any(|n| n == arg_name)
                         || actor_layout.state_field_names.iter().any(|n| n == arg_name)
                 } else {
                     actor_layout.state_field_names.iter().any(|n| n == arg_name)
                 };
-                if !is_valid {
-                    let note = Builder::invalid_spawn_arg_note(
-                        &child.ty,
-                        arg_name,
-                        explicit_init,
-                        &actor_layout.init_param_names,
-                        &actor_layout.state_field_names,
-                    );
-                    diagnostics.push(MirDiagnostic {
-                        kind: MirDiagnosticKind::InvalidActorSpawnArgument {
-                            actor: child.ty.clone(),
-                            argument: arg_name.clone(),
-                            // Real per-arg site from the child's own
-                            // declaration — never a sentinel, never a
-                            // fresh_site() counter local to this function.
-                            site: arg_expr.site,
-                        },
-                        note,
-                    });
-                    has_invalid_arg = true;
-                    break;
-                }
-            }
+                !is_valid
+            });
             if has_invalid_arg {
                 continue;
             }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -2195,13 +2195,9 @@ pub fn lower_hir_module_with_facts(
                                 // Required field not supplied and no declared default →
                                 // fail-closed diagnostic.
                                 diagnostics.push(MirDiagnostic {
-                                    kind: MirDiagnosticKind::NotYetImplemented {
-                                        construct: format!(
-                                            "supervisor `{}` child `{}` is missing a value \
-                                             for required state field `{field_name}` on actor \
-                                             `{}` (field has no declared default)",
-                                            sup_layout.name, child.name, child.actor_name
-                                        ),
+                                    kind: MirDiagnosticKind::MissingActorSpawnArgument {
+                                        actor: child.actor_name.clone(),
+                                        field: field_name.clone(),
                                         site: SiteId(0),
                                     },
                                     note: format!(
@@ -32272,8 +32268,9 @@ impl Builder {
     ) -> Option<Place> {
         let Some(arg) = explicit.get(field_name) else {
             self.diagnostics.push(MirDiagnostic {
-                kind: MirDiagnosticKind::NotYetImplemented {
-                    construct: format!("spawn `{actor_name}` missing field `{field_name}`"),
+                kind: MirDiagnosticKind::MissingActorSpawnArgument {
+                    actor: actor_name.to_string(),
+                    field: field_name.to_string(),
                     site: expr.site,
                 },
                 note: "actor spawn without an init block requires every state field by declaration name"

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -1073,6 +1073,13 @@ pub struct SupervisorChildLayout {
     /// registered as a static child and bound into the pool via
     /// `hew_supervisor_pool_member_add_static`.
     pub pool_count: Option<PoolCount>,
+    /// Real HIR site of this child's declaration
+    /// (`HirSupervisorChild.site`, registered in
+    /// `hew_hir::verify::collect_site_spans`). MIR diagnostics that have no
+    /// specific argument expression to blame (a missing required field) use
+    /// this site so the rendered caret lands on the child declaration
+    /// instead of an unregistered sentinel.
+    pub site: SiteId,
 }
 
 impl SupervisorChildLayout {

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -6292,6 +6292,14 @@ pub enum MirDiagnosticKind {
         argument: String,
         site: SiteId,
     },
+    /// A required actor state field was not supplied at a spawn/child site and
+    /// has no declared default. The compiler understands the fact — this is a
+    /// user error, NOT a lowering limitation (sibling of `InvalidActorSpawnArgument`).
+    MissingActorSpawnArgument {
+        actor: String,
+        field: String,
+        site: SiteId,
+    },
     /// Two actor receive handlers, or a handler and an existing function symbol,
     /// resolved to the same emitted MIR symbol.
     ActorHandlerSymbolCollision {

--- a/hew-mir/tests/actor/actor_field_defaults.rs
+++ b/hew-mir/tests/actor/actor_field_defaults.rs
@@ -109,11 +109,68 @@ fn missing_non_defaulted_actor_state_field_still_requires_spawn_arg() {
         pipeline.diagnostics.iter().any(|diag| {
             matches!(
                 &diag.kind,
-                MirDiagnosticKind::NotYetImplemented { construct, .. }
-                    if construct.contains("spawn `Pair` missing field `m`")
+                MirDiagnosticKind::MissingActorSpawnArgument { actor, field, .. }
+                    if actor == "Pair" && field == "m"
             )
         }),
-        "missing non-defaulted field should remain required; diagnostics: {:#?}",
+        "missing non-defaulted field should remain required, reported as a user error \
+         (MissingActorSpawnArgument), not a lowering limitation; diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+    assert!(
+        !pipeline
+            .diagnostics
+            .iter()
+            .any(|diag| matches!(&diag.kind, MirDiagnosticKind::NotYetImplemented { .. })),
+        "a missing spawn argument is a fully-understood user error and must never surface as \
+         NotYetImplemented; diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// Direct `spawn Actor()` missing a required state field reports exactly one
+/// `MissingActorSpawnArgument` — a user error the compiler fully understands,
+/// not a `NotYetImplemented` compiler-limitation signal.
+#[test]
+fn direct_spawn_missing_required_field_reports_single_missing_actor_spawn_argument() {
+    let pipeline = lower_module_from_source(
+        r"
+        actor Worker {
+            let id: i64;
+            receive fn work(x: i64) -> i64 { x }
+        }
+
+        fn main() -> i64 {
+            spawn Worker();
+            0
+        }
+        ",
+    );
+
+    let missing_matches: Vec<_> = pipeline
+        .diagnostics
+        .iter()
+        .filter(|diag| {
+            matches!(
+                &diag.kind,
+                MirDiagnosticKind::MissingActorSpawnArgument { actor, field, .. }
+                    if actor == "Worker" && field == "id"
+            )
+        })
+        .collect();
+    assert_eq!(
+        missing_matches.len(),
+        1,
+        "direct spawn missing a required field must report exactly one \
+         MissingActorSpawnArgument; diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+    assert!(
+        !pipeline
+            .diagnostics
+            .iter()
+            .any(|diag| matches!(&diag.kind, MirDiagnosticKind::NotYetImplemented { .. })),
+        "diagnostics: {:#?}",
         pipeline.diagnostics
     );
 }

--- a/hew-mir/tests/actor/actor_handler_lowering.rs
+++ b/hew-mir/tests/actor/actor_handler_lowering.rs
@@ -451,6 +451,8 @@ fn supervisor_child_layout_mirrors_cycle_capable_actor_metadata() {
             init_args: Vec::new(),
             pool_count: None,
             shutdown: None,
+            site: ids.site(),
+            span: 0..0,
         }],
         span: 0..0,
     };

--- a/hew-mir/tests/actor/supervisor_lowering.rs
+++ b/hew-mir/tests/actor/supervisor_lowering.rs
@@ -696,6 +696,59 @@ fn owned_collection_config_field_init_arg_is_walled_at_checker() {
     );
 }
 
+/// A supervisor `child` init arg naming a field the actor does not declare
+/// reports exactly one `InvalidActorSpawnArgument` for the bad field — the
+/// fail-open guard for the S4 delete: removing the supervisor-loop's redundant
+/// unknown-field check must not drop the only diagnostic for this mistake, and
+/// the correct `InvalidActorSpawnArgument` (already fired by the direct-spawn
+/// validator the synthesized child spawn routes through) must remain the sole
+/// report.
+#[test]
+fn supervisor_child_unknown_field_reports_exactly_one_invalid_actor_spawn_argument() {
+    let pipeline = lower_module_from_source(
+        r"
+        actor Worker {
+            let id: i64;
+            receive fn work(x: i64) -> i64 { x }
+        }
+
+        supervisor WorkerPool {
+            strategy: one_for_one;
+            intensity: 5 within 10s;
+            child w1: Worker(idx: 1)
+        }
+        ",
+    );
+
+    let invalid_matches: Vec<_> = pipeline
+        .diagnostics
+        .iter()
+        .filter(|diag| {
+            matches!(
+                &diag.kind,
+                MirDiagnosticKind::InvalidActorSpawnArgument { actor, argument, .. }
+                    if actor == "Worker" && argument == "idx"
+            )
+        })
+        .collect();
+    assert_eq!(
+        invalid_matches.len(),
+        1,
+        "supervisor child unknown field must report exactly one \
+         InvalidActorSpawnArgument for the bad field; diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+    assert!(
+        !pipeline
+            .diagnostics
+            .iter()
+            .any(|diag| matches!(&diag.kind, MirDiagnosticKind::NotYetImplemented { .. })),
+        "an unknown supervisor child init-arg field name is a fully-understood user error and \
+         must never surface as NotYetImplemented; diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
 /// A supervisor `child` missing a required actor state field (no init block,
 /// no declared default) reports `MissingActorSpawnArgument` — a user error the
 /// compiler fully understands — never `NotYetImplemented`.

--- a/hew-mir/tests/actor/supervisor_lowering.rs
+++ b/hew-mir/tests/actor/supervisor_lowering.rs
@@ -13,7 +13,7 @@
 use std::collections::HashMap;
 
 use hew_hir::{lower_program, HirDiagnosticKind, ResolutionCtx};
-use hew_mir::{lower_hir_module, FunctionCallConv, Instr, Place, Terminator};
+use hew_mir::{lower_hir_module, FunctionCallConv, Instr, MirDiagnosticKind, Place, Terminator};
 use hew_types::{module_registry::ModuleRegistry, BuiltinType, Checker, ResolvedTy};
 
 /// Lower a Hew source program to MIR, asserting no parse or HIR diagnostics.
@@ -693,5 +693,48 @@ fn owned_collection_config_field_init_arg_is_walled_at_checker() {
         "an owned `Vec` config init arg must stay walled until its clone-in-thunk codegen lands; \
          errors: {:#?}",
         tc_output.errors
+    );
+}
+
+/// A supervisor `child` missing a required actor state field (no init block,
+/// no declared default) reports `MissingActorSpawnArgument` — a user error the
+/// compiler fully understands — never `NotYetImplemented`.
+#[test]
+fn supervisor_child_missing_required_field_reports_missing_actor_spawn_argument() {
+    let pipeline = lower_module_from_source(
+        r"
+        actor Worker {
+            let id: i64;
+            receive fn work(x: i64) -> i64 { x }
+        }
+
+        supervisor WorkerPool {
+            strategy: one_for_one;
+            intensity: 5 within 10s;
+            child w1: Worker()
+        }
+        ",
+    );
+
+    assert!(
+        pipeline.diagnostics.iter().any(|diag| {
+            matches!(
+                &diag.kind,
+                MirDiagnosticKind::MissingActorSpawnArgument { actor, field, .. }
+                    if actor == "Worker" && field == "id"
+            )
+        }),
+        "supervisor child missing a required state field must report \
+         MissingActorSpawnArgument; diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+    assert!(
+        !pipeline
+            .diagnostics
+            .iter()
+            .any(|diag| matches!(&diag.kind, MirDiagnosticKind::NotYetImplemented { .. })),
+        "a missing supervisor child field is a fully-understood user error and must never \
+         surface as NotYetImplemented; diagnostics: {:#?}",
+        pipeline.diagnostics
     );
 }

--- a/hew-mir/tests/actor/supervisor_lowering.rs
+++ b/hew-mir/tests/actor/supervisor_lowering.rs
@@ -781,6 +781,25 @@ fn supervisor_child_missing_required_field_reports_missing_actor_spawn_argument(
          MissingActorSpawnArgument; diagnostics: {:#?}",
         pipeline.diagnostics
     );
+    let missing_matches: Vec<_> = pipeline
+        .diagnostics
+        .iter()
+        .filter(|diag| {
+            matches!(
+                &diag.kind,
+                MirDiagnosticKind::MissingActorSpawnArgument { actor, field, .. }
+                    if actor == "Worker" && field == "id"
+            )
+        })
+        .collect();
+    assert_eq!(
+        missing_matches.len(),
+        1,
+        "supervisor child missing a required state field must report exactly one \
+         MissingActorSpawnArgument — the post-loop layout pass and the synthesized \
+         spawn used to both independently diagnose the same field; diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
     assert!(
         !pipeline
             .diagnostics
@@ -788,6 +807,66 @@ fn supervisor_child_missing_required_field_reports_missing_actor_spawn_argument(
             .any(|diag| matches!(&diag.kind, MirDiagnosticKind::NotYetImplemented { .. })),
         "a missing supervisor child field is a fully-understood user error and must never \
          surface as NotYetImplemented; diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// A config-backed supervisor child (any init arg reads `config.field`) is
+/// entirely skipped by the synthesized-spawn machinery — the codegen init
+/// thunk builds its real spawn from `SupervisorChildLayout` instead. Before
+/// this fix, that skip ran BEFORE any field-name validation, so an unknown
+/// field name on such a child passed silently: the (now-deleted)
+/// supervisor-loop guard used to catch it, and the synthesized spawn never
+/// even ran on a config-backed child to catch it either. This is the
+/// fail-open regression the S4 delete introduced for config children
+/// specifically.
+#[test]
+fn supervisor_config_child_unknown_field_reports_invalid_actor_spawn_argument() {
+    let pipeline = lower_module_from_source(
+        r"
+        record AppConfig { size: i64 }
+
+        actor Cache {
+            var capacity: i64;
+            init(capacity: i64) {
+                capacity = capacity;
+            }
+            receive fn get_cap() -> i64 { capacity }
+        }
+
+        supervisor App(config: AppConfig) {
+            strategy: one_for_one;
+            child cache: Cache(bogus: config.size)
+        }
+        ",
+    );
+
+    let invalid_matches: Vec<_> = pipeline
+        .diagnostics
+        .iter()
+        .filter(|diag| {
+            matches!(
+                &diag.kind,
+                MirDiagnosticKind::InvalidActorSpawnArgument { actor, argument, .. }
+                    if actor == "Cache" && argument == "bogus"
+            )
+        })
+        .collect();
+    assert_eq!(
+        invalid_matches.len(),
+        1,
+        "an unknown field name on a config-backed supervisor child must report exactly \
+         one InvalidActorSpawnArgument — the config-init skip previously bypassed all \
+         field-name validation for such children; diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+    assert!(
+        !pipeline
+            .diagnostics
+            .iter()
+            .any(|diag| matches!(&diag.kind, MirDiagnosticKind::NotYetImplemented { .. })),
+        "an unknown field name is a fully-understood user error and must never surface as \
+         NotYetImplemented; diagnostics: {:#?}",
         pipeline.diagnostics
     );
 }

--- a/hew-mir/tests/actor/supervisor_lowering.rs
+++ b/hew-mir/tests/actor/supervisor_lowering.rs
@@ -820,6 +820,13 @@ fn supervisor_child_missing_required_field_reports_missing_actor_spawn_argument(
 /// even ran on a config-backed child to catch it either. This is the
 /// fail-open regression the S4 delete introduced for config children
 /// specifically.
+///
+/// An unknown arg name must report EXACTLY ONE diagnostic total — not the
+/// `InvalidActorSpawnArgument` plus a cascaded `MissingActorSpawnArgument` for
+/// the field the bad name was presumably meant to supply. Name validation
+/// runs before missing-field planning and skips that planning entirely once
+/// an invalid name is found, so `capacity` never gets flagged as missing
+/// alongside `bogus` being flagged as invalid.
 #[test]
 fn supervisor_config_child_unknown_field_reports_invalid_actor_spawn_argument() {
     let pipeline = lower_module_from_source(
@@ -841,23 +848,36 @@ fn supervisor_config_child_unknown_field_reports_invalid_actor_spawn_argument() 
         ",
     );
 
-    let invalid_matches: Vec<_> = pipeline
+    let relevant_matches: Vec<_> = pipeline
         .diagnostics
         .iter()
         .filter(|diag| {
             matches!(
                 &diag.kind,
-                MirDiagnosticKind::InvalidActorSpawnArgument { actor, argument, .. }
-                    if actor == "Cache" && argument == "bogus"
+                MirDiagnosticKind::InvalidActorSpawnArgument { actor, .. }
+                    if actor == "Cache"
+            ) || matches!(
+                &diag.kind,
+                MirDiagnosticKind::MissingActorSpawnArgument { actor, .. }
+                    if actor == "Cache"
             )
         })
         .collect();
     assert_eq!(
-        invalid_matches.len(),
+        relevant_matches.len(),
         1,
         "an unknown field name on a config-backed supervisor child must report exactly \
-         one InvalidActorSpawnArgument — the config-init skip previously bypassed all \
-         field-name validation for such children; diagnostics: {:#?}",
+         one diagnostic total — InvalidActorSpawnArgument for the bad name, and NO \
+         cascaded MissingActorSpawnArgument for the field it was meant to supply; \
+         diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+    assert!(
+        matches!(
+            &relevant_matches[0].kind,
+            MirDiagnosticKind::InvalidActorSpawnArgument { argument, .. } if argument == "bogus"
+        ),
+        "the one diagnostic must be InvalidActorSpawnArgument for `bogus`; diagnostics: {:#?}",
         pipeline.diagnostics
     );
     assert!(
@@ -867,6 +887,64 @@ fn supervisor_config_child_unknown_field_reports_invalid_actor_spawn_argument() 
             .any(|diag| matches!(&diag.kind, MirDiagnosticKind::NotYetImplemented { .. })),
         "an unknown field name is a fully-understood user error and must never surface as \
          NotYetImplemented; diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+}
+
+/// A config-backed child that supplies one required field with a VALID name
+/// but omits another required field entirely must still report
+/// `MissingActorSpawnArgument` for the omitted field — name validation must
+/// not blanket-suppress genuine missing-field diagnostics for config
+/// children, only the cascade from an actually-invalid name.
+#[test]
+fn supervisor_config_child_valid_arg_missing_other_field_reports_missing_actor_spawn_argument() {
+    let pipeline = lower_module_from_source(
+        r"
+        record AppConfig { size: i64 }
+
+        actor Cache {
+            var capacity: i64;
+            var ttl: i64;
+            init(capacity: i64, ttl: i64) {
+                capacity = capacity;
+                ttl = ttl;
+            }
+            receive fn get_cap() -> i64 { capacity }
+        }
+
+        supervisor App(config: AppConfig) {
+            strategy: one_for_one;
+            child cache: Cache(capacity: config.size)
+        }
+        ",
+    );
+
+    let missing_matches: Vec<_> = pipeline
+        .diagnostics
+        .iter()
+        .filter(|diag| {
+            matches!(
+                &diag.kind,
+                MirDiagnosticKind::MissingActorSpawnArgument { actor, field, .. }
+                    if actor == "Cache" && field == "ttl"
+            )
+        })
+        .collect();
+    assert_eq!(
+        missing_matches.len(),
+        1,
+        "a config-backed child supplying `capacity` with a valid name but omitting `ttl` \
+         must still report exactly one MissingActorSpawnArgument for `ttl`; \
+         diagnostics: {:#?}",
+        pipeline.diagnostics
+    );
+    assert!(
+        !pipeline.diagnostics.iter().any(|diag| matches!(
+            &diag.kind,
+            MirDiagnosticKind::InvalidActorSpawnArgument { .. }
+        )),
+        "the supplied `capacity` name is valid; no InvalidActorSpawnArgument should fire; \
+         diagnostics: {:#?}",
         pipeline.diagnostics
     );
 }

--- a/hew-parser/src/ast.rs
+++ b/hew-parser/src/ast.rs
@@ -1409,6 +1409,13 @@ pub struct ChildSpec {
     /// brutal_kill | infinity`.  `None` means the supervisor default applies.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shutdown: Option<ShutdownDirective>,
+    /// Byte span of the whole child declaration, from the `child`/`pool`
+    /// keyword through the clause's terminating `;`/`,`. HIR lowering mints a
+    /// real `SiteId` registered against this span so MIR diagnostics that have
+    /// no specific argument expression to point at (a missing required field)
+    /// still carry a caret at the child declaration rather than a sentinel.
+    #[serde(default)]
+    pub span: Span,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/hew-parser/src/parser/actor_machine_supervisor.rs
+++ b/hew-parser/src/parser/actor_machine_supervisor.rs
@@ -1181,6 +1181,7 @@ impl Parser<'_> {
                     }
                 }
                 Some(Token::Child | Token::Pool) => {
+                    let child_start = self.peek_span().start;
                     let is_pool = matches!(self.peek(), Some(Token::Pool));
                     self.advance();
                     let child_name = self.expect_ident()?;
@@ -1400,6 +1401,7 @@ impl Parser<'_> {
                         wired_to,
                         is_pool,
                         shutdown,
+                        span: child_start..self.last_token_end,
                     });
                 }
                 _ => {


### PR DESCRIPTION
## Summary

Missing fields on a direct actor `spawn` or a supervisor child declaration now
surface as a stable, actionable diagnostic instead of an internal NYI failure.
Unknown child argument names are validated once, up front, so they no longer
also trigger a duplicate missing-field diagnostic. Supervisor child
declarations register their own source site during HIR/MIR lowering, so
diagnostics for a child now carry that child's span instead of borrowing the
supervisor's.

## Verification

- `make ci-preflight`: 14/14 checks pass
- `cargo test -p hew-mir --test actor`: pass, extended coverage for missing
  fields, unknown-field dedup, and child-site attribution
- `cargo test -p hew-hir`: pass, new supervisor child-site verification checks
- `cargo test -p hew-cli --test supervisor_init_args_e2e`: pass, new end-to-end
  coverage for supervisor spawn diagnostics
- Six checked-MIR goldens regenerated; diffs are pure `SiteId` renumbering
  from the new child-site registration, no semantic change

## Out of scope

- Broader auditing of remaining NYI diagnostics elsewhere in the compiler
- Any codegen changes; this is a diagnostics- and lowering-only fix
