### PR TITLE
docs(cli): correct `hew build -g` Windows debug-info help text (#2235)

### DIFF
--- a/hew-cli/src/args.rs
+++ b/hew-cli/src/args.rs
@@ -441,11 +441,14 @@ pub struct BuildArgs {
     /// Build with debug info (no optimization, no stripping).
     ///
     /// Emits DWARF debug info into the native object. gdb and lldb read this
-    /// faithfully on Linux (ELF) and macOS (Mach-O). On Windows the output is
-    /// PE/COFF with embedded DWARF; Windows-native debuggers (and lldb-on-
-    /// Windows) expect CodeView/PDB instead, so DWARF-in-PE is not fully read
-    /// there. Windows-native debuggability is a tracked follow-up:
-    /// <https://github.com/hew-lang/hew/issues/2117>
+    /// faithfully on Linux (ELF) and macOS (Mach-O). On `windows-msvc` the
+    /// output is COFF with `CodeView` plus a sidecar `.pdb`, so MSVC-toolchain
+    /// debuggers (and lldb-on-Windows) read it natively (added in the now-
+    /// closed #2117: <https://github.com/hew-lang/hew/issues/2117>). On
+    /// `windows-gnu` the object is still PE/COFF with embedded DWARF, which
+    /// MSVC-native debuggers do not fully read; remaining Windows debug-info
+    /// polish is tracked in the #2117 follow-up:
+    /// <https://github.com/hew-lang/hew/issues/2235>
     #[arg(long, short = 'g')]
     pub debug: bool,
     /// LLVM middle-end optimization level: `0` (default, no optimization) or


### PR DESCRIPTION
Part (c) of #2235 (CodeView/PDB follow-ups from #2117).

## Problem

The `-g` / `--debug` help text on `hew build` still describes Windows debug
output as *PE/COFF with embedded DWARF* and cites #2117 as an open follow-up.
That is stale: #2117 (merged as #2230) added CodeView + a sidecar PDB for
`windows-msvc`. The codegen path now sets the LLVM `"CodeView"` module flag on
`windows-msvc` `-g` builds (`hew-codegen-rs/src/llvm.rs:40559`, gated
Windows-MSVC-only), so MSVC-toolchain debuggers read those builds natively;
only `windows-gnu` still emits DWARF-in-PE.

## Change

Docs-only edit to the `BuildArgs::debug` doc-comment in `hew-cli/src/args.rs`:

- `windows-msvc` → COFF + CodeView + sidecar `.pdb`, read natively by
  MSVC-toolchain debuggers (and lldb-on-Windows), noting #2117 is now closed.
- `windows-gnu` → still PE/COFF with embedded DWARF (unchanged behaviour).
- Points the remaining-Windows-polish reference at the open #2235 follow-up
  instead of the now-closed #2117.

No behavioural change; this only corrects user-facing `--help` text.

Scope note: parts (a) (CodeView e2e CI test) and (b) (`needs_pdb_debug`
predicate alignment) of #2235 are separate, non-docs work and are **not**
touched here.

## Verification (Linux)

- `cargo build -p hew-cli` — clean
- `cargo fmt -p hew-cli -- --check` — clean
- `cargo clippy -p hew-cli -- -D warnings` — clean
- `hew build --help` renders the corrected text
