### PR TITLE
fix(mir): preserve ownership when moving projected payloads

### DIFF
--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -118,6 +118,7 @@ pub(crate) fn hir_diagnostic_user_message(diagnostic: &hew_hir::HirDiagnostic) -
 pub(crate) fn mir_diagnostic_prefix(kind: &hew_mir::MirDiagnosticKind) -> &'static str {
     match kind {
         hew_mir::MirDiagnosticKind::UseAfterConsume { .. }
+        | hew_mir::MirDiagnosticKind::ProjectedPayloadMoveFromReadablePlace { .. }
         | hew_mir::MirDiagnosticKind::InitialisedBeforeUse { .. }
         | hew_mir::MirDiagnosticKind::DecisionMapTotal { .. }
         | hew_mir::MirDiagnosticKind::MustConsume { .. }
@@ -545,6 +546,9 @@ pub(crate) fn build_module_source_map(program: &hew_parser::ast::Program) -> Mod
 fn mir_kind_name(kind: &hew_mir::MirDiagnosticKind) -> &'static str {
     match kind {
         hew_mir::MirDiagnosticKind::UseAfterConsume { .. } => "UseAfterConsume",
+        hew_mir::MirDiagnosticKind::ProjectedPayloadMoveFromReadablePlace { .. } => {
+            "ProjectedPayloadMoveFromReadablePlace"
+        }
         hew_mir::MirDiagnosticKind::InitialisedBeforeUse { .. } => "InitialisedBeforeUse",
         hew_mir::MirDiagnosticKind::DecisionMapTotal { .. } => "DecisionMapTotal",
         hew_mir::MirDiagnosticKind::MustConsume { .. } => "MustConsume",
@@ -630,6 +634,9 @@ fn mir_place_label(place: &hew_mir::Place) -> String {
 fn mir_primary_site(kind: &hew_mir::MirDiagnosticKind) -> Option<hew_hir::SiteId> {
     match kind {
         hew_mir::MirDiagnosticKind::UseAfterConsume { used_at, .. } => Some(*used_at),
+        hew_mir::MirDiagnosticKind::ProjectedPayloadMoveFromReadablePlace { site, .. } => {
+            Some(*site)
+        }
         hew_mir::MirDiagnosticKind::InitialisedBeforeUse { use_site, .. } => Some(*use_site),
         hew_mir::MirDiagnosticKind::DecisionMapTotal { offending_sites } => {
             offending_sites.first().copied()
@@ -672,6 +679,23 @@ fn mir_diagnostic_message(diagnostic: &hew_mir::MirDiagnostic) -> String {
     let message = match &diagnostic.kind {
         hew_mir::MirDiagnosticKind::UseAfterConsume { name, .. } => {
             format!("binding `{name}` is used after it was consumed")
+        }
+        hew_mir::MirDiagnosticKind::ProjectedPayloadMoveFromReadablePlace { name, reason, .. } => {
+            let source = match reason {
+                hew_mir::ProjectedPayloadRejectReason::ReadablePlace => {
+                    "a `match` on a re-readable place"
+                }
+                hew_mir::ProjectedPayloadRejectReason::CapturedBinding => {
+                    "a `match` on a closure-captured binding"
+                }
+                hew_mir::ProjectedPayloadRejectReason::NestedDestructure => {
+                    "a nested `match` pattern"
+                }
+                hew_mir::ProjectedPayloadRejectReason::GuardedConsume => {
+                    "a `match`-arm guard that can fall through"
+                }
+            };
+            format!("cannot move the heap-owning payload `{name}` out of {source}")
         }
         hew_mir::MirDiagnosticKind::InitialisedBeforeUse { name, .. } => {
             format!("binding `{name}` may be read before it is initialized")
@@ -860,6 +884,12 @@ fn mir_context_notes(diagnostic: &hew_mir::MirDiagnostic) -> Vec<String> {
             notes.push(format!("binding id: {binding}"));
             notes.push(format!("consumed at site: {consumed_at}"));
             notes.push(format!("used at site: {used_at}"));
+        }
+        hew_mir::MirDiagnosticKind::ProjectedPayloadMoveFromReadablePlace {
+            binding, site, ..
+        } => {
+            notes.push(format!("binding id: {binding}"));
+            notes.push(format!("moved at site: {site}"));
         }
         hew_mir::MirDiagnosticKind::InitialisedBeforeUse {
             binding, use_site, ..

--- a/hew-cli/tests/match_payload_reassign_uaf_oracle.rs
+++ b/hew-cli/tests/match_payload_reassign_uaf_oracle.rs
@@ -357,3 +357,736 @@ fn fresh_scrutinee_move_reassign_flat_leak_slope() {
 fn borrow_only_projection_keeps_scrutinee_live() {
     assert_scribbled_run_exit("borrow_only", &borrow_only_loop_source(), 15);
 }
+
+// ── #2523 F1: re-readable *place* scrutinees ────────────────────────────────
+//
+// A projected heap payload moved out of a re-readable PLACE scrutinee
+// (`match h.b`, `match pair.0`, `match o.inner.b`, `match self.field`) is a
+// silent same-root-cause use-after-free: the match COPIES the place into a
+// temp, so nulling the temp cannot reach the origin field's storage — the
+// moved-from field keeps a dangling pointer the new owner later frees. Actual
+// physical neutralization of a copied place scrutinee is not soundly
+// expressible, so the move-out is REJECTED fail-closed before codegen. These
+// oracles pin the rejection (and prove the sound sibling paths are untouched).
+
+/// A record-FIELD place scrutinee (`match h.b`) matched in a loop, projected
+/// payload moved into `w`, `w` reassigned. Pre-fix: compiles clean and
+/// segfaults on the loop re-read. MUST reject at compile time.
+fn field_place_reread_loop_source() -> String {
+    format!(
+        "enum Box {{\n\
+         \x20   Full(Vec<i64>);\n\
+         \x20   Empty;\n\
+         }}\n\
+         record Holder {{ b: Box, }}\n\
+         \n\
+         fn main() {{\n\
+         \x20   let h = Holder {{ b: Box::Full(seed()) }};\n\
+         \x20   var i = 0;\n\
+         \x20   var sum = 0;\n\
+         \x20   while i < 5 {{\n\
+         \x20       match h.b {{\n\
+         \x20           Box::Full(v) => {{ sum = sum + v.len(); var w = v; w = seed(); }}\n\
+         \x20           Box::Empty => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   println(sum);\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// A record-FIELD place scrutinee move-out with NO re-read (single match). The
+/// temp-neutralize cannot reach `h.b`, so it leaks / risks a double-free at
+/// `h`'s drop. Uniformly rejected fail-closed (a leak is not an acceptable
+/// end state for a heap ownership transfer).
+fn field_place_no_reread_source() -> String {
+    format!(
+        "enum Box {{\n\
+         \x20   Full(Vec<i64>);\n\
+         \x20   Empty;\n\
+         }}\n\
+         record Holder {{ b: Box, }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let h = Holder {{ b: Box::Full(seed()) }};\n\
+         \x20   var out = 0;\n\
+         \x20   match h.b {{\n\
+         \x20       Box::Full(v) => {{ out = v.len(); var w = v; w = seed(); out = out + w.len(); }}\n\
+         \x20       Box::Empty => {{}}\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// A TUPLE-index place scrutinee (`match pair.0`) — same code path as a record
+/// field. MUST reject.
+fn tuple_place_reread_loop_source() -> String {
+    format!(
+        "enum Box {{\n\
+         \x20   Full(Vec<i64>);\n\
+         \x20   Empty;\n\
+         }}\n\
+         \n\
+         fn main() {{\n\
+         \x20   let pair = (Box::Full(seed()), 0);\n\
+         \x20   var i = 0;\n\
+         \x20   var sum = 0;\n\
+         \x20   while i < 5 {{\n\
+         \x20       match pair.0 {{\n\
+         \x20           Box::Full(v) => {{ sum = sum + v.len(); var w = v; w = seed(); }}\n\
+         \x20           Box::Empty => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   println(sum);\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// A NESTED record-field place scrutinee (`match o.inner.b`) — the recursive
+/// place-root predicate must see through the projection chain. MUST reject.
+fn nested_field_place_reread_loop_source() -> String {
+    format!(
+        "enum Box {{\n\
+         \x20   Full(Vec<i64>);\n\
+         \x20   Empty;\n\
+         }}\n\
+         record Inner {{ b: Box, }}\n\
+         record Outer {{ inner: Inner, }}\n\
+         \n\
+         fn main() {{\n\
+         \x20   let o = Outer {{ inner: Inner {{ b: Box::Full(seed()) }} }};\n\
+         \x20   var i = 0;\n\
+         \x20   var sum = 0;\n\
+         \x20   while i < 5 {{\n\
+         \x20       match o.inner.b {{\n\
+         \x20           Box::Full(v) => {{ sum = sum + v.len(); var w = v; w = seed(); }}\n\
+         \x20           Box::Empty => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   println(sum);\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// A read-only borrow of a record-FIELD place scrutinee must stay valid — the
+/// rejection fires only on a move-out (`Consume`), never on a borrow. The loop
+/// re-matches `h.b` every iteration and totals `3 * 5 = 15`.
+fn field_place_borrow_only_source() -> String {
+    format!(
+        "enum Box {{\n\
+         \x20   Full(Vec<i64>);\n\
+         \x20   Empty;\n\
+         }}\n\
+         record Holder {{ b: Box, }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let h = Holder {{ b: Box::Full(seed()) }};\n\
+         \x20   var i = 0;\n\
+         \x20   var sum = 0;\n\
+         \x20   while i < 5 {{\n\
+         \x20       match h.b {{\n\
+         \x20           Box::Full(v) => {{ sum = sum + v.len(); }}\n\
+         \x20           Box::Empty => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   sum\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// An EPHEMERAL (call) scrutinee move-out (`match mk()`) is a fresh sole-owner
+/// temp with no re-readable origin — it stays soundly neutralizable and must
+/// keep compiling and free exactly once. Guards against over-rejecting the
+/// ephemeral path when tightening the place path. Returns `3 + 3 = 6`.
+fn call_scrutinee_move_reassign_source() -> String {
+    format!(
+        "enum Box {{\n\
+         \x20   Full(Vec<i64>);\n\
+         \x20   Empty;\n\
+         }}\n\
+         fn mk() -> Box {{ Box::Full(seed()) }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var out = 0;\n\
+         \x20   match mk() {{\n\
+         \x20       Box::Full(v) => {{ out = v.len(); var w = v; w = seed(); out = out + w.len(); }}\n\
+         \x20       Box::Empty => {{}}\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// (F1 · use-after-free) A record-field place scrutinee move-out in a loop must
+/// be rejected at compile time — not left to segfault on the re-read.
+#[test]
+fn field_place_move_out_reread_is_rejected() {
+    assert_compile_fails(
+        "field_place_reread",
+        &field_place_reread_loop_source(),
+        "cannot move the heap-owning payload `v` out of a `match` on a re-readable place",
+    );
+}
+
+/// (F1) A single-match field-place move-out (no re-read) is also rejected —
+/// the temp-neutralize cannot reach `h.b`, so the transfer is unsound.
+#[test]
+fn field_place_move_out_no_reread_is_rejected() {
+    assert_compile_fails(
+        "field_place_no_reread",
+        &field_place_no_reread_source(),
+        "cannot move the heap-owning payload `v` out of a `match` on a re-readable place",
+    );
+}
+
+/// (F1) A tuple-index place scrutinee move-out is rejected (same code path).
+#[test]
+fn tuple_place_move_out_is_rejected() {
+    assert_compile_fails(
+        "tuple_place_reread",
+        &tuple_place_reread_loop_source(),
+        "cannot move the heap-owning payload `v` out of a `match` on a re-readable place",
+    );
+}
+
+/// (F1) A nested record-field place scrutinee move-out is rejected — the
+/// place-root predicate sees through the projection chain.
+#[test]
+fn nested_field_place_move_out_is_rejected() {
+    assert_compile_fails(
+        "nested_field_place",
+        &nested_field_place_reread_loop_source(),
+        "cannot move the heap-owning payload `v` out of a `match` on a re-readable place",
+    );
+}
+
+/// (F1 · over-fire guard) A read-only borrow of a field-place scrutinee stays
+/// valid — the rejection fires only on a move-out, never a borrow.
+#[test]
+fn field_place_borrow_only_keeps_scrutinee_live() {
+    assert_scribbled_run_exit("field_place_borrow", &field_place_borrow_only_source(), 15);
+}
+
+/// (F1 · over-fire guard) An ephemeral (call) scrutinee move-out is NOT a
+/// re-readable place — it stays soundly neutralizable, compiles, and frees
+/// exactly once under the poisoned-allocator triple.
+#[test]
+fn call_scrutinee_move_reassign_single_free() {
+    assert_scribbled_run_exit("call_scrutinee", &call_scrutinee_move_reassign_source(), 6);
+}
+
+// ── #2523 F1b: default-deny — wrapper-hidden / non-enumerated place scrutinees ─
+//
+// The F1 fix classified by an allowlist of REJECT shapes and defaulted every
+// other shape to the sound-only temp-neutralize — a fail-OPEN direction. A
+// place projection hidden behind a `Block` (`match { h.b }`) or `If`
+// (`match if c { h.b } else { h.b }`) wrapper is not one of the enumerated
+// place shapes, so it slipped through to the temp-neutralize and double-freed
+// deterministically (5/5), identical mechanism to the direct `match h.b`. The
+// classifier is now fail-CLOSED: only a bare owning binding or a *proven*
+// ephemeral producer (call / constructor / literal / await) takes the
+// neutralize path; every other shape — wrappers and any un-enumerated or future
+// HIR shape — is REJECTED before codegen. These oracles pin that direction so a
+// wrapper-hidden alias can never again reach the unsound neutralize.
+
+/// F1b primary: a record-FIELD place hidden behind a `Block` wrapper
+/// (`match { h.b }`). Pre-F1b: compiled clean and double-freed 5/5. MUST reject.
+fn block_wrapped_field_place_source() -> String {
+    format!(
+        "enum Box {{\n\
+         \x20   Full(Vec<i64>);\n\
+         \x20   Empty;\n\
+         }}\n\
+         record Holder {{ b: Box, }}\n\
+         \n\
+         fn main() {{\n\
+         \x20   let h = Holder {{ b: Box::Full(seed()) }};\n\
+         \x20   var i = 0;\n\
+         \x20   var sum = 0;\n\
+         \x20   while i < 5 {{\n\
+         \x20       match {{ h.b }} {{\n\
+         \x20           Box::Full(v) => {{ sum = sum + v.len(); var w = v; w = seed(); }}\n\
+         \x20           Box::Empty => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   println(sum);\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// F1b, second complex shape: a record-FIELD place behind an `If` wrapper
+/// (`match if c { h.b } else { h.b }`). Same alias-carrying tail, a different
+/// non-enumerated wrapper. MUST reject (fail-closed default).
+fn if_wrapped_field_place_source() -> String {
+    format!(
+        "enum Box {{\n\
+         \x20   Full(Vec<i64>);\n\
+         \x20   Empty;\n\
+         }}\n\
+         record Holder {{ b: Box, }}\n\
+         \n\
+         fn main() {{\n\
+         \x20   let h = Holder {{ b: Box::Full(seed()) }};\n\
+         \x20   var i = 0;\n\
+         \x20   var sum = 0;\n\
+         \x20   while i < 5 {{\n\
+         \x20       match if i < 2 {{ h.b }} else {{ h.b }} {{\n\
+         \x20           Box::Full(v) => {{ sum = sum + v.len(); var w = v; w = seed(); }}\n\
+         \x20           Box::Empty => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   println(sum);\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// (F1b) A block-wrapped field-place scrutinee move-out is rejected — the
+/// fail-closed default catches the wrapper the syntactic allowlist missed.
+#[test]
+fn block_wrapped_place_move_out_is_rejected() {
+    assert_compile_fails(
+        "block_wrapped_place",
+        &block_wrapped_field_place_source(),
+        "cannot move the heap-owning payload `v` out of a `match` on a re-readable place",
+    );
+}
+
+/// (F1b) An if-wrapped field-place scrutinee move-out is rejected — a second
+/// non-enumerated wrapper shape, proving the default-deny is not `Block`-only.
+#[test]
+fn if_wrapped_place_move_out_is_rejected() {
+    assert_compile_fails(
+        "if_wrapped_place",
+        &if_wrapped_field_place_source(),
+        "cannot move the heap-owning payload `v` out of a `match` on a re-readable place",
+    );
+}
+
+// ── #2523 F2: exhaustive projection-ownership correction (nested / capture /
+//     two independent fields) ─────────────────────────────────────────────────
+//
+// Three defects found by the codegen + cross reviews, one root cause (a
+// projected heap payload moved out of a scrutinee whose real storage the
+// temp-neutralize cannot reach, or a false use-after-consume on a valid
+// second-field move):
+//
+//   1. NESTED binders (`Outer::Wrap(Inner::Full(v))`) are bound from a
+//      TRANSIENT copy the predicate phase loads, not the outer value's real
+//      nested slot; neutralizing the transient cannot reach it, so a heap
+//      move-out double-frees / leaks. Now REJECTED fail-closed (the outer
+//      value's storage is not expressible as a single `Place::MachineVariant`).
+//      The enum and machine nested payloads share the identical
+//      `nested_binding_jobs` / `Place::MachineVariant` seam, so this enum
+//      coverage pins both.
+//   2. A closure-CAPTURED binding (`match b` inside `|| { … }` that captures
+//      `b`) is read from the closure environment by BYTE-COPY
+//      (`ClosureEnvFieldLoad`), NOT moved into the temp; the captured copy
+//      survives the move and double-frees when the env drops. Now REJECTED.
+//   3. TWO independent heap fields moved in one arm
+//      (`Both(x, y) => var wx = x; var wy = y;`) must both single-free — the
+//      per-field partial-projection consume-mark keeps the aggregate re-read
+//      forbidding without a false use-after-consume on the second move, and the
+//      neutralized-transfer edges keep the two owners in separate move
+//      components so neither scope-exit drop is wrongly stripped.
+
+/// (F2 item 1) A NESTED enum payload move-out from an ephemeral scrutinee
+/// (`match mk()`). The nested binder aliases a transient copy; the move-out is
+/// rejected fail-closed. Pre-fix: compiled and leaked / double-freed.
+fn nested_enum_move_out_source() -> String {
+    format!(
+        "enum Inner {{ Full(Vec<i64>); Hollow; }}\n\
+         enum Outer {{ Wrap(Inner); Bare; }}\n\
+         fn mk() -> Outer {{ Outer::Wrap(Inner::Full(seed())) }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var total = 0;\n\
+         \x20   match mk() {{\n\
+         \x20       Outer::Wrap(Inner::Full(v)) => {{ var w = v; total = w.len(); w = seed(); total = total + w.len(); }}\n\
+         \x20       Outer::Wrap(Inner::Hollow) => {{}}\n\
+         \x20       Outer::Bare => {{}}\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// (F2 item 1) The same nested move-out from an owned BINDING scrutinee
+/// (`match b`). Rejected fail-closed for the same reason: the nested slot is
+/// reachable only through a transient copy the neutralize cannot null.
+fn nested_enum_move_out_binding_source() -> String {
+    format!(
+        "enum Inner {{ Full(Vec<i64>); Hollow; }}\n\
+         enum Outer {{ Wrap(Inner); Bare; }}\n\
+         fn main() -> i64 {{\n\
+         \x20   let b = Outer::Wrap(Inner::Full(seed()));\n\
+         \x20   var total = 0;\n\
+         \x20   match b {{\n\
+         \x20       Outer::Wrap(Inner::Full(v)) => {{ var w = v; total = w.len(); w = seed(); total = total + w.len(); }}\n\
+         \x20       Outer::Wrap(Inner::Hollow) => {{}}\n\
+         \x20       Outer::Bare => {{}}\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// (F2 item 1 control) A borrow-only NESTED destructure never reaches the
+/// consume hook, so it stays valid: the loop reads the nested payload and
+/// totals correctly with no double-free.
+fn nested_enum_borrow_only_source() -> String {
+    format!(
+        "enum Inner {{ Full(Vec<i64>); Hollow; }}\n\
+         enum Outer {{ Wrap(Inner); Bare; }}\n\
+         fn main() -> i64 {{\n\
+         \x20   let b = Outer::Wrap(Inner::Full(seed()));\n\
+         \x20   var total = 0;\n\
+         \x20   match b {{\n\
+         \x20       Outer::Wrap(Inner::Full(v)) => {{ total = v.len(); }}\n\
+         \x20       Outer::Wrap(Inner::Hollow) => {{}}\n\
+         \x20       Outer::Bare => {{}}\n\
+         \x20   }}\n\
+         \x20   total\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// (F2 item 2) A closure-CAPTURED binding matched inside the closure, with a
+/// projected-payload move-out. The binding is read from the closure env by
+/// byte-copy, so the move-out is rejected fail-closed. Pre-fix: segfault /
+/// double-free 3/3 under the poisoned allocator.
+fn captured_binding_move_out_source() -> String {
+    format!(
+        "enum Box {{ Full(Vec<i64>); Empty; }}\n\
+         fn main() -> i64 {{\n\
+         \x20   let b = Box::Full(seed());\n\
+         \x20   var total = 0;\n\
+         \x20   let f = || {{\n\
+         \x20       match b {{\n\
+         \x20           Box::Full(v) => {{ var w = v; total = w.len(); w = seed(); }}\n\
+         \x20           Box::Empty => {{}}\n\
+         \x20       }}\n\
+         \x20   }};\n\
+         \x20   f();\n\
+         \x20   total\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// (F2 item 2 control) A closure-captured binding matched borrow-ONLY inside
+/// the closure never hits the consume hook, so it stays valid: it compiles and
+/// runs clean (the env-copy is read, never moved out).
+fn captured_binding_borrow_only_source() -> String {
+    format!(
+        "enum Box {{ Full(Vec<i64>); Empty; }}\n\
+         fn main() -> i64 {{\n\
+         \x20   let b = Box::Full(seed());\n\
+         \x20   let f = || -> i64 {{\n\
+         \x20       match b {{\n\
+         \x20           Box::Full(v) => v.len(),\n\
+         \x20           Box::Empty => 0,\n\
+         \x20       }}\n\
+         \x20   }};\n\
+         \x20   f()\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// (F2 item 3) TWO independent heap payload fields moved out of one arm, then
+/// both reassigned. Each field single-frees: the moved payload is freed once at
+/// its reassignment, the fresh owner once at scope exit. No false
+/// use-after-consume on the second move; no leak. Returns `3 + 3 = 6`.
+fn two_field_move_out_source() -> String {
+    format!(
+        "enum Pair {{ Both(Vec<i64>, Vec<i64>); Neither; }}\n\
+         fn mk() -> Pair {{ Pair::Both(seed(), seed()) }}\n\
+         fn main() -> i64 {{\n\
+         \x20   var out = 0;\n\
+         \x20   match mk() {{\n\
+         \x20       Pair::Both(x, y) => {{\n\
+         \x20           var wx = x; var wy = y;\n\
+         \x20           wx = seed(); wy = seed();\n\
+         \x20           out = wx.len() + wy.len();\n\
+         \x20       }}\n\
+         \x20       Pair::Neither => {{}}\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// (F2 item 3) The two-field move from an owned BINDING scrutinee — the shape
+/// the F1b consume-mark regressed into a false `E_MIR_CHECK: b is used after it
+/// was consumed` on the SECOND field. Must compile and single-free. Returns 6.
+fn two_field_move_out_binding_source() -> String {
+    format!(
+        "enum Pair {{ Both(Vec<i64>, Vec<i64>); Neither; }}\n\
+         fn main() -> i64 {{\n\
+         \x20   let b = Pair::Both(seed(), seed());\n\
+         \x20   var out = 0;\n\
+         \x20   match b {{\n\
+         \x20       Pair::Both(x, y) => {{\n\
+         \x20           var wx = x; var wy = y;\n\
+         \x20           wx = seed(); wy = seed();\n\
+         \x20           out = wx.len() + wy.len();\n\
+         \x20       }}\n\
+         \x20       Pair::Neither => {{}}\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// (F2 item 3, negative re-read) After BOTH fields are moved out, the aggregate
+/// binding must not be re-readable: a second `match b` is rejected at compile
+/// time as a use-after-move. Proves the per-field partial-projection mark still
+/// forbids re-read (the consume state is not weakened).
+fn two_field_reread_source() -> String {
+    format!(
+        "enum Pair {{ Both(Vec<i64>, Vec<i64>); Neither; }}\n\
+         fn main() -> i64 {{\n\
+         \x20   let b = Pair::Both(seed(), seed());\n\
+         \x20   var out = 0;\n\
+         \x20   match b {{\n\
+         \x20       Pair::Both(x, y) => {{ var wx = x; var wy = y; out = wx.len() + wy.len(); }}\n\
+         \x20       Pair::Neither => {{}}\n\
+         \x20   }}\n\
+         \x20   match b {{\n\
+         \x20       Pair::Both(x2, y2) => {{ out = out + x2.len() + y2.len(); }}\n\
+         \x20       Pair::Neither => {{}}\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// (F2 item 1) A nested projected-payload move-out from an ephemeral scrutinee
+/// is rejected fail-closed with the nested-pattern diagnostic.
+#[test]
+fn nested_enum_move_out_is_rejected() {
+    assert_compile_fails(
+        "nested_enum_move",
+        &nested_enum_move_out_source(),
+        "cannot move the heap-owning payload `v` out of a nested `match` pattern",
+    );
+}
+
+/// (F2 item 1) The same nested move-out from an owned binding scrutinee is also
+/// rejected — the reject is on the nested-destructure shape, not the scrutinee
+/// origin.
+#[test]
+fn nested_enum_move_out_binding_is_rejected() {
+    assert_compile_fails(
+        "nested_enum_move_binding",
+        &nested_enum_move_out_binding_source(),
+        "cannot move the heap-owning payload `v` out of a nested `match` pattern",
+    );
+}
+
+/// (F2 item 1 control) A borrow-only nested destructure stays valid and frees
+/// exactly once. Returns 3.
+#[test]
+fn nested_enum_borrow_only_is_valid() {
+    assert_scribbled_run_exit("nested_enum_borrow", &nested_enum_borrow_only_source(), 3);
+}
+
+/// (F2 item 2) A projected-payload move-out of a closure-captured binding is
+/// rejected fail-closed with the captured-binding diagnostic.
+#[test]
+fn captured_binding_move_out_is_rejected() {
+    assert_compile_fails(
+        "captured_binding_move",
+        &captured_binding_move_out_source(),
+        "cannot move the heap-owning payload `v` out of a `match` on a closure-captured binding",
+    );
+}
+
+/// (F2 item 2 control) A borrow-only match on a captured binding stays valid —
+/// no consume hook runs, so the env-copy is never moved out. Returns 3.
+#[test]
+fn captured_binding_borrow_only_is_valid() {
+    assert_scribbled_run_exit(
+        "captured_binding_borrow",
+        &captured_binding_borrow_only_source(),
+        3,
+    );
+}
+
+/// (F2 item 3) Two independent heap fields moved and reassigned in one arm
+/// single-free — no false use-after-consume, no leak. Ephemeral scrutinee.
+#[test]
+fn two_field_move_out_single_free() {
+    assert_scribbled_run_exit("two_field_move", &two_field_move_out_source(), 6);
+}
+
+/// (F2 item 3) The owned-binding two-field shape that F1b regressed into a
+/// false use-after-consume now compiles and single-frees.
+#[test]
+fn two_field_move_out_binding_single_free() {
+    assert_scribbled_run_exit(
+        "two_field_move_binding",
+        &two_field_move_out_binding_source(),
+        6,
+    );
+}
+
+/// (F2 item 3, negative re-read) The aggregate cannot be re-read after any
+/// field move — the second `match b` is a compile-time use-after-move.
+#[test]
+fn two_field_reread_is_use_after_move() {
+    assert_compile_fails(
+        "two_field_reread",
+        &two_field_reread_source(),
+        "used after it was consumed",
+    );
+}
+
+// ── F2 (guard continuation): fallthrough-capable match-arm guards ────────────
+//
+// A `match`-arm guard is evaluated BEFORE the arm is committed; a false guard
+// falls through to a later arm. If the guard CONSUMES a projected heap payload
+// (a block-expression guard containing a move, e.g. `if { var w = v; ... }`),
+// the consume neutralizes (nulls) the shared scrutinee payload slot before the
+// guard outcome is known. A false guard then falls through to a later arm that
+// re-projects the now-null slot → null-fault / abort. Because guard truth is
+// not statically known and every arm guard can fall through, projected
+// heap-payload CONSUMPTION inside any match-arm guard is rejected fail-closed,
+// regardless of the guard's (would-be) truth. A read-only borrow in the guard
+// (`v.len() > 100`) never reaches the consume hook and stays valid.
+
+/// (F2 guard) A block-expression guard that MOVES the projected payload (`var
+/// w = v`) and then falls through (guard false) to a later arm that
+/// re-destructures the same slot. The consume must be rejected at compile time
+/// as a guard-fallthrough move rather than null-fault at runtime.
+fn guarded_consume_fallthrough_source() -> String {
+    format!(
+        "enum Box {{ Full(Vec<i64>); Empty; }}\n\
+         fn main() -> i64 {{\n\
+         \x20   let b = Box::Full(seed());\n\
+         \x20   var out = 0;\n\
+         \x20   match b {{\n\
+         \x20       Box::Full(v) if {{ var w = v; w.len() > 100 }} => {{ out = 1; }}\n\
+         \x20       Box::Full(v2) => {{ out = v2.len(); }}\n\
+         \x20       Box::Empty => {{}}\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// (F2 guard) The same block-move guard with a would-be-TRUE predicate
+/// (`w.len() > 0`). The reject is on the consume-in-fallthrough-guard shape,
+/// not the guard's truth — guard truth is not statically known, so this is
+/// rejected identically.
+fn true_guarded_consume_source() -> String {
+    format!(
+        "enum Box {{ Full(Vec<i64>); Empty; }}\n\
+         fn main() -> i64 {{\n\
+         \x20   let b = Box::Full(seed());\n\
+         \x20   var out = 0;\n\
+         \x20   match b {{\n\
+         \x20       Box::Full(v) if {{ var w = v; w.len() > 0 }} => {{ out = 1; }}\n\
+         \x20       Box::Full(v2) => {{ out = v2.len(); }}\n\
+         \x20       Box::Empty => {{}}\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// (F2 guard control) A borrow-only guard (`v.len() > 100`) that evaluates
+/// false and falls through to a later arm. The borrow never reaches the
+/// consume hook, so the scrutinee payload stays live and the later arm reads it
+/// correctly. Guard false → `v2.len()` = 3.
+fn borrow_only_guard_fallthrough_source() -> String {
+    format!(
+        "enum Box {{ Full(Vec<i64>); Empty; }}\n\
+         fn main() -> i64 {{\n\
+         \x20   let b = Box::Full(seed());\n\
+         \x20   var out = 0;\n\
+         \x20   match b {{\n\
+         \x20       Box::Full(v) if v.len() > 100 => {{ out = 1; }}\n\
+         \x20       Box::Full(v2) => {{ out = v2.len(); }}\n\
+         \x20       Box::Empty => {{}}\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// (F2 guard) A projected heap-payload consumed inside a fallthrough-capable
+/// guard is rejected fail-closed — the false-guard fallthrough would otherwise
+/// re-project a neutralized (null) payload slot and abort.
+#[test]
+fn guarded_consume_fallthrough_is_rejected() {
+    assert_compile_fails(
+        "guarded_consume_fallthrough",
+        &guarded_consume_fallthrough_source(),
+        "cannot move the heap-owning payload `v` out of a `match`-arm guard that can fall through",
+    );
+}
+
+/// (F2 guard) The would-be-true guarded consume is rejected identically — the
+/// policy is on the consume-in-guard shape, not the guard's (unknown) truth.
+#[test]
+fn true_guarded_consume_is_rejected() {
+    assert_compile_fails(
+        "true_guarded_consume",
+        &true_guarded_consume_source(),
+        "cannot move the heap-owning payload `v` out of a `match`-arm guard that can fall through",
+    );
+}
+
+/// (F2 guard control) A borrow-only guard that falls through stays valid and
+/// the later arm reads the still-live payload. Returns 3.
+#[test]
+fn borrow_only_guard_fallthrough_runs_safely() {
+    assert_scribbled_run_exit(
+        "borrow_only_guard_fallthrough",
+        &borrow_only_guard_fallthrough_source(),
+        3,
+    );
+}

--- a/hew-cli/tests/match_payload_reassign_uaf_oracle.rs
+++ b/hew-cli/tests/match_payload_reassign_uaf_oracle.rs
@@ -1,0 +1,359 @@
+//! Projected-payload move-out UAF / double-free oracle (issue #2523).
+//!
+//! An enum/machine payload projected out by a `match` arm binder is a
+//! byte-copy ALIAS of the scrutinee's payload slot (`_v = move mvar.V.F`),
+//! never an independent buffer. Moving that binder into a new owner
+//! (`var w = v`) and then releasing the new owner (`w = seed()`, or the new
+//! owner's scope-exit drop) frees storage the scrutinee's own composite
+//! drop still owns — a double-free, and, if the scrutinee is re-read, a
+//! use-after-free of the freed payload.
+//!
+//! The fix has two halves, both pinned here:
+//!
+//!   * **Move-neutralization (memory safety).** At the move-out the source
+//!     payload slot is neutralized (nulled) so the scrutinee's null-tolerant
+//!     composite drop no-ops and the new owner's release is the SOLE free of
+//!     the buffer. Pinned by the poisoned-allocator runtime pins (a pre-fix
+//!     double-free aborts under `MallocScribble`) and the leak-slope guard
+//!     (the neutralize must not invert the UAF into a per-frame leak).
+//!
+//!   * **Consume agreement (fail-closed diagnostic).** Moving the projected
+//!     binder consumes the scrutinee; a later re-read (e.g. the next
+//!     iteration of the reporter's `while` loop) is rejected at compile time
+//!     as a use-after-move rather than left to null-dereference at runtime
+//!     (`hew_vec_len` is not null-tolerant). Pinned by the compile-fail
+//!     fixture.
+//!
+//! The control fixture proves the link is gated strictly on a genuine
+//! move-out: a read-only borrow (`v.len()`) of the projected payload keeps
+//! the scrutinee live and the loop still yields its total.
+
+#![cfg(unix)]
+
+mod support;
+
+use std::process::Command;
+
+use support::leak_slope::{assert_frame_slope_below_tolerance, compile_to_native};
+use support::{describe_output, hew_binary, repo_root, require_codegen};
+
+/// `Vec<i64>` producer shared by every fixture — a fresh, solely-owned heap
+/// buffer of length 3 per call.
+const SEED_FN: &str = "\
+fn seed() -> Vec<i64> {\n\
+\x20   let v: Vec<i64> = Vec::new();\n\
+\x20   v.push(1);\n\
+\x20   v.push(2);\n\
+\x20   v.push(3);\n\
+\x20   v\n\
+}\n";
+
+/// Compile a source and assert it is REJECTED with `expected` in the
+/// diagnostic stream (the fail-closed use-after-move surface).
+fn assert_compile_fails(shape_name: &str, source: &str, expected: &str) {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("payload-reassign-fail-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let hew_src = dir.path().join(format!("{shape_name}.hew"));
+    std::fs::write(&hew_src, source).expect("write hew source");
+
+    let output = Command::new(hew_binary())
+        .args([
+            "compile",
+            "--emit-dir",
+            dir.path().to_str().expect("emit-dir utf-8"),
+            hew_src.to_str().expect("hew src utf-8"),
+        ])
+        .current_dir(repo_root())
+        .output()
+        .expect("invoke hew compile");
+
+    assert!(
+        !output.status.success(),
+        "{shape_name}: expected a fail-closed use-after-move rejection, but compile \
+         succeeded — the projected-payload move-out did not consume the scrutinee:\n{}",
+        describe_output(&output)
+    );
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains(expected),
+        "{shape_name}: compile failed but did not mention `{expected}`:\n{combined}"
+    );
+}
+
+/// Compile a source and run it under the poisoned-allocator triple (no
+/// `leaks` dependency — works on any unix). Asserts a clean exit with
+/// `expected_exit`. A pre-fix double-free of the aliased payload aborts under
+/// `MallocScribble`; a use-after-free reads scribbled memory and miscomputes.
+fn assert_scribbled_run_exit(shape_name: &str, source: &str, expected_exit: i32) {
+    require_codegen();
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("payload-reassign-uaf-{shape_name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), shape_name);
+
+    let output = Command::new(&bin)
+        .env("MallocScribble", "1")
+        .env("MallocPreScribble", "1")
+        .env("MallocGuardEdges", "1")
+        .output()
+        .expect("run fixture binary");
+    assert_eq!(
+        output.status.code(),
+        Some(expected_exit),
+        "{shape_name}: expected clean exit {expected_exit} under the poisoned-allocator \
+         triple. A projected-payload move-out that does not neutralize the source slot \
+         double-frees the buffer (scrutinee composite drop + new owner release). \
+         Output:\n{}",
+        describe_output(&output)
+    );
+}
+
+// ── fixture sources ─────────────────────────────────────────────────────────
+
+/// The reporter's original shape (issue #2523): the projected payload is
+/// moved into `w`, `w` is reassigned (freeing the moved buffer), and the
+/// enum is re-matched on the next `while` iteration — a use-after-move that
+/// MUST be rejected at compile time.
+fn reread_loop_source() -> String {
+    format!(
+        "enum Box {{\n\
+         \x20   Full(Vec<i64>);\n\
+         \x20   Empty;\n\
+         }}\n\
+         \n\
+         fn main() {{\n\
+         \x20   let b = Box::Full(seed());\n\
+         \x20   var i = 0;\n\
+         \x20   var sum = 0;\n\
+         \x20   while i < 5 {{\n\
+         \x20       match b {{\n\
+         \x20           Box::Full(v) => {{\n\
+         \x20               sum = sum + v.len();\n\
+         \x20               var w = v;\n\
+         \x20               w = seed();\n\
+         \x20               sum = sum + w.len();\n\
+         \x20           }}\n\
+         \x20           Box::Empty => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   println(sum);\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// Move-out + reassign, single match, no re-read. `w = seed()` is the sole
+/// free of the moved payload buffer; the scrutinee's scope-exit composite
+/// drop must no-op on the neutralized slot. Pre-fix: double-free aborts.
+/// Returns `3 + 3 = 6`.
+fn move_reassign_no_reread_source() -> String {
+    format!(
+        "enum Box {{\n\
+         \x20   Full(Vec<i64>);\n\
+         \x20   Empty;\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let b = Box::Full(seed());\n\
+         \x20   var out = 0;\n\
+         \x20   match b {{\n\
+         \x20       Box::Full(v) => {{\n\
+         \x20           out = v.len();\n\
+         \x20           var w = v;\n\
+         \x20           w = seed();\n\
+         \x20           out = out + w.len();\n\
+         \x20       }}\n\
+         \x20       Box::Empty => {{}}\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// Move-out with NO reassign, single match, no re-read. The new owner `w`
+/// frees the moved buffer exactly once at its scope exit; the scrutinee's
+/// composite drop must no-op on the neutralized slot. Pre-fix: double-free
+/// aborts. Returns `3 + 3 = 6`.
+fn move_scope_drop_no_reread_source() -> String {
+    format!(
+        "enum Box {{\n\
+         \x20   Full(Vec<i64>);\n\
+         \x20   Empty;\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let b = Box::Full(seed());\n\
+         \x20   var out = 0;\n\
+         \x20   match b {{\n\
+         \x20       Box::Full(v) => {{\n\
+         \x20           out = v.len();\n\
+         \x20           let w = v;\n\
+         \x20           out = out + w.len();\n\
+         \x20       }}\n\
+         \x20       Box::Empty => {{}}\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// Aggregate payload: the projected binder is a `(Vec<i64>, Vec<i64>)`
+/// tuple; the neutralize must null BOTH heap leaves in the payload slot so
+/// the scrutinee's composite drop double-frees neither. Move-out, no
+/// re-read. Returns `3 + 3 + 3 = 9`.
+fn aggregate_payload_no_reread_source() -> String {
+    format!(
+        "enum Pair {{\n\
+         \x20   Both((Vec<i64>, Vec<i64>));\n\
+         \x20   Neither;\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let b = Pair::Both((seed(), seed()));\n\
+         \x20   var out = 0;\n\
+         \x20   match b {{\n\
+         \x20       Pair::Both(v) => {{\n\
+         \x20           out = v.0.len() + v.1.len();\n\
+         \x20           let w = v;\n\
+         \x20           out = out + w.0.len();\n\
+         \x20       }}\n\
+         \x20       Pair::Neither => {{}}\n\
+         \x20   }}\n\
+         \x20   out\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// Leak-slope guard: a FRESH scrutinee per iteration is projected,
+/// moved-out, and reassigned — no cross-iteration re-read, so it compiles.
+/// Every buffer is freed exactly once per frame (moved buffer by
+/// `w = seed()`, the seed buffer by `w`'s scope drop, the scrutinee slot
+/// neutralized). The neutralize must not invert the UAF into a per-frame
+/// leak — the slope stays flat.
+fn fresh_scrutinee_loop_source(frames: usize) -> String {
+    format!(
+        "enum Box {{\n\
+         \x20   Full(Vec<i64>);\n\
+         \x20   Empty;\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var i = 0;\n\
+         \x20   var acc = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let b = Box::Full(seed());\n\
+         \x20       match b {{\n\
+         \x20           Box::Full(v) => {{\n\
+         \x20               var w = v;\n\
+         \x20               w = seed();\n\
+         \x20               acc = acc + w.len();\n\
+         \x20           }}\n\
+         \x20           Box::Empty => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   acc\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+/// Control: a read-only borrow of the projected payload (`v.len()`) with NO
+/// move-out. The scrutinee stays live, the loop re-matches legitimately, and
+/// the total is exact. Guards against the consume-link over-firing on a
+/// borrow (which would spuriously reject this idiomatic code). Returns
+/// `3 * 5 = 15`.
+fn borrow_only_loop_source() -> String {
+    format!(
+        "enum Box {{\n\
+         \x20   Full(Vec<i64>);\n\
+         \x20   Empty;\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let b = Box::Full(seed());\n\
+         \x20   var i = 0;\n\
+         \x20   var sum = 0;\n\
+         \x20   while i < 5 {{\n\
+         \x20       match b {{\n\
+         \x20           Box::Full(v) => {{\n\
+         \x20               sum = sum + v.len();\n\
+         \x20           }}\n\
+         \x20           Box::Empty => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   sum\n\
+         }}\n\
+         \n\
+         {SEED_FN}"
+    )
+}
+
+// ── oracles ─────────────────────────────────────────────────────────────────
+
+/// (Consume agreement) The reporter's re-reading loop must be rejected at
+/// compile time as a use-after-move, not left to null-dereference at runtime.
+#[test]
+fn reread_after_payload_move_is_use_after_move() {
+    assert_compile_fails(
+        "reread_loop",
+        &reread_loop_source(),
+        "used after it was consumed",
+    );
+}
+
+/// (Memory safety) Move-out + reassign, no re-read: the moved buffer is freed
+/// exactly once; the scrutinee slot is neutralized. No double-free.
+#[test]
+fn move_reassign_no_reread_single_free() {
+    assert_scribbled_run_exit("move_reassign", &move_reassign_no_reread_source(), 6);
+}
+
+/// (Memory safety) Move-out with no reassign, no re-read: the new owner's
+/// scope-exit drop is the sole free; the scrutinee slot is neutralized.
+#[test]
+fn move_scope_drop_no_reread_single_free() {
+    assert_scribbled_run_exit("move_scope_drop", &move_scope_drop_no_reread_source(), 6);
+}
+
+/// (Memory safety, aggregate) An aggregate-tuple payload move-out neutralizes
+/// BOTH heap leaves — the scrutinee composite drop double-frees neither.
+#[test]
+fn aggregate_payload_move_out_single_free() {
+    assert_scribbled_run_exit(
+        "aggregate_payload",
+        &aggregate_payload_no_reread_source(),
+        9,
+    );
+}
+
+/// (Leak-slope) The neutralize must not invert the UAF into a per-frame leak.
+#[test]
+fn fresh_scrutinee_move_reassign_flat_leak_slope() {
+    assert_frame_slope_below_tolerance("payload_reassign_fresh", fresh_scrutinee_loop_source);
+}
+
+/// (Over-fire guard) A read-only borrow of the projected payload keeps the
+/// scrutinee live — the loop still re-matches and totals correctly.
+#[test]
+fn borrow_only_projection_keeps_scrutinee_live() {
+    assert_scribbled_run_exit("borrow_only", &borrow_only_loop_source(), 15);
+}

--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -13989,6 +13989,50 @@ fn emit_overwrite_collect_enum<'ctx>(
     Ok(cap)
 }
 
+/// #2523 — neutralize (null) an enum/machine payload slot whose heap ownership
+/// was TRANSFERRED out by a projected-payload move-out (`Instr::NeutralizePayloadSlot`).
+///
+/// `place` is always a `Place::MachineVariant`/`Place::EnumVariant` field. The
+/// projected-payload binder holds a byte-copy of this slot; once it is moved
+/// into a new owner, the new owner is the sole release authority, so the source
+/// slot must be nulled before the scrutinee's own drop can reach it.
+///
+/// Storing a zeroinitializer of the FIELD's LLVM type nulls every heap leaf of
+/// the moved field in a single store: a scalar single-pointer payload (`Vec<T>`
+/// / `HashMap` / `string`) becomes a null pointer directly, and an aggregate
+/// payload (a tuple/record field) has every leaf pointer nulled at once. The
+/// GEP addresses ONLY this field of the variant struct, so the enum tag and any
+/// sibling payload fields (an unmoved binder of the same variant) are untouched.
+/// After this store the scrutinee's composite drop reaches null leaves and every
+/// release symbol it calls (`hew_vec_free`, `hew_string_drop`, `hew_bytes_drop`,
+/// the collection frees) is null-tolerant and no-ops — no double-free, and the
+/// move-out's new owner performs the one and only free.
+///
+/// DIVERGENCE from the plan's "reuse `emit_overwrite_neutralize_leaves`/`_enum`":
+/// those helpers null only the OLD leaves that reappear in a NEW value (the
+/// overwrite-release alias case). A projected-payload move-out transfers the
+/// WHOLE field and has no "new value" to match against, so the correct operation
+/// is an unconditional null of every leaf of the moved field — a direct
+/// zeroinitializer store, which subsumes the plan's "scalar direct null store"
+/// and covers aggregate fields with the same guarantee.
+fn lower_neutralize_payload_slot(fn_ctx: &FnCtx<'_, '_>, place: Place) -> CodegenResult<()> {
+    let (field_ptr, field_ty) = place_pointer(fn_ctx, place)?;
+    let zero: BasicValueEnum = match field_ty {
+        BasicTypeEnum::PointerType(t) => t.const_null().into(),
+        BasicTypeEnum::IntType(t) => t.const_zero().into(),
+        BasicTypeEnum::FloatType(t) => t.const_zero().into(),
+        BasicTypeEnum::StructType(t) => t.const_zero().into(),
+        BasicTypeEnum::ArrayType(t) => t.const_zero().into(),
+        BasicTypeEnum::VectorType(t) => t.const_zero().into(),
+        BasicTypeEnum::ScalableVectorType(t) => t.const_zero().into(),
+    };
+    fn_ctx
+        .builder
+        .build_store(field_ptr, zero)
+        .llvm_ctx("neutralize payload slot store")?;
+    Ok(())
+}
+
 /// NEUTRALISE step for one owned heap-leaf slot of the OLD value: null the
 /// slot iff its pointer matches ANY collected new-leaf slot (branch-free
 /// compare chain + `select`). A null old leaf trivially "matches" a null
@@ -18569,6 +18613,10 @@ fn lower_instruction(
         }
         Instr::ActorStateFieldStore { field_offset, src } => {
             lower_actor_state_field_store(fn_ctx, *field_offset, *src)?;
+            let _ = ctx;
+        }
+        Instr::NeutralizePayloadSlot { place } => {
+            lower_neutralize_payload_slot(fn_ctx, *place)?;
             let _ = ctx;
         }
         Instr::TupleFieldLoad {

--- a/hew-mir/src/dataflow.rs
+++ b/hew-mir/src/dataflow.rs
@@ -277,6 +277,7 @@ fn transfer_block(
                 binding,
                 name,
                 site,
+                partial_projection,
                 ..
             } => {
                 match state.get(binding).copied() {
@@ -284,8 +285,17 @@ fn transfer_block(
                     // (`(t, t)` / `(h, ..., h)`): the second placement is a
                     // use-after-move — both aggregate fields would free the one
                     // handle. Flag it and anchor at the first placement.
+                    //
+                    // A PARTIAL-PROJECTION mark (#2523) is exempt: it records
+                    // that an owned aggregate had a *projection* moved out, and
+                    // each independent field move (`V(x, y) => let wx = x;
+                    // let wy = y;`) re-emits it. The fields are distinct sub-
+                    // objects, not the same handle placed twice, so a repeat on
+                    // an already-aliased binding is an idempotent no-op — the
+                    // binding is already in the re-read-forbidding state.
                     Some(BindingState::AliasedIntoAggregate(prev_site)) => {
-                        if use_after_consume_seen.insert((*binding, *site)) {
+                        if !*partial_projection && use_after_consume_seen.insert((*binding, *site))
+                        {
                             checks.push(MirCheck::UseAfterConsume {
                                 binding: *binding,
                                 name: name.clone(),
@@ -642,6 +652,9 @@ pub(crate) fn instr_reads_writes(instr: &Instr) -> (Vec<Place>, Vec<Place>) {
             (vec![*record, *src], vec![])
         }
         Instr::ActorStateFieldStore { src, .. } => (vec![*src], vec![]),
+        // The neutralize references the scrutinee's payload slot (keeping the
+        // base local live through the null store) and defines no new SSA value.
+        Instr::NeutralizePayloadSlot { place } => (vec![*place], vec![]),
         // Closure-env write-back (#1′): reads the env pointer (to GEP into it)
         // and the stored value. The env stays Live — only the field bytes are
         // overwritten through the pointer, opaque to the MIR lattice — so the

--- a/hew-mir/src/dump.rs
+++ b/hew-mir/src/dump.rs
@@ -869,6 +869,9 @@ fn render_instr(instr: &Instr) -> String {
                 render_place(src)
             )
         }
+        Instr::NeutralizePayloadSlot { place } => {
+            format!("neutralize_payload {}", render_place(place))
+        }
 
         // Actor spawn
         Instr::SpawnActor {
@@ -1290,6 +1293,11 @@ fn render_mir_statement(stmt: &MirStatement) -> String {
             name,
             site,
             ty,
+            // `partial_projection` is a checker-only discriminator (#2523); it
+            // is deliberately NOT rendered so the checked-MIR golden corpus
+            // stays byte-stable (the elaborated single-owner drop shape it
+            // influences is unchanged).
+            partial_projection: _,
         } => format!(
             "agg_alias {:?} {name} site={:?} ty={}",
             binding,
@@ -1481,6 +1489,15 @@ fn render_diag_kind(kind: &MirDiagnosticKind) -> String {
             used_at,
         } => format!(
             "UseAfterConsume {binding:?} {name} consumed={consumed_at:?} used={used_at:?}"
+        ),
+        MirDiagnosticKind::ProjectedPayloadMoveFromReadablePlace {
+            binding,
+            name,
+            site,
+            reason,
+        } => format!(
+            "ProjectedPayloadMoveFromReadablePlace {binding:?} {name} moved={site:?} \
+             reason={reason:?}"
         ),
         MirDiagnosticKind::InitialisedBeforeUse {
             binding,

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -61,10 +61,11 @@ pub use model::{
     IntArithOp, IntSignedness, IrPipeline, JoinBranch, LambdaActorShape, LambdaCapture,
     LambdaEnvFieldDrop, MachineLayout, MachineVariantLayout, MirCheck, MirConst, MirConstValue,
     MirDiagnostic, MirDiagnosticKind, MirHeapLayouts, MirLint, MirScope, MirStatement, Place,
-    PointerWidth, PolymorphicMirFunction, PoolCount, RawMirFunction, RecordLayout, RegexLiteral,
-    RuntimeCall, SelectArm, SelectArmKind, SendAliasMode, SourceOrigin, SpawnEnvFieldOwnership,
-    Strategy, SupervisorChildLayout, SupervisorConfigParam, SupervisorLayout, SuspendKind,
-    Terminator, ThirFunction, TraitObjectStorage, TrapKind, WitnessOperand,
+    PointerWidth, PolymorphicMirFunction, PoolCount, ProjectedPayloadRejectReason, RawMirFunction,
+    RecordLayout, RegexLiteral, RuntimeCall, SelectArm, SelectArmKind, SendAliasMode, SourceOrigin,
+    SpawnEnvFieldOwnership, Strategy, SupervisorChildLayout, SupervisorConfigParam,
+    SupervisorLayout, SuspendKind, Terminator, ThirFunction, TraitObjectStorage, TrapKind,
+    WitnessOperand,
 };
 pub use ownership::{
     AbiClass, CowHeapRelease, DropClass, FailClosedReason, HandleRole, HeapLeaf,

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -35,9 +35,9 @@ use crate::model::{
     CoalesceKeyKind, CoalesceKeyPlan, DecisionFact, DropKind, DropPlan, ElabBlock, ElabDrop,
     ElaboratedMirFunction, ExitPath, FieldOffset, FloatWidth, Instr, IntArithOp, IntSignedness,
     IrPipeline, JoinBranch, LambdaCapture, MirCheck, MirConst, MirConstValue, MirDiagnostic,
-    MirDiagnosticKind, MirStatement, Place, PointerWidth, RawMirFunction, SelectArm, SelectArmKind,
-    SourceOrigin, SpawnEnvFieldOwnership, Strategy, SuspendKind, Terminator, ThirFunction,
-    TraitObjectStorage, TrapKind,
+    MirDiagnosticKind, MirStatement, Place, PointerWidth, ProjectedPayloadRejectReason,
+    RawMirFunction, SelectArm, SelectArmKind, SourceOrigin, SpawnEnvFieldOwnership, Strategy,
+    SuspendKind, Terminator, ThirFunction, TraitObjectStorage, TrapKind,
 };
 use crate::ownership::FailClosedReason;
 use crate::ownership::LayoutClass;
@@ -9551,7 +9551,79 @@ struct StreamProducerPumpCtx {
     yield_ty: ResolvedTy,
 }
 
+/// #2523 — provenance for a `match`-arm binder projected out of an enum/machine
+/// payload (`lower_match_enum_tag`). The binder's storage is a byte-copy ALIAS
+/// of the scrutinee's payload slot; when the binder is moved into a new owner
+/// its heap ownership transfers, and the source slot must be neutralized so the
+/// scrutinee's own drop no-ops on it. Recorded strictly for
+/// `Place::MachineVariant`/`Place::EnumVariant` sources at the destructure site.
+#[derive(Debug, Clone)]
+struct ProjectedPayloadProvenance {
+    /// The interior projection the binder aliases; nulled by
+    /// `Instr::NeutralizePayloadSlot` at the binder's move-out.
+    source_place: Place,
+    /// The binder's own name, used to author the fail-closed diagnostic when
+    /// the scrutinee is a re-readable place (see [`ProjectedPayloadOrigin`]).
+    binder_name: String,
+    /// How the scrutinee was materialised — decides whether a projected-payload
+    /// move-out is soundly neutralizable at the temp, needs a consume-mark, or
+    /// must be rejected fail-closed.
+    origin: ProjectedPayloadOrigin,
+}
+
+/// #2523 — classification of a projected-payload binder's scrutinee, which
+/// decides how a move-out of the (heap-owning) binder is made sound.
+///
+/// The match lowers the scrutinee into a temp before destructuring. Whether
+/// nulling that temp (`Instr::NeutralizePayloadSlot`) actually neutralizes the
+/// payload's *sole surviving owner* depends on how the scrutinee reached the
+/// temp:
+#[derive(Debug, Clone)]
+enum ProjectedPayloadOrigin {
+    /// The scrutinee is a bare owning binding (`match b { … }`): the match
+    /// MOVES it into the temp, so the temp is the sole live copy. Neutralize
+    /// the temp AND consume-mark the binding (via `MirStatement::AggregateAlias`)
+    /// so a later re-read is a compile-time use-after-move rather than a read of
+    /// the nulled slot.
+    OwnedBinding(ProjectedScrutinee),
+    /// The scrutinee is an ephemeral producer (`match f() { … }`,
+    /// `match Box::Full(x) { … }`): the temp is a fresh, sole-owner value with
+    /// no re-readable origin, so neutralizing the temp transfers ownership
+    /// soundly with no consume-mark needed.
+    EphemeralTemp,
+    /// The FAIL-CLOSED default (#2523 F1/F1b/F2): the scrutinee is anything NOT
+    /// proven a fresh sole owner — a re-readable *place* projection (`match h.b`,
+    /// `match pair.0`, `match arr[i]`, `match self.field`), a `Block`/`If`/
+    /// `Scope` wrapper whose value is a sub-expression (`match { h.b }`), a
+    /// closure-CAPTURED binding (read from the env by copy, not moved into the
+    /// temp), a NESTED-pattern binder (extracted through a transient copy the
+    /// move cannot neutralize), or any un-enumerated / future HIR shape. The
+    /// move-out is REJECTED before codegen; `reason` selects the precise
+    /// diagnostic. Rejecting a wrapper-hidden but otherwise-safe producer is
+    /// acceptable — the safe default is to reject rather than risk aliasing.
+    /// Borrow-only matches never reach this arm (they do not consume the binder).
+    Reject(ProjectedPayloadRejectReason),
+}
+
+/// The re-readable scrutinee binding behind a [`ProjectedPayloadOrigin::OwnedBinding`],
+/// consume-marked (via `MirStatement::AggregateAlias`) at the binder's move-out
+/// so the checker rejects a later re-read as a use-after-move.
+#[derive(Debug, Clone)]
+struct ProjectedScrutinee {
+    binding: BindingId,
+    name: String,
+    ty: ResolvedTy,
+}
+
 #[derive(Debug, Default)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "Builder is the MIR-lowering state accumulator; each bool is an \
+              independent, orthogonal lowering-mode flag (e.g. the \
+              fallthrough-match-guard scope) that distinct call sites set and \
+              query on their own — collapsing them into an enum would force a \
+              single active-mode invariant the lowering does not have"
+)]
 struct Builder {
     /// Checker-authority stream for the *current* basic block. Drained
     /// into a `BasicBlock` when the cursor moves (`finish_current_block`)
@@ -10389,6 +10461,21 @@ struct Builder {
     /// record/string locals are released through the `elaborate` allow-set
     /// prover (`CowValue` arm), not `owned_locals` / this flag.
     overwrite_guard_flags: HashMap<BindingId, Place>,
+    /// #2523: provenance for projected enum/machine payload binders, keyed on
+    /// the binder's `BindingId`. Populated in `lower_match_enum_tag`'s binder
+    /// loop for `MachineVariant`/`EnumVariant` sources; consulted at the
+    /// binder's `Consume`-intent move-out to emit `NeutralizePayloadSlot` for
+    /// the source slot and `AggregateAlias` for the scrutinee.
+    projected_payload_provenance: HashMap<BindingId, ProjectedPayloadProvenance>,
+    /// Set while lowering a match-arm guard expression that
+    /// can fall through to a later arm. A projected heap-payload binder consumed
+    /// with this flag set is rejected fail-closed (`GuardedConsume`): its
+    /// `NeutralizePayloadSlot` would run before the guard outcome is known, so a
+    /// false guard would fall through to a later arm re-destructuring the
+    /// now-null payload (null-fault / abort). Borrow-only guards never reach the
+    /// consume hook and are unaffected. Saved/restored around each guard lowering
+    /// so nested guards compose.
+    in_fallthrough_match_guard: bool,
     /// #2418: runtime drop-flags for an owned collection local (owned-element
     /// `Vec`, plain `Vec`, `HashMap`/`HashSet` handle) that the pre-pass saw
     /// genuinely consumed (`intent=Consume`, a move-out such as `let ys = xs`)
@@ -14769,6 +14856,10 @@ impl Builder {
         // Goto the continuation, where subsequent statements lower with the
         // binders live.
         self.start_block(bind_bb);
+        // #2523 — classify the scrutinee once for the whole let-else so every
+        // heap-owning payload binder routes its move-out through the shared
+        // default-deny consume policy (see `classify_scrutinee_origin`).
+        let scrutinee_origin = self.classify_scrutinee_origin(scrutinee);
         let mut nested_binding_jobs: Vec<(u32, u32, hew_hir::HirMatchArmBinding)> = Vec::new();
         for pvp in payload_variant_predicates {
             // A failed nested check routes to the else block, same as a
@@ -14797,7 +14888,8 @@ impl Builder {
                 ty: binding_ty.clone(),
             });
             self.record_binding_scope(binding.binding);
-            if self.binding_seeds_drop_elaboration(&binding_ty) {
+            let keep_for_drop_elab = self.binding_seeds_drop_elaboration(&binding_ty);
+            if keep_for_drop_elab {
                 self.register_owned_local(
                     binding.binding,
                     binding.name.clone(),
@@ -14815,6 +14907,19 @@ impl Builder {
             });
             // Escape: insert into binding_locals and never restore.
             self.binding_locals.insert(binding.binding, dest);
+            // #2523 — record provenance for a heap-owning TOP-LEVEL let-else
+            // payload binder so its move-out routes through default-deny.
+            self.record_projected_payload_provenance(
+                binding.binding,
+                &binding.name,
+                Place::MachineVariant {
+                    local: scrutinee_local,
+                    variant_idx,
+                    field_idx: binding.field_idx,
+                },
+                scrutinee_origin.clone(),
+                keep_for_drop_elab,
+            );
         }
         for (src_local, src_variant_idx, binding) in nested_binding_jobs {
             let binding_ty = self.subst_ty(&binding.ty);
@@ -14825,7 +14930,8 @@ impl Builder {
                 ty: binding_ty.clone(),
             });
             self.record_binding_scope(binding.binding);
-            if self.binding_seeds_drop_elaboration(&binding_ty) {
+            let keep_for_drop_elab = self.binding_seeds_drop_elaboration(&binding_ty);
+            if keep_for_drop_elab {
                 self.register_owned_local(
                     binding.binding,
                     binding.name.clone(),
@@ -14842,6 +14948,19 @@ impl Builder {
                 },
             });
             self.binding_locals.insert(binding.binding, dest);
+            // #2523 F2 — nested let-else binder bound from a transient predicate
+            // copy; reject a heap-owning move-out fail-closed.
+            self.record_projected_payload_provenance(
+                binding.binding,
+                &binding.name,
+                Place::MachineVariant {
+                    local: src_local,
+                    variant_idx: src_variant_idx,
+                    field_idx: binding.field_idx,
+                },
+                ProjectedPayloadOrigin::Reject(ProjectedPayloadRejectReason::NestedDestructure),
+                keep_for_drop_elab,
+            );
         }
         // Aggregate-payload destructure (`Ok((n, s))`): the prelude `Let`
         // statements project the synthetic `__payload_*` temp into the leaf
@@ -15459,6 +15578,129 @@ impl Builder {
                             });
                         } else {
                             self.mark_binding_moved(*id);
+                        }
+                        // #2523 — a heap-owning projected enum/machine payload
+                        // binder is being moved into a new owner. Its storage is
+                        // a byte-copy ALIAS of the scrutinee's payload slot.
+                        // Whether the copy in the destination local can safely
+                        // become the SOLE owner depends on how the scrutinee
+                        // reached the match temp (`ProjectedPayloadOrigin`):
+                        //   * OwnedBinding — the match moved the binding into the
+                        //     temp, so nulling the temp transfers ownership; the
+                        //     scrutinee's null-tolerant drop no-ops, and marking
+                        //     the binding consumed (`AggregateAlias`) turns a
+                        //     later re-read into a compile-time use-after-move.
+                        //   * EphemeralTemp — the temp is a fresh sole-owner value
+                        //     (`match f()`), so nulling it transfers ownership
+                        //     with no re-readable origin to consume-mark.
+                        //   * ReadablePlace — the scrutinee was COPIED from a
+                        //     re-readable place (`match h.b`, `match pair.0`); the
+                        //     origin field's storage stays live and the temp-null
+                        //     cannot reach it, so a move-out would leave the field
+                        //     dangling (use-after-free / double-free). No sound
+                        //     physical neutralization of the origin is expressible
+                        //     here, so REJECT the move-out fail-closed before
+                        //     codegen (F1). Fires on every consume branch above,
+                        //     independent of the binder's own drop-flag tracking.
+                        if let Some(provenance) = self.projected_payload_provenance.get(id).cloned()
+                        {
+                            // A projected heap-payload consumed
+                            // inside a fallthrough-capable match-arm guard is
+                            // unsound: the neutralize (null store) runs before the
+                            // guard outcome is known, so a false guard falls
+                            // through to a later arm that re-destructures the
+                            // now-null payload (null-fault / abort). Override the
+                            // origin to reject fail-closed (unless it already
+                            // rejects for a more specific reason). Borrow-only
+                            // guards never reach this hook, so they stay valid.
+                            let origin = if self.in_fallthrough_match_guard
+                                && !matches!(provenance.origin, ProjectedPayloadOrigin::Reject(_))
+                            {
+                                ProjectedPayloadOrigin::Reject(
+                                    ProjectedPayloadRejectReason::GuardedConsume,
+                                )
+                            } else {
+                                provenance.origin
+                            };
+                            match origin {
+                                ProjectedPayloadOrigin::OwnedBinding(scrutinee) => {
+                                    self.push_instr(Instr::NeutralizePayloadSlot {
+                                        place: provenance.source_place,
+                                    });
+                                    // #2523 F2 — a PARTIAL-PROJECTION consume-mark:
+                                    // the owned scrutinee had one payload field
+                                    // moved out. Marks `b` re-read-forbidding
+                                    // (`AliasedIntoAggregate`) without the whole-
+                                    // value `(t, t)` double-placement check, so a
+                                    // second independent field move of the SAME
+                                    // scrutinee (`V(x, y) => let wx = x; let wy = y;`)
+                                    // is idempotent, not a false use-after-consume.
+                                    self.statements.push(MirStatement::AggregateAlias {
+                                        binding: scrutinee.binding,
+                                        name: scrutinee.name,
+                                        site: expr.site,
+                                        ty: scrutinee.ty,
+                                        partial_projection: true,
+                                    });
+                                }
+                                ProjectedPayloadOrigin::EphemeralTemp => {
+                                    self.push_instr(Instr::NeutralizePayloadSlot {
+                                        place: provenance.source_place,
+                                    });
+                                }
+                                ProjectedPayloadOrigin::Reject(reason) => {
+                                    // Do NOT emit the unsound temp-neutralize —
+                                    // its source cannot be safely neutralized, so
+                                    // reject the move-out fail-closed (F1/F1b/F2).
+                                    let note = match reason {
+                                        ProjectedPayloadRejectReason::ReadablePlace => {
+                                            "the matched place keeps ownership of the \
+                                             payload, so moving it out would leave the \
+                                             field's storage dangling (use-after-free on \
+                                             re-read, double-free at the place's drop); \
+                                             match an owned value instead"
+                                        }
+                                        ProjectedPayloadRejectReason::CapturedBinding => {
+                                            "the matched binding is captured by this \
+                                             closure and read from the closure environment \
+                                             by copy, so moving the payload out would leave \
+                                             the captured copy dangling (double-free when \
+                                             the environment drops); move the value into \
+                                             the closure and match it there, or match an \
+                                             owned value the closure does not capture"
+                                        }
+                                        ProjectedPayloadRejectReason::NestedDestructure => {
+                                            "the payload is extracted from a nested pattern \
+                                             through a temporary copy the move cannot \
+                                             neutralize, so moving it out would leave the \
+                                             outer value's storage dangling (double-free / \
+                                             leak at the outer value's drop); bind the \
+                                             nested value first, then match that owned \
+                                             binding in a separate step"
+                                        }
+                                        ProjectedPayloadRejectReason::GuardedConsume => {
+                                            "the payload is consumed inside a match-arm \
+                                             guard that can fall through, so the move-out \
+                                             would run before the guard result is known; a \
+                                             false guard would then fall through to a later \
+                                             arm that re-reads the now-moved payload \
+                                             (null-fault at runtime); consume the payload in \
+                                             the arm body instead of the guard, or match an \
+                                             owned value in a separate step after the guard"
+                                        }
+                                    };
+                                    self.diagnostics.push(MirDiagnostic {
+                                        kind:
+                                            MirDiagnosticKind::ProjectedPayloadMoveFromReadablePlace {
+                                                binding: *id,
+                                                name: provenance.binder_name,
+                                                site: expr.site,
+                                                reason,
+                                            },
+                                        note: note.to_string(),
+                                    });
+                                }
+                            }
                         }
                     }
                 }
@@ -19801,6 +20043,29 @@ impl Builder {
         ) && hir_expr_contains_synthetic_vec_string_index(scrutinee)
     }
 
+    /// #2523 provenance-skip predicate: true when the match scrutinee is the
+    /// `for x in <vec>` desugar's synthetic `Option<T>` next-producer for ANY
+    /// element type (`Vec<string>`, `Vec<(string, string)>`, `Vec<Person>`, …).
+    /// Each `Some(x)` payload is a FRESH, solely-owned per-frame element the
+    /// iteration handed the body — never a projection of a re-readable
+    /// aggregate that retains the bits — so its move-out (`let (k, val) = pair`,
+    /// `return pair`) is a legitimate ownership transfer that must NOT route
+    /// through the default-deny consume hook. The narrower
+    /// `is_vec_string_iter_next_scrutinee` still drives the `string`-specific
+    /// per-iteration release disposition; this one only gates the provenance
+    /// skip so no element type is falsely rejected as a re-readable-place move.
+    fn is_vec_iter_next_scrutinee(&self, scrutinee: &HirExpr) -> bool {
+        matches!(
+            &self.subst_ty(&scrutinee.ty),
+            ResolvedTy::Named {
+                name,
+                args,
+                builtin: None,
+                ..
+            } if name == "Option" && args.len() == 1
+        ) && hir_expr_contains_synthetic_vec_index(scrutinee)
+    }
+
     /// True when the match scrutinee is a generator `.next()` consumption node
     /// (`HirExprKind::GeneratorNext`) — either a source-level `g.next()` or the
     /// `for x in gen()` desugar's synthetic next-call. The yielded value bound by
@@ -21192,7 +21457,7 @@ impl Builder {
 
             // Guard check: failure branches to the next arm.
             if let Some(guard) = &arm.guard {
-                let guard_place = self.lower_value(guard);
+                let guard_place = self.lower_match_arm_guard(guard);
                 if let Some(guard_local) = guard_place {
                     let body_entry_bb = self.alloc_block();
                     self.finish_current_block(Terminator::Branch {
@@ -22237,7 +22502,7 @@ impl Builder {
             // Guard check (applies to literal and catch-all arms alike):
             // failure falls through to the next arm.
             if let Some(guard) = &arm.guard {
-                if let Some(guard_local) = self.lower_value(guard) {
+                if let Some(guard_local) = self.lower_match_arm_guard(guard) {
                     let body_entry_bb = self.alloc_block();
                     self.finish_current_block(Terminator::Branch {
                         cond: guard_local,
@@ -22916,6 +23181,175 @@ impl Builder {
     ///   (subsequent lowering continues here; result is result_local)
     /// ```
     ///
+    /// #2523 (F1b) — is `kind` a *provably ephemeral* scrutinee producer: a
+    /// shape that constructs a brand-new value or returns one by value from a
+    /// call/await/effect, so the match temp is a fresh SOLE owner with no
+    /// re-readable aliasing origin?
+    ///
+    /// A projected-payload move-out is sound only when nulling the match temp
+    /// neutralizes the payload's sole surviving owner. That holds for a bare
+    /// owning binding (moved into the temp — handled separately as
+    /// [`ProjectedPayloadOrigin::OwnedBinding`]) and for the fresh value
+    /// producers allowlisted here. It FAILS for a place projection
+    /// (`match h.b`, `match pair.0`, `match arr[i]`, machine-field access): the
+    /// match COPIES the place into the temp, so the origin keeps a live alias
+    /// the temp-null cannot reach (silent use-after-free / double-free).
+    ///
+    /// This predicate is the **fail-closed allowlist**: the classifier defaults
+    /// every shape NOT proven here (place projections, `Block`/`If`/`Scope`
+    /// wrappers whose value is a sub-expression, and any un-enumerated or future
+    /// shape) to [`ProjectedPayloadOrigin::ReadablePlace`], which rejects the
+    /// move-out before codegen. Rejecting a wrapper-hidden but otherwise-safe
+    /// producer (e.g. `match { mk() }`) is acceptable — the safe default is to
+    /// reject rather than risk aliasing. Wrappers are deliberately NOT peeled:
+    /// tracing a `Block`/`If` tail to guess ephemerality would reintroduce the
+    /// fail-open surface F1b closes (`match { h.b }` byte-copy-aliases `h`).
+    ///
+    /// Every arm is a value-producing rvalue that either builds a new aggregate
+    /// (`StructInit`, `TupleLiteral`, `MachineVariantCtor`, `Literal`) or moves
+    /// a value out by return/receive (`Call`, method calls, `ask`/`recv`/await
+    /// and machine effect nodes). None denote existing storage or a borrowed
+    /// view, so the produced temp is always a fresh sole owner. Shapes with any
+    /// aliasing risk (`Index`/`Slice` views, `FieldAccess`/`TupleIndex` places,
+    /// `ContextReader`, `RegexLiteralRef`, `ActorSelf`, `CoerceToDynTrait`,
+    /// `Yield`, wrappers, control flow) are intentionally omitted → rejected.
+    fn hir_scrutinee_is_ephemeral_producer(kind: &HirExprKind) -> bool {
+        matches!(
+            kind,
+            // Fresh scalar/aggregate literals and pure-value operators.
+            HirExprKind::Literal { .. }
+                | HirExprKind::Binary { .. }
+                | HirExprKind::Unary { .. }
+                | HirExprKind::NumericCast { .. }
+                | HirExprKind::SaturatingWidthCast { .. }
+                | HirExprKind::TryWidthCast { .. }
+                | HirExprKind::TupleLiteral { .. }
+                | HirExprKind::StructInit { .. }
+                | HirExprKind::MachineVariantCtor { .. }
+                | HirExprKind::IdentityCompare { .. }
+                | HirExprKind::CancellationTokenIsCancelled { .. }
+                // Calls return an owned value by value (Hew has no reference
+                // returns) — the result temp is a fresh sole owner.
+                | HirExprKind::Call { .. }
+                | HirExprKind::CallDynMethod { .. }
+                | HirExprKind::CallTraitMethodStatic { .. }
+                | HirExprKind::VarSelfMethodCall { .. }
+                | HirExprKind::ResolvedImplCall { .. }
+                | HirExprKind::NumericMethod { .. }
+                | HirExprKind::RecordCloneCall { .. }
+                // Spawns/closures/generators produce fresh handles or objects.
+                | HirExprKind::Spawn { .. }
+                | HirExprKind::SpawnedCall { .. }
+                | HirExprKind::SpawnLambdaActor { .. }
+                | HirExprKind::Closure { .. }
+                | HirExprKind::GenBlock { .. }
+                | HirExprKind::ActorGenStream { .. }
+                // ask/recv/await and machine effects MOVE a value out of the
+                // mailbox/channel/generator/machine — ownership transfers to the
+                // receiver, so the result is a fresh sole owner.
+                | HirExprKind::ActorAsk { .. }
+                | HirExprKind::RemoteActorAsk { .. }
+                | HirExprKind::AwaitTask { .. }
+                | HirExprKind::AwaitRestart { .. }
+                | HirExprKind::ConnAwaitRead { .. }
+                | HirExprKind::ListenerAwaitAccept { .. }
+                | HirExprKind::ChannelRecvAwait { .. }
+                | HirExprKind::StreamRecvAwait { .. }
+                | HirExprKind::GeneratorNext { .. }
+                | HirExprKind::Select { .. }
+                | HirExprKind::Join { .. }
+                | HirExprKind::WireCodec { .. }
+                | HirExprKind::MachineEmit { .. }
+                | HirExprKind::MachineStep { .. }
+                | HirExprKind::MachineTakeEmits { .. }
+        )
+    }
+
+    /// #2523 — classify a match/while-let/let-else/if-let scrutinee for the
+    /// projected-payload move-out policy. FAIL-CLOSED: only a scrutinee *proven*
+    /// a fresh sole owner takes the temp-neutralize consume path; everything
+    /// else is rejected before codegen. Shared by every top-level payload
+    /// binding loop so no destructuring construct bypasses default-deny.
+    ///
+    ///   * `OwnedBinding` — a bare owning `BindingRef` that is NOT captured by a
+    ///     closure. The match MOVES it into the temp, so nulling the temp
+    ///     transfers ownership and consume-marking the binding turns a re-read
+    ///     into a compile-time use-after-move.
+    ///   * `EphemeralTemp` — a proven fresh value producer (call / constructor /
+    ///     literal / await): the temp is a fresh sole owner, neutralize only.
+    ///   * `Reject(CapturedBinding)` — a closure-captured binding (F2): it is
+    ///     read from the closure environment by BYTE-COPY (`ClosureEnvFieldLoad`,
+    ///     see `capture_env_sources`), NOT moved into the temp, so the captured
+    ///     copy survives the move and double-frees when the env drops.
+    ///   * `Reject(ReadablePlace)` — a place projection or wrapper, or any
+    ///     un-enumerated shape (default-deny).
+    fn classify_scrutinee_origin(&self, scrutinee: &HirExpr) -> ProjectedPayloadOrigin {
+        match &scrutinee.kind {
+            HirExprKind::BindingRef {
+                resolved: ResolvedRef::Binding(id),
+                name,
+            } => {
+                if self.capture_env_sources.contains_key(id) {
+                    // F2 — captured binding: env-copy origin the neutralize
+                    // cannot reach. Reject rather than double-free.
+                    ProjectedPayloadOrigin::Reject(ProjectedPayloadRejectReason::CapturedBinding)
+                } else {
+                    ProjectedPayloadOrigin::OwnedBinding(ProjectedScrutinee {
+                        binding: *id,
+                        name: name.clone(),
+                        ty: self.subst_ty(&scrutinee.ty),
+                    })
+                }
+            }
+            other if Self::hir_scrutinee_is_ephemeral_producer(other) => {
+                ProjectedPayloadOrigin::EphemeralTemp
+            }
+            _ => ProjectedPayloadOrigin::Reject(ProjectedPayloadRejectReason::ReadablePlace),
+        }
+    }
+
+    /// Lower a match-arm GUARD expression with the
+    /// fallthrough-guard flag set, so any projected heap-payload consumed inside
+    /// it is rejected fail-closed (`GuardedConsume`) rather than emitting a
+    /// `NeutralizePayloadSlot` that would run before the guard outcome is known.
+    /// The flag is saved/restored so nested guards compose and the arm BODY
+    /// (where a consume IS committed once the arm is taken) is unaffected.
+    /// Borrow-only guards never reach the consume hook, so they stay valid.
+    fn lower_match_arm_guard(&mut self, guard: &HirExpr) -> Option<Place> {
+        let prev = self.in_fallthrough_match_guard;
+        self.in_fallthrough_match_guard = true;
+        let result = self.lower_value(guard);
+        self.in_fallthrough_match_guard = prev;
+        result
+    }
+
+    /// #2523 — record the interior-alias provenance for a heap-owning projected
+    /// payload binder so its `Consume`-intent move-out routes through the
+    /// default-deny consume hook (`lower_value`'s `Use { Consume }` arm). Gated
+    /// on `keep_for_drop_elab`: a bit-copy payload (`i64`) owns no heap, so there
+    /// is nothing to neutralize, double-free, or reject. Shared by every
+    /// top-level AND nested payload binding loop so no destructure path bypasses
+    /// the policy.
+    fn record_projected_payload_provenance(
+        &mut self,
+        binding_id: BindingId,
+        binder_name: &str,
+        source_place: Place,
+        origin: ProjectedPayloadOrigin,
+        keep_for_drop_elab: bool,
+    ) {
+        if keep_for_drop_elab {
+            self.projected_payload_provenance.insert(
+                binding_id,
+                ProjectedPayloadProvenance {
+                    source_place,
+                    binder_name: binder_name.to_string(),
+                    origin,
+                },
+            );
+        }
+    }
+
     /// Returns the result `Place::Local` that every arm body's value is
     /// moved into. For a Unit-valued match the result local is allocated
     /// but never read by codegen.
@@ -22987,6 +23421,11 @@ impl Builder {
         let vec_string_iter_next_scrutinee = self.is_vec_string_iter_next_scrutinee(scrutinee);
         let generator_next_scrutinee = Self::is_generator_next_scrutinee(scrutinee);
         let recv_next_scrutinee = Self::is_recv_next_scrutinee(scrutinee);
+        // #2523 — element-type-agnostic fresh-owned vec-element iteration
+        // (`for pair in v` over `Vec<(string, string)>`, `Vec<Person>`, …).
+        // Gates ONLY the provenance skip below; disposition still keys off the
+        // narrower string/generator/recv markers.
+        let vec_iter_next_scrutinee = self.is_vec_iter_next_scrutinee(scrutinee);
 
         // Lower the scrutinee in the entry block. A failure propagates
         // via `?`; the half-built match leaves no dangling block.
@@ -23009,7 +23448,13 @@ impl Builder {
             }
         };
 
-        // A from-call enum-composite scrutinee (`match f() { … }`) gets a
+        // #2523 — classify the scrutinee so a projected-payload move-out is
+        // made sound the right way (see `classify_scrutinee_origin`). FAIL-CLOSED:
+        // only a bare owning (non-captured) binding or a proven-ephemeral
+        // producer takes the temp-neutralize consume path; a place, a wrapper, a
+        // closure-captured binding, or any un-enumerated shape is REJECTED.
+        let scrutinee_origin = self.classify_scrutinee_origin(scrutinee);
+
         // synthetic owned binding over its temp so the arm-destructured
         // payload is released on every exit edge — most importantly the loop
         // back-edge, where each iteration previously leaked one payload
@@ -23101,7 +23546,7 @@ impl Builder {
             );
 
             if let Some(guard) = &wildcard.guard {
-                let guard_place = self.lower_value(guard);
+                let guard_place = self.lower_match_arm_guard(guard);
                 if let Some(guard_local) = guard_place {
                     let body_bb = self.alloc_block();
                     self.finish_current_block(Terminator::Branch {
@@ -23216,6 +23661,7 @@ impl Builder {
             );
             let arm_is_vec_iter_some = vec_string_iter_next_scrutinee && arm_is_some;
             let arm_is_generator_some = generator_next_scrutinee && arm_is_some;
+            let arm_is_fresh_owned_vec_iter_some = vec_iter_next_scrutinee && arm_is_some;
             // Recv-call scrutinee `Some` arm: the runtime hands the consumer a
             // FRESH, solely-owned heap value per frame (an `alloc_cstring_data`
             // block for `string`, a fresh `Bytes` header for `bytes`). The
@@ -23264,6 +23710,37 @@ impl Builder {
                 });
                 let previous = self.binding_locals.insert(binding.binding, dest);
                 overwritten_bindings.push((binding.binding, previous, keep_for_drop_elab));
+                // #2523 — record provenance for a heap-owning TOP-LEVEL projected
+                // payload binder so its `Consume`-intent move-out routes through
+                // the default-deny consume hook.
+                //
+                // EXCEPTION — the vec-string-iter / generator / recv `Some(x)`
+                // arms carry a FRESH, solely-owned per-frame payload (the
+                // synthetic `Option` shell holds a value the runtime just
+                // handed the consumer: `hew_vec_get_str`'s refcount-bumped
+                // owner, a coro yield, a received frame). Its release is already
+                // owned by the arm's own `Disposition::BodyEndReleased` +
+                // escape-suppression discipline (registered below). It is NOT a
+                // projection of a re-readable aggregate that retains the bits,
+                // so a move-out (`return line`, store to a longer-lived owner)
+                // is a legitimate ownership transfer, not a dangling-source
+                // hazard. Routing it through default-deny would falsely reject
+                // that transfer as a re-readable-place move-out. Skip it.
+                let is_fresh_owned_frame_payload =
+                    arm_is_fresh_owned_vec_iter_some || arm_is_generator_some || arm_is_recv_some;
+                if !is_fresh_owned_frame_payload {
+                    self.record_projected_payload_provenance(
+                        binding.binding,
+                        &binding.name,
+                        Place::MachineVariant {
+                            local: scrutinee_local,
+                            variant_idx,
+                            field_idx: binding.field_idx,
+                        },
+                        scrutinee_origin.clone(),
+                        keep_for_drop_elab,
+                    );
+                }
                 if arm_is_vec_iter_some && matches!(binding_ty, ResolvedTy::String) {
                     // `hew_vec_get_str` returns a FRESH, solely-owned retained
                     // owner (refcount bump via `hew_string_clone` — NOT a borrow
@@ -23415,14 +23892,29 @@ impl Builder {
                 });
                 let previous = self.binding_locals.insert(binding.binding, dest);
                 overwritten_bindings.push((binding.binding, previous, keep_for_drop_elab));
+                // #2523 F2 — a NESTED-pattern payload binder is bound from a
+                // TRANSIENT copy the predicate phase loaded (`src_local`), NOT
+                // from the outer value's real storage. Nulling that transient
+                // cannot reach the outer value's nested slot, so a heap-owning
+                // move-out would leave it dangling (double-free / leak). Record
+                // provenance with the `NestedDestructure` reject reason so the
+                // move-out is rejected fail-closed; a borrow-only nested binder
+                // never hits the consume hook and is unaffected.
+                self.record_projected_payload_provenance(
+                    binding.binding,
+                    &binding.name,
+                    Place::MachineVariant {
+                        local: src_local,
+                        variant_idx: src_variant_idx,
+                        field_idx: binding.field_idx,
+                    },
+                    ProjectedPayloadOrigin::Reject(ProjectedPayloadRejectReason::NestedDestructure),
+                    keep_for_drop_elab,
+                );
             }
-
-            // Guard check: evaluate the guard expression and branch. Placed
-            // after payload bindings so guard expressions may reference the
-            // arm's own constructor-payload bindings (e.g. `Some(n) if n > 0`).
             // Failure falls through to `fallthrough_bb` (re-try next arm).
             if let Some(guard) = &arm.guard {
-                let guard_place = self.lower_value(guard);
+                let guard_place = self.lower_match_arm_guard(guard);
                 if let Some(guard_local) = guard_place {
                     let body_entry_bb = self.alloc_block();
                     self.finish_current_block(Terminator::Branch {
@@ -23924,6 +24416,12 @@ impl Builder {
 
         let mut overwritten_bindings =
             Vec::with_capacity(bindings.len() + nested_binding_jobs.len());
+        // #2523 — classify the while-let scrutinee once so every heap-owning
+        // payload binder routes its move-out through the shared default-deny
+        // consume policy. The loop back-edge re-reads the scrutinee every
+        // iteration, so an owning-binding move-out MUST become a compile-time
+        // use-after-move (the canonical #2523 shape).
+        let scrutinee_origin = self.classify_scrutinee_origin(scrutinee);
         for binding in bindings {
             let binding_ty = self.subst_ty(&binding.ty);
             self.statements.push(MirStatement::Bind {
@@ -23933,7 +24431,8 @@ impl Builder {
                 ty: binding_ty.clone(),
             });
             self.record_binding_scope(binding.binding);
-            if self.binding_seeds_drop_elaboration(&binding_ty) {
+            let keep_for_drop_elab = self.binding_seeds_drop_elaboration(&binding_ty);
+            if keep_for_drop_elab {
                 self.register_owned_local(
                     binding.binding,
                     binding.name.clone(),
@@ -23954,6 +24453,19 @@ impl Builder {
                 self.transient_local_scopes.insert(local, body.scope);
             }
             overwritten_bindings.push((binding.binding, previous));
+            // #2523 — record provenance for a heap-owning TOP-LEVEL while-let
+            // payload binder so its move-out routes through default-deny.
+            self.record_projected_payload_provenance(
+                binding.binding,
+                &binding.name,
+                Place::MachineVariant {
+                    local: scrutinee_local,
+                    variant_idx,
+                    field_idx: binding.field_idx,
+                },
+                scrutinee_origin.clone(),
+                keep_for_drop_elab,
+            );
         }
         for (src_local, src_variant_idx, binding) in nested_binding_jobs {
             let binding_ty = self.subst_ty(&binding.ty);
@@ -23964,7 +24476,8 @@ impl Builder {
                 ty: binding_ty.clone(),
             });
             self.record_binding_scope(binding.binding);
-            if self.binding_seeds_drop_elaboration(&binding_ty) {
+            let keep_for_drop_elab = self.binding_seeds_drop_elaboration(&binding_ty);
+            if keep_for_drop_elab {
                 self.register_owned_local(
                     binding.binding,
                     binding.name.clone(),
@@ -23985,6 +24498,19 @@ impl Builder {
                 self.transient_local_scopes.insert(local, body.scope);
             }
             overwritten_bindings.push((binding.binding, previous));
+            // #2523 F2 — nested while-let binder bound from a transient predicate
+            // copy; reject a heap-owning move-out fail-closed.
+            self.record_projected_payload_provenance(
+                binding.binding,
+                &binding.name,
+                Place::MachineVariant {
+                    local: src_local,
+                    variant_idx: src_variant_idx,
+                    field_idx: binding.field_idx,
+                },
+                ProjectedPayloadOrigin::Reject(ProjectedPayloadRejectReason::NestedDestructure),
+                keep_for_drop_elab,
+            );
         }
 
         self.active_scopes.push(body.scope);
@@ -24192,6 +24718,10 @@ impl Builder {
 
         let mut overwritten_bindings =
             Vec::with_capacity(bindings.len() + nested_binding_jobs.len());
+        // #2523 — classify the if-let scrutinee once so every heap-owning
+        // payload binder routes its move-out through the shared default-deny
+        // consume policy.
+        let scrutinee_origin = self.classify_scrutinee_origin(scrutinee);
         for binding in bindings {
             let binding_ty = self.subst_ty(&binding.ty);
             self.statements.push(MirStatement::Bind {
@@ -24201,7 +24731,8 @@ impl Builder {
                 ty: binding_ty.clone(),
             });
             self.record_binding_scope(binding.binding);
-            if self.binding_seeds_drop_elaboration(&binding_ty) {
+            let keep_for_drop_elab = self.binding_seeds_drop_elaboration(&binding_ty);
+            if keep_for_drop_elab {
                 self.register_owned_local(
                     binding.binding,
                     binding.name.clone(),
@@ -24219,6 +24750,19 @@ impl Builder {
             });
             let previous = self.binding_locals.insert(binding.binding, dest);
             overwritten_bindings.push((binding.binding, previous));
+            // #2523 — record provenance for a heap-owning TOP-LEVEL if-let
+            // payload binder so its move-out routes through default-deny.
+            self.record_projected_payload_provenance(
+                binding.binding,
+                &binding.name,
+                Place::MachineVariant {
+                    local: scrutinee_local,
+                    variant_idx,
+                    field_idx: binding.field_idx,
+                },
+                scrutinee_origin.clone(),
+                keep_for_drop_elab,
+            );
         }
         for (src_local, src_variant_idx, binding) in nested_binding_jobs {
             let binding_ty = self.subst_ty(&binding.ty);
@@ -24229,7 +24773,8 @@ impl Builder {
                 ty: binding_ty.clone(),
             });
             self.record_binding_scope(binding.binding);
-            if self.binding_seeds_drop_elaboration(&binding_ty) {
+            let keep_for_drop_elab = self.binding_seeds_drop_elaboration(&binding_ty);
+            if keep_for_drop_elab {
                 self.register_owned_local(
                     binding.binding,
                     binding.name.clone(),
@@ -24247,6 +24792,19 @@ impl Builder {
             });
             let previous = self.binding_locals.insert(binding.binding, dest);
             overwritten_bindings.push((binding.binding, previous));
+            // #2523 F2 — nested if-let binder bound from a transient predicate
+            // copy; reject a heap-owning move-out fail-closed.
+            self.record_projected_payload_provenance(
+                binding.binding,
+                &binding.name,
+                Place::MachineVariant {
+                    local: src_local,
+                    variant_idx: src_variant_idx,
+                    field_idx: binding.field_idx,
+                },
+                ProjectedPayloadOrigin::Reject(ProjectedPayloadRejectReason::NestedDestructure),
+                keep_for_drop_elab,
+            );
         }
 
         self.active_scopes.push(body.scope);
@@ -35388,6 +35946,9 @@ impl Builder {
             name: name.clone(),
             site: operand.site,
             ty,
+            // Whole-value placement into a fresh aggregate: `(t, t)` double
+            // placement IS a use-after-move, so keep the strict check.
+            partial_projection: false,
         });
     }
 
@@ -35974,6 +36535,8 @@ impl Builder {
                     name,
                     site: operand.site,
                     ty,
+                    // Whole-value closure-pair placement: strict `(t, t)` check.
+                    partial_projection: false,
                 });
             }
             ClosurePairIngress::Borrowed { name } => {
@@ -36602,7 +37165,6 @@ fn elaborate(
         &builder.collection_drop_flags,
     );
 
-    // Value-class capstone — owned-aggregate-record scope-exit drop allow-set.
     // A by-value owned record (RC-4 bytes field / RC-6 string field / G12
     // Vec/HashMap/HashSet field) earns the tag-aware `DropKind::RecordInPlace`
     // (the recursive per-field `__hew_record_drop_inplace_<R>` thunk) ONLY when
@@ -37819,6 +38381,7 @@ fn instr_places(instr: &Instr) -> Vec<Place> {
         Instr::RecordFieldStore { record, src, .. } => vec![*record, *src],
         Instr::ActorStateFieldLoad { dest, .. } => vec![*dest],
         Instr::ActorStateFieldStore { src, .. } => vec![*src],
+        Instr::NeutralizePayloadSlot { place } => vec![*place],
         Instr::TupleFieldLoad { tuple, dest, .. } => vec![*tuple, *dest],
         Instr::TupleConstruct { elements, dest } => {
             let mut places = Vec::with_capacity(elements.len() + 1);
@@ -38617,7 +39180,9 @@ pub fn instr_source_places(instr: &Instr) -> Vec<Place> {
         | Instr::DurationLit { .. }
         // A field load out of the hidden actor-state pointer reads no
         // operand `Place` — the source is the implicit context arg.
-        | Instr::ActorStateFieldLoad { .. } => Vec::new(),
+        | Instr::ActorStateFieldLoad { .. }
+        // A payload-slot neutralize stores a constant null — no source operand.
+        | Instr::NeutralizePayloadSlot { .. } => Vec::new(),
         // Binary arithmetic / comparison: both operands are sources, the
         // dest (and any overflow-flag dest) is a write.
         Instr::IntAdd { lhs, rhs, .. }
@@ -38968,6 +39533,49 @@ fn hir_stmt_is_synthetic_vec_string_index(stmt: &HirStmt) -> bool {
     )
 }
 
+/// Element-type-AGNOSTIC companion to
+/// [`hir_expr_contains_synthetic_vec_string_index`]: true when the scrutinee
+/// carries the `for x in <vec>` desugar's synthetic `let __hew_iter_value_N =
+/// <vec>[i]` binding for ANY element type (owned tuple / record / enum, not
+/// just `string`). Used SOLELY by the #2523 provenance-skip decision: every
+/// such element is a FRESH, solely-owned per-frame value the iteration handed
+/// the body, never a projection of a re-readable aggregate that retains the
+/// bits, so a move-out (`let (k, val) = pair`, `return pair`) is a legitimate
+/// ownership transfer that must not route through default-deny. The
+/// string-specific disposition logic keeps its own narrower detector.
+fn hir_expr_contains_synthetic_vec_index(expr: &HirExpr) -> bool {
+    match &expr.kind {
+        HirExprKind::Block(block) => {
+            block.statements.iter().any(hir_stmt_is_synthetic_vec_index)
+                || block
+                    .tail
+                    .as_deref()
+                    .is_some_and(hir_expr_contains_synthetic_vec_index)
+        }
+        HirExprKind::If {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            hir_expr_contains_synthetic_vec_index(condition)
+                || hir_expr_contains_synthetic_vec_index(then_expr)
+                || else_expr
+                    .as_deref()
+                    .is_some_and(hir_expr_contains_synthetic_vec_index)
+        }
+        _ => false,
+    }
+}
+
+fn hir_stmt_is_synthetic_vec_index(stmt: &HirStmt) -> bool {
+    matches!(
+        &stmt.kind,
+        HirStmtKind::Let(binding, Some(value))
+            if binding.name.starts_with("__hew_iter_value_")
+                && matches!(value.kind, HirExprKind::Index { .. })
+    )
+}
+
 fn place_refs_local(place: Place, local: u32) -> bool {
     base_local(place) == Some(local)
 }
@@ -39182,7 +39790,10 @@ fn generator_yield_instr_escapes(instr: &Instr, local: u32) -> bool {
         // transfer ownership of any local out of the frame.
         | Instr::RecordCloneInplace { .. }
         // EnumCloneInplace has the same non-consuming-read semantics.
-        | Instr::EnumCloneInplace { .. } => false,
+        | Instr::EnumCloneInplace { .. }
+        // A payload-slot neutralize nulls the scrutinee's transferred slot; it
+        // does not hand any local out of the body.
+        | Instr::NeutralizePayloadSlot { .. } => false,
     }
 }
 
@@ -39453,7 +40064,10 @@ fn projection_alias_dest(instr: &Instr) -> Option<Place> {
         | Instr::RecordCloneInplace { .. }
         // EnumCloneInplace allocates a fresh enum clone with the same
         // non-aliasing guarantee (tag-dispatched payload deep-clone).
-        | Instr::EnumCloneInplace { .. } => None,
+        | Instr::EnumCloneInplace { .. }
+        // A payload-slot neutralize writes a constant null — it produces no
+        // interior-alias dest (it retires one).
+        | Instr::NeutralizePayloadSlot { .. } => None,
     }
 }
 
@@ -40057,6 +40671,20 @@ fn compute_projection_alias_taint(
     exempt_seed_locals: &HashSet<u32>,
     locals: &[ResolvedTy],
 ) -> HashSet<u32> {
+    // #2523 — projection slots whose heap ownership was TRANSFERRED to a new
+    // owner by a projected-payload move-out. The `Move` that copies such a slot
+    // into the new owner's local is followed by an `Instr::NeutralizePayloadSlot`
+    // that nulls the source, so the destination local is the SOLE owner, not a
+    // parent-interior alias — it must NOT be tainted (that would suppress its
+    // scope-exit drop and leak the transferred buffer, the very #2523 leak).
+    let neutralized_sources: HashSet<Place> = blocks
+        .iter()
+        .flat_map(|block| block.instructions.iter())
+        .filter_map(|instr| match instr {
+            Instr::NeutralizePayloadSlot { place } => Some(*place),
+            _ => None,
+        })
+        .collect();
     let mut tainted: HashSet<u32> = HashSet::new();
     for block in blocks {
         for instr in &block.instructions {
@@ -40073,7 +40701,10 @@ fn compute_projection_alias_taint(
                 }
             }
             if let Instr::Move { dest, src } = instr {
-                if place_is_interior_projection(*src) {
+                // An interior-projection move whose source is neutralized
+                // transfers ownership (#2523): the dest is the sole owner, not an
+                // alias. Skip the taint seed so its drop is admitted exactly once.
+                if place_is_interior_projection(*src) && !neutralized_sources.contains(src) {
                     if let Some(dl) = base_local(*dest) {
                         tainted.insert(dl);
                     }
@@ -48034,9 +48665,30 @@ fn dedup_whole_value_handoff(
         return;
     }
     let mut move_edges: Vec<(u32, u32)> = Vec::new();
+    // #2523 — an interior-projection move whose source slot is NEUTRALIZED
+    // (`Instr::NeutralizePayloadSlot`) is an ownership TRANSFER, not a
+    // shared-bits alias: the destination becomes the sole owner and the source
+    // field is nulled, so the two locals do NOT overlap. Such edges must be
+    // excluded from the hand-off/fan-out move graph. Otherwise two payload
+    // fields moved out of the SAME aggregate (`V(x, y) => var wx = x; var wy = y;`)
+    // collapse to `base_local(scrutinee)` and land in one undirected component,
+    // and the fan-out collapse below wrongly strips BOTH their scope-exit drops
+    // (leaking the reassigned owners — the #2523 two-field leak). This mirrors
+    // the identical neutralized-source exclusion in `compute_projection_alias_taint`.
+    let neutralized_sources: HashSet<Place> = blocks
+        .iter()
+        .flat_map(|block| block.instructions.iter())
+        .filter_map(|instr| match instr {
+            Instr::NeutralizePayloadSlot { place } => Some(*place),
+            _ => None,
+        })
+        .collect();
     for block in blocks {
         for instr in &block.instructions {
             if let Instr::Move { dest, src } = instr {
+                if place_is_interior_projection(*src) && neutralized_sources.contains(src) {
+                    continue;
+                }
                 if let (Some(sl), Some(dl)) = (base_local(*src), base_local(*dest)) {
                     if sl != dl {
                         move_edges.push((sl, dl));

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -4170,6 +4170,24 @@ pub enum Instr {
     },
     /// `dest = <src>` — load `src`, store into `dest`.
     Move { dest: Place, src: Place },
+    /// Neutralize (null) an enum/machine payload slot whose heap ownership has
+    /// just been TRANSFERRED to a new owner by a projected-payload move-out
+    /// (`#2523`). A `match` arm binder over an enum/machine payload is a
+    /// byte-copy ALIAS of the scrutinee's payload slot; when that binder is
+    /// moved into a new owner (`var w = v`), the new owner becomes the sole
+    /// release authority for the storage. This instruction nulls the source
+    /// `place` so the scrutinee's own (null-tolerant) drop spine no-ops on the
+    /// transferred slot — no double-free at the scrutinee's scope exit and no
+    /// use-after-free on a re-match (the checker separately rejects the re-read
+    /// as a use-after-move; see `AggregateAlias` on the scrutinee).
+    ///
+    /// `place` is always a `Place::MachineVariant`/`Place::EnumVariant`
+    /// projection (the provenance is recorded strictly for those two shapes at
+    /// the destructure site). Codegen lowers a scalar single-pointer payload to
+    /// a direct null store and an aggregate payload by nulling every heap leaf
+    /// (`emit_overwrite_neutralize_*`), so every release symbol the scrutinee's
+    /// drop later calls is a null-tolerant no-op.
+    NeutralizePayloadSlot { place: Place },
     /// Increment the refcount of a `bytes` value before a genuine co-owner is
     /// minted. This marker is emitted only by the MIR bytes ownership prover;
     /// codegen must not infer the retain from the LLVM storage type.
@@ -6162,11 +6180,26 @@ pub enum MirStatement {
     /// Modelling it as a `Use { Consume }` instead would suppress the source
     /// drop and break that machinery (it would silently turn the W3.053
     /// fail-closed double-free refusals into leaks).
+    ///
+    /// `partial_projection` (#2523) distinguishes two shapes that both alias a
+    /// binding into "an aggregate":
+    ///   * `false` — a whole owned value placed into a fresh aggregate field
+    ///     (the B1 case above). Placing the SAME binding twice (`(t, t)`) is a
+    ///     use-after-move double-free, so a repeat on an already-aliased binding
+    ///     is FLAGGED.
+    ///   * `true` — the scrutinee of a `match` whose OWNED projected payload is
+    ///     moved out (`match b { V(x, y) => { let wx = x; let wy = y; } }`). The
+    ///     mark records "the aggregate `b` has had a projection moved out; `b`
+    ///     must not be re-read". Each independent field move re-emits it, so on
+    ///     a partial-projection mark a repeat on an already-aliased binding is a
+    ///     NO-OP (idempotent), not a double-placement — the two fields are
+    ///     distinct sub-objects, not the same handle placed twice.
     AggregateAlias {
         binding: BindingId,
         name: String,
         site: SiteId,
         ty: ResolvedTy,
+        partial_projection: bool,
     },
     Return {
         site: Option<SiteId>,
@@ -6185,6 +6218,36 @@ pub struct MirDiagnostic {
     pub note: String,
 }
 
+/// #2523 — which unneutralizable scrutinee source shape forced a
+/// projected-payload move-out to be rejected fail-closed. Drives the precise
+/// user-facing message + help note (see `ProjectedPayloadMoveFromReadablePlace`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectedPayloadRejectReason {
+    /// A re-readable place scrutinee (`match h.b`, `match pair.0`,
+    /// `match arr[i]`, `match self.field`) or a wrapper hiding one
+    /// (`match { h.b }`): the match copies the place into a temp, leaving the
+    /// origin storage live and re-readable.
+    ReadablePlace,
+    /// A closure-captured binding (`match b` inside a closure that captures
+    /// `b`): the binding is read from the closure environment by byte-copy
+    /// (`ClosureEnvFieldLoad`), NOT moved into the temp, so the captured copy
+    /// survives the move and double-frees when the environment drops.
+    CapturedBinding,
+    /// A nested-pattern binder (`match x { Outer(Inner(v)) => … }`): the nested
+    /// payload is loaded into a transient copy by the predicate phase, so
+    /// neutralizing that transient cannot reach the outer value's real nested
+    /// storage (double-free / leak at the outer value's drop).
+    NestedDestructure,
+    /// A projected payload consumed INSIDE a match-arm guard that can fall
+    /// through (`match x { V(v) if cond(consume v) => …, _ => … }`): the
+    /// move-out's `NeutralizePayloadSlot` (null store) runs while lowering the
+    /// guard, BEFORE the guard outcome is known. A false guard falls through to
+    /// a later arm that re-destructures the now-null payload — a null-fault /
+    /// abort at runtime. Path-sensitive neutralization keyed on the guard
+    /// outcome is not expressible here, so the consume is rejected fail-closed.
+    GuardedConsume,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MirDiagnosticKind {
     UseAfterConsume {
@@ -6192,6 +6255,22 @@ pub enum MirDiagnosticKind {
         name: String,
         consumed_at: SiteId,
         used_at: SiteId,
+    },
+    /// #2523 — a heap-owning enum/machine payload is moved out of a scrutinee
+    /// whose original storage the move cannot safely neutralize, so the moved-
+    /// from source keeps a dangling pointer the new owner later frees (use-
+    /// after-free on a re-read, double-free / leak at the source's drop). The
+    /// move-out is rejected fail-closed before codegen. `reason` records which
+    /// unneutralizable source shape was hit (a re-readable place / wrapper, a
+    /// closure-captured binding read by copy, or a nested-pattern binder
+    /// extracted through a temporary copy). Sound move-outs come only from a
+    /// binding that OWNS the scrutinee (`match b`) or an ephemeral producer
+    /// (`match f()`).
+    ProjectedPayloadMoveFromReadablePlace {
+        binding: BindingId,
+        name: String,
+        site: SiteId,
+        reason: ProjectedPayloadRejectReason,
     },
     /// A binding is read before any initialising `let` for it appears.
     /// Surfaced from `MirCheck::InitialisedBeforeUse` in commit 2.


### PR DESCRIPTION
## Summary

Projected enum/struct payload move-outs (destructuring a `match`/`while let`/`if let`/`let else` arm's payload field, e.g. `match h { .Ok(v) => v.into() }`) could free the same allocation twice: the new binding's own drop and the containing enum's scope-exit drop both held a release authority over the moved-out field. Payload moves from an owned, non-aliased source (a bare owning binding, or a fresh producer such as a constructor/call result) now transfer exactly one release authority — the source slot is neutralized in MIR and codegen zeroes only the moved field, leaving the tag and any sibling payload fields untouched, while the new owner keeps its normal scope-exit release. Payload moves from any other shape — a re-readable place, a captured binding, a nested destructure, an unrecognized producer, or a consume inside a match guard whose fallthrough can still reach the guarded-against value — are rejected at compile time with a diagnostic instead of being allowed to silently corrupt memory.

## Verification

- `cargo test -p hew-cli --test match_payload_reassign_uaf_oracle`: 25/25 passing — new compiled regression coverage for re-read rejection, single-free overwrite, scope-exit paths, aggregate/two-field payloads, allocator-scribbled controls, leak-slope checks, and the readable-place/wrapper/nested/captured default-deny and guarded-consume cases.
- `hew-mir` corpus: 355/355 passing, golden output byte-stable.
- `make asan-fixtures` (Linux): 8/8 passing.
- Full CI preflight (15 lanes): all green on this exact commit.

## Out of scope

- A separate double-free in call-argument lowering — `match somefn(x.field) => ...` where the scrutinee is produced by passing a re-readable place projection into a function call — is a distinct defect in a subsystem this change does not touch, and is tracked in #2648.
