### PR TITLE
fix(runtime): release consumed connection on stream-clone failure

### DIFF
--- a/hew-runtime/Cargo.toml
+++ b/hew-runtime/Cargo.toml
@@ -58,6 +58,19 @@ otel = ["dep:ureq"]
 # production dependencies.
 forced-cancel-test = []
 
+# Deterministic clone-failure injection for the TCP stream-bridge consumed-
+# connection ownership tests (#2650). Lets a test force `tcp_clone_stream`'s
+# first and/or second clone to fail *with a live table entry* (the valid-
+# handle-clone-failed path that rlimit forcing cannot target deterministically
+# and cannot aim at clone #2), so the two failure branches of
+# `hew_tcp_stream_from_conn` and the fd-leak slope are exercised without
+# rlimit flakiness. Test-only — never in `default`/`full`. Auto-enabled under
+# `cfg(test)` for unit tests inside the crate; integration tests opt in via
+# `--features clone-failure-test` (mirrors `sim-transport`/`forced-cancel-test`).
+# Also widens the `#[cfg(test)]` transport table probes to the same gate so
+# integration tests can read them. Adds no production dependencies.
+clone-failure-test = []
+
 [dependencies]
 # CBOR body codec (ciborium, RFC 8949); CDDL schema in schemas/envelope.cddl.
 ciborium = "0.2"

--- a/hew-runtime/src/stream.rs
+++ b/hew-runtime/src/stream.rs
@@ -969,10 +969,16 @@ fn channel_sink_close(core: &mut Arc<crate::channel_core::ChannelCore>) {
 #[cfg(not(target_arch = "wasm32"))]
 #[no_mangle]
 pub unsafe extern "C" fn hew_tcp_stream_from_conn(conn: c_int) -> *mut HewStreamPair {
-    use crate::transport::{tcp_clone_stream, tcp_release_conn};
+    use crate::transport::{tcp_clone_stream, tcp_full_close_conn, tcp_release_conn};
 
     // Clone the read fd.
     let Some(read_stream) = tcp_clone_stream(conn) else {
+        // Consumed-on-call contract: `conn` is dead-by-move at the source level
+        // on every return path, so the runtime is its sole releaser. No clone
+        // survives here — fully close and release the original entry (removes
+        // the table slot and closes the fd) before returning the null pair.
+        // Without this the socket + table slot leak on an ordinary failure.
+        tcp_full_close_conn(conn);
         set_last_error_with_errno(
             format!("hew_tcp_stream_from_conn: invalid connection handle {conn}"),
             9, // EBADF
@@ -982,7 +988,11 @@ pub unsafe extern "C" fn hew_tcp_stream_from_conn(conn: c_int) -> *mut HewStream
 
     // Clone the write fd.
     let Some(write_stream) = tcp_clone_stream(conn) else {
-        // read_stream RAII drops its clone here.
+        // `read_stream` is a live dup of the socket and RAII-drops on return
+        // (closing its own dup fd). Full-close the original table entry: a
+        // distinct fd, so no double-close. Both fds are released and the table
+        // slot is freed — the consumed connection is not stranded.
+        tcp_full_close_conn(conn);
         set_last_error_with_errno(
             format!("hew_tcp_stream_from_conn: could not clone write fd for handle {conn}"),
             9, // EBADF

--- a/hew-runtime/src/stream.rs
+++ b/hew-runtime/src/stream.rs
@@ -952,8 +952,14 @@ fn channel_sink_close(core: &mut Arc<crate::channel_core::ChannelCore>) {
 /// stream and sink with `hew_stream_pair_stream_bytes` /
 /// `hew_stream_pair_sink_bytes`, then free with `hew_stream_pair_free`.
 ///
-/// Returns `null` with the last-error set to EBADF (errno 9) if `conn` is
-/// not a registered TCP connection handle.
+/// The `conn` handle is **consumed on every return path**: success *and*
+/// clone failure.  On either clone failure the original connection is fully
+/// closed and released from the table before the null pair is returned — the
+/// source-level `Connection` is dead-by-move regardless, so the runtime is the
+/// sole releaser and no fd/table slot can leak (#2650).  The last-error errno
+/// distinguishes the cause: **EBADF (9)** when `conn` is not a registered
+/// handle, otherwise the **real `dup(2)` errno** (e.g. `EMFILE`/`ENFILE` under
+/// fd pressure) so a resource-exhaustion failure is not mislabeled.
 ///
 /// # Safety
 ///
@@ -969,35 +975,78 @@ fn channel_sink_close(core: &mut Arc<crate::channel_core::ChannelCore>) {
 #[cfg(not(target_arch = "wasm32"))]
 #[no_mangle]
 pub unsafe extern "C" fn hew_tcp_stream_from_conn(conn: c_int) -> *mut HewStreamPair {
-    use crate::transport::{tcp_clone_stream, tcp_full_close_conn, tcp_release_conn};
+    use crate::transport::{
+        tcp_clone_stream_outcome, tcp_full_close_conn, tcp_release_conn, CloneOutcome,
+    };
 
     // Clone the read fd.
-    let Some(read_stream) = tcp_clone_stream(conn) else {
-        // Consumed-on-call contract: `conn` is dead-by-move at the source level
-        // on every return path, so the runtime is its sole releaser. No clone
-        // survives here — fully close and release the original entry (removes
-        // the table slot and closes the fd) before returning the null pair.
-        // Without this the socket + table slot leak on an ordinary failure.
-        tcp_full_close_conn(conn);
-        set_last_error_with_errno(
-            format!("hew_tcp_stream_from_conn: invalid connection handle {conn}"),
-            9, // EBADF
-        );
-        return ptr::null_mut();
+    let read_stream = match tcp_clone_stream_outcome(conn) {
+        CloneOutcome::Cloned(stream) => stream,
+        CloneOutcome::NoEntry => {
+            // Genuinely unknown handle: nothing is registered, so there is
+            // nothing to release. Report EBADF (the real "invalid handle").
+            set_last_error_with_errno(
+                format!("hew_tcp_stream_from_conn: invalid connection handle {conn}"),
+                9, // EBADF
+            );
+            return ptr::null_mut();
+        }
+        CloneOutcome::Failed(err) => {
+            // Valid handle, but the clone/dup(2) failed (e.g. EMFILE/ENFILE
+            // under fd pressure). Consumed-on-call contract: `conn` is
+            // dead-by-move at the source level on every return path, so the
+            // runtime is its sole releaser. No clone survives here — fully
+            // close and release the original entry (removes the table slot and
+            // closes the fd) before returning the null pair. Surface the *real*
+            // errno so the failure is distinguishable from a bad handle.
+            tcp_full_close_conn(conn);
+            let errno = err.raw_os_error().unwrap_or(libc::EIO);
+            set_last_error_with_errno_and_kind(
+                format!(
+                    "hew_tcp_stream_from_conn: could not clone read fd for handle {conn}: {err}"
+                ),
+                errno,
+                io_error_kind_tag(err.kind()),
+            );
+            return ptr::null_mut();
+        }
     };
 
     // Clone the write fd.
-    let Some(write_stream) = tcp_clone_stream(conn) else {
-        // `read_stream` is a live dup of the socket and RAII-drops on return
-        // (closing its own dup fd). Full-close the original table entry: a
-        // distinct fd, so no double-close. Both fds are released and the table
-        // slot is freed — the consumed connection is not stranded.
-        tcp_full_close_conn(conn);
-        set_last_error_with_errno(
-            format!("hew_tcp_stream_from_conn: could not clone write fd for handle {conn}"),
-            9, // EBADF
-        );
-        return ptr::null_mut();
+    let write_stream = match tcp_clone_stream_outcome(conn) {
+        CloneOutcome::Cloned(stream) => stream,
+        outcome => {
+            // `read_stream` is a live dup of the socket and RAII-drops on
+            // return (closing its own dup fd). Full-close the original table
+            // entry: a distinct fd, so no double-close. Both fds are released
+            // and the table slot is freed — the consumed connection is not
+            // stranded.
+            tcp_full_close_conn(conn);
+            match outcome {
+                CloneOutcome::Failed(err) => {
+                    let errno = err.raw_os_error().unwrap_or(libc::EIO);
+                    set_last_error_with_errno_and_kind(
+                        format!(
+                            "hew_tcp_stream_from_conn: could not clone write fd for handle {conn}: {err}"
+                        ),
+                        errno,
+                        io_error_kind_tag(err.kind()),
+                    );
+                }
+                // NoEntry after a successful first clone means the entry was
+                // removed out from under us (not reachable on the single-owner
+                // bridge path); report EBADF for completeness.
+                _ => {
+                    set_last_error_with_errno(
+                        format!(
+                            "hew_tcp_stream_from_conn: could not clone write fd for handle {conn}"
+                        ),
+                        9, // EBADF
+                    );
+                }
+            }
+            return ptr::null_mut();
+        }
     };
 
     // Release the original handle from the connection table WITHOUT calling

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -939,18 +939,50 @@ pub extern "C" fn hew_tcp_listener_local_port(listener: c_int) -> c_int {
     tcp_listener_local_port(listener).map_or(-1, c_int::from)
 }
 
+/// Outcome of a stream-clone attempt for the TCP bridge.
+///
+/// Distinguishes "no such connection handle" (a genuine EBADF) from "the
+/// handle is live but `try_clone`/`dup(2)` failed" (e.g. EMFILE/ENFILE under fd
+/// pressure), so `hew_tcp_stream_from_conn` can report the real errno instead
+/// of mislabeling a resource-exhaustion failure as an invalid handle.
+pub(crate) enum CloneOutcome {
+    /// The handle was live and the clone succeeded.
+    Cloned(TcpStream),
+    /// No connection with this handle is registered (genuine EBADF).
+    NoEntry,
+    /// The handle was live but the clone/dup failed with this OS error.
+    Failed(std::io::Error),
+}
+
 pub(crate) fn tcp_clone_stream(handle: c_int) -> Option<TcpStream> {
+    match tcp_clone_stream_outcome(handle) {
+        CloneOutcome::Cloned(stream) => Some(stream),
+        CloneOutcome::NoEntry | CloneOutcome::Failed(_) => None,
+    }
+}
+
+/// Clone a connection's socket, distinguishing "no such handle" from "handle
+/// live but clone failed" so the stream bridge can report the real errno. The
+/// `Option`-returning [`tcp_clone_stream`] delegates here for callers that only
+/// need success/failure.
+pub(crate) fn tcp_clone_stream_outcome(handle: c_int) -> CloneOutcome {
     TCP_API_STATE.access(|state| {
-        let stream = state.streams.get(&handle)?;
-        // Deterministic test-only injection: after confirming a live table
-        // entry exists (so we exercise the valid-handle-clone-failed path, not
-        // the missing-entry path), fail this clone if the current thread armed
-        // it. Production builds never compile this branch.
+        let Some(stream) = state.streams.get(&handle) else {
+            return CloneOutcome::NoEntry;
+        };
+        // Deterministic test-only injection: with a live table entry confirmed,
+        // fail this clone if the current thread armed it (the valid-handle-
+        // clone-failed path). Production builds never compile this branch.
         #[cfg(any(test, feature = "clone-failure-test"))]
         if clone_failure_hook::take_should_fail() {
-            return None;
+            return CloneOutcome::Failed(std::io::Error::from_raw_os_error(
+                clone_failure_hook::INJECTED_CLONE_ERRNO,
+            ));
         }
-        stream.try_clone().ok()
+        match stream.try_clone() {
+            Ok(clone) => CloneOutcome::Cloned(clone),
+            Err(err) => CloneOutcome::Failed(err),
+        }
     })
 }
 
@@ -960,6 +992,12 @@ pub(crate) fn tcp_clone_stream(handle: c_int) -> Option<TcpStream> {
 pub(crate) mod clone_failure_hook {
     use std::cell::RefCell;
     use std::collections::VecDeque;
+
+    /// OS errno the injected clone failure reports. `EMFILE` ("too many open
+    /// files") is the realistic `dup(2)` failure this lane exists to surface,
+    /// and is deliberately distinct from `EBADF` (9, the genuine-invalid-handle
+    /// code) so the diagnostic test can prove the two are no longer conflated.
+    pub const INJECTED_CLONE_ERRNO: i32 = libc::EMFILE;
 
     thread_local! {
         /// Pending forced-failure decisions for upcoming `tcp_clone_stream`
@@ -996,7 +1034,9 @@ pub(crate) mod clone_failure_hook {
 }
 
 #[cfg(any(test, feature = "clone-failure-test"))]
-pub use clone_failure_hook::{clear_clone_failures, force_next_clone_failures};
+pub use clone_failure_hook::{
+    clear_clone_failures, force_next_clone_failures, INJECTED_CLONE_ERRNO,
+};
 
 /// Remove a TCP connection handle from the table WITHOUT calling `shutdown`.
 ///

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -994,8 +994,8 @@ pub(crate) mod clone_failure_hook {
     use std::collections::VecDeque;
 
     /// OS errno the injected clone failure reports. `EMFILE` ("too many open
-    /// files") is the realistic `dup(2)` failure this lane exists to surface,
-    /// and is deliberately distinct from `EBADF` (9, the genuine-invalid-handle
+    /// files") is the realistic `dup(2)` failure the bridge must surface, and
+    /// is deliberately distinct from `EBADF` (9, the genuine-invalid-handle
     /// code) so the diagnostic test can prove the two are no longer conflated.
     pub const INJECTED_CLONE_ERRNO: i32 = libc::EMFILE;
 

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -940,8 +940,63 @@ pub extern "C" fn hew_tcp_listener_local_port(listener: c_int) -> c_int {
 }
 
 pub(crate) fn tcp_clone_stream(handle: c_int) -> Option<TcpStream> {
-    TCP_API_STATE.access(|state| state.streams.get(&handle)?.try_clone().ok())
+    TCP_API_STATE.access(|state| {
+        let stream = state.streams.get(&handle)?;
+        // Deterministic test-only injection: after confirming a live table
+        // entry exists (so we exercise the valid-handle-clone-failed path, not
+        // the missing-entry path), fail this clone if the current thread armed
+        // it. Production builds never compile this branch.
+        #[cfg(any(test, feature = "clone-failure-test"))]
+        if clone_failure_hook::take_should_fail() {
+            return None;
+        }
+        stream.try_clone().ok()
+    })
 }
+
+/// Deterministic clone-failure injection seam for the consumed-connection
+/// ownership tests (#2650). See the `clone-failure-test` feature.
+#[cfg(any(test, feature = "clone-failure-test"))]
+pub(crate) mod clone_failure_hook {
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+
+    thread_local! {
+        /// Pending forced-failure decisions for upcoming `tcp_clone_stream`
+        /// calls on this thread, in call order. `true` = fail the clone.
+        static FORCE: RefCell<VecDeque<bool>> = const { RefCell::new(VecDeque::new()) };
+    }
+
+    /// Test-only: arm deterministic failure of the next one/two
+    /// `tcp_clone_stream` calls on the CURRENT thread. `first` decides clone #1
+    /// (the read fd), `second` decides clone #2 (the write fd). Replaces any
+    /// previously-armed decisions. A clone that is never attempted — because an
+    /// earlier one failed and `hew_tcp_stream_from_conn` returned early — simply
+    /// leaves its arm unconsumed until the next `force_next_clone_failures`
+    /// clears it, so re-arming per loop iteration is safe.
+    pub fn force_next_clone_failures(first: bool, second: bool) {
+        FORCE.with(|f| {
+            let mut q = f.borrow_mut();
+            q.clear();
+            q.push_back(first);
+            q.push_back(second);
+        });
+    }
+
+    /// Clear any armed decisions on the current thread.
+    pub fn clear_clone_failures() {
+        FORCE.with(|f| f.borrow_mut().clear());
+    }
+
+    /// Consume the next armed decision (unarmed ⇒ `false`/succeed). Called by
+    /// `tcp_clone_stream` only after a live table entry is confirmed.
+    pub(crate) fn take_should_fail() -> bool {
+        FORCE.with(|f| f.borrow_mut().pop_front().unwrap_or(false))
+    }
+}
+
+#[cfg(any(test, feature = "clone-failure-test"))]
+pub use clone_failure_hook::{clear_clone_failures, force_next_clone_failures};
 
 /// Remove a TCP connection handle from the table WITHOUT calling `shutdown`.
 ///
@@ -1034,8 +1089,8 @@ pub(crate) fn tcp_listener_with_pending_conn_for_test() -> (c_int, TcpStream) {
 /// live streams table. Checks a specific token rather than the global count,
 /// so concurrent transport tests adding/removing their own handles do not cause
 /// false positives or false negatives.
-#[cfg(test)]
-pub(crate) fn tcp_streams_has_handle_for_test(handle: c_int) -> bool {
+#[cfg(any(test, feature = "clone-failure-test"))]
+pub fn tcp_streams_has_handle_for_test(handle: c_int) -> bool {
     TCP_API_STATE.access(|state| state.streams.contains_key(&handle))
 }
 

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -2736,19 +2736,52 @@ pub extern "C" fn hew_tcp_detach(conn: c_int) {
     crate::reactor::reactor_detach_conn(conn);
 }
 
+/// Fully close a TCP *connection* handle: detach it from the active-mode
+/// reactor, remove its table entry, and `shutdown(Both)` the socket before the
+/// stored `TcpStream` drops (closing the fd). Returns `true` if a connection
+/// entry was present and removed, `false` if `handle` is not a live connection.
+///
+/// This is the shared connection-close body used by [`hew_tcp_close`] (its
+/// connection branch) and by the clone-failure early-returns in
+/// `hew_tcp_stream_from_conn`. Factoring it here keeps a single close path so a
+/// *consumed* connection is released on every return path of the stream bridge,
+/// not only on full success.
+///
+/// Unlike [`tcp_release_conn`] (remove-without-shutdown, which keeps the socket
+/// alive for the two clones the success path just made) this fully tears the
+/// connection down. On the clone-failure paths there is no surviving clone that
+/// shares this fd — either no clone was made (first-clone failure) or the one
+/// live clone (`read_stream` on second-clone failure) is a distinct dup'd fd
+/// that RAII-drops independently — so `shutdown(Both)` here is safe and closes
+/// exactly the original fd.
+pub(crate) fn tcp_full_close_conn(handle: c_int) -> bool {
+    // Detach from the active-mode reactor first so the reactor stops polling a
+    // fd we are about to close (reactor-fd ownership: unregister before close).
+    // No-op on the bridge failure path (that path never attached to the
+    // reactor); kept for symmetry with `hew_tcp_close` and robustness if the
+    // call graph ever changes.
+    crate::reactor::reactor_detach_conn(handle);
+    TCP_API_STATE.access(|state| {
+        if let Some(stream) = state.streams.remove(&handle) {
+            let _ = stream.shutdown(Shutdown::Both);
+            true
+        } else {
+            false
+        }
+    })
+}
+
 /// Close either a TCP connection handle or listener handle.
 ///
 /// Returns 0 on success, -1 if handle is unknown.
 #[no_mangle]
 pub extern "C" fn hew_tcp_close(handle: c_int) -> c_int {
-    // Detach from the active-mode reactor first so the reactor stops polling a
-    // fd we are about to close (reactor-fd ownership: unregister before close).
-    crate::reactor::reactor_detach_conn(handle);
+    // Connection branch: detach from the reactor, remove, and shutdown.
+    if tcp_full_close_conn(handle) {
+        return 0;
+    }
+    // Otherwise it may be a listener handle.
     TCP_API_STATE.access(|state| {
-        if let Some(stream) = state.streams.remove(&handle) {
-            let _ = stream.shutdown(Shutdown::Both);
-            return 0;
-        }
         if state.listeners.remove(&handle).is_some() {
             return 0;
         }

--- a/hew-runtime/tests/tcp_stream_clone_ownership.rs
+++ b/hew-runtime/tests/tcp_stream_clone_ownership.rs
@@ -24,13 +24,14 @@ use std::ffi::CString;
 use std::io::Write;
 use std::net::{TcpListener, TcpStream};
 
+use hew_cabi::sink::hew_stream_last_errno;
 use hew_runtime::stream::{
     hew_stream_next_sized, hew_stream_pair_free, hew_stream_pair_stream_bytes,
     hew_tcp_stream_from_conn,
 };
 use hew_runtime::transport::{
     clear_clone_failures, force_next_clone_failures, hew_tcp_close, hew_tcp_connect,
-    tcp_streams_has_handle_for_test,
+    tcp_streams_has_handle_for_test, INJECTED_CLONE_ERRNO,
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -59,7 +60,7 @@ fn open_fd_count() -> usize {
     } else {
         "/dev/fd"
     };
-    std::fs::read_dir(dir).map(|it| it.count()).unwrap_or(0)
+    std::fs::read_dir(dir).map_or(0, std::iter::Iterator::count)
 }
 
 /// Drain all items from a `HewStream` into a flat `Vec<u8>`, freeing each
@@ -155,7 +156,7 @@ fn second_clone_failure_releases_table_entry() {
 // ── Shape 3: descriptor-leak slope ─────────────────────────────────────────────
 
 /// Repeated clone failures must not grow the process fd table (flat slope).
-/// This is the DoS guard: before the fix each failed conversion leaked the
+/// This is the `DoS` guard: before the fix each failed conversion leaked the
 /// original socket fd, so the slope grew with N. Peers are dropped each
 /// iteration so only the *runtime-side* accounting is under test.
 #[test]
@@ -241,4 +242,42 @@ fn success_path_releases_entry_without_breaking_roundtrip() {
 
     // SAFETY: pair is valid; stream slot already extracted.
     unsafe { hew_stream_pair_free(pair) };
+}
+
+// ── Shape 5: secondary diagnostic (rides along) ────────────────────────────────
+
+/// A clone/dup failure on a *valid* handle surfaces the real errno (the
+/// injected `EMFILE`), while a genuinely-unknown handle still reports EBADF (9).
+/// Distinguishes `NoEntry` from `CloneFailed` — a resource-exhaustion failure
+/// is no longer mislabeled as an invalid handle.
+#[test]
+fn clone_failure_errno_distinguishes_bad_handle_from_dup_failure() {
+    // Case 1: valid handle, forced clone/dup failure ⇒ the real (injected) errno.
+    let (conn, _peer) = make_bridge_pair();
+    let _ = hew_stream_last_errno(); // clear
+    force_next_clone_failures(true, false);
+    // SAFETY: conn is valid; forced first-clone failure.
+    let pair = unsafe { hew_tcp_stream_from_conn(conn) };
+    clear_clone_failures();
+    assert!(pair.is_null());
+    assert_eq!(
+        hew_stream_last_errno(),
+        INJECTED_CLONE_ERRNO,
+        "a dup(2) failure on a live handle must surface the real errno, not EBADF"
+    );
+    assert_ne!(
+        INJECTED_CLONE_ERRNO, 9,
+        "the injected clone errno must be distinct from EBADF for the test to have teeth"
+    );
+
+    // Case 2: genuinely-unknown handle ⇒ EBADF (9), unchanged.
+    let _ = hew_stream_last_errno();
+    // SAFETY: a large unregistered value is never a valid handle.
+    let pair = unsafe { hew_tcp_stream_from_conn(999_999) };
+    assert!(pair.is_null());
+    assert_eq!(
+        hew_stream_last_errno(),
+        9, // EBADF
+        "an unregistered handle must still report EBADF"
+    );
 }

--- a/hew-runtime/tests/tcp_stream_clone_ownership.rs
+++ b/hew-runtime/tests/tcp_stream_clone_ownership.rs
@@ -177,10 +177,17 @@ fn repeated_clone_failure_does_not_leak_fds() {
 
     let before = open_fd_count();
 
-    for _ in 0..N {
+    for i in 0..N {
         let (conn, peer) = make_bridge_pair();
-        // Alternate which clone fails so both branches are exercised in bulk.
-        force_next_clone_failures(true, false);
+        // Alternate which clone fails by iteration parity so both failure
+        // branches are exercised in bulk: even ⇒ first-clone failure (no clone
+        // survives), odd ⇒ second-clone (partial) failure (the live `read_stream`
+        // dup must not strand an fd). Both must leave a flat slope.
+        if i % 2 == 0 {
+            force_next_clone_failures(true, false);
+        } else {
+            force_next_clone_failures(false, true);
+        }
         // SAFETY: conn is valid; forced clone failure.
         let pair = unsafe { hew_tcp_stream_from_conn(conn) };
         assert!(pair.is_null(), "each conversion must fail and return null");

--- a/hew-runtime/tests/tcp_stream_clone_ownership.rs
+++ b/hew-runtime/tests/tcp_stream_clone_ownership.rs
@@ -1,0 +1,244 @@
+//! Consumed-connection ownership tests for the TCP-as-Stream/Sink bridge
+//! (`hew_tcp_stream_from_conn`, #2650).
+//!
+//! `into_stream_sink(self)` consumes its `Connection`: the source-level handle
+//! is dead-by-move on every return path, so the runtime is its sole releaser.
+//! Before the fix, the two `try_clone` early-returns released nothing — a
+//! clone failure (EMFILE/ENFILE under fd pressure) leaked the original socket
+//! fd *and* its `TCP_API_STATE` table slot, compounding to process-wide
+//! descriptor exhaustion. These tests prove the runtime now fully closes and
+//! releases the consumed connection on both clone-failure branches.
+//!
+//! Determinism comes from the `clone-failure-test` injection seam
+//! (`force_next_clone_failures`), which fails a chosen clone *with a live table
+//! entry present* — the valid-handle-clone-failed path. rlimit forcing (the
+//! validator's repro method) is non-deterministic and cannot target clone #2,
+//! so it is not the test vehicle here.
+//!
+//! Unix-gated to match `tcp_stream_bridge.rs` (fd counting + raw sockets have
+//! no portable Windows equivalent); Windows bridge coverage stays on the
+//! readiness punch-list. Requires `--features clone-failure-test`.
+#![cfg(all(unix, feature = "clone-failure-test"))]
+
+use std::ffi::CString;
+use std::io::Write;
+use std::net::{TcpListener, TcpStream};
+
+use hew_runtime::stream::{
+    hew_stream_next_sized, hew_stream_pair_free, hew_stream_pair_stream_bytes,
+    hew_tcp_stream_from_conn,
+};
+use hew_runtime::transport::{
+    clear_clone_failures, force_next_clone_failures, hew_tcp_close, hew_tcp_connect,
+    tcp_streams_has_handle_for_test,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Bind a loopback listener, connect via `hew_tcp_connect` (so the handle is
+/// registered in `TCP_API_STATE`), and return `(conn_handle, peer_stream)`.
+/// Mirrors `tcp_stream_bridge.rs::make_bridge_pair`.
+fn make_bridge_pair() -> (i32, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let addr = CString::new(format!("127.0.0.1:{port}")).unwrap();
+    // SAFETY: addr is a valid NUL-terminated C string.
+    let conn = unsafe { hew_tcp_connect(addr.as_ptr()) };
+    assert!(conn > 0, "hew_tcp_connect must succeed");
+    let (peer, _) = listener.accept().unwrap();
+    (conn, peer)
+}
+
+/// Count the process's currently-open file descriptors by listing `/dev/fd`
+/// (macOS/BSD) or `/proc/self/fd` (Linux). Used only for the leak-slope shape,
+/// which asserts a *flat* slope across N iterations rather than an absolute
+/// count, so transient fds from listing itself do not matter.
+fn open_fd_count() -> usize {
+    let dir = if std::path::Path::new("/proc/self/fd").exists() {
+        "/proc/self/fd"
+    } else {
+        "/dev/fd"
+    };
+    std::fs::read_dir(dir).map(|it| it.count()).unwrap_or(0)
+}
+
+/// Drain all items from a `HewStream` into a flat `Vec<u8>`, freeing each
+/// malloc'd buffer. Mirrors `tcp_stream_bridge.rs::drain_bytes`.
+///
+/// # Safety
+///
+/// `stream` must be a valid, non-null `*mut HewStream` from the runtime.
+unsafe fn drain_bytes(stream: *mut hew_runtime::stream::HewStream) -> Vec<u8> {
+    let mut out = Vec::new();
+    loop {
+        let mut size: usize = 0;
+        // SAFETY: stream is valid per caller; size is a stack-local.
+        let ptr = unsafe { hew_stream_next_sized(stream, std::ptr::addr_of_mut!(size)) };
+        if ptr.is_null() {
+            break;
+        }
+        // SAFETY: ptr points to `size` bytes malloc'd by the runtime.
+        let slice = unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), size) };
+        out.extend_from_slice(slice);
+        // SAFETY: ptr was malloc'd by hew_stream_next_sized; free it here.
+        unsafe { libc::free(ptr) };
+    }
+    out
+}
+
+// ── Shape 1: table-ownership probe, first-clone failure ────────────────────────
+
+/// First-clone failure with a valid handle must fully release the consumed
+/// connection: the table entry is gone and a follow-up close finds nothing.
+#[test]
+fn first_clone_failure_releases_table_entry() {
+    let (conn, _peer) = make_bridge_pair();
+    assert!(
+        tcp_streams_has_handle_for_test(conn),
+        "precondition: conn is registered in the streams table"
+    );
+
+    // Fail clone #1 (the read fd); clone #2 is never reached.
+    force_next_clone_failures(true, false);
+
+    // SAFETY: conn is a valid registered handle; the injection forces the
+    // first-clone-failure branch.
+    let pair = unsafe { hew_tcp_stream_from_conn(conn) };
+    clear_clone_failures();
+
+    assert!(pair.is_null(), "clone failure must return a null pair");
+    assert!(
+        !tcp_streams_has_handle_for_test(conn),
+        "the consumed connection must be released from the table on first-clone failure"
+    );
+
+    // Control (mirrors the validator's `second_close=-1`): the first close
+    // removed a real entry that existed exactly once, so a follow-up close
+    // finds nothing.
+    assert_eq!(
+        hew_tcp_close(conn),
+        -1,
+        "the entry was already released; a second close must report -1"
+    );
+}
+
+// ── Shape 2: table-ownership probe, second-clone failure (partial) ─────────────
+
+/// Second-clone failure (first clone succeeds, `read_stream` is a live dup)
+/// must still fully release the consumed connection: the surviving dup does not
+/// strand an owner and the table entry is gone.
+#[test]
+fn second_clone_failure_releases_table_entry() {
+    let (conn, _peer) = make_bridge_pair();
+    assert!(tcp_streams_has_handle_for_test(conn));
+
+    // Clone #1 succeeds; clone #2 (the write fd) fails.
+    force_next_clone_failures(false, true);
+
+    // SAFETY: conn is a valid registered handle; the injection forces the
+    // second-clone-failure (partial) branch.
+    let pair = unsafe { hew_tcp_stream_from_conn(conn) };
+    clear_clone_failures();
+
+    assert!(pair.is_null(), "clone failure must return a null pair");
+    assert!(
+        !tcp_streams_has_handle_for_test(conn),
+        "the consumed connection must be released on second-clone (partial) failure"
+    );
+    assert_eq!(
+        hew_tcp_close(conn),
+        -1,
+        "entry already released; second close reports -1"
+    );
+}
+
+// ── Shape 3: descriptor-leak slope ─────────────────────────────────────────────
+
+/// Repeated clone failures must not grow the process fd table (flat slope).
+/// This is the DoS guard: before the fix each failed conversion leaked the
+/// original socket fd, so the slope grew with N. Peers are dropped each
+/// iteration so only the *runtime-side* accounting is under test.
+#[test]
+fn repeated_clone_failure_does_not_leak_fds() {
+    const N: usize = 200;
+
+    // Warm up a few iterations so one-time lazy allocations (thread-locals,
+    // listener teardown buffers) settle before the baseline sample.
+    for _ in 0..8 {
+        let (conn, peer) = make_bridge_pair();
+        force_next_clone_failures(true, false);
+        // SAFETY: conn is valid; forced first-clone failure.
+        let pair = unsafe { hew_tcp_stream_from_conn(conn) };
+        assert!(pair.is_null());
+        drop(peer);
+    }
+    clear_clone_failures();
+
+    let before = open_fd_count();
+
+    for _ in 0..N {
+        let (conn, peer) = make_bridge_pair();
+        // Alternate which clone fails so both branches are exercised in bulk.
+        force_next_clone_failures(true, false);
+        // SAFETY: conn is valid; forced clone failure.
+        let pair = unsafe { hew_tcp_stream_from_conn(conn) };
+        assert!(pair.is_null(), "each conversion must fail and return null");
+        assert!(
+            !tcp_streams_has_handle_for_test(conn),
+            "each failed conversion must release its table entry"
+        );
+        drop(peer);
+    }
+    clear_clone_failures();
+
+    let after = open_fd_count();
+
+    // A leak of one fd per iteration would blow far past this bound; a small
+    // slack absorbs unrelated churn (loopback TIME_WAIT sockets do not hold
+    // fds, but be generous to avoid CI flakes).
+    let slack = 16;
+    assert!(
+        after <= before + slack,
+        "fd count grew across {N} forced clone failures: before={before} after={after} \
+         (a per-iteration leak would be ~{N}); consumed connections are not being released"
+    );
+}
+
+// ── Shape 4: normal success path unaffected ────────────────────────────────────
+
+/// With no injection the bridge succeeds, round-trips bytes, and releases the
+/// table entry *without shutdown* (the two clones keep the socket alive).
+/// Regression guard that the fix did not change success accounting.
+#[test]
+fn success_path_releases_entry_without_breaking_roundtrip() {
+    clear_clone_failures();
+    let payload = b"hello ownership";
+    let (conn, mut peer) = make_bridge_pair();
+
+    // SAFETY: conn is valid; no injection ⇒ normal success path.
+    let pair = unsafe { hew_tcp_stream_from_conn(conn) };
+    assert!(!pair.is_null(), "success path must return a non-null pair");
+
+    // The table entry is released on success (without shutdown; clones live).
+    assert!(
+        !tcp_streams_has_handle_for_test(conn),
+        "success path releases the table entry (unchanged accounting)"
+    );
+
+    // SAFETY: pair is valid; extract the stream half.
+    let stream_ptr = unsafe { hew_stream_pair_stream_bytes(pair) };
+    assert!(!stream_ptr.is_null());
+
+    peer.write_all(payload).unwrap();
+    drop(peer);
+
+    // SAFETY: stream_ptr is valid.
+    let received = unsafe { drain_bytes(stream_ptr) };
+    assert_eq!(
+        received, payload,
+        "bytes must round-trip on the success path"
+    );
+
+    // SAFETY: pair is valid; stream slot already extracted.
+    unsafe { hew_stream_pair_free(pair) };
+}

--- a/std/net/net.hew
+++ b/std/net/net.hew
@@ -366,8 +366,12 @@ trait ConnectionMethods {
     /// After this call, the original `conn` binding is statically unusable
     /// (move discipline: the `Connection` is consumed, matching `Closable::close`).
     /// The original handle is released from the TCP connection table as part
-    /// of the bridge call — the returned stream and sink each own an independent
-    /// socket clone.
+    /// of the bridge call — on **every** return path, success or failure. On
+    /// success the returned stream and sink each own an independent socket
+    /// clone; on clone failure the consumed connection is fully closed and
+    /// released before the null pair is returned, so no descriptor or table
+    /// slot leaks (the source handle is dead-by-move regardless, so the runtime
+    /// is its sole releaser).
     ///
     /// The returned pair composes with `stream.chunks()`, `stream.take(n)`,
     /// and `for await` loops.  Once `select{}` stream-next arms land, TCP
@@ -377,9 +381,10 @@ trait ConnectionMethods {
     /// stream will be used inside `select{}`: the park thread cannot interrupt
     /// a blocked `TcpStream::read` without a timeout.
     ///
-    /// If the factory returns a null pair (invalid fd), the extracted stream and
-    /// sink are also null.  Check with `stream.is_valid(s)` / `sink.is_valid(k)`
-    /// before use.
+    /// If the factory returns a null pair (clone failure), the extracted stream
+    /// and sink are also null; the consumed connection has already been fully
+    /// closed and released, so there is nothing for the caller to clean up.
+    /// Check with `stream.is_valid(s)` / `sink.is_valid(k)` before use.
     ///
     /// On `wasm32` targets this method is unavailable; the type checker rejects
     /// calls to `Connection` methods with `WasmUnsupportedFeature::TcpNetworking`
@@ -690,10 +695,13 @@ extern "C" {
     fn hew_connection_is_valid(conn: Connection) -> bool;
     fn hew_stream_last_error() -> string;
     fn hew_stream_last_errno() -> i32; // INTERNAL-ABI: OS errno from thread-local; 0 when none recorded
-    // TCP-to-Stream/Sink bridge.  Consumes the connection handle; returns a
-    // StreamPair whose halves are extracted with the pair extractor functions
-    // below.  Returns a null StreamPair on invalid fd (check with is_valid).
-    // Not available on wasm32; WASM-TODO(#1451).
+    // TCP-to-Stream/Sink bridge.  Consumes the connection handle on every
+    // return path; returns a StreamPair whose halves are extracted with the
+    // pair extractor functions below.  On clone failure the consumed
+    // connection is fully closed and released and a null StreamPair is returned
+    // (check with is_valid); the last-error errno is EBADF for an unknown
+    // handle, otherwise the real dup(2) errno.  Not available on wasm32;
+    // WASM-TODO(#1451).
     fn hew_tcp_stream_from_conn(conn: Connection) -> StreamPair;
     fn hew_stream_pair_stream_bytes(pair: StreamPair) -> Stream<bytes>;
     fn hew_stream_pair_sink_bytes(pair: StreamPair) -> Sink<bytes>;


### PR DESCRIPTION
## Summary

Releasing a `Connection` into a stream/sink pair now closes the underlying
handle on every return path, not just the success path. Previously, if either
of the two internal fd clones failed, the runtime returned `null` but left the
original connection's table entry (and fd) allocated — a resource leak
reachable by repeatedly hitting a clone failure (e.g. fd exhaustion under
load). The bridge now routes both clone-failure early-returns through the same
close path `hew_tcp_close` uses, while the success path keeps its existing
remove-without-shutdown semantics so the two live clones stay open correctly.
The clone-failure error now also reports the real `dup(2)` errno instead of a
generic failure code, distinguishing "no such handle" (EBADF) from a live
handle whose clone actually failed.

## Verification

- `cargo test -p hew-runtime --features clone-failure-test --test tcp_stream_clone_ownership`: 5/5 pass (first-clone-failure release, second-clone-failure release, fd-slope over 200 iterations, success round-trip, EBADF-vs-real-errno)
- `cargo test -p hew-runtime --test tcp_stream_bridge`: 6/6 pass (no regression on the existing bridge)
- Full obelisk preflight: ready-to-push on this exact head
- `clone-failure-test` feature target: passed, and confirmed inert in default/production builds (no injection symbols present in a default-feature build)
- Leak/sanitizer scans (MallocScribble/MallocPreScribble/MallocGuardEdges + stress reruns of the double-close-hazard path): clean

## Out of scope

- TCP broadcast semantics are a separate concern, tracked in #2657

Fixes #2650
