### PR TITLE
fix(std/net): route delayed network errors to actor-scoped error slots

### DIFF
--- a/hew-std/src/lib.rs
+++ b/hew-std/src/lib.rs
@@ -83,6 +83,12 @@ pub mod dns;
 pub mod http;
 #[cfg(not(target_family = "wasm"))]
 pub mod ipnet;
+// Shared #[cfg(test)] scaffolding for the tls/smtp/quic actor-scoped
+// last-error regression tests (#2659) — a single runtime-guard/actor-context
+// helper reused by all three so their tests serialize on one process-global
+// scheduler slot instead of racing on independent per-module locks.
+#[cfg(all(test, not(target_family = "wasm")))]
+mod net_error_slot_test_support;
 #[cfg(not(target_family = "wasm"))]
 pub mod quic;
 #[cfg(not(target_family = "wasm"))]

--- a/hew-std/src/net_error_slot_test_support.rs
+++ b/hew-std/src/net_error_slot_test_support.rs
@@ -1,0 +1,108 @@
+//! Shared `#[cfg(test)]` scaffolding for the TLS/SMTP/QUIC actor-scoped
+//! last-error regression tests (#2659).
+//!
+//! `hew_sched_init`/`hew_sched_shutdown`/`hew_runtime_cleanup` operate on a
+//! single process-global scheduler slot, and `hew_runtime_cleanup` reclaims
+//! *every* tracked actor, not just the caller's. A guard with its own
+//! private lock only serializes tests within the module that declared it —
+//! it does nothing to stop a TLS regression test's teardown from racing a
+//! concurrently running SMTP or QUIC regression test's still-live actor.
+//! Every protocol's actor-drift regression test shares this ONE lock/guard
+//! so they mutually exclude each other on the single scheduler slot, not
+//! just their own siblings within the same file.
+
+use std::ffi::c_void;
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+use hew_runtime::actor::{self, HewActor};
+use hew_runtime::{scheduler, set_current_context, HewExecutionContext};
+
+static NET_ERROR_SLOT_RUNTIME_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// RAII scheduler install/teardown guard shared by every TLS/SMTP/QUIC
+/// actor-drift regression test. Holding the single process-wide lock for
+/// the guard's full lifetime means one test's `hew_runtime_cleanup` can
+/// never reclaim an actor a concurrently running sibling test still owns.
+pub(crate) struct NetErrorSlotRuntimeGuard {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl NetErrorSlotRuntimeGuard {
+    pub(crate) fn new() -> Self {
+        let lock = NET_ERROR_SLOT_RUNTIME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        assert_eq!(scheduler::hew_sched_init(), 0);
+        Self { _lock: lock }
+    }
+}
+
+impl Drop for NetErrorSlotRuntimeGuard {
+    fn drop(&mut self) {
+        scheduler::hew_sched_shutdown();
+        scheduler::hew_runtime_cleanup();
+    }
+}
+
+/// Spawn a minimal, never-scheduled actor solely to obtain a stable,
+/// dereferenceable actor identity for `hew_actor_current_id()`. The dispatch
+/// stub is never invoked — this actor receives no messages.
+pub(crate) fn spawn_error_slot_test_actor() -> *mut HewActor {
+    unsafe extern "C-unwind" fn noop_dispatch(
+        _ctx: *mut HewExecutionContext,
+        _state: *mut c_void,
+        _msg_type: i32,
+        _data: *mut c_void,
+        _data_size: usize,
+        _borrow_mode: i32,
+    ) -> *mut c_void {
+        std::ptr::null_mut()
+    }
+
+    // SAFETY: null state / size 0 is a documented no-state spawn.
+    unsafe { actor::hew_actor_spawn(std::ptr::null_mut(), 0, Some(noop_dispatch)) }
+}
+
+/// RAII actor-execution-context install/restore guard. Restoration happens
+/// in `Drop`, not only after a closure returns normally — Rust runs `Drop`
+/// impls while unwinding, so a panic while `actor` is installed still
+/// restores the previous thread-local context before the unwind continues.
+/// A guard-based bracket (rather than install-call-restore) means a later
+/// test on the same OS thread never observes a stale actor pointer left
+/// installed by a panicked predecessor.
+pub(crate) struct ActorContextGuard {
+    // Owns the installed context's backing storage for the guard's whole
+    // lifetime; `set_current_context` only stores the pointer, so this must
+    // outlive every access made while it is installed.
+    _ctx: Box<HewExecutionContext>,
+    prev: *mut HewExecutionContext,
+}
+
+impl ActorContextGuard {
+    pub(crate) fn install(actor: *mut HewActor) -> Self {
+        let mut ctx = Box::new(HewExecutionContext {
+            actor,
+            ..Default::default()
+        });
+        let ctx_ptr: *mut HewExecutionContext = &raw mut *ctx;
+        let prev = set_current_context(ctx_ptr);
+        Self { _ctx: ctx, prev }
+    }
+}
+
+impl Drop for ActorContextGuard {
+    fn drop(&mut self) {
+        let _ = set_current_context(self.prev);
+    }
+}
+
+/// Install `actor` as the current dispatch's actor for the duration of `f`
+/// — the same install/restore bracket codegen places around every real
+/// dispatch (`hew_context_install`/`hew_context_restore`) — so
+/// `hew_actor_current_id()` resolves to `actor`'s id inside `f` exactly as
+/// it would mid-dispatch. Context restoration is unwind-safe: it happens in
+/// `ActorContextGuard::drop`, which still runs if `f` panics.
+pub(crate) fn with_actor_context<R>(actor: *mut HewActor, f: impl FnOnce() -> R) -> R {
+    let _guard = ActorContextGuard::install(actor);
+    f()
+}

--- a/hew-std/src/quic.rs
+++ b/hew-std/src/quic.rs
@@ -1816,7 +1816,7 @@ pub unsafe extern "C" fn hew_quic_event_free(event: *mut HewQuicEvent) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::{CStr, CString};
+    use std::ffi::{c_void, CStr, CString};
     use std::thread;
 
     use hew_runtime::bytes::hew_bytes_drop;
@@ -2416,59 +2416,137 @@ mod tests {
         unsafe { hew_quic_endpoint_close(ep) };
     }
 
-    /// A QUIC constructor error recorded for a given actor ID on one OS
-    /// thread must remain readable for that same actor ID on a different OS
-    /// thread — the scenario when an actor is parked mid-construct and
-    /// resumed on another scheduler worker.
+    /// Spawn a minimal, never-scheduled actor solely to obtain a stable,
+    /// dereferenceable actor identity for `hew_actor_current_id()`. The
+    /// dispatch stub is never invoked — this actor receives no messages.
+    fn spawn_error_slot_test_actor() -> *mut hew_runtime::actor::HewActor {
+        unsafe extern "C-unwind" fn noop_dispatch(
+            _ctx: *mut hew_runtime::HewExecutionContext,
+            _state: *mut c_void,
+            _msg_type: i32,
+            _data: *mut c_void,
+            _data_size: usize,
+            _borrow_mode: i32,
+        ) -> *mut c_void {
+            std::ptr::null_mut()
+        }
+
+        // SAFETY: null state / size 0 is a documented no-state spawn.
+        unsafe { hew_runtime::actor::hew_actor_spawn(std::ptr::null_mut(), 0, Some(noop_dispatch)) }
+    }
+
+    /// Install `actor` as the current dispatch's actor for the duration of
+    /// `f`, restoring whatever was previously installed afterward — the same
+    /// install/restore bracket codegen places around every real dispatch
+    /// (`hew_context_install`/`hew_context_restore`), so
+    /// `hew_actor_current_id()` resolves to `actor`'s id inside `f` exactly
+    /// as it would mid-dispatch.
+    fn with_actor_context<R>(actor: *mut hew_runtime::actor::HewActor, f: impl FnOnce() -> R) -> R {
+        let mut ctx = hew_runtime::HewExecutionContext {
+            actor,
+            ..Default::default()
+        };
+        let prev = hew_runtime::set_current_context(&raw mut ctx);
+        let result = f();
+        let _ = hew_runtime::set_current_context(prev);
+        result
+    }
+
+    static QUIC_RUNTIME_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct QuicRuntimeGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl QuicRuntimeGuard {
+        fn new() -> Self {
+            // The scheduler is process-global: repeated init is a no-op, but
+            // cleanup frees every tracked actor. Hold exclusive ownership for
+            // the full test so no other test can reclaim this actor.
+            let lock = QUIC_RUNTIME_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            assert_eq!(hew_runtime::scheduler::hew_sched_init(), 0);
+            Self { _lock: lock }
+        }
+    }
+
+    impl Drop for QuicRuntimeGuard {
+        fn drop(&mut self) {
+            hew_runtime::scheduler::hew_sched_shutdown();
+            hew_runtime::scheduler::hew_runtime_cleanup();
+        }
+    }
+
+    /// A QUIC constructor error recorded by the REAL `hew_quic_new_server`
+    /// failure path — while a given actor is the installed dispatch context
+    /// on OS thread A — must be readable through the REAL public
+    /// `hew_quic_last_error` accessor when that SAME actor is the installed
+    /// dispatch context on a DIFFERENT OS thread B.
     ///
-    /// Drives the actor-keyed slot directly via the `__*_for_actor` test
-    /// helpers (the same internal path `set_constructor_last_error` takes
-    /// when `hew_actor_current_id()` returns this actor ID), since a unit
-    /// test cannot inject actor context without a running scheduler.
+    /// This is the actual #2659 regression: an actor parked mid-construct
+    /// and resumed on another scheduler worker must not lose its recorded
+    /// error. Driving the module's own producer (`hew_quic_new_server`) and
+    /// public accessor (`hew_quic_last_error`) — rather than poking the
+    /// shared `parse_error_slot` map directly — means this test is RED
+    /// against the predecessor `thread_local!` implementation: a plain
+    /// `thread_local!` slot is intrinsically per-OS-thread storage, so thread
+    /// B's slot would stay empty no matter which actor either thread
+    /// believes is dispatching. It is GREEN only because
+    /// `set_/get_constructor_last_error` now key on actor identity via
+    /// `parse_error_slot`.
     ///
-    /// With the predecessor `thread_local!` this would have been empty on
-    /// thread B; with the actor-keyed slot it is not. Scoped to the
-    /// constructor slot only — the per-endpoint `state.last_error` mechanism
-    /// is untouched and out of scope for this lane.
+    /// Scoped to the constructor slot only — the per-endpoint
+    /// `state.last_error` mechanism is untouched and out of scope for this
+    /// lane.
     ///
     /// Run 3× to satisfy the flake gate.
     #[test]
     fn quic_constructor_error_visible_across_worker_threads_regression_2659() {
+        // hew_actor_spawn requires an installed runtime authority.
+        let _runtime = QuicRuntimeGuard::new();
+
         for run in 0..3_u32 {
-            const ACTOR_ID: u64 = 780_001;
+            let test_actor = spawn_error_slot_test_actor();
+            assert!(!test_actor.is_null(), "test actor should spawn");
+            let actor_addr = test_actor as usize;
 
             let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
             let barrier2 = barrier.clone();
 
             let handle = thread::spawn(move || {
-                // Simulate: actor ACTOR_ID resumes on thread B.
+                // Simulate: the actor resumes on thread B, a different OS
+                // thread than the one that recorded the error.
                 barrier2.wait();
-                hew_runtime::parse_error_slot::__get_error_for_actor(
-                    ACTOR_ID,
-                    hew_runtime::parse_error_slot::ErrorSlotKind::Quic,
-                )
+                let actor_ptr = actor_addr as *mut hew_runtime::actor::HewActor;
+                // SAFETY: the getter returns an owned malloc string.
+                with_actor_context(actor_ptr, || unsafe { take_string(hew_quic_last_error()) })
             });
 
-            // Thread A: write a constructor error as if actor ACTOR_ID hit a
-            // failed hew_quic_new_client/_server call.
-            hew_runtime::parse_error_slot::__set_error_for_actor(
-                ACTOR_ID,
-                hew_runtime::parse_error_slot::ErrorSlotKind::Quic,
-                "hew_quic_new_server: actor-migration regression",
-            );
+            // Thread A: install the SAME actor as the dispatch context and
+            // drive the real hew_quic_new_server failure path — the actual
+            // producer, not a direct slot poke.
+            with_actor_context(test_actor, || {
+                // SAFETY: null is explicitly handled.
+                let ep = unsafe { hew_quic_new_server(std::ptr::null()) };
+                assert!(ep.is_null());
+            });
             barrier.wait();
 
             let result = handle.join().expect("thread B panicked");
             assert_eq!(
-                result.as_deref(),
-                Some("hew_quic_new_server: actor-migration regression"),
-                "run {run}: QUIC constructor error written on thread A must be visible on thread B for same actor"
+                result, "invalid bind address",
+                "run {run}: QUIC constructor error recorded on thread A must be visible on thread B for the same actor"
             );
 
-            hew_runtime::parse_error_slot::__clear_error_for_actor(
-                ACTOR_ID,
-                hew_runtime::parse_error_slot::ErrorSlotKind::Quic,
-            );
+            // SAFETY: test_actor was spawned above and not yet stopped/freed.
+            unsafe { hew_runtime::actor::hew_actor_stop(test_actor) };
+            // hew_actor_free reaps every parse_error_slot entry for this
+            // actor via parse_error_slot::clear_all_for_actor — no manual
+            // clear needed.
+            // SAFETY: test_actor is stopped immediately above; free reclaims
+            // it exactly once.
+            assert_eq!(unsafe { hew_runtime::actor::hew_actor_free(test_actor) }, 0);
         }
     }
 

--- a/hew-std/src/quic.rs
+++ b/hew-std/src/quic.rs
@@ -34,21 +34,20 @@ const EVENT_STREAM_OPENED: i32 = 2;
 const EVENT_STREAM_CLOSED: i32 = 3;
 const EVENT_ERROR: i32 = -1;
 
-std::thread_local! {
-    static LAST_CONSTRUCTOR_ERROR: std::cell::RefCell<Option<String>> =
-        const { std::cell::RefCell::new(None) };
-}
-
 fn set_constructor_last_error(msg: impl Into<String>) {
-    LAST_CONSTRUCTOR_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
+    hew_runtime::parse_error_slot::set_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Quic,
+        msg,
+    );
 }
 
 fn clear_constructor_last_error() {
-    LAST_CONSTRUCTOR_ERROR.with(|error| *error.borrow_mut() = None);
+    hew_runtime::parse_error_slot::clear_error(hew_runtime::parse_error_slot::ErrorSlotKind::Quic);
 }
 
 fn get_constructor_last_error() -> String {
-    LAST_CONSTRUCTOR_ERROR.with(|error| error.borrow().clone().unwrap_or_default())
+    hew_runtime::parse_error_slot::get_error(hew_runtime::parse_error_slot::ErrorSlotKind::Quic)
+        .unwrap_or_default()
 }
 
 #[derive(Debug, Default)]
@@ -2415,6 +2414,62 @@ mod tests {
         assert!(unsafe { take_string(hew_quic_last_error()) }.is_empty());
         // SAFETY: ep was just created.
         unsafe { hew_quic_endpoint_close(ep) };
+    }
+
+    /// A QUIC constructor error recorded for a given actor ID on one OS
+    /// thread must remain readable for that same actor ID on a different OS
+    /// thread — the scenario when an actor is parked mid-construct and
+    /// resumed on another scheduler worker.
+    ///
+    /// Drives the actor-keyed slot directly via the `__*_for_actor` test
+    /// helpers (the same internal path `set_constructor_last_error` takes
+    /// when `hew_actor_current_id()` returns this actor ID), since a unit
+    /// test cannot inject actor context without a running scheduler.
+    ///
+    /// With the predecessor `thread_local!` this would have been empty on
+    /// thread B; with the actor-keyed slot it is not. Scoped to the
+    /// constructor slot only — the per-endpoint `state.last_error` mechanism
+    /// is untouched and out of scope for this lane.
+    ///
+    /// Run 3× to satisfy the flake gate.
+    #[test]
+    fn quic_constructor_error_visible_across_worker_threads_regression_2659() {
+        for run in 0..3_u32 {
+            const ACTOR_ID: u64 = 780_001;
+
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+            let barrier2 = barrier.clone();
+
+            let handle = thread::spawn(move || {
+                // Simulate: actor ACTOR_ID resumes on thread B.
+                barrier2.wait();
+                hew_runtime::parse_error_slot::__get_error_for_actor(
+                    ACTOR_ID,
+                    hew_runtime::parse_error_slot::ErrorSlotKind::Quic,
+                )
+            });
+
+            // Thread A: write a constructor error as if actor ACTOR_ID hit a
+            // failed hew_quic_new_client/_server call.
+            hew_runtime::parse_error_slot::__set_error_for_actor(
+                ACTOR_ID,
+                hew_runtime::parse_error_slot::ErrorSlotKind::Quic,
+                "hew_quic_new_server: actor-migration regression",
+            );
+            barrier.wait();
+
+            let result = handle.join().expect("thread B panicked");
+            assert_eq!(
+                result.as_deref(),
+                Some("hew_quic_new_server: actor-migration regression"),
+                "run {run}: QUIC constructor error written on thread A must be visible on thread B for same actor"
+            );
+
+            hew_runtime::parse_error_slot::__clear_error_for_actor(
+                ACTOR_ID,
+                hew_runtime::parse_error_slot::ErrorSlotKind::Quic,
+            );
+        }
     }
 
     #[test]

--- a/hew-std/src/quic.rs
+++ b/hew-std/src/quic.rs
@@ -1816,7 +1816,7 @@ pub unsafe extern "C" fn hew_quic_event_free(event: *mut HewQuicEvent) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::{c_void, CStr, CString};
+    use std::ffi::{CStr, CString};
     use std::thread;
 
     use hew_runtime::bytes::hew_bytes_drop;
@@ -2416,68 +2416,6 @@ mod tests {
         unsafe { hew_quic_endpoint_close(ep) };
     }
 
-    /// Spawn a minimal, never-scheduled actor solely to obtain a stable,
-    /// dereferenceable actor identity for `hew_actor_current_id()`. The
-    /// dispatch stub is never invoked — this actor receives no messages.
-    fn spawn_error_slot_test_actor() -> *mut hew_runtime::actor::HewActor {
-        unsafe extern "C-unwind" fn noop_dispatch(
-            _ctx: *mut hew_runtime::HewExecutionContext,
-            _state: *mut c_void,
-            _msg_type: i32,
-            _data: *mut c_void,
-            _data_size: usize,
-            _borrow_mode: i32,
-        ) -> *mut c_void {
-            std::ptr::null_mut()
-        }
-
-        // SAFETY: null state / size 0 is a documented no-state spawn.
-        unsafe { hew_runtime::actor::hew_actor_spawn(std::ptr::null_mut(), 0, Some(noop_dispatch)) }
-    }
-
-    /// Install `actor` as the current dispatch's actor for the duration of
-    /// `f`, restoring whatever was previously installed afterward — the same
-    /// install/restore bracket codegen places around every real dispatch
-    /// (`hew_context_install`/`hew_context_restore`), so
-    /// `hew_actor_current_id()` resolves to `actor`'s id inside `f` exactly
-    /// as it would mid-dispatch.
-    fn with_actor_context<R>(actor: *mut hew_runtime::actor::HewActor, f: impl FnOnce() -> R) -> R {
-        let mut ctx = hew_runtime::HewExecutionContext {
-            actor,
-            ..Default::default()
-        };
-        let prev = hew_runtime::set_current_context(&raw mut ctx);
-        let result = f();
-        let _ = hew_runtime::set_current_context(prev);
-        result
-    }
-
-    static QUIC_RUNTIME_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    struct QuicRuntimeGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-    }
-
-    impl QuicRuntimeGuard {
-        fn new() -> Self {
-            // The scheduler is process-global: repeated init is a no-op, but
-            // cleanup frees every tracked actor. Hold exclusive ownership for
-            // the full test so no other test can reclaim this actor.
-            let lock = QUIC_RUNTIME_TEST_LOCK
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            assert_eq!(hew_runtime::scheduler::hew_sched_init(), 0);
-            Self { _lock: lock }
-        }
-    }
-
-    impl Drop for QuicRuntimeGuard {
-        fn drop(&mut self) {
-            hew_runtime::scheduler::hew_sched_shutdown();
-            hew_runtime::scheduler::hew_runtime_cleanup();
-        }
-    }
-
     /// A QUIC constructor error recorded by the REAL `hew_quic_new_server`
     /// failure path — while a given actor is the installed dispatch context
     /// on OS thread A — must be readable through the REAL public
@@ -2503,8 +2441,14 @@ mod tests {
     /// Run 3× to satisfy the flake gate.
     #[test]
     fn quic_constructor_error_visible_across_worker_threads_regression_2659() {
-        // hew_actor_spawn requires an installed runtime authority.
-        let _runtime = QuicRuntimeGuard::new();
+        use crate::net_error_slot_test_support::{
+            spawn_error_slot_test_actor, with_actor_context, NetErrorSlotRuntimeGuard,
+        };
+
+        // hew_actor_spawn requires an installed runtime authority; shared
+        // across tls/smtp/quic so their regression tests serialize on the
+        // single process-global scheduler slot instead of racing.
+        let _runtime = NetErrorSlotRuntimeGuard::new();
 
         for run in 0..3_u32 {
             let test_actor = spawn_error_slot_test_actor();

--- a/hew-std/src/smtp.rs
+++ b/hew-std/src/smtp.rs
@@ -449,7 +449,7 @@ pub unsafe extern "C" fn hew_smtp_close(conn: *mut HewSmtpConn) {
 mod tests {
     use super::*;
     use std::cell::RefCell;
-    use std::ffi::{c_void, CStr, CString};
+    use std::ffi::{CStr, CString};
     use std::ptr;
     use std::rc::Rc;
 
@@ -796,68 +796,6 @@ mod tests {
         assert!(events.borrow().is_empty());
     }
 
-    /// Spawn a minimal, never-scheduled actor solely to obtain a stable,
-    /// dereferenceable actor identity for `hew_actor_current_id()`. The
-    /// dispatch stub is never invoked — this actor receives no messages.
-    fn spawn_error_slot_test_actor() -> *mut hew_runtime::actor::HewActor {
-        unsafe extern "C-unwind" fn noop_dispatch(
-            _ctx: *mut hew_runtime::HewExecutionContext,
-            _state: *mut c_void,
-            _msg_type: i32,
-            _data: *mut c_void,
-            _data_size: usize,
-            _borrow_mode: i32,
-        ) -> *mut c_void {
-            std::ptr::null_mut()
-        }
-
-        // SAFETY: null state / size 0 is a documented no-state spawn.
-        unsafe { hew_runtime::actor::hew_actor_spawn(std::ptr::null_mut(), 0, Some(noop_dispatch)) }
-    }
-
-    /// Install `actor` as the current dispatch's actor for the duration of
-    /// `f`, restoring whatever was previously installed afterward — the same
-    /// install/restore bracket codegen places around every real dispatch
-    /// (`hew_context_install`/`hew_context_restore`), so
-    /// `hew_actor_current_id()` resolves to `actor`'s id inside `f` exactly
-    /// as it would mid-dispatch.
-    fn with_actor_context<R>(actor: *mut hew_runtime::actor::HewActor, f: impl FnOnce() -> R) -> R {
-        let mut ctx = hew_runtime::HewExecutionContext {
-            actor,
-            ..Default::default()
-        };
-        let prev = hew_runtime::set_current_context(&raw mut ctx);
-        let result = f();
-        let _ = hew_runtime::set_current_context(prev);
-        result
-    }
-
-    static SMTP_RUNTIME_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    struct SmtpRuntimeGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-    }
-
-    impl SmtpRuntimeGuard {
-        fn new() -> Self {
-            // The scheduler is process-global: repeated init is a no-op, but
-            // cleanup frees every tracked actor. Hold exclusive ownership for
-            // the full test so no other test can reclaim this actor.
-            let lock = SMTP_RUNTIME_TEST_LOCK
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            assert_eq!(hew_runtime::scheduler::hew_sched_init(), 0);
-            Self { _lock: lock }
-        }
-    }
-
-    impl Drop for SmtpRuntimeGuard {
-        fn drop(&mut self) {
-            hew_runtime::scheduler::hew_sched_shutdown();
-            hew_runtime::scheduler::hew_runtime_cleanup();
-        }
-    }
-
     /// An SMTP error recorded by the REAL `hew_smtp_send` failure path —
     /// while a given actor is the installed dispatch context on OS thread A —
     /// must be readable through the REAL public `hew_smtp_last_error`
@@ -878,8 +816,14 @@ mod tests {
     /// Run 3× to satisfy the flake gate.
     #[test]
     fn smtp_error_visible_across_worker_threads_regression_2659() {
-        // hew_actor_spawn requires an installed runtime authority.
-        let _runtime = SmtpRuntimeGuard::new();
+        use crate::net_error_slot_test_support::{
+            spawn_error_slot_test_actor, with_actor_context, NetErrorSlotRuntimeGuard,
+        };
+
+        // hew_actor_spawn requires an installed runtime authority; shared
+        // across tls/smtp/quic so their regression tests serialize on the
+        // single process-global scheduler slot instead of racing.
+        let _runtime = NetErrorSlotRuntimeGuard::new();
 
         for run in 0..3_u32 {
             let test_actor = spawn_error_slot_test_actor();

--- a/hew-std/src/smtp.rs
+++ b/hew-std/src/smtp.rs
@@ -449,7 +449,7 @@ pub unsafe extern "C" fn hew_smtp_close(conn: *mut HewSmtpConn) {
 mod tests {
     use super::*;
     use std::cell::RefCell;
-    use std::ffi::{CStr, CString};
+    use std::ffi::{c_void, CStr, CString};
     use std::ptr;
     use std::rc::Rc;
 
@@ -796,57 +796,149 @@ mod tests {
         assert!(events.borrow().is_empty());
     }
 
-    /// An SMTP error recorded for a given actor ID on one OS thread must
-    /// remain readable for that same actor ID on a different OS thread — the
-    /// scenario when an actor is parked mid-send and resumed on another
-    /// scheduler worker.
+    /// Spawn a minimal, never-scheduled actor solely to obtain a stable,
+    /// dereferenceable actor identity for `hew_actor_current_id()`. The
+    /// dispatch stub is never invoked — this actor receives no messages.
+    fn spawn_error_slot_test_actor() -> *mut hew_runtime::actor::HewActor {
+        unsafe extern "C-unwind" fn noop_dispatch(
+            _ctx: *mut hew_runtime::HewExecutionContext,
+            _state: *mut c_void,
+            _msg_type: i32,
+            _data: *mut c_void,
+            _data_size: usize,
+            _borrow_mode: i32,
+        ) -> *mut c_void {
+            std::ptr::null_mut()
+        }
+
+        // SAFETY: null state / size 0 is a documented no-state spawn.
+        unsafe { hew_runtime::actor::hew_actor_spawn(std::ptr::null_mut(), 0, Some(noop_dispatch)) }
+    }
+
+    /// Install `actor` as the current dispatch's actor for the duration of
+    /// `f`, restoring whatever was previously installed afterward — the same
+    /// install/restore bracket codegen places around every real dispatch
+    /// (`hew_context_install`/`hew_context_restore`), so
+    /// `hew_actor_current_id()` resolves to `actor`'s id inside `f` exactly
+    /// as it would mid-dispatch.
+    fn with_actor_context<R>(actor: *mut hew_runtime::actor::HewActor, f: impl FnOnce() -> R) -> R {
+        let mut ctx = hew_runtime::HewExecutionContext {
+            actor,
+            ..Default::default()
+        };
+        let prev = hew_runtime::set_current_context(&raw mut ctx);
+        let result = f();
+        let _ = hew_runtime::set_current_context(prev);
+        result
+    }
+
+    static SMTP_RUNTIME_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct SmtpRuntimeGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl SmtpRuntimeGuard {
+        fn new() -> Self {
+            // The scheduler is process-global: repeated init is a no-op, but
+            // cleanup frees every tracked actor. Hold exclusive ownership for
+            // the full test so no other test can reclaim this actor.
+            let lock = SMTP_RUNTIME_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            assert_eq!(hew_runtime::scheduler::hew_sched_init(), 0);
+            Self { _lock: lock }
+        }
+    }
+
+    impl Drop for SmtpRuntimeGuard {
+        fn drop(&mut self) {
+            hew_runtime::scheduler::hew_sched_shutdown();
+            hew_runtime::scheduler::hew_runtime_cleanup();
+        }
+    }
+
+    /// An SMTP error recorded by the REAL `hew_smtp_send` failure path —
+    /// while a given actor is the installed dispatch context on OS thread A —
+    /// must be readable through the REAL public `hew_smtp_last_error`
+    /// accessor when that SAME actor is the installed dispatch context on a
+    /// DIFFERENT OS thread B.
     ///
-    /// Drives the actor-keyed slot directly via the `__*_for_actor` test
-    /// helpers (the same internal path `set_smtp_last_error` takes when
-    /// `hew_actor_current_id()` returns this actor ID), since a unit test
-    /// cannot inject actor context without a running scheduler.
-    ///
-    /// With the predecessor `thread_local!` this would have been empty on
-    /// thread B; with the actor-keyed slot it is not.
+    /// This is the actual #2659 regression: an actor parked mid-send and
+    /// resumed on another scheduler worker must not lose its recorded error.
+    /// Driving the module's own producer (`hew_smtp_send`) and public
+    /// accessor (`hew_smtp_last_error`) — rather than poking the shared
+    /// `parse_error_slot` map directly — means this test is RED against the
+    /// predecessor `thread_local!` implementation: a plain `thread_local!`
+    /// slot is intrinsically per-OS-thread storage, so thread B's slot would
+    /// stay empty no matter which actor either thread believes is
+    /// dispatching. It is GREEN only because `set_/get_smtp_last_error` now
+    /// key on actor identity via `parse_error_slot`.
     ///
     /// Run 3× to satisfy the flake gate.
     #[test]
     fn smtp_error_visible_across_worker_threads_regression_2659() {
+        // hew_actor_spawn requires an installed runtime authority.
+        let _runtime = SmtpRuntimeGuard::new();
+
         for run in 0..3_u32 {
-            const ACTOR_ID: u64 = 779_001;
+            let test_actor = spawn_error_slot_test_actor();
+            assert!(!test_actor.is_null(), "test actor should spawn");
+            let actor_addr = test_actor as usize;
+
+            let conn = make_test_conn();
+            let from = CString::new("not-an-email").unwrap();
+            let to = CString::new("recipient@example.com").unwrap();
+            let subject = CString::new("Hello").unwrap();
+            let body = CString::new("Body").unwrap();
 
             let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
             let barrier2 = barrier.clone();
 
             let handle = std::thread::spawn(move || {
-                // Simulate: actor ACTOR_ID resumes on thread B.
+                // Simulate: the actor resumes on thread B, a different OS
+                // thread than the one that recorded the error.
                 barrier2.wait();
-                hew_runtime::parse_error_slot::__get_error_for_actor(
-                    ACTOR_ID,
-                    hew_runtime::parse_error_slot::ErrorSlotKind::Smtp,
-                )
+                let actor_ptr = actor_addr as *mut hew_runtime::actor::HewActor;
+                with_actor_context(actor_ptr, last_error_text)
             });
 
-            // Thread A: write an SMTP error as if actor ACTOR_ID hit a failed
-            // send.
-            hew_runtime::parse_error_slot::__set_error_for_actor(
-                ACTOR_ID,
-                hew_runtime::parse_error_slot::ErrorSlotKind::Smtp,
-                "smtp send: actor-migration regression",
-            );
+            // Thread A: install the SAME actor as the dispatch context and
+            // drive the real hew_smtp_send failure path — the actual
+            // producer, not a direct slot poke.
+            with_actor_context(test_actor, || {
+                // SAFETY: `conn` is a valid test connection and the strings
+                // are valid C strings; the malformed `from` address is the
+                // documented failure path.
+                let rc = unsafe {
+                    hew_smtp_send(
+                        conn,
+                        from.as_ptr(),
+                        to.as_ptr(),
+                        subject.as_ptr(),
+                        body.as_ptr(),
+                    )
+                };
+                assert_eq!(rc, -1);
+            });
             barrier.wait();
 
             let result = handle.join().expect("thread B panicked");
-            assert_eq!(
-                result.as_deref(),
-                Some("smtp send: actor-migration regression"),
-                "run {run}: SMTP error written on thread A must be visible on thread B for same actor"
+            assert!(
+                result.contains("parse") || result.contains("address"),
+                "run {run}: SMTP error recorded on thread A must be visible on thread B for the same actor, got {result:?}"
             );
 
-            hew_runtime::parse_error_slot::__clear_error_for_actor(
-                ACTOR_ID,
-                hew_runtime::parse_error_slot::ErrorSlotKind::Smtp,
-            );
+            // SAFETY: `conn` came from `make_test_conn` and has not been freed yet.
+            unsafe { hew_smtp_close(conn) };
+            // SAFETY: test_actor was spawned above and not yet stopped/freed.
+            unsafe { hew_runtime::actor::hew_actor_stop(test_actor) };
+            // hew_actor_free reaps every parse_error_slot entry for this
+            // actor via parse_error_slot::clear_all_for_actor — no manual
+            // clear needed.
+            // SAFETY: test_actor is stopped immediately above; free reclaims
+            // it exactly once.
+            assert_eq!(unsafe { hew_runtime::actor::hew_actor_free(test_actor) }, 0);
         }
     }
 }

--- a/hew-std/src/smtp.rs
+++ b/hew-std/src/smtp.rs
@@ -4,27 +4,26 @@
 //! All returned strings and connection handles are allocated with `libc::malloc`
 //! / `Box` so callers can free them with the corresponding free function.
 use hew_cabi::cabi::{cstr_to_str, str_to_malloc};
-use std::cell::RefCell;
 use std::os::raw::c_char;
 
 use lettre::message::{header::ContentType, Mailbox};
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{Message, SmtpTransport, Transport};
 
-std::thread_local! {
-    static LAST_SMTP_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
-}
-
 fn set_smtp_last_error(msg: impl Into<String>) {
-    LAST_SMTP_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
+    hew_runtime::parse_error_slot::set_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Smtp,
+        msg,
+    );
 }
 
 fn clear_smtp_last_error() {
-    LAST_SMTP_ERROR.with(|error| *error.borrow_mut() = None);
+    hew_runtime::parse_error_slot::clear_error(hew_runtime::parse_error_slot::ErrorSlotKind::Smtp);
 }
 
 fn get_smtp_last_error() -> String {
-    LAST_SMTP_ERROR.with(|error| error.borrow().clone().unwrap_or_default())
+    hew_runtime::parse_error_slot::get_error(hew_runtime::parse_error_slot::ErrorSlotKind::Smtp)
+        .unwrap_or_default()
 }
 
 fn smtp_error_result(msg: impl Into<String>) -> i32 {
@@ -449,6 +448,7 @@ pub unsafe extern "C" fn hew_smtp_close(conn: *mut HewSmtpConn) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
     use std::ffi::{CStr, CString};
     use std::ptr;
     use std::rc::Rc;
@@ -794,5 +794,59 @@ mod tests {
         );
         assert_eq!(rc, -1);
         assert!(events.borrow().is_empty());
+    }
+
+    /// An SMTP error recorded for a given actor ID on one OS thread must
+    /// remain readable for that same actor ID on a different OS thread — the
+    /// scenario when an actor is parked mid-send and resumed on another
+    /// scheduler worker.
+    ///
+    /// Drives the actor-keyed slot directly via the `__*_for_actor` test
+    /// helpers (the same internal path `set_smtp_last_error` takes when
+    /// `hew_actor_current_id()` returns this actor ID), since a unit test
+    /// cannot inject actor context without a running scheduler.
+    ///
+    /// With the predecessor `thread_local!` this would have been empty on
+    /// thread B; with the actor-keyed slot it is not.
+    ///
+    /// Run 3× to satisfy the flake gate.
+    #[test]
+    fn smtp_error_visible_across_worker_threads_regression_2659() {
+        for run in 0..3_u32 {
+            const ACTOR_ID: u64 = 779_001;
+
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+            let barrier2 = barrier.clone();
+
+            let handle = std::thread::spawn(move || {
+                // Simulate: actor ACTOR_ID resumes on thread B.
+                barrier2.wait();
+                hew_runtime::parse_error_slot::__get_error_for_actor(
+                    ACTOR_ID,
+                    hew_runtime::parse_error_slot::ErrorSlotKind::Smtp,
+                )
+            });
+
+            // Thread A: write an SMTP error as if actor ACTOR_ID hit a failed
+            // send.
+            hew_runtime::parse_error_slot::__set_error_for_actor(
+                ACTOR_ID,
+                hew_runtime::parse_error_slot::ErrorSlotKind::Smtp,
+                "smtp send: actor-migration regression",
+            );
+            barrier.wait();
+
+            let result = handle.join().expect("thread B panicked");
+            assert_eq!(
+                result.as_deref(),
+                Some("smtp send: actor-migration regression"),
+                "run {run}: SMTP error written on thread A must be visible on thread B for same actor"
+            );
+
+            hew_runtime::parse_error_slot::__clear_error_for_actor(
+                ACTOR_ID,
+                hew_runtime::parse_error_slot::ErrorSlotKind::Smtp,
+            );
+        }
     }
 }

--- a/hew-std/src/tls.rs
+++ b/hew-std/src/tls.rs
@@ -4,7 +4,6 @@
 //! All `extern "C"` functions are designed to be called from compiled Hew
 //! programs via FFI. Any string returned by [`hew_tls_last_error`] is allocated
 //! with `libc::malloc`; callers must free it with `libc::free`.
-use std::cell::RefCell;
 use std::ffi::c_void;
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
@@ -26,10 +25,6 @@ const TLS_STATUS_SUCCESS: c_int = 0;
 const TLS_STATUS_RETRYABLE: c_int = 1;
 const TLS_STATUS_TLS_ERROR: c_int = 2;
 const TLS_STATUS_IO_ERROR: c_int = 3;
-
-std::thread_local! {
-    static LAST_TLS_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
-}
 
 // ── Opaque handle ─────────────────────────────────────────────────────────────
 
@@ -171,15 +166,19 @@ fn connect_tls(host: &str, port: u16) -> Result<HewTlsStream, BoxError> {
 }
 
 fn set_tls_last_error(msg: impl Into<String>) {
-    LAST_TLS_ERROR.with(|error| *error.borrow_mut() = Some(msg.into()));
+    hew_runtime::parse_error_slot::set_error(
+        hew_runtime::parse_error_slot::ErrorSlotKind::Tls,
+        msg,
+    );
 }
 
 fn clear_tls_last_error() {
-    LAST_TLS_ERROR.with(|error| *error.borrow_mut() = None);
+    hew_runtime::parse_error_slot::clear_error(hew_runtime::parse_error_slot::ErrorSlotKind::Tls);
 }
 
 fn get_tls_last_error() -> String {
-    LAST_TLS_ERROR.with(|error| error.borrow().as_ref().cloned().unwrap_or_else(String::new))
+    hew_runtime::parse_error_slot::get_error(hew_runtime::parse_error_slot::ErrorSlotKind::Tls)
+        .unwrap_or_default()
 }
 
 /// An empty, non-owning `BytesTriple` — the TLS read EOF/error sentinel.
@@ -1881,6 +1880,60 @@ mod tests {
             assert_eq!(
                 parsed, *expected,
                 "tls.hew `{name}` = {parsed} must match Rust `{name}` = {expected}"
+            );
+        }
+    }
+
+    /// A TLS error recorded for a given actor ID on one OS thread must remain
+    /// readable for that same actor ID on a different OS thread — the exact
+    /// scenario when an actor is parked mid-connect and resumed on another
+    /// scheduler worker.
+    ///
+    /// We drive the actor-keyed slot directly via the `__*_for_actor` test
+    /// helpers (the same internal path `set_tls_last_error` takes when
+    /// `hew_actor_current_id()` returns this actor ID), because a unit test
+    /// cannot inject actor context without a running scheduler.
+    ///
+    /// With the predecessor `thread_local!` this would have been empty on
+    /// thread B; with the actor-keyed slot it is not.
+    ///
+    /// Run 3× to satisfy the flake gate.
+    #[test]
+    fn tls_error_visible_across_worker_threads_regression_2659() {
+        for run in 0..3_u32 {
+            const ACTOR_ID: u64 = 778_001;
+
+            let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+            let barrier2 = barrier.clone();
+
+            let handle = thread::spawn(move || {
+                // Simulate: actor ACTOR_ID resumes on thread B.
+                barrier2.wait();
+                hew_runtime::parse_error_slot::__get_error_for_actor(
+                    ACTOR_ID,
+                    hew_runtime::parse_error_slot::ErrorSlotKind::Tls,
+                )
+            });
+
+            // Thread A: write a TLS error as if actor ACTOR_ID hit a failed
+            // hew_tls_connect.
+            hew_runtime::parse_error_slot::__set_error_for_actor(
+                ACTOR_ID,
+                hew_runtime::parse_error_slot::ErrorSlotKind::Tls,
+                "hew_tls_connect: actor-migration regression",
+            );
+            barrier.wait();
+
+            let result = handle.join().expect("thread B panicked");
+            assert_eq!(
+                result.as_deref(),
+                Some("hew_tls_connect: actor-migration regression"),
+                "run {run}: TLS error written on thread A must be visible on thread B for same actor"
+            );
+
+            hew_runtime::parse_error_slot::__clear_error_for_actor(
+                ACTOR_ID,
+                hew_runtime::parse_error_slot::ErrorSlotKind::Tls,
             );
         }
     }

--- a/hew-std/src/tls.rs
+++ b/hew-std/src/tls.rs
@@ -1884,57 +1884,106 @@ mod tests {
         }
     }
 
-    /// A TLS error recorded for a given actor ID on one OS thread must remain
-    /// readable for that same actor ID on a different OS thread — the exact
-    /// scenario when an actor is parked mid-connect and resumed on another
-    /// scheduler worker.
+    /// Spawn a minimal, never-scheduled actor solely to obtain a stable,
+    /// dereferenceable actor identity for `hew_actor_current_id()`. The
+    /// dispatch stub is never invoked — this actor receives no messages.
+    fn spawn_error_slot_test_actor() -> *mut hew_runtime::actor::HewActor {
+        unsafe extern "C-unwind" fn noop_dispatch(
+            _ctx: *mut hew_runtime::HewExecutionContext,
+            _state: *mut c_void,
+            _msg_type: i32,
+            _data: *mut c_void,
+            _data_size: usize,
+            _borrow_mode: i32,
+        ) -> *mut c_void {
+            std::ptr::null_mut()
+        }
+
+        // SAFETY: null state / size 0 is a documented no-state spawn.
+        unsafe { actor::hew_actor_spawn(std::ptr::null_mut(), 0, Some(noop_dispatch)) }
+    }
+
+    /// Install `actor` as the current dispatch's actor for the duration of
+    /// `f`, restoring whatever was previously installed afterward — the same
+    /// install/restore bracket codegen places around every real dispatch
+    /// (`hew_context_install`/`hew_context_restore`), so
+    /// `hew_actor_current_id()` resolves to `actor`'s id inside `f` exactly
+    /// as it would mid-dispatch.
+    fn with_actor_context<R>(actor: *mut hew_runtime::actor::HewActor, f: impl FnOnce() -> R) -> R {
+        let mut ctx = hew_runtime::HewExecutionContext {
+            actor,
+            ..Default::default()
+        };
+        let prev = hew_runtime::set_current_context(&raw mut ctx);
+        let result = f();
+        let _ = hew_runtime::set_current_context(prev);
+        result
+    }
+
+    /// A TLS error recorded by the REAL `hew_tls_connect` failure path —
+    /// while a given actor is the installed dispatch context on OS thread A —
+    /// must be readable through the REAL public `hew_tls_last_error`
+    /// accessor when that SAME actor is the installed dispatch context on a
+    /// DIFFERENT OS thread B.
     ///
-    /// We drive the actor-keyed slot directly via the `__*_for_actor` test
-    /// helpers (the same internal path `set_tls_last_error` takes when
-    /// `hew_actor_current_id()` returns this actor ID), because a unit test
-    /// cannot inject actor context without a running scheduler.
-    ///
-    /// With the predecessor `thread_local!` this would have been empty on
-    /// thread B; with the actor-keyed slot it is not.
+    /// This is the actual #2659 regression: an actor parked mid-connect and
+    /// resumed on another scheduler worker must not lose its recorded error.
+    /// Driving the module's own producer (`hew_tls_connect`) and public
+    /// accessor (`hew_tls_last_error`) — rather than poking the shared
+    /// `parse_error_slot` map directly — means this test is RED against the
+    /// predecessor `thread_local!` implementation: a plain `thread_local!`
+    /// slot is intrinsically per-OS-thread storage, so thread B's slot would
+    /// stay empty no matter which actor either thread believes is
+    /// dispatching. It is GREEN only because `set_/get_tls_last_error` now
+    /// key on actor identity via `parse_error_slot`.
     ///
     /// Run 3× to satisfy the flake gate.
     #[test]
     fn tls_error_visible_across_worker_threads_regression_2659() {
+        // hew_actor_spawn requires an installed runtime authority; reuse the
+        // same scheduler guard the attach/close tests above use.
+        let _runtime = TlsRuntimeGuard::new();
+
         for run in 0..3_u32 {
-            const ACTOR_ID: u64 = 778_001;
+            let test_actor = spawn_error_slot_test_actor();
+            assert!(!test_actor.is_null(), "test actor should spawn");
+            let actor_addr = test_actor as usize;
 
             let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
             let barrier2 = barrier.clone();
 
             let handle = thread::spawn(move || {
-                // Simulate: actor ACTOR_ID resumes on thread B.
+                // Simulate: the actor resumes on thread B, a different OS
+                // thread than the one that recorded the error.
                 barrier2.wait();
-                hew_runtime::parse_error_slot::__get_error_for_actor(
-                    ACTOR_ID,
-                    hew_runtime::parse_error_slot::ErrorSlotKind::Tls,
-                )
+                let actor_ptr = actor_addr as *mut hew_runtime::actor::HewActor;
+                with_actor_context(actor_ptr, last_error_string)
             });
 
-            // Thread A: write a TLS error as if actor ACTOR_ID hit a failed
-            // hew_tls_connect.
-            hew_runtime::parse_error_slot::__set_error_for_actor(
-                ACTOR_ID,
-                hew_runtime::parse_error_slot::ErrorSlotKind::Tls,
-                "hew_tls_connect: actor-migration regression",
-            );
+            // Thread A: install the SAME actor as the dispatch context and
+            // drive the real hew_tls_connect failure path — the actual
+            // producer, not a direct slot poke.
+            with_actor_context(test_actor, || {
+                // SAFETY: passing null is the documented failure path.
+                let ptr = unsafe { hew_tls_connect(std::ptr::null(), 443) };
+                assert!(ptr.is_null());
+            });
             barrier.wait();
 
             let result = handle.join().expect("thread B panicked");
             assert_eq!(
-                result.as_deref(),
-                Some("hew_tls_connect: actor-migration regression"),
-                "run {run}: TLS error written on thread A must be visible on thread B for same actor"
+                result, "hew_tls_connect: invalid host string",
+                "run {run}: TLS error recorded on thread A must be visible on thread B for the same actor"
             );
 
-            hew_runtime::parse_error_slot::__clear_error_for_actor(
-                ACTOR_ID,
-                hew_runtime::parse_error_slot::ErrorSlotKind::Tls,
-            );
+            // SAFETY: test_actor was spawned above and not yet stopped/freed.
+            unsafe { actor::hew_actor_stop(test_actor) };
+            // hew_actor_free reaps every parse_error_slot entry for this
+            // actor via parse_error_slot::clear_all_for_actor — no manual
+            // clear needed.
+            // SAFETY: test_actor is stopped immediately above; free reclaims
+            // it exactly once.
+            assert_eq!(unsafe { actor::hew_actor_free(test_actor) }, 0);
         }
     }
 }

--- a/hew-std/src/tls.rs
+++ b/hew-std/src/tls.rs
@@ -1884,42 +1884,6 @@ mod tests {
         }
     }
 
-    /// Spawn a minimal, never-scheduled actor solely to obtain a stable,
-    /// dereferenceable actor identity for `hew_actor_current_id()`. The
-    /// dispatch stub is never invoked — this actor receives no messages.
-    fn spawn_error_slot_test_actor() -> *mut hew_runtime::actor::HewActor {
-        unsafe extern "C-unwind" fn noop_dispatch(
-            _ctx: *mut hew_runtime::HewExecutionContext,
-            _state: *mut c_void,
-            _msg_type: i32,
-            _data: *mut c_void,
-            _data_size: usize,
-            _borrow_mode: i32,
-        ) -> *mut c_void {
-            std::ptr::null_mut()
-        }
-
-        // SAFETY: null state / size 0 is a documented no-state spawn.
-        unsafe { actor::hew_actor_spawn(std::ptr::null_mut(), 0, Some(noop_dispatch)) }
-    }
-
-    /// Install `actor` as the current dispatch's actor for the duration of
-    /// `f`, restoring whatever was previously installed afterward — the same
-    /// install/restore bracket codegen places around every real dispatch
-    /// (`hew_context_install`/`hew_context_restore`), so
-    /// `hew_actor_current_id()` resolves to `actor`'s id inside `f` exactly
-    /// as it would mid-dispatch.
-    fn with_actor_context<R>(actor: *mut hew_runtime::actor::HewActor, f: impl FnOnce() -> R) -> R {
-        let mut ctx = hew_runtime::HewExecutionContext {
-            actor,
-            ..Default::default()
-        };
-        let prev = hew_runtime::set_current_context(&raw mut ctx);
-        let result = f();
-        let _ = hew_runtime::set_current_context(prev);
-        result
-    }
-
     /// A TLS error recorded by the REAL `hew_tls_connect` failure path —
     /// while a given actor is the installed dispatch context on OS thread A —
     /// must be readable through the REAL public `hew_tls_last_error`
@@ -1940,9 +1904,14 @@ mod tests {
     /// Run 3× to satisfy the flake gate.
     #[test]
     fn tls_error_visible_across_worker_threads_regression_2659() {
-        // hew_actor_spawn requires an installed runtime authority; reuse the
-        // same scheduler guard the attach/close tests above use.
-        let _runtime = TlsRuntimeGuard::new();
+        use crate::net_error_slot_test_support::{
+            spawn_error_slot_test_actor, with_actor_context, NetErrorSlotRuntimeGuard,
+        };
+
+        // hew_actor_spawn requires an installed runtime authority; shared
+        // across tls/smtp/quic so their regression tests serialize on the
+        // single process-global scheduler slot instead of racing.
+        let _runtime = NetErrorSlotRuntimeGuard::new();
 
         for run in 0..3_u32 {
             let test_actor = spawn_error_slot_test_actor();


### PR DESCRIPTION
## Summary

TLS, SMTP, and QUIC delayed/constructor errors now route to the actor-scoped `parse_error_slot` instead of process-global last-error state. Previously, concurrent actors performing network operations could clobber each other's error reporting: actor B's failure would overwrite the error actor A was about to read via `hew_tls_last_error` / `hew_smtp_last_error` / `hew_quic_last_error`. Each actor now sees only its own delayed network errors.

Regression tests drive real failing producers (`hew_tls_connect`, `hew_smtp_send`, `hew_quic_new_server`) under actor A and read the public last-error getters under the same actor from another thread, with shared runtime-guard and unwind-safe actor-context test scaffolding to keep the concurrent tests isolated from each other's teardown.

## Verification

- `cargo nextest run --workspace`: 11534/11534 passed
- `cargo clippy -D warnings`: clean
- `cargo fmt --check`: clean
- `make test-stdlib`: 72/72 passed
- stdlib errno gate: passed
- `cargo test -p hew-std regression_2659 -- --test-threads=3`: all three regression tests pass concurrently (run 3x)
- `cargo build --target wasm32-wasip1`: builds clean
- Diff confined to the five intended `hew-std` files (+376/−24)

## Out of scope

- QUIC endpoint/connection `state.last_error` behaviour is untouched — this change covers the delayed/constructor error path only.
- No production ABI changes: the test-support module is private and gated by `#[cfg(all(test, not(target_family = "wasm")))]`.

Fixes #2659