### PR TITLE
fix(runtime): stop the cooperate checkpoint clobbering the last-error slot

### DIFF
--- a/hew-runtime/src/scheduler.rs
+++ b/hew-runtime/src/scheduler.rs
@@ -2861,12 +2861,17 @@ impl Drop for NoWorkerSchedulerForTest {
 ///
 /// # Safety
 ///
-/// No preconditions — may be called from any context. When called
-/// outside an installed execution context, this sets `hew_last_error` and
-/// returns 0.
+/// No preconditions — may be called from any context. When called outside
+/// an installed execution context, this returns 0 and leaves the
+/// thread-local last-error slot untouched, so a real diagnostic set by a
+/// prior operation survives.
 #[no_mangle]
 pub extern "C" fn hew_actor_cooperate() -> c_int {
-    let ctx = crate::execution_context::require_current_context();
+    // A fail-open cooperative-yield checkpoint must not disturb the caller's
+    // LAST_ERROR: use the silent context read, not require_current_context()
+    // (which sets EXECUTION_CONTEXT_NOT_INSTALLED as a side effect and would
+    // clobber a real error a straight-line `main()` is about to read back).
+    let ctx = crate::execution_context::current_context();
     if ctx.is_null() {
         return 0;
     }

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -2049,11 +2049,17 @@ pub use crate::execution_context::hew_get_reply_channel;
 /// # Safety
 ///
 /// No preconditions — may be called from any context. When called outside an
-/// installed execution context, this sets `hew_last_error` and returns 0.
+/// installed execution context, this returns 0 and leaves the thread-local
+/// last-error slot untouched, so a real diagnostic set by a prior operation
+/// survives.
 #[cfg_attr(target_arch = "wasm32", no_mangle)]
 #[must_use]
 pub extern "C" fn hew_actor_cooperate() -> c_int {
-    let ctx = crate::execution_context::require_current_context();
+    // A fail-open cooperative-yield checkpoint must not disturb the caller's
+    // LAST_ERROR: use the silent context read, not require_current_context()
+    // (which sets EXECUTION_CONTEXT_NOT_INSTALLED as a side effect and would
+    // clobber a real error a straight-line `main()` is about to read back).
+    let ctx = crate::execution_context::current_context();
     if ctx.is_null() {
         return 0;
     }

--- a/hew-runtime/src/task_scope.rs
+++ b/hew-runtime/src/task_scope.rs
@@ -2765,17 +2765,22 @@ mod tests {
     }
 
     #[test]
-    fn cooperate_without_execution_context_fails_closed() {
+    fn cooperate_without_execution_context_preserves_last_error() {
+        // The cooperate checkpoint fails open (returns 0) without an
+        // installed execution context and must not disturb the thread-local
+        // last-error slot: a clear slot stays clear, and a real diagnostic
+        // set by a prior operation survives the checkpoint (issue #2506).
         crate::hew_clear_error();
+        assert_eq!(crate::scheduler::hew_actor_cooperate(), 0);
+        assert!(crate::hew_last_error().is_null());
+
+        crate::set_last_error("real diagnostic from a prior operation");
         assert_eq!(crate::scheduler::hew_actor_cooperate(), 0);
         let err = crate::hew_last_error();
         assert!(!err.is_null());
         // SAFETY: hew_last_error returned a non-null C string.
         let err = unsafe { CStr::from_ptr(err).to_str().unwrap() };
-        assert_eq!(
-            err,
-            crate::execution_context::EXECUTION_CONTEXT_NOT_INSTALLED
-        );
+        assert_eq!(err, "real diagnostic from a prior operation");
         crate::hew_clear_error();
     }
 

--- a/hew-runtime/tests/execution_context.rs
+++ b/hew-runtime/tests/execution_context.rs
@@ -79,8 +79,15 @@ fn run_ctx_null_reader_case(case: u8) {
             assert_context_not_installed_error();
         }
         4 => {
+            // hew_actor_cooperate is a fail-open checkpoint, deliberately
+            // NOT a typed-error emitter: it must leave the last-error slot
+            // untouched so a real diagnostic set by a prior operation
+            // survives to its reader (issue #2506).
             assert_eq!(hew_runtime::scheduler::hew_actor_cooperate(), 0);
-            assert_context_not_installed_error();
+            assert!(
+                hew_last_error().is_null(),
+                "cooperate checkpoint must not write the last-error slot"
+            );
         }
         5 => {
             assert!(hew_runtime::arena::set_current_arena(ptr::null_mut()).is_null());

--- a/tests/hew/process_test.hew
+++ b/tests/hew/process_test.hew
@@ -99,6 +99,27 @@ fn test_try_run_argv_missing_command_returns_launch_failed() {
 }
 
 #[test]
+fn test_try_run_argv_missing_command_preserves_real_error() {
+    // Regression for #2506: the cooperative-yield checkpoint at
+    // last_process_error's function entry must not clobber the real
+    // launch-failure text with the "execution context not installed"
+    // sentinel when main() has no installed execution context.
+    // Cross-platform: a nonexistent command fails to launch
+    // (ENOENT-equivalent) on every OS, so no Unix-only tool is used.
+    let args: Vec<string> = Vec::new();
+    match process.try_run_argv("hew-process-command-that-does-not-exist-2506", args) {
+        Ok(_) => panic("expected missing command to fail to launch"),
+        Err(err) => match err {
+            ProcessError::LaunchFailed(message) => {
+                testing.assert_true(!message.contains("execution context not installed"));
+                testing.assert_true(message.contains("failed to execute"));
+            },
+            _ => panic("expected ProcessError::LaunchFailed"),
+        },
+    }
+}
+
+#[test]
 fn test_child_drop_reaps_running_process() {
     let pid_path = f"tests/hew/_process_drop_{datetime.now_nanos()}.pid";
     cleanup_file(pid_path);


### PR DESCRIPTION
## Why

The actor scheduler's cooperate checkpoint used `require_current_context()`, whose null-context path has a side effect: it writes the `EXECUTION_CONTEXT_NOT_INSTALLED` sentinel into `LAST_ERROR`. That write clobbered genuine diagnostics — for example a real process launch failure — before stdlib callers could read them, so `try_run_argv` callers saw the context sentinel instead of the actual OS error text.

## What

- **hew-runtime (native + WASM)**: `hew_actor_cooperate` in `scheduler.rs` and `scheduler_wasm.rs` now uses the non-clobbering `current_context()` probe. The null check is semantically identical; only the spurious `LAST_ERROR` write is gone. Cooperate's contract is its return code — it is deliberately not a typed-error emitter, and the checkpoint never fabricates an error into the slot.
- **Test contract fix**: two tests had encoded the clobber as a contract. `task_scope.rs`'s test is rewritten to assert the intended behaviour (a clear slot stays clear across a no-context cooperate, and a real diagnostic set before the checkpoint survives it); the execution-context catalogue case now documents cooperate as leaving the slot untouched.

## Test

- New compiled regression `test_try_run_argv_missing_command_preserves_real_error` in `tests/hew/process_test.hew`: asserts the surviving error contains the real "failed to execute" text and not the sentinel. Verified red against the pre-fix runtime, green with the fix.
- `cooperate_without_execution_context_preserves_last_error` (`task_scope.rs`): covers both negative-space conditions — no fabricated error on a clear slot, and a pre-set diagnostic surviving the checkpoint.
- Full workspace nextest, the compiled-suite ratchet, and clippy/fmt are clean; the `.hew` regression was run three times to rule out order sensitivity.

## Quality Checklist
- [x] PR title, body, and commit messages avoid internal-only orchestration/model vocabulary
- [x] No new `.ok()?` or `unwrap_or_default()` in codegen without `// JUSTIFIED` comment
- [x] New allocations have cleanup paths for sync, async, and actor shutdown contexts
- [x] Serialization changes include round-trip encode/decode tests
- [x] New runtime features have WASM implementation or `// WASM-TODO(#NNN):` marker (with issue ref, e.g. `#1451`), and new `hew_*` exports are classified in `scripts/jit-symbol-classification.toml`
- [x] No duplicated logic — checked for existing helpers before adding new ones

## Out of scope

- The workspace-wide audit of other last-error readers (fs/stream/channel/net) — this fix is confined to the cooperate checkpoint.
- The Unix-only `printf`/`kill` fixture portability cleanup in the process tests.
- The 8 remaining `require_current_context()` diagnostic callers are correct as-is (their readers want the sentinel) and are unchanged.

Fixes #2506