### PR TITLE
fix(runtime): route parse error slots through a silent context probe

### DIFF
--- a/hew-runtime/src/actor.rs
+++ b/hew-runtime/src/actor.rs
@@ -779,12 +779,10 @@ fn should_fail_arena_alloc() -> bool {
     })
 }
 
-/// Get the ID of the actor currently being dispatched on this thread.
+/// Derive the current actor's ID from an execution context pointer.
 ///
-/// Returns -1 if no actor is active (called from main or non-actor context).
-#[no_mangle]
-pub extern "C" fn hew_actor_current_id() -> i64 {
-    let ctx = crate::execution_context::require_current_context();
+/// Returns -1 when the context is null or carries no actor.
+fn actor_id_from_context(ctx: *mut crate::execution_context::HewExecutionContext) -> i64 {
     if ctx.is_null() {
         return -1;
     }
@@ -799,6 +797,29 @@ pub extern "C" fn hew_actor_current_id() -> i64 {
         // SAFETY: actor is non-null and valid when installed by the scheduler.
         unsafe { &*actor }.id as i64
     }
+}
+
+/// Get the ID of the actor currently being dispatched on this thread.
+///
+/// Returns -1 if no actor is active (called from main or non-actor context).
+/// When no execution context is installed, records the diagnostic
+/// `EXECUTION_CONTEXT_NOT_INSTALLED` in the generic last-error slot — callers
+/// treating an absent context as a failure rely on that write.
+#[no_mangle]
+pub extern "C" fn hew_actor_current_id() -> i64 {
+    let ctx = crate::execution_context::require_current_context();
+    actor_id_from_context(ctx)
+}
+
+/// Silent variant of [`hew_actor_current_id`]: returns the current actor id,
+/// or -1 outside any actor context, WITHOUT writing the generic `LAST_ERROR`
+/// slot when no execution context is installed. Use this for identity-routing
+/// decisions (e.g. the `parse_error_slot` non-actor fallback) where "no actor"
+/// is an expected, non-error condition — not for paths where an absent context
+/// is itself a diagnosable failure.
+pub(crate) fn hew_actor_current_id_silent() -> i64 {
+    let ctx = crate::execution_context::current_context();
+    actor_id_from_context(ctx)
 }
 
 /// Default message processing budget per activation.
@@ -6224,6 +6245,42 @@ mod tests {
     /// `Running → Idle → Stopped` instead of `Running → Crashed`, and drain
     /// returns `Drained` instead of `Incomplete { crashed }`.
     static DRAIN_TRAP_ON_STOP_RELEASE: AtomicBool = AtomicBool::new(false);
+
+    /// With no execution context installed, the diagnostic accessor
+    /// `hew_actor_current_id` writes `EXECUTION_CONTEXT_NOT_INSTALLED` into the
+    /// generic last-error slot (callers treating an absent context as a failure
+    /// depend on that), while `hew_actor_current_id_silent` returns the same -1
+    /// without touching the slot — it is a routing probe, not a diagnostic.
+    #[test]
+    fn silent_probe_diverges_from_diagnostic_on_missing_context() {
+        let prev = crate::execution_context::set_current_context(ptr::null_mut());
+
+        crate::hew_clear_error();
+        assert_eq!(hew_actor_current_id_silent(), -1);
+        assert!(
+            crate::hew_last_error().is_null(),
+            "silent probe must not write the generic last-error slot"
+        );
+
+        assert_eq!(hew_actor_current_id(), -1);
+        let err = crate::hew_last_error();
+        assert!(
+            !err.is_null(),
+            "diagnostic accessor must record the missing-context error"
+        );
+        // SAFETY: hew_last_error returned a non-null, NUL-terminated C string
+        // owned by the thread-local slot; it stays valid until the next write.
+        let msg = unsafe { std::ffi::CStr::from_ptr(err) }
+            .to_str()
+            .expect("last-error message is valid UTF-8");
+        assert_eq!(
+            msg,
+            crate::execution_context::EXECUTION_CONTEXT_NOT_INSTALLED
+        );
+
+        crate::hew_clear_error();
+        let _ = crate::execution_context::set_current_context(prev);
+    }
 
     /// `Suspended` is non-quiescent: a suspended actor owns a live continuation
     /// frame, so a `hew_actor_free` caller spinning on the state must block

--- a/hew-runtime/src/parse_error_slot.rs
+++ b/hew-runtime/src/parse_error_slot.rs
@@ -9,14 +9,20 @@
 //! This module provides a slot keyed by **(logical actor identity, error kind)**,
 //! not OS thread identity:
 //!
-//! - When a Hew actor is currently dispatched (`hew_actor_current_id() >= 0`),
-//!   the slot is stored in a process-wide `Mutex<HashMap<(u64, ErrorSlotKind), String>>`
-//!   keyed by the actor ID and error kind.  Each error type has its own per-actor
-//!   slot, so a yaml error cannot clear a datetime error and vice-versa.
+//! - When a Hew actor is currently dispatched
+//!   (`hew_actor_current_id_silent() >= 0`), the slot is stored in a
+//!   process-wide `Mutex<HashMap<(u64, ErrorSlotKind), String>>` keyed by the
+//!   actor ID and error kind.  Each error type has its own per-actor slot, so
+//!   a yaml error cannot clear a datetime error and vice-versa.
 //! - When called from outside any actor (main, test, blocking-pool helper),
-//!   `hew_actor_current_id()` returns -1 and the slot falls back to a
+//!   `hew_actor_current_id_silent()` returns -1 and the slot falls back to a
 //!   `thread_local!` `HashMap<ErrorSlotKind, String>` so that non-actor callers
 //!   remain isolated from each other and from other error types.
+//!
+//! The routing decision uses the SILENT probe deliberately: falling back to
+//! the thread-local slot is an expected, non-error condition, so it must not
+//! write "execution context not installed" into the generic last-error slot
+//! and destroy an unrelated real error (#2658).
 //!
 //! # Slot lifecycle
 //!
@@ -67,7 +73,8 @@ pub enum ErrorSlotKind {
 
 /// Global map from `(actor_id, ErrorSlotKind)` → last error message.
 ///
-/// Only populated when `hew_actor_current_id()` returns a non-negative value.
+/// Only populated when `hew_actor_current_id_silent()` returns a non-negative
+/// value.
 static ACTOR_PARSE_ERRORS: PoisonSafe<Option<HashMap<(u64, ErrorSlotKind), String>>> =
     PoisonSafe::new(None);
 
@@ -115,7 +122,7 @@ thread_local! {
 /// Record `msg` as the most recent error for `kind` in the current
 /// logical context (actor or thread).
 pub fn set_error(kind: ErrorSlotKind, msg: impl Into<String>) {
-    let id = crate::actor::hew_actor_current_id();
+    let id = crate::actor::hew_actor_current_id_silent();
     if id >= 0 {
         #[expect(clippy::cast_sign_loss, reason = "checked: id >= 0")]
         actor_map_set(id as u64, kind, msg.into());
@@ -128,7 +135,7 @@ pub fn set_error(kind: ErrorSlotKind, msg: impl Into<String>) {
 
 /// Clear the error for `kind` in the current logical context.
 pub fn clear_error(kind: ErrorSlotKind) {
-    let id = crate::actor::hew_actor_current_id();
+    let id = crate::actor::hew_actor_current_id_silent();
     if id >= 0 {
         #[expect(clippy::cast_sign_loss, reason = "checked: id >= 0")]
         actor_map_clear(id as u64, kind);
@@ -143,7 +150,7 @@ pub fn clear_error(kind: ErrorSlotKind) {
 /// context, or `None` if no error has been set.
 #[must_use]
 pub fn get_error(kind: ErrorSlotKind) -> Option<String> {
-    let id = crate::actor::hew_actor_current_id();
+    let id = crate::actor::hew_actor_current_id_silent();
     if id >= 0 {
         #[expect(clippy::cast_sign_loss, reason = "checked: id >= 0")]
         actor_map_get(id as u64, kind)
@@ -200,6 +207,110 @@ pub fn __clear_error_for_actor(actor_id: u64, kind: ErrorSlotKind) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Read the process-generic last-error slot as an owned string.
+    fn generic_last_error() -> Option<String> {
+        let ptr = crate::hew_last_error();
+        if ptr.is_null() {
+            return None;
+        }
+        // SAFETY: hew_last_error returned a non-null, NUL-terminated C string
+        // owned by the thread-local slot; it stays valid until the next write.
+        Some(
+            unsafe { std::ffi::CStr::from_ptr(ptr) }
+                .to_string_lossy()
+                .into_owned(),
+        )
+    }
+
+    /// Force a non-actor context for the duration of a closure, restoring the
+    /// previous execution context afterwards.
+    fn with_no_execution_context(f: impl FnOnce()) {
+        let prev = crate::execution_context::set_current_context(std::ptr::null_mut());
+        f();
+        let _ = crate::execution_context::set_current_context(prev);
+    }
+
+    /// Direct #2658 regression: a non-actor `get_error` fallback lookup is an
+    /// expected condition, so it must return `None` for an empty slot AND leave
+    /// a prior real generic error intact — not clobber it with
+    /// "execution context not installed".
+    #[test]
+    fn nonactor_get_error_preserves_generic_last_error() {
+        with_no_execution_context(|| {
+            crate::set_last_error("prior real error");
+            assert_eq!(get_error(ErrorSlotKind::Json), None);
+            assert_eq!(
+                generic_last_error().as_deref(),
+                Some("prior real error"),
+                "non-actor get_error must not clobber the generic last-error slot"
+            );
+            crate::hew_clear_error();
+        });
+    }
+
+    /// Same invariant for `set_error`: routing to the thread-local slot must
+    /// not disturb the generic last-error slot.
+    #[test]
+    fn nonactor_set_error_preserves_generic_last_error() {
+        with_no_execution_context(|| {
+            crate::set_last_error("prior real error");
+            set_error(ErrorSlotKind::Json, "json parse failed");
+            assert_eq!(
+                generic_last_error().as_deref(),
+                Some("prior real error"),
+                "non-actor set_error must not clobber the generic last-error slot"
+            );
+            clear_error(ErrorSlotKind::Json);
+            crate::hew_clear_error();
+        });
+    }
+
+    /// Same invariant for `clear_error`.
+    #[test]
+    fn nonactor_clear_error_preserves_generic_last_error() {
+        with_no_execution_context(|| {
+            crate::set_last_error("prior real error");
+            clear_error(ErrorSlotKind::Json);
+            assert_eq!(
+                generic_last_error().as_deref(),
+                Some("prior real error"),
+                "non-actor clear_error must not clobber the generic last-error slot"
+            );
+            crate::hew_clear_error();
+        });
+    }
+
+    /// From a clean generic slot, the routing probe inside set/clear/get must
+    /// write nothing at all — the slot stays null, not merely unchanged.
+    #[test]
+    fn nonactor_probe_writes_no_generic_error_from_clean_slot() {
+        with_no_execution_context(|| {
+            crate::hew_clear_error();
+            set_error(ErrorSlotKind::Yaml, "yaml parse failed");
+            assert_eq!(
+                generic_last_error(),
+                None,
+                "set_error routing probe wrote the generic slot"
+            );
+            assert_eq!(
+                get_error(ErrorSlotKind::Yaml).as_deref(),
+                Some("yaml parse failed")
+            );
+            assert_eq!(
+                generic_last_error(),
+                None,
+                "get_error routing probe wrote the generic slot"
+            );
+            clear_error(ErrorSlotKind::Yaml);
+            assert_eq!(
+                generic_last_error(),
+                None,
+                "clear_error routing probe wrote the generic slot"
+            );
+            assert_eq!(get_error(ErrorSlotKind::Yaml), None);
+        });
+    }
 
     /// A slot set and retrieved within the same non-actor thread returns the
     /// same string for the same error kind.

--- a/hew-runtime/src/scheduler_wasm.rs
+++ b/hew-runtime/src/scheduler_wasm.rs
@@ -3319,8 +3319,11 @@ mod tests {
         unsafe { crate::mailbox_wasm::hew_mailbox_free(mailbox) };
     }
 
-    // Dispatch callback that records hew_actor_current_id() into a static.
+    // Dispatch callback that records hew_actor_current_id() into a static,
+    // and the silent routing probe into a sibling static for parity checks.
     static DISPATCH_SAW_ACTOR_ID: std::sync::atomic::AtomicI64 =
+        std::sync::atomic::AtomicI64::new(-999);
+    static DISPATCH_SAW_SILENT_ACTOR_ID: std::sync::atomic::AtomicI64 =
         std::sync::atomic::AtomicI64::new(-999);
 
     unsafe extern "C-unwind" fn dispatch_record_current_id(
@@ -3333,6 +3336,10 @@ mod tests {
     ) -> *mut c_void {
         let id = crate::actor::hew_actor_current_id();
         DISPATCH_SAW_ACTOR_ID.store(id, std::sync::atomic::Ordering::Relaxed);
+        DISPATCH_SAW_SILENT_ACTOR_ID.store(
+            crate::actor::hew_actor_current_id_silent(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
 
         std::ptr::null_mut()
     }
@@ -3362,6 +3369,7 @@ mod tests {
         unsafe { hew_mailbox_send(mb, 0, ptr::null_mut(), 0) };
 
         DISPATCH_SAW_ACTOR_ID.store(-999, std::sync::atomic::Ordering::Relaxed);
+        DISPATCH_SAW_SILENT_ACTOR_ID.store(-999, std::sync::atomic::Ordering::Relaxed);
         // SAFETY: actor is valid, scheduler is initialized.
         unsafe { sched_enqueue(actor_ptr) };
         hew_sched_run();
@@ -3371,10 +3379,30 @@ mod tests {
             42,
             "hew_actor_current_id() must return the dispatching actor's ID, not -1"
         );
+        assert_eq!(
+            DISPATCH_SAW_SILENT_ACTOR_ID.load(std::sync::atomic::Ordering::Relaxed),
+            42,
+            "hew_actor_current_id_silent() must agree with the diagnostic \
+             accessor under dispatch"
+        );
 
         // SAFETY: mb is a valid mailbox pointer; all messages have been consumed.
         unsafe { hew_mailbox_free(mb) };
         hew_sched_shutdown();
+
+        // Outside dispatch both probes report -1; the silent probe must do so
+        // without writing the generic last-error slot (#2658).
+        let prev = crate::execution_context::set_current_context(ptr::null_mut());
+        crate::hew_clear_error();
+        assert_eq!(crate::actor::hew_actor_current_id_silent(), -1);
+        assert!(
+            crate::hew_last_error().is_null(),
+            "silent probe outside dispatch must leave the generic last-error \
+             slot untouched"
+        );
+        assert_eq!(crate::actor::hew_actor_current_id(), -1);
+        let _ = crate::execution_context::set_current_context(prev);
+        crate::hew_clear_error();
     }
 
     // Statics for the nested-activation test.


### PR DESCRIPTION
## Why

Parse error-slot routing (`set_error`/`clear_error`/`get_error` in `hew-runtime/src/parse_error_slot.rs`) identified the current actor via the diagnostic extern `hew_actor_current_id()`. When no execution context is installed, that extern writes the `EXECUTION_CONTEXT_NOT_INSTALLED` sentinel into `LAST_ERROR` as a side effect — so merely routing an error slot could corrupt the very error state the slot exists to protect. A prior parse error (or a clean null slot) got clobbered with an unrelated context diagnostic on non-actor threads.

Fixes #2658

## What

- **runtime**: added `hew_actor_current_id_silent()`, a `pub(crate)` probe built on the non-clobbering `execution_context::current_context()` and the shared `actor_id_from_context` helper — same actor-id semantics, no `LAST_ERROR` write. All three parse error-slot routing sites now use it. The diagnostic extern `hew_actor_current_id()` is untouched: same `#[no_mangle] extern "C"` signature, same sentinel-write contract (callers such as the execution-context tests explicitly consume that write).
- **tests**: a divergence test pins both contracts — silent probe returns -1 and leaves `hew_last_error()` null; diagnostic extern returns -1 and writes exactly the `EXECUTION_CONTEXT_NOT_INSTALLED` constant. Four non-actor regressions cover the error slot preserving a prior error and staying null from clean. A WASM scheduler parity test drives a real mailbox → enqueue → `hew_sched_run` dispatch and asserts both probes agree inside dispatch and stay silent outside it.

## Test

- `silent_probe_diverges_from_diagnostic_on_missing_context` (`actor.rs`) — mutation-verified: reverting the silent probe to `require_current_context()` fails this test plus all four non-actor slot tests
- `nonactor_*` regression tests in `parse_error_slot.rs` (prior-error preserved; slot stays null from clean)
- `self_api_sees_current_actor_during_dispatch` extended in `scheduler_wasm.rs` for silent/diagnostic probe parity on the WASM scheduler path

## Quality Checklist
- [x] PR title, body, and commit messages avoid internal-only orchestration/model vocabulary
- [x] No new `.ok()?` or `unwrap_or_default()` in codegen without `// JUSTIFIED` comment
- [x] New allocations have cleanup paths for sync, async, and actor shutdown contexts
- [x] Serialization changes include round-trip encode/decode tests (n/a — no serialization change)
- [x] New runtime features have WASM implementation or `// WASM-TODO(#NNN):` marker, and new `hew_*` exports are classified in `scripts/jit-symbol-classification.toml` (silent probe is `pub(crate)`, not an export; WASM path covered by the parity test)
- [x] No duplicated logic — the silent probe reuses `current_context()` and the shared `actor_id_from_context` helper