### PR TITLE
fix(mir): reject call-scrutinee double-free via return-provenance admission

### DIFF
--- a/hew-cli/src/diagnostic.rs
+++ b/hew-cli/src/diagnostic.rs
@@ -699,6 +699,9 @@ fn mir_diagnostic_message(diagnostic: &hew_mir::MirDiagnostic) -> String {
                 hew_mir::ProjectedPayloadRejectReason::GuardedConsume => {
                     "a `match`-arm guard that can fall through"
                 }
+                hew_mir::ProjectedPayloadRejectReason::AliasesCallerStorage => {
+                    "a `match` on a value that may alias caller storage"
+                }
             };
             format!("cannot move the heap-owning payload `{name}` out of {source}")
         }

--- a/hew-cli/tests/funcupdate_mir_baselines.rs
+++ b/hew-cli/tests/funcupdate_mir_baselines.rs
@@ -123,13 +123,14 @@ fn funcupdate_reassign_elab_mir_matches_committed_baselines() {
 }
 
 /// Split a dump into per-function chunks (a chunk starts at a column-0
-/// `fn ` line), canonicalize the run-varying ids inside each chunk, sort the
-/// chunks by signature line, and rejoin. The two recorded normalizations
-/// (see the manifest header): (1) dump FUNCTION ORDER is nondeterministic
-/// (map iteration); (2) `BindingId(n)` / `SiteId(n)` values depend on module
-/// iteration order, so each is renumbered per chunk in first-occurrence
-/// order. Everything else must match byte-for-byte — opcodes, drop plans,
-/// local structure.
+/// `fn ` line), apply the two recorded normalizations (see the manifest
+/// header), and rejoin: (1) sort chunks by signature line because dump
+/// FUNCTION ORDER is nondeterministic (map iteration); (2) renumber
+/// `BindingId(n)` / `SiteId(n)` values within each chunk in first-occurrence
+/// order because they depend on module iteration order. Within-chunk content
+/// order is preserved, so a reordered drop inside a chunk remains detectable;
+/// everything else must match byte-for-byte — opcodes, drop plans, local
+/// structure.
 fn normalize_fn_order(dump: &str) -> String {
     let mut chunks: Vec<String> = Vec::new();
     let mut current = String::new();

--- a/hew-cli/tests/funcupdate_mir_baselines.rs
+++ b/hew-cli/tests/funcupdate_mir_baselines.rs
@@ -1,0 +1,130 @@
+//! #2648 interface pin, MIR half — committed golden elaborated-MIR baselines
+//! for the funcupdate/reassign consumers.
+//!
+//! The Coarse freshness summary feeds two UAF gates: the destructive-
+//! funcupdate base gate (`expr_is_materialized_owner`) and the #2420
+//! reassign-overwrite gate (`reassign_rhs_may_alias_binding`). The frozen-
+//! reference differential (`hew-mir` `coarse_verdict_differential`) proves the
+//! boolean verdicts byte-identical; this harness proves the EMITTED elaborated
+//! MIR (including drop plans) of the fixtures that exercise those consumers is
+//! byte-identical to baselines generated at the branch base
+//! (`3683c2ac5`, `hew compile --dump-mir elab`, no normalization).
+//!
+//! Fail-closed manifest discipline:
+//! - every manifest row's fixture AND baseline file must exist (missing →
+//!   FAIL, never a silent skip);
+//! - every `.elab.mir` file in the baseline directory must be mapped by the
+//!   manifest (an orphan baseline → FAIL — no silent corpus shrinkage);
+//! - any byte difference between the live dump and the baseline → FAIL. The
+//!   baseline is regenerated only by an explicit, reviewed step (see the
+//!   manifest header), never by this test.
+
+mod support;
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::process::Command;
+
+use support::{hew_binary, repo_root};
+
+const BASELINE_DIR: &str = "tests/mir-baselines/funcupdate-reassign";
+
+fn manifest_rows(root: &Path) -> Vec<(String, String)> {
+    let manifest = root.join(BASELINE_DIR).join("manifest.tsv");
+    let text = std::fs::read_to_string(&manifest)
+        .unwrap_or_else(|e| panic!("manifest missing at {}: {e}", manifest.display()));
+    let mut rows = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut parts = line.split('\t');
+        let fixture = parts.next().expect("manifest row has a fixture column");
+        let baseline = parts
+            .next()
+            .unwrap_or_else(|| panic!("manifest row `{line}` is missing the baseline column"));
+        rows.push((fixture.to_string(), baseline.to_string()));
+    }
+    assert!(
+        !rows.is_empty(),
+        "manifest has zero rows — corpus collapsed"
+    );
+    rows
+}
+
+#[test]
+fn funcupdate_reassign_elab_mir_matches_committed_baselines() {
+    support::require_codegen();
+    let root = repo_root();
+    let rows = manifest_rows(root);
+
+    // Stale/missing detection half 1: every baseline file on disk is mapped.
+    let mapped: HashSet<&str> = rows.iter().map(|(_, b)| b.as_str()).collect();
+    for entry in std::fs::read_dir(root.join(BASELINE_DIR)).expect("baseline dir readable") {
+        let entry = entry.expect("baseline dir entry readable");
+        let name = entry.file_name();
+        let name = name.to_str().expect("utf-8 baseline file name");
+        if name.ends_with(".elab.mir") {
+            assert!(
+                mapped.contains(name),
+                "orphan baseline `{name}` is not mapped by manifest.tsv — remove it or add \
+                 its fixture row (no silent corpus shrinkage)"
+            );
+        }
+    }
+
+    for (fixture, baseline) in rows {
+        let fixture_path = root.join(&fixture);
+        // Stale/missing detection half 2: both sides of the row must exist.
+        assert!(
+            fixture_path.exists(),
+            "manifest fixture `{fixture}` does not exist — the corpus input was moved or \
+             deleted without a manifest update"
+        );
+        let baseline_path = root.join(BASELINE_DIR).join(&baseline);
+        let expected = std::fs::read_to_string(&baseline_path).unwrap_or_else(|e| {
+            panic!(
+                "committed baseline `{}` unreadable: {e}",
+                baseline_path.display()
+            )
+        });
+
+        let output = Command::new(hew_binary())
+            .current_dir(root)
+            .args(["compile", "--dump-mir", "elab"])
+            .arg(&fixture)
+            .output()
+            .expect("hew compile spawns");
+        assert!(
+            output.status.success(),
+            "`hew compile --dump-mir elab {fixture}` failed (exit {:?}):\n{}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let live = String::from_utf8(output.stdout).expect("utf-8 MIR dump");
+
+        assert!(
+            live == expected,
+            "elaborated MIR for `{fixture}` diverged from the committed baseline \
+             `{baseline}` (generated at 3683c2ac5). A funcupdate/reassign consumer's \
+             lowering or drop plan CHANGED — this is the Coarse-drift signal the boolean \
+             differential cannot see. If the change is intended and reviewed, regenerate \
+             the baseline per the manifest header. First differing line:\n{}",
+            first_diff(&expected, &live)
+        );
+    }
+}
+
+fn first_diff(expected: &str, live: &str) -> String {
+    for (i, (e, l)) in expected.lines().zip(live.lines()).enumerate() {
+        if e != l {
+            return format!("line {}:\n  baseline: {e}\n  live:     {l}", i + 1);
+        }
+    }
+    format!(
+        "line-count mismatch: baseline {} lines, live {} lines",
+        expected.lines().count(),
+        live.lines().count()
+    )
+}

--- a/hew-cli/tests/funcupdate_mir_baselines.rs
+++ b/hew-cli/tests/funcupdate_mir_baselines.rs
@@ -7,8 +7,11 @@
 //! reference differential (`hew-mir` `coarse_verdict_differential`) proves the
 //! boolean verdicts byte-identical; this harness proves the EMITTED elaborated
 //! MIR (including drop plans) of the fixtures that exercise those consumers is
-//! byte-identical to baselines generated at the branch base
-//! (`3683c2ac5`, `hew compile --dump-mir elab`, no normalization).
+//! identical to baselines generated at the branch base (`3683c2ac5`,
+//! `hew compile --dump-mir elab`) under ONE normalization rule: the dump's
+//! FUNCTION ORDER is nondeterministic (map iteration), so both sides are
+//! split into per-function chunks and sorted by signature line before the
+//! byte comparison; intra-function text must match exactly.
 //!
 //! Fail-closed manifest discipline:
 //! - every manifest row's fixture AND baseline file must exist (missing →
@@ -104,16 +107,78 @@ fn funcupdate_reassign_elab_mir_matches_committed_baselines() {
         );
         let live = String::from_utf8(output.stdout).expect("utf-8 MIR dump");
 
+        let expected_norm = normalize_fn_order(&expected);
+        let live_norm = normalize_fn_order(&live);
         assert!(
-            live == expected,
+            live_norm == expected_norm,
             "elaborated MIR for `{fixture}` diverged from the committed baseline \
              `{baseline}` (generated at 3683c2ac5). A funcupdate/reassign consumer's \
              lowering or drop plan CHANGED — this is the Coarse-drift signal the boolean \
              differential cannot see. If the change is intended and reviewed, regenerate \
-             the baseline per the manifest header. First differing line:\n{}",
-            first_diff(&expected, &live)
+             the baseline per the manifest header. First differing line (after \
+             fn-order normalization):\n{}",
+            first_diff(&expected_norm, &live_norm)
         );
     }
+}
+
+/// Split a dump into per-function chunks (a chunk starts at a column-0
+/// `fn ` line), canonicalize the run-varying ids inside each chunk, sort the
+/// chunks by signature line, and rejoin. The two recorded normalizations
+/// (see the manifest header): (1) dump FUNCTION ORDER is nondeterministic
+/// (map iteration); (2) `BindingId(n)` / `SiteId(n)` values depend on module
+/// iteration order, so each is renumbered per chunk in first-occurrence
+/// order. Everything else must match byte-for-byte — opcodes, drop plans,
+/// local structure.
+fn normalize_fn_order(dump: &str) -> String {
+    let mut chunks: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for line in dump.lines() {
+        if line.starts_with("fn ") && !current.is_empty() {
+            chunks.push(std::mem::take(&mut current));
+        }
+        current.push_str(line);
+        current.push('\n');
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    let mut chunks: Vec<String> = chunks
+        .iter()
+        .map(|c| canonicalize_ids(&canonicalize_ids(c, "BindingId("), "SiteId("))
+        .collect();
+    chunks.sort();
+    chunks.concat()
+}
+
+/// Renumber every `<marker>N)` occurrence in first-occurrence order
+/// (`<marker>#0)`, `<marker>#1)`, …) so run-varying id assignment cannot
+/// produce a false diff while any structural change still does.
+fn canonicalize_ids(chunk: &str, marker: &str) -> String {
+    let mut out = String::with_capacity(chunk.len());
+    let mut map: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut rest = chunk;
+    while let Some(pos) = rest.find(marker) {
+        let start = pos + marker.len();
+        let digits: String = rest[start..]
+            .chars()
+            .take_while(char::is_ascii_digit)
+            .collect();
+        if digits.is_empty() {
+            out.push_str(&rest[..start]);
+            rest = &rest[start..];
+            continue;
+        }
+        let next = map.len();
+        let id = *map.entry(digits.clone()).or_insert(next);
+        out.push_str(&rest[..pos]);
+        out.push_str(marker);
+        out.push('#');
+        out.push_str(&id.to_string());
+        rest = &rest[start + digits.len()..];
+    }
+    out.push_str(rest);
+    out
 }
 
 fn first_diff(expected: &str, live: &str) -> String {

--- a/hew-cli/tests/funcupdate_mir_baselines.rs
+++ b/hew-cli/tests/funcupdate_mir_baselines.rs
@@ -7,7 +7,7 @@
 //! reference differential (`hew-mir` `coarse_verdict_differential`) proves the
 //! boolean verdicts byte-identical; this harness proves the EMITTED elaborated
 //! MIR (including drop plans) of the fixtures that exercise those consumers is
-//! identical to baselines generated at the branch base (`3683c2ac5`,
+//! identical to baselines generated at the rebase base (`d5fbb9c86`,
 //! `hew compile --dump-mir elab`) under ONE normalization rule: the dump's
 //! FUNCTION ORDER is nondeterministic (map iteration), so both sides are
 //! split into per-function chunks and sorted by signature line before the
@@ -112,7 +112,7 @@ fn funcupdate_reassign_elab_mir_matches_committed_baselines() {
         assert!(
             live_norm == expected_norm,
             "elaborated MIR for `{fixture}` diverged from the committed baseline \
-             `{baseline}` (generated at 3683c2ac5). A funcupdate/reassign consumer's \
+             `{baseline}` (generated at d5fbb9c86). A funcupdate/reassign consumer's \
              lowering or drop plan CHANGED — this is the Coarse-drift signal the boolean \
              differential cannot see. If the change is intended and reviewed, regenerate \
              the baseline per the manifest header. First differing line (after \

--- a/hew-mir/src/lib.rs
+++ b/hew-mir/src/lib.rs
@@ -13,6 +13,7 @@ pub mod liveness;
 pub mod lower;
 pub mod model;
 pub mod ownership;
+pub mod return_provenance;
 pub mod runtime_call;
 pub mod runtime_symbols;
 pub mod state_clone;

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -8458,6 +8458,15 @@ fn lower_function(
     builder.lower_params(func);
     builder.funcupdate_base_proven =
         compute_funcupdate_base_provenance(func, funcupdate_fn_returns_fresh);
+    // #2648 S2b — the caller arg-scan's per-function local freshness facts,
+    // computed under the SAME module tables the S1 fixpoint used.
+    builder.call_scrutinee_local_freshness =
+        crate::return_provenance::compute_local_binding_freshness(
+            func,
+            &call_scrutinee_provenance.provenance,
+            &call_scrutinee_provenance.extern_table,
+            &call_scrutinee_provenance.may_mutate,
+        );
     builder.function_body(func);
 
     // Effective return type after type-parameter substitution.
@@ -9883,6 +9892,13 @@ struct Builder {
     /// preserves today's mint, never a wrongly-Fresh admit). See
     /// `crate::return_provenance::CallScrutineeProvenance`.
     call_scrutinee_provenance: Rc<crate::return_provenance::CallScrutineeProvenance>,
+    /// Per-function local-binding freshness facts (#2648 S2b) consumed by the
+    /// caller-side argument scan: which of the CURRENT function's locals are
+    /// provably solely-owned fresh values (S1 bits `∅`, plain `let`, not
+    /// aliased, single read). Computed once per lowered function in
+    /// `lower_function`; the empty default (synthetic machine-step builders,
+    /// child builders, tests) admits NO local argument — fail-closed.
+    call_scrutinee_local_freshness: crate::return_provenance::LocalBindingFreshness,
     /// Module-global RAII-2 param-ownership facts: which affine
     /// `#[resource]` free-fn params are CONSUME (callee owns + drops) vs
     /// BORROW (caller keeps + drops), and the call-arg `SiteId`s whose
@@ -11060,7 +11076,7 @@ impl Builder {
         // `Vec<_>`-iteration desugar, a `GeneratorNext`, a bare place, an
         // aggregate) is `NotApplicable` ON KIND — exactly `call_scrutinee_owned_ty`'s
         // early `None`, before any runtime-identity resolution can be consulted.
-        let HirExprKind::Call { callee, .. } = &scrutinee.kind else {
+        let HirExprKind::Call { callee, args } = &scrutinee.kind else {
             return Ok(CallScrutineeAdmission::NotApplicable);
         };
         if let HirExprKind::BindingRef { name, resolved } = &callee.kind {
@@ -11102,6 +11118,18 @@ impl Builder {
                 // precise summary ONLY for the interim `PARAM`-present reject.
                 if let Some(bits) = prov.provenance.get(id) {
                     if bits.contains(AliasBits::PARAM) {
+                        // S2b — the ParamsOnly caller arg-scan. A `{PARAM}`-only
+                        // summary means the return can alias ONLY the callee's
+                        // by-value heap parameters, so when EVERY argument is
+                        // provably fresh at this call site the returned value
+                        // derives exclusively from fresh inputs — a fresh sole
+                        // owner: ADMIT (the template/semver stdlib shape). A
+                        // mixed `PARAM|OPAQUE` summary stays an unconditional
+                        // reject — the `OPAQUE` component is never
+                        // arg-rescuable.
+                        if bits.is_params_only() && self.params_only_args_provably_fresh(args) {
+                            return Ok(CallScrutineeAdmission::Admit);
+                        }
                         return Err(Box::new(Self::call_scrutinee_reject(
                             scrutinee,
                             "the called function may return one of its by-value heap parameters \
@@ -11140,6 +11168,97 @@ impl Builder {
                 "#2648: {why}. Bind the call result to a `let` and match on the binding, or \
                  return a freshly-constructed value from the callee."
             ),
+        }
+    }
+
+    /// #2648 S2b — the caller-side argument scan for a `ParamsOnly` callee
+    /// (plan Fix-design (2), pulled forward from S4b by the ratchet evidence:
+    /// the interim PARAM-present reject falsely rejected genuine `ParamsOnly`
+    /// stdlib callers — `template.try_parse("…")` and friends). True iff EVERY
+    /// argument is provably fresh, in which case the callee's `PARAM`-aliasing
+    /// return can only alias fresh inputs — a fresh sole owner.
+    ///
+    /// Consulted ONLY for a `{PARAM}`-only summary; an `OPAQUE`-carrying
+    /// summary is never arg-rescuable.
+    fn params_only_args_provably_fresh(&self, args: &[HirExpr]) -> bool {
+        args.iter().all(|a| self.scrutinee_arg_provably_fresh(a))
+    }
+
+    /// The inline-fresh recursion. Fresh shapes ADMIT:
+    /// - a scalar-typed argument (owns no heap — cannot be the forwarded
+    ///   buffer);
+    /// - a literal / record clone (fresh by construction);
+    /// - an aggregate (`StructInit`/`TupleLiteral`/`MachineVariantCtor`) whose
+    ///   EVERY operand is recursively fresh;
+    /// - a nested call to a Fresh-summary module fn, or to a `ParamsOnly`
+    ///   module fn whose own arguments are recursively fresh;
+    /// - a builtin-collection method that lowers to a proved-owner EMITTED
+    ///   symbol (clone/retain/take — the F1 contract);
+    /// - a local binding proven solely-owned fresh by the per-function
+    ///   freshness facts (S1 bits `∅`, plain `let`, unaliased, single read).
+    ///
+    /// EVERYTHING ELSE fails closed — notably a heap-owning PLACE
+    /// (`h.b`, the primary #2648 forwarder repro), a bare parameter, an
+    /// aliased or re-read local, an extern call, and any unmodelled form.
+    fn scrutinee_arg_provably_fresh(&self, arg: &HirExpr) -> bool {
+        use crate::return_provenance::{method_return_provenance, ty_is_scalar_non_heap};
+        if ty_is_scalar_non_heap(&self.subst_ty(&arg.ty)) {
+            return true;
+        }
+        match &arg.kind {
+            HirExprKind::Literal(_) | HirExprKind::RecordCloneCall { .. } => true,
+            HirExprKind::StructInit { fields, base, .. } => {
+                fields
+                    .iter()
+                    .all(|(_, v)| self.scrutinee_arg_provably_fresh(v))
+                    && base
+                        .as_deref()
+                        .is_none_or(|b| self.scrutinee_arg_provably_fresh(b))
+            }
+            HirExprKind::TupleLiteral { elements } => elements
+                .iter()
+                .all(|e| self.scrutinee_arg_provably_fresh(e)),
+            HirExprKind::MachineVariantCtor { payload, .. } => payload
+                .as_ref()
+                .is_none_or(|fs| fs.iter().all(|(_, v)| self.scrutinee_arg_provably_fresh(v))),
+            HirExprKind::Call { callee, args } => {
+                let HirExprKind::BindingRef {
+                    name,
+                    resolved: ResolvedRef::Item(id),
+                } = &callee.kind
+                else {
+                    return false;
+                };
+                // An extern call dispatches by NAME (placeholder ItemId) and no
+                // heap-returning extern is trusted fresh in the interim.
+                if self.call_scrutinee_provenance.extern_names.contains(name) {
+                    return false;
+                }
+                match self.call_scrutinee_provenance.provenance.get(id) {
+                    Some(bits) if bits.is_fresh() => true,
+                    Some(bits) if bits.is_params_only() => {
+                        self.params_only_args_provably_fresh(args)
+                    }
+                    Some(_) => false,
+                    // An audited builtin collection constructor (`Vec::new()`)
+                    // is a fresh empty allocation — the same clause the
+                    // Precise policy's `classify_call` applies.
+                    None => crate::return_provenance::is_builtin_fresh_ctor(name),
+                }
+            }
+            // A builtin-collection getter is fresh iff the EMITTED symbol is a
+            // proved-owner clone/retain/take (the F1 contract) — never the HIR
+            // placeholder.
+            HirExprKind::ResolvedImplCall { .. } => self
+                .method_scrutinee_emitted_symbol(arg)
+                .is_some_and(|sym| method_return_provenance(&sym).is_fresh()),
+            HirExprKind::BindingRef {
+                resolved: ResolvedRef::Binding(id),
+                ..
+            } => self
+                .call_scrutinee_local_freshness
+                .local_is_provably_fresh(*id),
+            _ => false,
         }
     }
 
@@ -23606,25 +23725,36 @@ impl Builder {
 
     /// Group A plain-`Call` arm: apply the interim module-fn PARAM-present reject
     /// (the same rule the preflight admission classifier applies upstream — this
-    /// is the one-authority defence-in-depth for the #2523 twin). A resolved
-    /// module-fn callee whose precise summary contains PARAM forwards a by-value
-    /// heap parameter (a caller-retained borrow) → Reject. Every other callee
-    /// (`∅`/`OPAQUE`-only module fn, unknown/cross-module item, extern, builtin,
-    /// indirect/closure) keeps today's `EphemeralTemp` — the interim legacy
-    /// fail-open window; the FULL `OPAQUE`-only reject lands at S4b.
+    /// is the one-authority defence-in-depth for the #2523 twin), rescued by the
+    /// SAME S2b caller arg-scan: a `{PARAM}`-only summary whose every argument is
+    /// provably fresh is a fresh sole owner → `EphemeralTemp` (the twin agrees
+    /// with the preflight's `Admit`). A PARAM-carrying summary that the arg-scan
+    /// cannot rescue (a place/param/aliased-local argument, or a mixed
+    /// `PARAM|OPAQUE` return) → Reject. Every other callee (`∅`/`OPAQUE`-only
+    /// module fn, unknown/cross-module item, extern, builtin, indirect/closure)
+    /// keeps today's `EphemeralTemp` — the interim legacy fail-open window; the
+    /// FULL `OPAQUE`-only reject lands at S4b.
     fn classify_call_arm_scrutinee_origin(&self, scrutinee: &HirExpr) -> ProjectedPayloadOrigin {
         use crate::return_provenance::AliasBits;
-        if let HirExprKind::Call { callee, .. } = &scrutinee.kind {
+        if let HirExprKind::Call { callee, args } = &scrutinee.kind {
             if let HirExprKind::BindingRef {
+                name,
                 resolved: ResolvedRef::Item(id),
-                ..
             } = &callee.kind
             {
-                if let Some(bits) = self.call_scrutinee_provenance.provenance.get(id) {
-                    if bits.contains(AliasBits::PARAM) {
-                        return ProjectedPayloadOrigin::Reject(
-                            ProjectedPayloadRejectReason::AliasesCallerStorage,
-                        );
+                // An extern callee carries the PLACEHOLDER `ItemId(0)` — never
+                // consult the module summary for it (id collision); the
+                // preflight already rejected any heap-extern scrutinee.
+                if !self.call_scrutinee_provenance.extern_names.contains(name) {
+                    if let Some(bits) = self.call_scrutinee_provenance.provenance.get(id) {
+                        if bits.contains(AliasBits::PARAM) {
+                            if bits.is_params_only() && self.params_only_args_provably_fresh(args) {
+                                return ProjectedPayloadOrigin::EphemeralTemp;
+                            }
+                            return ProjectedPayloadOrigin::Reject(
+                                ProjectedPayloadRejectReason::AliasesCallerStorage,
+                            );
+                        }
                     }
                 }
             }
@@ -61492,6 +61622,7 @@ mod twin_gate_classifier {
             provenance,
             extern_names: HashSet::new(),
             extern_table: ExternContractTable::default(),
+            may_mutate: HashMap::new(),
         });
         let callee = expr(
             HirExprKind::BindingRef {
@@ -61500,16 +61631,100 @@ mod twin_gate_classifier {
             },
             ResolvedTy::Unit,
         );
+        // `passthru(h.b)` — the forwarded argument is a re-readable heap PLACE,
+        // so the S2b arg-scan cannot rescue the `{PARAM}` summary.
+        let place_arg = expr(
+            HirExprKind::FieldAccess {
+                object: Box::new(binding_ref("h", 0, ResolvedTy::String)),
+                field: "b".to_string(),
+            },
+            ResolvedTy::String,
+        );
         let call = expr(
             HirExprKind::Call {
                 callee: Box::new(callee),
-                args: vec![],
+                args: vec![place_arg],
             },
             ResolvedTy::String,
         );
         assert!(
             is_alias_reject(&b.classify_scrutinee_origin(&call)),
-            "a PARAM-forwarding module-fn call scrutinee must reject"
+            "a PARAM-forwarding module-fn call scrutinee over a place arg must reject"
+        );
+    }
+
+    #[test]
+    fn call_forwarding_a_param_summary_over_fresh_arg_admits() {
+        // S2b — the arg-scan rescue: the SAME `{PARAM}`-only callee over an
+        // inline string literal is a fresh sole owner (the template/semver
+        // stdlib shape) → the twin gate agrees with the preflight's Admit.
+        let mut b = Builder::default();
+        let mut provenance = HashMap::new();
+        provenance.insert(hew_hir::ItemId(7), AliasBits::PARAM);
+        b.call_scrutinee_provenance = Rc::new(CallScrutineeProvenance {
+            provenance,
+            extern_names: HashSet::new(),
+            extern_table: ExternContractTable::default(),
+            may_mutate: HashMap::new(),
+        });
+        let callee = expr(
+            HirExprKind::BindingRef {
+                name: "try_parse".to_string(),
+                resolved: ResolvedRef::Item(hew_hir::ItemId(7)),
+            },
+            ResolvedTy::Unit,
+        );
+        let literal_arg = expr(
+            HirExprKind::Literal(hew_hir::HirLiteral::String("hello {{.name".to_string())),
+            ResolvedTy::String,
+        );
+        let call = expr(
+            HirExprKind::Call {
+                callee: Box::new(callee),
+                args: vec![literal_arg],
+            },
+            ResolvedTy::String,
+        );
+        assert!(
+            is_ephemeral(&b.classify_scrutinee_origin(&call)),
+            "a ParamsOnly callee over an inline-fresh literal arg is a fresh sole owner"
+        );
+    }
+
+    #[test]
+    fn call_with_mixed_param_opaque_summary_rejects_despite_fresh_args() {
+        // A mixed `PARAM|OPAQUE` summary is never arg-rescuable — the OPAQUE
+        // component can alias a capture/global regardless of the arguments.
+        let mut b = Builder::default();
+        let mut provenance = HashMap::new();
+        provenance.insert(hew_hir::ItemId(7), AliasBits::PARAM | AliasBits::OPAQUE);
+        b.call_scrutinee_provenance = Rc::new(CallScrutineeProvenance {
+            provenance,
+            extern_names: HashSet::new(),
+            extern_table: ExternContractTable::default(),
+            may_mutate: HashMap::new(),
+        });
+        let callee = expr(
+            HirExprKind::BindingRef {
+                name: "mixed".to_string(),
+                resolved: ResolvedRef::Item(hew_hir::ItemId(7)),
+            },
+            ResolvedTy::Unit,
+        );
+        let literal_arg = expr(
+            HirExprKind::Literal(hew_hir::HirLiteral::String("x".to_string())),
+            ResolvedTy::String,
+        );
+        let call = expr(
+            HirExprKind::Call {
+                callee: Box::new(callee),
+                args: vec![literal_arg],
+            },
+            ResolvedTy::String,
+        );
+        assert!(
+            is_alias_reject(&b.classify_scrutinee_origin(&call)),
+            "a PARAM|OPAQUE summary must reject even over fresh args"
         );
     }
 
@@ -61524,6 +61739,7 @@ mod twin_gate_classifier {
             provenance,
             extern_names: HashSet::new(),
             extern_table: ExternContractTable::default(),
+            may_mutate: HashMap::new(),
         });
         let callee = expr(
             HirExprKind::BindingRef {

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -2738,6 +2738,15 @@ pub fn lower_hir_module_with_facts(
     // it without re-cloning the map.
     let funcupdate_fn_returns_fresh: Rc<HashMap<hew_hir::ItemId, bool>> =
         Rc::new(compute_fn_returns_fresh_owner(&origin_fns));
+    // Module-global call-scrutinee return-provenance context (#2648): the precise
+    // three-state provenance fixpoint (+ the interprocedural mutation summary),
+    // the declared-extern id set, and the audited extern contract table. Computed
+    // ONCE and threaded (as `Rc`) into every body-lowering builder so the
+    // preflight admission classifier rejects a forwarded borrowed-parameter
+    // scrutinee before the from-call owner mint fires.
+    let call_scrutinee_provenance: Rc<crate::return_provenance::CallScrutineeProvenance> = Rc::new(
+        crate::return_provenance::build_call_scrutinee_provenance(module, &origin_fns),
+    );
     // Module-global RAII-2 (#1295) param-ownership facts: which affine
     // `#[resource]` free-fn value params are CONSUME vs BORROW, and the
     // call-arg `SiteId`s whose over-stamped `Consume` intent is downgraded to a
@@ -2790,6 +2799,7 @@ pub fn lower_hir_module_with_facts(
                         &module_fn_names,
                         &module_generic_fn_names,
                         &funcupdate_fn_returns_fresh,
+                        &call_scrutinee_provenance,
                         &param_ownership,
                         &trait_impl_index,
                         &module.call_site_type_args,
@@ -2842,6 +2852,7 @@ pub fn lower_hir_module_with_facts(
                     &module_fn_names,
                     &module_generic_fn_names,
                     &funcupdate_fn_returns_fresh,
+                    &call_scrutinee_provenance,
                     &param_ownership,
                     &trait_impl_index,
                     &module.call_site_type_args,
@@ -2883,6 +2894,7 @@ pub fn lower_hir_module_with_facts(
                     &module_fn_names,
                     &module_generic_fn_names,
                     &funcupdate_fn_returns_fresh,
+                    &call_scrutinee_provenance,
                     &param_ownership,
                     &module.call_site_type_args,
                     &module.supervisor_child_slots,
@@ -2925,6 +2937,7 @@ pub fn lower_hir_module_with_facts(
                     &module_fn_names,
                     &module_generic_fn_names,
                     &funcupdate_fn_returns_fresh,
+                    &call_scrutinee_provenance,
                     &param_ownership,
                     &module.call_site_type_args,
                     &module.supervisor_child_slots,
@@ -3013,6 +3026,7 @@ pub fn lower_hir_module_with_facts(
                     &module_fn_names,
                     &module_generic_fn_names,
                     &funcupdate_fn_returns_fresh,
+                    &call_scrutinee_provenance,
                     &param_ownership,
                     &module.call_site_type_args,
                     &module.supervisor_child_slots,
@@ -3079,6 +3093,7 @@ pub fn lower_hir_module_with_facts(
             &module_fn_names,
             &module_generic_fn_names,
             &funcupdate_fn_returns_fresh,
+            &call_scrutinee_provenance,
             &param_ownership,
             &trait_impl_index,
             &module.call_site_type_args,
@@ -3380,6 +3395,7 @@ fn lower_actor_receive_handlers(
     module_fn_names: &HashSet<String>,
     module_generic_fn_names: &HashSet<String>,
     funcupdate_fn_returns_fresh: &Rc<HashMap<hew_hir::ItemId, bool>>,
+    call_scrutinee_provenance: &Rc<crate::return_provenance::CallScrutineeProvenance>,
     param_ownership: &Rc<ParamOwnershipFacts>,
     call_site_type_args: &HashMap<hew_hir::SiteId, Vec<ResolvedTy>>,
     supervisor_child_slots: &HashMap<hew_hir::SiteId, ChildSlot>,
@@ -3465,6 +3481,7 @@ fn lower_actor_receive_handlers(
             module_fn_names,
             module_generic_fn_names,
             funcupdate_fn_returns_fresh,
+            call_scrutinee_provenance,
             param_ownership,
             &HashMap::new(),
             call_site_type_args,
@@ -3496,6 +3513,7 @@ fn lower_actor_body_handlers(
     module_fn_names: &HashSet<String>,
     module_generic_fn_names: &HashSet<String>,
     funcupdate_fn_returns_fresh: &Rc<HashMap<hew_hir::ItemId, bool>>,
+    call_scrutinee_provenance: &Rc<crate::return_provenance::CallScrutineeProvenance>,
     param_ownership: &Rc<ParamOwnershipFacts>,
     call_site_type_args: &HashMap<hew_hir::SiteId, Vec<ResolvedTy>>,
     supervisor_child_slots: &HashMap<hew_hir::SiteId, ChildSlot>,
@@ -3520,6 +3538,7 @@ fn lower_actor_body_handlers(
             module_fn_names,
             module_generic_fn_names,
             funcupdate_fn_returns_fresh,
+            call_scrutinee_provenance,
             param_ownership,
             call_site_type_args,
             supervisor_child_slots,
@@ -3544,6 +3563,7 @@ fn lower_actor_body_handlers(
         module_fn_names,
         module_generic_fn_names,
         funcupdate_fn_returns_fresh,
+        call_scrutinee_provenance,
         param_ownership,
         call_site_type_args,
         supervisor_child_slots,
@@ -3565,6 +3585,7 @@ fn lower_actor_body_handlers(
         module_fn_names,
         module_generic_fn_names,
         funcupdate_fn_returns_fresh,
+        call_scrutinee_provenance,
         param_ownership,
         call_site_type_args,
         supervisor_child_slots,
@@ -3594,6 +3615,7 @@ fn lower_actor_init_handler(
     module_fn_names: &HashSet<String>,
     module_generic_fn_names: &HashSet<String>,
     funcupdate_fn_returns_fresh: &Rc<HashMap<hew_hir::ItemId, bool>>,
+    call_scrutinee_provenance: &Rc<crate::return_provenance::CallScrutineeProvenance>,
     param_ownership: &Rc<ParamOwnershipFacts>,
     call_site_type_args: &HashMap<hew_hir::SiteId, Vec<ResolvedTy>>,
     supervisor_child_slots: &HashMap<hew_hir::SiteId, ChildSlot>,
@@ -3647,6 +3669,7 @@ fn lower_actor_init_handler(
         module_fn_names,
         module_generic_fn_names,
         funcupdate_fn_returns_fresh,
+        call_scrutinee_provenance,
         param_ownership,
         &HashMap::new(),
         call_site_type_args,
@@ -3679,6 +3702,7 @@ fn lower_actor_lifecycle_handlers(
     module_fn_names: &HashSet<String>,
     module_generic_fn_names: &HashSet<String>,
     funcupdate_fn_returns_fresh: &Rc<HashMap<hew_hir::ItemId, bool>>,
+    call_scrutinee_provenance: &Rc<crate::return_provenance::CallScrutineeProvenance>,
     param_ownership: &Rc<ParamOwnershipFacts>,
     call_site_type_args: &HashMap<hew_hir::SiteId, Vec<ResolvedTy>>,
     supervisor_child_slots: &HashMap<hew_hir::SiteId, ChildSlot>,
@@ -3737,6 +3761,7 @@ fn lower_actor_lifecycle_handlers(
                     module_fn_names,
                     module_generic_fn_names,
                     funcupdate_fn_returns_fresh,
+                    call_scrutinee_provenance,
                     param_ownership,
                     &HashMap::new(),
                     call_site_type_args,
@@ -3788,6 +3813,7 @@ fn lower_actor_lifecycle_handlers(
                     module_fn_names,
                     module_generic_fn_names,
                     funcupdate_fn_returns_fresh,
+                    call_scrutinee_provenance,
                     param_ownership,
                     &HashMap::new(),
                     call_site_type_args,
@@ -4060,6 +4086,7 @@ fn lower_actor_lifecycle_handlers(
                     module_fn_names,
                     module_generic_fn_names,
                     funcupdate_fn_returns_fresh,
+                    call_scrutinee_provenance,
                     param_ownership,
                     &HashMap::new(),
                     call_site_type_args,
@@ -4168,6 +4195,7 @@ fn lower_actor_lifecycle_handlers(
                     module_fn_names,
                     module_generic_fn_names,
                     funcupdate_fn_returns_fresh,
+                    call_scrutinee_provenance,
                     param_ownership,
                     &HashMap::new(),
                     call_site_type_args,
@@ -4390,6 +4418,7 @@ fn synthesize_machine_step_fn(
     module_fn_names: &HashSet<String>,
     module_generic_fn_names: &HashSet<String>,
     funcupdate_fn_returns_fresh: &Rc<HashMap<hew_hir::ItemId, bool>>,
+    call_scrutinee_provenance: &Rc<crate::return_provenance::CallScrutineeProvenance>,
     param_ownership: &Rc<ParamOwnershipFacts>,
     call_site_type_args: &HashMap<hew_hir::SiteId, Vec<ResolvedTy>>,
     supervisor_child_slots: &HashMap<hew_hir::SiteId, ChildSlot>,
@@ -4440,6 +4469,7 @@ fn synthesize_machine_step_fn(
         module_fn_names: module_fn_names.clone(),
         module_generic_fn_names: module_generic_fn_names.clone(),
         funcupdate_fn_returns_fresh: funcupdate_fn_returns_fresh.clone(),
+        call_scrutinee_provenance: call_scrutinee_provenance.clone(),
         param_ownership: param_ownership.clone(),
         call_site_type_args: call_site_type_args.clone(),
         supervisor_child_slots: supervisor_child_slots.clone(),
@@ -5403,6 +5433,7 @@ fn lower_supervisor_bootstrap(
     module_fn_names: &HashSet<String>,
     module_generic_fn_names: &HashSet<String>,
     funcupdate_fn_returns_fresh: &Rc<HashMap<hew_hir::ItemId, bool>>,
+    call_scrutinee_provenance: &Rc<crate::return_provenance::CallScrutineeProvenance>,
     param_ownership: &Rc<ParamOwnershipFacts>,
     call_site_type_args: &HashMap<hew_hir::SiteId, Vec<ResolvedTy>>,
     supervisor_child_slots: &HashMap<hew_hir::SiteId, ChildSlot>,
@@ -5739,6 +5770,7 @@ fn lower_supervisor_bootstrap(
         module_fn_names,
         module_generic_fn_names,
         funcupdate_fn_returns_fresh,
+        call_scrutinee_provenance,
         param_ownership,
         &HashMap::new(),
         call_site_type_args,
@@ -8324,6 +8356,7 @@ fn lower_function(
     module_fn_names: &HashSet<String>,
     module_generic_fn_names: &HashSet<String>,
     funcupdate_fn_returns_fresh: &Rc<HashMap<hew_hir::ItemId, bool>>,
+    call_scrutinee_provenance: &Rc<crate::return_provenance::CallScrutineeProvenance>,
     param_ownership: &Rc<ParamOwnershipFacts>,
     trait_impl_index: &HashMap<
         hew_hir::dispatch::TraitImplKey,
@@ -8373,6 +8406,7 @@ fn lower_function(
         module_fn_names: module_fn_names.clone(),
         module_generic_fn_names: module_generic_fn_names.clone(),
         funcupdate_fn_returns_fresh: funcupdate_fn_returns_fresh.clone(),
+        call_scrutinee_provenance: call_scrutinee_provenance.clone(),
         param_ownership: param_ownership.clone(),
         trait_impl_index: trait_impl_index.clone(),
         subst,
@@ -9840,6 +9874,15 @@ struct Builder {
     /// builders share it cheaply; the empty default fails every call-base
     /// closed, which is sound. See `compute_fn_returns_fresh_owner`.
     funcupdate_fn_returns_fresh: Rc<HashMap<hew_hir::ItemId, bool>>,
+    /// Module-global call-scrutinee return-provenance context (#2648) for the
+    /// preflight admission classifier (`classify_call_scrutinee_admission`). Maps
+    /// each module-fn `ItemId` to its precise three-state return provenance, the
+    /// declared-extern id set, and the audited extern contract table. `Rc` so
+    /// child builders share it cheaply; the empty default classifies every callee
+    /// as an unknown item → interim `LegacyModuleCall` fail-open (sound —
+    /// preserves today's mint, never a wrongly-Fresh admit). See
+    /// `crate::return_provenance::CallScrutineeProvenance`.
+    call_scrutinee_provenance: Rc<crate::return_provenance::CallScrutineeProvenance>,
     /// Module-global RAII-2 param-ownership facts: which affine
     /// `#[resource]` free-fn params are CONSUME (callee owns + drops) vs
     /// BORROW (caller keeps + drops), and the call-arg `SiteId`s whose
@@ -10985,11 +11028,136 @@ impl Builder {
         Some(ty)
     }
 
+    /// #2648 preflight admission classifier — pure HIR, run at the TOP of every
+    /// call-scrutinee consumer BEFORE `lower_value`/CFG allocation. Returns the
+    /// admission token the from-call owner mint and the #2523 origin consume, or
+    /// an `Err(MirDiagnostic)` reject (ONE diagnostic, no partial MIR) for a
+    /// scrutinee whose callee may hand back a borrowed by-value parameter alias
+    /// (summary contains `PARAM`) or an un-audited heap-returning `extern`.
+    ///
+    /// # Interim behaviour (S2–S4, before the trusted-root precursor merges)
+    ///
+    /// - A resolved module-fn callee whose precise summary carries `PARAM`
+    ///   REJECTS — the PRIMARY #2648 forwarder double-free fix (`match
+    ///   passthru(h.b)`). Mixed `PARAM|OPAQUE` forwarders reject too.
+    /// - A module fn whose summary is `∅` (Fresh) or `OPAQUE`-only takes
+    ///   [`CallScrutineeAdmission::LegacyModuleCall`] — today's owner-mint
+    ///   admission EXACTLY (jwt/encrypt/semver/template keep compiling). The
+    ///   precise `OPAQUE`-only rejects + jwt/encrypt Fresh admits land at S4b.
+    /// - A declared heap-returning `extern` REJECTS — including a user extern
+    ///   whose NAME spoofs a runtime recv symbol (it resolves to
+    ///   `ResolvedRef::Item`, so it is keyed by id, never the name).
+    /// - Every recv/stream/`Builtin` carve-out, unknown/cross-module item, and
+    ///   indirect/closure callee behaves as today (`NotApplicable` /
+    ///   `LegacyModuleCall` fail-open).
+    fn classify_call_scrutinee_admission(
+        &self,
+        scrutinee: &HirExpr,
+    ) -> Result<crate::return_provenance::CallScrutineeAdmission, Box<MirDiagnostic>> {
+        use crate::return_provenance::{is_typed_recv_callee, AliasBits, CallScrutineeAdmission};
+        // Structural Call-gate FIRST: only a direct `Call` rvalue can mint the
+        // from-call owner. A non-`Call` scrutinee (a `Block`/`If` synthetic
+        // `Vec<_>`-iteration desugar, a `GeneratorNext`, a bare place, an
+        // aggregate) is `NotApplicable` ON KIND — exactly `call_scrutinee_owned_ty`'s
+        // early `None`, before any runtime-identity resolution can be consulted.
+        let HirExprKind::Call { callee, .. } = &scrutinee.kind else {
+            return Ok(CallScrutineeAdmission::NotApplicable);
+        };
+        if let HirExprKind::BindingRef { name, resolved } = &callee.kind {
+            // Typed carve-outs, keyed on the compiler-minted identity (NOT the
+            // display name): a recv/stream family or any `ResolvedRef::Builtin`
+            // callee carries its own per-iteration `BodyEndReleased` release, so
+            // no synthetic owner is minted. A user extern SPOOFING one of those
+            // names resolves to `ResolvedRef::Item` → does NOT match here → falls
+            // through to the reject arms below (closes the name-forgeable bypass).
+            if is_typed_recv_callee(callee) || matches!(resolved, ResolvedRef::Builtin(_)) {
+                return Ok(CallScrutineeAdmission::NotApplicable);
+            }
+            // Only a heap-owning-enum-composite return mints an owner; anything
+            // else is `NotApplicable`, exactly as `call_scrutinee_owned_ty`
+            // returns `None`.
+            let ty = self.subst_ty(&scrutinee.ty);
+            if !ty_is_heap_owning_enum_composite(&ty, &self.record_field_orders, &self.enum_layouts)
+            {
+                return Ok(CallScrutineeAdmission::NotApplicable);
+            }
+            let prov = &self.call_scrutinee_provenance;
+            // A declared user extern — even one whose name spoofs a runtime
+            // symbol — reaching the heap-enum ty-gate is an un-audited heap
+            // extern. A call to an extern dispatches by NAME (its call-site
+            // `ResolvedRef::Item` carries a placeholder id, not the declaration's),
+            // so extern detection keys on the name, BEFORE the runtime-symbol
+            // carve-out (closes the name-forgeable bypass). No heap extern is
+            // trusted-Fresh in the interim (the marker-backed jwt/encrypt rows
+            // land at S4b).
+            if prov.extern_names.contains(name) {
+                return Err(Box::new(Self::call_scrutinee_reject(
+                    scrutinee,
+                    "an un-audited heap-returning `extern` may hand back an interior pointer \
+                     the caller still owns",
+                )));
+            }
+            if let ResolvedRef::Item(id) = resolved {
+                // A resolved module fn with an analysable body: consult its
+                // precise summary ONLY for the interim `PARAM`-present reject.
+                if let Some(bits) = prov.provenance.get(id) {
+                    if bits.contains(AliasBits::PARAM) {
+                        return Err(Box::new(Self::call_scrutinee_reject(
+                            scrutinee,
+                            "the called function may return one of its by-value heap parameters \
+                             (a borrow the caller still owns), so minting a second owner over \
+                             the scrutinee would double-free",
+                        )));
+                    }
+                    // Fresh or `OPAQUE`-only → interim legacy fail-open mint.
+                    return Ok(CallScrutineeAdmission::LegacyModuleCall);
+                }
+            }
+            // A genuine runtime-symbol callee that resolves to neither a user
+            // extern nor an analysable module fn keeps today's name-based skip.
+            if crate::runtime_symbols::is_known_runtime_symbol(name) {
+                return Ok(CallScrutineeAdmission::NotApplicable);
+            }
+        }
+        // An unknown/missing/cross-module item or a non-`BindingRef` (indirect /
+        // closure) callee → interim legacy fail-open (today's mint); the precise
+        // `OPAQUE` reject for these lands at S4b.
+        Ok(CallScrutineeAdmission::LegacyModuleCall)
+    }
+
+    /// Build the single #2648 reject diagnostic (a clean NYI — no partial
+    /// codegen). `why` names the specific unsound shape. Boxed to keep the
+    /// preflight's `Result` `Err` variant small.
+    fn call_scrutinee_reject(scrutinee: &HirExpr, why: &str) -> MirDiagnostic {
+        MirDiagnostic {
+            kind: MirDiagnosticKind::NotYetImplemented {
+                construct: "call-scrutinee returning a borrowed parameter or un-audited heap \
+                            extern"
+                    .to_string(),
+                site: scrutinee.site,
+            },
+            note: format!(
+                "#2648: {why}. Bind the call result to a `let` and match on the binding, or \
+                 return a freshly-constructed value from the callee."
+            ),
+        }
+    }
+
     fn register_from_call_scrutinee_owner(
         &mut self,
+        admission: crate::return_provenance::CallScrutineeAdmission,
         scrutinee: &HirExpr,
         scrutinee_local: u32,
     ) -> Option<(BindingId, ResolvedTy)> {
+        use crate::return_provenance::CallScrutineeAdmission;
+        // The non-optional admission token gates the mint [F4]: `NotApplicable`
+        // mints nothing (the scrutinee's own release runs); `Admit` /
+        // `LegacyModuleCall` proceed to the existing owner gate. A `Reject` never
+        // reaches here — the preflight returned early at the consumer.
+        match admission {
+            CallScrutineeAdmission::NotApplicable => return None,
+            CallScrutineeAdmission::Admit | CallScrutineeAdmission::LegacyModuleCall => {}
+        }
         let ty = self.call_scrutinee_owned_ty(scrutinee)?;
         let binding = self.register_synthetic_owned_local(
             SYNTHETIC_CALL_SCRUTINEE_NAME,
@@ -14936,6 +15104,12 @@ impl Builder {
         payload_variant_predicates: &[hew_hir::HirPayloadVariantPredicate],
         else_body: &hew_hir::HirBlock,
     ) {
+        // #2648 preflight — run BEFORE any allocation or scrutinee lowering. A
+        // reject pushes one diagnostic and returns with no partial MIR.
+        if let Err(diag) = self.classify_call_scrutinee_admission(scrutinee) {
+            self.diagnostics.push(*diag);
+            return;
+        }
         // Entry: evaluate scrutinee, load tag, branch.
         let Some(scrutinee_place) = self.lower_value(scrutinee) else {
             return;
@@ -15153,6 +15327,17 @@ impl Builder {
             // (`apply_nested_fresh_string_temp_drops`), which splices one inline
             // `hew_string_drop` after the unused producer. No Vec-specific
             // handling is owed here.
+            //
+            // #2648 preflight — run BEFORE `lower_value`. A rejected discarded
+            // call-scrutinee (forwarded borrowed parameter, un-audited heap
+            // extern) pushes one diagnostic and emits no MIR / no owner. The
+            // early return is the safety guard; the non-Call HashMap-get owner
+            // path in `register_discarded_call_result_owner` is `NotApplicable`
+            // to the preflight and proceeds unchanged.
+            if let Err(diag) = self.classify_call_scrutinee_admission(expr) {
+                self.diagnostics.push(*diag);
+                return;
+            }
             if let Some(place) = self.lower_value(expr) {
                 self.register_discarded_call_result_owner(expr, place);
             }
@@ -23500,6 +23685,17 @@ impl Builder {
         arms: &[hew_hir::HirMatchArm],
         result_ty: &ResolvedTy,
     ) -> Option<Place> {
+        // #2648 preflight — run BEFORE any `lower_value`/CFG allocation. A reject
+        // (forwarded borrowed parameter, un-audited heap extern) pushes exactly
+        // one diagnostic and returns with NO partial MIR: no scrutinee call, no
+        // owner mint, no `NeutralizePayloadSlot`.
+        let scrutinee_admission = match self.classify_call_scrutinee_admission(scrutinee) {
+            Ok(admission) => admission,
+            Err(diag) => {
+                self.diagnostics.push(*diag);
+                return None;
+            }
+        };
         // Result local first so every arm's Move dominates it.
         let result_place = self.alloc_local(result_ty.clone());
 
@@ -23598,7 +23794,7 @@ impl Builder {
         // (#2429). No-op for binding-ref scrutinees, runtime-symbol
         // producers, and the recv/iter-next shapes that carry their own
         // release discipline.
-        self.register_from_call_scrutinee_owner(scrutinee, scrutinee_local);
+        self.register_from_call_scrutinee_owner(scrutinee_admission, scrutinee, scrutinee_local);
 
         // Load the tag into a fresh i64 local. `Place::EnumTag(local)`
         // is the substrate primitive; codegen GEPs to outer-struct
@@ -24468,6 +24664,15 @@ impl Builder {
                       the algorithm is one coherent unit and factoring it would obscure \
                       the loop CFG"
         )]
+        // #2648 preflight — run BEFORE any block allocation or scrutinee lowering.
+        // A reject leaves no half-built loop CFG.
+        let scrutinee_admission = match self.classify_call_scrutinee_admission(scrutinee) {
+            Ok(admission) => admission,
+            Err(diag) => {
+                self.diagnostics.push(*diag);
+                return None;
+            }
+        };
         let header_bb = self.alloc_block();
         let body_bb = self.alloc_block();
         let exit_bb = self.alloc_block();
@@ -24498,7 +24703,11 @@ impl Builder {
                 return None;
             }
         };
-        let scrutinee_owner = self.register_from_call_scrutinee_owner(scrutinee, scrutinee_local);
+        let scrutinee_owner = self.register_from_call_scrutinee_owner(
+            scrutinee_admission,
+            scrutinee,
+            scrutinee_local,
+        );
         let false_cleanup_bb = scrutinee_owner.as_ref().map(|_| self.alloc_block());
 
         // Load the variant tag into a fresh i64 local, mirroring
@@ -24778,6 +24987,13 @@ impl Builder {
         else_body: Option<&hew_hir::HirBlock>,
         result_ty: &ResolvedTy,
     ) -> Option<Place> {
+        // #2648 preflight — run BEFORE any allocation or scrutinee lowering. If-let
+        // mints no from-call owner but DOES classify the #2523 projected-payload
+        // origin; the reject short-circuits that too (no partial MIR).
+        if let Err(diag) = self.classify_call_scrutinee_admission(scrutinee) {
+            self.diagnostics.push(*diag);
+            return None;
+        }
         let result_place = self.alloc_local(self.subst_ty(result_ty));
 
         // Entry: evaluate scrutinee, load tag, branch.
@@ -52109,6 +52325,7 @@ mod slice3_invariants {
                 &HashSet::new(),
                 &HashSet::new(),
                 &std::rc::Rc::new(std::collections::HashMap::new()),
+                &std::rc::Rc::new(crate::return_provenance::CallScrutineeProvenance::default()),
                 &std::rc::Rc::new(ParamOwnershipFacts::default()),
                 &HashMap::new(),
                 &HashMap::new(),

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -8219,6 +8219,13 @@ fn collect_return_values_in_expr<'f>(expr: &'f HirExpr, out: &mut Vec<&'f HirExp
         HirExprKind::Match { scrutinee, arms } => {
             collect_return_values_in_expr(scrutinee, out);
             for arm in arms {
+                // A `return <expr>` buried in an arm GUARD exits the function:
+                // its value is a return path the summary must union, or a
+                // guard-forwarded borrow reads wrongly-Fresh and the preflight
+                // mints a second owner over caller-owned storage.
+                if let Some(guard) = &arm.guard {
+                    collect_return_values_in_expr(guard, out);
+                }
                 collect_return_values_in_expr(&arm.body, out);
             }
         }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -7765,7 +7765,7 @@ fn collect_borrow_arg_sites_in_expr(
 /// Conservative by construction: a helper that returns a let-bound local
 /// (`fn make() { let x = Inner { .. }; x }`) is classified non-fresh — sound
 /// (fail-closed), at the cost of over-rejecting that idiom as a funcupdate base.
-fn compute_fn_returns_fresh_owner(
+pub(crate) fn compute_fn_returns_fresh_owner(
     fns: &HashMap<hew_hir::ItemId, &HirFn>,
 ) -> HashMap<hew_hir::ItemId, bool> {
     let mut fresh: HashMap<hew_hir::ItemId, bool> = fns.keys().map(|&id| (id, false)).collect();
@@ -7841,99 +7841,18 @@ fn fn_body_returns_fresh_owner(f: &HirFn, fresh: &HashMap<hew_hir::ItemId, bool>
 ///
 /// EXHAUSTIVE and fail-closed: every form that is not provably non-aliasing
 /// (a bare binding, a method call, a deref, any unmodelled form) returns `true`.
+///
+/// # Delegation (#2648)
+///
+/// The leaf walk now lives ONCE in [`crate::return_provenance::return_alias_bits`],
+/// parameterized by a `LeafPolicy`. This function is the byte-identical **Coarse**
+/// wrapper: `return_alias_bits(expr, &CoarsePolicy) != ∅` reproduces the exact
+/// pre-refactor boolean, keeping the shared funcupdate (#2420 base gate) /
+/// reassign consumers unchanged while #2648's Precise driver consumes the same
+/// walk under a different policy. Pinned byte-identical by the
+/// `coarse_verdict_differential` frozen-reference test.
 fn return_value_may_alias_borrow(expr: &HirExpr, fresh: &HashMap<hew_hir::ItemId, bool>) -> bool {
-    match &expr.kind {
-        // Value-passthrough wrappers: the value flows from the tail / both
-        // branches / every arm — aliasing iff ANY reachable value aliases.
-        HirExprKind::Block(block) => block
-            .tail
-            .as_deref()
-            .is_none_or(|t| return_value_may_alias_borrow(t, fresh)),
-        HirExprKind::If {
-            then_expr,
-            else_expr,
-            ..
-        } => {
-            return_value_may_alias_borrow(then_expr, fresh)
-                || else_expr
-                    .as_deref()
-                    .is_none_or(|e| return_value_may_alias_borrow(e, fresh))
-        }
-        HirExprKind::Match { arms, .. } => {
-            arms.is_empty()
-                || arms
-                    .iter()
-                    .any(|arm| return_value_may_alias_borrow(&arm.body, fresh))
-        }
-        // A nested `return <e>` in value position (`... else { return p }`)
-        // contributes its own value; it aliases iff that value does.
-        HirExprKind::Return { value } => value
-            .as_deref()
-            .is_none_or(|v| return_value_may_alias_borrow(v, fresh)),
-        // Fresh leaves — NEVER an alias of a caller-owned value. A `.clone()` is
-        // a deep copy; a `Vec<T>` element load / slice is an independent heap
-        // element (push-clone + refcount); a literal owns nothing borrowed.
-        HirExprKind::RecordCloneCall { .. }
-        | HirExprKind::Index { .. }
-        | HirExprKind::Slice { .. }
-        | HirExprKind::Literal(_) => false,
-        // A construction aliases a parameter iff one of its owned operands does.
-        // Storing a managed operand into a field/element refcount-bumps or
-        // COW-copies a PROJECTION/temporary, but a WHOLE by-value parameter is
-        // moved without a bump (`Outer { inner: p }` returns a value whose
-        // `inner` aliases the caller's argument — the call-returns-a-constructor-
-        // embedding-a-borrow use-after-free). The recursion bottoms a bare
-        // parameter operand out at the `_ => true` arm, so it is caught.
-        HirExprKind::StructInit { fields, base, .. } => {
-            fields
-                .iter()
-                .any(|(_, v)| return_value_may_alias_borrow(v, fresh))
-                || base
-                    .as_deref()
-                    .is_some_and(|b| return_value_may_alias_borrow(b, fresh))
-        }
-        HirExprKind::TupleLiteral { elements } => elements
-            .iter()
-            .any(|e| return_value_may_alias_borrow(e, fresh)),
-        HirExprKind::MachineVariantCtor { payload, .. } => payload.as_ref().is_some_and(|fields| {
-            fields
-                .iter()
-                .any(|(_, v)| return_value_may_alias_borrow(v, fresh))
-        }),
-        // A call that is NOT to a statically-resolved Item — a closure value, a
-        // function-pointer parameter, or any indirect/dynamic dispatch — can hand
-        // back a CAPTURED by-value heap parameter through its environment, a
-        // HIDDEN argument the explicit-arg flow below cannot see:
-        // `fn f(p) { let g = || -> Inner { p }; g() }` returns `p` with ZERO
-        // explicit arguments, so an `args`-only test would conclude "no args ⇒ no
-        // alias ⇒ fresh" and admit `..f(o.inner)` — the closure-capture-return
-        // use-after-free. Trust ONLY a resolved Item (a free function whose body
-        // the fixpoint analyzed, or an owned-return-ABI extern / constructor);
-        // every other callee may-alias regardless of arguments. Fail closed.
-        HirExprKind::Call { callee, args } => {
-            !callee_is_resolved_item(callee)
-                // A resolved free-function / owned-ABI extern / constructor call
-                // aliases a parameter iff the callee is NOT proven to return a
-                // fresh owner AND some argument itself aliases a parameter (the
-                // callee could forward that argument out). A proven-fresh callee
-                // never aliases regardless of arguments; a non-fresh callee with
-                // only non-aliasing arguments (`string.repeat("a", 32)`) cannot
-                // alias the ENCLOSING function's parameters. Param-flow, composed
-                // through the fixpoint.
-                || (!callee_returns_fresh_owner(callee, fresh)
-                    && args.iter().any(|a| return_value_may_alias_borrow(a, fresh)))
-        }
-        // A projection aliases a parameter iff its object chain does: `p.inner`
-        // / `t.0` bottoms out at a bare parameter (`_ => true`) and carries that
-        // up; `makeOuter().inner` bottoms out at a fresh `Call` and does not.
-        HirExprKind::FieldAccess { object, .. } => return_value_may_alias_borrow(object, fresh),
-        HirExprKind::TupleIndex { tuple, .. } => return_value_may_alias_borrow(tuple, fresh),
-        // A by-value parameter is a BORROW; a bare local may itself hold a
-        // borrow (`let x = p; x`); a method call can return borrowed `self` /
-        // a parameter; a deref and every other form are not provably fresh.
-        // Fail closed: assume the value MAY alias.
-        _ => true,
-    }
+    crate::return_provenance::coarse_may_alias_borrow(expr, fresh)
 }
 
 /// Resolve a `Call` callee to its freshness fact.
@@ -7991,7 +7910,7 @@ fn callee_is_resolved_item(callee: &HirExpr) -> bool {
 /// recursing into nested control flow but NOT into closures. Exhaustive over
 /// `HirStmtKind`: a missed return statement would let a borrowed-param return
 /// escape the freshness summary (a use-after-free), so every form is handled.
-fn collect_return_values_in_block<'f>(block: &'f HirBlock, out: &mut Vec<&'f HirExpr>) {
+pub(crate) fn collect_return_values_in_block<'f>(block: &'f HirBlock, out: &mut Vec<&'f HirExpr>) {
     for stmt in &block.statements {
         match &stmt.kind {
             HirStmtKind::Let(_, init) => {

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -61356,3 +61356,192 @@ mod call_args_borrow_safe_bytes_append_pins {
         );
     }
 }
+
+#[cfg(test)]
+mod twin_gate_classifier {
+    //! #2648 (S3) — direct unit tests of the #2523 projected-payload twin
+    //! classifier (`classify_scrutinee_origin`). The precise-freshness arms
+    //! (Group B aggregate constructors, Group C1 `Binary`, the Group A `Call`
+    //! interim PARAM reject) are unreachable through full lowering in current
+    //! code — a temporary aggregate scrutinee hits an upstream "non-BitCopy match
+    //! destructure on temporary scrutinee" NYI, and every real collection getter
+    //! lowers to the fresh-owner clone choke — so the classifier's reject/admit
+    //! verdict is pinned here directly on synthetic HIR. Exact-value assertions
+    //! (the precise origin variant), fail-closed by default.
+    use super::*;
+    use crate::return_provenance::{AliasBits, CallScrutineeProvenance, ExternContractTable};
+
+    fn expr(kind: HirExprKind, ty: ResolvedTy) -> HirExpr {
+        HirExpr {
+            node: HirNodeId(u32::MAX),
+            site: SiteId(u32::MAX),
+            ty,
+            value_class: ValueClass::BitCopy,
+            intent: IntentKind::Read,
+            kind,
+            span: 0..0,
+        }
+    }
+
+    fn binding_ref(name: &str, id: u32, ty: ResolvedTy) -> HirExpr {
+        expr(
+            HirExprKind::BindingRef {
+                name: name.to_string(),
+                resolved: ResolvedRef::Binding(BindingId(id)),
+            },
+            ty,
+        )
+    }
+
+    fn is_alias_reject(o: &ProjectedPayloadOrigin) -> bool {
+        matches!(
+            o,
+            ProjectedPayloadOrigin::Reject(ProjectedPayloadRejectReason::AliasesCallerStorage)
+        )
+    }
+
+    fn is_ephemeral(o: &ProjectedPayloadOrigin) -> bool {
+        matches!(o, ProjectedPayloadOrigin::EphemeralTemp)
+    }
+
+    #[test]
+    fn string_binary_scrutinee_is_fresh() {
+        let b = Builder::default();
+        let bin = expr(
+            HirExprKind::Binary {
+                op: BinaryOp::Add,
+                left: Box::new(binding_ref("a", 0, ResolvedTy::String)),
+                right: Box::new(binding_ref("b", 1, ResolvedTy::String)),
+            },
+            ResolvedTy::String,
+        );
+        assert!(
+            is_ephemeral(&b.classify_scrutinee_origin(&bin)),
+            "a string concat allocates fresh (hew_string_concat) — a fresh sole owner"
+        );
+    }
+
+    #[test]
+    fn heap_non_string_binary_scrutinee_rejects() {
+        let b = Builder::default();
+        let bin = expr(
+            HirExprKind::Binary {
+                op: BinaryOp::Add,
+                left: Box::new(binding_ref("a", 0, ResolvedTy::Bytes)),
+                right: Box::new(binding_ref("b", 1, ResolvedTy::Bytes)),
+            },
+            ResolvedTy::Bytes,
+        );
+        assert!(
+            is_alias_reject(&b.classify_scrutinee_origin(&bin)),
+            "a heap non-string Binary is not proven fresh — fail closed"
+        );
+    }
+
+    #[test]
+    fn aggregate_over_a_heap_place_operand_rejects() {
+        let b = Builder::default();
+        // (h.b, 0) — the string field `h.b` is a re-readable heap place.
+        let field = expr(
+            HirExprKind::FieldAccess {
+                object: Box::new(binding_ref("h", 0, ResolvedTy::String)),
+                field: "b".to_string(),
+            },
+            ResolvedTy::String,
+        );
+        let tuple = expr(
+            HirExprKind::TupleLiteral {
+                elements: vec![field, binding_ref("n", 1, ResolvedTy::I64)],
+            },
+            ResolvedTy::Unit,
+        );
+        assert!(
+            is_alias_reject(&b.classify_scrutinee_origin(&tuple)),
+            "an aggregate embedding a live heap place operand must reject"
+        );
+    }
+
+    #[test]
+    fn aggregate_over_fresh_operands_is_fresh() {
+        let b = Builder::default();
+        // (m, n) — both scalar (the type short-circuit proves each operand ∅).
+        let tuple = expr(
+            HirExprKind::TupleLiteral {
+                elements: vec![
+                    binding_ref("m", 0, ResolvedTy::I64),
+                    binding_ref("n", 1, ResolvedTy::I64),
+                ],
+            },
+            ResolvedTy::Unit,
+        );
+        assert!(
+            is_ephemeral(&b.classify_scrutinee_origin(&tuple)),
+            "an aggregate whose every operand is fresh is a fresh sole owner"
+        );
+    }
+
+    #[test]
+    fn call_forwarding_a_param_summary_rejects() {
+        // A resolved module-fn callee whose precise summary carries PARAM forwards
+        // a by-value heap parameter — the twin gate rejects it (defence-in-depth
+        // for the #2523 forwarding-call twin; the preflight owns the same reject).
+        let mut b = Builder::default();
+        let mut provenance = HashMap::new();
+        provenance.insert(hew_hir::ItemId(7), AliasBits::PARAM);
+        b.call_scrutinee_provenance = Rc::new(CallScrutineeProvenance {
+            provenance,
+            extern_names: HashSet::new(),
+            extern_table: ExternContractTable::default(),
+        });
+        let callee = expr(
+            HirExprKind::BindingRef {
+                name: "passthru".to_string(),
+                resolved: ResolvedRef::Item(hew_hir::ItemId(7)),
+            },
+            ResolvedTy::Unit,
+        );
+        let call = expr(
+            HirExprKind::Call {
+                callee: Box::new(callee),
+                args: vec![],
+            },
+            ResolvedTy::String,
+        );
+        assert!(
+            is_alias_reject(&b.classify_scrutinee_origin(&call)),
+            "a PARAM-forwarding module-fn call scrutinee must reject"
+        );
+    }
+
+    #[test]
+    fn call_to_a_fresh_summary_admits() {
+        // A resolved module-fn callee with no PARAM bit keeps today's admission
+        // (the interim legacy window).
+        let mut b = Builder::default();
+        let mut provenance = HashMap::new();
+        provenance.insert(hew_hir::ItemId(7), AliasBits::EMPTY);
+        b.call_scrutinee_provenance = Rc::new(CallScrutineeProvenance {
+            provenance,
+            extern_names: HashSet::new(),
+            extern_table: ExternContractTable::default(),
+        });
+        let callee = expr(
+            HirExprKind::BindingRef {
+                name: "make_fresh".to_string(),
+                resolved: ResolvedRef::Item(hew_hir::ItemId(7)),
+            },
+            ResolvedTy::Unit,
+        );
+        let call = expr(
+            HirExprKind::Call {
+                callee: Box::new(callee),
+                args: vec![],
+            },
+            ResolvedTy::String,
+        );
+        assert!(
+            is_ephemeral(&b.classify_scrutinee_origin(&call)),
+            "a fresh-summary call scrutinee is an ephemeral fresh owner"
+        );
+    }
+}

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -16009,6 +16009,18 @@ impl Builder {
                                              the arm body instead of the guard, or match an \
                                              owned value in a separate step after the guard"
                                         }
+                                        ProjectedPayloadRejectReason::AliasesCallerStorage => {
+                                            "the scrutinee produces a value that may alias \
+                                             caller-visible storage (a call forwarding a \
+                                             by-value heap parameter, an aggregate over a \
+                                             re-readable heap place, or a borrowed collection \
+                                             getter), not a fresh sole owner, so moving the \
+                                             payload out would leave that storage dangling \
+                                             (use-after-free on a re-read, double-free at its \
+                                             drop); construct the value fresh at the \
+                                             scrutinee, or bind the call result to a `let` \
+                                             and match the binding"
+                                        }
                                     };
                                     self.diagnostics.push(MirDiagnostic {
                                         kind:
@@ -23467,99 +23479,35 @@ impl Builder {
         Some(result_place)
     }
 
-    /// Lower a match expression whose non-wildcard arms are all
-    /// `HirMatchArmPredicate::EnumVariant` — the fast enum-tag-compare chain.
+    /// #2648 (S3, the #2523 twin gate) — the **Group C2** unconditional
+    /// ephemeral-producer set: shapes whose produced value provably owns no
+    /// re-readable heap alias, so the match temp is always a fresh sole owner
+    /// regardless of any operand.
     ///
-    /// Emits the following block topology over `Place::EnumTag(scrutinee)`:
-    ///
-    /// ```text
-    /// entry_bb (current):
-    ///   scrutinee_local = lower(scrutinee)
-    ///   tag_local = Move from Place::EnumTag(scrutinee_local)
-    ///   Goto check_bb_0
-    ///
-    /// check_bb_i (one per non-wildcard arm i):
-    ///   k = ConstI64(variant_idx_i)
-    ///   cond_i = IntCmp(Eq, tag_local, k)
-    ///   Branch { cond_i, then: body_bb_i, else: check_bb_{i+1} }
-    ///
-    /// body_bb_i:
-    ///   result_local = lower(arm_i.body)
-    ///   Goto join_bb
-    ///
-    /// (last check falls through to either the wildcard body or the
-    /// fail-closed trap block)
-    ///
-    /// wildcard_bb (when a wildcard arm exists):
-    ///   result_local = lower(wildcard.body)
-    ///   Goto join_bb
-    ///
-    /// fallthrough_bb (when no wildcard arm — emitted as a runtime guard
-    /// even though the checker pre-gates non-exhaustive matches per
-    /// LESSONS `match-fail-closed`):
-    ///   Trap { kind: ExhaustivenessFallthrough }
-    ///
-    /// join_bb:
-    ///   (subsequent lowering continues here; result is result_local)
-    /// ```
-    ///
-    /// #2523 (F1b) — is `kind` a *provably ephemeral* scrutinee producer: a
-    /// shape that constructs a brand-new value or returns one by value from a
-    /// call/await/effect, so the match temp is a fresh SOLE owner with no
-    /// re-readable aliasing origin?
-    ///
-    /// A projected-payload move-out is sound only when nulling the match temp
-    /// neutralizes the payload's sole surviving owner. That holds for a bare
-    /// owning binding (moved into the temp — handled separately as
-    /// [`ProjectedPayloadOrigin::OwnedBinding`]) and for the fresh value
-    /// producers allowlisted here. It FAILS for a place projection
-    /// (`match h.b`, `match pair.0`, `match arr[i]`, machine-field access): the
-    /// match COPIES the place into the temp, so the origin keeps a live alias
-    /// the temp-null cannot reach (silent use-after-free / double-free).
-    ///
-    /// This predicate is the **fail-closed allowlist**: the classifier defaults
-    /// every shape NOT proven here (place projections, `Block`/`If`/`Scope`
-    /// wrappers whose value is a sub-expression, and any un-enumerated or future
-    /// shape) to [`ProjectedPayloadOrigin::ReadablePlace`], which rejects the
-    /// move-out before codegen. Rejecting a wrapper-hidden but otherwise-safe
-    /// producer (e.g. `match { mk() }`) is acceptable — the safe default is to
-    /// reject rather than risk aliasing. Wrappers are deliberately NOT peeled:
-    /// tracing a `Block`/`If` tail to guess ephemerality would reintroduce the
-    /// fail-open surface F1b closes (`match { h.b }` byte-copy-aliases `h`).
-    ///
-    /// Every arm is a value-producing rvalue that either builds a new aggregate
-    /// (`StructInit`, `TupleLiteral`, `MachineVariantCtor`, `Literal`) or moves
-    /// a value out by return/receive (`Call`, method calls, `ask`/`recv`/await
-    /// and machine effect nodes). None denote existing storage or a borrowed
-    /// view, so the produced temp is always a fresh sole owner. Shapes with any
-    /// aliasing risk (`Index`/`Slice` views, `FieldAccess`/`TupleIndex` places,
-    /// `ContextReader`, `RegexLiteralRef`, `ActorSelf`, `CoerceToDynTrait`,
-    /// `Yield`, wrappers, control flow) are intentionally omitted → rejected.
-    fn hir_scrutinee_is_ephemeral_producer(kind: &HirExprKind) -> bool {
+    /// This is the residue of the old blanket allowlist after the arms that CAN
+    /// alias caller storage were split out into precise gates
+    /// (`classify_producer_scrutinee_origin`): `Binary` (Group C1, string-concat
+    /// is fresh but a heap non-string result is not), the aggregate constructors
+    /// (Group B, fresh iff every owned operand is fresh), and the call/method
+    /// arms (Group A, gated on the return-provenance authority). Everything left
+    /// here is either scalar/bool-valued (the type short-circuit proves `∅`) or a
+    /// MOVE out of a channel/mailbox/generator/machine (ownership transfers to
+    /// the receiver), so it stays an unconditional `EphemeralTemp`.
+    fn hir_scrutinee_is_unconditional_ephemeral_producer(kind: &HirExprKind) -> bool {
         matches!(
             kind,
-            // Fresh scalar/aggregate literals and pure-value operators.
+            // Fresh scalar literals and pure-value operators (scalar/bool result).
             HirExprKind::Literal { .. }
-                | HirExprKind::Binary { .. }
                 | HirExprKind::Unary { .. }
                 | HirExprKind::NumericCast { .. }
                 | HirExprKind::SaturatingWidthCast { .. }
                 | HirExprKind::TryWidthCast { .. }
-                | HirExprKind::TupleLiteral { .. }
-                | HirExprKind::StructInit { .. }
-                | HirExprKind::MachineVariantCtor { .. }
                 | HirExprKind::IdentityCompare { .. }
                 | HirExprKind::CancellationTokenIsCancelled { .. }
-                // Calls return an owned value by value (Hew has no reference
-                // returns) — the result temp is a fresh sole owner.
-                | HirExprKind::Call { .. }
-                | HirExprKind::CallDynMethod { .. }
-                | HirExprKind::CallTraitMethodStatic { .. }
-                | HirExprKind::VarSelfMethodCall { .. }
-                | HirExprKind::ResolvedImplCall { .. }
-                | HirExprKind::NumericMethod { .. }
-                | HirExprKind::RecordCloneCall { .. }
-                // Spawns/closures/generators produce fresh handles or objects.
+                // Spawns/closures/generators produce fresh handles or objects. A
+                // `Closure` capturing a heap place is not destructured into
+                // payload binders on this path, so it never reaches the
+                // meaningful gate (fail-closed tightening is a future lane).
                 | HirExprKind::Spawn { .. }
                 | HirExprKind::SpawnedCall { .. }
                 | HirExprKind::SpawnLambdaActor { .. }
@@ -23585,6 +23533,182 @@ impl Builder {
                 | HirExprKind::MachineStep { .. }
                 | HirExprKind::MachineTakeEmits { .. }
         )
+    }
+
+    /// #2648 (S3) — classify a non-`BindingRef` producer scrutinee for the #2523
+    /// projected-payload move-out policy, routing every arm that CAN forward a
+    /// caller-visible alias through the precise return-provenance authority
+    /// (Fix-design-3, Groups A/B/C). No producer arm is an unconditional admit;
+    /// a value that may alias caller storage is `Reject(AliasesCallerStorage)`.
+    ///
+    /// Interim [Rev-8]: the module-fn / builtin-getter tightenings that are
+    /// precursor-INDEPENDENT are LIVE (the PARAM-forwarder reject and the F1
+    /// borrowed-getter reject); the FULL precise `OPAQUE`-only module-fn rejects
+    /// land at S4b, so a `∅`/`OPAQUE`-only module-fn or a user method call keeps
+    /// today's `EphemeralTemp` (the legacy fail-open window, stated explicitly).
+    fn classify_producer_scrutinee_origin(&self, scrutinee: &HirExpr) -> ProjectedPayloadOrigin {
+        match &scrutinee.kind {
+            // Group A — plain call: interim module-fn rule (mirrors the preflight
+            // admission classifier). A resolved module-fn callee whose precise
+            // summary carries PARAM forwards a by-value heap parameter → Reject;
+            // `∅`/`OPAQUE`-only/unknown/extern/indirect → legacy `EphemeralTemp`.
+            HirExprKind::Call { .. } => self.classify_call_arm_scrutinee_origin(scrutinee),
+            // Group A — builtin-collection getter (`Vec`/`HashMap`/`HashSet`
+            // dispatch; `ResolvedImplCall` is builtin-collection-only). The F1
+            // emitted-symbol contract is precursor-INDEPENDENT and LIVE: Fresh
+            // (`hew_vec_get_clone` / `hew_hashmap_get_clone_layout` / owned-return
+            // string/bytes) → `EphemeralTemp`; a borrowed getter
+            // (`hew_vec_get_owned`/`_ptr`, a `Vec<Vec<T>>` `.get`) → Reject.
+            HirExprKind::ResolvedImplCall { .. } => {
+                self.classify_builtin_getter_scrutinee_origin(scrutinee)
+            }
+            // Group A — a `.clone()` returns a fresh independent owner; and the
+            // user method / trait / numeric method calls. Interim [Rev-8]: no
+            // resolvable module-fn PARAM summary is reachable through the
+            // receiver-keyed HIR variants, so they keep today's admission
+            // (`EphemeralTemp`) — the legacy fail-open window for opaque-hidden
+            // method forwarding, closed by the FULL precise method verdicts at
+            // S4b. `NumericMethod` returns a scalar (the move-out never records a
+            // heap provenance), so its classification is inert either way.
+            HirExprKind::RecordCloneCall { .. }
+            | HirExprKind::VarSelfMethodCall { .. }
+            | HirExprKind::CallDynMethod { .. }
+            | HirExprKind::CallTraitMethodStatic { .. }
+            | HirExprKind::NumericMethod { .. } => ProjectedPayloadOrigin::EphemeralTemp,
+            // Group B (aggregate constructors) + Group C1 (`Binary`) share ONE
+            // precise-freshness gate (R6 — the SAME `return_alias_bits` operand
+            // recursion the callee summary and the caller arg-scan use):
+            // `EphemeralTemp` iff the scrutinee's precise bits are `∅`, else
+            // Reject. An `Outer { inner: h.b }` / `(h.b, …)` over a live place is
+            // rejected UNCONDITIONALLY; a string concat (`hew_string_concat`,
+            // fresh-allocating) is `∅`, while a non-string heap `Binary` is not.
+            HirExprKind::StructInit { .. }
+            | HirExprKind::TupleLiteral { .. }
+            | HirExprKind::MachineVariantCtor { .. }
+            | HirExprKind::Binary { .. } => {
+                if self.scrutinee_precise_bits(scrutinee).is_fresh() {
+                    ProjectedPayloadOrigin::EphemeralTemp
+                } else {
+                    ProjectedPayloadOrigin::Reject(
+                        ProjectedPayloadRejectReason::AliasesCallerStorage,
+                    )
+                }
+            }
+            // Group C2 — provably no re-readable heap operand → unconditional
+            // `EphemeralTemp`.
+            other if Self::hir_scrutinee_is_unconditional_ephemeral_producer(other) => {
+                ProjectedPayloadOrigin::EphemeralTemp
+            }
+            // Default-deny: a place projection / wrapper / any un-enumerated shape.
+            _ => ProjectedPayloadOrigin::Reject(ProjectedPayloadRejectReason::ReadablePlace),
+        }
+    }
+
+    /// Group A plain-`Call` arm: apply the interim module-fn PARAM-present reject
+    /// (the same rule the preflight admission classifier applies upstream — this
+    /// is the one-authority defence-in-depth for the #2523 twin). A resolved
+    /// module-fn callee whose precise summary contains PARAM forwards a by-value
+    /// heap parameter (a caller-retained borrow) → Reject. Every other callee
+    /// (`∅`/`OPAQUE`-only module fn, unknown/cross-module item, extern, builtin,
+    /// indirect/closure) keeps today's `EphemeralTemp` — the interim legacy
+    /// fail-open window; the FULL `OPAQUE`-only reject lands at S4b.
+    fn classify_call_arm_scrutinee_origin(&self, scrutinee: &HirExpr) -> ProjectedPayloadOrigin {
+        use crate::return_provenance::AliasBits;
+        if let HirExprKind::Call { callee, .. } = &scrutinee.kind {
+            if let HirExprKind::BindingRef {
+                resolved: ResolvedRef::Item(id),
+                ..
+            } = &callee.kind
+            {
+                if let Some(bits) = self.call_scrutinee_provenance.provenance.get(id) {
+                    if bits.contains(AliasBits::PARAM) {
+                        return ProjectedPayloadOrigin::Reject(
+                            ProjectedPayloadRejectReason::AliasesCallerStorage,
+                        );
+                    }
+                }
+            }
+        }
+        ProjectedPayloadOrigin::EphemeralTemp
+    }
+
+    /// Group A builtin-collection-getter arm (F1, precursor-independent): resolve
+    /// the EMITTED runtime symbol the site will lower to and consult the
+    /// emitted-symbol return contract. Fresh (a proved-owner clone/retain/take
+    /// getter or an owned-return string/bytes producer) → `EphemeralTemp`; a
+    /// borrowed getter (`hew_vec_get_owned`/`_ptr`, `hew_vec_get_layout`), an
+    /// interior getter, or an unresolvable element ABI → Reject (fail-closed).
+    fn classify_builtin_getter_scrutinee_origin(
+        &self,
+        scrutinee: &HirExpr,
+    ) -> ProjectedPayloadOrigin {
+        match self.method_scrutinee_emitted_symbol(scrutinee) {
+            Some(sym) if crate::return_provenance::method_return_provenance(&sym).is_fresh() => {
+                ProjectedPayloadOrigin::EphemeralTemp
+            }
+            _ => ProjectedPayloadOrigin::Reject(ProjectedPayloadRejectReason::AliasesCallerStorage),
+        }
+    }
+
+    /// Resolve the EMITTED runtime symbol a builtin-collection `ResolvedImplCall`
+    /// scrutinee will lower to, reproducing lowering's placeholder decisions [F1]:
+    /// a `HashMap` `get` always lowers to the fresh-owner clone choke regardless
+    /// of the checker's `hew_hashmap_get_layout` placeholder; a generic
+    /// `Vec<T>`-element method left a `_FAMILY` placeholder is re-resolved from the
+    /// substituted element exactly as the call lowering does; a concrete call
+    /// already carries its resolved linker-edge symbol. Returns `None` (→
+    /// fail-closed Reject) for an unresolvable element ABI (closure/function
+    /// elements the owned authority excludes) or a non-`ResolvedImplCall`.
+    fn method_scrutinee_emitted_symbol(&self, scrutinee: &HirExpr) -> Option<String> {
+        let HirExprKind::ResolvedImplCall {
+            receiver,
+            target_family,
+            target_symbol,
+            ..
+        } = &scrutinee.kind
+        else {
+            return None;
+        };
+        // `HashMap::get -> Option<V>` always routes to the fresh-owner clone
+        // choke (`hew_hashmap_get_clone_layout`), never the `hew_hashmap_get_layout`
+        // placeholder the checker recorded (see `lower_hashmap_index_trap`).
+        if matches!(
+            target_family,
+            hew_types::MethodTargetFamily::HashMap(hew_types::HashMapMethod::Get)
+        ) {
+            return Some("hew_hashmap_get_clone_layout".to_string());
+        }
+        // A generic-element `Vec<T>` method kept the `hew_vec_*_FAMILY`
+        // placeholder — re-resolve it from the substituted element, the same
+        // authority the call lowering consults.
+        if target_symbol.ends_with("_FAMILY") {
+            return self.resolve_polymorphic_vec_element_symbol(*target_family, &receiver.ty);
+        }
+        // Concrete dispatch: the checker already resolved the emitted symbol
+        // (e.g. an owned-value `Vec::get` carries `hew_vec_get_clone` directly).
+        Some(target_symbol.clone())
+    }
+
+    /// The precise three-state return-provenance bits of a scrutinee expression,
+    /// evaluated through the shared `return_alias_bits` walk under the module's
+    /// `PrecisePolicy`. Used by the Group B aggregate gate and the Group C1
+    /// `Binary` gate so all four #2648 consumers (callee summary, caller
+    /// arg-scan, aggregate scrutinee, `Binary` scrutinee) agree on operand
+    /// freshness (R6). The current function's local binding-provenance is not
+    /// threaded here — an aggregate scrutinee over a bare heap LOCAL operand
+    /// therefore reads as `{PARAM}` (non-fresh) and over-rejects fail-closed; no
+    /// reported case or fixture uses an aggregate/`Binary` scrutinee with a
+    /// fresh-local operand, and the precise local threading is a future
+    /// refinement.
+    fn scrutinee_precise_bits(&self, scrutinee: &HirExpr) -> crate::return_provenance::AliasBits {
+        use crate::return_provenance::{return_alias_bits, PrecisePolicy};
+        let local_bits: HashMap<BindingId, crate::return_provenance::AliasBits> = HashMap::new();
+        let policy = PrecisePolicy {
+            provenance: &self.call_scrutinee_provenance.provenance,
+            extern_table: &self.call_scrutinee_provenance.extern_table,
+            local_bits: &local_bits,
+        };
+        return_alias_bits(scrutinee, &policy)
     }
 
     /// #2523 — classify a match/while-let/let-else/if-let scrutinee for the
@@ -23623,10 +23747,7 @@ impl Builder {
                     })
                 }
             }
-            other if Self::hir_scrutinee_is_ephemeral_producer(other) => {
-                ProjectedPayloadOrigin::EphemeralTemp
-            }
-            _ => ProjectedPayloadOrigin::Reject(ProjectedPayloadRejectReason::ReadablePlace),
+            _ => self.classify_producer_scrutinee_origin(scrutinee),
         }
     }
 

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -27733,6 +27733,10 @@ impl Builder {
             current_function_symbol: shim_name.to_string(),
             current_function_call_conv: crate::model::FunctionCallConv::ClosureInvoke,
             task_entry_adapter_symbols: self.task_entry_adapter_symbols.clone(),
+            // #2648 — synthetic call wrapper (no user match scrutinees), but the
+            // provenance context is threaded uniformly: no child builder falls
+            // back to the legacy fail-open default.
+            call_scrutinee_provenance: self.call_scrutinee_provenance.clone(),
             ..Builder::default()
         };
 
@@ -33879,6 +33883,23 @@ impl Builder {
             // globally-unique bindings a closure can capture and embed in a
             // funcupdate base, so the child must see them to reject the borrow.
             funcupdate_param_ids: self.funcupdate_param_ids.clone(),
+            // #2648 — the module return-provenance context MUST reach every
+            // child builder: without it the preflight classifies a resolved
+            // module fn as an unknown item → interim `LegacyModuleCall`
+            // fail-open → a `match wrap(captured)` INSIDE a closure minted an
+            // owner the enclosing frame also releases (a reproduced
+            // double-free). Never `Builder::default()` for this field on a
+            // user-body child.
+            call_scrutinee_provenance: self.call_scrutinee_provenance.clone(),
+            // `call_scrutinee_local_freshness` is deliberately NOT inherited
+            // (the spread leaves it the empty fail-closed default): the
+            // parent's single-read/unaliased facts are computed for ONE
+            // execution of the parent body, while a child body (closure /
+            // lambda-actor / generator) can run any number of times per
+            // parent execution — a captured local that looks single-read in
+            // the parent may be re-read on every invocation. An empty map
+            // admits NO local argument inside child bodies; literal /
+            // fresh-ctor / Fresh-call arguments still admit.
             ..Builder::default()
         }
     }
@@ -34127,6 +34148,10 @@ impl Builder {
             current_function_symbol: shim_name.to_string(),
             current_function_call_conv: crate::model::FunctionCallConv::ClosureInvoke,
             task_entry_adapter_symbols: self.task_entry_adapter_symbols.clone(),
+            // #2648 — synthetic call wrapper (no user match scrutinees), but the
+            // provenance context is threaded uniformly: no child builder falls
+            // back to the legacy fail-open default.
+            call_scrutinee_provenance: self.call_scrutinee_provenance.clone(),
             ..Builder::default()
         };
 
@@ -35353,6 +35378,12 @@ impl Builder {
             current_function_call_conv: crate::model::FunctionCallConv::Default,
             task_entry_adapter_symbols: self.task_entry_adapter_symbols.clone(),
             in_gen_body: true,
+            // #2648 — the generator body is USER code: the preflight needs the
+            // module provenance context or a `match wrap(x)` inside a gen body
+            // silently takes the unknown-item legacy fail-open mint (the same
+            // closure-shim double-free class). Local-freshness facts stay the
+            // fail-closed empty default — see `child_builder_tables`.
+            call_scrutinee_provenance: self.call_scrutinee_provenance.clone(),
             ..Builder::default()
         };
         // Propagate the inadmissible-capture poison set into the body builder so

--- a/hew-mir/src/model.rs
+++ b/hew-mir/src/model.rs
@@ -6363,6 +6363,18 @@ pub enum ProjectedPayloadRejectReason {
     /// abort at runtime. Path-sensitive neutralization keyed on the guard
     /// outcome is not expressible here, so the consume is rejected fail-closed.
     GuardedConsume,
+    /// #2648 (S3, the #2523 twin gate) — a call/method/aggregate/`Binary`
+    /// scrutinee whose produced value MAY ALIAS caller-visible storage rather
+    /// than being a fresh sole owner: a call forwarding one of its by-value heap
+    /// parameters (`match passthru(h.b)`), an aggregate constructed over a
+    /// re-readable heap place operand (`match (Foo { b: h.b })`), a borrowed
+    /// collection getter (`hew_vec_get_owned`/`_ptr`, a `Vec<Vec<T>>` `.get`), or
+    /// a non-string heap `Binary`. Moving the projected payload out of such a
+    /// scrutinee would leave the aliased storage dangling (use-after-free on a
+    /// re-read, double-free at the source's drop), so the move-out is rejected
+    /// fail-closed before codegen. Construct the value fresh at the scrutinee, or
+    /// bind the call result to a `let` and match the binding.
+    AliasesCallerStorage,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -45,7 +45,9 @@
 
 use std::collections::HashMap;
 
-use hew_hir::{HirBlock, HirExpr, HirExprKind, HirFn, ResolvedRef};
+use std::collections::HashSet;
+
+use hew_hir::{BindingId, HirBlock, HirExpr, HirExprKind, HirFn, ResolvedRef};
 use hew_types::ResolvedTy;
 
 // ---------------------------------------------------------------------------
@@ -1049,6 +1051,595 @@ fn method_is_non_mutating(emitted_symbol: &str) -> bool {
 }
 
 // ---------------------------------------------------------------------------
+// Local binding-provenance sub-analysis [F2] — the BindingRef-to-local resolver
+// ---------------------------------------------------------------------------
+
+/// One source contributing bits to a local binding.
+enum DefSource<'f> {
+    /// A whole-value definition (a `let`/`var` init, a `var` whole-assign RHS, or
+    /// a pattern binder's scrutinee) — bits = `return_alias_bits(expr)`.
+    Value(&'f HirExpr),
+    /// A fail-closed definition (a projection-store `var`, an unmodelled binding
+    /// form) → `{OPAQUE}`.
+    Opaque,
+}
+
+#[derive(Default)]
+struct LocalDefs<'f> {
+    /// param heap-ness: id → true when the param owns heap (a `PARAM` alias root).
+    params: HashMap<BindingId, bool>,
+    /// per-binding contributing sources.
+    defs: HashMap<BindingId, Vec<DefSource<'f>>>,
+    /// alias edges (`let y = x` / `var y = x` whole) to union into one class.
+    alias_edges: Vec<(BindingId, BindingId)>,
+    /// bindings tainted `{OPAQUE}` by a mutation channel (their whole alias class
+    /// is poisoned).
+    tainted: HashSet<BindingId>,
+}
+
+/// Per-function local binding-provenance with MANDATORY alias closure [F2].
+///
+/// A by-value heap param is a `PARAM` alias root; a local's bits flow from its
+/// definition(s); a binding whose alias class is mutated (a projection-store, a
+/// mutating method, or a value passed to a not-proven-pure callee) is poisoned to
+/// `{OPAQUE}` across the WHOLE class — `let y = x; y.f = p; return x` must reject
+/// through `x` even though the store names `y`.
+#[must_use]
+#[allow(
+    clippy::implicit_hasher,
+    reason = "consumed with the pipeline's default-hasher summary maps"
+)]
+pub fn compute_local_binding_provenance(
+    f: &HirFn,
+    provenance: &HashMap<hew_hir::ItemId, AliasBits>,
+    extern_table: &ExternContractTable,
+    may_mutate: &HashMap<hew_hir::ItemId, bool>,
+) -> HashMap<BindingId, AliasBits> {
+    let mut collector = LocalDefs::default();
+    for p in &f.params {
+        collector.params.insert(p.id, !ty_is_scalar_non_heap(&p.ty));
+    }
+    let mut ctx = DefCollector {
+        defs: &mut collector,
+        may_mutate,
+    };
+    ctx.collect_block(&f.body);
+
+    // Union-find over alias classes.
+    let mut uf = UnionFind::default();
+    for &id in collector.params.keys() {
+        uf.make(id);
+    }
+    for id in collector.defs.keys() {
+        uf.make(*id);
+    }
+    for &(a, b) in &collector.alias_edges {
+        uf.make(a);
+        uf.make(b);
+        uf.union(a, b);
+    }
+    // A class is poisoned if ANY member is tainted.
+    let mut poisoned_roots: HashSet<BindingId> = HashSet::new();
+    for &t in &collector.tainted {
+        uf.make(t);
+        poisoned_roots.insert(uf.find(t));
+    }
+
+    // Fixpoint over binding bits (monotone union from the optimistic ∅ / PARAM
+    // seeds). Terminates: bits only grow over a finite 2-bit set.
+    let mut bits: HashMap<BindingId, AliasBits> = HashMap::new();
+    for (&id, &heap) in &collector.params {
+        bits.insert(
+            id,
+            if heap {
+                AliasBits::PARAM
+            } else {
+                AliasBits::EMPTY
+            },
+        );
+    }
+    for id in collector.defs.keys() {
+        bits.entry(*id).or_insert(AliasBits::EMPTY);
+    }
+    loop {
+        let mut changed = false;
+        for (&id, sources) in &collector.defs {
+            let policy = PrecisePolicy {
+                provenance,
+                extern_table,
+                local_bits: &bits,
+            };
+            let mut new_bits = *bits.get(&id).unwrap_or(&AliasBits::EMPTY);
+            for src in sources {
+                new_bits |= match src {
+                    DefSource::Value(e) => return_alias_bits(e, &policy),
+                    DefSource::Opaque => AliasBits::OPAQUE,
+                };
+            }
+            if new_bits != bits[&id] {
+                bits.insert(id, new_bits);
+                changed = true;
+            }
+        }
+        // Poison whole classes and propagate class unions.
+        let ids: Vec<BindingId> = bits.keys().copied().collect();
+        for id in ids {
+            let root = uf.find(id);
+            if poisoned_roots.contains(&root) && !bits[&id].is_opaque() {
+                let v = bits[&id] | AliasBits::OPAQUE;
+                bits.insert(id, v);
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    bits
+}
+
+/// A minimal union-find over `BindingId`s for the alias closure.
+#[derive(Default)]
+struct UnionFind {
+    parent: HashMap<BindingId, BindingId>,
+}
+
+impl UnionFind {
+    fn make(&mut self, id: BindingId) {
+        self.parent.entry(id).or_insert(id);
+    }
+
+    fn find(&mut self, id: BindingId) -> BindingId {
+        let p = *self.parent.get(&id).unwrap_or(&id);
+        if p == id {
+            return id;
+        }
+        let root = self.find(p);
+        self.parent.insert(id, root);
+        root
+    }
+
+    fn union(&mut self, a: BindingId, b: BindingId) {
+        let ra = self.find(a);
+        let rb = self.find(b);
+        if ra != rb {
+            self.parent.insert(ra, rb);
+        }
+    }
+}
+
+struct DefCollector<'a, 'f> {
+    defs: &'a mut LocalDefs<'f>,
+    may_mutate: &'a HashMap<hew_hir::ItemId, bool>,
+}
+
+impl<'f> DefCollector<'_, 'f> {
+    #[allow(
+        clippy::match_same_arms,
+        reason = "statement arms mirror the sealed HirStmtKind surface exhaustively"
+    )]
+    fn collect_block(&mut self, block: &'f HirBlock) {
+        for stmt in &block.statements {
+            match &stmt.kind {
+                hew_hir::HirStmtKind::Let(binding, Some(init)) => {
+                    // `let y = <BindingRef x>` unions y and x (an alias).
+                    if let Some(root) = binding_ref_local(init) {
+                        self.defs.alias_edges.push((binding.id, root));
+                    }
+                    self.defs
+                        .defs
+                        .entry(binding.id)
+                        .or_default()
+                        .push(DefSource::Value(init));
+                    self.collect_expr(init);
+                }
+                hew_hir::HirStmtKind::Let(binding, None) => {
+                    self.defs.defs.entry(binding.id).or_default();
+                }
+                hew_hir::HirStmtKind::Assign { target, value } => {
+                    if is_projection_place(target) {
+                        // A projection-store into a local `x.f = …` fail-closes x
+                        // AND taints its class (an alias smuggle the whole-value
+                        // walk cannot see).
+                        if let Some(root) = place_root_binding(target) {
+                            self.defs
+                                .defs
+                                .entry(root)
+                                .or_default()
+                                .push(DefSource::Opaque);
+                            self.defs.tainted.insert(root);
+                        }
+                    } else if let Some(root) = binding_ref_local(target) {
+                        // A whole `var x = value` contributes the value's bits.
+                        if let Some(rhs_root) = binding_ref_local(value) {
+                            self.defs.alias_edges.push((root, rhs_root));
+                        }
+                        self.defs
+                            .defs
+                            .entry(root)
+                            .or_default()
+                            .push(DefSource::Value(value));
+                    }
+                    self.collect_expr(value);
+                }
+                hew_hir::HirStmtKind::Expr(e) => self.collect_expr(e),
+                hew_hir::HirStmtKind::Return(Some(e)) => self.collect_expr(e),
+                hew_hir::HirStmtKind::Return(None) => {}
+                hew_hir::HirStmtKind::Defer { body, .. } => self.collect_expr(body),
+                hew_hir::HirStmtKind::LetElse {
+                    scrutinee,
+                    bindings,
+                    success_prelude,
+                    else_body,
+                    ..
+                } => {
+                    for b in bindings {
+                        self.defs
+                            .defs
+                            .entry(b.binding)
+                            .or_default()
+                            .push(DefSource::Value(scrutinee));
+                    }
+                    self.collect_expr(scrutinee);
+                    for s in success_prelude {
+                        if let hew_hir::HirStmtKind::Let(binding, Some(v)) = &s.kind {
+                            self.defs
+                                .defs
+                                .entry(binding.id)
+                                .or_default()
+                                .push(DefSource::Value(v));
+                            self.collect_expr(v);
+                        }
+                    }
+                    self.collect_block(else_body);
+                }
+            }
+        }
+        if let Some(tail) = &block.tail {
+            self.collect_expr(tail);
+        }
+    }
+
+    /// Walk an expression, recording pattern binders (Match/IfLet/WhileLet) and
+    /// the taint channels (mutating methods, may-mutate call args), and recursing.
+    #[allow(
+        clippy::too_many_lines,
+        clippy::match_same_arms,
+        reason = "the collector mirrors the sealed HirExprKind surface exhaustively"
+    )]
+    fn collect_expr(&mut self, expr: &'f HirExpr) {
+        match &expr.kind {
+            HirExprKind::Match {
+                scrutinee, arms, ..
+            } => {
+                for arm in arms {
+                    for b in &arm.bindings {
+                        self.defs
+                            .defs
+                            .entry(b.binding)
+                            .or_default()
+                            .push(DefSource::Value(scrutinee));
+                    }
+                    self.collect_expr(&arm.body);
+                    if let Some(guard) = &arm.guard {
+                        self.collect_expr(guard);
+                    }
+                }
+                self.collect_expr(scrutinee);
+            }
+            HirExprKind::IfLet {
+                scrutinee,
+                bindings,
+                body,
+                else_body,
+                ..
+            } => {
+                for b in bindings {
+                    self.defs
+                        .defs
+                        .entry(b.binding)
+                        .or_default()
+                        .push(DefSource::Value(scrutinee));
+                }
+                self.collect_expr(scrutinee);
+                self.collect_block(body);
+                if let Some(else_body) = else_body {
+                    self.collect_block(else_body);
+                }
+            }
+            HirExprKind::WhileLet {
+                scrutinee,
+                bindings,
+                body,
+                ..
+            } => {
+                for b in bindings {
+                    self.defs
+                        .defs
+                        .entry(b.binding)
+                        .or_default()
+                        .push(DefSource::Value(scrutinee));
+                }
+                self.collect_expr(scrutinee);
+                self.collect_block(body);
+            }
+            // Mutating-method taint: a mutating/storing method on a local
+            // receiver poisons its class.
+            HirExprKind::ResolvedImplCall {
+                receiver,
+                target_symbol,
+                args,
+                ..
+            } => {
+                if let Some(root) = place_root_binding(receiver) {
+                    if !method_is_non_mutating(target_symbol) {
+                        self.defs.tainted.insert(root);
+                    }
+                }
+                self.collect_expr(receiver);
+                for a in args {
+                    self.collect_expr(a);
+                }
+            }
+            HirExprKind::VarSelfMethodCall { receiver, args, .. }
+            | HirExprKind::CallDynMethod { receiver, args, .. }
+            | HirExprKind::CallTraitMethodStatic { receiver, args, .. } => {
+                if let Some(root) = place_root_binding(receiver) {
+                    self.defs.tainted.insert(root);
+                }
+                self.collect_expr(receiver);
+                for a in args {
+                    self.collect_expr(a);
+                }
+            }
+            HirExprKind::NumericMethod { receiver, arg, .. } => {
+                self.collect_expr(receiver);
+                self.collect_expr(arg);
+            }
+            // Caller-side call-argument taint: an argument reaching a heap local,
+            // passed to a not-proven-pure direct callee, poisons that local's
+            // class.
+            HirExprKind::Call { callee, args } => {
+                let pure = callee_is_proven_pure_item(callee, self.may_mutate);
+                for a in args {
+                    if !pure {
+                        let mut r = Reachable::default();
+                        reachable_bindings(a, &mut r);
+                        for b in r.bindings {
+                            self.defs.tainted.insert(b);
+                        }
+                    }
+                    self.collect_expr(a);
+                }
+                self.collect_expr(callee);
+            }
+            HirExprKind::Block(block) => self.collect_block(block),
+            HirExprKind::If {
+                then_expr,
+                else_expr,
+                ..
+            } => {
+                self.collect_expr(then_expr);
+                if let Some(e) = else_expr.as_deref() {
+                    self.collect_expr(e);
+                }
+            }
+            HirExprKind::StructInit { fields, base, .. } => {
+                for (_, v) in fields {
+                    self.collect_expr(v);
+                }
+                if let Some(base) = base.as_deref() {
+                    self.collect_expr(base);
+                }
+            }
+            HirExprKind::TupleLiteral { elements } => {
+                for e in elements {
+                    self.collect_expr(e);
+                }
+            }
+            HirExprKind::Binary { left, right, .. } => {
+                self.collect_expr(left);
+                self.collect_expr(right);
+            }
+            HirExprKind::Unary { operand, .. } => self.collect_expr(operand),
+            HirExprKind::FieldAccess { object, .. } => self.collect_expr(object),
+            HirExprKind::TupleIndex { tuple, .. } => self.collect_expr(tuple),
+            HirExprKind::Index { container, index } => {
+                self.collect_expr(container);
+                self.collect_expr(index);
+            }
+            HirExprKind::Return { value } => {
+                if let Some(v) = value.as_deref() {
+                    self.collect_expr(v);
+                }
+            }
+            // Leaves and unmodelled forms need no binder/taint recording here.
+            _ => {}
+        }
+    }
+}
+
+/// The local binding id a value expression refers to directly (a bare
+/// `BindingRef` to a `Binding`), or `None`.
+fn binding_ref_local(expr: &HirExpr) -> Option<BindingId> {
+    match &expr.kind {
+        HirExprKind::BindingRef {
+            resolved: ResolvedRef::Binding(id),
+            ..
+        } => Some(*id),
+        _ => None,
+    }
+}
+
+/// Whether a direct-call callee is a resolved module item proven
+/// `!may_mutate_heap_param` (or an owned-return extern/constructor with no
+/// analysable body). Everything else (indirect/closure/unresolved) is NOT proven
+/// pure.
+fn callee_is_proven_pure_item(
+    callee: &HirExpr,
+    may_mutate: &HashMap<hew_hir::ItemId, bool>,
+) -> bool {
+    if let HirExprKind::BindingRef {
+        resolved: ResolvedRef::Item(id),
+        ..
+    } = &callee.kind
+    {
+        !may_mutate.get(id).copied().unwrap_or(false)
+    } else {
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Precise policy + the module return-provenance fixpoint [Sol-3]
+// ---------------------------------------------------------------------------
+
+/// The Precise `LeafPolicy`: consumes the module provenance table (for the
+/// three-way `Call` resolution), the audited extern table, and the CURRENT
+/// function's local binding-provenance.
+///
+/// # Method-leaf note (S1)
+///
+/// The method leaf reads `method_return_provenance(target_symbol)` — the HIR
+/// PLACEHOLDER symbol. This is SOUND (a placeholder for a borrowed getter is
+/// `{OPAQUE}`, a placeholder for an owned getter is ALSO `{OPAQUE}`, never
+/// wrongly Fresh), but conservative: the owned-value `Vec::get` (emitted
+/// `hew_vec_get_clone`) reads `{OPAQUE}` until the wiring site (S2) supplies the
+/// emitted-symbol resolver that reproduces lowering's owned-element-class
+/// decision. It never admits a receiver alias.
+#[derive(Debug)]
+pub struct PrecisePolicy<'a> {
+    /// The module return-provenance summary (being computed — read for the
+    /// three-way `Call` resolution).
+    pub provenance: &'a HashMap<hew_hir::ItemId, AliasBits>,
+    /// The audited extern owned-return contract table.
+    pub extern_table: &'a ExternContractTable,
+    /// The CURRENT function's local binding-provenance.
+    pub local_bits: &'a HashMap<BindingId, AliasBits>,
+}
+
+impl LeafPolicy for PrecisePolicy<'_> {
+    fn classify_call(&self, callee: &HirExpr) -> CallClass {
+        // A non-item callee (closure value, fn-pointer param, dynamic dispatch,
+        // const, builtin) can hand back a captured heap param → Opaque.
+        let HirExprKind::BindingRef {
+            resolved: ResolvedRef::Item(id),
+            ..
+        } = &callee.kind
+        else {
+            return CallClass::Opaque;
+        };
+        // Clause 1: a resolved module fn → its summary (with arg substitution).
+        if let Some(bits) = self.provenance.get(id) {
+            if bits.is_fresh() {
+                CallClass::Fresh
+            } else if bits.is_params_only() {
+                CallClass::ParamSubst
+            } else {
+                CallClass::Opaque
+            }
+        // Clauses 2+3: an extern (scalar row → Fresh; heap/omitted → Opaque) or an
+        // unknown/missing item (absent from the table → Opaque). Never
+        // `unwrap_or(true)`.
+        } else if self.extern_table.provenance_of(*id).is_fresh() {
+            CallClass::Fresh
+        } else {
+            CallClass::Opaque
+        }
+    }
+
+    fn leaf_bits(&self, expr: &HirExpr) -> AliasBits {
+        // Type short-circuit: a value owning no heap cannot alias a heap param.
+        if ty_is_scalar_non_heap(&expr.ty) {
+            return AliasBits::EMPTY;
+        }
+        match &expr.kind {
+            // `a + b` on strings lowers to a fresh-allocating `hew_string_concat`
+            // whose result aliases neither operand → ∅. Any other heap `Binary`
+            // fails closed.
+            HirExprKind::Binary { .. } => {
+                if matches!(expr.ty, ResolvedTy::String) {
+                    AliasBits::EMPTY
+                } else {
+                    AliasBits::OPAQUE
+                }
+            }
+            // A method call → the emitted-symbol contract (S1: keyed on the
+            // placeholder `target_symbol`, sound-but-conservative — see the type
+            // doc).
+            HirExprKind::ResolvedImplCall { target_symbol, .. } => {
+                method_return_provenance(target_symbol)
+            }
+            // A binding reference to a tracked local reads its computed bits; a
+            // by-value param not in the local map is `{PARAM}`.
+            HirExprKind::BindingRef {
+                resolved: ResolvedRef::Binding(id),
+                ..
+            } => self.local_bits.get(id).copied().unwrap_or(AliasBits::PARAM),
+            // Other method calls (no emitted-symbol contract here), a non-local
+            // BindingRef (a module item/const/builtin), and every unmodelled form
+            // fail closed.
+            _ => AliasBits::OPAQUE,
+        }
+    }
+}
+
+/// The module return-provenance summary: `ItemId → ReturnProvenance`, a monotone
+/// least-fixpoint over the three-state lattice that starts every function at `∅`
+/// and grows by union to stability.
+///
+/// Each pass, for every function, recomputes its local binding-provenance under
+/// the current module table, then unions the bits of every value-bearing return
+/// path (`return_alias_bits` under [`PrecisePolicy`]). Bits only grow over a
+/// finite 2-bit set → terminates; start-empty is sound because every real alias
+/// source is injected by a non-recursive transfer (a bare param → `{PARAM}`, an
+/// opaque leaf → `{OPAQUE}`) and propagated by union.
+#[must_use]
+#[allow(
+    clippy::implicit_hasher,
+    reason = "built once over the pipeline's default-hasher origin_fns map"
+)]
+pub fn compute_call_scrutinee_return_provenance(
+    fns: &HashMap<hew_hir::ItemId, &HirFn>,
+    extern_table: &ExternContractTable,
+    may_mutate: &HashMap<hew_hir::ItemId, bool>,
+) -> HashMap<hew_hir::ItemId, ReturnProvenance> {
+    let mut provenance: HashMap<hew_hir::ItemId, AliasBits> =
+        fns.keys().map(|&id| (id, AliasBits::EMPTY)).collect();
+    loop {
+        let mut changed = false;
+        for (&id, &f) in fns {
+            let local_bits =
+                compute_local_binding_provenance(f, &provenance, extern_table, may_mutate);
+            let policy = PrecisePolicy {
+                provenance: &provenance,
+                extern_table,
+                local_bits: &local_bits,
+            };
+            let mut return_values: Vec<&HirExpr> = Vec::new();
+            crate::lower::collect_return_values_in_block(&f.body, &mut return_values);
+            if let Some(tail) = &f.body.tail {
+                if !matches!(tail.ty, ResolvedTy::Unit | ResolvedTy::Never) {
+                    return_values.push(tail);
+                }
+            }
+            let mut bits = provenance[&id];
+            for e in &return_values {
+                bits |= return_alias_bits(e, &policy);
+            }
+            if bits != provenance[&id] {
+                provenance.insert(id, bits);
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    provenance
+}
+
+// ---------------------------------------------------------------------------
 // Module-map helpers
 // ---------------------------------------------------------------------------
 
@@ -1374,6 +1965,140 @@ mod tests {
         assert!(
             params.iter().all(|p| r.bindings.contains(p)),
             "the returned `a` reaches the heap param binding"
+        );
+    }
+
+    // -- The module return-provenance fixpoint [Sol-3] --
+
+    fn provenance_of_source(
+        source: &str,
+    ) -> (hew_hir::HirModule, HashMap<hew_hir::ItemId, AliasBits>) {
+        let module = lower_source(source);
+        let origin_fns = origin_fns_of(&module);
+        let extern_table = build_extern_contract_table(&module);
+        let may_mutate = compute_may_mutate_heap_param(&origin_fns);
+        let prov =
+            compute_call_scrutinee_return_provenance(&origin_fns, &extern_table, &may_mutate);
+        (module, prov)
+    }
+
+    #[test]
+    fn fresh_producer_scc_converges_to_fresh() {
+        let (m, prov) = provenance_of_source(
+            r#"
+            fn make() -> string { "hello" }
+            fn wrap() -> string { make() }
+            "#,
+        );
+        assert!(prov[&fn_id(&m, "make")].is_fresh());
+        assert!(
+            prov[&fn_id(&m, "wrap")].is_fresh(),
+            "a chain of fresh producers is Fresh"
+        );
+    }
+
+    #[test]
+    fn forwarder_scc_converges_to_params_only() {
+        let (m, prov) = provenance_of_source(
+            r"
+            fn a(flag: bool, x: Vec<i64>) -> Vec<i64> { if flag { x } else { b(x) } }
+            fn b(x: Vec<i64>) -> Vec<i64> { a(true, x) }
+            fn passthru(x: Vec<i64>) -> Vec<i64> { x }
+            ",
+        );
+        assert!(
+            prov[&fn_id(&m, "passthru")].is_params_only(),
+            "an identity forwarder returns a param borrow → ParamsOnly, not Fresh"
+        );
+        assert!(
+            prov[&fn_id(&m, "a")].is_params_only(),
+            "the mutually-recursive forwarder SCC converges to ParamsOnly"
+        );
+        assert!(prov[&fn_id(&m, "b")].is_params_only());
+    }
+
+    #[test]
+    fn var_string_concat_composition_is_fresh() {
+        // Models template's `var out` + `out = out + seg` — every whole-assign is
+        // a fresh string concat, so `out` stays ∅ and the return is Fresh.
+        let (m, prov) = provenance_of_source(
+            r#"
+            fn build(seg: string) -> string {
+                var out = "";
+                out = out + seg;
+                out
+            }
+            "#,
+        );
+        assert!(
+            prov[&fn_id(&m, "build")].is_fresh(),
+            "string-concat var composition returns a fresh owner"
+        );
+    }
+
+    #[test]
+    fn returned_match_binder_over_fresh_scrutinee_is_fresh() {
+        let (m, prov) = provenance_of_source(
+            r#"
+            fn produce() -> Result<string, string> { Ok("x") }
+            fn unwrap_or_default() -> string {
+                match produce() { Ok(v) => v, Err(e) => e }
+            }
+            "#,
+        );
+        assert!(
+            prov[&fn_id(&m, "unwrap_or_default")].is_fresh(),
+            "a binder over a fresh call scrutinee is Fresh"
+        );
+    }
+
+    #[test]
+    fn helper_mediated_mutation_makes_the_return_opaque() {
+        // caller returns a heap param it passed to a param-mutating helper → the
+        // returned value now holds a smuggled alias → NOT Fresh (rejects).
+        let (m, prov) = provenance_of_source(
+            r"
+            fn helper(x: Vec<i64>, v: i64) { x.push(v); }
+            fn caller(h: Vec<i64>, v: i64) -> Vec<i64> { helper(h, v); h }
+            ",
+        );
+        assert!(
+            !prov[&fn_id(&m, "caller")].is_fresh(),
+            "a heap param mutated via a helper then returned must not be Fresh"
+        );
+        assert!(prov[&fn_id(&m, "caller")].is_opaque());
+    }
+
+    #[test]
+    fn aliased_mutation_return_is_opaque() {
+        // `let y = x; y.push(v); return x` — the store names y but x aliases it;
+        // alias closure must poison x too.
+        let (m, prov) = provenance_of_source(
+            r"
+            fn f(x: Vec<i64>, v: i64) -> Vec<i64> {
+                let y = x;
+                y.push(v);
+                x
+            }
+            ",
+        );
+        assert!(
+            prov[&fn_id(&m, "f")].is_opaque(),
+            "a mutation through an alias must poison the whole alias class"
+        );
+    }
+
+    #[test]
+    fn global_const_return_is_opaque_not_wrongly_fresh() {
+        let (m, prov) = provenance_of_source(
+            r#"
+            const GLOBAL: string = "g";
+            fn leak() -> string { GLOBAL }
+            "#,
+        );
+        assert!(
+            prov[&fn_id(&m, "leak")].is_opaque(),
+            "returning a module global is Opaque, never wrongly Fresh (the boolean+arg-scan hole)"
         );
     }
 

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -343,8 +343,197 @@ pub fn ty_is_scalar_non_heap(ty: &ResolvedTy) -> bool {
 }
 
 // ---------------------------------------------------------------------------
-// Placeholder seams filled in by later S1 layers (kept here so the module's
-// public surface is stable across the layered commits).
+// Method-call return contract — keyed on the EMITTED runtime symbol [F1]
+// ---------------------------------------------------------------------------
+
+/// EMITTED runtime symbols proved (by reading the runtime implementation) to
+/// hand back a NEW `+1` owner, so a method call lowering to one of them is a
+/// fresh sole owner (`∅`).
+///
+/// These are the descriptor-clone / retain / move-out getters — NOT the borrowed
+/// getters. The distinction is load-bearing and is the F1 correction: the HIR
+/// `ResolvedImplCall.target_symbol` is a *placeholder* (`hew_hashmap_get_layout`,
+/// `hew_vec_get_owned`/`_ptr`), and lowering picks the actual owned callee at
+/// emission time (`hew_vec_get_clone` for owned-value elements,
+/// `hew_hashmap_get_clone_layout` always for `HashMap` get). Keying on the HIR
+/// symbol/family would admit the receiver-alias class this lane rejects, so the
+/// contract keys on the EMITTED symbol the site will actually lower to.
+const PROVED_OWNER_METHOD_SYMBOLS: &[&str] = &[
+    "hew_vec_get_clone",
+    "hew_vec_get_str",
+    "hew_vec_pop_str",
+    "hew_vec_remove_at_str",
+    "hew_hashmap_get_clone_layout",
+    "hew_hashmap_remove_take_layout",
+];
+
+/// Return-provenance of a method call, given the EMITTED runtime symbol the site
+/// lowers to. Fresh (`∅`) ONLY for a proved-owner clone/retain/take symbol or an
+/// owned-return string/bytes producer; every borrowed getter
+/// (`hew_vec_get_owned`/`_ptr`/`_layout`, `hew_hashmap_get_layout`), interior
+/// getter, unknown, or family-only placeholder → `{OPAQUE}` (fail-closed).
+///
+/// The caller resolves which symbol the site emits by reproducing lowering's
+/// owned-element-class decision (`Builder::is_owned_vec_element`) at the wiring
+/// site (S2); this function is the sound EMITTED-symbol → provenance contract it
+/// consults.
+#[must_use]
+pub fn method_return_provenance(emitted_symbol: &str) -> AliasBits {
+    use crate::runtime_symbols::{callee_ownership_contract, ResultOwnership};
+    if PROVED_OWNER_METHOD_SYMBOLS.contains(&emitted_symbol) {
+        return AliasBits::EMPTY;
+    }
+    match callee_ownership_contract(emitted_symbol).result {
+        ResultOwnership::FreshOwnedString | ResultOwnership::FreshOwnedBytes => AliasBits::EMPTY,
+        ResultOwnership::Borrowed
+        | ResultOwnership::InteriorAliasOfReceiver
+        | ResultOwnership::Untracked => AliasBits::OPAQUE,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Audited ExternFn owned-return contract table [F3] — EMPTY/fail-closed interim
+// ---------------------------------------------------------------------------
+
+/// The audited positive allowlist of externs whose by-value return is a fresh
+/// `+1` owner, keyed by `ItemId`.
+///
+/// # Interim (S1–S4): EMPTY / fail-closed [Rev-8, round-6 item 2]
+///
+/// `StdlibOrigin` / `TrustedStdlibRoot` / `HirModule.stdlib_origins` do NOT exist
+/// at this base, so NO marker-backed row can be built yet. The interim table
+/// therefore admits ONLY scalar-return externs (a scalar owns nothing and aliases
+/// nothing — no trusted-root marker needed) and treats EVERY heap-returning
+/// extern as `{OPAQUE}` (absent from the table → fail-closed lookup). The
+/// marker-backed jwt/encrypt rows land at S4b once the trusted-root precursor
+/// (`stdlib-root-canonical-resolution`, U194) exposes the non-forgeable marker.
+///
+/// A user `extern "C" fn evil() -> string` returning an interior pointer is
+/// therefore `{OPAQUE}` here — never auto-trusted from `return_ty` heap-ness or
+/// the arbitrary `abi` string.
+#[derive(Debug, Default, Clone)]
+pub struct ExternContractTable {
+    rows: HashMap<hew_hir::ItemId, ReturnProvenance>,
+}
+
+impl ExternContractTable {
+    /// Return-provenance of a resolved extern `ItemId`. An extern absent from the
+    /// table (every heap-returning extern in the interim) is `{OPAQUE}` —
+    /// fail-closed.
+    #[must_use]
+    pub fn provenance_of(&self, id: hew_hir::ItemId) -> AliasBits {
+        self.rows.get(&id).copied().unwrap_or(AliasBits::OPAQUE)
+    }
+
+    /// Number of marker-backed / scalar rows. Zero marker-backed rows in the
+    /// interim; the value is the count of scalar-return externs admitted.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// True when no extern is admitted.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+}
+
+/// Build the interim (empty/fail-closed) extern contract table over a module's
+/// `extern "C"` declarations: scalar-return externs → Fresh; every
+/// heap-returning extern is omitted (→ `{OPAQUE}` on lookup). Zero marker-backed
+/// rows — the trusted-root precursor is required for those (S4b).
+#[must_use]
+pub fn build_extern_contract_table(module: &hew_hir::HirModule) -> ExternContractTable {
+    let mut rows: HashMap<hew_hir::ItemId, ReturnProvenance> = HashMap::new();
+    for item in &module.items {
+        if let hew_hir::HirItem::ExternFn(ef) = item {
+            if ty_is_scalar_non_heap(&ef.return_ty) {
+                rows.insert(ef.id, AliasBits::EMPTY);
+            }
+        }
+    }
+    ExternContractTable { rows }
+}
+
+// ---------------------------------------------------------------------------
+// Preflight carve-out detectors — pure HIR, keyed on TYPED identity [F4-new]
+// ---------------------------------------------------------------------------
+
+/// True when `callee` carries the compiler-minted typed runtime identity of a
+/// receive family (`ResolvedRef::Builtin(RuntimeCallFamily::{ChannelRecv* |
+/// StreamNext* | DuplexRecv*})`).
+///
+/// The carve-out keys on this TYPED identity, NOT the display name: a genuine
+/// recv callee resolves to `ResolvedRef::Builtin(fam)` and carries its own
+/// `BodyEndReleased` per-iteration release discipline (no synthetic owner must be
+/// minted), whereas a user-declared `extern "C" fn hew_channel_recv_layout(..)`
+/// resolves to `ResolvedRef::Item` → does NOT match → falls through to the
+/// three-way `Call` resolution → `{OPAQUE}` → REJECT (fail-closed; closes the
+/// name-forgeable bypass this lane fixes).
+#[must_use]
+pub fn is_typed_recv_callee(callee: &HirExpr) -> bool {
+    use hew_types::runtime_call::RuntimeCallFamily as F;
+    let HirExprKind::BindingRef {
+        resolved: ResolvedRef::Builtin(family),
+        ..
+    } = &callee.kind
+    else {
+        return false;
+    };
+    matches!(
+        family,
+        F::ChannelRecvLayout
+            | F::ChannelTryRecvLayout
+            | F::StreamNextLayout
+            | F::StreamTryNextLayout
+            | F::DuplexRecv
+            | F::DuplexRecvHalf
+            | F::DuplexTryRecv
+    )
+}
+
+/// True when `scrutinee` is a `Call` — the ONLY kind the from-call owner mint
+/// (`call_scrutinee_owned_ty`) engages on. A non-`Call` scrutinee (a `Block`/`If`
+/// synthetic `Vec<_>`-iteration desugar, a `GeneratorNext`, a bare place) is
+/// structurally `NotApplicable` — it can never reach the from-call owner mint, so
+/// its own release discipline runs unchanged. This is the `let HirExprKind::Call
+/// { .. } = &scrutinee.kind else { return None }` gate the preflight reproduces
+/// FIRST, before any runtime-identity or three-way `Call` resolution.
+#[must_use]
+pub fn scrutinee_is_call_kind(scrutinee: &HirExpr) -> bool {
+    matches!(&scrutinee.kind, HirExprKind::Call { .. })
+}
+
+/// The admission verdict a call/method/aggregate scrutinee consumer acts on
+/// (#2648 preflight). Pure-analysis shape; the wiring site (S2) maps `Admit` onto
+/// the `ProjectedPayloadOrigin` the #2523 classifier + the #2429 owner mint
+/// consume, and a reject onto a `MirDiagnostic` returned as `Err`.
+///
+/// `Reject` is NOT a variant here: the preflight returns `Result<_, MirDiagnostic>`
+/// at the wiring site, so a reject is `Err` (one diagnostic, early return, no
+/// partial MIR). This enum is the `Ok(..)` payload.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CallScrutineeAdmission {
+    /// Not a from-call owner shape (a non-`Call` scrutinee, a typed-recv/iter-next
+    /// carve-out, a builtin callee) → behave as today's `None`: no owner minted,
+    /// no reject, the scrutinee's own release discipline runs unchanged.
+    NotApplicable,
+    /// A `Fresh` (or `ParamsOnly`-with-all-fresh-args) scrutinee → mint the #2429
+    /// owner and classify #2523's move-out as `EphemeralTemp`.
+    Admit,
+    /// INTERIM ONLY (S2–S4; DELETED at S4b) [Rev-8, round-6 item 2]: a resolved
+    /// module-fn callee whose precise summary carries NO `PARAM` bit → today's
+    /// admission EXACTLY (the existing owner gate mints `__hew_call_scrutinee`;
+    /// #2523 keeps its legacy `EphemeralTemp`). The precise module summary is
+    /// consulted ONLY for the `PARAM`-present early reject, never for the
+    /// admission shape — so opaque-hidden forwarding stays legacy fail-open until
+    /// the trusted-root precursor merges.
+    LegacyModuleCall,
+}
+
+// ---------------------------------------------------------------------------
+// Module-map helpers
 // ---------------------------------------------------------------------------
 
 /// The set of `ItemId`s currently proven `false` (not fresh) under a coarse
@@ -479,6 +668,118 @@ mod tests {
             fn b(x: string) -> string { a(true, x) }
             ",
         );
+    }
+
+    // -- Method-call return contract [F1] --
+
+    #[test]
+    fn owned_value_vec_get_emits_clone_and_is_fresh() {
+        // The owned-value `Vec::get` lowers to `hew_vec_get_clone` (a descriptor
+        // clone → a fresh independent owner), even though its runtime contract is
+        // `Untracked`; the proved-owner set is what admits it.
+        assert!(method_return_provenance("hew_vec_get_clone").is_fresh());
+        assert!(method_return_provenance("hew_hashmap_get_clone_layout").is_fresh());
+        assert!(method_return_provenance("hew_hashmap_remove_take_layout").is_fresh());
+    }
+
+    #[test]
+    fn borrowed_vec_getters_are_opaque() {
+        // Collection-handle `Vec::get` lowers to `hew_vec_get_owned` — a slot
+        // borrow into the receiver storage; it MUST reject.
+        assert!(method_return_provenance("hew_vec_get_owned").is_opaque());
+        assert!(method_return_provenance("hew_vec_get_ptr").is_opaque());
+        assert!(method_return_provenance("hew_vec_get_layout").is_opaque());
+        assert!(method_return_provenance("hew_hashmap_get_layout").is_opaque());
+    }
+
+    #[test]
+    fn owned_return_string_method_is_fresh_and_unknown_symbol_is_opaque() {
+        // `s.slice(..)` → `hew_string_slice` → FreshOwnedString feeds semver.
+        assert!(method_return_provenance("hew_string_slice").is_fresh());
+        // An unknown / family-only placeholder fails closed.
+        assert!(method_return_provenance("hew_totally_unknown_symbol").is_opaque());
+    }
+
+    // -- Extern owned-return contract table (interim empty/fail-closed) [F3] --
+
+    #[test]
+    fn extern_table_admits_scalar_returns_and_rejects_heap_returns() {
+        let module = lower_source(
+            r#"
+            extern "C" {
+                fn scalar_ext() -> i64;
+                fn heap_ext() -> string;
+            }
+            "#,
+        );
+        let table = build_extern_contract_table(&module);
+        // Zero marker-backed rows in the interim: only the scalar extern is
+        // admitted; the heap-returning extern is absent → {OPAQUE} on lookup.
+        let mut scalar_id = None;
+        let mut heap_id = None;
+        for item in &module.items {
+            if let hew_hir::HirItem::ExternFn(ef) = item {
+                match ef.name.as_str() {
+                    "scalar_ext" => scalar_id = Some(ef.id),
+                    "heap_ext" => heap_id = Some(ef.id),
+                    _ => {}
+                }
+            }
+        }
+        let scalar_id = scalar_id.expect("scalar_ext must lower to an ExternFn");
+        let heap_id = heap_id.expect("heap_ext must lower to an ExternFn");
+        assert!(
+            table.provenance_of(scalar_id).is_fresh(),
+            "a scalar-return extern owns nothing and must be Fresh"
+        );
+        assert!(
+            table.provenance_of(heap_id).is_opaque(),
+            "a heap-return extern has no trusted-root marker in the interim → OPAQUE"
+        );
+        assert_eq!(table.len(), 1, "only the scalar extern is a row");
+    }
+
+    // -- Preflight structural carve-out --
+
+    #[test]
+    fn only_call_scrutinees_engage_the_owner_mint() {
+        let module = lower_source(
+            r#"
+            fn producer() -> Result<string, string> { Ok("x") }
+            fn use_call(r: Result<string, string>) -> i64 {
+                match producer() { Ok(_) => 1, Err(_) => 0 }
+            }
+            "#,
+        );
+        // Find the `match producer()` scrutinee inside `use_call` and confirm it
+        // is a Call kind; a bare-place / block scrutinee would not be.
+        let mut saw_call_scrutinee = false;
+        for item in &module.items {
+            if let hew_hir::HirItem::Function(f) = item {
+                if f.name == "use_call" {
+                    for stmt in &f.body.statements {
+                        collect_call_scrutinee(stmt, &mut saw_call_scrutinee);
+                    }
+                    if let Some(tail) = &f.body.tail {
+                        if let hew_hir::HirExprKind::Match { scrutinee, .. } = &tail.kind {
+                            saw_call_scrutinee |= scrutinee_is_call_kind(scrutinee);
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            saw_call_scrutinee,
+            "the `match producer()` scrutinee must be recognised as a Call kind"
+        );
+    }
+
+    fn collect_call_scrutinee(stmt: &hew_hir::HirStmt, out: &mut bool) {
+        if let hew_hir::HirStmtKind::Expr(e) = &stmt.kind {
+            if let hew_hir::HirExprKind::Match { scrutinee, .. } = &e.kind {
+                *out |= scrutinee_is_call_kind(scrutinee);
+            }
+        }
     }
 
     #[test]

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -763,6 +763,12 @@ pub fn reachable_bindings(expr: &HirExpr, out: &mut Reachable) {
         } => {
             reachable_bindings(scrutinee, out);
             for arm in arms {
+                // Guards read (and can escape) tracked bindings before any
+                // arm body runs — a guard-only reference must still reach the
+                // caller-side taint.
+                if let Some(guard) = &arm.guard {
+                    reachable_bindings(guard, out);
+                }
                 reachable_bindings(&arm.body, out);
             }
         }
@@ -1022,6 +1028,7 @@ impl MutationScan<'_> {
 
     #[allow(
         clippy::match_same_arms,
+        clippy::too_many_lines,
         reason = "mutation-scan arms mirror the sealed HirExprKind surface exhaustively"
     )]
     fn expr_mutates(&mut self, expr: &HirExpr) -> bool {
@@ -1080,7 +1087,16 @@ impl MutationScan<'_> {
             }
             HirExprKind::Match {
                 scrutinee, arms, ..
-            } => self.expr_mutates(scrutinee) || arms.iter().any(|a| self.expr_mutates(&a.body)),
+            } => {
+                // Guards run before arm bodies and can mutate a heap param
+                // (`0 if { p.push(x); true } => …`) — omit them and the
+                // may-mutate summary reads a guard-mutating callee as pure.
+                self.expr_mutates(scrutinee)
+                    || arms.iter().any(|a| {
+                        a.guard.as_ref().is_some_and(|g| self.expr_mutates(g))
+                            || self.expr_mutates(&a.body)
+                    })
+            }
             HirExprKind::StructInit { fields, base, .. } => {
                 fields.iter().any(|(_, v)| self.expr_mutates(v))
                     || base.as_deref().is_some_and(|b| self.expr_mutates(b))
@@ -2735,6 +2751,87 @@ mod tests {
             !summary[&fn_id(&module, "reader")],
             "a body that never touches the heap param is not may-mutate"
         );
+    }
+
+    #[test]
+    fn guard_buried_return_contributes_param_bits() {
+        // A `return p` inside a match-arm GUARD exits the function: its value
+        // is a return path. Missing it read this forwarder as Fresh(∅) — the
+        // preflight then admitted `match evil(p, 0)` and minted a second owner
+        // over the caller-owned borrow (the codegen-review exploit).
+        let (m, prov) = provenance_of_source(
+            r"
+            fn evil(p: Vec<i64>, k: i64) -> Vec<i64> {
+                let d = match k {
+                    0 if { return p; } => 0,
+                    _ => 1,
+                };
+                let out: Vec<i64> = Vec::new();
+                out.push(d);
+                out
+            }
+            ",
+        );
+        assert!(
+            prov[&fn_id(&m, "evil")].contains(AliasBits::PARAM),
+            "the guard-buried `return p` path must union {{PARAM}}: {:?}",
+            prov[&fn_id(&m, "evil")]
+        );
+    }
+
+    #[test]
+    fn guard_mutation_of_heap_param_is_may_mutate() {
+        // A mutation inside a match-arm guard runs before any body — the
+        // may-mutate summary must see it.
+        let module = lower_source(
+            r"
+            fn guard_mut(x: Vec<i64>, k: i64) -> i64 {
+                match k {
+                    0 if { x.push(1); true } => 0,
+                    _ => 1,
+                }
+            }
+            ",
+        );
+        let origin_fns = origin_fns_of(&module);
+        let summary = compute_may_mutate_heap_param(&origin_fns);
+        assert!(
+            summary[&fn_id(&module, "guard_mut")],
+            "x.push(1) inside a guard stores into the heap param → may-mutate"
+        );
+    }
+
+    #[test]
+    fn guard_only_binding_reference_is_reachable() {
+        // The total reachability visitor must see a binding referenced ONLY in
+        // a match-arm guard (the caller-side taint channel).
+        let module = lower_source(
+            r"
+            fn probe(h: Vec<i64>, k: i64) -> i64 {
+                match k {
+                    0 if h.len() > 0 => 0,
+                    _ => 1,
+                }
+            }
+            ",
+        );
+        for item in &module.items {
+            if let hew_hir::HirItem::Function(f) = item {
+                if f.name == "probe" {
+                    let h_id = f.params[0].id;
+                    let mut r = Reachable::default();
+                    if let Some(tail) = &f.body.tail {
+                        reachable_bindings(tail, &mut r);
+                    }
+                    assert!(
+                        r.bindings.contains(&h_id),
+                        "a guard-only reference to `h` must be reachable: {r:?}"
+                    );
+                    return;
+                }
+            }
+        }
+        panic!("probe not found");
     }
 
     #[test]

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -378,7 +378,7 @@ pub fn ty_is_scalar_non_heap(ty: &ResolvedTy) -> bool {
 /// `hew_vec_get_owned`/`_ptr`), and lowering picks the actual owned callee at
 /// emission time (`hew_vec_get_clone` for owned-value elements,
 /// `hew_hashmap_get_clone_layout` always for `HashMap` get). Keying on the HIR
-/// symbol/family would admit the receiver-alias class this lane rejects, so the
+/// symbol/family would admit the receiver-alias class this check rejects, so the
 /// contract keys on the EMITTED symbol the site will actually lower to.
 const PROVED_OWNER_METHOD_SYMBOLS: &[&str] = &[
     "hew_vec_get_clone",
@@ -583,7 +583,7 @@ pub fn build_call_scrutinee_provenance(
 /// minted), whereas a user-declared `extern "C" fn hew_channel_recv_layout(..)`
 /// resolves to `ResolvedRef::Item` → does NOT match → falls through to the
 /// three-way `Call` resolution → `{OPAQUE}` → REJECT (fail-closed; closes the
-/// name-forgeable bypass this lane fixes).
+/// name-forgeable bypass this admission check fixes).
 #[must_use]
 pub fn is_typed_recv_callee(callee: &HirExpr) -> bool {
     use hew_types::runtime_call::RuntimeCallFamily as F;

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -2489,9 +2489,9 @@ mod tests {
     /// only raise `compared`), so adding fixtures never breaks it while a
     /// disappearing corpus does.
     /// Floor on the number of `.hew` files discovered under the named roots.
-    const CORPUS_FILE_FLOOR: usize = 700;
+    const CORPUS_FILE_FLOOR: usize = 840;
     /// Floor on the number of inputs that lower standalone and are compared.
-    const COMPARED_FLOOR: usize = 700;
+    const COMPARED_FLOOR: usize = 800;
 
     #[test]
     fn coarse_verdict_differential() {
@@ -2501,6 +2501,7 @@ mod tests {
             .to_path_buf();
         let roots = [
             "std",
+            "tests/hew",
             "tests/vertical-slice/accept",
             "tests/vertical-slice/reject",
             "examples/v05/checked-mir",

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -1892,6 +1892,137 @@ mod tests {
         assert_eq!(coarse, frozen);
     }
 
+    /// Recursively collect every `.hew` file under `dir` into `out`.
+    fn collect_hew_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect_hew_files(&path, out);
+            } else if path.extension().is_some_and(|e| e == "hew") {
+                out.push(path);
+            }
+        }
+    }
+
+    /// The F5 interface pin (corpus half) [F5/Rev-4]: iterate the named corpus
+    /// roots, standalone-lower every `.hew` to HIR, and for EVERY function assert
+    /// the LIVE Coarse fixpoint (routed through the shared `return_alias_bits`
+    /// walk) equals the FROZEN pre-refactor transfer. Divergence on any function
+    /// is a silent-UAF-regression signal in the funcupdate (#2420 base) / reassign
+    /// consumers that share the Coarse authority.
+    ///
+    /// An input that fails BEFORE HIR (parse / resolve error, or a standalone
+    /// lowering that panics without the full module registry) is skipped and
+    /// counted; the `compared` floor guards against silent corpus shrinkage
+    /// turning the differential vacuous. The floor is a lower bound (new inputs
+    /// only raise `compared`), so adding fixtures never breaks it while a
+    /// disappearing corpus does.
+    /// Floor on the number of `.hew` files discovered under the named roots.
+    const CORPUS_FILE_FLOOR: usize = 700;
+    /// Floor on the number of inputs that lower standalone and are compared.
+    const COMPARED_FLOOR: usize = 700;
+
+    #[test]
+    fn coarse_verdict_differential() {
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("hew-mir crate dir has a repo-root parent")
+            .to_path_buf();
+        let roots = [
+            "std",
+            "tests/vertical-slice/accept",
+            "tests/vertical-slice/reject",
+            "examples/v05/checked-mir",
+            "examples/v05",
+        ];
+        let mut files: Vec<std::path::PathBuf> = Vec::new();
+        for r in roots {
+            collect_hew_files(&repo_root.join(r), &mut files);
+        }
+        files.sort();
+        files.dedup();
+        assert!(
+            files.len() >= CORPUS_FILE_FLOOR,
+            "corpus enumeration collapsed: found only {} `.hew` files under the named roots \
+             (repo_root={}); expected >= {CORPUS_FILE_FLOOR}",
+            files.len(),
+            repo_root.display(),
+        );
+
+        // The comparison runs on a worker thread with a large stack: a corpus
+        // input's standalone lowering can recurse deeply enough to overflow the
+        // default test stack (an abort `catch_unwind` cannot trap), so the big
+        // stack keeps the differential robust over the whole corpus.
+        let worker = std::thread::Builder::new()
+            .name("coarse-verdict-differential".into())
+            .stack_size(256 * 1024 * 1024)
+            .spawn(move || {
+                // Standalone lowering of a corpus file that expects the full
+                // module registry can panic; treat a panic as a skip, not a
+                // differential failure.
+                let prev_hook = std::panic::take_hook();
+                std::panic::set_hook(Box::new(|_| {}));
+
+                let mut compared = 0usize;
+                let mut skipped = 0usize;
+                let mut drift: Vec<String> = Vec::new();
+                for f in &files {
+                    let Ok(src) = std::fs::read_to_string(f) else {
+                        skipped += 1;
+                        continue;
+                    };
+                    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        let parsed = hew_parser::parse(&src);
+                        if !parsed.errors.is_empty() {
+                            return None;
+                        }
+                        let mut checker = hew_types::Checker::new(
+                            hew_types::module_registry::ModuleRegistry::new(vec![]),
+                        );
+                        let tc_output = checker.check_program(&parsed.program);
+                        let output = hew_hir::lower_program(
+                            &parsed.program,
+                            &tc_output,
+                            &hew_hir::ResolutionCtx,
+                            hew_hir::TargetArch::host(),
+                        );
+                        let origin_fns = origin_fns_of(&output.module);
+                        let live = compute_fn_returns_fresh_owner(&origin_fns);
+                        let frozen = compute_fn_returns_fresh_owner_ref(&origin_fns);
+                        Some(live == frozen)
+                    }));
+                    match outcome {
+                        Ok(Some(true)) => compared += 1,
+                        Ok(Some(false)) => {
+                            compared += 1;
+                            drift.push(f.display().to_string());
+                        }
+                        Ok(None) | Err(_) => skipped += 1,
+                    }
+                }
+
+                std::panic::set_hook(prev_hook);
+                (compared, skipped, drift)
+            })
+            .expect("spawn coarse-verdict-differential worker");
+        let (compared, skipped, drift) = worker.join().expect("worker thread panicked");
+
+        assert!(
+            drift.is_empty(),
+            "Coarse verdict drift between the shared walk and the frozen pre-refactor \
+             reference on {} corpus input(s): {drift:#?}",
+            drift.len(),
+        );
+        assert!(
+            compared >= COMPARED_FLOOR,
+            "the coarse differential went vacuous: only {compared} corpus input(s) lowered \
+             standalone ({skipped} skipped); silent corpus shrinkage below the {COMPARED_FLOOR} floor",
+        );
+    }
+
     // -- Method-call return contract [F1] --
 
     #[test]

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -36,9 +36,16 @@
 //! consumes the three-state verdict. Two parallel walkers were the drift that
 //! produced the #2523 twin — there is only one here.
 
+#![allow(
+    deprecated,
+    reason = "the reachability + mutation visitors visit the legacy CallTraitMethodStatic \
+              variant exhaustively (fail-closed as may-mutate); it is allowlist-gated at \
+              construction, matching the same allow in lower.rs"
+)]
+
 use std::collections::HashMap;
 
-use hew_hir::{HirExpr, HirExprKind, HirFn, ResolvedRef};
+use hew_hir::{HirBlock, HirExpr, HirExprKind, HirFn, ResolvedRef};
 use hew_types::ResolvedTy;
 
 // ---------------------------------------------------------------------------
@@ -533,6 +540,515 @@ pub enum CallScrutineeAdmission {
 }
 
 // ---------------------------------------------------------------------------
+// Total HIR reachability visitor + intra-procedural alias partition [F2-Rev6]
+// ---------------------------------------------------------------------------
+
+/// The set of tracked local/param bindings a value expression may carry an alias
+/// of, plus an `unknown` flag.
+///
+/// `unknown` is set when the visitor hits an unmodelled heap-bearing form — a
+/// fail-closed marker: an `unknown` reachability taints as if every tracked class
+/// were reached. This is what makes the mutation-side extraction TOTAL: a form
+/// the visitor cannot see through never silently reads as "reaches nothing".
+#[derive(Debug, Default, Clone)]
+pub struct Reachable {
+    /// Bindings the value may embed an alias of.
+    pub bindings: std::collections::HashSet<hew_hir::BindingId>,
+    /// True when an unmodelled heap-bearing sub-form was encountered.
+    pub unknown: bool,
+}
+
+/// Resolve the root binding of a place expression, walking through
+/// field/tuple/index/slice projections. `None` when the root is not a binding
+/// reference (a call result, a literal, an aggregate, …).
+#[must_use]
+#[allow(
+    clippy::match_same_arms,
+    reason = "projection arms are kept distinct to mirror the sealed HirExprKind surface"
+)]
+pub fn place_root_binding(expr: &HirExpr) -> Option<hew_hir::BindingId> {
+    match &expr.kind {
+        HirExprKind::BindingRef {
+            resolved: ResolvedRef::Binding(id),
+            ..
+        } => Some(*id),
+        HirExprKind::FieldAccess { object, .. } => place_root_binding(object),
+        HirExprKind::TupleIndex { tuple, .. } => place_root_binding(tuple),
+        HirExprKind::Index { container, .. } => place_root_binding(container),
+        HirExprKind::Slice { container, .. } => place_root_binding(container),
+        _ => None,
+    }
+}
+
+/// The TOTAL reachability visitor: descend EVERY expression AND statement form
+/// reachable from `expr` — aggregate operands, projections, wrappers (`Block`
+/// with ALL statements and the tail, `If`, `Match` arms), the array-literal
+/// desugar's non-tail push statements, `Closure`/`GenBlock` capture ledgers,
+/// call/method arguments and receivers, and every nested sub-expression —
+/// accumulating every tracked binding alias into `out`.
+///
+/// SEPARATE from the admission-side value-flow [`return_alias_bits`] (which stays
+/// tail-only, sound for the returned VALUE). Reusing the tail-only walk for
+/// REACHABILITY was the round-4 bug: `helper([h], p)` hides `h` in a non-tail
+/// push, and a `Closure` capturing `h` stores it in a ledger field an operand
+/// visitor never reaches.
+#[allow(
+    clippy::too_many_lines,
+    clippy::match_same_arms,
+    reason = "the reachability visitor mirrors the sealed HirExprKind surface exhaustively;               structurally-similar arms are kept separate for auditability"
+)]
+pub fn reachable_bindings(expr: &HirExpr, out: &mut Reachable) {
+    match &expr.kind {
+        HirExprKind::BindingRef {
+            resolved: ResolvedRef::Binding(id),
+            ..
+        } => {
+            out.bindings.insert(*id);
+        }
+        // Aggregates — an operand embedded in a struct/tuple/variant carries its
+        // alias into the constructed value.
+        HirExprKind::StructInit { fields, base, .. } => {
+            for (_, v) in fields {
+                reachable_bindings(v, out);
+            }
+            if let Some(base) = base.as_deref() {
+                reachable_bindings(base, out);
+            }
+        }
+        HirExprKind::TupleLiteral { elements } => {
+            for e in elements {
+                reachable_bindings(e, out);
+            }
+        }
+        HirExprKind::MachineVariantCtor { payload, .. } => {
+            if let Some(fields) = payload {
+                for (_, v) in fields {
+                    reachable_bindings(v, out);
+                }
+            }
+        }
+        // Projections and casts pass the alias through.
+        HirExprKind::FieldAccess { object, .. } => reachable_bindings(object, out),
+        HirExprKind::TupleIndex { tuple, .. } => reachable_bindings(tuple, out),
+        HirExprKind::Index { container, index } => {
+            reachable_bindings(container, out);
+            reachable_bindings(index, out);
+        }
+        HirExprKind::Slice { container, .. } => reachable_bindings(container, out),
+        HirExprKind::NumericCast { value, .. }
+        | HirExprKind::SaturatingWidthCast { value, .. }
+        | HirExprKind::TryWidthCast { value, .. }
+        | HirExprKind::CoerceToDynTrait { value, .. } => reachable_bindings(value, out),
+        // Wrappers — visit ALL statements (the array-literal desugar hides its
+        // push in a NON-tail statement) and the tail.
+        HirExprKind::Block(block) => reachable_bindings_in_block(block, out),
+        HirExprKind::If {
+            then_expr,
+            else_expr,
+            ..
+        } => {
+            reachable_bindings(then_expr, out);
+            if let Some(e) = else_expr.as_deref() {
+                reachable_bindings(e, out);
+            }
+        }
+        HirExprKind::Match {
+            scrutinee, arms, ..
+        } => {
+            reachable_bindings(scrutinee, out);
+            for arm in arms {
+                reachable_bindings(&arm.body, out);
+            }
+        }
+        // Calls / methods — an argument (or receiver) embedding a tracked local
+        // carries it to the call boundary.
+        HirExprKind::Call { callee, args } | HirExprKind::SpawnedCall { callee, args, .. } => {
+            reachable_bindings(callee, out);
+            for a in args {
+                reachable_bindings(a, out);
+            }
+        }
+        HirExprKind::CallDynMethod { receiver, args, .. }
+        | HirExprKind::ResolvedImplCall { receiver, args, .. }
+        | HirExprKind::CallTraitMethodStatic { receiver, args, .. }
+        | HirExprKind::VarSelfMethodCall { receiver, args, .. } => {
+            reachable_bindings(receiver, out);
+            for a in args {
+                reachable_bindings(a, out);
+            }
+        }
+        HirExprKind::NumericMethod { receiver, arg, .. } => {
+            reachable_bindings(receiver, out);
+            reachable_bindings(arg, out);
+        }
+        HirExprKind::Binary { left, right, .. } | HirExprKind::IdentityCompare { left, right } => {
+            reachable_bindings(left, out);
+            reachable_bindings(right, out);
+        }
+        HirExprKind::Unary { operand, .. } => reachable_bindings(operand, out),
+        // Capture ledgers — a closure/generator capturing a tracked local carries
+        // it across the callable boundary (an operand visitor cannot see these).
+        HirExprKind::Closure { captures, .. } => {
+            for cap in captures {
+                out.bindings.insert(cap.binding);
+            }
+        }
+        HirExprKind::GenBlock { captures, .. } => {
+            for cap in captures {
+                out.bindings.insert(cap.binding);
+            }
+        }
+        // Fresh-by-construction / non-heap leaves carry no caller local.
+        HirExprKind::Literal(_)
+        | HirExprKind::RegexLiteralRef { .. }
+        | HirExprKind::RecordCloneCall { .. }
+        | HirExprKind::ActorSelf
+        | HirExprKind::ContextReader { .. } => {}
+        HirExprKind::BindingRef { .. } => {
+            // A non-local binding reference (Item / Const / Builtin) — a global or
+            // module item, carries no tracked local.
+        }
+        // Any other form: fail closed if it could carry heap.
+        other => {
+            let _ = other;
+            if !ty_is_scalar_non_heap(&expr.ty) {
+                out.unknown = true;
+            }
+        }
+    }
+}
+
+/// Reachability over a block: EVERY statement (initializers, assignments,
+/// discarded expressions, returns, defers, let-else scrutinees/preludes) and the
+/// tail. The non-tail statements are what the tail-only value-flow walk misses.
+#[allow(
+    clippy::match_same_arms,
+    reason = "statement arms mirror the sealed HirStmtKind surface exhaustively"
+)]
+fn reachable_bindings_in_block(block: &HirBlock, out: &mut Reachable) {
+    for stmt in &block.statements {
+        match &stmt.kind {
+            hew_hir::HirStmtKind::Let(_, Some(init)) => reachable_bindings(init, out),
+            hew_hir::HirStmtKind::Let(_, None) => {}
+            hew_hir::HirStmtKind::Assign { target, value } => {
+                reachable_bindings(target, out);
+                reachable_bindings(value, out);
+            }
+            hew_hir::HirStmtKind::Expr(e) => reachable_bindings(e, out),
+            hew_hir::HirStmtKind::Return(Some(e)) => reachable_bindings(e, out),
+            hew_hir::HirStmtKind::Return(None) => {}
+            hew_hir::HirStmtKind::Defer { body, .. } => reachable_bindings(body, out),
+            hew_hir::HirStmtKind::LetElse {
+                scrutinee,
+                success_prelude,
+                else_body,
+                ..
+            } => {
+                reachable_bindings(scrutinee, out);
+                for s in success_prelude {
+                    if let hew_hir::HirStmtKind::Let(_, Some(v)) = &s.kind {
+                        reachable_bindings(v, out);
+                    }
+                }
+                reachable_bindings_in_block(else_body, out);
+            }
+        }
+    }
+    if let Some(tail) = &block.tail {
+        reachable_bindings(tail, out);
+    }
+}
+
+/// The by-value heap parameters of `f` (the borrows a caller still owns). A
+/// scalar param owns nothing → excluded; every non-scalar param is conservatively
+/// included (a precise `ty_owns_heap` refinement is a wiring-site concern; PARAM
+/// over-inclusion is sound).
+#[must_use]
+pub fn by_value_heap_param_bindings(f: &HirFn) -> std::collections::HashSet<hew_hir::BindingId> {
+    f.params
+        .iter()
+        .filter(|p| !ty_is_scalar_non_heap(&p.ty))
+        .map(|p| p.id)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Interprocedural may-mutate-heap-param summary [F2]
+// ---------------------------------------------------------------------------
+
+/// Whole-function conservative summary: does `f` MUTATE (or store into) any of
+/// its by-value heap parameters — the channel by which a returned param-borrow
+/// silently gains an alias?
+///
+/// A second monotone boolean fixpoint (init `false`), built beside the provenance
+/// fixpoint. `f` is may-mutate if its body:
+/// - projection-stores (`p.f = …` / `p[i] = …`) into a heap param;
+/// - calls a mutating / storing method on a heap param (anything NOT proven
+///   `BorrowsReceiver` + non-escaping string args);
+/// - passes a heap param (reachable through the total visitor) as an argument to
+///   a callee NOT proven `!may_mutate` under the current table;
+/// - invokes a callable parameter (an fn-pointer/closure param — conservatively
+///   may-mutate).
+///
+/// Audited pure externs are absent from `fns`, so they never set the bit; an
+/// unknown/indirect callee is treated as may-mutate (fail-closed).
+#[must_use]
+#[allow(
+    clippy::implicit_hasher,
+    reason = "built once over the pipeline's default-hasher origin_fns map"
+)]
+pub fn compute_may_mutate_heap_param(
+    fns: &HashMap<hew_hir::ItemId, &HirFn>,
+) -> HashMap<hew_hir::ItemId, bool> {
+    let mut summary: HashMap<hew_hir::ItemId, bool> = fns.keys().map(|&id| (id, false)).collect();
+    loop {
+        let mut changed = false;
+        for (&id, &f) in fns {
+            if summary[&id] {
+                continue;
+            }
+            if fn_mutates_heap_param(f, &summary) {
+                summary.insert(id, true);
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    summary
+}
+
+/// True when `f`'s body mutates one of its by-value heap params (or their alias
+/// class) under the current `summary`.
+fn fn_mutates_heap_param(f: &HirFn, summary: &HashMap<hew_hir::ItemId, bool>) -> bool {
+    let param_class = by_value_heap_param_bindings(f);
+    if param_class.is_empty() {
+        return false;
+    }
+    let mut ctx = MutationScan {
+        param_class: &param_class,
+        summary,
+        callable_params: f
+            .params
+            .iter()
+            .filter(|p| {
+                matches!(
+                    p.ty,
+                    ResolvedTy::Function { .. } | ResolvedTy::Closure { .. }
+                )
+            })
+            .map(|p| p.id)
+            .collect(),
+    };
+    ctx.block_mutates(&f.body)
+}
+
+struct MutationScan<'a> {
+    param_class: &'a std::collections::HashSet<hew_hir::BindingId>,
+    summary: &'a HashMap<hew_hir::ItemId, bool>,
+    callable_params: std::collections::HashSet<hew_hir::BindingId>,
+}
+
+impl MutationScan<'_> {
+    /// True when any tracked heap param is reachable from `expr` as an argument
+    /// value (via the total reachability visitor, including the `unknown`
+    /// fail-closed marker).
+    fn arg_reaches_param(&self, expr: &HirExpr) -> bool {
+        let mut r = Reachable::default();
+        reachable_bindings(expr, &mut r);
+        r.unknown || r.bindings.iter().any(|b| self.param_class.contains(b))
+    }
+
+    #[allow(
+        clippy::match_same_arms,
+        reason = "statement arms mirror the sealed HirStmtKind surface exhaustively"
+    )]
+    fn block_mutates(&mut self, block: &HirBlock) -> bool {
+        for stmt in &block.statements {
+            match &stmt.kind {
+                hew_hir::HirStmtKind::Let(_, Some(init)) => {
+                    if self.expr_mutates(init) {
+                        return true;
+                    }
+                }
+                hew_hir::HirStmtKind::Let(_, None) => {}
+                hew_hir::HirStmtKind::Assign { target, value } => {
+                    // A projection-store into a heap-param place is a mutation.
+                    if is_projection_place(target)
+                        && place_root_binding(target).is_some_and(|b| self.param_class.contains(&b))
+                    {
+                        return true;
+                    }
+                    if self.expr_mutates(target) || self.expr_mutates(value) {
+                        return true;
+                    }
+                }
+                hew_hir::HirStmtKind::Expr(e) => {
+                    if self.expr_mutates(e) {
+                        return true;
+                    }
+                }
+                hew_hir::HirStmtKind::Return(Some(e)) => {
+                    if self.expr_mutates(e) {
+                        return true;
+                    }
+                }
+                hew_hir::HirStmtKind::Return(None) => {}
+                hew_hir::HirStmtKind::Defer { body, .. } => {
+                    if self.expr_mutates(body) {
+                        return true;
+                    }
+                }
+                hew_hir::HirStmtKind::LetElse {
+                    scrutinee,
+                    else_body,
+                    ..
+                } => {
+                    if self.expr_mutates(scrutinee) || self.block_mutates(else_body) {
+                        return true;
+                    }
+                }
+            }
+        }
+        block.tail.as_deref().is_some_and(|t| self.expr_mutates(t))
+    }
+
+    #[allow(
+        clippy::match_same_arms,
+        reason = "mutation-scan arms mirror the sealed HirExprKind surface exhaustively"
+    )]
+    fn expr_mutates(&mut self, expr: &HirExpr) -> bool {
+        match &expr.kind {
+            // A mutating / storing method on a heap-param receiver.
+            HirExprKind::ResolvedImplCall {
+                receiver,
+                target_symbol,
+                args,
+                ..
+            } => {
+                if place_root_binding(receiver).is_some_and(|b| self.param_class.contains(&b))
+                    && !method_is_non_mutating(target_symbol)
+                {
+                    return true;
+                }
+                self.expr_mutates(receiver) || args.iter().any(|a| self.expr_mutates(a))
+            }
+            HirExprKind::VarSelfMethodCall { receiver, args, .. }
+            | HirExprKind::CallDynMethod { receiver, args, .. }
+            | HirExprKind::CallTraitMethodStatic { receiver, args, .. } => {
+                // No emitted-symbol contract available for these forms here →
+                // fail-closed: a mutating method on a heap-param receiver taints.
+                if place_root_binding(receiver).is_some_and(|b| self.param_class.contains(&b)) {
+                    return true;
+                }
+                self.expr_mutates(receiver) || args.iter().any(|a| self.expr_mutates(a))
+            }
+            HirExprKind::NumericMethod { receiver, arg, .. } => {
+                self.expr_mutates(receiver) || self.expr_mutates(arg)
+            }
+            // A direct call: may-mutate if the callee is not proven pure AND an
+            // argument reaches a heap-param class; a callable-param invocation is
+            // may-mutate unconditionally when an arg reaches (or when the invoked
+            // callable itself captures — conservatively any-arg).
+            HirExprKind::Call { callee, args } => {
+                let callee_pure = self.callee_is_proven_pure(callee);
+                if !callee_pure && args.iter().any(|a| self.arg_reaches_param(a)) {
+                    return true;
+                }
+                // A callable-parameter invocation with no explicit heap arg still
+                // may mutate through the callable's captures — fail-closed.
+                if self.callee_is_callable_param(callee) {
+                    return true;
+                }
+                args.iter().any(|a| self.expr_mutates(a))
+            }
+            HirExprKind::Block(block) => self.block_mutates(block),
+            HirExprKind::If {
+                then_expr,
+                else_expr,
+                ..
+            } => {
+                self.expr_mutates(then_expr)
+                    || else_expr.as_deref().is_some_and(|e| self.expr_mutates(e))
+            }
+            HirExprKind::Match {
+                scrutinee, arms, ..
+            } => self.expr_mutates(scrutinee) || arms.iter().any(|a| self.expr_mutates(&a.body)),
+            HirExprKind::StructInit { fields, base, .. } => {
+                fields.iter().any(|(_, v)| self.expr_mutates(v))
+                    || base.as_deref().is_some_and(|b| self.expr_mutates(b))
+            }
+            HirExprKind::TupleLiteral { elements } => elements.iter().any(|e| self.expr_mutates(e)),
+            HirExprKind::FieldAccess { object, .. } => self.expr_mutates(object),
+            HirExprKind::TupleIndex { tuple, .. } => self.expr_mutates(tuple),
+            HirExprKind::Index { container, index } => {
+                self.expr_mutates(container) || self.expr_mutates(index)
+            }
+            HirExprKind::Binary { left, right, .. } => {
+                self.expr_mutates(left) || self.expr_mutates(right)
+            }
+            HirExprKind::Unary { operand, .. } => self.expr_mutates(operand),
+            HirExprKind::Return { value } => value.as_deref().is_some_and(|v| self.expr_mutates(v)),
+            _ => false,
+        }
+    }
+
+    fn callee_is_callable_param(&self, callee: &HirExpr) -> bool {
+        matches!(
+            &callee.kind,
+            HirExprKind::BindingRef { resolved: ResolvedRef::Binding(id), .. }
+            if self.callable_params.contains(id)
+        )
+    }
+
+    fn callee_is_proven_pure(&self, callee: &HirExpr) -> bool {
+        // A resolved module item proven `!may_mutate` under the current summary is
+        // pure. `None` in the summary = an extern / constructor with no analysable
+        // body → pure by the owned-return ABI (matches the freshness gate's trust
+        // of owned-return externs). Everything else (closure/indirect/unresolved)
+        // is NOT proven pure → fail-closed.
+        if let HirExprKind::BindingRef {
+            resolved: ResolvedRef::Item(id),
+            ..
+        } = &callee.kind
+        {
+            !self.summary.get(id).copied().unwrap_or(false)
+        } else {
+            false
+        }
+    }
+}
+
+/// True when `place` is a projection (not a bare binding) — a `p.f` / `p[i]` /
+/// `p.0` place whose store mutates interior storage.
+fn is_projection_place(place: &HirExpr) -> bool {
+    matches!(
+        &place.kind,
+        HirExprKind::FieldAccess { .. }
+            | HirExprKind::TupleIndex { .. }
+            | HirExprKind::Index { .. }
+            | HirExprKind::Slice { .. }
+    )
+}
+
+/// True when an EMITTED method symbol is proven non-mutating AND non-storing —
+/// the ONLY exempt contract (`BorrowsReceiver` receiver + non-escaping string
+/// args). Everything else (a storing element write, an escaping arg, an unknown
+/// symbol's `FAIL_CLOSED` default) counts as mutating.
+fn method_is_non_mutating(emitted_symbol: &str) -> bool {
+    use crate::runtime_symbols::{
+        callee_ownership_contract, ReceiverOwnership, StringArgsOwnership,
+    };
+    let contract = callee_ownership_contract(emitted_symbol);
+    matches!(contract.receiver, ReceiverOwnership::BorrowsReceiver { .. })
+        && matches!(
+            contract.string_args,
+            StringArgsOwnership::BorrowingUse | StringArgsOwnership::PrintSink
+        )
+}
+
+// ---------------------------------------------------------------------------
 // Module-map helpers
 // ---------------------------------------------------------------------------
 
@@ -780,6 +1296,85 @@ mod tests {
                 *out |= scrutinee_is_call_kind(scrutinee);
             }
         }
+    }
+
+    // -- Interprocedural may-mutate-heap-param summary [F2] --
+
+    fn fn_id(module: &hew_hir::HirModule, name: &str) -> hew_hir::ItemId {
+        for item in &module.items {
+            if let hew_hir::HirItem::Function(f) = item {
+                if f.name == name {
+                    return f.id;
+                }
+            }
+        }
+        panic!("function {name} not found");
+    }
+
+    #[test]
+    fn method_mutation_on_heap_param_is_may_mutate() {
+        let module = lower_source(
+            r"
+            fn mutate(x: Vec<i64>, v: i64) { x.push(v); }
+            fn reader(x: Vec<i64>) -> i64 { 0 }
+            ",
+        );
+        let origin_fns = origin_fns_of(&module);
+        let summary = compute_may_mutate_heap_param(&origin_fns);
+        assert!(
+            summary[&fn_id(&module, "mutate")],
+            "x.push(v) stores into the heap param x → may-mutate"
+        );
+        assert!(
+            !summary[&fn_id(&module, "reader")],
+            "a body that never touches the heap param is not may-mutate"
+        );
+    }
+
+    #[test]
+    fn interprocedural_mutation_propagates_to_the_caller() {
+        let module = lower_source(
+            r"
+            fn mutate(x: Vec<i64>, v: i64) { x.push(v); }
+            fn caller(h: Vec<i64>, v: i64) { mutate(h, v); }
+            fn pure_target(x: Vec<i64>) -> i64 { 0 }
+            fn caller_pure(h: Vec<i64>) -> i64 { pure_target(h) }
+            ",
+        );
+        let origin_fns = origin_fns_of(&module);
+        let summary = compute_may_mutate_heap_param(&origin_fns);
+        assert!(
+            summary[&fn_id(&module, "caller")],
+            "passing a heap param to a may-mutate callee taints the caller"
+        );
+        assert!(
+            !summary[&fn_id(&module, "caller_pure")],
+            "passing a heap param to a proven-pure callee does not taint the caller"
+        );
+    }
+
+    #[test]
+    fn reachability_sees_a_heap_param_through_a_direct_ref() {
+        let module = lower_source(r"fn f(a: Vec<i64>) -> Vec<i64> { a }");
+        let f = module.items.iter().find_map(|it| match it {
+            hew_hir::HirItem::Function(f) if f.name == "f" => Some(f),
+            _ => None,
+        });
+        let f = f.expect("f present");
+        let params = by_value_heap_param_bindings(f);
+        assert_eq!(
+            params.len(),
+            1,
+            "the Vec<i64> param is a by-value heap param"
+        );
+        let tail = f.body.tail.as_deref().expect("f has a tail expr");
+        let mut r = Reachable::default();
+        reachable_bindings(tail, &mut r);
+        assert!(!r.unknown);
+        assert!(
+            params.iter().all(|p| r.bindings.contains(p)),
+            "the returned `a` reaches the heap param binding"
+        );
     }
 
     #[test]

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -1,0 +1,531 @@
+//! Call-scrutinee return provenance (#2648) — the sound, precise authority for
+//! *what a called function's by-value return may alias*.
+//!
+//! # Why this module exists
+//!
+//! The match/while-let/let-else/if-let/discarded call-scrutinee owner mint
+//! (`call_scrutinee_owned_ty`, #2429) and #2523's projected-payload move-out
+//! neutralize both rest on one premise: *a `Call` scrutinee's by-value return is
+//! a fresh sole owner*. That premise is FALSE for an identity-forwarding callee
+//! (`fn passthru(x: Box) -> Box { x }`) — by-value heap params are `Read`
+//! borrows (`by-value-heap-params-are-borrows`), so the return aliases storage
+//! the caller still owns; minting a second owner over it double-frees (#2648).
+//!
+//! This module replaces the fail-**open** admission with a **three-state
+//! may-alias lattice** `AliasBits = { PARAM, OPAQUE }` (Fresh = ∅), computed by a
+//! monotone least-fixpoint that starts EMPTY and grows by union. The lattice
+//! distinguishes an arg-rescuable forward (`ParamsOnly`, `{PARAM}`) from a
+//! never-rescuable alias (`Opaque`, `⊇{OPAQUE}` — a capture, a global, an
+//! interior borrow, an indirect callee), which a boolean cannot.
+//!
+//! # Status: UNWIRED (S1)
+//!
+//! Every item here is analysis machinery with NO behaviour change: the sole
+//! live edge is [`return_value_may_alias_borrow`] delegating to
+//! [`return_alias_bits`] under [`CoarsePolicy`], whose output is byte-identical
+//! to the pre-refactor boolean walk (proven by the `coarse_verdict_differential`
+//! frozen-reference test). The Precise driver, the interprocedural mutation
+//! summary, the preflight classifier, and the extern contract table are all
+//! authored here but consumed by no lowering path until S2+.
+//!
+//! # The one-authority discipline (`vec-element-width-symmetric-abi`)
+//!
+//! The leaf walk is written ONCE as [`return_alias_bits`], parameterized by a
+//! [`LeafPolicy`]. `CoarsePolicy` reproduces today's leaves exactly so the
+//! shared funcupdate/reassign gates stay byte-identical; `PrecisePolicy` (S2)
+//! consumes the three-state verdict. Two parallel walkers were the drift that
+//! produced the #2523 twin — there is only one here.
+
+use std::collections::HashMap;
+
+use hew_hir::{HirExpr, HirExprKind, HirFn, ResolvedRef};
+use hew_types::ResolvedTy;
+
+// ---------------------------------------------------------------------------
+// The three-state may-alias lattice
+// ---------------------------------------------------------------------------
+
+/// May-alias provenance bits for a value used as a function's by-value return.
+///
+/// - Empty (`∅`) is `Fresh`: aliases nothing caller-visible.
+/// - `PARAM` is `ParamsOnly`: may alias one of the callee's by-value heap
+///   params and nothing else (arg-rescuable — the forwarded param binds to some
+///   caller argument).
+/// - `OPAQUE` is `Opaque`: may alias a capture, a global, an interior borrow,
+///   or an indirect/unknown callee. Never rescuable by an argument scan.
+///
+/// The set is finite (2 bits), and the module fixpoint only ever unions bits in,
+/// so it terminates. This is a sound may-analysis: every real alias source is
+/// injected by a concrete (non-recursive) transfer and propagated to stability.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct AliasBits(u8);
+
+impl AliasBits {
+    /// Fresh — the value aliases nothing caller-visible. **ADMIT regardless of
+    /// args.**
+    pub const EMPTY: Self = Self(0);
+    /// The value may alias a by-value heap parameter (and nothing else). **May
+    /// scan caller args** — ADMIT iff every heap-owning argument is itself fresh.
+    pub const PARAM: Self = Self(0b01);
+    /// The value may alias something the analysis cannot see through. **REJECT
+    /// always; the arg scan cannot rescue it.**
+    pub const OPAQUE: Self = Self(0b10);
+
+    /// True when the value is provably a fresh sole owner (`∅`).
+    #[must_use]
+    pub const fn is_fresh(self) -> bool {
+        self.0 == 0
+    }
+
+    /// True when every set bit is `PARAM` (i.e. `ParamsOnly`, not `Opaque`) and
+    /// at least one bit is set. Only a `ParamsOnly` verdict licenses the caller
+    /// arg-scan — this is the load-bearing rule (a boolean + arg-scan is unsound
+    /// because it admits a zero-arg opaque return).
+    #[must_use]
+    pub const fn is_params_only(self) -> bool {
+        self.0 == Self::PARAM.0
+    }
+
+    /// True when the `OPAQUE` bit is set — a never-rescuable alias.
+    #[must_use]
+    pub const fn is_opaque(self) -> bool {
+        self.0 & Self::OPAQUE.0 != 0
+    }
+
+    /// True when `other`'s bits are all present in `self`.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
+
+impl std::ops::BitOr for AliasBits {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl std::ops::BitOrAssign for AliasBits {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl std::fmt::Debug for AliasBits {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (self.contains(Self::PARAM), self.contains(Self::OPAQUE)) {
+            (false, false) => f.write_str("Fresh(∅)"),
+            (true, false) => f.write_str("ParamsOnly({PARAM})"),
+            (false, true) => f.write_str("Opaque({OPAQUE})"),
+            (true, true) => f.write_str("Opaque({PARAM|OPAQUE})"),
+        }
+    }
+}
+
+/// Whole-function return provenance = the union of every value-bearing return
+/// path's `AliasBits`. This is the summary the module fixpoint computes per
+/// `ItemId`.
+pub type ReturnProvenance = AliasBits;
+
+// ---------------------------------------------------------------------------
+// The parameterized leaf walk — ONE authority, two policies
+// ---------------------------------------------------------------------------
+
+/// The interprocedural resolution of a `Call` callee, shared shape for both
+/// policies. The shared walk owns the recursion; the policy only classifies the
+/// callee.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum CallClass {
+    /// The callee is proven to hand back a fresh owner regardless of arguments
+    /// → contributes `∅`.
+    Fresh,
+    /// The callee may forward a by-value param → the call contributes the union
+    /// of its heap arguments' bits (argument substitution; a non-heap arg is `∅`
+    /// so unioning ALL args is a sound superset of "heap args only").
+    ParamSubst,
+    /// The callee may alias something unknowable, OR the callee is not a
+    /// statically-resolved item (a closure value, a fn-pointer param, an
+    /// indirect/dynamic dispatch that can return a captured heap param through
+    /// its environment) → contributes `{OPAQUE}` unconditionally. Fail-closed.
+    Opaque,
+}
+
+/// The leaf/callee decisions that differ between the Coarse (byte-identical to
+/// today) and Precise (#2648) walks. The structural arms (wrappers, aggregates,
+/// projections, the fresh `Index`/`Slice`/`Literal`/`RecordCloneCall` leaves)
+/// are policy-independent and live in [`return_alias_bits`].
+pub trait LeafPolicy {
+    /// Resolve a `Call`'s callee to its [`CallClass`].
+    fn classify_call(&self, callee: &HirExpr) -> CallClass;
+
+    /// Classify an expression that reaches the walk's fail-closed leaf (a
+    /// `BindingRef`, a `Binary`, a method call, or any unmodelled form). Coarse
+    /// returns `{OPAQUE}` unconditionally (today's `_ => true`); Precise applies
+    /// the delta leaf rules.
+    fn leaf_bits(&self, expr: &HirExpr) -> AliasBits;
+}
+
+/// The single structural walk. Structural arms are identical for every policy;
+/// the `Call` and fail-closed-leaf decisions are delegated to `policy`.
+///
+/// A `None` sub-position (a tail-less block, an else-less `if`, a value-less
+/// `return`, an empty `match`) contributes `{OPAQUE}` — fail-closed, exactly
+/// reproducing the pre-refactor boolean walk's `is_none_or(..)`/`arms.is_empty()`
+/// semantics.
+pub fn return_alias_bits<P: LeafPolicy>(expr: &HirExpr, policy: &P) -> AliasBits {
+    match &expr.kind {
+        // Value-passthrough wrappers: the value flows from the tail / both
+        // branches / every arm — aliases iff ANY reachable value aliases.
+        HirExprKind::Block(block) => match &block.tail {
+            None => AliasBits::OPAQUE,
+            Some(tail) => return_alias_bits(tail, policy),
+        },
+        HirExprKind::If {
+            then_expr,
+            else_expr,
+            ..
+        } => {
+            let mut bits = return_alias_bits(then_expr, policy);
+            bits |= match else_expr.as_deref() {
+                None => AliasBits::OPAQUE,
+                Some(e) => return_alias_bits(e, policy),
+            };
+            bits
+        }
+        HirExprKind::Match { arms, .. } => {
+            if arms.is_empty() {
+                AliasBits::OPAQUE
+            } else {
+                arms.iter().fold(AliasBits::EMPTY, |acc, arm| {
+                    acc | return_alias_bits(&arm.body, policy)
+                })
+            }
+        }
+        HirExprKind::Return { value } => match value.as_deref() {
+            None => AliasBits::OPAQUE,
+            Some(v) => return_alias_bits(v, policy),
+        },
+        // Fresh leaves — never a caller-owned alias. A `.clone()` is a deep copy;
+        // a `Vec<T>` element load / slice is an independent heap element; a
+        // literal owns nothing borrowed.
+        HirExprKind::RecordCloneCall { .. }
+        | HirExprKind::Index { .. }
+        | HirExprKind::Slice { .. }
+        | HirExprKind::Literal(_) => AliasBits::EMPTY,
+        // A construction aliases a parameter iff one of its owned operands does.
+        HirExprKind::StructInit { fields, base, .. } => {
+            let mut bits = fields.iter().fold(AliasBits::EMPTY, |acc, (_, v)| {
+                acc | return_alias_bits(v, policy)
+            });
+            if let Some(base) = base.as_deref() {
+                bits |= return_alias_bits(base, policy);
+            }
+            bits
+        }
+        HirExprKind::TupleLiteral { elements } => {
+            elements.iter().fold(AliasBits::EMPTY, |acc, e| {
+                acc | return_alias_bits(e, policy)
+            })
+        }
+        HirExprKind::MachineVariantCtor { payload, .. } => match payload {
+            None => AliasBits::EMPTY,
+            Some(fields) => fields.iter().fold(AliasBits::EMPTY, |acc, (_, v)| {
+                acc | return_alias_bits(v, policy)
+            }),
+        },
+        HirExprKind::Call { callee, args } => match policy.classify_call(callee) {
+            CallClass::Opaque => AliasBits::OPAQUE,
+            CallClass::Fresh => AliasBits::EMPTY,
+            CallClass::ParamSubst => args.iter().fold(AliasBits::EMPTY, |acc, a| {
+                acc | return_alias_bits(a, policy)
+            }),
+        },
+        // A projection aliases a parameter iff its object chain does.
+        HirExprKind::FieldAccess { object, .. } => return_alias_bits(object, policy),
+        HirExprKind::TupleIndex { tuple, .. } => return_alias_bits(tuple, policy),
+        // Every other form (a bare `BindingRef`, a `Binary`, a method call, a
+        // deref, any unmodelled shape) is not provably fresh → the policy's leaf.
+        _ => policy.leaf_bits(expr),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Coarse policy — byte-identical to the pre-refactor boolean walk
+// ---------------------------------------------------------------------------
+
+/// Reproduces today's `return_value_may_alias_borrow` leaves EXACTLY. The only
+/// bit it ever produces is `OPAQUE` (it collapses `ParamsOnly`/`Opaque`, exactly
+/// as the boolean did), so `return_alias_bits(e, &CoarsePolicy) != ∅` is
+/// bit-for-bit the old boolean. Consumed only by the pinned funcupdate/reassign
+/// gates via the [`return_value_may_alias_borrow`] wrapper.
+#[derive(Debug)]
+pub struct CoarsePolicy<'a> {
+    /// The module freshness summary — `compute_fn_returns_fresh_owner`'s output.
+    pub fresh: &'a HashMap<hew_hir::ItemId, bool>,
+}
+
+impl LeafPolicy for CoarsePolicy<'_> {
+    fn classify_call(&self, callee: &HirExpr) -> CallClass {
+        // `!callee_is_resolved_item(callee)` → OPAQUE (an indirect/closure callee
+        // can hand back a captured heap param through a hidden argument).
+        let HirExprKind::BindingRef {
+            resolved: ResolvedRef::Item(item_id),
+            ..
+        } = &callee.kind
+        else {
+            return CallClass::Opaque;
+        };
+        // A resolved item: `Some(f)` reads the analyzed body's verdict; `None`
+        // (an extern/runtime primitive/constructor) is fresh by the owned-return
+        // ABI — exactly today's `unwrap_or(true)`.
+        if self.fresh.get(item_id).copied().unwrap_or(true) {
+            CallClass::Fresh
+        } else {
+            CallClass::ParamSubst
+        }
+    }
+
+    fn leaf_bits(&self, _expr: &HirExpr) -> AliasBits {
+        // Today's `_ => true` — every unmodelled form fails closed.
+        AliasBits::OPAQUE
+    }
+}
+
+/// The byte-identical Coarse wrapper. `return_value_may_alias_borrow` in
+/// `lower.rs` delegates here so the funcupdate/reassign gates keep the exact
+/// pre-refactor verdict while the one leaf walk is shared with the Precise
+/// driver.
+#[must_use]
+#[allow(
+    clippy::implicit_hasher,
+    reason = "only ever called with the pipeline's default-hasher freshness summary map (compute_fn_returns_fresh_owner's output); a generic hasher param buys nothing"
+)]
+pub fn coarse_may_alias_borrow(expr: &HirExpr, fresh: &HashMap<hew_hir::ItemId, bool>) -> bool {
+    !return_alias_bits(expr, &CoarsePolicy { fresh }).is_fresh()
+}
+
+// ---------------------------------------------------------------------------
+// Type short-circuit — the scalar non-heap leaf (needs no layout registry)
+// ---------------------------------------------------------------------------
+
+/// True for a resolved type that is a scalar (or `unit`/`never`) leaf — a value
+/// that provably owns no heap and therefore cannot alias any heap parameter.
+///
+/// Conservative on purpose: it fires ONLY for the primitive-scalar leaves the
+/// type short-circuit needs without a layout registry (`semver`'s `maj/min/pat`
+/// are `i64`). A composite whose fields are all scalar is NOT short-circuited
+/// here — that needs the `ty_owns_heap` layout authority, threaded in at the
+/// wiring site (S2); leaving it to the structural aggregate recursion is sound
+/// (less precise, never unsound).
+#[must_use]
+pub fn ty_is_scalar_non_heap(ty: &ResolvedTy) -> bool {
+    matches!(
+        ty,
+        ResolvedTy::I8
+            | ResolvedTy::I16
+            | ResolvedTy::I32
+            | ResolvedTy::I64
+            | ResolvedTy::U8
+            | ResolvedTy::U16
+            | ResolvedTy::U32
+            | ResolvedTy::U64
+            | ResolvedTy::Isize
+            | ResolvedTy::Usize
+            | ResolvedTy::F32
+            | ResolvedTy::F64
+            | ResolvedTy::Bool
+            | ResolvedTy::Char
+            | ResolvedTy::Duration
+            | ResolvedTy::Unit
+            | ResolvedTy::Never
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Placeholder seams filled in by later S1 layers (kept here so the module's
+// public surface is stable across the layered commits).
+// ---------------------------------------------------------------------------
+
+/// The set of `ItemId`s currently proven `false` (not fresh) under a coarse
+/// bool table. Small helper used by tests and the differential harness to build
+/// the same `origin_fns` map the live pipeline builds.
+#[must_use]
+pub fn origin_fns_of(module: &hew_hir::HirModule) -> HashMap<hew_hir::ItemId, &HirFn> {
+    let mut origin_fns: HashMap<hew_hir::ItemId, &HirFn> = HashMap::new();
+    for item in &module.items {
+        if let hew_hir::HirItem::Function(f) = item {
+            origin_fns.insert(f.id, f);
+        }
+    }
+    origin_fns
+}
+
+/// A [`hew_mir::model::HeapOwnershipLayouts`]-shaped adapter that reports NO
+/// record/enum layouts. Under it, `ty_owns_heap` still classifies the scalar and
+/// collection-handle leaves correctly (they need no layout), and a composite of
+/// unknown layout conservatively reads as non-heap — so this adapter is for
+/// UNIT TESTS of the scalar/collection leaves only, never the wiring site (which
+/// supplies the Builder's real registries).
+#[derive(Debug)]
+pub struct EmptyLayouts;
+
+impl crate::model::HeapOwnershipLayouts for EmptyLayouts {
+    fn record_field_tys(&self, _name: &str, _args: &[ResolvedTy]) -> Option<Vec<ResolvedTy>> {
+        None
+    }
+
+    fn enum_variant_field_tys(
+        &self,
+        _name: &str,
+        _args: &[ResolvedTy],
+    ) -> Option<Vec<Vec<ResolvedTy>>> {
+        None
+    }
+}
+
+#[cfg(test)]
+#[path = "return_provenance_ref.rs"]
+mod frozen_reference;
+
+#[cfg(test)]
+mod tests {
+    use super::frozen_reference::compute_fn_returns_fresh_owner_ref;
+    use super::*;
+    use crate::lower::compute_fn_returns_fresh_owner;
+
+    /// Front-end-lower a `.hew` source string to a `HirModule`.
+    fn lower_source(source: &str) -> hew_hir::HirModule {
+        let parsed = hew_parser::parse(source);
+        assert!(
+            parsed.errors.is_empty(),
+            "parse errors: {:#?}",
+            parsed.errors
+        );
+        let mut checker =
+            hew_types::Checker::new(hew_types::module_registry::ModuleRegistry::new(vec![]));
+        let tc_output = checker.check_program(&parsed.program);
+        let output = hew_hir::lower_program(
+            &parsed.program,
+            &tc_output,
+            &hew_hir::ResolutionCtx,
+            hew_hir::TargetArch::host(),
+        );
+        output.module
+    }
+
+    /// The F5 interface pin (inline half): for every function in `source`, the
+    /// LIVE coarse fixpoint (now routed through the shared `return_alias_bits`
+    /// walk under `CoarsePolicy`) must produce the byte-identical `(ItemId, bool)`
+    /// verdict the FROZEN pre-refactor transfer produces. Any divergence is a
+    /// silent-UAF-regression signal in the funcupdate/reassign consumers.
+    fn assert_coarse_byte_identical(source: &str) {
+        let module = lower_source(source);
+        let origin_fns = origin_fns_of(&module);
+        let live = compute_fn_returns_fresh_owner(&origin_fns);
+        let frozen = compute_fn_returns_fresh_owner_ref(&origin_fns);
+        assert_eq!(
+            live, frozen,
+            "coarse verdict drift between shared walk and frozen reference:\nsource:\n{source}"
+        );
+    }
+
+    #[test]
+    fn coarse_differential_fresh_producers() {
+        assert_coarse_byte_identical(
+            r#"
+            fn make() -> string { "hello" }
+            fn concat(a: string) -> string { a + "!" }
+            fn wrap() -> string { make() }
+            "#,
+        );
+    }
+
+    #[test]
+    fn coarse_differential_forwarder_and_projection() {
+        assert_coarse_byte_identical(
+            r"
+            record Box { data: string }
+            fn passthru(x: string) -> string { x }
+            fn project(b: Box) -> string { b.data }
+            fn ctor(s: string) -> Box { Box { data: s } }
+            ",
+        );
+    }
+
+    #[test]
+    fn coarse_differential_control_flow_and_match() {
+        assert_coarse_byte_identical(
+            r"
+            fn choose(flag: bool, a: string, b: string) -> string {
+                if flag { a } else { b }
+            }
+            fn viamatch(r: Result<string, string>) -> string {
+                match r { Ok(v) => v, Err(e) => e }
+            }
+            fn nested(a: string) -> string {
+                let x = a;
+                x
+            }
+            ",
+        );
+    }
+
+    #[test]
+    fn coarse_differential_recursive_scc() {
+        assert_coarse_byte_identical(
+            r"
+            fn a(flag: bool, x: string) -> string { if flag { x } else { b(x) } }
+            fn b(x: string) -> string { a(true, x) }
+            ",
+        );
+    }
+
+    #[test]
+    fn alias_bits_lattice_states_are_distinct() {
+        assert!(AliasBits::EMPTY.is_fresh());
+        assert!(!AliasBits::EMPTY.is_params_only());
+        assert!(!AliasBits::EMPTY.is_opaque());
+
+        assert!(!AliasBits::PARAM.is_fresh());
+        assert!(AliasBits::PARAM.is_params_only());
+        assert!(!AliasBits::PARAM.is_opaque());
+
+        assert!(!AliasBits::OPAQUE.is_fresh());
+        assert!(!AliasBits::OPAQUE.is_params_only());
+        assert!(AliasBits::OPAQUE.is_opaque());
+    }
+
+    #[test]
+    fn union_of_param_and_opaque_is_not_params_only() {
+        let both = AliasBits::PARAM | AliasBits::OPAQUE;
+        assert!(!both.is_fresh());
+        assert!(
+            !both.is_params_only(),
+            "PARAM|OPAQUE must not license the arg-scan"
+        );
+        assert!(both.is_opaque());
+    }
+
+    #[test]
+    fn union_is_monotone_and_idempotent() {
+        let mut bits = AliasBits::EMPTY;
+        bits |= AliasBits::PARAM;
+        assert!(bits.is_params_only());
+        bits |= AliasBits::PARAM;
+        assert!(bits.is_params_only(), "union is idempotent");
+        bits |= AliasBits::OPAQUE;
+        assert!(bits.is_opaque());
+    }
+
+    #[test]
+    fn scalar_types_short_circuit_but_heap_types_do_not() {
+        assert!(ty_is_scalar_non_heap(&ResolvedTy::I64));
+        assert!(ty_is_scalar_non_heap(&ResolvedTy::Bool));
+        assert!(ty_is_scalar_non_heap(&ResolvedTy::Duration));
+        assert!(ty_is_scalar_non_heap(&ResolvedTy::Unit));
+        assert!(!ty_is_scalar_non_heap(&ResolvedTy::String));
+        assert!(!ty_is_scalar_non_heap(&ResolvedTy::Bytes));
+        assert!(!ty_is_scalar_non_heap(&ResolvedTy::CancellationToken));
+    }
+}

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -466,6 +466,70 @@ pub fn build_extern_contract_table(module: &hew_hir::HirModule) -> ExternContrac
 }
 
 // ---------------------------------------------------------------------------
+// Module-global preflight context — built once, threaded into every builder
+// ---------------------------------------------------------------------------
+
+/// The module-global call-scrutinee return-provenance context the #2648 preflight
+/// admission classifier consults at every scrutinee consumer.
+///
+/// Built ONCE per module (beside the coarse `compute_fn_returns_fresh_owner`
+/// summary): the precise three-state provenance summary over every module fn, the
+/// set of declared extern `ItemId`s, and the audited owned-return extern table.
+///
+/// `Default` (empty) fails SAFE: an empty summary classifies every module-fn
+/// callee as an unknown item → interim `LegacyModuleCall` (today's fail-open
+/// mint), never a wrongly-Fresh admit and never a spurious reject. The live
+/// pipeline always threads the fully-built context; the empty default only backs
+/// `Builder::default()` in unit tests that do not exercise a forwarder scrutinee.
+#[derive(Debug, Default, Clone)]
+pub struct CallScrutineeProvenance {
+    /// Per-module-fn `ItemId` → precise three-state return provenance.
+    pub provenance: HashMap<hew_hir::ItemId, ReturnProvenance>,
+    /// Every declared `extern "C"` fn NAME. A call to an extern dispatches by
+    /// name (its call-site `ResolvedRef::Item` carries a placeholder id, NOT the
+    /// declaration's `ItemId`), so extern detection at the preflight keys on the
+    /// name. A user extern whose name spoofs a runtime symbol is therefore caught
+    /// here (heap-extern reject) BEFORE the name-based runtime-symbol carve-out;
+    /// module-fn names are disjoint from extern names, so this cannot shadow a
+    /// module fn.
+    pub extern_names: HashSet<String>,
+    /// The audited owned-return extern contract table (interim: scalar → Fresh,
+    /// every heap extern → `{OPAQUE}`). Consumed by the precise fixpoint.
+    pub extern_table: ExternContractTable,
+}
+
+/// Build the module-global preflight context: the precise return-provenance
+/// fixpoint (via the interprocedural mutation summary), the declared-extern id
+/// set, and the audited extern contract table.
+#[must_use]
+#[allow(
+    clippy::implicit_hasher,
+    reason = "built once over the pipeline's default-hasher origin_fns map"
+)]
+pub fn build_call_scrutinee_provenance(
+    module: &hew_hir::HirModule,
+    origin_fns: &HashMap<hew_hir::ItemId, &HirFn>,
+) -> CallScrutineeProvenance {
+    let extern_table = build_extern_contract_table(module);
+    let extern_names: HashSet<String> = module
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            hew_hir::HirItem::ExternFn(ef) => Some(ef.name.clone()),
+            _ => None,
+        })
+        .collect();
+    let may_mutate = compute_may_mutate_heap_param(origin_fns);
+    let provenance =
+        compute_call_scrutinee_return_provenance(origin_fns, &extern_table, &may_mutate);
+    CallScrutineeProvenance {
+        provenance,
+        extern_names,
+        extern_table,
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Preflight carve-out detectors — pure HIR, keyed on TYPED identity [F4-new]
 // ---------------------------------------------------------------------------
 

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -423,9 +423,25 @@ pub fn method_return_provenance(emitted_symbol: &str) -> AliasBits {
 #[derive(Debug, Default, Clone)]
 pub struct ExternContractTable {
     rows: HashMap<hew_hir::ItemId, ReturnProvenance>,
+    /// Every declared `extern "C"` fn NAME. An extern CALL dispatches by name —
+    /// its call-site `ResolvedRef::Item` carries the PLACEHOLDER `ItemId(0)`,
+    /// NOT the declaration's id — so any id-keyed lookup for an extern callee
+    /// is an id COLLISION with the module-fn summary space (a real fn with the
+    /// colliding id could leak its `PARAM` bits into an extern caller's
+    /// summary, the jwt/encrypt contamination). The Precise walk therefore
+    /// checks the callee NAME here BEFORE any id lookup.
+    names: HashSet<String>,
 }
 
 impl ExternContractTable {
+    /// True when `name` is a declared `extern "C"` fn — the callee must be
+    /// classified by the extern contract (interim: `{OPAQUE}` for every
+    /// heap-or-unknown return), never by an id lookup.
+    #[must_use]
+    pub fn is_extern_name(&self, name: &str) -> bool {
+        self.names.contains(name)
+    }
+
     /// Return-provenance of a resolved extern `ItemId`. An extern absent from the
     /// table (every heap-returning extern in the interim) is `{OPAQUE}` —
     /// fail-closed.
@@ -455,14 +471,16 @@ impl ExternContractTable {
 #[must_use]
 pub fn build_extern_contract_table(module: &hew_hir::HirModule) -> ExternContractTable {
     let mut rows: HashMap<hew_hir::ItemId, ReturnProvenance> = HashMap::new();
+    let mut names: HashSet<String> = HashSet::new();
     for item in &module.items {
         if let hew_hir::HirItem::ExternFn(ef) = item {
+            names.insert(ef.name.clone());
             if ty_is_scalar_non_heap(&ef.return_ty) {
                 rows.insert(ef.id, AliasBits::EMPTY);
             }
         }
     }
-    ExternContractTable { rows }
+    ExternContractTable { rows, names }
 }
 
 // ---------------------------------------------------------------------------
@@ -496,6 +514,14 @@ pub struct CallScrutineeProvenance {
     /// The audited owned-return extern contract table (interim: scalar → Fresh,
     /// every heap extern → `{OPAQUE}`). Consumed by the precise fixpoint.
     pub extern_table: ExternContractTable,
+    /// The interprocedural may-mutate-heap-param summary [F2], retained so the
+    /// per-function local binding-provenance (the S2b caller arg-scan's
+    /// fresh-local resolver) can be recomputed at the lowering seam under the
+    /// SAME mutation taint the module fixpoint used. Empty default fails
+    /// closed via `callee_is_proven_pure_item`'s `unwrap_or(false)` — but the
+    /// arg-scan's fresh-local admit additionally requires an entry in the
+    /// freshness map, so an empty context never widens an admit.
+    pub may_mutate: HashMap<hew_hir::ItemId, bool>,
 }
 
 /// Build the module-global preflight context: the precise return-provenance
@@ -526,6 +552,7 @@ pub fn build_call_scrutinee_provenance(
         provenance,
         extern_names,
         extern_table,
+        may_mutate,
     }
 }
 
@@ -1139,6 +1166,12 @@ struct LocalDefs<'f> {
     /// bindings tainted `{OPAQUE}` by a mutation channel (their whole alias class
     /// is poisoned).
     tainted: HashSet<BindingId>,
+    /// bindings introduced by a PATTERN (match arm / if-let / while-let /
+    /// let-else destructure). A pattern binder aliases a payload slot of its
+    /// scrutinee — a value another owner (a minted scrutinee owner, an
+    /// `OwnedBinding` move) may also release — so the S2b arg-scan never
+    /// treats one as an independently-owned fresh value.
+    pattern_binders: HashSet<BindingId>,
 }
 
 /// Per-function local binding-provenance with MANDATORY alias closure [F2].
@@ -1159,6 +1192,94 @@ pub fn compute_local_binding_provenance(
     extern_table: &ExternContractTable,
     may_mutate: &HashMap<hew_hir::ItemId, bool>,
 ) -> HashMap<BindingId, AliasBits> {
+    local_binding_provenance_impl(f, provenance, extern_table, may_mutate).0
+}
+
+/// The CURRENT function's local-binding freshness facts for the S2b caller
+/// arg-scan — the S1 binding-provenance bits PLUS the shape facts the
+/// fresh-local admit requires (`local_is_provably_fresh`).
+///
+/// The empty `Default` fails closed: a binding absent from `bits` is never
+/// provably fresh, so a `Builder` that never computed the facts (a synthetic
+/// machine-step / test builder) admits no local argument.
+#[derive(Debug, Default, Clone)]
+pub struct LocalBindingFreshness {
+    /// S1 local binding-provenance bits (alias-closed, mutation-tainted).
+    pub bits: HashMap<BindingId, AliasBits>,
+    /// Bindings participating in ANY whole-value alias edge (`let y = x`).
+    /// An aliased binding has a second in-scope release authority over the
+    /// same value, so it is never admitted as a fresh argument.
+    pub aliased: HashSet<BindingId>,
+    /// Bindings introduced by a match/if-let/while-let/let-else pattern.
+    pub pattern_binders: HashSet<BindingId>,
+    /// TOTAL `BindingRef` occurrence count per binding across the whole body
+    /// (initializer positions do not count; every read does, including match
+    /// guards and closure/generator capture ledgers).
+    pub ref_counts: HashMap<BindingId, u32>,
+    /// True when the body contains a non-scalar expression form the counter
+    /// does not model — the count may be an undercount, so NO local is
+    /// admitted (fail-closed, mirroring `Reachable::unknown`).
+    pub saw_unknown_form: bool,
+}
+
+impl LocalBindingFreshness {
+    /// True when `id` is provably a solely-owned FRESH local at the call
+    /// site: its S1 bits are `∅` (no `PARAM`, no `OPAQUE`, no mutation
+    /// taint), it is a plain `let`/`var` local (not a pattern binder), it is
+    /// not whole-value aliased, and this argument position is its ONLY read
+    /// in the whole body — so the minted scrutinee owner is the single
+    /// release authority over the value it carries (the exactly-once
+    /// invariant; a second read would re-derive the buffer after the owner
+    /// released it).
+    #[must_use]
+    pub fn local_is_provably_fresh(&self, id: BindingId) -> bool {
+        !self.saw_unknown_form
+            && self.bits.get(&id).copied().is_some_and(AliasBits::is_fresh)
+            && !self.aliased.contains(&id)
+            && !self.pattern_binders.contains(&id)
+            && self.ref_counts.get(&id).copied() == Some(1)
+    }
+}
+
+/// Compute the [`LocalBindingFreshness`] facts for one function — the S2b
+/// arg-scan seam, run once per lowered function beside the funcupdate base
+/// provenance. Uses the SAME module tables the S1 fixpoint used so the local
+/// bits agree with the module summary.
+#[must_use]
+#[allow(
+    clippy::implicit_hasher,
+    reason = "consumed with the pipeline's default-hasher summary maps"
+)]
+pub fn compute_local_binding_freshness(
+    f: &HirFn,
+    provenance: &HashMap<hew_hir::ItemId, AliasBits>,
+    extern_table: &ExternContractTable,
+    may_mutate: &HashMap<hew_hir::ItemId, bool>,
+) -> LocalBindingFreshness {
+    let (bits, aliased, pattern_binders) =
+        local_binding_provenance_impl(f, provenance, extern_table, may_mutate);
+    let mut ref_counts: HashMap<BindingId, u32> = HashMap::new();
+    let mut saw_unknown_form = false;
+    count_binding_refs_in_block(&f.body, &mut ref_counts, &mut saw_unknown_form);
+    LocalBindingFreshness {
+        bits,
+        aliased,
+        pattern_binders,
+        ref_counts,
+        saw_unknown_form,
+    }
+}
+
+fn local_binding_provenance_impl(
+    f: &HirFn,
+    provenance: &HashMap<hew_hir::ItemId, AliasBits>,
+    extern_table: &ExternContractTable,
+    may_mutate: &HashMap<hew_hir::ItemId, bool>,
+) -> (
+    HashMap<BindingId, AliasBits>,
+    HashSet<BindingId>,
+    HashSet<BindingId>,
+) {
     let mut collector = LocalDefs::default();
     for p in &f.params {
         collector.params.insert(p.id, !ty_is_scalar_non_heap(&p.ty));
@@ -1239,7 +1360,208 @@ pub fn compute_local_binding_provenance(
             break;
         }
     }
-    bits
+    let aliased: HashSet<BindingId> = collector
+        .alias_edges
+        .iter()
+        .flat_map(|&(a, b)| [a, b])
+        .collect();
+    (bits, aliased, collector.pattern_binders)
+}
+
+/// TOTAL `BindingRef` occurrence counter over one function body — the S2b
+/// single-read fact. Mirrors the [`reachable_bindings`] surface (aggregates,
+/// projections, wrappers with ALL block statements, calls/methods, capture
+/// ledgers) plus `Scope` bodies and match-arm guards; any non-scalar form it
+/// does not model sets `unknown` so the caller fails closed (an undercount
+/// must never manufacture a "single use").
+#[allow(
+    clippy::match_same_arms,
+    clippy::too_many_lines,
+    reason = "the counter mirrors the sealed HirExprKind surface; structurally-similar arms stay separate for auditability"
+)]
+fn count_binding_refs(expr: &HirExpr, counts: &mut HashMap<BindingId, u32>, unknown: &mut bool) {
+    match &expr.kind {
+        HirExprKind::BindingRef {
+            resolved: ResolvedRef::Binding(id),
+            ..
+        } => {
+            *counts.entry(*id).or_insert(0) += 1;
+        }
+        HirExprKind::BindingRef { .. } => {}
+        HirExprKind::StructInit { fields, base, .. } => {
+            for (_, v) in fields {
+                count_binding_refs(v, counts, unknown);
+            }
+            if let Some(base) = base.as_deref() {
+                count_binding_refs(base, counts, unknown);
+            }
+        }
+        HirExprKind::TupleLiteral { elements } => {
+            for e in elements {
+                count_binding_refs(e, counts, unknown);
+            }
+        }
+        HirExprKind::MachineVariantCtor { payload, .. } => {
+            if let Some(fields) = payload {
+                for (_, v) in fields {
+                    count_binding_refs(v, counts, unknown);
+                }
+            }
+        }
+        HirExprKind::FieldAccess { object, .. } => count_binding_refs(object, counts, unknown),
+        HirExprKind::TupleIndex { tuple, .. } => count_binding_refs(tuple, counts, unknown),
+        HirExprKind::Index { container, index } => {
+            count_binding_refs(container, counts, unknown);
+            count_binding_refs(index, counts, unknown);
+        }
+        HirExprKind::Slice { container, .. } => count_binding_refs(container, counts, unknown),
+        HirExprKind::NumericCast { value, .. }
+        | HirExprKind::SaturatingWidthCast { value, .. }
+        | HirExprKind::TryWidthCast { value, .. }
+        | HirExprKind::CoerceToDynTrait { value, .. } => {
+            count_binding_refs(value, counts, unknown);
+        }
+        HirExprKind::Block(block) => count_binding_refs_in_block(block, counts, unknown),
+        HirExprKind::Scope { body } => count_binding_refs_in_block(body, counts, unknown),
+        HirExprKind::If {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            count_binding_refs(condition, counts, unknown);
+            count_binding_refs(then_expr, counts, unknown);
+            if let Some(e) = else_expr.as_deref() {
+                count_binding_refs(e, counts, unknown);
+            }
+        }
+        HirExprKind::Match {
+            scrutinee, arms, ..
+        } => {
+            count_binding_refs(scrutinee, counts, unknown);
+            for arm in arms {
+                if let Some(guard) = &arm.guard {
+                    count_binding_refs(guard, counts, unknown);
+                }
+                count_binding_refs(&arm.body, counts, unknown);
+            }
+        }
+        HirExprKind::IfLet {
+            scrutinee,
+            body,
+            else_body,
+            ..
+        } => {
+            count_binding_refs(scrutinee, counts, unknown);
+            count_binding_refs_in_block(body, counts, unknown);
+            if let Some(else_body) = else_body {
+                count_binding_refs_in_block(else_body, counts, unknown);
+            }
+        }
+        HirExprKind::WhileLet {
+            scrutinee, body, ..
+        } => {
+            count_binding_refs(scrutinee, counts, unknown);
+            count_binding_refs_in_block(body, counts, unknown);
+        }
+        HirExprKind::Call { callee, args } | HirExprKind::SpawnedCall { callee, args, .. } => {
+            count_binding_refs(callee, counts, unknown);
+            for a in args {
+                count_binding_refs(a, counts, unknown);
+            }
+        }
+        HirExprKind::CallDynMethod { receiver, args, .. }
+        | HirExprKind::ResolvedImplCall { receiver, args, .. }
+        | HirExprKind::CallTraitMethodStatic { receiver, args, .. }
+        | HirExprKind::VarSelfMethodCall { receiver, args, .. } => {
+            count_binding_refs(receiver, counts, unknown);
+            for a in args {
+                count_binding_refs(a, counts, unknown);
+            }
+        }
+        HirExprKind::NumericMethod { receiver, arg, .. } => {
+            count_binding_refs(receiver, counts, unknown);
+            count_binding_refs(arg, counts, unknown);
+        }
+        HirExprKind::Binary { left, right, .. } | HirExprKind::IdentityCompare { left, right } => {
+            count_binding_refs(left, counts, unknown);
+            count_binding_refs(right, counts, unknown);
+        }
+        HirExprKind::Unary { operand, .. } => count_binding_refs(operand, counts, unknown),
+        HirExprKind::Return { value } => {
+            if let Some(v) = value.as_deref() {
+                count_binding_refs(v, counts, unknown);
+            }
+        }
+        // A capture is a read that survives into the callable — count it so a
+        // captured local can never look single-use at an argument position.
+        HirExprKind::Closure { captures, .. } => {
+            for cap in captures {
+                *counts.entry(cap.binding).or_insert(0) += 1;
+            }
+        }
+        HirExprKind::GenBlock { captures, .. } => {
+            for cap in captures {
+                *counts.entry(cap.binding).or_insert(0) += 1;
+            }
+        }
+        HirExprKind::Literal(_)
+        | HirExprKind::RegexLiteralRef { .. }
+        | HirExprKind::RecordCloneCall { .. }
+        | HirExprKind::ActorSelf
+        | HirExprKind::ContextReader { .. } => {}
+        // Any other form: fail closed if it could carry heap (an unmodelled
+        // read would undercount).
+        other => {
+            let _ = other;
+            if !ty_is_scalar_non_heap(&expr.ty) {
+                *unknown = true;
+            }
+        }
+    }
+}
+
+/// Block-level counting: every statement form and the tail (mirrors
+/// [`reachable_bindings_in_block`]).
+#[allow(
+    clippy::match_same_arms,
+    reason = "statement arms mirror the sealed HirStmtKind surface exhaustively"
+)]
+fn count_binding_refs_in_block(
+    block: &HirBlock,
+    counts: &mut HashMap<BindingId, u32>,
+    unknown: &mut bool,
+) {
+    for stmt in &block.statements {
+        match &stmt.kind {
+            hew_hir::HirStmtKind::Let(_, Some(init)) => count_binding_refs(init, counts, unknown),
+            hew_hir::HirStmtKind::Let(_, None) => {}
+            hew_hir::HirStmtKind::Assign { target, value } => {
+                count_binding_refs(target, counts, unknown);
+                count_binding_refs(value, counts, unknown);
+            }
+            hew_hir::HirStmtKind::Expr(e) => count_binding_refs(e, counts, unknown),
+            hew_hir::HirStmtKind::Return(Some(e)) => count_binding_refs(e, counts, unknown),
+            hew_hir::HirStmtKind::Return(None) => {}
+            hew_hir::HirStmtKind::Defer { body, .. } => count_binding_refs(body, counts, unknown),
+            hew_hir::HirStmtKind::LetElse {
+                scrutinee,
+                success_prelude,
+                else_body,
+                ..
+            } => {
+                count_binding_refs(scrutinee, counts, unknown);
+                for s in success_prelude {
+                    if let hew_hir::HirStmtKind::Let(_, Some(v)) = &s.kind {
+                        count_binding_refs(v, counts, unknown);
+                    }
+                }
+                count_binding_refs_in_block(else_body, counts, unknown);
+            }
+        }
+    }
+    if let Some(tail) = &block.tail {
+        count_binding_refs(tail, counts, unknown);
+    }
 }
 
 /// A minimal union-find over `BindingId`s for the alias closure.
@@ -1338,6 +1660,7 @@ impl<'f> DefCollector<'_, 'f> {
                     ..
                 } => {
                     for b in bindings {
+                        self.defs.pattern_binders.insert(b.binding);
                         self.defs
                             .defs
                             .entry(b.binding)
@@ -1377,7 +1700,23 @@ impl<'f> DefCollector<'_, 'f> {
                 scrutinee, arms, ..
             } => {
                 for arm in arms {
+                    // A catch-all binding arm (`err => …`) carries its binder in
+                    // the PREDICATE, not `arm.bindings` — missing it left the
+                    // binder out of the local map, whose fail-closed leaf reads
+                    // an absent local as `{PARAM}` (the jwt/encrypt `err =>
+                    // Err(err)` PARAM contamination).
+                    if let hew_hir::HirMatchArmPredicate::Binding { binding_id, .. } =
+                        &arm.predicate
+                    {
+                        self.defs.pattern_binders.insert(*binding_id);
+                        self.defs
+                            .defs
+                            .entry(*binding_id)
+                            .or_default()
+                            .push(DefSource::Value(scrutinee));
+                    }
                     for b in &arm.bindings {
+                        self.defs.pattern_binders.insert(b.binding);
                         self.defs
                             .defs
                             .entry(b.binding)
@@ -1399,6 +1738,7 @@ impl<'f> DefCollector<'_, 'f> {
                 ..
             } => {
                 for b in bindings {
+                    self.defs.pattern_binders.insert(b.binding);
                     self.defs
                         .defs
                         .entry(b.binding)
@@ -1418,6 +1758,7 @@ impl<'f> DefCollector<'_, 'f> {
                 ..
             } => {
                 for b in bindings {
+                    self.defs.pattern_binders.insert(b.binding);
                     self.defs
                         .defs
                         .entry(b.binding)
@@ -1558,6 +1899,23 @@ fn callee_is_proven_pure_item(
 // Precise policy + the module return-provenance fixpoint [Sol-3]
 // ---------------------------------------------------------------------------
 
+/// The audited builtin collection constructors — checker-resolved static calls
+/// (`Vec::new()` / `HashMap::new()` / `HashSet::new()`) that lower to a fresh
+/// empty allocation (`hew_vec_new_*` / `hew_hashmap_new` / `hew_hashset_new`).
+///
+/// These reach HIR as a `Call` whose callee `BindingRef` carries the qualified
+/// static name and a SYNTHETIC `ItemId` (no analysable body), so they miss the
+/// module summary and would otherwise fail closed to `{OPAQUE}` — which turned
+/// every `Ctx`-style stdlib producer (`template.new_ctx()`) opaque and broke the
+/// S2b fresh-local arg-scan for its consumers. Name-keying is sound here: `::`
+/// is not a declarable module-fn or extern identifier, and a user impl method
+/// emitted under a qualified name carries a REAL `ItemId` that the module
+/// summary (consulted FIRST) resolves.
+#[must_use]
+pub fn is_builtin_fresh_ctor(name: &str) -> bool {
+    matches!(name, "Vec::new" | "HashMap::new" | "HashSet::new")
+}
+
 /// The Precise `LeafPolicy`: consumes the module provenance table (for the
 /// three-way `Call` resolution), the audited extern table, and the CURRENT
 /// function's local binding-provenance.
@@ -1587,12 +1945,23 @@ impl LeafPolicy for PrecisePolicy<'_> {
         // A non-item callee (closure value, fn-pointer param, dynamic dispatch,
         // const, builtin) can hand back a captured heap param → Opaque.
         let HirExprKind::BindingRef {
+            name,
             resolved: ResolvedRef::Item(id),
-            ..
         } = &callee.kind
         else {
             return CallClass::Opaque;
         };
+        // Clause 0: an extern call dispatches by NAME — its call-site id is the
+        // PLACEHOLDER `ItemId(0)`, so an id lookup would collide with a real
+        // module fn's summary (leaking that fn's `PARAM` bits into the extern
+        // caller — the jwt/encrypt false-reject contamination). No
+        // heap-returning extern is trusted in the interim → `{OPAQUE}`; a
+        // scalar-returning extern also lands here (sound: over-approximation
+        // only widens toward Opaque, and its consumers' scalar results are
+        // short-circuited by type at the leaves).
+        if self.extern_table.is_extern_name(name) {
+            return CallClass::Opaque;
+        }
         // Clause 1: a resolved module fn → its summary (with arg substitution).
         if let Some(bits) = self.provenance.get(id) {
             if bits.is_fresh() {
@@ -1602,11 +1971,13 @@ impl LeafPolicy for PrecisePolicy<'_> {
             } else {
                 CallClass::Opaque
             }
-        // Clauses 2+3: an extern (scalar row → Fresh; heap/omitted → Opaque) or an
-        // unknown/missing item (absent from the table → Opaque). Never
-        // `unwrap_or(true)`.
-        } else if self.extern_table.provenance_of(*id).is_fresh() {
+        // Clause 2: an extern (scalar row → Fresh; heap/omitted → Opaque), or
+        // Clause 3: an audited builtin collection constructor (`Vec::new()`
+        // inside `new_ctx()`-style producers) — a fresh empty allocation.
+        } else if self.extern_table.provenance_of(*id).is_fresh() || is_builtin_fresh_ctor(name) {
             CallClass::Fresh
+        // Clause 4: an unknown/missing item (absent from every table → Opaque).
+        // Never `unwrap_or(true)`.
         } else {
             CallClass::Opaque
         }

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -1096,6 +1096,42 @@ impl MutationScan<'_> {
             }
             HirExprKind::Unary { operand, .. } => self.expr_mutates(operand),
             HirExprKind::Return { value } => value.as_deref().is_some_and(|v| self.expr_mutates(v)),
+            // Loop / scope bodies — a mutation inside a loop mutates on every
+            // back-edge; missing these arms silently read a loop-mutating
+            // callee as pure.
+            HirExprKind::While {
+                condition, body, ..
+            } => self.expr_mutates(condition) || self.block_mutates(body),
+            HirExprKind::ForRange {
+                start,
+                end,
+                step,
+                body,
+                ..
+            } => {
+                self.expr_mutates(start)
+                    || self.expr_mutates(end)
+                    || self.expr_mutates(step)
+                    || self.block_mutates(body)
+            }
+            HirExprKind::Loop { body, .. } => self.block_mutates(body),
+            HirExprKind::Scope { body } => self.block_mutates(body),
+            HirExprKind::Break { value, .. } => {
+                value.as_deref().is_some_and(|v| self.expr_mutates(v))
+            }
+            HirExprKind::IfLet {
+                scrutinee,
+                body,
+                else_body,
+                ..
+            } => {
+                self.expr_mutates(scrutinee)
+                    || self.block_mutates(body)
+                    || else_body.as_ref().is_some_and(|b| self.block_mutates(b))
+            }
+            HirExprKind::WhileLet {
+                scrutinee, body, ..
+            } => self.expr_mutates(scrutinee) || self.block_mutates(body),
             _ => false,
         }
     }
@@ -1476,6 +1512,49 @@ fn count_binding_refs(expr: &HirExpr, counts: &mut HashMap<BindingId, u32>, unkn
             count_binding_refs(scrutinee, counts, unknown);
             count_binding_refs_in_block(body, counts, unknown);
         }
+        // Loop bodies: every read inside a loop counts (and a loop-carried read
+        // can execute more than once per textual occurrence, so a binding read
+        // inside a loop body is counted TWICE — a loop-body arg can never
+        // qualify as single-read).
+        HirExprKind::While {
+            condition, body, ..
+        } => {
+            count_binding_refs(condition, counts, unknown);
+            let mut inner: HashMap<BindingId, u32> = HashMap::new();
+            count_binding_refs_in_block(body, &mut inner, unknown);
+            for (id, n) in inner {
+                *counts.entry(id).or_insert(0) += n.saturating_mul(2);
+            }
+        }
+        HirExprKind::ForRange {
+            start,
+            end,
+            step,
+            body,
+            ..
+        } => {
+            count_binding_refs(start, counts, unknown);
+            count_binding_refs(end, counts, unknown);
+            count_binding_refs(step, counts, unknown);
+            let mut inner: HashMap<BindingId, u32> = HashMap::new();
+            count_binding_refs_in_block(body, &mut inner, unknown);
+            for (id, n) in inner {
+                *counts.entry(id).or_insert(0) += n.saturating_mul(2);
+            }
+        }
+        HirExprKind::Loop { body, .. } => {
+            let mut inner: HashMap<BindingId, u32> = HashMap::new();
+            count_binding_refs_in_block(body, &mut inner, unknown);
+            for (id, n) in inner {
+                *counts.entry(id).or_insert(0) += n.saturating_mul(2);
+            }
+        }
+        HirExprKind::Break { value, .. } => {
+            if let Some(v) = value.as_deref() {
+                count_binding_refs(v, counts, unknown);
+            }
+        }
+        HirExprKind::Continue { .. } => {}
         HirExprKind::Call { callee, args } | HirExprKind::SpawnedCall { callee, args, .. } => {
             count_binding_refs(callee, counts, unknown);
             for a in args {
@@ -1871,10 +1950,104 @@ impl<'f> DefCollector<'_, 'f> {
                     self.collect_expr(v);
                 }
             }
-            // Leaves and unmodelled forms need no binder/taint recording here.
-            _ => {}
+            // Loop / scope bodies — a `let` or a mutating call inside a loop
+            // body defines/taints exactly like straight-line code (the union
+            // over defs is flow-insensitive already). Missing these arms left
+            // every loop-body local OUT of the map, and the fail-closed local
+            // leaf then read each one as `{PARAM}` — the injection that poisoned
+            // the whole template render SCC to ParamsOnly.
+            HirExprKind::While {
+                condition, body, ..
+            } => {
+                self.collect_expr(condition);
+                self.collect_block(body);
+            }
+            HirExprKind::ForRange {
+                binding,
+                start,
+                end,
+                step,
+                body,
+                ..
+            } => {
+                // The loop counter is a compiler-stepped integer — register it
+                // so its `BindingRef`s resolve (∅ via the scalar short-circuit).
+                self.defs.defs.entry(binding.id).or_default();
+                self.collect_expr(start);
+                self.collect_expr(end);
+                self.collect_expr(step);
+                self.collect_block(body);
+            }
+            HirExprKind::Loop { body, .. } => self.collect_block(body),
+            HirExprKind::Scope { body } => self.collect_block(body),
+            HirExprKind::Break { value, .. } => {
+                if let Some(v) = value.as_deref() {
+                    self.collect_expr(v);
+                }
+            }
+            // A deep clone borrows its source non-mutatingly; descend for
+            // nested defs but do NOT taint the source.
+            HirExprKind::RecordCloneCall { src, .. } => self.collect_expr(src),
+            // Enum/machine variant construction embeds its operands by value —
+            // recurse them (the value-flow walk models the embedding); no taint.
+            HirExprKind::MachineVariantCtor { payload, .. } => {
+                if let Some(fields) = payload {
+                    for (_, v) in fields {
+                        self.collect_expr(v);
+                    }
+                }
+            }
+            // Pointer-identity comparison reads its operands without mutating
+            // or escaping them.
+            HirExprKind::IdentityCompare { left, right } => {
+                self.collect_expr(left);
+                self.collect_expr(right);
+            }
+            // Value-passthrough casts.
+            HirExprKind::NumericCast { value, .. }
+            | HirExprKind::SaturatingWidthCast { value, .. }
+            | HirExprKind::TryWidthCast { value, .. }
+            | HirExprKind::CoerceToDynTrait { value, .. } => self.collect_expr(value),
+            HirExprKind::Slice { container, .. } => self.collect_expr(container),
+            // Benign leaves: no binder, no taint, no sub-expression.
+            HirExprKind::Literal(_)
+            | HirExprKind::RegexLiteralRef { .. }
+            | HirExprKind::BindingRef { .. }
+            | HirExprKind::ActorSelf
+            | HirExprKind::ContextReader { .. }
+            | HirExprKind::Continue { .. } => {}
+            // Any OTHER form is unmodelled here: it may hide a mutation or an
+            // escape of a tracked binding (an actor send, a spawn capture, an
+            // await), so every binding reachable from it is tainted fail-closed
+            // rather than silently skipped.
+            other => {
+                let _ = other;
+                if !ty_is_scalar_non_heap(&expr.ty) || expr_has_substructure(expr) {
+                    let mut r = Reachable::default();
+                    reachable_bindings(expr, &mut r);
+                    for b in r.bindings {
+                        self.defs.tainted.insert(b);
+                    }
+                }
+            }
         }
     }
+}
+
+/// True when an expression form carries sub-expressions the def collector does
+/// not model — used to route scalar-RESULT composites (an await returning i64,
+/// an actor ask) through the fail-closed taint rather than skipping the
+/// bindings their operands may escape.
+fn expr_has_substructure(expr: &HirExpr) -> bool {
+    !matches!(
+        expr.kind,
+        HirExprKind::Literal(_)
+            | HirExprKind::RegexLiteralRef { .. }
+            | HirExprKind::BindingRef { .. }
+            | HirExprKind::ActorSelf
+            | HirExprKind::ContextReader { .. }
+            | HirExprKind::Continue { .. }
+    )
 }
 
 /// The local binding id a value expression refers to directly (a bare

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -1777,6 +1777,57 @@ mod tests {
         );
     }
 
+    #[test]
+    fn coarse_differential_aggregate_and_method_shapes() {
+        assert_coarse_byte_identical(
+            r"
+            record Box { data: string }
+            fn embed(p: string) -> Box { Box { data: p } }
+            fn tuple_embed(p: string) -> (string, i64) { (p, 0) }
+            fn via_method(v: Vec<i64>) -> i64 { v.len() }
+            ",
+        );
+    }
+
+    /// The four mandated Coarse negative pins [Sol-5 + F5]: the Coarse authority
+    /// (which the funcupdate/reassign gates consume) MUST still fail closed — a
+    /// forwarder, an aggregate embedding a param, and a mutation channel are all
+    /// NOT proven fresh. If any silently flipped to fresh, the shared UAF gates
+    /// would regress.
+    #[test]
+    fn coarse_still_fails_closed_on_the_unsafe_shapes() {
+        let module = lower_source(
+            r"
+            record Box { data: Vec<i64> }
+            fn recursive_forwarder(flag: bool, x: Vec<i64>) -> Vec<i64> {
+                if flag { x } else { recursive_forwarder(true, x) }
+            }
+            fn aggregate_embeds_param(p: Vec<i64>) -> Box { Box { data: p } }
+            fn mutation_channel(x: Vec<i64>, v: i64) -> Vec<i64> {
+                let y = x;
+                y.push(v);
+                x
+            }
+            ",
+        );
+        let origin_fns = origin_fns_of(&module);
+        let coarse = compute_fn_returns_fresh_owner(&origin_fns);
+        for name in [
+            "recursive_forwarder",
+            "aggregate_embeds_param",
+            "mutation_channel",
+        ] {
+            assert!(
+                !coarse[&fn_id(&module, name)],
+                "Coarse must fail closed (not-fresh) on `{name}` so the shared gates never regress"
+            );
+        }
+        // And the shared walk stays byte-identical to the frozen reference on the
+        // same unsafe shapes.
+        let frozen = compute_fn_returns_fresh_owner_ref(&origin_fns);
+        assert_eq!(coarse, frozen);
+    }
+
     // -- Method-call return contract [F1] --
 
     #[test]

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -173,6 +173,19 @@ pub trait LeafPolicy {
     /// returns `{OPAQUE}` unconditionally (today's `_ => true`); Precise applies
     /// the delta leaf rules.
     fn leaf_bits(&self, expr: &HirExpr) -> AliasBits;
+
+    /// Bits contributed by an ABSENT value position inside `enclosing` — a
+    /// tail-less block (a diverging `{ return …; }` match arm), an else-less
+    /// `if`, a value-less `return`, an empty `match`. Coarse keeps the
+    /// pre-refactor `{OPAQUE}` (byte-identical `is_none_or` semantics); Precise
+    /// applies the type short-circuit — a `Unit`/`Never`/scalar-typed enclosing
+    /// expression carries no heap value, so the absent position contributes `∅`
+    /// (a diverging arm must not poison a `ParamsOnly` summary to
+    /// `PARAM|OPAQUE`), while any heap-typed enclosing form stays fail-closed.
+    fn missing_position_bits(&self, enclosing: &HirExpr) -> AliasBits {
+        let _ = enclosing;
+        AliasBits::OPAQUE
+    }
 }
 
 /// The single structural walk. Structural arms are identical for every policy;
@@ -187,7 +200,7 @@ pub fn return_alias_bits<P: LeafPolicy>(expr: &HirExpr, policy: &P) -> AliasBits
         // Value-passthrough wrappers: the value flows from the tail / both
         // branches / every arm — aliases iff ANY reachable value aliases.
         HirExprKind::Block(block) => match &block.tail {
-            None => AliasBits::OPAQUE,
+            None => policy.missing_position_bits(expr),
             Some(tail) => return_alias_bits(tail, policy),
         },
         HirExprKind::If {
@@ -197,14 +210,14 @@ pub fn return_alias_bits<P: LeafPolicy>(expr: &HirExpr, policy: &P) -> AliasBits
         } => {
             let mut bits = return_alias_bits(then_expr, policy);
             bits |= match else_expr.as_deref() {
-                None => AliasBits::OPAQUE,
+                None => policy.missing_position_bits(expr),
                 Some(e) => return_alias_bits(e, policy),
             };
             bits
         }
         HirExprKind::Match { arms, .. } => {
             if arms.is_empty() {
-                AliasBits::OPAQUE
+                policy.missing_position_bits(expr)
             } else {
                 arms.iter().fold(AliasBits::EMPTY, |acc, arm| {
                     acc | return_alias_bits(&arm.body, policy)
@@ -212,7 +225,7 @@ pub fn return_alias_bits<P: LeafPolicy>(expr: &HirExpr, policy: &P) -> AliasBits
             }
         }
         HirExprKind::Return { value } => match value.as_deref() {
-            None => AliasBits::OPAQUE,
+            None => policy.missing_position_bits(expr),
             Some(v) => return_alias_bits(v, policy),
         },
         // Fresh leaves — never a caller-owned alias. A `.clone()` is a deep copy;
@@ -2017,6 +2030,17 @@ impl LeafPolicy for PrecisePolicy<'_> {
             _ => AliasBits::OPAQUE,
         }
     }
+
+    fn missing_position_bits(&self, enclosing: &HirExpr) -> AliasBits {
+        // A diverging `{ return …; }` arm / else-less `if` / value-less
+        // `return` in a `Unit`/`Never`/scalar position carries no heap value —
+        // it must not poison a `ParamsOnly` summary to `PARAM|OPAQUE`.
+        if ty_is_scalar_non_heap(&enclosing.ty) {
+            AliasBits::EMPTY
+        } else {
+            AliasBits::OPAQUE
+        }
+    }
 }
 
 /// The module return-provenance summary: `ItemId → ReturnProvenance`, a monotone
@@ -2611,6 +2635,37 @@ mod tests {
         assert!(
             prov[&fn_id(&m, "wrap")].is_fresh(),
             "a chain of fresh producers is Fresh"
+        );
+    }
+
+    #[test]
+    fn diverging_return_arm_does_not_poison_params_only() {
+        // A `{ return …; }` arm's body is a Unit-typed tail-less block; it
+        // carries no value, so it must contribute `∅` under the Precise
+        // policy — a param-embedding producer with a diverging arm stays
+        // `ParamsOnly` (arg-rescuable), not `PARAM|OPAQUE`
+        // (`match_diverging_arm_result_type` regression).
+        let (m, prov) = provenance_of_source(
+            r"
+            enum Status {
+                Good(string);
+                Bad;
+            }
+            fn parse(input: string, fail: bool) -> Status {
+                let result = match fail {
+                    true => {
+                        return Status::Bad;
+                    },
+                    false => Status::Good(input),
+                };
+                result
+            }
+            ",
+        );
+        assert!(
+            prov[&fn_id(&m, "parse")].is_params_only(),
+            "a diverging return-only arm contributes no bits: {:?}",
+            prov[&fn_id(&m, "parse")]
         );
     }
 

--- a/hew-mir/src/return_provenance.rs
+++ b/hew-mir/src/return_provenance.rs
@@ -2217,6 +2217,99 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // [F2/Rev-6] Interprocedural mutation reachability — the three channels the
+    // tail-only value-flow recursion misses: an alias hidden inside an aggregate
+    // argument, inside an array-literal desugar's non-tail push, and inside a
+    // closure capture ledger reached via a callable-parameter invocation. Each
+    // caller returns a heap param it smuggled through a may-mutate helper, so the
+    // return is OPAQUE and its `match caller()` scrutinee rejects at S4b. These
+    // pin the ANALYSIS verdict (the interim compile verdict is `LegacyModuleCall`
+    // fail-open; the precise reject lands at S4b).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn helper_mutates_aggregate_arg_is_opaque() {
+        // `helper(Wrapper { v: h }, ..); return h` — h is reachable through the
+        // StructInit operand of a may-mutate call argument.
+        let (m, prov) = provenance_of_source(
+            r"
+            type Wrapper { v: Vec<i64>; }
+            fn helper(w: Wrapper, x: i64) { w.v.push(x); }
+            fn caller(h: Vec<i64>, x: i64) -> Vec<i64> {
+                helper(Wrapper { v: h }, x);
+                h
+            }
+            ",
+        );
+        assert!(
+            prov[&fn_id(&m, "caller")].is_opaque(),
+            "a heap param smuggled inside an aggregate arg to a may-mutate helper is Opaque"
+        );
+    }
+
+    #[test]
+    fn helper_mutates_array_arg_is_opaque() {
+        // `helper([h], ..); return h` — h is reachable only through the array
+        // literal's non-tail push statement, which a tail-only walk misses.
+        let (m, prov) = provenance_of_source(
+            r"
+            fn helper(xs: Vec<Vec<i64>>, x: i64) { xs.push(Vec::new()); }
+            fn caller(h: Vec<i64>, x: i64) -> Vec<i64> {
+                helper([h], x);
+                h
+            }
+            ",
+        );
+        assert!(
+            prov[&fn_id(&m, "caller")].is_opaque(),
+            "a heap param inside an array-literal arg (non-tail push) to a may-mutate helper is Opaque"
+        );
+    }
+
+    #[test]
+    fn helper_invokes_capturing_closure_is_opaque() {
+        // `helper(|| { h.len(); }, ..); return h` — helper invokes its callable
+        // parameter (may-mutate, callable-param invocation), and h lives in the
+        // closure's capture ledger, invisible to an operand-only visitor.
+        let (m, prov) = provenance_of_source(
+            r"
+            fn helper(f: fn() -> i64, x: i64) -> i64 { f() }
+            fn caller(h: Vec<i64>, x: i64) -> Vec<i64> {
+                helper(|| { h.len() }, x);
+                h
+            }
+            ",
+        );
+        assert!(
+            prov[&fn_id(&m, "caller")].is_opaque(),
+            "a heap param captured by a closure arg to a callable-invoking helper is Opaque"
+        );
+    }
+
+    #[test]
+    fn generator_capture_of_heap_param_is_opaque() {
+        // The generator-capture analogue: `h` lives in a `gen { .. }` block's
+        // capture ledger (`GenBlock.captures`), passed to a may-mutate helper.
+        // The total reachability visitor must descend the generator capture
+        // ledger — an operand-only walk cannot see it.
+        let (m, prov) = provenance_of_source(
+            r"
+            fn drain<I>(g: I, sink: Vec<i64>) where I: Iterator<Item = i64> {
+                sink.push(0);
+            }
+            fn caller(h: Vec<i64>, sink: Vec<i64>) -> Vec<i64> {
+                drain(gen { yield h.len(); }, sink);
+                h
+            }
+            ",
+        );
+        assert!(
+            prov[&fn_id(&m, "caller")].is_opaque(),
+            "a heap param captured by a generator-block arg to a may-mutate helper is Opaque"
+        );
+    }
+
     #[test]
     fn alias_bits_lattice_states_are_distinct() {
         assert!(AliasBits::EMPTY.is_fresh());

--- a/hew-mir/src/return_provenance_ref.rs
+++ b/hew-mir/src/return_provenance_ref.rs
@@ -68,7 +68,7 @@ fn fn_body_returns_fresh_owner_ref(f: &HirFn, fresh: &HashMap<hew_hir::ItemId, b
 }
 
 /// Verbatim copy of the pre-refactor `return_value_may_alias_borrow` — the leaf
-/// this lane parameterizes. This is the transfer the differential pins.
+/// this module parameterizes. This is the transfer the differential pins.
 fn return_value_may_alias_borrow_ref(
     expr: &HirExpr,
     fresh: &HashMap<hew_hir::ItemId, bool>,

--- a/hew-mir/src/return_provenance_ref.rs
+++ b/hew-mir/src/return_provenance_ref.rs
@@ -1,0 +1,158 @@
+//! FROZEN REFERENCE — a verbatim, independently-executable copy of the
+//! pre-refactor call-return freshness transfer (`return_value_may_alias_borrow`
+//! and friends, captured at the base before the `return_alias_bits`
+//! parameterization).
+//!
+//! # Why a frozen copy and not a re-derivation
+//!
+//! The Coarse leaf walk is now shared with the Precise driver
+//! ([`super::return_alias_bits`] under [`super::CoarsePolicy`]). A stdlib-corpus
+//! golden plus a handful of negatives cannot establish that the shared walk is
+//! byte-identical over ALL HIR shapes / generated bodies / future inputs — and a
+//! Coarse drift is a silent UAF regression in the funcupdate (#2420 base gate)
+//! and reassign consumers. This module keeps the OLD transfer executable so the
+//! `coarse_verdict_differential` harness can compare `(ItemId, bool)` for every
+//! function in the corpus against the live path; any divergence fails.
+//!
+//! DO NOT "clean up" or refactor this file to call the new authority — that
+//! defeats the entire purpose. It is a snapshot, updated only by an explicit,
+//! reviewed baseline-refresh step.
+//!
+//! `#[cfg(test)]` only.
+
+use std::collections::HashMap;
+
+use hew_hir::{HirExpr, HirExprKind, HirFn, ResolvedRef};
+use hew_types::ResolvedTy;
+
+use crate::lower::collect_return_values_in_block;
+
+/// Verbatim copy of the pre-refactor `compute_fn_returns_fresh_owner`.
+pub fn compute_fn_returns_fresh_owner_ref(
+    fns: &HashMap<hew_hir::ItemId, &HirFn>,
+) -> HashMap<hew_hir::ItemId, bool> {
+    let mut fresh: HashMap<hew_hir::ItemId, bool> = fns.keys().map(|&id| (id, false)).collect();
+    loop {
+        let mut changed = false;
+        for (&id, &f) in fns {
+            if fresh[&id] {
+                continue;
+            }
+            if fn_body_returns_fresh_owner_ref(f, &fresh) {
+                fresh.insert(id, true);
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    fresh
+}
+
+/// Verbatim copy of the pre-refactor `fn_body_returns_fresh_owner`.
+fn fn_body_returns_fresh_owner_ref(f: &HirFn, fresh: &HashMap<hew_hir::ItemId, bool>) -> bool {
+    let mut return_values: Vec<&HirExpr> = Vec::new();
+    collect_return_values_in_block(&f.body, &mut return_values);
+    if let Some(tail) = &f.body.tail {
+        if !matches!(tail.ty, ResolvedTy::Unit | ResolvedTy::Never) {
+            return_values.push(tail);
+        }
+    }
+    if return_values.is_empty() {
+        return false;
+    }
+    return_values
+        .iter()
+        .all(|e| !return_value_may_alias_borrow_ref(e, fresh))
+}
+
+/// Verbatim copy of the pre-refactor `return_value_may_alias_borrow` — the leaf
+/// this lane parameterizes. This is the transfer the differential pins.
+fn return_value_may_alias_borrow_ref(
+    expr: &HirExpr,
+    fresh: &HashMap<hew_hir::ItemId, bool>,
+) -> bool {
+    match &expr.kind {
+        HirExprKind::Block(block) => block
+            .tail
+            .as_deref()
+            .is_none_or(|t| return_value_may_alias_borrow_ref(t, fresh)),
+        HirExprKind::If {
+            then_expr,
+            else_expr,
+            ..
+        } => {
+            return_value_may_alias_borrow_ref(then_expr, fresh)
+                || else_expr
+                    .as_deref()
+                    .is_none_or(|e| return_value_may_alias_borrow_ref(e, fresh))
+        }
+        HirExprKind::Match { arms, .. } => {
+            arms.is_empty()
+                || arms
+                    .iter()
+                    .any(|arm| return_value_may_alias_borrow_ref(&arm.body, fresh))
+        }
+        HirExprKind::Return { value } => value
+            .as_deref()
+            .is_none_or(|v| return_value_may_alias_borrow_ref(v, fresh)),
+        HirExprKind::RecordCloneCall { .. }
+        | HirExprKind::Index { .. }
+        | HirExprKind::Slice { .. }
+        | HirExprKind::Literal(_) => false,
+        HirExprKind::StructInit { fields, base, .. } => {
+            fields
+                .iter()
+                .any(|(_, v)| return_value_may_alias_borrow_ref(v, fresh))
+                || base
+                    .as_deref()
+                    .is_some_and(|b| return_value_may_alias_borrow_ref(b, fresh))
+        }
+        HirExprKind::TupleLiteral { elements } => elements
+            .iter()
+            .any(|e| return_value_may_alias_borrow_ref(e, fresh)),
+        HirExprKind::MachineVariantCtor { payload, .. } => payload.as_ref().is_some_and(|fields| {
+            fields
+                .iter()
+                .any(|(_, v)| return_value_may_alias_borrow_ref(v, fresh))
+        }),
+        HirExprKind::Call { callee, args } => {
+            !callee_is_resolved_item_ref(callee)
+                || (!callee_returns_fresh_owner_ref(callee, fresh)
+                    && args
+                        .iter()
+                        .any(|a| return_value_may_alias_borrow_ref(a, fresh)))
+        }
+        HirExprKind::FieldAccess { object, .. } => return_value_may_alias_borrow_ref(object, fresh),
+        HirExprKind::TupleIndex { tuple, .. } => return_value_may_alias_borrow_ref(tuple, fresh),
+        _ => true,
+    }
+}
+
+/// Verbatim copy of the pre-refactor `callee_returns_fresh_owner`.
+fn callee_returns_fresh_owner_ref(
+    callee: &HirExpr,
+    fresh: &HashMap<hew_hir::ItemId, bool>,
+) -> bool {
+    if let HirExprKind::BindingRef {
+        resolved: ResolvedRef::Item(item_id),
+        ..
+    } = &callee.kind
+    {
+        fresh.get(item_id).copied().unwrap_or(true)
+    } else {
+        false
+    }
+}
+
+/// Verbatim copy of the pre-refactor `callee_is_resolved_item`.
+fn callee_is_resolved_item_ref(callee: &HirExpr) -> bool {
+    matches!(
+        &callee.kind,
+        HirExprKind::BindingRef {
+            resolved: ResolvedRef::Item(_),
+            ..
+        }
+    )
+}

--- a/hew-mir/tests/lowering_calls.rs
+++ b/hew-mir/tests/lowering_calls.rs
@@ -6,6 +6,8 @@
 mod borrow_param_lowering;
 #[path = "lowering_calls/bytes_runtime_call_producer.rs"]
 mod bytes_runtime_call_producer;
+#[path = "lowering_calls/call_scrutinee_return_provenance.rs"]
+mod call_scrutinee_return_provenance;
 #[path = "lowering_calls/dyn_trait_dispatch.rs"]
 mod dyn_trait_dispatch;
 #[path = "lowering_calls/extern_string_ownership.rs"]

--- a/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
+++ b/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
@@ -202,13 +202,12 @@ fn forwarder_discarded_statement_rejects() {
 }
 
 #[test]
-fn forwarder_over_fresh_ctor_arg_rejects_interim() {
-    // `match forwarder(fresh_ctor())` — the callee summary is `{PARAM}`, so the
-    // interim PARAM-present gate REJECTS even though the argument is inline-fresh.
-    // This is the documented interim over-reject: the arg-scan rescue (ParamsOnly
-    // + every heap arg fresh → ADMIT) lands with the trusted-root work. Pinning
-    // the interim reject makes the later flip to ADMIT an explicit, reviewed
-    // behaviour change rather than a silent one.
+fn forwarder_over_fresh_ctor_arg_admits_with_arg_scan() {
+    // `match forwarder(fresh_ctor())` — the callee summary is `{PARAM}`-only and
+    // the argument is inline-fresh, so the S2b caller arg-scan ADMITS: the
+    // forwarded return can only alias the fresh ctor result, a fresh sole owner.
+    // (This flips the interim over-reject pin — the explicit, reviewed
+    // behaviour change the old test's comment promised.)
     let src = format!(
         "{FORWARDER}\n\
          fn fresh_ctor() -> Result<string, string> {{ Ok(\"x\") }}\n\
@@ -219,11 +218,234 @@ fn forwarder_over_fresh_ctor_arg_rejects_interim() {
     let p = pipeline(&src);
     assert_eq!(
         reject_count(&p),
+        0,
+        "a ParamsOnly forwarder over an inline-fresh arg admits (arg-scan rescue): {:#?}",
+        p.diagnostics
+    );
+    assert_eq!(unrelated_diag_count(&p), 0, "diags: {:#?}", p.diagnostics);
+    assert_eq!(
+        count_owner_mints(&p),
         1,
-        "interim: a PARAM forwarder over an inline-fresh arg rejects (arg-scan rescue is deferred): {:#?}",
+        "the admitted scrutinee mints EXACTLY ONE owner"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// S2b — the ParamsOnly caller arg-scan (template/semver-shaped admits + the
+// fail-closed arg rejects)
+// ---------------------------------------------------------------------------
+
+/// A `ParamsOnly` stdlib-parser shape: the result embeds the string parameter
+/// (`Ok(Template { src: src })` — summary `{PARAM}`).
+const PARSER: &str = r"
+    fn wrap(s: string) -> Result<string, string> { Ok(s) }
+";
+
+#[test]
+fn params_only_inline_literal_arg_admits_and_mints_owner() {
+    // `match template.try_parse("hello {{.name")` — the template fixture shape.
+    let src = format!(
+        "{PARSER}\n\
+         fn use_it() -> i64 {{\n\
+            match wrap(\"hello\") {{ Ok(_) => 1, Err(_) => 0 }}\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(
+        reject_count(&p),
+        0,
+        "a ParamsOnly callee over an inline literal admits: {:#?}",
+        p.diagnostics
+    );
+    assert_eq!(unrelated_diag_count(&p), 0, "diags: {:#?}", p.diagnostics);
+    assert_eq!(count_owner_mints(&p), 1, "exactly one owner over the admit");
+}
+
+#[test]
+fn params_only_let_bound_fresh_local_arg_admits() {
+    // `let v = "x"; match parse(v)` — the semver_test shape: a plain `let`
+    // local whose S1 bits are `∅`, unaliased, read exactly once.
+    let src = format!(
+        "{PARSER}\n\
+         fn use_it() -> i64 {{\n\
+            let v = \"1.2.3\";\n\
+            match wrap(v) {{ Ok(_) => 1, Err(_) => 0 }}\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(
+        reject_count(&p),
+        0,
+        "a let-bound provably-fresh local arg admits: {:#?}",
+        p.diagnostics
+    );
+    assert_eq!(unrelated_diag_count(&p), 0, "diags: {:#?}", p.diagnostics);
+    assert_eq!(count_owner_mints(&p), 1, "exactly one owner over the admit");
+}
+
+#[test]
+fn params_only_mixed_fresh_and_borrowed_args_reject() {
+    // One fresh literal + one borrowed place: the place could be the forwarded
+    // buffer, so the scan fails closed.
+    let src = r#"
+        type Holder { b: string; }
+        fn wrap2(a: string, b: string) -> Result<string, string> { Ok(a) }
+        fn use_it(h: Holder) -> i64 {
+            match wrap2("lit", h.b) { Ok(_) => 1, Err(_) => 0 }
+        }
+    "#;
+    let p = pipeline(src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "mixed fresh + borrowed-place args must reject: {:#?}",
         p.diagnostics
     );
     assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn params_only_param_of_caller_arg_rejects() {
+    // The caller's own by-value heap param is a borrow ITS caller still owns —
+    // never provably fresh.
+    let src = format!(
+        "{PARSER}\n\
+         fn use_it(s: string) -> i64 {{\n\
+            match wrap(s) {{ Ok(_) => 1, Err(_) => 0 }}\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "a param-of-caller arg must reject: {:#?}",
+        p.diagnostics
+    );
+    assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn params_only_unknown_callee_arg_rejects() {
+    // An argument produced by an un-audited heap extern is not provably fresh.
+    let src = format!(
+        "{PARSER}\n\
+         extern \"C\" {{\n\
+            fn ext_make() -> string;\n\
+         }}\n\
+         fn use_it() -> i64 {{\n\
+            match wrap(ext_make()) {{ Ok(_) => 1, Err(_) => 0 }}\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "an unknown/extern-produced arg must reject: {:#?}",
+        p.diagnostics
+    );
+    assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn params_only_aliased_local_arg_rejects() {
+    // `let w = v` — both alias one value; a second in-scope release authority
+    // exists, so neither is admissible as a fresh argument.
+    let src = format!(
+        "{PARSER}\n\
+         fn use_it() -> i64 {{\n\
+            let v = \"x\";\n\
+            let w = v;\n\
+            match wrap(w) {{ Ok(_) => 1, Err(_) => 0 }}\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "an aliased local arg must reject: {:#?}",
+        p.diagnostics
+    );
+    assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn params_only_reread_local_arg_rejects() {
+    // The local is read again after the scrutinee — the minted owner would
+    // free the buffer the later read still derives from.
+    let src = format!(
+        "{PARSER}\n\
+         fn take(s: string) -> i64 {{ 1 }}\n\
+         fn use_it() -> i64 {{\n\
+            let v = \"x\";\n\
+            let n = match wrap(v) {{ Ok(_) => 1, Err(_) => 0 }};\n\
+            n + take(v)\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "a re-read local arg must reject: {:#?}",
+        p.diagnostics
+    );
+    assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn params_only_pattern_binder_arg_rejects() {
+    // A match-payload binder aliases a payload slot another owner may release —
+    // never treated as an independently-owned fresh value.
+    let src = format!(
+        "{PARSER}\n\
+         fn make() -> Result<string, string> {{ Ok(\"x\") }}\n\
+         fn use_it() -> i64 {{\n\
+            match make() {{\n\
+                Ok(inner) => match wrap(inner) {{ Ok(_) => 1, Err(_) => 0 }},\n\
+                Err(_) => 0,\n\
+            }}\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "a pattern-binder arg must reject: {:#?}",
+        p.diagnostics
+    );
+}
+
+#[test]
+fn extern_result_bound_module_fn_takes_legacy_path() {
+    // The jwt/encrypt shape END-TO-END: a module fn binding an extern result
+    // and returning it through a catch-all error arm is `OPAQUE`-only (the
+    // extern-name id-collision and the catch-all `err =>` binder both stay out
+    // of the PARAM channel) → interim LegacyModuleCall: compiles and mints the
+    // owner as today.
+    let src = r#"
+        extern "C" {
+            fn ext_encode(payload: string) -> string;
+        }
+        fn last_err() -> Result<string, string> { Err("e") }
+        fn try_encode(payload: string) -> Result<string, string> {
+            let token = ext_encode(payload);
+            match last_err() {
+                Ok(_) => Ok(token),
+                err => err,
+            }
+        }
+        fn use_it() -> i64 {
+            match try_encode("{}") { Ok(_) => 1, Err(_) => 0 }
+        }
+    "#;
+    let p = pipeline(src);
+    assert_eq!(
+        reject_count(&p),
+        0,
+        "an OPAQUE-only extern-result module fn must take the legacy path: {:#?}",
+        p.diagnostics
+    );
+    assert_eq!(unrelated_diag_count(&p), 0, "diags: {:#?}", p.diagnostics);
+    assert!(any_owner_minted(&p), "legacy mint preserved");
 }
 
 #[test]

--- a/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
+++ b/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
@@ -281,3 +281,112 @@ fn spoofed_recv_symbol_extern_scrutinee_rejects() {
     );
     assert!(!any_owner_minted(&p));
 }
+
+// ---------------------------------------------------------------------------
+// S3 — the #2523 projected-payload twin gate (classify_scrutinee_origin)
+//
+// The twin classifier no longer admits every call/method/aggregate arm
+// unconditionally: it consults the same return-provenance authority. These
+// tests exercise the observable move-out behaviour through the in-memory MIR
+// (p.raw_mir / p.diagnostics), NOT --dump-mir.
+// ---------------------------------------------------------------------------
+
+/// A projected-payload move-out diagnostic (#2523's fail-closed reject at
+/// consume time), distinct from the preflight `NotYetImplemented` reject.
+fn payload_move_reject_count(p: &IrPipeline) -> usize {
+    p.diagnostics
+        .iter()
+        .filter(|d| {
+            matches!(
+                &d.kind,
+                MirDiagnosticKind::ProjectedPayloadMoveFromReadablePlace { .. }
+            )
+        })
+        .count()
+}
+
+#[test]
+fn twin_call_forwarder_move_out_rejects_with_no_neutralize() {
+    // The #2523 twin repro: a PARAM forwarder scrutinee whose Ok payload is
+    // MOVED OUT. The preflight rejects it before lowering, so no owner and no
+    // NeutralizePayloadSlot are emitted (the twin double-free is closed).
+    let src = format!(
+        "{FORWARDER}\n\
+         fn sink(s: string) -> i64 {{ 1 }}\n\
+         fn use_it(r: Result<string, string>) -> i64 {{\n\
+            match passthru(r) {{ Ok(inner) => sink(inner), Err(_) => 0 }}\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "the twin forwarder move-out must reject: {:#?}",
+        p.diagnostics
+    );
+    assert!(
+        !any_neutralize(&p),
+        "a rejected twin scrutinee must emit NO NeutralizePayloadSlot"
+    );
+    assert!(!any_owner_minted(&p), "and NO owner mint");
+}
+
+#[test]
+fn owned_record_getter_move_out_admits_not_rejected() {
+    // A `Vec<Rec>` `.get` lowers to the fresh-owner clone choke
+    // (`hew_vec_get_clone`), so the F1 emitted-symbol contract classifies it
+    // Fresh → EphemeralTemp: the Some-payload move-out ADMITS. No preflight
+    // reject (a getter is a `ResolvedImplCall`, not a `Call`) and, crucially, no
+    // projected-payload reject (the twin gate does not false-reject the clone
+    // getter that keeps `owned_nested_tuple_record` green).
+    let src = r"
+        type Rec { s: string; }
+        fn take(r: Rec) -> i64 { 1 }
+        fn use_it(ys: Vec<Rec>) -> i64 {
+            match ys.get(0) { Some(v) => take(v), None => 0 }
+        }
+    ";
+    let p = pipeline(src);
+    assert_eq!(reject_count(&p), 0, "getter must not preflight-reject");
+    assert_eq!(
+        payload_move_reject_count(&p),
+        0,
+        "an owned clone getter must not projected-payload-reject: {:#?}",
+        p.diagnostics
+    );
+    assert_eq!(unrelated_diag_count(&p), 0, "diags: {:#?}", p.diagnostics);
+}
+
+#[test]
+fn opaque_only_module_fn_move_out_admits_and_mints_owner() {
+    // An `OPAQUE`-only module fn (forwarding a heap extern result) is admitted
+    // via the interim LegacyModuleCall path; a move-out of its payload keeps the
+    // legacy classification (mints the owner as today, not rejected).
+    let src = r#"
+        extern "C" {
+            fn ext_make() -> Result<string, string>;
+        }
+        fn wrap() -> Result<string, string> { ext_make() }
+        fn sink(s: string) -> i64 { 1 }
+        fn use_it() -> i64 {
+            match wrap() { Ok(inner) => sink(inner), Err(_) => 0 }
+        }
+    "#;
+    let p = pipeline(src);
+    assert_eq!(
+        reject_count(&p),
+        0,
+        "an OPAQUE-only module fn move-out must not reject: {:#?}",
+        p.diagnostics
+    );
+    assert_eq!(
+        payload_move_reject_count(&p),
+        0,
+        "diags: {:#?}",
+        p.diagnostics
+    );
+    assert!(
+        any_owner_minted(&p),
+        "the interim LegacyModuleCall path mints the owner byte-for-byte as today"
+    );
+}

--- a/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
+++ b/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
@@ -1,0 +1,283 @@
+//! #2648 — call-scrutinee return-provenance PREFLIGHT wiring (S2).
+//!
+//! These tests exercise the full pipeline (parse → typecheck → HIR lower → MIR
+//! lower) and assert the preflight admission classifier's behaviour at the
+//! call-scrutinee consumers:
+//!
+//! - a forwarder whose summary carries `PARAM` (`fn passthru(x) { x }`) used as a
+//!   match / while-let / let-else / if-let / discarded scrutinee REJECTS with
+//!   exactly one `NotYetImplemented` diagnostic and NO partial MIR (no
+//!   `__hew_call_scrutinee` owner mint, no `NeutralizePayloadSlot`);
+//! - an `OPAQUE`-only module fn (a Hew fn forwarding a heap-returning extern
+//!   result, the jwt/encrypt shape) takes the interim `LegacyModuleCall` path —
+//!   it COMPILES and STILL mints the `__hew_call_scrutinee` owner byte-for-byte as
+//!   today (the legacy-output regression);
+//! - a fresh producer (`match make_fresh()`) admits and mints the owner;
+//! - a direct heap-returning extern scrutinee, and a user extern whose NAME spoofs
+//!   the `hew_channel_recv_layout` runtime symbol, both REJECT (keyed on the
+//!   `ItemId`, never the display name — the Rev-6 NEW-P0 typed-identity carve-out).
+//!
+//! LESSONS applied: `boundary-fail-closed` (the reject is a real diagnostic with
+//! no partial codegen), exact-value assertions (exactly one diagnostic; owner
+//! present/absent asserted, never `len() > 0`).
+
+use hew_hir::{lower_program, ResolutionCtx};
+use hew_mir::{lower_hir_module, IrPipeline, MirDiagnosticKind};
+use hew_types::module_registry::ModuleRegistry;
+use hew_types::Checker;
+
+const SYNTHETIC_CALL_SCRUTINEE_NAME: &str = "__hew_call_scrutinee";
+
+fn pipeline(source: &str) -> IrPipeline {
+    let parsed = hew_parser::parse(source);
+    assert!(
+        parsed.errors.is_empty(),
+        "parse errors: {:#?}",
+        parsed.errors
+    );
+    let mut checker = Checker::new(ModuleRegistry::new(vec![]));
+    let tc_output = checker.check_program(&parsed.program);
+    let output = lower_program(
+        &parsed.program,
+        &tc_output,
+        &ResolutionCtx,
+        hew_hir::TargetArch::host(),
+    );
+    lower_hir_module(&output.module)
+}
+
+/// Count the #2648 preflight reject diagnostics (a `NotYetImplemented` whose
+/// construct names the call-scrutinee reject).
+fn reject_count(p: &IrPipeline) -> usize {
+    p.diagnostics
+        .iter()
+        .filter(|d| {
+            matches!(
+                &d.kind,
+                MirDiagnosticKind::NotYetImplemented { construct, .. }
+                    if construct.contains("call-scrutinee")
+            )
+        })
+        .count()
+}
+
+/// Any other MIR diagnostic (a signal the program failed to lower for an
+/// unrelated reason — the test source must be otherwise clean).
+fn unrelated_diag_count(p: &IrPipeline) -> usize {
+    p.diagnostics.len() - reject_count(p)
+}
+
+/// True when ANY lowered function mints the `__hew_call_scrutinee` owner.
+fn any_owner_minted(p: &IrPipeline) -> bool {
+    p.raw_mir.iter().any(|f| {
+        f.blocks.iter().any(|b| {
+            b.statements.iter().any(|s| {
+                matches!(
+                    s,
+                    hew_mir::MirStatement::Bind { name, .. }
+                        if name == SYNTHETIC_CALL_SCRUTINEE_NAME
+                )
+            })
+        })
+    })
+}
+
+/// True when ANY lowered function emits a `NeutralizePayloadSlot` instruction.
+fn any_neutralize(p: &IrPipeline) -> bool {
+    p.raw_mir.iter().any(|f| {
+        f.blocks.iter().any(|b| {
+            b.instructions
+                .iter()
+                .any(|i| matches!(i, hew_mir::Instr::NeutralizePayloadSlot { .. }))
+        })
+    })
+}
+
+// ---------------------------------------------------------------------------
+// PARAM forwarder → REJECT at every consumer, no partial MIR [F4]
+// ---------------------------------------------------------------------------
+
+const FORWARDER: &str = r"
+    fn passthru(x: Result<string, string>) -> Result<string, string> { x }
+";
+
+#[test]
+fn forwarder_borrow_only_match_rejects_with_no_owner_or_neutralize() {
+    let src = format!(
+        "{FORWARDER}\n\
+         fn use_it(r: Result<string, string>) -> i64 {{\n\
+            match passthru(r) {{ Ok(_) => 1, Err(_) => 0 }}\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "exactly one #2648 reject; diags: {:#?}",
+        p.diagnostics
+    );
+    assert_eq!(
+        unrelated_diag_count(&p),
+        0,
+        "no unrelated diagnostics: {:#?}",
+        p.diagnostics
+    );
+    assert!(
+        !any_owner_minted(&p),
+        "a rejected forwarder scrutinee must mint NO __hew_call_scrutinee owner"
+    );
+    assert!(
+        !any_neutralize(&p),
+        "a rejected forwarder scrutinee must emit NO NeutralizePayloadSlot"
+    );
+}
+
+#[test]
+fn forwarder_while_let_rejects() {
+    let src = format!(
+        "{FORWARDER}\n\
+         fn use_it(r: Result<string, string>) {{\n\
+            while let Ok(_v) = passthru(r) {{ break; }}\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(reject_count(&p), 1, "diags: {:#?}", p.diagnostics);
+    assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn forwarder_let_else_rejects() {
+    let src = format!(
+        "{FORWARDER}\n\
+         fn use_it(r: Result<string, string>) -> i64 {{\n\
+            let Ok(_v) = passthru(r) else {{ return 0 }};\n\
+            1\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(reject_count(&p), 1, "diags: {:#?}", p.diagnostics);
+    assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn forwarder_if_let_rejects() {
+    let src = format!(
+        "{FORWARDER}\n\
+         fn use_it(r: Result<string, string>) -> i64 {{\n\
+            if let Ok(_v) = passthru(r) {{ 1 }} else {{ 0 }}\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(reject_count(&p), 1, "diags: {:#?}", p.diagnostics);
+    assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn forwarder_discarded_statement_rejects() {
+    let src = format!(
+        "{FORWARDER}\n\
+         fn use_it(r: Result<string, string>) {{\n\
+            passthru(r);\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(reject_count(&p), 1, "diags: {:#?}", p.diagnostics);
+    assert!(!any_owner_minted(&p));
+}
+
+// ---------------------------------------------------------------------------
+// Fresh producer + interim LegacyModuleCall → ADMIT, owner minted as today
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fresh_producer_match_admits_and_mints_owner() {
+    let src = r#"
+        fn make_fresh() -> Result<string, string> { Ok("x") }
+        fn use_it() -> i64 {
+            match make_fresh() { Ok(_) => 1, Err(_) => 0 }
+        }
+    "#;
+    let p = pipeline(src);
+    assert_eq!(reject_count(&p), 0, "a fresh producer must not reject");
+    assert_eq!(unrelated_diag_count(&p), 0, "diags: {:#?}", p.diagnostics);
+    assert!(
+        any_owner_minted(&p),
+        "a fresh heap-enum producer scrutinee mints the __hew_call_scrutinee owner"
+    );
+}
+
+#[test]
+fn opaque_only_module_fn_takes_legacy_path_and_mints_owner() {
+    // A Hew fn forwarding a heap-returning extern's result is `OPAQUE`-only (no
+    // PARAM) — the jwt/encrypt `try_encode` shape. Interim: it takes the
+    // `LegacyModuleCall` path → COMPILES and STILL mints the owner exactly as
+    // today (the legacy-output regression). Its precise-Fresh admit lands at S4b.
+    let src = r#"
+        extern "C" {
+            fn ext_make() -> Result<string, string>;
+        }
+        fn wrap() -> Result<string, string> { ext_make() }
+        fn use_it() -> i64 {
+            match wrap() { Ok(_) => 1, Err(_) => 0 }
+        }
+    "#;
+    let p = pipeline(src);
+    assert_eq!(
+        reject_count(&p),
+        0,
+        "an OPAQUE-only module fn must take the legacy path, not reject: {:#?}",
+        p.diagnostics
+    );
+    assert_eq!(unrelated_diag_count(&p), 0, "diags: {:#?}", p.diagnostics);
+    assert!(
+        any_owner_minted(&p),
+        "the interim LegacyModuleCall path preserves the owner mint byte-for-byte"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Direct heap extern + spoofed runtime-symbol extern → REJECT (keyed on ItemId)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn direct_heap_extern_scrutinee_rejects() {
+    let src = r#"
+        extern "C" {
+            fn ext_make() -> Result<string, string>;
+        }
+        fn use_it() -> i64 {
+            match ext_make() { Ok(_) => 1, Err(_) => 0 }
+        }
+    "#;
+    let p = pipeline(src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "an un-audited heap extern scrutinee must reject: {:#?}",
+        p.diagnostics
+    );
+    assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn spoofed_recv_symbol_extern_scrutinee_rejects() {
+    // A user extern whose NAME spoofs the compiler runtime recv symbol resolves to
+    // `ResolvedRef::Item` (not `Builtin`), so it is keyed by `ItemId` and REJECTS
+    // as a heap extern — it does NOT hit the name-only recv carve-out.
+    let src = r#"
+        extern "C" {
+            fn hew_channel_recv_layout(ch: i64) -> Result<string, string>;
+        }
+        fn use_it() -> i64 {
+            match hew_channel_recv_layout(0) { Ok(_) => 1, Err(_) => 0 }
+        }
+    "#;
+    let p = pipeline(src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "a spoofed recv-symbol extern must reject (typed identity, not name): {:#?}",
+        p.diagnostics
+    );
+    assert!(!any_owner_minted(&p));
+}

--- a/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
+++ b/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
@@ -950,7 +950,7 @@ fn guard_buried_return_forwarder_rejects() {
     // straight-line return is fresh. Missing the guard from the return-value
     // collection read `evil` as Fresh(∅) — the preflight admitted and minted
     // an owner over the forwarded borrow (REJECTS=0 MINTS=1, the double-free
-    // class this lane closes). The guard path must union {PARAM} → REJECT.
+    // class this check closes). The guard path must union {PARAM} → REJECT.
     let src = r#"
         fn evil(p: Result<string, string>, k: i64) -> Result<string, string> {
             let d = match k {

--- a/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
+++ b/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
@@ -942,3 +942,37 @@ fn generator_body_matches_mint_no_owner() {
         );
     }
 }
+
+#[test]
+fn guard_buried_return_forwarder_rejects() {
+    // The in-lane codegen-review exploit: `evil` forwards its caller-owned
+    // borrow `p` through a `return` buried in a match-arm GUARD while its
+    // straight-line return is fresh. Missing the guard from the return-value
+    // collection read `evil` as Fresh(∅) — the preflight admitted and minted
+    // an owner over the forwarded borrow (REJECTS=0 MINTS=1, the double-free
+    // class this lane closes). The guard path must union {PARAM} → REJECT.
+    let src = r#"
+        fn evil(p: Result<string, string>, k: i64) -> Result<string, string> {
+            let d = match k {
+                0 if { return p; } => 0,
+                _ => 1,
+            };
+            if d > 0 { Ok("fresh") } else { Ok("fresh") }
+        }
+        fn use_it(p: Result<string, string>) -> i64 {
+            match evil(p, 0) { Ok(_) => 1, Err(_) => 0 }
+        }
+    "#;
+    let p = pipeline(src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "a guard-buried return-forwarder scrutinee must reject: {:#?}",
+        p.diagnostics
+    );
+    assert!(
+        !any_owner_minted(&p),
+        "no owner may be minted over the guard-forwarded borrow"
+    );
+    assert!(!any_neutralize(&p));
+}

--- a/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
+++ b/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
@@ -717,3 +717,228 @@ fn method_call_forwarder_move_out_rejects_with_no_owner_or_neutralize() {
         "a rejected method-call forwarder must emit NO NeutralizePayloadSlot"
     );
 }
+
+// ---------------------------------------------------------------------------
+// S2c — child-builder provenance threading: closure / generator bodies are
+// USER code and must see the same #2648 verdicts as top-level bodies (the
+// cross-review P0: a child builder falling back to `Builder::default()` sent
+// `match wrap(s)` inside a closure through the unknown-item legacy fail-open
+// mint — a reproduced double-free under the poisoned allocator).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn closure_match_forwarder_over_capture_rejects() {
+    // The cross-review repro: a ParamsOnly forwarder matched over a captured
+    // heap value inside a closure invoked twice. Must reject with exactly one
+    // diagnostic and NO owner mint in any lowered function (including the
+    // closure shim) — never compile into a double-freeing binary.
+    let src = r"
+        fn wrap(s: Vec<i64>) -> Result<Vec<i64>, Vec<i64>> { Ok(s) }
+        fn runner(s: Vec<i64>) {
+            let f = || {
+                match wrap(s) {
+                    Ok(_) => match Ok(1) { Ok(_) => {}, Err(_) => {} },
+                    Err(_) => {},
+                }
+            };
+            f();
+            f();
+        }
+    ";
+    let p = pipeline(src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "a forwarder over a captured heap value inside a closure must reject: {:#?}",
+        p.diagnostics
+    );
+    assert!(
+        !any_owner_minted(&p),
+        "no __hew_call_scrutinee owner may be minted in ANY lowered function \
+         (including the closure shim)"
+    );
+    assert!(!any_neutralize(&p), "and no NeutralizePayloadSlot");
+}
+
+#[test]
+fn closure_match_params_only_literal_arg_admits() {
+    // The provenance thread must not blanket-reject closures: a ParamsOnly
+    // callee over an inline literal inside a closure is still a fresh sole
+    // owner — admitted, one owner minted in the shim.
+    let src = r#"
+        fn wrap(s: string) -> Result<string, string> { Ok(s) }
+        fn use_it() -> i64 {
+            let f = || {
+                match wrap("lit") { Ok(_) => 1, Err(_) => 0 }
+            };
+            f()
+        }
+    "#;
+    let p = pipeline(src);
+    assert_eq!(
+        reject_count(&p),
+        0,
+        "an inline-literal ParamsOnly scrutinee inside a closure admits: {:#?}",
+        p.diagnostics
+    );
+    assert_eq!(unrelated_diag_count(&p), 0, "diags: {:#?}", p.diagnostics);
+    assert_eq!(
+        count_owner_mints(&p),
+        1,
+        "exactly one owner, minted in the closure shim"
+    );
+}
+
+#[test]
+fn closure_local_arg_is_not_admitted_fail_closed() {
+    // A closure-body local is NOT in any freshness map (child builders keep
+    // the empty fail-closed facts — a child body can run any number of times
+    // per parent execution), so a local argument inside a closure rejects
+    // even though the same shape admits at top level.
+    let src = r#"
+        fn wrap(s: string) -> Result<string, string> { Ok(s) }
+        fn use_it() -> i64 {
+            let f = || {
+                let v = "x";
+                match wrap(v) { Ok(_) => 1, Err(_) => 0 }
+            };
+            f()
+        }
+    "#;
+    let p = pipeline(src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "a closure-body local arg fails closed: {:#?}",
+        p.diagnostics
+    );
+    assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn closure_while_let_forwarder_rejects() {
+    let src = format!(
+        "{FORWARDER}\n\
+         fn use_it(r: Result<string, string>) {{\n\
+            let f = || {{\n\
+                while let Ok(_v) = passthru(r) {{ break; }}\n\
+            }};\n\
+            f();\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(reject_count(&p), 1, "diags: {:#?}", p.diagnostics);
+    assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn closure_let_else_forwarder_rejects() {
+    let src = format!(
+        "{FORWARDER}\n\
+         fn use_it(r: Result<string, string>) -> i64 {{\n\
+            let f = || {{\n\
+                let Ok(_v) = passthru(r) else {{ return 0 }};\n\
+                1\n\
+            }};\n\
+            f()\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(reject_count(&p), 1, "diags: {:#?}", p.diagnostics);
+    assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn closure_if_let_forwarder_rejects() {
+    let src = format!(
+        "{FORWARDER}\n\
+         fn use_it(r: Result<string, string>) -> i64 {{\n\
+            let f = || {{\n\
+                if let Ok(_v) = passthru(r) {{ 1 }} else {{ 0 }}\n\
+            }};\n\
+            f()\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(reject_count(&p), 1, "diags: {:#?}", p.diagnostics);
+    assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn closure_discarded_forwarder_rejects() {
+    let src = format!(
+        "{FORWARDER}\n\
+         fn use_it(r: Result<string, string>) {{\n\
+            let f = || {{\n\
+                passthru(r);\n\
+            }};\n\
+            f();\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(reject_count(&p), 1, "diags: {:#?}", p.diagnostics);
+    assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn generator_body_matches_mint_no_owner() {
+    // A generator body is lowered by a child builder that carries NO
+    // `enum_layouts`, so `ty_is_heap_owning_enum_composite` is false for every
+    // scrutinee there: the from-call owner is NEVER minted in a gen body (the
+    // pre-existing leak-biased posture — the Result temp is not released) and
+    // the preflight's ty-gate returns `NotApplicable` for the same reason.
+    // The load-bearing safety fact is NO OWNER MINT — with no owner there is
+    // no second release authority, so the #2648 double-free class cannot fire
+    // in a gen body. Pinned for both a local-arg forwarder shape and an
+    // inline-literal shape; when generator bodies gain enum layouts (and with
+    // them scrutinee owners), these pins must flip to the closure-shim
+    // verdicts (reject / admit-with-one-mint).
+    for scrutinee_src in [
+        r#"
+        fn wrap(s: string) -> Result<string, string> { Ok(s) }
+        fn use_it() -> i64 {
+            var total = 0;
+            for v in gen {
+                let s = "x";
+                let n = match wrap(s) { Ok(_) => 1, Err(_) => 0 };
+                yield n;
+            } {
+                total = total + v;
+            }
+            total
+        }
+        "#,
+        r#"
+        fn wrap(s: string) -> Result<string, string> { Ok(s) }
+        fn use_it() -> i64 {
+            var total = 0;
+            for v in gen {
+                let n = match wrap("lit") { Ok(_) => 1, Err(_) => 0 };
+                yield n;
+            } {
+                total = total + v;
+            }
+            total
+        }
+        "#,
+    ] {
+        let p = pipeline(scrutinee_src);
+        assert_eq!(
+            unrelated_diag_count(&p),
+            0,
+            "gen-body sources must lower clean: {:#?}",
+            p.diagnostics
+        );
+        assert_eq!(
+            count_owner_mints(&p),
+            0,
+            "no __hew_call_scrutinee owner may exist in a gen body (no layouts, no mint,              no double-free surface)"
+        );
+        assert_eq!(
+            reject_count(&p),
+            0,
+            "the ty-gate returns NotApplicable in gen bodies today: {:#?}",
+            p.diagnostics
+        );
+    }
+}

--- a/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
+++ b/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
@@ -185,6 +185,56 @@ fn forwarder_discarded_statement_rejects() {
     assert!(!any_owner_minted(&p));
 }
 
+#[test]
+fn forwarder_over_fresh_ctor_arg_rejects_interim() {
+    // `match forwarder(fresh_ctor())` — the callee summary is `{PARAM}`, so the
+    // interim PARAM-present gate REJECTS even though the argument is inline-fresh.
+    // This is the documented interim over-reject: the arg-scan rescue (ParamsOnly
+    // + every heap arg fresh → ADMIT) lands with the trusted-root work. Pinning
+    // the interim reject makes the later flip to ADMIT an explicit, reviewed
+    // behaviour change rather than a silent one.
+    let src = format!(
+        "{FORWARDER}\n\
+         fn fresh_ctor() -> Result<string, string> {{ Ok(\"x\") }}\n\
+         fn use_it() -> i64 {{\n\
+            match passthru(fresh_ctor()) {{ Ok(_) => 1, Err(_) => 0 }}\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "interim: a PARAM forwarder over an inline-fresh arg rejects (arg-scan rescue is deferred): {:#?}",
+        p.diagnostics
+    );
+    assert!(!any_owner_minted(&p));
+}
+
+#[test]
+fn forwarder_reused_in_loop_rejects() {
+    // The #2648 loop-back-edge repro: a PARAM forwarder scrutinee inside a loop
+    // body would mint one owner per back-edge over the same forwarded buffer.
+    // The preflight rejects it before lowering — one diagnostic, no owner mint.
+    let src = format!(
+        "{FORWARDER}\n\
+         fn use_it(r: Result<string, string>) {{\n\
+            var i = 0;\n\
+            while i < 2 {{\n\
+                match passthru(r) {{ Ok(_) => {{}}, Err(_) => {{}} }}\n\
+                i = i + 1;\n\
+            }}\n\
+         }}\n"
+    );
+    let p = pipeline(&src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "a forwarder scrutinee reused across a loop back-edge rejects: {:#?}",
+        p.diagnostics
+    );
+    assert!(!any_owner_minted(&p));
+}
+
 // ---------------------------------------------------------------------------
 // Fresh producer + interim LegacyModuleCall → ADMIT, owner minted as today
 // ---------------------------------------------------------------------------
@@ -388,5 +438,40 @@ fn opaque_only_module_fn_move_out_admits_and_mints_owner() {
     assert!(
         any_owner_minted(&p),
         "the interim LegacyModuleCall path mints the owner byte-for-byte as today"
+    );
+}
+
+#[test]
+fn method_call_forwarder_move_out_rejects_with_no_owner_or_neutralize() {
+    // A user METHOD that forwards a by-value heap parameter
+    // (`fn forward(self, x) -> T { x }`) used as a match scrutinee whose payload
+    // is moved out. The method-call scrutinee resolves through the same
+    // return-provenance authority (summary `{PARAM}`), so the preflight rejects
+    // it before lowering — exactly one diagnostic, no owner mint, no neutralize.
+    let src = r"
+        type Holder { tag: i64; }
+        impl Holder {
+            fn forward(self, x: Result<string, string>) -> Result<string, string> { x }
+        }
+        fn sink(s: string) -> i64 { 1 }
+        fn use_it(h: Holder, r: Result<string, string>) -> i64 {
+            match h.forward(r) { Ok(inner) => sink(inner), Err(_) => 0 }
+        }
+    ";
+    let p = pipeline(src);
+    assert_eq!(
+        reject_count(&p),
+        1,
+        "a method-call forwarder scrutinee must reject: {:#?}",
+        p.diagnostics
+    );
+    assert_eq!(unrelated_diag_count(&p), 0, "diags: {:#?}", p.diagnostics);
+    assert!(
+        !any_owner_minted(&p),
+        "a rejected method-call forwarder must mint NO owner"
+    );
+    assert!(
+        !any_neutralize(&p),
+        "a rejected method-call forwarder must emit NO NeutralizePayloadSlot"
     );
 }

--- a/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
+++ b/hew-mir/tests/lowering_calls/call_scrutinee_return_provenance.rs
@@ -82,6 +82,22 @@ fn any_owner_minted(p: &IrPipeline) -> bool {
     })
 }
 
+/// Count `__hew_call_scrutinee` owner mints across every lowered function.
+fn count_owner_mints(p: &IrPipeline) -> usize {
+    p.raw_mir
+        .iter()
+        .flat_map(|f| f.blocks.iter())
+        .flat_map(|b| b.statements.iter())
+        .filter(|s| {
+            matches!(
+                s,
+                hew_mir::MirStatement::Bind { name, .. }
+                    if name == SYNTHETIC_CALL_SCRUTINEE_NAME
+            )
+        })
+        .count()
+}
+
 /// True when ANY lowered function emits a `NeutralizePayloadSlot` instruction.
 fn any_neutralize(p: &IrPipeline) -> bool {
     p.raw_mir.iter().any(|f| {
@@ -250,9 +266,11 @@ fn fresh_producer_match_admits_and_mints_owner() {
     let p = pipeline(src);
     assert_eq!(reject_count(&p), 0, "a fresh producer must not reject");
     assert_eq!(unrelated_diag_count(&p), 0, "diags: {:#?}", p.diagnostics);
-    assert!(
-        any_owner_minted(&p),
-        "a fresh heap-enum producer scrutinee mints the __hew_call_scrutinee owner"
+    assert_eq!(
+        count_owner_mints(&p),
+        1,
+        "a single fresh-producer scrutinee mints EXACTLY ONE __hew_call_scrutinee \
+         owner — never two over the same buffer (the #2648 double-mint invariant)"
     );
 }
 
@@ -279,9 +297,11 @@ fn opaque_only_module_fn_takes_legacy_path_and_mints_owner() {
         p.diagnostics
     );
     assert_eq!(unrelated_diag_count(&p), 0, "diags: {:#?}", p.diagnostics);
-    assert!(
-        any_owner_minted(&p),
-        "the interim LegacyModuleCall path preserves the owner mint byte-for-byte"
+    assert_eq!(
+        count_owner_mints(&p),
+        1,
+        "the interim LegacyModuleCall path preserves the owner mint byte-for-byte \
+         (exactly one owner, as today)"
     );
 }
 

--- a/scripts/asan-fixture-check.sh
+++ b/scripts/asan-fixture-check.sh
@@ -338,6 +338,12 @@ STRING_COW_SRC="${ROOT}/tests/vertical-slice/accept/string_cow_retain_share.hew"
 ENUM_YIELD_SRC="${ROOT}/tests/vertical-slice/accept/receive_gen_fn_owned_enum_yield.hew"
 RECORD_STREAM_BREAK_SRC="${ROOT}/tests/vertical-slice/accept/receive_gen_fn_record_stream_break.hew"
 ENUM_PAYLOAD_LOOP_SRC="${ROOT}/tests/vertical-slice/accept/enum_payload_call_loop_release.hew"
+# Admitted fresh-producer call scrutinee (#2648): a heap-owning-enum result built
+# FRESH through immutable bindings and a helper chain (the D108 shape the return-
+# provenance preflight must keep admitting). The preflight mints exactly one
+# synthetic owner over the call temp; a double-mint would double-free the payload
+# header — invisible to macOS `leaks`, caught here by ASan. Exits 0, clean.
+CALL_SCRUTINEE_FRESH_SRC="${ROOT}/tests/vertical-slice/accept/call_scrutinee_fresh_forwarder_release.hew"
 
 # ── Step 3: compile the Hew fixtures ─────────────────────────────────────
 echo ""
@@ -380,6 +386,9 @@ compile_asan_fixture "composite yield (record stream break)" "${RECORD_STREAM_BR
 
 ENUM_PAYLOAD_LOOP_BIN="${WORK_DIR}/enum_payload_call_loop_release"
 compile_asan_fixture "match-scrutinee enum payload (call loop)" "${ENUM_PAYLOAD_LOOP_SRC}" "${ENUM_PAYLOAD_LOOP_BIN}"
+
+CALL_SCRUTINEE_FRESH_BIN="${WORK_DIR}/call_scrutinee_fresh_forwarder_release"
+compile_asan_fixture "admitted fresh-producer call scrutinee (#2648)" "${CALL_SCRUTINEE_FRESH_SRC}" "${CALL_SCRUTINEE_FRESH_BIN}"
 
 # ── Step 3c: compile and link the clean probe via the CLI flag path ───────
 # Uses HEW_SANITIZE_ADDRESS=1 hew build (full link, not --emit-obj) to exercise
@@ -488,6 +497,17 @@ else
 fi
 
 if run_asan_fixture "match-scrutinee enum payload (call loop)" "${ENUM_PAYLOAD_LOOP_BIN}" 0; then
+  pass=$((pass + 1))
+else
+  fail=$((fail + 1))
+fi
+
+# ── Gate 9: admitted fresh-producer call scrutinee MUST be ASan/LSan-clean (#2648) ─
+# The return-provenance preflight admits a fresh-through-bindings producer and
+# mints exactly one synthetic owner over the call temp. This fixture proves that
+# admit path is leak-clean under ASan; a double-mint (the #2648 double-free) would
+# surface here as a heap-use-after-free on the payload header.
+if run_asan_fixture "admitted fresh-producer call scrutinee (#2648)" "${CALL_SCRUTINEE_FRESH_BIN}" 0; then
   pass=$((pass + 1))
 else
   fail=$((fail + 1))

--- a/std/text/template/template.hew
+++ b/std/text/template/template.hew
@@ -510,7 +510,10 @@ pub fn try_parse(src: string) -> Result<Template, TemplateError> {
 
 /// Parse and validate a template string, panicking if it is malformed.
 pub fn parse(src: string) -> Template {
-    match try_parse(src) {
+    // Bound before the match: `try_parse` forwards its parameter into the
+    // result, so matching the call directly would alias `src` (caller-owned).
+    let parsed = try_parse(src);
+    match parsed {
         Ok(t) => t,
         Err(err) => {
             panic(template_error_message(err));
@@ -526,7 +529,10 @@ pub fn render_try(t: Template, ctx: Ctx) -> Result<string, TemplateError> {
 
 /// Render a compiled template, panicking if the template is malformed.
 pub fn render_template(t: Template, ctx: Ctx) -> string {
-    match render_segment(t.src, ctx, "", false) {
+    // Bound before the match: the segment renderer's result derives from the
+    // caller-owned `t.src` place, so the call is not matched directly.
+    let rendered = render_segment(t.src, ctx, "", false);
+    match rendered {
         Ok(s) => s,
         Err(err) => {
             panic(template_error_message(err));
@@ -637,9 +643,13 @@ pub fn ctx_set_list(ctx: Ctx, key: string, items: Vec<string>) {
 /// }
 /// ```
 pub fn render(tmpl: string, ctx: Ctx) -> Result<string, string> {
-    match try_parse(tmpl) {
+    // Bound before the match: `try_parse` forwards its parameter into the
+    // result, so matching the call directly would alias `tmpl` (caller-owned).
+    let parsed = try_parse(tmpl);
+    match parsed {
         Ok(t) => {
-            match render_segment(t.src, ctx, "", false) {
+            let rendered = render_segment(t.src, ctx, "", false);
+            match rendered {
                 Ok(s) => Ok(s),
                 Err(err) => Err(template_error_message(err)),
             }

--- a/tests/mir-baselines/funcupdate-reassign/closure_consume_reassign_overwrite_release.elab.mir
+++ b/tests/mir-baselines/funcupdate-reassign/closure_consume_reassign_overwrite_release.elab.mir
@@ -1,0 +1,388 @@
+fn control -> i64
+  statements:
+    bind BindingId(1) s site=SiteId(0) ty=string
+    use BindingId(0) take_consume_arm site=SiteId(1) ty=bool intent=Read
+    use BindingId(1) s site=SiteId(2) ty=string intent=Consume
+    bind BindingId(2) moved site=SiteId(2) ty=string
+    use BindingId(2) moved site=SiteId(4) ty=string intent=Read
+    eval site=SiteId(7) ty=()
+    return site=Some(SiteId(3)) ty=i64
+    bind BindingId(1) s site=SiteId(8) ty=string
+    eval site=SiteId(9) ty=()
+    use BindingId(1) s site=SiteId(11) ty=string intent=Read
+    return site=Some(SiteId(10)) ty=i64
+    drop BindingId(2) moved ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 hew_string_length -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    branch[bb3: bb6/bb7] ->
+      (none)
+    return[bb4] ->
+      (none)
+    goto[bb5->bb3] ->
+      (none)
+    cancel[bb5] ->
+      (none)
+    goto[bb6->bb7] ->
+      (none)
+    call[bb7 hew_string_length -> bb8] ->
+      (none)
+    return[bb8] ->
+      (none)
+
+fn via_closure -> i64
+  statements:
+    bind BindingId(7) f site=SiteId(13) ty=fn(bool) -> i64
+    use BindingId(7) f site=SiteId(30) ty=fn(bool) -> i64 intent=Read
+    use BindingId(3) take_consume_arm site=SiteId(29) ty=bool intent=Read
+    return site=Some(SiteId(28)) ty=i64
+    drop BindingId(7) f ty=fn(bool) -> i64
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn __hew_closure_invoke_via_closure_0 -> i64
+  statements:
+    bind BindingId(5) s site=SiteId(15) ty=string
+    use BindingId(4) flag site=SiteId(16) ty=bool intent=Read
+    use BindingId(5) s site=SiteId(17) ty=string intent=Consume
+    bind BindingId(6) moved site=SiteId(17) ty=string
+    use BindingId(6) moved site=SiteId(19) ty=string intent=Read
+    eval site=SiteId(22) ty=()
+    return site=Some(SiteId(18)) ty=i64
+    bind BindingId(5) s site=SiteId(23) ty=string
+    eval site=SiteId(24) ty=()
+    use BindingId(5) s site=SiteId(26) ty=string intent=Read
+    return site=Some(SiteId(14)) ty=i64
+    drop BindingId(6) moved ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 hew_string_length -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    branch[bb3: bb6/bb7] ->
+      (none)
+    return[bb4] ->
+      (none)
+    goto[bb5->bb3] ->
+      (none)
+    cancel[bb5] ->
+      (none)
+    goto[bb6->bb7] ->
+      (none)
+    call[bb7 hew_string_length -> bb8] ->
+      (none)
+    return[bb8] ->
+      (none)
+
+fn main -> i64
+  statements:
+    return site=Some(SiteId(36)) ty=i64
+    eval site=SiteId(38) ty=()
+    return site=Some(SiteId(44)) ty=i64
+    eval site=SiteId(46) ty=()
+    return site=Some(SiteId(52)) ty=i64
+    eval site=SiteId(54) ty=()
+    return site=Some(SiteId(60)) ty=i64
+    eval site=SiteId(62) ty=()
+    return site=Some(SiteId(63)) ty=i64
+  drop_plans:
+    call[bb0 control -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb2/bb3] ->
+      (none)
+    return[bb2] ->
+      (none)
+    goto[bb3->bb4] ->
+      (none)
+    call[bb4 control -> bb6] ->
+      (none)
+    goto[bb5->bb4] ->
+      (none)
+    cancel[bb5] ->
+      (none)
+    branch[bb6: bb7/bb8] ->
+      (none)
+    return[bb7] ->
+      (none)
+    goto[bb8->bb9] ->
+      (none)
+    call[bb9 via_closure -> bb11] ->
+      (none)
+    goto[bb10->bb9] ->
+      (none)
+    cancel[bb10] ->
+      (none)
+    branch[bb11: bb12/bb13] ->
+      (none)
+    return[bb12] ->
+      (none)
+    goto[bb13->bb14] ->
+      (none)
+    call[bb14 via_closure -> bb16] ->
+      (none)
+    goto[bb15->bb14] ->
+      (none)
+    cancel[bb15] ->
+      (none)
+    branch[bb16: bb17/bb18] ->
+      (none)
+    return[bb17] ->
+      (none)
+    goto[bb18->bb19] ->
+      (none)
+    return[bb19] ->
+      (none)
+    goto[bb20->bb19] ->
+      (none)
+    cancel[bb20] ->
+      (none)
+
+fn i8::fmt -> string
+  statements:
+    use BindingId(16) val site=SiteId(134) ty=i8 intent=Read
+    return site=Some(SiteId(132)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i16::fmt -> string
+  statements:
+    use BindingId(17) val site=SiteId(138) ty=i16 intent=Read
+    return site=Some(SiteId(136)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i32::fmt -> string
+  statements:
+    use BindingId(18) val site=SiteId(141) ty=i32 intent=Read
+    return site=Some(SiteId(140)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i64::fmt -> string
+  statements:
+    use BindingId(19) val site=SiteId(144) ty=i64 intent=Read
+    return site=Some(SiteId(143)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u8::fmt -> string
+  statements:
+    use BindingId(20) val site=SiteId(147) ty=u8 intent=Read
+    return site=Some(SiteId(146)) ty=string
+  drop_plans:
+    call[bb0 to_string_u8 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u16::fmt -> string
+  statements:
+    use BindingId(21) val site=SiteId(150) ty=u16 intent=Read
+    return site=Some(SiteId(149)) ty=string
+  drop_plans:
+    call[bb0 to_string_u16 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u32::fmt -> string
+  statements:
+    use BindingId(22) val site=SiteId(153) ty=u32 intent=Read
+    return site=Some(SiteId(152)) ty=string
+  drop_plans:
+    call[bb0 to_string_u32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u64::fmt -> string
+  statements:
+    use BindingId(23) val site=SiteId(156) ty=u64 intent=Read
+    return site=Some(SiteId(155)) ty=string
+  drop_plans:
+    call[bb0 to_string_u64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn isize::fmt -> string
+  statements:
+    use BindingId(24) val site=SiteId(160) ty=isize intent=Read
+    return site=Some(SiteId(158)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn usize::fmt -> string
+  statements:
+    use BindingId(25) val site=SiteId(164) ty=usize intent=Read
+    return site=Some(SiteId(162)) ty=string
+  drop_plans:
+    call[bb0 to_string_u64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn bool::fmt -> string
+  statements:
+    use BindingId(26) val site=SiteId(167) ty=bool intent=Read
+    return site=Some(SiteId(166)) ty=string
+  drop_plans:
+    call[bb0 to_string_bool -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn char::fmt -> string
+  statements:
+    use BindingId(27) val site=SiteId(170) ty=char intent=Read
+    return site=Some(SiteId(169)) ty=string
+  drop_plans:
+    call[bb0 to_string_char -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn f64::fmt -> string
+  statements:
+    use BindingId(28) val site=SiteId(173) ty=f64 intent=Read
+    return site=Some(SiteId(172)) ty=string
+  drop_plans:
+    call[bb0 to_string_f64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn f32::fmt -> string
+  statements:
+    use BindingId(29) val site=SiteId(177) ty=f32 intent=Read
+    return site=Some(SiteId(175)) ty=string
+  drop_plans:
+    call[bb0 to_string_f64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string::fmt -> string
+  statements:
+    use BindingId(30) val site=SiteId(179) ty=string intent=Read
+    return site=Some(SiteId(179)) ty=string
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn duration::from_nanos -> duration
+  statements:
+    use BindingId(31) n site=SiteId(181) ty=i64 intent=Read
+    return site=Some(SiteId(180)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_micros -> duration
+  statements:
+    use BindingId(32) n site=SiteId(184) ty=i64 intent=Read
+    return site=Some(SiteId(183)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_millis -> duration
+  statements:
+    use BindingId(33) n site=SiteId(187) ty=i64 intent=Read
+    return site=Some(SiteId(186)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_secs -> duration
+  statements:
+    use BindingId(34) n site=SiteId(190) ty=i64 intent=Read
+    return site=Some(SiteId(189)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::fmt -> string
+  statements:
+    use BindingId(35) val site=SiteId(195) ty=duration intent=Read
+    return site=Some(SiteId(192)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+

--- a/tests/mir-baselines/funcupdate-reassign/closure_consume_reassign_overwrite_release.elab.mir
+++ b/tests/mir-baselines/funcupdate-reassign/closure_consume_reassign_overwrite_release.elab.mir
@@ -2,7 +2,7 @@ fn control -> i64
   statements:
     bind BindingId(1) s site=SiteId(0) ty=string
     use BindingId(0) take_consume_arm site=SiteId(1) ty=bool intent=Read
-    use BindingId(1) s site=SiteId(2) ty=string intent=Consume
+    use BindingId(1) s site=SiteId(2) ty=string intent=Read
     bind BindingId(2) moved site=SiteId(2) ty=string
     use BindingId(2) moved site=SiteId(4) ty=string intent=Read
     eval site=SiteId(7) ty=()
@@ -12,6 +12,7 @@ fn control -> i64
     use BindingId(1) s site=SiteId(11) ty=string intent=Read
     return site=Some(SiteId(10)) ty=i64
     drop BindingId(2) moved ty=string
+    drop BindingId(1) s ty=string
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -24,7 +25,8 @@ fn control -> i64
     branch[bb3: bb6/bb7] ->
       (none)
     return[bb4] ->
-      (none)
+      drop _5 ty=string kind=cow_heap(hew_string_drop)
+      drop _2 ty=string kind=cow_heap(hew_string_drop)
     goto[bb5->bb3] ->
       (none)
     cancel[bb5] ->
@@ -34,7 +36,7 @@ fn control -> i64
     call[bb7 hew_string_length -> bb8] ->
       (none)
     return[bb8] ->
-      (none)
+      drop _2 ty=string kind=cow_heap(hew_string_drop)
 
 fn via_closure -> i64
   statements:
@@ -51,7 +53,7 @@ fn __hew_closure_invoke_via_closure_0 -> i64
   statements:
     bind BindingId(5) s site=SiteId(15) ty=string
     use BindingId(4) flag site=SiteId(16) ty=bool intent=Read
-    use BindingId(5) s site=SiteId(17) ty=string intent=Consume
+    use BindingId(5) s site=SiteId(17) ty=string intent=Read
     bind BindingId(6) moved site=SiteId(17) ty=string
     use BindingId(6) moved site=SiteId(19) ty=string intent=Read
     eval site=SiteId(22) ty=()
@@ -61,6 +63,7 @@ fn __hew_closure_invoke_via_closure_0 -> i64
     use BindingId(5) s site=SiteId(26) ty=string intent=Read
     return site=Some(SiteId(14)) ty=i64
     drop BindingId(6) moved ty=string
+    drop BindingId(5) s ty=string
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -73,7 +76,8 @@ fn __hew_closure_invoke_via_closure_0 -> i64
     branch[bb3: bb6/bb7] ->
       (none)
     return[bb4] ->
-      (none)
+      drop _6 ty=string kind=cow_heap(hew_string_drop)
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
     goto[bb5->bb3] ->
       (none)
     cancel[bb5] ->
@@ -83,7 +87,7 @@ fn __hew_closure_invoke_via_closure_0 -> i64
     call[bb7 hew_string_length -> bb8] ->
       (none)
     return[bb8] ->
-      (none)
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
 
 fn main -> i64
   statements:

--- a/tests/mir-baselines/funcupdate-reassign/funcupdate_owned_field_drop_test.elab.mir
+++ b/tests/mir-baselines/funcupdate-reassign/funcupdate_owned_field_drop_test.elab.mir
@@ -1,0 +1,3147 @@
+fn test_funcupdate_string_field_override_drops_old -> ()
+  statements:
+    bind BindingId(0) c site=SiteId(0) ty=FlatConfig
+    bind BindingId(1) i site=SiteId(6) ty=i64
+    use BindingId(1) i site=SiteId(8) ty=i64 intent=Read
+    eval site=SiteId(21) ty=()
+    use BindingId(0) c site=SiteId(24) ty=FlatConfig intent=Read
+    use BindingId(0) c site=SiteId(16) ty=FlatConfig intent=Read
+    agg_alias BindingId(0) c site=SiteId(16) ty=FlatConfig
+    bind BindingId(0) c site=SiteId(10) ty=FlatConfig
+    eval site=SiteId(11) ty=()
+    use BindingId(1) i site=SiteId(19) ty=i64 intent=Read
+    bind BindingId(1) i site=SiteId(17) ty=i64
+    eval site=SiteId(18) ty=()
+    eval site=SiteId(22) ty=()
+    use BindingId(0) c site=SiteId(29) ty=FlatConfig intent=Read
+    eval site=SiteId(27) ty=()
+    drop BindingId(0) c ty=FlatConfig
+  drop_plans:
+    call[bb0 string$repeat -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    goto[bb1->bb2] ->
+      (none)
+    branch[bb2: bb3/bb4] ->
+      (none)
+    call[bb3 string$repeat -> bb5] ->
+      (none)
+    call[bb4 testing$assert_eq -> bb8] ->
+      (none)
+    branch[bb5: bb6/bb7] ->
+      (none)
+    panic[bb6] ->
+      (none)
+    goto[bb7->bb2] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+    call[bb8 string$repeat -> bb9] ->
+      (none)
+    call[bb9 testing$assert_eq_str -> bb10] ->
+      (none)
+    return[bb10] ->
+      (none)
+
+fn test_funcupdate_bitcopy_field_override_carries_label -> ()
+  statements:
+    bind BindingId(2) c site=SiteId(35) ty=FlatConfig
+    bind BindingId(3) i site=SiteId(41) ty=i64
+    use BindingId(3) i site=SiteId(43) ty=i64 intent=Read
+    use BindingId(2) c site=SiteId(49) ty=FlatConfig intent=Read
+    eval site=SiteId(56) ty=()
+    use BindingId(2) c site=SiteId(59) ty=FlatConfig intent=Read
+    use BindingId(2) c site=SiteId(51) ty=FlatConfig intent=Read
+    agg_alias BindingId(2) c site=SiteId(51) ty=FlatConfig
+    bind BindingId(2) c site=SiteId(45) ty=FlatConfig
+    eval site=SiteId(46) ty=()
+    use BindingId(3) i site=SiteId(54) ty=i64 intent=Read
+    bind BindingId(3) i site=SiteId(52) ty=i64
+    eval site=SiteId(53) ty=()
+    eval site=SiteId(57) ty=()
+    use BindingId(2) c site=SiteId(64) ty=FlatConfig intent=Read
+    eval site=SiteId(62) ty=()
+    drop BindingId(2) c ty=FlatConfig
+  drop_plans:
+    call[bb0 string$repeat -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    goto[bb1->bb2] ->
+      (none)
+    branch[bb2: bb3/bb4] ->
+      (none)
+    branch[bb3: bb5/bb6] ->
+      (none)
+    call[bb4 testing$assert_eq -> bb9] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    branch[bb6: bb7/bb8] ->
+      (none)
+    panic[bb7] ->
+      (none)
+    goto[bb8->bb2] ->
+      (none)
+    cancel[bb8] ->
+      (none)
+    call[bb9 string$repeat -> bb10] ->
+      (none)
+    call[bb10 testing$assert_eq_str -> bb11] ->
+      (none)
+    return[bb11] ->
+      (none)
+
+fn test_funcupdate_vec_field_override_drops_old -> ()
+  statements:
+    bind BindingId(4) init site=SiteId(70) ty=Vec<i64>
+    use BindingId(4) init site=SiteId(73) ty=Vec<i64> intent=Read
+    eval site=SiteId(72) ty=()
+    use BindingId(4) init site=SiteId(76) ty=Vec<i64> intent=Read
+    agg_alias BindingId(4) init site=SiteId(76) ty=Vec<i64>
+    bind BindingId(5) s site=SiteId(75) ty=VecHolder
+    bind BindingId(6) i site=SiteId(78) ty=i64
+    use BindingId(6) i site=SiteId(80) ty=i64 intent=Read
+    eval site=SiteId(95) ty=()
+    use BindingId(5) s site=SiteId(98) ty=VecHolder intent=Read
+    bind BindingId(7) next site=SiteId(82) ty=Vec<i64>
+    use BindingId(7) next site=SiteId(85) ty=Vec<i64> intent=Read
+    use BindingId(6) i site=SiteId(86) ty=i64 intent=Read
+    eval site=SiteId(84) ty=()
+    use BindingId(7) next site=SiteId(89) ty=Vec<i64> intent=Read
+    agg_alias BindingId(7) next site=SiteId(89) ty=Vec<i64>
+    use BindingId(5) s site=SiteId(90) ty=VecHolder intent=Read
+    agg_alias BindingId(5) s site=SiteId(90) ty=VecHolder
+    bind BindingId(5) s site=SiteId(87) ty=VecHolder
+    eval site=SiteId(88) ty=()
+    use BindingId(6) i site=SiteId(93) ty=i64 intent=Read
+    bind BindingId(6) i site=SiteId(91) ty=i64
+    eval site=SiteId(92) ty=()
+    eval site=SiteId(96) ty=()
+    use BindingId(5) s site=SiteId(104) ty=VecHolder intent=Read
+    eval site=SiteId(101) ty=()
+    drop BindingId(7) next ty=Vec<i64>
+    drop BindingId(5) s ty=VecHolder
+    drop BindingId(4) init ty=Vec<i64>
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 hew_vec_push_i64 -> bb2] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    branch[bb3: bb4/bb5] ->
+      (none)
+    call[bb4 Vec::new -> bb6] ->
+      (none)
+    call[bb5 testing$assert_eq_str -> bb10] ->
+      (none)
+    call[bb6 hew_vec_push_i64 -> bb7] ->
+      (none)
+    branch[bb7: bb8/bb9] ->
+      (none)
+    panic[bb8] ->
+      (none)
+    goto[bb9->bb3] ->
+      (none)
+    cancel[bb9] ->
+      (none)
+    call[bb10 hew_vec_len -> bb11] ->
+      (none)
+    call[bb11 testing$assert_eq -> bb12] ->
+      (none)
+    return[bb12] ->
+      (none)
+
+fn test_funcupdate_multi_field_override_drops_old -> ()
+  statements:
+    bind BindingId(8) init site=SiteId(107) ty=Vec<i64>
+    use BindingId(8) init site=SiteId(110) ty=Vec<i64> intent=Read
+    eval site=SiteId(109) ty=()
+    use BindingId(8) init site=SiteId(113) ty=Vec<i64> intent=Read
+    agg_alias BindingId(8) init site=SiteId(113) ty=Vec<i64>
+    bind BindingId(9) s site=SiteId(112) ty=VecHolder
+    bind BindingId(10) i site=SiteId(118) ty=i64
+    use BindingId(10) i site=SiteId(120) ty=i64 intent=Read
+    eval site=SiteId(139) ty=()
+    use BindingId(9) s site=SiteId(143) ty=VecHolder intent=Read
+    bind BindingId(11) next site=SiteId(122) ty=Vec<i64>
+    use BindingId(11) next site=SiteId(125) ty=Vec<i64> intent=Read
+    use BindingId(10) i site=SiteId(126) ty=i64 intent=Read
+    eval site=SiteId(124) ty=()
+    use BindingId(11) next site=SiteId(129) ty=Vec<i64> intent=Read
+    agg_alias BindingId(11) next site=SiteId(129) ty=Vec<i64>
+    use BindingId(9) s site=SiteId(134) ty=VecHolder intent=Read
+    agg_alias BindingId(9) s site=SiteId(134) ty=VecHolder
+    bind BindingId(9) s site=SiteId(127) ty=VecHolder
+    eval site=SiteId(128) ty=()
+    use BindingId(10) i site=SiteId(137) ty=i64 intent=Read
+    bind BindingId(10) i site=SiteId(135) ty=i64
+    eval site=SiteId(136) ty=()
+    eval site=SiteId(140) ty=()
+    use BindingId(9) s site=SiteId(148) ty=VecHolder intent=Read
+    eval site=SiteId(146) ty=()
+    drop BindingId(11) next ty=Vec<i64>
+    drop BindingId(9) s ty=VecHolder
+    drop BindingId(8) init ty=Vec<i64>
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 hew_vec_push_i64 -> bb2] ->
+      (none)
+    call[bb2 string$repeat -> bb3] ->
+      (none)
+    goto[bb3->bb4] ->
+      (none)
+    branch[bb4: bb5/bb6] ->
+      (none)
+    call[bb5 Vec::new -> bb7] ->
+      (none)
+    call[bb6 hew_vec_len -> bb12] ->
+      (none)
+    call[bb7 hew_vec_push_i64 -> bb8] ->
+      (none)
+    call[bb8 string$repeat -> bb9] ->
+      (none)
+    branch[bb9: bb10/bb11] ->
+      (none)
+    panic[bb10] ->
+      (none)
+    goto[bb11->bb4] ->
+      (none)
+    cancel[bb11] ->
+      (none)
+    call[bb12 testing$assert_eq -> bb13] ->
+      (none)
+    call[bb13 string$repeat -> bb14] ->
+      (none)
+    call[bb14 testing$assert_eq_str -> bb15] ->
+      (none)
+    return[bb15] ->
+      (none)
+
+fn test_funcupdate_hashmap_field_override_drops_old -> ()
+  statements:
+    bind BindingId(12) init site=SiteId(154) ty=HashMap<string, i64>
+    use BindingId(12) init site=SiteId(157) ty=HashMap<string, i64> intent=Read
+    eval site=SiteId(156) ty=()
+    use BindingId(12) init site=SiteId(161) ty=HashMap<string, i64> intent=Read
+    agg_alias BindingId(12) init site=SiteId(161) ty=HashMap<string, i64>
+    bind BindingId(13) h site=SiteId(160) ty=MapHolder
+    bind BindingId(14) i site=SiteId(163) ty=i64
+    use BindingId(14) i site=SiteId(165) ty=i64 intent=Read
+    eval site=SiteId(181) ty=()
+    use BindingId(13) h site=SiteId(184) ty=MapHolder intent=Read
+    bind BindingId(15) next site=SiteId(167) ty=HashMap<string, i64>
+    use BindingId(15) next site=SiteId(170) ty=HashMap<string, i64> intent=Read
+    use BindingId(14) i site=SiteId(172) ty=i64 intent=Read
+    eval site=SiteId(169) ty=()
+    use BindingId(15) next site=SiteId(175) ty=HashMap<string, i64> intent=Read
+    agg_alias BindingId(15) next site=SiteId(175) ty=HashMap<string, i64>
+    use BindingId(13) h site=SiteId(176) ty=MapHolder intent=Read
+    agg_alias BindingId(13) h site=SiteId(176) ty=MapHolder
+    bind BindingId(13) h site=SiteId(173) ty=MapHolder
+    eval site=SiteId(174) ty=()
+    use BindingId(14) i site=SiteId(179) ty=i64 intent=Read
+    bind BindingId(14) i site=SiteId(177) ty=i64
+    eval site=SiteId(178) ty=()
+    eval site=SiteId(182) ty=()
+    use BindingId(13) h site=SiteId(190) ty=MapHolder intent=Read
+    eval site=SiteId(187) ty=()
+    drop BindingId(15) next ty=HashMap<string, i64>
+    drop BindingId(13) h ty=MapHolder
+    drop BindingId(12) init ty=HashMap<string, i64>
+  drop_plans:
+    call[bb0 HashMap::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 hew_hashmap_insert_layout -> bb2] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    branch[bb3: bb4/bb5] ->
+      (none)
+    call[bb4 HashMap::new -> bb6] ->
+      (none)
+    call[bb5 testing$assert_eq -> bb10] ->
+      (none)
+    call[bb6 hew_hashmap_insert_layout -> bb7] ->
+      (none)
+    branch[bb7: bb8/bb9] ->
+      (none)
+    panic[bb8] ->
+      drop _6 ty=MapHolder kind=record_in_place
+    goto[bb9->bb3] ->
+      (none)
+    cancel[bb9] ->
+      drop _6 ty=MapHolder kind=record_in_place
+    call[bb10 hew_hashmap_len_layout -> bb11] ->
+      (none)
+    call[bb11 testing$assert_eq -> bb12] ->
+      (none)
+    return[bb12] ->
+      drop _6 ty=MapHolder kind=record_in_place
+
+fn test_funcupdate_hashset_field_override_drops_old -> ()
+  statements:
+    bind BindingId(16) init site=SiteId(193) ty=HashSet<i64>
+    use BindingId(16) init site=SiteId(196) ty=HashSet<i64> intent=Read
+    eval site=SiteId(195) ty=bool
+    use BindingId(16) init site=SiteId(199) ty=HashSet<i64> intent=Read
+    agg_alias BindingId(16) init site=SiteId(199) ty=HashSet<i64>
+    bind BindingId(17) h site=SiteId(198) ty=SetHolder
+    bind BindingId(18) i site=SiteId(201) ty=i64
+    use BindingId(18) i site=SiteId(203) ty=i64 intent=Read
+    eval site=SiteId(218) ty=()
+    use BindingId(17) h site=SiteId(221) ty=SetHolder intent=Read
+    bind BindingId(19) next site=SiteId(205) ty=HashSet<i64>
+    use BindingId(19) next site=SiteId(208) ty=HashSet<i64> intent=Read
+    use BindingId(18) i site=SiteId(209) ty=i64 intent=Read
+    eval site=SiteId(207) ty=bool
+    use BindingId(19) next site=SiteId(212) ty=HashSet<i64> intent=Read
+    agg_alias BindingId(19) next site=SiteId(212) ty=HashSet<i64>
+    use BindingId(17) h site=SiteId(213) ty=SetHolder intent=Read
+    agg_alias BindingId(17) h site=SiteId(213) ty=SetHolder
+    bind BindingId(17) h site=SiteId(210) ty=SetHolder
+    eval site=SiteId(211) ty=()
+    use BindingId(18) i site=SiteId(216) ty=i64 intent=Read
+    bind BindingId(18) i site=SiteId(214) ty=i64
+    eval site=SiteId(215) ty=()
+    eval site=SiteId(219) ty=()
+    use BindingId(17) h site=SiteId(227) ty=SetHolder intent=Read
+    eval site=SiteId(224) ty=()
+    drop BindingId(19) next ty=HashSet<i64>
+    drop BindingId(17) h ty=SetHolder
+    drop BindingId(16) init ty=HashSet<i64>
+  drop_plans:
+    call[bb0 HashSet::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 hew_hashset_insert_layout -> bb2] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    branch[bb3: bb4/bb5] ->
+      (none)
+    call[bb4 HashSet::new -> bb6] ->
+      (none)
+    call[bb5 testing$assert_eq -> bb10] ->
+      (none)
+    call[bb6 hew_hashset_insert_layout -> bb7] ->
+      (none)
+    branch[bb7: bb8/bb9] ->
+      (none)
+    panic[bb8] ->
+      drop _6 ty=SetHolder kind=record_in_place
+    goto[bb9->bb3] ->
+      (none)
+    cancel[bb9] ->
+      drop _6 ty=SetHolder kind=record_in_place
+    call[bb10 hew_hashset_len_layout -> bb11] ->
+      (none)
+    call[bb11 testing$assert_eq -> bb12] ->
+      (none)
+    return[bb12] ->
+      drop _6 ty=SetHolder kind=record_in_place
+
+fn testing$assert_eq -> ()
+  statements:
+    use BindingId(20) actual site=SiteId(232) ty=i64 intent=Read
+    use BindingId(21) expected site=SiteId(233) ty=i64 intent=Read
+    use BindingId(21) expected site=SiteId(238) ty=i64 intent=Read
+    return site=Some(SiteId(230)) ty=()
+    use BindingId(20) actual site=SiteId(242) ty=i64 intent=Read
+    eval site=SiteId(235) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    call[bb6 to_string_i64 -> bb7] ->
+      (none)
+    call[bb7 string_concat -> bb8] ->
+      (none)
+    call[bb8 panic -> bb9] ->
+      (none)
+    goto[bb9->bb3] ->
+      (none)
+    cancel[bb9] ->
+      (none)
+
+fn testing$assert_eq_u8 -> ()
+  statements:
+    use BindingId(22) actual site=SiteId(254) ty=u8 intent=Read
+    use BindingId(23) expected site=SiteId(255) ty=u8 intent=Read
+    use BindingId(23) expected site=SiteId(261) ty=u8 intent=Read
+    return site=Some(SiteId(252)) ty=()
+    use BindingId(22) actual site=SiteId(266) ty=u8 intent=Read
+    eval site=SiteId(257) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    call[bb6 to_string_i64 -> bb7] ->
+      (none)
+    call[bb7 string_concat -> bb8] ->
+      (none)
+    call[bb8 panic -> bb9] ->
+      (none)
+    goto[bb9->bb3] ->
+      (none)
+    cancel[bb9] ->
+      (none)
+
+fn testing$assert_ne_u8 -> ()
+  statements:
+    use BindingId(24) a site=SiteId(278) ty=u8 intent=Read
+    use BindingId(25) b site=SiteId(279) ty=u8 intent=Read
+    use BindingId(24) a site=SiteId(285) ty=u8 intent=Read
+    return site=Some(SiteId(276)) ty=()
+    use BindingId(25) b site=SiteId(290) ty=u8 intent=Read
+    eval site=SiteId(281) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    call[bb6 to_string_i64 -> bb7] ->
+      (none)
+    call[bb7 string_concat -> bb8] ->
+      (none)
+    call[bb8 string_concat -> bb9] ->
+      (none)
+    call[bb9 panic -> bb10] ->
+      (none)
+    goto[bb10->bb3] ->
+      (none)
+    cancel[bb10] ->
+      (none)
+
+fn testing$assert_eq_str -> ()
+  statements:
+    use BindingId(26) actual site=SiteId(305) ty=string intent=Read
+    use BindingId(27) expected site=SiteId(306) ty=string intent=Read
+    use BindingId(27) expected site=SiteId(311) ty=string intent=Read
+    return site=Some(SiteId(303)) ty=()
+    use BindingId(26) actual site=SiteId(315) ty=string intent=Read
+    eval site=SiteId(308) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 string::fmt -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    call[bb6 string::fmt -> bb7] ->
+      (none)
+    call[bb7 string_concat -> bb8] ->
+      (none)
+    call[bb8 string_concat -> bb9] ->
+      (none)
+    call[bb9 panic -> bb10] ->
+      (none)
+    goto[bb10->bb3] ->
+      (none)
+    cancel[bb10] ->
+      (none)
+
+fn testing$assert_ne -> ()
+  statements:
+    use BindingId(28) a site=SiteId(330) ty=i64 intent=Read
+    use BindingId(29) b site=SiteId(331) ty=i64 intent=Read
+    use BindingId(28) a site=SiteId(336) ty=i64 intent=Read
+    return site=Some(SiteId(328)) ty=()
+    use BindingId(29) b site=SiteId(340) ty=i64 intent=Read
+    eval site=SiteId(333) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    call[bb6 to_string_i64 -> bb7] ->
+      (none)
+    call[bb7 string_concat -> bb8] ->
+      (none)
+    call[bb8 string_concat -> bb9] ->
+      (none)
+    call[bb9 panic -> bb10] ->
+      (none)
+    goto[bb10->bb3] ->
+      (none)
+    cancel[bb10] ->
+      (none)
+
+fn testing$assert_true -> ()
+  statements:
+    use BindingId(30) condition site=SiteId(355) ty=bool intent=Read
+    return site=Some(SiteId(353)) ty=()
+    eval site=SiteId(357) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 panic -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    goto[bb4->bb3] ->
+      (none)
+    cancel[bb4] ->
+      (none)
+
+fn testing$assert_false -> ()
+  statements:
+    use BindingId(31) condition site=SiteId(361) ty=bool intent=Read
+    return site=Some(SiteId(360)) ty=()
+    eval site=SiteId(363) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 panic -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    goto[bb4->bb3] ->
+      (none)
+    cancel[bb4] ->
+      (none)
+
+fn testing$assert_gt -> ()
+  statements:
+    use BindingId(32) a site=SiteId(368) ty=i64 intent=Read
+    use BindingId(33) b site=SiteId(369) ty=i64 intent=Read
+    use BindingId(32) a site=SiteId(374) ty=i64 intent=Read
+    return site=Some(SiteId(366)) ty=()
+    use BindingId(33) b site=SiteId(378) ty=i64 intent=Read
+    eval site=SiteId(371) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    call[bb6 to_string_i64 -> bb7] ->
+      (none)
+    call[bb7 string_concat -> bb8] ->
+      (none)
+    call[bb8 panic -> bb9] ->
+      (none)
+    goto[bb9->bb3] ->
+      (none)
+    cancel[bb9] ->
+      (none)
+
+fn testing$assert_lt -> ()
+  statements:
+    use BindingId(34) a site=SiteId(390) ty=i64 intent=Read
+    use BindingId(35) b site=SiteId(391) ty=i64 intent=Read
+    use BindingId(34) a site=SiteId(396) ty=i64 intent=Read
+    return site=Some(SiteId(388)) ty=()
+    use BindingId(35) b site=SiteId(400) ty=i64 intent=Read
+    eval site=SiteId(393) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    call[bb6 to_string_i64 -> bb7] ->
+      (none)
+    call[bb7 string_concat -> bb8] ->
+      (none)
+    call[bb8 panic -> bb9] ->
+      (none)
+    goto[bb9->bb3] ->
+      (none)
+    cancel[bb9] ->
+      (none)
+
+fn string$from_int -> string
+  statements:
+    use BindingId(36) n site=SiteId(411) ty=i64 intent=Read
+    return site=Some(SiteId(410)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string$from_float -> string
+  statements:
+    use BindingId(37) f site=SiteId(415) ty=f64 intent=Read
+    return site=Some(SiteId(414)) ty=string
+  drop_plans:
+    call[bb0 to_string_f64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string$from_bool -> string
+  statements:
+    use BindingId(38) b site=SiteId(419) ty=bool intent=Read
+    return site=Some(SiteId(418)) ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    goto[bb1->bb3] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+
+fn string$from_char -> string
+  statements:
+    use BindingId(39) code site=SiteId(427) ty=i64 intent=Read
+    use BindingId(39) code site=SiteId(430) ty=i64 intent=Read
+    use BindingId(39) code site=SiteId(434) ty=i64 intent=Read
+    use BindingId(39) code site=SiteId(437) ty=i64 intent=Read
+    use BindingId(39) code site=SiteId(442) ty=i64 intent=Read
+    eval site=SiteId(449) ty=()
+    use BindingId(39) code site=SiteId(453) ty=i64 intent=Read
+    eval site=SiteId(439) ty=!
+    return site=Some(SiteId(450)) ty=string
+  drop_plans:
+    branch[bb0: bb2/bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    goto[bb1->bb2] ->
+      (none)
+    branch[bb2: bb4/bb3] ->
+      (none)
+    branch[bb3: bb5/bb6] ->
+      (none)
+    branch[bb4: bb7/bb8] ->
+      (none)
+    goto[bb5->bb6] ->
+      (none)
+    goto[bb6->bb4] ->
+      (none)
+    cancel[bb6] ->
+      (none)
+    call[bb7 to_string_i64 -> bb10] ->
+      (none)
+    goto[bb8->bb9] ->
+      (none)
+    call[bb9 hew_char_to_string -> bb13] ->
+      (none)
+    call[bb10 string_concat -> bb11] ->
+      (none)
+    call[bb11 panic -> bb12] ->
+      (none)
+    goto[bb12->bb9] ->
+      (none)
+    cancel[bb12] ->
+      (none)
+    return[bb13] ->
+      (none)
+
+fn string$to_int -> Option<i64>
+  statements:
+    use BindingId(40) s site=SiteId(457) ty=string intent=Read
+    bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(456) ty=Result<i64, string>
+    return site=Some(SiteId(455)) ty=Option<i64>
+    bind BindingId(41) value site=SiteId(459) ty=i64
+    use BindingId(41) value site=SiteId(460) ty=i64 intent=Read
+    drop BindingId(4294967231) __hew_call_scrutinee ty=Result<i64, string>
+  drop_plans:
+    call[bb0 string$try_to_int -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb3/bb6] ->
+      (none)
+    return[bb2] ->
+      drop _2 ty=Result<i64, string> kind=enum_in_place
+    goto[bb3->bb2] ->
+      (none)
+    cancel[bb3] ->
+      drop _2 ty=Result<i64, string> kind=enum_in_place
+    goto[bb4->bb2] ->
+      (none)
+    cancel[bb4] ->
+      drop _2 ty=Result<i64, string> kind=enum_in_place
+    panic[bb5] ->
+      drop _2 ty=Result<i64, string> kind=enum_in_place
+    branch[bb6: bb4/bb5] ->
+      (none)
+
+fn string$try_to_int -> Result<i64, string>
+  statements:
+    use BindingId(42) s site=SiteId(463) ty=string intent=Read
+    bind BindingId(43) slen site=SiteId(462) ty=i64
+    use BindingId(43) slen site=SiteId(466) ty=i64 intent=Read
+    return site=Some(SiteId(468)) ty=Result<i64, string>
+    eval site=SiteId(471) ty=()
+    bind BindingId(44) start site=SiteId(472) ty=i64
+    bind BindingId(45) negative site=SiteId(473) ty=bool
+    use BindingId(42) s site=SiteId(475) ty=string intent=Read
+    bind BindingId(46) first site=SiteId(474) ty=string
+    use BindingId(46) first site=SiteId(480) ty=string intent=Read
+    bind BindingId(45) negative site=SiteId(482) ty=bool
+    eval site=SiteId(483) ty=()
+    bind BindingId(44) start site=SiteId(484) ty=i64
+    eval site=SiteId(485) ty=()
+    use BindingId(46) first site=SiteId(488) ty=string intent=Read
+    eval site=SiteId(494) ty=()
+    use BindingId(44) start site=SiteId(496) ty=i64 intent=Read
+    use BindingId(43) slen site=SiteId(497) ty=i64 intent=Read
+    bind BindingId(44) start site=SiteId(490) ty=i64
+    eval site=SiteId(491) ty=()
+    return site=Some(SiteId(498)) ty=Result<i64, string>
+    eval site=SiteId(501) ty=()
+    bind BindingId(47) cutoff site=SiteId(502) ty=i64
+    use BindingId(45) negative site=SiteId(504) ty=bool intent=Read
+    bind BindingId(48) max_last_digit site=SiteId(503) ty=i64
+    bind BindingId(49) result site=SiteId(509) ty=i64
+    bind BindingId(50) i site=SiteId(0) ty=i64
+    use BindingId(42) s site=SiteId(514) ty=string intent=Read
+    use BindingId(50) i site=SiteId(515) ty=i64 intent=Read
+    use BindingId(50) i site=SiteId(517) ty=i64 intent=Read
+    eval site=SiteId(555) ty=()
+    use BindingId(45) negative site=SiteId(557) ty=bool intent=Read
+    use BindingId(44) start site=SiteId(510) ty=i64 intent=Read
+    use BindingId(43) slen site=SiteId(511) ty=i64 intent=Read
+    bind BindingId(51) digit site=SiteId(513) ty=string
+    use BindingId(51) digit site=SiteId(521) ty=string intent=Read
+    bind BindingId(52) d site=SiteId(520) ty=i64
+    use BindingId(51) digit site=SiteId(525) ty=string intent=Read
+    eval site=SiteId(523) ty=()
+    use BindingId(52) d site=SiteId(528) ty=i64 intent=Read
+    return site=Some(SiteId(530)) ty=Result<i64, string>
+    eval site=SiteId(533) ty=()
+    use BindingId(49) result site=SiteId(536) ty=i64 intent=Read
+    use BindingId(47) cutoff site=SiteId(537) ty=i64 intent=Read
+    use BindingId(49) result site=SiteId(540) ty=i64 intent=Read
+    use BindingId(47) cutoff site=SiteId(541) ty=i64 intent=Read
+    use BindingId(52) d site=SiteId(543) ty=i64 intent=Read
+    use BindingId(48) max_last_digit site=SiteId(544) ty=i64 intent=Read
+    return site=Some(SiteId(545)) ty=Result<i64, string>
+    eval site=SiteId(548) ty=()
+    use BindingId(49) result site=SiteId(552) ty=i64 intent=Read
+    use BindingId(52) d site=SiteId(554) ty=i64 intent=Read
+    bind BindingId(49) result site=SiteId(549) ty=i64
+    eval site=SiteId(550) ty=()
+    use BindingId(49) result site=SiteId(560) ty=i64 intent=Read
+    use BindingId(49) result site=SiteId(565) ty=i64 intent=Read
+    return site=Some(SiteId(556)) ty=Result<i64, string>
+    drop BindingId(51) digit ty=string
+    drop BindingId(46) first ty=string
+  drop_plans:
+    call[bb0 hew_string_length -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb2/bb3] ->
+      (none)
+    return[bb2] ->
+      (none)
+    goto[bb3->bb4] ->
+      (none)
+    call[bb4 hew_string_slice -> bb6] ->
+      (none)
+    goto[bb5->bb4] ->
+      (none)
+    cancel[bb5] ->
+      (none)
+    branch[bb6: bb7/bb8] ->
+      (none)
+    goto[bb7->bb9] ->
+      (none)
+    branch[bb8: bb10/bb11] ->
+      (none)
+    branch[bb9: bb13/bb14] ->
+      (none)
+    goto[bb10->bb12] ->
+      (none)
+    goto[bb11->bb12] ->
+      (none)
+    goto[bb12->bb9] ->
+      (none)
+    cancel[bb12] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+    return[bb13] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb14->bb15] ->
+      (none)
+    branch[bb15: bb17/bb18] ->
+      (none)
+    goto[bb16->bb15] ->
+      (none)
+    cancel[bb16] ->
+      (none)
+    goto[bb17->bb19] ->
+      (none)
+    goto[bb18->bb19] ->
+      (none)
+    branch[bb19: bb24/bb25] ->
+      (none)
+    branch[bb20: bb21/bb23] ->
+      (none)
+    branch[bb21: bb26/bb27] ->
+      (none)
+    branch[bb22: bb47/bb20] ->
+      (none)
+    branch[bb23: bb48/bb49] ->
+      (none)
+    panic[bb24] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb25->bb20] ->
+      (none)
+    cancel[bb25] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+    panic[bb26] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+    call[bb27 hew_string_slice -> bb28] ->
+      (none)
+    call[bb28 string$digit_value -> bb29] ->
+      (none)
+    call[bb29 hew_string_drop -> bb30] ->
+      (none)
+    branch[bb30: bb31/bb32] ->
+      (none)
+    return[bb31] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb32->bb33] ->
+      (none)
+    branch[bb33: bb36/bb35] ->
+      (none)
+    goto[bb34->bb33] ->
+      (none)
+    cancel[bb34] ->
+      (none)
+    branch[bb35: bb37/bb38] ->
+      (none)
+    branch[bb36: bb39/bb40] ->
+      (none)
+    goto[bb37->bb38] ->
+      (none)
+    goto[bb38->bb36] ->
+      (none)
+    cancel[bb38] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+    return[bb39] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb40->bb41] ->
+      (none)
+    branch[bb41: bb43/bb44] ->
+      (none)
+    goto[bb42->bb41] ->
+      (none)
+    cancel[bb42] ->
+      (none)
+    panic[bb43] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+    branch[bb44: bb45/bb46] ->
+      (none)
+    panic[bb45] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb46->bb22] ->
+      (none)
+    cancel[bb46] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+    panic[bb47] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb48->bb50] ->
+      (none)
+    branch[bb49: bb51/bb52] ->
+      (none)
+    return[bb50] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+    panic[bb51] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb52->bb50] ->
+      (none)
+    cancel[bb52] ->
+      drop _16 ty=string kind=cow_heap(hew_string_drop)
+
+fn string$to_float -> f64
+  statements:
+    use BindingId(53) s site=SiteId(568) ty=string intent=Read
+    bind BindingId(4294967231) __hew_call_scrutinee site=SiteId(567) ty=Result<f64, string>
+    return site=Some(SiteId(566)) ty=f64
+    bind BindingId(54) value site=SiteId(570) ty=f64
+    use BindingId(54) value site=SiteId(570) ty=f64 intent=Read
+    drop BindingId(4294967231) __hew_call_scrutinee ty=Result<f64, string>
+  drop_plans:
+    call[bb0 string$try_to_float -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb3/bb6] ->
+      (none)
+    return[bb2] ->
+      drop _2 ty=Result<f64, string> kind=enum_in_place
+    goto[bb3->bb2] ->
+      (none)
+    cancel[bb3] ->
+      drop _2 ty=Result<f64, string> kind=enum_in_place
+    goto[bb4->bb2] ->
+      (none)
+    cancel[bb4] ->
+      drop _2 ty=Result<f64, string> kind=enum_in_place
+    panic[bb5] ->
+      drop _2 ty=Result<f64, string> kind=enum_in_place
+    branch[bb6: bb4/bb5] ->
+      (none)
+
+fn string$try_to_float -> Result<f64, string>
+  statements:
+    use BindingId(55) s site=SiteId(574) ty=string intent=Read
+    use BindingId(55) s site=SiteId(579) ty=string intent=Read
+    return site=Some(SiteId(572)) ty=Result<f64, string>
+  drop_plans:
+    call[bb0 string$is_valid_float_literal -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb2/bb3] ->
+      (none)
+    call[bb2 string$parse_valid_float_literal -> bb5] ->
+      (none)
+    goto[bb3->bb4] ->
+      (none)
+    return[bb4] ->
+      (none)
+    goto[bb5->bb4] ->
+      (none)
+    cancel[bb5] ->
+      (none)
+
+fn string$is_valid_float_literal -> bool
+  statements:
+    use BindingId(56) s site=SiteId(585) ty=string intent=Read
+    bind BindingId(57) slen site=SiteId(584) ty=i64
+    use BindingId(57) slen site=SiteId(588) ty=i64 intent=Read
+    return site=Some(SiteId(590)) ty=bool
+    eval site=SiteId(592) ty=()
+    use BindingId(56) s site=SiteId(594) ty=string intent=Read
+    use BindingId(57) slen site=SiteId(595) ty=i64 intent=Read
+    bind BindingId(58) start site=SiteId(593) ty=i64
+    use BindingId(58) start site=SiteId(598) ty=i64 intent=Read
+    return site=Some(SiteId(600)) ty=bool
+    eval site=SiteId(602) ty=()
+    use BindingId(56) s site=SiteId(604) ty=string intent=Read
+    use BindingId(58) start site=SiteId(605) ty=i64 intent=Read
+    use BindingId(57) slen site=SiteId(606) ty=i64 intent=Read
+    bind BindingId(59) exponent_index site=SiteId(603) ty=i64
+    use BindingId(59) exponent_index site=SiteId(609) ty=i64 intent=Read
+    return site=Some(SiteId(611)) ty=bool
+    eval site=SiteId(613) ty=()
+    use BindingId(59) exponent_index site=SiteId(616) ty=i64 intent=Read
+    use BindingId(57) slen site=SiteId(619) ty=i64 intent=Read
+    use BindingId(59) exponent_index site=SiteId(621) ty=i64 intent=Read
+    bind BindingId(60) significand_end site=SiteId(614) ty=i64
+    use BindingId(56) s site=SiteId(624) ty=string intent=Read
+    use BindingId(58) start site=SiteId(625) ty=i64 intent=Read
+    use BindingId(60) significand_end site=SiteId(626) ty=i64 intent=Read
+    return site=Some(SiteId(628)) ty=bool
+    eval site=SiteId(630) ty=()
+    use BindingId(59) exponent_index site=SiteId(632) ty=i64 intent=Read
+    use BindingId(56) s site=SiteId(635) ty=string intent=Read
+    use BindingId(59) exponent_index site=SiteId(637) ty=i64 intent=Read
+    eval site=SiteId(642) ty=()
+    return site=Some(SiteId(643)) ty=bool
+    use BindingId(57) slen site=SiteId(639) ty=i64 intent=Read
+    return site=Some(SiteId(634)) ty=bool
+  drop_plans:
+    call[bb0 hew_string_length -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb2/bb3] ->
+      (none)
+    return[bb2] ->
+      (none)
+    goto[bb3->bb4] ->
+      (none)
+    call[bb4 string$float_parse_start -> bb6] ->
+      (none)
+    goto[bb5->bb4] ->
+      (none)
+    cancel[bb5] ->
+      (none)
+    branch[bb6: bb7/bb8] ->
+      (none)
+    return[bb7] ->
+      (none)
+    goto[bb8->bb9] ->
+      (none)
+    call[bb9 string$find_exponent_index -> bb11] ->
+      (none)
+    goto[bb10->bb9] ->
+      (none)
+    cancel[bb10] ->
+      (none)
+    branch[bb11: bb12/bb13] ->
+      (none)
+    return[bb12] ->
+      (none)
+    goto[bb13->bb14] ->
+      (none)
+    branch[bb14: bb16/bb17] ->
+      (none)
+    goto[bb15->bb14] ->
+      (none)
+    cancel[bb15] ->
+      (none)
+    goto[bb16->bb18] ->
+      (none)
+    goto[bb17->bb18] ->
+      (none)
+    call[bb18 string$is_valid_float_significand -> bb19] ->
+      (none)
+    branch[bb19: bb20/bb21] ->
+      (none)
+    return[bb20] ->
+      (none)
+    goto[bb21->bb22] ->
+      (none)
+    branch[bb22: bb24/bb25] ->
+      (none)
+    goto[bb23->bb22] ->
+      (none)
+    cancel[bb23] ->
+      (none)
+    branch[bb24: bb27/bb28] ->
+      (none)
+    goto[bb25->bb26] ->
+      (none)
+    return[bb26] ->
+      (none)
+    panic[bb27] ->
+      (none)
+    call[bb28 string$is_valid_float_exponent -> bb29] ->
+      (none)
+    return[bb29] ->
+      (none)
+    goto[bb30->bb26] ->
+      (none)
+    cancel[bb30] ->
+      (none)
+
+fn string$float_parse_start -> i64
+  statements:
+    bind BindingId(63) start site=SiteId(644) ty=i64
+    use BindingId(61) s site=SiteId(646) ty=string intent=Read
+    bind BindingId(64) first site=SiteId(645) ty=string
+    use BindingId(64) first site=SiteId(652) ty=string intent=Read
+    use BindingId(64) first site=SiteId(655) ty=string intent=Read
+    bind BindingId(65) has_sign site=SiteId(650) ty=bool
+    use BindingId(64) first site=SiteId(659) ty=string intent=Read
+    eval site=SiteId(657) ty=()
+    use BindingId(65) has_sign site=SiteId(661) ty=bool intent=Read
+    bind BindingId(63) start site=SiteId(662) ty=i64
+    eval site=SiteId(663) ty=()
+    eval site=SiteId(665) ty=()
+    use BindingId(63) start site=SiteId(667) ty=i64 intent=Read
+    use BindingId(62) slen site=SiteId(668) ty=i64 intent=Read
+    return site=Some(SiteId(669)) ty=i64
+    eval site=SiteId(671) ty=()
+    use BindingId(63) start site=SiteId(672) ty=i64 intent=Read
+    return site=Some(SiteId(672)) ty=i64
+    drop BindingId(64) first ty=string
+  drop_plans:
+    call[bb0 hew_string_slice -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb3/bb2] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    call[bb3 hew_string_drop -> bb4] ->
+      (none)
+    branch[bb4: bb5/bb6] ->
+      (none)
+    goto[bb5->bb7] ->
+      (none)
+    goto[bb6->bb7] ->
+      (none)
+    branch[bb7: bb8/bb9] ->
+      (none)
+    return[bb8] ->
+      (none)
+    goto[bb9->bb10] ->
+      (none)
+    return[bb10] ->
+      (none)
+    goto[bb11->bb10] ->
+      (none)
+    cancel[bb11] ->
+      (none)
+
+fn string$parse_valid_float_literal -> f64
+  statements:
+    use BindingId(66) s site=SiteId(674) ty=string intent=Read
+    bind BindingId(67) slen site=SiteId(673) ty=i64
+    use BindingId(66) s site=SiteId(677) ty=string intent=Read
+    use BindingId(67) slen site=SiteId(678) ty=i64 intent=Read
+    bind BindingId(68) start site=SiteId(676) ty=i64
+    use BindingId(66) s site=SiteId(681) ty=string intent=Read
+    bind BindingId(69) first site=SiteId(680) ty=string
+    use BindingId(69) first site=SiteId(686) ty=string intent=Read
+    bind BindingId(70) negative site=SiteId(685) ty=bool
+    use BindingId(69) first site=SiteId(690) ty=string intent=Read
+    eval site=SiteId(688) ty=()
+    use BindingId(66) s site=SiteId(693) ty=string intent=Read
+    use BindingId(68) start site=SiteId(694) ty=i64 intent=Read
+    use BindingId(67) slen site=SiteId(695) ty=i64 intent=Read
+    bind BindingId(71) exponent_index site=SiteId(692) ty=i64
+    use BindingId(71) exponent_index site=SiteId(699) ty=i64 intent=Read
+    use BindingId(67) slen site=SiteId(702) ty=i64 intent=Read
+    use BindingId(71) exponent_index site=SiteId(704) ty=i64 intent=Read
+    bind BindingId(72) significand_end site=SiteId(697) ty=i64
+    use BindingId(66) s site=SiteId(706) ty=string intent=Read
+    use BindingId(68) start site=SiteId(707) ty=i64 intent=Read
+    use BindingId(72) significand_end site=SiteId(708) ty=i64 intent=Read
+    bind BindingId(73) value site=SiteId(705) ty=f64
+    use BindingId(71) exponent_index site=SiteId(711) ty=i64 intent=Read
+    use BindingId(66) s site=SiteId(714) ty=string intent=Read
+    use BindingId(71) exponent_index site=SiteId(716) ty=i64 intent=Read
+    eval site=SiteId(726) ty=()
+    use BindingId(70) negative site=SiteId(728) ty=bool intent=Read
+    use BindingId(67) slen site=SiteId(718) ty=i64 intent=Read
+    bind BindingId(74) exponent site=SiteId(713) ty=i64
+    use BindingId(73) value site=SiteId(722) ty=f64 intent=Read
+    use BindingId(74) exponent site=SiteId(723) ty=i64 intent=Read
+    bind BindingId(73) value site=SiteId(720) ty=f64
+    eval site=SiteId(721) ty=()
+    use BindingId(73) value site=SiteId(732) ty=f64 intent=Read
+    use BindingId(73) value site=SiteId(734) ty=f64 intent=Read
+    return site=Some(SiteId(727)) ty=f64
+    drop BindingId(69) first ty=string
+  drop_plans:
+    call[bb0 hew_string_length -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 string$float_parse_start -> bb2] ->
+      (none)
+    call[bb2 hew_string_slice -> bb3] ->
+      (none)
+    call[bb3 hew_string_drop -> bb4] ->
+      (none)
+    call[bb4 string$find_exponent_index -> bb5] ->
+      (none)
+    branch[bb5: bb6/bb7] ->
+      (none)
+    goto[bb6->bb8] ->
+      (none)
+    goto[bb7->bb8] ->
+      (none)
+    call[bb8 string$parse_float_significand -> bb9] ->
+      (none)
+    branch[bb9: bb10/bb11] ->
+      (none)
+    branch[bb10: bb13/bb14] ->
+      (none)
+    goto[bb11->bb12] ->
+      (none)
+    branch[bb12: bb17/bb18] ->
+      (none)
+    panic[bb13] ->
+      (none)
+    call[bb14 string$parse_float_exponent -> bb15] ->
+      (none)
+    call[bb15 string$apply_float_exponent -> bb16] ->
+      (none)
+    goto[bb16->bb12] ->
+      (none)
+    cancel[bb16] ->
+      (none)
+    goto[bb17->bb19] ->
+      (none)
+    goto[bb18->bb19] ->
+      (none)
+    return[bb19] ->
+      (none)
+
+fn string$digit_value -> i64
+  statements:
+    use BindingId(75) ch site=SiteId(736) ty=string intent=Read
+    return site=Some(SiteId(735)) ty=i64
+  drop_plans:
+    goto[bb0->bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+    branch[bb2: bb14/bb3] ->
+      (none)
+    branch[bb3: bb15/bb4] ->
+      (none)
+    branch[bb4: bb16/bb5] ->
+      (none)
+    branch[bb5: bb17/bb6] ->
+      (none)
+    branch[bb6: bb18/bb7] ->
+      (none)
+    branch[bb7: bb19/bb8] ->
+      (none)
+    branch[bb8: bb20/bb9] ->
+      (none)
+    branch[bb9: bb21/bb10] ->
+      (none)
+    branch[bb10: bb22/bb11] ->
+      (none)
+    branch[bb11: bb23/bb12] ->
+      (none)
+    goto[bb12->bb1] ->
+      (none)
+    cancel[bb12] ->
+      (none)
+    panic[bb13] ->
+      (none)
+    goto[bb14->bb1] ->
+      (none)
+    cancel[bb14] ->
+      (none)
+    goto[bb15->bb1] ->
+      (none)
+    cancel[bb15] ->
+      (none)
+    goto[bb16->bb1] ->
+      (none)
+    cancel[bb16] ->
+      (none)
+    goto[bb17->bb1] ->
+      (none)
+    cancel[bb17] ->
+      (none)
+    goto[bb18->bb1] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    goto[bb19->bb1] ->
+      (none)
+    cancel[bb19] ->
+      (none)
+    goto[bb20->bb1] ->
+      (none)
+    cancel[bb20] ->
+      (none)
+    goto[bb21->bb1] ->
+      (none)
+    cancel[bb21] ->
+      (none)
+    goto[bb22->bb1] ->
+      (none)
+    cancel[bb22] ->
+      (none)
+    goto[bb23->bb1] ->
+      (none)
+    cancel[bb23] ->
+      (none)
+
+fn string$find_exponent_index -> i64
+  statements:
+    bind BindingId(79) exponent_index site=SiteId(748) ty=i64
+    bind BindingId(80) i site=SiteId(0) ty=i64
+    use BindingId(76) s site=SiteId(753) ty=string intent=Read
+    use BindingId(80) i site=SiteId(754) ty=i64 intent=Read
+    use BindingId(80) i site=SiteId(756) ty=i64 intent=Read
+    eval site=SiteId(781) ty=()
+    use BindingId(79) exponent_index site=SiteId(782) ty=i64 intent=Read
+    return site=Some(SiteId(782)) ty=i64
+    use BindingId(77) start site=SiteId(749) ty=i64 intent=Read
+    use BindingId(78) end site=SiteId(750) ty=i64 intent=Read
+    bind BindingId(81) ch site=SiteId(752) ty=string
+    use BindingId(81) ch site=SiteId(761) ty=string intent=Read
+    use BindingId(81) ch site=SiteId(764) ty=string intent=Read
+    bind BindingId(82) is_exponent site=SiteId(759) ty=bool
+    use BindingId(81) ch site=SiteId(768) ty=string intent=Read
+    eval site=SiteId(766) ty=()
+    use BindingId(82) is_exponent site=SiteId(771) ty=bool intent=Read
+    use BindingId(79) exponent_index site=SiteId(774) ty=i64 intent=Read
+    return site=Some(SiteId(776)) ty=i64
+    eval site=SiteId(778) ty=()
+    use BindingId(80) i site=SiteId(780) ty=i64 intent=Consume
+    bind BindingId(79) exponent_index site=SiteId(779) ty=i64
+    eval site=SiteId(780) ty=()
+    drop BindingId(81) ch ty=string
+  drop_plans:
+    branch[bb0: bb5/bb6] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb2/bb4] ->
+      (none)
+    branch[bb2: bb7/bb8] ->
+      (none)
+    branch[bb3: bb20/bb1] ->
+      (none)
+    return[bb4] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    goto[bb6->bb1] ->
+      (none)
+    cancel[bb6] ->
+      (none)
+    panic[bb7] ->
+      (none)
+    call[bb8 hew_string_slice -> bb9] ->
+      (none)
+    branch[bb9: bb11/bb10] ->
+      (none)
+    goto[bb10->bb11] ->
+      (none)
+    call[bb11 hew_string_drop -> bb12] ->
+      (none)
+    branch[bb12: bb13/bb14] ->
+      (none)
+    branch[bb13: bb16/bb17] ->
+      (none)
+    goto[bb14->bb15] ->
+      (none)
+    goto[bb15->bb3] ->
+      (none)
+    cancel[bb15] ->
+      (none)
+    return[bb16] ->
+      (none)
+    goto[bb17->bb18] ->
+      (none)
+    goto[bb18->bb15] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    goto[bb19->bb18] ->
+      (none)
+    cancel[bb19] ->
+      (none)
+    panic[bb20] ->
+      (none)
+
+fn string$is_valid_float_significand -> bool
+  statements:
+    use BindingId(84) start site=SiteId(784) ty=i64 intent=Read
+    use BindingId(85) end site=SiteId(785) ty=i64 intent=Read
+    return site=Some(SiteId(786)) ty=bool
+    eval site=SiteId(788) ty=()
+    bind BindingId(86) saw_digit site=SiteId(789) ty=bool
+    bind BindingId(87) saw_decimal site=SiteId(790) ty=bool
+    bind BindingId(88) i site=SiteId(0) ty=i64
+    use BindingId(83) s site=SiteId(795) ty=string intent=Read
+    use BindingId(88) i site=SiteId(796) ty=i64 intent=Read
+    use BindingId(88) i site=SiteId(798) ty=i64 intent=Read
+    eval site=SiteId(833) ty=()
+    use BindingId(86) saw_digit site=SiteId(834) ty=bool intent=Read
+    return site=Some(SiteId(834)) ty=bool
+    use BindingId(84) start site=SiteId(791) ty=i64 intent=Read
+    use BindingId(85) end site=SiteId(792) ty=i64 intent=Read
+    bind BindingId(89) ch site=SiteId(794) ty=string
+    use BindingId(89) ch site=SiteId(802) ty=string intent=Read
+    bind BindingId(90) is_decimal site=SiteId(801) ty=bool
+    use BindingId(90) is_decimal site=SiteId(805) ty=bool intent=Read
+    use BindingId(89) ch site=SiteId(809) ty=string intent=Read
+    use BindingId(89) ch site=SiteId(819) ty=string intent=Read
+    eval site=SiteId(807) ty=()
+    use BindingId(87) saw_decimal site=SiteId(811) ty=bool intent=Read
+    return site=Some(SiteId(812)) ty=bool
+    eval site=SiteId(814) ty=()
+    bind BindingId(87) saw_decimal site=SiteId(815) ty=bool
+    eval site=SiteId(816) ty=()
+    bind BindingId(91) digit site=SiteId(818) ty=i64
+    use BindingId(89) ch site=SiteId(823) ty=string intent=Read
+    eval site=SiteId(821) ty=()
+    use BindingId(91) digit site=SiteId(826) ty=i64 intent=Read
+    return site=Some(SiteId(828)) ty=bool
+    eval site=SiteId(830) ty=()
+    bind BindingId(86) saw_digit site=SiteId(831) ty=bool
+    eval site=SiteId(832) ty=()
+    drop BindingId(89) ch ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    branch[bb3: bb9/bb10] ->
+      (none)
+    goto[bb4->bb3] ->
+      (none)
+    cancel[bb4] ->
+      (none)
+    branch[bb5: bb6/bb8] ->
+      (none)
+    branch[bb6: bb11/bb12] ->
+      (none)
+    branch[bb7: bb28/bb5] ->
+      (none)
+    return[bb8] ->
+      (none)
+    panic[bb9] ->
+      (none)
+    goto[bb10->bb5] ->
+      (none)
+    cancel[bb10] ->
+      (none)
+    panic[bb11] ->
+      (none)
+    call[bb12 hew_string_slice -> bb13] ->
+      (none)
+    branch[bb13: bb14/bb15] ->
+      (none)
+    call[bb14 hew_string_drop -> bb17] ->
+      (none)
+    call[bb15 string$digit_value -> bb22] ->
+      (none)
+    goto[bb16->bb7] ->
+      (none)
+    cancel[bb16] ->
+      (none)
+    branch[bb17: bb18/bb19] ->
+      (none)
+    return[bb18] ->
+      (none)
+    goto[bb19->bb20] ->
+      (none)
+    goto[bb20->bb16] ->
+      (none)
+    cancel[bb20] ->
+      (none)
+    goto[bb21->bb20] ->
+      (none)
+    cancel[bb21] ->
+      (none)
+    call[bb22 hew_string_drop -> bb23] ->
+      (none)
+    branch[bb23: bb24/bb25] ->
+      (none)
+    return[bb24] ->
+      (none)
+    goto[bb25->bb26] ->
+      (none)
+    goto[bb26->bb16] ->
+      (none)
+    cancel[bb26] ->
+      (none)
+    goto[bb27->bb26] ->
+      (none)
+    cancel[bb27] ->
+      (none)
+    panic[bb28] ->
+      (none)
+
+fn string$is_valid_float_exponent -> bool
+  statements:
+    use BindingId(93) start site=SiteId(836) ty=i64 intent=Read
+    use BindingId(94) end site=SiteId(837) ty=i64 intent=Read
+    return site=Some(SiteId(838)) ty=bool
+    eval site=SiteId(840) ty=()
+    use BindingId(93) start site=SiteId(841) ty=i64 intent=Consume
+    bind BindingId(95) index site=SiteId(841) ty=i64
+    use BindingId(92) s site=SiteId(843) ty=string intent=Read
+    use BindingId(93) start site=SiteId(844) ty=i64 intent=Read
+    use BindingId(93) start site=SiteId(846) ty=i64 intent=Read
+    bind BindingId(96) first site=SiteId(842) ty=string
+    use BindingId(96) first site=SiteId(851) ty=string intent=Read
+    use BindingId(96) first site=SiteId(854) ty=string intent=Read
+    bind BindingId(97) has_sign site=SiteId(849) ty=bool
+    use BindingId(96) first site=SiteId(858) ty=string intent=Read
+    eval site=SiteId(856) ty=()
+    use BindingId(97) has_sign site=SiteId(860) ty=bool intent=Read
+    use BindingId(93) start site=SiteId(863) ty=i64 intent=Read
+    eval site=SiteId(866) ty=()
+    use BindingId(95) index site=SiteId(868) ty=i64 intent=Read
+    use BindingId(94) end site=SiteId(869) ty=i64 intent=Read
+    bind BindingId(95) index site=SiteId(861) ty=i64
+    eval site=SiteId(862) ty=()
+    return site=Some(SiteId(870)) ty=bool
+    eval site=SiteId(872) ty=()
+    bind BindingId(98) i site=SiteId(0) ty=i64
+    use BindingId(92) s site=SiteId(877) ty=string intent=Read
+    use BindingId(98) i site=SiteId(878) ty=i64 intent=Read
+    use BindingId(98) i site=SiteId(880) ty=i64 intent=Read
+    eval site=SiteId(896) ty=()
+    return site=Some(SiteId(897)) ty=bool
+    use BindingId(95) index site=SiteId(873) ty=i64 intent=Read
+    use BindingId(94) end site=SiteId(874) ty=i64 intent=Read
+    bind BindingId(99) digit site=SiteId(876) ty=string
+    use BindingId(99) digit site=SiteId(884) ty=string intent=Read
+    bind BindingId(100) value site=SiteId(883) ty=i64
+    use BindingId(99) digit site=SiteId(888) ty=string intent=Read
+    eval site=SiteId(886) ty=()
+    use BindingId(100) value site=SiteId(892) ty=i64 intent=Read
+    return site=Some(SiteId(895)) ty=bool
+    drop BindingId(99) digit ty=string
+    drop BindingId(96) first ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    branch[bb3: bb5/bb6] ->
+      (none)
+    goto[bb4->bb3] ->
+      (none)
+    cancel[bb4] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    call[bb6 hew_string_slice -> bb7] ->
+      (none)
+    branch[bb7: bb9/bb8] ->
+      (none)
+    goto[bb8->bb9] ->
+      (none)
+    call[bb9 hew_string_drop -> bb10] ->
+      (none)
+    branch[bb10: bb11/bb12] ->
+      (none)
+    branch[bb11: bb14/bb15] ->
+      (none)
+    goto[bb12->bb13] ->
+      (none)
+    branch[bb13: bb16/bb17] ->
+      (none)
+    panic[bb14] ->
+      (none)
+    goto[bb15->bb13] ->
+      (none)
+    cancel[bb15] ->
+      (none)
+    return[bb16] ->
+      (none)
+    goto[bb17->bb18] ->
+      (none)
+    branch[bb18: bb24/bb25] ->
+      (none)
+    goto[bb19->bb18] ->
+      (none)
+    cancel[bb19] ->
+      (none)
+    branch[bb20: bb21/bb23] ->
+      (none)
+    branch[bb21: bb26/bb27] ->
+      (none)
+    branch[bb22: bb35/bb20] ->
+      (none)
+    return[bb23] ->
+      (none)
+    panic[bb24] ->
+      (none)
+    goto[bb25->bb20] ->
+      (none)
+    cancel[bb25] ->
+      (none)
+    panic[bb26] ->
+      (none)
+    call[bb27 hew_string_slice -> bb28] ->
+      (none)
+    call[bb28 string$digit_value -> bb29] ->
+      (none)
+    call[bb29 hew_string_drop -> bb30] ->
+      (none)
+    branch[bb30: bb31/bb32] ->
+      (none)
+    return[bb31] ->
+      (none)
+    goto[bb32->bb33] ->
+      (none)
+    goto[bb33->bb22] ->
+      (none)
+    cancel[bb33] ->
+      (none)
+    goto[bb34->bb33] ->
+      (none)
+    cancel[bb34] ->
+      (none)
+    panic[bb35] ->
+      (none)
+
+fn string$parse_float_significand -> f64
+  statements:
+    bind BindingId(104) whole site=SiteId(898) ty=f64
+    bind BindingId(105) fraction site=SiteId(899) ty=f64
+    bind BindingId(106) fraction_scale site=SiteId(900) ty=f64
+    bind BindingId(107) saw_decimal site=SiteId(901) ty=bool
+    bind BindingId(108) i site=SiteId(0) ty=i64
+    use BindingId(101) s site=SiteId(906) ty=string intent=Read
+    use BindingId(108) i site=SiteId(907) ty=i64 intent=Read
+    use BindingId(108) i site=SiteId(909) ty=i64 intent=Read
+    eval site=SiteId(955) ty=()
+    use BindingId(104) whole site=SiteId(957) ty=f64 intent=Read
+    use BindingId(105) fraction site=SiteId(959) ty=f64 intent=Read
+    use BindingId(106) fraction_scale site=SiteId(960) ty=f64 intent=Read
+    return site=Some(SiteId(956)) ty=f64
+    use BindingId(102) start site=SiteId(902) ty=i64 intent=Read
+    use BindingId(103) end site=SiteId(903) ty=i64 intent=Read
+    bind BindingId(109) ch site=SiteId(905) ty=string
+    use BindingId(109) ch site=SiteId(913) ty=string intent=Read
+    bind BindingId(110) is_decimal site=SiteId(912) ty=bool
+    use BindingId(110) is_decimal site=SiteId(915) ty=bool intent=Read
+    use BindingId(109) ch site=SiteId(918) ty=string intent=Read
+    eval site=SiteId(924) ty=()
+    use BindingId(109) ch site=SiteId(926) ty=string intent=Read
+    eval site=SiteId(916) ty=()
+    bind BindingId(107) saw_decimal site=SiteId(920) ty=bool
+    eval site=SiteId(921) ty=()
+    eval site=SiteId(922) ty=()
+    bind BindingId(111) value site=SiteId(925) ty=i64
+    use BindingId(109) ch site=SiteId(930) ty=string intent=Read
+    eval site=SiteId(928) ty=()
+    use BindingId(111) value site=SiteId(933) ty=i64 intent=Read
+    bind BindingId(112) digit site=SiteId(932) ty=f64
+    use BindingId(107) saw_decimal site=SiteId(936) ty=bool intent=Read
+    use BindingId(105) fraction site=SiteId(941) ty=f64 intent=Read
+    use BindingId(112) digit site=SiteId(943) ty=f64 intent=Read
+    bind BindingId(105) fraction site=SiteId(938) ty=f64
+    eval site=SiteId(939) ty=()
+    use BindingId(106) fraction_scale site=SiteId(946) ty=f64 intent=Read
+    bind BindingId(106) fraction_scale site=SiteId(944) ty=f64
+    eval site=SiteId(945) ty=()
+    use BindingId(104) whole site=SiteId(952) ty=f64 intent=Read
+    use BindingId(112) digit site=SiteId(954) ty=f64 intent=Read
+    bind BindingId(104) whole site=SiteId(949) ty=f64
+    eval site=SiteId(950) ty=()
+    drop BindingId(109) ch ty=string
+  drop_plans:
+    branch[bb0: bb5/bb6] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb2/bb4] ->
+      (none)
+    branch[bb2: bb7/bb8] ->
+      (none)
+    branch[bb3: bb21/bb1] ->
+      (none)
+    return[bb4] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    goto[bb6->bb1] ->
+      (none)
+    cancel[bb6] ->
+      (none)
+    panic[bb7] ->
+      (none)
+    call[bb8 hew_string_slice -> bb9] ->
+      (none)
+    branch[bb9: bb10/bb11] ->
+      (none)
+    call[bb10 hew_string_drop -> bb13] ->
+      (none)
+    goto[bb11->bb12] ->
+      (none)
+    call[bb12 string$digit_value -> bb15] ->
+      (none)
+    goto[bb13->bb3] ->
+      (none)
+    cancel[bb13] ->
+      (none)
+    goto[bb14->bb12] ->
+      (none)
+    cancel[bb14] ->
+      (none)
+    call[bb15 hew_string_drop -> bb16] ->
+      (none)
+    call[bb16 string$digit_to_float -> bb17] ->
+      (none)
+    branch[bb17: bb18/bb19] ->
+      (none)
+    goto[bb18->bb20] ->
+      (none)
+    goto[bb19->bb20] ->
+      (none)
+    goto[bb20->bb3] ->
+      (none)
+    cancel[bb20] ->
+      (none)
+    panic[bb21] ->
+      (none)
+
+fn string$parse_float_exponent -> i64
+  statements:
+    use BindingId(114) start site=SiteId(961) ty=i64 intent=Consume
+    bind BindingId(116) index site=SiteId(961) ty=i64
+    bind BindingId(117) negative site=SiteId(962) ty=bool
+    use BindingId(113) s site=SiteId(964) ty=string intent=Read
+    use BindingId(114) start site=SiteId(965) ty=i64 intent=Read
+    use BindingId(114) start site=SiteId(967) ty=i64 intent=Read
+    bind BindingId(118) first site=SiteId(963) ty=string
+    use BindingId(118) first site=SiteId(971) ty=string intent=Read
+    bind BindingId(119) has_negative_sign site=SiteId(970) ty=bool
+    use BindingId(118) first site=SiteId(974) ty=string intent=Read
+    bind BindingId(120) has_positive_sign site=SiteId(973) ty=bool
+    use BindingId(118) first site=SiteId(978) ty=string intent=Read
+    eval site=SiteId(976) ty=()
+    use BindingId(119) has_negative_sign site=SiteId(980) ty=bool intent=Read
+    bind BindingId(117) negative site=SiteId(981) ty=bool
+    eval site=SiteId(982) ty=()
+    use BindingId(114) start site=SiteId(985) ty=i64 intent=Read
+    use BindingId(120) has_positive_sign site=SiteId(988) ty=bool intent=Read
+    eval site=SiteId(995) ty=()
+    bind BindingId(121) exponent site=SiteId(996) ty=i64
+    bind BindingId(116) index site=SiteId(983) ty=i64
+    eval site=SiteId(984) ty=()
+    use BindingId(114) start site=SiteId(991) ty=i64 intent=Read
+    bind BindingId(116) index site=SiteId(989) ty=i64
+    eval site=SiteId(990) ty=()
+    bind BindingId(122) i site=SiteId(0) ty=i64
+    use BindingId(113) s site=SiteId(1001) ty=string intent=Read
+    use BindingId(122) i site=SiteId(1002) ty=i64 intent=Read
+    use BindingId(122) i site=SiteId(1004) ty=i64 intent=Read
+    eval site=SiteId(1020) ty=()
+    use BindingId(117) negative site=SiteId(1022) ty=bool intent=Read
+    use BindingId(116) index site=SiteId(997) ty=i64 intent=Read
+    use BindingId(115) end site=SiteId(998) ty=i64 intent=Read
+    bind BindingId(123) digit site=SiteId(1000) ty=string
+    use BindingId(123) digit site=SiteId(1008) ty=string intent=Read
+    bind BindingId(124) value site=SiteId(1007) ty=i64
+    use BindingId(123) digit site=SiteId(1012) ty=string intent=Read
+    eval site=SiteId(1010) ty=()
+    use BindingId(121) exponent site=SiteId(1017) ty=i64 intent=Read
+    use BindingId(124) value site=SiteId(1019) ty=i64 intent=Read
+    bind BindingId(121) exponent site=SiteId(1014) ty=i64
+    eval site=SiteId(1015) ty=()
+    use BindingId(121) exponent site=SiteId(1026) ty=i64 intent=Read
+    use BindingId(121) exponent site=SiteId(1028) ty=i64 intent=Read
+    return site=Some(SiteId(1021)) ty=i64
+    drop BindingId(123) digit ty=string
+    drop BindingId(118) first ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    call[bb2 hew_string_slice -> bb3] ->
+      (none)
+    call[bb3 hew_string_drop -> bb4] ->
+      (none)
+    branch[bb4: bb5/bb6] ->
+      (none)
+    branch[bb5: bb8/bb9] ->
+      (none)
+    branch[bb6: bb10/bb11] ->
+      (none)
+    branch[bb7: bb19/bb20] ->
+      (none)
+    panic[bb8] ->
+      (none)
+    goto[bb9->bb7] ->
+      (none)
+    cancel[bb9] ->
+      (none)
+    branch[bb10: bb13/bb14] ->
+      (none)
+    goto[bb11->bb12] ->
+      (none)
+    goto[bb12->bb7] ->
+      (none)
+    cancel[bb12] ->
+      (none)
+    panic[bb13] ->
+      (none)
+    goto[bb14->bb12] ->
+      (none)
+    cancel[bb14] ->
+      (none)
+    branch[bb15: bb16/bb18] ->
+      (none)
+    branch[bb16: bb21/bb22] ->
+      (none)
+    branch[bb17: bb30/bb15] ->
+      (none)
+    branch[bb18: bb31/bb32] ->
+      (none)
+    panic[bb19] ->
+      (none)
+    goto[bb20->bb15] ->
+      (none)
+    cancel[bb20] ->
+      (none)
+    panic[bb21] ->
+      (none)
+    call[bb22 hew_string_slice -> bb23] ->
+      (none)
+    call[bb23 string$digit_value -> bb24] ->
+      (none)
+    call[bb24 hew_string_drop -> bb25] ->
+      (none)
+    branch[bb25: bb26/bb27] ->
+      (none)
+    panic[bb26] ->
+      (none)
+    branch[bb27: bb28/bb29] ->
+      (none)
+    panic[bb28] ->
+      (none)
+    goto[bb29->bb17] ->
+      (none)
+    cancel[bb29] ->
+      (none)
+    panic[bb30] ->
+      (none)
+    branch[bb31: bb34/bb35] ->
+      (none)
+    goto[bb32->bb33] ->
+      (none)
+    return[bb33] ->
+      (none)
+    panic[bb34] ->
+      (none)
+    goto[bb35->bb33] ->
+      (none)
+    cancel[bb35] ->
+      (none)
+
+fn string$apply_float_exponent -> f64
+  statements:
+    bind BindingId(127) scale site=SiteId(1029) ty=f64
+    use BindingId(126) exponent site=SiteId(1032) ty=i64 intent=Read
+    use BindingId(126) exponent site=SiteId(1037) ty=i64 intent=Read
+    use BindingId(126) exponent site=SiteId(1039) ty=i64 intent=Read
+    bind BindingId(128) exp_abs site=SiteId(1030) ty=i64
+    bind BindingId(129) i site=SiteId(0) ty=i64
+    use BindingId(127) scale site=SiteId(1045) ty=f64 intent=Read
+    bind BindingId(127) scale site=SiteId(1043) ty=f64
+    eval site=SiteId(1044) ty=()
+    eval site=SiteId(1047) ty=()
+    use BindingId(126) exponent site=SiteId(1050) ty=i64 intent=Read
+    use BindingId(128) exp_abs site=SiteId(1041) ty=i64 intent=Read
+    use BindingId(125) value site=SiteId(1054) ty=f64 intent=Read
+    use BindingId(127) scale site=SiteId(1055) ty=f64 intent=Read
+    use BindingId(125) value site=SiteId(1058) ty=f64 intent=Read
+    use BindingId(127) scale site=SiteId(1059) ty=f64 intent=Read
+    return site=Some(SiteId(1048)) ty=f64
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb4/bb5] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    branch[bb3: bb10/bb11] ->
+      (none)
+    panic[bb4] ->
+      (none)
+    goto[bb5->bb3] ->
+      (none)
+    cancel[bb5] ->
+      (none)
+    branch[bb6: bb7/bb9] ->
+      (none)
+    goto[bb7->bb8] ->
+      (none)
+    branch[bb8: bb12/bb6] ->
+      (none)
+    branch[bb9: bb13/bb14] ->
+      (none)
+    panic[bb10] ->
+      (none)
+    goto[bb11->bb6] ->
+      (none)
+    cancel[bb11] ->
+      (none)
+    panic[bb12] ->
+      (none)
+    goto[bb13->bb15] ->
+      (none)
+    goto[bb14->bb15] ->
+      (none)
+    return[bb15] ->
+      (none)
+
+fn string$digit_to_float -> f64
+  statements:
+    use BindingId(130) digit site=SiteId(1061) ty=i64 intent=Read
+    return site=Some(SiteId(1060)) ty=f64
+  drop_plans:
+    goto[bb0->bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+    branch[bb2: bb14/bb3] ->
+      (none)
+    branch[bb3: bb15/bb4] ->
+      (none)
+    branch[bb4: bb16/bb5] ->
+      (none)
+    branch[bb5: bb17/bb6] ->
+      (none)
+    branch[bb6: bb18/bb7] ->
+      (none)
+    branch[bb7: bb19/bb8] ->
+      (none)
+    branch[bb8: bb20/bb9] ->
+      (none)
+    branch[bb9: bb21/bb10] ->
+      (none)
+    branch[bb10: bb22/bb11] ->
+      (none)
+    branch[bb11: bb23/bb12] ->
+      (none)
+    goto[bb12->bb1] ->
+      (none)
+    cancel[bb12] ->
+      (none)
+    panic[bb13] ->
+      (none)
+    goto[bb14->bb1] ->
+      (none)
+    cancel[bb14] ->
+      (none)
+    goto[bb15->bb1] ->
+      (none)
+    cancel[bb15] ->
+      (none)
+    goto[bb16->bb1] ->
+      (none)
+    cancel[bb16] ->
+      (none)
+    goto[bb17->bb1] ->
+      (none)
+    cancel[bb17] ->
+      (none)
+    goto[bb18->bb1] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    goto[bb19->bb1] ->
+      (none)
+    cancel[bb19] ->
+      (none)
+    goto[bb20->bb1] ->
+      (none)
+    cancel[bb20] ->
+      (none)
+    goto[bb21->bb1] ->
+      (none)
+    cancel[bb21] ->
+      (none)
+    goto[bb22->bb1] ->
+      (none)
+    cancel[bb22] ->
+      (none)
+    goto[bb23->bb1] ->
+      (none)
+    cancel[bb23] ->
+      (none)
+
+fn string$is_empty -> bool
+  statements:
+    use BindingId(131) s site=SiteId(1074) ty=string intent=Read
+    return site=Some(SiteId(1073)) ty=bool
+  drop_plans:
+    call[bb0 hew_string_is_empty -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string$repeat -> string
+  statements:
+    use BindingId(132) s site=SiteId(1077) ty=string intent=Read
+    use BindingId(133) n site=SiteId(1078) ty=i64 intent=Read
+    return site=Some(SiteId(1076)) ty=string
+  drop_plans:
+    call[bb0 hew_string_repeat -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string$pad_left -> string
+  statements:
+    use BindingId(136) pad site=SiteId(1081) ty=string intent=Read
+    bind BindingId(137) pad_len site=SiteId(1080) ty=i64
+    use BindingId(137) pad_len site=SiteId(1084) ty=i64 intent=Read
+    eval site=SiteId(1090) ty=()
+    use BindingId(134) s site=SiteId(1092) ty=string intent=Read
+    bind BindingId(138) slen site=SiteId(1091) ty=i64
+    use BindingId(138) slen site=SiteId(1095) ty=i64 intent=Read
+    use BindingId(135) width site=SiteId(1096) ty=i64 intent=Read
+    eval site=SiteId(1086) ty=!
+    use BindingId(134) s site=SiteId(1097) ty=string intent=Consume
+    return site=Some(SiteId(1097)) ty=string
+    eval site=SiteId(1099) ty=()
+    use BindingId(136) pad site=SiteId(1102) ty=string intent=Read
+    use BindingId(135) width site=SiteId(1104) ty=i64 intent=Read
+    use BindingId(138) slen site=SiteId(1105) ty=i64 intent=Read
+    use BindingId(134) s site=SiteId(1107) ty=string intent=Read
+    return site=Some(SiteId(1100)) ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 panic -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    branch[bb3: bb5/bb6] ->
+      (none)
+    goto[bb4->bb3] ->
+      (none)
+    cancel[bb4] ->
+      (none)
+    return[bb5] ->
+      (none)
+    goto[bb6->bb7] ->
+      (none)
+    branch[bb7: bb9/bb10] ->
+      (none)
+    goto[bb8->bb7] ->
+      (none)
+    cancel[bb8] ->
+      (none)
+    panic[bb9] ->
+      (none)
+    call[bb10 string$repeat -> bb11] ->
+      (none)
+    return[bb11] ->
+      (none)
+
+fn string$pad_right -> string
+  statements:
+    use BindingId(141) pad site=SiteId(1109) ty=string intent=Read
+    bind BindingId(142) pad_len site=SiteId(1108) ty=i64
+    use BindingId(142) pad_len site=SiteId(1112) ty=i64 intent=Read
+    eval site=SiteId(1118) ty=()
+    use BindingId(139) s site=SiteId(1120) ty=string intent=Read
+    bind BindingId(143) slen site=SiteId(1119) ty=i64
+    use BindingId(143) slen site=SiteId(1123) ty=i64 intent=Read
+    use BindingId(140) width site=SiteId(1124) ty=i64 intent=Read
+    eval site=SiteId(1114) ty=!
+    use BindingId(139) s site=SiteId(1125) ty=string intent=Consume
+    return site=Some(SiteId(1125)) ty=string
+    eval site=SiteId(1127) ty=()
+    use BindingId(139) s site=SiteId(1129) ty=string intent=Read
+    use BindingId(141) pad site=SiteId(1131) ty=string intent=Read
+    use BindingId(140) width site=SiteId(1133) ty=i64 intent=Read
+    use BindingId(143) slen site=SiteId(1134) ty=i64 intent=Read
+    return site=Some(SiteId(1128)) ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 panic -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    branch[bb3: bb5/bb6] ->
+      (none)
+    goto[bb4->bb3] ->
+      (none)
+    cancel[bb4] ->
+      (none)
+    return[bb5] ->
+      (none)
+    goto[bb6->bb7] ->
+      (none)
+    branch[bb7: bb9/bb10] ->
+      (none)
+    goto[bb8->bb7] ->
+      (none)
+    cancel[bb8] ->
+      (none)
+    panic[bb9] ->
+      (none)
+    call[bb10 string$repeat -> bb11] ->
+      (none)
+    return[bb11] ->
+      (none)
+
+fn string$is_numeric -> bool
+  statements:
+    use BindingId(144) s site=SiteId(1137) ty=string intent=Read
+    bind BindingId(145) slen site=SiteId(1136) ty=i64
+    use BindingId(145) slen site=SiteId(1140) ty=i64 intent=Read
+    return site=Some(SiteId(1142)) ty=bool
+    eval site=SiteId(1144) ty=()
+    bind BindingId(146) i site=SiteId(0) ty=i64
+    use BindingId(144) s site=SiteId(1150) ty=string intent=Read
+    use BindingId(146) i site=SiteId(1151) ty=i64 intent=Read
+    use BindingId(146) i site=SiteId(1153) ty=i64 intent=Read
+    eval site=SiteId(1163) ty=()
+    return site=Some(SiteId(1164)) ty=bool
+    use BindingId(145) slen site=SiteId(1146) ty=i64 intent=Read
+    bind BindingId(147) d site=SiteId(1148) ty=i64
+    use BindingId(147) d site=SiteId(1159) ty=i64 intent=Read
+    return site=Some(SiteId(1162)) ty=bool
+  drop_plans:
+    call[bb0 hew_string_length -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb2/bb3] ->
+      (none)
+    return[bb2] ->
+      (none)
+    goto[bb3->bb4] ->
+      (none)
+    branch[bb4: bb10/bb11] ->
+      (none)
+    goto[bb5->bb4] ->
+      (none)
+    cancel[bb5] ->
+      (none)
+    branch[bb6: bb7/bb9] ->
+      (none)
+    branch[bb7: bb12/bb13] ->
+      (none)
+    branch[bb8: bb20/bb6] ->
+      (none)
+    return[bb9] ->
+      (none)
+    panic[bb10] ->
+      (none)
+    goto[bb11->bb6] ->
+      (none)
+    cancel[bb11] ->
+      (none)
+    panic[bb12] ->
+      (none)
+    call[bb13 hew_string_slice -> bb14] ->
+      (none)
+    call[bb14 string$digit_value -> bb15] ->
+      (none)
+    branch[bb15: bb16/bb17] ->
+      (none)
+    return[bb16] ->
+      (none)
+    goto[bb17->bb18] ->
+      (none)
+    goto[bb18->bb8] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    goto[bb19->bb18] ->
+      (none)
+    cancel[bb19] ->
+      (none)
+    panic[bb20] ->
+      (none)
+
+fn string$count -> i64
+  statements:
+    use BindingId(149) needle site=SiteId(1166) ty=string intent=Read
+    bind BindingId(150) nlen site=SiteId(1165) ty=i64
+    use BindingId(150) nlen site=SiteId(1169) ty=i64 intent=Read
+    return site=Some(SiteId(1171)) ty=i64
+    eval site=SiteId(1173) ty=()
+    bind BindingId(151) n site=SiteId(1174) ty=i64
+    bind BindingId(152) pos site=SiteId(1175) ty=i64
+    use BindingId(148) haystack site=SiteId(1177) ty=string intent=Read
+    bind BindingId(153) hlen site=SiteId(1176) ty=i64
+    use BindingId(152) pos site=SiteId(1180) ty=i64 intent=Read
+    use BindingId(153) hlen site=SiteId(1182) ty=i64 intent=Read
+    use BindingId(150) nlen site=SiteId(1183) ty=i64 intent=Read
+    use BindingId(148) haystack site=SiteId(1185) ty=string intent=Read
+    use BindingId(152) pos site=SiteId(1186) ty=i64 intent=Read
+    use BindingId(153) hlen site=SiteId(1187) ty=i64 intent=Read
+    eval site=SiteId(1207) ty=()
+    use BindingId(151) n site=SiteId(1208) ty=i64 intent=Read
+    return site=Some(SiteId(1208)) ty=i64
+    bind BindingId(154) rest site=SiteId(1184) ty=string
+    use BindingId(154) rest site=SiteId(1191) ty=string intent=Read
+    use BindingId(149) needle site=SiteId(1192) ty=string intent=Read
+    bind BindingId(156) idx site=SiteId(1189) ty=i64
+    use BindingId(151) n site=SiteId(1199) ty=i64 intent=Read
+    bind BindingId(155) i site=SiteId(1194) ty=i64
+    use BindingId(155) i site=SiteId(1194) ty=i64 intent=Read
+    use BindingId(151) n site=SiteId(1196) ty=i64 intent=Consume
+    return site=Some(SiteId(1196)) ty=i64
+    bind BindingId(151) n site=SiteId(1197) ty=i64
+    eval site=SiteId(1198) ty=()
+    use BindingId(152) pos site=SiteId(1204) ty=i64 intent=Read
+    use BindingId(156) idx site=SiteId(1205) ty=i64 intent=Read
+    use BindingId(150) nlen site=SiteId(1206) ty=i64 intent=Read
+    bind BindingId(152) pos site=SiteId(1201) ty=i64
+    eval site=SiteId(1202) ty=()
+    drop BindingId(154) rest ty=string
+  drop_plans:
+    call[bb0 hew_string_length -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb2/bb3] ->
+      (none)
+    return[bb2] ->
+      (none)
+    goto[bb3->bb4] ->
+      (none)
+    call[bb4 hew_string_length -> bb6] ->
+      (none)
+    goto[bb5->bb4] ->
+      (none)
+    cancel[bb5] ->
+      (none)
+    goto[bb6->bb7] ->
+      (none)
+    branch[bb7: bb10/bb11] ->
+      (none)
+    call[bb8 hew_string_slice -> bb12] ->
+      (none)
+    return[bb9] ->
+      (none)
+    panic[bb10] ->
+      (none)
+    branch[bb11: bb8/bb9] ->
+      (none)
+    call[bb12 hew_string_find -> bb13] ->
+      (none)
+    branch[bb13: bb15/bb18] ->
+      (none)
+    branch[bb14: bb20/bb21] ->
+      (none)
+    goto[bb15->bb14] ->
+      (none)
+    cancel[bb15] ->
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
+    return[bb16] ->
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
+    panic[bb17] ->
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
+    branch[bb18: bb16/bb17] ->
+      (none)
+    goto[bb19->bb14] ->
+      (none)
+    cancel[bb19] ->
+      (none)
+    panic[bb20] ->
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
+    branch[bb21: bb22/bb23] ->
+      (none)
+    panic[bb22] ->
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
+    branch[bb23: bb24/bb25] ->
+      (none)
+    panic[bb24] ->
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb25->bb7] ->
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
+    cancel[bb25] ->
+      drop _18 ty=string kind=cow_heap(hew_string_drop)
+
+fn string$starts_with -> bool
+  statements:
+    use BindingId(157) s site=SiteId(1210) ty=string intent=Read
+    use BindingId(158) prefix site=SiteId(1211) ty=string intent=Read
+    return site=Some(SiteId(1209)) ty=bool
+  drop_plans:
+    call[bb0 hew_string_starts_with -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string$ends_with -> bool
+  statements:
+    use BindingId(159) s site=SiteId(1214) ty=string intent=Read
+    use BindingId(160) suffix site=SiteId(1215) ty=string intent=Read
+    return site=Some(SiteId(1213)) ty=bool
+  drop_plans:
+    call[bb0 hew_string_ends_with -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string$contains -> bool
+  statements:
+    use BindingId(161) s site=SiteId(1218) ty=string intent=Read
+    use BindingId(162) sub site=SiteId(1219) ty=string intent=Read
+    return site=Some(SiteId(1217)) ty=bool
+  drop_plans:
+    call[bb0 hew_string_contains -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string$is_ascii -> bool
+  statements:
+    use BindingId(163) s site=SiteId(1222) ty=string intent=Read
+    bind BindingId(164) len site=SiteId(1221) ty=i64
+    bind BindingId(165) i site=SiteId(0) ty=i64
+    use BindingId(163) s site=SiteId(1229) ty=string intent=Read
+    use BindingId(165) i site=SiteId(1230) ty=i64 intent=Read
+    eval site=SiteId(1242) ty=()
+    return site=Some(SiteId(1243)) ty=bool
+    use BindingId(164) len site=SiteId(1225) ty=i64 intent=Read
+    bind BindingId(167) ch site=SiteId(1227) ty=char
+    use BindingId(167) ch site=SiteId(1238) ty=char intent=Read
+    bind BindingId(166) c site=SiteId(1232) ty=char
+    use BindingId(166) c site=SiteId(1232) ty=char intent=Read
+    return site=Some(SiteId(1234)) ty=bool
+    return site=Some(SiteId(1241)) ty=bool
+  drop_plans:
+    call[bb0 hew_string_length -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb6/bb7] ->
+      (none)
+    branch[bb2: bb3/bb5] ->
+      (none)
+    call[bb3 hew_string_char_at -> bb8] ->
+      (none)
+    branch[bb4: bb19/bb2] ->
+      (none)
+    return[bb5] ->
+      (none)
+    panic[bb6] ->
+      (none)
+    goto[bb7->bb2] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+    branch[bb8: bb10/bb13] ->
+      (none)
+    branch[bb9: bb15/bb16] ->
+      (none)
+    goto[bb10->bb9] ->
+      (none)
+    cancel[bb10] ->
+      (none)
+    return[bb11] ->
+      (none)
+    panic[bb12] ->
+      (none)
+    branch[bb13: bb11/bb12] ->
+      (none)
+    goto[bb14->bb9] ->
+      (none)
+    cancel[bb14] ->
+      (none)
+    return[bb15] ->
+      (none)
+    goto[bb16->bb17] ->
+      (none)
+    goto[bb17->bb4] ->
+      (none)
+    cancel[bb17] ->
+      (none)
+    goto[bb18->bb17] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    panic[bb19] ->
+      (none)
+
+fn string$trim -> string
+  statements:
+    use BindingId(168) s site=SiteId(1245) ty=string intent=Read
+    return site=Some(SiteId(1244)) ty=string
+  drop_plans:
+    call[bb0 hew_string_trim -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string$replace -> string
+  statements:
+    use BindingId(169) s site=SiteId(1248) ty=string intent=Read
+    use BindingId(170) old site=SiteId(1249) ty=string intent=Read
+    use BindingId(171) new_val site=SiteId(1250) ty=string intent=Read
+    return site=Some(SiteId(1247)) ty=string
+  drop_plans:
+    call[bb0 hew_string_replace -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string$split -> Vec<string>
+  statements:
+    use BindingId(172) s site=SiteId(1253) ty=string intent=Read
+    use BindingId(173) sep site=SiteId(1254) ty=string intent=Read
+    return site=Some(SiteId(1252)) ty=Vec<string>
+  drop_plans:
+    call[bb0 hew_string_split -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string$lines -> Vec<string>
+  statements:
+    bind BindingId(175) result site=SiteId(1256) ty=Vec<string>
+    use BindingId(174) s site=SiteId(1259) ty=string intent=Read
+    bind BindingId(176) slen site=SiteId(1258) ty=i64
+    bind BindingId(177) start site=SiteId(1261) ty=i64
+    use BindingId(177) start site=SiteId(1263) ty=i64 intent=Read
+    use BindingId(176) slen site=SiteId(1264) ty=i64 intent=Read
+    use BindingId(174) s site=SiteId(1266) ty=string intent=Read
+    use BindingId(177) start site=SiteId(1267) ty=i64 intent=Read
+    use BindingId(176) slen site=SiteId(1268) ty=i64 intent=Read
+    eval site=SiteId(1320) ty=()
+    use BindingId(176) slen site=SiteId(1321) ty=i64 intent=Consume
+    bind BindingId(183) final_end site=SiteId(1321) ty=i64
+    use BindingId(183) final_end site=SiteId(1324) ty=i64 intent=Read
+    use BindingId(177) start site=SiteId(1325) ty=i64 intent=Read
+    bind BindingId(178) rest site=SiteId(1265) ty=string
+    use BindingId(178) rest site=SiteId(1271) ty=string intent=Read
+    bind BindingId(179) found site=SiteId(1270) ty=Option<i64>
+    use BindingId(179) found site=SiteId(1275) ty=Option<i64> intent=Read
+    eval site=SiteId(1280) ty=()
+    use BindingId(179) found site=SiteId(1282) ty=Option<i64> intent=Consume
+    eval site=SiteId(1278) ty=()
+    bind BindingId(181) idx site=SiteId(1281) ty=i64
+    use BindingId(177) start site=SiteId(1286) ty=i64 intent=Read
+    use BindingId(181) idx site=SiteId(1287) ty=i64 intent=Read
+    bind BindingId(180) __option_unwrap_or_value site=SiteId(1284) ty=i64
+    use BindingId(180) __option_unwrap_or_value site=SiteId(1284) ty=i64 intent=Read
+    bind BindingId(182) end site=SiteId(1285) ty=i64
+    use BindingId(182) end site=SiteId(1290) ty=i64 intent=Read
+    use BindingId(177) start site=SiteId(1291) ty=i64 intent=Read
+    use BindingId(174) s site=SiteId(1294) ty=string intent=Read
+    use BindingId(182) end site=SiteId(1296) ty=i64 intent=Read
+    use BindingId(182) end site=SiteId(1298) ty=i64 intent=Read
+    use BindingId(182) end site=SiteId(1303) ty=i64 intent=Read
+    eval site=SiteId(1306) ty=()
+    use BindingId(175) result site=SiteId(1308) ty=Vec<string> intent=Read
+    use BindingId(174) s site=SiteId(1310) ty=string intent=Read
+    use BindingId(177) start site=SiteId(1311) ty=i64 intent=Read
+    use BindingId(182) end site=SiteId(1312) ty=i64 intent=Read
+    bind BindingId(182) end site=SiteId(1301) ty=i64
+    eval site=SiteId(1302) ty=()
+    eval site=SiteId(1307) ty=()
+    use BindingId(177) start site=SiteId(1317) ty=i64 intent=Read
+    use BindingId(181) idx site=SiteId(1318) ty=i64 intent=Read
+    bind BindingId(177) start site=SiteId(1314) ty=i64
+    eval site=SiteId(1315) ty=()
+    use BindingId(174) s site=SiteId(1328) ty=string intent=Read
+    use BindingId(183) final_end site=SiteId(1330) ty=i64 intent=Read
+    use BindingId(183) final_end site=SiteId(1332) ty=i64 intent=Read
+    use BindingId(183) final_end site=SiteId(1337) ty=i64 intent=Read
+    eval site=SiteId(1340) ty=()
+    use BindingId(175) result site=SiteId(1342) ty=Vec<string> intent=Read
+    use BindingId(174) s site=SiteId(1344) ty=string intent=Read
+    use BindingId(177) start site=SiteId(1345) ty=i64 intent=Read
+    use BindingId(183) final_end site=SiteId(1346) ty=i64 intent=Read
+    bind BindingId(183) final_end site=SiteId(1335) ty=i64
+    eval site=SiteId(1336) ty=()
+    eval site=SiteId(1341) ty=()
+    use BindingId(175) result site=SiteId(1348) ty=Vec<string> intent=Read
+    return site=Some(SiteId(1348)) ty=Vec<string>
+    drop BindingId(178) rest ty=string
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 hew_string_length -> bb2] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    branch[bb3: bb4/bb5] ->
+      (none)
+    call[bb4 hew_string_slice -> bb6] ->
+      (none)
+    branch[bb5: bb40/bb41] ->
+      (none)
+    call[bb6 hew_string_find -> bb7] ->
+      (none)
+    branch[bb7: bb9/bb12] ->
+      (none)
+    branch[bb8: bb13/bb14] ->
+      (none)
+    goto[bb9->bb8] ->
+      (none)
+    cancel[bb9] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb10->bb8] ->
+      (none)
+    cancel[bb10] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    panic[bb11] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    branch[bb12: bb10/bb11] ->
+      (none)
+    goto[bb13->bb5] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    cancel[bb13] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb14->bb15] ->
+      (none)
+    branch[bb15: bb18/bb21] ->
+      (none)
+    goto[bb16->bb15] ->
+      (none)
+    cancel[bb16] ->
+      (none)
+    branch[bb17: bb22/bb23] ->
+      (none)
+    goto[bb18->bb17] ->
+      (none)
+    cancel[bb18] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb19->bb17] ->
+      (none)
+    cancel[bb19] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    panic[bb20] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    branch[bb21: bb19/bb20] ->
+      (none)
+    panic[bb22] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    branch[bb23: bb24/bb25] ->
+      (none)
+    branch[bb24: bb26/bb27] ->
+      (none)
+    branch[bb25: bb29/bb30] ->
+      (none)
+    panic[bb26] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    call[bb27 hew_string_slice -> bb28] ->
+      (none)
+    goto[bb28->bb25] ->
+      (none)
+    cancel[bb28] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    branch[bb29: bb32/bb33] ->
+      (none)
+    goto[bb30->bb31] ->
+      (none)
+    call[bb31 hew_string_slice -> bb34] ->
+      (none)
+    panic[bb32] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb33->bb31] ->
+      (none)
+    cancel[bb33] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    call[bb34 hew_vec_push_str -> bb35] ->
+      (none)
+    branch[bb35: bb36/bb37] ->
+      (none)
+    panic[bb36] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    branch[bb37: bb38/bb39] ->
+      (none)
+    panic[bb38] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    goto[bb39->bb3] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    cancel[bb39] ->
+      drop _9 ty=string kind=cow_heap(hew_string_drop)
+    branch[bb40: bb42/bb43] ->
+      (none)
+    branch[bb41: bb45/bb46] ->
+      (none)
+    panic[bb42] ->
+      (none)
+    call[bb43 hew_string_slice -> bb44] ->
+      (none)
+    goto[bb44->bb41] ->
+      (none)
+    cancel[bb44] ->
+      (none)
+    branch[bb45: bb48/bb49] ->
+      (none)
+    goto[bb46->bb47] ->
+      (none)
+    call[bb47 hew_string_slice -> bb50] ->
+      (none)
+    panic[bb48] ->
+      (none)
+    goto[bb49->bb47] ->
+      (none)
+    cancel[bb49] ->
+      (none)
+    call[bb50 hew_vec_push_str -> bb51] ->
+      (none)
+    return[bb51] ->
+      (none)
+
+fn string$join -> string
+  statements:
+    use BindingId(184) parts site=SiteId(1350) ty=Vec<string> intent=Read
+    bind BindingId(186) n site=SiteId(1349) ty=i64
+    use BindingId(186) n site=SiteId(1352) ty=i64 intent=Read
+    return site=Some(SiteId(1354)) ty=string
+    eval site=SiteId(1356) ty=()
+    use BindingId(184) parts site=SiteId(1358) ty=Vec<string> intent=Read
+    bind BindingId(187) result site=SiteId(1357) ty=string
+    bind BindingId(188) i site=SiteId(0) ty=i64
+    use BindingId(187) result site=SiteId(1366) ty=string intent=Read
+    use BindingId(185) sep site=SiteId(1367) ty=string intent=Read
+    use BindingId(184) parts site=SiteId(1369) ty=Vec<string> intent=Read
+    use BindingId(188) i site=SiteId(1370) ty=i64 intent=Read
+    eval site=SiteId(1371) ty=()
+    use BindingId(187) result site=SiteId(1372) ty=string intent=Read
+    return site=Some(SiteId(1372)) ty=string
+    use BindingId(186) n site=SiteId(1361) ty=i64 intent=Read
+    bind BindingId(187) result site=SiteId(1363) ty=string
+    eval site=SiteId(1364) ty=()
+  drop_plans:
+    call[bb0 hew_vec_len -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb2/bb3] ->
+      (none)
+    return[bb2] ->
+      (none)
+    goto[bb3->bb4] ->
+      (none)
+    branch[bb4: bb6/bb7] ->
+      (none)
+    goto[bb5->bb4] ->
+      (none)
+    cancel[bb5] ->
+      (none)
+    panic[bb6] ->
+      (none)
+    branch[bb7: bb12/bb13] ->
+      (none)
+    branch[bb8: bb9/bb11] ->
+      (none)
+    branch[bb9: bb14/bb15] ->
+      (none)
+    branch[bb10: bb16/bb8] ->
+      (none)
+    return[bb11] ->
+      (none)
+    panic[bb12] ->
+      (none)
+    goto[bb13->bb8] ->
+      (none)
+    cancel[bb13] ->
+      (none)
+    panic[bb14] ->
+      (none)
+    goto[bb15->bb10] ->
+      (none)
+    cancel[bb15] ->
+      (none)
+    panic[bb16] ->
+      (none)
+
+fn string::len -> i64
+  statements:
+    return site=Some(SiteId(1373)) ty=i64
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::is_empty -> bool
+  statements:
+    return site=Some(SiteId(1374)) ty=bool
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::contains -> bool
+  statements:
+    return site=Some(SiteId(1375)) ty=bool
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::starts_with -> bool
+  statements:
+    return site=Some(SiteId(1376)) ty=bool
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::ends_with -> bool
+  statements:
+    return site=Some(SiteId(1377)) ty=bool
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::to_upper -> string
+  statements:
+    return site=Some(SiteId(1378)) ty=string
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::to_lower -> string
+  statements:
+    return site=Some(SiteId(1379)) ty=string
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::trim -> string
+  statements:
+    return site=Some(SiteId(1380)) ty=string
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::is_digit -> bool
+  statements:
+    return site=Some(SiteId(1381)) ty=bool
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::is_alpha -> bool
+  statements:
+    return site=Some(SiteId(1382)) ty=bool
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::is_alphanumeric -> bool
+  statements:
+    return site=Some(SiteId(1383)) ty=bool
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::clone -> string
+  statements:
+    return site=Some(SiteId(1384)) ty=string
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::replace -> string
+  statements:
+    return site=Some(SiteId(1385)) ty=string
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::split -> Vec<string>
+  statements:
+    return site=Some(SiteId(1386)) ty=Vec<string>
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string::lines -> Vec<string>
+  statements:
+    return site=Some(SiteId(1388)) ty=Vec<string>
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string::find -> Option<i64>
+  statements:
+    return site=Some(SiteId(1390)) ty=Option<i64>
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::slice -> string
+  statements:
+    return site=Some(SiteId(1391)) ty=string
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::repeat -> string
+  statements:
+    return site=Some(SiteId(1392)) ty=string
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::char_at -> Option<char>
+  statements:
+    return site=Some(SiteId(1393)) ty=Option<char>
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::get -> Option<char>
+  statements:
+    return site=Some(SiteId(1394)) ty=Option<char>
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::chars -> Vec<char>
+  statements:
+    return site=Some(SiteId(1395)) ty=Vec<char>
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string::char_count_utf8 -> i64
+  statements:
+    return site=Some(SiteId(1397)) ty=i64
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::codepoint_at_utf8 -> Option<i64>
+  statements:
+    return site=Some(SiteId(1398)) ty=Option<i64>
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn string::to_bytes -> bytes
+  statements:
+    return site=Some(SiteId(1399)) ty=bytes
+  drop_plans:
+    call[bb0 bytes::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i8::fmt -> string
+  statements:
+    use BindingId(234) val site=SiteId(1471) ty=i8 intent=Read
+    return site=Some(SiteId(1469)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i16::fmt -> string
+  statements:
+    use BindingId(235) val site=SiteId(1475) ty=i16 intent=Read
+    return site=Some(SiteId(1473)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i32::fmt -> string
+  statements:
+    use BindingId(236) val site=SiteId(1478) ty=i32 intent=Read
+    return site=Some(SiteId(1477)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i64::fmt -> string
+  statements:
+    use BindingId(237) val site=SiteId(1481) ty=i64 intent=Read
+    return site=Some(SiteId(1480)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u8::fmt -> string
+  statements:
+    use BindingId(238) val site=SiteId(1484) ty=u8 intent=Read
+    return site=Some(SiteId(1483)) ty=string
+  drop_plans:
+    call[bb0 to_string_u8 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u16::fmt -> string
+  statements:
+    use BindingId(239) val site=SiteId(1487) ty=u16 intent=Read
+    return site=Some(SiteId(1486)) ty=string
+  drop_plans:
+    call[bb0 to_string_u16 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u32::fmt -> string
+  statements:
+    use BindingId(240) val site=SiteId(1490) ty=u32 intent=Read
+    return site=Some(SiteId(1489)) ty=string
+  drop_plans:
+    call[bb0 to_string_u32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u64::fmt -> string
+  statements:
+    use BindingId(241) val site=SiteId(1493) ty=u64 intent=Read
+    return site=Some(SiteId(1492)) ty=string
+  drop_plans:
+    call[bb0 to_string_u64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn isize::fmt -> string
+  statements:
+    use BindingId(242) val site=SiteId(1497) ty=isize intent=Read
+    return site=Some(SiteId(1495)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn usize::fmt -> string
+  statements:
+    use BindingId(243) val site=SiteId(1501) ty=usize intent=Read
+    return site=Some(SiteId(1499)) ty=string
+  drop_plans:
+    call[bb0 to_string_u64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn bool::fmt -> string
+  statements:
+    use BindingId(244) val site=SiteId(1504) ty=bool intent=Read
+    return site=Some(SiteId(1503)) ty=string
+  drop_plans:
+    call[bb0 to_string_bool -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn char::fmt -> string
+  statements:
+    use BindingId(245) val site=SiteId(1507) ty=char intent=Read
+    return site=Some(SiteId(1506)) ty=string
+  drop_plans:
+    call[bb0 to_string_char -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn f64::fmt -> string
+  statements:
+    use BindingId(246) val site=SiteId(1510) ty=f64 intent=Read
+    return site=Some(SiteId(1509)) ty=string
+  drop_plans:
+    call[bb0 to_string_f64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn f32::fmt -> string
+  statements:
+    use BindingId(247) val site=SiteId(1514) ty=f32 intent=Read
+    return site=Some(SiteId(1512)) ty=string
+  drop_plans:
+    call[bb0 to_string_f64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string::fmt -> string
+  statements:
+    use BindingId(248) val site=SiteId(1516) ty=string intent=Read
+    return site=Some(SiteId(1516)) ty=string
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn duration::from_nanos -> duration
+  statements:
+    use BindingId(249) n site=SiteId(1518) ty=i64 intent=Read
+    return site=Some(SiteId(1517)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_micros -> duration
+  statements:
+    use BindingId(250) n site=SiteId(1521) ty=i64 intent=Read
+    return site=Some(SiteId(1520)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_millis -> duration
+  statements:
+    use BindingId(251) n site=SiteId(1524) ty=i64 intent=Read
+    return site=Some(SiteId(1523)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_secs -> duration
+  statements:
+    use BindingId(252) n site=SiteId(1527) ty=i64 intent=Read
+    return site=Some(SiteId(1526)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::fmt -> string
+  statements:
+    use BindingId(253) val site=SiteId(1532) ty=duration intent=Read
+    return site=Some(SiteId(1529)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+

--- a/tests/mir-baselines/funcupdate-reassign/gen_fn_consume_reassign_overwrite_release.elab.mir
+++ b/tests/mir-baselines/funcupdate-reassign/gen_fn_consume_reassign_overwrite_release.elab.mir
@@ -1,0 +1,392 @@
+fn emit_len -> Generator<i64, ()>
+  statements:
+    return site=Some(SiteId(16)) ty=Generator<i64, ()>
+  drop_plans:
+    call[bb0 hew_cont_frame_alloc -> bb1] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn __hew_gen_body_emit_len_0 -> ()
+  statements:
+    bind BindingId(1) s site=SiteId(0) ty=string
+    use BindingId(1) s site=SiteId(4) ty=string intent=Consume
+    bind BindingId(2) moved site=SiteId(4) ty=string
+    use BindingId(2) moved site=SiteId(7) ty=string intent=Read
+    eval site=SiteId(5) ty=()
+    bind BindingId(1) s site=SiteId(10) ty=string
+    eval site=SiteId(11) ty=()
+    use BindingId(1) s site=SiteId(14) ty=string intent=Read
+    eval site=SiteId(12) ty=()
+    drop BindingId(2) moved ty=string
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 hew_string_length -> bb4] ->
+      (none)
+    branch[bb2: bb6/bb7] ->
+      (none)
+    return[bb3] ->
+      (none)
+    yield[bb4->bb5] ->
+      (none)
+    goto[bb5->bb3] ->
+      (none)
+    cancel[bb5] ->
+      (none)
+    goto[bb6->bb7] ->
+      (none)
+    call[bb7 hew_string_length -> bb8] ->
+      (none)
+    yield[bb8->bb9] ->
+      (none)
+    goto[bb9->bb3] ->
+      (none)
+    cancel[bb9] ->
+      (none)
+
+fn main -> i64
+  statements:
+    bind BindingId(3) got_consume site=SiteId(17) ty=i64
+    bind BindingId(5) __hew_for_iter_4 site=SiteId(18) ty=Generator<i64, ()>
+    use BindingId(5) __hew_for_iter_4 site=SiteId(21) ty=Generator<i64, ()> intent=Read
+    eval site=SiteId(28) ty=()
+    eval site=SiteId(29) ty=()
+    bind BindingId(7) got_reassign site=SiteId(30) ty=i64
+    eval site=SiteId(27) ty=()
+    bind BindingId(6) v site=SiteId(25) ty=i64
+    use BindingId(6) v site=SiteId(24) ty=i64 intent=Consume
+    bind BindingId(3) got_consume site=SiteId(23) ty=i64
+    eval site=SiteId(24) ty=()
+    bind BindingId(9) __hew_for_iter_8 site=SiteId(31) ty=Generator<i64, ()>
+    use BindingId(9) __hew_for_iter_8 site=SiteId(34) ty=Generator<i64, ()> intent=Read
+    eval site=SiteId(41) ty=()
+    eval site=SiteId(42) ty=()
+    use BindingId(3) got_consume site=SiteId(44) ty=i64 intent=Read
+    eval site=SiteId(40) ty=()
+    bind BindingId(10) v site=SiteId(38) ty=i64
+    use BindingId(10) v site=SiteId(37) ty=i64 intent=Consume
+    bind BindingId(7) got_reassign site=SiteId(36) ty=i64
+    eval site=SiteId(37) ty=()
+    return site=Some(SiteId(46)) ty=i64
+    eval site=SiteId(48) ty=()
+    use BindingId(7) got_reassign site=SiteId(50) ty=i64 intent=Read
+    return site=Some(SiteId(52)) ty=i64
+    eval site=SiteId(54) ty=()
+    return site=Some(SiteId(55)) ty=i64
+  drop_plans:
+    call[bb0 emit_len -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    goto[bb1->bb2] ->
+      (none)
+    branch[bb2: bb5/bb8] ->
+      (none)
+    call[bb3 emit_len -> bb10] ->
+      (none)
+    goto[bb4->bb2] ->
+      (none)
+    cancel[bb4] ->
+      (none)
+    goto[bb5->bb4] ->
+      (none)
+    cancel[bb5] ->
+      (none)
+    goto[bb6->bb3] ->
+      (none)
+    cancel[bb6] ->
+      (none)
+    panic[bb7] ->
+      (none)
+    branch[bb8: bb6/bb7] ->
+      (none)
+    goto[bb9->bb4] ->
+      (none)
+    cancel[bb9] ->
+      (none)
+    goto[bb10->bb11] ->
+      (none)
+    branch[bb11: bb14/bb17] ->
+      (none)
+    branch[bb12: bb19/bb20] ->
+      (none)
+    goto[bb13->bb11] ->
+      (none)
+    cancel[bb13] ->
+      (none)
+    goto[bb14->bb13] ->
+      (none)
+    cancel[bb14] ->
+      (none)
+    goto[bb15->bb12] ->
+      (none)
+    cancel[bb15] ->
+      (none)
+    panic[bb16] ->
+      (none)
+    branch[bb17: bb15/bb16] ->
+      (none)
+    goto[bb18->bb13] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    return[bb19] ->
+      (none)
+    goto[bb20->bb21] ->
+      (none)
+    branch[bb21: bb23/bb24] ->
+      (none)
+    goto[bb22->bb21] ->
+      (none)
+    cancel[bb22] ->
+      (none)
+    return[bb23] ->
+      (none)
+    goto[bb24->bb25] ->
+      (none)
+    return[bb25] ->
+      (none)
+    goto[bb26->bb25] ->
+      (none)
+    cancel[bb26] ->
+      (none)
+
+fn i8::fmt -> string
+  statements:
+    use BindingId(19) val site=SiteId(126) ty=i8 intent=Read
+    return site=Some(SiteId(124)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i16::fmt -> string
+  statements:
+    use BindingId(20) val site=SiteId(130) ty=i16 intent=Read
+    return site=Some(SiteId(128)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i32::fmt -> string
+  statements:
+    use BindingId(21) val site=SiteId(133) ty=i32 intent=Read
+    return site=Some(SiteId(132)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i64::fmt -> string
+  statements:
+    use BindingId(22) val site=SiteId(136) ty=i64 intent=Read
+    return site=Some(SiteId(135)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u8::fmt -> string
+  statements:
+    use BindingId(23) val site=SiteId(139) ty=u8 intent=Read
+    return site=Some(SiteId(138)) ty=string
+  drop_plans:
+    call[bb0 to_string_u8 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u16::fmt -> string
+  statements:
+    use BindingId(24) val site=SiteId(142) ty=u16 intent=Read
+    return site=Some(SiteId(141)) ty=string
+  drop_plans:
+    call[bb0 to_string_u16 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u32::fmt -> string
+  statements:
+    use BindingId(25) val site=SiteId(145) ty=u32 intent=Read
+    return site=Some(SiteId(144)) ty=string
+  drop_plans:
+    call[bb0 to_string_u32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u64::fmt -> string
+  statements:
+    use BindingId(26) val site=SiteId(148) ty=u64 intent=Read
+    return site=Some(SiteId(147)) ty=string
+  drop_plans:
+    call[bb0 to_string_u64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn isize::fmt -> string
+  statements:
+    use BindingId(27) val site=SiteId(152) ty=isize intent=Read
+    return site=Some(SiteId(150)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn usize::fmt -> string
+  statements:
+    use BindingId(28) val site=SiteId(156) ty=usize intent=Read
+    return site=Some(SiteId(154)) ty=string
+  drop_plans:
+    call[bb0 to_string_u64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn bool::fmt -> string
+  statements:
+    use BindingId(29) val site=SiteId(159) ty=bool intent=Read
+    return site=Some(SiteId(158)) ty=string
+  drop_plans:
+    call[bb0 to_string_bool -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn char::fmt -> string
+  statements:
+    use BindingId(30) val site=SiteId(162) ty=char intent=Read
+    return site=Some(SiteId(161)) ty=string
+  drop_plans:
+    call[bb0 to_string_char -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn f64::fmt -> string
+  statements:
+    use BindingId(31) val site=SiteId(165) ty=f64 intent=Read
+    return site=Some(SiteId(164)) ty=string
+  drop_plans:
+    call[bb0 to_string_f64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn f32::fmt -> string
+  statements:
+    use BindingId(32) val site=SiteId(169) ty=f32 intent=Read
+    return site=Some(SiteId(167)) ty=string
+  drop_plans:
+    call[bb0 to_string_f64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string::fmt -> string
+  statements:
+    use BindingId(33) val site=SiteId(171) ty=string intent=Read
+    return site=Some(SiteId(171)) ty=string
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn duration::from_nanos -> duration
+  statements:
+    use BindingId(34) n site=SiteId(173) ty=i64 intent=Read
+    return site=Some(SiteId(172)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_micros -> duration
+  statements:
+    use BindingId(35) n site=SiteId(176) ty=i64 intent=Read
+    return site=Some(SiteId(175)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_millis -> duration
+  statements:
+    use BindingId(36) n site=SiteId(179) ty=i64 intent=Read
+    return site=Some(SiteId(178)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_secs -> duration
+  statements:
+    use BindingId(37) n site=SiteId(182) ty=i64 intent=Read
+    return site=Some(SiteId(181)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::fmt -> string
+  statements:
+    use BindingId(38) val site=SiteId(187) ty=duration intent=Read
+    return site=Some(SiteId(184)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+

--- a/tests/mir-baselines/funcupdate-reassign/gen_fn_consume_reassign_overwrite_release.elab.mir
+++ b/tests/mir-baselines/funcupdate-reassign/gen_fn_consume_reassign_overwrite_release.elab.mir
@@ -10,7 +10,7 @@ fn emit_len -> Generator<i64, ()>
 fn __hew_gen_body_emit_len_0 -> ()
   statements:
     bind BindingId(1) s site=SiteId(0) ty=string
-    use BindingId(1) s site=SiteId(4) ty=string intent=Consume
+    use BindingId(1) s site=SiteId(4) ty=string intent=Read
     bind BindingId(2) moved site=SiteId(4) ty=string
     use BindingId(2) moved site=SiteId(7) ty=string intent=Read
     eval site=SiteId(5) ty=()
@@ -19,6 +19,7 @@ fn __hew_gen_body_emit_len_0 -> ()
     use BindingId(1) s site=SiteId(14) ty=string intent=Read
     eval site=SiteId(12) ty=()
     drop BindingId(2) moved ty=string
+    drop BindingId(1) s ty=string
   drop_plans:
     branch[bb0: bb1/bb2] ->
       (none)
@@ -29,23 +30,25 @@ fn __hew_gen_body_emit_len_0 -> ()
     branch[bb2: bb6/bb7] ->
       (none)
     return[bb3] ->
-      (none)
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
     yield[bb4->bb5] ->
-      (none)
+      drop _7 ty=string kind=cow_heap(hew_string_drop)
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
     goto[bb5->bb3] ->
-      (none)
+      drop _7 ty=string kind=cow_heap(hew_string_drop)
     cancel[bb5] ->
-      (none)
+      drop _7 ty=string kind=cow_heap(hew_string_drop)
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
     goto[bb6->bb7] ->
       (none)
     call[bb7 hew_string_length -> bb8] ->
       (none)
     yield[bb8->bb9] ->
-      (none)
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
     goto[bb9->bb3] ->
       (none)
     cancel[bb9] ->
-      (none)
+      drop _3 ty=string kind=cow_heap(hew_string_drop)
 
 fn main -> i64
   statements:

--- a/tests/mir-baselines/funcupdate-reassign/manifest.tsv
+++ b/tests/mir-baselines/funcupdate-reassign/manifest.tsv
@@ -1,6 +1,11 @@
 # Funcupdate / reassign elaborated-MIR golden baselines (#2648 interface pin, MIR half).
 #
-# generating-revision: 3683c2ac5db3df2bdaa0dc16ba74012b0d20e9c8 (origin/main, the branch base)
+# generating-revision: d5fbb9c86288c79fe56427ddb20e4d4918c053eb (origin/main, the rebase base)
+#   (rebased forward from 3683c2ac5; the closure/gen-fn string fixtures were
+#   regenerated to carry the A240 string copy-on-write drop plan — string shares
+#   are now Read/retain, so the source binding keeps a scope-exit drop and every
+#   shared heap-string local drops via the cow_heap(hew_string_drop) destructor.
+#   The two owned-record fixtures are byte-identical across both revisions.)
 # dump-mode: hew compile --dump-mir elab <fixture>   (run from the repo root)
 # normalization: two run-variance normalizations — (1) the dump's function
 #   ORDER is nondeterministic (map iteration), so the harness splits both

--- a/tests/mir-baselines/funcupdate-reassign/manifest.tsv
+++ b/tests/mir-baselines/funcupdate-reassign/manifest.tsv
@@ -2,8 +2,11 @@
 #
 # generating-revision: 3683c2ac5db3df2bdaa0dc16ba74012b0d20e9c8 (origin/main, the branch base)
 # dump-mode: hew compile --dump-mir elab <fixture>   (run from the repo root)
-# normalization: none — the comparison is byte-for-byte; the dump is deterministic
-#   at a fixed revision, so any difference is a real lowering/drop-plan change.
+# normalization: fn-order sort ONLY — the dump's function ORDER is
+#   nondeterministic (map iteration), so the harness splits both sides into
+#   per-function chunks (column-0 `fn ` lines) and sorts by signature line
+#   before comparing; INTRA-function text is compared byte-for-byte, so any
+#   difference is a real lowering/drop-plan change.
 #
 # Purpose: the Coarse freshness summary (`compute_fn_returns_fresh_owner` /
 # `return_value_may_alias_borrow`) feeds the destructive-funcupdate base gate

--- a/tests/mir-baselines/funcupdate-reassign/manifest.tsv
+++ b/tests/mir-baselines/funcupdate-reassign/manifest.tsv
@@ -2,11 +2,12 @@
 #
 # generating-revision: 3683c2ac5db3df2bdaa0dc16ba74012b0d20e9c8 (origin/main, the branch base)
 # dump-mode: hew compile --dump-mir elab <fixture>   (run from the repo root)
-# normalization: fn-order sort ONLY — the dump's function ORDER is
-#   nondeterministic (map iteration), so the harness splits both sides into
-#   per-function chunks (column-0 `fn ` lines) and sorts by signature line
-#   before comparing; INTRA-function text is compared byte-for-byte, so any
-#   difference is a real lowering/drop-plan change.
+# normalization: two run-variance normalizations — (1) the dump's function
+#   ORDER is nondeterministic (map iteration), so the harness splits both
+#   sides into per-function chunks (column-0 `fn ` lines) and sorts by
+#   signature line; (2) within each chunk, BindingId/SiteId values are
+#   renumbered in first-occurrence order. Within-chunk content order is
+#   preserved, so a reordered drop inside a chunk remains detectable.
 #
 # Purpose: the Coarse freshness summary (`compute_fn_returns_fresh_owner` /
 # `return_value_may_alias_borrow`) feeds the destructive-funcupdate base gate

--- a/tests/mir-baselines/funcupdate-reassign/manifest.tsv
+++ b/tests/mir-baselines/funcupdate-reassign/manifest.tsv
@@ -1,0 +1,37 @@
+# Funcupdate / reassign elaborated-MIR golden baselines (#2648 interface pin, MIR half).
+#
+# generating-revision: 3683c2ac5db3df2bdaa0dc16ba74012b0d20e9c8 (origin/main, the branch base)
+# dump-mode: hew compile --dump-mir elab <fixture>   (run from the repo root)
+# normalization: none — the comparison is byte-for-byte; the dump is deterministic
+#   at a fixed revision, so any difference is a real lowering/drop-plan change.
+#
+# Purpose: the Coarse freshness summary (`compute_fn_returns_fresh_owner` /
+# `return_value_may_alias_borrow`) feeds the destructive-funcupdate base gate
+# (`expr_is_materialized_owner`) and the #2420 reassign-overwrite gate
+# (`reassign_rhs_may_alias_binding`). The frozen-reference differential pins the
+# boolean verdicts; THIS manifest pins the emitted elaborated MIR (including
+# drop plans) of the fixtures that exercise those two consumers, so a Coarse
+# drift that somehow escaped the boolean pin still fails here.
+#
+# Fixture universe (recorded justification, plan §Interface pin / manifest
+# universe): the named fixtures below are the corpus inputs that exercise the
+# funcupdate (`{ ..base, f }`) and var-reassign-overwrite consumers —
+# funcupdate_owned_field_drop_test (funcupdate owner gate),
+# var_record_reassign_ownership_test (#2420 reassign gate),
+# closure_consume_reassign_overwrite_release and
+# gen_fn_consume_reassign_overwrite_release (reassign gate inside closure / gen
+# fn bodies). tests/corpus/v05-value-model/{03,18} also contain the surface
+# syntax but do NOT compile at the generating revision (aspirational corpus:
+# `..base` not last in field list), so they cannot reach either consumer and
+# are excluded. A fixture that newly exercises these consumers must be added
+# here WITH a regenerated baseline (an unmapped baseline file fails the test).
+#
+# Regeneration is an explicit, reviewed step only: rebuild `hew` at the wanted
+# revision, re-run the dump-mode command per row, and record the new revision
+# above. The harness (hew-cli/tests/funcupdate_mir_baselines.rs) never writes.
+#
+# fixture<TAB>baseline
+tests/hew/funcupdate_owned_field_drop_test.hew	funcupdate_owned_field_drop_test.elab.mir
+tests/hew/var_record_reassign_ownership_test.hew	var_record_reassign_ownership_test.elab.mir
+tests/vertical-slice/accept/closure_consume_reassign_overwrite_release.hew	closure_consume_reassign_overwrite_release.elab.mir
+tests/vertical-slice/accept/gen_fn_consume_reassign_overwrite_release.hew	gen_fn_consume_reassign_overwrite_release.elab.mir

--- a/tests/mir-baselines/funcupdate-reassign/var_record_reassign_ownership_test.elab.mir
+++ b/tests/mir-baselines/funcupdate-reassign/var_record_reassign_ownership_test.elab.mir
@@ -1,0 +1,1512 @@
+fn mk -> S
+  statements:
+    return site=Some(SiteId(0)) ty=S
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn grow -> S
+  statements:
+    use BindingId(0) s site=SiteId(6) ty=S intent=Read
+    use BindingId(0) s site=SiteId(8) ty=S intent=Read
+    eval site=SiteId(4) ty=()
+    use BindingId(0) s site=SiteId(12) ty=S intent=Read
+    use BindingId(0) s site=SiteId(15) ty=S intent=Read
+    return site=Some(SiteId(9)) ty=S
+  drop_plans:
+    call[bb0 hew_vec_push_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb2/bb3] ->
+      (none)
+    panic[bb2] ->
+      (none)
+    return[bb3] ->
+      (none)
+
+fn mk_pair -> Pair
+  statements:
+    return site=Some(SiteId(16)) ty=Pair
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 Vec::new -> bb2] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn grow_pair -> Pair
+  statements:
+    use BindingId(1) p site=SiteId(24) ty=Pair intent=Read
+    use BindingId(1) p site=SiteId(26) ty=Pair intent=Read
+    eval site=SiteId(22) ty=()
+    use BindingId(1) p site=SiteId(29) ty=Pair intent=Read
+    use BindingId(1) p site=SiteId(32) ty=Pair intent=Read
+    eval site=SiteId(27) ty=()
+    use BindingId(1) p site=SiteId(37) ty=Pair intent=Read
+    use BindingId(1) p site=SiteId(40) ty=Pair intent=Read
+    use BindingId(1) p site=SiteId(42) ty=Pair intent=Read
+    return site=Some(SiteId(34)) ty=Pair
+  drop_plans:
+    call[bb0 hew_vec_push_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb2/bb3] ->
+      (none)
+    panic[bb2] ->
+      (none)
+    call[bb3 hew_vec_push_i64 -> bb4] ->
+      (none)
+    branch[bb4: bb5/bb6] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    return[bb6] ->
+      (none)
+
+fn refresh -> S
+  statements:
+    return site=Some(SiteId(43)) ty=S
+  drop_plans:
+    call[bb0 mk -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn test_var_reassign_through_aliasing_fn_is_exact -> ()
+  statements:
+    bind BindingId(3) s site=SiteId(45) ty=S
+    use BindingId(3) s site=SiteId(49) ty=S intent=Read
+    bind BindingId(3) s site=SiteId(47) ty=S
+    eval site=SiteId(48) ty=()
+    use BindingId(3) s site=SiteId(53) ty=S intent=Read
+    bind BindingId(3) s site=SiteId(51) ty=S
+    eval site=SiteId(52) ty=()
+    use BindingId(3) s site=SiteId(57) ty=S intent=Read
+    eval site=SiteId(55) ty=()
+    use BindingId(3) s site=SiteId(63) ty=S intent=Read
+    eval site=SiteId(60) ty=()
+    use BindingId(3) s site=SiteId(69) ty=S intent=Read
+    eval site=SiteId(66) ty=()
+    use BindingId(3) s site=SiteId(76) ty=S intent=Read
+    eval site=SiteId(73) ty=()
+    drop BindingId(3) s ty=S
+  drop_plans:
+    call[bb0 mk -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 grow -> bb2] ->
+      (none)
+    call[bb2 grow -> bb3] ->
+      (none)
+    call[bb3 testing$assert_eq -> bb4] ->
+      (none)
+    call[bb4 hew_vec_len -> bb5] ->
+      (none)
+    call[bb5 testing$assert_eq -> bb6] ->
+      (none)
+    branch[bb6: bb7/bb8] ->
+      (none)
+    panic[bb7] ->
+      (none)
+    call[bb8 testing$assert_eq -> bb9] ->
+      (none)
+    branch[bb9: bb10/bb11] ->
+      (none)
+    panic[bb10] ->
+      (none)
+    call[bb11 testing$assert_eq -> bb12] ->
+      (none)
+    return[bb12] ->
+      (none)
+
+fn test_loop_reassignment_accumulates_exact_elements -> ()
+  statements:
+    bind BindingId(4) s site=SiteId(80) ty=S
+    bind BindingId(5) i site=SiteId(0) ty=i64
+    use BindingId(4) s site=SiteId(87) ty=S intent=Read
+    eval site=SiteId(89) ty=()
+    use BindingId(4) s site=SiteId(92) ty=S intent=Read
+    bind BindingId(4) s site=SiteId(85) ty=S
+    eval site=SiteId(86) ty=()
+    eval site=SiteId(90) ty=()
+    use BindingId(4) s site=SiteId(98) ty=S intent=Read
+    eval site=SiteId(95) ty=()
+    use BindingId(4) s site=SiteId(104) ty=S intent=Read
+    eval site=SiteId(101) ty=()
+    use BindingId(4) s site=SiteId(111) ty=S intent=Read
+    eval site=SiteId(108) ty=()
+    use BindingId(4) s site=SiteId(118) ty=S intent=Read
+    eval site=SiteId(115) ty=()
+    drop BindingId(4) s ty=S
+  drop_plans:
+    call[bb0 mk -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb6/bb7] ->
+      (none)
+    branch[bb2: bb3/bb5] ->
+      (none)
+    call[bb3 grow -> bb8] ->
+      (none)
+    branch[bb4: bb9/bb2] ->
+      (none)
+    call[bb5 testing$assert_eq -> bb10] ->
+      (none)
+    panic[bb6] ->
+      (none)
+    goto[bb7->bb2] ->
+      (none)
+    cancel[bb7] ->
+      (none)
+    goto[bb8->bb4] ->
+      (none)
+    cancel[bb8] ->
+      (none)
+    panic[bb9] ->
+      (none)
+    call[bb10 hew_vec_len -> bb11] ->
+      (none)
+    call[bb11 testing$assert_eq -> bb12] ->
+      (none)
+    branch[bb12: bb13/bb14] ->
+      (none)
+    panic[bb13] ->
+      (none)
+    call[bb14 testing$assert_eq -> bb15] ->
+      (none)
+    branch[bb15: bb16/bb17] ->
+      (none)
+    panic[bb16] ->
+      (none)
+    call[bb17 testing$assert_eq -> bb18] ->
+      (none)
+    branch[bb18: bb19/bb20] ->
+      (none)
+    panic[bb19] ->
+      (none)
+    call[bb20 testing$assert_eq -> bb21] ->
+      (none)
+    return[bb21] ->
+      (none)
+
+fn test_two_vec_record_reassignment_is_exact -> ()
+  statements:
+    bind BindingId(6) p site=SiteId(122) ty=Pair
+    use BindingId(6) p site=SiteId(126) ty=Pair intent=Read
+    bind BindingId(6) p site=SiteId(124) ty=Pair
+    eval site=SiteId(125) ty=()
+    use BindingId(6) p site=SiteId(130) ty=Pair intent=Read
+    bind BindingId(6) p site=SiteId(128) ty=Pair
+    eval site=SiteId(129) ty=()
+    use BindingId(6) p site=SiteId(134) ty=Pair intent=Read
+    bind BindingId(6) p site=SiteId(132) ty=Pair
+    eval site=SiteId(133) ty=()
+    use BindingId(6) p site=SiteId(138) ty=Pair intent=Read
+    eval site=SiteId(136) ty=()
+    use BindingId(6) p site=SiteId(144) ty=Pair intent=Read
+    eval site=SiteId(141) ty=()
+    use BindingId(6) p site=SiteId(150) ty=Pair intent=Read
+    eval site=SiteId(147) ty=()
+    use BindingId(6) p site=SiteId(156) ty=Pair intent=Read
+    eval site=SiteId(153) ty=()
+    use BindingId(6) p site=SiteId(163) ty=Pair intent=Read
+    eval site=SiteId(160) ty=()
+    use BindingId(6) p site=SiteId(170) ty=Pair intent=Read
+    eval site=SiteId(167) ty=()
+    use BindingId(6) p site=SiteId(177) ty=Pair intent=Read
+    eval site=SiteId(174) ty=()
+    drop BindingId(6) p ty=Pair
+  drop_plans:
+    call[bb0 mk_pair -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 grow_pair -> bb2] ->
+      (none)
+    call[bb2 grow_pair -> bb3] ->
+      (none)
+    call[bb3 grow_pair -> bb4] ->
+      (none)
+    call[bb4 testing$assert_eq -> bb5] ->
+      (none)
+    call[bb5 hew_vec_len -> bb6] ->
+      (none)
+    call[bb6 testing$assert_eq -> bb7] ->
+      (none)
+    call[bb7 hew_vec_len -> bb8] ->
+      (none)
+    call[bb8 testing$assert_eq -> bb9] ->
+      (none)
+    branch[bb9: bb10/bb11] ->
+      (none)
+    panic[bb10] ->
+      (none)
+    call[bb11 testing$assert_eq -> bb12] ->
+      (none)
+    branch[bb12: bb13/bb14] ->
+      (none)
+    panic[bb13] ->
+      (none)
+    call[bb14 testing$assert_eq -> bb15] ->
+      (none)
+    branch[bb15: bb16/bb17] ->
+      (none)
+    panic[bb16] ->
+      (none)
+    call[bb17 testing$assert_eq -> bb18] ->
+      (none)
+    branch[bb18: bb19/bb20] ->
+      (none)
+    panic[bb19] ->
+      (none)
+    call[bb20 testing$assert_eq -> bb21] ->
+      (none)
+    return[bb21] ->
+      (none)
+
+fn test_reassignment_from_fresh_returning_fn_resets -> ()
+  statements:
+    bind BindingId(7) s site=SiteId(181) ty=S
+    use BindingId(7) s site=SiteId(185) ty=S intent=Read
+    bind BindingId(7) s site=SiteId(183) ty=S
+    eval site=SiteId(184) ty=()
+    use BindingId(7) s site=SiteId(189) ty=S intent=Read
+    bind BindingId(7) s site=SiteId(187) ty=S
+    eval site=SiteId(188) ty=()
+    use BindingId(7) s site=SiteId(193) ty=S intent=Read
+    eval site=SiteId(191) ty=()
+    use BindingId(7) s site=SiteId(199) ty=S intent=Read
+    eval site=SiteId(196) ty=()
+    use BindingId(7) s site=SiteId(204) ty=S intent=Read
+    bind BindingId(7) s site=SiteId(202) ty=S
+    eval site=SiteId(203) ty=()
+    use BindingId(7) s site=SiteId(208) ty=S intent=Read
+    eval site=SiteId(206) ty=()
+    use BindingId(7) s site=SiteId(214) ty=S intent=Read
+    eval site=SiteId(211) ty=()
+    use BindingId(7) s site=SiteId(220) ty=S intent=Read
+    eval site=SiteId(217) ty=()
+    drop BindingId(7) s ty=S
+  drop_plans:
+    call[bb0 mk -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 grow -> bb2] ->
+      (none)
+    call[bb2 refresh -> bb3] ->
+      (none)
+    call[bb3 testing$assert_eq -> bb4] ->
+      (none)
+    call[bb4 hew_vec_len -> bb5] ->
+      (none)
+    call[bb5 testing$assert_eq -> bb6] ->
+      (none)
+    call[bb6 grow -> bb7] ->
+      (none)
+    call[bb7 testing$assert_eq -> bb8] ->
+      (none)
+    call[bb8 hew_vec_len -> bb9] ->
+      (none)
+    call[bb9 testing$assert_eq -> bb10] ->
+      (none)
+    branch[bb10: bb11/bb12] ->
+      (none)
+    panic[bb11] ->
+      (none)
+    call[bb12 testing$assert_eq -> bb13] ->
+      (none)
+    return[bb13] ->
+      (none)
+
+fn test_conditional_reassignment_join_is_exact -> ()
+  statements:
+    bind BindingId(8) taken site=SiteId(224) ty=S
+    bind BindingId(9) skipped site=SiteId(226) ty=S
+    bind BindingId(10) hot site=SiteId(228) ty=bool
+    bind BindingId(11) cold site=SiteId(229) ty=bool
+    use BindingId(10) hot site=SiteId(230) ty=bool intent=Read
+    use BindingId(8) taken site=SiteId(233) ty=S intent=Read
+    eval site=SiteId(236) ty=()
+    use BindingId(11) cold site=SiteId(237) ty=bool intent=Read
+    bind BindingId(8) taken site=SiteId(231) ty=S
+    eval site=SiteId(232) ty=()
+    use BindingId(9) skipped site=SiteId(240) ty=S intent=Read
+    eval site=SiteId(243) ty=()
+    use BindingId(8) taken site=SiteId(246) ty=S intent=Read
+    bind BindingId(9) skipped site=SiteId(238) ty=S
+    eval site=SiteId(239) ty=()
+    eval site=SiteId(244) ty=()
+    use BindingId(8) taken site=SiteId(252) ty=S intent=Read
+    eval site=SiteId(249) ty=()
+    use BindingId(8) taken site=SiteId(258) ty=S intent=Read
+    eval site=SiteId(255) ty=()
+    use BindingId(9) skipped site=SiteId(264) ty=S intent=Read
+    eval site=SiteId(262) ty=()
+    use BindingId(9) skipped site=SiteId(270) ty=S intent=Read
+    eval site=SiteId(267) ty=()
+    drop BindingId(9) skipped ty=S
+    drop BindingId(8) taken ty=S
+  drop_plans:
+    call[bb0 mk -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 mk -> bb2] ->
+      (none)
+    branch[bb2: bb3/bb4] ->
+      (none)
+    call[bb3 grow -> bb6] ->
+      (none)
+    goto[bb4->bb5] ->
+      (none)
+    branch[bb5: bb7/bb8] ->
+      (none)
+    goto[bb6->bb5] ->
+      (none)
+    cancel[bb6] ->
+      (none)
+    call[bb7 grow -> bb10] ->
+      (none)
+    goto[bb8->bb9] ->
+      (none)
+    call[bb9 testing$assert_eq -> bb11] ->
+      (none)
+    goto[bb10->bb9] ->
+      (none)
+    cancel[bb10] ->
+      (none)
+    call[bb11 hew_vec_len -> bb12] ->
+      (none)
+    call[bb12 testing$assert_eq -> bb13] ->
+      (none)
+    branch[bb13: bb14/bb15] ->
+      (none)
+    panic[bb14] ->
+      (none)
+    call[bb15 testing$assert_eq -> bb16] ->
+      (none)
+    call[bb16 testing$assert_eq -> bb17] ->
+      (none)
+    call[bb17 hew_vec_len -> bb18] ->
+      (none)
+    call[bb18 testing$assert_eq -> bb19] ->
+      (none)
+    return[bb19] ->
+      (none)
+
+fn test_literal_rhs_embedding_own_projection_is_exact -> ()
+  statements:
+    bind BindingId(12) s site=SiteId(273) ty=S
+    use BindingId(12) s site=SiteId(279) ty=S intent=Read
+    eval site=SiteId(277) ty=()
+    use BindingId(12) s site=SiteId(285) ty=S intent=Read
+    use BindingId(12) s site=SiteId(288) ty=S intent=Read
+    bind BindingId(12) s site=SiteId(281) ty=S
+    eval site=SiteId(282) ty=()
+    use BindingId(12) s site=SiteId(293) ty=S intent=Read
+    use BindingId(12) s site=SiteId(296) ty=S intent=Read
+    bind BindingId(12) s site=SiteId(289) ty=S
+    eval site=SiteId(290) ty=()
+    use BindingId(12) s site=SiteId(299) ty=S intent=Read
+    eval site=SiteId(297) ty=()
+    use BindingId(12) s site=SiteId(305) ty=S intent=Read
+    eval site=SiteId(302) ty=()
+    use BindingId(12) s site=SiteId(311) ty=S intent=Read
+    eval site=SiteId(308) ty=()
+    drop BindingId(12) s ty=S
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 hew_vec_push_i64 -> bb2] ->
+      (none)
+    branch[bb2: bb3/bb4] ->
+      (none)
+    panic[bb3] ->
+      (none)
+    branch[bb4: bb5/bb6] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    call[bb6 testing$assert_eq -> bb7] ->
+      (none)
+    call[bb7 hew_vec_len -> bb8] ->
+      (none)
+    call[bb8 testing$assert_eq -> bb9] ->
+      (none)
+    branch[bb9: bb10/bb11] ->
+      (none)
+    panic[bb10] ->
+      (none)
+    call[bb11 testing$assert_eq -> bb12] ->
+      (none)
+    return[bb12] ->
+      (none)
+
+fn swap_w -> W
+  statements:
+    use BindingId(13) w site=SiteId(317) ty=W intent=Read
+    use BindingId(13) w site=SiteId(319) ty=W intent=Read
+    return site=Some(SiteId(315)) ty=W
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn grow_vec -> Vec<i64>
+  statements:
+    use BindingId(14) v site=SiteId(321) ty=Vec<i64> intent=Read
+    use BindingId(15) x site=SiteId(322) ty=i64 intent=Read
+    eval site=SiteId(320) ty=()
+    use BindingId(14) v site=SiteId(323) ty=Vec<i64> intent=Read
+    return site=Some(SiteId(323)) ty=Vec<i64>
+  drop_plans:
+    call[bb0 hew_vec_push_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn RecAcc__recv__bump -> ()
+  statements:
+    eval site=SiteId(329) ty=()
+  drop_plans:
+    call[bb0 grow -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn RecAcc__recv__reset -> ()
+  statements:
+    eval site=SiteId(333) ty=()
+  drop_plans:
+    call[bb0 mk -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn RecAcc__recv__report -> i64
+  statements:
+    return site=Some(SiteId(335)) ty=i64
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    call[bb2 hew_vec_len -> bb3] ->
+      (none)
+    branch[bb3: bb4/bb5] ->
+      (none)
+    panic[bb4] ->
+      (none)
+    return[bb5] ->
+      (none)
+
+fn RecAcc__recv__at -> i64
+  statements:
+    use BindingId(20) i site=SiteId(346) ty=i64 intent=Read
+    return site=Some(SiteId(343)) ty=i64
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn VecAcc__recv__bump -> ()
+  statements:
+    use BindingId(22) x site=SiteId(352) ty=i64 intent=Read
+    eval site=SiteId(350) ty=()
+  drop_plans:
+    call[bb0 grow_vec -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn VecAcc__recv__checksum -> i64
+  statements:
+    bind BindingId(24) sum site=SiteId(354) ty=i64
+    bind BindingId(26) __hew_for_iter_25 site=SiteId(357) ty=VecIter<i64>
+    use BindingId(26) __hew_for_iter_25 site=SiteId(359) ty=VecIter<i64> intent=Read
+    use BindingId(26) __hew_for_iter_25 site=SiteId(361) ty=VecIter<i64> intent=Read
+    eval site=SiteId(390) ty=()
+    eval site=SiteId(391) ty=()
+    use BindingId(24) sum site=SiteId(394) ty=i64 intent=Read
+    use BindingId(26) __hew_for_iter_25 site=SiteId(367) ty=VecIter<i64> intent=Read
+    use BindingId(26) __hew_for_iter_25 site=SiteId(369) ty=VecIter<i64> intent=Read
+    bind BindingId(28) __hew_iter_value_27 site=SiteId(371) ty=i64
+    use BindingId(26) __hew_for_iter_25 site=SiteId(374) ty=VecIter<i64> intent=Read
+    use BindingId(26) __hew_for_iter_25 site=SiteId(372) ty=VecIter<i64> intent=Modify
+    eval site=SiteId(377) ty=()
+    use BindingId(28) __hew_iter_value_27 site=SiteId(378) ty=i64 intent=Read
+    eval site=SiteId(389) ty=()
+    bind BindingId(29) x site=SiteId(387) ty=i64
+    use BindingId(24) sum site=SiteId(385) ty=i64 intent=Read
+    use BindingId(29) x site=SiteId(386) ty=i64 intent=Read
+    bind BindingId(24) sum site=SiteId(383) ty=i64
+    eval site=SiteId(384) ty=()
+    return site=Some(SiteId(392)) ty=i64
+    drop BindingId(26) __hew_for_iter_25 ty=VecIter<i64>
+  drop_plans:
+    goto[bb0->bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 hew_vec_len -> bb3] ->
+      (none)
+    branch[bb2: bb19/bb20] ->
+      (none)
+    branch[bb3: bb4/bb5] ->
+      (none)
+    goto[bb4->bb6] ->
+      (none)
+    branch[bb5: bb7/bb8] ->
+      (none)
+    branch[bb6: bb12/bb15] ->
+      (none)
+    panic[bb7] ->
+      (none)
+    branch[bb8: bb9/bb10] ->
+      (none)
+    panic[bb9] ->
+      (none)
+    goto[bb10->bb6] ->
+      (none)
+    cancel[bb10] ->
+      (none)
+    goto[bb11->bb1] ->
+      (none)
+    cancel[bb11] ->
+      (none)
+    branch[bb12: bb16/bb17] ->
+      (none)
+    goto[bb13->bb2] ->
+      (none)
+    cancel[bb13] ->
+      (none)
+    panic[bb14] ->
+      (none)
+    branch[bb15: bb13/bb14] ->
+      (none)
+    panic[bb16] ->
+      (none)
+    goto[bb17->bb11] ->
+      (none)
+    cancel[bb17] ->
+      (none)
+    goto[bb18->bb11] ->
+      (none)
+    cancel[bb18] ->
+      (none)
+    panic[bb19] ->
+      (none)
+    call[bb20 hew_vec_len -> bb21] ->
+      (none)
+    branch[bb21: bb22/bb23] ->
+      (none)
+    panic[bb22] ->
+      (none)
+    return[bb23] ->
+      (none)
+
+fn Swapper__recv__seed -> ()
+  statements:
+    eval site=SiteId(403) ty=()
+    eval site=SiteId(407) ty=()
+  drop_plans:
+    call[bb0 hew_vec_push_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 hew_vec_push_i64 -> bb2] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn Swapper__recv__flip -> ()
+  statements:
+    eval site=SiteId(412) ty=()
+  drop_plans:
+    call[bb0 swap_w -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn Swapper__recv__probe -> i64
+  statements:
+    return site=Some(SiteId(415)) ty=i64
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    branch[bb2: bb3/bb4] ->
+      (none)
+    panic[bb3] ->
+      (none)
+    branch[bb4: bb5/bb6] ->
+      (none)
+    panic[bb5] ->
+      (none)
+    branch[bb6: bb7/bb8] ->
+      (none)
+    panic[bb7] ->
+      (none)
+    return[bb8] ->
+      (none)
+
+fn test_actor_record_state_reassign_accumulates_exact -> ()
+  statements:
+    bind BindingId(33) a site=SiteId(426) ty=LocalPid<RecAcc>
+    bind BindingId(34) i site=SiteId(0) ty=i64
+    use BindingId(33) a site=SiteId(431) ty=LocalPid<RecAcc> intent=Read
+    eval site=SiteId(432) ty=()
+    use BindingId(33) a site=SiteId(435) ty=LocalPid<RecAcc> intent=Read
+    eval site=SiteId(430) ty=()
+    eval site=SiteId(443) ty=()
+    use BindingId(33) a site=SiteId(446) ty=LocalPid<RecAcc> intent=Read
+    bind BindingId(35) x site=SiteId(436) ty=i64
+    use BindingId(35) x site=SiteId(437) ty=i64 intent=Read
+    eval site=SiteId(455) ty=()
+    use BindingId(33) a site=SiteId(459) ty=LocalPid<RecAcc> intent=Read
+    bind BindingId(36) x site=SiteId(448) ty=i64
+    use BindingId(36) x site=SiteId(449) ty=i64 intent=Read
+    return site=Some(SiteId(456)) ty=()
+    bind BindingId(37) x site=SiteId(461) ty=i64
+    use BindingId(37) x site=SiteId(462) ty=i64 intent=Read
+    drop BindingId(33) a ty=LocalPid<RecAcc>
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb6/bb7] ->
+      (none)
+    branch[bb2: bb3/bb5] ->
+      (none)
+    send[bb3  -> bb8] ->
+      (none)
+    branch[bb4: bb9/bb2] ->
+      (none)
+    ask[bb5 actor4 -> bb10] ->
+      (none)
+    panic[bb6] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    goto[bb7->bb2] ->
+      (none)
+    cancel[bb7] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    goto[bb8->bb4] ->
+      (none)
+    cancel[bb8] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    panic[bb9] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    branch[bb10: bb12/bb15] ->
+      (none)
+    ask[bb11 actor4 -> bb18] ->
+      (none)
+    call[bb12 testing$assert_eq -> bb16] ->
+      (none)
+    call[bb13 testing$assert_true -> bb17] ->
+      (none)
+    panic[bb14] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    branch[bb15: bb13/bb14] ->
+      (none)
+    goto[bb16->bb11] ->
+      (none)
+    goto[bb17->bb11] ->
+      (none)
+    branch[bb18: bb20/bb23] ->
+      (none)
+    ask[bb19 actor4 -> bb26] ->
+      (none)
+    call[bb20 testing$assert_eq -> bb24] ->
+      (none)
+    call[bb21 testing$assert_true -> bb25] ->
+      (none)
+    panic[bb22] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    branch[bb23: bb21/bb22] ->
+      (none)
+    goto[bb24->bb19] ->
+      (none)
+    goto[bb25->bb19] ->
+      (none)
+    branch[bb26: bb28/bb31] ->
+      (none)
+    return[bb27] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    call[bb28 testing$assert_eq -> bb32] ->
+      (none)
+    call[bb29 testing$assert_true -> bb33] ->
+      (none)
+    panic[bb30] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    branch[bb31: bb29/bb30] ->
+      (none)
+    goto[bb32->bb27] ->
+      (none)
+    cancel[bb32] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    goto[bb33->bb27] ->
+      (none)
+    cancel[bb33] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+
+fn test_actor_record_state_fresh_reset_is_exact -> ()
+  statements:
+    bind BindingId(38) a site=SiteId(468) ty=LocalPid<RecAcc>
+    bind BindingId(39) i site=SiteId(0) ty=i64
+    use BindingId(38) a site=SiteId(473) ty=LocalPid<RecAcc> intent=Read
+    eval site=SiteId(474) ty=()
+    use BindingId(38) a site=SiteId(476) ty=LocalPid<RecAcc> intent=Read
+    eval site=SiteId(472) ty=()
+    eval site=SiteId(475) ty=()
+    use BindingId(38) a site=SiteId(478) ty=LocalPid<RecAcc> intent=Read
+    eval site=SiteId(477) ty=()
+    use BindingId(38) a site=SiteId(481) ty=LocalPid<RecAcc> intent=Read
+    eval site=SiteId(489) ty=()
+    use BindingId(38) a site=SiteId(493) ty=LocalPid<RecAcc> intent=Read
+    bind BindingId(40) x site=SiteId(482) ty=i64
+    use BindingId(40) x site=SiteId(483) ty=i64 intent=Read
+    return site=Some(SiteId(490)) ty=()
+    bind BindingId(41) x site=SiteId(495) ty=i64
+    use BindingId(41) x site=SiteId(496) ty=i64 intent=Read
+    drop BindingId(38) a ty=LocalPid<RecAcc>
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb6/bb7] ->
+      (none)
+    branch[bb2: bb3/bb5] ->
+      (none)
+    send[bb3  -> bb8] ->
+      (none)
+    branch[bb4: bb9/bb2] ->
+      (none)
+    send[bb5  -> bb10] ->
+      (none)
+    panic[bb6] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    goto[bb7->bb2] ->
+      (none)
+    cancel[bb7] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    goto[bb8->bb4] ->
+      (none)
+    cancel[bb8] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    panic[bb9] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    send[bb10  -> bb11] ->
+      (none)
+    ask[bb11 actor4 -> bb12] ->
+      (none)
+    branch[bb12: bb14/bb17] ->
+      (none)
+    ask[bb13 actor4 -> bb20] ->
+      (none)
+    call[bb14 testing$assert_eq -> bb18] ->
+      (none)
+    call[bb15 testing$assert_true -> bb19] ->
+      (none)
+    panic[bb16] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    branch[bb17: bb15/bb16] ->
+      (none)
+    goto[bb18->bb13] ->
+      (none)
+    goto[bb19->bb13] ->
+      (none)
+    branch[bb20: bb22/bb25] ->
+      (none)
+    return[bb21] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    call[bb22 testing$assert_eq -> bb26] ->
+      (none)
+    call[bb23 testing$assert_true -> bb27] ->
+      (none)
+    panic[bb24] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    branch[bb25: bb23/bb24] ->
+      (none)
+    goto[bb26->bb21] ->
+      (none)
+    cancel[bb26] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+    goto[bb27->bb21] ->
+      (none)
+    cancel[bb27] ->
+      drop actor4 ty=LocalPid<RecAcc> kind=resource
+
+fn test_actor_vec_state_reassign_accumulates_exact -> ()
+  statements:
+    bind BindingId(42) b site=SiteId(502) ty=LocalPid<VecAcc>
+    bind BindingId(43) i site=SiteId(0) ty=i64
+    use BindingId(42) b site=SiteId(507) ty=LocalPid<VecAcc> intent=Read
+    use BindingId(43) i site=SiteId(508) ty=i64 intent=Read
+    eval site=SiteId(509) ty=()
+    use BindingId(42) b site=SiteId(513) ty=LocalPid<VecAcc> intent=Read
+    eval site=SiteId(506) ty=()
+    return site=Some(SiteId(510)) ty=()
+    bind BindingId(44) x site=SiteId(514) ty=i64
+    use BindingId(44) x site=SiteId(515) ty=i64 intent=Read
+    drop BindingId(42) b ty=LocalPid<VecAcc>
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    branch[bb1: bb6/bb7] ->
+      (none)
+    branch[bb2: bb3/bb5] ->
+      (none)
+    send[bb3  -> bb8] ->
+      (none)
+    branch[bb4: bb9/bb2] ->
+      (none)
+    ask[bb5 actor2 -> bb10] ->
+      (none)
+    panic[bb6] ->
+      drop actor2 ty=LocalPid<VecAcc> kind=resource
+    goto[bb7->bb2] ->
+      (none)
+    cancel[bb7] ->
+      drop actor2 ty=LocalPid<VecAcc> kind=resource
+    goto[bb8->bb4] ->
+      (none)
+    cancel[bb8] ->
+      drop actor2 ty=LocalPid<VecAcc> kind=resource
+    panic[bb9] ->
+      drop actor2 ty=LocalPid<VecAcc> kind=resource
+    branch[bb10: bb12/bb15] ->
+      (none)
+    return[bb11] ->
+      drop actor2 ty=LocalPid<VecAcc> kind=resource
+    call[bb12 testing$assert_eq -> bb16] ->
+      (none)
+    call[bb13 testing$assert_true -> bb17] ->
+      (none)
+    panic[bb14] ->
+      drop actor2 ty=LocalPid<VecAcc> kind=resource
+    branch[bb15: bb13/bb14] ->
+      (none)
+    goto[bb16->bb11] ->
+      (none)
+    cancel[bb16] ->
+      drop actor2 ty=LocalPid<VecAcc> kind=resource
+    goto[bb17->bb11] ->
+      (none)
+    cancel[bb17] ->
+      drop actor2 ty=LocalPid<VecAcc> kind=resource
+
+fn test_actor_record_state_field_swap_is_exact -> ()
+  statements:
+    bind BindingId(45) s site=SiteId(521) ty=LocalPid<Swapper>
+    use BindingId(45) s site=SiteId(523) ty=LocalPid<Swapper> intent=Read
+    eval site=SiteId(522) ty=()
+    use BindingId(45) s site=SiteId(525) ty=LocalPid<Swapper> intent=Read
+    eval site=SiteId(524) ty=()
+    use BindingId(45) s site=SiteId(527) ty=LocalPid<Swapper> intent=Read
+    eval site=SiteId(526) ty=()
+    use BindingId(45) s site=SiteId(529) ty=LocalPid<Swapper> intent=Read
+    eval site=SiteId(528) ty=()
+    use BindingId(45) s site=SiteId(533) ty=LocalPid<Swapper> intent=Read
+    return site=Some(SiteId(530)) ty=()
+    bind BindingId(46) x site=SiteId(534) ty=i64
+    use BindingId(46) x site=SiteId(535) ty=i64 intent=Read
+    drop BindingId(45) s ty=LocalPid<Swapper>
+  drop_plans:
+    call[bb0 Vec::new -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 Vec::new -> bb2] ->
+      (none)
+    send[bb2  -> bb3] ->
+      (none)
+    send[bb3  -> bb4] ->
+      (none)
+    send[bb4  -> bb5] ->
+      (none)
+    send[bb5  -> bb6] ->
+      (none)
+    ask[bb6 actor4 -> bb7] ->
+      (none)
+    branch[bb7: bb9/bb12] ->
+      (none)
+    return[bb8] ->
+      drop actor4 ty=LocalPid<Swapper> kind=resource
+    call[bb9 testing$assert_eq -> bb13] ->
+      (none)
+    call[bb10 testing$assert_true -> bb14] ->
+      (none)
+    panic[bb11] ->
+      drop actor4 ty=LocalPid<Swapper> kind=resource
+    branch[bb12: bb10/bb11] ->
+      (none)
+    goto[bb13->bb8] ->
+      (none)
+    cancel[bb13] ->
+      drop actor4 ty=LocalPid<Swapper> kind=resource
+    goto[bb14->bb8] ->
+      (none)
+    cancel[bb14] ->
+      drop actor4 ty=LocalPid<Swapper> kind=resource
+
+fn testing$assert_eq -> ()
+  statements:
+    use BindingId(47) actual site=SiteId(543) ty=i64 intent=Read
+    use BindingId(48) expected site=SiteId(544) ty=i64 intent=Read
+    use BindingId(48) expected site=SiteId(549) ty=i64 intent=Read
+    return site=Some(SiteId(541)) ty=()
+    use BindingId(47) actual site=SiteId(553) ty=i64 intent=Read
+    eval site=SiteId(546) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    call[bb6 to_string_i64 -> bb7] ->
+      (none)
+    call[bb7 string_concat -> bb8] ->
+      (none)
+    call[bb8 panic -> bb9] ->
+      (none)
+    goto[bb9->bb3] ->
+      (none)
+    cancel[bb9] ->
+      (none)
+
+fn testing$assert_eq_u8 -> ()
+  statements:
+    use BindingId(49) actual site=SiteId(565) ty=u8 intent=Read
+    use BindingId(50) expected site=SiteId(566) ty=u8 intent=Read
+    use BindingId(50) expected site=SiteId(572) ty=u8 intent=Read
+    return site=Some(SiteId(563)) ty=()
+    use BindingId(49) actual site=SiteId(577) ty=u8 intent=Read
+    eval site=SiteId(568) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    call[bb6 to_string_i64 -> bb7] ->
+      (none)
+    call[bb7 string_concat -> bb8] ->
+      (none)
+    call[bb8 panic -> bb9] ->
+      (none)
+    goto[bb9->bb3] ->
+      (none)
+    cancel[bb9] ->
+      (none)
+
+fn testing$assert_ne_u8 -> ()
+  statements:
+    use BindingId(51) a site=SiteId(589) ty=u8 intent=Read
+    use BindingId(52) b site=SiteId(590) ty=u8 intent=Read
+    use BindingId(51) a site=SiteId(596) ty=u8 intent=Read
+    return site=Some(SiteId(587)) ty=()
+    use BindingId(52) b site=SiteId(601) ty=u8 intent=Read
+    eval site=SiteId(592) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    call[bb6 to_string_i64 -> bb7] ->
+      (none)
+    call[bb7 string_concat -> bb8] ->
+      (none)
+    call[bb8 string_concat -> bb9] ->
+      (none)
+    call[bb9 panic -> bb10] ->
+      (none)
+    goto[bb10->bb3] ->
+      (none)
+    cancel[bb10] ->
+      (none)
+
+fn testing$assert_eq_str -> ()
+  statements:
+    use BindingId(53) actual site=SiteId(616) ty=string intent=Read
+    use BindingId(54) expected site=SiteId(617) ty=string intent=Read
+    use BindingId(54) expected site=SiteId(622) ty=string intent=Read
+    return site=Some(SiteId(614)) ty=()
+    use BindingId(53) actual site=SiteId(626) ty=string intent=Read
+    eval site=SiteId(619) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 string::fmt -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    call[bb6 string::fmt -> bb7] ->
+      (none)
+    call[bb7 string_concat -> bb8] ->
+      (none)
+    call[bb8 string_concat -> bb9] ->
+      (none)
+    call[bb9 panic -> bb10] ->
+      (none)
+    goto[bb10->bb3] ->
+      (none)
+    cancel[bb10] ->
+      (none)
+
+fn testing$assert_ne -> ()
+  statements:
+    use BindingId(55) a site=SiteId(641) ty=i64 intent=Read
+    use BindingId(56) b site=SiteId(642) ty=i64 intent=Read
+    use BindingId(55) a site=SiteId(647) ty=i64 intent=Read
+    return site=Some(SiteId(639)) ty=()
+    use BindingId(56) b site=SiteId(651) ty=i64 intent=Read
+    eval site=SiteId(644) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    call[bb6 to_string_i64 -> bb7] ->
+      (none)
+    call[bb7 string_concat -> bb8] ->
+      (none)
+    call[bb8 string_concat -> bb9] ->
+      (none)
+    call[bb9 panic -> bb10] ->
+      (none)
+    goto[bb10->bb3] ->
+      (none)
+    cancel[bb10] ->
+      (none)
+
+fn testing$assert_true -> ()
+  statements:
+    use BindingId(57) condition site=SiteId(666) ty=bool intent=Read
+    return site=Some(SiteId(664)) ty=()
+    eval site=SiteId(668) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 panic -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    goto[bb4->bb3] ->
+      (none)
+    cancel[bb4] ->
+      (none)
+
+fn testing$assert_false -> ()
+  statements:
+    use BindingId(58) condition site=SiteId(672) ty=bool intent=Read
+    return site=Some(SiteId(671)) ty=()
+    eval site=SiteId(674) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 panic -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    goto[bb4->bb3] ->
+      (none)
+    cancel[bb4] ->
+      (none)
+
+fn testing$assert_gt -> ()
+  statements:
+    use BindingId(59) a site=SiteId(679) ty=i64 intent=Read
+    use BindingId(60) b site=SiteId(680) ty=i64 intent=Read
+    use BindingId(59) a site=SiteId(685) ty=i64 intent=Read
+    return site=Some(SiteId(677)) ty=()
+    use BindingId(60) b site=SiteId(689) ty=i64 intent=Read
+    eval site=SiteId(682) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    call[bb6 to_string_i64 -> bb7] ->
+      (none)
+    call[bb7 string_concat -> bb8] ->
+      (none)
+    call[bb8 panic -> bb9] ->
+      (none)
+    goto[bb9->bb3] ->
+      (none)
+    cancel[bb9] ->
+      (none)
+
+fn testing$assert_lt -> ()
+  statements:
+    use BindingId(61) a site=SiteId(701) ty=i64 intent=Read
+    use BindingId(62) b site=SiteId(702) ty=i64 intent=Read
+    use BindingId(61) a site=SiteId(707) ty=i64 intent=Read
+    return site=Some(SiteId(699)) ty=()
+    use BindingId(62) b site=SiteId(711) ty=i64 intent=Read
+    eval site=SiteId(704) ty=!
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    call[bb1 to_string_i64 -> bb4] ->
+      (none)
+    goto[bb2->bb3] ->
+      (none)
+    return[bb3] ->
+      (none)
+    call[bb4 string_concat -> bb5] ->
+      (none)
+    call[bb5 string_concat -> bb6] ->
+      (none)
+    call[bb6 to_string_i64 -> bb7] ->
+      (none)
+    call[bb7 string_concat -> bb8] ->
+      (none)
+    call[bb8 panic -> bb9] ->
+      (none)
+    goto[bb9->bb3] ->
+      (none)
+    cancel[bb9] ->
+      (none)
+
+fn i8::fmt -> string
+  statements:
+    use BindingId(71) val site=SiteId(791) ty=i8 intent=Read
+    return site=Some(SiteId(789)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i16::fmt -> string
+  statements:
+    use BindingId(72) val site=SiteId(795) ty=i16 intent=Read
+    return site=Some(SiteId(793)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i32::fmt -> string
+  statements:
+    use BindingId(73) val site=SiteId(798) ty=i32 intent=Read
+    return site=Some(SiteId(797)) ty=string
+  drop_plans:
+    call[bb0 to_string_i32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn i64::fmt -> string
+  statements:
+    use BindingId(74) val site=SiteId(801) ty=i64 intent=Read
+    return site=Some(SiteId(800)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u8::fmt -> string
+  statements:
+    use BindingId(75) val site=SiteId(804) ty=u8 intent=Read
+    return site=Some(SiteId(803)) ty=string
+  drop_plans:
+    call[bb0 to_string_u8 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u16::fmt -> string
+  statements:
+    use BindingId(76) val site=SiteId(807) ty=u16 intent=Read
+    return site=Some(SiteId(806)) ty=string
+  drop_plans:
+    call[bb0 to_string_u16 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u32::fmt -> string
+  statements:
+    use BindingId(77) val site=SiteId(810) ty=u32 intent=Read
+    return site=Some(SiteId(809)) ty=string
+  drop_plans:
+    call[bb0 to_string_u32 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn u64::fmt -> string
+  statements:
+    use BindingId(78) val site=SiteId(813) ty=u64 intent=Read
+    return site=Some(SiteId(812)) ty=string
+  drop_plans:
+    call[bb0 to_string_u64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn isize::fmt -> string
+  statements:
+    use BindingId(79) val site=SiteId(817) ty=isize intent=Read
+    return site=Some(SiteId(815)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn usize::fmt -> string
+  statements:
+    use BindingId(80) val site=SiteId(821) ty=usize intent=Read
+    return site=Some(SiteId(819)) ty=string
+  drop_plans:
+    call[bb0 to_string_u64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn bool::fmt -> string
+  statements:
+    use BindingId(81) val site=SiteId(824) ty=bool intent=Read
+    return site=Some(SiteId(823)) ty=string
+  drop_plans:
+    call[bb0 to_string_bool -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn char::fmt -> string
+  statements:
+    use BindingId(82) val site=SiteId(827) ty=char intent=Read
+    return site=Some(SiteId(826)) ty=string
+  drop_plans:
+    call[bb0 to_string_char -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn f64::fmt -> string
+  statements:
+    use BindingId(83) val site=SiteId(830) ty=f64 intent=Read
+    return site=Some(SiteId(829)) ty=string
+  drop_plans:
+    call[bb0 to_string_f64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn f32::fmt -> string
+  statements:
+    use BindingId(84) val site=SiteId(834) ty=f32 intent=Read
+    return site=Some(SiteId(832)) ty=string
+  drop_plans:
+    call[bb0 to_string_f64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+
+fn string::fmt -> string
+  statements:
+    use BindingId(85) val site=SiteId(836) ty=string intent=Read
+    return site=Some(SiteId(836)) ty=string
+  drop_plans:
+    return[bb0] ->
+      (none)
+
+fn duration::from_nanos -> duration
+  statements:
+    use BindingId(86) n site=SiteId(838) ty=i64 intent=Read
+    return site=Some(SiteId(837)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_micros -> duration
+  statements:
+    use BindingId(87) n site=SiteId(841) ty=i64 intent=Read
+    return site=Some(SiteId(840)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_millis -> duration
+  statements:
+    use BindingId(88) n site=SiteId(844) ty=i64 intent=Read
+    return site=Some(SiteId(843)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::from_secs -> duration
+  statements:
+    use BindingId(89) n site=SiteId(847) ty=i64 intent=Read
+    return site=Some(SiteId(846)) ty=duration
+  drop_plans:
+    branch[bb0: bb1/bb2] ->
+      (none)
+    panic[bb1] ->
+      (none)
+    return[bb2] ->
+      (none)
+
+fn duration::fmt -> string
+  statements:
+    use BindingId(90) val site=SiteId(852) ty=duration intent=Read
+    return site=Some(SiteId(849)) ty=string
+  drop_plans:
+    call[bb0 to_string_i64 -> bb1] ->
+      (none)
+    cancel[bb0] ->
+      (none)
+    return[bb1] ->
+      (none)
+

--- a/tests/vertical-slice/accept/call_scrutinee_fresh_forwarder_release.expected
+++ b/tests/vertical-slice/accept/call_scrutinee_fresh_forwarder_release.expected
@@ -1,0 +1,2 @@
+string=36033
+bytes=65

--- a/tests/vertical-slice/accept/call_scrutinee_fresh_forwarder_release.hew
+++ b/tests/vertical-slice/accept/call_scrutinee_fresh_forwarder_release.hew
@@ -1,0 +1,85 @@
+// An ADMITTED fresh-producer call scrutinee — the D108 shape the #2648
+// preflight must keep compiling and releasing cleanly: a heap-owning-enum
+// result built FRESH through immutable bindings and a helper chain, matched
+// directly (no `let`) and released exactly once per exit edge.
+//
+// The return provenance of every producer here is Fresh (∅): each returns a
+// freshly-constructed value routed through `let`/binder/helper-chain links,
+// never a by-value heap parameter borrow. So the preflight ADMITs the
+// scrutinee and mints exactly one synthetic owner over the call temp — the
+// admit path this fixture proves is ASan/LSan-clean.
+//
+// Output teeth: every payload is read back before its release (a
+// use-after-free garbles the totals; a double-free aborts), both Ok and Err
+// arms are taken, and the loop back-edge exercises the per-iteration release.
+
+fn compose(seg: string) -> string {
+    var out = "";
+    out = out + seg;
+    out = out + "-payload";
+    out
+}
+
+// Fresh through an immutable binding + a helper chain (compose → build → produce).
+fn build(seg: string) -> string {
+    let t = compose(seg);
+    t
+}
+
+fn produce(n: i64) -> Result<string, string> {
+    if n % 2 == 0 {
+        let v = build("even");
+        Ok(v)
+    } else {
+        Err(build("odd"))
+    }
+}
+
+fn produce_bytes(n: i64) -> Result<bytes, string> {
+    if n >= 0 {
+        let s = build("bytes");
+        Ok(s.to_bytes())
+    } else {
+        Err(build("neg"))
+    }
+}
+
+fn string_loop() -> i64 {
+    var oks = 0;
+    var errs = 0;
+    var i = 0;
+    while i < 6 {
+        match produce(i) {
+            Ok(s) => {
+                oks = oks + s.len();
+            },
+            Err(e) => {
+                errs = errs + e.len();
+            },
+        }
+        i = i + 1;
+    }
+    oks * 1000 + errs
+}
+
+fn bytes_loop() -> i64 {
+    var total = 0;
+    var i = 0;
+    while i < 5 {
+        match produce_bytes(i) {
+            Ok(b) => {
+                total = total + b.len();
+            },
+            Err(e) => {
+                total = total - e.len();
+            },
+        }
+        i = i + 1;
+    }
+    total
+}
+
+fn main() {
+    println(f"string={string_loop()}");
+    println(f"bytes={bytes_loop()}");
+}

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -397,6 +397,11 @@ run_accept_expect_status "machine_generic_record_field" 0
 run_accept_expect_stdout "generic_record_string_field"
 run_accept_expect_stdout "nested_string_concat_temp"
 
+# #2648: an admitted fresh-producer call scrutinee (fresh through immutable
+# bindings + a helper chain) must keep compiling and produce deterministic
+# output — the D108 non-regression the return-provenance preflight protects.
+run_accept_expect_stdout "call_scrutinee_fresh_forwarder_release"
+
 # Regression guard: a plain record with an Option<i64> field must compile and
 # run.  The MIR field classifier must NOT strip args from generic enum types
 # (Option, Result) even though their origin names appear in machine_layout_names.


### PR DESCRIPTION
## Summary

A call expression used as a `match`, `while let`, `let else`, or `if let` scrutinee could materialize aliasing temporaries whose composite drops double-free, even when the scrutinee body only borrows. The scrutinee now passes through a return-provenance admission gate before MIR emission, so the aliasing temps are never minted for a forwarding return.

The fix introduces a precise `Fresh | ParamsOnly | Opaque` return-provenance authority computed over a monotone may-alias SCC fixpoint. A preflight admission classifier gates all five scrutinee consumers before lowering (the admission token is non-optional — no consumer can emit without it). A `ParamsOnly` caller-argument scan admits genuine fresh-argument stdlib callers (jwt, encrypt, semver, template) while rejecting forwarders, alongside the twin-gate for the related forwarding case. The forwarder double-free is rejected fail-closed now (a call whose argument aliases a live place cannot mint an owner). Opaque-only module calls take an interim path that preserves today's ownership behaviour unchanged (no worse than the current baseline); their precise gating is the deferred follow-on below.

## Verification

- `cargo nextest run` (full workspace): 11660 passed
- Checked-MIR corpus verify: OK
- No-false-reject stdlib suites: jwt 12/12, encrypt 2/2, semver 27/27, template 22/22
- Vertical slice: 469 pass; ratchet 0/0; funcupdate leak oracles green
- Preflight: ready-to-push
- One baseline regen for string-COW behaviour (test-only, evidenced)

## Out of scope

- Precise opaque-module-function verdicts and trusted-extern admits are deliberately deferred; opaque-only module calls currently take the interim `LegacyModuleCall` path (unchanged from today's behaviour), and get their exact verdict with the stdlib-root canonical-resolution follow-on, which supplies the non-forgeable module-origin identity those admits require.

Fixes #2648
