### PR TITLE
ci: refresh ll-diff goldens and enforce the byte-identity gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,14 @@ jobs:
         # preflights.
         run: scripts/check-preflight-ci-parity.sh
 
+      - name: ll-byte-identity normaliser self-test
+        # Prove the ll-diff oracle's normaliser still catches real IR changes
+        # (string-content edits, numeric-const NAME changes) while staying
+        # transparent to pool-id reorderings.  No compiler build required —
+        # exercises scripts/ll-byte-identity.sh against synthetic .ll snippets.
+        # Guards the ll-diff gate itself from silently degrading into a no-op.
+        run: make ll-identity-selftest
+
       - name: Sandbox parity coverage check
         # Assert every VM-dependent hew-sandbox-wasm test binary (one
         # containing a function that spawns the hew-sandbox-vm Node runner)
@@ -460,6 +468,17 @@ jobs:
         # corpus (make checked-mir-golden) or a non-determinism bug crept
         # into dump_mir.  The hew binary is already built by this point.
         run: make checked-mir-verify
+
+      - name: Verify per-function .ll byte-identity corpus
+        # Recompiles every tests/ll-oracle/corpus/*.hew fixture (native and
+        # wasm32) and diffs the normalised per-function IR against the committed
+        # goldens.  A drift here means emitted LLVM IR changed: either an
+        # intentional codegen change that must regenerate the goldens in the
+        # same commit (make ll-golden, diff justified in the body), or an
+        # unintended regression.  This is a byte-identity gate — it stays green
+        # only while codegen output is unchanged.  The hew binary is already
+        # built by this point.
+        run: make ll-diff
 
       - name: Run repo-wide hew check corpus sweep (ratcheted)
         # Runs `hew check` over every tracked .hew file (excluding intentional

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -37,6 +37,7 @@ command_timeout_floor() {
         "make test-doc-examples") echo 45 ;;
         "make sandbox-parity") echo 150 ;;
         "make checked-mir-verify") echo 45 ;;
+        "make ll-diff") echo 45 ;;
         "make hew-check-all") echo 300 ;;
         *) echo 0 ;;
     esac
@@ -88,6 +89,7 @@ CI_REQUIRED_CHECKS=(
     "Fuzz-oracle ratchet (ci.yml: make fuzz-oracle)	make fuzz-oracle"
     "Sandbox parity (ci.yml: make sandbox-parity)	make sandbox-parity"
     "Checked-MIR golden corpus (ci.yml: make checked-mir-verify)	make checked-mir-verify"
+    "Per-function .ll byte-identity corpus (ci.yml: make ll-diff)	make ll-diff"
     "Doc-fence typecheck ratchet (ci.yml: make test-doc-examples)	make test-doc-examples"
     "Repo-wide hew corpus sweep (ci.yml: make hew-check-all)	make hew-check-all"
 )
@@ -793,6 +795,7 @@ case "$LANE" in
         add_command "make test-doc-examples"
         add_command "make sandbox-parity"
         add_command "make checked-mir-verify"
+        add_command "make ll-diff"
         add_command "make hew-check-all"
         ;;
     *)

--- a/tests/ll-oracle/corpus/golden/native/r4_arith.ll
+++ b/tests/ll-oracle/corpus/golden/native/r4_arith.ll
@@ -1,6 +1,15 @@
 ; ModuleID = 'r4_arith'
 source_filename = "r4_arith"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-apple-macosx13.0"
 
+%CrashInfo = type { i64, ptr }
+
+@str_lit = private unnamed_addr constant [3 x i8] c"ns\00", align 1
+
+declare void @hew_sleep_ns(i64)
+
+declare void @hew_sleep_until_ns(i64)
 
 declare void @hew_exit(i64)
 
@@ -16,7 +25,7 @@ declare ptr @hew_i64_to_string(i64)
 
 declare ptr @hew_u8_to_string(i8)
 
-declare ptr @hew_uint_to_string(i16)
+declare ptr @hew_uint_to_string(i32)
 
 declare ptr @hew_u64_to_string(i64)
 
@@ -104,21 +113,13 @@ declare ptr @hew_string_split(ptr, ptr)
 
 declare ptr @hew_string_lines(ptr)
 
-declare i32 @hew_string_find(ptr, ptr)
-
-declare i32 @hew_string_index_of_start(ptr, ptr)
-
 declare ptr @hew_string_slice(ptr, i64, i64)
 
 declare ptr @hew_string_repeat(ptr, i64)
 
-declare i32 @hew_string_char_at(ptr, i32)
-
 declare ptr @hew_string_chars(ptr)
 
 declare i32 @hew_string_char_count(ptr)
-
-declare i32 @hew_string_char_at_utf8(ptr, i32)
 
 declare void @hew_vec_push_bool(ptr, i1)
 
@@ -224,7 +225,27 @@ declare ptr @hew_bytes_to_string(ptr)
 
 declare void @hew_vec_append(ptr, ptr)
 
-declare void @hew_vec_remove_at(ptr, i64)
+declare i1 @hew_vec_remove_at_bool(ptr, i64)
+
+declare i8 @hew_vec_remove_at_i8(ptr, i64)
+
+declare i8 @hew_vec_remove_at_u8(ptr, i64)
+
+declare i16 @hew_vec_remove_at_i16(ptr, i64)
+
+declare i16 @hew_vec_remove_at_u16(ptr, i64)
+
+declare i32 @hew_vec_remove_at_i32(ptr, i64)
+
+declare i64 @hew_vec_remove_at_i64(ptr, i64)
+
+declare float @hew_vec_remove_at_f32(ptr, i64)
+
+declare double @hew_vec_remove_at_f64(ptr, i64)
+
+declare ptr @hew_vec_remove_at_str(ptr, i64)
+
+declare ptr @hew_vec_remove_at_ptr(ptr, i64)
 
 declare ptr @hew_vec_clone(ptr)
 
@@ -250,6 +271,12 @@ declare void @hew_node_api_connect(ptr)
 
 declare void @hew_node_api_shutdown()
 
+declare void @hew_node_api_load_keys(ptr)
+
+declare void @hew_node_api_allow_peer(i16, ptr)
+
+declare ptr @hew_node_api_identity_key()
+
 declare i64 @hew_actor_pid(ptr)
 
 declare i32 @hew_node_api_register_by_pid(ptr, i64)
@@ -257,6 +284,22 @@ declare i32 @hew_node_api_register_by_pid(ptr, i64)
 declare i64 @hew_remote_pid_from_raw(i64, i64)
 
 declare i64 @hew_node_api_lookup(ptr)
+
+declare ptr @hew_stream_channel(i64)
+
+declare ptr @hew_stream_pair_sink(ptr)
+
+declare ptr @hew_stream_pair_stream(ptr)
+
+declare void @hew_stream_pair_free(ptr)
+
+declare void @hew_sink_close(ptr)
+
+declare i32 @hew_sink_peer_closed(ptr)
+
+declare void @hew_actor_gen_sink_register(ptr, ptr)
+
+declare void @hew_actor_gen_sink_complete(ptr, ptr)
 
 define internal i32 @add_i32(i32 %0, i32 %1) {
 entry:
@@ -305,11 +348,11 @@ entry:
   %local_5 = alloca i32, align 4
   %local_6 = alloca i32, align 4
   %local_7 = alloca i64, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  %cast_int_src = load i64, ptr %local_0, align 4
+  %cast_int_src = load i64, ptr %local_0, align 8
   %cast_int_trunc = trunc i64 %cast_int_src to i8
   store i8 %cast_int_trunc, ptr %local_1, align 1
   %move_load = load i8, ptr %local_1, align 1
@@ -326,10 +369,10 @@ bb0:                                              ; preds = %entry
   store i32 %move_load5, ptr %local_6, align 4
   %cast_int_src6 = load i32, ptr %local_6, align 4
   %cast_int_sext7 = sext i32 %cast_int_src6 to i64
-  store i64 %cast_int_sext7, ptr %local_7, align 4
-  %move_load8 = load i64, ptr %local_7, align 4
-  store i64 %move_load8, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  store i64 %cast_int_sext7, ptr %local_7, align 8
+  %move_load8 = load i64, ptr %local_7, align 8
+  store i64 %move_load8, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
@@ -362,35 +405,35 @@ entry:
   %local_23 = alloca i8, align 1
   %local_24 = alloca i64, align 8
   %local_25 = alloca i8, align 1
-  store i64 %0, ptr %local_0, align 4
-  store i64 %1, ptr %local_1, align 4
+  store i64 %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %bitwise_lhs = load i64, ptr %local_0, align 4
-  %bitwise_rhs = load i64, ptr %local_1, align 4
+  %bitwise_lhs = load i64, ptr %local_0, align 8
+  %bitwise_rhs = load i64, ptr %local_1, align 8
   %bitand = and i64 %bitwise_lhs, %bitwise_rhs
-  store i64 %bitand, ptr %local_2, align 4
-  %move_load = load i64, ptr %local_2, align 4
-  store i64 %move_load, ptr %local_3, align 4
-  %bitwise_lhs1 = load i64, ptr %local_0, align 4
-  %bitwise_rhs2 = load i64, ptr %local_1, align 4
+  store i64 %bitand, ptr %local_2, align 8
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %local_3, align 8
+  %bitwise_lhs1 = load i64, ptr %local_0, align 8
+  %bitwise_rhs2 = load i64, ptr %local_1, align 8
   %bitor = or i64 %bitwise_lhs1, %bitwise_rhs2
-  store i64 %bitor, ptr %local_4, align 4
-  %move_load3 = load i64, ptr %local_4, align 4
-  store i64 %move_load3, ptr %local_5, align 4
-  %bitwise_lhs4 = load i64, ptr %local_0, align 4
-  %bitwise_rhs5 = load i64, ptr %local_1, align 4
+  store i64 %bitor, ptr %local_4, align 8
+  %move_load3 = load i64, ptr %local_4, align 8
+  store i64 %move_load3, ptr %local_5, align 8
+  %bitwise_lhs4 = load i64, ptr %local_0, align 8
+  %bitwise_rhs5 = load i64, ptr %local_1, align 8
   %bitxor = xor i64 %bitwise_lhs4, %bitwise_rhs5
-  store i64 %bitxor, ptr %local_6, align 4
-  %move_load6 = load i64, ptr %local_6, align 4
-  store i64 %move_load6, ptr %local_7, align 4
-  store i64 2, ptr %local_8, align 4
-  store i64 64, ptr %local_10, align 4
-  %cmp_lhs = load i64, ptr %local_8, align 4
-  %cmp_rhs = load i64, ptr %local_10, align 4
+  store i64 %bitxor, ptr %local_6, align 8
+  %move_load6 = load i64, ptr %local_6, align 8
+  store i64 %move_load6, ptr %local_7, align 8
+  store i64 2, ptr %local_8, align 8
+  store i64 64, ptr %local_10, align 8
+  %cmp_lhs = load i64, ptr %local_8, align 8
+  %cmp_rhs = load i64, ptr %local_10, align 8
   %cmp_bit = icmp uge i64 %cmp_lhs, %cmp_rhs
   %cmp_zext = zext i1 %cmp_bit to i8
   store i8 %cmp_zext, ptr %local_11, align 1
@@ -404,16 +447,16 @@ bb1:                                              ; preds = %bb0
   unreachable
 
 bb2:                                              ; preds = %bb0
-  %shl_lhs = load i64, ptr %local_0, align 4
-  %shl_rhs = load i64, ptr %local_8, align 4
+  %shl_lhs = load i64, ptr %local_0, align 8
+  %shl_rhs = load i64, ptr %local_8, align 8
   %shl = shl i64 %shl_lhs, %shl_rhs
-  store i64 %shl, ptr %local_9, align 4
-  %move_load7 = load i64, ptr %local_9, align 4
-  store i64 %move_load7, ptr %local_12, align 4
-  store i64 1, ptr %local_13, align 4
-  store i64 64, ptr %local_15, align 4
-  %cmp_lhs8 = load i64, ptr %local_13, align 4
-  %cmp_rhs9 = load i64, ptr %local_15, align 4
+  store i64 %shl, ptr %local_9, align 8
+  %move_load7 = load i64, ptr %local_9, align 8
+  store i64 %move_load7, ptr %local_12, align 8
+  store i64 1, ptr %local_13, align 8
+  store i64 64, ptr %local_15, align 8
+  %cmp_lhs8 = load i64, ptr %local_13, align 8
+  %cmp_rhs9 = load i64, ptr %local_15, align 8
   %cmp_bit10 = icmp uge i64 %cmp_lhs8, %cmp_rhs9
   %cmp_zext11 = zext i1 %cmp_bit10 to i8
   store i8 %cmp_zext11, ptr %local_16, align 1
@@ -427,19 +470,19 @@ bb3:                                              ; preds = %bb2
   unreachable
 
 bb4:                                              ; preds = %bb2
-  %shr_lhs = load i64, ptr %local_1, align 4
-  %shr_rhs = load i64, ptr %local_13, align 4
+  %shr_lhs = load i64, ptr %local_1, align 8
+  %shr_rhs = load i64, ptr %local_13, align 8
   %ashr = ashr i64 %shr_lhs, %shr_rhs
-  store i64 %ashr, ptr %local_14, align 4
-  %move_load14 = load i64, ptr %local_14, align 4
-  store i64 %move_load14, ptr %local_17, align 4
-  %checked_lhs = load i64, ptr %local_3, align 4
-  %checked_rhs = load i64, ptr %local_5, align 4
+  store i64 %ashr, ptr %local_14, align 8
+  %move_load14 = load i64, ptr %local_14, align 8
+  store i64 %move_load14, ptr %local_17, align 8
+  %checked_lhs = load i64, ptr %local_3, align 8
+  %checked_rhs = load i64, ptr %local_5, align 8
   %with_overflow = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_18, align 4
+  store i64 %checked_result, ptr %local_18, align 8
   store i8 %checked_overflow_widen, ptr %local_19, align 1
   %cond_load15 = load i8, ptr %local_19, align 1
   %cond_nz16 = icmp ne i8 %cond_load15, 0
@@ -451,13 +494,13 @@ bb5:                                              ; preds = %bb4
   unreachable
 
 bb6:                                              ; preds = %bb4
-  %checked_lhs17 = load i64, ptr %local_18, align 4
-  %checked_rhs18 = load i64, ptr %local_7, align 4
+  %checked_lhs17 = load i64, ptr %local_18, align 8
+  %checked_rhs18 = load i64, ptr %local_7, align 8
   %with_overflow19 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs17, i64 %checked_rhs18)
   %checked_result20 = extractvalue { i64, i1 } %with_overflow19, 0
   %checked_overflow21 = extractvalue { i64, i1 } %with_overflow19, 1
   %checked_overflow_widen22 = zext i1 %checked_overflow21 to i8
-  store i64 %checked_result20, ptr %local_20, align 4
+  store i64 %checked_result20, ptr %local_20, align 8
   store i8 %checked_overflow_widen22, ptr %local_21, align 1
   %cond_load23 = load i8, ptr %local_21, align 1
   %cond_nz24 = icmp ne i8 %cond_load23, 0
@@ -469,13 +512,13 @@ bb7:                                              ; preds = %bb6
   unreachable
 
 bb8:                                              ; preds = %bb6
-  %checked_lhs25 = load i64, ptr %local_20, align 4
-  %checked_rhs26 = load i64, ptr %local_12, align 4
+  %checked_lhs25 = load i64, ptr %local_20, align 8
+  %checked_rhs26 = load i64, ptr %local_12, align 8
   %with_overflow27 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs25, i64 %checked_rhs26)
   %checked_result28 = extractvalue { i64, i1 } %with_overflow27, 0
   %checked_overflow29 = extractvalue { i64, i1 } %with_overflow27, 1
   %checked_overflow_widen30 = zext i1 %checked_overflow29 to i8
-  store i64 %checked_result28, ptr %local_22, align 4
+  store i64 %checked_result28, ptr %local_22, align 8
   store i8 %checked_overflow_widen30, ptr %local_23, align 1
   %cond_load31 = load i8, ptr %local_23, align 1
   %cond_nz32 = icmp ne i8 %cond_load31, 0
@@ -487,13 +530,13 @@ bb9:                                              ; preds = %bb8
   unreachable
 
 bb10:                                             ; preds = %bb8
-  %checked_lhs33 = load i64, ptr %local_22, align 4
-  %checked_rhs34 = load i64, ptr %local_17, align 4
+  %checked_lhs33 = load i64, ptr %local_22, align 8
+  %checked_rhs34 = load i64, ptr %local_17, align 8
   %with_overflow35 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs33, i64 %checked_rhs34)
   %checked_result36 = extractvalue { i64, i1 } %with_overflow35, 0
   %checked_overflow37 = extractvalue { i64, i1 } %with_overflow35, 1
   %checked_overflow_widen38 = zext i1 %checked_overflow37 to i8
-  store i64 %checked_result36, ptr %local_24, align 4
+  store i64 %checked_result36, ptr %local_24, align 8
   store i8 %checked_overflow_widen38, ptr %local_25, align 1
   %cond_load39 = load i8, ptr %local_25, align 1
   %cond_nz40 = icmp ne i8 %cond_load39, 0
@@ -505,9 +548,9 @@ bb11:                                             ; preds = %bb10
   unreachable
 
 bb12:                                             ; preds = %bb10
-  %move_load41 = load i64, ptr %local_24, align 4
-  store i64 %move_load41, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load41 = load i64, ptr %local_24, align 8
+  store i64 %move_load41, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -540,14 +583,14 @@ entry:
   %local_17 = alloca i64, align 8
   %local_18 = alloca i64, align 8
   %local_19 = alloca i8, align 1
-  store i64 %0, ptr %local_0, align 4
-  store i64 %1, ptr %local_1, align 4
+  store i64 %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  store i64 0, ptr %local_3, align 4
-  %cmp_lhs = load i64, ptr %local_1, align 4
-  %cmp_rhs = load i64, ptr %local_3, align 4
+  store i64 0, ptr %local_3, align 8
+  %cmp_lhs = load i64, ptr %local_1, align 8
+  %cmp_rhs = load i64, ptr %local_3, align 8
   %cmp_bit = icmp eq i64 %cmp_lhs, %cmp_rhs
   %cmp_zext = zext i1 %cmp_bit to i8
   store i8 %cmp_zext, ptr %local_4, align 1
@@ -561,9 +604,9 @@ bb1:                                              ; preds = %bb0
   unreachable
 
 bb2:                                              ; preds = %bb0
-  store i64 -9223372036854775808, ptr %local_5, align 4
-  %cmp_lhs1 = load i64, ptr %local_0, align 4
-  %cmp_rhs2 = load i64, ptr %local_5, align 4
+  store i64 -9223372036854775808, ptr %local_5, align 8
+  %cmp_lhs1 = load i64, ptr %local_0, align 8
+  %cmp_rhs2 = load i64, ptr %local_5, align 8
   %cmp_bit3 = icmp eq i64 %cmp_lhs1, %cmp_rhs2
   %cmp_zext4 = zext i1 %cmp_bit3 to i8
   store i8 %cmp_zext4, ptr %local_6, align 1
@@ -572,9 +615,9 @@ bb2:                                              ; preds = %bb0
   br i1 %cond_nz6, label %bb3, label %bb4
 
 bb3:                                              ; preds = %bb2
-  store i64 -1, ptr %local_7, align 4
-  %cmp_lhs7 = load i64, ptr %local_1, align 4
-  %cmp_rhs8 = load i64, ptr %local_7, align 4
+  store i64 -1, ptr %local_7, align 8
+  %cmp_lhs7 = load i64, ptr %local_1, align 8
+  %cmp_rhs8 = load i64, ptr %local_7, align 8
   %cmp_bit9 = icmp eq i64 %cmp_lhs7, %cmp_rhs8
   %cmp_zext10 = zext i1 %cmp_bit9 to i8
   store i8 %cmp_zext10, ptr %local_8, align 1
@@ -583,15 +626,15 @@ bb3:                                              ; preds = %bb2
   br i1 %cond_nz12, label %bb5, label %bb4
 
 bb4:                                              ; preds = %bb3, %bb2
-  %div_lhs = load i64, ptr %local_0, align 4
-  %div_rhs = load i64, ptr %local_1, align 4
+  %div_lhs = load i64, ptr %local_0, align 8
+  %div_rhs = load i64, ptr %local_1, align 8
   %sdiv = sdiv i64 %div_lhs, %div_rhs
-  store i64 %sdiv, ptr %local_2, align 4
-  %move_load = load i64, ptr %local_2, align 4
-  store i64 %move_load, ptr %local_9, align 4
-  store i64 0, ptr %local_11, align 4
-  %cmp_lhs13 = load i64, ptr %local_1, align 4
-  %cmp_rhs14 = load i64, ptr %local_11, align 4
+  store i64 %sdiv, ptr %local_2, align 8
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %local_9, align 8
+  store i64 0, ptr %local_11, align 8
+  %cmp_lhs13 = load i64, ptr %local_1, align 8
+  %cmp_rhs14 = load i64, ptr %local_11, align 8
   %cmp_bit15 = icmp eq i64 %cmp_lhs13, %cmp_rhs14
   %cmp_zext16 = zext i1 %cmp_bit15 to i8
   store i8 %cmp_zext16, ptr %local_12, align 1
@@ -610,9 +653,9 @@ bb6:                                              ; preds = %bb4
   unreachable
 
 bb7:                                              ; preds = %bb4
-  store i64 -9223372036854775808, ptr %local_13, align 4
-  %cmp_lhs19 = load i64, ptr %local_0, align 4
-  %cmp_rhs20 = load i64, ptr %local_13, align 4
+  store i64 -9223372036854775808, ptr %local_13, align 8
+  %cmp_lhs19 = load i64, ptr %local_0, align 8
+  %cmp_rhs20 = load i64, ptr %local_13, align 8
   %cmp_bit21 = icmp eq i64 %cmp_lhs19, %cmp_rhs20
   %cmp_zext22 = zext i1 %cmp_bit21 to i8
   store i8 %cmp_zext22, ptr %local_14, align 1
@@ -621,9 +664,9 @@ bb7:                                              ; preds = %bb4
   br i1 %cond_nz24, label %bb8, label %bb9
 
 bb8:                                              ; preds = %bb7
-  store i64 -1, ptr %local_15, align 4
-  %cmp_lhs25 = load i64, ptr %local_1, align 4
-  %cmp_rhs26 = load i64, ptr %local_15, align 4
+  store i64 -1, ptr %local_15, align 8
+  %cmp_lhs25 = load i64, ptr %local_1, align 8
+  %cmp_rhs26 = load i64, ptr %local_15, align 8
   %cmp_bit27 = icmp eq i64 %cmp_lhs25, %cmp_rhs26
   %cmp_zext28 = zext i1 %cmp_bit27 to i8
   store i8 %cmp_zext28, ptr %local_16, align 1
@@ -632,19 +675,19 @@ bb8:                                              ; preds = %bb7
   br i1 %cond_nz30, label %bb10, label %bb9
 
 bb9:                                              ; preds = %bb8, %bb7
-  %div_lhs31 = load i64, ptr %local_0, align 4
-  %div_rhs32 = load i64, ptr %local_1, align 4
+  %div_lhs31 = load i64, ptr %local_0, align 8
+  %div_rhs32 = load i64, ptr %local_1, align 8
   %srem = srem i64 %div_lhs31, %div_rhs32
-  store i64 %srem, ptr %local_10, align 4
-  %move_load33 = load i64, ptr %local_10, align 4
-  store i64 %move_load33, ptr %local_17, align 4
-  %checked_lhs = load i64, ptr %local_9, align 4
-  %checked_rhs = load i64, ptr %local_17, align 4
+  store i64 %srem, ptr %local_10, align 8
+  %move_load33 = load i64, ptr %local_10, align 8
+  store i64 %move_load33, ptr %local_17, align 8
+  %checked_lhs = load i64, ptr %local_9, align 8
+  %checked_rhs = load i64, ptr %local_17, align 8
   %with_overflow = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_18, align 4
+  store i64 %checked_result, ptr %local_18, align 8
   store i8 %checked_overflow_widen, ptr %local_19, align 1
   %cond_load34 = load i8, ptr %local_19, align 1
   %cond_nz35 = icmp ne i8 %cond_load34, 0
@@ -661,9 +704,9 @@ bb11:                                             ; preds = %bb9
   unreachable
 
 bb12:                                             ; preds = %bb9
-  %move_load36 = load i64, ptr %local_18, align 4
-  store i64 %move_load36, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load36 = load i64, ptr %local_18, align 8
+  store i64 %move_load36, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
@@ -709,42 +752,42 @@ bb1:                                              ; preds = %bb0
   br label %bb2
 
 bb2:                                              ; preds = %bb1
-  store i64 200, ptr %local_3, align 4
-  %call_arg2 = load i64, ptr %local_3, align 4
+  store i64 200, ptr %local_3, align 8
+  %call_arg2 = load i64, ptr %local_3, align 8
   %call_result3 = call i64 @cast_chain(i64 %call_arg2)
-  store i64 %call_result3, ptr %local_4, align 4
+  store i64 %call_result3, ptr %local_4, align 8
   br label %bb3
 
 bb3:                                              ; preds = %bb2
-  %print_arg4 = load i64, ptr %local_4, align 4
+  %print_arg4 = load i64, ptr %local_4, align 8
   call void @hew_print_value(i8 1, i64 %print_arg4, i1 true)
   br label %bb4
 
 bb4:                                              ; preds = %bb3
-  store i64 12, ptr %local_5, align 4
-  store i64 10, ptr %local_6, align 4
-  %call_arg5 = load i64, ptr %local_5, align 4
-  %call_arg6 = load i64, ptr %local_6, align 4
+  store i64 12, ptr %local_5, align 8
+  store i64 10, ptr %local_6, align 8
+  %call_arg5 = load i64, ptr %local_5, align 8
+  %call_arg6 = load i64, ptr %local_6, align 8
   %call_result7 = call i64 @bitops(i64 %call_arg5, i64 %call_arg6)
-  store i64 %call_result7, ptr %local_7, align 4
+  store i64 %call_result7, ptr %local_7, align 8
   br label %bb5
 
 bb5:                                              ; preds = %bb4
-  %print_arg8 = load i64, ptr %local_7, align 4
+  %print_arg8 = load i64, ptr %local_7, align 8
   call void @hew_print_value(i8 1, i64 %print_arg8, i1 true)
   br label %bb6
 
 bb6:                                              ; preds = %bb5
-  store i64 17, ptr %local_8, align 4
-  store i64 5, ptr %local_9, align 4
-  %call_arg9 = load i64, ptr %local_8, align 4
-  %call_arg10 = load i64, ptr %local_9, align 4
+  store i64 17, ptr %local_8, align 8
+  store i64 5, ptr %local_9, align 8
+  %call_arg9 = load i64, ptr %local_8, align 8
+  %call_arg10 = load i64, ptr %local_9, align 8
   %call_result11 = call i64 @divrem(i64 %call_arg9, i64 %call_arg10)
-  store i64 %call_result11, ptr %local_10, align 4
+  store i64 %call_result11, ptr %local_10, align 8
   br label %bb7
 
 bb7:                                              ; preds = %bb6
-  %print_arg12 = load i64, ptr %local_10, align 4
+  %print_arg12 = load i64, ptr %local_10, align 8
   call void @hew_print_value(i8 1, i64 %print_arg12, i1 true)
   br label %bb8
 
@@ -754,10 +797,10 @@ bb8:                                              ; preds = %bb7
   store i8 %move_load, ptr %local_12, align 1
   %cast_int_src = load i8, ptr %local_12, align 1
   %cast_int_zext = zext i8 %cast_int_src to i64
-  store i64 %cast_int_zext, ptr %local_13, align 4
-  %move_load13 = load i64, ptr %local_13, align 4
-  store i64 %move_load13, ptr %local_14, align 4
-  %print_arg14 = load i64, ptr %local_14, align 4
+  store i64 %cast_int_zext, ptr %local_13, align 8
+  %move_load13 = load i64, ptr %local_13, align 8
+  store i64 %move_load13, ptr %local_14, align 8
+  %print_arg14 = load i64, ptr %local_14, align 8
   call void @hew_print_value(i8 1, i64 %print_arg14, i1 true)
   br label %bb9
 
@@ -767,21 +810,87 @@ bb9:                                              ; preds = %bb8
   store i16 %move_load15, ptr %local_16, align 2
   %cast_int_src16 = load i16, ptr %local_16, align 2
   %cast_int_zext17 = zext i16 %cast_int_src16 to i64
-  store i64 %cast_int_zext17, ptr %local_17, align 4
-  %print_arg18 = load i64, ptr %local_17, align 4
+  store i64 %cast_int_zext17, ptr %local_17, align 8
+  %print_arg18 = load i64, ptr %local_17, align 8
   call void @hew_print_value(i8 1, i64 %print_arg18, i1 true)
   br label %bb10
 
 bb10:                                             ; preds = %bb9
-  store i64 0, ptr %local_18, align 4
-  %move_load19 = load i64, ptr %local_18, align 4
-  store i64 %move_load19, ptr %return_slot, align 4
+  store i64 0, ptr %local_18, align 8
+  %move_load19 = load i64, ptr %local_18, align 8
+  store i64 %move_load19, ptr %return_slot, align 8
   %hew_lambda_drain_all_call = call i32 @hew_lambda_drain_all(i64 0)
-  %ret_val = load i64, ptr %return_slot, align 4
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 
 cancel_exit:                                      ; preds = %entry
   ret i64 0
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"i8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 8
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i8, ptr %local_0, align 1
+  %cast_int_sext = sext i8 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"i16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 8
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i16, ptr %local_0, align 2
+  %cast_int_sext = sext i16 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
 
 after_cooperate:                                  ; preds = %entry
   br label %bb0
@@ -821,14 +930,73 @@ entry:
   %return_slot = alloca ptr, align 8
   %local_0 = alloca i64, align 8
   %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_1, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i8, ptr %local_0, align 1
+  %call_result = call ptr @hew_u8_to_string(i8 %call_arg)
+  store ptr %call_result, ptr %local_1, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca ptr, align 8
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i16, ptr %local_0, align 2
+  %ffi_zext = zext i16 %call_arg to i32
+  %call_result = call ptr @hew_uint_to_string(i32 %ffi_zext)
   store ptr %call_result, ptr %local_1, align 8
   br label %bb1
 
@@ -857,8 +1025,7 @@ entry:
 
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
-  %ffi_arg_trunc = trunc i32 %call_arg to i16
-  %call_result = call ptr @hew_uint_to_string(i16 %ffi_arg_trunc)
+  %call_result = call ptr @hew_uint_to_string(i32 %call_arg)
   store ptr %call_result, ptr %local_1, align 8
   br label %bb1
 
@@ -880,19 +1047,83 @@ entry:
   %return_slot = alloca ptr, align 8
   %local_0 = alloca i64, align 8
   %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
   store ptr %call_result, ptr %local_1, align 8
   br label %bb1
 
 bb1:                                              ; preds = %bb0
   %move_load = load ptr, ptr %local_1, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"isize::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 8
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i64, ptr %local_0, align 8
+  store i64 %cast_int_src, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"usize::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 8
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i64, ptr %local_0, align 8
+  store i64 %cast_int_src, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
   store ptr %move_load, ptr %return_slot, align 8
   %ret_val = load ptr, ptr %return_slot, align 8
   ret ptr %ret_val
@@ -991,6 +1222,39 @@ after_cooperate:                                  ; preds = %entry
   br label %bb0
 }
 
+define internal ptr @"f32::fmt"(float %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca float, align 4
+  %local_1 = alloca double, align 8
+  %local_2 = alloca ptr, align 8
+  store float %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_float_src = load float, ptr %local_0, align 4
+  %cast_float_ext = fpext float %cast_float_src to double
+  store double %cast_float_ext, ptr %local_1, align 8
+  %call_arg = load double, ptr %local_1, align 8
+  %call_result = call ptr @hew_float_to_string(double %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
 define internal ptr @"string::fmt"(ptr %0) {
 entry:
   %return_slot = alloca ptr, align 8
@@ -999,10 +1263,264 @@ entry:
   br label %bb0
 
 bb0:                                              ; preds = %entry
+  %mir_share_string_load = load ptr, ptr %local_0, align 8
+  %mir_share_string_retain = call ptr @hew_string_clone(ptr %mir_share_string_load)
   %move_load = load ptr, ptr %local_0, align 8
   store ptr %move_load, ptr %return_slot, align 8
   %ret_val = load ptr, ptr %return_slot, align 8
   ret ptr %ret_val
+}
+
+define internal i64 @"duration::from_nanos"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_micros"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_millis"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_secs"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal ptr @"duration::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %hew_duration_nanos = load i64, ptr %local_0, align 8
+  %hew_duration_nanos_call = call i64 @hew_duration_nanos(i64 %hew_duration_nanos)
+  store i64 %hew_duration_nanos_call, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  store ptr @str_lit, ptr %local_3, align 8
+  %"hew_string_concat arg0" = load ptr, ptr %local_2, align 8
+  %"hew_string_concat arg1" = load ptr, ptr %local_3, align 8
+  %hew_string_concat_call = call ptr @hew_string_concat(ptr %"hew_string_concat arg0", ptr %"hew_string_concat arg1")
+  store ptr %hew_string_concat_call, ptr %local_4, align 8
+  %"hew_string_drop drop" = load ptr, ptr %local_2, align 8
+  call void @hew_string_drop(ptr %"hew_string_drop drop")
+  store ptr null, ptr %local_2, align 8
+  %move_load = load ptr, ptr %local_4, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal i32 @__hew_record_clone_inplace_CrashInfo(ptr %0, ptr %1) {
+entry:
+  br label %step_0_clone
+
+success:                                          ; preds = %step_0_store
+  ret i32 0
+
+fail:                                             ; preds = %rb_step_0
+  ret i32 1
+
+rb_step_0:                                        ; preds = %step_0_clone
+  br label %fail
+
+step_0_store:                                     ; preds = %step_0_clone
+  %dst_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  store ptr %clone_helper_f1, ptr %dst_f1_ptr, align 8
+  br label %success
+
+step_0_clone:                                     ; preds = %entry
+  %src_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %src_f1 = load ptr, ptr %src_f1_ptr, align 8
+  %clone_helper_f1 = call ptr @hew_string_clone(ptr %src_f1)
+  %cloned_f1_int = ptrtoint ptr %clone_helper_f1 to i64
+  %cloned_f1_null = icmp eq i64 %cloned_f1_int, 0
+  br i1 %cloned_f1_null, label %rb_step_0, label %step_0_store
+}
+
+define internal void @__hew_record_drop_inplace_CrashInfo(ptr %0) {
+entry:
+  %rec_int = ptrtoint ptr %0 to i64
+  %rec_is_null = icmp eq i64 %rec_int, 0
+  br i1 %rec_is_null, label %done, label %do_drop
+
+do_drop:                                          ; preds = %entry
+  %drop_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %drop_f1 = load ptr, ptr %drop_f1_ptr, align 8
+  call void @hew_string_drop(ptr %drop_f1)
+  br label %done
+
+done:                                             ; preds = %do_drop, %entry
+  ret void
+}
+
+declare void @hew_string_drop(ptr)
+
+define internal void @__hew_record_overwrite_release_CrashInfo(ptr %0, ptr %1) {
+entry:
+  %ow_slot_0 = alloca ptr, align 8
+  store ptr null, ptr %ow_slot_0, align 8
+  %ow_new_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  %ow_new_d0_f1_leaf = load ptr, ptr %ow_new_d0_f1_ptr, align 8
+  store ptr %ow_new_d0_f1_leaf, ptr %ow_slot_0, align 8
+  %ow_old_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %ow_old_d0_f1_val = load ptr, ptr %ow_old_d0_f1_ptr, align 8
+  %ow_old_d0_f1_int = ptrtoint ptr %ow_old_d0_f1_val to i64
+  %ow_old_d0_f1_cmp0_leaf = load ptr, ptr %ow_slot_0, align 8
+  %ow_old_d0_f1_cmp0_int = ptrtoint ptr %ow_old_d0_f1_cmp0_leaf to i64
+  %ow_old_d0_f1_cmp0_eq = icmp eq i64 %ow_old_d0_f1_int, %ow_old_d0_f1_cmp0_int
+  %ow_old_d0_f1_matched0 = or i1 false, %ow_old_d0_f1_cmp0_eq
+  %ow_old_d0_f1_neutralized = select i1 %ow_old_d0_f1_matched0, ptr null, ptr %ow_old_d0_f1_val
+  store ptr %ow_old_d0_f1_neutralized, ptr %ow_old_d0_f1_ptr, align 8
+  call void @__hew_record_drop_inplace_CrashInfo(ptr %0)
+  ret void
 }
 
 ; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
@@ -1019,6 +1537,9 @@ declare i32 @hew_actor_cooperate()
 declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #0
 
 declare i32 @hew_lambda_drain_all(i64)
+
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
+declare { i64, i1 } @llvm.smul.with.overflow.i64(i64, i64) #0
 
 attributes #0 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #1 = { cold noreturn nounwind memory(inaccessiblemem: write) }

--- a/tests/ll-oracle/corpus/golden/native/r4_layout.ll
+++ b/tests/ll-oracle/corpus/golden/native/r4_layout.ll
@@ -1,9 +1,12 @@
 ; ModuleID = 'r4_layout'
 source_filename = "r4_layout"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-apple-macosx13.0"
 
 %Point = type { i64, i64 }
 %Color = type { i8, [1 x i8] }
 %"Option$$Point" = type { i8, [2 x i64] }
+%CrashInfo = type { i64, ptr }
 
 @__hew_layout_new_16_8_plain = private constant { i64, i64, i8 } { i64 16, i64 8, i8 0 }
 @__hew_layout_push_16_8_plain = private constant { i64, i64, i8 } { i64 16, i64 8, i8 0 }
@@ -12,7 +15,11 @@ source_filename = "r4_layout"
 @__hew_map_value_layout_16_8_plain = private constant { i64, i64, i8, ptr, ptr } { i64 16, i64 8, i8 0, ptr null, ptr null }
 @str_lit = private unnamed_addr constant [7 x i8] c"origin\00", align 1
 @str_lit.1 = private unnamed_addr constant [7 x i8] c"origin\00", align 1
+@str_lit.2 = private unnamed_addr constant [3 x i8] c"ns\00", align 1
 
+declare void @hew_sleep_ns(i64)
+
+declare void @hew_sleep_until_ns(i64)
 
 declare void @hew_exit(i64)
 
@@ -28,7 +35,7 @@ declare ptr @hew_i64_to_string(i64)
 
 declare ptr @hew_u8_to_string(i8)
 
-declare ptr @hew_uint_to_string(i16)
+declare ptr @hew_uint_to_string(i32)
 
 declare ptr @hew_u64_to_string(i64)
 
@@ -116,21 +123,13 @@ declare ptr @hew_string_split(ptr, ptr)
 
 declare ptr @hew_string_lines(ptr)
 
-declare i32 @hew_string_find(ptr, ptr)
-
-declare i32 @hew_string_index_of_start(ptr, ptr)
-
 declare ptr @hew_string_slice(ptr, i64, i64)
 
 declare ptr @hew_string_repeat(ptr, i64)
 
-declare i32 @hew_string_char_at(ptr, i32)
-
 declare ptr @hew_string_chars(ptr)
 
 declare i32 @hew_string_char_count(ptr)
-
-declare i32 @hew_string_char_at_utf8(ptr, i32)
 
 declare void @hew_vec_push_bool(ptr, i1)
 
@@ -236,7 +235,27 @@ declare ptr @hew_bytes_to_string(ptr)
 
 declare void @hew_vec_append(ptr, ptr)
 
-declare void @hew_vec_remove_at(ptr, i64)
+declare i1 @hew_vec_remove_at_bool(ptr, i64)
+
+declare i8 @hew_vec_remove_at_i8(ptr, i64)
+
+declare i8 @hew_vec_remove_at_u8(ptr, i64)
+
+declare i16 @hew_vec_remove_at_i16(ptr, i64)
+
+declare i16 @hew_vec_remove_at_u16(ptr, i64)
+
+declare i32 @hew_vec_remove_at_i32(ptr, i64)
+
+declare i64 @hew_vec_remove_at_i64(ptr, i64)
+
+declare float @hew_vec_remove_at_f32(ptr, i64)
+
+declare double @hew_vec_remove_at_f64(ptr, i64)
+
+declare ptr @hew_vec_remove_at_str(ptr, i64)
+
+declare ptr @hew_vec_remove_at_ptr(ptr, i64)
 
 declare ptr @hew_vec_clone(ptr)
 
@@ -262,6 +281,12 @@ declare void @hew_node_api_connect(ptr)
 
 declare void @hew_node_api_shutdown()
 
+declare void @hew_node_api_load_keys(ptr)
+
+declare void @hew_node_api_allow_peer(i16, ptr)
+
+declare ptr @hew_node_api_identity_key()
+
 declare i64 @hew_actor_pid(ptr)
 
 declare i32 @hew_node_api_register_by_pid(ptr, i64)
@@ -270,26 +295,42 @@ declare i64 @hew_remote_pid_from_raw(i64, i64)
 
 declare i64 @hew_node_api_lookup(ptr)
 
+declare ptr @hew_stream_channel(i64)
+
+declare ptr @hew_stream_pair_sink(ptr)
+
+declare ptr @hew_stream_pair_stream(ptr)
+
+declare void @hew_stream_pair_free(ptr)
+
+declare void @hew_sink_close(ptr)
+
+declare i32 @hew_sink_peer_closed(ptr)
+
+declare void @hew_actor_gen_sink_register(ptr, ptr)
+
+declare void @hew_actor_gen_sink_complete(ptr, ptr)
+
 define internal %Point @make_point(i64 %0, i64 %1) {
 entry:
   %return_slot = alloca %Point, align 8
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
   %local_2 = alloca %Point, align 8
-  store i64 %0, ptr %local_0, align 4
-  store i64 %1, ptr %local_1, align 4
+  store i64 %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
   %field_0_init_ptr = getelementptr inbounds nuw %Point, ptr %local_2, i32 0, i32 0
-  %field_0_init_src = load i64, ptr %local_0, align 4
-  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 4
+  %field_0_init_src = load i64, ptr %local_0, align 8
+  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 8
   %field_1_init_ptr = getelementptr inbounds nuw %Point, ptr %local_2, i32 0, i32 1
-  %field_1_init_src = load i64, ptr %local_1, align 4
-  store i64 %field_1_init_src, ptr %field_1_init_ptr, align 4
-  %move_load = load %Point, ptr %local_2, align 4
-  store %Point %move_load, ptr %return_slot, align 4
-  %ret_val = load %Point, ptr %return_slot, align 4
+  %field_1_init_src = load i64, ptr %local_1, align 8
+  store i64 %field_1_init_src, ptr %field_1_init_ptr, align 8
+  %move_load = load %Point, ptr %local_2, align 8
+  store %Point %move_load, ptr %return_slot, align 8
+  %ret_val = load %Point, ptr %return_slot, align 8
   ret %Point %ret_val
 }
 
@@ -317,10 +358,10 @@ bb0:                                              ; preds = %after_cooperate
   %machine_tag_ptr = getelementptr inbounds nuw %Color, ptr %local_0, i32 0, i32 0
   %move_iN_load = load i8, ptr %machine_tag_ptr, align 1
   %move_iN_zext = zext i8 %move_iN_load to i64
-  store i64 %move_iN_zext, ptr %local_2, align 4
-  store i64 0, ptr %local_3, align 4
-  %cmp_lhs = load i64, ptr %local_2, align 4
-  %cmp_rhs = load i64, ptr %local_3, align 4
+  store i64 %move_iN_zext, ptr %local_2, align 8
+  store i64 0, ptr %local_3, align 8
+  %cmp_lhs = load i64, ptr %local_2, align 8
+  %cmp_rhs = load i64, ptr %local_3, align 8
   %cmp_bit = icmp eq i64 %cmp_lhs, %cmp_rhs
   %cmp_zext = zext i1 %cmp_bit to i8
   store i8 %cmp_zext, ptr %local_4, align 1
@@ -329,31 +370,31 @@ bb0:                                              ; preds = %after_cooperate
   br i1 %cond_nz, label %bb2, label %bb6
 
 bb1:                                              ; preds = %after_cooperate15, %after_cooperate10, %after_cooperate5
-  %move_load = load i64, ptr %local_1, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load = load i64, ptr %local_1, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 
 bb2:                                              ; preds = %bb0
-  store i64 0, ptr %local_9, align 4
-  %move_load1 = load i64, ptr %local_9, align 4
-  store i64 %move_load1, ptr %local_1, align 4
+  store i64 0, ptr %local_9, align 8
+  %move_load1 = load i64, ptr %local_9, align 8
+  store i64 %move_load1, ptr %local_1, align 8
   %hew_actor_cooperate2 = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel3 = icmp eq i32 %hew_actor_cooperate2, 2
   br i1 %hew_cooperate_is_cancel3, label %cancel_exit4, label %after_cooperate5
 
 bb3:                                              ; preds = %bb6
-  store i64 1, ptr %local_10, align 4
-  %move_load6 = load i64, ptr %local_10, align 4
-  store i64 %move_load6, ptr %local_1, align 4
+  store i64 1, ptr %local_10, align 8
+  %move_load6 = load i64, ptr %local_10, align 8
+  store i64 %move_load6, ptr %local_1, align 8
   %hew_actor_cooperate7 = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel8 = icmp eq i32 %hew_actor_cooperate7, 2
   br i1 %hew_cooperate_is_cancel8, label %cancel_exit9, label %after_cooperate10
 
 bb4:                                              ; preds = %bb7
-  store i64 2, ptr %local_11, align 4
-  %move_load11 = load i64, ptr %local_11, align 4
-  store i64 %move_load11, ptr %local_1, align 4
+  store i64 2, ptr %local_11, align 8
+  %move_load11 = load i64, ptr %local_11, align 8
+  store i64 %move_load11, ptr %local_1, align 8
   %hew_actor_cooperate12 = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel13 = icmp eq i32 %hew_actor_cooperate12, 2
   br i1 %hew_cooperate_is_cancel13, label %cancel_exit14, label %after_cooperate15
@@ -364,9 +405,9 @@ bb5:                                              ; preds = %bb7
   unreachable
 
 bb6:                                              ; preds = %bb0
-  store i64 1, ptr %local_5, align 4
-  %cmp_lhs16 = load i64, ptr %local_2, align 4
-  %cmp_rhs17 = load i64, ptr %local_5, align 4
+  store i64 1, ptr %local_5, align 8
+  %cmp_lhs16 = load i64, ptr %local_2, align 8
+  %cmp_rhs17 = load i64, ptr %local_5, align 8
   %cmp_bit18 = icmp eq i64 %cmp_lhs16, %cmp_rhs17
   %cmp_zext19 = zext i1 %cmp_bit18 to i8
   store i8 %cmp_zext19, ptr %local_6, align 1
@@ -375,9 +416,9 @@ bb6:                                              ; preds = %bb0
   br i1 %cond_nz21, label %bb3, label %bb7
 
 bb7:                                              ; preds = %bb6
-  store i64 2, ptr %local_7, align 4
-  %cmp_lhs22 = load i64, ptr %local_2, align 4
-  %cmp_rhs23 = load i64, ptr %local_7, align 4
+  store i64 2, ptr %local_7, align 8
+  %cmp_lhs22 = load i64, ptr %local_2, align 8
+  %cmp_rhs23 = load i64, ptr %local_7, align 8
   %cmp_bit24 = icmp eq i64 %cmp_lhs22, %cmp_rhs23
   %cmp_zext25 = zext i1 %cmp_bit24 to i8
   store i8 %cmp_zext25, ptr %local_8, align 1
@@ -455,41 +496,39 @@ entry:
   %local_39 = alloca i64, align 8
   %local_40 = alloca i8, align 1
   %local_41 = alloca i64, align 8
-  %local_42 = alloca i64, align 8
-  %local_43 = alloca i8, align 1
-  %local_44 = alloca %Color, align 8
+  %local_42 = alloca %Color, align 8
+  %local_43 = alloca i64, align 8
+  %local_44 = alloca i64, align 8
   %local_45 = alloca i64, align 8
-  %local_46 = alloca i64, align 8
-  %local_47 = alloca i64, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  store i64 3, ptr %local_0, align 4
-  store i64 4, ptr %local_1, align 4
-  %call_arg = load i64, ptr %local_0, align 4
-  %call_arg1 = load i64, ptr %local_1, align 4
+  store i64 3, ptr %local_0, align 8
+  store i64 4, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_0, align 8
+  %call_arg1 = load i64, ptr %local_1, align 8
   %call_result = call %Point @make_point(i64 %call_arg, i64 %call_arg1)
-  store %Point %call_result, ptr %local_2, align 4
+  store %Point %call_result, ptr %local_2, align 8
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load %Point, ptr %local_2, align 4
-  store %Point %move_load, ptr %local_3, align 4
+  %move_load = load %Point, ptr %local_2, align 8
+  store %Point %move_load, ptr %local_3, align 8
   %field_0_load_ptr = getelementptr inbounds nuw %Point, ptr %local_3, i32 0, i32 0
-  %field_0_load = load i64, ptr %field_0_load_ptr, align 4
-  store i64 %field_0_load, ptr %local_4, align 4
+  %field_0_load = load i64, ptr %field_0_load_ptr, align 8
+  store i64 %field_0_load, ptr %local_4, align 8
   %field_1_load_ptr = getelementptr inbounds nuw %Point, ptr %local_3, i32 0, i32 1
-  %field_1_load = load i64, ptr %field_1_load_ptr, align 4
-  store i64 %field_1_load, ptr %local_5, align 4
-  %checked_lhs = load i64, ptr %local_4, align 4
-  %checked_rhs = load i64, ptr %local_5, align 4
+  %field_1_load = load i64, ptr %field_1_load_ptr, align 8
+  store i64 %field_1_load, ptr %local_5, align 8
+  %checked_lhs = load i64, ptr %local_4, align 8
+  %checked_rhs = load i64, ptr %local_5, align 8
   %with_overflow = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_6, align 4
+  store i64 %checked_result, ptr %local_6, align 8
   store i8 %checked_overflow_widen, ptr %local_7, align 1
   %cond_load = load i8, ptr %local_7, align 1
   %cond_nz = icmp ne i8 %cond_load, 0
@@ -501,7 +540,7 @@ bb2:                                              ; preds = %bb1
   unreachable
 
 bb3:                                              ; preds = %bb1
-  %print_arg = load i64, ptr %local_6, align 4
+  %print_arg = load i64, ptr %local_6, align 8
   call void @hew_print_value(i8 1, i64 %print_arg, i1 true)
   br label %bb4
 
@@ -513,38 +552,38 @@ bb4:                                              ; preds = %bb3
 bb5:                                              ; preds = %bb4
   %move_load2 = load ptr, ptr %local_8, align 8
   store ptr %move_load2, ptr %local_9, align 8
-  store i64 10, ptr %local_10, align 4
-  store i64 20, ptr %local_11, align 4
+  store i64 10, ptr %local_10, align 8
+  store i64 20, ptr %local_11, align 8
   %field_0_init_ptr = getelementptr inbounds nuw %Point, ptr %local_12, i32 0, i32 0
-  %field_0_init_src = load i64, ptr %local_10, align 4
-  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 4
+  %field_0_init_src = load i64, ptr %local_10, align 8
+  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 8
   %field_1_init_ptr = getelementptr inbounds nuw %Point, ptr %local_12, i32 0, i32 1
-  %field_1_init_src = load i64, ptr %local_11, align 4
-  store i64 %field_1_init_src, ptr %field_1_init_ptr, align 4
+  %field_1_init_src = load i64, ptr %local_11, align 8
+  store i64 %field_1_init_src, ptr %field_1_init_ptr, align 8
   %"hew_vec_push_layout arg0" = load ptr, ptr %local_9, align 8
   call void @hew_vec_push_layout(ptr %"hew_vec_push_layout arg0", ptr %local_12, ptr @__hew_layout_push_16_8_plain)
   br label %bb6
 
 bb6:                                              ; preds = %bb5
-  store i64 5, ptr %local_13, align 4
-  store i64 5, ptr %local_14, align 4
+  store i64 5, ptr %local_13, align 8
+  store i64 5, ptr %local_14, align 8
   %field_0_init_ptr3 = getelementptr inbounds nuw %Point, ptr %local_15, i32 0, i32 0
-  %field_0_init_src4 = load i64, ptr %local_13, align 4
-  store i64 %field_0_init_src4, ptr %field_0_init_ptr3, align 4
+  %field_0_init_src4 = load i64, ptr %local_13, align 8
+  store i64 %field_0_init_src4, ptr %field_0_init_ptr3, align 8
   %field_1_init_ptr5 = getelementptr inbounds nuw %Point, ptr %local_15, i32 0, i32 1
-  %field_1_init_src6 = load i64, ptr %local_14, align 4
-  store i64 %field_1_init_src6, ptr %field_1_init_ptr5, align 4
+  %field_1_init_src6 = load i64, ptr %local_14, align 8
+  store i64 %field_1_init_src6, ptr %field_1_init_ptr5, align 8
   %"hew_vec_push_layout arg07" = load ptr, ptr %local_9, align 8
   call void @hew_vec_push_layout(ptr %"hew_vec_push_layout arg07", ptr %local_15, ptr @__hew_layout_push_16_8_plain)
   br label %bb7
 
 bb7:                                              ; preds = %bb6
-  store i64 0, ptr %local_16, align 4
+  store i64 0, ptr %local_16, align 8
   %"hew_vec_len arg0" = load ptr, ptr %local_9, align 8
   %hew_vec_len_call = call i64 @hew_vec_len(ptr %"hew_vec_len arg0")
-  store i64 %hew_vec_len_call, ptr %local_17, align 4
-  %cmp_lhs = load i64, ptr %local_16, align 4
-  %cmp_rhs = load i64, ptr %local_17, align 4
+  store i64 %hew_vec_len_call, ptr %local_17, align 8
+  %cmp_lhs = load i64, ptr %local_16, align 8
+  %cmp_rhs = load i64, ptr %local_17, align 8
   %cmp_bit = icmp uge i64 %cmp_lhs, %cmp_rhs
   %cmp_zext = zext i1 %cmp_bit to i8
   store i8 %cmp_zext, ptr %local_18, align 1
@@ -562,16 +601,16 @@ bb8:                                              ; preds = %bb7
 
 bb9:                                              ; preds = %bb7
   %"hew_vec_get_layout arg0" = load ptr, ptr %local_9, align 8
-  %"hew_vec_get_layout arg1" = load i64, ptr %local_16, align 4
+  %"hew_vec_get_layout arg1" = load i64, ptr %local_16, align 8
   %hew_vec_get_layout_call = call ptr @hew_vec_get_layout(ptr %"hew_vec_get_layout arg0", i64 %"hew_vec_get_layout arg1", ptr @__hew_layout_get_16_8_plain)
-  %hew_vec_get_layout_load = load %Point, ptr %hew_vec_get_layout_call, align 4
-  store %Point %hew_vec_get_layout_load, ptr %local_19, align 4
-  %move_load10 = load %Point, ptr %local_19, align 4
-  store %Point %move_load10, ptr %local_20, align 4
+  %hew_vec_get_layout_load = load %Point, ptr %hew_vec_get_layout_call, align 8
+  store %Point %hew_vec_get_layout_load, ptr %local_19, align 8
+  %move_load10 = load %Point, ptr %local_19, align 8
+  store %Point %move_load10, ptr %local_20, align 8
   %field_0_load_ptr11 = getelementptr inbounds nuw %Point, ptr %local_20, i32 0, i32 0
-  %field_0_load12 = load i64, ptr %field_0_load_ptr11, align 4
-  store i64 %field_0_load12, ptr %local_21, align 4
-  %print_arg13 = load i64, ptr %local_21, align 4
+  %field_0_load12 = load i64, ptr %field_0_load_ptr11, align 8
+  store i64 %field_0_load12, ptr %local_21, align 8
+  %print_arg13 = load i64, ptr %local_21, align 8
   call void @hew_print_value(i8 1, i64 %print_arg13, i1 true)
   br label %bb10
 
@@ -584,33 +623,35 @@ bb11:                                             ; preds = %bb10
   %move_load14 = load ptr, ptr %local_22, align 8
   store ptr %move_load14, ptr %local_23, align 8
   store ptr @str_lit, ptr %local_24, align 8
-  store i64 0, ptr %local_25, align 4
-  store i64 0, ptr %local_26, align 4
+  store i64 0, ptr %local_25, align 8
+  store i64 0, ptr %local_26, align 8
   %field_0_init_ptr15 = getelementptr inbounds nuw %Point, ptr %local_27, i32 0, i32 0
-  %field_0_init_src16 = load i64, ptr %local_25, align 4
-  store i64 %field_0_init_src16, ptr %field_0_init_ptr15, align 4
+  %field_0_init_src16 = load i64, ptr %local_25, align 8
+  store i64 %field_0_init_src16, ptr %field_0_init_ptr15, align 8
   %field_1_init_ptr17 = getelementptr inbounds nuw %Point, ptr %local_27, i32 0, i32 1
-  %field_1_init_src18 = load i64, ptr %local_26, align 4
-  store i64 %field_1_init_src18, ptr %field_1_init_ptr17, align 4
+  %field_1_init_src18 = load i64, ptr %local_26, align 8
+  store i64 %field_1_init_src18, ptr %field_1_init_ptr17, align 8
   %"hew_hashmap_insert_layout arg0" = load ptr, ptr %local_23, align 8
   %hew_hashmap_insert_layout_call = call i1 @hew_hashmap_insert_layout(ptr %"hew_hashmap_insert_layout arg0", ptr %local_24, ptr %local_27)
-  br label %bb12
+  %insert_existed = icmp eq i1 %hew_hashmap_insert_layout_call, false
+  br i1 %insert_existed, label %insert_overwrite_key_release, label %insert_overwrite_key_cont
 
-bb12:                                             ; preds = %bb11
+bb12:                                             ; preds = %insert_overwrite_key_cont
   store ptr @str_lit.1, ptr %local_29, align 8
   %"hew_hashmap_get_layout arg0" = load ptr, ptr %local_23, align 8
-  %hew_hashmap_get_layout_call = call ptr @hew_hashmap_get_layout(ptr %"hew_hashmap_get_layout arg0", ptr %local_29)
-  %hashmap_get_is_some = icmp ne ptr %hew_hashmap_get_layout_call, null
-  br i1 %hashmap_get_is_some, label %hashmap_get_some, label %hashmap_get_none
+  %machine_payload_ptr = getelementptr inbounds nuw %"Option$$Point", ptr %local_30, i32 0, i32 1
+  %machine_variant_field_ptr = getelementptr inbounds nuw { %Point }, ptr %machine_payload_ptr, i32 0, i32 0
+  %hew_hashmap_get_clone_layout_call = call i1 @hew_hashmap_get_clone_layout(ptr %"hew_hashmap_get_layout arg0", ptr %local_29, ptr %machine_variant_field_ptr)
+  br i1 %hew_hashmap_get_clone_layout_call, label %hashmap_get_some, label %hashmap_get_none
 
 bb13:                                             ; preds = %hashmap_get_some, %hashmap_get_none
   %machine_tag_ptr20 = getelementptr inbounds nuw %"Option$$Point", ptr %local_30, i32 0, i32 0
   %move_iN_load = load i8, ptr %machine_tag_ptr20, align 1
   %move_iN_zext = zext i8 %move_iN_load to i64
-  store i64 %move_iN_zext, ptr %local_31, align 4
-  store i64 0, ptr %local_32, align 4
-  %cmp_lhs21 = load i64, ptr %local_31, align 4
-  %cmp_rhs22 = load i64, ptr %local_32, align 4
+  store i64 %move_iN_zext, ptr %local_31, align 8
+  store i64 0, ptr %local_32, align 8
+  %cmp_lhs21 = load i64, ptr %local_31, align 8
+  %cmp_rhs22 = load i64, ptr %local_32, align 8
   %cmp_bit23 = icmp eq i64 %cmp_lhs21, %cmp_rhs22
   %cmp_zext24 = zext i1 %cmp_bit23 to i8
   store i8 %cmp_zext24, ptr %local_33, align 1
@@ -618,134 +659,111 @@ bb13:                                             ; preds = %hashmap_get_some, %
   %cond_nz26 = icmp ne i8 %cond_load25, 0
   br i1 %cond_nz26, label %bb15, label %bb18
 
-bb14:                                             ; preds = %after_cooperate69, %after_cooperate60
-  store i64 1, ptr %local_45, align 4
-  %machine_tag_ptr27 = getelementptr inbounds nuw %Color, ptr %local_44, i32 0, i32 0
-  %move_iN_load_wide = load i64, ptr %local_45, align 4
+bb14:                                             ; preds = %after_cooperate65, %after_cooperate59
+  store i64 1, ptr %local_43, align 8
+  %machine_tag_ptr27 = getelementptr inbounds nuw %Color, ptr %local_42, i32 0, i32 0
+  %move_iN_load_wide = load i64, ptr %local_43, align 8
   %move_iN_trunc = trunc i64 %move_iN_load_wide to i8
   store i8 %move_iN_trunc, ptr %machine_tag_ptr27, align 1
-  %call_arg28 = load %Color, ptr %local_44, align 1
+  %call_arg28 = load %Color, ptr %local_42, align 1
   %call_result29 = call i64 @color_code(%Color %call_arg28)
-  store i64 %call_result29, ptr %local_46, align 4
-  br label %bb25
+  store i64 %call_result29, ptr %local_44, align 8
+  br label %bb23
 
 bb15:                                             ; preds = %bb13
   %machine_payload_ptr30 = getelementptr inbounds nuw %"Option$$Point", ptr %local_30, i32 0, i32 1
   %machine_variant_field_ptr31 = getelementptr inbounds nuw { %Point }, ptr %machine_payload_ptr30, i32 0, i32 0
-  %move_load32 = load %Point, ptr %machine_variant_field_ptr31, align 4
-  store %Point %move_load32, ptr %local_36, align 4
+  %move_load32 = load %Point, ptr %machine_variant_field_ptr31, align 8
+  store %Point %move_load32, ptr %local_36, align 8
   %field_0_load_ptr33 = getelementptr inbounds nuw %Point, ptr %local_36, i32 0, i32 0
-  %field_0_load34 = load i64, ptr %field_0_load_ptr33, align 4
-  store i64 %field_0_load34, ptr %local_37, align 4
+  %field_0_load34 = load i64, ptr %field_0_load_ptr33, align 8
+  store i64 %field_0_load34, ptr %local_37, align 8
   %field_1_load_ptr35 = getelementptr inbounds nuw %Point, ptr %local_36, i32 0, i32 1
-  %field_1_load36 = load i64, ptr %field_1_load_ptr35, align 4
-  store i64 %field_1_load36, ptr %local_38, align 4
-  %checked_lhs37 = load i64, ptr %local_37, align 4
-  %checked_rhs38 = load i64, ptr %local_38, align 4
+  %field_1_load36 = load i64, ptr %field_1_load_ptr35, align 8
+  store i64 %field_1_load36, ptr %local_38, align 8
+  %checked_lhs37 = load i64, ptr %local_37, align 8
+  %checked_rhs38 = load i64, ptr %local_38, align 8
   %with_overflow39 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs37, i64 %checked_rhs38)
   %checked_result40 = extractvalue { i64, i1 } %with_overflow39, 0
   %checked_overflow41 = extractvalue { i64, i1 } %with_overflow39, 1
   %checked_overflow_widen42 = zext i1 %checked_overflow41 to i8
-  store i64 %checked_result40, ptr %local_39, align 4
+  store i64 %checked_result40, ptr %local_39, align 8
   store i8 %checked_overflow_widen42, ptr %local_40, align 1
   %cond_load43 = load i8, ptr %local_40, align 1
   %cond_nz44 = icmp ne i8 %cond_load43, 0
   br i1 %cond_nz44, label %bb19, label %bb20
 
 bb16:                                             ; preds = %bb18
-  store i64 1, ptr %local_41, align 4
-  %ineg_operand = load i64, ptr %local_41, align 4
-  %neg_with_overflow = call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 0, i64 %ineg_operand)
-  %neg_result = extractvalue { i64, i1 } %neg_with_overflow, 0
-  %neg_overflow = extractvalue { i64, i1 } %neg_with_overflow, 1
-  %neg_overflow_widen = zext i1 %neg_overflow to i8
-  store i64 %neg_result, ptr %local_42, align 4
-  store i8 %neg_overflow_widen, ptr %local_43, align 1
-  %cond_load45 = load i8, ptr %local_43, align 1
-  %cond_nz46 = icmp ne i8 %cond_load45, 0
-  br i1 %cond_nz46, label %bb22, label %bb23
+  store i64 -1, ptr %local_41, align 8
+  %print_arg45 = load i64, ptr %local_41, align 8
+  call void @hew_print_value(i8 1, i64 %print_arg45, i1 true)
+  br label %bb22
 
 bb17:                                             ; preds = %bb18
   %"hew_hashmap_free_layout drop" = load ptr, ptr %local_23, align 8
   call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop")
   store ptr null, ptr %local_23, align 8
-  %"hew_vec_free drop47" = load ptr, ptr %local_9, align 8
-  call void @hew_vec_free(ptr %"hew_vec_free drop47")
+  %"hew_vec_free drop46" = load ptr, ptr %local_9, align 8
+  call void @hew_vec_free(ptr %"hew_vec_free drop46")
   store ptr null, ptr %local_9, align 8
   call void @hew_trap_with_code(i32 208)
   call void @llvm.trap()
   unreachable
 
 bb18:                                             ; preds = %bb13
-  store i64 1, ptr %local_34, align 4
-  %cmp_lhs48 = load i64, ptr %local_31, align 4
-  %cmp_rhs49 = load i64, ptr %local_34, align 4
-  %cmp_bit50 = icmp eq i64 %cmp_lhs48, %cmp_rhs49
-  %cmp_zext51 = zext i1 %cmp_bit50 to i8
-  store i8 %cmp_zext51, ptr %local_35, align 1
-  %cond_load52 = load i8, ptr %local_35, align 1
-  %cond_nz53 = icmp ne i8 %cond_load52, 0
-  br i1 %cond_nz53, label %bb16, label %bb17
+  store i64 1, ptr %local_34, align 8
+  %cmp_lhs47 = load i64, ptr %local_31, align 8
+  %cmp_rhs48 = load i64, ptr %local_34, align 8
+  %cmp_bit49 = icmp eq i64 %cmp_lhs47, %cmp_rhs48
+  %cmp_zext50 = zext i1 %cmp_bit49 to i8
+  store i8 %cmp_zext50, ptr %local_35, align 1
+  %cond_load51 = load i8, ptr %local_35, align 1
+  %cond_nz52 = icmp ne i8 %cond_load51, 0
+  br i1 %cond_nz52, label %bb16, label %bb17
 
 bb19:                                             ; preds = %bb15
-  %"hew_hashmap_free_layout drop54" = load ptr, ptr %local_23, align 8
-  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop54")
+  %"hew_hashmap_free_layout drop53" = load ptr, ptr %local_23, align 8
+  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop53")
   store ptr null, ptr %local_23, align 8
-  %"hew_vec_free drop55" = load ptr, ptr %local_9, align 8
-  call void @hew_vec_free(ptr %"hew_vec_free drop55")
+  %"hew_vec_free drop54" = load ptr, ptr %local_9, align 8
+  call void @hew_vec_free(ptr %"hew_vec_free drop54")
   store ptr null, ptr %local_9, align 8
   call void @hew_trap_with_code(i32 201)
   call void @llvm.trap()
   unreachable
 
 bb20:                                             ; preds = %bb15
-  %print_arg56 = load i64, ptr %local_39, align 4
-  call void @hew_print_value(i8 1, i64 %print_arg56, i1 true)
+  %print_arg55 = load i64, ptr %local_39, align 8
+  call void @hew_print_value(i8 1, i64 %print_arg55, i1 true)
   br label %bb21
 
 bb21:                                             ; preds = %bb20
-  %hew_actor_cooperate57 = call i32 @hew_actor_cooperate()
-  %hew_cooperate_is_cancel58 = icmp eq i32 %hew_actor_cooperate57, 2
-  br i1 %hew_cooperate_is_cancel58, label %cancel_exit59, label %after_cooperate60
+  %hew_actor_cooperate56 = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel57 = icmp eq i32 %hew_actor_cooperate56, 2
+  br i1 %hew_cooperate_is_cancel57, label %cancel_exit58, label %after_cooperate59
 
 bb22:                                             ; preds = %bb16
-  %"hew_hashmap_free_layout drop63" = load ptr, ptr %local_23, align 8
-  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop63")
-  store ptr null, ptr %local_23, align 8
-  %"hew_vec_free drop64" = load ptr, ptr %local_9, align 8
-  call void @hew_vec_free(ptr %"hew_vec_free drop64")
-  store ptr null, ptr %local_9, align 8
-  call void @hew_trap_with_code(i32 201)
-  call void @llvm.trap()
-  unreachable
+  %hew_actor_cooperate62 = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel63 = icmp eq i32 %hew_actor_cooperate62, 2
+  br i1 %hew_cooperate_is_cancel63, label %cancel_exit64, label %after_cooperate65
 
-bb23:                                             ; preds = %bb16
-  %print_arg65 = load i64, ptr %local_42, align 4
-  call void @hew_print_value(i8 1, i64 %print_arg65, i1 true)
+bb23:                                             ; preds = %bb14
+  %print_arg68 = load i64, ptr %local_44, align 8
+  call void @hew_print_value(i8 1, i64 %print_arg68, i1 true)
   br label %bb24
 
 bb24:                                             ; preds = %bb23
-  %hew_actor_cooperate66 = call i32 @hew_actor_cooperate()
-  %hew_cooperate_is_cancel67 = icmp eq i32 %hew_actor_cooperate66, 2
-  br i1 %hew_cooperate_is_cancel67, label %cancel_exit68, label %after_cooperate69
-
-bb25:                                             ; preds = %bb14
-  %print_arg72 = load i64, ptr %local_46, align 4
-  call void @hew_print_value(i8 1, i64 %print_arg72, i1 true)
-  br label %bb26
-
-bb26:                                             ; preds = %bb25
-  store i64 0, ptr %local_47, align 4
-  %move_load73 = load i64, ptr %local_47, align 4
-  store i64 %move_load73, ptr %return_slot, align 4
-  %"hew_hashmap_free_layout drop74" = load ptr, ptr %local_23, align 8
-  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop74")
+  store i64 0, ptr %local_45, align 8
+  %move_load69 = load i64, ptr %local_45, align 8
+  store i64 %move_load69, ptr %return_slot, align 8
+  %"hew_hashmap_free_layout drop70" = load ptr, ptr %local_23, align 8
+  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop70")
   store ptr null, ptr %local_23, align 8
-  %"hew_vec_free drop75" = load ptr, ptr %local_9, align 8
-  call void @hew_vec_free(ptr %"hew_vec_free drop75")
+  %"hew_vec_free drop71" = load ptr, ptr %local_9, align 8
+  call void @hew_vec_free(ptr %"hew_vec_free drop71")
   store ptr null, ptr %local_9, align 8
   %hew_lambda_drain_all_call = call i32 @hew_lambda_drain_all(i64 0)
-  %ret_val = load i64, ptr %return_slot, align 4
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -753,6 +771,14 @@ cancel_exit:                                      ; preds = %entry
 
 after_cooperate:                                  ; preds = %entry
   br label %bb0
+
+insert_overwrite_key_release:                     ; preds = %bb11
+  %"hew_hashmap_insert_layout overwrite key" = load ptr, ptr %local_24, align 8
+  call void @hew_string_drop(ptr %"hew_hashmap_insert_layout overwrite key")
+  br label %insert_overwrite_key_cont
+
+insert_overwrite_key_cont:                        ; preds = %insert_overwrite_key_release, %bb11
+  br label %bb12
 
 hashmap_get_none:                                 ; preds = %bb12
   %machine_tag_ptr = getelementptr inbounds nuw %"Option$$Point", ptr %local_30, i32 0, i32 0
@@ -762,34 +788,97 @@ hashmap_get_none:                                 ; preds = %bb12
 hashmap_get_some:                                 ; preds = %bb12
   %machine_tag_ptr19 = getelementptr inbounds nuw %"Option$$Point", ptr %local_30, i32 0, i32 0
   store i8 0, ptr %machine_tag_ptr19, align 1
-  %machine_payload_ptr = getelementptr inbounds nuw %"Option$$Point", ptr %local_30, i32 0, i32 1
-  %machine_variant_field_ptr = getelementptr inbounds nuw { %Point }, ptr %machine_payload_ptr, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %machine_variant_field_ptr, ptr align 8 %hew_hashmap_get_layout_call, i64 16, i1 false)
   br label %bb13
 
-cancel_exit59:                                    ; preds = %bb21
-  %"hew_hashmap_free_layout drop61" = load ptr, ptr %local_23, align 8
-  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop61")
+cancel_exit58:                                    ; preds = %bb21
+  %"hew_hashmap_free_layout drop60" = load ptr, ptr %local_23, align 8
+  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop60")
   store ptr null, ptr %local_23, align 8
-  %"hew_vec_free drop62" = load ptr, ptr %local_9, align 8
-  call void @hew_vec_free(ptr %"hew_vec_free drop62")
+  %"hew_vec_free drop61" = load ptr, ptr %local_9, align 8
+  call void @hew_vec_free(ptr %"hew_vec_free drop61")
   store ptr null, ptr %local_9, align 8
   ret i64 0
 
-after_cooperate60:                                ; preds = %bb21
+after_cooperate59:                                ; preds = %bb21
   br label %bb14
 
-cancel_exit68:                                    ; preds = %bb24
-  %"hew_hashmap_free_layout drop70" = load ptr, ptr %local_23, align 8
-  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop70")
+cancel_exit64:                                    ; preds = %bb22
+  %"hew_hashmap_free_layout drop66" = load ptr, ptr %local_23, align 8
+  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop66")
   store ptr null, ptr %local_23, align 8
-  %"hew_vec_free drop71" = load ptr, ptr %local_9, align 8
-  call void @hew_vec_free(ptr %"hew_vec_free drop71")
+  %"hew_vec_free drop67" = load ptr, ptr %local_9, align 8
+  call void @hew_vec_free(ptr %"hew_vec_free drop67")
   store ptr null, ptr %local_9, align 8
   ret i64 0
 
-after_cooperate69:                                ; preds = %bb24
+after_cooperate65:                                ; preds = %bb22
   br label %bb14
+}
+
+define internal ptr @"i8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 8
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i8, ptr %local_0, align 1
+  %cast_int_sext = sext i8 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"i16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 8
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i16, ptr %local_0, align 2
+  %cast_int_sext = sext i16 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
 }
 
 define internal ptr @"i32::fmt"(i32 %0) {
@@ -826,14 +915,73 @@ entry:
   %return_slot = alloca ptr, align 8
   %local_0 = alloca i64, align 8
   %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_1, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i8, ptr %local_0, align 1
+  %call_result = call ptr @hew_u8_to_string(i8 %call_arg)
+  store ptr %call_result, ptr %local_1, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca ptr, align 8
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i16, ptr %local_0, align 2
+  %ffi_zext = zext i16 %call_arg to i32
+  %call_result = call ptr @hew_uint_to_string(i32 %ffi_zext)
   store ptr %call_result, ptr %local_1, align 8
   br label %bb1
 
@@ -862,8 +1010,7 @@ entry:
 
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
-  %ffi_arg_trunc = trunc i32 %call_arg to i16
-  %call_result = call ptr @hew_uint_to_string(i16 %ffi_arg_trunc)
+  %call_result = call ptr @hew_uint_to_string(i32 %call_arg)
   store ptr %call_result, ptr %local_1, align 8
   br label %bb1
 
@@ -885,19 +1032,83 @@ entry:
   %return_slot = alloca ptr, align 8
   %local_0 = alloca i64, align 8
   %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
   store ptr %call_result, ptr %local_1, align 8
   br label %bb1
 
 bb1:                                              ; preds = %bb0
   %move_load = load ptr, ptr %local_1, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"isize::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 8
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i64, ptr %local_0, align 8
+  store i64 %cast_int_src, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"usize::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 8
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i64, ptr %local_0, align 8
+  store i64 %cast_int_src, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
   store ptr %move_load, ptr %return_slot, align 8
   %ret_val = load ptr, ptr %return_slot, align 8
   ret ptr %ret_val
@@ -996,6 +1207,39 @@ after_cooperate:                                  ; preds = %entry
   br label %bb0
 }
 
+define internal ptr @"f32::fmt"(float %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca float, align 4
+  %local_1 = alloca double, align 8
+  %local_2 = alloca ptr, align 8
+  store float %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_float_src = load float, ptr %local_0, align 4
+  %cast_float_ext = fpext float %cast_float_src to double
+  store double %cast_float_ext, ptr %local_1, align 8
+  %call_arg = load double, ptr %local_1, align 8
+  %call_result = call ptr @hew_float_to_string(double %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
 define internal ptr @"string::fmt"(ptr %0) {
 entry:
   %return_slot = alloca ptr, align 8
@@ -1004,10 +1248,199 @@ entry:
   br label %bb0
 
 bb0:                                              ; preds = %entry
+  %mir_share_string_load = load ptr, ptr %local_0, align 8
+  %mir_share_string_retain = call ptr @hew_string_clone(ptr %mir_share_string_load)
   %move_load = load ptr, ptr %local_0, align 8
   store ptr %move_load, ptr %return_slot, align 8
   %ret_val = load ptr, ptr %return_slot, align 8
   ret ptr %ret_val
+}
+
+define internal i64 @"duration::from_nanos"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_micros"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_millis"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_secs"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal ptr @"duration::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %hew_duration_nanos = load i64, ptr %local_0, align 8
+  %hew_duration_nanos_call = call i64 @hew_duration_nanos(i64 %hew_duration_nanos)
+  store i64 %hew_duration_nanos_call, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  store ptr @str_lit.2, ptr %local_3, align 8
+  %"hew_string_concat arg0" = load ptr, ptr %local_2, align 8
+  %"hew_string_concat arg1" = load ptr, ptr %local_3, align 8
+  %hew_string_concat_call = call ptr @hew_string_concat(ptr %"hew_string_concat arg0", ptr %"hew_string_concat arg1")
+  store ptr %hew_string_concat_call, ptr %local_4, align 8
+  %"hew_string_drop drop" = load ptr, ptr %local_2, align 8
+  call void @hew_string_drop(ptr %"hew_string_drop drop")
+  store ptr null, ptr %local_2, align 8
+  %move_load = load ptr, ptr %local_4, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
 }
 
 define internal i32 @__hew_record_clone_inplace_Point(ptr %0, ptr %1) {
@@ -1034,9 +1467,74 @@ done:                                             ; preds = %do_drop, %entry
   ret void
 }
 
+define internal i32 @__hew_record_clone_inplace_CrashInfo(ptr %0, ptr %1) {
+entry:
+  br label %step_0_clone
+
+success:                                          ; preds = %step_0_store
+  ret i32 0
+
+fail:                                             ; preds = %rb_step_0
+  ret i32 1
+
+rb_step_0:                                        ; preds = %step_0_clone
+  br label %fail
+
+step_0_store:                                     ; preds = %step_0_clone
+  %dst_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  store ptr %clone_helper_f1, ptr %dst_f1_ptr, align 8
+  br label %success
+
+step_0_clone:                                     ; preds = %entry
+  %src_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %src_f1 = load ptr, ptr %src_f1_ptr, align 8
+  %clone_helper_f1 = call ptr @hew_string_clone(ptr %src_f1)
+  %cloned_f1_int = ptrtoint ptr %clone_helper_f1 to i64
+  %cloned_f1_null = icmp eq i64 %cloned_f1_int, 0
+  br i1 %cloned_f1_null, label %rb_step_0, label %step_0_store
+}
+
+define internal void @__hew_record_drop_inplace_CrashInfo(ptr %0) {
+entry:
+  %rec_int = ptrtoint ptr %0 to i64
+  %rec_is_null = icmp eq i64 %rec_int, 0
+  br i1 %rec_is_null, label %done, label %do_drop
+
+do_drop:                                          ; preds = %entry
+  %drop_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %drop_f1 = load ptr, ptr %drop_f1_ptr, align 8
+  call void @hew_string_drop(ptr %drop_f1)
+  br label %done
+
+done:                                             ; preds = %do_drop, %entry
+  ret void
+}
+
+declare void @hew_string_drop(ptr)
+
 define internal void @__hew_record_overwrite_release_Point(ptr %0, ptr %1) {
 entry:
   call void @__hew_record_drop_inplace_Point(ptr %0)
+  ret void
+}
+
+define internal void @__hew_record_overwrite_release_CrashInfo(ptr %0, ptr %1) {
+entry:
+  %ow_slot_0 = alloca ptr, align 8
+  store ptr null, ptr %ow_slot_0, align 8
+  %ow_new_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  %ow_new_d0_f1_leaf = load ptr, ptr %ow_new_d0_f1_ptr, align 8
+  store ptr %ow_new_d0_f1_leaf, ptr %ow_slot_0, align 8
+  %ow_old_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %ow_old_d0_f1_val = load ptr, ptr %ow_old_d0_f1_ptr, align 8
+  %ow_old_d0_f1_int = ptrtoint ptr %ow_old_d0_f1_val to i64
+  %ow_old_d0_f1_cmp0_leaf = load ptr, ptr %ow_slot_0, align 8
+  %ow_old_d0_f1_cmp0_int = ptrtoint ptr %ow_old_d0_f1_cmp0_leaf to i64
+  %ow_old_d0_f1_cmp0_eq = icmp eq i64 %ow_old_d0_f1_int, %ow_old_d0_f1_cmp0_int
+  %ow_old_d0_f1_matched0 = or i1 false, %ow_old_d0_f1_cmp0_eq
+  %ow_old_d0_f1_neutralized = select i1 %ow_old_d0_f1_matched0, ptr null, ptr %ow_old_d0_f1_val
+  store ptr %ow_old_d0_f1_neutralized, ptr %ow_old_d0_f1_ptr, align 8
+  call void @__hew_record_drop_inplace_CrashInfo(ptr %0)
   ret void
 }
 
@@ -1062,18 +1560,14 @@ declare ptr @hew_hashmap_new_with_layout(ptr, ptr)
 
 declare i1 @hew_hashmap_insert_layout(ptr, ptr, ptr)
 
-declare ptr @hew_hashmap_get_layout(ptr, ptr)
-
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #2
-
-; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
-declare { i64, i1 } @llvm.ssub.with.overflow.i64(i64, i64) #1
+declare i1 @hew_hashmap_get_clone_layout(ptr, ptr, ptr)
 
 declare void @hew_hashmap_free_layout(ptr)
 
 declare i32 @hew_lambda_drain_all(i64)
 
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
+declare { i64, i1 } @llvm.smul.with.overflow.i64(i64, i64) #1
+
 attributes #0 = { cold noreturn nounwind memory(inaccessiblemem: write) }
 attributes #1 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }

--- a/tests/ll-oracle/corpus/golden/native/r4_runtime_abi.ll
+++ b/tests/ll-oracle/corpus/golden/native/r4_runtime_abi.ll
@@ -123,19 +123,13 @@ declare ptr @hew_string_split(ptr, ptr)
 
 declare ptr @hew_string_lines(ptr)
 
-declare i32 @hew_string_find(ptr, ptr)
-
 declare ptr @hew_string_slice(ptr, i64, i64)
 
 declare ptr @hew_string_repeat(ptr, i64)
 
-declare i32 @hew_string_char_at(ptr, i32)
-
 declare ptr @hew_string_chars(ptr)
 
 declare i32 @hew_string_char_count(ptr)
-
-declare i32 @hew_string_char_at_utf8(ptr, i32)
 
 declare void @hew_vec_push_bool(ptr, i1)
 
@@ -300,6 +294,22 @@ declare i32 @hew_node_api_register_by_pid(ptr, i64)
 declare i64 @hew_remote_pid_from_raw(i64, i64)
 
 declare i64 @hew_node_api_lookup(ptr)
+
+declare ptr @hew_stream_channel(i64)
+
+declare ptr @hew_stream_pair_sink(ptr)
+
+declare ptr @hew_stream_pair_stream(ptr)
+
+declare void @hew_stream_pair_free(ptr)
+
+declare void @hew_sink_close(ptr)
+
+declare i32 @hew_sink_peer_closed(ptr)
+
+declare void @hew_actor_gen_sink_register(ptr, ptr)
+
+declare void @hew_actor_gen_sink_complete(ptr, ptr)
 
 define i8 @main() {
 entry:
@@ -747,14 +757,20 @@ bb45:                                             ; preds = %bb44
   %"hew_string_drop drop" = load ptr, ptr %local_61, align 8
   call void @hew_string_drop(ptr %"hew_string_drop drop")
   store ptr null, ptr %local_61, align 8
+  %"hew_string_drop drop132" = load ptr, ptr %local_59, align 8
+  call void @hew_string_drop(ptr %"hew_string_drop drop132")
+  store ptr null, ptr %local_59, align 8
+  %"hew_string_drop drop133" = load ptr, ptr %local_57, align 8
+  call void @hew_string_drop(ptr %"hew_string_drop drop133")
+  store ptr null, ptr %local_57, align 8
   %"hew_hashset_free_layout drop" = load ptr, ptr %local_48, align 8
   call void @hew_hashset_free_layout(ptr %"hew_hashset_free_layout drop")
   store ptr null, ptr %local_48, align 8
-  %"hew_hashmap_free_layout drop132" = load ptr, ptr %local_20, align 8
-  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop132")
+  %"hew_hashmap_free_layout drop134" = load ptr, ptr %local_20, align 8
+  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop134")
   store ptr null, ptr %local_20, align 8
-  %"hew_vec_free drop133" = load ptr, ptr %local_1, align 8
-  call void @hew_vec_free(ptr %"hew_vec_free drop133")
+  %"hew_vec_free drop135" = load ptr, ptr %local_1, align 8
+  call void @hew_vec_free(ptr %"hew_vec_free drop135")
   store ptr null, ptr %local_1, align 8
   %hew_lambda_drain_all_call = call i32 @hew_lambda_drain_all(i64 0)
   ret i8 0
@@ -1311,6 +1327,8 @@ entry:
   br label %bb0
 
 bb0:                                              ; preds = %entry
+  %mir_share_string_load = load ptr, ptr %local_0, align 8
+  %mir_share_string_retain = call ptr @hew_string_clone(ptr %mir_share_string_load)
   %move_load = load ptr, ptr %local_0, align 8
   store ptr %move_load, ptr %return_slot, align 8
   %ret_val = load ptr, ptr %return_slot, align 8
@@ -1489,6 +1507,9 @@ bb1:                                              ; preds = %bb0
   %"hew_string_concat arg1" = load ptr, ptr %local_3, align 8
   %hew_string_concat_call = call ptr @hew_string_concat(ptr %"hew_string_concat arg0", ptr %"hew_string_concat arg1")
   store ptr %hew_string_concat_call, ptr %local_4, align 8
+  %"hew_string_drop drop" = load ptr, ptr %local_2, align 8
+  call void @hew_string_drop(ptr %"hew_string_drop drop")
+  store ptr null, ptr %local_2, align 8
   %move_load = load ptr, ptr %local_4, align 8
   store ptr %move_load, ptr %return_slot, align 8
   %ret_val = load ptr, ptr %return_slot, align 8

--- a/tests/ll-oracle/corpus/golden/native/r4_suspend.ll
+++ b/tests/ll-oracle/corpus/golden/native/r4_suspend.ll
@@ -1,9 +1,12 @@
 ; ModuleID = 'r4_suspend'
 source_filename = "r4_suspend"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-apple-macosx13.0"
 
 %Adder = type { i64 }
 %"Result$$i64$AskError" = type { i8, [1 x i64] }
 %AskError = type { i8, [1 x i8] }
+%CrashInfo = type { i64, ptr }
 
 @str_actor_meta_name_Adder = private unnamed_addr constant [6 x i8] c"Adder\00", align 1
 @str_actor_meta_handler_Adder_0_set_base = private unnamed_addr constant [9 x i8] c"set_base\00", align 1
@@ -11,8 +14,12 @@ source_filename = "r4_suspend"
 @str_actor_type_name_Adder = private unnamed_addr constant [6 x i8] c"Adder\00", align 1
 @str_actor_handler_name_Adder_0_set_base = private unnamed_addr constant [16 x i8] c"Adder::set_base\00", align 1
 @str_actor_handler_name_Adder_1_add = private unnamed_addr constant [11 x i8] c"Adder::add\00", align 1
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @hew_module_init_xnode_codecs, ptr null }]
+@str_lit = private unnamed_addr constant [3 x i8] c"ns\00", align 1
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @hew_module_init_actor_codecs, ptr null }]
 
+declare void @hew_sleep_ns(i64)
+
+declare void @hew_sleep_until_ns(i64)
 
 declare void @hew_exit(i64)
 
@@ -28,7 +35,7 @@ declare ptr @hew_i64_to_string(i64)
 
 declare ptr @hew_u8_to_string(i8)
 
-declare ptr @hew_uint_to_string(i16)
+declare ptr @hew_uint_to_string(i32)
 
 declare ptr @hew_u64_to_string(i64)
 
@@ -116,21 +123,13 @@ declare ptr @hew_string_split(ptr, ptr)
 
 declare ptr @hew_string_lines(ptr)
 
-declare i32 @hew_string_find(ptr, ptr)
-
-declare i32 @hew_string_index_of_start(ptr, ptr)
-
 declare ptr @hew_string_slice(ptr, i64, i64)
 
 declare ptr @hew_string_repeat(ptr, i64)
 
-declare i32 @hew_string_char_at(ptr, i32)
-
 declare ptr @hew_string_chars(ptr)
 
 declare i32 @hew_string_char_count(ptr)
-
-declare i32 @hew_string_char_at_utf8(ptr, i32)
 
 declare void @hew_vec_push_bool(ptr, i1)
 
@@ -236,7 +235,27 @@ declare ptr @hew_bytes_to_string(ptr)
 
 declare void @hew_vec_append(ptr, ptr)
 
-declare void @hew_vec_remove_at(ptr, i64)
+declare i1 @hew_vec_remove_at_bool(ptr, i64)
+
+declare i8 @hew_vec_remove_at_i8(ptr, i64)
+
+declare i8 @hew_vec_remove_at_u8(ptr, i64)
+
+declare i16 @hew_vec_remove_at_i16(ptr, i64)
+
+declare i16 @hew_vec_remove_at_u16(ptr, i64)
+
+declare i32 @hew_vec_remove_at_i32(ptr, i64)
+
+declare i64 @hew_vec_remove_at_i64(ptr, i64)
+
+declare float @hew_vec_remove_at_f32(ptr, i64)
+
+declare double @hew_vec_remove_at_f64(ptr, i64)
+
+declare ptr @hew_vec_remove_at_str(ptr, i64)
+
+declare ptr @hew_vec_remove_at_ptr(ptr, i64)
 
 declare ptr @hew_vec_clone(ptr)
 
@@ -262,6 +281,12 @@ declare void @hew_node_api_connect(ptr)
 
 declare void @hew_node_api_shutdown()
 
+declare void @hew_node_api_load_keys(ptr)
+
+declare void @hew_node_api_allow_peer(i16, ptr)
+
+declare ptr @hew_node_api_identity_key()
+
 declare i64 @hew_actor_pid(ptr)
 
 declare i32 @hew_node_api_register_by_pid(ptr, i64)
@@ -270,11 +295,27 @@ declare i64 @hew_remote_pid_from_raw(i64, i64)
 
 declare i64 @hew_node_api_lookup(ptr)
 
+declare ptr @hew_stream_channel(i64)
+
+declare ptr @hew_stream_pair_sink(ptr)
+
+declare ptr @hew_stream_pair_stream(ptr)
+
+declare void @hew_stream_pair_free(ptr)
+
+declare void @hew_sink_close(ptr)
+
+declare i32 @hew_sink_peer_closed(ptr)
+
+declare void @hew_actor_gen_sink_register(ptr, ptr)
+
+declare void @hew_actor_gen_sink_complete(ptr, ptr)
+
 define internal i8 @Adder__recv__set_base(ptr %0, i64 %1, i32 %2) {
 entry:
   %return_slot = alloca i8, align 1
   %local_0 = alloca i64, align 8
-  store i64 %1, ptr %local_0, align 4
+  store i64 %1, ptr %local_0, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
@@ -283,8 +324,8 @@ bb0:                                              ; preds = %entry
   %actor_state_slot = getelementptr i8, ptr %ctx_actor_ptr, i64 16
   %actor_state_ptr = load ptr, ptr %actor_state_slot, align 8
   %actor_state_field_0_ptr = getelementptr inbounds nuw %Adder, ptr %actor_state_ptr, i32 0, i32 0
-  %actor_state_field_0_src = load i64, ptr %local_0, align 4
-  store i64 %actor_state_field_0_src, ptr %actor_state_field_0_ptr, align 4
+  %actor_state_field_0_src = load i64, ptr %local_0, align 8
+  store i64 %actor_state_field_0_src, ptr %actor_state_field_0_ptr, align 8
   ret i8 0
 }
 
@@ -295,7 +336,7 @@ entry:
   %local_1 = alloca i64, align 8
   %local_2 = alloca i64, align 8
   %local_3 = alloca i8, align 1
-  store i64 %1, ptr %local_0, align 4
+  store i64 %1, ptr %local_0, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
@@ -304,15 +345,15 @@ bb0:                                              ; preds = %entry
   %actor_state_slot = getelementptr i8, ptr %ctx_actor_ptr, i64 16
   %actor_state_ptr = load ptr, ptr %actor_state_slot, align 8
   %actor_state_field_0_ptr = getelementptr inbounds nuw %Adder, ptr %actor_state_ptr, i32 0, i32 0
-  %actor_state_field_0 = load i64, ptr %actor_state_field_0_ptr, align 4
-  store i64 %actor_state_field_0, ptr %local_1, align 4
-  %checked_lhs = load i64, ptr %local_1, align 4
-  %checked_rhs = load i64, ptr %local_0, align 4
+  %actor_state_field_0 = load i64, ptr %actor_state_field_0_ptr, align 8
+  store i64 %actor_state_field_0, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_1, align 8
+  %checked_rhs = load i64, ptr %local_0, align 8
   %with_overflow = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_2, align 4
+  store i64 %checked_result, ptr %local_2, align 8
   store i8 %checked_overflow_widen, ptr %local_3, align 1
   %cond_load = load i8, ptr %local_3, align 1
   %cond_nz = icmp ne i8 %cond_load, 0
@@ -324,9 +365,9 @@ bb1:                                              ; preds = %bb0
   unreachable
 
 bb2:                                              ; preds = %bb0
-  %move_load = load i64, ptr %local_2, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
@@ -350,16 +391,14 @@ entry:
   %local_14 = alloca i8, align 1
   %local_15 = alloca i64, align 8
   %local_16 = alloca i64, align 8
-  %local_17 = alloca i64, align 8
-  %local_18 = alloca i8, align 1
   %hew_sched_init_entry_call = call i32 @hew_sched_init()
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  store i64 10, ptr %local_1, align 4
+  store i64 10, ptr %local_1, align 8
   %field_0_init_ptr = getelementptr inbounds nuw %Adder, ptr %local_0, i32 0, i32 0
-  %field_0_init_src = load i64, ptr %local_1, align 4
-  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 4
+  %field_0_init_src = load i64, ptr %local_1, align 8
+  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 8
   %hew_sched_init_call = call i32 @hew_sched_init()
   %actor_meta_handlers_Adder = alloca [2 x { ptr, i32, i32, ptr, ptr, i32 }], align 8
   %actor_meta_handler_0 = getelementptr [2 x { ptr, i32, i32, ptr, ptr, i32 }], ptr %actor_meta_handlers_Adder, i32 0, i32 0
@@ -404,31 +443,31 @@ bb0:                                              ; preds = %entry
   call void @hew_actor_set_state_drop(ptr %hew_actor_spawn_call, ptr @__hew_state_drop_Adder)
   call void @hew_actor_set_state_clone(ptr %hew_actor_spawn_call, ptr @__hew_state_clone_Adder)
   store ptr %hew_actor_spawn_call, ptr %local_2, align 8
-  store i64 100, ptr %local_3, align 4
+  store i64 100, ptr %local_3, align 8
   %"actor_send receiver" = load ptr, ptr %local_2, align 8
   %actor_id_slot = getelementptr i8, ptr %"actor_send receiver", i64 8
-  %actor_id = load i64, ptr %actor_id_slot, align 4
+  %actor_id = load i64, ptr %actor_id_slot, align 8
   %hew_actor_send_by_id_call = call i32 @hew_actor_send_by_id(i64 %actor_id, ptr null, i32 1995638644, ptr %local_3, i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64))
-  %actor_send_failed = icmp ne i32 %hew_actor_send_by_id_call, 0
-  br i1 %actor_send_failed, label %actor_send_fail, label %bb1
+  %send_not_ok = icmp ne i32 %hew_actor_send_by_id_call, 0
+  br i1 %send_not_ok, label %actor_send_fail, label %bb1
 
 bb1:                                              ; preds = %bb0
-  store i64 42, ptr %local_4, align 4
+  store i64 42, ptr %local_4, align 8
   %"actor_ask receiver" = load ptr, ptr %local_2, align 8
   %hew_actor_ask_call = call ptr @hew_actor_ask(ptr %"actor_ask receiver", i32 311929158, ptr %local_4, i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64))
   %actor_ask_reply_is_null = icmp eq ptr %hew_actor_ask_call, null
   br i1 %actor_ask_reply_is_null, label %actor_ask_reply_err, label %actor_ask_reply_ok
 
 bb2:                                              ; preds = %actor_ask_reply_err, %actor_ask_reply_ok
-  %move_load = load %"Result$$i64$AskError", ptr %local_5, align 4
-  store %"Result$$i64$AskError" %move_load, ptr %local_8, align 4
+  %move_load = load %"Result$$i64$AskError", ptr %local_5, align 8
+  store %"Result$$i64$AskError" %move_load, ptr %local_8, align 8
   %machine_tag_ptr5 = getelementptr inbounds nuw %"Result$$i64$AskError", ptr %local_8, i32 0, i32 0
   %move_iN_load = load i8, ptr %machine_tag_ptr5, align 1
   %move_iN_zext = zext i8 %move_iN_load to i64
-  store i64 %move_iN_zext, ptr %local_10, align 4
-  store i64 0, ptr %local_11, align 4
-  %cmp_lhs = load i64, ptr %local_10, align 4
-  %cmp_rhs = load i64, ptr %local_11, align 4
+  store i64 %move_iN_zext, ptr %local_10, align 8
+  store i64 0, ptr %local_11, align 8
+  %cmp_lhs = load i64, ptr %local_10, align 8
+  %cmp_rhs = load i64, ptr %local_11, align 8
   %cmp_bit = icmp eq i64 %cmp_lhs, %cmp_rhs
   %cmp_zext = zext i1 %cmp_bit to i8
   store i8 %cmp_zext, ptr %local_12, align 1
@@ -436,35 +475,29 @@ bb2:                                              ; preds = %actor_ask_reply_err
   %cond_nz = icmp ne i8 %cond_load, 0
   br i1 %cond_nz, label %bb4, label %bb7
 
-bb3:                                              ; preds = %after_cooperate22, %after_cooperate
+bb3:                                              ; preds = %after_cooperate20, %after_cooperate
   %move_load6 = load i8, ptr %local_9, align 1
   store i8 %move_load6, ptr %return_slot, align 1
-  call void @hew_shutdown_initiate(i64 0)
+  call void @hew_shutdown_initiate_implicit(i64 0)
   %hew_shutdown_wait_call = call i32 @hew_shutdown_wait()
   %hew_lambda_drain_all_call = call i32 @hew_lambda_drain_all(i64 0)
+  call void @hew_runtime_cleanup_after_main()
   ret i8 0
 
 bb4:                                              ; preds = %bb2
   %machine_payload_ptr7 = getelementptr inbounds nuw %"Result$$i64$AskError", ptr %local_8, i32 0, i32 1
   %machine_variant_field_ptr8 = getelementptr inbounds nuw { i64 }, ptr %machine_payload_ptr7, i32 0, i32 0
-  %move_load9 = load i64, ptr %machine_variant_field_ptr8, align 4
-  store i64 %move_load9, ptr %local_15, align 4
-  %print_arg = load i64, ptr %local_15, align 4
+  %move_load9 = load i64, ptr %machine_variant_field_ptr8, align 8
+  store i64 %move_load9, ptr %local_15, align 8
+  %print_arg = load i64, ptr %local_15, align 8
   call void @hew_print_value(i8 1, i64 %print_arg, i1 true)
   br label %bb8
 
 bb5:                                              ; preds = %bb7
-  store i64 1, ptr %local_16, align 4
-  %ineg_operand = load i64, ptr %local_16, align 4
-  %neg_with_overflow = call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 0, i64 %ineg_operand)
-  %neg_result = extractvalue { i64, i1 } %neg_with_overflow, 0
-  %neg_overflow = extractvalue { i64, i1 } %neg_with_overflow, 1
-  %neg_overflow_widen = zext i1 %neg_overflow to i8
-  store i64 %neg_result, ptr %local_17, align 4
-  store i8 %neg_overflow_widen, ptr %local_18, align 1
-  %cond_load10 = load i8, ptr %local_18, align 1
-  %cond_nz11 = icmp ne i8 %cond_load10, 0
-  br i1 %cond_nz11, label %bb9, label %bb10
+  store i64 -1, ptr %local_16, align 8
+  %print_arg10 = load i64, ptr %local_16, align 8
+  call void @hew_print_value(i8 1, i64 %print_arg10, i1 true)
+  br label %bb9
 
 bb6:                                              ; preds = %bb7
   call void @hew_trap_with_code(i32 208)
@@ -472,15 +505,15 @@ bb6:                                              ; preds = %bb7
   unreachable
 
 bb7:                                              ; preds = %bb2
-  store i64 1, ptr %local_13, align 4
-  %cmp_lhs12 = load i64, ptr %local_10, align 4
-  %cmp_rhs13 = load i64, ptr %local_13, align 4
-  %cmp_bit14 = icmp eq i64 %cmp_lhs12, %cmp_rhs13
-  %cmp_zext15 = zext i1 %cmp_bit14 to i8
-  store i8 %cmp_zext15, ptr %local_14, align 1
-  %cond_load16 = load i8, ptr %local_14, align 1
-  %cond_nz17 = icmp ne i8 %cond_load16, 0
-  br i1 %cond_nz17, label %bb5, label %bb6
+  store i64 1, ptr %local_13, align 8
+  %cmp_lhs11 = load i64, ptr %local_10, align 8
+  %cmp_rhs12 = load i64, ptr %local_13, align 8
+  %cmp_bit13 = icmp eq i64 %cmp_lhs11, %cmp_rhs12
+  %cmp_zext14 = zext i1 %cmp_bit13 to i8
+  store i8 %cmp_zext14, ptr %local_14, align 1
+  %cond_load15 = load i8, ptr %local_14, align 1
+  %cond_nz16 = icmp ne i8 %cond_load15, 0
+  br i1 %cond_nz16, label %bb5, label %bb6
 
 bb8:                                              ; preds = %bb4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
@@ -488,19 +521,9 @@ bb8:                                              ; preds = %bb4
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb9:                                              ; preds = %bb5
-  call void @hew_trap_with_code(i32 201)
-  call void @llvm.trap()
-  unreachable
-
-bb10:                                             ; preds = %bb5
-  %print_arg18 = load i64, ptr %local_17, align 4
-  call void @hew_print_value(i8 1, i64 %print_arg18, i1 true)
-  br label %bb11
-
-bb11:                                             ; preds = %bb10
-  %hew_actor_cooperate19 = call i32 @hew_actor_cooperate()
-  %hew_cooperate_is_cancel20 = icmp eq i32 %hew_actor_cooperate19, 2
-  br i1 %hew_cooperate_is_cancel20, label %cancel_exit21, label %after_cooperate22
+  %hew_actor_cooperate17 = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel18 = icmp eq i32 %hew_actor_cooperate17, 2
+  br i1 %hew_cooperate_is_cancel18, label %cancel_exit19, label %after_cooperate20
 
 actor_send_fail:                                  ; preds = %bb0
   call void @hew_trap_with_code(i32 206)
@@ -508,14 +531,14 @@ actor_send_fail:                                  ; preds = %bb0
   unreachable
 
 actor_ask_reply_ok:                               ; preds = %bb1
-  %actor_ask_reply_value = load i64, ptr %hew_actor_ask_call, align 4
-  store i64 %actor_ask_reply_value, ptr %local_6, align 4
+  %actor_ask_reply_value = load i64, ptr %hew_actor_ask_call, align 8
+  store i64 %actor_ask_reply_value, ptr %local_6, align 8
   %machine_tag_ptr = getelementptr inbounds nuw %"Result$$i64$AskError", ptr %local_5, i32 0, i32 0
   store i8 0, ptr %machine_tag_ptr, align 1
   %machine_payload_ptr = getelementptr inbounds nuw %"Result$$i64$AskError", ptr %local_5, i32 0, i32 1
   %machine_variant_field_ptr = getelementptr inbounds nuw { i64 }, ptr %machine_payload_ptr, i32 0, i32 0
-  %emit_result_ok_v0_f0_src = load i64, ptr %local_6, align 4
-  store i64 %emit_result_ok_v0_f0_src, ptr %machine_variant_field_ptr, align 4
+  %emit_result_ok_v0_f0_src = load i64, ptr %local_6, align 8
+  store i64 %emit_result_ok_v0_f0_src, ptr %machine_variant_field_ptr, align 8
   call void @free(ptr %hew_actor_ask_call)
   br label %bb2
 
@@ -538,11 +561,77 @@ cancel_exit:                                      ; preds = %bb8
 after_cooperate:                                  ; preds = %bb8
   br label %bb3
 
-cancel_exit21:                                    ; preds = %bb11
+cancel_exit19:                                    ; preds = %bb9
   ret i8 0
 
-after_cooperate22:                                ; preds = %bb11
+after_cooperate20:                                ; preds = %bb9
   br label %bb3
+}
+
+define internal ptr @"i8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 8
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i8, ptr %local_0, align 1
+  %cast_int_sext = sext i8 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"i16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 8
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i16, ptr %local_0, align 2
+  %cast_int_sext = sext i16 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
 }
 
 define internal ptr @"i32::fmt"(i32 %0) {
@@ -579,14 +668,73 @@ entry:
   %return_slot = alloca ptr, align 8
   %local_0 = alloca i64, align 8
   %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_1, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i8, ptr %local_0, align 1
+  %call_result = call ptr @hew_u8_to_string(i8 %call_arg)
+  store ptr %call_result, ptr %local_1, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca ptr, align 8
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i16, ptr %local_0, align 2
+  %ffi_zext = zext i16 %call_arg to i32
+  %call_result = call ptr @hew_uint_to_string(i32 %ffi_zext)
   store ptr %call_result, ptr %local_1, align 8
   br label %bb1
 
@@ -615,8 +763,7 @@ entry:
 
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
-  %ffi_arg_trunc = trunc i32 %call_arg to i16
-  %call_result = call ptr @hew_uint_to_string(i16 %ffi_arg_trunc)
+  %call_result = call ptr @hew_uint_to_string(i32 %call_arg)
   store ptr %call_result, ptr %local_1, align 8
   br label %bb1
 
@@ -638,19 +785,83 @@ entry:
   %return_slot = alloca ptr, align 8
   %local_0 = alloca i64, align 8
   %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
   store ptr %call_result, ptr %local_1, align 8
   br label %bb1
 
 bb1:                                              ; preds = %bb0
   %move_load = load ptr, ptr %local_1, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"isize::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 8
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i64, ptr %local_0, align 8
+  store i64 %cast_int_src, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"usize::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 8
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i64, ptr %local_0, align 8
+  store i64 %cast_int_src, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
   store ptr %move_load, ptr %return_slot, align 8
   %ret_val = load ptr, ptr %return_slot, align 8
   ret ptr %ret_val
@@ -749,6 +960,39 @@ after_cooperate:                                  ; preds = %entry
   br label %bb0
 }
 
+define internal ptr @"f32::fmt"(float %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca float, align 4
+  %local_1 = alloca double, align 8
+  %local_2 = alloca ptr, align 8
+  store float %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_float_src = load float, ptr %local_0, align 4
+  %cast_float_ext = fpext float %cast_float_src to double
+  store double %cast_float_ext, ptr %local_1, align 8
+  %call_arg = load double, ptr %local_1, align 8
+  %call_result = call ptr @hew_float_to_string(double %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
 define internal ptr @"string::fmt"(ptr %0) {
 entry:
   %return_slot = alloca ptr, align 8
@@ -757,10 +1001,199 @@ entry:
   br label %bb0
 
 bb0:                                              ; preds = %entry
+  %mir_share_string_load = load ptr, ptr %local_0, align 8
+  %mir_share_string_retain = call ptr @hew_string_clone(ptr %mir_share_string_load)
   %move_load = load ptr, ptr %local_0, align 8
   store ptr %move_load, ptr %return_slot, align 8
   %ret_val = load ptr, ptr %return_slot, align 8
   ret ptr %ret_val
+}
+
+define internal i64 @"duration::from_nanos"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_micros"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_millis"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_secs"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal ptr @"duration::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %hew_duration_nanos = load i64, ptr %local_0, align 8
+  %hew_duration_nanos_call = call i64 @hew_duration_nanos(i64 %hew_duration_nanos)
+  store i64 %hew_duration_nanos_call, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  store ptr @str_lit, ptr %local_3, align 8
+  %"hew_string_concat arg0" = load ptr, ptr %local_2, align 8
+  %"hew_string_concat arg1" = load ptr, ptr %local_3, align 8
+  %hew_string_concat_call = call ptr @hew_string_concat(ptr %"hew_string_concat arg0", ptr %"hew_string_concat arg1")
+  store ptr %hew_string_concat_call, ptr %local_4, align 8
+  %"hew_string_drop drop" = load ptr, ptr %local_2, align 8
+  call void @hew_string_drop(ptr %"hew_string_drop drop")
+  store ptr null, ptr %local_2, align 8
+  %move_load = load ptr, ptr %local_4, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
 }
 
 define internal ptr @__hew_actor_dispatch_Adder(ptr %0, ptr %1, i32 %2, ptr %3, i64 %4, i32 %5) {
@@ -772,8 +1205,8 @@ unknown_msg_type:                                 ; preds = %payload_src
   call void @llvm.trap()
   unreachable
 
-dispatch_done:                                    ; preds = %msg_311929158, %msg_1995638644
-  %dispatch_suspend_handle = phi ptr [ null, %msg_1995638644 ], [ null, %msg_311929158 ]
+dispatch_done:                                    ; preds = %msg_sys_exit_unhandled, %msg_311929158, %msg_1995638644
+  %dispatch_suspend_handle = phi ptr [ null, %msg_1995638644 ], [ null, %msg_311929158 ], [ null, %msg_sys_exit_unhandled ]
   ret ptr %dispatch_suspend_handle
 
 borrow_src:                                       ; preds = %entry
@@ -789,6 +1222,7 @@ payload_src:                                      ; preds = %copy_src, %borrow_p
   switch i32 %2, label %unknown_msg_type [
     i32 1995638644, label %msg_1995638644
     i32 311929158, label %msg_311929158
+    i32 103, label %msg_sys_exit_unhandled
   ]
 
 borrow_payload_null:                              ; preds = %borrow_src
@@ -799,17 +1233,23 @@ borrow_payload_ok:                                ; preds = %borrow_src
   br label %payload_src
 
 msg_1995638644:                                   ; preds = %payload_src
-  %msg_arg_0 = load i64, ptr %payload_src_ptr, align 4
+  %msg_arg_0 = load i64, ptr %payload_src_ptr, align 8
   %call_set_base = call i8 @Adder__recv__set_base(ptr %0, i64 %msg_arg_0, i32 %5)
   br label %dispatch_done
 
 msg_311929158:                                    ; preds = %payload_src
-  %msg_arg_01 = load i64, ptr %payload_src_ptr, align 4
+  %msg_arg_01 = load i64, ptr %payload_src_ptr, align 8
   %call_add = call i64 @Adder__recv__add(ptr %0, i64 %msg_arg_01, i32 %5)
   %hew_get_reply_channel_call = call ptr @hew_get_reply_channel()
   %actor_reply_slot = alloca i64, align 8
-  store i64 %call_add, ptr %actor_reply_slot, align 4
+  store i64 %call_add, ptr %actor_reply_slot, align 8
   %hew_reply_call = call i1 @hew_reply(ptr %hew_get_reply_channel_call, ptr %actor_reply_slot, i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64))
+  br label %dispatch_done
+
+msg_sys_exit_unhandled:                           ; preds = %payload_src
+  %exit_reason_ptr = getelementptr inbounds nuw { i64, i32, i32 }, ptr %payload_src_ptr, i32 0, i32 1
+  %exit_reason = load i32, ptr %exit_reason_ptr, align 4
+  call void @hew_actor_exit_unhandled(i32 %exit_reason)
   br label %dispatch_done
 }
 
@@ -821,8 +1261,75 @@ declare ptr @hew_get_reply_channel()
 
 declare i1 @hew_reply(ptr, ptr, i64)
 
+declare void @hew_actor_exit_unhandled(i32)
+
 ; Function Attrs: cold noreturn nounwind memory(inaccessiblemem: write)
 declare void @llvm.trap() #0
+
+define internal i32 @__hew_record_clone_inplace_CrashInfo(ptr %0, ptr %1) {
+entry:
+  br label %step_0_clone
+
+success:                                          ; preds = %step_0_store
+  ret i32 0
+
+fail:                                             ; preds = %rb_step_0
+  ret i32 1
+
+rb_step_0:                                        ; preds = %step_0_clone
+  br label %fail
+
+step_0_store:                                     ; preds = %step_0_clone
+  %dst_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  store ptr %clone_helper_f1, ptr %dst_f1_ptr, align 8
+  br label %success
+
+step_0_clone:                                     ; preds = %entry
+  %src_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %src_f1 = load ptr, ptr %src_f1_ptr, align 8
+  %clone_helper_f1 = call ptr @hew_string_clone(ptr %src_f1)
+  %cloned_f1_int = ptrtoint ptr %clone_helper_f1 to i64
+  %cloned_f1_null = icmp eq i64 %cloned_f1_int, 0
+  br i1 %cloned_f1_null, label %rb_step_0, label %step_0_store
+}
+
+define internal void @__hew_record_drop_inplace_CrashInfo(ptr %0) {
+entry:
+  %rec_int = ptrtoint ptr %0 to i64
+  %rec_is_null = icmp eq i64 %rec_int, 0
+  br i1 %rec_is_null, label %done, label %do_drop
+
+do_drop:                                          ; preds = %entry
+  %drop_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %drop_f1 = load ptr, ptr %drop_f1_ptr, align 8
+  call void @hew_string_drop(ptr %drop_f1)
+  br label %done
+
+done:                                             ; preds = %do_drop, %entry
+  ret void
+}
+
+declare void @hew_string_drop(ptr)
+
+define internal void @__hew_record_overwrite_release_CrashInfo(ptr %0, ptr %1) {
+entry:
+  %ow_slot_0 = alloca ptr, align 8
+  store ptr null, ptr %ow_slot_0, align 8
+  %ow_new_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  %ow_new_d0_f1_leaf = load ptr, ptr %ow_new_d0_f1_ptr, align 8
+  store ptr %ow_new_d0_f1_leaf, ptr %ow_slot_0, align 8
+  %ow_old_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %ow_old_d0_f1_val = load ptr, ptr %ow_old_d0_f1_ptr, align 8
+  %ow_old_d0_f1_int = ptrtoint ptr %ow_old_d0_f1_val to i64
+  %ow_old_d0_f1_cmp0_leaf = load ptr, ptr %ow_slot_0, align 8
+  %ow_old_d0_f1_cmp0_int = ptrtoint ptr %ow_old_d0_f1_cmp0_leaf to i64
+  %ow_old_d0_f1_cmp0_eq = icmp eq i64 %ow_old_d0_f1_int, %ow_old_d0_f1_cmp0_int
+  %ow_old_d0_f1_matched0 = or i1 false, %ow_old_d0_f1_cmp0_eq
+  %ow_old_d0_f1_neutralized = select i1 %ow_old_d0_f1_matched0, ptr null, ptr %ow_old_d0_f1_val
+  store ptr %ow_old_d0_f1_neutralized, ptr %ow_old_d0_f1_ptr, align 8
+  call void @__hew_record_drop_inplace_CrashInfo(ptr %0)
+  ret void
+}
 
 define ptr @__hew_state_clone_Adder(ptr %0) {
 entry:
@@ -892,77 +1399,79 @@ declare void @free(ptr)
 
 declare i32 @hew_actor_ask_take_last_error()
 
-declare void @hew_shutdown_initiate(i64)
+declare void @hew_shutdown_initiate_implicit(i64)
 
 declare i32 @hew_shutdown_wait()
 
 declare i32 @hew_lambda_drain_all(i64)
 
-; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
-declare { i64, i1 } @llvm.ssub.with.overflow.i64(i64, i64) #2
+declare void @hew_runtime_cleanup_after_main()
 
 declare i32 @hew_actor_cooperate()
 
-define internal ptr @__hew_serialize_i64(ptr %0, ptr %1) {
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
+declare { i64, i1 } @llvm.smul.with.overflow.i64(i64, i64) #2
+
+define internal ptr @__hew_cbor_serialize_i64(ptr %0, ptr %1) {
 entry:
-  %ser_buf = call ptr @hew_ser_buf_new()
-  %ser_scalar = load i64, ptr %0, align 4
-  call void @hew_ser_push_i64(ptr %ser_buf, i64 %ser_scalar)
-  %ser_finish = call ptr @hew_ser_finish(ptr %ser_buf, ptr %1)
-  ret ptr %ser_finish
+  %cbor_ser_buf = call ptr @hew_cbor_ser_new()
+  %cbor_ser_scalar = load i64, ptr %0, align 8
+  call void @hew_cbor_ser_i64(ptr %cbor_ser_buf, i64 %cbor_ser_scalar)
+  %cbor_ser_finish = call ptr @hew_cbor_ser_finish(ptr %cbor_ser_buf, ptr %1)
+  ret ptr %cbor_ser_finish
 }
 
-define internal ptr @__hew_deserialize_i64(ptr %0, i64 %1, ptr %2) {
+define internal ptr @__hew_cbor_deserialize_i64(ptr %0, i64 %1, ptr %2) {
 entry:
-  %de_reader = call ptr @hew_de_reader_new(ptr %0, i64 %1)
-  store i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64), ptr %2, align 4
-  %de_value = call ptr @malloc(i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64))
-  %dst_as_int = ptrtoint ptr %de_value to i64
-  %dst_is_null = icmp eq i64 %dst_as_int, 0
-  br i1 %dst_is_null, label %de_oom, label %de_alloc_ok
+  %cbor_de_reader = call ptr @hew_cbor_de_new(ptr %0, i64 %1)
+  store i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64), ptr %2, align 8
+  %cbor_de_value = call ptr @malloc(i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64))
+  %cbor_dst_as_int = ptrtoint ptr %cbor_de_value to i64
+  %cbor_dst_is_null = icmp eq i64 %cbor_dst_as_int, 0
+  br i1 %cbor_dst_is_null, label %cbor_de_oom, label %cbor_de_alloc_ok
 
-de_oom:                                           ; preds = %entry
-  call void @hew_de_reader_free(ptr %de_reader)
+cbor_de_oom:                                      ; preds = %entry
+  call void @hew_cbor_de_free(ptr %cbor_de_reader)
   ret ptr null
 
-de_alloc_ok:                                      ; preds = %entry
-  %de_zero = call ptr @memset(ptr %de_value, i32 0, i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64))
-  %de_read_int = call i64 @hew_de_read_i64(ptr %de_reader)
-  store i64 %de_read_int, ptr %de_value, align 4
-  %de_failed = call i32 @hew_de_failed(ptr %de_reader)
-  call void @hew_de_reader_free(ptr %de_reader)
-  %de_is_failed = icmp ne i32 %de_failed, 0
-  br i1 %de_is_failed, label %de_fail, label %de_ok
+cbor_de_alloc_ok:                                 ; preds = %entry
+  %cbor_de_zero = call ptr @memset(ptr %cbor_de_value, i32 0, i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64))
+  %cbor_de_int = call i64 @hew_cbor_de_int_checked(ptr %cbor_de_reader, i32 64, i32 1)
+  store i64 %cbor_de_int, ptr %cbor_de_value, align 8
+  %cbor_de_failed = call i32 @hew_cbor_de_failed(ptr %cbor_de_reader)
+  call void @hew_cbor_de_free(ptr %cbor_de_reader)
+  %cbor_de_is_failed = icmp ne i32 %cbor_de_failed, 0
+  br i1 %cbor_de_is_failed, label %cbor_de_fail, label %cbor_de_ok
 
-de_ok:                                            ; preds = %de_alloc_ok
-  ret ptr %de_value
+cbor_de_ok:                                       ; preds = %cbor_de_alloc_ok
+  ret ptr %cbor_de_value
 
-de_fail:                                          ; preds = %de_alloc_ok
-  call void @free(ptr %de_value)
+cbor_de_fail:                                     ; preds = %cbor_de_alloc_ok
+  call void @free(ptr %cbor_de_value)
   ret ptr null
 }
 
-declare ptr @hew_ser_buf_new()
+declare ptr @hew_cbor_ser_new()
 
-declare void @hew_ser_push_i64(ptr, i64)
+declare void @hew_cbor_ser_i64(ptr, i64)
 
-declare ptr @hew_ser_finish(ptr, ptr)
+declare ptr @hew_cbor_ser_finish(ptr, ptr)
 
-declare ptr @hew_de_reader_new(ptr, i64)
+declare ptr @hew_cbor_de_new(ptr, i64)
 
-declare void @hew_de_reader_free(ptr)
+declare void @hew_cbor_de_free(ptr)
 
 declare ptr @memset(ptr, i32, i64)
 
-declare i64 @hew_de_read_i64(ptr)
+declare i64 @hew_cbor_de_int_checked(ptr, i32, i32)
 
-declare i32 @hew_de_failed(ptr)
+declare i32 @hew_cbor_de_failed(ptr)
 
-define private void @hew_module_init_xnode_codecs() {
+define private void @hew_module_init_actor_codecs() {
 entry:
-  call void @hew_xnode_register_codec(ptr @__hew_actor_dispatch_Adder, i32 1995638644, ptr @__hew_serialize_i64, ptr @__hew_deserialize_i64)
-  call void @hew_xnode_register_codec(ptr @__hew_actor_dispatch_Adder, i32 311929158, ptr @__hew_serialize_i64, ptr @__hew_deserialize_i64)
-  call void @hew_xnode_register_reply_codec(ptr @__hew_actor_dispatch_Adder, i32 311929158, ptr @__hew_serialize_i64, ptr @__hew_deserialize_i64)
+  call void @hew_xnode_register_codec(ptr @__hew_actor_dispatch_Adder, i32 1995638644, ptr @__hew_cbor_serialize_i64, ptr @__hew_cbor_deserialize_i64)
+  call void @hew_xnode_register_codec(ptr @__hew_actor_dispatch_Adder, i32 311929158, ptr @__hew_cbor_serialize_i64, ptr @__hew_cbor_deserialize_i64)
+  call void @hew_xnode_register_reply_codec(ptr @__hew_actor_dispatch_Adder, i32 311929158, ptr @__hew_cbor_serialize_i64, ptr @__hew_cbor_deserialize_i64)
   ret void
 }
 

--- a/tests/ll-oracle/corpus/golden/native/r4_thunks.ll
+++ b/tests/ll-oracle/corpus/golden/native/r4_thunks.ll
@@ -1,11 +1,19 @@
 ; ModuleID = 'r4_thunks'
 source_filename = "r4_thunks"
+target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "aarch64-apple-macosx13.0"
 
 %__hew_closure_env_make_adder_0 = type { i64 }
 %__hew_closure_env_make_multiplier_0 = type { i64 }
 %__hew_closure_env_main_0 = type {}
 %__hew_closure_env_main_1 = type { i64, i64 }
+%CrashInfo = type { i64, ptr }
 
+@str_lit = private unnamed_addr constant [3 x i8] c"ns\00", align 1
+
+declare void @hew_sleep_ns(i64)
+
+declare void @hew_sleep_until_ns(i64)
 
 declare void @hew_exit(i64)
 
@@ -21,7 +29,7 @@ declare ptr @hew_i64_to_string(i64)
 
 declare ptr @hew_u8_to_string(i8)
 
-declare ptr @hew_uint_to_string(i16)
+declare ptr @hew_uint_to_string(i32)
 
 declare ptr @hew_u64_to_string(i64)
 
@@ -109,21 +117,13 @@ declare ptr @hew_string_split(ptr, ptr)
 
 declare ptr @hew_string_lines(ptr)
 
-declare i32 @hew_string_find(ptr, ptr)
-
-declare i32 @hew_string_index_of_start(ptr, ptr)
-
 declare ptr @hew_string_slice(ptr, i64, i64)
 
 declare ptr @hew_string_repeat(ptr, i64)
 
-declare i32 @hew_string_char_at(ptr, i32)
-
 declare ptr @hew_string_chars(ptr)
 
 declare i32 @hew_string_char_count(ptr)
-
-declare i32 @hew_string_char_at_utf8(ptr, i32)
 
 declare void @hew_vec_push_bool(ptr, i1)
 
@@ -229,7 +229,27 @@ declare ptr @hew_bytes_to_string(ptr)
 
 declare void @hew_vec_append(ptr, ptr)
 
-declare void @hew_vec_remove_at(ptr, i64)
+declare i1 @hew_vec_remove_at_bool(ptr, i64)
+
+declare i8 @hew_vec_remove_at_i8(ptr, i64)
+
+declare i8 @hew_vec_remove_at_u8(ptr, i64)
+
+declare i16 @hew_vec_remove_at_i16(ptr, i64)
+
+declare i16 @hew_vec_remove_at_u16(ptr, i64)
+
+declare i32 @hew_vec_remove_at_i32(ptr, i64)
+
+declare i64 @hew_vec_remove_at_i64(ptr, i64)
+
+declare float @hew_vec_remove_at_f32(ptr, i64)
+
+declare double @hew_vec_remove_at_f64(ptr, i64)
+
+declare ptr @hew_vec_remove_at_str(ptr, i64)
+
+declare ptr @hew_vec_remove_at_ptr(ptr, i64)
 
 declare ptr @hew_vec_clone(ptr)
 
@@ -255,6 +275,12 @@ declare void @hew_node_api_connect(ptr)
 
 declare void @hew_node_api_shutdown()
 
+declare void @hew_node_api_load_keys(ptr)
+
+declare void @hew_node_api_allow_peer(i16, ptr)
+
+declare ptr @hew_node_api_identity_key()
+
 declare i64 @hew_actor_pid(ptr)
 
 declare i32 @hew_node_api_register_by_pid(ptr, i64)
@@ -263,28 +289,44 @@ declare i64 @hew_remote_pid_from_raw(i64, i64)
 
 declare i64 @hew_node_api_lookup(ptr)
 
+declare ptr @hew_stream_channel(i64)
+
+declare ptr @hew_stream_pair_sink(ptr)
+
+declare ptr @hew_stream_pair_stream(ptr)
+
+declare void @hew_stream_pair_free(ptr)
+
+declare void @hew_sink_close(ptr)
+
+declare i32 @hew_sink_peer_closed(ptr)
+
+declare void @hew_actor_gen_sink_register(ptr, ptr)
+
+declare void @hew_actor_gen_sink_complete(ptr, ptr)
+
 define internal i64 @apply({ ptr, ptr } %0, i64 %1) {
 entry:
   %return_slot = alloca i64, align 8
   %closure_call_fallback_ctx = alloca [16 x i64], align 8
-  store [16 x i64] zeroinitializer, ptr %closure_call_fallback_ctx, align 4
+  store [16 x i64] zeroinitializer, ptr %closure_call_fallback_ctx, align 8
   %local_0 = alloca { ptr, ptr }, align 8
   %local_1 = alloca i64, align 8
   %local_2 = alloca i64, align 8
   store { ptr, ptr } %0, ptr %local_0, align 8
-  store i64 %1, ptr %local_1, align 4
+  store i64 %1, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
   %closure_pair_load = load { ptr, ptr }, ptr %local_0, align 8
   %closure_fn_extract = extractvalue { ptr, ptr } %closure_pair_load, 0
   %closure_env_extract = extractvalue { ptr, ptr } %closure_pair_load, 1
-  %closure_call_arg = load i64, ptr %local_1, align 4
+  %closure_call_arg = load i64, ptr %local_1, align 8
   %closure_call_result = call i64 %closure_fn_extract(ptr %closure_call_fallback_ctx, ptr %closure_env_extract, i64 %closure_call_arg)
-  store i64 %closure_call_result, ptr %local_2, align 4
-  %move_load = load i64, ptr %local_2, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  store i64 %closure_call_result, ptr %local_2, align 8
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
@@ -292,31 +334,31 @@ define internal i64 @apply_twice({ ptr, ptr } %0, i64 %1) {
 entry:
   %return_slot = alloca i64, align 8
   %closure_call_fallback_ctx = alloca [16 x i64], align 8
-  store [16 x i64] zeroinitializer, ptr %closure_call_fallback_ctx, align 4
+  store [16 x i64] zeroinitializer, ptr %closure_call_fallback_ctx, align 8
   %local_0 = alloca { ptr, ptr }, align 8
   %local_1 = alloca i64, align 8
   %local_2 = alloca i64, align 8
   %local_3 = alloca i64, align 8
   store { ptr, ptr } %0, ptr %local_0, align 8
-  store i64 %1, ptr %local_1, align 4
+  store i64 %1, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
   %closure_pair_load = load { ptr, ptr }, ptr %local_0, align 8
   %closure_fn_extract = extractvalue { ptr, ptr } %closure_pair_load, 0
   %closure_env_extract = extractvalue { ptr, ptr } %closure_pair_load, 1
-  %closure_call_arg = load i64, ptr %local_1, align 4
+  %closure_call_arg = load i64, ptr %local_1, align 8
   %closure_call_result = call i64 %closure_fn_extract(ptr %closure_call_fallback_ctx, ptr %closure_env_extract, i64 %closure_call_arg)
-  store i64 %closure_call_result, ptr %local_2, align 4
+  store i64 %closure_call_result, ptr %local_2, align 8
   %closure_pair_load1 = load { ptr, ptr }, ptr %local_0, align 8
   %closure_fn_extract2 = extractvalue { ptr, ptr } %closure_pair_load1, 0
   %closure_env_extract3 = extractvalue { ptr, ptr } %closure_pair_load1, 1
-  %closure_call_arg4 = load i64, ptr %local_2, align 4
+  %closure_call_arg4 = load i64, ptr %local_2, align 8
   %closure_call_result5 = call i64 %closure_fn_extract2(ptr %closure_call_fallback_ctx, ptr %closure_env_extract3, i64 %closure_call_arg4)
-  store i64 %closure_call_result5, ptr %local_3, align 4
-  %move_load = load i64, ptr %local_3, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  store i64 %closure_call_result5, ptr %local_3, align 8
+  %move_load = load i64, ptr %local_3, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
@@ -326,13 +368,13 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca %__hew_closure_env_make_adder_0, align 8
   %local_2 = alloca { ptr, ptr }, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
   %field_0_init_ptr = getelementptr inbounds nuw %__hew_closure_env_make_adder_0, ptr %local_1, i32 0, i32 0
-  %field_0_init_src = load i64, ptr %local_0, align 4
-  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 4
+  %field_0_init_src = load i64, ptr %local_0, align 8
+  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 8
   %closure_env_box = call ptr @hew_dyn_box_alloc(i64 16, i64 8)
   store ptr @__hew_closure_env_free___hew_closure_invoke_make_adder_0, ptr %closure_env_box, align 8
   %closure_env_data = getelementptr inbounds i8, ptr %closure_env_box, i64 8
@@ -356,21 +398,21 @@ entry:
   %local_3 = alloca i64, align 8
   %local_4 = alloca i8, align 1
   store ptr %1, ptr %local_0, align 8
-  store i64 %2, ptr %local_1, align 4
+  store i64 %2, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
   %closure_env_ptr_load = load ptr, ptr %local_0, align 8
   %closure_capture_ptr = getelementptr inbounds nuw %__hew_closure_env_make_adder_0, ptr %closure_env_ptr_load, i32 0, i32 0
-  %closure_capture_load = load i64, ptr %closure_capture_ptr, align 4
-  store i64 %closure_capture_load, ptr %local_2, align 4
-  %checked_lhs = load i64, ptr %local_1, align 4
-  %checked_rhs = load i64, ptr %local_2, align 4
+  %closure_capture_load = load i64, ptr %closure_capture_ptr, align 8
+  store i64 %closure_capture_load, ptr %local_2, align 8
+  %checked_lhs = load i64, ptr %local_1, align 8
+  %checked_rhs = load i64, ptr %local_2, align 8
   %with_overflow = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_3, align 4
+  store i64 %checked_result, ptr %local_3, align 8
   store i8 %checked_overflow_widen, ptr %local_4, align 1
   %cond_load = load i8, ptr %local_4, align 1
   %cond_nz = icmp ne i8 %cond_load, 0
@@ -382,9 +424,9 @@ bb1:                                              ; preds = %bb0
   unreachable
 
 bb2:                                              ; preds = %bb0
-  %move_load = load i64, ptr %local_3, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load = load i64, ptr %local_3, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
@@ -394,13 +436,13 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca %__hew_closure_env_make_multiplier_0, align 8
   %local_2 = alloca { ptr, ptr }, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
   %field_0_init_ptr = getelementptr inbounds nuw %__hew_closure_env_make_multiplier_0, ptr %local_1, i32 0, i32 0
-  %field_0_init_src = load i64, ptr %local_0, align 4
-  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 4
+  %field_0_init_src = load i64, ptr %local_0, align 8
+  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 8
   %closure_env_box = call ptr @hew_dyn_box_alloc(i64 16, i64 8)
   store ptr @__hew_closure_env_free___hew_closure_invoke_make_multiplier_0, ptr %closure_env_box, align 8
   %closure_env_data = getelementptr inbounds i8, ptr %closure_env_box, i64 8
@@ -424,21 +466,21 @@ entry:
   %local_3 = alloca i64, align 8
   %local_4 = alloca i8, align 1
   store ptr %1, ptr %local_0, align 8
-  store i64 %2, ptr %local_1, align 4
+  store i64 %2, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
   %closure_env_ptr_load = load ptr, ptr %local_0, align 8
   %closure_capture_ptr = getelementptr inbounds nuw %__hew_closure_env_make_multiplier_0, ptr %closure_env_ptr_load, i32 0, i32 0
-  %closure_capture_load = load i64, ptr %closure_capture_ptr, align 4
-  store i64 %closure_capture_load, ptr %local_2, align 4
-  %checked_lhs = load i64, ptr %local_1, align 4
-  %checked_rhs = load i64, ptr %local_2, align 4
+  %closure_capture_load = load i64, ptr %closure_capture_ptr, align 8
+  store i64 %closure_capture_load, ptr %local_2, align 8
+  %checked_lhs = load i64, ptr %local_1, align 8
+  %checked_rhs = load i64, ptr %local_2, align 8
   %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_3, align 4
+  store i64 %checked_result, ptr %local_3, align 8
   store i8 %checked_overflow_widen, ptr %local_4, align 1
   %cond_load = load i8, ptr %local_4, align 1
   %cond_nz = icmp ne i8 %cond_load, 0
@@ -450,9 +492,9 @@ bb1:                                              ; preds = %bb0
   unreachable
 
 bb2:                                              ; preds = %bb0
-  %move_load = load i64, ptr %local_3, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load = load i64, ptr %local_3, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
@@ -460,7 +502,7 @@ define i8 @main() {
 entry:
   %return_slot = alloca i8, align 1
   %closure_call_fallback_ctx = alloca [16 x i64], align 8
-  store [16 x i64] zeroinitializer, ptr %closure_call_fallback_ctx, align 4
+  store [16 x i64] zeroinitializer, ptr %closure_call_fallback_ctx, align 8
   %local_0 = alloca %__hew_closure_env_main_0, align 8
   %local_1 = alloca { ptr, ptr }, align 8
   %local_2 = alloca { ptr, ptr }, align 8
@@ -498,34 +540,34 @@ bb0:                                              ; preds = %after_cooperate
   store ptr null, ptr %closure_env_ptr, align 8
   %move_load = load { ptr, ptr }, ptr %local_1, align 8
   store { ptr, ptr } %move_load, ptr %local_2, align 8
-  store i64 21, ptr %local_3, align 4
+  store i64 21, ptr %local_3, align 8
   %call_arg = load { ptr, ptr }, ptr %local_2, align 8
-  %call_arg1 = load i64, ptr %local_3, align 4
+  %call_arg1 = load i64, ptr %local_3, align 8
   %call_result = call i64 @apply({ ptr, ptr } %call_arg, i64 %call_arg1)
-  store i64 %call_result, ptr %local_4, align 4
+  store i64 %call_result, ptr %local_4, align 8
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %print_arg = load i64, ptr %local_4, align 4
+  %print_arg = load i64, ptr %local_4, align 8
   call void @hew_print_value(i8 1, i64 %print_arg, i1 true)
   br label %bb2
 
 bb2:                                              ; preds = %bb1
-  store i64 3, ptr %local_5, align 4
+  store i64 3, ptr %local_5, align 8
   %call_arg2 = load { ptr, ptr }, ptr %local_2, align 8
-  %call_arg3 = load i64, ptr %local_5, align 4
+  %call_arg3 = load i64, ptr %local_5, align 8
   %call_result4 = call i64 @apply_twice({ ptr, ptr } %call_arg2, i64 %call_arg3)
-  store i64 %call_result4, ptr %local_6, align 4
+  store i64 %call_result4, ptr %local_6, align 8
   br label %bb3
 
 bb3:                                              ; preds = %bb2
-  %print_arg5 = load i64, ptr %local_6, align 4
+  %print_arg5 = load i64, ptr %local_6, align 8
   call void @hew_print_value(i8 1, i64 %print_arg5, i1 true)
   br label %bb4
 
 bb4:                                              ; preds = %bb3
-  store i64 10, ptr %local_7, align 4
-  %call_arg6 = load i64, ptr %local_7, align 4
+  store i64 10, ptr %local_7, align 8
+  %call_arg6 = load i64, ptr %local_7, align 8
   %call_result7 = call { ptr, ptr } @make_adder(i64 %call_arg6)
   store { ptr, ptr } %call_result7, ptr %local_8, align 8
   br label %bb5
@@ -533,20 +575,20 @@ bb4:                                              ; preds = %bb3
 bb5:                                              ; preds = %bb4
   %move_load8 = load { ptr, ptr }, ptr %local_8, align 8
   store { ptr, ptr } %move_load8, ptr %local_9, align 8
-  store i64 32, ptr %local_10, align 4
+  store i64 32, ptr %local_10, align 8
   %closure_pair_load = load { ptr, ptr }, ptr %local_9, align 8
   %closure_fn_extract = extractvalue { ptr, ptr } %closure_pair_load, 0
   %closure_env_extract = extractvalue { ptr, ptr } %closure_pair_load, 1
-  %closure_call_arg = load i64, ptr %local_10, align 4
+  %closure_call_arg = load i64, ptr %local_10, align 8
   %closure_call_result = call i64 %closure_fn_extract(ptr %closure_call_fallback_ctx, ptr %closure_env_extract, i64 %closure_call_arg)
-  store i64 %closure_call_result, ptr %local_11, align 4
-  %print_arg9 = load i64, ptr %local_11, align 4
+  store i64 %closure_call_result, ptr %local_11, align 8
+  %print_arg9 = load i64, ptr %local_11, align 8
   call void @hew_print_value(i8 1, i64 %print_arg9, i1 true)
   br label %bb6
 
 bb6:                                              ; preds = %bb5
-  store i64 3, ptr %local_12, align 4
-  %call_arg10 = load i64, ptr %local_12, align 4
+  store i64 3, ptr %local_12, align 8
+  %call_arg10 = load i64, ptr %local_12, align 8
   %call_result11 = call { ptr, ptr } @make_multiplier(i64 %call_arg10)
   store { ptr, ptr } %call_result11, ptr %local_13, align 8
   br label %bb7
@@ -554,53 +596,53 @@ bb6:                                              ; preds = %bb5
 bb7:                                              ; preds = %bb6
   %move_load12 = load { ptr, ptr }, ptr %local_13, align 8
   store { ptr, ptr } %move_load12, ptr %local_14, align 8
-  store i64 7, ptr %local_15, align 4
+  store i64 7, ptr %local_15, align 8
   %call_arg13 = load { ptr, ptr }, ptr %local_14, align 8
-  %call_arg14 = load i64, ptr %local_15, align 4
+  %call_arg14 = load i64, ptr %local_15, align 8
   %call_result15 = call i64 @apply({ ptr, ptr } %call_arg13, i64 %call_arg14)
-  store i64 %call_result15, ptr %local_16, align 4
+  store i64 %call_result15, ptr %local_16, align 8
   br label %bb8
 
 bb8:                                              ; preds = %bb7
-  %print_arg16 = load i64, ptr %local_16, align 4
+  %print_arg16 = load i64, ptr %local_16, align 8
   call void @hew_print_value(i8 1, i64 %print_arg16, i1 true)
   br label %bb9
 
 bb9:                                              ; preds = %bb8
-  store i64 100, ptr %local_17, align 4
-  %move_load17 = load i64, ptr %local_17, align 4
-  store i64 %move_load17, ptr %local_18, align 4
-  store i64 5, ptr %local_19, align 4
-  %move_load18 = load i64, ptr %local_19, align 4
-  store i64 %move_load18, ptr %local_20, align 4
+  store i64 100, ptr %local_17, align 8
+  %move_load17 = load i64, ptr %local_17, align 8
+  store i64 %move_load17, ptr %local_18, align 8
+  store i64 5, ptr %local_19, align 8
+  %move_load18 = load i64, ptr %local_19, align 8
+  store i64 %move_load18, ptr %local_20, align 8
   %field_0_init_ptr = getelementptr inbounds nuw %__hew_closure_env_main_1, ptr %local_21, i32 0, i32 0
-  %field_0_init_src = load i64, ptr %local_18, align 4
-  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 4
+  %field_0_init_src = load i64, ptr %local_18, align 8
+  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 8
   %field_1_init_ptr = getelementptr inbounds nuw %__hew_closure_env_main_1, ptr %local_21, i32 0, i32 1
-  %field_1_init_src = load i64, ptr %local_20, align 4
-  store i64 %field_1_init_src, ptr %field_1_init_ptr, align 4
+  %field_1_init_src = load i64, ptr %local_20, align 8
+  store i64 %field_1_init_src, ptr %field_1_init_ptr, align 8
   %closure_fn_ptr19 = getelementptr inbounds nuw { ptr, ptr }, ptr %local_22, i32 0, i32 0
   %closure_env_ptr20 = getelementptr inbounds nuw { ptr, ptr }, ptr %local_22, i32 0, i32 1
   store ptr @__hew_closure_invoke_main_1, ptr %closure_fn_ptr19, align 8
   store ptr %local_21, ptr %closure_env_ptr20, align 8
   %move_load21 = load { ptr, ptr }, ptr %local_22, align 8
   store { ptr, ptr } %move_load21, ptr %local_23, align 8
-  store i64 4, ptr %local_24, align 4
+  store i64 4, ptr %local_24, align 8
   %closure_pair_load22 = load { ptr, ptr }, ptr %local_23, align 8
   %closure_fn_extract23 = extractvalue { ptr, ptr } %closure_pair_load22, 0
   %closure_env_extract24 = extractvalue { ptr, ptr } %closure_pair_load22, 1
-  %closure_call_arg25 = load i64, ptr %local_24, align 4
+  %closure_call_arg25 = load i64, ptr %local_24, align 8
   %closure_call_result26 = call i64 %closure_fn_extract23(ptr %closure_call_fallback_ctx, ptr %closure_env_extract24, i64 %closure_call_arg25)
-  store i64 %closure_call_result26, ptr %local_25, align 4
-  %print_arg27 = load i64, ptr %local_25, align 4
+  store i64 %closure_call_result26, ptr %local_25, align 8
+  %print_arg27 = load i64, ptr %local_25, align 8
   call void @hew_print_value(i8 1, i64 %print_arg27, i1 true)
   br label %bb10
 
 bb10:                                             ; preds = %bb9
   %closure_drop_env_slot = getelementptr inbounds nuw { ptr, ptr }, ptr %local_9, i32 0, i32 1
   %closure_drop_env = load ptr, ptr %closure_drop_env_slot, align 8
-  %closure_env_is_null = icmp eq ptr %closure_drop_env, null
-  br i1 %closure_env_is_null, label %closure_env_drop_cont, label %closure_env_free
+  %closure_drop_env_is_null = icmp eq ptr %closure_drop_env, null
+  br i1 %closure_drop_env_is_null, label %closure_drop_closure_env_drop_cont, label %closure_drop_closure_env_free
 
 cancel_exit:                                      ; preds = %entry
   ret i8 0
@@ -608,14 +650,14 @@ cancel_exit:                                      ; preds = %entry
 after_cooperate:                                  ; preds = %entry
   br label %bb0
 
-closure_env_free:                                 ; preds = %bb10
-  %closure_env_thunk_slot = getelementptr inbounds i8, ptr %closure_drop_env, i64 -8
-  %closure_env_free_thunk = load ptr, ptr %closure_env_thunk_slot, align 8
-  call void %closure_env_free_thunk(ptr %closure_drop_env)
+closure_drop_closure_env_free:                    ; preds = %bb10
+  %closure_drop_env_thunk_slot = getelementptr inbounds i8, ptr %closure_drop_env, i64 -8
+  %closure_drop_env_free_thunk = load ptr, ptr %closure_drop_env_thunk_slot, align 8
+  call void %closure_drop_env_free_thunk(ptr %closure_drop_env)
   store ptr null, ptr %closure_drop_env_slot, align 8
-  br label %closure_env_drop_cont
+  br label %closure_drop_closure_env_drop_cont
 
-closure_env_drop_cont:                            ; preds = %closure_env_free, %bb10
+closure_drop_closure_env_drop_cont:               ; preds = %closure_drop_closure_env_free, %bb10
   %hew_lambda_drain_all_call = call i32 @hew_lambda_drain_all(i64 0)
   ret i8 0
 }
@@ -629,18 +671,18 @@ entry:
   %local_3 = alloca i64, align 8
   %local_4 = alloca i8, align 1
   store ptr %1, ptr %local_0, align 8
-  store i64 %2, ptr %local_1, align 4
+  store i64 %2, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  store i64 2, ptr %local_2, align 4
-  %checked_lhs = load i64, ptr %local_1, align 4
-  %checked_rhs = load i64, ptr %local_2, align 4
+  store i64 2, ptr %local_2, align 8
+  %checked_lhs = load i64, ptr %local_1, align 8
+  %checked_rhs = load i64, ptr %local_2, align 8
   %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_3, align 4
+  store i64 %checked_result, ptr %local_3, align 8
   store i8 %checked_overflow_widen, ptr %local_4, align 1
   %cond_load = load i8, ptr %local_4, align 1
   %cond_nz = icmp ne i8 %cond_load, 0
@@ -652,9 +694,9 @@ bb1:                                              ; preds = %bb0
   unreachable
 
 bb2:                                              ; preds = %bb0
-  %move_load = load i64, ptr %local_3, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load = load i64, ptr %local_3, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
@@ -670,25 +712,25 @@ entry:
   %local_6 = alloca i64, align 8
   %local_7 = alloca i8, align 1
   store ptr %1, ptr %local_0, align 8
-  store i64 %2, ptr %local_1, align 4
+  store i64 %2, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
   %closure_env_ptr_load = load ptr, ptr %local_0, align 8
   %closure_capture_ptr = getelementptr inbounds nuw %__hew_closure_env_main_1, ptr %closure_env_ptr_load, i32 0, i32 0
-  %closure_capture_load = load i64, ptr %closure_capture_ptr, align 4
-  store i64 %closure_capture_load, ptr %local_2, align 4
+  %closure_capture_load = load i64, ptr %closure_capture_ptr, align 8
+  store i64 %closure_capture_load, ptr %local_2, align 8
   %closure_env_ptr_load1 = load ptr, ptr %local_0, align 8
   %closure_capture_ptr2 = getelementptr inbounds nuw %__hew_closure_env_main_1, ptr %closure_env_ptr_load1, i32 0, i32 1
-  %closure_capture_load3 = load i64, ptr %closure_capture_ptr2, align 4
-  store i64 %closure_capture_load3, ptr %local_3, align 4
-  %checked_lhs = load i64, ptr %local_1, align 4
-  %checked_rhs = load i64, ptr %local_3, align 4
+  %closure_capture_load3 = load i64, ptr %closure_capture_ptr2, align 8
+  store i64 %closure_capture_load3, ptr %local_3, align 8
+  %checked_lhs = load i64, ptr %local_1, align 8
+  %checked_rhs = load i64, ptr %local_3, align 8
   %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_4, align 4
+  store i64 %checked_result, ptr %local_4, align 8
   store i8 %checked_overflow_widen, ptr %local_5, align 1
   %cond_load = load i8, ptr %local_5, align 1
   %cond_nz = icmp ne i8 %cond_load, 0
@@ -700,13 +742,13 @@ bb1:                                              ; preds = %bb0
   unreachable
 
 bb2:                                              ; preds = %bb0
-  %checked_lhs4 = load i64, ptr %local_2, align 4
-  %checked_rhs5 = load i64, ptr %local_4, align 4
+  %checked_lhs4 = load i64, ptr %local_2, align 8
+  %checked_rhs5 = load i64, ptr %local_4, align 8
   %with_overflow6 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs4, i64 %checked_rhs5)
   %checked_result7 = extractvalue { i64, i1 } %with_overflow6, 0
   %checked_overflow8 = extractvalue { i64, i1 } %with_overflow6, 1
   %checked_overflow_widen9 = zext i1 %checked_overflow8 to i8
-  store i64 %checked_result7, ptr %local_6, align 4
+  store i64 %checked_result7, ptr %local_6, align 8
   store i8 %checked_overflow_widen9, ptr %local_7, align 1
   %cond_load10 = load i8, ptr %local_7, align 1
   %cond_nz11 = icmp ne i8 %cond_load10, 0
@@ -718,10 +760,76 @@ bb3:                                              ; preds = %bb2
   unreachable
 
 bb4:                                              ; preds = %bb2
-  %move_load = load i64, ptr %local_6, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load = load i64, ptr %local_6, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
+}
+
+define internal ptr @"i8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 8
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i8, ptr %local_0, align 1
+  %cast_int_sext = sext i8 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"i16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 8
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i16, ptr %local_0, align 2
+  %cast_int_sext = sext i16 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
 }
 
 define internal ptr @"i32::fmt"(i32 %0) {
@@ -758,14 +866,73 @@ entry:
   %return_slot = alloca ptr, align 8
   %local_0 = alloca i64, align 8
   %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_1, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 8
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i8, ptr %local_0, align 1
+  %call_result = call ptr @hew_u8_to_string(i8 %call_arg)
+  store ptr %call_result, ptr %local_1, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca ptr, align 8
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i16, ptr %local_0, align 2
+  %ffi_zext = zext i16 %call_arg to i32
+  %call_result = call ptr @hew_uint_to_string(i32 %ffi_zext)
   store ptr %call_result, ptr %local_1, align 8
   br label %bb1
 
@@ -794,8 +961,7 @@ entry:
 
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
-  %ffi_arg_trunc = trunc i32 %call_arg to i16
-  %call_result = call ptr @hew_uint_to_string(i16 %ffi_arg_trunc)
+  %call_result = call ptr @hew_uint_to_string(i32 %call_arg)
   store ptr %call_result, ptr %local_1, align 8
   br label %bb1
 
@@ -817,19 +983,83 @@ entry:
   %return_slot = alloca ptr, align 8
   %local_0 = alloca i64, align 8
   %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
   store ptr %call_result, ptr %local_1, align 8
   br label %bb1
 
 bb1:                                              ; preds = %bb0
   %move_load = load ptr, ptr %local_1, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"isize::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 8
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i64, ptr %local_0, align 8
+  store i64 %cast_int_src, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"usize::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 8
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i64, ptr %local_0, align 8
+  store i64 %cast_int_src, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
   store ptr %move_load, ptr %return_slot, align 8
   %ret_val = load ptr, ptr %return_slot, align 8
   ret ptr %ret_val
@@ -928,6 +1158,39 @@ after_cooperate:                                  ; preds = %entry
   br label %bb0
 }
 
+define internal ptr @"f32::fmt"(float %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca float, align 4
+  %local_1 = alloca double, align 8
+  %local_2 = alloca ptr, align 8
+  store float %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_float_src = load float, ptr %local_0, align 4
+  %cast_float_ext = fpext float %cast_float_src to double
+  store double %cast_float_ext, ptr %local_1, align 8
+  %call_arg = load double, ptr %local_1, align 8
+  %call_result = call ptr @hew_float_to_string(double %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
 define internal ptr @"string::fmt"(ptr %0) {
 entry:
   %return_slot = alloca ptr, align 8
@@ -936,10 +1199,264 @@ entry:
   br label %bb0
 
 bb0:                                              ; preds = %entry
+  %mir_share_string_load = load ptr, ptr %local_0, align 8
+  %mir_share_string_retain = call ptr @hew_string_clone(ptr %mir_share_string_load)
   %move_load = load ptr, ptr %local_0, align 8
   store ptr %move_load, ptr %return_slot, align 8
   %ret_val = load ptr, ptr %return_slot, align 8
   ret ptr %ret_val
+}
+
+define internal i64 @"duration::from_nanos"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_micros"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_millis"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_secs"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal ptr @"duration::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 8
+  %local_3 = alloca ptr, align 8
+  %local_4 = alloca ptr, align 8
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %hew_duration_nanos = load i64, ptr %local_0, align 8
+  %hew_duration_nanos_call = call i64 @hew_duration_nanos(i64 %hew_duration_nanos)
+  store i64 %hew_duration_nanos_call, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 8
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  store ptr @str_lit, ptr %local_3, align 8
+  %"hew_string_concat arg0" = load ptr, ptr %local_2, align 8
+  %"hew_string_concat arg1" = load ptr, ptr %local_3, align 8
+  %hew_string_concat_call = call ptr @hew_string_concat(ptr %"hew_string_concat arg0", ptr %"hew_string_concat arg1")
+  store ptr %hew_string_concat_call, ptr %local_4, align 8
+  %"hew_string_drop drop" = load ptr, ptr %local_2, align 8
+  call void @hew_string_drop(ptr %"hew_string_drop drop")
+  store ptr null, ptr %local_2, align 8
+  %move_load = load ptr, ptr %local_4, align 8
+  store ptr %move_load, ptr %return_slot, align 8
+  %ret_val = load ptr, ptr %return_slot, align 8
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal i32 @__hew_record_clone_inplace_CrashInfo(ptr %0, ptr %1) {
+entry:
+  br label %step_0_clone
+
+success:                                          ; preds = %step_0_store
+  ret i32 0
+
+fail:                                             ; preds = %rb_step_0
+  ret i32 1
+
+rb_step_0:                                        ; preds = %step_0_clone
+  br label %fail
+
+step_0_store:                                     ; preds = %step_0_clone
+  %dst_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  store ptr %clone_helper_f1, ptr %dst_f1_ptr, align 8
+  br label %success
+
+step_0_clone:                                     ; preds = %entry
+  %src_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %src_f1 = load ptr, ptr %src_f1_ptr, align 8
+  %clone_helper_f1 = call ptr @hew_string_clone(ptr %src_f1)
+  %cloned_f1_int = ptrtoint ptr %clone_helper_f1 to i64
+  %cloned_f1_null = icmp eq i64 %cloned_f1_int, 0
+  br i1 %cloned_f1_null, label %rb_step_0, label %step_0_store
+}
+
+define internal void @__hew_record_drop_inplace_CrashInfo(ptr %0) {
+entry:
+  %rec_int = ptrtoint ptr %0 to i64
+  %rec_is_null = icmp eq i64 %rec_int, 0
+  br i1 %rec_is_null, label %done, label %do_drop
+
+do_drop:                                          ; preds = %entry
+  %drop_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %drop_f1 = load ptr, ptr %drop_f1_ptr, align 8
+  call void @hew_string_drop(ptr %drop_f1)
+  br label %done
+
+done:                                             ; preds = %do_drop, %entry
+  ret void
+}
+
+declare void @hew_string_drop(ptr)
+
+define internal void @__hew_record_overwrite_release_CrashInfo(ptr %0, ptr %1) {
+entry:
+  %ow_slot_0 = alloca ptr, align 8
+  store ptr null, ptr %ow_slot_0, align 8
+  %ow_new_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  %ow_new_d0_f1_leaf = load ptr, ptr %ow_new_d0_f1_ptr, align 8
+  store ptr %ow_new_d0_f1_leaf, ptr %ow_slot_0, align 8
+  %ow_old_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %ow_old_d0_f1_val = load ptr, ptr %ow_old_d0_f1_ptr, align 8
+  %ow_old_d0_f1_int = ptrtoint ptr %ow_old_d0_f1_val to i64
+  %ow_old_d0_f1_cmp0_leaf = load ptr, ptr %ow_slot_0, align 8
+  %ow_old_d0_f1_cmp0_int = ptrtoint ptr %ow_old_d0_f1_cmp0_leaf to i64
+  %ow_old_d0_f1_cmp0_eq = icmp eq i64 %ow_old_d0_f1_int, %ow_old_d0_f1_cmp0_int
+  %ow_old_d0_f1_matched0 = or i1 false, %ow_old_d0_f1_cmp0_eq
+  %ow_old_d0_f1_neutralized = select i1 %ow_old_d0_f1_matched0, ptr null, ptr %ow_old_d0_f1_val
+  store ptr %ow_old_d0_f1_neutralized, ptr %ow_old_d0_f1_ptr, align 8
+  call void @__hew_record_drop_inplace_CrashInfo(ptr %0)
+  ret void
 }
 
 declare ptr @hew_dyn_box_alloc(i64, i64)

--- a/tests/ll-oracle/corpus/golden/wasm32/r4_arith.ll
+++ b/tests/ll-oracle/corpus/golden/wasm32/r4_arith.ll
@@ -1,6 +1,15 @@
 ; ModuleID = 'r4_arith'
 source_filename = "r4_arith"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20"
+target triple = "wasm32-unknown-unknown"
 
+%CrashInfo = type { i64, ptr }
+
+@str_lit = private unnamed_addr constant [3 x i8] c"ns\00", align 1
+
+declare void @hew_sleep_ns(i64)
+
+declare void @hew_sleep_until_ns(i64)
 
 declare void @hew_exit(i64)
 
@@ -16,7 +25,7 @@ declare ptr @hew_i64_to_string(i64)
 
 declare ptr @hew_u8_to_string(i8)
 
-declare ptr @hew_uint_to_string(i16)
+declare ptr @hew_uint_to_string(i32)
 
 declare ptr @hew_u64_to_string(i64)
 
@@ -104,21 +113,13 @@ declare ptr @hew_string_split(ptr, ptr)
 
 declare ptr @hew_string_lines(ptr)
 
-declare i32 @hew_string_find(ptr, ptr)
-
-declare i32 @hew_string_index_of_start(ptr, ptr)
-
 declare ptr @hew_string_slice(ptr, i64, i64)
 
 declare ptr @hew_string_repeat(ptr, i64)
 
-declare i32 @hew_string_char_at(ptr, i32)
-
 declare ptr @hew_string_chars(ptr)
 
 declare i32 @hew_string_char_count(ptr)
-
-declare i32 @hew_string_char_at_utf8(ptr, i32)
 
 declare void @hew_vec_push_bool(ptr, i1)
 
@@ -224,7 +225,27 @@ declare ptr @hew_bytes_to_string(ptr)
 
 declare void @hew_vec_append(ptr, ptr)
 
-declare void @hew_vec_remove_at(ptr, i64)
+declare i1 @hew_vec_remove_at_bool(ptr, i64)
+
+declare i8 @hew_vec_remove_at_i8(ptr, i64)
+
+declare i8 @hew_vec_remove_at_u8(ptr, i64)
+
+declare i16 @hew_vec_remove_at_i16(ptr, i64)
+
+declare i16 @hew_vec_remove_at_u16(ptr, i64)
+
+declare i32 @hew_vec_remove_at_i32(ptr, i64)
+
+declare i64 @hew_vec_remove_at_i64(ptr, i64)
+
+declare float @hew_vec_remove_at_f32(ptr, i64)
+
+declare double @hew_vec_remove_at_f64(ptr, i64)
+
+declare ptr @hew_vec_remove_at_str(ptr, i64)
+
+declare ptr @hew_vec_remove_at_ptr(ptr, i64)
 
 declare ptr @hew_vec_clone(ptr)
 
@@ -250,6 +271,12 @@ declare void @hew_node_api_connect(ptr)
 
 declare void @hew_node_api_shutdown()
 
+declare void @hew_node_api_load_keys(ptr)
+
+declare void @hew_node_api_allow_peer(i16, ptr)
+
+declare ptr @hew_node_api_identity_key()
+
 declare i64 @hew_actor_pid(ptr)
 
 declare i32 @hew_node_api_register_by_pid(ptr, i64)
@@ -257,6 +284,22 @@ declare i32 @hew_node_api_register_by_pid(ptr, i64)
 declare i64 @hew_remote_pid_from_raw(i64, i64)
 
 declare i64 @hew_node_api_lookup(ptr)
+
+declare ptr @hew_stream_channel(i64)
+
+declare ptr @hew_stream_pair_sink(ptr)
+
+declare ptr @hew_stream_pair_stream(ptr)
+
+declare void @hew_stream_pair_free(ptr)
+
+declare void @hew_sink_close(ptr)
+
+declare i32 @hew_sink_peer_closed(ptr)
+
+declare void @hew_actor_gen_sink_register(ptr, ptr)
+
+declare void @hew_actor_gen_sink_complete(ptr, ptr)
 
 define internal i32 @add_i32(i32 %0, i32 %1) {
 entry:
@@ -305,11 +348,11 @@ entry:
   %local_5 = alloca i32, align 4
   %local_6 = alloca i32, align 4
   %local_7 = alloca i64, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  %cast_int_src = load i64, ptr %local_0, align 4
+  %cast_int_src = load i64, ptr %local_0, align 8
   %cast_int_trunc = trunc i64 %cast_int_src to i8
   store i8 %cast_int_trunc, ptr %local_1, align 1
   %move_load = load i8, ptr %local_1, align 1
@@ -326,10 +369,10 @@ bb0:                                              ; preds = %entry
   store i32 %move_load5, ptr %local_6, align 4
   %cast_int_src6 = load i32, ptr %local_6, align 4
   %cast_int_sext7 = sext i32 %cast_int_src6 to i64
-  store i64 %cast_int_sext7, ptr %local_7, align 4
-  %move_load8 = load i64, ptr %local_7, align 4
-  store i64 %move_load8, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  store i64 %cast_int_sext7, ptr %local_7, align 8
+  %move_load8 = load i64, ptr %local_7, align 8
+  store i64 %move_load8, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
@@ -362,35 +405,35 @@ entry:
   %local_23 = alloca i8, align 1
   %local_24 = alloca i64, align 8
   %local_25 = alloca i8, align 1
-  store i64 %0, ptr %local_0, align 4
-  store i64 %1, ptr %local_1, align 4
+  store i64 %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %bitwise_lhs = load i64, ptr %local_0, align 4
-  %bitwise_rhs = load i64, ptr %local_1, align 4
+  %bitwise_lhs = load i64, ptr %local_0, align 8
+  %bitwise_rhs = load i64, ptr %local_1, align 8
   %bitand = and i64 %bitwise_lhs, %bitwise_rhs
-  store i64 %bitand, ptr %local_2, align 4
-  %move_load = load i64, ptr %local_2, align 4
-  store i64 %move_load, ptr %local_3, align 4
-  %bitwise_lhs1 = load i64, ptr %local_0, align 4
-  %bitwise_rhs2 = load i64, ptr %local_1, align 4
+  store i64 %bitand, ptr %local_2, align 8
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %local_3, align 8
+  %bitwise_lhs1 = load i64, ptr %local_0, align 8
+  %bitwise_rhs2 = load i64, ptr %local_1, align 8
   %bitor = or i64 %bitwise_lhs1, %bitwise_rhs2
-  store i64 %bitor, ptr %local_4, align 4
-  %move_load3 = load i64, ptr %local_4, align 4
-  store i64 %move_load3, ptr %local_5, align 4
-  %bitwise_lhs4 = load i64, ptr %local_0, align 4
-  %bitwise_rhs5 = load i64, ptr %local_1, align 4
+  store i64 %bitor, ptr %local_4, align 8
+  %move_load3 = load i64, ptr %local_4, align 8
+  store i64 %move_load3, ptr %local_5, align 8
+  %bitwise_lhs4 = load i64, ptr %local_0, align 8
+  %bitwise_rhs5 = load i64, ptr %local_1, align 8
   %bitxor = xor i64 %bitwise_lhs4, %bitwise_rhs5
-  store i64 %bitxor, ptr %local_6, align 4
-  %move_load6 = load i64, ptr %local_6, align 4
-  store i64 %move_load6, ptr %local_7, align 4
-  store i64 2, ptr %local_8, align 4
-  store i64 64, ptr %local_10, align 4
-  %cmp_lhs = load i64, ptr %local_8, align 4
-  %cmp_rhs = load i64, ptr %local_10, align 4
+  store i64 %bitxor, ptr %local_6, align 8
+  %move_load6 = load i64, ptr %local_6, align 8
+  store i64 %move_load6, ptr %local_7, align 8
+  store i64 2, ptr %local_8, align 8
+  store i64 64, ptr %local_10, align 8
+  %cmp_lhs = load i64, ptr %local_8, align 8
+  %cmp_rhs = load i64, ptr %local_10, align 8
   %cmp_bit = icmp uge i64 %cmp_lhs, %cmp_rhs
   %cmp_zext = zext i1 %cmp_bit to i8
   store i8 %cmp_zext, ptr %local_11, align 1
@@ -404,16 +447,16 @@ bb1:                                              ; preds = %bb0
   unreachable
 
 bb2:                                              ; preds = %bb0
-  %shl_lhs = load i64, ptr %local_0, align 4
-  %shl_rhs = load i64, ptr %local_8, align 4
+  %shl_lhs = load i64, ptr %local_0, align 8
+  %shl_rhs = load i64, ptr %local_8, align 8
   %shl = shl i64 %shl_lhs, %shl_rhs
-  store i64 %shl, ptr %local_9, align 4
-  %move_load7 = load i64, ptr %local_9, align 4
-  store i64 %move_load7, ptr %local_12, align 4
-  store i64 1, ptr %local_13, align 4
-  store i64 64, ptr %local_15, align 4
-  %cmp_lhs8 = load i64, ptr %local_13, align 4
-  %cmp_rhs9 = load i64, ptr %local_15, align 4
+  store i64 %shl, ptr %local_9, align 8
+  %move_load7 = load i64, ptr %local_9, align 8
+  store i64 %move_load7, ptr %local_12, align 8
+  store i64 1, ptr %local_13, align 8
+  store i64 64, ptr %local_15, align 8
+  %cmp_lhs8 = load i64, ptr %local_13, align 8
+  %cmp_rhs9 = load i64, ptr %local_15, align 8
   %cmp_bit10 = icmp uge i64 %cmp_lhs8, %cmp_rhs9
   %cmp_zext11 = zext i1 %cmp_bit10 to i8
   store i8 %cmp_zext11, ptr %local_16, align 1
@@ -427,19 +470,19 @@ bb3:                                              ; preds = %bb2
   unreachable
 
 bb4:                                              ; preds = %bb2
-  %shr_lhs = load i64, ptr %local_1, align 4
-  %shr_rhs = load i64, ptr %local_13, align 4
+  %shr_lhs = load i64, ptr %local_1, align 8
+  %shr_rhs = load i64, ptr %local_13, align 8
   %ashr = ashr i64 %shr_lhs, %shr_rhs
-  store i64 %ashr, ptr %local_14, align 4
-  %move_load14 = load i64, ptr %local_14, align 4
-  store i64 %move_load14, ptr %local_17, align 4
-  %checked_lhs = load i64, ptr %local_3, align 4
-  %checked_rhs = load i64, ptr %local_5, align 4
+  store i64 %ashr, ptr %local_14, align 8
+  %move_load14 = load i64, ptr %local_14, align 8
+  store i64 %move_load14, ptr %local_17, align 8
+  %checked_lhs = load i64, ptr %local_3, align 8
+  %checked_rhs = load i64, ptr %local_5, align 8
   %with_overflow = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_18, align 4
+  store i64 %checked_result, ptr %local_18, align 8
   store i8 %checked_overflow_widen, ptr %local_19, align 1
   %cond_load15 = load i8, ptr %local_19, align 1
   %cond_nz16 = icmp ne i8 %cond_load15, 0
@@ -451,13 +494,13 @@ bb5:                                              ; preds = %bb4
   unreachable
 
 bb6:                                              ; preds = %bb4
-  %checked_lhs17 = load i64, ptr %local_18, align 4
-  %checked_rhs18 = load i64, ptr %local_7, align 4
+  %checked_lhs17 = load i64, ptr %local_18, align 8
+  %checked_rhs18 = load i64, ptr %local_7, align 8
   %with_overflow19 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs17, i64 %checked_rhs18)
   %checked_result20 = extractvalue { i64, i1 } %with_overflow19, 0
   %checked_overflow21 = extractvalue { i64, i1 } %with_overflow19, 1
   %checked_overflow_widen22 = zext i1 %checked_overflow21 to i8
-  store i64 %checked_result20, ptr %local_20, align 4
+  store i64 %checked_result20, ptr %local_20, align 8
   store i8 %checked_overflow_widen22, ptr %local_21, align 1
   %cond_load23 = load i8, ptr %local_21, align 1
   %cond_nz24 = icmp ne i8 %cond_load23, 0
@@ -469,13 +512,13 @@ bb7:                                              ; preds = %bb6
   unreachable
 
 bb8:                                              ; preds = %bb6
-  %checked_lhs25 = load i64, ptr %local_20, align 4
-  %checked_rhs26 = load i64, ptr %local_12, align 4
+  %checked_lhs25 = load i64, ptr %local_20, align 8
+  %checked_rhs26 = load i64, ptr %local_12, align 8
   %with_overflow27 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs25, i64 %checked_rhs26)
   %checked_result28 = extractvalue { i64, i1 } %with_overflow27, 0
   %checked_overflow29 = extractvalue { i64, i1 } %with_overflow27, 1
   %checked_overflow_widen30 = zext i1 %checked_overflow29 to i8
-  store i64 %checked_result28, ptr %local_22, align 4
+  store i64 %checked_result28, ptr %local_22, align 8
   store i8 %checked_overflow_widen30, ptr %local_23, align 1
   %cond_load31 = load i8, ptr %local_23, align 1
   %cond_nz32 = icmp ne i8 %cond_load31, 0
@@ -487,13 +530,13 @@ bb9:                                              ; preds = %bb8
   unreachable
 
 bb10:                                             ; preds = %bb8
-  %checked_lhs33 = load i64, ptr %local_22, align 4
-  %checked_rhs34 = load i64, ptr %local_17, align 4
+  %checked_lhs33 = load i64, ptr %local_22, align 8
+  %checked_rhs34 = load i64, ptr %local_17, align 8
   %with_overflow35 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs33, i64 %checked_rhs34)
   %checked_result36 = extractvalue { i64, i1 } %with_overflow35, 0
   %checked_overflow37 = extractvalue { i64, i1 } %with_overflow35, 1
   %checked_overflow_widen38 = zext i1 %checked_overflow37 to i8
-  store i64 %checked_result36, ptr %local_24, align 4
+  store i64 %checked_result36, ptr %local_24, align 8
   store i8 %checked_overflow_widen38, ptr %local_25, align 1
   %cond_load39 = load i8, ptr %local_25, align 1
   %cond_nz40 = icmp ne i8 %cond_load39, 0
@@ -505,9 +548,9 @@ bb11:                                             ; preds = %bb10
   unreachable
 
 bb12:                                             ; preds = %bb10
-  %move_load41 = load i64, ptr %local_24, align 4
-  store i64 %move_load41, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load41 = load i64, ptr %local_24, align 8
+  store i64 %move_load41, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -540,14 +583,14 @@ entry:
   %local_17 = alloca i64, align 8
   %local_18 = alloca i64, align 8
   %local_19 = alloca i8, align 1
-  store i64 %0, ptr %local_0, align 4
-  store i64 %1, ptr %local_1, align 4
+  store i64 %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  store i64 0, ptr %local_3, align 4
-  %cmp_lhs = load i64, ptr %local_1, align 4
-  %cmp_rhs = load i64, ptr %local_3, align 4
+  store i64 0, ptr %local_3, align 8
+  %cmp_lhs = load i64, ptr %local_1, align 8
+  %cmp_rhs = load i64, ptr %local_3, align 8
   %cmp_bit = icmp eq i64 %cmp_lhs, %cmp_rhs
   %cmp_zext = zext i1 %cmp_bit to i8
   store i8 %cmp_zext, ptr %local_4, align 1
@@ -561,9 +604,9 @@ bb1:                                              ; preds = %bb0
   unreachable
 
 bb2:                                              ; preds = %bb0
-  store i64 -9223372036854775808, ptr %local_5, align 4
-  %cmp_lhs1 = load i64, ptr %local_0, align 4
-  %cmp_rhs2 = load i64, ptr %local_5, align 4
+  store i64 -9223372036854775808, ptr %local_5, align 8
+  %cmp_lhs1 = load i64, ptr %local_0, align 8
+  %cmp_rhs2 = load i64, ptr %local_5, align 8
   %cmp_bit3 = icmp eq i64 %cmp_lhs1, %cmp_rhs2
   %cmp_zext4 = zext i1 %cmp_bit3 to i8
   store i8 %cmp_zext4, ptr %local_6, align 1
@@ -572,9 +615,9 @@ bb2:                                              ; preds = %bb0
   br i1 %cond_nz6, label %bb3, label %bb4
 
 bb3:                                              ; preds = %bb2
-  store i64 -1, ptr %local_7, align 4
-  %cmp_lhs7 = load i64, ptr %local_1, align 4
-  %cmp_rhs8 = load i64, ptr %local_7, align 4
+  store i64 -1, ptr %local_7, align 8
+  %cmp_lhs7 = load i64, ptr %local_1, align 8
+  %cmp_rhs8 = load i64, ptr %local_7, align 8
   %cmp_bit9 = icmp eq i64 %cmp_lhs7, %cmp_rhs8
   %cmp_zext10 = zext i1 %cmp_bit9 to i8
   store i8 %cmp_zext10, ptr %local_8, align 1
@@ -583,15 +626,15 @@ bb3:                                              ; preds = %bb2
   br i1 %cond_nz12, label %bb5, label %bb4
 
 bb4:                                              ; preds = %bb3, %bb2
-  %div_lhs = load i64, ptr %local_0, align 4
-  %div_rhs = load i64, ptr %local_1, align 4
+  %div_lhs = load i64, ptr %local_0, align 8
+  %div_rhs = load i64, ptr %local_1, align 8
   %sdiv = sdiv i64 %div_lhs, %div_rhs
-  store i64 %sdiv, ptr %local_2, align 4
-  %move_load = load i64, ptr %local_2, align 4
-  store i64 %move_load, ptr %local_9, align 4
-  store i64 0, ptr %local_11, align 4
-  %cmp_lhs13 = load i64, ptr %local_1, align 4
-  %cmp_rhs14 = load i64, ptr %local_11, align 4
+  store i64 %sdiv, ptr %local_2, align 8
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %local_9, align 8
+  store i64 0, ptr %local_11, align 8
+  %cmp_lhs13 = load i64, ptr %local_1, align 8
+  %cmp_rhs14 = load i64, ptr %local_11, align 8
   %cmp_bit15 = icmp eq i64 %cmp_lhs13, %cmp_rhs14
   %cmp_zext16 = zext i1 %cmp_bit15 to i8
   store i8 %cmp_zext16, ptr %local_12, align 1
@@ -610,9 +653,9 @@ bb6:                                              ; preds = %bb4
   unreachable
 
 bb7:                                              ; preds = %bb4
-  store i64 -9223372036854775808, ptr %local_13, align 4
-  %cmp_lhs19 = load i64, ptr %local_0, align 4
-  %cmp_rhs20 = load i64, ptr %local_13, align 4
+  store i64 -9223372036854775808, ptr %local_13, align 8
+  %cmp_lhs19 = load i64, ptr %local_0, align 8
+  %cmp_rhs20 = load i64, ptr %local_13, align 8
   %cmp_bit21 = icmp eq i64 %cmp_lhs19, %cmp_rhs20
   %cmp_zext22 = zext i1 %cmp_bit21 to i8
   store i8 %cmp_zext22, ptr %local_14, align 1
@@ -621,9 +664,9 @@ bb7:                                              ; preds = %bb4
   br i1 %cond_nz24, label %bb8, label %bb9
 
 bb8:                                              ; preds = %bb7
-  store i64 -1, ptr %local_15, align 4
-  %cmp_lhs25 = load i64, ptr %local_1, align 4
-  %cmp_rhs26 = load i64, ptr %local_15, align 4
+  store i64 -1, ptr %local_15, align 8
+  %cmp_lhs25 = load i64, ptr %local_1, align 8
+  %cmp_rhs26 = load i64, ptr %local_15, align 8
   %cmp_bit27 = icmp eq i64 %cmp_lhs25, %cmp_rhs26
   %cmp_zext28 = zext i1 %cmp_bit27 to i8
   store i8 %cmp_zext28, ptr %local_16, align 1
@@ -632,19 +675,19 @@ bb8:                                              ; preds = %bb7
   br i1 %cond_nz30, label %bb10, label %bb9
 
 bb9:                                              ; preds = %bb8, %bb7
-  %div_lhs31 = load i64, ptr %local_0, align 4
-  %div_rhs32 = load i64, ptr %local_1, align 4
+  %div_lhs31 = load i64, ptr %local_0, align 8
+  %div_rhs32 = load i64, ptr %local_1, align 8
   %srem = srem i64 %div_lhs31, %div_rhs32
-  store i64 %srem, ptr %local_10, align 4
-  %move_load33 = load i64, ptr %local_10, align 4
-  store i64 %move_load33, ptr %local_17, align 4
-  %checked_lhs = load i64, ptr %local_9, align 4
-  %checked_rhs = load i64, ptr %local_17, align 4
+  store i64 %srem, ptr %local_10, align 8
+  %move_load33 = load i64, ptr %local_10, align 8
+  store i64 %move_load33, ptr %local_17, align 8
+  %checked_lhs = load i64, ptr %local_9, align 8
+  %checked_rhs = load i64, ptr %local_17, align 8
   %with_overflow = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_18, align 4
+  store i64 %checked_result, ptr %local_18, align 8
   store i8 %checked_overflow_widen, ptr %local_19, align 1
   %cond_load34 = load i8, ptr %local_19, align 1
   %cond_nz35 = icmp ne i8 %cond_load34, 0
@@ -661,13 +704,13 @@ bb11:                                             ; preds = %bb9
   unreachable
 
 bb12:                                             ; preds = %bb9
-  %move_load36 = load i64, ptr %local_18, align 4
-  store i64 %move_load36, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load36 = load i64, ptr %local_18, align 8
+  store i64 %move_load36, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
-define i64 @main() {
+define i64 @__original_main() {
 entry:
   %return_slot = alloca i64, align 8
   %local_0 = alloca i32, align 4
@@ -709,42 +752,42 @@ bb1:                                              ; preds = %bb0
   br label %bb2
 
 bb2:                                              ; preds = %bb1
-  store i64 200, ptr %local_3, align 4
-  %call_arg2 = load i64, ptr %local_3, align 4
+  store i64 200, ptr %local_3, align 8
+  %call_arg2 = load i64, ptr %local_3, align 8
   %call_result3 = call i64 @cast_chain(i64 %call_arg2)
-  store i64 %call_result3, ptr %local_4, align 4
+  store i64 %call_result3, ptr %local_4, align 8
   br label %bb3
 
 bb3:                                              ; preds = %bb2
-  %print_arg4 = load i64, ptr %local_4, align 4
+  %print_arg4 = load i64, ptr %local_4, align 8
   call void @hew_print_value(i8 1, i64 %print_arg4, i1 true)
   br label %bb4
 
 bb4:                                              ; preds = %bb3
-  store i64 12, ptr %local_5, align 4
-  store i64 10, ptr %local_6, align 4
-  %call_arg5 = load i64, ptr %local_5, align 4
-  %call_arg6 = load i64, ptr %local_6, align 4
+  store i64 12, ptr %local_5, align 8
+  store i64 10, ptr %local_6, align 8
+  %call_arg5 = load i64, ptr %local_5, align 8
+  %call_arg6 = load i64, ptr %local_6, align 8
   %call_result7 = call i64 @bitops(i64 %call_arg5, i64 %call_arg6)
-  store i64 %call_result7, ptr %local_7, align 4
+  store i64 %call_result7, ptr %local_7, align 8
   br label %bb5
 
 bb5:                                              ; preds = %bb4
-  %print_arg8 = load i64, ptr %local_7, align 4
+  %print_arg8 = load i64, ptr %local_7, align 8
   call void @hew_print_value(i8 1, i64 %print_arg8, i1 true)
   br label %bb6
 
 bb6:                                              ; preds = %bb5
-  store i64 17, ptr %local_8, align 4
-  store i64 5, ptr %local_9, align 4
-  %call_arg9 = load i64, ptr %local_8, align 4
-  %call_arg10 = load i64, ptr %local_9, align 4
+  store i64 17, ptr %local_8, align 8
+  store i64 5, ptr %local_9, align 8
+  %call_arg9 = load i64, ptr %local_8, align 8
+  %call_arg10 = load i64, ptr %local_9, align 8
   %call_result11 = call i64 @divrem(i64 %call_arg9, i64 %call_arg10)
-  store i64 %call_result11, ptr %local_10, align 4
+  store i64 %call_result11, ptr %local_10, align 8
   br label %bb7
 
 bb7:                                              ; preds = %bb6
-  %print_arg12 = load i64, ptr %local_10, align 4
+  %print_arg12 = load i64, ptr %local_10, align 8
   call void @hew_print_value(i8 1, i64 %print_arg12, i1 true)
   br label %bb8
 
@@ -754,10 +797,10 @@ bb8:                                              ; preds = %bb7
   store i8 %move_load, ptr %local_12, align 1
   %cast_int_src = load i8, ptr %local_12, align 1
   %cast_int_zext = zext i8 %cast_int_src to i64
-  store i64 %cast_int_zext, ptr %local_13, align 4
-  %move_load13 = load i64, ptr %local_13, align 4
-  store i64 %move_load13, ptr %local_14, align 4
-  %print_arg14 = load i64, ptr %local_14, align 4
+  store i64 %cast_int_zext, ptr %local_13, align 8
+  %move_load13 = load i64, ptr %local_13, align 8
+  store i64 %move_load13, ptr %local_14, align 8
+  %print_arg14 = load i64, ptr %local_14, align 8
   call void @hew_print_value(i8 1, i64 %print_arg14, i1 true)
   br label %bb9
 
@@ -767,17 +810,16 @@ bb9:                                              ; preds = %bb8
   store i16 %move_load15, ptr %local_16, align 2
   %cast_int_src16 = load i16, ptr %local_16, align 2
   %cast_int_zext17 = zext i16 %cast_int_src16 to i64
-  store i64 %cast_int_zext17, ptr %local_17, align 4
-  %print_arg18 = load i64, ptr %local_17, align 4
+  store i64 %cast_int_zext17, ptr %local_17, align 8
+  %print_arg18 = load i64, ptr %local_17, align 8
   call void @hew_print_value(i8 1, i64 %print_arg18, i1 true)
   br label %bb10
 
 bb10:                                             ; preds = %bb9
-  store i64 0, ptr %local_18, align 4
-  %move_load19 = load i64, ptr %local_18, align 4
-  store i64 %move_load19, ptr %return_slot, align 4
-  %hew_lambda_drain_all_call = call i32 @hew_lambda_drain_all(i64 0)
-  %ret_val = load i64, ptr %return_slot, align 4
+  store i64 0, ptr %local_18, align 8
+  %move_load19 = load i64, ptr %local_18, align 8
+  store i64 %move_load19, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -787,11 +829,77 @@ after_cooperate:                                  ; preds = %entry
   br label %bb0
 }
 
+define internal ptr @"i8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 4
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i8, ptr %local_0, align 1
+  %cast_int_sext = sext i8 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"i16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 4
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i16, ptr %local_0, align 2
+  %cast_int_sext = sext i16 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
 define internal ptr @"i32::fmt"(i32 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i32, align 4
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i32 %0, ptr %local_0, align 4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -800,13 +908,13 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
   %call_result = call ptr @hew_int_to_string(i32 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -818,24 +926,83 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"i64::fmt"(i64 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i64, align 8
-  %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  %local_1 = alloca ptr, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 4
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i8, ptr %local_0, align 1
+  %call_result = call ptr @hew_u8_to_string(i8 %call_arg)
+  store ptr %call_result, ptr %local_1, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca ptr, align 4
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i16, ptr %local_0, align 2
+  %ffi_zext = zext i16 %call_arg to i32
+  %call_result = call ptr @hew_uint_to_string(i32 %ffi_zext)
+  store ptr %call_result, ptr %local_1, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -847,9 +1014,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"u32::fmt"(i32 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i32, align 4
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i32 %0, ptr %local_0, align 4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -857,15 +1024,14 @@ entry:
 
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
-  %ffi_arg_trunc = trunc i32 %call_arg to i16
-  %call_result = call ptr @hew_uint_to_string(i16 %ffi_arg_trunc)
-  store ptr %call_result, ptr %local_1, align 8
+  %call_result = call ptr @hew_uint_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -877,24 +1043,90 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"u64::fmt"(i64 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i64, align 8
-  %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  %local_1 = alloca ptr, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"isize::fmt"(i32 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 4
+  store i32 %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i32, ptr %local_0, align 4
+  %cast_int_sext = sext i32 %cast_int_src to i64
+  store i64 %cast_int_sext, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"usize::fmt"(i32 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 4
+  store i32 %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i32, ptr %local_0, align 4
+  %cast_int_zext = zext i32 %cast_int_src to i64
+  store i64 %cast_int_zext, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -906,9 +1138,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"bool::fmt"(i8 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i8, align 1
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i8 %0, ptr %local_0, align 1
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -917,13 +1149,13 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i8, ptr %local_0, align 1
   %call_result = call ptr @hew_bool_to_string(i8 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -935,9 +1167,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"char::fmt"(i32 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i32, align 4
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i32 %0, ptr %local_0, align 4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -946,13 +1178,13 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
   %call_result = call ptr @hew_char_to_string(i32 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -964,9 +1196,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"f64::fmt"(double %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca double, align 8
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store double %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -975,13 +1207,46 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load double, ptr %local_0, align 8
   %call_result = call ptr @hew_float_to_string(double %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"f32::fmt"(float %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca float, align 4
+  %local_1 = alloca double, align 8
+  %local_2 = alloca ptr, align 4
+  store float %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_float_src = load float, ptr %local_0, align 4
+  %cast_float_ext = fpext float %cast_float_src to double
+  store double %cast_float_ext, ptr %local_1, align 8
+  %call_arg = load double, ptr %local_1, align 8
+  %call_result = call ptr @hew_float_to_string(double %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -993,16 +1258,276 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"string::fmt"(ptr %0) {
 entry:
-  %return_slot = alloca ptr, align 8
-  %local_0 = alloca ptr, align 8
-  store ptr %0, ptr %local_0, align 8
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca ptr, align 4
+  store ptr %0, ptr %local_0, align 4
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  %move_load = load ptr, ptr %local_0, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %mir_share_string_load = load ptr, ptr %local_0, align 4
+  %mir_share_string_retain = call ptr @hew_string_clone(ptr %mir_share_string_load)
+  %move_load = load ptr, ptr %local_0, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
+}
+
+define internal i64 @"duration::from_nanos"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_micros"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_millis"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_secs"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal ptr @"duration::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 4
+  %local_3 = alloca ptr, align 4
+  %local_4 = alloca ptr, align 4
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %hew_duration_nanos = load i64, ptr %local_0, align 8
+  %hew_duration_nanos_call = call i64 @hew_duration_nanos(i64 %hew_duration_nanos)
+  store i64 %hew_duration_nanos_call, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  store ptr @str_lit, ptr %local_3, align 4
+  %"hew_string_concat arg0" = load ptr, ptr %local_2, align 4
+  %"hew_string_concat arg1" = load ptr, ptr %local_3, align 4
+  %hew_string_concat_call = call ptr @hew_string_concat(ptr %"hew_string_concat arg0", ptr %"hew_string_concat arg1")
+  store ptr %hew_string_concat_call, ptr %local_4, align 4
+  %"hew_string_drop drop" = load ptr, ptr %local_2, align 4
+  call void @hew_string_drop(ptr %"hew_string_drop drop")
+  store ptr null, ptr %local_2, align 4
+  %move_load = load ptr, ptr %local_4, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define i64 @main() {
+entry:
+  %__original_main_call = call i64 @__original_main()
+  ret i64 %__original_main_call
+}
+
+define internal i32 @__hew_record_clone_inplace_CrashInfo(ptr %0, ptr %1) {
+entry:
+  br label %step_0_clone
+
+success:                                          ; preds = %step_0_store
+  ret i32 0
+
+fail:                                             ; preds = %rb_step_0
+  ret i32 1
+
+rb_step_0:                                        ; preds = %step_0_clone
+  br label %fail
+
+step_0_store:                                     ; preds = %step_0_clone
+  %dst_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  store ptr %clone_helper_f1, ptr %dst_f1_ptr, align 4
+  br label %success
+
+step_0_clone:                                     ; preds = %entry
+  %src_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %src_f1 = load ptr, ptr %src_f1_ptr, align 4
+  %clone_helper_f1 = call ptr @hew_string_clone(ptr %src_f1)
+  %cloned_f1_int = ptrtoint ptr %clone_helper_f1 to i64
+  %cloned_f1_null = icmp eq i64 %cloned_f1_int, 0
+  br i1 %cloned_f1_null, label %rb_step_0, label %step_0_store
+}
+
+define internal void @__hew_record_drop_inplace_CrashInfo(ptr %0) {
+entry:
+  %rec_int = ptrtoint ptr %0 to i64
+  %rec_is_null = icmp eq i64 %rec_int, 0
+  br i1 %rec_is_null, label %done, label %do_drop
+
+do_drop:                                          ; preds = %entry
+  %drop_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %drop_f1 = load ptr, ptr %drop_f1_ptr, align 4
+  call void @hew_string_drop(ptr %drop_f1)
+  br label %done
+
+done:                                             ; preds = %do_drop, %entry
+  ret void
+}
+
+declare void @hew_string_drop(ptr)
+
+define internal void @__hew_record_overwrite_release_CrashInfo(ptr %0, ptr %1) {
+entry:
+  %ow_slot_0 = alloca ptr, align 4
+  store ptr null, ptr %ow_slot_0, align 4
+  %ow_new_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  %ow_new_d0_f1_leaf = load ptr, ptr %ow_new_d0_f1_ptr, align 4
+  store ptr %ow_new_d0_f1_leaf, ptr %ow_slot_0, align 4
+  %ow_old_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %ow_old_d0_f1_val = load ptr, ptr %ow_old_d0_f1_ptr, align 4
+  %ow_old_d0_f1_int = ptrtoint ptr %ow_old_d0_f1_val to i64
+  %ow_old_d0_f1_cmp0_leaf = load ptr, ptr %ow_slot_0, align 4
+  %ow_old_d0_f1_cmp0_int = ptrtoint ptr %ow_old_d0_f1_cmp0_leaf to i64
+  %ow_old_d0_f1_cmp0_eq = icmp eq i64 %ow_old_d0_f1_int, %ow_old_d0_f1_cmp0_int
+  %ow_old_d0_f1_matched0 = or i1 false, %ow_old_d0_f1_cmp0_eq
+  %ow_old_d0_f1_neutralized = select i1 %ow_old_d0_f1_matched0, ptr null, ptr %ow_old_d0_f1_val
+  store ptr %ow_old_d0_f1_neutralized, ptr %ow_old_d0_f1_ptr, align 4
+  call void @__hew_record_drop_inplace_CrashInfo(ptr %0)
+  ret void
 }
 
 ; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
@@ -1018,7 +1543,8 @@ declare i32 @hew_actor_cooperate()
 ; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
 declare { i64, i1 } @llvm.sadd.with.overflow.i64(i64, i64) #0
 
-declare i32 @hew_lambda_drain_all(i64)
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
+declare { i64, i1 } @llvm.smul.with.overflow.i64(i64, i64) #0
 
 attributes #0 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #1 = { cold noreturn nounwind memory(inaccessiblemem: write) }

--- a/tests/ll-oracle/corpus/golden/wasm32/r4_layout.ll
+++ b/tests/ll-oracle/corpus/golden/wasm32/r4_layout.ll
@@ -1,18 +1,25 @@
 ; ModuleID = 'r4_layout'
 source_filename = "r4_layout"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20"
+target triple = "wasm32-unknown-unknown"
 
 %Point = type { i64, i64 }
 %Color = type { i8, [1 x i8] }
 %"Option$$Point" = type { i8, [2 x i64] }
+%CrashInfo = type { i64, ptr }
 
-@__hew_layout_new_16_8_plain = private constant { i64, i64, i8 } { i64 16, i64 8, i8 0 }
-@__hew_layout_push_16_8_plain = private constant { i64, i64, i8 } { i64 16, i64 8, i8 0 }
-@__hew_layout_get_16_8_plain = private constant { i64, i64, i8 } { i64 16, i64 8, i8 0 }
+@__hew_layout_new_16_8_plain = private constant { i32, i32, i8 } { i32 16, i32 8, i8 0 }
+@__hew_layout_push_16_8_plain = private constant { i32, i32, i8 } { i32 16, i32 8, i8 0 }
+@__hew_layout_get_16_8_plain = private constant { i32, i32, i8 } { i32 16, i32 8, i8 0 }
 @hew_layout_key_string = external constant i8
-@__hew_map_value_layout_16_8_plain = private constant { i64, i64, i8, ptr, ptr } { i64 16, i64 8, i8 0, ptr null, ptr null }
+@__hew_map_value_layout_16_8_plain = private constant { i32, i32, i8, ptr, ptr } { i32 16, i32 8, i8 0, ptr null, ptr null }
 @str_lit = private unnamed_addr constant [7 x i8] c"origin\00", align 1
 @str_lit.1 = private unnamed_addr constant [7 x i8] c"origin\00", align 1
+@str_lit.2 = private unnamed_addr constant [3 x i8] c"ns\00", align 1
 
+declare void @hew_sleep_ns(i64)
+
+declare void @hew_sleep_until_ns(i64)
 
 declare void @hew_exit(i64)
 
@@ -28,7 +35,7 @@ declare ptr @hew_i64_to_string(i64)
 
 declare ptr @hew_u8_to_string(i8)
 
-declare ptr @hew_uint_to_string(i16)
+declare ptr @hew_uint_to_string(i32)
 
 declare ptr @hew_u64_to_string(i64)
 
@@ -116,21 +123,13 @@ declare ptr @hew_string_split(ptr, ptr)
 
 declare ptr @hew_string_lines(ptr)
 
-declare i32 @hew_string_find(ptr, ptr)
-
-declare i32 @hew_string_index_of_start(ptr, ptr)
-
 declare ptr @hew_string_slice(ptr, i64, i64)
 
 declare ptr @hew_string_repeat(ptr, i64)
 
-declare i32 @hew_string_char_at(ptr, i32)
-
 declare ptr @hew_string_chars(ptr)
 
 declare i32 @hew_string_char_count(ptr)
-
-declare i32 @hew_string_char_at_utf8(ptr, i32)
 
 declare void @hew_vec_push_bool(ptr, i1)
 
@@ -236,7 +235,27 @@ declare ptr @hew_bytes_to_string(ptr)
 
 declare void @hew_vec_append(ptr, ptr)
 
-declare void @hew_vec_remove_at(ptr, i64)
+declare i1 @hew_vec_remove_at_bool(ptr, i64)
+
+declare i8 @hew_vec_remove_at_i8(ptr, i64)
+
+declare i8 @hew_vec_remove_at_u8(ptr, i64)
+
+declare i16 @hew_vec_remove_at_i16(ptr, i64)
+
+declare i16 @hew_vec_remove_at_u16(ptr, i64)
+
+declare i32 @hew_vec_remove_at_i32(ptr, i64)
+
+declare i64 @hew_vec_remove_at_i64(ptr, i64)
+
+declare float @hew_vec_remove_at_f32(ptr, i64)
+
+declare double @hew_vec_remove_at_f64(ptr, i64)
+
+declare ptr @hew_vec_remove_at_str(ptr, i64)
+
+declare ptr @hew_vec_remove_at_ptr(ptr, i64)
 
 declare ptr @hew_vec_clone(ptr)
 
@@ -262,6 +281,12 @@ declare void @hew_node_api_connect(ptr)
 
 declare void @hew_node_api_shutdown()
 
+declare void @hew_node_api_load_keys(ptr)
+
+declare void @hew_node_api_allow_peer(i16, ptr)
+
+declare ptr @hew_node_api_identity_key()
+
 declare i64 @hew_actor_pid(ptr)
 
 declare i32 @hew_node_api_register_by_pid(ptr, i64)
@@ -270,26 +295,42 @@ declare i64 @hew_remote_pid_from_raw(i64, i64)
 
 declare i64 @hew_node_api_lookup(ptr)
 
+declare ptr @hew_stream_channel(i64)
+
+declare ptr @hew_stream_pair_sink(ptr)
+
+declare ptr @hew_stream_pair_stream(ptr)
+
+declare void @hew_stream_pair_free(ptr)
+
+declare void @hew_sink_close(ptr)
+
+declare i32 @hew_sink_peer_closed(ptr)
+
+declare void @hew_actor_gen_sink_register(ptr, ptr)
+
+declare void @hew_actor_gen_sink_complete(ptr, ptr)
+
 define internal %Point @make_point(i64 %0, i64 %1) {
 entry:
   %return_slot = alloca %Point, align 8
   %local_0 = alloca i64, align 8
   %local_1 = alloca i64, align 8
   %local_2 = alloca %Point, align 8
-  store i64 %0, ptr %local_0, align 4
-  store i64 %1, ptr %local_1, align 4
+  store i64 %0, ptr %local_0, align 8
+  store i64 %1, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
   %field_0_init_ptr = getelementptr inbounds nuw %Point, ptr %local_2, i32 0, i32 0
-  %field_0_init_src = load i64, ptr %local_0, align 4
-  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 4
+  %field_0_init_src = load i64, ptr %local_0, align 8
+  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 8
   %field_1_init_ptr = getelementptr inbounds nuw %Point, ptr %local_2, i32 0, i32 1
-  %field_1_init_src = load i64, ptr %local_1, align 4
-  store i64 %field_1_init_src, ptr %field_1_init_ptr, align 4
-  %move_load = load %Point, ptr %local_2, align 4
-  store %Point %move_load, ptr %return_slot, align 4
-  %ret_val = load %Point, ptr %return_slot, align 4
+  %field_1_init_src = load i64, ptr %local_1, align 8
+  store i64 %field_1_init_src, ptr %field_1_init_ptr, align 8
+  %move_load = load %Point, ptr %local_2, align 8
+  store %Point %move_load, ptr %return_slot, align 8
+  %ret_val = load %Point, ptr %return_slot, align 8
   ret %Point %ret_val
 }
 
@@ -317,10 +358,10 @@ bb0:                                              ; preds = %after_cooperate
   %machine_tag_ptr = getelementptr inbounds nuw %Color, ptr %local_0, i32 0, i32 0
   %move_iN_load = load i8, ptr %machine_tag_ptr, align 1
   %move_iN_zext = zext i8 %move_iN_load to i64
-  store i64 %move_iN_zext, ptr %local_2, align 4
-  store i64 0, ptr %local_3, align 4
-  %cmp_lhs = load i64, ptr %local_2, align 4
-  %cmp_rhs = load i64, ptr %local_3, align 4
+  store i64 %move_iN_zext, ptr %local_2, align 8
+  store i64 0, ptr %local_3, align 8
+  %cmp_lhs = load i64, ptr %local_2, align 8
+  %cmp_rhs = load i64, ptr %local_3, align 8
   %cmp_bit = icmp eq i64 %cmp_lhs, %cmp_rhs
   %cmp_zext = zext i1 %cmp_bit to i8
   store i8 %cmp_zext, ptr %local_4, align 1
@@ -329,31 +370,31 @@ bb0:                                              ; preds = %after_cooperate
   br i1 %cond_nz, label %bb2, label %bb6
 
 bb1:                                              ; preds = %after_cooperate15, %after_cooperate10, %after_cooperate5
-  %move_load = load i64, ptr %local_1, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load = load i64, ptr %local_1, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 
 bb2:                                              ; preds = %bb0
-  store i64 0, ptr %local_9, align 4
-  %move_load1 = load i64, ptr %local_9, align 4
-  store i64 %move_load1, ptr %local_1, align 4
+  store i64 0, ptr %local_9, align 8
+  %move_load1 = load i64, ptr %local_9, align 8
+  store i64 %move_load1, ptr %local_1, align 8
   %hew_actor_cooperate2 = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel3 = icmp eq i32 %hew_actor_cooperate2, 2
   br i1 %hew_cooperate_is_cancel3, label %cancel_exit4, label %after_cooperate5
 
 bb3:                                              ; preds = %bb6
-  store i64 1, ptr %local_10, align 4
-  %move_load6 = load i64, ptr %local_10, align 4
-  store i64 %move_load6, ptr %local_1, align 4
+  store i64 1, ptr %local_10, align 8
+  %move_load6 = load i64, ptr %local_10, align 8
+  store i64 %move_load6, ptr %local_1, align 8
   %hew_actor_cooperate7 = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel8 = icmp eq i32 %hew_actor_cooperate7, 2
   br i1 %hew_cooperate_is_cancel8, label %cancel_exit9, label %after_cooperate10
 
 bb4:                                              ; preds = %bb7
-  store i64 2, ptr %local_11, align 4
-  %move_load11 = load i64, ptr %local_11, align 4
-  store i64 %move_load11, ptr %local_1, align 4
+  store i64 2, ptr %local_11, align 8
+  %move_load11 = load i64, ptr %local_11, align 8
+  store i64 %move_load11, ptr %local_1, align 8
   %hew_actor_cooperate12 = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel13 = icmp eq i32 %hew_actor_cooperate12, 2
   br i1 %hew_cooperate_is_cancel13, label %cancel_exit14, label %after_cooperate15
@@ -364,9 +405,9 @@ bb5:                                              ; preds = %bb7
   unreachable
 
 bb6:                                              ; preds = %bb0
-  store i64 1, ptr %local_5, align 4
-  %cmp_lhs16 = load i64, ptr %local_2, align 4
-  %cmp_rhs17 = load i64, ptr %local_5, align 4
+  store i64 1, ptr %local_5, align 8
+  %cmp_lhs16 = load i64, ptr %local_2, align 8
+  %cmp_rhs17 = load i64, ptr %local_5, align 8
   %cmp_bit18 = icmp eq i64 %cmp_lhs16, %cmp_rhs17
   %cmp_zext19 = zext i1 %cmp_bit18 to i8
   store i8 %cmp_zext19, ptr %local_6, align 1
@@ -375,9 +416,9 @@ bb6:                                              ; preds = %bb0
   br i1 %cond_nz21, label %bb3, label %bb7
 
 bb7:                                              ; preds = %bb6
-  store i64 2, ptr %local_7, align 4
-  %cmp_lhs22 = load i64, ptr %local_2, align 4
-  %cmp_rhs23 = load i64, ptr %local_7, align 4
+  store i64 2, ptr %local_7, align 8
+  %cmp_lhs22 = load i64, ptr %local_2, align 8
+  %cmp_rhs23 = load i64, ptr %local_7, align 8
   %cmp_bit24 = icmp eq i64 %cmp_lhs22, %cmp_rhs23
   %cmp_zext25 = zext i1 %cmp_bit24 to i8
   store i8 %cmp_zext25, ptr %local_8, align 1
@@ -410,7 +451,7 @@ after_cooperate15:                                ; preds = %bb4
   br label %bb1
 }
 
-define i64 @main() {
+define i64 @__original_main() {
 entry:
   %return_slot = alloca i64, align 8
   %local_0 = alloca i64, align 8
@@ -421,8 +462,8 @@ entry:
   %local_5 = alloca i64, align 8
   %local_6 = alloca i64, align 8
   %local_7 = alloca i8, align 1
-  %local_8 = alloca ptr, align 8
-  %local_9 = alloca ptr, align 8
+  %local_8 = alloca ptr, align 4
+  %local_9 = alloca ptr, align 4
   %local_10 = alloca i64, align 8
   %local_11 = alloca i64, align 8
   %local_12 = alloca %Point, align 8
@@ -435,14 +476,14 @@ entry:
   %local_19 = alloca %Point, align 8
   %local_20 = alloca %Point, align 8
   %local_21 = alloca i64, align 8
-  %local_22 = alloca ptr, align 8
-  %local_23 = alloca ptr, align 8
-  %local_24 = alloca ptr, align 8
+  %local_22 = alloca ptr, align 4
+  %local_23 = alloca ptr, align 4
+  %local_24 = alloca ptr, align 4
   %local_25 = alloca i64, align 8
   %local_26 = alloca i64, align 8
   %local_27 = alloca %Point, align 8
   %local_28 = alloca i8, align 1
-  %local_29 = alloca ptr, align 8
+  %local_29 = alloca ptr, align 4
   %local_30 = alloca %"Option$$Point", align 8
   %local_31 = alloca i64, align 8
   %local_32 = alloca i64, align 8
@@ -455,41 +496,39 @@ entry:
   %local_39 = alloca i64, align 8
   %local_40 = alloca i8, align 1
   %local_41 = alloca i64, align 8
-  %local_42 = alloca i64, align 8
-  %local_43 = alloca i8, align 1
-  %local_44 = alloca %Color, align 8
+  %local_42 = alloca %Color, align 8
+  %local_43 = alloca i64, align 8
+  %local_44 = alloca i64, align 8
   %local_45 = alloca i64, align 8
-  %local_46 = alloca i64, align 8
-  %local_47 = alloca i64, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  store i64 3, ptr %local_0, align 4
-  store i64 4, ptr %local_1, align 4
-  %call_arg = load i64, ptr %local_0, align 4
-  %call_arg1 = load i64, ptr %local_1, align 4
+  store i64 3, ptr %local_0, align 8
+  store i64 4, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_0, align 8
+  %call_arg1 = load i64, ptr %local_1, align 8
   %call_result = call %Point @make_point(i64 %call_arg, i64 %call_arg1)
-  store %Point %call_result, ptr %local_2, align 4
+  store %Point %call_result, ptr %local_2, align 8
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load %Point, ptr %local_2, align 4
-  store %Point %move_load, ptr %local_3, align 4
+  %move_load = load %Point, ptr %local_2, align 8
+  store %Point %move_load, ptr %local_3, align 8
   %field_0_load_ptr = getelementptr inbounds nuw %Point, ptr %local_3, i32 0, i32 0
-  %field_0_load = load i64, ptr %field_0_load_ptr, align 4
-  store i64 %field_0_load, ptr %local_4, align 4
+  %field_0_load = load i64, ptr %field_0_load_ptr, align 8
+  store i64 %field_0_load, ptr %local_4, align 8
   %field_1_load_ptr = getelementptr inbounds nuw %Point, ptr %local_3, i32 0, i32 1
-  %field_1_load = load i64, ptr %field_1_load_ptr, align 4
-  store i64 %field_1_load, ptr %local_5, align 4
-  %checked_lhs = load i64, ptr %local_4, align 4
-  %checked_rhs = load i64, ptr %local_5, align 4
+  %field_1_load = load i64, ptr %field_1_load_ptr, align 8
+  store i64 %field_1_load, ptr %local_5, align 8
+  %checked_lhs = load i64, ptr %local_4, align 8
+  %checked_rhs = load i64, ptr %local_5, align 8
   %with_overflow = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_6, align 4
+  store i64 %checked_result, ptr %local_6, align 8
   store i8 %checked_overflow_widen, ptr %local_7, align 1
   %cond_load = load i8, ptr %local_7, align 1
   %cond_nz = icmp ne i8 %cond_load, 0
@@ -501,50 +540,50 @@ bb2:                                              ; preds = %bb1
   unreachable
 
 bb3:                                              ; preds = %bb1
-  %print_arg = load i64, ptr %local_6, align 4
+  %print_arg = load i64, ptr %local_6, align 8
   call void @hew_print_value(i8 1, i64 %print_arg, i1 true)
   br label %bb4
 
 bb4:                                              ; preds = %bb3
   %hew_vec_new_with_layout_call = call ptr @hew_vec_new_with_layout(ptr @__hew_layout_new_16_8_plain)
-  store ptr %hew_vec_new_with_layout_call, ptr %local_8, align 8
+  store ptr %hew_vec_new_with_layout_call, ptr %local_8, align 4
   br label %bb5
 
 bb5:                                              ; preds = %bb4
-  %move_load2 = load ptr, ptr %local_8, align 8
-  store ptr %move_load2, ptr %local_9, align 8
-  store i64 10, ptr %local_10, align 4
-  store i64 20, ptr %local_11, align 4
+  %move_load2 = load ptr, ptr %local_8, align 4
+  store ptr %move_load2, ptr %local_9, align 4
+  store i64 10, ptr %local_10, align 8
+  store i64 20, ptr %local_11, align 8
   %field_0_init_ptr = getelementptr inbounds nuw %Point, ptr %local_12, i32 0, i32 0
-  %field_0_init_src = load i64, ptr %local_10, align 4
-  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 4
+  %field_0_init_src = load i64, ptr %local_10, align 8
+  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 8
   %field_1_init_ptr = getelementptr inbounds nuw %Point, ptr %local_12, i32 0, i32 1
-  %field_1_init_src = load i64, ptr %local_11, align 4
-  store i64 %field_1_init_src, ptr %field_1_init_ptr, align 4
-  %"hew_vec_push_layout arg0" = load ptr, ptr %local_9, align 8
+  %field_1_init_src = load i64, ptr %local_11, align 8
+  store i64 %field_1_init_src, ptr %field_1_init_ptr, align 8
+  %"hew_vec_push_layout arg0" = load ptr, ptr %local_9, align 4
   call void @hew_vec_push_layout(ptr %"hew_vec_push_layout arg0", ptr %local_12, ptr @__hew_layout_push_16_8_plain)
   br label %bb6
 
 bb6:                                              ; preds = %bb5
-  store i64 5, ptr %local_13, align 4
-  store i64 5, ptr %local_14, align 4
+  store i64 5, ptr %local_13, align 8
+  store i64 5, ptr %local_14, align 8
   %field_0_init_ptr3 = getelementptr inbounds nuw %Point, ptr %local_15, i32 0, i32 0
-  %field_0_init_src4 = load i64, ptr %local_13, align 4
-  store i64 %field_0_init_src4, ptr %field_0_init_ptr3, align 4
+  %field_0_init_src4 = load i64, ptr %local_13, align 8
+  store i64 %field_0_init_src4, ptr %field_0_init_ptr3, align 8
   %field_1_init_ptr5 = getelementptr inbounds nuw %Point, ptr %local_15, i32 0, i32 1
-  %field_1_init_src6 = load i64, ptr %local_14, align 4
-  store i64 %field_1_init_src6, ptr %field_1_init_ptr5, align 4
-  %"hew_vec_push_layout arg07" = load ptr, ptr %local_9, align 8
+  %field_1_init_src6 = load i64, ptr %local_14, align 8
+  store i64 %field_1_init_src6, ptr %field_1_init_ptr5, align 8
+  %"hew_vec_push_layout arg07" = load ptr, ptr %local_9, align 4
   call void @hew_vec_push_layout(ptr %"hew_vec_push_layout arg07", ptr %local_15, ptr @__hew_layout_push_16_8_plain)
   br label %bb7
 
 bb7:                                              ; preds = %bb6
-  store i64 0, ptr %local_16, align 4
-  %"hew_vec_len arg0" = load ptr, ptr %local_9, align 8
+  store i64 0, ptr %local_16, align 8
+  %"hew_vec_len arg0" = load ptr, ptr %local_9, align 4
   %hew_vec_len_call = call i64 @hew_vec_len(ptr %"hew_vec_len arg0")
-  store i64 %hew_vec_len_call, ptr %local_17, align 4
-  %cmp_lhs = load i64, ptr %local_16, align 4
-  %cmp_rhs = load i64, ptr %local_17, align 4
+  store i64 %hew_vec_len_call, ptr %local_17, align 8
+  %cmp_lhs = load i64, ptr %local_16, align 8
+  %cmp_rhs = load i64, ptr %local_17, align 8
   %cmp_bit = icmp uge i64 %cmp_lhs, %cmp_rhs
   %cmp_zext = zext i1 %cmp_bit to i8
   store i8 %cmp_zext, ptr %local_18, align 1
@@ -553,64 +592,66 @@ bb7:                                              ; preds = %bb6
   br i1 %cond_nz9, label %bb8, label %bb9
 
 bb8:                                              ; preds = %bb7
-  %"hew_vec_free drop" = load ptr, ptr %local_9, align 8
+  %"hew_vec_free drop" = load ptr, ptr %local_9, align 4
   call void @hew_vec_free(ptr %"hew_vec_free drop")
-  store ptr null, ptr %local_9, align 8
+  store ptr null, ptr %local_9, align 4
   call void @hew_trap_with_code(i32 205)
   call void @llvm.trap()
   unreachable
 
 bb9:                                              ; preds = %bb7
-  %"hew_vec_get_layout arg0" = load ptr, ptr %local_9, align 8
-  %"hew_vec_get_layout arg1" = load i64, ptr %local_16, align 4
+  %"hew_vec_get_layout arg0" = load ptr, ptr %local_9, align 4
+  %"hew_vec_get_layout arg1" = load i64, ptr %local_16, align 8
   %hew_vec_get_layout_call = call ptr @hew_vec_get_layout(ptr %"hew_vec_get_layout arg0", i64 %"hew_vec_get_layout arg1", ptr @__hew_layout_get_16_8_plain)
-  %hew_vec_get_layout_load = load %Point, ptr %hew_vec_get_layout_call, align 4
-  store %Point %hew_vec_get_layout_load, ptr %local_19, align 4
-  %move_load10 = load %Point, ptr %local_19, align 4
-  store %Point %move_load10, ptr %local_20, align 4
+  %hew_vec_get_layout_load = load %Point, ptr %hew_vec_get_layout_call, align 8
+  store %Point %hew_vec_get_layout_load, ptr %local_19, align 8
+  %move_load10 = load %Point, ptr %local_19, align 8
+  store %Point %move_load10, ptr %local_20, align 8
   %field_0_load_ptr11 = getelementptr inbounds nuw %Point, ptr %local_20, i32 0, i32 0
-  %field_0_load12 = load i64, ptr %field_0_load_ptr11, align 4
-  store i64 %field_0_load12, ptr %local_21, align 4
-  %print_arg13 = load i64, ptr %local_21, align 4
+  %field_0_load12 = load i64, ptr %field_0_load_ptr11, align 8
+  store i64 %field_0_load12, ptr %local_21, align 8
+  %print_arg13 = load i64, ptr %local_21, align 8
   call void @hew_print_value(i8 1, i64 %print_arg13, i1 true)
   br label %bb10
 
 bb10:                                             ; preds = %bb9
   %hew_hashmap_new_with_layout_call = call ptr @hew_hashmap_new_with_layout(ptr @hew_layout_key_string, ptr @__hew_map_value_layout_16_8_plain)
-  store ptr %hew_hashmap_new_with_layout_call, ptr %local_22, align 8
+  store ptr %hew_hashmap_new_with_layout_call, ptr %local_22, align 4
   br label %bb11
 
 bb11:                                             ; preds = %bb10
-  %move_load14 = load ptr, ptr %local_22, align 8
-  store ptr %move_load14, ptr %local_23, align 8
-  store ptr @str_lit, ptr %local_24, align 8
-  store i64 0, ptr %local_25, align 4
-  store i64 0, ptr %local_26, align 4
+  %move_load14 = load ptr, ptr %local_22, align 4
+  store ptr %move_load14, ptr %local_23, align 4
+  store ptr @str_lit, ptr %local_24, align 4
+  store i64 0, ptr %local_25, align 8
+  store i64 0, ptr %local_26, align 8
   %field_0_init_ptr15 = getelementptr inbounds nuw %Point, ptr %local_27, i32 0, i32 0
-  %field_0_init_src16 = load i64, ptr %local_25, align 4
-  store i64 %field_0_init_src16, ptr %field_0_init_ptr15, align 4
+  %field_0_init_src16 = load i64, ptr %local_25, align 8
+  store i64 %field_0_init_src16, ptr %field_0_init_ptr15, align 8
   %field_1_init_ptr17 = getelementptr inbounds nuw %Point, ptr %local_27, i32 0, i32 1
-  %field_1_init_src18 = load i64, ptr %local_26, align 4
-  store i64 %field_1_init_src18, ptr %field_1_init_ptr17, align 4
-  %"hew_hashmap_insert_layout arg0" = load ptr, ptr %local_23, align 8
+  %field_1_init_src18 = load i64, ptr %local_26, align 8
+  store i64 %field_1_init_src18, ptr %field_1_init_ptr17, align 8
+  %"hew_hashmap_insert_layout arg0" = load ptr, ptr %local_23, align 4
   %hew_hashmap_insert_layout_call = call i1 @hew_hashmap_insert_layout(ptr %"hew_hashmap_insert_layout arg0", ptr %local_24, ptr %local_27)
-  br label %bb12
+  %insert_existed = icmp eq i1 %hew_hashmap_insert_layout_call, false
+  br i1 %insert_existed, label %insert_overwrite_key_release, label %insert_overwrite_key_cont
 
-bb12:                                             ; preds = %bb11
-  store ptr @str_lit.1, ptr %local_29, align 8
-  %"hew_hashmap_get_layout arg0" = load ptr, ptr %local_23, align 8
-  %hew_hashmap_get_layout_call = call ptr @hew_hashmap_get_layout(ptr %"hew_hashmap_get_layout arg0", ptr %local_29)
-  %hashmap_get_is_some = icmp ne ptr %hew_hashmap_get_layout_call, null
-  br i1 %hashmap_get_is_some, label %hashmap_get_some, label %hashmap_get_none
+bb12:                                             ; preds = %insert_overwrite_key_cont
+  store ptr @str_lit.1, ptr %local_29, align 4
+  %"hew_hashmap_get_layout arg0" = load ptr, ptr %local_23, align 4
+  %machine_payload_ptr = getelementptr inbounds nuw %"Option$$Point", ptr %local_30, i32 0, i32 1
+  %machine_variant_field_ptr = getelementptr inbounds nuw { %Point }, ptr %machine_payload_ptr, i32 0, i32 0
+  %hew_hashmap_get_clone_layout_call = call i1 @hew_hashmap_get_clone_layout(ptr %"hew_hashmap_get_layout arg0", ptr %local_29, ptr %machine_variant_field_ptr)
+  br i1 %hew_hashmap_get_clone_layout_call, label %hashmap_get_some, label %hashmap_get_none
 
 bb13:                                             ; preds = %hashmap_get_some, %hashmap_get_none
   %machine_tag_ptr20 = getelementptr inbounds nuw %"Option$$Point", ptr %local_30, i32 0, i32 0
   %move_iN_load = load i8, ptr %machine_tag_ptr20, align 1
   %move_iN_zext = zext i8 %move_iN_load to i64
-  store i64 %move_iN_zext, ptr %local_31, align 4
-  store i64 0, ptr %local_32, align 4
-  %cmp_lhs21 = load i64, ptr %local_31, align 4
-  %cmp_rhs22 = load i64, ptr %local_32, align 4
+  store i64 %move_iN_zext, ptr %local_31, align 8
+  store i64 0, ptr %local_32, align 8
+  %cmp_lhs21 = load i64, ptr %local_31, align 8
+  %cmp_rhs22 = load i64, ptr %local_32, align 8
   %cmp_bit23 = icmp eq i64 %cmp_lhs21, %cmp_rhs22
   %cmp_zext24 = zext i1 %cmp_bit23 to i8
   store i8 %cmp_zext24, ptr %local_33, align 1
@@ -618,134 +659,110 @@ bb13:                                             ; preds = %hashmap_get_some, %
   %cond_nz26 = icmp ne i8 %cond_load25, 0
   br i1 %cond_nz26, label %bb15, label %bb18
 
-bb14:                                             ; preds = %after_cooperate69, %after_cooperate60
-  store i64 1, ptr %local_45, align 4
-  %machine_tag_ptr27 = getelementptr inbounds nuw %Color, ptr %local_44, i32 0, i32 0
-  %move_iN_load_wide = load i64, ptr %local_45, align 4
+bb14:                                             ; preds = %after_cooperate65, %after_cooperate59
+  store i64 1, ptr %local_43, align 8
+  %machine_tag_ptr27 = getelementptr inbounds nuw %Color, ptr %local_42, i32 0, i32 0
+  %move_iN_load_wide = load i64, ptr %local_43, align 8
   %move_iN_trunc = trunc i64 %move_iN_load_wide to i8
   store i8 %move_iN_trunc, ptr %machine_tag_ptr27, align 1
-  %call_arg28 = load %Color, ptr %local_44, align 1
+  %call_arg28 = load %Color, ptr %local_42, align 1
   %call_result29 = call i64 @color_code(%Color %call_arg28)
-  store i64 %call_result29, ptr %local_46, align 4
-  br label %bb25
+  store i64 %call_result29, ptr %local_44, align 8
+  br label %bb23
 
 bb15:                                             ; preds = %bb13
   %machine_payload_ptr30 = getelementptr inbounds nuw %"Option$$Point", ptr %local_30, i32 0, i32 1
   %machine_variant_field_ptr31 = getelementptr inbounds nuw { %Point }, ptr %machine_payload_ptr30, i32 0, i32 0
-  %move_load32 = load %Point, ptr %machine_variant_field_ptr31, align 4
-  store %Point %move_load32, ptr %local_36, align 4
+  %move_load32 = load %Point, ptr %machine_variant_field_ptr31, align 8
+  store %Point %move_load32, ptr %local_36, align 8
   %field_0_load_ptr33 = getelementptr inbounds nuw %Point, ptr %local_36, i32 0, i32 0
-  %field_0_load34 = load i64, ptr %field_0_load_ptr33, align 4
-  store i64 %field_0_load34, ptr %local_37, align 4
+  %field_0_load34 = load i64, ptr %field_0_load_ptr33, align 8
+  store i64 %field_0_load34, ptr %local_37, align 8
   %field_1_load_ptr35 = getelementptr inbounds nuw %Point, ptr %local_36, i32 0, i32 1
-  %field_1_load36 = load i64, ptr %field_1_load_ptr35, align 4
-  store i64 %field_1_load36, ptr %local_38, align 4
-  %checked_lhs37 = load i64, ptr %local_37, align 4
-  %checked_rhs38 = load i64, ptr %local_38, align 4
+  %field_1_load36 = load i64, ptr %field_1_load_ptr35, align 8
+  store i64 %field_1_load36, ptr %local_38, align 8
+  %checked_lhs37 = load i64, ptr %local_37, align 8
+  %checked_rhs38 = load i64, ptr %local_38, align 8
   %with_overflow39 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs37, i64 %checked_rhs38)
   %checked_result40 = extractvalue { i64, i1 } %with_overflow39, 0
   %checked_overflow41 = extractvalue { i64, i1 } %with_overflow39, 1
   %checked_overflow_widen42 = zext i1 %checked_overflow41 to i8
-  store i64 %checked_result40, ptr %local_39, align 4
+  store i64 %checked_result40, ptr %local_39, align 8
   store i8 %checked_overflow_widen42, ptr %local_40, align 1
   %cond_load43 = load i8, ptr %local_40, align 1
   %cond_nz44 = icmp ne i8 %cond_load43, 0
   br i1 %cond_nz44, label %bb19, label %bb20
 
 bb16:                                             ; preds = %bb18
-  store i64 1, ptr %local_41, align 4
-  %ineg_operand = load i64, ptr %local_41, align 4
-  %neg_with_overflow = call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 0, i64 %ineg_operand)
-  %neg_result = extractvalue { i64, i1 } %neg_with_overflow, 0
-  %neg_overflow = extractvalue { i64, i1 } %neg_with_overflow, 1
-  %neg_overflow_widen = zext i1 %neg_overflow to i8
-  store i64 %neg_result, ptr %local_42, align 4
-  store i8 %neg_overflow_widen, ptr %local_43, align 1
-  %cond_load45 = load i8, ptr %local_43, align 1
-  %cond_nz46 = icmp ne i8 %cond_load45, 0
-  br i1 %cond_nz46, label %bb22, label %bb23
+  store i64 -1, ptr %local_41, align 8
+  %print_arg45 = load i64, ptr %local_41, align 8
+  call void @hew_print_value(i8 1, i64 %print_arg45, i1 true)
+  br label %bb22
 
 bb17:                                             ; preds = %bb18
-  %"hew_hashmap_free_layout drop" = load ptr, ptr %local_23, align 8
+  %"hew_hashmap_free_layout drop" = load ptr, ptr %local_23, align 4
   call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop")
-  store ptr null, ptr %local_23, align 8
-  %"hew_vec_free drop47" = load ptr, ptr %local_9, align 8
-  call void @hew_vec_free(ptr %"hew_vec_free drop47")
-  store ptr null, ptr %local_9, align 8
+  store ptr null, ptr %local_23, align 4
+  %"hew_vec_free drop46" = load ptr, ptr %local_9, align 4
+  call void @hew_vec_free(ptr %"hew_vec_free drop46")
+  store ptr null, ptr %local_9, align 4
   call void @hew_trap_with_code(i32 208)
   call void @llvm.trap()
   unreachable
 
 bb18:                                             ; preds = %bb13
-  store i64 1, ptr %local_34, align 4
-  %cmp_lhs48 = load i64, ptr %local_31, align 4
-  %cmp_rhs49 = load i64, ptr %local_34, align 4
-  %cmp_bit50 = icmp eq i64 %cmp_lhs48, %cmp_rhs49
-  %cmp_zext51 = zext i1 %cmp_bit50 to i8
-  store i8 %cmp_zext51, ptr %local_35, align 1
-  %cond_load52 = load i8, ptr %local_35, align 1
-  %cond_nz53 = icmp ne i8 %cond_load52, 0
-  br i1 %cond_nz53, label %bb16, label %bb17
+  store i64 1, ptr %local_34, align 8
+  %cmp_lhs47 = load i64, ptr %local_31, align 8
+  %cmp_rhs48 = load i64, ptr %local_34, align 8
+  %cmp_bit49 = icmp eq i64 %cmp_lhs47, %cmp_rhs48
+  %cmp_zext50 = zext i1 %cmp_bit49 to i8
+  store i8 %cmp_zext50, ptr %local_35, align 1
+  %cond_load51 = load i8, ptr %local_35, align 1
+  %cond_nz52 = icmp ne i8 %cond_load51, 0
+  br i1 %cond_nz52, label %bb16, label %bb17
 
 bb19:                                             ; preds = %bb15
-  %"hew_hashmap_free_layout drop54" = load ptr, ptr %local_23, align 8
-  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop54")
-  store ptr null, ptr %local_23, align 8
-  %"hew_vec_free drop55" = load ptr, ptr %local_9, align 8
-  call void @hew_vec_free(ptr %"hew_vec_free drop55")
-  store ptr null, ptr %local_9, align 8
+  %"hew_hashmap_free_layout drop53" = load ptr, ptr %local_23, align 4
+  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop53")
+  store ptr null, ptr %local_23, align 4
+  %"hew_vec_free drop54" = load ptr, ptr %local_9, align 4
+  call void @hew_vec_free(ptr %"hew_vec_free drop54")
+  store ptr null, ptr %local_9, align 4
   call void @hew_trap_with_code(i32 201)
   call void @llvm.trap()
   unreachable
 
 bb20:                                             ; preds = %bb15
-  %print_arg56 = load i64, ptr %local_39, align 4
-  call void @hew_print_value(i8 1, i64 %print_arg56, i1 true)
+  %print_arg55 = load i64, ptr %local_39, align 8
+  call void @hew_print_value(i8 1, i64 %print_arg55, i1 true)
   br label %bb21
 
 bb21:                                             ; preds = %bb20
-  %hew_actor_cooperate57 = call i32 @hew_actor_cooperate()
-  %hew_cooperate_is_cancel58 = icmp eq i32 %hew_actor_cooperate57, 2
-  br i1 %hew_cooperate_is_cancel58, label %cancel_exit59, label %after_cooperate60
+  %hew_actor_cooperate56 = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel57 = icmp eq i32 %hew_actor_cooperate56, 2
+  br i1 %hew_cooperate_is_cancel57, label %cancel_exit58, label %after_cooperate59
 
 bb22:                                             ; preds = %bb16
-  %"hew_hashmap_free_layout drop63" = load ptr, ptr %local_23, align 8
-  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop63")
-  store ptr null, ptr %local_23, align 8
-  %"hew_vec_free drop64" = load ptr, ptr %local_9, align 8
-  call void @hew_vec_free(ptr %"hew_vec_free drop64")
-  store ptr null, ptr %local_9, align 8
-  call void @hew_trap_with_code(i32 201)
-  call void @llvm.trap()
-  unreachable
+  %hew_actor_cooperate62 = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel63 = icmp eq i32 %hew_actor_cooperate62, 2
+  br i1 %hew_cooperate_is_cancel63, label %cancel_exit64, label %after_cooperate65
 
-bb23:                                             ; preds = %bb16
-  %print_arg65 = load i64, ptr %local_42, align 4
-  call void @hew_print_value(i8 1, i64 %print_arg65, i1 true)
+bb23:                                             ; preds = %bb14
+  %print_arg68 = load i64, ptr %local_44, align 8
+  call void @hew_print_value(i8 1, i64 %print_arg68, i1 true)
   br label %bb24
 
 bb24:                                             ; preds = %bb23
-  %hew_actor_cooperate66 = call i32 @hew_actor_cooperate()
-  %hew_cooperate_is_cancel67 = icmp eq i32 %hew_actor_cooperate66, 2
-  br i1 %hew_cooperate_is_cancel67, label %cancel_exit68, label %after_cooperate69
-
-bb25:                                             ; preds = %bb14
-  %print_arg72 = load i64, ptr %local_46, align 4
-  call void @hew_print_value(i8 1, i64 %print_arg72, i1 true)
-  br label %bb26
-
-bb26:                                             ; preds = %bb25
-  store i64 0, ptr %local_47, align 4
-  %move_load73 = load i64, ptr %local_47, align 4
-  store i64 %move_load73, ptr %return_slot, align 4
-  %"hew_hashmap_free_layout drop74" = load ptr, ptr %local_23, align 8
-  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop74")
-  store ptr null, ptr %local_23, align 8
-  %"hew_vec_free drop75" = load ptr, ptr %local_9, align 8
-  call void @hew_vec_free(ptr %"hew_vec_free drop75")
-  store ptr null, ptr %local_9, align 8
-  %hew_lambda_drain_all_call = call i32 @hew_lambda_drain_all(i64 0)
-  %ret_val = load i64, ptr %return_slot, align 4
+  store i64 0, ptr %local_45, align 8
+  %move_load69 = load i64, ptr %local_45, align 8
+  store i64 %move_load69, ptr %return_slot, align 8
+  %"hew_hashmap_free_layout drop70" = load ptr, ptr %local_23, align 4
+  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop70")
+  store ptr null, ptr %local_23, align 4
+  %"hew_vec_free drop71" = load ptr, ptr %local_9, align 4
+  call void @hew_vec_free(ptr %"hew_vec_free drop71")
+  store ptr null, ptr %local_9, align 4
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -753,6 +770,14 @@ cancel_exit:                                      ; preds = %entry
 
 after_cooperate:                                  ; preds = %entry
   br label %bb0
+
+insert_overwrite_key_release:                     ; preds = %bb11
+  %"hew_hashmap_insert_layout overwrite key" = load ptr, ptr %local_24, align 4
+  call void @hew_string_drop(ptr %"hew_hashmap_insert_layout overwrite key")
+  br label %insert_overwrite_key_cont
+
+insert_overwrite_key_cont:                        ; preds = %insert_overwrite_key_release, %bb11
+  br label %bb12
 
 hashmap_get_none:                                 ; preds = %bb12
   %machine_tag_ptr = getelementptr inbounds nuw %"Option$$Point", ptr %local_30, i32 0, i32 0
@@ -762,41 +787,104 @@ hashmap_get_none:                                 ; preds = %bb12
 hashmap_get_some:                                 ; preds = %bb12
   %machine_tag_ptr19 = getelementptr inbounds nuw %"Option$$Point", ptr %local_30, i32 0, i32 0
   store i8 0, ptr %machine_tag_ptr19, align 1
-  %machine_payload_ptr = getelementptr inbounds nuw %"Option$$Point", ptr %local_30, i32 0, i32 1
-  %machine_variant_field_ptr = getelementptr inbounds nuw { %Point }, ptr %machine_payload_ptr, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %machine_variant_field_ptr, ptr align 8 %hew_hashmap_get_layout_call, i64 16, i1 false)
   br label %bb13
 
-cancel_exit59:                                    ; preds = %bb21
-  %"hew_hashmap_free_layout drop61" = load ptr, ptr %local_23, align 8
-  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop61")
-  store ptr null, ptr %local_23, align 8
-  %"hew_vec_free drop62" = load ptr, ptr %local_9, align 8
-  call void @hew_vec_free(ptr %"hew_vec_free drop62")
-  store ptr null, ptr %local_9, align 8
+cancel_exit58:                                    ; preds = %bb21
+  %"hew_hashmap_free_layout drop60" = load ptr, ptr %local_23, align 4
+  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop60")
+  store ptr null, ptr %local_23, align 4
+  %"hew_vec_free drop61" = load ptr, ptr %local_9, align 4
+  call void @hew_vec_free(ptr %"hew_vec_free drop61")
+  store ptr null, ptr %local_9, align 4
   ret i64 0
 
-after_cooperate60:                                ; preds = %bb21
+after_cooperate59:                                ; preds = %bb21
   br label %bb14
 
-cancel_exit68:                                    ; preds = %bb24
-  %"hew_hashmap_free_layout drop70" = load ptr, ptr %local_23, align 8
-  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop70")
-  store ptr null, ptr %local_23, align 8
-  %"hew_vec_free drop71" = load ptr, ptr %local_9, align 8
-  call void @hew_vec_free(ptr %"hew_vec_free drop71")
-  store ptr null, ptr %local_9, align 8
+cancel_exit64:                                    ; preds = %bb22
+  %"hew_hashmap_free_layout drop66" = load ptr, ptr %local_23, align 4
+  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop66")
+  store ptr null, ptr %local_23, align 4
+  %"hew_vec_free drop67" = load ptr, ptr %local_9, align 4
+  call void @hew_vec_free(ptr %"hew_vec_free drop67")
+  store ptr null, ptr %local_9, align 4
   ret i64 0
 
-after_cooperate69:                                ; preds = %bb24
+after_cooperate65:                                ; preds = %bb22
   br label %bb14
+}
+
+define internal ptr @"i8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 4
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i8, ptr %local_0, align 1
+  %cast_int_sext = sext i8 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"i16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 4
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i16, ptr %local_0, align 2
+  %cast_int_sext = sext i16 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
 }
 
 define internal ptr @"i32::fmt"(i32 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i32, align 4
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i32 %0, ptr %local_0, align 4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -805,13 +893,13 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
   %call_result = call ptr @hew_int_to_string(i32 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -823,24 +911,83 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"i64::fmt"(i64 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i64, align 8
-  %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  %local_1 = alloca ptr, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 4
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i8, ptr %local_0, align 1
+  %call_result = call ptr @hew_u8_to_string(i8 %call_arg)
+  store ptr %call_result, ptr %local_1, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca ptr, align 4
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i16, ptr %local_0, align 2
+  %ffi_zext = zext i16 %call_arg to i32
+  %call_result = call ptr @hew_uint_to_string(i32 %ffi_zext)
+  store ptr %call_result, ptr %local_1, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -852,9 +999,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"u32::fmt"(i32 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i32, align 4
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i32 %0, ptr %local_0, align 4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -862,15 +1009,14 @@ entry:
 
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
-  %ffi_arg_trunc = trunc i32 %call_arg to i16
-  %call_result = call ptr @hew_uint_to_string(i16 %ffi_arg_trunc)
-  store ptr %call_result, ptr %local_1, align 8
+  %call_result = call ptr @hew_uint_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -882,24 +1028,90 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"u64::fmt"(i64 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i64, align 8
-  %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  %local_1 = alloca ptr, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"isize::fmt"(i32 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 4
+  store i32 %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i32, ptr %local_0, align 4
+  %cast_int_sext = sext i32 %cast_int_src to i64
+  store i64 %cast_int_sext, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"usize::fmt"(i32 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 4
+  store i32 %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i32, ptr %local_0, align 4
+  %cast_int_zext = zext i32 %cast_int_src to i64
+  store i64 %cast_int_zext, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -911,9 +1123,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"bool::fmt"(i8 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i8, align 1
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i8 %0, ptr %local_0, align 1
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -922,13 +1134,13 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i8, ptr %local_0, align 1
   %call_result = call ptr @hew_bool_to_string(i8 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -940,9 +1152,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"char::fmt"(i32 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i32, align 4
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i32 %0, ptr %local_0, align 4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -951,13 +1163,13 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
   %call_result = call ptr @hew_char_to_string(i32 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -969,9 +1181,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"f64::fmt"(double %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca double, align 8
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store double %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -980,13 +1192,46 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load double, ptr %local_0, align 8
   %call_result = call ptr @hew_float_to_string(double %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"f32::fmt"(float %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca float, align 4
+  %local_1 = alloca double, align 8
+  %local_2 = alloca ptr, align 4
+  store float %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_float_src = load float, ptr %local_0, align 4
+  %cast_float_ext = fpext float %cast_float_src to double
+  store double %cast_float_ext, ptr %local_1, align 8
+  %call_arg = load double, ptr %local_1, align 8
+  %call_result = call ptr @hew_float_to_string(double %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -998,16 +1243,211 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"string::fmt"(ptr %0) {
 entry:
-  %return_slot = alloca ptr, align 8
-  %local_0 = alloca ptr, align 8
-  store ptr %0, ptr %local_0, align 8
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca ptr, align 4
+  store ptr %0, ptr %local_0, align 4
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  %move_load = load ptr, ptr %local_0, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %mir_share_string_load = load ptr, ptr %local_0, align 4
+  %mir_share_string_retain = call ptr @hew_string_clone(ptr %mir_share_string_load)
+  %move_load = load ptr, ptr %local_0, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
+}
+
+define internal i64 @"duration::from_nanos"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_micros"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_millis"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_secs"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal ptr @"duration::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 4
+  %local_3 = alloca ptr, align 4
+  %local_4 = alloca ptr, align 4
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %hew_duration_nanos = load i64, ptr %local_0, align 8
+  %hew_duration_nanos_call = call i64 @hew_duration_nanos(i64 %hew_duration_nanos)
+  store i64 %hew_duration_nanos_call, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  store ptr @str_lit.2, ptr %local_3, align 4
+  %"hew_string_concat arg0" = load ptr, ptr %local_2, align 4
+  %"hew_string_concat arg1" = load ptr, ptr %local_3, align 4
+  %hew_string_concat_call = call ptr @hew_string_concat(ptr %"hew_string_concat arg0", ptr %"hew_string_concat arg1")
+  store ptr %hew_string_concat_call, ptr %local_4, align 4
+  %"hew_string_drop drop" = load ptr, ptr %local_2, align 4
+  call void @hew_string_drop(ptr %"hew_string_drop drop")
+  store ptr null, ptr %local_2, align 4
+  %move_load = load ptr, ptr %local_4, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define i64 @main() {
+entry:
+  %__original_main_call = call i64 @__original_main()
+  ret i64 %__original_main_call
 }
 
 define internal i32 @__hew_record_clone_inplace_Point(ptr %0, ptr %1) {
@@ -1034,9 +1474,74 @@ done:                                             ; preds = %do_drop, %entry
   ret void
 }
 
+define internal i32 @__hew_record_clone_inplace_CrashInfo(ptr %0, ptr %1) {
+entry:
+  br label %step_0_clone
+
+success:                                          ; preds = %step_0_store
+  ret i32 0
+
+fail:                                             ; preds = %rb_step_0
+  ret i32 1
+
+rb_step_0:                                        ; preds = %step_0_clone
+  br label %fail
+
+step_0_store:                                     ; preds = %step_0_clone
+  %dst_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  store ptr %clone_helper_f1, ptr %dst_f1_ptr, align 4
+  br label %success
+
+step_0_clone:                                     ; preds = %entry
+  %src_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %src_f1 = load ptr, ptr %src_f1_ptr, align 4
+  %clone_helper_f1 = call ptr @hew_string_clone(ptr %src_f1)
+  %cloned_f1_int = ptrtoint ptr %clone_helper_f1 to i64
+  %cloned_f1_null = icmp eq i64 %cloned_f1_int, 0
+  br i1 %cloned_f1_null, label %rb_step_0, label %step_0_store
+}
+
+define internal void @__hew_record_drop_inplace_CrashInfo(ptr %0) {
+entry:
+  %rec_int = ptrtoint ptr %0 to i64
+  %rec_is_null = icmp eq i64 %rec_int, 0
+  br i1 %rec_is_null, label %done, label %do_drop
+
+do_drop:                                          ; preds = %entry
+  %drop_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %drop_f1 = load ptr, ptr %drop_f1_ptr, align 4
+  call void @hew_string_drop(ptr %drop_f1)
+  br label %done
+
+done:                                             ; preds = %do_drop, %entry
+  ret void
+}
+
+declare void @hew_string_drop(ptr)
+
 define internal void @__hew_record_overwrite_release_Point(ptr %0, ptr %1) {
 entry:
   call void @__hew_record_drop_inplace_Point(ptr %0)
+  ret void
+}
+
+define internal void @__hew_record_overwrite_release_CrashInfo(ptr %0, ptr %1) {
+entry:
+  %ow_slot_0 = alloca ptr, align 4
+  store ptr null, ptr %ow_slot_0, align 4
+  %ow_new_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  %ow_new_d0_f1_leaf = load ptr, ptr %ow_new_d0_f1_ptr, align 4
+  store ptr %ow_new_d0_f1_leaf, ptr %ow_slot_0, align 4
+  %ow_old_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %ow_old_d0_f1_val = load ptr, ptr %ow_old_d0_f1_ptr, align 4
+  %ow_old_d0_f1_int = ptrtoint ptr %ow_old_d0_f1_val to i64
+  %ow_old_d0_f1_cmp0_leaf = load ptr, ptr %ow_slot_0, align 4
+  %ow_old_d0_f1_cmp0_int = ptrtoint ptr %ow_old_d0_f1_cmp0_leaf to i64
+  %ow_old_d0_f1_cmp0_eq = icmp eq i64 %ow_old_d0_f1_int, %ow_old_d0_f1_cmp0_int
+  %ow_old_d0_f1_matched0 = or i1 false, %ow_old_d0_f1_cmp0_eq
+  %ow_old_d0_f1_neutralized = select i1 %ow_old_d0_f1_matched0, ptr null, ptr %ow_old_d0_f1_val
+  store ptr %ow_old_d0_f1_neutralized, ptr %ow_old_d0_f1_ptr, align 4
+  call void @__hew_record_drop_inplace_CrashInfo(ptr %0)
   ret void
 }
 
@@ -1062,18 +1567,12 @@ declare ptr @hew_hashmap_new_with_layout(ptr, ptr)
 
 declare i1 @hew_hashmap_insert_layout(ptr, ptr, ptr)
 
-declare ptr @hew_hashmap_get_layout(ptr, ptr)
-
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #2
-
-; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
-declare { i64, i1 } @llvm.ssub.with.overflow.i64(i64, i64) #1
+declare i1 @hew_hashmap_get_clone_layout(ptr, ptr, ptr)
 
 declare void @hew_hashmap_free_layout(ptr)
 
-declare i32 @hew_lambda_drain_all(i64)
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
+declare { i64, i1 } @llvm.smul.with.overflow.i64(i64, i64) #1
 
 attributes #0 = { cold noreturn nounwind memory(inaccessiblemem: write) }
 attributes #1 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }

--- a/tests/ll-oracle/corpus/golden/wasm32/r4_runtime_abi.ll
+++ b/tests/ll-oracle/corpus/golden/wasm32/r4_runtime_abi.ll
@@ -123,19 +123,13 @@ declare ptr @hew_string_split(ptr, ptr)
 
 declare ptr @hew_string_lines(ptr)
 
-declare i32 @hew_string_find(ptr, ptr)
-
 declare ptr @hew_string_slice(ptr, i64, i64)
 
 declare ptr @hew_string_repeat(ptr, i64)
 
-declare i32 @hew_string_char_at(ptr, i32)
-
 declare ptr @hew_string_chars(ptr)
 
 declare i32 @hew_string_char_count(ptr)
-
-declare i32 @hew_string_char_at_utf8(ptr, i32)
 
 declare void @hew_vec_push_bool(ptr, i1)
 
@@ -300,6 +294,22 @@ declare i32 @hew_node_api_register_by_pid(ptr, i64)
 declare i64 @hew_remote_pid_from_raw(i64, i64)
 
 declare i64 @hew_node_api_lookup(ptr)
+
+declare ptr @hew_stream_channel(i64)
+
+declare ptr @hew_stream_pair_sink(ptr)
+
+declare ptr @hew_stream_pair_stream(ptr)
+
+declare void @hew_stream_pair_free(ptr)
+
+declare void @hew_sink_close(ptr)
+
+declare i32 @hew_sink_peer_closed(ptr)
+
+declare void @hew_actor_gen_sink_register(ptr, ptr)
+
+declare void @hew_actor_gen_sink_complete(ptr, ptr)
 
 define i8 @__original_main() {
 entry:
@@ -747,14 +757,20 @@ bb45:                                             ; preds = %bb44
   %"hew_string_drop drop" = load ptr, ptr %local_61, align 4
   call void @hew_string_drop(ptr %"hew_string_drop drop")
   store ptr null, ptr %local_61, align 4
+  %"hew_string_drop drop132" = load ptr, ptr %local_59, align 4
+  call void @hew_string_drop(ptr %"hew_string_drop drop132")
+  store ptr null, ptr %local_59, align 4
+  %"hew_string_drop drop133" = load ptr, ptr %local_57, align 4
+  call void @hew_string_drop(ptr %"hew_string_drop drop133")
+  store ptr null, ptr %local_57, align 4
   %"hew_hashset_free_layout drop" = load ptr, ptr %local_48, align 4
   call void @hew_hashset_free_layout(ptr %"hew_hashset_free_layout drop")
   store ptr null, ptr %local_48, align 4
-  %"hew_hashmap_free_layout drop132" = load ptr, ptr %local_20, align 4
-  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop132")
+  %"hew_hashmap_free_layout drop134" = load ptr, ptr %local_20, align 4
+  call void @hew_hashmap_free_layout(ptr %"hew_hashmap_free_layout drop134")
   store ptr null, ptr %local_20, align 4
-  %"hew_vec_free drop133" = load ptr, ptr %local_1, align 4
-  call void @hew_vec_free(ptr %"hew_vec_free drop133")
+  %"hew_vec_free drop135" = load ptr, ptr %local_1, align 4
+  call void @hew_vec_free(ptr %"hew_vec_free drop135")
   store ptr null, ptr %local_1, align 4
   ret i8 0
 
@@ -1118,20 +1134,21 @@ after_cooperate:                                  ; preds = %entry
   br label %bb0
 }
 
-define internal ptr @"isize::fmt"(i64 %0) {
+define internal ptr @"isize::fmt"(i32 %0) {
 entry:
   %return_slot = alloca ptr, align 4
-  %local_0 = alloca i64, align 8
+  %local_0 = alloca i32, align 4
   %local_1 = alloca i64, align 8
   %local_2 = alloca ptr, align 4
-  store i64 %0, ptr %local_0, align 8
+  store i32 %0, ptr %local_0, align 4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %cast_int_src = load i64, ptr %local_0, align 8
-  store i64 %cast_int_src, ptr %local_1, align 8
+  %cast_int_src = load i32, ptr %local_0, align 4
+  %cast_int_sext = sext i32 %cast_int_src to i64
+  store i64 %cast_int_sext, ptr %local_1, align 8
   %call_arg = load i64, ptr %local_1, align 8
   %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
   store ptr %call_result, ptr %local_2, align 4
@@ -1150,20 +1167,21 @@ after_cooperate:                                  ; preds = %entry
   br label %bb0
 }
 
-define internal ptr @"usize::fmt"(i64 %0) {
+define internal ptr @"usize::fmt"(i32 %0) {
 entry:
   %return_slot = alloca ptr, align 4
-  %local_0 = alloca i64, align 8
+  %local_0 = alloca i32, align 4
   %local_1 = alloca i64, align 8
   %local_2 = alloca ptr, align 4
-  store i64 %0, ptr %local_0, align 8
+  store i32 %0, ptr %local_0, align 4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %cast_int_src = load i64, ptr %local_0, align 8
-  store i64 %cast_int_src, ptr %local_1, align 8
+  %cast_int_src = load i32, ptr %local_0, align 4
+  %cast_int_zext = zext i32 %cast_int_src to i64
+  store i64 %cast_int_zext, ptr %local_1, align 8
   %call_arg = load i64, ptr %local_1, align 8
   %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
   store ptr %call_result, ptr %local_2, align 4
@@ -1310,6 +1328,8 @@ entry:
   br label %bb0
 
 bb0:                                              ; preds = %entry
+  %mir_share_string_load = load ptr, ptr %local_0, align 4
+  %mir_share_string_retain = call ptr @hew_string_clone(ptr %mir_share_string_load)
   %move_load = load ptr, ptr %local_0, align 4
   store ptr %move_load, ptr %return_slot, align 4
   %ret_val = load ptr, ptr %return_slot, align 4
@@ -1488,6 +1508,9 @@ bb1:                                              ; preds = %bb0
   %"hew_string_concat arg1" = load ptr, ptr %local_3, align 4
   %hew_string_concat_call = call ptr @hew_string_concat(ptr %"hew_string_concat arg0", ptr %"hew_string_concat arg1")
   store ptr %hew_string_concat_call, ptr %local_4, align 4
+  %"hew_string_drop drop" = load ptr, ptr %local_2, align 4
+  call void @hew_string_drop(ptr %"hew_string_drop drop")
+  store ptr null, ptr %local_2, align 4
   %move_load = load ptr, ptr %local_4, align 4
   store ptr %move_load, ptr %return_slot, align 4
   %ret_val = load ptr, ptr %return_slot, align 4

--- a/tests/ll-oracle/corpus/golden/wasm32/r4_suspend.ll
+++ b/tests/ll-oracle/corpus/golden/wasm32/r4_suspend.ll
@@ -1,9 +1,12 @@
 ; ModuleID = 'r4_suspend'
 source_filename = "r4_suspend"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20"
+target triple = "wasm32-unknown-unknown"
 
 %Adder = type { i64 }
 %"Result$$i64$AskError" = type { i8, [1 x i64] }
 %AskError = type { i8, [1 x i8] }
+%CrashInfo = type { i64, ptr }
 
 @str_actor_meta_name_Adder = private unnamed_addr constant [6 x i8] c"Adder\00", align 1
 @str_actor_meta_handler_Adder_0_set_base = private unnamed_addr constant [9 x i8] c"set_base\00", align 1
@@ -11,8 +14,12 @@ source_filename = "r4_suspend"
 @str_actor_type_name_Adder = private unnamed_addr constant [6 x i8] c"Adder\00", align 1
 @str_actor_handler_name_Adder_0_set_base = private unnamed_addr constant [16 x i8] c"Adder::set_base\00", align 1
 @str_actor_handler_name_Adder_1_add = private unnamed_addr constant [11 x i8] c"Adder::add\00", align 1
-@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @hew_module_init_xnode_codecs, ptr null }]
+@str_lit = private unnamed_addr constant [3 x i8] c"ns\00", align 1
+@llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @hew_module_init_actor_codecs, ptr null }]
 
+declare void @hew_sleep_ns(i64)
+
+declare void @hew_sleep_until_ns(i64)
 
 declare void @hew_exit(i64)
 
@@ -28,7 +35,7 @@ declare ptr @hew_i64_to_string(i64)
 
 declare ptr @hew_u8_to_string(i8)
 
-declare ptr @hew_uint_to_string(i16)
+declare ptr @hew_uint_to_string(i32)
 
 declare ptr @hew_u64_to_string(i64)
 
@@ -116,21 +123,13 @@ declare ptr @hew_string_split(ptr, ptr)
 
 declare ptr @hew_string_lines(ptr)
 
-declare i32 @hew_string_find(ptr, ptr)
-
-declare i32 @hew_string_index_of_start(ptr, ptr)
-
 declare ptr @hew_string_slice(ptr, i64, i64)
 
 declare ptr @hew_string_repeat(ptr, i64)
 
-declare i32 @hew_string_char_at(ptr, i32)
-
 declare ptr @hew_string_chars(ptr)
 
 declare i32 @hew_string_char_count(ptr)
-
-declare i32 @hew_string_char_at_utf8(ptr, i32)
 
 declare void @hew_vec_push_bool(ptr, i1)
 
@@ -236,7 +235,27 @@ declare ptr @hew_bytes_to_string(ptr)
 
 declare void @hew_vec_append(ptr, ptr)
 
-declare void @hew_vec_remove_at(ptr, i64)
+declare i1 @hew_vec_remove_at_bool(ptr, i64)
+
+declare i8 @hew_vec_remove_at_i8(ptr, i64)
+
+declare i8 @hew_vec_remove_at_u8(ptr, i64)
+
+declare i16 @hew_vec_remove_at_i16(ptr, i64)
+
+declare i16 @hew_vec_remove_at_u16(ptr, i64)
+
+declare i32 @hew_vec_remove_at_i32(ptr, i64)
+
+declare i64 @hew_vec_remove_at_i64(ptr, i64)
+
+declare float @hew_vec_remove_at_f32(ptr, i64)
+
+declare double @hew_vec_remove_at_f64(ptr, i64)
+
+declare ptr @hew_vec_remove_at_str(ptr, i64)
+
+declare ptr @hew_vec_remove_at_ptr(ptr, i64)
 
 declare ptr @hew_vec_clone(ptr)
 
@@ -262,6 +281,12 @@ declare void @hew_node_api_connect(ptr)
 
 declare void @hew_node_api_shutdown()
 
+declare void @hew_node_api_load_keys(ptr)
+
+declare void @hew_node_api_allow_peer(i16, ptr)
+
+declare ptr @hew_node_api_identity_key()
+
 declare i64 @hew_actor_pid(ptr)
 
 declare i32 @hew_node_api_register_by_pid(ptr, i64)
@@ -270,21 +295,37 @@ declare i64 @hew_remote_pid_from_raw(i64, i64)
 
 declare i64 @hew_node_api_lookup(ptr)
 
+declare ptr @hew_stream_channel(i64)
+
+declare ptr @hew_stream_pair_sink(ptr)
+
+declare ptr @hew_stream_pair_stream(ptr)
+
+declare void @hew_stream_pair_free(ptr)
+
+declare void @hew_sink_close(ptr)
+
+declare i32 @hew_sink_peer_closed(ptr)
+
+declare void @hew_actor_gen_sink_register(ptr, ptr)
+
+declare void @hew_actor_gen_sink_complete(ptr, ptr)
+
 define internal i8 @Adder__recv__set_base(ptr %0, i64 %1, i32 %2) {
 entry:
   %return_slot = alloca i8, align 1
   %local_0 = alloca i64, align 8
-  store i64 %1, ptr %local_0, align 4
+  store i64 %1, ptr %local_0, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
   %ctx_actor_ptr_slot = getelementptr i8, ptr %0, i64 0
-  %ctx_actor_ptr = load ptr, ptr %ctx_actor_ptr_slot, align 8
+  %ctx_actor_ptr = load ptr, ptr %ctx_actor_ptr_slot, align 4
   %actor_state_slot = getelementptr i8, ptr %ctx_actor_ptr, i64 16
-  %actor_state_ptr = load ptr, ptr %actor_state_slot, align 8
+  %actor_state_ptr = load ptr, ptr %actor_state_slot, align 4
   %actor_state_field_0_ptr = getelementptr inbounds nuw %Adder, ptr %actor_state_ptr, i32 0, i32 0
-  %actor_state_field_0_src = load i64, ptr %local_0, align 4
-  store i64 %actor_state_field_0_src, ptr %actor_state_field_0_ptr, align 4
+  %actor_state_field_0_src = load i64, ptr %local_0, align 8
+  store i64 %actor_state_field_0_src, ptr %actor_state_field_0_ptr, align 8
   ret i8 0
 }
 
@@ -295,24 +336,24 @@ entry:
   %local_1 = alloca i64, align 8
   %local_2 = alloca i64, align 8
   %local_3 = alloca i8, align 1
-  store i64 %1, ptr %local_0, align 4
+  store i64 %1, ptr %local_0, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
   %ctx_actor_ptr_slot = getelementptr i8, ptr %0, i64 0
-  %ctx_actor_ptr = load ptr, ptr %ctx_actor_ptr_slot, align 8
+  %ctx_actor_ptr = load ptr, ptr %ctx_actor_ptr_slot, align 4
   %actor_state_slot = getelementptr i8, ptr %ctx_actor_ptr, i64 16
-  %actor_state_ptr = load ptr, ptr %actor_state_slot, align 8
+  %actor_state_ptr = load ptr, ptr %actor_state_slot, align 4
   %actor_state_field_0_ptr = getelementptr inbounds nuw %Adder, ptr %actor_state_ptr, i32 0, i32 0
-  %actor_state_field_0 = load i64, ptr %actor_state_field_0_ptr, align 4
-  store i64 %actor_state_field_0, ptr %local_1, align 4
-  %checked_lhs = load i64, ptr %local_1, align 4
-  %checked_rhs = load i64, ptr %local_0, align 4
+  %actor_state_field_0 = load i64, ptr %actor_state_field_0_ptr, align 8
+  store i64 %actor_state_field_0, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_1, align 8
+  %checked_rhs = load i64, ptr %local_0, align 8
   %with_overflow = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_2, align 4
+  store i64 %checked_result, ptr %local_2, align 8
   store i8 %checked_overflow_widen, ptr %local_3, align 1
   %cond_load = load i8, ptr %local_3, align 1
   %cond_nz = icmp ne i8 %cond_load, 0
@@ -324,18 +365,18 @@ bb1:                                              ; preds = %bb0
   unreachable
 
 bb2:                                              ; preds = %bb0
-  %move_load = load i64, ptr %local_2, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
-define i8 @main() {
+define i8 @__original_main() {
 entry:
   %return_slot = alloca i8, align 1
   %local_0 = alloca %Adder, align 8
   %local_1 = alloca i64, align 8
-  %local_2 = alloca ptr, align 8
+  %local_2 = alloca ptr, align 4
   %local_3 = alloca i64, align 8
   %local_4 = alloca i64, align 8
   %local_5 = alloca %"Result$$i64$AskError", align 8
@@ -350,85 +391,82 @@ entry:
   %local_14 = alloca i8, align 1
   %local_15 = alloca i64, align 8
   %local_16 = alloca i64, align 8
-  %local_17 = alloca i64, align 8
-  %local_18 = alloca i8, align 1
-  %hew_sched_init_entry_call = call i32 @hew_sched_init()
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  store i64 10, ptr %local_1, align 4
+  store i64 10, ptr %local_1, align 8
   %field_0_init_ptr = getelementptr inbounds nuw %Adder, ptr %local_0, i32 0, i32 0
-  %field_0_init_src = load i64, ptr %local_1, align 4
-  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 4
+  %field_0_init_src = load i64, ptr %local_1, align 8
+  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 8
   %hew_sched_init_call = call i32 @hew_sched_init()
   %actor_meta_handlers_Adder = alloca [2 x { ptr, i32, i32, ptr, ptr, i32 }], align 8
   %actor_meta_handler_0 = getelementptr [2 x { ptr, i32, i32, ptr, ptr, i32 }], ptr %actor_meta_handlers_Adder, i32 0, i32 0
   %actor_meta_handler_0_f0 = getelementptr inbounds nuw { ptr, i32, i32, ptr, ptr, i32 }, ptr %actor_meta_handler_0, i32 0, i32 0
-  store ptr @str_actor_meta_handler_Adder_0_set_base, ptr %actor_meta_handler_0_f0, align 8
+  store ptr @str_actor_meta_handler_Adder_0_set_base, ptr %actor_meta_handler_0_f0, align 4
   %actor_meta_handler_0_f1 = getelementptr inbounds nuw { ptr, i32, i32, ptr, ptr, i32 }, ptr %actor_meta_handler_0, i32 0, i32 1
   store i32 1995638644, ptr %actor_meta_handler_0_f1, align 4
   %actor_meta_handler_0_f2 = getelementptr inbounds nuw { ptr, i32, i32, ptr, ptr, i32 }, ptr %actor_meta_handler_0, i32 0, i32 2
   store i32 0, ptr %actor_meta_handler_0_f2, align 4
   %actor_meta_handler_0_f3 = getelementptr inbounds nuw { ptr, i32, i32, ptr, ptr, i32 }, ptr %actor_meta_handler_0, i32 0, i32 3
-  store ptr null, ptr %actor_meta_handler_0_f3, align 8
+  store ptr null, ptr %actor_meta_handler_0_f3, align 4
   %actor_meta_handler_0_f4 = getelementptr inbounds nuw { ptr, i32, i32, ptr, ptr, i32 }, ptr %actor_meta_handler_0, i32 0, i32 4
-  store ptr null, ptr %actor_meta_handler_0_f4, align 8
+  store ptr null, ptr %actor_meta_handler_0_f4, align 4
   %actor_meta_handler_0_f5 = getelementptr inbounds nuw { ptr, i32, i32, ptr, ptr, i32 }, ptr %actor_meta_handler_0, i32 0, i32 5
   store i32 0, ptr %actor_meta_handler_0_f5, align 4
   %actor_meta_handler_1 = getelementptr [2 x { ptr, i32, i32, ptr, ptr, i32 }], ptr %actor_meta_handlers_Adder, i32 0, i32 1
   %actor_meta_handler_1_f0 = getelementptr inbounds nuw { ptr, i32, i32, ptr, ptr, i32 }, ptr %actor_meta_handler_1, i32 0, i32 0
-  store ptr @str_actor_meta_handler_Adder_1_add, ptr %actor_meta_handler_1_f0, align 8
+  store ptr @str_actor_meta_handler_Adder_1_add, ptr %actor_meta_handler_1_f0, align 4
   %actor_meta_handler_1_f1 = getelementptr inbounds nuw { ptr, i32, i32, ptr, ptr, i32 }, ptr %actor_meta_handler_1, i32 0, i32 1
   store i32 311929158, ptr %actor_meta_handler_1_f1, align 4
   %actor_meta_handler_1_f2 = getelementptr inbounds nuw { ptr, i32, i32, ptr, ptr, i32 }, ptr %actor_meta_handler_1, i32 0, i32 2
   store i32 0, ptr %actor_meta_handler_1_f2, align 4
   %actor_meta_handler_1_f3 = getelementptr inbounds nuw { ptr, i32, i32, ptr, ptr, i32 }, ptr %actor_meta_handler_1, i32 0, i32 3
-  store ptr null, ptr %actor_meta_handler_1_f3, align 8
+  store ptr null, ptr %actor_meta_handler_1_f3, align 4
   %actor_meta_handler_1_f4 = getelementptr inbounds nuw { ptr, i32, i32, ptr, ptr, i32 }, ptr %actor_meta_handler_1, i32 0, i32 4
-  store ptr null, ptr %actor_meta_handler_1_f4, align 8
+  store ptr null, ptr %actor_meta_handler_1_f4, align 4
   %actor_meta_handler_1_f5 = getelementptr inbounds nuw { ptr, i32, i32, ptr, ptr, i32 }, ptr %actor_meta_handler_1, i32 0, i32 5
   store i32 0, ptr %actor_meta_handler_1_f5, align 4
   %actor_meta_handlers_ptr = getelementptr [2 x { ptr, i32, i32, ptr, ptr, i32 }], ptr %actor_meta_handlers_Adder, i32 0, i32 0
   %actor_meta_Adder = alloca { ptr, i32, ptr }, align 8
   %actor_meta_f0 = getelementptr inbounds nuw { ptr, i32, ptr }, ptr %actor_meta_Adder, i32 0, i32 0
-  store ptr @str_actor_meta_name_Adder, ptr %actor_meta_f0, align 8
+  store ptr @str_actor_meta_name_Adder, ptr %actor_meta_f0, align 4
   %actor_meta_f1 = getelementptr inbounds nuw { ptr, i32, ptr }, ptr %actor_meta_Adder, i32 0, i32 1
   store i32 2, ptr %actor_meta_f1, align 4
   %actor_meta_f2 = getelementptr inbounds nuw { ptr, i32, ptr }, ptr %actor_meta_Adder, i32 0, i32 2
-  store ptr %actor_meta_handlers_ptr, ptr %actor_meta_f2, align 8
+  store ptr %actor_meta_handlers_ptr, ptr %actor_meta_f2, align 4
   call void @hew_wasm_register_actor_meta(ptr %actor_meta_Adder)
   call void @hew_actor_register_type(ptr @__hew_actor_dispatch_Adder, ptr @str_actor_type_name_Adder)
   call void @hew_register_handler_name(ptr @__hew_actor_dispatch_Adder, i32 1995638644, ptr @str_actor_handler_name_Adder_0_set_base)
   call void @hew_register_handler_name(ptr @__hew_actor_dispatch_Adder, i32 311929158, ptr @str_actor_handler_name_Adder_1_add)
-  %hew_actor_spawn_call = call ptr @hew_actor_spawn(ptr %local_0, i64 ptrtoint (ptr getelementptr (%Adder, ptr null, i32 1) to i64), ptr @__hew_actor_dispatch_Adder)
+  %hew_actor_spawn_call = call ptr @hew_actor_spawn(ptr %local_0, i32 ptrtoint (ptr getelementptr (%Adder, ptr null, i32 1) to i32), ptr @__hew_actor_dispatch_Adder)
   call void @hew_actor_set_state_drop(ptr %hew_actor_spawn_call, ptr @__hew_state_drop_Adder)
   call void @hew_actor_set_state_clone(ptr %hew_actor_spawn_call, ptr @__hew_state_clone_Adder)
-  store ptr %hew_actor_spawn_call, ptr %local_2, align 8
-  store i64 100, ptr %local_3, align 4
-  %"actor_send receiver" = load ptr, ptr %local_2, align 8
+  store ptr %hew_actor_spawn_call, ptr %local_2, align 4
+  store i64 100, ptr %local_3, align 8
+  %"actor_send receiver" = load ptr, ptr %local_2, align 4
   %actor_id_slot = getelementptr i8, ptr %"actor_send receiver", i64 8
-  %actor_id = load i64, ptr %actor_id_slot, align 4
-  %hew_actor_send_by_id_call = call i32 @hew_actor_send_by_id(i64 %actor_id, ptr null, i32 1995638644, ptr %local_3, i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64))
-  %actor_send_failed = icmp ne i32 %hew_actor_send_by_id_call, 0
-  br i1 %actor_send_failed, label %actor_send_fail, label %bb1
+  %actor_id = load i64, ptr %actor_id_slot, align 8
+  %hew_actor_send_by_id_call = call i32 @hew_actor_send_by_id(i64 %actor_id, ptr null, i32 1995638644, ptr %local_3, i32 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i32))
+  %send_not_ok = icmp ne i32 %hew_actor_send_by_id_call, 0
+  br i1 %send_not_ok, label %actor_send_fail, label %bb1
 
 bb1:                                              ; preds = %bb0
-  store i64 42, ptr %local_4, align 4
-  %"actor_ask receiver" = load ptr, ptr %local_2, align 8
-  %hew_actor_ask_call = call ptr @hew_actor_ask(ptr %"actor_ask receiver", i32 311929158, ptr %local_4, i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64))
+  store i64 42, ptr %local_4, align 8
+  %"actor_ask receiver" = load ptr, ptr %local_2, align 4
+  %hew_actor_ask_call = call ptr @hew_actor_ask(ptr %"actor_ask receiver", i32 311929158, ptr %local_4, i32 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i32))
   %actor_ask_reply_is_null = icmp eq ptr %hew_actor_ask_call, null
   br i1 %actor_ask_reply_is_null, label %actor_ask_reply_err, label %actor_ask_reply_ok
 
 bb2:                                              ; preds = %actor_ask_reply_err, %actor_ask_reply_ok
-  %move_load = load %"Result$$i64$AskError", ptr %local_5, align 4
-  store %"Result$$i64$AskError" %move_load, ptr %local_8, align 4
+  %move_load = load %"Result$$i64$AskError", ptr %local_5, align 8
+  store %"Result$$i64$AskError" %move_load, ptr %local_8, align 8
   %machine_tag_ptr5 = getelementptr inbounds nuw %"Result$$i64$AskError", ptr %local_8, i32 0, i32 0
   %move_iN_load = load i8, ptr %machine_tag_ptr5, align 1
   %move_iN_zext = zext i8 %move_iN_load to i64
-  store i64 %move_iN_zext, ptr %local_10, align 4
-  store i64 0, ptr %local_11, align 4
-  %cmp_lhs = load i64, ptr %local_10, align 4
-  %cmp_rhs = load i64, ptr %local_11, align 4
+  store i64 %move_iN_zext, ptr %local_10, align 8
+  store i64 0, ptr %local_11, align 8
+  %cmp_lhs = load i64, ptr %local_10, align 8
+  %cmp_rhs = load i64, ptr %local_11, align 8
   %cmp_bit = icmp eq i64 %cmp_lhs, %cmp_rhs
   %cmp_zext = zext i1 %cmp_bit to i8
   store i8 %cmp_zext, ptr %local_12, align 1
@@ -436,35 +474,26 @@ bb2:                                              ; preds = %actor_ask_reply_err
   %cond_nz = icmp ne i8 %cond_load, 0
   br i1 %cond_nz, label %bb4, label %bb7
 
-bb3:                                              ; preds = %after_cooperate22, %after_cooperate
+bb3:                                              ; preds = %after_cooperate20, %after_cooperate
   %move_load6 = load i8, ptr %local_9, align 1
   store i8 %move_load6, ptr %return_slot, align 1
-  call void @hew_shutdown_initiate(i64 0)
-  %hew_shutdown_wait_call = call i32 @hew_shutdown_wait()
-  %hew_lambda_drain_all_call = call i32 @hew_lambda_drain_all(i64 0)
+  call void @hew_wasm_runtime_exit()
   ret i8 0
 
 bb4:                                              ; preds = %bb2
   %machine_payload_ptr7 = getelementptr inbounds nuw %"Result$$i64$AskError", ptr %local_8, i32 0, i32 1
   %machine_variant_field_ptr8 = getelementptr inbounds nuw { i64 }, ptr %machine_payload_ptr7, i32 0, i32 0
-  %move_load9 = load i64, ptr %machine_variant_field_ptr8, align 4
-  store i64 %move_load9, ptr %local_15, align 4
-  %print_arg = load i64, ptr %local_15, align 4
+  %move_load9 = load i64, ptr %machine_variant_field_ptr8, align 8
+  store i64 %move_load9, ptr %local_15, align 8
+  %print_arg = load i64, ptr %local_15, align 8
   call void @hew_print_value(i8 1, i64 %print_arg, i1 true)
   br label %bb8
 
 bb5:                                              ; preds = %bb7
-  store i64 1, ptr %local_16, align 4
-  %ineg_operand = load i64, ptr %local_16, align 4
-  %neg_with_overflow = call { i64, i1 } @llvm.ssub.with.overflow.i64(i64 0, i64 %ineg_operand)
-  %neg_result = extractvalue { i64, i1 } %neg_with_overflow, 0
-  %neg_overflow = extractvalue { i64, i1 } %neg_with_overflow, 1
-  %neg_overflow_widen = zext i1 %neg_overflow to i8
-  store i64 %neg_result, ptr %local_17, align 4
-  store i8 %neg_overflow_widen, ptr %local_18, align 1
-  %cond_load10 = load i8, ptr %local_18, align 1
-  %cond_nz11 = icmp ne i8 %cond_load10, 0
-  br i1 %cond_nz11, label %bb9, label %bb10
+  store i64 -1, ptr %local_16, align 8
+  %print_arg10 = load i64, ptr %local_16, align 8
+  call void @hew_print_value(i8 1, i64 %print_arg10, i1 true)
+  br label %bb9
 
 bb6:                                              ; preds = %bb7
   call void @hew_trap_with_code(i32 208)
@@ -472,15 +501,15 @@ bb6:                                              ; preds = %bb7
   unreachable
 
 bb7:                                              ; preds = %bb2
-  store i64 1, ptr %local_13, align 4
-  %cmp_lhs12 = load i64, ptr %local_10, align 4
-  %cmp_rhs13 = load i64, ptr %local_13, align 4
-  %cmp_bit14 = icmp eq i64 %cmp_lhs12, %cmp_rhs13
-  %cmp_zext15 = zext i1 %cmp_bit14 to i8
-  store i8 %cmp_zext15, ptr %local_14, align 1
-  %cond_load16 = load i8, ptr %local_14, align 1
-  %cond_nz17 = icmp ne i8 %cond_load16, 0
-  br i1 %cond_nz17, label %bb5, label %bb6
+  store i64 1, ptr %local_13, align 8
+  %cmp_lhs11 = load i64, ptr %local_10, align 8
+  %cmp_rhs12 = load i64, ptr %local_13, align 8
+  %cmp_bit13 = icmp eq i64 %cmp_lhs11, %cmp_rhs12
+  %cmp_zext14 = zext i1 %cmp_bit13 to i8
+  store i8 %cmp_zext14, ptr %local_14, align 1
+  %cond_load15 = load i8, ptr %local_14, align 1
+  %cond_nz16 = icmp ne i8 %cond_load15, 0
+  br i1 %cond_nz16, label %bb5, label %bb6
 
 bb8:                                              ; preds = %bb4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
@@ -488,19 +517,9 @@ bb8:                                              ; preds = %bb4
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb9:                                              ; preds = %bb5
-  call void @hew_trap_with_code(i32 201)
-  call void @llvm.trap()
-  unreachable
-
-bb10:                                             ; preds = %bb5
-  %print_arg18 = load i64, ptr %local_17, align 4
-  call void @hew_print_value(i8 1, i64 %print_arg18, i1 true)
-  br label %bb11
-
-bb11:                                             ; preds = %bb10
-  %hew_actor_cooperate19 = call i32 @hew_actor_cooperate()
-  %hew_cooperate_is_cancel20 = icmp eq i32 %hew_actor_cooperate19, 2
-  br i1 %hew_cooperate_is_cancel20, label %cancel_exit21, label %after_cooperate22
+  %hew_actor_cooperate17 = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel18 = icmp eq i32 %hew_actor_cooperate17, 2
+  br i1 %hew_cooperate_is_cancel18, label %cancel_exit19, label %after_cooperate20
 
 actor_send_fail:                                  ; preds = %bb0
   call void @hew_trap_with_code(i32 206)
@@ -508,14 +527,14 @@ actor_send_fail:                                  ; preds = %bb0
   unreachable
 
 actor_ask_reply_ok:                               ; preds = %bb1
-  %actor_ask_reply_value = load i64, ptr %hew_actor_ask_call, align 4
-  store i64 %actor_ask_reply_value, ptr %local_6, align 4
+  %actor_ask_reply_value = load i64, ptr %hew_actor_ask_call, align 8
+  store i64 %actor_ask_reply_value, ptr %local_6, align 8
   %machine_tag_ptr = getelementptr inbounds nuw %"Result$$i64$AskError", ptr %local_5, i32 0, i32 0
   store i8 0, ptr %machine_tag_ptr, align 1
   %machine_payload_ptr = getelementptr inbounds nuw %"Result$$i64$AskError", ptr %local_5, i32 0, i32 1
   %machine_variant_field_ptr = getelementptr inbounds nuw { i64 }, ptr %machine_payload_ptr, i32 0, i32 0
-  %emit_result_ok_v0_f0_src = load i64, ptr %local_6, align 4
-  store i64 %emit_result_ok_v0_f0_src, ptr %machine_variant_field_ptr, align 4
+  %emit_result_ok_v0_f0_src = load i64, ptr %local_6, align 8
+  store i64 %emit_result_ok_v0_f0_src, ptr %machine_variant_field_ptr, align 8
   call void @free(ptr %hew_actor_ask_call)
   br label %bb2
 
@@ -538,18 +557,84 @@ cancel_exit:                                      ; preds = %bb8
 after_cooperate:                                  ; preds = %bb8
   br label %bb3
 
-cancel_exit21:                                    ; preds = %bb11
+cancel_exit19:                                    ; preds = %bb9
   ret i8 0
 
-after_cooperate22:                                ; preds = %bb11
+after_cooperate20:                                ; preds = %bb9
   br label %bb3
+}
+
+define internal ptr @"i8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 4
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i8, ptr %local_0, align 1
+  %cast_int_sext = sext i8 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"i16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 4
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i16, ptr %local_0, align 2
+  %cast_int_sext = sext i16 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
 }
 
 define internal ptr @"i32::fmt"(i32 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i32, align 4
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i32 %0, ptr %local_0, align 4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -558,13 +643,13 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
   %call_result = call ptr @hew_int_to_string(i32 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -576,24 +661,83 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"i64::fmt"(i64 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i64, align 8
-  %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  %local_1 = alloca ptr, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 4
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i8, ptr %local_0, align 1
+  %call_result = call ptr @hew_u8_to_string(i8 %call_arg)
+  store ptr %call_result, ptr %local_1, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca ptr, align 4
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i16, ptr %local_0, align 2
+  %ffi_zext = zext i16 %call_arg to i32
+  %call_result = call ptr @hew_uint_to_string(i32 %ffi_zext)
+  store ptr %call_result, ptr %local_1, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -605,9 +749,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"u32::fmt"(i32 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i32, align 4
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i32 %0, ptr %local_0, align 4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -615,15 +759,14 @@ entry:
 
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
-  %ffi_arg_trunc = trunc i32 %call_arg to i16
-  %call_result = call ptr @hew_uint_to_string(i16 %ffi_arg_trunc)
-  store ptr %call_result, ptr %local_1, align 8
+  %call_result = call ptr @hew_uint_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -635,24 +778,90 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"u64::fmt"(i64 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i64, align 8
-  %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  %local_1 = alloca ptr, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"isize::fmt"(i32 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 4
+  store i32 %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i32, ptr %local_0, align 4
+  %cast_int_sext = sext i32 %cast_int_src to i64
+  store i64 %cast_int_sext, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"usize::fmt"(i32 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 4
+  store i32 %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i32, ptr %local_0, align 4
+  %cast_int_zext = zext i32 %cast_int_src to i64
+  store i64 %cast_int_zext, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -664,9 +873,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"bool::fmt"(i8 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i8, align 1
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i8 %0, ptr %local_0, align 1
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -675,13 +884,13 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i8, ptr %local_0, align 1
   %call_result = call ptr @hew_bool_to_string(i8 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -693,9 +902,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"char::fmt"(i32 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i32, align 4
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i32 %0, ptr %local_0, align 4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -704,13 +913,13 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
   %call_result = call ptr @hew_char_to_string(i32 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -722,9 +931,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"f64::fmt"(double %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca double, align 8
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store double %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -733,13 +942,46 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load double, ptr %local_0, align 8
   %call_result = call ptr @hew_float_to_string(double %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"f32::fmt"(float %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca float, align 4
+  %local_1 = alloca double, align 8
+  %local_2 = alloca ptr, align 4
+  store float %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_float_src = load float, ptr %local_0, align 4
+  %cast_float_ext = fpext float %cast_float_src to double
+  store double %cast_float_ext, ptr %local_1, align 8
+  %call_arg = load double, ptr %local_1, align 8
+  %call_result = call ptr @hew_float_to_string(double %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -751,19 +993,214 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"string::fmt"(ptr %0) {
 entry:
-  %return_slot = alloca ptr, align 8
-  %local_0 = alloca ptr, align 8
-  store ptr %0, ptr %local_0, align 8
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca ptr, align 4
+  store ptr %0, ptr %local_0, align 4
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  %move_load = load ptr, ptr %local_0, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %mir_share_string_load = load ptr, ptr %local_0, align 4
+  %mir_share_string_retain = call ptr @hew_string_clone(ptr %mir_share_string_load)
+  %move_load = load ptr, ptr %local_0, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 }
 
-define internal ptr @__hew_actor_dispatch_Adder(ptr %0, ptr %1, i32 %2, ptr %3, i64 %4, i32 %5) {
+define internal i64 @"duration::from_nanos"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_micros"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_millis"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_secs"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal ptr @"duration::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 4
+  %local_3 = alloca ptr, align 4
+  %local_4 = alloca ptr, align 4
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %hew_duration_nanos = load i64, ptr %local_0, align 8
+  %hew_duration_nanos_call = call i64 @hew_duration_nanos(i64 %hew_duration_nanos)
+  store i64 %hew_duration_nanos_call, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  store ptr @str_lit, ptr %local_3, align 4
+  %"hew_string_concat arg0" = load ptr, ptr %local_2, align 4
+  %"hew_string_concat arg1" = load ptr, ptr %local_3, align 4
+  %hew_string_concat_call = call ptr @hew_string_concat(ptr %"hew_string_concat arg0", ptr %"hew_string_concat arg1")
+  store ptr %hew_string_concat_call, ptr %local_4, align 4
+  %"hew_string_drop drop" = load ptr, ptr %local_2, align 4
+  call void @hew_string_drop(ptr %"hew_string_drop drop")
+  store ptr null, ptr %local_2, align 4
+  %move_load = load ptr, ptr %local_4, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define i8 @main() {
+entry:
+  %__original_main_call = call i8 @__original_main()
+  ret i8 %__original_main_call
+}
+
+define internal ptr @__hew_actor_dispatch_Adder(ptr %0, ptr %1, i32 %2, ptr %3, i32 %4, i32 %5) {
 entry:
   %dispatch_is_borrow = icmp ne i32 %5, 0
   br i1 %dispatch_is_borrow, label %borrow_src, label %copy_src
@@ -772,8 +1209,8 @@ unknown_msg_type:                                 ; preds = %payload_src
   call void @llvm.trap()
   unreachable
 
-dispatch_done:                                    ; preds = %msg_311929158, %msg_1995638644
-  %dispatch_suspend_handle = phi ptr [ null, %msg_1995638644 ], [ null, %msg_311929158 ]
+dispatch_done:                                    ; preds = %msg_sys_exit_unhandled, %msg_311929158, %msg_1995638644
+  %dispatch_suspend_handle = phi ptr [ null, %msg_1995638644 ], [ null, %msg_311929158 ], [ null, %msg_sys_exit_unhandled ]
   ret ptr %dispatch_suspend_handle
 
 borrow_src:                                       ; preds = %entry
@@ -789,6 +1226,7 @@ payload_src:                                      ; preds = %copy_src, %borrow_p
   switch i32 %2, label %unknown_msg_type [
     i32 1995638644, label %msg_1995638644
     i32 311929158, label %msg_311929158
+    i32 103, label %msg_sys_exit_unhandled
   ]
 
 borrow_payload_null:                              ; preds = %borrow_src
@@ -799,17 +1237,23 @@ borrow_payload_ok:                                ; preds = %borrow_src
   br label %payload_src
 
 msg_1995638644:                                   ; preds = %payload_src
-  %msg_arg_0 = load i64, ptr %payload_src_ptr, align 4
+  %msg_arg_0 = load i64, ptr %payload_src_ptr, align 8
   %call_set_base = call i8 @Adder__recv__set_base(ptr %0, i64 %msg_arg_0, i32 %5)
   br label %dispatch_done
 
 msg_311929158:                                    ; preds = %payload_src
-  %msg_arg_01 = load i64, ptr %payload_src_ptr, align 4
+  %msg_arg_01 = load i64, ptr %payload_src_ptr, align 8
   %call_add = call i64 @Adder__recv__add(ptr %0, i64 %msg_arg_01, i32 %5)
   %hew_get_reply_channel_call = call ptr @hew_get_reply_channel()
   %actor_reply_slot = alloca i64, align 8
-  store i64 %call_add, ptr %actor_reply_slot, align 4
-  %hew_reply_call = call i1 @hew_reply(ptr %hew_get_reply_channel_call, ptr %actor_reply_slot, i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64))
+  store i64 %call_add, ptr %actor_reply_slot, align 8
+  %hew_reply_call = call i1 @hew_reply(ptr %hew_get_reply_channel_call, ptr %actor_reply_slot, i32 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i32))
+  br label %dispatch_done
+
+msg_sys_exit_unhandled:                           ; preds = %payload_src
+  %exit_reason_ptr = getelementptr inbounds nuw { i64, i32, i32 }, ptr %payload_src_ptr, i32 0, i32 1
+  %exit_reason = load i32, ptr %exit_reason_ptr, align 4
+  call void @hew_actor_exit_unhandled(i32 %exit_reason)
   br label %dispatch_done
 }
 
@@ -819,10 +1263,77 @@ declare void @hew_panic()
 
 declare ptr @hew_get_reply_channel()
 
-declare i1 @hew_reply(ptr, ptr, i64)
+declare i1 @hew_reply(ptr, ptr, i32)
+
+declare void @hew_actor_exit_unhandled(i32)
 
 ; Function Attrs: cold noreturn nounwind memory(inaccessiblemem: write)
 declare void @llvm.trap() #0
+
+define internal i32 @__hew_record_clone_inplace_CrashInfo(ptr %0, ptr %1) {
+entry:
+  br label %step_0_clone
+
+success:                                          ; preds = %step_0_store
+  ret i32 0
+
+fail:                                             ; preds = %rb_step_0
+  ret i32 1
+
+rb_step_0:                                        ; preds = %step_0_clone
+  br label %fail
+
+step_0_store:                                     ; preds = %step_0_clone
+  %dst_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  store ptr %clone_helper_f1, ptr %dst_f1_ptr, align 4
+  br label %success
+
+step_0_clone:                                     ; preds = %entry
+  %src_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %src_f1 = load ptr, ptr %src_f1_ptr, align 4
+  %clone_helper_f1 = call ptr @hew_string_clone(ptr %src_f1)
+  %cloned_f1_int = ptrtoint ptr %clone_helper_f1 to i64
+  %cloned_f1_null = icmp eq i64 %cloned_f1_int, 0
+  br i1 %cloned_f1_null, label %rb_step_0, label %step_0_store
+}
+
+define internal void @__hew_record_drop_inplace_CrashInfo(ptr %0) {
+entry:
+  %rec_int = ptrtoint ptr %0 to i64
+  %rec_is_null = icmp eq i64 %rec_int, 0
+  br i1 %rec_is_null, label %done, label %do_drop
+
+do_drop:                                          ; preds = %entry
+  %drop_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %drop_f1 = load ptr, ptr %drop_f1_ptr, align 4
+  call void @hew_string_drop(ptr %drop_f1)
+  br label %done
+
+done:                                             ; preds = %do_drop, %entry
+  ret void
+}
+
+declare void @hew_string_drop(ptr)
+
+define internal void @__hew_record_overwrite_release_CrashInfo(ptr %0, ptr %1) {
+entry:
+  %ow_slot_0 = alloca ptr, align 4
+  store ptr null, ptr %ow_slot_0, align 4
+  %ow_new_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  %ow_new_d0_f1_leaf = load ptr, ptr %ow_new_d0_f1_ptr, align 4
+  store ptr %ow_new_d0_f1_leaf, ptr %ow_slot_0, align 4
+  %ow_old_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %ow_old_d0_f1_val = load ptr, ptr %ow_old_d0_f1_ptr, align 4
+  %ow_old_d0_f1_int = ptrtoint ptr %ow_old_d0_f1_val to i64
+  %ow_old_d0_f1_cmp0_leaf = load ptr, ptr %ow_slot_0, align 4
+  %ow_old_d0_f1_cmp0_int = ptrtoint ptr %ow_old_d0_f1_cmp0_leaf to i64
+  %ow_old_d0_f1_cmp0_eq = icmp eq i64 %ow_old_d0_f1_int, %ow_old_d0_f1_cmp0_int
+  %ow_old_d0_f1_matched0 = or i1 false, %ow_old_d0_f1_cmp0_eq
+  %ow_old_d0_f1_neutralized = select i1 %ow_old_d0_f1_matched0, ptr null, ptr %ow_old_d0_f1_val
+  store ptr %ow_old_d0_f1_neutralized, ptr %ow_old_d0_f1_ptr, align 4
+  call void @__hew_record_drop_inplace_CrashInfo(ptr %0)
+  ret void
+}
 
 define ptr @__hew_state_clone_Adder(ptr %0) {
 entry:
@@ -834,7 +1345,7 @@ ret_null:                                         ; preds = %alloc, %entry
   ret ptr null
 
 alloc:                                            ; preds = %entry
-  %state_wrapper = call ptr @malloc(i64 8)
+  %state_wrapper = call ptr @malloc(i32 8)
   %dst_as_int = ptrtoint ptr %state_wrapper to i64
   %dst_is_null = icmp eq i64 %dst_as_int, 0
   br i1 %dst_is_null, label %ret_null, label %memcpy_wholesale
@@ -847,7 +1358,7 @@ success:                                          ; preds = %memcpy_wholesale
   ret ptr %state_wrapper
 }
 
-declare ptr @malloc(i64)
+declare ptr @malloc(i32)
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #1
@@ -878,91 +1389,87 @@ declare void @hew_actor_register_type(ptr, ptr)
 
 declare void @hew_register_handler_name(ptr, i32, ptr)
 
-declare ptr @hew_actor_spawn(ptr, i64, ptr)
+declare ptr @hew_actor_spawn(ptr, i32, ptr)
 
 declare void @hew_actor_set_state_drop(ptr, ptr)
 
 declare void @hew_actor_set_state_clone(ptr, ptr)
 
-declare i32 @hew_actor_send_by_id(i64, ptr, i32, ptr, i64)
+declare i32 @hew_actor_send_by_id(i64, ptr, i32, ptr, i32)
 
-declare ptr @hew_actor_ask(ptr, i32, ptr, i64)
+declare ptr @hew_actor_ask(ptr, i32, ptr, i32)
 
 declare void @free(ptr)
 
 declare i32 @hew_actor_ask_take_last_error()
 
-declare void @hew_shutdown_initiate(i64)
-
-declare i32 @hew_shutdown_wait()
-
-declare i32 @hew_lambda_drain_all(i64)
-
-; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
-declare { i64, i1 } @llvm.ssub.with.overflow.i64(i64, i64) #2
+declare void @hew_wasm_runtime_exit()
 
 declare i32 @hew_actor_cooperate()
 
-define internal ptr @__hew_serialize_i64(ptr %0, ptr %1) {
+; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
+declare { i64, i1 } @llvm.smul.with.overflow.i64(i64, i64) #2
+
+define internal ptr @__hew_cbor_serialize_i64(ptr %0, ptr %1) {
 entry:
-  %ser_buf = call ptr @hew_ser_buf_new()
-  %ser_scalar = load i64, ptr %0, align 4
-  call void @hew_ser_push_i64(ptr %ser_buf, i64 %ser_scalar)
-  %ser_finish = call ptr @hew_ser_finish(ptr %ser_buf, ptr %1)
-  ret ptr %ser_finish
+  %cbor_ser_buf = call ptr @hew_cbor_ser_new()
+  %cbor_ser_scalar = load i64, ptr %0, align 8
+  call void @hew_cbor_ser_i64(ptr %cbor_ser_buf, i64 %cbor_ser_scalar)
+  %cbor_ser_finish = call ptr @hew_cbor_ser_finish(ptr %cbor_ser_buf, ptr %1)
+  ret ptr %cbor_ser_finish
 }
 
-define internal ptr @__hew_deserialize_i64(ptr %0, i64 %1, ptr %2) {
+define internal ptr @__hew_cbor_deserialize_i64(ptr %0, i32 %1, ptr %2) {
 entry:
-  %de_reader = call ptr @hew_de_reader_new(ptr %0, i64 %1)
-  store i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64), ptr %2, align 4
-  %de_value = call ptr @malloc(i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64))
-  %dst_as_int = ptrtoint ptr %de_value to i64
-  %dst_is_null = icmp eq i64 %dst_as_int, 0
-  br i1 %dst_is_null, label %de_oom, label %de_alloc_ok
+  %cbor_de_reader = call ptr @hew_cbor_de_new(ptr %0, i32 %1)
+  store i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64), ptr %2, align 8
+  %cbor_de_value = call ptr @malloc(i32 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i32))
+  %cbor_dst_as_int = ptrtoint ptr %cbor_de_value to i64
+  %cbor_dst_is_null = icmp eq i64 %cbor_dst_as_int, 0
+  br i1 %cbor_dst_is_null, label %cbor_de_oom, label %cbor_de_alloc_ok
 
-de_oom:                                           ; preds = %entry
-  call void @hew_de_reader_free(ptr %de_reader)
+cbor_de_oom:                                      ; preds = %entry
+  call void @hew_cbor_de_free(ptr %cbor_de_reader)
   ret ptr null
 
-de_alloc_ok:                                      ; preds = %entry
-  %de_zero = call ptr @memset(ptr %de_value, i32 0, i64 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i64))
-  %de_read_int = call i64 @hew_de_read_i64(ptr %de_reader)
-  store i64 %de_read_int, ptr %de_value, align 4
-  %de_failed = call i32 @hew_de_failed(ptr %de_reader)
-  call void @hew_de_reader_free(ptr %de_reader)
-  %de_is_failed = icmp ne i32 %de_failed, 0
-  br i1 %de_is_failed, label %de_fail, label %de_ok
+cbor_de_alloc_ok:                                 ; preds = %entry
+  %cbor_de_zero = call ptr @memset(ptr %cbor_de_value, i32 0, i32 ptrtoint (ptr getelementptr (i64, ptr null, i32 1) to i32))
+  %cbor_de_int = call i64 @hew_cbor_de_int_checked(ptr %cbor_de_reader, i32 64, i32 1)
+  store i64 %cbor_de_int, ptr %cbor_de_value, align 8
+  %cbor_de_failed = call i32 @hew_cbor_de_failed(ptr %cbor_de_reader)
+  call void @hew_cbor_de_free(ptr %cbor_de_reader)
+  %cbor_de_is_failed = icmp ne i32 %cbor_de_failed, 0
+  br i1 %cbor_de_is_failed, label %cbor_de_fail, label %cbor_de_ok
 
-de_ok:                                            ; preds = %de_alloc_ok
-  ret ptr %de_value
+cbor_de_ok:                                       ; preds = %cbor_de_alloc_ok
+  ret ptr %cbor_de_value
 
-de_fail:                                          ; preds = %de_alloc_ok
-  call void @free(ptr %de_value)
+cbor_de_fail:                                     ; preds = %cbor_de_alloc_ok
+  call void @free(ptr %cbor_de_value)
   ret ptr null
 }
 
-declare ptr @hew_ser_buf_new()
+declare ptr @hew_cbor_ser_new()
 
-declare void @hew_ser_push_i64(ptr, i64)
+declare void @hew_cbor_ser_i64(ptr, i64)
 
-declare ptr @hew_ser_finish(ptr, ptr)
+declare ptr @hew_cbor_ser_finish(ptr, ptr)
 
-declare ptr @hew_de_reader_new(ptr, i64)
+declare ptr @hew_cbor_de_new(ptr, i32)
 
-declare void @hew_de_reader_free(ptr)
+declare void @hew_cbor_de_free(ptr)
 
-declare ptr @memset(ptr, i32, i64)
+declare ptr @memset(ptr, i32, i32)
 
-declare i64 @hew_de_read_i64(ptr)
+declare i64 @hew_cbor_de_int_checked(ptr, i32, i32)
 
-declare i32 @hew_de_failed(ptr)
+declare i32 @hew_cbor_de_failed(ptr)
 
-define private void @hew_module_init_xnode_codecs() {
+define private void @hew_module_init_actor_codecs() {
 entry:
-  call void @hew_xnode_register_codec(ptr @__hew_actor_dispatch_Adder, i32 1995638644, ptr @__hew_serialize_i64, ptr @__hew_deserialize_i64)
-  call void @hew_xnode_register_codec(ptr @__hew_actor_dispatch_Adder, i32 311929158, ptr @__hew_serialize_i64, ptr @__hew_deserialize_i64)
-  call void @hew_xnode_register_reply_codec(ptr @__hew_actor_dispatch_Adder, i32 311929158, ptr @__hew_serialize_i64, ptr @__hew_deserialize_i64)
+  call void @hew_xnode_register_codec(ptr @__hew_actor_dispatch_Adder, i32 1995638644, ptr @__hew_cbor_serialize_i64, ptr @__hew_cbor_deserialize_i64)
+  call void @hew_xnode_register_codec(ptr @__hew_actor_dispatch_Adder, i32 311929158, ptr @__hew_cbor_serialize_i64, ptr @__hew_cbor_deserialize_i64)
+  call void @hew_xnode_register_reply_codec(ptr @__hew_actor_dispatch_Adder, i32 311929158, ptr @__hew_cbor_serialize_i64, ptr @__hew_cbor_deserialize_i64)
   ret void
 }
 

--- a/tests/ll-oracle/corpus/golden/wasm32/r4_thunks.ll
+++ b/tests/ll-oracle/corpus/golden/wasm32/r4_thunks.ll
@@ -1,11 +1,19 @@
 ; ModuleID = 'r4_thunks'
 source_filename = "r4_thunks"
+target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20"
+target triple = "wasm32-unknown-unknown"
 
 %__hew_closure_env_make_adder_0 = type { i64 }
 %__hew_closure_env_make_multiplier_0 = type { i64 }
 %__hew_closure_env_main_0 = type {}
 %__hew_closure_env_main_1 = type { i64, i64 }
+%CrashInfo = type { i64, ptr }
 
+@str_lit = private unnamed_addr constant [3 x i8] c"ns\00", align 1
+
+declare void @hew_sleep_ns(i64)
+
+declare void @hew_sleep_until_ns(i64)
 
 declare void @hew_exit(i64)
 
@@ -21,7 +29,7 @@ declare ptr @hew_i64_to_string(i64)
 
 declare ptr @hew_u8_to_string(i8)
 
-declare ptr @hew_uint_to_string(i16)
+declare ptr @hew_uint_to_string(i32)
 
 declare ptr @hew_u64_to_string(i64)
 
@@ -109,21 +117,13 @@ declare ptr @hew_string_split(ptr, ptr)
 
 declare ptr @hew_string_lines(ptr)
 
-declare i32 @hew_string_find(ptr, ptr)
-
-declare i32 @hew_string_index_of_start(ptr, ptr)
-
 declare ptr @hew_string_slice(ptr, i64, i64)
 
 declare ptr @hew_string_repeat(ptr, i64)
 
-declare i32 @hew_string_char_at(ptr, i32)
-
 declare ptr @hew_string_chars(ptr)
 
 declare i32 @hew_string_char_count(ptr)
-
-declare i32 @hew_string_char_at_utf8(ptr, i32)
 
 declare void @hew_vec_push_bool(ptr, i1)
 
@@ -229,7 +229,27 @@ declare ptr @hew_bytes_to_string(ptr)
 
 declare void @hew_vec_append(ptr, ptr)
 
-declare void @hew_vec_remove_at(ptr, i64)
+declare i1 @hew_vec_remove_at_bool(ptr, i64)
+
+declare i8 @hew_vec_remove_at_i8(ptr, i64)
+
+declare i8 @hew_vec_remove_at_u8(ptr, i64)
+
+declare i16 @hew_vec_remove_at_i16(ptr, i64)
+
+declare i16 @hew_vec_remove_at_u16(ptr, i64)
+
+declare i32 @hew_vec_remove_at_i32(ptr, i64)
+
+declare i64 @hew_vec_remove_at_i64(ptr, i64)
+
+declare float @hew_vec_remove_at_f32(ptr, i64)
+
+declare double @hew_vec_remove_at_f64(ptr, i64)
+
+declare ptr @hew_vec_remove_at_str(ptr, i64)
+
+declare ptr @hew_vec_remove_at_ptr(ptr, i64)
 
 declare ptr @hew_vec_clone(ptr)
 
@@ -255,6 +275,12 @@ declare void @hew_node_api_connect(ptr)
 
 declare void @hew_node_api_shutdown()
 
+declare void @hew_node_api_load_keys(ptr)
+
+declare void @hew_node_api_allow_peer(i16, ptr)
+
+declare ptr @hew_node_api_identity_key()
+
 declare i64 @hew_actor_pid(ptr)
 
 declare i32 @hew_node_api_register_by_pid(ptr, i64)
@@ -263,28 +289,44 @@ declare i64 @hew_remote_pid_from_raw(i64, i64)
 
 declare i64 @hew_node_api_lookup(ptr)
 
+declare ptr @hew_stream_channel(i64)
+
+declare ptr @hew_stream_pair_sink(ptr)
+
+declare ptr @hew_stream_pair_stream(ptr)
+
+declare void @hew_stream_pair_free(ptr)
+
+declare void @hew_sink_close(ptr)
+
+declare i32 @hew_sink_peer_closed(ptr)
+
+declare void @hew_actor_gen_sink_register(ptr, ptr)
+
+declare void @hew_actor_gen_sink_complete(ptr, ptr)
+
 define internal i64 @apply({ ptr, ptr } %0, i64 %1) {
 entry:
   %return_slot = alloca i64, align 8
   %closure_call_fallback_ctx = alloca [16 x i64], align 8
-  store [16 x i64] zeroinitializer, ptr %closure_call_fallback_ctx, align 4
+  store [16 x i64] zeroinitializer, ptr %closure_call_fallback_ctx, align 8
   %local_0 = alloca { ptr, ptr }, align 8
   %local_1 = alloca i64, align 8
   %local_2 = alloca i64, align 8
-  store { ptr, ptr } %0, ptr %local_0, align 8
-  store i64 %1, ptr %local_1, align 4
+  store { ptr, ptr } %0, ptr %local_0, align 4
+  store i64 %1, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  %closure_pair_load = load { ptr, ptr }, ptr %local_0, align 8
+  %closure_pair_load = load { ptr, ptr }, ptr %local_0, align 4
   %closure_fn_extract = extractvalue { ptr, ptr } %closure_pair_load, 0
   %closure_env_extract = extractvalue { ptr, ptr } %closure_pair_load, 1
-  %closure_call_arg = load i64, ptr %local_1, align 4
+  %closure_call_arg = load i64, ptr %local_1, align 8
   %closure_call_result = call i64 %closure_fn_extract(ptr %closure_call_fallback_ctx, ptr %closure_env_extract, i64 %closure_call_arg)
-  store i64 %closure_call_result, ptr %local_2, align 4
-  %move_load = load i64, ptr %local_2, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  store i64 %closure_call_result, ptr %local_2, align 8
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
@@ -292,31 +334,31 @@ define internal i64 @apply_twice({ ptr, ptr } %0, i64 %1) {
 entry:
   %return_slot = alloca i64, align 8
   %closure_call_fallback_ctx = alloca [16 x i64], align 8
-  store [16 x i64] zeroinitializer, ptr %closure_call_fallback_ctx, align 4
+  store [16 x i64] zeroinitializer, ptr %closure_call_fallback_ctx, align 8
   %local_0 = alloca { ptr, ptr }, align 8
   %local_1 = alloca i64, align 8
   %local_2 = alloca i64, align 8
   %local_3 = alloca i64, align 8
-  store { ptr, ptr } %0, ptr %local_0, align 8
-  store i64 %1, ptr %local_1, align 4
+  store { ptr, ptr } %0, ptr %local_0, align 4
+  store i64 %1, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  %closure_pair_load = load { ptr, ptr }, ptr %local_0, align 8
+  %closure_pair_load = load { ptr, ptr }, ptr %local_0, align 4
   %closure_fn_extract = extractvalue { ptr, ptr } %closure_pair_load, 0
   %closure_env_extract = extractvalue { ptr, ptr } %closure_pair_load, 1
-  %closure_call_arg = load i64, ptr %local_1, align 4
+  %closure_call_arg = load i64, ptr %local_1, align 8
   %closure_call_result = call i64 %closure_fn_extract(ptr %closure_call_fallback_ctx, ptr %closure_env_extract, i64 %closure_call_arg)
-  store i64 %closure_call_result, ptr %local_2, align 4
-  %closure_pair_load1 = load { ptr, ptr }, ptr %local_0, align 8
+  store i64 %closure_call_result, ptr %local_2, align 8
+  %closure_pair_load1 = load { ptr, ptr }, ptr %local_0, align 4
   %closure_fn_extract2 = extractvalue { ptr, ptr } %closure_pair_load1, 0
   %closure_env_extract3 = extractvalue { ptr, ptr } %closure_pair_load1, 1
-  %closure_call_arg4 = load i64, ptr %local_2, align 4
+  %closure_call_arg4 = load i64, ptr %local_2, align 8
   %closure_call_result5 = call i64 %closure_fn_extract2(ptr %closure_call_fallback_ctx, ptr %closure_env_extract3, i64 %closure_call_arg4)
-  store i64 %closure_call_result5, ptr %local_3, align 4
-  %move_load = load i64, ptr %local_3, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  store i64 %closure_call_result5, ptr %local_3, align 8
+  %move_load = load i64, ptr %local_3, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
@@ -326,51 +368,51 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca %__hew_closure_env_make_adder_0, align 8
   %local_2 = alloca { ptr, ptr }, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
   %field_0_init_ptr = getelementptr inbounds nuw %__hew_closure_env_make_adder_0, ptr %local_1, i32 0, i32 0
-  %field_0_init_src = load i64, ptr %local_0, align 4
-  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 4
+  %field_0_init_src = load i64, ptr %local_0, align 8
+  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 8
   %closure_env_box = call ptr @hew_dyn_box_alloc(i64 16, i64 8)
-  store ptr @__hew_closure_env_free___hew_closure_invoke_make_adder_0, ptr %closure_env_box, align 8
+  store ptr @__hew_closure_env_free___hew_closure_invoke_make_adder_0, ptr %closure_env_box, align 4
   %closure_env_data = getelementptr inbounds i8, ptr %closure_env_box, i64 8
   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %closure_env_data, ptr align 8 %local_1, i64 8, i1 false)
   %closure_fn_ptr = getelementptr inbounds nuw { ptr, ptr }, ptr %local_2, i32 0, i32 0
   %closure_env_ptr = getelementptr inbounds nuw { ptr, ptr }, ptr %local_2, i32 0, i32 1
-  store ptr @__hew_closure_invoke_make_adder_0, ptr %closure_fn_ptr, align 8
-  store ptr %closure_env_data, ptr %closure_env_ptr, align 8
-  %move_load = load { ptr, ptr }, ptr %local_2, align 8
-  store { ptr, ptr } %move_load, ptr %return_slot, align 8
-  %ret_val = load { ptr, ptr }, ptr %return_slot, align 8
+  store ptr @__hew_closure_invoke_make_adder_0, ptr %closure_fn_ptr, align 4
+  store ptr %closure_env_data, ptr %closure_env_ptr, align 4
+  %move_load = load { ptr, ptr }, ptr %local_2, align 4
+  store { ptr, ptr } %move_load, ptr %return_slot, align 4
+  %ret_val = load { ptr, ptr }, ptr %return_slot, align 4
   ret { ptr, ptr } %ret_val
 }
 
 define internal i64 @__hew_closure_invoke_make_adder_0(ptr %0, ptr %1, i64 %2) {
 entry:
   %return_slot = alloca i64, align 8
-  %local_0 = alloca ptr, align 8
+  %local_0 = alloca ptr, align 4
   %local_1 = alloca i64, align 8
   %local_2 = alloca i64, align 8
   %local_3 = alloca i64, align 8
   %local_4 = alloca i8, align 1
-  store ptr %1, ptr %local_0, align 8
-  store i64 %2, ptr %local_1, align 4
+  store ptr %1, ptr %local_0, align 4
+  store i64 %2, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  %closure_env_ptr_load = load ptr, ptr %local_0, align 8
+  %closure_env_ptr_load = load ptr, ptr %local_0, align 4
   %closure_capture_ptr = getelementptr inbounds nuw %__hew_closure_env_make_adder_0, ptr %closure_env_ptr_load, i32 0, i32 0
-  %closure_capture_load = load i64, ptr %closure_capture_ptr, align 4
-  store i64 %closure_capture_load, ptr %local_2, align 4
-  %checked_lhs = load i64, ptr %local_1, align 4
-  %checked_rhs = load i64, ptr %local_2, align 4
+  %closure_capture_load = load i64, ptr %closure_capture_ptr, align 8
+  store i64 %closure_capture_load, ptr %local_2, align 8
+  %checked_lhs = load i64, ptr %local_1, align 8
+  %checked_rhs = load i64, ptr %local_2, align 8
   %with_overflow = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_3, align 4
+  store i64 %checked_result, ptr %local_3, align 8
   store i8 %checked_overflow_widen, ptr %local_4, align 1
   %cond_load = load i8, ptr %local_4, align 1
   %cond_nz = icmp ne i8 %cond_load, 0
@@ -382,9 +424,9 @@ bb1:                                              ; preds = %bb0
   unreachable
 
 bb2:                                              ; preds = %bb0
-  %move_load = load i64, ptr %local_3, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load = load i64, ptr %local_3, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
@@ -394,51 +436,51 @@ entry:
   %local_0 = alloca i64, align 8
   %local_1 = alloca %__hew_closure_env_make_multiplier_0, align 8
   %local_2 = alloca { ptr, ptr }, align 8
-  store i64 %0, ptr %local_0, align 4
+  store i64 %0, ptr %local_0, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
   %field_0_init_ptr = getelementptr inbounds nuw %__hew_closure_env_make_multiplier_0, ptr %local_1, i32 0, i32 0
-  %field_0_init_src = load i64, ptr %local_0, align 4
-  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 4
+  %field_0_init_src = load i64, ptr %local_0, align 8
+  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 8
   %closure_env_box = call ptr @hew_dyn_box_alloc(i64 16, i64 8)
-  store ptr @__hew_closure_env_free___hew_closure_invoke_make_multiplier_0, ptr %closure_env_box, align 8
+  store ptr @__hew_closure_env_free___hew_closure_invoke_make_multiplier_0, ptr %closure_env_box, align 4
   %closure_env_data = getelementptr inbounds i8, ptr %closure_env_box, i64 8
   call void @llvm.memcpy.p0.p0.i64(ptr align 8 %closure_env_data, ptr align 8 %local_1, i64 8, i1 false)
   %closure_fn_ptr = getelementptr inbounds nuw { ptr, ptr }, ptr %local_2, i32 0, i32 0
   %closure_env_ptr = getelementptr inbounds nuw { ptr, ptr }, ptr %local_2, i32 0, i32 1
-  store ptr @__hew_closure_invoke_make_multiplier_0, ptr %closure_fn_ptr, align 8
-  store ptr %closure_env_data, ptr %closure_env_ptr, align 8
-  %move_load = load { ptr, ptr }, ptr %local_2, align 8
-  store { ptr, ptr } %move_load, ptr %return_slot, align 8
-  %ret_val = load { ptr, ptr }, ptr %return_slot, align 8
+  store ptr @__hew_closure_invoke_make_multiplier_0, ptr %closure_fn_ptr, align 4
+  store ptr %closure_env_data, ptr %closure_env_ptr, align 4
+  %move_load = load { ptr, ptr }, ptr %local_2, align 4
+  store { ptr, ptr } %move_load, ptr %return_slot, align 4
+  %ret_val = load { ptr, ptr }, ptr %return_slot, align 4
   ret { ptr, ptr } %ret_val
 }
 
 define internal i64 @__hew_closure_invoke_make_multiplier_0(ptr %0, ptr %1, i64 %2) {
 entry:
   %return_slot = alloca i64, align 8
-  %local_0 = alloca ptr, align 8
+  %local_0 = alloca ptr, align 4
   %local_1 = alloca i64, align 8
   %local_2 = alloca i64, align 8
   %local_3 = alloca i64, align 8
   %local_4 = alloca i8, align 1
-  store ptr %1, ptr %local_0, align 8
-  store i64 %2, ptr %local_1, align 4
+  store ptr %1, ptr %local_0, align 4
+  store i64 %2, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  %closure_env_ptr_load = load ptr, ptr %local_0, align 8
+  %closure_env_ptr_load = load ptr, ptr %local_0, align 4
   %closure_capture_ptr = getelementptr inbounds nuw %__hew_closure_env_make_multiplier_0, ptr %closure_env_ptr_load, i32 0, i32 0
-  %closure_capture_load = load i64, ptr %closure_capture_ptr, align 4
-  store i64 %closure_capture_load, ptr %local_2, align 4
-  %checked_lhs = load i64, ptr %local_1, align 4
-  %checked_rhs = load i64, ptr %local_2, align 4
+  %closure_capture_load = load i64, ptr %closure_capture_ptr, align 8
+  store i64 %closure_capture_load, ptr %local_2, align 8
+  %checked_lhs = load i64, ptr %local_1, align 8
+  %checked_rhs = load i64, ptr %local_2, align 8
   %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_3, align 4
+  store i64 %checked_result, ptr %local_3, align 8
   store i8 %checked_overflow_widen, ptr %local_4, align 1
   %cond_load = load i8, ptr %local_4, align 1
   %cond_nz = icmp ne i8 %cond_load, 0
@@ -450,17 +492,17 @@ bb1:                                              ; preds = %bb0
   unreachable
 
 bb2:                                              ; preds = %bb0
-  %move_load = load i64, ptr %local_3, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load = load i64, ptr %local_3, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
-define i8 @main() {
+define i8 @__original_main() {
 entry:
   %return_slot = alloca i8, align 1
   %closure_call_fallback_ctx = alloca [16 x i64], align 8
-  store [16 x i64] zeroinitializer, ptr %closure_call_fallback_ctx, align 4
+  store [16 x i64] zeroinitializer, ptr %closure_call_fallback_ctx, align 8
   %local_0 = alloca %__hew_closure_env_main_0, align 8
   %local_1 = alloca { ptr, ptr }, align 8
   %local_2 = alloca { ptr, ptr }, align 8
@@ -494,113 +536,113 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %closure_fn_ptr = getelementptr inbounds nuw { ptr, ptr }, ptr %local_1, i32 0, i32 0
   %closure_env_ptr = getelementptr inbounds nuw { ptr, ptr }, ptr %local_1, i32 0, i32 1
-  store ptr @__hew_closure_invoke_main_0, ptr %closure_fn_ptr, align 8
-  store ptr null, ptr %closure_env_ptr, align 8
-  %move_load = load { ptr, ptr }, ptr %local_1, align 8
-  store { ptr, ptr } %move_load, ptr %local_2, align 8
-  store i64 21, ptr %local_3, align 4
-  %call_arg = load { ptr, ptr }, ptr %local_2, align 8
-  %call_arg1 = load i64, ptr %local_3, align 4
+  store ptr @__hew_closure_invoke_main_0, ptr %closure_fn_ptr, align 4
+  store ptr null, ptr %closure_env_ptr, align 4
+  %move_load = load { ptr, ptr }, ptr %local_1, align 4
+  store { ptr, ptr } %move_load, ptr %local_2, align 4
+  store i64 21, ptr %local_3, align 8
+  %call_arg = load { ptr, ptr }, ptr %local_2, align 4
+  %call_arg1 = load i64, ptr %local_3, align 8
   %call_result = call i64 @apply({ ptr, ptr } %call_arg, i64 %call_arg1)
-  store i64 %call_result, ptr %local_4, align 4
+  store i64 %call_result, ptr %local_4, align 8
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %print_arg = load i64, ptr %local_4, align 4
+  %print_arg = load i64, ptr %local_4, align 8
   call void @hew_print_value(i8 1, i64 %print_arg, i1 true)
   br label %bb2
 
 bb2:                                              ; preds = %bb1
-  store i64 3, ptr %local_5, align 4
-  %call_arg2 = load { ptr, ptr }, ptr %local_2, align 8
-  %call_arg3 = load i64, ptr %local_5, align 4
+  store i64 3, ptr %local_5, align 8
+  %call_arg2 = load { ptr, ptr }, ptr %local_2, align 4
+  %call_arg3 = load i64, ptr %local_5, align 8
   %call_result4 = call i64 @apply_twice({ ptr, ptr } %call_arg2, i64 %call_arg3)
-  store i64 %call_result4, ptr %local_6, align 4
+  store i64 %call_result4, ptr %local_6, align 8
   br label %bb3
 
 bb3:                                              ; preds = %bb2
-  %print_arg5 = load i64, ptr %local_6, align 4
+  %print_arg5 = load i64, ptr %local_6, align 8
   call void @hew_print_value(i8 1, i64 %print_arg5, i1 true)
   br label %bb4
 
 bb4:                                              ; preds = %bb3
-  store i64 10, ptr %local_7, align 4
-  %call_arg6 = load i64, ptr %local_7, align 4
+  store i64 10, ptr %local_7, align 8
+  %call_arg6 = load i64, ptr %local_7, align 8
   %call_result7 = call { ptr, ptr } @make_adder(i64 %call_arg6)
-  store { ptr, ptr } %call_result7, ptr %local_8, align 8
+  store { ptr, ptr } %call_result7, ptr %local_8, align 4
   br label %bb5
 
 bb5:                                              ; preds = %bb4
-  %move_load8 = load { ptr, ptr }, ptr %local_8, align 8
-  store { ptr, ptr } %move_load8, ptr %local_9, align 8
-  store i64 32, ptr %local_10, align 4
-  %closure_pair_load = load { ptr, ptr }, ptr %local_9, align 8
+  %move_load8 = load { ptr, ptr }, ptr %local_8, align 4
+  store { ptr, ptr } %move_load8, ptr %local_9, align 4
+  store i64 32, ptr %local_10, align 8
+  %closure_pair_load = load { ptr, ptr }, ptr %local_9, align 4
   %closure_fn_extract = extractvalue { ptr, ptr } %closure_pair_load, 0
   %closure_env_extract = extractvalue { ptr, ptr } %closure_pair_load, 1
-  %closure_call_arg = load i64, ptr %local_10, align 4
+  %closure_call_arg = load i64, ptr %local_10, align 8
   %closure_call_result = call i64 %closure_fn_extract(ptr %closure_call_fallback_ctx, ptr %closure_env_extract, i64 %closure_call_arg)
-  store i64 %closure_call_result, ptr %local_11, align 4
-  %print_arg9 = load i64, ptr %local_11, align 4
+  store i64 %closure_call_result, ptr %local_11, align 8
+  %print_arg9 = load i64, ptr %local_11, align 8
   call void @hew_print_value(i8 1, i64 %print_arg9, i1 true)
   br label %bb6
 
 bb6:                                              ; preds = %bb5
-  store i64 3, ptr %local_12, align 4
-  %call_arg10 = load i64, ptr %local_12, align 4
+  store i64 3, ptr %local_12, align 8
+  %call_arg10 = load i64, ptr %local_12, align 8
   %call_result11 = call { ptr, ptr } @make_multiplier(i64 %call_arg10)
-  store { ptr, ptr } %call_result11, ptr %local_13, align 8
+  store { ptr, ptr } %call_result11, ptr %local_13, align 4
   br label %bb7
 
 bb7:                                              ; preds = %bb6
-  %move_load12 = load { ptr, ptr }, ptr %local_13, align 8
-  store { ptr, ptr } %move_load12, ptr %local_14, align 8
-  store i64 7, ptr %local_15, align 4
-  %call_arg13 = load { ptr, ptr }, ptr %local_14, align 8
-  %call_arg14 = load i64, ptr %local_15, align 4
+  %move_load12 = load { ptr, ptr }, ptr %local_13, align 4
+  store { ptr, ptr } %move_load12, ptr %local_14, align 4
+  store i64 7, ptr %local_15, align 8
+  %call_arg13 = load { ptr, ptr }, ptr %local_14, align 4
+  %call_arg14 = load i64, ptr %local_15, align 8
   %call_result15 = call i64 @apply({ ptr, ptr } %call_arg13, i64 %call_arg14)
-  store i64 %call_result15, ptr %local_16, align 4
+  store i64 %call_result15, ptr %local_16, align 8
   br label %bb8
 
 bb8:                                              ; preds = %bb7
-  %print_arg16 = load i64, ptr %local_16, align 4
+  %print_arg16 = load i64, ptr %local_16, align 8
   call void @hew_print_value(i8 1, i64 %print_arg16, i1 true)
   br label %bb9
 
 bb9:                                              ; preds = %bb8
-  store i64 100, ptr %local_17, align 4
-  %move_load17 = load i64, ptr %local_17, align 4
-  store i64 %move_load17, ptr %local_18, align 4
-  store i64 5, ptr %local_19, align 4
-  %move_load18 = load i64, ptr %local_19, align 4
-  store i64 %move_load18, ptr %local_20, align 4
+  store i64 100, ptr %local_17, align 8
+  %move_load17 = load i64, ptr %local_17, align 8
+  store i64 %move_load17, ptr %local_18, align 8
+  store i64 5, ptr %local_19, align 8
+  %move_load18 = load i64, ptr %local_19, align 8
+  store i64 %move_load18, ptr %local_20, align 8
   %field_0_init_ptr = getelementptr inbounds nuw %__hew_closure_env_main_1, ptr %local_21, i32 0, i32 0
-  %field_0_init_src = load i64, ptr %local_18, align 4
-  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 4
+  %field_0_init_src = load i64, ptr %local_18, align 8
+  store i64 %field_0_init_src, ptr %field_0_init_ptr, align 8
   %field_1_init_ptr = getelementptr inbounds nuw %__hew_closure_env_main_1, ptr %local_21, i32 0, i32 1
-  %field_1_init_src = load i64, ptr %local_20, align 4
-  store i64 %field_1_init_src, ptr %field_1_init_ptr, align 4
+  %field_1_init_src = load i64, ptr %local_20, align 8
+  store i64 %field_1_init_src, ptr %field_1_init_ptr, align 8
   %closure_fn_ptr19 = getelementptr inbounds nuw { ptr, ptr }, ptr %local_22, i32 0, i32 0
   %closure_env_ptr20 = getelementptr inbounds nuw { ptr, ptr }, ptr %local_22, i32 0, i32 1
-  store ptr @__hew_closure_invoke_main_1, ptr %closure_fn_ptr19, align 8
-  store ptr %local_21, ptr %closure_env_ptr20, align 8
-  %move_load21 = load { ptr, ptr }, ptr %local_22, align 8
-  store { ptr, ptr } %move_load21, ptr %local_23, align 8
-  store i64 4, ptr %local_24, align 4
-  %closure_pair_load22 = load { ptr, ptr }, ptr %local_23, align 8
+  store ptr @__hew_closure_invoke_main_1, ptr %closure_fn_ptr19, align 4
+  store ptr %local_21, ptr %closure_env_ptr20, align 4
+  %move_load21 = load { ptr, ptr }, ptr %local_22, align 4
+  store { ptr, ptr } %move_load21, ptr %local_23, align 4
+  store i64 4, ptr %local_24, align 8
+  %closure_pair_load22 = load { ptr, ptr }, ptr %local_23, align 4
   %closure_fn_extract23 = extractvalue { ptr, ptr } %closure_pair_load22, 0
   %closure_env_extract24 = extractvalue { ptr, ptr } %closure_pair_load22, 1
-  %closure_call_arg25 = load i64, ptr %local_24, align 4
+  %closure_call_arg25 = load i64, ptr %local_24, align 8
   %closure_call_result26 = call i64 %closure_fn_extract23(ptr %closure_call_fallback_ctx, ptr %closure_env_extract24, i64 %closure_call_arg25)
-  store i64 %closure_call_result26, ptr %local_25, align 4
-  %print_arg27 = load i64, ptr %local_25, align 4
+  store i64 %closure_call_result26, ptr %local_25, align 8
+  %print_arg27 = load i64, ptr %local_25, align 8
   call void @hew_print_value(i8 1, i64 %print_arg27, i1 true)
   br label %bb10
 
 bb10:                                             ; preds = %bb9
   %closure_drop_env_slot = getelementptr inbounds nuw { ptr, ptr }, ptr %local_9, i32 0, i32 1
-  %closure_drop_env = load ptr, ptr %closure_drop_env_slot, align 8
-  %closure_env_is_null = icmp eq ptr %closure_drop_env, null
-  br i1 %closure_env_is_null, label %closure_env_drop_cont, label %closure_env_free
+  %closure_drop_env = load ptr, ptr %closure_drop_env_slot, align 4
+  %closure_drop_env_is_null = icmp eq ptr %closure_drop_env, null
+  br i1 %closure_drop_env_is_null, label %closure_drop_closure_env_drop_cont, label %closure_drop_closure_env_free
 
 cancel_exit:                                      ; preds = %entry
   ret i8 0
@@ -608,39 +650,38 @@ cancel_exit:                                      ; preds = %entry
 after_cooperate:                                  ; preds = %entry
   br label %bb0
 
-closure_env_free:                                 ; preds = %bb10
-  %closure_env_thunk_slot = getelementptr inbounds i8, ptr %closure_drop_env, i64 -8
-  %closure_env_free_thunk = load ptr, ptr %closure_env_thunk_slot, align 8
-  call void %closure_env_free_thunk(ptr %closure_drop_env)
-  store ptr null, ptr %closure_drop_env_slot, align 8
-  br label %closure_env_drop_cont
+closure_drop_closure_env_free:                    ; preds = %bb10
+  %closure_drop_env_thunk_slot = getelementptr inbounds i8, ptr %closure_drop_env, i64 -8
+  %closure_drop_env_free_thunk = load ptr, ptr %closure_drop_env_thunk_slot, align 4
+  call void %closure_drop_env_free_thunk(ptr %closure_drop_env)
+  store ptr null, ptr %closure_drop_env_slot, align 4
+  br label %closure_drop_closure_env_drop_cont
 
-closure_env_drop_cont:                            ; preds = %closure_env_free, %bb10
-  %hew_lambda_drain_all_call = call i32 @hew_lambda_drain_all(i64 0)
+closure_drop_closure_env_drop_cont:               ; preds = %closure_drop_closure_env_free, %bb10
   ret i8 0
 }
 
 define internal i64 @__hew_closure_invoke_main_0(ptr %0, ptr %1, i64 %2) {
 entry:
   %return_slot = alloca i64, align 8
-  %local_0 = alloca ptr, align 8
+  %local_0 = alloca ptr, align 4
   %local_1 = alloca i64, align 8
   %local_2 = alloca i64, align 8
   %local_3 = alloca i64, align 8
   %local_4 = alloca i8, align 1
-  store ptr %1, ptr %local_0, align 8
-  store i64 %2, ptr %local_1, align 4
+  store ptr %1, ptr %local_0, align 4
+  store i64 %2, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  store i64 2, ptr %local_2, align 4
-  %checked_lhs = load i64, ptr %local_1, align 4
-  %checked_rhs = load i64, ptr %local_2, align 4
+  store i64 2, ptr %local_2, align 8
+  %checked_lhs = load i64, ptr %local_1, align 8
+  %checked_rhs = load i64, ptr %local_2, align 8
   %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_3, align 4
+  store i64 %checked_result, ptr %local_3, align 8
   store i8 %checked_overflow_widen, ptr %local_4, align 1
   %cond_load = load i8, ptr %local_4, align 1
   %cond_nz = icmp ne i8 %cond_load, 0
@@ -652,16 +693,16 @@ bb1:                                              ; preds = %bb0
   unreachable
 
 bb2:                                              ; preds = %bb0
-  %move_load = load i64, ptr %local_3, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load = load i64, ptr %local_3, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
 }
 
 define internal i64 @__hew_closure_invoke_main_1(ptr %0, ptr %1, i64 %2) {
 entry:
   %return_slot = alloca i64, align 8
-  %local_0 = alloca ptr, align 8
+  %local_0 = alloca ptr, align 4
   %local_1 = alloca i64, align 8
   %local_2 = alloca i64, align 8
   %local_3 = alloca i64, align 8
@@ -669,26 +710,26 @@ entry:
   %local_5 = alloca i8, align 1
   %local_6 = alloca i64, align 8
   %local_7 = alloca i8, align 1
-  store ptr %1, ptr %local_0, align 8
-  store i64 %2, ptr %local_1, align 4
+  store ptr %1, ptr %local_0, align 4
+  store i64 %2, ptr %local_1, align 8
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  %closure_env_ptr_load = load ptr, ptr %local_0, align 8
+  %closure_env_ptr_load = load ptr, ptr %local_0, align 4
   %closure_capture_ptr = getelementptr inbounds nuw %__hew_closure_env_main_1, ptr %closure_env_ptr_load, i32 0, i32 0
-  %closure_capture_load = load i64, ptr %closure_capture_ptr, align 4
-  store i64 %closure_capture_load, ptr %local_2, align 4
-  %closure_env_ptr_load1 = load ptr, ptr %local_0, align 8
+  %closure_capture_load = load i64, ptr %closure_capture_ptr, align 8
+  store i64 %closure_capture_load, ptr %local_2, align 8
+  %closure_env_ptr_load1 = load ptr, ptr %local_0, align 4
   %closure_capture_ptr2 = getelementptr inbounds nuw %__hew_closure_env_main_1, ptr %closure_env_ptr_load1, i32 0, i32 1
-  %closure_capture_load3 = load i64, ptr %closure_capture_ptr2, align 4
-  store i64 %closure_capture_load3, ptr %local_3, align 4
-  %checked_lhs = load i64, ptr %local_1, align 4
-  %checked_rhs = load i64, ptr %local_3, align 4
+  %closure_capture_load3 = load i64, ptr %closure_capture_ptr2, align 8
+  store i64 %closure_capture_load3, ptr %local_3, align 8
+  %checked_lhs = load i64, ptr %local_1, align 8
+  %checked_rhs = load i64, ptr %local_3, align 8
   %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
   %checked_result = extractvalue { i64, i1 } %with_overflow, 0
   %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
   %checked_overflow_widen = zext i1 %checked_overflow to i8
-  store i64 %checked_result, ptr %local_4, align 4
+  store i64 %checked_result, ptr %local_4, align 8
   store i8 %checked_overflow_widen, ptr %local_5, align 1
   %cond_load = load i8, ptr %local_5, align 1
   %cond_nz = icmp ne i8 %cond_load, 0
@@ -700,13 +741,13 @@ bb1:                                              ; preds = %bb0
   unreachable
 
 bb2:                                              ; preds = %bb0
-  %checked_lhs4 = load i64, ptr %local_2, align 4
-  %checked_rhs5 = load i64, ptr %local_4, align 4
+  %checked_lhs4 = load i64, ptr %local_2, align 8
+  %checked_rhs5 = load i64, ptr %local_4, align 8
   %with_overflow6 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %checked_lhs4, i64 %checked_rhs5)
   %checked_result7 = extractvalue { i64, i1 } %with_overflow6, 0
   %checked_overflow8 = extractvalue { i64, i1 } %with_overflow6, 1
   %checked_overflow_widen9 = zext i1 %checked_overflow8 to i8
-  store i64 %checked_result7, ptr %local_6, align 4
+  store i64 %checked_result7, ptr %local_6, align 8
   store i8 %checked_overflow_widen9, ptr %local_7, align 1
   %cond_load10 = load i8, ptr %local_7, align 1
   %cond_nz11 = icmp ne i8 %cond_load10, 0
@@ -718,17 +759,83 @@ bb3:                                              ; preds = %bb2
   unreachable
 
 bb4:                                              ; preds = %bb2
-  %move_load = load i64, ptr %local_6, align 4
-  store i64 %move_load, ptr %return_slot, align 4
-  %ret_val = load i64, ptr %return_slot, align 4
+  %move_load = load i64, ptr %local_6, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
   ret i64 %ret_val
+}
+
+define internal ptr @"i8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 4
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i8, ptr %local_0, align 1
+  %cast_int_sext = sext i8 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"i16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca i32, align 4
+  %local_2 = alloca ptr, align 4
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i16, ptr %local_0, align 2
+  %cast_int_sext = sext i16 %cast_int_src to i32
+  store i32 %cast_int_sext, ptr %local_1, align 4
+  %call_arg = load i32, ptr %local_1, align 4
+  %call_result = call ptr @hew_int_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
 }
 
 define internal ptr @"i32::fmt"(i32 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i32, align 4
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i32 %0, ptr %local_0, align 4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -737,13 +844,13 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
   %call_result = call ptr @hew_int_to_string(i32 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -755,24 +862,83 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"i64::fmt"(i64 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i64, align 8
-  %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  %local_1 = alloca ptr, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u8::fmt"(i8 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i8, align 1
+  %local_1 = alloca ptr, align 4
+  store i8 %0, ptr %local_0, align 1
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i8, ptr %local_0, align 1
+  %call_result = call ptr @hew_u8_to_string(i8 %call_arg)
+  store ptr %call_result, ptr %local_1, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"u16::fmt"(i16 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i16, align 2
+  %local_1 = alloca ptr, align 4
+  store i16 %0, ptr %local_0, align 2
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %call_arg = load i16, ptr %local_0, align 2
+  %ffi_zext = zext i16 %call_arg to i32
+  %call_result = call ptr @hew_uint_to_string(i32 %ffi_zext)
+  store ptr %call_result, ptr %local_1, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -784,9 +950,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"u32::fmt"(i32 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i32, align 4
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i32 %0, ptr %local_0, align 4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -794,15 +960,14 @@ entry:
 
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
-  %ffi_arg_trunc = trunc i32 %call_arg to i16
-  %call_result = call ptr @hew_uint_to_string(i16 %ffi_arg_trunc)
-  store ptr %call_result, ptr %local_1, align 8
+  %call_result = call ptr @hew_uint_to_string(i32 %call_arg)
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -814,24 +979,90 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"u64::fmt"(i64 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i64, align 8
-  %local_1 = alloca ptr, align 8
-  store i64 %0, ptr %local_0, align 4
+  %local_1 = alloca ptr, align 4
+  store i64 %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
   br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
 
 bb0:                                              ; preds = %after_cooperate
-  %call_arg = load i64, ptr %local_0, align 4
+  %call_arg = load i64, ptr %local_0, align 8
   %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"isize::fmt"(i32 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 4
+  store i32 %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i32, ptr %local_0, align 4
+  %cast_int_sext = sext i32 %cast_int_src to i64
+  store i64 %cast_int_sext, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"usize::fmt"(i32 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i32, align 4
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 4
+  store i32 %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_int_src = load i32, ptr %local_0, align 4
+  %cast_int_zext = zext i32 %cast_int_src to i64
+  store i64 %cast_int_zext, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_u64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -843,9 +1074,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"bool::fmt"(i8 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i8, align 1
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i8 %0, ptr %local_0, align 1
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -854,13 +1085,13 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i8, ptr %local_0, align 1
   %call_result = call ptr @hew_bool_to_string(i8 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -872,9 +1103,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"char::fmt"(i32 %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca i32, align 4
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store i32 %0, ptr %local_0, align 4
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -883,13 +1114,13 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load i32, ptr %local_0, align 4
   %call_result = call ptr @hew_char_to_string(i32 %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -901,9 +1132,9 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"f64::fmt"(double %0) {
 entry:
-  %return_slot = alloca ptr, align 8
+  %return_slot = alloca ptr, align 4
   %local_0 = alloca double, align 8
-  %local_1 = alloca ptr, align 8
+  %local_1 = alloca ptr, align 4
   store double %0, ptr %local_0, align 8
   %hew_actor_cooperate = call i32 @hew_actor_cooperate()
   %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
@@ -912,13 +1143,46 @@ entry:
 bb0:                                              ; preds = %after_cooperate
   %call_arg = load double, ptr %local_0, align 8
   %call_result = call ptr @hew_float_to_string(double %call_arg)
-  store ptr %call_result, ptr %local_1, align 8
+  store ptr %call_result, ptr %local_1, align 4
   br label %bb1
 
 bb1:                                              ; preds = %bb0
-  %move_load = load ptr, ptr %local_1, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %move_load = load ptr, ptr %local_1, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define internal ptr @"f32::fmt"(float %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca float, align 4
+  %local_1 = alloca double, align 8
+  %local_2 = alloca ptr, align 4
+  store float %0, ptr %local_0, align 4
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %cast_float_src = load float, ptr %local_0, align 4
+  %cast_float_ext = fpext float %cast_float_src to double
+  store double %cast_float_ext, ptr %local_1, align 8
+  %call_arg = load double, ptr %local_1, align 8
+  %call_result = call ptr @hew_float_to_string(double %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  %move_load = load ptr, ptr %local_2, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
 
 cancel_exit:                                      ; preds = %entry
@@ -930,16 +1194,276 @@ after_cooperate:                                  ; preds = %entry
 
 define internal ptr @"string::fmt"(ptr %0) {
 entry:
-  %return_slot = alloca ptr, align 8
-  %local_0 = alloca ptr, align 8
-  store ptr %0, ptr %local_0, align 8
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca ptr, align 4
+  store ptr %0, ptr %local_0, align 4
   br label %bb0
 
 bb0:                                              ; preds = %entry
-  %move_load = load ptr, ptr %local_0, align 8
-  store ptr %move_load, ptr %return_slot, align 8
-  %ret_val = load ptr, ptr %return_slot, align 8
+  %mir_share_string_load = load ptr, ptr %local_0, align 4
+  %mir_share_string_retain = call ptr @hew_string_clone(ptr %mir_share_string_load)
+  %move_load = load ptr, ptr %local_0, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
   ret ptr %ret_val
+}
+
+define internal i64 @"duration::from_nanos"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_micros"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_millis"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal i64 @"duration::from_secs"(i64 %0) {
+entry:
+  %return_slot = alloca i64, align 8
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca i64, align 8
+  %local_3 = alloca i8, align 1
+  store i64 %0, ptr %local_0, align 8
+  br label %bb0
+
+bb0:                                              ; preds = %entry
+  store i64 1000000000, ptr %local_1, align 8
+  %checked_lhs = load i64, ptr %local_0, align 8
+  %checked_rhs = load i64, ptr %local_1, align 8
+  %with_overflow = call { i64, i1 } @llvm.smul.with.overflow.i64(i64 %checked_lhs, i64 %checked_rhs)
+  %checked_result = extractvalue { i64, i1 } %with_overflow, 0
+  %checked_overflow = extractvalue { i64, i1 } %with_overflow, 1
+  %checked_overflow_widen = zext i1 %checked_overflow to i8
+  store i64 %checked_result, ptr %local_2, align 8
+  store i8 %checked_overflow_widen, ptr %local_3, align 1
+  %cond_load = load i8, ptr %local_3, align 1
+  %cond_nz = icmp ne i8 %cond_load, 0
+  br i1 %cond_nz, label %bb1, label %bb2
+
+bb1:                                              ; preds = %bb0
+  call void @hew_trap_with_code(i32 201)
+  call void @llvm.trap()
+  unreachable
+
+bb2:                                              ; preds = %bb0
+  %move_load = load i64, ptr %local_2, align 8
+  store i64 %move_load, ptr %return_slot, align 8
+  %ret_val = load i64, ptr %return_slot, align 8
+  ret i64 %ret_val
+}
+
+define internal ptr @"duration::fmt"(i64 %0) {
+entry:
+  %return_slot = alloca ptr, align 4
+  %local_0 = alloca i64, align 8
+  %local_1 = alloca i64, align 8
+  %local_2 = alloca ptr, align 4
+  %local_3 = alloca ptr, align 4
+  %local_4 = alloca ptr, align 4
+  store i64 %0, ptr %local_0, align 8
+  %hew_actor_cooperate = call i32 @hew_actor_cooperate()
+  %hew_cooperate_is_cancel = icmp eq i32 %hew_actor_cooperate, 2
+  br i1 %hew_cooperate_is_cancel, label %cancel_exit, label %after_cooperate
+
+bb0:                                              ; preds = %after_cooperate
+  %hew_duration_nanos = load i64, ptr %local_0, align 8
+  %hew_duration_nanos_call = call i64 @hew_duration_nanos(i64 %hew_duration_nanos)
+  store i64 %hew_duration_nanos_call, ptr %local_1, align 8
+  %call_arg = load i64, ptr %local_1, align 8
+  %call_result = call ptr @hew_i64_to_string(i64 %call_arg)
+  store ptr %call_result, ptr %local_2, align 4
+  br label %bb1
+
+bb1:                                              ; preds = %bb0
+  store ptr @str_lit, ptr %local_3, align 4
+  %"hew_string_concat arg0" = load ptr, ptr %local_2, align 4
+  %"hew_string_concat arg1" = load ptr, ptr %local_3, align 4
+  %hew_string_concat_call = call ptr @hew_string_concat(ptr %"hew_string_concat arg0", ptr %"hew_string_concat arg1")
+  store ptr %hew_string_concat_call, ptr %local_4, align 4
+  %"hew_string_drop drop" = load ptr, ptr %local_2, align 4
+  call void @hew_string_drop(ptr %"hew_string_drop drop")
+  store ptr null, ptr %local_2, align 4
+  %move_load = load ptr, ptr %local_4, align 4
+  store ptr %move_load, ptr %return_slot, align 4
+  %ret_val = load ptr, ptr %return_slot, align 4
+  ret ptr %ret_val
+
+cancel_exit:                                      ; preds = %entry
+  ret ptr null
+
+after_cooperate:                                  ; preds = %entry
+  br label %bb0
+}
+
+define i8 @main() {
+entry:
+  %__original_main_call = call i8 @__original_main()
+  ret i8 %__original_main_call
+}
+
+define internal i32 @__hew_record_clone_inplace_CrashInfo(ptr %0, ptr %1) {
+entry:
+  br label %step_0_clone
+
+success:                                          ; preds = %step_0_store
+  ret i32 0
+
+fail:                                             ; preds = %rb_step_0
+  ret i32 1
+
+rb_step_0:                                        ; preds = %step_0_clone
+  br label %fail
+
+step_0_store:                                     ; preds = %step_0_clone
+  %dst_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  store ptr %clone_helper_f1, ptr %dst_f1_ptr, align 4
+  br label %success
+
+step_0_clone:                                     ; preds = %entry
+  %src_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %src_f1 = load ptr, ptr %src_f1_ptr, align 4
+  %clone_helper_f1 = call ptr @hew_string_clone(ptr %src_f1)
+  %cloned_f1_int = ptrtoint ptr %clone_helper_f1 to i64
+  %cloned_f1_null = icmp eq i64 %cloned_f1_int, 0
+  br i1 %cloned_f1_null, label %rb_step_0, label %step_0_store
+}
+
+define internal void @__hew_record_drop_inplace_CrashInfo(ptr %0) {
+entry:
+  %rec_int = ptrtoint ptr %0 to i64
+  %rec_is_null = icmp eq i64 %rec_int, 0
+  br i1 %rec_is_null, label %done, label %do_drop
+
+do_drop:                                          ; preds = %entry
+  %drop_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %drop_f1 = load ptr, ptr %drop_f1_ptr, align 4
+  call void @hew_string_drop(ptr %drop_f1)
+  br label %done
+
+done:                                             ; preds = %do_drop, %entry
+  ret void
+}
+
+declare void @hew_string_drop(ptr)
+
+define internal void @__hew_record_overwrite_release_CrashInfo(ptr %0, ptr %1) {
+entry:
+  %ow_slot_0 = alloca ptr, align 4
+  store ptr null, ptr %ow_slot_0, align 4
+  %ow_new_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %1, i32 0, i32 1
+  %ow_new_d0_f1_leaf = load ptr, ptr %ow_new_d0_f1_ptr, align 4
+  store ptr %ow_new_d0_f1_leaf, ptr %ow_slot_0, align 4
+  %ow_old_d0_f1_ptr = getelementptr inbounds nuw %CrashInfo, ptr %0, i32 0, i32 1
+  %ow_old_d0_f1_val = load ptr, ptr %ow_old_d0_f1_ptr, align 4
+  %ow_old_d0_f1_int = ptrtoint ptr %ow_old_d0_f1_val to i64
+  %ow_old_d0_f1_cmp0_leaf = load ptr, ptr %ow_slot_0, align 4
+  %ow_old_d0_f1_cmp0_int = ptrtoint ptr %ow_old_d0_f1_cmp0_leaf to i64
+  %ow_old_d0_f1_cmp0_eq = icmp eq i64 %ow_old_d0_f1_int, %ow_old_d0_f1_cmp0_int
+  %ow_old_d0_f1_matched0 = or i1 false, %ow_old_d0_f1_cmp0_eq
+  %ow_old_d0_f1_neutralized = select i1 %ow_old_d0_f1_matched0, ptr null, ptr %ow_old_d0_f1_val
+  store ptr %ow_old_d0_f1_neutralized, ptr %ow_old_d0_f1_ptr, align 4
+  call void @__hew_record_drop_inplace_CrashInfo(ptr %0)
+  ret void
 }
 
 declare ptr @hew_dyn_box_alloc(i64, i64)
@@ -975,8 +1499,6 @@ entry:
 declare { i64, i1 } @llvm.smul.with.overflow.i64(i64, i64) #1
 
 declare i32 @hew_actor_cooperate()
-
-declare i32 @hew_lambda_drain_all(i64)
 
 attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 attributes #1 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }


### PR DESCRIPTION
## Summary

The `ll-oracle` byte-identity goldens were over 100 commits stale against the current compiler, so I regenerated all 10 (5 fixtures x native+wasm32). Every delta traces to benign intervening changes: i64 load/store alignment tightening from 4 to 8 in `r4_suspend` (matches the true 8-byte slot alignment), the A240 string-COW retain-on-share pattern in `string::fmt` and the generated record clone/drop helpers, a new `msg_sys_exit_unhandled` actor dispatch arm, a CBOR deserialize rename, and narrowing of unused runtime-ABI `declare` lines. No double-free, missing-drop, undef, or missing-terminator shapes anywhere in the corpus.

I also wired `make ll-diff` into CI — it existed as a make target but was never invoked, so it could never catch a real regression. It's now in the build-and-test job (after MIR verification), mirrored into `CI_REQUIRED_CHECKS`, the fallback preflight lane, and given a 45s timeout floor. A normaliser self-test now runs in the lint job to prove the oracle still catches real IR and string-content changes rather than being a silent no-op.

## Verification

- `make ll-diff`: 5 fixtures x native + 5 fixtures x wasm32, all byte-identical against the freshly built compiler
- `scripts/check-preflight-ci-parity.sh`: 17/17 fallback-lane parity, 12/12 CI-step coverage, 5/5 lane-to-gate assertions, all pass
- `scripts/ll-identity-selftest.sh`: 6/6 pass
- `make leak-scan` (source + commit messages): pass
- Native fixtures compile and link to executables during the corpus run, exercising LLVM's real backend, not just `llvm-as`

## Out of scope

- Local wasm32 native linking (`rust-lld` missing from PATH) is an environmental gap in this dev machine, not the gate; CI has the linker and the `.ll` emission/diff step (which is what this gate actually checks) is unaffected.

Fixes #2644