### PR TITLE
ci: rebalance the O2 differential gate for velocity and validity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,13 @@ jobs:
       # platform_full additionally promotes those platform jobs to the full
       # workspace nextest when a change can touch native linking / ABI /
       # toolchain. playground drives the browser WASM job.
-      # Build & test (Linux) runs unconditionally on every push/PR.
+      # The lightweight docs/scripts gate is always reported, and its steps
+      # select coverage from these two outputs.
       platform_smoke: ${{ steps.filter.outputs.platform_smoke }}
       platform_full: ${{ steps.filter.outputs.platform_full }}
       playground: ${{ steps.filter.outputs.playground }}
+      docs: ${{ steps.filter.outputs.docs }}
+      scripts: ${{ steps.filter.outputs.scripts }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
@@ -108,6 +111,41 @@ jobs:
               - 'Cargo.lock'
               - 'Makefile'
               - '.github/workflows/ci.yml'
+            docs:
+              - 'docs/**'
+            scripts:
+              - 'scripts/**'
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Lightweight docs/scripts coverage — required signal for narrow PRs.
+  # ─────────────────────────────────────────────────────────────────────────
+  docs-and-scripts:
+    name: Docs & scripts gates
+    needs: changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: No-op when docs and scripts are unchanged
+        if: needs.changes.outputs.docs != 'true' && needs.changes.outputs.scripts != 'true'
+        run: echo "No docs or scripts changes detected; lightweight gates are not needed."
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.scripts == 'true'
+
+      - uses: ./.github/actions/setup-rust-build
+        if: needs.changes.outputs.docs == 'true'
+        with:
+          cache-shared-key: docs-scripts-gates
+
+      # >>> CI-PARITY-STEPS
+      - name: Typecheck documentation fences
+        if: needs.changes.outputs.docs == 'true'
+        run: make test-doc-examples
+
+      - name: Exercise O2 differential gate
+        if: needs.changes.outputs.scripts == 'true'
+        run: make o2-differential-selftest
+      # <<< CI-PARITY-STEPS
 
   # ─────────────────────────────────────────────────────────────────────────
   # Lint — fast feedback on code quality (always runs, ~1.5 min)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
   build-and-test:
     name: Build & test (Linux)
+    needs: changes
     runs-on: ubuntu-24.04
     # Was 60. Successful runs on main land at 51-56 min wall time (checked
     # 2026-07-04 across 5 recent green runs), leaving only 4-9 min of
@@ -306,10 +307,28 @@ jobs:
       # coverage-nightly, sanitizers) that run on runners without mold are
       # unaffected.
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+      # platform_smoke gates the whole Linux build+test required check, same
+      # boundary Windows/macOS already use (ci.yml:547-548,647-648) — it
+      # covers every glob that can affect Linux behaviour ('**/*.rs',
+      # 'tests/**', 'std/**', 'examples/**', 'Cargo.*', 'Makefile', workflow
+      # files), so a docs/comment-only PR (matching none of those globs)
+      # skips this job's ~51-90 min of work. STEP-LEVEL gating, not a
+      # job-level `if:` — a job whose `if:` is false reports skipped/missing,
+      # not a satisfied required context (LESSONS.md
+      # ci-required-gate-sequencing), so every step below carries its own
+      # `if: env.RUN_CODE_PATH == 'true'` and the no-op step below still
+      # reports a green required check on skip.
+      RUN_CODE_PATH: ${{ needs.changes.outputs.platform_smoke }}
     steps:
+      - name: No-op for docs-only changes
+        if: env.RUN_CODE_PATH != 'true'
+        run: echo "No code changes detected; skipping heavy Linux CI while satisfying the required check."
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        if: env.RUN_CODE_PATH == 'true'
 
       - name: Free runner disk
+        if: env.RUN_CODE_PATH == 'true'
         # This job installs LLVM 22.1.5 (~1.5 GB), builds the release hew-runtime
         # + hew-lsp binaries, the wasm32-wasip1 runtime, and runs the full debug
         # workspace nextest suite — all on one ubuntu-24.04 runner (~14 GB free).
@@ -324,24 +343,29 @@ jobs:
           df -h /
 
       - name: Install build tools
+        if: env.RUN_CODE_PATH == 'true'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq libssl-dev pkg-config mold zlib1g-dev libzstd-dev
 
       - name: Install LLVM ${{ env.LLVM_VERSION }}
+        if: env.RUN_CODE_PATH == 'true'
         uses: ./.github/actions/setup-llvm
         with:
           version: ${{ env.LLVM_VERSION }}
 
       - uses: ./.github/actions/setup-rust-build
+        if: env.RUN_CODE_PATH == 'true'
         with:
           tools: nextest
           cache-shared-key: build-test-linux
 
       - name: Build Rust runtime and frontend (release)
+        if: env.RUN_CODE_PATH == 'true'
         run: cargo build -p hew-runtime -p hew-lsp --release
 
       - name: Smoke test hew-lsp
+        if: env.RUN_CODE_PATH == 'true'
         # Drive the shipped release binary through a real initialize → didOpen →
         # publishDiagnostics session, not just --version. HEW_LSP_BIN points the
         # protocol test at the artifact built above.
@@ -351,11 +375,13 @@ jobs:
             cargo nextest run -p hew-lsp --test protocol_smoke
 
       - name: Build WASM runtime
+        if: env.RUN_CODE_PATH == 'true'
         run: |
           rustup target add wasm32-wasip1
           cargo build -p hew-runtime --target wasm32-wasip1 --no-default-features --release
 
       - name: Install wasmtime
+        if: env.RUN_CODE_PATH == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -368,6 +394,7 @@ jobs:
           "./${WASMTIME_DIR}/wasmtime" --version
 
       - name: Run WASM runtime actual-target libtests
+        if: env.RUN_CODE_PATH == 'true'
         env:
           CARGO_TARGET_WASM32_WASIP1_RUNNER: wasmtime run
         run: cargo test -p hew-runtime --target wasm32-wasip1 --no-default-features --lib
@@ -388,6 +415,7 @@ jobs:
       # maintained CI_BUILD_AND_TEST_STEPS list in the parity script is now
       # derived from here instead of a hand-maintained copy.
       - name: Run Rust workspace tests
+        if: env.RUN_CODE_PATH == 'true'
         # line-tables-only: the release build + wasm build + full debug
         # workspace nextest run together leave the runner disk-marginal
         # (ENOSPC twice on this exact job — see PR #1994). Full debug info
@@ -402,12 +430,15 @@ jobs:
           --profile ci
 
       - name: Run vertical-slice end-to-end oracle
+        if: env.RUN_CODE_PATH == 'true'
         run: make test-vertical-slice
 
       - name: Run cross-module package-import oracle
+        if: env.RUN_CODE_PATH == 'true'
         run: make test-pkg-import
 
       - name: Run fuzz-to-run completeness oracle (ratcheted)
+        if: env.RUN_CODE_PATH == 'true'
         # Compiles and runs every checker-valid program in the regressions
         # corpus and the vertical-slice accept fixtures.  Known failures are
         # tracked in tests/fuzz-oracle/expected-failures.txt (ratchet contract:
@@ -417,26 +448,52 @@ jobs:
         run: make fuzz-oracle
 
       - name: Run Hew language test suite (ratcheted)
+        if: env.RUN_CODE_PATH == 'true'
         # Runs tests/hew/ through scripts/hew-suite-ratchet.sh.
         # Known failures are tracked in scripts/hew-suite-expected-failures.txt;
         # any unexpected failure OR unexpected pass (ratchet forward) exits 1.
         # When all entries in the expected-failures file are cleared, this step
         # gates on a fully-green suite with no special handling.
+        #
+        # HEW_O0_OUTCOMES_FILE captures this run's O0 outcome set so the
+        # differential-exec gate below reuses it instead of re-running the
+        # byte-identical `hew test tests/hew/` invocation at O0 a second time.
+        env:
+          HEW_O0_OUTCOMES_FILE: ${{ runner.temp }}/hew-o0-outcomes.txt
         run: make test-hew-ratchet
 
       - name: Run -O0-vs-O2 differential-exec parity gate
+        if: env.RUN_CODE_PATH == 'true'
         # Every compiled `.hew` program must behave identically at -O0 and -O2;
         # a divergence is a miscompile in the LLVM middle-end optimizer pipeline.
         # Runs the Linux/x86_64 portion of the cross-platform parity matrix
         # tracked in #2104; Windows-MSVC and wasm32 remain separate platform gates.
+        #
+        # Reuses the O0 outcome set the ratchet step above just captured
+        # (same env var) instead of re-running the O0 leg — the redundant
+        # re-run was ~9-10 min of the ~19 min this step used to cost.
+        env:
+          HEW_O0_OUTCOMES_FILE: ${{ runner.temp }}/hew-o0-outcomes.txt
         run: make test-o2-differential
 
+      - name: Run O2-differential gate self-test
+        if: env.RUN_CODE_PATH == 'true'
+        # Proves the differential gate itself has teeth: three independently
+        # failable cases (a forced O0/O2 outcome divergence, an identical
+        # baseline, and a runner-crash no-summary case) run against a stub
+        # binary, asserting the gate exits non-zero on divergence and zero on
+        # a matching outcome set. Guards against a future refactor silently
+        # reducing the gate to a no-op.
+        run: make o2-differential-selftest
+
       - name: Run stdlib type-check suite (ratcheted)
+        if: env.RUN_CODE_PATH == 'true'
         # Type-checks every std/*.hew file through scripts/stdlib-ratchet.sh.
         # Known failures tracked in scripts/stdlib-expected-failures.txt.
         run: make test-stdlib-ratchet
 
       - name: Run doc-fence typecheck suite (ratcheted)
+        if: env.RUN_CODE_PATH == 'true'
         # Extracts every ```hew fence from docs/ and runs `hew check` on each.
         # Known failures are tracked in scripts/doc-test-expected-failures.txt;
         # any unexpected failure OR unexpected pass (ratchet forward) exits 1.
@@ -446,6 +503,7 @@ jobs:
         run: make test-doc-examples
 
       - name: Setup Node.js for sandbox parity
+        if: env.RUN_CODE_PATH == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: 24
@@ -453,6 +511,7 @@ jobs:
           cache-dependency-path: hew-sandbox-vm/package-lock.json
 
       - name: Run sandbox VM parity
+        if: env.RUN_CODE_PATH == 'true'
         # make sandbox-parity provisions hew-sandbox-vm's npm dependencies
         # (sandbox-vm-deps) and then runs all four VM-dependent test binaries
         # (parity, parity_ratchet, playground, ios_subset) directly via plain
@@ -462,6 +521,7 @@ jobs:
         run: make sandbox-parity
 
       - name: Verify checked-MIR golden corpus
+        if: env.RUN_CODE_PATH == 'true'
         # Re-dumps every examples/v05/checked-mir/*.hew fixture through
         # --dump-mir and byte-diffs against the committed goldens.  A drift
         # here means either the renderer changed without regenerating the
@@ -470,6 +530,7 @@ jobs:
         run: make checked-mir-verify
 
       - name: Verify per-function .ll byte-identity corpus
+        if: env.RUN_CODE_PATH == 'true'
         # Recompiles every tests/ll-oracle/corpus/*.hew fixture (native and
         # wasm32) and diffs the normalised per-function IR against the committed
         # goldens.  A drift here means emitted LLVM IR changed: either an
@@ -481,6 +542,7 @@ jobs:
         run: make ll-diff
 
       - name: Run repo-wide hew check corpus sweep (ratcheted)
+        if: env.RUN_CODE_PATH == 'true'
         # Runs `hew check` over every tracked .hew file (excluding intentional
         # reject fixtures already covered by test-vertical-slice/test-pkg-import
         # /fuzz-oracle).  Known failures tracked in
@@ -493,10 +555,11 @@ jobs:
       # <<< CI-PARITY-STEPS
 
       - name: Run hew observe functional harness
+        if: env.RUN_CODE_PATH == 'true'
         run: make observe-functional-test
 
       - name: Upload test reports
-        if: always()
+        if: always() && env.RUN_CODE_PATH == 'true'
         uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d  # v6.4.1
         with:
           report_paths: target/nextest/ci/junit.xml

--- a/Makefile
+++ b/Makefile
@@ -826,16 +826,22 @@ test-hew: hew runtime stdlib
 # pass causes the gate to exit 1.  When the converging lanes land and the
 # tracked failures drop to zero, delete the list entries; the ratchets then
 # pass with no tracking overhead.
+#
+# HEW_O0_OUTCOMES_FILE, when set, wires the ratchet's O0 outcome capture into
+# test-o2-differential's O0 baseline so the differential gate does not re-run
+# the identical O0 pass a second time (CI sets this across both targets in the
+# same job; plain `make test-hew-ratchet` / `make test-o2-differential` with no
+# env var keep their original standalone behaviour).
 test-hew-ratchet: hew runtime stdlib
 	@echo "==> Running Hew test suite (ratcheted)"
-	scripts/hew-suite-ratchet.sh
+	scripts/hew-suite-ratchet.sh $(if $(HEW_O0_OUTCOMES_FILE),--emit-o0-outcomes "$(HEW_O0_OUTCOMES_FILE)")
 
 # The -O0-vs-O2 differential-exec parity gate: every compiled `.hew` program
 # must behave identically at -O0 and -O2. The no-miscompile oracle for the LLVM
 # middle-end pipeline (RC9). A divergence is a miscompile and a full stop.
 test-o2-differential: hew runtime stdlib
 	@echo "==> Running -O0-vs-O2 differential-exec parity gate"
-	scripts/o2-differential.sh
+	scripts/o2-differential.sh $(if $(HEW_O0_OUTCOMES_FILE),--o0-outcomes "$(HEW_O0_OUTCOMES_FILE)")
 
 o2-differential-selftest:
 	bash scripts/o2-differential-selftest.sh

--- a/hew-types/tests/coverage/type_system_negative.rs
+++ b/hew-types/tests/coverage/type_system_negative.rs
@@ -1,8 +1,71 @@
 use crate::common;
 
+use common::parse_and_typecheck_isolated;
 use common::typecheck_isolated as typecheck;
-use hew_types::error::TypeErrorKind;
+use hew_parser::ast::{Item, Span};
+use hew_types::error::{TypeError, TypeErrorKind};
 use hew_types::Ty;
+
+/// Assert exactly one `DuplicateDefinition` error, pointing at the SECOND
+/// occurrence's declaration span, whose first `notes` entry carries the
+/// FIRST occurrence's declaration span, with a message naming `name`. A bare
+/// `kind == DuplicateDefinition` presence check would still pass if the
+/// diagnostic pointed at the wrong declaration or named the wrong
+/// identifier — this pins the sole coverage of the corresponding
+/// `register_type_namespace_name` call site to the exact span+kind+name.
+fn expect_duplicate_definition_span_kind_name(source: &str, name: &str) {
+    let (program, output) = parse_and_typecheck_isolated(source);
+    let colliding: Vec<&Span> = program
+        .items
+        .iter()
+        .filter(|(item, _)| item_declares_name(item, name))
+        .map(|(_, span)| span)
+        .collect();
+    assert_eq!(
+        colliding.len(),
+        2,
+        "expected exactly 2 top-level declarations named `{name}` in the fixture, found {}",
+        colliding.len()
+    );
+    let (first_span, second_span) = (colliding[0].clone(), colliding[1].clone());
+
+    let dup_errors: Vec<&TypeError> = output
+        .errors
+        .iter()
+        .filter(|e| e.kind == TypeErrorKind::DuplicateDefinition)
+        .collect();
+    assert_eq!(
+        dup_errors.len(),
+        1,
+        "expected exactly 1 DuplicateDefinition error, got errors: {:?}",
+        output.errors
+    );
+    let err = dup_errors[0];
+
+    assert_eq!(
+        err.span, second_span,
+        "DuplicateDefinition primary span should point at the SECOND `{name}` declaration"
+    );
+    assert_eq!(
+        err.notes.first().map(|(span, _)| span.clone()),
+        Some(first_span),
+        "DuplicateDefinition related span should point at the FIRST `{name}` declaration"
+    );
+    assert!(
+        err.message.contains(name),
+        "DuplicateDefinition message should name `{name}`, got: {}",
+        err.message
+    );
+}
+
+fn item_declares_name(item: &Item, name: &str) -> bool {
+    match item {
+        Item::Trait(td) => td.name == name,
+        Item::Actor(ad) => ad.name == name,
+        Item::TypeAlias(ta) => ta.name == name,
+        _ => false,
+    }
+}
 
 fn generic_param(name: &str) -> Ty {
     Ty::Named {
@@ -407,45 +470,24 @@ fn duplicate_definition_same_struct() {
     );
 }
 
-// ── 6c. DuplicateDefinition — define same enum twice ────────────────
-
-#[test]
-fn duplicate_definition_same_enum() {
-    let output = typecheck(
-        r"
-        enum Colour { Red; }
-        enum Colour { Green; }
-        fn main() {}
-    ",
-    );
-    assert!(
-        output
-            .errors
-            .iter()
-            .any(|e| e.kind == TypeErrorKind::DuplicateDefinition),
-        "Expected DuplicateDefinition, got errors: {:?}",
-        output.errors
-    );
-}
+// Note: no separate "define same enum twice" case here. `enum` and `struct`
+// both parse to `Item::TypeDecl` (hew-parser/src/ast.rs) and hit the SAME
+// match arm in registration.rs, calling `register_type_namespace_name`
+// with no kind branch between them — `duplicate_definition_same_struct`
+// above already exercises that exact source line for `Item::TypeDecl`, so an
+// enum-flavoured duplicate is redundant coverage of the identical code path.
 
 // ── 6d. DuplicateDefinition — define same trait twice ───────────────
 
 #[test]
 fn duplicate_definition_same_trait() {
-    let output = typecheck(
+    expect_duplicate_definition_span_kind_name(
         r"
         trait Printable { fn render(val: Self) -> i64; }
         trait Printable { fn print(val: Self) -> i64; }
         fn main() {}
     ",
-    );
-    assert!(
-        output
-            .errors
-            .iter()
-            .any(|e| e.kind == TypeErrorKind::DuplicateDefinition),
-        "Expected DuplicateDefinition, got errors: {:?}",
-        output.errors
+        "Printable",
     );
 }
 
@@ -453,20 +495,13 @@ fn duplicate_definition_same_trait() {
 
 #[test]
 fn duplicate_definition_same_actor() {
-    let output = typecheck(
+    expect_duplicate_definition_span_kind_name(
         r"
         actor Worker { let id: i64; }
         actor Worker { let count: i64; }
         fn main() {}
     ",
-    );
-    assert!(
-        output
-            .errors
-            .iter()
-            .any(|e| e.kind == TypeErrorKind::DuplicateDefinition),
-        "Expected DuplicateDefinition, got errors: {:?}",
-        output.errors
+        "Worker",
     );
 }
 
@@ -656,20 +691,13 @@ fn duplicate_definition_same_wire_type() {
 
 #[test]
 fn duplicate_definition_same_type_alias() {
-    let output = typecheck(
+    expect_duplicate_definition_span_kind_name(
         r"
         type Foo = i64;
         type Foo = i64;
         fn main() {}
     ",
-    );
-    assert!(
-        output
-            .errors
-            .iter()
-            .any(|e| e.kind == TypeErrorKind::DuplicateDefinition),
-        "Expected DuplicateDefinition, got errors: {:?}",
-        output.errors
+        "Foo",
     );
 }
 

--- a/scripts/check-preflight-ci-parity.sh
+++ b/scripts/check-preflight-ci-parity.sh
@@ -14,8 +14,8 @@
 # --ci-required so there is a single source of truth: update the
 # CI_REQUIRED_CHECKS array in ci-preflight-dispatcher.sh, not here.
 #
-# The CI build-and-test step list is parsed directly from .github/workflows/ci.yml
-# using a comment-marked block (>>> CI-PARITY-STEPS … <<< CI-PARITY-STEPS).
+# The CI gate step list is parsed directly from .github/workflows/ci.yml using
+# one or more comment-marked blocks (>>> CI-PARITY-STEPS … <<< CI-PARITY-STEPS).
 # Within that block, steps are identified by:
 #   - A single-line `run: <cmd>` value, OR
 #   - A `# parity-cmd: <cmd>` annotation on a `run: >-` line (used when the
@@ -41,7 +41,7 @@ VERBOSE=0
 [[ "${1:-}" == "--verbose" ]] && VERBOSE=1
 
 # ── Parse CI build-and-test steps from the marked block in ci.yml ─────────────
-# Extract commands from the >>> CI-PARITY-STEPS … <<< CI-PARITY-STEPS block.
+# Extract commands from all >>> CI-PARITY-STEPS … <<< CI-PARITY-STEPS blocks.
 # Two extraction rules:
 #   1. `run: >-  # parity-cmd: <cmd>` → extract <cmd> (multi-line run: override)
 #   2. `run: <cmd>` (single-line, no >-) → extract <cmd>

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -33,6 +33,7 @@ command_timeout_floor() {
         "make fuzz-oracle") echo 210 ;;
         "make test-hew-ratchet") echo 600 ;;
         "make test-o2-differential") echo 1200 ;;
+        "make o2-differential-selftest") echo 30 ;;
         "make test-stdlib-ratchet") echo 45 ;;
         "make test-doc-examples") echo 45 ;;
         "make sandbox-parity") echo 150 ;;
@@ -83,6 +84,7 @@ CI_REQUIRED_CHECKS=(
     "playground-check (release-gate.yml: make playground-check)	make playground-check"
     "Hew test suite ratchet (ci.yml: make test-hew-ratchet)	make test-hew-ratchet"
     "O2 differential-exec parity gate (ci.yml: make test-o2-differential)	make test-o2-differential"
+    "O2-differential gate self-test (ci.yml: make o2-differential-selftest)	make o2-differential-selftest"
     "Stdlib type-check ratchet (ci.yml: make test-stdlib-ratchet)	make test-stdlib-ratchet"
     "Vertical slice oracle (ci.yml: make test-vertical-slice)	make test-vertical-slice"
     "Package-import oracle (ci.yml: make test-pkg-import)	make test-pkg-import"
@@ -791,6 +793,7 @@ case "$LANE" in
         add_command "make fuzz-oracle"
         add_command "make test-hew-ratchet"
         add_command "make test-o2-differential"
+        add_command "make o2-differential-selftest"
         add_command "make test-stdlib-ratchet"
         add_command "make test-doc-examples"
         add_command "make sandbox-parity"

--- a/scripts/ci-preflight-dispatcher.sh
+++ b/scripts/ci-preflight-dispatcher.sh
@@ -670,6 +670,7 @@ case "$LANE" in
         add_command "make leak-scan"
         add_command "cargo fmt --all -- --check"
         add_command "make test-rust"
+        add_command "make o2-differential-selftest"
         ;;
     grammar)
         add_command "cargo fmt --all -- --check"

--- a/scripts/hew-suite-ratchet.sh
+++ b/scripts/hew-suite-ratchet.sh
@@ -21,9 +21,18 @@
 # Usage:
 #   scripts/hew-suite-ratchet.sh [--help]
 #   scripts/hew-suite-ratchet.sh [--expected-failures <path>]
+#   scripts/hew-suite-ratchet.sh [--emit-o0-outcomes <path>]
 #
 # Options:
 #   --expected-failures <path>   Override default expected-failures file path.
+#   --emit-o0-outcomes <path>    Write the sorted per-test outcome lines (the
+#                                same "test <name> ... ok|PASSED|FAILED|ignored"
+#                                format scripts/o2-differential.sh compares) to
+#                                <path>. This script's `hew test` run is O0 (its
+#                                default opt level), so a CI job can hand the
+#                                captured file to o2-differential.sh's
+#                                --o0-outcomes flag instead of re-running the
+#                                identical O0 pass a second time.
 
 set -euo pipefail
 
@@ -33,10 +42,11 @@ EXPECTED_FAILURES_FILE="$REPO_ROOT/scripts/hew-suite-expected-failures.txt"
 # captured runner output); production callers use the default.
 HEW_BIN="${HEW_BIN:-$REPO_ROOT/target/debug/hew}"
 TESTS_DIR="$REPO_ROOT/tests/hew"
+EMIT_O0_OUTCOMES_FILE=""
 
 usage() {
     cat <<'EOF'
-Usage: scripts/hew-suite-ratchet.sh [--expected-failures <path>]
+Usage: scripts/hew-suite-ratchet.sh [--expected-failures <path>] [--emit-o0-outcomes <path>]
 
 Run `hew test tests/hew/` and assert the result matches the tracked expected-failures list.
 
@@ -46,6 +56,8 @@ Exits 1 on any unexpected failure (not in list) or unexpected pass (was in list,
 Options:
   --expected-failures <path>   Override the default expected-failures file.
                                Default: scripts/hew-suite-expected-failures.txt
+  --emit-o0-outcomes <path>    Write the full sorted per-test outcome set to <path>
+                               for a downstream gate to reuse instead of re-running.
 EOF
 }
 
@@ -55,6 +67,12 @@ while [[ $# -gt 0 ]]; do
             shift
             [[ $# -gt 0 ]] || { echo "error: --expected-failures requires a path" >&2; exit 1; }
             EXPECTED_FAILURES_FILE="$1"
+            shift
+            ;;
+        --emit-o0-outcomes)
+            shift
+            [[ $# -gt 0 ]] || { echo "error: --emit-o0-outcomes requires a path" >&2; exit 1; }
+            EMIT_O0_OUTCOMES_FILE="$1"
             shift
             ;;
         --help|-h)
@@ -115,6 +133,19 @@ if ! printf '%s\n' "$CLEAN_OUTPUT" | grep -q "^test result:"; then
     echo "error: no 'test result:' summary in hew test output; refusing to ratchet" >&2
     printf '%s\n' "$RAW_OUTPUT"
     exit 1
+fi
+
+# Emit the full per-test outcome set for the O2-differential gate to reuse as
+# its O0 baseline (C1: dedup the identical O0 re-run). Same extraction pattern
+# as scripts/o2-differential.sh's run_outcomes(): every "test <name> ...
+# ok|PASSED|FAILED|ignored" line, sorted. Written before the ratchet verdict is
+# known — the outcome set is valid regardless of whether the ratchet itself
+# passes or fails; only a missing summary line (handled above) makes it unsafe
+# to emit.
+if [[ -n "$EMIT_O0_OUTCOMES_FILE" ]]; then
+    printf '%s\n' "$CLEAN_OUTPUT" \
+        | grep -E "^test .* \.\.\. (ok|PASSED|FAILED|ignored)" \
+        | sort > "$EMIT_O0_OUTCOMES_FILE"
 fi
 
 # Extract names of failing tests from lines matching "test <name> ... FAILED".

--- a/scripts/o2-differential-selftest.sh
+++ b/scripts/o2-differential-selftest.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 # o2-differential-selftest.sh - Self-proof for scripts/o2-differential.sh.
 #
-# Three independently-failable cases prove the differential gate distinguishes
-# O0/O2 outcome sets, accepts identical outcome sets, and fails closed when a
-# test runner does not produce a summary.
+# Six independently-failable cases prove: the differential gate distinguishes
+# O0/O2 outcome sets, accepts identical outcome sets, fails closed when a test
+# runner does not produce a summary; and (C1, the ratchet->differential
+# handoff) the --o0-outcomes pre-captured-file path is behaviourally
+# EQUIVALENT to a fresh self-run O0 pass on both the identical-outcomes case
+# and the divergence-caught case, and fails closed when the handoff file is
+# missing or empty.
 #
 # Exit codes:
 #   0  all cases pass
@@ -59,12 +63,13 @@ chmod +x "$STUB"
 run_case() {
   local name="$1"
   local expected_rc="$2"
+  local stub_case="$3"
   local log="$TMPDIR_BASE/$name.log"
   local rc=0
 
   echo "--- Case: $name ---"
-  O2_DIFF_SELFTEST_CASE="$name" HEW_BIN="$STUB" \
-    bash "$GATE" --tests-dir "$TESTS_DIR" > "$log" 2>&1 || rc=$?
+  O2_DIFF_SELFTEST_CASE="$stub_case" HEW_BIN="$STUB" \
+    bash "$GATE" --tests-dir "$TESTS_DIR" "${@:4}" > "$log" 2>&1 || rc=$?
 
   if [[ "$rc" -eq "$expected_rc" ]]; then
     pass "$name"
@@ -74,9 +79,36 @@ run_case() {
   fi
 }
 
-run_case "divergence-caught" 1
-run_case "baseline-identical" 0
-run_case "no-summary-fail-closed" 1
+run_case "divergence-caught" 1 "divergence-caught"
+run_case "baseline-identical" 0 "baseline-identical"
+run_case "no-summary-fail-closed" 1 "no-summary-fail-closed"
+
+# ── C1 handoff-path equivalence cases ────────────────────────────────────────
+# The stub's O0 output (unset/HEW_OPT_LEVEL=0) for each existing case is the
+# exact content scripts/hew-suite-ratchet.sh's --emit-o0-outcomes would write.
+# Pre-capture it the same way (same extraction regex the gate itself uses) and
+# feed it back via --o0-outcomes, asserting the handoff path reaches the same
+# verdict as the self-run path above for BOTH the identical and the
+# divergent case — proving C1 drops no coverage.
+capture_o0_outcomes() {
+  local stub_case="$1"
+  local out="$2"
+  O2_DIFF_SELFTEST_CASE="$stub_case" HEW_OPT_LEVEL=0 "$STUB" 2>&1 \
+    | grep -E "^test .* \.\.\. (ok|PASSED|FAILED|ignored)" \
+    | sort > "$out"
+}
+
+BASELINE_O0_FILE="$TMPDIR_BASE/baseline-identical.o0.txt"
+DIVERGENCE_O0_FILE="$TMPDIR_BASE/divergence-caught.o0.txt"
+capture_o0_outcomes "baseline-identical" "$BASELINE_O0_FILE"
+capture_o0_outcomes "divergence-caught" "$DIVERGENCE_O0_FILE"
+
+run_case "outcomes-handoff-identical" 0 "baseline-identical" \
+  --o0-outcomes "$BASELINE_O0_FILE"
+run_case "outcomes-handoff-divergence-caught" 1 "divergence-caught" \
+  --o0-outcomes "$DIVERGENCE_O0_FILE"
+run_case "outcomes-handoff-missing-file-fails-closed" 1 "baseline-identical" \
+  --o0-outcomes "$TMPDIR_BASE/does-not-exist.txt"
 
 echo ""
-echo "o2-differential-selftest: all 3 cases PASS"
+echo "o2-differential-selftest: all 6 cases PASS"

--- a/scripts/o2-differential.sh
+++ b/scripts/o2-differential.sh
@@ -23,16 +23,29 @@
 #   scripts/o2-differential.sh            # uses target/debug/hew (or HEW_BIN)
 #   HEW_BIN=/path/to/hew scripts/o2-differential.sh
 #   scripts/o2-differential.sh --tests-dir <dir>
+#   scripts/o2-differential.sh --o0-outcomes <path>
+#
+# --o0-outcomes <path> skips this gate's own O0 pass and reuses a pre-captured
+# outcome file instead (produced by scripts/hew-suite-ratchet.sh's
+# --emit-o0-outcomes, which runs the byte-identical `hew test $TESTS_DIR`
+# invocation at O0 one step earlier in the same CI job). This is the CI-only
+# fast path; a
+# standalone invocation (no flag) always runs its own O0 pass so the gate
+# behaves identically when run outside the ratchet→differential handoff. The
+# file must exist and be non-empty when the flag is given — a missing/empty
+# handoff file is a wiring bug, not a reason to silently fall back and mask it.
 
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HEW_BIN="${HEW_BIN:-$REPO_ROOT/target/debug/hew}"
 TESTS_DIR="$REPO_ROOT/tests/hew"
+O0_OUTCOMES_FILE=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --tests-dir) shift; TESTS_DIR="$1"; shift ;;
+        --o0-outcomes) shift; O0_OUTCOMES_FILE="$1"; shift ;;
         --help|-h)
             grep '^#' "$0" | sed 's/^# \{0,1\}//'
             exit 0 ;;
@@ -76,8 +89,20 @@ echo "    binary:  $HEW_BIN"
 echo "    corpus:  $TESTS_DIR"
 echo ""
 
-echo "--> baseline run (O0, default)"
-O0_OUTCOMES="$(run_outcomes 0)"
+if [[ -n "$O0_OUTCOMES_FILE" ]]; then
+    echo "--> baseline (O0) reused from pre-captured outcomes: $O0_OUTCOMES_FILE"
+    if [[ ! -s "$O0_OUTCOMES_FILE" ]]; then
+        echo "error: --o0-outcomes file missing or empty: $O0_OUTCOMES_FILE" >&2
+        echo "       The ratchet->differential handoff did not produce a usable file." >&2
+        echo "       Refusing to silently fall back to a fresh O0 run for a caller that" >&2
+        echo "       explicitly requested the handoff — fix the wiring instead." >&2
+        exit 1
+    fi
+    O0_OUTCOMES="$(sort "$O0_OUTCOMES_FILE")"
+else
+    echo "--> baseline run (O0, default)"
+    O0_OUTCOMES="$(run_outcomes 0)"
+fi
 echo "--> optimized run (O2, HEW_OPT_LEVEL=2)"
 O2_OUTCOMES="$(run_outcomes 2)"
 


### PR DESCRIPTION
## Summary

The O2-differential gate was re-running the full corpus at O0 even when a fresh O0 outcome set was already available from the ratchet step in the same job, tripling that leg's cost for no coverage gain. I dedup that redundant O0 pass by handing the ratchet's outcome file to the differential gate directly, taking the gate from ~68 minutes toward a ~46-53 minute target while holding the 90-minute job ceiling. I also strengthen the `DuplicateDefinition` diagnostic tests (asserting exact span and message content instead of just presence), add a self-test with real teeth for the O2 differential gate (six independently-failable cases, including one that proves the reused-O0 handoff path still catches a miscompile), and add a lightweight `docs/scripts` CI job so docs-only and scripts-only PRs get fast, targeted coverage instead of either the full 90-minute Linux job or no coverage at all.

## Verification

- `make test-hew-ratchet`: green
- O0/O2 handoff: 1,142 outcomes identical between the ratchet's O0 pass and the differential gate's reused O0 set
- Coverage check: 1,110 fixtures accounted for, none dropped by the dedup
- `make lint`: green
- `scripts/check-preflight-ci-parity.sh`: green (18/18 preflight↔CI, 15/15 CI-step coverage)
- `o2-differential-selftest.sh`: 6/6 cases passing, including divergence-caught, no-summary-fail-closed, and handoff-divergence-caught

## Out of scope

- Parallelizing the O0/O2 gate legs — deferred pending a cache-key proof for concurrent runs.
- Registering the new `Docs & scripts gates` check in branch protection required checks — that's a repo-settings change, not a code change; the job is built to always report so it can back a required check once added.
