### PR TITLE
fix(runtime): scope the blocking pool to its runtime and fail closed on FFI without one

### DIFF
--- a/hew-codegen-rs/src/llvm.rs
+++ b/hew-codegen-rs/src/llvm.rs
@@ -38668,6 +38668,39 @@ fn module_uses_metric_authority(raw_mir: &[RawMirFunction]) -> bool {
     })
 }
 
+/// Does the module reach a blocking-pool offload authority (net DNS / TCP
+/// connect)?
+///
+/// The deadline-bounded syscall pool (`RuntimeInner::blocking_pool`) was a
+/// process-lifetime `blocking_pool::SHARED_POOL` singleton that worked with no
+/// runtime installed; it is now owned per-runtime and resolved through the
+/// fail-closed `rt_current_opt()` (`blocking_pool::shared_blocking_pool_opt`).
+/// A program that offloads a DNS resolve or a TCP connect from a non-actor
+/// context — e.g. `net.connect(..)` in a bare `main`, with no `spawn`, `Node`,
+/// or metrics use — would otherwise reach the offload with no runtime installed
+/// and fail closed with EINVAL, so the connect never completes. Touching the
+/// pool is therefore an independent reason to install the runtime at program
+/// entry, just like node/metrics.
+///
+/// The offload entrypoints are the connect family (`hew_tcp_connect`,
+/// `hew_tcp_connect_timed`, `hew_tcp_connect_timeout`) and the DNS family
+/// (`hew_dns_resolve*`, `hew_dns_lookup_host*`); every one begins with
+/// `hew_tcp_connect` or `hew_dns_`. Accept/read/write are direct blocking
+/// syscalls that never touch the pool, so they are deliberately not matched.
+/// Extern fns lower to `Terminator::Call` with the extern symbol as the callee
+/// (`hew-mir/src/lower.rs`), so scanning terminators by callee prefix is exact.
+fn module_uses_blocking_offload(raw_mir: &[RawMirFunction]) -> bool {
+    raw_mir.iter().any(|func| {
+        func.blocks.iter().any(|block| {
+            matches!(
+                &block.terminator,
+                Terminator::Call { callee, .. }
+                    if callee.starts_with("hew_tcp_connect") || callee.starts_with("hew_dns_")
+            )
+        })
+    })
+}
+
 /// Lower one function from `raw_mir`, consuming `elaborated_mir.drop_plans`
 /// to emit LIFO close calls before every exit terminator.
 ///
@@ -41647,7 +41680,8 @@ fn build_module_for_target<'ctx>(
     let module_uses_runtime = !pipeline.actor_layouts.is_empty()
         || !pipeline.supervisor_layouts.is_empty()
         || module_uses_node_authority(&pipeline.raw_mir)
-        || module_uses_metric_authority(&pipeline.raw_mir);
+        || module_uses_metric_authority(&pipeline.raw_mir)
+        || module_uses_blocking_offload(&pipeline.raw_mir);
     for sup in &pipeline.supervisor_layouts {
         emit_supervisor_bootstrap_body(
             ctx,

--- a/hew-runtime/src/blocking_pool.rs
+++ b/hew-runtime/src/blocking_pool.rs
@@ -8,7 +8,7 @@
 )]
 
 use std::ffi::c_void;
-use std::sync::{Arc, Condvar, Mutex, OnceLock};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
@@ -284,46 +284,75 @@ where
     }
 }
 
-/// Process-lifetime singleton wrapper around `*mut HewBlockingPool`.
+/// Per-runtime owner of a `*mut HewBlockingPool`.
 ///
-/// `*mut T` is neither `Send` nor `Sync`. This wrapper asserts both based on
-/// the pool's internal Mutex/Condvar synchronization. The pointer's allocation
-/// lives for the duration of the process — the singleton is never stopped, so
-/// the inner pointer never dangles.
-struct SharedPoolHandle(*mut HewBlockingPool);
+/// Held in a [`OnceLock`] field on the runtime (`RuntimeInner::blocking_pool`);
+/// created lazily on the first blocking offload and dropped with its runtime.
+/// `*mut T` is neither `Send` nor `Sync`; this wrapper asserts both based on the
+/// pool's internal Mutex/Condvar synchronization. The pointer is valid for the
+/// owning runtime's lifetime — it is stopped (queue drained, workers joined)
+/// only when this field drops, by which point cleanup has already joined every
+/// dispatch/reactor/worker thread that could submit to it.
+pub(crate) struct OwnedBlockingPool(*mut HewBlockingPool);
 
 // SAFETY: `HewBlockingPool` is heap-allocated by `hew_blocking_pool_new` and
-// internally synchronized via Mutex+Condvar. The singleton lives for the
-// lifetime of the process and is never freed via `hew_blocking_pool_stop`,
-// so the raw pointer remains valid for any thread that observes it.
-unsafe impl Send for SharedPoolHandle {}
+// internally synchronized via Mutex+Condvar. The handle is owned by exactly one
+// runtime and every access goes through the pool's own internal locks, so the
+// raw pointer can cross threads (worker/reactor submitters) safely.
+unsafe impl Send for OwnedBlockingPool {}
 // SAFETY: see Send. All access goes through the pool's own internal locks.
-unsafe impl Sync for SharedPoolHandle {}
+unsafe impl Sync for OwnedBlockingPool {}
 
-static SHARED_POOL: OnceLock<SharedPoolHandle> = OnceLock::new();
+impl OwnedBlockingPool {
+    /// Spawn a fresh blocking pool (its worker threads) and take ownership.
+    pub(crate) fn new() -> Self {
+        // SAFETY: `hew_blocking_pool_new` is safe to call (no preconditions); it
+        // returns a heap-allocated pool this handle now owns and stops on drop.
+        Self(unsafe { hew_blocking_pool_new() })
+    }
 
-/// Return the process-wide blocking pool, creating it on first call.
+    /// The raw pool pointer, valid for the owning runtime's lifetime.
+    pub(crate) fn as_ptr(&self) -> *mut HewBlockingPool {
+        self.0
+    }
+}
+
+impl Drop for OwnedBlockingPool {
+    fn drop(&mut self) {
+        if self.0.is_null() {
+            return;
+        }
+        // SAFETY: `self.0` came from `hew_blocking_pool_new` and is owned solely
+        // by this field, so it is stopped exactly once — when the runtime that
+        // owns it drops. `hew_runtime_cleanup` joins the reactor, ticker, and
+        // scheduler workers (the only submitters) BEFORE dropping `RuntimeInner`
+        // (`cleanup-all-exits`), so no submitting thread is parked on a pool slot
+        // here; `hew_blocking_pool_stop` drains the queue and joins the pool's
+        // own worker threads.
+        unsafe { hew_blocking_pool_stop(self.0) };
+    }
+}
+
+/// Return the calling runtime's blocking pool, creating it on first use.
 ///
-/// The returned pointer is valid for the lifetime of the process. It is
-/// shared across all transport callers (DNS, TCP, HTTP, etc.) that need to
-/// offload blocking syscalls with a deadline. Callers MUST NOT pass this
-/// pointer to [`hew_blocking_pool_stop`] — the singleton is never stopped.
+/// Resolves the pool through the current runtime (`rt_current().blocking_pool()`)
+/// and is therefore an init/mutate site: it spawns worker threads and requires a
+/// runtime to be installed (`deglobalize-reads-stay-tolerant` — this is not a
+/// tolerant read/sweep caller, so the fail-closed `rt_current()` is correct).
+/// The returned pointer is valid for that runtime's lifetime and is shared
+/// across its transport callers (DNS, TCP, HTTP, etc.) that offload blocking
+/// syscalls with a deadline. Callers MUST NOT pass this pointer to
+/// [`hew_blocking_pool_stop`] — the owning runtime stops it on drop.
 ///
-/// Idempotent: subsequent calls return the same pointer.
+/// Idempotent within a runtime: subsequent calls under the same runtime return
+/// the same pointer.
 ///
 /// WASM-TODO(#1451): there is no blocking pool on WASM; transport callers
 /// on WASM keep their pre-existing unguarded blocking shape until a
 /// WASM-compatible deadline primitive exists.
+#[must_use]
 pub fn shared_blocking_pool() -> *mut HewBlockingPool {
-    SHARED_POOL
-        .get_or_init(|| {
-            // SAFETY: hew_blocking_pool_new is safe to call (no preconditions);
-            // it returns a heap-allocated pool that is owned by the singleton
-            // and never freed.
-            let raw = unsafe { hew_blocking_pool_new() };
-            SharedPoolHandle(raw)
-        })
-        .0
+    crate::runtime::rt_current().blocking_pool()
 }
 
 /// Stop the pool: reject new work, wake all workers, and join threads.
@@ -613,20 +642,122 @@ mod tests {
         }
     }
 
-    /// `shared_blocking_pool` returns the same pointer on every call and
-    /// the pool is usable.
+    /// `shared_blocking_pool` returns the same pointer on every call within one
+    /// runtime, and the pool is usable.
     #[test]
     fn shared_blocking_pool_is_idempotent_and_usable() {
+        // The pool now resolves through `rt_current()`, so a runtime must be
+        // installed; the guard installs a worker-less default and reclaims it
+        // (stopping the pool) on drop.
+        let _runtime = crate::runtime_test_guard();
+
         let p1 = shared_blocking_pool();
         let p2 = shared_blocking_pool();
-        assert_eq!(p1, p2, "shared pool must be a singleton");
-        assert!(!p1.is_null(), "shared pool must be allocated");
+        assert_eq!(p1, p2, "the pool is a per-runtime singleton");
+        assert!(!p1.is_null(), "the pool must be allocated");
 
-        // Submit through the shared pool and observe the result. This proves
-        // the singleton is wired through `spawn_blocking_result` correctly.
-        // SAFETY: shared_blocking_pool returns a valid, never-stopped pool.
+        // Submit through the pool and observe the result. This proves it is
+        // wired through `spawn_blocking_result` correctly.
+        // SAFETY: shared_blocking_pool returns a valid pool for the installed
+        // runtime; it stays valid until the guard drops it below.
         let result = unsafe { spawn_blocking_result(p1, || 1729_u32, None) };
         assert_eq!(result, Ok(1729));
+    }
+
+    /// Two live runtimes own DIFFERENT blocking pools — the deglob's core teeth.
+    /// Before CAP-09's residual close, a process-global `SHARED_POOL` singleton
+    /// served both; now each `RuntimeInner` lazily owns its own, and both are
+    /// independently usable. Completing under the lane timeout is the join proof:
+    /// dropping each runtime stops its own pool without hanging.
+    #[test]
+    fn two_runtimes_do_not_share_the_blocking_pool() {
+        let _lock = crate::scheduler::SchedTestLock::acquire();
+
+        let rt_a = crate::runtime::RuntimeInner::new(crate::scheduler::worker_less_scheduler());
+        let rt_b = crate::runtime::RuntimeInner::new(crate::scheduler::worker_less_scheduler());
+
+        // Resolve each runtime's pool while it is the entered current runtime.
+        let pool_a = {
+            // SAFETY: rt_a is a stack local that outlives this enter guard.
+            let _enter = unsafe { crate::runtime::enter(&rt_a) };
+            shared_blocking_pool()
+        };
+        let pool_b = {
+            // SAFETY: rt_b is a stack local that outlives this enter guard.
+            let _enter = unsafe { crate::runtime::enter(&rt_b) };
+            shared_blocking_pool()
+        };
+
+        assert!(!pool_a.is_null() && !pool_b.is_null());
+        assert_ne!(
+            pool_a, pool_b,
+            "each runtime must own a distinct blocking pool, not share one global"
+        );
+
+        // Both pools are live and independently usable.
+        // SAFETY: pool_a came from rt_a's live pool; rt_a is still in scope.
+        let ran_a = unsafe { spawn_blocking_result(pool_a, || 41_i32 + 1, None) };
+        // SAFETY: pool_b came from rt_b's live pool; rt_b is still in scope.
+        let ran_b = unsafe { spawn_blocking_result(pool_b, || 20_i32 + 22, None) };
+        assert_eq!(ran_a, Ok(42));
+        assert_eq!(ran_b, Ok(42));
+
+        // Dropping rt_a then rt_b stops each pool (joins its workers); reaching
+        // the end of the test without hanging is the teardown-ordering proof.
+    }
+
+    /// Dropping a runtime stops its pool; a subsequent runtime gets a fresh,
+    /// usable pool rather than a stale/stopped handle. The drop must not hang
+    /// (its pool joins its own workers), and the fresh pool must accept work —
+    /// a stopped handle would return `PoolStopped`.
+    #[test]
+    fn runtime_drop_stops_its_pool_then_fresh_runtime_gets_a_live_pool() {
+        let _lock = crate::scheduler::SchedTestLock::acquire();
+
+        {
+            let rt = crate::runtime::RuntimeInner::new(crate::scheduler::worker_less_scheduler());
+            // SAFETY: rt is a stack local that outlives its enter guard.
+            let _enter = unsafe { crate::runtime::enter(&rt) };
+            let pool = shared_blocking_pool();
+            // SAFETY: pool is this runtime's live pool.
+            let ran = unsafe { spawn_blocking_result(pool, || 7_i32, None) };
+            assert_eq!(ran, Ok(7));
+            // rt drops here: its pool is stopped (workers joined) without hanging.
+        }
+
+        let rt2 = crate::runtime::RuntimeInner::new(crate::scheduler::worker_less_scheduler());
+        // SAFETY: rt2 is a stack local that outlives its enter guard.
+        let _enter = unsafe { crate::runtime::enter(&rt2) };
+        let pool2 = shared_blocking_pool();
+        assert!(
+            !pool2.is_null(),
+            "the fresh runtime lazily creates a new pool"
+        );
+        // A stale/stopped handle would reject work; a live fresh pool accepts it.
+        // SAFETY: pool2 is rt2's live pool.
+        let ran = unsafe { spawn_blocking_result(pool2, || 99_i32, None) };
+        assert_eq!(ran, Ok(99));
+    }
+
+    /// `shared_blocking_pool()` is an init/mutate site (it spawns threads), so it
+    /// resolves through the fail-closed `rt_current()`. With no runtime installed
+    /// it panics rather than fabricating a process-global pool — pinning the
+    /// `deglobalize-reads-stay-tolerant` / `no-fail-open-fallback-after-authority`
+    /// classification. If this panic is ever seen from a production path, that is
+    /// scope-guard condition 1 (a no-runtime caller).
+    #[test]
+    fn shared_blocking_pool_without_runtime_fails_closed() {
+        let _lock = crate::scheduler::SchedTestLock::acquire();
+        assert!(
+            crate::runtime::rt_default().is_none(),
+            "test requires the default runtime slot to be empty"
+        );
+
+        let panicked = std::panic::catch_unwind(shared_blocking_pool).is_err();
+        assert!(
+            panicked,
+            "shared_blocking_pool with no runtime installed must fail closed (panic)"
+        );
     }
 
     /// Null pool: caller gets `PoolStopped` without leaking the boxed task

--- a/hew-runtime/src/blocking_pool.rs
+++ b/hew-runtime/src/blocking_pool.rs
@@ -116,6 +116,12 @@ pub enum BlockingPoolError {
     TimedOut,
     /// The pool was null or has been stopped; the task was never enqueued.
     PoolStopped,
+    /// No runtime is installed, so there is no pool to offload onto. Surfaced by
+    /// the fail-closed [`shared_blocking_pool_opt`] path when a C-ABI offload
+    /// entrypoint is reached before `hew_sched_init` (production) or without a
+    /// runtime test guard (tests). The task was never enqueued; the entrypoint
+    /// returns a clean error to the C caller instead of aborting.
+    NoRuntime,
 }
 
 /// Result slot shared between the caller (waits) and the worker (writes).
@@ -353,6 +359,23 @@ impl Drop for OwnedBlockingPool {
 #[must_use]
 pub fn shared_blocking_pool() -> *mut HewBlockingPool {
     crate::runtime::rt_current().blocking_pool()
+}
+
+/// Return the calling runtime's blocking pool, or `None` when no runtime is
+/// installed.
+///
+/// This is the fail-closed sibling of [`shared_blocking_pool`]: it resolves
+/// through the non-panicking [`crate::runtime::rt_current_opt`] instead of the
+/// trapping `rt_current()`. C-ABI entrypoints that offload blocking syscalls
+/// (DNS resolve, TCP connect) call this so a request issued before
+/// `hew_sched_init` installs a runtime — or after teardown drops it — returns a
+/// defined error to the C caller instead of aborting across the ABI boundary.
+///
+/// Reaching a blocking-pool offload with no runtime installed is a programming
+/// error, but it must surface as a clean error return, never a SIGABRT.
+#[must_use]
+pub fn shared_blocking_pool_opt() -> Option<*mut HewBlockingPool> {
+    crate::runtime::rt_current_opt().map(crate::runtime::RuntimeInner::blocking_pool)
 }
 
 /// Stop the pool: reject new work, wake all workers, and join threads.
@@ -758,6 +781,32 @@ mod tests {
             panicked,
             "shared_blocking_pool with no runtime installed must fail closed (panic)"
         );
+    }
+
+    /// `shared_blocking_pool_opt` is the fail-closed sibling C-ABI offload
+    /// entrypoints resolve through: `None` with no runtime installed (so the
+    /// entrypoint returns a clean error instead of aborting), `Some` live pool
+    /// once a runtime is installed.
+    #[test]
+    fn shared_blocking_pool_opt_reflects_runtime_presence() {
+        let _lock = crate::scheduler::SchedTestLock::acquire();
+        assert!(
+            crate::runtime::rt_default().is_none(),
+            "test requires the default runtime slot to be empty"
+        );
+        assert!(
+            shared_blocking_pool_opt().is_none(),
+            "no runtime installed must resolve to None, not a fabricated pool"
+        );
+
+        let rt = crate::runtime::RuntimeInner::new(crate::scheduler::worker_less_scheduler());
+        // SAFETY: rt is a stack local that outlives its enter guard.
+        let _enter = unsafe { crate::runtime::enter(&rt) };
+        let pool = shared_blocking_pool_opt().expect("a runtime is installed");
+        assert!(!pool.is_null(), "an installed runtime yields a live pool");
+        // SAFETY: pool is the installed runtime's live pool.
+        let ran = unsafe { spawn_blocking_result(pool, || 7_u32, None) };
+        assert_eq!(ran, Ok(7));
     }
 
     /// Null pool: caller gets `PoolStopped` without leaking the boxed task

--- a/hew-runtime/src/execution_context.rs
+++ b/hew-runtime/src/execution_context.rs
@@ -159,13 +159,21 @@ pub fn set_current_partition_policy(policy: PartitionPolicy) -> bool {
 
 /// C-ABI surface for configuring the current dispatch's partition policy.
 ///
-/// `tag` is a [`PartitionPolicy`] discriminant; an unrecognised tag decodes to
-/// the `FailFast` default rather than fabricating a policy. Returns `false`
-/// when no execution context is installed (the slot cannot be set outside a
-/// dispatch boundary). Symmetric with the reader surface.
+/// `tag` is a [`PartitionPolicy`] discriminant, declared at a fixed 64-bit
+/// width (`i64`) so the extern is target-stable: `usize` is 32-bit on wasm32
+/// and would truncate the 64-bit argument the Hew extern pushes
+/// (`std/link_monitor.hew`: `fn hew_set_partition_policy(tag: i64) -> bool`;
+/// `ffi-abi-width-mirror`). An unrecognised tag — including a negative one, or
+/// (on a 32-bit target) one above `usize::MAX` — maps via the saturating
+/// `try_from` to `usize::MAX`, which `from_slot` fails closed to the `FailFast`
+/// default rather than fabricating a policy. Returns `false` when no execution
+/// context is installed (the slot cannot be set outside a dispatch boundary).
 #[no_mangle]
-pub extern "C" fn hew_set_partition_policy(tag: usize) -> bool {
-    set_current_partition_policy(PartitionPolicy::from_slot(tag as *const c_void))
+pub extern "C" fn hew_set_partition_policy(tag: i64) -> bool {
+    // A negative or out-of-range tag saturates to `usize::MAX`, an
+    // unrecognised slot value that `from_slot` decodes as `FailFast`.
+    let slot = usize::try_from(tag).unwrap_or(usize::MAX);
+    set_current_partition_policy(PartitionPolicy::from_slot(slot as *const c_void))
 }
 
 /// Target-architecture-aware byte size of [`HewExecutionContext`].
@@ -909,7 +917,9 @@ mod tests {
     }
 
     /// The C-ABI setter decodes the integer tag and writes the installed slot;
-    /// the reader projects the same policy back.
+    /// the reader projects the same policy back. The tag is passed at the
+    /// extern's `i64` width (`std/link_monitor.hew`), and a negative/unknown tag
+    /// fails closed to `FailFast`.
     #[test]
     fn hew_set_partition_policy_writes_slot_via_tag() {
         let _runtime_guard = crate::runtime_test_guard();
@@ -918,11 +928,30 @@ mod tests {
         let mut ctx = HewExecutionContext::default();
         let installed = &raw mut ctx;
         let prev = set_current_context(installed);
-        assert!(hew_set_partition_policy(
-            PartitionPolicy::Quarantine as usize
-        ));
+        assert!(hew_set_partition_policy(PartitionPolicy::Quarantine as i64));
         assert_eq!(current_partition_policy(), PartitionPolicy::Quarantine);
+        // A negative/unrecognised tag decodes to the FailFast default rather
+        // than fabricating a policy; the call still succeeds (a context is
+        // installed) and overwrites the slot.
+        assert!(hew_set_partition_policy(-1));
+        assert_eq!(current_partition_policy(), PartitionPolicy::FailFast);
         let _ = set_current_context(prev);
+    }
+
+    /// With no execution context installed the C-ABI setter fails closed:
+    /// it returns exactly `false` (not merely "not true"), because a partition
+    /// policy has no meaning outside an actor dispatch. This pins the
+    /// fail-closed contract the Hew wrapper (`set_partition_policy`) relies on.
+    #[test]
+    fn hew_set_partition_policy_fails_closed_without_context() {
+        let _runtime_guard = crate::runtime_test_guard();
+        let _context_guard = ContextResetGuard::new();
+
+        // No context installed for this dispatch.
+        assert!(current_context().is_null());
+        assert!(!hew_set_partition_policy(
+            PartitionPolicy::Quarantine as i64
+        ));
     }
 
     /// SEC-1 regression: a scoped reply-channel swap must transfer BOTH the

--- a/hew-runtime/src/hew_node.rs
+++ b/hew-runtime/src/hew_node.rs
@@ -5708,6 +5708,69 @@ mod tests {
         unsafe { assert_eq!(hew_node_stop(node_handle.as_ptr()), 0) };
     }
 
+    /// The `hew_set_partition_policy` C-ABI symbol — the exact export the Hew
+    /// surface (`std/link_monitor.hew`: `set_partition_policy`) lowers to —
+    /// flips the real send gate. This is the policy-takes-effect leg: driving
+    /// the setter (rather than pre-baking the slot as the test above does)
+    /// proves the FFI entry point installed on the dispatch context is what the
+    /// quarantine consult reads.
+    #[test]
+    fn set_partition_policy_symbol_drives_the_quarantine_gate() {
+        use crate::execution_context::{
+            hew_set_partition_policy, HewExecutionContext, PartitionPolicy, TestExecutionContext,
+        };
+        const PEER: u16 = 612;
+
+        // Position IS the ABI: the C-ABI tag is the discriminant, and the two
+        // Hew-side declarations that mirror it (`std/link_monitor.hew`'s
+        // `PartitionPolicy` and the `MONITOR_REF_HEW` prelude enum in
+        // `hew-types` `check::registration`) must keep this exact order. A drift
+        // here would silently misroute a policy tag across the FFI boundary
+        // (`builtin-enum-variant-mirror-discipline`).
+        assert_eq!(PartitionPolicy::FailFast as i64, 0);
+        assert_eq!(PartitionPolicy::Deadline as i64, 1);
+        assert_eq!(PartitionPolicy::MonitorLost as i64, 2);
+        assert_eq!(PartitionPolicy::CrashLinked as i64, 3);
+        assert_eq!(PartitionPolicy::Quarantine as i64, 4);
+
+        let _guard = crate::runtime_test_guard();
+        let bind_addr = CString::new("127.0.0.1:0").expect("valid bind addr");
+        // SAFETY: bind_addr is a valid C string for the duration of this test.
+        let node_handle = unsafe { TestNode::new(611, &bind_addr) };
+        assert!(!node_handle.as_ptr().is_null());
+        // SAFETY: pointer came from TestNode::new and is valid until drop.
+        unsafe { assert_eq!(hew_node_start(node_handle.as_ptr()), 0) };
+        // SAFETY: started node has a non-null cluster.
+        let node = unsafe { &*node_handle.as_ptr() };
+        assert!(!node.cluster.is_null());
+        // SAFETY: cluster is valid while the node is running.
+        let cluster = unsafe { &*node.cluster };
+        cluster.seed_member_for_test(PEER, crate::cluster::MEMBER_DEAD, 5);
+        quarantine_insert(PEER, 5);
+
+        // Install a dispatch context with the DEFAULT (null) policy slot, then
+        // drive the policy purely through the C-ABI setter.
+        let _ctx_guard = TestExecutionContext::install(HewExecutionContext::default());
+
+        // Quarantine (tag 4) installed via the setter blocks the buried peer.
+        assert!(hew_set_partition_policy(4));
+        assert!(
+            quarantine_blocks_send(node, PEER),
+            "Quarantine set via hew_set_partition_policy must block the buried peer"
+        );
+
+        // Overwriting with FailFast (tag 0) via the same setter clears the block:
+        // the slot is writable repeatedly within one dispatch, not one-shot.
+        assert!(hew_set_partition_policy(0));
+        assert!(
+            !quarantine_blocks_send(node, PEER),
+            "FailFast set via hew_set_partition_policy must not consult the set"
+        );
+
+        // SAFETY: stop the node before drop.
+        unsafe { assert_eq!(hew_node_stop(node_handle.as_ptr()), 0) };
+    }
+
     /// Initialise a real, worker-backed scheduler for a node test (delegates to
     /// the scheduler-side helper, which sees the module-private `stealers` and
     /// safely retires a `runtime_test_guard()` placeholder before init).

--- a/hew-runtime/src/runtime.rs
+++ b/hew-runtime/src/runtime.rs
@@ -97,6 +97,17 @@ pub(crate) struct RuntimeInner {
     /// (the `hew_node_monitor_recv` observation slots) and target-side remote
     /// watchers (the terminal-sweep fan-out list).
     pub(crate) dist_monitors: crate::dist_monitor::DistMonitorState,
+    /// Blocking-work thread pool for deadline-bounded syscall offload (DNS,
+    /// TCP connect). Was the process-global `blocking_pool::SHARED_POOL`
+    /// singleton; resolved through `rt_current()` by `shared_blocking_pool()`.
+    /// Lazily created on the first offload — a runtime that never touches
+    /// DNS/TCP spawns no pool threads — and stopped (queue drained, workers
+    /// joined) when this runtime drops. `hew_runtime_cleanup` has already joined
+    /// every submitting thread (reactor, ticker, workers) by then, so the pool's
+    /// `Drop` cannot strand a parked submitter (see the `hew_runtime_cleanup`
+    /// ordering). Two runtimes no longer share (or leak) one process-lifetime
+    /// pool.
+    pub(crate) blocking_pool: std::sync::OnceLock<crate::blocking_pool::OwnedBlockingPool>,
     /// Per-instance drop observer for the "exactly once" teardown oracles.
     ///
     /// Replaces the former process-global `RUNTIME_INNER_DROPS` counter, whose
@@ -126,6 +137,7 @@ impl RuntimeInner {
             metrics: crate::metrics::MetricsState::new(),
             monitors: crate::monitor::MonitorState::new(),
             dist_monitors: crate::dist_monitor::DistMonitorState::new(),
+            blocking_pool: std::sync::OnceLock::new(),
             #[cfg(test)]
             drop_probe: std::sync::Mutex::new(None),
         }
@@ -163,6 +175,18 @@ impl RuntimeInner {
     )]
     pub(crate) fn runtime_id(&self) -> RuntimeId {
         self.id
+    }
+
+    /// This runtime's blocking pool, created on first use.
+    ///
+    /// The [`OnceLock`](std::sync::OnceLock) keeps the pool private to the
+    /// runtime while `blocking_pool::shared_blocking_pool()` reads the raw
+    /// pointer through this accessor. First call spawns the pool's worker
+    /// threads; the pool is stopped when this runtime drops.
+    pub(crate) fn blocking_pool(&self) -> *mut crate::blocking_pool::HewBlockingPool {
+        self.blocking_pool
+            .get_or_init(crate::blocking_pool::OwnedBlockingPool::new)
+            .as_ptr()
     }
 }
 

--- a/hew-runtime/src/stream.rs
+++ b/hew-runtime/src/stream.rs
@@ -5049,6 +5049,9 @@ mod tests {
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
     fn factory_returns_pair_for_valid_conn() {
+        // `hew_tcp_connect` (in `make_loopback_conn`) offloads the resolve onto
+        // the current runtime's blocking pool, so a runtime must be installed.
+        let _guard = crate::runtime_test_guard();
         let (conn_handle, _peer) = make_loopback_conn();
 
         // SAFETY: conn_handle is a valid registered connection.
@@ -5099,6 +5102,9 @@ mod tests {
     #[test]
     #[cfg(not(target_arch = "wasm32"))]
     fn factory_consumes_original_conn_handle() {
+        // See `factory_returns_pair_for_valid_conn`: the connect offload needs a
+        // runtime-owned blocking pool.
+        let _guard = crate::runtime_test_guard();
         let (conn_handle, _peer) = make_loopback_conn();
 
         // SAFETY: conn_handle is valid.

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -20,7 +20,7 @@ use std::sync::{
     LazyLock, OnceLock,
 };
 
-use crate::blocking_pool::{shared_blocking_pool, spawn_blocking_result, BlockingPoolError};
+use crate::blocking_pool::{shared_blocking_pool_opt, spawn_blocking_result, BlockingPoolError};
 use crate::lifetime::poison_safe::{PoisonSafe, PoisonSafeRw};
 
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
@@ -1481,13 +1481,19 @@ fn resolve_addr_via_pool(
         #[expect(clippy::cast_sign_loss, reason = "checked > 0 above")]
         Some(std::time::Duration::from_millis(deadline_ms as u64))
     };
-    // SAFETY: shared_blocking_pool returns the current runtime's pool, valid
+    // Fail closed when no runtime is installed: reaching this offload without a
+    // runtime is a programming error, but it must return a defined error to the
+    // C caller rather than abort in `rt_current()` across the ABI boundary.
+    let Some(pool) = shared_blocking_pool_opt() else {
+        return Err(BlockingPoolError::NoRuntime);
+    };
+    // SAFETY: shared_blocking_pool_opt returns the current runtime's pool, valid
     // for that runtime's lifetime; this offload runs on a scheduler/reactor
     // thread that cleanup joins before the runtime (and its pool) is dropped,
     // so the pointer stays valid for this call.
     unsafe {
         spawn_blocking_result(
-            shared_blocking_pool(),
+            pool,
             move || {
                 target
                     .to_socket_addrs()
@@ -1560,6 +1566,16 @@ pub unsafe extern "C" fn hew_tcp_connect_timed(addr: *const c_char, deadline_ms:
             hew_cabi::sink::set_last_error_with_errno(
                 String::from("hew_tcp_connect: DNS resolution failed"),
                 0,
+            );
+            return -1;
+        }
+        Err(BlockingPoolError::NoRuntime) => {
+            // Fail closed: no runtime installed, so no blocking pool to offload
+            // DNS onto. Clean -1 with EINVAL rather than a SIGABRT across the ABI.
+            tcp_counters().error_count.fetch_add(1, Ordering::Relaxed);
+            hew_cabi::sink::set_last_error_with_errno(
+                String::from("hew_tcp_connect: no runtime installed"),
+                22, // EINVAL: entrypoint called before hew_sched_init
             );
             return -1;
         }
@@ -1748,6 +1764,16 @@ pub unsafe extern "C" fn hew_tcp_connect_timeout(
             return -1;
         }
         Err(BlockingPoolError::PoolStopped) => {
+            return -1;
+        }
+        Err(BlockingPoolError::NoRuntime) => {
+            // Fail closed: no runtime installed, so no blocking pool to offload
+            // DNS onto. Clean -1 with EINVAL rather than a SIGABRT across the ABI.
+            tcp_counters().error_count.fetch_add(1, Ordering::Relaxed);
+            hew_cabi::sink::set_last_error_with_errno(
+                String::from("hew_tcp_connect_timeout: no runtime installed"),
+                22, // EINVAL: entrypoint called before hew_sched_init
+            );
             return -1;
         }
     };
@@ -2451,6 +2477,49 @@ mod tests {
                 unsafe { crate::bytes::hew_bytes_drop(bytes.ptr) };
                 remove_stream(handle);
             },
+        );
+    }
+
+    /// A blocking-pool FFI entrypoint reached with NO runtime installed must
+    /// fail closed with a clean errno return, never abort in `rt_current()`
+    /// across the C ABI. This is the negative test the original blocking-pool
+    /// inventory lacked: `hew_tcp_connect*` reached the pool unguarded and would
+    /// SIGABRT when called before `hew_sched_init` installs a runtime.
+    #[test]
+    fn tcp_connect_without_runtime_fails_closed() {
+        let _lock = crate::scheduler::SchedTestLock::acquire();
+        assert!(
+            crate::runtime::rt_default().is_none(),
+            "test requires the default runtime slot to be empty"
+        );
+        let _ = hew_cabi::sink::take_last_errno();
+
+        let addr = std::ffi::CString::new("example.com:80").expect("valid C string");
+        // SAFETY: `addr` is a valid, NUL-terminated C string; the entrypoint must
+        // return -1 with no runtime installed, never abort.
+        let rc = unsafe { hew_tcp_connect(addr.as_ptr()) };
+        assert_eq!(
+            rc, -1,
+            "connect with no runtime installed must return -1, not abort"
+        );
+        assert_eq!(
+            hew_cabi::sink::take_last_errno(),
+            22,
+            "a no-runtime blocking offload must surface EINVAL (22)"
+        );
+
+        // The port-form entrypoint fails closed on the same guarded path.
+        let host = std::ffi::CString::new("example.com").expect("valid C string");
+        // SAFETY: `host` is a valid, NUL-terminated C string.
+        let rc = unsafe { hew_tcp_connect_timeout(host.as_ptr(), 80, 1000) };
+        assert_eq!(
+            rc, -1,
+            "connect_timeout with no runtime installed must return -1, not abort"
+        );
+        assert_eq!(
+            hew_cabi::sink::take_last_errno(),
+            22,
+            "a no-runtime blocking offload must surface EINVAL (22)"
         );
     }
 

--- a/hew-runtime/src/transport.rs
+++ b/hew-runtime/src/transport.rs
@@ -1481,8 +1481,10 @@ fn resolve_addr_via_pool(
         #[expect(clippy::cast_sign_loss, reason = "checked > 0 above")]
         Some(std::time::Duration::from_millis(deadline_ms as u64))
     };
-    // SAFETY: shared_blocking_pool returns a process-lifetime, never-stopped
-    // pool whose pointer stays valid for this call.
+    // SAFETY: shared_blocking_pool returns the current runtime's pool, valid
+    // for that runtime's lifetime; this offload runs on a scheduler/reactor
+    // thread that cleanup joins before the runtime (and its pool) is dropped,
+    // so the pointer stays valid for this call.
     unsafe {
         spawn_blocking_result(
             shared_blocking_pool(),

--- a/hew-runtime/tests/tcp_stream_bridge.rs
+++ b/hew-runtime/tests/tcp_stream_bridge.rs
@@ -26,6 +26,9 @@ use hew_runtime::transport::{hew_tcp_connect, hew_tcp_set_read_timeout};
 /// Bind a loopback listener, connect via `hew_tcp_connect` (so the handle is
 /// registered in `TCP_API_STATE`), and return (`conn_handle`, `peer_stream`).
 fn make_bridge_pair() -> (i32, TcpStream) {
+    // `hew_tcp_connect` offloads the resolve onto the current runtime's blocking
+    // pool, so a runtime must be installed first (idempotent across tests).
+    hew_runtime_testkit::ensure_scheduler();
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port();
     let addr = CString::new(format!("127.0.0.1:{port}")).unwrap();
@@ -245,6 +248,8 @@ fn compose_with_chunks_adapter() {
 /// can then call `hew_stream_last_errno()` to tell the pause from clean EOF.
 #[test]
 fn read_timeout_sets_nonzero_errno() {
+    // `hew_tcp_connect` needs a runtime-owned blocking pool (idempotent init).
+    hew_runtime_testkit::ensure_scheduler();
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port();
     let addr = CString::new(format!("127.0.0.1:{port}")).unwrap();

--- a/hew-runtime/tests/tcp_stream_clone_ownership.rs
+++ b/hew-runtime/tests/tcp_stream_clone_ownership.rs
@@ -40,6 +40,9 @@ use hew_runtime::transport::{
 /// registered in `TCP_API_STATE`), and return `(conn_handle, peer_stream)`.
 /// Mirrors `tcp_stream_bridge.rs::make_bridge_pair`.
 fn make_bridge_pair() -> (i32, TcpStream) {
+    // `hew_tcp_connect` offloads the resolve onto the current runtime's blocking
+    // pool, so a runtime must be installed first (idempotent across tests).
+    hew_runtime_testkit::ensure_scheduler();
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port();
     let addr = CString::new(format!("127.0.0.1:{port}")).unwrap();

--- a/hew-std/src/dns.rs
+++ b/hew-std/src/dns.rs
@@ -33,8 +33,10 @@ fn resolve_via_pool(host: &str, deadline_ms: i64) -> Result<Vec<IpAddr>, bool> {
         #[expect(clippy::cast_sign_loss, reason = "deadline_ms is checked > 0 above")]
         Some(Duration::from_millis(deadline_ms as u64))
     };
-    // SAFETY: shared_blocking_pool returns a process-lifetime pool that is
-    // never stopped; the pointer is valid for the call.
+    // SAFETY: shared_blocking_pool returns the current runtime's pool, valid for
+    // that runtime's lifetime; the resolve runs on a scheduler thread that
+    // cleanup joins before the runtime (and its pool) drops, so the pointer is
+    // valid for the call.
     let result = unsafe {
         spawn_blocking_result(
             shared_blocking_pool(),
@@ -169,6 +171,11 @@ mod tests {
     use super::*;
     use std::ffi::{CStr, CString};
 
+    // Resolving through the blocking pool now requires an installed runtime
+    // (`shared_blocking_pool()` reads `rt_current()`); this guard installs a
+    // real scheduler under a process-wide lock and stops the pool on drop.
+    use crate::net_error_slot_test_support::NetErrorSlotRuntimeGuard;
+
     /// Helper: read a C string pointer and free it.
     unsafe fn read_and_free(ptr: *mut c_char) -> String {
         assert!(!ptr.is_null());
@@ -181,6 +188,7 @@ mod tests {
 
     #[test]
     fn resolve_localhost() {
+        let _rt = NetErrorSlotRuntimeGuard::new();
         let host = CString::new("localhost").unwrap();
         // SAFETY: host is a valid NUL-terminated C string.
         let vec = unsafe { hew_dns_resolve(host.as_ptr()) };
@@ -207,6 +215,7 @@ mod tests {
 
     #[test]
     fn lookup_host_localhost() {
+        let _rt = NetErrorSlotRuntimeGuard::new();
         let host = CString::new("localhost").unwrap();
         // SAFETY: host is a valid NUL-terminated C string.
         let result = unsafe { hew_dns_lookup_host(host.as_ptr()) };
@@ -240,6 +249,7 @@ mod tests {
 
     #[test]
     fn resolve_invalid_hostname_returns_empty() {
+        let _rt = NetErrorSlotRuntimeGuard::new();
         let host = CString::new("this-host-does-not-exist.invalid.test").unwrap();
         // SAFETY: host is a valid NUL-terminated C string.
         let vec = unsafe { hew_dns_resolve(host.as_ptr()) };
@@ -252,6 +262,7 @@ mod tests {
 
     #[test]
     fn lookup_host_invalid_returns_null() {
+        let _rt = NetErrorSlotRuntimeGuard::new();
         let host = CString::new("this-host-does-not-exist.invalid.test").unwrap();
         // SAFETY: host is a valid NUL-terminated C string.
         let result = unsafe { hew_dns_lookup_host(host.as_ptr()) };
@@ -283,6 +294,7 @@ mod tests {
     /// well-known local host. Proves the delegating shim is wired right.
     #[test]
     fn resolve_timed_zero_means_no_deadline() {
+        let _rt = NetErrorSlotRuntimeGuard::new();
         let host = CString::new("localhost").unwrap();
         // SAFETY: host is a valid NUL-terminated C string.
         let vec = unsafe { hew_dns_resolve_timed(host.as_ptr(), 0) };
@@ -314,11 +326,16 @@ mod tests {
         use std::sync::Barrier;
         use std::time::{Duration, Instant};
 
+        // `shared_blocking_pool()` now resolves the current runtime's pool, so a
+        // runtime must be installed for the duration of the offload.
+        let _runtime = NetErrorSlotRuntimeGuard::new();
+
         let release = std::sync::Arc::new(Barrier::new(2));
         let release_clone = std::sync::Arc::clone(&release);
 
         let start = Instant::now();
-        // SAFETY: shared_blocking_pool returns a process-lifetime pool.
+        // SAFETY: shared_blocking_pool returns the current runtime's pool, valid
+        // while `_runtime` is held.
         let result = unsafe {
             spawn_blocking_result(
                 shared_blocking_pool(),

--- a/hew-std/src/dns.rs
+++ b/hew-std/src/dns.rs
@@ -5,7 +5,9 @@
 //! `libc::malloc` and NUL-terminated.
 use hew_cabi::cabi::{cstr_to_str, str_to_malloc};
 use hew_cabi::vec::HewVec;
-use hew_runtime::blocking_pool::{shared_blocking_pool, spawn_blocking_result, BlockingPoolError};
+use hew_runtime::blocking_pool::{
+    shared_blocking_pool_opt, spawn_blocking_result, BlockingPoolError,
+};
 use std::net::{IpAddr, ToSocketAddrs};
 use std::os::raw::c_char;
 use std::time::Duration;
@@ -23,7 +25,9 @@ use std::time::Duration;
 ///   The pool thread keeps running `getaddrinfo` until it returns; its
 ///   result is discarded when the worker publishes it (no leak; see
 ///   `spawn_blocking_result` saturation note).
-/// - `Err(false)` — `getaddrinfo` itself errored, or the pool was stopped.
+/// - `Err(false)` — `getaddrinfo` itself errored, the pool was stopped, or no
+///   runtime is installed (fail closed: the entrypoint returns its empty/null
+///   sentinel rather than aborting across the ABI).
 fn resolve_via_pool(host: &str, deadline_ms: i64) -> Result<Vec<IpAddr>, bool> {
     let host = format!("{host}:0");
     let deadline = if deadline_ms <= 0 {
@@ -33,13 +37,19 @@ fn resolve_via_pool(host: &str, deadline_ms: i64) -> Result<Vec<IpAddr>, bool> {
         #[expect(clippy::cast_sign_loss, reason = "deadline_ms is checked > 0 above")]
         Some(Duration::from_millis(deadline_ms as u64))
     };
-    // SAFETY: shared_blocking_pool returns the current runtime's pool, valid for
-    // that runtime's lifetime; the resolve runs on a scheduler thread that
+    // Fail closed when no runtime is installed: reaching this offload without a
+    // runtime is a programming error, but it must return the empty/null sentinel
+    // to the C caller rather than abort in `rt_current()` across the ABI.
+    let Some(pool) = shared_blocking_pool_opt() else {
+        return Err(false);
+    };
+    // SAFETY: shared_blocking_pool_opt returns the current runtime's pool, valid
+    // for that runtime's lifetime; the resolve runs on a scheduler thread that
     // cleanup joins before the runtime (and its pool) drops, so the pointer is
     // valid for the call.
     let result = unsafe {
         spawn_blocking_result(
-            shared_blocking_pool(),
+            pool,
             move || {
                 // Collect inside the closure so the iterator (which is not
                 // Send) doesn't escape; the result is `Vec<IpAddr>` which is.
@@ -53,7 +63,9 @@ fn resolve_via_pool(host: &str, deadline_ms: i64) -> Result<Vec<IpAddr>, bool> {
     match result {
         Ok(Ok(addrs)) => Ok(addrs),
         Err(BlockingPoolError::TimedOut) => Err(true),
-        Ok(Err(())) | Err(BlockingPoolError::PoolStopped) => Err(false),
+        Ok(Err(())) | Err(BlockingPoolError::PoolStopped | BlockingPoolError::NoRuntime) => {
+            Err(false)
+        }
     }
 }
 
@@ -238,6 +250,44 @@ mod tests {
         assert_eq!(unsafe { hew_cabi::vec::hew_vec_len(vec) }, 0);
         // SAFETY: vec was allocated by hew_dns_resolve and has not been freed.
         unsafe { hew_cabi::vec::hew_vec_free(vec) };
+    }
+
+    /// A DNS entrypoint reached with a real hostname but NO runtime installed
+    /// must fail closed with the empty/null sentinel, never abort in
+    /// `rt_current()` across the C ABI. This is the negative test the original
+    /// blocking-pool inventory lacked: the production entrypoints reached the
+    /// pool unguarded and would SIGABRT when called before `hew_sched_init`.
+    #[test]
+    fn resolve_without_runtime_fails_closed() {
+        // Hold the shared scheduler lock so no concurrent guard installs a
+        // runtime; do NOT install one ourselves.
+        let _lock = crate::net_error_slot_test_support::lock_without_runtime();
+        assert!(
+            shared_blocking_pool_opt().is_none(),
+            "test requires no runtime installed"
+        );
+
+        let host = CString::new("example.com").unwrap();
+        // SAFETY: host is a valid NUL-terminated C string; reaching the offload
+        // with no runtime must return an empty vec, not abort.
+        let vec = unsafe { hew_dns_resolve(host.as_ptr()) };
+        assert!(!vec.is_null(), "must return an empty vec, not null/abort");
+        // SAFETY: vec is a valid HewVec returned by hew_dns_resolve.
+        let len = unsafe { hew_cabi::vec::hew_vec_len(vec) };
+        assert_eq!(
+            len, 0,
+            "no runtime installed => empty resolution, fail closed"
+        );
+        // SAFETY: vec was allocated by hew_dns_resolve and has not been freed.
+        unsafe { hew_cabi::vec::hew_vec_free(vec) };
+
+        // The lookup variant fails closed to null on the same path.
+        // SAFETY: host is a valid NUL-terminated C string.
+        let result = unsafe { hew_dns_lookup_host(host.as_ptr()) };
+        assert!(
+            result.is_null(),
+            "lookup with no runtime must return null, not abort"
+        );
     }
 
     #[test]

--- a/hew-std/src/net_error_slot_test_support.rs
+++ b/hew-std/src/net_error_slot_test_support.rs
@@ -44,6 +44,19 @@ impl Drop for NetErrorSlotRuntimeGuard {
     }
 }
 
+/// Acquire the shared scheduler lock WITHOUT installing a runtime.
+///
+/// The fail-closed no-runtime tests need the guarantee that no runtime is
+/// installed while they exercise a blocking-pool FFI entrypoint. Holding this
+/// lock excludes every [`NetErrorSlotRuntimeGuard`]-based test from installing a
+/// scheduler on the single process-global slot for the returned guard's
+/// lifetime, so `shared_blocking_pool_opt()` observes `None`.
+pub(crate) fn lock_without_runtime() -> MutexGuard<'static, ()> {
+    NET_ERROR_SLOT_RUNTIME_TEST_LOCK
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
 /// Spawn a minimal, never-scheduled actor solely to obtain a stable,
 /// dereferenceable actor identity for `hew_actor_current_id()`. The dispatch
 /// stub is never invoked — this actor receives no messages.


### PR DESCRIPTION
## Summary

The blocking-work thread pool (deadline-bounded DNS/TCP-connect syscall offload) was a process-global `SHARED_POOL` singleton that was never stopped. It's now an `OwnedBlockingPool` field on `RuntimeInner`, created lazily on first offload and stopped (queue drained, workers joined) via a `Drop` when the runtime tears down — two runtimes no longer share or leak one process-lifetime pool.

Separately, `hew_set_partition_policy`'s C-ABI width didn't match its Hew extern: the setter took `tag: usize` (32-bit on wasm32), while `std/link_monitor.hew` declares and calls it with `i64`, which would truncate on wasm32. Fixed to a fixed-width `i64` parameter; an out-of-range tag now saturates to `usize::MAX` and fails closed to `FailFast` instead of fabricating a policy.

Last, the DNS/TCP-connect C-ABI entrypoints (`hew_dns_resolve*`, `hew_dns_lookup_host*`, `hew_tcp_connect*`) reached the blocking pool through `rt_current()`, which panics if no runtime is installed — a call to any of these before `hew_sched_init` would abort the process across the FFI boundary. They now route through a non-panicking `shared_blocking_pool_opt()`: DNS entrypoints return their empty-vec/null sentinel, TCP-connect entrypoints return -1 with `EINVAL`, instead of aborting.

## Verification

- `cargo test -p hew-runtime --lib`: 3261 passed, 0 failed, including new two-runtime pool-isolation tests and drop-ordering coverage.
- `make verify-ffi`: clean.
- New negative tests: DNS resolve/lookup and TCP-connect entrypoints with no runtime installed return their documented sentinel/errno rather than aborting — verified these tests fail without the guard (not just green).
- Preflight: ready-to-push.

## Out of scope

- A partition-policy compiler builtin — the `.hew`-facing surface is already covered by `std::link_monitor::set_partition_policy`, a pure library wrapper over the existing `hew_set_partition_policy` export. No new MIR lowering or codegen arm needed.
- Routing containers through channels — untouched by this change.
