### PR TITLE
fix(mir): mint the call-scrutinee owner for if-let and let-else

### DIFF
--- a/hew-cli/tests/if_let_call_scrutinee_leak_oracle.rs
+++ b/hew-cli/tests/if_let_call_scrutinee_leak_oracle.rs
@@ -1,0 +1,275 @@
+//! From-call `if let` scrutinee enum-payload leak oracle (#2429 class).
+//!
+//! `if let Some(b) = f() { … }` over an owned `Option`/`Result`/enum returned
+//! from a called function consumes the composite through an anonymous MIR temp.
+//! Before the fix, `lower_if_let` computed the #2648 admission but minted NO
+//! from-call owner (only `lower_match_enum_tag`/`lower_while_let` did), so the
+//! matched-arm payload was released on NO edge: each evaluation stranded one
+//! payload allocation — a `while … { if let Some(b) = f() { … } }` loop leaked
+//! one payload per iteration (validated slope 47 == 1 leak/iteration). The fix
+//! mints the synthetic scrutinee owner in `lower_if_let`, symmetric with
+//! match/while-let; the scope-exit drop elaboration then releases it on the
+//! matched edge (payload moved out, shell composite drop), the refuted `else`
+//! edge, and any nested-predicate fallthrough.
+//!
+//! Slope, not single-shot exact-zero: each shape is measured at LOW and HIGH
+//! iteration counts and the leak-node delta asserted within tolerance (the
+//! delta cancels the constant runtime baseline). A regression re-opens a
+//! 1-node-per-iteration slope and trips the assertion. The scribble pins are
+//! the exactly-once wall: the payload reads back verbatim before release, and
+//! the run exits clean under the poisoned-allocator triple (a double free
+//! aborts).
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+// ── slope shapes ────────────────────────────────────────────────────────────
+
+/// Owned `string` payload from a call, unwrapped by `if let Some` in a loop —
+/// the headline validated shape (slope 47 pre-fix).
+fn iflet_option_string_loop_source(frames: usize) -> String {
+    format!(
+        "fn f() -> Option<string> {{ Some(\"g2429-iflet-string\".to_upper()) }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       if let Some(b) = f() {{ total = total + b.len(); }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// `Result<bytes, _>` payload from a call, unwrapped by `if let Ok`.
+fn iflet_result_bytes_loop_source(frames: usize) -> String {
+    format!(
+        "fn f() -> Result<bytes, string> {{ Ok(\"g2429-iflet-bytes\".to_bytes()) }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       if let Ok(b) = f() {{ total = total + b.len(); }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// Composite (record) payload with an owned `string` field: rides the
+/// in-place composite drop through the same scrutinee seam.
+fn iflet_record_payload_loop_source(frames: usize) -> String {
+    format!(
+        "type Row {{\n\
+         \x20   name: string;\n\
+         \x20   id: i64;\n\
+         }}\n\
+         \n\
+         fn f(n: i64) -> Option<Row> {{\n\
+         \x20   Some(Row {{ name: \"g2429-iflet-row\".to_upper(), id: n }})\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       if let Some(r) = f(i) {{ total = total + r.id; }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total >= 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// The refuted (else) edge is the taken path every iteration: a `None`-tag
+/// call still allocates and returns the composite, whose shell must drop on
+/// the else edge. Flat slope proves the else-edge release fires.
+fn iflet_refuted_edge_loop_source(frames: usize) -> String {
+    format!(
+        "fn f() -> Option<string> {{ None }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var misses = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       if let Some(b) = f() {{ misses = misses + b.len(); }} else {{ misses = misses + 1; }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if misses == {frames} {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+// ── scope-guard shapes (must NOT over-widen the mint) ────────────────────────
+
+/// `Option<i64>` call scrutinee: no heap payload, so no owner is owed and no
+/// leak is possible. Flat slope pins that widening the mint did not introduce
+/// a spurious release of a scalar payload.
+fn scalar_iflet_loop_source(frames: usize) -> String {
+    format!(
+        "fn f() -> Option<i64> {{ Some(7) }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       if let Some(b) = f() {{ total = total + b; }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// An owned `Some(string)` bound to a LOCAL, then unwrapped by `if let` over
+/// the local — NOT a call scrutinee. The local already owns and drops the
+/// payload; `classify_call_scrutinee_admission` returns `NotApplicable` for a
+/// binding-ref scrutinee, so NO synthetic owner is minted. Flat slope pins
+/// that the mint stays gated on fresh owned-payload CALL scrutinees only —
+/// double-minting here would double-free.
+fn local_iflet_loop_source(frames: usize) -> String {
+    format!(
+        "fn main() -> i64 {{\n\
+         \x20   var total = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let opt = Some(\"g2429-local-owned\".to_upper());\n\
+         \x20       if let Some(b) = opt {{ total = total + b.len(); }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+// ── scribble exactly-once pins ──────────────────────────────────────────────
+
+/// Straight-line from-call `if let` scrutinee: released once, payload read
+/// back before the release. A double free (matched-edge release stacking on
+/// the shell composite drop) aborts under the poisoned allocator.
+const SINGLE_IFLET_SCRIBBLE_SOURCE: &str = "\
+fn f() -> Option<string> {\n\
+\x20   Some(\"g2429-iflet-single\".to_upper())\n\
+}\n\
+\n\
+fn main() {\n\
+\x20   if let Some(b) = f() {\n\
+\x20       if b.len() == 17 { print(\"m\"); }\n\
+\x20   }\n\
+}\n";
+
+/// Refuted edge straight-line: a `None`-tag composite must drop its shell on
+/// the else edge exactly once, no double free.
+const REFUTED_IFLET_SCRIBBLE_SOURCE: &str = "\
+fn f() -> Option<string> {\n\
+\x20   None\n\
+}\n\
+\n\
+fn main() {\n\
+\x20   if let Some(b) = f() {\n\
+\x20       print(b);\n\
+\x20   } else {\n\
+\x20       print(\"e\");\n\
+\x20   }\n\
+}\n";
+
+fn assert_exact_under_malloc_scribble(name: &str, source: &str, expected: &str) {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("if-let-call-scrutinee-{name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), name);
+    let output = run_under_malloc_scribble(&bin);
+
+    assert!(
+        output.status.success(),
+        "{name} must run clean under the poisoned allocator — a crash here means the \
+         from-call if-let scrutinee's payload was double-freed;\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        expected,
+        "{name} must read the payload back verbatim — scribbled/short output indicates a \
+         use-after-free read on a prematurely released payload;\n{}",
+        describe_output(&output)
+    );
+}
+
+// ── oracles ─────────────────────────────────────────────────────────────────
+
+/// #2429 if-let headline: owned-string payload holds a flat slope (slope 47
+/// pre-fix).
+#[test]
+fn iflet_option_string_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_iflet_option", iflet_option_string_loop_source);
+}
+
+/// `Result<bytes, _>` payload through the same if-let seam holds a flat slope.
+#[test]
+fn iflet_result_bytes_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_iflet_result", iflet_result_bytes_loop_source);
+}
+
+/// Record payload with an owned field rides the composite drop through the
+/// if-let seam.
+#[test]
+fn iflet_record_payload_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_iflet_record", iflet_record_payload_loop_source);
+}
+
+/// The refuted (else) edge releases the composite shell — flat slope proves
+/// the else-edge drop fires (care point A: mint precedes the branch).
+#[test]
+fn iflet_refuted_edge_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_iflet_refuted", iflet_refuted_edge_loop_source);
+}
+
+/// Scope guard: a scalar `Option<i64>` call scrutinee stays flat — the mint
+/// owes nothing and introduces no spurious release.
+#[test]
+fn scalar_iflet_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_iflet_scalar", scalar_iflet_loop_source);
+}
+
+/// Scope guard: an owned LOCAL unwrapped by if-let (not a call scrutinee)
+/// stays flat — the mint must not fire on a binding-ref scrutinee.
+#[test]
+fn local_iflet_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_iflet_local", local_iflet_loop_source);
+}
+
+/// Exactly-once wall: straight-line if-let releases the payload once, reads it
+/// back verbatim, no double free.
+#[test]
+fn single_from_call_iflet_no_double_free_under_malloc_scribble() {
+    assert_exact_under_malloc_scribble(
+        "g2429_single_iflet_scribble",
+        SINGLE_IFLET_SCRIBBLE_SOURCE,
+        "m",
+    );
+}
+
+/// Refuted-edge exactly-once wall: the `None`-tag composite shell drops once
+/// on the else edge, no double free.
+#[test]
+fn refuted_iflet_no_double_free_under_malloc_scribble() {
+    assert_exact_under_malloc_scribble(
+        "g2429_refuted_iflet_scribble",
+        REFUTED_IFLET_SCRIBBLE_SOURCE,
+        "e",
+    );
+}

--- a/hew-cli/tests/if_let_call_scrutinee_leak_oracle.rs
+++ b/hew-cli/tests/if_let_call_scrutinee_leak_oracle.rs
@@ -164,7 +164,7 @@ fn f() -> Option<string> {\n\
 \n\
 fn main() {\n\
 \x20   if let Some(b) = f() {\n\
-\x20       if b.len() == 17 { print(\"m\"); }\n\
+\x20       if b.len() == 18 { print(\"m\"); }\n\
 \x20   }\n\
 }\n";
 

--- a/hew-cli/tests/let_else_call_scrutinee_leak_oracle.rs
+++ b/hew-cli/tests/let_else_call_scrutinee_leak_oracle.rs
@@ -141,7 +141,7 @@ fn f() -> Option<string> {\n\
 \n\
 fn main() {\n\
 \x20   let Some(b) = f() else { return; };\n\
-\x20   if b.len() == 21 { print(\"m\"); }\n\
+\x20   if b.len() == 20 { print(\"m\"); }\n\
 }\n";
 
 fn assert_exact_under_malloc_scribble(name: &str, source: &str, expected: &str) {

--- a/hew-cli/tests/let_else_call_scrutinee_leak_oracle.rs
+++ b/hew-cli/tests/let_else_call_scrutinee_leak_oracle.rs
@@ -1,0 +1,219 @@
+//! From-call `let … else` scrutinee enum-payload leak oracle (#2429 class).
+//!
+//! `let Some(b) = f() else { … }` over an owned `Option`/`Result` returned
+//! from a called function consumes the composite through an anonymous MIR temp.
+//! Before the fix, `lower_let_else_stmt` computed the #2648 admission but
+//! minted NO from-call owner, so the unwrapped payload leaked once per
+//! evaluation (validated slope 47). The fix mints the synthetic scrutinee
+//! owner symmetric with match/while-let/if-let; the scope-exit drop
+//! elaboration releases it on the match edge (payload moved into the escaping
+//! binder, shell composite drop) AND on the divergent else edge
+//! (`return`/`break`/`continue`/`panic` — no move-out, so the FULL temp drops
+//! once).
+//!
+//! Care point B (the divergent-else edge): the else block diverges, and the
+//! full scrutinee temp must drop exactly once on that edge. The scribble pins
+//! exercise `return`/`break`/`continue` divergent edges under the poisoned
+//! allocator so a divergent-edge double free or under-drop is caught.
+
+#![cfg(unix)]
+
+mod support;
+
+use support::leak_slope::{
+    assert_frame_slope_below_tolerance, compile_to_native, run_under_malloc_scribble,
+};
+use support::{describe_output, require_codegen};
+
+// ── slope shapes ────────────────────────────────────────────────────────────
+
+/// Owned `string` payload from a call, unwrapped by `let … else { continue }`
+/// — the match edge is taken every iteration and the payload escapes into the
+/// binder. Slope 47 pre-fix.
+fn letelse_option_string_loop_source(frames: usize) -> String {
+    format!(
+        "fn f() -> Option<string> {{ Some(\"g2429-letelse-string\".to_upper()) }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       i = i + 1;\n\
+         \x20       let Some(b) = f() else {{ continue; }};\n\
+         \x20       total = total + b.len();\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// `Result<bytes, _>` payload unwrapped by `let Ok(b) = … else { continue }`.
+fn letelse_result_bytes_loop_source(frames: usize) -> String {
+    format!(
+        "fn f() -> Result<bytes, string> {{ Ok(\"g2429-letelse-bytes\".to_bytes()) }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var total = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       i = i + 1;\n\
+         \x20       let Ok(b) = f() else {{ continue; }};\n\
+         \x20       total = total + b.len();\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// The DIVERGENT else edge is taken every iteration: a `None`-tag call whose
+/// full composite temp must drop on the `continue` edge. Flat slope proves the
+/// divergent-else release fires (care point B).
+fn letelse_divergent_edge_loop_source(frames: usize) -> String {
+    format!(
+        "fn f() -> Option<string> {{ None }}\n\
+         \n\
+         fn body() -> i64 {{\n\
+         \x20   var misses = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < 64 {{\n\
+         \x20       i = i + 1;\n\
+         \x20       let Some(b) = f() else {{ misses = misses + 1; continue; }};\n\
+         \x20       misses = misses + b.len();\n\
+         \x20   }}\n\
+         \x20   misses\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   var acc = 0;\n\
+         \x20   var i = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       acc = acc + body();\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if acc > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+// ── scribble exactly-once pins ──────────────────────────────────────────────
+
+/// Divergent-else edges (`return` and `continue` on a refuted call) must each
+/// drop the FULL temp once. A divergent-edge double free or under-drop is
+/// caught here: clean exit + verbatim output required.
+const DIVERGENT_ELSE_SCRIBBLE_SOURCE: &str = "\
+fn some_f() -> Option<string> { Some(\"g2429-letelse-taken\".to_upper()) }\n\
+fn none_f() -> Option<string> { None }\n\
+\n\
+fn use_return() -> i64 {\n\
+\x20   let Some(b) = some_f() else { return 0; };\n\
+\x20   b.len()\n\
+}\n\
+\n\
+fn miss_return() -> i64 {\n\
+\x20   let Some(b) = none_f() else { return 7; };\n\
+\x20   b.len()\n\
+}\n\
+\n\
+fn loop_continue() -> i64 {\n\
+\x20   var seen = 0;\n\
+\x20   var i = 0;\n\
+\x20   while i < 3 {\n\
+\x20       i = i + 1;\n\
+\x20       let Some(b) = some_f() else { continue; };\n\
+\x20       seen = seen + b.len();\n\
+\x20   }\n\
+\x20   seen\n\
+}\n\
+\n\
+fn main() {\n\
+\x20   let a = use_return();\n\
+\x20   let b = miss_return();\n\
+\x20   let c = loop_continue();\n\
+\x20   if a > 0 && b == 7 && c > 0 { print(\"ok\"); }\n\
+}\n";
+
+/// Straight-line matched `let … else`: the payload escapes into the binder,
+/// released once at scope exit, read back verbatim.
+const SINGLE_LETELSE_SCRIBBLE_SOURCE: &str = "\
+fn f() -> Option<string> {\n\
+\x20   Some(\"g2429-letelse-single\".to_upper())\n\
+}\n\
+\n\
+fn main() {\n\
+\x20   let Some(b) = f() else { return; };\n\
+\x20   if b.len() == 21 { print(\"m\"); }\n\
+}\n";
+
+fn assert_exact_under_malloc_scribble(name: &str, source: &str, expected: &str) {
+    require_codegen();
+
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("let-else-call-scrutinee-{name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let bin = compile_to_native(source, dir.path(), name);
+    let output = run_under_malloc_scribble(&bin);
+
+    assert!(
+        output.status.success(),
+        "{name} must run clean under the poisoned allocator — a crash here means a \
+         divergent-else edge double-freed the from-call let-else scrutinee temp;\n{}",
+        describe_output(&output)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        expected,
+        "{name} must read the payload back verbatim — scribbled/short output indicates a \
+         use-after-free read on a prematurely released payload;\n{}",
+        describe_output(&output)
+    );
+}
+
+// ── oracles ─────────────────────────────────────────────────────────────────
+
+/// #2429 let-else headline: owned-string payload holds a flat slope (slope 47
+/// pre-fix).
+#[test]
+fn letelse_option_string_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_letelse_option", letelse_option_string_loop_source);
+}
+
+/// `Result<bytes, _>` payload through the same let-else seam holds a flat
+/// slope.
+#[test]
+fn letelse_result_bytes_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("g2429_letelse_result", letelse_result_bytes_loop_source);
+}
+
+/// The divergent (else) edge releases the full composite temp — flat slope
+/// proves the divergent-else drop fires (care point B).
+#[test]
+fn letelse_divergent_edge_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance(
+        "g2429_letelse_divergent",
+        letelse_divergent_edge_loop_source,
+    );
+}
+
+/// Exactly-once wall across divergent edges: `return`/`continue` on both taken
+/// and refuted calls, clean under the poisoned allocator.
+#[test]
+fn letelse_divergent_edges_no_double_free_under_malloc_scribble() {
+    assert_exact_under_malloc_scribble(
+        "g2429_letelse_divergent_scribble",
+        DIVERGENT_ELSE_SCRIBBLE_SOURCE,
+        "ok",
+    );
+}
+
+/// Straight-line matched let-else: single scope-exit release, payload
+/// readable, no double free.
+#[test]
+fn single_from_call_letelse_no_double_free_under_malloc_scribble() {
+    assert_exact_under_malloc_scribble(
+        "g2429_single_letelse_scribble",
+        SINGLE_LETELSE_SCRIBBLE_SOURCE,
+        "m",
+    );
+}

--- a/hew-cli/tests/run_e2e.rs
+++ b/hew-cli/tests/run_e2e.rs
@@ -2020,15 +2020,16 @@ fn check_match_destructure_wildcard_closure_field_fails_closed() {
     );
 }
 
-/// Fail-closed boundary (#2359): a generator yielding `Vec<indirect-enum>`
-/// is rejected at check time. The element's per-element node free is
-/// unwired, so the consuming body's per-frame release could only be the
-/// buffer-only `hew_vec_free` — a per-frame element-node leak (previously
-/// 2 nodes x N iterations, compiling clean). The refusal must fire at the
-/// yield/recv release-verdict consultation: the consumer binding is
-/// retracted from `owned_locals` before the end-of-pass
-/// `unsupported_vec_element_diagnostics` scan, so a scan-only check never
-/// sees it.
+/// Fail-closed boundary (#2359 / #2647): a generator yielding
+/// `Vec<indirect-enum>` is rejected at check time. The element's per-element
+/// node free is unwired, so the consuming body's per-frame release could only
+/// be the buffer-only `hew_vec_free` — a per-frame element-node leak
+/// (previously 2 nodes x N iterations, compiling clean). As of #2647 the
+/// `Vec<indirect-enum>` construction is rejected at the type-checker boundary
+/// (the earliest fail-closed point), which preempts the generator yield-seam
+/// release-verdict refusal for this fixture; the yield/recv seam refusal
+/// remains in MIR as a backstop for any shape that reaches it without local
+/// construction.
 #[test]
 fn check_gen_yield_vec_indirect_enum_fails_closed() {
     require_codegen();
@@ -2053,8 +2054,8 @@ fn check_gen_yield_vec_indirect_enum_fails_closed() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        combined.contains("every yielded or received frame would leak its heap nodes"),
-        "expected the yield/recv fail-closed diagnostic; got: {combined}"
+        combined.contains("indirect enum whose per-element release protocol is not yet wired"),
+        "expected the #2647 checker-boundary release-protocol reject; got: {combined}"
     );
 }
 

--- a/hew-cli/tests/select_arm_owned_binding_leak_oracle.rs
+++ b/hew-cli/tests/select_arm_owned_binding_leak_oracle.rs
@@ -168,6 +168,132 @@ fn escape_binding_loop_source(frames: usize) -> String {
     )
 }
 
+// ── non-string composite arm bindings (regression guards) ───────────────────
+//
+// A select/recv arm binding of a non-`string` composite (`Option<string>`,
+// `Option<record>`, a record) is registered as an owned local of its true type
+// and released exactly once by the general owned-local drop elaboration — the
+// leaf-`string` COW provers (`derive_cow_sole_owner` /
+// `derive_cow_fresh_borrowed_owner`) are NOT the release authority for these
+// shapes. These pins lock that in: a future `derive_cow` change that
+// accidentally routed a non-string arm binding through the string-only path
+// (suppressing its drop, or double-releasing it) would re-open a per-iteration
+// slope here. Escape, unused, and heap-owning-field-record shapes are covered.
+
+/// `Option<string>` reply from an ask select-arm, ESCAPING as the select
+/// result and consumed by a downstream `match` — released once per iteration
+/// as the `let`-bound composite, not stranded and not double-freed.
+fn opt_string_escape_loop_source(frames: usize) -> String {
+    format!(
+        "actor Maker {{\n\
+         \x20   receive fn make(n: i64) -> Option<string> {{\n\
+         \x20       Some(to_string(n).to_upper())\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let m = spawn Maker;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let x = select {{\n\
+         \x20           r from m.make(i) => r,\n\
+         \x20       }};\n\
+         \x20       match x {{\n\
+         \x20           Some(s) => {{ total = total + s.len(); }}\n\
+         \x20           None => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// `Option<Row>` (record with an owned `string` field) reply from an ask
+/// select-arm, ESCAPING as the select result — the composite carries its
+/// interior owned field through the same one release.
+fn opt_record_escape_loop_source(frames: usize) -> String {
+    format!(
+        "type Row {{ name: string; id: i64; }}\n\
+         \n\
+         actor Maker {{\n\
+         \x20   receive fn make(n: i64) -> Option<Row> {{\n\
+         \x20       Some(Row {{ name: to_string(n).to_upper(), id: n }})\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let m = spawn Maker;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   var total: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let x = select {{\n\
+         \x20           r from m.make(i) => r,\n\
+         \x20       }};\n\
+         \x20       match x {{\n\
+         \x20           Some(row) => {{ total = total + row.name.len(); }}\n\
+         \x20           None => {{}}\n\
+         \x20       }}\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if total > 0 {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// Owned `Row` record reply from an ask select-arm, binding UNUSED — the
+/// scope-exit drop releases the whole record (and its owned field) exactly
+/// once on the loop-body edge; a suppressed drop re-opens a per-iteration leak.
+fn record_unused_binding_loop_source(frames: usize) -> String {
+    format!(
+        "type Row {{ name: string; id: i64; }}\n\
+         \n\
+         actor Maker {{\n\
+         \x20   receive fn make(n: i64) -> Row {{\n\
+         \x20       Row {{ name: to_string(n).to_upper(), id: n }}\n\
+         \x20   }}\n\
+         }}\n\
+         \n\
+         fn main() -> i64 {{\n\
+         \x20   let m = spawn Maker;\n\
+         \x20   var i: i64 = 0;\n\
+         \x20   var hits: i64 = 0;\n\
+         \x20   while i < {frames} {{\n\
+         \x20       let r = select {{\n\
+         \x20           _row from m.make(i) => 1,\n\
+         \x20       }};\n\
+         \x20       hits = hits + r;\n\
+         \x20       i = i + 1;\n\
+         \x20   }}\n\
+         \x20   if hits == {frames} {{ 0 }} else {{ 1 }}\n\
+         }}\n"
+    )
+}
+
+/// Straight-line `Option<string>` escape: the arm-body move carries the owned
+/// composite into the select result; its interior `string` reads back verbatim
+/// and the run exits clean under the poisoned allocator (a double-free of the
+/// interior payload aborts; a use-after-free garbles the read-back).
+const OPT_STRING_ESCAPE_SCRIBBLE_SOURCE: &str = "\
+actor Maker {\n\
+\x20   receive fn make() -> Option<string> {\n\
+\x20       Some(\"opt-escape-owned-reply\".to_upper())\n\
+\x20   }\n\
+}\n\
+\n\
+fn main() -> i64 {\n\
+\x20   let m = spawn Maker;\n\
+\x20   let x = select {\n\
+\x20       r from m.make() => r,\n\
+\x20   };\n\
+\x20   match x {\n\
+\x20       Some(s) => { print(s); }\n\
+\x20       None => {}\n\
+\x20   }\n\
+\x20   0\n\
+}\n";
+
 // ── scribble exactly-once pins ──────────────────────────────────────────────
 
 /// Select-loser race (the `ask_reply_owned_select_loser.hew` design): the fast
@@ -325,5 +451,39 @@ fn unused_owned_binding_no_double_free_under_malloc_scribble() {
         "g1875_unused_binding_scribble",
         UNUSED_BINDING_SCRIBBLE_SOURCE,
         "k",
+    );
+}
+
+// ── non-string composite regression guards ──────────────────────────────────
+
+/// `Option<string>` ask-reply escaping the select arm: released once per
+/// iteration as the `let`-bound composite — flat slope.
+#[test]
+fn opt_string_escape_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("owned_opt_string_escape", opt_string_escape_loop_source);
+}
+
+/// `Option<Row>` (owned-field record) ask-reply escaping the select arm — flat
+/// slope; the interior owned field rides the one composite release.
+#[test]
+fn opt_record_escape_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("owned_opt_record_escape", opt_record_escape_loop_source);
+}
+
+/// Owned `Row` record ask-reply, binding unused: whole-record scope-exit
+/// release once per iteration — flat slope.
+#[test]
+fn record_unused_binding_loop_leak_slope_below_tolerance() {
+    assert_frame_slope_below_tolerance("owned_record_unused", record_unused_binding_loop_source);
+}
+
+/// Exactly-once wall for the `Option<string>` escape: the interior payload
+/// reads back verbatim and the run exits clean under the poisoned allocator.
+#[test]
+fn opt_string_escape_no_double_free_under_malloc_scribble() {
+    assert_exact_under_malloc_scribble(
+        "owned_opt_string_escape_scribble",
+        OPT_STRING_ESCAPE_SCRIBBLE_SOURCE,
+        "OPT-ESCAPE-OWNED-REPLY",
     );
 }

--- a/hew-mir/src/lower.rs
+++ b/hew-mir/src/lower.rs
@@ -15231,11 +15231,15 @@ impl Builder {
         else_body: &hew_hir::HirBlock,
     ) {
         // #2648 preflight — run BEFORE any allocation or scrutinee lowering. A
-        // reject pushes one diagnostic and returns with no partial MIR.
-        if let Err(diag) = self.classify_call_scrutinee_admission(scrutinee) {
-            self.diagnostics.push(*diag);
-            return;
-        }
+        // reject pushes one diagnostic and returns with no partial MIR; the
+        // admission token also gates the #2429 from-call owner mint below.
+        let scrutinee_admission = match self.classify_call_scrutinee_admission(scrutinee) {
+            Ok(admission) => admission,
+            Err(diag) => {
+                self.diagnostics.push(*diag);
+                return;
+            }
+        };
         // Entry: evaluate scrutinee, load tag, branch.
         let Some(scrutinee_place) = self.lower_value(scrutinee) else {
             return;
@@ -15257,6 +15261,18 @@ impl Builder {
                 return;
             }
         };
+
+        // #2429 — give a FROM-CALL enum-composite let-else scrutinee an owner,
+        // symmetric with `lower_match_enum_tag`/`lower_if_let`. Registered BEFORE
+        // the branch and the payload-predicate checks that route to `else_bb`, so
+        // the synthetic owned local is live on BOTH paths: the match path (payload
+        // moved out into the escaping binders, shell composite drop) and the
+        // divergent else path (`return`/`break`/`continue`/`panic` — no move-out,
+        // so the FULL temp drops once on that edge). The scope-exit drop
+        // elaboration frees it on whichever edge leaves the enclosing scope,
+        // including the divergent-else edges. No-op for the non-Call / carrier
+        // shapes per `register_from_call_scrutinee_owner`.
+        self.register_from_call_scrutinee_owner(scrutinee_admission, scrutinee, scrutinee_local);
 
         let tag_local = self.alloc_local(ResolvedTy::I64);
         self.push_instr(Instr::Move {
@@ -25324,13 +25340,18 @@ impl Builder {
         else_body: Option<&hew_hir::HirBlock>,
         result_ty: &ResolvedTy,
     ) -> Option<Place> {
-        // #2648 preflight — run BEFORE any allocation or scrutinee lowering. If-let
-        // mints no from-call owner but DOES classify the #2523 projected-payload
-        // origin; the reject short-circuits that too (no partial MIR).
-        if let Err(diag) = self.classify_call_scrutinee_admission(scrutinee) {
-            self.diagnostics.push(*diag);
-            return None;
-        }
+        // #2648 preflight — run BEFORE any allocation or scrutinee lowering. A
+        // reject short-circuits with no partial MIR; the admission token also
+        // gates the #2429 from-call owner mint below (symmetric with
+        // `lower_match_enum_tag`/`lower_while_let`), so it is threaded through
+        // rather than discarded.
+        let scrutinee_admission = match self.classify_call_scrutinee_admission(scrutinee) {
+            Ok(admission) => admission,
+            Err(diag) => {
+                self.diagnostics.push(*diag);
+                return None;
+            }
+        };
         let result_place = self.alloc_local(self.subst_ty(result_ty));
 
         // Entry: evaluate scrutinee, load tag, branch.
@@ -25352,6 +25373,22 @@ impl Builder {
                 return None;
             }
         };
+
+        // #2429 — give a FROM-CALL enum-composite if-let scrutinee an owner so
+        // its payload is released on EVERY exit edge, exactly as
+        // `lower_match_enum_tag`/`lower_while_let` already do. Registered here,
+        // BEFORE the branch and the mid-then `emit_payload_variant_predicate_checks`
+        // that route to `else_bb`, so the synthetic owned local is live on the
+        // matched edge (payload moved out, shell composite drop), the refuted
+        // `else_bb` edge, AND any nested-predicate fallthrough — the scope-exit
+        // drop elaboration then frees it once on whichever edge leaves the
+        // enclosing scope. No-op for binding-ref scrutinees, runtime-symbol
+        // producers, and the recv/iter-next shapes carrying their own release.
+        // Non-loop: the return is discarded (mirroring `lower_match_enum_tag`);
+        // the scope-exit machinery handles every edge, so no explicit
+        // per-iteration owner-drop plumbing is needed (that is `lower_while_let`'s
+        // loop-only concern).
+        self.register_from_call_scrutinee_owner(scrutinee_admission, scrutinee, scrutinee_local);
 
         let tag_local = self.alloc_local(ResolvedTy::I64);
         self.push_instr(Instr::Move {

--- a/hew-types/src/check/calls.rs
+++ b/hew-types/src/check/calls.rs
@@ -500,6 +500,23 @@ impl Checker {
                 self.record_type(span, &Ty::Error);
                 return Some(Ty::Error);
             }
+            // #2647 — converge the MIR indirect-enum reject here. An indirect
+            // enum takes the `Ptr` token, so it bypasses the `Layout`-gated
+            // admissibility check below and is admitted today, then fails closed
+            // deep in MIR. Reject it at the checker boundary with the same
+            // release-protocol reason.
+            if let Some(reason) = self.indirect_enum_vec_element_reject_reason(&elem_ty) {
+                self.report_error(
+                    TypeErrorKind::InvalidOperation,
+                    span,
+                    format!(
+                        "`{}` cannot be a `Vec` element: {reason}",
+                        elem_ty.user_facing()
+                    ),
+                );
+                self.record_type(span, &Ty::Error);
+                return Some(Ty::Error);
+            }
             if crate::vec_authority::classify_element(&elem_ty, &self.type_defs)
                 == Some(crate::vec_authority::VecElementToken::Layout)
                 && matches!(elem_ty, Ty::Named { .. })
@@ -1004,6 +1021,20 @@ impl Checker {
                 };
                 let elem_ty = lowered.remove(0);
                 let resolved_elem = self.subst.resolve(&elem_ty);
+                // #2647 — converge the MIR indirect-enum reject at the checker
+                // boundary (the `Ptr`-token element bypasses the `Layout` gate
+                // below). Same reason MIR fails closed with.
+                if let Some(reason) = self.indirect_enum_vec_element_reject_reason(&resolved_elem) {
+                    self.report_error(
+                        TypeErrorKind::InvalidOperation,
+                        span,
+                        format!(
+                            "`{}` cannot be a `Vec` element: {reason}",
+                            resolved_elem.user_facing()
+                        ),
+                    );
+                    return Ty::Error;
+                }
                 // Inherit the layout+Copy guard from check_call_against_expected_constructor.
                 if crate::vec_authority::classify_element(&resolved_elem, &self.type_defs)
                     == Some(crate::vec_authority::VecElementToken::Layout)

--- a/hew-types/src/check/methods.rs
+++ b/hew-types/src/check/methods.rs
@@ -4718,6 +4718,47 @@ impl Checker {
         "it has no clone/drop thunk path for the owned-element Vec runtime".to_string()
     }
 
+    /// #2647 — converge the MIR indirect-enum Vec-element reject at the checker
+    /// boundary. An `indirect enum` element takes the `Ptr` token in
+    /// [`classify_element`](crate::vec_authority::classify_element) (its `Vec`
+    /// buffer is one heap-boxed node pointer per slot, built by codegen's
+    /// `hew_vec_new_ptr` arm), so it never reaches the `Layout`-gated
+    /// admissibility check the record/enum arms consult — the checker admits it
+    /// today, then MIR rejects it with `Unsupported(NoReleaseProtocol)` because
+    /// the per-element node free is unwired. The two verdicts diverge: the
+    /// authoritative type-checker reports no error while the downstream MIR pass
+    /// fails closed.
+    ///
+    /// This surfaces the SAME release-protocol reason at the checker boundary
+    /// (where the element type is already known), matching MIR's reject for
+    /// EVERY indirect enum — scalar OR heap payload — because the indirect boxing
+    /// is a heap node the plain pointer-ABI buffer cannot release element by
+    /// element. It does NOT change the pointer-token ABI routing: `classify_element`
+    /// still tokens the element `Ptr`, so a pointer-backed element can never
+    /// select an owned Vec ABI family; this reject sits ABOVE that routing, not
+    /// in place of it.
+    ///
+    /// Returns `Some(reason)` for an indirect-enum element, `None` otherwise.
+    pub(super) fn indirect_enum_vec_element_reject_reason(&self, elem_ty: &Ty) -> Option<String> {
+        let Ty::Named {
+            name,
+            builtin: None,
+            ..
+        } = elem_ty
+        else {
+            return None;
+        };
+        let type_def = self.type_defs.get(name)?;
+        if type_def.is_indirect && matches!(type_def.kind, TypeDefKind::Enum) {
+            return Some(
+                "it is an indirect enum whose per-element release protocol is not yet wired, \
+                 so its heap nodes would leak at scope exit"
+                    .to_string(),
+            );
+        }
+        None
+    }
+
     /// Channel/stream element admission for the layout-witness queue path
     /// (`Sender<T>`/`Receiver<T>`/`Stream<T>` recv/send). An element is
     /// admissible when the codegen element witness can describe it:

--- a/hew-types/src/check/tests/collections.rs
+++ b/hew-types/src/check/tests/collections.rs
@@ -881,26 +881,24 @@ fn vec_self_recursive_enum_fails_closed_with_accurate_diagnostic() {
 }
 
 #[test]
-fn vec_indirect_enum_heap_payload_push_routes_to_pointer_abi() {
-    // CAP-01 regression: an `indirect enum` element with a heap-owning
-    // payload (a `string` variant here) satisfies every shape
-    // `vec_owned_element_admissible` checks — registered `Enum` kind,
-    // `RcFree` (no `Rc` payload), and no `Vec`/`HashMap`/`HashSet` field to
-    // trip the unowned-container guard — so it is reported `is_owned: true`.
-    // But `classify_element` correctly tokens an indirect enum `Ptr` (its
-    // `Vec` buffer is one heap-boxed pointer per slot, built by codegen's
-    // explicit `hew_vec_new_ptr` constructor arm for indirect enums), and
-    // `vec_owned_element_admissible` is blind to indirection: it never
-    // checks `TypeDef.is_indirect`. Before the vec-authority fix,
-    // `resolve_runtime_symbol` honoured the (wrong) `is_owned: true` and
-    // routed `push`/`pop`/`get`/... to `hew_vec_*_owned` — a construct/
-    // operate ABI split (pointer-plain buffer, owned-descriptor ops) that
-    // would corrupt the runtime the moment this element shape is used. The
-    // fix pins every `Ptr`-token element to the `_ptr`/base family
-    // regardless of `is_owned`, so this must type-check clean AND resolve
-    // every method to its pointer-ABI symbol.
+fn vec_indirect_enum_element_rejected_at_checker_boundary() {
+    // #2647 — checker/MIR Vec-element admission convergence. An `indirect enum`
+    // element takes the `Ptr` token in `classify_element` (its `Vec` buffer is
+    // one heap-boxed node pointer per slot, built by codegen's `hew_vec_new_ptr`
+    // arm), so it bypasses the `Layout`-gated `vec_owned_element_admissible`
+    // check the record/enum arms consult — the checker ADMITTED it, then MIR
+    // rejected it deep in lowering with `Unsupported(NoReleaseProtocol)` because
+    // the per-element node free is unwired. That divergence (authoritative
+    // type-checker clean, downstream MIR fail-closed) is closed here: the
+    // release-protocol reject now fires at the checker boundary where the
+    // element type is already known.
+    //
+    // The pointer-token ABI invariant is UNCHANGED and lives at the
+    // `classify_element`/`resolve_runtime_symbol` authority
+    // (`is_owned && abi != Ptr`), pinned by `vec_local_pid_push_routes_to_pointer_abi`
+    // — this reject sits ABOVE that routing, it does not replace it.
     let output = check_source(
-        r#"
+        r"
         indirect enum StrNode {
             Str(string);
             Empty;
@@ -908,42 +906,22 @@ fn vec_indirect_enum_heap_payload_push_routes_to_pointer_abi() {
 
         fn main() {
             let nodes: Vec<StrNode> = Vec::new();
-            nodes.push(StrNode::Str("a"));
-            nodes.push(StrNode::Empty);
-            let _ = nodes.get(0);
-            let _ = nodes.pop();
             let _ = nodes.len();
         }
-        "#,
+        ",
     );
 
     assert!(
-        output.errors.is_empty(),
-        "Vec<StrNode> (heap-payload indirect enum) must type-check clean: {:#?}",
+        output
+            .errors
+            .iter()
+            .any(|e| e.message.contains("cannot be a `Vec` element")
+                && e.message.contains("indirect enum")
+                && e.message.contains("release protocol")),
+        "Vec<StrNode> (indirect enum) must be rejected AT the checker with the \
+         release-protocol reason, converging with the MIR reject: {:#?}",
         output.errors
     );
-    for (method, expected_symbol) in [
-        ("push", "hew_vec_push_ptr"),
-        ("pop", "hew_vec_pop_ptr"),
-        ("get", "hew_vec_get_clone"),
-    ] {
-        assert!(
-            output.resolved_calls.values().any(|call| {
-                call.method_name == method && call.target.symbol_name == expected_symbol
-            }),
-            "Vec<StrNode>::{method} must route to {expected_symbol} via resolved_calls, \
-             never an `_owned` family symbol: {:#?}",
-            output.resolved_calls
-        );
-        assert!(
-            !output.resolved_calls.values().any(|call| {
-                call.method_name == method && call.target.symbol_name.ends_with("_owned")
-            }),
-            "Vec<StrNode>::{method} must never resolve to an `_owned` family symbol \
-             (construct/operate ABI split): {:#?}",
-            output.resolved_calls
-        );
-    }
 }
 
 #[test]

--- a/tests/vertical-slice/reject/gen_yield_vec_indirect_enum.hew
+++ b/tests/vertical-slice/reject/gen_yield_vec_indirect_enum.hew
@@ -3,10 +3,11 @@
 // consuming body must release, but the indirect-enum element's per-element
 // node free is unwired — the only available release is the buffer-only
 // `hew_vec_free`, which would leak every element node, once per frame.
-// The refusal fires at the yield/recv release seam itself (the picker
-// consultation), not the end-of-pass owned-locals scan: the consumer binding
-// is retracted from `owned_locals` before that scan runs, so a scan-only
-// check never sees it (the bypass that let this shape compile and leak).
+// As of #2647 the `Vec<indirect-enum>` construction is rejected at the
+// type-checker boundary (the earliest fail-closed point), which fires before
+// the value can reach the generator yield seam. The MIR yield/recv
+// release-verdict refusal remains as a backstop for any shape that reaches it
+// without local construction.
 indirect enum Wrapped {
     Val(i64);
 }

--- a/tests/vertical-slice/run.sh
+++ b/tests/vertical-slice/run.sh
@@ -4149,19 +4149,21 @@ if "${HEW}" check \
 fi
 grep -q 'match-destructure wildcard on owned aggregate field' "${reject_output}"
 
-# Reject (#2359): a generator yielding `Vec<indirect-enum>` fails CLOSED at
-# check time. The indirect-enum element's per-element node free is unwired,
-# so the yielded frame's only release would be the buffer-only `hew_vec_free`
-# — a per-frame element-node leak. The refusal fires at the yield/recv
-# release-verdict consultation (pre-retraction), so the retracted consumer
-# binding cannot bypass it the way it bypassed the final owned-locals scan.
+# Reject (#2359 / #2647): a generator yielding `Vec<indirect-enum>` fails
+# CLOSED at check time. The indirect-enum element's per-element node free is
+# unwired, so the yielded frame's only release would be the buffer-only
+# `hew_vec_free` — a per-frame element-node leak. As of #2647 the
+# `Vec<indirect-enum>` construction is rejected AT the type-checker boundary
+# (the earliest fail-closed point), which preempts the generator yield-seam
+# release-verdict refusal for this fixture; that yield-seam refusal remains in
+# MIR as a backstop for any shape that reaches it without local construction.
 if "${HEW}" check \
     "${ROOT}/tests/vertical-slice/reject/gen_yield_vec_indirect_enum.hew" \
     >"${reject_output}" 2>&1; then
   echo "expected gen_yield_vec_indirect_enum fixture to fail" >&2
   exit 1
 fi
-grep -q 'every yielded or received frame would leak its heap nodes' "${reject_output}"
+grep -q 'indirect enum whose per-element release protocol is not yet wired' "${reject_output}"
 
 # Guard (#2359, recv leg): `Channel<Vec<indirect-enum>>` stays rejected
 # UPSTREAM by the channel element-layout witness at check time — the recv


### PR DESCRIPTION
## Summary

`if let` and `let else` over a call expression (e.g. `if let Some(x) = f()`) were dropping the admission token the checker mints for the call's return value instead of threading it through to the lowering of the branch. The synthetic owner is now registered before the predicate branch in both `lower_if_let` and `lower_let_else_stmt`, so the owned payload has a live owner on the matched edge, the refuted edge, and any nested-predicate fallthrough — closing the leak class covered by #2429 and #2648.

Alongside this, `Vec` element admission now rejects indirect-enum elements at the checker boundary (#2647) instead of letting them fall through to MIR, matching the fail-closed contract already applied to other non-admissible shapes. The rejected shape had no live use; the still-admitted pointer-ABI shape (`Vec<LocalPid<T>>`) is unaffected and remains pinned by its own test.

## Verification

- `if_let_call_scrutinee_leak_oracle`: 8/8, `let_else_call_scrutinee_leak_oracle`: 5/5 — both green under `MallocScribble=1 MallocPreScribble=1 MallocGuardEdges=1`, exercising matched, refuted, and divergent (`return`/`continue`) edges with no double-free
- `test-hew-ratchet`: 0/0
- `make lint`: clean
- collections suite: 53 passing
- `run_e2e`: 162 passing

## Out of scope

- Owned-aggregate copy-on-write for `let alias = source` over `Vec`/`HashMap` remains fail-closed (`UseAfterConsume`). This is a capability-widening decision, not a leak fix, and stays out of this change.
- Widening the recv-escape checker admission for non-string payloads: the current admission surface has no live leak, so it isn't being widened speculatively.
- A separate reassigned-variable `while let` leak is being tracked and probed independently of this change.

This localizes to `lower_if_let`, `lower_let_else_stmt`, and the `Vec` element admission check in `hew-types` — it doesn't touch the fresh-temp-drop derivation shared by other in-flight ownership work, so that work can rebase on top of this cleanly.

Fixes #2429
Fixes #2648